### PR TITLE
[UI] Add DateTimePicker in UI; fix  clock styles

### DIFF
--- a/changelog/issue-2031.md
+++ b/changelog/issue-2031.md
@@ -1,4 +1,4 @@
 level: minor
 reference: issue 2031
 ---
-Taskcluster UI pickers now feature a time component, so for instance, users can now pick a particular time (hour:minute) on a particular day to set as the expiration time.
+Taskcluster UI revamped the date picker component to allow selecting the hour and the minute in addition to the date.

--- a/changelog/issue-2031.md
+++ b/changelog/issue-2031.md
@@ -1,0 +1,4 @@
+level: minor
+reference: issue 2031
+---
+Taskcluster UI pickers now feature a time component, so for instance, users can now pick a particular time (hour:minute) on a particular day to set as the expiration time.

--- a/ui/src/components/AuthConsent/index.jsx
+++ b/ui/src/components/AuthConsent/index.jsx
@@ -121,7 +121,6 @@ export default class AuthConsent extends Component {
                         name="expires"
                         value={expires}
                         onChange={onExpirationChange}
-                        format="yyyy/MM/dd"
                         maxDate={addYears(new Date(), 1001)}
                       />
                     }

--- a/ui/src/components/ClientForm/index.jsx
+++ b/ui/src/components/ClientForm/index.jsx
@@ -293,7 +293,6 @@ export default class ClientForm extends Component {
                 <DatePicker
                   value={expires}
                   onChange={this.handleExpirationChange}
-                  format="yyyy/MM/dd"
                   maxDate={addYears(new Date(), 1001)}
                 />
               }

--- a/ui/src/components/DatePicker/index.jsx
+++ b/ui/src/components/DatePicker/index.jsx
@@ -2,7 +2,7 @@ import React, { Component } from 'react';
 import { func } from 'prop-types';
 import classNames from 'classnames';
 import {
-  KeyboardDatePicker,
+  KeyboardDateTimePicker,
   MuiPickersUtilsProvider,
 } from '@material-ui/pickers';
 import { withStyles } from '@material-ui/core/styles';
