### PR TITLE
Task Group UX (breadcrumbs, hide metadata)

### DIFF
--- a/ui/src/components/Breadcrumbs/index.jsx
+++ b/ui/src/components/Breadcrumbs/index.jsx
@@ -1,0 +1,44 @@
+import React, { Component } from 'react';
+import { node, object } from 'prop-types';
+import classNames from 'classnames';
+import { omit } from 'ramda';
+import { withStyles } from '@material-ui/core/styles';
+import Paper from '@material-ui/core/Paper';
+import MuiBreadcrumbs from '@material-ui/lab/Breadcrumbs';
+import NavigateNextIcon from 'mdi-react/NavigateNextIcon';
+
+@withStyles(theme => ({
+  paper: {
+    padding: `${theme.spacing.double}px ${theme.spacing.double}px`,
+  },
+}))
+export default class Breadcrumbs extends Component {
+  static propTypes = {
+    // Properties applied to the Paper component.
+    paperProps: object,
+    // The breadcrumb children.
+    children: node.isRequired,
+  };
+
+  static defaultProps = {
+    paperProps: {},
+  };
+
+  render() {
+    const { classes, paperProps, children, ...props } = this.props;
+    const paperPropsRest = omit(['className'], paperProps);
+
+    return (
+      <Paper
+        className={classNames(classes.paper, paperProps.className)}
+        {...paperPropsRest}>
+        <MuiBreadcrumbs
+          separator={<NavigateNextIcon />}
+          aria-label="Breadcrumb"
+          {...props}>
+          {children}
+        </MuiBreadcrumbs>
+      </Paper>
+    );
+  }
+}

