### PR TITLE
include a value for FORCE_SSL for queue

### DIFF
--- a/infrastructure/terraform/queue-service.tf
+++ b/infrastructure/terraform/queue-service.tf
@@ -67,6 +67,7 @@ module "queue_secrets" {
   secrets = {
     NODE_ENV                         = "production"
     MONITORING_ENABLE                = "true"
+    FORCE_SSL                        = "false"
     PUBLISH_METADATA                 = "false"
     AWS_ACCESS_KEY_ID                = "${module.queue_user.access_key_id}"
     AWS_SECRET_ACCESS_KEY            = "${module.queue_user.secret_access_key}"


### PR DESCRIPTION
This was changed from `!env:flag` to `!env:bool` in `service/queue/config.yml` a while back and that caused the service to fail on startup.