### PR TITLE
Generate a documented release tarball for docker-worker

### DIFF
--- a/changelog/issue-2788.md
+++ b/changelog/issue-2788.md
@@ -1,0 +1,5 @@
+audience: worker-deployers
+level: patch
+reference: issue 2788
+---
+Docker-worker releases are now included in the assets on a Taskcluster release, with a well-documented format.

--- a/generated/docs-table-of-contents.json
+++ b/generated/docs-table-of-contents.json
@@ -3644,35 +3644,13 @@
                 },
                 "name": "worker-configuration",
                 "next": {
-                  "path": "reference/workers/worker-runner/linux-services",
-                  "title": "Linux"
+                  "path": "reference/workers/worker-runner/runner-configuration",
+                  "title": "Runner Configuration"
                 },
                 "path": "reference/workers/worker-runner/worker-configuration",
                 "prev": {
                   "path": "reference/workers/worker-runner/README",
                   "title": "worker-runner"
-                },
-                "up": {
-                  "path": "reference/workers/worker-runner/README",
-                  "title": "worker-runner"
-                }
-              },
-              {
-                "children": [
-                ],
-                "data": {
-                  "order": 20,
-                  "title": "Linux"
-                },
-                "name": "linux-services",
-                "next": {
-                  "path": "reference/workers/worker-runner/runner-configuration",
-                  "title": "Runner Configuration"
-                },
-                "path": "reference/workers/worker-runner/linux-services",
-                "prev": {
-                  "path": "reference/workers/worker-runner/worker-configuration",
-                  "title": "Worker Configuration"
                 },
                 "up": {
                   "path": "reference/workers/worker-runner/README",
@@ -3693,8 +3671,8 @@
                 },
                 "path": "reference/workers/worker-runner/runner-configuration",
                 "prev": {
-                  "path": "reference/workers/worker-runner/linux-services",
-                  "title": "Linux"
+                  "path": "reference/workers/worker-runner/worker-configuration",
+                  "title": "Worker Configuration"
                 },
                 "up": {
                   "path": "reference/workers/worker-runner/README",
@@ -3710,35 +3688,13 @@
                 },
                 "name": "providers",
                 "next": {
-                  "path": "reference/workers/worker-runner/windows-services",
-                  "title": "Generic-Worker Service"
+                  "path": "reference/workers/worker-runner/workers",
+                  "title": "Workers"
                 },
                 "path": "reference/workers/worker-runner/providers",
                 "prev": {
                   "path": "reference/workers/worker-runner/runner-configuration",
                   "title": "Runner Configuration"
-                },
-                "up": {
-                  "path": "reference/workers/worker-runner/README",
-                  "title": "worker-runner"
-                }
-              },
-              {
-                "children": [
-                ],
-                "data": {
-                  "order": 30,
-                  "title": "Generic-Worker Service"
-                },
-                "name": "windows-services",
-                "next": {
-                  "path": "reference/workers/worker-runner/workers",
-                  "title": "Workers"
-                },
-                "path": "reference/workers/worker-runner/windows-services",
-                "prev": {
-                  "path": "reference/workers/worker-runner/providers",
-                  "title": "Providers"
                 },
                 "up": {
                   "path": "reference/workers/worker-runner/README",
@@ -3759,8 +3715,8 @@
                 },
                 "path": "reference/workers/worker-runner/workers",
                 "prev": {
-                  "path": "reference/workers/worker-runner/windows-services",
-                  "title": "Generic-Worker Service"
+                  "path": "reference/workers/worker-runner/providers",
+                  "title": "Providers"
                 },
                 "up": {
                   "path": "reference/workers/worker-runner/README",

--- a/infrastructure/tooling/src/publish/tasks.js
+++ b/infrastructure/tooling/src/publish/tasks.js
@@ -547,7 +547,7 @@ module.exports = ({tasks, cmdOptions, credentials, baseDir, logsDir}) => {
   ensureTask(tasks, {
     title: `Publish clients/client to npm`,
     requires: [
-      'target-monoimage', // to make sure the build succeeds first..
+      'github-releaee', // to make sure the release finishes first..
     ],
     provides: [
       `publish-clients/client`,
@@ -568,7 +568,7 @@ module.exports = ({tasks, cmdOptions, credentials, baseDir, logsDir}) => {
   ensureTask(tasks, {
     title: `Publish clients/client-web to npm`,
     requires: [
-      'target-monoimage', // to make sure the build succeeds first..
+      'github-releaee', // to make sure the release finishes first..
     ],
     provides: [
       `publish-clients/client-web`,
@@ -598,7 +598,7 @@ module.exports = ({tasks, cmdOptions, credentials, baseDir, logsDir}) => {
   ensureTask(tasks, {
     title: `Publish clients/client-py to pypi`,
     requires: [
-      'target-monoimage', // to make sure the build succeeds first..
+      'github-releaee', // to make sure the release finishes first..
     ],
     provides: [
       `publish-clients/client-py`,

--- a/infrastructure/tooling/src/publish/tasks.js
+++ b/infrastructure/tooling/src/publish/tasks.js
@@ -123,6 +123,25 @@ module.exports = ({tasks, cmdOptions, credentials, baseDir, logsDir}) => {
   });
 
   ensureTask(tasks, {
+    title: 'Build docker-worker artifacts',
+    requires: ['cleaned-release-artifacts'],
+    provides: ['docker-worker-artifacts'],
+    run: async (requirements, utils) => {
+      await execCommand({
+        dir: path.join(REPO_ROOT, 'workers', 'docker-worker'),
+        command: ['./release.sh', '-o', path.join(artifactsDir, 'docker-worker-x64.tgz')],
+        utils,
+      });
+
+      const artifacts = ['docker-worker-x64.tgz'];
+
+      return {
+        'generic-worker-artifacts': artifacts,
+      };
+    },
+  });
+
+  ensureTask(tasks, {
     title: 'Build generic-worker artifacts',
     requires: ['cleaned-release-artifacts'],
     provides: ['generic-worker-artifacts'],
@@ -471,6 +490,7 @@ module.exports = ({tasks, cmdOptions, credentials, baseDir, logsDir}) => {
       'release-version',
       'client-shell-artifacts',
       'generic-worker-artifacts',
+      'docker-worker-artifacts',
       'worker-runner-artifacts',
       //'taskcluster-proxy-artifacts',
       'changelog-text',
@@ -504,6 +524,7 @@ module.exports = ({tasks, cmdOptions, credentials, baseDir, logsDir}) => {
 
       const files = requirements['client-shell-artifacts']
         .concat(requirements['generic-worker-artifacts'])
+        .concat(requirements['docker-worker-artifacts'])
         .concat(requirements['worker-runner-artifacts'])
         .concat(requirements['livelog-artifacts'])
         //.concat(requirements['taskcluster-proxy-artifacts'])
@@ -547,7 +568,7 @@ module.exports = ({tasks, cmdOptions, credentials, baseDir, logsDir}) => {
   ensureTask(tasks, {
     title: `Publish clients/client to npm`,
     requires: [
-      'github-releaee', // to make sure the release finishes first..
+      'github-release', // to make sure the release finishes first..
     ],
     provides: [
       `publish-clients/client`,
@@ -568,7 +589,7 @@ module.exports = ({tasks, cmdOptions, credentials, baseDir, logsDir}) => {
   ensureTask(tasks, {
     title: `Publish clients/client-web to npm`,
     requires: [
-      'github-releaee', // to make sure the release finishes first..
+      'github-release', // to make sure the release finishes first..
     ],
     provides: [
       `publish-clients/client-web`,
@@ -598,7 +619,7 @@ module.exports = ({tasks, cmdOptions, credentials, baseDir, logsDir}) => {
   ensureTask(tasks, {
     title: `Publish clients/client-py to pypi`,
     requires: [
-      'github-releaee', // to make sure the release finishes first..
+      'github-release', // to make sure the release finishes first..
     ],
     provides: [
       `publish-clients/client-py`,

--- a/tools/worker-runner/worker/dockerworker/dockerworker_test.go
+++ b/tools/worker-runner/worker/dockerworker/dockerworker_test.go
@@ -1,0 +1,84 @@
+// +build linux
+
+package dockerworker
+
+import (
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/Flaque/filet"
+	"github.com/stretchr/testify/require"
+	"github.com/taskcluster/taskcluster/v29/tools/worker-runner/cfg"
+	"github.com/taskcluster/taskcluster/v29/tools/worker-runner/run"
+)
+
+func TestStartWorkerJSFile(t *testing.T) {
+	defer filet.CleanUp(t)
+	dir := filet.TmpDir(t, "")
+
+	// this test requires `node` be in the path (part of the reason for
+	// introducing the docker-worker tarball format), so if that is not
+	// available then skip the test.
+	_, err := exec.LookPath("node")
+	if err != nil {
+		t.Skip("'node' is not the path")
+	}
+
+	// set up dir/repo/src/bin/worker.js to be a short node program that
+	// just exits successfully
+	binDir := filepath.Join(dir, "repo", "src", "bin")
+	require.NoError(t, os.MkdirAll(binDir, 0755))
+	workerJs := filepath.Join(binDir, "worker.js")
+	require.NoError(t, ioutil.WriteFile(workerJs, []byte("process.exit(0)"), 0644))
+
+	dw := dockerworker{
+		wicfg: dockerworkerConfig{
+			Path:       filepath.Join(dir, "repo"),
+			ConfigPath: filepath.Join(dir, "config.json"),
+		},
+	}
+	state := run.State{
+		// lots of omitted fields that aren't used
+		WorkerConfig: cfg.NewWorkerConfig(),
+	}
+	_, err = dw.StartWorker(&state)
+	require.NoError(t, err)
+
+	require.NoError(t, dw.Wait())
+}
+
+func TestStartWorkerReleaseTarball(t *testing.T) {
+	defer filet.CleanUp(t)
+	dir := filet.TmpDir(t, "")
+
+	// set up dir/repo/src/bin/worker.js to be a short node program that
+	// just exits successfully
+	binDir := filepath.Join(dir, "docker-worker", "bin")
+	require.NoError(t, os.MkdirAll(binDir, 0755))
+	workerScript := filepath.Join(binDir, "docker-worker")
+	require.NoError(t, ioutil.WriteFile(workerScript, []byte(`#! /bin/sh
+		bail() { echo "fake docker-worker: $1" >&2; exit 1; }
+		[ "$#" = "3" ] || bail "wrong number of args ($#)"
+		[ "$1" = "--host" ] || bail "no --host"
+		[ "$2" = "worker-runner" ] || bail "no worker-runner"
+		[ "$3" = "production" ] || bail "no prodcution"
+	`), 0755))
+
+	dw := dockerworker{
+		wicfg: dockerworkerConfig{
+			Path:       filepath.Join(dir, "docker-worker"),
+			ConfigPath: filepath.Join(dir, "config.json"),
+		},
+	}
+	state := run.State{
+		// lots of omitted fields that aren't used
+		WorkerConfig: cfg.NewWorkerConfig(),
+	}
+	_, err := dw.StartWorker(&state)
+	require.NoError(t, err)
+
+	require.NoError(t, dw.Wait())
+}

--- a/ui/docs/reference/workers/docker-worker/deployment.md
+++ b/ui/docs/reference/workers/docker-worker/deployment.md
@@ -1,0 +1,30 @@
+---
+title: Deployment
+order: 80
+---
+
+# Deployment
+
+Docker worker is released as part of the full Taskcluster release cycle.
+The release takes the form of a tarball, `docker-worker-x64.tgz`, attached to the Taskcluster release on the GitHub repository.
+This tarball is specific to the Linux x64 architecture.
+
+## Release Format
+
+The release tarball contains the docker-worker source and its dependencies as well as a copy of the correct Node version.
+It has a top-level directory named `docker-worker` and the entry point to run the worker is `docker-worker/bin/docker-worker`.
+
+The tarball can be extracted anywhere on the filesystem that is convenient.
+For example:
+
+```shell
+tar -C /usr/local -zxf docker-worker-x64.tgz
+```
+
+The corresponding worker-runner config would contain
+
+```yaml
+worker:
+    implementation: docker-worker
+    path: /usr/local/docker-worker
+```

--- a/ui/docs/reference/workers/worker-runner/linux-services.mdx
+++ b/ui/docs/reference/workers/worker-runner/linux-services.mdx
@@ -1,5 +1,0 @@
----
-title: Linux
-order: 20
----
-

--- a/ui/docs/reference/workers/worker-runner/windows-services.mdx
+++ b/ui/docs/reference/workers/worker-runner/windows-services.mdx
@@ -1,5 +1,0 @@
----
-title: Generic-Worker Service
-order: 30
----
-

--- a/ui/docs/reference/workers/worker-runner/workers.mdx
+++ b/ui/docs/reference/workers/worker-runner/workers.mdx
@@ -19,8 +19,8 @@ values in the 'worker' section of the runner configuration:
 ```yaml
 worker:
     implementation: docker-worker
-    # path to the root of the docker-worker repo clone
-    path: /path/to/docker-worker/repo
+    # path to the 'docker-worker' directory from the docker-worker release tarball
+    path: /path/to/docker-worker
     # path where worker-runner should write the generated
     # docker-worker configuration.
     configPath: ..

--- a/workers/docker-worker/release.sh
+++ b/workers/docker-worker/release.sh
@@ -1,30 +1,54 @@
-#!/bin/bash -e
+#! /bin/bash
 
-echo "Releasing docker-worker on Github"
+set -ex
 
-if [ "$DOCKER_WORKER_GITHUB_TOKEN" == "" ]; then
-  echo "You need to define the environment variable DOCKER_WORKER_GITHUB_TOKEN" >&2
-  echo "with a valid Github personal token." >&2
-  echo "If you intended to only deploy AMIs, then run the deploy.sh script." >&2
-  exit 1
-fi
+OUTPUT=docker-worker-x64.tgz
+while getopts "o:" opt; do
+    case "${opt}" in
+        o)  OUTPUT=$OPTARG
+            ;;
+    esac
+done
 
-remote=$(git remote -v | grep 'taskcluster/docker-worker' | head -1 | awk '{print $1}')
-if [ "$remote" == "" ]; then
-  git remote add tcdw git@github.com/taskcluster/docker-worker
-  remote=tcdw
-fi
+DW_ROOT=$(mktemp -d)
+trap "rm -rf $DW_ROOT" EXIT
 
-git fetch $remote
+# create an easy-to-use thing that will find the right paths, etc.
+mkdir -p $DW_ROOT/bin
+cat > $DW_ROOT/bin/docker-worker <<'EOF'
+#! /bin/bash
+DW_ROOT="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." >/dev/null 2>&1 && pwd )"
+NODE=$DW_ROOT/node/bin/node
+exec $NODE $DW_ROOT/src/bin/worker.js "${@}"
+EOF
+chmod +x $DW_ROOT/bin/docker-worker
 
-branch=$(git rev-parse --abbrev-ref HEAD)
-current_branch_head_sha=$(git rev-parse $branch)
-remote_branch_head_sha=$(git rev-parse $remote/$branch)
+# install docker-worker itself
+for f in src schemas .npmignore package.json yarn.lock config.yml bin-utils; do
+    cp -r $PWD/$f $DW_ROOT
+done
 
-if [ "$current_branch_head_sha" != "$remote_branch_head_sha" ]; then
-  echo "$branch and $remote/$branch mismatch!" >&2
-  exit 1
-fi
+# Install Node
+NODE_VERSION=12.11.0
+mkdir $DW_ROOT/node
+curl https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-x64.tar.xz | tar -C $DW_ROOT/node --strip-components=1 -xJf -
 
-release_name=$(deploy/bin/github-release.js)
-echo "$release_name has been released at https://github.com/taskcluster/docker-worker/releases/tag/$release_name"
+# Install Yarn (later to be removed)
+curl -L https://yarnpkg.com/latest.tar.gz | tar --transform 's|yarn-[^/]*/|yarn/|' -C $DW_ROOT -zvxf -
+
+# Install dependencies
+PATH=$DW_ROOT/node/bin:$DW_ROOT/node_modules/.bin:$PATH
+(
+    cd $DW_ROOT
+    ./yarn/bin/yarn install --dev
+)
+
+# Clean up some stuff
+rm -rf "$DW_ROOT/yarn"
+rm -rf "$DW_ROOT/node/include"
+rm -rf "$DW_ROOT/node/lib/node_modules/npm"
+rm -rf "$DW_ROOT/node/bin/npm"
+rm -rf "$DW_ROOT/node/bin/npx"
+
+# tar up the result..
+tar -C $DW_ROOT --transform 's|^\./|docker-worker/|' -czf $OUTPUT .


### PR DESCRIPTION
Github Bug/Issue: Fixes #2788

There's a staging push [here](https://github.com/taskcluster/taskcluster/runs/657783821)

I snuck in an unrelated commit here to avoid uploading packges to npm / pypi until the GH release is done.