### PR TITLE
Allow subscription endpoint to use https too

### DIFF
--- a/changelog/allow-https-sub-endpoint.md
+++ b/changelog/allow-https-sub-endpoint.md
@@ -1,0 +1,5 @@
+level: patch
+---
+The `GRAPHQL_SUBSCRIPTION_ENDPOINT` config for taskcluster-ui can now have scheme `http` or `https` instead of `ws`/`wss`.
+This allows easier generation of this configuration as `${TASKCLUSTER_ROOT_URL}/subscription`.
+The existing schemas are still accepted so no configuration change is required.

--- a/netlify.toml
+++ b/netlify.toml
@@ -9,7 +9,7 @@
   NODE_VERSION = "10.16.0"
   APPLICATION_NAME = "Taskcluster"
   GRAPHQL_ENDPOINT = "https://taskcluster-web-server.herokuapp.com/graphql"
-  GRAPHQL_SUBSCRIPTION_ENDPOINT = "wss://taskcluster-web-server.herokuapp.com/subscription"
+  GRAPHQL_SUBSCRIPTION_ENDPOINT = "https://taskcluster-web-server.herokuapp.com/subscription"
   UI_LOGIN_STRATEGY_NAMES = ""
   TASKCLUSTER_ROOT_URL = "https://taskcluster.net"
 

--- a/ui/.neutrinorc.js
+++ b/ui/.neutrinorc.js
@@ -64,7 +64,7 @@ module.exports = {
         UI_LOGIN_STRATEGY_NAMES: '',
         PORT: 5080,
         TASKCLUSTER_ROOT_URL: 'https://taskcluster.net',
-        GRAPHQL_SUBSCRIPTION_ENDPOINT: 'ws://localhost:5080/subscription',
+        GRAPHQL_SUBSCRIPTION_ENDPOINT: 'http://localhost:5080/subscription',
         GRAPHQL_ENDPOINT: 'http://localhost:5080/graphql',
         GA_TRACKING_ID: '',
         SENTRY_DSN: '',

--- a/ui/README.md
+++ b/ui/README.md
@@ -46,7 +46,7 @@ PORT=9000
 If you are not running the web service on your local machine, you will also need to set
 
 ```bash
-GRAPHQL_SUBSCRIPTION_ENDPOINT=wss://mydomain.com/subscription
+GRAPHQL_SUBSCRIPTION_ENDPOINT=https://mydomain.com/subscription
 GRAPHQL_ENDPOINT=https://mydomain.com/graphql
 ```
 

--- a/ui/src/App/index.jsx
+++ b/ui/src/App/index.jsx
@@ -72,7 +72,8 @@ export default class App extends Component {
   });
 
   wsLink = new WebSocketLink({
-    uri: process.env.GRAPHQL_SUBSCRIPTION_ENDPOINT,
+    // allow configuration of https:// or http:// and translate to ws:// or wss://
+    uri: process.env.GRAPHQL_SUBSCRIPTION_ENDPOINT.replace(/^http/, 'ws'),
     options: {
       reconnect: true,
       lazy: true,


### PR DESCRIPTION
Then it can be constructed from rootUrl just using string concatenation.