### PR TITLE
Make mocked db work again

### DIFF
--- a/changelog/QsU9-aBbSFaXRjTKMYv4iA.md
+++ b/changelog/QsU9-aBbSFaXRjTKMYv4iA.md
@@ -1,0 +1,3 @@
+audience: developers
+level: silent
+---

--- a/services/auth/test/helper.js
+++ b/services/auth/test/helper.js
@@ -426,11 +426,10 @@ exports.withGcp = (mock, skipping) => {
 
 exports.resetTables = (mock, skipping) => {
   setup('reset tables', async function() {
-    const sec = exports.secrets.get('db');
-
     if (mock) {
       exports.db['auth'].reset();
-    } {
+    } else {
+      const sec = exports.secrets.get('db');
       await resetTable({ testDbUrl: sec.testDbUrl, tableName: 'clients_entities' });
       await resetTable({ testDbUrl: sec.testDbUrl, tableName: 'roles_entities' });
     }

--- a/services/github/test/helper.js
+++ b/services/github/test/helper.js
@@ -136,11 +136,10 @@ exports.withServer = (mock, skipping) => {
 
 exports.resetTables = (mock, skipping) => {
   setup('reset tables', async function() {
-    const sec = exports.secrets.get('db');
-
     if (mock) {
       exports.db['github'].reset();
-    } {
+    } else {
+      const sec = exports.secrets.get('db');
       await resetTable({ testDbUrl: sec.testDbUrl, tableName: 'taskcluster_github_builds_entities' });
       await resetTable({ testDbUrl: sec.testDbUrl, tableName: 'taskcluster_integration_owners_entities' });
       await resetTable({ testDbUrl: sec.testDbUrl, tableName: 'taskcluster_checks_to_tasks_entities' });

--- a/services/hooks/test/helper.js
+++ b/services/hooks/test/helper.js
@@ -120,11 +120,10 @@ helper.withServer = (mock, skipping) => {
 
 exports.resetTables = (mock, skipping) => {
   setup('reset tables', async function() {
-    const sec = helper.secrets.get('db');
-
     if (mock) {
       helper.db.hooks.reset();
-    } {
+    } else {
+      const sec = helper.secrets.get('db');
       await resetTable({ testDbUrl: sec.testDbUrl, tableName: 'hooks_entities' });
       await resetTable({ testDbUrl: sec.testDbUrl, tableName: 'queues_entities' });
       await resetTable({ testDbUrl: sec.testDbUrl, tableName: 'last_fire_3_entities' });

--- a/services/index/test/helper.js
+++ b/services/index/test/helper.js
@@ -156,11 +156,10 @@ const stubbedQueue = () => {
 
 exports.resetTables = (mock, skipping) => {
   setup('reset tables', async function() {
-    const sec = exports.secrets.get('db');
-
     if (mock) {
       exports.db['fakeindex'].reset();
-    } {
+    } else {
+      const sec = exports.secrets.get('db');
       await resetTable({ testDbUrl: sec.testDbUrl, tableName: 'indexed_tasks_entities' });
       await resetTable({ testDbUrl: sec.testDbUrl, tableName: 'namespaces_entities' });
     }

--- a/services/notify/test/helper.js
+++ b/services/notify/test/helper.js
@@ -324,11 +324,10 @@ exports.withDb = (mock, skipping) => {
 
 exports.resetTables = (mock, skipping) => {
   setup('reset tables', async function() {
-    const sec = exports.secrets.get('db');
-
     if (mock) {
       exports.db['notify'].reset();
-    } {
+    } else {
+      const sec = exports.secrets.get('db');
       await resetTable({ testDbUrl: sec.testDbUrl, tableName: 'denylisted_notification_entities' });
       await resetTable({ testDbUrl: sec.testDbUrl, tableName: 'widgets' });
     }

--- a/services/queue/test/helper.js
+++ b/services/queue/test/helper.js
@@ -302,11 +302,10 @@ exports.makeWorkerType = () => `test-${slugid.v4().replace(/[_-]/g, '').toLowerC
 
 exports.resetTables = (mock, skipping) => {
   setup('reset tables', async function() {
-    const sec = exports.secrets.get('db');
-
     if (mock) {
       exports.db['queue'].reset();
-    } {
+    } else {
+      const sec = exports.secrets.get('db');
       await resetTable({ testDbUrl: sec.testDbUrl, tableName: 'queue_tasks_entities' });
       await resetTable({ testDbUrl: sec.testDbUrl, tableName: 'queue_artifacts_entities' });
       await resetTable({ testDbUrl: sec.testDbUrl, tableName: 'queue_task_groups_entities' });

--- a/services/web-server/test/graphql/artifacts_graphql_test.js
+++ b/services/web-server/test/graphql/artifacts_graphql_test.js
@@ -7,7 +7,7 @@ const getArtifacts = require('../fixtures/artifacts.graphql');
 const getLatestArtifacts = require('../fixtures/latestArtifacts.graphql');
 const artifactsCreated = require('../fixtures/artifactsCreated.graphql');
 
-helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
+helper.secrets.mockSuite(testing.suiteName(), ['db'], function(mock, skipping) {
   helper.withDb(mock, skipping);
   helper.withEntities(mock, skipping);
   helper.withClients(mock, skipping);

--- a/services/web-server/test/graphql/roles_test.js
+++ b/services/web-server/test/graphql/roles_test.js
@@ -10,7 +10,7 @@ const deleteRoleMutation = require('../fixtures/deleteRole.graphql');
 const listRoleIdsQuery = require('../fixtures/listRoleIds.graphql');
 const updateRoleMutation = require('../fixtures/updateRole.graphql');
 
-helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
+helper.secrets.mockSuite(testing.suiteName(), ['db'], function(mock, skipping) {
   helper.withDb(mock, skipping);
   helper.withEntities(mock, skipping);
   helper.withClients(mock, skipping);

--- a/services/web-server/test/graphql/tasks_graphql_test.js
+++ b/services/web-server/test/graphql/tasks_graphql_test.js
@@ -7,7 +7,7 @@ const taskQuery = require('../fixtures/task.graphql');
 const createTaskQuery = require('../fixtures/createTask.graphql');
 const subscribeTasks = require('../fixtures/tasksSubscriptions.graphql');
 
-helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
+helper.secrets.mockSuite(testing.suiteName(), ['db'], function(mock, skipping) {
   helper.withDb(mock, skipping);
   helper.withEntities(mock, skipping);
   helper.withClients(mock, skipping);

--- a/services/web-server/test/graphql/workermanager_test.js
+++ b/services/web-server/test/graphql/workermanager_test.js
@@ -4,7 +4,7 @@ const testing = require('taskcluster-lib-testing');
 const helper = require('../helper');
 const deleteWorkerPoolMutation = require('../fixtures/deleteWorkerPool.graphql');
 
-helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
+helper.secrets.mockSuite(testing.suiteName(), ['db'], function(mock, skipping) {
   helper.withDb(mock, skipping);
   helper.withEntities(mock, skipping);
   helper.withClients(mock, skipping);

--- a/services/web-server/test/helper.js
+++ b/services/web-server/test/helper.js
@@ -488,11 +488,10 @@ const stubbedClients = () => {
 
 exports.resetTables = (mock, skipping) => {
   setup('reset tables', async function() {
-    const sec = exports.secrets.get('db');
-
     if (mock) {
       exports.db['web_server'].reset();
-    } {
+    } else {
+      const sec = exports.secrets.get('db');
       await resetTable({ testDbUrl: sec.testDbUrl, tableName: 'authorization_codes_table_entities' });
       await resetTable({ testDbUrl: sec.testDbUrl, tableName: 'access_token_table_entities' });
       await resetTable({ testDbUrl: sec.testDbUrl, tableName: 'session_storage_table_entities' });

--- a/services/web-server/test/loaders/roles_loader_test.js
+++ b/services/web-server/test/loaders/roles_loader_test.js
@@ -10,7 +10,7 @@ const helper = require('../helper');
 const createRoleMutation = require('../fixtures/createRole.graphql');
 const loader = require('../../src/loaders/roles');
 
-helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
+helper.secrets.mockSuite(testing.suiteName(), ['db'], function(mock, skipping) {
   helper.withDb(mock, skipping);
   helper.withEntities(mock, skipping);
   helper.withClients(mock, skipping);

--- a/services/web-server/test/loaders/tasks_loader_test.js
+++ b/services/web-server/test/loaders/tasks_loader_test.js
@@ -10,7 +10,7 @@ const helper = require('../helper');
 const createTaskQuery = require('../fixtures/createTask.graphql');
 const loader = require('../../src/loaders/tasks');
 
-helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
+helper.secrets.mockSuite(testing.suiteName(), ['db'], function(mock, skipping) {
   helper.withDb(mock, skipping);
   helper.withEntities(mock, skipping);
   helper.withClients(mock, skipping);

--- a/services/worker-manager/test/helper.js
+++ b/services/worker-manager/test/helper.js
@@ -264,11 +264,10 @@ const stubbedNotify = () => {
 
 exports.resetTables = (mock, skipping) => {
   setup('reset tables', async function() {
-    const sec = exports.secrets.get('db');
-
     if (mock) {
       exports.db['worker_manager'].reset();
-    } {
+    } else {
+      const sec = exports.secrets.get('db');
       await resetTable({ testDbUrl: sec.testDbUrl, tableName: 'wmworkers_entities' });
       await resetTable({ testDbUrl: sec.testDbUrl, tableName: 'wmworker_pools_entities' });
       await resetTable({ testDbUrl: sec.testDbUrl, tableName: 'wmworker_pool_errors_entities' });


### PR DESCRIPTION
This makes the tests pass locally for all services afaict. However, I'm not 100% sure that what I've updated the `resetTables` functions to be is semantically correct so please check there. Otherwise it was just adding some `db` to nested test files.