### PR TITLE
Add GCP provider object. Implement listWorkers method

### DIFF
--- a/services/worker-manager/package.json
+++ b/services/worker-manager/package.json
@@ -16,6 +16,7 @@
     "test": "mocha test/*_test.js test/bidding-strategies/*_test.js"
   },
   "dependencies": {
+    "@google-cloud/compute": "^0.12.0",
     "array.prototype.flat": "^1.2.1",
     "array.prototype.flatmap": "^1.2.1",
     "moment": "^2.22.2"

--- a/services/worker-manager/src/main.js
+++ b/services/worker-manager/src/main.js
@@ -97,26 +97,26 @@ let load = loader({
   providers: {
     requires: ['cfg'],
     setup: async ({cfg}) => {
-      let providers = [];
+      let p = new Map();
       for (let x of cfg.providers) {
         let providerClass = Provider.load(x.className);
         let provider = new providerClass(...x.args);
-        providers.push(provider);
+        p.set(provider.id, provider);
       }
-      return providers;
+      return p;
     },
   },
 
   biddingStrategies: {
     requires: ['cfg'],
     setup: async ({cfg}) => {
-      let biddingStrategies = [];
+      let bs = new Map();
       for (let x of cfg.biddingStrategies) {
         let biddingStrategyClass = BiddingStrategy.load(x.className);
         let biddingStrategy = new biddingStrategyClass(...x.args);
-        biddingStrategies.push(biddingStrategy);
+        bs.set(biddingStrategy.id, biddingStrategy);
       }
-      return biddingStrategies;
+      return bs;
     },
   },
 

--- a/services/worker-manager/src/providers/gcpprovider.js
+++ b/services/worker-manager/src/providers/gcpprovider.js
@@ -1,0 +1,175 @@
+'use strict';
+
+const {Bid} = require('../bid');
+const {Provider} = require('../provider');
+const Worker = require('../worker');
+const Compute = require('@google-cloud/compute');
+
+class GCPProvider extends Provider {
+
+  /**
+   * Construct a GCP Provider
+   */
+  constructor({id}) {
+    super({id});
+    this.gcpCompute = new Compute();
+  }
+
+  convertToGCPStatus(taskclusterWorkerState) {
+    switch (taskclusterWorkerState) {
+      case Provider.states.booting: return ['STAGING'];
+      case Provider.states.requested: return ['PROVISIONING'];
+      case Provider.states.running: return ['RUNNING'];
+      case Provider.states.terminating: return ['STOPPING', 'SUSPENDING', 'SUSPENDED', 'TERMINATED'];
+    }
+  }
+
+  convertFromGCPStatus(gcpInstanceStatus) {
+    switch (gcpInstanceStatus) {
+      case 'PROVISIONING': return Provider.states.requested;
+      case 'STAGING': return Provider.states.requested;
+      case 'RUNNING': return Provider.states.running;
+      case 'STOPPING': return Provider.states.terminating;
+      case 'SUSPENDING': return Provider.states.terminating;
+      case 'SUSPENDED': return Provider.states.terminating;
+      case 'TERMINATED': return Provider.states.terminating;
+    }
+  }
+
+  /**
+   * this is called in provisioner
+   *
+   * @param states Array<String>
+   * @param workerTypes Array<String>
+   * @returns {Promise<Array<Worker>>}
+   */
+  async listWorkers({states, workerTypes}) {
+    console.log(`Got states: ${states}, and worker types: ${workerTypes}`);
+
+    let filter = workerTypes.map(wt => `(labels.worker-type = ${wt})`).join(' OR ');
+
+    const instances = (await this.gcpCompute.getVMs({
+      autoPaginate: false,
+      filter,
+    }))[0]
+      .filter(i => states.includes(this.convertFromGCPStatus(i.metadata.status)));
+
+    return instances.map(i => new Worker({
+      id: i.id, // i.id same as i.name (must be unique); i.metadata.id is numerical id of the instance
+      group: i.zone.id,
+      workerType: i.metadata.labels['worker-type'],
+      state: this.convertFromGCPStatus(i.metadata.status),
+      capacity: 1,
+      workerConfigurationId: i.metadata.labels['worker-configuration-id'],
+      providerData: {}, // todo I am not sure what provider data is supposed to be
+    }));
+  }
+
+  async queryWorkerState({workerId}) {
+    console.log(`Got worker id: ${workerId}`);
+    return 'This should be a string';
+  }
+
+  /**
+   * I'm not sure why this isn't async
+   * @param worker
+   */
+  workerInfo({worker}) {
+    console.log(`Got worker: ${worker}`);
+    return {};
+  }
+
+  async initiate() {
+    console.log('😳');
+  }
+
+  async terminate() {
+    console.log('😷');
+  }
+
+  /**
+   * This is called in provisioner
+   *
+   * @param workerType String
+   * @param workerConfiguration Proxy<WorkerConfiguration>
+   * @param demand Number
+   * @returns {Promise<Array<Bid>>}
+   */
+  async proposeBids({workerType, workerConfiguration, demand}) {
+    console.log(`Got worker type: ${workerType}, worker config: ${JSON.stringify(workerConfiguration, null, 2)}, demand: ${demand}`);
+
+    const expires = new Date();
+    expires.setDate(expires.getDate() + 1);
+
+    // get list of available workers from gcp
+
+    //
+
+    return [
+      new Bid({
+        providerId: this.id,
+        workerType: '',
+        workerConfigurationId: workerConfiguration.id,
+        expires,
+        price: 1, // for now hardcode
+        capacity: 2, // divisor for price
+        utilityFactor: 3, // some multiplier, not sure where would come from
+        firm: false, // true if it's smth like EC2 Reserved Instance
+        reliability: 1, // some number ???
+        estimatedDelay: 1, // this can be some static value
+      }),
+    ];
+  }
+
+  /**
+   * This is called in the provisioner
+   *
+   * @param Array<Bid> (accepted bids for this provider)
+   * @returns void
+   */
+  async submitBids({bids}) {
+    console.log(`Got bids: ${bids}. Submitting...`);
+  }
+
+  /**
+   * This is called in provisioner. Actually seems to be optional to implement
+   *
+   * @param bids Array<Bid> (all the bids are for this provider)
+   * @returns void
+   */
+  async rejectBids({bids}) {
+    console.log(`Got bids: ${bids}. Rejecting...`);
+  }
+
+  /**
+   * This method must not return until the request to terminate all workers is completed.
+   * @returns {Promise<void>}
+   */
+  async terminateAllWorkers() {
+    console.log(`Terminating workers... Please hold`);
+    return;
+  }
+
+  /**
+   *
+   * @param workerType
+   * @returns {Promise<void>}
+   */
+  async terminateWorkerType({workerType}) {
+    console.log(`Got worker type: ${workerType}. Terminating`);
+  }
+
+  /**
+   *
+   * @param workers
+   * @returns {Promise<void>}
+   */
+  async terminateWorkers({workers}) {
+    console.log(`Got workers: ${workers}. Terminating...`);
+  }
+
+}
+
+module.exports = {
+  GCPProvider,
+};

--- a/services/worker-manager/src/worker.js
+++ b/services/worker-manager/src/worker.js
@@ -38,12 +38,12 @@ class Worker extends WMObject {
     if (typeof capacity !== 'number') {
       this._throw(errors.InvalidWorker, 'capacity must be number');
     }
-    this.this.capacity = capacity;
+    this.capacity = capacity;
 
     if (typeof providerData !== 'object') {
       this._throw(errors.InvalidWorker, 'providerData must be an object');
     }
-    this.this.providerData = providerData;
+    this.providerData = providerData;
   }
 }
 


### PR DESCRIPTION
<!-- If this is related to a Bugzilla bug, please begin your title with [Bug XXXXX] and update the following link. -->
<!-- If there is no bug, consider making one and if you really don't want one, remove the link. -->

<!-- Include any other context you wish here. -->

Bugzilla Bug: [1487699](https://bugzilla.mozilla.org/show_bug.cgi?id=1487699)

Feedback I am looking for and questions I am having:

1. Should I add objects for AWS and packet.net, and work on all three in parallel? For example, after this PR I would make a similar PR (object + `listWorkers` method) for AWS and packet.net. Or is it better to finish GCP object first?

2. Please look at creation of Worker objects - does the information I get into it make sense?

3. What on Earth is `providerData`?

4. Is it even a thing, a worker of capacity > 1? If not, maybe just remove the `capacity` prop from Worker objects?

Nota bene: I am not adding tests at this point, because it's unclear to me whether any redesign is happening, and they are just not too useful at the moment. My messy working branch (can be observed here #431) has some hint on the tests, but I am not writing them at this point

Also, linter here is failing, but if this #529 is approved, it won't be ^__^