### PR TITLE
Fix typo causing Docker tarballs to contain .git directories

### DIFF
--- a/infrastructure/builder/src/build/service/heroku-buildpack.js
+++ b/infrastructure/builder/src/build/service/heroku-buildpack.js
@@ -195,7 +195,7 @@ exports.herokuBuildpackTasks = ({tasks, baseDir, spec, cfg, name, cmdOptions, re
       const appGitDir = path.join(appDir, '.git');
       return tar.pack(workDir, {
         entries: ['app', 'Dockerfile'],
-        ignore: fulname => name.startsWith(appGitDir),
+        ignore: name => name.startsWith(appGitDir),
       });
     },
   });


### PR DESCRIPTION
This just made Docker run a bit slower as we had to upload that tarball.