### PR TITLE
[WIP] Bug 1518251 - sketch of postgres interface

### DIFF
--- a/libraries/postgres/README.md
+++ b/libraries/postgres/README.md
@@ -1,0 +1,3 @@
+# Postgres support for Taskcluster
+
+

--- a/libraries/postgres/package.json
+++ b/libraries/postgres/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "taskcluster-lib-postgres",
+  "private": true,
+  "version": "10.0.0",
+  "author": "Dustin J. Mitchell <dustin@mozilla.com>",
+  "description": "Postgres schema and query management for Taskcluster.",
+  "license": "MPL-2.0",
+  "scripts": {
+    "lint": "eslint src/*.js test/*.js",
+    "test": "mocha test/*_test.js"
+  },
+  "files": [
+    "src"
+  ],
+  "main": "./src/index.js",
+  "dependencies": {
+    "pg": "^7.8.0"
+  }
+}

--- a/libraries/postgres/src/index.js
+++ b/libraries/postgres/src/index.js
@@ -1,0 +1,256 @@
+const {Pool, Client} = require('pg');
+const {dollarQuote} = require('./util');
+const assert = require('assert');
+const debug = require('debug')('taskcluster-lib-postgres');
+
+// Overall plan is: access is only through plpgsql functions, and those must
+// have a consistent API (args + result).  Upgrades can redefine these
+// functions and add new functions, but not change API as existing software may
+// be using those functions concurrently.
+
+const [READ, WRITE] = [Symbol('read'), Symbol('write')];
+
+class Schema{
+  /**
+   * Create a new Schema
+   *
+   * serviceName must be provided, and is used to namespace this service's
+   * tables apart from other services (note that the deployment may put
+   * other services' tables on other database servers entirely, so it is
+   * not allowed to rely on other services' tables)
+   *
+   * script is a script to create the schema, suitable as an argument to
+   * the Postgres DO statment; that is usually 'BEGIN stmt; stmt; .. END'.
+   */
+  constructor({serviceName, script}, {version, versions, methods}={}) {
+    assert(serviceName, 'serviceName is required');
+    this.serviceName = serviceName;
+    assert(script, 'script is required');
+    this.script = script;
+
+    this.version = version || 1;
+    this.versions = versions || [null];
+
+    assert.equal(this.versions.length, this.version);
+    this.versions.push(this);
+
+    this.methods = new Map(methods);
+  }
+
+  /**
+   * Add a new version to this schema; version must be one more than the
+   * previous version.  A script must be provided to upgrade from the previous
+   * version. All defined methods are reset.
+   */
+  addVersion(version, script) {
+    assert(version === this.version + 1, 'versions must increment by one');
+    return new Schema(
+      {script, serviceName: this.serviceName},
+      {version, versions: this.versions});
+  }
+
+  /**
+   * Add a new method to this schema version.  Calling the method on the
+   * resulting Database instance will invoke the given plpgsql script.  If the
+   * method was already defined in a previous version, then its args and
+   * returns must match the previous version exactly.
+   */
+  addMethod(method, rw, args, returns, script) {
+    assert(script, 'script is required');
+    if (this.methods.has(method)) {
+      const prev = this.methods.get(method);
+      assert.equal(args, prev.args,
+        'method args must match previous version');
+      assert.equal(returns, prev.returns,
+        'method returns must match previous version');
+    }
+    this.methods.set(method, {rw, args, returns, script});
+    return this;
+  }
+
+  /** setup **/
+
+  /**
+   * Get a Database instance based on this schema
+   */
+  async setup(dbOptions) {
+    const db = new Database({...dbOptions, schema: this});
+    const dbVersion = await db.getVersion();
+    if (dbVersion < this.version) {
+      throw new Error('Database version is older than this software version');
+    }
+    return db;
+  }
+
+  /**
+   * Upgrade this database to the latest version and define functions for all
+   * of the methods.
+   */
+  async upgrade(dbOptions) {
+    const db = new Database({...dbOptions, schema: this});
+    try {
+      const dbVersion = await db.getVersion();
+
+      // perform any necessary upgrades..
+      if (dbVersion < this.version) {
+        // run each of the upgrade scripts
+        for (let schema of this.versions.slice(dbVersion + 1)) {
+          debug(`upgrading to version ${schema.version}`);
+          await db._doUpgrade(schema.script, schema.version);
+        }
+      }
+
+      // if we are running upgrades, unconditionally define the function objects
+      // for the defined methods; this allows updates to those functions to fix
+      // bugs without a new schema version.
+      for (let [method, {args, returns, script}] of this.methods) {
+        debug(`defining method ${method}`);
+        await db._defineMethod(method, args, returns, script);
+      }
+    } finally {
+      await db.close();
+    }
+  }
+
+  /** testing **/
+
+  /**
+   * Get the schema as it was at the given version; this is used for testing
+   * upgrades from old versions.
+   */
+  atVersion(version) {
+    return this.versions[version];
+  }
+}
+
+class Database {
+  constructor({readDbUrl, writeDbUrl, schema}) {
+    assert(readDbUrl, 'readDbUrl is required');
+    assert(writeDbUrl, 'writeDbUrl is required');
+    assert(schema, 'schema is required');
+
+    this.schemaName = schema.serviceName.replace(/-/g, '_');
+
+    const makePool = dbUrl => {
+      const pool = new Pool({connectionString: dbUrl});
+      // always use the search path named after the serviceName (note that
+      // this Promise is unhandled, but this is how the pg docs recommend
+      // setting up a connection)
+      pool.on('connect', client => {
+        client.query(`set search_path to ${this.schemaName}`)
+          .catch(err => console.log('error setting search_path on new connection (ignored)'));
+      });
+      // ignore errors from *idle* connections
+      pool.on('error', client => {});
+      return pool;
+    };
+
+    this.pools = {
+      [READ]: makePool(readDbUrl),
+      [WRITE]: makePool(writeDbUrl),
+    };
+
+    // generate a JS method for each DB method defined in the schema
+    schema.methods.forEach(({rw}, method) => {
+      this[method] = async (...args) => {
+        const placeholders = [...new Array(args.length).keys()].map(i => `$${i+1}`).join(',');
+        const res = await this._withClient(rw, client => client.query(
+          `select * from ${this.schemaName}.${method}(${placeholders})`, args));
+        return res.rows;
+      };
+    });
+  }
+
+  /**
+   * Run cb with a client.
+   *
+   * This is for INTERNAL USE ONLY.  All external access to the DB should be
+   * performed via methods.
+   */
+  async _withClient(wr, cb) {
+    const pool = this.pools[wr];
+    const client = await pool.connect();
+    try {
+      try {
+        return await cb(client);
+      } catch (err) {
+        // show hints or details from this error in the debug log, to help
+        // debugging issues..
+        if (err.hint) {
+          debug(`HINT: ${err.hint}`);
+        }
+        if (err.detail) {
+          debug(`DETAIL: ${err.detail}`);
+        }
+        throw err;
+      }
+    } finally {
+      client.release();
+    }
+  }
+
+  /**
+   * Get the version of this database
+   */
+  async getVersion() {
+    // get from the version table or return 0
+    return await this._withClient(READ, async client => {
+      try {
+        const res = await client.query('select version from tcversion');
+        if (res.rowCount !== 1) {
+          throw new Error('database corrupted; tcversion should hvae exactly one row');
+        }
+        return res.rows[0].version;
+      } catch (err) {
+        // catch "relation does not exist" and treat it as version 0
+        if (err.code === '42P01') {
+          return 0;
+        }
+        throw err;
+      }
+    });
+  }
+
+  async _doUpgrade(script, version) {
+    await this._withClient(WRITE, async client => {
+      await client.query('begin');
+      if (version === 1) {
+        await client.query(`create schema if not exists "${this.schemaName}"`);
+        await client.query('create table tcversion as select 0 as version');
+      }
+      // check the version and lock it to prevent other things from changing it
+      const res = await client.query('select version from tcversion for update');
+      if (res.rowCount !== 1 || res.rows[0].version !== version - 1) {
+        throw Error('Multiple DB upgrades running simultaneously');
+      }
+      await client.query(`DO ${dollarQuote(script)}`);
+      await client.query('update tcversion set version = $1', [version]);
+      await client.query('commit');
+    });
+  }
+
+  async _defineMethod(method, args, returns, script) {
+    await this._withClient(WRITE, async client => {
+      await client.query(`create or replace function
+        ${this.schemaName}.${method}(${args})
+        returns ${returns}
+        as ${dollarQuote(script)}
+        language plpgsql`);
+    });
+  }
+
+  /**
+   * Wrap up operations on this DB
+   */
+  async close() {
+    await Promise.all([
+      this.pools[READ].end(),
+      this.pools[WRITE].end(),
+    ]);
+  }
+}
+
+exports.Schema = Schema;
+exports.Database = Database;
+exports.READ = READ;
+exports.WRITE = WRITE;

