### PR TITLE
[UI] Rely on key and fetchPolicy instead of resetStore

### DIFF
--- a/ui/README.md
+++ b/ui/README.md
@@ -113,6 +113,12 @@ import BookOpenPageVariantIcon from 'mdi-react/BookOpenPageVariantIcon';
 
 <sup>* We use this library because it provides substantially more icons with minimal file-system headaches.</sup>
 
+## Necessary Practices
+
+1. For views showing secret, user-linked data or are using `client.fetchMore` to load more data
+on page load, graphql queries of that view must include the `fetchPolicy: 'network-only'` option to ensure
+data reflects the user's permissions and is up-to-date when a user logs in/out.
+
 ## Table of Contents
 
 <!-- TOC BEGIN -->

--- a/ui/src/App/index.jsx
+++ b/ui/src/App/index.jsx
@@ -217,7 +217,7 @@ export default class App extends Component {
             <MuiThemeProvider theme={theme}>
               <FontStager />
               <CssBaseline />
-              <Main routes={routes} error={error} />
+              <Main key={auth.user} routes={routes} error={error} />
             </MuiThemeProvider>
           </ToggleThemeContext.Provider>
         </AuthContext.Provider>

--- a/ui/src/components/SignInDialog/index.jsx
+++ b/ui/src/components/SignInDialog/index.jsx
@@ -52,7 +52,7 @@ export default class SignInDialog extends Component {
     this.setState({ credentialsDialogOpen: true });
   };
 
-  handleCredentialsSignIn = async credentials => {
+  handleCredentialsSignIn = credentials => {
     const inOneWeek = new Date();
 
     inOneWeek.setDate(inOneWeek.getDate() + 7);
@@ -67,7 +67,6 @@ export default class SignInDialog extends Component {
         displayName: credentials.clientId,
       },
     });
-    await this.props.client.resetStore();
     this.props.onClose();
   };
 

--- a/ui/src/components/UserMenu/index.jsx
+++ b/ui/src/components/UserMenu/index.jsx
@@ -57,9 +57,6 @@ export default class UserMenu extends Component {
   handleSignOutClick = () => {
     this.handleMenuClose();
     this.props.onUnauthorize();
-    // Since Apollo caches query results, it’s important to get rid of them
-    // when the login state changes.
-    this.props.client.clearStore();
   };
 
   handleMenuClick = e => {

--- a/ui/src/views/Profile/index.jsx
+++ b/ui/src/views/Profile/index.jsx
@@ -14,7 +14,11 @@ import profileQuery from './profile.graphql';
 
 @hot(module)
 @withAuth
-@graphql(profileQuery)
+@graphql(profileQuery, {
+  options: () => ({
+    fetchPolicy: 'network-only',
+  }),
+})
 export default class Profile extends Component {
   render() {
     const {

--- a/ui/src/views/Secrets/ViewSecret/index.jsx
+++ b/ui/src/views/Secrets/ViewSecret/index.jsx
@@ -18,6 +18,7 @@ import deleteSecretQuery from './deleteSecret.graphql';
 @graphql(secretQuery, {
   skip: ({ match: { params } }) => !params.secret,
   options: ({ match: { params } }) => ({
+    fetchPolicy: 'network-only',
     variables: {
       name: decodeURIComponent(params.secret),
     },

--- a/ui/src/views/Tasks/InteractiveConnect/index.jsx
+++ b/ui/src/views/Tasks/InteractiveConnect/index.jsx
@@ -57,6 +57,7 @@ const getInteractiveStatus = ({
 @withAuth
 @graphql(taskQuery, {
   options: props => ({
+    fetchPolicy: 'network-only',
     errorPolicy: 'all',
     pollInterval: INTERACTIVE_CONNECT_TASK_POLL_INTERVAL,
     variables: {


### PR DESCRIPTION
`resetStore` causes the store to be cleared and all active queries to be refetched. The only problem is that for many of our views, we depend on`fetchMore` to fetch the full list. Refetching active queries will only fetch the first query. There would probably be other problems with some of our subscriptions.

To fix this issue, we should rely on the key prop and the `networkPolicy` property to refetch active queries. Changing the `key` prop of a component in React will re-render that component. This will have a similar effect as `resetStore` & `clearStore`.

Fixes https://github.com/taskcluster/taskcluster/issues/654.