### PR TITLE
Support new-credentials message in docker-worker

### DIFF
--- a/changelog/bug-1640267.md
+++ b/changelog/bug-1640267.md
@@ -1,0 +1,4 @@
+audience: general
+level: silent
+reference: bug 1640267
+---

--- a/changelog/issue-2890.md
+++ b/changelog/issue-2890.md
@@ -1,0 +1,4 @@
+audience: general
+level: silent
+reference: issue 2890
+---

--- a/changelog/issue-2951.md
+++ b/changelog/issue-2951.md
@@ -1,0 +1,4 @@
+audience: general
+level: silent
+reference: issue 2951
+---

--- a/internal/workerproto/README.md
+++ b/internal/workerproto/README.md
@@ -98,8 +98,8 @@ This mesage is sent when credentials are renewed.
 The message may or may not contain a `certificate` property.
 
 ```
-~{"type": "new-credentials", "clientId": "...", "accessToken": "..."}
-~{"type": "new-credentials", "clientId": "...", "accessToken": "...", "certificate": "..."}
+~{"type": "new-credentials", "client-id": "...", "access-token": "..."}
+~{"type": "new-credentials", "client-id": "...", "access-token": "...", "certificate": "..."}
 ```
 
 If this message is not supported, worker-runner will attempt to gracefully shut down the worker when credentials expire.

--- a/internal/workerproto/README.md
+++ b/internal/workerproto/README.md
@@ -90,3 +90,16 @@ Note that for non-structured log destinations, the body property `textPayload` i
 Using this property will make non-structured logs much easier to read.
 
 There is no reponse message.
+
+### new-credentials
+
+This message type, sent from worker-runner, contains new credentials which the worker should use for subsequent Taskcluster API calls that are not related to a task.
+This mesage is sent when credentials are renewed.
+The message may or may not contain a `certificate` property.
+
+```
+~{"type": "new-credentials", "clientId": "...", "accessToken": "..."}
+~{"type": "new-credentials", "clientId": "...", "accessToken": "...", "certificate": "..."}
+```
+
+If this message is not supported, worker-runner will attempt to gracefully shut down the worker when credentials expire.

--- a/workers/docker-worker/src/bin/worker.js
+++ b/workers/docker-worker/src/bin/worker.js
@@ -207,9 +207,8 @@ program.parse(process.argv);
 
   config.gc.addManager(config.volumeCache);
 
-  let runtime = new Runtime(config);
+  let runtime = new Runtime({...config, hostManager: host});
 
-  runtime.hostManager = host;
   runtime.imageManager = new ImageManager(runtime);
 
   let shutdownManager;

--- a/workers/docker-worker/src/bin/worker.js
+++ b/workers/docker-worker/src/bin/worker.js
@@ -11,7 +11,6 @@ const reportHostMetrics = require('../lib/stats/host_metrics');
 const fs = require('fs');
 const os = require('os');
 const program = require('commander');
-const taskcluster = require('taskcluster-client');
 const createLogger = require('../lib/log').createLogger;
 const Debug = require('debug');
 const _ = require('lodash');
@@ -136,11 +135,6 @@ program.parse(process.argv);
     config[field] = program[field];
   });
 
-  taskcluster.config({
-    rootUrl: config.rootUrl,
-    credentials: config.taskcluster,
-  });
-
   // If restrict CPU is set override capacity (as long as capacity is > 0)
   // Capacity could be set to zero by the host configuration if the credentials and
   // other necessary information could not be retrieved from the meta/user/secret-data
@@ -169,11 +163,6 @@ program.parse(process.argv);
 
   config.monitor.measure('workerStart', Date.now() - os.uptime());
   config.monitor.count('workerStart');
