### PR TITLE
Ignore client-py in eslint

### DIFF
--- a/package.json
+++ b/package.json
@@ -156,7 +156,7 @@
     "zurvan": "^0.5.2"
   },
   "scripts": {
-    "lint": "eslint --cache --ext js --ignore-pattern clients/client-web/build libraries services infrastructure clients test",
+    "lint": "eslint --cache --ext js --ignore-pattern clients/client-web/build --ignore-pattern clients/client-py libraries services infrastructure clients test",
     "test": "yarn workspaces run test",
     "test:meta": "mocha test/*_test.js",
     "fetch-coverage": "node test/fetch-coverage.js",


### PR DESCRIPTION
Otherwise virtualenvs in this directory contain JS files which eslint
proceeds to check.
