### PR TITLE
Document the services' URL structure

### DIFF
--- a/changelog/fYinNUocTZuYjdVanB_8Ag.md
+++ b/changelog/fYinNUocTZuYjdVanB_8Ag.md
@@ -1,0 +1,2 @@
+level: silent
+---

--- a/generated/docs-table-of-contents.json
+++ b/generated/docs-table-of-contents.json
@@ -1742,13 +1742,35 @@
         },
         "name": "schema",
         "next": {
-          "path": "reference/platform/README",
-          "title": "Taskcluster Platform"
+          "path": "reference/url-structure",
+          "title": "URL Structure"
         },
         "path": "reference/schema",
         "prev": {
           "path": "reference/guide",
           "title": "Guide to The Microservices"
+        },
+        "up": {
+          "path": "reference/README",
+          "title": "Taskcluster Reference"
+        }
+      },
+      {
+        "children": [
+        ],
+        "data": {
+          "order": 2,
+          "title": "URL Structure"
+        },
+        "name": "url-structure",
+        "next": {
+          "path": "reference/platform/README",
+          "title": "Taskcluster Platform"
+        },
+        "path": "reference/url-structure",
+        "prev": {
+          "path": "reference/schema",
+          "title": "Schema Index"
         },
         "up": {
           "path": "reference/README",
@@ -2169,7 +2191,7 @@
           }
         ],
         "data": {
-          "order": 2,
+          "order": 12,
           "title": "Taskcluster Platform"
         },
         "name": "platform",
@@ -2179,8 +2201,8 @@
         },
         "path": "reference/platform/README",
         "prev": {
-          "path": "reference/schema",
-          "title": "Schema Index"
+          "path": "reference/url-structure",
+          "title": "URL Structure"
         },
         "up": {
           "path": "reference/README",
@@ -2880,7 +2902,7 @@
           }
         ],
         "data": {
-          "order": 3,
+          "order": 13,
           "title": "Core Services"
         },
         "name": "core",
@@ -3054,7 +3076,7 @@
           }
         ],
         "data": {
-          "order": 5,
+          "order": 15,
           "title": "Integrations"
         },
         "name": "integrations",

--- a/ui/docs/reference/core/README.mdx
+++ b/ui/docs/reference/core/README.mdx
@@ -1,6 +1,6 @@
 ---
 title: Core Services
-order: 3
+order: 13
 ---
 
 Taskcluster core services are those which we provide for our users, but which are not fundamental to the operation of the service.

--- a/ui/docs/reference/integrations/README.mdx
+++ b/ui/docs/reference/integrations/README.mdx
@@ -1,6 +1,6 @@
 ---
 title: Integrations
-order: 5
+order: 15
 ---
 
 Integrations include services that interact with the world outside Taskcluster.

--- a/ui/docs/reference/platform/README.mdx
+++ b/ui/docs/reference/platform/README.mdx
@@ -1,6 +1,6 @@
 ---
 title: Taskcluster Platform
-order: 2
+order: 12
 ---
 
 The Taskcluster Platform encompasses the services required to execute tasks.

--- a/ui/docs/reference/url-structure.mdx
+++ b/ui/docs/reference/url-structure.mdx
@@ -1,0 +1,37 @@
+---
+title: URL Structure
+order: 2
+---
+
+# URL Structure
+
+This section describes the structure of URLs used to access a Taskcluster deployment.
+
+## RootUrl
+
+A Taskcluster `rootUrl` is a partial web address containing at least the scheme, host, and optionally a port. It cannot specify a path.
+
+Example:
+
+```
+https://taskcluster.example.com
+```
+
+Normally, a rootUrl has no trailing `/` characters.
+We suggest that libraries and tools be lenient and accept rootUrls containing a trailing `/`, but normalize to produce rootUrls without a trailing `/`.
+
+## URLs
+
+Taskcluster uses URLs with the following patterns:
+
+| destination | URL Pattern |
+| --- | --- |
+| Rest API method | `<rootUrl>/api/<service>/<version>/<path>` |
+| Documentation | `<rootUrl>/docs/<path>` |
+| JSON-Schemas | `<rootUrl>/schemas/<path>` |
+| [API References](/docs/manual/design/apis/reference-format) | `<rootUrl>/references/<path>` |
+| UI | `<rootUrl>/<path>` (for anything not matching above)|
+
+For example, the v1 Index method [`insertTask`](/docs/reference/core/index/api#insertTask) describes route `/task/<namespace>`, so a call to this method with rootURl `https://tc.example.com` and namespace `product.release.latest` would have full URL `https://tc.example.com/api/index/v1/task/product.release.latest`.
+
+*NOTE*: All of the Taskcluster clients construct API URLs for you.  Taskcluster also provides a [taskcluster-lib-urls](https://github.com/taskcluster/taskcluster-lib-urls) library in several languages to support generation of these URLs.


### PR DESCRIPTION
This moves some documentation out of tc-lib-urls, so I'll file a corresponding PR to remove it there.