### PR TITLE
[Bug 1587511] Allow worker-manager to terminate old workers

### DIFF
--- a/clients/client-go/tcworkermanager/tcworkermanager.go
+++ b/clients/client-go/tcworkermanager/tcworkermanager.go
@@ -36,6 +36,7 @@ package tcworkermanager
 
 import (
 	"net/url"
+	"time"
 
 	tcclient "github.com/taskcluster/taskcluster/clients/client-go/v24"
 )
@@ -280,6 +281,30 @@ func (workerManager *WorkerManager) RemoveWorker(workerPoolId, workerGroup, work
 	cd := tcclient.Client(*workerManager)
 	_, _, err := (&cd).APICall(nil, "DELETE", "/workers/"+url.QueryEscape(workerPoolId)+"/"+url.QueryEscape(workerGroup)+"/"+url.QueryEscape(workerId), nil, nil)
 	return err
+}
+
+// Allows a worker to claim new credentials and increase its own
+// maximum lifetime before a provider will terminate it.
+//
+// Required scopes:
+//   worker-manager:reregister-worker:<workerPoolId>/<workerGroup>/<workerId>
+//
+// See #reregister
+func (workerManager *WorkerManager) Reregister(workerPoolId, workerGroup, workerId string) (*RegisterWorkerResponse, error) {
+	cd := tcclient.Client(*workerManager)
+	responseObject, _, err := (&cd).APICall(nil, "GET", "/workers/"+url.QueryEscape(workerPoolId)+":/"+url.QueryEscape(workerGroup)+"/"+url.QueryEscape(workerId)+"/reregister", new(RegisterWorkerResponse), nil)
+	return responseObject.(*RegisterWorkerResponse), err
+}
+
+// Returns a signed URL for Reregister, valid for the specified duration.
+//
+// Required scopes:
+//   worker-manager:reregister-worker:<workerPoolId>/<workerGroup>/<workerId>
+//
+// See Reregister for more details.
+func (workerManager *WorkerManager) Reregister_SignedURL(workerPoolId, workerGroup, workerId string, duration time.Duration) (*url.URL, error) {
+	cd := tcclient.Client(*workerManager)
+	return (&cd).SignedURL("/workers/"+url.QueryEscape(workerPoolId)+":/"+url.QueryEscape(workerGroup)+"/"+url.QueryEscape(workerId)+"/reregister", nil, duration)
 }
 
 // Get the list of all the existing workers in a given worker pool.

