### PR TITLE
Fix pulse namespace for index

### DIFF
--- a/services/index/src/main.js
+++ b/services/index/src/main.js
@@ -118,7 +118,7 @@ let load = loader({
     requires: ['cfg', 'monitor'],
     setup: ({cfg, monitor}) => {
       return new Client({
-        namespace: 'takslcuster-index',
+        namespace: 'taskcluster-index',
         monitor: monitor.childMonitor('pulse-client'),
         credentials: pulseCredentials(cfg.pulse),
       });


### PR DESCRIPTION
taskcluster-index-handlers fails to start in v16.1.0 with the error ` "Error: Operation failed: QueueDeclare; 403 (ACCESS-REFUSED) with message "ACCESS_REFUSED - access to queue 'queue/takslcuster-index/index/incoming-tasks2'` because the namespace has a typo.