### PR TITLE
Configure renovate to send PRs on a weekly basis

### DIFF
--- a/package.json
+++ b/package.json
@@ -99,7 +99,8 @@
     "extends": [
       "config:base",
       ":preserveSemverRanges",
-      ":rebaseStalePrs"
+      ":rebaseStalePrs",
+      "schedule:weekly"
     ]
   },
   "eslintIgnore": [


### PR DESCRIPTION
From IRC:

```
<dustin> hassan: do we need to adjust renovate settings somehow for tc-web?  That's a lot of PRs :)
9:34 AM 
<hassan> dustin: yeah :) i think having renovate send a PR once a week would be good. thoughts?
9:36 AM 
<dustin> for just one dependency?  I suspect we would fall behind at that rate, judging by the number of PRs we've seen just for the other services
9:38 AM 
<hassan> dustin: no, for all dependencies. I prefer to deal with all renovate PRs at once than to be notified every couple of hours
9:38 AM 
<dustin> ah, that seems reasonable then.  Let's see what brian says
```