### PR TITLE
[UI] Resolve text-overflow inside the search box

### DIFF
--- a/ui/src/components/Search/index.jsx
+++ b/ui/src/components/Search/index.jsx
@@ -16,7 +16,7 @@ import { THEME } from '../../utils/constants';
     },
     '& $input': {
       transition: theme.transitions.create('width'),
-      width: 200,
+      width: 230,
       '&:focus': {
         width: 300,
       },


### PR DESCRIPTION
**Issue:** 

When the placeholder value has been changed inside the search box, the overflow of text happened inside the search box of the route - `/tasks/groups`, since the number of characters were more in this.

**What did I do to resolve this:**

I have increased the overall width of the search box while in stationary mode. In transition mode, it works like before.

**Before bug fix:**

<img width="1439" alt="1" src="https://user-images.githubusercontent.com/24657693/66143898-920cc680-e625-11e9-937e-4a4b988b86d2.png">

**After bug fix:**

<img width="1439" alt="2" src="https://user-images.githubusercontent.com/24657693/66143949-a650c380-e625-11e9-8eff-4b13348f5889.png">

Related to PR:https://github.com/taskcluster/taskcluster/pull/1443
 
