### PR TITLE
[UI] Make port 5080 the default port

### DIFF
--- a/ui/.neutrinorc.js
+++ b/ui/.neutrinorc.js
@@ -1,6 +1,9 @@
 const merge = require('deepmerge');
 const { join, resolve } = require('path');
 
+const DEFAULT_PORT = 5080;
+const port = process.env.PORT || DEFAULT_PORT;
+
 require('@babel/register')({
   presets: [require.resolve('@babel/preset-env')],
   cache: false,
@@ -35,7 +38,7 @@ module.exports = {
         title: process.env.APPLICATION_NAME
       },
       devServer: {
-        port: process.env.PORT,
+        port,
         historyApiFallback: {
           disableDotRule: true,
           rewrites: [


### PR DESCRIPTION
`process.env.PORT` is not defined in `.neutrinorc.js`. Because of this, `devServer` was defaulting to port 8080. This commit fixes this issue.