### PR TITLE
Remove use of single users in CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,10 +1,5 @@
 * @taskcluster/services-reviewers
 
-services/queue @jhford
-services/worker-manager @jhford
 services/web-server @taskcluster/frontend-reviewers
 clients/client-web @taskcluster/frontend-reviewers
 ui @taskcluster/frontend-reviewers
-clients/client @jhford
-
-infrastructure/builder @djmitche


### PR DESCRIPTION
This supports the notion that we're all in this together, I think :)
