### PR TITLE
visually divide API references into categories

### DIFF
--- a/ui/src/views/Documentation/Reference/ApiReference.jsx
+++ b/ui/src/views/Documentation/Reference/ApiReference.jsx
@@ -10,22 +10,10 @@ import Anchor from '../components/Anchor';
 import findRefDoc from '../../../utils/findRefDoc';
 
 class GroupEntry extends Component {
-
   render() {
     const { group, serviceName } = this.props;
     const [groupName, listOfEntries] = group;
-    const isGroupHeaderNeeded = (listOfEntries.length > 1) ? true : false;
 
-    if (!isGroupHeaderNeeded) {
-      const singleEntry = listOfEntries[0];
-      return (
-        <Entry
-          type="function"
-          entry={singleEntry}
-          serviceName={serviceName}
-        />
-      )
-    }
     return (
       <div>
         <br />
@@ -55,15 +43,18 @@ export default class ApiReference extends Component {
 
   groupBy = (list, keyGetter) => {
     const map = new Map();
+
     list.forEach(item => {
       const key = keyGetter(item);
       const collection = map.get(key);
+
       if (!collection) {
         map.set(key, [item]);
       } else {
         collection.push(item);
       }
     });
+
     return map;
   };
 
@@ -81,9 +72,9 @@ export default class ApiReference extends Component {
 
     const functionEntries =
       ref.entries && ref.entries.filter(({ type }) => type === 'function');
-
-    const groupedEntries = 
-      Array.from(this.groupBy(functionEntries, entry => entry.category));
+    const groupedEntries = Array.from(
+      this.groupBy(functionEntries, entry => entry.category)
+    );
 
     return (
       <div>
@@ -102,10 +93,10 @@ export default class ApiReference extends Component {
             </Typography>
             <br />
             {groupedEntries.map(group => (
-              <GroupEntry 
+              <GroupEntry
                 key={group[0]}
-                group={group} 
-                serviceName={ref.serviceName} 
+                group={group}
+                serviceName={ref.serviceName}
               />
             ))}
           </Fragment>

--- a/ui/src/views/Documentation/Reference/ApiReference.jsx
+++ b/ui/src/views/Documentation/Reference/ApiReference.jsx
@@ -9,29 +9,6 @@ import HeaderWithAnchor from '../components/HeaderWithAnchor';
 import Anchor from '../components/Anchor';
 import findRefDoc from '../../../utils/findRefDoc';
 
-class GroupEntry extends Component {
-  render() {
-    const { group, serviceName } = this.props;
-    const [groupName, listOfEntries] = group;
-
-    return (
-      <div>
-        <br />
-        <HeaderWithAnchor type="h4">{groupName}</HeaderWithAnchor>
-        <br />
-        {listOfEntries.map(entry => (
-          <Entry
-            key={`${entry.name}-${entry.query}`}
-            type="function"
-            entry={entry}
-            serviceName={serviceName}
-          />
-        ))}
-      </div>
-    );
-  }
-}
-
 @withRouter
 export default class ApiReference extends Component {
   static propTypes = {
@@ -93,11 +70,19 @@ export default class ApiReference extends Component {
             </Typography>
             <br />
             {groupedEntries.map(group => (
-              <GroupEntry
-                key={group[0]}
-                group={group}
-                serviceName={ref.serviceName}
-              />
+              <div key={group[0]}>
+                <HeaderWithAnchor type="h4">{group[0]}</HeaderWithAnchor>
+                <br />
+                {group[1].map(entry => (
+                  <Entry
+                    key={`${entry.name}-${entry.query}`}
+                    type="function"
+                    entry={entry}
+                    serviceName={ref.serviceName}
+                  />
+                ))}
+                <br />
+              </div>
             ))}
           </Fragment>
         )}

--- a/ui/src/views/Documentation/Reference/ApiReference.jsx
+++ b/ui/src/views/Documentation/Reference/ApiReference.jsx
@@ -9,6 +9,41 @@ import HeaderWithAnchor from '../components/HeaderWithAnchor';
 import Anchor from '../components/Anchor';
 import findRefDoc from '../../../utils/findRefDoc';
 
+class GroupEntry extends Component {
+
+  render() {
+    const { group, serviceName } = this.props;
+    const [groupName, listOfEntries] = group;
+    const isGroupHeaderNeeded = (listOfEntries.length > 1) ? true : false;
+
+    if (!isGroupHeaderNeeded) {
+      const singleEntry = listOfEntries[0];
+      return (
+        <Entry
+          type="function"
+          entry={singleEntry}
+          serviceName={serviceName}
+        />
+      )
+    }
+    return (
+      <div>
+        <br />
+        <Typography> {groupName} </Typography>
+        <br />
+        {listOfEntries.map(entry => (
+          <Entry
+            key={`${entry.name}-${entry.query}`}
+            type="function"
+            entry={entry}
+            serviceName={serviceName}
+          />
+        ))}
+      </div>
+    );
+  }
+}
+
 @withRouter
 export default class ApiReference extends Component {
   static propTypes = {
@@ -20,7 +55,7 @@ export default class ApiReference extends Component {
 
   groupBy = (list, keyGetter) => {
     const map = new Map();
-    list.forEach((item) => {
+    list.forEach(item => {
       const key = keyGetter(item);
       const collection = map.get(key);
       if (!collection) {
@@ -30,39 +65,6 @@ export default class ApiReference extends Component {
       }
     });
     return map;
-  };
-
-  renderSingleEntry = (entry, serviceName) => (
-      <Entry
-        key={`${entry.name}-${entry.query}`}
-        type="function"
-        entry={entry}
-        serviceName={serviceName}
-      />
-  );
-
-  renderGroupEntry = (groupName, entries, serviceName) => (
-    <div>
-      <Typography>{groupName}</Typography>
-      {entries.map(entry => (
-        <Entry
-          key={`${entry.name}-${entry.query}`}
-          type="function"
-          entry={entry}
-          serviceName={serviceName}
-        />
-      ))}
-    </div>
-  );
-
-  renderEntries = (groupedEntries, serviceName) => {
-    for (let entry of groupedEntries.entries()) {
-      const [ groupName, listOfEntries] = entry;
-      if (listOfEntries.length === 1) {
-        return this.renderSingleEntry(listOfEntries[0], serviceName);
-      }
-      return this.renderGroupEntry(groupName, listOfEntries, serviceName);
-    }
   };
 
   render() {
@@ -80,7 +82,8 @@ export default class ApiReference extends Component {
     const functionEntries =
       ref.entries && ref.entries.filter(({ type }) => type === 'function');
 
-    const groupedEntries = this.groupBy(functionEntries, entry=>entry.category);
+    const groupedEntries = 
+      Array.from(this.groupBy(functionEntries, entry => entry.category));
 
     return (
       <div>
@@ -98,7 +101,13 @@ export default class ApiReference extends Component {
               the manual.
             </Typography>
             <br />
-            {this.renderEntries(groupedEntries, ref.serviceName)}
+            {groupedEntries.map(group => (
+              <GroupEntry 
+                key={group[0]}
+                group={group} 
+                serviceName={ref.serviceName} 
+              />
+            ))}
           </Fragment>
         )}
       </div>

--- a/ui/src/views/Documentation/Reference/ApiReference.jsx
+++ b/ui/src/views/Documentation/Reference/ApiReference.jsx
@@ -17,7 +17,7 @@ class GroupEntry extends Component {
     return (
       <div>
         <br />
-        <Typography> {groupName} </Typography>
+        <HeaderWithAnchor type="h4">{groupName}</HeaderWithAnchor>
         <br />
         {listOfEntries.map(entry => (
           <Entry

--- a/ui/src/views/Documentation/Reference/ApiReference.jsx
+++ b/ui/src/views/Documentation/Reference/ApiReference.jsx
@@ -68,11 +68,9 @@ export default class ApiReference extends Component {
               <Anchor href="/docs/manual/design/apis">Using the APIs</Anchor> in
               the manual.
             </Typography>
-            <br />
             {groupedEntries.map(group => (
-              <div key={group[0]}>
+              <Fragment key={group[0]}>
                 <HeaderWithAnchor type="h4">{group[0]}</HeaderWithAnchor>
-                <br />
                 {group[1].map(entry => (
                   <Entry
                     key={`${entry.name}-${entry.query}`}
@@ -81,8 +79,7 @@ export default class ApiReference extends Component {
                     serviceName={ref.serviceName}
                   />
                 ))}
-                <br />
-              </div>
+              </Fragment>
             ))}
           </Fragment>
         )}


### PR DESCRIPTION
**Closes Issue #1577**
visually divide API references into categories
- use categories as small "headings" in the list of API methods for cases where there is more than one category (such as the Auth service). 
- In cases where there is only one category, there should be no change.

**Changes Applied**
1. Added `groupBy()` function which creates an array of API methods grouped by categories
2. Added `GroupEntry` component which uses conditional rendering to add headings and display lists of API methods
   - if category has only one method, displays single entry usng `entry` component
   - if category has more than one methods, displays heading and list of API methods using `entry` component

**Result**
- before
<img width="550" alt="before" src="https://user-images.githubusercontent.com/29671309/66702775-4a352000-ed46-11e9-815e-b0704a533ce7.PNG">

- after
<img width="550" alt="after" src="https://user-images.githubusercontent.com/29671309/66702778-5325f180-ed46-11e9-81cf-6764e31c95cb.PNG">


