### PR TITLE
Omit DEBUG when running a node subprocess

### DIFF
--- a/libraries/monitor/test/uncaught_test.js
+++ b/libraries/monitor/test/uncaught_test.js
@@ -50,7 +50,9 @@ suite('Uncaught Errors', () => {
       path.resolve(__dirname, './should_exit_with_error.js'),
       ['--correct'],
       {
-        env: process.env,
+        // omit DEBUG so that its output does not obscure the
+        // expected output
+        env: Object.assign(process.env, {DEBUG: undefined}),
         silent: true,
       }
     );


### PR DESCRIPTION
Without this, the DEBUG output obscures the expected stdout..

(found while looking for flaky tests)
