### PR TITLE
[UI] Bug 1600125 - Secret form save button outside text area

### DIFF
--- a/changelog/bug-1600125.md
+++ b/changelog/bug-1600125.md
@@ -1,0 +1,4 @@
+level: patch
+reference: bug 1600125
+---
+Taskcluster UI Secret view no longer requires the save button to be under the code editor to save a secret.

--- a/ui/src/components/SecretForm/index.jsx
+++ b/ui/src/components/SecretForm/index.jsx
@@ -25,6 +25,7 @@ import { secret } from '../../utils/prop-types';
 @withStyles(theme => ({
   fab: {
     ...theme.mixins.fab,
+    ...theme.mixins.actionButton,
   },
   saveSecretSpan: {
     position: 'fixed',


### PR DESCRIPTION
Bugzilla Bug: [1600125](https://bugzilla.mozilla.org/show_bug.cgi?id=1600125)