### PR TITLE
tc-lib-iterate updates

### DIFF
--- a/libraries/iterate/README.md
+++ b/libraries/iterate/README.md
@@ -15,13 +15,13 @@ var Iterate = require(`taskcluster-lib-iterate`);
 i = new Iterate({
   maxFailures: 5,
   maxIterationTime: 10000,
-  watchDog: 5000,
+  watchdogTime: 5000,
   waitTime: 2000,
-  handler: async (watchDog, state) => {
+  handler: async (watchdog, state) => {
     await doSomeWork();
-    watchDog.touch();  // tell Iterate that we`re doing work still
+    watchdog.touch();  // tell Iterate that we`re doing work still
     await doMoreWork();
-    watchDog.touch();
+    watchdog.touch();
   },
 });
 
@@ -53,7 +53,7 @@ All times are in milliseconds.
   iterations and then successfully exit.  Failed iterations count.
 * `maxFailures` (optional, default 7): number of failures to tolerate before considering the iteration loop a failure by emitting an `error` event.
   This provides a balance between quick recovery from transient errors and the crashing the process for persistent errors.
-* `watchDog`: this is the time within which `watchDog.touch` must be called or
+* `watchdogTime`: this is the time within which `watchdog.touch` must be called or
   the iteration is considered a failure.
 
 The main function of the `Iterate` instance is to call `handler` repeatedly.
@@ -63,7 +63,7 @@ The `watchdog` parameter is basically a ticking timebomb that must be defused fr
 It has methods `.start()`, `.stop()` and `.touch()` and emits `started`, `expired`, `stopped` and `touched`.
 What it allows an implementor is the abilty to say that while the absolute maximum iteration interval (`maxIterationTime`), incremental progress should be made.
 The idea here is that after each chunk of work in the handler, you run `.touch()`.
-If the `watchDog` duration elapses without a touch, then the iteration is considered faild.
+If the `watchdogTime` duration elapses without a touch, then the iteration is considered faild.
 This way, you can have a handler that can be marked as failing without waiting the full `maxIterationTime`.
 
 The `state` parameter is an object that is passed in to the handler function.

--- a/libraries/iterate/README.md
+++ b/libraries/iterate/README.md
@@ -53,8 +53,8 @@ All times are in milliseconds.
   iterations and then successfully exit.  Failed iterations count.
 * `maxFailures` (optional, default 7): number of failures to tolerate before considering the iteration loop a failure by emitting an `error` event.
   This provides a balance between quick recovery from transient errors and the crashing the process for persistent errors.
-* `watchdogTime`: this is the time within which `watchdog.touch` must be called or
-  the iteration is considered a failure.
+* `watchdogTime`: this is the time within which `watchdog.touch` must be called or the iteration is considered a failure.
+  If this value is omitted or zero, the watchdog is disabled.
 
 The main function of the `Iterate` instance is to call `handler` repeatedly.
 This is an async function, receiving two parameters -- `(watchdog, state)`.

--- a/libraries/iterate/README.md
+++ b/libraries/iterate/README.md
@@ -17,23 +17,16 @@ i = new Iterate({
   maxIterationTime: 10000,
   watchDog: 5000,
   waitTime: 2000,
-  handler: (watchDog, state) => {
-    console.log(`do some work`);
-
-    watchDog.touch(); // tell Iterate that we`re doing work still
-
-    console.log(`still working`);
+  handler: async (watchDog, state) => {
+    await doSomeWork();
+    watchDog.touch();  // tell Iterate that we`re doing work still
+    await doMoreWork();
     watchDog.touch();
-
-    return new Promise((res, rej) => {
-      console.log(`Almost done`);
-      watchDog.touch();
-      setTimeout(res, 2);
-    });
   },
 });
 
-// starting the iterator will invoke the handler immediately
+// starting the iterator will invoke the handler immediately, but returns before
+// the iteration is complete.
 i.start();
 
 i.on(`stopped`, () => {
@@ -46,43 +39,37 @@ i.on(`stopped`, () => {
 The constructor for the `Iterate` class takes an options object, with the following properties.
 All times are in milliseconds.
 
-* `maxIterationTime`: the absolute upper bounds for an iteration interval.
+* `handler`: the async function to call repeatedly, called as `await handler(watchdog, state)`.
+  See details below.
+* `monitor` (optional): instance of a `taskcluster-lib-monitor` instance with a name appropriate for this iterate instance.
+  This is used to report errors.
+* `maxIterationTime`: the maximum allowable duration of an iteration interval.
+  An iteration longer than this is considered failed.
   This time is exclusive of the time we wait between iterations.
-* `watchDog`: this is the time within which `watchDog.touch` must be called or
-  the iteration is considered a failure.
-* `handler`: promise returning function which contains work to execute.
-  Is passed in a `watchDog` and a `state` object reference.  The `watchDog`
-  object has `.touch()` to mark when progress is made and should be reset and a
-  `.stop()` in case you really don't care about it.  The state object is
-  initially empty but can be used to persist information between calls to the
-  handler.
-* `waitTime`: time between the conclusion of one iteration and commencement of another.
+* `minIterationTime` (optional): the minimum allowable duration of an iteration interval.
+  An iteration shorter than this is considered failed.
+* `waitTime`: the time to wait between finishing an iteration and beginning the next.
 * `maxIterations` (optional, default infinite): Complete up to this many
   iterations and then successfully exit.  Failed iterations count.
-* `maxFailures` (optional, default 7): When this number of failures occur
-  in consecutive iterations, treat as an error
-* `minIterationTime` (optional): If the iteration takes less time than this, consider it failed.
-* `monitor` (optional): instance of `taskcluster-lib-monitor` prefix with a
-  name appropriate for this iterate instance.
+* `maxFailures` (optional, default 7): number of failures to tolerate before considering the iteration loop a failure by emitting an `error` event.
+  This provides a balance between quick recovery from transient errors and the crashing the process for persistent errors.
+* `watchDog`: this is the time within which `watchDog.touch` must be called or
+  the iteration is considered a failure.
 
-The code to run is called a handler.  A handler is a function which returns a
-promise (e.g. async function).  This function is passed in the arguments
-`(watchdog, state)`.
+The main function of the `Iterate` instance is to call `handler` repeatedly.
+This is an async function, receiving two parameters -- `(watchdog, state)`.
 
-The `watchdog` parameter is basically a ticking timebomb.  It has methods
-`.start()`, `.stop()` and `.touch()` and emits `started`, `expired`, `stopped`
-and `touched`.  What it allows an implementor is the abilty to say that while
-the absolute maximum iteration interval (`maxIterationTime`), incremental
-progress should be made.  The idea here is that after each chunk of work in the
-handler, you run `.touch()`.  This way, you can have a handler that can be
-marked as failing without waiting the full `maxIterationTime`.  The delay for
-this watch dog is the `watchDog` property on the constructor options.
+The `watchdog` parameter is basically a ticking timebomb that must be defused frequently by calling its `.touch()` method.
+It has methods `.start()`, `.stop()` and `.touch()` and emits `started`, `expired`, `stopped` and `touched`.
+What it allows an implementor is the abilty to say that while the absolute maximum iteration interval (`maxIterationTime`), incremental progress should be made.
+The idea here is that after each chunk of work in the handler, you run `.touch()`.
+If the `watchDog` duration elapses without a touch, then the iteration is considered faild.
+This way, you can have a handler that can be marked as failing without waiting the full `maxIterationTime`.
 
 The `state` parameter is an object that is passed in to the handler function.
 It allows each iteration to accumulate data and use on following iterations.
-Because this object is passed in by reference, changes to properties on the
-object are saved, but reassignment of the state variable will not be saved. In
-other words, do `state.data = {count: 1}` and not `state = {count:1}`.
+Because this object is passed in by reference, changes to properties on the object are saved, but reassignment of the state variable will not be saved.
+In other words, do `state.data = {count: 1}` and not `state = {count:1}`.
 
 ## Events
 

--- a/libraries/iterate/README.md
+++ b/libraries/iterate/README.md
@@ -14,9 +14,9 @@ var Iterate = require(`taskcluster-lib-iterate`);
 
 i = new Iterate({
   maxFailures: 5,
-  maxIterationTime: 10,
-  watchDog: 5,
-  waitTime: 2,
+  maxIterationTime: 10000,
+  watchDog: 5000,
+  waitTime: 2000,
   handler: (watchDog, state) => {
     console.log(`do some work`);
 
@@ -42,27 +42,26 @@ i.on(`stopped`, () => {
 ```
 
 ## Options:
-The constructor for the `Iterate` class takes an object.  The object interprets
-the following properties:
 
-* `maxIterationTime`: the absolute upper bounds for an iteration interval, in
-  seconds.  This time is exclusive of the time we wait between iterations.
-* `watchDog`: this is the number of seconds to wait inside the iteration
-  before marking as a failure.
+The constructor for the `Iterate` class takes an options object, with the following properties.
+All times are in milliseconds.
+
+* `maxIterationTime`: the absolute upper bounds for an iteration interval.
+  This time is exclusive of the time we wait between iterations.
+* `watchDog`: this is the time within which `watchDog.touch` must be called or
+  the iteration is considered a failure.
 * `handler`: promise returning function which contains work to execute.
   Is passed in a `watchDog` and a `state` object reference.  The `watchDog`
   object has `.touch()` to mark when progress is made and should be reset and a
   `.stop()` in case you really don't care about it.  The state object is
   initially empty but can be used to persist information between calls to the
   handler.
-* `waitTime`: number of seconds between the conclusion of one iteration
-  and commencement of another.
+* `waitTime`: time between the conclusion of one iteration and commencement of another.
 * `maxIterations` (optional, default infinite): Complete up to this many
   iterations and then successfully exit.  Failed iterations count.
 * `maxFailures` (optional, default 7): When this number of failures occur
   in consecutive iterations, treat as an error
-* `minIterationTime` (optional): If not at least this number of seconds
-  have passed, treat the iteration as a failure
+* `minIterationTime` (optional): If the iteration takes less time than this, consider it failed.
 * `waitTimeAfterFail` (optional, default waitTime): If an iteration fails,
   wait a different amount of seconds before the next iteration (currently not
   implemented)

--- a/libraries/iterate/README.md
+++ b/libraries/iterate/README.md
@@ -60,7 +60,7 @@ The main function of the `Iterate` instance is to call `handler` repeatedly.
 This is an async function, receiving two parameters -- `(watchdog, state)`.
 
 The `watchdog` parameter is basically a ticking timebomb that must be defused frequently by calling its `.touch()` method.
-It has methods `.start()`, `.stop()` and `.touch()` and emits `started`, `expired`, `stopped` and `touched`.
+It has methods `.start()`, `.stop()` and `.touch()` and emits `expired` when it expires.
 What it allows an implementor is the abilty to say that while the absolute maximum iteration interval (`maxIterationTime`), incremental progress should be made.
 The idea here is that after each chunk of work in the handler, you run `.touch()`.
 If the `watchdogTime` duration elapses without a touch, then the iteration is considered faild.

--- a/libraries/iterate/README.md
+++ b/libraries/iterate/README.md
@@ -62,9 +62,6 @@ All times are in milliseconds.
 * `maxFailures` (optional, default 7): When this number of failures occur
   in consecutive iterations, treat as an error
 * `minIterationTime` (optional): If the iteration takes less time than this, consider it failed.
-* `waitTimeAfterFail` (optional, default waitTime): If an iteration fails,
-  wait a different amount of seconds before the next iteration (currently not
-  implemented)
 * `monitor` (optional): instance of `taskcluster-lib-monitor` prefix with a
   name appropriate for this iterate instance.
 
@@ -105,13 +102,3 @@ exit with a non-zero exit code when it would otherwise be emitted.
 * `error`: when the iteration is considered to be concluded and provides
   list of iteration errors.  If there are no handlers and this event is
   emitted, an exception will be thrown in a process.nextTick callback.
-
-## TODO
-There are a couple things that I`d like to do to this library
-
-* implement `waitTimeAfterFail` functionality
-* use events internally so that all error handling is done with the same code
-* emit events like `stopped-success` and `stopped-failure` to make handling shut
-  down easier.  Right now, we emit `stopped` on success and `stopped` *and*
-  `error` on failure.  We should either emit only one of `stopped` and `error`
-  or have the above mentioned events

--- a/libraries/iterate/src/iterate.js
+++ b/libraries/iterate/src/iterate.js
@@ -47,6 +47,7 @@ class Iterate extends events.EventEmitter {
 
     // Set default values
     opts = Object.assign({}, {
+      watchdogTime: 0,
       maxIterations: 0,
       maxFailures: 7,
       minIterationTime: 0,

--- a/libraries/iterate/src/iterate.js
+++ b/libraries/iterate/src/iterate.js
@@ -50,7 +50,6 @@ class Iterate extends events.EventEmitter {
       maxIterations: 0,
       maxFailures: 7,
       minIterationTime: 0,
-      waitTimeAfterFail: 0,
     }, opts);
 
     if (typeof opts.maxIterations !== 'number') {
@@ -82,11 +81,6 @@ class Iterate extends events.EventEmitter {
       throw new Error('waitTime must be number');
     }
     this.waitTime = opts.waitTime;
-
-    if (typeof opts.waitTimeAfterFail !== 'number') {
-      throw new Error('waitTimeAfterFail must be number');
-    }
-    this.waitTimeAfterFail = opts.waitTimeAfterFail || opts.waitTime;
 
     if (typeof opts.handler !== 'function') {
       throw new Error('handler must be a function');

--- a/libraries/iterate/src/iterate.js
+++ b/libraries/iterate/src/iterate.js
@@ -66,22 +66,22 @@ class Iterate extends events.EventEmitter {
     if (typeof opts.maxIterationTime !== 'number') {
       throw new Error('maxIterationTime must be number');
     }
-    this.maxIterationTime = opts.maxIterationTime * 1000;
+    this.maxIterationTime = opts.maxIterationTime;
 
     if (typeof opts.minIterationTime !== 'number') {
       throw new Error('minIterationTime must be number');
     }
-    this.minIterationTime = opts.minIterationTime * 1000;
+    this.minIterationTime = opts.minIterationTime;
 
     if (typeof opts.watchDog !== 'number') {
       throw new Error('watchDog must be number');
     }
-    this.watchDogTime = opts.watchDog * 1000;
+    this.watchDogTime = opts.watchDog;
 
     if (typeof opts.waitTime !== 'number') {
       throw new Error('waitTime must be number');
     }
-    this.waitTime = opts.waitTime * 1000;
+    this.waitTime = opts.waitTime;
 
     if (typeof opts.waitTimeAfterFail !== 'number') {
       throw new Error('waitTimeAfterFail must be number');
@@ -160,7 +160,7 @@ class Iterate extends events.EventEmitter {
       }
 
       // TODO: do this timing the better way
-      let diff = (new Date() - start) / 1000;
+      let diff = new Date() - start;
 
       // Let's check that if we have a minimum threshold for handler activity
       // time, and mark as failure when we exceed it

--- a/libraries/iterate/src/iterate.js
+++ b/libraries/iterate/src/iterate.js
@@ -139,7 +139,7 @@ class Iterate extends events.EventEmitter {
             }, this.maxIterationTime);
           }),
           watchdogRejector.promise(),
-          this.handler(watchdog, this.sharedState).then(() => {
+          Promise.resolve(this.handler(watchdog, this.sharedState)).then(() => {
             clearTimeout(maxIterationTimeTimer);
             watchdog.stop();
           }),

--- a/libraries/iterate/src/watchdog.js
+++ b/libraries/iterate/src/watchdog.js
@@ -12,7 +12,6 @@ class WatchDog extends events.EventEmitter {
   constructor(maxTime) {
     super();
     this.maxTime = maxTime;
-    events.EventEmitter.call(this);
     this.action = () => {
       let error = new Error('Watchdog expired!');
       // A better way to make this mandatory?

--- a/libraries/iterate/src/watchdog.js
+++ b/libraries/iterate/src/watchdog.js
@@ -31,7 +31,9 @@ class WatchDog extends events.EventEmitter {
    * Start the timers
    */
   start() {
-    this.__watchDog = setTimeout(this.action, this.maxTime);
+    if (this.maxTime) {
+      this.__watchDog = setTimeout(this.action, this.maxTime);
+    }
     this.emit('started');
     debug('started, emitted started event');
   }
@@ -54,9 +56,11 @@ class WatchDog extends events.EventEmitter {
    * keeps running
    */
   touch() {
-    let oldWD = this.__watchDog;
-    this.__watchDog = setTimeout(this.action, this.maxTime);
-    clearTimeout(oldWD);
+    if (this.__watchDog) {
+      let oldWD = this.__watchDog;
+      this.__watchDog = setTimeout(this.action, this.maxTime);
+      clearTimeout(oldWD);
+    }
     this.emit('touched');
     debug('touched, reset timer');
   }

--- a/libraries/iterate/src/watchdog.js
+++ b/libraries/iterate/src/watchdog.js
@@ -31,7 +31,6 @@ class WatchDog extends events.EventEmitter {
    */
   start() {
     this._set();
-    this.emit('started');
   }
 
   /**
@@ -39,7 +38,6 @@ class WatchDog extends events.EventEmitter {
    */
   stop() {
     this._clear();
-    this.emit('stopped');
   }
 
   /**
@@ -49,7 +47,6 @@ class WatchDog extends events.EventEmitter {
    */
   touch() {
     this._set();
-    this.emit('touched');
   }
 }
 module.exports = WatchDog;

--- a/libraries/iterate/src/watchdog.js
+++ b/libraries/iterate/src/watchdog.js
@@ -22,7 +22,7 @@ class WatchDog extends events.EventEmitter {
       } else {
         // This is being safe rather than sorry
         debug('exiting becase there is no expired event listener');
-        process.exit(1); // eslint-disable-line no-process-exit
+        //process.exit(1); // eslint-disable-line no-process-exit
       }
     };
   }

--- a/libraries/iterate/src/watchdog.js
+++ b/libraries/iterate/src/watchdog.js
@@ -1,52 +1,45 @@
 let events = require('events');
-let debug = require('debug')('watchdog');
 
 /**
- * This is a watch dog timer.  Think of it as a ticking
- * timebomb which will throw an explosion when it hasn't
- * been stopped or touched in `maxTime` seconds.  The
- * `WatchDog` will throw an `Error` with `msg` if the
- * timer is allowed to expire
+ * This is a watch dog timer.  Think of it as a ticking timebomb which will
+ * explode when it hasn't been stopped or touched in `maxTime` seconds.  The
+ * "explosion" in this case is just an 'expired' event.
  */
 class WatchDog extends events.EventEmitter {
   constructor(maxTime) {
     super();
     this.maxTime = maxTime;
-    this.action = () => {
-      let error = new Error('Watchdog expired!');
-      // A better way to make this mandatory?
-      if (this.listeners('expired').length > 0) {
-        debug('emitting expired event');
-        this.emit('expired', error);
-      } else {
-        // This is being safe rather than sorry
-        debug('exiting becase there is no expired event listener');
-        //process.exit(1); // eslint-disable-line no-process-exit
-      }
-    };
+    this.timer = null;
+  }
+
+  _set() {
+    this._clear();
+    if (this.maxTime) {
+      this.timer = setTimeout(() => this.emit('expired'), this.maxTime);
+    }
+  }
+
+  _clear() {
+    if (this.timer) {
+      clearTimeout(this.timer);
+      this.timer = null;
+    }
   }
 
   /**
    * Start the timers
    */
   start() {
-    if (this.maxTime) {
-      this.__watchDog = setTimeout(this.action, this.maxTime);
-    }
+    this._set();
     this.emit('started');
-    debug('started, emitted started event');
   }
 
   /**
    * Stop the timer
    */
   stop() {
-    if (this.__watchDog) {
-      debug('clearing timeout');
-      clearTimeout(this.__watchDog);
-    }
+    this._clear();
     this.emit('stopped');
-    debug('stopped, emitted stopped event');
   }
 
   /**
@@ -55,13 +48,8 @@ class WatchDog extends events.EventEmitter {
    * keeps running
    */
   touch() {
-    if (this.__watchDog) {
-      let oldWD = this.__watchDog;
-      this.__watchDog = setTimeout(this.action, this.maxTime);
-      clearTimeout(oldWD);
-    }
+    this._set();
     this.emit('touched');
-    debug('touched, reset timer');
   }
 }
 module.exports = WatchDog;

--- a/libraries/iterate/test/iterate_test.js
+++ b/libraries/iterate/test/iterate_test.js
@@ -97,7 +97,6 @@ suite('Iterate', () => {
 
     setTimeout(() => {
       assume(iterations).equals(5);
-      assume(i.currentIteration).equals(5);
       assume(i.keepGoing).is.ok();
       i.stop();
       assume(i.keepGoing).is.not.ok();
@@ -152,14 +151,13 @@ suite('Iterate', () => {
         // watchdog timer.  This will be tested in the tests for the
         // Iterate.iterate method
         i.on('error', err => {
-          assume(i.currentIteration).equals(0);
           debug('correctly getting expired watchdog timer');
           i.stop();
           assume(i.keepGoing).is.not.ok();
           done();
         });
         return new Promise((res, rej) => {
-          setTimeout(res, 6000);
+          setTimeout(res, 2000);
         });
 
       },

--- a/libraries/iterate/test/iterate_test.js
+++ b/libraries/iterate/test/iterate_test.js
@@ -69,7 +69,6 @@ suite('Iterate', () => {
 
     let i = new subject({
       maxIterationTime: 3000,
-      watchdogTime: 2000,
       waitTime: 1000,
       handler: async (watchdog, state) => {
         // In order to get the looping stuff to work, I had to stop the
@@ -115,8 +114,7 @@ suite('Iterate', () => {
 
     let i = new subject({
       maxIterationTime: 3000,
-      watchdogTime: 2000,
-      waitTime: 1000,
+      waitTime: 10,
       maxIterations: 5,
       handler: async (watchdog, state) => {
         watchdog.on('expired', () => {
@@ -173,7 +171,6 @@ suite('Iterate', () => {
   test('should emit error when overall iteration limit is hit', done => {
     let i = new subject({
       maxIterationTime: 1000,
-      watchdogTime: 100000,
       waitTime: 1000,
       maxFailures: 1,
       handler: async (watchdog, state) => {
@@ -198,7 +195,6 @@ suite('Iterate', () => {
   test('should emit iteration-failure when async handler fails', done => {
     let i = new subject({
       maxIterationTime: 1000,
-      watchdogTime: 100000,
       waitTime: 1000,
       maxFailures: 100,
       handler: async (watchdog, state) => {
@@ -218,7 +214,6 @@ suite('Iterate', () => {
   test('should emit iteration-failure when sync handler fails', done => {
     let i = new subject({
       maxIterationTime: 1000,
-      watchdogTime: 100000,
       waitTime: 1000,
       maxFailures: 100,
       handler: (watchdog, state) => {
@@ -239,7 +234,6 @@ suite('Iterate', () => {
     let i = new subject({
       maxIterationTime: 12000,
       minIterationTime: 10000,
-      watchdogTime: 10000,
       waitTime: 1000,
       handler: async (watchdog, state) => {
         watchdog.stop();
@@ -261,7 +255,6 @@ suite('Iterate', () => {
     let i = new subject({
       maxIterationTime: 12000,
       maxFailures: 1,
-      watchdogTime: 10000,
       waitTime: 1000,
       handler: async (watchdog, state) => {
         return new Promise((res, rej) => {
@@ -305,7 +298,6 @@ suite('Iterate', () => {
     let i = new subject({
       maxIterationTime: 12000,
       maxFailures: 1,
-      watchdogTime: 10000,
       waitTime: 1000,
       handler: async (watchdog, state) => {
         return new Promise((res, rej) => {
@@ -324,7 +316,6 @@ suite('Iterate', () => {
 
     let i = new subject({
       maxIterationTime: 3000,
-      watchdogTime: 2000,
       waitTime: 1000,
       maxIterations: 2,
       maxFailures: 1,
@@ -373,7 +364,6 @@ suite('Iterate', () => {
 
     let i = new subject({
       maxIterationTime: 3000,
-      watchdogTime: 2000,
       waitTime: 1000,
       handler: async (watchdog, state) => {
         debug('iterate!');
@@ -411,7 +401,6 @@ suite('Iterate', () => {
     let i = new subject({
       maxIterationTime: 3000,
       maxIterations: 1,
-      watchdogTime: 2000,
       waitTime: 1000,
       handler: async (watchdog, state) => {
         debug('iterate!');
@@ -455,7 +444,6 @@ suite('Iterate', () => {
         maxIterationTime: 3000,
         maxIterations: 1,
         maxFailures: 1,
-        watchdogTime: 2000,
         waitTime: 1000,
         handler: async (watchdog, state) => {
           debug('iterate!');
@@ -488,7 +476,6 @@ suite('Iterate', () => {
       let i = new subject({
         maxIterationTime: 3000,
         maxFailures: 1,
-        watchdogTime: 2000,
         waitTime: 1000,
         handler: async (watchdog, state) => {
           debug('iterate!');
@@ -521,7 +508,6 @@ suite('Iterate', () => {
         maxIterationTime: 3000,
         minIterationTime: 100000,
         maxFailures: 1,
-        watchdogTime: 2000,
         waitTime: 1000,
         handler: async (watchdog, state) => {
           return true;
@@ -552,7 +538,7 @@ suite('Iterate', () => {
       let i = new subject({
         maxIterationTime: 5000,
         maxFailures: 1,
-        watchdogTime: 1000,
+        watchdogTime: 100,
         waitTime: 1000,
         handler: async (watchdog, state) => {
           return new Promise((res, rej) => {
@@ -585,10 +571,8 @@ suite('Iterate', () => {
       let i = new subject({
         maxIterationTime: 3000,
         maxFailures: 1,
-        watchdogTime: 2000,
         waitTime: 1000,
         handler: async (watchdog, state) => {
-          watchdog.stop();
           return new Promise((res, rej) => {
             setTimeout(res, 6000);
           });
@@ -622,7 +606,6 @@ suite('Iterate', () => {
         maxIterationTime: 3000,
         maxIterations: 6,
         maxFailures: 5,
-        watchdogTime: 2000,
         waitTime: 1000,
         handler: async (watchdog, state) => {
           if (iterations++ % 2 === 0) {

--- a/libraries/iterate/test/iterate_test.js
+++ b/libraries/iterate/test/iterate_test.js
@@ -68,9 +68,9 @@ suite('Iterate', () => {
     let iterations = 0;
 
     let i = new subject({
-      maxIterationTime: 3,
-      watchDog: 2,
-      waitTime: 1,
+      maxIterationTime: 3000,
+      watchDog: 2000,
+      waitTime: 1000,
       handler: async (watchdog, state) => {
         // In order to get the looping stuff to work, I had to stop the
         // watchdog timer.  This will be tested in the tests for the
@@ -114,9 +114,9 @@ suite('Iterate', () => {
     let iterations = 0;
 
     let i = new subject({
-      maxIterationTime: 3,
-      watchDog: 2,
-      waitTime: 1,
+      maxIterationTime: 3000,
+      watchDog: 2000,
+      waitTime: 1000,
       maxIterations: 5,
       handler: async (watchdog, state) => {
         watchdog.on('expired', () => {
@@ -145,9 +145,9 @@ suite('Iterate', () => {
 
   test('should emit error when iteration watchdog expires', done => {
     let i = new subject({
-      maxIterationTime: 5,
-      watchDog: 1,
-      waitTime: 1,
+      maxIterationTime: 5000,
+      watchDog: 1000,
+      waitTime: 1000,
       maxFailures: 1,
       handler: async (watchdog, state) => {
         // In order to get the looping stuff to work, I had to stop the
@@ -172,9 +172,9 @@ suite('Iterate', () => {
 
   test('should emit error when overall iteration limit is hit', done => {
     let i = new subject({
-      maxIterationTime: 1,
-      watchDog: 100,
-      waitTime: 1,
+      maxIterationTime: 1000,
+      watchDog: 100000,
+      waitTime: 1000,
       maxFailures: 1,
       handler: async (watchdog, state) => {
         watchdog.stop();
@@ -197,10 +197,10 @@ suite('Iterate', () => {
 
   test('should emit error when iteration is too quick', done => {
     let i = new subject({
-      maxIterationTime: 12,
-      minIterationTime: 10,
-      watchDog: 10,
-      waitTime: 1,
+      maxIterationTime: 12000,
+      minIterationTime: 10000,
+      watchDog: 10000,
+      waitTime: 1000,
       handler: async (watchdog, state) => {
         watchdog.stop();
         return 1;
@@ -219,10 +219,10 @@ suite('Iterate', () => {
 
   test('should emit error after too many failures', done => {
     let i = new subject({
-      maxIterationTime: 12,
+      maxIterationTime: 12000,
       maxFailures: 1,
-      watchDog: 10,
-      waitTime: 1,
+      watchDog: 10000,
+      waitTime: 1000,
       handler: async (watchdog, state) => {
         return new Promise((res, rej) => {
           rej(new Error('hi'));
@@ -263,10 +263,10 @@ suite('Iterate', () => {
     process.on('uncaughtException', uncaughtHandler);
 
     let i = new subject({
-      maxIterationTime: 12,
+      maxIterationTime: 12000,
       maxFailures: 1,
-      watchDog: 10,
-      waitTime: 1,
+      watchDog: 10000,
+      waitTime: 1000,
       handler: async (watchdog, state) => {
         return new Promise((res, rej) => {
           rej(new Error('hi'));
@@ -283,9 +283,9 @@ suite('Iterate', () => {
     let v = {a: 1};
 
     let i = new subject({
-      maxIterationTime: 3,
-      watchDog: 2,
-      waitTime: 1,
+      maxIterationTime: 3000,
+      watchDog: 2000,
+      waitTime: 1000,
       maxIterations: 2,
       maxFailures: 1,
       handler: async (watchdog, state) => {
@@ -332,9 +332,9 @@ suite('Iterate', () => {
     let iterations = 0; //eslint-disable-line no-unused-vars
 
     let i = new subject({
-      maxIterationTime: 3,
-      watchDog: 2,
-      waitTime: 1,
+      maxIterationTime: 3000,
+      watchDog: 2000,
+      waitTime: 1000,
       handler: async (watchdog, state) => {
         debug('iterate!');
         iterations++;
@@ -369,10 +369,10 @@ suite('Iterate', () => {
     let iterations = 0; //eslint-disable-line no-unused-vars
 
     let i = new subject({
-      maxIterationTime: 3,
+      maxIterationTime: 3000,
       maxIterations: 1,
-      watchDog: 2,
-      waitTime: 1,
+      watchDog: 2000,
+      waitTime: 1000,
       handler: async (watchdog, state) => {
         debug('iterate!');
         iterations++;
@@ -412,11 +412,11 @@ suite('Iterate', () => {
 
     test('should be correct with maxFailures and maxIterations', done => {
       let i = new subject({
-        maxIterationTime: 3,
+        maxIterationTime: 3000,
         maxIterations: 1,
         maxFailures: 1,
-        watchDog: 2,
-        waitTime: 1,
+        watchDog: 2000,
+        waitTime: 1000,
         handler: async (watchdog, state) => {
           debug('iterate!');
           throw new Error('hi');
@@ -446,10 +446,10 @@ suite('Iterate', () => {
 
     test('should be correct with maxFailures only', done => {
       let i = new subject({
-        maxIterationTime: 3,
+        maxIterationTime: 3000,
         maxFailures: 1,
-        watchDog: 2,
-        waitTime: 1,
+        watchDog: 2000,
+        waitTime: 1000,
         handler: async (watchdog, state) => {
           debug('iterate!');
           throw new Error('hi');
@@ -478,11 +478,11 @@ suite('Iterate', () => {
 
     test('should be correct when handler takes too little time', done => {
       let i = new subject({
-        maxIterationTime: 3,
-        minIterationTime: 100,
+        maxIterationTime: 3000,
+        minIterationTime: 100000,
         maxFailures: 1,
-        watchDog: 2,
-        waitTime: 1,
+        watchDog: 2000,
+        waitTime: 1000,
         handler: async (watchdog, state) => {
           return true;
         },
@@ -510,10 +510,10 @@ suite('Iterate', () => {
 
     test('should be correct when handler takes too long (incremental watchdog)', done => {
       let i = new subject({
-        maxIterationTime: 5,
+        maxIterationTime: 5000,
         maxFailures: 1,
-        watchDog: 1,
-        waitTime: 1,
+        watchDog: 1000,
+        waitTime: 1000,
         handler: async (watchdog, state) => {
           return new Promise((res, rej) => {
             setTimeout(res, 3000);
@@ -543,10 +543,10 @@ suite('Iterate', () => {
 
     test('should be correct when handler takes too long (overall time)', done => {
       let i = new subject({
-        maxIterationTime: 3,
+        maxIterationTime: 3000,
         maxFailures: 1,
-        watchDog: 2,
-        waitTime: 1,
+        watchDog: 2000,
+        waitTime: 1000,
         handler: async (watchdog, state) => {
           watchdog.stop();
           return new Promise((res, rej) => {
@@ -579,11 +579,11 @@ suite('Iterate', () => {
       let iterations = 0;
 
       let i = new subject({
-        maxIterationTime: 3,
+        maxIterationTime: 3000,
         maxIterations: 6,
         maxFailures: 5,
-        watchDog: 2,
-        waitTime: 1,
+        watchDog: 2000,
+        waitTime: 1000,
         handler: async (watchdog, state) => {
           if (iterations++ % 2 === 0) {
             throw new Error('even, so failing');

--- a/libraries/iterate/test/iterate_test.js
+++ b/libraries/iterate/test/iterate_test.js
@@ -69,7 +69,7 @@ suite('Iterate', () => {
 
     let i = new subject({
       maxIterationTime: 3000,
-      watchDog: 2000,
+      watchdogTime: 2000,
       waitTime: 1000,
       handler: async (watchdog, state) => {
         // In order to get the looping stuff to work, I had to stop the
@@ -115,7 +115,7 @@ suite('Iterate', () => {
 
     let i = new subject({
       maxIterationTime: 3000,
-      watchDog: 2000,
+      watchdogTime: 2000,
       waitTime: 1000,
       maxIterations: 5,
       handler: async (watchdog, state) => {
@@ -146,7 +146,7 @@ suite('Iterate', () => {
   test('should emit error when iteration watchdog expires', done => {
     let i = new subject({
       maxIterationTime: 5000,
-      watchDog: 1000,
+      watchdogTime: 1000,
       waitTime: 1000,
       maxFailures: 1,
       handler: async (watchdog, state) => {
@@ -173,7 +173,7 @@ suite('Iterate', () => {
   test('should emit error when overall iteration limit is hit', done => {
     let i = new subject({
       maxIterationTime: 1000,
-      watchDog: 100000,
+      watchdogTime: 100000,
       waitTime: 1000,
       maxFailures: 1,
       handler: async (watchdog, state) => {
@@ -199,7 +199,7 @@ suite('Iterate', () => {
     let i = new subject({
       maxIterationTime: 12000,
       minIterationTime: 10000,
-      watchDog: 10000,
+      watchdogTime: 10000,
       waitTime: 1000,
       handler: async (watchdog, state) => {
         watchdog.stop();
@@ -221,7 +221,7 @@ suite('Iterate', () => {
     let i = new subject({
       maxIterationTime: 12000,
       maxFailures: 1,
-      watchDog: 10000,
+      watchdogTime: 10000,
       waitTime: 1000,
       handler: async (watchdog, state) => {
         return new Promise((res, rej) => {
@@ -265,7 +265,7 @@ suite('Iterate', () => {
     let i = new subject({
       maxIterationTime: 12000,
       maxFailures: 1,
-      watchDog: 10000,
+      watchdogTime: 10000,
       waitTime: 1000,
       handler: async (watchdog, state) => {
         return new Promise((res, rej) => {
@@ -284,7 +284,7 @@ suite('Iterate', () => {
 
     let i = new subject({
       maxIterationTime: 3000,
-      watchDog: 2000,
+      watchdogTime: 2000,
       waitTime: 1000,
       maxIterations: 2,
       maxFailures: 1,
@@ -333,7 +333,7 @@ suite('Iterate', () => {
 
     let i = new subject({
       maxIterationTime: 3000,
-      watchDog: 2000,
+      watchdogTime: 2000,
       waitTime: 1000,
       handler: async (watchdog, state) => {
         debug('iterate!');
@@ -371,7 +371,7 @@ suite('Iterate', () => {
     let i = new subject({
       maxIterationTime: 3000,
       maxIterations: 1,
-      watchDog: 2000,
+      watchdogTime: 2000,
       waitTime: 1000,
       handler: async (watchdog, state) => {
         debug('iterate!');
@@ -415,7 +415,7 @@ suite('Iterate', () => {
         maxIterationTime: 3000,
         maxIterations: 1,
         maxFailures: 1,
-        watchDog: 2000,
+        watchdogTime: 2000,
         waitTime: 1000,
         handler: async (watchdog, state) => {
           debug('iterate!');
@@ -448,7 +448,7 @@ suite('Iterate', () => {
       let i = new subject({
         maxIterationTime: 3000,
         maxFailures: 1,
-        watchDog: 2000,
+        watchdogTime: 2000,
         waitTime: 1000,
         handler: async (watchdog, state) => {
           debug('iterate!');
@@ -481,7 +481,7 @@ suite('Iterate', () => {
         maxIterationTime: 3000,
         minIterationTime: 100000,
         maxFailures: 1,
-        watchDog: 2000,
+        watchdogTime: 2000,
         waitTime: 1000,
         handler: async (watchdog, state) => {
           return true;
@@ -512,7 +512,7 @@ suite('Iterate', () => {
       let i = new subject({
         maxIterationTime: 5000,
         maxFailures: 1,
-        watchDog: 1000,
+        watchdogTime: 1000,
         waitTime: 1000,
         handler: async (watchdog, state) => {
           return new Promise((res, rej) => {
@@ -545,7 +545,7 @@ suite('Iterate', () => {
       let i = new subject({
         maxIterationTime: 3000,
         maxFailures: 1,
-        watchDog: 2000,
+        watchdogTime: 2000,
         waitTime: 1000,
         handler: async (watchdog, state) => {
           watchdog.stop();
@@ -582,7 +582,7 @@ suite('Iterate', () => {
         maxIterationTime: 3000,
         maxIterations: 6,
         maxFailures: 5,
-        watchDog: 2000,
+        watchdogTime: 2000,
         waitTime: 1000,
         handler: async (watchdog, state) => {
           if (iterations++ % 2 === 0) {

--- a/libraries/iterate/test/iterate_test.js
+++ b/libraries/iterate/test/iterate_test.js
@@ -195,6 +195,46 @@ suite('Iterate', () => {
     i.start();
   });
 
+  test('should emit iteration-failure when async handler fails', done => {
+    let i = new subject({
+      maxIterationTime: 1000,
+      watchdogTime: 100000,
+      waitTime: 1000,
+      maxFailures: 100,
+      handler: async (watchdog, state) => {
+        throw new Error('uhoh');
+      },
+    });
+
+    i.on('iteration-failure', err => {
+      i.stop();
+      assume(i.keepGoing).is.not.ok();
+      done();
+    });
+
+    i.start();
+  });
+
+  test('should emit iteration-failure when sync handler fails', done => {
+    let i = new subject({
+      maxIterationTime: 1000,
+      watchdogTime: 100000,
+      waitTime: 1000,
+      maxFailures: 100,
+      handler: (watchdog, state) => {
+        throw new Error('uhoh');
+      },
+    });
+
+    i.on('iteration-failure', err => {
+      i.stop();
+      assume(i.keepGoing).is.not.ok();
+      done();
+    });
+
+    i.start();
+  });
+
   test('should emit error when iteration is too quick', done => {
     let i = new subject({
       maxIterationTime: 12000,

--- a/libraries/iterate/test/watchdog_test.js
+++ b/libraries/iterate/test/watchdog_test.js
@@ -3,72 +3,88 @@ let sinon = require('sinon');
 let assume = require('assume');
 
 suite('watchdog', function() {
+  let events, start;
+
   setup(function() {
     this.clock = sinon.useFakeTimers();
-    sinon.stub(process, 'exit');
-    process.exit.throws(new Error('process.exit'));
+    start = new Date();
   });
 
   teardown(function() {
     this.clock.restore();
-    process.exit.restore();
   });
 
-  test('should emit when starting', function(done) {
+  const listen = w => {
+    events = [];
+    w.on('started', () => events.push(['started', new Date() - start]));
+    w.on('stopped', () => events.push(['stopped', new Date() - start]));
+    w.on('touched', () => events.push(['touched', new Date() - start]));
+    w.on('expired', () => events.push(['expired', new Date() - start]));
+  };
+
+  test('should emit when starting and stopping', function() {
     let w = new subject(10 * 1000);
-    w.on('started', function() {
-      done();
-    });
+    listen(w);
     w.start();
     w.stop();
+    assume(events).to.deeply.equal([
+      ['started', 0],
+      ['stopped', 0],
+    ]);
   });
 
-  test('should emit when touched', function(done) {
+  test('should emit when touched', function() {
     let w = new subject(10 * 1000);
-    w.on('touched', function() {
-      done();
-    });
+    listen(w);
     w.start();
     w.touch();
     w.stop();
+    assume(events).to.deeply.equal([
+      ['started', 0],
+      ['touched', 0],
+      ['stopped', 0],
+    ]);
   });
 
-  test('should emit when stopped', function(done) {
-    let w = new subject(10 * 1000);
-    w.on('stopped', function() {
-      done();
-    });
-    w.start();
-    w.stop();
-  });
-
-  test('should emit expired event', function(done) {
+  test('should emit expired event', function() {
     let w = new subject(1 * 1000);
-    w.on('expired', () => {
-      done();
-    });
+    listen(w);
     w.start();
     this.clock.tick(1000);
+    assume(events).to.deeply.equal([
+      ['started', 0],
+      ['expired', 1000],
+    ]);
   });
 
-  test('should not throw early', function() {
+  test('should not expire early', function() {
     let w = new subject(1 * 1000);
+    listen(w);
     w.start();
     this.clock.tick(999);
     w.stop();
+    assume(events).to.deeply.equal([
+      ['started', 0],
+      ['stopped', 999],
+    ]);
   });
 
   test('should throw on time', function() {
     let w = new subject(1 * 1000);
+    listen(w);
     w.start();
-    assume(() => {
-      this.clock.tick(1000);
-    }).throws('process.exit');
+    this.clock.tick(1000);
     w.stop();
+    assume(events).to.deeply.equal([
+      ['started', 0],
+      ['expired', 1000],
+      ['stopped', 1000],
+    ]);
   });
 
   test('touching should reset timer', function() {
     let w = new subject(1 * 1000);
+    listen(w);
     w.start();
     // We do this three times to ensure that the
     // time period stays constant and doesn't grow
@@ -78,9 +94,14 @@ suite('watchdog', function() {
     this.clock.tick(999);
     w.touch();
     this.clock.tick(999);
-    assume(() => {
-      this.clock.tick(1);
-    }).throws('process.exit');
+    this.clock.tick(1);
     w.stop();
+    assume(events).to.deeply.equal([
+      ['started', 0],
+      ['touched', 999],
+      ['touched', 1998],
+      ['expired', 2998],
+      ['stopped', 2998],
+    ]);
   });
 });

--- a/services/queue/src/claimresolver.js
+++ b/services/queue/src/claimresolver.js
@@ -54,14 +54,12 @@ class ClaimResolver {
     this.parallelism = options.parallelism;
     this.monitor = options.monitor;
 
-    const pollingDelaySecs = this.pollingDelay / 1000;
-    const maxIterationTimeSecs = 600;
     this.iterator = new Iterate({
       maxFailures: 10,
-      waitTime: pollingDelaySecs,
-      watchDog: maxIterationTimeSecs + 1, // disable watchdog
+      waitTime: this.pollingDelay,
+      watchDog: 601 * 1000, // disable watchdog
       monitor: this.monitor,
-      maxIterationTime: maxIterationTimeSecs,
+      maxIterationTime: 600 * 1000,
       handler: async () => {
         let loops = [];
         for (let i = 0; i < this.parallelism; i++) {

--- a/services/queue/src/claimresolver.js
+++ b/services/queue/src/claimresolver.js
@@ -57,7 +57,6 @@ class ClaimResolver {
     this.iterator = new Iterate({
       maxFailures: 10,
       waitTime: this.pollingDelay,
-      watchdogTime: 601 * 1000, // disable watchdog
       monitor: this.monitor,
       maxIterationTime: 600 * 1000,
       handler: async () => {

--- a/services/queue/src/claimresolver.js
+++ b/services/queue/src/claimresolver.js
@@ -57,7 +57,7 @@ class ClaimResolver {
     this.iterator = new Iterate({
       maxFailures: 10,
       waitTime: this.pollingDelay,
-      watchDog: 601 * 1000, // disable watchdog
+      watchdogTime: 601 * 1000, // disable watchdog
       monitor: this.monitor,
       maxIterationTime: 600 * 1000,
       handler: async () => {

--- a/services/queue/src/deadlineresolver.js
+++ b/services/queue/src/deadlineresolver.js
@@ -67,7 +67,6 @@ class DeadlineResolver {
     this.iterator = new Iterate({
       maxFailures: 10,
       waitTime: this.pollingDelay,
-      watchdogTime: 601 * 1000, // disable watchdog
       monitor: this.monitor,
       maxIterationTime: 601 * 1000,
       handler: async () => {

--- a/services/queue/src/deadlineresolver.js
+++ b/services/queue/src/deadlineresolver.js
@@ -64,14 +64,12 @@ class DeadlineResolver {
     this.parallelism = options.parallelism;
     this.monitor = options.monitor;
 
-    const pollingDelaySecs = this.pollingDelay / 1000;
-    const maxIterationTimeSecs = 600;
     this.iterator = new Iterate({
       maxFailures: 10,
-      waitTime: pollingDelaySecs,
-      watchDog: maxIterationTimeSecs + 1, // disable watchdog
+      waitTime: this.pollingDelay,
+      watchDog: 601 * 1000, // disable watchdog
       monitor: this.monitor,
-      maxIterationTime: maxIterationTimeSecs,
+      maxIterationTime: 601 * 1000,
       handler: async () => {
         let loops = [];
         for (let i = 0; i < this.parallelism; i++) {

--- a/services/queue/src/deadlineresolver.js
+++ b/services/queue/src/deadlineresolver.js
@@ -67,7 +67,7 @@ class DeadlineResolver {
     this.iterator = new Iterate({
       maxFailures: 10,
       waitTime: this.pollingDelay,
-      watchDog: 601 * 1000, // disable watchdog
+      watchdogTime: 601 * 1000, // disable watchdog
       monitor: this.monitor,
       maxIterationTime: 601 * 1000,
       handler: async () => {

--- a/services/queue/src/dependencyresolver.js
+++ b/services/queue/src/dependencyresolver.js
@@ -43,7 +43,6 @@ class DependencyResolver {
     this.iterator = new Iterate({
       maxFailures: 10,
       waitTime: this._pollingDelay,
-      watchdogTime: 601 * 1000, // disable watchdog
       monitor: this.monitor,
       maxIterationTime: 600 * 1000,
       handler: async () => {

--- a/services/queue/src/dependencyresolver.js
+++ b/services/queue/src/dependencyresolver.js
@@ -40,14 +40,12 @@ class DependencyResolver {
     this._parallelism = options.parallelism;
 
     // do iteration
-    const pollingDelaySecs = this._pollingDelay / 1000;
-    const maxIterationTimeSecs = 600;
     this.iterator = new Iterate({
       maxFailures: 10,
-      waitTime: pollingDelaySecs,
-      watchDog: maxIterationTimeSecs + 1, // disable watchdog
+      waitTime: this._pollingDelay,
+      watchDog: 601 * 1000, // disable watchdog
       monitor: this.monitor,
-      maxIterationTime: maxIterationTimeSecs,
+      maxIterationTime: 600 * 1000,
       handler: async () => {
         let loops = [];
         for (let i = 0; i < this._parallelism; i++) {

--- a/services/queue/src/dependencyresolver.js
+++ b/services/queue/src/dependencyresolver.js
@@ -43,7 +43,7 @@ class DependencyResolver {
     this.iterator = new Iterate({
       maxFailures: 10,
       waitTime: this._pollingDelay,
-      watchDog: 601 * 1000, // disable watchdog
+      watchdogTime: 601 * 1000, // disable watchdog
       monitor: this.monitor,
       maxIterationTime: 600 * 1000,
       handler: async () => {

--- a/services/worker-manager/src/main.js
+++ b/services/worker-manager/src/main.js
@@ -124,7 +124,7 @@ let load = loader({
     requires: ['providers', 'biddingStrategies', 'datastore'],
     setup: async ({providers, biddingStrategies, datastore}) => {
       return new Provisioner({
-        iterationGap: 60,
+        iterationGap: 60000,
         providers,
         biddingStrategies,
         datastore,

--- a/services/worker-manager/src/provisioner.js
+++ b/services/worker-manager/src/provisioner.js
@@ -51,7 +51,6 @@ class Provisioner extends WMObject {
     this.iterate = new Iterate({
       maxFailures: 30, // We really don't want it to crash
       maxIterationTime: 300000,
-      watchdogTime: 301000,
       waitTime: iterationGap,
       handler: async () => {
         await this.provision();

--- a/services/worker-manager/src/provisioner.js
+++ b/services/worker-manager/src/provisioner.js
@@ -51,7 +51,7 @@ class Provisioner extends WMObject {
     this.iterate = new Iterate({
       maxFailures: 30, // We really don't want it to crash
       maxIterationTime: 300000,
-      watchDog: 301000,
+      watchdogTime: 301000,
       waitTime: iterationGap,
       handler: async () => {
         await this.provision();

--- a/services/worker-manager/src/provisioner.js
+++ b/services/worker-manager/src/provisioner.js
@@ -41,7 +41,7 @@ let bidProxyHandler = {
  * Run all provisioning logic (e.g. Providers and Bidding Strategies)
  */
 class Provisioner extends WMObject {
-  constructor({iterationGap=30, providers, biddingStrategies, datastore}) {
+  constructor({iterationGap=30000, providers, biddingStrategies, datastore}) {
     super({id: 'provisioner'});
     this.providers = providers;
     this.biddingStrategies = biddingStrategies;
@@ -50,8 +50,8 @@ class Provisioner extends WMObject {
 
     this.iterate = new Iterate({
       maxFailures: 30, // We really don't want it to crash
-      maxIterationTime: 300,
-      watchDog: 301,
+      maxIterationTime: 300000,
+      watchDog: 301000,
       waitTime: iterationGap,
       handler: async () => {
         await this.provision();

--- a/services/worker-manager/test/provisioner_test.js
+++ b/services/worker-manager/test/provisioner_test.js
@@ -89,7 +89,7 @@ suite('Provisioner', () => {
     let biddingStrategies = new Map([[biddingStrategy.id, biddingStrategy]]);
 
     provisioner = new Provisioner({
-      iterationGap: 1,
+      iterationGap: 1000,
       providers,
       biddingStrategies,
       datastore,


### PR DESCRIPTION
This isn't everything I want to do with this library, but it's a start: simplification, better docs, remove some unused features, refactorings.

The big thing I want to finish up is the interface by which this is used in a process.  It has some weird behavior around throwing an unhandled error in the nextTick right now.  I think a better approach might be to provide an async `run` method that returns a promise when iteration is complete and rejects if there are too many failures.  But I'll do that in another PR.