### PR TITLE
Bug 1597777: additional_allowed_cors_origin is json

### DIFF
--- a/changelog/bug-1597777.md
+++ b/changelog/bug-1597777.md
@@ -1,0 +1,4 @@
+level: silent 
+reference: bug 1597777
+---
+web server service reading additional_allowed_cors_origin from json

--- a/services/web-server/config.yml
+++ b/services/web-server/config.yml
@@ -24,7 +24,7 @@ defaults:
     # to allow UI deploy previews to access a running deployment.
     allowedCORSOrigins:
       - !env TASKCLUSTER_ROOT_URL
-      - !env ADDITIONAL_ALLOWED_CORS_ORIGIN
+      - !env:json ADDITIONAL_ALLOWED_CORS_ORIGIN
 
   # Configuration of access to other taskcluster components
   taskcluster:


### PR DESCRIPTION
because https://github.com/taskcluster/taskcluster/blob/master/infrastructure/k8s/templates/taskcluster-web-server-secret.yaml#L17 said so.

and thus there are double backslashes in the actual origin regex in the community cluster, which need to cease being double backslashes by the time that actually gets used as a regex.

Bugzilla Bug: [1597777](https://bugzilla.mozilla.org/show_bug.cgi?id=1597777)
