### PR TITLE
Fix yarn changelog --no-bug

### DIFF
--- a/changelog/MoCoX17AQJ2rq32qWOhbTw.md
+++ b/changelog/MoCoX17AQJ2rq32qWOhbTw.md
@@ -1,0 +1,2 @@
+level: silent
+---

--- a/infrastructure/tooling/src/changelog/index.js
+++ b/infrastructure/tooling/src/changelog/index.js
@@ -219,7 +219,7 @@ const add = async (options) => {
   } else if (options.bug) {
     name = `bug-${options.bug}`;
     reference = `reference: bug ${options.bug}\n`;
-  } else if (options.noBug) {
+  } else if (options.bug === false) {
     name = taskcluster.slugid();
     reference = '';
   } else {

--- a/infrastructure/tooling/src/main.js
+++ b/infrastructure/tooling/src/main.js
@@ -62,7 +62,7 @@ program.command('changelog')
   .option('--silent', 'Add a silent changelog entry (no content required)')
   .option('--issue <issue>', 'Reference this issue # in the added changelog')
   .option('--bug <bug>', 'Reference this Bugzilla bug in the added changelog')
-  .option('--no-bug', 'This change does not reference a but or an issue')
+  .option('--no-bug', 'This change does not reference a bug or an issue')
   .action((...options) => {
     if (options.length !== 1) {
       console.error('unexpected command-line arguments');


### PR DESCRIPTION
Commander treats `--no-xxx` arguments specially, setting `xxx` to false
rather than setting `noXxx`.
