### PR TITLE
Bug 1616022 - use multiline regexp for updating generic-worker version number

### DIFF
--- a/changelog/bug-1616022.md
+++ b/changelog/bug-1616022.md
@@ -1,0 +1,4 @@
+level: patch
+reference: bug 1616022
+---
+Fixes the version number reported by generic-worker. This was first attempted (unsuccessfully) in release 25.2.0.

--- a/infrastructure/tooling/src/release/tasks.js
+++ b/infrastructure/tooling/src/release/tasks.js
@@ -164,6 +164,8 @@ module.exports = ({tasks, cmdOptions, credentials}) => {
       // matches the full package path to avoid false positives, but that
       // might result in missed changes where the full path is not used.
       const major = requirements['release-version'].replace(/\..*/, '');
+      // Note, this intentionally also includes scripts and yaml files that
+      // also refer to the release version.
       const goFiles = [
         'go.mod',
         'clients/client-go/**',
@@ -179,7 +181,7 @@ module.exports = ({tasks, cmdOptions, credentials}) => {
       const genericworker = 'workers/generic-worker/main.go';
       utils.status({message: `Update ${genericworker}`});
       await modifyRepoFile(genericworker, contents =>
-        contents.replace(/^(\s*version\s*=\s*).*/, `$1"${requirements['release-version']}"`));
+        contents.replace(/^(\s*version\s*=\s*).*/m, `$1"${requirements['release-version']}"`));
       changed.push(genericworker);
 
       return {'version-updated': changed};


### PR DESCRIPTION
Bugzilla Bug: [1616022](https://bugzilla.mozilla.org/show_bug.cgi?id=1616022)

This is the second attempt to fix [bug 1616022](https://bugzilla.mozilla.org/show_bug.cgi?id=1616022). The first occurred in PR #2369 (released in [25.2.0](https://github.com/taskcluster/taskcluster/releases/tag/v25.2.0)), but was __unsuccessful__. I'm currently testing by making a staging release in branch [`staging-release/bug1616022-v2`](https://github.com/taskcluster/taskcluster/commits/staging-release/bug1616022-v2).