### PR TITLE
Bug 1517662 - fix tests that fail when run simultaneously

### DIFF
--- a/services/hooks/test/helper.js
+++ b/services/hooks/test/helper.js
@@ -217,6 +217,10 @@ helper.withQueues = (mock, skipping) => {
         credentials: 'inMemory',
         signingKey: cfg.azure.signingKey,
       }));
+    } else {
+      // choose a unique name for the table, to avoid conflicting with other tests
+      const cfg = await helper.load('cfg');
+      helper.load.cfg('app.queuesTableName', cfg.app.queuesTableName + TABLE_SUFFIX);
     }
 
     helper.Queues = await helper.load('Queues');

--- a/services/notify/test/helper.js
+++ b/services/notify/test/helper.js
@@ -11,6 +11,7 @@ const builder = require('../src/api');
 const exchanges = require('../src/exchanges');
 const load = require('../src/main');
 const RateLimit = require('../src/ratelimit');
+const slugid = require('slugid');
 
 // Load configuration
 const cfg = config({profile: 'test'});
@@ -75,7 +76,11 @@ exports.withSQS = (mock, skipping) => {
 
     if (mock) {
       sqs = new MockSQS();
-      exports.ircSQSQueue = cfg.app.sqsQueueName;
+      const queueSuffix = slugid.nice().replace(/[_-]/g, '').slice(-10);
+      // use a unique sqs queue name to allow multiple versions of this test to run
+      // simultaneously without stepping on toes
+      exports.ircSQSQueue = `${cfg.app.sqsQueueName}-${queueSuffix}`;
+      exports.load.cfg('app.sqsQueueName', exports.ircSQSQueue);
       exports.load.inject('sqs', sqs);
       exports.checkSQSMessage = (queueUrl, check) => {
         const messages = sqs.queues[queueUrl];

--- a/services/queue/test/helper.js
+++ b/services/queue/test/helper.js
@@ -178,16 +178,19 @@ exports.withQueueService = (mock, skipping) => {
     if (mock) {
       helper.load.cfg('azure.fake', true);
       helper.queueService = await helper.load('queueService');
-    }
-  });
-
-  suiteSetup(async function() {
-    if (skipping()) {
-      return;
-    }
-
-    if (mock) {
       helper.queueService.client._reset();
+    } else {
+      // ensure we are using unique queue names from run to run of this service
+      // so that tests do not interfere with one another.  This prefix can only
+      // be 6 characters long..
+      const pfx = 'q' + new Date().getTime().toString().slice(-5);
+      const cfg = await helper.load('cfg');
+      helper.load.cfg('app.queuePrefix', pfx);
+      helper.load.cfg('app.claimQueue', `${pfx}-claim`);
+      helper.load.cfg('app.deadlineQueue', `${pfx}-deadline`);
+      helper.load.cfg('app.resolvedQueue', `${pfx}-resolved`);
+
+      helper.queueService = await helper.load('queueService');
     }
   });
 };


### PR DESCRIPTION
Lots of our tests assume exclusive access to some global resource.  This switches to using a uniquely-named resource for each test run, to avoid such conflicts.