### PR TITLE
Bug 1519943 - remove utility to display user profiles

### DIFF
--- a/services/login/src/main.js
+++ b/services/login/src/main.js
@@ -100,25 +100,6 @@ let load = loader({
       return monitor.oneShot('scanner', () => scanner(cfg, handlers));
     },
   },
-
-  // utility function to show Auth0 profile
-  'show-auth0-profile': {
-    requires: ['cfg', 'handlers'],
-    setup: async ({cfg, handlers}) => {
-      let userId = process.argv[3];
-      if (!userId) {
-        console.error('Specify an userId address on the command line');
-        process.exit(1);
-        return;
-      }
-
-      const handler = handlers['mozilla-auth0'];
-
-      console.log(await handler.profileFromUserId(userId));
-      process.exit(0);
-    },
-  },
-
 }, ['profile', 'process']);
 
 if (!module.parent) {


### PR DESCRIPTION
This requires "production" auth0 credentials which are easy to leak.
There are better ways to determine this information, anyway.

Bugzilla Bug: [1519943](https://bugzilla.mozilla.org/show_bug.cgi?id=1519943)
