### PR TITLE
[client-web] Remove external packages from webpack external

### DIFF
--- a/changelog/issue-1536.md
+++ b/changelog/issue-1536.md
@@ -1,4 +1,4 @@
-audience: developers
+audience: users 
 level: patch
 reference: issue 1536
 ---

--- a/changelog/issue-1536.md
+++ b/changelog/issue-1536.md
@@ -1,0 +1,5 @@
+audience: developers
+level: patch
+reference: issue 1536
+---
+taskcluster-client-web no longer shows the 'hawk is undefined' regression error.

--- a/clients/client-web/.neutrinorc.js
+++ b/clients/client-web/.neutrinorc.js
@@ -45,16 +45,6 @@ module.exports = {
         neutrino.config.externals(undefined);
       } else {
         neutrino.config.devtool('source-map');
-        neutrino.config.externals({
-          hawk: 'hawk',
-          'crypto-js': 'crypto-js',
-          'query-string': {
-            commonjs: 'query-string',
-            commonjs2: 'query-string',
-            amd: 'query-string',
-            root: 'queryString',
-          },
-        });
       }
 
       neutrino.config.resolve.alias.set('hawk', 'hawk/dist/browser.js');

--- a/clients/client-web/package.json
+++ b/clients/client-web/package.json
@@ -34,9 +34,11 @@
     "webpack-cli": "^3.2.3"
   },
   "dependencies": {
+    "taskcluster-lib-urls": "^12.0.0"
+  },
+  "peerDependencies": {
     "crypto-js": "^3.1.9-1",
     "hawk": "^7.0.7",
-    "query-string": "^6.1.0",
-    "taskcluster-lib-urls": "^12.0.0"
+    "query-string": "^6.1.0"
   }
 }


### PR DESCRIPTION
Move these packages instead to the list of peer-dependencies. It has the
same effect. webpack [seems to have an issue](https://github.com/webpack/webpack/issues/4824) with externals when the
build target is umd.