### PR TITLE
Bug 1543378 - detect and warn on pulse blockage

### DIFF
--- a/libraries/pulse/README.md
+++ b/libraries/pulse/README.md
@@ -485,6 +485,15 @@ For compatibility with the deployment at `taskcluster.net`, this function also
 accepts parameters `publish` and `aws`, which control publishing the references
 to an Amazon S3 bucket.
 
+## Blocked Connections
+
+When RabbitMQ gets low on resources, it [sends a message to publishing channels indicating that it is blocking](https://www.rabbitmq.com/connection-blocked.html).
+Typically this means that RabbtiMQ will slow down or stop accepting new messages, protecting the server.
+However, on a busy system it can easily cause send operations to hit their `sendDeadline`, creating cascading failures.
+
+The publisher sets its `blocked` property to true when the server indicates that it is currently being blocked by the server or when it is not connected to a server.
+Services using this facility can check the `blocked` property and elect to propagate this upstream as a temporary error.
+
 # Testing
 
 To run the tests, a simple `yarn test` will do.  But it will skip most of the tests!

--- a/libraries/pulse/src/client.js
+++ b/libraries/pulse/src/client.js
@@ -333,6 +333,12 @@ class Connection extends events.EventEmitter {
         }
       });
 
+      // pass on blocked/unblocked messages; see
+      // https://www.rabbitmq.com/connection-blocked.html#capabilities. Amqplib
+      // includes 'connection.blocked' in the client properties for us
+      amqp.on('blocked', () => { this.emit('blocked'); });
+      amqp.on('unblocked', () => { this.emit('unblocked'); });
+
       this.debug('connected');
       this.state = 'connected';
       this.emit('connected');


### PR DESCRIPTION
Bugzilla Bug: [1543378](https://bugzilla.mozilla.org/show_bug.cgi?id=1543378)

This just adds the property and a log message.  I'd like this in-place next time we see issues.  If it proves a reliable indicator, then we can start to build `if (this.publisher.blocked) { .. return 503 .. }` into things like `queue.createTask`.

I did test this with a local rabbitmq with
```
docker run -e RABBITMQ_VM_MEMORY_HIGH_WATERMARK=100MiB -ti --rm -p 5672:5672 rabbitmq:alpine
```
and noted that the functionality here works.  But also, even with a consumer running at full speed, RabbitMQ still hits that VM high watermark.  Maybe it's too low and just the statistics cause it to hit?  At any rate, i don't want to futz with getting a CI test that hits this limit.  This is enough.