### PR TITLE
Bug 1361375 - implement query string options for the testAuthenticate endpoint

### DIFF
--- a/services/auth/schemas/v1/test-authenticate-response.yml
+++ b/services/auth/schemas/v1/test-authenticate-response.yml
@@ -22,7 +22,7 @@ properties:
     uniqueItems:            true
   queryString:
     description: |
-      Query string for the testAuthenticate
-    type:                       string
-    additionalProperties:       false
-required: [clientId, scopes]
+      Query string for the testAuthenticate. Will be sent by test-authenticate route for testing endpoint.
+    type:                       object
+    default:                    {}
+required: [clientId, scopes, queryString]

--- a/services/auth/schemas/v1/test-authenticate-response.yml
+++ b/services/auth/schemas/v1/test-authenticate-response.yml
@@ -20,4 +20,9 @@ properties:
       type:                 string
       pattern: "^[\x20-\x7e]*$"
     uniqueItems:            true
+  queryString:
+    description: |
+      Query string for the testAuthenticate
+    type:                       string
+    additionalProperties:       false
 required: [clientId, scopes]

--- a/services/auth/src/api.js
+++ b/services/auth/src/api.js
@@ -1031,7 +1031,9 @@ builder.declare({
     'The request is validated, with any certificate, authorizedScopes, etc.',
     'applied, and the resulting scopes are checked against `requiredScopes`',
     'from the request body. On success, the response contains the clientId',
-    'and scopes as seen by the API method.',
+    'scopes and queryString as seen by the API method.',
+    'For testing the endpoints queryString will be sent in response, will',
+    'contain clientId and scopes for testing',
   ].join('\n'),
 }, async function(req, res) {
   await new Promise(next => APIBuilder.middleware.remoteAuthentication({
@@ -1060,10 +1062,9 @@ builder.declare({
     req.clientId(),
     req.scopes(),
   ]);
-  //setting headers as purposed by bug 161375
-  req.params.test_auth = {clientId, scopes};
-  res.setHeader('X-test_auth', {clientId, scopes});
-  res.reply({clientId, scopes});
+  
+  const queryString = {clientId, scopes};
+  res.reply({clientId, scopes, queryString});
 });
 
 builder.declare({
@@ -1120,24 +1121,3 @@ builder.declare({
   res.reply({clientId, scopes});
 });
 
-/** Query string to authenticate **/
-builder.declare({
-  method: 'get',
-  route: '/test-authenticate?q={auth}',
-  query: {
-    prefix: /^[A-Za-z0-9!@/:.+|_-]+$/, // should match clientId above
-    continuationToken: /./,
-    limit: /^[0-9]+$/,
-  },
-  name: 'queryString',
-  output: 'test-authenticate-response.yml',
-  stability: 'stable',
-  title: 'Query String',
-  description: [
-    'Get the query string passed in the url for authentication',
-    'A object will be query String present else null String would be received',
-  ].join('\n'),
-}, async function(req, res) {
-  let response = req.params.test_auth || '';
-  res.reply(response);
-});

--- a/services/auth/src/api.js
+++ b/services/auth/src/api.js
@@ -1135,7 +1135,7 @@ builder.declare({
   title: 'Query String',
   description: [
     'Get the query string passed in the url for authentication',
-    'A object will be query String present else null String would be received'
+    'A object will be query String present else null String would be received',
   ].join('\n'),
 }, async function(req, res) {
   let response = req.params.test_auth || '';

--- a/services/auth/src/api.js
+++ b/services/auth/src/api.js
@@ -1119,3 +1119,25 @@ builder.declare({
   ]);
   res.reply({clientId, scopes});
 });
+
+/** Query string to authenticate **/
+builder.declare({
+  method: 'get',
+  route: '/test-authenticate?q={auth}',
+  query: {
+    prefix: /^[A-Za-z0-9!@/:.+|_-]+$/, // should match clientId above
+    continuationToken: /./,
+    limit: /^[0-9]+$/,
+  },
+  name: 'queryString',
+  output: 'test-authenticate-response.yml',
+  stability: 'stable',
+  title: 'Query String',
+  description: [
+    'Get the query string passed in the url for authentication',
+    'A object will be query String present else null String would be received'
+  ].join('\n'),
+}, async function(req, res) {
+  let response = req.params.test_auth || '';
+  res.reply(response);
+});

--- a/services/auth/src/api.js
+++ b/services/auth/src/api.js
@@ -1060,6 +1060,9 @@ builder.declare({
     req.clientId(),
     req.scopes(),
   ]);
+  //setting headers as purposed by bug 161375
+  req.params.test_auth = {clientId, scopes};
+  res.setHeader('X-test_auth', {clientId, scopes});
   res.reply({clientId, scopes});
 });
 

--- a/services/auth/test/testauth_test.js
+++ b/services/auth/test/testauth_test.js
@@ -4,11 +4,13 @@ const helper = require('./helper');
 const credentials = {
   clientId: 'tester',
   accessToken: 'no-secret',
+  queryString: ''
 };
 
 const badcreds = {
   clientId: 'tester',
   accessToken: 'wrong',
+  queryString: ''
 };
 
 helper.secrets.mockSuite(helper.suiteName(__filename), ['app', 'azure'], function(mock, skipping) {
@@ -133,5 +135,14 @@ helper.secrets.mockSuite(`${helper.suiteName(__filename)} | get`, ['app', 'azure
       authorizedScopes: ['test:scopes-abc'],
     },
     errorCode: 'InsufficientScopes',
+  });
+
+  test('check for queryString in response', async()=>{
+    let auth = new helper.AuthClient({rootUrl: helper.rootUrl, credentials});
+    await auth.testAuthenticateGet().then((res) => {
+      assert(typeof(res.queryString) !== Object, 'queryString not present in the response');
+    }, err => {
+      assert(err, 'Request failed!');
+    });
   });
 });


### PR DESCRIPTION

Bugzilla Bug: [1361375](https://bugzilla.mozilla.org/show_bug.cgi?id=1361375)

implement query string options for the testAuthenticate endpoint . Changes done
1. created a variable `credential` to store the object `{clientId, scopes}`
2. for query string ,used `history.pushState()` to add query string to current url
3. for setting header of credential used `res.setHeader()` which will be set as `X-test_auth`
