### PR TITLE
Bug 1516463 - use minItems, not minLength, for array length

### DIFF
--- a/services/queue/schemas/v1/post-artifact-request.yml
+++ b/services/queue/schemas/v1/post-artifact-request.yml
@@ -84,7 +84,7 @@ oneOf:
           The worst case is that we have artifacts which incorrectly do not
           validate, which is not as big of a security concern.
         type: array
-        minLength: 1
+        minItems: 1
         items:
           title: "Multipart Part"
           type: object


### PR DESCRIPTION
(ported from https://github.com/taskcluster/taskcluster-queue/pull/309)