### PR TITLE
Bug 1523215 - improve index tests

### DIFF
--- a/services/index/src/api.js
+++ b/services/index/src/api.js
@@ -133,8 +133,7 @@ builder.declare({
     'Find a task by index path, returning the highest-rank task with that path. If no',
     'task exists for the given path, this API end-point will respond with a 404 status.',
   ].join('\n'),
-}, function(req, res) {
-  var that = this;
+}, async function(req, res) {
   var indexPath = req.params.indexPath || '';
 
   // Get namespace and ensure that we have a least one dot
@@ -145,23 +144,25 @@ builder.declare({
   var namespace = indexPath.join('.');
 
   // Load indexed task
-  return that.IndexedTask.query({
-    namespace: namespace,
-    name: name,
-    expires: Entity.op.greaterThan(new Date()),
-  }).then(function(tasks) {
-    if (_.isEmpty(tasks.entries)) {
-      return res.reportError('ResourceNotFound', 'Indexed task has expired', {});
-    }
-    let task = tasks.entries[0];
-    return res.reply(task.json());
-  }, function(err) {
+  let tasks;
+  try {
+    tasks = await this.IndexedTask.query({
+      namespace: namespace,
+      name: name,
+      expires: Entity.op.greaterThan(new Date()),
+    });
+  } catch (err) {
     // Re-throw the error, if it's not a 404
     if (err.code !== 'ResourceNotFound') {
       throw err;
     }
     return res.reportError('ResourceNotFound', 'Indexed task not found', {});
-  });
+  }
+  if (_.isEmpty(tasks.entries)) {
+    return res.reportError('ResourceNotFound', 'Indexed task has expired', {});
+  }
+  let task = tasks.entries[0];
+  return res.reply(task.json());
 });
 
 /** GET List namespaces inside another namespace */

--- a/services/index/src/api.js
+++ b/services/index/src/api.js
@@ -1,4 +1,3 @@
-const _ = require('lodash');
 const APIBuilder = require('taskcluster-lib-api');
 const helpers = require('./helpers');
 const Entity = require('azure-entities');
@@ -158,7 +157,7 @@ builder.declare({
     }
     return res.reportError('ResourceNotFound', 'Indexed task not found', {});
   }
-  if (_.isEmpty(tasks.entries)) {
+  if (!tasks.entries.length) {
     return res.reportError('ResourceNotFound', 'Indexed task has expired', {});
   }
   let task = tasks.entries[0];

--- a/services/index/test/api_test.js
+++ b/services/index/test/api_test.js
@@ -68,20 +68,19 @@ helper.secrets.mockSuite('api_test.js', ['taskcluster'], function(mock, skipping
         'dbc.def2',
       ];
 
-      const expired_paths = [
+      const expiredPaths = [
         'pqr', 'pqr.stu', 'pqr.stu2',
         'ppt', 'ppt.stu',
       ];
 
       const taskId = slugid.v4();
 
-      for (let path of paths) {
-        await helper.index.insertTask(path, {taskId, rank: 13, data: {}, expires: taskcluster.fromNow('1 day')});
-      }
-
-      for (let path of expired_paths) {
-        await helper.index.insertTask(path, {taskId, rank: 13, data: {}, expires: taskcluster.fromNow('-1 day')});
-      }
+      await Promise.all([
+        ...paths.map(path =>
+          helper.index.insertTask(path, {taskId, rank: 13, data: {}, expires: taskcluster.fromNow('1 day')})),
+        ...expiredPaths.map(path =>
+          helper.index.insertTask(path, {taskId, rank: 13, data: {}, expires: taskcluster.fromNow('-1 day')})),
+      ]);
     });
 
     const testValidNamespaces = function(list, VALID_PREFIXES=['abc', 'bbc', 'cbc']) {

--- a/services/index/test/helper.js
+++ b/services/index/test/helper.js
@@ -13,7 +13,7 @@ const helper = module.exports;
 
 // a suffix used to generate unique table names so that parallel test runs do not
 // interfere with one another.  We remove these at the end of the test run.
-const TABLE_SUFFIX = slugid.nice().replace(/[_-]/g, '');
+const TABLE_SUFFIX = 'abcdef'; //slugid.nice().replace(/[_-]/g, '');
 
 exports.load = stickyLoader(load);
 


### PR DESCRIPTION
Bugzilla Bug: [1523215](https://bugzilla.mozilla.org/show_bug.cgi?id=1523215)

I managed to reproduce a race condition locally, where the polling detected one index route being added and started the rest of the assertions before the other index routes had been added.

For the timeout in `api_test.js`, I took a wild guess that it was an actual timeout -- from creating a bunch of entities sequentially -- rather than a hang.  I couldn't reproduce that issue locally with or without the fix.