### PR TITLE
include internal/ in version bumps in yarn release

### DIFF
--- a/infrastructure/tooling/src/release/tasks.js
+++ b/infrastructure/tooling/src/release/tasks.js
@@ -171,6 +171,7 @@ module.exports = ({tasks, cmdOptions, credentials}) => {
         'clients/client-go/**',
         'clients/client-shell/**',
         'tools/**',
+        'internal/**',
         // Provide explicit list of allowed file extensions so that
         // workers/generic-worker/testdata/*.zip files are not modified.
         'workers/generic-worker/**.go',


### PR DESCRIPTION
Fixes #2479.

I looked at adding a `go sometihng` run to `yarn release` to make sure we got all of these, but [there is no simple invocation to do this](https://github.com/golang/go/issues/15513) and anyway generic-worker's tests don't compile under a simple `go test`.  So this will do.