### PR TITLE
Bug 1527424 - clean up error handling in TaskCreator

### DIFF
--- a/generated/references.json
+++ b/generated/references.json
@@ -4245,14 +4245,6 @@
   },
   {
     "content": {
-      "$id": "/schemas/hooks/v1/trigger-response.json#",
-      "$schema": "/schemas/common/metaschema.json#",
-      "title": "Trigger Hook Response"
-    },
-    "filename": "schemas/hooks/v1/trigger-response.json"
-  },
-  {
-    "content": {
       "$id": "/schemas/hooks/v1/trigger-hook.json#",
       "$schema": "/schemas/common/metaschema.json#",
       "description": "A request to trigger a hook.  The payload must be a JSON object, and is used as the context\nfor a JSON-e rendering of the hook's task template, as described in \"Firing Hooks\".\n",

--- a/services/hooks/schemas/v1/trigger-response.yml
+++ b/services/hooks/schemas/v1/trigger-response.yml
@@ -1,2 +1,0 @@
-$schema: "/schemas/common/metaschema.json#"
-title: "Trigger Hook Response"

--- a/services/hooks/src/listeners.js
+++ b/services/hooks/src/listeners.js
@@ -84,7 +84,12 @@ class HookListeners {
         hookId: hookId,
       }, true);
       if (latestHook) {
-        await this.taskcreator.fire(latestHook, {firedBy: 'pulseMessage', payload});
+        try {
+          await this.taskcreator.fire(latestHook, {firedBy: 'pulseMessage', payload});
+        } catch (err) {
+          // any errors were already reported via the LastFire table, so they
+          // can be safely ignored here
+        }
       }
     });
 

--- a/services/hooks/src/v1.js
+++ b/services/hooks/src/v1.js
@@ -548,7 +548,6 @@ const triggerHookCommon = async function({req, res, hook, payload, clientId, fir
   if (clientId) {
     context.clientId = clientId;
   }
-  let lastFire;
   let resp;
   let error;
 
@@ -568,23 +567,9 @@ const triggerHookCommon = async function({req, res, hook, payload, clientId, fir
       // hook did not produce a response, so return an empty object
       return res.reply({});
     }
-    lastFire = {
-      result: 'success',
-      taskId: resp.status.taskId,
-      time: new Date(),
-    };
   } catch (err) {
     error = err;
-    lastFire = {
-      result: 'error',
-      error: err,
-      time: new Date(),
-    };
   }
-
-  await hook.modify((hook) => {
-    hook.lastFire = lastFire;
-  });
 
   if (resp) {
     return res.reply(resp);

--- a/ui/docs/generated/hooks/schemas/v1/trigger-response.json
+++ b/ui/docs/generated/hooks/schemas/v1/trigger-response.json
@@ -1,5 +1,0 @@
-{
-  "$schema": "/schemas/common/metaschema.json#",
-  "title": "Trigger Hook Response",
-  "$id": "/schemas/hooks/v1/trigger-response.json#"
-}

--- a/ui/docs/generated/references.json
+++ b/ui/docs/generated/references.json
@@ -4245,14 +4245,6 @@
   },
   {
     "content": {
-      "$id": "/schemas/hooks/v1/trigger-response.json#",
-      "$schema": "/schemas/common/metaschema.json#",
-      "title": "Trigger Hook Response"
-    },
-    "filename": "schemas/hooks/v1/trigger-response.json"
-  },
-  {
-    "content": {
       "$id": "/schemas/hooks/v1/trigger-hook.json#",
       "$schema": "/schemas/common/metaschema.json#",
       "description": "A request to trigger a hook.  The payload must be a JSON object, and is used as the context\nfor a JSON-e rendering of the hook's task template, as described in \"Firing Hooks\".\n",


### PR DESCRIPTION
This refactors TaskCreator.fire to do a better job of error handling,
consistently updating LastFire and returning an API response or an
error.

This also drops an unused schema file and deletes some additional (now
moot) modifications of the lastFire field in the Hooks table.

Bugzilla Bug: [1527424](https://bugzilla.mozilla.org/show_bug.cgi?id=1527424)

cc: @ydidwania 
