### PR TITLE
Use cmdOptions.cache

### DIFF
--- a/infrastructure/builder/src/build/index.js
+++ b/infrastructure/builder/src/build/index.js
@@ -32,7 +32,7 @@ class Build {
   }
 
   async run() {
-    if (this.cmdOptions.noCache) {
+    if (!this.cmdOptions.cache) {
       await rimraf(this.baseDir);
     }
     await mkdirp(this.baseDir);

--- a/infrastructure/builder/src/build/monoimage.js
+++ b/infrastructure/builder/src/build/monoimage.js
@@ -325,7 +325,7 @@ const generateMonoimageTasks = ({tasks, baseDir, cmdOptions}) => {
         .some(image => image.RepoTags && image.RepoTags.indexOf(tag) !== -1);
       const imageOnRegistry = await dockerRegistryCheck({tag});
 
-      if (imageOnRegistry && cmdOptions.noCache) {
+      if (imageOnRegistry && !cmdOptions.cache) {
         throw new Error(
           `Image ${tag} already exists on the registry, but --no-cache was given.`);
       }

--- a/infrastructure/builder/src/release/index.js
+++ b/infrastructure/builder/src/release/index.js
@@ -13,7 +13,7 @@ class Release {
     this.build = new Build({
       ...cmdOptions,
       push: true, // always push the resuting image
-      noCache: true, // always build from scratch
+      cache: false, // always build from scratch
     });
   }
 


### PR DESCRIPTION
Either this never worked, or it worked once and `program` changed how it
interprets `--no-foo` options.
