### PR TITLE
Set default to bottom and follow log while viewing active log

### DIFF
--- a/ui/src/components/Log/index.jsx
+++ b/ui/src/components/Log/index.jsx
@@ -136,7 +136,7 @@ export default class Log extends Component {
 
   state = {
     lineNumber: null,
-    follow: null,
+    follow: true,
   };
 
   getHighlightFromHash() {

--- a/ui/src/components/Log/index.jsx
+++ b/ui/src/components/Log/index.jsx
@@ -194,7 +194,13 @@ export default class Log extends Component {
   };
 
   handleScroll = ({ scrollTop, scrollHeight, clientHeight }) => {
-    if (this.state.follow && scrollHeight - scrollTop !== clientHeight) {
+    if (
+      this.state.follow &&
+      scrollHeight - scrollTop !== clientHeight &&
+      // LazyLog triggers `handleScroll` on initial load.
+      // This will make sure it doesn't set follow to false on log load.
+      scrollTop !== 0
+    ) {
       this.setState({ follow: false });
     }
   };


### PR DESCRIPTION
There is a small different from the old UI is that the old version would not retain `follow log` if we refresh the page. 

I'm not sure this is a correct action, but I think it is because of the component triggers onScroll event and once we refreshing the page and condition `this.state.follow && scrollHeight - scrollTop !== clientHeight` will be `true` even though we not scroll the page yet.

I add a condition to prevent this situation so that the log always starts from the bottom now.

Fixes: #839 
