### PR TITLE
Bug 1577839 - fix handling of custom tags in aws provider

### DIFF
--- a/changelog/bug-1577839.md
+++ b/changelog/bug-1577839.md
@@ -1,0 +1,4 @@
+level: patch
+reference: bug 1577839
+---
+Including TagSpecifications in a launchConfig for the AWS provider now applies those tags to the indicated resources.  Before this version, those tags would be ignored.

--- a/services/worker-manager/src/providers/aws.js
+++ b/services/worker-manager/src/providers/aws.js
@@ -82,12 +82,16 @@ class AwsProvider extends Provider {
       if (toSpawnCounter <= 0) break; // eslint-disable-line
       // Make sure we don't get "The same resource type may not be specified
       // more than once in tag specifications" errors
-      const TagSpecifications = config.TagSpecifications ? config.TagSpecifications : [];
+      const TagSpecifications = config.launchConfig.TagSpecifications || [];
       const instanceTags = [];
       const otherTagSpecs = [];
-      TagSpecifications.forEach(ts =>
-        ts.ResourceType === 'instance' ? instanceTags.concat(ts.Tags) : otherTagSpecs.push(ts)
-      );
+      TagSpecifications.forEach(ts => {
+        if (ts.ResourceType === 'instance') {
+          ts.Tags.forEach(tag => instanceTags.push(tag));
+        } else {
+          otherTagSpecs.push(ts);
+        }
+      });
 
       const userData = Buffer.from(JSON.stringify({
         rootUrl: this.rootUrl,

--- a/services/worker-manager/test/fake-aws.js
+++ b/services/worker-manager/test/fake-aws.js
@@ -1,46 +1,42 @@
-const assert = require('assert');
-
 module.exports = {
   EC2: {
-    runInstances: ({defaultLaunchConfig, TagSpecifications, UserData}) => launchConfig => {
-      assert.deepStrictEqual(launchConfig,
-        {
-          ...defaultLaunchConfig.launchConfig,
-          MinCount: launchConfig.MinCount, // this is estimator's functionality, no need to test this here
-          MaxCount: launchConfig.MaxCount,
-          TagSpecifications,
-          UserData: Buffer.from(JSON.stringify(UserData)).toString('base64'),
+    runInstances: ({defaultLaunchConfig, TagSpecifications, UserData}) => {
+      const fake = launchConfig => {
+        // note that asserting in this function will not cause a test failure, as the error is logged
+        // as a worker error and provisioning succeeds.
+        fake.calls.push({launchConfig});
+        let Instances = [];
+        for (let i = 0; i < launchConfig.MinCount; i++) {
+          Instances.push({
+            InstanceId: `i-${i}`,
+            AmiLaunchIndex: '',
+            ImageId: launchConfig.ImageId,
+            InstanceType: launchConfig.InstanceType || 'm2.micro',
+            Architecture: 'x86',
+            Placement: {
+              AvailabilityZone: 'someregion',
+            },
+            PrivateIpAddress: '1.1.1.1',
+            OwnerId: '123123123',
+            State: {
+              Name: 'running',
+            },
+            StateReason: {
+              Message: 'yOu LaunCHed iT!!!1',
+            },
+          });
         }
-      );
-
-      let Instances = [];
-      for (let i = 0; i < launchConfig.MinCount; i++) {
-        Instances.push({
-          InstanceId: `i-${i}`,
-          AmiLaunchIndex: '',
-          ImageId: launchConfig.ImageId,
-          InstanceType: launchConfig.InstanceType || 'm2.micro',
-          Architecture: 'x86',
-          Placement: {
-            AvailabilityZone: 'someregion',
-          },
-          PrivateIpAddress: '1.1.1.1',
-          OwnerId: '123123123',
-          State: {
-            Name: 'running',
-          },
-          StateReason: {
-            Message: 'yOu LaunCHed iT!!!1',
-          },
-        });
-      }
-      return {
-        promise: () => ({
-          Instances,
-          Groups: [],
-          OwnerId: '123123123',
-        }),
+        return {
+          promise: () => ({
+            Instances,
+            Groups: [],
+            OwnerId: '123123123',
+          }),
+        };
       };
+
+      fake.calls = [];
+      return fake;
     },
 
     describeRegions: () => {

--- a/services/worker-manager/test/provider_aws_test.js
+++ b/services/worker-manager/test/provider_aws_test.js
@@ -145,15 +145,75 @@ helper.secrets.mockSuite(testing.suiteName(), ['azure'], function(mock, skipping
     });
 
     test('instance tags in launch spec - should merge them with our instance tags', async function() {
+      await workerPool.modify(wp => {
+        wp.config.launchConfigs[0].launchConfig.TagSpecifications = [{
+          ResourceType: 'instance',
+          Tags: [{Key: 'mytag', Value: 'testy'}],
+        }];
+      });
+      await provider.provision({workerPool});
+
+      assert.deepEqual(
+        aws.EC2().runInstances.calls.map(({launchConfig: {TagSpecifications}}) => TagSpecifications).sort(), [
+          [
+            {
+              ResourceType: 'instance',
+              Tags: [
+                {Key: 'mytag', Value: 'testy'},
+                {Key: 'CreatedBy', Value: 'taskcluster-wm-aws'},
+                {Key: 'Owner', Value: 'whatever@example.com'},
+                {Key: 'ManagedBy', Value: 'taskcluster'},
+                {Key: 'Name', Value: 'foo/bar'},
+              ],
+            },
+          ],
+        ]);
+
       sinon.restore();
     });
 
     test('no instance tags in launch spec, but other tags - should have 1 object per resource type', async function() {
+      await workerPool.modify(wp => {
+        wp.config.launchConfigs[0].launchConfig.TagSpecifications = [
+          {ResourceType: 'something-else', Tags: [{Key: 'mytag', Value: 'testy'}]},
+          {ResourceType: 'another-thing', Tags: [{Key: 'tag2', Value: 'testy'}]},
+        ];
+      });
+      await provider.provision({workerPool});
+
+      assert.deepEqual(
+        aws.EC2().runInstances.calls.map(({launchConfig: {TagSpecifications}}) => TagSpecifications).sort(), [
+          [
+            {
+              ResourceType: 'something-else',
+              Tags: [
+                {Key: 'mytag', Value: 'testy'},
+              ],
+            },
+            {
+              ResourceType: 'another-thing',
+              Tags: [
+                {Key: 'tag2', Value: 'testy'},
+              ],
+            },
+            {
+              ResourceType: 'instance',
+              Tags: [
+                {Key: 'CreatedBy', Value: 'taskcluster-wm-aws'},
+                {Key: 'Owner', Value: 'whatever@example.com'},
+                {Key: 'ManagedBy', Value: 'taskcluster'},
+                {Key: 'Name', Value: 'foo/bar'},
+              ],
+            },
+          ],
+        ]);
+
       sinon.restore();
     });
 
     test('UserData should be base64 encoded', async function() {
       sinon.restore();
+      this.skip();
     });
   });
 
@@ -267,18 +327,22 @@ helper.secrets.mockSuite(testing.suiteName(), ['azure'], function(mock, skipping
 
     test('stopped and terminated instances - should be marked as STOPPED in DB', async function() {
       sinon.restore();
+      this.skip();
     });
 
     test('pending/running,/shutting-down/stopping instances - should not reject', async function() {
       sinon.restore();
+      this.skip();
     });
 
     test('some strange status - should reject', async function() {
       sinon.restore();
+      this.skip();
     });
 
     test('instance terminated by hand - should be marked as STOPPED in DB; should not reject', async function() {
       sinon.restore();
+      this.skip();
     });
   });
 


### PR DESCRIPTION
Bugzilla Bug: [1577839](https://bugzilla.mozilla.org/show_bug.cgi?id=1577839)

This fixes the implementation in two ways:
 * looks for `TagSpecifications` in the launchConfig itself
 * includes the custom instance tags in `instanceTags` (`Array.concat` is a pure function)

It also removes the assertions from the fake `runInstances`.  Because errors from `runInstances` are handled internally, any assertion failures are logged (at the NOTICE level) and do not cause a test failure.