### PR TITLE
Bug 1558187 - handle connection failures better

### DIFF
--- a/libraries/pulse/test/helper.js
+++ b/libraries/pulse/test/helper.js
@@ -1,5 +1,7 @@
-const {Secrets} = require('taskcluster-lib-testing');
+const {Secrets, withMonitor} = require('taskcluster-lib-testing');
 const {defaultMonitorManager} = require('taskcluster-lib-monitor');
+
+withMonitor(exports, {noLoader: true});
 
 defaultMonitorManager.configure({
   serviceName: 'lib-pulse',

--- a/libraries/testing/README.md
+++ b/libraries/testing/README.md
@@ -359,6 +359,11 @@ The function does the following:
 
 Tests should import the MonitorManager instance from `../src/monitor.js` to get access to the messages and modify the message list
 
+Libraries can use this function as
+```js
+withMonitor(exports, {noLoader: true});
+```
+
 Time
 ----
 

--- a/libraries/testing/src/with-monitor.js
+++ b/libraries/testing/src/with-monitor.js
@@ -1,10 +1,10 @@
 const {defaultMonitorManager, LEVELS} = require('taskcluster-lib-monitor');
 
 let monitorSetup = false;
-module.exports = (helper) => {
+module.exports = (helper, options={}) => {
   // ensure that a single monitor instance is injected as soon as possible
   // (even before suite setups run), and only once.
-  if (!monitorSetup) {
+  if (!options.noLoader && !monitorSetup) {
     helper.load.inject('monitor', defaultMonitorManager.setup({
       fake: true,
       debug: true,


### PR DESCRIPTION
amqplib's failure handling is pretty poor -- it seems this particluar
error doesn't match IllegalOperationError.  This patch also adds some
lib-testing support to handle testing for error messages.  And it
sets prefetch=1 in a few places to get more stable test behavior.

Bugzilla Bug: [1558187](https://bugzilla.mozilla.org/show_bug.cgi?id=1558187)
