### PR TITLE
Bug 1534711 - pass rootUrl when initializing tc-client

### DIFF
--- a/services/login/src/scanner.js
+++ b/services/login/src/scanner.js
@@ -16,7 +16,10 @@ async function scanner(cfg, handlers) {
 
   // NOTE: this function performs once auth operation at a time.  It is better
   // for scans to take longer than for the auth service to be overloaded.
-  let auth = new taskcluster.Auth({credentials: cfg.app.credentials});
+  let auth = new taskcluster.Auth({
+    credentials: cfg.app.credentials,
+    rootUrl: cfg.taskcluster.rootUrl,
+  });
 
   const scan = async h => {
     const handler = handlers[h];


### PR DESCRIPTION
There don't appear to be any tests to run the scanner.  Login never got a lot of tests -- it used to be mostly UI.  And it will soon be merged into web-server, so I'm not sure it's worth adding any.  Even if we did have tests, they would have faked out the auth service, so this *particular* bug would have snuck through.

Bugzilla Bug: [1534711](https://bugzilla.mozilla.org/show_bug.cgi?id=1534711)
