### PR TITLE
No bug - trivial doc links fix

### DIFF
--- a/changelog/BcRMAjAzQhePEpkylqhbCA.md
+++ b/changelog/BcRMAjAzQhePEpkylqhbCA.md
@@ -1,0 +1,2 @@
+level: silent
+---

--- a/infrastructure/tooling/src/generate/generators/generic-worker.js
+++ b/infrastructure/tooling/src/generate/generators/generic-worker.js
@@ -70,15 +70,15 @@ exports.tasks.push({
     const schemaFiles = requirements['generic-worker-schemas'].map(({filename, content}) => ({
       $id: content.$id,
       title: content.title,
-      filename: path.basename(content.$id, '.json#').replace('_', '-') + '-payload.mdx',
+      filename_base: path.basename(content.$id, '.json#').replace('_', '-') + '-payload',
     }));
 
-    for (let {$id, title, filename} of schemaFiles) {
-      await writeRepoFile(path.join(gwDocsDir, filename), schemaMdx(title, $id));
+    for (let {$id, title, filename_base} of schemaFiles) {
+      await writeRepoFile(path.join(gwDocsDir, filename_base + '.mdx'), schemaMdx(title, $id));
     }
 
     const links = schemaFiles
-      .map(({title, filename}) => ` * [${title}](/docs/reference/workers/generic-worker/${filename})`)
+      .map(({title, filename_base}) => ` * [${title}](/docs/reference/workers/generic-worker/${filename_base})`)
       .join('\n');
 
     await modifyRepoFile(path.join(gwDocsDir, 'README.mdx'),

--- a/ui/docs/reference/workers/generic-worker/README.mdx
+++ b/ui/docs/reference/workers/generic-worker/README.mdx
@@ -7,7 +7,7 @@ This documentation is a work in progress.
 
 ## Payload Formats
 
-When submitting a task to the Taskcluster Queue (see [createTask](/reference/platform/queue/reference/api-docs#createTask)) you must provide a payload property for the task. 
+When submitting a task to the Taskcluster Queue (see [createTask](/docs/reference/platform/queue/api#createTask)) you must provide a payload property for the task.
 This `payload` property is specific to the worker implementation, and tells the worker what to execute, and which artifacts to upload.
 The worker will run the task, upload artifacts, and report status to the Queue.
 
@@ -17,10 +17,10 @@ Depending on the operating system of the worker, and the generic-worker engine t
 Please see the following pages for guidance:
 
 <!-- BEGIN PAYLOAD LINKS -->
- * [Generic worker payload - docker, posix](/docs/reference/workers/generic-worker/docker-posix-payload.mdx)
- * [Generic worker payload - multiuser, posix](/docs/reference/workers/generic-worker/multiuser-posix-payload.mdx)
- * [Generic worker payload - multiuser, windows](/docs/reference/workers/generic-worker/multiuser-windows-payload.mdx)
- * [Generic worker payload - simple, posix](/docs/reference/workers/generic-worker/simple-posix-payload.mdx)
+ * [Generic worker payload - docker, posix](/docs/reference/workers/generic-worker/docker-posix-payload)
+ * [Generic worker payload - multiuser, posix](/docs/reference/workers/generic-worker/multiuser-posix-payload)
+ * [Generic worker payload - multiuser, windows](/docs/reference/workers/generic-worker/multiuser-windows-payload)
+ * [Generic worker payload - simple, posix](/docs/reference/workers/generic-worker/simple-posix-payload)
 <!-- END PAYLOAD LINKS -->
 
 ## More Information


### PR DESCRIPTION
This fixes the broken payload links in https://community-tc.services.mozilla.com/docs/reference/workers/generic-worker.