### PR TITLE
[renovate] Do not rebase to save CI cycles

### DIFF
--- a/package.json
+++ b/package.json
@@ -197,6 +197,7 @@
       "config:base",
       "schedule:earlyMondays"
     ],
+    "rebaseConflictedPrs": false,
     "prHourlyLimit": 0,
     "prConcurrentLimit": 9,
     "rangeStrategy": "update-lockfile",


### PR DESCRIPTION
This will also keep us the free-tier for Netlify.

https://docs.renovatebot.com/configuration-options/#rebaseconflictedprs