### PR TITLE
Bug 1615011- Add handling for mounts points from tar.xz file

### DIFF
--- a/changelog/bug-1615011.md
+++ b/changelog/bug-1615011.md
@@ -1,0 +1,4 @@
+level: minor
+reference: bug 1615011
+---
+Generic worker task mounts now include support for `tar.xz` files, in addition to the existing archive formats they previously supported (`zip`, `tar.gz`, `rar`, `tar.bz2`).

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/gorilla/websocket v1.4.1
 	github.com/iancoleman/strcase v0.0.0-20191112232945-16388991a334
 	github.com/kr/text v0.1.0
-	github.com/mholt/archiver v2.1.0+incompatible
+	github.com/mholt/archiver v3.1.1+incompatible
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/nwaples/rardecode v1.0.0 // indirect
 	github.com/pborman/uuid v1.2.0
@@ -42,6 +42,7 @@ require (
 	github.com/taskcluster/websocktunnel v2.0.0+incompatible
 	github.com/tent/hawk-go v0.0.0-20161026210932-d341ea318957
 	github.com/xeipuuv/gojsonschema v1.1.0
+	github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8 // indirect
 	golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550
 	golang.org/x/net v0.0.0-20191002035440-2ec189313ef0
 	golang.org/x/sys v0.0.0-20191218084908-4a24b4065292

--- a/go.sum
+++ b/go.sum
@@ -74,6 +74,8 @@ github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/mholt/archiver v2.1.0+incompatible h1:1ivm7KAHPtPere1YDOdrY6xGdbMNGRWThZbYh5lWZT0=
 github.com/mholt/archiver v2.1.0+incompatible/go.mod h1:Dh2dOXnSdiLxRiPoVfIr/fI1TwETms9B8CTWfeh7ROU=
+github.com/mholt/archiver v3.1.1+incompatible h1:1dCVxuqs0dJseYEhi5pl7MYPH9zDa1wBi7mF09cbNkU=
+github.com/mholt/archiver v3.1.1+incompatible/go.mod h1:Dh2dOXnSdiLxRiPoVfIr/fI1TwETms9B8CTWfeh7ROU=
 github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG+4E0Y=
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
@@ -157,6 +159,8 @@ github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 h1:EzJWgHo
 github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415/go.mod h1:GwrjFmJcFw6At/Gs6z4yjiIwzuJ1/+UwLxMQDVQXShQ=
 github.com/xeipuuv/gojsonschema v1.1.0 h1:ngVtJC9TY/lg0AA/1k48FYhBrhRoFlEmWzsehpNAaZg=
 github.com/xeipuuv/gojsonschema v1.1.0/go.mod h1:5yf86TLmAcydyeJq5YvxkGPE2fm/u4myDekKRoLuqhs=
+github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8 h1:nIPpBwaJSVYIxUFsDv3M8ofmx9yWTog9BfvIu0q41lo=
+github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8/go.mod h1:HUYIGzjTL3rfEspMxjDjgmT5uz5wzYJKVo23qUhYTos=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=
 golang.org/x/crypto v0.0.0-20181203042331-505ab145d0a9/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2 h1:VklqNMn3ovrHsnt90PveolxSbWFaJdECFbxSq0Mqo2M=

--- a/workers/generic-worker/docker_posix.yml
+++ b/workers/generic-worker/docker_posix.yml
@@ -325,6 +325,7 @@ definitions:
         - rar
         - tar.bz2
         - tar.gz
+        - tar.xz
         - zip
     additionalProperties: false
     required:
@@ -364,6 +365,7 @@ definitions:
         - rar
         - tar.bz2
         - tar.gz
+        - tar.xz
         - zip
     additionalProperties: false
     required:

--- a/workers/generic-worker/gw-decision-task/tasks.yml
+++ b/workers/generic-worker/gw-decision-task/tasks.yml
@@ -304,6 +304,11 @@ Mounts:
   git2.24.0.2:
     directory: git
     content:
+      linux:
+        amd64:
+          url: 'https://mirrors.edge.kernel.org/pub/software/scm/git/git-2.24.1.tar.xz'
+          sha256: '723f24dce8fdd621a308b6187553fce7d5244205c065fe0a3aebd0b7c3f88562'
+          format: tar.xz
       windows:
         386:
           url: 'https://github.com/git-for-windows/git/releases/download/v2.24.0.windows.2/MinGit-2.24.0.2-32-bit.zip'

--- a/workers/generic-worker/mounts.go
+++ b/workers/generic-worker/mounts.go
@@ -676,6 +676,8 @@ func extract(fsContent FSContent, format string, dir string, task *TaskRun) erro
 		return archiver.Rar.Open(cacheFile, dir)
 	case "tar.bz2":
 		return archiver.TarBz2.Open(cacheFile, dir)
+	case "tar.xz":
+		return archiver.TarXz.Open(cacheFile, dir)
 	}
 	log.Fatalf("Unsupported format %v", format)
 	return fmt.Errorf("Unsupported archive format %v", format)

--- a/workers/generic-worker/multiuser_posix.yml
+++ b/workers/generic-worker/multiuser_posix.yml
@@ -337,6 +337,7 @@ definitions:
         - rar
         - tar.bz2
         - tar.gz
+        - tar.xz
         - zip
     additionalProperties: false
     required:
@@ -376,6 +377,7 @@ definitions:
         - rar
         - tar.bz2
         - tar.gz
+        - tar.xz
         - zip
     additionalProperties: false
     required:

--- a/workers/generic-worker/multiuser_windows.yml
+++ b/workers/generic-worker/multiuser_windows.yml
@@ -384,6 +384,7 @@ definitions:
         - rar
         - tar.bz2
         - tar.gz
+        - tar.xz
         - zip
     additionalProperties: false
     required:
@@ -423,6 +424,7 @@ definitions:
         - rar
         - tar.bz2
         - tar.gz
+        - tar.xz
         - zip
     additionalProperties: false
     required:

--- a/workers/generic-worker/simple_posix.yml
+++ b/workers/generic-worker/simple_posix.yml
@@ -315,6 +315,7 @@ definitions:
         - rar
         - tar.bz2
         - tar.gz
+        - tar.xz
         - zip
     additionalProperties: false
     required:
@@ -354,6 +355,7 @@ definitions:
         - rar
         - tar.bz2
         - tar.gz
+        - tar.xz
         - zip
     additionalProperties: false
     required:


### PR DESCRIPTION
Add ability to use a tar.xz as a source of mount point for
generic-worker.

Bugzilla Bug: [1615011](https://bugzilla.mozilla.org/show_bug.cgi?id=1615011) (the pmoore edit was just correction to bug number)