### PR TITLE
Add worker-runner to the release process

### DIFF
--- a/changelog/QoaFRYyEQSyH0y3mXS1GfA.md
+++ b/changelog/QoaFRYyEQSyH0y3mXS1GfA.md
@@ -1,0 +1,3 @@
+level: minor
+---
+Add worker-runner binaries to the list of release artifacts

--- a/infrastructure/tooling/src/generate/generators/worker-runner.js
+++ b/infrastructure/tooling/src/generate/generators/worker-runner.js
@@ -1,0 +1,17 @@
+const path = require('path');
+const {REPO_ROOT, execCommand} = require('../../utils');
+
+exports.tasks = [];
+
+exports.tasks.push({
+  title: 'Update worker-runner README file',
+  requires: ['references-json', 'target-go-version'],
+  provides: ['target-worker-runner'],
+  run: async (requirements, utils) => {
+    await execCommand({
+      dir: path.join(REPO_ROOT, 'tools', 'taskcluster-worker-runner'),
+      command: ['go', 'run', path.join('util', 'update-readme.go')],
+      utils,
+    });
+  },
+});

--- a/infrastructure/tooling/src/release/tasks.js
+++ b/infrastructure/tooling/src/release/tasks.js
@@ -184,11 +184,17 @@ module.exports = ({tasks, cmdOptions, credentials}) => {
         changed.push(file);
       }
 
-      const genericworker = 'workers/generic-worker/main.go';
-      utils.status({message: `Update ${genericworker}`});
-      await modifyRepoFile(genericworker, contents =>
-        contents.replace(/^(\s*version\s*=\s*).*/m, `$1"${requirements['release-version']}"`));
-      changed.push(genericworker);
+      const otherFiles = [
+        'workers/generic-worker/main.go',
+        'tools/taskcluster-worker-runner/version.go',
+      ];
+
+      for (const f of otherFiles) {
+        utils.status({message: `Update ${f}`});
+        await modifyRepoFile(f, contents =>
+          contents.replace(/^(\s*[vV]ersion\s*=\s*).*/m, `$1"${requirements['release-version']}"`));
+        changed.push(f);
+      }
 
       return {'version-updated': changed};
     },

--- a/tools/taskcluster-worker-runner/build.sh
+++ b/tools/taskcluster-worker-runner/build.sh
@@ -1,11 +1,18 @@
 #! /bin/bash
 
+outdir="./"
+
+if ! test -z "$1"; then
+    outdir=$1
+fi
+
 build() {
     local output=start-worker-${1}-${2}
-    GOOS="${1}" GOARCH="${2}" CGO_ENABLED=0 go build -o $output ./cmd/start-worker
+    GOOS="${1}" GOARCH="${2}" CGO_ENABLED=0 go build -o $outdir/$output ./cmd/start-worker
     echo $output
 }
-echo "Building:"
+
+echo "Building worker-runner:"
 build linux amd64
 build windows amd64
 build windows 386

--- a/tools/taskcluster-worker-runner/provider/provider/shutdown_unix.go
+++ b/tools/taskcluster-worker-runner/provider/provider/shutdown_unix.go
@@ -1,3 +1,5 @@
+// +build linux darwin freebsd
+
 package provider
 
 import "os/exec"


### PR DESCRIPTION
* `yarn generate` runs `util/update-readme.go`
*  `yarn release` updates `worker-runner` version
* `yarn release:publish` add `worker-runner` binaries to the release artifacts

Each commit is self contended to make reviewing easier. 