### PR TITLE
[Bug 1530644] Add tags to pulse messages

### DIFF
--- a/changelog/1530644.md
+++ b/changelog/1530644.md
@@ -1,0 +1,3 @@
+level: minor
+---
+Pulse messages now include a task's tags for better classification of the messages that are received.

--- a/clients/client-go/tcqueueevents/types.go
+++ b/clients/client-go/tcqueueevents/types.go
@@ -163,6 +163,86 @@ type (
 		WorkerID string `json:"workerId,omitempty"`
 	}
 
+	// Subset of a task definition
+	Task struct {
+
+		// Arbitrary key-value tags (only strings limited to 4k). These can be used
+		// to attach informal metadata to a task. Use this for informal tags that
+		// tasks can be classified by. You can also think of strings here as
+		// candidates for formal metadata. Something like
+		// `purpose: 'build' || 'test'` is a good example.
+		//
+		// Default:    {}
+		//
+		// Map entries:
+		// Max length: 4096
+		Tags map[string]string `json:"tags"`
+	}
+
+	// Subset of a task definition
+	Task1 struct {
+
+		// Arbitrary key-value tags (only strings limited to 4k). These can be used
+		// to attach informal metadata to a task. Use this for informal tags that
+		// tasks can be classified by. You can also think of strings here as
+		// candidates for formal metadata. Something like
+		// `purpose: 'build' || 'test'` is a good example.
+		//
+		// Default:    {}
+		//
+		// Map entries:
+		// Max length: 4096
+		Tags map[string]string `json:"tags"`
+	}
+
+	// Subset of a task definition
+	Task2 struct {
+
+		// Arbitrary key-value tags (only strings limited to 4k). These can be used
+		// to attach informal metadata to a task. Use this for informal tags that
+		// tasks can be classified by. You can also think of strings here as
+		// candidates for formal metadata. Something like
+		// `purpose: 'build' || 'test'` is a good example.
+		//
+		// Default:    {}
+		//
+		// Map entries:
+		// Max length: 4096
+		Tags map[string]string `json:"tags"`
+	}
+
+	// Subset of a task definition
+	Task3 struct {
+
+		// Arbitrary key-value tags (only strings limited to 4k). These can be used
+		// to attach informal metadata to a task. Use this for informal tags that
+		// tasks can be classified by. You can also think of strings here as
+		// candidates for formal metadata. Something like
+		// `purpose: 'build' || 'test'` is a good example.
+		//
+		// Default:    {}
+		//
+		// Map entries:
+		// Max length: 4096
+		Tags map[string]string `json:"tags"`
+	}
+
+	// Subset of a task definition
+	Task4 struct {
+
+		// Arbitrary key-value tags (only strings limited to 4k). These can be used
+		// to attach informal metadata to a task. Use this for informal tags that
+		// tasks can be classified by. You can also think of strings here as
+		// candidates for formal metadata. Something like
+		// `purpose: 'build' || 'test'` is a good example.
+		//
+		// Default:    {}
+		//
+		// Map entries:
+		// Max length: 4096
+		Tags map[string]string `json:"tags"`
+	}
+
 	// Message reporting that a task has complete successfully.
 	TaskCompletedMessage struct {
 
@@ -175,17 +255,8 @@ type (
 		// A representation of **task status** as known by the queue
 		Status TaskStatusStructure `json:"status"`
 
-		// Arbitrary key-value tags (only strings limited to 4k). These can be used
-		// to attach informal metadata to a task. Use this for informal tags that
-		// tasks can be classified by. You can also think of strings here as
-		// candidates for formal metadata. Something like
-		// `purpose: 'build' || 'test'` is a good example.
-		//
-		// Default:    {}
-		//
-		// Map entries:
-		// Max length: 4096
-		Tags map[string]string `json:"tags,omitempty"`
+		// Subset of a task definition
+		Task Task2 `json:"task,omitempty"`
 
 		// Message version
 		//
@@ -215,17 +286,8 @@ type (
 		// A representation of **task status** as known by the queue
 		Status TaskStatusStructure `json:"status"`
 
-		// Arbitrary key-value tags (only strings limited to 4k). These can be used
-		// to attach informal metadata to a task. Use this for informal tags that
-		// tasks can be classified by. You can also think of strings here as
-		// candidates for formal metadata. Something like
-		// `purpose: 'build' || 'test'` is a good example.
-		//
-		// Default:    {}
-		//
-		// Map entries:
-		// Max length: 4096
-		Tags map[string]string `json:"tags,omitempty"`
+		// Subset of a task definition
+		Task Task `json:"task,omitempty"`
 
 		// Message version
 		//
@@ -247,17 +309,8 @@ type (
 		// A representation of **task status** as known by the queue
 		Status TaskStatusStructure `json:"status"`
 
-		// Arbitrary key-value tags (only strings limited to 4k). These can be used
-		// to attach informal metadata to a task. Use this for informal tags that
-		// tasks can be classified by. You can also think of strings here as
-		// candidates for formal metadata. Something like
-		// `purpose: 'build' || 'test'` is a good example.
-		//
-		// Default:    {}
-		//
-		// Map entries:
-		// Max length: 4096
-		Tags map[string]string `json:"tags,omitempty"`
+		// Subset of a task definition
+		Task Task4 `json:"task,omitempty"`
 
 		// Message version
 		//
@@ -295,17 +348,8 @@ type (
 		// A representation of **task status** as known by the queue
 		Status TaskStatusStructure `json:"status"`
 
-		// Arbitrary key-value tags (only strings limited to 4k). These can be used
-		// to attach informal metadata to a task. Use this for informal tags that
-		// tasks can be classified by. You can also think of strings here as
-		// candidates for formal metadata. Something like
-		// `purpose: 'build' || 'test'` is a good example.
-		//
-		// Default:    {}
-		//
-		// Map entries:
-		// Max length: 4096
-		Tags map[string]string `json:"tags,omitempty"`
+		// Subset of a task definition
+		Task Task3 `json:"task,omitempty"`
 
 		// Message version
 		//
@@ -394,17 +438,8 @@ type (
 		// A representation of **task status** as known by the queue
 		Status TaskStatusStructure `json:"status"`
 
-		// Arbitrary key-value tags (only strings limited to 4k). These can be used
-		// to attach informal metadata to a task. Use this for informal tags that
-		// tasks can be classified by. You can also think of strings here as
-		// candidates for formal metadata. Something like
-		// `purpose: 'build' || 'test'` is a good example.
-		//
-		// Default:    {}
-		//
-		// Map entries:
-		// Max length: 4096
-		Tags map[string]string `json:"tags,omitempty"`
+		// Subset of a task definition
+		Task Task1 `json:"task,omitempty"`
 
 		// Message version
 		//

--- a/clients/client-go/tcqueueevents/types.go
+++ b/clients/client-go/tcqueueevents/types.go
@@ -175,6 +175,18 @@ type (
 		// A representation of **task status** as known by the queue
 		Status TaskStatusStructure `json:"status"`
 
+		// Arbitrary key-value tags (only strings limited to 4k). These can be used
+		// to attach informal metadata to a task. Use this for informal tags that
+		// tasks can be classified by. You can also think of strings here as
+		// candidates for formal metadata. Something like
+		// `purpose: 'build' || 'test'` is a good example.
+		//
+		// Default:    {}
+		//
+		// Map entries:
+		// Max length: 4096
+		Tags map[string]string `json:"tags,omitempty"`
+
 		// Message version
 		//
 		// Possible values:
@@ -203,6 +215,18 @@ type (
 		// A representation of **task status** as known by the queue
 		Status TaskStatusStructure `json:"status"`
 
+		// Arbitrary key-value tags (only strings limited to 4k). These can be used
+		// to attach informal metadata to a task. Use this for informal tags that
+		// tasks can be classified by. You can also think of strings here as
+		// candidates for formal metadata. Something like
+		// `purpose: 'build' || 'test'` is a good example.
+		//
+		// Default:    {}
+		//
+		// Map entries:
+		// Max length: 4096
+		Tags map[string]string `json:"tags,omitempty"`
+
 		// Message version
 		//
 		// Possible values:
@@ -222,6 +246,18 @@ type (
 
 		// A representation of **task status** as known by the queue
 		Status TaskStatusStructure `json:"status"`
+
+		// Arbitrary key-value tags (only strings limited to 4k). These can be used
+		// to attach informal metadata to a task. Use this for informal tags that
+		// tasks can be classified by. You can also think of strings here as
+		// candidates for formal metadata. Something like
+		// `purpose: 'build' || 'test'` is a good example.
+		//
+		// Default:    {}
+		//
+		// Map entries:
+		// Max length: 4096
+		Tags map[string]string `json:"tags,omitempty"`
 
 		// Message version
 		//
@@ -258,6 +294,18 @@ type (
 
 		// A representation of **task status** as known by the queue
 		Status TaskStatusStructure `json:"status"`
+
+		// Arbitrary key-value tags (only strings limited to 4k). These can be used
+		// to attach informal metadata to a task. Use this for informal tags that
+		// tasks can be classified by. You can also think of strings here as
+		// candidates for formal metadata. Something like
+		// `purpose: 'build' || 'test'` is a good example.
+		//
+		// Default:    {}
+		//
+		// Map entries:
+		// Max length: 4096
+		Tags map[string]string `json:"tags,omitempty"`
 
 		// Message version
 		//
@@ -345,6 +393,18 @@ type (
 
 		// A representation of **task status** as known by the queue
 		Status TaskStatusStructure `json:"status"`
+
+		// Arbitrary key-value tags (only strings limited to 4k). These can be used
+		// to attach informal metadata to a task. Use this for informal tags that
+		// tasks can be classified by. You can also think of strings here as
+		// candidates for formal metadata. Something like
+		// `purpose: 'build' || 'test'` is a good example.
+		//
+		// Default:    {}
+		//
+		// Map entries:
+		// Max length: 4096
+		Tags map[string]string `json:"tags,omitempty"`
 
 		// Message version
 		//

--- a/clients/client-go/tcqueueevents/types.go
+++ b/clients/client-go/tcqueueevents/types.go
@@ -179,70 +179,6 @@ type (
 		Tags map[string]string `json:"tags"`
 	}
 
-	// Subset of a task definition
-	Task1 struct {
-
-		// Arbitrary key-value tags (only strings limited to 4k). These can be used
-		// to attach informal metadata to a task. Use this for informal tags that
-		// tasks can be classified by. You can also think of strings here as
-		// candidates for formal metadata. Something like
-		// `purpose: 'build' || 'test'` is a good example.
-		//
-		// Default:    {}
-		//
-		// Map entries:
-		// Max length: 4096
-		Tags map[string]string `json:"tags"`
-	}
-
-	// Subset of a task definition
-	Task2 struct {
-
-		// Arbitrary key-value tags (only strings limited to 4k). These can be used
-		// to attach informal metadata to a task. Use this for informal tags that
-		// tasks can be classified by. You can also think of strings here as
-		// candidates for formal metadata. Something like
-		// `purpose: 'build' || 'test'` is a good example.
-		//
-		// Default:    {}
-		//
-		// Map entries:
-		// Max length: 4096
-		Tags map[string]string `json:"tags"`
-	}
-
-	// Subset of a task definition
-	Task3 struct {
-
-		// Arbitrary key-value tags (only strings limited to 4k). These can be used
-		// to attach informal metadata to a task. Use this for informal tags that
-		// tasks can be classified by. You can also think of strings here as
-		// candidates for formal metadata. Something like
-		// `purpose: 'build' || 'test'` is a good example.
-		//
-		// Default:    {}
-		//
-		// Map entries:
-		// Max length: 4096
-		Tags map[string]string `json:"tags"`
-	}
-
-	// Subset of a task definition
-	Task4 struct {
-
-		// Arbitrary key-value tags (only strings limited to 4k). These can be used
-		// to attach informal metadata to a task. Use this for informal tags that
-		// tasks can be classified by. You can also think of strings here as
-		// candidates for formal metadata. Something like
-		// `purpose: 'build' || 'test'` is a good example.
-		//
-		// Default:    {}
-		//
-		// Map entries:
-		// Max length: 4096
-		Tags map[string]string `json:"tags"`
-	}
-
 	// Message reporting that a task has complete successfully.
 	TaskCompletedMessage struct {
 
@@ -255,8 +191,11 @@ type (
 		// A representation of **task status** as known by the queue
 		Status TaskStatusStructure `json:"status"`
 
-		// Subset of a task definition
-		Task Task2 `json:"task,omitempty"`
+		// Subset of a task definition containing values that are useful for determining
+		// whether a message is interesting to the receiver. Where the full task
+		// definition is required, the receiver should call queue.task to download that
+		// definition.
+		Task Var `json:"task,omitempty"`
 
 		// Message version
 		//
@@ -286,8 +225,11 @@ type (
 		// A representation of **task status** as known by the queue
 		Status TaskStatusStructure `json:"status"`
 
-		// Subset of a task definition
-		Task Task `json:"task,omitempty"`
+		// Subset of a task definition containing values that are useful for determining
+		// whether a message is interesting to the receiver. Where the full task
+		// definition is required, the receiver should call queue.task to download that
+		// definition.
+		Task Var `json:"task,omitempty"`
 
 		// Message version
 		//
@@ -309,8 +251,11 @@ type (
 		// A representation of **task status** as known by the queue
 		Status TaskStatusStructure `json:"status"`
 
-		// Subset of a task definition
-		Task Task4 `json:"task,omitempty"`
+		// Subset of a task definition containing values that are useful for determining
+		// whether a message is interesting to the receiver. Where the full task
+		// definition is required, the receiver should call queue.task to download that
+		// definition.
+		Task Var `json:"task,omitempty"`
 
 		// Message version
 		//
@@ -348,8 +293,11 @@ type (
 		// A representation of **task status** as known by the queue
 		Status TaskStatusStructure `json:"status"`
 
-		// Subset of a task definition
-		Task Task3 `json:"task,omitempty"`
+		// Subset of a task definition containing values that are useful for determining
+		// whether a message is interesting to the receiver. Where the full task
+		// definition is required, the receiver should call queue.task to download that
+		// definition.
+		Task Var `json:"task,omitempty"`
 
 		// Message version
 		//
@@ -439,7 +387,7 @@ type (
 		Status TaskStatusStructure `json:"status"`
 
 		// Subset of a task definition
-		Task Task1 `json:"task,omitempty"`
+		Task Task `json:"task,omitempty"`
 
 		// Message version
 		//
@@ -567,5 +515,24 @@ type (
 		// Min length: 1
 		// Max length: 38
 		WorkerType string `json:"workerType"`
+	}
+
+	// Subset of a task definition containing values that are useful for determining
+	// whether a message is interesting to the receiver. Where the full task
+	// definition is required, the receiver should call queue.task to download that
+	// definition.
+	Var struct {
+
+		// Arbitrary key-value tags (only strings limited to 4k). These can be used
+		// to attach informal metadata to a task. Use this for informal tags that
+		// tasks can be classified by. You can also think of strings here as
+		// candidates for formal metadata. Something like
+		// `purpose: 'build' || 'test'` is a good example.
+		//
+		// Default:    {}
+		//
+		// Map entries:
+		// Max length: 4096
+		Tags map[string]string `json:"tags"`
 	}
 )

--- a/generated/references.json
+++ b/generated/references.json
@@ -2152,6 +2152,9 @@
         "status": {
           "$ref": "task-status.json#"
         },
+        "tags": {
+          "$ref": "task.json#/properties/tags"
+        },
         "version": {
           "description": "Message version",
           "enum": [
@@ -2270,6 +2273,9 @@
         "status": {
           "$ref": "task-status.json#"
         },
+        "tags": {
+          "$ref": "task.json#/properties/tags"
+        },
         "version": {
           "description": "Message version",
           "enum": [
@@ -2348,6 +2354,9 @@
         "status": {
           "$ref": "task-status.json#"
         },
+        "tags": {
+          "$ref": "task.json#/properties/tags"
+        },
         "version": {
           "description": "Message version",
           "enum": [
@@ -2411,6 +2420,9 @@
       "properties": {
         "status": {
           "$ref": "task-status.json#"
+        },
+        "tags": {
+          "$ref": "task.json#/properties/tags"
         },
         "version": {
           "description": "Message version",
@@ -2477,6 +2489,9 @@
         },
         "status": {
           "$ref": "task-status.json#"
+        },
+        "tags": {
+          "$ref": "task.json#/properties/tags"
         },
         "version": {
           "description": "Message version",

--- a/generated/references.json
+++ b/generated/references.json
@@ -2152,8 +2152,18 @@
         "status": {
           "$ref": "task-status.json#"
         },
-        "tags": {
-          "$ref": "task.json#/properties/tags"
+        "task": {
+          "additionalProperties": false,
+          "description": "Subset of a task definition\n",
+          "properties": {
+            "tags": {
+              "$ref": "task.json#/properties/tags"
+            }
+          },
+          "required": [
+            "tags"
+          ],
+          "type": "object"
         },
         "version": {
           "description": "Message version",
@@ -2273,8 +2283,18 @@
         "status": {
           "$ref": "task-status.json#"
         },
-        "tags": {
-          "$ref": "task.json#/properties/tags"
+        "task": {
+          "additionalProperties": false,
+          "description": "Subset of a task definition\n",
+          "properties": {
+            "tags": {
+              "$ref": "task.json#/properties/tags"
+            }
+          },
+          "required": [
+            "tags"
+          ],
+          "type": "object"
         },
         "version": {
           "description": "Message version",
@@ -2354,8 +2374,18 @@
         "status": {
           "$ref": "task-status.json#"
         },
-        "tags": {
-          "$ref": "task.json#/properties/tags"
+        "task": {
+          "additionalProperties": false,
+          "description": "Subset of a task definition\n",
+          "properties": {
+            "tags": {
+              "$ref": "task.json#/properties/tags"
+            }
+          },
+          "required": [
+            "tags"
+          ],
+          "type": "object"
         },
         "version": {
           "description": "Message version",
@@ -2421,8 +2451,18 @@
         "status": {
           "$ref": "task-status.json#"
         },
-        "tags": {
-          "$ref": "task.json#/properties/tags"
+        "task": {
+          "additionalProperties": false,
+          "description": "Subset of a task definition\n",
+          "properties": {
+            "tags": {
+              "$ref": "task.json#/properties/tags"
+            }
+          },
+          "required": [
+            "tags"
+          ],
+          "type": "object"
         },
         "version": {
           "description": "Message version",
@@ -2490,8 +2530,18 @@
         "status": {
           "$ref": "task-status.json#"
         },
-        "tags": {
-          "$ref": "task.json#/properties/tags"
+        "task": {
+          "additionalProperties": false,
+          "description": "Subset of a task definition\n",
+          "properties": {
+            "tags": {
+              "$ref": "task.json#/properties/tags"
+            }
+          },
+          "required": [
+            "tags"
+          ],
+          "type": "object"
         },
         "version": {
           "description": "Message version",

--- a/generated/references.json
+++ b/generated/references.json
@@ -2138,6 +2138,25 @@
   },
   {
     "content": {
+      "$id": "/schemas/queue/v1/task-pulse-definition.json#",
+      "$schema": "/schemas/common/metaschema.json#",
+      "additionalProperties": false,
+      "description": "Subset of a task definition containing values that are useful for determining\nwhether a message is interesting to the receiver. Where the full task\ndefinition is required, the receiver should call queue.task to download that\ndefinition.\n",
+      "properties": {
+        "tags": {
+          "$ref": "task.json#/properties/tags"
+        }
+      },
+      "required": [
+        "tags"
+      ],
+      "title": "Task Definition Structure for Pulse Messages",
+      "type": "object"
+    },
+    "filename": "schemas/queue/v1/task-pulse-definition.json"
+  },
+  {
+    "content": {
       "$id": "/schemas/queue/v1/task-pending-message.json#",
       "$schema": "/schemas/common/metaschema.json#",
       "additionalProperties": false,
@@ -2284,17 +2303,7 @@
           "$ref": "task-status.json#"
         },
         "task": {
-          "additionalProperties": false,
-          "description": "Subset of a task definition\n",
-          "properties": {
-            "tags": {
-              "$ref": "task.json#/properties/tags"
-            }
-          },
-          "required": [
-            "tags"
-          ],
-          "type": "object"
+          "$ref": "task-pulse-definition.json#"
         },
         "version": {
           "description": "Message version",
@@ -2375,17 +2384,7 @@
           "$ref": "task-status.json#"
         },
         "task": {
-          "additionalProperties": false,
-          "description": "Subset of a task definition\n",
-          "properties": {
-            "tags": {
-              "$ref": "task.json#/properties/tags"
-            }
-          },
-          "required": [
-            "tags"
-          ],
-          "type": "object"
+          "$ref": "task-pulse-definition.json#"
         },
         "version": {
           "description": "Message version",
@@ -2452,17 +2451,7 @@
           "$ref": "task-status.json#"
         },
         "task": {
-          "additionalProperties": false,
-          "description": "Subset of a task definition\n",
-          "properties": {
-            "tags": {
-              "$ref": "task.json#/properties/tags"
-            }
-          },
-          "required": [
-            "tags"
-          ],
-          "type": "object"
+          "$ref": "task-pulse-definition.json#"
         },
         "version": {
           "description": "Message version",
@@ -2531,17 +2520,7 @@
           "$ref": "task-status.json#"
         },
         "task": {
-          "additionalProperties": false,
-          "description": "Subset of a task definition\n",
-          "properties": {
-            "tags": {
-              "$ref": "task.json#/properties/tags"
-            }
-          },
-          "required": [
-            "tags"
-          ],
-          "type": "object"
+          "$ref": "task-pulse-definition.json#"
         },
         "version": {
           "description": "Message version",

--- a/services/queue/schemas/v1/task-completed-message.yml
+++ b/services/queue/schemas/v1/task-completed-message.yml
@@ -6,6 +6,7 @@ type:         object
 properties:
   version:    {$const: message-version}
   status:     {$ref: 'task-status.json#'}
+  tags: {$ref: "task.json#/properties/tags"}
   runId:
     description: |
       Id of the run that completed the task

--- a/services/queue/schemas/v1/task-completed-message.yml
+++ b/services/queue/schemas/v1/task-completed-message.yml
@@ -6,15 +6,7 @@ type:         object
 properties:
   version:    {$const: message-version}
   status:     {$ref: 'task-status.json#'}
-  task:
-    description: |
-      Subset of a task definition
-    type:               object
-    properties:
-      tags:     {$ref: "task.json#/properties/tags"}
-    additionalProperties: false
-    required:
-      - tags
+  task: {$ref: 'task-pulse-definition.json#'}
   runId:
     description: |
       Id of the run that completed the task

--- a/services/queue/schemas/v1/task-completed-message.yml
+++ b/services/queue/schemas/v1/task-completed-message.yml
@@ -6,7 +6,15 @@ type:         object
 properties:
   version:    {$const: message-version}
   status:     {$ref: 'task-status.json#'}
-  tags: {$ref: "task.json#/properties/tags"}
+  task:
+    description: |
+      Subset of a task definition
+    type:               object
+    properties:
+      tags:     {$ref: "task.json#/properties/tags"}
+    additionalProperties: false
+    required:
+      - tags
   runId:
     description: |
       Id of the run that completed the task

--- a/services/queue/schemas/v1/task-defined-message.yml
+++ b/services/queue/schemas/v1/task-defined-message.yml
@@ -7,7 +7,15 @@ type:         object
 properties:
   version:    {$const: message-version}
   status:     {$ref: 'task-status.json#'}
-  tags: {$ref: "task.json#/properties/tags"}
+  task:
+    description: |
+      Subset of a task definition
+    type:               object
+    properties:
+      tags:   {$ref: "task.json#/properties/tags"}
+    additionalProperties: false
+    required:
+      - tags
 additionalProperties: false
 required:
   - version

--- a/services/queue/schemas/v1/task-defined-message.yml
+++ b/services/queue/schemas/v1/task-defined-message.yml
@@ -7,15 +7,7 @@ type:         object
 properties:
   version:    {$const: message-version}
   status:     {$ref: 'task-status.json#'}
-  task:
-    description: |
-      Subset of a task definition
-    type:               object
-    properties:
-      tags:   {$ref: "task.json#/properties/tags"}
-    additionalProperties: false
-    required:
-      - tags
+  task: {$ref: 'task-pulse-definition.json#'}
 additionalProperties: false
 required:
   - version

--- a/services/queue/schemas/v1/task-defined-message.yml
+++ b/services/queue/schemas/v1/task-defined-message.yml
@@ -7,6 +7,7 @@ type:         object
 properties:
   version:    {$const: message-version}
   status:     {$ref: 'task-status.json#'}
+  tags: {$ref: "task.json#/properties/tags"}
 additionalProperties: false
 required:
   - version

--- a/services/queue/schemas/v1/task-exception-message.yml
+++ b/services/queue/schemas/v1/task-exception-message.yml
@@ -6,6 +6,7 @@ type:         object
 properties:
   version:    {$const: message-version}
   status:     {$ref: 'task-status.json#'}
+  tags: {$ref: "task.json#/properties/tags"}
   runId:
     description: |
       Id of the last run for the task, not provided if `deadline`

--- a/services/queue/schemas/v1/task-exception-message.yml
+++ b/services/queue/schemas/v1/task-exception-message.yml
@@ -6,15 +6,7 @@ type:         object
 properties:
   version:    {$const: message-version}
   status:     {$ref: 'task-status.json#'}
-  task:
-    description: |
-      Subset of a task definition
-    type:               object
-    properties:
-      tags:   {$ref: "task.json#/properties/tags"}
-    additionalProperties: false
-    required:
-      - tags
+  task: {$ref: 'task-pulse-definition.json#'}
   runId:
     description: |
       Id of the last run for the task, not provided if `deadline`

--- a/services/queue/schemas/v1/task-exception-message.yml
+++ b/services/queue/schemas/v1/task-exception-message.yml
@@ -6,7 +6,15 @@ type:         object
 properties:
   version:    {$const: message-version}
   status:     {$ref: 'task-status.json#'}
-  tags: {$ref: "task.json#/properties/tags"}
+  task:
+    description: |
+      Subset of a task definition
+    type:               object
+    properties:
+      tags:   {$ref: "task.json#/properties/tags"}
+    additionalProperties: false
+    required:
+      - tags
   runId:
     description: |
       Id of the last run for the task, not provided if `deadline`

--- a/services/queue/schemas/v1/task-failed-message.yml
+++ b/services/queue/schemas/v1/task-failed-message.yml
@@ -6,15 +6,7 @@ type:         object
 properties:
   version:    {$const: message-version}
   status:     {$ref: 'task-status.json#'}
-  task:
-    description: |
-      Subset of a task definition
-    type:               object
-    properties:
-      tags:   {$ref: "task.json#/properties/tags"}
-    additionalProperties: false
-    required:
-      - tags
+  task: {$ref: 'task-pulse-definition.json#'}
   runId:
     description: |
       Id of the run that failed.

--- a/services/queue/schemas/v1/task-failed-message.yml
+++ b/services/queue/schemas/v1/task-failed-message.yml
@@ -6,6 +6,7 @@ type:         object
 properties:
   version:    {$const: message-version}
   status:     {$ref: 'task-status.json#'}
+  tags: {$ref: "task.json#/properties/tags"}
   runId:
     description: |
       Id of the run that failed.

--- a/services/queue/schemas/v1/task-failed-message.yml
+++ b/services/queue/schemas/v1/task-failed-message.yml
@@ -6,7 +6,15 @@ type:         object
 properties:
   version:    {$const: message-version}
   status:     {$ref: 'task-status.json#'}
-  tags: {$ref: "task.json#/properties/tags"}
+  task:
+    description: |
+      Subset of a task definition
+    type:               object
+    properties:
+      tags:   {$ref: "task.json#/properties/tags"}
+    additionalProperties: false
+    required:
+      - tags
   runId:
     description: |
       Id of the run that failed.

--- a/services/queue/schemas/v1/task-pending-message.yml
+++ b/services/queue/schemas/v1/task-pending-message.yml
@@ -6,6 +6,7 @@ type:         object
 properties:
   version:    {$const: message-version}
   status:     {$ref: 'task-status.json#'}
+  tags: {$ref: "task.json#/properties/tags"}
   runId:
     description: |
       Id of run that became pending, `run-id`s always starts from 0

--- a/services/queue/schemas/v1/task-pending-message.yml
+++ b/services/queue/schemas/v1/task-pending-message.yml
@@ -6,7 +6,15 @@ type:         object
 properties:
   version:    {$const: message-version}
   status:     {$ref: 'task-status.json#'}
-  tags: {$ref: "task.json#/properties/tags"}
+  task:
+    description: |
+      Subset of a task definition
+    type:               object
+    properties:
+      tags:   {$ref: "task.json#/properties/tags"}
+    additionalProperties: false
+    required:
+      - tags
   runId:
     description: |
       Id of run that became pending, `run-id`s always starts from 0

--- a/services/queue/schemas/v1/task-pulse-definition.yml
+++ b/services/queue/schemas/v1/task-pulse-definition.yml
@@ -1,0 +1,14 @@
+$schema: "/schemas/common/metaschema.json#"
+title:              "Task Definition Structure for Pulse Messages"
+description: |
+  Subset of a task definition containing values that are useful for determining
+  whether a message is interesting to the receiver. Where the full task
+  definition is required, the receiver should call queue.task to download that
+  definition.
+type:               object
+properties:
+  tags:     {$ref: "task.json#/properties/tags"}
+additionalProperties: false
+required:
+  - tags
+

--- a/services/queue/src/api.js
+++ b/services/queue/src/api.js
@@ -723,7 +723,9 @@ builder.declare({
 
   // Construct task status, as we'll return this many times
   let status = task.status();
-  let tags = task.tags;
+  let taskPulseContents = {
+    tags: task.tags,
+  };
 
   // If first run isn't unscheduled or pending, all message must have been
   // published before, this can happen if we came from the catch-branch
@@ -735,7 +737,7 @@ builder.declare({
 
   // Publish task-defined message, we want this arriving before the
   // task-pending message, so we have to await publication here
-  await this.publisher.taskDefined({status, tags}, task.routes);
+  await this.publisher.taskDefined({status, task: taskPulseContents}, task.routes);
   this.monitor.log.taskDefined({taskId});
 
   // If first run is pending we publish messages about this
@@ -745,7 +747,7 @@ builder.declare({
       this.queueService.putPendingMessage(task, 0),
 
       // Put message in appropriate azure queue, and publish message to pulse
-      this.publisher.taskPending({status, tags, runId: 0}, task.routes),
+      this.publisher.taskPending({status, task: taskPulseContents, runId: 0}, task.routes),
     ]);
     this.monitor.log.taskPending({taskId, runId: 0});
   }
@@ -904,7 +906,9 @@ builder.declare({
 
   // Construct task status
   let status = task.status();
-  let tags = task.tags;
+  let taskPulseContents = {
+    tags: task.tags,
+  };
 
   // If runs are present, then we don't need to publish messages as this must
   // have happened already...
@@ -914,7 +918,7 @@ builder.declare({
   }
 
   // Publish task-defined message
-  await this.publisher.taskDefined({status, tags}, task.routes);
+  await this.publisher.taskDefined({status, task: taskPulseContents}, task.routes);
   this.monitor.log.taskDefined({taskId});
 
   // Reply
@@ -1752,13 +1756,15 @@ let resolveTask = async function(req, res, taskId, runId, target) {
 
   // Construct status object
   let status = task.status();
-  let tags = task.tags;
+  let taskPulseContents = {
+    tags: task.tags,
+  };
   // Post message about task resolution
   if (target === 'completed') {
     await this.publisher.taskCompleted({
       status,
       runId,
-      tags,
+      task: taskPulseContents,
       workerGroup: run.workerGroup,
       workerId: run.workerId,
     }, task.routes);
@@ -1767,7 +1773,7 @@ let resolveTask = async function(req, res, taskId, runId, target) {
     await this.publisher.taskFailed({
       status,
       runId,
-      tags,
+      task: taskPulseContents,
       workerGroup: run.workerGroup,
       workerId: run.workerId,
     }, task.routes);
@@ -1958,7 +1964,9 @@ builder.declare({
   }
 
   let status = task.status();
-  let tags = task.tags;
+  let taskPulseContents = {
+    tags: task.tags,
+  };
 
   // If a newRun was created and it is a retry with state pending then we better
   // publish messages about it. And if we're not retrying the task, because then
@@ -1974,7 +1982,7 @@ builder.declare({
       this.queueService.putPendingMessage(task, runId + 1),
       this.publisher.taskPending({
         status,
-        tags,
+        task: taskPulseContents,
         runId: runId + 1,
       }, task.routes),
     ]);
@@ -1992,7 +2000,7 @@ builder.declare({
     await this.publisher.taskException({
       status,
       runId,
-      tags,
+      task: taskPulseContents,
       workerGroup: run.workerGroup,
       workerId: run.workerId,
     }, task.routes);

--- a/services/queue/test/createtask_test.js
+++ b/services/queue/test/createtask_test.js
@@ -78,10 +78,14 @@ helper.secrets.mockSuite(testing.suiteName(), ['taskcluster', 'aws', 'azure'], f
     });
 
     debug('### Wait for defined message');
-    helper.assertPulseMessage('task-defined', m => _.isEqual(m.payload.status, r1.status));
+    helper.assertPulseMessage('task-defined', m => (
+      _.isEqual(m.payload.status, r1.status) &&
+      _.isEqual(m.payload.task.tags, taskDef.tags)));
 
     debug('### Wait for pending message');
-    helper.assertPulseMessage('task-pending', m => _.isEqual(m.payload.status, r1.status));
+    helper.assertPulseMessage('task-pending', m => (
+      _.isEqual(m.payload.status, r1.status) &&
+      _.isEqual(m.payload.task.tags, taskDef.tags)));
 
     debug('### Get task status');
     const r2 = await helper.queue.status(taskId);

--- a/services/queue/test/resolvetask_test.js
+++ b/services/queue/test/resolvetask_test.js
@@ -61,7 +61,9 @@ helper.secrets.mockSuite(testing.suiteName(), ['taskcluster', 'aws', 'azure'], f
       'assume:worker-id:my-worker-group-extended-extended/my-worker-extended-extended',
     );
     await helper.queue.reportCompleted(taskId, 0);
-    helper.assertPulseMessage('task-completed', m => m.payload.status.runs[0].state === 'completed');
+    helper.assertPulseMessage('task-completed', m => (
+      m.payload.status.runs[0].state === 'completed' &&
+      _.isEqual(m.payload.task.tags, taskDef.tags)));
     helper.clearPulseMessages();
 
     assert.deepEqual(monitorManager.messages.find(({Type}) => Type === 'task-completed'), {
@@ -74,7 +76,9 @@ helper.secrets.mockSuite(testing.suiteName(), ['taskcluster', 'aws', 'azure'], f
     debug('### Reporting task completed (again)');
     await helper.queue.reportCompleted(taskId, 0);
     // idempotent, but sends the message again..
-    helper.assertPulseMessage('task-completed', m => m.payload.status.runs[0].state === 'completed');
+    helper.assertPulseMessage('task-completed', m => (
+      m.payload.status.runs[0].state === 'completed' &&
+      _.isEqual(m.payload.task.tags, taskDef.tags)));
     helper.clearPulseMessages();
 
     debug('### Reporting task completed (using temp creds)');
@@ -104,7 +108,9 @@ helper.secrets.mockSuite(testing.suiteName(), ['taskcluster', 'aws', 'azure'], f
       'assume:worker-id:my-worker-group-extended-extended/my-worker-extended-extended',
     );
     await helper.queue.reportFailed(taskId, 0);
-    helper.assertPulseMessage('task-failed', m => m.payload.status.runs[0].state === 'failed');
+    helper.assertPulseMessage('task-failed', m => (
+      m.payload.status.runs[0].state === 'failed' &&
+      _.isEqual(m.payload.task.tags, taskDef.tags)));
     helper.clearPulseMessages();
 
     assert.deepEqual(monitorManager.messages.find(({Type}) => Type === 'task-failed'), {
@@ -116,7 +122,9 @@ helper.secrets.mockSuite(testing.suiteName(), ['taskcluster', 'aws', 'azure'], f
 
     debug('### Reporting task failed (again)');
     await helper.queue.reportFailed(taskId, 0);
-    helper.assertPulseMessage('task-failed', m => m.payload.status.runs[0].state === 'failed');
+    helper.assertPulseMessage('task-failed', m => (
+      m.payload.status.runs[0].state === 'failed' &&
+      _.isEqual(m.payload.task.tags, taskDef.tags)));
     helper.clearPulseMessages();
 
     debug('### Reporting task failed (using temp creds)');
@@ -149,7 +157,8 @@ helper.secrets.mockSuite(testing.suiteName(), ['taskcluster', 'aws', 'azure'], f
     });
     helper.assertPulseMessage('task-exception', m => (
       m.payload.status.runs[0].state === 'exception' &&
-      m.payload.status.runs[0].reasonResolved === 'malformed-payload'));
+      m.payload.status.runs[0].reasonResolved === 'malformed-payload' &&
+      _.isEqual(m.payload.task.tags, taskDef.tags)));
     helper.clearPulseMessages();
 
     assert.deepEqual(monitorManager.messages.find(({Type}) => Type === 'task-exception'), {
@@ -165,7 +174,8 @@ helper.secrets.mockSuite(testing.suiteName(), ['taskcluster', 'aws', 'azure'], f
     });
     helper.assertPulseMessage('task-exception', m => (
       m.payload.status.runs[0].state === 'exception' &&
-      m.payload.status.runs[0].reasonResolved === 'malformed-payload'));
+      m.payload.status.runs[0].reasonResolved === 'malformed-payload' &&
+      _.isEqual(m.payload.task.tags, taskDef.tags)));
     helper.clearPulseMessages();
 
     debug('### Check status of task');


### PR DESCRIPTION
Addition of tags to these pulse messages will allow listeners to better
classify the tasks that are appearing, especially after we add ~3 fields.

Bugzilla Bug: [1530644](https://bugzilla.mozilla.org/show_bug.cgi?id=1530644)
