### PR TITLE
Bug 1616649: azure-provider avoid blocking operations

### DIFF
--- a/changelog/bug-1616649.md
+++ b/changelog/bug-1616649.md
@@ -1,0 +1,5 @@
+level: patch
+reference: bug 1616649
+---
+reimplements azure-provider's use of the azure SDK to avoid blocking operations that can hold up worker-manager iterations
+resource creation operations that were previously waiting for completion in the provisioner now are tracked and checked on as part of the worker-scanner iteration

--- a/generated/references.json
+++ b/generated/references.json
@@ -9668,6 +9668,19 @@
           "version": 1
         },
         {
+          "description": "A worker has been marked as stopping",
+          "fields": {
+            "providerId": "The provider that did the work for this worker pool.",
+            "workerId": "The worker that was created",
+            "workerPoolId": "The worker pool ID (provisionerId/workerType)"
+          },
+          "level": "notice",
+          "name": "workerStopping",
+          "title": "Worker Stopping",
+          "type": "worker-stopping",
+          "version": 1
+        },
+        {
           "description": "The simple estimator has decided that we need some number of instances.",
           "fields": {
             "desiredCapacity": "Amount of capacity that this estimator thinks we should have",

--- a/services/worker-manager/src/data.js
+++ b/services/worker-manager/src/data.js
@@ -310,6 +310,7 @@ Worker.prototype.serializable = function() {
 Worker.states = {
   REQUESTED: 'requested',
   RUNNING: 'running',
+  STOPPING: 'stopping',
   STOPPED: 'stopped',
 };
 

--- a/services/worker-manager/src/monitor.js
+++ b/services/worker-manager/src/monitor.js
@@ -61,6 +61,20 @@ monitorManager.register({
 });
 
 monitorManager.register({
+  name: 'workerStopping',
+  title: 'Worker Stopping',
+  type: 'worker-stopping',
+  version: 1,
+  level: 'notice',
+  description: 'A worker has been marked as stopping',
+  fields: {
+    workerPoolId: 'The worker pool ID (provisionerId/workerType)',
+    providerId: 'The provider that did the work for this worker pool.',
+    workerId: 'The worker that was created',
+  },
+});
+
+monitorManager.register({
   name: 'simpleEstimate',
   title: 'Simple Estimate Provided',
   type: 'simple-estimate',

--- a/services/worker-manager/src/providers/azure.js
+++ b/services/worker-manager/src/providers/azure.js
@@ -327,9 +327,10 @@ class AzureProvider extends Provider {
 
     // verify that the embedded vmId matches what the worker is sending
     try {
-      assert.equal(payload.vmId, worker.workerId);
+      assert(worker.providerData.vm.id);
+      assert.equal(payload.vmId, worker.providerData.vm.id);
     } catch (err) {
-      this.monitor.log.registrationErrorWarning({message: 'Encountered vmId mismatch', error: err.toString(), vmId: payload.vmId, workerId: worker.workerId});
+      this.monitor.log.registrationErrorWarning({message: `vmId mismatch: ${payload.vmId} !== ${worker.providerData.vm.id}`, error: err.toString(), vmId: payload.vmId, workerId: worker.workerId});
       throw error();
     }
 

--- a/services/worker-manager/src/providers/azure.js
+++ b/services/worker-manager/src/providers/azure.js
@@ -148,8 +148,9 @@ class AzureProvider extends Provider {
     // Create "empty" workers to provision in provisionResources loop
     await Promise.all(cfgs.map(async cfg => {
       // This must be unique to currently existing instances and match [a-z]([-a-z0-9]*[a-z0-9])?
+      // 38 chars is workerPoolId / workerId limit
       const poolName = workerPoolId.replace(/[\/_]/g, '-').slice(0, 38);
-      const virtualMachineName = `vm-${poolName}-${nicerId()}-${nicerId()}`.slice(0, 64);
+      const virtualMachineName = `vm-${poolName}-${nicerId()}-${nicerId()}`.slice(0, 38);
       // Windows computer name cannot be more than 15 characters long, be entirely numeric,
       // or contain the following characters: ` ~ ! @ # $ % ^ & * ( ) = + _ [ ] { } \\ | ; : . " , < > / ?
       const computerName = nicerId().slice(0, 15);

--- a/services/worker-manager/src/providers/azure.js
+++ b/services/worker-manager/src/providers/azure.js
@@ -11,6 +11,8 @@ const generator = require('generate-password');
 const auth = require('@azure/ms-rest-nodeauth');
 const ComputeManagementClient = require('@azure/arm-compute').ComputeManagementClient;
 const NetworkManagementClient = require('@azure/arm-network').NetworkManagementClient;
+const msRestJS = require('@azure/ms-rest-js');
+const msRestAzure = require('@azure/ms-rest-azure-js');
 
 const {ApiError, Provider} = require('./provider');
 const {CloudAPI} = require('./cloudapi');
@@ -39,6 +41,17 @@ function generateAdminPassword() {
   });
 }
 
+function workerConfigWithSecrets(cfg) {
+  assert(_.has(cfg, 'osProfile'));
+  // Windows admin user name cannot be more than 20 characters long, be empty,
+  // end with a period(.), or contain the following characters: \\ / \" [ ] : | < > + = ; , ? * @.
+  cfg.osProfile.adminUsername = nicerId().slice(0, 20);
+  // we have to set a password, but we never want it to be used, so we throw it away
+  // a legitimate user who needs access can reset the password
+  cfg.osProfile.adminPassword = generateAdminPassword();
+  return cfg;
+}
+
 class AzureProvider extends Provider {
 
   constructor({
@@ -65,16 +78,16 @@ class AzureProvider extends Provider {
     // Azure SDK has builtin retry logic: https://docs.microsoft.com/en-us/azure/architecture/best-practices/retry-service-specific
     // compute rate limiting: https://docs.microsoft.com/en-us/azure/virtual-machines/troubleshooting/troubleshooting-throttling-errors
     const cloud = new CloudAPI({
-      types: ['get', 'query', 'list'],
+      types: ['query', 'get', 'list', 'opRead'],
       apiRateLimits,
       intervalDefault: 100 * 1000, // Intervals are enforced every 100 seconds
       intervalCapDefault: 2000, // The calls we make are all limited 20/sec so 20 * 100 are allowed
       monitor: this.monitor,
       providerId: this.providerId,
       errorHandler: ({err, tries}) => {
-        if (err.code === 429) { // too many requests
+        if (err.statusCode === 429) { // too many requests
           return {backoff: _backoffDelay * 50, reason: 'rateLimit', level: 'notice'};
-        } else if (err.code >= 500) { // For 500s, let's take a shorter backoff
+        } else if (err.statusCode >= 500) { // For 500s, let's take a shorter backoff
           return {backoff: _backoffDelay * Math.pow(2, tries), reason: 'errors', level: 'warning'};
         }
         // If we don't want to do anything special here, just throw and let the
@@ -100,6 +113,7 @@ class AzureProvider extends Provider {
     let credentials = await auth.loginWithServicePrincipalSecret(clientId, secret, domain);
     this.computeClient = new ComputeManagementClient(credentials, subscriptionId);
     this.networkClient = new NetworkManagementClient(credentials, subscriptionId);
+    this.restClient = new msRestAzure.AzureServiceClient(credentials);
   }
 
   async provision({workerPool, workerInfo}) {
@@ -123,12 +137,12 @@ class AzureProvider extends Provider {
       toSpawn -= cfg.capacityPerInstance;
     }
 
+    // Create "empty" workers to provision in provisionResources loop
     await Promise.all(cfgs.map(async cfg => {
       // This must be unique to currently existing instances and match [a-z]([-a-z0-9]*[a-z0-9])?
       // The lost entropy from downcasing, etc should be ok due to the fact that
       // only running instances need not be identical. We do not use this name to identify
       // workers in taskcluster.
-      const resourceGroupName = this.providerConfig.resourceGroupName;
       const poolName = workerPoolId.replace(/[\/_]/g, '-').slice(0, 38);
       const virtualMachineName = `vm-${poolName}-${nicerId()}`.slice(0, 38);
       // Windows computer name cannot be more than 15 characters long, be entirely numeric,
@@ -137,7 +151,45 @@ class AzureProvider extends Provider {
       const ipAddressName = `pip-${nicerId()}`.slice(0, 24);
       const networkInterfaceName = `nic-${nicerId()}`.slice(0, 24);
       const diskName = `disk-${nicerId()}`.slice(0, 24);
-      let ipAddress, networkInterface, virtualMachine;
+
+      const customData = Buffer.from(JSON.stringify({
+        workerPoolId,
+        providerId: this.providerId,
+        workerGroup: this.providerId,
+        rootUrl: this.rootUrl,
+        workerConfig: cfg.workerConfig || {},
+      })).toString('base64');
+
+      const config = {
+        ...cfg,
+        osProfile: {
+          ...cfg.osProfile,
+          // adminUsername and adminPassword will be added later
+          // because we are saving this config to providerData
+          // and they are obfuscated / intended to be secret
+          computerName,
+          customData,
+        },
+        storageProfile: {
+          ...cfg.storageProfile,
+          osDisk: {
+            ...(cfg.storageProfile || {}).osDisk,
+            name: diskName,
+          },
+        },
+        networkProfile: {
+          ...cfg.networkProfile,
+          // we add this when we have the NIC provisioned
+          networkInterfaces: [],
+        },
+        tags: {
+          ...cfg.tags || {},
+          'created-by': `taskcluster-wm-${this.providerId}`.replace(/[^a-zA-Z0-9-]/g, '-'),
+          'managed-by': 'taskcluster',
+          'worker-pool-id': workerPoolId.replace(/[^a-zA-Z0-9-]/g, '-').toLowerCase(),
+          'owner': workerPool.owner.replace(/[^a-zA-Z0-9-]/g, '-').toLowerCase(),
+        },
+      };
 
       let providerData = {
         location: cfg.location,
@@ -145,114 +197,42 @@ class AzureProvider extends Provider {
         vm: {
           name: virtualMachineName,
           computerName,
-          location: cfg.location,
+          config,
+          operation: false,
+          id: false,
         },
         ip: {
           name: ipAddressName,
-          location: cfg.location,
+          operation: false,
+          id: false,
         },
         nic: {
           name: networkInterfaceName,
-          location: cfg.location,
+          operation: false,
+          id: false,
         },
         disk: {
+          // created by the VM operation
           name: diskName,
-          location: cfg.location,
+          id: false,
+        },
+        subnet: {
+          id: cfg.subnetId,
         },
       };
 
-      try {
-        // create NIC, public IP, and VM
-        ipAddress = await this._enqueue('query', () => this.networkClient.publicIPAddresses.createOrUpdate(resourceGroupName, ipAddressName, {
-          location: cfg.location,
-          publicIPAllocationMethod: 'Dynamic',
-        }));
-
-        networkInterface = await this._enqueue('query', () => this.networkClient.networkInterfaces.createOrUpdate(resourceGroupName, networkInterfaceName, {
-          location: cfg.location,
-          ipConfigurations: [
-            {
-              name: ipAddressName,
-              privateIPAllocationMethod: 'Dynamic',
-              subnet: {
-                id: cfg.subnetId,
-              },
-              publicIPAddress: {
-                id: ipAddress.id,
-              },
-            },
-          ],
-        }));
-
-        const customData = Buffer.from(JSON.stringify({
-          workerPoolId,
-          providerId: this.providerId,
-          workerGroup: this.providerId,
-          rootUrl: this.rootUrl,
-          workerConfig: cfg.workerConfig || {},
-        })).toString('base64');
-
-        virtualMachine = await this._enqueue('query', () => this.computeClient.virtualMachines.createOrUpdate(resourceGroupName, virtualMachineName, {
-          ...cfg,
-          osProfile: {
-            ...cfg.osProfile,
-            // Windows admin user name cannot be more than 20 characters long, be empty,
-            // end with a period(.), or contain the following characters: \\ / \" [ ] : | < > + = ; , ? * @.
-            adminUsername: nicerId().slice(0, 20),
-            // we have to set a password, but we never want it to be used, so we throw it away
-            // a legitimate user who needs access can reset the password
-            adminPassword: generateAdminPassword(),
-            computerName,
-            customData,
-          },
-          storageProfile: {
-            ...cfg.storageProfile,
-            osDisk: {
-              ...(cfg.storageProfile || {}).osDisk,
-              name: diskName,
-            },
-          },
-          networkProfile: {
-            ...cfg.networkProfile,
-            networkInterfaces: [
-              {
-                id: networkInterface.id,
-                primary: true,
-              },
-            ],
-          },
-          tags: {
-            ...cfg.tags || {},
-            'created-by': `taskcluster-wm-${this.providerId}`.replace(/[^a-zA-Z0-9-]/g, '-'),
-            'managed-by': 'taskcluster',
-            'worker-pool-id': workerPoolId.replace(/[^a-zA-Z0-9-]/g, '-').toLowerCase(),
-            'owner': workerPool.owner.replace(/[^a-zA-Z0-9-]/g, '-').toLowerCase(),
-          },
-        }));
-      } catch (err) {
-        // we create multiple resources in order to provision a VM
-        // if we catch an error we want to deprovision those resources
-        await this._removeWorker({...providerData});
-        await workerPool.reportError({
-          kind: 'creation-error',
-          title: 'VM Creation Error',
-          description: err.message,
-          extra: err.details,
-        });
-        return;
-      }
       this.monitor.log.workerRequested({
         workerPoolId,
         providerId: this.providerId,
         workerGroup: this.providerId,
-        workerId: virtualMachine.vmId,
+        workerId: virtualMachineName,
       });
       const now = new Date();
       await this.Worker.create({
         workerPoolId,
         providerId: this.providerId,
         workerGroup: this.providerId,
-        workerId: virtualMachine.vmId,
+        workerId: virtualMachineName,
         created: now,
         lastModified: now,
         lastChecked: now,
@@ -387,19 +367,222 @@ class AzureProvider extends Provider {
 
   async scanPrepare() {
     this.seen = {};
+    this.errors = {};
+  }
+
+  /**
+   * Checks the status of ongoing Azure operations
+   * Returns true if the operation is in progress, false otherwise
+   *
+   * op: a URL for tracking the ongoing status of an Azure operation
+   * errors: a list that will have any errors found for that operation appended to it
+   */
+  async handleOperation({op, errors}) {
+    let req, resp;
+    try {
+      // TODO: we could be smarter about getting operation status
+      // see here: https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/async-operations
+      req = new msRestJS.WebResource(op, 'GET');
+      // sendLongRunningRequest polls until finished but this is just reading
+      // the status of an operation so it shouldn't block long
+      // it's ok if we hit an error here, that will trigger resource teardown
+      resp = await this._enqueue('opRead', () => this.restClient.sendLongRunningRequest(req));
+    } catch (err) {
+      // Rest API has different error semantics than the SDK
+      if (_.has(resp, 'status') && resp.status === 404) {
+        // operation not found because it has either expired or does not exist
+        // nothing more to do
+        return false;
+      }
+      throw err;
+    }
+
+    let body = resp.parsedBody;
+    if (body) {
+      // status is guaranteed to exist if the operation was found
+      if (body.status === 'InProgress') {
+        return true;
+      }
+      if (body.error) {
+        errors.push({
+          kind: 'operation-error',
+          title: 'Operation Error',
+          description: body.error.message,
+          extra: {
+            code: body.error.code,
+          },
+          notify: this.notify,
+          WorkerPoolError: this.WorkerPoolError,
+        });
+      }
+    }
+
+    return false;
+  }
+
+  /**
+   * provisionResource generically provisions individual resources
+   * Handles cases where:
+   *  we have not yet created a resource and need to create one,
+   *  we have requested a resource but it is not ready,
+   *  we have a resource ready to go
+   *
+   * worker: the worker for which the resource is being provisioned
+   * client: the Azure SDK client for the resource
+   * resourceType: the short name used to identify the resource in providerData
+   * resourceConfig: configuration to be passed to the SDK for resource creation
+   * modifyFn: a function (worker, resource) that takes the worker and the created
+   *   resource, allowing the worker to be modified.
+   */
+  async provisionResource({worker, client, resourceType, resourceConfig, modifyFn}) {
+    if (!_.has(worker.providerData, resourceType)) {
+      throw new Error(`Error provisioning worker: providerData does not contain resourceType ${resourceType}`);
+    }
+    let typeData = worker.providerData[resourceType];
+
+    // we have no id, so we try to lookup resource by name
+    if (!typeData.id) {
+      try {
+        let resource = await this._enqueue('query', () => client.get(
+          worker.providerData.resourceGroupName,
+          typeData.name,
+        ));
+        // we found the resource
+        await worker.modify(w => {
+          w.providerData[resourceType].id = resource.id;
+          modifyFn(w, resource);
+        });
+      } catch (err) {
+        if (err.statusCode !== 404) {
+          throw err;
+        }
+        // if we've made the request
+        // we should have an operation, check status
+        if (typeData.operation) {
+          let op = await this.handleOperation({
+            op: typeData.operation,
+            errors: this.errors[worker.workerPoolId],
+          });
+          if (!op) {
+            // if the operation has expired or does not exist
+            // chances are our instance has been deleted off band
+            await this.removeWorker({worker});
+          }
+        }
+      }
+    }
+    // failed to lookup resource by name
+    if (!typeData.id) {
+      // we need to create the resource
+      let resourceRequest = await this._enqueue('query', () => client.beginCreateOrUpdate(
+        worker.providerData.resourceGroupName,
+        typeData.name,
+        resourceConfig,
+      ));
+      // track operation
+      await worker.modify(w => {
+        w.providerData[resourceType].operation = resourceRequest.getPollState().azureAsyncOperationHeaderValue;
+      });
+    }
+  }
+
+  /**
+   * provisionResources wraps the process of provisioning worker resources
+   *
+   * This function is expected to be called several times per worker as
+   * resources are created.
+   */
+  async provisionResources({worker}) {
+    try {
+      // IP
+      let ipConfig = {
+        location: worker.providerData.location,
+        publicIPAllocationMethod: 'Dynamic',
+      };
+      await this.provisionResource({
+        worker,
+        client: this.networkClient.publicIPAddresses,
+        resourceType: 'ip',
+        resourceConfig: ipConfig,
+        modifyFn: () => {},
+      });
+      if (!worker.providerData.ip.id) {
+        return worker.state;
+      }
+
+      // NIC
+      let nicConfig = {
+        location: worker.providerData.location,
+        ipConfigurations: [
+          {
+            name: worker.providerData.nic.name,
+            privateIPAllocationMethod: 'Dynamic',
+            subnet: {
+              id: worker.providerData.subnet.id,
+            },
+            publicIPAddress: {
+              id: worker.providerData.ip.id,
+            },
+          },
+        ],
+      };
+      // set up the VM network interface config
+      let nicModifyFunc = (w, nic) => {
+        w.providerData.vm.config.networkProfile.networkInterfaces = [
+          {
+            id: nic.id,
+            primary: true,
+          },
+        ];
+      };
+      await this.provisionResource({
+        worker,
+        client: this.networkClient.networkInterfaces,
+        resourceType: 'nic',
+        resourceConfig: nicConfig,
+        modifyFn: nicModifyFunc,
+      });
+      if (!worker.providerData.nic.id) {
+        return worker.state;
+      }
+
+      // VM
+      // NB: if we ever need disk id for anything, we could get it here
+      await this.provisionResource({
+        worker,
+        client: this.computeClient.virtualMachines,
+        resourceType: 'vm',
+        resourceConfig: workerConfigWithSecrets(worker.providerData.vm.config),
+        modifyFn: () => {},
+      });
+      if (!worker.providerData.vm.id) {
+        return worker.state;
+      }
+      return this.Worker.states.RUNNING;
+    } catch (err) {
+      // we create multiple resources in order to provision a VM
+      // if we catch an error we want to deprovision those resources
+      await worker.workerPool.reportError({
+        kind: 'creation-error',
+        title: 'VM Creation Error',
+        description: err.message,
+      });
+    }
   }
 
   async checkWorker({worker}) {
     const states = this.Worker.states;
     this.seen[worker.workerPoolId] = this.seen[worker.workerPoolId] || 0;
-
-    let state = worker.state;
+    this.errors[worker.workerPoolId] = this.errors[worker.workerPoolId] || [];
+    let state = worker.state || states.REQUESTED;
     try {
       const {provisioningState} = await this._enqueue('get', () => this.computeClient.virtualMachines.get(
         worker.providerData.resourceGroupName,
         worker.providerData.vm.name,
       ));
-      if (['Creating', 'Updating', 'Starting', 'Running', 'Succeeded'].includes(provisioningState)) {
+      const successStates = ['Creating', 'Updating', 'Starting', 'Running', 'Succeeded'];
+      const failStates = ['Failed', 'Canceled', 'Deleting', 'Deallocating', 'Stopped', 'Deallocated'];
+      if (successStates.includes(provisioningState)) {
         this.seen[worker.workerPoolId] += worker.capacity || 1;
 
         // If the worker will be expired soon but it still exists,
@@ -412,16 +595,15 @@ class AzureProvider extends Provider {
           });
         }
         if (worker.providerData.terminateAfter && worker.providerData.terminateAfter < Date.now()) {
-          await this.removeWorker({worker});
+          state = await this.removeWorker({worker});
         }
-      } else if (['Failed', 'Canceled', 'Deleting', 'Deallocating', 'Stopped', 'Deallocated'].includes(provisioningState)) {
-        await this.removeWorker({worker});
+      } else if (failStates.includes(provisioningState)) {
+        state = await this.removeWorker({worker});
         this.monitor.log.workerStopped({
           workerPoolId: worker.workerPoolId,
           providerId: this.providerId,
           workerId: worker.workerId,
         });
-        state = states.STOPPED;
       } else {
         await worker.workerPool.reportError({
           kind: 'creation-error',
@@ -430,17 +612,19 @@ class AzureProvider extends Provider {
         });
       }
     } catch (err) {
-      if (err.code !== 'ResourceNotFound') {
+      if (err.statusCode !== 404) {
         throw err;
       }
-      await this.removeWorker({worker});
-      this.monitor.log.workerStopped({
-        workerPoolId: worker.workerPoolId,
-        providerId: this.providerId,
-        workerId: worker.workerId,
-      });
-      state = states.STOPPED;
+      // we're either provisioning or stopping this worker
+      if (state === states.REQUESTED) {
+        state = await this.provisionResources({worker});
+      }
+      // if provisioning went awry
+      if (state === states.STOPPING) {
+        state = await this.removeWorker({worker});
+      }
     }
+
     await worker.modify(w => {
       const now = new Date();
       if (w.state !== state) {
@@ -451,49 +635,158 @@ class AzureProvider extends Provider {
     });
   }
 
+  /*
+   * Called after an iteration of the worker scanner
+   */
   async scanCleanup() {
     this.monitor.log.scanSeen({providerId: this.providerId, seen: this.seen});
+    await Promise.all(Object.entries(this.seen).map(async ([workerPoolId, seen]) => {
+      const workerPool = await this.WorkerPool.load({
+        workerPoolId,
+      }, true);
+
+      if (!workerPool) {
+        return; // In this case, the workertype has been deleted so we can just move on
+      }
+
+      if (this.errors[workerPoolId].length) {
+        await Promise.all(this.errors[workerPoolId].map(error => workerPool.reportError(error)));
+      }
+    }));
   }
 
-  async _removeWorker({resourceGroupName, location, vm, ip, nic, disk}) {
-    // clean up related resources, continue on errors
-    // delete VM, IP, NIC, and disk
-    const ignoreNotFound = async (promise) => {
+  /*
+   * removeResource attempts to delete a resource and verify deletion
+   */
+  async removeResource({client, worker, resourceType}) {
+    if (!_.has(worker.providerData, resourceType)) {
+      throw new Error(`Error removing worker: providerData does not contain resourceType ${resourceType}`);
+    }
+    let typeData = worker.providerData[resourceType];
+
+    let shouldDelete = false;
+    // lookup resource by name
+    if (!typeData.id) {
       try {
-        await promise;
+        let {provisioningState} = await this._enqueue('query', () => client.get(
+          worker.providerData.resourceGroupName,
+          typeData.name,
+        ));
+        // resource could be successful, failed, etc.
+        // we have not yet tried to delete the resource
+        if (!(['Deleting', 'Deallocating', 'Deallocated'].includes(provisioningState))) {
+          shouldDelete = true;
+        }
       } catch (err) {
-        if (err.code === 404) {
-          return; // Nothing to do, it is already gone
+        if (err.statusCode === 404) {
+          // if we check for `true` we repeat lots of GET requests
+          // resource has been deleted and isn't in the API or never existed
+          await worker.modify(w => {
+            w.providerData[resourceType].id = false;
+          });
+          return true;
         }
         throw err;
       }
-    };
-    // VM, disk, and NIC _should_ be able to be deleted in parallel
-    // if we get "in use" failures for NIC/disk they will be retried
-    await Promise.all([
-      ignoreNotFound(this._enqueue('query', () => this.computeClient.virtualMachines.deleteMethod(
-        resourceGroupName,
-        vm.name,
-      ))),
-      ignoreNotFound(this._enqueue('query', () => this.networkClient.networkInterfaces.deleteMethod(
-        resourceGroupName,
-        nic.name,
-      ))),
-      await ignoreNotFound(this._enqueue('query', () => this.computeClient.disks.deleteMethod(
-        resourceGroupName,
-        disk.name,
-      ))),
-    ]);
-    // the public IP cannot be deleted as long as it is attached
-    // can become orphaned if we try to delete before the NIC is deleted
-    await ignoreNotFound(this._enqueue('query', () => this.networkClient.publicIPAddresses.deleteMethod(
-      resourceGroupName,
-      ip.name,
-    )));
+    }
+
+    // NB: possible resource leak if we don't require `return true`
+    // we don't check operation status: no differentiating between
+    // operation => create and operation => delete
+    if (typeData.id || shouldDelete) {
+      // we need to delete the resource
+      let deleteRequest = await this._enqueue('query', () => client.beginDeleteMethod(
+        worker.providerData.resourceGroupName,
+        typeData.name,
+      ));
+      // track operation
+      await worker.modify(w => {
+        w.providerData[resourceType].id = false;
+        w.providerData[resourceType].operation = deleteRequest.getPollState().azureAsyncOperationHeaderValue;
+      });
+    }
+    return false;
   }
 
+  /*
+   * removeWorker marks a worker for deletion and begins removal
+   *
+   * worker: the worker for which the resource is being provisioned
+   * client: the Azure SDK client for the resource
+   * resourceType: the short name used to identify the resource in providerData
+   */
   async removeWorker({worker}) {
-    await this._removeWorker({...worker.providerData});
+    let states = this.Worker.states;
+    if (worker.state === states.STOPPED) {
+      // we're done
+      return states.STOPPED;
+    }
+
+    let state = states.STOPPING;
+    // After we make the delete request we set id to false
+    // some delete operations (i.e. VMs) take a long time though
+    // we use the result of removeResource to _ensure_ deletion has completed
+    // before moving on to the next step, so that we don't leak resources
+    try {
+      // VM must be deleted before disk
+      // VM must be deleted before NIC
+      // NIC must be deleted before IP
+      let vmDeleted = await this.removeResource({
+        worker,
+        client: this.computeClient.virtualMachines,
+        resourceType: 'vm',
+      });
+      if (!vmDeleted || worker.providerData.vm.id) {
+        return state;
+      }
+      let nicDeleted = await this.removeResource({
+        worker,
+        client: this.networkClient.networkInterfaces,
+        resourceType: 'nic',
+      });
+      if (!nicDeleted || worker.providerData.nic.id) {
+        return state;
+      }
+      let ipDeleted = await this.removeResource({
+        worker,
+        client: this.networkClient.publicIPAddresses,
+        resourceType: 'ip',
+      });
+      if (!ipDeleted || worker.providerData.ip.id) {
+        return state;
+      }
+      let diskDeleted = await this.removeResource({
+        worker,
+        client: this.computeClient.disks,
+        resourceType: 'disk',
+      });
+      if (!diskDeleted || worker.providerData.disk.id) {
+        return state;
+      }
+      // change to stopped
+      state = states.STOPPED;
+      await worker.modify(w => {
+        const now = new Date();
+        w.lastModified = now;
+        w.lastChecked = now;
+        w.state = state;
+      });
+    } catch (err) {
+      // if this is called directly and not via checkWorker may not exist
+      this.errors = this.errors || {};
+      this.errors[worker.workerPoolId] = this.errors[worker.workerPoolId] || [];
+      this.errors[worker.workerPoolId].push({
+        kind: 'deletion-error',
+        title: 'Deletion Error',
+        description: err.message,
+        extra: {
+          code: err.code,
+        },
+        notify: this.notify,
+        WorkerPoolError: this.WorkerPoolError,
+      });
+    }
+    return state;
   }
 }
 

--- a/services/worker-manager/src/providers/azure.js
+++ b/services/worker-manager/src/providers/azure.js
@@ -208,6 +208,7 @@ class AzureProvider extends Provider {
           config,
           operation: false,
           id: false,
+          vmId: false,
         },
         ip: {
           name: ipAddressName,
@@ -335,10 +336,10 @@ class AzureProvider extends Provider {
 
     // verify that the embedded vmId matches what the worker is sending
     try {
-      assert(worker.providerData.vmId);
-      assert.equal(payload.vmId, worker.providerData.vmId);
+      assert(worker.providerData.vm.vmId);
+      assert.equal(payload.vmId, worker.providerData.vm.vmId);
     } catch (err) {
-      this.monitor.log.registrationErrorWarning({message: `vmId mismatch: ${payload.vmId} !== ${worker.providerData.vmId}`, error: err.toString(), vmId: payload.vmId, workerId: worker.workerId});
+      this.monitor.log.registrationErrorWarning({message: `vmId mismatch: ${payload.vmId} !== ${worker.providerData.vm.vmId}`, error: err.toString(), vmId: payload.vmId, workerId: worker.workerId});
       throw error();
     }
 

--- a/services/worker-manager/src/providers/azure.js
+++ b/services/worker-manager/src/providers/azure.js
@@ -339,7 +339,13 @@ class AzureProvider extends Provider {
       assert(worker.providerData.vm.vmId);
       assert.equal(payload.vmId, worker.providerData.vm.vmId);
     } catch (err) {
-      this.monitor.log.registrationErrorWarning({message: `vmId mismatch: ${payload.vmId} !== ${worker.providerData.vm.vmId}`, error: err.toString(), vmId: payload.vmId, workerId: worker.workerId});
+      this.monitor.log.registrationErrorWarning({
+        message: 'vmId mismatch',
+        error: err.toString(),
+        vmId: payload.vmId,
+        expectedVmId: worker.providerData.vm.vmId,
+        workerId: worker.workerId,
+      });
       throw error();
     }
 
@@ -638,7 +644,7 @@ class AzureProvider extends Provider {
         await worker.workerPool.reportError({
           kind: 'creation-error',
           title: 'Encountered unknown VM provisioningState or powerStates',
-          description: `Unknown provisioningState ${provisioningState}`,
+          description: `Unknown provisioningState ${provisioningState} or powerStates: ${powerStates}`,
         });
       }
     } catch (err) {

--- a/services/worker-manager/src/provisioner.js
+++ b/services/worker-manager/src/provisioner.js
@@ -117,6 +117,10 @@ class Provisioner {
       // from the list of previous provider IDs
       const providersByPool = new Map();
       const seen = worker => {
+        // don't count capacity for stopping workers
+        if (worker.state === this.Worker.states.STOPPING) {
+          return;
+        }
         const v = providersByPool.get(worker.workerPoolId);
         const isRequested = worker.state === this.Worker.states.REQUESTED;
         // compute the number of instances that have not yet called "registerWorker"

--- a/services/worker-manager/test/fake-azure.js
+++ b/services/worker-manager/test/fake-azure.js
@@ -94,7 +94,7 @@ class FakeAzure {
     const azureError = new Error("something went wrong");
 
     this.getVMStub = sinon.stub();
-    // first call returns provisioningState Creating, second returns Failed
+    // first call returns provisioningState Succeeded, second returns Failed
     this.getVMStub.onCall(0).returns({...instanceData, provisioningState: 'Succeeded'});
     this.getVMStub.onCall(1).returns({...instanceData, provisioningState: 'Failed'});
     this.getVMStub.onCall(2).throws(() => { return this.error(404); });

--- a/tools/taskcluster-worker-runner/provider/azure/azure.go
+++ b/tools/taskcluster-worker-runner/provider/azure/azure.go
@@ -74,7 +74,7 @@ func (p *AzureProvider) ConfigureRun(state *run.State) error {
 		customData.WorkerPoolId,
 		customData.ProviderId,
 		customData.WorkerGroup,
-		instanceData.Compute.VMID,
+		instanceData.Compute.Name,
 		workerIdentityProofMap)
 	if err != nil {
 		return err

--- a/tools/taskcluster-worker-runner/provider/azure/azure_test.go
+++ b/tools/taskcluster-worker-runner/provider/azure/azure_test.go
@@ -52,6 +52,7 @@ func TestConfigureRun(t *testing.T) {
 		"compute": {
 			"customData": "",
 			"vmId": "df09142e-c0dd-43d9-a515-489f19829dfd",
+			"name": "vm-w-p-test",
 			"location": "uswest",
 			"vmSize": "medium"
 		},
@@ -84,7 +85,7 @@ func TestConfigureRun(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, customData.ProviderId, reg.ProviderID)
 	require.Equal(t, customData.WorkerGroup, reg.WorkerGroup)
-	require.Equal(t, "df09142e-c0dd-43d9-a515-489f19829dfd", reg.WorkerID)
+	require.Equal(t, "vm-w-p-test", reg.WorkerID)
 	require.Equal(t, json.RawMessage(`{"document":"`+attestedDocument+`"}`), reg.WorkerIdentityProof)
 	require.Equal(t, "w/p", reg.WorkerPoolID)
 
@@ -94,7 +95,7 @@ func TestConfigureRun(t *testing.T) {
 	require.Equal(t, "cert", state.Credentials.Certificate, "cert is correct")
 	require.Equal(t, "w/p", state.WorkerPoolID, "workerPoolID is correct")
 	require.Equal(t, "wg", state.WorkerGroup, "workerGroup is correct")
-	require.Equal(t, "df09142e-c0dd-43d9-a515-489f19829dfd", state.WorkerID, "workerID is correct")
+	require.Equal(t, "vm-w-p-test", state.WorkerID, "workerID is correct")
 
 	require.Equal(t, map[string]interface{}{
 		"vm-id":         "df09142e-c0dd-43d9-a515-489f19829dfd",

--- a/tools/taskcluster-worker-runner/provider/azure/metadata.go
+++ b/tools/taskcluster-worker-runner/provider/azure/metadata.go
@@ -20,6 +20,7 @@ type InstanceData struct {
 	Compute struct {
 		Location string `json:"location"`
 		VMID     string `json:"vmId"`
+		Name     string `json:"name"`
 		VMSize   string `json:"vmSize"`
 	} `json:"compute"`
 	Network struct {


### PR DESCRIPTION
Bugzilla Bug: [1616649](https://bugzilla.mozilla.org/show_bug.cgi?id=1616649)

note: consulted with @ajvb about changing workerId to key off of generated names, got a 👍

I have tested this in my dev environment end-to-end, I used a custom build of worker-runner and was able to successfully register. Due to unrelated issues with the azure docker-worker VM tasks weren't claimed, but everything else works!*

\* to a reasonable observable degree of confidence