### PR TITLE
Use an explicit project for GCP credentials

### DIFF
--- a/clients/client-py/README.md
+++ b/clients/client-py/README.md
@@ -978,10 +978,11 @@ await asyncAuth.websocktunnelToken(wstAudience, wstClient) # -> result
 await asyncAuth.websocktunnelToken(wstAudience='value', wstClient='value') # -> result
 ```
 
-#### Get Temporary Read/Write GCP Credentials
-Get temporary GCP credentials for the given serviceAccount.
-projectId must always be the string "-", which means "use the same
-projectId as the account the service is running at.
+#### Get Temporary GCP Credentials
+Get temporary GCP credentials for the given serviceAccount in the given project.
+
+Only preconfigured projects are allowed.  Any serviceAccount in that project may
+be used.
 
 The call adds the necessary policy if the serviceAccount doesn't have it.
 The credentials are set to expire after an hour, but this behavior is

--- a/clients/client-py/taskcluster/aio/auth.py
+++ b/clients/client-py/taskcluster/aio/auth.py
@@ -493,11 +493,12 @@ class Auth(AsyncBaseClient):
 
     async def gcpCredentials(self, *args, **kwargs):
         """
-        Get Temporary Read/Write GCP Credentials
+        Get Temporary GCP Credentials
 
-        Get temporary GCP credentials for the given serviceAccount.
-        projectId must always be the string "-", which means "use the same
-        projectId as the account the service is running at.
+        Get temporary GCP credentials for the given serviceAccount in the given project.
+
+        Only preconfigured projects are allowed.  Any serviceAccount in that project may
+        be used.
 
         The call adds the necessary policy if the serviceAccount doesn't have it.
         The credentials are set to expire after an hour, but this behavior is

--- a/clients/client-py/taskcluster/auth.py
+++ b/clients/client-py/taskcluster/auth.py
@@ -493,11 +493,12 @@ class Auth(BaseClient):
 
     def gcpCredentials(self, *args, **kwargs):
         """
-        Get Temporary Read/Write GCP Credentials
+        Get Temporary GCP Credentials
 
-        Get temporary GCP credentials for the given serviceAccount.
-        projectId must always be the string "-", which means "use the same
-        projectId as the account the service is running at.
+        Get temporary GCP credentials for the given serviceAccount in the given project.
+
+        Only preconfigured projects are allowed.  Any serviceAccount in that project may
+        be used.
 
         The call adds the necessary policy if the serviceAccount doesn't have it.
         The credentials are set to expire after an hour, but this behavior is

--- a/clients/client-web/src/clients/Auth.js
+++ b/clients/client-web/src/clients/Auth.js
@@ -398,9 +398,9 @@ export default class Auth extends Client {
     return this.request(this.websocktunnelToken.entry, args);
   }
   /* eslint-disable max-len */
-  // Get temporary GCP credentials for the given serviceAccount.
-  // projectId must always be the string "-", which means "use the same
-  // projectId as the account the service is running at.
+  // Get temporary GCP credentials for the given serviceAccount in the given project.
+  // Only preconfigured projects are allowed.  Any serviceAccount in that project may
+  // be used.
   // The call adds the necessary policy if the serviceAccount doesn't have it.
   // The credentials are set to expire after an hour, but this behavior is
   // subject to change. Hence, you should always read the `expires` property

--- a/clients/client/src/apis.js
+++ b/clients/client/src/apis.js
@@ -523,7 +523,7 @@ module.exports = {
             "projectId",
             "serviceAccount"
           ],
-          "description": "Get temporary GCP credentials for the given serviceAccount.\nprojectId must always be the string \"-\", which means \"use the same\nprojectId as the account the service is running at.\n\nThe call adds the necessary policy if the serviceAccount doesn't have it.\nThe credentials are set to expire after an hour, but this behavior is\nsubject to change. Hence, you should always read the `expires` property\nfrom the response, if you intend to maintain active credentials in your\napplication.",
+          "description": "Get temporary GCP credentials for the given serviceAccount in the given project.\n\nOnly preconfigured projects are allowed.  Any serviceAccount in that project may\nbe used.\n\nThe call adds the necessary policy if the serviceAccount doesn't have it.\nThe credentials are set to expire after an hour, but this behavior is\nsubject to change. Hence, you should always read the `expires` property\nfrom the response, if you intend to maintain active credentials in your\napplication.",
           "method": "get",
           "name": "gcpCredentials",
           "output": "v1/gcp-credentials-response.json#",
@@ -532,7 +532,7 @@ module.exports = {
           "route": "/gcp/credentials/<projectId>/<serviceAccount>",
           "scopes": "auth:gcp:access-token:<projectId>/<serviceAccount>",
           "stability": "stable",
-          "title": "Get Temporary Read/Write GCP Credentials",
+          "title": "Get Temporary GCP Credentials",
           "type": "function"
         },
         {

--- a/generated/references.json
+++ b/generated/references.json
@@ -13141,7 +13141,7 @@
             "projectId",
             "serviceAccount"
           ],
-          "description": "Get temporary GCP credentials for the given serviceAccount.\nprojectId must always be the string \"-\", which means \"use the same\nprojectId as the account the service is running at.\n\nThe call adds the necessary policy if the serviceAccount doesn't have it.\nThe credentials are set to expire after an hour, but this behavior is\nsubject to change. Hence, you should always read the `expires` property\nfrom the response, if you intend to maintain active credentials in your\napplication.",
+          "description": "Get temporary GCP credentials for the given serviceAccount in the given project.\n\nOnly preconfigured projects are allowed.  Any serviceAccount in that project may\nbe used.\n\nThe call adds the necessary policy if the serviceAccount doesn't have it.\nThe credentials are set to expire after an hour, but this behavior is\nsubject to change. Hence, you should always read the `expires` property\nfrom the response, if you intend to maintain active credentials in your\napplication.",
           "method": "get",
           "name": "gcpCredentials",
           "output": "v1/gcp-credentials-response.json#",
@@ -13150,7 +13150,7 @@
           "route": "/gcp/credentials/<projectId>/<serviceAccount>",
           "scopes": "auth:gcp:access-token:<projectId>/<serviceAccount>",
           "stability": "stable",
-          "title": "Get Temporary Read/Write GCP Credentials",
+          "title": "Get Temporary GCP Credentials",
           "type": "function"
         },
         {

--- a/services/auth/src/api.js
+++ b/services/auth/src/api.js
@@ -123,11 +123,9 @@ const builder = new APIBuilder({
     // The websocktunnel config (with property `secret`)
     'websocktunnel',
 
-    // The google API authencation object used by the service
-    'googleAuth',
-
-    // The GCP credentials in use,
-    'gcpCredentials',
+    // An object containing {googleapis, auth, credentials} for interacting
+    // with GCP.
+    'gcp',
   ],
 });
 

--- a/services/auth/src/gcp.js
+++ b/services/auth/src/gcp.js
@@ -1,5 +1,4 @@
 const builder = require('./api');
-const {google} = require('googleapis');
 
 builder.declare({
   method: 'get',
@@ -31,16 +30,9 @@ builder.declare({
     );
   }
 
-  if (!this.googleAuth) {
-    return res.reportError(
-      'InternalServerError',
-      'The credentials for Google Cloud aren\'t available',
-    );
-  }
-
-  const iam = google.iam({
+  const iam = this.gcp.googleapis.iam({
     version: 'v1',
-    auth: this.googleAuth,
+    auth: this.gcp.auth,
   });
 
   // to understand the {get/set}IamPolicy calls, look at
@@ -76,7 +68,7 @@ builder.declare({
     data.bindings.push(binding);
   }
 
-  const myServiceAccount = this.gcpCredentials.client_email;
+  const myServiceAccount = this.gcp.credentials.client_email;
   if (!binding.members.includes(`serviceAccount:${myServiceAccount}`)) {
     binding.members.push(`serviceAccount:${myServiceAccount}`);
     await iam.projects.serviceAccounts.setIamPolicy({
@@ -88,9 +80,9 @@ builder.declare({
     });
   }
 
-  const iamcredentials = google.iamcredentials({
+  const iamcredentials = this.gcp.googleapis.iamcredentials({
     version: 'v1',
-    auth: this.googleAuth,
+    auth: this.gcp.auth,
   });
 
   response = await iamcredentials.projects.serviceAccounts.generateAccessToken({

--- a/services/auth/src/gcp.js
+++ b/services/auth/src/gcp.js
@@ -23,6 +23,10 @@ builder.declare({
   const serviceAccount = req.params.serviceAccount;
   const projectId = req.params.projectId;
 
+  if (!this.gcp.credentials) {
+    return res.reportError('ResourceNotFound', 'GCP credentials are not available');
+  }
+
   if (projectId !== '-') {
     return res.reportError(
       'InvalidRequestArguments',

--- a/services/auth/src/gcp.js
+++ b/services/auth/src/gcp.js
@@ -56,10 +56,8 @@ builder.declare({
   if (data.bindings === undefined) {
     data.bindings = [];
   }
-  let binding = data.bindings.filter(b => b.role === 'roles/iam.serviceAccountTokenCreator');
-  if (binding.length) {
-    binding = binding[0];
-  } else {
+  let binding = data.bindings.find(b => b.role === 'roles/iam.serviceAccountTokenCreator');
+  if (!binding) {
     binding = {
       role: 'roles/iam.serviceAccountTokenCreator',
       members: [],

--- a/services/auth/src/main.js
+++ b/services/auth/src/main.js
@@ -186,7 +186,10 @@ const load = Loader({
     requires: ['cfg'],
     setup: ({cfg}) => {
       const credentials = cfg.gcp.credentials;
-      const auth = googleapis.auth.fromJSON(credentials);
+
+      // note that this service can currently start up correctly without GCP
+      // credentials configured.
+      const auth = credentials ? googleapis.auth.fromJSON(credentials) : {};
 
       auth.scopes = [
         'https://www.googleapis.com/auth/cloud-platform',

--- a/services/auth/test/gcp_test.js
+++ b/services/auth/test/gcp_test.js
@@ -13,7 +13,7 @@ helper.secrets.mockSuite(testing.suiteName(), ['app', 'gcp', 'azure'], function(
 
   test('gcpCredentials invalid account', async () => {
     try {
-      await helper.apiClient.gcpCredentials('-', 'invalidserviceaccount@mozilla.com');
+      await helper.apiClient.gcpCredentials(helper.gcpAccount.project_id, 'invalid@mozilla.com');
     } catch (e) {
       if (e.statusCode !== 404) {
         throw e;
@@ -27,7 +27,7 @@ helper.secrets.mockSuite(testing.suiteName(), ['app', 'gcp', 'azure'], function(
     try {
       await helper.apiClient.gcpCredentials('invalidprojectid', helper.gcpAccount.email);
     } catch (e) {
-      if (e.statusCode !== 400) {
+      if (e.statusCode !== 404) {
         throw e;
       }
       return;
@@ -36,7 +36,7 @@ helper.secrets.mockSuite(testing.suiteName(), ['app', 'gcp', 'azure'], function(
   });
 
   test('gcpCredentials successful', async () => {
-    const res = await helper.apiClient.gcpCredentials('-', helper.gcpAccount.email);
+    const res = await helper.apiClient.gcpCredentials(helper.gcpAccount.project_id, helper.gcpAccount.email);
 
     if (mock) {
       assert.equal(res.accessToken, 'sekrit');
@@ -44,7 +44,7 @@ helper.secrets.mockSuite(testing.suiteName(), ['app', 'gcp', 'azure'], function(
   });
 
   test('gcpCredentials after setting policy', async () => {
-    await helper.apiClient.gcpCredentials('-', helper.gcpAccount.email);
+    await helper.apiClient.gcpCredentials(helper.gcpAccount.project_id, helper.gcpAccount.email);
 
     // verify that the service account is still configured correctly and not
     // endlessly adding bindings or members

--- a/services/auth/test/helper.js
+++ b/services/auth/test/helper.js
@@ -407,6 +407,7 @@ exports.withGcp = (mock, skipping) => {
       exports.gcpAccount = {
         email: 'test_client@example.com',
         name: 'testAccount',
+        project_id: credentials.project_id,
       };
     } else {
       const {credentials, auth, googleapis} = await exports.load('gcp');
@@ -429,7 +430,11 @@ exports.withGcp = (mock, skipping) => {
         },
       });
 
-      exports.gcpAccount = res.data;
+      exports.gcpAccount = {
+        email: res.data.email,
+        name: res.data.name,
+        project_id: credentials.project_id,
+      };
     }
   });
 


### PR DESCRIPTION
This changes the API method signature to require an explicit project_id in the request.  That means that later we can add support for multiple projects without changing the API.

This also supports mock testing with a fake google API implementation.