--- a/clients/client-py/README.md
+++ b/clients/client-py/README.md
@@ -3801,6 +3801,29 @@ await asyncWorkerManager.removeWorker(workerPoolId, workerGroup, workerId) # -> 
 await asyncWorkerManager.removeWorker(workerPoolId='value', workerGroup='value', workerId='value') # -> None
 ```
 
+#### Reregister Worker
+Allows a worker to claim new credentials and increase its own
+maximum lifetime before a provider will terminate it.
+
+
+
+Takes the following arguments:
+
+  * `workerPoolId`
+  * `workerGroup`
+  * `workerId`
+
+Has required output schema
+
+```python
+# Sync calls
+workerManager.reregister(workerPoolId, workerGroup, workerId) # -> result
+workerManager.reregister(workerPoolId='value', workerGroup='value', workerId='value') # -> result
+# Async call
+await asyncWorkerManager.reregister(workerPoolId, workerGroup, workerId) # -> result
+await asyncWorkerManager.reregister(workerPoolId='value', workerGroup='value', workerId='value') # -> result
+```
+
 #### Workers in a Worker Pool
 Get the list of all the existing workers in a given worker pool.
 

--- a/clients/client-py/taskcluster/generated/aio/workermanager.py
+++ b/clients/client-py/taskcluster/generated/aio/workermanager.py
@@ -187,6 +187,18 @@ class WorkerManager(AsyncBaseClient):
 
         return await self._makeApiCall(self.funcinfo["removeWorker"], *args, **kwargs)
 
+    async def reregister(self, *args, **kwargs):
+        """
+        Reregister Worker
+
+        Allows a worker to claim new credentials and increase its own
+        maximum lifetime before a provider will terminate it.
+
+        This method is ``stable``
+        """
+
+        return await self._makeApiCall(self.funcinfo["reregister"], *args, **kwargs)
+
     async def listWorkersForWorkerPool(self, *args, **kwargs):
         """
         Workers in a Worker Pool
@@ -315,6 +327,14 @@ class WorkerManager(AsyncBaseClient):
             'name': 'reportWorkerError',
             'output': 'v1/worker-pool-error.json#',
             'route': '/worker-pool-errors/<workerPoolId>',
+            'stability': 'stable',
+        },
+        "reregister": {
+            'args': ['workerPoolId', 'workerGroup', 'workerId'],
+            'method': 'get',
+            'name': 'reregister',
+            'output': 'v1/register-worker-response.json#',
+            'route': '/workers/<workerPoolId>:/<workerGroup>/<workerId>/reregister',
             'stability': 'stable',
         },
         "updateWorkerPool": {

--- a/clients/client-py/taskcluster/generated/workermanager.py
+++ b/clients/client-py/taskcluster/generated/workermanager.py
@@ -187,6 +187,18 @@ class WorkerManager(BaseClient):
 
         return self._makeApiCall(self.funcinfo["removeWorker"], *args, **kwargs)
 
+    def reregister(self, *args, **kwargs):
+        """
+        Reregister Worker
+
+        Allows a worker to claim new credentials and increase its own
+        maximum lifetime before a provider will terminate it.
+
+        This method is ``stable``
+        """
+
+        return self._makeApiCall(self.funcinfo["reregister"], *args, **kwargs)
+
     def listWorkersForWorkerPool(self, *args, **kwargs):
         """
         Workers in a Worker Pool
@@ -315,6 +327,14 @@ class WorkerManager(BaseClient):
             'name': 'reportWorkerError',
             'output': 'v1/worker-pool-error.json#',
             'route': '/worker-pool-errors/<workerPoolId>',
+            'stability': 'stable',
+        },
+        "reregister": {
+            'args': ['workerPoolId', 'workerGroup', 'workerId'],
+            'method': 'get',
+            'name': 'reregister',
+            'output': 'v1/register-worker-response.json#',
+            'route': '/workers/<workerPoolId>:/<workerGroup>/<workerId>/reregister',
             'stability': 'stable',
         },
         "updateWorkerPool": {

--- a/clients/client-shell/apis/services.go
+++ b/clients/client-shell/apis/services.go
@@ -1680,6 +1680,21 @@ var services = map[string]definitions.Service{
 				Input: "",
 			},
 			definitions.Entry{
+				Name:        "reregister",
+				Title:       "Reregister Worker",
+				Description: "Allows a worker to claim new credentials and increase its own\nmaximum lifetime before a provider will terminate it.",
+				Stability:   "stable",
+				Method:      "get",
+				Route:       "/workers/<workerPoolId>:/<workerGroup>/<workerId>/reregister",
+				Args: []string{
+					"workerPoolId",
+					"workerGroup",
+					"workerId",
+				},
+				Query: []string{},
+				Input: "",
+			},
+			definitions.Entry{
 				Name:        "listWorkersForWorkerPool",
 				Title:       "Workers in a Worker Pool",
 				Description: "Get the list of all the existing workers in a given worker pool.",

--- a/clients/client-web/src/clients/WorkerManager.js
+++ b/clients/client-web/src/clients/WorkerManager.js
@@ -23,6 +23,7 @@ export default class WorkerManager extends Client {
     this.worker.entry = {"args":["workerPoolId","workerGroup","workerId"],"category":"Workers","method":"get","name":"worker","output":true,"query":[],"route":"/workers/<workerPoolId>:/<workerGroup>/<workerId>","stability":"stable","type":"function"}; // eslint-disable-line
     this.createWorker.entry = {"args":["workerPoolId","workerGroup","workerId"],"category":"Workers","input":true,"method":"put","name":"createWorker","output":true,"query":[],"route":"/workers/<workerPoolId>:/<workerGroup>/<workerId>","scopes":"worker-manager:create-worker:<workerPoolId>/<workerGroup>/<workerId>","stability":"stable","type":"function"}; // eslint-disable-line
     this.removeWorker.entry = {"args":["workerPoolId","workerGroup","workerId"],"category":"Workers","method":"delete","name":"removeWorker","query":[],"route":"/workers/<workerPoolId>/<workerGroup>/<workerId>","scopes":"worker-manager:remove-worker:<workerPoolId>/<workerGroup>/<workerId>","stability":"stable","type":"function"}; // eslint-disable-line
+    this.reregister.entry = {"args":["workerPoolId","workerGroup","workerId"],"category":"Workers","method":"get","name":"reregister","output":true,"query":[],"route":"/workers/<workerPoolId>:/<workerGroup>/<workerId>/reregister","scopes":"worker-manager:reregister-worker:<workerPoolId>/<workerGroup>/<workerId>","stability":"stable","type":"function"}; // eslint-disable-line
     this.listWorkersForWorkerPool.entry = {"args":["workerPoolId"],"category":"Workers","method":"get","name":"listWorkersForWorkerPool","output":true,"query":["continuationToken","limit"],"route":"/workers/<workerPoolId>","stability":"stable","type":"function"}; // eslint-disable-line
     this.registerWorker.entry = {"args":[],"category":"Worker Interface","input":true,"method":"post","name":"registerWorker","output":true,"query":[],"route":"/worker/register","stability":"stable","type":"function"}; // eslint-disable-line
   }
@@ -149,6 +150,15 @@ export default class WorkerManager extends Client {
     this.validate(this.removeWorker.entry, args);
 
     return this.request(this.removeWorker.entry, args);
+  }
+  /* eslint-disable max-len */
+  // Allows a worker to claim new credentials and increase its own
+  // maximum lifetime before a provider will terminate it.
+  /* eslint-enable max-len */
+  reregister(...args) {
+    this.validate(this.reregister.entry, args);
+
+    return this.request(this.reregister.entry, args);
   }
   /* eslint-disable max-len */
   // Get the list of all the existing workers in a given worker pool.

--- a/clients/client/src/apis.js
+++ b/clients/client/src/apis.js
@@ -3365,6 +3365,25 @@ module.exports = {
         },
         {
           "args": [
+            "workerPoolId",
+            "workerGroup",
+            "workerId"
+          ],
+          "category": "Workers",
+          "description": "Allows a worker to claim new credentials and increase its own\nmaximum lifetime before a provider will terminate it.",
+          "method": "get",
+          "name": "reregister",
+          "output": "v1/register-worker-response.json#",
+          "query": [
+          ],
+          "route": "/workers/<workerPoolId>:/<workerGroup>/<workerId>/reregister",
+          "scopes": "worker-manager:reregister-worker:<workerPoolId>/<workerGroup>/<workerId>",
+          "stability": "stable",
+          "title": "Reregister Worker",
+          "type": "function"
+        },
+        {
+          "args": [
             "workerPoolId"
           ],
           "category": "Workers",

--- a/generated/references.json
+++ b/generated/references.json
@@ -227,15 +227,15 @@
       "additionalProperties": false,
       "description": "Conditions a worker can reach and actions to take in the case that they do.\nNot all providers necessarily implement all features of this in the same way.\nRead the providers docs to understand exactly what it will do.\n",
       "properties": {
-        "checkinTimeout": {
-          "default": 345600,
-          "description": "If specified, workers in this pool must re-register via `checkin()`\nwithin `checkinTimeout` seconds to get new credentials. If the\nworker has not done so, it will be terminated. This defaults\nto 96 hours.\n",
-          "title": "Checkin Timeout",
-          "type": "integer"
-        },
         "registrationTimeout": {
           "description": "Each worker in this pool has `registrationTimeout` seconds to\nregister itself with worker-manager after it has\nbeen requsted from the cloud provider. After this\ntimeout, worker-manager will terminate the instance,\nassuming it is broken.\n",
           "title": "Registration Timeout",
+          "type": "integer"
+        },
+        "reregisterTimeout": {
+          "default": 345600,
+          "description": "If specified, workers in this pool must re-register via `reregister()`\nwithin `reregisterTimeout` seconds to get new credentials. If the\nworker has not done so, it will be terminated. This defaults\nto 96 hours.\n",
+          "title": "Checkin Timeout",
           "type": "integer"
         }
       },
@@ -8316,6 +8316,25 @@
           "scopes": "worker-manager:remove-worker:<workerPoolId>/<workerGroup>/<workerId>",
           "stability": "stable",
           "title": "Remove a Worker",
+          "type": "function"
+        },
+        {
+          "args": [
+            "workerPoolId",
+            "workerGroup",
+            "workerId"
+          ],
+          "category": "Workers",
+          "description": "Allows a worker to claim new credentials and increase its own\nmaximum lifetime before a provider will terminate it.",
+          "method": "get",
+          "name": "reregister",
+          "output": "v1/register-worker-response.json#",
+          "query": [
+          ],
+          "route": "/workers/<workerPoolId>:/<workerGroup>/<workerId>/reregister",
+          "scopes": "worker-manager:reregister-worker:<workerPoolId>/<workerGroup>/<workerId>",
+          "stability": "stable",
+          "title": "Reregister Worker",
           "type": "function"
         },
         {

--- a/generated/references.json
+++ b/generated/references.json
@@ -227,8 +227,14 @@
       "additionalProperties": false,
       "description": "Conditions a worker can reach and actions to take in the case that they do.\nNot all providers necessarily implement all features of this in the same way.\nRead the providers docs to understand exactly what it will do.\n",
       "properties": {
+        "checkinTimeout": {
+          "default": 345600,
+          "description": "If specified, workers in this pool must re-register via `checkin()`\nwithin `checkinTimeout` seconds to get new credentials. If the\nworker has not done so, it will be terminated. This defaults\nto 96 hours.\n",
+          "title": "Checkin Timeout",
+          "type": "integer"
+        },
         "registrationTimeout": {
-          "description": "Each worker in this pool has `timeout` seconds to\nregister itself with worker-manager after it has\nbeen requsted from the cloud provider. After this\ntimeout, worker-manager will terminate the instance,\nassuming it is broken\n",
+          "description": "Each worker in this pool has `registrationTimeout` seconds to\nregister itself with worker-manager after it has\nbeen requsted from the cloud provider. After this\ntimeout, worker-manager will terminate the instance,\nassuming it is broken.\n",
           "title": "Registration Timeout",
           "type": "integer"
         }

--- a/services/worker-manager/schemas/v1/worker-lifecycle.yml
+++ b/services/worker-manager/schemas/v1/worker-lifecycle.yml
@@ -15,13 +15,13 @@ properties:
       been requsted from the cloud provider. After this
       timeout, worker-manager will terminate the instance,
       assuming it is broken.
-  checkinTimeout:
+  reregisterTimeout:
     title: Checkin Timeout
     type: integer
     default: 345600
     description: |
-      If specified, workers in this pool must re-register via `checkin()`
-      within `checkinTimeout` seconds to get new credentials. If the
+      If specified, workers in this pool must re-register via `reregister()`
+      within `reregisterTimeout` seconds to get new credentials. If the
       worker has not done so, it will be terminated. This defaults
       to 96 hours.
 additionalProperties: false

--- a/services/worker-manager/schemas/v1/worker-lifecycle.yml
+++ b/services/worker-manager/schemas/v1/worker-lifecycle.yml
@@ -10,10 +10,19 @@ properties:
     title: Registration Timeout
     type: integer
     description: |
-      Each worker in this pool has `timeout` seconds to
+      Each worker in this pool has `registrationTimeout` seconds to
       register itself with worker-manager after it has
       been requsted from the cloud provider. After this
       timeout, worker-manager will terminate the instance,
-      assuming it is broken
+      assuming it is broken.
+  checkinTimeout:
+    title: Checkin Timeout
+    type: integer
+    default: 345600
+    description: |
+      If specified, workers in this pool must re-register via `checkin()`
+      within `checkinTimeout` seconds to get new credentials. If the
+      worker has not done so, it will be terminated. This defaults
+      to 96 hours.
 additionalProperties: false
 required: []

--- a/services/worker-manager/src/providers/aws.js
+++ b/services/worker-manager/src/providers/aws.js
@@ -101,7 +101,7 @@ class AwsProvider extends Provider {
       return;
     }
 
-    const {registrationExpiry, checkinDeadline} = this.interpretLifecycle(workerPool.config);
+    const {registrationExpiry, reregisterDeadline} = this.interpretLifecycle(workerPool.config);
 
     const toSpawnPerConfig = Math.ceil(toSpawn / workerPool.config.launchConfigs.length);
     const shuffledConfigs = _.shuffle(workerPool.config.launchConfigs);
@@ -224,7 +224,7 @@ class AwsProvider extends Provider {
             state: i.State.Name,
             stateReason: i.StateReason.Message,
             registrationExpiry,
-            checkinDeadline,
+            reregisterDeadline,
           },
         });
       }));
@@ -282,7 +282,7 @@ class AwsProvider extends Provider {
       return await this.removeWorker({worker});
     }
 
-    if (worker.providerData.checkinDeadline && worker.providerData.checkinDeadline < Date.now()) {
+    if (worker.providerData.reregisterDeadline && worker.providerData.reregisterDeadline < Date.now()) {
       return await this.removeWorker({worker});
     }
 

--- a/services/worker-manager/src/providers/aws.js
+++ b/services/worker-manager/src/providers/aws.js
@@ -269,8 +269,12 @@ class AwsProvider extends Provider {
       w.state = this.Worker.states.RUNNING;
     });
 
-    // return object that has expires field
-    return {expires: taskcluster.fromNow('96 hours')};
+    let expires = taskcluster.fromNow('96 hours');
+    if (worker.providerData.reregistrationDeadline) {
+      expires = new Date(worker.providerData.reregistrationDeadline);
+    }
+
+    return {expires};
   }
 
   async checkWorker({worker}) {

--- a/services/worker-manager/src/providers/azure.js
+++ b/services/worker-manager/src/providers/azure.js
@@ -89,7 +89,7 @@ class AzureProvider extends Provider {
       return; // Nothing to do
     }
 
-    const {registrationExpiry, checkinDeadline} = this.interpretLifecycle(workerPool.config);
+    const {registrationExpiry, reregisterDeadline} = this.interpretLifecycle(workerPool.config);
 
     const cfgs = [];
     while (toSpawn > 0) {
@@ -238,7 +238,7 @@ class AzureProvider extends Provider {
         providerData: {
           ...providerData,
           registrationExpiry,
-          checkinDeadline,
+          reregisterDeadline,
         },
       });
     }));
@@ -370,7 +370,7 @@ class AzureProvider extends Provider {
       return await this.removeWorker({worker});
     }
 
-    if (worker.providerData.checkinDeadline && worker.providerData.checkinDeadline < Date.now()) {
+    if (worker.providerData.reregisterDeadline && worker.providerData.reregisterDeadline < Date.now()) {
       return await this.removeWorker({worker});
     }
 

--- a/services/worker-manager/src/providers/azure.js
+++ b/services/worker-manager/src/providers/azure.js
@@ -352,8 +352,12 @@ class AzureProvider extends Provider {
       w.state = this.Worker.states.RUNNING;
     });
 
-    // assume for the moment that workers self-terminate before 96 hours
-    return {expires: taskcluster.fromNow('96 hours')};
+    let expires = taskcluster.fromNow('96 hours');
+    if (worker.providerData.reregistrationDeadline) {
+      expires = new Date(worker.providerData.reregistrationDeadline);
+    }
+
+    return {expires};
   }
 
   async scanPrepare() {

--- a/services/worker-manager/src/providers/google.js
+++ b/services/worker-manager/src/providers/google.js
@@ -151,8 +151,13 @@ class GoogleProvider extends Provider {
       w.state = this.Worker.states.RUNNING;
     });
 
+    let expires = taskcluster.fromNow('96 hours');
+    if (worker.providerData.reregistrationDeadline) {
+      expires = new Date(worker.providerData.reregistrationDeadline);
+    }
+
     // assume for the moment that workers self-terminate before 96 hours
-    return {expires: taskcluster.fromNow('96 hours')};
+    return {expires};
   }
 
   async deprovision({workerPool}) {

--- a/services/worker-manager/src/providers/google.js
+++ b/services/worker-manager/src/providers/google.js
@@ -204,16 +204,7 @@ class GoogleProvider extends Provider {
       return; // Nothing to do
     }
 
-    let registrationExpiry, checkinDeadline = null;
-    if (workerPool.config.lifecycle){
-      const {registrationTimeout, checkinTimeout} = workerPool.config.lifecycle || {};
-      if (registrationTimeout) {
-        registrationExpiry = Date.now() + registrationTimeout * 1000;
-      }
-      if (checkinTimeout) {
-        checkinDeadline = Date.now() + checkinTimeout * 1000;
-      }
-    }
+    const {registrationExpiry, checkinDeadline} = this.interpretLifecycle(workerPool.config);
 
     const cfgs = [];
     while (toSpawn > 0) {

--- a/services/worker-manager/src/providers/google.js
+++ b/services/worker-manager/src/providers/google.js
@@ -204,7 +204,7 @@ class GoogleProvider extends Provider {
       return; // Nothing to do
     }
 
-    const {registrationExpiry, checkinDeadline} = this.interpretLifecycle(workerPool.config);
+    const {registrationExpiry, reregisterDeadline} = this.interpretLifecycle(workerPool.config);
 
     const cfgs = [];
     while (toSpawn > 0) {
@@ -317,7 +317,7 @@ class GoogleProvider extends Provider {
             zone: op.zone,
           },
           registrationExpiry,
-          checkinDeadline,
+          reregisterDeadline,
         },
       });
     }));
@@ -346,7 +346,7 @@ class GoogleProvider extends Provider {
       return await this.removeWorker({worker});
     }
 
-    if (worker.providerData.checkinDeadline && worker.providerData.checkinDeadline < Date.now()) {
+    if (worker.providerData.reregisterDeadline && worker.providerData.reregisterDeadline < Date.now()) {
       return await this.removeWorker({worker});
     }
 

--- a/services/worker-manager/src/providers/provider.js
+++ b/services/worker-manager/src/providers/provider.js
@@ -57,6 +57,10 @@ class Provider {
     throw new ApiError('not supported for this provider');
   }
 
+  async reregisterWorker({worker, workerPool, workerIdentityProof}) {
+    throw new ApiError('not supported for this provider');
+  }
+
   async cleanup() {
   }
 

--- a/services/worker-manager/src/providers/provider.js
+++ b/services/worker-manager/src/providers/provider.js
@@ -85,6 +85,20 @@ class Provider {
 
   async removeResources({workerPool}) {
   }
+
+  interpretLifecycle({lifecycle}) {
+    let registrationExpiry, checkinDeadline = null;
+    if (lifecycle){
+      const {registrationTimeout, checkinTimeout} = lifecycle;
+      if (registrationTimeout) {
+        registrationExpiry = Date.now() + registrationTimeout * 1000;
+      }
+      if (checkinTimeout) {
+        checkinDeadline = Date.now() + checkinTimeout * 1000;
+      }
+    }
+    return {registrationExpiry, checkinDeadline};
+  }
 }
 
 /**

--- a/services/worker-manager/src/providers/provider.js
+++ b/services/worker-manager/src/providers/provider.js
@@ -91,17 +91,17 @@ class Provider {
   }
 
   interpretLifecycle({lifecycle}) {
-    let registrationExpiry, checkinDeadline = null;
+    let registrationExpiry, reregisterDeadline = null;
     if (lifecycle){
-      const {registrationTimeout, checkinTimeout} = lifecycle;
+      const {registrationTimeout, reregisterTimeout} = lifecycle;
       if (registrationTimeout) {
         registrationExpiry = Date.now() + registrationTimeout * 1000;
       }
-      if (checkinTimeout) {
-        checkinDeadline = Date.now() + checkinTimeout * 1000;
+      if (reregisterTimeout) {
+        reregisterDeadline = Date.now() + reregisterTimeout * 1000;
       }
     }
-    return {registrationExpiry, checkinDeadline};
+    return {registrationExpiry, reregisterDeadline};
   }
 }
 

--- a/services/worker-manager/test/provider_aws_test.js
+++ b/services/worker-manager/test/provider_aws_test.js
@@ -489,7 +489,7 @@ helper.secrets.mockSuite(testing.suiteName(), ['azure'], function(mock, skipping
         state: helper.Worker.states.REQUESTED,
         providerData: {
           ...workerInDB.providerData,
-          checkinDeadline: Date.now() - 1000,
+          reregisterDeadline: Date.now() - 1000,
         },
       });
       provider.seen = {};
@@ -506,7 +506,7 @@ helper.secrets.mockSuite(testing.suiteName(), ['azure'], function(mock, skipping
         state: helper.Worker.states.REQUESTED,
         providerData: {
           ...workerInDB.providerData,
-          checkinDeadline: Date.now() + 1000,
+          reregisterDeadline: Date.now() + 1000,
         },
       });
       provider.seen = {};

--- a/services/worker-manager/test/provider_azure_test.js
+++ b/services/worker-manager/test/provider_azure_test.js
@@ -459,5 +459,20 @@ helper.secrets.mockSuite(testing.suiteName(), ['azure'], function(mock, skipping
       assert(res.expires - new Date() + 10000 > 96 * 3600 * 1000, res.expires);
       assert(res.expires - new Date() - 10000 < 96 * 3600 * 1000, res.expires);
     });
+
+    test('sweet success (different reregister)', async function() {
+      const worker = await helper.Worker.create({
+        ...defaultWorker,
+        providerData: {
+          reregistrationDeadline: taskcluster.fromNow('10 hours'),
+        },
+      });
+      const document = fs.readFileSync(path.resolve(__dirname, 'fixtures/azure_signature_good')).toString();
+      const workerIdentityProof = {document};
+      const res = await provider.registerWorker({workerPool, worker, workerIdentityProof});
+      // allow +- 10 seconds since time passes while the test executes
+      assert(res.expires - new Date() + 10000 > 10 * 3600 * 1000, res.expires);
+      assert(res.expires - new Date() - 10000 < 10 * 3600 * 1000, res.expires);
+    });
   });
 });

--- a/services/worker-manager/test/provider_azure_test.js
+++ b/services/worker-manager/test/provider_azure_test.js
@@ -280,7 +280,7 @@ helper.secrets.mockSuite(testing.suiteName(), ['azure'], function(mock, skipping
       state: helper.Worker.states.REQUESTED,
       providerData: {
         ...baseProviderData,
-        checkinDeadline: Date.now() - 1000,
+        reregisterDeadline: Date.now() - 1000,
       },
     });
     await provider.scanPrepare();
@@ -306,7 +306,7 @@ helper.secrets.mockSuite(testing.suiteName(), ['azure'], function(mock, skipping
       state: helper.Worker.states.REQUESTED,
       providerData: {
         ...baseProviderData,
-        checkinDeadline: Date.now() + 1000,
+        reregisterDeadline: Date.now() + 1000,
       },
     });
     await provider.scanPrepare();

--- a/services/worker-manager/test/provider_google_test.js
+++ b/services/worker-manager/test/provider_google_test.js
@@ -425,5 +425,19 @@ helper.secrets.mockSuite(testing.suiteName(), ['azure'], function(mock, skipping
       assert(res.expires - new Date() + 10000 > 96 * 3600 * 1000, res.expires);
       assert(res.expires - new Date() - 10000 < 96 * 3600 * 1000, res.expires);
     });
+
+    test('sweet success (different reregister)', async function() {
+      const worker = await helper.Worker.create({
+        ...defaultWorker,
+        providerData: {
+          reregistrationDeadline: taskcluster.fromNow('10 hours'),
+        },
+      });
+      const workerIdentityProof = {token: 'good'};
+      const res = await provider.registerWorker({workerPool, worker, workerIdentityProof});
+      // allow +- 10 seconds since time passes while the test executes
+      assert(res.expires - new Date() + 10000 > 10 * 3600 * 1000, res.expires);
+      assert(res.expires - new Date() - 10000 < 10 * 3600 * 1000, res.expires);
+    });
   });
 });

--- a/services/worker-manager/test/provider_google_test.js
+++ b/services/worker-manager/test/provider_google_test.js
@@ -255,7 +255,7 @@ helper.secrets.mockSuite(testing.suiteName(), ['azure'], function(mock, skipping
       state: helper.Worker.states.REQUESTED,
       providerData: {
         zone: 'us-east1-a',
-        checkinDeadline: Date.now() - 1000,
+        reregisterDeadline: Date.now() - 1000,
       },
     });
     await provider.scanPrepare();
@@ -278,7 +278,7 @@ helper.secrets.mockSuite(testing.suiteName(), ['azure'], function(mock, skipping
       state: helper.Worker.states.REQUESTED,
       providerData: {
         zone: 'us-east1-a',
-        checkinDeadline: Date.now() + 1000,
+        reregisterDeadline: Date.now() + 1000,
       },
     });
     await provider.scanPrepare();


### PR DESCRIPTION
This should allow misconfigured workers to be reaped among other things. Right now nothing in here actually supports re-registering but it should be easy to add to providers. Just wanted to validate this approach before moving ahead.

This was finished last week at all-hands and I haven't looked at it since then so consider this a 90% review and I'll make sure it is up to good quality today as I get it paged back into my head.

Bugzilla Bug: [1587511](https://bugzilla.mozilla.org/show_bug.cgi?id=1587511)

