### PR TITLE
Request worker termination when the worker process exits

### DIFF
--- a/changelog/CQPTekd3S8yeaGupCoR94w.md
+++ b/changelog/CQPTekd3S8yeaGupCoR94w.md
@@ -1,0 +1,4 @@
+audience: worker-deployers
+level: patch
+---
+Now, if the worker process running in aws/gcp exits, it will be requested to worker-manager to terminate the instance.

--- a/tools/worker-runner/provider/aws/awsprovider.go
+++ b/tools/worker-runner/provider/aws/awsprovider.go
@@ -159,7 +159,7 @@ func (p *AWSProvider) WorkerStarted(state *run.State) error {
 
 func (p *AWSProvider) WorkerFinished(state *run.State) error {
 	p.terminationTicker.Stop()
-	return nil
+	return provider.RemoveWorker(state, p.workerManagerClientFactory)
 }
 
 func clientFactory(rootURL string, credentials *tcclient.Credentials) (tc.WorkerManager, error) {

--- a/tools/worker-runner/provider/google/google.go
+++ b/tools/worker-runner/provider/google/google.go
@@ -128,7 +128,7 @@ func (p *GoogleProvider) WorkerStarted(state *run.State) error {
 }
 
 func (p *GoogleProvider) WorkerFinished(state *run.State) error {
-	return nil
+	return provider.RemoveWorker(state, p.workerManagerClientFactory)
 }
 
 func clientFactory(rootURL string, credentials *tcclient.Credentials) (tc.WorkerManager, error) {


### PR DESCRIPTION
If the worker process panics and exits, the instance stays in a zombie
state.

To mitigate the situation, when the worker exits, we request a worker
termination to worker-manager.