### PR TITLE
Bug 1619925 - lock taskstatus mutex while deregistering taskstatus change listeners

### DIFF
--- a/changelog/bug-1619925.md
+++ b/changelog/bug-1619925.md
@@ -1,0 +1,4 @@
+level: patch
+reference: bug 1619925
+---
+Bug fix: taskcluster-proxy credential updates from task reclaims no longer race with taskcluster proxy process termination. Previously if a task completed just as the task was being reclaimed, it was possible for generic-worker to terminate the taskcluster-proxy process while it was HTTP posting updated credentials to it, which caused generic-worker to crash.

--- a/workers/generic-worker/taskstatus.go
+++ b/workers/generic-worker/taskstatus.go
@@ -57,6 +57,12 @@ type TaskStatusManager struct {
 }
 
 func (tsm *TaskStatusManager) DeregisterListener(listener *TaskStatusChangeListener) {
+	// https://bugzil.la/1619925
+	// This lock ensures that any currently executing callbacks complete before
+	// the listener is deregistered, and that no new callbacks are scheduled
+	// once this method has started.
+	tsm.Lock()
+	defer tsm.Unlock()
 	// if Start() failed, a listener might not be registered, so check before deleting it...
 	if tsm.statusChangeListeners[listener] {
 		delete(tsm.statusChangeListeners, listener)


### PR DESCRIPTION
Bugzilla Bug: [1619925](https://bugzilla.mozilla.org/show_bug.cgi?id=1619925)

Should fix this intermittent panic (that caused our Windows 10 / amd64 CI worker to go out of commission and our CI backlog to build up):

```
panic: Could not PUT to http://localhost:80/credentials: Put http://localhost:80/credentials: read tcp 127.0.0.1:50828->127.0.0.1:80: wsarecv: An existing connection was forcibly closed by the remote host.

goroutine 37 [running]:
main.(*TaskclusterProxyTask).Start.func1(0xa8f230, 0x9)
        C:/Users/task_1582745095/taskcluster/workers/generic-worker/taskcluster_proxy.go:103 +0x77c
main.(*TaskStatusManager).updateStatus(0xc000466a00, 0xa8f230, 0x9, 0xc000045e28, 0xc00024c3e0, 0x2, 0x2, 0x0, 0x0)
        C:/Users/task_1582745095/taskcluster/workers/generic-worker/taskstatus.go:295 +0x5d0
main.(*TaskStatusManager).reclaim(0xc000466a00, 0x1b, 0xc000045f18)
        C:/Users/task_1582745095/taskcluster/workers/generic-worker/taskstatus.go:152 +0xb4
main.NewTaskStatusManager.func1(0xc000339c80, 0xc000466a00, 0xc000506000, 0xc000339c20)
        C:/Users/task_1582745095/taskcluster/workers/generic-worker/taskstatus.go:358 +0x304
created by main.NewTaskStatusManager
        C:/Users/task_1582745095/taskcluster/workers/generic-worker/taskstatus.go:331 +0x14e
```