### PR TITLE
Node library has Promises built-in

### DIFF
--- a/services/login/src/handlers/mozilla-auth0.js
+++ b/services/login/src/handlers/mozilla-auth0.js
@@ -83,10 +83,7 @@ class Handler {
   async profileFromUserId(userId) {
     const a0 = await this.getManagementApi();
 
-    const profile = new Promise((resolve, reject) =>
-      a0.getUser(userId, (err, prof) => err ? reject(err) : resolve(prof)));
-
-    return profile;
+    return a0.getUser(userId);
   }
 
   async userFromRequest(req, res) {


### PR DESCRIPTION
So I switched to auth0 library for Node from auth0 library for headless browser. The latter didn't have promises, whereas the former does. There was an error in prod, which this PR fixes