### PR TITLE
Correctly update the version in the generic-worker binary

### DIFF
--- a/changelog/BA0eOYvQTRqKeDmswEnQ9w.md
+++ b/changelog/BA0eOYvQTRqKeDmswEnQ9w.md
@@ -1,0 +1,2 @@
+level: silent
+---

--- a/infrastructure/tooling/src/release/tasks.js
+++ b/infrastructure/tooling/src/release/tasks.js
@@ -179,7 +179,7 @@ module.exports = ({tasks, cmdOptions, credentials}) => {
       const genericworker = 'workers/generic-worker/main.go';
       utils.status({message: `Update ${genericworker}`});
       await modifyRepoFile(genericworker, contents =>
-        contents.replace(/^(\w*version\w*=\w*).*/, `$1"${requirements['release-version']}"`));
+        contents.replace(/(tcVersion *= *)"[^"]*"/, `$1"${requirements['release-version']}"`));
       changed.push(genericworker);
 
       return {'version-updated': changed};


### PR DESCRIPTION
After releasing 25.1.1.:
```
dustin@hopper ~ $  tmp/generic-worker-multiuser-linux-amd64 --version
generic-worker (multiuser engine) 16.6.1 [ revision: https://github.com/taskcluster/generic-worker/commits/fc68b5c435791a63c5c8a02f2d8e7a6e0d7ce5f8 ]
```
oops :(