### PR TITLE
[UI] Make workers view mobile friendly

### DIFF
--- a/ui/src/views/Documentation/Reference/ApiReference.jsx
+++ b/ui/src/views/Documentation/Reference/ApiReference.jsx
@@ -10,22 +10,10 @@ import Anchor from '../components/Anchor';
 import findRefDoc from '../../../utils/findRefDoc';
 
 class GroupEntry extends Component {
-
   render() {
     const { group, serviceName } = this.props;
     const [groupName, listOfEntries] = group;
-    const isGroupHeaderNeeded = (listOfEntries.length > 1) ? true : false;
 
-    if (!isGroupHeaderNeeded) {
-      const singleEntry = listOfEntries[0];
-      return (
-        <Entry
-          type="function"
-          entry={singleEntry}
-          serviceName={serviceName}
-        />
-      )
-    }
     return (
       <div>
         <br />
@@ -55,15 +43,18 @@ export default class ApiReference extends Component {
 
   groupBy = (list, keyGetter) => {
     const map = new Map();
+
     list.forEach(item => {
       const key = keyGetter(item);
       const collection = map.get(key);
+
       if (!collection) {
         map.set(key, [item]);
       } else {
         collection.push(item);
       }
     });
+
     return map;
   };
 
@@ -81,9 +72,9 @@ export default class ApiReference extends Component {
 
     const functionEntries =
       ref.entries && ref.entries.filter(({ type }) => type === 'function');
-
-    const groupedEntries = 
-      Array.from(this.groupBy(functionEntries, entry => entry.category));
+    const groupedEntries = Array.from(
+      this.groupBy(functionEntries, entry => entry.category)
+    );
 
     return (
       <div>
@@ -102,10 +93,10 @@ export default class ApiReference extends Component {
             </Typography>
             <br />
             {groupedEntries.map(group => (
-              <GroupEntry 
+              <GroupEntry
                 key={group[0]}
-                group={group} 
-                serviceName={ref.serviceName} 
+                group={group}
+                serviceName={ref.serviceName}
               />
             ))}
           </Fragment>

--- a/ui/src/views/Documentation/Reference/ApiReference.jsx
+++ b/ui/src/views/Documentation/Reference/ApiReference.jsx
@@ -9,6 +9,41 @@ import HeaderWithAnchor from '../components/HeaderWithAnchor';
 import Anchor from '../components/Anchor';
 import findRefDoc from '../../../utils/findRefDoc';
 
+class GroupEntry extends Component {
+
+  render() {
+    const { group, serviceName } = this.props;
+    const [groupName, listOfEntries] = group;
+    const isGroupHeaderNeeded = (listOfEntries.length > 1) ? true : false;
+
+    if (!isGroupHeaderNeeded) {
+      const singleEntry = listOfEntries[0];
+      return (
+        <Entry
+          type="function"
+          entry={singleEntry}
+          serviceName={serviceName}
+        />
+      )
+    }
+    return (
+      <div>
+        <br />
+        <Typography> {groupName} </Typography>
+        <br />
+        {listOfEntries.map(entry => (
+          <Entry
+            key={`${entry.name}-${entry.query}`}
+            type="function"
+            entry={entry}
+            serviceName={serviceName}
+          />
+        ))}
+      </div>
+    );
+  }
+}
+
 @withRouter
 export default class ApiReference extends Component {
   static propTypes = {
@@ -20,7 +55,7 @@ export default class ApiReference extends Component {
 
   groupBy = (list, keyGetter) => {
     const map = new Map();
-    list.forEach((item) => {
+    list.forEach(item => {
       const key = keyGetter(item);
       const collection = map.get(key);
       if (!collection) {
@@ -30,39 +65,6 @@ export default class ApiReference extends Component {
       }
     });
     return map;
-  };
-
-  renderSingleEntry = (entry, serviceName) => (
-      <Entry
-        key={`${entry.name}-${entry.query}`}
-        type="function"
-        entry={entry}
-        serviceName={serviceName}
-      />
-  );
-
-  renderGroupEntry = (groupName, entries, serviceName) => (
-    <div>
-      <Typography>{groupName}</Typography>
-      {entries.map(entry => (
-        <Entry
-          key={`${entry.name}-${entry.query}`}
-          type="function"
-          entry={entry}
-          serviceName={serviceName}
-        />
-      ))}
-    </div>
-  );
-
-  renderEntries = (groupedEntries, serviceName) => {
-    for (let entry of groupedEntries.entries()) {
-      const [ groupName, listOfEntries] = entry;
-      if (listOfEntries.length === 1) {
-        return this.renderSingleEntry(listOfEntries[0], serviceName);
-      }
-      return this.renderGroupEntry(groupName, listOfEntries, serviceName);
-    }
   };
 
   render() {
@@ -80,7 +82,8 @@ export default class ApiReference extends Component {
     const functionEntries =
       ref.entries && ref.entries.filter(({ type }) => type === 'function');
 
-    const groupedEntries = this.groupBy(functionEntries, entry=>entry.category);
+    const groupedEntries = 
+      Array.from(this.groupBy(functionEntries, entry => entry.category));
 
     return (
       <div>
@@ -98,7 +101,13 @@ export default class ApiReference extends Component {
               the manual.
             </Typography>
             <br />
-            {this.renderEntries(groupedEntries, ref.serviceName)}
+            {groupedEntries.map(group => (
+              <GroupEntry 
+                key={group[0]}
+                group={group} 
+                serviceName={ref.serviceName} 
+              />
+            ))}
           </Fragment>
         )}
       </div>

--- a/ui/src/views/Provisioners/ViewWorkers/index.jsx
+++ b/ui/src/views/Provisioners/ViewWorkers/index.jsx
@@ -37,6 +37,7 @@ import workersQuery from './workers.graphql';
 @withStyles(theme => ({
   bar: {
     display: 'flex',
+    flexWrap: 'wrap',
     alignItems: 'center',
   },
   breadcrumbsPaper: {


### PR DESCRIPTION
**Closes Issue** #1585 
breadcrumbs and dropdown components should both sit on their own lines 
when the width of the screen is smaller

**Changes Applied**
added `flex-wrap` style to component

**Results**
- when width is smaller
<img width="300" alt="small" src="https://user-images.githubusercontent.com/29671309/66810444-4386f280-ef6a-11e9-99a6-ae5a8fbde6da.PNG">
