### PR TITLE
Possible fix for cookies not being sent in production

### DIFF
--- a/services/web-server/src/servers/createApp.js
+++ b/services/web-server/src/servers/createApp.js
@@ -24,10 +24,10 @@ module.exports = async ({ cfg, strategies }) => {
     }
     return o;
   }).filter(o => o);
-    app.use(cors({
-      origin: allowedCORSOrigins,
-      credentials: true
-    }));
+  app.use(cors({
+    origin: allowedCORSOrigins,
+    credentials: true,
+  }));
 
   app.use(session({
     store: new MemoryStore({

--- a/services/web-server/src/servers/createApp.js
+++ b/services/web-server/src/servers/createApp.js
@@ -24,7 +24,10 @@ module.exports = async ({ cfg, strategies }) => {
     }
     return o;
   }).filter(o => o);
-  app.use(cors({origin: allowedCORSOrigins}));
+    app.use(cors({
+      origin: allowedCORSOrigins,
+      credentials: true
+    }));
 
   app.use(session({
     store: new MemoryStore({

--- a/ui/src/App/index.jsx
+++ b/ui/src/App/index.jsx
@@ -69,6 +69,7 @@ export default class App extends Component {
 
   httpLink = new HttpLink({
     uri: process.env.GRAPHQL_ENDPOINT,
+    credentials: 'same-origin',
   });
 
   wsLink = new WebSocketLink({


### PR DESCRIPTION
Logging in with the mozilla-auth strategy works in localhost but fails in production with error "Authentication is required to generate credentials". This error is coming from `loaders/auth.js`.

The reason why this is happening is because the cookies are not being sent from the browser and so `req.user` is undefined. I figured https://www.apollographql.com/docs/react/recipes/authentication/#cookie might be the fix 🤞