### PR TITLE
Fix ordering of queue pops when numberOfMessages > 1

### DIFF
--- a/changelog/issue-2553.md
+++ b/changelog/issue-2553.md
@@ -1,0 +1,4 @@
+level: patch
+reference: issue 2553
+---
+The taskcluster-lib-azqueue library now returns "batches" of messages in the order they were inserted.

--- a/db/versions/0005.yml
+++ b/db/versions/0005.yml
@@ -1,0 +1,45 @@
+version: 5
+migrationScript: |-
+  begin
+  end
+downgradeScript: |-
+  begin
+  end
+methods:
+  azure_queue_get:
+    description: |
+      Get up to `count` messages from the given queue, setting the `visible`
+      column of each to the given value.  Returns a `message_id` and
+      `pop_receipt` for each one, for use with `azure_queue_delete` and
+      `azure_queue_update`.
+    mode: write
+    serviceName: queue
+    args: queue_name text, visible timestamp, count integer
+    returns: table (message_id uuid, message_text text, pop_receipt uuid)
+    # This updates the implementation in version 3 by sorting the results, as
+    # UPDATE .. RETURNING does not honor the order defined in the subquery.
+    body: |-
+      begin
+        return query
+          with updated as (
+            update azure_queue_messages m
+            set
+              pop_receipt = public.gen_random_uuid(),
+              visible = azure_queue_get.visible
+            where
+              m.message_id in (
+                select m2.message_id from azure_queue_messages m2
+                where m2.queue_name = azure_queue_get.queue_name
+                  and m2.visible <= now()
+                  and m2.expires > now()
+                order by m2.inserted
+                for update skip locked
+                limit count
+            )
+            returning m.inserted, m.message_id, m.message_text, m.pop_receipt
+          )
+          select
+            u.message_id, u.message_text, u.pop_receipt
+          from updated as u
+          order by u.inserted;
+      end

--- a/generated/db-schema.json
+++ b/generated/db-schema.json
@@ -1560,6 +1560,22 @@
       },
       "migrationScript": "begin\n  alter table azure_queue_messages\n    alter column inserted type timestamptz,\n    alter column visible type timestamptz,\n    alter column expires type timestamptz;\nend",
       "version": 4
+    },
+    {
+      "downgradeScript": "begin\nend",
+      "methods": {
+        "azure_queue_get": {
+          "args": "queue_name text, visible timestamp, count integer",
+          "body": "begin\n  return query\n    with updated as (\n      update azure_queue_messages m\n      set\n        pop_receipt = public.gen_random_uuid(),\n        visible = azure_queue_get.visible\n      where\n        m.message_id in (\n          select m2.message_id from azure_queue_messages m2\n          where m2.queue_name = azure_queue_get.queue_name\n            and m2.visible <= now()\n            and m2.expires > now()\n          order by m2.inserted\n          for update skip locked\n          limit count\n      )\n      returning m.inserted, m.message_id, m.message_text, m.pop_receipt\n    )\n    select\n      u.message_id, u.message_text, u.pop_receipt\n    from updated as u\n    order by u.inserted;\nend",
+          "deprecated": false,
+          "description": "Get up to `count` messages from the given queue, setting the `visible`\ncolumn of each to the given value.  Returns a `message_id` and\n`pop_receipt` for each one, for use with `azure_queue_delete` and\n`azure_queue_update`.\n",
+          "mode": "write",
+          "returns": "table (message_id uuid, message_text text, pop_receipt uuid)",
+          "serviceName": "queue"
+        }
+      },
+      "migrationScript": "begin\nend",
+      "version": 5
     }
   ]
 }

--- a/libraries/azqueue/test/get_messages_test.js
+++ b/libraries/azqueue/test/get_messages_test.js
@@ -96,6 +96,21 @@ helper.secrets.mockSuite(testing.suiteName(), ['db'], function(mock, skipping) {
     assert.deepEqual(result.map(({messageText}) => messageText).sort(), ['bar-2']);
   });
 
+  test('getting multiple items returns them in insertion order', async function() {
+    const queue = new AZQueue({ db: helper.db });
+
+    await queue.putMessage('foo', 'bar-1', { visibilityTimeout: 0, messageTTL: 100 });
+    await queue.putMessage('foo', 'bar-2', { visibilityTimeout: 0, messageTTL: 100 });
+    await queue.putMessage('foo', 'bar-3', { visibilityTimeout: 0, messageTTL: 100 });
+    await queue.putMessage('foo', 'bar-4', { visibilityTimeout: 0, messageTTL: 100 });
+    await queue.putMessage('foo', 'bar-5', { visibilityTimeout: 0, messageTTL: 100 });
+
+    const result = await queue.getMessages('foo', {visibilityTimeout: 10, numberOfMessages: 4});
+    assert.deepEqual(
+      result.map(({messageText}) => messageText),
+      ['bar-1', 'bar-2', 'bar-3', 'bar-4']);
+  });
+
   test('multiple parallel gets', async function() {
     const queue = new AZQueue({ db: helper.db });
 


### PR DESCRIPTION
When getting multiple messages from the queue in the same call, Azure
Queues returns those messages in the order they were received.  This
updates the Postgres implementation to do the same.