### PR TITLE
Bug 1574666 - move this repo to the community deploy ment

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -230,8 +230,8 @@ tasks:
                   else: {}
             each(job):
               taskId: {$eval: as_slugid(job.name)}
-              provisionerId: aws-provisioner-v1
-              workerType: github-worker
+              provisionerId: proj-taskcluster
+              workerType: ci
               created: {$fromNow: ''}
               deadline: {$fromNow: '3 hours'}
               dependencies: {$eval: job.dependencies}

--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -63,8 +63,6 @@ tasks:
         - name: taskcluster-lib-config
         - name: taskcluster-lib-validate
         - name: taskcluster-auth
-          env:
-            TEST_BUCKET: test-bucket-for-any-garbage
         - name: taskcluster-built-in-workers
         - name: taskcluster-github
         - name: taskcluster-hooks
@@ -122,7 +120,7 @@ tasks:
               CHROME_BIN=firefox DISPLAY=:99 yarn test
         - name: taskcluster-client-py-2.7
           image: 'python:2.7'
-          cache: {project-taskcluster-test-pip-cache: /cache}
+          cache: {taskcluster-test-pip-cache: /cache}
           install: >-
               cd clients/client-py &&
               virtualenv /sandbox &&
@@ -131,7 +129,7 @@ tasks:
               TOXENV=py27 /sandbox/bin/tox
         - name: taskcluster-client-py-3.6
           image: 'python:3.6'
-          cache: {project-taskcluster-test-pip-cache: /cache}
+          cache: {taskcluster-test-pip-cache: /cache}
           install: >-
               cd clients/client-py &&
               python3 -mvenv /sandbox &&
@@ -140,7 +138,7 @@ tasks:
               TOXENV=py36 /sandbox/bin/tox
         - name: taskcluster-client-py-3.7
           image: 'python:3.7'
-          cache: {project-taskcluster-test-pip-cache: /cache}
+          cache: {taskcluster-test-pip-cache: /cache}
           install: >-
               cd clients/client-py &&
               python3 -mvenv /sandbox &&
@@ -217,7 +215,7 @@ tasks:
                 cache:
                   $if: entry['cache']
                   then: {$eval: entry.cache}
-                  else: {project-taskcluster-test-yarn-cache: /cache}
+                  else: {taskcluster-test-yarn-cache: /cache}
                 dependencies:
                   $if: entry['post_packages']
                   then:
@@ -246,8 +244,10 @@ tasks:
                   - notify.email.${owner}.on-exception
                   - notify.irc-channel.#taskcluster-bots.on-any
               scopes:
-                - assume:project:taskcluster:tests:taskcluster
-                - docker-worker:cache:project-taskcluster-test-*
+                - secrets:get:project/taskcluster/testing/azure
+                - secrets:get:project/taskcluster/testing/codecov
+                - secrets:get:project/taskcluster/testing/taskcluster-*
+                - docker-worker:cache:taskcluster-test-*
               payload:
                 artifacts: {$eval: job.artifacts}
                 features:

