### PR TITLE
Nest generic-worker README under 'Workers'

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,10 +83,11 @@ It is not possible to run a full Taskcluster deployment directly from this repos
     * [ui/src/components/Snackbar](ui/src/components/Snackbar#readme)
     * [ui/src/components/SpeedDial](ui/src/components/SpeedDial#readme)
     * [ui/src/components/StatusLabel](ui/src/components/StatusLabel#readme)
-* [Generic Worker](workers/generic-worker#readme)
-    * [workers/generic-worker/imagesets](workers/generic-worker/imagesets#readme)
-    * [workers/generic-worker/server-logs](workers/generic-worker/server-logs#readme)
-    * [workers/generic-worker/worker_types](workers/generic-worker/worker_types#readme)
+* [Workers](workers#readme)
+    * [Generic Worker](workers/generic-worker#readme)
+        * [workers/generic-worker/imagesets](workers/generic-worker/imagesets#readme)
+        * [workers/generic-worker/server-logs](workers/generic-worker/server-logs#readme)
+        * [workers/generic-worker/worker_types](workers/generic-worker/worker_types#readme)
 <!-- TOC END -->
 
 ## Team Mentions

--- a/workers/README.md
+++ b/workers/README.md
@@ -1,0 +1,12 @@
+# Workers
+
+Workers operate outside of the Taskcluster services, claiming tasks from the queue and executing them.
+
+## Table of Contents
+
+<!-- TOC BEGIN -->
+* [Generic Worker](generic-worker#readme)
+    * [generic-worker/imagesets](generic-worker/imagesets#readme)
+    * [generic-worker/server-logs](generic-worker/server-logs#readme)
+    * [generic-worker/worker_types](generic-worker/worker_types#readme)
+<!-- TOC END -->


### PR DESCRIPTION
Should we remove any of the sub-directories that are showing up here?