### PR TITLE
Replace dead link to presentations to a link to the youtube group

### DIFF
--- a/ui/docs/resources.md
+++ b/ui/docs/resources.md
@@ -3,33 +3,20 @@ title: Resources
 noAnchors: true
 ---
 
-# Resources
+# Resources for Further Exploration
 
-### [<span class="glyphicon glyphicon-blackboard" aria-hidden="true"></span> Presentations](/docs/presentations)
+### [<span class="glyphicon glyphicon-blackboard" aria-hidden="true"></span> Videos](https://www.youtube.com/channel/UCD0odAg4RgoTDdomOx7lSuw)
 
-View videos, screencasts, and slides given about Taskcluster.
-
----
+The Taskcluster team has created a few videos to help you learn about and use Taskcluster.
 
 ### [<span class="glyphicon glyphicon-classic-hammer" aria-hidden="true"></span> Codetribute](https://codetribute.mozilla.org/projects/taskcluster)
 
 Codetribute collects bugs and issues that are good for newcomers to work on.  If you want to get started contributing to Taskcluster, this tool can help.
 
----
-
 ### [<span class="glyphicon glyphicon-bug" aria-hidden="true"></span> Bugzilla](https://bugzilla.mozilla.org/enter_bug.cgi?product=Taskcluster)
 
 Taskcluster uses Mozilla's Bugzilla to manage bugs and feature development. If you've found a bug, file it here.
 
----
-
 ### [<span class="glyphicon glyphicon-random" aria-hidden="true"></span> GitHub](https://github.com/taskcluster)
 
 Taskcluster's code and repositories. If you are looking for Taskcluster's code, this is where you will find it.
-
----
-
-### [<span class="glyphicon glyphicon-compressed" aria-hidden="true"></span> Travis CI](https://travis-ci.org/taskcluster)
-
-Travis is the continuous-integration system that builds much of the code on GitHub. Look here for information and statuses
-of building Taskcluster code repositories.


### PR DESCRIPTION
This also drops the Travis-CI link.  We don't use Travis-CI for much
anymore.

Fixes #472.