### PR TITLE
Bug 1602985 - don't check for dirty repo when releasing py client

### DIFF
--- a/changelog/bug-1602985.md
+++ b/changelog/bug-1602985.md
@@ -1,0 +1,3 @@
+level: silent
+reference: bug 1602985
+---

--- a/clients/client-py/release.sh
+++ b/clients/client-py/release.sh
@@ -25,6 +25,8 @@ if [ -n "$modified" ]; then
   echo "There are changes in the local tree.  This probably means"
   echo "you'll do something unintentional.  For safety's sake, please"
   echo 'revert or stash them!'
+  echo ''
+  echo -- "$modified"
   exit 66
 fi
 

--- a/infrastructure/tooling/src/release/tasks.js
+++ b/infrastructure/tooling/src/release/tasks.js
@@ -410,7 +410,7 @@ module.exports = ({tasks, cmdOptions, credentials, baseDir}) => {
         await npmPublish({
           dir: path.join(REPO_ROOT, clientName),
           apiKey: credentials.npmToken,
-          logfile: `${baseDir}/npm-publish-${clientName.replace('/', '-')}.log`,
+          logfile: `${baseDir}/publish-${clientName.replace('/', '-')}.log`,
           utils});
       },
     }));
@@ -433,7 +433,7 @@ module.exports = ({tasks, cmdOptions, credentials, baseDir}) => {
         dir: path.join(REPO_ROOT, 'clients', 'client-py'),
         username: credentials.pypiUsername,
         password: credentials.pypiPassword,
-        logfile: `${baseDir}/npm-publish-client-py.log`,
+        logfile: `${baseDir}/publish-client-py.log`,
         utils});
     },
   });


### PR DESCRIPTION
..and fix the log filenames in 'yarn release'

Bugzilla Bug: [1602985](https://bugzilla.mozilla.org/show_bug.cgi?id=1602985)