### PR TITLE
Simplify lib-config

### DIFF
--- a/infrastructure/builder/src/build/index.js
+++ b/infrastructure/builder/src/build/index.js
@@ -18,8 +18,8 @@ class Build {
   async run() {
     this.cfg = config({
       files: [
-        'build-config.yml',
-        'user-build-config.yml',
+        {path: 'build-config.yml', required: true},
+        {path: 'user-build-config.yml', required: false},
       ],
       env: process.env,
     });

--- a/libraries/config/README.md
+++ b/libraries/config/README.md
@@ -35,7 +35,6 @@ This library has support for the following syntax extensions:
  * `!env <NAME>`, load string from env variable `<NAME>`,
  * `!env:string <NAME>`, load string from env variable `<NAME>`.
  * `!env:number <NAME>`, load number from env variable `<NAME>`.
- * `!env:flag <NAME>`, load true if env variable `<NAME>` is defined,
  * `!env:bool <NAME>`, load boolean as /true/i or /false/i from env
     variable `<NAME>`,
  * `!env:json <NAME>`, load JSON object from env variable `<NAME>`, and,
@@ -62,12 +61,12 @@ The default options are shown here:
 var config = require('taskcluster-lib-config');
 
 var cfg = config({
-  files: [                // Files to load configuration from
-   'config.yml',          // These defaults are relative to process.cwd
-   'user-config.yml'
+  files: [ // Files to load configuration from
+   {path: 'config.yml', required: true}, // These defaults are relative to process.cwd
+   {path: 'user-config.yml', required: false},
   ]
-  profile:  undefined,    // Profile to apply (default to none)
-  env:      process.env   // Environment variables (mapping string to strings)
+  profile:  undefined, // Profile to apply (default to none)
+  env:      process.env, // Environment variables (mapping string to strings)
 });
 ```
 

--- a/libraries/config/src/config.js
+++ b/libraries/config/src/config.js
@@ -1,162 +1,43 @@
-let _ = require('lodash');
-let yaml = require('js-yaml');
-let fs = require('fs');
-let debug = require('debug')('taskcluster-lib-config');
-let assert = require('assert');
+const _ = require('lodash');
+const yaml = require('js-yaml');
+const fs = require('fs');
+const debug = require('debug')('taskcluster-lib-config');
+const assert = require('assert');
+const buildSchema = require('./schema');
 
-/**
- * Load configuration from files and environment variables.
- *
- * options:
- * ```js
- * {
- *   files: [               // Files to load configuration from
- *     'config.yml',        // Defaults are relative to process.cwd
- *     'user-config.yml'
- *   ]
- *   profile:  process.env.NODE_ENV, // Profile to apply
- *   env:      process.env  // Environment variables (mapping string to strings)
- * }
- * ```
- *
- * Configuration Format:
- * ```yaml
- * defaults:
- *   hostname:     localhost
- *   port:         8080
- * production:
- *   hostname:   example.com
- *   port:       !env:number PORT
- * ```
- *
- * The following special YAML types can be used to load from environment
- * variables:
- * ```
- * !env        <NAME>  Load string from env var <NAME>
- * !env:string <NAME>  Load string from env var <NAME>
- * !env:number <NAME>  Load number from env var <NAME>
- * !env:flag   <NAME>  Load true if env var <NAME> is defined
- * !env:bool   <NAME>  Load boolean as /true/i or /false/i from env var <NAME>
- * !env:json   <NAME>  Load JSON object from env var <NAME>
- * !env:list   <NAME>  Load list of space separated strings from env var <NAME>
- * ```
- *
- * If the environment variable in question isn't defined, the value will be
- * `undefined`, so it can fall-back to defaults from previous config file.
- */
-let config = (options = {}) => {
-  assert(options instanceof Object, 'Options must be an object!');
-  options = _.defaults({}, options, {
-    files: [
-      'config.yml',
-      'user-config.yml',
-    ],
-    profile: process.env.NODE_ENV || undefined,
-    env: process.env,
-  });
-  assert(options.files instanceof Array, 'Expected an array of files');
-  assert(typeof options.env === 'object', 'Expected env to be an object');
+const config = ({
+  profile = process.env.NODE_ENV,
+  env = process.env,
+  files = [
+    {path: 'config.yml', required: true},
+    {path: 'user-config.yml', required: false},
+  ],
+}) => {
+  assert(files instanceof Array, 'Expected an array of files');
+  assert(typeof env === 'object', 'Expected env to be an object');
 
-  // Create a YAML type that loads from environment variable
-  let createType = (name, typeName, deserialize) => {
-    // Create new YAML type
-    return new yaml.Type(name, {
-      // Takes a string as input
-      kind: 'scalar',
-      // Accepts any string on the form [A-Z0-9_]+
-      resolve(data) {
-        return typeof data === 'string' && /^[A-Z0-9_]+$/.test(data);
-      },
-      // Deserialize the data, in the case we read the environment variable
-      construct(data) {
-        let value = options.env[data];
-        try {
-          return deserialize(value);
-        } catch (err) {
-          // Print a warning, if the environment variable is present
-          if (value !== undefined) {
-            console.log('base.config: Warning failed to load %s from ' +
-                        'environment variable \'%s\'', typeName, data);
-          }
-          return undefined;
-        }
-      },
-    });
-  };
+  const schema = buildSchema(env);
 
-  // Construct YAML schema
-  const YAML_SCHEMA = yaml.Schema.create(yaml.JSON_SCHEMA, [
-    createType('!env', 'string', val => {
-      assert(typeof val === 'string');
-      return val;
-    }),
-    createType('!env:string', 'string', val => {
-      assert(typeof val === 'string');
-      return val;
-    }),
-    createType('!env:number', 'number', val => {
-      assert(typeof val === 'string');
-      return parseFloat(val);
-    }),
-    createType('!env:flag', 'flag', val => {
-      return typeof val === 'string';
-    }),
-    createType('!env:bool', 'boolean', val => {
-      assert(typeof val === 'string');
-      if (/^true$/i.test(val)) {
-        return true;
-      }
-      if (/^false$/i.test(val)) {
-        return false;
-      }
-      return undefined;
-    }),
-    createType('!env:json', 'json', val => {
-      assert(typeof val === 'string');
-      return JSON.parse(val);
-    }),
-    createType('!env:list', 'list', val => {
-      assert(typeof val === 'string');
-      return (val.match(/'[^']*'|"[^"]*"|[^ \t]+/g) || []).map(entry =>{
-        let n = entry.length;
-        if (entry[0] === '\'' && entry[n - 1] === '\'' ||
-            entry[0] === '"' && entry[n - 1] === '"') {
-          return entry.substring(1, n - 1);
-        }
-        return entry;
-      });
-    }),
-  ]);
-
-  // Load files and parse YAML files
-  let cfgs = [];
-  for (let file of options.files) {
-    let data;
-
-    // Load data from file
+  const cfgs = [];
+  for (const file of files) {
+    assert(file.path, 'Config files must be of the form {path: "...", required: true|false}');
+    assert(file.required !== undefined, 'Config files must be of the form {path: "...", required: true|false}');
+    let f;
     try {
-      data = fs.readFileSync(file, {encoding: 'utf-8'});
+      f = fs.readFileSync(file.path, {encoding: 'utf-8'});
     } catch (err) {
-      // Don't print error, if the file is just missing
-      if (err.code !== 'ENOENT') {
-        debug('Failed to load: %s, err: %s', file, err, err.stack);
-      } else {
-        debug('Config file missing: %s', file);
+      if (err.code !== 'ENOENT' || file.required) {
+        throw err;
       }
+      debug(`Skipping missing config file: ${file.path}`);
       continue;
     }
 
-    // Load YAML from data
-    try {
-      data = yaml.safeLoad(data, {
-        filename: file,
-        schema: YAML_SCHEMA,
-      });
-    } catch (err) {
-      debug('Failed to parse YAML from %s, err: %s',
-        file, err.toString(), err.stack);
-      throw new Error('Can\'t parse YAML from: ' + file + ' ' + err.toString());
-    }
+    const data = yaml.safeLoad(f, {
+      filename: file.path, // This just gets included in error messages
+      schema,
+    });
+
     // Add defaults to list of configurations if present
     if (data.defaults) {
       assert(typeof data.defaults === 'object',
@@ -165,18 +46,17 @@ let config = (options = {}) => {
     }
 
     // Add profile to list of configurations, if it is given
-    if (options.profile && data[options.profile]) {
-      let profile = data[options.profile];
-      assert(typeof profile === 'object', 'profile must be an object');
-      cfgs.unshift(profile);
+    if (profile && data[profile]) {
+      let prof = data[profile];
+      assert(typeof prof === 'object', 'profile must be an object');
+      cfgs.unshift(prof);
     }
   }
 
-  // If all configuration files failed to load we return undefined, so it'll
-  // cause an error.
   if (cfgs.length === 0) {
-    return undefined;
+    throw new Error('Must load at least one configuration file!');
   }
+
   // Combine all the configuration keys
   return _.defaultsDeep.apply(_, cfgs);
 };

--- a/libraries/config/src/schema.js
+++ b/libraries/config/src/schema.js
@@ -1,0 +1,60 @@
+const assert = require('assert');
+const yaml = require('js-yaml');
+
+/*
+ * Create a YAML type that loads from environment variable
+ */
+const createType = (env, name, typeName, deserialize) => {
+  return new yaml.Type(name, {
+    kind: 'scalar', // Takes a string as input
+    resolve: (data) => {
+      return typeof data === 'string' && /^[A-Z0-9_]+$/.test(data);
+    },
+    // Deserialize the data, in the case we read the environment variable
+    construct: (data) => {
+      let value = env[data];
+      if (value === undefined) {
+        return value;
+      }
+      assert(typeof value === 'string', `${name} key env vars must be strings: ${data} is ${typeof value}`);
+      return deserialize(value);
+    },
+  });
+};
+
+/*
+ * This schema allows our special !env types
+ */
+module.exports = env => yaml.Schema.create(yaml.JSON_SCHEMA, [
+  createType(env, '!env', 'string', val => {
+    return val;
+  }),
+  createType(env, '!env:string', 'string', val => {
+    return val;
+  }),
+  createType(env, '!env:number', 'number', val => {
+    return parseFloat(val);
+  }),
+  createType(env, '!env:bool', 'boolean', val => {
+    if (/^true$/i.test(val)) {
+      return true;
+    }
+    if (/^false$/i.test(val)) {
+      return false;
+    }
+    return undefined;
+  }),
+  createType(env, '!env:json', 'json', val => {
+    return JSON.parse(val);
+  }),
+  createType(env, '!env:list', 'list', val => {
+    return (val.match(/'[^']*'|"[^"]*"|[^ \t]+/g) || []).map(entry =>{
+      let n = entry.length;
+      if (entry[0] === '\'' && entry[n - 1] === '\'' ||
+          entry[0] === '"' && entry[n - 1] === '"') {
+        return entry.substring(1, n - 1);
+      }
+      return entry;
+    });
+  }),
+]);

--- a/libraries/config/test/config_test.js
+++ b/libraries/config/test/config_test.js
@@ -6,7 +6,7 @@ suite('config', function() {
   test('load yaml', () => {
     let cfg = config({
       files: [
-        path.join(__dirname, 'test.yml'),
+        {path: path.join(__dirname, 'test.yml'), required: true},
       ],
     });
 
@@ -18,7 +18,7 @@ suite('config', function() {
   test('load profile', () => {
     let cfg = config({
       files: [
-        path.join(__dirname, 'test-profile.yml'),
+        {path: path.join(__dirname, 'test-profile.yml'), required: true},
       ],
       profile: 'danish',
     });
@@ -31,7 +31,7 @@ suite('config', function() {
   test('load profile (default)', () => {
     let cfg = config({
       files: [
-        path.join(__dirname, 'test-profile.yml'),
+        {path: path.join(__dirname, 'test-profile.yml'), required: true},
       ],
     });
 
@@ -43,12 +43,11 @@ suite('config', function() {
   test('load !env', () => {
     let cfg = config({
       files: [
-        path.join(__dirname, 'test-env.yml'),
+        {path: path.join(__dirname, 'test-env.yml'), required: true},
       ],
       env: {
         ENV_VARIABLE: 'env-var-value',
         ENV_NUMBER: '32.4',
-        ENV_DEFINED: 'true',
         ENV_TRUE: 'true',
         ENV_FALSE: 'false',
         ENV_JSON: '{"test": 42}',
@@ -60,8 +59,6 @@ suite('config', function() {
       text: 'env-var-value',
       text2: 'env-var-value',
       number: 32.4,
-      unsetflag: false,
-      setflag: true,
       soTrue: true,
       unTrue: false,
       notThere: undefined,
@@ -71,20 +68,20 @@ suite('config', function() {
   });
 
   test('load missing file', () => {
-    let cfg = config({
-      files: [
-        path.join(__dirname, 'file-that-doesnt-exist.yml'),
-      ],
-    });
-
-    assume(cfg).deep.equals(undefined);
+    assume(() => {
+      config({
+        files: [
+          {path: path.join(__dirname, 'file-that-doesnt-exist.yml'), required: false},
+        ],
+      });
+    }).throws(/Must load at least one configuration/);
   });
 
   test('load yaml (merge missing file)', () => {
     let cfg = config({
       files: [
-        path.join(__dirname, 'test.yml'),
-        path.join(__dirname, 'file-that-doesnt-exist.yml'),
+        {path: path.join(__dirname, 'test.yml'), required: true},
+        {path: path.join(__dirname, 'file-that-doesnt-exist.yml'), required: false},
       ],
     });
 
@@ -96,13 +93,12 @@ suite('config', function() {
   test('load !env and overwrite text', () => {
     let cfg = config({
       files: [
-        path.join(__dirname, 'test.yml'),
-        path.join(__dirname, 'test-env.yml'),
+        {path: path.join(__dirname, 'test.yml'), required: true},
+        {path: path.join(__dirname, 'test-env.yml'), required: true},
       ],
       env: {
         ENV_VARIABLE: 'env-var-value',
         ENV_NUMBER: '32.4',
-        ENV_DEFINED: 'true',
         ENV_TRUE: 'true',
         ENV_FALSE: 'false',
         ENV_JSON: '{"test": 42}',
@@ -114,8 +110,6 @@ suite('config', function() {
       text: 'env-var-value',
       text2: 'env-var-value',
       number: 32.4,
-      unsetflag: false,
-      setflag: true,
       soTrue: true,
       unTrue: false,
       notThere: undefined,
@@ -127,12 +121,11 @@ suite('config', function() {
   test('load !env and fallback text', () => {
     let cfg = config({
       files: [
-        path.join(__dirname, 'test.yml'),
-        path.join(__dirname, 'test-env.yml'),
+        {path: path.join(__dirname, 'test.yml'), required: true},
+        {path: path.join(__dirname, 'test-env.yml'), required: true},
       ],
       env: {
         ENV_NUMBER: '32.4',
-        ENV_DEFINED: 'true',
         ENV_TRUE: 'true',
         ENV_FALSE: 'false',
         ENV_JSON: '{"test": 42}',
@@ -144,19 +137,11 @@ suite('config', function() {
       text: ['Hello', 'World'],
       text2: undefined,
       number: 32.4,
-      unsetflag: false,
-      setflag: true,
       soTrue: true,
       unTrue: false,
       notThere: undefined,
       json: {test: 42},
       list: ['abc', 'def', 'qouted string', ''],
     });
-  });
-
-  test('yell when options are wrong format', () => {
-    assume(() => {
-      config('oops');
-    }).throws('Options must be an object!');
   });
 });

--- a/libraries/config/test/test-env.yml
+++ b/libraries/config/test/test-env.yml
@@ -2,8 +2,6 @@ defaults:
   text:       !env           ENV_VARIABLE
   text2:      !env:string    ENV_VARIABLE
   number:     !env:number    ENV_NUMBER
-  unsetflag:  !env:flag      ENV_UNDEFINED
-  setflag:    !env:flag      ENV_DEFINED
   soTrue:     !env:bool      ENV_TRUE
   unTrue:     !env:bool      ENV_FALSE
   notThere:   !env:bool      ENV_NOT_SET

--- a/services/login/config.yml
+++ b/services/login/config.yml
@@ -33,9 +33,9 @@ defaults:
 
   server:
     port:       !env:number PORT
-    forceSSL:   !env:flag FORCE_SSL
+    forceSSL:   !env:bool FORCE_SSL
     env:        !env NODE_ENV
-    trustProxy: !env:flag TRUST_PROXY
+    trustProxy: !env:bool TRUST_PROXY
 production:
   handlers:
     mozilla-auth0:
@@ -59,6 +59,7 @@ test:
     port: 60174
     env: development
     forceSSL: false
+    trustProxy: true
 ngrok:
   handlers:
     test:

--- a/services/queue/config.yml
+++ b/services/queue/config.yml
@@ -116,7 +116,7 @@ defaults:
   server:
     port:             !env:number PORT
     env:              !env NODE_ENV
-    forceSSL:         !env:flag FORCE_SSL
+    forceSSL:         !env:bool FORCE_SSL
     trustProxy:       false
 
   # Azure credentials (for blob and queue storage)
@@ -203,6 +203,7 @@ test:
   server:
     port:             60401
     env:              development
+    forceSSL:         false
   azureTableAccount:  inMemory
 load-test:
   app:


### PR DESCRIPTION
* Remove `!env:flag` due to it being confusing and `!env:bool` is good enough
* Allow specifying which config files are allowed to be missing
* Stop catching and logging errors that should just be thrown
* Refactor to be easier to read


This is work in preparation for modifying lib-config to allow it to tell us what all of the `!env` vars are in order to automatically generate kubernetes configs.

Apologies for the one-giant-commit