### PR TITLE
Issue 2734 - use monorepo livelog/taskcluster-proxy in generic-worker CI

### DIFF
--- a/changelog/KuCkLEk0SRKlqWZBqtGwiw.md
+++ b/changelog/KuCkLEk0SRKlqWZBqtGwiw.md
@@ -1,0 +1,3 @@
+audience: worker-deployers
+level: silent
+---

--- a/workers/generic-worker/gw-decision-task/tasks.yml
+++ b/workers/generic-worker/gw-decision-task/tasks.yml
@@ -8,7 +8,6 @@ Types:
       - 'git2.24.0.2'
       - 'jq1.6'
       - 'ci-creds'
-      - 'taskcluster-proxy5.1.0'
       - 'golangci-lint-1.23.6'
     Command: BuildAndTest
     Features:
@@ -164,7 +163,6 @@ Commands:
             [ "$(uname -s)" != "Darwin" ] || base64 -D
             [ "$(uname -s)" != "Linux" ]  || base64 -d
           }
-          chmod a+x bin/taskcluster-proxy
           # go test: -race and -msan are only supported on linux/amd64, freebsd/amd64, darwin/amd64 and windows/amd64
           if [ "$(uname -m)" == "x86_64" ]; then
             RACE=-race
@@ -195,7 +193,6 @@ Commands:
           git reset --hard "${GITHUB_SHA}"
           git clean -fdx
           git checkout -B tmp -t "X${TASK_ID}"
-          go get -v -u github.com/taskcluster/livelog
           cd workers/generic-worker
           # go.mod and go.sum will be affected by above go get commands, so
           # tidy them before checking for changes. Not needed in go 1.14:
@@ -207,6 +204,8 @@ Commands:
           # output of wc command can contain spaces on darwin, so no quotes around expression
           test $(git status --porcelain | wc -l) == 0
           go install -tags "${ENGINE}" -v -ldflags "-X main.revision=${GITHUB_SHA}" ./...
+          go install ../../tools/taskcluster-proxy
+          go install ../../tools/livelog
           go vet -tags "${ENGINE}" ./...
           if [ "${ENGINE}" == "multiuser" ]; then
             cp "${TASK_USER_CREDENTIALS}" next-task-user.json
@@ -252,7 +251,6 @@ Commands:
       - 'git reset --hard %GITHUB_SHA%'
       - 'git clean -fdx'
       - 'git checkout -B tmp -t "X%TASK_ID%"'
-      - go get -v -u github.com/taskcluster/livelog
       - cd workers\generic-worker
       - |
         :: go.mod and go.sum will be affected by above go get commands, so
@@ -272,6 +270,8 @@ Commands:
         :: find.exe may have exited with exit code 1, so need to explicitly exit with 0
         exit /b 0
       - go install -tags "%ENGINE%" -v -ldflags "-X main.revision=%GITHUB_SHA%" ./...
+      - go install ..\..\tools\taskcluster-proxy
+      - go install ..\..\tools\livelog
       - go vet -tags "%ENGINE%" ./...
       - set CGO_ENABLED=%CGO_ENABLED_TESTS%
       - set GORACE=history_size=7
@@ -345,27 +345,6 @@ Mounts:
         all:
           url: 'http://localhost/secrets/v1/secret/project/taskcluster/testing/generic-worker/ci-creds'
           sha256: 'ef1d954dbae01a0810fcdb56f56761dbbb26692b0dc8cbb2994101512fc26992'
-  taskcluster-proxy5.1.0:
-    file: bin/taskcluster-proxy${EXTENSION}
-    content:
-      darwin:
-        amd64:
-          url: 'https://github.com/taskcluster/taskcluster-proxy/releases/download/v5.1.0/taskcluster-proxy-darwin-amd64'
-          sha256: '3faf524b9c6b9611339510797bf1013d4274e9f03e7c4bd47e9ab5ec8813d3ae'
-      linux:
-        armv6l:
-          url: 'https://github.com/taskcluster/taskcluster-proxy/releases/download/v5.1.0/taskcluster-proxy-linux-arm'
-          sha256: '896ed9f7b4b95a016ab17ceff3c0de873489713acf722a88ee8691a1a0bff11b'
-        amd64:
-          url: 'https://github.com/taskcluster/taskcluster-proxy/releases/download/v5.1.0/taskcluster-proxy-linux-amd64'
-          sha256: 'fcf000ca939b3ecbfc287405142f0f38ab4292b2f039ca9c6fc71fecfcfd065a'
-      windows:
-        386:
-          url: 'https://github.com/taskcluster/taskcluster-proxy/releases/download/v5.1.0/taskcluster-proxy-windows-386.exe'
-          sha256: '6d093e3fcb69fa325276136b6d421bed1f45a1f31a8e442eb994f2a11be27c5e'
-        amd64:
-          url: 'https://github.com/taskcluster/taskcluster-proxy/releases/download/v5.1.0/taskcluster-proxy-windows-amd64.exe'
-          sha256: '0764644101703202b100daa36b5cafe72829d12ac09319222f9676602640a8a6'
   golangci-lint-1.23.6:
     # Note - we can't extract to directory '.' since after generic-worker
     # extracts the files as the root user (since generic-worker runs as root),

--- a/workers/generic-worker/livelog.go
+++ b/workers/generic-worker/livelog.go
@@ -17,8 +17,8 @@ import (
 )
 
 var (
-	livelogName            = "public/logs/live.log"
-	internalGETPort uint16 = 60099
+	livelogName     = "public/logs/live.log"
+	internalGETPort uint16
 )
 
 type LiveLogFeature struct {
@@ -29,6 +29,7 @@ func (feature *LiveLogFeature) Name() string {
 }
 
 func (feature *LiveLogFeature) Initialise() error {
+	internalGETPort = config.LiveLogGETPort
 	return nil
 }
 


### PR DESCRIPTION
Github Bug/Issue: Fixes #2734