### PR TITLE
Change CodeEditor placeholder text color

### DIFF
--- a/changelog/issue-1615.md
+++ b/changelog/issue-1615.md
@@ -1,0 +1,4 @@
+level: minor
+reference: issue 1615
+---
+The placeholder for the CodeEditor component now looks like a placeholder.

--- a/ui/src/App/Main.jsx
+++ b/ui/src/App/Main.jsx
@@ -30,6 +30,9 @@ import isLoggedInQuery from './isLoggedIn.graphql';
       fontSize: 13,
       height: '100% !important',
     },
+    '.CodeMirror pre.CodeMirror-placeholder': {
+      color: `${theme.palette.grey[600]} !important`,
+    },
     '[disabled] .mdi-icon': {
       fill: theme.palette.primary.light,
     },


### PR DESCRIPTION

Issue: https://github.com/taskcluster/taskcluster/issues/1615

Changes Done:
Added a global style for Code Mirror placeholder text color