### PR TITLE
Google update pt2 (rate limiting)

### DIFF
--- a/generated/references.json
+++ b/generated/references.json
@@ -7897,6 +7897,33 @@
           "version": 1
         },
         {
+          "description": "We have either hit an api rate limit or 500s from google.",
+          "fields": {
+            "duration": "Length of time the queue is paused for in ms.",
+            "providerId": "Which provider has hit a limit (each provider manages a single project)",
+            "queueName": "Which queue is paused -- there is one for each class of api request",
+            "queueSize": "Number of requests remaining in the queue when it is paused.",
+            "reason": "Either `errors` or `rateLimit`."
+          },
+          "level": "any",
+          "name": "googleProviderPaused",
+          "title": "Google Provider Paused",
+          "type": "google-provider-paused",
+          "version": 1
+        },
+        {
+          "description": "A google provider has resumed api requests to google.",
+          "fields": {
+            "providerId": "Which provider has hit a limit (each provider manages a single project)",
+            "queueName": "Which queue is paused -- there is one for each class of api request"
+          },
+          "level": "notice",
+          "name": "googleProviderResumed",
+          "title": "Google Provider Resumed",
+          "type": "google-provider-resumed",
+          "version": 1
+        },
+        {
           "description": "A connection to Pulse has been established.  Taskcluster services\nautomatically reconnect to Pulse periodically and in the event of\nan error, but rapid reconnections may signal a Pulse failure.",
           "fields": {
           },

--- a/generated/references.json
+++ b/generated/references.json
@@ -7897,30 +7897,30 @@
           "version": 1
         },
         {
-          "description": "We have either hit an api rate limit or 500s from google.",
+          "description": "Rate limiting engaged for a cloud api",
           "fields": {
             "duration": "Length of time the queue is paused for in ms.",
-            "providerId": "Which provider has hit a limit (each provider manages a single project)",
+            "providerId": "Which provider has hit a limit",
             "queueName": "Which queue is paused -- there is one for each class of api request",
             "queueSize": "Number of requests remaining in the queue when it is paused.",
             "reason": "Either `errors` or `rateLimit`."
           },
           "level": "any",
-          "name": "googleProviderPaused",
-          "title": "Google Provider Paused",
-          "type": "google-provider-paused",
+          "name": "cloudApiPaused",
+          "title": "Cloud API Paused",
+          "type": "cloud-api-paused",
           "version": 1
         },
         {
-          "description": "A google provider has resumed api requests to google.",
+          "description": "A provider has resumed api requests.",
           "fields": {
             "providerId": "Which provider has hit a limit (each provider manages a single project)",
             "queueName": "Which queue is paused -- there is one for each class of api request"
           },
           "level": "notice",
-          "name": "googleProviderResumed",
-          "title": "Google Provider Resumed",
-          "type": "google-provider-resumed",
+          "name": "cloudApiResumed",
+          "title": "Cloud API Resumed",
+          "type": "cloud-api-resumed",
           "version": 1
         },
         {

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "netmask": "^1.0.5",
     "node-fetch": "^2.3.0",
     "nodemailer": "^6.0.0",
+    "p-queue": "^6.1.1",
     "passport": "^0.4.0",
     "passport-auth0": "^1.1.0",
     "passport-github": "^1.1.0",

--- a/services/worker-manager/src/monitor.js
+++ b/services/worker-manager/src/monitor.js
@@ -57,14 +57,14 @@ monitorManager.register({
 });
 
 monitorManager.register({
-  name: 'googleProviderPaused',
-  title: 'Google Provider Paused',
-  type: 'google-provider-paused',
+  name: 'cloudApiPaused',
+  title: 'Cloud API Paused',
+  type: 'cloud-api-paused',
   version: 1,
   level: 'any',
-  description: 'We have either hit an api rate limit or 500s from google.',
+  description: 'Rate limiting engaged for a cloud api',
   fields: {
-    providerId: 'Which provider has hit a limit (each provider manages a single project)',
+    providerId: 'Which provider has hit a limit',
     queueName: 'Which queue is paused -- there is one for each class of api request',
     reason: 'Either `errors` or `rateLimit`.',
     queueSize: 'Number of requests remaining in the queue when it is paused.',
@@ -73,12 +73,12 @@ monitorManager.register({
 });
 
 monitorManager.register({
-  name: 'googleProviderResumed',
-  title: 'Google Provider Resumed',
-  type: 'google-provider-resumed',
+  name: 'cloudApiResumed',
+  title: 'Cloud API Resumed',
+  type: 'cloud-api-resumed',
   version: 1,
   level: 'notice',
-  description: 'A google provider has resumed api requests to google.',
+  description: 'A provider has resumed api requests.',
   fields: {
     providerId: 'Which provider has hit a limit (each provider manages a single project)',
     queueName: 'Which queue is paused -- there is one for each class of api request',

--- a/services/worker-manager/src/monitor.js
+++ b/services/worker-manager/src/monitor.js
@@ -56,4 +56,33 @@ monitorManager.register({
   },
 });
 
+monitorManager.register({
+  name: 'googleProviderPaused',
+  title: 'Google Provider Paused',
+  type: 'google-provider-paused',
+  version: 1,
+  level: 'any',
+  description: 'We have either hit an api rate limit or 500s from google.',
+  fields: {
+    providerId: 'Which provider has hit a limit (each provider manages a single project)',
+    queueName: 'Which queue is paused -- there is one for each class of api request',
+    reason: 'Either `errors` or `rateLimit`.',
+    queueSize: 'Number of requests remaining in the queue when it is paused.',
+    duration: 'Length of time the queue is paused for in ms.',
+  },
+});
+
+monitorManager.register({
+  name: 'googleProviderResumed',
+  title: 'Google Provider Resumed',
+  type: 'google-provider-resumed',
+  version: 1,
+  level: 'notice',
+  description: 'A google provider has resumed api requests to google.',
+  fields: {
+    providerId: 'Which provider has hit a limit (each provider manages a single project)',
+    queueName: 'Which queue is paused -- there is one for each class of api request',
+  },
+});
+
 module.exports = monitorManager;

--- a/services/worker-manager/src/providers/google.js
+++ b/services/worker-manager/src/providers/google.js
@@ -98,7 +98,7 @@ class GoogleProvider extends Provider {
       }
 
       if (!queue.isPaused) {
-        this.monitor.log.googleProviderPaused({
+        this.monitor.log.cloudApiPaused({
           providerId: this.providerId,
           queueName: type,
           reason,
@@ -107,7 +107,7 @@ class GoogleProvider extends Provider {
         }, {level});
         queue.pause();
         setTimeout(() => {
-          this.monitor.log.googleProviderResumed({
+          this.monitor.log.cloudApiResumed({
             providerId: this.providerId,
             queueName: type,
           });

--- a/services/worker-manager/src/providers/google.js
+++ b/services/worker-manager/src/providers/google.js
@@ -175,7 +175,7 @@ class GoogleProvider extends Provider {
       running: workerPool.providerData[this.providerId].running,
     });
 
-    for (let i = 0; i < toSpawn; i++) {
+    await Promise.all(new Array(toSpawn).fill(null).map(async _ => {
       const region = regions[Math.floor(Math.random() * regions.length)];
       if (!this.zonesByRegion[region]) {
         this.zonesByRegion[region] = (await this._enqueue('get', () => this.compute.regions.get({
@@ -274,7 +274,7 @@ class GoogleProvider extends Provider {
           },
         },
       });
-    }
+    }));
   }
 
   /*

--- a/services/worker-manager/test/fake-google.js
+++ b/services/worker-manager/test/fake-google.js
@@ -81,6 +81,16 @@ class FakeGoogle {
       {message: 'something went wrong'},
     ];
     instanceInsertStub.onCall(1).throws(googleError);
+    const limitError = new Error('whatever');
+    limitError.code = 403;
+    instanceInsertStub.onCall(2).throws(limitError);
+    instanceInsertStub.onCall(3).returns({
+      data: {
+        targetId: '456', // This is the instanceId
+        name: 'foo',
+        zone: 'whatever/a',
+      },
+    });
 
     return {
       regions: {

--- a/services/worker-manager/test/provider_google_test.js
+++ b/services/worker-manager/test/provider_google_test.js
@@ -34,6 +34,7 @@ helper.secrets.mockSuite(testing.suiteName(), ['taskcluster', 'azure'], function
         instancePermissions: [],
         creds: '{}',
         workerServiceAccountId: '12345',
+        _backoffDelay: 1,
       },
     });
     workerPool = await helper.WorkerPool.create({
@@ -79,6 +80,16 @@ helper.secrets.mockSuite(testing.suiteName(), ['taskcluster', 'azure'], function
     assert.equal(errors.entries[0].description, 'something went wrong');
     const workers = await helper.Worker.scan({}, {});
     assert.equal(workers.entries.length, 1); // second loop should not have created one
+  });
+
+  test('provisioning loop with rate limiting', async function() {
+    // Notice this is only three loops, but instance insert fails on third try before succeeding on 4th
+    await provider.provision({workerPool});
+    await provider.provision({workerPool});
+    await provider.provision({workerPool});
+
+    const workers = await helper.Worker.scan({}, {});
+    assert.equal(workers.entries.length, 2);
   });
 
   test('de-provisioning loop', async function() {

--- a/ui/docs/manual/deploying/workers.md
+++ b/ui/docs/manual/deploying/workers.md
@@ -50,6 +50,12 @@ A google-based provider is configured in `providers` with the following structur
     "providerType": "google",
     "project": "<gcp project identifier>",
     "workerServiceAccountId": "<uniqueId of a service account in this project that workers will use>",
+    "apiRateLimits": {
+      "get": {"interval": 1000, "intervalCap": 20000},
+      "query": {"interval": 1000, "intervalCap": 40000},
+      "list": {"interval": 1000, "intervalCap": 20000},
+      "opRead": {"interval": 1000, "intervalCap": 20000}
+    },
     "creds": "<google credentials>"
   },
   ...
@@ -66,7 +72,15 @@ The project will need the following APIs enabled:
 * Compute Engine API
 * Identity and Access Management (IAM) API
 
-#### Service Account Credentials
+#### API Rate Limit Overrides
+
+By default worker-manager will limit its interactions with a GCP project to the
+[documented api rate limits](https://cloud.google.com/compute/docs/api-rate-limits). You
+can optionally override this for the categories `get`, `query`, `list`, and `opRead` which
+cover the entirety of calls that worker-manager makes. This could be useful if you get
+your limits raised by google.
+
+#### Service Accounts
 
 The provider requires *two* service accounts in the designated project.
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3007,6 +3007,11 @@ eventemitter3@^3.1.0:
   resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-3.1.0.tgz#090b4d6cdbd645ed10bf750d4b5407942d7ba163"
   integrity sha512-ivIvhpq/Y0uSjcHDcOIccjmYjGLcP09MFGE7ysAwkAvkXfpZlC985pH2/ui64DKazbTW/4kN3yqozUxlXzI6cA==
 
+eventemitter3@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-4.0.0.tgz#d65176163887ee59f386d64c82610b696a4a74eb"
+  integrity sha512-qerSRB0p+UDEssxTtm6EDKcE7W4OaoisfIMl4CngyEhjpYglocpNg6UEqCvemdGhosAsg4sO2dXJOdyBifPGCg==
+
 events@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/events/-/events-1.1.1.tgz#9ebdb7635ad099c70dcc4c2a1f5004288e8bd924"
@@ -5820,6 +5825,21 @@ p-map@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/p-map/-/p-map-2.0.0.tgz#be18c5a5adeb8e156460651421aceca56c213a50"
   integrity sha512-GO107XdrSUmtHxVoi60qc9tUl/KkNKm+X2CF4P9amalpGxv5YqVPJNfSb0wcA+syCopkZvYYIzW8OVTQW59x/w==
+
+p-queue@^6.1.1:
+  version "6.1.1"
+  resolved "https://registry.yarnpkg.com/p-queue/-/p-queue-6.1.1.tgz#eedbaf7335b4931ef857e2e58063fed461b97e80"
+  integrity sha512-R9gq36Th88xZ+rWAptN5IXLwqkwA1gagCQhT6ZXQ6RxEfmjb9ZW+UBzRVqv9sm5TQmbbI/TsKgGLbOaA61xR5w==
+  dependencies:
+    eventemitter3 "^4.0.0"
+    p-timeout "^3.1.0"
+
+p-timeout@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/p-timeout/-/p-timeout-3.1.0.tgz#198c1f503bb973e9b9727177a276c80afd6851f3"
+  integrity sha512-C27DYI+tCroT8J8cTEyySGydl2B7FlxrGNF5/wmMbl1V+jeehUCzEE/BVgzRebdm2K3ZitKOKx8YbdFumDyYmw==
+  dependencies:
+    p-finally "^1.0.0"
 
 p-try@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
This should do a better job of trying to keep us from hitting api rate limit issues with google.

I didn't use `withFakeTime` in the tests because `azure-entities` date validation doesn't like it. Instead just allowed passing in a shorter backoff base for testing.