### PR TITLE
Bug 1618983 - support reregistrationTimeout in static provider

### DIFF
--- a/changelog/bug-1618983.md
+++ b/changelog/bug-1618983.md
@@ -1,0 +1,4 @@
+level: patch
+reference: bug 1618983
+---
+The worker-manager's `static` provider type now supports worker lifecycles, and in particular `reregistrationTimeout`.

--- a/generated/references.json
+++ b/generated/references.json
@@ -228,13 +228,13 @@
       "description": "Conditions a worker can reach and actions to take in the case that they do.\nNot all providers necessarily implement all features of this in the same way.\nRead the providers docs to understand exactly what it will do.\n",
       "properties": {
         "registrationTimeout": {
-          "description": "Each worker in this pool has `registrationTimeout` seconds to\nregister itself with worker-manager after it has\nbeen requsted from the cloud provider. After this\ntimeout, worker-manager will terminate the instance,\nassuming it is broken.\n",
+          "description": "Each worker in this pool has `registrationTimeout` seconds to\nregister itself with worker-manager after it has\nbeen requsted from the cloud provider. After this\ntimeout, worker-manager will terminate the instance,\nassuming it is broken.\n\nThis parameter has no effect for worker pools using the static provider\ntype.\n",
           "title": "Registration Timeout",
           "type": "integer"
         },
         "reregistrationTimeout": {
           "default": 345600,
-          "description": "If specified, workers in this pool must re-register via `reregister()`\nwithin `reregistrationTimeout` seconds from the initial call to `register()`\nto get new credentials. If the worker has not done so, it will be\nterminated. This defaults to 96 hours.\n",
+          "description": "If specified, workers in this pool must re-register via `reregister()`\nwithin `reregistrationTimeout` seconds from the initial call to\n`register()` to get new credentials. If the worker has not done so, it\nwill be terminated.  This value also dictates the lifetime of the\ntemporary credentials granted to the worker, meaning that it cannot be\ngreater than 31 days.\n\nThe default value is 3 days.\n",
           "title": "Checkin Timeout",
           "type": "integer"
         }
@@ -756,6 +756,13 @@
       "$schema": "/schemas/common/metaschema.json#",
       "additionalProperties": false,
       "description": "A configuration for static workertypes",
+      "properties": {
+        "lifecycle": {
+          "$ref": "worker-lifecycle.json#"
+        }
+      },
+      "required": [
+      ],
       "title": "Static Provider Config",
       "type": "object"
     },

--- a/services/worker-manager/schemas/v1/config-static.yml
+++ b/services/worker-manager/schemas/v1/config-static.yml
@@ -3,3 +3,6 @@ title: Static Provider Config
 description: A configuration for static workertypes
 type: object
 additionalProperties: false
+required: []
+properties:
+  lifecycle: {$ref: 'worker-lifecycle.json#'}

--- a/services/worker-manager/schemas/v1/worker-lifecycle.yml
+++ b/services/worker-manager/schemas/v1/worker-lifecycle.yml
@@ -15,14 +15,21 @@ properties:
       been requsted from the cloud provider. After this
       timeout, worker-manager will terminate the instance,
       assuming it is broken.
+
+      This parameter has no effect for worker pools using the static provider
+      type.
   reregistrationTimeout:
     title: Checkin Timeout
     type: integer
     default: 345600
     description: |
       If specified, workers in this pool must re-register via `reregister()`
-      within `reregistrationTimeout` seconds from the initial call to `register()`
-      to get new credentials. If the worker has not done so, it will be
-      terminated. This defaults to 96 hours.
+      within `reregistrationTimeout` seconds from the initial call to
+      `register()` to get new credentials. If the worker has not done so, it
+      will be terminated.  This value also dictates the lifetime of the
+      temporary credentials granted to the worker, meaning that it cannot be
+      greater than 31 days.
+      
+      The default value is 3 days.
 additionalProperties: false
 required: []

