### PR TITLE
[UI] Prevent form resetting value when creating a new client

### DIFF
--- a/changelog/issue-2187.md
+++ b/changelog/issue-2187.md
@@ -1,0 +1,5 @@
+level: silent
+reference: issue 2187
+---
+
+Prevent resetting value when creating a new client

--- a/ui/src/views/Clients/ViewClient/index.jsx
+++ b/ui/src/views/Clients/ViewClient/index.jsx
@@ -103,10 +103,9 @@ export default class ViewClient extends Component {
 
   getClientFormKey = memoize(initialClient => JSON.stringify(initialClient), {
     serializer: initialClient => {
-      // Use expires as cache key
-      const serializeKey = JSON.stringify(omit(['expires'], initialClient));
-
-      return serializeKey;
+      // expires changes on every render so it's best to keep
+      // it out of the caching key
+      return JSON.stringify(omit(['expires'], initialClient));
     },
   });
 

--- a/ui/src/views/Clients/ViewClient/index.jsx
+++ b/ui/src/views/Clients/ViewClient/index.jsx
@@ -2,6 +2,8 @@ import { hot } from 'react-hot-loader';
 import React, { Component, Fragment } from 'react';
 import { graphql, withApollo } from 'react-apollo';
 import { parse } from 'qs';
+import memoize from 'fast-memoize';
+import { omit } from 'ramda';
 import { withStyles } from '@material-ui/core/styles';
 import { fade } from '@material-ui/core/styles/colorManipulator';
 import Card from '@material-ui/core/Card';
@@ -98,6 +100,15 @@ export default class ViewClient extends Component {
       open: false,
     },
   };
+
+  getClientFormKey = memoize(initialClient => JSON.stringify(initialClient), {
+    serializer: initialClient => {
+      // Use expires as cache key
+      const serializeKey = JSON.stringify(omit(['expires'], initialClient));
+
+      return serializeKey;
+    },
+  });
 
   handleDeleteClient = async clientId => {
     this.setState({ dialogError: null, loading: true });
@@ -360,7 +371,7 @@ export default class ViewClient extends Component {
               <Fragment>
                 <ErrorPanel fixed error={error} />
                 <ClientForm
-                  key={JSON.stringify(initialClient)}
+                  key={this.getClientFormKey(initialClient)}
                   loading={loading}
                   client={initialClient}
                   isNewClient


### PR DESCRIPTION
### Related Ticket
* Fixes #2187 

### Description
* When we click `save` button, it would trigger rerender multiple times since `GraphQL` would update `error` and `loading` props. This makes `initialClient`'s `expires` update. Therefore, when `key` props changed, the component `ClientForm` would create a new instance and reset form's value.
* To prevent the resetting, use `memoize` function from `fast-memoize` to cache function `getClientFormKey` return value and use `serializer` to set the `cache key`.