--- a/libraries/postgres/src/util.js
+++ b/libraries/postgres/src/util.js
@@ -1,0 +1,10 @@
+exports.dollarQuote = str => {
+  let i = '';
+  while (true) {
+    const quote = `$${i}$`;
+    if (str.indexOf(quote) === -1) {
+      return quote + str + quote;
+    }
+    i = i + '-';
+  }
+};

--- a/libraries/postgres/test/database_test.js
+++ b/libraries/postgres/test/database_test.js
@@ -1,0 +1,99 @@
+const {dbSuite} = require('./helper');
+const {Schema, Database, READ, WRITE} = require('..');
+const path = require('path');
+const assert = require('assert');
+
+dbSuite(path.basename(__filename), function() {
+  let db;
+
+  const schema = new Schema({
+    serviceName: 'taskcluster-lib-postgres',
+    script: `
+      begin
+        create table testing (a integer, b integer);
+      end`})
+    .addMethod('testdata', READ, '', 'void', `
+      begin
+        insert into testing values (1, 2), (3, 4);
+      end`)
+    .addMethod('addup', READ, 'x integer', 'table (total integer)', `
+      begin
+        return query select a+b+x as total from testing;
+      end`);
+
+  setup(function() {
+    db = new Database({schema, readDbUrl: this.dbUrl, writeDbUrl: this.dbUrl});
+  });
+
+  teardown(async function() {
+    await db.close();
+  });
+
+  test('getVersion with no version set', async function() {
+    assert.equal(await db.getVersion(), 0);
+  });
+
+  test('getVersion after set', async function() {
+    await db._withClient(WRITE, async client => {
+      await client.query('begin');
+      await client.query(`create schema if not exists "taskcluster_lib_postgres"`);
+      await client.query('create table if not exists tcversion as select 0 as version');
+      await client.query('update tcversion set version = $1', [3]);
+      await client.query('commit');
+    });
+    assert.equal(await db.getVersion(), 3);
+  });
+
+  test('_doUpgrade runs upgrade script with multiple statements', async function() {
+    await db._doUpgrade(`
+    begin
+      create table foo as select 1 as bar;
+      create table foo2 as select 2 as bar2;
+    end`, 1);
+    assert.equal(await db.getVersion(), 1);
+    await db._withClient(READ, async client => {
+      let res = await client.query('select * from foo');
+      assert.deepEqual(res.rows, [{bar: 1}]);
+      res = await client.query('select * from foo2');
+      assert.deepEqual(res.rows, [{bar2: 2}]);
+    });
+  });
+
+  test('failed _doUpgrade does not modify version', async function() {
+    try {
+      await db._doUpgrade(`
+      begin
+        create table tcversion (foo integer);
+      end`, 1);
+    } catch (err) {
+      assert.equal(err.code, '42P07'); // duplicate table
+      assert.equal(await db.getVersion(), 0);
+      return;
+    }
+    throw new Error('_doUpgrade did not fail');
+  });
+
+  test('_defineMethod redefines a function', async function() {
+    await db._withClient(WRITE, async client => {
+      await client.query(`create schema if not exists "taskcluster_lib_postgres"`);
+      await db._defineMethod('foo', 'name text', 'text',
+        'BEGIN return concat(\'first version\'); end');
+      await db._defineMethod('foo', 'name text', 'text',
+        'BEGIN return concat(\'abc\', name); end');
+      const res = await client.query('select * from foo(\'xyz\')');
+      assert.deepEqual(res.rows, [{foo: 'abcxyz'}]);
+    });
+  });
+
+  test('setup creates methods that can be called', async function() {
+    await schema.upgrade({runUpgrades: true, readDbUrl: this.dbUrl, writeDbUrl: this.dbUrl});
+    const db = await schema.setup({readDbUrl: this.dbUrl, writeDbUrl: this.dbUrl});
+    try {
+      await db.testdata();
+      const res = await db.addup(13);
+      assert.deepEqual(res.map(r => r.total).sort(), [16, 20]);
+    } finally {
+      await db.close();
+    }
+  });
+});

