### PR TITLE
Bug 1633882 - use updated call to uploadReleaseAssert

### DIFF
--- a/changelog/bug-1633882.md
+++ b/changelog/bug-1633882.md
@@ -1,0 +1,4 @@
+audience: general
+level: silent
+reference: bug 1633882
+---


### PR DESCRIPTION
See https://octokit.github.io/rest.js/v17#repos-upload-release-asset