### PR TITLE
tc-lib-postgres permissions

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -180,6 +180,7 @@ tasks:
           command: >-
             pg_ctlcluster 11 main start &&
             export ADMIN_DB_URL="$TEST_DB_URL" &&
+            export USERNAME_PREFIX="test" &&
             yarn db:upgrade
         - name: "taskcluster-db"
           image: taskcluster/node-and-postgres:node${node}-pg11

--- a/db/README.md
+++ b/db/README.md
@@ -51,7 +51,7 @@ const tcdb = require('taskcluster-db');
 The result is a taskcluster-lib-postgres Database instance all set up and ready to use.
 This uses the generated schema by default.
 
-Similarly, the `upgrade` method will upgrade a database to the current version.
+Similarly, the `upgrade` method will upgrade a database to the current version and set up table permissions for per-service postgres users.
 To upgrade to a specific version, pass `toVersion: <number>`.
 This functionality is typically used in tests, as in production deployments the deployers will run `yarn db:upgrade`.
 
@@ -59,7 +59,10 @@ This functionality is typically used in tests, as in production deployments the 
 const tcdb = require('taskcluster-db');
 
 setup('upgrade db', async function() {
-  await tcdb.upgrade({adminDbUrl: process.env.TEST_DB_URL});
+  await tcdb.upgrade({
+    adminDbUrl: process.env.TEST_DB_URL,
+    usernamePrefix: 'test',
+  });
 });
 ```
 

--- a/db/access.yml
+++ b/db/access.yml
@@ -1,9 +1,9 @@
 # <service-name-1>
-#   // tables that this service has WRITE permissions to
+#   // tables that this service has access to
 #   tables:
-#     - table-1
-#     - table-2
+#     <tableName>: [read|write]
+#     <tableName>: [read|write]
 #     - ...
 secrets:
   tables:
-  - secrets
+    secrets: write

--- a/db/src/main.js
+++ b/db/src/main.js
@@ -8,11 +8,16 @@ const main = async () => {
     throw new Error('$ADMIN_DB_URL is not set');
   }
 
+  const usernamePrefix = process.env.USERNAME_PREFIX;
+  if (!usernamePrefix) {
+    throw new Error('$USERNAME_PREFIX is not set');
+  }
+
   const showProgress = message => {
     util.log(chalk.green(message));
   };
 
-  await upgrade({showProgress, adminDbUrl});
+  await upgrade({showProgress, adminDbUrl, usernamePrefix});
 };
 
 main().catch(err => {

--- a/db/src/upgrade.js
+++ b/db/src/upgrade.js
@@ -1,10 +1,11 @@
 const {schema} = require('./schema.js');
 const {Database} = require('taskcluster-lib-postgres');
 
-exports.upgrade = async ({adminDbUrl, showProgress, toVersion, useDbDirectory}) => {
+exports.upgrade = async ({adminDbUrl, showProgress, usernamePrefix, toVersion, useDbDirectory}) => {
   await Database.upgrade({
     schema: schema(useDbDirectory),
     showProgress,
+    usernamePrefix,
     adminDbUrl,
     toVersion,
   });

--- a/db/versions/0001.yml
+++ b/db/versions/0001.yml
@@ -5,6 +5,7 @@ migrationScript: |-
       name text primary key,
       secret text
     );
+    grant select, insert, update, delete on secrets to $db_user_prefix$_secrets;
   end
 methods:
   get_secret:

--- a/generated/db-schema.json
+++ b/generated/db-schema.json
@@ -42,7 +42,7 @@
           "serviceName": "secrets"
         }
       },
-      "migrationScript": "begin\n  create table secrets (\n    name text primary key,\n    secret text\n  );\nend",
+      "migrationScript": "begin\n  create table secrets (\n    name text primary key,\n    secret text\n  );\n  grant select, insert, update, delete on secrets to $db_user_prefix$_secrets;\nend",
       "version": 1
     },
     {

--- a/generated/db-schema.json
+++ b/generated/db-schema.json
@@ -1,9 +1,9 @@
 {
   "access": {
     "secrets": {
-      "tables": [
-        "secrets"
-      ]
+      "tables": {
+        "secrets": "write"
+      }
     }
   },
   "versions": [

--- a/generated/docs-search.json
+++ b/generated/docs-search.json
@@ -78,6 +78,13 @@
   },
   {
     "element": "h2",
+    "id": "database",
+    "path": "/manual/deploying",
+    "subtitle": "Database",
+    "title": "Deploying Taskcluster"
+  },
+  {
+    "element": "h2",
     "id": "events",
     "path": "/manual/deploying",
     "subtitle": "Events",
@@ -208,6 +215,41 @@
     "path": "/manual/deploying/cloud-credentials",
     "subtitle": "Websocktunnel Credentials",
     "title": "Cloud Credentials"
+  },
+  {
+    "element": "h1",
+    "id": "database-configuration",
+    "path": "/manual/deploying/database",
+    "subtitle": null,
+    "title": "Database Configuration"
+  },
+  {
+    "element": "h2",
+    "id": "configuration",
+    "path": "/manual/deploying/database",
+    "subtitle": "Configuration",
+    "title": "Database Configuration"
+  },
+  {
+    "element": "h2",
+    "id": "db-users",
+    "path": "/manual/deploying/database",
+    "subtitle": "DB Users",
+    "title": "Database Configuration"
+  },
+  {
+    "element": "h2",
+    "id": "read-and-write-replicas",
+    "path": "/manual/deploying/database",
+    "subtitle": "Read and Write Replicas",
+    "title": "Database Configuration"
+  },
+  {
+    "element": "h2",
+    "id": "upgrades",
+    "path": "/manual/deploying/database",
+    "subtitle": "Upgrades",
+    "title": "Database Configuration"
   },
   {
     "element": "h1",

--- a/generated/docs-table-of-contents.json
+++ b/generated/docs-table-of-contents.json
@@ -1519,13 +1519,35 @@
             },
             "name": "cloud-credentials",
             "next": {
-              "path": "manual/deploying/github",
-              "title": "GitHub Integration"
+              "path": "manual/deploying/database",
+              "title": "Database Configuration"
             },
             "path": "manual/deploying/cloud-credentials",
             "prev": {
               "path": "manual/deploying/backups",
               "title": "Backups"
+            },
+            "up": {
+              "path": "manual/deploying",
+              "title": "Deploying Taskcluster"
+            }
+          },
+          {
+            "children": [
+            ],
+            "data": {
+              "order": 1000,
+              "title": "Database Configuration"
+            },
+            "name": "database",
+            "next": {
+              "path": "manual/deploying/github",
+              "title": "GitHub Integration"
+            },
+            "path": "manual/deploying/database",
+            "prev": {
+              "path": "manual/deploying/cloud-credentials",
+              "title": "Cloud Credentials"
             },
             "up": {
               "path": "manual/deploying",
@@ -1546,8 +1568,8 @@
             },
             "path": "manual/deploying/github",
             "prev": {
-              "path": "manual/deploying/cloud-credentials",
-              "title": "Cloud Credentials"
+              "path": "manual/deploying/database",
+              "title": "Database Configuration"
             },
             "up": {
               "path": "manual/deploying",

--- a/infrastructure/tooling/src/generate/generators/db-schema.js
+++ b/infrastructure/tooling/src/generate/generators/db-schema.js
@@ -6,10 +6,15 @@ const { writeRepoJSON, REPO_ROOT } = require('../../utils');
 exports.tasks = [{
   title: 'DB Schema',
   requires: [],
-  provides: ['schema-json'],
+  provides: ['db-schema-serializable'],
   run: async (requirements, utils) => {
     const schema = Schema.fromDbDirectory(path.join(REPO_ROOT, 'db'));
 
-    writeRepoJSON('generated/db-schema.json', JSON.parse(schema.asSerializable()));
+    const serializable = JSON.parse(schema.asSerializable());
+    writeRepoJSON('generated/db-schema.json', serializable);
+
+    return {
+      ['db-schema-serializable']: serializable,
+    };
   },
 }];

--- a/infrastructure/tooling/src/generate/generators/db-schema.js
+++ b/infrastructure/tooling/src/generate/generators/db-schema.js
@@ -14,7 +14,7 @@ exports.tasks = [{
     writeRepoJSON('generated/db-schema.json', serializable);
 
     return {
-      ['db-schema-serializable']: serializable,
+      'db-schema-serializable': serializable,
     };
   },
 }];

--- a/infrastructure/tooling/src/generate/generators/db-user-docs.js
+++ b/infrastructure/tooling/src/generate/generators/db-user-docs.js
@@ -14,7 +14,7 @@ exports.tasks = [{
     const content = await readRepoFile(docsFile);
     const adminUser = ` * \`<prefix>\` -- admin user`;
     const serviceUsers = services
