### PR TITLE
Fix codecov take 2

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -7,3 +7,6 @@ codecov:
   ci:
     - tools.taskcluster.net
 
+parsers:
+  javascript:
+    enable_partials: yes

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ user-build-config.yml
 *.log
 .idea
 user-config.yml
+/artifacts/

--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -46,8 +46,7 @@ tasks:
           PULSE_CONNECTION_STRING: amqp://guest:guest@localhost:5672/
         command: >-
           service rabbitmq-server start &&
-          yarn workspace taskcluster-lib-pulse coverage:report &&
-          bash <(curl -s https://codecov.io/bash) -b $TASK_ID/$RUN_ID
+          yarn workspace taskcluster-lib-pulse coverage:report
       - name: taskcluster-lib-references
       - name: taskcluster-lib-scopes
       - name: taskcluster-lib-testing
@@ -170,8 +169,7 @@ tasks:
                 $if: entry['command']
                 then: ${entry.command}
                 else: >-
-                  yarn workspace ${entry.name} coverage:report &&
-                  bash <(curl -s https://codecov.io/bash) -b $TASK_ID/$RUN_ID
+                  yarn workspace ${entry.name} coverage:report
               env: # add in any custom env vars that this package needs
                 $if: entry['env']
                 then: {$eval: entry.env}
@@ -206,6 +204,12 @@ tasks:
               - assume:project:taskcluster:tests:taskcluster
               - docker-worker:cache:project-taskcluster-test-*
             payload:
+              artifacts:
+                public: 
+                  # This is not used at the moment other than by the trailer task to upload results. Feel free to bump later
+                  expires: {$fromNow: '24 hours'}
+                  path: /taskcluster/artifacts
+                  type: directory
               features:
                 taskclusterProxy: true
               env:

--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -44,7 +44,8 @@ tasks:
           PULSE_CONNECTION_STRING: amqp://guest:guest@localhost:5672/
         command: >-
           service rabbitmq-server start &&
-          yarn workspace taskcluster-lib-pulse test
+          yarn workspace taskcluster-lib-pulse coverage:report &&
+          bash <(curl -s https://codecov.io/bash) -b $TASK_ID.$RUN_ID
       - name: taskcluster-lib-references
       - name: taskcluster-lib-scopes
       - name: taskcluster-lib-testing
@@ -166,7 +167,9 @@ tasks:
               command:  # use `command` if given, falling back to basic yarn test
                 $if: entry['command']
                 then: ${entry.command}
-                else: yarn workspace ${entry.name} coverage:report
+                else: >-
+                  yarn workspace ${entry.name} coverage:report &&
+                  bash <(curl -s https://codecov.io/bash) -b $TASK_ID.$RUN_ID
               env: # add in any custom env vars that this package needs
                 $if: entry['env']
                 then: {$eval: entry.env}
@@ -206,6 +209,7 @@ tasks:
               env:
                 $merge:
                 - DEBUG: ${debug}
+                  CI_BUILD_URL: 'https://tools.taskcluster.net/tasks/${as_slugid(job.name)}'
                   NO_TEST_SKIP:
                     $if: 'job.name != "taskcluster-lib-testing"'
                     then: true

--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -5,6 +5,12 @@ policy:
 tasks:
   $let:
     node: '10.15.3'
+    artifactsDir:
+      public:
+        # This is not used at the moment other than by the trailer task to upload results. Feel free to bump later
+        expires: {$fromNow: '24 hours'}
+        path: /taskcluster/artifacts
+        type: directory
   in:
     $let:
       debug:
@@ -47,6 +53,7 @@ tasks:
         command: >-
           service rabbitmq-server start &&
           yarn workspace taskcluster-lib-pulse coverage:report
+        artifacts: {$eval: artifactsDir}
       - name: taskcluster-lib-references
       - name: taskcluster-lib-scopes
       - name: taskcluster-lib-testing
@@ -151,13 +158,22 @@ tasks:
             { Xvfb :99 -screen 0 640x480x8 -nolisten tcp & } &&
             sleep 2 &&
             CHROME_BIN=firefox DISPLAY=:99 yarn test
+      - name: upload-coverage
+        command: >-
+            yarn fetch-coverage &&
+            bash <(curl -s https://codecov.io/bash) -b $TASK_ID/$RUN_ID
+        post_packages: true
     in:
       $let:
         allTasks:
           $map:
             $map:
               $flatten:
-                - $eval: packages
+                - $map: {$eval: packages}
+                  each(p):
+                    $merge:
+                      - {$eval: p}
+                      - {artifacts: {$eval: artifactsDir}}
                 - $eval: others
             each(entry):
               name: ${entry.name}
@@ -184,12 +200,24 @@ tasks:
                 $if: entry['cache']
                 then: {$eval: entry.cache}
                 else: {project-taskcluster-test-yarn-cache: /cache}
+              dependencies:
+                $if: entry['post_packages']
+                then:
+                  $map: {$eval: packages}
+                  each(p): {$eval: as_slugid(p.name)}
+                else: []
+              artifacts:
+                $if: entry['artifacts']
+                then: {$eval: entry.artifacts}
+                else: {}
           each(job):
             taskId: {$eval: as_slugid(job.name)}
             provisionerId: aws-provisioner-v1
             workerType: github-worker
             created: {$fromNow: ''}
             deadline: {$fromNow: '3 hours'}
+            dependencies: {$eval: job.dependencies}
+            requires: all-resolved
             extra:
               notify:
                 email:
@@ -204,12 +232,7 @@ tasks:
               - assume:project:taskcluster:tests:taskcluster
               - docker-worker:cache:project-taskcluster-test-*
             payload:
-              artifacts:
-                public: 
-                  # This is not used at the moment other than by the trailer task to upload results. Feel free to bump later
-                  expires: {$fromNow: '24 hours'}
-                  path: /taskcluster/artifacts
-                  type: directory
+              artifacts: {$eval: job.artifacts}
               features:
                 taskclusterProxy: true
               env:

--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -25,10 +25,12 @@ tasks:
           git_url: ${event.repository.url}
           url: ${event.repository.url}
           ref: ${event.after}
+          branch: ${event.ref}
         else:
           git_url: ${event.pull_request.head.repo.git_url}
           url: ${event.pull_request.head.repo.url}
           ref: ${event.pull_request.head.sha}
+          branch: ${event.pull_request.head.ref}
 
       # We keep the separate from "others" so that we can assert a 1-1 mapping onto existing packages
       packages:
@@ -209,7 +211,9 @@ tasks:
               env:
                 $merge:
                 - DEBUG: ${debug}
+                  CODECOV_NAME: ${job.name}
                   CI_BUILD_URL: 'https://tools.taskcluster.net/tasks/${as_slugid(job.name)}'
+                  GIT_BRANCH: ${repo.branch}
                   NO_TEST_SKIP:
                     $if: 'job.name != "taskcluster-lib-testing"'
                     then: true

--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -47,7 +47,7 @@ tasks:
         command: >-
           service rabbitmq-server start &&
           yarn workspace taskcluster-lib-pulse coverage:report &&
-          bash <(curl -s https://codecov.io/bash) -b $TASK_ID.$RUN_ID
+          bash <(curl -s https://codecov.io/bash) -b $TASK_ID/$RUN_ID
       - name: taskcluster-lib-references
       - name: taskcluster-lib-scopes
       - name: taskcluster-lib-testing
@@ -171,7 +171,7 @@ tasks:
                 then: ${entry.command}
                 else: >-
                   yarn workspace ${entry.name} coverage:report &&
-                  bash <(curl -s https://codecov.io/bash) -b $TASK_ID.$RUN_ID
+                  bash <(curl -s https://codecov.io/bash) -b $TASK_ID/$RUN_ID
               env: # add in any custom env vars that this package needs
                 $if: entry['env']
                 then: {$eval: entry.env}

--- a/libraries/api/package.json
+++ b/libraries/api/package.json
@@ -7,7 +7,7 @@
   "license": "MPL-2.0",
   "scripts": {
     "coverage": "nyc npm test",
-    "coverage:report": "nyc npm test && nyc report --reporter=text-lcov | codecov --pipe -p ../..",
+    "coverage:report": "nyc npm test && nyc report --reporter json",
     "lint": "eslint src/*.js test/*.js",
     "test": "mocha test/*_test.js"
   },

--- a/libraries/api/package.json
+++ b/libraries/api/package.json
@@ -7,7 +7,7 @@
   "license": "MPL-2.0",
   "scripts": {
     "coverage": "nyc npm test",
-    "coverage:report": "nyc npm test && nyc report --reporter json",
+    "coverage:report": "nyc npm test && nyc report --reporter json --report-dir ../../artifacts",
     "lint": "eslint src/*.js test/*.js",
     "test": "mocha test/*_test.js"
   },

--- a/libraries/app/package.json
+++ b/libraries/app/package.json
@@ -7,7 +7,7 @@
   "license": "MPL-2.0",
   "scripts": {
     "coverage": "nyc npm test",
-    "coverage:report": "nyc npm test && nyc report --reporter=text-lcov | codecov --pipe -p ../..",
+    "coverage:report": "nyc npm test && nyc report --reporter json",
     "lint": "eslint src/*.js test/*.js",
     "test": "mocha test/*_test.js"
   },

--- a/libraries/app/package.json
+++ b/libraries/app/package.json
@@ -7,7 +7,7 @@
   "license": "MPL-2.0",
   "scripts": {
     "coverage": "nyc npm test",
-    "coverage:report": "nyc npm test && nyc report --reporter json",
+    "coverage:report": "nyc npm test && nyc report --reporter json --report-dir ../../artifacts",
     "lint": "eslint src/*.js test/*.js",
     "test": "mocha test/*_test.js"
   },

--- a/libraries/azure/package.json
+++ b/libraries/azure/package.json
@@ -7,7 +7,7 @@
   "license": "MPL-2.0",
   "scripts": {
     "coverage": "nyc npm test",
-    "coverage:report": "nyc npm test && nyc report --reporter=text-lcov | codecov --pipe -p ../..",
+    "coverage:report": "nyc npm test && nyc report --reporter json",
     "lint": "eslint src/*.js test/*.js",
     "test": "mocha test/*_test.js"
   },

--- a/libraries/azure/package.json
+++ b/libraries/azure/package.json
@@ -7,7 +7,7 @@
   "license": "MPL-2.0",
   "scripts": {
     "coverage": "nyc npm test",
-    "coverage:report": "nyc npm test && nyc report --reporter json",
+    "coverage:report": "nyc npm test && nyc report --reporter json --report-dir ../../artifacts",
     "lint": "eslint src/*.js test/*.js",
     "test": "mocha test/*_test.js"
   },

--- a/libraries/config/package.json
+++ b/libraries/config/package.json
@@ -8,7 +8,7 @@
   "main": "./src/index.js",
   "scripts": {
     "coverage": "nyc npm test",
-    "coverage:report": "nyc npm test && nyc report --reporter json",
+    "coverage:report": "nyc npm test && nyc report --reporter json --report-dir ../../artifacts",
     "lint": "eslint src/*.js test/*.js",
     "test": "mocha test/*_test.js"
   }

--- a/libraries/config/package.json
+++ b/libraries/config/package.json
@@ -8,7 +8,7 @@
   "main": "./src/index.js",
   "scripts": {
     "coverage": "nyc npm test",
-    "coverage:report": "nyc npm test && nyc report --reporter=text-lcov | codecov --pipe -p ../..",
+    "coverage:report": "nyc npm test && nyc report --reporter json",
     "lint": "eslint src/*.js test/*.js",
     "test": "mocha test/*_test.js"
   }

--- a/libraries/iterate/package.json
+++ b/libraries/iterate/package.json
@@ -6,7 +6,7 @@
   "main": "src/index.js",
   "scripts": {
     "coverage": "nyc npm test",
-    "coverage:report": "nyc npm test && nyc report --reporter json",
+    "coverage:report": "nyc npm test && nyc report --reporter json --report-dir ../../artifacts",
     "lint": "eslint src/*.js test/*.js",
     "test": "mocha"
   },

--- a/libraries/iterate/package.json
+++ b/libraries/iterate/package.json
@@ -6,7 +6,7 @@
   "main": "src/index.js",
   "scripts": {
     "coverage": "nyc npm test",
-    "coverage:report": "nyc npm test && nyc report --reporter=text-lcov | codecov --pipe -p ../..",
+    "coverage:report": "nyc npm test && nyc report --reporter json",
     "lint": "eslint src/*.js test/*.js",
     "test": "mocha"
   },

--- a/libraries/loader/package.json
+++ b/libraries/loader/package.json
@@ -9,7 +9,7 @@
   },
   "scripts": {
     "coverage": "nyc npm test",
-    "coverage:report": "nyc npm test && nyc report --reporter json",
+    "coverage:report": "nyc npm test && nyc report --reporter json --report-dir ../../artifacts",
     "test": "mocha test/*.js",
     "lint": "eslint src/*.js test/*.js"
   },

--- a/libraries/loader/package.json
+++ b/libraries/loader/package.json
@@ -9,7 +9,7 @@
   },
   "scripts": {
     "coverage": "nyc npm test",
-    "coverage:report": "nyc npm test && nyc report --reporter=text-lcov | codecov --pipe -p ../..",
+    "coverage:report": "nyc npm test && nyc report --reporter json",
     "test": "mocha test/*.js",
     "lint": "eslint src/*.js test/*.js"
   },

--- a/libraries/monitor/package.json
+++ b/libraries/monitor/package.json
@@ -7,7 +7,7 @@
   "license": "MPL-2.0",
   "scripts": {
     "coverage": "nyc npm test",
-    "coverage:report": "nyc npm test && nyc report --reporter=text-lcov | codecov --pipe -p ../..",
+    "coverage:report": "nyc npm test && nyc report --reporter json",
     "lint": "eslint src/*.js test/*.js",
     "test": "mocha test/*_test.js"
   },

--- a/libraries/monitor/package.json
+++ b/libraries/monitor/package.json
@@ -7,7 +7,7 @@
   "license": "MPL-2.0",
   "scripts": {
     "coverage": "nyc npm test",
-    "coverage:report": "nyc npm test && nyc report --reporter json",
+    "coverage:report": "nyc npm test && nyc report --reporter json --report-dir ../../artifacts",
     "lint": "eslint src/*.js test/*.js",
     "test": "mocha test/*_test.js"
   },

--- a/libraries/pulse/package.json
+++ b/libraries/pulse/package.json
@@ -8,7 +8,7 @@
   "license": "MPL-2.0",
   "scripts": {
     "coverage": "nyc npm test",
-    "coverage:report": "nyc npm test && nyc report --reporter json",
+    "coverage:report": "nyc npm test && nyc report --reporter json --report-dir ../../artifacts",
     "test": "mocha test/*_test.js",
     "lint": "eslint src/*.js test/*.js"
   }

--- a/libraries/pulse/package.json
+++ b/libraries/pulse/package.json
@@ -8,7 +8,7 @@
   "license": "MPL-2.0",
   "scripts": {
     "coverage": "nyc npm test",
-    "coverage:report": "nyc npm test && nyc report --reporter=text-lcov | codecov --pipe -p ../..",
+    "coverage:report": "nyc npm test && nyc report --reporter json",
     "test": "mocha test/*_test.js",
     "lint": "eslint src/*.js test/*.js"
   }

--- a/libraries/references/package.json
+++ b/libraries/references/package.json
@@ -5,7 +5,7 @@
   "main": "src/index.js",
   "scripts": {
     "coverage": "nyc npm test",
-    "coverage:report": "nyc npm test && nyc report --reporter json",
+    "coverage:report": "nyc npm test && nyc report --reporter json --report-dir ../../artifacts",
     "lint": "eslint src/*.js test/*.js",
     "test": "mocha test/*_test.js"
   },

--- a/libraries/references/package.json
+++ b/libraries/references/package.json
@@ -5,7 +5,7 @@
   "main": "src/index.js",
   "scripts": {
     "coverage": "nyc npm test",
-    "coverage:report": "nyc npm test && nyc report --reporter=text-lcov | codecov --pipe -p ../..",
+    "coverage:report": "nyc npm test && nyc report --reporter json",
     "lint": "eslint src/*.js test/*.js",
     "test": "mocha test/*_test.js"
   },

--- a/libraries/scopes/package.json
+++ b/libraries/scopes/package.json
@@ -7,7 +7,7 @@
   "license": "MPL-2.0",
   "scripts": {
     "coverage": "nyc npm test",
-    "coverage:report": "nyc npm test && nyc report --reporter=text-lcov | codecov --pipe -p ../..",
+    "coverage:report": "nyc npm test && nyc report --reporter json",
     "lint": "eslint src/*.js test/*.js",
     "test": "mocha test/*_test.js"
   },

--- a/libraries/scopes/package.json
+++ b/libraries/scopes/package.json
@@ -7,7 +7,7 @@
   "license": "MPL-2.0",
   "scripts": {
     "coverage": "nyc npm test",
-    "coverage:report": "nyc npm test && nyc report --reporter json",
+    "coverage:report": "nyc npm test && nyc report --reporter json --report-dir ../../artifacts",
     "lint": "eslint src/*.js test/*.js",
     "test": "mocha test/*_test.js"
   },

--- a/libraries/testing/package.json
+++ b/libraries/testing/package.json
@@ -7,7 +7,7 @@
   "license": "MPL-2.0",
   "scripts": {
     "coverage": "nyc npm test",
-    "coverage:report": "nyc npm test && nyc report --reporter=text-lcov | codecov --pipe -p ../..",
+    "coverage:report": "nyc npm test && nyc report --reporter json",
     "lint": "eslint src/*.js test/*.js",
     "test": "mocha test/*_test.js"
   },

--- a/libraries/testing/package.json
+++ b/libraries/testing/package.json
@@ -7,7 +7,7 @@
   "license": "MPL-2.0",
   "scripts": {
     "coverage": "nyc npm test",
-    "coverage:report": "nyc npm test && nyc report --reporter json",
+    "coverage:report": "nyc npm test && nyc report --reporter json --report-dir ../../artifacts",
     "lint": "eslint src/*.js test/*.js",
     "test": "mocha test/*_test.js"
   },

--- a/libraries/validate/package.json
+++ b/libraries/validate/package.json
@@ -7,7 +7,7 @@
   "license": "MPL-2.0",
   "scripts": {
     "coverage": "nyc npm test",
-    "coverage:report": "nyc npm test && nyc report --reporter=text-lcov | codecov --pipe -p ../..",
+    "coverage:report": "nyc npm test && nyc report --reporter json",
     "lint": "eslint src/*.js test/*.js",
     "test": "mocha test/*_test.js"
   },

--- a/libraries/validate/package.json
+++ b/libraries/validate/package.json
@@ -7,7 +7,7 @@
   "license": "MPL-2.0",
   "scripts": {
     "coverage": "nyc npm test",
-    "coverage:report": "nyc npm test && nyc report --reporter json",
+    "coverage:report": "nyc npm test && nyc report --reporter json --report-dir ../../artifacts",
     "lint": "eslint src/*.js test/*.js",
     "test": "mocha test/*_test.js"
   },

--- a/package.json
+++ b/package.json
@@ -116,7 +116,6 @@
     "aws-sdk-mock": "^4.3.0",
     "capture-console": "^1.0.1",
     "cliff": "^0.1.10",
-    "codecov": "^3.5.0",
     "commander": "^2.19.0",
     "console-taskgraph": "^1.5.0",
     "depcheck": "^0.8.0",

--- a/package.json
+++ b/package.json
@@ -159,6 +159,7 @@
     "lint": "eslint --cache --ext js --ignore-pattern clients/client-web/build libraries services infrastructure clients test",
     "test": "yarn workspaces run test",
     "test:meta": "mocha test/*_test.js",
+    "fetch-coverage": "node test/fetch-coverage.js",
     "test:cleanup": "yarn workspace taskcluster-auth test:cleanup",
     "build": "node infrastructure/builder/src/main.js build",
     "generate": "node infrastructure/builder/src/main.js generate",

--- a/services/auth/package.json
+++ b/services/auth/package.json
@@ -5,7 +5,7 @@
   "main": "node src/server production",
   "scripts": {
     "coverage": "nyc npm test",
-    "coverage:report": "nyc npm test && nyc report --reporter json",
+    "coverage:report": "nyc npm test && nyc report --reporter json --report-dir ../../artifacts",
     "test": "mocha test/*_test.js",
     "test:cleanup": "mocha test/cleanup.js",
     "lint": "eslint src/*.js test/*.js"

--- a/services/auth/package.json
+++ b/services/auth/package.json
@@ -5,7 +5,7 @@
   "main": "node src/server production",
   "scripts": {
     "coverage": "nyc npm test",
-    "coverage:report": "nyc npm test && nyc report --reporter=text-lcov | codecov --pipe -p ../..",
+    "coverage:report": "nyc npm test && nyc report --reporter json",
     "test": "mocha test/*_test.js",
     "test:cleanup": "mocha test/cleanup.js",
     "lint": "eslint src/*.js test/*.js"

--- a/services/built-in-workers/package.json
+++ b/services/built-in-workers/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "coverage": "nyc npm test",
-    "coverage:report": "nyc npm test && nyc report --reporter json",
+    "coverage:report": "nyc npm test && nyc report --reporter json --report-dir ../../artifacts",
     "test": "mocha test/*_test.js",
     "lint": "eslint src/*.js test/*.js"
   }

--- a/services/built-in-workers/package.json
+++ b/services/built-in-workers/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "coverage": "nyc npm test",
-    "coverage:report": "nyc npm test && nyc report --reporter=text-lcov | codecov --pipe -p ../..",
+    "coverage:report": "nyc npm test && nyc report --reporter json",
     "test": "mocha test/*_test.js",
     "lint": "eslint src/*.js test/*.js"
   }

--- a/services/github/package.json
+++ b/services/github/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "coverage": "nyc npm test",
-    "coverage:report": "nyc npm test && nyc report --reporter json",
+    "coverage:report": "nyc npm test && nyc report --reporter json --report-dir ../../artifacts",
     "lint": "eslint src/*.js test/*.js",
     "test": "mocha test/*_test.js"
   }

--- a/services/github/package.json
+++ b/services/github/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "coverage": "nyc npm test",
-    "coverage:report": "nyc npm test && nyc report --reporter=text-lcov | codecov --pipe -p ../..",
+    "coverage:report": "nyc npm test && nyc report --reporter json",
     "lint": "eslint src/*.js test/*.js",
     "test": "mocha test/*_test.js"
   }

--- a/services/hooks/package.json
+++ b/services/hooks/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "coverage": "nyc npm test",
-    "coverage:report": "nyc npm test && nyc report --reporter=text-lcov | codecov --pipe -p ../..",
+    "coverage:report": "nyc npm test && nyc report --reporter json",
     "lint": "eslint src/*.js test/*.js",
     "test": "mocha test/*_test.js"
   },

--- a/services/hooks/package.json
+++ b/services/hooks/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "coverage": "nyc npm test",
-    "coverage:report": "nyc npm test && nyc report --reporter json",
+    "coverage:report": "nyc npm test && nyc report --reporter json --report-dir ../../artifacts",
     "lint": "eslint src/*.js test/*.js",
     "test": "mocha test/*_test.js"
   },

--- a/services/index/package.json
+++ b/services/index/package.json
@@ -5,7 +5,7 @@
   "main": "./src/main.js",
   "scripts": {
     "coverage": "nyc npm test",
-    "coverage:report": "nyc npm test && nyc report --reporter json",
+    "coverage:report": "nyc npm test && nyc report --reporter json --report-dir ../../artifacts",
     "lint": "eslint src/*.js test/*.js",
     "test": "mocha test/*_test.js"
   }

--- a/services/index/package.json
+++ b/services/index/package.json
@@ -5,7 +5,7 @@
   "main": "./src/main.js",
   "scripts": {
     "coverage": "nyc npm test",
-    "coverage:report": "nyc npm test && nyc report --reporter=text-lcov | codecov --pipe -p ../..",
+    "coverage:report": "nyc npm test && nyc report --reporter json",
     "lint": "eslint src/*.js test/*.js",
     "test": "mocha test/*_test.js"
   }

--- a/services/login/package.json
+++ b/services/login/package.json
@@ -7,7 +7,7 @@
   "license": "MPL-2.0",
   "scripts": {
     "coverage": "nyc npm test",
-    "coverage:report": "nyc npm test && nyc report --reporter=text-lcov | codecov --pipe -p ../..",
+    "coverage:report": "nyc npm test && nyc report --reporter json",
     "lint": "eslint src/*.js src/*/*.js test/*.js",
     "test": "mocha test/*_test.js"
   }

--- a/services/login/package.json
+++ b/services/login/package.json
@@ -7,7 +7,7 @@
   "license": "MPL-2.0",
   "scripts": {
     "coverage": "nyc npm test",
-    "coverage:report": "nyc npm test && nyc report --reporter json",
+    "coverage:report": "nyc npm test && nyc report --reporter json --report-dir ../../artifacts",
     "lint": "eslint src/*.js src/*/*.js test/*.js",
     "test": "mocha test/*_test.js"
   }

--- a/services/notify/package.json
+++ b/services/notify/package.json
@@ -6,7 +6,7 @@
   "license": "MPL-2.0",
   "scripts": {
     "coverage": "nyc npm test",
-    "coverage:report": "nyc npm test && nyc report --reporter json",
+    "coverage:report": "nyc npm test && nyc report --reporter json --report-dir ../../artifacts",
     "test": "mocha test/*_test.js",
     "lint": "eslint src/*.js test/*.js"
   }

--- a/services/notify/package.json
+++ b/services/notify/package.json
@@ -6,7 +6,7 @@
   "license": "MPL-2.0",
   "scripts": {
     "coverage": "nyc npm test",
-    "coverage:report": "nyc npm test && nyc report --reporter=text-lcov | codecov --pipe -p ../..",
+    "coverage:report": "nyc npm test && nyc report --reporter json",
     "test": "mocha test/*_test.js",
     "lint": "eslint src/*.js test/*.js"
   }

--- a/services/purge-cache/package.json
+++ b/services/purge-cache/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "coverage": "nyc npm test",
-    "coverage:report": "nyc npm test && nyc report --reporter json",
+    "coverage:report": "nyc npm test && nyc report --reporter json --report-dir ../../artifacts",
     "test": "mocha test/*_test.js",
     "lint": "eslint src/*.js test/*.js"
   }

--- a/services/purge-cache/package.json
+++ b/services/purge-cache/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "coverage": "nyc npm test",
-    "coverage:report": "nyc npm test && nyc report --reporter=text-lcov | codecov --pipe -p ../..",
+    "coverage:report": "nyc npm test && nyc report --reporter json",
     "test": "mocha test/*_test.js",
     "lint": "eslint src/*.js test/*.js"
   }

--- a/services/queue/package.json
+++ b/services/queue/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "coverage": "nyc npm test",
-    "coverage:report": "nyc npm test && nyc report --reporter json",
+    "coverage:report": "nyc npm test && nyc report --reporter json --report-dir ../../artifacts",
     "test": "mocha test/*_test.js",
     "lint": "eslint src/*.js test/*.js"
   }

