### PR TITLE
Improve error messages for registerWorker with invalid inputs

### DIFF
--- a/changelog/V9gQQys8RWiQUxYiQwsQSg.md
+++ b/changelog/V9gQQys8RWiQUxYiQwsQSg.md
@@ -1,0 +1,2 @@
+level: silent
+---

--- a/services/worker-manager/src/providers/aws.js
+++ b/services/worker-manager/src/providers/aws.js
@@ -196,8 +196,8 @@ class AwsProvider extends Provider {
     }
 
     const {document, signature} = workerIdentityProof;
-    if (!document || !signature) {
-      throw new ApiError('Token validation error');
+    if (!document || !signature || !(typeof document === "string")) {
+      throw new ApiError('Request must include both a document (string) and a signature');
     }
 
     if (!this.verifyInstanceIdentityDocument({document, signature})) {

--- a/services/worker-manager/test/provider_aws_test.js
+++ b/services/worker-manager/test/provider_aws_test.js
@@ -160,6 +160,19 @@ helper.secrets.mockSuite(testing.suiteName(), ['azure'], function(mock, skipping
   suite('[UNIT] AWS provider - registerWorker - negative test cases', function() {
     // For the positive integration test, see api_test.js, registerWorker endpoint
 
+    test('registerWorker - verifyInstanceIdentityDocument - document is not string', async function() {
+      const workerIdentityProof = {
+        "document": {'instanceId': 'abc'},
+        "signature": 'abcd',
+      };
+
+      await assert.rejects(
+        () => provider.registerWorker({worker: workerInDB, workerPool, workerIdentityProof}),
+        new ApiError('Request must include both a document (string) and a signature')
+      );
+      sinon.restore();
+    });
+
     test('registerWorker - verifyInstanceIdentityDocument - bad document', async function() {
       const workerIdentityProof = {
         "document": fs.readFileSync(path.resolve(__dirname, 'fixtures/aws_iid_DOCUMENT_bad')).toString(),
@@ -235,8 +248,7 @@ helper.secrets.mockSuite(testing.suiteName(), ['azure'], function(mock, skipping
       };
 
       await assert.rejects(() => provider.registerWorker({worker: workerInDB, workerPool, workerIdentityProof}),
-        new ApiError('Token validation error'),
-        'Should fail because there is no signature'
+        new ApiError('Request must include both a document (string) and a signature')
       );
       sinon.restore();
     });


### PR DESCRIPTION
This came up in slack today as a 500 and I figured we could do better.

I changed 'Token validation' since there's no token being validated, so it's kind of a misleading error message.