### PR TITLE
Remove outdated resolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,8 +94,5 @@
   "eslintIgnore": [
     "**/node_modules/**",
     "**/test/fixtures/**"
-  ],
-  "resolutions": {
-    "**/remotely-signed-s3/libxmljs": "^0.19.5"
-  }
+  ]
 }


### PR DESCRIPTION
We no longer need this after remotely-signed-s3 was released