### PR TITLE
DB migration: add a table

### DIFF
--- a/services/github/config.yml
+++ b/services/github/config.yml
@@ -9,6 +9,7 @@ defaults:
     buildsTableName: 'TaskclusterGithubBuilds'
     ownersDirectoryTableName: 'TaskclusterIntegrationOwners'
     checkRunsTableName: 'TaskclusterCheckRuns'
+    checksToTasksTableName: 'TaskclusterChecksToTasks'
     checkTaskRoute: 'checks'
     statusTaskRoute: 'statuses'
     publishMetaData: !env:bool PUBLISH_METADATA
@@ -93,6 +94,8 @@ staging:
     initialStatusQueue: 'checks-tasks'
     buildsTableName: 'TaskclusterGithubBuildsStaging'
     ownersDirectoryTableName: 'TaskclusterIntegrationOwnersStaging'
+    checkRunsTableName: 'TaskclusterCheckRunsStaging'
+    checksToTasksTableName: 'TaskclusterChecksToTasksStaging'
     name: 'tc-github-staging'
     statusContext: 'Taskcluster-Staging'
     botName: 'taskcluster-staging[bot]'

--- a/services/github/src/data.js
+++ b/services/github/src/data.js
@@ -114,3 +114,15 @@ module.exports.CheckRuns = Entity.configure({
     checkRunId: Entity.types.String,
   },
 });
+
+module.exports.ChecksToTasks = Entity.configure({
+  version: 1,
+  partitionKey: Entity.keys.StringKey('checkSuiteId'),
+  rowKey: Entity.keys.StringKey('checkRunId'),
+  properties: {
+    taskGroupId: Entity.types.String,
+    taskId: Entity.types.String,
+    checkSuiteId: Entity.types.String,
+    checkRunId: Entity.types.String,
+  },
+});

--- a/services/github/src/handlers.js
+++ b/services/github/src/handlers.js
@@ -503,6 +503,13 @@ async function statusHandler(message) {
         checkSuiteId: checkRun.data.check_suite.id.toString(),
         checkRunId: checkRun.data.id.toString(),
       });
