### PR TITLE
Fix view title for worker pool view error page

### DIFF
--- a/changelog/issue-1682.md
+++ b/changelog/issue-1682.md
@@ -1,0 +1,3 @@
+level: silent
+reference: issue 1682
+---

--- a/ui/src/components/Dashboard/index.jsx
+++ b/ui/src/components/Dashboard/index.jsx
@@ -164,6 +164,7 @@ export default class Dashboard extends Component {
     search: null,
     helpView: null,
     docs: false,
+    disableTitleFormatting: false,
   };
 
   static propTypes = {
@@ -194,6 +195,10 @@ export default class Dashboard extends Component {
      * If true, the documentation table of content will be displayed.
      */
     docs: bool,
+    /**
+     * If true, the title will not be formatted to uppercase.
+     */
+    disableTitleFormatting: bool,
   };
 
   static getDerivedStateFromError(error) {
@@ -243,6 +248,7 @@ export default class Dashboard extends Component {
       history,
       width,
       staticContext: _,
+      disableTitleFormatting,
       ...props
     } = this.props;
     const { error, navOpen, showHelpView, deploymentVersion } = this.state;
@@ -293,7 +299,7 @@ export default class Dashboard extends Component {
     );
     const isDocs = history.location.pathname.startsWith(DOCS_PATH_PREFIX);
     const isMobileView = width === 'sm' || width === 'xs';
-    const pageTitle = makeTitle(title);
+    const pageTitle = disableTitleFormatting ? title : makeTitle(title);
 
     return (
       <div className={classes.root}>

--- a/ui/src/views/WorkerManager/WMViewErrors/index.jsx
+++ b/ui/src/views/WorkerManager/WMViewErrors/index.jsx
@@ -72,9 +72,10 @@ export default class WMViewErrors extends Component {
 
     return (
       <Dashboard
-        title={`Errors for ${decodeURIComponent(
+        title={`Errors For "${decodeURIComponent(
           this.props.match.params.workerPoolId
-        )}`}
+        )}"`}
+        disableTitleFormatting
         search={
           <Search
             disabled={loading}


### PR DESCRIPTION
**Closes Issue** #1682 
view title should preserve the worker pool ID as it is w/o formatting
- ex. Errors For Taskcluster Imaging Taskcluster Imaging Ci
- ->  Errors For "taskcluster-imaging/taskcluster-imaging-ci"

**Changes Applied**
- added `disableTitleFormatting` prop to Dashboard component
- set the `disableTitleFormatting` prop to true for the dashboard in WMViewErrors

