### PR TITLE
[UI] Load docs in a single chunk

### DIFF
--- a/ui/src/views/Documentation/index.jsx
+++ b/ui/src/views/Documentation/index.jsx
@@ -113,13 +113,13 @@ export default class Documentation extends Component {
 
   async readDocFile(path) {
     try {
-      return await import(/* webpackChunkName: 'Documentation.page' */ `../../../docs/${path}.md`);
+      return await import(/* webpackMode: 'eager' */ `../../../docs/${path}.md`);
     } catch (err) {
       if (err.code !== 'MODULE_NOT_FOUND') {
         throw err;
       }
 
-      return import(/* webpackChunkName: 'Documentation.page' */ `../../../docs/${path}/README.md`);
+      return import(/* webpackMode: 'eager' */ `../../../docs/${path}/README.md`);
     }
   }
 


### PR DESCRIPTION
Make switching documentation pages in mobile faster. We don't need to do
this for the rest of the app because most users typically view one
micro service per visit whereas in docs people tend to view multiple pages. This commit enhances the performance in page transitions in docs.

`eager`: Generates no extra chunk. All modules are included in the current chunk and no additional network requests are made. A Promise is still returned but is already resolved. In contrast to a static import, the module isn't executed until the call to import() is made.