### PR TITLE
[UI] Revamp the Warning component in docs

### DIFF
--- a/changelog/CVgKPSmcRsqCpRkeHIDwoQ.md
+++ b/changelog/CVgKPSmcRsqCpRkeHIDwoQ.md
@@ -1,0 +1,2 @@
+level: silent
+---

--- a/ui/src/views/Documentation/components/Warning/index.jsx
+++ b/ui/src/views/Documentation/components/Warning/index.jsx
@@ -1,13 +1,29 @@
 import React from 'react';
 import { string } from 'prop-types';
-import ErrorPanel from '../../../../components/ErrorPanel';
+import { withStyles } from '@material-ui/core/styles';
+import { fade } from '@material-ui/core/styles/colorManipulator';
+import Paper from '@material-ui/core/Paper';
+import Markdown from '@mozilla-frontend-infra/components/Markdown';
 
-const Warning = ({ children }) => (
-  <ErrorPanel warning error={children} onClose={null} />
+const styles = withStyles(theme => ({
+  root: {
+    borderLeft: `5px solid ${theme.palette.warning.dark}`,
+    backgroundColor: fade(theme.palette.warning.main, 0.2),
+    padding: `${theme.spacing(1)}px ${theme.spacing(3)}px`,
+    margin: `${theme.spacing(3)} 0`,
+    '& a': {
+      ...theme.mixins.link,
+    },
+  },
+}));
+const Warning = ({ classes, children }) => (
+  <Paper square classes={{ root: classes.root }}>
+    <Markdown>{children}</Markdown>
+  </Paper>
 );
 
 Warning.propTypes = {
   children: string.isRequired,
 };
 
-export default Warning;
+export default styles(Warning);

--- a/ui/src/views/Documentation/components/Warning/index.jsx
+++ b/ui/src/views/Documentation/components/Warning/index.jsx
@@ -10,7 +10,7 @@ const styles = withStyles(theme => ({
     borderLeft: `5px solid ${theme.palette.warning.dark}`,
     backgroundColor: fade(theme.palette.warning.main, 0.2),
     padding: `${theme.spacing(1)}px ${theme.spacing(3)}px`,
-    margin: `${theme.spacing(3)} 0`,
+    margin: `${theme.spacing(3)}px 0`,
     '& a': {
       ...theme.mixins.link,
     },


### PR DESCRIPTION
#### Dark Theme

Before             |  After
:-------------------------:|:-------------------------:
<img width="1648" alt="Screen Shot 2019-12-23 at 12 55 07 PM" src="https://user-images.githubusercontent.com/3766511/71372942-a658c380-2583-11ea-8622-8bb44ecd8a5f.png"> | <img width="1648" alt="Screen Shot 2019-12-23 at 12 56 01 PM" src="https://user-images.githubusercontent.com/3766511/71372939-a658c380-2583-11ea-90f0-1510c4bfe2c4.png">

#### Light Theme

Before             |  After
:-------------------------:|:-------------------------:
<img width="1654" alt="Screen Shot 2019-12-23 at 12 55 23 PM" src="https://user-images.githubusercontent.com/3766511/71372941-a658c380-2583-11ea-8ca3-2b9aa15537f2.png">  |  <img width="1653" alt="Screen Shot 2019-12-23 at 12 55 48 PM" src="https://user-images.githubusercontent.com/3766511/71372940-a658c380-2583-11ea-92ae-0d900a75cbdd.png">



