### PR TITLE
Bug 1533937 - cleanup after tests (azure tables, at least) on push

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -62,6 +62,11 @@ tasks:
         command: yarn lint
       - name: test:meta
         command: yarn test:meta
+        # only do cleanup on pushes; no sense doing so on pull requests
+      - $if: 'tasks_for == "github-push" && event["ref"] == "refs/heads/master"'
+        then:
+          name: test:cleanup
+          command: yarn test:cleanup
       - name: taskcluster-terraform
         image: 'jonatanblue/gitlab-ci-terraform:latest'
         command: 'cd infrastructure/terraform; terraform fmt -check'

--- a/libraries/testing/src/with-entity.js
+++ b/libraries/testing/src/with-entity.js
@@ -4,7 +4,8 @@ const slugid = require('slugid');
 // a suffix used to generate unique table names so that parallel test runs do not
 // interfere with one another.  The table name includes the date so that old tables
 // can be removed by an out-of-band process (as CI for services does not have
-// permission to remove tables).
+// permission to remove tables).  Note that this suffix corresponds to a regex
+// in services/auth/test/cleanup.js!
 const TABLE_SUFFIX = (() => {
   const date = new Date().toJSON().split('T')[0].replace(/-/g, '');
   const rand = slugid.nice().replace(/[_-]/g, '').slice(0, 8);

--- a/package.json
+++ b/package.json
@@ -96,6 +96,7 @@
     "lint": "eslint --cache --ext js --ignore-pattern clients/client-web/build libraries services infrastructure clients test",
     "test": "yarn workspaces run test",
     "test:meta": "mocha test/*_test.js",
+    "test:cleanup": "yarn workspace taskcluster-auth test:cleanup",
     "build": "node infrastructure/builder/src/main.js build",
     "generate": "node infrastructure/builder/src/main.js generate",
     "heroku-prebuild": "echo $SOURCE_VERSION > .git-version",

--- a/services/auth/package.json
+++ b/services/auth/package.json
@@ -5,6 +5,7 @@
   "main": "node src/server production",
   "scripts": {
     "test": "mocha test/*_test.js",
+    "test:cleanup": "mocha test/cleanup.js",
     "lint": "eslint src/*.js test/*.js"
   },
   "dependencies": {

--- a/services/auth/test/cleanup.js
+++ b/services/auth/test/cleanup.js
@@ -1,0 +1,59 @@
+const helper = require('./helper');
+const azure = require('fast-azure-storage');
+
+suite('Test Cleanup', function() {
+  suiteSetup(async function() {
+    await helper.secrets.setup();
+    if (!helper.secrets.have('azure')) {
+      throw new Error('cleanup must run in an environment with access to the real azure credentials');
+    }
+  });
+
+  test('cleanup testing tables (for all services)', async function() {
+    const {accountId, accountKey: accessKey} = helper.secrets.get('azure');
+    const table = new azure.Table({accountId, accessKey});
+
+    // match the pattern used in libraries/testing/src/with-entity.js to name
+    // test tables.  This is unlikely to match "real" tables, which anyhow should
+    // be in a different storage account.
+    const tablePattern = /T([0-9]{8})T[a-zA-Z0-9]{8}$/;
+    const yesterday = new Date(new Date() - 1000*3600*24).toJSON().split('T')[0].replace(/-/g, '');
+    let nextTableName;
+    try {
+      await table.deleteTable('fooo');
+    } catch (err) {
+      console.log(Object.assign({}, err));
+    }
+    while (1) {
+      const result = await table.queryTables({nextTableName});
+      for (let name of result.tables) {
+        const match = tablePattern.exec(name);
+        if (!match) {
+          continue;
+        }
+
+        // see if this is too new - only delete tables from before yesterday
+        if (match[1] >= yesterday) {
+          continue;
+        }
+
+        console.log(`deleting ${name}`);
+        try {
+          await table.deleteTable(name);
+        } catch (err) {
+          // this is likely because there are parallel runs of this task, so ignore
+          // but log 404's
+          if (err.code !== 'ResourceNotFound') {
+            throw err;
+          }
+          console.log(`..failed: ${err}`);
+        }
+      }
+      if (result.nextTableName) {
+        nextTableName = result.nextTableName;
+      } else {
+        break;
+      }
+    }
+  });
+});


### PR DESCRIPTION
This just cleans up tables, but could easily be extended to any other kind of resource, e.g., SQS queues, Azure containers.

I guess ideally this would be a crontask, but in the absence of good support for those, I think running this just on pushes is a decent compromise.

Bugzilla Bug: [1533937](https://bugzilla.mozilla.org/show_bug.cgi?id=1533937)
