### PR TITLE
Bug 1601149 - accept non-escaped github PEMs with multiple lines

### DIFF
--- a/changelog/bug-1601149.md
+++ b/changelog/bug-1601149.md
@@ -1,0 +1,5 @@
+level: patch
+reference: bug 1601149
+---
+The `github.github_private_pem` Helm configuration now correctly accepts a configuration containing raw (unescaped) newlines.
+A change to how configuration values are escaped in the Helm templates caused this support to regress in 24.0.0.

--- a/services/github/src/github-auth.js
+++ b/services/github/src/github-auth.js
@@ -25,7 +25,7 @@ const retryPlugin = (octokit, options) => {
 const Octokit = require('@octokit/rest').plugin([retryPlugin]);
 
 const getPrivatePEM = cfg => {
-  const keyRe = /-----BEGIN RSA PRIVATE KEY-----(\n|\\n).*(\n|\\n)-----END RSA PRIVATE KEY-----(\n|\\n)?/;
+  const keyRe = /-----BEGIN RSA PRIVATE KEY-----(\n|\\n).*(\n|\\n)-----END RSA PRIVATE KEY-----(\n|\\n)?/s;
   const privatePEM = cfg.github.credentials.privatePEM;
   if (!keyRe.test(privatePEM)) {
     throw new Error(`Malformed GITHUB_PRIVATE_PEM: must match ${keyRe}; ` +

--- a/services/github/test/github-auth_test.js
+++ b/services/github/test/github-auth_test.js
@@ -2,18 +2,19 @@ const assert = require('assert');
 const githubAuth = require('../src/github-auth');
 const testing = require('taskcluster-lib-testing');
 
+const WITH_NEWLINES = '-----BEGIN RSA PRIVATE KEY-----\nsomekey\nline2\n-----END RSA PRIVATE KEY-----';
+const WITH_ESCAPED_NEWLINES = '-----BEGIN RSA PRIVATE KEY-----\\nsomekey\\nline2\\n-----END RSA PRIVATE KEY-----';
+
 suite(testing.suiteName(), function() {
   suite('getPrivatePEM', function() {
-    const privatePEM = '-----BEGIN RSA PRIVATE KEY-----\nsomekey\n-----END RSA PRIVATE KEY-----';
-
     test('with actual newlines', function() {
-      const cfg = {github: {credentials: {privatePEM}}};
-      assert.equal(githubAuth.getPrivatePEM(cfg), privatePEM);
+      const cfg = {github: {credentials: {privatePEM: WITH_NEWLINES}}};
+      assert.equal(githubAuth.getPrivatePEM(cfg), WITH_NEWLINES);
     });
 
     test('with escaped newlines', function() {
-      const cfg = {github: {credentials: {privatePEM: privatePEM.replace(/\n/g, '\\n')}}};
-      assert.equal(githubAuth.getPrivatePEM(cfg), privatePEM);
+      const cfg = {github: {credentials: {privatePEM: WITH_ESCAPED_NEWLINES}}};
+      assert.equal(githubAuth.getPrivatePEM(cfg), WITH_NEWLINES);
     });
 
     test('with invalid value', function() {


### PR DESCRIPTION
Bugzilla Bug: [1601149](https://bugzilla.mozilla.org/show_bug.cgi?id=1601149)