--- a/libraries/postgres/test/helper.js
+++ b/libraries/postgres/test/helper.js
@@ -1,0 +1,48 @@
+const {Client} = require('pg');
+const dbUrl = process.env.TEST_DB_URL;
+
+/**
+ * Tests should always use this serviceName (as this is the schema that
+ * the tests will clean out)
+ */
+exports.serviceName = 'taskcluster-lib-postgres';
+
+/**
+ * dbSuite(..) is a replacement for suite(..) that sets this.dbUrl when
+ * a dbUrl exists, or skips when none is available.
+ */
+if (dbUrl) {
+  exports.dbSuite = (...args) => {
+    suite(...args.slice(0, -1), function() {
+      suiteSetup('setup database', function() {
+        this.dbUrl = dbUrl;
+      });
+      setup('clear database', async function() {
+        await clearDb(dbUrl);
+      });
+      args[args.length - 1].call(this);
+    });
+  };
+} else {
+  // TODO: check NO_TEST_SKIP
+  console.error('Set TEST_DB_URL to run tests for this library');
+  exports.dbSuite = (...args) => {
+    suite(...args.slice(0, -1), function() {
+      suiteSetup(function() {
+        this.pending = true;
+      });
+      args[args.length - 1].call(this);
+    });
+  };
+}
+
+const clearDb = async dbUrl => {
+  const client = new Client({connectionString: dbUrl});
+  await client.connect();
+  try {
+    const schemaName = exports.serviceName.replace(/-/g, '_');
+    await client.query(`drop schema if exists ${schemaName} cascade`);
+  } finally {
+    client.end();
+  }
+};

