### PR TITLE
Bug 1553953 - limit chars in provisionerId and workerType

### DIFF
--- a/changelog/bug1553953.md
+++ b/changelog/bug1553953.md
@@ -1,0 +1,13 @@
+level: minor
+reference: bug 1553953
+---
+
+The `workerType` identifier now has a more restrictive pattern:
+ * consisting of lower-case alphanumeric plus dash (`-`)
+ * from 1 to 38 characters long
+ * beginning with a lower-case alphabetic character
+ * ending with a lower-case alphanumeric character (not a dash)
+Any worker types not matching this pattern will no longer function as of this version.
+
+This is considered a minor change because no known workerTypes (aside from some
+internal testing workerTypes) violate this pattern.

--- a/clients/client-go/tcqueue/types.go
+++ b/clients/client-go/tcqueue/types.go
@@ -324,18 +324,15 @@ type (
 		// Mininum:    0
 		PendingTasks int64 `json:"pendingTasks"`
 
-		// Unique identifier for the provisioner
+		// Unique identifier for a provisioner, that can supply specified
+		// `workerType`
 		//
-		// Syntax:     ^([a-zA-Z0-9-_]*)$
-		// Min length: 1
-		// Max length: 38
+		// Syntax:     ^[a-zA-Z0-9-_]{1,38}$
 		ProvisionerID string `json:"provisionerId"`
 
-		// Identifier for worker type within the specified provisioner
+		// Unique identifier for a worker-type within a specific provisioner
 		//
-		// Syntax:     ^([a-zA-Z0-9-_]*)$
-		// Min length: 1
-		// Max length: 38
+		// Syntax:     ^[a-z]([-a-z0-9]{0,36}[a-z0-9])?$
 		WorkerType string `json:"workerType"`
 	}
 
