### PR TITLE
Bug 1615312 - more aggressive cleanup of task directories on Linux/macOS

### DIFF
--- a/changelog/bug-1615312.md
+++ b/changelog/bug-1615312.md
@@ -1,0 +1,19 @@
+level: patch
+reference: bug 1615312
+---
+Old generic-worker task directories on POSIX systems (Linux/macOS) are now
+deleted more aggressively, by first running `chmod u+w -R <task dir>` before
+running `rm -rf <task dir>`.
+
+This bug always existed, and could leave files on the filesystem from previous
+tasks. Those files were not readable to other task users under the
+generic-worker multiuser engine where they were owned by a different OS user,
+but they did consume disk space. The files were readable by other tasks under
+the generic-worker simple engine, where all tasks run as the same user, but
+simple engine is not used for tasks that contain sensitive/private information.
+
+This bug was present in both the simple and multisuer engine, and has been
+fixed on both.
+
+Cleanup of Windows task directories will be handled separately in [bug
+1433854](https://bugzilla.mozilla.org/show_bug.cgi?id=1433854).

--- a/workers/generic-worker/gw-decision-task/tasks.yml
+++ b/workers/generic-worker/gw-decision-task/tasks.yml
@@ -22,9 +22,10 @@ Types:
     MaxRunTime: 3600
 
   CheckModules:
-    Name: 'Run `go mod tidy` and ensure that go.mod and go.sum do not change'
+    Name: 'Run `go mod tidy` to ensure that go.mod and go.sum and correct and source code is formatted with go fmt'
     Description: |
-                 Run `go mod tidy` to ensure that `go.mod` and `go.sum` are up-to-date.
+                 Run `go mod tidy` to ensure that `go.mod` and `go.sum` are up-to-date and
+                 `go fmt` to ensure that go source code is formatted.
                  See the [go modules wiki page](https://github.com/golang/go/wiki/Modules)
                  for more information.
     Mounts:
@@ -139,7 +140,7 @@ Commands:
           git reset --hard "${GITHUB_SHA}"
           git clean -fdx
           git checkout -B tmp -t "X${TASK_ID}"
-          cd workers/generic-worker
+          go fmt ./...
           go mod tidy
           test $(git status --porcelain | wc -l) == 0
 

--- a/workers/generic-worker/multiuser_posix.go
+++ b/workers/generic-worker/multiuser_posix.go
@@ -31,7 +31,12 @@ func platformFeatures() []Feature {
 
 func deleteDir(path string) error {
 	log.Print("Removing directory '" + path + "'...")
-	err := host.Run("/usr/bin/sudo", "/bin/rm", "-rf", path)
+	err := host.Run("/usr/bin/sudo", "/bin/chmod", "-R", "u+w", path)
+	if err != nil {
+		log.Print("WARNING: could not chmod -R u+w '" + path + "'")
+		log.Printf("%v", err)
+	}
+	err = host.Run("/usr/bin/sudo", "/bin/rm", "-rf", path)
 	if err != nil {
 		log.Print("WARNING: could not delete directory '" + path + "'")
 		log.Printf("%v", err)

--- a/workers/generic-worker/simple_docker.go
+++ b/workers/generic-worker/simple_docker.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	"github.com/taskcluster/shell"
+	"github.com/taskcluster/taskcluster/v24/workers/generic-worker/host"
 	"github.com/taskcluster/taskcluster/v24/workers/generic-worker/process"
 )
 
@@ -35,7 +36,12 @@ func platformFeatures() []Feature {
 
 func deleteDir(path string) error {
 	log.Print("Removing directory '" + path + "'...")
-	err := os.RemoveAll(path)
+	err := host.Run("/bin/chmod", "-R", "u+w", path)
+	if err != nil {
+		log.Print("WARNING: could not chmod -R u+w '" + path + "'")
+		log.Printf("%v", err)
+	}
+	err = host.Run("/bin/rm", "-rf", path)
 	if err != nil {
 		log.Print("WARNING: could not delete directory '" + path + "'")
 		log.Printf("%v", err)


### PR DESCRIPTION
Bugzilla Bug: [1615312](https://bugzilla.mozilla.org/show_bug.cgi?id=1615312)

This is a more aggressive cleanup of task directories on POSIX workers (Linux/macOS).

Currently our [raspberry pi worker](https://community-tc.services.mozilla.com/provisioners/proj-taskcluster/worker-types/gw-ci-raspbian-stretch) (Linux/ARM) keeps running out of disk space, and this should fix it. For the meantime, I manually deleted all task directories using the `chmod` and `rm` commands from this PR, to keep it running.