### PR TITLE
use worker-pool secrets and roles instead of worker-type

### DIFF
--- a/services/worker-manager/src/providers/google.js
+++ b/services/worker-manager/src/providers/google.js
@@ -251,10 +251,12 @@ class GoogleProvider extends Provider {
     return taskcluster.createTemporaryCredentials({
       clientId: `worker/google/${this.project}/${workerGroup}/${workerId}`,
       scopes: [
-        `assume:worker-type:${workerPoolId}`,
+        `assume:worker-type:${workerPoolId}`, // deprecated role
+        `assume:worker-pool:${workerPoolId}`,
         `assume:worker-id:${workerGroup}/${workerId}`,
         `queue:worker-id:${workerGroup}/${workerId}`,
-        `secrets:get:worker-type:${workerPoolId}`,
+        `secrets:get:worker-type:${workerPoolId}`, // deprecated secret name
+        `secrets:get:worker-pool:${workerPoolId}`,
         `queue:claim-work:${workerPoolId}`,
       ],
       start: taskcluster.fromNow('-15 minutes'),

--- a/ui/docs/manual/design/namespaces.md
+++ b/ui/docs/manual/design/namespaces.md
@@ -125,8 +125,10 @@ Both are listed here:
 * `repo:<host>/<path>:cron:<jobName>` -
    Roles of this form are used for cron jobs by the periodic task-graph generation support in Gecko.
 
-* `worker-type:<provisionerId>/<workerType>` -
-   Roles of this form represent scopes available to workers of the given type.
+* `worker-pool:<provisionerId>/<workerType>`,
+  `worker-type:<provisionerId>/<workerType>` -
+   Roles of this form represent scopes available to workers of the given pool.
+   The second form is deprecated, but still supported.
 
 ---
 


### PR DESCRIPTION
For the moment, let's allow both worker-type:.. and worker-pool:...