### PR TITLE
Add a best practice around trusting the content of pulse messages

### DIFF
--- a/changelog/YvhNWH3jSkyQSgAcrLf-Bg.md
+++ b/changelog/YvhNWH3jSkyQSgAcrLf-Bg.md
@@ -1,0 +1,3 @@
+audience: general
+level: silent
+---

--- a/dev-docs/best-practices/security.md
+++ b/dev-docs/best-practices/security.md
@@ -24,3 +24,16 @@ This means that even a user with `auth:gcp:access-token:*` cannot get credential
 
 In part, this best-practice aligns with user expectations: operations using the API should not be able to break the Taskcluster deployment in a way that cannot be fixed via other API calls.
 Equally importantly, this is a form of "defense in depth" against attacks that might compromise the Taskcluster services and then pivot to compromise CI processes that depend on the intergrity of those services.
+
+## Integrity, Reliability, and Privacy of Pulse Messages
+
+A correctly-configured Pulse server provides the following assurances:
+ * Only those with the password for an account can publish to an AMQP exchange, so for example a message on `exchanges/taskcluster-queue/v1/task-defined` must be published by the queue service
+ * Messages published to an exchange are reliably delivered to queues and on to consumers even in the face of temporary server failure
+ * Anyone with an account on the pulse server can consume messages on any exchange, so messages are not secret
+
+However, the pulse server is an external service that could be misconfigured or exploited.
+In this case, messages might be maliciously deleted, injected, or modified.
+
+As a design principle, Taskcluster services should avoid relying on the content of a message, and instead treat the message as a hint that something has changed in the backend storage.
+For example, when monitoring for changes to tasks, consumers of the `task-completed` exchange use the taskId in the message to fetch the task via `queue.task(..)`, and treat the result of that API call as authoritative.


### PR DESCRIPTION
This came up in a meeting at some point followed by "huh, we should write that down".  And now it's written.

The two things I can think of that don't follow this are:
 * hooks with `bindings` set to something (really more of a user-configuration issue)
 * tc-github, which iirc stores the payload of each GH webhook in a pulse message.  I think there's a bug to change that to store the payload in a table, which has the nice side-effect of being able to review previous webhook payloads for a repo.