### PR TITLE
Estimator updates to support `capacityPerInstance`

### DIFF
--- a/changelog/bug-1590175.md
+++ b/changelog/bug-1590175.md
@@ -1,0 +1,6 @@
+level: major
+reference: bug 1590175
+---
+Worker pools now support instance capacity in configuration such that larger instances can handle
+more tasks if desired. The configuration option was already accepted so nothing changes there but
+internally the option will start to have meaning.

--- a/generated/references.json
+++ b/generated/references.json
@@ -7905,12 +7905,12 @@
         {
           "description": "The simple estimator has decided that we need some number of instances.",
           "fields": {
-            "capacityPerInstance": "Amount of capacity a single instance provides",
-            "desiredSize": "Number that this estimator thinks we should have",
+            "desiredCapacity": "Amount of capacity that this estimator thinks we should have",
             "maxCapacity": "The maximum amount of capacity that should be running",
             "minCapacity": "The minimum amount of capacity that should be running",
             "pendingTasks": "The number of tasks the queue reports are pending for this worker pool",
-            "running": "Number of currently requested and running instances",
+            "requestedCapacity": "Amount of capacity that this estimator thinks we should add",
+            "runningCapacity": "Amount of currently requested and available capacity",
             "workerPoolId": "The worker pool name (provisionerId/workerType)"
           },
           "level": "notice",

--- a/services/worker-manager/src/estimator.js
+++ b/services/worker-manager/src/estimator.js
@@ -11,7 +11,11 @@ class Estimator {
     const {pendingTasks} = await this.queue.pendingTasks(provisionerId, workerType);
 
     // First we find the amount of capacity we want. This is a very simple approximation
-    const desiredCapacity = Math.max(minCapacity, Math.min(pendingTasks, maxCapacity));
+    // We add runningCapacity here to make the min/max stuff work and then remove it to
+    // decide how much more to request. In other words, we will ask to spawn
+    // enough capacity to cover all pending tasks at any time unless it would
+    // create more than maxCapacity instances
+    const desiredCapacity = Math.max(minCapacity, Math.min(pendingTasks + runningCapacity, maxCapacity));
 
     // Workers turn themselves off so we just return a positive number for
     // how many extra we want if we do want any

--- a/services/worker-manager/src/estimator.js
+++ b/services/worker-manager/src/estimator.js
@@ -6,28 +6,28 @@ class Estimator {
     this.monitor = monitor;
   }
 
-  async simple({workerPoolId, minCapacity, maxCapacity, capacityPerInstance, running}) {
+  async simple({workerPoolId, minCapacity, maxCapacity, runningCapacity}) {
     const {provisionerId, workerType} = splitWorkerPoolId(workerPoolId);
     const {pendingTasks} = await this.queue.pendingTasks(provisionerId, workerType);
 
     // First we find the amount of capacity we want. This is a very simple approximation
     const desiredCapacity = Math.max(minCapacity, Math.min(pendingTasks, maxCapacity));
 
-    const desiredSize = Math.round(desiredCapacity / capacityPerInstance);
+    // Workers turn themselves off so we just return a positive number for
+    // how many extra we want if we do want any
+    const requestedCapacity = Math.max(0, desiredCapacity - runningCapacity);
 
     this.monitor.log.simpleEstimate({
       workerPoolId,
       pendingTasks,
       minCapacity,
       maxCapacity,
-      capacityPerInstance,
-      running,
-      desiredSize,
+      runningCapacity,
+      desiredCapacity,
+      requestedCapacity,
     });
 
-    // Workers turn themselves off so we just return a positive number for
-    // how many extra we want if we do want any
-    return Math.max(0, desiredSize - running);
+    return requestedCapacity;
   }
 }
 

--- a/services/worker-manager/src/monitor.js
+++ b/services/worker-manager/src/monitor.js
@@ -29,9 +29,9 @@ monitorManager.register({
     pendingTasks: 'The number of tasks the queue reports are pending for this worker pool',
     minCapacity: 'The minimum amount of capacity that should be running',
     maxCapacity: 'The maximum amount of capacity that should be running',
-    capacityPerInstance: 'Amount of capacity a single instance provides',
-    running: 'Number of currently requested and running instances',
-    desiredSize: 'Number that this estimator thinks we should have',
+    runningCapacity: 'Amount of currently requested and available capacity',
+    desiredCapacity: 'Amount of capacity that this estimator thinks we should have',
+    requestedCapacity: 'Amount of capacity that this estimator thinks we should add',
   },
 });
 

--- a/services/worker-manager/src/providers/aws.js
+++ b/services/worker-manager/src/providers/aws.js
@@ -66,8 +66,7 @@ class AwsProvider extends Provider {
       workerPoolId,
       minCapacity: workerPool.config.minCapacity,
       maxCapacity: workerPool.config.maxCapacity,
-      capacityPerInstance: 1, // todo: this will be corrected along with estimator changes (bug 1579554)
-      running: workerPool.providerData[this.providerId].running,
+      runningCapacity: workerPool.providerData[this.providerId].running,
     });
     if (toSpawn === 0) {
       return;

--- a/services/worker-manager/src/providers/aws.js
+++ b/services/worker-manager/src/providers/aws.js
@@ -240,7 +240,7 @@ class AwsProvider extends Provider {
         case 'running':
         case 'shutting-down': //so that we don't turn on new instances until they're entirely gone
         case 'stopping':
-          this.seen[worker.workerPoolId] += worker.providerData.instanceCapacity;
+          this.seen[worker.workerPoolId] += worker.providerData.instanceCapacity || 1;
           return Promise.resolve();
 
         case 'terminated':

--- a/services/worker-manager/src/providers/aws.js
+++ b/services/worker-manager/src/providers/aws.js
@@ -62,7 +62,7 @@ class AwsProvider extends Provider {
       });
     }
 
