### PR TITLE
[hotfix] Make script path absolute

### DIFF
--- a/ui/src/index.html
+++ b/ui/src/index.html
@@ -4,7 +4,7 @@
         <meta charset="utf-8"/>
     </head>
     <body>
-        <script src="./static/env.js"></script>
+        <script src="/static/env.js"></script>
         <div id="root"></div>
     </body>
 </html>


### PR DESCRIPTION
Nested links are not working in the UI after adding `<script src="./static/env.js"></script>`. This PR makes it absolute rather than relative.