### PR TITLE
Fix up handling of titles in the TOC

### DIFF
--- a/deployment-docs/clouds.md
+++ b/deployment-docs/clouds.md
@@ -7,6 +7,7 @@ Services' data is stored in Azure Table Storage, so Azure credentials will be re
 
 Taskcluster can dynamically provision workers in a variety of clouds.
 You will need appropriate credentials for any clouds you intend to use for workers.
+Configuration of these clouds is partly handled as part of deployment (configuring the set of providers, supplying credentials) and partly handled by calls to the REST API (configuring worker pools).
 See the [worker-manager documentation](https://docs.taskcluster.net/docs/reference/core/worker-manager) for details on how these credentials are configured.
 
 The Terraform module is designed to namespace all resources it uses with a `prefix`, allowing multiple deployments of Taskcluster to share the same cloud accounts so long as the prefixes are different.

--- a/generated/docs-table-of-contents.json
+++ b/generated/docs-table-of-contents.json
@@ -820,7 +820,8 @@
                 "children": [
                 ],
                 "data": {
-                  "order": 1000
+                  "order": 1000,
+                  "title": "decision-task"
                 },
                 "name": "decision-task",
                 "next": {
@@ -841,7 +842,8 @@
                 "children": [
                 ],
                 "data": {
-                  "order": 1000
+                  "order": 1000,
+                  "title": "task-logs"
                 },
                 "name": "task-logs",
                 "next": {

--- a/generated/docs-table-of-contents.json
+++ b/generated/docs-table-of-contents.json
@@ -714,7 +714,7 @@
             "name": "env-vars",
             "next": {
               "path": "manual/design/conventions",
-              "title": "conventions"
+              "title": "Conventions"
             },
             "path": "manual/design/env-vars",
             "prev": {
@@ -784,7 +784,7 @@
                     "name": "ui",
                     "next": {
                       "path": "manual/design/conventions/decision-task",
-                      "title": "decision-task"
+                      "title": "Decision Tasks"
                     },
                     "path": "manual/design/conventions/actions/ui",
                     "prev": {
@@ -809,11 +809,11 @@
                 "path": "manual/design/conventions/actions",
                 "prev": {
                   "path": "manual/design/conventions",
-                  "title": "conventions"
+                  "title": "Conventions"
                 },
                 "up": {
                   "path": "manual/design/conventions",
-                  "title": "conventions"
+                  "title": "Conventions"
                 }
               },
               {
@@ -821,12 +821,12 @@
                 ],
                 "data": {
                   "order": 1000,
-                  "title": "decision-task"
+                  "title": "Decision Tasks"
                 },
                 "name": "decision-task",
                 "next": {
                   "path": "manual/design/conventions/task-logs",
-                  "title": "task-logs"
+                  "title": "Task Logs"
                 },
                 "path": "manual/design/conventions/decision-task",
                 "prev": {
@@ -835,7 +835,7 @@
                 },
                 "up": {
                   "path": "manual/design/conventions",
-                  "title": "conventions"
+                  "title": "Conventions"
                 }
               },
               {
@@ -843,7 +843,7 @@
                 ],
                 "data": {
                   "order": 1000,
-                  "title": "task-logs"
+                  "title": "Task Logs"
                 },
                 "name": "task-logs",
                 "next": {
@@ -853,16 +853,17 @@
                 "path": "manual/design/conventions/task-logs",
                 "prev": {
                   "path": "manual/design/conventions/decision-task",
-                  "title": "decision-task"
+                  "title": "Decision Tasks"
                 },
                 "up": {
                   "path": "manual/design/conventions",
-                  "title": "conventions"
+                  "title": "Conventions"
                 }
               }
             ],
             "data": {
-              "order": 1000
+              "order": 1000,
+              "title": "Conventions"
             },
             "name": "conventions",
             "next": {
@@ -1346,7 +1347,7 @@
         "path": "manual/using",
         "prev": {
           "path": "manual/design/conventions/task-logs",
-          "title": "task-logs"
+          "title": "Task Logs"
         },
         "up": {
           "path": "manual",

--- a/infrastructure/builder/src/generate/generators/docs-tocs.js
+++ b/infrastructure/builder/src/generate/generators/docs-tocs.js
@@ -114,9 +114,12 @@ function makeToc({ files, rootPath }) {
             child = {
               name,
               children: [],
-              data: Object.assign(item.data, {
-                order: item.data.order || 1000,
-              }),
+              data: {
+                // apply some defaults..
+                title: name === 'README' ? undefined : name,
+                order: 1000,
+                ...item.data,
+              },
               path: `${rootPath}${path.join('/')}`,
             };
 

--- a/ui/docs/manual/design/conventions/README.md
+++ b/ui/docs/manual/design/conventions/README.md
@@ -1,4 +1,6 @@
-# Conventions
+---
+title: Conventions
+---
 
 The Taskcluster platform is open-ended and can be adapted to a wide variety of situations.
 The developers have established some conventions for use of the platform that support some common continuous-integration and continuous-deployment concepts.

--- a/ui/docs/manual/design/conventions/decision-task.md
+++ b/ui/docs/manual/design/conventions/decision-task.md
@@ -1,3 +1,4 @@
+---
 title: Decision Tasks
 ---
 

--- a/ui/docs/manual/design/conventions/task-logs.md
+++ b/ui/docs/manual/design/conventions/task-logs.md
@@ -1,3 +1,4 @@
+---
 title: Task Logs
 ---
 

--- a/ui/docs/reference/core/worker-manager/README.md
+++ b/ui/docs/reference/core/worker-manager/README.md
@@ -9,9 +9,8 @@ Each provider has a `providerType` indicating the class that implements the prov
 
 The service currently includes providers for:
 
-* Static Workers (`static`)
-* Google Cloud (`google`)
-* Testing (`testing`, only used in the service's unit tests)
+* Static Workers ([`static`](/docs/reference/core/worker-manager/static))
+* Google Cloud ([`google`](/docs/reference/core/worker-manager/google))
 
 ## Worker Pools
 


### PR DESCRIPTION
This uncovered two more "missing" docs files.  With this change, they will at least appear in the TOC, if with an unexpected name.