### PR TITLE
Add titles for missing docs

### DIFF
--- a/generated/docs-table-of-contents.json
+++ b/generated/docs-table-of-contents.json
@@ -2361,7 +2361,7 @@
                 "name": "logs",
                 "next": {
                   "path": "reference/core/worker-manager/google",
-                  "title": "google"
+                  "title": "Google Provider Type"
                 },
                 "path": "reference/core/worker-manager/logs",
                 "prev": {
@@ -2377,12 +2377,13 @@
                 "children": [
                 ],
                 "data": {
-                  "order": 10
+                  "order": 10,
+                  "title": "Google Provider Type"
                 },
                 "name": "google",
                 "next": {
                   "path": "reference/core/worker-manager/static",
-                  "title": "static"
+                  "title": "Static Provider Type"
                 },
                 "path": "reference/core/worker-manager/google",
                 "prev": {
@@ -2398,7 +2399,8 @@
                 "children": [
                 ],
                 "data": {
-                  "order": 11
+                  "order": 11,
+                  "title": "Static Provider Type"
                 },
                 "name": "static",
                 "next": {
@@ -2408,7 +2410,7 @@
                 "path": "reference/core/worker-manager/static",
                 "prev": {
                   "path": "reference/core/worker-manager/google",
-                  "title": "google"
+                  "title": "Google Provider Type"
                 },
                 "up": {
                   "path": "reference/core/worker-manager/README",
@@ -2430,7 +2432,7 @@
                 "path": "reference/core/worker-manager/worker-interaction",
                 "prev": {
                   "path": "reference/core/worker-manager/static",
-                  "title": "static"
+                  "title": "Static Provider Type"
                 },
                 "up": {
                   "path": "reference/core/worker-manager/README",

--- a/ui/docs/reference/core/worker-manager/google.md
+++ b/ui/docs/reference/core/worker-manager/google.md
@@ -1,5 +1,6 @@
 ---
 order: 10
+title: Google Provider Type
 ---
 import SchemaTable from 'taskcluster-ui/components/SchemaTable'
 

--- a/ui/docs/reference/core/worker-manager/static.md
+++ b/ui/docs/reference/core/worker-manager/static.md
@@ -1,5 +1,6 @@
 ---
 order: 11
+title: Static Provider Type
 ---
 import SchemaTable from 'taskcluster-ui/components/SchemaTable'
 


### PR DESCRIPTION
If this fixes #1056 then we should probably either fail when generating docs with no title, or default to title = name.