### PR TITLE
Disable tasks on pools with insufficient capacity, linux-arm to tier 2

### DIFF
--- a/changelog/QF5L1OhCR_y8k8B2RF4zQA.md
+++ b/changelog/QF5L1OhCR_y8k8B2RF4zQA.md
@@ -1,0 +1,3 @@
+level: patch
+---
+The linux-arm builds of generic-worker are now considered [Tier-2](https://docs.taskcluster.net/docs/reference/workers/generic-worker/support-tiers), meaning that they are not tested in CI (but are still built).

--- a/ui/docs/reference/workers/generic-worker/support-tiers.mdx
+++ b/ui/docs/reference/workers/generic-worker/support-tiers.mdx
@@ -24,8 +24,6 @@ The Tier-1 platforms are:
 * generic-worker-multiuser-windows-amd64
 * generic-worker-simple-darwin-amd64
 * generic-worker-simple-linux-amd64
-* generic-worker-simple-linux-arm
-* generic-worker-simple-linux-arm64
 
 ## Tier 2
 
@@ -36,6 +34,8 @@ That means that
 * Binaries are not provided with each Taskcluster release
 
 * generic-worker-docker-linux-amd64
+* generic-worker-simple-linux-arm
+* generic-worker-simple-linux-arm64
 
 ## Tier 3
 

--- a/workers/generic-worker/gw-decision-task/tasks.yml
+++ b/workers/generic-worker/gw-decision-task/tasks.yml
@@ -45,9 +45,6 @@ Tasks:
     - WorkerPool: 'proj-taskcluster/gw-ci-macos'
       Env:
         ENGINE: 'simple'
-    - WorkerPool: 'proj-taskcluster/gw-ci-raspbian-stretch'
-      Env:
-        ENGINE: 'simple'
     - WorkerPool: 'proj-taskcluster/gw-ci-ubuntu-18-04'
       Env:
         ENGINE: 'multiuser'
@@ -57,37 +54,36 @@ Tasks:
     - WorkerPool: 'proj-taskcluster/gw-ci-ubuntu-18-04'
       Env:
         ENGINE: 'docker'
-    - WorkerPool: 'proj-taskcluster/gw-ci-windows10-amd64'
-      Env:
-        ENGINE: 'multiuser'
-        # We must set here since this worker pool does not have a Z: drive
-        GW_SKIP_Z_DRIVE_TESTS: 'true'
-        # This worker pool has no mozilla-build installation
-        GW_SKIP_MOZILLA_BUILD_TESTS: 'true'
-        # This worker pool has no python installation
-        GW_SKIP_PYTHON_TESTS: 'true'
-    - WorkerPool: 'proj-taskcluster/gw-ci-windows10-arm'
-      Env:
-        ENGINE: 'multiuser'
-        # We must set here since this worker pool does not have a Z: drive
-        GW_SKIP_Z_DRIVE_TESTS: 'true'
-        # This worker pool has no mozilla-build installation
-        GW_SKIP_MOZILLA_BUILD_TESTS: 'true'
-        # This worker pool has no python installation
-        GW_SKIP_PYTHON_TESTS: 'true'
     - WorkerPool: 'proj-taskcluster/gw-ci-windows2012r2-amd64'
       Env:
         ENGINE: 'multiuser'
         # We must set here since this worker type does not have a Z: drive
         GW_SKIP_Z_DRIVE_TESTS: 'true'
-#####################################################################
-#   #############################################################   #
-#   # DISABLING WINDOWS 7 UNTIL WE HAVE WINDOWS 7 WORKERS AGAIN #   #
-#   #############################################################   #
-#   - WorkerPool: 'proj-taskcluster/gw-ci-windows7-386'             #
-#     Env:                                                          #
-#       ENGINE: 'multiuser'                                         #
-#####################################################################
+# The following are disabled due to insufficient capacity:
+#    - WorkerPool: 'proj-taskcluster/gw-ci-raspbian-stretch'
+#      Env:
+#        ENGINE: 'simple'
+#    - WorkerPool: 'proj-taskcluster/gw-ci-windows10-amd64'
+#      Env:
+#        ENGINE: 'multiuser'
+#        # We must set here since this worker pool does not have a Z: drive
+#        GW_SKIP_Z_DRIVE_TESTS: 'true'
+#        # This worker pool has no mozilla-build installation
+#        GW_SKIP_MOZILLA_BUILD_TESTS: 'true'
+#        # This worker pool has no python installation
+#        GW_SKIP_PYTHON_TESTS: 'true'
+#    - WorkerPool: 'proj-taskcluster/gw-ci-windows10-arm'
+#      Env:
+#        ENGINE: 'multiuser'
+#        # We must set here since this worker pool does not have a Z: drive
+#        GW_SKIP_Z_DRIVE_TESTS: 'true'
+#        # This worker pool has no mozilla-build installation
+#        GW_SKIP_MOZILLA_BUILD_TESTS: 'true'
+#        # This worker pool has no python installation
+#        GW_SKIP_PYTHON_TESTS: 'true'
+#    - WorkerPool: 'proj-taskcluster/gw-ci-windows7-386'
+#      Env:
+#        ENGINE: 'multiuser'
   FormatSource:
     - WorkerPool: 'proj-taskcluster/gw-ci-ubuntu-18-04'
 


### PR DESCRIPTION
The worker pools behind these tasks are single workers or otherwise
unable to keep up with demand.  So, rather than merging PRs with yellow
dots or eventually red X's when the tasks time out, let's disable them.

Of these platforms, Windows 10 is a tier-1 platform, but that platform's
testing is covered by the Windows 2012 worker pool.  And linux-arm is a
tier-1 platform, but in the larger Mozilla scope is tier-2 at this
point.