### PR TITLE
Use a distinct port for internalGETPort in tests, too

### DIFF
--- a/changelog/issue-2783.md
+++ b/changelog/issue-2783.md
@@ -1,0 +1,4 @@
+audience: general
+level: silent
+reference: issue 2783
+---

--- a/workers/generic-worker/gcp_helper_test.go
+++ b/workers/generic-worker/gcp_helper_test.go
@@ -24,6 +24,12 @@ func (m *MockGCPProvisionedEnvironment) Setup(t *testing.T) func() {
 	oldGCPMetadataBaseURL := GCPMetadataBaseURL
 	GCPMetadataBaseURL = "http://localhost:13243/computeMetadata/v1"
 
+	// like LiveLogGETPort and LiveLogPUTPort below, we need to use a non-default port for
+	// the livelog internalGETPort, so that we don't conflict with a generic-worker in which
+	// the tests are running
+	oldInternalGETPort := internalGETPort
+	internalGETPort = 30583
+
 	// Create custom *http.ServeMux rather than using http.DefaultServeMux, so
 	// registered handler functions won't interfere with future tests that also
 	// use http.DefaultServeMux.
@@ -42,7 +48,9 @@ func (m *MockGCPProvisionedEnvironment) Setup(t *testing.T) func() {
 				"workerConfig": map[string]interface{}{
 					"genericWorker": map[string]interface{}{
 						"config": map[string]interface{}{
-							"deploymentId": "12345",
+							"deploymentId":   "12345",
+							"livelogGETPort": 30582,
+							"livelogPUTPort": 43264,
 						},
 					},
 				},
@@ -138,5 +146,6 @@ func (m *MockGCPProvisionedEnvironment) Setup(t *testing.T) func() {
 		t.Log("HTTP server for mock Provisioner and GCP metadata endpoints stopped")
 		GCPMetadataBaseURL = oldGCPMetadataBaseURL
 		configureForGCP = false
+		internalGETPort = oldInternalGETPort
 	}
 }

--- a/workers/generic-worker/helper_test.go
+++ b/workers/generic-worker/helper_test.go
@@ -92,8 +92,8 @@ func setupEnvironment(t *testing.T) (teardown func()) {
 	}
 }
 
-func setup(t *testing.T) (teardown func()) {
-	teardown = setupEnvironment(t)
+func setup(t *testing.T) func() {
+	teardown := setupEnvironment(t)
 	// configure the worker
 	testDir := filepath.Join(testdataDir, t.Name())
 	config = &gwconfig.Config{
@@ -163,9 +163,19 @@ func setup(t *testing.T) (teardown func()) {
 			},
 		},
 	}
+
+	// like LiveLogGETPort and LiveLogPUTPort above, we need to use a non-default port for
+	// the livelog internalGETPort, so that we don't conflict with a generic-worker in which
+	// the tests are running
+	oldInternalGETPort := internalGETPort
+	internalGETPort = 30583
+
 	configProvider = &TestProvider{}
 	setConfigRunTasksAsCurrentUser()
-	return teardown
+	return func() {
+		teardown()
+		internalGETPort = oldInternalGETPort
+	}
 }
 
 type TestProvider struct{}

--- a/workers/generic-worker/livelog.go
+++ b/workers/generic-worker/livelog.go
@@ -17,8 +17,12 @@ import (
 )
 
 var (
-	livelogName     = "public/logs/live.log"
-	internalGETPort uint16
+	livelogName = "public/logs/live.log"
+
+	// The port on which the livelog process listens.  This is then proxied
+	// to the user by the exposer.  This port must be different from liveLogGETPort
+	// and liveLogPUTPort.
+	internalGETPort uint16 = 60099
 )
 
 type LiveLogFeature struct {
@@ -29,7 +33,6 @@ func (feature *LiveLogFeature) Name() string {
 }
 
 func (feature *LiveLogFeature) Initialise() error {
-	internalGETPort = config.LiveLogGETPort
 	return nil
 }
 


### PR DESCRIPTION
Fixes #2783 (hopefully)