### PR TITLE
Bug 1538152 - "tell a story" about tasks in queue logging

### DIFF
--- a/generated/references.json
+++ b/generated/references.json
@@ -8230,16 +8230,80 @@
           "version": 1
         },
         {
-          "description": "Results of a claimWork from a worker.",
+          "description": "A task has been created (via defineTask or createTask).  This is logged when the task-defined\npulse message is sent.",
+          "fields": {
+            "taskId": "The task's taskId."
+          },
+          "type": "task-defined",
+          "version": 1
+        },
+        {
+          "description": "A task is now pending and ready to be executed.  This is logged when the task-pending pulse\nmessage is sent.",
+          "fields": {
+            "runId": "The runId that is now pending.",
+            "taskId": "The task's taskId."
+          },
+          "type": "task-pending",
+          "version": 1
+        },
+        {
+          "description": "A task is now being executed.  This is logged when the task-running pulse message is sent.",
+          "fields": {
+            "runId": "The runId that is now running.",
+            "taskId": "The task's taskId."
+          },
+          "type": "task-running",
+          "version": 1
+        },
+        {
+          "description": "A task run has been resolved as completed.  This is logged when the task-completed pulse\nmessage is sent.",
+          "fields": {
+            "runId": "The runId that was resolved.",
+            "taskId": "The task's taskId."
+          },
+          "type": "task-completed",
+          "version": 1
+        },
+        {
+          "description": "A task run has been resolved as failed.  This is logged when the task-failed pulse\nmessage is sent.",
+          "fields": {
+            "runId": "The runId that was resolved.",
+            "taskId": "The task's taskId."
+          },
+          "type": "task-failed",
+          "version": 1
+        },
+        {
+          "description": "A task run has been resolved as an exception.  This is logged when the task-exception pulse\nmessage is sent.",
+          "fields": {
+            "runId": "The runId that was resolved.",
+            "taskId": "The task's taskId."
+          },
+          "type": "task-exception",
+          "version": 1
+        },
+        {
+          "description": "A worker has claimed a task.  In cases where multple tasks were claimed,\none log message will be produced for each task.",
           "fields": {
             "provisionerId": "Provisioner that provisioned the worker claiming work.",
-            "requested": "The number of tasks the worker requested.",
-            "tasks": "An array of taskId that were given to the worker.",
+            "runId": "The run of this task assigned to the worker.",
+            "taskId": "The task given to the worker.",
             "workerGroup": "Group of worker claiming work.",
             "workerId": "The id of the claiming worker.",
             "workerType": "Type of worker claiming work."
           },
-          "type": "work-claimed",
+          "type": "task-claimed",
+          "version": 1
+        },
+        {
+          "description": "A worker has reclaimed a task it had previously claimed, extending its takenUntil\ntimestamp.",
+          "fields": {
+            "runId": "The run of this task being reclaimed.",
+            "taskId": "The task being reclaimed.",
+            "workerGroup": "Group of the reclaiming worker.",
+            "workerId": "Id of the reclaiming worker."
+          },
+          "type": "task-reclaimed",
           "version": 1
         },
         {

--- a/libraries/monitor/README.md
+++ b/libraries/monitor/README.md
@@ -25,7 +25,7 @@ const manager = new MonitorManager({
   serviceName: 'foo',
 });
 manager.setup({
-  mock: cfg.monitor.mock,  // false in production, true in testing
+  mock: cfg.monitor.mock,      // false in production, true in testing
   processName: 'server',       // or otherwise for e.g., periodic tasks
 });
 const monitor = manager.monitor(); // To get a root monitor
@@ -339,3 +339,16 @@ This function will:
  * shut down and flush monitoring
  * call `process.exit` on success or failure
 Note, then, that the function **does not return**.
+
+### Testing
+
+If the `mock` option is true, then all messges logged are available from the `messages` property on the MonitorManager, in the format `{Type, Fields, Logger}`.
+These messages can be cleared with the `reset()` method -- generally done in a Mocha `setup` function.
+This allows tests to assert that a message was logged correctly:
+
+```js
+assert.deepEqual(helper.monitor.messages.find(({Type}) => Type === 'task-claimed'), {
+  Type: 'task-claimed',
+  Fields: {...}
+});
+```

--- a/libraries/monitor/src/index.js
+++ b/libraries/monitor/src/index.js
@@ -145,13 +145,13 @@ class MonitorManager {
       this.destination = new stream.Writable({
         write: (chunk, encoding, next) => {
           try {
-            chunk = JSON.parse(chunk);
+            const {Type, Fields, Logger} = JSON.parse(chunk);
+            this.messages.push({Type, Fields, Logger});
           } catch (err) {
             if (err.name !== 'SyntaxError') {
               throw err;
             }
           }
-          this.messages.push(chunk);
           next();
         },
       });
@@ -236,7 +236,10 @@ class MonitorManager {
    * For use in testing only. Clears the events so this can be used again.
    */
   reset() {
-    this.messages = [];
+    if (!this.mock) {
+      throw new Error('monitor.reset is only valid on mock monitors');
+    }
+    this.messages.splice(0);
   }
 
   /*

--- a/libraries/monitor/test/logger_test.js
+++ b/libraries/monitor/test/logger_test.js
@@ -4,15 +4,29 @@ const Ajv = require('ajv');
 const MonitorManager = require('../src');
 
 suite('Logging', function() {
-  let manager;
-  let monitor;
+  let manager, monitor, messages, destination;
 
   setup(function() {
     manager = new MonitorManager({
       serviceName: 'testing-service',
     });
+    // similar to the mock destination, but capturing all fields
+    destination = new stream.Writable({
+      write: (chunk, encoding, next) => {
+        try {
+          messages.push(JSON.parse(chunk));
+        } catch (err) {
+          if (err.name !== 'SyntaxError') {
+            throw err;
+          }
+        }
+        next();
+      },
+    });
+    messages = [];
     manager.setup({
       level: 'debug',
+      destination,
       mock: true,
       verify: true,
     });
@@ -26,7 +40,7 @@ suite('Logging', function() {
   test('logger conforms to schema', function() {
     const schema = require('./mozlog_schema.json');
     monitor.info('something', {test: 123});
-    const event = manager.messages[0];
+    const event = messages[0];
 
     const ajv = new Ajv();
     assert(ajv.validate(schema, event), ajv.errorsText());
@@ -62,62 +76,62 @@ suite('Logging', function() {
 
   test('simple eliding', function() {
     monitor.info({credentials: 5});
-    assert.equal(manager.messages[0].Type, 'monitor.generic');
-    assert.equal(manager.messages[0].Fields.credentials, '...');
+    assert.equal(messages[0].Type, 'monitor.generic');
+    assert.equal(messages[0].Fields.credentials, '...');
   });
 
   test('nested eliding', function() {
     monitor.info({whatever: [{accessToken: 'hi'}]});
-    assert.equal(manager.messages[0].Type, 'monitor.generic');
-    assert.equal(manager.messages[0].Fields.whatever[0].accessToken, '...');
+    assert.equal(messages[0].Type, 'monitor.generic');
+    assert.equal(messages[0].Fields.whatever[0].accessToken, '...');
   });
 
   test('null eliding does not crash', function() {
     monitor.info({something: null});
-    assert.equal(manager.messages[0].Type, 'monitor.generic');
-    assert.equal(manager.messages[0].Fields.something, null);
+    assert.equal(messages[0].Type, 'monitor.generic');
+    assert.equal(messages[0].Fields.something, null);
   });
 
   test('empty data still logs', function() {
     monitor.info({whatever: 5});
-    assert.equal(manager.messages[0].Type, 'monitor.generic');
-    assert.equal(manager.messages[0].Fields.whatever, 5);
+    assert.equal(messages[0].Type, 'monitor.generic');
+    assert.equal(messages[0].Fields.whatever, 5);
   });
 
   test('string data still logs', function() {
     monitor.info('baz', 'hello');
-    assert.equal(manager.messages[0].Type, 'baz');
-    assert.equal(manager.messages[0].Fields.message, 'hello');
+    assert.equal(messages[0].Type, 'baz');
+    assert.equal(messages[0].Fields.message, 'hello');
   });
 
   test('number data still logs', function() {
     monitor.info('foobar', 5.0);
-    assert.equal(manager.messages[0].Type, 'foobar');
-    assert.equal(manager.messages[0].Fields.message, 5.0);
+    assert.equal(messages[0].Type, 'foobar');
+    assert.equal(messages[0].Fields.message, 5.0);
   });
 
   test('null data still logs', function() {
     monitor.info('something', null);
-    assert.equal(manager.messages[0].Type, 'monitor.loggingError');
-    assert.equal(manager.messages[0].Fields.error, 'Invalid field to be logged.');
-    assert.equal(manager.messages[0].Fields.origType, 'something');
-    assert.equal(manager.messages[0].Fields.orig, null);
+    assert.equal(messages[0].Type, 'monitor.loggingError');
+    assert.equal(messages[0].Fields.error, 'Invalid field to be logged.');
+    assert.equal(messages[0].Fields.origType, 'something');
+    assert.equal(messages[0].Fields.orig, null);
   });
 
   test('boolean data still logs', function() {
     monitor.info('something', true);
-    assert.equal(manager.messages[0].Type, 'monitor.loggingError');
-    assert.equal(manager.messages[0].Fields.error, 'Invalid field to be logged.');
-    assert.equal(manager.messages[0].Fields.origType, 'something');
-    assert.equal(manager.messages[0].Fields.orig, true);
+    assert.equal(messages[0].Type, 'monitor.loggingError');
+    assert.equal(messages[0].Fields.error, 'Invalid field to be logged.');
+    assert.equal(messages[0].Fields.origType, 'something');
+    assert.equal(messages[0].Fields.orig, true);
   });
 
   test('metadata still logs but alerts', function() {
     monitor.info('something', {meta: 'foo'});
-    assert.equal(manager.messages[0].Type, 'monitor.loggingError');
-    assert.equal(manager.messages[0].Fields.error, 'You may not set meta fields on logs directly.');
-    assert.equal(manager.messages[0].Fields.origType, 'something');
-    assert.equal(manager.messages[0].Fields.orig.meta, 'foo');
+    assert.equal(messages[0].Type, 'monitor.loggingError');
+    assert.equal(messages[0].Fields.error, 'You may not set meta fields on logs directly.');
+    assert.equal(messages[0].Fields.origType, 'something');
+    assert.equal(messages[0].Fields.orig.meta, 'foo');
   });
 
   test('all logging levels represented', function() {
@@ -135,11 +149,11 @@ suite('Logging', function() {
       monitor[level](`something.${level}`, {bar: i});
     });
 
-    assert.equal(manager.messages.length, 8);
+    assert.equal(messages.length, 8);
     levels.forEach((level, i) => {
-      assert.equal(manager.messages[i].Logger, `taskcluster.testing-service.root`);
-      assert.equal(manager.messages[i].Type, `something.${level}`);
-      assert.equal(manager.messages[i].Fields.bar, i);
+      assert.equal(messages[i].Logger, `taskcluster.testing-service.root`);
+      assert.equal(messages[i].Type, `something.${level}`);
+      assert.equal(messages[i].Fields.bar, i);
     });
   });
 
@@ -149,28 +163,36 @@ suite('Logging', function() {
     });
     b.setup({
       level: 'alert',
+      destination,
       mock: true,
     });
     const m = b.monitor();
     m.info('something', {whatever: 5}); // This should not get logged
     m.alert('something.else', {whatever: 6});
     m.emerg('something.even.else', {whatever: 7});
-    assert.equal(b.messages.length, 2);
+    assert.equal(messages.length, 2);
   });
 
+  const prettyDestination = new stream.Writable({
+    write: (chunk, encoding, next) => {
+      messages.push(chunk.toString());
+      next();
+    },
+  });
   test('pretty', function() {
     const b = new MonitorManager({
       serviceName: 'taskcluster-level',
     });
     b.setup({
       level: 'debug',
+      destination: prettyDestination,
       mock: true,
       pretty: true,
     });
     const m = b.monitor();
     m.info('something', {whatever: 5});
-    assert.equal(b.messages.length, 1);
-    const message = b.messages[0].toString();
+    assert.equal(messages.length, 1);
+    const message = messages[0].toString();
     assert(message.includes('INFO'));
     assert(message.includes('whatever: 5'));
   });
@@ -181,13 +203,14 @@ suite('Logging', function() {
     });
     b.setup({
       level: 'debug',
+      destination: prettyDestination,
       mock: true,
       pretty: true,
     });
     const m = b.monitor();
     m.err('something', {whatever: 'foo\nbar'});
-    assert.equal(b.messages.length, 1);
-    const message = b.messages[0].toString();
+    assert.equal(messages.length, 1);
+    const message = messages[0].toString();
     assert(message.includes('ERROR'));
     assert(message.includes('whatever: foo\\nbar'));
   });

--- a/services/queue/config.yml
+++ b/services/queue/config.yml
@@ -198,8 +198,9 @@ test:
     publicArtifactBucketProxies:
       'us-east-1':    'proxy-for-us-east-1'
   monitoring:
-    level: warning
-    enable: false
+    level: debug
+    enable: true
+    mock: true
   server:
     port:             60401
     env:              development

--- a/services/queue/src/api.js
+++ b/services/queue/src/api.js
@@ -735,6 +735,7 @@ builder.declare({
   // Publish task-defined message, we want this arriving before the
   // task-pending message, so we have to await publication here
   await this.publisher.taskDefined({status}, task.routes);
+  this.monitor.log.taskDefined({taskId});
 
   // If first run is pending we publish messages about this
   if (runZeroState === 'pending') {
@@ -745,6 +746,7 @@ builder.declare({
       // Put message in appropriate azure queue, and publish message to pulse
       this.publisher.taskPending({status, runId: 0}, task.routes),
     ]);
+    this.monitor.log.taskPending({taskId, runId: 0});
   }
 
   // Reply
@@ -911,6 +913,7 @@ builder.declare({
 
   // Publish task-defined message
   await this.publisher.taskDefined({status}, task.routes);
+  this.monitor.log.taskDefined({taskId});
 
   // Reply
   return res.reply({status});
@@ -1107,6 +1110,7 @@ builder.declare({
         runId: runId,
       }, task.routes),
     ]);
+    this.monitor.log.taskPending({taskId, runId});
   }
 
   return res.reply({status});
@@ -1228,10 +1232,12 @@ builder.declare({
     );
 
     // Publish message about the exception
+    const runId = task.runs.length - 1;
     await this.publisher.taskException(_.defaults({
       status,
-      runId: task.runs.length - 1,
+      runId,
     }, _.pick(run, 'workerGroup', 'workerId')), task.routes);
+    this.monitor.log.taskException({taskId, runId});
   }
 
   return res.reply({status});
@@ -1753,6 +1759,7 @@ let resolveTask = async function(req, res, taskId, runId, target) {
       workerGroup: run.workerGroup,
       workerId: run.workerId,
     }, task.routes);
+    this.monitor.log.taskCompleted({taskId, runId});
   } else {
     await this.publisher.taskFailed({
       status,
@@ -1760,6 +1767,7 @@ let resolveTask = async function(req, res, taskId, runId, target) {
       workerGroup: run.workerGroup,
       workerId: run.workerId,
     }, task.routes);
+    this.monitor.log.taskFailed({taskId, runId});
   }
 
   return res.reply({status});
@@ -1964,6 +1972,7 @@ builder.declare({
         runId: runId + 1,
       }, task.routes),
     ]);
+    this.monitor.log.taskPending({taskId, runId: runId + 1});
   } else {
     // Update dependency tracker, as the task is resolved (no new run)
     await this.queueService.putResolvedMessage(
@@ -1980,6 +1989,7 @@ builder.declare({
       workerGroup: run.workerGroup,
       workerId: run.workerId,
     }, task.routes);
+    this.monitor.log.taskException({taskId, runId});
   }
 
   // Reply to caller

--- a/services/queue/src/api.js
+++ b/services/queue/src/api.js
@@ -1359,13 +1359,15 @@ builder.declare({
     this.workerInfo.seen(provisionerId, workerType, workerGroup, workerId),
   ]);
 
-  this.monitor.log.workClaimed({
-    provisionerId,
-    workerType,
-    workerGroup,
-    workerId,
-    requested: count,
-    tasks: result.map(({status}) => status.taskId),
+  result.forEach(({runId, status: {taskId}}) => {
+    this.monitor.log.taskClaimed({
+      provisionerId,
+      workerType,
+      workerGroup,
+      workerId,
+      taskId,
+      runId,
+    });
   });
 
   await this.workerInfo.taskSeen(provisionerId, workerType, workerGroup, workerId, result);
@@ -1624,6 +1626,13 @@ builder.declare({
     task.scopes,
     this.credentials,
   );
+
+  this.monitor.log.taskReclaimed({
+    taskId,
+    runId,
+    workerId: run.workerId,
+    workerGroup: run.workerGroup,
+  });
 
   // Reply to caller
   return res.reply({

--- a/services/queue/src/claimresolver.js
+++ b/services/queue/src/claimresolver.js
@@ -230,6 +230,7 @@ class ClaimResolver {
           runId: runId + 1,
         }, task.routes),
       ]);
+      this.monitor.taskPending({taskId, runId: runId + 1});
     } else {
       // Update dependencyTracker
       await this.dependencyTracker.resolveTask(taskId, task.taskGroupId, task.schedulerId, 'exception');
@@ -241,6 +242,7 @@ class ClaimResolver {
         workerGroup: run.workerGroup,
         workerId: run.workerId,
       }, task.routes);
+      this.monitor.taskException({taskId, runId});
     }
 
     return remove();

--- a/services/queue/src/deadlineresolver.js
+++ b/services/queue/src/deadlineresolver.js
@@ -209,10 +209,12 @@ class DeadlineResolver {
       await this.dependencyTracker.resolveTask(taskId, task.taskGroupId, task.schedulerId, 'exception');
 
       // Publish messages about the last run
+      const runId = task.runs.length - 1;
       await this.publisher.taskException({
         status: task.status(),
-        runId: task.runs.length - 1,
+        runId,
       }, task.routes);
+      this.monitor.taskException({taskId, runId});
     }
 
     return remove();

--- a/services/queue/src/dependencytracker.js
+++ b/services/queue/src/dependencytracker.js
@@ -26,6 +26,7 @@ class DependencyTracker {
     assert(options.TaskDependency, 'Expected options.TaskDependency');
     assert(options.TaskRequirement, 'Expected options.TaskRequirement');
     assert(options.TaskGroupActiveSet, 'Expected options.TaskGroupActiveSet');
+    assert(options.monitor, 'Expected options.monitor');
 
     // Store options on this object
     this.Task = options.Task;
@@ -34,6 +35,7 @@ class DependencyTracker {
     this.TaskDependency = options.TaskDependency;
     this.TaskRequirement = options.TaskRequirement;
     this.TaskGroupActiveSet = options.TaskGroupActiveSet;
+    this.monitor = options.monitor;
   }
 
   /**
@@ -363,6 +365,7 @@ class DependencyTracker {
           runId: 0,
         }, task.routes),
       ]);
+      this.monitor.log.taskPending({taskId: task.taskId, runId: 0});
     }
 
     return status;

--- a/services/queue/src/main.js
+++ b/services/queue/src/main.js
@@ -387,9 +387,12 @@ let load = loader({
   dependencyTracker: {
     requires: [
       'Task', 'publisher', 'queueService', 'TaskDependency',
-      'TaskRequirement', 'TaskGroupActiveSet',
+      'TaskRequirement', 'TaskGroupActiveSet', 'monitor',
     ],
-    setup: (ctx) => new DependencyTracker(ctx),
+    setup: ({monitor, ...ctx}) => new DependencyTracker({
+      monitor: monitor.monitor('dependency-tracker'),
+      ...ctx}
+    ),
   },
 
   // Create EC2RegionResolver for regions we have artifact proxies in

--- a/services/queue/src/monitor.js
+++ b/services/queue/src/monitor.js
@@ -4,6 +4,12 @@ const manager = new MonitorManager({
   serviceName: 'queue',
 });
 
+/**
+ * For ease of debugging, all log messages about tasks have a top-level
+ * `taskId` field.  In cases where multiple tasks are handled together, prefer
+ * to make individual log entries for each task.
+ */
+
 manager.register({
   name: 'azureQueuePoll',
   type: 'azure-queue-poll',
@@ -18,18 +24,118 @@ manager.register({
 });
 
 manager.register({
-  name: 'workClaimed',
-  type: 'work-claimed',
+  name: 'taskDefined',
+  type: 'task-defined',
   version: 1,
   level: 'notice',
-  description: 'Results of a claimWork from a worker.',
+  description: `
+    A task has been created (via defineTask or createTask).  This is logged when the task-defined
+    pulse message is sent.`,
+  fields: {
+    taskId: 'The task\'s taskId.',
+  },
+});
+
+manager.register({
+  name: 'taskPending',
+  type: 'task-pending',
+  version: 1,
+  level: 'notice',
+  description: `
+    A task is now pending and ready to be executed.  This is logged when the task-pending pulse
+    message is sent.`,
+  fields: {
+    taskId: 'The task\'s taskId.',
+    runId: 'The runId that is now pending.',
+  },
+});
+
+manager.register({
+  name: 'taskRunning',
+  type: 'task-running',
+  version: 1,
+  level: 'notice',
+  description: `
+    A task is now being executed.  This is logged when the task-running pulse message is sent.`,
+  fields: {
+    taskId: 'The task\'s taskId.',
+    runId: 'The runId that is now running.',
+  },
+});
+
+manager.register({
+  name: 'taskCompleted',
+  type: 'task-completed',
+  version: 1,
+  level: 'notice',
+  description: `
+    A task run has been resolved as completed.  This is logged when the task-completed pulse
+    message is sent.`,
+  fields: {
+    taskId: 'The task\'s taskId.',
+    runId: 'The runId that was resolved.',
+  },
+});
+
+manager.register({
+  name: 'taskFailed',
+  type: 'task-failed',
+  version: 1,
+  level: 'notice',
+  description: `
+    A task run has been resolved as failed.  This is logged when the task-failed pulse
+    message is sent.`,
+  fields: {
+    taskId: 'The task\'s taskId.',
+    runId: 'The runId that was resolved.',
+  },
+});
+
+manager.register({
+  name: 'taskException',
+  type: 'task-exception',
+  version: 1,
+  level: 'notice',
+  description: `
+    A task run has been resolved as an exception.  This is logged when the task-exception pulse
+    message is sent.`,
+  fields: {
+    taskId: 'The task\'s taskId.',
+    runId: 'The runId that was resolved.',
+  },
+});
+
+manager.register({
+  name: 'taskClaimed',
+  type: 'task-claimed',
+  version: 1,
+  level: 'notice',
+  description: `
+    A worker has claimed a task.  In cases where multple tasks were claimed,
+    one log message will be produced for each task.`,
   fields: {
     provisionerId: 'Provisioner that provisioned the worker claiming work.',
     workerType: 'Type of worker claiming work.',
     workerGroup: 'Group of worker claiming work.',
     workerId: 'The id of the claiming worker.',
-    requested: 'The number of tasks the worker requested.',
-    tasks: 'An array of taskId that were given to the worker.',
+    taskId: 'The task given to the worker.',
+    runId: 'The run of this task assigned to the worker.',
+  },
+});
+
+manager.register({
+  name: 'taskReclaimed',
+  type: 'task-reclaimed',
+  version: 1,
+  level: 'notice',
+  description: `
+    A worker has reclaimed a task it had previously claimed, extending its takenUntil
+    timestamp.`,
+  fields: {
+    workerGroup: 'Group of the reclaiming worker.',
+    workerId: 'Id of the reclaiming worker.',
+    taskId: 'The task being reclaimed.',
+    runId: 'The run of this task being reclaimed.',
   },
 });
 

--- a/services/queue/src/workclaimer.js
+++ b/services/queue/src/workclaimer.js
@@ -280,6 +280,7 @@ class WorkClaimer extends events.EventEmitter {
       workerId: workerId,
       takenUntil: run.takenUntil,
     }, task.routes);
+    this._monitor.log.taskRunning({taskId, runId});
 
     let credentials = taskCreds(
       taskId,

--- a/services/queue/test/claimwork_test.js
+++ b/services/queue/test/claimwork_test.js
@@ -110,6 +110,21 @@ helper.secrets.mockSuite(__filename, ['taskcluster', 'aws', 'azure'], function(m
     // time before the request was made
     assume(takenUntil.getTime()).is.greaterThan(before.getTime() - 1);
 
+    // check that the task was logged
+    assert.deepEqual(helper.monitor.messages.find(({Type}) => Type === 'task-claimed'), {
+      Type: 'task-claimed',
+      Logger: 'taskcluster.queue.root.api',
+      Fields: {
+        provisionerId: "no-provisioner-extended-extended",
+        v: 1,
+        workerGroup: "my-worker-group-extended-extended",
+        workerId: "my-worker-extended-extended",
+        workerType,
+        taskId,
+        runId: 0,
+      },
+    });
+
     // Check that task definition is included..
     assume(r1.tasks[0].task).deep.equals(await helper.queue.task(taskId));
 
@@ -173,6 +188,19 @@ helper.secrets.mockSuite(__filename, ['taskcluster', 'aws', 'azure'], function(m
     let r3 = await queue.reclaimTask(taskId, 0);
     let takenUntil2 = new Date(r3.takenUntil);
     assume(takenUntil2.getTime()).is.greaterThan(takenUntil.getTime() - 1);
+
+    // check that the task was logged
+    assert.deepEqual(helper.monitor.messages.find(({Type}) => Type === 'task-reclaimed'), {
+      Type: 'task-reclaimed',
+      Logger: 'taskcluster.queue.root.api',
+      Fields: {
+        workerGroup: 'my-worker-group-extended-extended',
+        workerId: 'my-worker-extended-extended',
+        taskId,
+        runId: 0,
+        v: 1,
+      },
+    });
 
     debug('### reportCompleted');
     // Report completed with temp creds from reclaimTask

--- a/services/queue/test/createtask_test.js
+++ b/services/queue/test/createtask_test.js
@@ -60,6 +60,18 @@ helper.secrets.mockSuite(__filename, ['taskcluster', 'aws', 'azure'], function(m
     debug('### Create task');
     const r1 = await helper.queue.createTask(taskId, taskDef);
 
+    debug('### Check for log messages');
+    assert.deepEqual(helper.monitor.messages.find(({Type}) => Type === 'task-defined'), {
+      Logger: 'taskcluster.queue.root.api',
+      Type: 'task-defined',
+      Fields: {taskId, v: 1},
+    });
+    assert.deepEqual(helper.monitor.messages.find(({Type}) => Type === 'task-pending'), {
+      Logger: 'taskcluster.queue.root.api',
+      Type: 'task-pending',
+      Fields: {taskId, runId: 0, v: 1},
+    });
+
     debug('### Wait for defined message');
     helper.checkNextMessage('task-defined', m =>
       assume(r1.status).deep.equals(m.payload.status));

--- a/services/queue/test/helper.js
+++ b/services/queue/test/helper.js
@@ -59,6 +59,12 @@ exports.secrets = new Secrets({
 
 helper.rootUrl = 'http://localhost:60401';
 
+// flush the mock log messages for each test case
+setup(async function() {
+  helper.monitor = await helper.load('monitor');
+  helper.monitor.reset();
+});
+
 /**
  * helper.runWithFakeTime(<fn>, <time>), will run async function <fn> for <time>
  * fake milliseconds.  It is intended to wrap the function argument to Mocha's `test`.

--- a/services/queue/test/queueservice_test.js
+++ b/services/queue/test/queueservice_test.js
@@ -7,13 +7,11 @@ const request = require('superagent');
 const debug = require('debug')('test:queueservice');
 const xml2js = require('xml2js');
 const assume = require('assume');
-const MonitorManager = require('taskcluster-lib-monitor');
 const testing = require('taskcluster-lib-testing');
 const helper = require('./helper');
 
 helper.secrets.mockSuite(__filename, ['azure'], function(mock, skipping) {
   let queueService;
-  let monitorManager;
 
   suiteSetup(async () => {
     if (skipping()) {
@@ -21,14 +19,7 @@ helper.secrets.mockSuite(__filename, ['azure'], function(mock, skipping) {
     }
 
     const cfg = await helper.load('cfg');
-
-    monitorManager = new MonitorManager({
-      serviceName: 'test',
-    });
-    monitorManager.setup({
-      enable: false,
-      level: 'warning',
-    });
+    const monitorManager = await helper.load('monitor');
 
     if (mock) {
       queueService = new QueueService({
@@ -60,8 +51,6 @@ helper.secrets.mockSuite(__filename, ['azure'], function(mock, skipping) {
     if (skipping()) {
       return;
     }
-
-    monitorManager.reset();
 
     if (queueService) {
       queueService.terminate();

--- a/services/queue/test/resolvetask_test.js
+++ b/services/queue/test/resolvetask_test.js
@@ -60,6 +60,12 @@ helper.secrets.mockSuite(__filename, ['taskcluster', 'aws', 'azure'], function(m
     helper.checkNextMessage('task-completed', m =>
       assume(m.payload.status.runs[0].state).equals('completed'));
 
+    assert.deepEqual(helper.monitor.messages.find(({Type}) => Type === 'task-completed'), {
+      Logger: 'taskcluster.queue.root.api',
+      Type: 'task-completed',
+      Fields: {taskId, runId: 0, v: 1},
+    });
+
     debug('### Reporting task completed (again)');
     await helper.queue.reportCompleted(taskId, 0);
     // idempotent, but sends the message again..
@@ -95,6 +101,12 @@ helper.secrets.mockSuite(__filename, ['taskcluster', 'aws', 'azure'], function(m
     await helper.queue.reportFailed(taskId, 0);
     helper.checkNextMessage('task-failed', m =>
       assume(m.payload.status.runs[0].state).equals('failed'));
+
+    assert.deepEqual(helper.monitor.messages.find(({Type}) => Type === 'task-failed'), {
+      Logger: 'taskcluster.queue.root.api',
+      Type: 'task-failed',
+      Fields: {taskId, runId: 0, v: 1},
+    });
 
     debug('### Reporting task failed (again)');
     await helper.queue.reportFailed(taskId, 0);
@@ -132,6 +144,12 @@ helper.secrets.mockSuite(__filename, ['taskcluster', 'aws', 'azure'], function(m
     helper.checkNextMessage('task-exception', m => {
       assume(m.payload.status.runs[0].state).equals('exception');
       assume(m.payload.status.runs[0].reasonResolved).equals('malformed-payload');
+    });
+
+    assert.deepEqual(helper.monitor.messages.find(({Type}) => Type === 'task-exception'), {
+      Logger: 'taskcluster.queue.root.api',
+      Type: 'task-exception',
+      Fields: {taskId, runId: 0, v: 1},
     });
 
     debug('### Reporting task exception (again)');


### PR DESCRIPTION
This should allow us to search for `jsonPayload.Fields="<taskId>"` and find all of the interesting bits about a task.

Bugzilla Bug: [1538152](https://bugzilla.mozilla.org/show_bug.cgi?id=1538152)
