### PR TITLE
Omit needless punctuation in error message

### DIFF
--- a/services/queue/src/dependencytracker.js
+++ b/services/queue/src/dependencytracker.js
@@ -113,7 +113,7 @@ class DependencyTracker {
       if (missing.length > 0) {
         msg += '`task.dependencies` references non-existing tasks: \n';
         msg += missing.map(taskId => {
-          return ' * ' + taskId + ',';
+          return ' * ' + taskId;
         }).join('\n') + '\n';
         msg += 'All taskIds in `task.dependencies` **must** exist\n';
         msg += 'before the task is created.\n';


### PR DESCRIPTION
This had me briefly wondering if something had stuck a `,` into a taskId
(which wouldn't be too hard with Python's treatment of `foo,` as a
tuple)