### PR TITLE
Heading change in /worker-manager

### DIFF
--- a/ui/src/views/Tasks/NoTask/index.jsx
+++ b/ui/src/views/Tasks/NoTask/index.jsx
@@ -48,7 +48,7 @@ export default class NoTask extends Component {
       <Dashboard
         title="View Tasks"
         helpView={<HelpView description={description} />}
-        search={<Search onSubmit={this.handleTaskSearchSubmit} />}>
+        search={<Search placeholder="Search Task ID" onSubmit={this.handleTaskSearchSubmit} />}>
         <Typography className={classes.infoText}>
           Enter a task ID in the search box
         </Typography>

--- a/ui/src/views/Tasks/NoTask/index.jsx
+++ b/ui/src/views/Tasks/NoTask/index.jsx
@@ -48,7 +48,12 @@ export default class NoTask extends Component {
       <Dashboard
         title="View Tasks"
         helpView={<HelpView description={description} />}
-        search={<Search placeholder="Search Task ID" onSubmit={this.handleTaskSearchSubmit} />}>
+        search={
+          <Search
+            placeholder="Search Task ID"
+            onSubmit={this.handleTaskSearchSubmit}
+          />
+        }>
         <Typography className={classes.infoText}>
           Enter a task ID in the search box
         </Typography>

--- a/ui/src/views/Tasks/NoTaskGroup/index.jsx
+++ b/ui/src/views/Tasks/NoTaskGroup/index.jsx
@@ -48,7 +48,12 @@ export default class NoTaskGroup extends Component {
       <Dashboard
         title="Task Groups"
         helpView={<HelpView description={description} />}
-        search={<Search placeholder="Search Task Group ID" onSubmit={this.handleTaskGroupSearchSubmit} />}>
+        search={
+          <Search
+            placeholder="Search Task Group ID"
+            onSubmit={this.handleTaskGroupSearchSubmit}
+          />
+        }>
         <Typography className={classes.infoText}>
           Enter a task group ID in the search box
         </Typography>

--- a/ui/src/views/Tasks/NoTaskGroup/index.jsx
+++ b/ui/src/views/Tasks/NoTaskGroup/index.jsx
@@ -48,7 +48,7 @@ export default class NoTaskGroup extends Component {
       <Dashboard
         title="Task Groups"
         helpView={<HelpView description={description} />}
-        search={<Search onSubmit={this.handleTaskGroupSearchSubmit} />}>
+        search={<Search placeholder="Search Task Group ID" onSubmit={this.handleTaskGroupSearchSubmit} />}>
         <Typography className={classes.infoText}>
           Enter a task group ID in the search box
         </Typography>

--- a/ui/src/views/WorkerManager/WMViewWorkerPools/index.jsx
+++ b/ui/src/views/WorkerManager/WMViewWorkerPools/index.jsx
@@ -83,7 +83,7 @@ export default class WorkerManagerWorkerPoolsView extends Component {
 
     return (
       <Dashboard
-        title="Worker Pools"
+        title="Worker Manager"
         search={
           <Search
             disabled={loading}


### PR DESCRIPTION
**Issue:**

The heading was displayed as the `Worker Pools` in `/worker-manager` route which mismatches the current navbar heading for this route.

**What did I do to resolve this:**

Hence, I made the heading for this route as `Worker Manager` to match the navbar.
