### PR TITLE
Bug 1611696 - ignore status messages for unrecognized taskGroups

### DIFF
--- a/changelog/bug-1611696.md
+++ b/changelog/bug-1611696.md
@@ -1,0 +1,3 @@
+level: silent
+reference: bug 1611696
+---

--- a/services/github/src/handlers.js
+++ b/services/github/src/handlers.js
@@ -355,7 +355,11 @@ async function deprecatedStatusHandler(message) {
 
   let build = await this.context.Builds.load({
     taskGroupId,
-  });
+  }, true);
+  if (!build) {
+    // no status to update..
+    return;
+  }
 
   let debug = Debug(`${debugPrefix}:deprecated-result-handler:${build.eventId}`);
   debug(`Statuses API. Handling state change for task-group ${taskGroupId}`);


### PR DESCRIPTION
Bugzilla Bug: [1611696](https://bugzilla.mozilla.org/show_bug.cgi?id=1611696)
