### PR TITLE
when a tooling execCommand has no logfile, include output in error me…

### DIFF
--- a/infrastructure/tooling/src/utils/command.js
+++ b/infrastructure/tooling/src/utils/command.js
@@ -58,7 +58,8 @@ exports.execCommand = async ({
       if (code === 0 || ignoreReturn) {
         resolve(output);
       } else {
-        reject(new Error(`Nonzero exit status ${code}; see ${logfile} for details`));
+        reject(new Error(`Nonzero exit status ${code}; ` +
+          (logfile ? `see ${logfile} for details` : `\n${output}`)));
       }
     });
     cp.once('error', reject);


### PR DESCRIPTION
This just helps find the error instead of setting "see undefined for details"