### PR TITLE
increase a half-second timeout in lib-api tests

### DIFF
--- a/libraries/api/test/auth_test.js
+++ b/libraries/api/test/auth_test.js
@@ -14,7 +14,7 @@ suite('api/auth', function() {
   // Reference for test api server
   let _apiServer = null;
 
-  this.timeout(500);
+  this.timeout(1500);
 
   // Create test api
   const builder = new APIBuilder({


### PR DESCRIPTION
This timeout failed for me, probably when there was a "hiccup" with the disk on the VM I was using causing loading of schemas to take longer than 500ms.