### PR TITLE
Bug 1521796 - use promisepipe to capture errors writing out docs

### DIFF
--- a/libraries/docs/package.json
+++ b/libraries/docs/package.json
@@ -23,6 +23,7 @@
     "lodash": "^4.13.1",
     "mkdirp": "^0.5.1",
     "mz": "^2.7.0",
+    "promisepipe": "^3.0.0",
     "recursive-readdir-sync": "^1.0.6",
     "s3-upload-stream": "^1.0.7",
     "tar-stream": "^1.5.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7099,6 +7099,11 @@ promise@^8.0.1:
   dependencies:
     asap "~2.0.6"
 
+promisepipe@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/promisepipe/-/promisepipe-3.0.0.tgz#c9b6e5aa861ef5fcce6134f6f75e14f8f30bd3b2"
+  integrity sha512-V6TbZDJ/ZswevgkDNpGt/YqNCiZP9ASfgU+p83uJE6NrGtvSGoOcHLiDCqkMs2+yg7F5qHdLV8d0aS8O26G/KA==
+
 propagate@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/propagate/-/propagate-1.0.0.tgz#00c2daeedda20e87e3782b344adba1cddd6ad709"


### PR DESCRIPTION
@walac started using promisepipe on docker-worker a while ago, and it seems designed for precisely this situation.  With this change, I was unable to trigger a failure in a few thousand runs.