### PR TITLE
Fix 'Go to Line' functionality when 'Follow Log' is enabled

### DIFF
--- a/ui/src/components/Log/index.jsx
+++ b/ui/src/components/Log/index.jsx
@@ -190,7 +190,7 @@ export default class Log extends Component {
   };
 
   handleLineNumberChange = lineNumber => {
-    this.setState({ lineNumber });
+    this.setState({ lineNumber, follow: null });
   };
 
   handleScroll = ({ scrollTop, scrollHeight, clientHeight }) => {


### PR DESCRIPTION
Fixes https://github.com/taskcluster/taskcluster/issues/908

Resets `follow` in `Log` component's state when `lineNumber` is updated from the `Go to Line` dialog.