### PR TITLE
Add `taskcluster_root_url` to the JSON-e context for `.taskcluster.yml`

### DIFF
--- a/changelog/bug-1590848.md
+++ b/changelog/bug-1590848.md
@@ -1,0 +1,5 @@
+level: minor
+reference: bug 1590848
+---
+The JSON-e context used to render `.taskcluster.yml` in GitHub repositories now contains `taskcluster_root_url` giving the root URL.
+This can be used for conditionals in the file, or to generate URLs.

--- a/services/github/src/tc-yaml.js
+++ b/services/github/src/tc-yaml.js
@@ -227,6 +227,7 @@ class VersionOne extends TcYaml {
 
     try {
       return jsone(config, {
+        taskcluster_root_url: cfg.taskcluster.rootUrl,
         tasks_for: payload.tasks_for,
         event: payload.body,
         as_slugid,

--- a/services/github/test/data/configs/taskcluster.single.v1.yml
+++ b/services/github/test/data/configs/taskcluster.single.v1.yml
@@ -13,6 +13,6 @@ tasks:
           - test
       metadata:
         name: "name"
-        description: "description"
+        description: "run on ${taskcluster_root_url}"
         owner: ${event.pusher.email}
         source: ${event.repository.url}

--- a/services/github/test/intree_test.js
+++ b/services/github/test/intree_test.js
@@ -319,6 +319,7 @@ suite(testing.suiteName(), function() {
     },
     {
       'tasks[0].task.metadata.owner': '', // private email
+      'tasks[0].task.metadata.description': 'run on https://tc-tests.example.com',
       'tasks[0].task.metadata.source': 'https://github.com/TaskclusterRobot/hooks-testing',
       scopes: [
         'assume:repo:github.com/testorg/testrepo:branch:default_branch',

--- a/ui/docs/reference/integrations/github/taskcluster-yml-v1.mdx
+++ b/ui/docs/reference/integrations/github/taskcluster-yml-v1.mdx
@@ -64,6 +64,9 @@ The `tasks` property in the YAML file is rendered using [JSON-e](https://github.
 
 * `as_slugid` - a function which, given a label, will generate a slugid. Multiple calls with the same label for the same event will generate the same slugid, but different slugids in different events.  Use this to generate taskIds, etc.
 
+* `taskcluster_root_url` - the rootUrl of the Taskcluster deployment in which the template is being rendered.
+  This can be useful in cases where multiple Taskcluster deployments are configured for the same repository, or for generating URLs to other Taskcluster resources.
+
 Although the Github documentation does not make it clear, each ref that is updated in a `git push` operation triggers a distinct event.
 
 ### Result


### PR DESCRIPTION
This should help with having more than one TC deployment (temporarily) enabled for a given GitHub repository.

https://bugzilla.mozilla.org/show_bug.cgi?id=1574648 tracks migrating the Servo project to the new community deployment of Taskcluster. Since Servo’s usage of TC is somewhat complex, I’d like to do this transition progressively or at least with some testing before “flipping the switch”. This means having, for a time, both https://github.com/apps/taskcluster and https://github.com/apps/community-tc-integration/ enabled on the repository and reacting to the same GitHub events based on the same `.taskcluster.yml` file.

However we’ll likely want to generate tasks with different payloads for each deployment. (If only with a different `provisionerId`.) Providing the deployment’s root URL in the context allows `.taskcluster.yml` to do so using JSON-e conditionals.

This PR is made in GitHub’s web editor based on looking at surrounding code and guessing, and is entirely untested. Any guidance is appreciated, starting with whether this sounds like a good approach.