### PR TITLE
Bug 1547729 - use structured logging to report hook fires

### DIFF
--- a/generated/references.json
+++ b/generated/references.json
@@ -11545,6 +11545,21 @@
           "version": 1
         },
         {
+          "description": "A hook was fired, meaning that a task was created for it.  This is also\nlogged when the attempt to fire the hook failed, in which case the 'result'\nfield is \"failed\".  Since this is often the result of user error, the error\nmessage itself is not included; consult the last-fires for the indicated\nhook to see them.",
+          "fields": {
+            "firedBy": "The event leading to the hook being fired",
+            "hookGroupId": "The group ID of the hook that failed",
+            "hookId": "The ID of the hook that failed",
+            "result": "\"success\" (task created), \"failure\" (task not created), or \"declined\" (hook did not generate a task)\"",
+            "taskId": "The taskId of the task that was (or would have been) created"
+          },
+          "level": "info",
+          "name": "hookFire",
+          "title": "A hook was fired",
+          "type": "hook-fire",
+          "version": 1
+        },
+        {
           "description": "A pulse publisher has been notified by the pulse server\nthat it has been blocked, usually because the server is\nresource-constrained.  If `blocked` is false, then the\nnotification is that the publisher has been unblocked\nafter having previously been blocked.",
           "fields": {
             "blocked": "If true, the publisher has been blocked; if false, it has been unblocked."

--- a/services/hooks/src/monitor.js
+++ b/services/hooks/src/monitor.js
@@ -4,4 +4,26 @@ const monitorManager = defaultMonitorManager.configure({
   serviceName: 'hooks',
 });
 
+monitorManager.register({
+  name: 'hookFire',
+  title: 'A hook was fired',
+  type: 'hook-fire',
+  version: 1,
+  level: 'info',
+  description: `
+    A hook was fired, meaning that a task was created for it.  This is also
+    logged when the attempt to fire the hook failed, in which case the 'result'
+    field is "failed".  Since this is often the result of user error, the error
+    message itself is not included; consult the last-fires for the indicated
+    hook to see them.
+  `,
+  fields: {
+    hookGroupId: 'The group ID of the hook that failed',
+    hookId: 'The ID of the hook that failed',
+    firedBy: 'The event leading to the hook being fired',
+    taskId: 'The taskId of the task that was (or would have been) created',
+    result: '"success" (task created), "failure" (task not created), or "declined" (hook did not generate a task)"',
+  },
+});
+
 module.exports = monitorManager;

--- a/services/hooks/src/taskcreator.js
+++ b/services/hooks/src/taskcreator.js
@@ -119,8 +119,7 @@ class TaskCreator {
 
       if (!task) {
         this.monitor.count(`fire.${context.firedBy}.declined`);
-        debug(`hook ${hook.hookGroupId}/${hook.hookId} declined to produce a task`);
-        return {response: {}};
+        return {response: {}, declined: true};
       }
       this.monitor.count(`fire.${context.firedBy}.created`);
 
@@ -155,7 +154,15 @@ class TaskCreator {
       }
     };
 
-    const {lastFire, error, response} = await inner();
+    const {lastFire, error, response, declined} = await inner();
+
+    this.monitor.log.hookFire({
+      hookGroupId: hook.hookGroupId,
+      hookId: hook.hookId,
+      firedBy: context.firedBy,
+      taskId: options.taskId,
+      result: error ? 'failure' : (declined ? 'declined' : 'success'),
+    });
 
     if (lastFire) {
       await this.appendLastFire(lastFire);


### PR DESCRIPTION
This reports *all* fires, bot successful, failed, and declined.  It's
easy enough for consumers interested only in failures to filter those
out.

Bugzilla Bug: [1547729](https://bugzilla.mozilla.org/show_bug.cgi?id=XXXXX)
