### PR TITLE
Bug 1639713: /dev/shm should be a bind mount, not a device mount

### DIFF
--- a/changelog/bug-1639713.md
+++ b/changelog/bug-1639713.md
@@ -1,0 +1,5 @@
+level: patch
+audience: users
+reference: bug 1639713
+---
+Tasks using the `hostSharedMemory` device capability will now properly mount `/dev/shm` from the host into the container.

--- a/workers/docker-worker/src/lib/devices/shared_memory_device_manager.js
+++ b/workers/docker-worker/src/lib/devices/shared_memory_device_manager.js
@@ -25,8 +25,9 @@ class SharedMemoryDeviceManager {
 
 class SharedMemoryDevice {
   constructor() {
-    this.mountPoints = [
-      '/dev/shm',
+    this.mountPoints = [];
+    this.binds = [
+      '/dev/shm:/dev/shm',
     ];
   }
 

--- a/workers/docker-worker/src/lib/task.js
+++ b/workers/docker-worker/src/lib/task.js
@@ -138,6 +138,7 @@ async function buildDeviceBindings(devices, expandedScopes) {
   }
 
   let deviceBindings = [];
+  let bindMounts = [];
   for (let deviceType of Object.keys(devices || {})) {
     let device = devices[deviceType];
     device.mountPoints.forEach((mountPoint) => {
@@ -149,9 +150,12 @@ async function buildDeviceBindings(devices, expandedScopes) {
         },
       );
     });
+    if (device.binds) {
+      bindMounts = _.union(bindMounts, device.binds);
+    }
   }
 
-  return deviceBindings;
+  return [deviceBindings, bindMounts];
 }
 
 class Reclaimer {
@@ -365,11 +369,6 @@ class Task extends EventEmitter {
     });
     let expandedScopes = (await auth.expandScopes({scopes: this.task.scopes})).scopes;
 
-    if (this.options.devices) {
-      let bindings = await buildDeviceBindings(this.options.devices, expandedScopes);
-      procConfig.create.HostConfig['Devices'] = bindings;
-    }
-
     if (linkInfo.links) {
       procConfig.create.HostConfig.Links = linkInfo.links.map(link => {
         return link.name + ':' + link.alias;
@@ -384,6 +383,12 @@ class Task extends EventEmitter {
       }
       return binding;
     });
+
+    if (this.options.devices) {
+      let bindings = await buildDeviceBindings(this.options.devices, expandedScopes);
+      procConfig.create.HostConfig['Devices'] = bindings[0];
+      binds = _.union(binds, bindings[1]);
+    }
 
     if (this.task.payload.cache) {
       let bindings = await buildVolumeBindings(this.task.payload.cache,

--- a/workers/docker-worker/src/lib/task.js
+++ b/workers/docker-worker/src/lib/task.js
@@ -155,7 +155,7 @@ async function buildDeviceBindings(devices, expandedScopes) {
     }
   }
 
-  return [deviceBindings, bindMounts];
+  return {deviceBindings, bindMounts};
 }
 
 class Reclaimer {
@@ -386,8 +386,8 @@ class Task extends EventEmitter {
 
     if (this.options.devices) {
       let bindings = await buildDeviceBindings(this.options.devices, expandedScopes);
-      procConfig.create.HostConfig['Devices'] = bindings[0];
-      binds = _.union(binds, bindings[1]);
+      procConfig.create.HostConfig['Devices'] = bindings.deviceBindings;
+      binds = _.union(binds, bindings.bindMounts);
     }
 
     if (this.task.payload.cache) {


### PR DESCRIPTION
Bugzilla Bug: [1639713](https://bugzilla.mozilla.org/show_bug.cgi?id=1639713)

Capability devices normally use the equivalent of `--device` for mounting devices from the host into the container. `/dev/shm` is different since it is a tmpfs volume, and it should be mounted using a bind mount equivalent to `--volume`.

Note that a test already exists for this, but I'm not sure if those are run, since it should have exhibited the same error reported in bugzilla.