### PR TITLE
Add ref=opener to sign-in buttons

### DIFF
--- a/changelog/issue-1839.md
+++ b/changelog/issue-1839.md
@@ -1,0 +1,4 @@
+level: patch
+reference: issue 1839
+---
+Sign-In buttons now work properly with Firefox Nightly, instead of failing with a blank tab.

--- a/ui/src/components/SignInDialog/index.jsx
+++ b/ui/src/components/SignInDialog/index.jsx
@@ -93,6 +93,7 @@ export default class SignInDialog extends Component {
                 button
                 component="a"
                 href="/login/mozilla-auth0"
+                rel="opener"
                 target="_blank">
                 <ListItemAvatar>
                   <Avatar>
@@ -107,6 +108,7 @@ export default class SignInDialog extends Component {
                 button
                 component="a"
                 href="/login/github"
+                rel="opener"
                 target="_blank">
                 <ListItemAvatar>
                   <Avatar>


### PR DESCRIPTION
Credit to @glandium for the fix!

Github Bug/Issue: Fixes #1839.