### PR TITLE
Support web-server without pulse directly

### DIFF
--- a/services/web-server/src/PulseEngine/index.js
+++ b/services/web-server/src/PulseEngine/index.js
@@ -13,15 +13,18 @@ export default class PulseEngine {
    * Each subscription gets one queue (named after the subscriptionId), with a
    * binding for each item in `subscriptions`. We then consume from that queue.
    * We automatically re-bind on connection recycles, and rely on the caller to
-   * re-subscribe on service restart. */
-
+   * re-subscribe on service restart.
+   *
+   * If the pulseClient is null, this will do nothing, as if no pulse messages
+   * were received.
+   */
   constructor({ monitor, pulseClient }) {
     this.monitor = monitor;
     this.subscriptions = new Map();
 
     this.client = pulseClient;
 
-    if (this.client.isFakeClient) {
+    if (!this.client) {
       // we are now set up to accept subscription requests, but won't do
       // anything with them.
       return;

--- a/services/web-server/src/index.js
+++ b/services/web-server/src/index.js
@@ -5,7 +5,7 @@ import loader from 'taskcluster-lib-loader';
 import docs from 'taskcluster-lib-docs';
 import config from 'taskcluster-lib-config';
 import { createServer } from 'http';
-import { FakeClient, Client, pulseCredentials } from 'taskcluster-lib-pulse';
+import { Client, pulseCredentials } from 'taskcluster-lib-pulse';
 import { ApolloServer } from 'apollo-server-express';
 import monitorManager from './monitor';
 import createApp from './servers/createApp';
@@ -68,7 +68,7 @@ const load = loader(
             `\n\nNo Pulse namespace defined; no Pulse messages will be received.`
           );
 
-          return new FakeClient();
+          return null;
         }
 
         return new Client({


### PR DESCRIPTION
The old incarnation used tc-lib-pulse's FakeClient, which was intended
only for testing and is no longer exposed by that library.

Refs #618 