### PR TITLE
[Bug 1630113] Support multiple matrix msgtypes

### DIFF
--- a/changelog/bug-1630113.md
+++ b/changelog/bug-1630113.md
@@ -1,0 +1,6 @@
+audience: users
+level: minor
+reference: bug 1630113
+---
+Matrix integration now supports `m.text`, `m.emote`, and `m.notice` msgtypes. The default is
+`m.notice` which was the only value supported previously.

--- a/clients/client-go/tcnotify/types.go
+++ b/clients/client-go/tcnotify/types.go
@@ -137,7 +137,9 @@ type (
 		Template string `json:"template,omitempty"`
 	}
 
-	// Request to send a Matrix notice.
+	// Request to send a Matrix notice. Many of these fields are better understood by
+	// checking the matrix spec itself. The precise definitions of these fields is
+	// beyond the scope of this document.
 	SendMatrixNoticeRequest struct {
 
 		// Unformatted text that will be displayed in the room if you do not
@@ -150,6 +152,17 @@ type (
 		// Text that will be rendered by matrix clients that support the given
 		// format in that format. For instance, `<h1>Header Text</h1>`.
 		FormattedBody string `json:"formattedBody,omitempty"`
+
+		// Which of the `m.room.message` msgtypes to use. At the moment only the
+		// types that take `body`/`format`/`formattedBody` are supported.
+		//
+		// Possible values:
+		//   * "m.notice"
+		//   * "m.text"
+		//   * "m.emote"
+		//
+		// Default:    "m.notice"
+		Msgtype string `json:"msgtype,omitempty"`
 
 		// The fully qualified room name, such as `!whDRjjSmICCgrhFHsQ:mozilla.org`
 		// If you are using riot, you can find this under the advanced settings for a room.

--- a/generated/references.json
+++ b/generated/references.json
@@ -3959,7 +3959,7 @@
       "$id": "/schemas/notify/v1/matrix-request.json#",
       "$schema": "/schemas/common/metaschema.json#",
       "additionalProperties": false,
-      "description": "Request to send a Matrix notice.",
+      "description": "Request to send a Matrix notice. Many of these fields are better understood by\nchecking the matrix spec itself. The precise definitions of these fields is\nbeyond the scope of this document.\n",
       "properties": {
         "body": {
           "description": "Unformatted text that will be displayed in the room if you do not\nspecify `formattedBody` or if a user's client can not render the format.\n",
@@ -3971,6 +3971,16 @@
         },
         "formattedBody": {
           "description": "Text that will be rendered by matrix clients that support the given\nformat in that format. For instance, `<h1>Header Text</h1>`.\n",
+          "type": "string"
+        },
+        "msgtype": {
+          "default": "m.notice",
+          "description": "Which of the `m.room.message` msgtypes to use. At the moment only the\ntypes that take `body`/`format`/`formattedBody` are supported.\n",
+          "enum": [
+            "m.notice",
+            "m.text",
+            "m.emote"
+          ],
           "type": "string"
         },
         "roomId": {

--- a/services/notify/schemas/v1/matrix-request.yml
+++ b/services/notify/schemas/v1/matrix-request.yml
@@ -21,6 +21,12 @@ properties:
     description: |
       Text that will be rendered by matrix clients that support the given
       format in that format. For instance, `<h1>Header Text</h1>`.
+  notice:
+    type: boolean
+    default: true
+    description: |
+      Send the notification as a notice (`msgtype: m.notice`)
+      instead of a normal message (`msgtype: m.text`). Defaults to true.
 additionalProperties: false
 required:
   - roomId

--- a/services/notify/schemas/v1/matrix-request.yml
+++ b/services/notify/schemas/v1/matrix-request.yml
@@ -1,6 +1,9 @@
 $schema: "/schemas/common/metaschema.json#"
 title: "Send Matrix Notice Request"
-description: Request to send a Matrix notice.
+description: |
+  Request to send a Matrix notice. Many of these fields are better understood by
+  checking the matrix spec itself. The precise definitions of these fields is
+  beyond the scope of this document.
 type: object
 properties:
   roomId:
@@ -21,12 +24,16 @@ properties:
     description: |
       Text that will be rendered by matrix clients that support the given
       format in that format. For instance, `<h1>Header Text</h1>`.
-  notice:
-    type: boolean
-    default: true
+  msgtype:
+    type: string
+    enum:
+      - m.notice
+      - m.text
+      - m.emote
+    default: m.notice
     description: |
-      Send the notification as a notice (`msgtype: m.notice`)
-      instead of a normal message (`msgtype: m.text`). Defaults to true.
+      Which of the `m.room.message` msgtypes to use. At the moment only the
+      types that take `body`/`format`/`formattedBody` are supported.
 additionalProperties: false
 required:
   - roomId

--- a/services/notify/src/handler.js
+++ b/services/notify/src/handler.js
@@ -115,12 +115,14 @@ class Handler {
           if (_.has(task, 'extra.notify.matrixFormattedBody')) {
             formattedBody = this.renderMessage(task.extra.notify.matrixFormattedBody, {task, status, taskId});
           }
+          let notice = _.get(task, 'extra.notify.matrixNotice');
           try {
             return await this.notifier.matrix({
               roomId,
               format,
               formattedBody,
               body,
+              notice,
             });
           } catch (err) {
             // This just means that we haven't been invited to the room yet

--- a/services/notify/src/handler.js
+++ b/services/notify/src/handler.js
@@ -107,6 +107,7 @@ class Handler {
         case 'matrix-room': {
           const roomId = route.slice(2, route.length - 1).join('.');
           let body = `'${task.metadata.name}' resolved as '${status.state}': ${href}`;
+          let msgtype = _.get(task, 'extra.notify.matrixMsgtype') || 'm.notice';
           let formattedBody = undefined;
           let format = _.get(task, 'extra.notify.matrixFormat');
           if (_.has(task, 'extra.notify.matrixBody')) {
@@ -115,14 +116,13 @@ class Handler {
           if (_.has(task, 'extra.notify.matrixFormattedBody')) {
             formattedBody = this.renderMessage(task.extra.notify.matrixFormattedBody, {task, status, taskId});
           }
-          let notice = _.get(task, 'extra.notify.matrixNotice');
           try {
             return await this.notifier.matrix({
               roomId,
               format,
               formattedBody,
               body,
-              notice,
+              msgtype,
             });
           } catch (err) {
             // This just means that we haven't been invited to the room yet

--- a/services/notify/src/matrix.js
+++ b/services/notify/src/matrix.js
@@ -25,8 +25,7 @@ class MatrixBot {
     await this._client.startClient();
   }
 
-  async sendMessage({roomId, format, formattedBody, body, notice}) {
-    let msgtype = notice ? 'm.notice' : 'm.text';
+  async sendMessage({roomId, format, formattedBody, body, notice, msgtype}) {
     await this._client.sendEvent(roomId, 'm.room.message', {formatted_body: formattedBody, body, msgtype, format}, '');
   }
 }

--- a/services/notify/src/matrix.js
+++ b/services/notify/src/matrix.js
@@ -25,8 +25,9 @@ class MatrixBot {
     await this._client.startClient();
   }
 
-  async sendNotice({roomId, format, formattedBody, body}) {
-    await this._client.sendEvent(roomId, 'm.room.message', {formatted_body: formattedBody, body, msgtype: 'm.notice', format}, '');
+  async sendMessage({roomId, format, formattedBody, body, notice}) {
+    let msgtype = notice ? 'm.notice' : 'm.text';
+    await this._client.sendEvent(roomId, 'm.room.message', {formatted_body: formattedBody, body, msgtype, format}, '');
   }
 }
 

--- a/services/notify/src/notifier.js
+++ b/services/notify/src/notifier.js
@@ -142,8 +142,8 @@ class Notifier {
     return res;
   }
 
-  async matrix({roomId, format, formattedBody, body, notice}) {
-    if (this.isDuplicate(roomId, format, formattedBody, body)) {
+  async matrix({roomId, format, formattedBody, body, notice, msgtype}) {
+    if (this.isDuplicate(roomId, format, formattedBody, body, msgtype)) {
       debug('Duplicate matrix send detected. Not attempting resend.');
       return;
     }
@@ -153,8 +153,8 @@ class Notifier {
       return;
     }
 
-    await this._matrix.sendMessage({roomId, format, formattedBody, body, notice});
-    this.markSent(roomId, format, formattedBody, body);
+    await this._matrix.sendMessage({roomId, format, formattedBody, body, notice, msgtype});
+    this.markSent(roomId, format, formattedBody, body, msgtype);
     this.monitor.log.matrix({dest: roomId});
   }
 }

--- a/services/notify/src/notifier.js
+++ b/services/notify/src/notifier.js
@@ -142,7 +142,7 @@ class Notifier {
     return res;
   }
 
-  async matrix({roomId, format, formattedBody, body}) {
+  async matrix({roomId, format, formattedBody, body, notice}) {
     if (this.isDuplicate(roomId, format, formattedBody, body)) {
       debug('Duplicate matrix send detected. Not attempting resend.');
       return;
@@ -153,7 +153,7 @@ class Notifier {
       return;
     }
 
-    await this._matrix.sendNotice({roomId, format, formattedBody, body});
+    await this._matrix.sendMessage({roomId, format, formattedBody, body, notice});
     this.markSent(roomId, format, formattedBody, body);
     this.monitor.log.matrix({dest: roomId});
   }

--- a/services/notify/test/api_test.js
+++ b/services/notify/test/api_test.js
@@ -190,9 +190,21 @@ helper.secrets.mockSuite(testing.suiteName(), ['db', 'aws'], function(mock, skip
   });
 
   test('matrix', async function() {
+    await helper.apiClient.matrix({body: 'Does this work?', roomId: '!foobar:baz.com', msgtype: 'm.text'});
+    assert.equal(helper.matrixClient.sendEvent.callCount, 1);
+    assert.equal(helper.matrixClient.sendEvent.args[0][0], '!foobar:baz.com');
+    assert.equal(helper.matrixClient.sendEvent.args[0][2].body, 'Does this work?');
+    assert.equal(helper.matrixClient.sendEvent.args[0][2].msgtype, 'm.text');
+    assert(monitorManager.messages.find(m => m.Type === 'matrix'));
+    assert(monitorManager.messages.find(m => m.Type === 'matrix-forbidden') === undefined);
+  });
+
+  test('matrix (default msgtype)', async function() {
     await helper.apiClient.matrix({body: 'Does this work?', roomId: '!foobar:baz.com'});
     assert.equal(helper.matrixClient.sendEvent.callCount, 1);
     assert.equal(helper.matrixClient.sendEvent.args[0][0], '!foobar:baz.com');
+    assert.equal(helper.matrixClient.sendEvent.args[0][2].body, 'Does this work?');
+    assert.equal(helper.matrixClient.sendEvent.args[0][2].msgtype, 'm.notice');
     assert(monitorManager.messages.find(m => m.Type === 'matrix'));
     assert(monitorManager.messages.find(m => m.Type === 'matrix-forbidden') === undefined);
   });

--- a/services/notify/test/handler_test.js
+++ b/services/notify/test/handler_test.js
@@ -165,7 +165,7 @@ helper.secrets.mockSuite(testing.suiteName(), ['db', 'aws'], function(mock, skip
   test('matrix', async () => {
     const route = 'test-notify.matrix-room.!gBxblkbeeBSadzOniu:mozilla.org.on-any';
     const task = makeTask([route]);
-    task.extra = {notify: {matrixFormat: 'matrix.foo', matrixBody: '${taskId}', matrixFormattedBody: '<h1>${taskId}</h1>', matrixNotice: false}};
+    task.extra = {notify: {matrixFormat: 'matrix.foo', matrixBody: '${taskId}', matrixFormattedBody: '<h1>${taskId}</h1>', matrixMsgtype: 'm.text'}};
     helper.queue.addTask(baseStatus.taskId, task);
     await helper.fakePulseMessage({
       payload: {
@@ -181,6 +181,29 @@ helper.secrets.mockSuite(testing.suiteName(), ['db', 'aws'], function(mock, skip
     assert.equal(helper.matrixClient.sendEvent.args[0][2].body, 'DKPZPsvvQEiw67Pb3rkdNg');
     assert.equal(helper.matrixClient.sendEvent.args[0][2].formatted_body, '<h1>DKPZPsvvQEiw67Pb3rkdNg</h1>');
     assert.equal(helper.matrixClient.sendEvent.args[0][2].msgtype, 'm.text');
+    assert(monitorManager.messages.find(m => m.Type === 'matrix'));
+    assert(monitorManager.messages.find(m => m.Type === 'matrix-forbidden') === undefined);
+  });
+
+  test('matrix (default notice)', async () => {
+    const route = 'test-notify.matrix-room.!gBxblkbeeBSadzOniu:mozilla.org.on-any';
+    const task = makeTask([route]);
+    task.extra = {notify: {matrixFormat: 'matrix.foo', matrixBody: '${taskId}', matrixFormattedBody: '<h1>${taskId}</h1>'}};
+    helper.queue.addTask(baseStatus.taskId, task);
+    await helper.fakePulseMessage({
+      payload: {
+        status: baseStatus,
+      },
+      exchange: 'exchange/taskcluster-queue/v1/task-completed',
+      routingKey: 'doesnt-matter',
+      routes: [route],
+    });
+    assert.equal(helper.matrixClient.sendEvent.callCount, 1);
+    assert.equal(helper.matrixClient.sendEvent.args[0][0], '!gBxblkbeeBSadzOniu:mozilla.org');
+    assert.equal(helper.matrixClient.sendEvent.args[0][2].format, 'matrix.foo');
+    assert.equal(helper.matrixClient.sendEvent.args[0][2].body, 'DKPZPsvvQEiw67Pb3rkdNg');
+    assert.equal(helper.matrixClient.sendEvent.args[0][2].formatted_body, '<h1>DKPZPsvvQEiw67Pb3rkdNg</h1>');
+    assert.equal(helper.matrixClient.sendEvent.args[0][2].msgtype, 'm.notice');
     assert(monitorManager.messages.find(m => m.Type === 'matrix'));
     assert(monitorManager.messages.find(m => m.Type === 'matrix-forbidden') === undefined);
   });

--- a/services/notify/test/handler_test.js
+++ b/services/notify/test/handler_test.js
@@ -165,7 +165,7 @@ helper.secrets.mockSuite(testing.suiteName(), ['db', 'aws'], function(mock, skip
   test('matrix', async () => {
     const route = 'test-notify.matrix-room.!gBxblkbeeBSadzOniu:mozilla.org.on-any';
     const task = makeTask([route]);
-    task.extra = {notify: {matrixFormat: 'matrix.foo', matrixBody: '${taskId}', matrixFormattedBody: '<h1>${taskId}</h1>'}};
+    task.extra = {notify: {matrixFormat: 'matrix.foo', matrixBody: '${taskId}', matrixFormattedBody: '<h1>${taskId}</h1>', matrixNotice: false}};
     helper.queue.addTask(baseStatus.taskId, task);
     await helper.fakePulseMessage({
       payload: {
@@ -180,6 +180,7 @@ helper.secrets.mockSuite(testing.suiteName(), ['db', 'aws'], function(mock, skip
     assert.equal(helper.matrixClient.sendEvent.args[0][2].format, 'matrix.foo');
     assert.equal(helper.matrixClient.sendEvent.args[0][2].body, 'DKPZPsvvQEiw67Pb3rkdNg');
     assert.equal(helper.matrixClient.sendEvent.args[0][2].formatted_body, '<h1>DKPZPsvvQEiw67Pb3rkdNg</h1>');
+    assert.equal(helper.matrixClient.sendEvent.args[0][2].msgtype, 'm.text');
     assert(monitorManager.messages.find(m => m.Type === 'matrix'));
     assert(monitorManager.messages.find(m => m.Type === 'matrix-forbidden') === undefined);
   });

--- a/ui/docs/reference/core/notify/usage.mdx
+++ b/ui/docs/reference/core/notify/usage.mdx
@@ -54,6 +54,7 @@ In irc, matrix, and email you can set custom messages by adding fields to your t
 given a context of the [task definition](/docs/reference/platform/queue/api#get-task-definition)
 and the `status` section of [task status](/docs/reference/platform/queue/references/events#message-payload-4).
 The task definition is in the context under the key `task` and the status is in the context under the key `status`. `taskId` is also provided.
+The matrix fields are defined in detail in the matrix specification.
 The fields you add to your task definition are all in the `task.extra` section under a key `notify`. They are as follows:
 
 __task.extra.notify.ircUserMessage:__ This should evaluate to a string and is the message sent to a user in irc if a `notify.irc-user` event occurs
@@ -66,7 +67,7 @@ __task.extra.notify.matrixFormattedBody:__ This is a rich message suitable to be
 
 __task.extra.notify.matrixFormat:__ The format for `formattedBody`. For instance, `org.matrix.custom.html`
 
-__task.extra.notify.matrixNotice:__ Send the notification as a notice (`msgtype: m.notice`) instead of a normal message (`msgtype: m.text`). Defaults to true.
+__task.extra.notify.matrixMsgtype:__ Which matrix `m.room.message` msgtype to use. Note that it is `Msgtype` and not `msgType` to match matrix naming scheme. Defaults to `m.notice`.
 
 __task.extra.notify.email.content:__ This should evaluate to a markdown string and is the body of an email
 

--- a/ui/docs/reference/core/notify/usage.mdx
+++ b/ui/docs/reference/core/notify/usage.mdx
@@ -66,6 +66,8 @@ __task.extra.notify.matrixFormattedBody:__ This is a rich message suitable to be
 
 __task.extra.notify.matrixFormat:__ The format for `formattedBody`. For instance, `org.matrix.custom.html`
 
+__task.extra.notify.matrixNotice:__ Send the notification as a notice (`msgtype: m.notice`) instead of a normal message (`msgtype: m.text`). Defaults to true.
+
 __task.extra.notify.email.content:__ This should evaluate to a markdown string and is the body of an email
 
 __task.extra.notify.email.subject:__ This should evaluate to a normal string and is the subject of an email


### PR DESCRIPTION
This adds support for the basic `m.text`, `m.notice`, and `m.emote` msgtypes.
We can add support for more complicated types later if we want them but this
should cover most of our bases for now.

Thanks to @SimonSapin for the initial code and the idea.

Bugzilla Bug: [1630113](https://bugzilla.mozilla.org/show_bug.cgi?id=1630113)
