### PR TITLE
[Bug 1545939] Restart all containers once a day

### DIFF
--- a/changelog/bug-1545939.md
+++ b/changelog/bug-1545939.md
@@ -1,0 +1,6 @@
+level: patch
+reference: bug 1545939
+---
+All long-runnning processes are now restarted once every 24 hours by kubernetes. This
+is partially to replicate how Heroku ran the services and partially just because it
+is a good idea.

--- a/infrastructure/k8s/templates/taskcluster-auth-deployment-web.yaml
+++ b/infrastructure/k8s/templates/taskcluster-auth-deployment-web.yaml
@@ -47,3 +47,12 @@ spec:
             timeoutSeconds: 5
             periodSeconds: 10
             initialDelaySeconds: 3
+          livenessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - '-c'
+                - 'exit $(awk ''BEGIN{srand(); print (rand() > 0.3)}'')'
+            initialDelaySeconds: 86400
+            periodSeconds: 60
+            failureThreshold: 1

--- a/infrastructure/k8s/templates/taskcluster-built-in-workers-deployment-server.yaml
+++ b/infrastructure/k8s/templates/taskcluster-built-in-workers-deployment-server.yaml
@@ -37,3 +37,12 @@ spec:
             - secretRef:
                 name: taskcluster-built-in-workers
           ports: []
+          livenessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - '-c'
+                - 'exit $(awk ''BEGIN{srand(); print (rand() > 0.3)}'')'
+            initialDelaySeconds: 86400
+            periodSeconds: 60
+            failureThreshold: 1

--- a/infrastructure/k8s/templates/taskcluster-github-deployment-web.yaml
+++ b/infrastructure/k8s/templates/taskcluster-github-deployment-web.yaml
@@ -47,3 +47,12 @@ spec:
             timeoutSeconds: 5
             periodSeconds: 10
             initialDelaySeconds: 3
+          livenessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - '-c'
+                - 'exit $(awk ''BEGIN{srand(); print (rand() > 0.3)}'')'
+            initialDelaySeconds: 86400
+            periodSeconds: 60
+            failureThreshold: 1

--- a/infrastructure/k8s/templates/taskcluster-github-deployment-worker.yaml
+++ b/infrastructure/k8s/templates/taskcluster-github-deployment-worker.yaml
@@ -37,3 +37,12 @@ spec:
             - secretRef:
                 name: taskcluster-github
           ports: []
+          livenessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - '-c'
+                - 'exit $(awk ''BEGIN{srand(); print (rand() > 0.3)}'')'
+            initialDelaySeconds: 86400
+            periodSeconds: 60
+            failureThreshold: 1

--- a/infrastructure/k8s/templates/taskcluster-hooks-deployment-listeners.yaml
+++ b/infrastructure/k8s/templates/taskcluster-hooks-deployment-listeners.yaml
@@ -37,3 +37,12 @@ spec:
             - secretRef:
                 name: taskcluster-hooks
           ports: []
+          livenessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - '-c'
+                - 'exit $(awk ''BEGIN{srand(); print (rand() > 0.3)}'')'
+            initialDelaySeconds: 86400
+            periodSeconds: 60
+            failureThreshold: 1

--- a/infrastructure/k8s/templates/taskcluster-hooks-deployment-scheduler.yaml
+++ b/infrastructure/k8s/templates/taskcluster-hooks-deployment-scheduler.yaml
@@ -37,3 +37,12 @@ spec:
             - secretRef:
                 name: taskcluster-hooks
           ports: []
+          livenessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - '-c'
+                - 'exit $(awk ''BEGIN{srand(); print (rand() > 0.3)}'')'
+            initialDelaySeconds: 86400
+            periodSeconds: 60
+            failureThreshold: 1

--- a/infrastructure/k8s/templates/taskcluster-hooks-deployment-web.yaml
+++ b/infrastructure/k8s/templates/taskcluster-hooks-deployment-web.yaml
@@ -47,3 +47,12 @@ spec:
             timeoutSeconds: 5
             periodSeconds: 10
             initialDelaySeconds: 3
