### PR TITLE
Bug 1580666 - add missing await

### DIFF
--- a/services/auth/test/containers_test.js
+++ b/services/auth/test/containers_test.js
@@ -32,7 +32,14 @@ helper.secrets.mockSuite(testing.suiteName(), ['azure', 'gcp'], function(mock, s
 
       // zero out the container
       const blobService = new azure.Blob(credentials);
-      blobService.deleteBlob(containerName, "Roles", {});
+      try {
+        await blobService.deleteBlob(containerName, "Roles", {});
+      } catch (err) {
+        if (err.code !== 'BlobNotFound') {
+          throw err;
+        }
+        // ignore BlobNotFound here, as that's the desired result
+      }
     }
   });
 


### PR DESCRIPTION
This fixes an intermittent failure that occurred when the test queried the blob before the blob was deleted.

Bugzilla Bug: [1580666](https://bugzilla.mozilla.org/show_bug.cgi?id=1580666)
