### PR TITLE
Use a non-`-` schedulerId when editing a task in the UI.

### DIFF
--- a/changelog/1596171.md
+++ b/changelog/1596171.md
@@ -1,0 +1,3 @@
+level: silent
+reference: bug 1596171
+---

--- a/ui/src/utils/constants.js
+++ b/ui/src/utils/constants.js
@@ -280,3 +280,4 @@ export const NULL_WORKER_POOL = {
   emailOnError: false,
   config: {},
 };
+export const UI_SCHEDULER_ID = 'taskcluster-ui';

--- a/ui/src/views/Tasks/CreateTask/index.jsx
+++ b/ui/src/views/Tasks/CreateTask/index.jsx
@@ -36,6 +36,7 @@ import { nice } from '../../../utils/slugid';
 import formatTaskMutation from '../../../utils/formatTaskMutation';
 import {
   TASKS_CREATE_STORAGE_KEY,
+  UI_SCHEDULER_ID,
   ISO_8601_REGEX,
 } from '../../../utils/constants';
 import urls from '../../../utils/urls';
@@ -46,7 +47,7 @@ import db from '../../../utils/db';
 const defaultTask = {
   provisionerId: 'proj-getting-started',
   workerType: 'tutorial',
-  schedulerId: 'taskcluster-ui',
+  schedulerId: UI_SCHEDULER_ID,
   created: new Date().toISOString(),
   deadline: toDate(addHours(new Date(), 3)).toISOString(),
   payload: {

--- a/ui/src/views/Tasks/ViewTask/index.jsx
+++ b/ui/src/views/Tasks/ViewTask/index.jsx
@@ -1,7 +1,7 @@
 import { hot } from 'react-hot-loader';
 import React, { Component, Fragment } from 'react';
 import { withApollo, graphql } from 'react-apollo';
-import { omit, pathOr } from 'ramda';
+import { omit, pathOr, mergeRight } from 'ramda';
 import cloneDeep from 'lodash.clonedeep';
 import Spinner from '@mozilla-frontend-infra/components/Spinner';
 import { withStyles } from '@material-ui/core/styles';
@@ -41,6 +41,7 @@ import {
   VALID_TASK,
   TASK_ADDED_FIELDS,
   TASK_POLL_INTERVAL,
+  UI_SCHEDULER_ID,
 } from '../../../utils/constants';
 import db from '../../../utils/db';
 import ErrorPanel from '../../../components/ErrorPanel';
@@ -288,17 +289,20 @@ export default class ViewTask extends Component {
   handleCloneTask = () => {
     const task = removeKeys(cloneDeep(this.props.data.task), ['__typename']);
 
-    return omit(
-      [
-        ...TASK_ADDED_FIELDS,
-        'routes',
-        'taskGroupId',
-        'schedulerId',
-        'priority',
-        'dependencies',
-        'requires',
-      ],
-      task
+    return mergeRight(
+      omit(
+        [
+          ...TASK_ADDED_FIELDS,
+          'routes',
+          'taskGroupId',
+          'schedulerId',
+          'priority',
+          'dependencies',
+          'requires',
+        ],
+        task
+      ),
+      { schedulerId: UI_SCHEDULER_ID }
     );
   };
 


### PR DESCRIPTION
Bugzilla Bug: [1596171](https://bugzilla.mozilla.org/show_bug.cgi?id=1596171)