### PR TITLE
Add back ejs to prod because web-server uses it for login page

### DIFF
--- a/changelog/U3wqIgKuSVu-QZfE_5AAog.md
+++ b/changelog/U3wqIgKuSVu-QZfE_5AAog.md
@@ -1,0 +1,4 @@
+audience: general
+level: patch
+---
+A dependency that was mistakenly thought to be unused has been added back

--- a/package.json
+++ b/package.json
@@ -115,6 +115,7 @@
     "topo-sort": "^1.0.0",
     "type-is": "^1.6.15",
     "uuid": "^3.3.2",
+    "ejs": "^2.6.1",
     "walk": "^2.3.9"
   },
   "devDependencies": {
@@ -134,7 +135,6 @@
     "cronstrue": "^1.82.0",
     "cross-env": "^6.0.3",
     "dockerode": "^3.0.0",
-    "ejs": "^2.6.1",
     "error-stack-parser": "^2.0.2",
     "eslint": "^6.6.0",
     "github-slugger": "^1.2.1",
@@ -196,7 +196,8 @@
       "eslint",
       "c8",
       "cross-env",
-      "morgan"
+      "morgan",
+      "ejs"
     ]
   },
   "renovate": {


### PR DESCRIPTION
The package is not `required`, just configured for express.
Not sure how to catch this automatically so we'll just manually make
it special.

Probably want to make a release with this first thing monday!