-      .map(s => ` * \`<prefix>_taskcluster_${s}\` -- user for Taskcluster ${s} service`)
+      .map(s => ` * \`<prefix>_${s}\` -- user for Taskcluster ${s} service`)
       .join('\n');
     const newContent = content.replace(
       /(<!-- USERLIST BEGIN -->)(?:.|\n)*(<!-- USERLIST END -->)/m,

--- a/infrastructure/tooling/src/generate/generators/db-user-docs.js
+++ b/infrastructure/tooling/src/generate/generators/db-user-docs.js
@@ -1,0 +1,27 @@
+const path = require('path');
+const { Schema } = require('taskcluster-lib-postgres');
+const {readRepoFile, writeRepoFile, REPO_ROOT} = require('../../utils');
+
+exports.tasks = [{
+  title: 'Users in DB Deployment Docs',
+  requires: ['db-schema-serializable'],
+  provides: [],
+  run: async (requirements, utils) => {
+    const schema = Schema.fromDbDirectory(path.join(REPO_ROOT, 'db'));
+    const services = Object.keys(schema.access).sort();
+
+    const docsFile = path.join('ui', 'docs', 'manual', 'deploying', 'database.mdx');
+    const content = await readRepoFile(docsFile);
+    const adminUser = ` * \`<prefix>\` -- admin user`;
+    const serviceUsers = services
+      .map(s => ` * \`<prefix>_taskcluster_${s}\` -- user for Taskcluster ${s} service`)
+      .join('\n');
+    const newContent = content.replace(
+      /(<!-- USERLIST BEGIN -->)(?:.|\n)*(<!-- USERLIST END -->)/m,
+      `$1\n${adminUser}\n${serviceUsers}\n$2`);
+
+    if (content !== newContent) {
+      await writeRepoFile(docsFile, newContent);
+    }
+  },
+}];

--- a/infrastructure/tooling/src/generate/generators/readme-stored-procedures.js
+++ b/infrastructure/tooling/src/generate/generators/readme-stored-procedures.js
@@ -1,12 +1,13 @@
 const path = require('path');
 const { Schema } = require('taskcluster-lib-postgres');
-const {readRepoFile, writeRepoFile, REPO_ROOT} = require('../../utils');
+const {readRepoFile, writeRepoFile} = require('../../utils');
 
 exports.tasks = [{
   title: 'README Stored Procedures',
+  requires: ['db-schema-serializable'],
   provides: ['readme-stored-procedures'],
   run: async (requirements, utils) => {
-    const schema = Schema.fromDbDirectory(path.join(REPO_ROOT, 'db'));
+    const schema = Schema.fromSerializable(requirements['db-schema-serializable']);
     const methods = schema.allMethods();
     const serviceNames = [...new Set([...methods].map(({ serviceName }) => serviceName).sort())];
     const services = new Map();

--- a/libraries/postgres/src/Database.js
+++ b/libraries/postgres/src/Database.js
@@ -94,9 +94,9 @@ class Database {
   static async _checkPermissions({db, schema, usernamePrefix}) {
     await db._withClient('admin', async (client) => {
       // determine current permissions in the form ["username: priv on table"].
-      // This includes information frmo the column_privileges table as if it
-      // was granting access to the entire table.  We never use column
-      // grants, so such an overstimation doesn't hurt.  And revoking access
+      // This includes information from the column_privileges table as if it
+      // was granting access to the entire table. We never use column
+      // grants, so such an overstimation doesn't hurt. And revoking access
       // to a table implicitly revokes column grants for that table, too.
       const res = await client.query(`
         select grantee, table_name, privilege_type

--- a/libraries/postgres/src/Database.js
+++ b/libraries/postgres/src/Database.js
@@ -102,16 +102,16 @@ class Database {
         select grantee, table_name, privilege_type
           from information_schema.table_privileges
           where table_schema = 'public'
-           and grantee like $1 || '_%'
+           and grantee like $1 || '\\_%'
            and table_catalog = current_catalog
            and table_name != 'tcversion'
         union
         select grantee, table_name, privilege_type
           from information_schema.column_privileges
           where table_schema = 'public'
-           and grantee like $1 || '_%'
+           and grantee like $1 || '\\_%'
            and table_catalog = current_catalog
-           and table_name != 'tcversion'`, [usernamePrefix]);
+           and table_name != 'tcversion'`, [usernamePrefix.replace('_', '\\_')]);
       const currentPrivs = new Set(
         res.rows.map(row => `${row.grantee}: ${row.privilege_type} on ${row.table_name}`));
 

--- a/libraries/postgres/src/Schema.js
+++ b/libraries/postgres/src/Schema.js
@@ -1,3 +1,4 @@
+const {isPlainObject} = require('lodash');
 const fs = require('fs');
 const assert = require('assert').strict;
 const yaml = require('js-yaml');
@@ -103,14 +104,16 @@ class Schema{
   }
 
   static _checkAccess(access) {
-    assert(typeof access === 'object' && !(access instanceof Array),
-      'access.yml should define an object');
+    assert(isPlainObject(access), 'access.yml should define an object');
     Object.keys(access).forEach(serviceName => {
       const serviceAccess = access[serviceName];
-      assert(typeof serviceAccess === 'object' && !(serviceAccess instanceof Array),
-        'each service in access.yml should define an object');
+      assert(isPlainObject(serviceAccess), 'each service in access.yml should define an object');
       assert.deepEqual(Object.keys(serviceAccess).sort(), ['tables'],
         'each service in access.yml should only have a `tables` property');
+      assert(isPlainObject(serviceAccess.tables), `${serviceName}.tables should be an object`);
+      Object.entries(serviceAccess.tables).forEach(([table, mode]) => {
+        assert(['read', 'write'].includes(mode), `${serviceName}.tables.${table} should be read or write`);
+      });
     });
   }
 

--- a/libraries/postgres/test/helper.js
+++ b/libraries/postgres/test/helper.js
@@ -35,6 +35,6 @@ const clearDb = async dbUrl => {
     await client.query(`drop schema if exists public cascade`);
     await client.query(`create schema public`);
   } finally {
-    client.end();
+    await client.end();
   }
 };

--- a/libraries/postgres/test/schema_test.js
+++ b/libraries/postgres/test/schema_test.js
@@ -188,10 +188,20 @@ suite(path.basename(__filename), function() {
         () => Schema._checkAccess({test: []}),
         /should define an object/);
     });
-    test('service has keys aside from table', function() {
+    test('service has keys aside from tables', function() {
       assert.throws(
         () => Schema._checkAccess({test: {views: []}}),
         /should only have a `tables` property/);
+    });
+    test('service tables is an array', function() {
+      assert.throws(
+        () => Schema._checkAccess({test: {tables: []}}),
+        /should be an object/);
+    });
+    test('service tables has invalid mode', function() {
+      assert.throws(
+        () => Schema._checkAccess({test: {tables: {test: 'admin'}}}),
+        /should be read or write/);
     });
   });
 

--- a/libraries/testing/README.md
+++ b/libraries/testing/README.md
@@ -317,11 +317,18 @@ withDb
 ------
 
 This function is intended for use with `mockSuite` and the [usual configuration](../../db) for Postgres databases.
-In mock mode, it sets up a FakeDatabase, while in "real" mode it sets up a "real" database using `$TEST_DB_URL`.
+In mock mode, it sets up a FakeDatabase.
+In "real" mode it sets up a "real" database using `$TEST_DB_URL`, accessed with a user corresponding to the given serviceName.
 In either case, the resulting database is injected into the taskcluster-lib-loader as `db` and also available as `helper.db`.
 
 In the real case, the database is set upgraded to the latest version at the beginning of the suite.
-It is up to the test suite implementation to reset the contents of the database between tests.
+
+In both the real and mock cases, is up to the test suite implementation to reset the contents of the database between tests.
+Ideally this is done via `helper.db.procs` methods.
+
+Note that this is intended to operate against a temporary Postgres server such as one running in a docker container.
+It's not a good idea to run this against a "real" Postgres server.
+In particular, it will create a bunch of users with names beginning with `test_` (global to the server) and reset their passwords and access.
 
 The function is typically used like this:
 
@@ -336,7 +343,7 @@ exports.secrets = new Secrets({
 });
 
 exports.withDb = (mock, skipping) => {
-  withDb(mock, skipping, exports, 'secrets');
+  withDb(mock, skipping, exports, 'my-service');
 };
 ```
 

--- a/libraries/testing/src/index.js
+++ b/libraries/testing/src/index.js
@@ -9,5 +9,5 @@ module.exports = {
   suiteName: require('./suite-name'),
   withPulse: require('./with-pulse'),
   withMonitor: require('./with-monitor'),
-  withDb: require('./with-db'),
+  ...require('./with-db'),
 };

--- a/ui/docs/manual/deploying/README.mdx
+++ b/ui/docs/manual/deploying/README.mdx
@@ -27,6 +27,11 @@ A Taskcluster deployment's configuration comes in the form of Helm "values".
 Most of those are undocumented, but see:
  * [static clients](/docs/manual/deploying/static-clients)
 
+## Database
+
+Taskcluster uses a Postgres database for its backend storage.
+See [Database Configuration](/docs/manual/deploying/database) for details.
+
 ## Clouds
 
 Taskcluster is a multi-cloud system, and as such expects credentials for several cloud providers.

--- a/ui/docs/manual/deploying/database.mdx
+++ b/ui/docs/manual/deploying/database.mdx
@@ -1,0 +1,76 @@
+---
+title: Database Configuration
+---
+
+import Warning from 'taskcluster-ui/views/Documentation/components/Warning';
+
+# Database Configuration
+
+Taskcluster uses a Postgres 11 database for its backend storage.
+A single database is shared among all services.
+
+Taskcluster assumes that it "owns" the database, but can share a single server with other users.
+For production purposes we recommend a dedicated server, due to the possibility of contention for server resources, but sharing a server acceptable for non-production environments.
+
+## DB Users
+
+Each service uses its own Postgres user to access the database, and Taskcluster uses this functionality internally to isolate services from one another.
+The Taskcluster deployment process additionally requires an "admin" user that is used for schema migrations and to update the permissions of the per-service users.
+This admin user must have full permission to all resources in the selected database, as well as permission to grant and revoke access for the service users.
+
+The admin user can have any name.
+Because users are global to a Postgres server, Taskcluster requires a name prefix which is applied to each per-service user.
+In a non-production environment, this allows several installations of Taskcluster to co-exist on the same server.
+We recommend that the admin username and the prefix be the same string.
+
+The set of users that must be configured, then, are:
+
+TODO: generate this list automatically from db/access.yml
+
+ * `<prefix>` -- admin user
+ * `<prefix>_taskcluster_queue` -- user for the queue service
+ * ...
+
+Set these up using something with the following effect:
+
+```
+CREATE USER <prefix> PASSWORD '<admin_password>';
+GRANT ALL ON DATABASE <dbname> TO <prefix> WITH GRANT OPTION;
+CREATE USER <prefix>_taskcluster_queue PASSWORD '<queue_password>';
+...
+```
+
+## Read and Write Replicas
+
+Taskcluster assumes full transactional consistency from Postgres.
+That is, once a transaction is committed, the results of that transaction must be visible everywhere.
+Furthermore, Taskcluster relies on per-row locks to perform queueing operations.
+Within these parameters, the backend database can be replicated and sharded as load and availability demand.
+
+Taskcluster allows each service to be configured with both "read-only" and "read-write" access configuration.
+The read-only configuration will only be used to read from the database.
+This can be used to direct reads to read-only replicas, in cases where the read load is significantly higher than the write load.
+However, note that these read-only replicas must conform to the consistency requirements described above.
+
+## Configuration
+
+Database access is configured with URL-shaped strings as defined by [node-postgres](https://node-postgres.com/features/connecting).
+
+Each service that requires database access has Helm properties `<service>.readDbUrl` and `<service>.writeDbUrl`.
+Set these values to include the corresponding database users' credentials.
+In a non-replicated scenario, set each service's read and write URLs to the same value.
+For example:
+
+```yaml
+queue:
+  readDbUrl: postgresql://prod_taskcluster_queue:sekrit@readonly.tc-db.example.com/taskcluster_prod
+  writeDbUrl: postgresql://prod_taskcluster_queue:sekrit@readwrite.tc-db.example.com/taskcluster_prod
+```
+
+<Warning>
+Note that the admin user's credentials should not appear anywhere in the Helm configuration!
+</Warning>
+
+## Upgrades
+
+TBD

--- a/ui/docs/manual/deploying/database.mdx
+++ b/ui/docs/manual/deploying/database.mdx
@@ -75,7 +75,7 @@ Note that the admin user's credentials should not appear anywhere in the Helm co
 Database upgrade must be completed *before* the corresponding code is deployed.
 Taskcluster maintains the invariant that older code is compatible with newer databases, so the existing deployment will continue to function after the database upgrade is committed.
 
-To run an upgrade, run a docker container using the new Taskcluster imaage.
+To run an upgrade, run a docker container using the new Taskcluster image.
 Set `ADMIN_DB_URL` and `USERNAME_PREFIX` to the values described above and run:
 
 ```shell

--- a/ui/docs/manual/deploying/database.mdx
+++ b/ui/docs/manual/deploying/database.mdx
@@ -73,4 +73,18 @@ Note that the admin user's credentials should not appear anywhere in the Helm co
 
 ## Upgrades
 
-TBD
+Database upgrade must be completed *before* the corresponding code is deployed.
+Taskcluster maintains the invariant that older code is compatible with newer databases, so the existing deployment will continue to function after the database upgrade is committed.
+
+To run an upgrade, run a docker container using the new Taskcluster imaage.
+Set `ADMIN_DB_URL` and `USERNAME_PREFIX` to the values described above and run:
+
+```shell
+docker run -ti --rm -e ADMIN_DB_URL -e USERNAME_PREFIX taskcluster/taskcluster:1.2.3 db:upgrade
+```
+
+The output will describe the changes taking place.
+
+<Warning>
+As with any upgrade, consult the release notes before running the upgrade.
+</Warning>

--- a/ui/docs/manual/deploying/database.mdx
+++ b/ui/docs/manual/deploying/database.mdx
@@ -25,11 +25,10 @@ We recommend that the admin username and the prefix be the same string.
 
 The set of users that must be configured, then, are:
 
-TODO: generate this list automatically from db/access.yml
-
+<!-- USERLIST BEGIN -->
  * `<prefix>` -- admin user
- * `<prefix>_taskcluster_queue` -- user for the queue service
- * ...
+ * `<prefix>_taskcluster_secrets` -- user for Taskcluster secrets service
+<!-- USERLIST END -->
 
 Set these up using something with the following effect:
 

--- a/ui/docs/manual/deploying/database.mdx
+++ b/ui/docs/manual/deploying/database.mdx
@@ -27,7 +27,7 @@ The set of users that must be configured, then, are:
 
 <!-- USERLIST BEGIN -->
  * `<prefix>` -- admin user
- * `<prefix>_taskcluster_secrets` -- user for Taskcluster secrets service
+ * `<prefix>_secrets` -- user for Taskcluster secrets service
 <!-- USERLIST END -->
 
 Set these up using something with the following effect:


### PR DESCRIPTION
Handling of permissions for tc-lib-postgres.

Reference:
 * https://www.postgresql.org/docs/9.0/sql-grant.html
    * note that it appears that `GRANT .. on ALL TABLES IN SCHEMA` just enumerates the current set of tables and grants on each of them -- it does not automatically expand to include newly-added tables!
 * https://www.postgresql.org/docs/11/infoschema-table-privileges.html

I tested and verified that permissions changes are handled transactionally just like almost everything else in postgres, so these grants / revokes won't take effect until the transaction commits.

My next steps:
 * [x] update `access.yml` format to include read-only access to tables
 * [x] write a function to diff `access.yml` and the information schema and generate a set of SQL commands to reconcile the two
 * [x] manage permissions for routines (procedures) too?
 * [x] ensure that column_privileges is not set for relevant tables (just in case)
 * [x] update test harness for services to create and use the per-service user, so that we get unit test failures if permissions are incorrect
 * [x] finish deployment documentation
 * [x] figure out order of operations so that permissions don't cause an outage during upgrades
 * [x] generate user list in deployment docs automatically 