### PR TITLE
Heading change in /tasks/index route

### DIFF
--- a/ui/src/views/Tasks/TaskIndex/ListNamespaces/index.jsx
+++ b/ui/src/views/Tasks/TaskIndex/ListNamespaces/index.jsx
@@ -135,7 +135,7 @@ export default class ListNamespaces extends Component {
 
     return (
       <Dashboard
-        title="Index Browser"
+        title="Task Index"
         helpView={<HelpView description={description} />}>
         <Fragment>
           {loading && <Spinner loading />}


### PR DESCRIPTION
**Issue:**

The heading was displayed as the `Index Browser` in `/tasks/index` route which mismatches the current navbar heading for this route.

**What did I do to resolve this:**

Hence, I made the heading for this route as `Task Index` to match the navbar.