### PR TITLE
[UI] Allow task search

### DIFF
--- a/ui/src/components/Search/index.jsx
+++ b/ui/src/components/Search/index.jsx
@@ -65,7 +65,7 @@ export default class Search extends PureComponent {
     spellCheck: false,
     value: undefined,
     onChange: null,
-    defaultValue: null,
+    defaultValue: undefined,
     formProps: {},
   };
 

--- a/ui/src/views/Tasks/TaskIndex/IndexedTask/index.jsx
+++ b/ui/src/views/Tasks/TaskIndex/IndexedTask/index.jsx
@@ -35,7 +35,7 @@ import indexedTaskQuery from './indexedTask.graphql';
 })
 export default class IndexedTask extends Component {
   state = {
-    namespaceInput: `${this.props.match.params.namespace}.${this.props.match.params.namespaceTaskId}`,
+    indexPathInput: `${this.props.match.params.namespace}.${this.props.match.params.namespaceTaskId}`,
   };
 
   componentDidUpdate(prevProps) {
@@ -90,11 +90,11 @@ export default class IndexedTask extends Component {
     });
   };
 
-  handleNamespaceInputChange = e =>
-    this.setState({ namespaceInput: e.target.value });
+  handleIndexPathInputChange = e =>
+    this.setState({ indexPathInput: e.target.value });
 
