### PR TITLE
Reorder docker build steps to skip yarn install if no change

### DIFF
--- a/changelog/issue-1084.md
+++ b/changelog/issue-1084.md
@@ -1,0 +1,7 @@
+level: minor
+reference: issue 1084
+---
+
+The Dockerfile for the Taskcluster services is now checked-in rather than
+generated at build time. It has been reordered so that changes to things
+other than package.json won't re-install packages.


### PR DESCRIPTION
Optionally we could do this as well. I think it skips `yarn install` if you haven't changed `package.json`. This should cut down on build time significantly in most cases during development?