### PR TITLE
[UI] Enable form save button on edit if logged out

### DIFF
--- a/ui/src/components/ClientForm/index.jsx
+++ b/ui/src/components/ClientForm/index.jsx
@@ -385,7 +385,6 @@ export default class ClientForm extends Component {
         ) : (
           <Fragment>
             <Button
-              requiresAuth
               tooltipOpen
               variant="round"
               onClick={this.handleSaveClient}

--- a/ui/src/components/HookForm/index.jsx
+++ b/ui/src/components/HookForm/index.jsx
@@ -813,7 +813,6 @@ export default class HookForm extends Component {
                 ),
               }}
               tooltipProps={{ title: 'Save Hook' }}
-              requiresAuth
               classes={{ root: classes.successIcon }}
               variant="round"
               disabled={!this.validHook() || actionLoading || !isHookDirty}

--- a/ui/src/components/RoleForm/index.jsx
+++ b/ui/src/components/RoleForm/index.jsx
@@ -282,7 +282,6 @@ export default class RoleForm extends Component {
               spanProps={{
                 className: classNames(classes.fab, classes.saveRoleSpan),
               }}
-              requiresAuth
               tooltipOpen
               onClick={this.handleSaveRole}
               className={classes.saveIcon}

--- a/ui/src/components/SecretForm/index.jsx
+++ b/ui/src/components/SecretForm/index.jsx
@@ -255,7 +255,6 @@ export default class SecretForm extends Component {
                 className: classNames(classes.fab, classes.saveSecretSpan),
               }}
               tooltipProps={{ title: 'Save Secret' }}
-              requiresAuth
               classes={{ root: classes.successIcon }}
               variant="round"
               className={classes.saveIcon}

--- a/ui/src/components/WMWorkerPoolEditor/index.jsx
+++ b/ui/src/components/WMWorkerPoolEditor/index.jsx
@@ -286,6 +286,14 @@ export default class WMWorkerPoolEditor extends Component {
       onDialogActionComplete,
     } = this.props;
     const { workerPool, error, actionLoading, validation } = this.state;
+    const { description, emailOnError, owner, providerId, workerPoolId } = this.props.workerPool;
+    const isWorkerPoolDirty =
+      isNewWorkerPool ||
+      workerPool.description !== description ||
+      workerPool.emailOnError !== emailOnError ||
+      workerPool.owner !== owner ||
+      workerPool.providerId !== providerId ||
+      joinWorkerPoolId(workerPool.workerPoolId1, workerPool.workerPoolId2) !== workerPoolId;
 
     return (
       <Fragment>
@@ -404,8 +412,7 @@ export default class WMWorkerPoolEditor extends Component {
               : classes.saveIconSpan,
           }}
           name="saveRequest"
-          disabled={!this.isValid()}
-          requiresAuth
+          disabled={!this.isValid() || !isWorkerPoolDirty}
           tooltipProps={{ title: 'Save Worker Pool' }}
           onClick={this.handleOnClick}
           classes={{ root: classes.saveIcon }}


### PR DESCRIPTION
- Remove requiresAuth attribute from save button when editing
- Add isWorkerPoolDirty variable to serve as condition when checking for changes to enable/disable worked pool editor form save button

Github Bug/Issue: Fixes #1961