### PR TITLE
Add SQLi tests for the scan method

### DIFF
--- a/db/test/versions/0002_test.js
+++ b/db/test/versions/0002_test.js
@@ -1,8 +1,10 @@
 const assert = require('assert').strict;
+const path = require('path');
 const { snakeCase } = require('change-case');
 const helper = require('../helper');
 const testing = require('taskcluster-lib-testing');
-const {UNDEFINED_TABLE} = require('taskcluster-lib-postgres');
+const tcdb = require('taskcluster-db');
+const {Schema, UNDEFINED_TABLE} = require('taskcluster-lib-postgres');
 
 suite(testing.suiteName(), function() {
   helper.withDbForVersion();
@@ -41,27 +43,67 @@ suite(testing.suiteName(), function() {
     'WMWorkerPoolErrors',
   ];
 
-  azureTableNames.forEach(azureTableName => {
-    const postgresTableName = `${snakeCase(azureTableName)}_entities`;
-
-    test(`${postgresTableName} table initially not created`, async function () {
-      await helper.withDbClient(async client => {
-        await assert.rejects(
-          () => client.query(`select * from ${postgresTableName}`),
-          err => err.code === UNDEFINED_TABLE);
-      });
+  const assertNoTable = async postgresTableName => {
+    await helper.withDbClient(async client => {
+      await assert.rejects(
+        () => client.query(`select * from ${postgresTableName}`),
+        err => err.code === UNDEFINED_TABLE);
     });
+  };
+
+  const assertTable = async postgresTableName => {
+    await helper.withDbClient(async client => {
+      const res = await client.query(`select * from ${postgresTableName}`);
+      assert.deepEqual(res.rows, []);
+    });
+  };
+
+  /* Note that these tests run in order */
+
+  test(`tables created on upgrade`, async function () {
+    await helper.upgradeTo(1);
+
+    for (let azureTableName of azureTableNames) {
+      const postgresTableName = `${snakeCase(azureTableName)}_entities`;
+      await assertNoTable(postgresTableName);
+    }
+
+    await helper.upgradeTo(2);
+
+    for (let azureTableName of azureTableNames) {
+      const postgresTableName = `${snakeCase(azureTableName)}_entities`;
+      await assertTable(postgresTableName);
+    }
   });
-  azureTableNames.forEach(azureTableName => {
-    const postgresTableName = `${snakeCase(azureTableName)}_entities`;
 
-    test(`${postgresTableName} table created`, async function () {
-      await helper.upgradeTo(2);
+  test(`tables dropped on downgrade`, async function () {
+    await helper.downgradeTo(1);
+    for (let azureTableName of azureTableNames) {
+      const postgresTableName = `${snakeCase(azureTableName)}_entities`;
+      await assertNoTable(postgresTableName);
+    }
+  });
 
-      await helper.withDbClient(async client => {
-        const res = await client.query(`select * from ${postgresTableName}`);
-        assert.deepEqual(res.rows, []);
-      });
-    });
+  test('stored function bodies match those in tc-lib-entities tests', function() {
+    // This is a meta-check to ensure that the tests in tc-lib-entities, which
+    // use a private copy of the stored functions, are testing the exact same
+    // thing as we are using in version 0002.
+    const testSchema = Schema.fromDbDirectory(path.join(__dirname, '../../../libraries/entities/test/db'));
+    const testVersion = testSchema.getVersion(1);
+
+    const realSchema = tcdb.schema({useDbDirectory: true});
+    const realVersion = realSchema.getVersion(2);
+    for (let azureTableName of azureTableNames) {
+      const postgresTableName = `${snakeCase(azureTableName)}_entities`;
+      for (let methodSuffix of ['load', 'create', 'remove', 'modify', 'scan']) {
+        const method = `${postgresTableName}_${methodSuffix}`;
+
+        const realMethod = realVersion.methods[method].body;
+        assert(realMethod, `Method ${method} not defined`);
+
+        const testMethod = testVersion.methods[`test_entities_${methodSuffix}`].body;
+        assert.equal(testMethod.replace(/test_entities/g, postgresTableName), realMethod);
+      }
+    }
   });
 });

--- a/libraries/entities/test/db/versions/0001.yml
+++ b/libraries/entities/test/db/versions/0001.yml
@@ -106,6 +106,18 @@ methods:
     serviceName: test-entities
     args: pk text, rk text, condition text, size integer, page integer
     returns: table (partition_key text, row_key text, value jsonb, version integer, etag uuid)
+    # SECURITY-CRITICAL: this function substitutes its parameters into a SQL
+    # string and executes it, bringing risk of SQL injection.  This is safe
+    # because:
+    #  - partition_key and row_key are passed through `quote_literal` and thus
+    #  safely quoted
+    #    https://www.postgresql.org/docs/11/functions-string.html
+    #    > Return the given string suitably quoted to be used as a string
+    #    > literal in an SQL statement string. Embedded single-quotes and
+    #    > backslashes are properly doubled.
+    #  - size and page are both integers
+    #  - condition is guaranteed to be safe by the implementation of the JS
+    #    `scan` method
     body: |-
       declare
         sql text := 'select test_entities.partition_key, test_entities.row_key, test_entities.value, test_entities.version, test_entities.etag from test_entities';


### PR DESCRIPTION
This adds tests and some comments about the dangers of the tc-lib-entities `scan` method.

Happily, no issues found :)

Github Bug/Issue: Fixes #2457