### PR TITLE
Include azure.accountId in web-server settings for development

### DIFF
--- a/services/web-server/config.yml
+++ b/services/web-server/config.yml
@@ -87,6 +87,9 @@ development:
     signingKey: 'REALULTIMATEPOWER.NET'
     cryptoKey: 'CNcj2aOozdo7Pn+HEkAIixwninIwKnbYc6JPS9mNxZk='
 
+    # this is required to start the service without Azure credentials
+    accountId: fake
+
   login:
     sessionSecret: 'keyboard cat'
 


### PR DESCRIPTION
This allows the service to start up without azure credentials.  With
just accountId set, it will "mostly" work -- everything except the
sign-in and third-party sign-in support.