### PR TITLE
Add output.text from an artifact

### DIFF
--- a/changelog/bug-1552323.md
+++ b/changelog/bug-1552323.md
@@ -1,5 +1,5 @@
 level: minor
 reference: bug 1552323
 ---
-Fixes bug 1552323 and issue https://github.com/mozilla-mobile/fenix/issues/6760
-Adds ability to customize checks output in taskcluster-github Checks feature
+Adds ability to customize checks output in taskcluster-github Checks feature.
+Apart from the bug mentioned, fixes the issue https://github.com/mozilla-mobile/fenix/issues/6760

--- a/changelog/bug-1552323.md
+++ b/changelog/bug-1552323.md
@@ -1,0 +1,5 @@
+level: minor
+reference: bug 1552323
+---
+Fixes bug 1552323 and issue https://github.com/mozilla-mobile/fenix/issues/6760
+Adds ability to customize checks output in taskcluster-github Checks feature

--- a/generated/docs-search.json
+++ b/generated/docs-search.json
@@ -2073,6 +2073,34 @@
   },
   {
     "element": "h1",
+    "id": "taskcluster-github-checks",
+    "path": "/reference/integrations/github/checks",
+    "subtitle": null,
+    "title": "Taskcluster-Github Checks"
+  },
+  {
+    "element": "h2",
+    "id": "custom-output-in-checks",
+    "path": "/reference/integrations/github/checks",
+    "subtitle": "Custom Output in Checks",
+    "title": "Taskcluster-Github Checks"
+  },
+  {
+    "element": "h3",
+    "id": "debugging-errors-in-custom-output",
+    "path": "/reference/integrations/github/checks",
+    "subtitle": "Debugging Errors in Custom Output",
+    "title": "Taskcluster-Github Checks"
+  },
+  {
+    "element": "h2",
+    "id": "reporting-bugs",
+    "path": "/reference/integrations/github/checks",
+    "subtitle": "Reporting Bugs",
+    "title": "Taskcluster-Github Checks"
+  },
+  {
+    "element": "h1",
     "id": "taskcluster-yml-version-0",
     "path": "/reference/integrations/github/taskcluster-yml-v0",
     "subtitle": null,

--- a/generated/docs-table-of-contents.json
+++ b/generated/docs-table-of-contents.json
@@ -3135,13 +3135,35 @@
                 },
                 "name": "taskcluster-yml-v0",
                 "next": {
-                  "path": "reference/workers/README",
-                  "title": "Workers"
+                  "path": "reference/integrations/github/checks",
+                  "title": "checks"
                 },
                 "path": "reference/integrations/github/taskcluster-yml-v0",
                 "prev": {
                   "path": "reference/integrations/github/taskcluster-yml-v1",
                   "title": ".taskcluster.yml version 1"
+                },
+                "up": {
+                  "path": "reference/integrations/github/README",
+                  "title": "github"
+                }
+              },
+              {
+                "children": [
+                ],
+                "data": {
+                  "order": 1000,
+                  "title": "checks"
+                },
+                "name": "checks",
+                "next": {
+                  "path": "reference/workers/README",
+                  "title": "Workers"
+                },
+                "path": "reference/integrations/github/checks",
+                "prev": {
+                  "path": "reference/integrations/github/taskcluster-yml-v0",
+                  "title": ".taskcluster.yml version 0"
                 },
                 "up": {
                   "path": "reference/integrations/github/README",
@@ -3438,8 +3460,8 @@
         },
         "path": "reference/workers/README",
         "prev": {
-          "path": "reference/integrations/github/taskcluster-yml-v0",
-          "title": ".taskcluster.yml version 0"
+          "path": "reference/integrations/github/checks",
+          "title": "checks"
         },
         "up": {
           "path": "reference/README",

--- a/services/github/src/constants.js
+++ b/services/github/src/constants.js
@@ -15,4 +15,5 @@ module.exports = {
     'intermittent-task': 'neutral', // queue status means: will be retried
   },
   CHECKRUN_TEXT: 'View task in Taskcluster',
+  CUSTOM_CHECKRUN_TEXT_ARTIFACT_NAME: 'customCheckRunText.md',
 };

--- a/services/github/src/constants.js
+++ b/services/github/src/constants.js
@@ -15,5 +15,5 @@ module.exports = {
     'intermittent-task': 'neutral', // queue status means: will be retried
   },
   CHECKRUN_TEXT: 'View task in Taskcluster',
-  CUSTOM_CHECKRUN_TEXT_ARTIFACT_NAME: 'customCheckRunText.md',
+  CUSTOM_CHECKRUN_TEXT_ARTIFACT_NAME: 'public/customCheckRunText.md',
 };

