### PR TITLE
Set build settings to the way heroku wants them

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,7 +96,8 @@
     "test": "yarn workspaces run test",
     "test:meta": "mocha test/*_test.js",
     "build": "node infrastructure/builder/src/main.js build",
-    "generate": "node infrastructure/builder/src/main.js generate"
+    "generate": "node infrastructure/builder/src/main.js generate",
+    "heroku-postbuild": "echo Skip build on Heroku"
   },
   "renovate": {
     "extends": [
@@ -110,5 +111,6 @@
     "**/node_modules/**",
     "**/test/fixtures/**",
     "services/web-server/build"
-  ]
+  ],
+  "heroku-run-build-script": true
 }


### PR DESCRIPTION
As described in https://help.heroku.com/P5IMU3MP/heroku-node-js-build-script-change-faq

iiuc, `heroku-run-build-script` is just there so that we can opt in to the new behavior now rather than being surprised on the 11th.