### PR TITLE
Return better errors from tc-client-py

### DIFF
--- a/clients/client-py/taskcluster/aio/asyncclient.py
+++ b/clients/client-py/taskcluster/aio/asyncclient.py
@@ -187,8 +187,8 @@ class AsyncBaseClient(BaseClient):
                     pass  # Ignore JSON errors in error messages
                 # Find error message
                 message = "Unknown Server Error"
-                if isinstance(data, dict):
-                    message = data.get('message')
+                if isinstance(data, dict) and 'message' in data:
+                    message = data['message']
                 else:
                     if status == 401:
                         message = "Authentication Error"


### PR DESCRIPTION
Without this change, you often see
```
taskcluster.exceptions.TaskclusterRestFailure: None
```
which isn't exactly helpful.  This occurs when `data` is `{}`, so we
check for that case and fall back to a default message when that occurs.