### PR TITLE
Bug 1616921 - enable gomod in renovate

### DIFF
--- a/package.json
+++ b/package.json
@@ -206,11 +206,15 @@
     "prHourlyLimit": 0,
     "prConcurrentLimit": 9,
     "rangeStrategy": "update-lockfile",
-    "ignoreDeps": [
-      "aws-sdk"
+    "packageRules": [
+      {
+        "packageNames": ["aws-sdk", "golang.org/x/sys"],
+        "schedule": ["after 9pm on sunday"]
+      }
     ],
     "enabledManagers": [
-      "npm"
+      "npm",
+      "gomod"
     ]
   },
   "eslintIgnore": [


### PR DESCRIPTION
This also switches from ignoring updates to frequently-updated packages
to just getting a weekly PR for those updates.  That will let us keep
reasonably up-to-date with those packages without being overwhelmed.

Bugzilla Bug: [1616921](https://bugzilla.mozilla.org/show_bug.cgi?id=1616921)
