### PR TITLE
Bug 1527699 - don't ignore exit status from yarn generate

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -68,6 +68,7 @@ tasks:
         command: 'cd infrastructure/terraform; terraform fmt -check'
       - name: yarn generate
         command: |
+            set -o pipefail;
             yarn generate | cat &&
             if ! output=$(git status --porcelain) || [ -n "$output" ]; then
                 echo "*** yarn generate produced changes to the repository; these changes should be checked in ***";


### PR DESCRIPTION
Bugzilla Bug: [1527699](https://bugzilla.mozilla.org/show_bug.cgi?id=1527699)
