### PR TITLE
Remove some TODOs

### DIFF
--- a/changelog/P-IpBKPgQyCIbt7HWVq6gA.md
+++ b/changelog/P-IpBKPgQyCIbt7HWVq6gA.md
@@ -1,0 +1,2 @@
+level: silent
+---

--- a/clients/client-py/taskcluster/aio/asyncclient.py
+++ b/clients/client-py/taskcluster/aio/asyncclient.py
@@ -84,7 +84,6 @@ class AsyncBaseClient(BaseClient):
         routeParams, payload, query, paginationHandler, paginationLimit = x
         route = self._subArgsInRoute(entry, routeParams)
 
-        # TODO: Check for limit being in the Query of the api ref
         if paginationLimit and 'limit' in entry.get('query', []):
             query['limit'] = paginationLimit
 

--- a/clients/client-py/taskcluster/client.py
+++ b/clients/client-py/taskcluster/client.py
@@ -260,7 +260,6 @@ class BaseClient(object):
         routeParams, payload, query, paginationHandler, paginationLimit = x
         route = self._subArgsInRoute(entry, routeParams)
 
-        # TODO: Check for limit being in the Query of the api ref
         if paginationLimit and 'limit' in entry.get('query', []):
             query['limit'] = paginationLimit
 

--- a/clients/client-py/test/test_client.py
+++ b/clients/client-py/test/test_client.py
@@ -566,9 +566,6 @@ def test_missing_input_raises(client):
         client.no_args_with_input()
 
 
-# TODO: I should run the same things through the node client and compare the output
-
-
 def test_string_pass_through(client):
     expected = 'johnwrotethis'
     actual = client.topicName(expected)
@@ -833,8 +830,6 @@ def test_permacred_insufficient_scopes():
             'accessToken': 'no-secret',
         }
     })
-    # TODO: this should be TaskclusterAuthFailure; most likely the client
-    # is expecting AuthorizationFailure instead of AuthenticationFailure
     with pytest.raises(exc.TaskclusterRestFailure):
         client.testAuthenticate({
             'clientScopes': ['test:*'],

--- a/clients/client-shell/cmds/group/actors.go
+++ b/clients/client-shell/cmds/group/actors.go
@@ -185,7 +185,7 @@ func filterTask(status tcqueue.TaskStatusStructure, flags *pflag.FlagSet) bool {
 		}
 	}
 
-	// TODO add other filters here when necessary
+	// ..other filters can be added here as necessary
 
 	return true
 }

--- a/clients/client-shell/config/serialization.go
+++ b/clients/client-shell/config/serialization.go
@@ -27,11 +27,9 @@ func configFile() string {
 	return filepath.Join(configFolder, "taskcluster.yml")
 }
 
-// Load will load confiration file, and initialize a default configuration
+// Load will load configuration file, and initialize a default configuration
 // if no configuration is present. This only returns an error if a configuration
 // file is present, but we are unable to parse it.
