### PR TITLE
Run gofmt / go lint at the top level, like for JS

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -92,6 +92,9 @@ tasks:
         others:
         - name: lint
           command: yarn lint
+        - name: lint:go
+          image: taskcluster/node-and-go:node${node}-go${go.release}
+          command: yarn lint:go
         - name: test:meta
           command: "yarn test:meta | cat"
           # only do cleanup on pushes; no sense doing so on pull requests
@@ -168,29 +171,25 @@ tasks:
           install: >-
               cd internal
           command: >-
-              curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $GOPATH/bin v1.23.6 &&
-              golangci-lint run && go test -v -race ./...
+              go test -v -race ./...
         - name: taskcluster-client-go-${go.release}
           image: 'golang:${go.release}'
           install: >-
               cd clients/client-go
           command: >-
-              curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $GOPATH/bin v1.23.6 &&
-              golangci-lint run && go test -v -race ./...
+              go test -v -race ./...
         - name: taskcluster-client-shell-${go.release}
           image: 'golang:${go.release}'
           install: >-
               cd clients/client-shell
           command: >-
-              curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $GOPATH/bin v1.23.6 &&
-              golangci-lint run && go test -v -race ./...
+              go test -v -race ./...
         - name: tools-${go.release}
           image: 'golang:${go.release}'
           install: >-
               cd tools
           command: >-
-              curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $GOPATH/bin v1.23.6 &&
-              golangci-lint run && go test -v -race ./...
+              go test -v -race ./...
         - name: check for invalid go pseudo-versions
           # see https://github.com/taskcluster/taskcluster/issues/1492
           image: 'golang:${go.release}'

--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -190,13 +190,6 @@ tasks:
               cd tools
           command: >-
               go test -v -race ./...
-        - name: check for invalid go pseudo-versions
-          # see https://github.com/taskcluster/taskcluster/issues/1492
-          image: 'golang:${go.release}'
-          install: ":"
-          command: >-
-              (cd clients/client-go && go list -m all) &&
-              (cd clients/client-shell && go list -m all)
         - name: "yarn db:upgrade"
           image: taskcluster/node-and-postgres:node${node}-pg11
           command: >-

--- a/changelog/NCM67ernT4im7Oh-SEJeNg.md
+++ b/changelog/NCM67ernT4im7Oh-SEJeNg.md
@@ -1,0 +1,3 @@
+audience: general
+level: silent
+---

--- a/entrypoint
+++ b/entrypoint
@@ -59,6 +59,7 @@ worker-manager/expire-worker-pools) cd services/worker-manager && exec node src/
 worker-manager/expire-errors) cd services/worker-manager && exec node src/main.js expireErrors;;
 worker-manager/write-docs) cd services/worker-manager && exec node src/main.js writeDocs;;
 script/lint) shift; exec yarn run lint "${@}";;
+script/lint:go) shift; exec yarn run lint:go "${@}";;
 script/test) shift; exec yarn run test "${@}";;
 script/fetch-coverage) shift; exec yarn run fetch-coverage "${@}";;
 script/test:cleanup) shift; exec yarn run test:cleanup "${@}";;

--- a/infrastructure/docker-images/build-node-and-go.sh
+++ b/infrastructure/docker-images/build-node-and-go.sh
@@ -22,7 +22,8 @@ FROM node:${node_version}-stretch
 COPY --from=golang /usr/local/go /usr/local/go
 COPY --from=golang /go /go
 ENV GOPATH /go
-ENV PATH $GOPATH/bin:/usr/local/go/bin:$PATH
+ENV PATH \$GOPATH/bin:/usr/local/go/bin:\$PATH
+RUN curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b \$GOPATH/bin v1.23.6
 EOF
 
 docker build -t "taskcluster/node-and-go:node${node_version}-go${go_version}" ${tmpdir}

--- a/package.json
+++ b/package.json
@@ -185,6 +185,7 @@
   },
   "scripts": {
     "lint": "eslint --cache --ext js --ignore-pattern clients/client-web/build --ignore-pattern clients/client-py libraries services infrastructure clients test db",
+    "lint:go": "sh test/go-lint.sh",
     "test": "yarn workspaces run test",
     "fetch-coverage": "node test/fetch-coverage.js",
     "test:cleanup": "yarn workspace taskcluster-auth test:cleanup",

--- a/test/go-lint.sh
+++ b/test/go-lint.sh
@@ -1,0 +1,12 @@
+#! /bin/sh
+
+echo "Running gofmt.."
+unformatted_files=$(git ls-files | grep '\.go$' | xargs gofmt -l)
+if [ -n "${unformatted_files}" ]; then
+    echo 'Go files not formatted with gofmt:'
+    echo "${unformatted_files}"
+    exit 1;
+fi
+
+echo "Running golangci-lint.."
+golangci-lint run --build-tags simple


### PR DESCRIPTION
This makes it easy to see when tests pass but there are some lints to fix, without having to open up logs and search for issues.

This PR also removes the check added in #1492, which is no longer necessary.