### PR TITLE
Bug 1527427 - fix event emission in lib-pulse

### DIFF
--- a/libraries/pulse/src/consumer.js
+++ b/libraries/pulse/src/consumer.js
@@ -62,7 +62,7 @@ class PulseConsumer {
     await this.client.withChannel(channel => this._createAndBindQueue(channel));
 
     // then set up to call _handleConnection on all connections
-    this.client.onConnected(this._handleConnection);
+    this.stopHandlingConnections = this.client.onConnected(this._handleConnection);
   }
 
   /**
@@ -85,6 +85,9 @@ class PulseConsumer {
    */
   async _shutdown() {
     const {channel, consumerTag} = this;
+
+    // reverse the effect of onConnected
+    this.stopHandlingConnections();
 
     if (channel && consumerTag) {
       this.consumerTag = null;

--- a/libraries/pulse/src/publisher.js
+++ b/libraries/pulse/src/publisher.js
@@ -189,7 +189,7 @@ class PulsePublisher {
    */
   async _start() {
     this._setChannel(null);
-    this.client.onConnected(this._handleConnection);
+    this.stopHandlingConnections = this.client.onConnected(this._handleConnection);
 
     await this._assertExchanges();
     await this._declareMethods();
@@ -293,7 +293,7 @@ class PulsePublisher {
   }
 
   async stop() {
-    this.client.removeListener(this._handleConnection);
+    this.stopHandlingConnections();
     this.channelPromise = Promise.reject(new Error('PulsePublisher is stopped'));
   }
 


### PR DESCRIPTION
* Be more careful to remove events on client, since it is long-lived
* Allow more than the default 10 events on client and connection, since
  in normal use the number might be much larger.

Bugzilla Bug: [1527427](https://bugzilla.mozilla.org/show_bug.cgi?id=1527427)
