### PR TITLE
Bug 1597276 - Only open log viewer when artifact is plain text

### DIFF
--- a/changelog/bug-1597276.md
+++ b/changelog/bug-1597276.md
@@ -1,0 +1,4 @@
+level: patch
+reference: bug 1597276
+---
+Taskcluster UI now doesn't open artifacts in the log viewer by default when the file is not plain text.

--- a/services/web-server/src/entities/Artifact.js
+++ b/services/web-server/src/entities/Artifact.js
@@ -3,7 +3,7 @@ module.exports = class Artifact {
     Object.assign(this, data);
     this.taskId = taskId;
     this.isPublic = /^public\//.test(this.name);
-    this.isLog = /^text\/*/.test(this.contentType);
+    this.isLog = /^text\/plain*/.test(this.contentType);
 
     if (runId) {
       this.runId = runId;


### PR DESCRIPTION
Fixes https://bugzilla.mozilla.org/show_bug.cgi?id=1597276.