### PR TITLE
Add logging about DB and connection pools

### DIFF
--- a/changelog/issue-2522.md
+++ b/changelog/issue-2522.md
@@ -1,0 +1,4 @@
+level: patch
+reference: issue 2522
+---
+Services that use a database now log information about that database, including connection pool counts and stored-function invocations.

--- a/db/src/setup.js
+++ b/db/src/setup.js
@@ -2,12 +2,13 @@ const {schema} = require('./schema.js');
 const {Database} = require('taskcluster-lib-postgres');
 const {FakeDatabase} = require('./fakes');
 
-exports.setup = async ({writeDbUrl, readDbUrl, serviceName, useDbDirectory}) => {
+exports.setup = async ({writeDbUrl, readDbUrl, serviceName, useDbDirectory, monitor}) => {
   return await Database.setup({
     schema: schema({useDbDirectory}),
     writeDbUrl,
     readDbUrl,
     serviceName,
+    monitor,
   });
 };
 

--- a/db/test/helper.js
+++ b/db/test/helper.js
@@ -95,6 +95,7 @@ exports.withDbForProcs = function({ serviceName }) {
       readDbUrl: exports.dbUrl,
       serviceName,
       useDbDirectory: true,
+      monitor: false,
     });
 
     exports.fakeDb = await tcdb.fakeSetup({

--- a/generated/references.json
+++ b/generated/references.json
@@ -11425,6 +11425,31 @@
           "version": 1
         },
         {
+          "description": "This message is logged for each invocation of a Postgres stored function.",
+          "fields": {
+            "name": "The name of the DB function"
+          },
+          "level": "info",
+          "name": "dbFunctionCall",
+          "title": "DB Method Call",
+          "type": "db-function-call",
+          "version": 1
+        },
+        {
+          "description": "This message is logged every 5 minutes from each process that is using the database,\nonce for each pool.  Most services have both a \"read\" pool and a \"write\" pool.  The\nfields come from the node-postgres package.",
+          "fields": {
+            "idleCount": "The number of connections (out of the total) which are not currently in use",
+            "pool": "The name of the pool within the process",
+            "totalCount": "The total number of connections",
+            "waitingCount": "The number of operations waiting for an idle connection"
+          },
+          "level": "notice",
+          "name": "dbPoolCounts",
+          "title": "DB Pool Counts",
+          "type": "db-pool-counts",
+          "version": 1
+        },
+        {
           "description": "A timer and audit for express API endpoints.\nYou can combine this with auth audit logs to get\na complete picture of what was authorized when.\n\nHere, anything that is not public should have authenticated\nand if it authenticated, we will tell the clientId here. Given\nthat, it is not necessarily true that the endpoint was\n_authorized_. You can tell that by the statusCode.",
           "fields": {
             "apiVersion": "The version of the API (e.g., `v1`)",
@@ -11970,6 +11995,31 @@
           "version": 1
         },
         {
+          "description": "This message is logged for each invocation of a Postgres stored function.",
+          "fields": {
+            "name": "The name of the DB function"
+          },
+          "level": "info",
+          "name": "dbFunctionCall",
+          "title": "DB Method Call",
+          "type": "db-function-call",
+          "version": 1
+        },
+        {
+          "description": "This message is logged every 5 minutes from each process that is using the database,\nonce for each pool.  Most services have both a \"read\" pool and a \"write\" pool.  The\nfields come from the node-postgres package.",
+          "fields": {
+            "idleCount": "The number of connections (out of the total) which are not currently in use",
+            "pool": "The name of the pool within the process",
+            "totalCount": "The total number of connections",
+            "waitingCount": "The number of operations waiting for an idle connection"
+          },
+          "level": "notice",
+          "name": "dbPoolCounts",
+          "title": "DB Pool Counts",
+          "type": "db-pool-counts",
+          "version": 1
+        },
+        {
           "description": "A client has been issued Taskcluster credentials",
           "fields": {
             "clientId": "The clientId of the issued credentials",
@@ -12157,6 +12207,31 @@
           "name": "loggingError",
           "title": "Error in Logging",
           "type": "monitor.loggingError",
+          "version": 1
+        },
+        {
+          "description": "This message is logged for each invocation of a Postgres stored function.",
+          "fields": {
+            "name": "The name of the DB function"
+          },
+          "level": "info",
+          "name": "dbFunctionCall",
+          "title": "DB Method Call",
+          "type": "db-function-call",
+          "version": 1
+        },
+        {
+          "description": "This message is logged every 5 minutes from each process that is using the database,\nonce for each pool.  Most services have both a \"read\" pool and a \"write\" pool.  The\nfields come from the node-postgres package.",
+          "fields": {
+            "idleCount": "The number of connections (out of the total) which are not currently in use",
+            "pool": "The name of the pool within the process",
+            "totalCount": "The total number of connections",
+            "waitingCount": "The number of operations waiting for an idle connection"
+          },
+          "level": "notice",
+          "name": "dbPoolCounts",
+          "title": "DB Pool Counts",
+          "type": "db-pool-counts",
           "version": 1
         },
         {
@@ -12438,6 +12513,31 @@
           "name": "apiMethod",
           "title": "API Method Report",
           "type": "monitor.apiMethod",
+          "version": 1
+        },
+        {
+          "description": "This message is logged for each invocation of a Postgres stored function.",
+          "fields": {
+            "name": "The name of the DB function"
+          },
+          "level": "info",
+          "name": "dbFunctionCall",
+          "title": "DB Method Call",
+          "type": "db-function-call",
+          "version": 1
+        },
+        {
+          "description": "This message is logged every 5 minutes from each process that is using the database,\nonce for each pool.  Most services have both a \"read\" pool and a \"write\" pool.  The\nfields come from the node-postgres package.",
+          "fields": {
+            "idleCount": "The number of connections (out of the total) which are not currently in use",
+            "pool": "The name of the pool within the process",
+            "totalCount": "The total number of connections",
+            "waitingCount": "The number of operations waiting for an idle connection"
+          },
+          "level": "notice",
+          "name": "dbPoolCounts",
+          "title": "DB Pool Counts",
+          "type": "db-pool-counts",
           "version": 1
         },
         {
@@ -14022,6 +14122,31 @@
           "version": 1
         },
         {
+          "description": "This message is logged for each invocation of a Postgres stored function.",
+          "fields": {
+            "name": "The name of the DB function"
+          },
+          "level": "info",
+          "name": "dbFunctionCall",
+          "title": "DB Method Call",
+          "type": "db-function-call",
+          "version": 1
+        },
+        {
+          "description": "This message is logged every 5 minutes from each process that is using the database,\nonce for each pool.  Most services have both a \"read\" pool and a \"write\" pool.  The\nfields come from the node-postgres package.",
+          "fields": {
+            "idleCount": "The number of connections (out of the total) which are not currently in use",
+            "pool": "The name of the pool within the process",
+            "totalCount": "The total number of connections",
+            "waitingCount": "The number of operations waiting for an idle connection"
+          },
+          "level": "notice",
+          "name": "dbPoolCounts",
+          "title": "DB Pool Counts",
+          "type": "db-pool-counts",
+          "version": 1
+        },
+        {
           "description": "A timer and audit for express API endpoints.\nYou can combine this with auth audit logs to get\na complete picture of what was authorized when.\n\nHere, anything that is not public should have authenticated\nand if it authenticated, we will tell the clientId here. Given\nthat, it is not necessarily true that the endpoint was\n_authorized_. You can tell that by the statusCode.",
           "fields": {
             "apiVersion": "The version of the API (e.g., `v1`)",
@@ -14385,6 +14510,31 @@
           "name": "apiMethod",
           "title": "API Method Report",
           "type": "monitor.apiMethod",
+          "version": 1
+        },
+        {
+          "description": "This message is logged for each invocation of a Postgres stored function.",
+          "fields": {
+            "name": "The name of the DB function"
+          },
+          "level": "info",
+          "name": "dbFunctionCall",
+          "title": "DB Method Call",
+          "type": "db-function-call",
+          "version": 1
+        },
+        {
+          "description": "This message is logged every 5 minutes from each process that is using the database,\nonce for each pool.  Most services have both a \"read\" pool and a \"write\" pool.  The\nfields come from the node-postgres package.",
+          "fields": {
+            "idleCount": "The number of connections (out of the total) which are not currently in use",
+            "pool": "The name of the pool within the process",
+            "totalCount": "The total number of connections",
+            "waitingCount": "The number of operations waiting for an idle connection"
+          },
+          "level": "notice",
+          "name": "dbPoolCounts",
+          "title": "DB Pool Counts",
+          "type": "db-pool-counts",
           "version": 1
         }
       ]
@@ -14784,6 +14934,31 @@
           "version": 1
         },
         {
+          "description": "This message is logged for each invocation of a Postgres stored function.",
+          "fields": {
+            "name": "The name of the DB function"
+          },
+          "level": "info",
+          "name": "dbFunctionCall",
+          "title": "DB Method Call",
+          "type": "db-function-call",
+          "version": 1
+        },
+        {
+          "description": "This message is logged every 5 minutes from each process that is using the database,\nonce for each pool.  Most services have both a \"read\" pool and a \"write\" pool.  The\nfields come from the node-postgres package.",
+          "fields": {
+            "idleCount": "The number of connections (out of the total) which are not currently in use",
+            "pool": "The name of the pool within the process",
+            "totalCount": "The total number of connections",
+            "waitingCount": "The number of operations waiting for an idle connection"
+          },
+          "level": "notice",
+          "name": "dbPoolCounts",
+          "title": "DB Pool Counts",
+          "type": "db-pool-counts",
+          "version": 1
+        },
+        {
           "description": "A connection to Pulse has been established.  Taskcluster services\nautomatically reconnect to Pulse periodically and in the event of\nan error, but rapid reconnections may signal a Pulse failure.",
           "fields": {
           },
@@ -15094,6 +15269,31 @@
           "name": "loggingError",
           "title": "Error in Logging",
           "type": "monitor.loggingError",
+          "version": 1
+        },
+        {
+          "description": "This message is logged for each invocation of a Postgres stored function.",
+          "fields": {
+            "name": "The name of the DB function"
+          },
+          "level": "info",
+          "name": "dbFunctionCall",
+          "title": "DB Method Call",
+          "type": "db-function-call",
+          "version": 1
+        },
+        {
+          "description": "This message is logged every 5 minutes from each process that is using the database,\nonce for each pool.  Most services have both a \"read\" pool and a \"write\" pool.  The\nfields come from the node-postgres package.",
+          "fields": {
+            "idleCount": "The number of connections (out of the total) which are not currently in use",
+            "pool": "The name of the pool within the process",
+            "totalCount": "The total number of connections",
+            "waitingCount": "The number of operations waiting for an idle connection"
+          },
+          "level": "notice",
+          "name": "dbPoolCounts",
+          "title": "DB Pool Counts",
+          "type": "db-pool-counts",
           "version": 1
         },
         {
@@ -15637,6 +15837,31 @@
           "name": "apiMethod",
           "title": "API Method Report",
           "type": "monitor.apiMethod",
+          "version": 1
+        },
+        {
+          "description": "This message is logged for each invocation of a Postgres stored function.",
+          "fields": {
+            "name": "The name of the DB function"
+          },
+          "level": "info",
+          "name": "dbFunctionCall",
+          "title": "DB Method Call",
+          "type": "db-function-call",
+          "version": 1
+        },
+        {
+          "description": "This message is logged every 5 minutes from each process that is using the database,\nonce for each pool.  Most services have both a \"read\" pool and a \"write\" pool.  The\nfields come from the node-postgres package.",
+          "fields": {
+            "idleCount": "The number of connections (out of the total) which are not currently in use",
+            "pool": "The name of the pool within the process",
+            "totalCount": "The total number of connections",
+            "waitingCount": "The number of operations waiting for an idle connection"
+          },
+          "level": "notice",
+          "name": "dbPoolCounts",
+          "title": "DB Pool Counts",
+          "type": "db-pool-counts",
           "version": 1
         },
         {
@@ -16268,6 +16493,31 @@
           "name": "loggingError",
           "title": "Error in Logging",
           "type": "monitor.loggingError",
+          "version": 1
+        },
+        {
+          "description": "This message is logged for each invocation of a Postgres stored function.",
+          "fields": {
+            "name": "The name of the DB function"
+          },
+          "level": "info",
+          "name": "dbFunctionCall",
+          "title": "DB Method Call",
+          "type": "db-function-call",
+          "version": 1
+        },
+        {
+          "description": "This message is logged every 5 minutes from each process that is using the database,\nonce for each pool.  Most services have both a \"read\" pool and a \"write\" pool.  The\nfields come from the node-postgres package.",
+          "fields": {
+            "idleCount": "The number of connections (out of the total) which are not currently in use",
+            "pool": "The name of the pool within the process",
+            "totalCount": "The total number of connections",
+            "waitingCount": "The number of operations waiting for an idle connection"
+          },
+          "level": "notice",
+          "name": "dbPoolCounts",
+          "title": "DB Pool Counts",
+          "type": "db-pool-counts",
           "version": 1
         },
         {

--- a/libraries/entities/test/helper.js
+++ b/libraries/entities/test/helper.js
@@ -1,6 +1,17 @@
 const {Client} = require('pg');
 const { Database } = require('taskcluster-lib-postgres');
+const {defaultMonitorManager} = require('taskcluster-lib-monitor');
 const dbUrl = process.env.TEST_DB_URL;
+
+defaultMonitorManager.configure({
+  serviceName: 'lib-entities',
+});
+
+const monitor = defaultMonitorManager.setup({
+  fake: true,
+  debug: true,
+  validate: true,
+});
 
 /**
  * dbSuite(..) is a replacement for suite(..) that sets this.dbUrl when
@@ -35,6 +46,7 @@ exports.withDb = async ({ schema, serviceName }) => {
     readDbUrl: exports.dbUrl,
     writeDbUrl: exports.dbUrl,
     serviceName,
+    monitor,
   });
 
   await Database.upgrade({

--- a/libraries/postgres/test/helper.js
+++ b/libraries/postgres/test/helper.js
@@ -1,5 +1,19 @@
 const {Client} = require('pg');
+const {withMonitor} = require('taskcluster-lib-testing');
+const {defaultMonitorManager} = require('taskcluster-lib-monitor');
 const dbUrl = process.env.TEST_DB_URL;
+
+withMonitor(exports, {noLoader: true});
+
+defaultMonitorManager.configure({
+  serviceName: 'lib-postgres',
+});
+
+exports.monitor = defaultMonitorManager.setup({
+  fake: true,
+  debug: true,
+  validate: true,
+});
 
 /**
  * dbSuite(..) is a replacement for suite(..) that sets this.dbUrl when

--- a/libraries/testing/src/with-db.js
+++ b/libraries/testing/src/with-db.js
@@ -96,6 +96,7 @@ module.exports.withDb = (mock, skipping, helper, serviceName) => {
         writeDbUrl: serviceDbUrl,
         serviceName,
         useDbDirectory: true,
+        monitor: false,
       });
     }
 

--- a/services/auth/src/main.js
+++ b/services/auth/src/main.js
@@ -48,11 +48,12 @@ const load = Loader({
   },
 
   db: {
-    requires: ['cfg'],
-    setup: ({cfg}) => tcdb.setup({
+    requires: ['cfg', 'monitor'],
+    setup: ({cfg, monitor}) => tcdb.setup({
       readDbUrl: cfg.postgres.readDbUrl,
       writeDbUrl: cfg.postgres.writeDbUrl,
       serviceName: 'auth',
+      monitor,
     }),
   },
 

--- a/services/github/src/main.js
+++ b/services/github/src/main.js
@@ -86,11 +86,12 @@ const load = loader({
   },
 
   db: {
-    requires: ["cfg"],
-    setup: ({ cfg }) => tcdb.setup({
+    requires: ["cfg", 'monitor'],
+    setup: ({cfg, monitor}) => tcdb.setup({
       readDbUrl: cfg.postgres.readDbUrl,
       writeDbUrl: cfg.postgres.writeDbUrl,
       serviceName: 'github',
+      monitor,
     }),
   },
 

--- a/services/hooks/src/main.js
+++ b/services/hooks/src/main.js
@@ -33,11 +33,12 @@ const load = loader({
   },
 
   db: {
-    requires: ["cfg"],
-    setup: ({ cfg }) => tcdb.setup({
+    requires: ["cfg", 'monitor'],
+    setup: ({cfg, monitor}) => tcdb.setup({
       readDbUrl: cfg.postgres.readDbUrl,
       writeDbUrl: cfg.postgres.writeDbUrl,
       serviceName: 'hooks',
+      monitor,
     }),
   },
 

--- a/services/index/src/main.js
+++ b/services/index/src/main.js
@@ -21,11 +21,12 @@ let load = loader({
   },
 
   db: {
-    requires: ["cfg"],
-    setup: ({ cfg }) => tcdb.setup({
+    requires: ["cfg", 'monitor'],
+    setup: ({cfg, monitor}) => tcdb.setup({
       readDbUrl: cfg.postgres.readDbUrl,
       writeDbUrl: cfg.postgres.writeDbUrl,
       serviceName: 'index',
+      monitor,
     }),
   },
 

--- a/services/notify/src/main.js
+++ b/services/notify/src/main.js
@@ -63,12 +63,14 @@ const load = loader({
   },
 
   db: {
-    requires: ['process', 'cfg'],
-    setup: ({process, cfg}) => tcdb.setup({
+    requires: ['process', 'cfg', 'monitor'],
+    setup: ({process, cfg, monitor}) => tcdb.setup({
       serviceName: 'notify',
       readDbUrl: cfg.postgres.readDbUrl,
       writeDbUrl: cfg.postgres.writeDbUrl,
-      statementTimeout: process === 'server' ? 30000 : 0}),
+      statementTimeout: process === 'server' ? 30000 : 0,
+      monitor,
+    }),
   },
 
   generateReferences: {

--- a/services/purge-cache/src/main.js
+++ b/services/purge-cache/src/main.js
@@ -34,11 +34,12 @@ const load = loader({
   },
 
   db: {
-    requires: ["cfg"],
-    setup: ({ cfg }) => tcdb.setup({
+    requires: ["cfg", 'monitor'],
+    setup: ({cfg, monitor}) => tcdb.setup({
       readDbUrl: cfg.postgres.readDbUrl,
       writeDbUrl: cfg.postgres.writeDbUrl,
       serviceName: 'purge_cache',
+      monitor,
     }),
   },
 

--- a/services/queue/src/main.js
+++ b/services/queue/src/main.js
@@ -95,11 +95,12 @@ let load = loader({
   },
 
   db: {
-    requires: ["cfg"],
-    setup: ({ cfg }) => tcdb.setup({
+    requires: ["cfg", 'monitor'],
+    setup: ({cfg, monitor}) => tcdb.setup({
       readDbUrl: cfg.postgres.readDbUrl,
       writeDbUrl: cfg.postgres.writeDbUrl,
       serviceName: 'queue',
+      monitor,
     }),
   },
 

--- a/services/secrets/src/main.js
+++ b/services/secrets/src/main.js
@@ -36,11 +36,12 @@ let load = loader({
   },
 
   db: {
-    requires: ['cfg'],
-    setup: ({cfg}) => tcdb.setup({
+    requires: ['cfg', 'monitor'],
+    setup: ({cfg, monitor}) => tcdb.setup({
       readDbUrl: cfg.postgres.readDbUrl,
       writeDbUrl: cfg.postgres.writeDbUrl,
       serviceName: 'secrets',
+      monitor,
     }),
   },
 

--- a/services/web-server/src/main.js
+++ b/services/web-server/src/main.js
@@ -184,11 +184,12 @@ const load = loader(
     },
 
     db: {
-      requires: ['cfg'],
-      setup: ({cfg}) => tcdb.setup({
+      requires: ['cfg', 'monitor'],
+      setup: ({cfg, monitor}) => tcdb.setup({
         readDbUrl: cfg.postgres.readDbUrl,
         writeDbUrl: cfg.postgres.writeDbUrl,
         serviceName: 'web_server',
+        monitor,
       }),
     },
 

--- a/services/worker-manager/src/main.js
+++ b/services/worker-manager/src/main.js
@@ -32,11 +32,12 @@ let load = loader({
   },
 
   db: {
-    requires: ["cfg"],
-    setup: ({ cfg }) => tcdb.setup({
+    requires: ["cfg", 'monitor'],
+    setup: ({cfg, monitor}) => tcdb.setup({
       readDbUrl: cfg.postgres.readDbUrl,
       writeDbUrl: cfg.postgres.writeDbUrl,
       serviceName: 'worker_manager',
+      monitor,
     }),
   },
 


### PR DESCRIPTION
The first of these two commits can get cherry-picked to `master` once #2570 lands.  The other adds support for passing monitor from each service, and will remain on the tc-lib-postgres branch until phase 1.

Github Bug/Issue: Fixes #2522