### PR TITLE
Rename Blacklist to Denylist

### DIFF
--- a/clients/client-web/src/clients/Notify.js
+++ b/clients/client-web/src/clients/Notify.js
@@ -14,9 +14,9 @@ export default class Notify extends Client {
     this.email.entry = {"args":[],"input":true,"method":"post","name":"email","query":[],"route":"/email","scopes":"notify:email:<address>","stability":"experimental","type":"function"}; // eslint-disable-line
     this.pulse.entry = {"args":[],"input":true,"method":"post","name":"pulse","query":[],"route":"/pulse","scopes":"notify:pulse:<routingKey>","stability":"experimental","type":"function"}; // eslint-disable-line
     this.irc.entry = {"args":[],"input":true,"method":"post","name":"irc","query":[],"route":"/irc","scopes":{"else":"notify:irc-user:<user>","if":"channelRequest","then":"notify:irc-channel:<channel>"},"stability":"experimental","type":"function"}; // eslint-disable-line
-    this.addBlacklistAddress.entry = {"args":[],"input":true,"method":"post","name":"addBlacklistAddress","query":[],"route":"/blacklist/add","scopes":"notify:manage-blacklist:<notificationType>/<notificationAddress>","stability":"experimental","type":"function"}; // eslint-disable-line
-    this.deleteBlacklistAddress.entry = {"args":[],"input":true,"method":"delete","name":"deleteBlacklistAddress","query":[],"route":"/blacklist/delete","scopes":"notify:manage-blacklist:<notificationType>/<notificationAddress>","stability":"experimental","type":"function"}; // eslint-disable-line
-    this.list.entry = {"args":[],"method":"get","name":"list","output":true,"query":["continuationToken","limit"],"route":"/blacklist/list","stability":"experimental","type":"function"}; // eslint-disable-line
+    this.addDenylistAddress.entry = {"args":[],"input":true,"method":"post","name":"addDenylistAddress","query":[],"route":"/denylist/add","scopes":"notify:manage-denylist:<notificationType>/<notificationAddress>","stability":"experimental","type":"function"}; // eslint-disable-line
+    this.deleteDenylistAddress.entry = {"args":[],"input":true,"method":"delete","name":"deleteDenylistAddress","query":[],"route":"/denylist/delete","scopes":"notify:manage-denylist:<notificationType>/<notificationAddress>","stability":"experimental","type":"function"}; // eslint-disable-line
+    this.list.entry = {"args":[],"method":"get","name":"list","output":true,"query":["continuationToken","limit"],"route":"/denylist/list","stability":"experimental","type":"function"}; // eslint-disable-line
   }
   /* eslint-disable max-len */
   // Respond without doing anything.
@@ -63,26 +63,26 @@ export default class Notify extends Client {
     return this.request(this.irc.entry, args);
   }
   /* eslint-disable max-len */
-  // Add the given address to the notification blacklist. The address
+  // Add the given address to the notification denylist. The address
   // can be of either of the three supported address type namely pulse, email
-  // or IRC(user or channel). Addresses in the blacklist will be ignored
+  // or IRC(user or channel). Addresses in the denylist will be ignored
   // by the notification service.
   /* eslint-enable max-len */
