### PR TITLE
Speed back up queue tests

### DIFF
--- a/services/queue/test/deadline_test.js
+++ b/services/queue/test/deadline_test.js
@@ -47,7 +47,7 @@ helper.secrets.mockSuite(__filename, ['taskcluster', 'aws', 'azure'], function(m
     helper.checkNextMessage('task-defined');
 
     debug('### Start deadlineReaper');
-    const deadlineReaper = await helper.startPollingService('deadline-resolver');
+    await helper.startPollingService('deadline-resolver');
 
     debug('### Check for task-exception message');
     await testing.poll(async () => {
@@ -60,7 +60,7 @@ helper.secrets.mockSuite(__filename, ['taskcluster', 'aws', 'azure'], function(m
     }, Infinity);
 
     debug('### Stop deadlineReaper');
-    await deadlineReaper.terminate();
+    await helper.stopPollingService();
 
     debug('### Validate task status');
     const r2 = await helper.queue.status(taskId);
@@ -78,7 +78,7 @@ helper.secrets.mockSuite(__filename, ['taskcluster', 'aws', 'azure'], function(m
     helper.checkNextMessage('task-pending');
 
     debug('### Start deadlineReaper');
-    const deadlineReaper = await helper.startPollingService('deadline-resolver');
+    await helper.startPollingService('deadline-resolver');
     await testing.poll(async () => assert(helper.messages.length >= 1), Infinity);
 
     debug('### Check for task-exception message');
@@ -91,7 +91,7 @@ helper.secrets.mockSuite(__filename, ['taskcluster', 'aws', 'azure'], function(m
     });
 
     debug('### Stop deadlineReaper');
-    await deadlineReaper.terminate();
+    await helper.stopPollingService();
 
     debug('### Validate task status');
     const r2 = await helper.queue.status(taskId);
@@ -116,7 +116,7 @@ helper.secrets.mockSuite(__filename, ['taskcluster', 'aws', 'azure'], function(m
     helper.checkNextMessage('task-running');
 
     debug('### Start deadlineReaper');
-    const deadlineReaper = await helper.startPollingService('deadline-resolver');
+    await helper.startPollingService('deadline-resolver');
     await testing.poll(async () => assert(helper.messages.length >= 1), Infinity);
 
     debug('### Check for task-exception message');
@@ -129,7 +129,7 @@ helper.secrets.mockSuite(__filename, ['taskcluster', 'aws', 'azure'], function(m
     });
 
     debug('### Stop deadlineReaper');
-    await deadlineReaper.terminate();
+    await helper.stopPollingService();
 
     debug('### Validate task status');
     const r3 = await helper.queue.status(taskId);
@@ -158,14 +158,14 @@ helper.secrets.mockSuite(__filename, ['taskcluster', 'aws', 'azure'], function(m
     helper.checkNextMessage('task-completed');
 
     debug('### Start deadlineReaper');
-    const deadlineReaper = await helper.startPollingService('deadline-resolver');
+    await helper.startPollingService('deadline-resolver');
 
     debug('### Ensure that we got no task-exception message');
     await testing.sleep(1000); // give it time to poll
     assume(helper.messages.length).to.equal(0);
 
     debug('### Stop deadlineReaper');
-    deadlineReaper.terminate();
+    await helper.stopPollingService();
 
     debug('### Validate task status');
     const r4 = await helper.queue.status(taskId);

--- a/services/queue/test/dependency_test.js
+++ b/services/queue/test/dependency_test.js
@@ -42,7 +42,7 @@ helper.secrets.mockSuite(__filename, ['taskcluster', 'aws', 'azure'], function(m
     }, taskDef());
 
     // Start dependency-resolver
-    const dependencyResolver = await helper.startPollingService('dependency-resolver');
+    await helper.startPollingService('dependency-resolver');
 
     debug('### Create taskA and taskB');
     let r1 = await helper.queue.createTask(taskIdA, taskA);
@@ -98,7 +98,7 @@ helper.secrets.mockSuite(__filename, ['taskcluster', 'aws', 'azure'], function(m
       assume(d2.tasks).has.length(0);
     }
 
-    await dependencyResolver.terminate();
+    await helper.stopPollingService();
   }, mock));
 
   test('taskA <- taskB, taskC, taskD, taskE', helper.runWithFakeTime(async () => {
@@ -117,7 +117,7 @@ helper.secrets.mockSuite(__filename, ['taskcluster', 'aws', 'azure'], function(m
     let taskE = _.cloneDeep(taskB);
 
     // Start dependency-resolver
-    const dependencyResolver = await helper.startPollingService('dependency-resolver');
+    await helper.startPollingService('dependency-resolver');
 
     debug('### Create taskA');
     await helper.queue.createTask(taskIdA, taskA);
@@ -184,7 +184,7 @@ helper.secrets.mockSuite(__filename, ['taskcluster', 'aws', 'azure'], function(m
     assume(tids).contains(taskIdD);
     assume(tids).contains(taskIdE);
 
-    await dependencyResolver.terminate();
+    await helper.stopPollingService();
   }, mock));
 
   test('taskA, taskB <- taskC && taskA <- taskD', helper.runWithFakeTime(async () => {
@@ -203,7 +203,7 @@ helper.secrets.mockSuite(__filename, ['taskcluster', 'aws', 'azure'], function(m
     }, taskDef());
 
     // Start dependency-resolver
-    const dependencyResolver = await helper.startPollingService('dependency-resolver');
+    await helper.startPollingService('dependency-resolver');
 
     debug('### Create taskA, taskB, taskC');
     let r1 = await helper.queue.createTask(taskIdA, taskA);
@@ -253,7 +253,7 @@ helper.secrets.mockSuite(__filename, ['taskcluster', 'aws', 'azure'], function(m
       async () => helper.checkNextMessage('task-pending', m => assert.equal(m.payload.status.taskId, taskIdC)),
       Infinity);
 
-    await dependencyResolver.terminate();
+    await helper.stopPollingService();
   }, mock));
 
   test('taskA <- taskA (self-dependency)', helper.runWithFakeTime(async () => {
@@ -350,7 +350,7 @@ helper.secrets.mockSuite(__filename, ['taskcluster', 'aws', 'azure'], function(m
     }, taskDef());
 
     // Start dependency-resolver
-    const dependencyResolver = await helper.startPollingService('dependency-resolver');
+    await helper.startPollingService('dependency-resolver');
 
     debug('### Create taskA and taskB');
     let r1 = await helper.queue.createTask(taskIdA, taskA);
@@ -371,7 +371,7 @@ helper.secrets.mockSuite(__filename, ['taskcluster', 'aws', 'azure'], function(m
     let r3 = await helper.queue.status(taskIdB);
     assume(r3.status.state).equals('unscheduled');
 
-    await dependencyResolver.terminate();
+    await helper.stopPollingService();
   }, mock));
 
   test('taskA <- taskB (cancelTask)', helper.runWithFakeTime(async () => {
@@ -401,7 +401,7 @@ helper.secrets.mockSuite(__filename, ['taskcluster', 'aws', 'azure'], function(m
     let r3 = await helper.queue.status(taskIdB);
     assume(r3.status.state).equals('unscheduled');
 
-    await dependencyResolver.terminate();
+    await helper.stopPollingService();
   }, mock));
 
   test('taskA <- taskB (reportFailed w. all-resolved)', helper.runWithFakeTime(async () => {
@@ -415,7 +415,7 @@ helper.secrets.mockSuite(__filename, ['taskcluster', 'aws', 'azure'], function(m
     }, taskDef());
 
     // Start dependency-resolver
-    const dependencyResolver = await helper.startPollingService('dependency-resolver');
+    await helper.startPollingService('dependency-resolver');
 
     debug('### Create taskA and taskB');
     let r1 = await helper.queue.createTask(taskIdA, taskA);
@@ -441,7 +441,7 @@ helper.secrets.mockSuite(__filename, ['taskcluster', 'aws', 'azure'], function(m
       async () => helper.checkNextMessage('task-pending', m => assert.equal(m.payload.status.taskId, taskIdB)),
       Infinity);
 
-    await dependencyResolver.terminate();
+    await helper.stopPollingService();
   }, mock));
 
   test('expiration of relationships', helper.runWithFakeTime(async () => {

--- a/services/queue/test/dependency_test.js
+++ b/services/queue/test/dependency_test.js
@@ -32,7 +32,7 @@ helper.secrets.mockSuite(__filename, ['taskcluster', 'aws', 'azure'], function(m
     },
   });
 
-  test('taskA <- taskB', async () => {
+  test('taskA <- taskB', helper.runWithFakeTime(async () => {
     let taskIdA = slugid.v4();
     let taskIdB = slugid.v4();
 
@@ -97,9 +97,11 @@ helper.secrets.mockSuite(__filename, ['taskcluster', 'aws', 'azure'], function(m
       assume(d2.taskId).equals(taskIdB);
       assume(d2.tasks).has.length(0);
     }
-  });
 
-  test('taskA <- taskB, taskC, taskD, taskE', async () => {
+    await dependencyResolver.terminate();
+  }, mock));
+
+  test('taskA <- taskB, taskC, taskD, taskE', helper.runWithFakeTime(async () => {
     let taskIdA = slugid.v4();
     let taskIdB = slugid.v4();
     let taskIdC = slugid.v4();
@@ -181,9 +183,11 @@ helper.secrets.mockSuite(__filename, ['taskcluster', 'aws', 'azure'], function(m
     assume(tids).contains(taskIdC);
     assume(tids).contains(taskIdD);
     assume(tids).contains(taskIdE);
-  });
 
-  test('taskA, taskB <- taskC && taskA <- taskD', async () => {
+    await dependencyResolver.terminate();
+  }, mock));
+
+  test('taskA, taskB <- taskC && taskA <- taskD', helper.runWithFakeTime(async () => {
     let taskIdA = slugid.v4();
     let taskIdB = slugid.v4();
     let taskIdC = slugid.v4();
@@ -248,9 +252,11 @@ helper.secrets.mockSuite(__filename, ['taskcluster', 'aws', 'azure'], function(m
     await testing.poll(
       async () => helper.checkNextMessage('task-pending', m => assert.equal(m.payload.status.taskId, taskIdC)),
       Infinity);
-  });
 
-  test('taskA <- taskA (self-dependency)', async () => {
+    await dependencyResolver.terminate();
+  }, mock));
+
+  test('taskA <- taskA (self-dependency)', helper.runWithFakeTime(async () => {
     let taskIdA = slugid.v4();
     let taskA = _.defaults({
       dependencies: [taskIdA],
@@ -271,9 +277,9 @@ helper.secrets.mockSuite(__filename, ['taskcluster', 'aws', 'azure'], function(m
       workerGroup: 'my-worker-group-extended-extended',
       workerId: 'my-worker-extended-extended',
     });
-  });
+  }, mock));
 
-  test('taskA, taskB <- taskB (self-dependency)', async () => {
+  test('taskA, taskB <- taskB (self-dependency)', helper.runWithFakeTime(async () => {
     let taskIdA = slugid.v4();
     let taskIdB = slugid.v4();
 
@@ -305,7 +311,7 @@ helper.secrets.mockSuite(__filename, ['taskcluster', 'aws', 'azure'], function(m
     let r3 = await helper.queue.status(taskIdB);
     assume(r3.status.state).equals('unscheduled');
     helper.checkNoNextMessage('task-pending'); // because of the self-dep
-  });
+  }, mock));
 
   test('taskX <- taskA (missing dependency)', async () => {
     let taskIdA = slugid.v4();
@@ -334,7 +340,7 @@ helper.secrets.mockSuite(__filename, ['taskcluster', 'aws', 'azure'], function(m
     );
   });
 
-  test('taskA <- taskB (reportFailed)', async () => {
+  test('taskA <- taskB (reportFailed)', helper.runWithFakeTime(async () => {
     let taskIdA = slugid.v4();
     let taskIdB = slugid.v4();
 
@@ -364,9 +370,11 @@ helper.secrets.mockSuite(__filename, ['taskcluster', 'aws', 'azure'], function(m
     await new Promise(accept => setTimeout(accept, 2000));
     let r3 = await helper.queue.status(taskIdB);
     assume(r3.status.state).equals('unscheduled');
-  });
 
-  test('taskA <- taskB (cancelTask)', async () => {
+    await dependencyResolver.terminate();
+  }, mock));
+
+  test('taskA <- taskB (cancelTask)', helper.runWithFakeTime(async () => {
     let taskIdA = slugid.v4();
     let taskIdB = slugid.v4();
 
@@ -392,9 +400,11 @@ helper.secrets.mockSuite(__filename, ['taskcluster', 'aws', 'azure'], function(m
     await new Promise(accept => setTimeout(accept, 1000));
     let r3 = await helper.queue.status(taskIdB);
     assume(r3.status.state).equals('unscheduled');
-  });
 
-  test('taskA <- taskB (reportFailed w. all-resolved)', async () => {
+    await dependencyResolver.terminate();
+  }, mock));
+
+  test('taskA <- taskB (reportFailed w. all-resolved)', helper.runWithFakeTime(async () => {
     let taskIdA = slugid.v4();
     let taskIdB = slugid.v4();
 
@@ -430,9 +440,11 @@ helper.secrets.mockSuite(__filename, ['taskcluster', 'aws', 'azure'], function(m
     await testing.poll(
       async () => helper.checkNextMessage('task-pending', m => assert.equal(m.payload.status.taskId, taskIdB)),
       Infinity);
-  });
 
-  test('expiration of relationships', async () => {
+    await dependencyResolver.terminate();
+  }, mock));
+
+  test('expiration of relationships', helper.runWithFakeTime(async () => {
     const taskIdA = slugid.v4();
     const taskA = _.defaults({
       dependencies: [taskIdA],
@@ -484,6 +496,6 @@ helper.secrets.mockSuite(__filename, ['taskcluster', 'aws', 'azure'], function(m
     const r10 = await TaskRequirement.load({taskId: taskIdB, requiredTaskId: taskIdB}, true);
     assert(r9, 'Expected TaskDependency');
     assert(r10, 'Expected TaskRequirement');
-  });
+  }, mock));
 
 });

--- a/services/queue/test/helper.js
+++ b/services/queue/test/helper.js
@@ -461,16 +461,21 @@ exports.withPollingServices = (mock, skipping) => {
       helper.load.remove(service);
       return svc;
     };
+    helper.stopPollingService = async () => {
+      if (svc) {
+        await svc.terminate();
+        svc = null;
+      }
+    };
   });
 
   teardown(async function() {
     if (svc) {
-      await svc.terminate();
-      svc = null;
+      throw new Error('Must call stopPollingService if you have started a service');
     }
   });
 
-  suiteTeardown(async function() {
+  suiteTeardown(function() {
     helper.startPollingService = null;
   });
 };

--- a/services/queue/test/helper.js
+++ b/services/queue/test/helper.js
@@ -461,6 +461,9 @@ exports.withPollingServices = (mock, skipping) => {
       helper.load.remove(service);
       return svc;
     };
+    // This needs to be done manually within the context of the test
+    // because if it happens in a teardown, it happens _after_ zurvan
+    // has slowed down time again and that breaks this somehow
     helper.stopPollingService = async () => {
       if (svc) {
         await svc.terminate();

--- a/services/queue/test/queueservice_test.js
+++ b/services/queue/test/queueservice_test.js
@@ -9,13 +9,13 @@ const debug = require('debug')('test:queueservice');
 const xml2js = require('xml2js');
 const assume = require('assume');
 const config = require('taskcluster-lib-config');
-const MonitorManager = require('taskcluster-lib-monitor');
+const Monitor = require('taskcluster-lib-monitor');
 const testing = require('taskcluster-lib-testing');
 const helper = require('./helper');
 
 helper.secrets.mockSuite(__filename, ['azure'], function(mock, skipping) {
   let queueService;
-  let monitorManager;
+  let monitor;
 
   suiteSetup(async () => {
     if (skipping()) {
@@ -24,12 +24,9 @@ helper.secrets.mockSuite(__filename, ['azure'], function(mock, skipping) {
 
     const cfg = await helper.load('cfg');
 
-    monitorManager = new MonitorManager({
-      serviceName: 'test',
-    });
-    monitorManager.setup({
-      enable: false,
-      level: 'warning',
+    monitor = new Monitor({
+      projectName: 'test',
+      mock: true,
       patchGlobal: false,
     });
 
@@ -42,7 +39,7 @@ helper.secrets.mockSuite(__filename, ['azure'], function(mock, skipping) {
         deadlineQueue: cfg.app.deadlineQueue,
         pendingPollTimeout: 30 * 1000,
         deadlineDelay: 10,
-        monitor: monitorManager.monitor(),
+        monitor,
       });
     } else {
       queueService = new QueueService({
@@ -54,7 +51,7 @@ helper.secrets.mockSuite(__filename, ['azure'], function(mock, skipping) {
         deadlineQueue: cfg.app.deadlineQueue,
         pendingPollTimeout: 30 * 1000,
         deadlineDelay: 1000,
-        monitor: monitorManager.monitor(),
+        monitor,
       });
     }
   });
@@ -64,7 +61,7 @@ helper.secrets.mockSuite(__filename, ['azure'], function(mock, skipping) {
       return;
     }
 
-    monitorManager.reset();
+    monitor.reset();
 
     if (queueService) {
       queueService.terminate();

--- a/services/queue/test/retry_test.js
+++ b/services/queue/test/retry_test.js
@@ -33,7 +33,7 @@ helper.secrets.mockSuite(__filename, ['taskcluster', 'aws', 'azure'], function(m
     },
   };
 
-  test('createTask, claimTask, claim-expired, retry, ...', async () => {
+  test('createTask, claimTask, claim-expired, retry, ...', helper.runWithFakeTime(async () => {
     const taskId = slugid.v4();
 
     debug('### Creating task');
@@ -93,9 +93,12 @@ helper.secrets.mockSuite(__filename, ['taskcluster', 'aws', 'azure'], function(m
     }, Infinity);
     helper.checkNoNextMessage('task-exception');
 
+    debug('### Stop claimResolver (again)');
+    await claimResolver.terminate();
+
     debug('### Task status (again)');
     const r5 = await helper.queue.status(taskId);
     // this time it's exception, since it's out of retries
     assume(r5.status.state).equals('exception');
-  });
+  }, mock));
 });

--- a/services/queue/test/retry_test.js
+++ b/services/queue/test/retry_test.js
@@ -50,7 +50,7 @@ helper.secrets.mockSuite(__filename, ['taskcluster', 'aws', 'azure'], function(m
     helper.checkNextMessage('task-running');
 
     debug('### Start claim-resolver');
-    let claimResolver = await helper.startPollingService('claim-resolver');
+    await helper.startPollingService('claim-resolver');
 
     debug('### Wait for task-pending message after reaping');
     await testing.poll(async () => {
@@ -64,7 +64,7 @@ helper.secrets.mockSuite(__filename, ['taskcluster', 'aws', 'azure'], function(m
     helper.checkNoNextMessage('task-exception');
 
     debug('### Stop claimResolver');
-    await claimResolver.terminate();
+    await helper.stopPollingService();
 
     debug('### Task status');
     const r3 = await helper.queue.status(taskId);
@@ -79,7 +79,7 @@ helper.secrets.mockSuite(__filename, ['taskcluster', 'aws', 'azure'], function(m
     debug(`claimed until ${r4.takenUntil}, ${new Date(r2.takenUntil) - new Date()}ms from now`);
 
     debug('### Start claimResolver (again)');
-    claimResolver = await helper.startPollingService('claim-resolver');
+    await helper.startPollingService('claim-resolver');
 
     debug('### Wait for task-exception message (again)');
     await testing.poll(async () => {
@@ -94,7 +94,7 @@ helper.secrets.mockSuite(__filename, ['taskcluster', 'aws', 'azure'], function(m
     helper.checkNoNextMessage('task-exception');
 
     debug('### Stop claimResolver (again)');
-    await claimResolver.terminate();
+    await helper.stopPollingService();
 
     debug('### Task status (again)');
     const r5 = await helper.queue.status(taskId);

--- a/services/queue/test/taskgroup_test.js
+++ b/services/queue/test/taskgroup_test.js
@@ -91,6 +91,8 @@ helper.secrets.mockSuite(__filename, ['taskcluster', 'aws', 'azure'], function(m
     }, Infinity);
     // note that depending on timing we are likely to get two such
     // messages; that's OK
+
+    await dependencyResolver.terminate();
   });
 
   test('schedulerId is fixed per taskGroupId', async () => {

--- a/services/queue/test/taskgroup_test.js
+++ b/services/queue/test/taskgroup_test.js
@@ -74,7 +74,7 @@ helper.secrets.mockSuite(__filename, ['taskcluster', 'aws', 'azure'], function(m
     helper.checkNextMessage('task-completed', message => message.payload.status.taskId === taskIdB);
 
     // dependencies are resolved by an out-of-band process, so wait for it to complete
-    const dependencyResolver = await helper.startPollingService('dependency-resolver');
+    await helper.startPollingService('dependency-resolver');
 
     await testing.poll(async () => {
       // When using real queues, we may get results from dependency resolution
@@ -92,7 +92,7 @@ helper.secrets.mockSuite(__filename, ['taskcluster', 'aws', 'azure'], function(m
     // note that depending on timing we are likely to get two such
     // messages; that's OK
 
-    await dependencyResolver.terminate();
+    await helper.stopPollingService();
   });
 
   test('schedulerId is fixed per taskGroupId', async () => {


### PR DESCRIPTION
This makes some weirdness from changing time mocks before teardown a non-issue I think.

The tests are now fast again but also actually run.