### PR TITLE
renovate: ignore golang.org/x/tools

### DIFF
--- a/package.json
+++ b/package.json
@@ -184,7 +184,12 @@
       "config:base",
       ":preserveSemverRanges",
       "schedule:weekly"
-    ]
+    ],
+    "gomod": {
+      "ignoreDeps": [
+        "golang.org/x/tools"
+      ]
+    }
   },
   "eslintIgnore": [
     "**/node_modules/**",


### PR DESCRIPTION
This package is not versioned using go modules, and gets updates all the
time, meaning that we get a renovate PR for it every week (such as #1115).
