### PR TITLE
[UI] Add search feature in purge caches page

### DIFF
--- a/changelog/issue-2876.md
+++ b/changelog/issue-2876.md
@@ -1,0 +1,5 @@
+audience: users
+level: patch
+reference: issue 2876
+---
+The purge cache UI view now allows filtering a search result by cache name.

--- a/ui/src/utils/constants.js
+++ b/ui/src/utils/constants.js
@@ -31,7 +31,7 @@ export const VIEW_ROLES_PAGE_SIZE = 1000;
 export const VIEW_SECRETS_PAGE_SIZE = 100;
 export const VIEW_DENYLIST_PAGE_SIZE = 20;
 export const VIEW_NAMESPACES_PAGE_SIZE = 20;
-export const VIEW_CACHE_PURGES_PAGE_SIZE = 20;
+export const VIEW_CACHE_PURGES_PAGE_SIZE = 1000;
 export const HOOKS_LAST_FIRE_TYPE = {
   NO_FIRE: 'NoFire',
   SUCCESSFUL_FIRE: 'HookSuccessfulFire',

--- a/ui/src/views/CachePurges/ViewCachePurges/index.jsx
+++ b/ui/src/views/CachePurges/ViewCachePurges/index.jsx
@@ -6,6 +6,7 @@ import Spinner from '@mozilla-frontend-infra/components/Spinner';
 import { withStyles } from '@material-ui/core/styles';
 import Typography from '@material-ui/core/Typography';
 import PlusIcon from 'mdi-react/PlusIcon';
+import qs, { parse, stringify } from 'qs';
 import Dashboard from '../../../components/Dashboard';
 import Button from '../../../components/Button';
 import CachePurgesTable from '../../../components/CachePurgesTable';
@@ -13,6 +14,7 @@ import HelpView from '../../../components/HelpView';
 import { VIEW_CACHE_PURGES_PAGE_SIZE } from '../../../utils/constants';
 import ErrorPanel from '../../../components/ErrorPanel';
 import cachePurgesQuery from './cachePurges.graphql';
+import Search from '../../../components/Search';
 
 @hot(module)
 @graphql(cachePurgesQuery, {
@@ -67,12 +69,25 @@ export default class ViewCachePurges extends Component {
     });
   };
 
+  handlePurgeCacheSubmit = cacheSearch => {
+    const query = parse(window.location.search.slice(1));
+
+    this.props.history.push({
+      search: stringify({
+        ...query,
+        search: cacheSearch,
+      }),
+    });
+  };
+
   render() {
     const {
       classes,
       description,
       data: { loading, error, cachePurges },
     } = this.props;
+    const query = qs.parse(this.props.location.search.slice(1));
+    const cacheSearch = query.search;
 
     return (
       <Dashboard
@@ -87,12 +102,21 @@ export default class ViewCachePurges extends Component {
             </Typography>
           </HelpView>
         }
-        title="Purge Caches">
+        title="Purge Caches"
+        search={
+          <Search
+            disabled={loading}
+            defaultValue={cacheSearch}
+            onSubmit={this.handlePurgeCacheSubmit}
+            placeholder="Cache Name contains"
+          />
+        }>
         <Fragment>
           {!cachePurges && loading && <Spinner loading />}
           <ErrorPanel fixed error={error} />
           {cachePurges && (
             <CachePurgesTable
+              searchTerm={cacheSearch}
               cachePurgesConnection={cachePurges}
               onPageChange={this.handlePageChange}
             />


### PR DESCRIPTION
Fixes #2865

> Expected behaviour
> You should be able to search for a cache
> 
> Actual behaviour
> There is no easy way to search for a cache name. You need to click the next page button until you find the cache you are looking for.

- [x]  Add search feature in `Purge Caches` page.

- [x]  Increase the number of entries per page to 1000.

_Screenshots_

![new](https://user-images.githubusercontent.com/30138596/82720402-cfb38200-9cd0-11ea-905d-ec72a1af3ff2.png)

![new2](https://user-images.githubusercontent.com/30138596/82720404-d17d4580-9cd0-11ea-9ee4-f3d28ea59a09.png)
