### PR TITLE
[Bug 1520918] Add denylist queries to web-server

### DIFF
--- a/services/web-server/src/clients.js
+++ b/services/web-server/src/clients.js
@@ -9,6 +9,7 @@ import {
   Queue,
   QueueEvents,
   Secrets,
+  Notify,
 } from 'taskcluster-client';
 
 export default options => ({
@@ -22,4 +23,5 @@ export default options => ({
   queue: new Queue(options),
   secrets: new Secrets(options),
   queueEvents: new QueueEvents(options),
+  notify: new Notify(options),
 });

--- a/services/web-server/src/graphql/Notify.graphql
+++ b/services/web-server/src/graphql/Notify.graphql
@@ -1,0 +1,28 @@
+type NotificationAddress {
+  notificationType: String!
+  notificationAddress: String!
+}
+
+input NotificationAddressInput {
+  notificationType: String!
+  notificationAddress: String!
+}
+
+type NotificationAddressEdge implements Edge {
+  cursor: String
+  node: NotificationAddress
+}
+
+type NotificationAddressConnection implements Connection {
+  pageInfo: PageInfo
+  edges: [NotificationAddressEdge]
+}
+
+extend type Query {
+  listDenylistAddresses(filter: JSON, connection: PageConnection): NotificationAddressConnection
+}
+
+extend type Mutation {
+  addDenylistAddress(address: NotificationAddressInput!): NotificationAddress
+  deleteDenylistAddress(address: NotificationAddressInput!): NotificationAddress
+}

--- a/services/web-server/src/graphql/Notify.graphql
+++ b/services/web-server/src/graphql/Notify.graphql
@@ -4,10 +4,10 @@ type NotificationAddress {
 }
 
 enum NotificationType {
-  email
-  pulse
-  ircUser
-  ircChannel
+  EMAIL
+  PULSE
+  IRC_USER
+  IRC_CHANNEL
 }
 
 input NotificationAddressInput {

--- a/services/web-server/src/graphql/Notify.graphql
+++ b/services/web-server/src/graphql/Notify.graphql
@@ -1,10 +1,17 @@
 type NotificationAddress {
-  notificationType: String!
+  notificationType: NotificationType!
   notificationAddress: String!
 }
 
+enum NotificationType {
+  email
+  pulse
+  ircUser
+  ircChannel
+}
+
 input NotificationAddressInput {
-  notificationType: String!
+  notificationType: NotificationType!
   notificationAddress: String!
 }
 

--- a/services/web-server/src/graphql/Root.graphql
+++ b/services/web-server/src/graphql/Root.graphql
@@ -30,7 +30,8 @@ union Node =
   CachePurge |
   SecretListItem |
   Client |
-  RoleCompact
+  RoleCompact |
+  NotificationAddress
 
 interface Edge {
   cursor: String

--- a/services/web-server/src/loaders/notify.js
+++ b/services/web-server/src/loaders/notify.js
@@ -1,0 +1,24 @@
+import DataLoader from 'dataloader';
+import sift from 'sift';
+import ConnectionLoader from '../ConnectionLoader';
+
+export default ({ notify }) => {
+  const denylist = new ConnectionLoader(async ({ filter, options }) => {
+    const raw = await notify.list(options);
+    const addresses = raw.addresses.map(address => {
+      return {
+        notificationType: address.notificationType,
+        notificationAddress: address.notificationAddress,
+      };
+     });
+
+    return {
+      ...raw,
+      items: filter ? sift(filter, addresses) : addresses,
+    };
+  });
+
+  return {
+    denylist
+  };
+};

--- a/services/web-server/src/loaders/notify.js
+++ b/services/web-server/src/loaders/notify.js
@@ -10,7 +10,7 @@ export default ({ notify }) => {
         notificationType: address.notificationType,
         notificationAddress: address.notificationAddress,
       };
-     });
+    });
 
     return {
       ...raw,
@@ -19,6 +19,6 @@ export default ({ notify }) => {
   });
 
   return {
-    denylist
+    denylist,
   };
 };

