### PR TITLE
Truncate multiple tables at once in testing

### DIFF
--- a/changelog/YbCrJBWqTLW2KDAMYuCF0A.md
+++ b/changelog/YbCrJBWqTLW2KDAMYuCF0A.md
@@ -1,0 +1,3 @@
+audience: general
+level: silent
+---

--- a/dev-docs/postgres-phase-2-guidelines.md
+++ b/dev-docs/postgres-phase-2-guidelines.md
@@ -96,7 +96,7 @@ In the version test, include a copy of the `Entity` configuration from the
 service's `data.js`, stripped of comments and older versions.  Use
 `helper.testEntityTable` to easily test the version.
 
-When running the service's unit tests, you will probably need to update the tests to clear out the new table instead of the old.  This is typically, but not always, a `resetTable` call in `test/helper.js`.
+When running the service's unit tests, you will probably need to update the tests to clear out the new table instead of the old.  This is typically, but not always, a `resetTables` call in `test/helper.js`.
 Try not to make any other changes to the service or its unit tests.
 If you do change the tests, such as to add additional test cases or use encodable characters in strings, do so in a commit *before* this one, so that reviewers can double-check those changes work against the existing entities table.
 

--- a/libraries/testing/README.md
+++ b/libraries/testing/README.md
@@ -355,6 +355,28 @@ helper.secrets.mockSuite(testing.suiteName(), ['db'], function(mock, skipping) {
 });
 ```
 
+There is also a utility function, `resetTables`, which will truncate a list of tables.
+This is typically used in a `setup` function to start each test with a clean slate.
+
+```js
+const {resetTables} = require('taskcluster-lib-testing');
+
+exports.resetTables = (mock, skipping) => {
+  setup('reset tables', async function() {
+    if (mock) {
+      // call the reset method on the fake db
+      exports.db['someservice'].reset();
+    } else {
+      const sec = exports.secrets.get('db');
+      await resetTables({ testDbUrl: sec.testDbUrl, tableNames: [
+        'some_table',
+        'another_table',
+      ]});
+    }
+  });
+};
+```
+
 withPulse
 ---------
 

--- a/libraries/testing/src/with-db.js
+++ b/libraries/testing/src/with-db.js
@@ -37,11 +37,13 @@ const resetDb = async ({testDbUrl}) => {
   }
 };
 
-const resetTable = async ({testDbUrl, tableName}) => {
+const resetTables = async ({testDbUrl, tableNames}) => {
   const client = new Client({connectionString: testDbUrl});
   await client.connect();
   try {
-    await ignorePgErrors(client.query(`truncate ${tableName}`), UNDEFINED_TABLE);
+    for (let tableName of tableNames) {
+      await ignorePgErrors(client.query(`truncate ${tableName}`), UNDEFINED_TABLE);
+    }
   } finally {
     await client.end();
   }
@@ -112,4 +114,4 @@ module.exports.withDb.secret = [
 
 // this is useful for taskcluster-db's tests, as well
 module.exports.resetDb = resetDb;
-module.exports.resetTable = resetTable;
+module.exports.resetTables = resetTables;

--- a/services/auth/test/helper.js
+++ b/services/auth/test/helper.js
@@ -11,7 +11,7 @@ const {APIBuilder} = require('taskcluster-lib-api');
 const SchemaSet = require('taskcluster-lib-validate');
 const staticScopes = require('../src/static-scopes.json');
 const makeSentryManager = require('./../src/sentrymanager');
-const {stickyLoader, Secrets, withEntity, withPulse, withMonitor, withDb, resetTable} = require('taskcluster-lib-testing');
+const {stickyLoader, Secrets, withEntity, withPulse, withMonitor, withDb, resetTables} = require('taskcluster-lib-testing');
 
 exports.load = stickyLoader(load);
 
@@ -432,8 +432,7 @@ exports.resetTables = (mock, skipping) => {
       exports.db['auth'].reset();
     } else {
       const sec = exports.secrets.get('db');
-      await resetTable({ testDbUrl: sec.testDbUrl, tableName: 'clients_entities' });
-      await resetTable({ testDbUrl: sec.testDbUrl, tableName: 'roles_entities' });
+      await resetTables({ testDbUrl: sec.testDbUrl, tableNames: ['clients_entities', 'roles_entities'] });
     }
   });
 };

--- a/services/github/test/helper.js
+++ b/services/github/test/helper.js
@@ -6,7 +6,7 @@ const taskcluster = require('taskcluster-client');
 const load = require('../src/main');
 const fakeGithubAuth = require('./github-auth');
 const data = require('../src/data');
-const {fakeauth, stickyLoader, Secrets, withEntity, withPulse, withMonitor, withDb, resetTable} = require('taskcluster-lib-testing');
+const {fakeauth, stickyLoader, Secrets, withEntity, withPulse, withMonitor, withDb, resetTables} = require('taskcluster-lib-testing');
 
 exports.load = stickyLoader(load);
 
@@ -141,10 +141,12 @@ exports.resetTables = (mock, skipping) => {
       exports.db['github'].reset();
     } else {
       const sec = exports.secrets.get('db');
-      await resetTable({ testDbUrl: sec.testDbUrl, tableName: 'taskcluster_github_builds_entities' });
-      await resetTable({ testDbUrl: sec.testDbUrl, tableName: 'taskcluster_integration_owners_entities' });
-      await resetTable({ testDbUrl: sec.testDbUrl, tableName: 'taskcluster_checks_to_tasks_entities' });
-      await resetTable({ testDbUrl: sec.testDbUrl, tableName: 'taskcluster_check_runs_entities' });
+      await resetTables({ testDbUrl: sec.testDbUrl, tableNames: [
+        'taskcluster_github_builds_entities',
+        'taskcluster_integration_owners_entities',
+        'taskcluster_checks_to_tasks_entities',
+        'taskcluster_check_runs_entities',
+      ]});
     }
   });
 };

--- a/services/hooks/test/helper.js
+++ b/services/hooks/test/helper.js
@@ -1,7 +1,7 @@
 const data = require('../src/data');
 const taskcluster = require('taskcluster-client');
 const taskcreator = require('../src/taskcreator');
-const {stickyLoader, fakeauth, Secrets, withEntity, withPulse, withMonitor, withDb, resetTable} = require('taskcluster-lib-testing');
+const {stickyLoader, fakeauth, Secrets, withEntity, withPulse, withMonitor, withDb, resetTables} = require('taskcluster-lib-testing');
 const builder = require('../src/api');
 const load = require('../src/main');
 
@@ -125,9 +125,11 @@ exports.resetTables = (mock, skipping) => {
       helper.db.hooks.reset();
     } else {
       const sec = helper.secrets.get('db');
-      await resetTable({ testDbUrl: sec.testDbUrl, tableName: 'hooks_entities' });
-      await resetTable({ testDbUrl: sec.testDbUrl, tableName: 'queues_entities' });
-      await resetTable({ testDbUrl: sec.testDbUrl, tableName: 'last_fire_3_entities' });
+      await resetTables({ testDbUrl: sec.testDbUrl, tableNames: [
+        'hooks_entities',
+        'queues_entities',
+        'last_fire_3_entities',
+      ]});
     }
   });
 };

--- a/services/index/test/helper.js
+++ b/services/index/test/helper.js
@@ -3,7 +3,7 @@ const data = require('../src/data');
 const builder = require('../src/api');
 const taskcluster = require('taskcluster-client');
 const load = require('../src/main');
-const {fakeauth, stickyLoader, Secrets, withEntity, withPulse, withMonitor, withDb, resetTable} = require('taskcluster-lib-testing');
+const {fakeauth, stickyLoader, Secrets, withEntity, withPulse, withMonitor, withDb, resetTables} = require('taskcluster-lib-testing');
 
 const helper = module.exports;
 
@@ -161,8 +161,10 @@ exports.resetTables = (mock, skipping) => {
       exports.db['fakeindex'].reset();
     } else {
       const sec = exports.secrets.get('db');
-      await resetTable({ testDbUrl: sec.testDbUrl, tableName: 'indexed_tasks_entities' });
-      await resetTable({ testDbUrl: sec.testDbUrl, tableName: 'namespaces_entities' });
+      await resetTables({ testDbUrl: sec.testDbUrl, tableNames: [
+        'indexed_tasks_entities',
+        'namespaces_entities',
+      ]});
     }
   });
 };

--- a/services/notify/test/helper.js
+++ b/services/notify/test/helper.js
@@ -2,7 +2,7 @@ const assert = require('assert');
 const path = require('path');
 const aws = require('aws-sdk');
 const taskcluster = require('taskcluster-client');
-const {stickyLoader, Secrets, fakeauth, withEntity, withPulse, withMonitor, withDb, resetTable} = require('taskcluster-lib-testing');
+const {stickyLoader, Secrets, fakeauth, withEntity, withPulse, withMonitor, withDb, resetTables} = require('taskcluster-lib-testing');
 const builder = require('../src/api');
 const load = require('../src/main');
 const RateLimit = require('../src/ratelimit');
@@ -329,8 +329,10 @@ exports.resetTables = (mock, skipping) => {
       exports.db['notify'].reset();
     } else {
       const sec = exports.secrets.get('db');
-      await resetTable({ testDbUrl: sec.testDbUrl, tableName: 'denylisted_notification_entities' });
-      await resetTable({ testDbUrl: sec.testDbUrl, tableName: 'widgets' });
+      await resetTables({ testDbUrl: sec.testDbUrl, tableNames: [
+        'denylisted_notification_entities',
+        'widgets',
+      ]});
     }
   });
 };

--- a/services/queue/test/helper.js
+++ b/services/queue/test/helper.js
@@ -7,7 +7,7 @@ const data = require('../src/data');
 const temporary = require('temporary');
 const mockAwsS3 = require('mock-aws-s3');
 const nock = require('nock');
-const {fakeauth, stickyLoader, Secrets, withEntity, withPulse, withMonitor, withDb, resetTable} = require('taskcluster-lib-testing');
+const {fakeauth, stickyLoader, Secrets, withEntity, withPulse, withMonitor, withDb, resetTables} = require('taskcluster-lib-testing');
 
 const helper = module.exports;
 
@@ -307,16 +307,18 @@ exports.resetTables = (mock, skipping) => {
       exports.db['queue'].reset();
     } else {
       const sec = exports.secrets.get('db');
-      await resetTable({ testDbUrl: sec.testDbUrl, tableName: 'queue_tasks_entities' });
-      await resetTable({ testDbUrl: sec.testDbUrl, tableName: 'queue_artifacts_entities' });
-      await resetTable({ testDbUrl: sec.testDbUrl, tableName: 'queue_task_groups_entities' });
-      await resetTable({ testDbUrl: sec.testDbUrl, tableName: 'queue_task_group_members_entities' });
-      await resetTable({ testDbUrl: sec.testDbUrl, tableName: 'queue_task_group_active_sets_entities' });
-      await resetTable({ testDbUrl: sec.testDbUrl, tableName: 'queue_task_requirement_entities' });
-      await resetTable({ testDbUrl: sec.testDbUrl, tableName: 'queue_task_dependency_entities' });
-      await resetTable({ testDbUrl: sec.testDbUrl, tableName: 'queue_worker_entities' });
-      await resetTable({ testDbUrl: sec.testDbUrl, tableName: 'queue_worker_type_entities' });
-      await resetTable({ testDbUrl: sec.testDbUrl, tableName: 'queue_provisioner_entities' });
+      await resetTables({ testDbUrl: sec.testDbUrl, tableNames: [
+        'queue_tasks_entities',
+        'queue_artifacts_entities',
+        'queue_task_groups_entities',
+        'queue_task_group_members_entities',
+        'queue_task_group_active_sets_entities',
+        'queue_task_requirement_entities',
+        'queue_task_dependency_entities',
+        'queue_worker_entities',
+        'queue_worker_type_entities',
+        'queue_provisioner_entities',
+      ]});
     }
   });
 };

--- a/services/web-server/test/helper.js
+++ b/services/web-server/test/helper.js
@@ -1,6 +1,6 @@
 const load = require('../src/main');
 const taskcluster = require('taskcluster-client');
-const {Secrets, stickyLoader, withMonitor, withEntity, withPulse, withDb, resetTable} = require('taskcluster-lib-testing');
+const {Secrets, stickyLoader, withMonitor, withEntity, withPulse, withDb, resetTables} = require('taskcluster-lib-testing');
 const sinon = require('sinon');
 const AuthorizationCode = require('../src/data/AuthorizationCode');
 const AccessToken = require('../src/data/AccessToken');
@@ -498,10 +498,12 @@ exports.resetTables = (mock, skipping) => {
       exports.db['web_server'].reset();
     } else {
       const sec = exports.secrets.get('db');
-      await resetTable({ testDbUrl: sec.testDbUrl, tableName: 'authorization_codes_table_entities' });
-      await resetTable({ testDbUrl: sec.testDbUrl, tableName: 'access_token_table_entities' });
-      await resetTable({ testDbUrl: sec.testDbUrl, tableName: 'session_storage_table_entities' });
-      await resetTable({ testDbUrl: sec.testDbUrl, tableName: 'github_access_token_table_entities' });
+      await resetTables({ testDbUrl: sec.testDbUrl, tableNames: [
+        'authorization_codes_table_entities',
+        'access_token_table_entities',
+        'session_storage_table_entities',
+        'github_access_token_table_entities',
+      ]});
     }
   });
 };

--- a/services/worker-manager/test/helper.js
+++ b/services/worker-manager/test/helper.js
@@ -1,7 +1,7 @@
 const taskcluster = require('taskcluster-client');
 const {FakeAzure} = require('./fake-azure.js');
 const {FakeGoogle} = require('./fake-google.js');
-const {stickyLoader, Secrets, withEntity, fakeauth, withMonitor, withPulse, withDb, resetTable} = require('taskcluster-lib-testing');
+const {stickyLoader, Secrets, withEntity, fakeauth, withMonitor, withPulse, withDb, resetTables} = require('taskcluster-lib-testing');
 const builder = require('../src/api');
 const data = require('../src/data');
 const load = require('../src/main');
@@ -268,9 +268,11 @@ exports.resetTables = (mock, skipping) => {
       exports.db['worker_manager'].reset();
     } else {
       const sec = exports.secrets.get('db');
-      await resetTable({ testDbUrl: sec.testDbUrl, tableName: 'wmworkers_entities' });
-      await resetTable({ testDbUrl: sec.testDbUrl, tableName: 'worker_pools' });
-      await resetTable({ testDbUrl: sec.testDbUrl, tableName: 'wmworker_pool_errors_entities' });
+      await resetTables({ testDbUrl: sec.testDbUrl, tableNames: [
+        'wmworkers_entities',
+        'worker_pools',
+        'wmworker_pool_errors_entities',
+      ]});
     }
   });
 };


### PR DESCRIPTION
This should save a bit of time by not setting up a new postgres
connection for each table.
