### PR TITLE
Fix docs parser mdx

### DIFF
--- a/changelog/X5QnJXUUTMSMk8sPWS9P1g.md
+++ b/changelog/X5QnJXUUTMSMk8sPWS9P1g.md
@@ -1,0 +1,2 @@
+level: silent
+---

--- a/ui/docs/manual/deploying/github.mdx
+++ b/ui/docs/manual/deploying/github.mdx
@@ -11,11 +11,11 @@ The GitHub service requires a GitHub App in order to interact with GitHub.
 To create such an app, use the docs at https://developer.github.com/apps/building-github-apps/creating-a-github-app/.
 
 * Ownership: if possible, create the application under a relevant GitHub organization.  Apps can be transferred after creation, though, so this is not critical.
-* Name: not critical, but we recommend "<deployment-name>-taskcluster".
+* Name: not critical, but we recommend "&lt;deployment-name>-taskcluster".
 * Homepage URL should link to your deployment's root URL
 * Setup URL should link to your taskcluster instance's quickstart guide, `/quickstart` on your deployment's root URL
 * Webhook URL should link to `/api/github/v1/github` on your deployment's root URL
-* Set the secret to an arbitrary value that you also configure in your Taskcluster instance's settings. 
+* Set the secret to an arbitrary value that you also configure in your Taskcluster instance's settings.
 * Set permissions as follows:
   * repo administration: read-only
   * checks: read & write

--- a/ui/docs/manual/deploying/login-strategies.mdx
+++ b/ui/docs/manual/deploying/login-strategies.mdx
@@ -30,7 +30,7 @@ JSON *requires* the use of the double-quote character (`"`), but shells, YAML pa
 
 In order to enable the GitHub login strategy, specify the GitHub client ID and secret for an OAuth application created for use against this service and its web UI.
 Create it under "Settings" (for yourself or for an org) -> "Developer Settings" -> "OAuth Apps" -> "New OAuth App".
-The name for the app is not critical, but we suggest something like "<deployment-name>-taskcluster-signin".
+The name for the app is not critical, but we suggest something like "&lt;deployment-name>-taskcluster-signin".
 
 The callback URL should be `<rootUrl>/login/github/callback`, or `http://localhost:3050/login/github/callback` for local development.
 


### PR DESCRIPTION
Running the UI was throwing `SyntaxError: unknown: Expected corresponding JSX closing tag for <deployment-name>`.