### PR TITLE
Be less precise with coverage diffs

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -9,6 +9,13 @@ codecov:
 
 comment: off
 
+coverage:
+  precision: 0
+  status:
+    project:
+      default:
+        threshold: 1 # This combined with precision 0 should stop us from failing checks randomly
+
 parsers:
   javascript:
     enable_partials: yes


### PR DESCRIPTION
This should stop the coverage check flaking on master and such. If this doesn't help, we can just turn the check off on master or something.

Another option is to figure out why coverage seemingly randomly changes by tiny amounts on each patch but that is harder and probably best left for another day.