--- a/services/worker-manager/test/provider_static_test.js
+++ b/services/worker-manager/test/provider_static_test.js
@@ -1,0 +1,102 @@
+const taskcluster = require('taskcluster-client');
+const assert = require('assert');
+const helper = require('./helper');
+const {StaticProvider} = require('../src/providers/static');
+const testing = require('taskcluster-lib-testing');
+
+helper.secrets.mockSuite(testing.suiteName(), ['azure'], function(mock, skipping) {
+  helper.withEntities(mock, skipping);
+  helper.withPulse(mock, skipping);
+  helper.withFakeQueue(mock, skipping);
+  helper.withFakeNotify(mock, skipping);
+
+  let provider;
+  let workerPool;
+  let providerId = 'stat';
+  let workerPoolId = 'foo/bar';
+
+  setup(async function() {
+    provider = new StaticProvider({
+      providerId,
+      notify: await helper.load('notify'),
+      monitor: (await helper.load('monitor')).childMonitor('google'),
+      estimator: await helper.load('estimator'),
+      fakeCloudApis: {},
+      rootUrl: helper.rootUrl,
+      Worker: helper.Worker,
+      WorkerPool: helper.WorkerPool,
+      WorkerPoolError: helper.WorkerPoolError,
+      providerConfig: {},
+    });
+    workerPool = await helper.WorkerPool.create({
+      workerPoolId,
+      providerId,
+      description: 'none',
+      previousProviderIds: [],
+      created: new Date(),
+      lastModified: new Date(),
+      config: {
+        lifecycle: {
+          reregistrationTimeout: 3600,
+        },
+      },
+      owner: 'whatever@example.com',
+      providerData: {},
+      emailOnError: false,
+    });
+    await provider.setup();
+  });
+
+  suite('registerWorker', function() {
+    const workerGroup = providerId;
+    const workerId = 'abc123';
+
+    const defaultWorker = {
+      workerPoolId,
+      workerGroup,
+      workerId,
+      providerId,
+      created: taskcluster.fromNow('0 seconds'),
+      lastModified: taskcluster.fromNow('0 seconds'),
+      lastChecked: taskcluster.fromNow('0 seconds'),
+      capacity: 1,
+      expires: taskcluster.fromNow('90 seconds'),
+      state: 'requested',
+      providerData: {
+        staticSecret: 'good',
+      },
+    };
+
+    test('no token', async function() {
+      const worker = await helper.Worker.create({
+        ...defaultWorker,
+      });
+      const workerIdentityProof = {};
+      await assert.rejects(() =>
+        provider.registerWorker({workerPool, worker, workerIdentityProof}),
+      /missing staticSecret/);
+    });
+
+    test('invalid token', async function() {
+      const worker = await helper.Worker.create({
+        ...defaultWorker,
+      });
+      const workerIdentityProof = {staticSecret: 'invalid'};
+      await assert.rejects(() =>
+        provider.registerWorker({workerPool, worker, workerIdentityProof}),
+      /bad staticSecret/);
+    });
+
+    test('successful registration', async function() {
+      const worker = await helper.Worker.create({
+        ...defaultWorker,
+      });
+      const workerIdentityProof = {staticSecret: 'good'};
+      const res = await provider.registerWorker({workerPool, worker, workerIdentityProof});
+      const expectedExpires = new Date(Date.now() + 3600 * 1000);
+      // allow +- 10 seconds since time passes while the test executes
+      assert(Math.abs(res.expires - expectedExpires) < 10000,
+        `${res.expires}, ${expectedExpires}, diff = ${res.expires - expectedExpires} ms`);
+    });
+  });
+});


### PR DESCRIPTION
Bugzilla Bug: [1618983](https://bugzilla.mozilla.org/show_bug.cgi?id=1618983)

This will allow static workers to run for 31 days, if configured that way.  And if they reboot in that time, then they can run forever.