### PR TITLE
[UI] Make setTimeout work with large timeout values

### DIFF
--- a/ui/src/auth/AuthController.js
+++ b/ui/src/auth/AuthController.js
@@ -1,6 +1,6 @@
 import mitt from 'mitt';
 import { snake, upper } from 'change-case';
-import { AUTH_STORE } from '../utils/constants';
+import { MAX_SET_TIMEOUT_DELAY, AUTH_STORE } from '../utils/constants';
 import credentialsQuery from './credentials.graphql';
 import removeKeys from '../utils/removeKeys';
 import UserSession from './UserSession';
@@ -82,7 +82,7 @@ export default class AuthController {
       this.renewalTimer = window.setTimeout(() => {
         this.renewalTimer = null;
         this.renew(user);
-      }, timeout);
+      }, Math.min(timeout, MAX_SET_TIMEOUT_DELAY));
     }
   }
 

--- a/ui/src/utils/constants.js
+++ b/ui/src/utils/constants.js
@@ -220,3 +220,6 @@ export const DENYLIST_NOTIFICATION_TYPES = {
 
 export const KNOWN_ACRONYMS = ['IRC', 'API'];
 export const AUTH_STORE = '@@TASKCLUSTER_WEB_AUTH';
+// The delay (in milliseconds) for `setTimeout` is a 32 bit signed quantity,
+// which limits it to 2^31-1 ms (2147483647 ms) or 24.855 days.
+export const MAX_SET_TIMEOUT_DELAY = 2 ** 31 - 1;


### PR DESCRIPTION
The delay (in milliseconds) for `setTimeout` is a 32 bit signed quantity, which limits it to 2^31-1 ms (2147483647 ms) or 24.855 days. Renewal timers are sometimes 1000 years so we should make sure we don't go past the max value.