### PR TITLE
Bug 1635897 - use repos.getCommit for getting releases' sha

### DIFF
--- a/changelog/bug-1635897.md
+++ b/changelog/bug-1635897.md
@@ -1,0 +1,5 @@
+audience: users
+level: patch
+reference: bug 1635897
+---
+Taskcluster-GitHub now correctly determines the sha for releases from signed tags.

--- a/services/github/src/handlers.js
+++ b/services/github/src/handlers.js
@@ -612,12 +612,13 @@ async function jobHandler(message) {
   let pullNumber = message.payload.details['event.pullNumber'];
   if (!sha) {
     debug('Trying to get commit info in job handler...');
-    let commitInfo = await instGithub.git.getRef({
+    let commitInfo = await instGithub.repos.getCommit({
+      headers: {accept: 'application/vnd.github.3.sha'},
       owner: organization,
       repo: repository,
-      ref: `tags/${message.payload.details['event.version']}`,
+      ref: `refs/tags/${message.payload.details['event.version']}`,
     });
-    sha = commitInfo.data.object.sha;
+    sha = commitInfo.data;
   }
 
   debug(`handling ${message.payload.details['event.type']} webhook for: ${organization}/${repository}@${sha}`);


### PR DESCRIPTION
Bugzilla Bug: [1635897](https://bugzilla.mozilla.org/show_bug.cgi?id=1635897)