### PR TITLE
Fix ErrorPanel "X" close button in light theme

### DIFF
--- a/ui/src/components/ErrorPanel/index.jsx
+++ b/ui/src/components/ErrorPanel/index.jsx
@@ -11,6 +11,11 @@ import { CONTENT_MAX_WIDTH } from '../../utils/constants';
       color: theme.palette.secondary.dark,
     },
   },
+  error: {
+    '& svg': {
+      fill: theme.palette.error.contrastText,
+    },
+  },
   link: {
     '& a': {
       ...theme.mixins.link,
@@ -68,6 +73,7 @@ export default class ErrorPanel extends Component {
   render() {
     const { classes, className, fixed, error: _, ...props } = this.props;
     const { error } = this.state;
+    const hasWarning = Boolean(props.warning);
     const errorMessage =
       error && error.graphQLErrors && error.graphQLErrors[0]
         ? error.graphQLErrors[0].message
@@ -77,7 +83,8 @@ export default class ErrorPanel extends Component {
       error && (
         <MuiErrorPanel
           className={classNames(className, classes.link, {
-            [classes.warning]: Boolean(props.warning),
+            [classes.error]: !hasWarning,
+            [classes.warning]: hasWarning,
             [classes.fixed]: fixed,
           })}
           error={errorMessage}

--- a/ui/src/theme.js
+++ b/ui/src/theme.js
@@ -24,13 +24,13 @@ const warning = {
   main: amber[500],
   dark: amber[700],
   light: amber[200],
-  contrastText: 'rgba(0, 0, 0, 0.87)',
+  contrastText: THEME.PRIMARY_TEXT_LIGHT,
 };
 const error = {
   main: red[500],
   dark: red[700],
   light: red[300],
-  contrastText: THEME.PRIMARY_LIGHT,
+  contrastText: THEME.PRIMARY_TEXT_DARK,
 };
 const createTheme = isDarkTheme => {
   const primaryMain = isDarkTheme ? THEME.PRIMARY_DARK : THEME.PRIMARY_LIGHT;

--- a/ui/src/theme.js
+++ b/ui/src/theme.js
@@ -30,6 +30,7 @@ const error = {
   main: red[500],
   dark: red[700],
   light: red[300],
+  contrastText: THEME.PRIMARY_LIGHT,
 };
 const createTheme = isDarkTheme => {
   const primaryMain = isDarkTheme ? THEME.PRIMARY_DARK : THEME.PRIMARY_LIGHT;


### PR DESCRIPTION
Added contrastText key in error theme, referencing to light theme color, and created a new class to change fill property of svg in ErrorPanel component.

Closes #1385

<!-- If this is related to a Bugzilla bug, please begin your title with [Bug XXXXX]
     and update this link.

     Is this change user-visible?  If so, please include a file in changelog/ describing it.
     See https://github.com/taskcluster/taskcluster/blob/master/dev-docs/best-practices/changelog.md
-->
