### PR TITLE
Bug 1544917 - limit access to web-server using CORS

### DIFF
--- a/libraries/api/test/route_test.js
+++ b/libraries/api/test/route_test.js
@@ -322,6 +322,17 @@ suite(testing.suiteName(), function() {
       });
   });
 
+  test('cors header', function() {
+    const url = u('/single-param/Hello');
+    return request
+      .get(url)
+      .set('origin', 'https://tc.example.com')
+      .then(function(res) {
+        assert(res.ok, 'Request failed');
+        assert.equal(res.header['access-control-allow-origin'], '*');
+      });
+  });
+
   test('cache header', function() {
     const url = u('/single-param/Hello');
     return request

--- a/services/web-server/config.yml
+++ b/services/web-server/config.yml
@@ -13,6 +13,15 @@ defaults:
     # Port to listen for requests on
     port: !env:number PORT
 
+    # The CORS allowed origins (passed to https://yarnpkg.com/en/package/cors);
+    # typically this is the root URL, but in testing it may have other values.
+    # The legacy root URL is special-cased.  Values beginning with `/` are
+    # treated as regular expressions.  ADDITIONAL_ALLOWED_CORS_ORIGIN is used
+    # to allow UI deploy previews to access a running deployment.
+    allowedCORSOrigins:
+      - !env TASKCLUSTER_ROOT_URL
+      - !env ADDITIONAL_ALLOWED_CORS_ORIGIN
+
   # Configuration of access to other taskcluster components
   taskcluster:
     rootUrl: !env TASKCLUSTER_ROOT_URL
@@ -62,6 +71,12 @@ development:
   server:
     # taskcluster-ui's dev server assumes port 3050
     port: 3050
+    # for testing, allow any origin
+    allowedCORSOrigins: [true]
+
+test:
+  server:
+    port: 63821
 
 production:
   pulse:

--- a/services/web-server/src/main.js
+++ b/services/web-server/src/main.js
@@ -186,3 +186,5 @@ const load = loader(
 if (!module.parent) {
   load.crashOnError(process.argv[2] || 'devServer');
 }
+
+module.exports = load;

--- a/services/web-server/src/servers/createApp.js
+++ b/services/web-server/src/servers/createApp.js
@@ -11,7 +11,18 @@ module.exports = async ({ cfg, strategies }) => {
 
   app.set('view engine', 'ejs');
   app.set('views', 'src/views');
-  app.use(cors());
+
+  const allowedCORSOrigins = cfg.server.allowedCORSOrigins.map(o => {
+    if (typeof(o) === 'string' && o.startsWith('/')) {
+      return new RegExp(o.slice(1, o.length - 1));
+    }
+    if (o === 'https://taskcluster.net') {
+      o = 'https://taskcluster-ui.herokuapp.com';
+    }
+    return o;
+  }).filter(o => o);
+  app.use(cors({origin: allowedCORSOrigins}));
+
   app.use(passport.initialize());
   app.use(credentials());
   app.use(compression());

--- a/services/web-server/test/helper.js
+++ b/services/web-server/test/helper.js
@@ -9,3 +9,34 @@ suiteSetup(async function() {
 });
 
 withMonitor(exports);
+
+exports.withServer = (mock, skipping) => {
+  let webServer;
+
+  suiteSetup('withServer', async function() {
+    if (skipping()) {
+      return;
+    }
+    const cfg = await exports.load('cfg');
+
+    webServer = await exports.load('server');
+    await new Promise((resolve, reject) => {
+      webServer.once('error', reject);
+      webServer.listen(cfg.server.port, function() {
+        resolve();
+      });
+    });
+
+    exports.serverPort = cfg.server.port;
+  });
+
+  suiteTeardown(async function() {
+    if (skipping()) {
+      return;
+    }
+    if (webServer) {
+      await new Promise(resolve => webServer.close(resolve));
+      webServer = null;
+    }
+  });
+};

--- a/services/web-server/test/server_test.js
+++ b/services/web-server/test/server_test.js
@@ -1,0 +1,47 @@
+const assert = require('assert');
+const helper = require('./helper');
+const request = require('superagent');
+const testing = require('taskcluster-lib-testing');
+
+suite(testing.suiteName(), () => {
+  const makeSuite = (allowedCORSOrigins, requestOrigin, responseOrigin) => {
+    suite(`with ${JSON.stringify(allowedCORSOrigins)}, request origin = ${requestOrigin}`, function() {
+      suiteSetup(async function() {
+        await helper.load('cfg');
+        helper.load.save();
+        helper.load.cfg('server.allowedCORSOrigins', allowedCORSOrigins);
+      });
+
+      suiteTeardown(function() {
+        helper.load.restore();
+      });
+
+      helper.withServer(false, () => false);
+
+      test('request', async function() {
+        const res = await request
+          .options(`http://localhost:${helper.serverPort}/graphql`)
+          .set('origin', requestOrigin);
+        assert.equal(res.headers['access-control-allow-origin'], responseOrigin);
+      });
+    });
+  };
+
+  // a "regular" rootUrl
+  makeSuite(['https://tc.example.com'], 'https://tc.example.com', 'https://tc.example.com');
+
+  // * is used in local development
+  makeSuite([true], 'http://localhost', 'http://localhost');
+
+  // legacy rootUrl is a special case
+  makeSuite(
+    ['https://taskcluster.net'],
+    'https://taskcluster-ui.herokuapp.com',
+    'https://taskcluster-ui.herokuapp.com');
+
+  // check that deploy previews are supported..
+  makeSuite(
+    ['https://tc.example.com', "/https://deploy-preview-\\d+--taskcluster-web\\.netlify\\.com/"],
+    'https://deploy-preview-897--taskcluster-web.netlify.com/',
+    'https://deploy-preview-897--taskcluster-web.netlify.com/');
+});


### PR DESCRIPTION
This should work OK for local development, PRs, and on https://taskcluster-ui.herokuapp.com.

The intent is to set ADDITIONAL_ALLOWED_CORS_ORIGIN to `/https://deploy-preview-\\d+--taskcluster-web\\.netlify\\.com/` in whatever deployment we choose to aim the deploy previews at (ideally staging, at least soon).

Bugzilla Bug: [1544917](https://bugzilla.mozilla.org/show_bug.cgi?id=1544917)
