### PR TITLE
[docs] update devdocs

### DIFF
--- a/changelog/issue-1946.md
+++ b/changelog/issue-1946.md
@@ -1,0 +1,3 @@
+level: silent
+reference: issue 1946
+---

--- a/dev-docs/development-process.md
+++ b/dev-docs/development-process.md
@@ -49,7 +49,7 @@ To run the Taskcluster UI:
     For example:
 
     ```sh
-    export TASKCLUSTER_ROOT_URL=https://taskcluster.net
+    export TASKCLUSTER_ROOT_URL=https://community-tc.services.mozilla.com
     ```
   * Change to the `services/web-server` directory and run `yarn start`.
     This will start a web server on port 3050.


### PR DESCRIPTION
Change `export TASKCLUSTER_ROOT_URL=https://taskcluster.net` to `export TASKCLUSTER_ROOT_URL=https://community-tc.services.mozilla.com`

Closes  #1946 