### PR TITLE
Upgrade js-yaml

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -4370,18 +4370,10 @@ js-stringify@^1.0.1:
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
   integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
 
-js-yaml@3.13.1, js-yaml@^3.11.0, js-yaml@^3.13.1:
+js-yaml@3.13.1, js-yaml@^3.11.0, js-yaml@^3.13.1, js-yaml@^3.4.2:
   version "3.13.1"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.13.1.tgz#aff151b30bfdfa8e49e05da22e7415e9dfa37847"
   integrity sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==
-  dependencies:
-    argparse "^1.0.7"
-    esprima "^4.0.0"
-
-js-yaml@^3.4.2:
-  version "3.12.2"
-  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.12.2.tgz#ef1d067c5a9d9cb65bd72f285b5d8105c77f14fc"
-  integrity sha512-QHn/Lh/7HhZ/Twc7vJYQTkjuCa0kaCcDcjK5Zlk2rvnUpy7DxMJ23+Jc2dcyvltwQVg1nygAVlB2oRDFHoRS5Q==
   dependencies:
     argparse "^1.0.7"
     esprima "^4.0.0"


### PR DESCRIPTION
Before:
```
(go1.12.9) (v10.16.3) dustin@lamport ~/p/taskcluster [master] $ yarn why js-yaml
yarn why v1.17.3                            
[1/4] Why do we have the module "js-yaml"...?    
[2/4] Initialising dependency graph...                                        
[3/4] Finding dependency...            
[4/4] Calculating file sizes...                                          
=> Found "js-yaml@3.13.1"                                          
info Has been hoisted to "js-yaml"          
info Reasons this module exists                               
   - "workspace-aggregator-40c80817-c81b-4c3c-87b1-ad45bf1d8e88" depends on it
   - Specified in "dependencies"                                                   
   - Hoisted from "_project_#mocha#js-yaml"          
   - Hoisted from "_project_#js-yaml"                                                                          
   - Hoisted from "_project_#eslint#js-yaml"                                                               
   - Hoisted from "_project_#md-directory#gray-matter#js-yaml"     
info Disk size without dependencies: "752KB"
info Disk size with unique dependencies: "1.34MB"                                                                        
info Disk size with transitive dependencies: "1.42MB"  
info Number of shared dependencies: 3                   
=> Found "depcheck#js-yaml@3.12.2"                                                                      
info This module exists because "_project_#depcheck" depends on it.        
info Disk size without dependencies: "416KB"                                                                       
info Disk size with unique dependencies: "1.02MB"                                                                                                             
info Disk size with transitive dependencies: "1.09MB"                                                                
info Number of shared dependencies: 3                                                                                   
Done in 0.93s.                                                                                                
```

depcheck's `package.json` says `"js-yaml': "^3.4.2"`, so 3.13.1 should be fine.  But `yarn upgrade --latest js-yaml` doesn't change the lockfile at all. I accomplished this diff by manually deleting the 3.4.2 clause of `yarn.lock` and re-running `yarn`.

https://github.com/yarnpkg/yarn/issues/4986 suggests that this is the only way.