### PR TITLE
Upgrade react-lazylog to 4.2.0

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -78,7 +78,7 @@
     "react-ga": "^2.5.3",
     "react-helmet": "^5.2.1",
     "react-hot-loader": "^4.8.4",
-    "react-lazylog": "^4.1.0",
+    "react-lazylog": "^4.2.0",
     "react-router-dom": "^4.3.1",
     "react-schema-viewer": "^3.2.0",
     "react-virtualized": "^9.21.0",

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -9095,10 +9095,10 @@ react-is@^16.3.2, react-is@^16.6.3, react-is@^16.7.0, react-is@^16.8.1:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.8.1.tgz#a80141e246eb894824fb4f2901c0c50ef31d4cdb"
   integrity sha512-ioMCzVDWvCvKD8eeT+iukyWrBGrA3DiFYkXfBsVYIRdaREZuBjENG+KjrikavCLasozqRWTwFUagU/O4vPpRMA==
 
-react-lazylog@^4.1.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/react-lazylog/-/react-lazylog-4.1.0.tgz#27039d271794c73f7e81cf752000e22ef179565d"
-  integrity sha512-ue1PtP0j+rOpT54TZGR+pD57vJZ+LJr4bb5qbXCmZmeG1W3v5ZjOD70TUa458CDLeXwQixFMPo6azvWmHcr+zw==
+react-lazylog@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/react-lazylog/-/react-lazylog-4.2.0.tgz#edc58d744d7fb0cf8f8b105ff6f8e903cd247df7"
+  integrity sha512-i+qP4uQXVr79SUJrmXHMgaHM32Pevp1FwnLQwuEjA8m94XdGyl0oBf+XObjTLTo026h0ZzNg6sxszXqO59lH1g==
   dependencies:
     "@mattiasbuelens/web-streams-polyfill" "^0.2.0"
     fetch-readablestream "^0.2.0"
@@ -10778,7 +10778,8 @@ tar@^4:
     yallist "^3.0.2"
 
 "taskcluster-lib-scopes@link:../libraries/scopes":
-  version "14.2.0"
+  version "0.0.0"
+  uid ""
 
 taskcluster-lib-urls@^12.0.0:
   version "12.0.0"


### PR DESCRIPTION
Fixes #985

To understand the fix, please see https://github.com/mozilla-frontend-infra/react-lazylog/pull/43