### PR TITLE
Implement "shutdown" message

### DIFF
--- a/changelog/YJtFHaNFSRiqY9Gpa3fEEA.md
+++ b/changelog/YJtFHaNFSRiqY9Gpa3fEEA.md
@@ -1,0 +1,4 @@
+level: patch
+---
+AWS, GCP and Azure providers support the "shutdown" message, which requests
+the worker-manager to terminate the instance

--- a/tools/taskcluster-worker-runner/protocol.md
+++ b/tools/taskcluster-worker-runner/protocol.md
@@ -53,6 +53,17 @@ Before the connection is initialized, the connection's capabilities are unknown,
 
 The following sections describe the defined message types, each under a heading giving the corresponding capability.
 
+### shutdown
+
+When worker-runner receives this message, and the provider supports it, it will invoke the function `RemoveWorker` from
+worker-manager. If the function fails, then we initiate a system shutdown.
+
+```
+~{"type": "shutdown"}
+```
+
+This is a no response message.
+
 ### graceful-termination
 
 Graceful termination is a way of indicating that the worker should shut down gracefully but quickly.

--- a/tools/taskcluster-worker-runner/protocol/capabilities.go
+++ b/tools/taskcluster-worker-runner/protocol/capabilities.go
@@ -2,10 +2,6 @@ package protocol
 
 import "sort"
 
