### PR TITLE
Bug 1616022 - fix regexp for updating generic-worker version on release

### DIFF
--- a/changelog/bug-1616022.md
+++ b/changelog/bug-1616022.md
@@ -1,0 +1,4 @@
+level: minor
+reference: bug 1616022
+---
+Generic worker now correctly reports its version number. The version number was incorrectly reported in release 25.1.1.

--- a/infrastructure/tooling/src/release/tasks.js
+++ b/infrastructure/tooling/src/release/tasks.js
@@ -179,7 +179,7 @@ module.exports = ({tasks, cmdOptions, credentials}) => {
       const genericworker = 'workers/generic-worker/main.go';
       utils.status({message: `Update ${genericworker}`});
       await modifyRepoFile(genericworker, contents =>
-        contents.replace(/^(\w*version\w*=\w*).*/, `$1"${requirements['release-version']}"`));
+        contents.replace(/^(\s*version\s*=\s*).*/, `$1"${requirements['release-version']}"`));
       changed.push(genericworker);
 
       return {'version-updated': changed};


### PR DESCRIPTION
Bugzilla Bug: [1616022](https://bugzilla.mozilla.org/show_bug.cgi?id=1616022)