### PR TITLE
Bug 1534022 - add more tests regarding duplicate roles

### DIFF
--- a/clients/client-web/src/clients/Auth.js
+++ b/clients/client-web/src/clients/Auth.js
@@ -198,7 +198,7 @@ export default class Auth extends Client {
   /* eslint-disable max-len */
   // Update an existing role.
   // The caller's scopes must satisfy all of the new scopes being added, but
-  // need not satisfy all of the client's existing scopes.
+  // need not satisfy all of the role's existing scopes.
   // An update of a role that will generate an infinite expansion will result
   // in an error response.
   /* eslint-enable max-len */

--- a/clients/client/src/apis.js
+++ b/clients/client/src/apis.js
@@ -257,7 +257,7 @@ module.exports = {
           "args": [
             "roleId"
           ],
-          "description": "Update an existing role.\n\nThe caller's scopes must satisfy all of the new scopes being added, but\nneed not satisfy all of the client's existing scopes.\n\nAn update of a role that will generate an infinite expansion will result\nin an error response.",
+          "description": "Update an existing role.\n\nThe caller's scopes must satisfy all of the new scopes being added, but\nneed not satisfy all of the role's existing scopes.\n\nAn update of a role that will generate an infinite expansion will result\nin an error response.",
           "input": "v1/create-role-request.json#",
           "method": "post",
           "name": "updateRole",

--- a/generated/references.json
+++ b/generated/references.json
@@ -11807,7 +11807,7 @@
           "args": [
             "roleId"
           ],
-          "description": "Update an existing role.\n\nThe caller's scopes must satisfy all of the new scopes being added, but\nneed not satisfy all of the client's existing scopes.\n\nAn update of a role that will generate an infinite expansion will result\nin an error response.",
+          "description": "Update an existing role.\n\nThe caller's scopes must satisfy all of the new scopes being added, but\nneed not satisfy all of the role's existing scopes.\n\nAn update of a role that will generate an infinite expansion will result\nin an error response.",
           "input": "v1/create-role-request.json#",
           "method": "post",
           "name": "updateRole",

--- a/services/auth/schemas/v1/list-roles-response.yml
+++ b/services/auth/schemas/v1/list-roles-response.yml
@@ -3,6 +3,6 @@ title:                      "Get All Roles (no pagination)"
 description: |
   List of roles
 type:                       array
-uniqueItems: false
+uniqueItems: true
 items:
   $ref: 'get-role-response.json#'

--- a/services/auth/src/v1.js
+++ b/services/auth/src/v1.js
@@ -825,7 +825,7 @@ builder.declare({
     'Update an existing role.',
     '',
     'The caller\'s scopes must satisfy all of the new scopes being added, but',
-    'need not satisfy all of the client\'s existing scopes.',
+    'need not satisfy all of the role\'s existing scopes.',
     '',
     'An update of a role that will generate an infinite expansion will result',
     'in an error response.',

--- a/ui/docs/generated/auth/references/api.json
+++ b/ui/docs/generated/auth/references/api.json
@@ -249,7 +249,7 @@
       "title": "Update Role",
       "input": "v1/create-role-request.json#",
       "output": "v1/get-role-response.json#",
-      "description": "Update an existing role.\n\nThe caller's scopes must satisfy all of the new scopes being added, but\nneed not satisfy all of the client's existing scopes.\n\nAn update of a role that will generate an infinite expansion will result\nin an error response.",
+      "description": "Update an existing role.\n\nThe caller's scopes must satisfy all of the new scopes being added, but\nneed not satisfy all of the role's existing scopes.\n\nAn update of a role that will generate an infinite expansion will result\nin an error response.",
       "scopes": {
         "AllOf": [
           "auth:update-role:<roleId>",

--- a/ui/docs/generated/references.json
+++ b/ui/docs/generated/references.json
@@ -11807,7 +11807,7 @@
           "args": [
             "roleId"
           ],
-          "description": "Update an existing role.\n\nThe caller's scopes must satisfy all of the new scopes being added, but\nneed not satisfy all of the client's existing scopes.\n\nAn update of a role that will generate an infinite expansion will result\nin an error response.",
+          "description": "Update an existing role.\n\nThe caller's scopes must satisfy all of the new scopes being added, but\nneed not satisfy all of the role's existing scopes.\n\nAn update of a role that will generate an infinite expansion will result\nin an error response.",
           "input": "v1/create-role-request.json#",
           "method": "post",
           "name": "updateRole",


### PR DESCRIPTION
Bugzilla Bug: [1534022](https://bugzilla.mozilla.org/show_bug.cgi?id=1534022)

This doesn't actually fix anything, but does restore the schema restriction on unique items, which should help at least to detect this sooner next time.  Then maybe we can see in the logs what modified the roles.