+
+      await this.context.ChecksToTasks.create({
+        taskGroupId,
+        taskId,
+        checkSuiteId: checkRun.data.check_suite.id.toString(),
+        checkRunId: checkRun.data.id.toString(),
+      });
     }
   } catch (e) {
     debug(`Failed to update status: ${build.organization}/${build.repository}@${build.sha}`);
@@ -796,6 +803,16 @@ async function taskDefinedHandler(message) {
   debug(`Created check run for task ${taskId}, task group ${taskGroupId}. Now updating data base`);
 
   await this.context.CheckRuns.create({
+    taskGroupId,
+    taskId,
+    checkSuiteId: checkRun.data.check_suite.id.toString(),
+    checkRunId: checkRun.data.id.toString(),
+  }).catch(async (err) => {
+    await this.createExceptionComment({instGithub, organization, repository, sha, error: err});
+    throw err;
+  });
+
+  await this.context.ChecksToTasks.create({
     taskGroupId,
     taskId,
     checkSuiteId: checkRun.data.check_suite.id.toString(),

--- a/services/github/src/main.js
+++ b/services/github/src/main.js
@@ -144,6 +144,20 @@ const load = loader({
     }),
   },
 
+  ChecksToTasks: {
+    requires: ['cfg', 'monitor'],
+    setup: async ({cfg, monitor}) => data.ChecksToTasks.setup({
+      tableName: cfg.app.checksToTasksTableName,
+      credentials: sasCredentials({
+        accountId: cfg.azure.accountId,
+        tableName: cfg.app.checksToTasksTableName,
+        rootUrl: cfg.taskcluster.rootUrl,
+        credentials: cfg.taskcluster.credentials,
+      }),
+      monitor: monitor.monitor('table.checkstotasks'),
+    }),
+  },
+
   api: {
     requires: [
       'cfg', 'monitor', 'schemaset', 'github', 'publisher', 'Builds',
@@ -206,8 +220,21 @@ const load = loader({
       'pulseClient',
       'publisher',
       'CheckRuns',
+      'ChecksToTasks',
     ],
-    setup: async ({cfg, github, monitor, intree, schemaset, reference, Builds, pulseClient, publisher, CheckRuns}) =>
+    setup: async ({
+      cfg,
+      github,
+      monitor,
+      intree,
+      schemaset,
+      reference,
+      Builds,
+      pulseClient,
+      publisher,
+      CheckRuns,
+      ChecksToTasks,
+    }) =>
       new Handlers({
         rootUrl: cfg.taskcluster.rootUrl,
         credentials: cfg.pulse,
@@ -219,7 +246,7 @@ const load = loader({
         deprecatedInitialStatusQueueName: cfg.app.deprecatedInitialStatusQueue,
         resultStatusQueueName: cfg.app.resultStatusQueue,
         initialStatusQueueName: cfg.app.initialStatusQueue,
-        context: {cfg, github, schemaset, Builds, CheckRuns, publisher},
+        context: {cfg, github, schemaset, Builds, CheckRuns, ChecksToTasks, publisher},
         pulseClient,
       }),
   },

--- a/services/github/test/helper.js
+++ b/services/github/test/helper.js
@@ -98,9 +98,11 @@ exports.withEntities = (mock, skipping) => {
     exports.buildsTableName = `TaskclusterGithubBuildsV${tableVersion}`;
     exports.ownersTableName = `TaskclusterIntegrationOwnersV${tableVersion}`;
     exports.checkRunsTableName = `TaskclusterCheckRunsV${tableVersion}`;
+    exports.checksToTasksTableName = `TaskclustersToTasksV${tableVersion}`;
     exports.load.cfg('app.buildsTableName', exports.buildsTableName);
     exports.load.cfg('app.ownersDirectoryTableName', exports.ownersTableName);
     exports.load.cfg('app.checkRunsTableName', exports.checkRunsTableName);
+    exports.load.cfg('app.checksToTasksTableName', exports.checksToTasksTableName);
 
     if (mock) {
       const cfg = await exports.load('cfg');
@@ -116,6 +118,10 @@ exports.withEntities = (mock, skipping) => {
         tableName: 'CheckRuns',
         credentials: 'inMemory',
       }));
+      exports.load.inject('ChecksToTasks', data.ChecksToTasks.setup({
+        tableName: 'ChecksToTasks',
+        credentials: 'inMemory',
+      }));
     }
 
     exports.Builds = await exports.load('Builds');
@@ -126,6 +132,9 @@ exports.withEntities = (mock, skipping) => {
 
     exports.CheckRuns = await exports.load('CheckRuns');
     await exports.CheckRuns.ensureTable();
+
+    exports.ChecksToTasks = await exports.load('ChecksToTasks');
+    await exports.ChecksToTasks.ensureTable();
   });
 
   const cleanup = async () => {
@@ -133,6 +142,7 @@ exports.withEntities = (mock, skipping) => {
       await exports.Builds.scan({}, {handler: secret => secret.remove()});
       await exports.OwnersDirectory.scan({}, {handler: secret => secret.remove()});
       await exports.CheckRuns.scan({}, {handler: secret => secret.remove()});
+      await exports.ChecksToTasks.scan({}, {handler: secret => secret.remove()});
     }
   };
   suiteSetup(cleanup);


### PR DESCRIPTION
<!-- If this is related to a Bugzilla bug, please begin your title with [Bug XXXXX] and update the following link. -->
<!-- If there is no bug, consider making one and if you really don't want one, remove the link. -->

<!-- Include any other context you wish here. -->

Bugzilla Bug: [1531606](https://bugzilla.mozilla.org/show_bug.cgi?id=1531606)

I need this for [retrigger implementation](https://bugzilla.mozilla.org/show_bug.cgi?id=1528650#c1). For retriggering a task, I plan the usual `this.context.ChecksToTasks.load({checkSuiteId, checkRunId})`, and for retriggering the whole task group - `this.context.ChecksToTasks.query({checkSuiteId})`.