### PR TITLE
[hotfix] Fix worker-manager tests

### DIFF
--- a/services/worker-manager/test/api_test.js
+++ b/services/worker-manager/test/api_test.js
@@ -41,9 +41,9 @@ helper.secrets.mockSuite(testing.suiteName(), ['taskcluster', 'azure'], function
       }
     }
 
-    assert.equal(pages, 4);
+    assert.equal(pages, 5);
     assert.deepStrictEqual(providerIds.sort(),
-      ['testing1', 'testing2', 'static', 'google'].sort());
+      ['testing1', 'testing2', 'static', 'google', 'aws'].sort());
   });
 
   const workerPoolCompare = (workerPoolId, input, result) => {


### PR DESCRIPTION
This was a semantic merge conflict: a PR landed to add a new provider at
about the same time as a PR landed assuming the current number of
providers.
