### PR TITLE
Return correct dependency value for docker-worker artifact

### DIFF
--- a/infrastructure/tooling/src/publish/tasks.js
+++ b/infrastructure/tooling/src/publish/tasks.js
@@ -174,7 +174,7 @@ module.exports = ({tasks, cmdOptions, credentials, baseDir, logsDir}) => {
       const artifacts = ['docker-worker-x64.tgz'];
 
       return {
-        'generic-worker-artifacts': artifacts,
+        'docker-worker-artifacts': artifacts,
       };
     },
   });


### PR DESCRIPTION
This is what caused the 29.5.0 release to succeed but not do anything.