### PR TITLE
Grant scope to the worker to terminate itself

### DIFF
--- a/changelog/EMxihKGCRHmzKZT9nXtG-w.md
+++ b/changelog/EMxihKGCRHmzKZT9nXtG-w.md
@@ -1,0 +1,3 @@
+level: patch
+---
+Update `registerWorker` API to grant scopes for workers to terminate themselves

--- a/clients/client-go/tcworkermanager/types.go
+++ b/clients/client-go/tcworkermanager/types.go
@@ -38,6 +38,7 @@ type (
 	// * `queue:worker-id:<workerGroup>/<workerId>`
 	// * `secrets:get:worker-pool:<workerPoolId>`
 	// * `queue:claim-work:<workerPoolId>`
+	// * `worker-manager:remove-worker:<workerPoolId>/<workerGroup>/<workerId>`
 	Credentials struct {
 		AccessToken string `json:"accessToken"`
 
@@ -122,6 +123,7 @@ type (
 		// * `queue:worker-id:<workerGroup>/<workerId>`
 		// * `secrets:get:worker-pool:<workerPoolId>`
 		// * `queue:claim-work:<workerPoolId>`
+		// * `worker-manager:remove-worker:<workerPoolId>/<workerGroup>/<workerId>`
 		Credentials Credentials `json:"credentials"`
 
 		// Time at which the included credentials will expire.  Workers must either

--- a/generated/references.json
+++ b/generated/references.json
@@ -438,7 +438,7 @@
       "properties": {
         "credentials": {
           "additionalProperties": false,
-          "description": "The credentials the worker\nwill need to perform its work.  Specifically, credentials with scopes\n* `assume:worker-pool:<workerPoolId>`\n* `assume:worker-id:<workerGroup>/<workerId>`\n* `queue:worker-id:<workerGroup>/<workerId>`\n* `secrets:get:worker-pool:<workerPoolId>`\n* `queue:claim-work:<workerPoolId>`\n",
+          "description": "The credentials the worker\nwill need to perform its work.  Specifically, credentials with scopes\n* `assume:worker-pool:<workerPoolId>`\n* `assume:worker-id:<workerGroup>/<workerId>`\n* `queue:worker-id:<workerGroup>/<workerId>`\n* `secrets:get:worker-pool:<workerPoolId>`\n* `queue:claim-work:<workerPoolId>`\n* `worker-manager:remove-worker:<workerPoolId>/<workerGroup>/<workerId>`\n",
           "properties": {
             "accessToken": {
               "type": "string"

--- a/services/worker-manager/schemas/v1/register-worker-response.yml
+++ b/services/worker-manager/schemas/v1/register-worker-response.yml
@@ -22,6 +22,7 @@ properties:
       * `queue:worker-id:<workerGroup>/<workerId>`
       * `secrets:get:worker-pool:<workerPoolId>`
       * `queue:claim-work:<workerPoolId>`
+      * `worker-manager:remove-worker:<workerPoolId>/<workerGroup>/<workerId>`
     properties:
       accessToken:
         type: string

--- a/services/worker-manager/src/api.js
+++ b/services/worker-manager/src/api.js
@@ -669,6 +669,7 @@ builder.declare({
       `secrets:get:worker-type:${worker.workerPoolId}`, // deprecated secret name
       `secrets:get:worker-pool:${worker.workerPoolId}`,
       `queue:claim-work:${worker.workerPoolId}`,
+      `worker-manager:remove-worker:${worker.workerPoolId}/${worker.workerGroup}/${worker.workerId}`,
     ],
     start: taskcluster.fromNow('-15 minutes'),
     expiry: expires,


### PR DESCRIPTION
We are having issues with the shutdown behavior in AWS instances.
When the worker is done, it calls `shutdown -h now` to stop the
instances and then the `workerManager` can terminate it later. The
problem is that sometimes the shutdown process stalls inside the
instance, hanging the worker forever.

Granting the scope to call `registerWorker` allows the worker to request
`workerManager` to terminate the worker, avoiding the shutdown issue.