### PR TITLE
[Docs] Fix video link

### DIFF
--- a/ui/docs/tutorial/hello-world.mdx
+++ b/ui/docs/tutorial/hello-world.mdx
@@ -70,7 +70,3 @@ The log view shows the output of the task, including that from downloading the d
 Scrolling all the way to the bottom, you should see the greeting output by the `echo` command.
 
 You've run your first task!
-
-### See Also
-
- * ["Taskcluster Hello World" video by mrrrgn and dustin](https://vreplay.mozilla.com/replay/showRecordingExternal.html?key=7AvN2iczQYcI3lY)


### PR DESCRIPTION
### What does this PR do
Remove broken video link from the Hello World tutorial.

### Description
The video link on the hello world tutorial was broken and needed to be removed.

Issue: [1058](https://github.com/taskcluster/taskcluster/issues/1058)
