### PR TITLE
Revert json-e dependency to 3.0.1

### DIFF
--- a/changelog/bug-1621630-2.md
+++ b/changelog/bug-1621630-2.md
@@ -1,0 +1,4 @@
+level: minor
+reference: bug 1621630
+---
+JSON-e has been reverted to v3.0.1, meaning that short-circuit evaluation of boolean operators is again unsupported.  This support will return soon.

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "irc-upd": "^0.10.0",
     "iterall": "^1.2.2",
     "js-yaml": "^3.13.1",
-    "json-e": "3.0.2",
+    "json-e": "3.0.1",
     "json-parameterization": "^2.0.0",
     "jsonwebtoken": "^8.1.1",
     "jwks-rsa": "^1.2.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4397,10 +4397,10 @@ json-buffer@3.0.0:
   resolved "https://registry.yarnpkg.com/json-buffer/-/json-buffer-3.0.0.tgz#5b1f397afc75d677bde8bcfc0e47e1f9a3d9a898"
   integrity sha1-Wx85evx11ne96Lz8Dkfh+aPZqJg=
 
-json-e@3.0.2:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/json-e/-/json-e-3.0.2.tgz#46b6c8e0dde340c3ead8f90efe35f3e1ee99e55b"
-  integrity sha512-6WtdeX8HkMvfKfT064c7pzonvQ5DNiAjUiiZH5S28XzAESkfl3uc1X7N8Yg+8Ka2lqqvYOnWincT926q0jMsSg==
+json-e@3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/json-e/-/json-e-3.0.1.tgz#8e674e622012559747994f872739ea142cff4453"
+  integrity sha512-ZYUZ6KXdeL52Gd9yh7ig3k0a+O/5XwlBnel5fDHuCxAcAMXfqbed5FkCnZYiv52E0uB8dHoP5W7xOHjfISzHnQ==
   dependencies:
     json-stable-stringify-without-jsonify "^1.0.1"
 


### PR DESCRIPTION
<!-- Did you remember to add a changelog snippet? See
     https://github.com/taskcluster/taskcluster/blob/master/dev-docs/best-practices/changelog.md

     If this is related to a Bugzilla bug, please begin your title with [Bug XXXXX]
     and update this link.  Otherwise, just remove it from your PR comment.  -->

Bugzilla Bug: [1621630](https://bugzilla.mozilla.org/show_bug.cgi?id=1621630)

