### PR TITLE
Bug 1260285 - add a metaschema that enforces some basic sanity

### DIFF
--- a/libraries/references/schemas/metadata-metaschema.yml
+++ b/libraries/references/schemas/metadata-metaschema.yml
@@ -1,9 +1,19 @@
-$schema: "http://json-schema.org/draft-06/schema#"
+$schema: "/schemas/common/metaschema.json#"
 $id: "/schemas/common/metadata-metaschema.json#"
 title: "JSON-Schema Meta-Schema, with the addition of a `metadata` property"
-allOf:
-  - {$ref: "http://json-schema.org/draft-06/schema#"}
-  - type: object
+description: |
+  This is a refinement of the Taskcluster metaschema, with the following changes:
+
+    * top level must be an object (no trivial true or false schemas)
+    * `{metadata: {name, version}}` must be present at the top level
+
+  Note that any schema that validates against this metaschema will also
+  validate against the upstream draft-06 metaschema, and is usable by any
+  JSON-schema tool.
+definitions:
+  # require that every schema have a top-level metadata metaschema
+  topLevelMetadata:
+    type: object
     properties:
       metadata:
         title: "Metadata for this schema"
@@ -27,9 +37,14 @@ allOf:
           version:
             title: "Version of the document format"
             type: integer
-          additionalProperties: false
+        additionalProperties: false
         required:
           - version
           - name
+    additionalProperties: true
     required:
       - metadata
+
+allOf:
+  - {$ref: "./metaschema.json#"}
+  - {$ref: "#/definitions/topLevelMetadata"}

--- a/libraries/references/schemas/metaschema.yml
+++ b/libraries/references/schemas/metaschema.yml
@@ -1,0 +1,55 @@
+$schema: "http://json-schema.org/draft-06/schema#"
+$id: "/schemas/common/metaschema.json#"
+title: "Taskcluster JSON-Schema Meta-Schema, with some stricter validation"
+description: |
+  This is a refinement of JSON-schema, with the following changes:
+
+    * if `properties` is present, `type` and `additionalProperties` must be present, too
+    * if `entries` is present, `type` and `uniqueItems` must be present, too
+
+  Note that any schema that validates against this metaschema will also
+  validate against the upstream draft-06 metaschema, and is usable by any
+  JSON-schema tool.
+definitions:
+  # requirements on the top level and subschemas
+  schema:
+    allOf:
+      - {$ref: "#/definitions/recurse"}
+      - {$ref: "#/definitions/requiredProperties"}
+  schemaArray:
+    type: array
+    items: {$ref: "#/definitions/schema"}
+  recurse:
+    properties:
+      additionalItems: {$ref: "#/definitions/schema"}
+      items:
+        anyOf:
+          - {$ref: "#/definitions/schema"}
+          - {$ref: "#/definitions/schemaArray"}
+      contains: {$ref: "#/definitions/schema"}
+      additionalProperties: {$ref: "#/definitions/schema"}
+      definitions:
+        additionalProperties: {$ref: "#/definitions/schema"}
+      properties:
+        additionalProperties: {$ref: "#/definitions/schema"}
+      patternProperties:
+        additionalProperties: {$ref: "#/definitions/schema"}
+      dependencies:
+        additionalProperties:
+          anyOf:
+            - {$ref: "#/definitions/schema"}
+            - {$ref: "http://json-schema.org/draft-06/schema#/definitions/stringArray"}
+      propertyNames: {$ref: "#/definitions/schema"}
+      allOf: {$ref: "#/definitions/schemaArray"}
+      anyOf: {$ref: "#/definitions/schemaArray"}
+      oneOf: {$ref: "#/definitions/schemaArray"}
+      not: {$ref: "#/definitions/schema"}
+
+  requiredProperties:
+    dependencies:
+      properties: ['type', 'additionalProperties', 'required']
+      entries: ['type', 'uniqueItems']
+
+allOf:
+  - {$ref: "http://json-schema.org/draft-06/schema#"}
+  - {$ref: "#/definitions/schema"}

--- a/libraries/references/src/validate.js
+++ b/libraries/references/src/validate.js
@@ -182,3 +182,5 @@ class ValidationProblems extends Error {
     this.problems = problems;
   }
 }
+
+exports.ValidationProblems = ValidationProblems;