@@ -39,7 +39,7 @@ export default class DatePicker extends Component {
 
     return (
       <MuiPickersUtilsProvider utils={DateFnsUtils}>
-        <KeyboardDatePicker
+        <KeyboardDateTimePicker
           className={classNames(classes.datePicker, className)}
           showTodayButton
           keyboardIcon={<CalendarIcon />}
@@ -47,6 +47,7 @@ export default class DatePicker extends Component {
           leftArrowIcon={<ChevronLeftIcon />}
           value={value}
           onChange={onChange}
+          format="yyyy/MM/dd hh:mm a"
           {...props}
         />
       </MuiPickersUtilsProvider>

--- a/ui/src/components/SecretForm/index.jsx
+++ b/ui/src/components/SecretForm/index.jsx
@@ -204,7 +204,6 @@ export default class SecretForm extends Component {
               label="Expires"
               value={expires}
               onChange={this.handleExpirationChange}
-              format="yyyy/MM/dd"
               maxDate={addYears(new Date(), 1001)}
             />
           </ListItem>

--- a/ui/src/theme.js
+++ b/ui/src/theme.js
@@ -297,7 +297,7 @@ const createTheme = isDarkTheme => {
       },
       MuiPickersToolbarText: {
         toolbarTxt: {
-          color: 'rgba(255, 255, 255, 0.54)',
+          color: THEME.PRIMARY_TEXT_DIMMED,
         },
         toolbarBtnSelected: {
           color: THEME.PRIMARY_TEXT_DARK,
@@ -345,7 +345,7 @@ const createTheme = isDarkTheme => {
         },
         thumb: {
           borderColor: THEME.SECONDARY,
-          backgroundColor: 'rgba(254,255, 255, 0.9)',
+          backgroundColor: THEME.PRIMARY_TEXT_DARK,
         },
         noPoint: {
           backgroundColor: THEME.SECONDARY,
@@ -360,14 +360,9 @@ const createTheme = isDarkTheme => {
         tabs: {
           color: '#fff',
           backgroundColor: THEME.SECONDARY,
-        },
-      },
-      PrivateTabIndicator: {
-        colorPrimary: {
-          backgroundColor: '#fff',
-        },
-        colorSecondary: {
-          backgroundColor: '#000',
+          '& .MuiTabs-indicator': {
+            backgroundColor: isDarkTheme ? '#fff' : '#000',
+          },
         },
       },
       MuiListItem: {

--- a/ui/src/theme.js
+++ b/ui/src/theme.js
@@ -297,7 +297,7 @@ const createTheme = isDarkTheme => {
       },
       MuiPickersToolbarText: {
         toolbarTxt: {
-          color: THEME.PRIMARY_TEXT_DIMMED,
+          color: 'rgba(255, 255, 255, 0.54)',
         },
         toolbarBtnSelected: {
           color: THEME.PRIMARY_TEXT_DARK,

--- a/ui/src/theme.js
+++ b/ui/src/theme.js
@@ -334,6 +334,22 @@ const createTheme = isDarkTheme => {
           },
         },
       },
+      MuiPickersClock: {
+        pin: {
+          backgroundColor: THEME.SECONDARY,
+        }
+      },
+      MuiPickersClockPointer: {
+        pointer: {
+          backgroundColor: THEME.SECONDARY,
+        },
+        thumb: {
+          borderColor: THEME.SECONDARY,
+        },
+        noPoint: {
+          backgroundColor: THEME.SECONDARY,
+        },
+      },
       MuiListItem: {
         root: {
           userSelect: 'text',

--- a/ui/src/theme.js
+++ b/ui/src/theme.js
@@ -358,7 +358,16 @@ const createTheme = isDarkTheme => {
       },
       MuiPickerDTTabs: {
         tabs: {
+          color: '#fff',
           backgroundColor: THEME.SECONDARY,
+        },
+      },
+      PrivateTabIndicator: {
+        colorPrimary: {
+          backgroundColor: '#fff',
+        },
+        colorSecondary: {
+          backgroundColor: '#000',
         },
       },
       MuiListItem: {

--- a/ui/src/theme.js
+++ b/ui/src/theme.js
@@ -297,7 +297,7 @@ const createTheme = isDarkTheme => {
       },
       MuiPickersToolbarText: {
         toolbarTxt: {
-          color: THEME.PRIMARY_TEXT_DARK,
+          color: 'rgba(255, 255, 255, 0.54)',
         },
         toolbarBtnSelected: {
           color: THEME.PRIMARY_TEXT_DARK,
@@ -345,8 +345,19 @@ const createTheme = isDarkTheme => {
         },
         thumb: {
           borderColor: THEME.SECONDARY,
+          backgroundColor: 'rgba(254,255, 255, 0.9)',
         },
         noPoint: {
+          backgroundColor: THEME.SECONDARY,
+        },
+      },
+      MuiPickersClockNumber: {
+        clockNumberSelected: {
+          color: '#fff',
+        },
+      },
+      MuiPickerDTTabs: {
+        tabs: {
           backgroundColor: THEME.SECONDARY,
         },
       },

--- a/ui/src/theme.js
+++ b/ui/src/theme.js
@@ -337,7 +337,7 @@ const createTheme = isDarkTheme => {
       MuiPickersClock: {
         pin: {
           backgroundColor: THEME.SECONDARY,
-        }
+        },
       },
       MuiPickersClockPointer: {
         pointer: {

--- a/ui/src/utils/constants.js
+++ b/ui/src/utils/constants.js
@@ -49,6 +49,7 @@ export const THEME = {
   PRIMARY_TEXT_LIGHT: 'rgba(0, 0, 0, 0.9)',
   SECONDARY_TEXT_DARK: 'rgba(255, 255, 255, 0.7)',
   SECONDARY_TEXT_LIGHT: 'rgba(0, 0, 0, 0.7)',
+  PRIMARY_TEXT_DIMMED: 'rgba(255, 255, 255, 0.54)',
   SECONDARY: '#4177a5',
   DRAWER_WIDTH: 240,
   DIVIDER: 'rgba(0, 0, 0, 0.12)',

--- a/ui/src/utils/constants.js
+++ b/ui/src/utils/constants.js
@@ -49,7 +49,6 @@ export const THEME = {
   PRIMARY_TEXT_LIGHT: 'rgba(0, 0, 0, 0.9)',
   SECONDARY_TEXT_DARK: 'rgba(255, 255, 255, 0.7)',
   SECONDARY_TEXT_LIGHT: 'rgba(0, 0, 0, 0.7)',
-  PRIMARY_TEXT_DIMMED: 'rgba(255, 255, 255, 0.54)',
   SECONDARY: '#4177a5',
   DRAWER_WIDTH: 240,
   DIVIDER: 'rgba(0, 0, 0, 0.12)',


### PR DESCRIPTION
- Replaced `KeyboardDatePicker` with `KeyboardDateTimePicker` to additionally allow choosing time in pickers across the UI
- Removed `format` prop from three components that render `DatePicker` - `SecretForm`, `ClientForm` and `AuthConsent`, so the new `format` in `DatePicker` works correctly
- Introduced new styles in `theme.js` so that the hour and clock hands display prominently in the pickers, across both dark and light themes

For choosing prominent colors for the clock hands, I started by looking at how the colors were displayed on the [material-ui-pickers demo page](https://material-ui-pickers.dev/demo/datetime-picker). It looks like their clock hand colors match the color of the main toolbar, so I decided to go the same route for the picker here, and chose the color of the main toolbar at `/secrets/create` - `#4177a5`, which is defined as `THEME.SECONDARY` - https://github.com/taskcluster/taskcluster/blob/5e6c2b635b916f495873e9b64fd07a69fb090946/ui/src/utils/constants.js#L52

I used the same color for both dark and light themes, and they stood out quite well, but if required, I can change the color based on theme.

---
## Screenshots (clock visibility) 

### Dark Theme 

### Before - 

![2](https://user-images.githubusercontent.com/11348778/69837278-ebefce00-121b-11ea-8c59-9fb1eab0962e.png)

![3](https://user-images.githubusercontent.com/11348778/69837290-fdd17100-121b-11ea-966d-ab19549d3fea.png)

### After - 

![dark-hour](https://user-images.githubusercontent.com/11348778/69837310-10e44100-121c-11ea-89ea-cca529d9d0ac.png)

![dark-min](https://user-images.githubusercontent.com/11348778/69837348-412bdf80-121c-11ea-9832-a3da20253269.png)

---

### Light Theme

###  Before - 
![5-1](https://user-images.githubusercontent.com/11348778/69837606-ac29e600-121d-11ea-9b52-7aff773f17f6.png)

![6-2](https://user-images.githubusercontent.com/11348778/69837616-b2b85d80-121d-11ea-8d0f-07ecb97c380e.png)

### After -

![light-hour-noop](https://user-images.githubusercontent.com/11348778/69837693-03c85180-121e-11ea-9dc7-747ce80df9a6.png)

![light-hour-noppoint](https://user-images.githubusercontent.com/11348778/69837698-075bd880-121e-11ea-8fa7-84e9435e302e.png)

---

I also changed the background-color of `MuiPickersClockPointer.noPoint`, because otherwise, the white circle in the blue looked a bit jarring -

![light-hour](https://user-images.githubusercontent.com/11348778/69837745-468a2980-121e-11ea-8197-6e619361592f.png)
 

---

Github Bug/Issue: Fixes #2031 