### PR TITLE
Let renovate run more often and make more PRs

### DIFF
--- a/package.json
+++ b/package.json
@@ -186,9 +186,11 @@
   "renovate": {
     "extends": [
       "config:base",
-      ":preserveSemverRanges",
-      "schedule:weekly"
+      ":preserveSemverRanges"
     ],
+    "schedule": "at any time",
+    "prHourlyLimit": 5,
+    "prConcurrentLimit": 10,
     "gomod": {
       "ignoreDeps": [
         "golang.org/x/tools"


### PR DESCRIPTION
We have a lot of un-updated dependencies.  My guess is that we're
getting two Node and two Golang PR's per week (running once per week
with prHourlyLimit=2), and have been falling behind quickly.  So this
opens things up quite a bit.  If my hunch is correct, and once we get
up-to-date, we can scale this back to run daily so that PRs aren't
popping up mid-day.

