### PR TITLE
Redirect UI linkage for scopes starting with 'assume:'

### DIFF
--- a/ui/src/components/ClientForm/index.jsx
+++ b/ui/src/components/ClientForm/index.jsx
@@ -25,7 +25,7 @@ import Button from '../Button';
 import { client } from '../../utils/prop-types';
 import splitLines from '../../utils/splitLines';
 import Link from '../../utils/Link';
-import scopeRedirect from '../../utils/scopeRedirect';
+import scopeLink from '../../utils/scopeLink';
 
 @withStyles(theme => ({
   fab: {
@@ -323,7 +323,7 @@ export default class ClientForm extends Component {
                           key={scope}
                           button
                           component={Link}
-                          to={scopeRedirect(scope)}
+                          to={scopeLink(scope)}
                           className={classes.listItemButton}>
                           <ListItemText secondary={<code>{scope}</code>} />
                           <LinkIcon />

--- a/ui/src/components/HookForm/index.jsx
+++ b/ui/src/components/HookForm/index.jsx
@@ -482,6 +482,7 @@ export default class HookForm extends Component {
                   name="hookGroupId"
                   onChange={this.handleHookGroupIdChange}
                   fullWidth
+                  autoFocus
                   value={hook.hookGroupId}
                 />
               </ListItem>

--- a/ui/src/components/RoleForm/index.jsx
+++ b/ui/src/components/RoleForm/index.jsx
@@ -15,7 +15,7 @@ import SpeedDialAction from '../SpeedDialAction';
 import { role } from '../../utils/prop-types';
 import Link from '../../utils/Link';
 import splitLines from '../../utils/splitLines';
-import scopeRedirect from '../../utils/scopeRedirect';
+import scopeLink from '../../utils/scopeLink';
 
 @withStyles(theme => ({
   fab: {
@@ -201,7 +201,7 @@ export default class RoleForm extends Component {
                           key={scope}
                           button
                           component={Link}
-                          to={scopeRedirect(scope)}
+                          to={scopeLink(scope)}
                           className={classes.listItemButton}>
                           <ListItemText secondary={<code>{scope}</code>} />
                           <LinkIcon />

--- a/ui/src/utils/scopeLink.js
+++ b/ui/src/utils/scopeLink.js
@@ -1,0 +1,7 @@
+// Given a scope, if it starts with "assume:"
+// then a link to the relevant role is returned
+// else a link to the scope inspector is returned.
+export default scope =>
+  scope.startsWith('assume:')
+    ? `/auth/roles/${encodeURIComponent(scope.replace('assume:', ''))}`
+    : `/auth/scopes/${encodeURIComponent(scope)}`;

--- a/ui/src/utils/scopeRedirect.js
+++ b/ui/src/utils/scopeRedirect.js
@@ -1,6 +1,0 @@
-const scopeRedirect = scope =>
-  scope.startsWith('assume:')
-    ? `/auth/roles/${encodeURIComponent(scope.replace('assume:', ''))}`
-    : `/auth/scopes/${encodeURIComponent(scope)}`;
-
-export default scopeRedirect;

--- a/ui/src/views/Scopes/ScopesetExpander/index.jsx
+++ b/ui/src/views/Scopes/ScopesetExpander/index.jsx
@@ -16,7 +16,7 @@ import ErrorPanel from '../../../components/ErrorPanel';
 import splitLines from '../../../utils/splitLines';
 import Link from '../../../utils/Link';
 import scopesetQuery from './scopeset.graphql';
-import scopeRedirect from '../../../utils/scopeRedirect';
+import scopeLink from '../../../utils/scopeLink';
 
 @hot(module)
 @withStyles(theme => ({
@@ -85,7 +85,7 @@ export default class ScopesetExpander extends Component {
                           key={scope}
                           button
                           component={Link}
-                          to={scopeRedirect(scope)}
+                          to={scopeLink(scope)}
                           className={classes.listItemButton}>
                           <ListItemText secondary={scope} />
                           <LinkIcon size={16} />


### PR DESCRIPTION
Scopes that start with 'assume:' will now direct to `/auth/roles/...` and scopes that don't will maintain their original linkage `/auth/scopes/...`.

Fixes #884.