### PR TITLE
[Bug 1547077] Use new logo on notify emails

### DIFF
--- a/changelog/bug-1547077.md
+++ b/changelog/bug-1547077.md
@@ -1,0 +1,4 @@
+level: patch
+reference:  bug 1547077
+---
+Emails now use the modern Taskcluster logo

--- a/services/notify/src/templates/css/common.css
+++ b/services/notify/src/templates/css/common.css
@@ -233,3 +233,8 @@ hr {
     background-color: #34495e !important;
     border-color: #34495e !important; } }
 
+
+.logo {
+  margin-top: 5px;
+  margin-bottom: -5px;
+}

--- a/services/notify/src/templates/fullscreen/html.pug
+++ b/services/notify/src/templates/fullscreen/html.pug
@@ -55,7 +55,7 @@ html(lang="en")
         td.container
           .content
             h1
-              img.logo(src="https://docs.taskcluster.net/assets/taskcluster-180.png", height="32px")
+              img.logo(src="https://media.taskcluster.net/logo/logo-96x120.png", height="32px")
               | &nbsp;Taskcluster
             table.main
               tr

--- a/services/notify/src/templates/simple/html.pug
+++ b/services/notify/src/templates/simple/html.pug
@@ -55,7 +55,7 @@ html(lang="en")
         td.container
           .content
             h1
-              img.logo(src="https://docs.taskcluster.net/assets/taskcluster-180.png", height="32px")
+              img.logo(src="https://media.taskcluster.net/logo/logo-96x120.png", height="32px")
               | &nbsp;Taskcluster
             table.main
               tr


### PR DESCRIPTION

Bugzilla Bug: [1547077](https://bugzilla.mozilla.org/show_bug.cgi?id=1547077)

![email_screenshot](https://user-images.githubusercontent.com/127521/60828513-67ff5180-a167-11e9-9308-590b52c271a7.png)
