### PR TITLE
Heading change in /purge-caches

### DIFF
--- a/ui/src/views/CachePurges/ViewCachePurges/index.jsx
+++ b/ui/src/views/CachePurges/ViewCachePurges/index.jsx
@@ -86,7 +86,7 @@ export default class ViewCachePurges extends Component {
             </Typography>
           </HelpView>
         }
-        title="Cache Purges">
+        title="Purge Caches">
         <Fragment>
           {!cachePurges && loading && <Spinner loading />}
           <ErrorPanel fixed error={error} />


### PR DESCRIPTION
**Issue:**

The heading was displayed as the `Cache Purges` in the `/purge-caches` route which mismatches the current navbar heading for this route.

**What did I do to resolve this:**

Hence, I made the heading for this route as `Purge Caches` to match the navbar.
