### PR TITLE
[UI] Only underline <a /> elements

### DIFF
--- a/ui/src/components/Markdown/index.jsx
+++ b/ui/src/components/Markdown/index.jsx
@@ -5,7 +5,7 @@ import { withStyles } from '@material-ui/core/styles';
 
 const useStyles = withStyles(theme => ({
   markdown: {
-    '& a, & a code': {
+    '& a': {
       ...theme.mixins.link,
     },
   },

--- a/ui/src/views/Documentation/components/Anchor/index.jsx
+++ b/ui/src/views/Documentation/components/Anchor/index.jsx
@@ -6,9 +6,7 @@ import resolve from 'resolve-pathname';
 
 const useStyles = withStyles(theme => ({
   link: {
-    '&, & code': {
-      ...theme.mixins.link,
-    },
+    ...theme.mixins.link,
   },
 }));
 


### PR DESCRIPTION
This would remove the double borders when a <code> element happens to be a link:

![Screen Shot 2019-03-13 at 11 41 09 AM](https://user-images.githubusercontent.com/3766511/54292650-f599ae80-4584-11e9-8720-ee6e1d64d983.png)

