### PR TITLE
use 'dbCryptoKeys' everywhere, fix typo

### DIFF
--- a/changelog/QCZ2xnUdSa6lZ8U5VdKoBQ.md
+++ b/changelog/QCZ2xnUdSa6lZ8U5VdKoBQ.md
@@ -1,0 +1,3 @@
+audience: general
+level: silent
+---

--- a/changelog/issue-2962.md
+++ b/changelog/issue-2962.md
@@ -2,4 +2,4 @@ audience: developers
 level: silent
 reference: issue 2962
 ---
-taskcluster-lib-postgres now supports `cryptoKeys` which allow for encrypting columns of a table.
+taskcluster-lib-postgres now supports a `dbCryptoKeys` configuration parameter which allow for encrypting columns of a table.

--- a/db/src/setup.js
+++ b/db/src/setup.js
@@ -3,7 +3,7 @@ const {Database, Keyring} = require('taskcluster-lib-postgres');
 const {FakeDatabase} = require('./fakes');
 
 exports.setup = async ({writeDbUrl, readDbUrl, serviceName, useDbDirectory,
-  statementTimeout, poolSize, monitor, azureCryptoKey, cryptoKeys}) => {
+  statementTimeout, poolSize, monitor, azureCryptoKey, dbCryptoKeys}) => {
   return await Database.setup({
     schema: schema({useDbDirectory}),
     writeDbUrl,
@@ -13,12 +13,12 @@ exports.setup = async ({writeDbUrl, readDbUrl, serviceName, useDbDirectory,
     poolSize,
     monitor,
     azureCryptoKey,
-    cryptoKeys,
+    dbCryptoKeys,
   });
 };
 
-exports.fakeSetup = async ({serviceName, azureCryptoKey, cryptoKeys}) => {
-  const keyring = new Keyring({azureCryptoKey, cryptoKeys});
+exports.fakeSetup = async ({serviceName, azureCryptoKey, dbCryptoKeys}) => {
+  const keyring = new Keyring({azureCryptoKey, dbCryptoKeys});
   return new FakeDatabase({
     schema: schema({useDbDirectory: true}),
     serviceName,

--- a/db/test/helper.js
+++ b/db/test/helper.js
@@ -59,7 +59,7 @@ exports.withDbForVersion = function() {
         serviceName,
         useDbDirectory: true,
         monitor: false,
-        cryptoKeys: [
+        dbCryptoKeys: [
           {
             id: 'db-tests',
             algo: 'aes-256',
@@ -127,7 +127,7 @@ exports.withDbForProcs = function({ serviceName }) {
       serviceName,
       useDbDirectory: true,
       monitor: false,
-      cryptoKeys: [
+      dbCryptoKeys: [
         {
           id: 'db-tests',
           algo: 'aes-256',
@@ -139,7 +139,7 @@ exports.withDbForProcs = function({ serviceName }) {
 
     exports.fakeDb = await tcdb.fakeSetup({
       serviceName,
-      cryptoKeys: [
+      dbCryptoKeys: [
         {
           id: 'db-tests',
           algo: 'aes-256',

--- a/libraries/postgres/README.md
+++ b/libraries/postgres/README.md
@@ -25,7 +25,7 @@ const db = Database.setup({
   statementTimeout: ..., // optional
   poolSize: ..., // optional, default 5
   azureCryptoKey: ..., // optional, only required to read lib-entities encrypted data
-  cryptoKeys: ..., // optional, only required if encrypting columns
+  dbCryptoKeys: ..., // optional, only required if encrypting columns, usually from cfg.postgres.dbCryptoKeys
 });
 ```
 
@@ -35,7 +35,7 @@ The `monitor` is a taskcluster-lib-monitor instance, used to report database met
 if `statementTimeout` is set, then it is treated as a timeout (in milliseconds) after which a statement will be aborted.
 This is typically used in web processes to abort statements running longer than 30s, after which time the HTTP client has likely given up.
 
-The `azureCryptoKey`, and `cryptoKeys` parameters are explained below in "Secret Data" and "Encryption".
+The `azureCryptoKey`, and `dbCryptoKeys` parameters are explained below in "Secret Data" and "Encryption".
 
 The `poolSize` parameter specifies the maximum number of Postgres clients in each pool of clients, with two pools (read and write) in use.
 DB function calls made when there are no clients available will be queued and wait until a client is avaliable.
@@ -255,7 +255,7 @@ The `db.encrypt` and `db.decrypt` methods serve to encrypt and decrypt values fo
 Both take a parameter named `value` that will either be encrypted and built into a format suitable for storing in the db
 or pulled out of that format and decryped.
 
-To enable encryption/decryption, provide `Database.setup` with at least one of `azureCryptoKey` or `cryptoKeys`. The first
+To enable encryption/decryption, provide `Database.setup` with at least one of `azureCryptoKey` or `dbCryptoKeys`. The first
 of which is the key that `lib-entities` used for encryption. The latter is structured like
 
 ```javascript

--- a/libraries/postgres/src/Database.js
+++ b/libraries/postgres/src/Database.js
@@ -52,7 +52,7 @@ class Database {
   /**
    * Get a new Database instance
    */
-  static async setup({schema, readDbUrl, writeDbUrl, cryptoKeys,
+  static async setup({schema, readDbUrl, writeDbUrl, dbCryptoKeys,
     azureCryptoKey, serviceName, monitor, statementTimeout, poolSize}) {
     assert(readDbUrl, 'readDbUrl is required');
     assert(writeDbUrl, 'writeDbUrl is required');
@@ -60,7 +60,7 @@ class Database {
     assert(serviceName, 'serviceName is required');
     assert(monitor !== undefined, 'monitor is required (but use `false` to disable)');
 
-    const keyring = new Keyring({azureCryptoKey, cryptoKeys});
+    const keyring = new Keyring({azureCryptoKey, dbCryptoKeys});
 
     const db = new Database({
       urlsByMode: {[READ]: readDbUrl, [WRITE]: writeDbUrl},

--- a/libraries/postgres/src/Keyring.js
+++ b/libraries/postgres/src/Keyring.js
@@ -4,7 +4,7 @@ class Keyring {
   /**
    * Construct a new keyring from a service's configuration.
    */
-  constructor({azureCryptoKey, cryptoKeys}) {
+  constructor({azureCryptoKey, dbCryptoKeys}) {
     this.crypto = new Map();
     this.currentCrypto = undefined;
 
@@ -24,8 +24,8 @@ class Keyring {
 
     // Our standard postgres keys. Anything in here will be considered more current than azure keys.
     // A key here with the name `azure` will override `azureCryptoKey`.
-    if (cryptoKeys) {
-      for (const {id, algo, key} of cryptoKeys) {
+    if (dbCryptoKeys) {
+      for (const {id, algo, key} of dbCryptoKeys) {
         assert(id, 'Keyring crypto keys must have `id`');
         assert(algo, 'Keyring crypto keys must have `algo`');
         assert(key, 'Keyring crypto keys must have `key`');

--- a/libraries/postgres/test/database_test.js
+++ b/libraries/postgres/test/database_test.js
@@ -726,7 +726,7 @@ helper.dbSuite(path.basename(__filename), function() {
 
       // This new_db does not have azureCryptoKey as it's current key but can still read old encryptions
       const new_db = await Database.setup({schema, readDbUrl: helper.dbUrl, writeDbUrl: helper.dbUrl,
-        serviceName: 'service-2', monitor, azureCryptoKey, cryptoKeys: [
+        serviceName: 'service-2', monitor, azureCryptoKey, dbCryptoKeys: [
           {id: 'foo', algo: 'aes-256', key: pgCryptoKey},
         ]});
       assert.equal(new_db.keyring.currentCryptoKey('aes-256').id, 'foo');

--- a/libraries/postgres/test/keyring_test.js
+++ b/libraries/postgres/test/keyring_test.js
@@ -22,14 +22,14 @@ suite(path.basename(__filename), function() {
   });
 
   test('only pg (single key)', function() {
-    const keyring = new Keyring({cryptoKeys: [{id: 'foo', algo: 'aes-256', key: pgCryptoKey}]});
+    const keyring = new Keyring({dbCryptoKeys: [{id: 'foo', algo: 'aes-256', key: pgCryptoKey}]});
     const {id, key} = keyring.currentCryptoKey('aes-256');
     assert.equal(id, 'foo');
     assert.equal(key.toString('base64'), pgCryptoKey);
   });
 
   test('only pg (multiple keys)', function() {
-    const keyring = new Keyring({cryptoKeys: [
+    const keyring = new Keyring({dbCryptoKeys: [
       {id: 'foo', algo: 'aes-256', key: pgCryptoKey},
       {id: 'bar', algo: 'aes-256', key: pgCryptoKey2},
     ]});
@@ -42,14 +42,14 @@ suite(path.basename(__filename), function() {
   });
 
   test('pg and azure (single key)', function() {
-    const keyring = new Keyring({cryptoKeys: [{id: 'foo', algo: 'aes-256', key: pgCryptoKey}]});
+    const keyring = new Keyring({dbCryptoKeys: [{id: 'foo', algo: 'aes-256', key: pgCryptoKey}]});
     const {id, key} = keyring.currentCryptoKey('aes-256');
     assert.equal(id, 'foo');
     assert.equal(key.toString('base64'), pgCryptoKey);
   });
 
   test('pg and azure (multiple keys)', function() {
-    const keyring = new Keyring({azureCryptoKey, cryptoKeys: [
+    const keyring = new Keyring({azureCryptoKey, dbCryptoKeys: [
       {id: 'foo', algo: 'aes-256', key: pgCryptoKey},
       {id: 'bar', algo: 'aes-256', key: pgCryptoKey2},
     ]});
@@ -64,31 +64,31 @@ suite(path.basename(__filename), function() {
 
   test('nonexistent algo', function() {
     assert.throws(() => {
-      new Keyring({cryptoKeys: [{id: 'foo', algo: 'bad-algo', key: pgCryptoKey}]});
+      new Keyring({dbCryptoKeys: [{id: 'foo', algo: 'bad-algo', key: pgCryptoKey}]});
     }, /Got bad-algo for foo/);
   });
 
   test('missing key', function() {
     assert.throws(() => {
-      new Keyring({cryptoKeys: [{id: 'foo', algo: 'aes-256'}]});
+      new Keyring({dbCryptoKeys: [{id: 'foo', algo: 'aes-256'}]});
     }, /Keyring crypto keys must have `key`/);
   });
 
   test('missing id', function() {
     assert.throws(() => {
-      new Keyring({cryptoKeys: [{algo: 'aes-256', key: pgCryptoKey}]});
+      new Keyring({dbCryptoKeys: [{algo: 'aes-256', key: pgCryptoKey}]});
     }, /Keyring crypto keys must have `id`/);
   });
 
   test('missing algo', function() {
     assert.throws(() => {
-      new Keyring({cryptoKeys: [{id: 'foo', key: pgCryptoKey}]});
+      new Keyring({dbCryptoKeys: [{id: 'foo', key: pgCryptoKey}]});
     }, /Keyring crypto keys must have `algo`/);
   });
 
   test('bad key', function() {
     assert.throws(() => {
-      new Keyring({cryptoKeys: [{id: 'foo', algo: 'aes-256', key: 'too-short'}]});
+      new Keyring({dbCryptoKeys: [{id: 'foo', algo: 'aes-256', key: 'too-short'}]});
     }, /aes-256 key must be 32 bytes in base64 in foo/);
   });
 });

--- a/libraries/testing/src/with-db.js
+++ b/libraries/testing/src/with-db.js
@@ -65,7 +65,7 @@ module.exports.withDb = (mock, skipping, helper, serviceName) => {
       return;
     }
 
-    const cryptoKeys = [
+    const dbCryptoKeys = [
       {
         id: 'testing',
         algo: 'aes-256',
@@ -74,7 +74,7 @@ module.exports.withDb = (mock, skipping, helper, serviceName) => {
     ];
 
     if (mock) {
-      helper.db = await tcdb.fakeSetup({serviceName, cryptoKeys});
+      helper.db = await tcdb.fakeSetup({serviceName, dbCryptoKeys});
     } else {
       const sec = helper.secrets.get('db');
 
@@ -97,7 +97,7 @@ module.exports.withDb = (mock, skipping, helper, serviceName) => {
         serviceName,
         useDbDirectory: true,
         monitor: false,
-        cryptoKeys,
+        dbCryptoKeys,
       });
     }
 

--- a/services/worker-manager/src/main.js
+++ b/services/worker-manager/src/main.js
@@ -46,7 +46,7 @@ let load = loader({
       serviceName: 'worker_manager',
       monitor: monitor.childMonitor('db'),
       statementTimeout: process === 'server' ? 30000 : 0,
-      crypoKeys: cfg.postgres.dbCryptoKeys,
+      dbCryptoKeys: cfg.postgres.dbCryptoKeys,
     }),
   },
 


### PR DESCRIPTION
This fixes a typo in `services/worker-manager/src/main.js` (`crytoKeys`), and additionally calls the value `dbCryptoKeys` throughout, rather than using different names in the configuration and the source code.