### PR TITLE
Update links in documentation

### DIFF
--- a/clients/client/README.md
+++ b/clients/client/README.md
@@ -65,7 +65,7 @@ This replaces any given options with new values.
 
 **NOTE** `PulseListener` is no longer included in `taskcluster-client`;
 instead, use `PulseConsumer` from
-[taskcluster-lib-pulse](https://github.com/taskcluster/tree/master/libraries/pulse).
+[taskcluster-lib-pulse](../../libraries/pulse).
 
 However, this library helpfully includes bindings for exchanges declared by
 various Taskcluster services.  To use these with `taskcluster-lib-pulse`,
@@ -90,7 +90,7 @@ let pc = await pulse.consume({
 
 The set of API entries listed below is generated from the built-in references.
 Detailed documentation with description, payload and result format details is
-available in the [docs reference section](https://github.com/taskcluster/taskcluster/tree/master/libraries/references).
+available in the reference section of the Taskcluster documentation.
 
 On the documentation site, entries have a
 _signature_.  You'll find that it matches the signatures below. Notice that all

--- a/clients/client/README.md
+++ b/clients/client/README.md
@@ -65,7 +65,7 @@ This replaces any given options with new values.
 
 **NOTE** `PulseListener` is no longer included in `taskcluster-client`;
 instead, use `PulseConsumer` from
-[taskcluster-lib-pulse](https://github.com/taskcluster/taskcluster-lib-pulse).
+[taskcluster-lib-pulse](https://github.com/taskcluster/tree/master/libraries/pulse).
 
 However, this library helpfully includes bindings for exchanges declared by
 various Taskcluster services.  To use these with `taskcluster-lib-pulse`,
@@ -90,7 +90,7 @@ let pc = await pulse.consume({
 
 The set of API entries listed below is generated from the built-in references.
 Detailed documentation with description, payload and result format details is
-available in the [docs reference section](https://docs.taskcluster.net/docs/reference).
+available in the [docs reference section](https://github.com/taskcluster/taskcluster/tree/master/libraries/references).
 
 On the documentation site, entries have a
 _signature_.  You'll find that it matches the signatures below. Notice that all

--- a/infrastructure/builder/docs/services.md
+++ b/infrastructure/builder/docs/services.md
@@ -33,7 +33,7 @@ get the (longish) list of `-e` environment variables that must be supplied from 
 
 ## Documentation and Metadata
 
-Services annotated with `docs: generated` in the build spec are expected to produce a documentation directory as defined by [taskcluster-lib-docs](https://github.com/taskcluster/taskcluster/tree/master/libraries/docs) when the `write-docs` component is run:
+Services annotated with `docs: generated` in the build spec are expected to produce a documentation directory as defined by [taskcluster-lib-docs](../../../libraries/docs) when the `write-docs` component is run:
 
 ```
 DOCS_OUTPUT_DIR=/output/docs docker run -v $somepath:/output write-docs

--- a/infrastructure/builder/docs/services.md
+++ b/infrastructure/builder/docs/services.md
@@ -33,7 +33,7 @@ get the (longish) list of `-e` environment variables that must be supplied from 
 
 ## Documentation and Metadata
 
-Services annotated with `docs: generated` in the build spec are expected to produce a documentation directory as defined by [taskcluster-lib-docs](https://github.com/taskcluster/taskcluster-lib-docs) when the `write-docs` component is run:
+Services annotated with `docs: generated` in the build spec are expected to produce a documentation directory as defined by [taskcluster-lib-docs](https://github.com/taskcluster/taskcluster/tree/master/libraries/docs) when the `write-docs` component is run:
 
 ```
 DOCS_OUTPUT_DIR=/output/docs docker run -v $somepath:/output write-docs

--- a/infrastructure/builder/docs/terraform-json.md
+++ b/infrastructure/builder/docs/terraform-json.md
@@ -8,7 +8,7 @@ Terraform.  As such, it complies with Terraform's odd data structure
 requirements.  It contains an object with a single property, `locals`, the
 value of which is an object with string values providing local variables
 expected by the
-[Taskcluster-Terraform](https://github.com/taskcluster/taskcluster/tree/master/infrastructure/terraform)
+[Taskcluster-Terraform](../../terraform)
 deployment system.
 
 In particular, it has properties:

--- a/infrastructure/builder/docs/terraform-json.md
+++ b/infrastructure/builder/docs/terraform-json.md
@@ -8,7 +8,7 @@ Terraform.  As such, it complies with Terraform's odd data structure
 requirements.  It contains an object with a single property, `locals`, the
 value of which is an object with string values providing local variables
 expected by the
-[Taskcluster-Terraform](https://github.com/taskcluster/taskcluster-terraform)
+[Taskcluster-Terraform](https://github.com/taskcluster/taskcluster/tree/master/infrastructure/terraform)
 deployment system.
 
 In particular, it has properties:

--- a/infrastructure/terraform/README.md
+++ b/infrastructure/terraform/README.md
@@ -17,7 +17,7 @@ in the shell you are applying this from.
 ## Requirements not managed here
 
 - A kubernetes cluster
-- An (nginx ingress controller)[https://kubernetes.github.io/ingress-nginx/deploy/] in said cluster
+- An [nginx ingress controller](https://kubernetes.github.io/ingress-nginx/deploy/) in said cluster
 - A TLS secret for the rootUrl hostname in the same Kubernetes namespace as the controller
 - A rabbitmq cluster with the RabbitMQ management plugin enabled
 - An SES email address set up in AWS. This cannot be created automatically by Terraform.

--- a/libraries/api/README.md
+++ b/libraries/api/README.md
@@ -406,7 +406,7 @@ not repeat it!
 
 The `APIBuilder` instance will have an async `build` method that takes additional options and
 returns an API instance which can be passed to
-[taskcluster-lib-app](https://github.com/taskcluster/taskcluster/tree/master/libraries/app).  The
+[taskcluster-lib-app](../app).  The
 options to `builder.build` are:
 
  * `rootUrl` - the root URL for this instance of Taskcluster; this is used both to call the
@@ -417,9 +417,9 @@ options to `builder.build` are:
    specified in `context` when the API was declared.  The purpose of this parameter is to
    provide uesful application-specific objects such as Azure table objects or
    other API clients to the API methods.
- * `monitor` (required) - an instance of [taskcluster-lib-monitor](https://github.com/taskcluster/taskcluster/tree/master/libraries/monitor)
+ * `monitor` (required) - an instance of [taskcluster-lib-monitor](../monitor)
  * `schemaset` (required) - a schemaset; this is from
-   [taskcluster-lib-validate](https://github.com/taskcluster/taskcluster/tree/master/libraries/validate).
+   [taskcluster-lib-validate](../validate).
  * `signatureValidator` - a validator for Hawk signatures; this is only required for
    the Auth service, as the default signature validator consults the Auth service.
  * `nonceManager` - a function to check for replay attacks (seldom used)
@@ -437,7 +437,7 @@ reference data structure, and an `express(app)` method that configures the API
 on the given express app.
 
 For most Taskcluster services, the startup process uses
-[taskcluster-lib-loader](https://github.com/taskcluster/taskcluster/tree/master/libraries/loader),
+[taskcluster-lib-loader](../loader),
 and the relevant loader components are defined like this:
 
 ```js
@@ -477,4 +477,4 @@ It should pass, although some tests will be skipped.
 If you are not modifing functionality tested by the skipped tests you're ready to get started: write some tests for the new functionality, then implement it!
 If you are modifying something requiring credentials, copy `user-config-example.yml` to `user-config.yml` and fill in the necessary credentials based on the comments in that file.
 
-The taskcluster team has a series of [best practices](https://github.com/taskcluster/taskcluster/blob/master/ui/docs/manual/design/devel/best-practices) which may help guide you in modifying the source code and making a pull request.
+The taskcluster team has a series of [best practices](../../ui/docs/manual/design/devel/best-practices) which may help guide you in modifying the source code and making a pull request.

--- a/libraries/api/README.md
+++ b/libraries/api/README.md
@@ -140,7 +140,7 @@ Examples:
 ### Scopes
 
 Scopes should be specified in
-[scope expression form](https://github.com/taskcluster/taskcluster-lib-scopes#new-style).
+[scope expression form](https://github.com/taskcluster/taskcluster/tree/master/libraries/scopes#new-style).
 Parameters are substituted into scopes with `<paramName>`
 syntax.  For example, the following definition allows the method when *either*
 the caller's scopes satisfy `queue:create-task..` for the given `provisionerId`
@@ -406,7 +406,7 @@ not repeat it!
 
 The `APIBuilder` instance will have an async `build` method that takes additional options and
 returns an API instance which can be passed to
-[taskcluster-lib-app](https://github.com/taskcluster/taskcluster-lib-app).  The
+[taskcluster-lib-app](https://github.com/taskcluster/taskcluster/tree/master/libraries/app).  The
 options to `builder.build` are:
 
  * `rootUrl` - the root URL for this instance of Taskcluster; this is used both to call the
@@ -417,9 +417,9 @@ options to `builder.build` are:
    specified in `context` when the API was declared.  The purpose of this parameter is to
    provide uesful application-specific objects such as Azure table objects or
    other API clients to the API methods.
- * `monitor` (required) - an instance of [taskcluster-lib-monitor](https://github.com/taskcluster/taskcluster-lib-monitor)
+ * `monitor` (required) - an instance of [taskcluster-lib-monitor](https://github.com/taskcluster/taskcluster/tree/master/libraries/monitor)
  * `schemaset` (required) - a schemaset; this is from
-   [taskcluster-lib-validate](https://github.com/taskcluster/taskcluster-lib-validate).
+   [taskcluster-lib-validate](https://github.com/taskcluster/taskcluster/tree/master/libraries/validate).
  * `signatureValidator` - a validator for Hawk signatures; this is only required for
    the Auth service, as the default signature validator consults the Auth service.
  * `nonceManager` - a function to check for replay attacks (seldom used)
@@ -437,7 +437,7 @@ reference data structure, and an `express(app)` method that configures the API
 on the given express app.
 
 For most Taskcluster services, the startup process uses
-[taskcluster-lib-loader](https://github.com/taskcluster/taskcluster-lib-loader),
+[taskcluster-lib-loader](https://github.com/taskcluster/taskcluster/tree/master/libraries/loader),
 and the relevant loader components are defined like this:
 
 ```js
@@ -477,4 +477,4 @@ It should pass, although some tests will be skipped.
 If you are not modifing functionality tested by the skipped tests you're ready to get started: write some tests for the new functionality, then implement it!
 If you are modifying something requiring credentials, copy `user-config-example.yml` to `user-config.yml` and fill in the necessary credentials based on the comments in that file.
 
-The taskcluster team has a series of [best practices](/docs/manual/devel/best-practices) which may help guide you in modifying the source code and making a pull request.
+The taskcluster team has a series of [best practices](https://github.com/taskcluster/taskcluster/blob/master/ui/docs/manual/design/devel/best-practices) which may help guide you in modifying the source code and making a pull request.

--- a/libraries/api/README.md
+++ b/libraries/api/README.md
@@ -140,7 +140,7 @@ Examples:
 ### Scopes
 
 Scopes should be specified in
-[scope expression form](https://github.com/taskcluster/taskcluster/tree/master/libraries/scopes#new-style).
+[scope expression form](../scopes#new-style).
 Parameters are substituted into scopes with `<paramName>`
 syntax.  For example, the following definition allows the method when *either*
 the caller's scopes satisfy `queue:create-task..` for the given `provisionerId`

--- a/libraries/app/README.md
+++ b/libraries/app/README.md
@@ -4,7 +4,7 @@ This library supports Taskcluster microservices, providing a pre-built Express
 server based on a common configuration format.
 
 The usage is pretty simple.  It is generally invoked in a
-[taskcluster-lib-loader](https://github.com/taskcluster/taskcluster-lib-loader)
+[taskcluster-lib-loader](https://github.com/taskcluster/taskcluster/tree/master/libraries/loader)
 stanza named server, like this:
 
 ```js
@@ -34,7 +34,7 @@ The configuration (here `cfg.server`) has the following options:
  * `robotsTxt`: include a /robots.txt; *default is true*
 
 The values of the `apis` key are from
-[taskcluster-lib-api](https://github.com/taskcluster/taskcluster-lib-api); each
+[taskcluster-lib-api](https://github.com/taskcluster/taskcluster/tree/master/libraries/api); each
 is the result of the `APIBuilder.build` method in that library. In particular,
 each object should have an `express(app)` method which configures an Express
 app for the API.

--- a/libraries/app/README.md
+++ b/libraries/app/README.md
@@ -4,7 +4,7 @@ This library supports Taskcluster microservices, providing a pre-built Express
 server based on a common configuration format.
 
 The usage is pretty simple.  It is generally invoked in a
-[taskcluster-lib-loader](https://github.com/taskcluster/taskcluster/tree/master/libraries/loader)
+[taskcluster-lib-loader](../loader)
 stanza named server, like this:
 
 ```js
@@ -34,7 +34,7 @@ The configuration (here `cfg.server`) has the following options:
  * `robotsTxt`: include a /robots.txt; *default is true*
 
 The values of the `apis` key are from
-[taskcluster-lib-api](https://github.com/taskcluster/taskcluster/tree/master/libraries/api); each
+[taskcluster-lib-api](../api); each
 is the result of the `APIBuilder.build` method in that library. In particular,
 each object should have an `express(app)` method which configures an Express
 app for the API.

--- a/libraries/docs/README.md
+++ b/libraries/docs/README.md
@@ -33,21 +33,21 @@ production service starts up.  The tarball contains a mixture of documentation
 from the project's README, auto-generated documentation for pulse exchanges and
 APIs, and hand-written documentation.
 
-The [taskcluster-docs](https://github.com/taskcluster/taskcluster/blob/master/libraries/docs/docs/) project
+The [taskcluster-docs](/docs/) project
 then downloads those tarballs and incorporates the results into the
 documentation page.
 
 Documentation Format
 --------------------
 
-The format for the tarball that is uploaded to s3 is [documented here](https://github.com/taskcluster/taskcluster/blob/master/libraries/docs/docs/format.md).
+The format for the tarball that is uploaded to s3 is [documented here](/docs/format.md).
 
 Usage
 -----
 
 **[Old Way Only] Do not forget to add the scopes before pushing your service to production! `[auth:aws-s3:read-write:taskcluster-raw-docs/<project>/]`**
 
-This library should be included as a component in a [Taskcluster Component Loader](https://github.com/taskcluster/taskcluster/tree/master/libraries/loader)
+This library should be included as a component in a [Taskcluster Component Loader](../loader)
 setup so that it is called upon a service starting in Heroku or as a post-publish step in a library. Options and defaults are listed
 below.
 

--- a/libraries/docs/README.md
+++ b/libraries/docs/README.md
@@ -33,21 +33,21 @@ production service starts up.  The tarball contains a mixture of documentation
 from the project's README, auto-generated documentation for pulse exchanges and
 APIs, and hand-written documentation.
 
-The [taskcluster-docs](https://github.com/taskcluster/taskcluster-docs) project
+The [taskcluster-docs](https://github.com/taskcluster/taskcluster/blob/master/libraries/docs/docs/) project
 then downloads those tarballs and incorporates the results into the
 documentation page.
 
 Documentation Format
 --------------------
 
-The format for the tarball that is uploaded to s3 is [documented here](https://github.com/taskcluster/taskcluster-lib-docs/blob/master/docs/format.md).
+The format for the tarball that is uploaded to s3 is [documented here](https://github.com/taskcluster/taskcluster/blob/master/libraries/docs/docs/format.md).
 
 Usage
 -----
 
 **[Old Way Only] Do not forget to add the scopes before pushing your service to production! `[auth:aws-s3:read-write:taskcluster-raw-docs/<project>/]`**
 
-This library should be included as a component in a [Taskcluster Component Loader](https://github.com/taskcluster/taskcluster-lib-loader)
+This library should be included as a component in a [Taskcluster Component Loader](https://github.com/taskcluster/taskcluster/tree/master/libraries/loader)
 setup so that it is called upon a service starting in Heroku or as a post-publish step in a library. Options and defaults are listed
 below.
 

--- a/libraries/docs/README.md
+++ b/libraries/docs/README.md
@@ -33,14 +33,14 @@ production service starts up.  The tarball contains a mixture of documentation
 from the project's README, auto-generated documentation for pulse exchanges and
 APIs, and hand-written documentation.
 
-The [taskcluster-docs](/docs/) project
+The [taskcluster-docs](docs/) project
 then downloads those tarballs and incorporates the results into the
 documentation page.
 
 Documentation Format
 --------------------
 
-The format for the tarball that is uploaded to s3 is [documented here](/docs/format.md).
+The format for the tarball that is uploaded to s3 is [documented here](docs/format.md).
 
 Usage
 -----

--- a/libraries/pulse/README.md
+++ b/libraries/pulse/README.md
@@ -1,7 +1,7 @@
 # Pulse Library
 
 Library for interacting with Pulse and Taskcluster-Pulse.  See [the
-docs](https://github.com/taskcluster/taskcluster/blob/doc/ui/docs/manual/design/apis/pulse.md) for more
+docs](../../ui/docs/manual/design/apis/pulse.md) for more
 information on Pulse.
 
 This library is designed for use in Taskcluster services, both for producing
@@ -365,7 +365,7 @@ support for sending messages is quite simple, but this component also handles
 declaring exchanges, message schemas, and so on, and producing a reference
 document that can be consumed by client libraries to generate easy-to-use
 clients. All of this is similar to what
-[taskcluster-lib-api](https://github.com/taskcluster/taskcluster/tree/master/libraries/api) does
+[taskcluster-lib-api](../api) does
 for HTTP APIs.
 
 ## Declaring Exchanges

--- a/libraries/pulse/README.md
+++ b/libraries/pulse/README.md
@@ -1,7 +1,7 @@
 # Pulse Library
 
 Library for interacting with Pulse and Taskcluster-Pulse.  See [the
-docs](https://docs.taskcluster.net/manual/design/apis/pulse) for more
+docs](https://github.com/taskcluster/taskcluster/blob/doc/ui/docs/manual/design/apis/pulse.md) for more
 information on Pulse.
 
 This library is designed for use in Taskcluster services, both for producing
@@ -365,7 +365,7 @@ support for sending messages is quite simple, but this component also handles
 declaring exchanges, message schemas, and so on, and producing a reference
 document that can be consumed by client libraries to generate easy-to-use
 clients. All of this is similar to what
-[taskcluster-lib-api](https://github.com/taskcluster/taskcluster-lib-api) does
+[taskcluster-lib-api](https://github.com/taskcluster/taskcluster/tree/master/libraries/api) does
 for HTTP APIs.
 
 ## Declaring Exchanges
@@ -389,11 +389,11 @@ const exchanges = new Exchanges({
 ```
 
 The `serviceName` should match that passed to
-[taskcluster-lib-validate](https://github.com/taskcluster/taskcluster-lib-validate).
+[taskcluster-lib-validate](https://github.com/taskcluster/taskcluster/tree/master/libraries/validate).
 The `projectName` is used to construct exchange and queue names.  It should
 match the pulse namespace (at least in production deployments) and the name
 passed to
-[taskcluster-lib-monitor](https://github.com/taskcluster/taskcluster-lib-monitor),
+[taskcluster-lib-monitor](https://github.com/taskcluster/taskcluster/tree/master/libraries/monitor),
 
 Having created the `exchanges` instance, declare exchanges on it:
 
@@ -472,7 +472,7 @@ By convention, these are prefixed with `route.`.
 The `exchanges.reference()` method will return a reference document suitable
 for publication under `<rootUrl>/references`.
 
-This is typically passed to [taskcluster-lib-docs](https://github.com/taskcluster/taskcluster-lib-docs) like this:
+This is typically passed to [taskcluster-lib-docs](https://github.com/taskcluster/taskcluster/tree/master/libraries/docs) like this:
 
 ```javascript
 Docs.documenter({

--- a/libraries/pulse/README.md
+++ b/libraries/pulse/README.md
@@ -389,11 +389,11 @@ const exchanges = new Exchanges({
 ```
 
 The `serviceName` should match that passed to
-[taskcluster-lib-validate](https://github.com/taskcluster/taskcluster/tree/master/libraries/validate).
+[taskcluster-lib-validate](../validate).
 The `projectName` is used to construct exchange and queue names.  It should
 match the pulse namespace (at least in production deployments) and the name
 passed to
-[taskcluster-lib-monitor](https://github.com/taskcluster/taskcluster/tree/master/libraries/monitor),
+[taskcluster-lib-monitor](../monitor),
 
 Having created the `exchanges` instance, declare exchanges on it:
 
@@ -472,7 +472,7 @@ By convention, these are prefixed with `route.`.
 The `exchanges.reference()` method will return a reference document suitable
 for publication under `<rootUrl>/references`.
 
-This is typically passed to [taskcluster-lib-docs](https://github.com/taskcluster/taskcluster/tree/master/libraries/docs) like this:
+This is typically passed to [taskcluster-lib-docs](../docs) like this:
 
 ```javascript
 Docs.documenter({

--- a/libraries/references/README.md
+++ b/libraries/references/README.md
@@ -14,7 +14,7 @@ meta-schemas under `schemas/`.
 ## Built Services
 
 This input format corresponds to a directory structure built by
-[taskcluster-builder](https://github.com/taskcluster/taskcluster/tree/master/infrastructure/builder)
+[taskcluster-builder](../../infrastructure/builder)
 during the cluster build process:
 
 ```
@@ -32,7 +32,7 @@ during the cluster build process:
 ```
 
 This is a subset of the
-[taskcluster-lib-docs](https://github.com/taskcluster/taskcluster/tree/master/libraries/loader)
+[taskcluster-lib-docs](../docs)
 documentation tarball format, and `metadata.json` is defined there.  The
 library will in fact load any `.json` files in `references` and interpret them
 according to their schema.  So, the `$schema` property of every file in

--- a/libraries/references/README.md
+++ b/libraries/references/README.md
@@ -14,7 +14,7 @@ meta-schemas under `schemas/`.
 ## Built Services
 
 This input format corresponds to a directory structure built by
-[taskcluster-builder](https://github.com/taskcluster/taskcluster-builder)
+[taskcluster-builder](https://github.com/taskcluster/taskcluster/tree/master/infrastructure/builder)
 during the cluster build process:
 
 ```
@@ -32,7 +32,7 @@ during the cluster build process:
 ```
 
 This is a subset of the
-[taskcluster-lib-docs](https://github.com/taskcluster/taskcluster-lib-docs)
+[taskcluster-lib-docs](https://github.com/taskcluster/taskcluster/tree/master/libraries/loader)
 documentation tarball format, and `metadata.json` is defined there.  The
 library will in fact load any `.json` files in `references` and interpret them
 according to their schema.  So, the `$schema` property of every file in

--- a/libraries/scopes/README.md
+++ b/libraries/scopes/README.md
@@ -2,7 +2,7 @@
 
 Simple utilities to validate scopes, scope-sets, and scope-expression satisfiability.
 
-For information on scopes, see [the Taskcluster documentation](https://github.com/taskcluster/taskcluster/blob/master/ui/docs/manual/design/apis/hawk/scopes.md).
+For information on scopes, see [the Taskcluster documentation](../../ui/docs/manual/design/apis/hawk/scopes.md).
 
 ## Usage
 

--- a/libraries/scopes/README.md
+++ b/libraries/scopes/README.md
@@ -2,7 +2,7 @@
 
 Simple utilities to validate scopes, scope-sets, and scope-expression satisfiability.
 
-For information on scopes, see [the Taskcluster documentation](/docs/manual/integrations/apis/scopes).
+For information on scopes, see [the Taskcluster documentation](https://github.com/taskcluster/taskcluster/blob/master/ui/docs/manual/design/apis/hawk/scopes.md).
 
 ## Usage
 

--- a/libraries/testing/README.md
+++ b/libraries/testing/README.md
@@ -280,7 +280,7 @@ Test schemas with a positive and negative test cases.
 The method should be called within a `suite`, as it will call the mocha `test`
 function to define a test for each schema case.
 
- * `schemasetOptions` - {}  // options to pass to the [taskcluster-lib-validate](https://github.com/taskcluster/taskcluster/tree/master/libraries/validate) constructor
+ * `schemasetOptions` - {}  // options to pass to the [taskcluster-lib-validate](../validate) constructor
  * `cases` - array of test cases
  * `basePath` -  base path for relative pathnames in test cases (default `path.join(__dirname, 'validate')`)
 

--- a/libraries/testing/README.md
+++ b/libraries/testing/README.md
@@ -280,7 +280,7 @@ Test schemas with a positive and negative test cases.
 The method should be called within a `suite`, as it will call the mocha `test`
 function to define a test for each schema case.
 
- * `schemasetOptions` - {}  // options to pass to the [taskcluster-lib-validate](https://github.com/taskcluster/taskcluster-lib-validate) constructor
+ * `schemasetOptions` - {}  // options to pass to the [taskcluster-lib-validate](https://github.com/taskcluster/taskcluster/tree/master/libraries/validate) constructor
  * `cases` - array of test cases
  * `basePath` -  base path for relative pathnames in test cases (default `path.join(__dirname, 'validate')`)
 

--- a/services/auth/README.md
+++ b/services/auth/README.md
@@ -36,4 +36,4 @@ To do so, copy `user-config-example.yml` to `user-config.yml` and fill in the ne
 Taskcluster team members can provide you with some testing-only credentials -- just ask, and provide a GPG key (use https://keybase.io if you don't have one).
 You can get your own pulse credentials at https://pulseguardian.mozilla.org.
 
-The taskcluster team has a series of [best practices](https://github.com/taskcluster/taskcluster/tree/master/dev-docs) which may help guide you in modifying the source code and making a pull request.
+The taskcluster team has a series of [best practices](../../dev-docs/best-practices) which may help guide you in modifying the source code and making a pull request.

--- a/services/auth/README.md
+++ b/services/auth/README.md
@@ -36,4 +36,4 @@ To do so, copy `user-config-example.yml` to `user-config.yml` and fill in the ne
 Taskcluster team members can provide you with some testing-only credentials -- just ask, and provide a GPG key (use https://keybase.io if you don't have one).
 You can get your own pulse credentials at https://pulseguardian.mozilla.org.
 
-The taskcluster team has a series of [best practices](/docs/manual/devel/best-practices) which may help guide you in modifying the source code and making a pull request.
+The taskcluster team has a series of [best practices](https://github.com/taskcluster/taskcluster/tree/master/dev-docs) which may help guide you in modifying the source code and making a pull request.

--- a/services/treeherder/README.md
+++ b/services/treeherder/README.md
@@ -26,7 +26,7 @@ All jobs that are reported to Treeherder must have some basic information about 
 itself, such as job symbol, job name, platform, etc.
 
 This configuration needs to be declared in the task definition under `task.extra.treeherder`
-and is validated against a [published schema](https://schemas.taskcluster.net/treeherder/v1/task-treeherder-config.json#).
+and is validated against a [published schema](https://github.com/taskcluster/taskcluster/blob/master/services/treeherder/schemas/v1/task-treeherder-config.yml).
 
 ## Example  Task
 
@@ -82,7 +82,7 @@ messages that are concerned about, such as only a particular destination
 
 ## Schema
 
-All jobs messages must validate against a [published schema](https://schemas.taskcluster.net/treeherder/v1/pulse-job.json#).
+All jobs messages must validate against a [published schema](https://github.com/taskcluster/taskcluster/blob/master/services/treeherder/schemas/v1/pulse-job.yml).
 Any jobs that do not match this schema will be reported in the application logs and
 an administrator of the application can review the logs if a job is not appearing
 on the pulse exchange.

--- a/services/treeherder/README.md
+++ b/services/treeherder/README.md
@@ -82,7 +82,7 @@ messages that are concerned about, such as only a particular destination
 
 ## Schema
 
-All jobs messages must validate against a [published schema](v1/pulse-job.yml).
+All jobs messages must validate against a [published schema](schemas/v1/pulse-job.yml).
 Any jobs that do not match this schema will be reported in the application logs and
 an administrator of the application can review the logs if a job is not appearing
 on the pulse exchange.

--- a/services/treeherder/README.md
+++ b/services/treeherder/README.md
@@ -26,7 +26,7 @@ All jobs that are reported to Treeherder must have some basic information about 
 itself, such as job symbol, job name, platform, etc.
 
 This configuration needs to be declared in the task definition under `task.extra.treeherder`
-and is validated against a [published schema](https://github.com/taskcluster/taskcluster/blob/master/services/treeherder/schemas/v1/task-treeherder-config.yml).
+and is validated against a [published schema](schemas/v1/task-treeherder-config.yml).
 
 ## Example  Task
 
@@ -82,7 +82,7 @@ messages that are concerned about, such as only a particular destination
 
 ## Schema
 
-All jobs messages must validate against a [published schema](https://github.com/taskcluster/taskcluster/blob/master/services/treeherder/schemas/v1/pulse-job.yml).
+All jobs messages must validate against a [published schema](v1/pulse-job.yml).
 Any jobs that do not match this schema will be reported in the application logs and
 an administrator of the application can review the logs if a job is not appearing
 on the pulse exchange.

--- a/services/web-server/README.md
+++ b/services/web-server/README.md
@@ -11,7 +11,7 @@ by the web application.
 
 ## Configuration
 
-Configuration is done via [taskcluster-lib-config](https://github.com/taskcluster/taskcluster/tree/master/libraries/loader) like all
+Configuration is done via [taskcluster-lib-config](../../libraries/config) like all
 other Taskcluster services. The main configuration file is `config.yml`, and
 that refers to environment variables.  In production, those environment
 variables are provided as part of the deployment.  During development,

--- a/services/web-server/README.md
+++ b/services/web-server/README.md
@@ -11,7 +11,7 @@ by the web application.
 
 ## Configuration
 
-Configuration is done via [taskcluster-lib-config](/librarices/config) like all
+Configuration is done via [taskcluster-lib-config](https://github.com/taskcluster/taskcluster/tree/master/libraries/loader) like all
 other Taskcluster services. The main configuration file is `config.yml`, and
 that refers to environment variables.  In production, those environment
 variables are provided as part of the deployment.  During development,


### PR DESCRIPTION
Almost all links are updated ! Still a second cross check would be helpful!
https://github.com/taskcluster/taskcluster-lib-azure/releases in azure README.md
https://github.com/taskcluster/schema-validator-publisher/blob/master/package.json in valida README.md
these links are still need to be updated ! couldn't find the updated links!