### PR TITLE
Use a bigger pool for postgres connections when importing

### DIFF
--- a/db/src/setup.js
+++ b/db/src/setup.js
@@ -2,13 +2,14 @@ const {schema} = require('./schema.js');
 const {Database} = require('taskcluster-lib-postgres');
 const {FakeDatabase} = require('./fakes');
 
-exports.setup = async ({writeDbUrl, readDbUrl, serviceName, useDbDirectory, statementTimeout, monitor}) => {
+exports.setup = async ({writeDbUrl, readDbUrl, serviceName, useDbDirectory, statementTimeout, poolSize, monitor}) => {
   return await Database.setup({
     schema: schema({useDbDirectory}),
     writeDbUrl,
     readDbUrl,
     serviceName,
     statementTimeout,
+    poolSize,
     monitor,
   });
 };

--- a/infrastructure/tooling/src/importer/util.js
+++ b/infrastructure/tooling/src/importer/util.js
@@ -15,6 +15,9 @@ exports.requireEnv = name => {
   throw new Error(`$${name} must be given`);
 };
 
+// number of table (or table-chunk) imports to run in parallel
+exports.CONCURRENCY = 30;
+
 // tables that are allowed to migrate
 exports.ALLOWED_TABLES = [
   // 'Clients',

--- a/libraries/postgres/README.md
+++ b/libraries/postgres/README.md
@@ -21,14 +21,20 @@ const db = Database.setup({
   writeDbUrl: ..,
   readDbUrl: ..,
   serviceName: ...,
+  monitor: ...,
   statementTimeout: ..., // optional
+  poolSize: ..., // optional, default 5
 });
 ```
 
 The read and write URLs typically come from serivce configuration.
 The read URL is used for queries that only read data, and can operate on read-only server mirrors, while queries that will modify the content of the database use the write URL.
+The `monitor` is a taskcluster-lib-monitor instance, used to report database metrics.
 if `statementTimeout` is set, then it is treated as a timeout (in seconds) after which a statement will be aborted.
 This is typically used in web processes to abort statements running longer than 30s, after which time the HTTP client has likely given up.
+
+The `poolSize` parameter specifies the maximum number of Postgres clients in each pool of clients, with two pools (read and write) in use.
+DB function calls made when there are no clients available will be queued and wait until a client is avaliable.
 
 Once that is finished, the methods defined in the schema can be called on the `db.fns` object.
 For example, if the schema defines a `getWidgetsPerWorker` method:

--- a/libraries/postgres/src/Database.js
+++ b/libraries/postgres/src/Database.js
@@ -50,14 +50,19 @@ class Database {
   /**
    * Get a new Database instance
    */
-  static async setup({schema, readDbUrl, writeDbUrl, serviceName, monitor, statementTimeout}) {
+  static async setup({schema, readDbUrl, writeDbUrl, serviceName, monitor, statementTimeout, poolSize}) {
     assert(readDbUrl, 'readDbUrl is required');
     assert(writeDbUrl, 'writeDbUrl is required');
     assert(schema, 'schema is required');
     assert(serviceName, 'serviceName is required');
     assert(monitor !== undefined, 'monitor is required (but use `false` to disable)');
 
-    const db = new Database({urlsByMode: {[READ]: readDbUrl, [WRITE]: writeDbUrl}, monitor, statementTimeout});
+    const db = new Database({
+      urlsByMode: {[READ]: readDbUrl, [WRITE]: writeDbUrl},
+      monitor,
+      statementTimeout,
+      poolSize,
+    });
     db._createProcs({schema, serviceName});
 
     const dbVersion = await db.currentVersion();
@@ -444,13 +449,13 @@ class Database {
   /**
    * Private constructor (use Database.setup and Database.upgrade instead)
    */
-  constructor({urlsByMode, monitor, statementTimeout}) {
+  constructor({urlsByMode, monitor, statementTimeout, poolSize}) {
     assert(!statementTimeout || typeof statementTimeout === 'number' || typeof statementTimeout === 'boolean');
     const makePool = dbUrl => {
-      // use a max of 5 connections. For services running both a read and write
-      // pool, this is a maximum of 10 concurrent connections.  Other requests
-      // will be queued.
-      const pool = new Pool({connectionString: dbUrl, max: 5});
+      // default to a max of 5 connections. For services running both a read
+      // and write pool, this is a maximum of 10 concurrent connections.  Other
+      // requests will be queued.
+      const pool = new Pool({connectionString: dbUrl, max: poolSize || 5});
       // ignore errors from *idle* connections.  From the docs:
       //
       // > When a client is sitting idly in the pool it can still emit errors


### PR DESCRIPTION
This will get us partway to making this configurable on a per-deployment basis, too.