### PR TITLE
Bug 1563342 - Provide providerId in instance attributes

### DIFF
--- a/services/worker-manager/src/providers/google.js
+++ b/services/worker-manager/src/providers/google.js
@@ -2,7 +2,6 @@ const slugid = require('slugid');
 const _ = require('lodash');
 const fs = require('fs');
 const taskcluster = require('taskcluster-client');
-const libUrls = require('taskcluster-lib-urls');
 const uuid = require('uuid');
 const {google} = require('googleapis');
 const {ApiError, Provider} = require('./provider');
@@ -322,8 +321,8 @@ class GoogleProvider extends Provider {
                   key: 'taskcluster',
                   value: JSON.stringify({
                     workerPoolId,
+                    providerId: this.providerId,
                     workerGroup: this.providerId,
-                    credentialUrl: libUrls.api(this.rootUrl, 'worker-manager', 'v1', `credentials/google/${workerPoolId}`),
                     rootUrl: this.rootUrl,
                     userData: workerPool.config.userData,
                   }),

--- a/ui/docs/reference/core/worker-manager/google.md
+++ b/ui/docs/reference/core/worker-manager/google.md
@@ -53,3 +53,13 @@ See the note above about using a dedicated project.
 Worker-pool configuration for a worker-pool using this provider type must match the following schema.
 
 <SchemaTable schema="/schemas/worker-manager/v1/config-google.json" />
+
+## Worker Interaction
+
+The provider starts workers with an instance attribute named `taskcluster` containing a JSON object with the following properties:
+
+* `workerPoolId` -- worker pool for this worker
+* `providerId` -- provider ID that started the worker
+* `workerGroup` -- the worker's workerGroup (currently equal to the providerId, but do not depend on this)
+* `rootUrl` -- root URL for the Taskcluster deployment
+* `userData` -- userData from the worker pool configuration


### PR DESCRIPTION
This value is required to call registerWorker, since by that time the
worker pool's primary provider might have changed.

Note that this also drops the unused credentialsUrl.

Bugzilla Bug: [1563342](https://bugzilla.mozilla.org/show_bug.cgi?id=1563342)
