### PR TITLE
Bug 1582376 - increase AMQP frame size

### DIFF
--- a/changelog/bug1582376.md
+++ b/changelog/bug1582376.md
@@ -1,0 +1,6 @@
+level: patch
+reference: bug 1582376
+---
+Taskcluster now uses the AMQP server's value for `frame_max`, rather than enforcing its own limit of 4k.
+The server level should be configured to 128k.
+This is the default for RabbitMQ, so in most cases no change is required.

--- a/clients/client-go/tcqueue/types.go
+++ b/clients/client-go/tcqueue/types.go
@@ -1097,6 +1097,10 @@ type (
 		// List of task-specific routes. Pulse messages about the task will be CC'ed to
 		// `route.<value>` for each `<value>` in this array.
 		//
+		// This array has a maximum size due to a limitation of the AMQP protocol,
+		// over which Pulse runs.  All routes must fit in the same "frame" of this
+		// protocol, and the frames have a fixed maximum size (typically 128k).
+		//
 		// Default:    []
 		//
 		// Array items:
@@ -1263,6 +1267,10 @@ type (
 
 		// List of task-specific routes. Pulse messages about the task will be CC'ed to
 		// `route.<value>` for each `<value>` in this array.
+		//
+		// This array has a maximum size due to a limitation of the AMQP protocol,
+		// over which Pulse runs.  All routes must fit in the same "frame" of this
+		// protocol, and the frames have a fixed maximum size (typically 128k).
 		//
 		// Default:    []
 		//

--- a/generated/references.json
+++ b/generated/references.json
@@ -1389,7 +1389,7 @@
         "routes": {
           "default": [
           ],
-          "description": "List of task-specific routes. Pulse messages about the task will be CC'ed to\n`route.<value>` for each `<value>` in this array.\n",
+          "description": "List of task-specific routes. Pulse messages about the task will be CC'ed to\n`route.<value>` for each `<value>` in this array.\n\nThis array has a maximum size due to a limitation of the AMQP protocol,\nover which Pulse runs.  All routes must fit in the same \"frame\" of this\nprotocol, and the frames have a fixed maximum size (typically 128k).\n",
           "items": {
             "description": "A task specific route.\n",
             "maxLength": 249,

--- a/libraries/pulse/src/credentials.js
+++ b/libraries/pulse/src/credentials.js
@@ -29,6 +29,8 @@ const pulseCredentials = ({username, password, hostname, vhost}) => {
         5671, // Port for SSL
         '/',
         encodeURIComponent(vhost),
+        // don't artificially limit frame size (https://bugzilla.mozilla.org/show_bug.cgi?id=1582376)
+        '?frameMax=0',
       ].join(''),
     };
   };

--- a/libraries/pulse/test/credentials_test.js
+++ b/libraries/pulse/test/credentials_test.js
@@ -25,7 +25,7 @@ suite(testing.suiteName(), function() {
 
     assert.equal(
       credentials.connectionString,
-      'amqps://me:letmein@pulse.abc.com:5671/%2F');
+      'amqps://me:letmein@pulse.abc.com:5671/%2F?frameMax=0');
   });
 
   test('builds a connection string with urlencoded values', async function() {
@@ -38,6 +38,6 @@ suite(testing.suiteName(), function() {
 
     assert.equal(
       credentials.connectionString,
-      'amqps://ali-escaper:/@%5C%7C()%3C%3E&:bobby-tables:/@%5C%7C()%3C%3E&@pulse.abc.com:5671/%2F');
+      'amqps://ali-escaper:/@%5C%7C()%3C%3E&:bobby-tables:/@%5C%7C()%3C%3E&@pulse.abc.com:5671/%2F?frameMax=0');
   });
 });

--- a/services/queue/schemas/v1/task.yml
+++ b/services/queue/schemas/v1/task.yml
@@ -78,6 +78,10 @@ properties:
     description: |
       List of task-specific routes. Pulse messages about the task will be CC'ed to
       `route.<value>` for each `<value>` in this array.
+
+      This array has a maximum size due to a limitation of the AMQP protocol,
+      over which Pulse runs.  All routes must fit in the same "frame" of this
+      protocol, and the frames have a fixed maximum size (typically 128k).
     type:           array
     default:        []
     items:

--- a/ui/docs/manual/deploying/pulse.mdx
+++ b/ui/docs/manual/deploying/pulse.mdx
@@ -5,4 +5,13 @@ title: Pulse
 Taskcluster uses RabbitMQ to communicate between microservices.
 The particular approach it takes to this communication is called "Pulse", taken from a larger project at Mozilla, but it can run against any RabbitMQ deployment, either local or hosted by a commercial provider.
 
-Most services will require service-specific credentials for access to Pulse.
+See [/docs/manual/design/apis/pulse](the Pulse design page) for information on how Taskcluster expects this to be configured.
+This is satisfied by a mostly-default RabbitMQ installation.
+
+Most services require service-specific credentials for access to Pulse.
+
+## Details
+
+Taskcluster is particularly sensitive to the AMQP `frame_max` parameter.
+It must fit all the "routes" for a task into the header of an AMQP message, and the header must fit in a single frame.
+RabbitMQ's default frame_max is 128k, and other AMQP servers should be configured similarly.


### PR DESCRIPTION
I tested this with 128 routes on a single message, no problem.

256 caused a buffer overflow in node, but let's pretend that didn't happen.  The current max for routes in a task is 64, and that seems a good number.

Bugzilla Bug: [1582376](https://bugzilla.mozilla.org/show_bug.cgi?id=1582376)
