### PR TITLE
Fix README typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,4 +176,4 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
 
 <!-- ALL-CONTRIBUTORS-LIST:END -->
 
-This project follows the [all-contributors](https://github.com/all-contributors/all-contributors) specification. Contributions of any kind welcome!
+This project follows the [all-contributors](https://github.com/all-contributors/all-contributors) specification. Contributions of any kind are welcome!


### PR DESCRIPTION
**What the PR does**

Add missing the word 'are' in the README message `Contributions of any kind welcome!`

**Description**

A typo exists in the current README file for the project as shown in the screenshot below,

![typo](https://user-images.githubusercontent.com/27225249/66142401-03d91600-e60e-11e9-84e8-e2694fe3b095.png)

*Expected*: `Contributions of any kind are welcome!`
