### PR TITLE
Better documentation of the provider.setup method

### DIFF
--- a/services/worker-manager/src/providers/provider.js
+++ b/services/worker-manager/src/providers/provider.js
@@ -34,9 +34,10 @@ class Provider {
   }
 
   /**
-   * Once the returned promise is
-   * resolve, the Provider must be fully working. This is called for a provider
-   * whether it is being used to provision or not.
+   * This is called at process start-up for all configured providers (that is,
+   * once for each providerId).  It can be used as an "async constructor" such
+   * as to set up object properties that must be awaited.  It can also be used
+   * to construct provider-global objects in a cloud service, for example.
    */
   async setup() {
   }


### PR DESCRIPTION
This clears up some of the confusion I had in #923, and is based on how the method is called.

I did notice that if `setup` fails, the process startup will fail.  For things like creating IAM users, that could mean that e.g., an EC2 outage would stop the worker-manager from starting up.  Should we try to soften that requirement a little bit?  Ideas how?  I can file a followup bug..