### PR TITLE
[UI] Add fetchPolicy network-only to task view

### DIFF
--- a/ui/src/views/Tasks/ViewTask/index.jsx
+++ b/ui/src/views/Tasks/ViewTask/index.jsx
@@ -103,6 +103,7 @@ const getCachesFromTask = task =>
 @graphql(taskQuery, {
   skip: props => !props.match.params.taskId,
   options: props => ({
+    fetchPolicy: 'network-only',
     pollInterval: TASK_POLL_INTERVAL,
     errorPolicy: 'all',
     variables: {


### PR DESCRIPTION
This will make sure data is up-to-date when user visits an already cached task.