-
-  config.queue = new taskcluster.Queue({
-    rootUrl: config.rootUrl,
-    credentials: config.taskcluster,
-  });
 
   const schemaset = new SchemaSet({
     serviceName: 'docker-worker',

--- a/workers/docker-worker/src/lib/devices/audio_device_manager.js
+++ b/workers/docker-worker/src/lib/devices/audio_device_manager.js
@@ -39,7 +39,7 @@ class AudioDeviceManager {
     `);
 
     if (deviceList.length === 0) {
-      throw new Error('No audio devices found; try setting deviceManager.loopbackAudio.enabled = false to disable the feature, or building the snd-aloop module into the kernel and configuring it');
+      throw new Error('No audio devices found; try setting deviceManagement.loopbackAudio.enabled = false to disable the feature, or building the snd-aloop module into the kernel and configuring it');
     }
 
     return deviceList;

--- a/workers/docker-worker/src/lib/devices/video_device_manager.js
+++ b/workers/docker-worker/src/lib/devices/video_device_manager.js
@@ -34,7 +34,7 @@ class VideoDeviceManager {
     `);
 
     if (deviceList.length === 0) {
-      throw new Error('No video devices found; try setting deviceManager.loopbackVideo.enabled = false to disable the feature, or building the v4l2loopback module into the kernel');
+      throw new Error('No video devices found; try setting deviceManagement.loopbackVideo.enabled = false to disable the feature, or building the v4l2loopback module into the kernel');
     }
 
     return deviceList;

--- a/workers/docker-worker/src/lib/docker/indexed_image.js
+++ b/workers/docker-worker/src/lib/docker/indexed_image.js
@@ -19,11 +19,6 @@ module.exports = class IndexedImage extends ArtifactImage {
     this.stream = stream;
     this.namespace = imageDetails.namespace;
     this.artifactPath = imageDetails.path;
-    this.index = new taskcluster.Index({
-      rootUrl: this.runtime.rootUrl,
-      credentials: this.runtime.taskcluster,
-      authorizedScopes: this.taskScopes,
-    });
     this.task = task;
     this.knownHashes = this.runtime.imageManager.imageHashes;
   }
@@ -52,8 +47,14 @@ module.exports = class IndexedImage extends ArtifactImage {
       return this.taskId;
     }
 
+    const index = new taskcluster.Index({
+      rootUrl: this.runtime.rootUrl,
+      credentials: this.runtime.taskcluster,
+      authorizedScopes: this.taskScopes,
+    });
+
     try {
-      let {taskId} = await this.index.findTask(this.namespace);
+      let {taskId} = await index.findTask(this.namespace);
       this.taskId = taskId;
       return taskId;
     } catch(e) {

--- a/workers/docker-worker/src/lib/host/test.js
+++ b/workers/docker-worker/src/lib/host/test.js
@@ -54,4 +54,6 @@ module.exports = {
   async shutdown() {
     process.exit(0);
   },
+  async onNewCredentials(cb) {
+  },
 };

--- a/workers/docker-worker/src/lib/host/worker-runner.js
+++ b/workers/docker-worker/src/lib/host/worker-runner.js
@@ -26,9 +26,9 @@ module.exports = {
     protocol.on('new-credentials-msg', msg => {
       if (newCredentialsCallback) {
         newCredentialsCallback({
-          clientId: msg.clientId,
-          accessToken: msg.accessToken,
-          certificate: msg.certificate,
+          clientId: msg['client-id'],
+          accessToken: msg['access-token'],
+          certificate: msg['certificate'],
         });
       }
     });

--- a/workers/docker-worker/src/lib/host/worker-runner.js
+++ b/workers/docker-worker/src/lib/host/worker-runner.js
@@ -6,18 +6,31 @@ const {StreamTransport, Protocol} = require('../worker-runner-protocol');
 // persistent state is as module-level globals.
 let protocol;
 let gracefulTermination = false;
+let newCredentialsCallback = null;
 
 module.exports = {
   setup() {
     const transp = new StreamTransport(process.stdin, process.stdout);
     protocol = new Protocol(transp);
 
-    // docker-worker doesn't support a finish-your-tasks-first termination,
-    // so we ignore that portion of the message
     protocol.addCapability('graceful-termination');
-    protocol.addCapability('shutdown');
     protocol.on('graceful-termination-msg', () => {
+      // docker-worker doesn't support a finish-your-tasks-first termination,
+      // so we ignore that portion of the message
       gracefulTermination = true;
+    });
+
+    protocol.addCapability('shutdown');
+
+    protocol.addCapability('new-credentials');
+    protocol.on('new-credentials-msg', msg => {
+      if (newCredentialsCallback) {
+        newCredentialsCallback({
+          clientId: msg.clientId,
+          accessToken: msg.accessToken,
+          certificate: msg.certificate,
+        });
+      }
     });
 
     protocol.start();
@@ -47,5 +60,9 @@ module.exports = {
       throw new Error('Shutdown called but worker-runner doesn\'t support this capability');
     }
     protocol.send({type: 'shutdown'});
+  },
+
+  async onNewCredentials(cb) {
+    newCredentialsCallback = cb;
   },
 };

--- a/workers/docker-worker/src/lib/queueservice.js
+++ b/workers/docker-worker/src/lib/queueservice.js
@@ -1,4 +1,5 @@
 const Debug = require('debug');
+const taskcluster = require('taskcluster-client');
 const assert = require('assert');
 
 const MAX_MESSAGES_PER_REQUEST = 32;
@@ -9,22 +10,15 @@ let debug = Debug('taskcluster-docker-worker:queueService');
  * Create a task queue that will poll for queues that could contain messages and
  * claim work based on the available capacity of the worker.
  *
- * config:
+ * config: (a copy of Runtime)
  * {
  *   workerId:          // Worker ID for this worker
  *   workerType:        // Worker type for this worker
  *   workerGroup:       // Worker group for this worker
  *   provisionerID:     // ID of the provisioner used for this worker
- *   queue:             // Queue instance as provided by taskcluster-client
  *   log:               // Logger instance
- *   task: {
- *     dequeueCount:    // Times a task should be dequeued before permanently
- *                      // removing from the queue.
- *   }
- *   taskQueue: {
- *     expiration:            // Time in milliseconds used to determine if the
- *                            // queues should be refreshed
- *   }
+ *   taskcluster:       // Taskcluster credentials
+ *   rootUrl:           // Root URL
  * }
  *
  */
@@ -34,15 +28,16 @@ class TaskQueue {
     assert(config.workerType, 'Worker type is required');
     assert(config.workerGroup, 'Worker group is required');
     assert(config.provisionerId, 'Provisioner ID is required');
-    assert(config.queue, 'Instance of taskcluster queue is required');
+    assert(config.taskcluster, 'Taskcluster credentials are required');
+    assert(config.rootUrl, 'Taskcluster rotoUrl is required');
     assert(config.log, 'Logger is required');
-    this.queues = null;
-    this.queue = config.queue;
+
+    this.runtime = config;
+
     this.workerType = config.workerType;
     this.provisionerId = config.provisionerId;
     this.workerGroup = config.workerGroup;
     this.workerId = config.workerId;
-    this.client = config.queue;
     this.log = config.log;
   }
 
@@ -57,7 +52,8 @@ class TaskQueue {
     capacity = Math.min(capacity, MAX_MESSAGES_PER_REQUEST);
     debug(`polling for ${capacity} tasks`);
 
-    let result = await this.queue.claimWork(this.provisionerId, this.workerType, {
+    const queue = this.queueClient();
+    let result = await queue.claimWork(this.provisionerId, this.workerType, {
       tasks: capacity,
       workerGroup: this.workerGroup,
       workerId: this.workerId,
@@ -72,6 +68,28 @@ class TaskQueue {
       });
     });
     return result.tasks;
+  }
+
+  /**
+   * Call the queue service's claimTask endpoint
+   */
+  async claimTask(taskId, runId) {
+    const queue = this.queueClient();
+    return await queue.claimTask(taskId, runId, {
+      workerId: this.runtime.workerId,
+      workerGroup: this.runtime.workerGroup,
+    });
+  }
+
+  /**
+   * Create a new Queue client object.  This is done on-demand so that it uses
+   * the most up-to-date credentials.
+   */
+  queueClient() {
+    return new taskcluster.Queue({
+      rooturl: this.runtime.rooturl,
+      credentials: this.runtime.taskcluster,
+    });
   }
 }
 

--- a/workers/docker-worker/src/lib/queueservice.js
+++ b/workers/docker-worker/src/lib/queueservice.js
@@ -87,7 +87,7 @@ class TaskQueue {
    */
   queueClient() {
     return new taskcluster.Queue({
-      rooturl: this.runtime.rooturl,
+      rootUrl: this.runtime.rootUrl,
       credentials: this.runtime.taskcluster,
     });
   }

--- a/workers/docker-worker/src/lib/runtime.js
+++ b/workers/docker-worker/src/lib/runtime.js
@@ -21,13 +21,6 @@ Runtime.prototype = {
   docker: null,
 
   /**
-  Authenticated queue instance.
-
-  @type {taskcluster.Queue}
-  */
-  queue: null,
-
-  /**
   Pulse credentials `{username: '...', password: '...'}`
 
   @type {Object}

--- a/workers/docker-worker/src/lib/runtime.js
+++ b/workers/docker-worker/src/lib/runtime.js
@@ -10,6 +10,13 @@ function Runtime(options) {
 
   // Ensure capacity is always a number.
   if (this.capacity) {this.capacity = parseInt(this.capacity, 10);}
+
+  // set up to update credentials as necessary
+  if (this.hostManager) {
+    this.hostManager.onNewCredentials(creds => {
+      this.taskcluster = creds;
+    });
+  }
 }
 
 Runtime.prototype = {

--- a/workers/docker-worker/src/lib/task_listener.js
+++ b/workers/docker-worker/src/lib/task_listener.js
@@ -4,7 +4,6 @@ execution of tasks.
 */
 const TaskQueue = require('./queueservice');
 const DeviceManager = require('./devices/device_manager');
-const taskcluster = require('taskcluster-client');
 const Debug = require('debug');
 const got = require('got');
 const { Task } = require('./task');
@@ -386,11 +385,6 @@ class TaskListener extends EventEmitter {
           message: 'initial taskId not included in result from superseder'});
         return [claim];
       }
-
-      const queue = new taskcluster.Queue({
-        rootUrl: this.runtime.rootUrl,
-        credentials: this.runtime.taskcluster,
-      });
 
       // claim runId 0 for each of those tasks; we can consider adding support
       // for other runIds later.

--- a/workers/docker-worker/test/integration/container_volume_caching_test.js
+++ b/workers/docker-worker/test/integration/container_volume_caching_test.js
@@ -493,7 +493,8 @@ helper.secrets.mockSuite(suiteName(), ['docker', 'ci-creds'], function(mock, ski
     assert.throws(() => fs.readdirSync(fullCacheDir), err => err.code === 'ENOENT');
   });
 
-  test('purge cache during run task', async () => {
+  // intermittent - https://bugzilla.mozilla.org/show_bug.cgi?id=1640267
+  test.skip('purge cache during run task', async () => {
     let cacheName = 'docker-worker-garbage-caches-tmp-obj-dir-' + Date.now().toString();
     let neededScope = 'docker-worker:cache:' + cacheName;
     let fullCacheDir = path.join(localCacheDir, cacheName);

--- a/workers/docker-worker/test/integration/file_artifact_test.js
+++ b/workers/docker-worker/test/integration/file_artifact_test.js
@@ -273,7 +273,8 @@ helper.secrets.mockSuite(suiteName(), ['docker', 'ci-creds'], function(mock, ski
     assert.equal(result.artifacts['public/my-missing.txt'].storageType, 'error');
   });
 
-  test('upload retry', async () => {
+  // intermittent https://github.com/taskcluster/taskcluster/issues/2951
+  test.skip('upload retry', async () => {
     await retryUtil.init();
     let retry = false;
     let blocked = false;


### PR DESCRIPTION
This does some refactoring in docker-worker.  It doesn't touch generic-worker, because I want to wait until #2854 lands as that will conflict pretty badly.

Note that worker-runner doesn't send this message yet, as the reregisterWorker call doesn't exist yet.

Github Bug/Issue: refs #2890