### PR TITLE
Rename stored db function to expire_cache_purges

### DIFF
--- a/changelog/Frzjxl83ReqEFnwDdjO2VQ.md
+++ b/changelog/Frzjxl83ReqEFnwDdjO2VQ.md
@@ -1,0 +1,3 @@
+audience: general
+level: silent
+---

--- a/db/fns.md
+++ b/db/fns.md
@@ -92,7 +92,7 @@
 | cache_purges_entities_modify | write | partition_key text, row_key text, properties jsonb, version integer, old_etag uuid | table (etag uuid) | See taskcluster-lib-entities |
 | cache_purges_entities_remove | write | partition_key text, row_key text | table (etag uuid) | See taskcluster-lib-entities |
 | cache_purges_entities_scan | read | pk text, rk text, condition text, size integer, page integer | table (partition_key text, row_key text, value jsonb, version integer, etag uuid) | See taskcluster-lib-entities |
-| cache_purges_expires | write | expires_in timestamptz | integer | Expire cache purges that come before `expires_in`.<br />Returns a count of rows that have been deleted. |
+| expire_cache_purges | write | expires_in timestamptz | integer | Expire cache purges that come before `expires_in`.<br />Returns a count of rows that have been deleted. |
 | purge_cache | write | provisioner_id_in text, worker_type_in text, cache_name_in text, before_in timestamptz, expires_in timestamptz | void | Publish a request to purge caches with name `cache_name_in`<br />on `provisioner_id_in`/`worker_type_in` workers. |
 | purge_requests | read | provisioner_id_in text, worker_type_in text | table (provisioner_id text, worker_type text, cache_name text, before timestamptz) | List the caches for this `provisioner_id_in`/`worker_type_in`. |
 ## queue

--- a/db/src/fakes/purge_cache.js
+++ b/db/src/fakes/purge_cache.js
@@ -101,7 +101,7 @@ class FakePurgeCache {
       });
   }
 
-  cache_purges_expires(exp) {
+  expire_cache_purges(exp) {
     const cachePurges = this._getCaches();
     let count = 0;
 
@@ -112,7 +112,7 @@ class FakePurgeCache {
       }
     });
 
-    return [{ 'cache_purges_expires': count }];
+    return [{ 'expire_cache_purges': count }];
   }
 
   async cache_purges_load(provisionerId, workerType, cacheName) {

--- a/db/test/fns/purge_cache_test.js
+++ b/db/test/fns/purge_cache_test.js
@@ -136,7 +136,7 @@ suite(testing.suiteName(), function() {
     compare(entries, samples);
   });
 
-  helper.dbTest('cache_purges_expires', async function(db, isFake) {
+  helper.dbTest('expire_cache_purges', async function(db, isFake) {
     const samples = [
       { provisioner_id: 'prov-3', worker_type: 'wt-3', cache_name: 'cache-3', before: fromNow('4 days'), expires: fromNow('- 1 day')},
       { provisioner_id: 'prov-3', worker_type: 'wt-3', cache_name: 'cache-4', before: fromNow('6 days'), expires: fromNow('- 2 days')},
@@ -153,7 +153,7 @@ suite(testing.suiteName(), function() {
       );
     }
 
-    const count = (await db.fns.cache_purges_expires(fromNow()))[0].cache_purges_expires;
+    const count = (await db.fns.expire_cache_purges(fromNow()))[0].expire_cache_purges;
 
     assert.equal(count, 3);
 

--- a/db/versions/0009.yml
+++ b/db/versions/0009.yml
@@ -267,7 +267,7 @@ methods:
         set (before, expires, etag) = (before_in, expires_in, new_etag)
         where cache_purges.provisioner_id = provisioner_id_in and cache_purges.worker_type = worker_type_in and cache_purges.cache_name = cache_name_in;
       end
-  cache_purges_expires:
+  expire_cache_purges:
     description: |-
       Expire cache purges that come before `expires_in`.
       Returns a count of rows that have been deleted.

--- a/generated/db-schema.json
+++ b/generated/db-schema.json
@@ -2169,7 +2169,7 @@
           "returns": "table (partition_key text, row_key text, value jsonb, version integer, etag uuid)",
           "serviceName": "purge_cache"
         },
-        "cache_purges_expires": {
+        "expire_cache_purges": {
           "args": "expires_in timestamptz",
           "body": "declare\n  count integer;\nbegin\n  delete from cache_purges where cache_purges.expires < expires_in;\n  if found then\n    get diagnostics count = row_count;\n    return count;\n  end if;\n  return 0;\nend",
           "deprecated": false,

--- a/services/purge-cache/src/main.js
+++ b/services/purge-cache/src/main.js
@@ -50,8 +50,8 @@ const load = loader({
         const now = taskcluster.fromNow(cfg.app.cachePurgeExpirationDelay);
         debug('Expiring cache-purges at: %s, from before %s', new Date(), now);
         const count = (
-          await db.fns.cache_purges_expires(now)
-        )[0].cache_purges_expires;
+          await db.fns.expire_cache_purges(now)
+        )[0].expire_cache_purges;
         debug('Expired %s cache-purges', count);
       });
     },

--- a/services/purge-cache/test/expire_test.js
+++ b/services/purge-cache/test/expire_test.js
@@ -7,7 +7,7 @@ helper.secrets.mockSuite(testing.suiteName(), ['db'], function(mock, skipping) {
   helper.withDb(mock, skipping);
 
   test('expire nothing', async function() {
-    const count = (await helper.db.fns.cache_purges_expires(new Date()))[0].cache_purges_expires;
+    const count = (await helper.db.fns.expire_cache_purges(new Date()))[0].expire_cache_purges;
     assume(count).to.equal(0);
   });
 
@@ -23,7 +23,7 @@ helper.secrets.mockSuite(testing.suiteName(), ['db'], function(mock, skipping) {
     await helper.db.fns.purge_cache(wt.provisionerId, wt.workerType, 'a', times[0], times[1]);
     await helper.db.fns.purge_cache(wt.provisionerId, wt.workerType, 'b', times[0], times[3]);
 
-    const count = (await helper.db.fns.cache_purges_expires(times[2]))[0].cache_purges_expires;
+    const count = (await helper.db.fns.expire_cache_purges(times[2]))[0].expire_cache_purges;
     assume(count).to.equal(1);
 
     const caches = await helper.db.fns.all_purge_requests(5, 0);


### PR DESCRIPTION
This function only just landed and certainly hasn't been released, so
there is no harm in changing it in-place.
