### PR TITLE
Scanner calls a function that is gone

### DIFF
--- a/services/login/src/scanner.js
+++ b/services/login/src/scanner.js
@@ -41,11 +41,16 @@ async function scanner(cfg, handlers) {
 
     for (let client of clients) {
       debug('examining client', client.clientId);
-      if (!client.clientId.match(CLIENT_ID_PATTERN) || client.disabled) {
+
+      const patternMatch = client.clientId.match(CLIENT_ID_PATTERN);
+
+      if (!patternMatch || client.disabled) {
         continue;
       }
 
-      if (!user || user.identity !== handler.identityFromClientId(client.clientId)) {
+      const identity = patternMatch && patternMatch[1];
+
+      if (!user || user.identity !== identity) {
         user = await handler.userFromClientId(client.clientId);
 
         if (!user) {


### PR DESCRIPTION
<!-- If this is related to a Bugzilla bug, please begin your title with [Bug XXXXX] and update the following link. -->
<!-- If there is no bug, consider making one and if you really don't want one, remove the link. -->

<!-- Include any other context you wish here. -->

Bugzilla Bug: [1535366](https://bugzilla.mozilla.org/show_bug.cgi?id=1535366)
