### PR TITLE
Bug 1593754 - use pulse.namespace for the pulse namespace

### DIFF
--- a/changelog/bug-1593754.md
+++ b/changelog/bug-1593754.md
@@ -1,0 +1,4 @@
+level: patch
+reference: bug 1593754
+---
+The web-server service now uses the correct Pulse namespace to listen for pulse messages.  This fixes one more bug preventing task and task-group UI from dynamically updating.

--- a/services/web-server/src/main.js
+++ b/services/web-server/src/main.js
@@ -56,7 +56,7 @@ const load = loader(
 
         return new Client({
           monitor: monitor.childMonitor('pulse-client'),
-          namespace: cfg.pulse.username,
+          namespace: cfg.pulse.namespace,
           credentials: pulseCredentials(cfg.pulse),
         });
       },


### PR DESCRIPTION
Bugzilla Bug: [1593754](https://bugzilla.mozilla.org/show_bug.cgi?id=1593754)

It turns out this was just a bug where we were using the wrong config value.