### PR TITLE
Build docker-worker tarballs in an environment that can compile extensions

### DIFF
--- a/changelog/issue-2808.md
+++ b/changelog/issue-2808.md
@@ -1,0 +1,4 @@
+audience: general
+level: silent
+reference: issue 2808
+---

--- a/workers/docker-worker/release.sh
+++ b/workers/docker-worker/release.sh
@@ -29,6 +29,7 @@ for f in src schemas .npmignore package.json yarn.lock config.yml bin-utils; do
 done
 
 # Install Node
+# TODO: use the same node version as everything else, bug 1636164
 NODE_VERSION=12.11.0
 mkdir $DW_ROOT/node
 curl https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-x64.tar.xz | tar -C $DW_ROOT/node --strip-components=1 -xJf -


### PR DESCRIPTION
Github Bug/Issue: Fixes #2808

I took the third option, running this build in a docker image.  This also drops some TODOs to sort out the node versions, but that's going to be fixed soon in the ref'd bug.