### PR TITLE
Bug 1523801 : Blacklist listening to some specific exchanges

### DIFF
--- a/services/hooks/src/v1.js
+++ b/services/hooks/src/v1.js
@@ -263,7 +263,7 @@ builder.declare({
   });
   if (denied) {
     return res.reportError('InputError', '{{message}}', {
-      message: 'One or more of the exchanges below have been denied access to hooks\n' + hookDef.bindings,
+      message: 'One or more of the exchanges below have been denied access to hooks\n' + JSON.stringify(hookDef.bindings),
     });
   }
 
@@ -370,7 +370,7 @@ builder.declare({
   });
   if (denied) {
     return res.reportError('InputError', '{{message}}', {
-      message: 'One or more of the exchanges below have been denied access to hooks\n' + hookDef.bindings,
+      message: 'One or more of the exchanges below have been denied access to hooks\n' + JSON.stringify(hookDef.bindings),
     });
   }
 


### PR DESCRIPTION
Display the bindings of the hook definition in the error message in case of denied exchanges being used.

Bugzilla Bug: [1523801](https://bugzilla.mozilla.org/show_bug.cgi?id=1523801)