--- a/services/github/src/constants.js
+++ b/services/github/src/constants.js
@@ -1,0 +1,18 @@
+module.exports = {
+  CONCLUSIONS: { // maps status communicated by the queue service to github checkrun conclusions
+    /*eslint-disable quote-props*/
+    'completed': 'success',
+    'failed': 'failure',
+    'exception': 'failure',
+    'deadline-exceeded': 'timed_out',
+    'canceled': 'cancelled',
+    'superseded': 'neutral', // queue status means: is not relevant anymore
+    'claim-expired': 'failure',
+    'worker-shutdown': 'neutral', // queue status means: will be retried
+    'malformed-payload': 'action_required', // github status means "correct your task definition"
+    'resource-unavailable': 'failure',
+    'internal-error': 'failure',
+    'intermittent-task': 'neutral', // queue status means: will be retried
+  },
+  CHECKRUN_TEXT: 'View task in Taskcluster',
+};

--- a/services/github/src/constants.js
+++ b/services/github/src/constants.js
@@ -15,5 +15,5 @@ module.exports = {
     'intermittent-task': 'neutral', // queue status means: will be retried
   },
   CHECKRUN_TEXT: 'View task in Taskcluster',
-  CUSTOM_CHECKRUN_TEXT_ARTIFACT_NAME: 'public/customCheckRunText.md',
+  CUSTOM_CHECKRUN_TEXT_ARTIFACT_NAME: 'public/github/customCheckRunText.md',
 };

