### PR TITLE
Encoding artifact url correctly

### DIFF
--- a/services/web-server/src/loaders/artifacts.js
+++ b/services/web-server/src/loaders/artifacts.js
@@ -29,12 +29,12 @@ module.exports = ({ queue }, isAuthed, rootUrl) => {
           ? urls.api(
             'queue',
             'v1',
-            `task/${taskId}/runs/${runId}/artifacts/${encodeURIComponent(artifact.name)}`
+            `task/${taskId}/runs/${runId}/artifacts/${encodeURI(artifact.name)}`
           )
           : urls.api(
             'queue',
             'v1',
-            `task/${taskId}/artifacts/${encodeURIComponent(artifact.name)}`
+            `task/${taskId}/artifacts/${encodeURI(artifact.name)}`
           ),
       };
     }

--- a/services/web-server/src/loaders/artifacts.js
+++ b/services/web-server/src/loaders/artifacts.js
@@ -29,12 +29,12 @@ module.exports = ({ queue }, isAuthed, rootUrl) => {
           ? urls.api(
             'queue',
             'v1',
-            `task/${taskId}/runs/${runId}/artifacts/${artifact.name}`
+            `task/${taskId}/runs/${runId}/artifacts/${encodeURIComponent(artifact.name)}`
           )
           : urls.api(
             'queue',
             'v1',
-            `task/${taskId}/artifacts/${artifact.name}`
+            `task/${taskId}/artifacts/${encodeURIComponent(artifact.name)}`
           ),
       };
     }


### PR DESCRIPTION
Fixes #1079 

Always encoding artifact url but leaving / un-escaped.

Is this what was required?