### PR TITLE
correctly include metadata in fields

### DIFF
--- a/changelog/c20QJm0BT0e_6VKlDpp2yQ.md
+++ b/changelog/c20QJm0BT0e_6VKlDpp2yQ.md
@@ -1,4 +1,4 @@
 audience: deployers
 level: patch
 ---
-Taskcluster services now include metadata at the top level of Fields for `generic.*` logging messages, rather than in a `meta` property.
+Taskcluster services now include metadata at the top level of Fields for `generic.*` logging messages, rather than in `meta` or `fields` sub-properties.

--- a/libraries/monitor/src/logger.js
+++ b/libraries/monitor/src/logger.js
@@ -140,7 +140,7 @@ class Logger {
 
     if (this.metadata) {
       // include metadata, but prefer a value from fields if set in both places
-      fields = {...this.metadata, fields};
+      fields = {...this.metadata, ...fields};
     }
 
     // determine a top-level message for the log entry..


### PR DESCRIPTION
I noticed this while working on the google provider tests.  Apparently I failed to notice this when I tested 2f57cefb4dc698f680041d4c70c4eb5a3ee5e85d manually!  That commit hasn't been released yet, so this just fixes the fix.