### PR TITLE
Google provider cleanup part 1

### DIFF
--- a/services/worker-manager/config.yml
+++ b/services/worker-manager/config.yml
@@ -44,5 +44,8 @@ test:
       providerType: static
     google:
       providerType: google
+      project: foo
+      creds: {}
+      workerServiceAccountId: 12345
     aws:
       providerType: aws

--- a/services/worker-manager/src/providers/google.js
+++ b/services/worker-manager/src/providers/google.js
@@ -1,6 +1,5 @@
 const slugid = require('slugid');
 const _ = require('lodash');
-const fs = require('fs');
 const taskcluster = require('taskcluster-client');
 const uuid = require('uuid');
 const {google} = require('googleapis');
@@ -14,25 +13,21 @@ class GoogleProvider extends Provider {
     ...conf
   }) {
     super(conf);
-    let {project, instancePermissions, creds, credsFile} = providerConfig;
+    let {project, creds, workerServiceAccountId} = providerConfig;
     this.configSchema = 'config-google';
 
-    this.instancePermissions = instancePermissions;
     this.project = project;
     this.zonesByRegion = {};
+    this.workerServiceAccountId = workerServiceAccountId;
+    this.workerServiceAccountEmail = `${workerServiceAccountId}@${project}.iam.gserviceaccount.com`;
 
     if (fakeCloudApis && fakeCloudApis.google) {
       this.ownClientEmail = 'whatever@example.com';
       this.compute = fakeCloudApis.google.compute();
-      this.iam = fakeCloudApis.google.iam();
-      this.crm = fakeCloudApis.google.cloudresourcemanager();
       this.oauth2 = new fakeCloudApis.google.OAuth2({project});
       return;
     }
 
-    if (!creds && credsFile) {
-      creds = JSON.parse(fs.readFileSync(credsFile));
-    }
     try {
       creds = JSON.parse(creds);
     } catch (err) {
@@ -45,122 +40,12 @@ class GoogleProvider extends Provider {
     const client = google.auth.fromJSON(creds);
     client.scopes = [
       'https://www.googleapis.com/auth/compute', // For configuring instance templates, groups, etc
-      'https://www.googleapis.com/auth/iam', // For setting up service accounts for each WorkerPool
-      'https://www.googleapis.com/auth/cloud-platform', // To set roles for service accounts
     ];
     this.compute = google.compute({
       version: 'v1',
       auth: client,
     });
-    this.iam = google.iam({
-      version: 'v1',
-      auth: client,
-    });
-    this.crm = google.cloudresourcemanager({
-      version: 'v1',
-      auth: client,
-    });
-
     this.oauth2 = new google.auth.OAuth2();
-  }
-
-  /*
-   * We will first set up a service account and role for each worker to use
-   * since the default service account workers get is not very restricted
-   */
-  async setup() {
-    const accountId = 'taskcluster-workers';
-    this.workerAccountEmail = `${accountId}@${this.project}.iam.gserviceaccount.com`;
-    const accountRef = `projects/${this.project}/serviceAccounts/${this.workerAccountEmail}`;
-    const roleId = 'taskcluster_workers';
-    const roleName =`projects/${this.project}/roles/${roleId}`;
-
-    // First we set up the service account
-    const serviceAccount = await this.readModifySet({
-      read: async () => (await this.iam.projects.serviceAccounts.get({
-        name: accountRef,
-      })).data,
-      compare: () => true, // We do not modify this resource
-      modify: () => {}, // Not needed due to no modifications
-      set: async () => (await this.iam.projects.serviceAccounts.create({
-        name: `projects/${this.project}`,
-        accountId,
-        requestBody: {
-          serviceAccount: {
-            displayName: 'Taskcluster Workers',
-            description: 'A service account shared by all Taskcluster workers.',
-          },
-        },
-      })).data,
-    });
-    this.workerAccountId = serviceAccount.uniqueId;
-
-    // Next we ensure that worker-manager can create instances with
-    // this service account
-    // If this is not the first time this has been set up, it will
-    // simply overwrite the values in there now. This will undo manual changes.
-    await this.iam.projects.serviceAccounts.setIamPolicy({
-      resource: `projects/${this.project}/serviceAccounts/${this.workerAccountEmail}`,
-      requestBody: {
-        policy: {
-          bindings: [{
-            role: 'roles/iam.serviceAccountUser',
-            members: [`serviceAccount:${this.ownClientEmail}`],
-          }],
-        },
-      },
-    });
-
-    // Now we create a role or update it with whatever permissions we've configured
-    // for this provider
-    await this.readModifySet({
-      read: async () => (await this.iam.projects.roles.get({
-        name: roleName,
-      })).data,
-      compare: role => _.isEqual(role.includedPermissions, this.instancePermissions),
-      modify: async role => {
-        role.includedPermissions = this.instancePermissions;
-        await this.iam.projects.roles.patch({
-          name: roleName,
-          updateMask: 'includedPermissions',
-          requestBody: role,
-        });
-      },
-      set: async () => this.iam.projects.roles.create({
-        parent: `projects/${this.project}`,
-        requestBody: {
-          roleId,
-          role: {
-            title: 'Taskcluster Workers',
-            description: 'Role shared by all Taskcluster workers.',
-            includedPermissions: this.instancePermissions,
-          },
-        },
-      }),
-    });
-
-    // Assign the role to the serviceAccount and we're good to go!
-    // Projects always have these policies so no need for set()
-    const binding = {
-      role: `projects/${this.project}/roles/${roleId}`,
-      members: [`serviceAccount:${this.workerAccountEmail}`],
-    };
-    await this.readModifySet({
-      read: async () => (await this.crm.projects.getIamPolicy({
-        resource: this.project,
-        requestBody: {},
-      })).data,
-      compare: policy => policy.bindings.some(b => _.isEqual(b, binding)),
-      modify: async policy => {
-        policy.bindings.push(binding);
-        await this.crm.projects.setIamPolicy({
-          resource: this.project,
-          requestBody: {
-            policy,
-          },
-        });
-      },
-    });
   }
 
   async registerWorker({worker, workerPool, workerIdentityProof}) {
@@ -198,7 +83,7 @@ class GoogleProvider extends Provider {
     // Now check to make sure that the serviceAccount that the worker has is the
     // serviceAccount that we have configured that worker to use. Nobody else in the project
     // should have permissions to create instances with this serviceAccount.
-    if (payload.sub !== this.workerAccountId) {
+    if (payload.sub !== this.workerServiceAccountId) {
       throw error();
     }
 
@@ -284,7 +169,7 @@ class GoogleProvider extends Provider {
             networkInterfaces: workerPool.config.networkInterfaces,
             disks: workerPool.config.disks,
             serviceAccounts: [{
-              email: this.workerAccountEmail,
+              email: this.workerServiceAccountEmail,
               scopes: [
                 /*
                  * This looks scary but is ok. According to
@@ -506,55 +391,6 @@ class GoogleProvider extends Provider {
     }
     await obj.delete(args);
     return false;
-  }
-
-  /*
-   * A useful wrapper for interacting with resources
-   * that google wants you to use read-modify-set semantics with
-   * Example: https://cloud.google.com/iam/docs/creating-custom-roles#read-modify-write
-   */
-  async readModifySet({
-    compare,
-    read,
-    modify,
-    set,
-    tries = 0,
-  }) {
-    let resource;
-    try {
-      // First try to get the resource
-      resource = await read();
-    } catch (err) {
-      if (err.code !== 404) {
-        throw err;
-      }
-    }
-
-    try {
-      if (resource) {
-        // If the value in google is different
-        // from the one we want it to be, we try to update it
-        if (!compare(resource)) {
-          resource = await modify(resource);
-        }
-        return resource;
-      } else {
-        // If the resource was never there in the first place, create it
-        return await set();
-      }
-    } catch (err) {
-      if (err.code !== 409 && tries < 5) {
-        throw err;
-      }
-      await new Promise(accept => setTimeout(accept, Math.pow(2, tries) * 100));
-      return await this.readModifySet({
-        compare,
-        read,
-        modify,
-        set,
-        tries: tries++,
-      });
-    }
   }
 }
 

--- a/services/worker-manager/test/fake-google.js
+++ b/services/worker-manager/test/fake-google.js
@@ -45,7 +45,7 @@ class FakeGoogle {
 
     // For now we only support creating one of these per project
     // in this fake. We can support multiples later if needed
-    this.serviceAccount = null;
+    this.serviceAccount = 12345;
     this.role = null;
 
     this.iamPolicy = {
@@ -98,6 +98,24 @@ class FakeGoogle {
       zoneOperations: {
         get: async () => opStub(),
         delete: async () => {},
+      },
+    };
+  }
+
+  iam() {
+    return {
+      projects: {
+        serviceAccounts: {
+          get: async () => {
+            if (this.serviceAccount) {
+              return {
+                data: this.serviceAccount,
+              };
+            } else {
+              throw this.error(404);
+            }
+          },
+        },
       },
     };
   }

--- a/services/worker-manager/test/fake-google.js
+++ b/services/worker-manager/test/fake-google.js
@@ -101,66 +101,6 @@ class FakeGoogle {
       },
     };
   }
-
-  iam() {
-    return {
-      projects: {
-        serviceAccounts: {
-          get: async () => {
-            if (this.serviceAccount) {
-              return {
-                data: this.serviceAccount,
-              };
-            } else {
-              throw this.error(404);
-            }
-          },
-          create: async ({requestBody}) => {
-            if (this.serviceAccount) {
-              throw this.error(409);
-            } else {
-              this.serviceAccount = {uniqueId: WORKER_SERVICE_ACCOUNT_ID, ...requestBody.serviceAccount};
-              return {data: this.serviceAccount};
-            }
-          },
-          setIamPolicy: async () => {},
-        },
-        roles: {
-          get: async () => {
-            if (this.role) {
-              return {data: this.role};
-            } else {
-              throw this.error(404);
-            }
-          },
-          patch: async ({requestBody}) => {
-            if (!this.role) {
-              throw this.error(404);
-            } else {
-              this.role = requestBody;
-            }
-          },
-          create: async ({requestBody}) => {
-            if (this.role) {
-              throw this.error(409);
-            } else {
-              this.role = requestBody.role;
-              return {data: this.role};
-            }
-          },
-        },
-      },
-    };
-  }
-
-  cloudresourcemanager() {
-    return {
-      projects: {
-        getIamPolicy: async () => ({data: this.iamPolicy}),
-        setIamPolicy: async ({requestBody}) => this.iamPolicy = requestBody.policy,
-      },
-    };
-  }
 }
 
 module.exports = {

--- a/services/worker-manager/test/provider_google_test.js
+++ b/services/worker-manager/test/provider_google_test.js
@@ -33,6 +33,7 @@ helper.secrets.mockSuite(testing.suiteName(), ['taskcluster', 'azure'], function
         project: 'testy',
         instancePermissions: [],
         creds: '{}',
+        workerServiceAccountId: '12345',
       },
     });
     workerPool = await helper.WorkerPool.create({

--- a/ui/docs/manual/deploying/workers.md
+++ b/ui/docs/manual/deploying/workers.md
@@ -49,12 +49,8 @@ A google-based provider is be configured in `providers` with the following struc
   "myProvider": {
     "providerType": "google",
     "project": "<gcp project identifier>",
-    "instancePermissions": [
-      "<instance permission>",
-      "<instance permission>"
-    ],
-    "creds": "<google credentials>",
-    "credsFile": "<filename containing google credentials>"
+    "workerServiceAccountId": "<uniqueId of a service account in this project that workers will use>",
+    "creds": "<google credentials>"
   },
   ...
 }
@@ -69,21 +65,22 @@ The project will need the following APIs enabled:
 
 * Compute Engine API
 * Identity and Access Management (IAM) API
-* Cloud Resource Manager API
 
 #### Service Account Credentials
 
-The provider requires a service account in the designated project, with the following roles:
+The provider requires *two* service accounts in the designated project.
 
-* `roles/iam.serviceAccountAdmin` ("Service Account Admin")
-* `roles/iam.roleAdmin` ("Role Administrator")
-* `roles/resourcemanager.projectIamAdmin` ("Project IAM Admin")
-* `roles/compute.admin` ("Compute Admin")
+The first is the service account that worker-manager will assign to workers
+it starts. Give this service account whatever google permissions you wish your
+workers to have. This could be something like writing to stackdriver for example.
+You provide the `uniqueId` of this service account in the `workerServiceAccountId` field.
 
-These roles confer almost total control over the GCP project.
-See the note above about using a dedicated project.
+The second is for worker-manager to run as itself with the following roles:
 
-The GCP credentials for this service account are provided either in string form (`creds`) or in a file (`credsFile`).
+* `roles/compute.instanceAdmin` ("Compute Instance Admin (beta)")
+* `roles/iam.serviceAccountUser` ("Service Account User")
+
+The GCP credentials for this service account are provided in string form (`creds`).
 In either case, the data is the large JSON object containing a service account's keys. The object looks something like this:
 
 ```
@@ -100,14 +97,7 @@ In either case, the data is the large JSON object containing a service account's
   "client_x509_cert_url": "https://www.googleapis.com/robot/v1/metadata/x509/thisthing%40something.iam.gserviceaccount.com"
 }
 ```
-and will need to be included as a single string in the `creds` property.
-
-#### Instance Permissions
-
-The `instancePermissions` configuration defines the permissions granted to the GCP role assumed by the workers.
-Each string in this array is a GCP IAM permission string.
-Typically, this will include permissions to write to StackDriver, such as `logging.logEntries.create`.
-
+and will need to be included either as a string, base64'd string, or just json/yaml in the `creds` property.
 
 ### AWS
 

--- a/ui/docs/manual/deploying/workers.md
+++ b/ui/docs/manual/deploying/workers.md
@@ -77,7 +77,7 @@ You provide the `uniqueId` of this service account in the `workerServiceAccountI
 
 The second is for worker-manager to run as itself with the following roles:
 
-* `roles/compute.instanceAdmin` ("Compute Instance Admin (beta)")
+* `roles/compute.admin` ("Compute Admin")
 * `roles/iam.serviceAccountUser` ("Service Account User")
 
 The GCP credentials for this service account are provided in string form (`creds`).


### PR DESCRIPTION
This removes the ability for google provider to set up its own service accounts for workers. This both simplifies the code significantly and makes worker-manager much safer to run! Couple of other QOL improvements here as well. Part 2 should be coming soon where we clean up a few last TODOs and add some rate limiting logic.