### PR TITLE
Make migrationScript and downgradeScript optional

### DIFF
--- a/changelog/issue-2681.md
+++ b/changelog/issue-2681.md
@@ -1,0 +1,4 @@
+audience: developers
+level: silent
+reference: issue 2681
+---

--- a/db/versions/0005.yml
+++ b/db/versions/0005.yml
@@ -1,10 +1,4 @@
 version: 5
-migrationScript: |-
-  begin
-  end
-downgradeScript: |-
-  begin
-  end
 methods:
   azure_queue_get:
     description: |

--- a/db/versions/0006.yml
+++ b/db/versions/0006.yml
@@ -1,10 +1,4 @@
 version: 6
-migrationScript: |-
-  begin
-  end
-downgradeScript: |-
-  begin
-  end
 methods:
   azure_queue_count:
     description: |

--- a/db/versions/0007.yml
+++ b/db/versions/0007.yml
@@ -1,10 +1,4 @@
 version: 7
-migrationScript: |-
-  begin
-  end
-downgradeScript: |-
-  begin
-  end
 methods:
   # This updates the _scan methods to treat 'page' as an offset.  The previous
   # approach (from verison 2) did not work.

--- a/generated/db-schema.json
+++ b/generated/db-schema.json
@@ -1793,7 +1793,6 @@
       "version": 4
     },
     {
-      "downgradeScript": "begin\nend",
       "methods": {
         "azure_queue_get": {
           "args": "queue_name text, visible timestamp, count integer",
@@ -1805,11 +1804,9 @@
           "serviceName": "queue"
         }
       },
-      "migrationScript": "begin\nend",
       "version": 5
     },
     {
-      "downgradeScript": "begin\nend",
       "methods": {
         "azure_queue_count": {
           "args": "queue_name text",
@@ -1821,11 +1818,9 @@
           "serviceName": "queue"
         }
       },
-      "migrationScript": "begin\nend",
       "version": 6
     },
     {
-      "downgradeScript": "begin\nend",
       "methods": {
         "access_token_table_entities_scan": {
           "args": "pk text, rk text, condition text, size integer, page integer",
@@ -2107,7 +2102,6 @@
           "serviceName": "worker_manager"
         }
       },
-      "migrationScript": "begin\nend",
       "version": 7
     }
   ]

--- a/libraries/postgres/README.md
+++ b/libraries/postgres/README.md
@@ -130,7 +130,8 @@ version: 17
 # `$db_user_prefix$`, so such statements can take the form `grant .. to
 # $db_user_prefix$_worker_manager`.  The script can be included inline in the YAML
 # using `|-`, or specify a filename to load the script from an external file in the
-# same directory.
+# same directory.  In cases where no migration is required (such as adding or modifying
+# stored functions), this property can be omitted.
 migrationScript: |-
   begin
     create ...;
@@ -139,7 +140,8 @@ migrationScript: |-
   end
 
 # Similar to migrationScript, but reversing its effects.  It's OK for this to lose data.
-# This can similarly specify a filename.
+# This can similarly specify a filename.  This is only required if migrationScript is
+# present.
 downgradeScript: |-
   begin
     revoke ...;

--- a/libraries/postgres/src/Database.js
+++ b/libraries/postgres/src/Database.js
@@ -389,10 +389,12 @@ class Database {
         if (res.rowCount !== 1 || res.rows[0].version !== version.version - 1) {
           throw Error('Multiple DB upgrades running simultaneously');
         }
-        showProgress('..running migration script');
-        const migrationScript = version.migrationScript
-          .replace(/\$db_user_prefix\$/g, usernamePrefix);
-        await client.query(`DO ${dollarQuote(migrationScript)}`);
+        if (version.migrationScript) {
+          showProgress('..running migration script');
+          const migrationScript = version.migrationScript
+            .replace(/\$db_user_prefix\$/g, usernamePrefix);
+          await client.query(`DO ${dollarQuote(migrationScript)}`);
+        }
         showProgress('..defining methods');
         for (let [methodName, { args, body, returns}] of Object.entries(version.methods)) {
           await client.query(`create or replace function
@@ -423,10 +425,12 @@ class Database {
         if (res.rowCount !== 1 || res.rows[0].version !== fromVersion.version) {
           throw Error('Multiple DB modifications running simultaneously');
         }
-        showProgress('..running downgrade script');
-        const downgradeScript = fromVersion.downgradeScript
-          .replace(/\$db_user_prefix\$/g, usernamePrefix);
-        await client.query(`DO ${dollarQuote(downgradeScript)}`);
+        if (fromVersion.downgradeScript) {
+          showProgress('..running downgrade script');
+          const downgradeScript = fromVersion.downgradeScript
+            .replace(/\$db_user_prefix\$/g, usernamePrefix);
+          await client.query(`DO ${dollarQuote(downgradeScript)}`);
+        }
         showProgress('..defining methods');
         for (let [methodName, { args, body, returns}] of Object.entries(toVersion.methods)) {
           await client.query(`create or replace function

--- a/libraries/postgres/src/util.js
+++ b/libraries/postgres/src/util.js
@@ -14,6 +14,11 @@ exports.dollarQuote = str => {
 };
 
 exports.loadSql = (value, dir) => {
+  // sql values are optional
+  if (!value) {
+    return value;
+  }
+
   // if this doesn't look like a filename, treat it literally
   if (value.includes('\n')) {
     return value;

--- a/libraries/postgres/test/version_test.js
+++ b/libraries/postgres/test/version_test.js
@@ -10,16 +10,20 @@ suite(path.basename(__filename), function() {
         /version field missing/);
     });
 
-    test('migrationScript field required', function() {
+    test('downgradeScript field required if migrationScript present', function() {
       assert.throws(
-        () => Version._checkContent({downgradeScript: 'check', version: 1, methods: {}}, '0001.yml'),
-        /migrationScript field missing/);
+        () => Version._checkContent({version: 1, methods: {}, migrationScript: 'yep'}, '0001.yml'),
+        /Cannot specify just one of/);
     });
 
-    test('downgradeScript field required', function() {
+    test('migrationScript field required if downgradeScript present', function() {
       assert.throws(
-        () => Version._checkContent({migrationScript: 'check', version: 1, methods: {}}, '0001.yml'),
-        /downgradeScript field missing/);
+        () => Version._checkContent({version: 1, methods: {}, downgradeScript: 'yep'}, '0001.yml'),
+        /Cannot specify just one of/);
+    });
+
+    test('missing migrationScript and downgradeScript is OK', function() {
+      Version._checkContent({version: 1, methods: {}}, '0001.yml');
     });
 
     test('methods field required', function() {


### PR DESCRIPTION
We have had two revisions now with no upgrade/downgrade scripts, so this seems a reasonable tweak.