### PR TITLE
Add a function to generate links in clients-go readme

### DIFF
--- a/changelog/issue-2268.md
+++ b/changelog/issue-2268.md
@@ -1,0 +1,4 @@
+audience: developers
+level: silent
+reference: issue 2268
+---

--- a/clients/client-go/README.md
+++ b/clients/client-go/README.md
@@ -13,6 +13,46 @@ the API methods.
 
 For a general guide to using Taskcluster clients, see [Calling Taskcluster APIs](https://docs.taskcluster.net/docs/manual/using/api).
 
+This library provides the following packages to interface with Taskcluster:
+
+### HTTP APIs
+
+<!--HTTP-API-start-->
+* http://godoc.org/github.com/taskcluster/taskcluster/clients/client-go/tcauthevents
+
+* http://godoc.org/github.com/taskcluster/taskcluster/clients/client-go/tcgithubevents
+
+* http://godoc.org/github.com/taskcluster/taskcluster/clients/client-go/tchooksevents
+
+* http://godoc.org/github.com/taskcluster/taskcluster/clients/client-go/tcnotifyevents
+
+* http://godoc.org/github.com/taskcluster/taskcluster/clients/client-go/tcqueueevents
+
+* http://godoc.org/github.com/taskcluster/taskcluster/clients/client-go/tcworkermanagerevents
+ <!--HTTP-API-end-->
+
+### AMQP APIs
+
+<!--AMQP-API-start-->
+* http://godoc.org/github.com/taskcluster/taskcluster/clients/client-go/tcauth
+
+* http://godoc.org/github.com/taskcluster/taskcluster/clients/client-go/tcgithub
+
+* http://godoc.org/github.com/taskcluster/taskcluster/clients/client-go/tchooks
+
+* http://godoc.org/github.com/taskcluster/taskcluster/clients/client-go/tcindex
+
+* http://godoc.org/github.com/taskcluster/taskcluster/clients/client-go/tcnotify
+
+* http://godoc.org/github.com/taskcluster/taskcluster/clients/client-go/tcpurgecache
+
+* http://godoc.org/github.com/taskcluster/taskcluster/clients/client-go/tcqueue
+
+* http://godoc.org/github.com/taskcluster/taskcluster/clients/client-go/tcsecrets
+
+* http://godoc.org/github.com/taskcluster/taskcluster/clients/client-go/tcworkermanager
+ <!--AMQP-API-end-->
+
 ### Setup
 
 Before invoking API methods, create a client object corresponding to the service you wish to communicate with.

--- a/clients/client-go/tcauth/tcauth.go
+++ b/clients/client-go/tcauth/tcauth.go
@@ -7,7 +7,6 @@
 //
 // This package was generated from the schema defined at
 // /references/auth/v1/api.json
-
 // Authentication related API end-points for Taskcluster and related
 // services. These API end-points are of interest if you wish to:
 //   * Authorize a request signed with Taskcluster credentials,

--- a/clients/client-go/tcauthevents/tcauthevents.go
+++ b/clients/client-go/tcauthevents/tcauthevents.go
@@ -7,7 +7,6 @@
 //
 // This package was generated from the schema defined at
 // /references/auth/v1/exchanges.json
-
 // The auth service is responsible for storing credentials, managing
 // assignment of scopes, and validation of request signatures from other
 // services.

--- a/clients/client-go/tcgithub/tcgithub.go
+++ b/clients/client-go/tcgithub/tcgithub.go
@@ -7,7 +7,6 @@
 //
 // This package was generated from the schema defined at
 // /references/github/v1/api.json
-
 // The github service is responsible for creating tasks in reposnse
 // to GitHub events, and posting results to the GitHub UI.
 //

--- a/clients/client-go/tcgithubevents/tcgithubevents.go
+++ b/clients/client-go/tcgithubevents/tcgithubevents.go
@@ -7,7 +7,6 @@
 //
 // This package was generated from the schema defined at
 // /references/github/v1/exchanges.json
-
 // The github service publishes a pulse
 // message for supported github events, translating Github webhook
 // events into pulse messages.

--- a/clients/client-go/tchooks/tchooks.go
+++ b/clients/client-go/tchooks/tchooks.go
@@ -7,7 +7,6 @@
 //
 // This package was generated from the schema defined at
 // /references/hooks/v1/api.json
-
 // The hooks service provides a mechanism for creating tasks in response to events.
 //
 // See:

--- a/clients/client-go/tchooksevents/tchooksevents.go
+++ b/clients/client-go/tchooksevents/tchooksevents.go
@@ -7,7 +7,6 @@
 //
 // This package was generated from the schema defined at
 // /references/hooks/v1/exchanges.json
-
 // The hooks service is responsible for creating tasks at specific times orin .  response to webhooks and API calls.Using this exchange allows us tomake hooks which repsond to particular pulse messagesThese exchanges provide notifications when a hook is created, updatedor deleted. This is so that the listener running in a different hooks process at the other end can direct another listener specified by`hookGroupId` and `hookId` to synchronize its bindings. But you are ofcourse welcome to use these for other purposes, monitoring changes for example.
 //
 // See:

--- a/clients/client-go/tcindex/tcindex.go
+++ b/clients/client-go/tcindex/tcindex.go
@@ -7,7 +7,6 @@
 //
 // This package was generated from the schema defined at
 // /references/index/v1/api.json
-
 // The index service is responsible for indexing tasks. The service ensures that
 // tasks can be located by user-defined names.
 //

--- a/clients/client-go/tcnotify/tcnotify.go
+++ b/clients/client-go/tcnotify/tcnotify.go
@@ -7,7 +7,6 @@
 //
 // This package was generated from the schema defined at
 // /references/notify/v1/api.json
-
 // The notification service listens for tasks with associated notifications
 // and handles requests to send emails and post pulse messages.
 //

--- a/clients/client-go/tcnotifyevents/tcnotifyevents.go
+++ b/clients/client-go/tcnotifyevents/tcnotifyevents.go
@@ -7,7 +7,6 @@
 //
 // This package was generated from the schema defined at
 // /references/notify/v1/exchanges.json
-
 // This pretty much only contains the simple free-form
 // message that can be published from this service from a request
 // by anybody with the proper scopes.

--- a/clients/client-go/tcpurgecache/tcpurgecache.go
+++ b/clients/client-go/tcpurgecache/tcpurgecache.go
@@ -7,7 +7,6 @@
 //
 // This package was generated from the schema defined at
 // /references/purge-cache/v1/api.json
-
 // The purge-cache service is responsible for tracking cache-purge requests.
 //
 // User create purge requests for specific caches on specific workers, and

--- a/clients/client-go/tcqueue/tcqueue.go
+++ b/clients/client-go/tcqueue/tcqueue.go
@@ -7,7 +7,6 @@
 //
 // This package was generated from the schema defined at
 // /references/queue/v1/api.json
-
 // The queue service is responsible for accepting tasks and track their state
 // as they are executed by workers. In order ensure they are eventually
 // resolved.

--- a/clients/client-go/tcqueueevents/tcqueueevents.go
+++ b/clients/client-go/tcqueueevents/tcqueueevents.go
@@ -7,7 +7,6 @@
 //
 // This package was generated from the schema defined at
 // /references/queue/v1/exchanges.json
-
 // The queue service is responsible for accepting tasks and track their state
 // as they are executed by workers. In order ensure they are eventually
 // resolved.

--- a/clients/client-go/tcsecrets/tcsecrets.go
+++ b/clients/client-go/tcsecrets/tcsecrets.go
@@ -7,7 +7,6 @@
 //
 // This package was generated from the schema defined at
 // /references/secrets/v1/api.json
-
 // The secrets service provides a simple key/value store for small bits of secret
 // data.  Access is limited by scopes, so values can be considered secret from
 // those who do not have the relevant scopes.

--- a/clients/client-go/tcworkermanager/tcworkermanager.go
+++ b/clients/client-go/tcworkermanager/tcworkermanager.go
@@ -7,7 +7,6 @@
 //
 // This package was generated from the schema defined at
 // /references/worker-manager/v1/api.json
-
 // This service manages workers, including provisioning for dynamic worker pools.
 //
 // See:

--- a/clients/client-go/tcworkermanagerevents/tcworkermanagerevents.go
+++ b/clients/client-go/tcworkermanagerevents/tcworkermanagerevents.go
@@ -7,7 +7,6 @@
 //
 // This package was generated from the schema defined at
 // /references/worker-manager/v1/exchanges.json
-
 // These exchanges provide notifications when a worker pool is created or updated.This is so that the provisioner running in a differentprocess at the other end can synchronize to the changes. But you are ofcourse welcome to use these for other purposes, monitoring changes for example.
 //
 // See:


### PR DESCRIPTION
Fixes #2268 

This PR addresses issue #2268, which is to generate godoc links in README.me file when `yarn generate` is run in the directory `client/client-go`.

This is the first time I am writing a piece of code in Golang. I was able to generate the links in the readme file when ``yarn generate`` is run. I would like to get some feedback and nudge me in the right direction if this is not what we need to achieve, please. 

@djmitche 