### PR TITLE
Bug 1491551 - return ECONNABORTED with a good message for timeout

### DIFF
--- a/changelog/bug-1491551.md
+++ b/changelog/bug-1491551.md
@@ -1,0 +1,4 @@
+level: patch
+reference: bug 1491551
+---
+When an API request times out, the JS client now correctly retuns an error describing a timeout with `err.code === 'ECONNABORTED'`, instead of `err.code === 'ABORTED'`.


### PR DESCRIPTION
This works around a bug in Superagent.

Bugzilla Bug: [1491551](https://bugzilla.mozilla.org/show_bug.cgi?id=1491551)
