### PR TITLE
Bug 1540804 - generic-worker: publicIP config optional

### DIFF
--- a/changelog/bug-1540804.md
+++ b/changelog/bug-1540804.md
@@ -1,0 +1,9 @@
+audience: worker-deployers
+level: minor
+reference: bug 1540804
+---
+Config property `publicIP` of generic-worker workers is now optional. When not
+provided, rdp into Windows workers will no longer be possible, Chain of Trust
+environment reports will no longer include the public IP, and livelogs via
+stateless dns server will no longer work (however this will not affect livelog
+served over websocktunnel).

--- a/workers/generic-worker/README.md
+++ b/workers/generic-worker/README.md
@@ -8,7 +8,7 @@ For documentation of the worker from a user's perspective, see the [online docum
 
 To see a full description of all the config options available to you, run `generic-worker --help`:
 ```
-generic-worker (multiuser engine) 16.6.1
+generic-worker (multiuser engine) 28.2.2
 
 generic-worker is a taskcluster worker that can run on any platform that supports go (golang).
 See http://taskcluster.github.io/generic-worker/ for more details. Essentially, the worker is
@@ -17,6 +17,7 @@ and reports back results to the queue.
 
   Usage:
     generic-worker run                      [--config         CONFIG-FILE]
+                                            [--with-worker-runner]
                                             [--worker-runner-protocol-pipe PIPE]
                                             [--configure-for-aws | --configure-for-gcp | --configure-for-azure]
     generic-worker show-payload-schema
@@ -25,7 +26,9 @@ and reports back results to the queue.
     generic-worker --version
 
   Targets:
-    run                                     Runs the generic-worker.
+    run                                     Runs the generic-worker.  Pass --with-worker-runner if
+                                            running under that service, otherwise generic-worker will
+                                            not communicate with worker-runner.
     show-payload-schema                     Each taskcluster task defines a payload to be
                                             interpreted by the worker that executes it. This
                                             payload is validated against a json schema baked
@@ -84,11 +87,6 @@ and reports back results to the queue.
           clientId                          Taskcluster client ID used by generic worker to
                                             talk to taskcluster queue.
           ed25519SigningKeyLocation         The ed25519 signing key for signing artifacts with.
-          publicIP                          The IP address for clients to be directed to
-                                            for serving live logs; see
-                                            https://github.com/taskcluster/livelog and
-                                            https://github.com/taskcluster/stateless-dns-server
-                                            Also used by chain of trust.
           rootURL                           The root URL of the taskcluster deployment to which
                                             clientId and accessToken grant access. For example,
                                             'https://community-tc.services.mozilla.com/'.
@@ -173,6 +171,11 @@ and reports back results to the queue.
           provisionerId                     The taskcluster provisioner which is taking care
                                             of provisioning environments with generic-worker
                                             running on them. [default: "test-provisioner"]
+          publicIP                          The IP address for clients to be directed to for
+                                            serving live logs when not using websocktunnel; see
+                                            https://github.com/taskcluster/livelog and
+                                            https://github.com/taskcluster/stateless-dns-server
+                                            Also used by chain of trust when present.
           purgeCacheRootURL                 The root URL for taskcluster purge cache API calls.
                                             If not provided, the value from config property
                                             rootURL is used. Intended for development/testing.

--- a/workers/generic-worker/chain_of_trust.go
+++ b/workers/generic-worker/chain_of_trust.go
@@ -41,7 +41,7 @@ type ArtifactHash struct {
 }
 
 type CoTEnvironment struct {
-	PublicIPAddress  string `json:"publicIpAddress"`
+	PublicIPAddress  string `json:"publicIpAddress,omitempty"`
 	PrivateIPAddress string `json:"privateIpAddress"`
 	InstanceID       string `json:"instanceId"`
 	InstanceType     string `json:"instanceType"`
@@ -156,12 +156,15 @@ func (feature *ChainOfTrustTaskFeature) Stop(err *ExecutionErrors) {
 		WorkerGroup: config.WorkerGroup,
 		WorkerID:    config.WorkerID,
 		Environment: CoTEnvironment{
-			PublicIPAddress:  config.PublicIP.String(),
 			PrivateIPAddress: config.PrivateIP.String(),
 			InstanceID:       config.InstanceID,
 			InstanceType:     config.InstanceType,
 			Region:           config.Region,
 		},
+	}
+
+	if config.PublicIP != nil {
+		cotCert.Environment.PublicIPAddress = config.PublicIP.String()
 	}
 
 	certBytes, e := json.MarshalIndent(cotCert, "", "  ")

--- a/workers/generic-worker/config_test.go
+++ b/workers/generic-worker/config_test.go
@@ -14,22 +14,14 @@ func TestMissingIPConfig(t *testing.T) {
 	file := &gwconfig.File{
 		Path: filepath.Join("testdata", "config", "noip.json"),
 	}
-	const setting = "publicIP"
 	_, err := loadConfig(file, NO_PROVIDER)
 	if err != nil {
 		t.Fatalf("%v", err)
 	}
 	err = config.Validate()
-	if err == nil {
-		t.Fatal("Was expecting to get an error back, but didn't get one!")
-	}
-	switch typ := err.(type) {
-	case gwconfig.MissingConfigError:
-		if typ.Setting != setting {
-			t.Errorf("Error message references the wrong missing setting:\n%s\n\nExpected missing setting %q not %q", typ, setting, typ.Setting)
-		}
-	default:
-		t.Fatalf("Was expecting an error of type gwconfig.MissingConfigError but received error of type %T", err)
+	// See https://bugzil.la/1540804 - publicIP is now optional.
+	if err != nil {
+		t.Fatalf("Was expecting no error, but got: %v", err)
 	}
 }
 

--- a/workers/generic-worker/gwconfig/config.go
+++ b/workers/generic-worker/gwconfig/config.go
@@ -130,7 +130,6 @@ func (c *Config) Validate() error {
 		{value: c.LiveLogPUTPort, name: "livelogPUTPort", disallowed: 0},
 		{value: c.LiveLogGETPort, name: "livelogGETPort", disallowed: 0},
 		{value: c.ProvisionerID, name: "provisionerId", disallowed: ""},
-		{value: c.PublicIP, name: "publicIP", disallowed: net.IP(nil)},
 		{value: c.RootURL, name: "rootURL", disallowed: ""},
 		{value: c.Subdomain, name: "subdomain", disallowed: ""},
 		{value: c.TasksDir, name: "tasksDir", disallowed: ""},

--- a/workers/generic-worker/helper_test.go
+++ b/workers/generic-worker/helper_test.go
@@ -80,6 +80,7 @@ func setupEnvironment(t *testing.T) (teardown func()) {
 		// taskContext.TaskDir set to the testdata subfolder, and we don't
 		// want to delete that, which is why we delete testDir and not
 		// config.TasksDir or taskContext.TaskDir
+		t.Logf("Removing test directory %v...", testDir)
 		err := os.RemoveAll(testDir)
 		if err != nil {
 			t.Logf("WARNING: Not able to clean up after test: %v", err)

--- a/workers/generic-worker/main.go
+++ b/workers/generic-worker/main.go
@@ -473,6 +473,17 @@ func RunWorker() (exitCode ExitCode) {
 	if RotateTaskEnvironment() {
 		return REBOOT_REQUIRED
 	}
+	// There are always at least 5 seconds between tasks, however, the new task
+	// directory is created as soon as the previous task completes, so it is
+	// possible for the very first task to complete in less than a second, and
+	// the "new" task environment directory to be created, before the time has
+	// incremented by a second, and therefore the very first task directory
+	// could have the same name as the second task directory. To avoid the
+	// problems this could potentially cause (e.g. the task username being the
+	// same, the directory paths being the same) we wait 1.01 seconds before
+	// starting the very first task. After that, the 5 second minimum time
+	// between tasks is enough to ensure this.
+	time.Sleep(time.Millisecond * 1010)
 	for {
 
 		// See https://bugzil.la/1298010 - routinely check if this worker type is

--- a/workers/generic-worker/simple_docker_test.go
+++ b/workers/generic-worker/simple_docker_test.go
@@ -4,7 +4,6 @@ package main
 
 import (
 	"fmt"
-	"log"
 	"os"
 	"path/filepath"
 	"testing"
@@ -33,18 +32,20 @@ func TestNewTaskDirectoryForEachTask(t *testing.T) {
 	var backingLogsFound uint = 0
 	err := filepath.Walk(config.TasksDir, func(path string, info os.FileInfo, err error) error {
 		if info.IsDir() {
+			t.Logf("Found dir %v", path)
 			return nil
 		}
+		t.Logf("Found file %v", path)
 		if info.Name() != "live_backing.log" {
-			return fmt.Errorf("Discovered file %q but was expecting %q", info.Name(), "live_backing.log")
+			return fmt.Errorf("Discovered file with name %q but was expecting %q", info.Name(), "live_backing.log")
 		}
 		backingLogsFound++
 		return nil
 	})
 	if err != nil {
-		log.Fatal(err)
+		t.Fatalf("%v", err)
 	}
 	if backingLogsFound != config.NumberOfTasksToRun {
-		log.Fatalf("Expected to find %v backing logs, but found %v", config.NumberOfTasksToRun, backingLogsFound)
+		t.Fatalf("Expected to find %v backing logs, but found %v", config.NumberOfTasksToRun, backingLogsFound)
 	}
 }

--- a/workers/generic-worker/usage.go
+++ b/workers/generic-worker/usage.go
@@ -101,11 +101,6 @@ and reports back results to the queue.
           clientId                          Taskcluster client ID used by generic worker to
                                             talk to taskcluster queue.
           ed25519SigningKeyLocation         The ed25519 signing key for signing artifacts with.
-          publicIP                          The IP address for clients to be directed to
-                                            for serving live logs; see
-                                            https://github.com/taskcluster/livelog and
-                                            https://github.com/taskcluster/stateless-dns-server
-                                            Also used by chain of trust.
           rootURL                           The root URL of the taskcluster deployment to which
                                             clientId and accessToken grant access. For example,
                                             'https://community-tc.services.mozilla.com/'.
@@ -190,6 +185,11 @@ and reports back results to the queue.
           provisionerId                     The taskcluster provisioner which is taking care
                                             of provisioning environments with generic-worker
                                             running on them. [default: "test-provisioner"]
+          publicIP                          The IP address for clients to be directed to for
+                                            serving live logs when not using websocktunnel; see
+                                            https://github.com/taskcluster/livelog and
+                                            https://github.com/taskcluster/stateless-dns-server
+                                            Also used by chain of trust when present.
           purgeCacheRootURL                 The root URL for taskcluster purge cache API calls.
                                             If not provided, the value from config property
                                             rootURL is used. Intended for development/testing.

--- a/workers/generic-worker/win32/merge_test.go
+++ b/workers/generic-worker/win32/merge_test.go
@@ -1,7 +1,6 @@
 package win32_test
 
 import (
-	"log"
 	"testing"
 
 	"github.com/taskcluster/taskcluster/v29/workers/generic-worker/win32"
@@ -10,7 +9,7 @@ import (
 func TestMergeNilListsFirstNil(t *testing.T) {
 	res, err := win32.MergeEnvLists(nil, &[]string{"FOO=bar"})
 	if err != nil {
-		log.Fatalf("Hit error: %v", err)
+		t.Fatalf("Hit error: %v", err)
 	}
 	if res == nil || len(*res) != 1 || (*res)[0] != "FOO=bar" {
 		t.Fatalf("Did not merge correctly; got %#v", res)
@@ -20,7 +19,7 @@ func TestMergeNilListsFirstNil(t *testing.T) {
 func TestMergeNilListsSecondNil(t *testing.T) {
 	res, err := win32.MergeEnvLists(&[]string{"FOO=bar"}, nil)
 	if err != nil {
-		log.Fatalf("Hit error: %v", err)
+		t.Fatalf("Hit error: %v", err)
 	}
 	if res == nil || len(*res) != 1 || (*res)[0] != "FOO=bar" {
 		t.Fatalf("Did not merge correctly; got %#v", res)

--- a/workers/generic-worker/win32/win32_windows_test.go
+++ b/workers/generic-worker/win32/win32_windows_test.go
@@ -2,7 +2,6 @@ package win32_test
 
 import (
 	"fmt"
-	"log"
 
 	"github.com/taskcluster/taskcluster/v29/workers/generic-worker/win32"
 )
@@ -20,7 +19,7 @@ func ExampleMergeEnvLists() {
 	}
 	res, err := win32.MergeEnvLists(lists...)
 	if err != nil {
-		log.Fatalf("Hit error: %v", err)
+		fmt.Printf("Hit error: %v\n", err)
 	}
 	fmt.Println(*res)
 	// Output:


### PR DESCRIPTION
Bugzilla Bug: [1540804](https://bugzilla.mozilla.org/show_bug.cgi?id=1540804)

Although this makes `publicIP` optional, we should still provide the config setting on workers where the RDP feature is needed, since without it RDP will no longer be possible until we have interactive tasks running through websocktunnel. However, we can already stop providing the config setting for linux/mac workers with this change, so long as their livelogs are already configured to be served through websocktunnel. @escapewindow has [already confirmed](https://bugzilla.mozilla.org/show_bug.cgi?id=1540804#c3) that the reference to public IP in Chain of Trust is optional.