### PR TITLE
Bug 1525130 - write out 'references.json' for use by client builders

### DIFF
--- a/infrastructure/references/relativize.js
+++ b/infrastructure/references/relativize.js
@@ -1,10 +1,16 @@
 const fs = require('fs');
+const path = require('path');
 const References = require('taskcluster-lib-references');
 
 const build = (input, output, rootUrl) => {
   const serializable = JSON.parse(fs.readFileSync(input, {encoding: 'utf8'}));
   const refs = References.fromSerializable({serializable});
+
+  // write uri-structured data to the root where nginx will serve it
   refs.asAbsolute(rootUrl).writeUriStructured({directory: output});
+
+  // write out a single `references/references.json` containing the same data
+  fs.writeFileSync(path.join(output, 'references', 'references.json'), input);
 };
 
 if (!module.parent) {


### PR DESCRIPTION
I'm not sure where to document this -- to be honest our documentation of deployment-related stuff is almost completely absent.  But, hopefully this will help @petemoore with client generation, as it allows a single HTTP request to get all of the necessary data without having to "spider" the references and schemas URLs.

Bugzilla Bug: [1525130](https://bugzilla.mozilla.org/show_bug.cgi?id=1525130)
