### PR TITLE
[tc-lib-postgres] Do not allow capital letters for db methods

### DIFF
--- a/db/0001.yml
+++ b/db/0001.yml
@@ -8,16 +8,16 @@ migrationScript: |-
     );
   end
 methods:
-  getSecret:
+  get_secret:
     mode: read
     serviceName: secrets
     args: name text
     returns: table (secret text, expires timestamp)
     body: |-
       begin
-        return query select secrets.secret, secrets.expires from secrets where secrets.name = getSecret.name;
+        return query select secrets.secret, secrets.expires from secrets where secrets.name = get_secret.name;
       end
-  listSecrets:
+  list_secrets:
     mode: read
     serviceName: secrets
     args: ''
@@ -26,7 +26,7 @@ methods:
       begin
         return query select secrets.name as name, secrets.expires as expires from secrets;
       end
-  removeSecret:
+  remove_secret:
     mode: write
     serviceName: secrets
     args: name text
@@ -35,7 +35,7 @@ methods:
       begin
         delete from secrets where name = name;
       end
-  setSecret:
+  set_secret:
     mode: write
     serviceName: secrets
     args: name text, secret text, expires timestamp
@@ -48,7 +48,7 @@ methods:
       end
 
 
-      this.db.procs.secrets.listSecrets
+      this.db.procs.secrets.list_secrets
 
       db = Database.setup({serviceName: 'worker-manager', readDbUrl, writeDbUrl, ...})
       get all read methods for all services

--- a/libraries/postgres/src/Database.js
+++ b/libraries/postgres/src/Database.js
@@ -25,6 +25,9 @@ class Database {
 
     // generate a JS method for each DB method defined in the schema
     schema.allMethods().forEach(({ name, mode}) => {
+      // ensure that quoting of identifiers is correct
+      assert(!/.*[A-Z].*/.test(name), 'db procedure methods should not have capital letters');
+
       this.procs[name] = async (...args) => {
         const placeholders = [...new Array(args.length).keys()].map(i => `$${i + 1}`).join(',');
         const res = await this._withClient(mode, client => client.query(

--- a/libraries/postgres/src/Schema.js
+++ b/libraries/postgres/src/Schema.js
@@ -54,7 +54,7 @@ class Schema{
   }
 
   latestVersion() {
-    return this.versions[this.versions.length - 1]
+    return this.versions[this.versions.length - 1];
   }
 
   allMethods() {

--- a/libraries/postgres/test/database_test.js
+++ b/libraries/postgres/test/database_test.js
@@ -125,14 +125,10 @@ dbSuite(path.basename(__filename), function() {
       }],
     });
 
-    try {
-      await Database.upgrade({schema, runUpgrades: true, readDbUrl: this.dbUrl, writeDbUrl: this.dbUrl});
-      assert.fail('should have failed');
-    } catch (e) {
-      assert(e);
-    }
-    finally {
-      await db.close();
-    }
+    await assert.rejects(
+      Database.upgrade({schema, runUpgrades: true, readDbUrl: this.dbUrl, writeDbUrl: this.dbUrl}),
+      /capital letters/,
+    );
+    await db.close();
   });
 });

--- a/libraries/postgres/test/database_test.js
+++ b/libraries/postgres/test/database_test.js
@@ -32,7 +32,7 @@ dbSuite(path.basename(__filename), function() {
           },
         },
       },
-    ]
+    ],
   });
 
   setup(function() {
@@ -101,6 +101,37 @@ dbSuite(path.basename(__filename), function() {
       const res = await db.procs.addup(13);
       assert.deepEqual(res.map(r => r.total).sort(), [16, 20]);
     } finally {
+      await db.close();
+    }
+  });
+
+  test('procedure methods does not have capital letters', async function () {
+    const schema = Schema.fromSerializable({
+      versions: [{
+        version: 1,
+        migrationScript: `begin
+            create table testing (a integer, b integer);
+          end`,
+        methods: {
+          testData: {
+            mode: 'write',
+            args: '',
+            returns: 'void',
+            body: `begin
+              insert into testing values (1, 2), (3, 4);
+            end`,
+          },
+        },
+      }],
+    });
+
+    try {
+      await Database.upgrade({schema, runUpgrades: true, readDbUrl: this.dbUrl, writeDbUrl: this.dbUrl});
+      assert.fail('should have failed');
+    } catch (e) {
+      assert(e);
+    }
+    finally {
       await db.close();
     }
   });

--- a/libraries/postgres/test/db-simple/0001.yml
+++ b/libraries/postgres/test/db-simple/0001.yml
@@ -7,11 +7,11 @@ migrationScript: |-
     );
   end
 methods:
-  getSecret:
+  get_secret:
     mode: read
     args: name text
     returns: table (secret text)
     body: |-
       begin
-        return query select secrets.secret from secrets where secrets.name = getSecret.name;
+        return query select secrets.secret from secrets where secrets.name = get_secret.name;
       end

--- a/libraries/postgres/test/db-simple/0002.yml
+++ b/libraries/postgres/test/db-simple/0002.yml
@@ -5,7 +5,7 @@ migrationScript: |-
       add column expires timestamp not null defeault now() + interval '1000 years';
   end
 methods:
-  listSecrets:
+  list_secrets:
     mode: read
     args: ''
     returns: table (name text, expires timestamp)

--- a/libraries/postgres/test/schema_test.js
+++ b/libraries/postgres/test/schema_test.js
@@ -8,17 +8,17 @@ suite(path.basename(__filename), function() {
       const sch = Schema.fromDbDirectory(path.join(__dirname, 'db-simple'));
       const ver2 = sch.latestVersion();
       assert.equal(ver2.version, 2);
-      assert.deepEqual(Object.keys(ver2.methods), ['listSecrets']);
+      assert.deepEqual(Object.keys(ver2.methods), ['list_secrets']);
       assert(ver2.migrationScript.startsWith('begin'));
       assert.deepEqual(ver2, sch.getVersion(2));
 
       const ver1 = sch.getVersion(1);
-      assert.deepEqual(Object.keys(ver1.methods), ['getSecret']);
+      assert.deepEqual(Object.keys(ver1.methods), ['get_secret']);
 
       assert.deepEqual([...sch.allMethods()].sort(),
         [
-          {name: 'getSecret', mode: READ},
-          {name: 'listSecrets', mode: READ},
+          {name: 'get_secret', mode: READ},
+          {name: 'list_secrets', mode: READ},
         ]);
     });
 
@@ -47,8 +47,8 @@ suite(path.basename(__filename), function() {
     const sch = Schema.fromDbDirectory(path.join(__dirname, 'db-simple'));
     assert.deepEqual([...sch.allMethods()].sort(),
       [
-        {name: 'getSecret', mode: READ},
-        {name: 'listSecrets', mode: READ},
+        {name: 'get_secret', mode: READ},
+        {name: 'list_secrets', mode: READ},
       ]);
   });
 });


### PR DESCRIPTION
Rather than rely on capital letters, I thought about disallowing them. Using snake case for method names would align better with method names. Capital letters should probably just be SQL commands. Let me know if you disagree. Also, this is not tested.