### PR TITLE
Remove check that all (unsupported) blob artifacts are complete

### DIFF
--- a/changelog/issue-2527.md
+++ b/changelog/issue-2527.md
@@ -1,0 +1,3 @@
+level: silent
+reference: issue 2527
+---

--- a/services/queue/src/api.js
+++ b/services/queue/src/api.js
@@ -1478,26 +1478,6 @@ let resolveTask = async function(req, res, taskId, runId, target) {
     workerId: run.workerId,
   });
 
-  // Ensure that all blob artifacts which were created are present before
-  // allowing resolution as 'completed'
-  if (target === 'completed') {
-    let haveAllBlobs = true;
-    await this.Artifact.query({
-      taskId,
-      runId,
-      storageType: 'blob',
-      present: false,
-    }, {
-      limit: 1,
-      handler: () => { haveAllBlobs = false; },
-    });
-
-    if (!haveAllBlobs) {
-      return res.reportError('RequestConflict',
-        'All blob artifacts must be present to resolve task as completed');
-    }
-  }
-
   await task.modify((task) => {
     let run = task.runs[runId];
 


### PR DESCRIPTION
Support for blob artifacts was removed some time ago.  This check uses
non-date conditions in `Entity.scan`, which isn't supported in postgres.

This code doesn't do anything when there are no blob artifacts, and there never are.