### PR TITLE
Bug 1574854 - Remove "404" from pages not found

### DIFF
--- a/changelog/bug-1574854.md
+++ b/changelog/bug-1574854.md
@@ -1,0 +1,4 @@
+level: patch
+reference: bug 1574854
+---
+Taskcluster UI now does not show a "404" text when a page could not be found in the UI so as not to pretend an HTTP response code that didn't occur.

--- a/ui/src/components/NotFound/index.jsx
+++ b/ui/src/components/NotFound/index.jsx
@@ -45,9 +45,6 @@ export default class NotFound extends Component {
 
     return (
       <div className={classes.root}>
-        <Typography variant="h1" className={classes.typography}>
-          404
-        </Typography>
         <Typography variant="h4" className={classes.typography}>
           We couldn&apos;t find a page at that address.
           <br />


### PR DESCRIPTION
Bugzilla Bug: [1574854](https://bugzilla.mozilla.org/show_bug.cgi?id=1574854)