### PR TITLE
[Bug 1638047] - limit log viewer to public text/plain *.log files

### DIFF
--- a/changelog/bug-1638047.md
+++ b/changelog/bug-1638047.md
@@ -2,4 +2,4 @@ audience: general
 level: patch
 reference: bug 1638047
 ---
-This release fixes a bug where the web UI opens the log viewer for any `text/plain` artifacts, which breaks for private artifacts. The web UI will now only use the log viewer for public `text/plain` `*.log` files.
+This release fixes a bug where the web UI opens the log viewer for any `text/plain` artifacts, which breaks for private artifacts. The web UI will now only use the log viewer for `text/plain` `*.log` files.

--- a/changelog/bug-1638047.md
+++ b/changelog/bug-1638047.md
@@ -1,0 +1,5 @@
+audience: general
+level: patch
+reference: bug 1638047
+---
+This release fixes a bug where the web UI opens the log viewer for any `text/plain` artifacts, which breaks for private artifacts. The web UI will now only use the log viewer for public `text/plain` `*.log` files.

--- a/services/web-server/src/entities/Artifact.js
+++ b/services/web-server/src/entities/Artifact.js
@@ -3,7 +3,8 @@ module.exports = class Artifact {
     Object.assign(this, data);
     this.taskId = taskId;
     this.isPublic = /^public\//.test(this.name);
-    this.isLog = /^text\/plain*/.test(this.contentType);
+    // bug 1638047 - limit log viewer to public text/plain *.log files
+    this.isLog = /^text\/plain.*/.test(this.contentType) && /\.log$/.test(this.name) && this.isPublic;
 
     if (runId) {
       this.runId = runId;

--- a/services/web-server/src/entities/Artifact.js
+++ b/services/web-server/src/entities/Artifact.js
@@ -4,7 +4,7 @@ module.exports = class Artifact {
     this.taskId = taskId;
     this.isPublic = /^public\//.test(this.name);
     // bug 1638047 - limit log viewer to public text/plain *.log files
-    this.isLog = /^text\/plain.*/.test(this.contentType) && /\.log$/.test(this.name) && this.isPublic;
+    this.isLog = /^text\/plain.*/.test(this.contentType) && /\.log$/.test(this.name);
 
     if (runId) {
       this.runId = runId;


### PR DESCRIPTION
Bugzilla Bug: [1638047](https://bugzilla.mozilla.org/show_bug.cgi?id=1638047)