### PR TITLE
Make task group default sort clearer

### DIFF
--- a/ui/src/components/TaskGroupTable/index.jsx
+++ b/ui/src/components/TaskGroupTable/index.jsx
@@ -141,8 +141,8 @@ export default class TaskGroupTable extends Component {
   };
 
   state = {
-    sortBy: null,
-    sortDirection: null,
+    sortBy: 'Name',
+    sortDirection: 'asc',
     tasks: [],
   };
 


### PR DESCRIPTION
Fixes https://github.com/taskcluster/taskcluster/issues/246.