### PR TITLE
Bug 1520061 - build monorepo from a git clone, not working copy

### DIFF
--- a/infrastructure/builder/taskcluster-spec/build.yml
+++ b/infrastructure/builder/taskcluster-spec/build.yml
@@ -1,4 +1,8 @@
 ---
+# http://bugzil.la/1516347 will remove this ugliness!
+monorepo:
+  https://github.com/taskcluster/taskcluster#master
+
 repositories:
 
 # services


### PR DESCRIPTION
This will get changed pretty radically when we build into a single docker image (bug 1516347). But the fundamental problem is still there: balancing ease of development against security.

Building from your working copy makes it easy to, for example, build an image of your current work in progress and test it in a dev deployment.  As I've implemented this, doing otherwise would require pushing to a github repo, then editing the spec to point to that branch on that repo, then building.

Other ideas:
 * `git clone` from the working copy by default, and warn if `git status` shows un-checked-in files.  This would safely ignore everything that git ignores
 * `git clone` from the working copy when given a command-line option (e.g., `--local-repo`)

thoughts?