### PR TITLE
Fix syntax error in namespace.mdx

### DIFF
--- a/ui/docs/manual/using/namespaces.mdx
+++ b/ui/docs/manual/using/namespaces.mdx
@@ -264,6 +264,6 @@ The scopes cover:
 
 <Warning>
 In some cases, projects need additional scopes.
-To do so, create a role `project:<project>:grants/<grantName` containing the desired scopes.
+To do so, create a role `project:&lt;project>:grants/&lt;grantName>` containing the desired scopes.
 This role can then be assumed where necessary, or project admins can use it to grant specific scopes as desired.
 </Warning>


### PR DESCRIPTION
This may not be the best fix -- ideally the content of `<Warning>` would
be treated as Markdown, and in markdown `<` is not a special character
when included in backticks.

Refs #1472.