### PR TITLE
Changelog addendum for generic-worker merge

### DIFF
--- a/changelog/bug-1608828.md
+++ b/changelog/bug-1608828.md
@@ -1,8 +1,6 @@
 level: major
 reference: bug 1608828
 ---
-Generic worker is now shipped as part of the taskcluster platform release. The generic-worker codebase has been integrated into the monorepo. The former generic-worker github repo is now archived.
+Generic worker is now shipped as part of the taskcluster platform release. The generic-worker codebase has been integrated into the monorepo. The former generic-worker github repo is now archived.  Consequently, the generic worker version number now matches the taskcluster platform release number.  The generic-worker binaries are published to https://github.com/taskcluster/taskcluster/releases.
 
-Consequently, the generic worker version number now matches the taskcluster platform release number.
-
-The generic-worker binaries are published to https://github.com/taskcluster/taskcluster/releases.
+With this change, the import path for the Taskcluster Go client library changes from `github.com/taskcluster/taskcluster/clients/client-go/vNN` to `github.com/taskcluster/taskcluster/vNN/clients/client-go`.  Functionality of the library remains unchanged.

--- a/clients/client-go/README.md
+++ b/clients/client-go/README.md
@@ -22,8 +22,8 @@ The most common case is to use `NewFromEnv`, reading environment variables for c
 
 ```go
 import (
-	tcclient "github.com/taskcluster/taskcluster/clients/client-go/v24"
-	"github.com/taskcluster/taskcluster/clients/client-go/v24/tcqueue"
+	tcclient "github.com/taskcluster/taskcluster/v24/clients/client-go"
+	"github.com/taskcluster/taskcluster/v24/clients/client-go/tcqueue"
 )
 queue := tcqueue.NewFromEnv()
 ```
@@ -53,8 +53,8 @@ For example, the `CreateTask` method is called like this:
 
 ```go
 import (
-	tcclient "github.com/taskcluster/taskcluster/clients/client-go/v24"
-	"github.com/taskcluster/taskcluster/clients/client-go/v24/tcqueue"
+	tcclient "github.com/taskcluster/taskcluster/v24/clients/client-go"
+	"github.com/taskcluster/taskcluster/v24/clients/client-go/tcqueue"
     "github.com/taskcluster/slugid-go"
 )
 task := tcqueue.TaskDefinitionRequest{..};
@@ -99,8 +99,8 @@ import (
 	"strconv"
 	"time"
 
-	tcclient "github.com/taskcluster/taskcluster/clients/client-go/v24"
-	"github.com/taskcluster/taskcluster/clients/client-go/v24/tcqueue"
+	tcclient "github.com/taskcluster/taskcluster/v24/clients/client-go"
+	"github.com/taskcluster/taskcluster/v24/clients/client-go/tcqueue"
 )
 
 const (
@@ -192,8 +192,8 @@ import (
 	"time"
 
 	"github.com/taskcluster/slugid-go/slugid"
-	tcclient "github.com/taskcluster/taskcluster/clients/client-go/v24"
-	"github.com/taskcluster/taskcluster/clients/client-go/v24/tcqueue"
+	tcclient "github.com/taskcluster/taskcluster/v24/clients/client-go"
+	"github.com/taskcluster/taskcluster/v24/clients/client-go/tcqueue"
 )
 
 // *********************************************************


### PR DESCRIPTION
This calls out the import path change explicitly (and also fixes import paths in the client README)