### PR TITLE
Rely on an env var for canonical_host

### DIFF
--- a/changelog/OlF1yHM_SoKK81FH4ZiD_g.md
+++ b/changelog/OlF1yHM_SoKK81FH4ZiD_g.md
@@ -1,0 +1,2 @@
+level: silent
+---

--- a/static.json
+++ b/static.json
@@ -6,6 +6,7 @@
     "/docs/**": "docs.html",
     "/**": "index.html"
   },
+  "canonical_host": "${HOST}",
   "redirects": {
     "/robots.txt": {
       "url": "/robots.txt",


### PR DESCRIPTION
From https://github.com/heroku/heroku-buildpack-static#canonical-host, it looks like we can use an environment variable to specify the redirect. I suggest the following:

taskcluster-ui app -> `HOST=community-tc.services.mozilla.com`
taskcluster-net app -> `HOST=docs.taskcluster.net`

Thoughts?