### PR TITLE
Bug 1558519 - create a github release as part of yarn release

### DIFF
--- a/clients/client-shell/README.md
+++ b/clients/client-shell/README.md
@@ -20,20 +20,8 @@ To install, download the `taskcluster` binary for the latest release your
 platform, and run it!  On POSIX platforms you will need to `chmod +x` of
 course.
 
-<!--
-These no longer work since the artifact has expired
-
- * [darwin-amd64](https://index.taskcluster.net/v1/task/project.taskcluster.taskcluster-cli.latest/artifacts/public/darwin-amd64/taskcluster)
- * [freebsd-386](https://index.taskcluster.net/v1/task/project.taskcluster.taskcluster-cli.latest/artifacts/public/freebsd-386/taskcluster)
- * [freebsd-amd64](https://index.taskcluster.net/v1/task/project.taskcluster.taskcluster-cli.latest/artifacts/public/freebsd-amd64/taskcluster)
- * [linux-386](https://index.taskcluster.net/v1/task/project.taskcluster.taskcluster-cli.latest/artifacts/public/linux-386/taskcluster)
- * [linux-amd64](https://index.taskcluster.net/v1/task/project.taskcluster.taskcluster-cli.latest/artifacts/public/linux-amd64/taskcluster)
- * [openbsd-amd64](https://index.taskcluster.net/v1/task/project.taskcluster.taskcluster-cli.latest/artifacts/public/openbsd-amd64/taskcluster)
- * [windows-386](https://index.taskcluster.net/v1/task/project.taskcluster.taskcluster-cli.latest/artifacts/public/windows-386/taskcluster.exe)
- * [windows-amd64](https://index.taskcluster.net/v1/task/project.taskcluster.taskcluster-cli.latest/artifacts/public/windows-amd64/taskcluster.exe)
--->
- * [linux-amd64](https://github.com/taskcluster/taskcluster-cli/releases/download/v0.9.0/taskcluster-linux-amd64)
- * [darwin-amd64](https://github.com/taskcluster/taskcluster-cli/releases/download/v0.9.0/taskcluster-darwin-amd64)
+ * [linux-amd64](https://github.com/taskcluster/taskcluster/releases/download/v14.3.19/taskcluster-linux-amd64)
+ * [darwin-amd64](https://github.com/taskcluster/taskcluster/releases/download/v14.3.19/taskcluster-darwin-amd64)
 
 ## Development
 

--- a/infrastructure/builder/src/main.js
+++ b/infrastructure/builder/src/main.js
@@ -26,6 +26,7 @@ program.command('build')
 
 program.command('release')
   .option('--base-dir <base-dir>', 'Base directory for build (fast and big!; default /tmp/taskcluster-builder-build)')
+  .option('--gh-token <gh-token>', 'GitHub access token')
   .option('--dry-run', 'Do not run any tasks, but generate the list of tasks')
   .option('-p, --push', 'Push docker image and git commit + tag (without this, changes are purely local)')
   .action((...options) => {

--- a/infrastructure/builder/src/release/index.js
+++ b/infrastructure/builder/src/release/index.js
@@ -10,6 +10,10 @@ class Release {
   constructor(cmdOptions) {
     this.cmdOptions = cmdOptions;
 
+    if (cmdOptions.push && !cmdOptions.ghToken) {
+      throw new Error('Cannot use --push without --gh-token');
+    }
+
     this.baseDir = cmdOptions['baseDir'] || '/tmp/taskcluster-builder-build';
 
     // The `yarn build` process is a subgraph of the release taskgraph, with some
@@ -33,6 +37,7 @@ class Release {
     generateReleaseTasks({
       tasks,
       cmdOptions: this.cmdOptions,
+      baseDir: this.baseDir,
     });
 
     return tasks;
@@ -66,7 +71,12 @@ class Release {
     console.log(`Release version: ${context['release-version']}`);
     console.log(`Release docker image: ${context['monoimage-docker-image']}`);
     if (!this.cmdOptions.push) {
-      console.log('  NOTE: image and git commit + tag not pushed (use --push)');
+      console.log('NOTE: image and git commit + tag not pushed (use --push)');
+    } else {
+      console.log(`GitHub release: ${context['github-release']}`);
+      console.log('** YOUR NEXT STEPS **');
+      console.log(' * run `npm publish` in clients/client');
+      console.log(' * run `./release.sh --real` in clients/client-py');
     }
   }
 }

--- a/infrastructure/builder/src/release/index.js
+++ b/infrastructure/builder/src/release/index.js
@@ -76,6 +76,7 @@ class Release {
       console.log(`GitHub release: ${context['github-release']}`);
       console.log('** YOUR NEXT STEPS **');
       console.log(' * run `npm publish` in clients/client');
+      console.log(' * run `npm publish` in clients/client-web');
       console.log(' * run `./release.sh --real` in clients/client-py');
     }
   }

--- a/infrastructure/builder/src/release/tasks.js
+++ b/infrastructure/builder/src/release/tasks.js
@@ -115,6 +115,12 @@ module.exports = ({tasks, cmdOptions, baseDir}) => {
         contents.replace(/VersionNumber = .*/, `VersionNumber = "${requirements['release-version']}"`));
       changed.push(shellclient);
 
+      const shellreadme = 'clients/client-shell/cmds/version/version.go';
+      utils.status({message: `Update ${shellreadme}`});
+      await modifyRepoFile(shellreadme, contents =>
+        contents.replace(/download\/v[0-9.]*\/taskcluster-/, `download/v${requirements['release-version']}/taskcluster-"`));
+      changed.push(shellreadme);
+
       // the go client requires the major version number in its import path, so
       // just about every file needs to be edited.  This matches the full package
       // path to avoid false positives, but that might result in missed changes


### PR DESCRIPTION
With this change, `yarn release` now requires a github PAT, and will
fail if `--push` is given without a PAT.

Bugzilla Bug: [1558519](https://bugzilla.mozilla.org/show_bug.cgi?id=1558519)
