### PR TITLE
Bug 1522307 - fix startup of built-in-workers

### DIFF
--- a/services/built-in-workers/src/main.js
+++ b/services/built-in-workers/src/main.js
@@ -56,12 +56,13 @@ const load = loader({
     requires: ['queue', 'cfg'],
     setup: ({cfg, queue}) => new taskqueue.TaskQueue(cfg, queue, 'fail'),
   },
+
   server: {
     requires: ['succeedTaskQueue', 'failTaskQueue'],
-    setup: ({failTaskQueue, succeedTaskQueue}) => async function() {
+    setup: async ({failTaskQueue, succeedTaskQueue}) => {
       await Promise.all([
-        this.succeedTaskQueue.runWorker(),
-        this.failTaskQueue.runWorker(),
+        succeedTaskQueue.runWorker(),
+        failTaskQueue.runWorker(),
       ]);
     },
   },


### PR DESCRIPTION
Bugzilla Bug: [1522307](https://bugzilla.mozilla.org/show_bug.cgi?id=1522307)

/cc @hybrid1999 

This fixes a combination of => and `function` syntax, so the component actually works.  Without this it was just exiting immediately on startup.