### PR TITLE
Ensure all deployments have unique container names

### DIFF
--- a/infrastructure/k8s/templates/taskcluster-auth-deployment-web.yaml
+++ b/infrastructure/k8s/templates/taskcluster-auth-deployment-web.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       serviceAccountName: taskcluster-auth
       containers:
-        - name: taskcluster-auth
+        - name: taskcluster-auth-web
           image: '{{ .Values.dockerImage }}'
           imagePullPolicy: Always
           args:

--- a/infrastructure/k8s/templates/taskcluster-built-in-workers-deployment-server.yaml
+++ b/infrastructure/k8s/templates/taskcluster-built-in-workers-deployment-server.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       serviceAccountName: taskcluster-built-in-workers
       containers:
-        - name: taskcluster-built-in-workers
+        - name: taskcluster-built-in-workers-server
           image: '{{ .Values.dockerImage }}'
           imagePullPolicy: Always
           args:

--- a/infrastructure/k8s/templates/taskcluster-github-deployment-web.yaml
+++ b/infrastructure/k8s/templates/taskcluster-github-deployment-web.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       serviceAccountName: taskcluster-github
       containers:
-        - name: taskcluster-github
+        - name: taskcluster-github-web
           image: '{{ .Values.dockerImage }}'
           imagePullPolicy: Always
           args:

--- a/infrastructure/k8s/templates/taskcluster-github-deployment-worker.yaml
+++ b/infrastructure/k8s/templates/taskcluster-github-deployment-worker.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       serviceAccountName: taskcluster-github
       containers:
-        - name: taskcluster-github
+        - name: taskcluster-github-worker
           image: '{{ .Values.dockerImage }}'
           imagePullPolicy: Always
           args:

--- a/infrastructure/k8s/templates/taskcluster-hooks-deployment-listeners.yaml
+++ b/infrastructure/k8s/templates/taskcluster-hooks-deployment-listeners.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       serviceAccountName: taskcluster-hooks
       containers:
-        - name: taskcluster-hooks
+        - name: taskcluster-hooks-listeners
           image: '{{ .Values.dockerImage }}'
           imagePullPolicy: Always
           args:

--- a/infrastructure/k8s/templates/taskcluster-hooks-deployment-scheduler.yaml
+++ b/infrastructure/k8s/templates/taskcluster-hooks-deployment-scheduler.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       serviceAccountName: taskcluster-hooks
       containers:
-        - name: taskcluster-hooks
+        - name: taskcluster-hooks-scheduler
           image: '{{ .Values.dockerImage }}'
           imagePullPolicy: Always
           args:

--- a/infrastructure/k8s/templates/taskcluster-hooks-deployment-web.yaml
+++ b/infrastructure/k8s/templates/taskcluster-hooks-deployment-web.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       serviceAccountName: taskcluster-hooks
       containers:
-        - name: taskcluster-hooks
+        - name: taskcluster-hooks-web
           image: '{{ .Values.dockerImage }}'
           imagePullPolicy: Always
           args:

--- a/infrastructure/k8s/templates/taskcluster-index-deployment-handlers.yaml
+++ b/infrastructure/k8s/templates/taskcluster-index-deployment-handlers.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       serviceAccountName: taskcluster-index
       containers:
-        - name: taskcluster-index
+        - name: taskcluster-index-handlers
           image: '{{ .Values.dockerImage }}'
           imagePullPolicy: Always
           args:

--- a/infrastructure/k8s/templates/taskcluster-index-deployment-web.yaml
+++ b/infrastructure/k8s/templates/taskcluster-index-deployment-web.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       serviceAccountName: taskcluster-index
       containers:
-        - name: taskcluster-index
+        - name: taskcluster-index-web
           image: '{{ .Values.dockerImage }}'
           imagePullPolicy: Always
           args:

--- a/infrastructure/k8s/templates/taskcluster-notify-deployment-handler.yaml
+++ b/infrastructure/k8s/templates/taskcluster-notify-deployment-handler.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       serviceAccountName: taskcluster-notify
       containers:
-        - name: taskcluster-notify
+        - name: taskcluster-notify-handler
           image: '{{ .Values.dockerImage }}'
           imagePullPolicy: Always
           args:

--- a/infrastructure/k8s/templates/taskcluster-notify-deployment-irc.yaml
+++ b/infrastructure/k8s/templates/taskcluster-notify-deployment-irc.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       serviceAccountName: taskcluster-notify
       containers:
-        - name: taskcluster-notify
+        - name: taskcluster-notify-irc
           image: '{{ .Values.dockerImage }}'
           imagePullPolicy: Always
           args:

--- a/infrastructure/k8s/templates/taskcluster-notify-deployment-web.yaml
+++ b/infrastructure/k8s/templates/taskcluster-notify-deployment-web.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       serviceAccountName: taskcluster-notify
       containers:
-        - name: taskcluster-notify
+        - name: taskcluster-notify-web
           image: '{{ .Values.dockerImage }}'
           imagePullPolicy: Always
           args:

--- a/infrastructure/k8s/templates/taskcluster-purge-cache-deployment-web.yaml
+++ b/infrastructure/k8s/templates/taskcluster-purge-cache-deployment-web.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       serviceAccountName: taskcluster-purge-cache
       containers:
-        - name: taskcluster-purge-cache
+        - name: taskcluster-purge-cache-web
           image: '{{ .Values.dockerImage }}'
           imagePullPolicy: Always
           args:

--- a/infrastructure/k8s/templates/taskcluster-queue-deployment-claimResolver.yaml
+++ b/infrastructure/k8s/templates/taskcluster-queue-deployment-claimResolver.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       serviceAccountName: taskcluster-queue
       containers:
-        - name: taskcluster-queue
+        - name: taskcluster-queue-claimresolver
           image: '{{ .Values.dockerImage }}'
           imagePullPolicy: Always
           args:

--- a/infrastructure/k8s/templates/taskcluster-queue-deployment-deadlineResolver.yaml
+++ b/infrastructure/k8s/templates/taskcluster-queue-deployment-deadlineResolver.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       serviceAccountName: taskcluster-queue
       containers:
-        - name: taskcluster-queue
+        - name: taskcluster-queue-deadlineresolver
           image: '{{ .Values.dockerImage }}'
           imagePullPolicy: Always
           args:

--- a/infrastructure/k8s/templates/taskcluster-queue-deployment-dependencyResolver.yaml
+++ b/infrastructure/k8s/templates/taskcluster-queue-deployment-dependencyResolver.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       serviceAccountName: taskcluster-queue
       containers:
-        - name: taskcluster-queue
+        - name: taskcluster-queue-dependencyresolver
           image: '{{ .Values.dockerImage }}'
           imagePullPolicy: Always
           args:

--- a/infrastructure/k8s/templates/taskcluster-queue-deployment-web.yaml
+++ b/infrastructure/k8s/templates/taskcluster-queue-deployment-web.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       serviceAccountName: taskcluster-queue
       containers:
-        - name: taskcluster-queue
+        - name: taskcluster-queue-web
           image: '{{ .Values.dockerImage }}'
           imagePullPolicy: Always
           args:

--- a/infrastructure/k8s/templates/taskcluster-references-deployment-web.yaml
+++ b/infrastructure/k8s/templates/taskcluster-references-deployment-web.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       serviceAccountName: taskcluster-references
       containers:
-        - name: taskcluster-references
+        - name: taskcluster-references-web
           image: '{{ .Values.dockerImage }}'
           imagePullPolicy: Always
           args:

--- a/infrastructure/k8s/templates/taskcluster-secrets-deployment-web.yaml
+++ b/infrastructure/k8s/templates/taskcluster-secrets-deployment-web.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       serviceAccountName: taskcluster-secrets
       containers:
-        - name: taskcluster-secrets
+        - name: taskcluster-secrets-web
           image: '{{ .Values.dockerImage }}'
           imagePullPolicy: Always
           args:

--- a/infrastructure/k8s/templates/taskcluster-ui-deployment-web.yaml
+++ b/infrastructure/k8s/templates/taskcluster-ui-deployment-web.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       serviceAccountName: taskcluster-ui
       containers:
-        - name: taskcluster-ui
+        - name: taskcluster-ui-web
           image: '{{ .Values.dockerImage }}'
           imagePullPolicy: Always
           args:

--- a/infrastructure/k8s/templates/taskcluster-web-server-deployment-web.yaml
+++ b/infrastructure/k8s/templates/taskcluster-web-server-deployment-web.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       serviceAccountName: taskcluster-web-server
       containers:
-        - name: taskcluster-web-server
+        - name: taskcluster-web-server-web
           image: '{{ .Values.dockerImage }}'
           imagePullPolicy: Always
           args:

--- a/infrastructure/k8s/templates/taskcluster-worker-manager-deployment-provisioner.yaml
+++ b/infrastructure/k8s/templates/taskcluster-worker-manager-deployment-provisioner.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       serviceAccountName: taskcluster-worker-manager
       containers:
-        - name: taskcluster-worker-manager
+        - name: taskcluster-worker-manager-provisioner
           image: '{{ .Values.dockerImage }}'
           imagePullPolicy: Always
           args:

--- a/infrastructure/k8s/templates/taskcluster-worker-manager-deployment-web.yaml
+++ b/infrastructure/k8s/templates/taskcluster-worker-manager-deployment-web.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       serviceAccountName: taskcluster-worker-manager
       containers:
-        - name: taskcluster-worker-manager
+        - name: taskcluster-worker-manager-web
           image: '{{ .Values.dockerImage }}'
           imagePullPolicy: Always
           args:

--- a/infrastructure/k8s/templates/taskcluster-worker-manager-deployment-workerscanner.yaml
+++ b/infrastructure/k8s/templates/taskcluster-worker-manager-deployment-workerscanner.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       serviceAccountName: taskcluster-worker-manager
       containers:
-        - name: taskcluster-worker-manager
+        - name: taskcluster-worker-manager-workerscanner
           image: '{{ .Values.dockerImage }}'
           imagePullPolicy: Always
           args:

--- a/infrastructure/tooling/templates/k8s/deployment.yaml
+++ b/infrastructure/tooling/templates/k8s/deployment.yaml
@@ -15,7 +15,7 @@ spec:
     spec:
       serviceAccountName: ${projectName}
       containers:
-      - name: ${projectName}
+      - name: ${projectName}-${lowercase(procName)}
         image: '{{ .Values.dockerImage }}'
         imagePullPolicy: Always
         args: ['${serviceName}/${procName}']


### PR DESCRIPTION
In order to track cpu and memory utilization per cronjob or deployment,
we need each one to have a unique container name. This is because
Stackdriver does not tag those metrics based on their metadata, but does
tag them based on the container name. Currently, it looks like all the
cronjobs have unique names but many of the deployments share container
names. This commit changes the deployment naming to match the cronjob
naming.

https://bugzilla.mozilla.org/show_bug.cgi?id=1616858