--- a/libraries/pulse/test/helper.js
+++ b/libraries/pulse/test/helper.js
@@ -14,7 +14,7 @@ exports.monitor = defaultMonitorManager.setup({
 });
 
 exports.secrets = new Secrets({
-  secretName: 'project/taskcluster/testing/taskcluster-lib-pulse',
+  secretName: [],
   secrets: {
     pulse: [
       {env: 'PULSE_CONNECTION_STRING', name: 'connectionString'},

--- a/libraries/testing/src/secrets.js
+++ b/libraries/testing/src/secrets.js
@@ -118,6 +118,10 @@ class Secrets {
     const that = this;
     let skipping = false;
 
+    if (secretList.some(n => ! this.secrets[n])) {
+      throw new Error(`Unknown secrets in ${JSON.stringify(secretList)}`);
+    }
+
     suite(`${title} (mock)`, function() {
       suiteSetup(async function() {
         skipping = false;

--- a/libraries/testing/src/with-entity.js
+++ b/libraries/testing/src/with-entity.js
@@ -105,5 +105,5 @@ module.exports = (mock, skipping, helper, loaderComponent, cls,
 
 module.exports.secret = [
   {env: 'AZURE_ACCOUNT', cfg: 'azure.accountId', name: 'accountId'},
-  {env: 'AZURE_ACCOUNT_KEY', cfg: 'azure.accessKey', name: 'accountKey'},
+  {env: 'AZURE_ACCOUNT_KEY', cfg: 'azure.accessKey', name: 'accessKey'},
 ];

--- a/libraries/testing/test/secrets_test.js
+++ b/libraries/testing/test/secrets_test.js
@@ -203,8 +203,8 @@ suite(suiteName(), function() {
     });
 
     suiteSetup(function() {
-      nock('http://taskcluster:80')
-        .get('/secrets.taskcluster.net/v1/secret/path%2Fto%2Fsecret')
+      nock('http://proxy')
+        .get('/api/secrets/v1/secret/path%2Fto%2Fsecret')
         .reply(200, (uri, requestBody) => {
           return {secret: {SECRET_VALUE: '13'}};
         });
@@ -216,6 +216,7 @@ suite(suiteName(), function() {
 
     test('with TASK_ID set', async function() {
       process.env.TASK_ID = '1234';
+      process.env.TASKCLUSTER_PROXY_URL = 'http://proxy';
       assert.deepEqual(await secrets._fetchSecrets(), {SECRET_VALUE: '13'});
     });
   });

--- a/services/auth/config.yml
+++ b/services/auth/config.yml
@@ -170,3 +170,5 @@ test:
     env:                      development
     development:              true
     trustProxy:               true
+  taskcluster:
+    rootUrl: "https://tc.example.com"

--- a/services/auth/test/azure_test.js
+++ b/services/auth/test/azure_test.js
@@ -5,7 +5,7 @@ const azure = require('fast-azure-storage');
 const taskcluster = require('taskcluster-client');
 const testing = require('taskcluster-lib-testing');
 
-helper.secrets.mockSuite(testing.suiteName(), ['app', 'azure', 'gcp'], function(mock, skipping) {
+helper.secrets.mockSuite(testing.suiteName(), ['azure', 'gcp'], function(mock, skipping) {
   if (mock) {
     return; // We only test this with real creds
   }
@@ -22,8 +22,7 @@ helper.secrets.mockSuite(testing.suiteName(), ['app', 'azure', 'gcp'], function(
   });
 
   test('azureAccounts', function() {
-    return helper.apiClient.azureAccounts(
-    ).then(function(result) {
+    return helper.apiClient.azureAccounts().then(function(result) {
       assert.deepEqual(result.accounts, _.keys(helper.cfg.app.azureAccounts));
     });
   });

--- a/services/auth/test/cleanup.js
+++ b/services/auth/test/cleanup.js
@@ -12,7 +12,7 @@ suite('Test Cleanup', function() {
 
   test('cleanup testing containers (for all services)', async function() {
     this.timeout(0);
-    const {accountId, accountKey: accessKey} = helper.secrets.get('azure');
+    const {accountId, accessKey} = helper.secrets.get('azure');
     const blob = new azure.Blob({accountId, accessKey});
 
     // specify a few prefixes of known test containers, including those from
@@ -58,7 +58,7 @@ suite('Test Cleanup', function() {
   test('cleanup testing tables (for all services)', async function() {
     this.timeout(0);
 
-    const {accountId, accountKey: accessKey} = helper.secrets.get('azure');
+    const {accountId, accessKey} = helper.secrets.get('azure');
     const table = new azure.Table({accountId, accessKey});
 
     // match the pattern used in libraries/testing/src/with-entity.js to name

--- a/services/auth/test/client_test.js
+++ b/services/auth/test/client_test.js
@@ -5,7 +5,7 @@ const assume = require('assume');
 const testing = require('taskcluster-lib-testing');
 const taskcluster = require('taskcluster-client');
 
-helper.secrets.mockSuite(testing.suiteName(), ['app', 'azure', 'gcp'], function(mock, skipping) {
+helper.secrets.mockSuite(testing.suiteName(), ['azure', 'gcp'], function(mock, skipping) {
   helper.withCfg(mock, skipping);
   helper.withPulse(mock, skipping);
   helper.withEntities(mock, skipping);

--- a/services/auth/test/gcp_test.js
+++ b/services/auth/test/gcp_test.js
@@ -3,7 +3,7 @@ const assert = require('assert');
 const helper = require('./helper');
 const testing = require('taskcluster-lib-testing');
 
-helper.secrets.mockSuite(testing.suiteName(), ['app', 'gcp', 'azure'], function(mock, skipping) {
+helper.secrets.mockSuite(testing.suiteName(), ['gcp', 'azure'], function(mock, skipping) {
   helper.withCfg(mock, skipping);
   helper.withGcp(mock, skipping);
   helper.withPulse(mock, skipping);

--- a/services/auth/test/helper.js
+++ b/services/auth/test/helper.js
@@ -38,7 +38,7 @@ exports.secrets = new Secrets({
   secrets: {
     azure: [
       {env: 'AZURE_ACCOUNT', cfg: 'azure.accountId', name: 'accountId'},
-      {env: 'AZURE_ACCOUNT_KEY', cfg: 'azure.accessKey', name: 'accountKey'},
+      {env: 'AZURE_ACCOUNT_KEY', cfg: 'azure.accessKey', name: 'accessKey'},
     ],
     aws: [
       {env: 'AWS_ACCESS_KEY_ID', cfg: 'aws.accessKeyId'},

--- a/services/auth/test/helper.js
+++ b/services/auth/test/helper.js
@@ -31,11 +31,11 @@ withMonitor(exports);
 
 // set up the testing secrets
 exports.secrets = new Secrets({
-  secretName: 'project/taskcluster/testing/taskcluster-auth',
+  secretName: [
+    'project/taskcluster/testing/azure',
+    'project/taskcluster/testing/taskcluster-auth',
+  ],
   secrets: {
-    app: [
-      {env: 'AZURE_ACCOUNTS', cfg: 'app.azureAccounts', mock: {fakeaccount: 'key'}},
-    ],
     azure: [
       {env: 'AZURE_ACCOUNT', cfg: 'azure.accountId', name: 'accountId'},
       {env: 'AZURE_ACCOUNT_KEY', cfg: 'azure.accessKey', name: 'accountKey'},
@@ -43,13 +43,7 @@ exports.secrets = new Secrets({
     aws: [
       {env: 'AWS_ACCESS_KEY_ID', cfg: 'aws.accessKeyId'},
       {env: 'AWS_SECRET_ACCESS_KEY', cfg: 'aws.secretAccessKey'},
-    ],
-    taskcluster: [
-      {env: 'TASKCLUSTER_ROOT_URL', cfg: 'taskcluster.rootUrl', name: 'rootUrl', mock: exports.rootUrl},
-    ],
-    sentry: [
-      {env: 'SENTRY_AUTH_TOKEN', cfg: 'sentry.authToken'},
-      {env: 'SENTRY_HOSTNAME', cfg: 'sentry.hostname'},
+      {env: 'TEST_BUCKET', cfg: 'test.testBucket'},
     ],
     gcp: [
       {env: 'GCP_CREDENTIALS_ALLOWED_PROJECTS', cfg: 'gcpCredentials.allowedProjects', name: 'allowedProjects', mock: {}},
@@ -71,6 +65,9 @@ exports.withCfg = (mock, skipping) => {
       accessToken: clientId === 'static/taskcluster/root' ? exports.rootAccessToken : 'must-be-at-least-22-characters',
       description: 'testing',
     })));
+
+    // override cfg.app.azureAccounts based on cfg.azure
+    exports.load.cfg('app.azureAccounts', {[exports.cfg.azure.accountId]: exports.cfg.azure.accessKey});
   });
 };
 
@@ -415,7 +412,6 @@ exports.withGcp = (mock, skipping) => {
       };
     } else {
       const {credentials, allowedServiceAccounts} = await exports.load('gcp');
-      console.log(credentials);
       exports.gcpAccount = {
         email: allowedServiceAccounts[0],
         project_id: credentials.project_id,

--- a/services/auth/test/purgeExpiredClients_test.js
+++ b/services/auth/test/purgeExpiredClients_test.js
@@ -3,7 +3,7 @@ const assume = require('assume');
 const taskcluster = require('taskcluster-client');
 const testing = require('taskcluster-lib-testing');
 
-helper.secrets.mockSuite(testing.suiteName(), ['app', 'azure', 'gcp'], function(mock, skipping) {
+helper.secrets.mockSuite(testing.suiteName(), ['azure', 'gcp'], function(mock, skipping) {
   helper.withCfg(mock, skipping);
   helper.withPulse(mock, skipping);
   helper.withEntities(mock, skipping);

--- a/services/auth/test/remotevalidation_test.js
+++ b/services/auth/test/remotevalidation_test.js
@@ -5,7 +5,7 @@ const taskcluster = require('taskcluster-client');
 const request = require('superagent');
 const testing = require('taskcluster-lib-testing');
 
-helper.secrets.mockSuite(testing.suiteName(), ['app', 'azure', 'gcp'], function(mock, skipping) {
+helper.secrets.mockSuite(testing.suiteName(), ['azure', 'gcp'], function(mock, skipping) {
   helper.withCfg(mock, skipping);
   helper.withPulse(mock, skipping);
   helper.withEntities(mock, skipping);

--- a/services/auth/test/role_test.js
+++ b/services/auth/test/role_test.js
@@ -6,7 +6,7 @@ const assume = require('assume');
 const testing = require('taskcluster-lib-testing');
 const taskcluster = require('taskcluster-client');
 
-helper.secrets.mockSuite(testing.suiteName(), ['app', 'azure', 'gcp'], function(mock, skipping) {
+helper.secrets.mockSuite(testing.suiteName(), ['azure', 'gcp'], function(mock, skipping) {
   helper.withCfg(mock, skipping);
   helper.withPulse(mock, skipping);
   helper.withEntities(mock, skipping, {orderedTests: true});

--- a/services/auth/test/rolelogic_test.js
+++ b/services/auth/test/rolelogic_test.js
@@ -4,7 +4,7 @@ const taskcluster = require('taskcluster-client');
 const mocha = require('mocha');
 const testing = require('taskcluster-lib-testing');
 
-helper.secrets.mockSuite(testing.suiteName(), ['app', 'azure', 'gcp'], function(mock, skipping) {
+helper.secrets.mockSuite(testing.suiteName(), ['azure', 'gcp'], function(mock, skipping) {
   helper.withCfg(mock, skipping);
   helper.withPulse(mock, skipping);
   helper.withEntities(mock, skipping);

--- a/services/auth/test/s3_test.js
+++ b/services/auth/test/s3_test.js
@@ -5,7 +5,7 @@ const helper = require('./helper');
 const debug = require('debug')('s3_test');
 const testing = require('taskcluster-lib-testing');
 
-helper.secrets.mockSuite(testing.suiteName(), ['app', 'aws', 'gcp'], function(mock, skipping) {
+helper.secrets.mockSuite(testing.suiteName(), ['aws', 'gcp'], function(mock, skipping) {
   if (mock) {
     return; // This is actually testing sts tokens and we are not going to mock those
   }

--- a/services/auth/test/scoperesolver_test.js
+++ b/services/auth/test/scoperesolver_test.js
@@ -15,7 +15,7 @@ suite(testing.suiteName(), () => {
     scopeResolver = new ScopeResolver({monitor, disableCache: true});
   });
 
-  helper.secrets.mockSuite('setup and listening', ['app', 'azure', 'gcp'], function(mock, skipping) {
+  helper.secrets.mockSuite('setup and listening', ['azure', 'gcp'], function(mock, skipping) {
     helper.withEntities(mock, skipping);
     helper.withRoles(mock, skipping);
     helper.withPulse(mock, skipping);

--- a/services/auth/test/sentry_test.js
+++ b/services/auth/test/sentry_test.js
@@ -3,7 +3,7 @@ const taskcluster = require('taskcluster-client');
 const assert = require('assert');
 const testing = require('taskcluster-lib-testing');
 
-helper.secrets.mockSuite(testing.suiteName(), ['app', 'gcp'], function(mock, skipping) {
+helper.secrets.mockSuite(testing.suiteName(), ['gcp'], function(mock, skipping) {
   if (!mock) {
     return; // We don't test this with real credentials for now!
   }

--- a/services/auth/test/staticclients_test.js
+++ b/services/auth/test/staticclients_test.js
@@ -4,7 +4,7 @@ const helper = require('./helper');
 const assume = require('assume');
 const testing = require('taskcluster-lib-testing');
 
-helper.secrets.mockSuite(testing.suiteName(), ['app', 'azure', 'gcp'], function(mock, skipping) {
+helper.secrets.mockSuite(testing.suiteName(), ['azure', 'gcp'], function(mock, skipping) {
   helper.withCfg(mock, skipping);
   helper.withPulse(mock, skipping);
   helper.withEntities(mock, skipping);

--- a/services/auth/test/statsum_test.js
+++ b/services/auth/test/statsum_test.js
@@ -2,7 +2,7 @@ const helper = require('./helper');
 const assert = require('assert');
 const testing = require('taskcluster-lib-testing');
 
-helper.secrets.mockSuite(testing.suiteName(), ['app', 'azure', 'gcp'], function(mock, skipping) {
+helper.secrets.mockSuite(testing.suiteName(), ['azure', 'gcp'], function(mock, skipping) {
   helper.withCfg(mock, skipping);
   helper.withPulse(mock, skipping);
   helper.withEntities(mock, skipping);

--- a/services/auth/test/stories_test.js
+++ b/services/auth/test/stories_test.js
@@ -4,7 +4,7 @@ const assume = require('assume');
 const taskcluster = require('taskcluster-client');
 const testing = require('taskcluster-lib-testing');
 
-helper.secrets.mockSuite(testing.suiteName(), ['app', 'azure', 'gcp'], function(mock, skipping) {
+helper.secrets.mockSuite(testing.suiteName(), ['azure', 'gcp'], function(mock, skipping) {
   helper.withCfg(mock, skipping);
   helper.withPulse(mock, skipping);
   helper.withEntities(mock, skipping, {orderedTests: true});

--- a/services/auth/test/testauth_test.js
+++ b/services/auth/test/testauth_test.js
@@ -13,7 +13,7 @@ const badcreds = {
 };
 
 suite(testing.suiteName(), function() {
-  helper.secrets.mockSuite('testAuth', ['app', 'azure', 'gcp'], function(mock, skipping) {
+  helper.secrets.mockSuite('testAuth', ['azure', 'gcp'], function(mock, skipping) {
     helper.withCfg(mock, skipping);
     helper.withPulse(mock, skipping);
     helper.withEntities(mock, skipping);
@@ -100,7 +100,7 @@ suite(testing.suiteName(), function() {
     });
   });
 
-  helper.secrets.mockSuite('testAuthGet', ['app', 'azure', 'gcp'], function(mock, skipping) {
+  helper.secrets.mockSuite('testAuthGet', ['azure', 'gcp'], function(mock, skipping) {
     helper.withCfg(mock, skipping);
     helper.withPulse(mock, skipping);
     helper.withEntities(mock, skipping);

--- a/services/auth/test/websocktunnel_test.js
+++ b/services/auth/test/websocktunnel_test.js
@@ -3,7 +3,7 @@ const assert = require('assert');
 const jwt = require('jsonwebtoken');
 const testing = require('taskcluster-lib-testing');
 
-helper.secrets.mockSuite(testing.suiteName(), ['app', 'azure', 'gcp'], function(mock, skipping) {
+helper.secrets.mockSuite(testing.suiteName(), ['azure', 'gcp'], function(mock, skipping) {
   helper.withCfg(mock, skipping);
   helper.withPulse(mock, skipping);
   helper.withEntities(mock, skipping);

--- a/services/github/config.yml
+++ b/services/github/config.yml
@@ -127,6 +127,7 @@ test:
 
   taskcluster:
     schedulerId: tc-gh-devel
+    rootUrl: "https://tc.example.com"
 
   pulse:
     namespace: 'taskcluster-fake'

--- a/services/github/test/api_test.js
+++ b/services/github/test/api_test.js
@@ -9,7 +9,7 @@ const testing = require('taskcluster-lib-testing');
  * the github webhook endpoint which is tested
  * in webhook_test.js
  */
-helper.secrets.mockSuite(testing.suiteName(), ['taskcluster'], function(mock, skipping) {
+helper.secrets.mockSuite(testing.suiteName(), ['azure'], function(mock, skipping) {
   helper.withEntities(mock, skipping);
   helper.withFakeGithub(mock, skipping);
   helper.withPulse(mock, skipping);

--- a/services/github/test/handler_test.js
+++ b/services/github/test/handler_test.js
@@ -12,7 +12,7 @@ const {LEVELS} = require('taskcluster-lib-monitor');
  * This tests the event handlers, faking out all of the services they
  * interact with.
  */
-helper.secrets.mockSuite(testing.suiteName(), ['taskcluster'], function(mock, skipping) {
+helper.secrets.mockSuite(testing.suiteName(), ['azure'], function(mock, skipping) {
   helper.withEntities(mock, skipping);
   helper.withFakeGithub(mock, skipping);
   helper.withPulse(mock, skipping);

--- a/services/github/test/helper.js
+++ b/services/github/test/helper.js
@@ -6,7 +6,6 @@ const taskcluster = require('taskcluster-client');
 const load = require('../src/main');
 const fakeGithubAuth = require('./github-auth');
 const data = require('../src/data');
-const libUrls = require('taskcluster-lib-urls');
 const {fakeauth, stickyLoader, Secrets, withEntity, withPulse, withMonitor} = require('taskcluster-lib-testing');
 
 exports.load = stickyLoader(load);
@@ -20,13 +19,9 @@ withMonitor(exports);
 
 // set up the testing secrets
 exports.secrets = new Secrets({
-  secretName: 'project/taskcluster/testing/taskcluster-github',
+  secretName: 'project/taskcluster/testing/azure',
   secrets: {
-    taskcluster: [
-      {env: 'TASKCLUSTER_ROOT_URL', cfg: 'taskcluster.rootUrl', name: 'rootUrl', mock: libUrls.testRootUrl()},
-      {env: 'TASKCLUSTER_CLIENT_ID', cfg: 'taskcluster.credentials.clientId', name: 'clientId'},
-      {env: 'TASKCLUSTER_ACCESS_TOKEN', cfg: 'taskcluster.credentials.accessToken', name: 'accessToken'},
-    ],
+    azure: withEntity.secret,
   },
   load: exports.load,
 });

--- a/services/github/test/pulse_test.js
+++ b/services/github/test/pulse_test.js
@@ -3,7 +3,7 @@ const helper = require('./helper');
 const libUrls = require('taskcluster-lib-urls');
 const testing = require('taskcluster-lib-testing');
 
-helper.secrets.mockSuite(testing.suiteName(), ['taskcluster'], function(mock, skipping) {
+helper.secrets.mockSuite(testing.suiteName(), ['azure'], function(mock, skipping) {
   helper.withEntities(mock, skipping);
   helper.withPulse(mock, skipping);
   helper.withFakeGithub(mock, skipping);

--- a/services/github/test/sync_test.js
+++ b/services/github/test/sync_test.js
@@ -5,7 +5,7 @@ const testing = require('taskcluster-lib-testing');
 /**
  * Tests of installation syncing
  */
-helper.secrets.mockSuite(testing.suiteName(), ['taskcluster'], function(mock, skipping) {
+helper.secrets.mockSuite(testing.suiteName(), ['azure'], function(mock, skipping) {
   helper.withEntities(mock, skipping);
   helper.withFakeGithub(mock, skipping);
   helper.withPulse(mock, skipping);

--- a/services/github/test/webhook_test.js
+++ b/services/github/test/webhook_test.js
@@ -2,7 +2,7 @@ const helper = require('./helper');
 const assert = require('assert');
 const testing = require('taskcluster-lib-testing');
 
-helper.secrets.mockSuite(testing.suiteName(), ['taskcluster'], function(mock, skipping) {
+helper.secrets.mockSuite(testing.suiteName(), ['azure'], function(mock, skipping) {
   helper.withEntities(mock, skipping);
   helper.withFakeGithub(mock, skipping);
   helper.withPulse(mock, skipping);

--- a/services/hooks/config.yml
+++ b/services/hooks/config.yml
@@ -49,6 +49,9 @@ production:
 
 test:
   # See user-config-example.yml for secrets credentials required for tests
+  taskcluster:
+    rootUrl: "https://tc.example.com"
+
   app:
     component:        hooks-tests
     hookTableName:    HooksTestTable2

--- a/services/hooks/test/api_test.js
+++ b/services/hooks/test/api_test.js
@@ -6,7 +6,7 @@ const taskcluster = require('taskcluster-client');
 const helper = require('./helper');
 const testing = require('taskcluster-lib-testing');
 
-helper.secrets.mockSuite(testing.suiteName(), ['taskcluster'], function(mock, skipping) {
+helper.secrets.mockSuite(testing.suiteName(), ['azure'], function(mock, skipping) {
   helper.withEntities(mock, skipping);
   helper.withTaskCreator(mock, skipping);
   helper.withPulse(mock, skipping);

--- a/services/hooks/test/expires_test.js
+++ b/services/hooks/test/expires_test.js
@@ -4,7 +4,7 @@ const assume = require('assume');
 const testing = require('taskcluster-lib-testing');
 
 suite(testing.suiteName(), function() {
-  helper.secrets.mockSuite('expires_test.js', ['taskcluster'], function(mock, skipping) {
+  helper.secrets.mockSuite('expires_test.js', ['azure'], function(mock, skipping) {
     helper.withEntities(mock, skipping);
 
     test('expire nothing', async function() {

--- a/services/hooks/test/helper.js
+++ b/services/hooks/test/helper.js
@@ -4,7 +4,6 @@ const taskcreator = require('../src/taskcreator');
 const {stickyLoader, fakeauth, Secrets, withEntity, withPulse, withMonitor} = require('taskcluster-lib-testing');
 const builder = require('../src/api');
 const load = require('../src/main');
-const libUrls = require('taskcluster-lib-urls');
 
 const helper = exports;
 
@@ -17,14 +16,10 @@ helper.load.inject('process', 'test');
 withMonitor(helper);
 
 helper.secrets = new Secrets({
-  secretName: 'project/taskcluster/testing/taskcluster-hooks',
+  secretName: 'project/taskcluster/testing/azure',
   load: helper.load,
   secrets: {
-    taskcluster: [
-      {env: 'TASKCLUSTER_CLIENT_ID', cfg: 'taskcluster.credentials.clientId', name: 'clientId'},
-      {env: 'TASKCLUSTER_ACCESS_TOKEN', cfg: 'taskcluster.credentials.accessToken', name: 'accessToken'},
-      {env: 'TASKCLUSTER_ROOT_URL', cfg: 'taskcluster.rootUrl', name: 'rootUrl', mock: libUrls.testRootUrl()},
-    ],
+    azure: withEntity.secret,
   },
 });
 

--- a/services/hooks/test/listeners_test.js
+++ b/services/hooks/test/listeners_test.js
@@ -5,7 +5,7 @@ const sinon = require('sinon');
 const helper = require('./helper');
 const testing = require('taskcluster-lib-testing');
 
-helper.secrets.mockSuite(testing.suiteName(), ['taskcluster'], function(mock, skipping) {
+helper.secrets.mockSuite(testing.suiteName(), ['azure'], function(mock, skipping) {
   helper.withEntities(mock, skipping);
   helper.withTaskCreator(mock, skipping);
   helper.withPulse(mock, skipping);

--- a/services/hooks/test/scheduler_test.js
+++ b/services/hooks/test/scheduler_test.js
@@ -4,7 +4,7 @@ const helper = require('./helper');
 const taskcluster = require('taskcluster-client');
 const testing = require('taskcluster-lib-testing');
 
-helper.secrets.mockSuite(testing.suiteName(), ['taskcluster'], function(mock, skipping) {
+helper.secrets.mockSuite(testing.suiteName(), ['azure'], function(mock, skipping) {
   helper.withEntities(mock, skipping);
   helper.withTaskCreator(mock, skipping);
 

--- a/services/index/config.yml
+++ b/services/index/config.yml
@@ -72,6 +72,8 @@ production:
     trustProxy: !env:bool TRUST_PROXY
 
 test:
+  taskcluster:
+    rootUrl: "https://tc.example.com"
   app:
     indexedTaskTableName: 'DummyTestIndexedTasks'
     namespaceTableName: 'DummyTestNamespaces'

--- a/services/index/test/api_test.js
+++ b/services/index/test/api_test.js
@@ -8,7 +8,7 @@ const assume = require('assume');
 const libUrls = require('taskcluster-lib-urls');
 const testing = require('taskcluster-lib-testing');
 
-helper.secrets.mockSuite(testing.suiteName(), ['taskcluster'], function(mock, skipping) {
+helper.secrets.mockSuite(testing.suiteName(), ['azure'], function(mock, skipping) {
   helper.withEntities(mock, skipping);
   helper.withFakeQueue(mock, skipping);
   helper.withPulse(mock, skipping);

--- a/services/index/test/helper.js
+++ b/services/index/test/helper.js
@@ -3,7 +3,6 @@ const data = require('../src/data');
 const builder = require('../src/api');
 const taskcluster = require('taskcluster-client');
 const load = require('../src/main');
-const libUrls = require('taskcluster-lib-urls');
 const {fakeauth, stickyLoader, Secrets, withEntity, withPulse, withMonitor} = require('taskcluster-lib-testing');
 
 const helper = module.exports;
@@ -19,14 +18,9 @@ withMonitor(exports);
 
 // set up the testing secrets
 exports.secrets = new Secrets({
-  secretName: 'project/taskcluster/testing/taskcluster-index',
+  secretName: 'project/taskcluster/testing/azure',
   secrets: {
-    taskcluster: [
-      {env: 'TASKCLUSTER_ROOT_URL', cfg: 'taskcluster.rootUrl', name: 'rootUrl',
-        mock: libUrls.testRootUrl()},
-      {env: 'TASKCLUSTER_CLIENT_ID', cfg: 'taskcluster.credentials.clientId', name: 'clientId'},
-      {env: 'TASKCLUSTER_ACCESS_TOKEN', cfg: 'taskcluster.credentials.accessToken', name: 'accessToken'},
-    ],
+    azure: withEntity.secret,
   },
   load: exports.load,
 });

--- a/services/index/test/index_test.js
+++ b/services/index/test/index_test.js
@@ -6,7 +6,7 @@ const _ = require('lodash');
 const testing = require('taskcluster-lib-testing');
 const taskcluster = require('taskcluster-client');
 
-helper.secrets.mockSuite(testing.suiteName(), ['taskcluster'], function(mock, skipping) {
+helper.secrets.mockSuite(testing.suiteName(), ['azure'], function(mock, skipping) {
   helper.withEntities(mock, skipping);
   helper.withFakeQueue(mock, skipping);
   helper.withPulse(mock, skipping);

--- a/services/notify/config.yml
+++ b/services/notify/config.yml
@@ -69,6 +69,8 @@ production:
 
 # Configuration of tests
 test:
+  taskcluster:
+    rootUrl: "https://tc.example.com"
   aws:
     region:           us-east-1
   app:

--- a/services/notify/test/api_test.js
+++ b/services/notify/test/api_test.js
@@ -3,7 +3,7 @@ const assert = require('assert');
 const helper = require('./helper');
 const testing = require('taskcluster-lib-testing');
 
-helper.secrets.mockSuite(testing.suiteName(), ['taskcluster', 'aws'], function(mock, skipping) {
+helper.secrets.mockSuite(testing.suiteName(), ['azure', 'aws'], function(mock, skipping) {
   helper.withEntities(mock, skipping);
   helper.withPulse(mock, skipping);
   helper.withSES(mock, skipping);

--- a/services/notify/test/handler_test.js
+++ b/services/notify/test/handler_test.js
@@ -3,7 +3,7 @@ const assert = require('assert');
 const helper = require('./helper');
 const testing = require('taskcluster-lib-testing');
 
-helper.secrets.mockSuite(testing.suiteName(), ['taskcluster', 'aws'], function(mock, skipping) {
+helper.secrets.mockSuite(testing.suiteName(), ['azure', 'aws'], function(mock, skipping) {
   helper.withDenier(mock, skipping);
   helper.withFakeQueue(mock, skipping);
   helper.withSES(mock, skipping);

--- a/services/notify/test/helper.js
+++ b/services/notify/test/helper.js
@@ -7,7 +7,6 @@ const builder = require('../src/api');
 const load = require('../src/main');
 const RateLimit = require('../src/ratelimit');
 const data = require('../src/data');
-const libUrls = require('taskcluster-lib-urls');
 
 const testclients = {
   'test-client': ['*'],
@@ -28,13 +27,12 @@ withMonitor(exports);
 
 // set up the testing secrets
 exports.secrets = new Secrets({
-  secretName: 'project/taskcluster/testing/taskcluster-notify',
+  secretName: [
+    'project/taskcluster/testing/azure',
+    'project/taskcluster/testing/taskcluster-notify',
+  ],
   secrets: {
-    taskcluster: [
-      {env: 'TASKCLUSTER_CLIENT_ID', cfg: 'taskcluster.credentials.clientId', name: 'clientId'},
-      {env: 'TASKCLUSTER_ACCESS_TOKEN', cfg: 'taskcluster.credentials.accessToken', name: 'accessToken'},
-      {env: 'TASKCLUSTER_ROOT_URL', cfg: 'taskcluster.rootUrl', name: 'rootUrl', mock: libUrls.testRootUrl()},
-    ],
+    azure: withEntity.secret,
     aws: [
       {env: 'AWS_ACCESS_KEY_ID', cfg: 'aws.accessKeyId'},
       {env: 'AWS_SECRET_ACCESS_KEY', cfg: 'aws.secretAccessKey'},

--- a/services/purge-cache/config.yml
+++ b/services/purge-cache/config.yml
@@ -37,6 +37,9 @@ production:
     env:                          'production'
 
 test:
+  taskcluster:
+    rootUrl: "https://tc.example.com"
+
   app:
     cachePurgeExpirationDelay:   '7 days'
 

--- a/services/purge-cache/test/expire_test.js
+++ b/services/purge-cache/test/expire_test.js
@@ -3,7 +3,7 @@ const taskcluster = require('taskcluster-client');
 const assume = require('assume');
 const testing = require('taskcluster-lib-testing');
 
-helper.secrets.mockSuite(testing.suiteName(), ['taskcluster'], function(mock, skipping) {
+helper.secrets.mockSuite(testing.suiteName(), ['azure'], function(mock, skipping) {
   helper.withEntities(mock, skipping);
 
   test('expire nothing', async function() {

--- a/services/purge-cache/test/helper.js
+++ b/services/purge-cache/test/helper.js
@@ -2,7 +2,6 @@ const path = require('path');
 const builder = require('../src/api');
 const data = require('../src/data');
 const taskcluster = require('taskcluster-client');
-const libUrls = require('taskcluster-lib-urls');
 const load = require('../src/main');
 const {stickyLoader, Secrets, fakeauth, withEntity, withMonitor} = require('taskcluster-lib-testing');
 
@@ -25,13 +24,9 @@ withMonitor(exports);
 
 // set up the testing secrets
 exports.secrets = new Secrets({
-  secretName: 'project/taskcluster/testing/taskcluster-purge-cache',
+  secretName: 'project/taskcluster/testing/azure',
   secrets: {
-    taskcluster: [
-      {env: 'TASKCLUSTER_ROOT_URL', cfg: 'taskcluster.rootUrl', name: 'rootUrl', mock: libUrls.testRootUrl()},
-      {env: 'TASKCLUSTER_CLIENT_ID', cfg: 'taskcluster.credentials.clientId', name: 'clientId'},
-      {env: 'TASKCLUSTER_ACCESS_TOKEN', cfg: 'taskcluster.credentials.accessToken', name: 'accessToken'},
-    ],
+    azure: withEntity.secret,
   },
   load: exports.load,
 });

--- a/services/purge-cache/test/purgecache_test.js
+++ b/services/purge-cache/test/purgecache_test.js
@@ -2,7 +2,7 @@ const helper = require('./helper');
 const assume = require('assume');
 const testing = require('taskcluster-lib-testing');
 
-helper.secrets.mockSuite(testing.suiteName(), ['taskcluster'], function(mock, skipping) {
+helper.secrets.mockSuite(testing.suiteName(), ['azure'], function(mock, skipping) {
   helper.withEntities(mock, skipping);
   helper.withServer(mock, skipping);
 

--- a/services/queue/config.yml
+++ b/services/queue/config.yml
@@ -120,7 +120,7 @@ defaults:
   # Azure credentials (for blob and queue storage)
   azure:
     accountId:                !env AZURE_ACCOUNT_ID
-    accountKey:               !env AZURE_ACCOUNT_KEY
+    accessKey:                !env AZURE_ACCOUNT_KEY
 
   pulse:
     username:                 !env PULSE_USERNAME

--- a/services/queue/config.yml
+++ b/services/queue/config.yml
@@ -161,6 +161,9 @@ production:
 
 # Configuration of tests
 test:
+  taskcluster:
+    rootUrl: "https://tc.example.com"
+
   app:
     # For testing purposes we let claims expire very fast
     claimTimeout:                 1

--- a/services/queue/src/blobstore.js
+++ b/services/queue/src/blobstore.js
@@ -10,7 +10,7 @@ let assert = require('assert');
  *   container:            // Container name to use
  *   credentials: {
  *     accountName:        // Azure storage account name
- *     accountKey:         // Azure storage account key
+ *     accessKey:          // Azure storage account key
  *   }
  * }
  */
@@ -21,7 +21,7 @@ let BlobStore = function(options) {
   // http://dl.windowsazure.com/nodestoragedocs/index.html
   this.service = azure.createBlobService(
     options.credentials.accountId,
-    options.credentials.accountKey,
+    options.credentials.accessKey,
   ).withFilter(new azure.ExponentialRetryPolicyFilter());
 };
 

--- a/services/queue/src/main.js
+++ b/services/queue/src/main.js
@@ -117,8 +117,8 @@ let load = loader({
       's3Controller',
     ],
     setup: async ({cfg, monitor, process, blobStore, publicArtifactBucket,
-      privateArtifactBucket, s3Controller}) => {
-      return data.Artifact.setup({
+      privateArtifactBucket, s3Controller}) =>
+      data.Artifact.setup({
         tableName: cfg.app.artifactTableName,
         operationReportChance: cfg.app.azureReportChance,
         operationReportThreshold: cfg.app.azureReportThreshold,
@@ -136,15 +136,14 @@ let load = loader({
           s3Controller: s3Controller,
         },
         monitor: monitor.childMonitor('table.artifacts'),
-      });
-    },
+      }),
   },
 
   // Create task table
   Task: {
     requires: ['cfg', 'monitor', 'process'],
-    setup: async ({cfg, monitor, process}) => {
-      return data.Task.setup({
+    setup: async ({cfg, monitor, process}) =>
+      data.Task.setup({
         tableName: cfg.app.taskTableName,
         operationReportChance: cfg.app.azureReportChance,
         operationReportThreshold: cfg.app.azureReportThreshold,
@@ -155,15 +154,14 @@ let load = loader({
           credentials: cfg.taskcluster.credentials,
         }),
         monitor: monitor.childMonitor('table.tasks'),
-      });
-    },
+      }),
   },
 
   // Create task-group table
   TaskGroup: {
     requires: ['cfg', 'monitor', 'process'],
-    setup: async ({cfg, monitor, process}) => {
-      return data.TaskGroup.setup({
+    setup: async ({cfg, monitor, process}) =>
+      data.TaskGroup.setup({
         tableName: cfg.app.taskGroupTableName,
         operationReportChance: cfg.app.azureReportChance,
         operationReportThreshold: cfg.app.azureReportThreshold,
@@ -174,15 +172,14 @@ let load = loader({
           credentials: cfg.taskcluster.credentials,
         }),
         monitor: monitor.childMonitor('table.taskgroups'),
-      });
-    },
+      }),
   },
 
   // Create task-group member table
   TaskGroupMember: {
     requires: ['cfg', 'monitor', 'process'],
-    setup: async ({cfg, monitor, process}) => {
-      return data.TaskGroupMember.setup({
+    setup: async ({cfg, monitor, process}) =>
+      data.TaskGroupMember.setup({
         tableName: cfg.app.taskGroupMemberTableName,
         operationReportChance: cfg.app.azureReportChance,
         operationReportThreshold: cfg.app.azureReportThreshold,
@@ -193,17 +190,16 @@ let load = loader({
           credentials: cfg.taskcluster.credentials,
         }),
         monitor: monitor.childMonitor('table.taskgroupmembers'),
-      });
-    },
+      }),
   },
 
   // Create task-group size table (uses TaskGroupMember entity)
   TaskGroupActiveSet: {
     requires: ['cfg', 'monitor', 'process'],
-    setup: async ({cfg, monitor, process}) => {
+    setup: async ({cfg, monitor, process}) =>
       // NOTE: this uses the same entity type definition as TaskGroupMember,
       // but presence in either table indicates different things
-      return data.TaskGroupMember.setup({
+      data.TaskGroupMember.setup({
         tableName: cfg.app.taskGroupActiveSetTableName,
         operationReportChance: cfg.app.azureReportChance,
         operationReportThreshold: cfg.app.azureReportThreshold,
@@ -214,15 +210,14 @@ let load = loader({
           credentials: cfg.taskcluster.credentials,
         }),
         monitor: monitor.childMonitor('table.taskgroupactivesets'),
-      });
-    },
+      }),
   },
 
   // Create TaskRequirement table
   TaskRequirement: {
     requires: ['cfg', 'monitor', 'process'],
-    setup: async ({cfg, monitor, process}) => {
-      return data.TaskRequirement.setup({
+    setup: async ({cfg, monitor, process}) =>
+      data.TaskRequirement.setup({
         tableName: cfg.app.taskRequirementTableName,
         operationReportChance: cfg.app.azureReportChance,
         operationReportThreshold: cfg.app.azureReportThreshold,
@@ -233,8 +228,7 @@ let load = loader({
           credentials: cfg.taskcluster.credentials,
         }),
         monitor: monitor.childMonitor('table.taskrequirements'),
-      });
-    },
+      }),
   },
 
   // Create TaskDependency table
@@ -259,8 +253,8 @@ let load = loader({
   // Create Provisioner table
   Provisioner: {
     requires: ['cfg', 'monitor', 'process'],
-    setup: async ({cfg, monitor, process}) => {
-      let Provisioner = data.Provisioner.setup({
+    setup: async ({cfg, monitor, process}) =>
+      data.Provisioner.setup({
         tableName: cfg.app.provisionerTableName,
         operationReportChance: cfg.app.azureReportChance,
         operationReportThreshold: cfg.app.azureReportThreshold,
@@ -271,17 +265,14 @@ let load = loader({
           credentials: cfg.taskcluster.credentials,
         }),
         monitor: monitor.childMonitor('table.provisioner'),
-      });
-      await Provisioner.ensureTable();
-      return Provisioner;
-    },
+      }),
   },
 
   // Create WorkerType table
   WorkerType: {
     requires: ['cfg', 'monitor', 'process'],
-    setup: async ({cfg, monitor, process}) => {
-      let WorkerType = data.WorkerType.setup({
+    setup: async ({cfg, monitor, process}) =>
+      data.WorkerType.setup({
         tableName: cfg.app.workerTypeTableName,
         operationReportChance: cfg.app.azureReportChance,
         operationReportThreshold: cfg.app.azureReportThreshold,
@@ -292,17 +283,14 @@ let load = loader({
           credentials: cfg.taskcluster.credentials,
         }),
         monitor: monitor.childMonitor('table.workerType'),
-      });
-      await WorkerType.ensureTable();
-      return WorkerType;
-    },
+      }),
   },
 
   // Create Worker table
   Worker: {
     requires: ['cfg', 'monitor', 'process'],
-    setup: async ({cfg, monitor, process}) => {
-      let Worker = data.Worker.setup({
+    setup: async ({cfg, monitor, process}) =>
+      data.Worker.setup({
         tableName: cfg.app.workerTableName,
         operationReportChance: cfg.app.azureReportChance,
         operationReportThreshold: cfg.app.azureReportThreshold,
@@ -313,10 +301,7 @@ let load = loader({
           credentials: cfg.taskcluster.credentials,
         }),
         monitor: monitor.childMonitor('table.worker'),
-      });
-      await Worker.ensureTable();
-      return Worker;
-    },
+      }),
   },
 
   // Create QueueService to manage azure queues

--- a/services/queue/src/queueservice.js
+++ b/services/queue/src/queueservice.js
@@ -69,7 +69,7 @@ class QueueService {
    *   pendingPollTimeout:   // Timeout embedded in signed poll URL (ms)
    *   credentials: {
    *     accountId:          // Azure storage account name
-   *     accountKey:         // Azure storage account key
+   *     accessKey:          // Azure storage account key
    *     fake:               // if true, use in-memory version
    *   },
    *   claimQueue:           // Queue name for the claim expiration queue
@@ -101,7 +101,7 @@ class QueueService {
     } else {
       this.client = new azure.Queue({
         accountId: options.credentials.accountId,
-        accessKey: options.credentials.accountKey,
+        accessKey: options.credentials.accessKey,
         timeout: AZURE_QUEUE_TIMEOUT,
       });
     }

--- a/services/queue/test/artifact_test.js
+++ b/services/queue/test/artifact_test.js
@@ -19,7 +19,7 @@ const http = require('http');
 const https = require('https');
 const testing = require('taskcluster-lib-testing');
 
-helper.secrets.mockSuite(testing.suiteName(), ['taskcluster', 'aws', 'azure'], function(mock, skipping) {
+helper.secrets.mockSuite(testing.suiteName(), ['aws', 'azure'], function(mock, skipping) {
   helper.withAmazonIPRanges(mock, skipping);
   helper.withPulse(mock, skipping);
   helper.withS3(mock, skipping);

--- a/services/queue/test/canceltask_test.js
+++ b/services/queue/test/canceltask_test.js
@@ -6,7 +6,7 @@ const assume = require('assume');
 const helper = require('./helper');
 const testing = require('taskcluster-lib-testing');
 
-helper.secrets.mockSuite(testing.suiteName(), ['taskcluster', 'aws', 'azure'], function(mock, skipping) {
+helper.secrets.mockSuite(testing.suiteName(), ['aws', 'azure'], function(mock, skipping) {
   helper.withAmazonIPRanges(mock, skipping);
   helper.withPulse(mock, skipping);
   helper.withS3(mock, skipping);

--- a/services/queue/test/claimresolver_test.js
+++ b/services/queue/test/claimresolver_test.js
@@ -7,7 +7,7 @@ const testing = require('taskcluster-lib-testing');
 const monitorManager = require('../src/monitor');
 const {LEVELS} = require('taskcluster-lib-monitor');
 
-helper.secrets.mockSuite(testing.suiteName(), ['taskcluster', 'aws', 'azure'], function(mock, skipping) {
+helper.secrets.mockSuite(testing.suiteName(), ['aws', 'azure'], function(mock, skipping) {
   helper.withAmazonIPRanges(mock, skipping);
   helper.withPollingServices(mock, skipping);
   helper.withPulse(mock, skipping);

--- a/services/queue/test/claimtask_test.js
+++ b/services/queue/test/claimtask_test.js
@@ -5,7 +5,7 @@ const assume = require('assume');
 const helper = require('./helper');
 const testing = require('taskcluster-lib-testing');
 
-helper.secrets.mockSuite(testing.suiteName(), ['taskcluster', 'aws', 'azure'], function(mock, skipping) {
+helper.secrets.mockSuite(testing.suiteName(), ['aws', 'azure'], function(mock, skipping) {
   helper.withAmazonIPRanges(mock, skipping);
   helper.withPulse(mock, skipping);
   helper.withS3(mock, skipping);

--- a/services/queue/test/claimwork_test.js
+++ b/services/queue/test/claimwork_test.js
@@ -8,7 +8,7 @@ const testing = require('taskcluster-lib-testing');
 const monitorManager = require('../src/monitor');
 const {LEVELS} = require('taskcluster-lib-monitor');
 
-helper.secrets.mockSuite(testing.suiteName(), ['taskcluster', 'aws', 'azure'], function(mock, skipping) {
+helper.secrets.mockSuite(testing.suiteName(), ['aws', 'azure'], function(mock, skipping) {
   helper.withAmazonIPRanges(mock, skipping);
   helper.withPulse(mock, skipping);
   helper.withS3(mock, skipping);

--- a/services/queue/test/createtask_test.js
+++ b/services/queue/test/createtask_test.js
@@ -9,7 +9,7 @@ const testing = require('taskcluster-lib-testing');
 const monitorManager = require('../src/monitor');
 const {LEVELS} = require('taskcluster-lib-monitor');
 
-helper.secrets.mockSuite(testing.suiteName(), ['taskcluster', 'aws', 'azure'], function(mock, skipping) {
+helper.secrets.mockSuite(testing.suiteName(), ['aws', 'azure'], function(mock, skipping) {
   helper.withAmazonIPRanges(mock, skipping);
   helper.withS3(mock, skipping);
   helper.withQueueService(mock, skipping);

--- a/services/queue/test/deadline_test.js
+++ b/services/queue/test/deadline_test.js
@@ -8,7 +8,7 @@ const testing = require('taskcluster-lib-testing');
 const monitorManager = require('../src/monitor');
 const {LEVELS} = require('taskcluster-lib-monitor');
 
-helper.secrets.mockSuite(testing.suiteName(), ['taskcluster', 'aws', 'azure'], function(mock, skipping) {
+helper.secrets.mockSuite(testing.suiteName(), ['aws', 'azure'], function(mock, skipping) {
   helper.withPollingServices(mock, skipping);
   helper.withAmazonIPRanges(mock, skipping);
   helper.withS3(mock, skipping);

--- a/services/queue/test/dependency_test.js
+++ b/services/queue/test/dependency_test.js
@@ -9,7 +9,7 @@ const helper = require('./helper');
 const monitorManager = require('../src/monitor');
 const {LEVELS} = require('taskcluster-lib-monitor');
 
-helper.secrets.mockSuite(testing.suiteName(), ['taskcluster', 'aws', 'azure'], function(mock, skipping) {
+helper.secrets.mockSuite(testing.suiteName(), ['aws', 'azure'], function(mock, skipping) {
   helper.withAmazonIPRanges(mock, skipping);
   helper.withPollingServices(mock, skipping);
   helper.withPulse(mock, skipping);

--- a/services/queue/test/expiretask_test.js
+++ b/services/queue/test/expiretask_test.js
@@ -5,7 +5,7 @@ const assume = require('assume');
 const helper = require('./helper');
 const testing = require('taskcluster-lib-testing');
 
-helper.secrets.mockSuite(testing.suiteName(), ['taskcluster', 'aws', 'azure'], function(mock, skipping) {
+helper.secrets.mockSuite(testing.suiteName(), ['aws', 'azure'], function(mock, skipping) {
   helper.withAmazonIPRanges(mock, skipping);
   helper.withPulse(mock, skipping);
   helper.withS3(mock, skipping);

--- a/services/queue/test/gettask_test.js
+++ b/services/queue/test/gettask_test.js
@@ -4,7 +4,7 @@ const assume = require('assume');
 const helper = require('./helper');
 const testing = require('taskcluster-lib-testing');
 
-helper.secrets.mockSuite(testing.suiteName(), ['taskcluster', 'aws', 'azure'], function(mock, skipping) {
+helper.secrets.mockSuite(testing.suiteName(), ['aws', 'azure'], function(mock, skipping) {
   helper.withAmazonIPRanges(mock, skipping);
   helper.withPulse(mock, skipping);
   helper.withS3(mock, skipping);

--- a/services/queue/test/helper.js
+++ b/services/queue/test/helper.js
@@ -1,7 +1,6 @@
 const _ = require('lodash');
 const slugid = require('slugid');
 const taskcluster = require('taskcluster-client');
-const libUrls = require('taskcluster-lib-urls');
 const builder = require('../src/api');
 const load = require('../src/main');
 const data = require('../src/data');
@@ -24,14 +23,11 @@ withMonitor(exports);
 
 // set up the testing secrets
 exports.secrets = new Secrets({
-  secretName: 'project/taskcluster/testing/taskcluster-queue',
+  secretName: [
+    'project/taskcluster/testing/azure',
+    'project/taskcluster/testing/taskcluster-queue',
+  ],
   secrets: {
-    taskcluster: [
-      {env: 'TASKCLUSTER_ROOT_URL', cfg: 'taskcluster.rootUrl', name: 'rootUrl',
-        mock: libUrls.testRootUrl()},
-      {env: 'TASKCLUSTER_CLIENT_ID', cfg: 'taskcluster.credentials.clientId', name: 'clientId'},
-      {env: 'TASKCLUSTER_ACCESS_TOKEN', cfg: 'taskcluster.credentials.accessToken', name: 'accessToken'},
-    ],
     aws: [
       {env: 'AWS_ACCESS_KEY_ID', cfg: 'aws.accessKeyId', name: 'accessKeyId'},
       {env: 'AWS_SECRET_ACCESS_KEY', cfg: 'aws.secretAccessKey', name: 'secretAccessKey'},
@@ -48,10 +44,7 @@ exports.secrets = new Secrets({
       {env: 'BLOB_ARTIFACT_REGION', cfg: 'app.blobArtifactRegion', name: 'blobArtifactRegion',
         mock: 'us-central-7'},
     ],
-    azure: [
-      {env: 'AZURE_ACCOUNT_ID', cfg: 'azure.accountId', name: 'accountId'},
-      {env: 'AZURE_ACCOUNT_KEY', cfg: 'azure.accountKey', name: 'accountKey'},
-    ],
+    azure: withEntity.secret,
   },
   load: exports.load,
 });

--- a/services/queue/test/querytasks_test.js
+++ b/services/queue/test/querytasks_test.js
@@ -5,7 +5,7 @@ const assume = require('assume');
 const helper = require('./helper');
 const testing = require('taskcluster-lib-testing');
 
-helper.secrets.mockSuite(testing.suiteName(), ['taskcluster', 'aws', 'azure'], function(mock, skipping) {
+helper.secrets.mockSuite(testing.suiteName(), ['aws', 'azure'], function(mock, skipping) {
   helper.withAmazonIPRanges(mock, skipping);
   helper.withPulse(mock, skipping);
   helper.withS3(mock, skipping);

--- a/services/queue/test/reruntask_test.js
+++ b/services/queue/test/reruntask_test.js
@@ -5,7 +5,7 @@ const taskcluster = require('taskcluster-client');
 const helper = require('./helper');
 const testing = require('taskcluster-lib-testing');
 
-helper.secrets.mockSuite(testing.suiteName(), ['taskcluster', 'aws', 'azure'], function(mock, skipping) {
+helper.secrets.mockSuite(testing.suiteName(), ['aws', 'azure'], function(mock, skipping) {
   helper.withAmazonIPRanges(mock, skipping);
   helper.withPulse(mock, skipping);
   helper.withS3(mock, skipping);

--- a/services/queue/test/resolvetask_test.js
+++ b/services/queue/test/resolvetask_test.js
@@ -9,7 +9,7 @@ const testing = require('taskcluster-lib-testing');
 const monitorManager = require('../src/monitor');
 const {LEVELS} = require('taskcluster-lib-monitor');
 
-helper.secrets.mockSuite(testing.suiteName(), ['taskcluster', 'aws', 'azure'], function(mock, skipping) {
+helper.secrets.mockSuite(testing.suiteName(), ['aws', 'azure'], function(mock, skipping) {
   helper.withAmazonIPRanges(mock, skipping);
   helper.withPulse(mock, skipping);
   helper.withS3(mock, skipping);

--- a/services/queue/test/retry_test.js
+++ b/services/queue/test/retry_test.js
@@ -5,7 +5,7 @@ const assume = require('assume');
 const helper = require('./helper');
 const testing = require('taskcluster-lib-testing');
 
-helper.secrets.mockSuite(testing.suiteName(), ['taskcluster', 'aws', 'azure'], function(mock, skipping) {
+helper.secrets.mockSuite(testing.suiteName(), ['aws', 'azure'], function(mock, skipping) {
   helper.withAmazonIPRanges(mock, skipping);
   helper.withPulse(mock, skipping);
   helper.withS3(mock, skipping);

--- a/services/queue/test/taskgroup_test.js
+++ b/services/queue/test/taskgroup_test.js
@@ -7,7 +7,7 @@ const assume = require('assume');
 const helper = require('./helper');
 const testing = require('taskcluster-lib-testing');
 
-helper.secrets.mockSuite(testing.suiteName(), ['taskcluster', 'aws', 'azure'], function(mock, skipping) {
+helper.secrets.mockSuite(testing.suiteName(), ['aws', 'azure'], function(mock, skipping) {
   helper.withAmazonIPRanges(mock, skipping);
   helper.withPollingServices(mock, skipping);
   helper.withPulse(mock, skipping);

--- a/services/queue/test/workerinfo_test.js
+++ b/services/queue/test/workerinfo_test.js
@@ -4,7 +4,7 @@ const taskcluster = require('taskcluster-client');
 const helper = require('./helper');
 const testing = require('taskcluster-lib-testing');
 
-helper.secrets.mockSuite(testing.suiteName(), ['taskcluster', 'aws', 'azure'], function(mock, skipping) {
+helper.secrets.mockSuite(testing.suiteName(), ['aws', 'azure'], function(mock, skipping) {
   helper.withAmazonIPRanges(mock, skipping);
   helper.withPulse(mock, skipping);
   helper.withS3(mock, skipping);

--- a/services/queue/user-config-example.yml
+++ b/services/queue/user-config-example.yml
@@ -12,8 +12,8 @@ defaults:
     privateBlobArtifactBucket: ...
     blobArtifactRegion: us-west-2
   azure:
-    accountName:        pamplemousse
-    accountKey:         '...'
+    accountId:        pamplemousse
+    accessKey:         '...'
   pulse:
     username:           '...'
     password:           '...'

--- a/services/secrets/config.yml
+++ b/services/secrets/config.yml
@@ -52,6 +52,9 @@ production:
     trustProxy:                   true
 
 test:
+  taskcluster:
+    rootUrl: "https://tc.example.com"
+
   app:
     statsComponent:               'test-queue'
     # four days in the future, so secrets are always expired

--- a/services/secrets/test/api_test.js
+++ b/services/secrets/test/api_test.js
@@ -4,7 +4,7 @@ const slugid = require('slugid');
 const taskcluster = require('taskcluster-client');
 const testing = require('taskcluster-lib-testing');
 
-helper.secrets.mockSuite(testing.suiteName(), ['taskcluster'], function(mock, skipping) {
+helper.secrets.mockSuite(testing.suiteName(), ['azure'], function(mock, skipping) {
   helper.withEntities(mock, skipping);
   helper.withServer(mock, skipping);
 

--- a/services/secrets/test/helper.js
+++ b/services/secrets/test/helper.js
@@ -3,7 +3,6 @@ const {fakeauth, stickyLoader, Secrets, withMonitor} = require('taskcluster-lib-
 const load = require('../src/main');
 const data = require('../src/data');
 const builder = require('../src/api.js');
-const libUrls = require('taskcluster-lib-urls');
 const {withEntity} = require('taskcluster-lib-testing');
 
 exports.load = stickyLoader(load);
@@ -17,13 +16,9 @@ withMonitor(exports);
 
 // set up the testing secrets
 exports.secrets = new Secrets({
-  secretName: 'project/taskcluster/testing/taskcluster-secrets',
+  secretName: 'project/taskcluster/testing/azure',
   secrets: {
-    taskcluster: [
-      {env: 'TASKCLUSTER_ROOT_URL', cfg: 'taskcluster.rootUrl', name: 'rootUrl', mock: libUrls.testRootUrl()},
-      {env: 'TASKCLUSTER_CLIENT_ID', cfg: 'taskcluster.credentials.clientId', name: 'clientId'},
-      {env: 'TASKCLUSTER_ACCESS_TOKEN', cfg: 'taskcluster.credentials.accessToken', name: 'accessToken'},
-    ],
+    azure: withEntity.secret,
   },
   load: exports.load,
 });

--- a/services/web-server/config.yml
+++ b/services/web-server/config.yml
@@ -84,7 +84,6 @@ development:
     allowedCORSOrigins: [true]
 
   azure:
-    accountId: 'jungle'
     signingKey: 'REALULTIMATEPOWER.NET'
     cryptoKey: 'CNcj2aOozdo7Pn+HEkAIixwninIwKnbYc6JPS9mNxZk='
 
@@ -95,8 +94,10 @@ test:
   app:
     publicUrl: http://localhost:5080
 
+  taskcluster:
+    rootUrl: https://tc.example.com
+
   azure:
-    accountId: 'jungle'
     signingKey: 'REALULTIMATEPOWER.NET'
     cryptoKey: 'CNcj2aOozdo7Pn+HEkAIixwninIwKnbYc6JPS9mNxZk='
 

--- a/services/web-server/test/auth_test.js
+++ b/services/web-server/test/auth_test.js
@@ -4,7 +4,7 @@ const helper = require('./helper');
 const testing = require('taskcluster-lib-testing');
 const credentialsQuery = require('./fixtures/credentials.graphql');
 
-helper.secrets.mockSuite(testing.suiteName(), ['taskcluster'], function(mock, skipping) {
+helper.secrets.mockSuite(testing.suiteName(), ['azure'], function(mock, skipping) {
   helper.withEntities(mock, skipping);
   helper.withServer(mock, skipping);
 

--- a/services/web-server/test/helper.js
+++ b/services/web-server/test/helper.js
@@ -22,14 +22,9 @@ exports.rootUrl = libUrls.testRootUrl();
 
 // set up the testing secrets
 exports.secrets = new Secrets({
-  secretName: 'project/taskcluster/testing/taskcluster-web-server',
+  secretName: 'project/taskcluster/testing/azure',
   secrets: {
-    taskcluster: [
-      {env: 'TASKCLUSTER_ROOT_URL', cfg: 'taskcluster.rootUrl', name: 'rootUrl',
-        mock: exports.rootUrl},
-      {env: 'TASKCLUSTER_CLIENT_ID', cfg: 'taskcluster.credentials.clientId', name: 'clientId'},
-      {env: 'TASKCLUSTER_ACCESS_TOKEN', cfg: 'taskcluster.credentials.accessToken', name: 'accessToken'},
-    ],
+    azure: withEntity.secret,
   },
   load: exports.load,
 });

--- a/services/web-server/test/login_strategies_github_test.js
+++ b/services/web-server/test/login_strategies_github_test.js
@@ -3,7 +3,7 @@ const testing = require('taskcluster-lib-testing');
 const helper = require('./helper');
 const Github = require('../src/login/strategies/github');
 
-helper.secrets.mockSuite(testing.suiteName(), ['taskcluster'], function(mock, skipping) {
+helper.secrets.mockSuite(testing.suiteName(), ['azure'], function(mock, skipping) {
   helper.withEntities(mock, skipping);
   helper.withGithubClient();
 

--- a/services/web-server/test/server_test.js
+++ b/services/web-server/test/server_test.js
@@ -3,7 +3,7 @@ const helper = require('./helper');
 const request = require('superagent');
 const testing = require('taskcluster-lib-testing');
 
-helper.secrets.mockSuite(testing.suiteName(), ['taskcluster'], function(mock, skipping) {
+helper.secrets.mockSuite(testing.suiteName(), ['azure'], function(mock, skipping) {
   helper.withEntities(mock, skipping);
   const makeSuite = (allowedCORSOrigins, requestOrigin, responseOrigin) => {
     suite(`with ${JSON.stringify(allowedCORSOrigins)}, request origin = ${requestOrigin}`, function() {

--- a/services/web-server/test/third_party_test.js
+++ b/services/web-server/test/third_party_test.js
@@ -7,7 +7,7 @@ const moment = require('moment');
 const helper = require('./helper');
 const tryCatch = require('../src/utils/tryCatch');
 
-helper.secrets.mockSuite(testing.suiteName(), ['taskcluster'], function(mock, skipping) {
+helper.secrets.mockSuite(testing.suiteName(), ['azure'], function(mock, skipping) {
   helper.withEntities(mock, skipping);
   helper.withFakeAuth(mock, skipping);
   helper.withServer(mock, skipping);

--- a/services/worker-manager/config.yml
+++ b/services/worker-manager/config.yml
@@ -33,6 +33,8 @@ test:
     env: 'development'
     forceSSL: false
     trustProxy: false
+  taskcluster:
+    rootUrl: "https://tc.example.com"
   azure:
     accountId: "pamplemousse"
   app:

--- a/services/worker-manager/test/api_test.js
+++ b/services/worker-manager/test/api_test.js
@@ -5,7 +5,7 @@ const testing = require('taskcluster-lib-testing');
 const fs = require('fs');
 const path = require('path');
 
-helper.secrets.mockSuite(testing.suiteName(), ['taskcluster'], function(mock, skipping) {
+helper.secrets.mockSuite(testing.suiteName(), ['azure'], function(mock, skipping) {
   helper.withEntities(mock, skipping);
   helper.withPulse(mock, skipping);
   helper.withProviders(mock, skipping);
@@ -829,6 +829,18 @@ helper.secrets.mockSuite(testing.suiteName(), ['taskcluster'], function(mock, sk
     const workerGroup = 'wg';
     const workerId = 'wi';
     const workerIdentityProof = {'token': 'tok'};
+
+    suiteSetup(function() {
+      helper.load.save();
+
+      // create fake clientId / accessToken for temporary creds
+      helper.load.cfg('taskcluster.credentials.clientId', 'fake');
+      helper.load.cfg('taskcluster.credentials.accessToken', 'fake');
+    });
+
+    suiteTeardown(function() {
+      helper.load.restore();
+    });
 
     const defaultRegisterWorker = {
       workerPoolId, providerId, workerGroup, workerId, workerIdentityProof,

--- a/services/worker-manager/test/expiration_test.js
+++ b/services/worker-manager/test/expiration_test.js
@@ -3,7 +3,7 @@ const helper = require('./helper');
 const testing = require('taskcluster-lib-testing');
 const taskcluster = require('taskcluster-client');
 
-helper.secrets.mockSuite(testing.suiteName(), ['taskcluster'], function(mock, skipping) {
+helper.secrets.mockSuite(testing.suiteName(), ['azure'], function(mock, skipping) {
   helper.withEntities(mock, skipping);
 
   suite('expireWorkerPools', function() {

--- a/services/worker-manager/test/helper.js
+++ b/services/worker-manager/test/helper.js
@@ -1,4 +1,3 @@
-const libUrls = require('taskcluster-lib-urls');
 const taskcluster = require('taskcluster-client');
 const {FakeGoogle} = require('./fake-google.js');
 const {stickyLoader, Secrets, withEntity, fakeauth, withMonitor, withPulse} = require('taskcluster-lib-testing');
@@ -16,13 +15,9 @@ withMonitor(exports);
 
 // set up the testing secrets
 exports.secrets = new Secrets({
-  secretName: 'project/taskcluster/testing/taskcluster-worker-manager',
+  secretName: 'project/taskcluster/testing/azure',
   secrets: {
-    taskcluster: [
-      {env: 'TASKCLUSTER_CLIENT_ID', cfg: 'taskcluster.credentials.clientId', name: 'clientId', mock: 'testing'},
-      {env: 'TASKCLUSTER_ACCESS_TOKEN', cfg: 'taskcluster.credentials.accessToken', name: 'accessToken', mock: 'testing'},
-      {env: 'TASKCLUSTER_ROOT_URL', cfg: 'taskcluster.rootUrl', name: 'rootUrl', mock: libUrls.testRootUrl()},
-    ],
+    azure: withEntity.secret,
   },
   load: exports.load,
 });

--- a/services/worker-manager/test/provider_aws_test.js
+++ b/services/worker-manager/test/provider_aws_test.js
@@ -10,7 +10,7 @@ const fs = require('fs');
 const path = require('path');
 const taskcluster = require('taskcluster-client');
 
-helper.secrets.mockSuite(testing.suiteName(), ['taskcluster'], function(mock, skipping) {
+helper.secrets.mockSuite(testing.suiteName(), ['azure'], function(mock, skipping) {
   helper.withEntities(mock, skipping);
   helper.withPulse(mock, skipping);
   helper.withFakeQueue(mock, skipping);

--- a/services/worker-manager/test/provider_google_test.js
+++ b/services/worker-manager/test/provider_google_test.js
@@ -6,7 +6,7 @@ const {FakeGoogle} = require('./fake-google');
 const {GoogleProvider} = require('../src/providers/google');
 const testing = require('taskcluster-lib-testing');
 
-helper.secrets.mockSuite(testing.suiteName(), ['taskcluster'], function(mock, skipping) {
+helper.secrets.mockSuite(testing.suiteName(), ['azure'], function(mock, skipping) {
   helper.withEntities(mock, skipping);
   helper.withPulse(mock, skipping);
   helper.withFakeQueue(mock, skipping);

--- a/services/worker-manager/test/provisioner_test.js
+++ b/services/worker-manager/test/provisioner_test.js
@@ -4,7 +4,7 @@ const testing = require('taskcluster-lib-testing');
 const monitorManager = require('../src/monitor');
 const {LEVELS} = require('taskcluster-lib-monitor');
 
-helper.secrets.mockSuite(testing.suiteName(), ['taskcluster'], function(mock, skipping) {
+helper.secrets.mockSuite(testing.suiteName(), ['azure'], function(mock, skipping) {
   helper.withEntities(mock, skipping);
   helper.withPulse(mock, skipping);
   helper.withFakeNotify(mock, skipping);

--- a/services/worker-manager/test/worker_pool_errors_test.js
+++ b/services/worker-manager/test/worker_pool_errors_test.js
@@ -5,7 +5,7 @@ const testing = require('taskcluster-lib-testing');
 const monitorManager = require('../src/monitor');
 const {LEVELS} = require('taskcluster-lib-monitor');
 
-helper.secrets.mockSuite(testing.suiteName(), ['taskcluster'], function(mock, skipping) {
+helper.secrets.mockSuite(testing.suiteName(), ['azure'], function(mock, skipping) {
   helper.withFakeNotify(mock, skipping);
   helper.withEntities(mock, skipping);
   helper.withPulse(mock, skipping);

--- a/services/worker-manager/test/worker_scanner_test.js
+++ b/services/worker-manager/test/worker_scanner_test.js
@@ -5,7 +5,7 @@ const taskcluster = require('taskcluster-client');
 const monitorManager = require('../src/monitor');
 const {LEVELS} = require('taskcluster-lib-monitor');
 
-helper.secrets.mockSuite(testing.suiteName(), ['taskcluster'], function(mock, skipping) {
+helper.secrets.mockSuite(testing.suiteName(), ['azure'], function(mock, skipping) {
   helper.withEntities(mock, skipping);
   helper.withPulse(mock, skipping);
   helper.withProviders(mock, skipping);

--- a/test/shared-secrets.js
+++ b/test/shared-secrets.js
@@ -20,8 +20,10 @@ const main = async () => {
     };
   }
   const secrets = new taskcluster.Secrets(configs);
-  const {secret: results} = await secrets.get('project/taskcluster/testing/shared');
-  console.log(Object.entries(results).map(([key, val]) => `export ${key}=${val}`).join('\n'));
+  for (let secretName of ['project/taskcluster/testing/codecov']) {
+    const {secret: results} = await secrets.get(secretName);
+    console.log(Object.entries(results).map(([key, val]) => `export ${key}=${val}`).join('\n'));
+  }
 };
 
 main().catch(console.error);


### PR DESCRIPTION
Bugzilla Bug: [1574666](https://bugzilla.mozilla.org/show_bug.cgi?id=1574666)

* Use the proj-taskcluster/ci worker pool
* Use a new set of secrets, including Azure credentials (rather than fetching from Auth)

This will be a breaking change: PRs for branches not rebased onto this one will no longer work, because they'll use the "old" worker types and the wrong secrets.  I don't see a great way around that.  We will just need to do some rebasing.  We only have 37 open PRs ;)

Also, this one will fail on the old deployment so expect some X's below - a [push](https://community-tc.services.mozilla.com/tasks/groups/doiuNx_YT9Ovi-5heI7PYA) was green.  