### PR TITLE
Docs: Fix invalid SID

### DIFF
--- a/changelog/pull-2313.md
+++ b/changelog/pull-2313.md
@@ -1,0 +1,2 @@
+level: silent
+---

--- a/ui/docs/manual/deploying/cloud-credentials.mdx
+++ b/ui/docs/manual/deploying/cloud-credentials.mdx
@@ -42,7 +42,7 @@ The user to which this access key corresponds should have an AWS IAM policy like
       "Resource": "arn:aws:sts::<account-id-without-hyphens>:federated-user/TemporaryS3ReadWriteCredentials"
     },
     {
-      "Sid": "allow-taskcluster-auth-to-delegate-access",
+      "Sid": "AllowTaskclusterAuthToDelegateAccess",
       "Effect": "Allow",
       "Action": [
         "s3:ListBucket",


### PR DESCRIPTION
Per https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_grammar.html: "For IAM policies, basic alphanumeric characters (A-Z,a-z,0-9) are the only allowed characters in the Sid value."

This patch represents the change I had to make to successfully create the policy in AWS.

Tangentially related to https://bugzilla.mozilla.org/show_bug.cgi?id=1609276 in that I had to fix this to make progress on it. No changelog entry as it's literally just fixing a typo in the docs. 