### PR TITLE
Fixed bustage from PR 2895

### DIFF
--- a/workers/generic-worker/gw-decision-task/main.go
+++ b/workers/generic-worker/gw-decision-task/main.go
@@ -195,9 +195,11 @@ func (dt *DecisionTask) GenerateTasks() (*TaskGroup, error) {
 				if content != nil {
 					mountEntry := map[string]interface{}{
 						"content": map[string]string{
-							"url":    content.URL,
-							"sha256": content.SHA256,
+							"url": content.URL,
 						},
+					}
+					if content.SHA256 != "" {
+						mountEntry["content"].(map[string]string)["sha256"] = content.SHA256
 					}
 					if mount.Directory != "" {
 						mountEntry["directory"] = mount.Directory


### PR DESCRIPTION
The CI was broken in commit d150e72543df134bfd59069b1b8f6905ceb18652 with [this error](https://community-tc.services.mozilla.com/tasks/GpX7eJP5TXCUhNYC2_nvXA/runs/0/logs/https%3A%2F%2Fcommunity-tc.services.mozilla.com%2Fapi%2Fqueue%2Fv1%2Ftask%2FGpX7eJP5TXCUhNYC2_nvXA%2Fruns%2F0%2Fartifacts%2Fpublic%2Flogs%2Flive_backing.log) from #2895:

```
[taskcluster 2020-05-23T00:35:16.109Z] Worker Type (proj-taskcluster/gw-ci-windows2012r2-amd64) settings:
[taskcluster 2020-05-23T00:35:16.109Z]   {
[taskcluster 2020-05-23T00:35:16.109Z]     "availability-zone": "us-east-1b",
[taskcluster 2020-05-23T00:35:16.109Z]     "config": {
[taskcluster 2020-05-23T00:35:16.109Z]       "deploymentId": "31956a952b9dc567"
[taskcluster 2020-05-23T00:35:16.109Z]     },
[taskcluster 2020-05-23T00:35:16.109Z]     "generic-worker": {
[taskcluster 2020-05-23T00:35:16.109Z]       "engine": "multiuser",
[taskcluster 2020-05-23T00:35:16.109Z]       "go-arch": "amd64",
[taskcluster 2020-05-23T00:35:16.109Z]       "go-os": "windows",
[taskcluster 2020-05-23T00:35:16.109Z]       "go-version": "go1.13.7",
[taskcluster 2020-05-23T00:35:16.109Z]       "release": "https://github.com/taskcluster/taskcluster/releases/tag/v29.2.0",
[taskcluster 2020-05-23T00:35:16.109Z]       "revision": "12bb103c4967339ed2dcdddeb63023c993905e03",
[taskcluster 2020-05-23T00:35:16.109Z]       "source": "https://github.com/taskcluster/taskcluster/commits/12bb103c4967339ed2dcdddeb63023c993905e03",
[taskcluster 2020-05-23T00:35:16.109Z]       "version": "29.2.0"
[taskcluster 2020-05-23T00:35:16.109Z]     },
[taskcluster 2020-05-23T00:35:16.109Z]     "image": "ami-0e25602446699a013",
[taskcluster 2020-05-23T00:35:16.109Z]     "instance-id": "i-0c82eb7fea98fd897",
[taskcluster 2020-05-23T00:35:16.109Z]     "instance-type": "m3.2xlarge",
[taskcluster 2020-05-23T00:35:16.109Z]     "local-ipv4": "10.0.19.19",
[taskcluster 2020-05-23T00:35:16.109Z]     "public-hostname": "",
[taskcluster 2020-05-23T00:35:16.109Z]     "public-ipv4": "54.165.55.224",
[taskcluster 2020-05-23T00:35:16.109Z]     "region": "us-east-1"
[taskcluster 2020-05-23T00:35:16.109Z]   }
[taskcluster 2020-05-23T00:35:16.109Z] Task ID: GpX7eJP5TXCUhNYC2_nvXA
[taskcluster 2020-05-23T00:35:16.109Z] === Task Starting ===
[taskcluster:error] TASK FAIL since the task payload is invalid. See errors:
[taskcluster:error] - mounts.3: Must validate one and only one schema (oneOf)
[taskcluster:error] - mounts.3.content: Must validate one and only one schema (oneOf)
[taskcluster:error] - mounts.3.content.sha256: Does not match pattern '^[a-f0-9]{64}$'
[taskcluster:error] Validation of payload failed for task GpX7eJP5TXCUhNYC2_nvXA
```

The CI failed, but it looks like the PR was merged anyway, maybe using Administrative override permissions?

In any case, this fixes the bustage introduced in that PR.