### PR TITLE
[github] Add a flexible route for handling task status reporting.

### DIFF
--- a/services/github/src/main.js
+++ b/services/github/src/main.js
@@ -201,6 +201,7 @@ const load = loader({
       'publisher',
       'CheckRuns',
       'ChecksToTasks',
+      'OwnersDirectory',
     ],
     setup: async ({
       cfg,
@@ -214,6 +215,7 @@ const load = loader({
       publisher,
       CheckRuns,
       ChecksToTasks,
+      OwnersDirectory,
     }) =>
       new Handlers({
         rootUrl: cfg.taskcluster.rootUrl,
@@ -226,8 +228,9 @@ const load = loader({
         deprecatedInitialStatusQueueName: cfg.app.deprecatedInitialStatusQueue,
         resultStatusQueueName: cfg.app.resultStatusQueue,
         initialStatusQueueName: cfg.app.initialStatusQueue,
-        context: {cfg, github, schemaset, Builds, CheckRuns, ChecksToTasks, publisher},
+        context: {cfg, github, schemaset, Builds, CheckRuns, ChecksToTasks, publisher, OwnersDirectory},
         pulseClient,
+        OwnersDirectory,
       }),
   },
 

--- a/services/github/src/parse-route.js
+++ b/services/github/src/parse-route.js
@@ -1,0 +1,48 @@
+// Routing key will be in the form:
+// treeherder.<version>.<user/project>|<project>.<revision>.<pushLogId/pullRequestId>
+// [0] routing key prefix used for listening to only treeherder relevant messages
+// [1] routing key version
+// [2] in the form of user/project for github repos and just project for hg.mozilla.org
+// [3] Top level revision for the push
+// [4] Pull Request ID (github) or Push Log ID (hg.mozilla.org) of the push
+//     Note: pushes ot a branch on github would not have a PR ID
+module.exports = function parseRoute(route) {
+  let project, revision, pushId, version, owner, parsedProject;
+
+  let parsedRoute = route.split('.');
+  let destination = parsedRoute[0];
+  let version = parsedRoute[1];
+
+  try {
+    switch (version) {
+      case 'v1':
+	if (parsedRoute[2] != "checks") {
+	  throw new Error();
+        }
+	organization = parsedRoute[3];
+	repositorh = parsedRoute[4];
+	eventType = parsedRoute[5];
+	revision = parsedRoute[6];
+	if (parsedRoute.length !== 7) {
+          throw new Error();
+	}
+	break;
+      default:
+        throw new Error();
+    }
+  } catch (e) {
+    throw new Error(
+      'Unrecognized treeherder routing key format. Possible formats are:\n' +
+      'v1: github.v1.checks.<owner>.<repository>.<event>.<revision>' +
+      `but received: ${route}`
+    );
+  }
+
+  return {
+    destination: destination,
+    organization: organization,
+    repository: repository,
+    sha: revision,
+    eventType: eventType,
+  };
+};


### PR DESCRIPTION
Bugzilla Bug: [1533235](https://bugzilla.mozilla.org/show_bug.cgi?id=1533235)

@owlishDeveloper  We've talked a few times about having a more flexible route that can be used to report checks from tasks. This is a very quick sketch of what ain implementation for it might look like.