### PR TITLE
Remove reference to tools.taskcluster.net in APIs tutorial doc

### DIFF
--- a/test/meta_test.js
+++ b/test/meta_test.js
@@ -183,7 +183,6 @@ suite('Repo Meta Tests', function () {
       'ui/docs/reference/integrations/github/taskcluster-yml-v0.md',
       'ui/docs/reference/integrations/github/taskcluster-yml-v1.md',
       'ui/docs/reference/platform/queue/worker-hierarchy.md',
-      'ui/docs/tutorial/apis.md',
       'ui/docs/tutorial/authenticate.md',
       'ui/docs/tutorial/create-task-via-api.md',
       'ui/docs/tutorial/debug-task.md',

--- a/ui/docs/tutorial/apis.md
+++ b/ui/docs/tutorial/apis.md
@@ -9,11 +9,6 @@ followup:
 
 This section shows you how to access Taskcluster APIs programmatically.  The
 examples use JavaScript (ES6) using the JavaScript [taskcluster
-client](https://github.com/taskcluster/taskcluster-client) but apply to [other
+client](https://github.com/taskcluster/taskcluster/tree/master/clients/client) but apply to [other
 supported
 languages](/docs/manual/using/integration/libraries).
-
-Note: the graphical Taskcluster tools on `tools.taskcluster.net` are all
-written in client-side JavaScript using
-[taskcluster-client-web](https://github.com/taskcluster/taskcluster-client-web),
-the client library designed for use in browser frontends.


### PR DESCRIPTION
Bugzilla Bug: [1562752](https://bugzilla.mozilla.org/show_bug.cgi?id=1562752)

Also updates the content to reflect changes to the codebases.