### PR TITLE
Fix perRequestInstance service discovery interaction

### DIFF
--- a/changelog/JOVMlrV9RmKalqOITppiMQ.md
+++ b/changelog/JOVMlrV9RmKalqOITppiMQ.md
@@ -1,0 +1,4 @@
+audience: developers
+level: patch
+---
+An issue with building external urls with traceId'd clients has been fixed

--- a/clients/client/src/client.js
+++ b/clients/client/src/client.js
@@ -207,12 +207,12 @@ exports.createClient = function(reference, name) {
     this._options.rootUrl = this._options.rootUrl.replace(/\/$/, '');
     this._options._trueRootUrl = this._options.rootUrl.replace(/\/$/, ''); // Useful for buildUrl/buildSignedUrl in certain cases
 
-    const serviceDiscoveryScheme = options.serviceDiscoveryScheme || DEFAULT_SERVICE_DISCOVERY_SCHEME;
-    if (!SERVICE_DISCOVERY_SCHEMES.includes(serviceDiscoveryScheme)) {
-      throw new Error(`Invalid Taskcluster client service discovery scheme: ${serviceDiscoveryScheme}`);
+    this._options.serviceDiscoveryScheme = options.serviceDiscoveryScheme || DEFAULT_SERVICE_DISCOVERY_SCHEME;
+    if (!SERVICE_DISCOVERY_SCHEMES.includes(this._options.serviceDiscoveryScheme)) {
+      throw new Error(`Invalid Taskcluster client service discovery scheme: ${this._options.serviceDiscoveryScheme}`);
     }
 
-    if (serviceDiscoveryScheme === 'k8s-dns') {
+    if (this._options.serviceDiscoveryScheme === 'k8s-dns') {
       this._options.rootUrl = `http://taskcluster-${serviceName}`; // Notice this is http, not https
     }
 
@@ -291,7 +291,7 @@ exports.createClient = function(reference, name) {
   };
 
   Client.prototype.use = function(optionsUpdates) {
-    let options = _.defaults({}, optionsUpdates, this._options);
+    let options = _.defaults({}, optionsUpdates, {rootUrl: this._options._trueRootUrl}, this._options);
     return new Client(options);
   };
 

--- a/clients/client/test/client_test.js
+++ b/clients/client/test/client_test.js
@@ -482,6 +482,30 @@ suite(testing.suiteName(), function() {
           urlPrefix: trueUrlPrefix || urlPrefix,
           type: 'external',
         },
+        {
+          buildUrl: (...arg) => {
+            const cc = client.taskclusterPerRequestInstance({traceId: 'foo'});
+            return cc.buildUrl(...arg);
+          },
+          buildSignedUrl: (...arg) => {
+            const cc = client.taskclusterPerRequestInstance({traceId: 'foo'});
+            return cc.buildSignedUrl(...arg);
+          },
+          urlPrefix,
+          type: 'internal (per request)',
+        },
+        {
+          buildUrl: (...arg) => {
+            const cc = client.taskclusterPerRequestInstance({traceId: 'foo'});
+            return cc.externalBuildUrl(...arg);
+          },
+          buildSignedUrl: (...arg) => {
+            const cc = client.taskclusterPerRequestInstance({traceId: 'foo'});
+            return cc.externalBuildSignedUrl(...arg);
+          },
+          urlPrefix: trueUrlPrefix || urlPrefix,
+          type: 'external (per request)',
+        },
       ]) {
         suite(cl.type, function() {
           test('BuildUrl', async () => {


### PR DESCRIPTION
We were using the internal rootUrl as the real rootUrl for children instances made by `taskclusterPerRequestInstance`
