### PR TITLE
Use 'providerId' instead of 'name' in providers

### DIFF
--- a/services/worker-manager/src/main.js
+++ b/services/worker-manager/src/main.js
@@ -181,18 +181,18 @@ let load = loader({
     setup: async ({cfg, monitor, notify, estimator, Worker, WorkerType, schemaset}) => {
       const _providers = {};
       const validator = await schemaset.validator(cfg.taskcluster.rootUrl);
-      for (const [name, meta] of Object.entries(cfg.providers)) {
+      for (const [providerId, meta] of Object.entries(cfg.providers)) {
         let Prov;
         switch(meta.providerType) {
           case 'testing': Prov = require('./provider_testing').TestingProvider; break;
           case 'static': Prov = require('./provider_static').StaticProvider; break;
           case 'google': Prov = require('./provider_google').GoogleProvider; break;
-          default: throw new Error(`Unkown providerType ${meta.providerType} selected for providerId ${name}.`);
+          default: throw new Error(`Unkown providerType ${meta.providerType} selected for providerId ${providerId}.`);
         }
-        _providers[name] = new Prov({
-          name,
+        _providers[providerId] = new Prov({
+          providerId,
           notify,
-          monitor: monitor.childMonitor(name),
+          monitor: monitor.childMonitor(providerId),
           rootUrl: cfg.taskcluster.rootUrl,
           taskclusterCredentials: cfg.taskcluster.credentials,
           estimator,
@@ -201,7 +201,7 @@ let load = loader({
           validator,
           ...meta,
         });
-        await _providers[name].setup();
+        await _providers[providerId].setup();
       }
       return _providers;
     },

--- a/services/worker-manager/src/provider.js
+++ b/services/worker-manager/src/provider.js
@@ -10,7 +10,7 @@ class Provider {
    * logic should be started in `initiate` below.
    */
   constructor({
-    name,
+    providerId,
     monitor,
     notify,
     rootUrl,
@@ -20,8 +20,7 @@ class Provider {
     validator,
     WorkerType,
   }) {
-    // TODO: -> providerId
-    this.name = name;
+    this.providerId = providerId;
     this.monitor = monitor;
     this.validator = validator;
     this.notify = notify;

--- a/services/worker-manager/test/provider_google_test.js
+++ b/services/worker-manager/test/provider_google_test.js
@@ -18,7 +18,7 @@ helper.secrets.mockSuite(testing.suiteName(), ['taskcluster', 'azure'], function
 
   setup(async function() {
     provider = new GoogleProvider({
-      name: providerId,
+      providerId,
       notify: await helper.load('notify'),
       monitor: (await helper.load('monitor')).childMonitor('google'),
       estimator: await helper.load('estimator'),


### PR DESCRIPTION
A pretty small change, but it means that the code reads `this.provisionerId`, giving a much better clue as to what the value is than `this.name`.