### PR TITLE
Created confirmation dialog before deleting hook

### DIFF
--- a/ui/src/components/HookForm/index.jsx
+++ b/ui/src/components/HookForm/index.jsx
@@ -141,24 +141,12 @@ const initialHook = {
 }))
 /** A form to view/edit/create a hook */
 export default class HookForm extends Component {
-  static defaultProps = {
-    isNewHook: false,
-    hook: initialHook,
-    hookLastFires: null,
-    onTriggerHook: null,
-    onCreateHook: null,
-    onUpdateHook: null,
-    onDeleteHook: null,
-    actionLoading: false,
-    dialogError: null,
-  };
-
   static propTypes = {
     /** Part of a GraphQL hook response containing info about that hook.
-    Not needed when creating a new hook */
+     Not needed when creating a new hook */
     hook: hook.isRequired,
     /** Part of the same Grahql hook response as above containing info
-    about some last hook fired attempts */
+     about some last hook fired attempts */
     hookLastFires: array,
     /** Set to `true` when creating a new hook. */
     isNewHook: bool,
@@ -178,6 +166,27 @@ export default class HookForm extends Component {
      * Callback function fired when the DialogAction component throws an error.
      * */
     onDialogActionError: func,
+    /**
+     * Callback function fired when the DialogAction triggers the
+     * onComplete handler after successfully deleting a hook.
+     * */
+    onDialogActionDeleteComplete: func,
+  };
+
+  static defaultProps = {
+    isNewHook: false,
+    hook: initialHook,
+    hookLastFires: null,
+    onTriggerHook: null,
+    onCreateHook: null,
+    onUpdateHook: null,
+    onDeleteHook: null,
+    actionLoading: false,
+    dialogError: null,
+    onDialogActionError: null,
+    onDialogDeleteHook: null,
+    deleteDialogOpen: null,
+    onDialogActionDeleteComplete: null,
   };
 
   state = {
@@ -281,11 +290,12 @@ export default class HookForm extends Component {
       hook: { hookId, hookGroupId },
     } = this.state;
 
-    onDeleteHook &&
-      onDeleteHook({
+    if (onDeleteHook) {
+      return onDeleteHook({
         hookId,
         hookGroupId,
       });
+    }
   };
 
   handleEmailOnErrorChange = () => {
@@ -498,12 +508,13 @@ export default class HookForm extends Component {
     const {
       actionLoading,
       dialogOpen,
-      dialogDeleteHook,
+      deleteDialogOpen,
       dialogError,
       classes,
       isNewHook,
-      onActionDialogClose,
+      onDialogActionClose,
       onDialogActionError,
+      onDialogActionDeleteComplete,
       onDialogDeleteHook,
       onDialogOpen,
     } = this.props;
@@ -821,8 +832,8 @@ export default class HookForm extends Component {
             fullScreen
             open={dialogOpen}
             onSubmit={this.handleTriggerHookSubmit}
-            onComplete={onActionDialogClose}
-            onClose={onActionDialogClose}
+            onComplete={onDialogActionClose}
+            onClose={onDialogActionClose}
             onError={onDialogActionError}
             error={dialogError}
             confirmText="Trigger Hook"
@@ -860,20 +871,20 @@ export default class HookForm extends Component {
             }
           />
         )}
-        {dialogDeleteHook && (
+        {deleteDialogOpen && (
           <DialogAction
-            open={dialogDeleteHook}
+            open={deleteDialogOpen}
             title="Delete?"
             onSubmit={this.handleDeleteHook}
-            onComplete={onActionDialogClose}
-            onClose={onActionDialogClose}
+            onComplete={onDialogActionDeleteComplete}
+            onClose={onDialogActionClose}
             onError={onDialogActionError}
             error={dialogError}
             confirmText="Delete Hook"
             body={
-              <p>
+              <Typography>
                 This will delete {hook.hookGroupId}/{hook.hookId}
-              </p>
+              </Typography>
             }
           />
         )}

--- a/ui/src/components/HookForm/index.jsx
+++ b/ui/src/components/HookForm/index.jsx
@@ -498,11 +498,13 @@ export default class HookForm extends Component {
     const {
       actionLoading,
       dialogOpen,
+      dialogDeleteHook,
       dialogError,
       classes,
       isNewHook,
       onActionDialogClose,
       onDialogActionError,
+      onDialogDeleteHook,
       onDialogOpen,
     } = this.props;
     const {
@@ -793,7 +795,7 @@ export default class HookForm extends Component {
                 requiresAuth
                 tooltipOpen
                 icon={<DeleteIcon />}
-                onClick={this.handleDeleteHook}
+                onClick={onDialogDeleteHook}
                 className={classes.deleteIcon}
                 ButtonProps={{
                   disabled: actionLoading,
@@ -855,6 +857,23 @@ export default class HookForm extends Component {
                   </Grid>
                 </Grid>
               </Fragment>
+            }
+          />
+        )}
+        {dialogDeleteHook && (
+          <DialogAction
+            open={dialogDeleteHook}
+            title="Delete?"
+            onSubmit={this.handleDeleteHook}
+            onComplete={onActionDialogClose}
+            onClose={onActionDialogClose}
+            onError={onDialogActionError}
+            error={dialogError}
+            confirmText="Delete Hook"
+            body={
+              <p>
+                This will delete {hook.hookGroupId}/{hook.hookId}
+              </p>
             }
           />
         )}

--- a/ui/src/views/Hooks/ViewHook/index.jsx
+++ b/ui/src/views/Hooks/ViewHook/index.jsx
@@ -29,6 +29,7 @@ export default class ViewHook extends Component {
     actionLoading: false,
     error: null,
     dialogError: null,
+    dialogDeleteHook: false,
     dialogOpen: false,
     snackbar: {
       message: '',
@@ -127,6 +128,7 @@ export default class ViewHook extends Component {
     this.setState({
       actionLoading: false,
       dialogOpen: false,
+      dialogDeleteHook: false,
       dialogError: null,
       error: null,
     });
@@ -134,6 +136,10 @@ export default class ViewHook extends Component {
 
   handleDialogOpen = () => {
     this.setState({ dialogOpen: true });
+  };
+
+  handleDeleteDialogHook = () => {
+    this.setState({ dialogDeleteHook: true });
   };
 
   handleDialogActionError = error => {
@@ -160,6 +166,7 @@ export default class ViewHook extends Component {
       error: err,
       dialogError,
       actionLoading,
+      dialogDeleteHook,
       dialogOpen,
       snackbar,
     } = this.state;
@@ -193,12 +200,14 @@ export default class ViewHook extends Component {
                 hook={data.hook}
                 hookLastFires={hookLastFires}
                 dialogOpen={dialogOpen}
+                dialogDeleteHook={dialogDeleteHook}
                 onTriggerHook={this.handleTriggerHook}
                 onUpdateHook={this.handleUpdateHook}
                 onDeleteHook={this.handleDeleteHook}
                 onActionDialogClose={this.handleActionDialogClose}
                 onDialogActionError={this.handleDialogActionError}
                 onDialogOpen={this.handleDialogOpen}
+                onDialogDeleteHook={this.handleDeleteDialogHook}
               />
             )}
           </Fragment>

--- a/ui/src/views/Hooks/ViewHook/index.jsx
+++ b/ui/src/views/Hooks/ViewHook/index.jsx
@@ -29,7 +29,7 @@ export default class ViewHook extends Component {
     actionLoading: false,
     error: null,
     dialogError: null,
-    dialogDeleteHook: false,
+    deleteDialogOpen: false,
     dialogOpen: false,
     snackbar: {
       message: '',
@@ -70,20 +70,13 @@ export default class ViewHook extends Component {
   handleDeleteHook = async ({ hookId, hookGroupId }) => {
     this.preRunningAction();
 
-    try {
-      await this.props.client.mutate({
-        mutation: deleteHookQuery,
-        variables: {
-          hookId,
-          hookGroupId,
-        },
-      });
-
-      this.setState({ error: null, actionLoading: false });
-      this.props.history.push('/hooks');
-    } catch (error) {
-      this.setState({ error, actionLoading: false });
-    }
+    return this.props.client.mutate({
+      mutation: deleteHookQuery,
+      variables: {
+        hookId,
+        hookGroupId,
+      },
+    });
   };
 
   handleTriggerHook = async ({ hookGroupId, hookId, payload }) => {
@@ -99,7 +92,7 @@ export default class ViewHook extends Component {
       refetchQueries: ['Hook'],
       awaitRefetchQueries: true,
     });
-    this.handleSnackbarOpen({ message: 'Hook Updated', open: true });
+    this.handleSnackbarOpen({ message: 'Hook Triggered', open: true });
   };
 
   handleUpdateHook = async ({ hookGroupId, hookId, payload }) => {
@@ -128,7 +121,7 @@ export default class ViewHook extends Component {
     this.setState({
       actionLoading: false,
       dialogOpen: false,
-      dialogDeleteHook: false,
+      deleteDialogOpen: false,
       dialogError: null,
       error: null,
     });
@@ -139,7 +132,7 @@ export default class ViewHook extends Component {
   };
 
   handleDeleteDialogHook = () => {
-    this.setState({ dialogDeleteHook: true });
+    this.setState({ deleteDialogOpen: true });
   };
 
   handleDialogActionError = error => {
@@ -160,13 +153,17 @@ export default class ViewHook extends Component {
     });
   };
 
+  handleActionDialogDeleteComplete = () => {
+    this.props.history.push('/hooks');
+  };
+
   render() {
     const { isNewHook, data } = this.props;
     const {
       error: err,
       dialogError,
       actionLoading,
-      dialogDeleteHook,
+      deleteDialogOpen,
       dialogOpen,
       snackbar,
     } = this.state;
@@ -200,11 +197,14 @@ export default class ViewHook extends Component {
                 hook={data.hook}
                 hookLastFires={hookLastFires}
                 dialogOpen={dialogOpen}
-                dialogDeleteHook={dialogDeleteHook}
+                deleteDialogOpen={deleteDialogOpen}
                 onTriggerHook={this.handleTriggerHook}
                 onUpdateHook={this.handleUpdateHook}
                 onDeleteHook={this.handleDeleteHook}
-                onActionDialogClose={this.handleActionDialogClose}
+                onDialogActionDeleteComplete={
+                  this.handleActionDialogDeleteComplete
+                }
+                onDialogActionClose={this.handleActionDialogClose}
                 onDialogActionError={this.handleDialogActionError}
                 onDialogOpen={this.handleDialogOpen}
                 onDialogDeleteHook={this.handleDeleteDialogHook}


### PR DESCRIPTION
Fixes #957 
@helfi92 

Before: No confirmation dialog on deleting hook.

After:

![is this ok](https://user-images.githubusercontent.com/22501334/61478649-878c4a80-a9af-11e9-851a-ffa5e2a672bd.png)

Confirmation dialog box comes first on deleting hook.

Let me know if this needs any changes!
Thank you! :)
