### PR TITLE
Replace deprecated things for Octokit

### DIFF
--- a/changelog/bug-1621420.md
+++ b/changelog/bug-1621420.md
@@ -1,0 +1,3 @@
+audience: general
+level: silent
+---

--- a/services/github/src/handlers.js
+++ b/services/github/src/handlers.js
@@ -597,12 +597,12 @@ async function jobHandler(message) {
   let pullNumber = message.payload.details['event.pullNumber'];
   if (!sha) {
     debug('Trying to get commit info in job handler...');
-    let commitInfo = await instGithub.repos.getCommitRefSha({
+    let commitInfo = await instGithub.git.getRef({
       owner: organization,
       repo: repository,
-      ref: `refs/tags/${message.payload.details['event.version']}`,
+      ref: `tags/${message.payload.details['event.version']}`,
     });
-    sha = commitInfo.data.sha;
+    sha = commitInfo.data.object.sha;
   }
 
   debug(`handling ${message.payload.details['event.type']} webhook for: ${organization}/${repository}@${sha}`);


### PR DESCRIPTION
Bugzilla Bug: [1621420](https://bugzilla.mozilla.org/show_bug.cgi?id=1621420)

If this is not done, tc-gh will be broken once we upgrade Octokit to v17 (the current latest version).