### PR TITLE
Bug 1572764: Do not automatically log HTTP transactions in go client

### DIFF
--- a/changelog/bug1572764.md
+++ b/changelog/bug1572764.md
@@ -1,0 +1,8 @@
+level: minor
+reference: bug 1572764
+---
+
+The go client doesn't log the full request in case of an error anymore.
+It logs only the method, hostname, port and response body. It logs the
+full request when the environment variable `TASKCLUSTER_DEBUG` is
+defined.


### PR DESCRIPTION
By default, only logs method, hostname, port, and response body.
It avoids leaks of secrets contained in the requests.

If the environment variable `TASKCLUSTER_DEBUG` is defined, then the
full request is logged.

Bugzilla Bug: [1572764](https://bugzilla.mozilla.org/show_bug.cgi?id=1572764)
