### PR TITLE
Bug 1552238 - [BREAKING] refer to workerTypes with workerTypeName

### DIFF
--- a/clients/client-py/README.md
+++ b/clients/client-py/README.md
@@ -4347,7 +4347,7 @@ Create a new workertype. If the workertype already exists, this will throw an er
 
 Takes the following arguments:
 
-  * `name`
+  * `workerTypeName`
 
 Has required input schema
 
@@ -4355,11 +4355,11 @@ Has required output schema
 
 ```python
 # Sync calls
-workerManager.createWorkerType(name, payload) # -> result
-workerManager.createWorkerType(payload, name='value') # -> result
+workerManager.createWorkerType(workerTypeName, payload) # -> result
+workerManager.createWorkerType(payload, workerTypeName='value') # -> result
 # Async call
-await asyncWorkerManager.createWorkerType(name, payload) # -> result
-await asyncWorkerManager.createWorkerType(payload, name='value') # -> result
+await asyncWorkerManager.createWorkerType(workerTypeName, payload) # -> result
+await asyncWorkerManager.createWorkerType(payload, workerTypeName='value') # -> result
 ```
 
 #### Update WorkerType
@@ -4369,7 +4369,7 @@ Given an existing workertype definition, this will modify it and return the new 
 
 Takes the following arguments:
 
-  * `name`
+  * `workerTypeName`
 
 Has required input schema
 
@@ -4377,31 +4377,31 @@ Has required output schema
 
 ```python
 # Sync calls
-workerManager.updateWorkerType(name, payload) # -> result
-workerManager.updateWorkerType(payload, name='value') # -> result
+workerManager.updateWorkerType(workerTypeName, payload) # -> result
+workerManager.updateWorkerType(payload, workerTypeName='value') # -> result
 # Async call
-await asyncWorkerManager.updateWorkerType(name, payload) # -> result
-await asyncWorkerManager.updateWorkerType(payload, name='value') # -> result
+await asyncWorkerManager.updateWorkerType(workerTypeName, payload) # -> result
+await asyncWorkerManager.updateWorkerType(payload, workerTypeName='value') # -> result
 ```
 
 #### Get WorkerType
-Given an existing workertype defition, this will fetch it.
+Fetch an existing workertype defition.
 
 
 
 Takes the following arguments:
 
-  * `name`
+  * `workerTypeName`
 
 Has required output schema
 
 ```python
 # Sync calls
-workerManager.workerType(name) # -> result
-workerManager.workerType(name='value') # -> result
+workerManager.workerType(workerTypeName) # -> result
+workerManager.workerType(workerTypeName='value') # -> result
 # Async call
-await asyncWorkerManager.workerType(name) # -> result
-await asyncWorkerManager.workerType(name='value') # -> result
+await asyncWorkerManager.workerType(workerTypeName) # -> result
+await asyncWorkerManager.workerType(workerTypeName='value') # -> result
 ```
 
 #### Delete WorkerType
@@ -4411,15 +4411,15 @@ Delete an existing workertype definition.
 
 Takes the following arguments:
 
-  * `name`
+  * `workerTypeName`
 
 ```python
 # Sync calls
-workerManager.deleteWorkerType(name) # -> None
-workerManager.deleteWorkerType(name='value') # -> None
+workerManager.deleteWorkerType(workerTypeName) # -> None
+workerManager.deleteWorkerType(workerTypeName='value') # -> None
 # Async call
-await asyncWorkerManager.deleteWorkerType(name) # -> None
-await asyncWorkerManager.deleteWorkerType(name='value') # -> None
+await asyncWorkerManager.deleteWorkerType(workerTypeName) # -> None
+await asyncWorkerManager.deleteWorkerType(workerTypeName='value') # -> None
 ```
 
 #### List All WorkerTypes
@@ -4442,7 +4442,7 @@ Get Taskcluster credentials for a worker given an Instance Identity Token
 
 Takes the following arguments:
 
-  * `name`
+  * `workerTypeName`
 
 Has required input schema
 
@@ -4450,11 +4450,11 @@ Has required output schema
 
 ```python
 # Sync calls
-workerManager.credentialsGoogle(name, payload) # -> result
-workerManager.credentialsGoogle(payload, name='value') # -> result
+workerManager.credentialsGoogle(workerTypeName, payload) # -> result
+workerManager.credentialsGoogle(payload, workerTypeName='value') # -> result
 # Async call
-await asyncWorkerManager.credentialsGoogle(name, payload) # -> result
-await asyncWorkerManager.credentialsGoogle(payload, name='value') # -> result
+await asyncWorkerManager.credentialsGoogle(workerTypeName, payload) # -> result
+await asyncWorkerManager.credentialsGoogle(payload, workerTypeName='value') # -> result
 ```
 
 

--- a/clients/client-py/taskcluster/aio/workermanager.py
+++ b/clients/client-py/taskcluster/aio/workermanager.py
@@ -59,7 +59,7 @@ class WorkerManager(AsyncBaseClient):
         """
         Get WorkerType
 
-        Given an existing workertype defition, this will fetch it.
+        Fetch an existing workertype defition.
 
         This method is ``experimental``
         """
@@ -101,28 +101,28 @@ class WorkerManager(AsyncBaseClient):
 
     funcinfo = {
         "createWorkerType": {
-            'args': ['name'],
+            'args': ['workerTypeName'],
             'input': 'v1/create-workertype-request.json#',
             'method': 'put',
             'name': 'createWorkerType',
             'output': 'v1/workertype-full.json#',
-            'route': '/workertype/<name>',
+            'route': '/workertype/<workerTypeName>',
             'stability': 'experimental',
         },
         "credentialsGoogle": {
-            'args': ['name'],
+            'args': ['workerTypeName'],
             'input': 'v1/credentials-google-request.json#',
             'method': 'post',
             'name': 'credentialsGoogle',
             'output': 'v1/temp-creds-response.json#',
-            'route': '/credentials/google/<name>',
+            'route': '/credentials/google/<workerTypeName>',
             'stability': 'experimental',
         },
         "deleteWorkerType": {
-            'args': ['name'],
+            'args': ['workerTypeName'],
             'method': 'delete',
             'name': 'deleteWorkerType',
-            'route': '/workertype/<name>',
+            'route': '/workertype/<workerTypeName>',
             'stability': 'experimental',
         },
         "listWorkerTypes": {
@@ -142,20 +142,20 @@ class WorkerManager(AsyncBaseClient):
             'stability': 'stable',
         },
         "updateWorkerType": {
-            'args': ['name'],
+            'args': ['workerTypeName'],
             'input': 'v1/create-workertype-request.json#',
             'method': 'post',
             'name': 'updateWorkerType',
             'output': 'v1/workertype-full.json#',
-            'route': '/workertype/<name>',
+            'route': '/workertype/<workerTypeName>',
             'stability': 'experimental',
         },
         "workerType": {
-            'args': ['name'],
+            'args': ['workerTypeName'],
             'method': 'get',
             'name': 'workerType',
             'output': 'v1/workertype-full.json#',
-            'route': '/workertype/<name>',
+            'route': '/workertype/<workerTypeName>',
             'stability': 'experimental',
         },
     }