--- a/libraries/postgres/test/mocha.opts
+++ b/libraries/postgres/test/mocha.opts
@@ -1,0 +1,3 @@
+--ui tdd
+--timeout 120s
+--reporter spec

--- a/libraries/postgres/test/schema_test.js
+++ b/libraries/postgres/test/schema_test.js
@@ -1,0 +1,23 @@
+const {dbSuite} = require('./helper');
+const {Schema} = require('..');
+const path = require('path');
+
+suite(path.basename(__filename), function() {
+  suite('constructor', function() {
+    test('configure single version', function() {
+      const sch = new Schema({
+        serviceName: 'taskcluster-lib-postgres',
+        script: 'create table',
+      });
+    });
+
+    test('configure multiple versions', function() {
+      const sch = new Schema({
+        serviceName: 'taskcluster-lib-postgres',
+        script: 'create table',
+      }).addVersion(2, 'alter table');
+    });
+
+    // TODO: more
+  });
+});

--- a/libraries/postgres/test/util_test.js
+++ b/libraries/postgres/test/util_test.js
@@ -1,0 +1,15 @@
+const {dollarQuote} = require('../src/util');
+const assert = require('assert');
+const path = require('path');
+
+suite(path.basename(__filename), function() {
+  suite('dollarQuote', function() {
+    test('simple string', function() {
+      assert.equal(dollarQuote('abcd'), '$$abcd$$');
+    });
+
+    test('string containing $$', function() {
+      assert.equal(dollarQuote('pre $$abcd$$ post'), '$-$pre $$abcd$$ post$-$');
+    });
+  });
+});

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "taskcluster-lib-iterate": "link:libraries/iterate",
     "taskcluster-lib-loader": "link:libraries/loader",
     "taskcluster-lib-monitor": "link:libraries/monitor",
