### PR TITLE
Bug 1523376 - use crypto-js instead of stealing Hawk's copy

### DIFF
--- a/clients/client-web/README.md
+++ b/clients/client-web/README.md
@@ -3,7 +3,7 @@
 **A Taskcluster client library for the browser.**
 
 This client library is generated from the auto-generated API reference. taskcluster-client-web differs from
-[taskcluster-client](https://github.com/taskcluster/taskcluster-client) by providing a version that is compatible
+[taskcluster-client](https://yarnpkg.com/en/package/taskcluster-client) by providing a version that is compatible
 with the browser out of the box and does not require a build step to use.
 
 ## Installation
@@ -96,7 +96,7 @@ require(['taskcluster-client-web'], ({ Queue }) => {
 ```
 
 Note that this module can be imported in a Node.js environment without error, but is not guaranteed to work.
-If you need Taskcluster support in a Node.js environment, see the `taskcluster-client` package.
+If you need Taskcluster support in a Node.js environment, see the `[taskcluster-client](https://yarnpkg.com/en/package/taskcluster-client)` package.
 
 ## Calling API Endpoints
 
@@ -380,7 +380,7 @@ queue
   .then(signedUrl => { /* ... });
 ```
 
-**NOTE**: This method returns a promise, unlike in taskcluster-client.
+**NOTE**: This method returns a promise, unlike in [taskcluster-client](https://yarnpkg.com/en/package/taskcluster-client).
 
 Please note that the `payload` parameter cannot be encoded in the signed URL
 and must be sent as request payload. This should work fine, just remember that
@@ -460,7 +460,7 @@ const auth = new Auth({
 ```
 
 This is common server-side when using
-[taskcluster-client](https://github.com/taskcluster/taskcluster-client), but
+[taskcluster-client](https://yarnpkg.com/en/package/taskcluster-client), but
 for web applications the credentials are usually acquired through some
 user-login process. For such cases, the client uses a `credentialAgent` to get
 Taskcluster credentials corresponding to the logged-in user. Agents can be

--- a/clients/client-web/README.md
+++ b/clients/client-web/README.md
@@ -95,6 +95,9 @@ require(['taskcluster-client-web'], ({ Queue }) => {
 </script>
 ```
 
+Note that this module can be imported in a Node.js environment without error, but is not guaranteed to work.
+If you need Taskcluster support in a Node.js environment, see the `taskcluster-client` package.
+
 ## Calling API Endpoints
 
 To invoke an API endpoint, instantiate a taskcluster client class.

--- a/clients/client-web/package.json
+++ b/clients/client-web/package.json
@@ -13,6 +13,7 @@
     "build": "neutrino build --require dotenv/config",
     "lint": "neutrino lint",
     "prepare": "yarn build",
+    "pretest": "node -e 'require(\".\")'",
     "test": "neutrino test --require dotenv/config"
   },
   "devDependencies": {
@@ -28,6 +29,7 @@
     "neutrino-preset-mozilla-frontend-infra": "^4.1.0"
   },
   "dependencies": {
+    "crypto-js": "^3.1.9-1",
     "hawk": "^7.0.7",
     "query-string": "^6.1.0",
     "taskcluster-lib-urls": "^10.0.0"

--- a/clients/client-web/src/credentials.js
+++ b/clients/client-web/src/credentials.js
@@ -1,11 +1,11 @@
-import hawk from 'hawk';
+import { algo, enc } from 'crypto-js';
 import { v4 } from './utils';
 import Auth from './clients/Auth';
 
+const createHmac = (...args) => algo.HMAC.create(...args);
+const sha256 = algo.SHA256;
+const base64 = enc.Base64;
 const THIRTY_ONE_DAYS = 31 * 24 * 60 * 60 * 1000;
-const createHmac = (...args) => hawk.crypto.utils.algo.HMAC.create(...args);
-const sha256 = hawk.crypto.utils.algo.SHA256;
-const base64 = hawk.crypto.utils.enc.Base64;
 
 /**
  * Construct a set of temporary credentials.

--- a/clients/client-web/yarn.lock
+++ b/clients/client-web/yarn.lock
@@ -2777,6 +2777,11 @@ crypto-browserify@^3.11.0:
     randombytes "^2.0.0"
     randomfill "^1.0.3"
 
+crypto-js@^3.1.9-1:
+  version "3.1.9-1"
+  resolved "https://registry.yarnpkg.com/crypto-js/-/crypto-js-3.1.9-1.tgz#fda19e761fc077e01ffbfdc6e9fdfc59e8806cd8"
+  integrity sha1-/aGedh/Ad+Af+/3G6f38WeiAbNg=
+
 css-color-names@0.0.4:
   version "0.0.4"
   resolved "https://registry.yarnpkg.com/css-color-names/-/css-color-names-0.0.4.tgz#808adc2e79cf84738069b646cb20ec27beb629e0"


### PR DESCRIPTION
This also adds a check that the library can be require`d in a Node
environment, which helps at least one user (Treeherder) to run some
of its tests in a Node environment.  We do *not* guarantee that any of
the module's functionality actually works outside of a browser.

Bugzilla Bug: [1523376](https://bugzilla.mozilla.org/show_bug.cgi?id=1523376)
