### PR TITLE
only serve /playground in development

### DIFF
--- a/services/web-server/config.yml
+++ b/services/web-server/config.yml
@@ -3,6 +3,8 @@ defaults:
     # the URL at which this service will be available, without a trailing `/`
     publicUrl: !env PUBLIC_URL
     loginStrategies: !env:list LOGIN_STRATEGIES
+    # if true, serve the /playground path
+    playground: false
 
   monitoring:
     enable: !env:bool MONITORING_ENABLE
@@ -40,6 +42,7 @@ development:
     # this assumes that taskcluster-ui's dev server is running on port 5080
     publicUrl: http://localhost:5080
     loginStrategies: []
+    playground: true
   server:
     # taskcluster-ui's dev server assumes port 3050
     port: 3050

--- a/services/web-server/src/index.js
+++ b/services/web-server/src/index.js
@@ -153,10 +153,12 @@ const load = loader(
 
         /* eslint-disable no-console */
         console.log(`\n\nWeb server running on port ${cfg.server.port}.`);
-        console.log(
-          `\nOpen the interactive GraphQL Playground and schema explorer in your browser at:
-        http://localhost:${cfg.server.port}/playground\n`
-        );
+        if (cfg.app.playground) {
+          console.log(
+            `\nOpen the interactive GraphQL Playground and schema explorer in your browser at:
+          http://localhost:${cfg.server.port}/playground\n`
+          );
+        }
         /* eslint-enable no-console */
       },
     },

--- a/services/web-server/src/servers/createApp.js
+++ b/services/web-server/src/servers/createApp.js
@@ -21,13 +21,16 @@ export default async ({ cfg }) => {
       limit: '1mb',
     })
   );
-  app.get(
-    '/playground',
-    playground({
-      endpoint: '/graphql',
-      subscriptionsEndpoint: '/subscription',
-    })
-  );
+
+  if (cfg.app.playground) {
+    app.get(
+      '/playground',
+      playground({
+        endpoint: '/graphql',
+        subscriptionsEndpoint: '/subscription',
+      })
+    );
+  }
 
   cfg.app.loginStrategies.forEach(strategy => {
     const { default: loginStrategy } = require(`../login/${strategy}`);


### PR DESCRIPTION
It probably doesn't hurt to have the playground out there in production, but it seems like leaving dangling functionality is unnecessary risk.