### PR TITLE
[Bug 1523801] Blacklist listening to some specific exchanges

### DIFF
--- a/services/hooks/config.yml
+++ b/services/hooks/config.yml
@@ -51,8 +51,7 @@ defaults:
     password:       !env PULSE_PASSWORD
     hostname:       !env PULSE_HOSTNAME
     vhost:          !env PULSE_VHOST
-    denylist: 
-      exchanges: [taskcluster-queue, taskcluster-hooks]
+    denylist:       [taskcluster-queue, taskcluster-hooks]
 
 
 production:

--- a/services/hooks/config.yml
+++ b/services/hooks/config.yml
@@ -51,6 +51,8 @@ defaults:
     password:       !env PULSE_PASSWORD
     hostname:       !env PULSE_HOSTNAME
     vhost:          !env PULSE_VHOST
+    denylist: 
+      exchanges: [taskcluster-queue, taskcluster-hooks]
 
 
 production:

--- a/services/hooks/src/main.js
+++ b/services/hooks/src/main.js
@@ -129,7 +129,7 @@ const load = loader({
     requires: ['cfg', 'schemaset', 'Hook', 'LastFire', 'taskcreator', 'monitor', 'publisher', 'pulseClient'],
     setup: ({cfg, schemaset, Hook, LastFire, taskcreator, monitor, publisher, pulseClient}) => builder.build({
       rootUrl: cfg.taskcluster.rootUrl,
-      context: {Hook, LastFire, taskcreator, publisher, denyList: cfg.pulse.denylist.exchanges},
+      context: {Hook, LastFire, taskcreator, publisher, denylist: cfg.pulse.denylist},
       schemaset,
       publish: cfg.app.publishMetaData,
       aws: cfg.aws.validator,

--- a/services/hooks/src/main.js
+++ b/services/hooks/src/main.js
@@ -129,7 +129,7 @@ const load = loader({
     requires: ['cfg', 'schemaset', 'Hook', 'LastFire', 'taskcreator', 'monitor', 'publisher', 'pulseClient'],
     setup: ({cfg, schemaset, Hook, LastFire, taskcreator, monitor, publisher, pulseClient}) => builder.build({
       rootUrl: cfg.taskcluster.rootUrl,
-      context: {Hook, LastFire, taskcreator, publisher},
+      context: {Hook, LastFire, taskcreator, publisher, denyList: cfg.pulse.denylist.exchanges},
       schemaset,
       publish: cfg.app.publishMetaData,
       aws: cfg.aws.validator,

--- a/services/hooks/src/v1.js
+++ b/services/hooks/src/v1.js
@@ -36,7 +36,7 @@ const builder = new APIBuilder({
     hookGroupId: /^[a-zA-Z0-9-_]{1,64}$/,
     hookId: /^[a-zA-Z0-9-_\/]{1,64}$/,
   },
-  context: ['Hook', 'LastFire', 'taskcreator', 'publisher', 'denyList'],
+  context: ['Hook', 'LastFire', 'taskcreator', 'publisher', 'denylist'],
 });
 
 module.exports = builder;
@@ -222,7 +222,7 @@ builder.declare({
 
   let denied = await isDeniedBinding({
     bindings: hookDef.bindings || [],
-    denyList: this.denyList,
+    denylist: this.denylist,
   });
   if (denied) {
     return res.reportError('InputError', '{{message}}', {
@@ -329,7 +329,7 @@ builder.declare({
 
   let denied = await isDeniedBinding({
     bindings: hookDef.bindings,
-    denyList: this.denyList,
+    denylist: this.denylist,
   });
   if (denied) {
     return res.reportError('InputError', '{{message}}', {
@@ -594,8 +594,8 @@ const triggerHookCommon = async function({req, res, hook, payload, clientId, fir
   }
 };
 
-const isDeniedBinding = async ({bindings, denyList}) => {
-  let denyPattern = new RegExp(`^exchange/(${denyList.join('|')})/`);
+const isDeniedBinding = async ({bindings, denylist}) => {
+  let denyPattern = new RegExp(`^exchange/(${denylist.join('|')})/`);
   let denied=false;
   bindings.forEach((binding) => {
     if (denyPattern.test(binding.exchange)) {


### PR DESCRIPTION
<!-- If this is related to a Bugzilla bug, please begin your title with [Bug XXXXX] and update the following link. -->
<!-- If there is no bug, consider making one and if you really don't want one, remove the link. -->

<!-- Include any other context you wish here. -->
This PR involves checking the exchanges in the hook definition against a `denyList`at creation/updation of a hook. I have also written 2 tests one for each.
The `config.yml` looks like
```
pulse:
      denylist: 
           exchanges: [taskcluster-queue, taskcluster-hooks]
```
@djmitche I am guessing you'd want some changes to the above format. Do let me know while reviewing :)

Bugzilla Bug: [1523801](https://bugzilla.mozilla.org/show_bug.cgi?id=1523801)
