### PR TITLE
Fix using build.sh for running generic-worker tests locally

### DIFF
--- a/changelog/QVPvIFOyRCSFj7GOJPyvoA.md
+++ b/changelog/QVPvIFOyRCSFj7GOJPyvoA.md
@@ -1,0 +1,3 @@
+audience: general
+level: silent
+---

--- a/go.mod
+++ b/go.mod
@@ -49,7 +49,7 @@ require (
 	golang.org/x/crypto v0.0.0-20200604202706-70a84ac30bf9
 	golang.org/x/net v0.0.0-20200602114024-627f9648deb9
 	golang.org/x/sys v0.0.0-20200602225109-6fdc65e7d980
-	golang.org/x/tools v0.0.0-20200610052024-8d7dbee4c8ae
+	golang.org/x/tools v0.0.0-20200610160956-3e83d1e96d0e
 	gopkg.in/tylerb/graceful.v1 v1.2.15
 	gopkg.in/yaml.v2 v2.2.8
 	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c

--- a/go.sum
+++ b/go.sum
@@ -215,6 +215,7 @@ golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8U
 golang.org/x/crypto v0.0.0-20200604202706-70a84ac30bf9 h1:vEg9joUBmeBcK9iSJftGNf3coIG4HqZElCPehJsfAYM=
 golang.org/x/crypto v0.0.0-20200604202706-70a84ac30bf9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
+golang.org/x/lint v0.0.0-20190313153728-d0100b6bd8b3 h1:XQyxROzUlZH+WIQwySDgnISgOivlhjIEwaQaJEJrrN0=
 golang.org/x/lint v0.0.0-20190313153728-d0100b6bd8b3/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
 golang.org/x/mod v0.2.0 h1:KU7oHjnv3XNWfa5COkzUifxZmxp1TyI7ImMXqFxLwvQ=
 golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
@@ -254,8 +255,8 @@ golang.org/x/tools v0.0.0-20180221164845-07fd8470d635/go.mod h1:n7NCudcB/nEzxVGm
 golang.org/x/tools v0.0.0-20190114222345-bf090417da8b/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20190311212946-11955173bddd/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=
 golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
-golang.org/x/tools v0.0.0-20200610052024-8d7dbee4c8ae h1:Tzc/wv256GkBNOkrWbHBeV3T08mrVevgo/q5KSGltr0=
-golang.org/x/tools v0.0.0-20200610052024-8d7dbee4c8ae/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
+golang.org/x/tools v0.0.0-20200610160956-3e83d1e96d0e h1:e4QHf+oWc6QYokfYSNYRbbyKYP01forNHSVGS06jJ54=
+golang.org/x/tools v0.0.0-20200610160956-3e83d1e96d0e/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=

--- a/workers/generic-worker/build.sh
+++ b/workers/generic-worker/build.sh
@@ -60,13 +60,24 @@ fi
 
 function install {
   if ! $PUBLISH; then
-      GOOS="${2}" GOARCH="${3}" CGO_ENABLED=0 go install -ldflags "-X main.revision=$(git rev-parse HEAD)" -tags "${1}" -v ./...
       GOOS="${2}" GOARCH="${3}" go vet -tags "${1}" ./...
       # note, this just builds tests, it doesn't run them!
-      GOOS="${2}" GOARCH="${3}" CGO_ENABLED=0 go test -tags "${1}" -c .
-      GOOS="${2}" GOARCH="${3}" CGO_ENABLED=0 go test -tags "${1}" -c ./livelog
+      go list ./... | while read package; do
+        GOOS="${2}" GOARCH="${3}" CGO_ENABLED=0 go test -tags "${1}" -c "${package}"
+      done
   fi
   GOOS="${2}" GOARCH="${3}" CGO_ENABLED=0 go build -o "$OUTPUT_DIR/generic-worker-${1}-${2}-${3}" -ldflags "-X main.revision=$(git rev-parse HEAD)" -tags "${1}" -v .
+  # check that revision number made it into target binary
+  if [ "${2}" == "$(go env GOHOSTOS)" ] && [ "${3}" == "$(go env GOHOSTARCH)" ]; then
+    if ! "$OUTPUT_DIR/generic-worker-${1}-${2}-${3}" --version | \
+    grep -Eq 'revision: https://github.com/taskcluster/taskcluster/commits/[a-z0-9]{40}'; then
+      echo "The --version option does not output a proper revision link"
+      exit 1
+    else
+      # ANSI escape sequence for green tick
+      echo -e "\x1b\x5b\x33\x32\x6d\xe2\x9c\x93\x1b\x5b\x30\x6d Revision number included in $OUTPUT_DIR/generic-worker-${1}-${2}-${3}"
+    fi
+  fi
 }
 
 # NOTE: when changing this, also update
@@ -94,7 +105,7 @@ else
      darwin) install simple    "${MY_GOHOSTOS}" "${MY_GOHOSTARCH}"
              install multiuser "${MY_GOHOSTOS}" "${MY_GOHOSTARCH}"
              ;;
