### PR TITLE
Bug 1527416 - get a fresh copy of the hook before triggering

### DIFF
--- a/services/hooks/src/listeners.js
+++ b/services/hooks/src/listeners.js
@@ -74,8 +74,14 @@ class HookListeners {
       // we manage bindings manually in syncBindings
       bindings: [],
     }, async ({payload}) => {
-      // Fire the hook
-      await this.taskcreator.fire(hook, {firedBy: 'pulseMessage', payload});
+      // Get a fresh copy of the hook and fire it, if it still exists
+      let latestHook = await this.Hook.load({
+        hookGroupId: hook.hookGroupId,
+        hookId: hook.hookId,
+      }, true);
+      if (latestHook) {
+        await this.taskcreator.fire(latestHook, {firedBy: 'pulseMessage', payload});
+      }
     });
 
     this.listeners.push(listener);


### PR DESCRIPTION
Bugzilla Bug: [1527416](https://bugzilla.mozilla.org/show_bug.cgi?id=1527416)
