### PR TITLE
Bug 1632929 - use target_commitish to get SHA for releases

### DIFF
--- a/changelog/bug-1632929.md
+++ b/changelog/bug-1632929.md
@@ -1,0 +1,5 @@
+audience: users
+level: patch
+reference: bug 1632929
+---
+Taskcluster-Github now uses a release event's `target_commitish` property instead of the `tag` property to determine the SHA of the released commit.  This is important in cases where tags are created as part of the release-creation call, as GitHub sends the release event before the tag is created.

--- a/services/github/test/handler_test.js
+++ b/services/github/test/handler_test.js
@@ -284,6 +284,10 @@ helper.secrets.mockSuite(testing.suiteName(), ['db'], function(mock, skipping) {
         // This should be solved in a more reliable fashion.
         delete details['event.head.sha'];
         delete details['event.head.ref'];
+        delete body['pull_request'];
+        body['release'] = {
+          target_commitish: 'refs/tags/v1.2.3',
+        };
         details['event.version'] = 'v1.2.3';
       }
       if (eventType === 'tag') {


### PR DESCRIPTION
Bugzilla Bug: [1632929](https://bugzilla.mozilla.org/show_bug.cgi?id=1632929)