-     freebsd) install simple    "${MY_GOHOSTOS}" "${MY_GOHOSTARCH}"
+    freebsd) install simple    "${MY_GOHOSTOS}" "${MY_GOHOSTARCH}"
              ;;
     windows) install multiuser "${MY_GOHOSTOS}" "${MY_GOHOSTARCH}"
              ;;
@@ -103,20 +114,24 @@ fi
 
 ls -1 "$OUTPUT_DIR"/generic-worker-*
 
-CGO_ENABLED=0 go get github.com/taskcluster/livelog
+CGO_ENABLED=0 go get \
+  github.com/taskcluster/taskcluster/v30/tools/livelog \
+  github.com/taskcluster/taskcluster/v30/tools/taskcluster-proxy \
+  golang.org/x/lint/golint \
+  github.com/gordonklaus/ineffassign \
+  golang.org/x/tools/cmd/goimports
+
+# Previous `go get` command modifies go module, so let's clean that up
+go mod tidy
 
 if $TEST; then
-  go get github.com/taskcluster/taskcluster/v30/tools/taskcluster-proxy
-  CGO_ENABLED=1 GORACE="history_size=7" /usr/bin/sudo "GOPATH=$GOPATH" "GW_TESTS_RUN_AS_CURRENT_USER=" "TASKCLUSTER_CERTIFICATE=$TASKCLUSTER_CERTIFICATE" "TASKCLUSTER_ACCESS_TOKEN=$TASKCLUSTER_ACCESS_TOKEN" "TASKCLUSTER_CLIENT_ID=$TASKCLUSTER_CLIENT_ID" "TASKCLUSTER_ROOT_URL=$TASKCLUSTER_ROOT_URL" $(which go) test -v -tags multiuser -ldflags "-X github.com/taskcluster/taskcluster/v30/workers/generic-worker.revision=$(git rev-parse HEAD)" -race -timeout 1h ./...
+  CGO_ENABLED=1 GORACE="history_size=7" go test -v -tags simple -ldflags "-X github.com/taskcluster/taskcluster/v30/workers/generic-worker.revision=$(git rev-parse HEAD)" -race -timeout 1h ./...
   MYGOHOSTOS="$(go env GOHOSTOS)"
   if [ "${MYGOHOSTOS}" == "linux" ] || [ "${MYGOHOSTOS}" == "darwin" ]; then
     CGO_ENABLED=1 GORACE="history_size=7" go test -v -tags docker -ldflags "-X github.com/taskcluster/taskcluster/v30/workers/generic-worker.revision=$(git rev-parse HEAD)" -race -timeout 1h ./...
   fi
-  go get golang.org/x/lint/golint
   golint $(go list ./...) | sed "s*${PWD}/**"
-  go get github.com/gordonklaus/ineffassign
   ineffassign .
-  go get golang.org/x/tools/cmd/goimports
 
   # We should uncomment this goimports command once either we no longer have
   # ciruclar go module dependencies that cause an older version of
@@ -126,8 +141,6 @@ if $TEST; then
   # goimports -w .
 
 fi
-
-go mod tidy
 
 echo "Build successful!"
 if ! $PUBLISH; then

--- a/workers/generic-worker/main_test.go
+++ b/workers/generic-worker/main_test.go
@@ -41,6 +41,10 @@ func TestIdleWithoutCrash(t *testing.T) {
 	}
 }
 
+// TestRevisionNumberStored is useful for ensuring that the test binary
+// includes the git revision number, so that it emulates the release binary.
+// There is a separate test that the release binary includes the revision
+// number in build.sh.
 func TestRevisionNumberStored(t *testing.T) {
 	if !regexp.MustCompile("^[0-9a-f]{40}$").MatchString(revision) {
 		t.Fatalf("Git revision could not be determined - got '%v' but expected to match regular expression '^[0-9a-f](40)$'\n"+


### PR DESCRIPTION
#3006 was closed, but it highlighted some genuine issues:

* The generic-worker binaries were not checked to ensure the git revision was included in the version information
* Running generic-worker tests from the command line was non-trivial

This PR is inspired from #3006, and solves these two issues by adding a check that the generic-worker binary includes the revision number (credit to @djmitche for this) and also fixes `build.sh -t` to work without needing root privileges. This means that you no longer need to run e.g.:

```
$ CGO_ENABLED=1 GORACE="history_size=7" go test -v -tags simple -ldflags "-X github.com/taskcluster/taskcluster/v30/workers/generic-worker.revision=$(git rev-parse HEAD)" -race ./...
```

from the command line, just to run the tests. Instead you can simply run e.g.:

```
./build.sh -t
```

Note, we could add `/workers/generic-worker/build.sh -a -t` to the top level `yarn test` - although it adds a bit of time on for tests - what do you think dustin? I didn't add it here, as I'm not sure if we want that or not, but can add it if you like.