### PR TITLE
Bug 1622052 - distinguish local and remote proto capabilities

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -389,6 +389,7 @@ tasks:
               - secrets:get:project/taskcluster/testing/generic-worker/ci-creds
               - queue:scheduler-id:taskcluster-github
               - queue:create-task:highest:proj-taskcluster/gw-ci-*
+              - queue:route:checks
           releaseTasks:
           - taskId: {$eval: 'as_slugid("release")'}
             taskGroupId: {$eval: as_slugid('taskGroupId')}

--- a/changelog/bug-1622052.md
+++ b/changelog/bug-1622052.md
@@ -1,0 +1,4 @@
+level: patch
+reference: bug 1622052
+---
+The protocol between workers and worker manager now correctly negotiates capabilities.

--- a/tools/taskcluster-worker-runner/protocol.md
+++ b/tools/taskcluster-worker-runner/protocol.md
@@ -44,8 +44,6 @@ Since all messages aside from `welcome` and `hello` are associated with a capabi
 ```
 on startup and nothing more.
 
-If a worker is run outside of a taskcluster-worker-runner context, it will never see the `welcome` message and thus never write `hello` or any other message.
-
 A connection is considered "initialized" on the `hello` message has been sent (on a worker) or received (on start-worker).
 Before the connection is initialized, the connection's capabilities are unknown, so protocol users should wait until initialization before querying capabilities.
 

--- a/tools/taskcluster-worker-runner/protocol/capabilities.go
+++ b/tools/taskcluster-worker-runner/protocol/capabilities.go
@@ -2,28 +2,28 @@ package protocol
 
 import "sort"
 
-type Capabilities struct {
+type capabilities struct {
 	// use a map as a poor-man's set
 	capabilities map[string]bool
 }
 
-func EmptyCapabilities() *Capabilities {
-	return &Capabilities{
+func EmptyCapabilities() *capabilities {
+	return &capabilities{
 		capabilities: make(map[string]bool),
 	}
 }
 
-func FromCapabilitiesList(caplist []string) *Capabilities {
+func FromCapabilitiesList(caplist []string) *capabilities {
 	caps := make(map[string]bool)
 	for _, c := range caplist {
 		caps[c] = true
 	}
-	return &Capabilities{
+	return &capabilities{
 		capabilities: caps,
 	}
 }
 
-func (caps *Capabilities) List() []string {
+func (caps *capabilities) List() []string {
 	rv := make([]string, 0, len(caps.capabilities))
 	for c := range caps.capabilities {
 		rv = append(rv, c)
@@ -32,20 +32,20 @@ func (caps *Capabilities) List() []string {
 	return rv
 }
 
-func (caps *Capabilities) Add(c string) {
+func (caps *capabilities) Add(c string) {
 	caps.capabilities[c] = true
 }
 
-func (caps *Capabilities) Remove(c string) {
+func (caps *capabilities) Remove(c string) {
 	delete(caps.capabilities, c)
 }
 
-func (caps *Capabilities) Has(c string) bool {
+func (caps *capabilities) Has(c string) bool {
 	_, has := caps.capabilities[c]
 	return has
 }
 
-func (caps *Capabilities) LimitTo(other *Capabilities) {
+func (caps *capabilities) LimitTo(other *capabilities) {
 	newcaps := make(map[string]bool)
 	for c := range caps.capabilities {
 		if other.Has(c) {

--- a/tools/taskcluster-worker-runner/protocol/protocol.go
+++ b/tools/taskcluster-worker-runner/protocol/protocol.go
@@ -11,15 +11,16 @@ type Protocol struct {
 	// transport over which this protocol is running
 	transport Transport
 
-	// current set of agreed capabilities (but call WaitUntilInitialized first
-	// to avoid finding the empty set at startup)
-	Capabilities *Capabilities
-
-	// Capabilities of the remote peer
-	RemoteCapabilities *Capabilities
+	// local and remote capabilities
+	localCapabilities  *capabilities
+	remoteCapabilities *capabilities
 
 	// callbacks per message type
 	callbacks map[string][]MessageCallback
+
+	// tracking for whether Start has been called yet
+	started      bool
+	startedMutex sync.Mutex
 
 	// tracking for whether this protocol is intialized
 	initialized     bool
@@ -29,8 +30,8 @@ type Protocol struct {
 func NewProtocol(transport Transport) *Protocol {
 	return &Protocol{
 		transport:          transport,
-		Capabilities:       EmptyCapabilities(),
-		RemoteCapabilities: EmptyCapabilities(),
+		localCapabilities:  EmptyCapabilities(),
+		remoteCapabilities: EmptyCapabilities(),
 		callbacks:          make(map[string][]MessageCallback),
 		initialized:        false,
 		initializedCond: sync.Cond{
@@ -62,28 +63,31 @@ func listOfStrings(val interface{}) []string {
 func (prot *Protocol) Start(asWorker bool) {
 	if asWorker {
 		prot.Register("welcome", func(msg Message) {
-			prot.RemoteCapabilities = FromCapabilitiesList(listOfStrings(msg.Properties["capabilities"]))
+			prot.remoteCapabilities = FromCapabilitiesList(listOfStrings(msg.Properties["capabilities"]))
 			prot.Send(Message{
 				Type: "hello",
 				Properties: map[string]interface{}{
-					"capabilities": prot.Capabilities.List(),
+					"capabilities": prot.localCapabilities.List(),
 				},
 			})
 			prot.SetInitialized()
 		})
 	} else {
 		prot.Register("hello", func(msg Message) {
-			prot.RemoteCapabilities = FromCapabilitiesList(listOfStrings(msg.Properties["capabilities"]))
+			prot.remoteCapabilities = FromCapabilitiesList(listOfStrings(msg.Properties["capabilities"]))
 			prot.SetInitialized()
 		})
 
 		prot.Send(Message{
 			Type: "welcome",
 			Properties: map[string]interface{}{
-				"capabilities": prot.Capabilities.List(),
+				"capabilities": prot.localCapabilities.List(),
 			},
 		})
 	}
+	prot.startedMutex.Lock()
+	prot.started = true
+	prot.startedMutex.Unlock()
 	go prot.recvLoop()
 }
 
@@ -107,10 +111,21 @@ func (prot *Protocol) WaitUntilInitialized() {
 	}
 }
 
-// Check if a capability is supported, after waiting for initialization.
+// Add the given capability to the local capabilities
+func (prot *Protocol) AddCapability(c string) {
+	prot.startedMutex.Lock()
+	defer prot.startedMutex.Unlock()
+	if prot.started {
+		panic("Cannot AddCapability after protocol is started")
+	}
+	prot.localCapabilities.Add(c)
+}
+
+// Check if a capability is supported by both ends of the protocol, after
+// waiting for initialization.
 func (prot *Protocol) Capable(c string) bool {
 	prot.WaitUntilInitialized()
-	return prot.Capabilities.Has(c)
+	return prot.localCapabilities.Has(c) && prot.remoteCapabilities.Has(c)
 }
 
 // Send a message.  This happens without waiting for initialization; as the

--- a/tools/taskcluster-worker-runner/protocol/protocol_test.go
+++ b/tools/taskcluster-worker-runner/protocol/protocol_test.go
@@ -13,59 +13,101 @@ func RequireInitialized(t *testing.T, prot *Protocol, initialized bool) {
 	require.Equal(t, initialized, prot.initialized)
 }
 
-func TestProtocol(t *testing.T) {
-	runnerTransp := NewStdioTransport()
-	workerTransp := NewStdioTransport()
+func TestCapabilityNegotiation(t *testing.T) {
+	test := func(t *testing.T, runnerHasCap bool, workerHasCap bool) {
+		runnerTransp := NewStdioTransport()
+		workerTransp := NewStdioTransport()
 
-	// wire those together in both directions, and finish them at
-	// the end of the test
-	go func() {
-		_, err := io.Copy(runnerTransp, workerTransp)
-		if err != nil {
-			panic(err)
+		// wire those together in both directions, and finish them at
+		// the end of the test
+		go func() {
+			_, err := io.Copy(runnerTransp, workerTransp)
+			if err != nil {
+				panic(err)
+			}
+		}()
+		go func() {
+			_, err := io.Copy(workerTransp, runnerTransp)
+			if err != nil {
+				panic(err)
+			}
+		}()
+		defer runnerTransp.Close()
+		defer workerTransp.Close()
+
+		runnerProto := NewProtocol(runnerTransp)
+		workerProto := NewProtocol(workerTransp)
+
+		if runnerHasCap {
+			runnerProto.AddCapability("test-capability")
 		}
-	}()
-	go func() {
-		_, err := io.Copy(workerTransp, runnerTransp)
-		if err != nil {
-			panic(err)
+		if workerHasCap {
+			workerProto.AddCapability("test-capability")
 		}
-	}()
-	defer runnerTransp.Close()
-	defer workerTransp.Close()
 
-	runnerProto := NewProtocol(runnerTransp)
-	workerProto := NewProtocol(workerTransp)
+		gotWelcome := false
+		var welcomeCaps []string
+		workerProto.Register("welcome", func(msg Message) {
+			gotWelcome = true
+			welcomeCaps = listOfStrings(msg.Properties["capabilities"])
+		})
 
-	gotWelcome := false
-	var welcomeCaps []string
-	workerProto.Register("welcome", func(msg Message) {
-		gotWelcome = true
-		welcomeCaps = listOfStrings(msg.Properties["capabilities"])
+		var helloCaps []string
+		runnerProto.Register("hello", func(msg Message) {
+			helloCaps = listOfStrings(msg.Properties["capabilities"])
+		})
+
+		RequireInitialized(t, runnerProto, false)
+		RequireInitialized(t, workerProto, false)
+
+		runnerProto.Start(false)
+
+		RequireInitialized(t, runnerProto, false)
+		RequireInitialized(t, workerProto, false)
+
+		workerProto.Start(true)
+
+		runnerProto.WaitUntilInitialized()
+		workerProto.WaitUntilInitialized()
+
+		RequireInitialized(t, workerProto, true)
+		RequireInitialized(t, runnerProto, true)
+
+		require.True(t, gotWelcome)
+		if runnerHasCap {
+			require.Equal(t, welcomeCaps, []string{"test-capability"})
+		} else {
+			require.Equal(t, welcomeCaps, []string{})
+		}
+
+		if workerHasCap {
+			require.Equal(t, helloCaps, []string{"test-capability"})
+		} else {
+			require.Equal(t, helloCaps, []string{})
+		}
+
+		// Capable should only return true when both have the capability
+		if runnerHasCap && workerHasCap {
+			require.Equal(t, true, workerProto.Capable("test-capability"))
+			require.Equal(t, true, runnerProto.Capable("test-capability"))
+		} else {
+			require.Equal(t, false, workerProto.Capable("test-capability"))
+			require.Equal(t, false, runnerProto.Capable("test-capability"))
+		}
+	}
+
+	t.Run("no-capabilities", func(t *testing.T) { test(t, false, false) })
+	t.Run("runner-capabilities", func(t *testing.T) { test(t, true, false) })
+	t.Run("worker-capabilities", func(t *testing.T) { test(t, false, true) })
+	t.Run("both-capabilities", func(t *testing.T) { test(t, true, true) })
+}
+
+func TestAddCapabilitiesTooLate(t *testing.T) {
+	transp := NewNullTransport()
+	proto := NewProtocol(transp)
+	proto.Start(false)
+	RequireInitialized(t, proto, false)
+	require.Panics(t, func() {
+		proto.AddCapability("test-capability")
 	})
-
-	var helloCaps []string
-	runnerProto.Register("hello", func(msg Message) {
-		helloCaps = listOfStrings(msg.Properties["capabilities"])
-	})
-
-	RequireInitialized(t, runnerProto, false)
-	RequireInitialized(t, workerProto, false)
-
-	runnerProto.Start(false)
-
-	RequireInitialized(t, runnerProto, false)
-	RequireInitialized(t, workerProto, false)
-
-	workerProto.Start(true)
-
-	runnerProto.WaitUntilInitialized()
-	workerProto.WaitUntilInitialized()
-
-	RequireInitialized(t, workerProto, true)
-	RequireInitialized(t, runnerProto, true)
-
-	require.True(t, gotWelcome)
-	require.Equal(t, welcomeCaps, EmptyCapabilities().List())
-	require.Equal(t, helloCaps, EmptyCapabilities().List())
 }

--- a/tools/taskcluster-worker-runner/protocol/testing.go
+++ b/tools/taskcluster-worker-runner/protocol/testing.go
@@ -1,0 +1,88 @@
+package protocol
+
+import (
+	"sync"
+)
+
+// FakeTransport implements Transport and records sent messages.  It is used
+// for testing.
+type FakeTransport struct {
+	mux          sync.Mutex
+	messages     []Message
+	fakeMessages chan Message
+}
+
+func NewFakeTransport() *FakeTransport {
+	return &FakeTransport{
+		messages:     []Message{},
+		fakeMessages: make(chan Message, 10),
+	}
+}
+
+func (transp *FakeTransport) Send(msg Message) {
+	transp.mux.Lock()
+	defer transp.mux.Unlock()
+	transp.messages = append(transp.messages, msg)
+}
+
+func (transp *FakeTransport) Recv() (Message, bool) {
+	msg, ok := <-transp.fakeMessages
+	return msg, ok
+}
+
+// Queue a message to be received over this transport
+func (transp *FakeTransport) InjectMessage(msg Message) {
+	transp.fakeMessages <- msg
+}
+
+// Close this transport, indicating no more messages will be received
+func (transp *FakeTransport) Close() {
+	close(transp.fakeMessages)
+}
+
+// Get the messages that have been sent over this transport
+func (transp *FakeTransport) Messages() []Message {
+	transp.mux.Lock()
+	defer transp.mux.Unlock()
+	// make a copy of the messages that won't be modified concurrently
+	rv := make([]Message, len(transp.messages))
+	copy(rv, transp.messages)
+	return rv
+}
+
+// Clear the list of received messages
+func (transp *FakeTransport) ClearMessages() {
+	transp.mux.Lock()
+	defer transp.mux.Unlock()
+	transp.messages = []Message{}
+}
+
+// Generate a fake protocol that is initialized has the given capabilities.  Used
+// for testing.
+func FakeProtocolWithCapabilities(capabilities ...string) (transp *FakeTransport, proto *Protocol) {
+	transp = NewFakeTransport()
+
+	capabilitiesIface := make([]interface{}, 0)
+	for _, capability := range capabilities {
+		capabilitiesIface = append(capabilitiesIface, capability)
+	}
+
+	transp.InjectMessage(Message{
+		Type: "hello",
+		Properties: map[string]interface{}{
+			"capabilities": capabilitiesIface,
+		},
+	})
+
+	proto = NewProtocol(transp)
+	for _, capability := range capabilities {
+		proto.AddCapability(capability)
+	}
+
+	proto.Start(false)
+	proto.WaitUntilInitialized()
+
+	transp.ClearMessages()
+
+	return
+}

--- a/tools/taskcluster-worker-runner/protocol/transport.go
+++ b/tools/taskcluster-worker-runner/protocol/transport.go
@@ -168,34 +168,3 @@ func (transp *NullTransport) Recv() (Message, bool) {
 	// no messages are ever received
 	select {}
 }
-
-// FakeTransport implements Transport and records sent messages.  It is used
-// for testing.
-type FakeTransport struct {
-	mux      sync.Mutex
-	messages []Message
-}
-
-func NewFakeTransport() *FakeTransport {
-	return &FakeTransport{messages: []Message{}}
-}
-
-func (transp *FakeTransport) Send(msg Message) {
-	transp.mux.Lock()
-	defer transp.mux.Unlock()
-	transp.messages = append(transp.messages, msg)
-}
-
-func (transp *FakeTransport) Messages() []Message {
-	transp.mux.Lock()
-	defer transp.mux.Unlock()
-	// make a copy of the messages that won't be modified concurrently
-	rv := make([]Message, len(transp.messages))
-	copy(rv, transp.messages)
-	return rv
-}
-
-func (transp *FakeTransport) Recv() (Message, bool) {
-	// no messages are ever received
-	select {}
-}

--- a/tools/taskcluster-worker-runner/provider/aws/awsprovider.go
+++ b/tools/taskcluster-worker-runner/provider/aws/awsprovider.go
@@ -141,8 +141,8 @@ func (p *AWSProvider) WorkerStarted(state *run.State) error {
 			log.Printf("Shutdown error: %v\n", err)
 		}
 	})
-	p.proto.Capabilities.Add("shutdown")
-	p.proto.Capabilities.Add("graceful-termination")
+	p.proto.AddCapability("shutdown")
+	p.proto.AddCapability("graceful-termination")
 
 	go func() {
 		for {

--- a/tools/taskcluster-worker-runner/provider/azure/azure.go
+++ b/tools/taskcluster-worker-runner/provider/azure/azure.go
@@ -159,8 +159,8 @@ func (p *AzureProvider) WorkerStarted(state *run.State) error {
 			log.Printf("Shutdown error: %v\n", err)
 		}
 	})
-	p.proto.Capabilities.Add("shutdown")
-	p.proto.Capabilities.Add("graceful-termination")
+	p.proto.AddCapability("shutdown")
+	p.proto.AddCapability("graceful-termination")
 
 	// start polling for graceful shutdown
 	p.terminationTicker = time.NewTicker(30 * time.Second)

--- a/tools/taskcluster-worker-runner/provider/google/google.go
+++ b/tools/taskcluster-worker-runner/provider/google/google.go
@@ -121,8 +121,8 @@ func (p *GoogleProvider) WorkerStarted(state *run.State) error {
 			log.Printf("Shutdown error: %v\n", err)
 		}
 	})
-	p.proto.Capabilities.Add("shutdown")
-	p.proto.Capabilities.Add("graceful-termination")
+	p.proto.AddCapability("shutdown")
+	p.proto.AddCapability("graceful-termination")
 
 	return nil
 }

--- a/tools/taskcluster-worker-runner/provider/google/google_test.go
+++ b/tools/taskcluster-worker-runner/provider/google/google_test.go
@@ -104,10 +104,17 @@ func TestGoogleConfigureRun(t *testing.T) {
 	require.Equal(t, "in-central1-b", state.WorkerLocation["zone"])
 
 	transp := protocol.NewFakeTransport()
+	defer transp.Close()
+	transp.InjectMessage(protocol.Message{
+		Type: "hello",
+		Properties: map[string]interface{}{
+			"capabilities": []interface{}{"shutdown"},
+		},
+	})
 	proto := protocol.NewProtocol(transp)
-	proto.SetInitialized()
 
 	p.SetProtocol(proto)
 	require.NoError(t, p.WorkerStarted(&state))
+	proto.Start(false)
 	require.True(t, proto.Capable("shutdown"))
 }

--- a/workers/generic-worker/gw-decision-task/main.go
+++ b/workers/generic-worker/gw-decision-task/main.go
@@ -307,6 +307,7 @@ func (dt *DecisionTask) TaskDefinition(workerPool string, name string, descripti
 		ProvisionerID: provisionerID,
 		SchedulerID:   schedulerID,
 		Scopes:        scopes,
+		Routes:        []string{"checks"},
 		TaskGroupID:   dt.TaskGroupID,
 		WorkerType:    workerType,
 	}, nil

--- a/workers/generic-worker/main.go
+++ b/workers/generic-worker/main.go
@@ -252,7 +252,7 @@ func initializeWorkerRunnerProtocol(input io.Reader, output io.Writer, withWorke
 	}
 
 	WorkerRunnerProtocol = protocol.NewProtocol(workerRunnerTransport)
-	WorkerRunnerProtocol.Capabilities.Add("graceful-termination")
+	WorkerRunnerProtocol.AddCapability("graceful-termination")
 	WorkerRunnerProtocol.Start(true)
 
 	// when not using worker-runner, consider the protocol initialized with no capabilities


### PR DESCRIPTION
This makes capabilities a private property of Protocol, with methods to
manipulate it.  It also prohibits adding a capability after
protocol.Start is called.

This change simplifies the interface, but makes the tests a bit more
verbose!

Bugzilla Bug: [1622052](https://bugzilla.mozilla.org/show_bug.cgi?id=1622052)

I've cherry-picked the try-checks thing so that I can see the g-w results in the github checks on this PR.  If #2500 doesn't land as-is, I'll remove that commit before merging this PR.