### PR TITLE
Force redirect from netlify domain to Heroku app

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -18,6 +18,7 @@
   from = "https://taskcluster-web.netlify.com/*"
   to = "https://taskcluster-ui.herokuapp.com/:splat"
   status = 301
+  force = true
 
 # Rule for Single Page Applications (docs)
 [[redirects]]


### PR DESCRIPTION
From reading the documentation, I noticed that redirects are not applied if the file with the path mentioned in `from` exists. To override it, the `force` option has to be set to `true`.

Fixes #969