--- a/clients/client-py/taskcluster/workermanager.py
+++ b/clients/client-py/taskcluster/workermanager.py
@@ -59,7 +59,7 @@ class WorkerManager(BaseClient):
         """
         Get WorkerType
 
-        Given an existing workertype defition, this will fetch it.
+        Fetch an existing workertype defition.
 
         This method is ``experimental``
         """
@@ -101,28 +101,28 @@ class WorkerManager(BaseClient):
 
     funcinfo = {
         "createWorkerType": {
-            'args': ['name'],
+            'args': ['workerTypeName'],
             'input': 'v1/create-workertype-request.json#',
             'method': 'put',
             'name': 'createWorkerType',
             'output': 'v1/workertype-full.json#',
-            'route': '/workertype/<name>',
+            'route': '/workertype/<workerTypeName>',
             'stability': 'experimental',
         },
         "credentialsGoogle": {
-            'args': ['name'],
+            'args': ['workerTypeName'],
             'input': 'v1/credentials-google-request.json#',
             'method': 'post',
             'name': 'credentialsGoogle',
             'output': 'v1/temp-creds-response.json#',
-            'route': '/credentials/google/<name>',
+            'route': '/credentials/google/<workerTypeName>',
             'stability': 'experimental',
         },
         "deleteWorkerType": {
-            'args': ['name'],
+            'args': ['workerTypeName'],
             'method': 'delete',
             'name': 'deleteWorkerType',
-            'route': '/workertype/<name>',
+            'route': '/workertype/<workerTypeName>',
             'stability': 'experimental',
         },
         "listWorkerTypes": {
@@ -142,20 +142,20 @@ class WorkerManager(BaseClient):
             'stability': 'stable',
         },
         "updateWorkerType": {
-            'args': ['name'],
+            'args': ['workerTypeName'],
             'input': 'v1/create-workertype-request.json#',
             'method': 'post',
             'name': 'updateWorkerType',
             'output': 'v1/workertype-full.json#',
-            'route': '/workertype/<name>',
+            'route': '/workertype/<workerTypeName>',
             'stability': 'experimental',
         },
         "workerType": {
-            'args': ['name'],
+            'args': ['workerTypeName'],
             'method': 'get',
             'name': 'workerType',
             'output': 'v1/workertype-full.json#',
-            'route': '/workertype/<name>',
+            'route': '/workertype/<workerTypeName>',
             'stability': 'experimental',
         },
     }

--- a/clients/client-web/src/clients/WorkerManager.js
+++ b/clients/client-web/src/clients/WorkerManager.js
@@ -11,12 +11,12 @@ export default class WorkerManager extends Client {
       ...options,
     });
     this.ping.entry = {"args":[],"method":"get","name":"ping","query":[],"route":"/ping","stability":"stable","type":"function"}; // eslint-disable-line
-    this.createWorkerType.entry = {"args":["name"],"input":true,"method":"put","name":"createWorkerType","output":true,"query":[],"route":"/workertype/<name>","scopes":{"AllOf":["worker-manager:create-worker-type:<name>","worker-manager:provider:<provider>"]},"stability":"experimental","type":"function"}; // eslint-disable-line
-    this.updateWorkerType.entry = {"args":["name"],"input":true,"method":"post","name":"updateWorkerType","output":true,"query":[],"route":"/workertype/<name>","scopes":{"AllOf":["worker-manager:update-worker-type:<name>","worker-manager:provider:<provider>"]},"stability":"experimental","type":"function"}; // eslint-disable-line
-    this.workerType.entry = {"args":["name"],"method":"get","name":"workerType","output":true,"query":[],"route":"/workertype/<name>","stability":"experimental","type":"function"}; // eslint-disable-line
-    this.deleteWorkerType.entry = {"args":["name"],"method":"delete","name":"deleteWorkerType","query":[],"route":"/workertype/<name>","scopes":"worker-manager:delete-worker-type:<name>","stability":"experimental","type":"function"}; // eslint-disable-line
+    this.createWorkerType.entry = {"args":["workerTypeName"],"input":true,"method":"put","name":"createWorkerType","output":true,"query":[],"route":"/workertype/<workerTypeName>","scopes":{"AllOf":["worker-manager:create-worker-type:<workerTypeName>","worker-manager:provider:<provider>"]},"stability":"experimental","type":"function"}; // eslint-disable-line
+    this.updateWorkerType.entry = {"args":["workerTypeName"],"input":true,"method":"post","name":"updateWorkerType","output":true,"query":[],"route":"/workertype/<workerTypeName>","scopes":{"AllOf":["worker-manager:update-worker-type:<workerTypeName>","worker-manager:provider:<provider>"]},"stability":"experimental","type":"function"}; // eslint-disable-line
+    this.workerType.entry = {"args":["workerTypeName"],"method":"get","name":"workerType","output":true,"query":[],"route":"/workertype/<workerTypeName>","stability":"experimental","type":"function"}; // eslint-disable-line
+    this.deleteWorkerType.entry = {"args":["workerTypeName"],"method":"delete","name":"deleteWorkerType","query":[],"route":"/workertype/<workerTypeName>","scopes":"worker-manager:delete-worker-type:<workerTypeName>","stability":"experimental","type":"function"}; // eslint-disable-line
     this.listWorkerTypes.entry = {"args":[],"method":"get","name":"listWorkerTypes","output":true,"query":["continuationToken","limit"],"route":"/workertypes","stability":"experimental","type":"function"}; // eslint-disable-line