-  handleTaskNamespaceSearchSubmit = () => {
-    this.props.history.replace(`/tasks/index/${this.state.namespaceInput}`);
+  handleIndexPathSearchSubmit = () => {
+    this.props.history.replace(`/tasks/index/${this.state.indexPathInput}`);
   };
 
   render() {
@@ -121,10 +121,10 @@ export default class IndexedTask extends Component {
         search={
           <Search
             disabled={loading}
-            value={this.state.namespaceInput}
-            onChange={this.handleNamespaceInputChange}
-            onSubmit={this.handleTaskNamespaceSearchSubmit}
-            placeholder="Search"
+            value={this.state.indexPathInput}
+            onChange={this.handleIndexPathInputChange}
+            onSubmit={this.handleIndexPathSearchSubmit}
+            placeholder="Search path.to.index"
           />
         }>
         {loading && <Spinner loading />}

--- a/ui/src/views/Tasks/TaskIndex/IndexedTask/index.jsx
+++ b/ui/src/views/Tasks/TaskIndex/IndexedTask/index.jsx
@@ -5,6 +5,7 @@ import dotProp from 'dot-prop-immutable';
 import Spinner from '@mozilla-frontend-infra/components/Spinner';
 import Dashboard from '../../../../components/Dashboard';
 import HelpView from '../../../../components/HelpView';
+import Search from '../../../../components/Search';
 import IndexedEntry from '../../../../components/IndexedEntry';
 import { ARTIFACTS_PAGE_SIZE } from '../../../../utils/constants';
 import ErrorPanel from '../../../../components/ErrorPanel';
@@ -33,6 +34,10 @@ import indexedTaskQuery from './indexedTask.graphql';
   }),
 })
 export default class IndexedTask extends Component {
+  state = {
+    namespaceInput: this.props.match.params.namespace,
+  };
+
   componentDidUpdate(prevProps) {
     if (
       'indexedTask' in this.props.indexedTaskData &&
@@ -85,6 +90,13 @@ export default class IndexedTask extends Component {
     });
   };
 
+  handleNamespaceInputChange = e =>
+    this.setState({ namespaceInput: e.target.value });
+
+  handleTaskNamespaceSearchSubmit = () => {
+    this.props.history.replace(`/tasks/index/${this.state.namespaceInput}`);
+  };
+
   render() {
     const {
       latestArtifactsData: {
@@ -105,7 +117,16 @@ export default class IndexedTask extends Component {
     return (
       <Dashboard
         title="Index Browser"
-        helpView={<HelpView description={description} />}>
+        helpView={<HelpView description={description} />}
+        search={
+          <Search
+            disabled={loading}
+            value={this.state.namespaceInput}
+            onChange={this.handleNamespaceInputChange}
+            onSubmit={this.handleTaskNamespaceSearchSubmit}
+            placeholder="Search"
+          />
+        }>
         {loading && <Spinner loading />}
         {!loading && (
           <ErrorPanel fixed error={indexedTaskError || latestArtifactsError} />

--- a/ui/src/views/Tasks/TaskIndex/IndexedTask/index.jsx
+++ b/ui/src/views/Tasks/TaskIndex/IndexedTask/index.jsx
@@ -35,7 +35,7 @@ import indexedTaskQuery from './indexedTask.graphql';
 })
 export default class IndexedTask extends Component {
   state = {
-    namespaceInput: this.props.match.params.namespace,
+    namespaceInput: `${this.props.match.params.namespace}.${this.props.match.params.namespaceTaskId}`,
   };
 
   componentDidUpdate(prevProps) {

--- a/ui/src/views/Tasks/TaskIndex/ListNamespaces/index.jsx
+++ b/ui/src/views/Tasks/TaskIndex/ListNamespaces/index.jsx
@@ -68,7 +68,6 @@ export default class ListNamespaces extends Component {
   }
 
   handleNamespacesPageChange = ({ cursor, previousCursor }) => {
-    this.setState({ namespaceInput: this.props.match.params.namespace });
     const {
       match: {
         params: { namespace },

--- a/ui/src/views/Tasks/TaskIndex/ListNamespaces/index.jsx
+++ b/ui/src/views/Tasks/TaskIndex/ListNamespaces/index.jsx
@@ -43,17 +43,9 @@ const defaultEmpty = defaultTo('');
   }),
 })
 export default class ListNamespaces extends Component {
-  state = {
-    namespaceInput: '',
-  };
-
-  componentDidMount() {
-    if (this.props.match.params.namespace) {
-      this.setState({ namespaceInput: this.props.match.params.namespace });
-    } else {
-      this.setState({ namespaceInput: '' });
-    }
-  }
+  state = this.props.match.params.namespace
+    ? { indexPathInput: this.props.match.params.namespace }
+    : { indexPathInput: '' };
 
   componentDidUpdate(prevProps) {
     if (
@@ -64,7 +56,9 @@ export default class ListNamespaces extends Component {
   }
 
   async loadNamespace() {
-    this.setState({ namespaceInput: this.props.match.params.namespace });
+    this.props.match.params.namespace
+      ? this.setState({ indexPathInput: this.props.match.params.namespace })
+      : this.setState({ indexPathInput: '' });
   }
 
   handleNamespacesPageChange = ({ cursor, previousCursor }) => {
@@ -139,12 +133,12 @@ export default class ListNamespaces extends Component {
     });
   };
 
-  handleNamespaceInputChange = e => {
-    this.setState({ namespaceInput: e.target.value });
+  handleIndexPathInputChange = e => {
+    this.setState({ indexPathInput: e.target.value });
   };
 
-  handleTaskNamespaceSearchSubmit = () => {
-    this.props.history.replace(`/tasks/index/${this.state.namespaceInput}`);
+  handleIndexPathSearchSubmit = () => {
+    this.props.history.replace(`/tasks/index/${this.state.indexPathInput}`);
   };
 
   render() {
@@ -160,13 +154,14 @@ export default class ListNamespaces extends Component {
         error: taskNamespaceError,
       },
       description,
-      match,
     } = this.props;
+    const { indexPathInput } = this.state;
     const hasIndexedTasks =
       taskNamespace && taskNamespace.edges && taskNamespace.edges.length > 0;
     const hasNamespaces =
       namespaces && namespaces.edges && namespaces.edges.length > 0;
     const loading = namespacesLoading || taskNamespaceLoading;
+    const isSinglePath = indexPathInput.split('.').length === 1;
 
     return (
       <Dashboard
@@ -175,22 +170,25 @@ export default class ListNamespaces extends Component {
         search={
           <Search
             disabled={loading}
-            value={this.state.namespaceInput}
-            onChange={this.handleNamespaceInputChange}
-            onSubmit={this.handleTaskNamespaceSearchSubmit}
-            placeholder="Search"
+            value={indexPathInput}
+            onChange={this.handleIndexPathInputChange}
+            onSubmit={this.handleIndexPathSearchSubmit}
+            placeholder="Search path.to.index"
           />
         }>
         <Fragment>
           {loading && <Spinner loading />}
           <ErrorPanel fixed error={namespacesError || taskNamespaceError} />
-          {!loading && !hasNamespaces && !hasIndexedTasks && (
+          {!loading && !hasNamespaces && !hasIndexedTasks && !isSinglePath && (
             <Redirect
-              to={`/tasks/index/${match.params.namespace
+              to={`/tasks/index/${indexPathInput
                 .split('.')
                 .slice(0, -1)
-                .join('.')}/${match.params.namespace.split('.').slice(-1)[0]}`}
+                .join('.')}/${indexPathInput.split('.').slice(-1)[0]}`}
             />
+          )}
+          {!loading && !hasNamespaces && !hasIndexedTasks && isSinglePath && (
+            <Typography>No items for this page.</Typography>
           )}
           {!loading && hasNamespaces && (
             <Fragment>

--- a/ui/src/views/Tasks/TaskIndex/ListNamespaces/index.jsx
+++ b/ui/src/views/Tasks/TaskIndex/ListNamespaces/index.jsx
@@ -44,8 +44,16 @@ const defaultEmpty = defaultTo('');
 })
 export default class ListNamespaces extends Component {
   state = {
-    namespaceInput: this.props.match.params.namespace,
+    namespaceInput: '',
   };
+
+  componentDidMount() {
+    if (this.props.match.params.namespace) {
+      this.setState({ namespaceInput: this.props.match.params.namespace });
+    } else {
+      this.setState({ namespaceInput: '' });
+    }
+  }
 
   componentDidUpdate(prevProps) {
     if (

--- a/ui/src/views/Tasks/TaskIndex/ListNamespaces/index.jsx
+++ b/ui/src/views/Tasks/TaskIndex/ListNamespaces/index.jsx
@@ -1,3 +1,4 @@
+import { Redirect } from 'react-router-dom';
 import { hot } from 'react-hot-loader';
 import React, { Component, Fragment } from 'react';
 import { graphql, withApollo } from 'react-apollo';
@@ -7,6 +8,7 @@ import Spinner from '@mozilla-frontend-infra/components/Spinner';
 import Typography from '@material-ui/core/Typography';
 import Dashboard from '../../../../components/Dashboard';
 import HelpView from '../../../../components/HelpView';
+import Search from '../../../../components/Search';
 import IndexNamespacesTable from '../../../../components/IndexNamespacesTable';
 import IndexTaskNamespaceTable from '../../../../components/IndexTaskNamespaceTable';
 import { VIEW_NAMESPACES_PAGE_SIZE } from '../../../../utils/constants';
@@ -41,7 +43,24 @@ const defaultEmpty = defaultTo('');
   }),
 })
 export default class ListNamespaces extends Component {
+  state = {
+    namespaceInput: this.props.match.params.namespace,
+  };
+
+  componentDidUpdate(prevProps) {
+    if (
+      prevProps.match.params.namespace !== this.props.match.params.namespace
+    ) {
+      this.loadNamespace(this.props);
+    }
+  }
+
+  async loadNamespace() {
+    this.setState({ namespaceInput: this.props.match.params.namespace });
+  }
+
   handleNamespacesPageChange = ({ cursor, previousCursor }) => {
+    this.setState({ namespaceInput: this.props.match.params.namespace });
     const {
       match: {
         params: { namespace },
@@ -113,6 +132,14 @@ export default class ListNamespaces extends Component {
     });
   };
 
+  handleNamespaceInputChange = e => {
+    this.setState({ namespaceInput: e.target.value });
+  };
+
+  handleTaskNamespaceSearchSubmit = () => {
+    this.props.history.replace(`/tasks/index/${this.state.namespaceInput}`);
+  };
+
   render() {
     const {
       namespacesData: {
@@ -126,6 +153,7 @@ export default class ListNamespaces extends Component {
         error: taskNamespaceError,
       },
       description,
+      match,
     } = this.props;
     const hasIndexedTasks =
       taskNamespace && taskNamespace.edges && taskNamespace.edges.length > 0;
@@ -136,12 +164,26 @@ export default class ListNamespaces extends Component {
     return (
       <Dashboard
         title="Task Index"
-        helpView={<HelpView description={description} />}>
+        helpView={<HelpView description={description} />}
+        search={
+          <Search
+            disabled={loading}
+            value={this.state.namespaceInput}
+            onChange={this.handleNamespaceInputChange}
+            onSubmit={this.handleTaskNamespaceSearchSubmit}
+            placeholder="Search"
+          />
+        }>
         <Fragment>
           {loading && <Spinner loading />}
           <ErrorPanel fixed error={namespacesError || taskNamespaceError} />
           {!loading && !hasNamespaces && !hasIndexedTasks && (
-            <Typography>No items for this page.</Typography>
+            <Redirect
+              to={`/tasks/index/${match.params.namespace
+                .split('.')
+                .slice(0, -1)
+                .join('.')}/${match.params.namespace.split('.').slice(-1)[0]}`}
+            />
           )}
           {!loading && hasNamespaces && (
             <Fragment>

--- a/ui/src/views/Tasks/TaskIndex/ListNamespaces/index.jsx
+++ b/ui/src/views/Tasks/TaskIndex/ListNamespaces/index.jsx
@@ -43,9 +43,11 @@ const defaultEmpty = defaultTo('');
   }),
 })
 export default class ListNamespaces extends Component {
-  state = this.props.match.params.namespace
-    ? { indexPathInput: this.props.match.params.namespace }
-    : { indexPathInput: '' };
+  state = {
+    indexPathInput: this.props.match.params.namespace
+      ? this.props.match.params.namespace
+      : '',
+  };
 
   componentDidUpdate(prevProps) {
     if (


### PR DESCRIPTION
This PR allows search for indexed tasks like in old site https://tools.taskcluster.net/index/

1) Users can put `buildbot.branches.mozilla-esr52/linux64-asan` or `buildbot.branches.mozilla-esr52.linux64-asan` in searchbox or URL and see the task
2) Users can put `buildbot.branches` in searchbox or URL and see `/tasks/index/buildbot.branches`
3) Searchbox tracks namespace

@helfi92 kindly review this PR. It works but I think it could be done better)

Idea: 
I think we can move the searchbox above Indexed Tasks and Namespaces titles because it's hard to read and write long namespaces in the box 

![bug1](https://user-images.githubusercontent.com/44370635/66946868-aadc9980-f073-11e9-9f27-45a9ecb3cc0b.PNG)
![bug2](https://user-images.githubusercontent.com/44370635/66946872-aca65d00-f073-11e9-8c85-fdbd93047667.PNG)

Closes #1148 