### PR TITLE
Adjust netlify publish command

### DIFF
--- a/changelog/KS3gz-X8TumrS-e0eSl6og.md
+++ b/changelog/KS3gz-X8TumrS-e0eSl6og.md
@@ -1,0 +1,2 @@
+level: silent
+---

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,7 +1,7 @@
 [build]
   base    = "ui"
   command = "GENERATE_ENV_JS=1 yarn build"
-  publish = "ui/build"
+  publish = "build"
 
 [build.environment]
   YARN_FLAGS = "--frozen-lockfile"


### PR DESCRIPTION
After re-linking the repo ([see comment](https://github.com/taskcluster/taskcluster/pull/2274#issuecomment-575216982)), Netlify is failing with "Deploy directory 'ui/ui/build' does not exist". https://community.netlify.com/t/deploy-directory-web-web-public-does-not-exist/4405 suggests that the publish command now gets run inside the base directory.