-    this.credentialsGoogle.entry = {"args":["name"],"input":true,"method":"post","name":"credentialsGoogle","output":true,"query":[],"route":"/credentials/google/<name>","stability":"experimental","type":"function"}; // eslint-disable-line
+    this.credentialsGoogle.entry = {"args":["workerTypeName"],"input":true,"method":"post","name":"credentialsGoogle","output":true,"query":[],"route":"/credentials/google/<workerTypeName>","stability":"experimental","type":"function"}; // eslint-disable-line
   }
   /* eslint-disable max-len */
   // Respond without doing anything.
@@ -44,7 +44,7 @@ export default class WorkerManager extends Client {
     return this.request(this.updateWorkerType.entry, args);
   }
   /* eslint-disable max-len */
-  // Given an existing workertype defition, this will fetch it.
+  // Fetch an existing workertype defition.
   /* eslint-enable max-len */
   workerType(...args) {
     this.validate(this.workerType.entry, args);

--- a/clients/client/src/apis.js
+++ b/clients/client/src/apis.js
@@ -3753,7 +3753,7 @@ module.exports = {
         },
         {
           "args": [
-            "name"
+            "workerTypeName"
           ],
           "description": "Create a new workertype. If the workertype already exists, this will throw an error.",
           "input": "v1/create-workertype-request.json#",
@@ -3762,10 +3762,10 @@ module.exports = {
           "output": "v1/workertype-full.json#",
           "query": [
           ],
-          "route": "/workertype/<name>",
+          "route": "/workertype/<workerTypeName>",
           "scopes": {
             "AllOf": [
-              "worker-manager:create-worker-type:<name>",
+              "worker-manager:create-worker-type:<workerTypeName>",
               "worker-manager:provider:<provider>"
             ]
           },
@@ -3775,7 +3775,7 @@ module.exports = {
         },
         {
           "args": [
-            "name"
+            "workerTypeName"
           ],
           "description": "Given an existing workertype definition, this will modify it and return the new definition.",
           "input": "v1/create-workertype-request.json#",
@@ -3784,10 +3784,10 @@ module.exports = {
           "output": "v1/workertype-full.json#",
           "query": [
           ],
-          "route": "/workertype/<name>",
+          "route": "/workertype/<workerTypeName>",
           "scopes": {
             "AllOf": [
-              "worker-manager:update-worker-type:<name>",
+              "worker-manager:update-worker-type:<workerTypeName>",
               "worker-manager:provider:<provider>"
             ]
           },
@@ -3797,30 +3797,30 @@ module.exports = {
         },
         {
           "args": [
-            "name"
+            "workerTypeName"
           ],
-          "description": "Given an existing workertype defition, this will fetch it.",
+          "description": "Fetch an existing workertype defition.",
           "method": "get",
           "name": "workerType",
           "output": "v1/workertype-full.json#",
           "query": [
           ],
-          "route": "/workertype/<name>",
+          "route": "/workertype/<workerTypeName>",
           "stability": "experimental",
           "title": "Get WorkerType",
           "type": "function"
         },
         {
           "args": [
-            "name"
+            "workerTypeName"
           ],
           "description": "Delete an existing workertype definition.",
           "method": "delete",
           "name": "deleteWorkerType",
           "query": [
           ],
-          "route": "/workertype/<name>",
-          "scopes": "worker-manager:delete-worker-type:<name>",
+          "route": "/workertype/<workerTypeName>",
+          "scopes": "worker-manager:delete-worker-type:<workerTypeName>",
           "stability": "experimental",
           "title": "Delete WorkerType",
           "type": "function"
@@ -3843,7 +3843,7 @@ module.exports = {
         },
         {
           "args": [
-            "name"
+            "workerTypeName"
           ],
           "description": "Get Taskcluster credentials for a worker given an Instance Identity Token",
           "input": "v1/credentials-google-request.json#",
@@ -3852,7 +3852,7 @@ module.exports = {
           "output": "v1/temp-creds-response.json#",
           "query": [
           ],
-          "route": "/credentials/google/<name>",
+          "route": "/credentials/google/<workerTypeName>",
           "stability": "experimental",
           "title": "Google Credentials",
           "type": "function"

--- a/generated/references.json
+++ b/generated/references.json
@@ -63,14 +63,6 @@
           "title": "Last Modified",
           "type": "string"
         },
-        "name": {
-          "description": "The name of this workertype.\n",
-          "maxLength": 38,
-          "minLength": 1,
-          "pattern": "[a-z]([-a-z0-9]*[a-z0-9])?",
-          "title": "WorkerType Name",
-          "type": "string"
-        },
         "owner": {
           "description": "An email address to notify when there are provisioning errors for this\nworkertype.\n",
           "format": "email",
@@ -89,6 +81,12 @@
           "description": "If true, a user has requested that this workertype be deleted",
           "title": "Scheduled For Deletion",
           "type": "boolean"
+        },
+        "workerTypeName": {
+          "description": "The name of this workertype (of the form `providerId/workerType`)\n",
+          "pattern": "^[a-zA-Z0-9-_]{1,38}/[a-z]([-a-z0-9]{0,36}[a-z0-9])?$",
+          "title": "WorkerType Name",
+          "type": "string"
         }
       },
       "required": [
@@ -143,9 +141,6 @@
       "additionalProperties": false,
       "description": "The message that is emitted when workertypes are created/changed/deleted.",
       "properties": {
-        "name": {
-          "$ref": "workertype-full.json#/properties/provider"
-        },
         "previousProvider": {
           "description": "If this is defined, it was the provider that handled this workertype in the \nconfiguration before the current one. This will be used by providers to clean\nup any resources created for this workerType when they are no longer responsible\nfor it.\n",
           "maxLength": 38,
@@ -156,10 +151,13 @@
         },
         "provider": {
           "$ref": "workertype-full.json#/properties/provider"
+        },
+        "workerTypeName": {
+          "$ref": "workertype-full.json#/properties/workerTypeName"
         }
       },
       "required": [
-        "name",
+        "workerTypeName",
         "provider"
       ],
       "title": "WorkerType Pulse Message",
@@ -7875,7 +7873,7 @@
           "description": "A workerType's provisioning run has completed",
           "fields": {
             "provider": "The name of the provider that did the work for this workertype.",
-            "workerType": "The name of the workertype."
+            "workerTypeName": "The worker type name (provisionerId/workerType)"
           },
           "level": "info",
           "name": "workertypeProvisioned",
@@ -7892,7 +7890,7 @@
             "minCapacity": "The minimum amount of capacity that should be running",
             "pendingTasks": "The number of tasks the queue reports are pending for this workerType",
             "running": "Number of currently requested and running instances",
-            "workerType": "The name of the workertype."
+            "workerTypeName": "The worker type name (provisionerId/workerType)"
           },
           "level": "notice",
           "name": "simpleEstimate",
@@ -8040,7 +8038,7 @@
         },
         {
           "args": [
-            "name"
+            "workerTypeName"
           ],
           "description": "Create a new workertype. If the workertype already exists, this will throw an error.",
           "input": "v1/create-workertype-request.json#",
@@ -8049,10 +8047,10 @@
           "output": "v1/workertype-full.json#",
           "query": [
           ],
-          "route": "/workertype/<name>",
+          "route": "/workertype/<workerTypeName>",
           "scopes": {
             "AllOf": [
-              "worker-manager:create-worker-type:<name>",
+              "worker-manager:create-worker-type:<workerTypeName>",
               "worker-manager:provider:<provider>"
             ]
           },
@@ -8062,7 +8060,7 @@
         },
         {
           "args": [
-            "name"
+            "workerTypeName"
           ],
           "description": "Given an existing workertype definition, this will modify it and return the new definition.",
           "input": "v1/create-workertype-request.json#",
@@ -8071,10 +8069,10 @@
           "output": "v1/workertype-full.json#",
           "query": [
           ],
-          "route": "/workertype/<name>",
+          "route": "/workertype/<workerTypeName>",
           "scopes": {
             "AllOf": [
-              "worker-manager:update-worker-type:<name>",
+              "worker-manager:update-worker-type:<workerTypeName>",
               "worker-manager:provider:<provider>"
             ]
           },
@@ -8084,30 +8082,30 @@
         },
         {
           "args": [
-            "name"
+            "workerTypeName"
           ],
-          "description": "Given an existing workertype defition, this will fetch it.",
+          "description": "Fetch an existing workertype defition.",
           "method": "get",
           "name": "workerType",
           "output": "v1/workertype-full.json#",
           "query": [
           ],
-          "route": "/workertype/<name>",
+          "route": "/workertype/<workerTypeName>",
           "stability": "experimental",
           "title": "Get WorkerType",
           "type": "function"
         },
         {
           "args": [
-            "name"
+            "workerTypeName"
           ],
           "description": "Delete an existing workertype definition.",
           "method": "delete",
           "name": "deleteWorkerType",
           "query": [
           ],
-          "route": "/workertype/<name>",
-          "scopes": "worker-manager:delete-worker-type:<name>",
+          "route": "/workertype/<workerTypeName>",
+          "scopes": "worker-manager:delete-worker-type:<workerTypeName>",
           "stability": "experimental",
           "title": "Delete WorkerType",
           "type": "function"
@@ -8130,7 +8128,7 @@
         },
         {
           "args": [
-            "name"
+            "workerTypeName"
           ],
           "description": "Get Taskcluster credentials for a worker given an Instance Identity Token",
           "input": "v1/credentials-google-request.json#",
@@ -8139,7 +8137,7 @@
           "output": "v1/temp-creds-response.json#",
           "query": [
           ],
-          "route": "/credentials/google/<name>",
+          "route": "/credentials/google/<workerTypeName>",
           "stability": "experimental",
           "title": "Google Credentials",
           "type": "function"

--- a/services/worker-manager/README.md
+++ b/services/worker-manager/README.md
@@ -7,6 +7,11 @@ It currently includes providers for:
 * Static Workers
 * Google Cloud
 
+## workerTypeName
+
+This service considers a "workerTypeName" to be a string of the shape `<provisionerId>/<workerType>`.
+This definition is used internally and in the worker-manager API, with translations made to interact with other services such as Queue.
+
 ## Development
 
 No special configuration is required for development.

--- a/services/worker-manager/config.yml
+++ b/services/worker-manager/config.yml
@@ -4,7 +4,6 @@ defaults:
     workerTypeTableName: WMWorkerTypes
     workerTypeErrorTableName: WMWorkerTypeErrors
     errorsExpirationTime: '-4 days' # Anything older than a few days goes away
-    provisionerId: worker-manager
   monitoring:
     level: !env LEVEL
   taskcluster:

--- a/services/worker-manager/schemas/v1/pulse-workertype-message.yml
+++ b/services/worker-manager/schemas/v1/pulse-workertype-message.yml
@@ -3,7 +3,7 @@ title: WorkerType Pulse Message
 description: The message that is emitted when workertypes are created/changed/deleted.
 type: object
 properties:
-  name: {$ref: "workertype-full.json#/properties/provider"}
+  workerTypeName: {$ref: "workertype-full.json#/properties/workerTypeName"}
   provider: {$ref: "workertype-full.json#/properties/provider"}
   previousProvider:
     title: Previous Provider
@@ -18,5 +18,5 @@ properties:
       for it.
 additionalProperties: false
 required:
-  - name
+  - workerTypeName
   - provider

--- a/services/worker-manager/schemas/v1/workertype-full.yml
+++ b/services/worker-manager/schemas/v1/workertype-full.yml
@@ -4,15 +4,14 @@ description: |
   A complete workerType definition.
 type:               object
 properties:
-  name:
+  workerTypeName:
     title: WorkerType Name
     type:           string
-    # Limit this more than usual to increase chances it works on various clouds unchanged
-    pattern:        '[a-z]([-a-z0-9]*[a-z0-9])?'
-    minLength:      {$const: identifier-min-length}
-    maxLength:      {$const: identifier-max-length}
+    # Note that the workerType portion is quite severely limited in hopes it works with
+    # most cloud providers
+    pattern:        '^[a-zA-Z0-9-_]{1,38}/[a-z]([-a-z0-9]{0,36}[a-z0-9])?$'
     description: |
-      The name of this workertype.
+      The name of this workertype (of the form `providerId/workerType`)
   provider:
     title: Provider
     type:           string

--- a/services/worker-manager/src/estimator.js
+++ b/services/worker-manager/src/estimator.js
@@ -1,12 +1,14 @@
+const {splitWorkerTypeName} = require('./util');
+
 class Estimator {
-  constructor({queue, provisionerId, monitor}) {
+  constructor({queue, monitor}) {
     this.queue = queue;
-    this.provisionerId = provisionerId;
     this.monitor = monitor;
   }
 
-  async simple({name, minCapacity, maxCapacity, capacityPerInstance, running}) {
-    const {pendingTasks} = await this.queue.pendingTasks(this.provisionerId, name);
+  async simple({workerTypeName, minCapacity, maxCapacity, capacityPerInstance, running}) {
+    const {provisionerId, workerType} = splitWorkerTypeName(workerTypeName);
+    const {pendingTasks} = await this.queue.pendingTasks(provisionerId, workerType);
 
     // First we find the amount of capacity we want. This is a very simple approximation
     const desiredCapacity = Math.max(minCapacity, Math.min(pendingTasks, maxCapacity));
@@ -14,7 +16,7 @@ class Estimator {
     const desiredSize = Math.round(desiredCapacity / capacityPerInstance);
 
     this.monitor.log.simpleEstimate({
-      workerType: name,
+      workerTypeName,
       pendingTasks,
       minCapacity,
       maxCapacity,

--- a/services/worker-manager/src/main.js
+++ b/services/worker-manager/src/main.js
@@ -171,7 +171,6 @@ let load = loader({
   estimator: {
     requires: ['cfg', 'queue', 'monitor'],
     setup: ({cfg, queue, monitor}) => new Estimator({
-      provisionerId: cfg.app.provisionerId,
       queue,
       monitor: monitor.childMonitor('estimator'),
     }),
@@ -194,7 +193,6 @@ let load = loader({
           name,
           notify,
           monitor: monitor.childMonitor(name),
-          provisionerId: cfg.app.provisionerId,
           rootUrl: cfg.taskcluster.rootUrl,
           taskclusterCredentials: cfg.taskcluster.credentials,
           estimator,
@@ -214,7 +212,6 @@ let load = loader({
     setup: async ({cfg, monitor, WorkerType, providers, notify, pulseClient, reference}) => {
       const provisioner = new Provisioner({
         monitor: monitor.childMonitor('provisioner'),
-        provisionerId: cfg.app.provisionerId,
         WorkerType,
         providers,
         notify,

--- a/services/worker-manager/src/monitor.js
+++ b/services/worker-manager/src/monitor.js
@@ -12,7 +12,7 @@ monitorManager.register({
   level: 'info',
   description: 'A workerType\'s provisioning run has completed',
   fields: {
-    workerType: 'The name of the workertype.',
+    workerTypeName: 'The worker type name (provisionerId/workerType)',
     provider: 'The name of the provider that did the work for this workertype.',
   },
 });
@@ -25,7 +25,7 @@ monitorManager.register({
   level: 'notice',
   description: 'The simple estimator has decided that we need some number of instances.',
   fields: {
-    workerType: 'The name of the workertype.',
+    workerTypeName: 'The worker type name (provisionerId/workerType)',
     pendingTasks: 'The number of tasks the queue reports are pending for this workerType',
     minCapacity: 'The minimum amount of capacity that should be running',
     maxCapacity: 'The maximum amount of capacity that should be running',

--- a/services/worker-manager/src/provider.js
+++ b/services/worker-manager/src/provider.js
@@ -13,7 +13,6 @@ class Provider {
     name,
     monitor,
     notify,
-    provisionerId,
     rootUrl,
     taskclusterCredentials,
     estimator,
@@ -25,7 +24,6 @@ class Provider {
     this.monitor = monitor;
     this.validator = validator;
     this.notify = notify;
-    this.provisionerId = provisionerId;
     this.rootUrl = rootUrl;
     this.taskclusterCredentials = taskclusterCredentials;
     this.estimator = estimator;

--- a/services/worker-manager/src/provider_testing.js
+++ b/services/worker-manager/src/provider_testing.js
@@ -7,15 +7,15 @@ class TestingProvider extends Provider {
   }
 
   async createResources({workerType}) {
-    this.monitor.notice('create-resource', {workerType: workerType.name});
+    this.monitor.notice('create-resource', {workerTypeName: workerType.workerTypeName});
   }
 
   async updateResources({workerType}) {
-    this.monitor.notice('update-resource', {workerType: workerType.name});
+    this.monitor.notice('update-resource', {workerTypeName: workerType.workerTypeName});
   }
 
   async removeResources({workerType}) {
-    this.monitor.notice('remove-resource', {workerType: workerType.name});
+    this.monitor.notice('remove-resource', {workerTypeName: workerType.workerTypeName});
   }
 }
 

--- a/services/worker-manager/src/provisioner.js
+++ b/services/worker-manager/src/provisioner.js
@@ -6,8 +6,7 @@ const {consume} = require('taskcluster-lib-pulse');
  * Run all provisioning logic
  */
 class Provisioner {
-  constructor({provisionerId, providers, iterateConf, WorkerType, monitor, notify, pulseClient, reference, rootUrl}) {
-    this.provisionerId = provisionerId;
+  constructor({providers, iterateConf, WorkerType, monitor, notify, pulseClient, reference, rootUrl}) {
     this.providers = providers;
     this.WorkerType = WorkerType;
     this.monitor = monitor;
@@ -67,8 +66,8 @@ class Provisioner {
   }
 
   async onMessage({exchange, payload}) {
-    const {name, provider: providerName, previousProvider} = payload;
-    const workerType = await this.WorkerType.load({name});
+    const {workerTypeName, provider: providerName, previousProvider} = payload;
+    const workerType = await this.WorkerType.load({workerTypeName});
     const provider = this.providers[providerName]; // Always have a provider
     switch (exchange.split('/').pop()) {
       case 'workertype-created': {
@@ -118,7 +117,7 @@ class Provisioner {
         }));
 
         this.monitor.log.workertypeProvisioned({
-          workerType: workerType.name,
+          workerTypeName: workerType.workerTypeName,
           provider: workerType.provider,
         });
       },

--- a/services/worker-manager/src/util.js
+++ b/services/worker-manager/src/util.js
@@ -1,0 +1,24 @@
+const assert = require('assert');
+
+/**
+ * We consider a "workerTypeName" to be a string of the shape "<provisionerId>/<workerType>".
+ * For the most part, this service is concerned only with workerTypeNames, simply treating
+ * them as a combined identifier, but when calling other APIs like the queue we must use
+ * the constituent parts.
+ *
+ * These two functions serve to split and join workerTypeNames.
+ */
+const splitWorkerTypeName = workerTypeName => {
+  const split = workerTypeName.split('/');
+  assert.equal(split.length, 2, `invalid workerTypeName ${workerTypeName}`);
+  return {provisionerId: split[0], workerType: split[1]};
+};
+exports.splitWorkerTypeName = splitWorkerTypeName;
+
+const joinWorkerTypeName = (provisionerId, workerType) => {
+  assert(typeof provisionerId === 'string', 'provisionerId omitted');
+  assert(typeof workerType === 'string', 'workerType omitted');
+  assert(provisionerId.indexOf('/') === -1, 'provisionerId cannot contain `/`');
+  return `${provisionerId}/${workerType}`;
+};
+exports.joinWorkerTypeName = joinWorkerTypeName;

--- a/services/worker-manager/test/api_test.js
+++ b/services/worker-manager/test/api_test.js
@@ -12,16 +12,16 @@ helper.secrets.mockSuite(testing.suiteName(), ['taskcluster', 'azure'], function
     await helper.workerManager.ping();
   });
 
-  const workerTypeCompare = (name, input, result, deletion = false) => {
+  const workerTypeCompare = (workerTypeName, input, result, deletion = false) => {
     const {created, lastModified, scheduledForDeletion, ...definition} = result;
     assert(created);
     assert(lastModified);
     assert(scheduledForDeletion === deletion);
-    assert.deepEqual({name, ...input}, definition);
+    assert.deepEqual({workerTypeName, ...input}, definition);
   };
 
   test('create workertype', async function() {
-    const name = 'ee';
+    const workerTypeName = 'pp/ee';
     const input = {
       provider: 'testing1',
       description: 'bar',
@@ -29,8 +29,9 @@ helper.secrets.mockSuite(testing.suiteName(), ['taskcluster', 'azure'], function
       owner: 'example@example.com',
       emailOnError: false,
     };
-    workerTypeCompare(name, input, await helper.workerManager.createWorkerType(name, input));
-    const name2 = 'ee2';
+    workerTypeCompare(workerTypeName, input,
+      await helper.workerManager.createWorkerType(workerTypeName, input));
+    const workerTypeName2 = 'pp/ee2';
     const input2 = {
       provider: 'testing1',
       description: 'bing',
@@ -38,11 +39,12 @@ helper.secrets.mockSuite(testing.suiteName(), ['taskcluster', 'azure'], function
       owner: 'example@example.com',
       emailOnError: false,
     };
-    workerTypeCompare(name2, input2, await helper.workerManager.createWorkerType(name2, input2));
+    workerTypeCompare(workerTypeName2, input2,
+      await helper.workerManager.createWorkerType(workerTypeName2, input2));
   });
 
   test('update workertype', async function() {
-    const name = 'ee';
+    const workerTypeName = 'pp/ee';
     const input = {
       provider: 'testing1',
       description: 'bar',
@@ -50,8 +52,8 @@ helper.secrets.mockSuite(testing.suiteName(), ['taskcluster', 'azure'], function
       owner: 'example@example.com',
       emailOnError: false,
     };
-    const initial = await helper.workerManager.createWorkerType(name, input);
-    workerTypeCompare(name, input, initial);
+    const initial = await helper.workerManager.createWorkerType(workerTypeName, input);
+    workerTypeCompare(workerTypeName, input, initial);
     const input2 = {
       provider: 'testing2',
       description: 'bing',
@@ -59,8 +61,8 @@ helper.secrets.mockSuite(testing.suiteName(), ['taskcluster', 'azure'], function
       owner: 'example@example.com',
       emailOnError: false,
     };
-    const updated = await helper.workerManager.updateWorkerType(name, input2);
-    workerTypeCompare(name, input2, updated);
+    const updated = await helper.workerManager.updateWorkerType(workerTypeName, input2);
+    workerTypeCompare(workerTypeName, input2, updated);
 
     assert.equal(initial.lastModified, initial.created);
     assert.equal(initial.created, updated.created);
@@ -69,7 +71,7 @@ helper.secrets.mockSuite(testing.suiteName(), ['taskcluster', 'azure'], function
 
   test('create workertype (invalid provider)', async function() {
     try {
-      await helper.workerManager.createWorkerType('oo', {
+      await helper.workerManager.createWorkerType('pp/oo', {
         provider: 'foo',
         description: 'e',
         config: {},
@@ -86,7 +88,7 @@ helper.secrets.mockSuite(testing.suiteName(), ['taskcluster', 'azure'], function
   });
 
   test('update workertype (invalid provider)', async function() {
-    await helper.workerManager.createWorkerType('oo', {
+    await helper.workerManager.createWorkerType('pp/oo', {
       provider: 'testing1',
       description: 'e',
       config: {},
@@ -94,7 +96,7 @@ helper.secrets.mockSuite(testing.suiteName(), ['taskcluster', 'azure'], function
       emailOnError: false,
     });
     try {
-      await helper.workerManager.updateWorkerType('oo', {
+      await helper.workerManager.updateWorkerType('pp/oo', {
         provider: 'foo',
         description: 'e',
         config: {},
@@ -111,7 +113,7 @@ helper.secrets.mockSuite(testing.suiteName(), ['taskcluster', 'azure'], function
   });
 
   test('create workertype (already exists)', async function() {
-    await helper.workerManager.createWorkerType('oo', {
+    await helper.workerManager.createWorkerType('pp/oo', {
       provider: 'testing1',
       description: 'e',
       config: {},
@@ -119,7 +121,7 @@ helper.secrets.mockSuite(testing.suiteName(), ['taskcluster', 'azure'], function
       emailOnError: false,
     });
     try {
-      await helper.workerManager.createWorkerType('oo', {
+      await helper.workerManager.createWorkerType('pp/oo', {
         provider: 'testing2',
         description: 'e',
         config: {},
@@ -137,7 +139,7 @@ helper.secrets.mockSuite(testing.suiteName(), ['taskcluster', 'azure'], function
 
   test('update workertype (does not exist)', async function() {
     try {
-      await helper.workerManager.updateWorkerType('oo', {
+      await helper.workerManager.updateWorkerType('pp/oo', {
         provider: 'testing1',
         description: 'e',
         config: {},
@@ -154,7 +156,7 @@ helper.secrets.mockSuite(testing.suiteName(), ['taskcluster', 'azure'], function
   });
 
   test('get workertype', async function() {
-    const name = 'ee';
+    const workerTypeName = 'pp/ee';
     const input = {
       provider: 'testing1',
       description: 'bar',
@@ -162,13 +164,13 @@ helper.secrets.mockSuite(testing.suiteName(), ['taskcluster', 'azure'], function
       owner: 'example@example.com',
       emailOnError: false,
     };
-    await helper.workerManager.createWorkerType(name, input);
-    workerTypeCompare(name, input, await helper.workerManager.workerType(name));
+    await helper.workerManager.createWorkerType(workerTypeName, input);
+    workerTypeCompare(workerTypeName, input, await helper.workerManager.workerType(workerTypeName));
   });
 
   test('get workertype (does not exist)', async function() {
     try {
-      await helper.workerManager.workerType('oo');
+      await helper.workerManager.workerType('pp/oo');
     } catch (err) {
       if (err.code !== 'ResourceNotFound') {
         throw err;
@@ -179,7 +181,7 @@ helper.secrets.mockSuite(testing.suiteName(), ['taskcluster', 'azure'], function
   });
 
   test('delete workertype', async function() {
-    const name = 'ee';
+    const workerTypeName = 'pp/ee';
     const input = {
       provider: 'testing1',
       description: 'bar',
@@ -187,14 +189,16 @@ helper.secrets.mockSuite(testing.suiteName(), ['taskcluster', 'azure'], function
       owner: 'example@example.com',
       emailOnError: false,
     };
-    workerTypeCompare(name, input, await helper.workerManager.createWorkerType(name, input));
-    await helper.workerManager.deleteWorkerType(name);
-    workerTypeCompare(name, input, await helper.workerManager.workerType(name), true);
+    workerTypeCompare(workerTypeName, input,
+      await helper.workerManager.createWorkerType(workerTypeName, input));
+    await helper.workerManager.deleteWorkerType(workerTypeName);
+    workerTypeCompare(workerTypeName, input,
+      await helper.workerManager.workerType(workerTypeName), true);
   });
 
   test('delete workertype (does not exist)', async function() {
     try {
-      await helper.workerManager.deleteWorkerType('whatever');
+      await helper.workerManager.deleteWorkerType('pp/whatever');
     } catch (err) {
       if (err.code !== 'ResourceNotFound') {
         throw err;
@@ -223,39 +227,44 @@ helper.secrets.mockSuite(testing.suiteName(), ['taskcluster', 'azure'], function
   };
 
   test('create (google) workertype', async function() {
-    const name = 'ee';
-    workerTypeCompare(name, googleInput, await helper.workerManager.createWorkerType(name, googleInput));
+    const workerTypeName = 'pp/ee';
+    workerTypeCompare(workerTypeName, googleInput,
+      await helper.workerManager.createWorkerType(workerTypeName, googleInput));
   });
 
   test('credentials google', async function() {
-    const name = 'ee';
+    const workerTypeName = 'pp/ee';
     await helper.Worker.create({
-      workerType: name,
-      workerId: 'gcp-abc123', // TODO: Don't just copy-paste this from fake-google
+      workerTypeName,
+      workerGroup: 'google',
+      workerId: 'abc123',
       provider: 'google',
       created: new Date(),
       expires: taskcluster.fromNow('1 hour'),
       state: helper.Worker.states.REQUESTED,
       providerData: {},
     });
-    workerTypeCompare(name, googleInput, await helper.workerManager.createWorkerType(name, googleInput));
-    await helper.workerManager.credentialsGoogle(name, {token: 'abc'});
+    workerTypeCompare(workerTypeName, googleInput,
+      await helper.workerManager.createWorkerType(workerTypeName, googleInput));
+    await helper.workerManager.credentialsGoogle(workerTypeName, {token: 'abc'});
   });
 
   test('credentials google (but wrong worker)', async function() {
-    const name = 'ee';
+    const workerTypeName = 'pp/ee';
     await helper.Worker.create({
-      workerType: name,
-      workerId: 'gcp-wrong',
+      workerTypeName,
+      workerGroup: 'google',
+      workerId: 'gcp',
       provider: 'google',
       created: new Date(),
       expires: taskcluster.fromNow('1 hour'),
       state: helper.Worker.states.REQUESTED,
       providerData: {},
     });
-    workerTypeCompare(name, googleInput, await helper.workerManager.createWorkerType(name, googleInput));
+    workerTypeCompare(workerTypeName, googleInput,
+      await helper.workerManager.createWorkerType(workerTypeName, googleInput));
     try {
-      await helper.workerManager.credentialsGoogle(name, {token: 'abc'});
+      await helper.workerManager.credentialsGoogle(workerTypeName, {token: 'abc'});
     } catch (err) {
       if (err.code !== 'InputError') {
         throw err;
@@ -266,19 +275,21 @@ helper.secrets.mockSuite(testing.suiteName(), ['taskcluster', 'azure'], function
   });
 
   test('credentials google (but wrong workertype)', async function() {
-    const name = 'ee';
+    const workerTypeName = 'pp/ee';
     await helper.Worker.create({
-      workerType: 'wrong',
-      workerId: 'gcp-abc123', // TODO: Don't just copy-paste this from fake-google
+      workerTypeName: 'wrong',
+      workerGroup: 'google',
+      workerId: 'abc123', // TODO: Don't just copy-paste this from fake-google
       provider: 'google',
       created: new Date(),
       expires: taskcluster.fromNow('1 hour'),
       state: helper.Worker.states.REQUESTED,
       providerData: {},
     });
-    workerTypeCompare(name, googleInput, await helper.workerManager.createWorkerType(name, googleInput));
+    workerTypeCompare(workerTypeName, googleInput,
+      await helper.workerManager.createWorkerType(workerTypeName, googleInput));
     try {
-      await helper.workerManager.credentialsGoogle(name, {token: 'abc'});
+      await helper.workerManager.credentialsGoogle(workerTypeName, {token: 'abc'});
     } catch (err) {
       if (err.code !== 'InputError') {
         throw err;
@@ -289,21 +300,23 @@ helper.secrets.mockSuite(testing.suiteName(), ['taskcluster', 'azure'], function
   });
 
   test('credentials google (second fetch fails)', async function() {
-    const name = 'ee';
+    const workerTypeName = 'pp/ee';
     await helper.Worker.create({
-      workerType: name,
-      workerId: 'gcp-abc123', // TODO: Don't just copy-paste this from fake-google
+      workerTypeName,
+      workerGroup: 'google',
+      workerId: 'abc123', // TODO: Don't just copy-paste this from fake-google
       provider: 'google',
       created: new Date(),
       expires: taskcluster.fromNow('1 hour'),
       state: helper.Worker.states.REQUESTED,
       providerData: {},
     });
-    workerTypeCompare(name, googleInput, await helper.workerManager.createWorkerType(name, googleInput));
+    workerTypeCompare(workerTypeName, googleInput,
+      await helper.workerManager.createWorkerType(workerTypeName, googleInput));
 
-    await helper.workerManager.credentialsGoogle(name, {token: 'abc'});
+    await helper.workerManager.credentialsGoogle(workerTypeName, {token: 'abc'});
     try {
-      await helper.workerManager.credentialsGoogle(name, {token: 'abc'});
+      await helper.workerManager.credentialsGoogle(workerTypeName, {token: 'abc'});
     } catch (err) {
       if (err.code !== 'InputError') {
         throw err;

--- a/services/worker-manager/test/provider_google_test.js
+++ b/services/worker-manager/test/provider_google_test.js
@@ -14,14 +14,13 @@ helper.secrets.mockSuite(testing.suiteName(), ['taskcluster', 'azure'], function
   let workerType;
   let worker;
   let providerName = 'google';
-  let workerTypeName = 'foobar';
+  let workerTypeName = 'foo/bar';
 
   setup(async function() {
     provider = new GoogleProvider({
       name: providerName,
       notify: await helper.load('notify'),
       monitor: (await helper.load('monitor')).childMonitor('google'),
-      provisionerId: 'whatever',
       estimator: await helper.load('estimator'),
       fake: true,
       rootUrl: helper.rootUrl,
@@ -29,7 +28,7 @@ helper.secrets.mockSuite(testing.suiteName(), ['taskcluster', 'azure'], function
       WorkerType: helper.WorkerType,
     });
     workerType = await helper.WorkerType.create({
-      name: workerTypeName,
+      workerTypeName,
       provider: providerName,
       description: 'none',
       scheduledForDeletion: false,
@@ -52,8 +51,9 @@ helper.secrets.mockSuite(testing.suiteName(), ['taskcluster', 'azure'], function
       emailOnError: false,
     });
     worker = await helper.Worker.create({
-      workerType: workerTypeName,
-      workerId: 'gcp-abc123', // TODO: Don't just copy-paste this from fake-google
+      workerTypeName: workerTypeName,
+      workerGroup: providerName,
+      workerId: 'abc123',
       provider: providerName,
       created: new Date(),
       expires: taskcluster.fromNow('1 hour'),

--- a/services/worker-manager/test/util_test.js
+++ b/services/worker-manager/test/util_test.js
@@ -1,0 +1,32 @@
+const assert = require('assert');
+const util = require('../src/util');
+const testing = require('taskcluster-lib-testing');
+
+suite(testing.suiteName(), function() {
+  suite('workerTypeName', function() {
+    test('splitWorkerTypeName for valid workerTypeName', function() {
+      assert.deepEqual(util.splitWorkerTypeName('provFoo/wtFoo'),
+        {provisionerId: 'provFoo', workerType: 'wtFoo'});
+    });
+
+    test('splitWorkerTypeName for invalid workerTypeName', function() {
+      assert.throws(() => util.splitWorkerTypeName('noSlashes'), /invalid workerTypeName/);
+    });
+
+    test('joinWorkerTypeName for valid inputs', function() {
+      assert.equal(util.joinWorkerTypeName('myProv', 'myWt'), 'myProv/myWt');
+    });
+
+    test('joinWorkerTypeName for undefined provisionerId', function() {
+      assert.throws(() => util.joinWorkerTypeName(undefined, 'myWt'), /provisionerId omitted/);
+    });
+
+    test('joinWorkerTypeName for invalid provisionerId', function() {
+      assert.throws(() => util.joinWorkerTypeName('a/b', 'myWt'), /provisionerId cannot contain/);
+    });
+
+    test('joinWorkerTypeName for undefined workerTypoe', function() {
+      assert.throws(() => util.joinWorkerTypeName('myProv', undefined), /workerType omitted/);
+    });
+  });
+});


### PR DESCRIPTION
This is of the form `<provisionerId>/<workerType>`, but within the
worker-manager is treated as a single unit.

Note that this is a breaking change, as it changes the indexes for the
Azure tables.  That means all installs will need to delete existing
tables and allow the service to re-create them.  At this point in
deployment of this service, that's not a great harm.

An unfortunate downside of this change is that URLs look like
`/api/worker-manager/v1/worker-type/some-provisioner%7Esome-worker-type`,
with the `/` inside the workerTypeName escaped.  I played around a bit
with the route matching and it seems like `path-to-regexp` (which
Express uses to parse its routes) is completely broken regarding
parameter expressions in the version used by Express 4.  Express 5
should do better, so let's plan to revisit this issue at that time.

Bugzilla Bug: [1552238](https://bugzilla.mozilla.org/show_bug.cgi?id=1552238)
