### PR TITLE
[web-server] Allow OPTIONS cors for graphql endpoints

### DIFF
--- a/services/web-server/src/servers/createApp.js
+++ b/services/web-server/src/servers/createApp.js
@@ -73,6 +73,7 @@ module.exports = async ({ cfg, strategies, AuthorizationCode, AccessToken, auth,
   app.use(compression());
   app.use(bodyParser.urlencoded({ extended: true }));
   app.use(bodyParser.json());
+  app.options('/graphql', cors(corsOptions));
   app.post(
     '/graphql',
     cors(corsOptions),


### PR DESCRIPTION
Possibly a fix for [bug 1597777](https://bugzilla.mozilla.org/show_bug.cgi?id=1597777).