### PR TITLE
Fenix issue - idea# 2

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "js-yaml": "^3.13.1",
     "json-e": "^3.0.0",
     "json-parameterization": "^2.0.0",
+    "json2md": "^1.7.0",
     "jsonwebtoken": "^8.1.1",
     "jwks-rsa": "^1.2.1",
     "lodash": "4.17.15",

--- a/services/github/config.yml
+++ b/services/github/config.yml
@@ -6,6 +6,7 @@ defaults:
     deprecatedInitialStatusQueue: 'stat-init'
     resultStatusQueue: 'ch-result'
     initialStatusQueue: 'ch-init'
+    artifactQueue: 'ch-artifacts'
     buildsTableName: 'TaskclusterGithubBuilds'
     ownersDirectoryTableName: 'TaskclusterIntegrationOwners'
     checkRunsTableName: 'TaskclusterCheckRuns'

--- a/services/github/src/main.js
+++ b/services/github/src/main.js
@@ -226,6 +226,7 @@ const load = loader({
         deprecatedInitialStatusQueueName: cfg.app.deprecatedInitialStatusQueue,
         resultStatusQueueName: cfg.app.resultStatusQueue,
         initialStatusQueueName: cfg.app.initialStatusQueue,
+        artifactQueueName: cfg.app.artifactQueue,
         context: {cfg, github, schemaset, Builds, CheckRuns, ChecksToTasks, publisher},
         pulseClient,
       }),

--- a/yarn.lock
+++ b/yarn.lock
@@ -3977,6 +3977,11 @@ indent-string@^3.0.0:
   resolved "https://registry.yarnpkg.com/indent-string/-/indent-string-3.2.0.tgz#4a5fd6d27cc332f37e5419a504dbb837105c9289"
   integrity sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok=
 
+indento@^1.1.7:
+  version "1.1.12"
+  resolved "https://registry.yarnpkg.com/indento/-/indento-1.1.12.tgz#e95942e88e528655df33f129b6826019a1a221fd"
+  integrity sha512-hWlFlRL6dd06MU5SsOZZ6kzO7t/7ZjcxWh1Yf/MjGtyKQMC8SPS5GbZ2XqMBGaGn+HM2QQawYxSLtS7Zv0w0BQ==
+
 inflight@^1.0.4:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/inflight/-/inflight-1.0.6.tgz#49bd6331d7d02d0c09bc910a1075ba8165b56df9"
@@ -4359,6 +4364,13 @@ json-stringify-safe@^5.0.1, json-stringify-safe@~5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz#1296a2d58fd45f19a0f6ce01d65701e2c735b6eb"
   integrity sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=
+
+json2md@^1.7.0:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/json2md/-/json2md-1.7.0.tgz#aaf4bad77ec8c0e623169a288add12b6493e180e"
+  integrity sha512-g/lg6H3sEeyqCTqNLn8DTsqAa2wwqUI0Y7MnZ8d6wJLMJLgsMp5mBO9hPIPPuFjv/C1vYBoKAZG8TdTfcIGZCA==
+  dependencies:
+    indento "^1.1.7"
 
 json5@^2.1.0:
   version "2.1.1"
@@ -7196,44 +7208,48 @@ tar-stream@^2.0.0:
     readable-stream "^3.1.1"
 
 "taskcluster-client@link:clients/client":
-  version "25.2.0"
-  dependencies:
-    "@hapi/hawk" "^7.1.2"
-    debug "^4.1.1"
-    lodash "^4.17.4"
-    slugid "^2.0.0"
-    superagent "^5.0.0"
-    taskcluster-lib-urls "^12.0.0"
+  version "0.0.0"
+  uid ""
 
 "taskcluster-lib-api@link:libraries/api":
-  version "25.2.0"
+  version "0.0.0"
+  uid ""
 
 "taskcluster-lib-app@link:libraries/app":
-  version "25.2.0"
+  version "0.0.0"
+  uid ""
 
 "taskcluster-lib-azure@link:libraries/azure":