--- a/services/queue/package.json
+++ b/services/queue/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "coverage": "nyc npm test",
-    "coverage:report": "nyc npm test && nyc report --reporter=text-lcov | codecov --pipe -p ../..",
+    "coverage:report": "nyc npm test && nyc report --reporter json",
     "test": "mocha test/*_test.js",
     "lint": "eslint src/*.js test/*.js"
   }

--- a/services/secrets/package.json
+++ b/services/secrets/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "coverage": "nyc npm test",
-    "coverage:report": "nyc npm test && nyc report --reporter json",
+    "coverage:report": "nyc npm test && nyc report --reporter json --report-dir ../../artifacts",
     "test": "mocha test/*_test.js",
     "lint": "eslint src/*.js test/*.js"
   }

--- a/services/secrets/package.json
+++ b/services/secrets/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "coverage": "nyc npm test",
-    "coverage:report": "nyc npm test && nyc report --reporter=text-lcov | codecov --pipe -p ../..",
+    "coverage:report": "nyc npm test && nyc report --reporter json",
     "test": "mocha test/*_test.js",
     "lint": "eslint src/*.js test/*.js"
   }

--- a/services/treeherder/package.json
+++ b/services/treeherder/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "coverage": "nyc npm test",
-    "coverage:report": "nyc npm test && nyc report --reporter json",
+    "coverage:report": "nyc npm test && nyc report --reporter json --report-dir ../../artifacts",
     "test": "mocha test/*_test.js",
     "lint": "eslint src/*.js test/*.js"
   }

