### PR TITLE
[UI] Do not show breadcrumb component before picking a namespace

### DIFF
--- a/ui/src/views/Tasks/TaskIndex/ListNamespaces/index.jsx
+++ b/ui/src/views/Tasks/TaskIndex/ListNamespaces/index.jsx
@@ -154,6 +154,7 @@ export default class ListNamespaces extends Component {
   render() {
     const {
       classes,
+      match: { params },
       namespacesData: {
         namespaces,
         loading: namespacesLoading,
@@ -199,7 +200,7 @@ export default class ListNamespaces extends Component {
                 .join('.')}/${indexPathInput.split('.').slice(-1)[0]}`}
             />
           )}
-          {!loading && indexPathInput && (
+          {!loading && params.namespace && (
             <Fragment>
               <Breadcrumbs>
                 <Link to="/tasks/index">


### PR DESCRIPTION
Fixes https://github.com/taskcluster/taskcluster/issues/2662.