### PR TITLE
[Bug 1631638] Make the runaway provisioning error a bit less flaky

### DIFF
--- a/changelog/bug-1631638.md
+++ b/changelog/bug-1631638.md
@@ -1,0 +1,5 @@
+audience: deployers
+level: patch
+reference: bug 1631638
+---
+Overprovisioning alerts are now less spammy for small workerpool sizes

--- a/libraries/monitor/src/monitor.js
+++ b/libraries/monitor/src/monitor.js
@@ -254,7 +254,7 @@ class Monitor {
     }
     const serialized = serializeError(err);
     if (this.manager._reporter) {
-      extra['reportId'] = this.manager._reporter.report(err);
+      extra['reportId'] = this.manager._reporter.report(err, level, extra);
     }
     this.log.errorReport({...serialized, ...extra}, {level});
   }

--- a/libraries/monitor/src/plugins/sentry.js
+++ b/libraries/monitor/src/plugins/sentry.js
@@ -1,5 +1,16 @@
 const Sentry = require('@sentry/node');
 
+const tcToSentryLevel = {
+  emerg: 'fatal',
+  alert: 'error',
+  crit: 'error',
+  err: 'error',
+  warning: 'warning',
+  notice: 'info',
+  info: 'info',
+  debug: 'debug',
+};
+
 class SentryReporter {
   constructor({dsn, taskclusterVersion, serviceName, processName}) {
     if (!dsn) {
@@ -15,7 +26,17 @@ class SentryReporter {
     });
   }
 
-  report(error) {
+  report(error, level, extra) {
+    Sentry.configureScope(scope => {
+      if (level) {
+        scope.setLevel(tcToSentryLevel[level] || 'error');
+      }
+      if (extra) {
+        Object.entries(extra).forEach(([k, v]) => {
+          scope.setTag(k, v);
+        });
+      }
+    });
     return Sentry.captureException(error);
   }
 

--- a/libraries/monitor/src/plugins/testreporter.js
+++ b/libraries/monitor/src/plugins/testreporter.js
@@ -7,7 +7,7 @@ class TestReporter {
     this.log = log;
   }
 
-  report(error) {
+  report(error, level, extra) {
     this.internal.push(error);
     return slugid.v4();
   }

--- a/libraries/monitor/test/reporter_test.js
+++ b/libraries/monitor/test/reporter_test.js
@@ -8,7 +8,7 @@ suite(testing.suiteName(), function() {
 
   suite('sentry', function() {
     let monitorManager, monitor, scope, reported;
-    suiteSetup(function() {
+    setup(function() {
       scope = nock('https://sentry.example.com')
         .post('/api/448/store/')
         .reply(200, (_, report)=> {reported = report;});
@@ -43,6 +43,33 @@ suite(testing.suiteName(), function() {
       assert.equal(reported.tags.service, 'testing-service');
       assert.equal(reported.tags.proc, 'foo');
       assert.equal(reported.release, '123:foo');
+      assert.equal(reported.level, 'error');
+    });
+    test('error report with level', async function() {
+      monitor.reportError(new Error('hi'), 'notice');
+      await monitor.terminate();
+      assert.equal(reported.tags.service, 'testing-service');
+      assert.equal(reported.tags.proc, 'foo');
+      assert.equal(reported.release, '123:foo');
+      assert.equal(reported.level, 'info');
+    });
+    test('error report with tags', async function() {
+      monitor.reportError(new Error('hi'), {baz: 'bing'});
+      await monitor.terminate();
+      assert.equal(reported.tags.service, 'testing-service');
+      assert.equal(reported.tags.proc, 'foo');
+      assert.equal(reported.tags.baz, 'bing');
+      assert.equal(reported.release, '123:foo');
+      assert.equal(reported.level, 'error');
+    });
+    test('error report with level and tags', async function() {
+      monitor.reportError(new Error('hi'), 'warning', {baz: 'bing'});
+      await monitor.terminate();
+      assert.equal(reported.tags.service, 'testing-service');
+      assert.equal(reported.tags.proc, 'foo');
+      assert.equal(reported.tags.baz, 'bing');
+      assert.equal(reported.release, '123:foo');
+      assert.equal(reported.level, 'warning');
     });
   });
 });

--- a/services/worker-manager/src/estimator.js
+++ b/services/worker-manager/src/estimator.js
@@ -31,8 +31,13 @@ class Estimator {
     // This 1.25 factor is picked arbitrarily. Ideally this never triggers unless
     // we have some bug in the providers (which is somewhat likely especially with
     // new implementations)
+    // We also pick existingCapacity > 25 as a lower threshold to avoid throwing this
+    // when a small pool has worker configs that have more capacity than the max
+    // e.g. a maxCapacity of 2 with a config that has capacity 12
+    // Eventually we can disallow this condition but we allowed it at first so
+    // we have to live with it for a bit.
     let overProvisioned = false;
-    if (existingCapacity > (maxCapacity * 1.25)) {
+    if (existingCapacity > 25 && existingCapacity > (maxCapacity * 1.25)) {
       overProvisioned = true;
     }
 

--- a/services/worker-manager/test/estimator_test.js
+++ b/services/worker-manager/test/estimator_test.js
@@ -66,7 +66,7 @@ helper.secrets.mockSuite(testing.suiteName(), ['azure'], function(mock, skipping
 
   test('over-satisfied estimation', async function() {
     const workerInfo = {
-      existingCapacity: 10,
+      existingCapacity: 50,
       requestedCapacity: 0,
     };
     const estimate = await estimator.simple({
@@ -79,7 +79,25 @@ helper.secrets.mockSuite(testing.suiteName(), ['azure'], function(mock, skipping
     assert.strictEqual(estimate, 0);
     assert.strictEqual(monitorManager.messages.length, 2);
     assert(monitorManager.messages.some(({Type, Severity}) => Type === 'simple-estimate' && Severity === 3));
-    assert(monitorManager.messages.some(({Type, Fields}) => Type === 'monitor.error' && Fields.existingCapacity === 10));
+    assert(monitorManager.messages.some(({Type, Fields}) => Type === 'monitor.error' && Fields.existingCapacity === 50));
+    monitorManager.reset();
+  });
+
+  test('over-satisfied estimation (false positive is not raised)', async function() {
+    const workerInfo = {
+      existingCapacity: 5,
+      requestedCapacity: 0,
+    };
+    const estimate = await estimator.simple({
+      workerPoolId: 'foo/bar',
+      maxCapacity: 1,
+      minCapacity: 1,
+      workerInfo,
+    });
+
+    assert.strictEqual(estimate, 0);
+    assert.strictEqual(monitorManager.messages.length, 1);
+    assert(monitorManager.messages.some(({Type, Severity}) => Type === 'simple-estimate' && Severity === 5));
     monitorManager.reset();
   });
 });


### PR DESCRIPTION
This is a quite hacky fix to an already hacky alert. If you don't like this approach
feel free to r- it and my feelings will not be hurt. I see this whole part of w-m
getting a pretty good pass shortly with postgres support and cost-savings work
so I mostly want this to stop scaring me every couple weeks for now.

This also passes through tags into sentry reports that we were dropping before

Bugzilla Bug: [1631638](https://bugzilla.mozilla.org/show_bug.cgi?id=1631638)
