### PR TITLE
Deployment docs: link to tree, not generated site

### DIFF
--- a/deployment-docs/clouds.md
+++ b/deployment-docs/clouds.md
@@ -7,7 +7,7 @@ Services' data is stored in Azure Table Storage, so Azure credentials will be re
 
 Taskcluster can dynamically provision workers in a variety of clouds.
 You will need appropriate credentials for any clouds you intend to use for workers.
-See the [worker-manager documentation](https://docs.taskcluster.net/docs/reference/core/worker-manager) for details on how these credentials are configured.
+See the [worker-manager documentation](https://github.com/taskcluster/taskcluster/blob/master/ui/docs/reference/core/worker-manager/google.md) for details on how these credentials are configured.
 
 The Terraform module is designed to namespace all resources it uses with a `prefix`, allowing multiple deployments of Taskcluster to share the same cloud accounts so long as the prefixes are different.
 We use this internally to deploy multiple development deployments.


### PR DESCRIPTION
Apparently docs.tc.n doesn't always update on time. This changes the link to the thing that does always update.

<!-- If this is related to a Bugzilla bug, please begin your title with [Bug XXXXX]
     and update this link.

     Is this change user-visible?  If so, please include a file in changelog/ describing it.
     See https://github.com/taskcluster/taskcluster/blob/master/dev-docs/best-practices/changelog.md
-->

Bugzilla Bug: [XXXXX](https://bugzilla.mozilla.org/show_bug.cgi?id=XXXXX)
