### PR TITLE
Add taskcluster-proxy to releases

### DIFF
--- a/changelog/EP7fStTETSijolmkfxmm0Q.md
+++ b/changelog/EP7fStTETSijolmkfxmm0Q.md
@@ -1,0 +1,4 @@
+audience: developers
+level: patch
+---
+Release tasks now have access to taskcluster-proxy

--- a/taskcluster/ci/release/kind.yml
+++ b/taskcluster/ci/release/kind.yml
@@ -11,6 +11,7 @@ job-defaults:
   worker-type: release
   worker:
     max-run-time: 3600
+    taskcluster-proxy: true
     artifacts:
       - path: taskcluster/release-debug-logs
         name: debug-logs # Note: this should never be public because who knows what is in here


### PR DESCRIPTION
Fetching secrets doesn't happen in staging releases so I missed this.
