### PR TITLE
Avoid fetching on empty pages

### DIFF
--- a/services/web-server/src/ConnectionLoader.js
+++ b/services/web-server/src/ConnectionLoader.js
@@ -6,21 +6,9 @@ const FIRST = '$$FIRST$$';
 module.exports = class ConnectionLoader {
   constructor(singleConnectionHandler) {
     const fetch = async ({ connection, options, ...props }) => {
-      const result = connection
+      return connection
         ? await singleConnectionHandler({ connection, options, ...props })
         : await singleConnectionHandler({ options, ...props });
-
-      if (result.continuationToken && !result.items.length) {
-        return fetch({
-          ...props,
-          options: {
-            ...options,
-            continuationToken: result.continuationToken,
-          },
-        });
-      }
-
-      return result;
     };
 
     return new DataLoader(connections =>


### PR DESCRIPTION
This used to be a hack back when we were running under azure where we
sometimes get a continuation token but no entries in the response. In postgres, if we get
a continuation token, there will always be a set of entries with it.