### PR TITLE
Bug 1608176 - allow `client.SignedURL(..)` to take a full URL again

### DIFF
--- a/changelog/bug-1608176.md
+++ b/changelog/bug-1608176.md
@@ -1,0 +1,4 @@
+level: patch
+reference: bug 1608176
+---
+The go client's `client.SignedURL(..)` function can now accept and sign full URLs in its first argument.  This allows signing arbitrary URLs, even if they are not on the same RootURL as the client.

--- a/clients/client-go/codegenerator/model/api.go
+++ b/clients/client-go/codegenerator/model/api.go
@@ -359,8 +359,10 @@ func (entry *APIEntry) generateDirectMethod(apiName string) string {
 
 func (entry *APIEntry) generateSignedURLMethod(apiName string) string {
 	// if no required scopes, no reason to provide a signed url
-	// method, since no auth is required, so unsigned url already works
-	if entry.Scopes.Type == "" {
+	// method, since no auth is required, so unsigned url already works,
+	// except for TestAuthenticateGet, which can be usefully used to test
+	// with signed URLs
+	if entry.Scopes.Type == "" && entry.MethodName != "TestAuthenticateGet" {
 		return ""
 	}
 	comment := "// Returns a signed URL for " + entry.MethodName + ", valid for the specified duration.\n"

--- a/clients/client-go/creds_test.go
+++ b/clients/client-go/creds_test.go
@@ -3,6 +3,7 @@ package tcclient_test
 import (
 	"fmt"
 	"net/http"
+	"net/url"
 	"os"
 	"reflect"
 	"testing"
@@ -130,6 +131,25 @@ func Test_PermaCred_Bewit(t *testing.T) {
 	}
 	client := tcauth.New(testCreds, rootURL)
 	url, err := client.TestAuthenticateGet_SignedURL(15 * time.Minute)
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
+	resp, err := http.Get(url.String())
+	if 200 != resp.StatusCode {
+		t.Fatalf("Got unexpected statusCode %d", resp.StatusCode)
+		return
+	}
+}
+
+func Test_PermaCred_Bewit_SignedURL(t *testing.T) {
+	rootURL := os.Getenv("TASKCLUSTER_ROOT_URL")
+	if rootURL == "" {
+		t.Skip("Cannot run test, TASKCLUSTER_ROOT_URL is not set to a non-empty string")
+	}
+	client := tcclient.Client{Credentials: testCreds}
+	url, err := client.SignedURL(rootURL+"/api/auth/v1/test-authenticate-get/", url.Values{}, 15*time.Minute)
 	if err != nil {
 		t.Error(err)
 		return

--- a/clients/client-go/http.go
+++ b/clients/client-go/http.go
@@ -17,8 +17,8 @@ import (
 	"time"
 
 	"github.com/taskcluster/httpbackoff/v3"
-	hawk "github.com/tent/hawk-go"
 	tcurls "github.com/taskcluster/taskcluster-lib-urls"
+	hawk "github.com/tent/hawk-go"
 )
 
 var debug = false
@@ -259,15 +259,21 @@ func (client *Client) APICall(payload interface{}, method, route string, result 
 	return result, callSummary, nil
 }
 
-// SignedURL creates a signed URL using the given Client, where route is the
-// url path relative to the RootURL stored in the Client, query is the set of
-// query string parameters, if any, and duration is the amount of time that the
-// signed URL should remain valid for.
+// SignedURL creates a signed URL using the given Client, where route is
+// either a url path relative to `<RootURL>/api/<serviceName>/<apiVersion>` or
+// a fully qualified URL.  query is the set of query string parameters, if any,
+// and duration is the amount of time that the signed URL should remain valid
+// for.  The full-URL form permits signing URLs that are not even on the given
+// RootURL.
 func (client *Client) SignedURL(route string, query url.Values, duration time.Duration) (u *url.URL, err error) {
-	u, err = setURL(client, route, query)
-	if err != nil {
-		return
+	u, err = url.Parse(route)
+	if err != nil || u.Host == "" {
+		u, err = setURL(client, route, query)
+		if err != nil {
+			return
+		}
 	}
+
 	credentials := &hawk.Credentials{
 		ID:   client.Credentials.ClientID,
 		Key:  client.Credentials.AccessToken,

--- a/clients/client-go/http_test.go
+++ b/clients/client-go/http_test.go
@@ -391,3 +391,40 @@ func TestHTTPRequestGeneration(t *testing.T) {
 		t.Fail()
 	}
 }
+
+func TestSignedURL_PartialURL(t *testing.T) {
+	client := Client{
+		Credentials: &Credentials{
+			ClientID:    "test-signin",
+			AccessToken: "fake-key",
+		},
+		RootURL:     "https://tc.example.com",
+		ServiceName: "grapes",
+		APIVersion:  "v2",
+	}
+
+	res, err := client.SignedURL("foo/bar", url.Values{"param": []string{"p1"}}, time.Minute)
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
+	if res.Host != "tc.example.com" {
+		t.Fatalf("Got unexpected host %s", res.Host)
+		return
+	}
+	if res.Path != "/api/grapes/v2/foo/bar" {
+		t.Fatalf("Got unexpected path %s", res.Path)
+		return
+	}
+	if res.Query()["param"][0] != "p1" {
+		t.Fatalf("Got unexpected query %s", res.Query())
+		return
+	}
+
+	_, ok := res.Query()["bewit"]
+	if !ok {
+		t.Fatalf("Query does not have a 'bewit'")
+		return
+	}
+}

--- a/clients/client-go/http_test.go
+++ b/clients/client-go/http_test.go
@@ -392,6 +392,43 @@ func TestHTTPRequestGeneration(t *testing.T) {
 	}
 }
 
+func TestSignedURL_FullURL(t *testing.T) {
+	client := Client{
+		Credentials: &Credentials{
+			ClientID:    "test-signin",
+			AccessToken: "fake-key",
+		},
+		RootURL:     "https://tc.example.com",
+		ServiceName: "grapes",
+		APIVersion:  "v2",
+	}
+
+	res, err := client.SignedURL("https://tc.example.com/api/barley/v1/foo/bar", url.Values{"param": []string{"p1"}}, time.Minute)
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
+	if res.Host != "tc.example.com" {
+		t.Fatalf("Got unexpected host %s", res.Host)
+		return
+	}
+	if res.Path != "/api/barley/v1/foo/bar" {
+		t.Fatalf("Got unexpected path %s", res.Path)
+		return
+	}
+	if res.Query()["param"][0] != "p1" {
+		t.Fatalf("Got unexpected query %s", res.Query())
+		return
+	}
+
+	_, ok := res.Query()["bewit"]
+	if !ok {
+		t.Fatalf("Query does not have a 'bewit'")
+		return
+	}
+}
+
 func TestSignedURL_PartialURL(t *testing.T) {
 	client := Client{
 		Credentials: &Credentials{

--- a/clients/client-go/tcauth/tcauth.go
+++ b/clients/client-go/tcauth/tcauth.go
@@ -759,3 +759,11 @@ func (auth *Auth) TestAuthenticateGet() (*TestAuthenticateResponse, error) {
 	responseObject, _, err := (&cd).APICall(nil, "GET", "/test-authenticate-get/", new(TestAuthenticateResponse), nil)
 	return responseObject.(*TestAuthenticateResponse), err
 }
+
+// Returns a signed URL for TestAuthenticateGet, valid for the specified duration.
+//
+// See TestAuthenticateGet for more details.
+func (auth *Auth) TestAuthenticateGet_SignedURL(duration time.Duration) (*url.URL, error) {
+	cd := tcclient.Client(*auth)
+	return (&cd).SignedURL("/test-authenticate-get/", nil, duration)
+}


### PR DESCRIPTION
Bugzilla Bug: [1608176](https://bugzilla.mozilla.org/show_bug.cgi?id=1608176)

This is functionality we had long, long ago, and on which [taskcluster-proxy depended](https://github.com/taskcluster/taskcluster-proxy/pull/46).  It's easy enough to re-introduce it!

I also added some tests for bewit support.  Happily, they passed :)