+    "taskcluster-lib-postgres": "link:libraries/postgres",
     "taskcluster-lib-pulse": "link:libraries/pulse",
     "taskcluster-lib-references": "link:libraries/references",
     "taskcluster-lib-scopes": "link:libraries/scopes",

--- a/services/secrets/config.yml
+++ b/services/secrets/config.yml
@@ -17,11 +17,9 @@ defaults:
       clientId:                   !env TASKCLUSTER_CLIENT_ID
       accessToken:                !env TASKCLUSTER_ACCESS_TOKEN
 
-  azure:
-    accountId:                    !env AZURE_ACCOUNT
-    tableName:                    !env AZURE_TABLE_NAME
-    cryptoKey:                    !env AZURE_CRYPTO_KEY
-    signingKey:                   !env AZURE_SIGNING_KEY
+  postgres:
+    readDbUrl:                    !env READ_DB_URL
+    writeDbUrl:                   !env WRITE_DB_URL
 
   monitoring:
     project:                    !env MONITORING_PROJECT

--- a/services/secrets/src/api.js
+++ b/services/secrets/src/api.js
@@ -19,7 +19,7 @@ let builder = new APIBuilder({
   ].join('\n'),
   serviceName: 'secrets',
   apiVersion: 'v1',
-  context: ['cfg', 'Secret'],
+  context: ['cfg', 'db'],
 });
 
 // Export API
@@ -46,24 +46,7 @@ builder.declare({
 }, async function(req, res) {
   let {name} = req.params;
   let {secret, expires} = req.body;
-  try {
-    await this.Secret.create({
-      name: name,
-      secret: secret,
-      expires: new Date(expires),
-    });
-  } catch (e) {
-    // If the entity exists, update it
-    if (e.name === 'EntityAlreadyExistsError') {
-      let item = await this.Secret.load({name});
-      await item.modify(function() {
-        this.secret = secret;
-        this.expires = new Date(expires);
-      });
-    } else {
-      throw e;
-    }
-  }
+  await this.db.setSecret(name, secret, expires);
   res.reply({});
 });
 
@@ -79,15 +62,7 @@ builder.declare({
   ].join('\n'),
 }, async function(req, res) {
   let {name} = req.params;
-  try {
-    await this.Secret.remove({name: name});
-  } catch (e) {
-    if (e.name === 'ResourceNotFoundError') {
-      return res.reportError('ResourceNotFound', 'Secret not found', {});
-    } else {
-      throw e;
-    }
-  }
+  await this.db.removeSecret(name);
   res.reply({});
 });
 
