### PR TITLE
Bug 1593809 - github.bot_username and 404's from github.latest

### DIFF
--- a/changelog/bug-1593809.md
+++ b/changelog/bug-1593809.md
@@ -1,0 +1,5 @@
+level: patch
+reference: bug 1593809
+---
+The taskcluster-github service now correctly uses the `github.bot_username` configuration to look up the latest status for a branch.
+Deployments of Taskcluster should double-check that this value is set correctly; see the [deployment docs](https://docs.taskcluster.net/docs/manual/deploying/github) for details.

--- a/services/github/config.yml
+++ b/services/github/config.yml
@@ -59,7 +59,6 @@ production:
     deprecatedInitialStatusQueue: 'stat-init'
     resultStatusQueue: 'ch-result'
     initialStatusQueue: 'ch-init'
-    botName: 'taskcluster[bot]'
 
   intree:
     provisionerId: 'aws-provisioner-v1'
@@ -87,7 +86,6 @@ staging:
     ownersDirectoryTableName: 'TaskclusterIntegrationOwnersStaging'
     name: 'tc-github-staging'
     statusContext: 'Taskcluster-Staging'
-    botName: 'taskcluster-staging[bot]'
 
   intree:
     provisionerId: 'aws-provisioner-v1'

--- a/services/github/src/api.js
+++ b/services/github/src/api.js
@@ -145,7 +145,9 @@ async function installationAuthenticate(owner, OwnersDirectory, github) {
  Returns either status object or undefined (if not found).
 ***/
 async function findTCStatus(github, owner, repo, branch, configuration) {
-  let taskclusterBot = (await github.users.getByUsername({username: configuration.app.botName})).data;
+  const botName = configuration.app.botName;
+  const username = botName.endsWith('[bot]') ? botName : `${botName}[bot]`;
+  const taskclusterBot = (await github.users.getByUsername({username})).data;
   // Statuses is an array of status objects, where we find the relevant status
   let statuses = (await github.repos.listStatusesForRef({owner, repo, ref: branch})).data;
   return statuses.find(statusObject => statusObject.creator.id === taskclusterBot.id);

--- a/services/github/src/api.js
+++ b/services/github/src/api.js
@@ -149,7 +149,16 @@ async function findTCStatus(github, owner, repo, branch, configuration) {
   const username = botName.endsWith('[bot]') ? botName : `${botName}[bot]`;
   const taskclusterBot = (await github.users.getByUsername({username})).data;
   // Statuses is an array of status objects, where we find the relevant status
-  let statuses = (await github.repos.listStatusesForRef({owner, repo, ref: branch})).data;
+  let statuses;
+
+  try {
+    statuses = (await github.repos.listStatusesForRef({owner, repo, ref: branch})).data;
+  } catch (e) {
+    if (e.code === 404) {
+      return undefined;
+    }
+    throw e;
+  }
   return statuses.find(statusObject => statusObject.creator.id === taskclusterBot.id);
 }
 
@@ -461,17 +470,14 @@ builder.declare({
 
   // Get task group ID
   if (instGithub) {
-    try {
-      let status = await findTCStatus(instGithub, owner, repo, branch, this.cfg);
+    let status = await findTCStatus(instGithub, owner, repo, branch, this.cfg);
 
-      return res.redirect(status.target_url);
-    } catch (e) {
-      debug(`Error creating link: ${JSON.stringify(e)}`);
-      await this.monitor.reportError(e);
-      return res.status(500).send();
+    if (!status) {
+      return res.reportError('ResourceNotFound', 'Status not found', {});
     }
+
+    return res.redirect(status.target_url);
   }
-  return res.status(404).send();
 });
 
 builder.declare({

--- a/services/github/test/api_test.js
+++ b/services/github/test/api_test.js
@@ -106,7 +106,7 @@ helper.secrets.mockSuite(testing.suiteName(), ['azure'], function(mock, skipping
       ref: 'master',
       info: [{creator: {id: 123345}, state: 'success'}],
     });
-    github.inst(9090).setUser({id: 55555, email: 'noreply@github.com', username: 'magicalTCspirit'});
+    github.inst(9090).setUser({id: 55555, email: 'noreply@github.com', username: 'magicalTCspirit[bot]'});
   });
 
   test('all builds', async function() {

--- a/services/github/test/github-auth.js
+++ b/services/github/test/github-auth.js
@@ -100,8 +100,12 @@ class FakeGithub {
       },
       'repos.listStatusesForRef': async ({owner, repo, ref}) => {
         const key = `${owner}/${repo}@${ref}`;
-        if (this._statuses[key]) {
-          return {data: this._statuses[key]};
+        const info = this._statuses[key]
+        if (info && info.errorStatus) {
+          throwError(info.errorStatus);
+        }
+        if (info) {
+          return {data: info};
         } else {
           throwError(404);
         }

--- a/ui/docs/manual/deploying/github.mdx
+++ b/ui/docs/manual/deploying/github.mdx
@@ -33,7 +33,13 @@ Set the fields as follows:
 * Webhook URL should link to `/api/github/v1/github` on your deployment's root URL
 * Set the secret to an arbitrary value that you also configure in your Taskcluster instance's settings. 
 
-### How to set up private keys? 
+### Configuration
+
+In the Helm templates, you'll need to set
+
+* `github.bot_username` -- this should match the name in the integration's URL.  For example, if the URL is https://github.com/apps/acme-taskclsuter then the `bot_name` should be `acme-taskcluster`.
+* `github.github_app_id` -- numeric app_id
+* `github.github_private_pem` -- see below
 
 On the app's settings page, generate a private key, and add its PEM to your Taskcluster instance's configs.
 This is a multiline string.


### PR DESCRIPTION
Bugzilla Bug: [1593809](https://bugzilla.mozilla.org/show_bug.cgi?id=1593809)

This does two linked things:

 * Takes BOT_USERNAME as a config, since it is different per deployment.  From GitHub's perspective, the username is the App name plus `[bot]`, e.g., `cloudopsstage-taskcluster[bot]`.  Partially to simplify configuration and partially because @edunham already set all of the config to names lacking `[bot]`.
 * Handles 404's from the github API method by passing them along to the caller -- both for badges (with a new-repo svg) and for latest.