### PR TITLE
Fix TypeError when profile has no identites

### DIFF
--- a/changelog/Vgd_TWwSRZya05pr1h0mBA.md
+++ b/changelog/Vgd_TWwSRZya05pr1h0mBA.md
@@ -1,0 +1,3 @@
+level: patch
+---
+Taskcluster login no longer throws a TypeError when a profile from the PersonAPI has no identities when logging in via auth0.

--- a/services/web-server/src/login/strategies/mozilla-auth0.js
+++ b/services/web-server/src/login/strategies/mozilla-auth0.js
@@ -122,7 +122,7 @@ module.exports = class MozillaAuth0 {
     // if the identity is a github or firefox-accounts identity, then we want
     // to add the username after a `|` character, to disambiguate the
     // otherwise-numeric usernames
-    if (userId.startsWith('github|')) {
+    if (userId.startsWith('github|') && profile.identities) {
       for (let {provider, connection, user_id: github_user_id} of profile.identities) {
         if (provider === 'github' && connection === 'github') {
           // we expect the auth0 user_id to be `github|<githubUserId>`
@@ -132,7 +132,7 @@ module.exports = class MozillaAuth0 {
           break;
         }
       }
-    } else if (userId.startsWith('oauth2|firefoxaccounts|')) {
+    } else if (userId.startsWith('oauth2|firefoxaccounts|') && profile.identities) {
       for (let {provider, connection, profileData} of profile.identities) {
         if (provider === 'oauth2' && connection === 'firefoxaccounts') {
           // we expect the auth0 user_id to be `oauth|firefoxaccounts|<fxa_sub>`

--- a/services/web-server/test/login_strategies_mozilla_auth0_test.js
+++ b/services/web-server/test/login_strategies_mozilla_auth0_test.js
@@ -95,6 +95,13 @@ suite(testing.suiteName(), () => {
               access_information: {},
               identities,
             };
+          case 'oauth2|firefoxaccounts|noidentities':
+            return {
+              user_id: { value: 'oauth2|firefoxaccounts|noidentities' },
+              access_information: {},
+              email: 'rockets@ksc',
+              fxa_sub: 'noidentities',
+            };
           default:
             return null;
         }
@@ -152,6 +159,12 @@ suite(testing.suiteName(), () => {
       const user = await strategy.userFromIdentity('mozilla-auth0/email|slashy!2Fslashy');
       assert.equal(user.identity, 'mozilla-auth0/email|slashy!2Fslashy');
       assert.deepEqual(user.roles, []);
+    });
+
+    test('profile without identities should not return a user', async function() {
+      const user = await strategy.userFromIdentity('mozilla-auth0/oauth2|firefoxaccounts|noidentities');
+
+      assert.equal(user, null);
     });
   });
 });


### PR DESCRIPTION
Resolves https://sentry.prod.mozaws.net/operations/taskcluster-firefox-ci/issues/6734112/.