### PR TITLE
Bug 1585141 - remove references to aws-provisioner-v1

### DIFF
--- a/changelog/bug-1585141.md
+++ b/changelog/bug-1585141.md
@@ -1,0 +1,3 @@
+level: silent
+reference: bug 1585141
+---

--- a/clients/client-go/README.md
+++ b/clients/client-go/README.md
@@ -482,7 +482,7 @@ func main() {
 		},
 		Payload:       *payloadJSON,
 		Priority:      "normal",
-		ProvisionerID: "aws-provisioner-v1",
+		ProvisionerID: "some-provisioner-id",
 		Requires:      "all-completed",
 		Retries:       5,
 		Routes:        []string{},
@@ -490,7 +490,7 @@ func main() {
 		Scopes:        []string{},
 		Tags:          map[string]string{},
 		TaskGroupID:   taskID,
-		WorkerType:    "win2012r2",
+		WorkerType:    "some-worker-type",
 	}
 
 	tsr, err := myQueue.CreateTask(taskID, taskDef)

--- a/clients/client-go/tcqueue/tcqueue.go
+++ b/clients/client-go/tcqueue/tcqueue.go
@@ -849,9 +849,9 @@ func (queue *Queue) GetProvisioner(provisionerId string) (*ProvisionerResponse, 
 // Declare a provisioner, supplying some details about it.
 //
 // `declareProvisioner` allows updating one or more properties of a provisioner as long as the required scopes are
-// possessed. For example, a request to update the `aws-provisioner-v1`
+// possessed. For example, a request to update the `my-provisioner`
 // provisioner with a body `{description: 'This provisioner is great'}` would require you to have the scope
-// `queue:declare-provisioner:aws-provisioner-v1#description`.
+// `queue:declare-provisioner:my-provisioner#description`.
 //
 // The term "provisioner" is taken broadly to mean anything with a provisionerId.
 // This does not necessarily mean there is an associated service performing any
@@ -921,9 +921,9 @@ func (queue *Queue) GetWorkerType(provisionerId, workerType string) (*WorkerType
 // Declare a workerType, supplying some details about it.
 //
 // `declareWorkerType` allows updating one or more properties of a worker-type as long as the required scopes are
-// possessed. For example, a request to update the `gecko-b-1-w2008` worker-type within the `aws-provisioner-v1`
+// possessed. For example, a request to update the `highmem` worker-type within the `my-provisioner`
 // provisioner with a body `{description: 'This worker type is great'}` would require you to have the scope
-// `queue:declare-worker-type:aws-provisioner-v1/gecko-b-1-w2008#description`.
+// `queue:declare-worker-type:my-provisioner/highmem#description`.
 //
 // Required scopes:
 //   For property in properties each queue:declare-worker-type:<provisionerId>/<workerType>#<property>

--- a/clients/client-py/README.md
+++ b/clients/client-py/README.md
@@ -3717,9 +3717,9 @@ await asyncQueue.getProvisioner(provisionerId='value') # -> result
 Declare a provisioner, supplying some details about it.
 
 `declareProvisioner` allows updating one or more properties of a provisioner as long as the required scopes are
-possessed. For example, a request to update the `aws-provisioner-v1`
+possessed. For example, a request to update the `my-provisioner`
 provisioner with a body `{description: 'This provisioner is great'}` would require you to have the scope
-`queue:declare-provisioner:aws-provisioner-v1#description`.
+`queue:declare-provisioner:my-provisioner#description`.
 
 The term "provisioner" is taken broadly to mean anything with a provisionerId.
 This does not necessarily mean there is an associated service performing any
@@ -3821,9 +3821,9 @@ await asyncQueue.getWorkerType(provisionerId='value', workerType='value') # -> r
 Declare a workerType, supplying some details about it.
 
 `declareWorkerType` allows updating one or more properties of a worker-type as long as the required scopes are
-possessed. For example, a request to update the `gecko-b-1-w2008` worker-type within the `aws-provisioner-v1`
+possessed. For example, a request to update the `highmem` worker-type within the `my-provisioner`
 provisioner with a body `{description: 'This worker type is great'}` would require you to have the scope
-`queue:declare-worker-type:aws-provisioner-v1/gecko-b-1-w2008#description`.
+`queue:declare-worker-type:my-provisioner/highmem#description`.
 
 
 

--- a/clients/client-py/taskcluster/generated/aio/queue.py
+++ b/clients/client-py/taskcluster/generated/aio/queue.py
@@ -641,9 +641,9 @@ class Queue(AsyncBaseClient):
         Declare a provisioner, supplying some details about it.
 
         `declareProvisioner` allows updating one or more properties of a provisioner as long as the required scopes are
-        possessed. For example, a request to update the `aws-provisioner-v1`
+        possessed. For example, a request to update the `my-provisioner`
         provisioner with a body `{description: 'This provisioner is great'}` would require you to have the scope
-        `queue:declare-provisioner:aws-provisioner-v1#description`.
+        `queue:declare-provisioner:my-provisioner#description`.
 
         The term "provisioner" is taken broadly to mean anything with a provisionerId.
         This does not necessarily mean there is an associated service performing any
@@ -705,9 +705,9 @@ class Queue(AsyncBaseClient):
         Declare a workerType, supplying some details about it.
 
         `declareWorkerType` allows updating one or more properties of a worker-type as long as the required scopes are
-        possessed. For example, a request to update the `gecko-b-1-w2008` worker-type within the `aws-provisioner-v1`
+        possessed. For example, a request to update the `highmem` worker-type within the `my-provisioner`
         provisioner with a body `{description: 'This worker type is great'}` would require you to have the scope
-        `queue:declare-worker-type:aws-provisioner-v1/gecko-b-1-w2008#description`.
+        `queue:declare-worker-type:my-provisioner/highmem#description`.
 
         This method is ``experimental``
         """

--- a/clients/client-py/taskcluster/generated/queue.py
+++ b/clients/client-py/taskcluster/generated/queue.py
@@ -641,9 +641,9 @@ class Queue(BaseClient):
         Declare a provisioner, supplying some details about it.
 
         `declareProvisioner` allows updating one or more properties of a provisioner as long as the required scopes are
-        possessed. For example, a request to update the `aws-provisioner-v1`
+        possessed. For example, a request to update the `my-provisioner`
         provisioner with a body `{description: 'This provisioner is great'}` would require you to have the scope
-        `queue:declare-provisioner:aws-provisioner-v1#description`.
+        `queue:declare-provisioner:my-provisioner#description`.
 
         The term "provisioner" is taken broadly to mean anything with a provisionerId.
         This does not necessarily mean there is an associated service performing any
@@ -705,9 +705,9 @@ class Queue(BaseClient):
         Declare a workerType, supplying some details about it.
 
         `declareWorkerType` allows updating one or more properties of a worker-type as long as the required scopes are
-        possessed. For example, a request to update the `gecko-b-1-w2008` worker-type within the `aws-provisioner-v1`
+        possessed. For example, a request to update the `highmem` worker-type within the `my-provisioner`
         provisioner with a body `{description: 'This worker type is great'}` would require you to have the scope
-        `queue:declare-worker-type:aws-provisioner-v1/gecko-b-1-w2008#description`.
+        `queue:declare-worker-type:my-provisioner/highmem#description`.
 
         This method is ``experimental``
         """

--- a/clients/client-shell/apis/services.go
+++ b/clients/client-shell/apis/services.go
@@ -1311,7 +1311,7 @@ var services = map[string]definitions.Service{
 			definitions.Entry{
 				Name:        "declareProvisioner",
 				Title:       "Update a provisioner",
-				Description: "Declare a provisioner, supplying some details about it.\n\n`declareProvisioner` allows updating one or more properties of a provisioner as long as the required scopes are\npossessed. For example, a request to update the `aws-provisioner-v1`\nprovisioner with a body `{description: 'This provisioner is great'}` would require you to have the scope\n`queue:declare-provisioner:aws-provisioner-v1#description`.\n\nThe term \"provisioner\" is taken broadly to mean anything with a provisionerId.\nThis does not necessarily mean there is an associated service performing any\nprovisioning activity.",
+				Description: "Declare a provisioner, supplying some details about it.\n\n`declareProvisioner` allows updating one or more properties of a provisioner as long as the required scopes are\npossessed. For example, a request to update the `my-provisioner`\nprovisioner with a body `{description: 'This provisioner is great'}` would require you to have the scope\n`queue:declare-provisioner:my-provisioner#description`.\n\nThe term \"provisioner\" is taken broadly to mean anything with a provisionerId.\nThis does not necessarily mean there is an associated service performing any\nprovisioning activity.",
 				Stability:   "experimental",
 				Method:      "put",
 				Route:       "/provisioners/<provisionerId>",
@@ -1368,7 +1368,7 @@ var services = map[string]definitions.Service{
 			definitions.Entry{
 				Name:        "declareWorkerType",
 				Title:       "Update a worker-type",
-				Description: "Declare a workerType, supplying some details about it.\n\n`declareWorkerType` allows updating one or more properties of a worker-type as long as the required scopes are\npossessed. For example, a request to update the `gecko-b-1-w2008` worker-type within the `aws-provisioner-v1`\nprovisioner with a body `{description: 'This worker type is great'}` would require you to have the scope\n`queue:declare-worker-type:aws-provisioner-v1/gecko-b-1-w2008#description`.",
+				Description: "Declare a workerType, supplying some details about it.\n\n`declareWorkerType` allows updating one or more properties of a worker-type as long as the required scopes are\npossessed. For example, a request to update the `highmem` worker-type within the `my-provisioner`\nprovisioner with a body `{description: 'This worker type is great'}` would require you to have the scope\n`queue:declare-worker-type:my-provisioner/highmem#description`.",
 				Stability:   "experimental",
 				Method:      "put",
 				Route:       "/provisioners/<provisionerId>/worker-types/<workerType>",

--- a/clients/client-shell/cmds/group/actors_test.go
+++ b/clients/client-shell/cmds/group/actors_test.go
@@ -70,8 +70,8 @@ func listTaskGroupHandler(w http.ResponseWriter, _ *http.Request) {
 			    {
 			      "status": {
 			        "taskId": "ANnmjMocTymeTID0tlNJAw",
-			        "provisionerId": "aws-provisioner-v1",
-			        "workerType": "github-worker",
+			        "provisionerId": "some-provisioner-id",
+			        "workerType": "some-worker-type",
 			        "schedulerId": "taskcluster-github",
 			        "taskGroupId": "e4WPJRJeSdaSdKxeWzDlNQ",
 			        "deadline": "2017-03-30T15:49:31.389Z",

--- a/clients/client-web/src/clients/Queue.js
+++ b/clients/client-web/src/clients/Queue.js
@@ -525,9 +525,9 @@ export default class Queue extends Client {
   /* eslint-disable max-len */
   // Declare a provisioner, supplying some details about it.
   // `declareProvisioner` allows updating one or more properties of a provisioner as long as the required scopes are
-  // possessed. For example, a request to update the `aws-provisioner-v1`
+  // possessed. For example, a request to update the `my-provisioner`
   // provisioner with a body `{description: 'This provisioner is great'}` would require you to have the scope
-  // `queue:declare-provisioner:aws-provisioner-v1#description`.
+  // `queue:declare-provisioner:my-provisioner#description`.
   // The term "provisioner" is taken broadly to mean anything with a provisionerId.
   // This does not necessarily mean there is an associated service performing any
   // provisioning activity.
@@ -573,9 +573,9 @@ export default class Queue extends Client {
   /* eslint-disable max-len */
   // Declare a workerType, supplying some details about it.
   // `declareWorkerType` allows updating one or more properties of a worker-type as long as the required scopes are
-  // possessed. For example, a request to update the `gecko-b-1-w2008` worker-type within the `aws-provisioner-v1`
+  // possessed. For example, a request to update the `highmem` worker-type within the `my-provisioner`
   // provisioner with a body `{description: 'This worker type is great'}` would require you to have the scope
-  // `queue:declare-worker-type:aws-provisioner-v1/gecko-b-1-w2008#description`.
+  // `queue:declare-worker-type:my-provisioner/highmem#description`.
   /* eslint-enable max-len */
   declareWorkerType(...args) {
     this.validate(this.declareWorkerType.entry, args);

--- a/clients/client/src/apis.js
+++ b/clients/client/src/apis.js
@@ -2911,7 +2911,7 @@ module.exports = {
             "provisionerId"
           ],
           "category": "Queue Service",
-          "description": "Declare a provisioner, supplying some details about it.\n\n`declareProvisioner` allows updating one or more properties of a provisioner as long as the required scopes are\npossessed. For example, a request to update the `aws-provisioner-v1`\nprovisioner with a body `{description: 'This provisioner is great'}` would require you to have the scope\n`queue:declare-provisioner:aws-provisioner-v1#description`.\n\nThe term \"provisioner\" is taken broadly to mean anything with a provisionerId.\nThis does not necessarily mean there is an associated service performing any\nprovisioning activity.",
+          "description": "Declare a provisioner, supplying some details about it.\n\n`declareProvisioner` allows updating one or more properties of a provisioner as long as the required scopes are\npossessed. For example, a request to update the `my-provisioner`\nprovisioner with a body `{description: 'This provisioner is great'}` would require you to have the scope\n`queue:declare-provisioner:my-provisioner#description`.\n\nThe term \"provisioner\" is taken broadly to mean anything with a provisionerId.\nThis does not necessarily mean there is an associated service performing any\nprovisioning activity.",
           "input": "v1/update-provisioner-request.json#",
           "method": "put",
           "name": "declareProvisioner",
@@ -2990,7 +2990,7 @@ module.exports = {
             "workerType"
           ],
           "category": "Queue Service",
-          "description": "Declare a workerType, supplying some details about it.\n\n`declareWorkerType` allows updating one or more properties of a worker-type as long as the required scopes are\npossessed. For example, a request to update the `gecko-b-1-w2008` worker-type within the `aws-provisioner-v1`\nprovisioner with a body `{description: 'This worker type is great'}` would require you to have the scope\n`queue:declare-worker-type:aws-provisioner-v1/gecko-b-1-w2008#description`.",
+          "description": "Declare a workerType, supplying some details about it.\n\n`declareWorkerType` allows updating one or more properties of a worker-type as long as the required scopes are\npossessed. For example, a request to update the `highmem` worker-type within the `my-provisioner`\nprovisioner with a body `{description: 'This worker type is great'}` would require you to have the scope\n`queue:declare-worker-type:my-provisioner/highmem#description`.",
           "input": "v1/update-workertype-request.json#",
           "method": "put",
           "name": "declareWorkerType",

--- a/generated/references.json
+++ b/generated/references.json
@@ -10102,7 +10102,7 @@
             "provisionerId"
           ],
           "category": "Queue Service",
-          "description": "Declare a provisioner, supplying some details about it.\n\n`declareProvisioner` allows updating one or more properties of a provisioner as long as the required scopes are\npossessed. For example, a request to update the `aws-provisioner-v1`\nprovisioner with a body `{description: 'This provisioner is great'}` would require you to have the scope\n`queue:declare-provisioner:aws-provisioner-v1#description`.\n\nThe term \"provisioner\" is taken broadly to mean anything with a provisionerId.\nThis does not necessarily mean there is an associated service performing any\nprovisioning activity.",
+          "description": "Declare a provisioner, supplying some details about it.\n\n`declareProvisioner` allows updating one or more properties of a provisioner as long as the required scopes are\npossessed. For example, a request to update the `my-provisioner`\nprovisioner with a body `{description: 'This provisioner is great'}` would require you to have the scope\n`queue:declare-provisioner:my-provisioner#description`.\n\nThe term \"provisioner\" is taken broadly to mean anything with a provisionerId.\nThis does not necessarily mean there is an associated service performing any\nprovisioning activity.",
           "input": "v1/update-provisioner-request.json#",
           "method": "put",
           "name": "declareProvisioner",
@@ -10181,7 +10181,7 @@
             "workerType"
           ],
           "category": "Queue Service",
-          "description": "Declare a workerType, supplying some details about it.\n\n`declareWorkerType` allows updating one or more properties of a worker-type as long as the required scopes are\npossessed. For example, a request to update the `gecko-b-1-w2008` worker-type within the `aws-provisioner-v1`\nprovisioner with a body `{description: 'This worker type is great'}` would require you to have the scope\n`queue:declare-worker-type:aws-provisioner-v1/gecko-b-1-w2008#description`.",
+          "description": "Declare a workerType, supplying some details about it.\n\n`declareWorkerType` allows updating one or more properties of a worker-type as long as the required scopes are\npossessed. For example, a request to update the `highmem` worker-type within the `my-provisioner`\nprovisioner with a body `{description: 'This worker type is great'}` would require you to have the scope\n`queue:declare-worker-type:my-provisioner/highmem#description`.",
           "input": "v1/update-workertype-request.json#",
           "method": "put",
           "name": "declareWorkerType",

--- a/libraries/scopes/README.md
+++ b/libraries/scopes/README.md
@@ -179,12 +179,12 @@ that one set of scopes must be completely satisfied.
 
 ```js
 let myScopes = [
-    'queue:create-task:aws-provisioner-v1/*',
+    'queue:create-task:some-provisioner-id/*',
     'secrets:get:garbage/my-secrets/*',
 ]
 assert(scopeUtils.scopeMatch(myScopes, [
     // either both of these scopes must be satisfied
-    ['queue:create-task:aws-provisioner-v1/my-worker', 'secrets:get:garbage/my-secrets/xx'],
+    ['queue:create-task:some-provisioner-id/my-worker', 'secrets:get:garbage/my-secrets/xx'],
     // or this scope
     ['some-other-scope'],
 ])

--- a/services/github/config.yml
+++ b/services/github/config.yml
@@ -61,8 +61,8 @@ production:
     initialStatusQueue: 'ch-init'
 
   intree:
-    provisionerId: 'aws-provisioner-v1'
-    workerType: 'github-worker'
+    provisionerId: 'default-provisioner'
+    workerType: 'default'
 
   server:
     env: 'production'
@@ -86,10 +86,6 @@ staging:
     ownersDirectoryTableName: 'TaskclusterIntegrationOwnersStaging'
     name: 'tc-github-staging'
     statusContext: 'Taskcluster-Staging'
-
-  intree:
-    provisionerId: 'aws-provisioner-v1'
-    workerType: 'github-worker'
 
   server:
     env: 'production'

--- a/services/github/test/data/configs/taskcluster.dependencies.v1.yml
+++ b/services/github/test/data/configs/taskcluster.dependencies.v1.yml
@@ -8,7 +8,7 @@ tasks:
       dependencies:
       - "py36"
       - "py37"
-      provisionerId: aws-provisioner-v1
+      provisionerId: test-provisioner
       workerType: releng-svc
       created: {$fromNow: ''}
       deadline: {$fromNow: '1 hour'}
@@ -22,7 +22,7 @@ tasks:
         source: source
 
     - taskId: "py36"
-      provisionerId: aws-provisioner-v1
+      provisionerId: test-provisioner
       workerType: github-worker
       created: {$fromNow: ''}
       deadline: {$fromNow: '1 hour'}
@@ -40,7 +40,7 @@ tasks:
     - taskId: "docker_push"
       dependencies:
       - "docker_build"
-      provisionerId: aws-provisioner-v1
+      provisionerId: test-provisioner
       workerType: releng-svc
       created: {$fromNow: ''}
       deadline: {$fromNow: '1 hour'}
@@ -54,7 +54,7 @@ tasks:
         source: source
 
     - taskId: "py37"
-      provisionerId: aws-provisioner-v1
+      provisionerId: test-provisioner
       workerType: github-worker
       created: {$fromNow: ''}
       deadline: {$fromNow: '1 hour'}

--- a/services/hooks/test/validate_test/create-hook-request.json
+++ b/services/hooks/test/validate_test/create-hook-request.json
@@ -7,7 +7,7 @@
     },
     "task":
     {
-        "provisionerId": "aws-provisioner-v1",
+        "provisionerId": "test-provisioner",
         "workerType": "gecko-t-linux-xlarge",
         "payload": {},
         "metadata": {

--- a/services/notify/test/handler_test.js
+++ b/services/notify/test/handler_test.js
@@ -40,7 +40,7 @@ helper.secrets.mockSuite(testing.suiteName(), ['azure', 'aws'], function(mock, s
 
   let baseStatus = {
     taskId: 'DKPZPsvvQEiw67Pb3rkdNg',
-    provisionerId: 'aws-provisioner-v1',
+    provisionerId: 'test-provisioner',
     workerType: 'gecko-t-win7-32-gpu',
     schedulerId: 'gecko-level-3',
     taskGroupId: 'NA3wajh1SQ-yVPlNUO8OYw',

--- a/services/queue/src/api.js
+++ b/services/queue/src/api.js
@@ -2125,9 +2125,9 @@ builder.declare({
     'Declare a provisioner, supplying some details about it.',
     '',
     '`declareProvisioner` allows updating one or more properties of a provisioner as long as the required scopes are',
-    'possessed. For example, a request to update the `aws-provisioner-v1`',
+    'possessed. For example, a request to update the `my-provisioner`',
     'provisioner with a body `{description: \'This provisioner is great\'}` would require you to have the scope',
-    '`queue:declare-provisioner:aws-provisioner-v1#description`.',
+    '`queue:declare-provisioner:my-provisioner#description`.',
     '',
     'The term "provisioner" is taken broadly to mean anything with a provisionerId.',
     'This does not necessarily mean there is an associated service performing any',
@@ -2285,9 +2285,9 @@ builder.declare({
     'Declare a workerType, supplying some details about it.',
     '',
     '`declareWorkerType` allows updating one or more properties of a worker-type as long as the required scopes are',
-    'possessed. For example, a request to update the `gecko-b-1-w2008` worker-type within the `aws-provisioner-v1`',
+    'possessed. For example, a request to update the `highmem` worker-type within the `my-provisioner`',
     'provisioner with a body `{description: \'This worker type is great\'}` would require you to have the scope',
-    '`queue:declare-worker-type:aws-provisioner-v1/gecko-b-1-w2008#description`.',
+    '`queue:declare-worker-type:my-provisioner/highmem#description`.',
   ].join('\n'),
 }, async function(req, res) {
   const {provisionerId, workerType} = req.params;

--- a/services/web-server/README.md
+++ b/services/web-server/README.md
@@ -144,8 +144,8 @@ Variables:
 {
   "taskId": "fN1SbArXTPSVFNUvaOlinQ",
   "task": {
-    "provisionerId": "aws-provisioner-v1",
-    "workerType": "tutorial",
+    "provisionerId": "test-provisioner",
+    "workerType": "highcpu",
     "retries": 0,
     "created": "2018-03-07T05:53:06.683Z",
     "deadline": "2018-03-07T06:03:06.683Z",

--- a/ui/docs/manual/tasks/README.mdx
+++ b/ui/docs/manual/tasks/README.mdx
@@ -20,17 +20,17 @@ documentation](/docs/reference/platform/queue/task-schema), but a
 simple task might look like this:
 
 ```yaml
-provisionerId:      aws-provisioner-v1
+provisionerId:      proj-getting-started
 workerType:         tutorial
 created:            2020-01-04T04:18.084Z
 deadline:           2020-01-05T04:18.084Z
 metadata:
   name:             Example Task
   description:      Eample from TC Manual
-  owner:            nobody@taskcluster.net
-  source:           https://github.com/taskcluster/taskcluster-docs
+  owner:            nobody@example.com
+  source:           https://github.com/taskcluster/taskcluster
 payload:
-  image:            ubuntu:16.04
+  image:            ubuntu:18.04
   command:          ['echo', 'hello world']
 ```
 

--- a/ui/docs/manual/using/scheduled-tasks.mdx
+++ b/ui/docs/manual/using/scheduled-tasks.mdx
@@ -34,8 +34,8 @@ The scopes actually used by the hook's task are, of course, defined in
 include `queue:create-task:<provisionerId>/<workerType>` unless the task will
 be creating more tasks (for example, a [decision task](/docs/manual/conventions/decision-task)).
 
-For the documentation repository, the hook is named `taskcluster/docs-update`.
-The task has scopes
+For example, at one time the Taskcluster documentation was updated by a hook named `taskcluster/docs-update`.
+The task had scopes
 
 ```yaml
 task:
@@ -45,14 +45,14 @@ task:
     - "secrets:get:project/taskcluster/tc-docs/mozillians"
 ```
 
-and the hook role has those scopes plus the required `create-task` scope:
+and the hook role had those scopes plus the required `create-task` scope:
 
 ```yaml
 "hook-id:taskcluster/docs-update":
   - "auth:aws-s3:read-only:taskcluster-raw-docs/*"
   - "auth:aws-s3:read-write:docs-taskcluster-net/"
   - "secrets:get:project/taskcluster/tc-docs/mozillians"
-  - "queue:create-task:aws-provisioner-v1/github-worker"
+  - "queue:create-task:aws-provisioner/taskcluster"
 ```
 
 ## Advice

--- a/ui/docs/reference/integrations/github/taskcluster-yml-v1.mdx
+++ b/ui/docs/reference/integrations/github/taskcluster-yml-v1.mdx
@@ -231,8 +231,8 @@ tasks:
   $match:
     'tasks_for == "github-pull-request" && event["action"] in ["opened", "reopened", "synchronize"]':
       taskId: {$eval: as_slugid("pr_task")}
-      provisionerId: aws-provisioner-v1
-      workerType: github-worker
+      provisionerId: proj-taskcluster
+      workerType: ci
       scopes:
         - secrets:get:project/taskcluster/testing/taskcluster-github
       payload:
@@ -253,8 +253,8 @@ tasks:
         source: ${event.repository.url}
     'tasks_for == "github-push"':
       taskId: {$eval: as_slugid("push_task")}
-      provisionerId: aws-provisioner-v1
-      workerType: github-worker
+      provisionerId: proj-taskcluster
+      workerType: ci
       scopes:
         - secrets:get:project/taskcluster/testing/taskcluster-github
       payload:

--- a/ui/docs/reference/platform/auth/scopes.mdx
+++ b/ui/docs/reference/platform/auth/scopes.mdx
@@ -11,8 +11,8 @@ scopes. For example:
 
 ```js
 [
-    "queue:create-task:aws-provisioner-v1/tutorial",
-    "queue:route:index.garbage.*",
+    "queue:create-task:proj-getting-started/tutorial",
+    "queue:route:index.tutorial.*",
 ]
 ```
 

--- a/ui/docs/tutorial/authenticate.mdx
+++ b/ui/docs/tutorial/authenticate.mdx
@@ -46,7 +46,7 @@ provides a tool that can do all of the above for you.
 See [#1619](https://github.com/taskcluster/taskcluster/pull/1619) for progress.</Warning>
 
 ```
-$ eval `taskcluster signin --scope queue:create-task:aws-provisioner-v1/tutorial`
+$ eval `taskcluster signin --scope queue:create-task:proj-getting-started/tutorial`
 Starting
 Listening for a callback on: http://localhost:37885
 Opening URL: https://tc.example.com/auth/clients/new?name=cli&description=Temporary+client+for+use+on+the+command+line&scope=*&expires=1d&callback_url=http%3A%2F%2Flocalhost%3A37885
@@ -59,7 +59,7 @@ You can test the results with the same tool:
 $ ./taskcluster api auth currentScopes
 {
     "scopes": [
-        "queue:create-task:aws-provisioner-v1/tutorial"
+        "queue:create-task:proj-getting-started/tutorial"
     ]
 }
 ```

--- a/ui/docs/tutorial/monitor-task-status.mdx
+++ b/ui/docs/tutorial/monitor-task-status.mdx
@@ -40,7 +40,7 @@ let payload = {
 };
 
 let task = {
-  provisionerId:      'aws-provisioner-v1',
+  provisionerId:      'proj-getting-started',
   workerType:         'tutorial',
   created:            taskcluster.fromNowJSON('0 seconds'),
   deadline:           taskcluster.fromNowJSON('2 days 3 hours'),

--- a/ui/src/components/HookForm/index.jsx
+++ b/ui/src/components/HookForm/index.jsx
@@ -45,10 +45,10 @@ const initialHook = {
   schedule: [],
   bindings: [],
   task: {
-    provisionerId: 'aws-provisioner-v1',
+    provisionerId: 'proj-getting-started',
     workerType: 'tutorial',
     payload: {
-      image: 'ubuntu:14.04',
+      image: 'ubuntu:latest',
       command: ['/bin/bash', '-c', 'echo "hello World"'],
       maxRunTime: 60 * 10,
     },

--- a/ui/src/views/Quickstart/index.jsx
+++ b/ui/src/views/Quickstart/index.jsx
@@ -35,8 +35,8 @@ const taskDefinition = {
   tasks: {
     $match: {
       taskId: { $eval: 'as_slugid("pr_task")' },
-      provisionerId: 'aws-provisioner-v1',
-      workerType: 'github-worker',
+      provisionerId: 'proj-getting-started',
+      workerType: 'tutorial',
       payload: {
         maxRunTime: 3600,
         image: 'node',

--- a/ui/src/views/Tasks/CreateTask/index.jsx
+++ b/ui/src/views/Tasks/CreateTask/index.jsx
@@ -42,7 +42,7 @@ import Button from '../../../components/Button';
 import db from '../../../utils/db';
 
 const defaultTask = {
-  provisionerId: 'aws-provisioner-v1',
+  provisionerId: 'proj-getting-started',
   workerType: 'tutorial',
   created: new Date().toISOString(),
   deadline: toDate(addHours(new Date(), 3)).toISOString(),


### PR DESCRIPTION
Bugzilla Bug: [1585141](https://bugzilla.mozilla.org/show_bug.cgi?id=1585141)

We could consider, in a followup, and once the workerPoolId / taskQueueId stuff is done, making a top-level `default_worker_pool_id` config that is passed to tc-github and the UI and used to generate these default tasks.