### PR TITLE
Fix 1754: [UI] Make search case insensitive

### DIFF
--- a/changelog/issue-1754.md
+++ b/changelog/issue-1754.md
@@ -1,4 +1,4 @@
-level: minor
+level: silent
 reference: issue 1754
 ---
-Make search case insensitive for Roles and Secrets pages
+Make search case insensitive for Roles, Secrets and Clients pages

--- a/changelog/issue-1754.md
+++ b/changelog/issue-1754.md
@@ -1,0 +1,4 @@
+level: minor
+reference: issue 1754
+---
+Make search case insensitive for Roles and Secrets pages

--- a/ui/src/components/WMWorkerPoolsTable/index.jsx
+++ b/ui/src/components/WMWorkerPoolsTable/index.jsx
@@ -63,7 +63,7 @@ export default class WorkerManagerWorkerPoolsTable extends Component {
     (workerPools, sortBy, sortDirection, searchTerm, includeDeleted) => {
       const filteredWorkerPoolsBySearchTerm = searchTerm
         ? workerPools.filter(({ workerPoolId }) =>
-            workerPoolId.includes(searchTerm)
+            RegExp(searchTerm, 'i').test(workerPoolId)
           )
         : workerPools;
       const filteredWorkerPools = includeDeleted

--- a/ui/src/views/Clients/ViewClients/clients.graphql
+++ b/ui/src/views/Clients/ViewClients/clients.graphql
@@ -1,5 +1,5 @@
-query Clients($clientsConnection: PageConnection, $clientOptions: ClientsOptions) {
-  clients(connection: $clientsConnection, clientOptions: $clientOptions) {
+query Clients($clientsConnection: PageConnection, $clientOptions: ClientsOptions, $filter: JSON) {
+  clients(connection: $clientsConnection, clientOptions: $clientOptions, filter: $filter) {
     pageInfo {
       hasNextPage
       hasPreviousPage

--- a/ui/src/views/Clients/ViewClients/index.jsx
+++ b/ui/src/views/Clients/ViewClients/index.jsx
@@ -19,16 +19,18 @@ import ErrorPanel from '../../../components/ErrorPanel';
 @graphql(clientsQuery, {
   options: props => ({
     variables: {
-      clientOptions: {
-        ...(props.history.location.search
-          ? {
-              prefix: parse(props.history.location.search.slice(1)).search,
-            }
-          : null),
-      },
+      clientOptions: null,
       clientsConnection: {
         limit: VIEW_CLIENTS_PAGE_SIZE,
       },
+      filter: props.history.location.search
+        ? {
+            clientId: {
+              $regex: parse(props.history.location.search.slice(1)).search,
+              $options: 'i',
+            },
+          }
+        : null,
     },
   }),
 })
@@ -47,12 +49,11 @@ export default class ViewClients extends PureComponent {
       : '';
 
     await refetch({
-      clientOptions: {
-        ...(search ? { prefix: search } : null),
-      },
+      clientOptions: null,
       clientsConnection: {
         limit: VIEW_CLIENTS_PAGE_SIZE,
       },
+      filter: search ? { clientId: { $regex: search, $options: 'i' } } : null,
     });
 
     if (search !== searchUri) {

--- a/ui/src/views/Roles/ViewRoles/Roles.jsx
+++ b/ui/src/views/Roles/ViewRoles/Roles.jsx
@@ -15,7 +15,9 @@ import { VIEW_ROLES_PAGE_SIZE } from '../../../utils/constants';
         limit: VIEW_ROLES_PAGE_SIZE,
       },
       filter: {
-        ...(props.searchTerm ? { roleId: { $regex: props.searchTerm } } : null),
+        ...(props.searchTerm
+          ? { roleId: { $regex: props.searchTerm, $options: 'i' } }
+          : null),
       },
     },
   }),

--- a/ui/src/views/Secrets/ViewSecrets/index.jsx
+++ b/ui/src/views/Secrets/ViewSecrets/index.jsx
@@ -46,7 +46,9 @@ export default class ViewSecrets extends Component {
       secretsConnection: {
         limit: VIEW_SECRETS_PAGE_SIZE,
       },
-      filter: secretSearch ? { name: { $regex: secretSearch } } : null,
+      filter: secretSearch
+        ? { name: { $regex: secretSearch, $options: 'i' } }
+        : null,
     });
   };
 


### PR DESCRIPTION
Make search case insensitive for Roles and Secrets by adding regexp option \i

<!-- Did you remember to add a changelog snippet? See
     https://github.com/taskcluster/taskcluster/blob/master/dev-docs/best-practices/changelog.md

     If this is related to a Bugzilla bug, please begin your title with [Bug XXXXX]
     and update this link.  Otherwise, just remove it from your PR comment.  -->

<!-- If this is related to a GitHub Bug/Issue, Please write Issue Number after # in the next line. Otherwise, just remove it from your PR comment. -->

Github Bug/Issue: Fixes #1754