### PR TITLE
Bug 1633622 - build the build directory in tc-client-web

### DIFF
--- a/changelog/bug-1633622.md
+++ b/changelog/bug-1633622.md
@@ -1,0 +1,5 @@
+audience: users
+level: patch
+reference: bug 1633622
+---
+The taskcluster-client-web package now contains the `build` directory as expected.

--- a/infrastructure/tooling/src/utils/npm.js
+++ b/infrastructure/tooling/src/utils/npm.js
@@ -31,7 +31,9 @@ exports.npmPublish = async ({dir, apiToken, logfile, utils}) => {
     // just add the token to both of them..
     fs.writeFileSync(npmrc,
       `//registry.yarnpkg.com/:_authToken=${apiToken}\n` +
-      `//registry.npmjs.org/:_authToken=${apiToken}\n`);
+      `//registry.npmjs.org/:_authToken=${apiToken}\n` +
+      // set unsafe-perm since we run as root when publishing
+      'unsafe-perm=true\n');
 
     await execCommand({
       dir,


### PR DESCRIPTION
Bugzilla Bug: [1633622](https://bugzilla.mozilla.org/show_bug.cgi?id=1633622)

This is not something we can test in a staging release (since it involves pushing a package), but I did test it locally by running `npm pack` as root both without and with `unsafe-perm`.