### PR TITLE
document DB connection counts

### DIFF
--- a/changelog/SBYYr-RSRBKXzkPOsMaGMw.md
+++ b/changelog/SBYYr-RSRBKXzkPOsMaGMw.md
@@ -1,0 +1,3 @@
+level: silent
+reference: issue 2539
+---

--- a/generated/docs-search.json
+++ b/generated/docs-search.json
@@ -239,6 +239,13 @@
   },
   {
     "element": "h2",
+    "id": "connection-counts",
+    "path": "/manual/deploying/database",
+    "subtitle": "Connection Counts",
+    "title": "Database Configuration"
+  },
+  {
+    "element": "h2",
     "id": "db-users",
     "path": "/manual/deploying/database",
     "subtitle": "DB Users",

--- a/libraries/postgres/src/Database.js
+++ b/libraries/postgres/src/Database.js
@@ -365,7 +365,10 @@ class Database {
   constructor({urlsByMode, statementTimeout}) {
     assert(!statementTimeout || typeof statementTimeout === 'number');
     const makePool = dbUrl => {
-      const pool = new Pool({connectionString: dbUrl});
+      // use a max of 5 connections. For services running both a read and write
+      // pool, this is a maximum of 10 concurrent connections.  Other requests
+      // will be queued.
+      const pool = new Pool({connectionString: dbUrl, max: 5});
       // ignore errors from *idle* connections.  From the docs:
       //
       // > When a client is sitting idly in the pool it can still emit errors

--- a/ui/docs/manual/deploying/database.mdx
+++ b/ui/docs/manual/deploying/database.mdx
@@ -64,6 +64,17 @@ The read-only configuration will only be used to read from the database.
 This can be used to direct reads to read-only replicas, in cases where the read load is significantly higher than the write load.
 However, note that these read-only replicas must conform to the consistency requirements described above.
 
+## Connection Counts
+
+Each Kubernetes deployment can use up to 10 connections.
+In particular, the `web` pods may, under load, use this maximum.
+Periodic tasks and worker pods will user fewer connections.
+A basic deployment of Taskcluster with the default scale of one for each Kubernetes deployment can use about 150 connections when under load.
+
+We recommend starting Postgres' `max_connections` to 200 for such Taskcluster deployments.
+Adjust that number based on observed connection counts.
+Increase the number as necessary when scaling up Kubernetes deployments.
+
 ## Configuration
 
 Database access is configured with URL-shaped strings as defined by [node-postgres](https://node-postgres.com/features/connecting).


### PR DESCRIPTION
This adds documentation for DB connection counts.  In load-testing my dev env, I found that the default `max_connections` for an N1 CloudSQL instance was too small.  Note that Postgres is not designed to scale into lots and lots of connections -- it allocates memory for each one -- so massively over-estimating this number is not good.

This is still pretty vague -- basically a guess and some advice.  @edunham do you think that's sufficient?  The errors when the connections max out are pretty easy to spot.