### PR TITLE
Make worker manager form invalid if owner not provided

### DIFF
--- a/changelog/issue-2201.md
+++ b/changelog/issue-2201.md
@@ -1,0 +1,3 @@
+level: silent
+reference: issue 2201
+---

--- a/ui/src/components/WMWorkerPoolEditor/index.jsx
+++ b/ui/src/components/WMWorkerPoolEditor/index.jsx
@@ -133,6 +133,7 @@ export default class WMWorkerPoolEditor extends Component {
       },
       owner: {
         error: null,
+        check: false,
         message: null,
       },
     },
@@ -151,6 +152,7 @@ export default class WMWorkerPoolEditor extends Component {
           ...this.state.validation,
           owner: {
             error: !validity.valid,
+            check: true,
             message: validationMessage,
           },
         },
@@ -186,7 +188,7 @@ export default class WMWorkerPoolEditor extends Component {
     return (
       !this.state.invalidProviderConfig &&
       !Object.values(validation).some(({ error }) => Boolean(error)) &&
-      providerId !== ''
+      providerId !== '' && this.state.validation.owner.check
     );
   }
 

--- a/ui/src/components/WMWorkerPoolEditor/index.jsx
+++ b/ui/src/components/WMWorkerPoolEditor/index.jsx
@@ -133,7 +133,6 @@ export default class WMWorkerPoolEditor extends Component {
       },
       owner: {
         error: null,
-        check: false,
         message: null,
       },
     },
@@ -152,7 +151,6 @@ export default class WMWorkerPoolEditor extends Component {
           ...this.state.validation,
           owner: {
             error: !validity.valid,
-            check: true,
             message: validationMessage,
           },
         },
@@ -181,14 +179,15 @@ export default class WMWorkerPoolEditor extends Component {
 
   isValid() {
     const {
-      workerPool: { providerId },
+      workerPool: { workerPoolId1, workerPoolId2, owner },
       validation,
     } = this.state;
 
     return (
       !this.state.invalidProviderConfig &&
       !Object.values(validation).some(({ error }) => Boolean(error)) &&
-      providerId !== '' && this.state.validation.owner.check
+      workerPoolId1 !== '' &&
+      workerPoolId2 !== '' &&  owner !== ''
     );
   }
 

--- a/ui/src/components/WMWorkerPoolEditor/index.jsx
+++ b/ui/src/components/WMWorkerPoolEditor/index.jsx
@@ -187,7 +187,8 @@ export default class WMWorkerPoolEditor extends Component {
       !this.state.invalidProviderConfig &&
       !Object.values(validation).some(({ error }) => Boolean(error)) &&
       workerPoolId1 !== '' &&
-      workerPoolId2 !== '' &&  owner !== ''
+      workerPoolId2 !== '' &&
+      owner !== ''
     );
   }
 


### PR DESCRIPTION
Save WM button is enabled only when all fields are filled, including owner field.

Fixes https://github.com/taskcluster/taskcluster/issues/2201.