### PR TITLE
Only shut down between claimWork calls.

### DIFF
--- a/changelog/issue-3080.md
+++ b/changelog/issue-3080.md
@@ -1,0 +1,5 @@
+audience: worker-deployers
+level: patch
+reference: issue 3080
+---
+Docker-worker is now more careful to shut down only when it is idle and has not begun to claim a task, avoiding race conditions that could lead to `claim-expired` tasks.

--- a/taskcluster/ci/docker-worker/kind.yml
+++ b/taskcluster/ci/docker-worker/kind.yml
@@ -25,6 +25,7 @@ job-defaults:
     max-run-time: 10800
     docker-image: {taskcluster: worker-ci}
     env:
+      DEBUG: "*"
       WORKER_CI: '1'
       TASKCLUSTER_ROOT_URL: https://community-tc.services.mozilla.com
       NO_TEST_SKIP: 'true'

--- a/workers/docker-worker/src/bin/worker.js
+++ b/workers/docker-worker/src/bin/worker.js
@@ -213,16 +213,12 @@ program.parse(process.argv);
 
   let shutdownManager;
 
-  // Billing cycle logic is host specific so we cannot handle shutdowns without
-  // both the host and the configuration to shutdown.
-  if (host && config.shutdown) {
-    runtime.log('handle shutdowns');
-    shutdownManager = new ShutdownManager(host, runtime);
-    // Recommended by AWS to query every 5 seconds.  Termination window is 2 minutes
-    // so at the very least should have 1m55s to cleanly shutdown.
-    await shutdownManager.scheduleTerminationPoll();
-    runtime.shutdownManager = shutdownManager;
-  }
+  config.shutdown = config.shutdown || {};
+  shutdownManager = new ShutdownManager(host, runtime);
+  // Recommended by AWS to query every 5 seconds.  Termination window is 2 minutes
+  // so at the very least should have 1m55s to cleanly shutdown.
+  await shutdownManager.scheduleTerminationPoll();
+  runtime.shutdownManager = shutdownManager;
 
   if (runtime.logging.secureLiveLogging) {
     verifySSLCertificates(runtime);
@@ -231,7 +227,6 @@ program.parse(process.argv);
   // Build the listener and connect to the queue.
   let taskListener = new TaskListener(runtime);
   runtime.gc.taskListener = taskListener;
-  shutdownManager.observe(taskListener);
 
   await taskListener.connect();
 

--- a/workers/docker-worker/src/lib/task.js
+++ b/workers/docker-worker/src/lib/task.js
@@ -742,6 +742,7 @@ class Task extends EventEmitter {
    * @param {String} reason - Reason for aborting the test run (Example: worker-shutdown)
   */
   abort(reason) {
+    debug(`aborting task ${this.status.taskId} with reason ${reason}`);
     this.stopReclaims();
     this.taskState = 'aborted';
     this.taskException = reason;

--- a/workers/docker-worker/src/lib/task_listener.js
+++ b/workers/docker-worker/src/lib/task_listener.js
@@ -40,25 +40,6 @@ class TaskListener extends EventEmitter {
     this.deviceManager = new DeviceManager(runtime);
   }
 
-  listenForShutdowns() {
-    // If node will be shutdown, stop consuming events.
-    if (this.runtime.shutdownManager) {
-      this.runtime.shutdownManager.once('nodeTermination', async () => {
-        debug('nodeterm');
-        this.runtime.monitor.count('spotTermination');
-        await this.pause();
-        for (let state of this.runningTasks) {
-          try {
-            state.handler.abort('worker-shutdown');
-          } catch (e) {
-            debug('Caught error, but node is being terminated so continue on.');
-          }
-          this.cleanupRunningState(state);
-        }
-      });
-    }
-  }
-
   async cancelTask(message) {
     let runId = message.payload.runId;
     let reason = message.payload.status.runs[runId].reasonResolved;
@@ -122,6 +103,7 @@ class TaskListener extends EventEmitter {
   async getTasks() {
     let availableCapacity = await this.availableCapacity();
     if (availableCapacity === 0) {
+      debug('not calling claimWork because capacity is zero');
       return;
     }
 
@@ -137,54 +119,102 @@ class TaskListener extends EventEmitter {
       this.runtime.monitor,
     );
     // Do not claim tasks if not enough resources are available
-    if (exceedsThreshold) {return;}
+    if (exceedsThreshold) {
+      debug('not calling claimWork because not enough disk space');
+      return;
+    }
 
     let claims = await this.taskQueue.claimWork(availableCapacity);
 
-    if (claims.length === 0) {
-      // If the queue has no work for us, and we are not doing anything, then
-      // we are officially idle.  Note that we do not want to consider ourselves
-      // idle *before* the claimWork call returns, as we may be configured to
-      // shut down very quickly on idle, and shut down while still waiting for
-      // tasks from the queue (issue #2629).
-      if (this.isIdle()) {
-        this.emit('idle', this);
-      }
-    } else {
+    if (claims.length !== 0) {
       // only purge caches if we're about to start a task; this avoids calling
       // purge-cache on every getTasks loop
       await this.runtime.volumeCache.purgeCaches();
+
+      let tasksets = await Promise.all(claims.map(this.applySuperseding.bind(this)));
+      // call runTaskset for each taskset, but do not wait for it to complete
+      Promise.all(tasksets.map(this.runTaskset.bind(this)));
+    }
+  }
+
+  // Poll for tasks.  This happens periodically, even in cases where we have no capacity
+  // for new tasks (in which case getTasks returns immediately).
+  async taskPoll() {
+    try {
+      await this.getTasks();
+    } catch (e) {
+      this.runtime.log('[alert-operator] task retrieval error', {
+        message: e.toString(),
+        err: e,
+        stack: e.stack,
+      });
     }
 
-    let tasksets = await Promise.all(claims.map(this.applySuperseding.bind(this)));
-    // call runTaskset for each taskset, but do not wait for it to complete
-    Promise.all(tasksets.map(this.runTaskset.bind(this))).then(() => {
-      if (this.runtime.shutdownManager.shouldExit()) {
-        this.runtime.logEvent({eventType: 'instanceShutdown'});
-        process.exit();
-      }
-    });
+    // report idle/working state to the shutdown manager
+    if (this.isIdle()) {
+      this.runtime.shutdownManager.onIdle();
+    } else {
+      this.runtime.shutdownManager.onWorking();
+    }
+
+    // check for any reasons we might want to shut down in between claim
+    // attempts.
+    switch (this.runtime.shutdownManager.shouldExit()) {
+      case 'immediate':
+        this.runtime.monitor.count('spotTermination');
+
+        // abruptly terminate existing jobs
+        for (let state of this.runningTasks) {
+          try {
+            state.handler.abort('worker-shutdown');
+          } catch (e) {
+            debug(`error aborting with worker-shutdown: ${e}`);
+            // ignore error in production; queue will treat it as claim-expired
+          }
+          this.cleanupRunningState(state);
+        }
+
+        // wait until all tasks are finished..
+        while (!this.isIdle()) {
+          await new Promise(res => setTimeout(res, 100));
+        }
+
+        // terminate the worker
+        await this.shutdown();
+        break;
+
+      case 'graceful':
+        // stop accepting new jobs
+        this.runtime.capacity = 0;
+
+        // if we're idle, shut down now, otherwise keep polling
+        if (this.isIdle()) {
+          await this.shutdown();
+        }
+        break;
+    }
   }
 
   scheduleTaskPoll(nextPoll = this.taskPollInterval) {
-    this.pollTimeoutId = setTimeout(async () => {
-      try {
-        await this.getTasks();
-      } catch (e) {
-        this.runtime.log('[alert-operator] task retrieval error', {
-          message: e.toString(),
-          err: e,
-          stack: e.stack,
-        });
-      }
-      this.scheduleTaskPoll();
+    if (this.paused) {
+      return;
+    }
+
+    this.pollTimeoutId = setTimeout(() => {
+      this.taskPoll()
+        .catch(err => {
+          this.runtime.log('error polling tasks', {
+            message: err.toString(),
+            err: err,
+            stack: err.stack,
+          });
+        })
+        .then(() => this.scheduleTaskPoll());
     }, nextPoll);
   }
 
   async connect() {
     debug('begin consuming tasks');
-    //refactor to just have shutdown manager call terminate()
-    this.listenForShutdowns();
 
     this.runtime.logEvent({
       eventType: 'instanceBoot',
@@ -198,14 +228,15 @@ class TaskListener extends EventEmitter {
   }
 
   async close() {
+    await this.pause();
     clearInterval(this.reportCapacityStateIntervalId);
-    clearTimeout(this.pollTimeoutId);
   }
 
   /**
   Halt the flow of incoming tasks (but handle existing ones).
   */
   async pause() {
+    this.paused = true;
     clearTimeout(this.pollTimeoutId);
   }
 
@@ -213,7 +244,27 @@ class TaskListener extends EventEmitter {
   Resume the flow of incoming tasks.
   */
   async resume() {
+    this.paused = false;
     this.scheduleTaskPoll();
+  }
+
+  /**
+   * Shut down the worker
+   */
+  async shutdown() {
+    // stop accepting new tasks
+    await this.pause();
+
+    // (just in case..)
+    this.runtime.capacity = 0;
+
+    // send several historical log messages
+    this.runtime.log('shutdown');
+    this.runtime.logEvent({eventType: 'instanceShutdown'});
+    this.runtime.log('exit');
+
+    // defer to the host impelementation to actually shut down
+    await this.host.shutdown();
   }
 
   isIdle() {
@@ -253,12 +304,6 @@ class TaskListener extends EventEmitter {
     this.recordCapacity();
 
     this.runningTasks.push(runningState);
-
-    // After going from an idle to a working state issue a 'working' event.
-    // unless we receive a notification of worker shutdown
-    if (this.runningTasks.length === 1 && !this.runtime.shutdownManager.shouldExit()) {
-      this.emit('working', this);
-    }
   }
 
   removeRunningTask(runningState) {
@@ -510,10 +555,6 @@ class TaskListener extends EventEmitter {
       runningState.handler = taskHandler;
 
       this.addRunningTask(runningState);
-
-      if (this.runtime.shutdownManager.shouldExit()) {
-        runningState.handler.abort('worker-shutdown');
-      }
 
       // Run the task and collect runtime metrics.
       try {

--- a/workers/docker-worker/test/integration/shutdown_test.js
+++ b/workers/docker-worker/test/integration/shutdown_test.js
@@ -45,14 +45,14 @@ helper.secrets.mockSuite(suiteName(), ['docker', 'ci-creds'], function(mock, ski
   test('shutdown without ever working a task', async () => {
     let res = await Promise.all([
       worker.launch(),
-      waitForEvent(worker, 'pending shutdown'),
+      waitForEvent(worker, 'worker idle'),
       waitForEvent(worker, 'exit'),
     ]);
-    assert.equal(res[1].time, 5);
+    assert.equal(res[1].afterIdleSeconds, 5);
   });
 
   test('with timer shutdown', async () => {
-    await [worker.launch(), waitForEvent(worker, 'pending shutdown')];
+    await [worker.launch(), waitForEvent(worker, 'worker idle')];
 
     let res = await Promise.all([
       worker.postToQueue({
@@ -68,18 +68,18 @@ helper.secrets.mockSuite(suiteName(), ['docker', 'ci-creds'], function(mock, ski
         },
       }),
       waitForEvent(worker, 'task resolved'),
-      waitForEvent(worker, 'pending shutdown'),
+      waitForEvent(worker, 'worker idle'),
       waitForEvent(worker, 'exit'),
     ]);
     // Ensure task completed.
     assert.equal(res[1].taskState, 'completed');
-    assert.equal(res[2].time, 5);
+    assert.equal(res[2].afterIdleSeconds, 5);
   });
 
   test('cancel idle', async () => {
     await Promise.all([
       worker.launch(),
-      waitForEvent(worker, 'pending shutdown'),
+      waitForEvent(worker, 'worker idle'),
     ]);
 
     // Posting work should untrigger the shutdown timer and process the task.
@@ -96,9 +96,9 @@ helper.secrets.mockSuite(suiteName(), ['docker', 'ci-creds'], function(mock, ski
           maxRunTime: 60 * 60,
         },
       }),
-      waitForEvent(worker, 'cancel pending shutdown'),
+      waitForEvent(worker, 'worker working'),
       waitForEvent(worker, 'task resolved'),
-      waitForEvent(worker, 'pending shutdown'),
+      waitForEvent(worker, 'worker idle'),
     ]);
 
     assert.ok(events[1], 'cancel event fired');

--- a/workers/docker-worker/test/shutdown_manager_test.js
+++ b/workers/docker-worker/test/shutdown_manager_test.js
@@ -1,0 +1,82 @@
+const ShutdownManager = require('../src/lib/shutdown_manager');
+const assert = require('assert').strict;
+const monitor = require('./fixtures/monitor');
+const Debug = require('debug');
+const {suiteName} = require('taskcluster-lib-testing');
+
+const log = Debug('log');
+
+suite(suiteName(), function() {
+  let terminationTime = false;
+  const host = {
+    billingCycleUptime() {
+      return 13;
+    },
+    getTerminationTime() {
+      return terminationTime;
+    },
+  };
+
+  const makeConfig = (overrides = {}) => ({
+    monitor,
+    log,
+    ...overrides,
+  });
+
+  test('should not exit by default', function() {
+    const sm = new ShutdownManager(host, makeConfig());
+    assert.equal(sm.shouldExit(), false);
+  });
+
+  test('immediate exit on SIGTERM', function() {
+    const sm = new ShutdownManager(host, makeConfig());
+    process.emit('SIGTERM');
+    assert.equal(sm.shouldExit(), 'immediate');
+  });
+
+  test('onIdle does nothing with no config', async function() {
+    const sm = new ShutdownManager(host, makeConfig());
+    sm.onIdle();
+    assert.equal(sm.shouldExit(), false);
+  });
+
+  test('onIdle does nothing if not enabled', async function() {
+    const sm = new ShutdownManager(host, makeConfig({
+      shutdown: {enabled: false},
+    }));
+    sm.onIdle();
+    assert.equal(sm.shouldExit(), false);
+  });
+
+  test('onIdle starts a timer, exits graceful', async function() {
+    const sm = new ShutdownManager(host, makeConfig({
+      shutdown: {enabled: true, afterIdleSeconds: 0.01},
+    }));
+    sm.onIdle();
+    assert.equal(sm.shouldExit(), false);
+    await new Promise(res => setTimeout(res, 50));
+    assert.equal(sm.shouldExit(), 'graceful');
+  });
+
+  test('onWorking cancels timer', async function() {
+    const sm = new ShutdownManager(host, makeConfig({
+      shutdown: {enabled: true, afterIdleSeconds: 0.05},
+    }));
+    sm.onIdle();
+    assert.equal(sm.shouldExit(), false);
+    assert(sm.idleTimeout);
+    await new Promise(res => setTimeout(res, 10));
+    sm.onWorking();
+    assert(!sm.idleTimeout);
+    assert.equal(sm.shouldExit(), false);
+    await new Promise(res => setTimeout(res, 50));
+    assert.equal(sm.shouldExit(), false);
+  });
+
+  test('_setExit will not downgrade', function() {
+    const sm = new ShutdownManager(host, makeConfig());
+    sm.exit = 'immediate';
+    sm._setExit('graceful');
+    assert.equal(sm.shouldExit(), 'immediate');
+  });
+});


### PR DESCRIPTION
This avoids the issue where the worker starts shutting down while
waiting for a claimWork call that eventually returns tasks (which
otherwise leaves those tasks timing out to claim-expired).

This substantially refactors ShutdownManager and TaskListener to match.

If this passes CI, I'll refactor the "host.getTerminationTime" thing a bit (it doesn't even return a time! and it doesn't distinguish graceful from immediate shutdown)

Github Bug/Issue: Fixes #3080