### PR TITLE
Attempt to fix renovate PRs (weekly instead of daily)

### DIFF
--- a/changelog/issue-niSSIctzX93Fh5QmnvSE2T8QnUhwF19a.md
+++ b/changelog/issue-niSSIctzX93Fh5QmnvSE2T8QnUhwF19a.md
@@ -1,0 +1,3 @@
+level: silent
+reference: issue niSSIctzX93Fh5QmnvSE2T8QnUhwF19a
+---

--- a/package.json
+++ b/package.json
@@ -190,7 +190,6 @@
       "config:base",
       "schedule:earlyMondays"
     ],
-    "schedule": "at any time",
     "prHourlyLimit": 0,
     "prConcurrentLimit": 9,
     "rangeStrategy": "update-lockfile",


### PR DESCRIPTION
`schedule:earlyMondays` already defines a schedule property in https://github.com/renovatebot/presets/blob/2cda948b40835151157e778ccb3f96387b7974eb/packages/renovate-config-schedule/package.json#L12-L15. It's possible that `"schedule": "at any time",` was overwriting the preset's value.