-// TODO	we could simplify this function and only go through the definitions once
-//		and what happens if a value is tied to an env var AND to the config file?
 func Load() (map[string]map[string]interface{}, error) {
 	config := make(map[string]map[string]interface{})
 

--- a/infrastructure/tooling/src/utils/docker.js
+++ b/infrastructure/tooling/src/utils/docker.js
@@ -262,8 +262,7 @@ exports.dockerImages = async ({baseDir}) => {
 exports.dockerRegistryCheck = async ({tag}) => {
   const [repo, imagetag] = tag.split(/:/);
   try {
-    // Acces the registry API directly to see if this tag already exists, and do not push if so.
-    // TODO: this won't work with custom registries!
+    // Access the registry API directly to see if this tag already exists, and do not push if so.
     const res = await got(`https://index.docker.io/v1/repositories/${repo}/tags`, {json: true});
     if (res.body && res.body.map(l => l.name).includes(imagetag)) {
       return true;

--- a/libraries/monitor/src/monitormanager.js
+++ b/libraries/monitor/src/monitormanager.js
@@ -59,7 +59,7 @@ class MonitorManager {
     level,
     version,
     description,
-    fields = {}, // TODO: Consider making these defined with json-schema and validate only in dev or something
+    fields = {},
   }) {
     assert(!this._setup, 'Cannot register after MonitorManager has been setup');
     assert(title, `Must provide a human readable title for this log type ${name}`);

--- a/libraries/references/src/validate.js
+++ b/libraries/references/src/validate.js
@@ -201,8 +201,7 @@ exports.validate = (references) => {
           problems.push(`${filename}: unknown metadata.version ${metadata.version}`);
         }
       } else if (metadata.name === 'logs') {
-        // Nothing to do for now
-        // TODO: Start validating fields with schemas?
+        // Nothing to do..
       } else {
         problems.push(`${filename}: unknown metadata.name ${metadata.name}`);
       }

--- a/services/auth/test/stories_test.js
+++ b/services/auth/test/stories_test.js
@@ -77,6 +77,7 @@ helper.secrets.mockSuite(testing.suiteName(), ['azure', 'gcp'], function(mock, s
             'auth:reset-access-token:test-users/charlene/*',
             'assume:test-role:role1',
             'assume:test-role:role2',
+            'scope3a',
           ],
         }),
       });
@@ -160,8 +161,7 @@ helper.secrets.mockSuite(testing.suiteName(), ['azure', 'gcp'], function(mock, s
       });
     });
 
