### PR TITLE
Remove references to tools.taskcluster.net in docs and hooks service test

### DIFF
--- a/services/hooks/test/validate_test/create-hook-request.json
+++ b/services/hooks/test/validate_test/create-hook-request.json
@@ -14,7 +14,7 @@
             "name": "Example Task",
             "description": "Markdown description of **what** this task does",
             "owner": "name@example.com",
-            "source": "http://tools.taskcluster.net/task-creator/"
+            "source": "http://tc.example.com/tasks/create"
         }
     }
 }

--- a/test/meta_test.js
+++ b/test/meta_test.js
@@ -174,24 +174,7 @@ suite('Repo Meta Tests', function () {
     const whitelist = new Set([
       '.codecov.yml',
       '.taskcluster.yml',
-      'services/hooks/test/validate_test/create-hook-request.json',
       'test/meta_test.js',
-      'ui/docs/reference/core/notify/usage.md',
-      'ui/docs/reference/guide.md',
-      'ui/docs/reference/integrations/github/intro.md',
-      'ui/docs/reference/integrations/github/taskcluster-yml-v0.md',
-      'ui/docs/reference/integrations/github/taskcluster-yml-v1.md',
-      'ui/docs/reference/platform/queue/worker-hierarchy.md',
-      'ui/docs/tutorial/authenticate.md',
-      'ui/docs/tutorial/create-task-via-api.md',
-      'ui/docs/tutorial/debug-task.md',
-      'ui/docs/tutorial/download-task-artifacts.md',
-      'ui/docs/tutorial/finding-tasks.md',
-      'ui/docs/tutorial/gecko-decision-task.md',
-      'ui/docs/tutorial/gecko-tasks.md',
-      'ui/docs/tutorial/hello-world.md',
-      'ui/docs/tutorial/monitor-task-status.md',
-      'ui/src/components/HookForm/index.jsx',
     ]);
 
     let res;

--- a/ui/docs/reference/core/notify/usage.md
+++ b/ui/docs/reference/core/notify/usage.md
@@ -10,7 +10,7 @@ There are (as of today) three types of notifications and four types of filters p
 
 ### Notification Types
 
-__IRC:__ This is only enabled on ``irc.mozilla.org`` for now. You can specify either a user or a channel to send a notification to upon task completion. You'll receive a message like the following: ``Task "Taskcluster Notify Test" complete with status 'completed'. Inspect: https://tools.taskcluster.net/task-inspector/#f0rU3kS7RmG3xSWwbq6Ndw``.
+__IRC:__ This is only enabled on ``irc.mozilla.org`` for now. You can specify either a user or a channel to send a notification to upon task completion. You'll receive a message like the following: ``Task "Taskcluster Notify Test" complete with status 'completed'. Inspect: https://tc.example.com/tasks/f0rU3kS7RmG3xSWwbq6Ndw``.
 
 __Email:__ We can you both nicely formatted or plain text emails depending on which email client you want to use. You can send to any email address, so long as you have the correct scopes (we'll discuss scopes later).
 

--- a/ui/docs/reference/guide.md
+++ b/ui/docs/reference/guide.md
@@ -81,11 +81,3 @@ These services are useful to the Taskcluster team, but probably not as useful to
 The [statsum service](operations/statsum) handles generic, statstically sound aggregation of system metrics.
 The [stats-collector service](operations/stats-collector) performs some very purpose-specific calculations to help the team measure the system against its defined service levels.
 The [diagnostics service](operations/diagnostics) service performs end-to-end diagnostic tests of the Taskcluster system to detect errors.
-
-### Tools Interface
-
-The [tools site](https://tools.taskcluster.net/) provides an extensive UI for interacting with TaskCluser services.
-While the site itself is a static React application, it makes use of several services for its dynamic behavior.
-The [login service](integrations/login) provides a way for users to get Taskcluster credentials.
-The [events service](core/events) connects the web browser to Pulse.
-And the [cors-proxy](core/cors-proxy) service enables secure access to external CORS-protected services.

--- a/ui/docs/reference/integrations/github/intro.md
+++ b/ui/docs/reference/integrations/github/intro.md
@@ -10,6 +10,4 @@ projects as simple to test as calling `npm test` all the way up to
 the very complex set of tasks to perform in order to test and build
 the Firefox browser.
 
-The syntax offers an enormous amount of flexibility. [The quickstart tool](https://tools.taskcluster.net/quickstart/) should get you going quickly.
-
-The eventual goal of this project is to support all platforms and allow users to define workflows for testing, shipping, and landing patches from within their configurations. Currently, we offer mostly Linux support and have Windows available.
+The syntax offers an enormous amount of flexibility. The eventual goal of this project is to support all platforms and allow users to define workflows for testing, shipping, and landing patches from within their configurations. Currently, we offer mostly Linux support and have Windows available.

--- a/ui/docs/reference/integrations/github/taskcluster-yml-v0.md
+++ b/ui/docs/reference/integrations/github/taskcluster-yml-v0.md
@@ -105,7 +105,7 @@ Pushes, pull requests, and releases all are given access to [scopes](/docs/manua
 * `Release` -- `assume:repo:github.com/<organization>/<repository>:release`
 * `Tag` -- `assume:repo:github.com/<organization>/<repository>:tag:<tag>`
 
-In the [role manager](https://tools.taskcluster.net/auth/roles/), you can set up roles however you like. To give permissions to every event in your repository, you can make a role `repo:github.com/<organization>/<repository>:*` or you can give fine-grained permissions to only releases or specific branches, etc. [Read more](/manual/design/apis/hawk/scopes) about how scopes and roles work to see what you can do. There are lots of examples in the roles inspector for other repositories that have been set up. Look for roles that begin with `repo:github.com/` to see how they work.
+In the Roles tool (under Authorization), you can set up roles however you like. To give permissions to every event in your repository, you can make a role `repo:github.com/<organization>/<repository>:*` or you can give fine-grained permissions to only releases or specific branches, etc. [Read more](/manual/design/apis/hawk/scopes) about how scopes and roles work to see what you can do.
 
 ### Who Can Trigger Jobs?
 

--- a/ui/docs/reference/integrations/github/taskcluster-yml-v1.md
+++ b/ui/docs/reference/integrations/github/taskcluster-yml-v1.md
@@ -200,7 +200,7 @@ tasks:
 
 #### Provisioner ID and Worker Type
 
-You need to know which provisioner and which worker type you want to use to run your tasks. If you plan on using AWS provisioner, you can look up or create a worker type [here](https://tools.taskcluster.net/aws-provisioner/).
+You need to know which provisioner and which worker type you want to use to run your tasks. If you don't know which worker to use, consult the administrators of the Taskcluster deployment. You can see a list of all worker types in the Provisioners tool.
 
 ## Scopes and Roles
 
@@ -210,7 +210,7 @@ You need to know which provisioner and which worker type you want to use to run 
 * `assume:repo:github.com/<owner>/<repo>:release` for a release event
 * `assume:repo:github.com/<organization>/<repository>:tag:<tag>` for a tag event
 
-In the [role manager](https://tools.taskcluster.net/auth/roles/), you can set up roles however you like. To give permissions to every event in your repository, you can make a role `repo:github.com/<organization>/<repository>:*` or you can give fine-grained permissions to specific github events or specific branches.
+In the Roles tool (under Authorization), you can set up roles however you like. To give permissions to every event in your repository, you can make a role `repo:github.com/<organization>/<repository>:*` or you can give fine-grained permissions to specific github events or specific branches.
 
 Careful configuration of these roles and the related tasks can allow powerful behaviors such as binary uploads on push, without allowing pull requests access to those capabilities. There are lots of examples in the role manager for other repositories that have been set up. Look for roles that begin with `repo:github.com/` to see how they work.
 

--- a/ui/docs/reference/platform/queue/worker-hierarchy.md
+++ b/ui/docs/reference/platform/queue/worker-hierarchy.md
@@ -12,10 +12,7 @@ The queue defines a hierarchy of resources that consume tasks from queues:
 [Provisioners](/docs/manual/task-execution/provisioning), identified with a
 `provisionerId`, are responsible for groups of worker types. While some
 provisioners, such as the AWS provisioner, are active software components,
-others are simply identifiers within the Queue service's data structures.  For
-example, there is no active management of the
-[`releng-hardware`](https://tools.taskcluster.net/provisioners/releng-hardware)
-`provisionerId`.
+others are simply identifiers within the Queue service's data structures.
 
 Provisioners can be declared, and metadata associated with them, via the
 [declareProvisioner](/docs/reference/platform/queue/api#declareProvisioner)

--- a/ui/docs/tutorial/authenticate.md
+++ b/ui/docs/tutorial/authenticate.md
@@ -17,7 +17,7 @@ site.
 If you haven't already, try the "[Hello World](hello-world)" tutorial to make
 sure that you can sign in to the tools site.
 
-Open the [client manager](https://tools.taskcluster.net/auth/clients/) and create a new client:
+Open the Clients tool (under Authorization) and create a new client:
 
  * Add `tutorial` to the end of the clientId
  * Set the expiration date to tomorrow, and check "Automatically delete this client when it expires"
@@ -41,7 +41,7 @@ provides a tool that can do all of the above for you.
 $ eval `taskcluster signin --scope queue:create-task:aws-provisioner-v1/tutorial`
 Starting
 Listening for a callback on: http://localhost:37885
-Opening URL: https://tools.taskcluster.net/auth/clients/new?name=cli&description=Temporary+client+for+use+on+the+command+line&scope=*&expires=1d&callback_url=http%3A%2F%2Flocalhost%3A37885
+Opening URL: https://tc.example.com/auth/clients/new?name=cli&description=Temporary+client+for+use+on+the+command+line&scope=*&expires=1d&callback_url=http%3A%2F%2Flocalhost%3A37885
 Credentials output as environment variables
 ```
 

--- a/ui/docs/tutorial/create-task-via-api.md
+++ b/ui/docs/tutorial/create-task-via-api.md
@@ -236,7 +236,7 @@ let runTask = async () => {
 
   console.log("Created task:\n" + JSON.stringify(result.status, null, 2));
   console.log("Inspect it at:");
-  console.log("https://tools.taskcluster.net/task-inspector/#" + taskId);
+  console.log("https://tc.example.com/tasks/" + taskId);
 }
 
 runTask().catch(console.error);

--- a/ui/docs/tutorial/debug-task.md
+++ b/ui/docs/tutorial/debug-task.md
@@ -15,9 +15,7 @@ features, debug with Taskcluster.
 
 You can run a task on any computer with Docker installed.
 
-First, navigate to your task in the [task
-inspector](https://tools.taskcluster.net/groups) and select the "task
-details" tab.
+First, navigate to your task in the Task Inspector and select the "task details" tab.
 
 If the `payload` section of the task details specifies any
 [features](/docs/reference/workers/docker-worker/docs/features)
@@ -38,7 +36,7 @@ Taskcluster has an "interactive" mode with which you can get a terminal and/or
 VNC connection to a running task execution environment.
 
 There are two ways to access this mode. The easiest is to enter the task's ID
-in the [task inspector](https://tools.taskcluster.net/groups). Under
+in the Task Inspector. Under
 "actions", select "Create with SSH/VNC task". If you have permission to create
 tasks directly (rather than by pushing to a version-control server) then you
 can use this option. Some projects also provide

--- a/ui/docs/tutorial/download-task-artifacts.md
+++ b/ui/docs/tutorial/download-task-artifacts.md
@@ -70,7 +70,7 @@ let runTask = async () => {
     
   console.log("Created task:\n" + JSON.stringify(result.status, null, 2));    
   console.log("Inspect it at:");    
-  console.log("https://tools.taskcluster.net/task-inspector/#" + taskId);    
+  console.log("https://tc.example.com/tasks/" + taskId);    
     
   while (1) {
     console.log("waiting for completion..");

--- a/ui/docs/tutorial/finding-tasks.md
+++ b/ui/docs/tutorial/finding-tasks.md
@@ -5,13 +5,13 @@ title: Finding Tasks
 # Finding Tasks
 
 The "table of contents" for Taskcluster tasks is the
-[Index](https://tools.taskcluster.net/index/). When a task completes
+[Index](https://tc.example.com/tasks/index). When a task completes
 successfully, it is added to the index at an "index route" given by any
 `task.routes` entries that begin with `index.`. (Actually, the Queue just
 [sends pulse messages to well-known exchanges](/docs/reference/platform/queue/exchanges).
 The Index listens to `index.*` for task completion, and indexes the tasks appropriately).
 
-What that means is, you can use the [Index Browser](https://tools.taskcluster.net/index/)
+What that means is, you can use the [Index Browser](https://tc.example.com/tasks/index)
 to find tasks.  The precise format of the index paths is partially defined in the
 [namespaces](/docs/manual/devel/namespaces) document.
 

--- a/ui/docs/tutorial/gecko-decision-task.md
+++ b/ui/docs/tutorial/gecko-decision-task.md
@@ -10,9 +10,9 @@ It parses this file, substituting a number of variables based on the push, and s
 This task is the "decision task", which will in turn create all of the tasks for the push.
 
 The scopes available to the decision task are limited by the repository's role.
-For example, the Cypress branch's decision task has only the scopes in [repo:hg.mozilla.org/projects/cypress:*](https://tools.taskcluster.net/auth/roles/#repo:hg.mozilla.org%252fprojects%252fcypress:*).
+For example, the Cypress branch's decision task has only the scopes in [repo:hg.mozilla.org/projects/cypress:*](https://tc.example.com/auth/roles/#repo:hg.mozilla.org%252fprojects%252fcypress:*).
 
 This pattern occurs even for a try push.
 That means you can modify how the decision task is invoked, or even what the decision task does, in a try push!
 
-You can find a link to the latest mozilla-central decision task in [the Taskcluster index](https://tools.taskcluster.net/index/#gecko.v2.mozilla-central.latest.firefox/gecko.v2.mozilla-central.latest.firefox.decision).
+You can find a link to the latest mozilla-central decision task in [the Taskcluster index](https://tc.example.com/index/#gecko.v2.mozilla-central.latest.firefox/gecko.v2.mozilla-central.latest.firefox.decision).

--- a/ui/docs/tutorial/gecko-tasks.md
+++ b/ui/docs/tutorial/gecko-tasks.md
@@ -15,7 +15,7 @@ When a developer pushes to a Gecko repository, a long chain of events begins:
  * These tasks are arranged in a "task graph", with some tasks (e.g., tests) depending on others (builds).
    Once its prerequisite tasks complete, a dependent task begins.
  * The result of each task is sent to [TreeHerder](https://treeherder.mozilla.org) where developers and sheriffs can track the status of the push.
- * The outputs from each task -- log files, Firefox installers, and so on -- appear attached to each task (viewable in the [Task Inspector](https://tools.taskcluster.net/task-inspector/)) when it completes.
+ * The outputs from each task -- log files, Firefox installers, and so on -- appear attached to each task (viewable in the [Task Inspector](https://tc.example.com/tasks)) when it completes.
 
 Due to its "self-service" design, very little of this process is actually part of Taskcluster, so we provide only a brief overview and some pointers.
 

--- a/ui/docs/tutorial/hello-world.md
+++ b/ui/docs/tutorial/hello-world.md
@@ -21,7 +21,7 @@ We support sign-in by Mozillians, as well as by developers and employees with LD
 If that doesn't sound familiar to you, head over to [Mozillians](https://mozillians.org) and set up a new account for yourself.
 Now you're a Mozillian -- thanks for rocking the free web with us!
 
-Visit the [Task Creator](https://tools.taskcluster.net/task-creator) and click the "Sign In" link in the upper right corner.
+Visit the [Task Creator](https://tc.example.com/tasks/create) and click the "Sign In" link in the upper right corner.
 Sign in using whatever method best suits you.
 If you just set up a Mozillians account, use that.
 Click the "Grant Permission" button, which will return you to the task creator.
@@ -44,7 +44,7 @@ metadata:
   name: Example Task
   description: Markdown description of **what** this task does
   owner: name@example.com
-  source: 'https://tools.taskcluster.net/task-creator/'
+  source: 'https://github.com/username/repo'
 ```
 
 Happily, this is already set up to print "hello world"!

--- a/ui/docs/tutorial/monitor-task-status.md
+++ b/ui/docs/tutorial/monitor-task-status.md
@@ -61,7 +61,7 @@ let runTask = async () => {
 
   console.log("Created task:\n" + JSON.stringify(result.status, null, 2));
   console.log("Inspect it at:");
-  console.log("https://tools.taskcluster.net/task-inspector/#" + taskId);
+  console.log("https://tc.example.com/tasks/" + taskId);
 
   while (1) {
     let result = await queue.status(taskId);

--- a/ui/src/components/HookForm/index.jsx
+++ b/ui/src/components/HookForm/index.jsx
@@ -56,7 +56,7 @@ const initialHook = {
       name: 'Hook Task',
       description: 'Task Description',
       owner: 'name@example.com',
-      source: 'https://tools.taskcluster.net/hooks',
+      source: 'https://tc.example.com/hooks',
     },
     expires: { $fromNow: '3 months' },
     deadline: { $fromNow: '6 hours' },


### PR DESCRIPTION


<!-- If this is related to a Bugzilla bug, please begin your title with [Bug XXXXX]
     and update this link.

     Is this change user-visible?  If so, please include a file in changelog/ describing it.
     See https://github.com/taskcluster/taskcluster/blob/master/dev-docs/best-practices/changelog.md
-->

Bugzilla Bug: [1562752](https://bugzilla.mozilla.org/show_bug.cgi?id=1562752)

I am not sure about the changes made to the tutorial docs, "Hello World" and "Authentication", specifically.

/cc @djmitche 