--- a/services/web-server/src/loaders/notify.js
+++ b/services/web-server/src/loaders/notify.js
@@ -1,9 +1,8 @@
-import DataLoader from 'dataloader';
 import sift from 'sift';
 import ConnectionLoader from '../ConnectionLoader';
 
 export default ({ notify }) => {
-  const denylist = new ConnectionLoader(async ({ filter, options }) => {
+  const listDenylistAddresses = new ConnectionLoader(async ({ filter, options }) => {
     const raw = await notify.list(options);
     const addresses = raw.addresses.map(address => {
       return {
@@ -19,6 +18,6 @@ export default ({ notify }) => {
   });
 
   return {
-    denylist,
+    listDenylistAddresses,
   };
 };

--- a/services/web-server/src/resolvers/Notify.js
+++ b/services/web-server/src/resolvers/Notify.js
@@ -1,0 +1,19 @@
+export default {
+  Query: {
+    listDenylistAddresses(parent, { connection, filter }, { loaders }) {
+      return loaders.notify.load({ connection, filter });
+    },
+  },
+  Mutation: {
+    async addDenylistAddress(parent, { address }, { clients }) {
+      await clients.notify.addDenylistAddress(address);
+
+      return address;
+    },
+    async deleteDenylistAddress(parent, { address }, { clients }) {
+      await clients.notify.deleteDenylistAddress(address);
+
+      return address;
+    },
+  },
+};

--- a/services/web-server/src/resolvers/Notify.js
+++ b/services/web-server/src/resolvers/Notify.js
@@ -1,4 +1,10 @@
 export default {
+  NotificationType: {
+    EMAIL: 'email',
+    PULSE: 'pulse',
+    IRC_USER: 'irc-user',
+    IRC_CHANNEL: 'irc-channel',
+  },
   Query: {
     listDenylistAddresses(parent, { connection, filter }, { loaders }) {
       return loaders.listDenylistAddresses.load({ connection, filter });

--- a/services/web-server/src/resolvers/Notify.js
+++ b/services/web-server/src/resolvers/Notify.js
@@ -1,7 +1,7 @@
 export default {
   Query: {
     listDenylistAddresses(parent, { connection, filter }, { loaders }) {
-      return loaders.notify.load({ connection, filter });
+      return loaders.listDenylistAddresses.load({ connection, filter });
     },
   },
   Mutation: {


### PR DESCRIPTION
Bugzilla Bug: [1520918](https://bugzilla.mozilla.org/show_bug.cgi?id=1520918)

Alright so I tried making some changes but I'm getting an AssertionErro:- 

```
ojaswin@ojaswin-Inspiron-3521:~/TaskCluster/taskcluster-services/services/web-server$ yarn start
yarn run v1.12.3
$ NODE_ENV=development webpack

webpack is watching the files…

Hash: fcd1679f2701661734b7
Version: webpack 4.28.4
Time: 5163ms
Built at: 02/18/2019 9:39:34 PM
   Asset     Size  Chunks             Chunk Names
index.js  493 KiB   index  [emitted]  index


No Pulse namespace defined; no Pulse messages will be received.
AssertionError [ERR_ASSERTION]: config taskcluster.rootUrl is required
    at setup (/home/ojaswin/TaskCluster/taskcluster-services/services/web-server/build/index.js:1405:52)
    at Promise (/home/ojaswin/TaskCluster/taskcluster-services/libraries/loader/src/loader.js:149:33)
    at new Promise (<anonymous>)
    at loaded.(anonymous function).Promise.all.then.deps (/home/ojaswin/TaskCluster/taskcluster-services/libraries/loader/src/loader.js:147:18)
    at process._tickCallback (internal/process/next_tick.js:68:7)
    at Function.Module.runMain (internal/modules/cjs/loader.js:745:11)
    at startup (internal/bootstrap/node.js:283:19)
    at bootstrapNodeJSCore (internal/bootstrap/node.js:743:3)

```

`(/home/ojaswin/TaskCluster/taskcluster-services/services/web-server/build/index.js:1405:52)` I can't seem to find this directory in which the error occurred as well 