### PR TITLE
Add cleanup for role smoketest 

### DIFF
--- a/infrastructure/tooling/src/smoketest/checks/role.js
+++ b/infrastructure/tooling/src/smoketest/checks/role.js
@@ -27,6 +27,20 @@ exports.tasks.push({
         'project:taskcluster:smoketest:abc/*' ],
     };
     assert.deepEqual(expandedRole.scopes, expectedScopes.scopes);
-    await auth.deleteRole(roleId);
+    const query = {};
+    const anHourAgo = Date.now() - (1000*60*60);
+    while (1) {
+      const res = await auth.listRoles2();
+      for(let i=0;i<res.roles.length;i++){
+        if(res.roles[i].roleId.includes('project:taskcluster:smoketest:') && res.roles[i].lastModified < anHourAgo){
+          await auth.deleteRole(res.roles[i].roleId);
+        }
+      }
+      if (res.continuationToken) {
+        query.continuationToken = res.continuationToken;
+      } else {
+        break;
+      }
+    }
   },
 });


### PR DESCRIPTION
This PR is a follow up to #1724  which is to accomplish the following tasks. The original issue is #1246

- [ ]  clean up: at the end of the test, please use listRoles2, including its pagination feature, to look for roles that this check might have created in the past (based on the pattern of roleId it creates). For any matching roles, look at the lastModified date, and if it is older than 1 hour, remove the role. This will allow us to eventually "clean up" any leftover roles from failed test runs, crashed workers, etc. The "older than 1 hour" part avoids deleting a role that is being used by another check running at exactly the same time (which can happen more often than you'd think!)

I am not sure if this is an efficient way to do it, please guide me if I am taking the wrong approach here. )
@djmitche 