### PR TITLE
[github] Allow `.taskcluster.yml` to set `schedulerId`.

### DIFF
--- a/changelog/github-scheduler.md
+++ b/changelog/github-scheduler.md
@@ -1,0 +1,3 @@
+level: patch
+---
+With the proper scopes, github repositories can now override the default scheduler. This only works with experimental `checks` status reporting.

--- a/changelog/github-scheduler.md
+++ b/changelog/github-scheduler.md
@@ -1,3 +1,3 @@
 level: patch
 ---
-With the proper scopes, github repositories can now override the default scheduler. This only works with experimental `checks` status reporting.
+With the proper scopes, github repositories can now override the default scheduler. Adding custom schedulerId to the task definition while using github's Statuses API might break the status reporting functionality of tc-github in the case of successful build. Therefore, this only works with experimental `checks` status reporting.

--- a/services/github/src/tc-yaml.js
+++ b/services/github/src/tc-yaml.js
@@ -282,8 +282,8 @@ class VersionOne extends TcYaml {
         taskMap[taskId] = {
           taskId,
           task: {
-            ...taskWithoutTaskId,
             schedulerId: cfg.taskcluster.schedulerId,
+            ...taskWithoutTaskId,
           },
         };
       });

--- a/services/github/test/tc-yaml_test.js
+++ b/services/github/test/tc-yaml_test.js
@@ -91,7 +91,7 @@ suite(testing.suiteName(), function() {
       assume(config.tasks[1].taskId).to.not.equal(config.tasks[1].task.taskGroupId);
     });
 
-    test('compileTasks forces schedulerId, but uses user-supplied taskId/taskGroupId', function() {
+    test('compileTasks uses user-supplied taskId/taskGroupId/schedulerId', function() {
       const config = {
         tasks: [{
           taskId: 'task-1',
@@ -109,7 +109,7 @@ suite(testing.suiteName(), function() {
         task: {
           created: now,
           taskGroupId: 'tgid-1',
-          schedulerId: 'test-sched',
+          schedulerId: 'my-scheduler-id',
           routes: ['statuses-queue'],
         },
       }, {
@@ -117,7 +117,7 @@ suite(testing.suiteName(), function() {
         task: {
           created: now,
           taskGroupId: 'tgid-2',
-          schedulerId: 'test-sched',
+          schedulerId: 'my-scheduler-id',
           routes: ['statuses-queue'],
         },
       }]);

--- a/ui/docs/reference/integrations/github/taskcluster-yml-v1.md
+++ b/ui/docs/reference/integrations/github/taskcluster-yml-v1.md
@@ -89,7 +89,12 @@ The result looks like this:
 }
 ```
 
-Taskcluster-Github will set the schedulerId of each task, as is required for proper status tracking of the resulting task.
+Taskcluster-Github will set the `schedulerId` of each task, as is required for proper status tracking of the resulting task.
+With the change , it became possible to set a custom `schedulerId` in the task definition, provided you have the scopes
+for using that particular `schedulerId`. However, adding custom schedulerId to the task definition while using github's 
+Statuses API can break the status reporting functionality of tc-github in the case of successful build. 
+Checks API implementation in tc-github is currently in experimental state.
+
 
 The `taskId` and `taskGroupId` properties can be set by the JSON-e template,
 but default values are also available.  If the JSON-e rendering produces only


### PR DESCRIPTION
Fixes #748.