### PR TITLE
[Bug 1491551] continue - expire limit lastfires to 100 per hookId

### DIFF
--- a/services/hooks/config.yml
+++ b/services/hooks/config.yml
@@ -6,6 +6,7 @@ defaults:
     lastFireTableName: !env LASTFIRE_TABLE_NAME
     queuesTableName:  !env QUEUE_TABLE_NAME
     publishMetaData:  !env:bool PUBLISH_METADATA
+    lastFiresExpirationDelay: '- 1 day'
     scheduler:
       pollingDelay:   60000
   influx:

--- a/services/hooks/package.json
+++ b/services/hooks/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "heroku-prebuild": "echo $SOURCE_VERSION > .git-version",
     "lint": "eslint src/*.js test/*.js",
-    "test": "mocha test/expires_test.js"
+    "test": "mocha test/*_test.js"
   },
   "author": "",
   "license": "MPL-2.0",

--- a/services/hooks/package.json
+++ b/services/hooks/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "heroku-prebuild": "echo $SOURCE_VERSION > .git-version",
     "lint": "eslint src/*.js test/*.js",
-    "test": "mocha test/*_test.js"
+    "test": "mocha test/expires_test.js"
   },
   "author": "",
   "license": "MPL-2.0",

--- a/services/hooks/src/data.js
+++ b/services/hooks/src/data.js
@@ -222,37 +222,39 @@ LastFire.prototype.definition = function() {
 };
 
 LastFire.expires = async function(Hook, now, n = 100) {
-  const hookIds = new Set();
+  const hookKeys = [];
   let count = 0;
   await Hook.scan({},
     {
       handler: async hook => {
-        const { hookId } = await hook.definition();
-        hookIds.add(hookId);
+        const { hookGroupId, hookId } = await hook.definition();
+        hookKeys.push({ hookGroupId, hookId });
       },
     },
   );
 
-  for (hookId of hookIds) {
+  for ({ hookGroupId, hookId } of hookKeys) {
     const hookData = [];
     await this.scan({
       taskCreateTime: Entity.op.lessThan(now),
+      hookGroupId: Entity.op.equal(hookGroupId),
       hookId: Entity.op.equal(hookId)}, {
       limit: 500,
       handler: async item => {
-        const { hookGroupId, taskId, taskCreateTime } = await item.definition();
-        hookData.push({hookGroupId, taskId, taskCreateTime});
+        const { taskId, taskCreateTime } = await item.definition();
+        hookData.push({taskId, taskCreateTime});
       },
     },
     );
     hookData.sort((a, b) =>
       new Date(b.taskCreateTime) - new Date(a.taskCreateTime));
 
-    for(let i=n;i<hookData.length;i++) {
+    hookData.splice(0, n);
+    for(let data of hookData) {
       await this.remove({
-        hookGroupId: hookData[i].hookGroupId,
+        hookGroupId,
         hookId,
-        taskId: hookData[i].taskId});
+        taskId: data.taskId});
       count++;
     }
   }

--- a/services/hooks/src/main.js
+++ b/services/hooks/src/main.js
@@ -227,12 +227,12 @@ const load = loader({
   },
 
   expires: {
-    requires: ['cfg', 'LastFire', 'monitor'],
-    setup: ({cfg, LastFire, monitor}) => {
+    requires: ['cfg', 'Hook', 'LastFire', 'monitor'],
+    setup: ({cfg, Hook, LastFire, monitor}) => {
       return monitor.oneShot('expire LastFires', async () => {
         const expirationTime = taskcluster.fromNow(cfg.app.lastFiresExpirationDelay);
         debug('Expiring lastFires rows');
-        const count = await LastFire.expires(expirationTime);
+        const count = await LastFire.expires(Hook, expirationTime);
         debug(`Expired ${count} rows`);
       });
     },

--- a/services/hooks/src/main.js
+++ b/services/hooks/src/main.js
@@ -226,6 +226,18 @@ const load = loader({
     setup: ({schedulerNoStart}) => schedulerNoStart.start(),
   },
 
+  expires: {
+    requires: ['cfg', 'LastFire', 'monitor'],
+    setup: ({cfg, LastFire, monitor}) => {
+      return monitor.oneShot('expire LastFires', async () => {
+        const expirationTime = taskcluster.fromNow(cfg.app.lastFiresExpirationDelay);
+        debug('Expiring lastFires rows');
+        const count = await LastFire.expires(expirationTime);
+        debug(`Expired ${count} rows`);
+      });
+    },
+  },
+
 }, ['profile', 'process']);
 
 // If this file is executed launch component from first argument

--- a/services/hooks/src/v1.js
+++ b/services/hooks/src/v1.js
@@ -354,6 +354,22 @@ builder.declare({
   await this.Hook.remove({hookGroupId, hookId}, true);
   this.publisher.hookDeleted({hookGroupId, hookId});
 
+  try {
+    await this.LastFire.query({
+      hookGroupId: req.params.hookGroupId,
+      hookId: req.params.hookId,
+    }, {
+      handler: async (lastFire) => {
+        await lastFire.remove(false, true);
+      },
+    });
+
+    this.publisher.hookLastFiresDeleted({hookGroupId, hookId});
+    // eslint-disable-next-line no-empty
+  } catch (err) {
+    // The hook may have not been ever triggered
+  }
+
   return res.status(200).json({});
 });
 

--- a/services/hooks/src/v1.js
+++ b/services/hooks/src/v1.js
@@ -363,11 +363,9 @@ builder.declare({
         await lastFire.remove(false, true);
       },
     });
-
-    this.publisher.hookLastFiresDeleted({hookGroupId, hookId});
-    // eslint-disable-next-line no-empty
   } catch (err) {
     // The hook may have not been ever triggered
+    throw err;
   }
 
   return res.status(200).json({});

--- a/services/hooks/src/v1.js
+++ b/services/hooks/src/v1.js
@@ -354,20 +354,14 @@ builder.declare({
   await this.Hook.remove({hookGroupId, hookId}, true);
   this.publisher.hookDeleted({hookGroupId, hookId});
 
-  try {
-    await this.LastFire.query({
-      hookGroupId: req.params.hookGroupId,
-      hookId: req.params.hookId,
-    }, {
-      handler: async (lastFire) => {
-        await lastFire.remove(false, true);
-      },
-    });
-  } catch (err) {
-    // The hook may have not been ever triggered
-    throw err;
-  }
-
+  await this.LastFire.query({
+    hookGroupId: req.params.hookGroupId,
+    hookId: req.params.hookId,
+  }, {
+    handler: async (lastFire) => {
+      await lastFire.remove(false, true);
+    },
+  });
   return res.status(200).json({});
 });
 

--- a/services/hooks/test/api_test.js
+++ b/services/hooks/test/api_test.js
@@ -259,10 +259,23 @@ helper.secrets.mockSuite('api_test.js', ['taskcluster'], function(mock, skipping
       await helper.hooks.createHook('foo', 'bar', hookWithTriggerSchema);
       await helper.hooks.removeHook('foo', 'bar');
       await helper.hooks.hook('foo', 'bar').then(
-        () => { throw new Error('The resource should not exist'); },
+        () => { throw new Error('The resource in Hook Table should not exist'); },
         (err) => { assume(err.statusCode).equals(404); });
       helper.checkNextMessage('hook-deleted', ({payload}) =>
         assume({hookGroupId: 'foo', hookId: 'bar'}).deep.equals(payload));
+      await helper.hooks.listLastFires('foo', 'bar').then(
+        () => { throw new Error('The resource in LastFires table should not exist'); },
+        (err) => { assume(err.statusCode).equals(404); });
+    });
+
+    test('remove all lastFires info of the hook ', async () => {
+      await helper.hooks.createHook('foo', 'bar', hookWithTriggerSchema);
+      await helper.hooks.triggerHook('foo', 'bar', {location: 'Belo Horizonte, MG',
+        foo: 'triggerHook'});
+      await helper.hooks.removeHook('foo', 'bar');
+      await helper.hooks.listLastFires('foo', 'bar').then(
+        () => { throw new Error('The resource in LastFires table should not exist'); },
+        (err) => { assume(err.statusCode).equals(404); });
     });
 
     test('removed empty groups', async () => {

--- a/services/hooks/test/expires_test.js
+++ b/services/hooks/test/expires_test.js
@@ -1,0 +1,47 @@
+const helper = require('./helper');
+const taskcluster = require('taskcluster-client');
+const assume = require('assume');
+
+suite('expires_test', function() {
+  helper.secrets.mockSuite('expires_test.js', ['taskcluster'], function(mock, skipping) {
+    helper.withLastFire(mock, skipping);
+
+    test('expire nothing', async function() {
+      const count = await helper.LastFire.expires(new Date());
+      assume(count).to.equal(0);
+    });
+
+    test('keep only 5 most recent lastfire', async function() {
+      const taskIds = [];
+      let entity = {
+        hookGroupId: 'testHookGroup',
+        hookId: 'testhook',
+        firedBy: 'expires-test',
+        result: 'success',
+        error: '',
+      };
+      for(let i=0; i<12;i++) {
+        taskIds.push(taskcluster.slugid());
+        time = new Date();
+        await helper.LastFire.create({...entity, taskId: taskIds[i], taskCreateTime: new Date()});
+      }
+      const count = await helper.LastFire.expires(new Date(), 5);
+      assume(count).to.equal(7);
+
+      recentTaskIds = [];
+      await helper.LastFire.query({
+        hookGroupId: 'testHookGroup',
+        hookId: 'testhook'},
+      {
+        handler: async lastFire => {
+          item = await lastFire.definition();
+          const { taskId } = item;
+          recentTaskIds.push(taskId);
+        },
+      }
+      );
+      taskIds.splice(0, 7);
+      assume(recentTaskIds.sort()).eql(taskIds.sort());
+    });
+  });
+});


### PR DESCRIPTION
Another alternative solution is to get the hookIds from the Hook table. Then load from `Lastfires`  for  each hookId and delete instead of one long scan in the current patch. Because i'm think there can be memory leak with the present solution.