### PR TITLE
Bug 1619286 - add a site-specific link to github app to the quickstart

### DIFF
--- a/changelog/bug-1619286.md
+++ b/changelog/bug-1619286.md
@@ -1,0 +1,4 @@
+audience: general
+level: silent
+reference: bug 1619286
+---

--- a/ui/src/views/Quickstart/index.jsx
+++ b/ui/src/views/Quickstart/index.jsx
@@ -375,16 +375,11 @@ export default class QuickStart extends Component {
                   </Typography>
                 </li>
                 <li>
-                  <Typography paragraph>
-                    Make sure to install the{' '}
-                    <a
-                      href="https://github.com/apps/taskcluster"
-                      target="_blank"
-                      rel="noopener noreferrer">
-                      Taskcluster-GitHub integration
-                    </a>
-                    .
-                  </Typography>
+                  <SiteSpecific>
+                    Make sure to install the [GitHub app](%github_app_url%) on
+                    your repo. If you do not have permission, you may need to
+                    ask the repository or organization owners to do so.
+                  </SiteSpecific>
                 </li>
               </ul>
               <Typography variant="body2" paragraph>


### PR DESCRIPTION
Bugzilla Bug: [1619286](https://bugzilla.mozilla.org/show_bug.cgi?id=1619286)
