### PR TITLE
[bug 1602642] Fix typo in allowed buckets config

### DIFF
--- a/changelog/bug-1602642.md
+++ b/changelog/bug-1602642.md
@@ -1,0 +1,6 @@
+level: patch
+reference: bug 1602642
+---
+The typo in configuration for aws s3 bucket credentialing is fixed.
+
+It was set as `allowdBuckets` and is now `allowedBuckets`

--- a/services/auth/config.yml
+++ b/services/auth/config.yml
@@ -100,7 +100,7 @@ defaults:
     # - accessKeyId: ..
     #   secretAccessKey: ..
     #   buckets: [bucket1, bucket2, ..]
-    allowdBuckets:            !env:json:optional AWS_CREDENTIALS_ALLOWED_BUCKETS
+    allowedBuckets:            !env:json:optional AWS_CREDENTIALS_ALLOWED_BUCKETS
 
   # Configuration for the GCP serviceAccounts to which the `gcpCredentials`
   # endpoint can grant access.


### PR DESCRIPTION
<!-- Did you remember to add a changelog snippet? See
     https://github.com/taskcluster/taskcluster/blob/master/dev-docs/best-practices/changelog.md

     If this is related to a Bugzilla bug, please begin your title with [Bug XXXXX]
     and update this link.  Otherwise, just remove it from your PR comment.  -->

Bugzilla Bug: [1602642](https://bugzilla.mozilla.org/show_bug.cgi?id=1602642)

<!-- If this is related to a GitHub Bug/Issue, Please write Issue Number after # in the next line. Otherwise, just remove it from your PR comment. -->

Note: This can either land on master and deploy with 24.1.0 or it can land and then we make a branch to make 24.0.2.