--- a/libraries/references/test/metaschema_test.js
+++ b/libraries/references/test/metaschema_test.js
@@ -1,0 +1,128 @@
+const assert = require('assert');
+const _ = require('lodash');
+const Ajv = require('ajv');
+const {getCommonSchemas} = require('../src/common-schemas');
+
+suite('metaschema_test.js', function() {
+  suiteSetup('setup Ajv', function() {
+    const ajv = new Ajv({
+      format: 'full',
+      verbose: true,
+      allErrors: true,
+      validateSchema: false,
+    });
+    ajv.addMetaSchema(require('ajv/lib/refs/json-schema-draft-06.json'));
+
+    // add the metadata metaschema
+    const schemas = getCommonSchemas();
+    ajv.addMetaSchema(_.find(schemas, {filename: 'schemas/metaschema.yml'}).content);
+    ajv.addMetaSchema(_.find(schemas, {filename: 'schemas/metadata-metaschema.yml'}).content);
+
+    validate = (content, failureCheck) => {
+      const problems = [];
+      try {
+        ajv.validateSchema(content);
+        if (ajv.errors) {
+          ajv
+            .errorsText(ajv.errors, {separator: '%%/%%', dataVar: 'schema'})
+            .split('%%/%%')
+            .forEach(err => problems.push(err));
+        }
+      } catch (err) {
+        problems.push(err.toString());
+      }
+      if (!failureCheck) {
+        if (problems.length) {
+          throw new Error(problems.join('; '));
+        }
+      } else if (!problems.some(failureCheck)) {
+        throw new Error(problems.length > 0 ? problems.join('; ') : 'Did not any problems (but expected some)');
+      }
+    };
+  });
+
+  suite('metaschema', function() {
+    const $schema = '/schemas/common/metaschema.json#';
+
+    test('if properties are given, additionalProperties must be present', function() {
+      validate({
+        $schema,
+        type: 'object',
+        properties: {x: {type: 'string'}},
+        required: [],
+      }, f => f.match(/schema should have properties .* when property properties is present/));
+    });
+
+    test('if properties are given, type must be present', function() {
+      validate({
+        $schema,
+        additionalProperties: true,
+        properties: {x: {type: 'string'}},
+        required: [],
+      }, f => f.match(/schema should have properties .* when property properties is present/));
+    });
+
+    test('if properties are given, required must be present', function() {
+      validate({
+        $schema,
+        additionalProperties: true,
+        type: 'object',
+        properties: {x: {type: 'string'}},
+      }, f => f.match(/schema should have properties .* when property properties is present/));
+    });
+
+    test('if entries are given, additionalProperties must be present', function() {
+      validate({
+        $schema,
+        type: 'object',
+        entries: {type: 'string'},
+      }, f => f.match(/schema should have properties type, uniqueItems when property entries is present/));
+    });
+
+    test('if entries are given, type must be present', function() {
+      validate({
+        $schema,
+        uniqueItems: true,
+        entries: {type: 'string'},
+      }, f => f.match(/schema should have properties type, uniqueItems when property entries is present/));
+    });
+  });
+
+  suite('metadata-metaschema', function() {
+    const $schema = '/schemas/common/metadata-metaschema.json#';
+    const metadata = {name: 'sch', version: 1};
+
+    test('metadata is required', function() {
+      validate({
+        $schema,
+      }, f => f.match(/schema should have required property 'metadata'/));
+    });
+
+    test('metadata.name is required', function() {
+      validate({
+        $schema,
+        metadata: {version: 0},
+      }, f => f.match(/schema.metadata should have required property 'name'/));
+    });
+
+    test('metadata.version is required', function() {
+      validate({
+        $schema,
+        metadata: {name: 'foo'},
+      }, f => f.match(/schema.metadata should have required property 'version'/));
+    });
+
+    test('metadata.otherProperty is forbidden', function() {
+      validate({
+        $schema,
+        metadata: {name: 'foo', version: 0, otherProperty: 'foo'},
+      }, f => f.match(/schema.metadata should NOT have additional properties/));
+    });
+
+    test('fully specified schema is valid', function() {
+      validate({
+        $schema, metadata,
+      });
+    });
+  });
+});


### PR DESCRIPTION
This factors out a new '/schemas/common/metaschema.json#' that enforces
some basic things on our schemas.  This is strictly *more* restrictive
than vanilla draft-06 json-schema, so a compliant schema remains usable
by any other schema-handling tools.

(ported from https://github.com/taskcluster/taskcluster-lib-references/pull/6)