### PR TITLE
Add opt-out for Matrix notifications being "notices" rather than messages

### DIFF
--- a/services/notify/schemas/v1/matrix-request.yml
+++ b/services/notify/schemas/v1/matrix-request.yml
@@ -21,6 +21,12 @@ properties:
     description: |
       Text that will be rendered by matrix clients that support the given
       format in that format. For instance, `<h1>Header Text</h1>`.
+  notice:
+    type: boolean
+    default: true
+    description: |
+      Send the notification as a notice (`msgtype: m.notice`)
+      instead of a normal message (`msgtype: m.text`). Defaults to true.
 additionalProperties: false
 required:
   - roomId

--- a/services/notify/src/handler.js
+++ b/services/notify/src/handler.js
@@ -115,12 +115,14 @@ class Handler {
           if (_.has(task, 'extra.notify.matrixFormattedBody')) {
             formattedBody = this.renderMessage(task.extra.notify.matrixFormattedBody, {task, status, taskId});
           }
+          let notice = _.get(task, 'extra.notify.matrixNotice');
           try {
             return await this.notifier.matrix({
               roomId,
               format,
               formattedBody,
               body,
+              notice,
             });
           } catch (err) {
             // This just means that we haven't been invited to the room yet

--- a/services/notify/src/matrix.js
+++ b/services/notify/src/matrix.js
@@ -25,8 +25,9 @@ class MatrixBot {
     await this._client.startClient();
   }
 
-  async sendNotice({roomId, format, formattedBody, body}) {
-    await this._client.sendEvent(roomId, 'm.room.message', {formatted_body: formattedBody, body, msgtype: 'm.notice', format}, '');
+  async sendMessage({roomId, format, formattedBody, body, notice}) {
+    let msgtype = notice ? 'm.notice' : 'm.text';
+    await this._client.sendEvent(roomId, 'm.room.message', {formatted_body: formattedBody, body, msgtype, format}, '');
   }
 }
 

--- a/services/notify/src/notifier.js
+++ b/services/notify/src/notifier.js
@@ -142,7 +142,7 @@ class Notifier {
     return res;
   }
 
-  async matrix({roomId, format, formattedBody, body}) {
+  async matrix({roomId, format, formattedBody, body, notice}) {
     if (this.isDuplicate(roomId, format, formattedBody, body)) {
       debug('Duplicate matrix send detected. Not attempting resend.');
       return;
@@ -153,7 +153,7 @@ class Notifier {
       return;
     }
 
-    await this._matrix.sendNotice({roomId, format, formattedBody, body});
+    await this._matrix.sendMessage({roomId, format, formattedBody, body, notice});
     this.markSent(roomId, format, formattedBody, body);
     this.monitor.log.matrix({dest: roomId});
   }

--- a/services/notify/test/handler_test.js
+++ b/services/notify/test/handler_test.js
@@ -165,7 +165,7 @@ helper.secrets.mockSuite(testing.suiteName(), ['db', 'azure', 'aws'], function(m
   test('matrix', async () => {
     const route = 'test-notify.matrix-room.!gBxblkbeeBSadzOniu:mozilla.org.on-any';
     const task = makeTask([route]);
-    task.extra = {notify: {matrixFormat: 'matrix.foo', matrixBody: '${taskId}', matrixFormattedBody: '<h1>${taskId}</h1>'}};
+    task.extra = {notify: {matrixFormat: 'matrix.foo', matrixBody: '${taskId}', matrixFormattedBody: '<h1>${taskId}</h1>', matrixNotice: false}};
     helper.queue.addTask(baseStatus.taskId, task);
     await helper.fakePulseMessage({
       payload: {
@@ -180,6 +180,7 @@ helper.secrets.mockSuite(testing.suiteName(), ['db', 'azure', 'aws'], function(m
     assert.equal(helper.matrixClient.sendEvent.args[0][2].format, 'matrix.foo');
     assert.equal(helper.matrixClient.sendEvent.args[0][2].body, 'DKPZPsvvQEiw67Pb3rkdNg');
     assert.equal(helper.matrixClient.sendEvent.args[0][2].formatted_body, '<h1>DKPZPsvvQEiw67Pb3rkdNg</h1>');
+    assert.equal(helper.matrixClient.sendEvent.args[0][2].msgtype, 'm.text');
     assert(monitorManager.messages.find(m => m.Type === 'matrix'));
     assert(monitorManager.messages.find(m => m.Type === 'matrix-forbidden') === undefined);
   });

--- a/ui/docs/reference/core/notify/usage.mdx
+++ b/ui/docs/reference/core/notify/usage.mdx
@@ -66,6 +66,8 @@ __task.extra.notify.matrixFormattedBody:__ This is a rich message suitable to be
 
 __task.extra.notify.matrixFormat:__ The format of the formatted body. Read matrix documentation for `m.room.message msgtypes` to understand options
 
+__task.extra.notify.matrixNotice:__ Send the notification as a notice (`msgtype: m.notice`) instead of a normal message (`msgtype: m.text`). Defaults to true.
+
 __task.extra.notify.email.content:__ This should evaluate to a markdown string and is the body of an email
 
 __task.extra.notify.email.subject:__ This should evaluate to a normal string and is the subject of an email


### PR DESCRIPTION
Riot appears not to trigger a desktop notification when a notice contains my username and a "watched keyword". This is configurable in Riot’s settings, but sending a normal message instead would make it easier for people to be notified of failures they are interested in.

This is a boolean because Matrix’s other message types do not seem relevant here: emote, image, file, audio, location, video.

This commit is a first pass at adding this, however it is done entirely "blind" since my laptop does not have the required Node version, so I can’t easily run tests or regenerate generated files. I’d appreciate someone taking over.