+          livenessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - '-c'
+                - 'exit $(awk ''BEGIN{srand(); print (rand() > 0.3)}'')'
+            initialDelaySeconds: 86400
+            periodSeconds: 60
+            failureThreshold: 1

--- a/infrastructure/k8s/templates/taskcluster-index-deployment-handlers.yaml
+++ b/infrastructure/k8s/templates/taskcluster-index-deployment-handlers.yaml
@@ -37,3 +37,12 @@ spec:
             - secretRef:
                 name: taskcluster-index
           ports: []
+          livenessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - '-c'
+                - 'exit $(awk ''BEGIN{srand(); print (rand() > 0.3)}'')'
+            initialDelaySeconds: 86400
+            periodSeconds: 60
+            failureThreshold: 1

--- a/infrastructure/k8s/templates/taskcluster-index-deployment-web.yaml
+++ b/infrastructure/k8s/templates/taskcluster-index-deployment-web.yaml
@@ -47,3 +47,12 @@ spec:
             timeoutSeconds: 5
             periodSeconds: 10
             initialDelaySeconds: 3
+          livenessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - '-c'
+                - 'exit $(awk ''BEGIN{srand(); print (rand() > 0.3)}'')'
+            initialDelaySeconds: 86400
+            periodSeconds: 60
+            failureThreshold: 1

--- a/infrastructure/k8s/templates/taskcluster-notify-deployment-handler.yaml
+++ b/infrastructure/k8s/templates/taskcluster-notify-deployment-handler.yaml
@@ -37,3 +37,12 @@ spec:
             - secretRef:
                 name: taskcluster-notify
           ports: []
+          livenessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - '-c'
+                - 'exit $(awk ''BEGIN{srand(); print (rand() > 0.3)}'')'
+            initialDelaySeconds: 86400
+            periodSeconds: 60
+            failureThreshold: 1

--- a/infrastructure/k8s/templates/taskcluster-notify-deployment-irc.yaml
+++ b/infrastructure/k8s/templates/taskcluster-notify-deployment-irc.yaml
@@ -37,3 +37,12 @@ spec:
             - secretRef:
                 name: taskcluster-notify
           ports: []
+          livenessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - '-c'
+                - 'exit $(awk ''BEGIN{srand(); print (rand() > 0.3)}'')'
+            initialDelaySeconds: 86400
+            periodSeconds: 60
+            failureThreshold: 1

--- a/infrastructure/k8s/templates/taskcluster-notify-deployment-web.yaml
+++ b/infrastructure/k8s/templates/taskcluster-notify-deployment-web.yaml
@@ -47,3 +47,12 @@ spec:
             timeoutSeconds: 5
             periodSeconds: 10
             initialDelaySeconds: 3
+          livenessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - '-c'
+                - 'exit $(awk ''BEGIN{srand(); print (rand() > 0.3)}'')'
+            initialDelaySeconds: 86400
+            periodSeconds: 60
+            failureThreshold: 1

--- a/infrastructure/k8s/templates/taskcluster-purge-cache-deployment-web.yaml
+++ b/infrastructure/k8s/templates/taskcluster-purge-cache-deployment-web.yaml
@@ -47,3 +47,12 @@ spec:
             timeoutSeconds: 5
             periodSeconds: 10
             initialDelaySeconds: 3
+          livenessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - '-c'
+                - 'exit $(awk ''BEGIN{srand(); print (rand() > 0.3)}'')'
+            initialDelaySeconds: 86400
+            periodSeconds: 60
+            failureThreshold: 1

--- a/infrastructure/k8s/templates/taskcluster-queue-deployment-claimResolver.yaml
+++ b/infrastructure/k8s/templates/taskcluster-queue-deployment-claimResolver.yaml
@@ -37,3 +37,12 @@ spec:
             - secretRef:
                 name: taskcluster-queue
           ports: []
