### PR TITLE
add worker-reviewers as reviewers of the go client

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,4 +2,5 @@
 
 services/web-server @taskcluster/frontend-reviewers
 clients/client-web @taskcluster/frontend-reviewers
+clients/client-go @taskcluster/worker-reviewers
 ui @taskcluster/frontend-reviewers


### PR DESCRIPTION
With the idea that worker-reviewers tend to be the Golang experts on the team (note that we already send client-web reviews to frontend-reviewers for similar reasons, and that we often cancel review requests to that team for API-references-only changes).