### PR TITLE
Bug 1598649 - automate the release process

### DIFF
--- a/infrastructure/tooling/src/main.js
+++ b/infrastructure/tooling/src/main.js
@@ -32,6 +32,7 @@ program.command('build')
 program.command('release')
   .option('--base-dir <base-dir>', 'Base directory for build (fast and big!; default /tmp/taskcluster-builder-build)')
   .option('--gh-token <gh-token>', 'GitHub access token (required unless --no-push)')
+  .option('--npm-token <npm-token>', 'NPM authentication token (required unless --no-push)')
   .option('--dry-run', 'Do not run any tasks, but generate the list of tasks')
   .option('--no-push', 'Do not push the docker image and git commit + tags (but your local repo is still modified)')
   .action((...options) => {

--- a/infrastructure/tooling/src/main.js
+++ b/infrastructure/tooling/src/main.js
@@ -31,12 +31,17 @@ program.command('build')
 
 program.command('release')
   .option('--base-dir <base-dir>', 'Base directory for build (fast and big!; default /tmp/taskcluster-builder-build)')
-  .option('--gh-token <gh-token>', 'GitHub access token (required unless --no-push)')
-  .option('--npm-token <npm-token>', 'NPM authentication token (required unless --no-push)')
-  .option('--pypi-username <username>', 'PyPI username (required unless --no-push)')
-  .option('--pypi-password <password>', 'PyPI password (required unless --no-push)')
   .option('--dry-run', 'Do not run any tasks, but generate the list of tasks')
   .option('--no-push', 'Do not push the docker image and git commit + tags (but your local repo is still modified)')
+  .on('--help', () => {
+    console.log([
+      '',
+      'Set the following environment variables (unless --no-push):',
+      ' * GH_TOKEN - GitHub access token with permissions to create a release',
+      ' * NPM_TOKEN - NPM authentication token with permission to publish client libraries',
+      ' * PYPI_USERNAME / PYPI_PASSWORD - PyPI credentials with permission to upload taskcluster-client',
+    ].join('\n'));
+  })
   .action((...options) => {
     if (options.length !== 1) {
       console.error('unexpected command-line arguments');

--- a/infrastructure/tooling/src/main.js
+++ b/infrastructure/tooling/src/main.js
@@ -33,6 +33,8 @@ program.command('release')
   .option('--base-dir <base-dir>', 'Base directory for build (fast and big!; default /tmp/taskcluster-builder-build)')
   .option('--gh-token <gh-token>', 'GitHub access token (required unless --no-push)')
   .option('--npm-token <npm-token>', 'NPM authentication token (required unless --no-push)')
+  .option('--pypi-username <username>', 'PyPI username (required unless --no-push)')
+  .option('--pypi-password <password>', 'PyPI password (required unless --no-push)')
   .option('--dry-run', 'Do not run any tasks, but generate the list of tasks')
   .option('--no-push', 'Do not push the docker image and git commit + tags (but your local repo is still modified)')
   .action((...options) => {

--- a/infrastructure/tooling/src/release/index.js
+++ b/infrastructure/tooling/src/release/index.js
@@ -18,6 +18,10 @@ class Release {
       throw new Error('The --npm-token option is required (unless --no-push)');
     }
 
+    if (cmdOptions.push && (!cmdOptions.pypiUsername || !cmdOptions.pypiPassword)) {
+      throw new Error('The --pypi-* options are required (unless --no-push)');
+    }
+
     this.baseDir = cmdOptions['baseDir'] || '/tmp/taskcluster-builder-build';
 
     // The `yarn build` process is a subgraph of the release taskgraph, with some
@@ -76,11 +80,9 @@ class Release {
     console.log(`Release version: ${context['release-version']}`);
     console.log(`Release docker image: ${context['monoimage-docker-image']}`);
     if (!this.cmdOptions.push) {
-      console.log('NOTE: image and git commit + tags not pushed due to --no-push option');
+      console.log('NOTE: image, git commit + tags, and packages not pushed due to --no-push option');
     } else {
       console.log(`GitHub release: ${context['github-release']}`);
-      console.log('** YOUR NEXT STEPS **');
-      console.log(' * run `./release.sh --real` in clients/client-py');
     }
   }
 }

--- a/infrastructure/tooling/src/release/index.js
+++ b/infrastructure/tooling/src/release/index.js
@@ -14,6 +14,10 @@ class Release {
       throw new Error('The --gh-token option is required (unless --no-push)');
     }
 
+    if (cmdOptions.push && !cmdOptions.npmToken) {
+      throw new Error('The --npm-token option is required (unless --no-push)');
+    }
+
     this.baseDir = cmdOptions['baseDir'] || '/tmp/taskcluster-builder-build';
 
     // The `yarn build` process is a subgraph of the release taskgraph, with some
@@ -58,6 +62,7 @@ class Release {
         // and let's be sane about how many git clones we do..
         git: new Lock(8),
       },
+      target: 'target-release',
       renderer: process.stdout.isTTY ?
         new ConsoleRenderer({elideCompleted: true}) :
         new LogRenderer(),
@@ -75,8 +80,6 @@ class Release {
     } else {
       console.log(`GitHub release: ${context['github-release']}`);
       console.log('** YOUR NEXT STEPS **');
-      console.log(' * run `npm publish` in clients/client');
-      console.log(' * run `npm publish` in clients/client-web');
       console.log(' * run `./release.sh --real` in clients/client-py');
     }
   }

--- a/infrastructure/tooling/src/release/index.js
+++ b/infrastructure/tooling/src/release/index.js
@@ -10,16 +10,12 @@ class Release {
   constructor(cmdOptions) {
     this.cmdOptions = cmdOptions;
 
-    if (cmdOptions.push && !cmdOptions.ghToken) {
-      throw new Error('The --gh-token option is required (unless --no-push)');
-    }
-
-    if (cmdOptions.push && !cmdOptions.npmToken) {
-      throw new Error('The --npm-token option is required (unless --no-push)');
-    }
-
-    if (cmdOptions.push && (!cmdOptions.pypiUsername || !cmdOptions.pypiPassword)) {
-      throw new Error('The --pypi-* options are required (unless --no-push)');
+    if (cmdOptions.push) {
+      ['GH_TOKEN', 'NPM_TOKEN', 'PYPI_USERNAME', 'PYPI_PASSWORD'].forEach(e => {
+        if (!process.env[e]) {
+          throw new Error(`$${e} is required (unless --no-push)`);
+        }
+      });
     }
 
     this.baseDir = cmdOptions['baseDir'] || '/tmp/taskcluster-builder-build';
@@ -45,6 +41,12 @@ class Release {
     generateReleaseTasks({
       tasks,
       cmdOptions: this.cmdOptions,
+      credentials: {
+        ghToken: process.env.GH_TOKEN,
+        npmToken: process.env.NPM_TOKEN,
+        pypiUsername: process.env.PYPI_USERNAME,
+        pypiPassword: process.env.PYPI_PASSWORD,
+      },
       baseDir: this.baseDir,
     });
 

--- a/infrastructure/tooling/src/release/tasks.js
+++ b/infrastructure/tooling/src/release/tasks.js
@@ -28,7 +28,7 @@ const {
 
 const readFile = util.promisify(fs.readFile);
 
-module.exports = ({tasks, cmdOptions, baseDir}) => {
+module.exports = ({tasks, cmdOptions, credentials, baseDir}) => {
   const artifactsDir = path.join(baseDir, 'release-artifacts');
 
   ensureTask(tasks, {
@@ -356,7 +356,7 @@ module.exports = ({tasks, cmdOptions, baseDir}) => {
         return utils.skip({});
       }
 
-      const octokit = new Octokit({auth: `token ${cmdOptions.ghToken}`});
+      const octokit = new Octokit({auth: `token ${credentials.ghToken}`});
 
       utils.status({message: `Create Release`});
       const release = await octokit.repos.createRelease({
@@ -409,7 +409,7 @@ module.exports = ({tasks, cmdOptions, baseDir}) => {
 
         await npmPublish({
           dir: path.join(REPO_ROOT, clientName),
-          apiKey: cmdOptions.npmToken,
+          apiKey: credentials.npmToken,
           utils});
       },
     }));
@@ -430,8 +430,8 @@ module.exports = ({tasks, cmdOptions, baseDir}) => {
 
       await pyClientRelease({
         dir: path.join(REPO_ROOT, 'clients', 'client-py'),
-        username: cmdOptions.pypiUsername,
-        password: cmdOptions.pypiPassword,
+        username: credentials.pypiUsername,
+        password: credentials.pypiPassword,
         utils});
     },
   });

--- a/infrastructure/tooling/src/release/tasks.js
+++ b/infrastructure/tooling/src/release/tasks.js
@@ -22,6 +22,7 @@ const {
   writeRepoYAML,
   modifyRepoFile,
   removeRepoFile,
+  pyClientRelease,
   REPO_ROOT,
 } = require('../utils');
 
@@ -414,11 +415,34 @@ module.exports = ({tasks, cmdOptions, baseDir}) => {
     }));
 
   ensureTask(tasks, {
+    title: `Publish clients/client-py to pypi`,
+    requires: [
+      'version-updated',
+      'target-monoimage', // to make sure the build succeeds first..
+    ],
+    provides: [
+      `publish-clients/client-py`,
+    ],
+    run: async (requirements, utils) => {
+      if (!cmdOptions.push) {
+        return utils.skip({});
+      }
+
+      await pyClientRelease({
+        dir: path.join(REPO_ROOT, 'clients', 'client-py'),
+        username: cmdOptions.pypiUsername,
+        password: cmdOptions.pypiPassword,
+        utils});
+    },
+  });
+
+  ensureTask(tasks, {
     title: 'Release Complete',
     requires: [
       'github-release',
       'publish-clients/client',
       'publish-clients/client-web',
+      'publish-clients/client-py',
     ],
     provides: [
       'target-release',

--- a/infrastructure/tooling/src/utils/index.js
+++ b/infrastructure/tooling/src/utils/index.js
@@ -6,4 +6,5 @@ module.exports = {
   ...require('./command'),
   ...require('./config'),
   ...require('./npm'),
+  ...require('./pypi'),
 };

--- a/infrastructure/tooling/src/utils/index.js
+++ b/infrastructure/tooling/src/utils/index.js
@@ -5,4 +5,5 @@ module.exports = {
   ...require('./docker'),
   ...require('./command'),
   ...require('./config'),
+  ...require('./npm'),
 };

--- a/infrastructure/tooling/src/utils/npm.js
+++ b/infrastructure/tooling/src/utils/npm.js
@@ -1,0 +1,47 @@
+const util = require('util');
+const path = require('path');
+const rimraf = util.promisify(require('rimraf'));
+const mkdirp = util.promisify(require('mkdirp'));
+const child_process = require('child_process');
+const Observable = require('zen-observable');
+const taskcluster = require('taskcluster-client');
+const {REPO_ROOT} = require('./repo');
+
+/**
+ * Perform an `npm publish`
+ *
+ * - dir -- directory to publish from
+ * - apiToken -- npm API token
+ * - utils -- taskgraph utils (waitFor, etc.)
+ */
+exports.npmPublish = async ({dir, apiToken, utils}) => {
+  // override HOME so this doesn't use the user's npm token
+  const homeDir = path.join(REPO_ROOT, 'temp', taskcluster.slugid());
+
+  await mkdirp(homeDir);
+  try {
+    await utils.waitFor(new Observable(observer => {
+      const proc = child_process.spawn('npm', ['publish'], {
+        env: {
+          ...process.env,
+          HOME: homeDir,
+          NPM_TOKEN: apiToken,
+        },
+        cwd: dir,
+      });
+      const loglines = data =>
+        data.toString('utf-8').trimRight().split(/[\r\n]+/).forEach(l => observer.next(l));
+      proc.stdout.on('data', loglines);
+      proc.stderr.on('data', loglines);
+      proc.on('close', code => {
+        if (code !== 0) {
+          observer.error(new Error(`npm exited with code ${code}`));
+        } else {
+          observer.complete();
+        }
+      });
+    }));
+  } finally {
+    await rimraf(homeDir);
+  }
+};

--- a/infrastructure/tooling/src/utils/pypi.js
+++ b/infrastructure/tooling/src/utils/pypi.js
@@ -1,0 +1,50 @@
+const util = require('util');
+const path = require('path');
+const rimraf = util.promisify(require('rimraf'));
+const mkdirp = util.promisify(require('mkdirp'));
+const child_process = require('child_process');
+const Observable = require('zen-observable');
+const taskcluster = require('taskcluster-client');
+const {REPO_ROOT} = require('./repo');
+
+/**
+ * Call the Python client's `release.sh`
+ *
+ * - dir -- directory to publish from
+ * - username, password -- for pypi
+ * - utils -- taskgraph utils (waitFor, etc.)
+ */
+exports.pyClientRelease = async ({dir, username, password, utils}) => {
+  // override HOME so this doesn't use the user's credentials
+  const homeDir = path.join(REPO_ROOT, 'temp', taskcluster.slugid());
+
+  await mkdirp(homeDir);
+  try {
+    await utils.waitFor(new Observable(observer => {
+      const proc = child_process.spawn('bash', ['./release.sh'], {
+        env: {
+          ...process.env,
+          HOME: homeDir,
+          TWINE_USERNAME: username,
+          TWINE_PASSWORD: password,
+          TWINE_REPOSITORY_URL: 'https://upload.pypi.org/legacy/',
+          TWINE_NON_INTERACTIVE: '1',
+        },
+        cwd: dir,
+      });
+      const loglines = data =>
+        data.toString('utf-8').trimRight().split(/[\r\n]+/).forEach(l => observer.next(l));
+      proc.stdout.on('data', loglines);
+      proc.stderr.on('data', loglines);
+      proc.on('close', code => {
+        if (code !== 0) {
+          observer.error(new Error(`release.sh exited with code ${code}`));
+        } else {
+          observer.complete();
+        }
+      });
+    }));
+  } finally {
+    await rimraf(homeDir);
+  }
+};


### PR DESCRIPTION
Bugzilla Bug: [1598649](https://bugzilla.mozilla.org/show_bug.cgi?id=1598649)

This will be the first step: automating all parts of the release but still running it locally.  The next step will be to split this up and run most of it in CI, so that `yarn release` tags and pushes, with the rest of the fun happening remotely.

* [x] publish to pypi
* [x] remove debugging commented-out stuff