### PR TITLE
Stop loading the `azure` secret

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -280,7 +280,6 @@ tasks:
                   - notify.email.${owner}.on-failed
                   - notify.email.${owner}.on-exception
               scopes:
-                - secrets:get:project/taskcluster/testing/azure
                 - secrets:get:project/taskcluster/testing/codecov
                 - secrets:get:project/taskcluster/testing/taskcluster-*
                 - docker-worker:cache:taskcluster-test-*

--- a/changelog/N__STNQESvKiZq0PO2_M8g.md
+++ b/changelog/N__STNQESvKiZq0PO2_M8g.md
@@ -1,0 +1,3 @@
+audience: general
+level: silent
+---

--- a/services/auth/test/helper.js
+++ b/services/auth/test/helper.js
@@ -32,10 +32,7 @@ withMonitor(exports);
 
 // set up the testing secrets
 exports.secrets = new Secrets({
-  secretName: [
-    'project/taskcluster/testing/azure',
-    'project/taskcluster/testing/taskcluster-auth',
-  ],
+  secretName: 'project/taskcluster/testing/taskcluster-auth',
   secrets: {
     db: withDb.secret,
     azure: [

--- a/services/github/test/helper.js
+++ b/services/github/test/helper.js
@@ -19,7 +19,6 @@ withMonitor(exports);
 
 // set up the testing secrets
 exports.secrets = new Secrets({
-  secretName: 'project/taskcluster/testing/azure',
   secrets: {
     db: withDb.secret,
   },

--- a/services/hooks/test/helper.js
+++ b/services/hooks/test/helper.js
@@ -16,7 +16,6 @@ helper.load.inject('process', 'test');
 withMonitor(helper);
 
 helper.secrets = new Secrets({
-  secretName: 'project/taskcluster/testing/azure',
   load: helper.load,
   secrets: {
     db: withDb.secret,

--- a/services/index/test/helper.js
+++ b/services/index/test/helper.js
@@ -18,7 +18,6 @@ withMonitor(exports);
 
 // set up the testing secrets
 exports.secrets = new Secrets({
-  secretName: 'project/taskcluster/testing/azure',
   secrets: {
     db: withDb.secret,
   },

--- a/services/notify/test/helper.js
+++ b/services/notify/test/helper.js
@@ -30,7 +30,6 @@ withMonitor(exports);
 // set up the testing secrets
 exports.secrets = new Secrets({
   secretName: [
-    'project/taskcluster/testing/azure',
     'project/taskcluster/testing/taskcluster-notify',
   ],
   secrets: {

--- a/services/purge-cache/test/helper.js
+++ b/services/purge-cache/test/helper.js
@@ -23,7 +23,6 @@ withMonitor(exports);
 
 // set up the testing secrets
 exports.secrets = new Secrets({
-  secretName: 'project/taskcluster/testing/azure',
   secrets: {
     db: withDb.secret,
   },

--- a/services/queue/test/helper.js
+++ b/services/queue/test/helper.js
@@ -23,7 +23,6 @@ withMonitor(exports);
 // set up the testing secrets
 exports.secrets = new Secrets({
   secretName: [
-    'project/taskcluster/testing/azure',
     'project/taskcluster/testing/taskcluster-queue',
   ],
   secrets: {

--- a/services/secrets/test/helper.js
+++ b/services/secrets/test/helper.js
@@ -16,7 +16,6 @@ withMonitor(exports);
 
 // set up the testing secrets
 exports.secrets = new Secrets({
-  secretName: 'project/taskcluster/testing/azure',
   secrets: {
     db: withDb.secret,
   },

--- a/services/web-server/test/helper.js
+++ b/services/web-server/test/helper.js
@@ -32,7 +32,6 @@ exports.rootUrl = libUrls.testRootUrl();
 
 // set up the testing secrets
 exports.secrets = new Secrets({
-  secretName: 'project/taskcluster/testing/azure',
   secrets: {
     db: withDb.secret,
   },

--- a/services/worker-manager/test/estimator_test.js
+++ b/services/worker-manager/test/estimator_test.js
@@ -2,7 +2,7 @@ const assert = require('assert');
 const helper = require('./helper');
 const testing = require('taskcluster-lib-testing');
 
-helper.secrets.mockSuite(testing.suiteName(), ['azure'], function(mock, skipping) {
+helper.secrets.mockSuite(testing.suiteName(), ['db'], function(mock, skipping) {
   helper.withFakeQueue(mock, skipping);
   helper.withFakeNotify(mock, skipping);
 

--- a/services/worker-manager/test/helper.js
+++ b/services/worker-manager/test/helper.js
@@ -19,7 +19,6 @@ withMonitor(exports);
 
 // set up the testing secrets
 exports.secrets = new Secrets({
-  secretName: 'project/taskcluster/testing/azure',
   secrets: {
     azure: withEntity.secret,
     db: withDb.secret,

--- a/workers/generic-worker/gw-decision-task/tasks.yml
+++ b/workers/generic-worker/gw-decision-task/tasks.yml
@@ -344,7 +344,6 @@ Mounts:
       windows:
         all:
           url: 'http://localhost/secrets/v1/secret/project/taskcluster/testing/generic-worker/ci-creds'
-          sha256: 'ef1d954dbae01a0810fcdb56f56761dbbb26692b0dc8cbb2994101512fc26992'
   golangci-lint-1.23.6:
     # Note - we can't extract to directory '.' since after generic-worker
     # extracts the files as the root user (since generic-worker runs as root),


### PR DESCRIPTION
The auth service still needs an account for its tests, but other
services do not, so moved this credential into tc-auth's secret.

I also deleted the pamplemousse storage account and re-created it, so auth's tests might fail.. Hopefully not.