### PR TITLE
[Bug 1627769] Fix slow leak of wedged workers

### DIFF
--- a/changelog/bug-1627769.md
+++ b/changelog/bug-1627769.md
@@ -1,0 +1,5 @@
+audience: admins
+level: patch
+reference: bug 1627769
+---
+Worker lifecycle defaults are now being properly applied.

--- a/generated/references.json
+++ b/generated/references.json
@@ -234,7 +234,7 @@
         },
         "reregistrationTimeout": {
           "default": 345600,
-          "description": "If specified, workers in this pool must re-register via `reregister()`\nwithin `reregistrationTimeout` seconds from the initial call to\n`register()` to get new credentials. If the worker has not done so, it\nwill be terminated.  This value also dictates the lifetime of the\ntemporary credentials granted to the worker, meaning that it must be\nless than 30 days.\n\nThe default value is 3 days.\n",
+          "description": "If specified, workers in this pool must re-register via `reregister()`\nwithin `reregistrationTimeout` seconds from the initial call to\n`register()` to get new credentials. If the worker has not done so, it\nwill be terminated.  This value also dictates the lifetime of the\ntemporary credentials granted to the worker, meaning that it must be\nless than 30 days. The default value is 4 days.\n",
           "maximum": 2678400,
           "title": "Checkin Timeout",
           "type": "integer"

--- a/libraries/references/src/validate.js
+++ b/libraries/references/src/validate.js
@@ -39,7 +39,7 @@ const forAllRefs = (content, cb) => {
     if (Array.isArray(value)) {
       value.forEach((v, i) => recurse(v, `${path}[${i}]`));
     } else if (typeof value === 'object') {
-      if (value.$ref && Object.keys(value).length === 1) {
+      if (value.$ref) {
         cb(value.$ref, path);
       } else {
         for (const [k, v] of Object.entries(value)) {

--- a/services/worker-manager/schemas/v1/worker-lifecycle.yml
+++ b/services/worker-manager/schemas/v1/worker-lifecycle.yml
@@ -21,7 +21,7 @@ properties:
   reregistrationTimeout:
     title: Checkin Timeout
     type: integer
-    default: 345600   # 3 days
+    default: 345600   # 4 days (note this is also set in interpretLifecycle; update both if changing)
     maximum: 2678400  # 30 days
     description: |
       If specified, workers in this pool must re-register via `reregister()`
@@ -29,8 +29,6 @@ properties:
       `register()` to get new credentials. If the worker has not done so, it
       will be terminated.  This value also dictates the lifetime of the
       temporary credentials granted to the worker, meaning that it must be
-      less than 30 days.
-      
-      The default value is 3 days.
+      less than 30 days. The default value is 4 days.
 additionalProperties: false
 required: []

--- a/services/worker-manager/src/providers/provider.js
+++ b/services/worker-manager/src/providers/provider.js
@@ -94,22 +94,21 @@ class Provider {
    * supports this action. Also returns the reregistrationTimeout
    * in milliseconds (as opposed to the seconds it is defined in) for
    * doing date math with easier.
+   * This defaults reregistrationTimeout to 4 days. Note that
+   * this is also set in the lifecycle schema so update there if
+   * changing.
    */
-  static interpretLifecycle({lifecycle}) {
+  static interpretLifecycle({lifecycle: {registrationTimeout, reregistrationTimeout} = {}}) {
+    reregistrationTimeout = reregistrationTimeout || 345600;
     let terminateAfter = null;
-    if (!lifecycle) {
-      return {terminateAfter, reregistrationTimeout: null};
-    }
 
-    let {registrationTimeout, reregistrationTimeout} = lifecycle;
-    if (registrationTimeout !== undefined) {
+    if (registrationTimeout !== undefined && registrationTimeout < reregistrationTimeout) {
       terminateAfter = Date.now() + registrationTimeout * 1000;
-    }
-    if (reregistrationTimeout !== undefined && registrationTimeout === undefined ||
-        reregistrationTimeout < registrationTimeout) {
+    } else {
       terminateAfter = Date.now() + reregistrationTimeout * 1000;
     }
-    return {terminateAfter, reregistrationTimeout: reregistrationTimeout * 1000 || null};
+
+    return {terminateAfter, reregistrationTimeout: reregistrationTimeout * 1000};
   }
 
   // Report an error concerning this worker pool.  This handles notifications and logging.

--- a/services/worker-manager/test/provider_test.js
+++ b/services/worker-manager/test/provider_test.js
@@ -22,17 +22,17 @@ helper.secrets.mockSuite(testing.suiteName(), ['db'], function(mock, skipping) {
   });
 
   test('no lifecycle', async function() {
-    assert.equal(null, Provider.interpretLifecycle({}).terminateAfter);
+    assert.equal(345600100, Provider.interpretLifecycle({}).terminateAfter);
   });
 
   test('empty lifecycle', async function() {
-    assert.equal(null, Provider.interpretLifecycle({lifecycle: {}}).terminateAfter);
+    assert.equal(345600100, Provider.interpretLifecycle({lifecycle: {}}).terminateAfter);
   });
 
   test('only registrationTimeout', async function() {
     assert.deepEqual({
       terminateAfter: 10100,
-      reregistrationTimeout: null,
+      reregistrationTimeout: 345600000,
     }, Provider.interpretLifecycle({lifecycle: {registrationTimeout: 10}}));
   });
 


### PR DESCRIPTION
Previous to this, the default lifecycles weren't getting applied. This was
fine in the 99% case where the worker succesfully registered as at that time
the `terminateAfter` date gets set to the `expires` of the creds returned.

However for workers that did not register, the `reregisterTimeout` was null
and these workers were allowed to live forever. To apply this to all currently
existing pools, we should run `ci-admin apply`/`tc-admin apply`.

We had to add a default to all places where the lifecycle `$ref` was used. However Ajv does not allow the default to be specified outside of `properties` and `items` so we just do it where it is "imported".

This also changes our reference validation because in Ajv, `$ref` doesn't actually have to be alone. It can have siblings that it will merge with.

Bugzilla Bug: [1627769](https://bugzilla.mozilla.org/show_bug.cgi?id=1627769)
