### PR TITLE
Have a better task info in Checks

### DIFF
--- a/services/github/src/handlers.js
+++ b/services/github/src/handlers.js
@@ -418,7 +418,7 @@ async function statusHandler(message) {
       const checkRun = await instGithub.checks.create({
         owner: organization,
         repo: repository,
-        name: `${taskDefinition.metadata.name}: task ${taskId}`,
+        name: `${taskDefinition.metadata.name}`,
         head_sha: sha,
         output: {
           title: `${this.context.cfg.app.statusContext} (${eventType.split('.')[0]})`,
@@ -731,7 +731,7 @@ async function taskDefinedHandler(message) {
   const checkRun = await instGithub.checks.create({
     owner: organization,
     repo: repository,
-    name: `${taskDefinition.metadata.name}: task ${taskId}`,
+    name: `${taskDefinition.metadata.name}`,
     head_sha: sha,
     output: {
       title: `${this.context.cfg.app.statusContext} (${eventType.split('.')[0]})`,

--- a/services/github/src/handlers.js
+++ b/services/github/src/handlers.js
@@ -545,7 +545,7 @@ async function jobHandler(message) {
   }
 
   if (message.payload.details['event.type'].startsWith('pull_request.')) {
-    debug(`Checking pull request permission for for ${organization}/${repository}@${sha}...`);
+    debug(`Checking pull request permission for ${organization}/${repository}@${sha}...`);
 
     // Decide if a user has permissions to run tasks.
     let login = message.payload.details['event.head.user.login'];

--- a/services/github/src/handlers.js
+++ b/services/github/src/handlers.js
@@ -105,7 +105,6 @@ class Handlers {
     // (see this.createTasks for example)
     this.queueClient = new taskcluster.Queue({
       rootUrl: this.context.cfg.taskcluster.rootUrl,
-      credentials: this.context.cfg.taskcluster.credentials,
     });
 
     // Listen for new jobs created via the api webhook endpoint
@@ -228,7 +227,10 @@ class Handlers {
 
   // Create a collection of tasks, centralized here to enable testing without creating tasks.
   async createTasks({scopes, tasks}) {
-    const scopedQueueClient = this.queueClient.use({authorizedScopes: scopes});
+    const scopedQueueClient = this.queueClient.use({
+      authorizedScopes: scopes,
+      credentials: this.context.cfg.taskcluster.credentials,
+    });
     await Promise.all(tasks.map(t => scopedQueueClient.createTask(t.taskId, t.task)));
   }
 

--- a/services/github/src/handlers.js
+++ b/services/github/src/handlers.js
@@ -100,6 +100,9 @@ class Handlers {
     assert(!this.deprecatedResultStatusPq, 'Cannot setup twice!');
     assert(!this.deprecatedInitialStatusPq, 'Cannot setup twice!');
 
+    // This is a simple Queue client without scopes to use throughout the handlers for simple things
+    // Where scopes are needed, use this.queueClient.use({authorizedScopes: scopes}).blahblah
+    // (see this.createTasks for example)
     this.queueClient = new taskcluster.Queue({
       rootUrl: this.context.cfg.taskcluster.rootUrl,
       credentials: this.context.cfg.taskcluster.credentials,
@@ -409,7 +412,7 @@ async function statusHandler(message) {
         check_run_id: checkRun.checkRunId,
       });
     } else {
-      const taskDefinition = await this.queueClient.task(taskId).catch(debug);
+      const taskDefinition = await this.queueClient.task(taskId);
       debug(`Result status. Got task build from DB and task definition for ${taskId} from Queue service`);
 
       const checkRun = await instGithub.checks.create({
@@ -717,7 +720,7 @@ async function taskDefinedHandler(message) {
     installationId,
   } = await this.context.Builds.load({taskGroupId});
 
-  const taskDefinition = await this.queueClient.task(taskId).catch(debug);
+  const taskDefinition = await this.queueClient.task(taskId);
   debug(`Initial status. Got task build from DB and task definition for ${taskId} from Queue service`);
 
   // Authenticating as installation.

--- a/services/github/test/handler_test.js
+++ b/services/github/test/handler_test.js
@@ -78,9 +78,20 @@ helper.secrets.mockSuite('handlers', ['taskcluster'], function(mock, skipping) {
     github = await helper.load('github');
     handlers = await helper.load('handlers');
 
+    await handlers.setup();
+
     // stub out `createTasks` so that we don't actually create tasks
     handlers.createTasks = sinon.stub();
-    await handlers.setup();
+    handlers.queueClient = {
+      task: (_) => {
+        return Promise.resolve({
+          metadata: {
+            name: 'Task Name',
+            description: 'Task Description',
+          },
+        });
+      },
+    };
 
     // set up the allowPullRequests key
     github.inst(5828).setRepoInfo({


### PR DESCRIPTION
I retain task id in the check names to ensure different tasks with the same name will get different check runs without throwing errors. But I have the task name from `taskDefinition.metadata` preceding that, so that when you look at the list of 27 tasks, you could instantly tell which is which. I am also missing link to the task group - so I added it to the task description.

Downside of this particular solution is that I make additional network call. Alternative solution would be to add metadata to the pulse messages. (I would actually prefer the alternative solution, unless there are objections. I think queue service won't die if it will send some additional bit of data, wheres additional network calls here make tc-gh more brittle. On the other hand, those messages are public API, so changing them...)