### PR TITLE
Avoid closing the listener to which an https.Server was attached

### DIFF
--- a/changelog/enDr6FUCT_SDvWCgQcd6SQ.md
+++ b/changelog/enDr6FUCT_SDvWCgQcd6SQ.md
@@ -1,0 +1,2 @@
+level: silent
+---

--- a/workers/generic-worker/expose/local.go
+++ b/workers/generic-worker/expose/local.go
@@ -46,21 +46,6 @@ func (exposer *localExposer) getURL(listener net.Listener, scheme string) *url.U
 	}
 }
 
-// close is a utility for exposures
-func (exposer *localExposer) close(listener net.Listener, proxy exposeProxy) error {
-	if proxy != nil {
-		if err := proxy.Close(); err != nil {
-			return err
-		}
-	}
-	if listener != nil {
-		if err := listener.Close(); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
 type localHTTPExposure struct {
 	exposer    *localExposer
 	targetPort uint16
@@ -87,7 +72,13 @@ func (exposure *localHTTPExposure) start() error {
 }
 
 func (exposure *localHTTPExposure) Close() error {
-	return exposure.exposer.close(exposure.listener, exposure.proxy)
+	if exposure.proxy != nil {
+		if err := exposure.proxy.Close(); err != nil {
+			return err
+		}
+	}
+	exposure.proxy = nil
+	return nil
 }
 
 func (exposure *localHTTPExposure) GetURL() *url.URL {
@@ -120,7 +111,13 @@ func (exposure *localPortExposure) start() error {
 }
 
 func (exposure *localPortExposure) Close() error {
-	return exposure.exposer.close(exposure.listener, exposure.proxy)
+	if exposure.proxy != nil {
+		if err := exposure.proxy.Close(); err != nil {
+			return err
+		}
+	}
+	exposure.proxy = nil
+	return nil
 }
 
 func (exposure *localPortExposure) GetURL() *url.URL {

--- a/workers/generic-worker/expose/local_test.go
+++ b/workers/generic-worker/expose/local_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestConstructor(t *testing.T) {
@@ -46,7 +47,10 @@ func TestLocalExposeHTTP(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ExposeHTTP returned an error: %v", err)
 	}
-	defer exposure.Close()
+	defer func() {
+		err := exposure.Close()
+		require.NoError(t, err)
+	}()
 
 	gotURL := exposure.GetURL()
 	host, port, _ := net.SplitHostPort(gotURL.Host)

--- a/workers/generic-worker/livelog.go
+++ b/workers/generic-worker/livelog.go
@@ -145,6 +145,7 @@ func (l *LiveLogTask) Stop(err *ExecutionErrors) {
 
 	if l.exposure != nil {
 		closeErr := l.exposure.Close()
+		l.exposure = nil
 		if closeErr != nil {
 			log.Printf("WARNING: could not terminate livelog exposure: %s", closeErr)
 		}


### PR DESCRIPTION
In #2408 I initially thought perhaps we were closing the exposure twice, so this also adds a commit to set `l.exposure` to nil after closing it, avoiding that particular situation.

Github Bug/Issue: Refs #2408