### PR TITLE
Fix SchemaTable to parse refs relatively

### DIFF
--- a/ui/src/views/Documentation/Reference/SchemaIndex.jsx
+++ b/ui/src/views/Documentation/Reference/SchemaIndex.jsx
@@ -21,12 +21,14 @@ export default class SchemaIndex extends Component {
     return (
       <div>
         <HeaderWithAnchor>Schema Index</HeaderWithAnchor>
-        {sortedReferences.map(entry => (
+        {sortedReferences.map(ref => (
           <Entry
-            key={entry.content.$id}
-            serviceName="unknown"
+            key={ref.content.$id}
             type="schema"
-            entry={entry}
+            entry={{
+              $id: ref.content.$id,
+              schema: ref.content,
+            }}
           />
         ))}
       </div>


### PR DESCRIPTION
This moves the logic to calculate entry schema references into the Entry
class.  It's still a bit awkward to show both actual reference entries
*and* schemas using the same Entry class, but it gets all the nice
expanding and hash reference behavior without code duplication.

I suppose an alternative would be to factor that behavior out into a ReferenceExpansionPanel class and then use that in both Entry and SchemaPanel.

Fixes #657, fixes #689.  cc: @arshadkazmi42 