### PR TITLE
Bug 1606006 - generate a new ephemeral queue name on every connection

### DIFF
--- a/changelog/bug-1606006.md
+++ b/changelog/bug-1606006.md
@@ -1,0 +1,5 @@
+audience: deployers
+level: patch
+reference: bug 1606006
+---
+Services that use ephemeral queues now use a different queue name on each connection.  This avoids issues with RESOURCE-LOCKED from RabbitMQ.

--- a/libraries/pulse/src/consumer.js
+++ b/libraries/pulse/src/consumer.js
@@ -41,7 +41,6 @@ class PulseConsumer {
     if (ephemeral) {
       assert(!queueName, 'Must not pass a queueName for ephemeral consumers');
       assert(onConnected, 'Must pass onConnected for ephemeral consumers');
-      this.queueName = slugid.nice();
     } else {
       assert(queueName, 'Must pass a queueName');
       this.queueName = queueName;
@@ -145,7 +144,11 @@ class PulseConsumer {
   }
 
   async _createAndBindQueue(channel) {
-    const queueName = this.client.fullObjectName('queue', this.queueName);
+    const queueName = this.client.fullObjectName(
+      'queue',
+      // for ephemeral queues, generate a new queueName on every connection,
+      // as autodelete is not an immediate operation
+      this.ephemeral ? slugid.nice() : this.queueName);
     await channel.assertQueue(queueName, {
       exclusive: this.ephemeral,
       durable: true,


### PR DESCRIPTION
Bugzilla Bug: [1606006](https://bugzilla.mozilla.org/show_bug.cgi?id=1606006)
