### PR TITLE
Set up monitors for all TC services' `db` property

### DIFF
--- a/changelog/issue-2522.md
+++ b/changelog/issue-2522.md
@@ -1,0 +1,4 @@
+level: patch
+reference: issue 2522
+---
+Services that use a database now log information about that database, including connection pool counts and stored-function invocations.

--- a/db/src/setup.js
+++ b/db/src/setup.js
@@ -2,13 +2,14 @@ const {schema} = require('./schema.js');
 const {Database} = require('taskcluster-lib-postgres');
 const {FakeDatabase} = require('./fakes');
 
-exports.setup = async ({writeDbUrl, readDbUrl, serviceName, useDbDirectory, statementTimeout}) => {
+exports.setup = async ({writeDbUrl, readDbUrl, serviceName, useDbDirectory, statementTimeout, monitor}) => {
   return await Database.setup({
     schema: schema({useDbDirectory}),
     writeDbUrl,
     readDbUrl,
     serviceName,
     statementTimeout,
+    monitor,
   });
 };
 

--- a/db/test/helper.js
+++ b/db/test/helper.js
@@ -95,6 +95,7 @@ exports.withDbForProcs = function({ serviceName }) {
       readDbUrl: exports.dbUrl,
       serviceName,
       useDbDirectory: true,
+      monitor: false,
     });
 
     exports.fakeDb = await tcdb.fakeSetup({

--- a/generated/references.json
+++ b/generated/references.json
@@ -11425,6 +11425,31 @@
           "version": 1
         },
         {
+          "description": "This message is logged for each invocation of a Postgres stored function.",
+          "fields": {
+            "name": "The name of the DB function"
+          },
+          "level": "info",
+          "name": "dbFunctionCall",
+          "title": "DB Method Call",
+          "type": "db-function-call",
+          "version": 1
+        },
+        {
+          "description": "This message is logged every 5 minutes from each process that is using the database,\nonce for each pool.  Most services have both a \"read\" pool and a \"write\" pool.  The\nfields come from the node-postgres package.",
+          "fields": {
+            "idleCount": "The number of connections (out of the total) which are not currently in use",
+            "pool": "The name of the pool within the process",
+            "totalCount": "The total number of connections",
+            "waitingCount": "The number of operations waiting for an idle connection"
+          },
+          "level": "notice",
+          "name": "dbPoolCounts",
+          "title": "DB Pool Counts",
+          "type": "db-pool-counts",
+          "version": 1
+        },
+        {
           "description": "A timer and audit for express API endpoints.\nYou can combine this with auth audit logs to get\na complete picture of what was authorized when.\n\nHere, anything that is not public should have authenticated\nand if it authenticated, we will tell the clientId here. Given\nthat, it is not necessarily true that the endpoint was\n_authorized_. You can tell that by the statusCode.",
           "fields": {
             "apiVersion": "The version of the API (e.g., `v1`)",
@@ -11970,6 +11995,31 @@
           "version": 1
         },
         {
+          "description": "This message is logged for each invocation of a Postgres stored function.",
+          "fields": {
+            "name": "The name of the DB function"
+          },
+          "level": "info",
+          "name": "dbFunctionCall",
+          "title": "DB Method Call",
+          "type": "db-function-call",
+          "version": 1
+        },
+        {
+          "description": "This message is logged every 5 minutes from each process that is using the database,\nonce for each pool.  Most services have both a \"read\" pool and a \"write\" pool.  The\nfields come from the node-postgres package.",
+          "fields": {
+            "idleCount": "The number of connections (out of the total) which are not currently in use",
+            "pool": "The name of the pool within the process",
+            "totalCount": "The total number of connections",
+            "waitingCount": "The number of operations waiting for an idle connection"
+          },
+          "level": "notice",
+          "name": "dbPoolCounts",
+          "title": "DB Pool Counts",
+          "type": "db-pool-counts",
+          "version": 1
+        },
+        {
           "description": "A client has been issued Taskcluster credentials",
           "fields": {
             "clientId": "The clientId of the issued credentials",
@@ -12157,6 +12207,31 @@
           "name": "loggingError",
           "title": "Error in Logging",
           "type": "monitor.loggingError",
+          "version": 1
+        },
+        {
+          "description": "This message is logged for each invocation of a Postgres stored function.",
+          "fields": {
+            "name": "The name of the DB function"
+          },
+          "level": "info",
+          "name": "dbFunctionCall",
+          "title": "DB Method Call",
+          "type": "db-function-call",
+          "version": 1
+        },
+        {
+          "description": "This message is logged every 5 minutes from each process that is using the database,\nonce for each pool.  Most services have both a \"read\" pool and a \"write\" pool.  The\nfields come from the node-postgres package.",
+          "fields": {
+            "idleCount": "The number of connections (out of the total) which are not currently in use",
+            "pool": "The name of the pool within the process",
+            "totalCount": "The total number of connections",
+            "waitingCount": "The number of operations waiting for an idle connection"
+          },
+          "level": "notice",
+          "name": "dbPoolCounts",
+          "title": "DB Pool Counts",
+          "type": "db-pool-counts",
           "version": 1
         },
         {
@@ -12438,6 +12513,31 @@
           "name": "apiMethod",
           "title": "API Method Report",
           "type": "monitor.apiMethod",
+          "version": 1
+        },
+        {
+          "description": "This message is logged for each invocation of a Postgres stored function.",
+          "fields": {
+            "name": "The name of the DB function"
+          },
+          "level": "info",
+          "name": "dbFunctionCall",
+          "title": "DB Method Call",
+          "type": "db-function-call",
+          "version": 1
+        },
+        {
+          "description": "This message is logged every 5 minutes from each process that is using the database,\nonce for each pool.  Most services have both a \"read\" pool and a \"write\" pool.  The\nfields come from the node-postgres package.",
+          "fields": {
+            "idleCount": "The number of connections (out of the total) which are not currently in use",
+            "pool": "The name of the pool within the process",
+            "totalCount": "The total number of connections",
+            "waitingCount": "The number of operations waiting for an idle connection"
+          },
+          "level": "notice",
+          "name": "dbPoolCounts",
+          "title": "DB Pool Counts",
+          "type": "db-pool-counts",
           "version": 1
         },
         {
@@ -14022,6 +14122,31 @@
           "version": 1
         },
         {
+          "description": "This message is logged for each invocation of a Postgres stored function.",
+          "fields": {
+            "name": "The name of the DB function"
+          },
+          "level": "info",
+          "name": "dbFunctionCall",
+          "title": "DB Method Call",
+          "type": "db-function-call",
+          "version": 1
+        },
+        {
+          "description": "This message is logged every 5 minutes from each process that is using the database,\nonce for each pool.  Most services have both a \"read\" pool and a \"write\" pool.  The\nfields come from the node-postgres package.",
+          "fields": {
+            "idleCount": "The number of connections (out of the total) which are not currently in use",
+            "pool": "The name of the pool within the process",
+            "totalCount": "The total number of connections",
+            "waitingCount": "The number of operations waiting for an idle connection"
+          },
+          "level": "notice",
+          "name": "dbPoolCounts",
+          "title": "DB Pool Counts",
+          "type": "db-pool-counts",
+          "version": 1
+        },
+        {
           "description": "A timer and audit for express API endpoints.\nYou can combine this with auth audit logs to get\na complete picture of what was authorized when.\n\nHere, anything that is not public should have authenticated\nand if it authenticated, we will tell the clientId here. Given\nthat, it is not necessarily true that the endpoint was\n_authorized_. You can tell that by the statusCode.",
           "fields": {
             "apiVersion": "The version of the API (e.g., `v1`)",
@@ -14385,6 +14510,31 @@
           "name": "apiMethod",
           "title": "API Method Report",
           "type": "monitor.apiMethod",
+          "version": 1
+        },
+        {
+          "description": "This message is logged for each invocation of a Postgres stored function.",
+          "fields": {
+            "name": "The name of the DB function"
+          },
+          "level": "info",
+          "name": "dbFunctionCall",
+          "title": "DB Method Call",
+          "type": "db-function-call",
+          "version": 1
+        },
+        {
+          "description": "This message is logged every 5 minutes from each process that is using the database,\nonce for each pool.  Most services have both a \"read\" pool and a \"write\" pool.  The\nfields come from the node-postgres package.",
+          "fields": {
+            "idleCount": "The number of connections (out of the total) which are not currently in use",
+            "pool": "The name of the pool within the process",
+            "totalCount": "The total number of connections",
+            "waitingCount": "The number of operations waiting for an idle connection"
+          },
+          "level": "notice",
+          "name": "dbPoolCounts",
+          "title": "DB Pool Counts",
+          "type": "db-pool-counts",
           "version": 1
         }
       ]
@@ -14784,6 +14934,31 @@
           "version": 1
         },
         {
+          "description": "This message is logged for each invocation of a Postgres stored function.",
+          "fields": {
+            "name": "The name of the DB function"
+          },
+          "level": "info",
+          "name": "dbFunctionCall",
+          "title": "DB Method Call",
+          "type": "db-function-call",
+          "version": 1
+        },
+        {
+          "description": "This message is logged every 5 minutes from each process that is using the database,\nonce for each pool.  Most services have both a \"read\" pool and a \"write\" pool.  The\nfields come from the node-postgres package.",
+          "fields": {
+            "idleCount": "The number of connections (out of the total) which are not currently in use",
+            "pool": "The name of the pool within the process",
+            "totalCount": "The total number of connections",
+            "waitingCount": "The number of operations waiting for an idle connection"
+          },
+          "level": "notice",
+          "name": "dbPoolCounts",
+          "title": "DB Pool Counts",
+          "type": "db-pool-counts",
+          "version": 1
+        },
+        {
           "description": "A connection to Pulse has been established.  Taskcluster services\nautomatically reconnect to Pulse periodically and in the event of\nan error, but rapid reconnections may signal a Pulse failure.",
           "fields": {
           },
@@ -15094,6 +15269,31 @@
           "name": "loggingError",
           "title": "Error in Logging",
           "type": "monitor.loggingError",
+          "version": 1
+        },
+        {
+          "description": "This message is logged for each invocation of a Postgres stored function.",
+          "fields": {
+            "name": "The name of the DB function"
+          },
+          "level": "info",
+          "name": "dbFunctionCall",
+          "title": "DB Method Call",
+          "type": "db-function-call",
+          "version": 1
+        },
+        {
+          "description": "This message is logged every 5 minutes from each process that is using the database,\nonce for each pool.  Most services have both a \"read\" pool and a \"write\" pool.  The\nfields come from the node-postgres package.",
+          "fields": {
+            "idleCount": "The number of connections (out of the total) which are not currently in use",
+            "pool": "The name of the pool within the process",
+            "totalCount": "The total number of connections",
+            "waitingCount": "The number of operations waiting for an idle connection"
+          },
+          "level": "notice",
+          "name": "dbPoolCounts",
+          "title": "DB Pool Counts",
+          "type": "db-pool-counts",
           "version": 1
         },
         {
@@ -15637,6 +15837,31 @@
           "name": "apiMethod",
           "title": "API Method Report",
           "type": "monitor.apiMethod",
+          "version": 1
+        },
+        {
+          "description": "This message is logged for each invocation of a Postgres stored function.",
+          "fields": {
+            "name": "The name of the DB function"
+          },
+          "level": "info",
+          "name": "dbFunctionCall",
+          "title": "DB Method Call",
+          "type": "db-function-call",
+          "version": 1
+        },
+        {
+          "description": "This message is logged every 5 minutes from each process that is using the database,\nonce for each pool.  Most services have both a \"read\" pool and a \"write\" pool.  The\nfields come from the node-postgres package.",
+          "fields": {
+            "idleCount": "The number of connections (out of the total) which are not currently in use",
+            "pool": "The name of the pool within the process",
+            "totalCount": "The total number of connections",
+            "waitingCount": "The number of operations waiting for an idle connection"
+          },
+          "level": "notice",
+          "name": "dbPoolCounts",
+          "title": "DB Pool Counts",
+          "type": "db-pool-counts",
           "version": 1
         },
         {
@@ -16268,6 +16493,31 @@
           "name": "loggingError",
           "title": "Error in Logging",
           "type": "monitor.loggingError",
+          "version": 1
+        },
+        {
+          "description": "This message is logged for each invocation of a Postgres stored function.",
+          "fields": {
+            "name": "The name of the DB function"
+          },
+          "level": "info",
+          "name": "dbFunctionCall",
+          "title": "DB Method Call",
+          "type": "db-function-call",
+          "version": 1
+        },
+        {
+          "description": "This message is logged every 5 minutes from each process that is using the database,\nonce for each pool.  Most services have both a \"read\" pool and a \"write\" pool.  The\nfields come from the node-postgres package.",
+          "fields": {
+            "idleCount": "The number of connections (out of the total) which are not currently in use",
+            "pool": "The name of the pool within the process",
+            "totalCount": "The total number of connections",
+            "waitingCount": "The number of operations waiting for an idle connection"
+          },
+          "level": "notice",
+          "name": "dbPoolCounts",
+          "title": "DB Pool Counts",
+          "type": "db-pool-counts",
           "version": 1
         },
         {

--- a/libraries/entities/test/helper.js
+++ b/libraries/entities/test/helper.js
@@ -1,6 +1,17 @@
 const {Client} = require('pg');
 const { Database } = require('taskcluster-lib-postgres');
+const {defaultMonitorManager} = require('taskcluster-lib-monitor');
 const dbUrl = process.env.TEST_DB_URL;
+
+defaultMonitorManager.configure({
+  serviceName: 'lib-entities',
+});
+
+const monitor = defaultMonitorManager.setup({
+  fake: true,
+  debug: true,
+  validate: true,
+});
 
 /**
  * dbSuite(..) is a replacement for suite(..) that sets this.dbUrl when
@@ -35,6 +46,7 @@ exports.withDb = async ({ schema, serviceName }) => {
     readDbUrl: exports.dbUrl,
     writeDbUrl: exports.dbUrl,
     serviceName,
+    monitor,
   });
 
   await Database.upgrade({

--- a/libraries/postgres/src/Database.js
+++ b/libraries/postgres/src/Database.js
@@ -3,6 +3,7 @@ const pg = require('pg');
 const {dollarQuote, annotateError} = require('./util');
 const assert = require('assert').strict;
 const {READ, WRITE, DUPLICATE_OBJECT, UNDEFINED_TABLE} = require('./constants');
+const {defaultMonitorManager} = require('taskcluster-lib-monitor');
 
 // Postgres extensions to "create".
 const EXTENSIONS = [
@@ -14,17 +15,49 @@ const EXTENSIONS = [
 // questionable decision can be overridden globally:
 pg.defaults.parseInputDatesAsUTC = true;
 
+defaultMonitorManager.register({
+  name: 'dbFunctionCall',
+  title: 'DB Method Call',
+  type: 'db-function-call',
+  level: 'info',
+  version: 1,
+  description: `This message is logged for each invocation of a Postgres stored function.`,
+  fields: {
+    name: 'The name of the DB function',
+  },
+});
+
+defaultMonitorManager.register({
+  name: 'dbPoolCounts',
+  title: 'DB Pool Counts',
+  type: 'db-pool-counts',
+  level: 'notice',
+  version: 1,
+  description: `
+    This message is logged every 5 minutes from each process that is using the database,
+    once for each pool.  Most services have both a "read" pool and a "write" pool.  The
+    fields come from the node-postgres package.
+  `,
+  fields: {
+    pool: 'The name of the pool within the process',
+    totalCount: 'The total number of connections',
+    idleCount: 'The number of connections (out of the total) which are not currently in use',
+    waitingCount: 'The number of operations waiting for an idle connection',
+  },
+});
+
 class Database {
   /**
    * Get a new Database instance
    */
-  static async setup({schema, readDbUrl, writeDbUrl, serviceName, statementTimeout}) {
+  static async setup({schema, readDbUrl, writeDbUrl, serviceName, monitor, statementTimeout}) {
     assert(readDbUrl, 'readDbUrl is required');
     assert(writeDbUrl, 'writeDbUrl is required');
     assert(schema, 'schema is required');
     assert(serviceName, 'serviceName is required');
+    assert(monitor !== undefined, 'monitor is required (but use `false` to disable)');
 
-    const db = new Database({urlsByMode: {[READ]: readDbUrl, [WRITE]: writeDbUrl}, statementTimeout});
+    const db = new Database({urlsByMode: {[READ]: readDbUrl, [WRITE]: writeDbUrl}, monitor, statementTimeout});
     db._createProcs({schema, serviceName});
 
     const dbVersion = await db.currentVersion();
@@ -49,6 +82,8 @@ class Database {
           throw new Error(
             `${serviceName} is not allowed to call read-write methods for other services`);
         }
+
+        this._logDbFunctionCall({name: method.name});
 
         const placeholders = [...new Array(args.length).keys()].map(i => `$${i + 1}`).join(',');
         const res = await this._withClient(method.mode, async client => {
@@ -409,7 +444,7 @@ class Database {
   /**
    * Private constructor (use Database.setup and Database.upgrade instead)
    */
-  constructor({urlsByMode, statementTimeout}) {
+  constructor({urlsByMode, monitor, statementTimeout}) {
     assert(!statementTimeout || typeof statementTimeout === 'number' || typeof statementTimeout === 'boolean');
     const makePool = dbUrl => {
       // use a max of 5 connections. For services running both a read and write
@@ -452,10 +487,14 @@ class Database {
       return pool;
     };
 
+    this.monitor = monitor;
+
     this.pools = {};
     for (let mode of Object.keys(urlsByMode)) {
       this.pools[mode] = makePool(urlsByMode[mode]);
     }
+
+    this._startMonitoringPools();
 
     this.fns = {};
   }
@@ -524,14 +563,55 @@ class Database {
   }
 
   /**
+   * Periodically monitor pool size, producing a measure every 5m.  These values
+   * should represent a long-term trend so more frequent reports are not useful.
+   */
+  _startMonitoringPools() {
+    this._poolMonitorInterval = setInterval(() => {
+      for (const [name, pool] of Object.entries(this.pools)) {
+        this._logDbPoolCounts({
+          pool: name,
+          totalCount: pool.totalCount,
+          idleCount: pool.idleCount,
+          waitingCount: pool.waitingCount,
+        });
+      }
+    }, 300 * 1000);
+  }
+
+  _stopMonitoringPools() {
+    if (this._poolMonitorInterval) {
+      clearInterval(this._poolMonitorInterval);
+    }
+    this._poolMonitorInterval = null;
+  }
+
+  /**
    * Wrap up operations on this DB
    */
   async close() {
+    this._stopMonitoringPools();
     await Promise.all(Object.values(this.pools).map(pool => pool.end()));
   }
 
   static _validUsernamePrefix(usernamePrefix) {
     return usernamePrefix.match(/^[a-z_]+$/);
+  }
+
+  /**
+   * Depending on context, we may not have a monitor (e.g., during upgrade), so
+   * these methods wrap calls to `monitor.<foo>` with a check for monitor being
+   * undefined, ignoring the call in that case.
+   */
+  _logDbFunctionCall(fields) {
+    if (this.monitor) {
+      this.monitor.log.dbFunctionCall(fields);
+    }
+  }
+  _logDbPoolCounts(fields) {
+    if (this.monitor) {
+      this.monitor.log.dbPoolCounts(fields);
+    }
   }
 }
 

--- a/libraries/postgres/test/helper.js
+++ b/libraries/postgres/test/helper.js
@@ -1,5 +1,19 @@
 const {Client} = require('pg');
+const {withMonitor} = require('taskcluster-lib-testing');
+const {defaultMonitorManager} = require('taskcluster-lib-monitor');
 const dbUrl = process.env.TEST_DB_URL;
+
+withMonitor(exports, {noLoader: true});
+
+defaultMonitorManager.configure({
+  serviceName: 'lib-postgres',
+});
+
+exports.monitor = defaultMonitorManager.setup({
+  fake: true,
+  debug: true,
+  validate: true,
+});
 
 /**
  * dbSuite(..) is a replacement for suite(..) that sets this.dbUrl when

--- a/libraries/testing/src/with-db.js
+++ b/libraries/testing/src/with-db.js
@@ -96,6 +96,7 @@ module.exports.withDb = (mock, skipping, helper, serviceName) => {
         writeDbUrl: serviceDbUrl,
         serviceName,
         useDbDirectory: true,
+        monitor: false,
       });
     }
 

--- a/services/auth/src/main.js
+++ b/services/auth/src/main.js
@@ -48,11 +48,12 @@ const load = Loader({
   },
 
   db: {
-    requires: ['cfg', 'process'],
-    setup: ({cfg, process}) => tcdb.setup({
+    requires: ['cfg', 'process', 'monitor'],
+    setup: ({cfg, process, monitor}) => tcdb.setup({
       readDbUrl: cfg.postgres.readDbUrl,
       writeDbUrl: cfg.postgres.writeDbUrl,
       serviceName: 'auth',
+      monitor: monitor.childMonitor('db'),
       statementTimeout: process === 'server' ? 30000 : 0,
     }),
   },

--- a/services/github/src/main.js
+++ b/services/github/src/main.js
@@ -86,11 +86,12 @@ const load = loader({
   },
 
   db: {
-    requires: ["cfg", "process"],
-    setup: ({cfg, process}) => tcdb.setup({
+    requires: ["cfg", "process", "monitor"],
+    setup: ({cfg, process, monitor}) => tcdb.setup({
       readDbUrl: cfg.postgres.readDbUrl,
       writeDbUrl: cfg.postgres.writeDbUrl,
       serviceName: 'github',
+      monitor: monitor.childMonitor('db'),
       statementTimeout: process === 'server' ? 30000 : 0,
     }),
   },

--- a/services/hooks/src/main.js
+++ b/services/hooks/src/main.js
@@ -33,11 +33,12 @@ const load = loader({
   },
 
   db: {
-    requires: ["cfg", "process"],
-    setup: ({cfg, process}) => tcdb.setup({
+    requires: ["cfg", "process", "monitor"],
+    setup: ({cfg, process, monitor}) => tcdb.setup({
       readDbUrl: cfg.postgres.readDbUrl,
       writeDbUrl: cfg.postgres.writeDbUrl,
       serviceName: 'hooks',
+      monitor: monitor.childMonitor('db'),
       statementTimeout: process === 'server' ? 30000 : 0,
     }),
   },

--- a/services/index/src/main.js
+++ b/services/index/src/main.js
@@ -21,11 +21,12 @@ let load = loader({
   },
 
   db: {
-    requires: ["cfg", "process"],
-    setup: ({cfg, process}) => tcdb.setup({
+    requires: ["cfg", "process", "monitor"],
+    setup: ({cfg, process, monitor}) => tcdb.setup({
       readDbUrl: cfg.postgres.readDbUrl,
       writeDbUrl: cfg.postgres.writeDbUrl,
       serviceName: 'index',
+      monitor: monitor.childMonitor('db'),
       statementTimeout: process === 'server' ? 30000 : 0,
     }),
   },

--- a/services/notify/src/main.js
+++ b/services/notify/src/main.js
@@ -63,12 +63,13 @@ const load = loader({
   },
 
   db: {
-    requires: ['process', 'cfg'],
-    setup: ({process, cfg}) => tcdb.setup({
+    requires: ['process', 'cfg', 'monitor'],
+    setup: ({process, cfg, monitor}) => tcdb.setup({
       serviceName: 'notify',
       readDbUrl: cfg.postgres.readDbUrl,
       writeDbUrl: cfg.postgres.writeDbUrl,
       statementTimeout: process === 'server' ? 30000 : 0,
+      monitor: monitor.childMonitor('db'),
     }),
   },
 

--- a/services/purge-cache/src/main.js
+++ b/services/purge-cache/src/main.js
@@ -34,11 +34,12 @@ const load = loader({
   },
 
   db: {
-    requires: ["cfg", "process"],
-    setup: ({cfg, process}) => tcdb.setup({
+    requires: ["cfg", "process", "monitor"],
+    setup: ({cfg, process, monitor}) => tcdb.setup({
       readDbUrl: cfg.postgres.readDbUrl,
       writeDbUrl: cfg.postgres.writeDbUrl,
       serviceName: 'purge_cache',
+      monitor: monitor.childMonitor('db'),
       statementTimeout: process === 'server' ? 30000 : 0,
     }),
   },

--- a/services/queue/src/main.js
+++ b/services/queue/src/main.js
@@ -95,11 +95,12 @@ let load = loader({
   },
 
   db: {
-    requires: ["cfg", "process"],
-    setup: ({cfg, process}) => tcdb.setup({
+    requires: ["cfg", "process", "monitor"],
+    setup: ({cfg, process, monitor}) => tcdb.setup({
       readDbUrl: cfg.postgres.readDbUrl,
       writeDbUrl: cfg.postgres.writeDbUrl,
       serviceName: 'queue',
+      monitor: monitor.childMonitor('db'),
       statementTimeout: process === 'server' ? 30000 : 0,
     }),
   },

--- a/services/secrets/src/main.js
+++ b/services/secrets/src/main.js
@@ -36,11 +36,12 @@ let load = loader({
   },
 
   db: {
-    requires: ['cfg', 'process'],
-    setup: ({cfg, process}) => tcdb.setup({
+    requires: ['cfg', 'process', 'monitor'],
+    setup: ({cfg, process, monitor}) => tcdb.setup({
       readDbUrl: cfg.postgres.readDbUrl,
       writeDbUrl: cfg.postgres.writeDbUrl,
       serviceName: 'secrets',
+      monitor: monitor.childMonitor('db'),
       statementTimeout: process === 'server' ? 30000 : 0,
     }),
   },

--- a/services/web-server/src/main.js
+++ b/services/web-server/src/main.js
@@ -184,11 +184,12 @@ const load = loader(
     },
 
     db: {
-      requires: ['cfg', 'process'],
-      setup: ({cfg, process}) => tcdb.setup({
+      requires: ['cfg', 'process', 'monitor'],
+      setup: ({cfg, process, monitor}) => tcdb.setup({
         readDbUrl: cfg.postgres.readDbUrl,
         writeDbUrl: cfg.postgres.writeDbUrl,
         serviceName: 'web_server',
+        monitor: monitor.childMonitor('db'),
         statementTimeout: process === 'server' ? 30000 : 0,
       }),
     },

--- a/services/worker-manager/src/main.js
+++ b/services/worker-manager/src/main.js
@@ -32,11 +32,12 @@ let load = loader({
   },
 
   db: {
-    requires: ["cfg", "process"],
-    setup: ({cfg, process}) => tcdb.setup({
+    requires: ["cfg", "process", "monitor"],
+    setup: ({cfg, process, monitor}) => tcdb.setup({
       readDbUrl: cfg.postgres.readDbUrl,
       writeDbUrl: cfg.postgres.writeDbUrl,
       serviceName: 'worker_manager',
+      monitor: monitor.childMonitor('db'),
       statementTimeout: process === 'server' ? 30000 : 0,
     }),
   },


### PR DESCRIPTION
This is the other half of #2522.  The first commit here is cherry-picked from master, and the second updated to include #2601.  We'll count #2601 fixed when this merges back to master.