### PR TITLE
Fix promises in irc

### DIFF
--- a/services/notify/src/irc.js
+++ b/services/notify/src/irc.js
@@ -1,5 +1,4 @@
 const debug = require('debug')('notify');
-const util = require('util');
 const irc = require('irc-upd');
 const assert = require('assert');
 const aws = require('aws-sdk');
@@ -56,10 +55,14 @@ class IRCBot {
   }
 
   async start() {
-    await util.promisify(this.client.connect)().catch((e) => {
-      // We always get an error when connecting to irc.mozilla.org
-      if (e.command !== 'rpl_welcome') {
-        throw e;
+    await new Promise((resolve, reject) => {
+      try {
+        this.client.connect(resolve);
+      } catch (err) {
+        if (err.command !== 'rpl_welcome') {
+          reject(err);
+        }
+        resolve();
       }
     });
 
@@ -129,7 +132,13 @@ class IRCBot {
   async terminate() {
     this.stopping = true;
     await this.done;
-    await util.promisify(this.client.disconnect)();
+    await new Promise((resolve, reject) => {
+      try {
+        this.client.disconnect(resolve);
+      } catch (err) {
+        reject(err);
+      }
+    });
   }
 
 }


### PR DESCRIPTION
The `util.promisify` doesn't seem to have worked and I'm not sure why! This should work I hope.

Currently:

```

Jan 15 09:03:16 taskcluster-notify app/irc.1: 2019-01-15T17:03:16.591Z taskcluster-lib-loader error while loading component 'irc': TypeError: this.once is not a function 
Jan 15 09:03:16 taskcluster-notify app/irc.1: TypeError: this.once is not a function 
Jan 15 09:03:16 taskcluster-notify app/irc.1:     at Client.connect (/app/node_modules/irc-upd/lib/irc.js:785:14) 
Jan 15 09:03:16 taskcluster-notify app/irc.1:     at Promise (internal/util.js:276:30) 
Jan 15 09:03:16 taskcluster-notify app/irc.1:     at new Promise (<anonymous>) 
Jan 15 09:03:16 taskcluster-notify app/irc.1:     at internal/util.js:275:12 
Jan 15 09:03:16 taskcluster-notify app/irc.1:     at IRCBot.start (/app/services/notify/src/irc.js:59:46) 
Jan 15 09:03:16 taskcluster-notify app/irc.1:     at setup (/app/services/notify/src/main.js:162:20) 
Jan 15 09:03:16 taskcluster-notify app/irc.1:     at Promise (/app/libraries/loader/src/loader.js:217:33) 
Jan 15 09:03:16 taskcluster-notify app/irc.1:     at new Promise (<anonymous>) 
Jan 15 09:03:16 taskcluster-notify app/irc.1:     at loaded.(anonymous function).Promise.all.then.deps (/app/libraries/loader/src/loader.js:215:18) 
Jan 15 09:03:16 taskcluster-notify app/irc.1:     at process._tickCallback (internal/process/next_tick.js:68:7) 
Jan 15 09:03:16 taskcluster-notify app/irc.1:     at Function.Module.runMain (internal/modules/cjs/loader.js:744:11) 
Jan 15 09:03:16 taskcluster-notify app/irc.1:     at startup (internal/bootstrap/node.js:285:19) 
Jan 15 09:03:16 taskcluster-notify app/irc.1:     at bootstrapNodeJSCore (internal/bootstrap/node.js:739:3) 
Jan 15 09:03:16 taskcluster-notify heroku/irc.1: State changed from up to crashed 
Jan 15 09:03:16 taskcluster-notify heroku/irc.1: Process exited with status 1 
```