### PR TITLE
Bug 1616900 - wait for proto initialization in tests

### DIFF
--- a/changelog/bug-1616900.md
+++ b/changelog/bug-1616900.md
@@ -1,0 +1,3 @@
+level: silent
+reference: bug 1616900
+---

--- a/tools/taskcluster-worker-runner/protocol/protocol_test.go
+++ b/tools/taskcluster-worker-runner/protocol/protocol_test.go
@@ -44,11 +44,9 @@ func TestProtocol(t *testing.T) {
 		welcomeCaps = listOfStrings(msg.Properties["capabilities"])
 	})
 
-	done := make(chan bool)
 	var helloCaps []string
 	runnerProto.Register("hello", func(msg Message) {
 		helloCaps = listOfStrings(msg.Properties["capabilities"])
-		close(done)
 	})
 
 	RequireInitialized(t, runnerProto, false)
@@ -61,7 +59,8 @@ func TestProtocol(t *testing.T) {
 
 	workerProto.Start(true)
 
-	<-done
+	runnerProto.WaitUntilInitialized()
+	workerProto.WaitUntilInitialized()
 
 	RequireInitialized(t, workerProto, true)
 	RequireInitialized(t, runnerProto, true)


### PR DESCRIPTION
This avoids a subtle race condition where `runnerProto` is not
considered initialized until some time *after* the `hello` message is
received, as the function handling that message must run.

`go test -race` missed this because the use of a Mutex avoids an actual
data race.  The bug here is at a higher level than that.

Bugzilla Bug: [1616900](https://bugzilla.mozilla.org/show_bug.cgi?id=1616900)
