### PR TITLE
Bug 1587511 pt 1 tests

### DIFF
--- a/changelog/bug-1577839.md
+++ b/changelog/bug-1577839.md
@@ -1,0 +1,4 @@
+level: silent
+reference: bug 1577839
+---
+Add tests for AWS provider

--- a/services/worker-manager/src/providers/aws.js
+++ b/services/worker-manager/src/providers/aws.js
@@ -115,11 +115,13 @@ class AwsProvider extends Provider {
       // Make sure we don't get "The same resource type may not be specified
       // more than once in tag specifications" errors
       const TagSpecifications = config.launchConfig.TagSpecifications || [];
-      const instanceTags = [];
-      const otherTagSpecs = [];
-      TagSpecifications.forEach(ts =>
-        ts.ResourceType === 'instance' ? instanceTags.concat(ts.Tags) : otherTagSpecs.push(ts),
-      );
+      let instanceTags = [];
+      let otherTagSpecs = [];
+      TagSpecifications.forEach(ts => {
+        ts.ResourceType === 'instance'
+          ? instanceTags = instanceTags.concat(ts.Tags)
+          : otherTagSpecs.push(ts);
+      });
 
       const userData = Buffer.from(JSON.stringify({
         ...config.additionalUserData,

--- a/services/worker-manager/src/providers/aws.js
+++ b/services/worker-manager/src/providers/aws.js
@@ -297,7 +297,7 @@ class AwsProvider extends Provider {
       throw e;
     }
 
-    Promise.all(instanceStatuses.map(is => {
+    return Promise.all(instanceStatuses.map(is => {
       switch (is.InstanceState.Name) {
         case 'pending':
         case 'running':
@@ -316,7 +316,7 @@ class AwsProvider extends Provider {
           return worker.modify(w => {w.state = this.Worker.states.STOPPED;});
 
         default:
-          return Promise.reject(`Unknown state: ${is.InstanceState.Name} for ${is.InstanceId}`);
+          return Promise.reject(new Error(`Unknown state: ${is.InstanceState.Name} for ${is.InstanceId}`));
       }
     }));
   }

--- a/services/worker-manager/test/fake-aws.js
+++ b/services/worker-manager/test/fake-aws.js
@@ -1,46 +1,42 @@
-const assert = require('assert');
-
 module.exports = {
   EC2: {
-    runInstances: ({defaultLaunchConfig, TagSpecifications, UserData}) => launchConfig => {
-      assert.deepStrictEqual(launchConfig,
-        {
-          ...defaultLaunchConfig.launchConfig,
-          MinCount: launchConfig.MinCount, // this is estimator's functionality, no need to test this here
-          MaxCount: launchConfig.MaxCount,
-          TagSpecifications,
-          UserData: Buffer.from(JSON.stringify(UserData)).toString('base64'),
-        },
-      );
+    runInstances: () => {
+      const fake = launchConfig => {
+        fake.calls.push({launchConfig});
 
-      let Instances = [];
-      for (let i = 0; i < launchConfig.MinCount; i++) {
-        Instances.push({
-          InstanceId: `i-${i}`,
-          AmiLaunchIndex: '',
-          ImageId: launchConfig.ImageId,
-          InstanceType: launchConfig.InstanceType || 'm2.micro',
-          Architecture: 'x86',
-          Placement: {
-            AvailabilityZone: 'someregion',
-          },
-          PrivateIpAddress: '1.1.1.1',
-          OwnerId: '123123123',
-          State: {
-            Name: 'running',
-          },
-          StateReason: {
-            Message: 'yOu LaunCHed iT!!!1',
-          },
-        });
-      }
-      return {
-        promise: () => ({
-          Instances,
-          Groups: [],
-          OwnerId: '123123123',
-        }),
+        let Instances = [];
+        for (let i = 0; i < launchConfig.MinCount; i++) {
+          Instances.push({
+            InstanceId: `i-${i}`,
+            AmiLaunchIndex: '',
+            ImageId: launchConfig.ImageId,
+            InstanceType: launchConfig.InstanceType || 'm2.micro',
+            Architecture: 'x86',
+            Placement: {
+              AvailabilityZone: 'someregion',
+            },
+            PrivateIpAddress: '1.1.1.1',
+            OwnerId: '123123123',
+            State: {
+              Name: 'running',
+            },
+            StateReason: {
+              Message: 'yOu LaunCHed iT!!!1',
+            },
+          });
+        }
+        return {
+          promise: () => ({
+            Instances,
+            Groups: [],
+            OwnerId: '123123123',
+          }),
+        };
       };
+
+      fake.calls = [];
+
+      return fake;
     },
 
     describeRegions: () => {

--- a/services/worker-manager/test/fake-aws.js
+++ b/services/worker-manager/test/fake-aws.js
@@ -63,5 +63,16 @@ module.exports = {
         }),
       };
     },
+
+    // to make this function return the status you want, pass it in as an instance id
+    // in other words, make the status your workerId in the worker fixture
+    describeInstanceStatus: options => ({
+      promise: () => ({
+        InstanceStatuses: [{
+          InstanceState: {Name: options.InstanceIds[0]},
+          InstanceId: 'dummy-worker',
+        }],
+      }),
+    }),
   },
 };

--- a/services/worker-manager/test/fixtures/schemas/sample-aws-worker-pull.json
+++ b/services/worker-manager/test/fixtures/schemas/sample-aws-worker-pull.json
@@ -1,4 +1,12 @@
 {
+  "workerPoolId": "delete/worker",
+  "providerId": "aws",
+  "description": "a workertype",
+  "owner": "owlish@mozilla.com",
+  "emailOnError": true,
+  "created": "2019-10-18T21:16:41.593Z",
+  "lastModified": "2019-10-18T21:16:41.593Z",
+  "config": {
     "launchConfigs": [
       {
         "launchConfig": {
@@ -28,3 +36,4 @@
     "minCapacity": 1,
     "maxCapacity": 1
   }
+}

--- a/services/worker-manager/test/fixtures/schemas/sample-google-config.json
+++ b/services/worker-manager/test/fixtures/schemas/sample-google-config.json
@@ -1,0 +1,19 @@
+{
+  "launchConfigs": [
+    {
+      "launchConfig": {
+        "ImageId": "banana"
+      },
+      "region": "us-west",
+      "capacityPerInstance": 1,
+      "workerConfig": {},
+      "zone": "darkness",
+      "machineType": "some-cool-type",
+      "disks": [],
+      "networkInterfaces": [],
+      "scheduling": {}
+    }
+  ],
+  "minCapacity": 1,
+  "maxCapacity": 1
+}

--- a/services/worker-manager/test/provider_aws_test.js
+++ b/services/worker-manager/test/provider_aws_test.js
@@ -1,3 +1,5 @@
+/* eslint-disable comma-dangle */
+
 const {ApiError} = require('../src/providers/provider');
 const assert = require('assert');
 const sinon = require('sinon');
@@ -48,32 +50,6 @@ helper.secrets.mockSuite(testing.suiteName(), ['azure'], function(mock, skipping
     providerData: {},
     emailOnError: false,
   };
-  const TagSpecifications = [
-    ...(defaultLaunchConfig.launchConfig.TagSpecifications ? defaultLaunchConfig.launchConfig.TagSpecifications : []),
-    {
-      ResourceType: 'instance',
-      Tags: [
-        {
-          Key: 'CreatedBy',
-          Value: `taskcluster-wm-${providerId}`,
-        }, {
-          Key: 'Owner',
-          Value: workerPool.owner,
-        },
-        {
-          Key: 'ManagedBy',
-          Value: 'taskcluster',
-        },
-        {
-          Key: 'Name',
-          Value: `${workerPoolId}`,
-        },
-        {
-          Key: 'WorkerPoolId',
-          Value: `${workerPoolId}`,
-        }],
-    },
-  ];
   const defaultWorker = {
     workerPoolId,
     workerGroup: providerId,
@@ -212,7 +188,7 @@ helper.secrets.mockSuite(testing.suiteName(), ['azure'], function(mock, skipping
               {Key: "WorkerPoolId", Value: "foo/bar"},
             ],
           },
-        ]
+        ],
       );
 
       sinon.restore();
@@ -230,10 +206,10 @@ helper.secrets.mockSuite(testing.suiteName(), ['azure'], function(mock, skipping
 
       assert.notStrictEqual(workers.entries.length, 0);
       assert.deepStrictEqual(
-         JSON.parse(Buffer.from(
-           ...aws.EC2().runInstances.calls.map(({launchConfig: {UserData}}) => UserData),
-           'base64'
-         ).toString()),
+        JSON.parse(Buffer.from(
+          ...aws.EC2().runInstances.calls.map(({launchConfig: {UserData}}) => UserData),
+          'base64'
+        ).toString()),
         {
           somethingImportant: 'apple',
           rootUrl: provider.rootUrl,

--- a/services/worker-manager/test/provider_aws_test.js
+++ b/services/worker-manager/test/provider_aws_test.js
@@ -1,5 +1,3 @@
-/* eslint-disable comma-dangle */
-
 const {ApiError} = require('../src/providers/provider');
 const assert = require('assert');
 const sinon = require('sinon');
@@ -208,7 +206,7 @@ helper.secrets.mockSuite(testing.suiteName(), ['azure'], function(mock, skipping
       assert.deepStrictEqual(
         JSON.parse(Buffer.from(
           ...aws.EC2().runInstances.calls.map(({launchConfig: {UserData}}) => UserData),
-          'base64'
+          'base64' // eslint-disable-line comma-dangle
         ).toString()),
         {
           somethingImportant: 'apple',
@@ -217,7 +215,7 @@ helper.secrets.mockSuite(testing.suiteName(), ['azure'], function(mock, skipping
           providerId: provider.providerId,
           workerGroup: provider.providerId,
           workerConfig: workerPool.config.launchConfigs[0].workerConfig,
-        }
+        } // eslint-disable-line comma-dangle
       );
 
       sinon.restore();
@@ -357,7 +355,7 @@ helper.secrets.mockSuite(testing.suiteName(), ['azure'], function(mock, skipping
       const workers = await helper.Worker.scan({}, {});
       assert.notStrictEqual(workers.entries.length, 0);
       workers.entries.forEach(w =>
-        assert.strictEqual(w.state, helper.Worker.states.STOPPED)
+        assert.strictEqual(w.state, helper.Worker.states.STOPPED) // eslint-disable-line comma-dangle
       );
       assert.strictEqual(provider.seen[worker.workerPoolId], 0);
 
@@ -377,7 +375,7 @@ helper.secrets.mockSuite(testing.suiteName(), ['azure'], function(mock, skipping
       const workers = await helper.Worker.scan({}, {});
       assert.notStrictEqual(workers.entries.length, 0);
       workers.entries.forEach(w =>
-        assert.strictEqual(w.state, helper.Worker.states.REQUESTED)
+        assert.strictEqual(w.state, helper.Worker.states.REQUESTED) // eslint-disable-line comma-dangle
       );
       assert.strictEqual(provider.seen[worker.workerPoolId], 1);
 
@@ -411,7 +409,7 @@ helper.secrets.mockSuite(testing.suiteName(), ['azure'], function(mock, skipping
       const workers = await helper.Worker.scan({}, {});
       assert.notStrictEqual(workers.entries.length, 0);
       workers.entries.forEach(w =>
-        assert.strictEqual(w.state, helper.Worker.states.STOPPED)
+        assert.strictEqual(w.state, helper.Worker.states.STOPPED) // eslint-disable-line comma-dangle
       );
       assert.strictEqual(provider.seen[worker.workerPoolId], 0);
 

--- a/services/worker-manager/test/provider_aws_test.js
+++ b/services/worker-manager/test/provider_aws_test.js
@@ -91,6 +91,7 @@ helper.secrets.mockSuite(testing.suiteName(), ['azure'], function(mock, skipping
       region: actualWorkerIid.region,
       imageId: actualWorkerIid.imageId,
       instanceType: actualWorkerIid.instanceType,
+      instanceCapacity: defaultLaunchConfig.capacityPerInstance,
       architecture: actualWorkerIid.architecture,
       availabilityZone: actualWorkerIid.availabilityZone,
       privateIp: actualWorkerIid.privateIp,
@@ -366,21 +367,78 @@ helper.secrets.mockSuite(testing.suiteName(), ['azure'], function(mock, skipping
   });
 
   suite('AWS provider - checkWorker', function() {
-    // TODO: Can someone fill these out and then I'll add tests for the lifecycle stuff here as well?
 
-    test('stopped and terminated instances - should be marked as STOPPED in DB', async function() {
+    test('stopped instances - should be marked as STOPPED in DB, should not add to seen', async function() {
+      const worker = await helper.Worker.create({
+        ...workerInDB,
+        workerId: 'stopped', // stub function will return this as status
+        state: helper.Worker.states.RUNNING,
+      });
+
+      provider.seen = {};
+      await provider.checkWorker({worker: worker});
+
+      const workers = await helper.Worker.scan({}, {});
+      assert.notStrictEqual(workers.entries.length, 0);
+      workers.entries.forEach(w =>
+        assert.strictEqual(w.state, helper.Worker.states.STOPPED)
+      );
+      assert.strictEqual(provider.seen[worker.workerPoolId], 0);
+
       sinon.restore();
     });
 
     test('pending/running,/shutting-down/stopping instances - should not reject', async function() {
+      const worker = await helper.Worker.create({
+        ...workerInDB,
+        workerId: 'running', // stub function will return this as status
+        state: helper.Worker.states.REQUESTED,
+      });
+
+      provider.seen = {};
+      await provider.checkWorker({worker: worker});
+
+      const workers = await helper.Worker.scan({}, {});
+      assert.notStrictEqual(workers.entries.length, 0);
+      workers.entries.forEach(w =>
+        assert.strictEqual(w.state, helper.Worker.states.REQUESTED)
+      );
+      assert.strictEqual(provider.seen[worker.workerPoolId], 1);
+
       sinon.restore();
     });
 
     test('some strange status - should reject', async function() {
+      const worker = await helper.Worker.create({
+        ...workerInDB,
+        workerId: 'banana', // stub function will return this as status
+        state: helper.Worker.states.REQUESTED,
+      });
+
+      provider.seen = {};
+      await assert.rejects(provider.checkWorker({worker: worker}));
+      assert.strictEqual(provider.seen[worker.workerPoolId], 0);
+
       sinon.restore();
     });
 
     test('instance terminated by hand - should be marked as STOPPED in DB; should not reject', async function() {
+      const worker = await helper.Worker.create({
+        ...workerInDB,
+        workerId: 'terminated', // stub function will return this as status
+        state: helper.Worker.states.RUNNING,
+      });
+
+      provider.seen = {};
+      await provider.checkWorker({worker: worker});
+
+      const workers = await helper.Worker.scan({}, {});
+      assert.notStrictEqual(workers.entries.length, 0);
+      workers.entries.forEach(w =>
+        assert.strictEqual(w.state, helper.Worker.states.STOPPED)
+      );
+      assert.strictEqual(provider.seen[worker.workerPoolId], 0);
+
       sinon.restore();
     });
   });

--- a/services/worker-manager/test/provider_aws_test.js
+++ b/services/worker-manager/test/provider_aws_test.js
@@ -128,7 +128,7 @@ helper.secrets.mockSuite(testing.suiteName(), ['azure'], function(mock, skipping
 
     sinon.stub(aws, 'EC2').returns({
       ...fakeAWS.EC2,
-      runInstances: fakeAWS.EC2.runInstances({defaultLaunchConfig, TagSpecifications, UserData}),
+      runInstances: fakeAWS.EC2.runInstances(),
     });
 
     await provider.setup();
@@ -156,10 +156,71 @@ helper.secrets.mockSuite(testing.suiteName(), ['azure'], function(mock, skipping
     });
 
     test('instance tags in launch spec - should merge them with our instance tags', async function() {
+      await workerPool.modify(wp => {
+        wp.config.launchConfigs[0].launchConfig.TagSpecifications = [{
+          ResourceType: 'instance',
+          Tags: [{Key: 'mytag', Value: 'testy'}],
+        }];
+      });
+
+      await provider.provision({workerPool});
+      const workers = await helper.Worker.scan({}, {});
+
+      assert.notStrictEqual(workers.entries.length, 0);
+      assert.deepStrictEqual(
+        ...aws.EC2().runInstances.calls.map(({launchConfig: {TagSpecifications}}) => TagSpecifications),
+        [
+          {
+            ResourceType: 'instance',
+            Tags: [
+              {Key: 'mytag', Value: 'testy'},
+              {Key: 'CreatedBy', Value: 'taskcluster-wm-aws'},
+              {Key: 'Owner', Value: 'whatever@example.com'},
+              {Key: 'ManagedBy', Value: 'taskcluster'},
+              {Key: 'Name', Value: 'foo/bar'},
+              {Key: "WorkerPoolId", Value: "foo/bar"},
+            ],
+          },
+        ],
+      );
+
       sinon.restore();
     });
 
     test('no instance tags in launch spec, but other tags - should have 1 object per resource type', async function() {
+      await workerPool.modify(wp => {
+        wp.config.launchConfigs[0].launchConfig.TagSpecifications = [{
+          ResourceType: 'launch-template',
+          Tags: [{Key: 'fruit', Value: 'banana'}],
+        }];
+      });
+
+      await provider.provision({workerPool});
+      const workers = await helper.Worker.scan({}, {});
+
+      assert.notStrictEqual(workers.entries.length, 0);
+      assert.deepStrictEqual(
+        ...aws.EC2().runInstances.calls.map(({launchConfig: {TagSpecifications}}) => TagSpecifications),
+        [
+          {
+            ResourceType: 'launch-template',
+            Tags: [
+              {Key: 'fruit', Value: 'banana'},
+            ],
+          },
+          {
+            ResourceType: 'instance',
+            Tags: [
+              {Key: 'CreatedBy', Value: 'taskcluster-wm-aws'},
+              {Key: 'Owner', Value: 'whatever@example.com'},
+              {Key: 'ManagedBy', Value: 'taskcluster'},
+              {Key: 'Name', Value: 'foo/bar'},
+              {Key: "WorkerPoolId", Value: "foo/bar"},
+            ],
+          },
+        ]
+      );
+
       sinon.restore();
     });
 

--- a/services/worker-manager/test/provider_aws_test.js
+++ b/services/worker-manager/test/provider_aws_test.js
@@ -74,13 +74,6 @@ helper.secrets.mockSuite(testing.suiteName(), ['azure'], function(mock, skipping
         }],
     },
   ];
-  const UserData = {
-    rootUrl: helper.rootUrl,
-    workerPoolId,
-    providerId,
-    workerGroup: providerId,
-    workerConfig: {foo: 5},
-  };
   const defaultWorker = {
     workerPoolId,
     workerGroup: providerId,
@@ -225,6 +218,31 @@ helper.secrets.mockSuite(testing.suiteName(), ['azure'], function(mock, skipping
     });
 
     test('UserData should be base64 encoded', async function() {
+      await workerPool.modify(wp => {
+        wp.config.launchConfigs[0].additionalUserData = {
+          somethingImportant: "apple",
+        };
+      });
+
+      await provider.provision({workerPool});
+      const workers = await helper.Worker.scan({}, {});
+
+      assert.notStrictEqual(workers.entries.length, 0);
+      assert.deepStrictEqual(
+         JSON.parse(Buffer.from(
+           ...aws.EC2().runInstances.calls.map(({launchConfig: {UserData}}) => UserData),
+           'base64'
+         ).toString()),
+        {
+          somethingImportant: 'apple',
+          rootUrl: provider.rootUrl,
+          workerPoolId: workerPool.workerPoolId,
+          providerId: provider.providerId,
+          workerGroup: provider.providerId,
+          workerConfig: workerPool.config.launchConfigs[0].workerConfig,
+        }
+      );
+
       sinon.restore();
     });
   });

--- a/services/worker-manager/test/schema_validate_test.js
+++ b/services/worker-manager/test/schema_validate_test.js
@@ -21,8 +21,6 @@ suite(testing.suiteName(), () => {
         path: 'sample-aws-config.json',
         success: true,
       },
-
-
       {
         schema: 'v1/config-google.json#',
         path: 'sample-google-config.json',

--- a/services/worker-manager/test/schema_validate_test.js
+++ b/services/worker-manager/test/schema_validate_test.js
@@ -13,7 +13,19 @@ suite(testing.suiteName(), () => {
     cases: [
       {
         schema: 'v1/worker-pool-full.json#',
+        path: 'sample-aws-worker-pull.json',
+        success: true,
+      },
+      {
+        schema: 'v1/config-aws.json#',
         path: 'sample-aws-config.json',
+        success: true,
+      },
+
+
+      {
+        schema: 'v1/config-google.json#',
+        path: 'sample-google-config.json',
         success: true,
       },
     ],


### PR DESCRIPTION
<!-- Did you remember to add a changelog snippet? See
     https://github.com/taskcluster/taskcluster/blob/master/dev-docs/best-practices/changelog.md

     If this is related to a Bugzilla bug, please begin your title with [Bug XXXXX]
     and update this link.  Otherwise, just remove it from your PR comment.  -->

Bugzilla Bug: [1577839](https://bugzilla.mozilla.org/show_bug.cgi?id=1577839)

I'd like some feedback on the way I stub `EC2.describeInstanceStatus`, especially from @djmitche (I know bstack approves)

I disabled "comma-dangle" for the file because I'd like to format long function arguments on every line, and you don't need a comma after the last function argument or parameter

I used Dustin's idea of `fake.call` in the `EC2.runInstances` stub. Re: [this comment in the old Dustin's PR](https://github.com/taskcluster/taskcluster/pull/1701/files#diff-71648e88330ea7c4c8837b3d2fadf21eR5) - the bug in the fixture was that in my eternal wisdom I instantiated the stub and passed in default `TagSpecifications`, so that was the only thing the stub could assert on. In case of user-defined tags, we needed to assert on the whole entirety: the default tags + the user tags. Assertion itself _did_ work tho 😛😄 I agree, however, that assertions are better done in one place instead of in two places, so the `fake.call` was brought from the above PR.