### PR TITLE
only check access.yml when upgrading to the latest version

### DIFF
--- a/changelog/J5L-zmdmQEqb8W2h1HgBNA.md
+++ b/changelog/J5L-zmdmQEqb8W2h1HgBNA.md
@@ -1,0 +1,2 @@
+level: silent
+---

--- a/libraries/postgres/src/Database.js
+++ b/libraries/postgres/src/Database.js
@@ -102,8 +102,12 @@ class Database {
         }
       });
 
-      showProgress('...checking permissions');
-      await Database._checkPermissions({db, schema, usernamePrefix});
+      // access.yml corresponds to the latest version, so only check
+      // permissions if upgrading to that version
+      if (toVersion === schema.latestVersion().version) {
+        showProgress('...checking permissions');
+        await Database._checkPermissions({db, schema, usernamePrefix});
+      }
     } finally {
       await db.close();
     }


### PR DESCRIPTION
This check is mainly a security check for deployments, and will continue to work in that capacity.  But, when performing db-version tests, we upgrade to specific non-latest versions, so checking permissions against access.yml doesn't make sense (and fails).