### PR TITLE
Fix clean up of role smoketest

### DIFF
--- a/infrastructure/tooling/src/smoketest/checks/role.js
+++ b/infrastructure/tooling/src/smoketest/checks/role.js
@@ -13,7 +13,7 @@ exports.tasks.push({
     const randomId = taskcluster.slugid();
     const roleId = `project:taskcluster:smoketest:${randomId}:*`;
     const payload = {
-      description: 'smoketest test',
+      description: 'smoketest for creating a role and expanding it',
       scopes: ['project:taskcluster:smoketest:<..>/*'],
     };
     const expandPayload = {
@@ -31,9 +31,9 @@ exports.tasks.push({
     const anHourAgo = Date.now() - (1000*60*60);
     while (1) {
       const res = await auth.listRoles2();
-      for(let i=0;i<res.roles.length;i++){
-        if(res.roles[i].roleId.includes('project:taskcluster:smoketest:') && res.roles[i].lastModified < anHourAgo){
-          await auth.deleteRole(res.roles[i].roleId);
+      for(let role of res.roles){
+        if(role.roleId.includes('project:taskcluster:smoketest:') && role.lastModified < new Date(anHourAgo)){
+          await auth.deleteRole(role.roleId);
         }
       }
       if (res.continuationToken) {


### PR DESCRIPTION
This PR is a follow up to the Add cleanup for role smoketest #1776 pull request which traces back to the original issue #1246. The issue for not cleaning up was with the time condition.

- Updated the for loop syntax

- Cleans up by deleting the role if the last modified time is 1 hour or more

@djmitche 