-  addBlacklistAddress(...args) {
-    this.validate(this.addBlacklistAddress.entry, args);
+  addDenylistAddress(...args) {
+    this.validate(this.addDenylistAddress.entry, args);
 
-    return this.request(this.addBlacklistAddress.entry, args);
+    return this.request(this.addDenylistAddress.entry, args);
   }
   /* eslint-disable max-len */
-  // Delete the specified address from the notification blacklist.
+  // Delete the specified address from the notification denylist.
   /* eslint-enable max-len */
-  deleteBlacklistAddress(...args) {
-    this.validate(this.deleteBlacklistAddress.entry, args);
+  deleteDenylistAddress(...args) {
+    this.validate(this.deleteDenylistAddress.entry, args);
 
-    return this.request(this.deleteBlacklistAddress.entry, args);
+    return this.request(this.deleteDenylistAddress.entry, args);
   }
   /* eslint-disable max-len */
-  // Lists all the blacklisted addresses.
+  // Lists all the denylisted addresses.
   // By default this end-point will try to return up to 1000 addresses in one
   // request. But it **may return less**, even if more tasks are available.
   // It may also return a `continuationToken` even though there are no more

--- a/clients/client/src/apis.js
+++ b/clients/client/src/apis.js
@@ -2044,37 +2044,37 @@ module.exports = {
         {
           "args": [
           ],
-          "description": "Add the given address to the notification blacklist. The address\ncan be of either of the three supported address type namely pulse, email\nor IRC(user or channel). Addresses in the blacklist will be ignored\nby the notification service.",
+          "description": "Add the given address to the notification denylist. The address\ncan be of either of the three supported address type namely pulse, email\nor IRC(user or channel). Addresses in the denylist will be ignored\nby the notification service.",
           "input": "v1/notification-address.json#",
           "method": "post",
-          "name": "addBlacklistAddress",
+          "name": "addDenylistAddress",
           "query": [
           ],
-          "route": "/blacklist/add",
-          "scopes": "notify:manage-blacklist:<notificationType>/<notificationAddress>",
+          "route": "/denylist/add",
+          "scopes": "notify:manage-denylist:<notificationType>/<notificationAddress>",
           "stability": "experimental",
-          "title": "Blacklist Given Address",
+          "title": "Denylist Given Address",
           "type": "function"
         },
         {
           "args": [
           ],
-          "description": "Delete the specified address from the notification blacklist.",
+          "description": "Delete the specified address from the notification denylist.",
           "input": "v1/notification-address.json#",
           "method": "delete",
-          "name": "deleteBlacklistAddress",
+          "name": "deleteDenylistAddress",
           "query": [
           ],
-          "route": "/blacklist/delete",
-          "scopes": "notify:manage-blacklist:<notificationType>/<notificationAddress>",
+          "route": "/denylist/delete",
+          "scopes": "notify:manage-denylist:<notificationType>/<notificationAddress>",
           "stability": "experimental",
-          "title": "Delete Blacklisted Address",
+          "title": "Delete Denylisted Address",
           "type": "function"
         },
         {
           "args": [
           ],
-          "description": "Lists all the blacklisted addresses.\n\nBy default this end-point will try to return up to 1000 addresses in one\nrequest. But it **may return less**, even if more tasks are available.\nIt may also return a `continuationToken` even though there are no more\nresults. However, you can only be sure to have seen all results if you\nkeep calling `list` with the last `continuationToken` until you\nget a result without a `continuationToken`.\n\nIf you are not interested in listing all the members at once, you may\nuse the query-string option `limit` to return fewer.",
+          "description": "Lists all the denylisted addresses.\n\nBy default this end-point will try to return up to 1000 addresses in one\nrequest. But it **may return less**, even if more tasks are available.\nIt may also return a `continuationToken` even though there are no more\nresults. However, you can only be sure to have seen all results if you\nkeep calling `list` with the last `continuationToken` until you\nget a result without a `continuationToken`.\n\nIf you are not interested in listing all the members at once, you may\nuse the query-string option `limit` to return fewer.",
           "method": "get",
           "name": "list",
           "output": "v1/notification-address-list.json#",
@@ -2082,9 +2082,9 @@ module.exports = {
             "continuationToken",
             "limit"
           ],
-          "route": "/blacklist/list",
+          "route": "/denylist/list",
           "stability": "experimental",
-          "title": "List Blacklisted Notifications",
+          "title": "List Denylisted Notifications",
           "type": "function"
         }
       ],

--- a/generated/docs/notify/references/api.json
+++ b/generated/docs/notify/references/api.json
@@ -62,33 +62,33 @@
     {
       "type": "function",
       "method": "post",
-      "route": "/blacklist/add",
+      "route": "/denylist/add",
       "query": [],
       "args": [],
-      "name": "addBlacklistAddress",
+      "name": "addDenylistAddress",
       "stability": "experimental",
-      "title": "Blacklist Given Address",
+      "title": "Denylist Given Address",
       "input": "v1/notification-address.json#",
-      "description": "Add the given address to the notification blacklist. The address\ncan be of either of the three supported address type namely pulse, email\nor IRC(user or channel). Addresses in the blacklist will be ignored\nby the notification service.",
-      "scopes": "notify:manage-blacklist:<notificationType>/<notificationAddress>"
+      "description": "Add the given address to the notification denylist. The address\ncan be of either of the three supported address type namely pulse, email\nor IRC(user or channel). Addresses in the denylist will be ignored\nby the notification service.",
+      "scopes": "notify:manage-denylist:<notificationType>/<notificationAddress>"
     },
     {
       "type": "function",
       "method": "delete",
-      "route": "/blacklist/delete",
+      "route": "/denylist/delete",
       "query": [],
       "args": [],
-      "name": "deleteBlacklistAddress",
+      "name": "deleteDenylistAddress",
       "stability": "experimental",
-      "title": "Delete Blacklisted Address",
+      "title": "Delete Denylisted Address",
       "input": "v1/notification-address.json#",
-      "description": "Delete the specified address from the notification blacklist.",
-      "scopes": "notify:manage-blacklist:<notificationType>/<notificationAddress>"
+      "description": "Delete the specified address from the notification denylist.",
+      "scopes": "notify:manage-denylist:<notificationType>/<notificationAddress>"
     },
     {
       "type": "function",
       "method": "get",
-      "route": "/blacklist/list",
+      "route": "/denylist/list",
       "query": [
         "continuationToken",
         "limit"
@@ -96,9 +96,9 @@
       "args": [],
       "name": "list",
       "stability": "experimental",
-      "title": "List Blacklisted Notifications",
+      "title": "List Denylisted Notifications",
       "output": "v1/notification-address-list.json#",
-      "description": "Lists all the blacklisted addresses.\n\nBy default this end-point will try to return up to 1000 addresses in one\nrequest. But it **may return less**, even if more tasks are available.\nIt may also return a `continuationToken` even though there are no more\nresults. However, you can only be sure to have seen all results if you\nkeep calling `list` with the last `continuationToken` until you\nget a result without a `continuationToken`.\n\nIf you are not interested in listing all the members at once, you may\nuse the query-string option `limit` to return fewer."
+      "description": "Lists all the denylisted addresses.\n\nBy default this end-point will try to return up to 1000 addresses in one\nrequest. But it **may return less**, even if more tasks are available.\nIt may also return a `continuationToken` even though there are no more\nresults. However, you can only be sure to have seen all results if you\nkeep calling `list` with the last `continuationToken` until you\nget a result without a `continuationToken`.\n\nIf you are not interested in listing all the members at once, you may\nuse the query-string option `limit` to return fewer."
     }
   ]
 }

--- a/generated/references.json
+++ b/generated/references.json
@@ -9429,37 +9429,37 @@
         {
           "args": [
           ],
-          "description": "Add the given address to the notification blacklist. The address\ncan be of either of the three supported address type namely pulse, email\nor IRC(user or channel). Addresses in the blacklist will be ignored\nby the notification service.",
+          "description": "Add the given address to the notification denylist. The address\ncan be of either of the three supported address type namely pulse, email\nor IRC(user or channel). Addresses in the denylist will be ignored\nby the notification service.",
           "input": "v1/notification-address.json#",
           "method": "post",
-          "name": "addBlacklistAddress",
+          "name": "addDenylistAddress",
           "query": [
           ],
-          "route": "/blacklist/add",
-          "scopes": "notify:manage-blacklist:<notificationType>/<notificationAddress>",
+          "route": "/denylist/add",
+          "scopes": "notify:manage-denylist:<notificationType>/<notificationAddress>",
           "stability": "experimental",
-          "title": "Blacklist Given Address",
+          "title": "Denylist Given Address",
           "type": "function"
         },
         {
           "args": [
           ],
-          "description": "Delete the specified address from the notification blacklist.",
+          "description": "Delete the specified address from the notification denylist.",
           "input": "v1/notification-address.json#",
           "method": "delete",
-          "name": "deleteBlacklistAddress",
+          "name": "deleteDenylistAddress",
           "query": [
           ],
-          "route": "/blacklist/delete",
-          "scopes": "notify:manage-blacklist:<notificationType>/<notificationAddress>",
+          "route": "/denylist/delete",
+          "scopes": "notify:manage-denylist:<notificationType>/<notificationAddress>",
           "stability": "experimental",
-          "title": "Delete Blacklisted Address",
+          "title": "Delete Denylisted Address",
           "type": "function"
         },
         {
           "args": [
           ],
-          "description": "Lists all the blacklisted addresses.\n\nBy default this end-point will try to return up to 1000 addresses in one\nrequest. But it **may return less**, even if more tasks are available.\nIt may also return a `continuationToken` even though there are no more\nresults. However, you can only be sure to have seen all results if you\nkeep calling `list` with the last `continuationToken` until you\nget a result without a `continuationToken`.\n\nIf you are not interested in listing all the members at once, you may\nuse the query-string option `limit` to return fewer.",
+          "description": "Lists all the denylisted addresses.\n\nBy default this end-point will try to return up to 1000 addresses in one\nrequest. But it **may return less**, even if more tasks are available.\nIt may also return a `continuationToken` even though there are no more\nresults. However, you can only be sure to have seen all results if you\nkeep calling `list` with the last `continuationToken` until you\nget a result without a `continuationToken`.\n\nIf you are not interested in listing all the members at once, you may\nuse the query-string option `limit` to return fewer.",
           "method": "get",
           "name": "list",
           "output": "v1/notification-address-list.json#",
@@ -9467,9 +9467,9 @@
             "continuationToken",
             "limit"
           ],
-          "route": "/blacklist/list",
+          "route": "/denylist/list",
           "stability": "experimental",
-          "title": "List Blacklisted Notifications",
+          "title": "List Denylisted Notifications",
           "type": "function"
         }
       ],

