### PR TITLE
Make importer faster

### DIFF
--- a/infrastructure/tooling/src/importer/index.js
+++ b/infrastructure/tooling/src/importer/index.js
@@ -27,7 +27,7 @@ const main = async ({ operation }) => {
 
   const taskgraph = new TaskGraph(tasks, {
     locks: {
-      concurrency: new Lock(5),
+      concurrency: new Lock(6),
     },
   });
   const context = await taskgraph.run();

--- a/infrastructure/tooling/src/importer/util.js
+++ b/infrastructure/tooling/src/importer/util.js
@@ -50,7 +50,7 @@ exports.ALLOWED_TABLES = [
 ];
 
 // For certain tables, we would like to import faster to make sure we don't
-// spend over 8 hours (TVW duration) importing
+// spend over 8 hours (TCW duration) importing
 exports.LARGE_TABLES = [
   'QueueArtifacts',
   'QueueTasks',


### PR DESCRIPTION
Make import faster by splitting large tables into multiple imports.

The two largest tables that are currently preventing us from being within the 8 hours range are QueueTasks and QueueArtifacts:

```
--- QueueTasks ---
Rows imported: 14060373
Elapsed time: 10h 5m 4.4s

--- QueueArtifacts ---
Rows imported: 125737200
Elapsed time: 1d 2m 34.1s
```