### PR TITLE
Dependencies not shown when a task doesn't have a decision task

### DIFF
--- a/changelog/bug-1595418.md
+++ b/changelog/bug-1595418.md
@@ -1,0 +1,5 @@
+level: patch
+reference: bug 1595418
+---
+Taskcluster UI now properly shows task dependencies of tasks that don't have a decision task.
+A task with no decision task is a common thing to have outside the firefox-ci cluster.

--- a/services/web-server/src/loaders/tasks.js
+++ b/services/web-server/src/loaders/tasks.js
@@ -3,16 +3,15 @@ const sift = require('../utils/sift');
 const fetch = require('../utils/fetch');
 const ConnectionLoader = require('../ConnectionLoader');
 const Task = require('../entities/Task');
+const tryCatch = require('../utils/tryCatch');
 
 module.exports = ({ queue, index }) => {
   const task = new DataLoader(taskIds =>
-    Promise.all(
-      taskIds.map(async taskId => {
-        const task = await queue.task(taskId);
+    Promise.all(taskIds.map(async (taskId) => {
+      const [error, task] = await tryCatch(queue.task(taskId));
 
-        return new Task(taskId, null, task);
-      }),
-    ),
+      return error || new Task(taskId, null, task);
+    })),
   );
   const indexedTask = new DataLoader(indexPaths =>
     Promise.all(indexPaths.map(indexPath => index.findTask(indexPath))),

--- a/services/web-server/src/loaders/tasks.js
+++ b/services/web-server/src/loaders/tasks.js
@@ -3,14 +3,15 @@ const sift = require('../utils/sift');
 const fetch = require('../utils/fetch');
 const ConnectionLoader = require('../ConnectionLoader');
 const Task = require('../entities/Task');
-const tryCatch = require('../utils/tryCatch');
 
 module.exports = ({ queue, index }) => {
   const task = new DataLoader(taskIds =>
     Promise.all(taskIds.map(async (taskId) => {
-      const [error, task] = await tryCatch(queue.task(taskId));
-
-      return error || new Task(taskId, null, task);
+      try {
+        return new Task(taskId, null, await queue.task(taskId));
+      } catch (err) {
+        return err;
+      }
     })),
   );
   const indexedTask = new DataLoader(indexPaths =>


### PR DESCRIPTION
Fixes https://bugzilla.mozilla.org/show_bug.cgi?id=1595418 and https://bugzilla.mozilla.org/show_bug.cgi?id=1595506. 