### PR TITLE
Revert "Catch one more case of loader update"

### DIFF
--- a/services/web-server/src/index.js
+++ b/services/web-server/src/index.js
@@ -169,8 +169,5 @@ const load = loader(
 );
 
 if (!module.parent) {
-  load(process.argv[2]).catch(err => {
-    console.log(err.stack); // eslint-disable-line no-console
-    process.exit(1);
-  });
+  load(process.argv[2]);
 }


### PR DESCRIPTION
Reverts taskcluster/taskcluster#232

```
/Users/haali/Documents/Mozilla/projects/taskcluster/libraries/loader/src/loader.js:110
      throw new Error(`Target is type ${typeof target}, not string`);
      ^

Error: Target is type undefined, not string
```