### PR TITLE
enable encryption on azure resources

### DIFF
--- a/infrastructure/terraform/main.tf
+++ b/infrastructure/terraform/main.tf
@@ -137,6 +137,8 @@ resource "azurerm_storage_account" "base" {
   location                 = "${var.azure_region}"
   account_tier             = "Standard"
   account_replication_type = "RAGRS"
+  enable_blob_encryption   = "true"
+  enable_file_encryption   = "true"
 
   tags {
     environment = "staging"


### PR DESCRIPTION
This seemed to fix issues where Azure was complaining that disabling encryption was not supported.  I'm guessing some default has changed?