### PR TITLE
Reduce padding in Search component

### DIFF
--- a/ui/src/components/Search/index.jsx
+++ b/ui/src/components/Search/index.jsx
@@ -26,7 +26,7 @@ import { THEME } from '../../utils/constants';
     width: '100%',
   },
   search: {
-    width: theme.spacing.unit * 6,
+    width: theme.spacing.unit * 5,
     height: '100%',
     position: 'absolute',
     pointerEvents: 'none',
@@ -42,7 +42,7 @@ import { THEME } from '../../utils/constants';
     paddingTop: theme.spacing.unit,
     paddingRight: theme.spacing.unit,
     paddingBottom: theme.spacing.unit,
-    paddingLeft: theme.spacing.unit * 7,
+    paddingLeft: theme.spacing.unit * 5,
     border: 0,
     display: 'block',
     verticalAlign: 'middle',


### PR DESCRIPTION
Before:

<img width="218" alt="Screen Shot 2019-03-14 at 3 36 59 PM" src="https://user-images.githubusercontent.com/3766511/54386310-0888ad80-466f-11e9-8c63-46f6b04452a6.png">


After:

![Screen Shot 2019-03-15 at 8 41 22 AM](https://user-images.githubusercontent.com/3766511/54431965-323ce580-46fe-11e9-9a09-111312e2ee8d.png)

Fixes https://github.com/taskcluster/taskcluster/issues/428.