### PR TITLE
Add deleteOnExpiration in create client smoketest

### DIFF
--- a/infrastructure/tooling/src/smoketest/checks/createClient.js
+++ b/infrastructure/tooling/src/smoketest/checks/createClient.js
@@ -22,6 +22,7 @@ exports.tasks.push({
 
     let clientId = `project/taskcluster/smoketest/${randomId}`;
     const payload = {
+      "deleteOnExpiration": true,
       "expires": taskcluster.fromNowJSON('1 hour'),
       "description": `Create a client and use it ${clientId}`,
       "scopes": [`auth:reset-access-token:project/taskcluster/smoketest/${randomId}`],


### PR DESCRIPTION
<!-- Did you remember to add a changelog snippet? See
     https://github.com/taskcluster/taskcluster/blob/master/dev-docs/best-practices/changelog.md

     If this is related to a Bugzilla bug, please begin your title with [Bug XXXXX]
     and update this link.  Otherwise, just remove it from your PR comment.  -->

 
<!-- If this is related to a GitHub Bug/Issue, Please write Issue Number after # in the next line. Otherwise, just remove it from your PR comment. -->

Github Bug/Issue: Fixes #2310 

Added `deleteOnExpiration` in the payload which is used to create a new client. By default `deleteOnExpiration` is set to false.

@djmitche 