### PR TITLE
Force `go mod tidy` to be run by renovate

### DIFF
--- a/changelog/brSrfgj3Sxi1ECduQiqZuw.md
+++ b/changelog/brSrfgj3Sxi1ECduQiqZuw.md
@@ -1,0 +1,2 @@
+level: silent
+---

--- a/package.json
+++ b/package.json
@@ -222,6 +222,9 @@
     "enabledManagers": [
       "npm",
       "gomod"
+    ],
+    "postUpdateOptions": [
+      "gomodTidy"
     ]
   },
   "eslintIgnore": [

--- a/tools/taskcluster-worker-runner/renovate.json
+++ b/tools/taskcluster-worker-runner/renovate.json
@@ -1,8 +1,0 @@
-{
-  "extends": [
-    "config:base"
-  ],
-  "ignoreDeps": [
-    "golang.org/x/sys"
-  ]
-}


### PR DESCRIPTION
Context:
* https://github.com/renovatebot/config-help/issues/558#issuecomment-594010549
* https://docs.renovatebot.com/configuration-options/#postupdateoptions