### PR TITLE
Bug 1574656 - add workerConfig to google configs

### DIFF
--- a/changelog/bug1574656.md
+++ b/changelog/bug1574656.md
@@ -1,0 +1,5 @@
+level: patch
+reference: bug 1574656
+---
+Worker-pool configurations for google-based providers now accept a `workerConfig` property, which is passed to new workers.
+The existing `userData` property is deprecated.

--- a/generated/references.json
+++ b/generated/references.json
@@ -753,8 +753,14 @@
         },
         "userData": {
           "additionalProperties": true,
-          "description": "Arbitrary configuration that Worker Manager will make available to the worker\non start up via instance metadata.\n",
-          "title": "User Data",
+          "description": "Supplied as a `userData` property in the `taskcluster` instance metadata attribute.\n[Taskcluster-worker-runner](https://github.com/taskcluster/taskcluster-worker-runner) ignores this field.\nPrefer to use the `workerConfig` property.\n",
+          "title": "User Data (deprecated)",
+          "type": "object"
+        },
+        "workerConfig": {
+          "additionalProperties": true,
+          "description": "This value is supplied unchanged as the `workerConfig` property of the `taskcluster` instance metadata attribute.\nThe expectation is that the worker will merge this information with configuration from other sources,\nand this is precisely what [taskcluster-worker-runner](https://github.com/taskcluster/taskcluster-worker-runner) does.\nThis property must not be used for secret configuration, as it is visible both in the worker pool configuration and in the worker instance's metadata.\nInstead, put secret configuration in the [secrets service](https://github.com/taskcluster/taskcluster-worker-runner#secrets).\n",
+          "title": "Worker Config",
           "type": "object"
         }
       },
@@ -764,7 +770,6 @@
         "capacityPerInstance",
         "machineType",
         "regions",
-        "userData",
         "scheduling",
         "networkInterfaces",
         "disks"

--- a/services/worker-manager/schemas/v1/config-google.yml
+++ b/services/worker-manager/schemas/v1/config-google.yml
@@ -38,13 +38,16 @@ properties:
     uniqueItems: true
     items:
       type: string
-  userData:
-    title: User Data
+  workerConfig:
+    title: Worker Config
     type: object
     additionalProperties: true
     description: |
-      Arbitrary configuration that Worker Manager will make available to the worker
-      on start up via instance metadata.
+      This value is supplied unchanged as the `workerConfig` property of the `taskcluster` instance metadata attribute.
+      The expectation is that the worker will merge this information with configuration from other sources,
+      and this is precisely what [taskcluster-worker-runner](https://github.com/taskcluster/taskcluster-worker-runner) does.
+      This property must not be used for secret configuration, as it is visible both in the worker pool configuration and in the worker instance's metadata.
+      Instead, put secret configuration in the [secrets service](https://github.com/taskcluster/taskcluster-worker-runner#secrets).
   scheduling:
     title: Scheduling
     type: object
@@ -72,6 +75,14 @@ properties:
     items:
       type: object
       additionalProperties: true
+  userData:
+    title: User Data (deprecated)
+    type: object
+    additionalProperties: true
+    description: |
+      Supplied as a `userData` property in the `taskcluster` instance metadata attribute.
+      [Taskcluster-worker-runner](https://github.com/taskcluster/taskcluster-worker-runner) ignores this field.
+      Prefer to use the `workerConfig` property.
 additionalProperties: false
 required:
   - minCapacity
@@ -79,7 +90,6 @@ required:
   - capacityPerInstance
   - machineType
   - regions
-  - userData
   - scheduling
   - networkInterfaces
   - disks

--- a/services/worker-manager/src/providers/google.js
+++ b/services/worker-manager/src/providers/google.js
@@ -308,6 +308,7 @@ class GoogleProvider extends Provider {
                     providerId: this.providerId,
                     workerGroup: this.providerId,
                     rootUrl: this.rootUrl,
+                    workerConfig: workerPool.config.workerConfig || {},
                     userData: workerPool.config.userData,
                   }),
                 },

--- a/services/worker-manager/test/api_test.js
+++ b/services/worker-manager/test/api_test.js
@@ -765,7 +765,7 @@ helper.secrets.mockSuite(testing.suiteName(), ['taskcluster', 'azure'], function
       capacityPerInstance: 1,
       machineType: 'n1-standard-2',
       regions: ['us-east1'],
-      userData: {},
+      workerConfig: {},
       scheduling: {},
       networkInterfaces: [],
       disks: [],

--- a/services/worker-manager/test/provider_google_test.js
+++ b/services/worker-manager/test/provider_google_test.js
@@ -48,7 +48,7 @@ helper.secrets.mockSuite(testing.suiteName(), ['taskcluster', 'azure'], function
         capacityPerInstance: 1,
         machineType: 'n1-standard-2',
         regions: ['us-east1'],
-        userData: {},
+        workerConfig: {},
         scheduling: {},
         networkInterfaces: [],
         disks: [],

--- a/ui/docs/reference/core/worker-manager/google.md
+++ b/ui/docs/reference/core/worker-manager/google.md
@@ -92,7 +92,8 @@ The provider starts workers with an instance attribute named `taskcluster` conta
 * `providerId` -- provider ID that started the worker
 * `workerGroup` -- the worker's workerGroup (currently equal to the providerId, but do not depend on this)
 * `rootUrl` -- root URL for the Taskcluster deployment
-* `userData` -- userData from the worker pool configuration
+* `workerConfig` -- worker configuration supplied as part of the worker pool configuration
+* `userData` -- userData from the worker pool configuration (deprecated)
 
 The worker's `workerId` is identical to its instance ID, which can be retrieved from the GCP metadata service at `instance/id`.
 


### PR DESCRIPTION
The `userData` property remains just so that existing configs continue to work after this change.  It is ignored by tc-worker-runner.

I didn't see an easy way to assert this was being added to the metadata, but it seems clear enough.

Bugzilla Bug: [1574656](https://bugzilla.mozilla.org/show_bug.cgi?id=1574656)
