### PR TITLE
Require newer tc-lib-urls in python client

### DIFF
--- a/changelog/NzegYUX3TxSDwwDh-6xqrA.md
+++ b/changelog/NzegYUX3TxSDwwDh-6xqrA.md
@@ -1,0 +1,2 @@
+level: silent
+---

--- a/clients/client-py/setup.py
+++ b/clients/client-py/setup.py
@@ -27,7 +27,7 @@ install_requires = [
     'requests>=2.4.3',
     'mohawk>=0.3.4',
     'slugid>=2',
-    'taskcluster-urls>=10.1.0',
+    'taskcluster-urls>=12.1.0',
     'six>=1.10.0',
 ]
 


### PR DESCRIPTION
We now use normalize_root_url, so require the version where that was
introduced.

See https://github.com/taskcluster/tc-admin/pull/60