### PR TITLE
Fix Taskcluster shell linux binary download link

### DIFF
--- a/infrastructure/builder/src/release/tasks.js
+++ b/infrastructure/builder/src/release/tasks.js
@@ -138,7 +138,7 @@ module.exports = ({tasks, cmdOptions, baseDir}) => {
       const shellreadme = 'clients/client-shell/README.md';
       utils.status({message: `Update ${shellreadme}`});
       await modifyRepoFile(shellreadme, contents =>
-        contents.replace(/download\/v[0-9.]*\/taskcluster-/g, `download/v${requirements['release-version']}/taskcluster-"`));
+        contents.replace(/download\/v[0-9.]*\/taskcluster-/g, `download/v${requirements['release-version']}/taskcluster-`));
       changed.push(shellreadme);
 
       const shellgomod = 'clients/client-shell/go.mod';


### PR DESCRIPTION
Removes the stray `"` from the download link.