### PR TITLE
Allow running go test ./... without rootURL

### DIFF
--- a/changelog/Otc0tAj0TMK39FQJ68OX6g.md
+++ b/changelog/Otc0tAj0TMK39FQJ68OX6g.md
@@ -1,0 +1,2 @@
+level: silent
+---

--- a/clients/client-go/codegenerator/model/model.go
+++ b/clients/client-go/codegenerator/model/model.go
@@ -160,7 +160,9 @@ func FormatSourceAndSave(sourceFile string, sourceCode []byte) {
 	formattedContent = regexp.MustCompile(`(?:[ \t]*//\n)?[ \t]*// See http://127.0.0.1:.*\n`).ReplaceAll(formattedContent, []byte(""))
 
 	// goimports often gets confused about versions based on whatever it finds
-	// in GOPATH, so reset the TC version to the appropriate value
+	// in GOPATH, so reset the TC version to the appropriate value.  Note that
+	// the last argument here will be updated to the current version by `yarn
+	// release`, so this will always substitute the correct version.
 	formattedContent = regexp.MustCompile(`github.com/taskcluster/taskcluster/v[0-9]+/`).ReplaceAll(formattedContent, []byte("github.com/taskcluster/taskcluster/v25/"))
 
 	// only perform general format, if that worked...

--- a/clients/client-go/integrationtest/integration_test.go
+++ b/clients/client-go/integrationtest/integration_test.go
@@ -1,192 +1,38 @@
 package integrationtest
 
 import (
-	"encoding/json"
 	"testing"
-	"time"
 
-	"github.com/taskcluster/slugid-go/slugid"
+	"github.com/stretchr/testify/require"
 	tcclient "github.com/taskcluster/taskcluster/v25/clients/client-go"
-	"github.com/taskcluster/taskcluster/v25/clients/client-go/tcindex"
-	"github.com/taskcluster/taskcluster/v25/clients/client-go/tcqueue"
-	"github.com/taskcluster/taskcluster/v25/internal/jsontest"
+	"github.com/taskcluster/taskcluster/v25/clients/client-go/tcauth"
+	"github.com/taskcluster/taskcluster/v25/clients/client-go/tcsecrets"
+	"github.com/taskcluster/taskcluster/v25/internal/testrooturl"
 )
 
-// This is a silly test that looks for the garbage index namespace, to somewhat
-// validate that the index client was generated correctly.
-//
-// Note, no credentials are needed.
-func TestGarbageNamespaces(t *testing.T) {
-	Index := tcindex.NewFromEnv()
-	n, err := Index.ListNamespaces("garbage", "", "")
-	if err != nil {
-		t.Fatalf("%v\n", err)
+// This function tests a simple unauthenticated request for the list of configured
+// secrets.
+func TestSecretList(t *testing.T) {
+	rootURL := testrooturl.Get(t)
+	secrets := tcsecrets.New(nil, rootURL)
+	list, err := secrets.List("", "")
+	require.NoError(t, err)
+	for _, secret := range list.Secrets {
+		t.Logf("Secret: %s", secret)
 	}
-	t.Logf("Namespaces: %#v", n.Namespaces)
 }
 
-func permaCreds(t *testing.T) *tcclient.Credentials {
-	permaCreds := tcclient.CredentialsFromEnvVars()
-	if permaCreds.ClientID == "" || permaCreds.AccessToken == "" {
-		t.Skip("Skipping test since TASKCLUSTER_CLIENT_ID and/or TASKCLUSTER_ACCESS_TOKEN env vars not set")
-	}
-	if permaCreds.Certificate != "" {
-		t.Skip("Skipping test since temporary credentials are in use, and permanent credentials are needed")
-	}
-	return permaCreds
-}
-
-// Tests whether it is possible to define a task against the production Queue.
-func TestDefineTask(t *testing.T) {
-	rootURL := tcclient.RootURLFromEnvVars()
-	if rootURL == "" {
-		t.Skip("Cannot run test, neither TASKCLUSTER_PROXY_URL nor TASKCLUSTER_ROOT_URL are set to non-empty strings")
-	}
-	permaCreds := permaCreds(t)
-	myQueue := tcqueue.New(permaCreds, rootURL)
-
-	taskID := slugid.Nice()
-	taskGroupID := slugid.Nice()
-	created := time.Now()
-	deadline := created.AddDate(0, 0, 1)
-	expires := deadline
-
-	td := &tcqueue.TaskDefinitionRequest{
-		Created:  tcclient.Time(created),
-		Deadline: tcclient.Time(deadline),
-		Expires:  tcclient.Time(expires),
-		Extra:    json.RawMessage(`{"index":{"rank":12345}}`),
-		Metadata: tcqueue.TaskMetadata{
-			Description: "Stuff",
-			Name:        "[TC] Pete",
-			Owner:       "pmoore@mozilla.com",
-			Source:      "http://everywhere.com/",
-		},
-		Payload:       json.RawMessage(`{"features":{"relengApiProxy":true}}`),
-		ProvisionerID: "win-provisioner",
-		Retries:       5,
-		Routes: []string{
-			"garbage.tc-client-go.test",
-		},
-		SchedulerID: "go-test-test-scheduler",
-		Scopes: []string{
-			"queue:task-priority:high",
-		},
-		Tags:        map[string]string{"createdForUser": "cbook@mozilla.com"},
-		Priority:    "high",
-		TaskGroupID: taskGroupID,
-		WorkerType:  "win2008-worker",
-	}
-
-	tsr, err := myQueue.CreateTask(taskID, td)
-
-	//////////////////////////////////
-	// And now validate results.... //
-	//////////////////////////////////
-
-	if err != nil {
-		t.Fatalf("%s", err)
-	}
-
-	t.Logf("Task %v created successfully in %v", taskID, rootURL)
-
-	if provisionerID := tsr.Status.ProvisionerID; provisionerID != "win-provisioner" {
-		t.Errorf("provisionerId 'win-provisioner' expected but got %s", provisionerID)
-	}
-	if schedulerID := tsr.Status.SchedulerID; schedulerID != "go-test-test-scheduler" {
-		t.Errorf("schedulerId 'go-test-test-scheduler' expected but got %s", schedulerID)
-	}
-	if retriesLeft := tsr.Status.RetriesLeft; retriesLeft != 5 {
-		t.Errorf("Expected 'retriesLeft' to be 5, but got %v", retriesLeft)
-	}
-	if state := tsr.Status.State; state != "pending" {
-		t.Errorf("Expected 'state' to be 'pending', but got %s", state)
-	}
-
-	taskDef, err := myQueue.Task(taskID)
-
-	if err != nil {
-		t.Fatalf("%s", err)
-	}
-
-	submittedPayload, err := json.Marshal(taskDef)
-
-	if err != nil {
-		t.Fatalf("%s", err)
-	}
-
-	// only the contents is relevant below - the formatting and order of properties does not matter
-	// since a json comparison is done, not a string comparison...
-	expectedJSON := []byte(`
-	{
-	  "created":  "` + created.UTC().Format("2006-01-02T15:04:05.000Z") + `",
-	  "deadline": "` + deadline.UTC().Format("2006-01-02T15:04:05.000Z") + `",
-	  "expires":  "` + expires.UTC().Format("2006-01-02T15:04:05.000Z") + `",
-
-	  "taskGroupId": "` + taskGroupID + `",
-	  "workerType":  "win2008-worker",
-	  "schedulerId": "go-test-test-scheduler",
-
-	  "payload": {
-	    "features": {
-	      "relengApiProxy":true
-	    }
-	  },
-
-      "dependencies": [],
-      "requires": "all-completed",
-
-	  "priority":      "high",
-	  "provisionerId": "win-provisioner",
-	  "retries":       5,
-
-	  "routes": [
-	    "garbage.tc-client-go.test"
-	  ],
-
-	  "scopes": [
-	  	"queue:task-priority:high"
-	  ],
-
-	  "tags": {
-	    "createdForUser": "cbook@mozilla.com"
-	  },
-
-	  "extra": {
-	    "index": {
-	      "rank": 12345
-	    }
-	  },
-
-	  "metadata": {
-	    "description": "Stuff",
-	    "name":        "[TC] Pete",
-	    "owner":       "pmoore@mozilla.com",
-	    "source":      "http://everywhere.com/"
-	  }
-	}
-	`)
-
-	jsonCorrect, formattedExpected, formattedActual, err := jsontest.JsonEqual(expectedJSON, submittedPayload)
-	if err != nil {
-		t.Fatalf("Exception thrown formatting json data!\n%s\n\nStruggled to format either:\n%s\n\nor:\n\n%s", err, string(expectedJSON), submittedPayload)
-	}
-
-	if !jsonCorrect {
-		t.Log("Anticipated json not generated. Expected:")
-		t.Logf("%s", formattedExpected)
-		t.Log("Actual:")
-		t.Errorf("%s", formattedActual)
-	}
-
-	// check it is possible to cancel the unscheduled task using **temporary credentials**
-	tempCreds, err := permaCreds.CreateTemporaryCredentials(30*time.Second, "queue:cancel-task:"+td.SchedulerID+"/"+td.TaskGroupID+"/"+taskID)
-	if err != nil {
-		t.Fatalf("Exception thrown generating temporary credentials!\n\n%s\n\n", err)
-	}
-	myQueue = tcqueue.New(tempCreds, rootURL)
-	_, err = myQueue.CancelTask(taskID)
-	if err != nil {
-		t.Fatalf("Exception thrown cancelling task with temporary credentials!\n\n%s\n\n", err)
-	}
+// This function uses the auth.TestAuthenticate endpoint to check authenticated access.
+func TestAuthenticate(t *testing.T) {
+	rootURL := testrooturl.Get(t)
+	auth := tcauth.New(&tcclient.Credentials{
+		ClientID:    "tester",
+		AccessToken: "no-secret",
+	}, rootURL)
+	res, err := auth.TestAuthenticate(&tcauth.TestAuthenticateRequest{
+		ClientScopes:   []string{"a:scope"},
+		RequiredScopes: []string{"a:scope"},
+	})
+	require.NoError(t, err)
+	require.Equal(t, "tester", res.ClientID)
 }

--- a/internal/scopes/scopes_test.go
+++ b/internal/scopes/scopes_test.go
@@ -1,21 +1,15 @@
 package scopes
 
 import (
-	"os"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 	"github.com/taskcluster/taskcluster/v25/clients/client-go/tcauth"
+	"github.com/taskcluster/taskcluster/v25/internal/testrooturl"
 )
 
 func authClient(t *testing.T) *tcauth.Auth {
-	rootURL := os.Getenv("TASKCLUSTER_ROOT_URL")
-	if rootURL == "" {
-		t.Skip("Set TASKCLUSTER_ROOT_URL to run tests")
-		return nil
-	}
-	// tests only call public APIs, so no auth needed and we can use mozilla production deployment
-	return tcauth.New(nil, rootURL)
+	return tcauth.New(nil, testrooturl.Get(t))
 }
 
 func accept(t *testing.T, given Given, required Required) {

--- a/internal/testrooturl/testrooturl.go
+++ b/internal/testrooturl/testrooturl.go
@@ -17,6 +17,21 @@ func Get(t *testing.T) string {
 			t.Fatal("TASKCLUSTER_ROOT_URL must be set when NO_TEST_SKIP is set")
 		}
 	}
-	// tests only call public APIs, so no auth needed and we can use mozilla production deployment
 	return rootURL
+}
+
+// Like Get, but also return clientID, accessToken, and optional certificate.
+func GetWithCreds(t *testing.T) (rootURL string, clientID string, accessToken string, certificate string) {
+	rootURL = os.Getenv("TASKCLUSTER_ROOT_URL")
+	clientID = os.Getenv("TASKCLUSTER_CLIENT_ID")
+	accessToken = os.Getenv("TASKCLUSTER_ACCESS_TOKEN")
+	certificate = os.Getenv("TASKCLUSTER_CERTIFICATE")
+	if rootURL == "" || clientID == "" || accessToken == "" {
+		if os.Getenv("NO_TEST_SKIP") == "" {
+			t.Skip("Set TASKCLUSTER_ROOT_URL, TASKCLUSTER_CLIENT_ID, and TASKCLUSTER_ACCESS_TOKEN to run tests")
+		} else {
+			t.Fatal("TASKCLUSTER_ROOT_URL, TASKCLUSTER_CLIENT_ID, and TASKCLUSTER_ACCESS_TOKEN must be set when NO_TEST_SKIP is set")
+		}
+	}
+	return
 }

--- a/internal/testrooturl/testrooturl.go
+++ b/internal/testrooturl/testrooturl.go
@@ -1,0 +1,22 @@
+package testrooturl
+
+import (
+	"os"
+	"testing"
+)
+
+// Get gets the rootURL, or skips the test if a root URL is not available,
+// *unless* NO_TEST_SKIP is set, in which case this is considered a fatal
+// error.
+func Get(t *testing.T) string {
+	rootURL := os.Getenv("TASKCLUSTER_ROOT_URL")
+	if rootURL == "" {
+		if os.Getenv("NO_TEST_SKIP") == "" {
+			t.Skip("Set TASKCLUSTER_ROOT_URL to run tests")
+		} else {
+			t.Fatal("TASKCLUSTER_ROOT_URL must be set when NO_TEST_SKIP is set")
+		}
+	}
+	// tests only call public APIs, so no auth needed and we can use mozilla production deployment
+	return rootURL
+}

--- a/workers/generic-worker/gw-decision-task/main.go
+++ b/workers/generic-worker/gw-decision-task/main.go
@@ -216,6 +216,7 @@ func (dt *DecisionTask) GenerateTasks() (*TaskGroup, error) {
 				"env": map[string]string{
 					"GITHUB_SHA":       os.Getenv("GITHUB_SHA"),
 					"GITHUB_CLONE_URL": os.Getenv("GITHUB_CLONE_URL"),
+					"NO_TEST_SKIP":     "true",
 				},
 			}
 			for k, v := range task.Env {

--- a/workers/generic-worker/tcproxy/tcproxy_test.go
+++ b/workers/generic-worker/tcproxy/tcproxy_test.go
@@ -4,17 +4,16 @@ import (
 	"encoding/json"
 	"io/ioutil"
 	"net/http"
-	"os"
 	"runtime"
 	"testing"
 
 	tcclient "github.com/taskcluster/taskcluster/v25/clients/client-go"
 	"github.com/taskcluster/taskcluster/v25/clients/client-go/tcauth"
-	"github.com/taskcluster/taskcluster/v25/workers/generic-worker/testutil"
+	"github.com/taskcluster/taskcluster/v25/internal/testrooturl"
 )
 
 func TestTcProxy(t *testing.T) {
-	testutil.RequireTaskclusterCredentials(t)
+	rootURL, clientID, accessToken, certificate := testrooturl.GetWithCreds(t)
 	var executable string
 	switch runtime.GOOS {
 	case "windows":
@@ -23,12 +22,12 @@ func TestTcProxy(t *testing.T) {
 		executable = "taskcluster-proxy"
 	}
 	creds := &tcclient.Credentials{
-		ClientID:         os.Getenv("TASKCLUSTER_CLIENT_ID"),
-		AccessToken:      os.Getenv("TASKCLUSTER_ACCESS_TOKEN"),
-		Certificate:      os.Getenv("TASKCLUSTER_CERTIFICATE"),
+		ClientID:         clientID,
+		AccessToken:      accessToken,
+		Certificate:      certificate,
 		AuthorizedScopes: []string{"queue:get-artifact:SampleArtifacts/_/X.txt"},
 	}
-	ll, err := New(executable, 34569, os.Getenv("TASKCLUSTER_ROOT_URL"), creds)
+	ll, err := New(executable, 34569, rootURL, creds)
 	// Do defer before checking err since err could be a different error and
 	// process may have already started up.
 	defer func() {


### PR DESCRIPTION
Aside from the `./workers/generic-worker` package (which requires a build tag), this makes all of the go packages pass or skip when running a bare `go test`.  When running under CI, `NO_TEST_SKIP` is set, and these tests will fail if not given the proper credentials.

This follows on to #2356 and contains its commits.  I can rebase once that lands.