-  version "25.2.0"
+  version "0.0.0"
+  uid ""
 
 "taskcluster-lib-config@link:libraries/config":
-  version "25.2.0"
+  version "0.0.0"
+  uid ""
 
 "taskcluster-lib-iterate@link:libraries/iterate":
-  version "25.2.0"
+  version "0.0.0"
+  uid ""
 
 "taskcluster-lib-loader@link:libraries/loader":
-  version "25.2.0"
+  version "0.0.0"
+  uid ""
 
 "taskcluster-lib-monitor@link:libraries/monitor":
-  version "25.2.0"
+  version "0.0.0"
+  uid ""
 
 "taskcluster-lib-postgres@link:libraries/postgres":
-  version "25.2.0"
+  version "0.0.0"
+  uid ""
 
 "taskcluster-lib-pulse@link:libraries/pulse":
-  version "25.2.0"
+  version "0.0.0"
+  uid ""
 
 "taskcluster-lib-references@link:libraries/references":
-  version "25.2.0"
+  version "0.0.0"
+  uid ""
 
 taskcluster-lib-scopes@^11.0.0:
   version "11.0.0"
@@ -7243,7 +7259,8 @@ taskcluster-lib-scopes@^11.0.0:
     fast-json-stable-stringify "^2.1.0"
 
 "taskcluster-lib-testing@link:libraries/testing":
-  version "25.2.0"
+  version "0.0.0"
+  uid ""
 
 taskcluster-lib-urls@^12.0.0:
   version "12.0.0"
@@ -7251,7 +7268,8 @@ taskcluster-lib-urls@^12.0.0:
   integrity sha512-OrEFE0m3p/+mGsmIwjttLhSKg3io6MpJLhYtPNjVSZA9Ix8Y5tprN3vM6a3MjWt5asPF6AKZsfT43cgpGwJB0g==
 
 "taskcluster-lib-validate@link:libraries/validate":
-  version "25.2.0"
+  version "0.0.0"
+  uid ""
 
 temporary@^1.0.0:
   version "1.0.1"


### PR DESCRIPTION
Note: Please disregard the first commit. I want it for now, but it will be rebased before the actual PR.

As we discussed in my previous draft PR, I made the solution more generic. So this attempts to solve not just the Fenix issue but also [this](https://bugzilla.mozilla.org/show_bug.cgi?id=1552323).

The general idea is that if people want custom task results in checkruns, they need: 
* to arrange for an artifact in a JSON format created upon the task completion. The artifact's name should be provided in the `extra` section of the task definition
* to provide us a template to select the data they need from the JSON and to format it with a markup so that it's pretty. The template should be provided in the `extra` section of the task definition in the form of a function that takes in an object and returns a [json2md template](https://github.com/IonicaBizau/json2md#readme), like so:
```javascript
extra: {
  customCheckRun: {
     artifactName: 'NAME',
     createMarkup: o => ([{h1: `${o.name}`}, {p: `${o.results}`}])
  }
}
```

tc-github then would 
1. react on a pulse message (either task status message or artifact-create message.... I left the `artifactCreatedHandler` from the previous PR just for the clarity, so that the new code is in a separate function. I agree that adding this functionality to `statusHandler` is probably better),
2. get the task definition from the queue
3. check if custom check run is required
4. if yes, call AWS for the artifact contents using [S3.selectObjectContent api](https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/S3.html#selectObjectContent-property)
5. use the provided `createMarkup` function to populate it with the actual data and generates the string using `json2md` library
6. add the above to the check run create or update api call to github

Step 4 can be implemented as a new API endpoint in the Queue service.

Possible drawbacks of this method:
* S3.selectObjectContent  might be expensive 💸 (needs checking)
* Added dependency
* Arranging the JSON artifact might be tricky for users

Feedback I am looking for:
* If this is conceptually feasible, tell me so and point out the weak spots and possible improvements
* If this is not conceptually feasible, tell me so and explain reasons.

Thank you!