### PR TITLE
[Bug 1587511] (part 1) Terminate workers that don't register 

### DIFF
--- a/changelog/bug-1577839.md
+++ b/changelog/bug-1577839.md
@@ -1,0 +1,4 @@
+level: silent
+reference: bug 1577839
+---
+Add tests for AWS provider

--- a/changelog/bug-1587511.md
+++ b/changelog/bug-1587511.md
@@ -1,0 +1,9 @@
+level: minor
+reference: bug 1587511
+---
+WorkerPools can now be configured to terminate workers that fail to register after some amount of time.
+Both of the google and aws providers now support a `lifecycle` object that for now has a single key
+of `registrationTimeout`. It is optional and if it is provided the value is an integer with the number
+of seconds a worker has to register before it is terminated.
+
+This helps catch misconfigured or broken workers before they become zombies or worse.

--- a/generated/references.json
+++ b/generated/references.json
@@ -222,6 +222,26 @@
   },
   {
     "content": {
+      "$id": "/schemas/worker-manager/v1/worker-lifecycle.json#",
+      "$schema": "/schemas/common/metaschema.json#",
+      "additionalProperties": false,
+      "description": "Conditions a worker can reach and actions to take in the case that they do.\nNot all providers necessarily implement all features of this in the same way.\nRead the providers docs to understand exactly what it will do.\n",
+      "properties": {
+        "registrationTimeout": {
+          "description": "Each worker in this pool has `timeout` seconds to\nregister itself with worker-manager after it has\nbeen requsted from the cloud provider. After this\ntimeout, worker-manager will terminate the instance,\nassuming it is broken\n",
+          "title": "Registration Timeout",
+          "type": "integer"
+        }
+      },
+      "required": [
+      ],
+      "title": "Worker Lifecycle",
+      "type": "object"
+    },
+    "filename": "schemas/worker-manager/v1/worker-lifecycle.json"
+  },
+  {
+    "content": {
       "$id": "/schemas/worker-manager/v1/worker-full.json#",
       "$schema": "/schemas/common/metaschema.json#",
       "additionalProperties": false,
@@ -804,6 +824,9 @@
           "type": "array",
           "uniqueItems": false
         },
+        "lifecycle": {
+          "$ref": "worker-lifecycle.json#"
+        },
         "maxCapacity": {
           "description": "The maximum amount of capacity that worker-manager should make\navailable at any given time.\n",
           "minimum": 0,
@@ -917,6 +940,9 @@
           "title": "Launch Configurations",
           "type": "array",
           "uniqueItems": true
+        },
+        "lifecycle": {
+          "$ref": "worker-lifecycle.json#"
         },
         "maxCapacity": {
           "description": "Maximum capacity that should not be exceeded at any given time for the entire workerpool",

--- a/services/worker-manager/schemas/v1/config-aws.yml
+++ b/services/worker-manager/schemas/v1/config-aws.yml
@@ -66,6 +66,7 @@ properties:
         - region
         - launchConfig
         - capacityPerInstance
+  lifecycle: {$ref: 'worker-lifecycle.json#'}
   minCapacity:
     title: Minimum Capacity
     type: integer

--- a/services/worker-manager/schemas/v1/config-google.yml
+++ b/services/worker-manager/schemas/v1/config-google.yml
@@ -19,6 +19,7 @@ properties:
     description: |
       The maximum amount of capacity that worker-manager should make
       available at any given time.
+  lifecycle: {$ref: 'worker-lifecycle.json#'}
   launchConfigs:
     type: array
     title: Choices

--- a/services/worker-manager/schemas/v1/worker-lifecycle.yml
+++ b/services/worker-manager/schemas/v1/worker-lifecycle.yml
@@ -1,0 +1,19 @@
+$schema: "/schemas/common/metaschema.json#"
+title: Worker Lifecycle
+description: |
+  Conditions a worker can reach and actions to take in the case that they do.
+  Not all providers necessarily implement all features of this in the same way.
+  Read the providers docs to understand exactly what it will do.
+type: object
+properties:
+  registrationTimeout:
+    title: Registration Timeout
+    type: integer
+    description: |
+      Each worker in this pool has `timeout` seconds to
+      register itself with worker-manager after it has
+      been requsted from the cloud provider. After this
+      timeout, worker-manager will terminate the instance,
+      assuming it is broken
+additionalProperties: false
+required: []

--- a/services/worker-manager/src/providers/aws.js
+++ b/services/worker-manager/src/providers/aws.js
@@ -115,11 +115,13 @@ class AwsProvider extends Provider {
       // Make sure we don't get "The same resource type may not be specified
       // more than once in tag specifications" errors
       const TagSpecifications = config.launchConfig.TagSpecifications || [];
-      const instanceTags = [];
-      const otherTagSpecs = [];
-      TagSpecifications.forEach(ts =>
-        ts.ResourceType === 'instance' ? instanceTags.concat(ts.Tags) : otherTagSpecs.push(ts),
-      );
+      let instanceTags = [];
+      let otherTagSpecs = [];
+      TagSpecifications.forEach(ts => {
+        ts.ResourceType === 'instance'
+          ? instanceTags = instanceTags.concat(ts.Tags)
+          : otherTagSpecs.push(ts);
+      });
 
       const userData = Buffer.from(JSON.stringify({
         ...config.additionalUserData,

--- a/services/worker-manager/src/providers/aws.js
+++ b/services/worker-manager/src/providers/aws.js
@@ -100,6 +100,12 @@ class AwsProvider extends Provider {
     if (toSpawn === 0) {
       return;
     }
+
+    let registrationExpiry = null;
+    if ((workerPool.config.lifecycle || {}).registrationTimeout) {
+      registrationExpiry = Date.now() + workerPool.config.lifecycle.registrationTimeout * 1000;
+    }
+
     const toSpawnPerConfig = Math.ceil(toSpawn / workerPool.config.launchConfigs.length);
     const shuffledConfigs = _.shuffle(workerPool.config.launchConfigs);
 
@@ -218,6 +224,7 @@ class AwsProvider extends Provider {
             owner: spawned.OwnerId,
             state: i.State.Name,
             stateReason: i.StateReason.Message,
+            registrationExpiry,
           },
         });
       }));
@@ -268,6 +275,12 @@ class AwsProvider extends Provider {
 
   async checkWorker({worker}) {
     this.seen[worker.workerPoolId] = this.seen[worker.workerPoolId] || 0;
+
+    if (worker.providerData.registrationExpiry &&
+      worker.state === this.Worker.states.REQUESTED &&
+      worker.providerData.registrationExpiry < Date.now()) {
+      return await this.removeWorker({worker});
+    }
 
     let state = worker.state;
     try {

--- a/services/worker-manager/test/fake-aws.js
+++ b/services/worker-manager/test/fake-aws.js
@@ -53,17 +53,22 @@ module.exports = {
       };
     },
 
-    terminateInstances: ({InstanceIds}) => {
-      return {
-        promise: () => ({
-          TerminatingInstances: InstanceIds.map(iid => ({
-            InstanceId: iid,
-            CurrentState: {
-              Name: 'shutting-down',
-            },
-          })),
-        }),
+    terminateInstances: () => {
+      const fake = ({InstanceIds}) => {
+        fake.calls.push({InstanceIds});
+        return {
+          promise: () => ({
+            TerminatingInstances: InstanceIds.map(iid => ({
+              InstanceId: iid,
+              CurrentState: {
+                Name: 'shutting-down',
+              },
+            })),
+          }),
+        };
       };
+      fake.calls = [];
+      return fake;
     },
 
     // to make this function return the status you want, pass it in as an instance id

--- a/services/worker-manager/test/fake-aws.js
+++ b/services/worker-manager/test/fake-aws.js
@@ -1,48 +1,44 @@
-const assert = require('assert');
-
 let InstanceId = 0;
 
 module.exports = {
   EC2: {
-    runInstances: ({defaultLaunchConfig, TagSpecifications, UserData}) => launchConfig => {
-      assert.deepStrictEqual(launchConfig,
-        {
-          ...defaultLaunchConfig.launchConfig,
-          MinCount: launchConfig.MinCount, // this is estimator's functionality, no need to test this here
-          MaxCount: launchConfig.MaxCount,
-          TagSpecifications,
-          UserData: Buffer.from(JSON.stringify(UserData)).toString('base64'),
-        },
-      );
+    runInstances: () => {
+      const fake = launchConfig => {
+        fake.calls.push({launchConfig});
 
-      let Instances = [];
-      for (let i = 0; i < launchConfig.MinCount; i++) {
-        Instances.push({
-          InstanceId: `i-${InstanceId++}`,
-          AmiLaunchIndex: '',
-          ImageId: launchConfig.ImageId,
-          InstanceType: launchConfig.InstanceType || 'm2.micro',
-          Architecture: 'x86',
-          Placement: {
-            AvailabilityZone: 'someregion',
-          },
-          PrivateIpAddress: '1.1.1.1',
-          OwnerId: '123123123',
-          State: {
-            Name: 'running',
-          },
-          StateReason: {
-            Message: 'yOu LaunCHed iT!!!1',
-          },
-        });
-      }
-      return {
-        promise: () => ({
-          Instances,
-          Groups: [],
-          OwnerId: '123123123',
-        }),
+        let Instances = [];
+        for (let i = 0; i < launchConfig.MinCount; i++) {
+          Instances.push({
+            InstanceId: `i-${InstanceId++}`,
+            AmiLaunchIndex: '',
+            ImageId: launchConfig.ImageId,
+            InstanceType: launchConfig.InstanceType || 'm2.micro',
+            Architecture: 'x86',
+            Placement: {
+              AvailabilityZone: 'someregion',
+            },
+            PrivateIpAddress: '1.1.1.1',
+            OwnerId: '123123123',
+            State: {
+              Name: 'running',
+            },
+            StateReason: {
+              Message: 'yOu LaunCHed iT!!!1',
+            },
+          });
+        }
+        return {
+          promise: () => ({
+            Instances,
+            Groups: [],
+            OwnerId: '123123123',
+          }),
+        };
       };
+
+      fake.calls = [];
+
+      return fake;
     },
 
     describeRegions: () => {

--- a/services/worker-manager/test/fake-aws.js
+++ b/services/worker-manager/test/fake-aws.js
@@ -65,5 +65,16 @@ module.exports = {
         }),
       };
     },
+
+    // to make this function return the status you want, pass it in as an instance id
+    // in other words, make the status your workerId in the worker fixture
+    describeInstanceStatus: options => ({
+      promise: () => ({
+        InstanceStatuses: [{
+          InstanceState: {Name: options.InstanceIds[0]},
+          InstanceId: 'dummy-worker',
+        }],
+      }),
+    }),
   },
 };

--- a/services/worker-manager/test/fixtures/schemas/sample-aws-config.json
+++ b/services/worker-manager/test/fixtures/schemas/sample-aws-config.json
@@ -1,30 +1,30 @@
 {
-    "launchConfigs": [
-      {
-        "launchConfig": {
-          "ImageId": "ami-blabla",
-          "KeyName": "somekey",
-          "SecurityGroupIds": [
-            "sg-yadayada"
-          ],
-          "InstanceType": "m5.xlarge"
-        },
-        "region": "us-west-2",
-        "capacityPerInstance": 1
+  "launchConfigs": [
+    {
+      "launchConfig": {
+        "ImageId": "ami-blabla",
+        "KeyName": "somekey",
+        "SecurityGroupIds": [
+          "sg-yadayada"
+        ],
+        "InstanceType": "m5.xlarge"
       },
-      {
-        "launchConfig": {
-          "ImageId": "ami-yadayada",
-          "KeyName": "anotherkey",
-          "SecurityGroupIds": [
-            "sg-blahblahblah"
-          ],
-          "InstanceType": "m5.xlarge"
-        },
-        "region": "us-east-1",
-        "capacityPerInstance": 1
-      }
-    ],
-    "minCapacity": 1,
-    "maxCapacity": 1
-  }
+      "region": "us-west-2",
+      "capacityPerInstance": 1
+    },
+    {
+      "launchConfig": {
+        "ImageId": "ami-yadayada",
+        "KeyName": "anotherkey",
+        "SecurityGroupIds": [
+          "sg-blahblahblah"
+        ],
+        "InstanceType": "m5.xlarge"
+      },
+      "region": "us-east-1",
+      "capacityPerInstance": 1
+    }
+  ],
+  "minCapacity": 1,
+  "maxCapacity": 1
+}

--- a/services/worker-manager/test/fixtures/schemas/sample-aws-worker-pull.json
+++ b/services/worker-manager/test/fixtures/schemas/sample-aws-worker-pull.json
@@ -1,4 +1,12 @@
 {
+  "workerPoolId": "delete/worker",
+  "providerId": "aws",
+  "description": "a workertype",
+  "owner": "owlish@mozilla.com",
+  "emailOnError": true,
+  "created": "2019-10-18T21:16:41.593Z",
+  "lastModified": "2019-10-18T21:16:41.593Z",
+  "config": {
     "launchConfigs": [
       {
         "launchConfig": {
@@ -28,3 +36,4 @@
     "minCapacity": 1,
     "maxCapacity": 1
   }
+}

--- a/services/worker-manager/test/fixtures/schemas/sample-google-config.json
+++ b/services/worker-manager/test/fixtures/schemas/sample-google-config.json
@@ -1,0 +1,19 @@
+{
+  "launchConfigs": [
+    {
+      "launchConfig": {
+        "ImageId": "banana"
+      },
+      "region": "us-west",
+      "capacityPerInstance": 1,
+      "workerConfig": {},
+      "zone": "darkness",
+      "machineType": "some-cool-type",
+      "disks": [],
+      "networkInterfaces": [],
+      "scheduling": {}
+    }
+  ],
+  "minCapacity": 1,
+  "maxCapacity": 1
+}

--- a/services/worker-manager/test/provider_aws_test.js
+++ b/services/worker-manager/test/provider_aws_test.js
@@ -1,5 +1,3 @@
-/* eslint-disable comma-dangle */
-
 const {ApiError} = require('../src/providers/provider');
 const assert = require('assert');
 const sinon = require('sinon');
@@ -233,7 +231,7 @@ helper.secrets.mockSuite(testing.suiteName(), ['azure'], function(mock, skipping
       assert.deepStrictEqual(
         JSON.parse(Buffer.from(
           ...aws.EC2().runInstances.calls.map(({launchConfig: {UserData}}) => UserData),
-          'base64'
+          'base64' // eslint-disable-line comma-dangle
         ).toString()),
         {
           somethingImportant: 'apple',
@@ -242,7 +240,7 @@ helper.secrets.mockSuite(testing.suiteName(), ['azure'], function(mock, skipping
           providerId: provider.providerId,
           workerGroup: provider.providerId,
           workerConfig: workerPool.config.launchConfigs[0].workerConfig,
-        }
+        } // eslint-disable-line comma-dangle
       );
 
       sinon.restore();
@@ -382,7 +380,7 @@ helper.secrets.mockSuite(testing.suiteName(), ['azure'], function(mock, skipping
       const workers = await helper.Worker.scan({}, {});
       assert.notStrictEqual(workers.entries.length, 0);
       workers.entries.forEach(w =>
-        assert.strictEqual(w.state, helper.Worker.states.STOPPED)
+        assert.strictEqual(w.state, helper.Worker.states.STOPPED) // eslint-disable-line comma-dangle
       );
       assert.strictEqual(provider.seen[worker.workerPoolId], 0);
 
@@ -402,7 +400,7 @@ helper.secrets.mockSuite(testing.suiteName(), ['azure'], function(mock, skipping
       const workers = await helper.Worker.scan({}, {});
       assert.notStrictEqual(workers.entries.length, 0);
       workers.entries.forEach(w =>
-        assert.strictEqual(w.state, helper.Worker.states.REQUESTED)
+        assert.strictEqual(w.state, helper.Worker.states.REQUESTED) // eslint-disable-line comma-dangle
       );
       assert.strictEqual(provider.seen[worker.workerPoolId], 1);
 
@@ -436,7 +434,7 @@ helper.secrets.mockSuite(testing.suiteName(), ['azure'], function(mock, skipping
       const workers = await helper.Worker.scan({}, {});
       assert.notStrictEqual(workers.entries.length, 0);
       workers.entries.forEach(w =>
-        assert.strictEqual(w.state, helper.Worker.states.STOPPED)
+        assert.strictEqual(w.state, helper.Worker.states.STOPPED) // eslint-disable-line comma-dangle
       );
       assert.strictEqual(provider.seen[worker.workerPoolId], 0);
 

--- a/services/worker-manager/test/provider_aws_test.js
+++ b/services/worker-manager/test/provider_aws_test.js
@@ -1,3 +1,5 @@
+/* eslint-disable comma-dangle */
+
 const {ApiError} = require('../src/providers/provider');
 const assert = require('assert');
 const sinon = require('sinon');
@@ -48,32 +50,6 @@ helper.secrets.mockSuite(testing.suiteName(), ['azure'], function(mock, skipping
     providerData: {},
     emailOnError: false,
   };
-  const TagSpecifications = [
-    ...(defaultLaunchConfig.launchConfig.TagSpecifications ? defaultLaunchConfig.launchConfig.TagSpecifications : []),
-    {
-      ResourceType: 'instance',
-      Tags: [
-        {
-          Key: 'CreatedBy',
-          Value: `taskcluster-wm-${providerId}`,
-        }, {
-          Key: 'Owner',
-          Value: workerPool.owner,
-        },
-        {
-          Key: 'ManagedBy',
-          Value: 'taskcluster',
-        },
-        {
-          Key: 'Name',
-          Value: `${workerPoolId}`,
-        },
-        {
-          Key: 'WorkerPoolId',
-          Value: `${workerPoolId}`,
-        }],
-    },
-  ];
   const defaultWorker = {
     workerPoolId,
     workerGroup: providerId,
@@ -237,7 +213,7 @@ helper.secrets.mockSuite(testing.suiteName(), ['azure'], function(mock, skipping
               {Key: "WorkerPoolId", Value: "foo/bar"},
             ],
           },
-        ]
+        ],
       );
 
       sinon.restore();
@@ -255,10 +231,10 @@ helper.secrets.mockSuite(testing.suiteName(), ['azure'], function(mock, skipping
 
       assert.notStrictEqual(workers.entries.length, 0);
       assert.deepStrictEqual(
-         JSON.parse(Buffer.from(
-           ...aws.EC2().runInstances.calls.map(({launchConfig: {UserData}}) => UserData),
-           'base64'
-         ).toString()),
+        JSON.parse(Buffer.from(
+          ...aws.EC2().runInstances.calls.map(({launchConfig: {UserData}}) => UserData),
+          'base64'
+        ).toString()),
         {
           somethingImportant: 'apple',
           rootUrl: provider.rootUrl,

--- a/services/worker-manager/test/provider_aws_test.js
+++ b/services/worker-manager/test/provider_aws_test.js
@@ -153,7 +153,7 @@ helper.secrets.mockSuite(testing.suiteName(), ['azure'], function(mock, skipping
         assert.strictEqual(w.providerData.region, defaultLaunchConfig.region, 'Region should come from the chosen config');
         // Check that this is setting times correctly to within a second or so to allow for some time
         // for the provisioning loop
-        assert(workers.entries[0].providerData.registrationExpiry - now - (6000 * 1000) < 1000);
+        assert(workers.entries[0].providerData.registrationExpiry - now - (6000 * 1000) < 5000);
       });
       sinon.restore();
     });

--- a/services/worker-manager/test/provider_aws_test.js
+++ b/services/worker-manager/test/provider_aws_test.js
@@ -40,6 +40,9 @@ helper.secrets.mockSuite(testing.suiteName(), ['azure'], function(mock, skipping
       ],
       minCapacity: 1,
       maxCapacity: 2,
+      lifecycle: {
+        registrationTimeout: 6000,
+      },
     },
     owner: 'whatever@example.com',
     providerData: {},
@@ -137,7 +140,8 @@ helper.secrets.mockSuite(testing.suiteName(), ['azure'], function(mock, skipping
   suite('AWS provider - provision', function() {
 
     test('positive test', async function() {
-      await provider.provision({workerPool, existingCapacity: 0});
+      const now = Date.now();
+      await provider.provision({workerPool});
       const workers = await helper.Worker.scan({}, {});
 
       assert.notStrictEqual(workers.entries.length, 0);
@@ -147,6 +151,9 @@ helper.secrets.mockSuite(testing.suiteName(), ['azure'], function(mock, skipping
         assert.strictEqual(w.workerGroup, providerId, 'Worker group id should be the same as provider id');
         assert.strictEqual(w.state, helper.Worker.states.REQUESTED, 'Worker should be marked as requested');
         assert.strictEqual(w.providerData.region, defaultLaunchConfig.region, 'Region should come from the chosen config');
+        // Check that this is setting times correctly to within a second or so to allow for some time
+        // for the provisioning loop
+        assert(workers.entries[0].providerData.registrationExpiry - now - (6000 * 1000) < 1000);
       });
       sinon.restore();
     });
@@ -305,6 +312,7 @@ helper.secrets.mockSuite(testing.suiteName(), ['azure'], function(mock, skipping
   });
 
   suite('AWS provider - checkWorker', function() {
+    // TODO: Can someone fill these out and then I'll add tests for the lifecycle stuff here as well?
 
     test('stopped and terminated instances - should be marked as STOPPED in DB', async function() {
       sinon.restore();

--- a/services/worker-manager/test/provider_google_test.js
+++ b/services/worker-manager/test/provider_google_test.js
@@ -75,7 +75,7 @@ helper.secrets.mockSuite(testing.suiteName(), ['azure'], function(mock, skipping
 
   test('provisioning loop', async function() {
     const now = Date.now();
-    await provider.provision({workerPool});
+    await provider.provision({workerPool, existingCapacity: 0});
     const workers = await helper.Worker.scan({}, {});
     // Check that this is setting times correctly to within a second or so to allow for some time
     // for the provisioning loop
@@ -201,7 +201,10 @@ helper.secrets.mockSuite(testing.suiteName(), ['azure'], function(mock, skipping
       workerGroup: 'whatever',
       workerId: 'whatever',
       providerId,
+      capacity: 1,
       created: taskcluster.fromNow('-1 hour'),
+      lastModified: taskcluster.fromNow('-2 weeks'),
+      lastChecked: taskcluster.fromNow('-2 weeks'),
       expires: taskcluster.fromNow('1 week'),
       state: helper.Worker.states.REQUESTED,
       providerData: {
@@ -223,6 +226,9 @@ helper.secrets.mockSuite(testing.suiteName(), ['azure'], function(mock, skipping
       providerId,
       created: taskcluster.fromNow('-1 hour'),
       expires: taskcluster.fromNow('1 week'),
+      capacity: 1,
+      lastModified: taskcluster.fromNow('-2 weeks'),
+      lastChecked: taskcluster.fromNow('-2 weeks'),
       state: helper.Worker.states.REQUESTED,
       providerData: {
         zone: 'us-east1-a',

--- a/services/worker-manager/test/provider_google_test.js
+++ b/services/worker-manager/test/provider_google_test.js
@@ -214,7 +214,7 @@ helper.secrets.mockSuite(testing.suiteName(), ['azure'], function(mock, skipping
     });
     await provider.scanPrepare();
     await provider.checkWorker({worker});
-    await provider.scanCleanup({responsibleFor: new Set([workerPoolId])});
+    await provider.scanCleanup();
     assert(fakeGoogle.instanceDeleteStub.called);
   });
 
@@ -237,7 +237,7 @@ helper.secrets.mockSuite(testing.suiteName(), ['azure'], function(mock, skipping
     });
     await provider.scanPrepare();
     await provider.checkWorker({worker});
-    await provider.scanCleanup({responsibleFor: new Set([workerPoolId])});
+    await provider.scanCleanup();
     assert(!fakeGoogle.instanceDeleteStub.called);
   });
 

--- a/services/worker-manager/test/provider_google_test.js
+++ b/services/worker-manager/test/provider_google_test.js
@@ -50,6 +50,9 @@ helper.secrets.mockSuite(testing.suiteName(), ['azure'], function(mock, skipping
       config: {
         minCapacity: 1,
         maxCapacity: 1,
+        lifecycle: {
+          registrationTimeout: 6000,
+        },
         launchConfigs: [
           {
             capacityPerInstance: 1,
@@ -71,8 +74,12 @@ helper.secrets.mockSuite(testing.suiteName(), ['azure'], function(mock, skipping
   });
 
   test('provisioning loop', async function() {
-    await provider.provision({workerPool, existingCapacity: 0});
+    const now = Date.now();
+    await provider.provision({workerPool});
     const workers = await helper.Worker.scan({}, {});
+    // Check that this is setting times correctly to within a second or so to allow for some time
+    // for the provisioning loop
+    assert(workers.entries[0].providerData.registrationExpiry - now - (6000 * 1000) < 1000);
     assert.deepEqual(workers.entries[0].providerData.operation, {
       name: 'foo',
       zone: 'whatever/a',
@@ -186,6 +193,46 @@ helper.secrets.mockSuite(testing.suiteName(), ['azure'], function(mock, skipping
     await provider.checkWorker({worker});
     await provider.scanCleanup();
     assert(worker.expires > expires);
+  });
+
+  test('remove unregistered workers', async function() {
+    const worker = await helper.Worker.create({
+      workerPoolId,
+      workerGroup: 'whatever',
+      workerId: 'whatever',
+      providerId,
+      created: taskcluster.fromNow('-1 hour'),
+      expires: taskcluster.fromNow('1 week'),
+      state: helper.Worker.states.REQUESTED,
+      providerData: {
+        zone: 'us-east1-a',
+        registrationExpiry: Date.now() - 1000,
+      },
+    });
+    await provider.scanPrepare();
+    await provider.checkWorker({worker});
+    await provider.scanCleanup({responsibleFor: new Set([workerPoolId])});
+    assert(fakeGoogle.instanceDeleteStub.called);
+  });
+
+  test('don\'t remove unregistered workers that are new', async function() {
+    const worker = await helper.Worker.create({
+      workerPoolId,
+      workerGroup: 'whatever',
+      workerId: 'whatever',
+      providerId,
+      created: taskcluster.fromNow('-1 hour'),
+      expires: taskcluster.fromNow('1 week'),
+      state: helper.Worker.states.REQUESTED,
+      providerData: {
+        zone: 'us-east1-a',
+        registrationExpiry: Date.now() + 1000,
+      },
+    });
+    await provider.scanPrepare();
+    await provider.checkWorker({worker});
+    await provider.scanCleanup({responsibleFor: new Set([workerPoolId])});
+    assert(!fakeGoogle.instanceDeleteStub.called);
   });
 
   suite('_enqueue p-queues', function() {

--- a/services/worker-manager/test/provider_google_test.js
+++ b/services/worker-manager/test/provider_google_test.js
@@ -79,7 +79,7 @@ helper.secrets.mockSuite(testing.suiteName(), ['azure'], function(mock, skipping
     const workers = await helper.Worker.scan({}, {});
     // Check that this is setting times correctly to within a second or so to allow for some time
     // for the provisioning loop
-    assert(workers.entries[0].providerData.registrationExpiry - now - (6000 * 1000) < 1000);
+    assert(workers.entries[0].providerData.registrationExpiry - now - (6000 * 1000) < 5000);
     assert.deepEqual(workers.entries[0].providerData.operation, {
       name: 'foo',
       zone: 'whatever/a',

--- a/services/worker-manager/test/schema_validate_test.js
+++ b/services/worker-manager/test/schema_validate_test.js
@@ -21,8 +21,6 @@ suite(testing.suiteName(), () => {
         path: 'sample-aws-config.json',
         success: true,
       },
-
-
       {
         schema: 'v1/config-google.json#',
         path: 'sample-google-config.json',

--- a/services/worker-manager/test/schema_validate_test.js
+++ b/services/worker-manager/test/schema_validate_test.js
@@ -13,7 +13,19 @@ suite(testing.suiteName(), () => {
     cases: [
       {
         schema: 'v1/worker-pool-full.json#',
+        path: 'sample-aws-worker-pull.json',
+        success: true,
+      },
+      {
+        schema: 'v1/config-aws.json#',
         path: 'sample-aws-config.json',
+        success: true,
+      },
+
+
+      {
+        schema: 'v1/config-google.json#',
+        path: 'sample-google-config.json',
         success: true,
       },
     ],


### PR DESCRIPTION


Bugzilla Bug: [1587511](https://bugzilla.mozilla.org/show_bug.cgi?id=1587511)

This is just part one because the bug is for terminating workers if they go idle for a long time and don't try to claim or reclaim work. That will be a bigger project requiring queue<-->w-m interaction.

Sticking this key inside a `lifecycle` field allows us to add more settings like this in the future but if it feels unwieldy, let me know and I will move it up. Also happy to change names, etc. As an example, we could add the `runningTimeout` to account for the 96 hour thing in this bug.

TODO:

- [x] Test this on a dev environment
- [x] Figure out how to do worker tests for aws provider and add lifecycle tests for it. @owlishDeveloper I think you were working on adding these tests before? Is it in a state where you could either share the code with me or make a PR into this one with the tests? 