### PR TITLE
Fix go mod in release for client-shell

### DIFF
--- a/infrastructure/builder/src/release/tasks.js
+++ b/infrastructure/builder/src/release/tasks.js
@@ -141,11 +141,17 @@ module.exports = ({tasks, cmdOptions, baseDir}) => {
         contents.replace(/download\/v[0-9.]*\/taskcluster-/, `download/v${requirements['release-version']}/taskcluster-"`));
       changed.push(shellreadme);
 
+      const shellgomod = 'clients/client-shell/go.mod';
+      const major = requirements['release-version'].replace(/\..*/, '');
+      utils.status({message: `Update ${shellgomod}`});
+      await modifyRepoFile(shellgomod, contents =>
+        contents.replace(/(\tgithub.com\/taskcluster\/taskcluster\/clients\/client-go\/v)\d+ +v.*/g, `$1${major} v${requirements['release-version']}`));
+      changed.push(shellgomod);
+
       // the go client requires the major version number in its import path, so
       // just about every file needs to be edited.  This matches the full package
       // path to avoid false positives, but that might result in missed changes
       // where the full path is not used.
-      const major = requirements['release-version'].replace(/\..*/, '');
       for (let file of await gitLsFiles({patterns: ['clients/client-go/**', 'clients/client-shell/**']})) {
         await modifyRepoFile(file, contents =>
           contents.replace(/(github.com\/taskcluster\/taskcluster\/clients\/client-go\/v)\d+/g, `$1${major}`));


### PR DESCRIPTION
@milescrabill asking for your review for your golang brain.

this is the bit of the services stuff that updates our go clients when we release a new version. The shell library relies on the go-client library. Before this change, trying to cut a release yelled about not finding the version of the go-client library that we wanted. I believe it was because this was updating

```
github.com/taskcluster/taskcluster/clients/client-go/v14 v14.0.0-20190713182157-1b8e18d76d60
```
to 

```
github.com/taskcluster/taskcluster/clients/client-go/v15 v14.0.0-20190713182157-1b8e18d76d60
```

which obviously doesn't make any sense. Now it updates it to 

```
github.com/taskcluster/taskcluster/clients/client-go/v15 v15.0.0
```
Does that make sense to you?

cc @djmitche so you can tell if this was actually correct for the way we cut releases when you're back
