### PR TITLE
Use kubectl to interact with dev clusters

### DIFF
--- a/changelog/issue-1108.md
+++ b/changelog/issue-1108.md
@@ -1,0 +1,5 @@
+level: patch
+reference: issue #1108
+---
+The development process has been improved to use kubectl directly instead of helm.
+Helm is still used to render templates because we need to support it.

--- a/dev-docs/development-process.md
+++ b/dev-docs/development-process.md
@@ -125,7 +125,7 @@ You will first need to have
 * a rabbitmq cluster
 * an azure account
 * an aws account and an IAM user in that account
-* helm3 installed
+* helm installed
 * latest version of kubectl installed
 
 Once those are all set up, you will need:
@@ -147,18 +147,15 @@ Now follow along:
    be encryped at rest.
    * SubscriptionId can be found in the Azure console
    * RabbitMQ account creds are in passwordstore at tc/cloudamqp.com/hip-macaw
-1. Run `yarn dev:template` and see if it complains about any missing values in
+1. Run `yarn dev:verify` and see if it complains about any missing values in
    your configuration
 1. If you want to deploy local changes, run `yarn build --push` and add the
    resulting image id to your config file with the key `dockerImage`.
-1. `yarn dev:install` will use helm to apply all of your kubernetes resources
+1. `yarn dev:apply` will use helm+kubectl to apply all of your kubernetes resources
    to the cluster. *Note that this will create a new namespace in the cluster
-   for you and switch your kubectl context to it*
-1. `yarn dev:upgrade` will update an already installed cluster (once helm fixes
-   things).  Note that this isn't able to change lots of things such as the
-   docker image, so you may want to get in the habit of doing `dev:uninstall`
-   followed by `dev:install`, instead.
-1. `yarn dev:uninstall` will uninstall your deployment.
+   for you and switch your kubectl context to it*. If you make changes, just apply
+   again. It should change anything you've changed and remove anything you've removed.
+1. `yarn dev:delete` will uninstall your deployment.
 
 Troubleshooting:
 * Certbot error `[Errno 13] Permission denied: '/var/log/letsencrypt' Either run as root, or set --config-dir, --work-dir, and --logs-dir to writeable paths.` - do not run as root, but set the directories instead.

--- a/dev-docs/development-process.md
+++ b/dev-docs/development-process.md
@@ -125,7 +125,7 @@ You will first need to have
 * a rabbitmq cluster
 * an azure account
 * an aws account and an IAM user in that account
-* helm installed
+* helm installed (either 2 or 3 should Just Work)
 * latest version of kubectl installed
 
 Once those are all set up, you will need:

--- a/infrastructure/builder/src/dev/helm.js
+++ b/infrastructure/builder/src/dev/helm.js
@@ -1,56 +1,148 @@
-const child_process = require('child_process');
-const {REPO_ROOT, readRepoYAML} = require('../utils');
+const {REPO_ROOT, readRepoYAML, execCommand} = require('../utils');
+const {TaskGraph} = require('console-taskgraph');
+
+const resourceTypes = [
+  'cronjob',
+  'deployment',
+  'ingress',
+  'rolebinding',
+  'role',
+  'secret',
+  'serviceaccount',
+  'service',
+];
+
+const actions = [
+  {
+    title: 'Check dev-config.yml',
+    requires: [],
+    provides: ['dev-config'],
+    run: async (requirements, utils) => {
+      const config = await readRepoYAML('dev-config.yml');
+      if (!config.meta || !config.meta.deploymentPrefix) {
+        throw new Error('Must have configured dev-config.yml to deploy.');
+      }
+      return {'dev-config': config};
+    },
+  },
+  {
+    title: 'Helm version detection',
+    requires: [],
+    provides: ['helm-version'],
+    run: async (requirements, utils) => {
+      const res = await execCommand({
+        command: ['helm', 'version'],
+        dir: REPO_ROOT,
+        keepAllOutput: true,
+        ignoreReturn: true, // Helm 2 yells about tiller
+        utils,
+      });
+      const match = /SemVer:"(v[0-9]+.[0-9]+.[0-9]+)"/g.exec(res);
+      if (!match) {
+        throw new Error(`Could not determine helm version from: ${res}`);
+      } else if (match[1].includes('v3')) {
+        return {'helm-version': 3};
+      } else if (match[1].includes('v2')) {
+        return {'helm-version': 2};
+      } else {
+        throw new Error(`Must use supported helm version (2 or 3). You have ${match[1]}`);
+      }
+    },
+  },
+  {
+    title: 'Generate k8s Resources',
+    requires: ['dev-config', 'helm-version'],
+    provides: ['target-templates'],
+    run: async (requirements, utils) => {
+      let command = ['helm', 'template'];
+      if (requirements['helm-version'] === 3) {
+        command.push('taskcluster');
+      }
+      command = command.concat(['-f', './dev-config.yml', 'infrastructure/k8s']);
+      return {
+        'target-templates': await execCommand({
+          command,
+          dir: REPO_ROOT,
+          keepAllOutput: true,
+          utils,
+        }),
+      };
+    },
+  },
+  {
+    title: 'Generate Namespace',
+    requires: ['dev-config'],
+    provides: ['dev-namespace'],
+    run: async (requirements, utils) => {
+      const namespace = requirements['dev-config'].meta.deploymentPrefix;
+      await execCommand({
+        command: ['kubectl', 'create', 'namespace', namespace],
+        dir: REPO_ROOT,
+        keepAllOutput: true,
+        ignoreReturn: true, // If it already exists, that is fine. we'll fail on switching to namespace
+        utils,
+      });
+      return {'dev-namespace': namespace};
+    },
+  },
+  {
+    title: 'Switch to Namespace',
+    requires: ['dev-namespace'],
+    provides: ['namespace-switch'],
+    run: async (requirements, utils) => {
+      await execCommand({
+        command: ['kubectl', 'config', 'set-context', '--current', '--namespace', requirements['dev-namespace']],
+        dir: REPO_ROOT,
+        keepAllOutput: true,
+        utils,
+      });
+    },
+  },
+  {
+    title: 'Verify Your Deployment',
+    requires: ['target-templates'],
+    provides: ['target-verify'],
+    run: async (requirements, utils) => ({
+      'target-verify': await execCommand({
+        command: ['kubectl', 'apply', '--dry-run', '-f', '-'],
+        dir: REPO_ROOT,
+        stdin: requirements['target-templates'],
+        keepAllOutput: true,
+        utils,
+      }),
+    }),
+  },
+  {
+    title: 'Apply Your Deployment',
+    requires: ['target-templates', 'namespace-switch'],
+    provides: ['target-apply'],
+    run: async (requirements, utils) => ({
+      'target-apply': await execCommand({
+        command: ['kubectl', 'apply', '--prune', '-l', 'app.kubernetes.io/part-of=taskcluster', '-f', '-'],
+        dir: REPO_ROOT,
+        stdin: requirements['target-templates'],
+        keepAllOutput: true,
+        utils,
+      }),
+    }),
+  },
+  {
+    title: 'Delete Your Deployment',
+    requires: ['namespace-switch'],
+    provides: ['target-delete'],
+    run: async (requirements, utils) => ({
+      'target-delete': await execCommand({
+        command: ['kubectl', 'delete', resourceTypes.join(','), '-l', 'app.kubernetes.io/part-of=taskcluster'],
+        dir: REPO_ROOT,
+        keepAllOutput: true,
+        utils,
+      }),
+    }),
+  },
+];
 
 module.exports = async action => {
-  const config = await readRepoYAML('dev-config.yml');
-  if (!config.meta || !config.meta.deploymentPrefix) {
-    throw new Error('Must have configured dev-config.yml to run helm.');
-  }
-
-  const namespace = config.meta.deploymentPrefix;
-
-  if (action !== 'template') {
-    let res = child_process.spawnSync('kubectl', ['create', 'namespace', namespace]);
-    let output = res.stdout.toString() + res.stderr.toString();
-    if (res.status !== 0) {
-      if (!output.includes('AlreadyExists')) {
-        throw new Error(output);
-      }
-    }
-
-    res = child_process.spawnSync('kubectl', ['config', 'set-context', '--current', '--namespace', namespace]);
-    output = res.stdout.toString() + res.stderr.toString();
-    console.log(output);
-    if (res.status !== 0) {
-      throw new Error('Failed to update kubectl context');
-    }
-  }
-
-  let extraArgs = [];
-  if (action !== 'uninstall') {
-    extraArgs = extraArgs.concat([
-      '-f',
-      './dev-config.yml',
-      './infrastructure/k8s',
-    ]);
-  }
-
-  const helm = child_process.spawn('helm', [
-    action,
-    'taskcluster',
-    ...extraArgs,
-  ], {
-    cwd: REPO_ROOT,
-  });
-
-  helm.stdout.on('data', d => console.log(d.toString()));
-  helm.stderr.on('data', d => console.log(d.toString()));
-  return new Promise((resolve, reject) => {
-    helm.on('exit', (code, signal) => {
-      if (code !== 0) {
-        return reject('helm command failed');
-      }
-      resolve();
-    });
-  });
+  const target = action ? [`target-${action}`] : undefined;
+  const taskgraph = new TaskGraph(actions, {target});
+  await taskgraph.run();
 };

--- a/infrastructure/builder/src/dev/index.js
+++ b/infrastructure/builder/src/dev/index.js
@@ -46,8 +46,8 @@ const main = async (options) => {
     await writeRepoYAML(USER_CONF_FILE, _.merge(userConfig, answer));
   }
 
-  if (options.helmAction) {
-    await helm(options.helmAction);
+  if (options.k8sAction) {
+    await helm(options.k8sAction);
   }
 };
 

--- a/infrastructure/builder/src/main.js
+++ b/infrastructure/builder/src/main.js
@@ -76,7 +76,7 @@ program.command('changelog')
 
 program.command('dev')
   .option('--init', 'Set up resources and configure')
