### PR TITLE
Bug 1524406 - Fix keys for LastFire table

### DIFF
--- a/infrastructure/terraform/hooks-service.tf
+++ b/infrastructure/terraform/hooks-service.tf
@@ -39,7 +39,7 @@ module "hooks_secrets" {
     PULSE_VHOST              = "${var.rabbitmq_vhost}"
     HOOK_TABLE_NAME          = "Hooks"
     QUEUE_TABLE_NAME         = "Queue"
-    LASTFIRE_TABLE_NAME      = "LastFire"
+    LASTFIRE_TABLE_NAME      = "LastFire2"
     TABLE_CRYPTO_KEY         = "${base64encode(random_string.hooks_table_crypto_key.result)}"
     TABLE_SIGNING_KEY        = "${random_string.hooks_table_signing_key.result}"
   }

--- a/services/hooks/src/data.js
+++ b/services/hooks/src/data.js
@@ -195,7 +195,7 @@ exports.Queues = Queues;
 
 const LastFire = Entity.configure({
   version: 1,
-  partitionKey: Entity.keys.StringKey('hookGroupId', 'hookId'),
+  partitionKey: Entity.keys.CompositeKey('hookGroupId', 'hookId'),
   rowKey: Entity.keys.StringKey('taskId'),
   signEntities: true,
   properties: {


### PR DESCRIPTION
Since this changes the keys, we cannot use the same table.  So this also
updates the table name in the Terraform configuration to point to a
fresh new table.

Bugzilla Bug: [1524406](https://bugzilla.mozilla.org/show_bug.cgi?id=1524406)
