### PR TITLE
Bug 1600071: Fix overprovisioning for workers that are slow to boot up

### DIFF
--- a/changelog/bug-1600071.md
+++ b/changelog/bug-1600071.md
@@ -1,0 +1,4 @@
+level: patch
+reference: bug 1600071
+---
+Avoid overprovisioning for instances that take a long time to boot.

--- a/services/worker-manager/docs/providers.md
+++ b/services/worker-manager/docs/providers.md
@@ -86,7 +86,7 @@ It is, however, useful in testing.
 
 After calling `initiate`, the provisioner process enters a provisioning loop.
 Each iteration begins by calling `prepare()` for every provider.
-It then calls `provision({workerPool, existingCapacity})` or `deprovision({workerPool})` for each worker pool.
+It then calls `provision({workerPool, workerInfo})` or `deprovision({workerPool})` for each worker pool.
 Finally, it calls `cleanup()` for every provider.
 
 the `provision` method is responsible for measuring demand (such as by examining the number of pending tasks) and starting any workers required.

--- a/services/worker-manager/src/providers/aws.js
+++ b/services/worker-manager/src/providers/aws.js
@@ -82,7 +82,7 @@ class AwsProvider extends Provider {
     this._enqueue = cloud.enqueue.bind(cloud);
   }
 
