### PR TITLE
Fix yarn dev:init

### DIFF
--- a/infrastructure/tooling/src/dev/aws.js
+++ b/infrastructure/tooling/src/dev/aws.js
@@ -42,6 +42,7 @@ module.exports = async ({userConfig, answer, configTmpl}) => {
   const prefix = (answer.meta || {}).deploymentPrefix || (userConfig.meta || {}).deploymentPrefix;
 
   userConfig.queue = userConfig.queue || {};
+  userConfig.meta = userConfig.meta || {};
 
   // TODO: Add both blob buckets
   // TODO: Also set up auth/notify aws stuff


### PR DESCRIPTION
`yarn dev:init` was throwing:

```shell
TypeError: Cannot read property 'lastAppliedPublicBucketPolicy' of undefined
    at module.exports (/Users/haali/Documents/Mozilla/projects/taskcluster/infrastructure/tooling/src/dev/aws.js:76:24)
    at process._tickCallback (internal/process/next_tick.js:68:7)
```