### PR TITLE
Bug 1571133 - report worker pool errors to service log

### DIFF
--- a/generated/references.json
+++ b/generated/references.json
@@ -7767,6 +7767,21 @@
           "version": 1
         },
         {
+          "description": "An error was reported regarding the given worker pool.  Such errors are generally\nthe responsibility of the owner of the worker pool, but may also indicate issues\nwith the Taskcluster deployment and as such are reported in the service logs as\nwell.  Note that the 'extra' data associated with such a report is not included\nhere.  To see that, use the UI or API to view the worker pool errors directly.",
+          "fields": {
+            "description": "Description of the error",
+            "errorId": "The unique id of this error report",
+            "kind": "The error kind",
+            "title": "The error title",
+            "workerPoolId": "The workerPool where the error occurred"
+          },
+          "level": "warning",
+          "name": "workerError",
+          "title": "Worker Error",
+          "type": "worker-error",
+          "version": 1
+        },
+        {
           "description": "A connection to Pulse has been established.  Taskcluster services\nautomatically reconnect to Pulse periodically and in the event of\nan error, but rapid reconnections may signal a Pulse failure.",
           "fields": {
           },

--- a/generated/references.json
+++ b/generated/references.json
@@ -7775,7 +7775,7 @@
             "title": "The error title",
             "workerPoolId": "The workerPool where the error occurred"
           },
-          "level": "warning",
+          "level": "notice",
           "name": "workerError",
           "title": "Worker Error",
           "type": "worker-error",

--- a/services/worker-manager/src/api.js
+++ b/services/worker-manager/src/api.js
@@ -20,7 +20,6 @@ let builder = new APIBuilder({
     'WorkerPoolError',
     'providers',
     'publisher',
-    'notify',
   ],
 });
 
@@ -292,8 +291,6 @@ builder.declare({
     title: input.title,
     description: input.description,
     extra: {...input.extra, workerGroup, workerId},
-    notify: this.notify,
-    WorkerPoolError: this.WorkerPoolError,
   });
 
   res.reply(wpe.serializable());

--- a/services/worker-manager/src/main.js
+++ b/services/worker-manager/src/main.js
@@ -45,8 +45,8 @@ let load = loader({
   },
 
   WorkerPool: {
-    requires: ['cfg', 'monitor'],
-    setup: ({cfg, monitor}) => data.WorkerPool.setup({
+    requires: ['cfg', 'monitor', 'notify', 'WorkerPoolError'],
+    setup: ({cfg, monitor, notify, WorkerPoolError}) => data.WorkerPool.setup({
       tableName: cfg.app.workerPoolTableName,
       credentials: sasCredentials({
         accountId: cfg.azure.accountId,
@@ -55,6 +55,11 @@ let load = loader({
         credentials: cfg.taskcluster.credentials,
       }),
       monitor: monitor.childMonitor('table.workerPools'),
+      context: {
+        monitor,
+        notify,
+        WorkerPoolError,
+      },
     }),
   },
 
@@ -142,7 +147,7 @@ let load = loader({
   },
 
   api: {
-    requires: ['cfg', 'schemaset', 'monitor', 'Worker', 'WorkerPool', 'WorkerPoolError', 'providers', 'publisher', 'notify'],
+    requires: ['cfg', 'schemaset', 'monitor', 'Worker', 'WorkerPool', 'WorkerPoolError', 'providers', 'publisher'],
     setup: async ({
       cfg,
       schemaset,
@@ -152,7 +157,6 @@ let load = loader({
       WorkerPoolError,
       providers,
       publisher,
-      notify,
     }) => builder.build({
       rootUrl: cfg.taskcluster.rootUrl,
       context: {
@@ -162,7 +166,6 @@ let load = loader({
         WorkerPoolError,
         providers,
         publisher,
-        notify,
       },
       monitor: monitor.childMonitor('api'),
       schemaset,

--- a/services/worker-manager/src/monitor.js
+++ b/services/worker-manager/src/monitor.js
@@ -35,4 +35,25 @@ monitorManager.register({
   },
 });
 
+monitorManager.register({
+  name: 'workerError',
+  type: 'worker-error',
+  title: 'Worker Error',
+  level: 'warning',
+  version: 1,
+  description: `
+    An error was reported regarding the given worker pool.  Such errors are generally
+    the responsibility of the owner of the worker pool, but may also indicate issues
+    with the Taskcluster deployment and as such are reported in the service logs as
+    well.  Note that the 'extra' data associated with such a report is not included
+    here.  To see that, use the UI or API to view the worker pool errors directly.`,
+  fields: {
+    workerPoolId: 'The workerPool where the error occurred',
+    errorId: 'The unique id of this error report',
+    kind: 'The error kind',
+    title: 'The error title',
+    description: 'Description of the error',
+  },
+});
+
 module.exports = monitorManager;

--- a/services/worker-manager/src/monitor.js
+++ b/services/worker-manager/src/monitor.js
@@ -39,7 +39,7 @@ monitorManager.register({
   name: 'workerError',
   type: 'worker-error',
   title: 'Worker Error',
-  level: 'warning',
+  level: 'notice',
   version: 1,
   description: `
     An error was reported regarding the given worker pool.  Such errors are generally

--- a/services/worker-manager/src/providers/google.js
+++ b/services/worker-manager/src/providers/google.js
@@ -325,8 +325,6 @@ class GoogleProvider extends Provider {
             kind: 'creation-error',
             title: 'Instance Creation Error',
             description: error.message, // TODO: Make sure we clear exposing this with security folks
-            notify: this.notify,
-            WorkerPoolError: this.WorkerPoolError,
           });
         }
         return;

--- a/services/worker-manager/test/worker_pool_errors_test.js
+++ b/services/worker-manager/test/worker_pool_errors_test.js
@@ -140,7 +140,7 @@ helper.secrets.mockSuite(testing.suiteName(), ['taskcluster', 'azure'], function
         description: 'WHO KNOWS',
         v: 1,
       },
-      Severity: LEVELS.warning,
+      Severity: LEVELS.notice,
     });
   });
 });


### PR DESCRIPTION
These aren't reported as errors in the service log (so wouldn't go to
StackDriver, for example), but still constitute useful data for service
operators who might, for example, monitor the frequency of such errors
and use that to get alerted of cloud-related outages (with attendant
false-positives from someone misconfiguring their worker pool).

Bugzilla Bug: [1571133](https://bugzilla.mozilla.org/show_bug.cgi?id=1571133)
