### PR TITLE
Bug 1525419 - escape env variable contents on Windows properly

### DIFF
--- a/changelog/bug-1525419.md
+++ b/changelog/bug-1525419.md
@@ -1,0 +1,5 @@
+audience: users
+level: patch
+reference: bug 1525419
+---
+Generic worker tasks on Windows can now define environment variables that contain special characters `()%!^"<>&|`. Previously they were not escaped.

--- a/workers/generic-worker/build.sh
+++ b/workers/generic-worker/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -exv
+#!/bin/bash -e
 
 cd "$(dirname "${0}")"
 

--- a/workers/generic-worker/envvars_broken_on_docker_test.go
+++ b/workers/generic-worker/envvars_broken_on_docker_test.go
@@ -17,14 +17,27 @@ func TestWorkerLocation(t *testing.T) {
 	config.WorkerLocation = `{"cloud":"9","biscuits":"free"}`
 
 	payload := GenericWorkerPayload{
-		Command: goRun(
-			"check-env.go",
-			"TASKCLUSTER_WORKER_LOCATION",
-			`{"cloud":"9","biscuits":"free"}`,
-			"RUN_ID",
-			"0",
-			"TASKCLUSTER_ROOT_URL",
-			config.RootURL,
+		Env: map[string]string{
+			"STRANGE_VAR": `()%!^"<>&|`,
+		},
+		Command: append(
+			// In multiuser engine on Windows, the env vars are exported to a
+			// file at the end of each command, and then imported by the
+			// wrapper script at the start of the following command. Therefore
+			// make sure we have at least two commands in order to also test
+			// export/import of env vars between commands.
+			helloGoodbye(),
+			goRun(
+				"check-env.go",
+				"TASKCLUSTER_WORKER_LOCATION",
+				`{"cloud":"9","biscuits":"free"}`,
+				"RUN_ID",
+				"0",
+				"TASKCLUSTER_ROOT_URL",
+				config.RootURL,
+				"STRANGE_VAR",
+				`()%!^"<>&|`,
+			)...,
 		),
 		MaxRunTime: 180,
 	}

--- a/workers/generic-worker/helper_windows_test.go
+++ b/workers/generic-worker/helper_windows_test.go
@@ -7,6 +7,8 @@ import (
 	"strconv"
 	"strings"
 	"syscall"
+
+	"github.com/taskcluster/taskcluster/v28/workers/generic-worker/win32"
 )
 
 func helloGoodbye() []string {
@@ -95,7 +97,7 @@ func goRunFileOutput(outputFile, goFile string, args ...string) []string {
 // run runs the command line args specified in args and redirects the output to
 // file outputFile if it is not an empty string.
 func run(args []string, outputFile string) string {
-	run := cmdExeEscape(makeCmdLine(args))
+	run := win32.CMDExeEscape(makeCmdLine(args))
 
 	if outputFile != "" {
 		run += ` > ` + syscall.EscapeArg(outputFile)
@@ -113,19 +115,6 @@ func makeCmdLine(args []string) string {
 		s += syscall.EscapeArg(v)
 	}
 	return s
-}
-
-// cmdExeEscape escapes cmd.exe metacharacters
-// See: https://blogs.msdn.microsoft.com/twistylittlepassagesallalike/2011/04/23/everyone-quotes-command-line-arguments-the-wrong-way/
-func cmdExeEscape(text string) string {
-	cmdEscaped := ""
-	for _, c := range text {
-		if strings.ContainsRune(`()%!^"<>&|`, c) {
-			cmdEscaped += "^"
-		}
-		cmdEscaped += string(c)
-	}
-	return cmdEscaped
 }
 
 func copyTestdataFile(path string) []string {

--- a/workers/generic-worker/win32/win32_windows.go
+++ b/workers/generic-worker/win32/win32_windows.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"strings"
 	"syscall"
 	"time"
 	"unicode/utf16"
@@ -813,4 +814,17 @@ func DeleteProfile(
 		err = os.NewSyscallError("DeleteProfileW", e1)
 	}
 	return
+}
+
+// CMDExeEscape escapes cmd.exe metacharacters
+// See: https://blogs.msdn.microsoft.com/twistylittlepassagesallalike/2011/04/23/everyone-quotes-command-line-arguments-the-wrong-way/
+func CMDExeEscape(text string) string {
+	cmdEscaped := ""
+	for _, c := range text {
+		if strings.ContainsRune(`()%!^"<>&|`, c) {
+			cmdEscaped += "^"
+		}
+		cmdEscaped += string(c)
+	}
+	return cmdEscaped
 }


### PR DESCRIPTION
Bugzilla Bug: [1525419](https://bugzilla.mozilla.org/show_bug.cgi?id=1525419)

This should fix the escaping of special characters in environment variables on Windows (except newline/linefeed characters which is tracked in [bug 1495760](https://bugzilla.mozilla.org/show_bug.cgi?id=1495760)).

We'll need to wait for the CI to complete - I haven't manually tested on Windows.