### PR TITLE
Bug 1551607 - use docker volumes for building

### DIFF
--- a/infrastructure/builder/src/build/index.js
+++ b/infrastructure/builder/src/build/index.js
@@ -55,7 +55,6 @@ class Build {
       return;
     }
     const context = await taskgraph.run({'build-can-start': true});
-    console.log('DONE');
 
     console.log(`Monoimage docker image: ${context['monoimage-docker-image']}`);
     if (!this.cmdOptions.push) {

--- a/infrastructure/builder/src/build/index.js
+++ b/infrastructure/builder/src/build/index.js
@@ -55,6 +55,7 @@ class Build {
       return;
     }
     const context = await taskgraph.run({'build-can-start': true});
+    console.log('DONE');
 
     console.log(`Monoimage docker image: ${context['monoimage-docker-image']}`);
     if (!this.cmdOptions.push) {

--- a/infrastructure/builder/src/build/monoimage.js
+++ b/infrastructure/builder/src/build/monoimage.js
@@ -395,7 +395,7 @@ const generateMonoimageTasks = ({tasks, baseDir, cmdOptions}) => {
       await dockerRun({
         image: nodeImage,
         workingDir: '/',
-        command: ['bash', '-cex', 'ls -al /base && tar -C /base/app -cf - . | tar -C /app -xf -'],
+        command: ['bash', '-cex', 'tar -C /base/app -cf - . | tar -C /app -xf -'],
         logfile: `${baseDir}/app-copy.log`,
         utils,
         mounts: [

--- a/infrastructure/builder/src/build/monoimage.js
+++ b/infrastructure/builder/src/build/monoimage.js
@@ -1,16 +1,14 @@
 const util = require('util');
-const assert = require('assert');
 const fs = require('fs');
 const path = require('path');
 const rimraf = util.promisify(require('rimraf'));
+const mkdirp = util.promisify(require('mkdirp'));
 const {quote} = require('shell-quote');
 const tar = require('tar-fs');
-const copy = require('recursive-copy');
 const yaml = require('js-yaml');
 const Stamp = require('./stamp');
 const appRootDir = require('app-root-dir');
 const {
-  gitClone,
   gitIsDirty,
   gitDescribe,
   dockerRun,
@@ -19,10 +17,13 @@ const {
   dockerBuild,
   dockerRegistryCheck,
   ensureDockerImage,
+  ensureDockerVolume,
   ensureTask,
   listServices,
   dockerPush,
 } = require('../utils');
+
+const DOCKER_VOLUME_NAME = 'taskcluster-builder-build';
 
 /**
  * The "monoimage" is a single docker image containing all tasks.  This build process goes
@@ -31,6 +32,7 @@ const {
  *  - Clone the monorepo (from the current working copy)
  *  - Build it (install dependencies, transpile, etc.)
  *    - generate an "entrypoint" script to allow things like "docker run <monoimage> service/web"
+ *    - done in a Docker volume to avoid Docker for Mac bugs
  *  - Build the docker image containing the app (/app)
  *
  *  All of this is done using a "hooks" approach to allow segmenting the various oddball bits of
@@ -39,8 +41,6 @@ const {
 const generateMonoimageTasks = ({tasks, baseDir, cmdOptions}) => {
   const packageJson = JSON.parse(fs.readFileSync(path.join(appRootDir.get(), 'package.json')));
   const nodeVersion = packageJson.engines.node;
-  const workDir = path.join(baseDir, 'monoimage');
-  const appDir = path.join(workDir, 'app');
 
   // list of all services in the monorepo
   const services = listServices({repoDir: appRootDir.get()});
@@ -49,6 +49,8 @@ const generateMonoimageTasks = ({tasks, baseDir, cmdOptions}) => {
   const nodeImage = `node:${nodeVersion}`;
   // but the alpine image can run the services..
   const nodeAlpineImage = `node:${nodeVersion}-alpine`;
+
+  const sourceDir = appRootDir.get();
 
   ensureDockerImage(tasks, baseDir, nodeImage);
   ensureDockerImage(tasks, baseDir, nodeAlpineImage);
@@ -66,40 +68,43 @@ const generateMonoimageTasks = ({tasks, baseDir, cmdOptions}) => {
     requires: ['monorepo-git-descr'],
     build: async (requirements, utils) => {
       // let the services know what version they are running
-      fs.writeFileSync(path.join(appDir, 'taskcluster-version'), requirements['monorepo-git-descr']);
+      await dockerRun({
+        image: nodeImage,
+        workingDir: '/base/app',
+        command: ['sh', '-c', `echo "${requirements['monorepo-git-descr']}" > taskcluster-version`],
+        mounts: [
+          {Type: 'volume', Target: '/base', Source: requirements['build-docker-volume']},
+        ],
+        logfile: `${baseDir}/tc-version.log`,
+        utils,
+        baseDir,
+      });
     },
   });
 
   hooks.push({
     name: 'API Services',
     build: async (requirements, utils) => {
-      const cacheDir = path.join(workDir, 'cache');
-      if (!fs.existsSync(cacheDir)) {
-        fs.mkdirSync(cacheDir);
-      }
-
       await dockerRun({
         image: nodeImage,
-        workingDir: '/app',
-        command: ['yarn', 'install', '--frozen-lockfile'],
-        binds: [
-          `${appDir}:/app`,
-          `${cacheDir}:/cache`,
+        workingDir: '/base/app',
+        command: ['sh', '-ce', [
+          'mkdir -p /base/cache',
+          'YARN_CACHE_FOLDER=/base/cache yarn install --frozen-lockfile',
+          // remove some junk
+          'rm -rf .node-gyp',
+        ].join('\n')],
+        mounts: [
+          {Type: 'volume', Target: '/base', Source: requirements['build-docker-volume']},
         ],
-        env: [
-          'YARN_CACHE_FOLDER=/cache',
-        ],
-        logfile: `${workDir}/yarn-install.log`,
+        logfile: `${baseDir}/yarn-install.log`,
         utils,
         baseDir,
       });
-
-      // remove the junk in .node-gyp
-      await rimraf(path.join(appDir, '.node-gyp'));
     },
     entrypoints: async (requirements, utils, procs) => {
       services.forEach(name => {
-        const procsPath = path.join(appDir, 'services', name, 'procs.yml');
+        const procsPath = path.join(sourceDir, 'services', name, 'procs.yml');
         if (!fs.existsSync(procsPath)) {
           throw new Error(`Service ${name} has no procs.yml`);
         }
@@ -125,27 +130,22 @@ const generateMonoimageTasks = ({tasks, baseDir, cmdOptions}) => {
   hooks.push({
     name: 'web-ui',
     build: async (requirements, utils, procs) => {
-      const cacheDir = path.join(workDir, 'cache');
-      if (!fs.existsSync(cacheDir)) {
-        fs.mkdirSync(cacheDir);
-      }
-
-      utils.step({title: 'Run Yarn Install'});
-
       await dockerRun({
         image: nodeImage,
-        workingDir: '/app/ui',
-        env: ['YARN_CACHE_FOLDER=/cache'],
-        command: ['bash', '-c', 'yarn install'],
-        logfile: `${workDir}/yarn-ui-install.log`,
-        utils,
-        binds: [
-          `${appDir}:/app`,
-          `${cacheDir}:/cache`,
+        workingDir: '/base/app/ui',
+        command: ['sh', '-ce', [
+          'mkdir -p /base/cache',
+          'YARN_CACHE_FOLDER=/base/cache yarn install --frozen-lockfile',
+          // remove some junk
+          'rm -rf .node-gyp',
+        ].join('\n')],
+        mounts: [
+          {Type: 'volume', Target: '/base', Source: requirements['build-docker-volume']},
         ],
+        logfile: `${baseDir}/yarn-ui-install.log`,
+        utils,
         baseDir,
       });
-
     },
     entrypoints: async (requirements, utils, procs) => {
       procs['ui/web'] = 'cd /app/ui && yarn build && ' +
@@ -154,21 +154,38 @@ const generateMonoimageTasks = ({tasks, baseDir, cmdOptions}) => {
   });
 
   ensureTask(tasks, {
+    title: 'Set Up Docker Volume',
+    requires: [],
+    provides: [
+      'build-docker-volume',
+    ],
+    locks: ['docker'],
+    run: async (requirements, utils) => {
+      await ensureDockerVolume({
+        baseDir,
+        name: DOCKER_VOLUME_NAME,
+        empty: !cmdOptions.cache,
+        image: nodeAlpineImage,
+        utils,
+      });
+      return {
+        'build-docker-volume': DOCKER_VOLUME_NAME,
+      };
+    },
+  });
+
+  ensureTask(tasks, {
     title: 'Clone Monorepo from Working Copy',
     requires: [
       'build-can-start', // (used to delay building in `yarn release`)
+      'build-docker-volume',
     ],
     provides: [
-      'monorepo-dir', // full path of the repository
-      'monorepo-exact-source', // exact source URL for the repository
       'monorepo-git-descr', // `git describe --tag --always` output
       'monorepo-stamp',
     ],
     locks: ['git'],
     run: async (requirements, utils) => {
-      const sourceDir = appRootDir.get();
-      const repoDir = path.join(baseDir, 'monorepo');
-
       // Clone from the current working copy, rather than anything upstream;
       // this avoids the need to land-and-push changes.  This is a git clone
       // operation instead of a raw filesystem copy so that any non-checked-in
@@ -183,90 +200,101 @@ const generateMonoimageTasks = ({tasks, baseDir, cmdOptions}) => {
           ].join(' '));
         }
       }
-      const {exactRev, changed} = await gitClone({
-        dir: repoDir,
-        url: sourceDir + '#HEAD',
+
+      // clone the local git repository into the docker volume, using a bit of shell logic
+      // to skip doing so if it's already up to date.
+      const gitCloneScript = [
+        'baserev=`if [ -d /base/monorepo ]; then git --git-dir=/base/monorepo/.git rev-parse HEAD; fi`',
+        'srcrev=`git --git-dir=/src/.git rev-parse HEAD`',
+        'if [ "$baserev" != "$srcrev" ]; then',
+        // We _could_ try to manipulate the repo that already exists by
+        // fetching and checking out, but it can get into weird states easily.
+        // This is doubly true when we do things like set depth=1 etc.
+        //
+        // Instead, we just blow it away and clone. This is lightweight since we
+        // do use that depth=1 anyway.
+        '  rm -rf /base/monorepo',
+        '  git clone /src /base/monorepo --depth 1',
+        'fi',
+      ].join('\n');
+      await dockerRun({
+        image: nodeImage,
+        workingDir: '/',
+        command: ['bash', '-cex', gitCloneScript],
+        logfile: `${baseDir}/git-clone.log`,
+        utils,
+        mounts: [
+          {Type: 'volume', Target: '/base', Source: requirements['build-docker-volume']},
+          {Type: 'bind', Target: '/src', Source: sourceDir},
+        ],
+        baseDir,
+      });
+
+      const {gitDescription} = await gitDescribe({
+        dir: sourceDir,
         utils,
       });
 
       const repoUrl = 'https://github.com/taskcluster/taskcluster';
       const stamp = new Stamp({step: 'repo-clone', version: 1},
-        `${repoUrl}#${exactRev}`);
+        `${repoUrl}#${gitDescription}`);
 
-      const {gitDescription} = await gitDescribe({
-        dir: repoDir,
-        utils,
-      });
-
-      const provides = {
-        'monorepo-dir': repoDir,
-        'monorepo-exact-source': `${repoUrl}#${exactRev}`,
+      return {
         'monorepo-git-descr': gitDescription,
         'monorepo-stamp': stamp,
       };
-
-      // we needed to know some information about this repo up-front, so we
-      // got it from the working copy we're running from.  Now, double-check
-      // that the information is still correct in the checked-out copy of
-      // the repo
-      const clonedPackageJson = JSON.parse(fs.readFileSync(path.join(repoDir, 'package.json')));
-      const clonedNodeVersion = clonedPackageJson.engines.node;
-      assert.equal(clonedNodeVersion, nodeVersion,
-        'the local working copy has a different engins.node from the ' +
-        'monorepo revision being built; this is not supported');
-
-      const clonedServices = listServices({repoDir});
-      assert.deepEqual(clonedServices, services,
-        'the local working copy has a different set of services from the ' +
-        'monorepo revision being built; this is not supported');
-
-      if (changed) {
-        return provides;
-      } else {
-        return utils.skip({provides});
-      }
     },
   });
 
-  const buildRequires = new Set([
-    'monorepo-dir',
-    'monorepo-exact-source',
-    'monorepo-stamp',
-    `docker-image-${nodeImage}`,
-  ]);
+  const buildRequires = new Set();
   hooks.forEach(({requires}) => requires && requires.forEach(req => buildRequires.add(req)));
 
   ensureTask(tasks, {
     title: 'Build Monorepo',
-    requires: [...buildRequires],
+    requires: [
+      'monorepo-stamp',
+      `docker-image-${nodeImage}`,
+      'build-docker-volume',
+      ...buildRequires,
+    ],
     provides: [
-      'monoimage-built-app-dir',
       'monoimage-stamp',
     ],
     locks: ['docker'],
     run: async (requirements, utils) => {
-      const repoDir = requirements['monorepo-dir'];
-
+      const appStampDir = path.join(baseDir, 'app-stamp');
       const stamp = new Stamp({step: 'monoimage-build', version: 1},
         {nodeVersion},
         ...[...buildRequires]
           .filter(req => req.endsWith('-stamp'))
           .map(req => requirements[req]));
+
       const provides = {
-        ['monoimage-built-app-dir']: appDir,
         ['monoimage-stamp']: stamp,
       };
 
-      // if we've already built this appDir with this revision, we're done.
-      if (stamp.dirStamped(appDir)) {
+      // if we've already built this with this revision, we're done.
+      if (stamp.dirStamped(appStampDir)) {
         return utils.skip({provides});
       } else {
-        await rimraf(appDir);
+        await rimraf(appStampDir);
       }
+      await mkdirp(appStampDir);
 
       utils.step({title: 'Copy Source Repository'});
-      const filter = ['**/*', '!**/node_modules/**', '!**/node_modules', '!**/.git/**', '!**/.git'];
-      await copy(repoDir, appDir, {filter, dot: true});
+      await dockerRun({
+        image: nodeImage,
+        workingDir: '/',
+        command: ['bash', '-cex', [
+          'rm -rf /base/app',
+          'mkdir -p /base/app',
+          'tar -C /base/monorepo --exclude=./.git -cf - . | tar -C /base/app -xf -',
+        ].join('\n')],
+        logfile: `${baseDir}/app-copy.log`,
+        utils,
+        mounts: [{Type: 'volume', Target: '/base', Source: requirements['build-docker-volume']}],
+        baseDir,
+      });
 
       for (let {name, build} of hooks) {
         if (build) {
@@ -295,18 +323,33 @@ const generateMonoimageTasks = ({tasks, baseDir, cmdOptions}) => {
           '*) exec "${@}";;',
           'esac',
         ]).join('\n');
-      fs.writeFileSync(path.join(appDir, 'entrypoint'), entrypointScript, {mode: 0o777});
+      const entrypointFile = path.join(baseDir, 'entrypoint');
+      fs.writeFileSync(entrypointFile, entrypointScript, {mode: 0o777});
 
-      stamp.stampDir(appDir);
+      await dockerRun({
+        image: nodeImage,
+        workingDir: '/',
+        command: ['bash', '-cex', 'cp /entrypoint /base/app/entrypoint'],
+        logfile: `${baseDir}/entrypoint-copy.log`,
+        utils,
+        mounts: [
+          {Type: 'volume', Target: '/base', Source: requirements['build-docker-volume']},
+          {Type: 'bind', Target: '/entrypoint', Source: entrypointFile},
+        ],
+        baseDir,
+      });
+
+      stamp.stampDir(appStampDir);
       return provides;
     },
   });
 
   ensureTask(tasks, {
-    title: `Build Monoimage`,
+    title: `Build Docker Image`,
     requires: [
+      'monoimage-stamp',
       'monorepo-git-descr',
-      'monoimage-built-app-dir',
+      'build-docker-volume',
       `docker-image-${nodeAlpineImage}`,
     ],
     provides: [
@@ -315,8 +358,6 @@ const generateMonoimageTasks = ({tasks, baseDir, cmdOptions}) => {
     ],
     locks: ['docker'],
     run: async (requirements, utils) => {
-
-      // find the requirements ending in '-stamp' that we should depend on
       const tag = `taskcluster/taskcluster:${requirements['monorepo-git-descr']}`;
 
       utils.step({title: 'Check for Existing Images'});
@@ -343,12 +384,28 @@ const generateMonoimageTasks = ({tasks, baseDir, cmdOptions}) => {
         return utils.skip({provides});
       }
 
-      utils.step({title: 'Building'});
+      // The bulk of the docker image is the `app` directory, currently residing on
+      // the docker volume.  Docker-build cannot access volumes, though, so we must
+      // copy that data to baseDir first, then pack it into a tarball for the build.
 
-      const tarball = tar.pack(workDir, {
-        // include the built app dir as app/
-        entries: ['app', 'Dockerfile'],
+      utils.step({title: 'Copying /app out of docker volume'});
+
+      const appDir = path.join(baseDir, 'app');
+      await mkdirp(appDir);
+      await dockerRun({
+        image: nodeImage,
+        workingDir: '/',
+        command: ['bash', '-cex', 'ls -al /base && tar -C /base/app -cf - . | tar -C /app -xf -'],
+        logfile: `${baseDir}/app-copy.log`,
+        utils,
+        mounts: [
+          {Type: 'volume', Target: '/base', Source: requirements['build-docker-volume']},
+          {Type: 'bind', Target: '/app', Source: appDir},
+        ],
+        baseDir,
       });
+
+      utils.step({title: 'Building'});
 
       const dockerfile = [
         `FROM ${nodeAlpineImage}`,
@@ -361,11 +418,16 @@ const generateMonoimageTasks = ({tasks, baseDir, cmdOptions}) => {
         'WORKDIR /app',
         'ENTRYPOINT ["/app/entrypoint"]',
       ].join('\n');
-      fs.writeFileSync(path.join(workDir, 'Dockerfile'), dockerfile);
+      fs.writeFileSync(path.join(baseDir, 'Dockerfile'), dockerfile);
+
+      const tarball = tar.pack(baseDir, {
+        // include the built app dir as app/
+        entries: ['app', 'Dockerfile'],
+      });
 
       await dockerBuild({
         tarball: tarball,
-        logfile: `${workDir}/docker-build.log`,
+        logfile: `${baseDir}/docker-build.log`,
         tag,
         utils,
         baseDir,
@@ -397,7 +459,7 @@ const generateMonoimageTasks = ({tasks, baseDir, cmdOptions}) => {
       }
 
       await dockerPush({
-        logfile: `${workDir}/docker-push.log`,
+        logfile: `${baseDir}/docker-push.log`,
         tag,
         utils,
         baseDir,

--- a/package.json
+++ b/package.json
@@ -139,7 +139,6 @@
     "nyc": "^14.1.1",
     "qlobber": "^3.1.0",
     "raw-loader": "^3.0.0",
-    "recursive-copy": "^2.0.9",
     "rmp": "^0.0.0",
     "semver": "^6.1.1",
     "shell-quote": "^1.6.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -908,11 +908,6 @@ arr-union@^3.1.0:
   resolved "https://registry.yarnpkg.com/arr-union/-/arr-union-3.1.0.tgz#e39b09aea9def866a8f206e288af63919bae39c4"
   integrity sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=
 
-array-differ@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/array-differ/-/array-differ-1.0.0.tgz#eff52e3758249d33be402b8bb8e564bb2b5d4031"
-  integrity sha1-7/UuN1gknTO+QCuLuOVkuytdQDE=
-
 array-filter@~0.0.0:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/array-filter/-/array-filter-0.0.1.tgz#7da8cf2e26628ed732803581fd21f67cacd2eeec"
@@ -938,22 +933,10 @@ array-reduce@~0.0.0:
   resolved "https://registry.yarnpkg.com/array-reduce/-/array-reduce-0.0.0.tgz#173899d3ffd1c7d9383e4479525dbe278cab5f2b"
   integrity sha1-FziZ0//Rx9k4PkR5Ul2+J4yrXys=
 
-array-union@^1.0.1:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/array-union/-/array-union-1.0.2.tgz#9a34410e4f4e3da23dea375be5be70f24778ec39"
-  integrity sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=
-  dependencies:
-    array-uniq "^1.0.1"
-
 array-uniq@1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/array-uniq/-/array-uniq-1.0.2.tgz#5fcc373920775723cfd64d65c64bef53bf9eba6d"
   integrity sha1-X8w3OSB3VyPP1k1lxkvvU7+eum0=
-
-array-uniq@^1.0.1:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/array-uniq/-/array-uniq-1.0.3.tgz#af6ac877a25cc7f74e058894753858dfdb24fdb6"
-  integrity sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=
 
 array-unique@^0.3.2:
   version "0.3.2"
@@ -978,7 +961,7 @@ array.prototype.flatmap@^1.2.1:
     es-abstract "^1.10.0"
     function-bind "^1.1.1"
 
-arrify@^1.0.0, arrify@^1.0.1:
+arrify@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/arrify/-/arrify-1.0.1.tgz#898508da2226f380df904728456849c1501a4b0d"
   integrity sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=
@@ -2241,19 +2224,6 @@ degenerator@^1.0.4:
     escodegen "1.x.x"
     esprima "3.x.x"
 
-del@^2.2.0:
-  version "2.2.2"
-  resolved "https://registry.yarnpkg.com/del/-/del-2.2.2.tgz#c12c981d067846c84bcaf862cff930d907ffd1a8"
-  integrity sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=
-  dependencies:
-    globby "^5.0.0"
-    is-path-cwd "^1.0.0"
-    is-path-in-cwd "^1.0.0"
-    object-assign "^4.0.1"
-    pify "^2.0.0"
-    pinkie-promise "^2.0.0"
-    rimraf "^2.2.8"
-
 delayed-stream@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
@@ -2510,11 +2480,6 @@ email-templates@^5.0.2:
     preview-email "^0.0.10"
     underscore.string "^3.3.5"
 
-emitter-mixin@0.0.3:
-  version "0.0.3"
-  resolved "https://registry.yarnpkg.com/emitter-mixin/-/emitter-mixin-0.0.3.tgz#5948cb286f2e48edc3b251a7cfc1f7883396d65c"
-  integrity sha1-WUjLKG8uSO3DslGnz8H3iDOW1lw=
-
 emoji-regex@^7.0.1:
   version "7.0.3"
   resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-7.0.3.tgz#933a04052860c85e83c122479c4748a8e4c72156"
@@ -2548,13 +2513,6 @@ errlop@^1.1.1:
   integrity sha512-WX7QjiPHhsny7/PQvrhS5VMizXXKoKCS3udaBp8gjlARdbn+XmK300eKBAAN0hGyRaTCtRpOaxK+xFVPUJ3zkw==
   dependencies:
     editions "^2.1.2"
-
-errno@^0.1.2:
-  version "0.1.7"
-  resolved "https://registry.yarnpkg.com/errno/-/errno-0.1.7.tgz#4684d71779ad39af177e3f007996f7c67c852618"
-  integrity sha512-MfrRBDWzIWifgq6tJj60gkAwtLNb6sQPlcFrSOflcP1aFmmruKQ2wRnze/8V6kgyz7H3FF8Npzv78mZ7XLLflg==
-  dependencies:
-    prr "~1.0.1"
 
 error-ex@^1.2.0, error-ex@^1.3.1:
   version "1.3.2"
@@ -3343,7 +3301,7 @@ getpass@^0.1.1:
   dependencies:
     assert-plus "^1.0.0"
 
-glob@7.1.3, glob@^7.0.3, glob@^7.1.2, glob@^7.1.3:
+glob@7.1.3, glob@^7.1.2, glob@^7.1.3:
   version "7.1.3"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.3.tgz#3960832d3f1574108342dafd3a67b332c0969df1"
   integrity sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==
@@ -3390,18 +3348,6 @@ globals@^11.1.0, globals@^11.7.0:
   version "11.11.0"
   resolved "https://registry.yarnpkg.com/globals/-/globals-11.11.0.tgz#dcf93757fa2de5486fbeed7118538adf789e9c2e"
   integrity sha512-WHq43gS+6ufNOEqlrDBxVEbb8ntfXrfAUU2ZOpCxrBdGKW3gyv8mCxAfIBD0DroPKGrJ2eSsXsLtY9MPntsyTw==
-
-globby@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/globby/-/globby-5.0.0.tgz#ebd84667ca0dbb330b99bcfc68eac2bc54370e0d"
-  integrity sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=
-  dependencies:
-    array-union "^1.0.1"
-    arrify "^1.0.0"
-    glob "^7.0.3"
-    object-assign "^4.0.1"
-    pify "^2.0.0"
-    pinkie-promise "^2.0.0"
 
 google-auth-library@^4.0.0:
   version "4.0.0"
@@ -3483,7 +3429,7 @@ got@^9.5.0:
     to-readable-stream "^1.0.0"
     url-parse-lax "^3.0.0"
 
-graceful-fs@*, graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.1.4, graceful-fs@^4.1.6:
+graceful-fs@*, graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.1.6:
   version "4.1.15"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.15.tgz#ffb703e1066e8a0eeaa4c8b80ba9253eeefbfb00"
   integrity sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==
@@ -4141,25 +4087,6 @@ is-observable@^1.1.0:
   dependencies:
     symbol-observable "^1.1.0"
 
-is-path-cwd@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/is-path-cwd/-/is-path-cwd-1.0.0.tgz#d225ec23132e89edd38fda767472e62e65f1106d"
-  integrity sha1-0iXsIxMuie3Tj9p2dHLmLmXxEG0=
-
-is-path-in-cwd@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/is-path-in-cwd/-/is-path-in-cwd-1.0.1.tgz#5ac48b345ef675339bd6c7a48a912110b241cf52"
-  integrity sha512-FjV1RTW48E7CWM7eE/J2NJvAEEVektecDBVBE5Hh3nM1Jd0kvhHtX68Pr3xsDf857xt3Y4AkwVULK1Vku62aaQ==
-  dependencies:
-    is-path-inside "^1.0.0"
-
-is-path-inside@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/is-path-inside/-/is-path-inside-1.0.1.tgz#8ef5b7de50437a3fdca6b4e865ef7aa55cb48036"
-  integrity sha1-jvW33lBDej/cprToZe96pVy0gDY=
-  dependencies:
-    path-is-inside "^1.0.1"
-
 is-plain-object@^2.0.1, is-plain-object@^2.0.3, is-plain-object@^2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/is-plain-object/-/is-plain-object-2.0.4.tgz#2c163b3fafb1b606d9d17928f05c2a1c38e07677"
@@ -4573,11 +4500,6 @@ juice@^5.1.0:
     mensch "^0.3.3"
     slick "^1.12.2"
     web-resource-inliner "^4.2.1"
-
-junk@^1.0.1:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/junk/-/junk-1.0.3.tgz#87be63488649cbdca6f53ab39bec9ccd2347f592"
-  integrity sha1-h75jSIZJy9ym9Tqzm+yczSNH9ZI=
 
 just-extend@^4.0.2:
   version "4.0.2"
@@ -5110,16 +5032,6 @@ math-interval-parser@^1.1.0:
   dependencies:
     xregexp "^2.0.0"
 
-maximatch@^0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/maximatch/-/maximatch-0.1.0.tgz#86cd8d6b04c9f307c05a6b9419906d0360fb13a2"
-  integrity sha1-hs2NawTJ8wfAWmuUGZBtA2D7E6I=
-  dependencies:
-    array-differ "^1.0.0"
-    array-union "^1.0.1"
-    arrify "^1.0.0"
-    minimatch "^3.0.0"
-
 md-directory@^0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/md-directory/-/md-directory-0.1.2.tgz#073565c186407ab1149888efd6cca278b314d6b5"
@@ -5273,7 +5185,7 @@ mimic-response@^1.0.0, mimic-response@^1.0.1:
   resolved "https://registry.yarnpkg.com/mimic-response/-/mimic-response-1.0.1.tgz#4923538878eef42063cb8a3e3b0798781487ab1b"
   integrity sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==
 
-"minimatch@2 || 3", minimatch@3.0.4, minimatch@^3.0.0, minimatch@^3.0.2, minimatch@^3.0.4:
+"minimatch@2 || 3", minimatch@3.0.4, minimatch@^3.0.2, minimatch@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083"
   integrity sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==
@@ -6080,7 +5992,7 @@ path-is-absolute@^1.0.0:
   resolved "https://registry.yarnpkg.com/path-is-absolute/-/path-is-absolute-1.0.1.tgz#174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f"
   integrity sha1-F0uSaHNVNP+8es5r9TpanhtcX18=
 
-path-is-inside@^1.0.1, path-is-inside@^1.0.2:
+path-is-inside@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/path-is-inside/-/path-is-inside-1.0.2.tgz#365417dede44430d1c11af61027facf074bdfc53"
   integrity sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=
@@ -6128,11 +6040,6 @@ performance-now@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-2.1.0.tgz#6309f4e0e5fa913ec1c69307ae364b4b377c9e7b"
   integrity sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=
-
-pify@^2.0.0, pify@^2.3.0:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/pify/-/pify-2.3.0.tgz#ed141a6ac043a849ea588498e7dca8b15330e90c"
-  integrity sha1-7RQaasBDqEnqWISY59yosVMw6Qw=
 
 pify@^3.0.0:
   version "3.0.0"
@@ -6301,11 +6208,6 @@ proxy-from-env@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-1.0.0.tgz#33c50398f70ea7eb96d21f7b817630a55791c7ee"
   integrity sha1-M8UDmPcOp+uW0h97gXYwpVeRx+4=
-
-prr@~1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/prr/-/prr-1.0.1.tgz#d3fc114ba06995a45ec6893f484ceb1d78f5f476"
-  integrity sha1-0/wRS6BplaRexok/SEzrHXj19HY=
 
 pruddy-error@^2.0.2:
   version "2.0.2"
@@ -6658,22 +6560,6 @@ readable-stream@~2.0.0:
     string_decoder "~0.10.x"
     util-deprecate "~1.0.1"
 
-recursive-copy@^2.0.9:
-  version "2.0.10"
-  resolved "https://registry.yarnpkg.com/recursive-copy/-/recursive-copy-2.0.10.tgz#a39402f2270c5f8b562b48d438a42e2e6e5c644c"
-  integrity sha512-S9J9XJUnfZ2NUS3lK6lx6HWLl2nWui+f7AKuu+qoFs4ikEPYgZ3qKk1T6tmBnr7PzhtKnawE+6TREy9XQKmxCA==
-  dependencies:
-    del "^2.2.0"
-    emitter-mixin "0.0.3"
-    errno "^0.1.2"
-    graceful-fs "^4.1.4"
-    junk "^1.0.1"
-    maximatch "^0.1.0"
-    mkdirp "^0.5.1"
-    pify "^2.3.0"
-    promise "^7.0.1"
-    slash "^1.0.0"
-
 recursive-readdir-sync@^1.0.6:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/recursive-readdir-sync/-/recursive-readdir-sync-1.0.6.tgz#1dbf6d32f3c5bb8d3cde97a6c588d547a9e13d56"
@@ -6869,7 +6755,7 @@ right-align@^0.1.1:
   dependencies:
     align-text "^0.1.1"
 
-rimraf@2.6.3, rimraf@^2.2.8, rimraf@^2.6.1, rimraf@^2.6.2, rimraf@^2.6.3:
+rimraf@2.6.3, rimraf@^2.6.1, rimraf@^2.6.2, rimraf@^2.6.3:
   version "2.6.3"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.3.tgz#b2d104fe0d8fb27cf9e0a1cda8262dd3833c6cab"
   integrity sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==
@@ -7134,11 +7020,6 @@ sinon@^7.1.1, sinon@^7.2.2:
     lolex "^3.1.0"
     nise "^1.4.10"
     supports-color "^5.5.0"
-
-slash@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/slash/-/slash-1.0.0.tgz#c41f2f6c39fc16d1cd17ad4b5d896114ae470d55"
-  integrity sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU=
 
 slice-ansi@0.0.4:
   version "0.0.4"
@@ -7679,47 +7560,52 @@ tar@^4:
     yallist "^3.0.2"
 
 "taskcluster-client@link:clients/client":
-  version "14.0.0"
-  dependencies:
-    debug "^4.0.0"
-    hawk "^7.0.10"
-    lodash "^4.17.4"
-    slugid "^2.0.0"
-    superagent "^5.0.0"
-    taskcluster-lib-urls "^12.0.0"
+  version "0.0.0"
+  uid ""
 
 "taskcluster-lib-api@link:libraries/api":
-  version "12.8.1"
+  version "0.0.0"
+  uid ""
 
 "taskcluster-lib-app@link:libraries/app":
-  version "10.2.0"
+  version "0.0.0"
+  uid ""
 
 "taskcluster-lib-azure@link:libraries/azure":
-  version "10.0.0"
+  version "0.0.0"
+  uid ""
 
 "taskcluster-lib-config@link:libraries/config":
-  version "3.0.0"
+  version "0.0.0"
+  uid ""
 
 "taskcluster-lib-iterate@link:libraries/iterate":
-  version "11.0.0"
+  version "0.0.0"
+  uid ""
 
 "taskcluster-lib-loader@link:libraries/loader":
-  version "11.0.0"
+  version "0.0.0"
+  uid ""
 
 "taskcluster-lib-monitor@link:libraries/monitor":
-  version "11.1.1"
+  version "0.0.0"
+  uid ""
 
 "taskcluster-lib-pulse@link:libraries/pulse":
-  version "11.1.1"
+  version "0.0.0"
+  uid ""
 
 "taskcluster-lib-references@link:libraries/references":
-  version "1.5.0"
+  version "0.0.0"
+  uid ""
 
 "taskcluster-lib-scopes@link:libraries/scopes":
-  version "10.0.1"
+  version "0.0.0"
+  uid ""
 
 "taskcluster-lib-testing@link:libraries/testing":
-  version "12.1.2"
+  version "0.0.0"
+  uid ""
 
 taskcluster-lib-urls@^12.0.0:
   version "12.0.0"
@@ -7727,7 +7613,8 @@ taskcluster-lib-urls@^12.0.0:
   integrity sha512-OrEFE0m3p/+mGsmIwjttLhSKg3io6MpJLhYtPNjVSZA9Ix8Y5tprN3vM6a3MjWt5asPF6AKZsfT43cgpGwJB0g==
 
 "taskcluster-lib-validate@link:libraries/validate":
-  version "12.0.0"
+  version "0.0.0"
+  uid ""
 
 taskgroup@^4.0.5, taskgroup@^4.2.0:
   version "4.3.1"


### PR DESCRIPTION
This requires a good deal more manual copying back and forth, but means
that the `yarn install` operations run entirely on a docker volume,
rather than over a bind mount.  Bind mounts don't work reliably on
Docker for Mac, so this change allows `yarn build` to operate correclty
on such systems.

Bugzilla Bug: [1551607](https://bugzilla.mozilla.org/show_bug.cgi?id=1551607)
