### PR TITLE
Bug 1550000 - strip all but the first line of multiline errors

### DIFF
--- a/libraries/monitor/src/monitor.js
+++ b/libraries/monitor/src/monitor.js
@@ -245,7 +245,13 @@ class Monitor {
       extra = level;
       level = 'err';
     }
-    this.log.errorReport(Object.assign({}, serializeError(err), extra), {level});
+    const serialized = serializeError(err);
+
+    // stackdriver doesn't like multiline prefixes to its stacks, so
+    // pre-process this down to "<FIRST LINE>\n  at ..."
+    serialized.stack = serialized.stack
+      .replace(/^([^\n]*)(?:\n[^\n]*)*?((?:\n {4}at[^\n]+)+)$/s, '$1$2');
+    this.log.errorReport({...serialized, ...extra}, {level});
   }
 
   /**

--- a/libraries/monitor/test/monitor_test.js
+++ b/libraries/monitor/test/monitor_test.js
@@ -304,7 +304,21 @@ suite(testing.suiteName(), function() {
       assert.equal(monitorManager.messages[0].severity, 'ERROR');
       assert.equal(monitorManager.messages[0].Fields.name, 'Error');
       assert.equal(monitorManager.messages[0].Fields.message, 'oh no');
+      assert.equal(monitorManager.messages[0].message, 'Error: oh no');
       assert(monitorManager.messages[0].Fields.stack);
+    });
+
+    test('should record first line of multiline errors', function() {
+      monitor.reportError(new Error('uhoh\nsomething went wrong\n..again'));
+      assert.equal(monitorManager.messages.length, 1);
+      // only the first line in the stack..
+      assert(monitorManager.messages[0].Fields.stack
+        .startsWith('Error: uhoh\n    at '));
+      // and only the first line in the top-level message
+      assert.equal(monitorManager.messages[0].message, 'Error: uhoh');
+      // but Fields.message has the whole thing..
+      assert.equal(monitorManager.messages[0].Fields.message,
+        'uhoh\nsomething went wrong\n..again');
     });
 
     test('should record errors with extra', function() {


### PR DESCRIPTION
..at least, in Fields.stack and in message, which are the two fields
StackDriver is concerned with.

Bugzilla Bug: [1550000](https://bugzilla.mozilla.org/show_bug.cgi?id=1550000)
