### PR TITLE
fix - can't copy from scope expander

### DIFF
--- a/ui/src/theme.js
+++ b/ui/src/theme.js
@@ -329,6 +329,19 @@ const createTheme = isDarkTheme => {
           },
         },
       },
+      MuiListItem: {
+        root: {
+          userSelect: 'text',
+        },
+      },
+      MuiChip: {
+        label: {
+          userSelect: 'text',
+        },
+        root: {
+          userSelect: 'text',
+        },
+      },
       MuiPickersCalendarHeader: {
         iconButton: {
           backgroundColor: 'transparent',


### PR DESCRIPTION
Fixes #1211 

Hey @helfi92 !

I couldn't locally test the changes after the latest commit on package.json in ```ui/package.json```, the start script throws this error:

```
$ GENERATE_ENV_JS=1 webpack-dev-server --mode development
'GENERATE_ENV_JS' is not recognized as an internal or external command,
operable program or batch file.
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

I believe this is some kind of issue with windows. Could you please tell me a way around this?

Also, do we need a ripple affect on button click, or the hover effects would suffice?

And I did see the deploy preview, and we can copy from scope expander now! =)

And, what other changes does this need?

Thanks! =)