### PR TITLE
More helpful doc for `task.extra.notify.matrixFormat`

### DIFF
--- a/ui/docs/reference/core/notify/usage.mdx
+++ b/ui/docs/reference/core/notify/usage.mdx
@@ -64,7 +64,7 @@ __task.extra.notify.matrixBody:__ This is a simple text message suitable to be r
 
 __task.extra.notify.matrixFormattedBody:__ This is a rich message suitable to be rendered by capable matrix clients. Matrix will fall back to `matrixBody` if not supported.
 
-__task.extra.notify.matrixFormat:__ The format of the formatted body. Read matrix documentation for `m.room.message msgtypes` to understand options
+__task.extra.notify.matrixFormat:__ The format for `formattedBody`. For instance, `org.matrix.custom.html`
 
 __task.extra.notify.email.content:__ This should evaluate to a markdown string and is the body of an email
 


### PR DESCRIPTION
Copied from the corresponding API schema docs in `services/notify/schemas/v1/matrix-request.yml`. The previous one was misleading since `matrixFormat` does not set `msgtype`

<!-- Did you remember to add a changelog snippet? See
     https://github.com/taskcluster/taskcluster/blob/master/dev-docs/best-practices/changelog.md

     If this is related to a Bugzilla bug, please begin your title with [Bug XXXXX]
     and update this link.  Otherwise, just remove it from your PR comment.  -->