### PR TITLE
Bug #286 Reopen the section menu when clicking "next" solved

### DIFF
--- a/ui/src/components/Dashboard/DocsSidebarList.jsx
+++ b/ui/src/components/Dashboard/DocsSidebarList.jsx
@@ -118,6 +118,9 @@ export default class DocsSidebarList extends Component {
     if (currentMenu !== previousMenu) {
       Object.assign(newState, { menuOpen: true });
     }
+    if (currentMenu == previousMenu && state.previousPathname !== newState.previousPathname) {
+      Object.assign(newState, { menuOpen: true });
+    }
 
     return newState;
   }


### PR DESCRIPTION
[UI] Reopen the section menu when clicking "next" #286
Bugzilla Bug: [#286](https://github.com/taskcluster/taskcluster/issues/286)
