### PR TITLE
Use UTC with Postgres

### DIFF
--- a/changelog/issue-2536.md
+++ b/changelog/issue-2536.md
@@ -1,0 +1,4 @@
+level: patch
+reference: issue 2536
+---
+The node-postgres library is now configured to correctly handle timezones.  As no data was stored with timestamps until now, this is not a breaking change.

--- a/db/versions/0004.yml
+++ b/db/versions/0004.yml
@@ -1,0 +1,19 @@
+version: 4
+# in version 3, this table was incorrectly set up with timestamp columns
+# lacking timezones, causing issues when the server and client timezones do not
+# agree.
+migrationScript: |-
+  begin
+    alter table azure_queue_messages
+      alter column inserted type timestamptz,
+      alter column visible type timestamptz,
+      alter column expires type timestamptz;
+  end
+downgradeScript: |-
+  begin
+    alter table azure_queue_messages
+      alter column inserted type timestamp,
+      alter column visible type timestamp,
+      alter column expires type timestamp;
+  end
+methods: []

--- a/generated/db-schema.json
+++ b/generated/db-schema.json
@@ -1553,6 +1553,13 @@
       },
       "migrationScript": "begin\n  create table azure_queue_messages (\n    message_id uuid not null primary key,\n    queue_name text not null,\n    message_text text not null,\n    inserted timestamp not null,\n    visible timestamp not null, -- visible after this time\n    expires timestamp not null,  -- expired after this time\n    pop_receipt uuid -- null means not popped\n  );\n  -- 'get' operations sort by inserted within a queue\n  create index azure_queue_messages_inserted on azure_queue_messages(queue_name, inserted);\n  grant select, insert, update, delete on azure_queue_messages to $db_user_prefix$_queue;\nend",
       "version": 3
+    },
+    {
+      "downgradeScript": "begin\n  alter table azure_queue_messages\n    alter column inserted type timestamp,\n    alter column visible type timestamp,\n    alter column expires type timestamp;\nend",
+      "methods": {
+      },
+      "migrationScript": "begin\n  alter table azure_queue_messages\n    alter column inserted type timestamptz,\n    alter column visible type timestamptz,\n    alter column expires type timestamptz;\nend",
+      "version": 4
     }
   ]
 }

--- a/libraries/postgres/src/Database.js
+++ b/libraries/postgres/src/Database.js
@@ -1,4 +1,5 @@
 const {Pool} = require('pg');
+const pg = require('pg');
 const {dollarQuote, annotateError} = require('./util');
 const assert = require('assert').strict;
 const {READ, WRITE, DUPLICATE_OBJECT, UNDEFINED_TABLE} = require('./constants');
@@ -7,6 +8,11 @@ const {READ, WRITE, DUPLICATE_OBJECT, UNDEFINED_TABLE} = require('./constants');
 const EXTENSIONS = [
   'pgcrypto',
 ];
+
+// Node-postgres assumes that all Date objects are in the local timezone.  In
+// Taskcluster, we always use Date objects in UTC.  Happily, the library's
+// questionable decision can be overridden globally:
+pg.defaults.parseInputDatesAsUTC = true;
 
 class Database {
   /**


### PR DESCRIPTION
This fixes failures of tests to run on machines not in UTC.

Actually, only the first commit is required, but the second is something else I tried to fix this, and is a good idea anyway -- it makes very clear to anyone else using the database the precise time that the timestamps indicate, without guessing "UTC? Mountain View?"

I added a card to https://github.com/taskcluster/taskcluster/projects/3 to track checking for and rejecting TIMESTAMP columns, so I don't make the same mistake again.

The entities tables do not have any timestamp(tz) columns, so no change needed.

Github Bug/Issue: Fixes #2536