### PR TITLE
Use the proj-taskcluster/dw-ci builder for docker-worker tests

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -415,7 +415,7 @@ tasks:
               - queue:route:checks
           dockerWorkerTasks: # These remain separate from workerTasks for now until we audit permissions (bug 1635985)
           - provisionerId: proj-taskcluster
-            workerType: ci
+            workerType: dw-ci
             taskId: {$eval: as_slugid("docker-worker-lint")}
             taskGroupId: {$eval: as_slugid('taskGroupId')}
             created: {$fromNow: ''}


### PR DESCRIPTION
Github Bug/Issue: Refs https://github.com/mozilla/community-tc-config/pull/265