### PR TITLE
Switch to Node 10.14

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -84,7 +84,7 @@ tasks:
                 then: true
               TEST_BUCKET: 'test-bucket-for-any-garbage' # TODO: Allow each project to specify its own env
             maxRunTime: 3600
-            image: "node:8"
+            image: "node:10.14.0"
             command:
               - "/bin/bash"
               - "-lc"

--- a/infrastructure/builder/package.json
+++ b/infrastructure/builder/package.json
@@ -13,7 +13,7 @@
   },
   "engine-strict": true,
   "engines": {
-    "node": "^8.10.0",
+    "node": "10.14.0",
     "yarn": "^1.0.0"
   },
   "devDependencies": {

--- a/services/auth/package.json
+++ b/services/auth/package.json
@@ -44,7 +44,7 @@
   },
   "engine-strict": true,
   "engines": {
-    "node": "^8.10.0",
+    "node": "10.14.0",
     "yarn": "^1.0.0"
   }
 }

--- a/services/github/package.json
+++ b/services/github/package.json
@@ -35,7 +35,7 @@
   },
   "engine-strict": true,
   "engines": {
-    "node": "^8.0.0",
+    "node": "10.14.0",
     "yarn": "^1.0.0"
   }
 }

--- a/services/hooks/package.json
+++ b/services/hooks/package.json
@@ -34,7 +34,7 @@
   },
   "engine-strict": true,
   "engines": {
-    "node": "^8.0.0",
+    "node": "10.14.0",
     "yarn": "^1.0.0"
   }
 }

--- a/services/index/package.json
+++ b/services/index/package.json
@@ -25,7 +25,7 @@
   },
   "engine-strict": true,
   "engines": {
-    "node": "^8.0.0",
+    "node": "10.14.0",
     "yarn": "^1.0.0"
   }
 }

--- a/services/login/package.json
+++ b/services/login/package.json
@@ -31,7 +31,7 @@
   },
   "engine-strict": true,
   "engines": {
-    "node": "^8.3.0",
+    "node": "10.14.0",
     "yarn": "^1.0.0"
   }
 }

--- a/services/notify/package.json
+++ b/services/notify/package.json
@@ -34,7 +34,7 @@
   },
   "engine-strict": true,
   "engines": {
-    "node": "^8.0.0",
+    "node": "10.14.0",
     "yarn": "^1.0.0"
   }
 }

--- a/services/purge-cache/package.json
+++ b/services/purge-cache/package.json
@@ -24,7 +24,7 @@
   },
   "engine-strict": true,
   "engines": {
-    "node": "^8.0.0",
+    "node": "10.14.0",
     "yarn": "^1.0.0"
   }
 }

--- a/services/queue/package.json
+++ b/services/queue/package.json
@@ -35,7 +35,7 @@
   },
   "engine-strict": true,
   "engines": {
-    "node": "^8.10.0",
-    "yarn": "^1.0.2"
+    "node": "10.14.0",
+    "yarn": "^1.0.0"
   }
 }

--- a/services/secrets/package.json
+++ b/services/secrets/package.json
@@ -25,7 +25,7 @@
   },
   "engine-strict": true,
   "engines": {
-    "node": "^8.0.0",
+    "node": "10.14.0",
     "yarn": "^1.0.0"
   }
 }

--- a/services/treeherder/package.json
+++ b/services/treeherder/package.json
@@ -24,7 +24,7 @@
   },
   "engine-strict": true,
   "engines": {
-    "node": "^8.0.0",
+    "node": "10.14.0",
     "yarn": "^1.0.0"
   }
 }


### PR DESCRIPTION
Later version of Node (`10.14.2` and up) could break tests in tc-lib-references (there was a change in Node 10.14.2 for which `fs-mock` library we use to mock the file system needs a patch).