### PR TITLE
Only manage node packages with renovate

### DIFF
--- a/package.json
+++ b/package.json
@@ -193,11 +193,7 @@
     "prHourlyLimit": 5,
     "prConcurrentLimit": 10,
     "rangeStrategy": "update-lockfile",
-    "gomod": {
-      "ignoreDeps": [
-        "golang.org/x/tools"
-      ]
-    }
+    "enabeledManagers": ["node"]
   },
   "eslintIgnore": [
     "**/node_modules/**",


### PR DESCRIPTION
Issues like #1492 seem to keep croppping up.  This might be a bug in
renovate, but is probably just buggy `go mod`.  Let's let the versions
sit still for a while -- the go client doesn't have a whole lot of
dependencies anyway.