### PR TITLE
Refactor StyleGuideRenderer to be a functional component

### DIFF
--- a/ui/src/styleguide/StyleGuideRenderer.jsx
+++ b/ui/src/styleguide/StyleGuideRenderer.jsx
@@ -1,15 +1,12 @@
-/* eslint-disable import/no-extraneous-dependencies */
-import React, { Component, Fragment } from 'react';
+import React, { Fragment } from 'react';
 import StyleGuide from 'react-styleguidist/lib/rsg-components/StyleGuide/StyleGuideRenderer';
 import FontStager from '../components/FontStager';
 
-export default class StyleGuideRenderer extends Component {
-  render() {
-    return (
-      <Fragment>
-        <FontStager />
-        <StyleGuide {...this.props} />
-      </Fragment>
-    );
-  }
-}
+const StyleGuideRenderer = props => (
+  <Fragment>
+    <FontStager />
+    <StyleGuide {...props} />
+  </Fragment>
+);
+
+export default StyleGuideRenderer;


### PR DESCRIPTION
This is a minor refactoring PR simplifying `ui/src/styleguide/StyleGuideRenderer.jsx`