### PR TITLE
[bug 1593142] Generalize support for backoffs and queueing in worker-manager

### DIFF
--- a/changelog/bug-1593142.md
+++ b/changelog/bug-1593142.md
@@ -1,0 +1,4 @@
+level: patch
+reference: bug 1593142
+---
+AWS Providers in Worker Manager now handle `RequestLimitExceeded` errors from AWS gracefully with exponential backoff

--- a/services/worker-manager/docs/providers.md
+++ b/services/worker-manager/docs/providers.md
@@ -115,4 +115,4 @@ The worker-manager service runs a background job to scan existing workers for st
 This occurs frequently, in a loop.
 Each iteration begins by calling `scanPrepare()` for each provider.
 Then, for each worker that is not STOPPED, `provider.checkWorker({worker})` is called.
-Finally, it calls `scanCleanup()` for each provider.
+Finally, it calls `scanCleanup({responsibleFor})` for each provider. The argument is a set of workerpools the provider is responsible for.

--- a/services/worker-manager/src/providers/aws.js
+++ b/services/worker-manager/src/providers/aws.js
@@ -34,9 +34,9 @@ class AwsProvider extends Provider {
     this.configSchema = 'config-aws';
     this.ec2iid_RSA_key = fs.readFileSync(path.resolve(__dirname, 'aws-keys/RSA-key-forSignature')).toString();
     this.providerConfig = Object.assign({}, {
-      intervalCapDefault: 1000,
-      intervalDefault: 60 * 1000,
-      _backoffDelay: 1000,
+      intervalCapDefault: 500,
+      intervalDefault: 10 * 1000,
+      _backoffDelay: 2000,
     }, providerConfig);
 
   }
@@ -310,7 +310,6 @@ class AwsProvider extends Provider {
     });
   }
 
