### PR TITLE
Use the task's Queue client to fetch artifacts for mounts

### DIFF
--- a/changelog/issue-3004.md
+++ b/changelog/issue-3004.md
@@ -1,0 +1,5 @@
+audience: users
+level: patch
+reference: issue 3004
+---
+Generic-worker now uses the task's credentials to fetch artifacts specified in the `mounts` property of the task's payload.  This will allow use of private artifacts in mounts.

--- a/workers/generic-worker/.gitignore
+++ b/workers/generic-worker/.gitignore
@@ -1,0 +1,1 @@
+important-docs/

--- a/workers/generic-worker/mounts.go
+++ b/workers/generic-worker/mounts.go
@@ -722,7 +722,7 @@ func (ac *ArtifactContent) Download(task *TaskRun) (file string, sha256 string, 
 	basename := slugid.Nice()
 	file = filepath.Join(config.DownloadsDir, basename)
 	var signedURL *url.URL
-	signedURL, err = queue.GetLatestArtifact_SignedURL(ac.TaskID, ac.Artifact, time.Minute*30)
+	signedURL, err = task.Queue.GetLatestArtifact_SignedURL(ac.TaskID, ac.Artifact, time.Minute*30)
 	if err != nil {
 		return
 	}


### PR DESCRIPTION
Github Bug/Issue: Fixes #3004