### PR TITLE
[bug 1531576] Add clientId to express logs and remove unstructured version

### DIFF
--- a/libraries/monitor/src/builtins.js
+++ b/libraries/monitor/src/builtins.js
@@ -32,6 +32,7 @@ module.exports = [
       name: 'The name of the endpoint.',
       statusCode: 'The http status code that the endpoint resolved with.',
       duration: 'The duration in ms of the endpoint.',
+      clientId: 'The clientId (if one exists) that called this endpoint.',
     },
   },
   {

--- a/libraries/monitor/src/monitor.js
+++ b/libraries/monitor/src/monitor.js
@@ -119,7 +119,7 @@ class Monitor {
     return (req, res, next) => {
       let sent = false;
       const start = process.hrtime();
-      const send = () => {
+      const send = async () => {
         try {
           // Avoid sending twice
           if (sent) {
@@ -131,6 +131,8 @@ class Monitor {
 
           this.log.expressTimer({
             name,
+            hasAuthed: req.hasAuthed,
+            clientId: req.hasAuthed ? await req.clientId() : '',
             statusCode: res.statusCode,
             duration: d[0] * 1000 + d[1] / 1000000,
           });


### PR DESCRIPTION
According to the metrics in the bug, the `console.log` at the end of authorization is the source of a lot of the logging volume currently. If we merge some extra information into the express metrics, we can avoid logging two lines.

Bugzilla Bug: [1531576](https://bugzilla.mozilla.org/show_bug.cgi?id=1531576)
