### PR TITLE
Bug 1623183 - handle error events from pg Clients

### DIFF
--- a/changelog/bug-1623183.md
+++ b/changelog/bug-1623183.md
@@ -1,0 +1,3 @@
+level: silent
+reference: bug 1623183
+---


### PR DESCRIPTION
The node-pg docs do not mention it, but a read of the source verifies
that it's up to the user of a Client object to intercept `error` events
while it's checked out from the pool (and then to stop intercepting them
before releasing it to the pool).
