### PR TITLE
[UI/Enhancement] Add a way to jump to a task ID/task group from the log viewer in less clicks

### DIFF
--- a/ui/src/components/Dashboard/SidebarList.jsx
+++ b/ui/src/components/Dashboard/SidebarList.jsx
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import List from '@material-ui/core/List';
-import HexagonMultipleIcon from 'mdi-react/HexagonMultipleIcon';
+import FeatureSearchIcon from 'mdi-react/FeatureSearchIcon';
 import HexagonSlice4 from 'mdi-react/HexagonSlice4Icon';
 import PlusCircleIcon from 'mdi-react/PlusCircleIcon';
 import GroupIcon from 'mdi-react/GroupIcon';
@@ -26,7 +26,7 @@ export default class SidebarList extends Component {
   render() {
     return (
       <List disablePadding>
-        <SidebarListItem to="/tasks" icon={<HexagonMultipleIcon />}>
+        <SidebarListItem to="/tasks" icon={<FeatureSearchIcon />}>
           View Task
         </SidebarListItem>
         <SidebarListItem to="/tasks/create" icon={<PlusCircleIcon />}>

--- a/ui/src/components/Dashboard/SidebarList.jsx
+++ b/ui/src/components/Dashboard/SidebarList.jsx
@@ -26,11 +26,11 @@ export default class SidebarList extends Component {
   render() {
     return (
       <List disablePadding>
-        <SidebarListItem to="/tasks" icon={<FeatureSearchIcon />}>
-          View Task
-        </SidebarListItem>
         <SidebarListItem to="/tasks/create" icon={<PlusCircleIcon />}>
           Create task
+        </SidebarListItem>
+        <SidebarListItem to="/tasks" icon={<FeatureSearchIcon />}>
+          View Task
         </SidebarListItem>
         <SidebarListItem to="/tasks/groups" icon={<GroupIcon />}>
           Task Groups

--- a/ui/src/components/Log/ViewDifferentTaskButton.jsx
+++ b/ui/src/components/Log/ViewDifferentTaskButton.jsx
@@ -4,7 +4,6 @@ import Dialog from '@material-ui/core/Dialog';
 import DialogTitle from '@material-ui/core/DialogTitle';
 import DialogActions from '@material-ui/core/DialogActions';
 import DialogContent from '@material-ui/core/DialogContent';
-import DialogContentText from '@material-ui/core/DialogContentText';
 import TextField from '@material-ui/core/TextField';
 import FeatureSearchIcon from 'mdi-react/FeatureSearchIcon';
 import SpeedDialAction from '../SpeedDialAction';
@@ -19,10 +18,6 @@ export default class ViewDifferentTaskButton extends Component {
 
   handleChange = e => {
     this.setState({ taskId: e.target.value });
-
-    if (e.target.value) {
-      this.setState({ isValid: true });
-    }
   };
 
   handleClose = () => {
@@ -40,7 +35,7 @@ export default class ViewDifferentTaskButton extends Component {
 
   render() {
     const { open } = this.props;
-    const { dialogOpen, isValid } = this.state;
+    const { dialogOpen } = this.state;
 
     return (
       <Fragment>
@@ -63,25 +58,12 @@ export default class ViewDifferentTaskButton extends Component {
             View Different Task
           </DialogTitle>
           <DialogContent>
-            <DialogContentText>
-              <div>
-                <p>Require to match regular expression:</p>
-                <p>
-                  {
-                    '/^[A-Za-z0-9_-]{8}[Q-T][A-Za-z0-9_-][CGKOSWaeimquy26-][A-Za-z0-9_-]{10}[AQgw]$/'
-                  }
-                </p>
-              </div>
-            </DialogContentText>
             <form onSubmit={this.handleSubmit}>
               <TextField
-                id="text"
                 label="Task ID"
                 autoFocus
                 fullWidth
                 onChange={this.handleChange}
-                type="text"
-                margin="dense"
               />
             </form>
           </DialogContent>
@@ -89,10 +71,9 @@ export default class ViewDifferentTaskButton extends Component {
             <Button onClick={this.handleClose}>Cancel</Button>
             <Button
               onClick={this.handleSubmit}
-              disabled={!isValid}
               variant="contained"
               color="secondary">
-              Go to task
+              View Task
             </Button>
           </DialogActions>
         </Dialog>

--- a/ui/src/components/Log/ViewDifferentTaskButton.jsx
+++ b/ui/src/components/Log/ViewDifferentTaskButton.jsx
@@ -1,0 +1,91 @@
+import React, { Component, Fragment } from 'react';
+import { withRouter } from 'react-router-dom';
+import Dialog from '@material-ui/core/Dialog';
+import DialogTitle from '@material-ui/core/DialogTitle';
+import DialogActions from '@material-ui/core/DialogActions';
+import DialogContent from '@material-ui/core/DialogContent';
+import TextField from '@material-ui/core/TextField';
+import FeatureSearchIcon from 'mdi-react/FeatureSearchIcon';
+import SpeedDialAction from '../SpeedDialAction';
+import Button from '../Button';
+
+@withRouter
+export default class ViewDifferentTaskButton extends Component {
+  state = {
+    dialogOpen: false,
+    taskId: '',
+  };
+
+  handleChange = e => {
+    this.setState({ taskId: e.target.value });
+
+    if (e.target.value) {
+      this.setState({ isValid: true });
+    }
+  };
+
+  handleClose = () => {
+    this.setState({ dialogOpen: false });
+  };
+
+  handleOpenClick = () => {
+    this.setState({ dialogOpen: true });
+  };
+
+  handleSubmit = e => {
+    e.preventDefault();
+    this.props.history.push(`/tasks/${this.state.taskId}`);
+  };
+
+  render() {
+    const { open } = this.props;
+    const { dialogOpen, isValid } = this.state;
+
+    return (
+      <Fragment>
+        <SpeedDialAction
+          open={open}
+          tooltipOpen
+          icon={<FeatureSearchIcon />}
+          tooltipTitle="View Different Task"
+          onClick={this.handleOpenClick}
+          ButtonProps={{
+            variant: 'round',
+            color: 'secondary',
+          }}
+        />
+        <Dialog
+          open={dialogOpen}
+          onClose={this.handleClose}
+          aria-labelledby="view-different-task">
+          <DialogTitle id="view-different-task">
+            View Different Task
+          </DialogTitle>
+          <DialogContent>
+            <form onSubmit={this.handleSubmit}>
+              <TextField
+                id="text"
+                label="Task ID"
+                autoFocus
+                fullWidth
+                onChange={this.handleChange}
+                type="text"
+                margin="dense"
+              />
+            </form>
+          </DialogContent>
+          <DialogActions>
+            <Button onClick={this.handleClose}>Cancel</Button>
+            <Button
+              onClick={this.handleSubmit}
+              disabled={!isValid}
+              variant="contained"
+              color="secondary">
+              Go to task
+            </Button>
+          </DialogActions>
+        </Dialog>
+      </Fragment>
+    );
+  }
+}

--- a/ui/src/components/Log/ViewDifferentTaskButton.jsx
+++ b/ui/src/components/Log/ViewDifferentTaskButton.jsx
@@ -4,6 +4,7 @@ import Dialog from '@material-ui/core/Dialog';
 import DialogTitle from '@material-ui/core/DialogTitle';
 import DialogActions from '@material-ui/core/DialogActions';
 import DialogContent from '@material-ui/core/DialogContent';
+import DialogContentText from '@material-ui/core/DialogContentText';
 import TextField from '@material-ui/core/TextField';
 import FeatureSearchIcon from 'mdi-react/FeatureSearchIcon';
 import SpeedDialAction from '../SpeedDialAction';
@@ -62,6 +63,16 @@ export default class ViewDifferentTaskButton extends Component {
             View Different Task
           </DialogTitle>
           <DialogContent>
+            <DialogContentText>
+              <div>
+                <p>Require to match regular expression:</p>
+                <p>
+                  {
+                    '/^[A-Za-z0-9_-]{8}[Q-T][A-Za-z0-9_-][CGKOSWaeimquy26-][A-Za-z0-9_-]{10}[AQgw]$/'
+                  }
+                </p>
+              </div>
+            </DialogContentText>
             <form onSubmit={this.handleSubmit}>
               <TextField
                 id="text"

--- a/ui/src/components/Log/index.jsx
+++ b/ui/src/components/Log/index.jsx
@@ -253,8 +253,6 @@ export default class Log extends Component {
           href: url,
           target: '_blank',
           rel: 'noopener noreferrer',
-          variant: 'round',
-          color: 'secondary',
         }}
       />
     );

--- a/ui/src/components/Log/index.jsx
+++ b/ui/src/components/Log/index.jsx
@@ -11,6 +11,8 @@ import OpenInNewIcon from 'mdi-react/OpenInNewIcon';
 import GoToLineButton from './GoToLineButton';
 import Loading from './Loading';
 import Button from '../Button';
+import SpeedDial from '../SpeedDial';
+import SpeedDialAction from '../SpeedDialAction';
 
 const LINE_NUMBER_MATCH = /L(\d+)-?(\d+)?/;
 const FOLLOW_STORAGE_KEY = 'follow-log';
@@ -93,6 +95,11 @@ const FOLLOW_STORAGE_KEY = 'follow-log';
   fabIcon: {
     ...theme.mixins.fabIcon,
   },
+  logSpeedDial: {
+    ...theme.mixins.fab,
+    ...theme.mixins.actionButton,
+    bottom: theme.spacing.triple,
+  },
 }))
 /**
  * Render a lazy-loading log viewer.
@@ -102,7 +109,6 @@ export default class Log extends Component {
     stream: false,
     actions: null,
     GoToLineButtonProps: null,
-    RawLogButtonProps: null,
     FollowLogButtonProps: null,
   };
 
@@ -128,10 +134,6 @@ export default class Log extends Component {
      * Specify props for the "Follow log" floating action button.
      */
     FollowLogButtonProps: object,
-    /**
-     * Specify props for the "Raw log" floating action button.
-     */
-    RawLogButtonProps: object,
   };
 
   state = {
@@ -231,10 +233,6 @@ export default class Log extends Component {
       actions,
       GoToLineButtonProps,
       FollowLogButtonProps,
-      RawLogButtonProps: {
-        className: RawLogButtonClassName,
-        ...RawLogButtonPropsRest
-      },
       ...props
     } = this.props;
     const highlight = this.getHighlightFromHash();
@@ -245,18 +243,19 @@ export default class Log extends Component {
       overflow: 'initial',
     };
     const rawLogButton = (
-      <Button
-        spanProps={{ className: RawLogButtonClassName }}
-        tooltipProps={{ title: 'Raw Log' }}
-        component="a"
-        href={url}
-        target="_blank"
-        rel="noopener noreferrer"
-        variant="round"
-        color="secondary"
-        {...RawLogButtonPropsRest}>
-        <OpenInNewIcon />
-      </Button>
+      <SpeedDialAction
+        tooltipOpen
+        icon={<OpenInNewIcon />}
+        tooltipTitle="Raw Log"
+        ButtonProps={{
+          component: 'a',
+          href: url,
+          target: '_blank',
+          rel: 'noopener noreferrer',
+          variant: 'round',
+          color: 'secondary',
+        }}
+      />
     );
     const FollowLogButtonRest = omit(['className'], FollowLogButtonProps);
 
@@ -284,7 +283,6 @@ export default class Log extends Component {
               extraLines={5}
               {...props}
             />
-            {rawLogButton}
             <div className={classes.logActions}>
               <GoToLineButton
                 onLineNumberChange={this.handleLineNumberChange}
@@ -309,6 +307,9 @@ export default class Log extends Component {
               </Button>
             </div>
             {actions}
+            <SpeedDial className={classes.logSpeedDial}>
+              {rawLogButton}
+            </SpeedDial>
           </Fragment>
         )}
       />

--- a/ui/src/components/Log/index.jsx
+++ b/ui/src/components/Log/index.jsx
@@ -9,6 +9,7 @@ import { withStyles } from '@material-ui/core/styles';
 import ArrowDownBoldCircleOutlineIcon from 'mdi-react/ArrowDownBoldCircleOutlineIcon';
 import OpenInNewIcon from 'mdi-react/OpenInNewIcon';
 import GoToLineButton from './GoToLineButton';
+import ViewDifferentTaskButton from './ViewDifferentTaskButton';
 import Loading from './Loading';
 import Button from '../Button';
 import SpeedDial from '../SpeedDial';
@@ -308,6 +309,7 @@ export default class Log extends Component {
             </div>
             {actions}
             <SpeedDial className={classes.logSpeedDial}>
+              <ViewDifferentTaskButton />
               {rawLogButton}
             </SpeedDial>
           </Fragment>

--- a/ui/src/views/Tasks/TaskLog/index.jsx
+++ b/ui/src/views/Tasks/TaskLog/index.jsx
@@ -2,7 +2,7 @@ import { hot } from 'react-hot-loader';
 import React, { Component } from 'react';
 import { graphql } from 'react-apollo';
 import { withStyles } from '@material-ui/core/styles';
-import ArrowRightIcon from 'mdi-react/ArrowRightIcon';
+import ArrowLeftIcon from 'mdi-react/ArrowLeftIcon';
 import Dashboard from '../../../components/Dashboard';
 import Button from '../../../components/Button';
 import Log from '../../../components/Log';
@@ -55,7 +55,7 @@ export default class TaskLog extends Component {
               to={`/tasks/${match.params.taskId}/runs/${match.params.runId}`}
               variant="round"
               color="secondary">
-              <ArrowRightIcon />
+              <ArrowLeftIcon />
             </Button>
           }
         />

--- a/ui/src/views/Tasks/TaskLog/index.jsx
+++ b/ui/src/views/Tasks/TaskLog/index.jsx
@@ -16,11 +16,6 @@ import taskQuery from './task.graphql';
     ...theme.mixins.fab,
     ...theme.mixins.actionButton,
     bottom: theme.spacing.triple,
-  },
-  rawLogButton: {
-    ...theme.mixins.fab,
-    ...theme.mixins.actionButton,
-    bottom: theme.spacing.triple,
     right: theme.spacing.unit * 12,
   },
 }))
@@ -52,7 +47,6 @@ export default class TaskLog extends Component {
         <Log
           url={url}
           stream={stream}
-          RawLogButtonProps={{ className: classes.rawLogButton }}
           actions={
             <Button
               spanProps={{ className: classes.fab }}


### PR DESCRIPTION
### Description
* Related Issue #818 
* Move `Raw Log`  button into a `SpeedDial` component
* Add `View Different Task` button in `SpeedDial` to let users go to different tasks
