### PR TITLE
Bug 1631829 - tag all azure worker resources with standard tags

### DIFF
--- a/changelog/bug-1631829.md
+++ b/changelog/bug-1631829.md
@@ -1,0 +1,5 @@
+audience: general
+level: patch
+reference: bug 1631829
+---
+The worker-manager Azure provider now tags all worker related Azure resources with the set of standard tags.

--- a/services/worker-manager/src/providers/azure.js
+++ b/services/worker-manager/src/providers/azure.js
@@ -187,6 +187,12 @@ class AzureProvider extends Provider {
           // we add this when we have the NIC provisioned
           networkInterfaces: [],
         },
+      };
+
+      let providerData = {
+        location: cfg.location,
+        resourceGroupName: this.providerConfig.resourceGroupName,
+        workerConfig: cfg.workerConfig,
         tags: {
           ...cfg.tags || {},
           'created-by': `taskcluster-wm-${this.providerId}`,
@@ -197,12 +203,6 @@ class AzureProvider extends Provider {
           'root-url': this.rootUrl,
           'owner': workerPool.owner,
         },
-      };
-
-      let providerData = {
-        location: cfg.location,
-        resourceGroupName: this.providerConfig.resourceGroupName,
-        workerConfig: cfg.workerConfig,
         vm: {
           name: virtualMachineName,
           computerName,
@@ -505,7 +505,7 @@ class AzureProvider extends Provider {
       let resourceRequest = await this._enqueue('query', () => client.beginCreateOrUpdate(
         worker.providerData.resourceGroupName,
         typeData.name,
-        resourceConfig,
+        {...resourceConfig, ...worker.providerData.tags},
       ));
       // track operation
       await worker.modify(w => {

--- a/ui/docs/reference/core/worker-manager/azure.mdx
+++ b/ui/docs/reference/core/worker-manager/azure.mdx
@@ -41,7 +41,7 @@ The document should have audience equal to the deployment's `rootUrl` and `forma
 
 ## Tags
 
-The provider starts workers with the following labels. The tags `provider-id`, `worker-group`, `worker-pool-id`, and `root-url` are used by the worker for configuration while `customData` is broken in the instance metadata service.
+The provider creates worker resources with the following labels. The tags `provider-id`, `worker-group`, `worker-pool-id`, and `root-url` are used by the worker for configuration while `customData` is broken in the instance metadata service.
 
  * `provider-id` - provider ID that started the worker
  * `worker-group` - the worker's workerGroup (currently equal to the providerId, but do not depend on this)


### PR DESCRIPTION
Bugzilla Bug: [1631829](https://bugzilla.mozilla.org/show_bug.cgi?id=1631829)