### PR TITLE
Revert "Bug 1558240 - separate '=== Task Finished ===' from log output"

### DIFF
--- a/changelog/bug-1558240.md
+++ b/changelog/bug-1558240.md
@@ -1,0 +1,4 @@
+level: patch
+reference: bug 1558240
+---
+The generic-worker logging change that appeared in v25.4.0 has been reverted.

--- a/workers/generic-worker/artifacts_multiuser_test.go
+++ b/workers/generic-worker/artifacts_multiuser_test.go
@@ -72,7 +72,6 @@ func TestChainOfTrustUpload(t *testing.T) {
 			Extracts: []string{
 				"hello world!",
 				"goodbye world!",
-				"",
 				"=== Task Finished ===",
 				"Exit Code: 0",
 			},

--- a/workers/generic-worker/main.go
+++ b/workers/generic-worker/main.go
@@ -1153,7 +1153,7 @@ func (task *TaskRun) Run() (err *ExecutionErrors) {
 	started := time.Now()
 	defer func() {
 		finished := time.Now()
-		task.Info("\n=== Task Finished ===")
+		task.Info("=== Task Finished ===")
 		// Round(0) forces wall time calculation instead of monotonic time in case machine slept etc
 		task.Info("Task Duration: " + finished.Round(0).Sub(started).String())
 	}()


### PR DESCRIPTION
Reverts taskcluster/taskcluster#2406

[Bug 1558240](https://bugzil.la/1558240) was raised for docker-worker, so unfortunately this fix doesn't apply. Although generic-worker logs a similar line, it does not log it directly after the command output (it logs the exit status of the command after the command output). Also note that in generic-worker there can be several commands, so a fix would need to occur once per command rather than once per task. A unit test would have demonstrated this. 😜  Also note each log line is prefixed by a timestamp, so the fix would have left a trailing timestamp at the end of the command output too.

I'm also not sure a new line should be added, in the same way that if a command executed from a bash session completes without outputting a trailing newline character, the new bash prompt will appear directly after the output, without a new line. This informs the user that no trailing newline was present. It reflects what the command actually output, rather than what the shell thinks the command should have output. If a new line should be present, I think it is more appropriate for the chosen command to be modified to produce it, since the logger should be agnostic to the command output.

In any case, since the fix didn't work, and was for the wrong worker implementation, I'm rolling back.