### PR TITLE
require --force to rerun a non-failed, non-exception task

### DIFF
--- a/changelog/issue-1062.md
+++ b/changelog/issue-1062.md
@@ -1,0 +1,4 @@
+level: minor
+reference: issue #1062
+---
+The taskcluster cli `rerun` action now takes a `--force` option. It will refuse to rerun non-exception, non-failed tasks without `--force`.

--- a/clients/client-shell/cmds/task/actors_test.go
+++ b/clients/client-shell/cmds/task/actors_test.go
@@ -77,6 +77,7 @@ func (suite *FakeServerSuite) TestRunCancelCommand() {
 func (suite *FakeServerSuite) TestRunRerunCommand() {
 	// set up to run a command and capture output
 	buf, cmd := setUpCommand()
+	cmd.Flags().Bool("force", true, "")
 
 	// run the command
 	args := []string{fakeTaskID}

--- a/clients/client-shell/cmds/task/actors_test.go
+++ b/clients/client-shell/cmds/task/actors_test.go
@@ -74,7 +74,7 @@ func (suite *FakeServerSuite) TestRunCancelCommand() {
 	suite.Equal("cancelled 'cancelled'\n", buf.String())
 }
 
-func (suite *FakeServerSuite) TestRunRerunCommand() {
+func (suite *FakeServerSuite) TestRunRerunCommandForce() {
 	// set up to run a command and capture output
 	buf, cmd := setUpCommand()
 	cmd.Flags().Bool("force", true, "")
@@ -84,6 +84,17 @@ func (suite *FakeServerSuite) TestRunRerunCommand() {
 	assert.NoError(suite.T(), runRerun(&tcclient.Credentials{}, args, cmd.OutOrStdout(), cmd.Flags()))
 
 	suite.Equal("running 'running'\n", buf.String())
+}
+
+func (suite *FakeServerSuite) TestRunRerunCommandNoForce() {
+	// set up to run a command and capture output
+	_, cmd := setUpCommand()
+
+	// run the command
+	args := []string{fakeTaskID}
+	// this should error out, if we don't have --force on a completed
+	// task
+	assert.Error(suite.T(), runRerun(&tcclient.Credentials{}, args, cmd.OutOrStdout(), cmd.Flags()))
 }
 
 func (suite *FakeServerSuite) TestRunCompleteCommand() {

--- a/clients/client-shell/cmds/task/task.go
+++ b/clients/client-shell/cmds/task/task.go
@@ -57,6 +57,7 @@ func init() {
 
 	rerunCmd.Flags().BoolP("noop", "n", false, "Using this flag, will tell the command to not actually run, but prints out what it would do.")
 	rerunCmd.Flags().BoolP("confirm", "c", false, "Prompts user with a confirmation (y/n) before performing any changes.")
+	rerunCmd.Flags().BoolP("force", "f", false, "Allows a user to rerun a task not in the exception or failed state.")
 
 	runcancelCmd.Flags().BoolP("noop", "n", false, "Using this flag, will tell the command to not actually run, but prints out what it would do.")
 	runcancelCmd.Flags().BoolP("confirm", "c", false, "Prompts user with a confirmation (y/n) before performing any changes.")


### PR DESCRIPTION
This bit us again in Fx 69.0b9 this week. This appears to work in my limited testing:

- I can't rerun a green task without `--force`.
- I can rerun the green task with `--force`.
- I can rerun a red task without `--force`.

Fixes #1062.