### PR TITLE
[Bug 1533972] Be more permissive with uncaught errors

### DIFF
--- a/libraries/monitor/src/monitor.js
+++ b/libraries/monitor/src/monitor.js
@@ -267,7 +267,7 @@ class Monitor {
    *
    */
   reportError(err, level, extra = {}) {
-    if (!(err instanceof Error)) {
+    if (err.hasOwnProperty && !(err.hasOwnProperty('stack') || err.hasOwnProperty('message'))) {
       err = new Error(err);
     }
     if (level) {

--- a/services/notify/src/main.js
+++ b/services/notify/src/main.js
@@ -170,10 +170,10 @@ const load = loader({
   irc: {
     requires: ['cfg', 'monitor'],
     setup: async ({cfg, monitor}) => {
-      monitor = monitor.monitor('irc');
       let client = new IRC(_.merge(cfg.irc, {
         aws: cfg.aws,
         queueName: cfg.app.sqsQueueName,
+        monitor: monitor.monitor('irc'),
       }));
       await client.start();
       return client;


### PR DESCRIPTION
I believe a too-strict check is hiding an actual error [in this](https://console.cloud.google.com/errors/CL6y69eE1bPn_AE?time=PT1H&project=heroku-logging&organizationId=442341870013).

Bugzilla Bug: [1533972](https://bugzilla.mozilla.org/show_bug.cgi?id=1533972)
