### PR TITLE
Prevent onConnected from occuring before a message

### DIFF
--- a/changelog/issue-2913.md
+++ b/changelog/issue-2913.md
@@ -1,0 +1,4 @@
+audience: general
+level: silent
+reference: issue 2913
+---

--- a/libraries/pulse/src/consumer.js
+++ b/libraries/pulse/src/consumer.js
@@ -183,7 +183,10 @@ class PulseConsumer {
       // connection (better safe than sorry)
       channel.on('error', () => conn.failed());
 
-      const consumer = await channel.consume(queueName, async (msg) => {
+      // NOTE: channel.consume is not async!  In fact, await'ing it can
+      // result in a message arriving before the onConnected callback is
+      // invoked.
+      const consumer = channel.consume(queueName, async (msg) => {
         // If the consumer is cancelled by RabbitMQ, the message callback will
         // be invoked with null.  This might happen if the queue is deleted, in
         // which case we probably want to reconnect and redeclare everything.


### PR DESCRIPTION
This avoids a race condition where a consumer's onConnected callback
could be called *after* the first message is delivered.

This commit also fixes `consumer_test.js` to only start publishing
messages once connected.  This avoids the risk that the messages would
all be published before the consumer began; since this is an ephemeral
consumer, that would mean it receives no messages.

Github Bug/Issue: Fixes #2913