### PR TITLE
Fix: Worker types view modal not opening

### DIFF
--- a/ui/src/components/Button/index.jsx
+++ b/ui/src/components/Button/index.jsx
@@ -50,7 +50,7 @@ export default class Button extends Component {
     spanProps: object,
   };
 
-  handleButtonClick = () => {
+  handleButtonClick = e => {
     const { onClick, track } = this.props;
 
     if (track && process.env.GA_TRACKING_ID) {
@@ -60,7 +60,7 @@ export default class Button extends Component {
     }
 
     if (onClick) {
-      onClick();
+      onClick(e);
     }
   };
 

--- a/ui/src/components/WorkerTypesTable/index.jsx
+++ b/ui/src/components/WorkerTypesTable/index.jsx
@@ -141,7 +141,7 @@ export default class WorkerTypesTable extends Component {
     });
   };
 
-  handleDrawerOpen = ({ target: { name } }) =>
+  handleDrawerOpen = ({ currentTarget: { name } }) =>
     memoize(
       name =>
         this.setState({


### PR DESCRIPTION
A [commit](https://github.com/taskcluster/taskcluster-web/commit/508ff89e65304d8e67723f039b62502c5ed91dbe) later added after the migration of tc-web to the monorepo has started.