### PR TITLE
Convince 'yarn test:meta' that it is not running in a terminal

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -77,7 +77,7 @@ tasks:
         - name: lint
           command: yarn lint
         - name: test:meta
-          command: yarn test:meta
+          command: "yarn test:meta | cat"
           # only do cleanup on pushes; no sense doing so on pull requests
         - $if: 'tasks_for == "github-push" && event["ref"] == "refs/heads/master"'
           then:


### PR DESCRIPTION
This avoids console-taskgraph outputting animation, which makes for a very large and repetitive logfile.