-var KnownCapabilities = []string{
-	"graceful-termination",
-}
-
 type Capabilities struct {
 	// use a map as a poor-man's set
 	capabilities map[string]bool
@@ -15,10 +11,6 @@ func EmptyCapabilities() *Capabilities {
 	return &Capabilities{
 		capabilities: make(map[string]bool),
 	}
-}
-
-func FullCapabilities() *Capabilities {
-	return FromCapabilitiesList(KnownCapabilities)
 }
 
 func FromCapabilitiesList(caplist []string) *Capabilities {

--- a/tools/taskcluster-worker-runner/protocol/capabilities_test.go
+++ b/tools/taskcluster-worker-runner/protocol/capabilities_test.go
@@ -22,7 +22,8 @@ func TestAdd(t *testing.T) {
 }
 
 func TestRemove(t *testing.T) {
-	caps := FullCapabilities()
+	caps := EmptyCapabilities()
+	caps.Add("graceful-termination")
 	assert.True(t, caps.Has("graceful-termination"))
 	caps.Remove("graceful-termination")
 	assert.False(t, caps.Has("graceful-termination"))

--- a/tools/taskcluster-worker-runner/protocol/protocol_test.go
+++ b/tools/taskcluster-worker-runner/protocol/protocol_test.go
@@ -66,9 +66,6 @@ func TestProtocol(t *testing.T) {
 	RequireInitialized(t, runnerProto, true)
 
 	require.True(t, gotWelcome)
-	require.Equal(t, welcomeCaps, KnownCapabilities)
-	require.Equal(t, helloCaps, KnownCapabilities)
-
-	require.True(t, workerProto.Capable("graceful-termination"))
-	require.True(t, runnerProto.Capable("graceful-termination"))
+	require.Equal(t, welcomeCaps, EmptyCapabilities().List())
+	require.Equal(t, helloCaps, EmptyCapabilities().List())
 }

--- a/tools/taskcluster-worker-runner/provider/aws/awsprovider_test.go
+++ b/tools/taskcluster-worker-runner/provider/aws/awsprovider_test.go
@@ -96,6 +96,14 @@ func TestAWSConfigureRun(t *testing.T) {
 	require.Equal(t, "aws", state.WorkerLocation["cloud"])
 	require.Equal(t, "us-west-2", state.WorkerLocation["region"])
 	require.Equal(t, "us-west-2a", state.WorkerLocation["availabilityZone"])
+
+	transp := protocol.NewFakeTransport()
+	proto := protocol.NewProtocol(transp)
+	proto.SetInitialized()
+
+	p.SetProtocol(proto)
+	require.NoError(t, p.WorkerStarted(&state))
+	require.True(t, proto.Capable("shutdown"))
 }
 
 func TestCheckTerminationTime(t *testing.T) {

--- a/tools/taskcluster-worker-runner/provider/azure/azure_test.go
+++ b/tools/taskcluster-worker-runner/provider/azure/azure_test.go
@@ -115,6 +115,14 @@ func TestConfigureRun(t *testing.T) {
 
 	require.Equal(t, "azure", state.WorkerLocation["cloud"])
 	require.Equal(t, "uswest", state.WorkerLocation["region"])
+
+	transp := protocol.NewFakeTransport()
+	proto := protocol.NewProtocol(transp)
+	proto.SetInitialized()
+
+	p.SetProtocol(proto)
+	require.NoError(t, p.WorkerStarted(&state))
+	require.True(t, proto.Capable("shutdown"))
 }
 
 func TestCheckTerminationTime(t *testing.T) {

--- a/tools/taskcluster-worker-runner/provider/google/google.go
+++ b/tools/taskcluster-worker-runner/provider/google/google.go
@@ -2,6 +2,7 @@ package google
 
 import (
 	"fmt"
+	"log"
 	"strings"
 
 	tcclient "github.com/taskcluster/taskcluster/v27/clients/client-go"
@@ -113,11 +114,20 @@ func (p *GoogleProvider) SetProtocol(proto *protocol.Protocol) {
 	p.proto = proto
 }
 
-func (p *GoogleProvider) WorkerStarted() error {
+func (p *GoogleProvider) WorkerStarted(state *run.State) error {
+	p.proto.Register("shutdown", func(msg protocol.Message) {
+		err := provider.RemoveWorker(state, p.workerManagerClientFactory)
+		if err != nil {
+			log.Printf("Shutdown error: %v\n", err)
+		}
+	})
+	p.proto.Capabilities.Add("shutdown")
+	p.proto.Capabilities.Add("graceful-termination")
+
 	return nil
 }
 
-func (p *GoogleProvider) WorkerFinished() error {
+func (p *GoogleProvider) WorkerFinished(state *run.State) error {
 	return nil
 }
 

--- a/tools/taskcluster-worker-runner/provider/google/google_test.go
+++ b/tools/taskcluster-worker-runner/provider/google/google_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/taskcluster/taskcluster/v27/tools/taskcluster-worker-runner/cfg"
+	"github.com/taskcluster/taskcluster/v27/tools/taskcluster-worker-runner/protocol"
 	"github.com/taskcluster/taskcluster/v27/tools/taskcluster-worker-runner/run"
 	"github.com/taskcluster/taskcluster/v27/tools/taskcluster-worker-runner/tc"
 )
@@ -101,4 +102,12 @@ func TestGoogleConfigureRun(t *testing.T) {
 	require.Equal(t, "google", state.WorkerLocation["cloud"])
 	require.Equal(t, "in-central1", state.WorkerLocation["region"])
 	require.Equal(t, "in-central1-b", state.WorkerLocation["zone"])
+
+	transp := protocol.NewFakeTransport()
+	proto := protocol.NewProtocol(transp)
+	proto.SetInitialized()
+
+	p.SetProtocol(proto)
+	require.NoError(t, p.WorkerStarted(&state))
+	require.True(t, proto.Capable("shutdown"))
 }

--- a/tools/taskcluster-worker-runner/provider/provider/common.go
+++ b/tools/taskcluster-worker-runner/provider/provider/common.go
@@ -3,12 +3,18 @@ package provider
 import (
 	"encoding/json"
 	"fmt"
+	"log"
 	"time"
 
 	"github.com/taskcluster/taskcluster/v27/clients/client-go/tcworkermanager"
 	"github.com/taskcluster/taskcluster/v27/tools/taskcluster-worker-runner/run"
 	"github.com/taskcluster/taskcluster/v27/tools/taskcluster-worker-runner/tc"
 )
+
+// WorkerInfo contains the information to identify the worker
+type WorkerInfo struct {
+	WorkerPoolID, WorkerGroup, WorkerID string
+}
 
 // Register this worker with the worker-manager, and update the state with the parameters and the results.
 func RegisterWorker(state *run.State, wm tc.WorkerManager, workerPoolID, providerID, workerGroup, workerID string, workerIdentityProofMap map[string]interface{}) (*json.RawMessage, error) {
@@ -44,4 +50,30 @@ func RegisterWorker(state *run.State, wm tc.WorkerManager, workerPoolID, provide
 	}
 
 	return &wc, nil
+}
+
+// RemoveWorker will request worker-manager to terminate the given worker, if it
+// fails, it shuts down us
+func RemoveWorker(state *run.State, factory tc.WorkerManagerClientFactory) error {
+	shutdown := func() error {
+		log.Printf("Falling back to system shutdown")
+		if err := Shutdown(); err != nil {
+			log.Printf("Error shutting down the worker: %v\n", err)
+			return err
+		}
+		return nil
+	}
+
+	wc, err := factory(state.RootURL, &state.Credentials)
+	if err != nil {
+		log.Printf("Error instanciating worker-manager client: %v\n", err)
+		return shutdown()
+	}
+
+	if err = wc.RemoveWorker(state.WorkerPoolID, state.WorkerGroup, state.WorkerID); err != nil {
+		log.Printf("Error removing the worker: %v\n", err)
+		return shutdown()
+	}
+
+	return err
 }

--- a/tools/taskcluster-worker-runner/provider/provider/iface.go
+++ b/tools/taskcluster-worker-runner/provider/provider/iface.go
@@ -25,10 +25,10 @@ type Provider interface {
 	// provider-specific things that should occur while the worker is running.
 	// Note that this is called before the protocol has started, so it will still
 	// have no capabilities.
-	WorkerStarted() error
+	WorkerStarted(state *run.State) error
 
 	// The worker has exited.  Handle any necessary communication with the provider.
 	// Note that this method may not always be called, e.g., in the event of a system
 	// failure.
-	WorkerFinished() error
+	WorkerFinished(state *run.State) error
 }

--- a/tools/taskcluster-worker-runner/provider/provider/shutdown_linux.go
+++ b/tools/taskcluster-worker-runner/provider/provider/shutdown_linux.go
@@ -1,0 +1,8 @@
+package provider
+
+import "os/exec"
+
+// Shutdown spawns the "shutdown -h now" command to halt the machine
+func Shutdown() error {
+	return exec.Command("shutdown", "-h", "now").Run()
+}

--- a/tools/taskcluster-worker-runner/provider/provider/shutdown_windows.go
+++ b/tools/taskcluster-worker-runner/provider/provider/shutdown_windows.go
@@ -1,0 +1,8 @@
+package provider
+
+import "golang.org/x/sys/windows"
+
+// Shutdown initiates a system shutdown
+func Shutdown() error {
+	return windows.InitiateSystemShutdownEx(nil, nil, 0, true, false, 0)
+}

--- a/tools/taskcluster-worker-runner/provider/standalone/standalone.go
+++ b/tools/taskcluster-worker-runner/provider/standalone/standalone.go
@@ -67,11 +67,11 @@ func (p *StandaloneProvider) UseCachedRun(run *run.State) error {
 func (p *StandaloneProvider) SetProtocol(proto *protocol.Protocol) {
 }
 
-func (p *StandaloneProvider) WorkerStarted() error {
+func (p *StandaloneProvider) WorkerStarted(state *run.State) error {
 	return nil
 }
 
-func (p *StandaloneProvider) WorkerFinished() error {
+func (p *StandaloneProvider) WorkerFinished(state *run.State) error {
 	return nil
 }
 

--- a/tools/taskcluster-worker-runner/provider/static/static.go
+++ b/tools/taskcluster-worker-runner/provider/static/static.go
@@ -91,11 +91,11 @@ func (p *StaticProvider) SetProtocol(proto *protocol.Protocol) {
 	p.proto = proto
 }
 
-func (p *StaticProvider) WorkerStarted() error {
+func (p *StaticProvider) WorkerStarted(state *run.State) error {
 	return nil
 }
 
-func (p *StaticProvider) WorkerFinished() error {
+func (p *StaticProvider) WorkerFinished(state *run.State) error {
 	return nil
 }
 

--- a/tools/taskcluster-worker-runner/runner/run.go
+++ b/tools/taskcluster-worker-runner/runner/run.go
@@ -176,7 +176,7 @@ func Run(configFile string) (state run.State, err error) {
 		return
 	}
 
-	err = provider.WorkerStarted()
+	err = provider.WorkerStarted(&state)
 	if err != nil {
 		return
 	}
@@ -192,7 +192,7 @@ func Run(configFile string) (state run.State, err error) {
 
 	// shut things down
 
-	err = provider.WorkerFinished()
+	err = provider.WorkerFinished(&state)
 	if err != nil {
 		return
 	}

--- a/tools/taskcluster-worker-runner/tc/fakeworkermanager.go
+++ b/tools/taskcluster-worker-runner/tc/fakeworkermanager.go
@@ -46,6 +46,10 @@ func (wm *FakeWorkerManager) RegisterWorker(payload *tcworkermanager.RegisterWor
 	}, nil
 }
 
+func (wm *FakeWorkerManager) RemoveWorker(workerPoolID, workerGroup, workerID string) error {
+	return nil
+}
+
 // Get the single registration that has occurred, or an error if there are not
 // exactly one.  This resets the list of registrations in the process.
 func FakeWorkerManagerRegistration() (*tcworkermanager.RegisterWorkerRequest, error) {

--- a/tools/taskcluster-worker-runner/tc/fakeworkermanager_test.go
+++ b/tools/taskcluster-worker-runner/tc/fakeworkermanager_test.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/taskcluster/taskcluster/v27/clients/client-go/tcworkermanager"
 )
 
@@ -17,7 +17,11 @@ func TestWorkerManagerRegisterWorker(t *testing.T) {
 		WorkerIdentityProof: json.RawMessage{},
 		WorkerPoolID:        "w/p",
 	})
-	if assert.NoError(t, err) {
-		assert.Equal(t, "testing", reg.Credentials.ClientID)
-	}
+	require.NoError(t, err)
+	require.Equal(t, "testing", reg.Credentials.ClientID)
+}
+
+func TestWorkerManagerRemoveWorker(t *testing.T) {
+	wm, _ := FakeWorkerManagerClientFactory("https://tc.example.com", nil)
+	require.NoError(t, wm.RemoveWorker("w/p", "wg", "wid"))
 }

--- a/tools/taskcluster-worker-runner/tc/workermanager.go
+++ b/tools/taskcluster-worker-runner/tc/workermanager.go
@@ -9,6 +9,7 @@ import (
 // use of fakes that also match this interface.
 type WorkerManager interface {
 	RegisterWorker(payload *tcworkermanager.RegisterWorkerRequest) (*tcworkermanager.RegisterWorkerResponse, error)
+	RemoveWorker(workerPoolID, workerGroup, workerID string) error
 }
 
 // A factory type that can create new instances of the WorkerManager interface.


### PR DESCRIPTION
The "shutdown" message is implemented for AWS, Azure and GCP providers.
When received, worker-runner will call the worker-worker manager
RemoveWorker API. If it fails, it will fall back to the system
shutdown.

For Linux, the "system shutdown" is the execution of the command
"shutdown -h now". For Windows, it will call the Win32 API
InitiateSystemShutdownEx.

The static and standalone providers don't implement the "shutdown"
message.
