### PR TITLE
Bug 1536863 - be a little more flexible in reading the chimeric Auth0 profiles

### DIFF
--- a/services/login/src/handlers/mozilla-auth0.js
+++ b/services/login/src/handlers/mozilla-auth0.js
@@ -169,9 +169,12 @@ class Handler {
       for (let {provider, connection, profileData} of profile.identities) {
         if (provider === 'oauth2' && connection === 'firefoxaccounts') {
           // we expect the auth0 user_id to be `oauth|firefoxaccounts|<fxa_sub>`
-          assert(user_id.endsWith(profileData.fxa_sub),
+          // sometimes fxa_sub is on profileData, sometimes on the profile
+          const fxa_sub = profileData ? profileData.fxa_sub : profile.fxa_sub;
+          assert(user_id.endsWith(fxa_sub),
             `Auth0 user_id ${user_id} not formatted as expected`);
-          identity += `|${profileData.email}`;
+          const email = profileData ? profileData.email : profile.email;
+          identity += `|${email}`;
           break;
         }
       }

--- a/services/login/test/handlers_mozilla_auth0_test.js
+++ b/services/login/test/handlers_mozilla_auth0_test.js
@@ -21,8 +21,7 @@ suite('handlers/mozilla-auth0', function() {
     const identities = [
       {provider: 'ad', connection: 'Mozilla-LDAP'},
       {provider: 'github', connection: 'github', user_id: 1234},
-      {provider: 'oauth2', connection: 'firefoxaccounts',
-        profileData: {fxa_sub: 'abcdef', email: 'rockets@ksc'}},
+      {provider: 'oauth2', connection: 'firefoxaccounts'},
       {provider: 'email', connection: 'email', user_id: 'slashy/slashy'},
     ];
     return {
@@ -42,6 +41,8 @@ suite('handlers/mozilla-auth0', function() {
         case 'oauth2|firefoxaccounts|abcdef':
           return {
             user_id: 'oauth2|firefoxaccounts|abcdef',
+            email: 'rockets@ksc',
+            fxa_sub: 'abcdef',
             identities,
           };
         case 'email|slashy/slashy':


### PR DESCRIPTION
This is sort of sticking our fingers in our ears and hoping it keeps working.  The new implementation in web-server will, I hope, use the People API, and hopefully that's a bit more stable.

Bugzilla Bug: [1536863](https://bugzilla.mozilla.org/show_bug.cgi?id=1536863)
