### PR TITLE
[bug 1593762] Allow workerpools with underscores in name for go…

### DIFF
--- a/changelog/bug-1593762.md
+++ b/changelog/bug-1593762.md
@@ -1,0 +1,4 @@
+level: patch
+reference: bug 1593762
+---
+The google provider now accepts workerpools with underscores in the name

--- a/services/worker-manager/src/providers/google.js
+++ b/services/worker-manager/src/providers/google.js
@@ -211,7 +211,7 @@ class GoogleProvider extends Provider {
       // The lost entropy from downcasing, etc should be ok due to the fact that
       // only running instances need not be identical. We do not use this name to identify
       // workers in taskcluster.
-      const poolName = workerPoolId.replace(/\//g, '-').slice(0, 38);
+      const poolName = workerPoolId.replace(/[\/_]/g, '-').slice(0, 38);
       const instanceName = `${poolName}-${slugid.nice().replace(/_/g, '-').toLowerCase()}`;
 
       let op;


### PR DESCRIPTION
<!-- Did you remember to add a changelog snippet? See
     https://github.com/taskcluster/taskcluster/blob/master/dev-docs/best-practices/changelog.md

     If this is related to a Bugzilla bug, please begin your title with [Bug XXXXX]
     and update this link.  Otherwise, just remove it from your PR comment.  -->

Bugzilla Bug: [1593762](https://bugzilla.mozilla.org/show_bug.cgi?id=1593762)

<!-- If this is related to a GitHub Bug/Issue, Please write Issue Number after # in the next line. Otherwise, just remove it from your PR comment. -->

Github Bug/Issue: Fixes #XXXX