### PR TITLE
Add missing README

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ It is not possible to run a full Taskcluster deployment directly from this repos
     * [Secrets Service](services/secrets#readme)
     * [Treeherder Service](services/treeherder#readme)
     * [Web-Server Service](services/web-server#readme)
+    * [Worker Manager](services/worker-manager#readme)
 * [Taskcluster Web](ui#readme)
     * [ui/src/components/DateDistance](ui/src/components/DateDistance#readme)
     * [ui/src/components/Markdown](ui/src/components/Markdown#readme)

--- a/generated/docs/worker-manager/README.md
+++ b/generated/docs/worker-manager/README.md
@@ -1,0 +1,1 @@
+# Worker Manager

--- a/services/README.md
+++ b/services/README.md
@@ -17,4 +17,5 @@ These are any packages that are run as part of a deployment of Taskcluster.
 * [Secrets Service](secrets#readme)
 * [Treeherder Service](treeherder#readme)
 * [Web-Server Service](web-server#readme)
+* [Worker Manager](worker-manager#readme)
 <!-- TOC END -->

--- a/services/worker-manager/README.md
+++ b/services/worker-manager/README.md
@@ -1,0 +1,1 @@
+# Worker Manager


### PR DESCRIPTION
This is needed so that the table of content for /docs is generated properly. The content of the README can be filled out later.