### PR TITLE
Fix readme links

### DIFF
--- a/ui/docs/reference/core/web-server/README.mdx
+++ b/ui/docs/reference/core/web-server/README.mdx
@@ -23,8 +23,8 @@ Again, this approach is intended only for use by the Taskcluster UI.
 
 The following login strategies are supported:
 
-* [GitHub](github-login-strategy)
-* [Mozilla-Auth0](mozilla-auth0-login-strategy)
+* [GitHub](/docs/reference/core/web-server/github-login-strategy)
+* [Mozilla-Auth0](/docs/reference/core/web-server/mozilla-auth0-login-strategy)
 
 ## Third Party Login
 


### PR DESCRIPTION
Relative links are tricky in the docs, but origin-relative will always work..