### PR TITLE
[Bug 1407]: [UI] Remove material-ui warning in console

### DIFF
--- a/ui/src/components/SpeedDialAction/index.jsx
+++ b/ui/src/components/SpeedDialAction/index.jsx
@@ -39,6 +39,7 @@ export default class SpeedDialAction extends Component {
       tooltipTitle,
       ...props
     } = this.props;
+    const other = {};
     const lackingAuth = requiresAuth && !user;
     const buttonProps = {
       ...ButtonProps,
@@ -52,12 +53,19 @@ export default class SpeedDialAction extends Component {
         }
       : null;
 
+    if (buttonProps.disabled) {
+      // Remove material-ui disabled prop warning
+      // https://github.com/mui-org/material-ui/issues/15216
+      other.component = 'span';
+    }
+
     return (
       <MuiSpeedDialAction
         className={classNames(classes.secondaryIcon, className)}
         ButtonProps={buttonProps}
         {...title}
         {...props}
+        {...other}
       />
     );
   }


### PR DESCRIPTION
Add 'other' parameter with component 'span' into SpeedDialAction(/ui/src/components/SpeedDialAction/index.jsx) for preventing warning in console

<!-- Did you remember to add a changelog snippet? See
     https://github.com/taskcluster/taskcluster/blob/master/dev-docs/best-practices/changelog.md

     If this is related to a Bugzilla bug, please begin your title with [Bug XXXXX]
     and update this link.  Otherwise, just remove it from your PR comment.  -->

Closes #1407.
