### PR TITLE
Bug 1633882 - fix uploadReleaseAsset call

### DIFF
--- a/changelog/bug-1633882.md
+++ b/changelog/bug-1633882.md
@@ -1,0 +1,4 @@
+audience: general
+level: silent
+reference: bug 1633882
+---

--- a/infrastructure/tooling/src/publish/tasks.js
+++ b/infrastructure/tooling/src/publish/tasks.js
@@ -510,7 +510,7 @@ module.exports = ({tasks, cmdOptions, credentials, baseDir, logsDir}) => {
         .map(name => ({name, contentType: 'application/octet-stream'}));
       for (let {name, contentType} of files) {
         utils.status({message: `Upload Release asset ${name}`});
-        const file = await readFile(path.join(artifactsDir, name));
+        const data = await readFile(path.join(artifactsDir, name));
 
         /* Artifact uploads to GitHub seem to fail.. a lot.  So we retry each
          * one a few times with some delay, in hopes of getting lucky.  */
@@ -520,11 +520,11 @@ module.exports = ({tasks, cmdOptions, credentials, baseDir, logsDir}) => {
             await octokit.repos.uploadReleaseAsset({
               url: upload_url,
               headers: {
-                'content-length': file.length,
+                'content-length': data.length,
                 'content-type': contentType,
               },
               name,
-              file,
+              data,
             });
           } catch (err) {
             if (!retries) {


### PR DESCRIPTION
Bugzilla Bug: [1633882](https://bugzilla.mozilla.org/show_bug.cgi?id=1633882)

https://octokit.github.io/rest.js/v17#repos-upload-release-asset is *very* misleading.  It's correct about one of the four parameters it lists, and fails to mention three others.