+          livenessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - '-c'
+                - 'exit $(awk ''BEGIN{srand(); print (rand() > 0.3)}'')'
+            initialDelaySeconds: 86400
+            periodSeconds: 60
+            failureThreshold: 1

--- a/infrastructure/k8s/templates/taskcluster-queue-deployment-deadlineResolver.yaml
+++ b/infrastructure/k8s/templates/taskcluster-queue-deployment-deadlineResolver.yaml
@@ -37,3 +37,12 @@ spec:
             - secretRef:
                 name: taskcluster-queue
           ports: []
+          livenessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - '-c'
+                - 'exit $(awk ''BEGIN{srand(); print (rand() > 0.3)}'')'
+            initialDelaySeconds: 86400
+            periodSeconds: 60
+            failureThreshold: 1

--- a/infrastructure/k8s/templates/taskcluster-queue-deployment-dependencyResolver.yaml
+++ b/infrastructure/k8s/templates/taskcluster-queue-deployment-dependencyResolver.yaml
@@ -37,3 +37,12 @@ spec:
             - secretRef:
                 name: taskcluster-queue
           ports: []
+          livenessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - '-c'
+                - 'exit $(awk ''BEGIN{srand(); print (rand() > 0.3)}'')'
+            initialDelaySeconds: 86400
+            periodSeconds: 60
+            failureThreshold: 1

--- a/infrastructure/k8s/templates/taskcluster-queue-deployment-web.yaml
+++ b/infrastructure/k8s/templates/taskcluster-queue-deployment-web.yaml
@@ -47,3 +47,12 @@ spec:
             timeoutSeconds: 5
             periodSeconds: 10
             initialDelaySeconds: 3
+          livenessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - '-c'
+                - 'exit $(awk ''BEGIN{srand(); print (rand() > 0.3)}'')'
+            initialDelaySeconds: 86400
+            periodSeconds: 60
+            failureThreshold: 1

--- a/infrastructure/k8s/templates/taskcluster-references-deployment-web.yaml
+++ b/infrastructure/k8s/templates/taskcluster-references-deployment-web.yaml
@@ -47,3 +47,12 @@ spec:
             timeoutSeconds: 5
             periodSeconds: 10
             initialDelaySeconds: 3
+          livenessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - '-c'
+                - 'exit $(awk ''BEGIN{srand(); print (rand() > 0.3)}'')'
+            initialDelaySeconds: 86400
+            periodSeconds: 60
+            failureThreshold: 1

--- a/infrastructure/k8s/templates/taskcluster-secrets-deployment-web.yaml
+++ b/infrastructure/k8s/templates/taskcluster-secrets-deployment-web.yaml
@@ -47,3 +47,12 @@ spec:
             timeoutSeconds: 5
             periodSeconds: 10
             initialDelaySeconds: 3
+          livenessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - '-c'
+                - 'exit $(awk ''BEGIN{srand(); print (rand() > 0.3)}'')'
+            initialDelaySeconds: 86400
+            periodSeconds: 60
+            failureThreshold: 1

--- a/infrastructure/k8s/templates/taskcluster-ui-deployment-web.yaml
+++ b/infrastructure/k8s/templates/taskcluster-ui-deployment-web.yaml
@@ -47,3 +47,12 @@ spec:
             timeoutSeconds: 5
             periodSeconds: 10
             initialDelaySeconds: 3
+          livenessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - '-c'
+                - 'exit $(awk ''BEGIN{srand(); print (rand() > 0.3)}'')'
+            initialDelaySeconds: 86400
+            periodSeconds: 60
+            failureThreshold: 1

--- a/infrastructure/k8s/templates/taskcluster-web-server-deployment-web.yaml
+++ b/infrastructure/k8s/templates/taskcluster-web-server-deployment-web.yaml
@@ -47,3 +47,12 @@ spec:
             timeoutSeconds: 5
             periodSeconds: 10
             initialDelaySeconds: 3