-  // should this be implemented on Provider? Looks like it's going to be the same for all providers
   async scanPrepare() {
     this.seen = {};
     this.errors = {};

--- a/services/worker-manager/src/providers/aws.js
+++ b/services/worker-manager/src/providers/aws.js
@@ -5,6 +5,7 @@ const crypto = require('crypto');
 const fs = require('fs');
 const path = require('path');
 const _ = require('lodash');
+const {CloudAPI} = require('./cloudapi');
 
 class AwsProvider extends Provider {
   constructor({
@@ -18,6 +19,8 @@ class AwsProvider extends Provider {
     validator,
     notify,
     providerConfig,
+    intervalCapDefault = 1000,
+    intervalDefault = 60 * 1000,
   }) {
     super({
       providerId,
@@ -33,6 +36,8 @@ class AwsProvider extends Provider {
     this.configSchema = 'config-aws';
     this.ec2iid_RSA_key = fs.readFileSync(path.resolve(__dirname, 'aws-keys/RSA-key-forSignature')).toString();
     this.providerConfig = providerConfig;
+    this.intervalCapDefault = intervalCapDefault;
+    this.intervalDefault = intervalDefault;
   }
 
   async setup() {
@@ -43,13 +48,32 @@ class AwsProvider extends Provider {
 
     const regions = (await ec2.describeRegions({}).promise()).Regions;
 
+    let requestTypes = {};
     this.ec2s = {};
     regions.forEach(r => {
       this.ec2s[r.RegionName] = new aws.EC2({
         region: r.RegionName,
         credentials: this.providerConfig.credentials,
       });
+      // These three categories are described in https://docs.aws.amazon.com/AWSEC2/latest/APIReference/query-api-troubleshooting.html#api-request-rate
+      for (const category of ['describe', 'modify', 'security']) {
+        // AWS does not publish limits for each category so we just pick some nice round numbers with the defaults
+        // The backoff and retry should handle it if these are too high and we can tune them over time
+        requestTypes[`${r.RegionName}.${category}`] = {};
+      }
     });
+
+    const cloud = new CloudAPI({
+      types: Object.keys(requestTypes),
+      apiRateLimits: requestTypes,
+      intervalDefault: this.intervalDefault,
+      intervalCapDefault: this.intervalCapDefault,
+      monitor: this.monitor,
+      errorHandler: ({err, tries}) => {
+        // TODO: WHAT TO DO HERE?
+      },
+    });
+    this._enqueue = cloud.enqueue.bind(cloud);
   }
 
   async provision({workerPool}) {
@@ -109,7 +133,7 @@ class AwsProvider extends Provider {
       const instanceCount = Math.ceil(Math.min(toSpawnCounter, toSpawnPerConfig) / config.capacityPerInstance);
       let spawned;
       try {
-        spawned = await this.ec2s[config.region].runInstances({
+        spawned = await this._enqueue(`${config.region}.modify`, () => this.ec2s[config.region].runInstances({
           ...config.launchConfig,
 
           UserData: userData.toString('base64'), // The string needs to be base64-encoded. See the docs above
@@ -139,7 +163,7 @@ class AwsProvider extends Provider {
                 }],
             },
           ],
-        }).promise();
+        }).promise());
       } catch (e) {
         return await workerPool.reportError({
           kind: 'creation-error',
@@ -221,10 +245,11 @@ class AwsProvider extends Provider {
 
     let instanceStatuses;
     try {
-      instanceStatuses = (await this.ec2s[worker.providerData.region].describeInstanceStatus({
+      const region = worker.providerData.region;
+      instanceStatuses = (await this._enqueue(`${region}.describe`, () => this.ec2s[region].describeInstanceStatus({
         InstanceIds: [worker.workerId.toString()],
         IncludeAllInstances: true,
-      }).promise()).InstanceStatuses;
+      }).promise())).InstanceStatuses;
     } catch (e) {
       if (e.code === 'InvalidInstanceID.NotFound') { // aws throws this error for instances that had been terminated, too
         return worker.modify(w => {w.state = this.Worker.states.STOPPED;});
@@ -254,9 +279,10 @@ class AwsProvider extends Provider {
   async removeWorker({worker}) {
     let result;
     try {
-      result = await this.ec2s[worker.providerData.region].terminateInstances({
+      const region = worker.providerData.region;
+      result = await this._enqueue(`${region}.modify`, () => this.ec2s[region].terminateInstances({
         InstanceIds: [worker.workerId],
-      }).promise();
+      }).promise());
     } catch (e) {
       const workerPool = await this.WorkerPool.load({
         workerPoolId: worker.workerPoolId,

--- a/services/worker-manager/src/providers/aws.js
+++ b/services/worker-manager/src/providers/aws.js
@@ -318,6 +318,7 @@ class AwsProvider extends Provider {
     for (const workerPoolId of responsibleFor) {
       this.seen[workerPoolId] = this.seen[workerPoolId] || 0;
     }
+    this.monitor.notice('scan-seen', {providerId: this.providerId, seen: this.seen, responsible: [...responsibleFor]});
     await Promise.all(Object.entries(this.seen).map(async ([workerPoolId, seen]) => {
       const workerPool = await this.WorkerPool.load({
         workerPoolId,

--- a/services/worker-manager/src/providers/aws.js
+++ b/services/worker-manager/src/providers/aws.js
@@ -315,7 +315,10 @@ class AwsProvider extends Provider {
     this.errors = {};
   }
 
-  async scanCleanup() {
+  async scanCleanup({responsibleFor}) {
+    for (const workerPoolId of responsibleFor) {
+      this.seen[workerPoolId] = this.seen[workerPoolId] || 0;
+    }
     await Promise.all(Object.entries(this.seen).map(async ([workerPoolId, seen]) => {
       const workerPool = await this.WorkerPool.load({
         workerPoolId,

--- a/services/worker-manager/src/providers/aws.js
+++ b/services/worker-manager/src/providers/aws.js
@@ -312,7 +312,6 @@ class AwsProvider extends Provider {
 
   async scanPrepare() {
     this.seen = {};
-    this.errors = {};
   }
 
   async scanCleanup({responsibleFor}) {

--- a/services/worker-manager/src/providers/aws.js
+++ b/services/worker-manager/src/providers/aws.js
@@ -34,7 +34,7 @@ class AwsProvider extends Provider {
     this.configSchema = 'config-aws';
     this.ec2iid_RSA_key = fs.readFileSync(path.resolve(__dirname, 'aws-keys/RSA-key-forSignature')).toString();
     this.providerConfig = Object.assign({}, {
-      intervalCapDefault: 500,
+      intervalCapDefault: 150,
       intervalDefault: 10 * 1000,
       _backoffDelay: 2000,
     }, providerConfig);

--- a/services/worker-manager/src/providers/cloudapi.js
+++ b/services/worker-manager/src/providers/cloudapi.js
@@ -1,0 +1,89 @@
+const {default: PQueue} = require('p-queue');
+
+/**
+ * All cloud providers we interface with have things like api request rate
+ * limiting. This class provides an abstracted way to talk to them but pause
+ * with backoffs when we're told to slow down.
+ *
+ * The constructor takes an array of `types`, each of which will be an individual
+ * queue. This is useful because clouds often have different categories of request
+ * tracked differently or count limits separately across regions.
+ *
+ * It also takes `apiRateLimits` which should have a key for each `type` and values
+ * of `{interval, intervalCap}`. The meanings of these values can be found in
+ * p-queue documentation. For each of these you can also specify a default for if you
+ * have not set a value for a type.
+ *
+ * You must provide a taskcluster-lib-monitor logger to this class.
+ *
+ * Finally, it takes an `errorHandler` which is a function that takes an error and `tries` counter
+ * as the arguments and must throw an error or return an object containing three values:
+ *   backoff: which is a time in ms for how long requests should be paused
+ *   level: a taskcluster-lib-monitor logging level for the message about this
+ *   reason: a human-readable reason for the backoff
+ * If you throw an error, this class will pass the error right back along to where
+ * you called enqueue in the first place. This should be used for errors that are
+ * expected or should not pause the entire provider.
+ */
+class CloudAPI {
+
+  constructor({
+    types,
+    apiRateLimits,
+    intervalDefault,
+    intervalCapDefault,
+    monitor,
+    errorHandler,
+  }) {
+    this.queues = {};
+    this.errorHandler = errorHandler;
+    this.monitor = monitor;
+    for (const type of types) {
+      const {interval, intervalCap} = (apiRateLimits[type] || {});
+      this.queues[type] = new PQueue({
+        interval: interval || intervalDefault,
+        intervalCap: intervalCap || intervalCapDefault,
+      });
+    }
+  }
+
+  async enqueue(type, func, tries = 0) {
+    const queue = this.queues[type];
+    if (!queue) {
+      throw new Error(`Unknown p-queue attempted: ${type}`);
+    }
+    try {
+      return await queue.add(func, {priority: tries});
+    } catch (err) {
+      let {backoff, level, reason} = this.errorHandler({err, tries});
+
+      if (!queue.isPaused) {
+        this.monitor.log.cloudApiPaused({
+          providerId: this.providerId,
+          queueName: type,
+          reason: reason || 'unknown',
+          queueSize: queue.size,
+          duration: backoff,
+        }, {level: level || 'notice'});
+        queue.pause();
+        setTimeout(() => {
+          this.monitor.log.cloudApiResumed({
+            providerId: this.providerId,
+            queueName: type,
+          });
+          queue.start();
+        }, backoff);
+      }
+
+      if (tries > 4) {
+        throw err;
+      }
+
+      return await this.enqueue(type, func, tries + 1);
+    }
+  }
+}
+
+module.exports = {
+  CloudAPI,
+};

--- a/services/worker-manager/src/providers/google.js
+++ b/services/worker-manager/src/providers/google.js
@@ -372,6 +372,7 @@ class GoogleProvider extends Provider {
   async scanCleanup({responsibleFor}) {
     for (const workerPoolId of responsibleFor) {
       this.seen[workerPoolId] = this.seen[workerPoolId] || 0;
+      this.errors[workerPoolId] = this.errors[workerPoolId] || [];
     }
     await Promise.all(Object.entries(this.seen).map(async ([workerPoolId, seen]) => {
       const workerPool = await this.WorkerPool.load({

--- a/services/worker-manager/src/providers/google.js
+++ b/services/worker-manager/src/providers/google.js
@@ -369,7 +369,10 @@ class GoogleProvider extends Provider {
   /*
    * Called after an iteration of the worker scanner
    */
-  async scanCleanup() {
+  async scanCleanup({responsibleFor}) {
+    for (const workerPoolId of responsibleFor) {
+      this.seen[workerPoolId] = this.seen[workerPoolId] || 0;
+    }
     await Promise.all(Object.entries(this.seen).map(async ([workerPoolId, seen]) => {
       const workerPool = await this.WorkerPool.load({
         workerPoolId,

--- a/services/worker-manager/src/providers/provider.js
+++ b/services/worker-manager/src/providers/provider.js
@@ -65,7 +65,7 @@ class Provider {
   async checkWorker({worker}) {
   }
 
-  async scanCleanup() {
+  async scanCleanup({responsibleFor}) {
   }
 
   async createWorker({workerPool, workerGroup, workerId, input}) {

--- a/services/worker-manager/src/providers/testing.js
+++ b/services/worker-manager/src/providers/testing.js
@@ -44,7 +44,7 @@ class TestingProvider extends Provider {
     });
   }
 
-  async scanCleanup() {
+  async scanCleanup({responsibleFor}) {
     this.monitor.notice('scan-cleanup', {});
   }
 

--- a/services/worker-manager/src/provisioner.js
+++ b/services/worker-manager/src/provisioner.js
@@ -109,7 +109,11 @@ class Provisioner {
           return;
         }
 
-        await provider.provision({workerPool});
+        try {
+          await provider.provision({workerPool});
+        } catch (err) {
+          this.monitor.reportError(err, {providerId: workerPool.providerId}); // Just report this and move on
+        }
 
         await Promise.all(workerPool.previousProviderIds.map(async pId => {
           const provider = this.providers.get(pId);
@@ -119,7 +123,11 @@ class Provisioner {
             return;
           }
 
-          await provider.deprovision({workerPool});
+          try {
+            await provider.deprovision({workerPool});
+          } catch (err) {
+            this.monitor.reportError(err, {providerId: pId}); // Just report this and move on
+          }
         }));
 
         this.monitor.log.workerPoolProvisioned({

--- a/services/worker-manager/src/worker-scanner.js
+++ b/services/worker-manager/src/worker-scanner.js
@@ -65,7 +65,11 @@ class WorkerScanner {
         seen(worker.providerId, worker.workerPoolId);
         const provider = this.providers.get(worker.providerId);
         if (provider) {
-          await provider.checkWorker({worker});
+          try {
+            await provider.checkWorker({worker});
+          } catch (err) {
+            this.monitor.reportError(err); // Just report it and move on so this doesn't block other providers
+          }
         } else {
           this.monitor.info(
             `Worker ${worker.workerGroup}/${worker.workerId} has unknown providerId ${worker.providerId} (ignoring)`);

--- a/services/worker-manager/test/provider_google_test.js
+++ b/services/worker-manager/test/provider_google_test.js
@@ -152,7 +152,7 @@ helper.secrets.mockSuite(testing.suiteName(), ['azure'], function(mock, skipping
     // On the first run we've faked that the instance is running
     await provider.scanPrepare();
     await provider.checkWorker({worker});
-    await provider.scanCleanup();
+    await provider.scanCleanup({responsibleFor: new Set([workerPoolId])});
     await workerPool.reload();
     assert.equal(workerPool.providerData.google.running, 1);
     await worker.reload();
@@ -161,7 +161,7 @@ helper.secrets.mockSuite(testing.suiteName(), ['azure'], function(mock, skipping
     // And now we fake it is stopped
     await provider.scanPrepare();
     await provider.checkWorker({worker});
-    await provider.scanCleanup();
+    await provider.scanCleanup({responsibleFor: new Set([workerPoolId])});
     await workerPool.reload();
     assert.equal(workerPool.providerData.google.running, 0);
     await worker.reload();
@@ -182,7 +182,7 @@ helper.secrets.mockSuite(testing.suiteName(), ['azure'], function(mock, skipping
     });
     await provider.scanPrepare();
     await provider.checkWorker({worker});
-    await provider.scanCleanup();
+    await provider.scanCleanup({responsibleFor: new Set([workerPoolId])});
     assert(worker.expires > expires);
   });
 


### PR DESCRIPTION
Bugzilla Bug: [1593142](https://bugzilla.mozilla.org/show_bug.cgi?id=1593142)

I'm running this in heroku currently and it appears to work at least from a not-throwing-errors perspective. I see it logging `cloud-api-paused` and `cloud-api-resumed` so that's good news too. Each loop of the provisioning and worker-scanning loops seems to finish with plenty of time remaining for now. I'd like to watch this a bit longer before landing this PR but put it up for review now.