### PR TITLE
Bug 1517000 - add counts of all fires

### DIFF
--- a/services/hooks/src/taskcreator.js
+++ b/services/hooks/src/taskcreator.js
@@ -77,6 +77,8 @@ class TaskCreator {
       created: new Date(),
       retry: true,
     });
+    this.monitor.count(`fire.${context.firedBy}.all`);
+
     // create a queue instance with its authorized scopes limited to those
     // assigned to the hook.
     let role = 'assume:hook-id:' + hook.hookGroupId + '/' + hook.hookId;
@@ -89,9 +91,11 @@ class TaskCreator {
 
     const task = this.taskForHook(hook, context, options);
     if (!task) {
+      this.monitor.count(`fire.${context.firedBy}.declined`);
       debug(`hook ${hook.hookGroupId}/${hook.hookId} declined to produce a task`);
       return;
     }
+    this.monitor.count(`fire.${context.firedBy}.created`);
 
     debug('firing hook %s/%s to create taskId: %s',
       hook.hookGroupId, hook.hookId, options.taskId);


### PR DESCRIPTION
This separates the different firedBy options, and also distinguishes
task-creation that results in a task from that which results in no task
("declined").

This should allow us to see any spikes in task-creation if, for example,
there is abuse of the pulse bindings option.

Bugzilla Bug: [1517000](https://bugzilla.mozilla.org/show_bug.cgi?id=1517000)
