### PR TITLE
Bug 1604175 - Revert max task deadline to 5 days

### DIFF
--- a/changelog/bug-1604175.md
+++ b/changelog/bug-1604175.md
@@ -1,0 +1,4 @@
+level: minor
+reference: bug 1604175
+---
+The maximum "deadline" has been reverted to 5 days, after its change to 10 days in v24.1.3.  Values over 7 days caused internal server errors anyway, because the Azure queue backend cannot handle delays greater than that value.  Since this functionality never worked, the revert is considered minor.

--- a/clients/client-go/tcqueue/types.go
+++ b/clients/client-go/tcqueue/types.go
@@ -795,7 +795,7 @@ type (
 		// Deadline of the task, by which this task must be complete. `pending` and
 		// `running` runs are resolved as **exception** if not resolved by other means
 		// before the deadline. After the deadline, a task is immutable. Note,
-		// deadline cannot be more than 10 days into the future
+		// deadline cannot be more than 5 days into the future
 		Deadline tcclient.Time `json:"deadline"`
 
 		// List of dependent tasks. These must either be _completed_ or _resolved_
@@ -966,7 +966,7 @@ type (
 		// Deadline of the task, by which this task must be complete. `pending` and
 		// `running` runs are resolved as **exception** if not resolved by other means
 		// before the deadline. After the deadline, a task is immutable. Note,
-		// deadline cannot be more than 10 days into the future
+		// deadline cannot be more than 5 days into the future
 		Deadline tcclient.Time `json:"deadline"`
 
 		// List of dependent tasks. These must either be _completed_ or _resolved_
@@ -1285,7 +1285,7 @@ type (
 		// Deadline of the task, by which this task must be complete. `pending` and
 		// `running` runs are resolved as **exception** if not resolved by other means
 		// before the deadline. After the deadline, a task is immutable. Note,
-		// deadline cannot be more than 10 days into the future
+		// deadline cannot be more than 5 days into the future
 		Deadline tcclient.Time `json:"deadline"`
 
 		// Task expiration, time at which task definition and

--- a/clients/client-go/tcqueueevents/types.go
+++ b/clients/client-go/tcqueueevents/types.go
@@ -438,7 +438,7 @@ type (
 		// Deadline of the task, by which this task must be complete. `pending` and
 		// `running` runs are resolved as **exception** if not resolved by other means
 		// before the deadline. After the deadline, a task is immutable. Note,
-		// deadline cannot be more than 10 days into the future
+		// deadline cannot be more than 5 days into the future
 		Deadline tcclient.Time `json:"deadline"`
 
 		// Task expiration, time at which task definition and

--- a/generated/references.json
+++ b/generated/references.json
@@ -1578,7 +1578,7 @@
           "type": "string"
         },
         "deadline": {
-          "description": "Deadline of the task, by which this task must be complete. `pending` and\n`running` runs are resolved as **exception** if not resolved by other means\nbefore the deadline. After the deadline, a task is immutable. Note,\ndeadline cannot be more than 10 days into the future\n",
+          "description": "Deadline of the task, by which this task must be complete. `pending` and\n`running` runs are resolved as **exception** if not resolved by other means\nbefore the deadline. After the deadline, a task is immutable. Note,\ndeadline cannot be more than 5 days into the future\n",
           "format": "date-time",
           "title": "Deadline",
           "type": "string"
@@ -1751,7 +1751,7 @@
       "description": "A representation of **task status** as known by the queue\n",
       "properties": {
         "deadline": {
-          "description": "Deadline of the task, by which this task must be complete. `pending` and\n`running` runs are resolved as **exception** if not resolved by other means\nbefore the deadline. After the deadline, a task is immutable. Note,\ndeadline cannot be more than 10 days into the future\n",
+          "description": "Deadline of the task, by which this task must be complete. `pending` and\n`running` runs are resolved as **exception** if not resolved by other means\nbefore the deadline. After the deadline, a task is immutable. Note,\ndeadline cannot be more than 5 days into the future\n",
           "format": "date-time",
           "title": "Deadline",
           "type": "string"
@@ -3325,7 +3325,7 @@
           "type": "string"
         },
         "deadline": {
-          "description": "Deadline of the task, by which this task must be complete. `pending` and\n`running` runs are resolved as **exception** if not resolved by other means\nbefore the deadline. After the deadline, a task is immutable. Note,\ndeadline cannot be more than 10 days into the future\n",
+          "description": "Deadline of the task, by which this task must be complete. `pending` and\n`running` runs are resolved as **exception** if not resolved by other means\nbefore the deadline. After the deadline, a task is immutable. Note,\ndeadline cannot be more than 5 days into the future\n",
           "format": "date-time",
           "title": "Deadline",
           "type": "string"

--- a/services/queue/schemas/constants.yml
+++ b/services/queue/schemas/constants.yml
@@ -64,7 +64,7 @@ deadline:
     Deadline of the task, by which this task must be complete. `pending` and
     `running` runs are resolved as **exception** if not resolved by other means
     before the deadline. After the deadline, a task is immutable. Note,
-    deadline cannot be more than 10 days into the future
+    deadline cannot be more than 5 days into the future
   type:         string
   format:       date-time
 

--- a/services/queue/src/api.js
+++ b/services/queue/src/api.js
@@ -425,11 +425,12 @@ let patchAndValidateTaskDef = function(taskId, taskDef) {
   }
 
   let msToDeadline = deadline.getTime() - new Date().getTime();
-  // Validate that deadline is less than 10 days from now, allow 15 min drift
-  if (msToDeadline > 10 * 24 * 60 * 60 * 1000 + 15 * 60 * 1000) {
+  // Validate that deadline is less than 5 days from now, allow 15 min drift
+  // NOTE: Azure does not allow more than 7 days - see https://bugzilla.mozilla.org/show_bug.cgi?id=1604175
+  if (msToDeadline > 5 * 24 * 60 * 60 * 1000 + 15 * 60 * 1000) {
     return {
       code: 'InputError',
-      message: '`deadline` cannot be more than 10 days into the future',
+      message: '`deadline` cannot be more than 5 days into the future',
       details: {deadline: taskDef.deadline},
     };
   }


### PR DESCRIPTION
Reverts #2218.  Bugzilla Bug: [1604175](https://bugzilla.mozilla.org/show_bug.cgi?id=1604175)

I could be convinced to flag this as a major change.