-  .option('--helm-action <action>', 'Run a specific action (install, uninstall, upgrade, template)')
+  .option('--k8s-action <action>', 'Run a specific action (apply, delete, template)')
   .action((...options) => {
     if (options.length !== 1) {
       console.error('unexpected command-line arguments');

--- a/infrastructure/builder/src/utils/command.js
+++ b/infrastructure/builder/src/utils/command.js
@@ -1,5 +1,5 @@
 const child_process = require('child_process');
-const {PassThrough} = require('stream');
+const {Transform} = require('stream');
 
 /**
  * Run a command and display its output.
@@ -9,24 +9,47 @@ const {PassThrough} = require('stream');
  * - utils -- taskgraph utils (waitFor, etc.)
  * - env -- optional environment variables for the command
  */
-exports.execCommand = async ({dir, command, utils, env = process.env}) => {
+exports.execCommand = async ({
+  dir,
+  command,
+  utils,
+  stdin,
+  keepAllOutput = false,
+  env = process.env,
+  ignoreReturn = false,
+}) => {
   const cp = child_process.spawn(command[0], command.slice(1), {
     cwd: dir,
     env,
-    stdio: ['ignore', 'pipe', 'pipe'],
+    stdio: [stdin ? 'pipe' : 'ignore', 'pipe', 'pipe'],
   });
 
-  const output = new PassThrough();
-  cp.stdout.pipe(output);
-  cp.stderr.pipe(output);
+  let output = '';
 
-  await utils.waitFor(output);
-  await new Promise((resolve, reject) => {
-    cp.once('close', code => {
-      if (code === 0) {
-        resolve();
+  const stream = new Transform({
+    transform: (chunk, encoding, callback) => {
+      if (keepAllOutput) {
+        output += chunk.toString();
       } else {
-        reject(new Error(`Nonzero exit status ${code} from ${command[0]}`));
+        output = '...\n' + chunk.toString();
+      }
+      callback(null, output);
+    },
+  });
+  cp.stdout.pipe(stream);
+  cp.stderr.pipe(stream);
+  if (stdin) {
+    cp.stdin.write(stdin);
+    cp.stdin.end();
+  }
+
+  await utils.waitFor(stream);
+  return await new Promise((resolve, reject) => {
+    cp.once('close', code => {
+      if (code === 0 || ignoreReturn) {
+        resolve(output);
+      } else {
+        reject(new Error(`Nonzero exit status ${code} from ${command[0]}:\n${output}`));
       }
     });
     cp.once('error', reject);

--- a/infrastructure/builder/templates/k8s/cron.yaml
+++ b/infrastructure/builder/templates/k8s/cron.yaml
@@ -2,31 +2,16 @@ apiVersion: batch/v1beta1
 kind: CronJob
 metadata:
   name: ${projectName}-${lowercase(procName)}
-  labels:
-    app.kubernetes.io/name: ${projectName}
-    app.kubernetes.io/instance: '{{ .Release.Name }}'
-    app.kubernetes.io/component: ${projectName}-${lowercase(procName)}
-    app.kubernetes.io/part-of: taskcluster
-    app.kubernetes.io/managed-by: helm
+  labels: {$eval: labels}
 spec:
   schedule: ${schedule}
   jobTemplate:
     metadata:
-      labels:
-        app.kubernetes.io/name: ${projectName}
-        app.kubernetes.io/instance: '{{ .Release.Name }}'
-        app.kubernetes.io/component: ${projectName}-${lowercase(procName)}
-        app.kubernetes.io/part-of: taskcluster
-        app.kubernetes.io/managed-by: helm
+      labels: {$eval: labels}
     spec:
       template:
         metadata:
-          labels:
-            app.kubernetes.io/name: ${projectName}
-            app.kubernetes.io/instance: '{{ .Release.Name }}'
-            app.kubernetes.io/component: ${projectName}-${lowercase(procName)}
-            app.kubernetes.io/part-of: taskcluster
-            app.kubernetes.io/managed-by: helm
+          labels: {$eval: labels}
         spec:
           restartPolicy: OnFailure
           activeDeadlineSeconds: {$eval: 'deadlineSeconds'}

--- a/infrastructure/builder/templates/k8s/deployment.yaml
+++ b/infrastructure/builder/templates/k8s/deployment.yaml
@@ -2,31 +2,16 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: ${projectName}-${lowercase(procName)}
-  labels:
-    app.kubernetes.io/name: ${projectName}
-    app.kubernetes.io/instance: '{{ .Release.Name }}'
-    app.kubernetes.io/component: ${projectName}-${lowercase(procName)}
-    app.kubernetes.io/part-of: taskcluster
-    app.kubernetes.io/managed-by: helm
+  labels: {$eval: labels}
 spec:
-  selector:
-    matchLabels:
-      app.kubernetes.io/name: ${projectName}
-      app.kubernetes.io/instance: '{{ .Release.Name }}'
-      app.kubernetes.io/component: ${projectName}-${lowercase(procName)}
-      app.kubernetes.io/part-of: taskcluster
-      app.kubernetes.io/managed-by: helm
   replicas: REPLICA_CONFIG_STRING
+  selector:
+      matchLabels: {$eval: labels}
   template:
     metadata:
       annotations:
         checksum/secret: '{{ include (print $.Template.BasePath "/${projectName}-secret.yaml") . | sha256sum }}'
-      labels:
-        app.kubernetes.io/name: ${projectName}
-        app.kubernetes.io/instance: '{{ .Release.Name }}'
-        app.kubernetes.io/component: ${projectName}-${lowercase(procName)}
-        app.kubernetes.io/part-of: taskcluster
-        app.kubernetes.io/managed-by: helm
+      labels: {$eval: labels}
     spec:
       serviceAccountName: ${projectName}
       containers:

--- a/infrastructure/builder/templates/k8s/ingress.yaml
+++ b/infrastructure/builder/templates/k8s/ingress.yaml
@@ -2,6 +2,7 @@ apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
   name: taskcluster-ingress
+  labels: {$eval: labels}
   annotations:
     'kubernetes.io/ingress.global-static-ip-name': '{{ .Values.ingressStaticIpName }}'
     'ingress.gcp.kubernetes.io/pre-shared-cert': '{{ .Values.ingressCertName }}'

--- a/infrastructure/builder/templates/k8s/role.yaml
+++ b/infrastructure/builder/templates/k8s/role.yaml
@@ -2,6 +2,7 @@ kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: ${projectName}-secrets-read
+  labels: {$eval: labels}
 rules:
 - apiGroups: ['']
   resources: ['secrets/${projectName}']

--- a/infrastructure/builder/templates/k8s/rolebinding.yaml
+++ b/infrastructure/builder/templates/k8s/rolebinding.yaml
@@ -3,6 +3,7 @@ kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: ${projectName}-secrets-read
+  labels: {$eval: labels}
 subjects:
 - kind: User
   name: ${projectName}

--- a/infrastructure/builder/templates/k8s/secret.yaml
+++ b/infrastructure/builder/templates/k8s/secret.yaml
@@ -3,6 +3,7 @@ kind: Secret
 type: Opaque
 metadata:
   name: ${projectName}
+  labels: {$eval: labels}
 data:
   $merge:
     $map: {$eval: secrets}

--- a/infrastructure/builder/templates/k8s/service.yaml
+++ b/infrastructure/builder/templates/k8s/service.yaml
@@ -2,13 +2,10 @@ kind: Service
 apiVersion: v1
 metadata:
   name: ${projectName}
+  labels: {$eval: labels}
 spec:
   type: NodePort
-  selector:
-    app.kubernetes.io/name: ${projectName}
-    app.kubernetes.io/instance: '{{ .Release.Name }}'
-    app.kubernetes.io/component: ${projectName}-${lowercase(procName)}
-    app.kubernetes.io/part-of: taskcluster
+  selector: {$eval: labels}
   ports:
   - protocol: TCP
     port: 80

--- a/infrastructure/builder/templates/k8s/serviceaccount.yaml
+++ b/infrastructure/builder/templates/k8s/serviceaccount.yaml
@@ -3,3 +3,4 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: ${projectName}
+  labels: {$eval: labels}

--- a/infrastructure/k8s/templates/ingress.yaml
+++ b/infrastructure/k8s/templates/ingress.yaml
@@ -2,6 +2,11 @@ apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
   name: taskcluster-ingress
+  labels:
+    app.kubernetes.io/name: taskcluster-ingress
+    app.kubernetes.io/instance: '{{ .Release.Name }}'
+    app.kubernetes.io/component: taskcluster-ingress-ingress
+    app.kubernetes.io/part-of: taskcluster
   annotations:
     kubernetes.io/ingress.global-static-ip-name: '{{ .Values.ingressStaticIpName }}'
     ingress.gcp.kubernetes.io/pre-shared-cert: '{{ .Values.ingressCertName }}'

--- a/infrastructure/k8s/templates/taskcluster-auth-cron-purgeExpiredClients.yaml
+++ b/infrastructure/k8s/templates/taskcluster-auth-cron-purgeExpiredClients.yaml
@@ -2,31 +2,20 @@ apiVersion: batch/v1beta1
 kind: CronJob
 metadata:
   name: taskcluster-auth-purgeexpiredclients
-  labels:
+  labels: &ref_0
     app.kubernetes.io/name: taskcluster-auth
     app.kubernetes.io/instance: '{{ .Release.Name }}'
     app.kubernetes.io/component: taskcluster-auth-purgeexpiredclients
     app.kubernetes.io/part-of: taskcluster
-    app.kubernetes.io/managed-by: helm
 spec:
   schedule: 0 0 * * *
   jobTemplate:
     metadata:
-      labels:
-        app.kubernetes.io/name: taskcluster-auth
-        app.kubernetes.io/instance: '{{ .Release.Name }}'
-        app.kubernetes.io/component: taskcluster-auth-purgeexpiredclients
-        app.kubernetes.io/part-of: taskcluster
-        app.kubernetes.io/managed-by: helm
+      labels: *ref_0
     spec:
       template:
         metadata:
-          labels:
-            app.kubernetes.io/name: taskcluster-auth
-            app.kubernetes.io/instance: '{{ .Release.Name }}'
-            app.kubernetes.io/component: taskcluster-auth-purgeexpiredclients
-            app.kubernetes.io/part-of: taskcluster
-            app.kubernetes.io/managed-by: helm
+          labels: *ref_0
         spec:
           restartPolicy: OnFailure
           activeDeadlineSeconds: 86400

--- a/infrastructure/k8s/templates/taskcluster-auth-deployment-web.yaml
+++ b/infrastructure/k8s/templates/taskcluster-auth-deployment-web.yaml
@@ -2,31 +2,20 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: taskcluster-auth-web
-  labels:
+  labels: &ref_0
     app.kubernetes.io/name: taskcluster-auth
     app.kubernetes.io/instance: '{{ .Release.Name }}'
     app.kubernetes.io/component: taskcluster-auth-web
     app.kubernetes.io/part-of: taskcluster
-    app.kubernetes.io/managed-by: helm
 spec:
-  selector:
-    matchLabels:
-      app.kubernetes.io/name: taskcluster-auth
-      app.kubernetes.io/instance: '{{ .Release.Name }}'
-      app.kubernetes.io/component: taskcluster-auth-web
-      app.kubernetes.io/part-of: taskcluster
-      app.kubernetes.io/managed-by: helm
   replicas: {{ int (.Values.auth.procs.web.replicas) }}
+  selector:
+    matchLabels: *ref_0
   template:
     metadata:
       annotations:
         checksum/secret: '{{ include (print $.Template.BasePath "/taskcluster-auth-secret.yaml") . | sha256sum }}'
-      labels:
-        app.kubernetes.io/name: taskcluster-auth
-        app.kubernetes.io/instance: '{{ .Release.Name }}'
-        app.kubernetes.io/component: taskcluster-auth-web
-        app.kubernetes.io/part-of: taskcluster
-        app.kubernetes.io/managed-by: helm
+      labels: *ref_0
     spec:
       serviceAccountName: taskcluster-auth
       containers:

--- a/infrastructure/k8s/templates/taskcluster-auth-role.yaml
+++ b/infrastructure/k8s/templates/taskcluster-auth-role.yaml
@@ -2,6 +2,11 @@ kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: taskcluster-auth-secrets-read
+  labels:
+    app.kubernetes.io/name: taskcluster-auth
+    app.kubernetes.io/instance: '{{ .Release.Name }}'
+    app.kubernetes.io/component: taskcluster-auth-secrets
+    app.kubernetes.io/part-of: taskcluster
 rules:
   - apiGroups:
       - ''

--- a/infrastructure/k8s/templates/taskcluster-auth-rolebinding.yaml
+++ b/infrastructure/k8s/templates/taskcluster-auth-rolebinding.yaml
@@ -2,6 +2,11 @@ kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: taskcluster-auth-secrets-read
+  labels:
+    app.kubernetes.io/name: taskcluster-auth
+    app.kubernetes.io/instance: '{{ .Release.Name }}'
+    app.kubernetes.io/component: taskcluster-auth-secrets
+    app.kubernetes.io/part-of: taskcluster
 subjects:
   - kind: User
     name: taskcluster-auth

--- a/infrastructure/k8s/templates/taskcluster-auth-secret.yaml
+++ b/infrastructure/k8s/templates/taskcluster-auth-secret.yaml
@@ -3,6 +3,11 @@ kind: Secret
 type: Opaque
 metadata:
   name: taskcluster-auth
+  labels:
+    app.kubernetes.io/name: taskcluster-auth
+    app.kubernetes.io/instance: '{{ .Release.Name }}'
+    app.kubernetes.io/component: taskcluster-auth-secrets
+    app.kubernetes.io/part-of: taskcluster
 data:
   TASKCLUSTER_ROOT_URL: '{{ if typeIs "<nil>" .Values.rootUrl }}{{ else }}{{ .Values.rootUrl | toJson | trimAll "\"" | b64enc }}{{ end }}'
   CLIENT_TABLE_NAME: '{{ if typeIs "<nil>" .Values.auth.client_table_name }}{{ else }}{{ .Values.auth.client_table_name | toJson | trimAll "\"" | b64enc }}{{ end }}'

--- a/infrastructure/k8s/templates/taskcluster-auth-service-web.yaml
+++ b/infrastructure/k8s/templates/taskcluster-auth-service-web.yaml
@@ -2,13 +2,14 @@ kind: Service
 apiVersion: v1
 metadata:
   name: taskcluster-auth
-spec:
-  type: NodePort
-  selector:
+  labels: &ref_0
     app.kubernetes.io/name: taskcluster-auth
     app.kubernetes.io/instance: '{{ .Release.Name }}'
     app.kubernetes.io/component: taskcluster-auth-web
     app.kubernetes.io/part-of: taskcluster
+spec:
+  type: NodePort
+  selector: *ref_0
   ports:
     - protocol: TCP
       port: 80

--- a/infrastructure/k8s/templates/taskcluster-auth-serviceaccount.yaml
+++ b/infrastructure/k8s/templates/taskcluster-auth-serviceaccount.yaml
@@ -2,3 +2,8 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: taskcluster-auth
+  labels:
+    app.kubernetes.io/name: taskcluster-auth
+    app.kubernetes.io/instance: '{{ .Release.Name }}'
+    app.kubernetes.io/component: taskcluster-auth-secrets
+    app.kubernetes.io/part-of: taskcluster

--- a/infrastructure/k8s/templates/taskcluster-built-in-workers-deployment-server.yaml
+++ b/infrastructure/k8s/templates/taskcluster-built-in-workers-deployment-server.yaml
@@ -2,31 +2,20 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: taskcluster-built-in-workers-server
-  labels:
+  labels: &ref_0
     app.kubernetes.io/name: taskcluster-built-in-workers
     app.kubernetes.io/instance: '{{ .Release.Name }}'
     app.kubernetes.io/component: taskcluster-built-in-workers-server
     app.kubernetes.io/part-of: taskcluster
-    app.kubernetes.io/managed-by: helm
 spec:
-  selector:
-    matchLabels:
-      app.kubernetes.io/name: taskcluster-built-in-workers
-      app.kubernetes.io/instance: '{{ .Release.Name }}'
-      app.kubernetes.io/component: taskcluster-built-in-workers-server
-      app.kubernetes.io/part-of: taskcluster
-      app.kubernetes.io/managed-by: helm
   replicas: {{ int (.Values.built_in_workers.procs.server.replicas) }}
+  selector:
+    matchLabels: *ref_0
   template:
     metadata:
       annotations:
         checksum/secret: '{{ include (print $.Template.BasePath "/taskcluster-built-in-workers-secret.yaml") . | sha256sum }}'
-      labels:
-        app.kubernetes.io/name: taskcluster-built-in-workers
-        app.kubernetes.io/instance: '{{ .Release.Name }}'
-        app.kubernetes.io/component: taskcluster-built-in-workers-server
-        app.kubernetes.io/part-of: taskcluster
-        app.kubernetes.io/managed-by: helm
+      labels: *ref_0
     spec:
       serviceAccountName: taskcluster-built-in-workers
       containers:

--- a/infrastructure/k8s/templates/taskcluster-built-in-workers-role.yaml
+++ b/infrastructure/k8s/templates/taskcluster-built-in-workers-role.yaml
@@ -2,6 +2,11 @@ kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: taskcluster-built-in-workers-secrets-read
+  labels:
+    app.kubernetes.io/name: taskcluster-built-in-workers
+    app.kubernetes.io/instance: '{{ .Release.Name }}'
+    app.kubernetes.io/component: taskcluster-built-in-workers-secrets
+    app.kubernetes.io/part-of: taskcluster
 rules:
   - apiGroups:
       - ''

--- a/infrastructure/k8s/templates/taskcluster-built-in-workers-rolebinding.yaml
+++ b/infrastructure/k8s/templates/taskcluster-built-in-workers-rolebinding.yaml
@@ -2,6 +2,11 @@ kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: taskcluster-built-in-workers-secrets-read
+  labels:
+    app.kubernetes.io/name: taskcluster-built-in-workers
+    app.kubernetes.io/instance: '{{ .Release.Name }}'
+    app.kubernetes.io/component: taskcluster-built-in-workers-secrets
+    app.kubernetes.io/part-of: taskcluster
 subjects:
   - kind: User
     name: taskcluster-built-in-workers

--- a/infrastructure/k8s/templates/taskcluster-built-in-workers-secret.yaml
+++ b/infrastructure/k8s/templates/taskcluster-built-in-workers-secret.yaml
@@ -3,6 +3,11 @@ kind: Secret
 type: Opaque
 metadata:
   name: taskcluster-built-in-workers
+  labels:
+    app.kubernetes.io/name: taskcluster-built-in-workers
+    app.kubernetes.io/instance: '{{ .Release.Name }}'
+    app.kubernetes.io/component: taskcluster-built-in-workers-secrets
+    app.kubernetes.io/part-of: taskcluster
 data:
   TASKCLUSTER_ROOT_URL: '{{ if typeIs "<nil>" .Values.rootUrl }}{{ else }}{{ .Values.rootUrl | toJson | trimAll "\"" | b64enc }}{{ end }}'
   TASKCLUSTER_CLIENT_ID: '{{ if typeIs "<nil>" .Values.built_in_workers.taskcluster_client_id }}{{ else }}{{ .Values.built_in_workers.taskcluster_client_id | toJson | trimAll "\"" | b64enc }}{{ end }}'

--- a/infrastructure/k8s/templates/taskcluster-built-in-workers-serviceaccount.yaml
+++ b/infrastructure/k8s/templates/taskcluster-built-in-workers-serviceaccount.yaml
@@ -2,3 +2,8 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: taskcluster-built-in-workers
+  labels:
+    app.kubernetes.io/name: taskcluster-built-in-workers
+    app.kubernetes.io/instance: '{{ .Release.Name }}'
+    app.kubernetes.io/component: taskcluster-built-in-workers-secrets
+    app.kubernetes.io/part-of: taskcluster

--- a/infrastructure/k8s/templates/taskcluster-github-cron-sync.yaml
+++ b/infrastructure/k8s/templates/taskcluster-github-cron-sync.yaml
@@ -2,31 +2,20 @@ apiVersion: batch/v1beta1
 kind: CronJob
 metadata:
   name: taskcluster-github-sync
-  labels:
+  labels: &ref_0
     app.kubernetes.io/name: taskcluster-github
     app.kubernetes.io/instance: '{{ .Release.Name }}'
     app.kubernetes.io/component: taskcluster-github-sync
     app.kubernetes.io/part-of: taskcluster
-    app.kubernetes.io/managed-by: helm
 spec:
   schedule: 0 0 * * *
   jobTemplate:
     metadata:
-      labels:
-        app.kubernetes.io/name: taskcluster-github
-        app.kubernetes.io/instance: '{{ .Release.Name }}'
-        app.kubernetes.io/component: taskcluster-github-sync
-        app.kubernetes.io/part-of: taskcluster
-        app.kubernetes.io/managed-by: helm
+      labels: *ref_0
     spec:
       template:
         metadata:
-          labels:
-            app.kubernetes.io/name: taskcluster-github
-            app.kubernetes.io/instance: '{{ .Release.Name }}'
-            app.kubernetes.io/component: taskcluster-github-sync
-            app.kubernetes.io/part-of: taskcluster
-            app.kubernetes.io/managed-by: helm
+          labels: *ref_0
         spec:
           restartPolicy: OnFailure
           activeDeadlineSeconds: 86400

--- a/infrastructure/k8s/templates/taskcluster-github-deployment-web.yaml
+++ b/infrastructure/k8s/templates/taskcluster-github-deployment-web.yaml
@@ -2,31 +2,20 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: taskcluster-github-web
-  labels:
+  labels: &ref_0
     app.kubernetes.io/name: taskcluster-github
     app.kubernetes.io/instance: '{{ .Release.Name }}'
     app.kubernetes.io/component: taskcluster-github-web
     app.kubernetes.io/part-of: taskcluster
-    app.kubernetes.io/managed-by: helm
 spec:
-  selector:
-    matchLabels:
-      app.kubernetes.io/name: taskcluster-github
-      app.kubernetes.io/instance: '{{ .Release.Name }}'
-      app.kubernetes.io/component: taskcluster-github-web
-      app.kubernetes.io/part-of: taskcluster
-      app.kubernetes.io/managed-by: helm
   replicas: {{ int (.Values.github.procs.web.replicas) }}
+  selector:
+    matchLabels: *ref_0
   template:
     metadata:
       annotations:
         checksum/secret: '{{ include (print $.Template.BasePath "/taskcluster-github-secret.yaml") . | sha256sum }}'
-      labels:
-        app.kubernetes.io/name: taskcluster-github
-        app.kubernetes.io/instance: '{{ .Release.Name }}'
-        app.kubernetes.io/component: taskcluster-github-web
-        app.kubernetes.io/part-of: taskcluster
-        app.kubernetes.io/managed-by: helm
+      labels: *ref_0
     spec:
       serviceAccountName: taskcluster-github
       containers:

--- a/infrastructure/k8s/templates/taskcluster-github-deployment-worker.yaml
+++ b/infrastructure/k8s/templates/taskcluster-github-deployment-worker.yaml
@@ -2,31 +2,20 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: taskcluster-github-worker
-  labels:
+  labels: &ref_0
     app.kubernetes.io/name: taskcluster-github
     app.kubernetes.io/instance: '{{ .Release.Name }}'
     app.kubernetes.io/component: taskcluster-github-worker
     app.kubernetes.io/part-of: taskcluster
-    app.kubernetes.io/managed-by: helm
 spec:
-  selector:
-    matchLabels:
-      app.kubernetes.io/name: taskcluster-github
-      app.kubernetes.io/instance: '{{ .Release.Name }}'
-      app.kubernetes.io/component: taskcluster-github-worker
-      app.kubernetes.io/part-of: taskcluster
-      app.kubernetes.io/managed-by: helm
   replicas: {{ int (.Values.github.procs.worker.replicas) }}
+  selector:
+    matchLabels: *ref_0
   template:
     metadata:
       annotations:
         checksum/secret: '{{ include (print $.Template.BasePath "/taskcluster-github-secret.yaml") . | sha256sum }}'
-      labels:
-        app.kubernetes.io/name: taskcluster-github
-        app.kubernetes.io/instance: '{{ .Release.Name }}'
-        app.kubernetes.io/component: taskcluster-github-worker
-        app.kubernetes.io/part-of: taskcluster
-        app.kubernetes.io/managed-by: helm
+      labels: *ref_0
     spec:
       serviceAccountName: taskcluster-github
       containers:

--- a/infrastructure/k8s/templates/taskcluster-github-role.yaml
+++ b/infrastructure/k8s/templates/taskcluster-github-role.yaml
@@ -2,6 +2,11 @@ kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: taskcluster-github-secrets-read
+  labels:
+    app.kubernetes.io/name: taskcluster-github
+    app.kubernetes.io/instance: '{{ .Release.Name }}'
+    app.kubernetes.io/component: taskcluster-github-secrets
+    app.kubernetes.io/part-of: taskcluster
 rules:
   - apiGroups:
       - ''

--- a/infrastructure/k8s/templates/taskcluster-github-rolebinding.yaml
+++ b/infrastructure/k8s/templates/taskcluster-github-rolebinding.yaml
@@ -2,6 +2,11 @@ kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: taskcluster-github-secrets-read
+  labels:
+    app.kubernetes.io/name: taskcluster-github
+    app.kubernetes.io/instance: '{{ .Release.Name }}'
+    app.kubernetes.io/component: taskcluster-github-secrets
+    app.kubernetes.io/part-of: taskcluster
 subjects:
   - kind: User
     name: taskcluster-github

--- a/infrastructure/k8s/templates/taskcluster-github-secret.yaml
+++ b/infrastructure/k8s/templates/taskcluster-github-secret.yaml
@@ -3,6 +3,11 @@ kind: Secret
 type: Opaque
 metadata:
   name: taskcluster-github
+  labels:
+    app.kubernetes.io/name: taskcluster-github
+    app.kubernetes.io/instance: '{{ .Release.Name }}'
+    app.kubernetes.io/component: taskcluster-github-secrets
+    app.kubernetes.io/part-of: taskcluster
 data:
   BOT_USERNAME: '{{ if typeIs "<nil>" .Values.github.bot_username }}{{ else }}{{ .Values.github.bot_username | toJson | trimAll "\"" | b64enc }}{{ end }}'
   TASKCLUSTER_ROOT_URL: '{{ if typeIs "<nil>" .Values.rootUrl }}{{ else }}{{ .Values.rootUrl | toJson | trimAll "\"" | b64enc }}{{ end }}'

--- a/infrastructure/k8s/templates/taskcluster-github-service-web.yaml
+++ b/infrastructure/k8s/templates/taskcluster-github-service-web.yaml
@@ -2,13 +2,14 @@ kind: Service
 apiVersion: v1
 metadata:
   name: taskcluster-github
-spec:
-  type: NodePort
-  selector:
+  labels: &ref_0
     app.kubernetes.io/name: taskcluster-github
     app.kubernetes.io/instance: '{{ .Release.Name }}'
     app.kubernetes.io/component: taskcluster-github-web
     app.kubernetes.io/part-of: taskcluster
+spec:
+  type: NodePort
+  selector: *ref_0
   ports:
     - protocol: TCP
       port: 80

--- a/infrastructure/k8s/templates/taskcluster-github-serviceaccount.yaml
+++ b/infrastructure/k8s/templates/taskcluster-github-serviceaccount.yaml
@@ -2,3 +2,8 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: taskcluster-github
+  labels:
+    app.kubernetes.io/name: taskcluster-github
+    app.kubernetes.io/instance: '{{ .Release.Name }}'
+    app.kubernetes.io/component: taskcluster-github-secrets
+    app.kubernetes.io/part-of: taskcluster

--- a/infrastructure/k8s/templates/taskcluster-hooks-cron-expires.yaml
+++ b/infrastructure/k8s/templates/taskcluster-hooks-cron-expires.yaml
@@ -2,31 +2,20 @@ apiVersion: batch/v1beta1
 kind: CronJob
 metadata:
   name: taskcluster-hooks-expires
-  labels:
+  labels: &ref_0
     app.kubernetes.io/name: taskcluster-hooks
     app.kubernetes.io/instance: '{{ .Release.Name }}'
     app.kubernetes.io/component: taskcluster-hooks-expires
     app.kubernetes.io/part-of: taskcluster
-    app.kubernetes.io/managed-by: helm
 spec:
   schedule: 10 0 * * *
   jobTemplate:
     metadata:
-      labels:
-        app.kubernetes.io/name: taskcluster-hooks
-        app.kubernetes.io/instance: '{{ .Release.Name }}'
-        app.kubernetes.io/component: taskcluster-hooks-expires
-        app.kubernetes.io/part-of: taskcluster
-        app.kubernetes.io/managed-by: helm
+      labels: *ref_0
     spec:
       template:
         metadata:
-          labels:
-            app.kubernetes.io/name: taskcluster-hooks
-            app.kubernetes.io/instance: '{{ .Release.Name }}'
-            app.kubernetes.io/component: taskcluster-hooks-expires
-            app.kubernetes.io/part-of: taskcluster
-            app.kubernetes.io/managed-by: helm
+          labels: *ref_0
         spec:
           restartPolicy: OnFailure
           activeDeadlineSeconds: 86400

--- a/infrastructure/k8s/templates/taskcluster-hooks-deployment-listeners.yaml
+++ b/infrastructure/k8s/templates/taskcluster-hooks-deployment-listeners.yaml
@@ -2,31 +2,20 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: taskcluster-hooks-listeners
-  labels:
+  labels: &ref_0
     app.kubernetes.io/name: taskcluster-hooks
     app.kubernetes.io/instance: '{{ .Release.Name }}'
     app.kubernetes.io/component: taskcluster-hooks-listeners
     app.kubernetes.io/part-of: taskcluster
-    app.kubernetes.io/managed-by: helm
 spec:
-  selector:
-    matchLabels:
-      app.kubernetes.io/name: taskcluster-hooks
-      app.kubernetes.io/instance: '{{ .Release.Name }}'
-      app.kubernetes.io/component: taskcluster-hooks-listeners
-      app.kubernetes.io/part-of: taskcluster
-      app.kubernetes.io/managed-by: helm
   replicas: {{ int (.Values.hooks.procs.listeners.replicas) }}
+  selector:
+    matchLabels: *ref_0
   template:
     metadata:
       annotations:
         checksum/secret: '{{ include (print $.Template.BasePath "/taskcluster-hooks-secret.yaml") . | sha256sum }}'
-      labels:
-        app.kubernetes.io/name: taskcluster-hooks
-        app.kubernetes.io/instance: '{{ .Release.Name }}'
-        app.kubernetes.io/component: taskcluster-hooks-listeners
-        app.kubernetes.io/part-of: taskcluster
-        app.kubernetes.io/managed-by: helm
+      labels: *ref_0
     spec:
       serviceAccountName: taskcluster-hooks
       containers:

--- a/infrastructure/k8s/templates/taskcluster-hooks-deployment-scheduler.yaml
+++ b/infrastructure/k8s/templates/taskcluster-hooks-deployment-scheduler.yaml
@@ -2,31 +2,20 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: taskcluster-hooks-scheduler
-  labels:
+  labels: &ref_0
     app.kubernetes.io/name: taskcluster-hooks
     app.kubernetes.io/instance: '{{ .Release.Name }}'
     app.kubernetes.io/component: taskcluster-hooks-scheduler
     app.kubernetes.io/part-of: taskcluster
-    app.kubernetes.io/managed-by: helm
 spec:
-  selector:
-    matchLabels:
-      app.kubernetes.io/name: taskcluster-hooks
-      app.kubernetes.io/instance: '{{ .Release.Name }}'
-      app.kubernetes.io/component: taskcluster-hooks-scheduler
-      app.kubernetes.io/part-of: taskcluster
-      app.kubernetes.io/managed-by: helm
   replicas: {{ int (.Values.hooks.procs.scheduler.replicas) }}
+  selector:
+    matchLabels: *ref_0
   template:
     metadata:
       annotations:
         checksum/secret: '{{ include (print $.Template.BasePath "/taskcluster-hooks-secret.yaml") . | sha256sum }}'
-      labels:
-        app.kubernetes.io/name: taskcluster-hooks
-        app.kubernetes.io/instance: '{{ .Release.Name }}'
-        app.kubernetes.io/component: taskcluster-hooks-scheduler
-        app.kubernetes.io/part-of: taskcluster
-        app.kubernetes.io/managed-by: helm
+      labels: *ref_0
     spec:
       serviceAccountName: taskcluster-hooks
       containers:

--- a/infrastructure/k8s/templates/taskcluster-hooks-deployment-web.yaml
+++ b/infrastructure/k8s/templates/taskcluster-hooks-deployment-web.yaml
@@ -2,31 +2,20 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: taskcluster-hooks-web
-  labels:
+  labels: &ref_0
     app.kubernetes.io/name: taskcluster-hooks
     app.kubernetes.io/instance: '{{ .Release.Name }}'
     app.kubernetes.io/component: taskcluster-hooks-web
     app.kubernetes.io/part-of: taskcluster
-    app.kubernetes.io/managed-by: helm
 spec:
-  selector:
-    matchLabels:
-      app.kubernetes.io/name: taskcluster-hooks
-      app.kubernetes.io/instance: '{{ .Release.Name }}'
-      app.kubernetes.io/component: taskcluster-hooks-web
-      app.kubernetes.io/part-of: taskcluster
-      app.kubernetes.io/managed-by: helm
   replicas: {{ int (.Values.hooks.procs.web.replicas) }}
+  selector:
+    matchLabels: *ref_0
   template:
     metadata:
       annotations:
         checksum/secret: '{{ include (print $.Template.BasePath "/taskcluster-hooks-secret.yaml") . | sha256sum }}'
-      labels:
-        app.kubernetes.io/name: taskcluster-hooks
-        app.kubernetes.io/instance: '{{ .Release.Name }}'
-        app.kubernetes.io/component: taskcluster-hooks-web
-        app.kubernetes.io/part-of: taskcluster
-        app.kubernetes.io/managed-by: helm
+      labels: *ref_0
     spec:
       serviceAccountName: taskcluster-hooks
       containers:

--- a/infrastructure/k8s/templates/taskcluster-hooks-role.yaml
+++ b/infrastructure/k8s/templates/taskcluster-hooks-role.yaml
@@ -2,6 +2,11 @@ kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: taskcluster-hooks-secrets-read
+  labels:
+    app.kubernetes.io/name: taskcluster-hooks
+    app.kubernetes.io/instance: '{{ .Release.Name }}'
+    app.kubernetes.io/component: taskcluster-hooks-secrets
+    app.kubernetes.io/part-of: taskcluster
 rules:
   - apiGroups:
       - ''

--- a/infrastructure/k8s/templates/taskcluster-hooks-rolebinding.yaml
+++ b/infrastructure/k8s/templates/taskcluster-hooks-rolebinding.yaml
@@ -2,6 +2,11 @@ kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: taskcluster-hooks-secrets-read
+  labels:
+    app.kubernetes.io/name: taskcluster-hooks
+    app.kubernetes.io/instance: '{{ .Release.Name }}'
+    app.kubernetes.io/component: taskcluster-hooks-secrets
+    app.kubernetes.io/part-of: taskcluster
 subjects:
   - kind: User
     name: taskcluster-hooks

--- a/infrastructure/k8s/templates/taskcluster-hooks-secret.yaml
+++ b/infrastructure/k8s/templates/taskcluster-hooks-secret.yaml
@@ -3,6 +3,11 @@ kind: Secret
 type: Opaque
 metadata:
   name: taskcluster-hooks
+  labels:
+    app.kubernetes.io/name: taskcluster-hooks
+    app.kubernetes.io/instance: '{{ .Release.Name }}'
+    app.kubernetes.io/component: taskcluster-hooks-secrets
+    app.kubernetes.io/part-of: taskcluster
 data:
   HOOK_TABLE_NAME: '{{ if typeIs "<nil>" .Values.hooks.hook_table_name }}{{ else }}{{ .Values.hooks.hook_table_name | toJson | trimAll "\"" | b64enc }}{{ end }}'
   LASTFIRE_TABLE_NAME: '{{ if typeIs "<nil>" .Values.hooks.lastfire_table_name }}{{ else }}{{ .Values.hooks.lastfire_table_name | toJson | trimAll "\"" | b64enc }}{{ end }}'

--- a/infrastructure/k8s/templates/taskcluster-hooks-service-web.yaml
+++ b/infrastructure/k8s/templates/taskcluster-hooks-service-web.yaml
@@ -2,13 +2,14 @@ kind: Service
 apiVersion: v1
 metadata:
   name: taskcluster-hooks
-spec:
-  type: NodePort
-  selector:
+  labels: &ref_0
     app.kubernetes.io/name: taskcluster-hooks
     app.kubernetes.io/instance: '{{ .Release.Name }}'
     app.kubernetes.io/component: taskcluster-hooks-web
     app.kubernetes.io/part-of: taskcluster
+spec:
+  type: NodePort
+  selector: *ref_0
   ports:
     - protocol: TCP
       port: 80

--- a/infrastructure/k8s/templates/taskcluster-hooks-serviceaccount.yaml
+++ b/infrastructure/k8s/templates/taskcluster-hooks-serviceaccount.yaml
@@ -2,3 +2,8 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: taskcluster-hooks
+  labels:
+    app.kubernetes.io/name: taskcluster-hooks
+    app.kubernetes.io/instance: '{{ .Release.Name }}'
+    app.kubernetes.io/component: taskcluster-hooks-secrets
+    app.kubernetes.io/part-of: taskcluster

--- a/infrastructure/k8s/templates/taskcluster-index-cron-expire.yaml
+++ b/infrastructure/k8s/templates/taskcluster-index-cron-expire.yaml
@@ -2,31 +2,20 @@ apiVersion: batch/v1beta1
 kind: CronJob
 metadata:
   name: taskcluster-index-expire
-  labels:
+  labels: &ref_0
     app.kubernetes.io/name: taskcluster-index
     app.kubernetes.io/instance: '{{ .Release.Name }}'
     app.kubernetes.io/component: taskcluster-index-expire
     app.kubernetes.io/part-of: taskcluster
-    app.kubernetes.io/managed-by: helm
 spec:
   schedule: 0 0 * * *
   jobTemplate:
     metadata:
-      labels:
-        app.kubernetes.io/name: taskcluster-index
-        app.kubernetes.io/instance: '{{ .Release.Name }}'
-        app.kubernetes.io/component: taskcluster-index-expire
-        app.kubernetes.io/part-of: taskcluster
-        app.kubernetes.io/managed-by: helm
+      labels: *ref_0
     spec:
       template:
         metadata:
-          labels:
-            app.kubernetes.io/name: taskcluster-index
-            app.kubernetes.io/instance: '{{ .Release.Name }}'
-            app.kubernetes.io/component: taskcluster-index-expire
-            app.kubernetes.io/part-of: taskcluster
-            app.kubernetes.io/managed-by: helm
+          labels: *ref_0
         spec:
           restartPolicy: OnFailure
           activeDeadlineSeconds: 86400

--- a/infrastructure/k8s/templates/taskcluster-index-deployment-handlers.yaml
+++ b/infrastructure/k8s/templates/taskcluster-index-deployment-handlers.yaml
@@ -2,31 +2,20 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: taskcluster-index-handlers
-  labels:
+  labels: &ref_0
     app.kubernetes.io/name: taskcluster-index
     app.kubernetes.io/instance: '{{ .Release.Name }}'
     app.kubernetes.io/component: taskcluster-index-handlers
     app.kubernetes.io/part-of: taskcluster
-    app.kubernetes.io/managed-by: helm
 spec:
-  selector:
-    matchLabels:
-      app.kubernetes.io/name: taskcluster-index
-      app.kubernetes.io/instance: '{{ .Release.Name }}'
-      app.kubernetes.io/component: taskcluster-index-handlers
-      app.kubernetes.io/part-of: taskcluster
-      app.kubernetes.io/managed-by: helm
   replicas: {{ int (.Values.index.procs.handlers.replicas) }}
+  selector:
+    matchLabels: *ref_0
   template:
     metadata:
       annotations:
         checksum/secret: '{{ include (print $.Template.BasePath "/taskcluster-index-secret.yaml") . | sha256sum }}'
-      labels:
-        app.kubernetes.io/name: taskcluster-index
-        app.kubernetes.io/instance: '{{ .Release.Name }}'
-        app.kubernetes.io/component: taskcluster-index-handlers
-        app.kubernetes.io/part-of: taskcluster
-        app.kubernetes.io/managed-by: helm
+      labels: *ref_0
     spec:
       serviceAccountName: taskcluster-index
       containers:

--- a/infrastructure/k8s/templates/taskcluster-index-deployment-web.yaml
+++ b/infrastructure/k8s/templates/taskcluster-index-deployment-web.yaml
@@ -2,31 +2,20 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: taskcluster-index-web
-  labels:
+  labels: &ref_0
     app.kubernetes.io/name: taskcluster-index
     app.kubernetes.io/instance: '{{ .Release.Name }}'
     app.kubernetes.io/component: taskcluster-index-web
     app.kubernetes.io/part-of: taskcluster
-    app.kubernetes.io/managed-by: helm
 spec:
-  selector:
-    matchLabels:
-      app.kubernetes.io/name: taskcluster-index
-      app.kubernetes.io/instance: '{{ .Release.Name }}'
-      app.kubernetes.io/component: taskcluster-index-web
-      app.kubernetes.io/part-of: taskcluster
-      app.kubernetes.io/managed-by: helm
   replicas: {{ int (.Values.index.procs.web.replicas) }}
+  selector:
+    matchLabels: *ref_0
   template:
     metadata:
       annotations:
         checksum/secret: '{{ include (print $.Template.BasePath "/taskcluster-index-secret.yaml") . | sha256sum }}'
-      labels:
-        app.kubernetes.io/name: taskcluster-index
-        app.kubernetes.io/instance: '{{ .Release.Name }}'
-        app.kubernetes.io/component: taskcluster-index-web
-        app.kubernetes.io/part-of: taskcluster
-        app.kubernetes.io/managed-by: helm
+      labels: *ref_0
     spec:
       serviceAccountName: taskcluster-index
       containers:

--- a/infrastructure/k8s/templates/taskcluster-index-role.yaml
+++ b/infrastructure/k8s/templates/taskcluster-index-role.yaml
@@ -2,6 +2,11 @@ kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: taskcluster-index-secrets-read
+  labels:
+    app.kubernetes.io/name: taskcluster-index
+    app.kubernetes.io/instance: '{{ .Release.Name }}'
+    app.kubernetes.io/component: taskcluster-index-secrets
+    app.kubernetes.io/part-of: taskcluster
 rules:
   - apiGroups:
       - ''

--- a/infrastructure/k8s/templates/taskcluster-index-rolebinding.yaml
+++ b/infrastructure/k8s/templates/taskcluster-index-rolebinding.yaml
@@ -2,6 +2,11 @@ kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: taskcluster-index-secrets-read
+  labels:
+    app.kubernetes.io/name: taskcluster-index
+    app.kubernetes.io/instance: '{{ .Release.Name }}'
+    app.kubernetes.io/component: taskcluster-index-secrets
+    app.kubernetes.io/part-of: taskcluster
 subjects:
   - kind: User
     name: taskcluster-index

--- a/infrastructure/k8s/templates/taskcluster-index-secret.yaml
+++ b/infrastructure/k8s/templates/taskcluster-index-secret.yaml
@@ -3,6 +3,11 @@ kind: Secret
 type: Opaque
 metadata:
   name: taskcluster-index
+  labels:
+    app.kubernetes.io/name: taskcluster-index
+    app.kubernetes.io/instance: '{{ .Release.Name }}'
+    app.kubernetes.io/component: taskcluster-index-secrets
+    app.kubernetes.io/part-of: taskcluster
 data:
   AZURE_ACCOUNT_ID: '{{ if typeIs "<nil>" .Values.azureAccountId }}{{ else }}{{ .Values.azureAccountId | toJson | trimAll "\"" | b64enc }}{{ end }}'
   LEVEL: '{{ if typeIs "<nil>" .Values.index.level }}{{ else }}{{ .Values.index.level | toJson | trimAll "\"" | b64enc }}{{ end }}'

--- a/infrastructure/k8s/templates/taskcluster-index-service-web.yaml
+++ b/infrastructure/k8s/templates/taskcluster-index-service-web.yaml
@@ -2,13 +2,14 @@ kind: Service
 apiVersion: v1
 metadata:
   name: taskcluster-index
-spec:
-  type: NodePort
-  selector:
+  labels: &ref_0
     app.kubernetes.io/name: taskcluster-index
     app.kubernetes.io/instance: '{{ .Release.Name }}'
     app.kubernetes.io/component: taskcluster-index-web
     app.kubernetes.io/part-of: taskcluster
+spec:
+  type: NodePort
+  selector: *ref_0
   ports:
     - protocol: TCP
       port: 80

--- a/infrastructure/k8s/templates/taskcluster-index-serviceaccount.yaml
+++ b/infrastructure/k8s/templates/taskcluster-index-serviceaccount.yaml
@@ -2,3 +2,8 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: taskcluster-index
+  labels:
+    app.kubernetes.io/name: taskcluster-index
+    app.kubernetes.io/instance: '{{ .Release.Name }}'
+    app.kubernetes.io/component: taskcluster-index-secrets
+    app.kubernetes.io/part-of: taskcluster

--- a/infrastructure/k8s/templates/taskcluster-notify-deployment-handler.yaml
+++ b/infrastructure/k8s/templates/taskcluster-notify-deployment-handler.yaml
@@ -2,31 +2,20 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: taskcluster-notify-handler
-  labels:
+  labels: &ref_0
     app.kubernetes.io/name: taskcluster-notify
     app.kubernetes.io/instance: '{{ .Release.Name }}'
     app.kubernetes.io/component: taskcluster-notify-handler
     app.kubernetes.io/part-of: taskcluster
-    app.kubernetes.io/managed-by: helm
 spec:
-  selector:
-    matchLabels:
-      app.kubernetes.io/name: taskcluster-notify
-      app.kubernetes.io/instance: '{{ .Release.Name }}'
-      app.kubernetes.io/component: taskcluster-notify-handler
-      app.kubernetes.io/part-of: taskcluster
-      app.kubernetes.io/managed-by: helm
   replicas: {{ int (.Values.notify.procs.handler.replicas) }}
+  selector:
+    matchLabels: *ref_0
   template:
     metadata:
       annotations:
         checksum/secret: '{{ include (print $.Template.BasePath "/taskcluster-notify-secret.yaml") . | sha256sum }}'
-      labels:
-        app.kubernetes.io/name: taskcluster-notify
-        app.kubernetes.io/instance: '{{ .Release.Name }}'
-        app.kubernetes.io/component: taskcluster-notify-handler
-        app.kubernetes.io/part-of: taskcluster
-        app.kubernetes.io/managed-by: helm
+      labels: *ref_0
     spec:
       serviceAccountName: taskcluster-notify
       containers:

--- a/infrastructure/k8s/templates/taskcluster-notify-deployment-irc.yaml
+++ b/infrastructure/k8s/templates/taskcluster-notify-deployment-irc.yaml
@@ -2,31 +2,20 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: taskcluster-notify-irc
-  labels:
+  labels: &ref_0
     app.kubernetes.io/name: taskcluster-notify
     app.kubernetes.io/instance: '{{ .Release.Name }}'
     app.kubernetes.io/component: taskcluster-notify-irc
     app.kubernetes.io/part-of: taskcluster
-    app.kubernetes.io/managed-by: helm
 spec:
-  selector:
-    matchLabels:
-      app.kubernetes.io/name: taskcluster-notify
-      app.kubernetes.io/instance: '{{ .Release.Name }}'
-      app.kubernetes.io/component: taskcluster-notify-irc
-      app.kubernetes.io/part-of: taskcluster
-      app.kubernetes.io/managed-by: helm
   replicas: {{ int (.Values.notify.procs.irc.replicas) }}
+  selector:
+    matchLabels: *ref_0
   template:
     metadata:
       annotations:
         checksum/secret: '{{ include (print $.Template.BasePath "/taskcluster-notify-secret.yaml") . | sha256sum }}'
-      labels:
-        app.kubernetes.io/name: taskcluster-notify
-        app.kubernetes.io/instance: '{{ .Release.Name }}'
-        app.kubernetes.io/component: taskcluster-notify-irc
-        app.kubernetes.io/part-of: taskcluster
-        app.kubernetes.io/managed-by: helm
+      labels: *ref_0
     spec:
       serviceAccountName: taskcluster-notify
       containers:

--- a/infrastructure/k8s/templates/taskcluster-notify-deployment-web.yaml
+++ b/infrastructure/k8s/templates/taskcluster-notify-deployment-web.yaml
@@ -2,31 +2,20 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: taskcluster-notify-web
-  labels:
+  labels: &ref_0
     app.kubernetes.io/name: taskcluster-notify
     app.kubernetes.io/instance: '{{ .Release.Name }}'
     app.kubernetes.io/component: taskcluster-notify-web
     app.kubernetes.io/part-of: taskcluster
-    app.kubernetes.io/managed-by: helm
 spec:
-  selector:
-    matchLabels:
-      app.kubernetes.io/name: taskcluster-notify
-      app.kubernetes.io/instance: '{{ .Release.Name }}'
-      app.kubernetes.io/component: taskcluster-notify-web
-      app.kubernetes.io/part-of: taskcluster
-      app.kubernetes.io/managed-by: helm
   replicas: {{ int (.Values.notify.procs.web.replicas) }}
+  selector:
+    matchLabels: *ref_0
   template:
     metadata:
       annotations:
         checksum/secret: '{{ include (print $.Template.BasePath "/taskcluster-notify-secret.yaml") . | sha256sum }}'
-      labels:
-        app.kubernetes.io/name: taskcluster-notify
-        app.kubernetes.io/instance: '{{ .Release.Name }}'
-        app.kubernetes.io/component: taskcluster-notify-web
-        app.kubernetes.io/part-of: taskcluster
-        app.kubernetes.io/managed-by: helm
+      labels: *ref_0
     spec:
       serviceAccountName: taskcluster-notify
       containers:

--- a/infrastructure/k8s/templates/taskcluster-notify-role.yaml
+++ b/infrastructure/k8s/templates/taskcluster-notify-role.yaml
@@ -2,6 +2,11 @@ kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: taskcluster-notify-secrets-read
+  labels:
+    app.kubernetes.io/name: taskcluster-notify
+    app.kubernetes.io/instance: '{{ .Release.Name }}'
+    app.kubernetes.io/component: taskcluster-notify-secrets
+    app.kubernetes.io/part-of: taskcluster
 rules:
   - apiGroups:
       - ''

--- a/infrastructure/k8s/templates/taskcluster-notify-rolebinding.yaml
+++ b/infrastructure/k8s/templates/taskcluster-notify-rolebinding.yaml
@@ -2,6 +2,11 @@ kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: taskcluster-notify-secrets-read
+  labels:
+    app.kubernetes.io/name: taskcluster-notify
+    app.kubernetes.io/instance: '{{ .Release.Name }}'
+    app.kubernetes.io/component: taskcluster-notify-secrets
+    app.kubernetes.io/part-of: taskcluster
 subjects:
   - kind: User
     name: taskcluster-notify

--- a/infrastructure/k8s/templates/taskcluster-notify-secret.yaml
+++ b/infrastructure/k8s/templates/taskcluster-notify-secret.yaml
@@ -3,6 +3,11 @@ kind: Secret
 type: Opaque
 metadata:
   name: taskcluster-notify
+  labels:
+    app.kubernetes.io/name: taskcluster-notify
+    app.kubernetes.io/instance: '{{ .Release.Name }}'
+    app.kubernetes.io/component: taskcluster-notify-secrets
+    app.kubernetes.io/part-of: taskcluster
 data:
   EMAIL_SOURCE_ADDRESS: '{{ if typeIs "<nil>" .Values.notify.email_source_address }}{{ else }}{{ .Values.notify.email_source_address | toJson | trimAll "\"" | b64enc }}{{ end }}'
   EMAIL_BLACKLIST: '{{ if typeIs "<nil>" .Values.notify.email_blacklist }}{{ else }}{{ .Values.notify.email_blacklist | toJson | trimAll "\"" | b64enc }}{{ end }}'

--- a/infrastructure/k8s/templates/taskcluster-notify-service-web.yaml
+++ b/infrastructure/k8s/templates/taskcluster-notify-service-web.yaml
@@ -2,13 +2,14 @@ kind: Service
 apiVersion: v1
 metadata:
   name: taskcluster-notify
-spec:
-  type: NodePort
-  selector:
+  labels: &ref_0
     app.kubernetes.io/name: taskcluster-notify
     app.kubernetes.io/instance: '{{ .Release.Name }}'
     app.kubernetes.io/component: taskcluster-notify-web
     app.kubernetes.io/part-of: taskcluster
+spec:
+  type: NodePort
+  selector: *ref_0
   ports:
     - protocol: TCP
       port: 80

--- a/infrastructure/k8s/templates/taskcluster-notify-serviceaccount.yaml
+++ b/infrastructure/k8s/templates/taskcluster-notify-serviceaccount.yaml
@@ -2,3 +2,8 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: taskcluster-notify
+  labels:
+    app.kubernetes.io/name: taskcluster-notify
+    app.kubernetes.io/instance: '{{ .Release.Name }}'
+    app.kubernetes.io/component: taskcluster-notify-secrets
+    app.kubernetes.io/part-of: taskcluster

--- a/infrastructure/k8s/templates/taskcluster-purge-cache-cron-expireCachePurges.yaml
+++ b/infrastructure/k8s/templates/taskcluster-purge-cache-cron-expireCachePurges.yaml
@@ -2,31 +2,20 @@ apiVersion: batch/v1beta1
 kind: CronJob
 metadata:
   name: taskcluster-purge-cache-expirecachepurges
-  labels:
+  labels: &ref_0
     app.kubernetes.io/name: taskcluster-purge-cache
     app.kubernetes.io/instance: '{{ .Release.Name }}'
     app.kubernetes.io/component: taskcluster-purge-cache-expirecachepurges
     app.kubernetes.io/part-of: taskcluster
-    app.kubernetes.io/managed-by: helm
 spec:
   schedule: 0 0 * * *
   jobTemplate:
     metadata:
-      labels:
-        app.kubernetes.io/name: taskcluster-purge-cache
-        app.kubernetes.io/instance: '{{ .Release.Name }}'
-        app.kubernetes.io/component: taskcluster-purge-cache-expirecachepurges
-        app.kubernetes.io/part-of: taskcluster
-        app.kubernetes.io/managed-by: helm
+      labels: *ref_0
     spec:
       template:
         metadata:
-          labels:
-            app.kubernetes.io/name: taskcluster-purge-cache
-            app.kubernetes.io/instance: '{{ .Release.Name }}'
-            app.kubernetes.io/component: taskcluster-purge-cache-expirecachepurges
-            app.kubernetes.io/part-of: taskcluster
-            app.kubernetes.io/managed-by: helm
+          labels: *ref_0
         spec:
           restartPolicy: OnFailure
           activeDeadlineSeconds: 86400

--- a/infrastructure/k8s/templates/taskcluster-purge-cache-deployment-web.yaml
+++ b/infrastructure/k8s/templates/taskcluster-purge-cache-deployment-web.yaml
@@ -2,31 +2,20 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: taskcluster-purge-cache-web
-  labels:
+  labels: &ref_0
     app.kubernetes.io/name: taskcluster-purge-cache
     app.kubernetes.io/instance: '{{ .Release.Name }}'
     app.kubernetes.io/component: taskcluster-purge-cache-web
     app.kubernetes.io/part-of: taskcluster
-    app.kubernetes.io/managed-by: helm
 spec:
-  selector:
-    matchLabels:
-      app.kubernetes.io/name: taskcluster-purge-cache
-      app.kubernetes.io/instance: '{{ .Release.Name }}'
-      app.kubernetes.io/component: taskcluster-purge-cache-web
-      app.kubernetes.io/part-of: taskcluster
-      app.kubernetes.io/managed-by: helm
   replicas: {{ int (.Values.purge_cache.procs.web.replicas) }}
+  selector:
+    matchLabels: *ref_0
   template:
     metadata:
       annotations:
         checksum/secret: '{{ include (print $.Template.BasePath "/taskcluster-purge-cache-secret.yaml") . | sha256sum }}'
-      labels:
-        app.kubernetes.io/name: taskcluster-purge-cache
-        app.kubernetes.io/instance: '{{ .Release.Name }}'
-        app.kubernetes.io/component: taskcluster-purge-cache-web
-        app.kubernetes.io/part-of: taskcluster
-        app.kubernetes.io/managed-by: helm
+      labels: *ref_0
     spec:
       serviceAccountName: taskcluster-purge-cache
       containers:

--- a/infrastructure/k8s/templates/taskcluster-purge-cache-role.yaml
+++ b/infrastructure/k8s/templates/taskcluster-purge-cache-role.yaml
@@ -2,6 +2,11 @@ kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: taskcluster-purge-cache-secrets-read
+  labels:
+    app.kubernetes.io/name: taskcluster-purge-cache
+    app.kubernetes.io/instance: '{{ .Release.Name }}'
+    app.kubernetes.io/component: taskcluster-purge-cache-secrets
+    app.kubernetes.io/part-of: taskcluster
 rules:
   - apiGroups:
       - ''

--- a/infrastructure/k8s/templates/taskcluster-purge-cache-rolebinding.yaml
+++ b/infrastructure/k8s/templates/taskcluster-purge-cache-rolebinding.yaml
@@ -2,6 +2,11 @@ kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: taskcluster-purge-cache-secrets-read
+  labels:
+    app.kubernetes.io/name: taskcluster-purge-cache
+    app.kubernetes.io/instance: '{{ .Release.Name }}'
+    app.kubernetes.io/component: taskcluster-purge-cache-secrets
+    app.kubernetes.io/part-of: taskcluster
 subjects:
   - kind: User
     name: taskcluster-purge-cache

--- a/infrastructure/k8s/templates/taskcluster-purge-cache-secret.yaml
+++ b/infrastructure/k8s/templates/taskcluster-purge-cache-secret.yaml
@@ -3,6 +3,11 @@ kind: Secret
 type: Opaque
 metadata:
   name: taskcluster-purge-cache
+  labels:
+    app.kubernetes.io/name: taskcluster-purge-cache
+    app.kubernetes.io/instance: '{{ .Release.Name }}'
+    app.kubernetes.io/component: taskcluster-purge-cache-secrets
+    app.kubernetes.io/part-of: taskcluster
 data:
   LEVEL: '{{ if typeIs "<nil>" .Values.purge_cache.level }}{{ else }}{{ .Values.purge_cache.level | toJson | trimAll "\"" | b64enc }}{{ end }}'
   FORCE_SSL: '{{ if typeIs "<nil>" .Values.forceSSL }}{{ else }}{{ .Values.forceSSL | toJson | trimAll "\"" | b64enc }}{{ end }}'

--- a/infrastructure/k8s/templates/taskcluster-purge-cache-service-web.yaml
+++ b/infrastructure/k8s/templates/taskcluster-purge-cache-service-web.yaml
@@ -2,13 +2,14 @@ kind: Service
 apiVersion: v1
 metadata:
   name: taskcluster-purge-cache
-spec:
-  type: NodePort
-  selector:
+  labels: &ref_0
     app.kubernetes.io/name: taskcluster-purge-cache
     app.kubernetes.io/instance: '{{ .Release.Name }}'
     app.kubernetes.io/component: taskcluster-purge-cache-web
     app.kubernetes.io/part-of: taskcluster
+spec:
+  type: NodePort
+  selector: *ref_0
   ports:
     - protocol: TCP
       port: 80

--- a/infrastructure/k8s/templates/taskcluster-purge-cache-serviceaccount.yaml
+++ b/infrastructure/k8s/templates/taskcluster-purge-cache-serviceaccount.yaml
@@ -2,3 +2,8 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: taskcluster-purge-cache
+  labels:
+    app.kubernetes.io/name: taskcluster-purge-cache
+    app.kubernetes.io/instance: '{{ .Release.Name }}'
+    app.kubernetes.io/component: taskcluster-purge-cache-secrets
+    app.kubernetes.io/part-of: taskcluster

--- a/infrastructure/k8s/templates/taskcluster-queue-cron-expireArtifacts.yaml
+++ b/infrastructure/k8s/templates/taskcluster-queue-cron-expireArtifacts.yaml
@@ -2,31 +2,20 @@ apiVersion: batch/v1beta1
 kind: CronJob
 metadata:
   name: taskcluster-queue-expireartifacts
-  labels:
+  labels: &ref_0
     app.kubernetes.io/name: taskcluster-queue
     app.kubernetes.io/instance: '{{ .Release.Name }}'
     app.kubernetes.io/component: taskcluster-queue-expireartifacts
     app.kubernetes.io/part-of: taskcluster
-    app.kubernetes.io/managed-by: helm
 spec:
   schedule: 0 0 * * *
   jobTemplate:
     metadata:
-      labels:
-        app.kubernetes.io/name: taskcluster-queue
-        app.kubernetes.io/instance: '{{ .Release.Name }}'
-        app.kubernetes.io/component: taskcluster-queue-expireartifacts
-        app.kubernetes.io/part-of: taskcluster
-        app.kubernetes.io/managed-by: helm
+      labels: *ref_0
     spec:
       template:
         metadata:
-          labels:
-            app.kubernetes.io/name: taskcluster-queue
-            app.kubernetes.io/instance: '{{ .Release.Name }}'
-            app.kubernetes.io/component: taskcluster-queue-expireartifacts
-            app.kubernetes.io/part-of: taskcluster
-            app.kubernetes.io/managed-by: helm
+          labels: *ref_0
         spec:
           restartPolicy: OnFailure
           activeDeadlineSeconds: 86400

--- a/infrastructure/k8s/templates/taskcluster-queue-cron-expireQueues.yaml
+++ b/infrastructure/k8s/templates/taskcluster-queue-cron-expireQueues.yaml
@@ -2,31 +2,20 @@ apiVersion: batch/v1beta1
 kind: CronJob
 metadata:
   name: taskcluster-queue-expirequeues
-  labels:
+  labels: &ref_0
     app.kubernetes.io/name: taskcluster-queue
     app.kubernetes.io/instance: '{{ .Release.Name }}'
     app.kubernetes.io/component: taskcluster-queue-expirequeues
     app.kubernetes.io/part-of: taskcluster
-    app.kubernetes.io/managed-by: helm
 spec:
   schedule: 0 0 * * *
   jobTemplate:
     metadata:
-      labels:
-        app.kubernetes.io/name: taskcluster-queue
-        app.kubernetes.io/instance: '{{ .Release.Name }}'
-        app.kubernetes.io/component: taskcluster-queue-expirequeues
-        app.kubernetes.io/part-of: taskcluster
-        app.kubernetes.io/managed-by: helm
+      labels: *ref_0
     spec:
       template:
         metadata:
-          labels:
-            app.kubernetes.io/name: taskcluster-queue
-            app.kubernetes.io/instance: '{{ .Release.Name }}'
-            app.kubernetes.io/component: taskcluster-queue-expirequeues
-            app.kubernetes.io/part-of: taskcluster
-            app.kubernetes.io/managed-by: helm
+          labels: *ref_0
         spec:
           restartPolicy: OnFailure
           activeDeadlineSeconds: 86400

--- a/infrastructure/k8s/templates/taskcluster-queue-cron-expireTask.yaml
+++ b/infrastructure/k8s/templates/taskcluster-queue-cron-expireTask.yaml
@@ -2,31 +2,20 @@ apiVersion: batch/v1beta1
 kind: CronJob
 metadata:
   name: taskcluster-queue-expiretask
-  labels:
+  labels: &ref_0
     app.kubernetes.io/name: taskcluster-queue
     app.kubernetes.io/instance: '{{ .Release.Name }}'
     app.kubernetes.io/component: taskcluster-queue-expiretask
     app.kubernetes.io/part-of: taskcluster
-    app.kubernetes.io/managed-by: helm
 spec:
   schedule: 0 0 * * *
   jobTemplate:
     metadata:
-      labels:
-        app.kubernetes.io/name: taskcluster-queue
-        app.kubernetes.io/instance: '{{ .Release.Name }}'
-        app.kubernetes.io/component: taskcluster-queue-expiretask
-        app.kubernetes.io/part-of: taskcluster
-        app.kubernetes.io/managed-by: helm
+      labels: *ref_0
     spec:
       template:
         metadata:
-          labels:
-            app.kubernetes.io/name: taskcluster-queue
-            app.kubernetes.io/instance: '{{ .Release.Name }}'
-            app.kubernetes.io/component: taskcluster-queue-expiretask
-            app.kubernetes.io/part-of: taskcluster
-            app.kubernetes.io/managed-by: helm
+          labels: *ref_0
         spec:
           restartPolicy: OnFailure
           activeDeadlineSeconds: 86400

--- a/infrastructure/k8s/templates/taskcluster-queue-cron-expireTaskDependency.yaml
+++ b/infrastructure/k8s/templates/taskcluster-queue-cron-expireTaskDependency.yaml
@@ -2,31 +2,20 @@ apiVersion: batch/v1beta1
 kind: CronJob
 metadata:
   name: taskcluster-queue-expiretaskdependency
-  labels:
+  labels: &ref_0
     app.kubernetes.io/name: taskcluster-queue
     app.kubernetes.io/instance: '{{ .Release.Name }}'
     app.kubernetes.io/component: taskcluster-queue-expiretaskdependency
     app.kubernetes.io/part-of: taskcluster
-    app.kubernetes.io/managed-by: helm
 spec:
   schedule: 0 0 * * *
   jobTemplate:
     metadata:
-      labels:
-        app.kubernetes.io/name: taskcluster-queue
-        app.kubernetes.io/instance: '{{ .Release.Name }}'
-        app.kubernetes.io/component: taskcluster-queue-expiretaskdependency
-        app.kubernetes.io/part-of: taskcluster
-        app.kubernetes.io/managed-by: helm
+      labels: *ref_0
     spec:
       template:
         metadata:
-          labels:
-            app.kubernetes.io/name: taskcluster-queue
-            app.kubernetes.io/instance: '{{ .Release.Name }}'
-            app.kubernetes.io/component: taskcluster-queue-expiretaskdependency
-            app.kubernetes.io/part-of: taskcluster
-            app.kubernetes.io/managed-by: helm
+          labels: *ref_0
         spec:
           restartPolicy: OnFailure
           activeDeadlineSeconds: 86400

--- a/infrastructure/k8s/templates/taskcluster-queue-cron-expireTaskGroupMembers.yaml
+++ b/infrastructure/k8s/templates/taskcluster-queue-cron-expireTaskGroupMembers.yaml
@@ -2,31 +2,20 @@ apiVersion: batch/v1beta1
 kind: CronJob
 metadata:
   name: taskcluster-queue-expiretaskgroupmembers
-  labels:
+  labels: &ref_0
     app.kubernetes.io/name: taskcluster-queue
     app.kubernetes.io/instance: '{{ .Release.Name }}'
     app.kubernetes.io/component: taskcluster-queue-expiretaskgroupmembers
     app.kubernetes.io/part-of: taskcluster
-    app.kubernetes.io/managed-by: helm
 spec:
   schedule: 0 0 * * *
   jobTemplate:
     metadata:
-      labels:
-        app.kubernetes.io/name: taskcluster-queue
-        app.kubernetes.io/instance: '{{ .Release.Name }}'
-        app.kubernetes.io/component: taskcluster-queue-expiretaskgroupmembers
-        app.kubernetes.io/part-of: taskcluster
-        app.kubernetes.io/managed-by: helm
+      labels: *ref_0
     spec:
       template:
         metadata:
-          labels:
-            app.kubernetes.io/name: taskcluster-queue
-            app.kubernetes.io/instance: '{{ .Release.Name }}'
-            app.kubernetes.io/component: taskcluster-queue-expiretaskgroupmembers
-            app.kubernetes.io/part-of: taskcluster
-            app.kubernetes.io/managed-by: helm
+          labels: *ref_0
         spec:
           restartPolicy: OnFailure
           activeDeadlineSeconds: 86400

--- a/infrastructure/k8s/templates/taskcluster-queue-cron-expireTaskGroupSizes.yaml
+++ b/infrastructure/k8s/templates/taskcluster-queue-cron-expireTaskGroupSizes.yaml
@@ -2,31 +2,20 @@ apiVersion: batch/v1beta1
 kind: CronJob
 metadata:
   name: taskcluster-queue-expiretaskgroupsizes
-  labels:
+  labels: &ref_0
     app.kubernetes.io/name: taskcluster-queue
     app.kubernetes.io/instance: '{{ .Release.Name }}'
     app.kubernetes.io/component: taskcluster-queue-expiretaskgroupsizes
     app.kubernetes.io/part-of: taskcluster
-    app.kubernetes.io/managed-by: helm
 spec:
   schedule: 0 0 * * *
   jobTemplate:
     metadata:
-      labels:
-        app.kubernetes.io/name: taskcluster-queue
-        app.kubernetes.io/instance: '{{ .Release.Name }}'
-        app.kubernetes.io/component: taskcluster-queue-expiretaskgroupsizes
-        app.kubernetes.io/part-of: taskcluster
-        app.kubernetes.io/managed-by: helm
+      labels: *ref_0
     spec:
       template:
         metadata:
-          labels:
-            app.kubernetes.io/name: taskcluster-queue
-            app.kubernetes.io/instance: '{{ .Release.Name }}'
-            app.kubernetes.io/component: taskcluster-queue-expiretaskgroupsizes
-            app.kubernetes.io/part-of: taskcluster
-            app.kubernetes.io/managed-by: helm
+          labels: *ref_0
         spec:
           restartPolicy: OnFailure
           activeDeadlineSeconds: 86400

--- a/infrastructure/k8s/templates/taskcluster-queue-cron-expireTaskGroups.yaml
+++ b/infrastructure/k8s/templates/taskcluster-queue-cron-expireTaskGroups.yaml
@@ -2,31 +2,20 @@ apiVersion: batch/v1beta1
 kind: CronJob
 metadata:
   name: taskcluster-queue-expiretaskgroups
-  labels:
+  labels: &ref_0
     app.kubernetes.io/name: taskcluster-queue
     app.kubernetes.io/instance: '{{ .Release.Name }}'
     app.kubernetes.io/component: taskcluster-queue-expiretaskgroups
     app.kubernetes.io/part-of: taskcluster
-    app.kubernetes.io/managed-by: helm
 spec:
   schedule: 0 0 * * *
   jobTemplate:
     metadata:
-      labels:
-        app.kubernetes.io/name: taskcluster-queue
-        app.kubernetes.io/instance: '{{ .Release.Name }}'
-        app.kubernetes.io/component: taskcluster-queue-expiretaskgroups
-        app.kubernetes.io/part-of: taskcluster
-        app.kubernetes.io/managed-by: helm
+      labels: *ref_0
     spec:
       template:
         metadata:
-          labels:
-            app.kubernetes.io/name: taskcluster-queue
-            app.kubernetes.io/instance: '{{ .Release.Name }}'
-            app.kubernetes.io/component: taskcluster-queue-expiretaskgroups
-            app.kubernetes.io/part-of: taskcluster
-            app.kubernetes.io/managed-by: helm
+          labels: *ref_0
         spec:
           restartPolicy: OnFailure
           activeDeadlineSeconds: 86400

--- a/infrastructure/k8s/templates/taskcluster-queue-cron-expireTaskRequirement.yaml
+++ b/infrastructure/k8s/templates/taskcluster-queue-cron-expireTaskRequirement.yaml
@@ -2,31 +2,20 @@ apiVersion: batch/v1beta1
 kind: CronJob
 metadata:
   name: taskcluster-queue-expiretaskrequirement
-  labels:
+  labels: &ref_0
     app.kubernetes.io/name: taskcluster-queue
     app.kubernetes.io/instance: '{{ .Release.Name }}'
     app.kubernetes.io/component: taskcluster-queue-expiretaskrequirement
     app.kubernetes.io/part-of: taskcluster
-    app.kubernetes.io/managed-by: helm
 spec:
   schedule: 0 0 * * *
   jobTemplate:
     metadata:
-      labels:
-        app.kubernetes.io/name: taskcluster-queue
-        app.kubernetes.io/instance: '{{ .Release.Name }}'
-        app.kubernetes.io/component: taskcluster-queue-expiretaskrequirement
-        app.kubernetes.io/part-of: taskcluster
-        app.kubernetes.io/managed-by: helm
+      labels: *ref_0
     spec:
       template:
         metadata:
-          labels:
-            app.kubernetes.io/name: taskcluster-queue
-            app.kubernetes.io/instance: '{{ .Release.Name }}'
-            app.kubernetes.io/component: taskcluster-queue-expiretaskrequirement
-            app.kubernetes.io/part-of: taskcluster
-            app.kubernetes.io/managed-by: helm
+          labels: *ref_0
         spec:
           restartPolicy: OnFailure
           activeDeadlineSeconds: 86400

--- a/infrastructure/k8s/templates/taskcluster-queue-cron-expireWorkerInfo.yaml
+++ b/infrastructure/k8s/templates/taskcluster-queue-cron-expireWorkerInfo.yaml
@@ -2,31 +2,20 @@ apiVersion: batch/v1beta1
 kind: CronJob
 metadata:
   name: taskcluster-queue-expireworkerinfo
-  labels:
+  labels: &ref_0
     app.kubernetes.io/name: taskcluster-queue
     app.kubernetes.io/instance: '{{ .Release.Name }}'
     app.kubernetes.io/component: taskcluster-queue-expireworkerinfo
     app.kubernetes.io/part-of: taskcluster
-    app.kubernetes.io/managed-by: helm
 spec:
   schedule: 0 0 * * *
   jobTemplate:
     metadata:
-      labels:
-        app.kubernetes.io/name: taskcluster-queue
-        app.kubernetes.io/instance: '{{ .Release.Name }}'
-        app.kubernetes.io/component: taskcluster-queue-expireworkerinfo
-        app.kubernetes.io/part-of: taskcluster
-        app.kubernetes.io/managed-by: helm
+      labels: *ref_0
     spec:
       template:
         metadata:
-          labels:
-            app.kubernetes.io/name: taskcluster-queue
-            app.kubernetes.io/instance: '{{ .Release.Name }}'
-            app.kubernetes.io/component: taskcluster-queue-expireworkerinfo
-            app.kubernetes.io/part-of: taskcluster
-            app.kubernetes.io/managed-by: helm
+          labels: *ref_0
         spec:
           restartPolicy: OnFailure
           activeDeadlineSeconds: 86400

--- a/infrastructure/k8s/templates/taskcluster-queue-deployment-claimResolver.yaml
+++ b/infrastructure/k8s/templates/taskcluster-queue-deployment-claimResolver.yaml
@@ -2,31 +2,20 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: taskcluster-queue-claimresolver
-  labels:
+  labels: &ref_0
     app.kubernetes.io/name: taskcluster-queue
     app.kubernetes.io/instance: '{{ .Release.Name }}'
     app.kubernetes.io/component: taskcluster-queue-claimresolver
     app.kubernetes.io/part-of: taskcluster
-    app.kubernetes.io/managed-by: helm
 spec:
-  selector:
-    matchLabels:
-      app.kubernetes.io/name: taskcluster-queue
-      app.kubernetes.io/instance: '{{ .Release.Name }}'
-      app.kubernetes.io/component: taskcluster-queue-claimresolver
-      app.kubernetes.io/part-of: taskcluster
-      app.kubernetes.io/managed-by: helm
   replicas: {{ int (.Values.queue.procs.claimResolver.replicas) }}
+  selector:
+    matchLabels: *ref_0
   template:
     metadata:
       annotations:
         checksum/secret: '{{ include (print $.Template.BasePath "/taskcluster-queue-secret.yaml") . | sha256sum }}'
-      labels:
-        app.kubernetes.io/name: taskcluster-queue
-        app.kubernetes.io/instance: '{{ .Release.Name }}'
-        app.kubernetes.io/component: taskcluster-queue-claimresolver
-        app.kubernetes.io/part-of: taskcluster
-        app.kubernetes.io/managed-by: helm
+      labels: *ref_0
     spec:
       serviceAccountName: taskcluster-queue
       containers:

--- a/infrastructure/k8s/templates/taskcluster-queue-deployment-deadlineResolver.yaml
+++ b/infrastructure/k8s/templates/taskcluster-queue-deployment-deadlineResolver.yaml
@@ -2,31 +2,20 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: taskcluster-queue-deadlineresolver
-  labels:
+  labels: &ref_0
     app.kubernetes.io/name: taskcluster-queue
     app.kubernetes.io/instance: '{{ .Release.Name }}'
     app.kubernetes.io/component: taskcluster-queue-deadlineresolver
     app.kubernetes.io/part-of: taskcluster
-    app.kubernetes.io/managed-by: helm
 spec:
-  selector:
-    matchLabels:
-      app.kubernetes.io/name: taskcluster-queue
-      app.kubernetes.io/instance: '{{ .Release.Name }}'
-      app.kubernetes.io/component: taskcluster-queue-deadlineresolver
-      app.kubernetes.io/part-of: taskcluster
-      app.kubernetes.io/managed-by: helm
   replicas: {{ int (.Values.queue.procs.deadlineResolver.replicas) }}
+  selector:
+    matchLabels: *ref_0
   template:
     metadata:
       annotations:
         checksum/secret: '{{ include (print $.Template.BasePath "/taskcluster-queue-secret.yaml") . | sha256sum }}'
-      labels:
-        app.kubernetes.io/name: taskcluster-queue
-        app.kubernetes.io/instance: '{{ .Release.Name }}'
-        app.kubernetes.io/component: taskcluster-queue-deadlineresolver
-        app.kubernetes.io/part-of: taskcluster
-        app.kubernetes.io/managed-by: helm
+      labels: *ref_0
     spec:
       serviceAccountName: taskcluster-queue
       containers:

--- a/infrastructure/k8s/templates/taskcluster-queue-deployment-dependencyResolver.yaml
+++ b/infrastructure/k8s/templates/taskcluster-queue-deployment-dependencyResolver.yaml
@@ -2,31 +2,20 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: taskcluster-queue-dependencyresolver
-  labels:
+  labels: &ref_0
     app.kubernetes.io/name: taskcluster-queue
     app.kubernetes.io/instance: '{{ .Release.Name }}'
     app.kubernetes.io/component: taskcluster-queue-dependencyresolver
     app.kubernetes.io/part-of: taskcluster
-    app.kubernetes.io/managed-by: helm
 spec:
-  selector:
-    matchLabels:
-      app.kubernetes.io/name: taskcluster-queue
-      app.kubernetes.io/instance: '{{ .Release.Name }}'
-      app.kubernetes.io/component: taskcluster-queue-dependencyresolver
-      app.kubernetes.io/part-of: taskcluster
-      app.kubernetes.io/managed-by: helm
   replicas: {{ int (.Values.queue.procs.dependencyResolver.replicas) }}
+  selector:
+    matchLabels: *ref_0
   template:
     metadata:
       annotations:
         checksum/secret: '{{ include (print $.Template.BasePath "/taskcluster-queue-secret.yaml") . | sha256sum }}'
-      labels:
-        app.kubernetes.io/name: taskcluster-queue
-        app.kubernetes.io/instance: '{{ .Release.Name }}'
-        app.kubernetes.io/component: taskcluster-queue-dependencyresolver
-        app.kubernetes.io/part-of: taskcluster
-        app.kubernetes.io/managed-by: helm
+      labels: *ref_0
     spec:
       serviceAccountName: taskcluster-queue
       containers:

--- a/infrastructure/k8s/templates/taskcluster-queue-deployment-web.yaml
+++ b/infrastructure/k8s/templates/taskcluster-queue-deployment-web.yaml
@@ -2,31 +2,20 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: taskcluster-queue-web
-  labels:
+  labels: &ref_0
     app.kubernetes.io/name: taskcluster-queue
     app.kubernetes.io/instance: '{{ .Release.Name }}'
     app.kubernetes.io/component: taskcluster-queue-web
     app.kubernetes.io/part-of: taskcluster
-    app.kubernetes.io/managed-by: helm
 spec:
-  selector:
-    matchLabels:
-      app.kubernetes.io/name: taskcluster-queue
-      app.kubernetes.io/instance: '{{ .Release.Name }}'
-      app.kubernetes.io/component: taskcluster-queue-web
-      app.kubernetes.io/part-of: taskcluster
-      app.kubernetes.io/managed-by: helm
   replicas: {{ int (.Values.queue.procs.web.replicas) }}
+  selector:
+    matchLabels: *ref_0
   template:
     metadata:
       annotations:
         checksum/secret: '{{ include (print $.Template.BasePath "/taskcluster-queue-secret.yaml") . | sha256sum }}'
-      labels:
-        app.kubernetes.io/name: taskcluster-queue
-        app.kubernetes.io/instance: '{{ .Release.Name }}'
-        app.kubernetes.io/component: taskcluster-queue-web
-        app.kubernetes.io/part-of: taskcluster
-        app.kubernetes.io/managed-by: helm
+      labels: *ref_0
     spec:
       serviceAccountName: taskcluster-queue
       containers:

--- a/infrastructure/k8s/templates/taskcluster-queue-role.yaml
+++ b/infrastructure/k8s/templates/taskcluster-queue-role.yaml
@@ -2,6 +2,11 @@ kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: taskcluster-queue-secrets-read
+  labels:
+    app.kubernetes.io/name: taskcluster-queue
+    app.kubernetes.io/instance: '{{ .Release.Name }}'
+    app.kubernetes.io/component: taskcluster-queue-secrets
+    app.kubernetes.io/part-of: taskcluster
 rules:
   - apiGroups:
       - ''

--- a/infrastructure/k8s/templates/taskcluster-queue-rolebinding.yaml
+++ b/infrastructure/k8s/templates/taskcluster-queue-rolebinding.yaml
@@ -2,6 +2,11 @@ kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: taskcluster-queue-secrets-read
+  labels:
+    app.kubernetes.io/name: taskcluster-queue
+    app.kubernetes.io/instance: '{{ .Release.Name }}'
+    app.kubernetes.io/component: taskcluster-queue-secrets
+    app.kubernetes.io/part-of: taskcluster
 subjects:
   - kind: User
     name: taskcluster-queue

--- a/infrastructure/k8s/templates/taskcluster-queue-secret.yaml
+++ b/infrastructure/k8s/templates/taskcluster-queue-secret.yaml
@@ -3,6 +3,11 @@ kind: Secret
 type: Opaque
 metadata:
   name: taskcluster-queue
+  labels:
+    app.kubernetes.io/name: taskcluster-queue
+    app.kubernetes.io/instance: '{{ .Release.Name }}'
+    app.kubernetes.io/component: taskcluster-queue-secrets
+    app.kubernetes.io/part-of: taskcluster
 data:
   PUBLIC_BLOB_ARTIFACT_BUCKET: '{{ if typeIs "<nil>" .Values.queue.public_blob_artifact_bucket }}{{ else }}{{ .Values.queue.public_blob_artifact_bucket | toJson | trimAll "\"" | b64enc }}{{ end }}'
   PRIVATE_BLOB_ARTIFACT_BUCKET: '{{ if typeIs "<nil>" .Values.queue.private_blob_artifact_bucket }}{{ else }}{{ .Values.queue.private_blob_artifact_bucket | toJson | trimAll "\"" | b64enc }}{{ end }}'

--- a/infrastructure/k8s/templates/taskcluster-queue-service-web.yaml
+++ b/infrastructure/k8s/templates/taskcluster-queue-service-web.yaml
@@ -2,13 +2,14 @@ kind: Service
 apiVersion: v1
 metadata:
   name: taskcluster-queue
-spec:
-  type: NodePort
-  selector:
+  labels: &ref_0
     app.kubernetes.io/name: taskcluster-queue
     app.kubernetes.io/instance: '{{ .Release.Name }}'
     app.kubernetes.io/component: taskcluster-queue-web
     app.kubernetes.io/part-of: taskcluster
+spec:
+  type: NodePort
+  selector: *ref_0
   ports:
     - protocol: TCP
       port: 80

--- a/infrastructure/k8s/templates/taskcluster-queue-serviceaccount.yaml
+++ b/infrastructure/k8s/templates/taskcluster-queue-serviceaccount.yaml
@@ -2,3 +2,8 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: taskcluster-queue
+  labels:
+    app.kubernetes.io/name: taskcluster-queue
+    app.kubernetes.io/instance: '{{ .Release.Name }}'
+    app.kubernetes.io/component: taskcluster-queue-secrets
+    app.kubernetes.io/part-of: taskcluster

--- a/infrastructure/k8s/templates/taskcluster-references-deployment-web.yaml
+++ b/infrastructure/k8s/templates/taskcluster-references-deployment-web.yaml
@@ -2,31 +2,20 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: taskcluster-references-web
-  labels:
+  labels: &ref_0
     app.kubernetes.io/name: taskcluster-references
     app.kubernetes.io/instance: '{{ .Release.Name }}'
     app.kubernetes.io/component: taskcluster-references-web
     app.kubernetes.io/part-of: taskcluster
-    app.kubernetes.io/managed-by: helm
 spec:
-  selector:
-    matchLabels:
-      app.kubernetes.io/name: taskcluster-references
-      app.kubernetes.io/instance: '{{ .Release.Name }}'
-      app.kubernetes.io/component: taskcluster-references-web
-      app.kubernetes.io/part-of: taskcluster
-      app.kubernetes.io/managed-by: helm
   replicas: {{ int (.Values.references.procs.web.replicas) }}
+  selector:
+    matchLabels: *ref_0
   template:
     metadata:
       annotations:
         checksum/secret: '{{ include (print $.Template.BasePath "/taskcluster-references-secret.yaml") . | sha256sum }}'
-      labels:
-        app.kubernetes.io/name: taskcluster-references
-        app.kubernetes.io/instance: '{{ .Release.Name }}'
-        app.kubernetes.io/component: taskcluster-references-web
-        app.kubernetes.io/part-of: taskcluster
-        app.kubernetes.io/managed-by: helm
+      labels: *ref_0
     spec:
       serviceAccountName: taskcluster-references
       containers:

--- a/infrastructure/k8s/templates/taskcluster-references-role.yaml
+++ b/infrastructure/k8s/templates/taskcluster-references-role.yaml
@@ -2,6 +2,11 @@ kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: taskcluster-references-secrets-read
+  labels:
+    app.kubernetes.io/name: taskcluster-references
+    app.kubernetes.io/instance: '{{ .Release.Name }}'
+    app.kubernetes.io/component: taskcluster-references-secrets
+    app.kubernetes.io/part-of: taskcluster
 rules:
   - apiGroups:
       - ''

--- a/infrastructure/k8s/templates/taskcluster-references-rolebinding.yaml
+++ b/infrastructure/k8s/templates/taskcluster-references-rolebinding.yaml
@@ -2,6 +2,11 @@ kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: taskcluster-references-secrets-read
+  labels:
+    app.kubernetes.io/name: taskcluster-references
+    app.kubernetes.io/instance: '{{ .Release.Name }}'
+    app.kubernetes.io/component: taskcluster-references-secrets
+    app.kubernetes.io/part-of: taskcluster
 subjects:
   - kind: User
     name: taskcluster-references

--- a/infrastructure/k8s/templates/taskcluster-references-secret.yaml
+++ b/infrastructure/k8s/templates/taskcluster-references-secret.yaml
@@ -3,4 +3,9 @@ kind: Secret
 type: Opaque
 metadata:
   name: taskcluster-references
+  labels:
+    app.kubernetes.io/name: taskcluster-references
+    app.kubernetes.io/instance: '{{ .Release.Name }}'
+    app.kubernetes.io/component: taskcluster-references-secrets
+    app.kubernetes.io/part-of: taskcluster
 data: {}

--- a/infrastructure/k8s/templates/taskcluster-references-service-web.yaml
+++ b/infrastructure/k8s/templates/taskcluster-references-service-web.yaml
@@ -2,13 +2,14 @@ kind: Service
 apiVersion: v1
 metadata:
   name: taskcluster-references
-spec:
-  type: NodePort
-  selector:
+  labels: &ref_0
     app.kubernetes.io/name: taskcluster-references
     app.kubernetes.io/instance: '{{ .Release.Name }}'
     app.kubernetes.io/component: taskcluster-references-web
     app.kubernetes.io/part-of: taskcluster
+spec:
+  type: NodePort
+  selector: *ref_0
   ports:
     - protocol: TCP
       port: 80

--- a/infrastructure/k8s/templates/taskcluster-references-serviceaccount.yaml
+++ b/infrastructure/k8s/templates/taskcluster-references-serviceaccount.yaml
@@ -2,3 +2,8 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: taskcluster-references
+  labels:
+    app.kubernetes.io/name: taskcluster-references
+    app.kubernetes.io/instance: '{{ .Release.Name }}'
+    app.kubernetes.io/component: taskcluster-references-secrets
+    app.kubernetes.io/part-of: taskcluster

--- a/infrastructure/k8s/templates/taskcluster-secrets-cron-expire.yaml
+++ b/infrastructure/k8s/templates/taskcluster-secrets-cron-expire.yaml
@@ -2,31 +2,20 @@ apiVersion: batch/v1beta1
 kind: CronJob
 metadata:
   name: taskcluster-secrets-expire
-  labels:
+  labels: &ref_0
     app.kubernetes.io/name: taskcluster-secrets
     app.kubernetes.io/instance: '{{ .Release.Name }}'
     app.kubernetes.io/component: taskcluster-secrets-expire
     app.kubernetes.io/part-of: taskcluster
-    app.kubernetes.io/managed-by: helm
 spec:
   schedule: 0 * * * *
   jobTemplate:
     metadata:
-      labels:
-        app.kubernetes.io/name: taskcluster-secrets
-        app.kubernetes.io/instance: '{{ .Release.Name }}'
-        app.kubernetes.io/component: taskcluster-secrets-expire
-        app.kubernetes.io/part-of: taskcluster
-        app.kubernetes.io/managed-by: helm
+      labels: *ref_0
     spec:
       template:
         metadata:
-          labels:
-            app.kubernetes.io/name: taskcluster-secrets
-            app.kubernetes.io/instance: '{{ .Release.Name }}'
-            app.kubernetes.io/component: taskcluster-secrets-expire
-            app.kubernetes.io/part-of: taskcluster
-            app.kubernetes.io/managed-by: helm
+          labels: *ref_0
         spec:
           restartPolicy: OnFailure
           activeDeadlineSeconds: 600

--- a/infrastructure/k8s/templates/taskcluster-secrets-deployment-web.yaml
+++ b/infrastructure/k8s/templates/taskcluster-secrets-deployment-web.yaml
@@ -2,31 +2,20 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: taskcluster-secrets-web
-  labels:
+  labels: &ref_0
     app.kubernetes.io/name: taskcluster-secrets
     app.kubernetes.io/instance: '{{ .Release.Name }}'
     app.kubernetes.io/component: taskcluster-secrets-web
     app.kubernetes.io/part-of: taskcluster
-    app.kubernetes.io/managed-by: helm
 spec:
-  selector:
-    matchLabels:
-      app.kubernetes.io/name: taskcluster-secrets
-      app.kubernetes.io/instance: '{{ .Release.Name }}'
-      app.kubernetes.io/component: taskcluster-secrets-web
-      app.kubernetes.io/part-of: taskcluster
-      app.kubernetes.io/managed-by: helm
   replicas: {{ int (.Values.secrets.procs.web.replicas) }}
+  selector:
+    matchLabels: *ref_0
   template:
     metadata:
       annotations:
         checksum/secret: '{{ include (print $.Template.BasePath "/taskcluster-secrets-secret.yaml") . | sha256sum }}'
-      labels:
-        app.kubernetes.io/name: taskcluster-secrets
-        app.kubernetes.io/instance: '{{ .Release.Name }}'
-        app.kubernetes.io/component: taskcluster-secrets-web
-        app.kubernetes.io/part-of: taskcluster
-        app.kubernetes.io/managed-by: helm
+      labels: *ref_0
     spec:
       serviceAccountName: taskcluster-secrets
       containers:

--- a/infrastructure/k8s/templates/taskcluster-secrets-role.yaml
+++ b/infrastructure/k8s/templates/taskcluster-secrets-role.yaml
@@ -2,6 +2,11 @@ kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: taskcluster-secrets-secrets-read
+  labels:
+    app.kubernetes.io/name: taskcluster-secrets
+    app.kubernetes.io/instance: '{{ .Release.Name }}'
+    app.kubernetes.io/component: taskcluster-secrets-secrets
+    app.kubernetes.io/part-of: taskcluster
 rules:
   - apiGroups:
       - ''

--- a/infrastructure/k8s/templates/taskcluster-secrets-rolebinding.yaml
+++ b/infrastructure/k8s/templates/taskcluster-secrets-rolebinding.yaml
@@ -2,6 +2,11 @@ kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: taskcluster-secrets-secrets-read
+  labels:
+    app.kubernetes.io/name: taskcluster-secrets
+    app.kubernetes.io/instance: '{{ .Release.Name }}'
+    app.kubernetes.io/component: taskcluster-secrets-secrets
+    app.kubernetes.io/part-of: taskcluster
 subjects:
   - kind: User
     name: taskcluster-secrets

--- a/infrastructure/k8s/templates/taskcluster-secrets-secret.yaml
+++ b/infrastructure/k8s/templates/taskcluster-secrets-secret.yaml
@@ -3,6 +3,11 @@ kind: Secret
 type: Opaque
 metadata:
   name: taskcluster-secrets
+  labels:
+    app.kubernetes.io/name: taskcluster-secrets
+    app.kubernetes.io/instance: '{{ .Release.Name }}'
+    app.kubernetes.io/component: taskcluster-secrets-secrets
+    app.kubernetes.io/part-of: taskcluster
 data:
   TASKCLUSTER_ROOT_URL: '{{ if typeIs "<nil>" .Values.rootUrl }}{{ else }}{{ .Values.rootUrl | toJson | trimAll "\"" | b64enc }}{{ end }}'
   TASKCLUSTER_CLIENT_ID: '{{ if typeIs "<nil>" .Values.secrets.taskcluster_client_id }}{{ else }}{{ .Values.secrets.taskcluster_client_id | toJson | trimAll "\"" | b64enc }}{{ end }}'

--- a/infrastructure/k8s/templates/taskcluster-secrets-service-web.yaml
+++ b/infrastructure/k8s/templates/taskcluster-secrets-service-web.yaml
@@ -2,13 +2,14 @@ kind: Service
 apiVersion: v1
 metadata:
   name: taskcluster-secrets
-spec:
-  type: NodePort
-  selector:
+  labels: &ref_0
     app.kubernetes.io/name: taskcluster-secrets
     app.kubernetes.io/instance: '{{ .Release.Name }}'
     app.kubernetes.io/component: taskcluster-secrets-web
     app.kubernetes.io/part-of: taskcluster
+spec:
+  type: NodePort
+  selector: *ref_0
   ports:
     - protocol: TCP
       port: 80

--- a/infrastructure/k8s/templates/taskcluster-secrets-serviceaccount.yaml
+++ b/infrastructure/k8s/templates/taskcluster-secrets-serviceaccount.yaml
@@ -2,3 +2,8 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: taskcluster-secrets
+  labels:
+    app.kubernetes.io/name: taskcluster-secrets
+    app.kubernetes.io/instance: '{{ .Release.Name }}'
+    app.kubernetes.io/component: taskcluster-secrets-secrets
+    app.kubernetes.io/part-of: taskcluster

--- a/infrastructure/k8s/templates/taskcluster-ui-deployment-web.yaml
+++ b/infrastructure/k8s/templates/taskcluster-ui-deployment-web.yaml
@@ -2,31 +2,20 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: taskcluster-ui-web
-  labels:
+  labels: &ref_0
     app.kubernetes.io/name: taskcluster-ui
     app.kubernetes.io/instance: '{{ .Release.Name }}'
     app.kubernetes.io/component: taskcluster-ui-web
     app.kubernetes.io/part-of: taskcluster
-    app.kubernetes.io/managed-by: helm
 spec:
-  selector:
-    matchLabels:
-      app.kubernetes.io/name: taskcluster-ui
-      app.kubernetes.io/instance: '{{ .Release.Name }}'
-      app.kubernetes.io/component: taskcluster-ui-web
-      app.kubernetes.io/part-of: taskcluster
-      app.kubernetes.io/managed-by: helm
   replicas: {{ int (.Values.ui.procs.web.replicas) }}
+  selector:
+    matchLabels: *ref_0
   template:
     metadata:
       annotations:
         checksum/secret: '{{ include (print $.Template.BasePath "/taskcluster-ui-secret.yaml") . | sha256sum }}'
-      labels:
-        app.kubernetes.io/name: taskcluster-ui
-        app.kubernetes.io/instance: '{{ .Release.Name }}'
-        app.kubernetes.io/component: taskcluster-ui-web
-        app.kubernetes.io/part-of: taskcluster
-        app.kubernetes.io/managed-by: helm
+      labels: *ref_0
     spec:
       serviceAccountName: taskcluster-ui
       containers:

--- a/infrastructure/k8s/templates/taskcluster-ui-role.yaml
+++ b/infrastructure/k8s/templates/taskcluster-ui-role.yaml
@@ -2,6 +2,11 @@ kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: taskcluster-ui-secrets-read
+  labels:
+    app.kubernetes.io/name: taskcluster-ui
+    app.kubernetes.io/instance: '{{ .Release.Name }}'
+    app.kubernetes.io/component: taskcluster-ui-secrets
+    app.kubernetes.io/part-of: taskcluster
 rules:
   - apiGroups:
       - ''

--- a/infrastructure/k8s/templates/taskcluster-ui-rolebinding.yaml
+++ b/infrastructure/k8s/templates/taskcluster-ui-rolebinding.yaml
@@ -2,6 +2,11 @@ kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: taskcluster-ui-secrets-read
+  labels:
+    app.kubernetes.io/name: taskcluster-ui
+    app.kubernetes.io/instance: '{{ .Release.Name }}'
+    app.kubernetes.io/component: taskcluster-ui-secrets
+    app.kubernetes.io/part-of: taskcluster
 subjects:
   - kind: User
     name: taskcluster-ui

--- a/infrastructure/k8s/templates/taskcluster-ui-secret.yaml
+++ b/infrastructure/k8s/templates/taskcluster-ui-secret.yaml
@@ -3,6 +3,11 @@ kind: Secret
 type: Opaque
 metadata:
   name: taskcluster-ui
+  labels:
+    app.kubernetes.io/name: taskcluster-ui
+    app.kubernetes.io/instance: '{{ .Release.Name }}'
+    app.kubernetes.io/component: taskcluster-ui-secrets
+    app.kubernetes.io/part-of: taskcluster
 data:
   APPLICATION_NAME: '{{ if typeIs "<nil>" .Values.ui.application_name }}{{ else }}{{ .Values.ui.application_name | toJson | trimAll "\"" | b64enc }}{{ end }}'
   GRAPHQL_SUBSCRIPTION_ENDPOINT: '{{ if typeIs "<nil>" .Values.ui.graphql_subscription_endpoint }}{{ else }}{{ .Values.ui.graphql_subscription_endpoint | toJson | trimAll "\"" | b64enc }}{{ end }}'

--- a/infrastructure/k8s/templates/taskcluster-ui-service-web.yaml
+++ b/infrastructure/k8s/templates/taskcluster-ui-service-web.yaml
@@ -2,13 +2,14 @@ kind: Service
 apiVersion: v1
 metadata:
   name: taskcluster-ui
-spec:
-  type: NodePort
-  selector:
+  labels: &ref_0
     app.kubernetes.io/name: taskcluster-ui
     app.kubernetes.io/instance: '{{ .Release.Name }}'
     app.kubernetes.io/component: taskcluster-ui-web
     app.kubernetes.io/part-of: taskcluster
+spec:
+  type: NodePort
+  selector: *ref_0
   ports:
     - protocol: TCP
       port: 80

--- a/infrastructure/k8s/templates/taskcluster-ui-serviceaccount.yaml
+++ b/infrastructure/k8s/templates/taskcluster-ui-serviceaccount.yaml
@@ -2,3 +2,8 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: taskcluster-ui
+  labels:
+    app.kubernetes.io/name: taskcluster-ui
+    app.kubernetes.io/instance: '{{ .Release.Name }}'
+    app.kubernetes.io/component: taskcluster-ui-secrets
+    app.kubernetes.io/part-of: taskcluster

--- a/infrastructure/k8s/templates/taskcluster-web-server-cron-scanner.yaml
+++ b/infrastructure/k8s/templates/taskcluster-web-server-cron-scanner.yaml
@@ -2,31 +2,20 @@ apiVersion: batch/v1beta1
 kind: CronJob
 metadata:
   name: taskcluster-web-server-scanner
-  labels:
+  labels: &ref_0
     app.kubernetes.io/name: taskcluster-web-server
     app.kubernetes.io/instance: '{{ .Release.Name }}'
     app.kubernetes.io/component: taskcluster-web-server-scanner
     app.kubernetes.io/part-of: taskcluster
-    app.kubernetes.io/managed-by: helm
 spec:
   schedule: 0 0 * * *
   jobTemplate:
     metadata:
-      labels:
-        app.kubernetes.io/name: taskcluster-web-server
-        app.kubernetes.io/instance: '{{ .Release.Name }}'
-        app.kubernetes.io/component: taskcluster-web-server-scanner
-        app.kubernetes.io/part-of: taskcluster
-        app.kubernetes.io/managed-by: helm
+      labels: *ref_0
     spec:
       template:
         metadata:
-          labels:
-            app.kubernetes.io/name: taskcluster-web-server
-            app.kubernetes.io/instance: '{{ .Release.Name }}'
-            app.kubernetes.io/component: taskcluster-web-server-scanner
-            app.kubernetes.io/part-of: taskcluster
-            app.kubernetes.io/managed-by: helm
+          labels: *ref_0
         spec:
           restartPolicy: OnFailure
           activeDeadlineSeconds: 86400

--- a/infrastructure/k8s/templates/taskcluster-web-server-deployment-web.yaml
+++ b/infrastructure/k8s/templates/taskcluster-web-server-deployment-web.yaml
@@ -2,31 +2,20 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: taskcluster-web-server-web
-  labels:
+  labels: &ref_0
     app.kubernetes.io/name: taskcluster-web-server
     app.kubernetes.io/instance: '{{ .Release.Name }}'
     app.kubernetes.io/component: taskcluster-web-server-web
     app.kubernetes.io/part-of: taskcluster
-    app.kubernetes.io/managed-by: helm
 spec:
-  selector:
-    matchLabels:
-      app.kubernetes.io/name: taskcluster-web-server
-      app.kubernetes.io/instance: '{{ .Release.Name }}'
-      app.kubernetes.io/component: taskcluster-web-server-web
-      app.kubernetes.io/part-of: taskcluster
-      app.kubernetes.io/managed-by: helm
   replicas: {{ int (.Values.web_server.procs.web.replicas) }}
+  selector:
+    matchLabels: *ref_0
   template:
     metadata:
       annotations:
         checksum/secret: '{{ include (print $.Template.BasePath "/taskcluster-web-server-secret.yaml") . | sha256sum }}'
-      labels:
-        app.kubernetes.io/name: taskcluster-web-server
-        app.kubernetes.io/instance: '{{ .Release.Name }}'
-        app.kubernetes.io/component: taskcluster-web-server-web
-        app.kubernetes.io/part-of: taskcluster
-        app.kubernetes.io/managed-by: helm
+      labels: *ref_0
     spec:
       serviceAccountName: taskcluster-web-server
       containers:

--- a/infrastructure/k8s/templates/taskcluster-web-server-role.yaml
+++ b/infrastructure/k8s/templates/taskcluster-web-server-role.yaml
@@ -2,6 +2,11 @@ kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: taskcluster-web-server-secrets-read
+  labels:
+    app.kubernetes.io/name: taskcluster-web-server
+    app.kubernetes.io/instance: '{{ .Release.Name }}'
+    app.kubernetes.io/component: taskcluster-web-server-secrets
+    app.kubernetes.io/part-of: taskcluster
 rules:
   - apiGroups:
       - ''

--- a/infrastructure/k8s/templates/taskcluster-web-server-rolebinding.yaml
+++ b/infrastructure/k8s/templates/taskcluster-web-server-rolebinding.yaml
@@ -2,6 +2,11 @@ kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: taskcluster-web-server-secrets-read
+  labels:
+    app.kubernetes.io/name: taskcluster-web-server
+    app.kubernetes.io/instance: '{{ .Release.Name }}'
+    app.kubernetes.io/component: taskcluster-web-server-secrets
+    app.kubernetes.io/part-of: taskcluster
 subjects:
   - kind: User
     name: taskcluster-web-server

--- a/infrastructure/k8s/templates/taskcluster-web-server-secret.yaml
+++ b/infrastructure/k8s/templates/taskcluster-web-server-secret.yaml
@@ -3,6 +3,11 @@ kind: Secret
 type: Opaque
 metadata:
   name: taskcluster-web-server
+  labels:
+    app.kubernetes.io/name: taskcluster-web-server
+    app.kubernetes.io/instance: '{{ .Release.Name }}'
+    app.kubernetes.io/component: taskcluster-web-server-secrets
+    app.kubernetes.io/part-of: taskcluster
 data:
   PUBLIC_URL: '{{ if typeIs "<nil>" .Values.web_server.public_url }}{{ else }}{{ .Values.web_server.public_url | toJson | trimAll "\"" | b64enc }}{{ end }}'
   LEVEL: '{{ if typeIs "<nil>" .Values.web_server.level }}{{ else }}{{ .Values.web_server.level | toJson | trimAll "\"" | b64enc }}{{ end }}'

--- a/infrastructure/k8s/templates/taskcluster-web-server-service-web.yaml
+++ b/infrastructure/k8s/templates/taskcluster-web-server-service-web.yaml
@@ -2,13 +2,14 @@ kind: Service
 apiVersion: v1
 metadata:
   name: taskcluster-web-server
-spec:
-  type: NodePort
-  selector:
+  labels: &ref_0
     app.kubernetes.io/name: taskcluster-web-server
     app.kubernetes.io/instance: '{{ .Release.Name }}'
     app.kubernetes.io/component: taskcluster-web-server-web
     app.kubernetes.io/part-of: taskcluster
+spec:
+  type: NodePort
+  selector: *ref_0
   ports:
     - protocol: TCP
       port: 80

--- a/infrastructure/k8s/templates/taskcluster-web-server-serviceaccount.yaml
+++ b/infrastructure/k8s/templates/taskcluster-web-server-serviceaccount.yaml
@@ -2,3 +2,8 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: taskcluster-web-server
+  labels:
+    app.kubernetes.io/name: taskcluster-web-server
+    app.kubernetes.io/instance: '{{ .Release.Name }}'
+    app.kubernetes.io/component: taskcluster-web-server-secrets
+    app.kubernetes.io/part-of: taskcluster

--- a/infrastructure/k8s/templates/taskcluster-worker-manager-cron-expire-errors.yaml
+++ b/infrastructure/k8s/templates/taskcluster-worker-manager-cron-expire-errors.yaml
@@ -2,31 +2,20 @@ apiVersion: batch/v1beta1
 kind: CronJob
 metadata:
   name: taskcluster-worker-manager-expire-errors
-  labels:
+  labels: &ref_0
     app.kubernetes.io/name: taskcluster-worker-manager
     app.kubernetes.io/instance: '{{ .Release.Name }}'
     app.kubernetes.io/component: taskcluster-worker-manager-expire-errors
     app.kubernetes.io/part-of: taskcluster
-    app.kubernetes.io/managed-by: helm
 spec:
   schedule: 10 0 * * *
   jobTemplate:
     metadata:
-      labels:
-        app.kubernetes.io/name: taskcluster-worker-manager
-        app.kubernetes.io/instance: '{{ .Release.Name }}'
-        app.kubernetes.io/component: taskcluster-worker-manager-expire-errors
-        app.kubernetes.io/part-of: taskcluster
-        app.kubernetes.io/managed-by: helm
+      labels: *ref_0
     spec:
       template:
         metadata:
-          labels:
-            app.kubernetes.io/name: taskcluster-worker-manager
-            app.kubernetes.io/instance: '{{ .Release.Name }}'
-            app.kubernetes.io/component: taskcluster-worker-manager-expire-errors
-            app.kubernetes.io/part-of: taskcluster
-            app.kubernetes.io/managed-by: helm
+          labels: *ref_0
         spec:
           restartPolicy: OnFailure
           activeDeadlineSeconds: 86400

--- a/infrastructure/k8s/templates/taskcluster-worker-manager-cron-expire-worker-pools.yaml
+++ b/infrastructure/k8s/templates/taskcluster-worker-manager-cron-expire-worker-pools.yaml
@@ -2,31 +2,20 @@ apiVersion: batch/v1beta1
 kind: CronJob
 metadata:
   name: taskcluster-worker-manager-expire-worker-pools
-  labels:
+  labels: &ref_0
     app.kubernetes.io/name: taskcluster-worker-manager
     app.kubernetes.io/instance: '{{ .Release.Name }}'
     app.kubernetes.io/component: taskcluster-worker-manager-expire-worker-pools
     app.kubernetes.io/part-of: taskcluster
-    app.kubernetes.io/managed-by: helm
 spec:
   schedule: 0 1 * * *
   jobTemplate:
     metadata:
-      labels:
-        app.kubernetes.io/name: taskcluster-worker-manager
-        app.kubernetes.io/instance: '{{ .Release.Name }}'
-        app.kubernetes.io/component: taskcluster-worker-manager-expire-worker-pools
-        app.kubernetes.io/part-of: taskcluster
-        app.kubernetes.io/managed-by: helm
+      labels: *ref_0
     spec:
       template:
         metadata:
-          labels:
-            app.kubernetes.io/name: taskcluster-worker-manager
-            app.kubernetes.io/instance: '{{ .Release.Name }}'
-            app.kubernetes.io/component: taskcluster-worker-manager-expire-worker-pools
-            app.kubernetes.io/part-of: taskcluster
-            app.kubernetes.io/managed-by: helm
+          labels: *ref_0
         spec:
           restartPolicy: OnFailure
           activeDeadlineSeconds: 86400

--- a/infrastructure/k8s/templates/taskcluster-worker-manager-cron-expire-workers.yaml
+++ b/infrastructure/k8s/templates/taskcluster-worker-manager-cron-expire-workers.yaml
@@ -2,31 +2,20 @@ apiVersion: batch/v1beta1
 kind: CronJob
 metadata:
   name: taskcluster-worker-manager-expire-workers
-  labels:
+  labels: &ref_0
     app.kubernetes.io/name: taskcluster-worker-manager
     app.kubernetes.io/instance: '{{ .Release.Name }}'
     app.kubernetes.io/component: taskcluster-worker-manager-expire-workers
     app.kubernetes.io/part-of: taskcluster
-    app.kubernetes.io/managed-by: helm
 spec:
   schedule: 0 0 * * *
   jobTemplate:
     metadata:
-      labels:
-        app.kubernetes.io/name: taskcluster-worker-manager
-        app.kubernetes.io/instance: '{{ .Release.Name }}'
-        app.kubernetes.io/component: taskcluster-worker-manager-expire-workers
-        app.kubernetes.io/part-of: taskcluster
-        app.kubernetes.io/managed-by: helm
+      labels: *ref_0
     spec:
       template:
         metadata:
-          labels:
-            app.kubernetes.io/name: taskcluster-worker-manager
-            app.kubernetes.io/instance: '{{ .Release.Name }}'
-            app.kubernetes.io/component: taskcluster-worker-manager-expire-workers
-            app.kubernetes.io/part-of: taskcluster
-            app.kubernetes.io/managed-by: helm
+          labels: *ref_0
         spec:
           restartPolicy: OnFailure
           activeDeadlineSeconds: 86400

--- a/infrastructure/k8s/templates/taskcluster-worker-manager-deployment-provisioner.yaml
+++ b/infrastructure/k8s/templates/taskcluster-worker-manager-deployment-provisioner.yaml
@@ -2,31 +2,20 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: taskcluster-worker-manager-provisioner
-  labels:
+  labels: &ref_0
     app.kubernetes.io/name: taskcluster-worker-manager
     app.kubernetes.io/instance: '{{ .Release.Name }}'
     app.kubernetes.io/component: taskcluster-worker-manager-provisioner
     app.kubernetes.io/part-of: taskcluster
-    app.kubernetes.io/managed-by: helm
 spec:
-  selector:
-    matchLabels:
-      app.kubernetes.io/name: taskcluster-worker-manager
-      app.kubernetes.io/instance: '{{ .Release.Name }}'
-      app.kubernetes.io/component: taskcluster-worker-manager-provisioner
-      app.kubernetes.io/part-of: taskcluster
-      app.kubernetes.io/managed-by: helm
   replicas: {{ int (.Values.worker_manager.procs.provisioner.replicas) }}
+  selector:
+    matchLabels: *ref_0
   template:
     metadata:
       annotations:
         checksum/secret: '{{ include (print $.Template.BasePath "/taskcluster-worker-manager-secret.yaml") . | sha256sum }}'
-      labels:
-        app.kubernetes.io/name: taskcluster-worker-manager
-        app.kubernetes.io/instance: '{{ .Release.Name }}'
-        app.kubernetes.io/component: taskcluster-worker-manager-provisioner
-        app.kubernetes.io/part-of: taskcluster
-        app.kubernetes.io/managed-by: helm
+      labels: *ref_0
     spec:
       serviceAccountName: taskcluster-worker-manager
       containers:

--- a/infrastructure/k8s/templates/taskcluster-worker-manager-deployment-web.yaml
+++ b/infrastructure/k8s/templates/taskcluster-worker-manager-deployment-web.yaml
@@ -2,31 +2,20 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: taskcluster-worker-manager-web
-  labels:
+  labels: &ref_0
     app.kubernetes.io/name: taskcluster-worker-manager
     app.kubernetes.io/instance: '{{ .Release.Name }}'
     app.kubernetes.io/component: taskcluster-worker-manager-web
     app.kubernetes.io/part-of: taskcluster
-    app.kubernetes.io/managed-by: helm
 spec:
-  selector:
-    matchLabels:
-      app.kubernetes.io/name: taskcluster-worker-manager
-      app.kubernetes.io/instance: '{{ .Release.Name }}'
-      app.kubernetes.io/component: taskcluster-worker-manager-web
-      app.kubernetes.io/part-of: taskcluster
-      app.kubernetes.io/managed-by: helm
   replicas: {{ int (.Values.worker_manager.procs.web.replicas) }}
+  selector:
+    matchLabels: *ref_0
   template:
     metadata:
       annotations:
         checksum/secret: '{{ include (print $.Template.BasePath "/taskcluster-worker-manager-secret.yaml") . | sha256sum }}'
-      labels:
-        app.kubernetes.io/name: taskcluster-worker-manager
-        app.kubernetes.io/instance: '{{ .Release.Name }}'
-        app.kubernetes.io/component: taskcluster-worker-manager-web
-        app.kubernetes.io/part-of: taskcluster
-        app.kubernetes.io/managed-by: helm
+      labels: *ref_0
     spec:
       serviceAccountName: taskcluster-worker-manager
       containers:

--- a/infrastructure/k8s/templates/taskcluster-worker-manager-deployment-workerscanner.yaml
+++ b/infrastructure/k8s/templates/taskcluster-worker-manager-deployment-workerscanner.yaml
@@ -2,31 +2,20 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: taskcluster-worker-manager-workerscanner
-  labels:
+  labels: &ref_0
     app.kubernetes.io/name: taskcluster-worker-manager
     app.kubernetes.io/instance: '{{ .Release.Name }}'
     app.kubernetes.io/component: taskcluster-worker-manager-workerscanner
     app.kubernetes.io/part-of: taskcluster
-    app.kubernetes.io/managed-by: helm
 spec:
-  selector:
-    matchLabels:
-      app.kubernetes.io/name: taskcluster-worker-manager
-      app.kubernetes.io/instance: '{{ .Release.Name }}'
-      app.kubernetes.io/component: taskcluster-worker-manager-workerscanner
-      app.kubernetes.io/part-of: taskcluster
-      app.kubernetes.io/managed-by: helm
   replicas: {{ int (.Values.worker_manager.procs.workerscanner.replicas) }}
+  selector:
+    matchLabels: *ref_0
   template:
     metadata:
       annotations:
         checksum/secret: '{{ include (print $.Template.BasePath "/taskcluster-worker-manager-secret.yaml") . | sha256sum }}'
-      labels:
-        app.kubernetes.io/name: taskcluster-worker-manager
-        app.kubernetes.io/instance: '{{ .Release.Name }}'
-        app.kubernetes.io/component: taskcluster-worker-manager-workerscanner
-        app.kubernetes.io/part-of: taskcluster
-        app.kubernetes.io/managed-by: helm
+      labels: *ref_0
     spec:
       serviceAccountName: taskcluster-worker-manager
       containers:

--- a/infrastructure/k8s/templates/taskcluster-worker-manager-role.yaml
+++ b/infrastructure/k8s/templates/taskcluster-worker-manager-role.yaml
@@ -2,6 +2,11 @@ kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: taskcluster-worker-manager-secrets-read
+  labels:
+    app.kubernetes.io/name: taskcluster-worker-manager
+    app.kubernetes.io/instance: '{{ .Release.Name }}'
+    app.kubernetes.io/component: taskcluster-worker-manager-secrets
+    app.kubernetes.io/part-of: taskcluster
 rules:
   - apiGroups:
       - ''

--- a/infrastructure/k8s/templates/taskcluster-worker-manager-rolebinding.yaml
+++ b/infrastructure/k8s/templates/taskcluster-worker-manager-rolebinding.yaml
@@ -2,6 +2,11 @@ kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: taskcluster-worker-manager-secrets-read
+  labels:
+    app.kubernetes.io/name: taskcluster-worker-manager
+    app.kubernetes.io/instance: '{{ .Release.Name }}'
+    app.kubernetes.io/component: taskcluster-worker-manager-secrets
+    app.kubernetes.io/part-of: taskcluster
 subjects:
   - kind: User
     name: taskcluster-worker-manager

--- a/infrastructure/k8s/templates/taskcluster-worker-manager-secret.yaml
+++ b/infrastructure/k8s/templates/taskcluster-worker-manager-secret.yaml
@@ -3,6 +3,11 @@ kind: Secret
 type: Opaque
 metadata:
   name: taskcluster-worker-manager
+  labels:
+    app.kubernetes.io/name: taskcluster-worker-manager
+    app.kubernetes.io/instance: '{{ .Release.Name }}'
+    app.kubernetes.io/component: taskcluster-worker-manager-secrets
+    app.kubernetes.io/part-of: taskcluster
 data:
   LEVEL: '{{ if typeIs "<nil>" .Values.worker_manager.level }}{{ else }}{{ .Values.worker_manager.level | toJson | trimAll "\"" | b64enc }}{{ end }}'
   TASKCLUSTER_ROOT_URL: '{{ if typeIs "<nil>" .Values.rootUrl }}{{ else }}{{ .Values.rootUrl | toJson | trimAll "\"" | b64enc }}{{ end }}'

--- a/infrastructure/k8s/templates/taskcluster-worker-manager-service-web.yaml
+++ b/infrastructure/k8s/templates/taskcluster-worker-manager-service-web.yaml
@@ -2,13 +2,14 @@ kind: Service
 apiVersion: v1
 metadata:
   name: taskcluster-worker-manager
-spec:
-  type: NodePort
-  selector:
+  labels: &ref_0
     app.kubernetes.io/name: taskcluster-worker-manager
     app.kubernetes.io/instance: '{{ .Release.Name }}'
     app.kubernetes.io/component: taskcluster-worker-manager-web
     app.kubernetes.io/part-of: taskcluster
+spec:
+  type: NodePort
+  selector: *ref_0
   ports:
     - protocol: TCP
       port: 80

--- a/infrastructure/k8s/templates/taskcluster-worker-manager-serviceaccount.yaml
+++ b/infrastructure/k8s/templates/taskcluster-worker-manager-serviceaccount.yaml
@@ -2,3 +2,8 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: taskcluster-worker-manager
+  labels:
+    app.kubernetes.io/name: taskcluster-worker-manager
+    app.kubernetes.io/instance: '{{ .Release.Name }}'
+    app.kubernetes.io/component: taskcluster-worker-manager-secrets
+    app.kubernetes.io/part-of: taskcluster

--- a/package.json
+++ b/package.json
@@ -175,10 +175,9 @@
     "heroku-prebuild": "echo {\\\"version\\\"\\: \\\"$SOURCE_VERSION\\\"} > version.json",
     "heroku-postbuild": "if [ $PROCFILE = \"ui/Procfile\" ]; then cd ui && yarn install --frozen-lockfile && yarn build; fi",
     "dev:init": "node infrastructure/builder/src/main.js dev --init",
-    "dev:install": "node infrastructure/builder/src/main.js dev --helm-action install",
-    "dev:uninstall": "node infrastructure/builder/src/main.js dev --helm-action uninstall",
-    "dev:template": "node infrastructure/builder/src/main.js dev --helm-action template",
-    "dev:upgrade": "node infrastructure/builder/src/main.js dev --helm-action upgrade"
+    "dev:apply": "node infrastructure/builder/src/main.js dev --k8s-action apply",
+    "dev:delete": "node infrastructure/builder/src/main.js dev --k8s-action delete",
+    "dev:verify": "node infrastructure/builder/src/main.js dev --k8s-action verify"
   },
   "renovate": {
     "extends": [


### PR DESCRIPTION
This should allow redeploying the cluster without uninstalling first!

It should also be faster and more verbose about what it is doing.