### PR TITLE
Bug 1555213 - remove previous providers when they are done

### DIFF
--- a/services/worker-manager/src/main.js
+++ b/services/worker-manager/src/main.js
@@ -234,6 +234,7 @@ let load = loader({
     setup: async ({cfg, monitor, Worker, WorkerPool, providers}) => {
       const workerScanner = new WorkerScanner({
         Worker,
+        WorkerPool,
         providers,
         monitor: monitor.childMonitor('worker-scanner'),
       });

--- a/services/worker-manager/src/providers/provider.js
+++ b/services/worker-manager/src/providers/provider.js
@@ -74,23 +74,30 @@ class Provider {
   }
 
   /**
-   * Given a worker pool configuration, do whatever the provider might
-   * do with this worker pool. This may mean nothing at all in the case of
-   * static provider!
+   * Given a worker pool configuration, do whatever the provider might do with
+   * this worker pool to create workers to do work. This may mean nothing at
+   * all in the case of static provider!
    */
   async provision({workerPool}) {
   }
 
-  // This is the oposite of provision. Given a worker pool, tear down whatever
-  // resources this provider has created for it. Once complete, remove yourself
-  // from the worker pool's list of previous providers.
+  /**
+   * This is the oposite of provision, and is called for providers that are
+   * no longer the provider for the given workerPool, but may still have workers
+   * or other resources defined for the workerPool.
+   *
+   * The provider should tear down whatever resources this provider has created
+   * for the worker pool.  This will be called in every provisioning loop until
+   * there are no remaining workers in this pool with this providerId.  The
+   * provider can pro-actively stop any such workers, or wait for them to stop
+   * themselves.
+   */
   async deprovision({workerPool}) {
   }
 
   /**
    * Anything a provider may want to do every provisioning loop but not tied
    * to any one worker pool. Called _after_ all provision() calls are complete.
-   * You may want to use this time to remove outdated worker pools for instance.
    */
   async cleanup() {
   }
@@ -116,7 +123,8 @@ class Provider {
 
   /**
    * Called when a new worker pool is added to this provider to allow the provider
-   * to do whatever setup is necessary
+   * to do whatever setup is necessary, such as creating shared resources for the
+   * workers.  This activity is specific to the pool, but not to individual workers.
    */
   async createResources({workerPool}) {
   }
@@ -131,7 +139,9 @@ class Provider {
   }
 
   /**
-   * Called when a worker pool is removed and this provider was providing for it.
+   * Called when a worker pool is removed and this provider was providing for it.  After
+   * this call completes correctly, this provider is removed from the list of previous
+   * providerIds for this worker pool.
    */
   async removeResources({workerPool}) {
   }

--- a/services/worker-manager/src/providers/testing.js
+++ b/services/worker-manager/src/providers/testing.js
@@ -16,6 +16,12 @@ class TestingProvider extends Provider {
 
   async removeResources({workerPool}) {
     this.monitor.notice('remove-resource', {workerPoolId: workerPool.workerPoolId});
+    if (workerPool.providerData.failRemoveResources) {
+      await workerPool.modify(wp => {
+        wp.providerData.failRemoveResources -= 1;
+      });
+      throw new Error('uhoh removing resources');
+    }
   }
 
   async provision({workerPool}) {

--- a/services/worker-manager/src/provisioner.js
+++ b/services/worker-manager/src/provisioner.js
@@ -83,11 +83,7 @@ class Provisioner {
         if (providerId === previousProviderId) {
           await provider.updateResources({workerPool});
         } else {
-          const previousProvider = this.providers.get(previousProviderId);
-          await Promise.all([
-            provider.createResources({workerPool}),
-            previousProvider && previousProvider.removeResources({workerPool}),
-          ]);
+          await provider.createResources({workerPool});
         }
         break;
       }

--- a/services/worker-manager/src/worker-scanner.js
+++ b/services/worker-manager/src/worker-scanner.js
@@ -8,11 +8,13 @@ const Iterate = require('taskcluster-lib-iterate');
 class WorkerScanner {
   constructor({
     Worker,
+    WorkerPool,
     providers,
     monitor,
     iterateConf = {},
   }) {
     this.Worker = Worker;
+    this.WorkerPool = WorkerPool;
     this.providers = providers;
     this.monitor = monitor;
     this.iterate = new Iterate({
@@ -41,16 +43,64 @@ class WorkerScanner {
   }
 
   async scan() {
+    // track the providerIds seen for each worker pool, so they can be removed
+    // from the list of previous provider IDs
+    const providersByPool = new Map();
+    const seen = (providerId, workerPoolId) => {
+      const v = providersByPool.get(workerPoolId);
+      if (v) {
+        v.add(providerId);
+      } else {
+        providersByPool.set(workerPoolId, new Set([providerId]));
+      }
+    };
+
     await this.providers.forAll(p => p.scanPrepare());
     await this.Worker.scan({
       state: Entity.op.notEqual(this.Worker.states.STOPPED),
     }, {
       handler: async worker => {
+        seen(worker.providerId, worker.workerPoolId);
         const provider = this.providers.get(worker.providerId);
-        await provider.checkWorker({worker});
+        if (provider) {
+          await provider.checkWorker({worker});
+        } else {
+          this.monitor.info(
+            `Worker ${worker.workerGroup}/${worker.workerId} has unknown providerId ${worker.providerId} (ignoring)`);
+        }
       },
     });
     await this.providers.forAll(p => p.scanCleanup());
+
+    // Now, see if we can remove any previous providers
+    await this.WorkerPool.scan({}, {
+      handler: async workerPool => {
+        const {previousProviderIds, workerPoolId} = workerPool;
+        const stillCurrent = providersByPool.get(workerPoolId) || new Set();
+        const removable = previousProviderIds.filter(providerId => !stillCurrent.has(providerId));
+
+        for (let providerId of removable) {
+          const provider = this.providers.get(providerId);
+          if (provider) {
+            try {
+              await provider.removeResources({workerPool});
+            } catch (err) {
+              // report error and try again next time..
+              this.monitor.reportError(err, {workerPoolId, providerId});
+              continue;
+            }
+          } else {
+            this.monitor.info(
+              `Worker pool ${workerPoolId} has unknown previous providerId ${providerId} (removing)`);
+          }
+
+          // the provider is done with this pool, so remove it from the list of previous providers
+          await workerPool.modify(wp => {
+            wp.previousProviderIds = wp.previousProviderIds.filter(pid => pid !== providerId);
+          });
+        }
+      },
+    });
   }
 }
 

--- a/services/worker-manager/test/provisioner_test.js
+++ b/services/worker-manager/test/provisioner_test.js
@@ -198,12 +198,6 @@ helper.secrets.mockSuite(testing.suiteName(), ['taskcluster', 'azure'], function
         routingKey: 'primary.#',
         routes: [],
       });
-      assert.deepEqual(monitorManager.messages.find(msg => msg.Type === 'remove-resource'), {
-        Logger: 'taskcluster.worker-manager.provider.testing1',
-        Type: 'remove-resource',
-        Severity: LEVELS.notice,
-        Fields: {workerPoolId: 'pp/foo'},
-      });
       assert.deepEqual(monitorManager.messages.find(msg => msg.Type === 'create-resource'), {
         Logger: 'taskcluster.worker-manager.provider.testing2',
         Type: 'create-resource',

--- a/services/worker-manager/test/worker_scanner_test.js
+++ b/services/worker-manager/test/worker_scanner_test.js
@@ -11,14 +11,17 @@ helper.secrets.mockSuite(testing.suiteName(), ['taskcluster', 'azure'], function
   helper.withProviders(mock, skipping);
   helper.withWorkerScanner(mock, skipping);
 
-  const testCase = async ({workers, assertion}) => {
+  const testCase = async ({workers=[], workerPools=[], assertion, expectErrors}) => {
     await Promise.all(workers.map(w => helper.Worker.create(w)));
+    await Promise.all(workerPools.map(wp => helper.WorkerPool.create(wp)));
     return (testing.runWithFakeTime(async () => {
       await helper.initiateWorkerScanner();
       await testing.poll(async () => {
-        const error = monitorManager.messages.find(({Type}) => Type === 'monitor.error');
-        if (error) {
-          throw new Error(JSON.stringify(error, null, 2));
+        if (!expectErrors) {
+          const error = monitorManager.messages.find(({Type}) => Type === 'monitor.error');
+          if (error) {
+            throw new Error(JSON.stringify(error, null, 2));
+          }
         }
         workers.forEach(w => {
           assert.deepEqual(monitorManager.messages.find(
@@ -37,8 +40,12 @@ helper.secrets.mockSuite(testing.suiteName(), ['taskcluster', 'azure'], function
           });
         });
         await assertion();
-      });
+      }, 30, 1000);
       await helper.terminateWorkerScanner();
+
+      if (expectErrors) {
+        monitorManager.messages = [];
+      }
     }, {
       mock,
       maxTime: 30000,
@@ -65,6 +72,68 @@ helper.secrets.mockSuite(testing.suiteName(), ['taskcluster', 'azure'], function
         workerId: 'testing-123',
       });
       assert(worker.providerData.checked);
+    },
+  }));
+
+  test('worker for previous provider is stopped', () => testCase({
+    workers: [
+      {
+        workerPoolId: 'ff/ee',
+        workerGroup: 'whatever',
+        workerId: 'testing-OLD',
+        providerId: 'testing1',
+        created: new Date(),
+        expires: taskcluster.fromNow('1 hour'),
+        state: helper.Worker.states.STOPPED,
+        providerData: {},
+      },
+      {
+        workerPoolId: 'ff/ee',
+        workerGroup: 'whatever',
+        workerId: 'testing-123',
+        providerId: 'testing2',
+        created: new Date(),
+        expires: taskcluster.fromNow('1 hour'),
+        state: helper.Worker.states.REQUESTED,
+        providerData: {},
+      },
+    ],
+    workerPools: [
+      {
+        workerPoolId: 'ff/ee',
+        providerId: 'testing2',
+        previousProviderIds: ['testing1'],
+        description: '',
+        created: taskcluster.fromNow('-1 hour'),
+        lastModified: taskcluster.fromNow('-1 hour'),
+        config: {},
+        owner: 'foo@example.com',
+        emailOnError: false,
+        providerData: {
+          // make removeResources fail on the first try, to test error handling
+          failRemoveResources: 1,
+        },
+      },
+    ],
+    expectErrors: true,
+    assertion: async () => {
+      const worker = await helper.Worker.load({
+        workerPoolId: 'ff/ee',
+        workerGroup: 'whatever',
+        workerId: 'testing-123',
+      });
+      assert(worker.providerData.checked);
+
+      const wp = await helper.WorkerPool.load({workerPoolId: 'ff/ee'});
+      assert.deepEqual(wp.previousProviderIds, []);
+
+      assert.deepEqual(monitorManager.messages.find(
+        msg => msg.Type === 'remove-resource' && msg.Logger.endsWith('testing1')), {
+        Logger: `taskcluster.worker-manager.provider.testing1`,
+        Type: 'remove-resource',
+        Fields: {workerPoolId: 'ff/ee'},
+        Severity: LEVELS.notice,
+      });
     },
   }));
 


### PR DESCRIPTION
This defers calling removeResources until all workers in the pool for a
specific provider are STOPPED.

This brings up some questions that might lead to good followups:

 * how are workers removed from the Worker table?
 * should we consider workers in the STOPPED state but still in the table to be a reason to hold onto the provider's resources?

Bugzilla Bug: [1555213](https://bugzilla.mozilla.org/show_bug.cgi?id=1555213)
