### PR TITLE
Revert "HOTFIX: Do not run strategy if config for strategy is undefined"

### DIFF
--- a/services/web-server/src/index.js
+++ b/services/web-server/src/index.js
@@ -149,12 +149,8 @@ const load = loader(
         const strategies = {};
 
         Object.keys(cfg.login.strategies).forEach((name) => {
-          const hasConfigValues = Object.values(cfg.login.strategies[name]).filter(Boolean).length !== 0;
-
-          if (hasConfigValues) {
-            const Strategy = require('./login/strategies/' + name);
-            strategies[name] = new Strategy({ name, cfg });
-          }
+          const Strategy = require('./login/strategies/' + name);
+          strategies[name] = new Strategy({ name, cfg });
         });
 
         return strategies;


### PR DESCRIPTION
Reverts taskcluster/taskcluster#664

Now that configs are set in heroku, the service will run smoothly.