### PR TITLE
Fix web-server relative path causing sign-ins to fail

### DIFF
--- a/changelog/WmP_hUuOSO6kds4-yD691A.md
+++ b/changelog/WmP_hUuOSO6kds4-yD691A.md
@@ -1,0 +1,4 @@
+audience: users
+level: patch
+---
+An incorrect use of a relative path caused sign-ins to fail in v30.0.1.  This has been fixed.

--- a/services/web-server/src/servers/createApp.js
+++ b/services/web-server/src/servers/createApp.js
@@ -1,4 +1,5 @@
 const bodyParser = require('body-parser');
+const path = require('path');
 const bodyParserGraphql = require('body-parser-graphql');
 const session = require('express-session');
 const compression = require('compression');
@@ -19,7 +20,7 @@ module.exports = async ({ cfg, strategies, AuthorizationCode, AccessToken, auth,
 
   app.set('trust proxy', cfg.server.trustProxy);
   app.set('view engine', 'ejs');
-  app.set('views', 'src/views');
+  app.set('views', path.resolve(path.join(__dirname, '../views')));
 
   const allowedCORSOrigins = cfg.server.allowedCORSOrigins.map(o => {
     if (typeof(o) === 'string' && o.startsWith('/')) {


### PR DESCRIPTION
I was able to replicate the bug in my dev environment, and will verify the fix while this runs in CI.