--- a/ui/src/components/TaskDetailsCard/index.jsx
+++ b/ui/src/components/TaskDetailsCard/index.jsx
@@ -36,7 +36,7 @@ import Link from '../../utils/Link';
     paddingTop: theme.spacing.double,
     paddingBottom: theme.spacing.double,
     '&:last-child': {
-      paddingBottom: theme.spacing.triple,
+      paddingBottom: theme.spacing.double,
     },
   },
   sourceHeadline: {
@@ -97,12 +97,7 @@ export default class TaskDetailsCard extends Component {
 
   state = {
     showPayload: false,
-    showExtra: false,
     showMore: false,
-  };
-
-  handleToggleExtra = () => {
-    this.setState({ showExtra: !this.state.showExtra });
   };
 
   handleTogglePayload = () => {
@@ -115,7 +110,7 @@ export default class TaskDetailsCard extends Component {
 
   render() {
     const { classes, task, dependentTasks } = this.props;
-    const { showPayload, showExtra, showMore } = this.state;
+    const { showPayload, showMore } = this.state;
     const isExternal = task.metadata.source.startsWith('https://');
     const payload = deepSortObject(task.payload);
 
@@ -126,8 +121,13 @@ export default class TaskDetailsCard extends Component {
             <Typography variant="h5" className={classes.headline}>
               Task Details
             </Typography>
-
             <List>
+              <ListItem>
+                <ListItemText
+                  primary="State"
+                  secondary={<StatusLabel state={task.status.state} />}
+                />
+              </ListItem>
               <ListItem
                 button
                 className={classes.listItemButton}
@@ -152,42 +152,6 @@ export default class TaskDetailsCard extends Component {
                 rel="noopener noreferrer">
                 <ListItemText primary="View task definition" />
                 <OpenInNewIcon />
-              </ListItem>
-              <ListItem>
-                <ListItemText
-                  primary="Task Group ID"
-                  secondary={task.taskGroupId}
-                />
-                <ListItemSecondaryAction
-                  className={classes.listItemSecondaryAction}>
-                  <CopyToClipboard
-                    title={`${task.taskGroupId} (Copy)`}
-                    text={task.taskGroupId}>
-                    <IconButton>
-                      <ContentCopyIcon />
-                    </IconButton>
-                  </CopyToClipboard>
-                  <IconButton
-                    title="View Task Group"
-                    component={Link}
-                    to={`/tasks/groups/${task.taskGroupId}`}>
-                    <LinkIcon />
-                  </IconButton>
-                </ListItemSecondaryAction>
-              </ListItem>
-              <CopyToClipboard
-                title={`${task.taskId} (Copy)`}
-                text={task.taskId}>
-                <ListItem button className={classes.listItemButton}>
-                  <ListItemText primary="Task ID" secondary={task.taskId} />
-                  <ContentCopyIcon />
-                </ListItem>
-              </CopyToClipboard>
-              <ListItem>
-                <ListItemText
-                  primary="State"
-                  secondary={<StatusLabel state={task.status.state} />}
-                />
               </ListItem>
               <CopyToClipboard
                 title={`${task.created} (Copy)`}
@@ -230,70 +194,6 @@ export default class TaskDetailsCard extends Component {
                   </IconButton>
                 </ListItemSecondaryAction>
               </ListItem>
-              {dependentTasks && dependentTasks.length ? (
-                <Fragment>
-                  <ListItem>
-                    <ListItemText
-                      primary="Dependencies"
-                      secondary={
-                        <Fragment>
-                          This task will be scheduled when
-                          <strong>
-                            <em> dependencies </em>
-                          </strong>
-                          are
-                          {task.requires === 'ALL_COMPLETED' ? (
-                            <Fragment>
-                              &nbsp;
-                              <code>all-completed</code> successfully.
-                            </Fragment>
-                          ) : (
-                            <Fragment>
-                              &nbsp;
-                              <code>all-resolved</code> with any resolution.
-                            </Fragment>
-                          )}
-                        </Fragment>
-                      }
-                    />
-                  </ListItem>
-                  <List dense disablePadding>
-                    {dependentTasks.map(task => (
-                      <ListItem
-                        classes={{
-                          container: classes.listItemWithSecondaryAction,
-                        }}
-                        key={task.taskId}>
-                        <StatusLabel state={task.status.state} />
-                        <ListItemText primary={task.metadata.name} />
-                        <ListItemSecondaryAction
-                          className={classes.listItemSecondaryAction}>
-                          <CopyToClipboard
-                            title={`${task.metadata.name} (Copy)`}
-                            text={task.metadata.name}>
-                            <IconButton>
-                              <ContentCopyIcon />
-                            </IconButton>
-                          </CopyToClipboard>
-                          <IconButton
-                            title="View Task"
-                            component={Link}
-                            to={`/tasks/${task.taskId}`}>
-                            <LinkIcon />
-                          </IconButton>
-                        </ListItemSecondaryAction>
-                      </ListItem>
-                    ))}
-                  </List>
-                </Fragment>
-              ) : (
-                <ListItem>
-                  <ListItemText
-                    primary="Dependencies"
-                    secondary={<em>n/a</em>}
-                  />
-                </ListItem>
-              )}
               <ListItem
                 button
                 className={classes.listItemButton}
@@ -315,32 +215,6 @@ export default class TaskDetailsCard extends Component {
                   </ListItem>
                 </List>
               </Collapse>
-
-              {Object.keys(task.extra).length !== 0 && (
-                <Fragment>
-                  <ListItem
-                    button
-                    className={classes.listItemButton}
-                    onClick={this.handleToggleExtra}>
-                    <ListItemText primary="Extra" />
-                    {showExtra ? <ChevronUpIcon /> : <ChevronDownIcon />}
-                  </ListItem>
-                  <Collapse in={showExtra} timeout="auto">
-                    <List component="div" disablePadding>
-                      <ListItem>
-                        <ListItemText
-                          disableTypography
-                          primary={
-                            <Code language="json">
-                              {JSON.stringify(task.extra, null, 2)}
-                            </Code>
-                          }
-                        />
-                      </ListItem>
-                    </List>
-                  </Collapse>
-                </Fragment>
-              )}
               <ListItem
                 button
                 className={classes.listItemButton}
@@ -394,6 +268,70 @@ export default class TaskDetailsCard extends Component {
                     }
                   />
                 </ListItem>
+                {dependentTasks && dependentTasks.length ? (
+                  <Fragment>
+                    <ListItem>
+                      <ListItemText
+                        primary="Dependencies"
+                        secondary={
+                          <Fragment>
+                            This task will be scheduled when
+                            <strong>
+                              <em> dependencies </em>
+                            </strong>
+                            are
+                            {task.requires === 'ALL_COMPLETED' ? (
+                              <Fragment>
+                                &nbsp;
+                                <code>all-completed</code> successfully.
+                              </Fragment>
+                            ) : (
+                              <Fragment>
+                                &nbsp;
+                                <code>all-resolved</code> with any resolution.
+                              </Fragment>
+                            )}
+                          </Fragment>
+                        }
+                      />
+                    </ListItem>
+                    <List dense disablePadding>
+                      {dependentTasks.map(task => (
+                        <ListItem
+                          classes={{
+                            container: classes.listItemWithSecondaryAction,
+                          }}
+                          key={task.taskId}>
+                          <StatusLabel state={task.status.state} />
+                          <ListItemText primary={task.metadata.name} />
+                          <ListItemSecondaryAction
+                            className={classes.listItemSecondaryAction}>
+                            <CopyToClipboard
+                              title={`${task.metadata.name} (Copy)`}
+                              text={task.metadata.name}>
+                              <IconButton>
+                                <ContentCopyIcon />
+                              </IconButton>
+                            </CopyToClipboard>
+                            <IconButton
+                              title="View Task"
+                              component={Link}
+                              to={`/tasks/${task.taskId}`}>
+                              <LinkIcon />
+                            </IconButton>
+                          </ListItemSecondaryAction>
+                        </ListItem>
+                      ))}
+                    </List>
+                  </Fragment>
+                ) : (
+                  <ListItem>
+                    <ListItemText
+                      primary="Dependencies"
+                      secondary={<em>n/a</em>}
+                    />
+                  </ListItem>
+                )}
                 <ListItem>
                   <ListItemText
                     primary="Scheduler ID"
@@ -452,6 +390,21 @@ export default class TaskDetailsCard extends Component {
                     }
                   />
                 </ListItem>
+                {Object.keys(task.extra).length !== 0 && (
+                  <ListItem>
+                    <ListItemText
+                      disableTypography
+                      primary={
+                        <Typography variant="subtitle1">Extra</Typography>
+                      }
+                      secondary={
+                        <Code language="json">
+                          {JSON.stringify(task.extra, null, 2)}
+                        </Code>
+                      }
+                    />
+                  </ListItem>
+                )}
               </List>
             </Collapse>
           </CardContent>

--- a/ui/src/components/TaskDetailsCard/index.jsx
+++ b/ui/src/components/TaskDetailsCard/index.jsx
@@ -128,31 +128,6 @@ export default class TaskDetailsCard extends Component {
                   secondary={<StatusLabel state={task.status.state} />}
                 />
               </ListItem>
-              <ListItem
-                button
-                className={classes.listItemButton}
-                component="a"
-                href={task.metadata.source}
-                target="_blank"
-                rel="noopener noreferrer">
-                <ListItemText
-                  className={classes.sourceHeadlineText}
-                  classes={{ secondary: classes.sourceHeadline }}
-                  primary="Source"
-                  secondary={task.metadata.source}
-                />
-                {isExternal ? <OpenInNewIcon /> : <LinkIcon />}
-              </ListItem>
-              <ListItem
-                button
-                className={classes.listItemButton}
-                component="a"
-                href={urls.api('queue', 'v1', `task/${task.taskId}`)}
-                target="_blank"
-                rel="noopener noreferrer">
-                <ListItemText primary="View task definition" />
-                <OpenInNewIcon />
-              </ListItem>
               <CopyToClipboard
                 title={`${task.created} (Copy)`}
                 text={task.created}>
@@ -218,6 +193,16 @@ export default class TaskDetailsCard extends Component {
               <ListItem
                 button
                 className={classes.listItemButton}
+                component="a"
+                href={urls.api('queue', 'v1', `task/${task.taskId}`)}
+                target="_blank"
+                rel="noopener noreferrer">
+                <ListItemText primary="View task definition" />
+                <OpenInNewIcon />
+              </ListItem>
+              <ListItem
+                button
+                className={classes.listItemButton}
                 onClick={this.handleToggleMore}>
                 <ListItemText primary={showMore ? 'Less...' : 'More...'} />
                 {showMore ? <ChevronUpIcon /> : <ChevronDownIcon />}
@@ -225,6 +210,21 @@ export default class TaskDetailsCard extends Component {
             </List>
             <Collapse in={showMore} timeout="auto">
               <List>
+                <ListItem
+                  button
+                  className={classes.listItemButton}
+                  component="a"
+                  href={task.metadata.source}
+                  target="_blank"
+                  rel="noopener noreferrer">
+                  <ListItemText
+                    className={classes.sourceHeadlineText}
+                    classes={{ secondary: classes.sourceHeadline }}
+                    primary="Source"
+                    secondary={task.metadata.source}
+                  />
+                  {isExternal ? <OpenInNewIcon /> : <LinkIcon />}
+                </ListItem>
                 <ListItem>
                   <ListItemText
                     primary="Retries Left"

--- a/ui/src/components/TaskRunsCard/index.jsx
+++ b/ui/src/components/TaskRunsCard/index.jsx
@@ -150,6 +150,7 @@ export default class TaskRunsCard extends Component {
 
   state = {
     showArtifacts: false,
+    showMore: false,
   };
 
   getCurrentRun() {
@@ -284,6 +285,10 @@ export default class TaskRunsCard extends Component {
     );
   }
 
+  handleToggleMore = () => {
+    this.setState({ showMore: !this.state.showMore });
+  };
+
   render() {
     const {
       classes,
@@ -293,7 +298,7 @@ export default class TaskRunsCard extends Component {
       workerType,
       theme,
     } = this.props;
-    const { showArtifacts } = this.state;
+    const { showArtifacts, showMore } = this.state;
     const run = this.getCurrentRun();
     const liveLogArtifact = this.getLiveLogArtifactFromRun(run);
 
@@ -305,167 +310,183 @@ export default class TaskRunsCard extends Component {
               {run ? `Task Run ${selectedRunId}` : 'Task Run'}
             </Typography>
             {run ? (
-              <List>
-                <ListItem>
-                  <ListItemText
-                    primary="State"
-                    secondary={<StatusLabel state={run.state} />}
-                  />
-                </ListItem>
-                <ListItem>
-                  <ListItemText
-                    primary="Reason Created"
-                    secondary={<StatusLabel state={run.reasonCreated} />}
-                  />
-                </ListItem>
-                <CopyToClipboard
-                  title={`${run.scheduled} (Copy)`}
-                  text={run.scheduled}>
-                  <ListItem button className={classes.listItemButton}>
+              <Fragment>
+                <List>
+                  <ListItem>
                     <ListItemText
-                      primary="Scheduled"
-                      secondary={<DateDistance from={run.scheduled} />}
+                      primary="State"
+                      secondary={<StatusLabel state={run.state} />}
                     />
-                    <ContentCopyIcon />
                   </ListItem>
-                </CopyToClipboard>
-                <CopyToClipboard
-                  title={`${run.started} (Copy)`}
-                  text={run.started}>
-                  <ListItem button className={classes.listItemButton}>
-                    <ListItemText
-                      primary="Started"
-                      secondary={
-                        run.started ? (
-                          <DateDistance
-                            from={run.started}
-                            offset={run.scheduled}
-                          />
-                        ) : (
-                          <em>n/a</em>
-                        )
-                      }
-                    />
-                    <ContentCopyIcon />
-                  </ListItem>
-                </CopyToClipboard>
-                <CopyToClipboard
-                  title={`${run.resolved} (Copy)`}
-                  text={run.resolved}>
-                  <ListItem button className={classes.listItemButton}>
-                    <ListItemText
-                      primary="Resolved"
-                      secondary={
-                        run.resolved ? (
-                          <DateDistance
-                            from={run.resolved}
-                            offset={run.started}
-                          />
-                        ) : (
-                          <em>n/a</em>
-                        )
-                      }
-                    />
-                    <ContentCopyIcon />
-                  </ListItem>
-                </CopyToClipboard>
-                <ListItem>
-                  <ListItemText
-                    primary="Reason Resolved"
-                    secondary={
-                      run.reasonResolved ? (
-                        <StatusLabel state={run.reasonResolved} />
-                      ) : (
-                        <em>n/a</em>
-                      )
-                    }
-                  />
-                </ListItem>
-                <ListItem>
-                  <ListItemText
-                    primary="Worker Group"
-                    secondary={run.workerGroup || <em>n/a</em>}
-                  />
-                </ListItem>
-                <ListItem>
-                  <ListItemText primary="Worker ID" secondary={run.workerId} />
-                  <ListItemSecondaryAction
-                    className={classes.listItemSecondaryAction}>
-                    <CopyToClipboard
-                      title={`${run.workerId} (Copy)`}
-                      text={run.workerId}>
-                      <IconButton>
-                        <ContentCopyIcon />
-                      </IconButton>
-                    </CopyToClipboard>
-                    <IconButton
-                      title="View Worker"
+                  {liveLogArtifact && (
+                    <ListItem
+                      button
+                      className={classes.listItemButton}
                       component={Link}
-                      to={`/provisioners/${provisionerId}/worker-types/${workerType}/workers/${
-                        run.workerId
-                      }`}>
+                      to={this.getArtifactUrl(liveLogArtifact)}>
+                      <ListItemText
+                        primary={
+                          <Fragment>
+                            View Live Log{' '}
+                            <Label
+                              status="info"
+                              mini
+                              className={classes.liveLogLabel}>
+                              LOG
+                            </Label>
+                          </Fragment>
+                        }
+                        secondary={liveLogArtifact.name}
+                      />
                       <LinkIcon />
-                    </IconButton>
-                  </ListItemSecondaryAction>
-                </ListItem>
-                <CopyToClipboard
-                  title={`${run.takenUntil} (Copy)`}
-                  text={run.takenUntil}>
-                  <ListItem button className={classes.listItemButton}>
-                    <ListItemText
-                      primary="Taken Until"
-                      secondary={
-                        run.takenUntil ? (
-                          <DateDistance from={run.takenUntil} />
-                        ) : (
-                          <em>n/a</em>
-                        )
-                      }
-                    />
-                    <ContentCopyIcon />
-                  </ListItem>
-                </CopyToClipboard>
-                {liveLogArtifact && (
+                    </ListItem>
+                  )}
                   <ListItem
                     button
                     className={classes.listItemButton}
-                    component={Link}
-                    to={this.getArtifactUrl(liveLogArtifact)}>
-                    <ListItemText
-                      primary={
-                        <Fragment>
-                          View Live Log{' '}
-                          <Label
-                            status="info"
-                            mini
-                            className={classes.liveLogLabel}>
-                            LOG
-                          </Label>
-                        </Fragment>
-                      }
-                      secondary={liveLogArtifact.name}
-                    />
-                    <LinkIcon />
+                    onClick={this.handleToggleArtifacts}>
+                    <ListItemText primary="Artifacts" />
+                    {showArtifacts ? <ChevronUpIcon /> : <ChevronDownIcon />}
                   </ListItem>
-                )}
-                <ListItem
-                  button
-                  className={classes.listItemButton}
-                  onClick={this.handleToggleArtifacts}>
-                  <ListItemText primary="Artifacts" />
-                  {showArtifacts ? <ChevronUpIcon /> : <ChevronDownIcon />}
-                </ListItem>
-                <Collapse in={showArtifacts} timeout="auto">
-                  <List component="div" disablePadding>
-                    <ListItem
-                      className={classes.artifactsListItemContainer}
-                      component="div"
-                      disableGutters>
-                      {this.renderArtifactsTable()}
+                  <Collapse in={showArtifacts} timeout="auto">
+                    <List component="div" disablePadding>
+                      <ListItem
+                        className={classes.artifactsListItemContainer}
+                        component="div"
+                        disableGutters>
+                        {this.renderArtifactsTable()}
+                      </ListItem>
+                    </List>
+                  </Collapse>
+                  <CopyToClipboard
+                    title={`${run.scheduled} (Copy)`}
+                    text={run.scheduled}>
+                    <ListItem button className={classes.listItemButton}>
+                      <ListItemText
+                        primary="Scheduled"
+                        secondary={<DateDistance from={run.scheduled} />}
+                      />
+                      <ContentCopyIcon />
                     </ListItem>
+                  </CopyToClipboard>
+                  <CopyToClipboard
+                    title={`${run.started} (Copy)`}
+                    text={run.started}>
+                    <ListItem button className={classes.listItemButton}>
+                      <ListItemText
+                        primary="Started"
+                        secondary={
+                          run.started ? (
+                            <DateDistance
+                              from={run.started}
+                              offset={run.scheduled}
+                            />
+                          ) : (
+                            <em>n/a</em>
+                          )
+                        }
+                      />
+                      <ContentCopyIcon />
+                    </ListItem>
+                  </CopyToClipboard>
+                  <CopyToClipboard
+                    title={`${run.resolved} (Copy)`}
+                    text={run.resolved}>
+                    <ListItem button className={classes.listItemButton}>
+                      <ListItemText
+                        primary="Resolved"
+                        secondary={
+                          run.resolved ? (
+                            <DateDistance
+                              from={run.resolved}
+                              offset={run.started}
+                            />
+                          ) : (
+                            <em>n/a</em>
+                          )
+                        }
+                      />
+                      <ContentCopyIcon />
+                    </ListItem>
+                  </CopyToClipboard>
+                  <ListItem
+                    button
+                    className={classes.listItemButton}
+                    onClick={this.handleToggleMore}>
+                    <ListItemText primary={showMore ? 'Less...' : 'More...'} />
+                    {showMore ? <ChevronUpIcon /> : <ChevronDownIcon />}
+                  </ListItem>
+                </List>
+                <Collapse in={showMore} timeout="auto">
+                  <List component="div" disablePadding>
+                    <ListItem>
+                      <ListItemText
+                        primary="Reason Created"
+                        secondary={<StatusLabel state={run.reasonCreated} />}
+                      />
+                    </ListItem>
+                    <ListItem>
+                      <ListItemText
+                        primary="Reason Resolved"
+                        secondary={
+                          run.reasonResolved ? (
+                            <StatusLabel state={run.reasonResolved} />
+                          ) : (
+                            <em>n/a</em>
+                          )
+                        }
+                      />
+                    </ListItem>
+                    <ListItem>
+                      <ListItemText
+                        primary="Worker Group"
+                        secondary={run.workerGroup || <em>n/a</em>}
+                      />
+                    </ListItem>
+                    <ListItem>
+                      <ListItemText
+                        primary="Worker ID"
+                        secondary={run.workerId}
+                      />
+                      <ListItemSecondaryAction
+                        className={classes.listItemSecondaryAction}>
+                        <CopyToClipboard
+                          title={`${run.workerId} (Copy)`}
+                          text={run.workerId}>
+                          <IconButton>
+                            <ContentCopyIcon />
+                          </IconButton>
+                        </CopyToClipboard>
+                        <IconButton
+                          title="View Worker"
+                          component={Link}
+                          to={`/provisioners/${provisionerId}/worker-types/${workerType}/workers/${
+                            run.workerId
+                          }`}>
+                          <LinkIcon />
+                        </IconButton>
+                      </ListItemSecondaryAction>
+                    </ListItem>
+                    <CopyToClipboard
+                      title={`${run.takenUntil} (Copy)`}
+                      text={run.takenUntil}>
+                      <ListItem button className={classes.listItemButton}>
+                        <ListItemText
+                          primary="Taken Until"
+                          secondary={
+                            run.takenUntil ? (
+                              <DateDistance from={run.takenUntil} />
+                            ) : (
+                              <em>n/a</em>
+                            )
+                          }
+                        />
+                        <ContentCopyIcon />
+                      </ListItem>
+                    </CopyToClipboard>
                   </List>
                 </Collapse>
-              </List>
+              </Fragment>
             ) : (
               <div className={classes.boxVariant}>
                 <NoRunsIcon

--- a/ui/src/views/Tasks/ViewTask/index.jsx
+++ b/ui/src/views/Tasks/ViewTask/index.jsx
@@ -36,6 +36,7 @@ import SpeedDial from '../../../components/SpeedDial';
 import SpeedDialAction from '../../../components/SpeedDialAction';
 import DialogAction from '../../../components/DialogAction';
 import TaskActionForm from '../../../components/TaskActionForm';
+import Breadcrumbs from '../../../components/Breadcrumbs';
 import {
   ACTIONS_JSON_KNOWN_KINDS,
   ARTIFACTS_PAGE_SIZE,
@@ -50,6 +51,7 @@ import removeKeys from '../../../utils/removeKeys';
 import parameterizeTask from '../../../utils/parameterizeTask';
 import { nice } from '../../../utils/slugid';
 import formatTaskMutation from '../../../utils/formatTaskMutation';
+import Link from '../../../utils/Link';
 import submitTaskAction from '../submitTaskAction';
 import taskQuery from './task.graphql';
 import scheduleTaskQuery from './scheduleTask.graphql';
@@ -93,6 +95,9 @@ const getCachesFromTask = task =>
   dialogListItem: {
     paddingTop: 0,
     paddingBottom: 0,
+  },
+  link: {
+    ...theme.mixins.link,
   },
 }))
 @graphql(taskQuery, {
@@ -710,9 +715,18 @@ export default class ViewTask extends Component {
         />
         {task && (
           <Fragment>
-            <Typography variant="h5" className={classes.title}>
-              {task.metadata.name}
-            </Typography>
+            <Breadcrumbs>
+              <Typography
+                className={classes.link}
+                component={Link}
+                to={`/tasks/groups/${task.taskGroupId}`}>
+                Task Group
+              </Typography>
+              <Typography color="textSecondary">
+                {task.metadata.name}
+              </Typography>
+            </Breadcrumbs>
+            <br />
             <Typography variant="subtitle1">
               <Markdown>{task.metadata.description}</Markdown>
             </Typography>


### PR DESCRIPTION
**Problem 1**: Users of Taskcluster usually don't care about most of the information presented in the Task Group view. All that information displayed at once tend to confuse people.

**Solution 1**: Only show the most important information a user usually cares about. Hide everything else under the "More..." panel.

**Problem 2**: The relationship between a task group and a task id is not clearly shown in the task group view

**Solution 2**: Use breadcrumbs.

