### PR TITLE
Improve 404 error message for index service

### DIFF
--- a/changelog/HlsKXj6YSXyheh1KWKDMCA.md
+++ b/changelog/HlsKXj6YSXyheh1KWKDMCA.md
@@ -1,0 +1,3 @@
+level: patch
+---
+The taskcluster-index service now responds with a 404 and "Indexed task not found" when a task is not found, instead of the misleading "Indexed task has expired".

--- a/services/index/src/api.js
+++ b/services/index/src/api.js
@@ -72,7 +72,7 @@ builder.declare({
     return res.reportError('ResourceNotFound', 'Indexed task not found', {});
   }
   if (!tasks.entries.length) {
-    return res.reportError('ResourceNotFound', 'Indexed task has expired', {});
+    return res.reportError('ResourceNotFound', 'Indexed task not found', {});
   }
   let task = tasks.entries[0];
   return res.reply(task.json());


### PR DESCRIPTION
It seems that `query` returns an empty array in the not-found case, rather than throwing an error.  At any rate, an expired entry is probably best represented as "not found" anyway.