### PR TITLE
Bug 1596171 - do not omit schedulerId when cloning a task

### DIFF
--- a/changelog/bug-1596171.md
+++ b/changelog/bug-1596171.md
@@ -1,0 +1,4 @@
+level: patch
+reference: bug 1596171
+---
+The "Edit" button in the task view no loner removes the schedulerId

--- a/ui/src/views/Tasks/ViewTask/index.jsx
+++ b/ui/src/views/Tasks/ViewTask/index.jsx
@@ -293,7 +293,6 @@ export default class ViewTask extends Component {
         ...TASK_ADDED_FIELDS,
         'routes',
         'taskGroupId',
-        'schedulerId',
         'priority',
         'dependencies',
         'requires',


### PR DESCRIPTION
Bugzilla Bug: [1596171](https://bugzilla.mozilla.org/show_bug.cgi?id=1596171)

I will admit I didn't think too hard about this change.  WCPGW?