### PR TITLE
Add boolean operators short-circuiting for `.taskcluster.yml`s

### DIFF
--- a/changelog/issue-244.md
+++ b/changelog/issue-244.md
@@ -1,0 +1,5 @@
+level: minor
+reference: issue 244
+---
+The json-e library now supports short-circuiting in boolean logic, and so does Taskcluster for taskcluster.ymls now!
+

--- a/changelog/issue-244.md
+++ b/changelog/issue-244.md
@@ -1,5 +1,5 @@
 level: minor
-reference: issue 244
+reference: issue no-bug
 ---
 The json-e library now supports short-circuiting in boolean logic, and so does Taskcluster for taskcluster.ymls now!
 

--- a/changelog/issue-244.md
+++ b/changelog/issue-244.md
@@ -1,5 +1,4 @@
 level: minor
-reference: issue no-bug
 ---
 The json-e library now supports short-circuiting in boolean logic, and so does Taskcluster for taskcluster.ymls now!
 

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "irc-upd": "^0.10.0",
     "iterall": "^1.2.2",
     "js-yaml": "^3.13.1",
-    "json-e": "^3.0.0",
+    "json-e": "^4.0.0",
     "json-parameterization": "^2.0.0",
     "jsonwebtoken": "^8.1.1",
     "jwks-rsa": "^1.2.1",

--- a/services/hooks/test/taskcreator_test.js
+++ b/services/hooks/test/taskcreator_test.js
@@ -163,7 +163,7 @@ suite(testing.suiteName(), function() {
       try {
         await creator.fire(hook, {firedBy: 'me'}, {taskId});
       } catch (err) {
-        if (!err.toString().match(/unknown context value uhoh/)) {
+        if (!err.toString().match(/SyntaxError/)) {
           throw err;
         }
 
@@ -173,7 +173,7 @@ suite(testing.suiteName(), function() {
           taskId: taskId,
         });
         assume(lf.result).to.equal('error');
-        assume(lf.error).to.match(/unknown context value uhoh/);
+        assume(lf.error).to.match(/SyntaxError/);
         assume(lf.firedBy).to.equal('me');
 
         assertFireLogged({firedBy: "me", taskId, result: 'failure'});

--- a/yarn.lock
+++ b/yarn.lock
@@ -4362,10 +4362,10 @@ json-buffer@3.0.0:
   resolved "https://registry.yarnpkg.com/json-buffer/-/json-buffer-3.0.0.tgz#5b1f397afc75d677bde8bcfc0e47e1f9a3d9a898"
   integrity sha1-Wx85evx11ne96Lz8Dkfh+aPZqJg=
 
-json-e@^3.0.0:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/json-e/-/json-e-3.0.1.tgz#8e674e622012559747994f872739ea142cff4453"
-  integrity sha512-ZYUZ6KXdeL52Gd9yh7ig3k0a+O/5XwlBnel5fDHuCxAcAMXfqbed5FkCnZYiv52E0uB8dHoP5W7xOHjfISzHnQ==
+json-e@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/json-e/-/json-e-4.0.0.tgz#a95739914fe567baf452340c9392dcd12eaa998b"
+  integrity sha512-B+EmuBzVRCWQ1G1kYzD73whYrXNF1R7fCrAZyrvUnXcqWoTxrMTrOiYZX6y+pmXh0h+QrXRPMsTJhP2wMbge5g==
   dependencies:
     json-stable-stringify-without-jsonify "^1.0.1"
 
@@ -7265,44 +7265,48 @@ tar-stream@^2.0.0:
     readable-stream "^3.1.1"
 
 "taskcluster-client@link:clients/client":
-  version "25.4.0"
-  dependencies:
-    "@hapi/hawk" "^7.1.2"
-    debug "^4.1.1"
-    lodash "^4.17.4"
-    slugid "^2.0.0"
-    superagent "^5.0.0"
-    taskcluster-lib-urls "^12.0.0"
+  version "0.0.0"
+  uid ""
 
 "taskcluster-lib-api@link:libraries/api":
-  version "25.4.0"
+  version "0.0.0"
+  uid ""
 
 "taskcluster-lib-app@link:libraries/app":
-  version "25.4.0"
+  version "0.0.0"
+  uid ""
 
 "taskcluster-lib-azure@link:libraries/azure":
-  version "25.4.0"
+  version "0.0.0"
+  uid ""
 
 "taskcluster-lib-config@link:libraries/config":
-  version "25.4.0"
+  version "0.0.0"
+  uid ""
 
 "taskcluster-lib-iterate@link:libraries/iterate":
-  version "25.4.0"
+  version "0.0.0"
+  uid ""
 
 "taskcluster-lib-loader@link:libraries/loader":
-  version "25.4.0"
+  version "0.0.0"
+  uid ""
 
 "taskcluster-lib-monitor@link:libraries/monitor":
-  version "25.4.0"
+  version "0.0.0"
+  uid ""
 
 "taskcluster-lib-postgres@link:libraries/postgres":
-  version "25.4.0"
+  version "0.0.0"
+  uid ""
 
 "taskcluster-lib-pulse@link:libraries/pulse":
-  version "25.4.0"
+  version "0.0.0"
+  uid ""
 
 "taskcluster-lib-references@link:libraries/references":
-  version "25.4.0"
+  version "0.0.0"
+  uid ""
 
 taskcluster-lib-scopes@^11.0.0:
   version "11.0.0"
@@ -7312,7 +7316,8 @@ taskcluster-lib-scopes@^11.0.0:
     fast-json-stable-stringify "^2.1.0"
 
 "taskcluster-lib-testing@link:libraries/testing":
-  version "25.4.0"
+  version "0.0.0"
+  uid ""
 
 taskcluster-lib-urls@^12.0.0:
   version "12.0.0"
@@ -7320,7 +7325,8 @@ taskcluster-lib-urls@^12.0.0:
   integrity sha512-OrEFE0m3p/+mGsmIwjttLhSKg3io6MpJLhYtPNjVSZA9Ix8Y5tprN3vM6a3MjWt5asPF6AKZsfT43cgpGwJB0g==
 
 "taskcluster-lib-validate@link:libraries/validate":
-  version "25.4.0"
+  version "0.0.0"
+  uid ""
 
 temporary@^1.0.0:
   version "1.0.1"


### PR DESCRIPTION
I'm a renovate bot 🤖

The new json-e version adds support for boolean logic operators short-circuiting, so hopefully writing `.taskcluster.yml`s will now be less of a pain. Thank you @Nicrii for the work on json-e!