### PR TITLE
Do not reqiure a changelog for changes that only affect go.mod/sum

### DIFF
--- a/changelog/VxQghtPGTDSilg3zoHTrxQ.md
+++ b/changelog/VxQghtPGTDSilg3zoHTrxQ.md
@@ -1,0 +1,2 @@
+level: silent
+---

--- a/infrastructure/tooling/src/changelog/index.js
+++ b/infrastructure/tooling/src/changelog/index.js
@@ -168,6 +168,7 @@ const check_pr = async (pr) => {
   const boringFiles = [
     /yarn\.lock$/,
     /package\.json$/,
+    /^go\.(mod|sum)$/,
     /^\.yarn$/,
     /^\.taskcluster.yml/,
     /^infrastructure\//,


### PR DESCRIPTION
In particular, this should whitelist renovate's changes