### PR TITLE
Bug 1604649 - skip loading a worker if no tasks are claimed

### DIFF
--- a/changelog/bug-1604649.md
+++ b/changelog/bug-1604649.md
@@ -1,0 +1,4 @@
+level: patch
+reference: bug 1604649
+---
+The queue now avoids calling GetEntity for a worker in claimWork when no work was claimed, providing a very minor reduction in Azure load.

--- a/services/queue/src/workerinfo.js
+++ b/services/queue/src/workerinfo.js
@@ -164,6 +164,10 @@ class WorkerInfo {
   }
 
   async taskSeen(provisionerId, workerType, workerGroup, workerId, tasks) {
+    if (!tasks.length) {
+      return;
+    }
+
     // Keep track of most recent tasks of a worker
     const worker = await this.Worker.load({
       provisionerId,
@@ -172,7 +176,7 @@ class WorkerInfo {
       workerId,
     }, true);
 
-    if (!tasks.length || !worker || worker.quarantineUntil.getTime() > new Date().getTime()) {
+    if (!worker || worker.quarantineUntil.getTime() > new Date().getTime()) {
       return;
     }
 


### PR DESCRIPTION
This is a very minor reduction in total queries to Azure.  I don't expect this to "fix" the ServerBusy errors at all..

Bugzilla Bug: [1604649](https://bugzilla.mozilla.org/show_bug.cgi?id=1604649)
