### PR TITLE
Add github client-related scopes

### DIFF
--- a/infrastructure/terraform/auth-service.tf
+++ b/infrastructure/terraform/auth-service.tf
@@ -74,6 +74,12 @@ locals {
         "auth:enable-client:mozilla-auth0/*",
         "auth:reset-access-token:mozilla-auth0/*",
         "auth:update-client:mozilla-auth0/*",
+        "auth:create-client:github/*",
+        "auth:delete-client:github/*",
+        "auth:disable-client:github/*",
+        "auth:enable-client:github/*",
+        "auth:reset-access-token:github/*",
+        "auth:update-client:github/*",
         "assume:login-identity:*",
       ]
     },


### PR DESCRIPTION
Without this, temporary credentials don't work for github logins, since they require that the issuer have `auth:create-client:<clientId>`.