### PR TITLE
Avoid passing unnecessary `onTaskNamespaceClick` prop to `IndexTaskNamespaceTable` component

### DIFF
--- a/ui/src/views/Tasks/TaskIndex/ListNamespaces/index.jsx
+++ b/ui/src/views/Tasks/TaskIndex/ListNamespaces/index.jsx
@@ -158,7 +158,6 @@ export default class ListNamespaces extends Component {
             <Fragment>
               <Typography variant="subtitle1">Indexed Tasks</Typography>
               <IndexTaskNamespaceTable
-                onTaskNamespaceClick={this.handleTaskNamespaceClick}
                 onPageChange={this.handleTaskNamespacePageChange}
                 connection={taskNamespace}
               />


### PR DESCRIPTION
The [ `IndexTaskNamespaceTable` component](https://github.com/taskcluster/taskcluster/blob/master/ui/src/components/IndexTaskNamespaceTable/index.jsx#L32) does not require a `onTaskNamespaceClick` prop but was passed one. This PR cleans it up.