### PR TITLE
Bug 1616922 - adapt TestFileArtifactTwiceInPayload to disallow same artifact twice

### DIFF
--- a/changelog/aeki4OImR8iFYCwyo-Mr1A.md
+++ b/changelog/aeki4OImR8iFYCwyo-Mr1A.md
@@ -1,0 +1,2 @@
+level: silent
+---

--- a/changelog/bug-1616922.md
+++ b/changelog/bug-1616922.md
@@ -1,4 +1,8 @@
 level: patch
 reference: bug 1616922
 ---
-Generic-Worker documentation is now included in the Taskcluster documentation site.
+Generic-Worker documentation is now included in the Taskcluster documentation site,
+and the generic-worker task payload has been slightly tightened.
+
+* `task.payload.artifacts` must contain unique items
+* `task.payload.onExitStatus.retry` must contain unique items

--- a/workers/generic-worker/artifacts_broken_on_docker_test.go
+++ b/workers/generic-worker/artifacts_broken_on_docker_test.go
@@ -135,28 +135,7 @@ func TestFileArtifactTwiceInPayload(t *testing.T) {
 	}
 	td := testTask(t)
 
-	taskID := submitAndAssert(t, td, payload, "completed", "completed")
-
-	artifacts, err := testQueue.ListArtifacts(taskID, "0", "", "")
-
-	if err != nil {
-		t.Fatalf("Error listing artifacts: %v", err)
-	}
-
-	if l := len(artifacts.Artifacts); l != 3 {
-		t.Fatalf("Was expecting 3 artifacts, but got %v", l)
-	}
-
-	// use the artifact names as keys in a map, so we can look up that each key exists
-	a := map[string]bool{
-		artifacts.Artifacts[0].Name: true,
-		artifacts.Artifacts[1].Name: true,
-		artifacts.Artifacts[2].Name: true,
-	}
-
-	if !a["public/build/X.txt"] || !a["public/logs/live.log"] || !a["public/logs/live_backing.log"] {
-		t.Fatalf("Wrong artifacts presented in task %v", taskID)
-	}
+	_ = submitAndAssert(t, td, payload, "exception", "malformed-payload")
 }
 
 func TestArtifactIncludedAsFileAndDirectoryInPayload(t *testing.T) {


### PR DESCRIPTION
A [test failure](https://community-tc.services.mozilla.com/tasks/groups/PoP3IcGlTHyVUYov269yyw) crept in for `TestFileArtifactTwiceInPayload` in #2399 but went unnoticed due to [bug 1533235](https://bugzilla.mozilla.org/show_bug.cgi?id=1533235).

The failure is due to a slight change in behaviour introduced in #2399 that disallows duplicate artifacts being entered in a task payload. Previously it was allowed, as no conflict of information ensues from having identical entries. It was a [permissive approach](https://en.wikipedia.org/wiki/Robustness_principle) but I'm also ok with us being more restrictive, as it may help avoid bugs in downstream code that parse task payloads and assume that entries are unique.