### PR TITLE
Bug 1558240 - separate '=== Task Finished ===' from log output

### DIFF
--- a/changelog/bug-1558240.md
+++ b/changelog/bug-1558240.md
@@ -1,0 +1,4 @@
+level: patch
+reference: bug 1558240
+---
+Generic-worker now outputs a newline before `=== Task Finished ===`, to ensure that line is separated from other output in the logs.

--- a/workers/generic-worker/artifacts_multiuser_test.go
+++ b/workers/generic-worker/artifacts_multiuser_test.go
@@ -72,6 +72,7 @@ func TestChainOfTrustUpload(t *testing.T) {
 			Extracts: []string{
 				"hello world!",
 				"goodbye world!",
+				"",
 				"=== Task Finished ===",
 				"Exit Code: 0",
 			},

--- a/workers/generic-worker/main.go
+++ b/workers/generic-worker/main.go
@@ -1153,7 +1153,7 @@ func (task *TaskRun) Run() (err *ExecutionErrors) {
 	started := time.Now()
 	defer func() {
 		finished := time.Now()
-		task.Info("=== Task Finished ===")
+		task.Info("\n=== Task Finished ===")
 		// Round(0) forces wall time calculation instead of monotonic time in case machine slept etc
 		task.Info("Task Duration: " + finished.Round(0).Sub(started).String())
 	}()


### PR DESCRIPTION
Bugzilla Bug: [1558240](https://bugzilla.mozilla.org/show_bug.cgi?id=1558240)
