### PR TITLE
[UI] role editor description to rendered markdown

### DIFF
--- a/ui/src/components/RoleForm/index.jsx
+++ b/ui/src/components/RoleForm/index.jsx
@@ -2,6 +2,7 @@ import React, { Component, Fragment } from 'react';
 import { oneOfType, object, string, func, bool } from 'prop-types';
 import { withStyles } from '@material-ui/core/styles';
 import classNames from 'classnames';
+import MarkdownTextArea from '@mozilla-frontend-infra/components/MarkdownTextArea';
 import List from '@material-ui/core/List';
 import ListItem from '@material-ui/core/ListItem';
 import ListItemText from '@material-ui/core/ListItemText';
@@ -43,6 +44,10 @@ import { formatScope, scopeLink } from '../../utils/scopeUtils';
   },
   deleteIcon: {
     ...theme.mixins.errorIcon,
+  },
+  roleDescriptionListItem: {
+    marginTop: theme.spacing.unit,
+    marginBottom: theme.spacing.triple,
   },
 }))
 /** A form to view/edit/create a role */
@@ -191,15 +196,13 @@ export default class RoleForm extends Component {
               </ListItem>
             </Fragment>
           )}
-          <ListItem>
-            <TextField
-              label="Description"
+          <ListItem className={classes.roleDescriptionListItem}>
+            <MarkdownTextArea
               name="description"
               onChange={this.handleInputChange}
-              fullWidth
-              multiline
-              rows={5}
               value={description}
+              placeholder="Role description (markdown)"
+              defaultTabIndex={isNewRole ? 0 : 1}
             />
           </ListItem>
           <ListItem>


### PR DESCRIPTION
### **Issue #1459: Role editor should show description in markdown**
change the role editor description from initial text-entry box 
to a tabbed view showing both a preview and a place to write the description.

-------------------------------------------------------------------
### **Change Applied:**

- replaced `TextField` component to `MarkdownTextArea` component for the description part in `RoleForm` UI component
- added `name` property to component in order to make use of `handleInputChange` function for onChange property

---------------------------------------------------------------------
### **Result:**

- before fix: 
<img width="500" alt="#1459 - before" src="https://user-images.githubusercontent.com/29671309/66150262-baa9b600-e64f-11e9-9e6c-136955e85258.PNG">

- after fix:
<img width="500" alt="#1459 - after (write)" src="https://user-images.githubusercontent.com/29671309/66150327-e2008300-e64f-11e9-8740-e4dc5f4b55ab.PNG">
<img width="500" alt="#1459 - after (preview)" src="https://user-images.githubusercontent.com/29671309/66150321-ddd46580-e64f-11e9-969d-b9011587b2ae.PNG">

Closes https://github.com/taskcluster/taskcluster/issues/1459.
