### PR TITLE
[docker-worker] Add test for empty cache

### DIFF
--- a/workers/docker-worker/test/integration/container_volume_caching_test.js
+++ b/workers/docker-worker/test/integration/container_volume_caching_test.js
@@ -566,19 +566,19 @@ helper.secrets.mockSuite(suiteName(), ['docker', 'ci-creds'], function(mock, ski
       },
     });
     const payload = {
-        image: 'taskcluster/test-ubuntu',
-        command: cmd(
-          'sleep 5',
-        ),
-        features: {
-          localLiveLog: true,
-        },
-        cache: {},
-        maxRunTime: 5 * 60,
+      image: 'taskcluster/test-ubuntu',
+      command: cmd(
+        'sleep 5',
+      ),
+      features: {
+        localLiveLog: true,
+      },
+      cache: {},
+      maxRunTime: 5 * 60,
     };
 
     let task = {
-      payload
+      payload,
     };
     let task2 = {
       payload: {
@@ -594,7 +594,6 @@ helper.secrets.mockSuite(suiteName(), ['docker', 'ci-creds'], function(mock, ski
     };
 
     let worker = new TestWorker(DockerWorker);
-
 
     await worker.launch();
 

--- a/workers/docker-worker/test/integration/container_volume_caching_test.js
+++ b/workers/docker-worker/test/integration/container_volume_caching_test.js
@@ -556,6 +556,55 @@ helper.secrets.mockSuite(suiteName(), ['docker', 'ci-creds'], function(mock, ski
     assert.throws(() => fs.readdirSync(fullCacheDir), err => err.code === 'ENOENT');
   });
 
+  test.only('empty cache does not throw', async () => {
+    settings.configure({
+      cache: {
+        volumeCachePath: volumeCacheDir,
+      },
+      garbageCollection: {
+        interval: 100,
+      },
+    });
+    const payload = {
+        image: 'taskcluster/test-ubuntu',
+        command: cmd(
+          'sleep 5',
+        ),
+        features: {
+          localLiveLog: true,
+        },
+        cache: {},
+        maxRunTime: 5 * 60,
+    };
+
+    let task = {
+      payload
+    };
+    let task2 = {
+      payload: {
+        ...payload,
+        cache: null,
+      },
+    };
+    let task3 = {
+      payload: {
+        ...payload,
+        cache: undefined,
+      },
+    };
+
+    let worker = new TestWorker(DockerWorker);
+
+
+    await worker.launch();
+
+    await worker.postToQueue(task);
+    await worker.postToQueue(task2);
+    await worker.postToQueue(task3);
+
+    await worker.terminate();
+  });
+
   test('purge cache based on exit status', async () => {
     let cacheName = 'docker-worker-garbage-caches-tmp-obj-dir-' + Date.now().toString();
     let neededScope = 'docker-worker:cache:' + cacheName;

--- a/workers/docker-worker/test/integration/container_volume_caching_test.js
+++ b/workers/docker-worker/test/integration/container_volume_caching_test.js
@@ -556,7 +556,7 @@ helper.secrets.mockSuite(suiteName(), ['docker', 'ci-creds'], function(mock, ski
     assert.throws(() => fs.readdirSync(fullCacheDir), err => err.code === 'ENOENT');
   });
 
-  test.only('empty cache does not throw', async () => {
+  test('empty cache does not throw', async () => {
     settings.configure({
       cache: {
         volumeCachePath: volumeCacheDir,


### PR DESCRIPTION
I'm not sure how to replicate the issue locally but here's some tests for https://community-tc.services.mozilla.com/tasks/W3NTy3axQ1GiaIfLwkwtgQ/runs/0/logs/https%3A%2F%2Fcommunity-tc.services.mozilla.com%2Fapi%2Fqueue%2Fv1%2Ftask%2FW3NTy3axQ1GiaIfLwkwtgQ%2Fruns%2F0%2Fartifacts%2Fpublic%2Flogs%2Flive.log.

Relates to https://github.com/taskcluster/taskcluster/pull/2874.