### PR TITLE
Bug 1631099 - retry on 401's (Bad Credentials) from GitHub

### DIFF
--- a/changelog/bug-1631099.md
+++ b/changelog/bug-1631099.md
@@ -1,0 +1,5 @@
+audience: users
+level: patch
+reference: bug 1631099
+---
+Taskcluster-GitHub now retries on 401 "Bad Credentials" errors from GitHub, as suggested by [GitHub developers](https://github.community/t5/GitHub-API-Development-and/Random-401-errors-after-using-freshly-generated-installation/m-p/23531/highlight/true#M1680).

--- a/services/github/src/github-auth.js
+++ b/services/github/src/github-auth.js
@@ -11,7 +11,9 @@ const retryPlugin = (octokit, options) => {
       try {
         return await request(options);
       } catch (err) {
-        if (attempt < retries && err.name === 'HttpError' && (err.status >= 500 || err.status === 404)) {
+        // 404 and 401 are both retried because they can occur spuriously, likely due to MySQL db replication
+        // delays at GitHub.
+        if (attempt < retries && err.name === 'HttpError' && (err.status >= 500 || err.status === 401 || err.status === 404)) {
           await sleep(baseBackoff * Math.pow(2, attempt));
           continue;
         }


### PR DESCRIPTION
Bugzilla Bug: [1631099](https://bugzilla.mozilla.org/show_bug.cgi?id=1631099)

Based on [this comment](https://github.community/t5/GitHub-API-Development-and/Random-401-errors-after-using-freshly-generated-installation/m-p/23531/highlight/true#M1680) (and the thread around it).