### PR TITLE
Stop using the promise dependency

### DIFF
--- a/clients/client/package.json
+++ b/clients/client/package.json
@@ -13,7 +13,6 @@
     "debug": "^4.0.0",
     "hawk": "^7.0.10",
     "lodash": "^4.17.4",
-    "promise": "^8.0.1",
     "slugid": "^2.0.0",
     "superagent": "^5.0.0",
     "taskcluster-lib-urls": "^12.0.0"

--- a/clients/client/src/client.js
+++ b/clients/client/src/client.js
@@ -12,7 +12,6 @@ let crypto = require('crypto');
 let slugid = require('slugid');
 let http = require('http');
 let https = require('https');
-let Promise = require('promise');
 let querystring = require('querystring');
 let tcUrl = require('taskcluster-lib-urls');
 

--- a/libraries/api/test/noncemanager_test.js
+++ b/libraries/api/test/noncemanager_test.js
@@ -1,6 +1,5 @@
 const API = require('../src/api');
 const assert = require('assert');
-const Promise = require('promise');
 const debug = require('debug')('base:test:nonceManager');
 const testing = require('taskcluster-lib-testing');
 

--- a/libraries/app/src/index.js
+++ b/libraries/app/src/index.js
@@ -3,7 +3,6 @@ let _ = require('lodash');
 let debug = require('debug')('base:app');
 let assert = require('assert');
 let morganDebug = require('morgan-debug');
-let Promise = require('promise');
 let http = require('http');
 let sslify = require('express-sslify');
 let hsts = require('hsts');

--- a/libraries/testing/test/fakeauth_test.js
+++ b/libraries/testing/test/fakeauth_test.js
@@ -7,7 +7,6 @@ const MonitorManager = require('taskcluster-lib-monitor');
 const App = require('taskcluster-lib-app');
 const assert = require('assert');
 const taskcluster = require('taskcluster-client');
-const Promise = require('promise');
 const path = require('path');
 const libUrls = require('taskcluster-lib-urls');
 const testing = require('taskcluster-lib-testing');

--- a/libraries/validate/src/publish.js
+++ b/libraries/validate/src/publish.js
@@ -1,7 +1,6 @@
 const _ = require('lodash');
 const assert = require('assert');
 const debug = require('debug')('taskcluster-lib-validate');
-const Promise = require('promise');
 const fs = require('fs');
 const path = require('path');
 const mkdirp = require('mkdirp');

--- a/package.json
+++ b/package.json
@@ -73,7 +73,6 @@
     "nodemailer": "^6.0.0",
     "passport": "^0.4.0",
     "passport-github": "^1.1.0",
-    "promise": "^8.0.1",
     "promisepipe": "^3.0.0",
     "quick-lru": "^4.0.0",
     "ramda": "^0.26.0",

--- a/services/hooks/src/data.js
+++ b/services/hooks/src/data.js
@@ -1,5 +1,4 @@
 const Entity = require('azure-entities');
-const Promise = require('promise');
 const _ = require('lodash');
 
 /** Entity for tracking hooks and associated state **/

--- a/services/hooks/src/scheduler.js
+++ b/services/hooks/src/scheduler.js
@@ -3,7 +3,6 @@ const events = require('events');
 const Entity = require('azure-entities');
 const data = require('./data');
 const debug = require('debug')('hooks:scheduler');
-const Promise = require('promise');
 const taskcluster = require('taskcluster-client');
 const nextDate = require('./nextdate');
 const taskcreator = require('./taskcreator');

--- a/yarn.lock
+++ b/yarn.lock
@@ -9005,51 +9005,56 @@ tar@^4:
     yallist "^3.0.2"
 
 "taskcluster-client@link:clients/client":
-  version "13.0.0"
-  dependencies:
-    debug "^4.0.0"
-    hawk "^7.0.10"
-    lodash "^4.17.4"
-    promise "^8.0.1"
-    slugid "^2.0.0"
-    superagent "^5.0.0"
-    taskcluster-lib-urls "^12.0.0"
+  version "0.0.0"
+  uid ""
 
 "taskcluster-lib-api@link:libraries/api":
-  version "12.8.1"
+  version "0.0.0"
+  uid ""
 
 "taskcluster-lib-app@link:libraries/app":
-  version "10.2.0"
+  version "0.0.0"
+  uid ""
 
 "taskcluster-lib-azure@link:libraries/azure":
-  version "10.0.0"
+  version "0.0.0"
+  uid ""
 
 "taskcluster-lib-config@link:libraries/config":
-  version "3.0.0"
+  version "0.0.0"
+  uid ""
 
 "taskcluster-lib-docs@link:libraries/docs":
-  version "11.0.0"
+  version "0.0.0"
+  uid ""
 
 "taskcluster-lib-iterate@link:libraries/iterate":
-  version "11.0.0"
+  version "0.0.0"
+  uid ""
 
 "taskcluster-lib-loader@link:libraries/loader":
-  version "11.0.0"
+  version "0.0.0"
+  uid ""
 
 "taskcluster-lib-monitor@link:libraries/monitor":
-  version "11.1.1"
+  version "0.0.0"
+  uid ""
 
 "taskcluster-lib-pulse@link:libraries/pulse":
-  version "11.1.1"
+  version "0.0.0"
+  uid ""
 
 "taskcluster-lib-references@link:libraries/references":
-  version "1.5.0"
+  version "0.0.0"
+  uid ""
 
 "taskcluster-lib-scopes@link:libraries/scopes":
-  version "10.0.1"
+  version "0.0.0"
+  uid ""
 
 "taskcluster-lib-testing@link:libraries/testing":
-  version "12.1.2"
+  version "0.0.0"
+  uid ""
 
 taskcluster-lib-urls@^12.0.0:
   version "12.0.0"
@@ -9057,7 +9062,8 @@ taskcluster-lib-urls@^12.0.0:
   integrity sha512-OrEFE0m3p/+mGsmIwjttLhSKg3io6MpJLhYtPNjVSZA9Ix8Y5tprN3vM6a3MjWt5asPF6AKZsfT43cgpGwJB0g==
 
 "taskcluster-lib-validate@link:libraries/validate":
-  version "12.0.0"
+  version "0.0.0"
+  uid ""
 
 taskgroup@^4.0.5, taskgroup@^4.2.0:
   version "4.3.1"


### PR DESCRIPTION
Since Node 0.12, Promise has been built-in and available as a global.

For a while, we used a Promise library because `Promise.race` was not
available.  It is available now.