### PR TITLE
Bug 1551249 - always hide claim messages for at least one second

### DIFF
--- a/services/queue/src/queueservice.js
+++ b/services/queue/src/queueservice.js
@@ -11,10 +11,12 @@ let slugid = require('slugid');
 /** Timeout for azure queue requests */
 const AZURE_QUEUE_TIMEOUT = 7 * 1000;
 
-/** Get seconds until `target` relative to now (by default) */
+/** Get seconds until `target` relative to now (by default).  This rounds up
+ * and always waits at least one second, to avoid races in tests where
+ * everything happens in a matter of milliseconds. */
 let secondsTo = (target, relativeTo = new Date()) => {
-  let delta = Math.floor((target.getTime() - relativeTo.getTime()) / 1000);
-  return Math.max(delta, 0); // never return negative time
+  let delta = Math.ceil((target.getTime() - relativeTo.getTime()) / 1000);
+  return Math.max(delta, 1);
 };
 
 /** Validate task description object */

--- a/services/queue/src/workclaimer.js
+++ b/services/queue/src/workclaimer.js
@@ -219,9 +219,11 @@ class WorkClaimer extends events.EventEmitter {
       }
     }
 
-    // Set takenUntil to now + claimTimeout
+    // Set takenUntil to now + claimTimeout, rounding up to the nearest second
+    // since we compare these times for equality after sending them to Azure
+    // and toJSON()
     let takenUntil = new Date();
-    takenUntil.setSeconds(takenUntil.getSeconds() + this._claimTimeout);
+    takenUntil.setSeconds(Math.ceil(takenUntil.getSeconds() + this._claimTimeout));
 
     // Modify task, don't send putClaimMessage more than once!
     let msgSent = false;


### PR DESCRIPTION
..and use whole-second takenUntil values to avoid encoding/decoding
errors.

I'm not sure the second part is necessary, but I think it can't hurt.

Bugzilla Bug: [1551249](https://bugzilla.mozilla.org/show_bug.cgi?id=1551249)
