### PR TITLE
Fail with a useful error message when audio/video loopback are not available

### DIFF
--- a/changelog/Zju_nhigQ0KlRslJbNfSCQ.md
+++ b/changelog/Zju_nhigQ0KlRslJbNfSCQ.md
@@ -1,0 +1,4 @@
+audience: worker-deployers
+level: patch
+---
+Docker-worker will now fail early with a useful error message if the loopback audio or video devices are not available, but are configured.

--- a/workers/docker-worker/src/lib/devices/audio_device_manager.js
+++ b/workers/docker-worker/src/lib/devices/audio_device_manager.js
@@ -38,6 +38,10 @@ class AudioDeviceManager {
       Devices: ${JSON.stringify(deviceList, null, 2)}
     `);
 
+    if (deviceList.length === 0) {
+      throw new Error('No audio devices found; try setting deviceManager.loopbackAudio.enabled = false to disable the feature, or building the snd-aloop module into the kernel and configuring it');
+    }
+
     return deviceList;
   }
 

--- a/workers/docker-worker/src/lib/devices/video_device_manager.js
+++ b/workers/docker-worker/src/lib/devices/video_device_manager.js
@@ -33,6 +33,10 @@ class VideoDeviceManager {
       Devices: ${JSON.stringify(deviceList, null, 2)}
     `);
 
+    if (deviceList.length === 0) {
+      throw new Error('No video devices found; try setting deviceManager.loopbackVideo.enabled = false to disable the feature, or building the v4l2loopback module into the kernel');
+    }
+
     return deviceList;
   }
 
@@ -40,7 +44,7 @@ class VideoDeviceManager {
     let devices = this.getAvailableDevices();
     if (!devices.length) {
       throw new Error(`
-        Fatal error... Could not acquire audio device: ${JSON.stringify(this.devices)}
+        Fatal error... Could not acquire video device: ${JSON.stringify(this.devices)}
       `);
     }
 


### PR DESCRIPTION
This seems a common error mode with docker-worker, and until today I didn't realize it could be configured around!

This should at least give better logging..