### PR TITLE
Update generic-worker to send log messages with a 'body' prop

### DIFF
--- a/changelog/asLY7YXqQRaZQdlOXgm7eQ.md
+++ b/changelog/asLY7YXqQRaZQdlOXgm7eQ.md
@@ -1,0 +1,2 @@
+level: silent
+---

--- a/tools/taskcluster-worker-runner/logging/protocol/proto.go
+++ b/tools/taskcluster-worker-runner/logging/protocol/proto.go
@@ -1,0 +1,19 @@
+package logging
+
+import (
+	"github.com/taskcluster/taskcluster/v28/tools/taskcluster-worker-runner/logging"
+	"github.com/taskcluster/taskcluster/v28/tools/taskcluster-worker-runner/protocol"
+)
+
+func SetProtocol(proto *protocol.Protocol) {
+	// Register to receive log messages on the given protocol
+	proto.AddCapability("log")
+	proto.Register("log", func(msg protocol.Message) {
+		body, ok := msg.Properties["body"]
+		if ok {
+			logging.Destination.LogStructured(body.(map[string]interface{}))
+		} else {
+			logging.Destination.LogUnstructured("received log message from worker lacking 'body' property")
+		}
+	})
+}

--- a/tools/taskcluster-worker-runner/logging/protocol/proto_test.go
+++ b/tools/taskcluster-worker-runner/logging/protocol/proto_test.go
@@ -1,0 +1,83 @@
+package logging
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"github.com/taskcluster/taskcluster/v28/tools/taskcluster-worker-runner/logging"
+	"github.com/taskcluster/taskcluster/v28/tools/taskcluster-worker-runner/protocol"
+	ptesting "github.com/taskcluster/taskcluster/v28/tools/taskcluster-worker-runner/protocol/testing"
+)
+
+func TestLoggingProtocol(t *testing.T) {
+	oldLogDestination := logging.Destination
+	defer func() { logging.Destination = oldLogDestination }()
+	logDest := &logging.TestLogDestination{}
+	logging.Destination = logDest
+
+	wkr := ptesting.NewFakeWorkerWithCapabilities("log")
+	defer wkr.Close()
+
+	SetProtocol(wkr.RunnerProtocol)
+	wkr.RunnerProtocol.Start(false)
+
+	// wait for the worker protocol to be initialized before sending
+	// any log messages
+	wkr.WorkerProtocol.WaitUntilInitialized()
+
+	waitForLogMessage := func() {
+		for {
+			if len(logDest.Messages()) > 0 {
+				break
+			}
+			time.Sleep(10 * time.Millisecond)
+		}
+	}
+
+	t.Run("well-formed log message from worker", func(t *testing.T) {
+		defer logDest.Clear()
+		wkr.WorkerProtocol.Send(protocol.Message{
+			Type: "log",
+			Properties: map[string]interface{}{
+				"body": map[string]interface{}{
+					"metric": "foos",
+					"value":  10,
+				},
+			},
+		})
+
+		waitForLogMessage()
+
+		require.Equal(t,
+			[]map[string]interface{}{
+				map[string]interface{}{
+					"metric": "foos",
+					"value":  10.0,
+				},
+			},
+			logDest.Messages(),
+		)
+	})
+
+	t.Run("badly-formed log message from worker", func(t *testing.T) {
+		defer logDest.Clear()
+		wkr.WorkerProtocol.Send(protocol.Message{
+			Type: "log",
+			Properties: map[string]interface{}{
+				"textPayload": "I forgot about the body property, oops",
+			},
+		})
+
+		waitForLogMessage()
+
+		require.Equal(t,
+			[]map[string]interface{}{
+				map[string]interface{}{
+					"textPayload": "received log message from worker lacking 'body' property",
+				},
+			},
+			logDest.Messages(),
+		)
+	})
+}

--- a/tools/taskcluster-worker-runner/runner/run.go
+++ b/tools/taskcluster-worker-runner/runner/run.go
@@ -11,6 +11,7 @@ import (
 	"github.com/taskcluster/taskcluster/v28/tools/taskcluster-worker-runner/credexp"
 	"github.com/taskcluster/taskcluster/v28/tools/taskcluster-worker-runner/files"
 	"github.com/taskcluster/taskcluster/v28/tools/taskcluster-worker-runner/logging"
+	loggingProtocol "github.com/taskcluster/taskcluster/v28/tools/taskcluster-worker-runner/logging/protocol"
 	"github.com/taskcluster/taskcluster/v28/tools/taskcluster-worker-runner/perms"
 	"github.com/taskcluster/taskcluster/v28/tools/taskcluster-worker-runner/protocol"
 	"github.com/taskcluster/taskcluster/v28/tools/taskcluster-worker-runner/provider"
@@ -169,13 +170,8 @@ func Run(configFile string) (state run.State, err error) {
 
 	proto := protocol.NewProtocol(transp)
 
-	// Register to receive log messages on the given protocol
-	proto.AddCapability("log")
-	proto.Register("log", func(msg protocol.Message) {
-		logging.Destination.LogStructured(msg.Properties["body"].(map[string]interface{}))
-	})
-
 	// inform other components about the protocol
+	loggingProtocol.SetProtocol(proto)
 	provider.SetProtocol(proto)
 	worker.SetProtocol(proto)
 	ce.SetProtocol(proto)

--- a/workers/generic-worker/workerrunner.go
+++ b/workers/generic-worker/workerrunner.go
@@ -36,7 +36,9 @@ func (w *loggingWriter) Write(p []byte) (n int, err error) {
 		WorkerRunnerProtocol.Send(protocol.Message{
 			Type: "log",
 			Properties: map[string]interface{}{
-				"textPayload": message,
+				"body": map[string]interface{}{
+					"textPayload": message,
+				},
 			},
 		})
 	} else {


### PR DESCRIPTION
A malformed log message would have made worker-runner panic and crash,
which would be unfortunate and hard to debug, so this also adds some
resiliency there and tests it.

This was an oversight on my part -- I changed the design while working on #2435 and missed to change it in generic-worker.

I'd like to get this landed since it's broken in master, but afterward we could thin of adding purpose-specific `Send` messages for each defined message type in the protocol, to prevent this in the future.