### PR TITLE
Remove patch coverage report

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -12,6 +12,7 @@ comment: off
 coverage:
   precision: 0
   status:
+    patch: off
     project:
       default:
         threshold: 1 # This combined with precision 0 should stop us from failing checks randomly


### PR DESCRIPTION
This is proving to be more annoying than useful for now.