### PR TITLE
Bug 1606948 - remove no-longer-necessary installs

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -330,9 +330,6 @@ tasks:
                     curl -o- -L https://yarnpkg.com/install.sh | bash
                     export PATH="$HOME/.yarn/bin:$HOME/.config/yarn/global/node_modules/.bin:$PATH"
 
-                    # set up Python (see bug 1606948)
-                    apt-get update && apt-get install -y python3-venv python-virtualenv
-
                     # clone the repo (shallow won't work here as it misses tags)
                     git clone --quiet --no-single-branch --tags ${repo.git_url} taskcluster
                     cd taskcluster

--- a/changelog/bug-1606948.md
+++ b/changelog/bug-1606948.md
@@ -1,0 +1,3 @@
+level: silent
+reference: bug 1606948
+---


### PR DESCRIPTION
Bugzilla Bug: [1606948](https://bugzilla.mozilla.org/show_bug.cgi?id=1606948)
