### PR TITLE
Bug 1518137 - better libraries/api error handling, fix InsufficientScopes

### DIFF
--- a/libraries/api/README.md
+++ b/libraries/api/README.md
@@ -312,16 +312,16 @@ expiration time to prevent callers from extending their access beyond the
 allowed time.
 
 The `async req.authorize(params, options)` throws an error with the code
-'AuthorizationError' if the client does not satisfy the scope
+'InsufficientScopes' if the client does not satisfy the scope
 expression in `options.scopes`. You can catch this if you wish
 or let it bubble up and taskcluster-lib-api will return a detailed error message
 to the client.
 
-The AuthorizationError has 3 extra fields to help inspect the results.
+The InsufficientScopes error object has 3 extra fields to help inspect the results.
 
-**err.scopes:** The scopeset containing the scopes the client has
-**err.expression:** The scope expression that was not satisfied
-**err.missing:** The reduced subset of the expression containing only scopes that were missing
+**err.details.scopes:** The scopeset containing the scopes the client has
+**err.details.required:** The scope expression that was not satisfied
+**err.details.unsatisfied:** The reduced subset of the expression containing only scopes that were missing
 
 The first argument to `req.authorize` must be an object where the keys are parameters
 to the scope expression defined in the method definition. If any parameters are missing

--- a/libraries/api/src/middleware/handle.js
+++ b/libraries/api/src/middleware/handle.js
@@ -27,11 +27,6 @@ const callHandler = ({entry, context, monitor}) => {
         }
       }
     }).catch((err) => {
-      if (err.code === 'AuthorizationError') {
-        return next(new ErrorReply({code: 'InsufficientScopes', message: err.message, details: err.details}));
-      } else if (err.code === 'AuthenticationError') {
-        return next(new ErrorReply({code: 'AuthenticationFailed', message: err.message, details: err.details}));
-      }
       return next(err);
     });
   };

--- a/libraries/testing/test/fakeauth_test.js
+++ b/libraries/testing/test/fakeauth_test.js
@@ -31,7 +31,7 @@ builder.declare({
     await req.authorize();
     return res.reply({hasTestScope: true});
   } catch (err) {
-    if (err.code !== 'AuthorizationError') {
+    if (err.code !== 'InsufficientScopes') {
       throw err;
     }
     return res.reply({hasTestScope: false});


### PR DESCRIPTION
The important thing here is not losing track of the message template, so
users still see the explanation of their InsufficientScopes error.  But
this also factors out the translation of AuthorizationError ->
InsufficientScopes and AuthenticationError -> AuthenticationFailed.