@@ -560,9 +557,10 @@ type (
 		// Date and time where the provisioner was last seen active
 		LastDateActive tcclient.Time `json:"lastDateActive"`
 
-		// Syntax:     ^([a-zA-Z0-9-_]*)$
-		// Min length: 1
-		// Max length: 38
+		// Unique identifier for a provisioner, that can supply specified
+		// `workerType`
+		//
+		// Syntax:     ^[a-zA-Z0-9-_]{1,38}$
 		ProvisionerID string `json:"provisionerId"`
 
 		// This is the stability of the provisioner. Accepted values:
@@ -620,9 +618,10 @@ type (
 		// of when the provisioner was last seen active.
 		LastDateActive tcclient.Time `json:"lastDateActive"`
 
-		// Syntax:     ^([a-zA-Z0-9-_]*)$
-		// Min length: 1
-		// Max length: 38
+		// Unique identifier for a provisioner, that can supply specified
+		// `workerType`
+		//
+		// Syntax:     ^[a-zA-Z0-9-_]{1,38}$
 		ProvisionerID string `json:"provisionerId"`
 
 		// This is the stability of the provisioner. Accepted values:
@@ -1070,9 +1069,7 @@ type (
 		// Unique identifier for a provisioner, that can supply specified
 		// `workerType`
 		//
-		// Syntax:     ^([a-zA-Z0-9-_]*)$
-		// Min length: 1
-		// Max length: 38
+		// Syntax:     ^[a-zA-Z0-9-_]{1,38}$
 		ProvisionerID string `json:"provisionerId"`
 
 		// The tasks relation to its dependencies. This property specifies the
@@ -1160,9 +1157,7 @@ type (
 
 		// Unique identifier for a worker-type within a specific provisioner
 		//
-		// Syntax:     ^([a-zA-Z0-9-_]*)$
-		// Min length: 1
-		// Max length: 38
+		// Syntax:     ^[a-z]([-a-z0-9]{0,36}[a-z0-9])?$
 		WorkerType string `json:"workerType"`
 	}
 
@@ -1242,9 +1237,7 @@ type (
 		// Unique identifier for a provisioner, that can supply specified
 		// `workerType`
 		//
-		// Syntax:     ^([a-zA-Z0-9-_]*)$
-		// Min length: 1
-		// Max length: 38
+		// Syntax:     ^[a-zA-Z0-9-_]{1,38}$
 		ProvisionerID string `json:"provisionerId"`
 
 		// The tasks relation to its dependencies. This property specifies the
@@ -1332,9 +1325,7 @@ type (
 
 		// Unique identifier for a worker-type within a specific provisioner
 		//
-		// Syntax:     ^([a-zA-Z0-9-_]*)$
-		// Min length: 1
-		// Max length: 38
+		// Syntax:     ^[a-z]([-a-z0-9]{0,36}[a-z0-9])?$
 		WorkerType string `json:"workerType"`
 	}
 
@@ -1506,9 +1497,7 @@ type (
 		// Unique identifier for a provisioner, that can supply specified
 		// `workerType`
 		//
-		// Syntax:     ^([a-zA-Z0-9-_]*)$
-		// Min length: 1
-		// Max length: 38
+		// Syntax:     ^[a-zA-Z0-9-_]{1,38}$
 		ProvisionerID string `json:"provisionerId"`
 
 		// Number of retries left for the task in case of infrastructure issues
@@ -1567,9 +1556,7 @@ type (
 
 		// Unique identifier for a worker-type within a specific provisioner
 		//
-		// Syntax:     ^([a-zA-Z0-9-_]*)$
-		// Min length: 1
-		// Max length: 38
+		// Syntax:     ^[a-z]([-a-z0-9]{0,36}[a-z0-9])?$
 		WorkerType string `json:"workerType"`
 	}
 
@@ -1689,9 +1676,10 @@ type (
 		// Date of the first time this worker claimed a task.
 		FirstClaim tcclient.Time `json:"firstClaim"`
 
-		// Syntax:     ^([a-zA-Z0-9-_]*)$
-		// Min length: 1
-		// Max length: 38
+		// Unique identifier for a provisioner, that can supply specified
+		// `workerType`
+		//
+		// Syntax:     ^[a-zA-Z0-9-_]{1,38}$
 		ProvisionerID string `json:"provisionerId"`
 
 		// Quarantining a worker allows the machine to remain alive but not accept jobs.
@@ -1719,11 +1707,9 @@ type (
 		// Max length: 38
 		WorkerID string `json:"workerId"`
 
-		// WorkerType name.
+		// Unique identifier for a worker-type within a specific provisioner
 		//
-		// Syntax:     ^([a-zA-Z0-9-_]*)$
-		// Min length: 1
-		// Max length: 38
+		// Syntax:     ^[a-z]([-a-z0-9]{0,36}[a-z0-9])?$
 		WorkerType string `json:"workerType"`
 	}
 
@@ -1739,9 +1725,10 @@ type (
 		// Date and time where the worker-type was last seen active
 		LastDateActive tcclient.Time `json:"lastDateActive"`
 
-		// Syntax:     ^([a-zA-Z0-9-_]*)$
-		// Min length: 1
-		// Max length: 38
+		// Unique identifier for a provisioner, that can supply specified
+		// `workerType`
+		//
+		// Syntax:     ^[a-zA-Z0-9-_]{1,38}$
 		ProvisionerID string `json:"provisionerId"`
 
 		// This is the stability of the worker-type. Accepted values:
@@ -1755,11 +1742,9 @@ type (
 		//   * "deprecated"
 		Stability string `json:"stability"`
 
-		// WorkerType name.
+		// Unique identifier for a worker-type within a specific provisioner
 		//
-		// Syntax:     ^([a-zA-Z0-9-_]*)$
-		// Min length: 1
-		// Max length: 38
+		// Syntax:     ^[a-z]([-a-z0-9]{0,36}[a-z0-9])?$
 		WorkerType string `json:"workerType"`
 	}
 
@@ -1869,9 +1854,10 @@ type (
 		// of when the worker-type was last seen active.
 		LastDateActive tcclient.Time `json:"lastDateActive"`
 
-		// Syntax:     ^([a-zA-Z0-9-_]*)$
-		// Min length: 1
-		// Max length: 38
+		// Unique identifier for a provisioner, that can supply specified
+		// `workerType`
+		//
+		// Syntax:     ^[a-zA-Z0-9-_]{1,38}$
 		ProvisionerID string `json:"provisionerId"`
 
 		// This is the stability of the worker-type. Accepted values:
@@ -1885,11 +1871,9 @@ type (
 		//   * "deprecated"
 		Stability string `json:"stability"`
 
-		// WorkerType name.
+		// Unique identifier for a worker-type within a specific provisioner
 		//
-		// Syntax:     ^([a-zA-Z0-9-_]*)$
-		// Min length: 1
-		// Max length: 38
+		// Syntax:     ^[a-z]([-a-z0-9]{0,36}[a-z0-9])?$
 		WorkerType string `json:"workerType"`
 	}
 )

--- a/clients/client-go/tcqueueevents/types.go
+++ b/clients/client-go/tcqueueevents/types.go
@@ -450,9 +450,7 @@ type (
 		// Unique identifier for a provisioner, that can supply specified
 		// `workerType`
 		//
-		// Syntax:     ^([a-zA-Z0-9-_]*)$
-		// Min length: 1
-		// Max length: 38
+		// Syntax:     ^[a-zA-Z0-9-_]{1,38}$
 		ProvisionerID string `json:"provisionerId"`
 
 		// Number of retries left for the task in case of infrastructure issues
@@ -511,9 +509,7 @@ type (
 
 		// Unique identifier for a worker-type within a specific provisioner
 		//
-		// Syntax:     ^([a-zA-Z0-9-_]*)$
-		// Min length: 1
-		// Max length: 38
+		// Syntax:     ^[a-z]([-a-z0-9]{0,36}[a-z0-9])?$
 		WorkerType string `json:"workerType"`
 	}
 

--- a/generated/references.json
+++ b/generated/references.json
@@ -1490,11 +1490,7 @@
           "type": "string"
         },
         "provisionerId": {
-          "maxLength": 38,
-          "minLength": 1,
-          "pattern": "^([a-zA-Z0-9-_]*)$",
-          "title": "Provisioner ID",
-          "type": "string"
+          "$ref": "task.json#/properties/provisionerId"
         },
         "stability": {
           "description": "This is the stability of the worker-type. Accepted values:\n  * `experimental`\n  * `stable`\n  * `deprecated`\n",
@@ -1507,12 +1503,7 @@
           "type": "string"
         },
         "workerType": {
-          "description": "WorkerType name.\n",
-          "maxLength": 38,
-          "minLength": 1,
-          "pattern": "^([a-zA-Z0-9-_]*)$",
-          "title": "Worker-type Name",
-          "type": "string"
+          "$ref": "task.json#/properties/workerType"
         }
       },
       "required": [
@@ -1608,11 +1599,7 @@
           "type": "string"
         },
         "provisionerId": {
-          "maxLength": 38,
-          "minLength": 1,
-          "pattern": "^([a-zA-Z0-9-_]*)$",
-          "title": "Provisioner ID",
-          "type": "string"
+          "$ref": "task.json#/properties/provisionerId"
         },
         "quarantineUntil": {
           "description": "Quarantining a worker allows the machine to remain alive but not accept jobs.\nOnce the quarantineUntil time has elapsed, the worker resumes accepting jobs.\nNote that a quarantine can be lifted by setting `quarantineUntil` to the present time (or\nsomewhere in the past).\n",
@@ -1646,12 +1633,7 @@
           "type": "string"
         },
         "workerType": {
-          "description": "WorkerType name.\n",
-          "maxLength": 38,
-          "minLength": 1,
-          "pattern": "^([a-zA-Z0-9-_]*)$",
-          "title": "WorkerType name",
-          "type": "string"
+          "$ref": "task.json#/properties/workerType"
         }
       },
       "required": [
@@ -1838,9 +1820,7 @@
         },
         "provisionerId": {
           "description": "Unique identifier for a provisioner, that can supply specified\n`workerType`\n",
-          "maxLength": 38,
-          "minLength": 1,
-          "pattern": "^([a-zA-Z0-9-_]*)$",
+          "pattern": "^[a-zA-Z0-9-_]{1,38}$",
           "title": "Provisioner Id",
           "type": "string"
         },
@@ -1918,9 +1898,7 @@
         },
         "workerType": {
           "description": "Unique identifier for a worker-type within a specific provisioner\n",
-          "maxLength": 38,
-          "minLength": 1,
-          "pattern": "^([a-zA-Z0-9-_]*)$",
+          "pattern": "^[a-z]([-a-z0-9]{0,36}[a-z0-9])?$",
           "title": "Worker Type",
           "type": "string"
         }
@@ -2871,11 +2849,7 @@
           "type": "string"
         },
         "provisionerId": {
-          "maxLength": 38,
-          "minLength": 1,
-          "pattern": "^([a-zA-Z0-9-_]*)$",
-          "title": "Provisioner ID",
-          "type": "string"
+          "$ref": "task.json#/properties/provisionerId"
         },
         "stability": {
           "description": "This is the stability of the provisioner. Accepted values:\n  * `experimental`\n  * `stable`\n  * `deprecated`\n",
@@ -3386,20 +3360,10 @@
           "type": "integer"
         },
         "provisionerId": {
-          "description": "Unique identifier for the provisioner\n",
-          "maxLength": 38,
-          "minLength": 1,
-          "pattern": "^([a-zA-Z0-9-_]*)$",
-          "title": "Provisioner Id",
-          "type": "string"
+          "$ref": "task.json#/properties/provisionerId"
         },
         "workerType": {
-          "description": "Identifier for worker type within the specified provisioner\n",
-          "maxLength": 38,
-          "minLength": 1,
-          "pattern": "^([a-zA-Z0-9-_]*)$",
-          "title": "Worker Type",
-          "type": "string"
+          "$ref": "task.json#/properties/workerType"
         }
       },
       "required": [
@@ -3447,11 +3411,7 @@
                 "type": "string"
               },
               "provisionerId": {
-                "maxLength": 38,
-                "minLength": 1,
-                "pattern": "^([a-zA-Z0-9-_]*)$",
-                "title": "Provisioner ID",
-                "type": "string"
+                "$ref": "task.json#/properties/provisionerId"
               },
               "stability": {
                 "description": "This is the stability of the worker-type. Accepted values:\n * `experimental`\n * `stable`\n * `deprecated`\n",
@@ -3464,12 +3424,7 @@
                 "type": "string"
               },
               "workerType": {
-                "description": "WorkerType name.\n",
-                "maxLength": 38,
-                "minLength": 1,
-                "pattern": "^([a-zA-Z0-9-_]*)$",
-                "title": "WorkerType name",
-                "type": "string"
+                "$ref": "task.json#/properties/workerType"
               }
             },
             "required": [
@@ -3639,11 +3594,7 @@
                 "type": "string"
               },
               "provisionerId": {
-                "maxLength": 38,
-                "minLength": 1,
-                "pattern": "^([a-zA-Z0-9-_]*)$",
-                "title": "Provisioner ID",
-                "type": "string"
+                "$ref": "task.json#/properties/provisionerId"
               },
               "stability": {
                 "description": "This is the stability of the provisioner. Accepted values:\n * `experimental`\n * `stable`\n * `deprecated`\n",

--- a/services/queue/schemas/constants.yml
+++ b/services/queue/schemas/constants.yml
@@ -31,6 +31,13 @@ identifier-pattern:     ^([a-zA-Z0-9-_]*)$
 identifier-min-length:  1
 identifier-max-length:  38
 
+# provisionerId and workerType together form a workerPoolId, so these are
+# components of worker-manager's workerpoolid-pattern.  Note that both of these
+# enforce character length limits, so no `..-{min,max}-length` constants are
+# required.
+provisionerid-pattern: '^[a-zA-Z0-9-_]{1,38}$'
+workertype-pattern: '^[a-z]([-a-z0-9]{0,36}[a-z0-9])?$'
+
 # Run identifier limitations, these are also somewhat founded in RabbitMQ
 # routing key limitations
 min-run-id:     0

--- a/services/queue/schemas/v1/list-provisioners-response.yml
+++ b/services/queue/schemas/v1/list-provisioners-response.yml
@@ -9,12 +9,7 @@ properties:
       title:      "Provisioner Information"
       type:       object
       properties:
-        provisionerId:
-          title:        "Provisioner ID"
-          type:         string
-          minLength:    {$const: identifier-min-length}
-          maxLength:    {$const: identifier-max-length}
-          pattern:      {$const: identifier-pattern}
+        provisionerId: {$ref: "task.json#/properties/provisionerId"}
         stability:
           title:        "Stability"
           description: |

--- a/services/queue/schemas/v1/list-workertypes-response.yml
+++ b/services/queue/schemas/v1/list-workertypes-response.yml
@@ -14,20 +14,8 @@ properties:
       type:         object
       title:        "Worker Type"
       properties:
-        workerType:
-          type:           string
-          title:          "WorkerType name"
-          description: |
-            WorkerType name.
-          minLength:    {$const: identifier-min-length}
-          maxLength:    {$const: identifier-max-length}
-          pattern:      {$const: identifier-pattern}
-        provisionerId:
-          title:        "Provisioner ID"
-          type:         string
-          minLength:    {$const: identifier-min-length}
-          maxLength:    {$const: identifier-max-length}
-          pattern:      {$const: identifier-pattern}
+        provisionerId: {$ref: "task.json#/properties/provisionerId"}
+        workerType: {$ref: "task.json#/properties/workerType"}
         stability:
           title:        "Stability"
           description: |

--- a/services/queue/schemas/v1/pending-tasks-response.yml
+++ b/services/queue/schemas/v1/pending-tasks-response.yml
@@ -5,22 +5,8 @@ description: |
   `provisionerId` and `workerType`.
 type:               object
 properties:
-  provisionerId:
-    title:          "Provisioner Id"
-    description: |
-      Unique identifier for the provisioner
-    type:           string
-    minLength:      {$const: identifier-min-length}
-    maxLength:      {$const: identifier-max-length}
-    pattern:        {$const: identifier-pattern}
-  workerType:
-    title:          "Worker Type"
-    description: |
-      Identifier for worker type within the specified provisioner
-    type:           string
-    minLength:      {$const: identifier-min-length}
-    maxLength:      {$const: identifier-max-length}
-    pattern:        {$const: identifier-pattern}
+  provisionerId: {$ref: "task.json#/properties/provisionerId"}
+  workerType: {$ref: "task.json#/properties/workerType"}
   pendingTasks:
     type:           integer
     minimum:        0

--- a/services/queue/schemas/v1/provisioner-response.yml
+++ b/services/queue/schemas/v1/provisioner-response.yml
@@ -4,12 +4,7 @@ description: |
   Response containing information about a provisioner.
 type:           object
 properties:
-  provisionerId:
-    title:        "Provisioner ID"
-    type:         string
-    minLength:    {$const: identifier-min-length}
-    maxLength:    {$const: identifier-max-length}
-    pattern:      {$const: identifier-pattern}
+  provisionerId: {$ref: "task.json#/properties/provisionerId"}
   stability:
     title:        "Stability"
     description: |

--- a/services/queue/schemas/v1/task.yml
+++ b/services/queue/schemas/v1/task.yml
@@ -10,17 +10,13 @@ properties:
       Unique identifier for a provisioner, that can supply specified
       `workerType`
     type:           string
-    minLength:      {$const: identifier-min-length}
-    maxLength:      {$const: identifier-max-length}
-    pattern:        {$const: identifier-pattern}
+    pattern:        {$const: provisionerid-pattern}
   workerType:
     title:          "Worker Type"
     description: |
       Unique identifier for a worker-type within a specific provisioner
     type:           string
-    minLength:      {$const: identifier-min-length}
-    maxLength:      {$const: identifier-max-length}
-    pattern:        {$const: identifier-pattern}
+    pattern:        {$const: workertype-pattern}
   schedulerId:
     title:          "Scheduler Identifier"
     description: |

--- a/services/queue/schemas/v1/worker-response.yml
+++ b/services/queue/schemas/v1/worker-response.yml
@@ -4,20 +4,8 @@ description: |
   Response containing information about a worker.
 type:           object
 properties:
-  provisionerId:
-    title:        "Provisioner ID"
-    type:         string
-    minLength:    {$const: identifier-min-length}
-    maxLength:    {$const: identifier-max-length}
-    pattern:      {$const: identifier-pattern}
-  workerType:
-    type:         string
-    title:        "WorkerType name"
-    description: |
-      WorkerType name.
-    minLength:    {$const: identifier-min-length}
-    maxLength:    {$const: identifier-max-length}
-    pattern:      {$const: identifier-pattern}
+  provisionerId: {$ref: "task.json#/properties/provisionerId"}
+  workerType: {$ref: "task.json#/properties/workerType"}
   workerGroup:
     title:        "Worker Group"
     description: |

--- a/services/queue/schemas/v1/workertype-response.yml
+++ b/services/queue/schemas/v1/workertype-response.yml
@@ -4,20 +4,8 @@ description: |
   Response to a worker-type request from a provisioner.
 type:           object
 properties:
-  provisionerId:
-    title:        "Provisioner ID"
-    type:         string
-    minLength:    {$const: identifier-min-length}
-    maxLength:    {$const: identifier-max-length}
-    pattern:      {$const: identifier-pattern}
-  workerType:
-    type:         string
-    title:        "Worker-type Name"
-    description: |
-      WorkerType name.
-    minLength:    {$const: identifier-min-length}
-    maxLength:    {$const: identifier-max-length}
-    pattern:      {$const: identifier-pattern}
+  provisionerId: {$ref: "task.json#/properties/provisionerId"}
+  workerType: {$ref: "task.json#/properties/workerType"}
   stability:
     title:        "Stability"
     description: |

--- a/services/queue/test/claimresolver_test.js
+++ b/services/queue/test/claimresolver_test.js
@@ -18,7 +18,7 @@ helper.secrets.mockSuite(testing.suiteName(), ['taskcluster', 'aws', 'azure'], f
   helper.withServer(mock, skipping);
 
   // Generate random workerType id to use for this test
-  const workerType = slugid.v4();
+  const workerType = helper.makeWorkerType();
 
   const makeTask = (retries) => {
     return {

--- a/services/queue/test/claimwork_test.js
+++ b/services/queue/test/claimwork_test.js
@@ -18,7 +18,7 @@ helper.secrets.mockSuite(testing.suiteName(), ['taskcluster', 'aws', 'azure'], f
   helper.withServer(mock, skipping);
 
   // Generate random workerType id to use for this test
-  const workerType = slugid.v4();
+  const workerType = helper.makeWorkerType();
 
   const makeTask = (priority, workerType) => {
     return {
@@ -263,7 +263,7 @@ helper.secrets.mockSuite(testing.suiteName(), ['taskcluster', 'aws', 'azure'], f
   });
 
   test('createTask twice, claimWork, reportCompleted', async () => {
-    let workerType = slugid.v4(); // need a fresh workerType
+    let workerType = helper.makeWorkerType();
     let taskId = slugid.v4();
     let task = makeTask('normal', workerType);
 

--- a/services/queue/test/helper.js
+++ b/services/queue/test/helper.js
@@ -1,4 +1,5 @@
 const _ = require('lodash');
+const slugid = require('slugid');
 const taskcluster = require('taskcluster-client');
 const libUrls = require('taskcluster-lib-urls');
 const builder = require('../src/api');
@@ -331,3 +332,8 @@ helper.runExpiration = async component => {
     helper.load.restore();
   }
 };
+
+/**
+ * Make a random workerType name
+ */
+exports.makeWorkerType = () => `test-${slugid.v4().replace(/[_-]/g, '').toLowerCase()}-a`;

--- a/services/worker-manager/schemas/constants.yml
+++ b/services/worker-manager/schemas/constants.yml
@@ -10,6 +10,6 @@ identifier-max-length:  38
 # Slugid pattern, for when-ever that is useful
 slugid-pattern: "^[A-Za-z0-9_-]{8}[Q-T][A-Za-z0-9_-][CGKOSWaeimquy26-][A-Za-z0-9_-]{10}[AQgw]$"
 
-# Note that the portion after the `/` is quite severely limited in hopes it works with
+# Note that this pattern corresponds to queue's provisionerid-pattern + `/` + workertype-pattern
 # most cloud providers
 workerpoolid-pattern: '^[a-zA-Z0-9-_]{1,38}/[a-z]([-a-z0-9]{0,36}[a-z0-9])?$'


### PR DESCRIPTION
This brings these symbols into correspondence with the limits on
workerPoolId, which are designed to be compatible with various cloud
providers.

Bugzilla Bug: [1553953](https://bugzilla.mozilla.org/show_bug.cgi?id=1553953)
