### PR TITLE
Enforce the format of some DB config variables

### DIFF
--- a/libraries/postgres/test/database_test.js
+++ b/libraries/postgres/test/database_test.js
@@ -391,6 +391,16 @@ helper.dbSuite(path.basename(__filename), function() {
       assert(!db.fns.old);
     });
 
+    test('non-numeric statementTimeout is not alloewd', async function() {
+      await assert.rejects(() => Database.setup({
+        schema,
+        readDbUrl: helper.dbUrl,
+        writeDbUrl: helper.dbUrl,
+        serviceName: 'service-1',
+        statementTimeout: 'about 3 seconds',
+      }), err => err.code === 'ERR_ASSERTION');
+    });
+
     test('slow methods are aborted if statementTimeout is set', async function() {
       await Database.upgrade({schema, adminDbUrl: helper.dbUrl, usernamePrefix: 'test'});
       db = await Database.setup({
@@ -447,5 +457,15 @@ helper.dbSuite(path.basename(__filename), function() {
       await db.fns.testdata();
       await db.close();
     });
+  });
+
+  test('_validUsernamePrefix', function() {
+    assert(Database._validUsernamePrefix('a_b_c'));
+    assert(!Database._validUsernamePrefix(''));
+    assert(!Database._validUsernamePrefix('abc_123'));
+    assert(!Database._validUsernamePrefix('123'));
+    // this would be a particularly bizarre thing to put in the deployment configuration,
+    // but hey, it won't work!
+    assert(!Database._validUsernamePrefix(`'; drop table clients`));
   });
 });

--- a/ui/docs/manual/deploying/database.mdx
+++ b/ui/docs/manual/deploying/database.mdx
@@ -17,11 +17,13 @@ For production purposes we recommend a dedicated server, due to the possibility 
 Each service uses its own Postgres user to access the database, and Taskcluster uses this functionality internally to isolate services from one another.
 The Taskcluster deployment process additionally requires an "admin" user that is used for schema migrations and to update the permissions of the per-service users.
 This admin user must have full permission to all resources in the selected database, as well as permission to grant and revoke access for the service users.
-
 The admin user can have any name.
+
 Because users are global to a Postgres server, Taskcluster requires a name prefix which is applied to each per-service user.
 In a non-production environment, this allows several installations of Taskcluster to co-exist on the same server.
 We recommend that the admin username and the prefix be the same string.
+
+The prefix must consist of one ore more lowercase alphanumeric characters, and underscore (`/[a-z_]+/`).
 
 The set of users that must be configured, then, are:
 


### PR DESCRIPTION
Both of these values are substituted directly into SQL queries, so out of an abundance of caution let's make sure they have an appropriate format.

Github Bug/Issue: Fixes #2454