### PR TITLE
Bug 1519969 - Sending an email to an invalid address fails

### DIFF
--- a/generated/references.json
+++ b/generated/references.json
@@ -4963,6 +4963,7 @@
         },
         "owner": {
           "description": "Email of the person or group responsible for this hook.",
+          "format": "email",
           "maxLength": 255,
           "title": "Owner",
           "type": "string"

--- a/services/hooks/schemas/v1/hook-metadata.yml
+++ b/services/hooks/schemas/v1/hook-metadata.yml
@@ -17,6 +17,7 @@ properties:
     description: "Email of the person or group responsible for this hook."
     type: "string"
     maxLength: 255
+    format: email
   emailOnError:
     title: "Email on error"
     description: "Whether to email the owner on an error creating the task."

--- a/ui/docs/generated/hooks/schemas/v1/hook-metadata.json
+++ b/ui/docs/generated/hooks/schemas/v1/hook-metadata.json
@@ -19,7 +19,8 @@
       "title": "Owner",
       "description": "Email of the person or group responsible for this hook.",
       "type": "string",
-      "maxLength": 255
+      "maxLength": 255,
+      "format": "email"
     },
     "emailOnError": {
       "title": "Email on error",

--- a/ui/docs/generated/references.json
+++ b/ui/docs/generated/references.json
@@ -4963,6 +4963,7 @@
         },
         "owner": {
           "description": "Email of the person or group responsible for this hook.",
+          "format": "email",
           "maxLength": 255,
           "title": "Owner",
           "type": "string"


### PR DESCRIPTION
Bug 1519969 
https://bugzilla.mozilla.org/show_bug.cgi?id=1519969

currently stuck at the implementation to find email of the person creating the Hook !

Kindly help me out here !