### PR TITLE
Make Task Group status more visible on mobile

### DIFF
--- a/changelog/issue-1908.md
+++ b/changelog/issue-1908.md
@@ -1,0 +1,3 @@
+level: silent
+reference: issue 1908
+---

--- a/ui/src/components/TaskGroupTable/index.jsx
+++ b/ui/src/components/TaskGroupTable/index.jsx
@@ -94,23 +94,14 @@ const createSortedTasks = memoize(
     textDecoration: 'none',
     ...theme.mixins.hover,
     ...theme.mixins.listItemButton,
-    [theme.breakpoints.down('sm')]: {
-      paddingLeft: 0,
-      paddingRight: 0,
-    },
   },
   taskGroupName: {
     marginRight: theme.spacing(1),
-    maxWidth: '55vw',
     whiteSpace: 'nowrap',
     overflow: 'hidden',
     textOverflow: 'ellipsis',
     verticalAlign: 'middle',
     display: 'inline-block',
-    [theme.breakpoints.down('sm')]: {
-      maxWidth: '90%',
-      marginRight: theme.spacing.unit * 0.5,
-    },
   },
   table: {
     marginBottom: theme.spacing(1),
@@ -131,27 +122,22 @@ const createSortedTasks = memoize(
   tableHeadCell: {
     color: theme.palette.text.secondary,
   },
+  tableSecondHeadCell: {
+    display: 'flex',
+    flex: 1,
+    justifyContent: 'flex-end',
+  },
   tableRow: {
     display: 'flex',
   },
   tableFirstCell: {
-    flex: 1,
-    [theme.breakpoints.down('sm')]: {
-      minWidth: 0,
-      paddingLeft: 0,
-      paddingRight: theme.spacing.unit,
-    },
+    width: '60%',
   },
   tableSecondCell: {
-    flex: 0.5,
     display: 'flex',
-    flexGrow: 0,
-    flexDirection: 'column',
-    justifyContent: 'center',
-    [theme.breakpoints.down('sm')]: {
-      paddingLeft: 0,
-      paddingRight: '0 !important',
-    },
+    justifyContent: 'flex-end',
+    alignItems: 'center',
+    width: '40%',
   },
   noTasksText: {
     marginTop: theme.spacing(2),
@@ -245,7 +231,9 @@ export default class TaskGroupTable extends Component {
               <Typography variant="body2" className={classes.taskGroupName}>
                 {taskGroup.metadata.name}
               </Typography>
-              <LinkIcon size={iconSize} />
+              <span>
+                <LinkIcon size={iconSize} />
+              </span>
             </Link>
           </TableCell>
           <TableCell
@@ -253,7 +241,9 @@ export default class TaskGroupTable extends Component {
             className={classes.tableSecondCell}
             component="div"
             role="cell">
-            <StatusLabel state={taskGroup.status.state} />
+            <span>
+              <StatusLabel state={taskGroup.status.state} />
+            </span>
           </TableCell>
         </TableRow>
       );
@@ -286,7 +276,11 @@ export default class TaskGroupTable extends Component {
                   Name
                 </TableSortLabel>
               </TableCell>
-              <TableCell size="small" component="div" role="columnheader">
+              <TableCell
+                size="small"
+                component="div"
+                role="columnheader"
+                className={classes.tableSecondHeadCell}>
                 <TableSortLabel
                   className={classes.tableHeadCell}
                   id="Status"

--- a/ui/src/components/TaskGroupTable/index.jsx
+++ b/ui/src/components/TaskGroupTable/index.jsx
@@ -94,6 +94,10 @@ const createSortedTasks = memoize(
     textDecoration: 'none',
     ...theme.mixins.hover,
     ...theme.mixins.listItemButton,
+    [theme.breakpoints.down('sm')]: {
+      paddingLeft: 0,
+      paddingRight: 0,
+    },
   },
   taskGroupName: {
     marginRight: theme.spacing(1),
@@ -103,6 +107,10 @@ const createSortedTasks = memoize(
     textOverflow: 'ellipsis',
     verticalAlign: 'middle',
     display: 'inline-block',
+    [theme.breakpoints.down('sm')]: {
+      maxWidth: '90%',
+      marginRight: theme.spacing.unit * 0.5,
+    },
   },
   table: {
     marginBottom: theme.spacing(1),
@@ -128,6 +136,11 @@ const createSortedTasks = memoize(
   },
   tableFirstCell: {
     flex: 1,
+    [theme.breakpoints.down('sm')]: {
+      minWidth: 0,
+      paddingLeft: 0,
+      paddingRight: theme.spacing.unit,
+    },
   },
   tableSecondCell: {
     flex: 0.5,
@@ -135,6 +148,10 @@ const createSortedTasks = memoize(
     flexGrow: 0,
     flexDirection: 'column',
     justifyContent: 'center',
+    [theme.breakpoints.down('sm')]: {
+      paddingLeft: 0,
+      paddingRight: '0 !important',
+    },
   },
   noTasksText: {
     marginTop: theme.spacing(2),


### PR DESCRIPTION
Github Bug/Issue: Fixes #1908

The only page I found with the issue is the page that displays a Task Group. Please let me know if I missed another page with the same issue.

I added breakpoints for small devices to remove extra padding on the right and left sides of the table being displayed and made it so the entire status is visible and the name takes up the rest of the space.

Result: 
![make-status-more-visible-on-mobile](https://user-images.githubusercontent.com/2024584/68540890-75169200-034d-11ea-94a2-ff15a23b7a2f.png)
