### PR TITLE
[UI] Icon replacement #1657

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1,0 +1,64 @@
+{
+  "name": "taskcluster-ui",
+  "version": "20.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "cross-env": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-6.0.3.tgz",
+      "integrity": "sha512-+KqxF6LCvfhWvADcDPqo64yVIB31gv/jQulX2NGzKS/g3GEVz6/pt4wjHFtFWsHMddebWD/sDthJemzM4MaAag==",
+      "dev": true,
+      "requires": {
+        "cross-spawn": "^7.0.0"
+      }
+    },
+    "cross-spawn": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.1.tgz",
+      "integrity": "sha512-u7v4o84SwFpD32Z8IIcPZ6z1/ie24O6RU3RbtL5Y316l3KuHVPx9ItBgWQ6VlfAFnRnTtMUrsQ9MUUTuEZjogg==",
+      "dev": true,
+      "requires": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      }
+    },
+    "isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+      "dev": true
+    },
+    "path-key": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.0.tgz",
+      "integrity": "sha512-8cChqz0RP6SHJkMt48FW0A7+qUOn+OsnOsVtzI59tZ8m+5bCSk7hzwET0pulwOM2YMn9J1efb07KB9l9f30SGg==",
+      "dev": true
+    },
+    "shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "requires": {
+        "shebang-regex": "^3.0.0"
+      }
+    },
+    "shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true
+    },
+    "which": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.1.tgz",
+      "integrity": "sha512-N7GBZOTswtB9lkQBZA4+zAXrjEIWAUOB93AvzUiudRzRxhUdLURQ7D/gAIMY1gatT/LTbmbcv8SiYazy3eYB7w==",
+      "dev": true,
+      "requires": {
+        "isexe": "^2.0.0"
+      }
+    }
+  }
+}

--- a/ui/package.json
+++ b/ui/package.json
@@ -61,7 +61,7 @@
     "markdown-it-link-attributes": "^3.0.0",
     "material-ui-pickers": "2.2.4",
     "material-ui-treeview": "^3.2.0",
-    "mdi-react": "^5.0.0",
+    "mdi-react": "^6.2.0",
     "mdx-loader": "^3.0.2",
     "mitt": "^1.1.3",
     "prism-themes": "^1.0.1",

--- a/ui/src/utils/constants.js
+++ b/ui/src/utils/constants.js
@@ -10,7 +10,7 @@ import ArchiveIcon from 'mdi-react/ArchiveIcon';
 import FileWordIcon from 'mdi-react/FileWordIcon';
 import FileExcelIcon from 'mdi-react/FileExcelIcon';
 import FilePowerpointIcon from 'mdi-react/FilePowerpointIcon';
-import FileXmlIcon from 'mdi-react/FileXmlIcon';
+import FileCodeIcon from 'mdi-react/FileCodeIcon';
 import FileVideoIcon from 'mdi-react/FileVideoIcon';
 import FileImageIcon from 'mdi-react/FileImageIcon';
 import FileMusicIcon from 'mdi-react/FileMusicIcon';
@@ -109,7 +109,7 @@ export const MIMETYPE_ICONS = [
   [FileExcelIcon, ['text/csv']],
   [FilePowerpointIcon, []],
   [
-    FileXmlIcon,
+    FileCodeIcon,
     [
       'application/javascript',
       'application/json',

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -7735,10 +7735,10 @@ mdi-react@^4.0.0:
   resolved "https://registry.yarnpkg.com/mdi-react/-/mdi-react-4.4.0.tgz#5901a3eda1f0dc5eacec1b13f2e2ee40e883b791"
   integrity sha512-IxWW/10EHSYSDz5Hce1JzgvBiNtUHWERVDRWY6S+Bc07zUjWcRvQFDQND8GIgXG2Mnr/7uQFk25MBtSgLHQ0Gw==
 
-mdi-react@^5.0.0:
-  version "5.6.0"
-  resolved "https://registry.yarnpkg.com/mdi-react/-/mdi-react-5.6.0.tgz#4e7c55db60ed01b71e681b0a784ab88f2fe0e44d"
-  integrity sha512-mes6iLVHCEs0gDg/WNiF/xBZ6ES6EQtd10Aoe186yKU/TeWiYDLgmKaybIyV2UPsplD0bfHpxyhS2B0W9c+pqg==
+mdi-react@^6.2.0:
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/mdi-react/-/mdi-react-6.2.0.tgz#861f2fe6dea0721b416eef776ba839333087ef31"
+  integrity sha512-IM1+/YjJ5DJ4rWKDqphfxra6RM52T6Yiki1pr7dJzoE8B5SoPln0D3wwPMWuwEm9fd8oqsM8eMwAYuim3tgmzg==
 
 mdurl@^1.0.1:
   version "1.0.1"
@@ -11764,7 +11764,8 @@ tar@^4:
     yallist "^3.0.3"
 
 "taskcluster-lib-scopes@link:../libraries/scopes":
-  version "20.0.0"
+  version "0.0.0"
+  uid ""
 
 taskcluster-lib-urls@^12.0.0:
   version "12.0.0"


### PR DESCRIPTION
Fixes #1657 

Replaced the FileXmlIcon to FileCodeIcon.
Also, migrated to mdi-react v6 from mdi-react v5 as FileCodeIcon is not available in v5.


