### PR TITLE
Bug 1559471 - use JWTs with HS256 for logins

### DIFF
--- a/infrastructure/terraform/web-server-service.tf
+++ b/infrastructure/terraform/web-server-service.tf
@@ -10,6 +10,10 @@ resource "random_string" "web_server_access_token" {
   override_special = "_-"
 }
 
+resource "random_string" "web_server_jwt_key" {
+  length = 66
+}
+
 module "web_server_secrets" {
   source            = "modules/service-secrets"
   project_name      = "taskcluster-web-server"
@@ -25,6 +29,7 @@ module "web_server_secrets" {
     PULSE_HOSTNAME           = "${var.rabbitmq_hostname}"
     PULSE_VHOST              = "${var.rabbitmq_vhost}"
     PUBLIC_URL               = "${var.root_url}"
+    JWT_KEY                  = "${random_string.web_server_jwt_key.result}"
   }
 }
 

--- a/services/web-server/README.md
+++ b/services/web-server/README.md
@@ -73,7 +73,7 @@ The `taskcluster-ui` service expects this service to run on port 3050.
 
 To pass credentials to the server from the GraphQL Playground, click the "HTTP Headers"
 section, and paste a JSON object with a key of "Authorization" with a value of
-"Bearer YOUR_ACCESS_TOKEN", such as:
+"Bearer YOUR_TC_TOKEN", such as:
 
 ```json
 {
@@ -83,16 +83,29 @@ section, and paste a JSON object with a key of "Authorization" with a value of
 
 <img src="https://cldup.com/XDpBc-qY5Q.png" alt="authorization header" height="75%" width="75%" />
 
+You can find your TC token in localStorage after signing into the UI.
+
 ## Login Strategies
 
 Taskcluster supports the following strategies:
 * GitHub
 * Mozilla Auth0
 
+All login strategies require configuration of the `login.jwt.key` configuration value, which is a secret used for HMAC signatures.
+For development, it can be anything.
+
+```sh
+JWT_KEY=this-is-a-secret-value-be-very-careful-with-it
+```
+
 ### GitHub
 
 In order to enable the GitHub login strategy, specify the GitHub client ID and secret for an OAuth application created
-for use against this service and its web UI:
+for use against this service and its web UI.
+
+The callback URL should be `http://localhost:3050/login/github/callback` for local development, or `<rootUrl>/login/github/callback` for a deployment.
+
+Configure it as:
 
 ```sh
 UI_LOGIN_STRATEGIES='{"github": {"clientId": "..", "clientSecret": ".."}}'

--- a/services/web-server/config.yml
+++ b/services/web-server/config.yml
@@ -50,8 +50,9 @@ defaults:
     #   clientSecret: !env GITHUB_CLIENT_SECRET
     strategies: !env:json UI_LOGIN_STRATEGIES
     jwt:
-      publicKey: !env JWT_PUBLIC_KEY
-      privateKey: !env JWT_PRIVATE_KEY
+      # this should be a random string, and is used as input to the HS256 JWT
+      # signing algorithm
+      key: !env JWT_KEY
 
 development:
   app:

--- a/services/web-server/src/loaders/auth.js
+++ b/services/web-server/src/loaders/auth.js
@@ -15,7 +15,7 @@ module.exports = (clients, isAuthed, rootUrl, monitor, strategies, req, cfg) => 
         const credentialError = new WebServerError('InputError', 'Could not generate credentials for this access token');
         const [jwtError, jwtResponse] = await tryCatch(
           jwt.verify({
-            publicKey: cfg.login.jwt.publicKey,
+            key: cfg.login.jwt.key,
             token: taskclusterToken,
             options: {
               audience: rootUrl,

--- a/services/web-server/src/login/strategies/github.js
+++ b/services/web-server/src/login/strategies/github.js
@@ -88,7 +88,7 @@ module.exports = class Github {
           const user = await this.getUser({ userId: profile.username });
           const { token: taskclusterToken, expires: providerExpires } = jwt.generate({
             rootUrl: this.rootUrl,
-            privateKey: this.jwtConfig.privateKey,
+            key: this.jwtConfig.key,
             sub: user.identity,
             // GitHub tokens don't expire
             exp: Math.floor(taskcluster.fromNow('1000 year').getTime() / 1000),

--- a/services/web-server/src/login/strategies/mozilla-auth0.js
+++ b/services/web-server/src/login/strategies/mozilla-auth0.js
@@ -212,7 +212,7 @@ module.exports = class MozillaAuth0 {
 
           const { token: taskclusterToken, expires: providerExpires } = jwt.generate({
             rootUrl: this.rootUrl,
-            privateKey: this.jwt.privateKey,
+            key: this.jwt.key,
             sub: user.identity,
             exp: await this.expFromIdToken(extraParams.id_token),
           });

--- a/services/web-server/src/utils/jwt.js
+++ b/services/web-server/src/utils/jwt.js
@@ -8,8 +8,8 @@ const verify = util.promisify(jwt.verify);
 // A utility to generate and verify Taskcluster jwt tokens
 // with expiration taken from the sign-in process
 module.exports = {
-  generate: ({ rootUrl, privateKey, exp, sub, ...rest }) => {
-    assert(privateKey, `jwt.generate requires a privateKey`);
+  generate: ({ rootUrl, key, exp, sub, ...rest }) => {
+    assert(key, `jwt.generate requires a key`);
     const now = taskcluster.fromNow();
     const payload = {
       // If the current time is greater than the exp, the JWT is invalid
@@ -22,20 +22,20 @@ module.exports = {
       sub,
       ...rest,
     };
-    const token = jwt.sign(payload, privateKey.trim(), { algorithm: 'RS256' });
+    const token = jwt.sign(payload, key, { algorithm: 'HS256' });
 
     return {
       token,
       expires: new Date(exp * 1000),
     };
   },
-  verify: ({ publicKey, token, options }) => {
-    assert(publicKey, 'jwt.verify requires a privateKey');
+  verify: ({ key, token, options }) => {
+    assert(key, 'jwt.verify requires a key');
     assert(options.issuer, 'jwt.verify requires an issuer');
     assert(options.audience, 'jwt.verify requires an audience');
 
-    return verify(token, publicKey.trim(), {
-      algorithms: ['RS256'],
+    return verify(token, key, {
+      algorithms: ['HS256'],
       ...options,
     });
   },


### PR DESCRIPTION
This also adds configuration to terraform to invent an HMAC secret.

The *generation* of these JWTs is tested to work locally.  I can't test more than that because the `callback.ejs` page has `window.opener = null`, so it doesn't actually call back.  I'll try this in dustin-dev as well to see if it works better there.  @helfi92 is that something you've seen in your local testing of signins?

Bugzilla Bug: [1559471](https://bugzilla.mozilla.org/show_bug.cgi?id=1559471)
