### PR TITLE
Restrict the allowable charcters for wstClient

### DIFF
--- a/generated/references.json
+++ b/generated/references.json
@@ -6462,7 +6462,7 @@
         },
         "wstClient": {
           "description": "Id for the websocktunnel client connection; this will be the same as the requested `wstClient`.\n",
-          "pattern": "^[A-Za-z0-9!@/:.+|_-]+$",
+          "pattern": "^[a-zA-Z0-9_~.%-]+$",
           "title": "Websocktunnel Client",
           "type": "string"
         }

--- a/services/auth/schemas/v1/websocktunnel-token-response.yml
+++ b/services/auth/schemas/v1/websocktunnel-token-response.yml
@@ -7,7 +7,7 @@ properties:
   wstClient:
     type: string
     title: Websocktunnel Client
-    pattern: {$const: "clientId"}
+    pattern: "^[a-zA-Z0-9_~.%-]+$"
     description: |
       Id for the websocktunnel client connection; this will be the same as the requested `wstClient`.
   wstAudience:

--- a/services/auth/src/websocktunnel.js
+++ b/services/auth/src/websocktunnel.js
@@ -6,7 +6,7 @@ builder.declare({
   route: '/websocktunnel/:wstAudience/:wstClient',
   params: {
     wstAudience: /^[a-zA-Z0-9_-]{1,38}$/, // identifier-token format
-    wstClient: /^[A-Za-z0-9!@/:.+|_-]+$/, // clientID format
+    wstClient: /^[a-zA-Z0-9_~.%-]+$/, // websocktunnel's clientId format
   },
   name: 'websocktunnelToken',
   output: 'websocktunnel-token-response.yml',

--- a/services/auth/test/websocktunnel_test.js
+++ b/services/auth/test/websocktunnel_test.js
@@ -10,7 +10,7 @@ helper.secrets.mockSuite(helper.suiteName(__filename), ['app', 'azure'], functio
 
   test('websocktunnelToken', async () => {
     const wstAudience = 'websocktunnel-usw2';
-    const wstClient = 'my-group/my-id';
+    const wstClient = 'my-group-my-id';
     const resp = await helper.apiClient.websocktunnelToken(wstAudience, wstClient);
 
     assert.equal(resp.wstClient, wstClient);

--- a/ui/docs/generated/auth/schemas/v1/websocktunnel-token-response.json
+++ b/ui/docs/generated/auth/schemas/v1/websocktunnel-token-response.json
@@ -7,7 +7,7 @@
     "wstClient": {
       "type": "string",
       "title": "Websocktunnel Client",
-      "pattern": "^[A-Za-z0-9!@/:.+|_-]+$",
+      "pattern": "^[a-zA-Z0-9_~.%-]+$",
       "description": "Id for the websocktunnel client connection; this will be the same as the requested `wstClient`.\n"
     },
     "wstAudience": {

--- a/ui/docs/generated/references.json
+++ b/ui/docs/generated/references.json
@@ -6462,7 +6462,7 @@
         },
         "wstClient": {
           "description": "Id for the websocktunnel client connection; this will be the same as the requested `wstClient`.\n",
-          "pattern": "^[A-Za-z0-9!@/:.+|_-]+$",
+          "pattern": "^[a-zA-Z0-9_~.%-]+$",
           "title": "Websocktunnel Client",
           "type": "string"
         }


### PR DESCRIPTION
The websocktunnel already requires:

> The client ID must be URL-safe, specifically matching
> /^[a-zA-Z0-9_~.-%]+$/. It is recommended to urlencode any string to meet
> this requirement.

So apply the same limits here.

(I only just noticed / remembered this restriction)