### PR TITLE
Bug 1599122 - spawn a more precise number of instances

### DIFF
--- a/changelog/bug-1599122.md
+++ b/changelog/bug-1599122.md
@@ -1,0 +1,4 @@
+level: patch
+reference: bug 1599122
+---
+Worker-manager's AWS provider now more precisely aligns its worker-spawning counts to the desired capacity.  Due to rounding, it may previously have spawned up to one additional instance per launchConfig.

--- a/services/worker-manager/src/providers/aws.js
+++ b/services/worker-manager/src/providers/aws.js
@@ -183,7 +183,9 @@ class AwsProvider extends Provider {
         });
       }
 
-      toSpawnCounter -= toSpawnPerConfig;
+      // count down the capacity we actually spawned (which may be somewhat
+      // greater than toSpawnPerConfig due to rounding)
+      toSpawnCounter -= instanceCount * config.capacityPerInstance;
 
       await Promise.all(spawned.Instances.map(i => {
         return this.Worker.create({

--- a/services/worker-manager/test/fake-aws.js
+++ b/services/worker-manager/test/fake-aws.js
@@ -1,5 +1,7 @@
 const assert = require('assert');
 
+let InstanceId = 0;
+
 module.exports = {
   EC2: {
     runInstances: ({defaultLaunchConfig, TagSpecifications, UserData}) => launchConfig => {
@@ -16,7 +18,7 @@ module.exports = {
       let Instances = [];
       for (let i = 0; i < launchConfig.MinCount; i++) {
         Instances.push({
-          InstanceId: `i-${i}`,
+          InstanceId: `i-${InstanceId++}`,
           AmiLaunchIndex: '',
           ImageId: launchConfig.ImageId,
           InstanceType: launchConfig.InstanceType || 'm2.micro',

--- a/services/worker-manager/test/provider_aws_test.js
+++ b/services/worker-manager/test/provider_aws_test.js
@@ -148,6 +148,28 @@ helper.secrets.mockSuite(testing.suiteName(), ['azure'], function(mock, skipping
       sinon.restore();
     });
 
+    test('spawns an appropriate number of instances', async function() {
+      await workerPool.modify(wp => {
+        wp.config = {
+          launchConfigs: [
+            {...defaultLaunchConfig, capacityPerInstance: 6},
+            {...defaultLaunchConfig, capacityPerInstance: 6},
+            {...defaultLaunchConfig, capacityPerInstance: 6},
+            {...defaultLaunchConfig, capacityPerInstance: 6},
+            {...defaultLaunchConfig, capacityPerInstance: 6},
+          ],
+          minCapacity: 34, // not a multiple of number of configs or capPerInstance
+          maxCapacity: 34,
+        };
+      });
+      await provider.provision({workerPool});
+      const workers = await helper.Worker.scan({}, {});
+
+      // capacity 34 at 6 per instance should be 6 instances..
+      assert.strictEqual(workers.entries.length, 6);
+      sinon.restore();
+    });
+
     test('instance tags in launch spec - should merge them with our instance tags', async function() {
       sinon.restore();
     });


### PR DESCRIPTION
Bugzilla Bug: [1599122](https://bugzilla.mozilla.org/show_bug.cgi?id=1599122)

Note that while this addresses an overprovisioning, it is a *limited* overprovisioning -- at most one instance per launchConfig, and there were 10 launchConfigs in the worker pool that led to bug 1599122.  So this cannot (alone) account for 100's of additional instances.