### PR TITLE
Placeholder for '/tasks' and '/tasks/groups'

### DIFF
--- a/ui/src/views/Tasks/NoTask/index.jsx
+++ b/ui/src/views/Tasks/NoTask/index.jsx
@@ -48,7 +48,7 @@ export default class NoTask extends Component {
       <Dashboard
         title="View Tasks"
         helpView={<HelpView description={description} />}
-        search={<Search onSubmit={this.handleTaskSearchSubmit} />}>
+        search={<Search placeholder="Search Task ID" onSubmit={this.handleTaskSearchSubmit} />}>
         <Typography className={classes.infoText}>
           Enter a task ID in the search box
         </Typography>

--- a/ui/src/views/Tasks/NoTask/index.jsx
+++ b/ui/src/views/Tasks/NoTask/index.jsx
@@ -48,7 +48,12 @@ export default class NoTask extends Component {
       <Dashboard
         title="View Tasks"
         helpView={<HelpView description={description} />}
-        search={<Search placeholder="Search Task ID" onSubmit={this.handleTaskSearchSubmit} />}>
+        search={
+          <Search
+            placeholder="Search Task ID"
+            onSubmit={this.handleTaskSearchSubmit}
+          />
+        }>
         <Typography className={classes.infoText}>
           Enter a task ID in the search box
         </Typography>

--- a/ui/src/views/Tasks/NoTaskGroup/index.jsx
+++ b/ui/src/views/Tasks/NoTaskGroup/index.jsx
@@ -48,7 +48,12 @@ export default class NoTaskGroup extends Component {
       <Dashboard
         title="Task Groups"
         helpView={<HelpView description={description} />}
-        search={<Search placeholder="Search Task Group ID" onSubmit={this.handleTaskGroupSearchSubmit} />}>
+        search={
+          <Search
+            placeholder="Search Task Group ID"
+            onSubmit={this.handleTaskGroupSearchSubmit}
+          />
+        }>
         <Typography className={classes.infoText}>
           Enter a task group ID in the search box
         </Typography>

--- a/ui/src/views/Tasks/NoTaskGroup/index.jsx
+++ b/ui/src/views/Tasks/NoTaskGroup/index.jsx
@@ -48,7 +48,7 @@ export default class NoTaskGroup extends Component {
       <Dashboard
         title="Task Groups"
         helpView={<HelpView description={description} />}
-        search={<Search onSubmit={this.handleTaskGroupSearchSubmit} />}>
+        search={<Search placeholder="Search Task Group ID" onSubmit={this.handleTaskGroupSearchSubmit} />}>
         <Typography className={classes.infoText}>
           Enter a task group ID in the search box
         </Typography>


### PR DESCRIPTION
A unique placeholder has been added for  '/tasks' and '/tasks/groups' routes. 

Resolves #1416