### PR TITLE
Authorizaton SidebarListGroup should be open when any one of the option under that is selected

### DIFF
--- a/ui/src/components/Dashboard/SidebarList.jsx
+++ b/ui/src/components/Dashboard/SidebarList.jsx
@@ -23,6 +23,14 @@ import SidebarListGroup from './SidebarListGroup';
 import SidebarListItem from './SidebarListItem';
 
 export default class SidebarList extends Component {
+  state ={
+    sidebarKeepOpen:false,
+  }
+
+  handleSidebarKeepOpen = () =>{
+  this.setState({sidebarKeepOpen:true});
+  }
+
   render() {
     return (
       <List disablePadding>
@@ -43,22 +51,25 @@ export default class SidebarList extends Component {
           skipPrefetch
           to="/auth"
           title="Authorization"
+          sidebarkeepopen={this.handleSidebarKeepOpen}
           icon={<AccountKeyIcon />}>
-          <SidebarListItem to="/auth/clients" icon={<AccountMultipleIcon />}>
+          <SidebarListItem onClick={this.handleSidebarKeepOpen} to="/auth/clients" icon={<AccountMultipleIcon />}>
             Clients
           </SidebarListItem>
-          <SidebarListItem to="/auth/roles" icon={<AccountStarIcon />}>
+          <SidebarListItem onClick={this.handleSidebarKeepOpen} to="/auth/roles" icon={<AccountStarIcon />}>
             Roles
           </SidebarListItem>
-          <SidebarListItem to="/auth/scopes" icon={<AccountSettingsIcon />}>
+          <SidebarListItem onClick={this.handleSidebarKeepOpen} to="/auth/scopes" icon={<AccountSettingsIcon />}>
             Scopes
           </SidebarListItem>
           <SidebarListItem
+            onClick={this.handleSidebarKeepOpen}
             to="/auth/scopes/compare"
             icon={<ScaleBalanceIcon />}>
             Compare Scopes
           </SidebarListItem>
           <SidebarListItem
+            onClick={this.handleSidebarKeepOpen}
             to="/auth/scopes/expansions"
             icon={<ArrowExpandVerticalIcon />}>
             Expand Scopes

--- a/ui/src/components/Dashboard/SidebarList.jsx
+++ b/ui/src/components/Dashboard/SidebarList.jsx
@@ -23,13 +23,13 @@ import SidebarListGroup from './SidebarListGroup';
 import SidebarListItem from './SidebarListItem';
 
 export default class SidebarList extends Component {
-  state ={
-    sidebarKeepOpen:false,
-  }
+  state = {
+    sidebarKeepOpen: false,
+  };
 
-  handleSidebarKeepOpen = () =>{
-  this.setState({sidebarKeepOpen:true});
-  }
+  handleSidebarKeepOpen = () => {
+    this.setState({ sidebarKeepOpen: true });
+  };
 
   render() {
     return (
@@ -53,13 +53,22 @@ export default class SidebarList extends Component {
           title="Authorization"
           sidebarkeepopen={this.handleSidebarKeepOpen}
           icon={<AccountKeyIcon />}>
-          <SidebarListItem onClick={this.handleSidebarKeepOpen} to="/auth/clients" icon={<AccountMultipleIcon />}>
+          <SidebarListItem
+            onClick={this.handleSidebarKeepOpen}
+            to="/auth/clients"
+            icon={<AccountMultipleIcon />}>
             Clients
           </SidebarListItem>
-          <SidebarListItem onClick={this.handleSidebarKeepOpen} to="/auth/roles" icon={<AccountStarIcon />}>
+          <SidebarListItem
+            onClick={this.handleSidebarKeepOpen}
+            to="/auth/roles"
+            icon={<AccountStarIcon />}>
             Roles
           </SidebarListItem>
-          <SidebarListItem onClick={this.handleSidebarKeepOpen} to="/auth/scopes" icon={<AccountSettingsIcon />}>
+          <SidebarListItem
+            onClick={this.handleSidebarKeepOpen}
+            to="/auth/scopes"
+            icon={<AccountSettingsIcon />}>
             Scopes
           </SidebarListItem>
           <SidebarListItem

--- a/ui/src/components/Dashboard/SidebarListGroup.jsx
+++ b/ui/src/components/Dashboard/SidebarListGroup.jsx
@@ -34,6 +34,14 @@ export default class SidebarListGroup extends Component {
     e.preventDefault();
     this.setState({ open: !this.state.open });
   };
+  
+  componentDidMount(){
+    if(this.props.sidebarkeepopen){
+      this.setState({
+        open:true
+      })
+    }
+  }
 
   render() {
     const { classes, children, icon, title, to, ...props } = this.props;

--- a/ui/src/components/Dashboard/SidebarListGroup.jsx
+++ b/ui/src/components/Dashboard/SidebarListGroup.jsx
@@ -34,12 +34,12 @@ export default class SidebarListGroup extends Component {
     e.preventDefault();
     this.setState({ open: !this.state.open });
   };
-  
-  componentDidMount(){
-    if(this.props.sidebarkeepopen){
+
+  componentDidMount() {
+    if (this.props.sidebarkeepopen) {
       this.setState({
-        open:true
-      })
+        open: true,
+      });
     }
   }
 


### PR DESCRIPTION
**Issue:**
If any one of the options under `Authorization`(`Roles`, `Clients`, `Scopes`, `Compare Scopes`, `Expand Scopes`) in Sidebar has been clicked,  the `Authorization` SidebarListGroup should be opened(while clicking the hamburger icon again).

**Before bug fix:**
<img width="1084" alt="Screen Shot 2019-11-01 at 8 03 13 PM" src="https://user-images.githubusercontent.com/24657693/68033756-5d546380-fce6-11e9-94ca-d8ffa694da5e.png">

**After bug fix:**
<img width="958" alt="Screen Shot 2019-11-01 at 8 03 28 PM" src="https://user-images.githubusercontent.com/24657693/68033771-634a4480-fce6-11e9-954a-472b008289f1.png">


