### PR TITLE
Add purgecache smoketest

### DIFF
--- a/infrastructure/tooling/src/smoketest/checks/purgeCache.js
+++ b/infrastructure/tooling/src/smoketest/checks/purgeCache.js
@@ -10,13 +10,13 @@ exports.tasks.push({
   ],
   run: async () => {
     let purge = new taskcluster.PurgeCache(taskcluster.fromEnvVars());
-    const provisionorId = 'built-in'
-    const workerType = 'succeed'
+    const provisionorId = 'built-in';
+    const workerType = 'succeed';
     const payload = {
-        cacheName:'smoketest-cache'
+      cacheName: 'smoketest-cache',
     };
-    await purge.purgeCache(provisionorId,workerType,payload)
-    const pretendWorker = await purge.purgeRequests(provisionorId,workerType)
-    assert.equal(pretendWorker.requests[0].cacheName,payload.cacheName,"Error")
- }
+    await purge.purgeCache(provisionorId, workerType, payload);
+    const pretendWorker = await purge.purgeRequests(provisionorId, workerType);
+    assert.equal(pretendWorker.requests[0].cacheName, payload.cacheName, "Error");
+  },
 });

--- a/infrastructure/tooling/src/smoketest/checks/purgeCache.js
+++ b/infrastructure/tooling/src/smoketest/checks/purgeCache.js
@@ -10,13 +10,13 @@ exports.tasks.push({
   ],
   run: async () => {
     let purge = new taskcluster.PurgeCache(taskcluster.fromEnvVars());
-    const provisionorId = 'built-in';
+    const provisionerId = 'built-in';
     const workerType = 'succeed';
     const payload = {
       cacheName: 'smoketest-cache',
     };
-    await purge.purgeCache(provisionorId, workerType, payload);
-    const pretendWorker = await purge.purgeRequests(provisionorId, workerType);
+    await purge.purgeCache(provisionerId, workerType, payload);
+    const pretendWorker = await purge.purgeRequests(provisionerId, workerType);
     assert.equal(pretendWorker.requests[0].cacheName, payload.cacheName, "Error");
   },
 });

--- a/infrastructure/tooling/src/smoketest/checks/purgeCache.js
+++ b/infrastructure/tooling/src/smoketest/checks/purgeCache.js
@@ -1,0 +1,22 @@
+const taskcluster = require('taskcluster-client');
+const assert = require('assert');
+
+exports.tasks = [];
+exports.tasks.push({
+  title: 'Create purge cache smoke test',
+  requires: [],
+  provides: [
+    'purge-cache',
+  ],
+  run: async () => {
+    let purge = new taskcluster.PurgeCache(taskcluster.fromEnvVars());
+    const provisionorId = 'built-in'
+    const workerType = 'succeed'
+    const payload = {
+        cacheName:'smoketest-cache'
+    };
+    await purge.purgeCache(provisionorId,workerType,payload)
+    const pretendWorker = await purge.purgeRequests(provisionorId,workerType)
+    assert.equal(pretendWorker.requests[0].cacheName,payload.cacheName,"Error")
+ }
+});


### PR DESCRIPTION
This PR which addresses the issue #1248  adds a new test to the yarn smoketest by adding a module to `infrastructure/tooling/src/smoketest/checks/`. It calls the purge-cache service to create a purge, then pretend to be a worker and see that the purge was properly recorded.