### PR TITLE
Increase golangci-lint timeout since sometimes it times out

### DIFF
--- a/changelog/AXXNEjbFSQGBb_g28-RMbw.md
+++ b/changelog/AXXNEjbFSQGBb_g28-RMbw.md
@@ -1,0 +1,2 @@
+level: silent
+---

--- a/workers/generic-worker/gw-decision-task/tasks.yml
+++ b/workers/generic-worker/gw-decision-task/tasks.yml
@@ -219,7 +219,7 @@ Commands:
             GW_TESTS_RUN_AS_CURRENT_USER=true GORACE=history_size=7 CGO_ENABLED=1 go test -tags "${ENGINE}" -timeout 45m -ldflags "-X github.com/taskcluster/taskcluster/v25/workers/generic-worker.revision=${GITHUB_SHA}" -v ${RACE} ${VET}
           fi
           GORACE=history_size=7 CGO_ENABLED=${CGO_ENABLED_TESTS} go test -tags "${ENGINE}" -timeout 45m -ldflags "-X github.com/taskcluster/taskcluster/v25/workers/generic-worker.revision=${GITHUB_SHA}" -v ${RACE} ${VET} ./...
-          ../../../golangci-lint/golangci-lint-1.23.6-*/golangci-lint run --build-tags "${ENGINE}"
+          ../../../golangci-lint/golangci-lint-1.23.6-*/golangci-lint run --build-tags "${ENGINE}" --timeout=15m
     Windows:
       - |
         :: go test: -race and -msan are only supported on linux/amd64, freebsd/amd64, darwin/amd64 and windows/amd64
@@ -288,9 +288,9 @@ Commands:
         :: i've also made it an if/else so that one of them has to run, as there should always be a
         :: linter
         if exist ..\..\..\golangci-lint\golangci-lint-1.23.6-windows-amd64 (
-          ..\..\..\golangci-lint\golangci-lint-1.23.6-windows-amd64\golangci-lint.exe run --build-tags "%ENGINE%"
+          ..\..\..\golangci-lint\golangci-lint-1.23.6-windows-amd64\golangci-lint.exe run --build-tags "%ENGINE%" --timeout=15m
         ) else (
-          ..\..\..\golangci-lint\golangci-lint-1.23.6-windows-386\golangci-lint.exe run --build-tags "%ENGINE%"
+          ..\..\..\golangci-lint\golangci-lint-1.23.6-windows-386\golangci-lint.exe run --build-tags "%ENGINE%" --timeout=15m
         )
 
 Mounts:


### PR DESCRIPTION
I noticed the [following failure](https://community-tc.services.mozilla.com/tasks/Xwz-vWvpSA6E5BPbLyu3GA/runs/0/logs/https%3A%2F%2Fcommunity-tc.services.mozilla.com%2Fapi%2Fqueue%2Fv1%2Ftask%2FXwz-vWvpSA6E5BPbLyu3GA%2Fruns%2F0%2Fartifacts%2Fpublic%2Flogs%2Flive_backing.log#L11420) on the master branch, which happened on the raspberry pi tester:

```
../../../golangci-lint/golangci-lint-1.23.6-*/golangci-lint run --build-tags "${ENGINE}"
+ ../../../golangci-lint/golangci-lint-1.23.6-linux-armv6/golangci-lint run --build-tags simple
level=error msg="Timeout exceeded: try increase it by passing --timeout option"
[taskcluster 2020-03-03T19:19:50.001Z]    Exit Code: 4
[taskcluster 2020-03-03T19:19:50.001Z]    User Time: 10m12.912047s
[taskcluster 2020-03-03T19:19:50.001Z]  Kernel Time: 52.221656s
[taskcluster 2020-03-03T19:19:50.001Z]    Wall Time: 10m35.287375514s
[taskcluster 2020-03-03T19:19:50.001Z]       Result: FAILED
[taskcluster 2020-03-03T19:19:50.005Z] === Task Finished ===
```

Default timeout is one minute, but I think we shouldn't be concerned if it takes up to 15 minutes to complete all linting tasks. Since 15m is considerably longer than 1m, hopefully this will be the last we see of this issue.