### PR TITLE
Bug 1598649 - split into 'yarn release' and 'yarn release:publish'

### DIFF
--- a/changelog/bug-1598649.md
+++ b/changelog/bug-1598649.md
@@ -1,0 +1,4 @@
+level: silent
+reference: bug 1598649
+---
+Taskcluster releases are now performed in two parts: first in the Git repository, and then publishing all of the various artifacts of the release.

--- a/entrypoint
+++ b/entrypoint
@@ -64,6 +64,7 @@ script/fetch-coverage) shift; exec yarn run fetch-coverage "${@}";;
 script/test:cleanup) shift; exec yarn run test:cleanup "${@}";;
 script/build) shift; exec yarn run build "${@}";;
 script/release) shift; exec yarn run release "${@}";;
+script/release:publish) shift; exec yarn run release:publish "${@}";;
 script/generate) shift; exec yarn run generate "${@}";;
 script/changelog) shift; exec yarn run changelog "${@}";;
 script/changelog:show) shift; exec yarn run changelog:show "${@}";;

--- a/infrastructure/tooling/src/build/index.js
+++ b/infrastructure/tooling/src/build/index.js
@@ -25,6 +25,12 @@ class Build {
     generateMonoimageTasks({
       tasks,
       baseDir: this.baseDir,
+      credentials: {
+        // these are optional for `yarn build` but will always be supplied with
+        // `yarn release`
+        dockerUsername: process.env.DOCKER_USERNAME,
+        dockerPassword: process.env.DOCKER_PASSWORD,
+      },
       cmdOptions: this.cmdOptions,
     });
 

--- a/infrastructure/tooling/src/build/monoimage.js
+++ b/infrastructure/tooling/src/build/monoimage.js
@@ -30,7 +30,7 @@ const tempDir = path.join(REPO_ROOT, 'temp');
  *  All of this is done using a "hooks" approach to allow segmenting the various oddball bits of
  *  this process by theme.
  */
-const generateMonoimageTasks = ({tasks, baseDir, cmdOptions}) => {
+const generateMonoimageTasks = ({tasks, baseDir, cmdOptions, credentials}) => {
   const sourceDir = appRootDir.get();
 
   ensureTask(tasks, {
@@ -197,11 +197,20 @@ const generateMonoimageTasks = ({tasks, baseDir, cmdOptions}) => {
         return utils.skip({provides});
       }
 
+      const dockerPushOptions = {};
+      if (credentials.dockerUsername && credentials.dockerPassword) {
+        dockerPushOptions.credentials = {
+          username: credentials.dockerUsername,
+          password: credentials.dockerPassword,
+        };
+      }
+
       await dockerPush({
         logfile: `${baseDir}/docker-push.log`,
         tag,
         utils,
         baseDir,
+        ...dockerPushOptions,
       });
 
       return provides;

--- a/infrastructure/tooling/src/main.js
+++ b/infrastructure/tooling/src/main.js
@@ -40,6 +40,7 @@ program.command('release')
       ' * GH_TOKEN - GitHub access token with permissions to create a release',
       ' * NPM_TOKEN - NPM authentication token with permission to publish client libraries',
       ' * PYPI_USERNAME / PYPI_PASSWORD - PyPI credentials with permission to upload taskcluster-client',
+      ' * DOCKER_USERNAME / DOCKER_PASSWORD - Docker credentials with permission to taskcluster/taskcluster',
     ].join('\n'));
   })
   .action((...options) => {

--- a/infrastructure/tooling/src/main.js
+++ b/infrastructure/tooling/src/main.js
@@ -30,9 +30,23 @@ program.command('build')
   });
 
 program.command('release')
+  .description('tag a release and push it to GitHub')
+  .option('--dry-run', 'Do not run any tasks, but generate the list of tasks')
+  .option('--no-push', 'Do not push the git commit + tags (but your local repo is still modified)')
+  .action((...options) => {
+    if (options.length !== 1) {
+      console.error('unexpected command-line arguments');
+      process.exit(1);
+    }
+    const {main} = require('./release');
+    run(main, options[0]);
+  });
+
+program.command('release:publish')
+  .description('publish a release based on Git tag')
   .option('--base-dir <base-dir>', 'Base directory for build (fast and big!; default /tmp/taskcluster-builder-build)')
   .option('--dry-run', 'Do not run any tasks, but generate the list of tasks')
-  .option('--no-push', 'Do not push the docker image and git commit + tags (but your local repo is still modified)')
+  .option('--no-push', 'Do not push the GitHub release, docker images, packages, etc.')
   .on('--help', () => {
     console.log([
       '',
@@ -48,7 +62,7 @@ program.command('release')
       console.error('unexpected command-line arguments');
       process.exit(1);
     }
-    const {main} = require('./release');
+    const {main} = require('./publish');
     run(main, options[0]);
   });
 

--- a/infrastructure/tooling/src/publish/index.js
+++ b/infrastructure/tooling/src/publish/index.js
@@ -1,0 +1,99 @@
+const os = require('os');
+const util = require('util');
+const rimraf = util.promisify(require('rimraf'));
+const mkdirp = util.promisify(require('mkdirp'));
+const {TaskGraph, Lock, ConsoleRenderer, LogRenderer} = require('console-taskgraph');
+const {Build} = require('../build');
+const generatePublishTasks = require('./tasks');
+
+class Publish {
+  constructor(cmdOptions) {
+    this.cmdOptions = cmdOptions;
+
+    if (cmdOptions.push) {
+      [
+        'GH_TOKEN',
+        'NPM_TOKEN',
+        'PYPI_USERNAME',
+        'PYPI_PASSWORD',
+        'DOCKER_USERNAME',
+        'DOCKER_PASSWORD',
+      ].forEach(e => {
+        if (!process.env[e]) {
+          throw new Error(`$${e} is required (unless --no-push)`);
+        }
+      });
+    }
+
+    this.baseDir = cmdOptions['baseDir'] || '/tmp/taskcluster-builder-build';
+
+    // The `yarn build` process is a subgraph of the publish taskgraph, with some
+    // options "forced"
+    this.build = new Build({
+      ...cmdOptions,
+      cache: false, // always build from scratch
+    });
+  }
+
+  generateTasks() {
+    let tasks = this.build.generateTasks();
+
+    generatePublishTasks({
+      tasks,
+      cmdOptions: this.cmdOptions,
+      credentials: {
+        ghToken: process.env.GH_TOKEN,
+        npmToken: process.env.NPM_TOKEN,
+        pypiUsername: process.env.PYPI_USERNAME,
+        pypiPassword: process.env.PYPI_PASSWORD,
+        dockerUsername: process.env.DOCKER_USERNAME,
+        dockerPassword: process.env.DOCKER_PASSWORD,
+      },
+      baseDir: this.baseDir,
+    });
+
+    return tasks;
+  }
+
+  async run() {
+    if (!this.cmdOptions.cache) {
+      await rimraf(this.baseDir);
+    }
+    await mkdirp(this.baseDir);
+
+    let tasks = this.generateTasks();
+
+    const taskgraph = new TaskGraph(tasks, {
+      locks: {
+        // limit ourselves to one docker process per CPU
+        docker: new Lock(os.cpus().length),
+        // and let's be sane about how many git clones we do..
+        git: new Lock(8),
+      },
+      target: 'target-publish',
+      renderer: process.stdout.isTTY ?
+        new ConsoleRenderer({elideCompleted: true}) :
+        new LogRenderer(),
+    });
+    if (this.cmdOptions.dryRun) {
+      console.log('Dry run successful.');
+      return;
+    }
+    const context = await taskgraph.run();
+
+    console.log(`Release version: ${context['release-version']}`);
+    console.log(`Release docker image: ${context['monoimage-docker-image']}`);
+    if (!this.cmdOptions.push) {
+      console.log('NOTE: image, git commit + tags, and packages not pushed due to --no-push option');
+    } else {
+      console.log(`GitHub release: ${context['github-release']}`);
+    }
+  }
+}
+
+const main = async (options) => {
+  const publish = new Publish(options);
+  await publish.run();
+};
+
+module.exports = {main, Publish};

--- a/infrastructure/tooling/src/publish/tasks.js
+++ b/infrastructure/tooling/src/publish/tasks.js
@@ -1,0 +1,224 @@
+const Octokit = require('@octokit/rest');
+const fs = require('fs');
+const util = require('util');
+const path = require('path');
+const rimraf = util.promisify(require('rimraf'));
+const mkdirp = util.promisify(require('mkdirp'));
+const {
+  ensureTask,
+  gitDescribe,
+  npmPublish,
+  execCommand,
+  pyClientRelease,
+  readRepoFile,
+  REPO_ROOT,
+} = require('../utils');
+
+const readFile = util.promisify(fs.readFile);
+
+module.exports = ({tasks, cmdOptions, credentials, baseDir}) => {
+  const artifactsDir = path.join(baseDir, 'release-artifacts');
+
+  ensureTask(tasks, {
+    title: 'Get release version',
+    requires: [],
+    provides: ['release-version'],
+    run: async (requirements, utils) => {
+      const {gitDescription} = await gitDescribe({
+        dir: REPO_ROOT,
+        utils,
+      });
+
+      if (!gitDescription.match(/^v\d+\.\d+\.\d+$/)) {
+        throw new Error(`Can only publish releases from git revisions with tags of the form X.Y.Z, not ${gitDescription}`);
+      }
+
+      return {
+        'release-version': gitDescription.slice(1),
+      };
+    },
+  });
+
+  ensureTask(tasks, {
+    title: 'Get ChangeLog',
+    requires: ['release-version'],
+    provides: [
+      'changelog-text',
+      'build-can-start', // wait to build until we're sure this worked..
+    ],
+    run: async (requirements, utils) => {
+      // recover the changelog for this version from CHANGELOG.md, where `yarn
+      // release` put it
+      const changelogFile = await readRepoFile('CHANGELOG.md');
+      const version = requirements['release-version'];
+      const regex = new RegExp(`^## v${version}\n+(.*?)\n^## v`, 'sm');
+      const match = changelogFile.match(regex);
+      if (!match) {
+        throw new Error(`Could not find version ${version} in CHANGELOG.md`);
+      }
+      return {
+        'changelog-text': match[1],
+        'build-can-start': true,
+      };
+    },
+  });
+
+  ensureTask(tasks, {
+    title: 'Clean release-artifacts',
+    requires: [],
+    provides: ['cleaned-release-artifacts'],
+    run: async (requirements, utils) => {
+      await rimraf(artifactsDir);
+      await mkdirp(artifactsDir);
+    },
+  });
+
+  ensureTask(tasks, {
+    title: 'Build client-shell artifacts',
+    requires: ['cleaned-release-artifacts'],
+    provides: ['client-shell-artifacts'],
+    run: async (requirements, utils) => {
+      await execCommand({
+        dir: artifactsDir,
+        command: ['go', 'get', '-u', 'github.com/mitchellh/gox'],
+        utils,
+      });
+
+      const osarch = 'linux/amd64 darwin/amd64';
+      await execCommand({
+        dir: path.join(REPO_ROOT, 'clients', 'client-shell'),
+        command: [
+          'gox',
+          `-osarch=${osarch}`,
+          `-output=${artifactsDir}/taskcluster-{{.OS}}-{{.Arch}}`,
+        ],
+        utils,
+      });
+
+      const artifacts = osarch.split(' ')
+        .map(osarch => {
+          const [os, arch] = osarch.split('/');
+          return `taskcluster-${os}-${arch}`;
+        });
+
+      return {
+        'client-shell-artifacts': artifacts,
+      };
+    },
+  });
+
+  /* -- docker image build occurs here -- */
+
+  ensureTask(tasks, {
+    title: 'Create GitHub Release',
+    requires: [
+      'release-version',
+      'client-shell-artifacts',
+      'changelog-text',
+      'target-monoimage',
+    ],
+    provides: [
+      'github-release',
+    ],
+    run: async (requirements, utils) => {
+      if (!cmdOptions.push) {
+        return utils.skip({});
+      }
+
+      const octokit = new Octokit({auth: `token ${credentials.ghToken}`});
+
+      utils.status({message: `Create Release`});
+      const release = await octokit.repos.createRelease({
+        owner: 'taskcluster',
+        repo: 'taskcluster',
+        tag_name: `v${requirements['release-version']}`,
+        name: `v${requirements['release-version']}`,
+        body: await requirements['changelog-text'],
+        draft: false,
+        prerelease: false,
+      });
+      const {upload_url} = release.data;
+
+      const files = requirements['client-shell-artifacts']
+        .map(name => ({name, contentType: 'application/octet-stream'}));
+      for (let {name, contentType} of files) {
+        utils.status({message: `Upload Release asset ${name}`});
+        const file = await readFile(path.join(artifactsDir, name));
+        await octokit.repos.uploadReleaseAsset({
+          url: upload_url,
+          headers: {
+            'content-length': file.length,
+            'content-type': contentType,
+          },
+          name,
+          file,
+        });
+      }
+
+      return {
+        'github-release': release.data.html_url,
+      };
+    },
+  });
+
+  ['clients/client', 'clients/client-web'].forEach(clientName =>
+    ensureTask(tasks, {
+      title: `Publish ${clientName} to npm`,
+      requires: [
+        'target-monoimage', // to make sure the build succeeds first..
+      ],
+      provides: [
+        `publish-${clientName}`,
+      ],
+      run: async (requirements, utils) => {
+        if (!cmdOptions.push) {
+          return utils.skip({});
+        }
+
+        await npmPublish({
+          dir: path.join(REPO_ROOT, clientName),
+          apiKey: credentials.npmToken,
+          logfile: `${baseDir}/publish-${clientName.replace('/', '-')}.log`,
+          utils});
+      },
+    }));
+
+  ensureTask(tasks, {
+    title: `Publish clients/client-py to pypi`,
+    requires: [
+      'target-monoimage', // to make sure the build succeeds first..
+    ],
+    provides: [
+      `publish-clients/client-py`,
+    ],
+    run: async (requirements, utils) => {
+      if (!cmdOptions.push) {
+        return utils.skip({});
+      }
+
+      await pyClientRelease({
+        dir: path.join(REPO_ROOT, 'clients', 'client-py'),
+        username: credentials.pypiUsername,
+        password: credentials.pypiPassword,
+        logfile: `${baseDir}/publish-client-py.log`,
+        utils});
+    },
+  });
+
+  ensureTask(tasks, {
+    title: 'Publish Complete',
+    requires: [
+      'target-monoimage',
+      'github-release',
+      'publish-clients/client',
+      'publish-clients/client-web',
+      'publish-clients/client-py',
+    ],
+    provides: [
+      'target-publish',
+    ],
+    run: async (requirements, utils) => {
+      // this just gathers requirements into a single target..
+    },
+  });
+};

--- a/infrastructure/tooling/src/release/index.js
+++ b/infrastructure/tooling/src/release/index.js
@@ -1,73 +1,24 @@
 const os = require('os');
-const util = require('util');
-const rimraf = util.promisify(require('rimraf'));
-const mkdirp = util.promisify(require('mkdirp'));
 const {TaskGraph, Lock, ConsoleRenderer, LogRenderer} = require('console-taskgraph');
-const {Build} = require('../build');
 const generateReleaseTasks = require('./tasks');
 
 class Release {
   constructor(cmdOptions) {
     this.cmdOptions = cmdOptions;
-
-    if (cmdOptions.push) {
-      [
-        'GH_TOKEN',
-        'NPM_TOKEN',
-        'PYPI_USERNAME',
-        'PYPI_PASSWORD',
-        'DOCKER_USERNAME',
-        'DOCKER_PASSWORD',
-      ].forEach(e => {
-        if (!process.env[e]) {
-          throw new Error(`$${e} is required (unless --no-push)`);
-        }
-      });
-    }
-
-    this.baseDir = cmdOptions['baseDir'] || '/tmp/taskcluster-builder-build';
-
-    // The `yarn build` process is a subgraph of the release taskgraph, with some
-    // options "forced"
-    this.build = new Build({
-      ...cmdOptions,
-      cache: false, // always build from scratch
-    });
   }
 
-  /**
-   * Generate the tasks for `yarn build`.  The result is a set of tasks which
-   * culminates in one providing `monoimage-docker-image`, a docker image path
-   * for the resulting monoimage.  The tasks in this subgraph that clone and build the
-   * repository depend on `build-can-start` (tasks to download docker images,
-   * and other such preparatory work, can begin earlier)
-   */
   generateTasks() {
-    let tasks = this.build.generateTasks();
+    const tasks = [];
 
     generateReleaseTasks({
       tasks,
       cmdOptions: this.cmdOptions,
-      credentials: {
-        ghToken: process.env.GH_TOKEN,
-        npmToken: process.env.NPM_TOKEN,
-        pypiUsername: process.env.PYPI_USERNAME,
-        pypiPassword: process.env.PYPI_PASSWORD,
-        dockerUsername: process.env.DOCKER_USERNAME,
-        dockerPassword: process.env.DOCKER_PASSWORD,
-      },
-      baseDir: this.baseDir,
     });
 
     return tasks;
   }
 
   async run() {
-    if (!this.cmdOptions.cache) {
-      await rimraf(this.baseDir);
-    }
-    await mkdirp(this.baseDir);
-
     let tasks = this.generateTasks();
 
     const taskgraph = new TaskGraph(tasks, {
@@ -89,11 +40,8 @@ class Release {
     const context = await taskgraph.run();
 
     console.log(`Release version: ${context['release-version']}`);
-    console.log(`Release docker image: ${context['monoimage-docker-image']}`);
     if (!this.cmdOptions.push) {
       console.log('NOTE: image, git commit + tags, and packages not pushed due to --no-push option');
-    } else {
-      console.log(`GitHub release: ${context['github-release']}`);
     }
   }
 }

--- a/infrastructure/tooling/src/release/index.js
+++ b/infrastructure/tooling/src/release/index.js
@@ -11,7 +11,14 @@ class Release {
     this.cmdOptions = cmdOptions;
 
     if (cmdOptions.push) {
-      ['GH_TOKEN', 'NPM_TOKEN', 'PYPI_USERNAME', 'PYPI_PASSWORD'].forEach(e => {
+      [
+        'GH_TOKEN',
+        'NPM_TOKEN',
+        'PYPI_USERNAME',
+        'PYPI_PASSWORD',
+        'DOCKER_USERNAME',
+        'DOCKER_PASSWORD',
+      ].forEach(e => {
         if (!process.env[e]) {
           throw new Error(`$${e} is required (unless --no-push)`);
         }
@@ -46,6 +53,8 @@ class Release {
         npmToken: process.env.NPM_TOKEN,
         pypiUsername: process.env.PYPI_USERNAME,
         pypiPassword: process.env.PYPI_PASSWORD,
+        dockerUsername: process.env.DOCKER_USERNAME,
+        dockerPassword: process.env.DOCKER_PASSWORD,
       },
       baseDir: this.baseDir,
     });

--- a/infrastructure/tooling/src/release/tasks.js
+++ b/infrastructure/tooling/src/release/tasks.js
@@ -1,11 +1,5 @@
 const semver = require('semver');
-const Octokit = require('@octokit/rest');
-const fs = require('fs');
 const {ChangeLog} = require('../changelog');
-const util = require('util');
-const path = require('path');
-const rimraf = util.promisify(require('rimraf'));
-const mkdirp = util.promisify(require('mkdirp'));
 const {
   ensureTask,
   gitLsFiles,
@@ -13,8 +7,6 @@ const {
   gitCommit,
   gitTag,
   gitPush,
-  npmPublish,
-  execCommand,
   readRepoJSON,
   readRepoFile,
   writeRepoFile,
@@ -22,15 +14,10 @@ const {
   writeRepoYAML,
   modifyRepoFile,
   removeRepoFile,
-  pyClientRelease,
   REPO_ROOT,
 } = require('../utils');
 
-const readFile = util.promisify(fs.readFile);
-
-module.exports = ({tasks, cmdOptions, credentials, baseDir}) => {
-  const artifactsDir = path.join(baseDir, 'release-artifacts');
-
+module.exports = ({tasks, cmdOptions, credentials}) => {
   ensureTask(tasks, {
     title: 'Get Changelog',
     requires: [
@@ -262,61 +249,12 @@ module.exports = ({tasks, cmdOptions, credentials, baseDir}) => {
   });
 
   ensureTask(tasks, {
-    title: 'Clean release-artifacts',
-    requires: [],
-    provides: ['cleaned-release-artifacts'],
-    run: async (requirements, utils) => {
-      await rimraf(artifactsDir);
-      await mkdirp(artifactsDir);
-    },
-  });
-
-  ensureTask(tasks, {
-    title: 'Build client-shell artifacts',
-    requires: [
-      'cleaned-release-artifacts',
-      'version-updated',
-    ],
-    provides: ['client-shell-artifacts'],
-    run: async (requirements, utils) => {
-      await execCommand({
-        dir: artifactsDir,
-        command: ['go', 'get', '-u', 'github.com/mitchellh/gox'],
-        utils,
-      });
-
-      const osarch = 'linux/amd64 darwin/amd64';
-      await execCommand({
-        dir: path.join(REPO_ROOT, 'clients', 'client-shell'),
-        command: [
-          'gox',
-          `-osarch=${osarch}`,
-          `-output=${artifactsDir}/taskcluster-{{.OS}}-{{.Arch}}`,
-        ],
-        utils,
-      });
-
-      const artifacts = osarch.split(' ')
-        .map(osarch => {
-          const [os, arch] = osarch.split('/');
-          return `taskcluster-${os}-${arch}`;
-        });
-
-      return {
-        'client-shell-artifacts': artifacts,
-      };
-    },
-  });
-
-  /* -- docker image build occurs here -- */
-
-  ensureTask(tasks, {
     title: 'Push Tag',
     requires: [
       'repo-tagged',
     ],
     provides: [
-      'pushed-tag',
+      'target-release',
     ],
     run: async (requirements, utils) => {
       if (!cmdOptions.push) {
@@ -334,123 +272,6 @@ module.exports = ({tasks, cmdOptions, credentials, baseDir}) => {
       return {
         'pushed-tag': tags[0],
       };
-    },
-  });
-
-  /* --- remainder would be done in CI --- */
-
-  ensureTask(tasks, {
-    title: 'Create GitHub Release',
-    requires: [
-      'release-version',
-      'client-shell-artifacts',
-      'pushed-tag',
-      'changelog',
-      'target-monoimage',
-    ],
-    provides: [
-      'github-release',
-    ],
-    run: async (requirements, utils) => {
-      if (!cmdOptions.push) {
-        return utils.skip({});
-      }
-
-      const octokit = new Octokit({auth: `token ${credentials.ghToken}`});
-
-      utils.status({message: `Create Release`});
-      const release = await octokit.repos.createRelease({
-        owner: 'taskcluster',
-        repo: 'taskcluster',
-        tag_name: requirements['pushed-tag'],
-        name: requirements['pushed-tag'],
-        body: await requirements['changelog'].format(),
-        draft: false,
-        prerelease: false,
-      });
-      const {upload_url} = release.data;
-
-      const files = requirements['client-shell-artifacts']
-        .map(name => ({name, contentType: 'application/octet-stream'}));
-      for (let {name, contentType} of files) {
-        utils.status({message: `Upload Release asset ${name}`});
-        const file = await readFile(path.join(artifactsDir, name));
-        await octokit.repos.uploadReleaseAsset({
-          url: upload_url,
-          headers: {
-            'content-length': file.length,
-            'content-type': contentType,
-          },
-          name,
-          file,
-        });
-      }
-
-      return {
-        'github-release': release.data.html_url,
-      };
-    },
-  });
-
-  ['clients/client', 'clients/client-web'].forEach(clientName =>
-    ensureTask(tasks, {
-      title: `Publish ${clientName} to npm`,
-      requires: [
-        'version-updated',
-        'target-monoimage', // to make sure the build succeeds first..
-      ],
-      provides: [
-        `publish-${clientName}`,
-      ],
-      run: async (requirements, utils) => {
-        if (!cmdOptions.push) {
-          return utils.skip({});
-        }
-
-        await npmPublish({
-          dir: path.join(REPO_ROOT, clientName),
-          apiKey: credentials.npmToken,
-          logfile: `${baseDir}/publish-${clientName.replace('/', '-')}.log`,
-          utils});
-      },
-    }));
-
-  ensureTask(tasks, {
-    title: `Publish clients/client-py to pypi`,
-    requires: [
-      'version-updated',
-      'target-monoimage', // to make sure the build succeeds first..
-    ],
-    provides: [
-      `publish-clients/client-py`,
-    ],
-    run: async (requirements, utils) => {
-      if (!cmdOptions.push) {
-        return utils.skip({});
-      }
-
-      await pyClientRelease({
-        dir: path.join(REPO_ROOT, 'clients', 'client-py'),
-        username: credentials.pypiUsername,
-        password: credentials.pypiPassword,
-        logfile: `${baseDir}/publish-client-py.log`,
-        utils});
-    },
-  });
-
-  ensureTask(tasks, {
-    title: 'Release Complete',
-    requires: [
-      'github-release',
-      'publish-clients/client',
-      'publish-clients/client-web',
-      'publish-clients/client-py',
-    ],
-    provides: [
-      'target-release',
-    ],
-    run: async (requirements, utils) => {
-      // this just gathers requirements into a single target..
     },
   });
 };

--- a/infrastructure/tooling/src/utils/command.js
+++ b/infrastructure/tooling/src/utils/command.js
@@ -42,7 +42,7 @@ exports.execCommand = async ({
       } else {
         output = '...\n' + chunk.toString();
       }
-      callback(null, output);
+      callback(null, chunk);
     },
   });
   cp.stdout.pipe(stream);

--- a/infrastructure/tooling/src/utils/docker.js
+++ b/infrastructure/tooling/src/utils/docker.js
@@ -1,3 +1,4 @@
+const util = require('util');
 const split = require('split');
 const fs = require('fs');
 const os = require('os');
@@ -5,8 +6,13 @@ const path = require('path');
 const Docker = require('dockerode');
 const Observable = require('zen-observable');
 const {PassThrough, Transform} = require('stream');
+const taskcluster = require('taskcluster-client');
+const {REPO_ROOT} = require('./repo');
 const got = require('got');
 const {spawn} = require('child_process');
+const {execCommand} = require('./command');
+const mkdirp = util.promisify(require('mkdirp'));
+const rimraf = util.promisify(require('rimraf'));
 
 /**
  * Set up to call docker in the given baseDir (internal use only)
@@ -283,25 +289,42 @@ exports.dockerRegistryCheck = async ({tag}) => {
  * - baseDir -- base directory for operations
  * - tag -- tag to push
  * - logfile -- name of the file to write the log to
+ * - credentials -- {username, secret} for docker access
+ *     (optional; uses existing docker creds if omitted)
  * - utils -- taskgraph utils (waitFor, etc.)
  */
-exports.dockerPush = async ({baseDir, tag, logfile, utils}) => {
-  await utils.waitFor(new Observable(observer => {
-    const push = spawn('docker', ['push', tag]);
-    push.on('error', err => observer.error(err));
-    if (logfile) {
-      const logStream = fs.createWriteStream(logfile);
-      push.stdout.pipe(logStream);
-      push.stderr.pipe(logStream);
+exports.dockerPush = async ({baseDir, tag, logfile, credentials, utils}) => {
+  let homeDir;
+  const env = {...process.env};
+
+  try {
+    if (credentials) {
+      // override HOME so this doesn't use the user's credentials
+      homeDir = path.join(REPO_ROOT, 'temp', taskcluster.slugid());
+      await mkdirp(homeDir);
+      env.HOME = homeDir;
+
+      // run `docker login` to set up credentials in the temp homedir
+      await execCommand({
+        dir: baseDir,
+        command: ['docker', 'login', '--username', credentials.username, '--password-stdin'],
+        utils,
+        stdin: credentials.password,
+        logfile,
+        env,
+      });
     }
-    push.stdout.pipe(split(/\r?\n/, null, {trailing: false})).on('data', d => observer.next(d.toString()));
-    push.stderr.pipe(split(/\r?\n/, null, {trailing: false})).on('data', d => observer.next(d.toString()));
-    push.on('exit', (code, signal) => {
-      if (code !== 0) {
-        observer.error(new Error(`push failed! check ${logfile} for reason`));
-      } else {
-        observer.complete();
-      }
+
+    await execCommand({
+      dir: baseDir,
+      command: ['docker', 'push', tag],
+      utils,
+      logfile,
+      env,
     });
-  }));
+  } finally {
+    if (homeDir) {
+      await rimraf(homeDir);
+    }
+  }
 };

--- a/package.json
+++ b/package.json
@@ -171,6 +171,7 @@
     "test:cleanup": "yarn workspace taskcluster-auth test:cleanup",
     "build": "node infrastructure/tooling/src/main.js build",
     "release": "node infrastructure/tooling/src/main.js release",
+    "release:publish": "node infrastructure/tooling/src/main.js release:publish",
     "generate": "node infrastructure/tooling/src/main.js generate",
     "changelog": "node infrastructure/tooling/src/main.js changelog",
     "changelog:show": "node infrastructure/tooling/src/main.js changelog:show",


### PR DESCRIPTION
Bugzilla Bug: [1598649](https://bugzilla.mozilla.org/show_bug.cgi?id=1598649)

Next step will be to perform the `yarn release:publish` portion in CI on pushes to tags.