### PR TITLE
Bug 1621630 - roll back JSON-e to 3.0.2 temporarily

### DIFF
--- a/changelog/bug-1621630.md
+++ b/changelog/bug-1621630.md
@@ -1,0 +1,4 @@
+level: minor
+reference: bug 1621630
+---
+JSON-e has been reverted to v3.0.2, meaning that short-circuit evaluation of boolean operators is again unsupported.  This support will return soon.

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "irc-upd": "^0.10.0",
     "iterall": "^1.2.2",
     "js-yaml": "^3.13.1",
-    "json-e": "^4.0.0",
+    "json-e": "3.0.2",
     "json-parameterization": "^2.0.0",
     "jsonwebtoken": "^8.1.1",
     "jwks-rsa": "^1.2.1",

--- a/services/hooks/test/taskcreator_test.js
+++ b/services/hooks/test/taskcreator_test.js
@@ -163,7 +163,7 @@ suite(testing.suiteName(), function() {
       try {
         await creator.fire(hook, {firedBy: 'me'}, {taskId});
       } catch (err) {
-        if (!err.toString().match(/SyntaxError/)) {
+        if (!err.toString().match(/unknown context value uhoh/)) {
           throw err;
         }
 
@@ -173,7 +173,7 @@ suite(testing.suiteName(), function() {
           taskId: taskId,
         });
         assume(lf.result).to.equal('error');
-        assume(lf.error).to.match(/SyntaxError/);
+        assume(lf.error).to.match(/unknown context value uhoh/);
         assume(lf.firedBy).to.equal('me');
 
         assertFireLogged({firedBy: "me", taskId, result: 'failure'});

--- a/yarn.lock
+++ b/yarn.lock
@@ -4397,10 +4397,10 @@ json-buffer@3.0.0:
   resolved "https://registry.yarnpkg.com/json-buffer/-/json-buffer-3.0.0.tgz#5b1f397afc75d677bde8bcfc0e47e1f9a3d9a898"
   integrity sha1-Wx85evx11ne96Lz8Dkfh+aPZqJg=
 
-json-e@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/json-e/-/json-e-4.0.0.tgz#a95739914fe567baf452340c9392dcd12eaa998b"
-  integrity sha512-B+EmuBzVRCWQ1G1kYzD73whYrXNF1R7fCrAZyrvUnXcqWoTxrMTrOiYZX6y+pmXh0h+QrXRPMsTJhP2wMbge5g==
+json-e@3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/json-e/-/json-e-3.0.2.tgz#46b6c8e0dde340c3ead8f90efe35f3e1ee99e55b"
+  integrity sha512-6WtdeX8HkMvfKfT064c7pzonvQ5DNiAjUiiZH5S28XzAESkfl3uc1X7N8Yg+8Ka2lqqvYOnWincT926q0jMsSg==
   dependencies:
     json-stable-stringify-without-jsonify "^1.0.1"
 
@@ -7300,44 +7300,48 @@ tar-stream@^2.0.0:
     readable-stream "^3.1.1"
 
 "taskcluster-client@link:clients/client":
-  version "26.0.1"
-  dependencies:
-    "@hapi/hawk" "^7.1.2"
-    debug "^4.1.1"
-    lodash "^4.17.4"
-    slugid "^2.0.0"
-    superagent "^5.0.0"
-    taskcluster-lib-urls "^12.0.0"
+  version "0.0.0"
+  uid ""
 
 "taskcluster-lib-api@link:libraries/api":
-  version "26.0.1"
+  version "0.0.0"
+  uid ""
 
 "taskcluster-lib-app@link:libraries/app":
-  version "26.0.1"
+  version "0.0.0"
+  uid ""
 
 "taskcluster-lib-azure@link:libraries/azure":
-  version "26.0.1"
+  version "0.0.0"
+  uid ""
 
 "taskcluster-lib-config@link:libraries/config":
-  version "26.0.1"
+  version "0.0.0"
+  uid ""
 
 "taskcluster-lib-iterate@link:libraries/iterate":
-  version "26.0.1"
+  version "0.0.0"
+  uid ""
 
 "taskcluster-lib-loader@link:libraries/loader":
-  version "26.0.1"
+  version "0.0.0"
+  uid ""
 
 "taskcluster-lib-monitor@link:libraries/monitor":
-  version "26.0.1"
+  version "0.0.0"
+  uid ""
 
 "taskcluster-lib-postgres@link:libraries/postgres":
-  version "26.0.1"
+  version "0.0.0"
+  uid ""
 
 "taskcluster-lib-pulse@link:libraries/pulse":
-  version "26.0.1"
+  version "0.0.0"
+  uid ""
 
 "taskcluster-lib-references@link:libraries/references":
-  version "26.0.1"
+  version "0.0.0"
+  uid ""
 
 taskcluster-lib-scopes@^11.0.0:
   version "11.0.0"
@@ -7347,7 +7351,8 @@ taskcluster-lib-scopes@^11.0.0:
     fast-json-stable-stringify "^2.1.0"
 
 "taskcluster-lib-testing@link:libraries/testing":
-  version "26.0.1"
+  version "0.0.0"
+  uid ""
 
 taskcluster-lib-urls@^12.0.0:
   version "12.0.0"
@@ -7355,7 +7360,8 @@ taskcluster-lib-urls@^12.0.0:
   integrity sha512-OrEFE0m3p/+mGsmIwjttLhSKg3io6MpJLhYtPNjVSZA9Ix8Y5tprN3vM6a3MjWt5asPF6AKZsfT43cgpGwJB0g==
 
 "taskcluster-lib-validate@link:libraries/validate":
-  version "26.0.1"
+  version "0.0.0"
+  uid ""
 
 temporary@^1.0.0:
   version "1.0.1"


### PR DESCRIPTION
Bugzilla Bug: [1621630](https://bugzilla.mozilla.org/show_bug.cgi?id=1621630)

See the bug for details -- this caused errors in production.