### PR TITLE
[Bug 1527723] Allow setting defaults for loader virtual components

### DIFF
--- a/libraries/loader/README.md
+++ b/libraries/loader/README.md
@@ -96,7 +96,9 @@ let server = await load('server', {port: 8080});
 ```
 
 Finally, you can specify virtual components, for example you may wish to force
-the caller of `load` to always specify a port.
+the caller of `load` to always specify a port or provide a default. If you
+set the default of the virtual component to a falsy value, you will force
+the user to provide a value for you.
 
 ```js
 let loader = require('taskcluster-lib-loader');
@@ -116,7 +118,7 @@ let load = loader({
       return server;
     }
   },
-  
+
   // Definition of 'express' component, notice that even through the 'server'
   // components setup function returns a promise, `ctx.server` is a server
   // object as resolved.
@@ -130,10 +132,10 @@ let load = loader({
     }
   }
 
-  // Virtual components that must always be specified for `load` to work
-}, ['port']);
+  // Virtual components that can be specified for `load` to work
+}, {'port': 900});
 
-// Create express (here we're forced to specify port)
+// Create express (here we specify a port)
 let server = await load('express', {port: 80});
 ```
 
@@ -150,18 +152,11 @@ particularly useful for getting a fresh component between tests.
 
 We generally recommend one component loader per project, and that you expose
 it in an executable such that you do `node server.js <component>` to start a
-process running the specified component.  A handy way to run the loader on startup,
-given both the profile ($NODE_ENV) and process (target component):
+process running the specified component.
 
 ```js
 // If this file is executed launch component from first argument
 if (!module.parent) {
-  load(process.argv[2], {
-    process: process.argv[2],
-    profile: process.env.NODE_ENV,
-  }).catch(err => {
-    console.log(err.stack);
-    process.exit(1);
-  });
+  load(process.argv[2]);
 }
 ```

--- a/libraries/loader/README.md
+++ b/libraries/loader/README.md
@@ -157,6 +157,9 @@ process running the specified component.
 ```js
 // If this file is executed launch component from first argument
 if (!module.parent) {
-  load(process.argv[2]);
+  load(process.argv[2]).catch(err => {
+    console.log(err.stack);
+    process.exit(1);
+  });
 }
 ```

--- a/libraries/loader/package.json
+++ b/libraries/loader/package.json
@@ -28,7 +28,6 @@
   "dependencies": {
     "assume": "^2.1.0",
     "debug": "^4.1.0",
-    "lodash": "^4.17.11",
     "topo-sort": "^1.0.0"
   }
 }

--- a/libraries/loader/src/loader.js
+++ b/libraries/loader/src/loader.js
@@ -58,7 +58,12 @@ function renderGraph(componentDirectory, sortedComponents) {
  */
 function loader(componentDirectory, virtualComponents = {}) {
   assume(componentDirectory).is.an('object');
-  assume(virtualComponents).is.an('object');
+  if (virtualComponents instanceof Array) {
+    virtualComponents = virtualComponents.reduce((acc, k) => {
+      acc[k] = null;
+      return acc;
+    }, {});
+  }
   const virtualKeys = Object.keys(virtualComponents);
   assume(Object.keys(componentDirectory).filter(x => virtualKeys.includes(x))).has.length(0);
   componentDirectory = Object.assign({}, componentDirectory);

--- a/libraries/loader/src/loader.js
+++ b/libraries/loader/src/loader.js
@@ -67,7 +67,7 @@ function loader(componentDirectory, virtualComponents = {}) {
   Object.entries(componentDirectory).forEach(([name, def]) => {
     validateComponent(def, name);
     for (let dep of def.requires || []) {
-      if (componentDirectory[dep] === undefined && virtualComponents[dep] === undefined) {
+      if (!componentDirectory.hasOwnProperty(dep) && !virtualComponents.hasOwnProperty(dep)) {
         throw new Error('Cannot require undefined component: ' + dep);
       }
     }

--- a/libraries/loader/test/loader_tests.js
+++ b/libraries/loader/test/loader_tests.js
@@ -38,11 +38,29 @@ describe('component loader', () => {
           return deps.dep;
         },
       },
-    }, ['dep']);
+    }, {
+      dep: null,
+    });
 
     assume(await load('test', {
       dep: a,
     })).equals(a);
+  });
+
+  it('should allow setting defaults for virtual components', async () => {
+    let load = subject({
+      test: {
+        requires: ['dep'],
+        setup: deps => {
+          return deps.dep;
+        },
+      },
+    }, {
+      dep: 5,
+    });
+
+    assume(await load('test', {})).equals(5);
+    assume(await load('test')).equals(5);
   });
 
   it('should allow overwrites', async () => {
@@ -53,7 +71,7 @@ describe('component loader', () => {
           return 'Hello World';
         },
       },
-    }, []);
+    }, {});
 
     assume(await load('test', {
       test: 'Mocking Hello World',
@@ -372,7 +390,9 @@ describe('component loader', () => {
           return deps.dep;
         },
       },
-    }, ['dep']);
+    }, {
+      dep: null,
+    });
 
     await load('graphviz', {
       dep: a,
@@ -383,7 +403,9 @@ describe('component loader', () => {
     try {
       let load = subject({
         dep1: 'string',
-      }, ['dep1']);
+      }, {
+        'dep1': null,
+      });
       throw new Error();
     } catch (e) {
       if (!e.message.match(/assertation failure/)) {

--- a/libraries/loader/test/loader_tests.js
+++ b/libraries/loader/test/loader_tests.js
@@ -47,6 +47,25 @@ describe('component loader', () => {
     })).equals(a);
   });
 
+  it('should accept a virtual component as array', async () => {
+    let a = {a: 1};
+
+    let load = subject({
+      test: {
+        requires: ['dep'],
+        setup: deps => {
+          return deps.dep;
+        },
+      },
+    }, [
+      'dep',
+    ]);
+
+    assume(await load('test', {
+      dep: a,
+    })).equals(a);
+  });
+
   it('should allow setting defaults for virtual components', async () => {
     let load = subject({
       test: {

--- a/libraries/loader/test/runtests.sh
+++ b/libraries/loader/test/runtests.sh
@@ -1,4 +1,0 @@
-#!/bin/bash
-set -e
-set -x
-mocha .test/*_tests.js

--- a/services/auth/src/main.js
+++ b/services/auth/src/main.js
@@ -261,7 +261,10 @@ const load = Loader({
 
 // If this file is executed launch component from first argument
 if (!module.parent) {
-  load(process.argv[2]);
+  load(process.argv[2]).catch(err => {
+    console.log(err.stack);
+    process.exit(1);
+  });
 }
 
 module.exports = load;

--- a/services/auth/src/main.js
+++ b/services/auth/src/main.js
@@ -254,17 +254,14 @@ const load = Loader({
       });
     },
   },
-}, ['profile', 'process']);
+}, {
+  profile: process.argv[2],
+  process: process.env.NODE_ENV,
+});
 
 // If this file is executed launch component from first argument
 if (!module.parent) {
-  load(process.argv[2], {
-    process: process.argv[2],
-    profile: process.env.NODE_ENV,
-  }).catch(err => {
-    console.log(err.stack);
-    process.exit(1);
-  });
+  load(process.argv[2]);
 }
 
 module.exports = load;

--- a/services/built-in-workers/src/main.js
+++ b/services/built-in-workers/src/main.js
@@ -73,7 +73,10 @@ const load = loader({
 
 // If this file is executed launch component from first argument
 if (!module.parent) {
-  load(process.argv[2]);
+  load(process.argv[2]).catch(err => {
+    console.log(err.stack);
+    process.exit(1);
+  });
 }
 
 module.exports = load;

--- a/services/built-in-workers/src/main.js
+++ b/services/built-in-workers/src/main.js
@@ -66,17 +66,14 @@ const load = loader({
       ]);
     },
   },
-}, ['process', 'profile']);
+}, {
+  profile: process.argv[2],
+  process: process.env.NODE_ENV,
+});
 
 // If this file is executed launch component from first argument
 if (!module.parent) {
-  load(process.argv[2], {
-    process: process.argv[2],
-    profile: process.env.NODE_ENV,
-  }).catch(err => {
-    console.log(err.stack);
-    process.exit(1);
-  });
+  load(process.argv[2]);
 }
-// Export load for tests
+
 module.exports = load;

--- a/services/github/src/main.js
+++ b/services/github/src/main.js
@@ -237,7 +237,10 @@ const load = loader({
 
 // If this file is executed launch component from first argument
 if (!module.parent) {
-  load(process.argv[2]);
+  load(process.argv[2]).catch(err => {
+    console.log(err.stack);
+    process.exit(1);
+  });
 }
 
 module.exports = load;

--- a/services/github/src/main.js
+++ b/services/github/src/main.js
@@ -230,17 +230,14 @@ const load = loader({
     requires: ['handlers'],
     setup: async ({handlers}) => handlers.setup(),
   },
-}, ['profile', 'process']);
+}, {
+  profile: process.argv[2],
+  process: process.env.NODE_ENV,
+});
 
+// If this file is executed launch component from first argument
 if (!module.parent) {
-  load(process.argv[2], {
-    process: process.argv[2],
-    profile: process.env.NODE_ENV,
-  }).catch(err => {
-    console.log(err.stack || err);
-    process.exit(1);
-  });
+  load(process.argv[2]);
 }
 
-// Export load for tests
 module.exports = load;

--- a/services/hooks/src/main.js
+++ b/services/hooks/src/main.js
@@ -245,7 +245,10 @@ const load = loader({
 
 // If this file is executed launch component from first argument
 if (!module.parent) {
-  load(process.argv[2]);
+  load(process.argv[2]).catch(err => {
+    console.log(err.stack);
+    process.exit(1);
+  });
 }
 
 module.exports = load;

--- a/services/hooks/src/main.js
+++ b/services/hooks/src/main.js
@@ -238,19 +238,14 @@ const load = loader({
       });
     },
   },
-
-}, ['profile', 'process']);
+}, {
+  profile: process.argv[2],
+  process: process.env.NODE_ENV,
+});
 
 // If this file is executed launch component from first argument
 if (!module.parent) {
-  load(process.argv[2], {
-    process: process.argv[2],
-    profile: process.env.NODE_ENV,
-  }).catch(err => {
-    console.log(err.stack);
-    process.exit(1);
-  });
+  load(process.argv[2]);
 }
 
-// Export load for tests
 module.exports = load;

--- a/services/index/src/main.js
+++ b/services/index/src/main.js
@@ -189,7 +189,10 @@ var load = loader({
 
 // If this file is executed launch component from first argument
 if (!module.parent) {
-  load(process.argv[2]);
+  load(process.argv[2]).catch(err => {
+    console.log(err.stack);
+    process.exit(1);
+  });
 }
 
 module.exports = load;

--- a/services/index/src/main.js
+++ b/services/index/src/main.js
@@ -182,18 +182,14 @@ var load = loader({
       });
     },
   },
-}, ['process', 'profile']);
+}, {
+  profile: process.argv[2],
+  process: process.env.NODE_ENV,
+});
 
-// If server.js is executed start the server
+// If this file is executed launch component from first argument
 if (!module.parent) {
-  load(process.argv[2], {
-    process: process.argv[2],
-    profile: process.env.NODE_ENV,
-  }).catch(err => {
-    console.log(err.stack);
-    process.exit(1);
-  });
+  load(process.argv[2]);
 }
 
-// Export load for tests
 module.exports = load;

--- a/services/login/src/main.js
+++ b/services/login/src/main.js
@@ -100,16 +100,14 @@ let load = loader({
       return monitor.oneShot('scanner', () => scanner(cfg, handlers));
     },
   },
-}, ['profile', 'process']);
+}, {
+  profile: process.argv[2],
+  process: process.env.NODE_ENV,
+});
 
+// If this file is executed launch component from first argument
 if (!module.parent) {
-  load(process.argv[2], {
-    profile: process.env.NODE_ENV,
-    process: process.argv[2],
-  }).catch(err => {
-    console.log('Server crashed: ' + err.stack);
-    process.exit(1);
-  });
+  load(process.argv[2]);
 }
 
 module.exports = load;

--- a/services/login/src/main.js
+++ b/services/login/src/main.js
@@ -107,7 +107,10 @@ let load = loader({
 
 // If this file is executed launch component from first argument
 if (!module.parent) {
-  load(process.argv[2]);
+  load(process.argv[2]).catch(err => {
+    console.log(err.stack);
+    process.exit(1);
+  });
 }
 
 module.exports = load;

--- a/services/notify/src/main.js
+++ b/services/notify/src/main.js
@@ -210,7 +210,10 @@ const load = loader({
 
 // If this file is executed launch component from first argument
 if (!module.parent) {
-  load(process.argv[2]);
+  load(process.argv[2]).catch(err => {
+    console.log(err.stack);
+    process.exit(1);
+  });
 }
 
 module.exports = load;

--- a/services/notify/src/main.js
+++ b/services/notify/src/main.js
@@ -203,18 +203,14 @@ const load = loader({
     }),
   },
 
-}, ['profile', 'process']);
+}, {
+  profile: process.argv[2],
+  process: process.env.NODE_ENV,
+});
 
 // If this file is executed launch component from first argument
 if (!module.parent) {
-  load(process.argv[2], {
-    process: process.argv[2],
-    profile: process.env.NODE_ENV,
-  }).catch(err => {
-    console.log(err.stack);
-    process.exit(1);
-  });
+  load(process.argv[2]);
 }
 
-// Export load for tests
 module.exports = load;

--- a/services/purge-cache/src/main.js
+++ b/services/purge-cache/src/main.js
@@ -115,7 +115,10 @@ const load = loader({
 
 // If this file is executed launch component from first argument
 if (!module.parent) {
-  load(process.argv[2]);
+  load(process.argv[2]).catch(err => {
+    console.log(err.stack);
+    process.exit(1);
+  });
 }
 
 module.exports = load;

--- a/services/purge-cache/src/main.js
+++ b/services/purge-cache/src/main.js
@@ -108,17 +108,14 @@ const load = loader({
       apis: [api],
     }),
   },
-}, ['profile', 'process']);
+}, {
+  profile: process.argv[2],
+  process: process.env.NODE_ENV,
+});
 
+// If this file is executed launch component from first argument
 if (!module.parent) {
-  load(process.argv[2], {
-    process: process.argv[2],
-    profile: process.env.NODE_ENV,
-  }).catch(err => {
-    console.log(err.stack);
-    process.exit(1);
-  });
+  load(process.argv[2]);
 }
 
-// Export load for tests
 module.exports = load;

--- a/services/queue/src/main.js
+++ b/services/queue/src/main.js
@@ -711,18 +711,14 @@ let load = loader({
     setup: ({cfg}) => require('./load-test')(cfg),
   },
 
-}, ['profile', 'process']);
+}, {
+  profile: process.argv[2],
+  process: process.env.NODE_ENV,
+});
 
 // If this file is executed launch component from first argument
 if (!module.parent) {
-  load(process.argv[2], {
-    process: process.argv[2],
-    profile: process.env.NODE_ENV,
-  }).catch(err => {
-    console.log(err.stack);
-    process.exit(1);
-  });
+  load(process.argv[2]);
 }
 
-// Export load for tests
 module.exports = load;

--- a/services/queue/src/main.js
+++ b/services/queue/src/main.js
@@ -718,7 +718,10 @@ let load = loader({
 
 // If this file is executed launch component from first argument
 if (!module.parent) {
-  load(process.argv[2]);
+  load(process.argv[2]).catch(err => {
+    console.log(err.stack);
+    process.exit(1);
+  });
 }
 
 module.exports = load;

--- a/services/secrets/src/main.js
+++ b/services/secrets/src/main.js
@@ -118,18 +118,14 @@ var load = loader({
       });
     },
   },
-}, ['process', 'profile']);
+}, {
+  profile: process.argv[2],
+  process: process.env.NODE_ENV,
+});
 
 // If this file is executed launch component from first argument
 if (!module.parent) {
-  load(process.argv[2], {
-    process: process.argv[2],
-    profile: process.env.NODE_ENV,
-  }).catch(err => {
-    console.log(err.stack);
-    process.exit(1);
-  });
+  load(process.argv[2]);
 }
 
-// Export load for tests
 module.exports = load;

--- a/services/secrets/src/main.js
+++ b/services/secrets/src/main.js
@@ -125,7 +125,10 @@ var load = loader({
 
 // If this file is executed launch component from first argument
 if (!module.parent) {
-  load(process.argv[2]);
+  load(process.argv[2]).catch(err => {
+    console.log(err.stack);
+    process.exit(1);
+  });
 }
 
 module.exports = load;

--- a/services/treeherder/src/main.js
+++ b/services/treeherder/src/main.js
@@ -122,7 +122,10 @@ let load = loader({
 
 // If this file is executed launch component from first argument
 if (!module.parent) {
-  load(process.argv[2]);
+  load(process.argv[2]).catch(err => {
+    console.log(err.stack);
+    process.exit(1);
+  });
 }
 
 module.exports = load;

--- a/services/treeherder/src/main.js
+++ b/services/treeherder/src/main.js
@@ -115,17 +115,14 @@ let load = loader({
       await handler.start();
     },
   },
-}, ['profile', 'process']);
+}, {
+  profile: process.argv[2],
+  process: process.env.NODE_ENV,
+});
 
 // If this file is executed launch component from first argument
 if (!module.parent) {
-  load(process.argv[2], {
-    profile: process.env.NODE_ENV,
-    process: process.argv[2],
-  }).catch(err => {
-    console.log('Server crashed: ' + err.stack);
-    process.exit(1);
-  });
+  load(process.argv[2]);
 }
 
 module.exports = load;

--- a/services/web-server/src/index.js
+++ b/services/web-server/src/index.js
@@ -160,18 +160,14 @@ const load = loader(
       },
     },
   },
-  ['profile', 'process']
+  {
+    // default to 'devServer' since webpack does not pass any command-line args
+    // when running in development mode
+    profile: process.env.NODE_ENV || 'development',
+    process: process.argv[2] || 'devServer',
+  }
 );
 
 if (!module.parent) {
-  // default to 'devServer' since webpack does not pass any command-line args
-  // when running in development mode
-  const target = process.argv[2] || 'devServer';
-  load(target, {
-    process: target,
-    profile: process.env.NODE_ENV || 'development',
-  }).catch(err => {
-    console.log(err.stack); // eslint-disable-line no-console
-    process.exit(1);
-  });
+  load(process.argv[2]);
 }

--- a/services/worker-manager/lib/main.js
+++ b/services/worker-manager/lib/main.js
@@ -138,18 +138,14 @@ let load = loader({
       await provisioner.initiate();
     },
   },
-
-}, ['process', 'profile']);
-
-module.exports = load;
+}, {
+  profile: process.argv[2],
+  process: process.env.NODE_ENV,
+});
 
 // If this file is executed launch component from first argument
 if (!module.parent) {
-  load(process.argv[2], {
-    process: process.argv[2],
-    profile: process.env.NODE_ENV,
-  }).catch(err => {
-    console.log(err.stack);
-    process.exit(1);
-  });
+  load(process.argv[2]);
 }
+
+module.exports = load;

--- a/services/worker-manager/lib/main.js
+++ b/services/worker-manager/lib/main.js
@@ -145,7 +145,10 @@ let load = loader({
 
 // If this file is executed launch component from first argument
 if (!module.parent) {
-  load(process.argv[2]);
+  load(process.argv[2]).catch(err => {
+    console.log(err.stack);
+    process.exit(1);
+  });
 }
 
 module.exports = load;


### PR DESCRIPTION
This simplifies the setup at the bottom of the `main.js` in our services and allows for easier requiring of components in modules that otherwise are not loaded by the loader. An example of what I want to do is:

```js
const monitor = require('./main')('monitor').prefix('script');
monitor.info('whatever', {foo: 5});
```
This way we can configure monitor in one place, using configuration loaded in the same way as all of our other components but also allow people to have modules that exist outside the `main.js` setup.


Bugzilla Bug: [1527723](https://bugzilla.mozilla.org/show_bug.cgi?id=1527723)
