### PR TITLE
Remove content with broken link

### DIFF
--- a/ui/docs/tutorial/hack-tc.md
+++ b/ui/docs/tutorial/hack-tc.md
@@ -8,6 +8,3 @@ followup:
 Hacking on Taskcluster is really easy. Head over to the [Taskcluster GitHub
 page](https://github.com/taskcluster) and dive right in. Fork a project you
 want to contribute to and feel free to make pull requests.
-
-The code base uses ES2015+ syntax and features like Promises and Async Functions.
-Jump over to [async JavaScript](async-javascript) if you need to learn more.


### PR DESCRIPTION
The `async-javascript` tutorial is not present in the docs and I wasn't sure what to replace it with. So, I removed the content with the broken link.

Should we instead redirect to another link (for instance, [MDN docs on async functions](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/async_function))? :thinking: 