-  async provision({workerPool, existingCapacity}) {
+  async provision({workerPool, workerInfo}) {
     const {workerPoolId} = workerPool;
 
     if (!workerPool.providerData[this.providerId]) {
@@ -95,7 +95,7 @@ class AwsProvider extends Provider {
       workerPoolId,
       minCapacity: workerPool.config.minCapacity,
       maxCapacity: workerPool.config.maxCapacity,
-      existingCapacity,
+      workerInfo,
     });
     if (toSpawn === 0) {
       return;

--- a/services/worker-manager/src/providers/azure.js
+++ b/services/worker-manager/src/providers/azure.js
@@ -102,12 +102,12 @@ class AzureProvider extends Provider {
     this.networkClient = new NetworkManagementClient(credentials, subscriptionId);
   }
 
-  async provision({workerPool, existingCapacity}) {
+  async provision({workerPool, workerInfo}) {
     const {workerPoolId} = workerPool;
     let toSpawn = await this.estimator.simple({
       workerPoolId,
       ...workerPool.config,
-      existingCapacity,
+      workerInfo,
     });
 
     if (toSpawn === 0) {

--- a/services/worker-manager/src/providers/google.js
+++ b/services/worker-manager/src/providers/google.js
@@ -191,7 +191,7 @@ class GoogleProvider extends Provider {
     }
   }
 
-  async provision({workerPool, existingCapacity}) {
+  async provision({workerPool, workerInfo}) {
     const {workerPoolId} = workerPool;
 
     if (!workerPool.providerData[this.providerId]) {
@@ -203,7 +203,7 @@ class GoogleProvider extends Provider {
     let toSpawn = await this.estimator.simple({
       workerPoolId,
       ...workerPool.config,
-      existingCapacity,
+      workerInfo,
     });
 
     if (toSpawn === 0) {

--- a/services/worker-manager/src/providers/provider.js
+++ b/services/worker-manager/src/providers/provider.js
@@ -47,7 +47,7 @@ class Provider {
   async prepare() {
   }
 
-  async provision({workerPool, existingCapacity}) {
+  async provision({workerPool, workerInfo}) {
   }
 
   async deprovision({workerPool}) {

--- a/services/worker-manager/src/providers/testing.js
+++ b/services/worker-manager/src/providers/testing.js
@@ -26,8 +26,8 @@ class TestingProvider extends Provider {
     }
   }
 
-  async provision({workerPool, existingCapacity}) {
-    this.monitor.notice('test-provision', {workerPoolId: workerPool.workerPoolId, existingCapacity});
+  async provision({workerPool, workerInfo}) {
+    this.monitor.notice('test-provision', {workerPoolId: workerPool.workerPoolId, workerInfo});
   }
 
   async deprovision({workerPool}) {

--- a/services/worker-manager/test/estimator_test.js
+++ b/services/worker-manager/test/estimator_test.js
@@ -14,11 +14,15 @@ helper.secrets.mockSuite(testing.suiteName(), ['azure'], function(mock, skipping
   });
 
   test('empty estimation', async function() {
+    const workerInfo = {
+      existingCapacity: 0,
+      requestedCapacity: 0,
+    };
     const estimate = await estimator.simple({
       workerPoolId: 'foo/bar',
       maxCapacity: 0,
       minCapacity: 0,
-      existingCapacity: 0,
+      workerInfo,
     });
 
     assert.strictEqual(estimate, 0);
@@ -27,11 +31,15 @@ helper.secrets.mockSuite(testing.suiteName(), ['azure'], function(mock, skipping
   });
 
   test('single estimation', async function() {
+    const workerInfo = {
+      existingCapacity: 0,
+      requestedCapacity: 0,
+    };
     const estimate = await estimator.simple({
       workerPoolId: 'foo/bar',
       maxCapacity: 1,
       minCapacity: 1,
-      existingCapacity: 0,
+      workerInfo,
     });
 
     assert.strictEqual(estimate, 1);
@@ -40,11 +48,15 @@ helper.secrets.mockSuite(testing.suiteName(), ['azure'], function(mock, skipping
   });
 
   test('satisfied estimation', async function() {
+    const workerInfo = {
+      existingCapacity: 0,
+      requestedCapacity: 1,
+    };
     const estimate = await estimator.simple({
       workerPoolId: 'foo/bar',
       maxCapacity: 1,
       minCapacity: 1,
-      existingCapacity: 1,
+      workerInfo,
     });
 
     assert.strictEqual(estimate, 0);
@@ -53,11 +65,15 @@ helper.secrets.mockSuite(testing.suiteName(), ['azure'], function(mock, skipping
   });
 
   test('over-satisfied estimation', async function() {
+    const workerInfo = {
+      existingCapacity: 10,
+      requestedCapacity: 0,
+    };
     const estimate = await estimator.simple({
       workerPoolId: 'foo/bar',
       maxCapacity: 1,
       minCapacity: 1,
-      existingCapacity: 10,
+      workerInfo,
     });
 
     assert.strictEqual(estimate, 0);

--- a/services/worker-manager/test/provider_aws_test.js
+++ b/services/worker-manager/test/provider_aws_test.js
@@ -110,7 +110,11 @@ helper.secrets.mockSuite(testing.suiteName(), ['azure'], function(mock, skipping
 
     test('positive test', async function() {
       const now = Date.now();
-      await provider.provision({workerPool, existingCapacity: 0});
+      const workerInfo = {
+        existingCapacity: 0,
+        requestedCapacity: 0,
+      };
+      await provider.provision({workerPool, workerInfo});
       const workers = await helper.Worker.scan({}, {});
 
       assert.notStrictEqual(workers.entries.length, 0);
@@ -141,7 +145,11 @@ helper.secrets.mockSuite(testing.suiteName(), ['azure'], function(mock, skipping
           maxCapacity: 34,
         };
       });
-      await provider.provision({workerPool, existingCapacity: 0});
+      const workerInfo = {
+        existingCapacity: 0,
+        requestedCapacity: 0,
+      };
+      await provider.provision({workerPool, workerInfo});
       const workers = await helper.Worker.scan({}, {});
 
       // capacity 34 at 6 per instance should be 6 instances..
@@ -159,7 +167,11 @@ helper.secrets.mockSuite(testing.suiteName(), ['azure'], function(mock, skipping
         }
       });
 
-      await provider.provision({workerPool, existingCapacity: 0});
+      const workerInfo = {
+        existingCapacity: 0,
+        requestedCapacity: 0,
+      };
+      await provider.provision({workerPool, workerInfo});
       const workers = await helper.Worker.scan({}, {});
 
       assert.notStrictEqual(workers.entries.length, 0);
@@ -193,7 +205,11 @@ helper.secrets.mockSuite(testing.suiteName(), ['azure'], function(mock, skipping
         }
       });
 
-      await provider.provision({workerPool, existingCapacity: 0});
+      const workerInfo = {
+        existingCapacity: 0,
+        requestedCapacity: 0,
+      };
+      await provider.provision({workerPool, workerInfo});
       const workers = await helper.Worker.scan({}, {});
 
       assert.notStrictEqual(workers.entries.length, 0);
@@ -231,7 +247,11 @@ helper.secrets.mockSuite(testing.suiteName(), ['azure'], function(mock, skipping
         }
       });
 
-      await provider.provision({workerPool, existingCapacity: 0});
+      const workerInfo = {
+        existingCapacity: 0,
+        requestedCapacity: 0,
+      };
+      await provider.provision({workerPool, workerInfo});
       const workers = await helper.Worker.scan({}, {});
 
       assert.notStrictEqual(workers.entries.length, 0);

--- a/services/worker-manager/test/provider_azure_test.js
+++ b/services/worker-manager/test/provider_azure_test.js
@@ -100,7 +100,11 @@ helper.secrets.mockSuite(testing.suiteName(), ['azure'], function(mock, skipping
 
   test('provisioning loop', async function() {
     const now = Date.now();
-    await provider.provision({workerPool, existingCapacity: 0});
+    const workerInfo = {
+      existingCapacity: 0,
+      requestedCapacity: 0,
+    };
+    await provider.provision({workerPool, workerInfo});
     const workers = await helper.Worker.scan({}, {});
     // Check that this is setting times correctly to within a second or so to allow for some time
     // for the provisioning loop
@@ -109,9 +113,13 @@ helper.secrets.mockSuite(testing.suiteName(), ['azure'], function(mock, skipping
   });
 
   test('provisioning loop with failure', async function() {
+    const workerInfo = {
+      existingCapacity: 0,
+      requestedCapacity: 0,
+    };
     // The fake throws an error on the second call
-    await provider.provision({workerPool, existingCapacity: 0});
-    await provider.provision({workerPool, existingCapacity: 0});
+    await provider.provision({workerPool, workerInfo});
+    await provider.provision({workerPool, workerInfo});
     const errors = await helper.WorkerPoolError.scan({}, {});
     assert.equal(errors.entries.length, 1);
     assert.equal(errors.entries[0].description, 'something went wrong');
@@ -120,10 +128,14 @@ helper.secrets.mockSuite(testing.suiteName(), ['azure'], function(mock, skipping
   });
 
   test('provisioning loop with rate limiting', async function() {
+    const workerInfo = {
+      existingCapacity: 0,
+      requestedCapacity: 0,
+    };
     // Notice this is only three loops, but instance insert fails on third try before succeeding on 4th
-    await provider.provision({workerPool, existingCapacity: 0});
-    await provider.provision({workerPool, existingCapacity: 0});
-    await provider.provision({workerPool, existingCapacity: 0});
+    await provider.provision({workerPool, workerInfo});
+    await provider.provision({workerPool, workerInfo});
+    await provider.provision({workerPool, workerInfo});
 
     const workers = await helper.Worker.scan({}, {});
     assert.equal(workers.entries.length, 2);
@@ -167,7 +179,11 @@ helper.secrets.mockSuite(testing.suiteName(), ['azure'], function(mock, skipping
   });
 
   test('worker-scan loop', async function() {
-    await provider.provision({workerPool, existingCapacity: 0});
+    const workerInfo = {
+      existingCapacity: 0,
+      requestedCapacity: 0,
+    };
+    await provider.provision({workerPool, workerInfo});
     const worker = await helper.Worker.load({
       workerPoolId: 'foo/bar',
       workerId: '123',

--- a/services/worker-manager/test/provider_google_test.js
+++ b/services/worker-manager/test/provider_google_test.js
@@ -75,7 +75,11 @@ helper.secrets.mockSuite(testing.suiteName(), ['azure'], function(mock, skipping
 
   test('provisioning loop', async function() {
     const now = Date.now();
-    await provider.provision({workerPool, existingCapacity: 0});
+    const workerInfo = {
+      existingCapacity: 0,
+      requestedCapacity: 0,
+    };
+    await provider.provision({workerPool, workerInfo});
     const workers = await helper.Worker.scan({}, {});
     // Check that this is setting times correctly to within a second or so to allow for some time
     // for the provisioning loop
@@ -87,9 +91,13 @@ helper.secrets.mockSuite(testing.suiteName(), ['azure'], function(mock, skipping
   });
 
   test('provisioning loop with failure', async function() {
+    const workerInfo = {
+      existingCapacity: 0,
+      requestedCapacity: 0,
+    };
     // The fake throws an error on the second call
-    await provider.provision({workerPool, existingCapacity: 0});
-    await provider.provision({workerPool, existingCapacity: 0});
+    await provider.provision({workerPool, workerInfo});
+    await provider.provision({workerPool, workerInfo});
     const errors = await helper.WorkerPoolError.scan({}, {});
     assert.equal(errors.entries.length, 1);
     assert.equal(errors.entries[0].description, 'something went wrong');
@@ -98,10 +106,14 @@ helper.secrets.mockSuite(testing.suiteName(), ['azure'], function(mock, skipping
   });
 
   test('provisioning loop with rate limiting', async function() {
+    const workerInfo = {
+      existingCapacity: 0,
+      requestedCapacity: 0,
+    };
     // Notice this is only three loops, but instance insert fails on third try before succeeding on 4th
-    await provider.provision({workerPool, existingCapacity: 0});
-    await provider.provision({workerPool, existingCapacity: 0});
-    await provider.provision({workerPool, existingCapacity: 0});
+    await provider.provision({workerPool, workerInfo});
+    await provider.provision({workerPool, workerInfo});
+    await provider.provision({workerPool, workerInfo});
 
     const workers = await helper.Worker.scan({}, {});
     assert.equal(workers.entries.length, 2);
@@ -149,7 +161,11 @@ helper.secrets.mockSuite(testing.suiteName(), ['azure'], function(mock, skipping
   });
 
   test('worker-scan loop', async function() {
-    await provider.provision({workerPool, existingCapacity: 0});
+    const workerInfo = {
+      existingCapacity: 0,
+      requestedCapacity: 0,
+    };
+    await provider.provision({workerPool, workerInfo});
     const worker = await helper.Worker.load({
       workerPoolId: 'foo/bar',
       workerId: '123',

--- a/services/worker-manager/test/provisioner_test.js
+++ b/services/worker-manager/test/provisioner_test.js
@@ -48,7 +48,7 @@ helper.secrets.mockSuite(testing.suiteName(), ['azure'], function(mock, skipping
                 msg => msg.Type === 'test-provision' && msg.Fields.workerPoolId === wt.workerPoolId), {
                 Logger: `taskcluster.worker-manager.provider.${pId}`,
                 Type: 'test-provision',
-                Fields: {workerPoolId: wt.workerPoolId, existingCapacity: wt.existingCapacity},
+                Fields: {workerPoolId: wt.workerPoolId, workerInfo: {}},
                 Severity: LEVELS.notice,
               });
           }));
@@ -171,6 +171,7 @@ helper.secrets.mockSuite(testing.suiteName(), ['azure'], function(mock, skipping
       workers: [
         {
           workerPoolId: 'ff/ee',
+          existingCapacity: 0,
           workerGroup: 'whatever',
           workerId: 'testing-OLD',
           providerId: 'testing1',
@@ -184,6 +185,7 @@ helper.secrets.mockSuite(testing.suiteName(), ['azure'], function(mock, skipping
         },
         {
           workerPoolId: 'ff/ee',
+          existingCapacity: 0,
           workerGroup: 'whatever',
           workerId: 'testing-123',
           providerId: 'testing2',
@@ -429,7 +431,7 @@ helper.secrets.mockSuite(testing.suiteName(), ['azure'], function(mock, skipping
           msg => msg.Type === 'test-provision' && msg.Fields.workerPoolId === workerPool.workerPoolId), {
           Logger: `taskcluster.worker-manager.provider.${workerPool.input.providerId}`,
           Type: 'test-provision',
-          Fields: {workerPoolId: workerPool.workerPoolId, existingCapacity: 0},
+          Fields: {workerPoolId: workerPool.workerPoolId, workerInfo: {}},
           Severity: LEVELS.notice,
         });
 
@@ -468,7 +470,7 @@ helper.secrets.mockSuite(testing.suiteName(), ['azure'], function(mock, skipping
           msg => msg.Type === 'test-provision' && msg.Fields.workerPoolId === workerPool.workerPoolId), {
           Logger: `taskcluster.worker-manager.provider.${workerPool.input.providerId}`,
           Type: 'test-provision',
-          Fields: {workerPoolId: workerPool.workerPoolId, existingCapacity: 0},
+          Fields: {workerPoolId: workerPool.workerPoolId, workerInfo: {}},
           Severity: LEVELS.notice,
         });
 
@@ -491,7 +493,7 @@ helper.secrets.mockSuite(testing.suiteName(), ['azure'], function(mock, skipping
           msg => msg.Type === 'test-provision' && msg.Fields.workerPoolId === workerPool.workerPoolId), {
           Logger: `taskcluster.worker-manager.provider.${workerPool.input.providerId}`,
           Type: 'test-provision',
-          Fields: {workerPoolId: workerPool.workerPoolId, existingCapacity: 0},
+          Fields: {workerPoolId: workerPool.workerPoolId, workerInfo: {}},
           Severity: LEVELS.notice,
         });
     });


### PR DESCRIPTION
For workers that are booting, worker-manager considers them as "ready"
and possibly running tasks, and it ignores the fact that they will
eventually claim the current pending tasks. This is not a problem if the
instances of these workers boot relatively quickly.

If the instances take a long time to get ready (like baremetal
instances), worker-manager will keep spawning more instances while there
are pending tasks and until we reach the maximum capacity, causing an
overprovisioning problem.

We fix this by subtracting the number of instances in the REQUESTED
state from the total number to spawn.