-    // TODO: bug 1242473
-    test.skip('charlene replaces role3 with one of its constituent scopes', async () => {
+    test('charlene replaces role3 with one of its constituent scopes', async () => {
       await charlene.updateClient('test-users/charlene/travis-tests', {
         description: 'Permacred created by test',
         expires: taskcluster.fromNow('3 hours'),

--- a/services/hooks/src/data.js
+++ b/services/hooks/src/data.js
@@ -13,7 +13,7 @@ const Hook = Entity.configure({
     metadata: Entity.types.JSON,
     // task template
     task: Entity.types.JSON,
-    // pulse bindings (TODO; empty for now)
+    // pulse bindings
     bindings: Entity.types.JSON,
     // timings for the task (in fromNow format, e.g., "1 day")
     deadline: Entity.types.String,
@@ -38,7 +38,7 @@ const Hook = Entity.configure({
     metadata: Entity.types.JSON,
     // task template
     task: Entity.types.JSON,
-    // pulse bindings (TODO; empty for now)
+    // pulse bindings
     bindings: Entity.types.JSON,
     // timings for the task (in fromNow format, e.g., "1 day")
     deadline: Entity.types.String,
@@ -71,7 +71,7 @@ const Hook = Entity.configure({
     metadata: Entity.types.JSON,
     // task template
     task: Entity.types.JSON,
-    // pulse bindings (TODO; empty for now)
+    // pulse bindings
     bindings: Entity.types.JSON,
     // timings for the task (in fromNow format, e.g., "1 day")
     deadline: Entity.types.String,
@@ -102,7 +102,7 @@ const Hook = Entity.configure({
     metadata: Entity.types.JSON,
     // task template
     task: Entity.types.JSON,
-    // pulse bindings (TODO; empty for now)
+    // pulse bindings
     bindings: Entity.types.JSON,
     // timings for the task (in fromNow format, e.g., "1 day")
     deadline: Entity.types.String,
@@ -135,7 +135,7 @@ const Hook = Entity.configure({
     metadata: Entity.types.JSON,
     // task template
     task: Entity.types.JSON,
-    // pulse bindings (TODO; empty for now)
+    // pulse bindings
     bindings: Entity.types.JSON,
     // schedule for this task (see schemas/schedule.yml)
     schedule: Entity.types.JSON,
@@ -166,7 +166,7 @@ const Hook = Entity.configure({
     metadata: Entity.types.JSON,
     // task template
     task: Entity.types.JSON,
-    // pulse bindings (TODO; empty for now)
+    // pulse bindings
     bindings: Entity.types.JSON,
     // schedule for this task (see schemas/schedule.yml)
     schedule: Entity.types.JSON,

--- a/services/queue/src/artifacts.js
+++ b/services/queue/src/artifacts.js
@@ -598,7 +598,6 @@ builder.declare({
   let runId = parseInt(req.params.runId, 10);
   let continuation = req.query.continuationToken || null;
   let limit = parseInt(req.query.limit || 1000, 10);
-  // TODO: Add support querying using prefix
 
   let [task, artifacts] = await Promise.all([
     this.Task.load({taskId}, true),
@@ -666,7 +665,6 @@ builder.declare({
   let taskId = req.params.taskId;
   let continuation = req.query.continuationToken || null;
   let limit = parseInt(req.query.limit || 1000, 10);
-  // TODO: Add support querying using prefix
 
   // Load task status structure from table
   let task = await this.Task.load({taskId}, true);

--- a/services/queue/src/dependencytracker.js
+++ b/services/queue/src/dependencytracker.js
@@ -242,12 +242,6 @@ class DependencyTracker {
           taskId: dep.dependentTaskId,
           requiredTaskId: taskId,
         }, true);
-        // TODO: Use return code from the remove statement to avoid checking
-        //       isBlocked(...) if no requirement was deleted.
-        //       Note, this will only work if we assume deletion happened, in
-        //       cases where a retry is necessary. Hence, this optimization
-        //       requires some mechanism to cheaply signal if retry or deletion
-        //       occurred. We can do that if this slow.
 
         if (!await this.isBlocked(dep.dependentTaskId)) {
           await this.scheduleTask(dep.dependentTaskId);


### PR DESCRIPTION
This has some relatively low-impact changes to remove TODO's from the monorepo.

There are still a few:

```
clients/client-web/.neutrinorc.js:              // TODO: Override using tap() so as to not have to repeat the
clients/client-web/.neutrinorc.js:        // TODO: Remove this when fixed in @neutrinojs/library.
infrastructure/tooling/src/dev/aws.js:  // TODO: Add both blob buckets
infrastructure/tooling/src/dev/aws.js:  // TODO: Also set up auth/notify aws stuff
infrastructure/tooling/src/dev/rabbit.js:        if (!['hooks', 'auth'].includes(service)) { // These services hardcode namespace TODO: fix?
infrastructure/tooling/src/dev/taskcluster.js:  // TODO: Figure out what any of these should be set to
infrastructure/tooling/src/dev/taskcluster.js:  //TODO: These github things can/should be questions in this setup thing
infrastructure/tooling/src/dev/taskcluster.js:  // TODO: These can/should be generated by dev:init aws setup
infrastructure/tooling/src/dev/taskcluster.js:  // TODO: This eventually should just build these from rootUrl itself probably
infrastructure/tooling/src/generate/generators/k8s.js:          paths: conf['paths'] || [`/api/${name}/*`], // TODO: This version of config is only for gcp ingress :(
infrastructure/tooling/src/generate/generators/k8s.js:        // TODO: iirc google doesn't set the headers that we need to trust proxy so we don't set this, let's fix it
infrastructure/tooling/src/generate/generators/k8s.js:        // TODO: In config.ymls somehow mark fields as "required" or "optional" and then assert
infrastructure/tooling/src/generate/generators/k8s.js:            cpu: '50m', // TODO: revisit these defaults
infrastructure/tooling/src/generate/generators/k8s.js:            cpu: '50m', // TODO: revisit these defaults
services/web-server/src/graphql/Provisioners.graphql:# TODO: Provisioner mutations
ui/src/components/ProvisionerDetailsTable/index.jsx:  // TODO: Action not working.
ui/src/components/TaskActionForm/index.jsx:    // TODO: Replace with taskAction
ui/src/views/Provisioners/ViewWorker/index.jsx:    // TODO: Action not working.
ui/src/views/Provisioners/ViewWorkers/index.jsx:  // TODO: Action not working
```

That breaks down to:
 * Neutrino config for client-web
 * `yarn dev`
 * Worker Actions support in the UI.