### PR TITLE
Bug 1544601 - use correct table name for hooks

### DIFF
--- a/infrastructure/terraform/auth-service.tf
+++ b/infrastructure/terraform/auth-service.tf
@@ -112,7 +112,7 @@ locals {
       scopes = [
         "auth:azure-table:read-write:${azurerm_storage_account.base.name}/Hooks",
         "auth:azure-table:read-write:${azurerm_storage_account.base.name}/Queue",
-        "auth:azure-table:read-write:${azurerm_storage_account.base.name}/LastFire",
+        "auth:azure-table:read-write:${azurerm_storage_account.base.name}/LastFire2",
         "assume:hook-id:*",
         "notify:email:*",
         "queue:create-task:*",


### PR DESCRIPTION
Bugzilla Bug: [1544601](https://bugzilla.mozilla.org/show_bug.cgi?id=1544601)
