### PR TITLE
Reset DB user roles after tests

### DIFF
--- a/changelog/VFoTTBIjRfOrc18KrZ_MyQ.md
+++ b/changelog/VFoTTBIjRfOrc18KrZ_MyQ.md
@@ -1,0 +1,2 @@
+level: silent
+---

--- a/libraries/postgres/test/database_test.js
+++ b/libraries/postgres/test/database_test.js
@@ -116,7 +116,13 @@ helper.dbSuite(path.basename(__filename), function() {
           }
         }
       }
+    });
+    // start off the roles from a clean slate..
+    await resetRoles(db);
+  };
 
+  const resetRoles = async db => {
+    await db._withClient('admin', async client => {
       // drop attributes and group membership for all test_* users
       const res = await client.query(`
         select *
@@ -129,6 +135,11 @@ helper.dbSuite(path.basename(__filename), function() {
       }
     });
   };
+
+  suiteTeardown(async function() {
+    db = new Database({urlsByMode: {admin: helper.dbUrl}});
+    await resetRoles(db);
+  });
 
   teardown(async function() {
     if (db) {


### PR DESCRIPTION
This removes the `badrole` from `test-service2` after the
tc-lib-postgres tests complete.  Without this, other tests fail if
run against the same DB instance.