### PR TITLE
Bug 1622943 - limit lifecycle.reregistrationTimeout to 30 days

### DIFF
--- a/changelog/bug-1622943.md
+++ b/changelog/bug-1622943.md
@@ -1,0 +1,4 @@
+level: patch
+reference: bug 1622943
+---
+The maximum value for a worker's `lifecycle.reregistrationTimeout` is now 30 days.  Values greater than this cannot be represented in the worker's temporary credentials anyway.

--- a/generated/references.json
+++ b/generated/references.json
@@ -234,7 +234,8 @@
         },
         "reregistrationTimeout": {
           "default": 345600,
-          "description": "If specified, workers in this pool must re-register via `reregister()`\nwithin `reregistrationTimeout` seconds from the initial call to\n`register()` to get new credentials. If the worker has not done so, it\nwill be terminated.  This value also dictates the lifetime of the\ntemporary credentials granted to the worker, meaning that it cannot be\ngreater than 31 days.\n\nThe default value is 3 days.\n",
+          "description": "If specified, workers in this pool must re-register via `reregister()`\nwithin `reregistrationTimeout` seconds from the initial call to\n`register()` to get new credentials. If the worker has not done so, it\nwill be terminated.  This value also dictates the lifetime of the\ntemporary credentials granted to the worker, meaning that it must be\nless than 30 days.\n\nThe default value is 3 days.\n",
+          "maximum": 2678400,
           "title": "Checkin Timeout",
           "type": "integer"
         }

--- a/services/worker-manager/schemas/v1/worker-lifecycle.yml
+++ b/services/worker-manager/schemas/v1/worker-lifecycle.yml
@@ -21,14 +21,15 @@ properties:
   reregistrationTimeout:
     title: Checkin Timeout
     type: integer
-    default: 345600
+    default: 345600   # 3 days
+    maximum: 2678400  # 30 days
     description: |
       If specified, workers in this pool must re-register via `reregister()`
       within `reregistrationTimeout` seconds from the initial call to
       `register()` to get new credentials. If the worker has not done so, it
       will be terminated.  This value also dictates the lifetime of the
-      temporary credentials granted to the worker, meaning that it cannot be
-      greater than 31 days.
+      temporary credentials granted to the worker, meaning that it must be
+      less than 30 days.
       
       The default value is 3 days.
 additionalProperties: false


### PR DESCRIPTION
Bugzilla Bug: [1622943](https://bugzilla.mozilla.org/show_bug.cgi?id=1622943)
