### PR TITLE
Bug 1433854 - remove files and directories more forcefully on windows

### DIFF
--- a/changelog/bug-1433854.md
+++ b/changelog/bug-1433854.md
@@ -1,0 +1,14 @@
+level: patch
+reference: bug 1433854
+---
+Task directories from previous task runs on Windows are now more aggressively
+purged.
+
+This should reduce the amount of time spent trying to delete task directories
+between task runs, and also the amount of logging, in addition to freeing up
+more disk space.
+
+This issue always existed on the Windows version of generic-worker. A similar
+issue existed on macOS and Linux but was fixed in bug 1615312 which was
+initially tagged for release in v25.0.0, but first appeared in release 25.3.0
+due to some problems with the release process.

--- a/workers/generic-worker/multiuser_windows.go
+++ b/workers/generic-worker/multiuser_windows.go
@@ -46,8 +46,12 @@ func deleteDir(path string) error {
 	}
 	log.Print("WARNING: could not delete directory '" + path + "' with os.RemoveAll(path) method")
 	log.Printf("%v", err)
-	log.Print("Trying to remove directory '" + path + "' via del command...")
+	log.Print("Trying to remove directory '" + path + "' via del and rmdir commands...")
 	err = host.Run("cmd", "/c", "del", "/s", "/q", "/f", path)
+	if err != nil {
+		log.Printf("%#v", err)
+	}
+	err = host.Run("cmd", "/c", "rmdir", "/s", "/q", path)
 	if err != nil {
 		log.Printf("%#v", err)
 	}


### PR DESCRIPTION
Bugzilla Bug: [1433854](https://bugzilla.mozilla.org/show_bug.cgi?id=1433854)

Tested and working on Windows 10 / ARM laptop. After upgrading the worker to the version built from this branch, the several hundred previous task directories lurking on the machine were deleted successfully. Note this was causing around 15 min delay between a task completing and the next one starting, so this is a big performance gain on workers that didn't have their own cleanup (Note OpenCloudConfig was doing a similar cleanup itself).

Note, the inspiration for this approach came from [this article](https://www.ghacks.net/2017/07/18/how-to-delete-large-folders-in-windows-super-fast/).