### PR TITLE
Update TEST_DB_URL missing failure message to point to dev docs

### DIFF
--- a/changelog/ZCZhEhhoQ82YA86-T2lavA.md
+++ b/changelog/ZCZhEhhoQ82YA86-T2lavA.md
@@ -1,0 +1,3 @@
+audience: general
+level: silent
+---

--- a/db/test/helper.js
+++ b/db/test/helper.js
@@ -7,7 +7,7 @@ const debug = require('debug')('db-helper');
 const {UNDEFINED_TABLE} = require('taskcluster-lib-postgres');
 
 exports.dbUrl = process.env.TEST_DB_URL;
-assert(exports.dbUrl, "TEST_DB_URL must be set to run db/ tests");
+assert(exports.dbUrl, "TEST_DB_URL must be set to run db/ tests - see dev-docs/development-process.md for more information");
 
 /**
  * Set up to test a DB version.


### PR DESCRIPTION
Github Bug/Issue: Fixes #3021