### PR TITLE
Add Python client helper for easier usage.

### DIFF
--- a/changelog/pr-2028.md
+++ b/changelog/pr-2028.md
@@ -1,0 +1,4 @@
+level: minor
+reference: issue 2028
+---
+Add a Python client helper to ease integration into customers projects.

--- a/changelog/pr-2028.md
+++ b/changelog/pr-2028.md
@@ -1,4 +1,4 @@
 level: minor
 reference: issue 2028
 ---
-Add a Python client helper to ease integration into customers projects.
+The Taskcluster Python client now has helper classes to ease integration into customers' projects.

--- a/clients/client-py/README.md
+++ b/clients/client-py/README.md
@@ -359,6 +359,9 @@ await hooks.ping()
 Supported environment variables are:
 - `TASKCLUSTER_ROOT_URL` to specify your Taskcluster instance base url. You can either use that variable or instanciate `TaskclusterConfig` with the base url.
 - `TASKCLUSTER_CLIENT_ID` & `TASKCLUSTER_ACCESS_TOKEN` to specify your client credentials instead of providing them to `TaskclusterConfig.auth`
+- `TASKCLUSTER_PROXY_URL` to specify the proxy address used to reach Taskcluster in a task. It defaults to `http://taskcluster` when not specified.
+
+For more details on Taskcluster environment variables, [here is the documentation](https://docs.taskcluster.net/docs/manual/design/env-vars).
 
 ### Loading secrets across multiple authentications
 

--- a/clients/client-py/README.md
+++ b/clients/client-py/README.md
@@ -320,7 +320,7 @@ Generally a project using this library will face different use cases and authent
 
 ### Shared authentication
 
-The class `taskcluster.helper.TaskclusterConfig` is made to be instancied once in your project, usually in a top level module. That singleton is then accessed by different parts of your projects, whenever a Taskcluster service is needed.
+The class `taskcluster.helper.TaskclusterConfig` is made to be instantiated once in your project, usually in a top level module. That singleton is then accessed by different parts of your projects, whenever a Taskcluster service is needed.
 
 Here is a sample usage:
 

--- a/clients/client-py/README.md
+++ b/clients/client-py/README.md
@@ -308,6 +308,155 @@ taskcluster.fromNow("1 year", dateObj=dateObject1);
 # datetime.datetime(2018, 1, 21, 17, 59, 0, 328934)
 ```
 
+## Library helpers to easily integrate Taskcluster in your project
+
+The Python Taskcluster client has a module `taskcluster.helper` with utilities which allows you to easily share authentication options across multiple services in your project.
+
+Generally a project using this library will face different use cases and authentication options:
+
+* No authentication for a new contributor without Taskcluster access,
+* Specific client credentials through environment variables on a developer's computer,
+* Taskcluster Proxy when running inside a task.
+
+### Shared authentication
+
+The class `taskcluster.helper.TaskclusterConfig` is made to be instancied once in your project, usually in a top level module. That singleton is then accessed by different parts of your projects, whenever a Taskcluster service is needed.
+
+Here is a sample usage:
+
+1. in `project/__init__.py`, no call to Taskcluster is made at that point:
+
+```python
+from taskcluster.helper import Taskcluster config
+
+tc = TaskclusterConfig('https://community-tc.services.mozilla.com')
+```
+
+2. in `project/boot.py`, we authenticate on Taskcuster with provided credentials, or environment variables, or taskcluster proxy (in that order):
+
+```python
+from project import tc
+
+tc.auth(client_id='XXX', access_token='YYY')
+```
+
+3. at that point, you can load any service using the authenticated wrapper from anywhere in your code:
+
+```python
+from project import tc
+
+# Synchronous service class
+queue = tc.get_service('queue')
+
+# Asynchronous service class
+hooks = tc.get_service('hooks', use_async=True)
+
+# You can then use these classes as documented below:
+queue.ping()
+await hooks.ping()
+```
+
+Supported environment variables are:
+- `TASKCLUSTER_ROOT_URL` to specify your Taskcluster instance base url. You can either use that variable or instanciate `TaskclusterConfig` with the base url.
+- `TASKCLUSTER_CLIENT_ID` & `TASKCLUSTER_ACCESS_TOKEN` to specify your client credentials instead of providing them to `TaskclusterConfig.auth`
+
+### Loading secrets across multiple authentications
+
+Another available utility is `taskcluster.helper.load_secrets` which allows you to retrieve a secret using an authenticated `taskcluster.Secrets` instance (using `TaskclusterConfig.get_service` or the synchronous class directly). 
+
+This utility loads a secret, but allows you to:
+1. share a secret across multiple projects, by using key prefixes inside the secret,
+2. check that some required keys are present in the secret,
+3. provide some default values,
+4. provide a local secret source instead of using the Taskcluster service (useful for local development or sharing _secrets_ with contributors)
+
+Let's say you have a secret on a Taskcluster instance named `project/foo/prod-config`, which is needed by a backend and some tasks. Here is its content:
+
+```yaml
+---
+common:
+  environment: production
+  remote_log: https://log.xx.com/payload
+
+backend:
+  bugzilla_token: XXXX
+
+task:
+  backend_url: https://backend.foo.mozilla.com
+```
+
+In your backend, you would do:
+
+```python
+from taskcluster import Secrets
+from taskcluster.helper import load_secrets
+
+prod_config = load_secrets(
+  Secrets({...}),
+  'project/foo/prod-config',
+
+  # We only need the common & backend parts
+  prefixes=['common', 'backend'],
+
+  # We absolutely need a bugzilla token to run
+  required=['bugzilla_token'],
+
+  # Let's provide some default value for the environment
+  existing={
+    'environment': 'dev',
+  }
+)
+# prod_config == {
+#   "environment": "production"
+#   "remote_log": "https://log.xx.com/payload",
+#   "bugzilla_token": "XXXX",
+# }
+```
+
+In your task, you could do the following using `TaskclusterConfig` mentionned above (the class has a shortcut to use an authenticated `Secrets` service automatically):
+
+```python
+from project import tc
+
+prod_config = tc.load_secrets(
+  'project/foo/prod-config',
+
+  # We only need the common & bot parts
+  prefixes=['common', 'bot'],
+
+  # Let's provide some default value for the environment and backend_url
+  existing={
+    'environment': 'dev',
+    'backend_url': 'http://localhost:8000',
+  }
+)
+# prod_config == {
+#   "environment": "production"
+#   "remote_log": "https://log.xx.com/payload",
+#   "backend_url": "https://backend.foo.mozilla.com",
+# }
+```
+
+To provide local secrets value, you first need to load these values as a dictionary (usually by reading a local file in your format of choice : YAML, JSON, ...) and providing the dictionary to `load_secrets` by using the `local_secrets` parameter:
+
+```python
+import os
+import yaml
+
+from taskcluster import Secrets
+from taskcluster.helper import load_secrets
+
+local_path = 'path/to/file.yml'
+
+prod_config = load_secrets(
+  Secrets({...}),
+  'project/foo/prod-config',
+
+  # We support an optional local file to provide some configuration without reaching Taskcluster
+  local_secrets=yaml.safe_load(open(local_path)) if os.path.exists(local_path) else None,
+)
+```
+
 ## Methods contained in the client library
 
 <!-- START OF GENERATED DOCS -->

--- a/clients/client-py/taskcluster/helper.py
+++ b/clients/client-py/taskcluster/helper.py
@@ -1,0 +1,128 @@
+# -*- coding: utf-8 -*-
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import os
+
+import logging
+import json
+from taskcluster.generated import _client_importer
+
+logger = logging.getLogger(__name__)
+
+
+class TaskclusterConfig(object):
+    """
+    Local configuration used to access Taskcluster service and objects
+    """
+
+    def __init__(self, url="https://community-tc.services.mozilla.com"):
+        self.options = None
+        self.secrets = None
+        self.default_url = os.environ.get("TASKCLUSTER_ROOT_URL", url)
+
+    def auth(self, client_id=None, access_token=None, max_retries=12):
+        """
+        Build Taskcluster credentials options
+        Supports, by order of preference:
+         * directly provided credentials
+         * credentials from local configuration
+         * credentials from environment variables
+         * taskclusterProxy
+         * no authentication
+        """
+        self.options = {"maxRetries": max_retries}
+
+        if client_id is None and access_token is None:
+            # Credentials preference: Use local config from release-services
+            xdg = os.path.expanduser(os.environ.get("XDG_CONFIG_HOME", "~/.config"))
+            config = os.path.join(xdg, "taskcluster", "config.json")
+            logger.debug("Reading local configuration in {}".format(config))
+            try:
+                assert os.path.exists(config), "No user config available"
+                data = json.load(open(config))
+                client_id = data["auth"]["client_id"]
+                access_token = data["auth"]["access_token"]
+                assert (
+                    client_id is not None and access_token is not None
+                ), "Missing values in user folder"
+                logger.info("Using taskcluster credentials from local configuration")
+            except Exception:
+                # Credentials preference: Use env. variables
+                client_id = os.environ.get("TASKCLUSTER_CLIENT_ID")
+                access_token = os.environ.get("TASKCLUSTER_ACCESS_TOKEN")
+                logger.info("Using taskcluster credentials from environment")
+        else:
+            logger.info("Using taskcluster credentials from cli")
+
+        if client_id is not None and access_token is not None:
+            # Use provided credentials
+            self.options["credentials"] = {
+                "clientId": client_id,
+                "accessToken": access_token,
+            }
+            self.options["rootUrl"] = self.default_url
+
+        elif "TASK_ID" in os.environ:
+            # Use Taskcluster Proxy when running in a task
+            logger.info("Taskcluster Proxy enabled")
+            self.options["rootUrl"] = "http://taskcluster"
+
+        else:
+            logger.info("No Taskcluster authentication.")
+            self.options["rootUrl"] = self.default_url
+
+    def get_service(self, service_name):
+        """
+        Build a Taskcluster service instance using current authentication
+        """
+        assert self.options is not None, "Not authenticated"
+
+        service = getattr(_client_importer, service_name.capitalize(), None)
+        assert service is not None, "Invalid Taskcluster service {}".format(
+            service_name
+        )
+        return service(self.options)
+
+    def load_secrets(
+        self, secret_name, prefixes=[], required=[], existing={}, local_secrets=None
+    ):
+        """
+        Fetch a specific set of secrets by name and verify that the required
+        secrets exist.
+        Also supports providing local secrets to avoid using remote Taskcluster service
+        for local development (or contributor onboarding)
+        A user can specify prefixes to limit the part of secrets used (useful when a secret
+        is shared amongst several services)
+        """
+        self.secrets = {}
+        if existing:
+            self.secrets.update(existing)
+
+        if isinstance(local_secrets, dict):
+            # Use local secrets file to avoid using Taskcluster secrets
+            logger.info("Using provided local secrets")
+            all_secrets = local_secrets
+        else:
+            # Use Taskcluster secret service
+            assert secret_name is not None, "Missing Taskcluster secret secret_name"
+            secrets_service = self.get_service("secrets")
+            all_secrets = secrets_service.get(secret_name).get("secret", dict())
+            logger.info("Loaded Taskcluster secret {}".format(secret_name))
+
+        if prefixes:
+            # Use secrets behind supported prefixes
+            for prefix in prefixes:
+                self.secrets.update(all_secrets.get(prefix, dict()))
+
+        else:
+            # Use all secrets available
+            self.secrets.update(all_secrets)
+
+        # Check required secrets
+        for required_secret in required:
+            if required_secret not in self.secrets:
+                raise Exception("Missing value {} in secrets.".format(required_secret))
+
+        return self.secrets

--- a/clients/client-py/taskcluster/helper.py
+++ b/clients/client-py/taskcluster/helper.py
@@ -53,7 +53,7 @@ class TaskclusterConfig(object):
         elif "TASK_ID" in os.environ:
             # Use Taskcluster Proxy when running in a task
             logger.info("Taskcluster Proxy enabled")
-            self.options["rootUrl"] = "http://taskcluster"
+            self.options["rootUrl"] = os.environ.get("TASKCLUSTER_PROXY_URL", "http://taskcluster")
 
         else:
             logger.info("No Taskcluster authentication.")

--- a/clients/client-py/taskcluster/helper.py
+++ b/clients/client-py/taskcluster/helper.py
@@ -6,8 +6,8 @@
 import os
 
 import logging
-import json
 from taskcluster.generated import _client_importer
+from taskcluster.generated.aio import _client_importer as _async_client_importer
 
 logger = logging.getLogger(__name__)
 
@@ -17,17 +17,17 @@ class TaskclusterConfig(object):
     Local configuration used to access Taskcluster service and objects
     """
 
-    def __init__(self, url="https://community-tc.services.mozilla.com"):
+    def __init__(self, url=None):
         self.options = None
         self.secrets = None
         self.default_url = os.environ.get("TASKCLUSTER_ROOT_URL", url)
+        assert self.default_url is not None, "You must specify a Taskcluster deployment url"
 
     def auth(self, client_id=None, access_token=None, max_retries=12):
         """
         Build Taskcluster credentials options
         Supports, by order of preference:
          * directly provided credentials
-         * credentials from local configuration
          * credentials from environment variables
          * taskclusterProxy
          * no authentication
@@ -35,24 +35,10 @@ class TaskclusterConfig(object):
         self.options = {"maxRetries": max_retries}
 
         if client_id is None and access_token is None:
-            # Credentials preference: Use local config from release-services
-            xdg = os.path.expanduser(os.environ.get("XDG_CONFIG_HOME", "~/.config"))
-            config = os.path.join(xdg, "taskcluster", "config.json")
-            logger.debug("Reading local configuration in {}".format(config))
-            try:
-                assert os.path.exists(config), "No user config available"
-                data = json.load(open(config))
-                client_id = data["auth"]["client_id"]
-                access_token = data["auth"]["access_token"]
-                assert (
-                    client_id is not None and access_token is not None
-                ), "Missing values in user folder"
-                logger.info("Using taskcluster credentials from local configuration")
-            except Exception:
-                # Credentials preference: Use env. variables
-                client_id = os.environ.get("TASKCLUSTER_CLIENT_ID")
-                access_token = os.environ.get("TASKCLUSTER_ACCESS_TOKEN")
-                logger.info("Using taskcluster credentials from environment")
+            # Credentials preference: Use env. variables
+            client_id = os.environ.get("TASKCLUSTER_CLIENT_ID")
+            access_token = os.environ.get("TASKCLUSTER_ACCESS_TOKEN")
+            logger.info("Using taskcluster credentials from environment")
         else:
             logger.info("Using taskcluster credentials from cli")
 
@@ -73,13 +59,15 @@ class TaskclusterConfig(object):
             logger.info("No Taskcluster authentication.")
             self.options["rootUrl"] = self.default_url
 
-    def get_service(self, service_name):
+    def get_service(self, service_name, use_async=False):
         """
         Build a Taskcluster service instance using current authentication
         """
-        assert self.options is not None, "Not authenticated"
+        if self.options is None:
+            self.auth()
 
-        service = getattr(_client_importer, service_name.capitalize(), None)
+        client_importer = _async_client_importer if use_async else _client_importer
+        service = getattr(client_importer, service_name.capitalize(), None)
         assert service is not None, "Invalid Taskcluster service {}".format(
             service_name
         )
@@ -88,41 +76,55 @@ class TaskclusterConfig(object):
     def load_secrets(
         self, secret_name, prefixes=[], required=[], existing={}, local_secrets=None
     ):
-        """
-        Fetch a specific set of secrets by name and verify that the required
-        secrets exist.
-        Also supports providing local secrets to avoid using remote Taskcluster service
-        for local development (or contributor onboarding)
-        A user can specify prefixes to limit the part of secrets used (useful when a secret
-        is shared amongst several services)
-        """
-        self.secrets = {}
-        if existing:
-            self.secrets.update(existing)
-
-        if isinstance(local_secrets, dict):
-            # Use local secrets file to avoid using Taskcluster secrets
-            logger.info("Using provided local secrets")
-            all_secrets = local_secrets
-        else:
-            # Use Taskcluster secret service
-            assert secret_name is not None, "Missing Taskcluster secret secret_name"
-            secrets_service = self.get_service("secrets")
-            all_secrets = secrets_service.get(secret_name).get("secret", dict())
-            logger.info("Loaded Taskcluster secret {}".format(secret_name))
-
-        if prefixes:
-            # Use secrets behind supported prefixes
-            for prefix in prefixes:
-                self.secrets.update(all_secrets.get(prefix, dict()))
-
-        else:
-            # Use all secrets available
-            self.secrets.update(all_secrets)
-
-        # Check required secrets
-        for required_secret in required:
-            if required_secret not in self.secrets:
-                raise Exception("Missing value {} in secrets.".format(required_secret))
-
+        """Shortcut to use load_secrets helper with current authentication"""
+        self.secrets = load_secrets(
+            self.get_service('secrets'),
+            secret_name,
+            prefixes,
+            required,
+            existing,
+            local_secrets,
+        )
         return self.secrets
+
+
+def load_secrets(
+    secrets_service, secret_name, prefixes=[], required=[], existing={}, local_secrets=None
+):
+    """
+    Fetch a specific set of secrets by name and verify that the required
+    secrets exist.
+    Also supports providing local secrets to avoid using remote Taskcluster service
+    for local development (or contributor onboarding)
+    A user can specify prefixes to limit the part of secrets used (useful when a secret
+    is shared amongst several services)
+    """
+    secrets = {}
+    if existing:
+        secrets.update(existing)
+
+    if isinstance(local_secrets, dict):
+        # Use local secrets file to avoid using Taskcluster secrets
+        logger.info("Using provided local secrets")
+        all_secrets = local_secrets
+    else:
+        # Use Taskcluster secret service
+        assert secret_name is not None, "Missing Taskcluster secret secret_name"
+        all_secrets = secrets_service.get(secret_name).get("secret", dict())
+        logger.info("Loaded Taskcluster secret {}".format(secret_name))
+
+    if prefixes:
+        # Use secrets behind supported prefixes
+        for prefix in prefixes:
+            secrets.update(all_secrets.get(prefix, dict()))
+
+    else:
+        # Use all secrets available
+        secrets.update(all_secrets)
+
+    # Check required secrets
+    for required_secret in required:
+        if required_secret not in secrets:
+            raise Exception("Missing value {} in secrets.".format(required_secret))
+
+    return secrets


### PR DESCRIPTION
This is a relatively thin wrapper around the taskcluster library to provide some easier access to secrets and services in different authentication contexts.
We (Mozilla relman/salltt teal) use this class across different projects:
- in [mozilla/code-review](https://github.com/mozilla/code-review/blob/master/tools/code_review_tools/taskcluster.py)
- in [mozilla/code-coverage](https://github.com/mozilla/code-coverage/blob/master/tools/code_coverage_tools/taskcluster.py)
- in [mozilla/libmozevent](https://github.com/mozilla/libmozevent/blob/master/libmozevent/taskcluster.py)

The idea is to instanciante only one `TaskclusterConfig` in the user's project, authenticate once (usually at the beginning of runtime), then access all the Taskcluster services through that wrapper so they all get the same configuration.

It supports Taskcluster authentifications in this order:
* directly provided credentials
* credentials from local configuration (XDG folder : `~/.config/taskcluster/config.json`)
* credentials from environment variables
* `taskclusterProxy`
* no authentication

We use it all over the place, in our bots (Python 3 cli apps) running in taskcluster, in web backend or other services running in Heroku, but also on our own computers while developing.

Here you can see [a sample usage in code review bot](https://github.com/mozilla/code-review/blob/master/bot/code_review_bot/cli.py#L52)

An even simpler usage could be:

```python
from taskcluster.helper import TaskclusterConfig

t = TaskclusterConfig()
t.auth() # will use env or XDG profile

q = t.get_service('queue')
print(q) # would give <taskcluster.generated.queue.Queue object at 0x7fc199174358>

s = t.load_secrets(
    'project/XXX/testdev',
    existing={
        "somekey": "a",
    },
    required=["topsecretkey"],
)
print(s) # would give {"someKey": "a", "topsecretkey": ...}
```

I'm totally open to change any naming you find 

No changelog snippet nor documentation, as i'm not sure you'll approve this addition....