### PR TITLE
Add coverage badge to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,9 @@
   <a href="https://www.irccloud.com/invite?channel=%23taskcluster&amp;hostname=irc.mozilla.org&amp;port=6697&amp;ssl=1" target="_blank">
     <img src="https://img.shields.io/badge/IRC-%23taskcluster-1e72ff.svg?style=flat"  height="20">
   </a>
+  <a href="https://codecov.io/gh/taskcluster/taskcluster">
+    <img src="https://codecov.io/gh/taskcluster/taskcluster/branch/master/graph/badge.svg" />
+  </a>
 </p>
 
 <hr/>


### PR DESCRIPTION
Not strictly necessary, just a nice way to get to the coverage page when we want to see it.
