### PR TITLE
Bug #1398 "Compare Scopesets" and "Expand Scopesets" should have a linkable URL

### DIFF
--- a/ui/src/views/Scopes/ScopesetComparison/index.jsx
+++ b/ui/src/views/Scopes/ScopesetComparison/index.jsx
@@ -7,6 +7,7 @@ import CodeEditor from '@mozilla-frontend-infra/components/CodeEditor';
 import Grid from '@material-ui/core/Grid';
 import Typography from '@material-ui/core/Typography';
 import ScaleBalanceIcon from 'mdi-react/ScaleBalanceIcon';
+import { URLSearchParams } from 'apollo-server-env';
 import Dashboard from '../../../components/Dashboard/index';
 import Button from '../../../components/Button/index';
 import splitLines from '../../../utils/splitLines';
@@ -49,6 +50,19 @@ export default class ScopesetComparison extends Component {
     this.setState({ scopeTextB });
   };
 
+  componentDidMount() {
+    const searchParams = new URLSearchParams(this.props.location.search);
+    const scopesA = searchParams.get('qA');
+    const scopesB = searchParams.get('qB');
+
+    if (scopesA && scopesB) {
+      this.setState(() => ({
+        scopeTextA: scopesA.replace(/%/g, '\n'),
+        scopeTextB: scopesB.replace(/%/g, '\n'),
+      }));
+    }
+  }
+
   handleCompareScopesClick = async () => {
     const { scopeTextA, scopeTextB } = this.state;
 
@@ -57,6 +71,13 @@ export default class ScopesetComparison extends Component {
       const scopesB = splitLines(scopeTextB);
       const scopesetDiff = this.getScopesetDiff(scopesA, scopesB);
       const cellColors = this.getCellColors(scopesetDiff);
+      const scopeParamA = scopesA.join('%');
+      const scopeParamB = scopesB.join('%');
+
+      this.props.history.push({
+        pathname: '/auth/scopes/compare',
+        search: `?qA=${scopeParamA}&qB=${scopeParamB}`,
+      });
 
       this.setState({ scopesetDiff, cellColors });
     }
@@ -99,7 +120,7 @@ export default class ScopesetComparison extends Component {
     const { scopeTextA, scopeTextB, scopesetDiff, cellColors } = this.state;
 
     return (
-      <Dashboard title="Compare Scopes">
+      <Dashboard title="Compare Scopesets">
         <Fragment>
           <Grid className={classes.editorGrid} container spacing={8}>
             <Grid item xs={12} md={6}>

--- a/ui/src/views/Scopes/ScopesetComparison/index.jsx
+++ b/ui/src/views/Scopes/ScopesetComparison/index.jsx
@@ -7,7 +7,7 @@ import CodeEditor from '@mozilla-frontend-infra/components/CodeEditor';
 import Grid from '@material-ui/core/Grid';
 import Typography from '@material-ui/core/Typography';
 import ScaleBalanceIcon from 'mdi-react/ScaleBalanceIcon';
-import { URLSearchParams } from 'apollo-server-env';
+import { parse, stringify } from 'qs';
 import Dashboard from '../../../components/Dashboard/index';
 import Button from '../../../components/Button/index';
 import splitLines from '../../../utils/splitLines';
@@ -51,14 +51,18 @@ export default class ScopesetComparison extends Component {
   };
 
   componentDidMount() {
-    const searchParams = new URLSearchParams(this.props.location.search);
-    const scopesA = searchParams.get('qA');
-    const scopesB = searchParams.get('qB');
+    const query = parse(this.props.location.search.slice(1));
+    const { scopesA, scopesB } = query;
 
     if (scopesA && scopesB) {
+      const scopesetDiff = this.getScopesetDiff(scopesA, scopesB);
+      const cellColors = this.getCellColors(scopesetDiff);
+
       this.setState(() => ({
-        scopeTextA: scopesA.replace(/%/g, '\n'),
-        scopeTextB: scopesB.replace(/%/g, '\n'),
+        scopeTextA: scopesA.join('\n'),
+        scopeTextB: scopesB.join('\n'),
+        scopesetDiff,
+        cellColors,
       }));
     }
   }
@@ -71,12 +75,12 @@ export default class ScopesetComparison extends Component {
       const scopesB = splitLines(scopeTextB);
       const scopesetDiff = this.getScopesetDiff(scopesA, scopesB);
       const cellColors = this.getCellColors(scopesetDiff);
-      const scopeParamA = scopesA.join('%');
-      const scopeParamB = scopesB.join('%');
+      const queryObj = { scopesA, scopesB };
+      const queryStr = stringify(queryObj);
 
       this.props.history.push({
         pathname: '/auth/scopes/compare',
-        search: `?qA=${scopeParamA}&qB=${scopeParamB}`,
+        search: queryStr,
       });
 
       this.setState({ scopesetDiff, cellColors });

--- a/ui/src/views/Scopes/ScopesetExpander/index.jsx
+++ b/ui/src/views/Scopes/ScopesetExpander/index.jsx
@@ -41,8 +41,25 @@ export default class ScopesetExpander extends Component {
     scopeText: '',
   };
 
+  componentDidMount() {
+    const searchParams = new URLSearchParams(this.props.location.search);
+    const scope = searchParams.get('q');
+
+    if (scope) {
+      this.setState(() => ({
+        scopeText: scope.replace(/%/g, '\n'),
+      }));
+    }
+  }
+
   handleExpandScopesClick = async () => {
     const scopes = splitLines(this.state.scopeText);
+    const scopeParam = scopes.join('%');
+
+    this.props.history.push({
+      pathname: '/auth/scopes/expansions',
+      search: `?q=${scopeParam}`,
+    });
 
     this.setState({ scopes });
   };
@@ -59,7 +76,7 @@ export default class ScopesetExpander extends Component {
 
     return (
       <Dashboard
-        title="Expand Scopes"
+        title="Expand Scopesets"
         helpView={<HelpView description={description} />}>
         <Fragment>
           <CodeEditor

--- a/ui/src/views/Scopes/ScopesetExpander/index.jsx
+++ b/ui/src/views/Scopes/ScopesetExpander/index.jsx
@@ -38,18 +38,20 @@ import { formatScope, scopeLink } from '../../../utils/scopeUtils';
   },
 }))
 export default class ScopesetExpander extends Component {
-  state = {
-    scopeText: '',
-  };
+  constructor(props) {
+    super(props);
 
-  componentDidMount() {
     const query = parse(this.props.location.search.slice(1));
     const { scopes } = query;
 
     if (scopes) {
-      this.setState(() => ({
+      this.state = {
         scopeText: scopes.join('\n'),
-      }));
+      };
+    } else {
+      this.state = {
+        scopeText: '',
+      };
     }
   }
 

--- a/ui/src/views/Scopes/ScopesetExpander/index.jsx
+++ b/ui/src/views/Scopes/ScopesetExpander/index.jsx
@@ -10,6 +10,7 @@ import ListItemText from '@material-ui/core/ListItemText';
 import Typography from '@material-ui/core/Typography';
 import ArrowExpandVerticalIcon from 'mdi-react/ArrowExpandVerticalIcon';
 import LinkIcon from 'mdi-react/LinkIcon';
+import { parse, stringify } from 'qs';
 import HelpView from '../../../components/HelpView';
 import Dashboard from '../../../components/Dashboard/index';
 import Button from '../../../components/Button';
@@ -42,23 +43,24 @@ export default class ScopesetExpander extends Component {
   };
 
   componentDidMount() {
-    const searchParams = new URLSearchParams(this.props.location.search);
-    const scope = searchParams.get('q');
+    const query = parse(this.props.location.search.slice(1));
+    const { scopes } = query;
 
-    if (scope) {
+    if (scopes) {
       this.setState(() => ({
-        scopeText: scope.replace(/%/g, '\n'),
+        scopeText: scopes.join('\n'),
       }));
     }
   }
 
   handleExpandScopesClick = async () => {
     const scopes = splitLines(this.state.scopeText);
-    const scopeParam = scopes.join('%');
+    const queryObj = { scopes };
+    const queryStr = stringify(queryObj);
 
     this.props.history.push({
       pathname: '/auth/scopes/expansions',
-      search: `?q=${scopeParam}`,
+      search: queryStr,
     });
 
     this.setState({ scopes });


### PR DESCRIPTION
I have developed a solution. First I used `history.push() `on the `this.props` object to explicitly return an object with 2 properties within the `if` statement in `handleCompareScopesClick()` method. I also accounted for comma use within scopes as seen in the example:

```
[
  "queue:create-task:aws-provisioner-v1/tutorial",
  "queue:route:index.garbage.*",
]
```

Within the `handleCompareScopesClick()` method:

```
handleCompareScopesClick = async () => {
  ...
  const scopeParamA = scopesA.join('%');
  const scopeParamB = scopesB.join('%');

  this.props.history.push({ 
    pathname: '/auth/scopes/compare',
    search: `?q1=${scopeParamA}&q2=${scopeParamB}`,
  });
...
}
```

This will push a new query string to the Url where each line is delimited by the '%' symbol. Now, in order for a user to share the Url. All the user has to do is share the Url in the address bar. I implemented a lifecycle method of `componentDidMount()` to take the Url parameters and set the state:

The `replace()` method is used to change all occurrences of the '%' within the query string to the newline syntax - '\n' this will place all text in the correct format.

```
componentDidMount() {
  const searchParams = new URLSearchParams(this.props.location.search);
  const scopesA = searchParams.get('qA');
  const scopesB = searchParams.get('qB');

  if (scopesA && scopesB) {
    this.setState(() => ({
      scopeTextA: scopesA.replace(/%/g, '\n'),
      scopeTextA: scopesB.replace(/%/g, '\n'),
    }));
  }
}
```

This will take any query values and pass them into the state properties. All the user has to do at this point is to click the "Compare Scopes" button. *I have also added the same functionality to the Scopeset Expander.*
