### PR TITLE
[web-server] use montior logging, don't console.log in prod

### DIFF
--- a/generated/references.json
+++ b/generated/references.json
@@ -8097,6 +8097,27 @@
           "version": 1
         },
         {
+          "description": "A connection to Pulse has been established.  Taskcluster services\nautomatically reconnect to Pulse periodically and in the event of\nan error, but rapid reconnections may signal a Pulse failure.",
+          "fields": {
+          },
+          "level": "info",
+          "name": "pulseConnected",
+          "title": "Connection to pulse established",
+          "type": "pulse.connected",
+          "version": 1
+        },
+        {
+          "description": "A connection to Pulse has ended or failed.  This may be due to normal\nreconnection or to an error communicating with Pulse.  The service\nautomatically reconnects, so even an error is not necessarily a problem.",
+          "fields": {
+            "error": "The error message, if the disconnection was due to an error."
+          },
+          "level": "info",
+          "name": "pulseDisconnected",
+          "title": "Connection to pulse has ended",
+          "type": "pulse.disconnected",
+          "version": 1
+        },
+        {
           "description": "A pulse publisher has been notified by the pulse server\nthat it has been blocked, usually because the server is\nresource-constrained.  If `blocked` is false, then the\nnotification is that the publisher has been unblocked\nafter having previously been blocked.",
           "fields": {
             "blocked": "If true, the publisher has been blocked; if false, it has been unblocked."
@@ -8465,6 +8486,27 @@
           "name": "loggingError",
           "title": "Error in Logging",
           "type": "monitor.loggingError",
+          "version": 1
+        },
+        {
+          "description": "A connection to Pulse has been established.  Taskcluster services\nautomatically reconnect to Pulse periodically and in the event of\nan error, but rapid reconnections may signal a Pulse failure.",
+          "fields": {
+          },
+          "level": "info",
+          "name": "pulseConnected",
+          "title": "Connection to pulse established",
+          "type": "pulse.connected",
+          "version": 1
+        },
+        {
+          "description": "A connection to Pulse has ended or failed.  This may be due to normal\nreconnection or to an error communicating with Pulse.  The service\nautomatically reconnects, so even an error is not necessarily a problem.",
+          "fields": {
+            "error": "The error message, if the disconnection was due to an error."
+          },
+          "level": "info",
+          "name": "pulseDisconnected",
+          "title": "Connection to pulse has ended",
+          "type": "pulse.disconnected",
           "version": 1
         },
         {
@@ -8907,6 +8949,27 @@
           "name": "apiMethod",
           "title": "API Method Report",
           "type": "monitor.apiMethod",
+          "version": 1
+        },
+        {
+          "description": "A connection to Pulse has been established.  Taskcluster services\nautomatically reconnect to Pulse periodically and in the event of\nan error, but rapid reconnections may signal a Pulse failure.",
+          "fields": {
+          },
+          "level": "info",
+          "name": "pulseConnected",
+          "title": "Connection to pulse established",
+          "type": "pulse.connected",
+          "version": 1
+        },
+        {
+          "description": "A connection to Pulse has ended or failed.  This may be due to normal\nreconnection or to an error communicating with Pulse.  The service\nautomatically reconnects, so even an error is not necessarily a problem.",
+          "fields": {
+            "error": "The error message, if the disconnection was due to an error."
+          },
+          "level": "info",
+          "name": "pulseDisconnected",
+          "title": "Connection to pulse has ended",
+          "type": "pulse.disconnected",
           "version": 1
         },
         {
@@ -10766,6 +10829,27 @@
           "version": 1
         },
         {
+          "description": "A connection to Pulse has been established.  Taskcluster services\nautomatically reconnect to Pulse periodically and in the event of\nan error, but rapid reconnections may signal a Pulse failure.",
+          "fields": {
+          },
+          "level": "info",
+          "name": "pulseConnected",
+          "title": "Connection to pulse established",
+          "type": "pulse.connected",
+          "version": 1
+        },
+        {
+          "description": "A connection to Pulse has ended or failed.  This may be due to normal\nreconnection or to an error communicating with Pulse.  The service\nautomatically reconnects, so even an error is not necessarily a problem.",
+          "fields": {
+            "error": "The error message, if the disconnection was due to an error."
+          },
+          "level": "info",
+          "name": "pulseDisconnected",
+          "title": "Connection to pulse has ended",
+          "type": "pulse.disconnected",
+          "version": 1
+        },
+        {
           "description": "A pulse publisher has been notified by the pulse server\nthat it has been blocked, usually because the server is\nresource-constrained.  If `blocked` is false, then the\nnotification is that the publisher has been unblocked\nafter having previously been blocked.",
           "fields": {
             "blocked": "If true, the publisher has been blocked; if false, it has been unblocked."
@@ -11369,6 +11453,27 @@
           "version": 1
         },
         {
+          "description": "A connection to Pulse has been established.  Taskcluster services\nautomatically reconnect to Pulse periodically and in the event of\nan error, but rapid reconnections may signal a Pulse failure.",
+          "fields": {
+          },
+          "level": "info",
+          "name": "pulseConnected",
+          "title": "Connection to pulse established",
+          "type": "pulse.connected",
+          "version": 1
+        },
+        {
+          "description": "A connection to Pulse has ended or failed.  This may be due to normal\nreconnection or to an error communicating with Pulse.  The service\nautomatically reconnects, so even an error is not necessarily a problem.",
+          "fields": {
+            "error": "The error message, if the disconnection was due to an error."
+          },
+          "level": "info",
+          "name": "pulseDisconnected",
+          "title": "Connection to pulse has ended",
+          "type": "pulse.disconnected",
+          "version": 1
+        },
+        {
           "description": "A pulse publisher has been notified by the pulse server\nthat it has been blocked, usually because the server is\nresource-constrained.  If `blocked` is false, then the\nnotification is that the publisher has been unblocked\nafter having previously been blocked.",
           "fields": {
             "blocked": "If true, the publisher has been blocked; if false, it has been unblocked."
@@ -11675,6 +11780,27 @@
           "name": "hookFire",
           "title": "A hook was fired",
           "type": "hook-fire",
+          "version": 1
+        },
+        {
+          "description": "A connection to Pulse has been established.  Taskcluster services\nautomatically reconnect to Pulse periodically and in the event of\nan error, but rapid reconnections may signal a Pulse failure.",
+          "fields": {
+          },
+          "level": "info",
+          "name": "pulseConnected",
+          "title": "Connection to pulse established",
+          "type": "pulse.connected",
+          "version": 1
+        },
+        {
+          "description": "A connection to Pulse has ended or failed.  This may be due to normal\nreconnection or to an error communicating with Pulse.  The service\nautomatically reconnects, so even an error is not necessarily a problem.",
+          "fields": {
+            "error": "The error message, if the disconnection was due to an error."
+          },
+          "level": "info",
+          "name": "pulseDisconnected",
+          "title": "Connection to pulse has ended",
+          "type": "pulse.disconnected",
           "version": 1
         },
         {
@@ -12132,6 +12258,27 @@
           "name": "apiMethod",
           "title": "API Method Report",
           "type": "monitor.apiMethod",
+          "version": 1
+        },
+        {
+          "description": "A connection to Pulse has been established.  Taskcluster services\nautomatically reconnect to Pulse periodically and in the event of\nan error, but rapid reconnections may signal a Pulse failure.",
+          "fields": {
+          },
+          "level": "info",
+          "name": "pulseConnected",
+          "title": "Connection to pulse established",
+          "type": "pulse.connected",
+          "version": 1
+        },
+        {
+          "description": "A connection to Pulse has ended or failed.  This may be due to normal\nreconnection or to an error communicating with Pulse.  The service\nautomatically reconnects, so even an error is not necessarily a problem.",
+          "fields": {
+            "error": "The error message, if the disconnection was due to an error."
+          },
+          "level": "info",
+          "name": "pulseDisconnected",
+          "title": "Connection to pulse has ended",
+          "type": "pulse.disconnected",
           "version": 1
         },
         {
@@ -12699,6 +12846,27 @@
           "name": "apiMethod",
           "title": "API Method Report",
           "type": "monitor.apiMethod",
+          "version": 1
+        },
+        {
+          "description": "A connection to Pulse has been established.  Taskcluster services\nautomatically reconnect to Pulse periodically and in the event of\nan error, but rapid reconnections may signal a Pulse failure.",
+          "fields": {
+          },
+          "level": "info",
+          "name": "pulseConnected",
+          "title": "Connection to pulse established",
+          "type": "pulse.connected",
+          "version": 1
+        },
+        {
+          "description": "A connection to Pulse has ended or failed.  This may be due to normal\nreconnection or to an error communicating with Pulse.  The service\nautomatically reconnects, so even an error is not necessarily a problem.",
+          "fields": {
+            "error": "The error message, if the disconnection was due to an error."
+          },
+          "level": "info",
+          "name": "pulseDisconnected",
+          "title": "Connection to pulse has ended",
+          "type": "pulse.disconnected",
           "version": 1
         },
         {

--- a/libraries/monitor/src/monitor.js
+++ b/libraries/monitor/src/monitor.js
@@ -268,7 +268,7 @@ class Monitor {
   _register({name, type, version, level, fields}) {
     assert(!this[name], `Cannot override "${name}" as custom message type.`);
     const requiredFields = Object.keys(fields);
-    this.log[name] = (fields, overrides={}) => {
+    this.log[name] = (fields={}, overrides={}) => {
       if (this.verify) {
         assert(level !== 'any' || overrides.level !== undefined, 'Must provide `overrides.level` if registered level is `any`.');
         const providedFields = Object.keys(fields);

--- a/services/web-server/Procfile
+++ b/services/web-server/Procfile
@@ -1,5 +1,5 @@
 # GENERATED FILE from `yarn generate`! To update, change procs.yml and regenerate.
 
-web: cd services/web-server && node src/main.js devServer
+web: cd services/web-server && node src/main.js server
 scanner: cd services/web-server && node src/main.js scanner
 write-docs: cd services/web-server && node src/main.js writeDocs

--- a/services/web-server/procs.yml
+++ b/services/web-server/procs.yml
@@ -1,6 +1,6 @@
 web:
   type: web
-  command: node src/main.js devServer
+  command: node src/main.js server
   readinessPath: /.well-known/apollo/server-health
 scanner:
   type: cron

--- a/services/web-server/src/PulseEngine/index.js
+++ b/services/web-server/src/PulseEngine/index.js
@@ -1,11 +1,8 @@
-const Debug = require('debug');
 const { slugid } = require('taskcluster-client');
 const PulseIterator = require('./PulseIterator');
 const MessageIterator = require('./MessageIterator');
 const EventIterator = require('./EventIterator');
 const Subscription = require('./Subscription');
-
-const debug = Debug('PulseEngine');
 
 module.exports = class PulseEngine {
   /* Operation:
@@ -42,8 +39,6 @@ module.exports = class PulseEngine {
   }
 
   connected(connection) {
-    debug('Connected to AMQP server');
-
     // reset everything and reconcile
     Array.from(this.subscriptions.values()).forEach(sub => sub.reset());
     this.reset();
@@ -60,6 +55,7 @@ module.exports = class PulseEngine {
         subscriptionId,
         handleMessage,
         handleError,
+        monitor: this.monitor,
         subscriptions,
       })
     );
@@ -103,8 +99,6 @@ module.exports = class PulseEngine {
 
   innerReconcileSubscriptions() {
     return this._syncReload(async () => {
-      debug('Reconciling subscriptions');
-
       const { connection, client } = this;
 
       // if there's no connection, there's nothing to do; reconciliation

--- a/services/web-server/src/main.js
+++ b/services/web-server/src/main.js
@@ -43,10 +43,6 @@ const load = loader(
             process.env.NODE_ENV !== 'production',
             'cfg.pulse.namespace is required'
           );
-          // eslint-disable-next-line no-console
-          console.log(
-            `\n\nNo Pulse namespace defined; no Pulse messages will be received.`
-          );
 
           return null;
         }
@@ -105,7 +101,7 @@ const load = loader(
       setup: ({ cfg, strategies }) => createApp({ cfg, strategies }),
     },
 
-    server: {
+    httpServer: {
       requires: ['app', 'schema', 'context'],
       setup: ({ app, schema, context }) => {
         const server = new ApolloServer({
@@ -152,8 +148,8 @@ const load = loader(
     },
 
     devServer: {
-      requires: ['cfg', 'server'],
-      setup: async ({ cfg, server }) => {
+      requires: ['cfg', 'httpServer'],
+      setup: async ({ cfg, httpServer }) => {
         // apply some sanity-checks
         assert(cfg.server.port, 'config server.port is required');
         assert(
@@ -161,7 +157,7 @@ const load = loader(
           'config taskcluster.rootUrl is required'
         );
 
-        await new Promise(resolve => server.listen(cfg.server.port, resolve));
+        await new Promise(resolve => httpServer.listen(cfg.server.port, resolve));
 
         /* eslint-disable no-console */
         console.log(`\n\nWeb server running on port ${cfg.server.port}.`);
@@ -171,7 +167,19 @@ const load = loader(
           http://localhost:${cfg.server.port}/playground\n`
           );
         }
+        if (!cfg.pulse.namespace) {
+          console.log(
+            `\nNo Pulse namespace defined; no Pulse messages will be received.\n`
+          );
+        }
         /* eslint-enable no-console */
+      },
+    },
+
+    server: {
+      requires: ['cfg', 'httpServer'],
+      setup: async ({ cfg, httpServer }) => {
+        await new Promise(resolve => httpServer.listen(cfg.server.port, resolve));
       },
     },
   },

--- a/services/web-server/src/monitor.js
+++ b/services/web-server/src/monitor.js
@@ -18,4 +18,32 @@ monitorManager.register({
   },
 });
 
+monitorManager.register({
+  name: 'bindPulseSubscription',
+  title: 'Bind a Pulse Subscription',
+  type: 'bind-pulse-subscription',
+  version: 1,
+  level: 'debug',
+  description: `
+    The PulseEngine has created a queue and bound it to one or more exchanges in
+    response to a GraphQL subsscription request.`,
+  fields: {
+    subscriptionId: 'The subscriptionId, which will also appear in the AMQP queue name',
+  },
+});
+
+monitorManager.register({
+  name: 'unbindPulseSubscription',
+  title: 'Unbind a Pulse Subscription',
+  type: 'unbind-pulse-subscription',
+  version: 1,
+  level: 'debug',
+  description: `
+    The PulseEngine has deleted a queue bound to one or more exchanges in
+    response to termination of a GraphQL subsscription request.`,
+  fields: {
+    subscriptionId: 'The subscriptionId, which will also appear in the AMQP queue name',
+  },
+});
+
 module.exports = monitorManager;


### PR DESCRIPTION
```
{"EnvVersion":"2.0","Fields":{"v":1},"Hostname":"lamport","Logger":"taskcluster.web-server.pulse-client","Pid":3736,"Severity":6,"Timestamp":1560836735114000000,"Type":"pulse.connected","serviceContext":{"service":"web-server"},"severity":"INFO"}
{"EnvVersion":"2.0","Fields":{"subscriptionId":"ImIJ5mbsRO-GXifGMRoYFg","v":1},"Hostname":"lamport","Logger":"taskcluster.web-server.pulse-engine","Pid":3736,"Severity":7,"Timestamp":1560836738247000000,"Type":"bind-pulse-subscription","serviceContext":{"service":"web-server"},"severity":"DEBUG"}
{"EnvVersion":"2.0","Fields":{"subscriptionId":"ImIJ5mbsRO-GXifGMRoYFg","v":1},"Hostname":"lamport","Logger":"taskcluster.web-server.pulse-engine","Pid":3736,"Severity":7,"Timestamp":1560836738753000000,"Type":"unbind-pulse-subscription","serviceContext":{"service":"web-server"},"severity":"DEBUG"}
```

Note that the subscription information is at level DEBUG.  I'm not sure if that's useful since only INFO is logged by default, but let's see.