### PR TITLE
Bug 1630124 - fix deadlock in livelog

### DIFF
--- a/changelog/bug-1630124.md
+++ b/changelog/bug-1630124.md
@@ -1,0 +1,4 @@
+audience: general
+level: silent
+reference: bug 1630124
+---

--- a/tools/livelog/sequence_test.go
+++ b/tools/livelog/sequence_test.go
@@ -20,13 +20,16 @@ type ChunkReader struct {
 }
 
 // read data in units of at most a chunk, somewhat slowly, to test the
-// "streaming" capability of the server
+// "streaming" capability of the server.  Note that if this produces data
+// too quickly, internal buffers will fill up and the connection will be
+// dropped.  ioutil.ReadAll from an http connection is not very quick,
+// particularly when GC pauses occur.
 func (c *ChunkReader) Read(p []byte) (n int, err error) {
 	if c.chunk_num >= len(c.chunks) {
 		err = io.EOF
 		return
 	}
-	time.Sleep(50 * time.Microsecond)
+	time.Sleep(200 * time.Microsecond)
 
 	remaining := len(c.chunks[c.chunk_num]) - c.partial
 	if remaining > len(p) {
@@ -62,7 +65,7 @@ func TestSequence(t *testing.T) {
 
 	// generate some longish chunks
 	var chunks [][]byte
-	for i := 0; i < 10000; i++ {
+	for i := 0; i < 5000; i++ {
 		chunks = append(chunks, []byte(fmt.Sprintf("%d|%s\n", i, TEXT)))
 	}
 

--- a/tools/livelog/writer/stream.go
+++ b/tools/livelog/writer/stream.go
@@ -158,11 +158,14 @@ func (self *Stream) Consume() error {
 				continue
 			}
 
+			// If this handle is backed up, drop it..
 			pendingWrites := len(handle.events)
 			if pendingWrites >= EVENT_BUFFER_SIZE-1 {
 				log.Printf("Removing handle with %d pending writes\n", pendingWrites)
-				// Remove the handle from any future event writes...
-				self.Unobserve(handle)
+				// Remove the handle from any future event writes.  We can't use
+				// Unobserve here as it locks self.mutex, which we have already
+				// locked.
+				delete(self.handles, handle)
 				close(handle.events)
 				continue
 			}

--- a/tools/livelog/writer/stream.go
+++ b/tools/livelog/writer/stream.go
@@ -26,6 +26,10 @@ type Handles map[*StreamHandle]struct{}
 // emptyStruct cannot be declared as a constant, so var is next best option
 var emptyStruct = struct{}{}
 
+// by default, use the system temp dir; this is overridden in tests so they can
+// reliably clean up.
+var TempDir = ""
+
 type Stream struct {
 	Path   string
 	reader *io.Reader
@@ -39,7 +43,7 @@ type Stream struct {
 }
 
 func NewStream(read io.Reader) (*Stream, error) {
-	dir, err := ioutil.TempDir("", "livelog")
+	dir, err := ioutil.TempDir(TempDir, "livelog")
 	if err != nil {
 		return nil, err
 	}

--- a/tools/livelog/writer/stream.go
+++ b/tools/livelog/writer/stream.go
@@ -161,7 +161,7 @@ func (self *Stream) Consume() error {
 			// If this handle is backed up, drop it..
 			pendingWrites := len(handle.events)
 			if pendingWrites >= EVENT_BUFFER_SIZE-1 {
-				log.Printf("Removing handle with %d pending writes\n", pendingWrites)
+				log.Printf("Removing handle that has failed to keep up (losing data)")
 				// Remove the handle from any future event writes.  We can't use
 				// Unobserve here as it locks self.mutex, which we have already
 				// locked.

--- a/tools/livelog/writer/stream_handle.go
+++ b/tools/livelog/writer/stream_handle.go
@@ -58,7 +58,7 @@ func (self *StreamHandle) writeEvent(event *Event, w io.Writer) (int64, error) {
 
 	// Should come before length equality check...
 	if writeErr != nil {
-		return int64(self.Offset), writeErr
+		return int64(0), writeErr
 	}
 
 	return int64(written), writeErr


### PR DESCRIPTION
Bugzilla Bug: [1630124](https://bugzilla.mozilla.org/show_bug.cgi?id=XXXXX)

The second commit here fixes a deadlock.  The bug was an oversight on my part in a modification I made while migrating to the monorepo -- so a new, never-released bug.

In trying to reproduce this I filled my `/tmp`, so I added some support for deleting temp files in tests.

I'm not confident this is going to fix bug 1630124, as the deadlock was in code that handles the situation where a consumer has more than 100 log output "events" buffered.  If it doesn't deadlock, then the effect is to cut off the consumer early, which should cause the test to fail.  But, I can't reproduce that behavior locally, and the test is set up such that it produces data more slowly than it consumes it (ChunkReader has a 20ns delay between chunks, while we use `ioutil.ReadAll` to consume).  So I'd like to land this and see if it still fails in CI, and if so continue to debug from there.