### PR TITLE
Provider updates

### DIFF
--- a/generated/references.json
+++ b/generated/references.json
@@ -7881,21 +7881,22 @@
           "version": 1
         },
         {
-          "description": "The simple estimator has decided that we need some number of instances.",
+          "description": "The simple estimator has decided that we need some amount of capacity.",
           "fields": {
-            "capacityPerInstance": "Amount of capacity a single instance provides",
-            "desiredSize": "Number that this estimator thinks we should have",
+            "desiredCapacity": "Amount of capacity the estimator believes is needed",
             "maxCapacity": "The maximum amount of capacity that should be running",
             "minCapacity": "The minimum amount of capacity that should be running",
+            "pendingCapacity": "Amount of capacity the provider believes is coming online currently",
             "pendingTasks": "The number of tasks the queue reports are pending for this worker pool",
-            "running": "Number of currently requested and running instances",
+            "requestingCapacity": "Amount of capacity the estimator is asking the provider to add",
+            "runningCapacity": "Amount of capacity the provider believes exists currently",
             "workerPoolId": "The worker pool name (provisionerId/workerType)"
           },
           "level": "notice",
           "name": "simpleEstimate",
           "title": "Simple Estimate Provided",
           "type": "simple-estimate",
-          "version": 1
+          "version": 2
         },
         {
           "description": "An error was reported regarding the given worker pool.  Such errors are generally\nthe responsibility of the owner of the worker pool, but may also indicate issues\nwith the Taskcluster deployment and as such are reported in the service logs as\nwell.  Note that the 'extra' data associated with such a report is not included\nhere.  To see that, use the UI or API to view the worker pool errors directly.",

--- a/services/worker-manager/src/estimator.js
+++ b/services/worker-manager/src/estimator.js
@@ -6,28 +6,37 @@ class Estimator {
     this.monitor = monitor;
   }
 
-  async simple({workerPoolId, minCapacity, maxCapacity, capacityPerInstance, running}) {
+  /**
+   * This calculates the desired extra capacity at any given time. It does not
+   * calculate how many workers you want. You'll probably want to divide by the capacity
+   * each instance provides for this.
+   */
+  async simple({workerPoolId, minCapacity, maxCapacity, runningCapacity, pendingCapacity}) {
     const {provisionerId, workerType} = splitWorkerPoolId(workerPoolId);
     const {pendingTasks} = await this.queue.pendingTasks(provisionerId, workerType);
 
     // First we find the amount of capacity we want. This is a very simple approximation
-    const desiredCapacity = Math.max(minCapacity, Math.min(pendingTasks, maxCapacity));
+    // You'll notice that we add runningCapacity and then immediately subtract it
+    // in the next line but it is added in to make logging make sense and for its
+    // interactions with Math.max and Math.min
+    const desiredCapacity = Math.max(minCapacity, Math.min(pendingTasks + runningCapacity, maxCapacity));
 
-    const desiredSize = Math.round(desiredCapacity / capacityPerInstance);
+    // Workers turn themselves off so we just return a positive number for
+    // how many extra we want if we do want any
+    const requestingCapacity = Math.max(0, desiredCapacity - pendingCapacity - runningCapacity);
 
     this.monitor.log.simpleEstimate({
       workerPoolId,
       pendingTasks,
       minCapacity,
       maxCapacity,
-      capacityPerInstance,
-      running,
-      desiredSize,
+      runningCapacity,
+      pendingCapacity,
+      desiredCapacity,
+      requestingCapacity,
     });
 
-    // Workers turn themselves off so we just return a positive number for
-    // how many extra we want if we do want any
-    return Math.max(0, desiredSize - running);
+    return requestingCapacity;
   }
 }
 

--- a/services/worker-manager/src/monitor.js
+++ b/services/worker-manager/src/monitor.js
@@ -21,17 +21,18 @@ monitorManager.register({
   name: 'simpleEstimate',
   title: 'Simple Estimate Provided',
   type: 'simple-estimate',
-  version: 1,
+  version: 2,
   level: 'notice',
-  description: 'The simple estimator has decided that we need some number of instances.',
+  description: 'The simple estimator has decided that we need some amount of capacity.',
   fields: {
     workerPoolId: 'The worker pool name (provisionerId/workerType)',
     pendingTasks: 'The number of tasks the queue reports are pending for this worker pool',
     minCapacity: 'The minimum amount of capacity that should be running',
     maxCapacity: 'The maximum amount of capacity that should be running',
-    capacityPerInstance: 'Amount of capacity a single instance provides',
-    running: 'Number of currently requested and running instances',
-    desiredSize: 'Number that this estimator thinks we should have',
+    runningCapacity: 'Amount of capacity the provider believes exists currently',
+    pendingCapacity: 'Amount of capacity the provider believes is coming online currently',
+    desiredCapacity: 'Amount of capacity the estimator believes is needed',
+    requestingCapacity: 'Amount of capacity the estimator is asking the provider to add',
   },
 });
 

--- a/services/worker-manager/src/providers/google.js
+++ b/services/worker-manager/src/providers/google.js
@@ -365,6 +365,15 @@ class GoogleProvider extends Provider {
     const {status} = res.data;
     if (['PROVISIONING', 'STAGING', 'RUNNING'].includes(status)) {
       this.seen[worker.workerPoolId] += 1;
+      // If the worker will be expired soon but it still exists,
+      // update it to stick around a while longer. Ff this doesn't happen,
+      // long-lived instances become orphaned from the provider. We don't update
+      // this on every loop just to avoid the extra work when not needed
+      if (worker.expires < taskcluster.fromNow('1 day')) {
+        await worker.modify(w => {
+          w.expires = taskcluster.fromNow('1 week');
+        });
+      }
     } else if (['TERMINATED', 'STOPPED'].includes(status)) {
       await this._enqueue('query', () => this.compute.instances.delete({
         project: worker.providerData.project,


### PR DESCRIPTION
This should fix some cases I've noticed in testing (or theorized could happen) where we end up having the wrong amount of instances.

This does not update the aws provider to this interface. @owlishDeveloper has decided to make that part of the changes in the other update that is being worked on for that.

Next steps after this will be to support multiple configs like we're going to for aws provider and also open up the configs to whatever we want to pass along as in bug 1581483.
