### PR TITLE
Bug 1637104 - use static binaries in utility docker images

### DIFF
--- a/changelog/bug-1637104.md
+++ b/changelog/bug-1637104.md
@@ -1,0 +1,5 @@
+audience: deployers
+level: patch
+reference: bug 1637104
+---
+The livelog, taskcluster-proxy, and websocktunnel Docker images now use statically-linked binaries, meaning they will not fail on startup.

--- a/infrastructure/tooling/src/publish/tasks.js
+++ b/infrastructure/tooling/src/publish/tasks.js
@@ -246,7 +246,7 @@ module.exports = ({tasks, cmdOptions, credentials, baseDir, logsDir}) => {
         dir: REPO_ROOT,
         logfile: path.join(logsDir, '/websocktunnel-build.log'),
         utils,
-        env: process.env,
+        env: {CGO_ENABLED: '0', ...process.env},
       });
 
       utils.step({title: 'Building Docker Image'});
@@ -326,7 +326,7 @@ module.exports = ({tasks, cmdOptions, credentials, baseDir, logsDir}) => {
         dir: REPO_ROOT,
         logfile: path.join(logsDir, 'livelog-build.log'),
         utils,
-        env: process.env,
+        env: {CGO_ENABLED: '0', ...process.env},
       });
 
       utils.step({title: 'Building Docker Image'});
@@ -402,7 +402,7 @@ module.exports = ({tasks, cmdOptions, credentials, baseDir, logsDir}) => {
         dir: REPO_ROOT,
         logfile: path.join(logsDir, 'taskcluster-proxy-build.log'),
         utils,
-        env: process.env,
+        env: {CGO_ENABLED: '0', ...process.env},
       });
 
       utils.step({title: 'Building Docker Image'});


### PR DESCRIPTION
Bugzilla Bug: [1637104](https://bugzilla.mozilla.org/show_bug.cgi?id=1637104)
