### PR TITLE
[UI] Remove reliance on url pathname in ScrollToTop

### DIFF
--- a/ui/src/utils/ScrollToTop.jsx
+++ b/ui/src/utils/ScrollToTop.jsx
@@ -1,16 +1,21 @@
 import { Component } from 'react';
-import { node } from 'prop-types';
-import { withRouter } from 'react-router-dom';
+import { string, node } from 'prop-types';
 
-@withRouter
-/** Scroll the window to the top when the pathname changes. */
+/** Scroll the window to the top when `scrollKey` changes. */
 export default class ScrollToTop extends Component {
   static propTypes = {
     children: node,
+    /* Restore scroll position when `scrollKey` changes. */
+    scrollKey: string,
+  };
+
+  static defaultProps = {
+    scrollKey: null,
+    children: null,
   };
 
   componentDidUpdate(prevProps) {
-    if (this.props.location.pathname !== prevProps.location.pathname) {
+    if (this.props.scrollKey !== prevProps.scrollKey) {
       window.scrollTo(0, 0);
     }
   }

--- a/ui/src/views/Documentation/index.jsx
+++ b/ui/src/views/Documentation/index.jsx
@@ -137,7 +137,7 @@ export default class Documentation extends Component {
             ? pageInfo.data.title
             : 'Documentation'
         }>
-        <ScrollToTop>
+        <ScrollToTop scrollKey={Page ? Page.toString() : null}>
           {error ? (
             <NotFound isDocs />
           ) : (


### PR DESCRIPTION
Given that pages are loaded asynchronously, it doesn't make sense for the
window to scroll to the the top once the pathname changes (current behavior for docs) since it doesn't necessarily mean the next/previous page is fully loaded. Let's rely on a `scrollKey` prop instead and only scroll to the top when it changes.

Fixes https://github.com/taskcluster/taskcluster/issues/392.