### PR TITLE
Bug 1638002 - use region / location for workerGroup in dynamically-provisioned workers

### DIFF
--- a/changelog/bug-1638002.md
+++ b/changelog/bug-1638002.md
@@ -1,0 +1,5 @@
+audience: users
+level: minor
+reference: bug 1638002
+---
+The Azure, AWS, and Google worker provisioners now use an instance's region or location as `workerGroup`, instead of the worker pool's `providerId`.

--- a/services/worker-manager/src/providers/aws.js
+++ b/services/worker-manager/src/providers/aws.js
@@ -130,7 +130,7 @@ class AwsProvider extends Provider {
         rootUrl: this.rootUrl,
         workerPoolId,
         providerId: this.providerId,
-        workerGroup: this.providerId,
+        workerGroup: config.region,
         // NOTE: workerConfig is deprecated and isn't used after worker-runner v29.0.1
         workerConfig: config.workerConfig || {},
       }));
@@ -224,14 +224,14 @@ class AwsProvider extends Provider {
         this.monitor.log.workerRequested({
           workerPoolId,
           providerId: this.providerId,
-          workerGroup: this.providerId,
+          workerGroup: config.region,
           workerId: i.InstanceId,
         });
         const now = new Date();
         return this.Worker.create({
           workerPoolId,
           providerId: this.providerId,
-          workerGroup: this.providerId,
+          workerGroup: config.region,
           workerId: i.InstanceId,
           created: now,
           lastModified: now,

--- a/services/worker-manager/src/providers/azure.js
+++ b/services/worker-manager/src/providers/azure.js
@@ -158,12 +158,16 @@ class AzureProvider extends Provider {
       const networkInterfaceName = `nic-${nicerId()}`.slice(0, 24);
       const diskName = `disk-${nicerId()}`.slice(0, 24);
 
+      // workerGroup is the azure location; this is a required field in the config
+      const workerGroup = cfg.location;
+      assert(workerGroup, 'cfg.location is not set');
+
       // Note: worker-runner 1.0.3 and higher ignore customData due to
       // https://github.com/MicrosoftDocs/azure-docs/issues/30370
       const customData = Buffer.from(JSON.stringify({
         workerPoolId,
         providerId: this.providerId,
-        workerGroup: this.providerId,
+        workerGroup,
         rootUrl: this.rootUrl,
         // NOTE: workerConfig is deprecated and isn't used after worker-runner v29.0.1
         workerConfig: cfg.workerConfig || {},
@@ -202,7 +206,7 @@ class AzureProvider extends Provider {
           'created-by': `taskcluster-wm-${this.providerId}`,
           'managed-by': 'taskcluster',
           'provider-id': this.providerId,
-          'worker-group': this.providerId,
+          'worker-group': workerGroup,
           'worker-pool-id': workerPoolId,
           'root-url': this.rootUrl,
           'owner': workerPool.owner,
@@ -238,14 +242,14 @@ class AzureProvider extends Provider {
       this.monitor.log.workerRequested({
         workerPoolId,
         providerId: this.providerId,
-        workerGroup: this.providerId,
+        workerGroup,
         workerId: virtualMachineName,
       });
       const now = new Date();
       await this.Worker.create({
         workerPoolId,
         providerId: this.providerId,
-        workerGroup: this.providerId,
+        workerGroup,
         workerId: virtualMachineName,
         created: now,
         lastModified: now,

--- a/services/worker-manager/src/providers/google.js
+++ b/services/worker-manager/src/providers/google.js
@@ -223,6 +223,7 @@ class GoogleProvider extends Provider {
       // workers in taskcluster.
       const poolName = workerPoolId.replace(/[\/_]/g, '-').slice(0, 38);
       const instanceName = `${poolName}-${slugid.nice().replace(/_/g, '-').toLowerCase()}`;
+      const workerGroup = cfg.region;
       const labels = {
         'created-by': `taskcluster-wm-${this.providerId}`.replace(/[^a-zA-Z0-9-]/g, '-'),
         'managed-by': 'taskcluster',
@@ -280,7 +281,7 @@ class GoogleProvider extends Provider {
                   value: JSON.stringify({
                     workerPoolId,
                     providerId: this.providerId,
-                    workerGroup: this.providerId,
+                    workerGroup,
                     rootUrl: this.rootUrl,
                     // NOTE: workerConfig is deprecated and isn't used after worker-runner v29.0.1
                     workerConfig: cfg.workerConfig || {},
@@ -309,14 +310,14 @@ class GoogleProvider extends Provider {
       this.monitor.log.workerRequested({
         workerPoolId,
         providerId: this.providerId,
-        workerGroup: this.providerId,
+        workerGroup,
         workerId: op.targetId,
       });
       const now = new Date();
       await this.Worker.create({
         workerPoolId,
         providerId: this.providerId,
-        workerGroup: this.providerId,
+        workerGroup,
         workerId: op.targetId,
         created: now,
         lastModified: now,

--- a/services/worker-manager/test/fake-aws.js
+++ b/services/worker-manager/test/fake-aws.js
@@ -15,7 +15,7 @@ module.exports = {
             InstanceType: launchConfig.InstanceType || 'm2.micro',
             Architecture: 'x86',
             Placement: {
-              AvailabilityZone: 'someregion',
+              AvailabilityZone: 'some-region-c',
             },
             PrivateIpAddress: '1.1.1.1',
             OwnerId: '123123123',

--- a/services/worker-manager/test/provider_aws_test.js
+++ b/services/worker-manager/test/provider_aws_test.js
@@ -32,7 +32,7 @@ helper.secrets.mockSuite(testing.suiteName(), ['db'], function(mock, skipping) {
   };
   const defaultWorker = {
     workerPoolId,
-    workerGroup: providerId,
+    workerGroup: 'us-west-2',
     providerId,
     created: taskcluster.fromNow('0 seconds'),
     expires: taskcluster.fromNow('90 seconds'),
@@ -132,7 +132,7 @@ helper.secrets.mockSuite(testing.suiteName(), ['db'], function(mock, skipping) {
 
       workers.entries.forEach(w => {
         assert.strictEqual(w.workerPoolId, workerPoolId, 'Worker was created for a wrong worker pool');
-        assert.strictEqual(w.workerGroup, providerId, 'Worker group id should be the same as provider id');
+        assert.strictEqual(w.workerGroup, 'us-west-2', 'Worker group should be az');
         assert.strictEqual(w.state, helper.Worker.states.REQUESTED, 'Worker should be marked as requested');
         assert.strictEqual(w.providerData.region, defaultLaunchConfig.region, 'Region should come from the chosen config');
         // Check that this is setting times correctly to within a second or so to allow for some time
@@ -312,7 +312,7 @@ helper.secrets.mockSuite(testing.suiteName(), ['db'], function(mock, skipping) {
           rootUrl: provider.rootUrl,
           workerPoolId: workerPool.workerPoolId,
           providerId: provider.providerId,
-          workerGroup: provider.providerId,
+          workerGroup: 'us-west-2',
           workerConfig: workerPool.config.launchConfigs[0].workerConfig,
         } // eslint-disable-line comma-dangle
       );

--- a/services/worker-manager/test/provider_azure_test.js
+++ b/services/worker-manager/test/provider_azure_test.js
@@ -120,6 +120,7 @@ helper.secrets.mockSuite(testing.suiteName(), ['db'], function(mock, skipping) {
     // for the provisioning loop
     assert(workers.entries[0].providerData.terminateAfter - now - (6000 * 1000) < 5000);
     assert.equal(workers.entries[0].workerPoolId, workerPoolId);
+    assert.equal(workers.entries[0].workerGroup, 'westus');
   });
 
   test('provisioning loop with failure', async function() {
@@ -162,7 +163,7 @@ helper.secrets.mockSuite(testing.suiteName(), ['db'], function(mock, skipping) {
   test.skip('removeWorker deletes VM if it exists and has an id', async function() {
     const worker = await helper.Worker.create({
       workerPoolId,
-      workerGroup: 'whatever',
+      workerGroup: 'westus',
       workerId: 'whatever',
       providerId,
       created: taskcluster.fromNow('0 seconds'),
@@ -187,7 +188,7 @@ helper.secrets.mockSuite(testing.suiteName(), ['db'], function(mock, skipping) {
   test('checkWorker calls removeWorker() if worker is stopping', async function() {
     const worker = await helper.Worker.create({
       workerPoolId,
-      workerGroup: 'whatever',
+      workerGroup: 'westus',
       workerId: 'whatever',
       providerId,
       created: taskcluster.fromNow('0 seconds'),
@@ -250,7 +251,7 @@ helper.secrets.mockSuite(testing.suiteName(), ['db'], function(mock, skipping) {
     const expires = taskcluster.fromNow('-1 week');
     const worker = await helper.Worker.create({
       workerPoolId,
-      workerGroup: 'whatever',
+      workerGroup: 'westus',
       workerId: 'whatever',
       providerId,
       created: taskcluster.fromNow('-2 weeks'),
@@ -272,7 +273,7 @@ helper.secrets.mockSuite(testing.suiteName(), ['db'], function(mock, skipping) {
   test('remove unregistered workers', async function() {
     const worker = await helper.Worker.create({
       workerPoolId,
-      workerGroup: 'whatever',
+      workerGroup: 'westus',
       workerId: 'whatever',
       providerId,
       capacity: 1,
@@ -299,7 +300,7 @@ helper.secrets.mockSuite(testing.suiteName(), ['db'], function(mock, skipping) {
   test('don\'t remove unregistered workers that are new', async function() {
     const worker = await helper.Worker.create({
       workerPoolId,
-      workerGroup: 'whatever',
+      workerGroup: 'westus',
       workerId: 'whatever',
       providerId,
       created: taskcluster.fromNow('-1 hour'),
@@ -325,7 +326,7 @@ helper.secrets.mockSuite(testing.suiteName(), ['db'], function(mock, skipping) {
   test('remove very old workers', async function() {
     const worker = await helper.Worker.create({
       workerPoolId,
-      workerGroup: 'whatever',
+      workerGroup: 'westus',
       workerId: 'whatever',
       providerId,
       capacity: 1,
@@ -352,7 +353,7 @@ helper.secrets.mockSuite(testing.suiteName(), ['db'], function(mock, skipping) {
   test('don\'t remove current workers', async function() {
     const worker = await helper.Worker.create({
       workerPoolId,
-      workerGroup: 'whatever',
+      workerGroup: 'westus',
       workerId: 'whatever',
       providerId,
       created: taskcluster.fromNow('-1 hour'),
@@ -376,7 +377,7 @@ helper.secrets.mockSuite(testing.suiteName(), ['db'], function(mock, skipping) {
   });
 
   suite('registerWorker', function() {
-    const workerGroup = providerId;
+    const workerGroup = 'westus';
     const vmId = '5d06deb3-807b-46dd-aef5-78aaf9193f71';
     const defaultWorker = {
       workerPoolId,

--- a/services/worker-manager/test/provider_google_test.js
+++ b/services/worker-manager/test/provider_google_test.js
@@ -101,6 +101,8 @@ helper.secrets.mockSuite(testing.suiteName(), ['db'], function(mock, skipping) {
       name: 'foo',
       zone: 'whatever/a',
     });
+    // TODO: check that the metadata in the compute.instance.insert call has correct properties
+    // https://github.com/taskcluster/taskcluster/issues/2827
   });
 
   test('provisioning loop with failure', async function() {
@@ -158,7 +160,7 @@ helper.secrets.mockSuite(testing.suiteName(), ['db'], function(mock, skipping) {
     const workerId = '12345';
     const worker = await helper.Worker.create({
       workerPoolId,
-      workerGroup: 'whatever',
+      workerGroup: 'us-east1',
       workerId,
       providerId,
       created: taskcluster.fromNow('0 seconds'),
@@ -183,7 +185,7 @@ helper.secrets.mockSuite(testing.suiteName(), ['db'], function(mock, skipping) {
     const worker = await helper.Worker.load({
       workerPoolId: 'foo/bar',
       workerId: '123',
-      workerGroup: 'google',
+      workerGroup: 'us-east1',
     });
 
     assert(worker.providerData.operation);
@@ -208,7 +210,7 @@ helper.secrets.mockSuite(testing.suiteName(), ['db'], function(mock, skipping) {
     const expires = taskcluster.fromNow('-1 week');
     const worker = await helper.Worker.create({
       workerPoolId,
-      workerGroup: 'whatever',
+      workerGroup: 'us-east1',
       workerId: 'whatever',
       providerId,
       created: taskcluster.fromNow('-2 weeks'),
@@ -228,7 +230,7 @@ helper.secrets.mockSuite(testing.suiteName(), ['db'], function(mock, skipping) {
   test('remove unregistered workers', async function() {
     const worker = await helper.Worker.create({
       workerPoolId,
-      workerGroup: 'whatever',
+      workerGroup: 'us-east1',
       workerId: 'whatever',
       providerId,
       capacity: 1,
@@ -251,7 +253,7 @@ helper.secrets.mockSuite(testing.suiteName(), ['db'], function(mock, skipping) {
   test('don\'t remove unregistered workers that are new', async function() {
     const worker = await helper.Worker.create({
       workerPoolId,
-      workerGroup: 'whatever',
+      workerGroup: 'us-east1',
       workerId: 'whatever',
       providerId,
       created: taskcluster.fromNow('-1 hour'),
@@ -274,7 +276,7 @@ helper.secrets.mockSuite(testing.suiteName(), ['db'], function(mock, skipping) {
   test('remove very old workers', async function() {
     const worker = await helper.Worker.create({
       workerPoolId,
-      workerGroup: 'whatever',
+      workerGroup: 'us-east1',
       workerId: 'whatever',
       providerId,
       capacity: 1,
@@ -297,7 +299,7 @@ helper.secrets.mockSuite(testing.suiteName(), ['db'], function(mock, skipping) {
   test('don\'t remove current workers', async function() {
     const worker = await helper.Worker.create({
       workerPoolId,
-      workerGroup: 'whatever',
+      workerGroup: 'us-east1',
       workerId: 'whatever',
       providerId,
       capacity: 1,
@@ -367,7 +369,7 @@ helper.secrets.mockSuite(testing.suiteName(), ['db'], function(mock, skipping) {
   });
 
   suite('registerWorker', function() {
-    const workerGroup = providerId;
+    const workerGroup = 'us-east1';
     const workerId = 'abc123';
 
     const defaultWorker = {

--- a/ui/docs/reference/core/worker-manager/aws.mdx
+++ b/ui/docs/reference/core/worker-manager/aws.mdx
@@ -15,10 +15,12 @@ The provider starts workers with a JSON object in user-data containing the follo
 * `workerPoolId` -- worker pool for this worker
 * `rootUrl` -- root URL for the Taskcluster deployment
 * `providerId` -- provider ID that started the worker
-* `workerGroup` -- the worker's workerGroup (currently equal to the providerId, but do not depend on this)
+* `workerGroup` -- the worker's region
 * `workerConfig` -- worker configuration supplied as part of the worker pool configuration (deprecated; use the result of `registerWorker` instead)
 
 The worker's `workerId` is identical to its instance ID, which the worker can retrieve from the AWS metadata service.
+This should be unique within the scope of the `workerGroup` (region).
+Note that the `workerGroup` does not include the availability zone, as this information is not always available until after the worker has been created.
 
 The worker should call `workerManager.registerWorker` with an `workerIdentityProof` containing properties
 

--- a/ui/docs/reference/core/worker-manager/azure.mdx
+++ b/ui/docs/reference/core/worker-manager/azure.mdx
@@ -26,7 +26,7 @@ The provider starts workers with an instance attribute named `taskcluster` conta
 
 * `workerPoolId` -- worker pool for this worker
 * `providerId` -- provider ID that started the worker
-* `workerGroup` -- the worker's workerGroup (currently equal to the providerId, but do not depend on this)
+* `workerGroup` -- the `location` of the launchConfig used to start the worker
 * `rootUrl` -- root URL for the Taskcluster deployment
 * `workerConfig` -- worker configuration supplied as part of the worker pool configuration (deprecated; use the result of `registerWorker` instead)
 

--- a/ui/docs/reference/core/worker-manager/google.mdx
+++ b/ui/docs/reference/core/worker-manager/google.mdx
@@ -20,7 +20,7 @@ The provider starts workers with an instance attribute named `taskcluster` conta
 
 * `workerPoolId` -- worker pool for this worker
 * `providerId` -- provider ID that started the worker
-* `workerGroup` -- the worker's workerGroup (currently equal to the providerId, but do not depend on this)
+* `workerGroup` -- the worker's region (taken from the launchConfig used to start the worker)
 * `rootUrl` -- root URL for the Taskcluster deployment
 * `workerConfig` -- worker configuration supplied as part of the worker pool configuration (deprecated; use the result of `registerWorker` instead)
 


### PR DESCRIPTION
Bugzilla Bug: [1638002](https://bugzilla.mozilla.org/show_bug.cgi?id=1638002)

Note that for AWS this is the best we can get, as it's possible to configure EC2 launchConfigs to allow EC2 to select the AZ.  For Azure, location is as specific as it gets.  But for Google, we could potentially use `cfg.zone` as that's a required configuration value.