### PR TITLE
[UI] Deep Link search in /secrets

### DIFF
--- a/ui/src/views/Secrets/ViewSecrets/index.jsx
+++ b/ui/src/views/Secrets/ViewSecrets/index.jsx
@@ -33,10 +33,6 @@ import secretsQuery from './secrets.graphql';
   },
 }))
 export default class ViewSecrets extends Component {
-  state = {
-    secretSearch: '',
-  };
-
   handleSecretSearchSubmit = async secretSearch => {
     const {
       data: { refetch },
@@ -51,9 +47,14 @@ export default class ViewSecrets extends Component {
         : null,
     });
 
-    this.props.history.push(
-      `/secrets${secretSearch ? `?search=${secretSearch}` : ''}`
-    );
+    const query = qs.parse(window.location.search.slice(1));
+
+    this.props.history.push({
+      search: qs.stringify({
+        ...query,
+        search: secretSearch,
+      }),
+    });
   };
 
   handleCreate = () => {
@@ -64,6 +65,8 @@ export default class ViewSecrets extends Component {
     const {
       data: { fetchMore },
     } = this.props;
+    const query = qs.parse(this.props.location.search.slice(1));
+    const secretSearch = query.search;
 
     return fetchMore({
       query: secretsQuery,
@@ -73,10 +76,10 @@ export default class ViewSecrets extends Component {
           cursor,
           previousCursor,
         },
-        filter: this.state.secretSearch
+        filter: secretSearch
           ? {
               name: {
-                $regex: escapeStringRegexp(this.state.secretSearch),
+                $regex: escapeStringRegexp(secretSearch),
                 $options: 'i',
               },
             }
@@ -102,7 +105,8 @@ export default class ViewSecrets extends Component {
       description,
       data: { loading, error, secrets },
     } = this.props;
-    const { searchTerm } = this.state;
+    const query = qs.parse(this.props.location.search.slice(1));
+    const secretSearch = query.search;
 
     return (
       <Dashboard
@@ -111,6 +115,7 @@ export default class ViewSecrets extends Component {
         search={
           <Search
             disabled={loading}
+            defaultValue={secretSearch}
             onSubmit={this.handleSecretSearchSubmit}
             placeholder="Secret contains"
           />

--- a/ui/src/views/Secrets/ViewSecrets/index.jsx
+++ b/ui/src/views/Secrets/ViewSecrets/index.jsx
@@ -18,14 +18,21 @@ import secretsQuery from './secrets.graphql';
 
 @hot(module)
 @graphql(secretsQuery, {
-  options: () => ({
-    fetchPolicy: 'network-only',
-    variables: {
-      secretsConnection: {
-        limit: VIEW_SECRETS_PAGE_SIZE,
+  options: props => {
+    const { search } = qs.parse(props.location.search.slice(1));
+
+    return {
+      fetchPolicy: 'network-only',
+      variables: {
+        secretsConnection: {
+          limit: VIEW_SECRETS_PAGE_SIZE,
+        },
+        filter: search
+          ? { name: { $regex: escapeStringRegexp(search), $options: 'i' } }
+          : null,
       },
-    },
-  }),
+    };
+  },
 })
 @withStyles(theme => ({
   plusIconSpan: {
@@ -125,7 +132,7 @@ export default class ViewSecrets extends Component {
           <ErrorPanel fixed error={error} />
           {secrets && (
             <SecretsTable
-              searchTerm={searchTerm}
+              searchTerm={secretSearch}
               onPageChange={this.handlePageChange}
               secretsConnection={secrets}
             />

--- a/ui/src/views/Secrets/ViewSecrets/index.jsx
+++ b/ui/src/views/Secrets/ViewSecrets/index.jsx
@@ -6,6 +6,7 @@ import Spinner from '@mozilla-frontend-infra/components/Spinner';
 import { withStyles } from '@material-ui/core/styles';
 import PlusIcon from 'mdi-react/PlusIcon';
 import escapeStringRegexp from 'escape-string-regexp';
+import qs from 'qs';
 import Dashboard from '../../../components/Dashboard';
 import Search from '../../../components/Search';
 import SecretsTable from '../../../components/SecretsTable';
@@ -49,7 +50,10 @@ export default class ViewSecrets extends Component {
         ? { name: { $regex: escapeStringRegexp(secretSearch), $options: 'i' } }
         : null,
     });
-    this.setState({ secretSearch });
+
+    this.props.history.push(
+      `/secrets${secretSearch ? `?search=${secretSearch}` : ''}`
+    );
   };
 
   handleCreate = () => {


### PR DESCRIPTION
<!-- Did you remember to add a changelog snippet? See
     https://github.com/taskcluster/taskcluster/blob/master/dev-docs/best-practices/changelog.md

     If this is related to a Bugzilla bug, please begin your title with [Bug XXXXX]
     and update this link.  Otherwise, just remove it from your PR comment.  -->

<!-- If this is related to a GitHub Bug/Issue, Please write Issue Number after # in the next line. Otherwise, just remove it from your PR comment. -->

@helfi92 I noticed the intended behavior for `/secrets` already exists in `/hooks`, and can be seen here (as an example) - https://firefox-ci-tc.services.mozilla.com/hooks?search=project-

So I figured it might be worth a try to replicate the functionality already present in `ListHooks/index.jsx`. 

This change uses the `qs` package to parse out the search term from the query string, and pushes it onto `history`. Thus, once you do the following steps -
1. Visit `/secrets` and search for an item, example `project/`
2. Click on a secret
3. Go back

The browser URL now contains the search term you searched for -

![Screenshot 2020-04-13 23 34 30](https://user-images.githubusercontent.com/11348778/79203699-64d97600-7e09-11ea-9256-cac1e6aae77c.png)

whereas it is currently just `/secrets` after you go back -

![Screenshot 2020-04-13 22 08 03](https://user-images.githubusercontent.com/11348778/79203773-83d80800-7e09-11ea-8b87-82b9f71cdc90.png)

However, the page still lists all the available results at `/secrets`. 

I wasn't quite sure about why this behavior at `/secrets` is different from `/hooks`, so I figured it would be nice to get your thoughts on this, if possible, before I investigate further. I wonder if the `refetch()` in the Submit Handler from [here](https://github.com/taskcluster/taskcluster/blob/master/ui/src/views/Secrets/ViewSecrets/index.jsx#L46-L53) makes any difference. However, the [docs](https://www.apollographql.com/docs/react/data/queries/#refetching) from Apollo GraphQL mention this just refreshes the query results in response to a user action, and as far as I can see, the `filter` still lists the correct search string -

Would be really great if I could some thoughts/tips about the next steps!

![Screenshot 2020-04-13 23 33 02](https://user-images.githubusercontent.com/11348778/79204796-1a58f900-7e0b-11ea-8c40-13231fee7db5.png)

Github Bug/Issue: Fixes #2123 