### PR TITLE
Tests cover both having and not having publicIP in config

### DIFF
--- a/workers/generic-worker/helper_test.go
+++ b/workers/generic-worker/helper_test.go
@@ -404,7 +404,6 @@ func GWTest(t *testing.T) *Test {
 			NumberOfTasksToRun:        1,
 			PrivateIP:                 net.ParseIP("87.65.43.21"),
 			ProvisionerID:             "test-provisioner",
-			PublicIP:                  net.ParseIP("12.34.56.78"),
 			Region:                    "test-worker-group",
 			// should be enough for tests, and travis-ci.org CI environments don't
 			// have a lot of free disk

--- a/workers/generic-worker/mounts_broken_on_docker_test.go
+++ b/workers/generic-worker/mounts_broken_on_docker_test.go
@@ -5,6 +5,7 @@ package main
 import (
 	"encoding/json"
 	"io/ioutil"
+	"net"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -14,6 +15,7 @@ import (
 func TestMounts(t *testing.T) {
 
 	defer setup(t)()
+	config.PublicIP = net.ParseIP("12.34.56.78")
 
 	taskID1 := CreateArtifactFromFile(t, "SampleArtifacts/_/X.txt", "SampleArtifacts/_/X.txt")
 	taskID2 := CreateArtifactFromFile(t, "mozharness.zip", "public/build/mozharness.zip")


### PR DESCRIPTION
I spotted that when no public IP is provided, that the worker can crash (it happened for me when running generic-worker locally) - this PR is to see if the tests already capture this, when `publicIP` config isn't provided in tests.