### PR TITLE
Bug 1559434 - encode slashes in pulse passwords

### DIFF
--- a/changelog/bug-1559434.md
+++ b/changelog/bug-1559434.md
@@ -1,0 +1,4 @@
+level: patch
+reference: bug 1559434
+---
+Pulse passwords are now correctly encoded and can contain `/` characters.

--- a/libraries/pulse/src/credentials.js
+++ b/libraries/pulse/src/credentials.js
@@ -20,9 +20,9 @@ const pulseCredentials = ({username, password, hostname, vhost}) => {
     return {
       connectionString: [
         'amqps://', // Ensure that we're using SSL
-        encodeURI(username),
+        encodeURIComponent(username),
         ':',
-        encodeURI(password),
+        encodeURIComponent(password),
         '@',
         hostname,
         ':',

--- a/libraries/pulse/test/credentials_test.js
+++ b/libraries/pulse/test/credentials_test.js
@@ -38,6 +38,6 @@ suite(testing.suiteName(), function() {
 
     assert.equal(
       credentials.connectionString,
-      'amqps://ali-escaper:/@%5C%7C()%3C%3E&:bobby-tables:/@%5C%7C()%3C%3E&@pulse.abc.com:5671/%2F?frameMax=0');
+      'amqps://ali-escaper%3A%2F%40%5C%7C()%3C%3E%26:bobby-tables%3A%2F%40%5C%7C()%3C%3E%26@pulse.abc.com:5671/%2F?frameMax=0');
   });
 });


### PR DESCRIPTION
Bugzilla Bug: [1559434](https://bugzilla.mozilla.org/show_bug.cgi?id=1559434)
