### PR TITLE
Bug 1587145 - Add peer dependencies to the list of dependencies

### DIFF
--- a/clients/client-web/package.json
+++ b/clients/client-web/package.json
@@ -37,11 +37,9 @@
     "webpack-cli": "^3.2.3"
   },
   "dependencies": {
-    "taskcluster-lib-urls": "^12.0.0"
-  },
-  "peerDependencies": {
     "crypto-js": "^3.1.9-1",
     "hawk": "^7.0.7",
+    "taskcluster-lib-urls": "^12.0.0",
     "query-string": "^6.1.0"
   }
 }


### PR DESCRIPTION
Treeherder turns out no longer uses a couple of the peer dependencies. Treeherder is okay with a bigger package size so I'm adding them back here.