### PR TITLE
Make tc-github tests run without credentials.

### DIFF
--- a/services/github/test/api_test.js
+++ b/services/github/test/api_test.js
@@ -14,6 +14,10 @@ helper.secrets.mockSuite('api_test.js', ['taskcluster'], function(mock, skipping
   helper.withServer(mock, skipping);
 
   suiteSetup(async function() {
+    if (skipping()) {
+      return;
+    }
+
     await helper.Builds.create({
       organization: 'abc123',
       repository: 'def456',

--- a/services/github/test/helper.js
+++ b/services/github/test/helper.js
@@ -25,7 +25,7 @@ exports.secrets = new Secrets({
   secretName: 'project/taskcluster/testing/taskcluster-github',
   secrets: {
     taskcluster: [
-      {env: 'TASKCLUSTER_ROOT_URL', cfg: 'taskcluster.rootUrl', name: 'rootUrl'},
+      {env: 'TASKCLUSTER_ROOT_URL', cfg: 'taskcluster.rootUrl', name: 'rootUrl', mock: libUrls.testRootUrl()},
       {env: 'TASKCLUSTER_CLIENT_ID', cfg: 'taskcluster.credentials.clientId', name: 'clientId'},
       {env: 'TASKCLUSTER_ACCESS_TOKEN', cfg: 'taskcluster.credentials.accessToken', name: 'accessToken'},
     ],

--- a/services/github/test/sync_test.js
+++ b/services/github/test/sync_test.js
@@ -12,6 +12,10 @@ helper.secrets.mockSuite('syncInstallations', ['taskcluster'], function(mock, sk
   let github;
 
   suiteSetup(async function() {
+    if (skipping()) {
+      return;
+    }
+
     await helper.OwnersDirectory.scan({}, {
       handler: owner => owner.remove(),
     });


### PR DESCRIPTION
There's a bit of "how did this ever work" going on here!  Without tests, these suites should skip, but until this patch would have been calling `helper.Builds.create(..)` etc.  At any rate, this `if (skipping()) ..` is an idiom used in all of the other services, so it's easy to add it here.  Similarly for the default value for rootUrl.