### PR TITLE
Add note that provisionerId and workerGroup are often the same

### DIFF
--- a/services/worker-manager/README.md
+++ b/services/worker-manager/README.md
@@ -13,6 +13,11 @@ This service currently includes providers for:
 * Google Cloud (`google`)
 * Testing (`testing`, only used in the service's unit tests)
 
+## Worker Identity
+
+Workers are identified by a combination of a `workerGroup` and a `workerId`.
+In order to ensure a unique identity for each worker, providers are expected to use their `providerId` as the `workerGroup`, but are free to choose an arbitrary (but unqiue and valid) `workerId` for each worker.
+
 ## workerTypeName
 
 This service considers a "workerTypeName" to be a string of the shape `<provisionerId>/<workerType>`.

--- a/services/worker-manager/schemas/v1/workertype-full.yml
+++ b/services/worker-manager/schemas/v1/workertype-full.yml
@@ -15,6 +15,8 @@ properties:
   providerId:
     title: Provider
     type:           string
+    # note that this is typically used as the workerGroup for workers,
+    # so its format should match that for workerGroup.
     minLength:      {$const: identifier-min-length}
     maxLength:      {$const: identifier-max-length}
     pattern:        {$const: identifier-pattern}


### PR DESCRIPTION
(just docs, since the formats for `workerGroup` and `providerId` already match)