### PR TITLE
Update yarn version in netlify.toml

### DIFF
--- a/changelog/QuzMVVs9Rta6AoOwbZTOgA.md
+++ b/changelog/QuzMVVs9Rta6AoOwbZTOgA.md
@@ -1,0 +1,3 @@
+audience: general
+level: silent
+---

--- a/netlify.toml
+++ b/netlify.toml
@@ -9,7 +9,7 @@
 
 [build.environment]
   YARN_FLAGS = "--frozen-lockfile"
-  YARN_VERSION = "1.10.1"
+  YARN_VERSION = "1.22.4"
   NODE_VERSION = "12.16.1"
   APPLICATION_NAME = "Taskcluster"
   GRAPHQL_ENDPOINT = "https://community-tc.services.mozilla.com/graphql"


### PR DESCRIPTION
Hopefully this will fix the failing netlify jobs.  But maybe not: it had been installing yarn 1.10, but because we embed yarn in the repo, it was actually using 1.22.4 to do the install.

Still, I can't reproduce the issue locally, so let's give this fix a shot..