### PR TITLE
Fix typo in development-process.md

### DIFF
--- a/dev-docs/development-process.md
+++ b/dev-docs/development-process.md
@@ -43,7 +43,7 @@ To run the Taskcluster UI:
     For example:
 
     ```sh
-    export TASKCLUSTER_ROOT_URL=https://taskcluster-staging.net
+    export TASKCLUSTER_ROOT_URL=https://taskcluster.net
     ```
   * Change to the `services/web-server` directory and run `yarn start`.
     This will start a web server on port 3050.


### PR DESCRIPTION
Fixed  typo in development-process.md changing TASKCLUSTER_ROOT_URL from "https://taskcluster-staging.net" to "https://taskcluster.net"

<!-- If this is related to a Bugzilla bug, please begin your title with [Bug XXXXX]
     and update this link.

     Is this change user-visible?  If so, please include a file in changelog/ describing it.
     See https://github.com/taskcluster/taskcluster/blob/master/dev-docs/best-practices/changelog.md
-->