### PR TITLE
Bug 1556526 - allow extra fields in updateWorkerPool

### DIFF
--- a/clients/client-py/taskcluster/generated/aio/workermanager.py
+++ b/clients/client-py/taskcluster/generated/aio/workermanager.py
@@ -171,7 +171,7 @@ class WorkerManager(AsyncBaseClient):
         },
         "updateWorkerPool": {
             'args': ['workerPoolId'],
-            'input': 'v1/create-worker-pool-request.json#',
+            'input': 'v1/update-worker-pool-request.json#',
             'method': 'post',
             'name': 'updateWorkerPool',
             'output': 'v1/worker-pool-full.json#',

--- a/clients/client-py/taskcluster/generated/workermanager.py
+++ b/clients/client-py/taskcluster/generated/workermanager.py
@@ -171,7 +171,7 @@ class WorkerManager(BaseClient):
         },
         "updateWorkerPool": {
             'args': ['workerPoolId'],
-            'input': 'v1/create-worker-pool-request.json#',
+            'input': 'v1/update-worker-pool-request.json#',
             'method': 'post',
             'name': 'updateWorkerPool',
             'output': 'v1/worker-pool-full.json#',

--- a/clients/client/src/apis.js
+++ b/clients/client/src/apis.js
@@ -3778,7 +3778,7 @@ module.exports = {
             "workerPoolId"
           ],
           "description": "Given an existing worker pool definition, this will modify it and return\nthe new definition.\n\nTo delete a worker pool, set its `providerId` to `\"null-provider\"`.\nAfter any existing workers have exited, a cleanup job will remove the\nworker pool.  During that time, the worker pool can be updated again, such\nas to set its `providerId` to a real provider.",
-          "input": "v1/create-worker-pool-request.json#",
+          "input": "v1/update-worker-pool-request.json#",
           "method": "post",
           "name": "updateWorkerPool",
           "output": "v1/worker-pool-full.json#",

--- a/generated/references.json
+++ b/generated/references.json
@@ -293,6 +293,58 @@
   },
   {
     "content": {
+      "$id": "/schemas/worker-manager/v1/update-worker-pool-request.json#",
+      "$schema": "/schemas/common/metaschema.json#",
+      "additionalProperties": false,
+      "description": "Fields that are defined by a user for a worker pool.\nUsed to modify worker-pool definitions.\n\nThe `workerPoolId`, `created`, and `lastModified` fields are optional and\nallowed only to ease the common practice of getting a worker pool definition\nwith `workerPool(..)`, modifying it, and writing it back with\n`updateWorkerPool(..).  `workerPoolId` must be correct if\nsupplied, and the values of `created` and `lastModified` are ignored.\n",
+      "properties": {
+        "config": {
+          "$ref": "worker-pool-full.json#/properties/config"
+        },
+        "created": {
+          "description": "Ignored on update",
+          "format": "date-time",
+          "title": "Created",
+          "type": "string"
+        },
+        "description": {
+          "$ref": "worker-pool-full.json#/properties/description"
+        },
+        "emailOnError": {
+          "$ref": "worker-pool-full.json#/properties/emailOnError"
+        },
+        "lastModified": {
+          "description": "Ignored on update",
+          "format": "date-time",
+          "title": "Last Modified",
+          "type": "string"
+        },
+        "owner": {
+          "$ref": "worker-pool-full.json#/properties/owner"
+        },
+        "providerId": {
+          "$ref": "worker-pool-full.json#/properties/providerId"
+        },
+        "workerPoolId": {
+          "pattern": "^[a-zA-Z0-9-_]{1,38}/[a-z]([-a-z0-9]{0,36}[a-z0-9])?$",
+          "title": "Worker Pool ID",
+          "type": "string"
+        }
+      },
+      "required": [
+        "providerId",
+        "description",
+        "config",
+        "owner",
+        "emailOnError"
+      ],
+      "title": "Worker Pool Definition",
+      "type": "object"
+    },
+    "filename": "schemas/worker-manager/v1/update-worker-pool-request.json"
+  },
+  {
+    "content": {
       "$id": "/schemas/worker-manager/v1/temp-creds-response.json#",
       "$schema": "/schemas/common/metaschema.json#",
       "additionalProperties": false,
@@ -378,7 +430,7 @@
       "$id": "/schemas/worker-manager/v1/create-worker-pool-request.json#",
       "$schema": "/schemas/common/metaschema.json#",
       "additionalProperties": false,
-      "description": "Fields that are defined by a user for a worker pool.\nUsed to create and modify definitions. There is a larger\nset of fields for viewing since some parts are generated\nby the service.\n",
+      "description": "Fields that are defined by a user for a worker pool.\nUsed to create worker-pool definitions. There is a larger\nset of fields for viewing since some parts are generated\nby the service.\n",
       "properties": {
         "config": {
           "$ref": "worker-pool-full.json#/properties/config"
@@ -8238,7 +8290,7 @@
             "workerPoolId"
           ],
           "description": "Given an existing worker pool definition, this will modify it and return\nthe new definition.\n\nTo delete a worker pool, set its `providerId` to `\"null-provider\"`.\nAfter any existing workers have exited, a cleanup job will remove the\nworker pool.  During that time, the worker pool can be updated again, such\nas to set its `providerId` to a real provider.",
-          "input": "v1/create-worker-pool-request.json#",
+          "input": "v1/update-worker-pool-request.json#",
           "method": "post",
           "name": "updateWorkerPool",
           "output": "v1/worker-pool-full.json#",

--- a/services/worker-manager/schemas/constants.yml
+++ b/services/worker-manager/schemas/constants.yml
@@ -9,3 +9,7 @@ identifier-max-length:  38
 
 # Slugid pattern, for when-ever that is useful
 slugid-pattern: "^[A-Za-z0-9_-]{8}[Q-T][A-Za-z0-9_-][CGKOSWaeimquy26-][A-Za-z0-9_-]{10}[AQgw]$"
+
+# Note that the portion after the `/` is quite severely limited in hopes it works with
+# most cloud providers
+workerpoolid-pattern: '^[a-zA-Z0-9-_]{1,38}/[a-z]([-a-z0-9]{0,36}[a-z0-9])?$'

--- a/services/worker-manager/schemas/v1/create-worker-pool-request.yml
+++ b/services/worker-manager/schemas/v1/create-worker-pool-request.yml
@@ -2,7 +2,7 @@ $schema: "/schemas/common/metaschema.json#"
 title: Worker Pool Definition
 description: |
   Fields that are defined by a user for a worker pool.
-  Used to create and modify definitions. There is a larger
+  Used to create worker-pool definitions. There is a larger
   set of fields for viewing since some parts are generated
   by the service.
 type: object

--- a/services/worker-manager/schemas/v1/update-worker-pool-request.yml
+++ b/services/worker-manager/schemas/v1/update-worker-pool-request.yml
@@ -1,0 +1,39 @@
+$schema: "/schemas/common/metaschema.json#"
+title: Worker Pool Definition
+description: |
+  Fields that are defined by a user for a worker pool.
+  Used to modify worker-pool definitions.
+
+  The `workerPoolId`, `created`, and `lastModified` fields are optional and
+  allowed only to ease the common practice of getting a worker pool definition
+  with `workerPool(..)`, modifying it, and writing it back with
+  `updateWorkerPool(..).  `workerPoolId` must be correct if
+  supplied, and the values of `created` and `lastModified` are ignored.
+type: object
+properties:
+  providerId: {$ref: "worker-pool-full.json#/properties/providerId"}
+  description: {$ref: "worker-pool-full.json#/properties/description"}
+  config: {$ref: "worker-pool-full.json#/properties/config"}
+  owner: {$ref: "worker-pool-full.json#/properties/owner"}
+  emailOnError: {$ref: "worker-pool-full.json#/properties/emailOnError"}
+  workerPoolId:
+    title: Worker Pool ID
+    type:           string
+    pattern:        {$const: workerpoolid-pattern}
+  created:
+    title: Created
+    type:                   string
+    format:                 date-time
+    description: 'Ignored on update'
+  lastModified:
+    title: Last Modified
+    type:                   string
+    format:                 date-time
+    description: 'Ignored on update'
+additionalProperties: false
+required:
+  - providerId
+  - description
+  - config
+  - owner
+  - emailOnError

--- a/services/worker-manager/schemas/v1/worker-pool-full.yml
+++ b/services/worker-manager/schemas/v1/worker-pool-full.yml
@@ -7,9 +7,7 @@ properties:
   workerPoolId:
     title: Worker Pool ID
     type:           string
-    # Note that the portion after the `/` is quite severely limited in hopes it works with
-    # most cloud providers
-    pattern:        '^[a-zA-Z0-9-_]{1,38}/[a-z]([-a-z0-9]{0,36}[a-z0-9])?$'
+    pattern:        {$const: workerpoolid-pattern}
     description: |
       The ID of this worker pool (of the form `providerId/workerType` for compatibility)
   providerId:

--- a/services/worker-manager/src/api.js
+++ b/services/worker-manager/src/api.js
@@ -97,7 +97,7 @@ builder.declare({
   name: 'updateWorkerPool',
   title: 'Update Worker Pool',
   stability: APIBuilder.stability.experimental,
-  input: 'create-worker-pool-request.yml',
+  input: 'update-worker-pool-request.yml',
   output: 'worker-pool-full.yml',
   scopes: {AllOf: [
     'worker-manager:update-worker-type:<workerPoolId>',
@@ -130,6 +130,10 @@ builder.declare({
   const error = provider.validate(input.config);
   if (error) {
     return res.reportError('InputValidationError', error);
+  }
+
+  if (input.workerPoolId && input.workerPoolId !== workerPoolId) {
+    return res.reportError('InputError', 'Incorrect workerPoolId in request body', {});
   }
 
   const workerPool = await this.WorkerPool.load({

--- a/services/worker-manager/test/api_test.js
+++ b/services/worker-manager/test/api_test.js
@@ -60,9 +60,13 @@ helper.secrets.mockSuite(testing.suiteName(), ['taskcluster', 'azure'], function
       config: {},
       owner: 'example@example.com',
       emailOnError: false,
+      // these should be ignored
+      created: taskcluster.fromNow('10 days'),
+      lastModified: taskcluster.fromNow('10 days'),
     };
     const updated = await helper.workerManager.updateWorkerPool(workerPoolId, input2);
-    workerPoolCompare(workerPoolId, input2, updated);
+    const {created: _1, lastModified: _2, ...expected} = input2;
+    workerPoolCompare(workerPoolId, expected, updated);
 
     assert.equal(initial.lastModified, initial.created);
     assert.equal(initial.created, updated.created);
@@ -85,6 +89,32 @@ helper.secrets.mockSuite(testing.suiteName(), ['taskcluster', 'azure'], function
       return;
     }
     throw new Error('Allowed to specify an invalid providerId');
+  });
+
+  test('update worker pool (invalid workerPoolId)', async function() {
+    await helper.workerManager.createWorkerPool('pp/oo', {
+      providerId: 'testing1',
+      description: 'e',
+      config: {},
+      owner: 'example@example.com',
+      emailOnError: false,
+    });
+    try {
+      await helper.workerManager.updateWorkerPool('pp/oo', {
+        workerPoolId: 'something/different',
+        providerId: 'testing1',
+        description: 'e',
+        config: {},
+        owner: 'example@example.com',
+        emailOnError: false,
+      });
+    } catch (err) {
+      if (err.code !== 'InputError') {
+        throw err;
+      }
+      return;
+    }
+    throw new Error('Allowed to specify an invalid workerPoolId');
   });
 
   test('update worker pool (invalid providerId)', async function() {


### PR DESCRIPTION
This allows `workerPoolId`, `created`, and `lastModified`, ignoring the
latter two, for user convenience in something like

```js
wp = await wm.workerPool(wpId);
wp.config.foo = 'bar';
await wm.updateWorkerPool(wpId, wp);
```

Bugzilla Bug: [1556526](https://bugzilla.mozilla.org/show_bug.cgi?id=1556526)
