### PR TITLE
Fix `yarn changelog` no longer running.

### DIFF
--- a/infrastructure/tooling/src/main.js
+++ b/infrastructure/tooling/src/main.js
@@ -126,6 +126,3 @@ program.command('*', {noHelp: true})
   .action(() => program.help(txt => txt));
 
 program.parse(process.argv);
-if (!program.args.length) {
-  program.help();
-}


### PR DESCRIPTION
The commander upgrade in #1860 led to `program.args` always being
empty, leading to always printing help, and commander helpfully calls
process.exit after printing help.
