### PR TITLE
Update yarn to latest release

### DIFF
--- a/.yarnrc
+++ b/.yarnrc
@@ -2,5 +2,5 @@
 # yarn lockfile v1
 
 
-lastUpdateCheck 1571157270895
-yarn-path ".yarn/releases/yarn-1.19.1.js"
+lastUpdateCheck 1575566019664
+yarn-path ".yarn/releases/yarn-1.21.0.js"

--- a/changelog/bug-2114.md
+++ b/changelog/bug-2114.md
@@ -1,0 +1,3 @@
+level: silent
+reference: bug 2114
+---

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "engine-strict": true,
   "engines": {
     "node": "12.13.1",
-    "yarn": "^1.0.0"
+    "yarn": "^1.21.0"
   },
   "workspaces": [
     "libraries/*",

--- a/ui/package.json
+++ b/ui/package.json
@@ -5,7 +5,7 @@
   "license": "MPL-2.0",
   "engines": {
     "node": "12.13.1",
-    "yarn": ">=1.10.0"
+    "yarn": "^1.21.0"
   },
   "scripts": {
     "build": "webpack --mode production",


### PR DESCRIPTION
This is accomplished via `yarn policies set-version` and then
updating the `package.json` engines sections (both ui and metapackage). I've left that note in the commit comment so we can remember how to do this next time.

This replaces #2114