### PR TITLE
Bug 1596171 - default to schedulerId taskcluster-ui in task-creator

### DIFF
--- a/changelog/bug-1596171.md
+++ b/changelog/bug-1596171.md
@@ -1,0 +1,3 @@
+level: silent
+reference: bug 1596171
+---

--- a/ui/src/views/Tasks/CreateTask/index.jsx
+++ b/ui/src/views/Tasks/CreateTask/index.jsx
@@ -46,10 +46,11 @@ import db from '../../../utils/db';
 const defaultTask = {
   provisionerId: 'proj-getting-started',
   workerType: 'tutorial',
+  schedulerId: 'taskcluster-ui',
   created: new Date().toISOString(),
   deadline: toDate(addHours(new Date(), 3)).toISOString(),
   payload: {
-    image: 'ubuntu:13.10',
+    image: 'ubuntu:latest',
     command: [
       '/bin/bash',
       '-c',
@@ -59,8 +60,8 @@ const defaultTask = {
     maxRunTime: 600 + 30,
   },
   metadata: {
-    name: 'Example Task',
-    description: 'Markdown description of **what** this task does',
+    name: 'example-task',
+    description: 'An **example** task',
     owner: 'name@example.com',
     source: `${window.location.origin}/tasks/create`,
   },


### PR DESCRIPTION
Bugzilla Bug: [1596171](https://bugzilla.mozilla.org/show_bug.cgi?id=1596171)

