### PR TITLE
Avoid using tc-lib-scopes in tc-ui

### DIFF
--- a/changelog/issue-2318.md
+++ b/changelog/issue-2318.md
@@ -1,0 +1,3 @@
+level: silent
+reference: issue 2318
+---

--- a/ui/package.json
+++ b/ui/package.json
@@ -87,7 +87,6 @@
     "resolve-pathname": "^3.0.0",
     "shebang-loader": "^0.0.1",
     "subscriptions-transport-ws": "^0.9.16",
-    "taskcluster-lib-scopes": "link:../libraries/scopes",
     "taskcluster-lib-urls": "^12.0.0",
     "typeface-roboto": "^0.0.75",
     "ws-shell": "^0.1.5"

--- a/ui/src/utils/scopes.js
+++ b/ui/src/utils/scopes.js
@@ -1,0 +1,29 @@
+/**
+ * These utilities are copied from tc-lib-scopes, which is otherwise not
+ * designed for use in a webpack'd application.
+ */
+
+/**
+ * Return true if the given scope matches the given pattern (possibly
+ * ending with *)
+ */
+const patternMatch = (pattern, scope) => {
+  if (scope === pattern) {
+    return true;
+  }
+
+  if (/\*$/.test(pattern)) {
+    return scope.indexOf(pattern.slice(0, -1)) === 0;
+  }
+
+  return false;
+};
+
+/**
+ * Finds scope intersections between two scope sets.
+ */
+exports.scopeIntersection = (scopeset1, scopeset2) =>
+  [
+    ...scopeset1.filter(s1 => scopeset2.some(s2 => patternMatch(s2, s1))),
+    ...scopeset2.filter(s2 => scopeset1.some(s1 => patternMatch(s1, s2))),
+  ].filter((v, i, a) => a.indexOf(v) === i);

--- a/ui/src/views/ThirdPartyLogin/index.jsx
+++ b/ui/src/views/ThirdPartyLogin/index.jsx
@@ -1,10 +1,10 @@
 import { hot } from 'react-hot-loader';
 import React, { Component } from 'react';
 import { graphql } from 'react-apollo';
-import { scopeIntersection } from 'taskcluster-lib-scopes';
 import { parse } from 'qs';
 import Spinner from '@mozilla-frontend-infra/components/Spinner';
 import Typography from '@material-ui/core/Typography';
+import { scopeIntersection } from '../../utils/scopes';
 import AuthConsent from '../../components/AuthConsent';
 import Dashboard from '../../components/Dashboard';
 import { withAuth } from '../../utils/Auth';

--- a/ui/test/utils_scopes_test.js
+++ b/ui/test/utils_scopes_test.js
@@ -1,0 +1,116 @@
+const assert = require('assert');
+const { scopeIntersection } = require('../src/utils/scopes');
+
+describe('utils_scopes_test.js', () => {
+  describe('scopeIntersection', () => {
+    const testScopeIntersection = (scope1, scope2, expected, message) => {
+      assert.deepEqual(
+        scopeIntersection(scope1, scope2).sort(),
+        expected.sort(),
+        message
+      );
+      assert.deepEqual(
+        scopeIntersection(scope2, scope1).sort(),
+        expected.sort(),
+        message
+      );
+    };
+
+    it('single exact match, [string]', () => {
+      const scope = ['foo:bar'];
+
+      testScopeIntersection(scope, scope, scope, `expected ${scope}`);
+    });
+
+    it('empty [string] in scopesets', () => {
+      const scope1 = ['foo:bar'];
+      const scope2 = [''];
+
+      testScopeIntersection(scope1, scope2, [], 'expected an empty set');
+    });
+
+    it('prefix', () => {
+      const scope1 = ['foo:bar'];
+      const scope2 = ['foo:*'];
+
+      testScopeIntersection(scope1, scope2, scope1, `expected ${scope1}`);
+    });
+
+    it('star not at end', () => {
+      const scope1 = ['foo:bar:bing'];
+      const scope2 = ['foo:*:bing'];
+
+      testScopeIntersection(scope1, scope2, [], 'expected an empty set');
+    });
+
+    it('star at beginning', () => {
+      const scope1 = ['foo:bar'];
+      const scope2 = ['*:bar'];
+
+      testScopeIntersection(scope1, scope2, [], 'expected an empty set');
+    });
+
+    it('prefix with no star', () => {
+      const scope1 = ['foo:bar'];
+      const scope2 = ['foo:'];
+
+      testScopeIntersection(scope1, scope2, [], 'expected empty set');
+    });
+
+    it('star but not prefix', () => {
+      const scope1 = ['foo:bar:*'];
+      const scope2 = ['bar:bing'];
+
+      testScopeIntersection(scope1, scope2, [], 'expected empty set');
+    });
+
+    it('star but not prefix', () => {
+      const scope1 = ['bar:*'];
+      const scope2 = ['foo:bar:bing'];
+
+      testScopeIntersection(scope1, scope2, [], 'expected empty set');
+    });
+
+    it('disjunction', () => {
+      const scope1 = ['bar:*'];
+      const scope2 = ['foo:x', 'bar:x'];
+
+      testScopeIntersection(scope1, scope2, ['bar:x'], "expected ['bar:x']");
+    });
+
+    it('conjuction', () => {
+      const scope1 = ['bar:y', 'foo:x'];
+      const scope2 = ['bar:*', 'foo:x'];
+
+      testScopeIntersection(scope1, scope2, scope1, `expected ${scope1}`);
+    });
+
+    it('empty pattern', () => {
+      const scope1 = [''];
+      const scope2 = ['foo:bar'];
+
+      testScopeIntersection(scope1, scope2, [], 'expected empty set');
+    });
+
+    it('empty patterns', () => {
+      const scope1 = [];
+      const scope2 = ['foo:bar'];
+
+      testScopeIntersection(scope1, scope2, [], 'expected empty set');
+    });
+
+    it('bare star', () => {
+      const scope1 = ['foo:bar', 'bar:bing'];
+      const scope2 = ['*'];
+
+      testScopeIntersection(scope1, scope2, scope1, `expected ${scope1}`);
+    });
+
+    it('empty conjunction in scopesets', () => {
+      const scope1 = ['foo:bar'];
+      const scope2 = [];
+
+      testScopeIntersection(scope1, scope2, [], 'expected empty set');
+    });
+  });
+});

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -12640,9 +12640,6 @@ tar@^4:
     safe-buffer "^5.1.2"
     yallist "^3.0.3"
 
-"taskcluster-lib-scopes@link:../libraries/scopes":
-  version "24.2.0"
-
 taskcluster-lib-urls@^12.0.0:
   version "12.0.0"
   resolved "https://registry.yarnpkg.com/taskcluster-lib-urls/-/taskcluster-lib-urls-12.0.0.tgz#f56190eec9e9597d37a42ad0e7f461e8e0e6732b"


### PR DESCRIPTION
This includes a simple in-file implementation of flatten in terms of
reduce, and switches to fast-json-stable-stringify (which was already an
indirect requirement in ui/) for all stable stringification.

This should fix the netlify build errors.  We'll need to land this ASAP so that we can ship a release.

Github Bug/Issue: Fixes #2318
