### PR TITLE
Wrap async callbacks functions to call done(..)

### DIFF
--- a/changelog/GNPpHu8QTT6LQ73vfWmIrw.md
+++ b/changelog/GNPpHu8QTT6LQ73vfWmIrw.md
@@ -1,0 +1,2 @@
+level: silent
+---

--- a/services/web-server/src/utils/unpromisify.js
+++ b/services/web-server/src/utils/unpromisify.js
@@ -1,7 +1,8 @@
 /**
  * Wrap an async `fn` in such a way that it can act as a function taking a callback
  * as its last argument.  That callback either gets cb(err) for errors, or cb(null, res)
- * or (if returnsArray is true) cb(null, ...res)
+ * or (if returnsArray is true) cb(null, ...res).  The resuting function has the
+ * appropriate arity (one more than the input arity, to account for the 'done' argument)
  */
 module.exports = (fn, {returnsArray} = {}) => {
   // eslint-disable-next-line no-unused-vars

--- a/services/web-server/src/utils/unpromisify.js
+++ b/services/web-server/src/utils/unpromisify.js
@@ -1,0 +1,19 @@
+/**
+ * Wrap an async `fn` in such a way that it can act as a function taking a callback
+ * as its last argument.  That callback either gets cb(err) for errors, or cb(null, res)
+ * or (if returnsArray is true) cb(null, ...res)
+ */
+module.exports = (fn, {returnsArray} = {}) => {
+  // eslint-disable-next-line no-unused-vars
+  const call = (self, args) => {
+    const done = args.pop();
+    Promise.resolve(fn.apply(self, args)).then(
+      returnsArray ? res => done.call(null, null, ...res) : res => done.call(null, null, res),
+      err => done.call(null, err));
+  };
+
+  // preserve arity by generating code..
+  const args = [...new Array(fn.length + 1)].map((_, i) => `arg${i}`);
+  // eslint-disable-next-line no-eval
+  return eval(`const x = function (${args}) { return call(this, [...arguments]); }; x`);
+};

--- a/services/web-server/test/unpromisify_test.js
+++ b/services/web-server/test/unpromisify_test.js
@@ -1,0 +1,57 @@
+const assert = require('assert');
+const unpromisify = require('../src/utils/unpromisify');
+const testing = require('taskcluster-lib-testing');
+
+suite(testing.suiteName(), () => {
+
+  // sleep until the next event-loop round
+  const sleep = () => new Promise(resolve => setTimeout(resolve, 1));
+
+  test('Successful callback', function(done) {
+    const success = unpromisify(async (a, b) => {
+      await sleep();
+      return a + b;
+    });
+    assert.equal(success.length, 3); // a, b, done
+
+    success(10, 20, (err, sum) => {
+      if (err) {
+        return done(err);
+      }
+      assert.equal(sum, 30);
+      done();
+    });
+  });
+
+  test('Successful callback returning an array', function(done) {
+    const success = unpromisify(async (a, b) => {
+      await sleep();
+      return [a + b, a * b];
+    }, {returnsArray: true});
+    assert.equal(success.length, 3); // a, b, done
+
+    success(10, 20, (err, sum, product) => {
+      if (err) {
+        return done(err);
+      }
+      assert.equal(sum, 30);
+      assert.equal(product, 200);
+      done();
+    });
+  });
+
+  test('Unsuccessful callback', function(done) {
+    const success = unpromisify(async () => {
+      await sleep();
+      throw new Error('uhoh');
+    });
+    assert.equal(success.length, 1); // done
+
+    success((err, sum) => {
+      if (!err || !err.toString().match(/uhoh/)) {
+        return done(new Error('expected an error'));
+      }
+      done();
+    });
+  });
+});


### PR DESCRIPTION
I like what this does to oauth2.js -- a simple wrapper that allows use of async functions without any trouble.

The unpromisify.js is pretty gnarly, though.  There appears to be no better way to set a function's arity, and oauth2orize will call functions completely differently based on their arity, so we need to match the original arity including the trailing `done` method.

Like elsewhere, there's one spot in here where I made a function `async` even though it doesn't use `await`, because that allows any thrown exceptions to be treated as Promise rejections.