### PR TITLE
Fix notify monitor is required error

### DIFF
--- a/changelog/T4aTRVi3RGiCS6slQohlgQ.md
+++ b/changelog/T4aTRVi3RGiCS6slQohlgQ.md
@@ -1,0 +1,4 @@
+audience: deployers
+level: patch
+---
+Fix error in notify service (monitor is required)

--- a/services/notify/src/main.js
+++ b/services/notify/src/main.js
@@ -68,9 +68,10 @@ const load = loader({
   },
 
   db: {
-    requires: ['process', 'cfg'],
+    requires: ['process', 'cfg', 'monitor'],
     setup: ({process, cfg}) => tcdb.setup({
       serviceName: 'notify',
+      monitor: monitor.childMonitor('notify'),
       ...cfg.postgres,
       statementTimeout: process === 'server' ? 30000 : 0}),
   },

--- a/services/notify/src/main.js
+++ b/services/notify/src/main.js
@@ -69,9 +69,9 @@ const load = loader({
 
   db: {
     requires: ['process', 'cfg', 'monitor'],
-    setup: ({process, cfg}) => tcdb.setup({
+    setup: ({process, cfg, monitor}) => tcdb.setup({
       serviceName: 'notify',
-      monitor: monitor.childMonitor('notify'),
+      monitor: monitor.childMonitor('db'),
       ...cfg.postgres,
       statementTimeout: process === 'server' ? 30000 : 0}),
   },


### PR DESCRIPTION
From slack:

> hmm, what we're seeing is the error at https://github.com/taskcluster/taskcluster/blob/master/libraries/postgres/src/Database.js#L58
> from https://github.com/taskcluster/taskcluster/commit/979653f465104abb27709e7532128a9cf5963dbc
> which is new in v28.2.0. we were on v28.1.0 before

_untested_ but should work.