### PR TITLE
Bug in checks: creates a checkrun for the whole group

### DIFF
--- a/services/github/src/handlers.js
+++ b/services/github/src/handlers.js
@@ -295,11 +295,17 @@ async function deprecatedStatusHandler(message) {
     do {
       let group = await this.queueClient.listTaskGroup(message.payload.taskGroupId, params);
       params.continuationToken = group.continuationToken;
-      group.tasks.forEach(task => {
-        if (['failed', 'exception'].includes(task.status.state)) {
+
+      for (let i = 0; i < group.tasks.length; i++) {
+        // don't post group status for checks API
+        if (group.tasks[i].task.routes.includes(this.context.cfg.app.checkTaskRoute)) {return;}
+
+        if (['failed', 'exception'].includes(group.tasks[i].status.state)) {
           state = 'failure';
+          break; // one failure is enough, no need to loop through the whole thing
         }
-      });
+      }
+
     } while (params.continuationToken);
   }
 

--- a/services/github/src/handlers.js
+++ b/services/github/src/handlers.js
@@ -298,15 +298,18 @@ async function deprecatedStatusHandler(message) {
 
       for (let i = 0; i < group.tasks.length; i++) {
         // don't post group status for checks API
-        if (group.tasks[i].task.routes.includes(this.context.cfg.app.checkTaskRoute)) {return;}
+        if (group.tasks[i].task.routes.includes(this.context.cfg.app.checkTaskRoute)) {
+          debug(`Task group result status not updated: Task group ${taskGroupId} uses Checks API. Exiting`);
+          return;
+        }
 
         if (['failed', 'exception'].includes(group.tasks[i].status.state)) {
           state = 'failure';
-          break; // one failure is enough, no need to loop through the whole thing
+          break; // one failure is enough
         }
       }
 
-    } while (params.continuationToken);
+    } while (params.continuationToken && state === 'success');
   }
 
   if (message.exchange.endsWith('task-exception') || message.exchange.endsWith('task-failed')) {

--- a/services/github/src/handlers.js
+++ b/services/github/src/handlers.js
@@ -3,7 +3,6 @@ const taskcluster = require('taskcluster-client');
 const libUrls = require('taskcluster-lib-urls');
 const yaml = require('js-yaml');
 const assert = require('assert');
-const _ = require('lodash');
 const prAllowed = require('./pr-allowed');
 const {consume} = require('taskcluster-lib-pulse');
 
@@ -292,15 +291,12 @@ async function deprecatedStatusHandler(message) {
   let state = 'success';
 
   if (message.exchange.endsWith('task-group-resolved')) {
-    let queue = new taskcluster.Queue({
-      rootUrl: this.context.cfg.taskcluster.rootUrl,
-    });
     let params = {};
     do {
-      let group = await queue.listTaskGroup(message.payload.taskGroupId, params);
+      let group = await this.queueClient.listTaskGroup(message.payload.taskGroupId, params);
       params.continuationToken = group.continuationToken;
       group.tasks.forEach(task => {
-        if (_.includes(['failed', 'exception'], task.status.state)) {
+        if (['failed', 'exception'].includes(task.status.state)) {
           state = 'failure';
         }
       });
@@ -495,13 +491,13 @@ async function jobHandler(message) {
       debug(`${organization}/${repository}@${sha} has no '.taskcluster.yml'. Skipping.`);
       return;
     }
-    if (_.endsWith(e.message, '</body>\n</html>\n') && e.message.length > 10000) {
+    if (e.message.endsWith('</body>\n</html>\n') && e.message.length > 10000) {
       // We kept getting full html 500/400 pages from github in the logs.
       // I consider this to be a hard-to-fix bug in octokat, so let's make
       // the logs usable for now and try to fix this later. It's a relatively
       // rare occurence.
       debug('Detected an extremely long error. Truncating!');
-      e.message = _.join(_.take(e.message, 100).concat('...'), '');
+      e.message = e.message.slice(0, 100).concat('...');
       e.stack = e.stack.split('</body>\n</html>\n')[1] || e.stack;
     }
     debug(`Error fetching yaml for ${organization}/${repository}@${sha}: ${e.message} \n ${e.stack}`);

--- a/services/github/src/tc-yaml.js
+++ b/services/github/src/tc-yaml.js
@@ -128,7 +128,7 @@ class VersionZero extends TcYaml {
         throw new Error('Cannot specify both `branches` and `excludeBranches` in the same task!');
       }
 
-      return _.some(events, ev => {
+      return events.some(ev => {
         if (!event.startsWith(_.trimEnd(ev, '*'))) {
           return false;
         }
@@ -138,9 +138,9 @@ class VersionZero extends TcYaml {
         }
 
         if (includeBranches) {
-          return _.includes(includeBranches, branch);
+          return includeBranches.includes(branch);
         } else if (excludeBranches) {
-          return !_.includes(excludeBranches, branch);
+          return !excludeBranches.includes(branch);
         } else {
           return true;
         }
@@ -154,7 +154,7 @@ class VersionZero extends TcYaml {
       config.tasks = config.tasks.map((task) => {
         return {
           taskId: task.taskId,
-          task: _.extend(task.task, {taskGroupId, schedulerId: cfg.taskcluster.schedulerId}),
+          task: {...task.task, ...{taskGroupId, schedulerId: cfg.taskcluster.schedulerId}},
         };
       });
     }


### PR DESCRIPTION
I decided to try this: since we get all the tasks anyway, I added a check to examine their `routes` field. If at least a single task belongs to the checks API - stop the whole handler.

I also modified the loop so that we stop iterating as soon as we found a failing task. For all the above I have to use good old `for` loop (I know, I'm so fancy ✨)

Finally, I scratched my lodash itch