### PR TITLE
fix python client issue

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,16 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        
+        
+        
+
+        {
+            "name": "Python module/package",
+            "type": "python",
+            "request": "launch",
+            "program": "${file}",
+            "console": "integratedTerminal"
+        }
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "python.pythonPath": "/usr/local/bin/python3"
+}


### PR DESCRIPTION
Bug 1135584: [py client] We should return 'None' when the content length is 0, the HTTP status is 204 and something appropriate for non-json responses

Bugzilla Bug 1135584  https://bugzilla.mozilla.org/show_bug.cgi?id=1135584