--- a/services/notify/config.yml
+++ b/services/notify/config.yml
@@ -12,7 +12,7 @@ defaults:
     maxMessageTime:               600
     # Email address to blacklist, useful to mitigate temporary misuse
     emailBlacklist:               !env:json EMAIL_BLACKLIST
-    blacklistedNotificationTableName: !env BLACKLISTED_NOTIFICATION_TABLE_NAME
+    denylistedNotificationTableName: !env DENYLISTED_NOTIFICATION_TABLE_NAME
     # ignore tasks with reasonResolved matching something in this list
     ignoreTaskReasonResolved:
         - canceled
@@ -76,7 +76,7 @@ test:
     sourceEmail: '"Taskcluster Notify Testing" <taskcluster-noreply-testing@mozilla.com>'
     sqsQueueName: taskcluster-notify-test-irc
     routePrefix: test-notify
-    blacklistedNotificationTableName: TestBlacklistedNotification
+    denylistedNotificationTableName: TestDenylistedNotification
     publishMetaData: false
   azure:
     accountId:        'jungle'

--- a/services/notify/src/data.js
+++ b/services/notify/src/data.js
@@ -1,15 +1,15 @@
 const Entity = require('azure-entities');
 
-const BlacklistedNotification = Entity.configure({
+const DenylistedNotification = Entity.configure({
   version: 1,
   partitionKey: Entity.keys.StringKey('notificationType'),
   rowKey: Entity.keys.StringKey('notificationAddress'),
   properties: {
     // the type could be email, pulse, irc-user or irc-channel
     notificationType: Entity.types.String,
-    // the address of the blacklisted destination
+    // the address of the denylisted destination
     notificationAddress: Entity.types.String,
   },
 });
 
-exports.BlacklistedNotification = BlacklistedNotification;
+exports.DenylistedNotification = DenylistedNotification;

--- a/services/notify/src/main.js
+++ b/services/notify/src/main.js
@@ -54,17 +54,17 @@ const load = loader({
     }),
   },
 
-  BlacklistedNotification: {
+  DenylistedNotification: {
     requires: ['cfg', 'monitor', 'process'],
-    setup: ({cfg, monitor, process}) => data.BlacklistedNotification.setup({
-      tableName: cfg.app.blacklistedNotificationTableName,
+    setup: ({cfg, monitor, process}) => data.DenylistedNotification.setup({
+      tableName: cfg.app.denylistedNotificationTableName,
       credentials: sasCredentials({
         accountId: cfg.azure.accountId,
-        tableName: cfg.app.blacklistedNotificationTableName,
+        tableName: cfg.app.denylistedNotificationTableName,
         rootUrl: cfg.taskcluster.rootUrl,
         credentials: cfg.taskcluster.credentials,
       }),
-      monitor: monitor.prefix('table.blacklist'),
+      monitor: monitor.prefix('table.denylist'),
     }),
   },
 
@@ -200,10 +200,10 @@ const load = loader({
   },
 
   api: {
-    requires: ['cfg', 'monitor', 'schemaset', 'notifier', 'BlacklistedNotification'],
-    setup: ({cfg, monitor, schemaset, notifier, BlacklistedNotification}) => builder.build({
+    requires: ['cfg', 'monitor', 'schemaset', 'notifier', 'DenylistedNotification'],
+    setup: ({cfg, monitor, schemaset, notifier, DenylistedNotification}) => builder.build({
       rootUrl: cfg.taskcluster.rootUrl,
-      context: {notifier, BlacklistedNotification},
+      context: {notifier, DenylistedNotification},
       publish: cfg.app.publishMetaData,
       aws: cfg.aws,
       monitor: monitor.prefix('api'),

--- a/services/notify/src/notifier.js
+++ b/services/notify/src/notifier.js
@@ -70,9 +70,9 @@ class Notifier {
       return;
     }
 
-    // Don't notify emails on the blacklist
+    // Don't notify emails on the denylist
     if (this.options.emailBlacklist.includes(address)) {
-      debug('Blacklist email: %s send detected, discarding the notification', address);
+      debug('Denylist email: %s send detected, discarding the notification', address);
       return;
     }
 

--- a/services/notify/test/helper.js
+++ b/services/notify/test/helper.js
@@ -399,7 +399,7 @@ exports.withServer = (mock, skipping) => {
   });
 };
 
-exports.withBlacklist = (mock, skipping) => {
+exports.withDenylist = (mock, skipping) => {
   suiteSetup(async function() {
     if (skipping()) {
       return;
@@ -407,26 +407,26 @@ exports.withBlacklist = (mock, skipping) => {
 
     if (mock) {
       const cfg = await exports.load('cfg');
-      exports.load.inject('BlacklistedNotification', data.BlacklistedNotification.setup({
-        tableName: 'BlacklistedNotification',
+      exports.load.inject('DenylistedNotification', data.DenylistedNotification.setup({
+        tableName: 'DenylistedNotification',
         credentials: 'inMemory',
       }));
     } else {
       // suffix the table name config with a short suffix so that parallel
       // test runs have a good chance of not stepping on each others' feet
       const cfg = await exports.load('cfg');
-      exports.load.cfg('app.blacklistedNotificationTableName',
-        cfg.app.blacklistedNotificationTableName + TABLE_SUFFIX);
+      exports.load.cfg('app.denylistedNotificationTableName',
+        cfg.app.denylistedNotificationTableName + TABLE_SUFFIX);
     }
 
-    exports.BlacklistedNotification = await exports.load('BlacklistedNotification');
-    await exports.BlacklistedNotification.ensureTable();
+    exports.DenylistedNotification = await exports.load('DenylistedNotification');
+    await exports.DenylistedNotification.ensureTable();
   });
 
   // Clear the table entries before each test
   const cleanup = async () => {
     if (!skipping()) {
-      await exports.BlacklistedNotification.scan({}, {handler: address => address.remove()});
+      await exports.DenylistedNotification.scan({}, {handler: address => address.remove()});
     }
   };
   setup(cleanup);


### PR DESCRIPTION
@imbstack suggested using a term with less cultural baggage (at least in the US) than "blacklist".  Seems reasonable! /cc @OjaswinM 