--- a/services/treeherder/package.json
+++ b/services/treeherder/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "coverage": "nyc npm test",
-    "coverage:report": "nyc npm test && nyc report --reporter=text-lcov | codecov --pipe -p ../..",
+    "coverage:report": "nyc npm test && nyc report --reporter json",
     "test": "mocha test/*_test.js",
     "lint": "eslint src/*.js test/*.js"
   }

--- a/services/web-server/package.json
+++ b/services/web-server/package.json
@@ -7,7 +7,7 @@
   "license": "MPL-2.0",
   "scripts": {
     "coverage": "nyc npm test",
-    "coverage:report": "nyc npm test && nyc report --reporter json",
+    "coverage:report": "nyc npm test && nyc report --reporter json --report-dir ../../artifacts",
     "start": "NODE_ENV=development node src/main.js devServer",
     "lint": "eslint --cache --format codeframe --ext mjs,js src test",
     "test": "mocha test/*_test.js"

--- a/services/web-server/package.json
+++ b/services/web-server/package.json
@@ -7,7 +7,7 @@
   "license": "MPL-2.0",
   "scripts": {
     "coverage": "nyc npm test",
-    "coverage:report": "nyc npm test && nyc report --reporter=text-lcov | codecov --pipe -p ../..",
+    "coverage:report": "nyc npm test && nyc report --reporter json",
     "start": "NODE_ENV=development node src/main.js devServer",
     "lint": "eslint --cache --format codeframe --ext mjs,js src test",
     "test": "mocha test/*_test.js"

--- a/services/worker-manager/package.json
+++ b/services/worker-manager/package.json
@@ -8,7 +8,7 @@
   "private": true,
   "scripts": {
     "coverage": "nyc npm test",
-    "coverage:report": "nyc npm test && nyc report --reporter json",
+    "coverage:report": "nyc npm test && nyc report --reporter json --report-dir ../../artifacts",
     "lint": "eslint src/*.js test/*.js",
     "fixlint": "eslint --fix src/*.js test/*.js",
     "test": "mocha test/*_test.js"

--- a/services/worker-manager/package.json
+++ b/services/worker-manager/package.json
@@ -8,7 +8,7 @@
   "private": true,
   "scripts": {
     "coverage": "nyc npm test",
-    "coverage:report": "nyc npm test && nyc report --reporter=text-lcov | codecov --pipe -p ../..",
+    "coverage:report": "nyc npm test && nyc report --reporter json",
     "lint": "eslint src/*.js test/*.js",
     "fixlint": "eslint --fix src/*.js test/*.js",
     "test": "mocha test/*_test.js"

--- a/test/fetch-coverage.js
+++ b/test/fetch-coverage.js
@@ -1,0 +1,37 @@
+/**
+ * Download coverage from previous tasks
+ */
+const taskcluster = require('taskcluster-client');
+const fs = require('mz/fs');
+const path = require('path');
+
+const COVERAGE_DIR = 'coverage';
+
+const main = async () => {
+  let configs;
+  if (process.env.TASKCLUSTER_PROXY_URL) {
+    configs = {
+      rootUrl: process.env.TASKCLUSTER_PROXY_URL,
+    };
+  } else {
+    configs = {
+      rootUrl: process.env.TASKCLUSTER_ROOT_URL,
+      credentials: {
+        clientId: process.env.TASKCLUSTER_CLIENT_ID,
+        accessToken: process.env.TASKCLUSTER_ACCESS_TOKEN,
+      },
+    };
+  }
+  const queue = new taskcluster.Queue(configs);
+  const {dependencies} = await queue.task(process.env.TASK_ID);
+
+  await fs.mkdir(COVERAGE_DIR);
+  for (const taskId of dependencies) {
+    const coverage = await queue.getLatestArtifact(taskId, 'public/coverage-final.json');
+    const filename = path.join(COVERAGE_DIR, `${taskId}-coverage.json`);
+    console.log(`Writing ${filename}`);
+    await fs.writeFile(filename, JSON.stringify(coverage));
+  }
+};
+
+main().catch(console.error);

--- a/yarn.lock
+++ b/yarn.lock
@@ -893,11 +893,6 @@ argparse@^1.0.7:
   dependencies:
     sprintf-js "~1.0.2"
 
-argv@^0.0.2:
-  version "0.0.2"
-  resolved "https://registry.yarnpkg.com/argv/-/argv-0.0.2.tgz#ecbd16f8949b157183711b1bda334f37840185ab"
-  integrity sha1-7L0W+JSbFXGDcRsb2jNPN4QBhas=
-
 arr-diff@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/arr-diff/-/arr-diff-4.0.0.tgz#d6461074febfec71e7e15235761a329a5dc7c520"
@@ -1763,17 +1758,6 @@ code-point-at@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/code-point-at/-/code-point-at-1.1.0.tgz#0d070b4d043a5bea33a2f1a40e2edb3d9a4ccf77"
   integrity sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=
-
-codecov@^3.5.0:
-  version "3.5.0"
-  resolved "https://registry.yarnpkg.com/codecov/-/codecov-3.5.0.tgz#3d0748932f9cb41e1ad7f21fa346ef1b2b1bed47"
-  integrity sha512-/OsWOfIHaQIr7aeZ4pY0UC1PZT6kimoKFOFYFNb6wxo3iw12nRrh+mNGH72rnXxNsq6SGfesVPizm/6Q3XqcFQ==
-  dependencies:
-    argv "^0.0.2"
-    ignore-walk "^3.0.1"
-    js-yaml "^3.13.1"
-    teeny-request "^3.11.3"
-    urlgrey "^0.4.4"
 
 coffee-script@^1.12.4:
   version "1.12.7"
@@ -7696,47 +7680,52 @@ tar@^4:
     yallist "^3.0.2"
 
 "taskcluster-client@link:clients/client":
-  version "14.0.0"
-  dependencies:
-    debug "^4.0.0"
-    hawk "^7.0.10"
-    lodash "^4.17.4"
-    slugid "^2.0.0"
-    superagent "^5.0.0"
-    taskcluster-lib-urls "^12.0.0"
+  version "0.0.0"
+  uid ""
 
 "taskcluster-lib-api@link:libraries/api":
-  version "12.8.1"
+  version "0.0.0"
+  uid ""
 
 "taskcluster-lib-app@link:libraries/app":
-  version "10.2.0"
+  version "0.0.0"
+  uid ""
 
 "taskcluster-lib-azure@link:libraries/azure":
-  version "10.0.0"
+  version "0.0.0"
+  uid ""
 
 "taskcluster-lib-config@link:libraries/config":
-  version "3.0.0"
+  version "0.0.0"
+  uid ""
 
 "taskcluster-lib-iterate@link:libraries/iterate":
-  version "11.0.0"
+  version "0.0.0"
+  uid ""
 
 "taskcluster-lib-loader@link:libraries/loader":
-  version "11.0.0"
+  version "0.0.0"
+  uid ""
 
 "taskcluster-lib-monitor@link:libraries/monitor":
-  version "11.1.1"
+  version "0.0.0"
+  uid ""
 
 "taskcluster-lib-pulse@link:libraries/pulse":
-  version "11.1.1"
+  version "0.0.0"
+  uid ""
 
 "taskcluster-lib-references@link:libraries/references":
-  version "1.5.0"
+  version "0.0.0"
+  uid ""
 
 "taskcluster-lib-scopes@link:libraries/scopes":
-  version "10.0.1"
+  version "0.0.0"
+  uid ""
 
 "taskcluster-lib-testing@link:libraries/testing":
-  version "12.1.2"
+  version "0.0.0"
+  uid ""
 
 taskcluster-lib-urls@^12.0.0:
   version "12.0.0"
@@ -7744,7 +7733,8 @@ taskcluster-lib-urls@^12.0.0:
   integrity sha512-OrEFE0m3p/+mGsmIwjttLhSKg3io6MpJLhYtPNjVSZA9Ix8Y5tprN3vM6a3MjWt5asPF6AKZsfT43cgpGwJB0g==
 
 "taskcluster-lib-validate@link:libraries/validate":
-  version "12.0.0"
+  version "0.0.0"
+  uid ""
 
 taskgroup@^4.0.5, taskgroup@^4.2.0:
   version "4.3.1"
@@ -7758,15 +7748,6 @@ teamwork@3.x.x:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/teamwork/-/teamwork-3.0.3.tgz#0c08748efe00c32c1eaf1128ef7f07ba0c7cc4ea"
   integrity sha512-OCB56z+G70iA1A1OFoT+51TPzfcgN0ks75uN3yhxA+EU66WTz2BevNDK4YzMqfaL5tuAvxy4iFUn35/u8pxMaQ==
-
-teeny-request@^3.11.3:
-  version "3.11.3"
-  resolved "https://registry.yarnpkg.com/teeny-request/-/teeny-request-3.11.3.tgz#335c629f7645e5d6599362df2f3230c4cbc23a55"
-  integrity sha512-CKncqSF7sH6p4rzCgkb/z/Pcos5efl0DmolzvlqRQUNcpRIruOhY9+T1FsIlyEbfWd7MsFpodROOwHYh2BaXzw==
-  dependencies:
-    https-proxy-agent "^2.2.1"
-    node-fetch "^2.2.0"
-    uuid "^3.3.2"
 
 temporary@^1.0.0:
   version "1.0.0"
@@ -8195,11 +8176,6 @@ url@0.10.3:
   dependencies:
     punycode "1.3.2"
     querystring "0.2.0"
-
-urlgrey@^0.4.4:
-  version "0.4.4"
-  resolved "https://registry.yarnpkg.com/urlgrey/-/urlgrey-0.4.4.tgz#892fe95960805e85519f1cd4389f2cb4cbb7652f"
-  integrity sha1-iS/pWWCAXoVRnxzUOJ8stMu3ZS8=
 
 urljoin@^0.1.5:
   version "0.1.5"


### PR DESCRIPTION
Ok, so what we've done here is just manually collect all the reports and submit them in one go. That should make reporting more reliable.