### PR TITLE
Adding versions in docs path for api and event reference

### DIFF
--- a/infrastructure/builder/src/generate/generators/docs-tocs.js
+++ b/infrastructure/builder/src/generate/generators/docs-tocs.js
@@ -70,12 +70,11 @@ async function readGeneratedDocs() {
     // Rename keys to include the section, tier and service name
     // e.g., docs/intro -> reference/integrations/github/docs/intro
     Object.keys(mdFiles).forEach(oldKey => {
-      const path = `reference/${metadata.tier}/${projectName}/${oldKey}`;
+      let path = `reference/${metadata.tier}/${projectName}/${oldKey}`;
 
       if(oldKey === "references/events" || oldKey === "references/api"){
-        path = `reference/${metadata.tier}/${projectName}/v1/${oldKey}`
+        path = `reference/${metadata.tier}/${projectName}/v1/${oldKey}`;
       }
-      
       delete Object.assign(mdFiles, {
         [removeExtension(path)]: Object.assign(mdFiles[oldKey]),
       })[oldKey];

--- a/infrastructure/builder/src/generate/generators/docs-tocs.js
+++ b/infrastructure/builder/src/generate/generators/docs-tocs.js
@@ -72,6 +72,10 @@ async function readGeneratedDocs() {
     Object.keys(mdFiles).forEach(oldKey => {
       const path = `reference/${metadata.tier}/${projectName}/${oldKey}`;
 
+      if(oldKey === "references/events" || oldKey === "references/api"){
+        path = `reference/${metadata.tier}/${projectName}/v1/${oldKey}`
+      }
+      
       delete Object.assign(mdFiles, {
         [removeExtension(path)]: Object.assign(mdFiles[oldKey]),
       })[oldKey];

--- a/services/github/src/handlers.js
+++ b/services/github/src/handlers.js
@@ -756,7 +756,7 @@ async function taskGroupCreationHandler(message) {
  * checks api function
  *
  * @param message - taskDefined exchange message
- *   https://docs.taskcluster.net/docs/reference/platform/taskcluster-queue/references/events#taskDefined
+ *   https://docs.taskcluster.net/docs/reference/platform/taskcluster-queue/references/v1/events#taskDefined
  * @returns {Promise<void>}
  */
 async function taskDefinedHandler(message) {

--- a/services/notify/docs/usage.md
+++ b/services/notify/docs/usage.md
@@ -44,8 +44,8 @@ But what you've really been waiting for is to know how to use this, so here's a 
 ### Setting Custom Messages
 
 In both irc and email you can set custom messages by adding fields to your task definition. The fields will be rendered with [jsone](https://taskcluster.github.io/json-e/)
-given a context of the [task definition](/docs/reference/platform/taskcluster-queue/references/api#get-task-definition)
-and the `status` section of [task status](/docs/reference/platform/taskcluster-queue/references/events#message-payload-4).
+given a context of the [task definition](/docs/reference/platform/taskcluster-queue/references/v1/api#get-task-definition)
+and the `status` section of [task status](/docs/reference/platform/taskcluster-queue/references/v1/events#message-payload-4).
 The task definition is in the context under the key `task` and the status is in the context under the key `status`.
 The fields you add to your task definition are all in the `task.extra` section under a key `notify`. They are as follows:
 

--- a/services/queue/docs/actions.md
+++ b/services/queue/docs/actions.md
@@ -23,7 +23,7 @@ implementations are completely different.
 
 Actions are defined at the provisioner level. To set the actions to a
 provisioner, perform a call to the queue's
-[declareProvisioner](/docs/reference/platform/taskcluster-queue/references/api#declareProvisioner)
+[declareProvisioner](/docs/reference/platform/taskcluster-queue/references/v1/api#declareProvisioner)
 method, supplying a list of actions.
 
 An action is comprised with the following properties:
@@ -50,9 +50,9 @@ specific to a context will only be returned by the appropriate API method.
 
 | `context`     | API Method                                                                             |
 |---------------|----------------------------------------------------------------------------------------|
-| `provisioner` | [getProvisioner](/docs/reference/platform/taskcluster-queue/references/api#getProvisioner)* |
-| `worker-type` | [getWorkerType](/docs/reference/platform/taskcluster-queue/references/api#getWorkerType)    |
-| `worker`      | [getWorker](/docs/reference/platform/taskcluster-queue/references/api#getWorker)            |
+| `provisioner` | [getProvisioner](/docs/reference/platform/taskcluster-queue/references/v1/api#getProvisioner)* |
+| `worker-type` | [getWorkerType](/docs/reference/platform/taskcluster-queue/references/v1/api#getWorkerType)    |
+| `worker`      | [getWorker](/docs/reference/platform/taskcluster-queue/references/v1/api#getWorker)            |
 
 Note that all actions are declared at the provisioner level, regardless of
 context.  For symmetry, `getProvisioner` also returns all actions, not just

--- a/services/queue/docs/worker-hierarchy.md
+++ b/services/queue/docs/worker-hierarchy.md
@@ -16,7 +16,7 @@ example, there is no active management of the
 `provisionerId`.
 
 Provisioners can be declared, and metadata associated with them, via the
-[declareProvisioner](/docs/reference/platform/taskcluster-queue/references/api#declareProvisioner)
+[declareProvisioner](/docs/reference/platform/taskcluster-queue/references/v1/api#declareProvisioner)
 API method.
 
 ## Worker Types
@@ -27,7 +27,7 @@ interchangeable workers that can all perform the same work. Tasks are queued
 for a specific worker type, and workers claim work for a single worker type.
 
 Worker types can be declared, and metadata associated with them, via the
-[declareWorkerType](/docs/reference/platform/taskcluster-queue/references/api#declareWorkerType)
+[declareWorkerType](/docs/reference/platform/taskcluster-queue/references/v1/api#declareWorkerType)
 API method.
 
 ## Workers
@@ -37,5 +37,5 @@ perform work, and are identified by `workerGroup/workerId`. A worker claims and
 performs work from a single worker type.
 
 Workers can be declared, and metadata associated with them, via the
-[declareWorker](/docs/reference/platform/taskcluster-queue/references/api#declareWorker)
+[declareWorker](/docs/reference/platform/taskcluster-queue/references/v1/api#declareWorker)
 API method.

--- a/ui/docs/static/manual/tasks/runs.md
+++ b/ui/docs/static/manual/tasks/runs.md
@@ -33,7 +33,7 @@ result in an automatic re-run if there are sufficient retries left for the
 task. Task cancellation and a few other unusual circumstances are also
 represented by the `exception` state, and distinguished by the `reason` field
 in the task status -- see the [queue API
-reference](/docs/reference/platform/taskcluster-queue/references/api) for details.
+reference](/docs/reference/platform/taskcluster-queue/references/v1/api) for details.
 
 A task's state is based on the state of its latest run, with the addition of an
 `unscheduled` state for a task with no runs (as is the case when the task's

--- a/ui/docs/static/manual/using/artifacts.md
+++ b/ui/docs/static/manual/using/artifacts.md
@@ -39,7 +39,7 @@ an absolute path, while Generic-Worker requires a relative path, and for
 Taskcluster-Worker the path format depends on the engine in use.
 
 It is also possible, although unusual, to create artifacts using the [Queue
-API](/docs/reference/platform/taskcluster-queue/references/api#createArtifact).
+API](/docs/reference/platform/taskcluster-queue/references/v1/api#createArtifact).
 
 ## Passing Artifacts Between Tasks
 
@@ -50,7 +50,7 @@ application, with task B running tests on the built product.
 In this case, task B should list task A in its `dependencies` property so that
 it does not begin until that task is complete. It should then download the
 resulting artifact on task A using a URL to the
-[Queue.getLatestArtifact](/docs/reference/platform/taskcluster-queue/references/api#getLatestArtifact)
+[Queue.getLatestArtifact](/docs/reference/platform/taskcluster-queue/references/v1/api#getLatestArtifact)
 endpoint. That will generally look like this:
 
     https://queue.taskcluster.net/v1/task/URFDBjl5RtSNz_NJEH3hlw/artifacts/public/build.zip

--- a/ui/docs/static/tutorial/create-task-via-api.md
+++ b/ui/docs/static/tutorial/create-task-via-api.md
@@ -17,7 +17,7 @@ import SchemaTable from '../../../src/components/SchemaTable'
 ## Constructing a Task Definition
 
 To create a task we must construct a _task definition_, the API [reference
-documentation](/docs/reference/platform/taskcluster-queue/references/api) for the
+documentation](/docs/reference/platform/taskcluster-queue/references/v1/api) for the
 Queue service specifies a JSON schema for the `queue.createTask` method.  The
 payload for that method is:
 
@@ -244,7 +244,7 @@ Note that it may take a few minutes for this task to execute, as Taskcluster mus
 create a new Amazon EC2 instance to run it.
 
 If you are curious about the `createTask(taskId, payload)` method you can look
-it up in the [API docs](/docs/reference/platform/queue/reference/api-docs/) for the Queue. You should notice that
+it up in the [API docs](/docs/reference/platform/queue/reference/v1/api-docs/) for the Queue. You should notice that
 the API docs lists a `Signature` property, like
 `Signature: createTask(taskId, payload) : result`. These signatures are used to
 call methods in automatically generated client libraries. This allows for


### PR DESCRIPTION
<!-- If this is related to a Bugzilla bug, please begin your title with [Bug XXXXX] and update the following link. -->
<!-- If there is no bug, consider making one and if you really don't want one, remove the link. -->

<!-- Include any other context you wish here. -->

Bugzilla Bug: [1461815](https://bugzilla.mozilla.org/show_bug.cgi?id=1461815)

@djmitche I read the code present in the (infrastructure/builder/src/generate) and found that service-docs.js and docs-tocs.js are used for copying files from service folder. I made changes to only service folder because when we run yarn generate, ui/docs/generated file will automatically update with the added version.

can you comment If I am in the right direction or not? And what will be my next step to solve this issue.