### PR TITLE
Bug 1621270 - retry GitHub artifact uploads

### DIFF
--- a/changelog/bug-1621270.md
+++ b/changelog/bug-1621270.md
@@ -1,0 +1,3 @@
+level: silent
+reference: bug 1621270
+---

--- a/infrastructure/tooling/src/publish/tasks.js
+++ b/infrastructure/tooling/src/publish/tasks.js
@@ -179,15 +179,31 @@ module.exports = ({tasks, cmdOptions, credentials, baseDir}) => {
       for (let {name, contentType} of files) {
         utils.status({message: `Upload Release asset ${name}`});
         const file = await readFile(path.join(artifactsDir, name));
-        await octokit.repos.uploadReleaseAsset({
-          url: upload_url,
-          headers: {
-            'content-length': file.length,
-            'content-type': contentType,
-          },
-          name,
-          file,
-        });
+
+        /* Artifact uploads to GitHub seem to fail.. a lot.  So we retry each
+         * one a few times with some delay, in hopes of getting lucky.  */
+        let retries = 5;
+        while (retries-- > 0) {
+          try {
+            await octokit.repos.uploadReleaseAsset({
+              url: upload_url,
+              headers: {
+                'content-length': file.length,
+                'content-type': contentType,
+              },
+              name,
+              file,
+            });
+          } catch (err) {
+            if (!retries) {
+              throw err;
+            }
+            await new Promise(resolve => setTimeout(resolve, 5000));
+            utils.status({message: `Upload release asset ${name} - retrying after error`});
+            continue;
+          }
+          break;
+        }
       }
 
       return {


### PR DESCRIPTION
Bugzilla Bug: [1621270](https://bugzilla.mozilla.org/show_bug.cgi?id=1621270)
