### PR TITLE
Use a 30s query timeout in web API processes

### DIFF
--- a/db/src/setup.js
+++ b/db/src/setup.js
@@ -2,12 +2,13 @@ const {schema} = require('./schema.js');
 const {Database} = require('taskcluster-lib-postgres');
 const {FakeDatabase} = require('./fakes');
 
-exports.setup = async ({writeDbUrl, readDbUrl, serviceName, useDbDirectory}) => {
+exports.setup = async ({writeDbUrl, readDbUrl, serviceName, useDbDirectory, statementTimeout}) => {
   return await Database.setup({
     schema: schema({useDbDirectory}),
     writeDbUrl,
     readDbUrl,
     serviceName,
+    statementTimeout,
   });
 };
 

--- a/libraries/postgres/src/Database.js
+++ b/libraries/postgres/src/Database.js
@@ -432,7 +432,10 @@ class Database {
       pool.on('error', client => {});
       pool.on('connect', async client => {
         if (statementTimeout) {
-          // note that postgres placeholders don't seem to work here.  So we check
+          // For web API servers, we want to abort queries that take too long, sa
+          // the HTTP client has probably given up.
+          //
+          // Note that postgres placeholders don't seem to work here.  So we check
           // that this is a number (above) and subtitute it directly
           await client.query(`set statement_timeout = ${statementTimeout}`);
         }

--- a/services/auth/src/main.js
+++ b/services/auth/src/main.js
@@ -48,11 +48,12 @@ const load = Loader({
   },
 
   db: {
-    requires: ['cfg'],
-    setup: ({cfg}) => tcdb.setup({
+    requires: ['cfg', 'process'],
+    setup: ({cfg, process}) => tcdb.setup({
       readDbUrl: cfg.postgres.readDbUrl,
       writeDbUrl: cfg.postgres.writeDbUrl,
       serviceName: 'auth',
+      statementTimeout: process === 'server' ? 30000 : 0,
     }),
   },
 

--- a/services/github/src/main.js
+++ b/services/github/src/main.js
@@ -86,11 +86,12 @@ const load = loader({
   },
 
   db: {
-    requires: ["cfg"],
-    setup: ({ cfg }) => tcdb.setup({
+    requires: ["cfg", "process"],
+    setup: ({cfg, process}) => tcdb.setup({
       readDbUrl: cfg.postgres.readDbUrl,
       writeDbUrl: cfg.postgres.writeDbUrl,
       serviceName: 'github',
+      statementTimeout: process === 'server' ? 30000 : 0,
     }),
   },
 

--- a/services/hooks/src/main.js
+++ b/services/hooks/src/main.js
@@ -33,11 +33,12 @@ const load = loader({
   },
 
   db: {
-    requires: ["cfg"],
-    setup: ({ cfg }) => tcdb.setup({
+    requires: ["cfg", "process"],
+    setup: ({cfg, process}) => tcdb.setup({
       readDbUrl: cfg.postgres.readDbUrl,
       writeDbUrl: cfg.postgres.writeDbUrl,
       serviceName: 'hooks',
+      statementTimeout: process === 'server' ? 30000 : 0,
     }),
   },
 

--- a/services/index/src/main.js
+++ b/services/index/src/main.js
@@ -21,11 +21,12 @@ let load = loader({
   },
 
   db: {
-    requires: ["cfg"],
-    setup: ({ cfg }) => tcdb.setup({
+    requires: ["cfg", "process"],
+    setup: ({cfg, process}) => tcdb.setup({
       readDbUrl: cfg.postgres.readDbUrl,
       writeDbUrl: cfg.postgres.writeDbUrl,
       serviceName: 'index',
+      statementTimeout: process === 'server' ? 30000 : 0,
     }),
   },
 

--- a/services/notify/src/main.js
+++ b/services/notify/src/main.js
@@ -68,7 +68,8 @@ const load = loader({
       serviceName: 'notify',
       readDbUrl: cfg.postgres.readDbUrl,
       writeDbUrl: cfg.postgres.writeDbUrl,
-      statementTimeout: process === 'server' ? 30000 : 0}),
+      statementTimeout: process === 'server' ? 30000 : 0,
+    }),
   },
 
   generateReferences: {

--- a/services/purge-cache/src/main.js
+++ b/services/purge-cache/src/main.js
@@ -34,11 +34,12 @@ const load = loader({
   },
 
   db: {
-    requires: ["cfg"],
-    setup: ({ cfg }) => tcdb.setup({
+    requires: ["cfg", "process"],
+    setup: ({cfg, process}) => tcdb.setup({
       readDbUrl: cfg.postgres.readDbUrl,
       writeDbUrl: cfg.postgres.writeDbUrl,
       serviceName: 'purge_cache',
+      statementTimeout: process === 'server' ? 30000 : 0,
     }),
   },
 

--- a/services/queue/src/main.js
+++ b/services/queue/src/main.js
@@ -95,11 +95,12 @@ let load = loader({
   },
 
   db: {
-    requires: ["cfg"],
-    setup: ({ cfg }) => tcdb.setup({
+    requires: ["cfg", "process"],
+    setup: ({cfg, process}) => tcdb.setup({
       readDbUrl: cfg.postgres.readDbUrl,
       writeDbUrl: cfg.postgres.writeDbUrl,
       serviceName: 'queue',
+      statementTimeout: process === 'server' ? 30000 : 0,
     }),
   },
 

--- a/services/secrets/src/main.js
+++ b/services/secrets/src/main.js
@@ -36,11 +36,12 @@ let load = loader({
   },
 
   db: {
-    requires: ['cfg'],
-    setup: ({cfg}) => tcdb.setup({
+    requires: ['cfg', 'process'],
+    setup: ({cfg, process}) => tcdb.setup({
       readDbUrl: cfg.postgres.readDbUrl,
       writeDbUrl: cfg.postgres.writeDbUrl,
       serviceName: 'secrets',
+      statementTimeout: process === 'server' ? 30000 : 0,
     }),
   },
 

--- a/services/web-server/src/main.js
+++ b/services/web-server/src/main.js
@@ -184,11 +184,12 @@ const load = loader(
     },
 
     db: {
-      requires: ['cfg'],
-      setup: ({cfg}) => tcdb.setup({
+      requires: ['cfg', 'process'],
+      setup: ({cfg, process}) => tcdb.setup({
         readDbUrl: cfg.postgres.readDbUrl,
         writeDbUrl: cfg.postgres.writeDbUrl,
         serviceName: 'web_server',
+        statementTimeout: process === 'server' ? 30000 : 0,
       }),
     },
 

--- a/services/worker-manager/src/main.js
+++ b/services/worker-manager/src/main.js
@@ -32,11 +32,12 @@ let load = loader({
   },
 
   db: {
-    requires: ["cfg"],
-    setup: ({ cfg }) => tcdb.setup({
+    requires: ["cfg", "process"],
+    setup: ({cfg, process}) => tcdb.setup({
       readDbUrl: cfg.postgres.readDbUrl,
       writeDbUrl: cfg.postgres.writeDbUrl,
       serviceName: 'worker_manager',
+      statementTimeout: process === 'server' ? 30000 : 0,
     }),
   },
 


### PR DESCRIPTION
Note that this will conflict with #2571 :(

Github Bug/Issue: Fixes #2566 