### PR TITLE
[client-web] Bug 1587145 - generate a single build asset

### DIFF
--- a/changelog/bug-1587145.md
+++ b/changelog/bug-1587145.md
@@ -1,0 +1,6 @@
+audience: general
+level: patch
+reference: bug 1587145
+---
+taskcluster-client-web now only builds a single umd asset. This asset is
+compatible with both cjs and esm.

--- a/clients/client-web/package.json
+++ b/clients/client-web/package.json
@@ -2,7 +2,6 @@
   "name": "taskcluster-client-web",
   "version": "29.6.0",
   "main": "build/index.js",
-  "module": "build/esm/index.js",
   "author": "Eli Perelman <eli@eliperelman.com>",
   "license": "MPL-2.0",
   "repository": "https://github.com/taskcluster/taskcluster/tree/master/clients/client-web",

--- a/clients/client-web/webpack.config.js
+++ b/clients/client-web/webpack.config.js
@@ -1,16 +1,3 @@
 const neutrino = require('neutrino');
 
-const config = neutrino().webpack();
-const output = config.output;
-
-module.exports = [
-  config,
-  {
-    ...config,
-    output: {
-      ...output,
-      path: `${output.path}/esm`,
-      libraryTarget: 'var',
-    },
-  },
-];
+module.exports = neutrino().webpack();


### PR DESCRIPTION
Generating two separate builds seems to have caused some issues when importing. It should be fine to generate a single umd build (default) which is compatible everywhere. Tested this locally and seems to fix the issue sclement was seeing.