### PR TITLE
Bug 1536435 - support linked identities

### DIFF
--- a/services/login/test/handlers_mozilla_auth0_test.js
+++ b/services/login/test/handlers_mozilla_auth0_test.js
@@ -17,30 +17,37 @@ suite('handlers/mozilla-auth0', function() {
   });
 
   handler.getManagementApi = () => {
+    // simulate linked identities by including all of them here
+    const identities = [
+      {provider: 'ad', connection: 'Mozilla-LDAP'},
+      {provider: 'github', connection: 'github',
+        profileData: {user_id: 1234, nickname: 'helfi92'}},
+      {provider: 'oauth2', connection: 'firefoxaccounts',
+        profileData: {fxa_sub: 'abcdef', email: 'rockets@ksc'}},
+      {provider: 'email', connection: 'email', user_id: 'slashy/slashy'},
+    ];
     return {
       getUser: ({id}) => {
         switch (id) {
         case 'ad|Mozilla-LDAP|dmitchell':
           return {
-            identities: [{provider: 'ad', connection: 'Mozilla-LDAP'}],
             user_id: 'ad|Mozilla-LDAP|dmitchell',
+            identities,
           };
         case 'github|1234':
           return {
-            identities: [{provider: 'github', connection: 'github'}],
             user_id: 'github|1234',
-            nickname: 'helfi92',
+            identities,
           };
         case 'oauth2|firefoxaccounts|abcdef':
           return {
             user_id: 'oauth2|firefoxaccounts|abcdef',
-            identities: [{provider: 'oauth2', connection: 'firefoxaccounts'}],
-            nickname: 'djmitche',
+            identities,
           };
         case 'email|slashy/slashy':
           return {
             user_id: 'email|slashy/slashy',
-            identities: [{provider: 'email', connection: 'email'}],
+            identities,
           };
         default:
           return null;
@@ -76,8 +83,8 @@ suite('handlers/mozilla-auth0', function() {
 
     testUserFromClientId({
       name: 'firefoxaccounts clientId',
-      clientId: 'mozilla-auth0/oauth2|firefoxaccounts|abcdef|djmitche/',
-      identity: 'mozilla-auth0/oauth2|firefoxaccounts|abcdef|djmitche',
+      clientId: 'mozilla-auth0/oauth2|firefoxaccounts|abcdef|rockets@ksc/',
+      identity: 'mozilla-auth0/oauth2|firefoxaccounts|abcdef|rockets@ksc',
     });
 
     testUserFromClientId({


### PR DESCRIPTION
Now that we link identities, the format of the `identities` property has
changed, invalidating some assumptions.  Happily those assumptions were
represented with assertions so we got errors instead of undefined
behavior!

In particular, an account with a github identity now has an identity
like:

```json
    {
      "provider": "github",
      "connection": "github",
      "profileData": {
        "userId": 1234,
        "nickname": "developer1234"
      }
    },
```

and an account with a firefoxaccounts sign-in has

```json
    {
      "profileData": {
        "email": "foo@bar.com",
        "fxa_sub": "97ff4ba365255c2a92d362ea017baa15",
        ...
      },
      "provider": "oauth2",
      "user_id": "firefoxaccounts|97ff4ba365255c2a92d362ea017baa15",
      "connection": "firefoxaccounts",
      "isSocial": true
    }
```
Bugzilla Bug: [1536435](https://bugzilla.mozilla.org/show_bug.cgi?id=1536435)
