### PR TITLE
Use a distinct port for internalGETPort in tests, too

### DIFF
--- a/changelog/issue-2783.md
+++ b/changelog/issue-2783.md
@@ -1,0 +1,4 @@
+audience: general
+level: silent
+reference: issue 2783
+---

--- a/workers/generic-worker/helper_test.go
+++ b/workers/generic-worker/helper_test.go
@@ -163,6 +163,12 @@ func setup(t *testing.T) (teardown func()) {
 			},
 		},
 	}
+
+	// like LiveLogGETPort and LiveLogPUTPort above, we need to use a non-default port for
+	// the livelog internalGETPort, so that we don't conflict with a generic-worker in which
+	// the tests are running
+	internalGETPort = 30583
+
 	configProvider = &TestProvider{}
 	setConfigRunTasksAsCurrentUser()
 	return teardown

--- a/workers/generic-worker/livelog.go
+++ b/workers/generic-worker/livelog.go
@@ -17,8 +17,12 @@ import (
 )
 
 var (
-	livelogName     = "public/logs/live.log"
-	internalGETPort uint16
+	livelogName = "public/logs/live.log"
+
+	// The port on which the livelog process listens.  This is then proxied
+	// to the user by the exposer.  This port must be different from liveLogGETPort
+	// and liveLogPUTPort.
+	internalGETPort uint16 = 60099
 )
 
 type LiveLogFeature struct {
@@ -29,7 +33,6 @@ func (feature *LiveLogFeature) Name() string {
 }
 
 func (feature *LiveLogFeature) Initialise() error {
-	internalGETPort = config.LiveLogGETPort
 	return nil
 }
 


### PR DESCRIPTION
Fixes #2783.