### PR TITLE
Add Retrigger All functionality

### DIFF
--- a/services/github/config.yml
+++ b/services/github/config.yml
@@ -6,6 +6,7 @@ defaults:
     deprecatedInitialStatusQueue: 'stat-init'
     resultStatusQueue: 'ch-result'
     initialStatusQueue: 'ch-init'
+    checkSuiteQueue: 'ch-suite'
     buildsTableName: 'TaskclusterGithubBuilds'
     ownersDirectoryTableName: 'TaskclusterIntegrationOwners'
     checkRunsTableName: 'TaskclusterCheckRuns'

--- a/services/github/schemas/v1/github-check-suite-message.yml
+++ b/services/github/schemas/v1/github-check-suite-message.yml
@@ -1,0 +1,54 @@
+$schema: "/schemas/common/metaschema.json#"
+title: "GitHub Check Suite Message"
+description: Message reporting that a Check Suite event has occurred
+type: object
+properties:
+  version: {$const: message-version}
+  organization:
+    description: The GitHub `organization` which had an event.
+    type: string
+    minLength: {$const: github-identifier-min-length}
+    maxLength: {$const: github-identifier-max-length}
+    pattern: {$const: github-identifier-pattern}
+  repository:
+    description: The GitHub `repository` which had an event.
+    type: string
+    minLength: {$const: github-identifier-min-length}
+    maxLength: {$const: github-identifier-max-length}
+    pattern: {$const: github-identifier-pattern}
+  installationId:
+    description: The installation which had an event.
+    type: integer
+    minimum: {$const: github-installation-minimum}
+    maximum: {$const: github-installation-maximum}
+  action:
+    description: The GitHub `action` which triggered an event.
+    enum: [assigned, unassigned, labeled, unlabeled, opened, edited, closed, reopened, synchronize, review_requested, review_request_removed]
+  eventId:
+    type: string
+    description: The GitHub webhook deliveryId. Extracted from the header 'X-GitHub-Delivery'
+    pattern: {$const: github-guid-pattern}
+  body:
+    type: object
+    description: The raw body of github event (for version 1)
+  tasks_for:
+    type: string
+    description: The type of the event (for version 1)
+  branch:
+    type: string
+    description: The head branch of the event (for version 1)
+  ref:
+    type: string
+    description: The head ref for the event (for version 1)
+additionalProperties: false
+required:
+  - version
+  - organization
+  - repository
+  - action
+  - installationId
+  - eventId
+  - body
+  - tasks_for
+  - branch
+  - ref

--- a/services/github/src/api.js
+++ b/services/github/src/api.js
@@ -276,6 +276,16 @@ builder.declare({
         }, true);
         return resolve(res, 200, 'Created table row!');
 
+      case 'check_suite':
+        msg.organization = sanitizeGitHubField(body.repository.owner.login);
+        msg.action = body.action;
+        msg.installationId = body.installation.id;
+        publisherKey = 'checkSuite';
+        msg.tasks_for = 'github-check-suite';
+        msg.branch = body.check_suite.head_branch;
+        msg.ref = body.check_suite.head_sha;
+        break;
+
       default:
         return resolve(res, 400, 'No publisher available for X-GitHub-Event: ' + eventType);
     }

--- a/services/github/src/exchanges.js
+++ b/services/github/src/exchanges.js
@@ -3,8 +3,7 @@ const _ = require('lodash');
 const assert = require('assert');
 
 /** Build common routing key construct for `exchanges.declare` */
-const commonRoutingKey = function(options) {
-  options = options || {};
+const commonRoutingKey = function(options = {}) {
   let routingKey = [
     {
       name: 'routingKeyKind',
@@ -139,6 +138,23 @@ exchanges.declare({
   messageBuilder: commonMessageBuilder,
   routingKeyBuilder: msg => _.pick(msg, 'organization', 'repository'),
   CCBuilder: commonCCBuilder,
+});
+
+/** check suite exchange */
+exchanges.declare({
+  exchange: 'check-suite',
+  name: 'checkSuite',
+  title: 'GitHub Check Suite Event',
+  description: [
+    'When a GitHub check suite event is posted it will be broadcast on this',
+    'exchange with the designated `organization` and `repository`',
+    'in the routing-key along with event specific metadata in the payload.',
+  ].join('\n'),
+  routingKey: commonRoutingKey({hasActions: true}),
+  schema: 'github-check-suite-message.yml',
+  messageBuilder: commonMessageBuilder,
+  routingKeyBuilder: msg => _.pick(msg, 'organization', 'repository', 'action'),
+  CCBuilder: () => [],
 });
 
 // Export exchanges

--- a/services/github/src/main.js
+++ b/services/github/src/main.js
@@ -227,6 +227,7 @@ const load = loader({
         deprecatedInitialStatusQueueName: cfg.app.deprecatedInitialStatusQueue,
         resultStatusQueueName: cfg.app.resultStatusQueue,
         initialStatusQueueName: cfg.app.initialStatusQueue,
+        checkSuiteQueueName: cfg.app.checkSuiteQueue,
         context: {cfg, github, schemaset, Builds, CheckRuns, ChecksToTasks, publisher},
         pulseClient,
       }),

--- a/services/github/src/utils.js
+++ b/services/github/src/utils.js
@@ -29,6 +29,34 @@ const throttleRequest = async ({url, method, delay = 10, response = {status: 0},
   return res;
 };
 
+const generateQueueClientScopes = ({tasks_for, push, reportingRoute, schedulerId}) => {
+  let scopes = [];
+
+  switch (tasks_for) {
+    case 'github-pull-request':
+      scopes = [`assume:repo:github.com/${ payload.organization }/${ payload.repository }:pull-request`];
+      break;
+    case 'github-push':
+      if (push) {
+        scopes = [`assume:repo:github.com/${ payload.organization }/${ payload.repository }:${push.type}:${push.ref}`]
+      } else {
+        scopes = [];
+      }
+      break;
+    case 'github-release':
+      scopes = [`assume:repo:github.com/${ payload.organization }/${ payload.repository }:release`];
+      break;
+    default:
+      scopes = [];
+  }
+
+  scopes.push(`queue:route:${reportingRoute}`);
+  scopes.push(`queue:scheduler-id:${schedulerId}`);
+
+  return scopes;
+};
+
 module.exports = {
   throttleRequest,
+  generateQueueClientScopes,
 };


### PR DESCRIPTION
I am putting this up in a form of a draft PR to hand this over. This is the work I have been doing on `Retrigger All`. `Retrigger` and `Retrigger failed checks` would be very similar to this except that handler deals with an individual task.

You are free to continue working on this (can be an Outreachy/GSoC/volunteer/Mozilla intern task) or you can discard this entirely and come up with your own ideas.