### PR TITLE
update to new monoimage, with fixes

### DIFF
--- a/infrastructure/references/relativize.js
+++ b/infrastructure/references/relativize.js
@@ -10,7 +10,7 @@ const build = (input, output, rootUrl) => {
   refs.asAbsolute(rootUrl).writeUriStructured({directory: output});
 
   // write out a single `references/references.json` containing the same data
-  fs.writeFileSync(path.join(output, 'references', 'references.json'), input);
+  fs.writeFileSync(path.join(output, 'references', 'references.json'), serializable);
 };
 
 if (!module.parent) {

--- a/infrastructure/terraform/secrets-service.tf
+++ b/infrastructure/terraform/secrets-service.tf
@@ -27,6 +27,7 @@ module "secrets_secrets" {
     TASKCLUSTER_CLIENT_ID    = "static/taskcluster/secrets"
     TASKCLUSTER_ACCESS_TOKEN = "${random_string.secrets_access_token.result}"
     NODE_ENV                 = "production"
+    FORCE_SSL                = "false"
     MONITORING_ENABLE        = "false"
     PUBLISH_METADATA         = "false"
     AZURE_ACCOUNT            = "${azurerm_storage_account.base.name}"

--- a/infrastructure/terraform/taskcluster.tf.json
+++ b/infrastructure/terraform/taskcluster.tf.json
@@ -1,7 +1,7 @@
 {
   "locals": {
-    "taskcluster_image_gce-provider": "taskcluster/taskcluster-gce-provider:SVC-6539ef08a8f6",
-    "taskcluster_image_events": "taskcluster/taskcluster-events:SVC-43a5c6de328a",
-    "taskcluster_image_monoimage": "taskcluster/taskcluster-monoimage:SVC-ec654c65f8bc"
+    "taskcluster_image_gce-provider": "taskcluster/taskcluster-gce-provider:SVC-350cb1c698c7",
+    "taskcluster_image_events": "taskcluster/taskcluster-events:SVC-41586979a2fd",
+    "taskcluster_image_monoimage": "taskcluster/taskcluster-monoimage:SVC-25c05f33f1ac"
   }
 }

--- a/infrastructure/terraform/web-ui.tf
+++ b/infrastructure/terraform/web-ui.tf
@@ -15,6 +15,7 @@ module "web_ui" {
   source         = "modules/deployment"
   project_name   = "taskcluster-ui"
   service_name   = "ui"
+  proc_name      = "web"
   root_url       = "${var.root_url}"
   docker_image   = "${local.taskcluster_image_monoimage}"
   secret_name    = "${module.web_ui_secrets.secret_name}"


### PR DESCRIPTION
* set `FORCE_SSL` for secrets (c.f. #354)
* set `proc_name` for tc-ui so that it runs the right entrypoint (ui/web) and has the correct deployment name (taskcluster-ui-web).  Note that terraform and kubernetes don't get along here, leaving the taskcluster-ui-static deployment abandoned.
* fix #353 (derp)