### PR TITLE
Resolve error message in code editor component

### DIFF
--- a/changelog/issue-1688.md
+++ b/changelog/issue-1688.md
@@ -1,0 +1,3 @@
+level: silent
+reference: issue 1688
+---

--- a/ui/src/components/WMWorkerPoolEditor/index.jsx
+++ b/ui/src/components/WMWorkerPoolEditor/index.jsx
@@ -394,10 +394,7 @@ export default class WMWorkerPoolEditor extends Component {
               }
               secondary={
                 <CodeEditor
-                  value={
-                    JSON.stringify(workerPool.config, null, 2) ||
-                    JSON.stringify({})
-                  }
+                  value={JSON.stringify(workerPool.config || {}, null, 2)}
                   onChange={this.handleEditorChange}
                   lint
                 />

--- a/ui/src/components/WMWorkerPoolEditor/index.jsx
+++ b/ui/src/components/WMWorkerPoolEditor/index.jsx
@@ -1,7 +1,6 @@
 import React, { Component, Fragment } from 'react';
 import { withRouter } from 'react-router-dom';
 import { oneOfType, object, string, func, bool } from 'prop-types';
-import { equals } from 'ramda';
 import List from '@material-ui/core/List';
 import ListSubheader from '@material-ui/core/ListSubheader';
 import ListItem from '@material-ui/core/ListItem';
@@ -209,24 +208,16 @@ export default class WMWorkerPoolEditor extends Component {
       target: { value: providerId },
     } = event;
     const { providers } = this.props;
-    const {
-      workerPool: { config: oldConfig },
-    } = this.state;
     const providerInfo = providers.find(i => i.providerId === providerId);
 
     if (!providerInfo) {
       return;
     }
 
-    // update config to default for this providerType only if not already set
-    const config = equals(oldConfig, {})
-      ? PROVIDER_DEFAULT_CONFIGS.get(providerInfo.providerType)
-      : oldConfig;
-
     this.setState({
       workerPool: {
         ...this.state.workerPool,
-        config,
+        config: PROVIDER_DEFAULT_CONFIGS.get(providerInfo.providerType),
         providerId: providerInfo.providerId,
       },
     });

--- a/ui/src/components/WMWorkerPoolEditor/index.jsx
+++ b/ui/src/components/WMWorkerPoolEditor/index.jsx
@@ -394,7 +394,10 @@ export default class WMWorkerPoolEditor extends Component {
               }
               secondary={
                 <CodeEditor
-                  value={JSON.stringify(workerPool.config, null, 2)}
+                  value={
+                    JSON.stringify(workerPool.config, null, 2) ||
+                    JSON.stringify({})
+                  }
                   onChange={this.handleEditorChange}
                   lint
                 />


### PR DESCRIPTION
Hi @helfi92 , I found the problem with this issue was that the `aws` provider does not have a `workerPool.Config` value (it returns an empty string). Please let me know if what I have done is sufficient to resolve this issue.


Closes #1688