--- a/services/github/src/constants.js
+++ b/services/github/src/constants.js
@@ -1,6 +1,6 @@
 module.exports = {
   CONCLUSIONS: { // maps status communicated by the queue service to github checkrun conclusions
-    /*eslint-disable quote-props*/
+    /*eslint quote-props: ["error", "consistent-as-needed"]*/
     'completed': 'success',
     'failed': 'failure',
     'exception': 'failure',

--- a/services/github/src/handlers.js
+++ b/services/github/src/handlers.js
@@ -491,7 +491,6 @@ async function statusHandler(message) {
   );
   try {
     const taskDefinition = await this.queueClient.task(taskId);
-    debug(`Result status. Got task build from DB and task definition for ${taskId} from Queue service`);
     const {customCheckRun} = (taskDefinition.extra && taskDefinition.extra.github) || {};
 
     let customCheckRunText = '';
@@ -551,9 +550,9 @@ async function statusHandler(message) {
         output: {
           title: `${this.context.cfg.app.statusContext} (${eventType.split('.')[0]})`,
           summary: `${taskDefinition.metadata.description}`,
-          text: `[${CHECKRUN_TEXT}](${taskUI(this.context.cfg.taskcluster.rootUrl, taskGroupId, taskId)})\n${customCheckRunText || ''}`,
+          text: `[${CHECKRUN_TEXT}](${taskGroupUI(this.context.cfg.taskcluster.rootUrl, taskGroupId)})\n${customCheckRunText || ''}`,
         },
-        details_url: taskGroupUI(this.context.cfg.taskcluster.rootUrl, taskGroupId),
+        details_url: taskUI(this.context.cfg.taskcluster.rootUrl, taskGroupId, taskId),
       });
 
       await this.context.CheckRuns.create({

--- a/services/github/src/handlers.js
+++ b/services/github/src/handlers.js
@@ -496,21 +496,12 @@ async function statusHandler(message) {
 
     let customCheckRunText = '';
 
-    const scopedQueueClient = this.queueClient.use({
-      authorizedScopes: taskDefinition.scopes,
-      credentials: this.context.cfg.taskcluster.credentials,
-    });
     const url = this.queueClient
-      .buildUrl(scopedQueueClient.getArtifact, taskId, runId, textArtifactName);
+      .buildUrl(this.queueClient.getArtifact, taskId, runId, textArtifactName);
 
     let res = await utils.throttleRequest({url, method: 'GET'});
 
     if (res.status >= 400 && res.status !== 404) {
-      /*
-        Some possible errors:
-          - insufficient scopes: statusCode 403
-          - no artifact entity in DB, no artifact in S3: statusCode 404
-      */
       await this.createExceptionComment({
         debug,
         instGithub,

--- a/services/github/src/handlers.js
+++ b/services/github/src/handlers.js
@@ -3,22 +3,7 @@ const libUrls = require('taskcluster-lib-urls');
 const yaml = require('js-yaml');
 const assert = require('assert');
 const {consume} = require('taskcluster-lib-pulse');
-
-const CONCLUSIONS = { // maps status communicated by the queue service to github checkrun conclusions
-  /*eslint-disable quote-props*/
-  'completed': 'success',
-  'failed': 'failure',
-  'exception': 'failure',
-  'deadline-exceeded': 'timed_out',
-  'canceled': 'cancelled',
-  'superseded': 'neutral', // queue status means: is not relevant anymore
-  'claim-expired': 'failure',
-  'worker-shutdown': 'neutral', // queue status means: will be retried
-  'malformed-payload': 'action_required', // github status means "correct your task definition"
-  'resource-unavailable': 'failure',
-  'internal-error': 'failure',
-  'intermittent-task': 'neutral', // queue status means: will be retried
-};
+const {CONCLUSIONS, CHECKRUN_TEXT} = require('./constants');
 
 /**
  * Create handlers
@@ -523,7 +508,7 @@ async function statusHandler(message) {
         output: {
           title: `${this.context.cfg.app.statusContext} (${eventType.split('.')[0]})`,
           summary: `${taskDefinition.metadata.description}`,
-          text: `[View task in Taskcluster](${taskUI(this.context.cfg.taskcluster.rootUrl, taskGroupId, taskId)})\n${customCheckRunText || ''}`,
+          text: `[${CHECKRUN_TEXT}](${taskUI(this.context.cfg.taskcluster.rootUrl, taskGroupId, taskId)})\n${customCheckRunText || ''}`,
         },
       });
     } else {
@@ -535,7 +520,7 @@ async function statusHandler(message) {
         output: {
           title: `${this.context.cfg.app.statusContext} (${eventType.split('.')[0]})`,
           summary: `${taskDefinition.metadata.description}`,
-          text: `[View task in Taskcluster](${taskUI(this.context.cfg.taskcluster.rootUrl, taskGroupId, taskId)})\n${customCheckRunText || ''}`,
+          text: `[${CHECKRUN_TEXT}](${taskUI(this.context.cfg.taskcluster.rootUrl, taskGroupId, taskId)})\n${customCheckRunText || ''}`,
         },
         details_url: taskGroupUI(this.context.cfg.taskcluster.rootUrl, taskGroupId),
       });

--- a/services/github/src/handlers.js
+++ b/services/github/src/handlers.js
@@ -507,9 +507,8 @@ async function statusHandler(message) {
       if (res.status >= 400) {
         /*
           Some possible errors:
-            - insufficient scopes: statusCode 403, code InsufficientScopes
-            - no artifact entity in DB: statusCode 404, code ResourceNotFound
-            - no artifact in S3: statusCode 404, code UnknownError
+            - insufficient scopes: statusCode 403
+            - no artifact entity in DB, no artifact in S3: statusCode 404
         */
         await this.createExceptionComment({
           debug,
@@ -517,12 +516,12 @@ async function statusHandler(message) {
           organization,
           repository,
           sha,
-          error: new Error(res.response.error.text),
+          error: res.response.error,
         });
+        await this.monitor.reportError(res.response.error);
 
-        await this.monitor.reportError(res);
       } else if (res.status >= 200 && res.status < 300) {
-        customCheckRunText = res.text;
+        customCheckRunText = res.text.toString();
       }
     }
 

--- a/services/github/src/handlers.js
+++ b/services/github/src/handlers.js
@@ -749,7 +749,7 @@ async function jobHandler(message) {
     if (err.code !== 'EntityAlreadyExists') {
       throw err;
     }
-    let build = await this.Builds.load({
+    let build = await this.context.Builds.load({
       taskGroupId,
     });
     assert.equal(build.state, groupState, `State for ${organization}/${repository}@${sha}

--- a/services/github/src/handlers.js
+++ b/services/github/src/handlers.js
@@ -495,7 +495,12 @@ async function statusHandler(message) {
 
     let customCheckRunText = '';
     if (customCheckRun && customCheckRun.textArtifactName) {
-      customCheckRunText = (await this.queueClient.getArtifact(taskId, runId, customCheckRun.textArtifactName)).toString();
+      console.log('🧿', taskDefinition.scopes);
+      const scopedQueueClient = this.queueClient.use({
+        authorizedScopes: taskDefinition.scopes,
+        credentials: this.context.cfg.taskcluster.credentials,
+      });
+      customCheckRunText = (await scopedQueueClient.getArtifact(taskId, runId, customCheckRun.textArtifactName)).toString();
     }
 
 

--- a/services/github/src/handlers.js
+++ b/services/github/src/handlers.js
@@ -520,7 +520,10 @@ async function statusHandler(message) {
           sha,
           error: res.response.error,
         });
-        await this.monitor.reportError(res.response.error);
+
+        if (res.status < 500) {
+          await this.monitor.reportError(res.response.error);
+        }
 
       } else if (res.status >= 200 && res.status < 300) {
         customCheckRunText = res.text.toString();

--- a/services/github/src/handlers.js
+++ b/services/github/src/handlers.js
@@ -506,11 +506,11 @@ async function statusHandler(message) {
   try {
     const taskDefinition = await this.queueClient.task(taskId);
     debug(`Result status. Got task build from DB and task definition for ${taskId} from Queue service`);
-    const {checkRunArtifactName} = taskDefinition.extra.github;
+    const {customCheckRun} = (taskDefinition.extra && taskDefinition.extra.github) || {};
 
-    let checkRunArtifact = '';
-    if (checkRunArtifactName) {
-      checkRunArtifact = (await this.queueClient.getArtifact(taskId, runId, checkRunArtifactName)).toString();
+    let customCheckRunText = '';
+    if (customCheckRun && customCheckRun.textArtifactName) {
+      customCheckRunText = (await this.queueClient.getArtifact(taskId, runId, customCheckRun.textArtifactName)).toString();
     }
 
 
@@ -523,7 +523,7 @@ async function statusHandler(message) {
         output: {
           title: `${this.context.cfg.app.statusContext} (${eventType.split('.')[0]})`,
           summary: `${taskDefinition.metadata.description}`,
-          text: `[View task in Taskcluster](${taskUI(this.context.cfg.taskcluster.rootUrl, taskGroupId, taskId)})\n${checkRunArtifact || ''}`,
+          text: `[View task in Taskcluster](${taskUI(this.context.cfg.taskcluster.rootUrl, taskGroupId, taskId)})\n${customCheckRunText || ''}`,
         },
       });
     } else {
@@ -535,7 +535,7 @@ async function statusHandler(message) {
         output: {
           title: `${this.context.cfg.app.statusContext} (${eventType.split('.')[0]})`,
           summary: `${taskDefinition.metadata.description}`,
-          text: `[View task in Taskcluster](${taskUI(this.context.cfg.taskcluster.rootUrl, taskGroupId, taskId)})\n${checkRunArtifact || ''}`,
+          text: `[View task in Taskcluster](${taskUI(this.context.cfg.taskcluster.rootUrl, taskGroupId, taskId)})\n${customCheckRunText || ''}`,
         },
         details_url: taskGroupUI(this.context.cfg.taskcluster.rootUrl, taskGroupId),
       });

--- a/services/github/src/handlers.js
+++ b/services/github/src/handlers.js
@@ -501,7 +501,9 @@ async function statusHandler(message) {
         credentials: this.context.cfg.taskcluster.credentials,
       });
 
-      const url = this.queueClient.buildUrl(scopedQueueClient.getArtifact, taskId, runId, customCheckRun.textArtifactName);
+      const url = this.queueClient
+        .buildUrl(scopedQueueClient.getArtifact, taskId, runId, customCheckRun.textArtifactName);
+
       let res = await utils.throttleRequest({url, method: 'GET'});
 
       if (res.status >= 400) {

--- a/services/github/src/utils.js
+++ b/services/github/src/utils.js
@@ -1,0 +1,31 @@
+const request = require('superagent');
+const util = require('util');
+
+const setTimeoutPromise = util.promisify(setTimeout);
+
+const throttleRequest = async ({url, method, delay = 10, response = {status: 0}, attempt = 1}) => {
+  if (attempt > 5) {
+    return response;
+  }
+
+  let res;
+  try {
+    res = await request(method, url);
+  } catch (e) {
+    if (e.status >= 400 && e.status < 500) {
+      return e;
+    }
+    if (e.status >= 500) {
+      const newDelay = 2**attempt * 100;
+      return await setTimeoutPromise(
+        newDelay,
+        throttleRequest({url, method, delay: newDelay, response: e, attempt: attempt + 1})
+      );
+    }
+  }
+  return res;
+};
+
+module.exports = {
+  throttleRequest,
+};

--- a/services/github/src/utils.js
+++ b/services/github/src/utils.js
@@ -17,12 +17,13 @@ const throttleRequest = async ({url, method, delay = 10, response = {status: 0},
     }
     if (e.status >= 500) {
       const newDelay = 2 ** attempt * 100;
-      /* eslint-disable comma-dangle */
-      return await setTimeoutPromise(
-        newDelay,
-        throttleRequest({url, method, delay: newDelay, response: e, attempt: attempt + 1})
-      );
-      /* eslint-enable comma-dangle */
+      return await setTimeoutPromise(newDelay, throttleRequest({
+        url,
+        method,
+        delay: newDelay,
+        response: e,
+        attempt: attempt + 1,
+      }));
     }
   }
   return res;

--- a/services/github/src/utils.js
+++ b/services/github/src/utils.js
@@ -16,11 +16,13 @@ const throttleRequest = async ({url, method, delay = 10, response = {status: 0},
       return e;
     }
     if (e.status >= 500) {
-      const newDelay = 2**attempt * 100;
+      const newDelay = 2 ** attempt * 100;
+      /* eslint-disable comma-dangle */
       return await setTimeoutPromise(
         newDelay,
         throttleRequest({url, method, delay: newDelay, response: e, attempt: attempt + 1})
       );
+      /* eslint-enable comma-dangle */
     }
   }
   return res;

--- a/services/github/test/handler_test.js
+++ b/services/github/test/handler_test.js
@@ -121,7 +121,9 @@ helper.secrets.mockSuite(testing.suiteName(), ['azure'], function(mock, skipping
         }
       },
       listTaskGroup: async () => ({tasks: []}),
-      getArtifact: async() => CUSTOM_CHECKRUN_TEXT,
+      use: () => ({
+        getArtifact: async() => CUSTOM_CHECKRUN_TEXT,
+      }),
     };
 
     // set up the allowPullRequests key

--- a/services/github/test/handler_test.js
+++ b/services/github/test/handler_test.js
@@ -125,7 +125,7 @@ helper.secrets.mockSuite(testing.suiteName(), ['azure'], function(mock, skipping
       use: () => ({
         getArtifact: async() => CUSTOM_CHECKRUN_TEXT,
       }),
-      buildUrl: () => 'url'
+      buildUrl: () => 'url',
     };
 
     // set up the allowPullRequests key
@@ -781,10 +781,12 @@ helper.secrets.mockSuite(testing.suiteName(), ['azure'], function(mock, skipping
 
       assert(github.inst(9988).checks.update.calledOnce, 'checks.update was not called');
       let [args] = github.inst(9988).checks.update.firstCall.args;
+      /* eslint-disable comma-dangle */
       assert.strictEqual(
         args.output.text,
         `[${CHECKRUN_TEXT}](${libUrls.testRootUrl()}/tasks/${CUSTOM_CHECKRUN_TASKID})\n${CUSTOM_CHECKRUN_TEXT}`
       );
+      /* eslint-enable comma-dangle */
       sinon.restore();
     });
 
@@ -803,7 +805,8 @@ helper.secrets.mockSuite(testing.suiteName(), ['azure'], function(mock, skipping
       });
       assert(monitorManager.messages.some(({Type, Severity}) => Type === 'monitor.error' && Severity === LEVELS.err));
       monitorManager.reset();
-    })
+      sinon.restore();
+    });
   });
 
   suite('Statuses API: initial status handler', function() {

--- a/services/github/test/handler_test.js
+++ b/services/github/test/handler_test.js
@@ -645,10 +645,15 @@ helper.secrets.mockSuite(testing.suiteName(), ['azure'], function(mock, skipping
       }
     });
 
+    setup(function() {
+      sinon.stub(utils, "throttleRequest").returns({status: 404, response: {error: {text: "Resource not found"}}});
+    });
+
     teardown(async function() {
       await helper.Builds.remove({taskGroupId: TASKGROUPID}, true);
       await helper.CheckRuns.remove({taskGroupId: TASKGROUPID, taskId: TASKID}, true);
       await helper.CheckRuns.remove({taskGroupId: TASKGROUPID, taskId: CUSTOM_CHECKRUN_TASKID}, true);
+      sinon.restore();
     });
 
     const TASKGROUPID = 'AXB-sjV-SoCyibyq3P32ow';
@@ -769,6 +774,7 @@ helper.secrets.mockSuite(testing.suiteName(), ['azure'], function(mock, skipping
     test('successfully adds custom check run text from an artifact', async function () {
       await addBuild({state: 'pending', taskGroupId: TASKGROUPID});
       await addCheckRun({taskGroupId: TASKGROUPID, taskId: CUSTOM_CHECKRUN_TASKID});
+      sinon.restore();
       sinon.stub(utils, "throttleRequest").returns({status: 200, text: CUSTOM_CHECKRUN_TEXT});
       await simulateExchangeMessage({
         taskGroupId: TASKGROUPID,
@@ -794,6 +800,7 @@ helper.secrets.mockSuite(testing.suiteName(), ['azure'], function(mock, skipping
       // note: production code doesn't throw the error, just logs it, so the handlers is not interrupted
       await addBuild({state: 'pending', taskGroupId: TASKGROUPID});
       await addCheckRun({taskGroupId: TASKGROUPID, taskId: CUSTOM_CHECKRUN_TASKID});
+      sinon.restore();
       sinon.stub(utils, "throttleRequest").returns({status: 418, response: {error: {text: "I'm a tea pot"}}});
       await simulateExchangeMessage({
         taskGroupId: TASKGROUPID,

--- a/ui/docs/reference/integrations/github/checks.mdx
+++ b/ui/docs/reference/integrations/github/checks.mdx
@@ -4,8 +4,7 @@ Taskcluster-Github supports [Github's Checks API](https://developer.github.com/v
 At the moment, the feature is in beta. If you would like to try it out:
 * Make sure you use `.taskcluster.yml` v1
 * Add `reporting: checks-v1` line at the root level of your `.taskcluster.yml`
-* You will need `queue:route:checks` scope for your github client (at the time of writing, you need to contact the
-releng team to get that scope).
+* You will need `queue:route:checks` scope for your `repo:github.com/org/repo:<action>` role.
 * If you are using a decision task, make sure you add `route.checks` to the `routes` of your tasks
 
 ## Custom Output in Checks

--- a/ui/docs/reference/integrations/github/checks.mdx
+++ b/ui/docs/reference/integrations/github/checks.mdx
@@ -8,33 +8,44 @@ At the moment, the feature is in beta. If you would like to try it out:
 * If you are using a decision task, make sure you add `route.checks` to the `routes` of your tasks
 
 ## Custom Output in Checks
+ 
+ When a task completes, the Taskcluster-GitHub service can optionally include task-specific information in the check run 
+ displayed in the GitHub checks tab.  To do so, it looks for an artifact on the task named 
+ `public/github/customCheckRunText.md` and uses the artifact content as the check run text.  
+ The artifact name can be customized by setting `task.extra.github.customCheckRun.textArtifactName` in the task definition.  
+ For example:
+```
+payload:
+  ...
+  artifacts:
+    public/github/customCheckRunText.md:
+      type: file
+      path: checkrun.md
+```
+or, if for example all build results are in `public/results`:
+```
+payload:
+  ...
+  artifacts:
+    public/results:
+      type: directory
+      path: results
+task:
+  extra:
+    github:
+      customCheckRun:
+        textArtifactName: public/results/checkrun.md
+```
 
-If you need to add some sort of custom output to your checks (for example, you would like to process
-your logs and add some results to the check's body):
-* You need to arrange for an artifact with the custom text (plain or Markdown) you'd like to add to your check 
- (for the above example, you arrange the processing of your logs in the way you want, 
- format the result the way you want using Markdown and save the result in an artifact)
-* Add something like 
-    ```YML
-    extra:
-        github:
-            customCheckRun:
-                textArtifactName: <artifact_name>
-    ```
- to the definition of the task for which you want customize the check. If you don't want to bother with that,
- you can just make sure you name your artifact `customCheckRunText.md`, and tc-gh would fetch that automatically.
- Please note that at the moment we do not support private artifacts for this functionality, so do make sure
- to add `public/` prefix to your artifact name when using `Queue.createArtifact` endpoint
- (like this: `public/<file_name>`).
  
 ### Debugging Errors in Custom Output
  
 * If you see a `Cannot GET blahblah (403)` kind of error, it's likely that your artifact is private. Make sure you use
-  a public artifact.
+  a public artifact (see note on the naming convention above).
 * If there is no error at all and you don't see your custom text in the checkrun, it means there was a 
   404 kind of error. It can mean the artifact wasn't created successfully or there is a typo in the name of your
   artifact or in your `extra.github.customCheckRun` section if you use one.
-  Make sure the artifact exists and is named correctly.
+  Make sure the artifact exists and is named or referenced correctly.
   
 ## Reporting Bugs
 

--- a/ui/docs/reference/integrations/github/checks.mdx
+++ b/ui/docs/reference/integrations/github/checks.mdx
@@ -22,18 +22,15 @@ your logs and add some results to the check's body):
                 textArtifactName: <artifact_name>
     ```
  to the definition of the task for which you want customize the check. If you don't want to bother with that,
- you can just make sure you name your artifact `customCheckRunText.md`, and tc-gh would fetch that automatically
-* If it's OK with you that the artifact is public, make sure to start the name of your artifact with
- `public/`, like this: `public/<file_name>` both when you create the artifact and reference it in your
- task definition. In this case, you will not need any scopes.
-* If you don't want the artifact to be public, name your artifact simply `<file_name>` both when creating it
- and referencing it in your task definition. In this case, you will need a `queue:get-artifact:<file_name>`
- scope. Add it to the `scopes` section of the same task.
+ you can just make sure you name your artifact `customCheckRunText.md`, and tc-gh would fetch that automatically.
+ Please note that at the moment we do not support private artifacts for this functionality, so do make sure
+ to add `public/` prefix to your artifact name when using `Queue.createArtifact` endpoint
+ (like this: `public/<file_name>`).
  
 ### Debugging Errors in Custom Output
  
-* If you see a `Cannot GET blahblah (403)` kind of error, it's likely that your artifact is private and you
-  forgot to add the scope to the `scopes` section of your task definition.
+* If you see a `Cannot GET blahblah (403)` kind of error, it's likely that your artifact is private. Make sure you use
+  a public artifact.
 * If there is no error at all and you don't see your custom text in the checkrun, it means there was a 
   404 kind of error. It can mean the artifact wasn't created successfully or there is a typo in the name of your
   artifact or in your `extra.github.customCheckRun` section if you use one.
@@ -41,6 +38,7 @@ your logs and add some results to the check's body):
   
 ## Reporting Bugs
 
-If you are unhappy with something in Checks, please [file a bug here](https://bugzilla.mozilla.org/enter_bug.cgi?product=Taskcluster&component=Services)
+If you are unhappy with something in Checks or want to make a feature request, please 
+[file a bug here](https://bugzilla.mozilla.org/enter_bug.cgi?product=Taskcluster&component=Services)
 If you want the bug to be addressed sooner rather than later, do make sure to start the `Summary` field with `[tc-github]`.
 Thank you!

--- a/ui/docs/reference/integrations/github/checks.mdx
+++ b/ui/docs/reference/integrations/github/checks.mdx
@@ -21,7 +21,8 @@ your logs and add some results to the check's body):
             customCheckRun:
                 textArtifactName: <artifact_name>
     ```
- to the definition of the task for which you want customize the check.
+ to the definition of the task for which you want customize the check. If you don't want to bother with that,
+ you can just make sure you name your artifact `customCheckRunText.md`, and tc-gh would fetch that automatically
 * If it's OK with you that the artifact is public, make sure to start the name of your artifact with
  `public/`, like this: `public/<file_name>` both when you create the artifact and reference it in your
  task definition. In this case, you will not need any scopes.
@@ -33,9 +34,10 @@ your logs and add some results to the check's body):
  
 * If you see a `Cannot GET blahblah (403)` kind of error, it's likely that your artifact is private and you
   forgot to add the scope to the `scopes` section of your task definition.
-* If you see a `Cannot GET blahblah (404)` kind of error, it means the artifact wasn't created successfully
-  or there is an error in your `extra.github.customCheckRun` section.
-  Make sure the artifact exists.
+* If there is no error at all and you don't see your custom text in the checkrun, it means there was a 
+  404 kind of error. It can mean the artifact wasn't created successfully or there is a typo in the name of your
+  artifact or in your `extra.github.customCheckRun` section if you use one.
+  Make sure the artifact exists and is named correctly.
   
 ## Reporting Bugs
 

--- a/ui/docs/reference/integrations/github/checks.mdx
+++ b/ui/docs/reference/integrations/github/checks.mdx
@@ -4,7 +4,8 @@ Taskcluster-Github supports [Github's Checks API](https://developer.github.com/v
 At the moment, the feature is in beta. If you would like to try it out:
 * Make sure you use `.taskcluster.yml` v1
 * Add `reporting: checks-v1` line at the root level of your `.taskcluster.yml`
-* You will need `queue:route:checks` scope
+* You will need `queue:route:checks` scope for your github client (at the time of writing, you need to contact the
+releng team to get that scope).
 * If you are using a decision task, make sure you add `route.checks` to the `routes` of your tasks
 
 ## Custom Output in Checks
@@ -33,7 +34,8 @@ your logs and add some results to the check's body):
  
 * If you see a `Cannot GET blahblah (403)` kind of error, it's likely that your artifact is private and you
   forgot to add the scope to the `scopes` section of your task definition.
-* If you see a `Cannot GET blahblah (404)` kind of error, it means the artifact wasn't created successfully.
+* If you see a `Cannot GET blahblah (404)` kind of error, it means the artifact wasn't created successfully
+  or there is an error in your `extra.github.customCheckRun` section.
   Make sure the artifact exists.
   
 ## Reporting Bugs

--- a/ui/docs/reference/integrations/github/checks.mdx
+++ b/ui/docs/reference/integrations/github/checks.mdx
@@ -1,0 +1,43 @@
+# Taskcluster-Github Checks
+
+Taskcluster-Github supports [Github's Checks API](https://developer.github.com/v3/checks/).
+At the moment, the feature is in beta. If you would like to try it out:
+* Make sure you use `.taskcluster.yml` v1
+* Add `reporting: checks-v1` line at the root level of your `.taskcluster.yml`
+* You will need `queue:route:checks` scope
+* If you are using a decision task, make sure you add `route.checks` to the `routes` of your tasks
+
+## Custom Output in Checks
+
+If you need to add some sort of custom output to your checks (for example, you would like to process
+your logs and add some results to the check's body):
+* You need to arrange for an artifact with the custom text (plain or Markdown) you'd like to add to your check 
+ (for the above example, you arrange the processing of your logs in the way you want, 
+ format the result the way you want using Markdown and save the result in an artifact)
+* Add something like 
+    ```YML
+    extra:
+        github:
+            customCheckRun:
+                textArtifactName: <artifact_name>
+    ```
+ to the definition of the task for which you want customize the check.
+* If it's OK with you that the artifact is public, make sure to start the name of your artifact with
+ `public/`, like this: `public/<file_name>` both when you create the artifact and reference it in your
+ task definition. In this case, you will not need any scopes.
+* If you don't want the artifact to be public, name your artifact simply `<file_name>` both when creating it
+ and referencing it in your task definition. In this case, you will need a `queue:get-artifact:<file_name>`
+ scope. Add it to the `scopes` section of the same task.
+ 
+### Debugging Errors in Custom Output
+ 
+* If you see a `Cannot GET blahblah (403)` kind of error, it's likely that your artifact is private and you
+  forgot to add the scope to the `scopes` section of your task definition.
+* If you see a `Cannot GET blahblah (404)` kind of error, it means the artifact wasn't created successfully.
+  Make sure the artifact exists.
+  
+## Reporting Bugs
+
+If you are unhappy with something in Checks, please [file a bug here](https://bugzilla.mozilla.org/enter_bug.cgi?product=Taskcluster&component=Services)
+If you want the bug to be addressed sooner rather than later, do make sure to start the `Summary` field with `[tc-github]`.
+Thank you!


### PR DESCRIPTION
<!-- Did you remember to add a changelog snippet? See
     https://github.com/taskcluster/taskcluster/blob/master/dev-docs/best-practices/changelog.md

     If this is related to a Bugzilla bug, please begin your title with [Bug XXXXX]
     and update this link.  Otherwise, just remove it from your PR comment.  -->

Bugzilla Bug: [1552323](https://bugzilla.mozilla.org/show_bug.cgi?id=1552323)
as well as the Finix feature request.

The general idea is that if people want custom task results in checkruns, they need:

* Arrange for an artifact with markdown-formatted output in `.md` format
* Put the artifact's name in the task definition's `extra.github`
* Taskcluster-github will post the contents of the artifact in the check run