### PR TITLE
[Bug 1638370] Fetch vmId in registerWorker for azure provider if it does not exist yet

### DIFF
--- a/changelog/bug-1638370.md
+++ b/changelog/bug-1638370.md
@@ -1,0 +1,5 @@
+audience: worker-deployers
+level: patch
+reference: bug 1638370
+---
+Azure provider no longer has a race condition between `registerWorker` and `checkWorker`.

--- a/services/worker-manager/test/fake-azure.js
+++ b/services/worker-manager/test/fake-azure.js
@@ -87,7 +87,7 @@ class FakeAzure {
           },
         ],
       },
-      vmId: "a-vm-id",
+      vmId: "5d06deb3-807b-46dd-aef5-78aaf9193f71",
       provisioningState: 'Creating',
     };
 


### PR DESCRIPTION
This should ensure we always have the vmId for registerWorker if the
vm exists. 

This is safe to do because we are using the vm name to fetch the vmId
which is what we are doing in checkWorker anyway. Even if someone passes
in a different worker to `registerWorker` we'll get a different vmId than
the one they can sign and provide as proof.

Bugzilla Bug: [1638370](https://bugzilla.mozilla.org/show_bug.cgi?id=1638370)
