### PR TITLE
Fix CHANGELOG typo.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -131,7 +131,7 @@ Helm is still used to render templates because we need to support it.
 
 ## v15.0.0
 
-[MAJOR] The web-server application no longer generates a JWT when logging in. It uses a sessions to keep track of users.
+[MAJOR] The web-server application no longer generates a JWT when logging in. It uses sessions to keep track of users.
 The `JWT_KEY` configuration variable in web-server should be replaced with `SESSION_SECRET` which is used to compute
 the session hash.
 


### PR DESCRIPTION
**What the PR does**

Fix typo in the CHANGELOG.md file.

**Description**

The screenshot below shows a typo that exists in the current CHANGELOG file for this project.

![session-typo](https://user-images.githubusercontent.com/27225249/66154374-f596f400-e625-11e9-954f-ca91f75af9f8.png)

It should be `It uses sessions to keep track of users` instead of `It uses a sessions to keep track of users`.
