### PR TITLE
Don't require TASKCLUSTER_* env vars to be set for generic-worker CI tests

### DIFF
--- a/changelog/HBDvjvnGTvOVUcCcCG89Zw.md
+++ b/changelog/HBDvjvnGTvOVUcCcCG89Zw.md
@@ -1,0 +1,3 @@
+audience: general
+level: silent
+---

--- a/workers/generic-worker/helper_broken_on_docker_test.go
+++ b/workers/generic-worker/helper_broken_on_docker_test.go
@@ -39,11 +39,7 @@ func CancelTask(t *testing.T) (td *tcqueue.TaskDefinitionRequest, payload Generi
 		Command:    command,
 		MaxRunTime: 300,
 	}
-	fullCreds := &tcclient.Credentials{
-		AccessToken: config.AccessToken,
-		ClientID:    config.ClientID,
-		Certificate: config.Certificate,
-	}
+	fullCreds := config.Credentials()
 	td = testTask(t)
 	tempCreds, err := fullCreds.CreateNamedTemporaryCredentials("project/taskcluster:generic-worker-tester/"+t.Name(), time.Minute, "queue:cancel-task:"+td.SchedulerID+"/"+td.TaskGroupID+"/*")
 	if err != nil {

--- a/workers/generic-worker/helper_test.go
+++ b/workers/generic-worker/helper_test.go
@@ -474,6 +474,9 @@ func GWTest(t *testing.T) *Test {
 		for _, s := range mocktc.ServiceProviders(t) {
 			s.RegisterService(r)
 		}
+		testConfig.AccessToken = "test-access-token"
+		testConfig.ClientID = "test-client-id"
+		testConfig.Certificate = ""
 	}
 
 	r.NotFoundHandler = http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {

--- a/workers/generic-worker/mocktc/queue.go
+++ b/workers/generic-worker/mocktc/queue.go
@@ -72,6 +72,10 @@ func (queue *Queue) ClaimWork(provisionerId, workerType string, payload *tcqueue
 				tcqueue.TaskClaim{
 					Task:   j.Task,
 					Status: j.Status,
+					Credentials: tcqueue.TaskCredentials{
+						ClientID:    "test-task-client-id",
+						AccessToken: "test-task-access-token",
+					},
 				},
 			)
 			if len(tasks) == int(maxTasks) {


### PR DESCRIPTION
Github Bug/Issue: Fixes #3007