### PR TITLE
[UI] Replace text field by MarkdownTextArea

### DIFF
--- a/ui/src/components/ClientForm/index.jsx
+++ b/ui/src/components/ClientForm/index.jsx
@@ -9,6 +9,7 @@ import classNames from 'classnames';
 import List from '@material-ui/core/List';
 import ListItem from '@material-ui/core/ListItem';
 import ListItemText from '@material-ui/core/ListItemText';
+import MarkdownTextArea from '@mozilla-frontend-infra/components/MarkdownTextArea';
 import TextField from '@material-ui/core/TextField';
 import Switch from '@material-ui/core/Switch';
 import FormGroup from '@material-ui/core/FormGroup';
@@ -324,14 +325,11 @@ export default class ClientForm extends Component {
             />
           </ListItem>
           <ListItem>
-            <TextField
-              label="Description"
-              name="description"
+            <MarkdownTextArea
               onChange={this.handleInputChange}
-              fullWidth
-              multiline
-              rows={5}
+              placeholder="Client form description (markdown)"
               value={description}
+              defaultTabIndex={isNewClient ? 0 : 1}
             />
           </ListItem>
           <ListItem>

--- a/ui/src/components/ClientForm/index.jsx
+++ b/ui/src/components/ClientForm/index.jsx
@@ -326,8 +326,9 @@ export default class ClientForm extends Component {
           </ListItem>
           <ListItem>
             <MarkdownTextArea
+              name="description"
               onChange={this.handleInputChange}
-              placeholder="Client form description (markdown)"
+              placeholder="Client description (markdown)"
               value={description}
               defaultTabIndex={isNewClient ? 0 : 1}
             />

--- a/ui/src/components/RoleForm/index.jsx
+++ b/ui/src/components/RoleForm/index.jsx
@@ -197,21 +197,12 @@ export default class RoleForm extends Component {
               </ListItem>
             </Fragment>
           )}
-<<<<<<< HEAD
-          <ListItem className={classes.roleDescriptionListItem}>
-            <MarkdownTextArea
-              name="description"
-              onChange={this.handleInputChange}
-              value={description}
-              placeholder="Role description (markdown)"
-=======
           <ListItem>
             <MarkdownTextArea
               name="description"
               onChange={this.handleInputChange}
               placeholder="Role description (markdown)"
               value={description}
->>>>>>> 53d7c4dd8... [UI] Replace text field by MarkdownTextArea
               defaultTabIndex={isNewRole ? 0 : 1}
             />
           </ListItem>

--- a/ui/src/components/RoleForm/index.jsx
+++ b/ui/src/components/RoleForm/index.jsx
@@ -207,8 +207,9 @@ export default class RoleForm extends Component {
 =======
           <ListItem>
             <MarkdownTextArea
+              name="description"
               onChange={this.handleInputChange}
-              placeholder="Role form description (markdown)"
+              placeholder="Role description (markdown)"
               value={description}
 >>>>>>> 53d7c4dd8... [UI] Replace text field by MarkdownTextArea
               defaultTabIndex={isNewRole ? 0 : 1}

--- a/ui/src/components/RoleForm/index.jsx
+++ b/ui/src/components/RoleForm/index.jsx
@@ -2,7 +2,6 @@ import React, { Component, Fragment } from 'react';
 import { oneOfType, object, string, func, bool } from 'prop-types';
 import { withStyles } from '@material-ui/core/styles';
 import classNames from 'classnames';
-import MarkdownTextArea from '@mozilla-frontend-infra/components/MarkdownTextArea';
 import List from '@material-ui/core/List';
 import ListItem from '@material-ui/core/ListItem';
 import ListItemText from '@material-ui/core/ListItemText';

--- a/ui/src/components/RoleForm/index.jsx
+++ b/ui/src/components/RoleForm/index.jsx
@@ -7,6 +7,7 @@ import List from '@material-ui/core/List';
 import ListItem from '@material-ui/core/ListItem';
 import ListItemText from '@material-ui/core/ListItemText';
 import TextField from '@material-ui/core/TextField';
+import MarkdownTextArea from '@mozilla-frontend-infra/components/MarkdownTextArea';
 import Typography from '@material-ui/core/Typography';
 import ContentSaveIcon from 'mdi-react/ContentSaveIcon';
 import DeleteIcon from 'mdi-react/DeleteIcon';
@@ -196,12 +197,20 @@ export default class RoleForm extends Component {
               </ListItem>
             </Fragment>
           )}
+<<<<<<< HEAD
           <ListItem className={classes.roleDescriptionListItem}>
             <MarkdownTextArea
               name="description"
               onChange={this.handleInputChange}
               value={description}
               placeholder="Role description (markdown)"
+=======
+          <ListItem>
+            <MarkdownTextArea
+              onChange={this.handleInputChange}
+              placeholder="Role form description (markdown)"
+              value={description}
+>>>>>>> 53d7c4dd8... [UI] Replace text field by MarkdownTextArea
               defaultTabIndex={isNewRole ? 0 : 1}
             />
           </ListItem>


### PR DESCRIPTION
Import MarkdownTextArea, replace Texfield in description fields with MarkdownTextArea in RoleForm and ClientForm

Finally I got rid of previous commits on master branch. Now I really understand how to work with branches!

Closes #1387 

the same in roles/create , roles/... and clients/...
![solved_3 1_issue](https://user-images.githubusercontent.com/44370635/66037742-20a01b80-e532-11e9-8027-76142329c09f.PNG)