### PR TITLE
Allow deprecated functions

### DIFF
--- a/changelog/GyYxIoiJTgCktahTEIIoyg.md
+++ b/changelog/GyYxIoiJTgCktahTEIIoyg.md
@@ -1,0 +1,3 @@
+audience: general
+level: silent
+---

--- a/db/src/fakes/index.js
+++ b/db/src/fakes/index.js
@@ -23,14 +23,19 @@ class FakeDatabase {
   constructor({schema, serviceName}) {
     const allMethods = schema.allMethods();
     this.fns = {};
+    this.deprecatedFns = {};
 
     COMPONENT_CLASSES.forEach(({name, cls}) => {
       const instance = new cls({schema, serviceName});
       this[name] = instance;
 
-      allMethods.forEach(({ name: methodName, mode, serviceName: fnServiceName }) => {
+      allMethods.forEach(({ name: methodName, mode, serviceName: fnServiceName, deprecated }) => {
         if (instance[methodName]) {
-          this.fns[methodName] = async (...args) => {
+          let collection = this.fns;
+          if (deprecated) {
+            collection = this.deprecatedFns;
+          }
+          collection[methodName] = async (...args) => {
             if (serviceName !== fnServiceName && mode === WRITE) {
               throw new Error(
                 `${serviceName} is not allowed to call any methods that do not belong to this service and which have mode=WRITE`,

--- a/db/test/all_fns_test.js
+++ b/db/test/all_fns_test.js
@@ -1,3 +1,4 @@
+const _ = require('lodash');
 const assert = require('assert').strict;
 const tcdb = require('taskcluster-db');
 const testing = require('taskcluster-lib-testing');
@@ -6,13 +7,18 @@ const {FakeDatabase} = require('../src/fakes');
 suite(testing.suiteName(), function() {
   test('Set of real functions matches the set of fake functions', function() {
     const schema = tcdb.schema({useDbDirectory: true});
-    const dbMethods = schema.allMethods().map(({name}) => name).sort();
+    const allMethods = schema.allMethods();
+    let [dbMethods, deprecatedDbMethods] = _.partition(allMethods, {'deprecated': false});
+    dbMethods = dbMethods.map(({name}) => name).sort();
+    deprecatedDbMethods = deprecatedDbMethods.map(({name}) => name).sort();
 
     const fakeDb = new FakeDatabase({schema, serviceName: 'test'});
     const fakeMethods = Object.keys(fakeDb.fns).sort();
+    const deprecatedFakeMethods = Object.keys(fakeDb.deprecatedFns).sort();
 
     // If this fails, probably someone somewhere added a stored function in a
-    // DB version and did not a fake version.
+    // DB version and did not add a fake version.
     assert.deepEqual(dbMethods, fakeMethods);
+    assert.deepEqual(deprecatedDbMethods, deprecatedFakeMethods);
   });
 });

--- a/libraries/postgres/README.md
+++ b/libraries/postgres/README.md
@@ -174,6 +174,9 @@ methods:
     # still exist in the database!  Defaults to false, so this is omitted unless needed.
     # All other method fields can be omitted when this is true, thus supporting
     # deprecating a method without changing it.
+    # When a method is deprecated, it is no longer available in `db.fns` but is made
+    # available in `db.deprecatedFns` for use in testing but this method should no
+    # longer be used in production.
     deprecated: true
 
     # The body of the stored function.  This is passed verbatim to `CREATE FUNCTION`.

--- a/libraries/postgres/src/Database.js
+++ b/libraries/postgres/src/Database.js
@@ -396,7 +396,11 @@ class Database {
           await client.query(`DO ${dollarQuote(migrationScript)}`);
         }
         showProgress('..defining methods');
-        for (let [methodName, { args, body, returns}] of Object.entries(version.methods)) {
+        for (let [methodName, {deprecated, args, body, returns}] of Object.entries(version.methods)) {
+          // We don't need to do anything for deprecated methods
+          if (deprecated) {
+            continue;
+          }
           await client.query(`create or replace function
           "${methodName}"(${args})
           returns ${returns}

--- a/libraries/postgres/src/Database.js
+++ b/libraries/postgres/src/Database.js
@@ -76,13 +76,14 @@ class Database {
   _createProcs({schema, serviceName}) {
     // generate a JS method for each DB method defined in the schema
     this.fns = {};
+    this.deprecatedFns = {};
     schema.allMethods().forEach(method => {
-      // ignore deprecated methods
+      let collection = this.fns;
       if (method.deprecated) {
-        return;
+        collection = this.deprecatedFns;
       }
 
-      this.fns[method.name] = async (...args) => {
+      collection[method.name] = async (...args) => {
         if (serviceName !== method.serviceName && method.mode !== READ) {
           throw new Error(
             `${serviceName} is not allowed to call read-write methods for ${method.serviceName}`);

--- a/libraries/postgres/src/Database.js
+++ b/libraries/postgres/src/Database.js
@@ -397,10 +397,9 @@ class Database {
           await client.query(`DO ${dollarQuote(migrationScript)}`);
         }
         showProgress('..defining methods');
-        for (let [methodName, {deprecated, args, body, returns}] of Object.entries(version.methods)) {
-          // We don't need to do anything for deprecated methods
-          if (deprecated) {
-            continue;
+        for (let [methodName, {args, body, returns, deprecated}] of Object.entries(version.methods)) {
+          if (deprecated && !args && !returns && !body) {
+            continue; // This allows just deprecating without changing a method
           }
           await client.query(`create or replace function
           "${methodName}"(${args})

--- a/libraries/postgres/src/Database.js
+++ b/libraries/postgres/src/Database.js
@@ -85,7 +85,7 @@ class Database {
       this.fns[method.name] = async (...args) => {
         if (serviceName !== method.serviceName && method.mode !== READ) {
           throw new Error(
-            `${serviceName} is not allowed to call read-write methods for other services`);
+            `${serviceName} is not allowed to call read-write methods for ${method.serviceName}`);
         }
 
         this._logDbFunctionCall({name: method.name});

--- a/libraries/postgres/src/Schema.js
+++ b/libraries/postgres/src/Schema.js
@@ -115,9 +115,7 @@ class Schema {
       (acc, version) => {
         Object.entries(version.methods).forEach(([name, method]) => {
           if (method.deprecated) {
-            const content = acc.get(name);
-            assert(content, 'Cannot deprecate new functions');
-            Object.assign(method, content, {deprecated: true});
+            Object.assign(method, acc.get(name), {deprecated: true});
           }
           acc.set(name, method);
         });

--- a/libraries/postgres/src/Schema.js
+++ b/libraries/postgres/src/Schema.js
@@ -113,7 +113,14 @@ class Schema {
   allMethods() {
     const map = this.versions.reduce(
       (acc, version) => {
-        Object.entries(version.methods).forEach(([name, method]) => acc.set(name, method));
+        Object.entries(version.methods).forEach(([name, method]) => {
+          if (method.deprecated) {
+            const content = acc.get(name);
+            assert(content, 'Cannot deprecate new functions');
+            Object.assign(method, content, {deprecated: true});
+          }
+          acc.set(name, method);
+        });
         return acc;
       }, new Map());
 


### PR DESCRIPTION
As part of working on the existing-capacity stuff I found that deprecating db functions didn't actually work. This splits those changes out into a PR by itself.