### PR TITLE
Bug 1615631 - include generic-worker artifacts in GH release

### DIFF
--- a/changelog/bug-1615631.md
+++ b/changelog/bug-1615631.md
@@ -1,0 +1,3 @@
+level: silent
+reference: bug 1615631
+---


### PR DESCRIPTION
This uses `build.sh` to build the artifacts, running it in such a way
that it skips the tests (which should already have passed) and simply
builds the artifacts.

Bugzilla Bug: [1615631](https://bugzilla.mozilla.org/show_bug.cgi?id=1615631)
