### PR TITLE
Bug 1544608 - really, don't kill connection on channel errors

### DIFF
--- a/libraries/pulse/src/client.js
+++ b/libraries/pulse/src/client.js
@@ -225,9 +225,12 @@ class Client extends events.EventEmitter {
         try {
           await channel.close();
         } catch (err) {
-          // an error trying to close the channel suggests the connection is dead, so
-          // recycle, but continue to throw the first error
-          conn.failed();
+          if (!(err instanceof amqplib.IllegalOperationError)) {
+            // IllegalOperationError happens when we are closing a broken
+            // channel; any other error trying to close the channel suggests
+            // the connection is dead, so mark it failed.
+            conn.failed();
+          }
         }
       }
     });


### PR DESCRIPTION
Bugzilla Bug: [1544608](https://bugzilla.mozilla.org/show_bug.cgi?id=1544608)

Well, the last PR didn't do the trick, because it still tried to close the "poisoned" channel, which failed because the channel was poisoned.  This adds special handling for that case to `withChannel`, and then reconfigures hooks to use `withChannel`.