### PR TITLE
Stop renovate from rebasing stale PRs

### DIFF
--- a/package.json
+++ b/package.json
@@ -106,7 +106,6 @@
     "extends": [
       "config:base",
       ":preserveSemverRanges",
-      ":rebaseStalePrs",
       "schedule:weekly"
     ]
   },


### PR DESCRIPTION
Especially when we have a big batch of renovate requests, they tend to add a lot of load as they all rebase and re-run all CI jobs on every commit to master.  In most cases, this rebasing isn't necessary, and in the cases where it is it's easy enough to check the checkbox in the PR.