@@ -107,21 +82,18 @@ builder.declare({
   ].join('\n'),
 }, async function(req, res) {
   let {name} = req.params;
-  let item = undefined;
-  try {
-    item = await this.Secret.load({name});
-  } catch (e) {
-    if (e.name === 'ResourceNotFoundError') {
-      return res.reportError('ResourceNotFound', 'Secret not found', {});
-    } else {
-      throw e;
-    }
+  const rows = await this.db.getSecret(name);
+  if (rows.length === 0) {
+    return res.reportError('ResourceNotFound', 'Secret not found', {});
   }
-  if (item.isExpired()) {
+  const row = rows[0];
+  if (row.expires < new Date()) {
     return res.reportError('ResourceExpired', 'The requested resource has expired.', {});
-  } else {
-    res.reply(item.json());
   }
+  res.reply({
+    secret: JSON.parse(row.secret),
+    expires: row.expires.toJSON(),
+  });
 });
 
 builder.declare({
@@ -149,12 +121,10 @@ builder.declare({
     'use the query-string option `limit` to return fewer.',
   ].join('\n'),
 }, async function(req, res) {
-  const continuation = req.query.continuationToken || null;
-  const limit = Math.min(parseInt(req.query.limit || 1000, 10), 1000);
-  const query = await this.Secret.scan({}, {continuation, limit});
+  // TODO: continuationToken / limit
+  const secrets = await this.db.listSecrets();
 
   return res.reply({
-    secrets: query.entries.map(secret => secret.name),
-    continuationToken: query.continuation || undefined,
+    secrets: secrets.map(secret => secret.name),
   });
 });

--- a/services/secrets/src/schema.js
+++ b/services/secrets/src/schema.js
@@ -1,0 +1,35 @@
+const {Schema, READ, WRITE} = require('taskcluster-lib-postgres');
+
+const schema = new Schema({
+  serviceName: 'secrets',
+  script: `
+    begin
+      create table secrets (
+        name text primary key,
+        secret text
+      );
+    end`})
+  .addVersion(2, `
+    begin
+      alter table secrets add column expires timestamp;
+    end`)
+  .addMethod('getSecret', READ, 'name text', 'table (secret text, expires timestamp)', `
+    begin
+      return query select secrets.secret, secrets.expires from secrets where secrets.name = getSecret.name;
+    end`)
+  .addMethod('listSecrets', READ, '', 'table (name text, expires timestamp)', `
+    begin
+      return query select secrets.name as name, secrets.expires as expires from secrets;
+    end`)
+  .addMethod('removeSecret', WRITE, 'name text', 'void', `
+    begin
+      delete from secrets where name = name;
+    end`)
+  .addMethod('setSecret', WRITE, 'name text, secret text, expires timestamp', 'void', `
+    begin
+      insert into secrets values (name, secret, expires)
+      on conflict do update
+      set secret=secret, expires=expires;
+    end`);
+
+module.exports = schema;

--- a/yarn.lock
+++ b/yarn.lock
@@ -851,6 +851,11 @@ buffer-more-ints@~1.0.0:
   resolved "https://registry.yarnpkg.com/buffer-more-ints/-/buffer-more-ints-1.0.0.tgz#ef4f8e2dddbad429ed3828a9c55d44f05c611422"
   integrity sha512-EMetuGFz5SLsT0QTnXzINh4Ksr+oo4i+UGTXEshiGCQWnsgSs7ZhJ8fzlwQ+OzEMs0MpDAMr1hxnblp5a4vcHg==
 
+buffer-writer@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/buffer-writer/-/buffer-writer-2.0.0.tgz#ce7eb81a38f7829db09c873f2fbb792c0c98ec04"
+  integrity sha512-a7ZpuTZU1TRtnwyCNW3I5dc0wWNC3VR9S++Ewyk2HHZdrO3CQJqSpd+95Us590V6AL7JqUAH2IwZ/398PmNFgw==
+
 buffer@4.9.1:
   version "4.9.1"
   resolved "https://registry.yarnpkg.com/buffer/-/buffer-4.9.1.tgz#6d1bb601b07a4efced97094132093027c95bc298"
@@ -4267,6 +4272,11 @@ pac-resolver@^3.0.0:
   resolved "https://registry.yarnpkg.com/package/-/package-1.0.1.tgz#d25a1f99e2506dcb27d6704b83dca8a312e4edcc"
   integrity sha1-0lofmeJQbcsn1nBLg9yooxLk7cw=
 
+packet-reader@0.3.1:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/packet-reader/-/packet-reader-0.3.1.tgz#cd62e60af8d7fea8a705ec4ff990871c46871f27"
+  integrity sha1-zWLmCvjX/qinBexP+ZCHHEaHHyc=
+
 param-case@^1.1.0:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/param-case/-/param-case-1.1.2.tgz#dcb091a43c259b9228f1c341e7b6a44ea0bf9743"
@@ -4367,6 +4377,52 @@ performance-now@^2.1.0:
   resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-2.1.0.tgz#6309f4e0e5fa913ec1c69307ae364b4b377c9e7b"
   integrity sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=
 
+pg-connection-string@0.1.3:
+  version "0.1.3"
+  resolved "https://registry.yarnpkg.com/pg-connection-string/-/pg-connection-string-0.1.3.tgz#da1847b20940e42ee1492beaf65d49d91b245df7"
+  integrity sha1-2hhHsglA5C7hSSvq9l1J2RskXfc=
+
+pg-int8@1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/pg-int8/-/pg-int8-1.0.1.tgz#943bd463bf5b71b4170115f80f8efc9a0c0eb78c"
+  integrity sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==
+
+pg-pool@^2.0.4:
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/pg-pool/-/pg-pool-2.0.6.tgz#7b561a482feb0a0e599b58b5137fd2db3ad8111c"
+  integrity sha512-hod2zYQxM8Gt482q+qONGTYcg/qVcV32VHVPtktbBJs0us3Dj7xibISw0BAAXVMCzt8A/jhfJvpZaxUlqtqs0g==
+
+pg-types@~2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/pg-types/-/pg-types-2.0.0.tgz#038ddc302a0340efcdb46d0581cc7caa2303cbba"
+  integrity sha512-THUD7gQll5tys+5eQ8Rvs7DjHiIC3bLqixk3gMN9Hu8UrCBAOjf35FoI39rTGGc3lM2HU/R+Knpxvd11mCwOMA==
+  dependencies:
+    pg-int8 "1.0.1"
+    postgres-array "~2.0.0"
+    postgres-bytea "~1.0.0"
+    postgres-date "~1.0.0"
+    postgres-interval "^1.1.0"
+
+pg@^7.8.0:
+  version "7.8.0"
+  resolved "https://registry.yarnpkg.com/pg/-/pg-7.8.0.tgz#541c25b3323d85f67ce7d4501a77470976868ce9"
+  integrity sha512-yS3C9YD+ft0H7G47uU0eKajgTieggCXdA+Fxhm5G+wionY6kPBa8BEVDwPLMxQvkRkv3/LXiFEqjZm9gfxdW+g==
+  dependencies:
+    buffer-writer "2.0.0"
+    packet-reader "0.3.1"
+    pg-connection-string "0.1.3"
+    pg-pool "^2.0.4"
+    pg-types "~2.0.0"
+    pgpass "1.x"
+    semver "4.3.2"
+
+pgpass@1.x:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/pgpass/-/pgpass-1.0.2.tgz#2a7bb41b6065b67907e91da1b07c1847c877b306"
+  integrity sha1-Knu0G2BltnkH6R2hsHwYR8h3swY=
+  dependencies:
+    split "^1.0.0"
+
 pify@^2.0.0, pify@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/pify/-/pify-2.3.0.tgz#ed141a6ac043a849ea588498e7dca8b15330e90c"
@@ -4398,6 +4454,28 @@ pluralize@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/pluralize/-/pluralize-7.0.0.tgz#298b89df8b93b0221dbf421ad2b1b1ea23fc6777"
   integrity sha512-ARhBOdzS3e41FbkW/XWrTEtukqqLoK5+Z/4UeDaLuSW+39JPeFgs4gCGqsrJHVZX0fUrx//4OF0K1CUGwlIFow==
+
+postgres-array@~2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/postgres-array/-/postgres-array-2.0.0.tgz#48f8fce054fbc69671999329b8834b772652d82e"
+  integrity sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==
+
+postgres-bytea@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/postgres-bytea/-/postgres-bytea-1.0.0.tgz#027b533c0aa890e26d172d47cf9ccecc521acd35"
+  integrity sha1-AntTPAqokOJtFy1Hz5zOzFIazTU=
+
+postgres-date@~1.0.0:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/postgres-date/-/postgres-date-1.0.3.tgz#e2d89702efdb258ff9d9cee0fe91bd06975257a8"
+  integrity sha1-4tiXAu/bJY/52c7g/pG9BpdSV6g=
+
+postgres-interval@^1.1.0:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/postgres-interval/-/postgres-interval-1.1.2.tgz#bf71ff902635f21cb241a013fc421d81d1db15a9"
+  integrity sha512-fC3xNHeTskCxL1dC8KOtxXt7YeFmlbTYtn7ul8MkVERuTmf7pI4DrkAxcw3kh1fQ9uz4wQmd03a1mRiXUZChfQ==
+  dependencies:
+    xtend "^4.0.0"
 
 prelude-ls@~1.1.2:
   version "1.1.2"
@@ -5049,6 +5127,11 @@ scandirectory@^2.5.0:
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.6.0.tgz#7e74256fbaa49c75aa7c7a205cc22799cac80004"
   integrity sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg==
 
+semver@4.3.2:
+  version "4.3.2"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-4.3.2.tgz#c7a07158a80bedd052355b770d82d6640f803be7"
+  integrity sha1-x6BxWKgL7dBSNVt3DYLWZA+AO+c=
+
 send@0.16.2:
   version "0.16.2"
   resolved "https://registry.yarnpkg.com/send/-/send-0.16.2.tgz#6ecca1e0f8c156d141597559848df64730a6bbc1"
@@ -5282,7 +5365,7 @@ split-ca@^1.0.0:
   resolved "https://registry.yarnpkg.com/split-ca/-/split-ca-1.0.1.tgz#6c83aff3692fa61256e0cd197e05e9de157691a6"
   integrity sha1-bIOv82kvphJW4M0ZfgXp3hV2kaY=
 
-split@^1.0.1:
+split@^1.0.0, split@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/split/-/split-1.0.1.tgz#605bd9be303aa59fb35f9229fbea0ddec9ea07d9"
   integrity sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==
@@ -5583,6 +5666,10 @@ tar@^4:
   uid ""
 
 "taskcluster-lib-monitor@link:libraries/monitor":
+  version "0.0.0"
+  uid ""
+
+"taskcluster-lib-postgres@link:libraries/postgres":
   version "0.0.0"
   uid ""
 


### PR DESCRIPTION
This is a sketch of a new taskcluster-lib-postgres, plus use of that
library in the secrets service.  This is *not* meant to land as-is; instead
please see it as a working sketch of a general idea.

# Overview

The central idea here is to make all DB access go via stored procedures,
and to keep the behavior of those stored procedures fixed forever, such
that old and new versions of a TC service can run simultaneously with no
downtime, even after a schema upgrade.  That schema upgrade will include
modifications to all affected stored procedures such that they continue
to have the same behavior despite changes to the underlying tables.

# Discipline

As we have for Azure tables, we will need to commit to only ever
appending to a Schema object (.addVersion, .addMethod) and never
modifying the existing definitions, except for bugfixes to existing
stored procedures. This has been easy to verify in review for Azure.

# Deployment

Users can deploy all services on a single postgres server (by setting
all *_DB_URL to the same value), in which case the services will not
collide with one another since they use distinct schema names.  Users
can also choose to deploy some or all services to different databases or
even servers, or to split read and write traffic to different servers.

# Updates

We will work a one-off run of `updateDb` into every terraform run, such
that the running application won't be updated to the new version until
`updateDb` has run successfully.  That will perform schema migrations
where necessary (as specified by `addVersion`) and will re-write the
stored functions on every run so that updates that only affect functions
do not require a database version change.

# Testing DB Definitions

An advantage of keeping *all* history of a schema is that we can test
inter-version compatibility.  For example, we can upgrade to version 1,
insert some test data, verify that function X returns expected data,
then upgrade to the latest version and verify that it continues to
return precisely the same data.

With a little more thought, we can regularize and automate this approach
so that it's easy to test that method behaviors don't change from
version to version.

# Testing Non-DB Code

Because all access to the DB is via regularized DB functions that appear
as normal JS functions, replacing the DB object with a fake is trivial.
So, most services can be tested both with and without a DB, just as we
do now for Azure, meaning that contributors can just run `yarn test` and
get useful results, without setting up a postgres server.

# TODO

 - secrets tests for DB definitions
 - secrets tests updated to use fakes
 - terraform support
 - deploy secrets to a dev environment using postgres

# Future

 - pg-cursor supports streaming responses, so we could have some methods
   return streaming data, rather than the full set of rows
 - performance metrics (slow queries, etc.)
 - wrapper for continuation / limit handling
 - custom pg datatype for on-the-fly encryption / decryption (which is
   what azure-entities does)