+          livenessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - '-c'
+                - 'exit $(awk ''BEGIN{srand(); print (rand() > 0.3)}'')'
+            initialDelaySeconds: 86400
+            periodSeconds: 60
+            failureThreshold: 1

--- a/infrastructure/k8s/templates/taskcluster-worker-manager-deployment-provisioner.yaml
+++ b/infrastructure/k8s/templates/taskcluster-worker-manager-deployment-provisioner.yaml
@@ -37,3 +37,12 @@ spec:
             - secretRef:
                 name: taskcluster-worker-manager
           ports: []
+          livenessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - '-c'
+                - 'exit $(awk ''BEGIN{srand(); print (rand() > 0.3)}'')'
+            initialDelaySeconds: 86400
+            periodSeconds: 60
+            failureThreshold: 1

--- a/infrastructure/k8s/templates/taskcluster-worker-manager-deployment-web.yaml
+++ b/infrastructure/k8s/templates/taskcluster-worker-manager-deployment-web.yaml
@@ -47,3 +47,12 @@ spec:
             timeoutSeconds: 5
             periodSeconds: 10
             initialDelaySeconds: 3
+          livenessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - '-c'
+                - 'exit $(awk ''BEGIN{srand(); print (rand() > 0.3)}'')'
+            initialDelaySeconds: 86400
+            periodSeconds: 60
+            failureThreshold: 1

--- a/infrastructure/k8s/templates/taskcluster-worker-manager-deployment-workerscanner.yaml
+++ b/infrastructure/k8s/templates/taskcluster-worker-manager-deployment-workerscanner.yaml
@@ -37,3 +37,12 @@ spec:
             - secretRef:
                 name: taskcluster-worker-manager
           ports: []
+          livenessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - '-c'
+                - 'exit $(awk ''BEGIN{srand(); print (rand() > 0.3)}'')'
+            initialDelaySeconds: 86400
+            periodSeconds: 60
+            failureThreshold: 1

--- a/infrastructure/tooling/templates/k8s/deployment.yaml
+++ b/infrastructure/tooling/templates/k8s/deployment.yaml
@@ -49,9 +49,15 @@ spec:
             timeoutSeconds: 5
             periodSeconds: 10
             initialDelaySeconds: 3
+        # After 24 hours, we start randomly deciding to exit the container.
+        # Taskcluster services are created with the assumption that they will
+        # not run indefinitely.
         livenessProbe:
           exec:
-            command: "exit $(awk 'BEGIN{srand(); print (rand() > 0.3)}')"
+            command:
+            - /bin/sh
+            - -c
+            - exit $(awk 'BEGIN{srand(); print (rand() > 0.3)}')
           initialDelaySeconds: 86400
-          periodSeconds: 10
+          periodSeconds: 60
           failureThreshold: 1

--- a/infrastructure/tooling/templates/k8s/deployment.yaml
+++ b/infrastructure/tooling/templates/k8s/deployment.yaml
@@ -49,3 +49,9 @@ spec:
             timeoutSeconds: 5
             periodSeconds: 10
             initialDelaySeconds: 3
+        livenessProbe:
+          exec:
+            command: "exit $(awk 'BEGIN{srand(); print (rand() > 0.3)}')"
+          initialDelaySeconds: 86400
+          periodSeconds: 10
+          failureThreshold: 1


### PR DESCRIPTION
<!-- Did you remember to add a changelog snippet? See
     https://github.com/taskcluster/taskcluster/blob/master/dev-docs/best-practices/changelog.md

This replicates heroku and keeps things running smoothly in general. Tested this for a bit with a smaller `initialDelaySeconds` in my dev deployment and it appears to work just fine.


Bugzilla Bug: [1545939](https://bugzilla.mozilla.org/show_bug.cgi?id=1545939)
