### PR TITLE
Log DB info once a minute

### DIFF
--- a/libraries/postgres/src/Database.js
+++ b/libraries/postgres/src/Database.js
@@ -560,7 +560,7 @@ class Database {
   }
 
   /**
-   * Periodically monitor pool size, producing a measure every 5m.  These values
+   * Periodically monitor pool size, producing a measure every 1m.  These values
    * should represent a long-term trend so more frequent reports are not useful.
    */
   _startMonitoringPools() {
@@ -573,7 +573,7 @@ class Database {
           waitingCount: pool.waitingCount,
         });
       }
-    }, 300 * 1000);
+    }, 60 * 1000);
   }
 
   _stopMonitoringPools() {


### PR DESCRIPTION
Stackdriver aggregates log-based metrics into 1 minute buckets. By
outputting this log info once a minute, we can ensure every process is
represented in every bucket. Without doing this, metrics derived from it
would be much harder to interpret, since the processes whose data was
represented in each bucket would vary depending on when they were
started.