-    const toSpawn = await this.estimator.simple({
+    let toSpawn = await this.estimator.simple({
       workerPoolId,
       minCapacity: workerPool.config.minCapacity,
       maxCapacity: workerPool.config.maxCapacity,
@@ -71,14 +71,17 @@ class AwsProvider extends Provider {
     if (toSpawn === 0) {
       return;
     }
-    const toSpawnPerConfig = Math.ceil(toSpawn / workerPool.config.launchConfigs.length);
 
-    const shuffledConfigs = _.shuffle(workerPool.config.launchConfigs);
+    const cfgs = [];
+    const maxPerConfig = 15;
+    while (toSpawn> 0) {
+      const cfg = _.sample(workerPool.config.launchConfigs);
+      const provided = Math.min(toSpawn, maxPerConfig * cfg.capacityPerInstance);
+      cfgs.push([provided, cfg]);
+      toSpawn -= provided;
+    }
 
-    let spawned;
-    let toSpawnCounter = toSpawn;
-    for await (let config of shuffledConfigs) {
-      if (toSpawnCounter <= 0) break; // eslint-disable-line
+    await Promise.all(cfgs.map(async ([toSpawnThisConfig, config]) => {
       // Make sure we don't get "The same resource type may not be specified
       // more than once in tag specifications" errors
       const TagSpecifications = config.launchConfig.TagSpecifications || [];
@@ -108,14 +111,15 @@ class AwsProvider extends Provider {
         });
       }
 
+      let spawned;
       try {
         spawned = await this.ec2s[config.region].runInstances({
           ...config.launchConfig,
 
           UserData: userData.toString('base64'), // The string needs to be base64-encoded. See the docs above
 
-          MaxCount: Math.min(toSpawnCounter, toSpawnPerConfig),
-          MinCount: Math.min(toSpawnCounter, toSpawnPerConfig),
+          MaxCount: toSpawnThisConfig,
+          MinCount: toSpawnThisConfig,
           TagSpecifications: [
             ...otherTagSpecs,
             {
@@ -150,8 +154,6 @@ class AwsProvider extends Provider {
         });
       }
 
-      toSpawnCounter -= toSpawnPerConfig;
-
       await Promise.all(spawned.Instances.map(i => {
         return this.Worker.create({
           workerPoolId,
@@ -163,6 +165,7 @@ class AwsProvider extends Provider {
           state: this.Worker.states.REQUESTED,
           providerData: {
             region: config.region,
+            instanceCapacity: config.capacityPerInstance,
             groups: spawned.Groups,
             amiLaunchIndex: i.AmiLaunchIndex,
             imageId: i.ImageId,
@@ -176,9 +179,7 @@ class AwsProvider extends Provider {
           },
         });
       }));
-    }
-
-    return;
+    }));
   }
 
   /**
@@ -239,7 +240,7 @@ class AwsProvider extends Provider {
         case 'running':
         case 'shutting-down': //so that we don't turn on new instances until they're entirely gone
         case 'stopping':
-          this.seen[worker.workerPoolId] += 1;
+          this.seen[worker.workerPoolId] += worker.providerData.instanceCapacity;
           return Promise.resolve();
 
         case 'terminated':

--- a/services/worker-manager/src/providers/aws.js
+++ b/services/worker-manager/src/providers/aws.js
@@ -106,6 +106,7 @@ class AwsProvider extends Provider {
         });
       }
 
+      const instanceCount = Math.ceil(Math.min(toSpawnCounter, toSpawnPerConfig) / config.capacityPerInstance);
       let spawned;
       try {
         spawned = await this.ec2s[config.region].runInstances({
@@ -113,8 +114,8 @@ class AwsProvider extends Provider {
 
           UserData: userData.toString('base64'), // The string needs to be base64-encoded. See the docs above
 
-          MaxCount: Math.min(toSpawnCounter, toSpawnPerConfig),
-          MinCount: Math.min(toSpawnCounter, toSpawnPerConfig),
+          MaxCount: instanceCount,
+          MinCount: instanceCount,
           TagSpecifications: [
             ...otherTagSpecs,
             {

--- a/services/worker-manager/src/providers/google.js
+++ b/services/worker-manager/src/providers/google.js
@@ -232,8 +232,7 @@ class GoogleProvider extends Provider {
     const toSpawn = await this.estimator.simple({
       workerPoolId,
       ...workerPool.config,
-      capacityPerInstance: 1, // TODO (bug 1587234) Hardcoded for now until estimator updates
-      running: workerPool.providerData[this.providerId].running,
+      runningCapacity: workerPool.providerData[this.providerId].running,
     });
 
     await Promise.all(new Array(toSpawn).fill(null).map(async i => {

--- a/services/worker-manager/src/providers/google.js
+++ b/services/worker-manager/src/providers/google.js
@@ -368,7 +368,7 @@ class GoogleProvider extends Provider {
       }));
       const {status} = data;
       if (['PROVISIONING', 'STAGING', 'RUNNING'].includes(status)) {
-        this.seen[worker.workerPoolId] += worker.providerData.instanceCapacity;
+        this.seen[worker.workerPoolId] += worker.providerData.instanceCapacity || 1;
 
         // If the worker will be expired soon but it still exists,
         // update it to stick around a while longer. If this doesn't happen,

--- a/services/worker-manager/src/providers/google.js
+++ b/services/worker-manager/src/providers/google.js
@@ -240,7 +240,7 @@ class GoogleProvider extends Provider {
     }
 
     const cfgs = [];
-    while (toSpawn> 0) {
+    while (toSpawn > 0) {
       const cfg = _.sample(workerPool.config.launchConfigs);
       cfgs.push(cfg);
       toSpawn -= cfg.capacityPerInstance;

--- a/ui/docs/reference/core/worker-manager/README.mdx
+++ b/ui/docs/reference/core/worker-manager/README.mdx
@@ -32,3 +32,5 @@ This combination is expected to be unique within a given worker pool.
 How workers are managed depends on the provider.
 In some cases, workers must be configured explicitly with API methods.
 In other cases, the provider manages all aspects of the workers and no user control is available.
+
+Each worker has a "capacity" it provides which is simply how many tasks it can run concurrently.


### PR DESCRIPTION
Bugzilla Bug: [1590175](https://bugzilla.mozilla.org/show_bug.cgi?id=1590175)

This involved some changes to how each provider loops over launch configs. I've tested the google provider in dev but it would be nice if @owlishDeveloper or someone can test the aws provider. I can provide an image for whoever wants it so they can avoid building it again themselves.