### PR TITLE
Add create secret and read it back smoketest

### DIFF
--- a/infrastructure/tooling/src/smoketest/checks/secrets.js
+++ b/infrastructure/tooling/src/smoketest/checks/secrets.js
@@ -1,0 +1,32 @@
+const taskcluster = require('taskcluster-client');
+
+exports.tasks = [];
+exports.tasks.push({
+  title: 'Create secret/read-it-back check',
+  requires: [],
+  provides: [
+    'smoke-secret',
+  ],
+  run: async () => {
+    let secrets = new taskcluster.Secrets(taskcluster.fromEnvVars());
+    let baseUrl = 'project/taskcluster/smoketest/';
+    const payload = {
+      "expires": "2030-10-08T02:59:43.613Z",
+      "secret": {
+        "description": "Outreachy Applicant",
+        "type": "object",
+      },
+    };
+    await secrets.set(baseUrl, payload);
+    const getSecret = await secrets.get(baseUrl);
+    if (getSecret.secret.description === payload.secret.description) {
+      secrets.remove(baseUrl);
+    }
+    const getSecretAgain = await secrets.get(baseUrl).catch(function(err){
+      return(
+        "No Secrets Found" + err
+      );
+    });
+    getSecretAgain!==getSecret? 'Success' : 'Failed';
+  },
+});

--- a/infrastructure/tooling/src/smoketest/checks/secrets.js
+++ b/infrastructure/tooling/src/smoketest/checks/secrets.js
@@ -10,23 +10,22 @@ exports.tasks.push({
   ],
   run: async () => {
     let secrets = new taskcluster.Secrets(taskcluster.fromEnvVars());
-    let baseUrl = 'project/taskcluster/smoketest/';
     let secretName = taskcluster.slugid();
+    let secretPrefix = `project/taskcluster/smoketest/${secretName}`;
     const payload = {
       "expires": taskcluster.fromNowJSON('2 minutes'),
       "secret": {
-        "description": secretName,
+        "description": `Secret ${secretName}`,
         "type": "object",
       },
     };
-    await secrets.set(baseUrl, payload);
-    const getSecret = await secrets.get(baseUrl);
+    await secrets.set(secretPrefix, payload);
+    const getSecret = await secrets.get(secretPrefix);
     assert.deepEqual(getSecret.secret, payload.secret);
-    await secrets.remove(baseUrl);
+    await secrets.remove(secretPrefix);
     await assert.rejects(
-      () => secrets.get(baseUrl),
-    ).then(()=>{
-      err => assert.equal(err.code, 404);
-    });
+      () => secrets.get(secretPrefix),
+      err => assert.equal(err.code, 404)
+    );
   },
 });


### PR DESCRIPTION
 This PR addresses #1247, which is to create a secret, read it back and then read it again and if it is the same one as the created, remove the secret then try to get the secret again which fails.

After running `yarn smoketest`

![smoketest](https://user-images.githubusercontent.com/30138596/66374269-3c8b3d80-e9c8-11e9-8a67-4daef9652080.png)

@djmitche @helfi92 