### PR TITLE
Handle shutdowns in one place in worker-runner

### DIFF
--- a/changelog/issue-3093.md
+++ b/changelog/issue-3093.md
@@ -1,0 +1,4 @@
+audience: general
+level: silent
+reference: issue 3093
+---

--- a/tools/worker-runner/errorreport/errorreport.go
+++ b/tools/worker-runner/errorreport/errorreport.go
@@ -28,6 +28,9 @@ func (er *ErrorReporter) SetProtocol(proto *workerproto.Protocol) {
 }
 
 func (er *ErrorReporter) HandleMessage(msg workerproto.Message) {
+	er.state.Lock()
+	defer er.state.Unlock()
+
 	validate := func(things map[string]interface{}, key, expectedType string) bool {
 		if _, ok := things[key]; !ok {
 			return false

--- a/tools/worker-runner/errorreport/errorreport_test.go
+++ b/tools/worker-runner/errorreport/errorreport_test.go
@@ -21,81 +21,50 @@ func TestHandleMessage(t *testing.T) {
 	kind := "severe"
 	title := "test error"
 
-	t.Run("with capability", func(t *testing.T) {
-		wkr := ptesting.NewFakeWorkerWithCapabilities("error-report")
-		defer wkr.Close()
+	wkr := ptesting.NewFakeWorkerWithCapabilities("error-report")
+	defer wkr.Close()
 
-		state := run.State{}
-		er := new(&state, tc.FakeWorkerManagerClientFactory)
+	state := run.State{}
+	er := new(&state, tc.FakeWorkerManagerClientFactory)
 
-		er.SetProtocol(wkr.RunnerProtocol)
-		wkr.RunnerProtocol.Start(false)
-		wkr.RunnerProtocol.WaitUntilInitialized()
-		wkr.WorkerProtocol.Start(true)
-		wkr.WorkerProtocol.Send(workerproto.Message{
-			Type: "error-report",
-			Properties: map[string]interface{}{
-				"description": description,
-				"extra":       extra,
-				"kind":        kind,
-				"title":       title,
-			},
-		})
+	er.SetProtocol(wkr.RunnerProtocol)
+	wkr.RunnerProtocol.Start(false)
+	wkr.RunnerProtocol.WaitUntilInitialized()
+	wkr.WorkerProtocol.Start(true)
+	wkr.WorkerProtocol.Send(workerproto.Message{
+		Type: "error-report",
+		Properties: map[string]interface{}{
+			"description": description,
+			"extra":       extra,
+			"kind":        kind,
+			"title":       title,
+		},
+	})
 
-		var reports []*tcworkermanager.WorkerErrorReport
-		var err error
-		func() {
-			for i := 0; i < 200; i++ {
-				reports, err = tc.FakeWorkerManagerWorkerErrorReports()
-				if len(reports) == 1 {
-					return
-				}
-				time.Sleep(10 * time.Millisecond)
+	var reports []*tcworkermanager.WorkerErrorReport
+	var err error
+	func() {
+		for i := 0; i < 200; i++ {
+			reports, err = tc.FakeWorkerManagerWorkerErrorReports()
+			if len(reports) == 1 {
+				return
 			}
-			t.Fatalf("worker error report not received")
-		}()
-		require.NoError(t, err)
-		require.Len(t, reports, 1)
+			time.Sleep(10 * time.Millisecond)
+		}
+		t.Fatalf("worker error report not received")
+	}()
+	require.NoError(t, err)
+	require.Len(t, reports, 1)
 
-		require.Equal(t, description, reports[0].Description)
-		require.Equal(t, kind, reports[0].Kind)
-		require.Equal(t, title, reports[0].Title)
+	require.Equal(t, description, reports[0].Description)
+	require.Equal(t, kind, reports[0].Kind)
+	require.Equal(t, title, reports[0].Title)
 
-		receivedExtra, err := reports[0].Extra.MarshalJSON()
-		require.NoError(t, err)
-		sentExtra, err := json.Marshal(extra)
-		require.NoError(t, err)
-		require.Equal(t, sentExtra, receivedExtra)
+	receivedExtra, err := reports[0].Extra.MarshalJSON()
+	require.NoError(t, err)
+	sentExtra, err := json.Marshal(extra)
+	require.NoError(t, err)
+	require.Equal(t, sentExtra, receivedExtra)
 
-		require.True(t, true)
-	})
-
-	t.Run("without capability", func(t *testing.T) {
-		wkr := ptesting.NewFakeWorkerWithCapabilities()
-		defer wkr.Close()
-
-		state := run.State{}
-		er := new(&state, tc.FakeWorkerManagerClientFactory)
-
-		er.SetProtocol(wkr.RunnerProtocol)
-		wkr.RunnerProtocol.Start(false)
-		wkr.RunnerProtocol.WaitUntilInitialized()
-		wkr.WorkerProtocol.Start(true)
-		wkr.WorkerProtocol.Send(workerproto.Message{
-			Type: "error-report",
-			Properties: map[string]interface{}{
-				"description": description,
-				"extra":       extra,
-				"kind":        kind,
-				"title":       title,
-			},
-		})
-
-		// note that without a delay we may not have waited
-		// long enough for potential calls to finish
-
-		reports, err := tc.FakeWorkerManagerWorkerErrorReports()
-		require.Errorf(t, err, "No reportWorkerError calls")
-		require.Len(t, reports, 0)
-	})
+	require.True(t, true)
 }

--- a/tools/worker-runner/errorreport/errorreport_test.go
+++ b/tools/worker-runner/errorreport/errorreport_test.go
@@ -13,10 +13,6 @@ import (
 	"github.com/taskcluster/taskcluster/v31/tools/worker-runner/tc"
 )
 
-func init() {
-	workerManagerClientFactory = tc.FakeWorkerManagerClientFactory
-}
-
 func TestHandleMessage(t *testing.T) {
 	description := "this is a serious error"
 	extra := map[string]interface{}{
@@ -30,10 +26,9 @@ func TestHandleMessage(t *testing.T) {
 		defer wkr.Close()
 
 		state := run.State{}
-		wkr.RunnerProtocol.Register("error-report", func(msg workerproto.Message) {
-			HandleMessage(msg, workerManagerClientFactory, &state)
-		})
-		wkr.RunnerProtocol.AddCapability("error-report")
+		er := new(&state, tc.FakeWorkerManagerClientFactory)
+
+		er.SetProtocol(wkr.RunnerProtocol)
 		wkr.RunnerProtocol.Start(false)
 		wkr.RunnerProtocol.WaitUntilInitialized()
 		wkr.WorkerProtocol.Start(true)
@@ -79,6 +74,10 @@ func TestHandleMessage(t *testing.T) {
 		wkr := ptesting.NewFakeWorkerWithCapabilities()
 		defer wkr.Close()
 
+		state := run.State{}
+		er := new(&state, tc.FakeWorkerManagerClientFactory)
+
+		er.SetProtocol(wkr.RunnerProtocol)
 		wkr.RunnerProtocol.Start(false)
 		wkr.RunnerProtocol.WaitUntilInitialized()
 		wkr.WorkerProtocol.Start(true)

--- a/tools/worker-runner/exit/exit.go
+++ b/tools/worker-runner/exit/exit.go
@@ -1,0 +1,95 @@
+package exit
+
+import (
+	"log"
+
+	taskcluster "github.com/taskcluster/taskcluster/v31/clients/client-go"
+	"github.com/taskcluster/taskcluster/v31/clients/client-go/tcworkermanager"
+	"github.com/taskcluster/taskcluster/v31/internal/workerproto"
+	"github.com/taskcluster/taskcluster/v31/tools/worker-runner/cfg"
+	"github.com/taskcluster/taskcluster/v31/tools/worker-runner/run"
+	"github.com/taskcluster/taskcluster/v31/tools/worker-runner/tc"
+)
+
+// ExitManager manages worker exit.
+type ExitManager struct {
+	runnercfg *cfg.RunnerConfig
+	state     *run.State
+
+	// Factory for worker-manager clients
+	factory tc.WorkerManagerClientFactory
+}
+
+func (em *ExitManager) SetProtocol(proto *workerproto.Protocol) {
+	// On "shutdown", request worker-manager to terminate us; if that fails,
+	// try shutting down
+	proto.Register("shutdown", func(msg workerproto.Message) {
+		em.shutdown()
+	})
+	proto.AddCapability("shutdown")
+}
+
+func (em *ExitManager) WorkerFinished() error {
+	em.shutdown()
+	return nil
+}
+
+// Try calling worker-manager's RemoveWorker method, and if successful
+// exit and wait for the instance to be terminated.  Otherwise, try
+// shutting down the host directly
+func (em *ExitManager) shutdown() {
+	em.state.Lock()
+	defer em.state.Unlock()
+
+	// In anticipation of
+	// https://github.com/taskcluster/taskcluster/issues/2886, this is a
+	// fast-and-dirty way to determine what it means to "shut down" this
+	// worker.
+	dynamicallyProvisioned := !(em.runnercfg.Provider.ProviderType == "static" || em.runnercfg.Provider.ProviderType == "standalone")
+
+	if !dynamicallyProvisioned {
+		log.Println("Host is not dynamically provisioned; exiting")
+		return
+	}
+
+	log.Println("Shutting down on request from worker")
+
+	shutdown := func() {
+		log.Printf("Falling back to system shutdown")
+		if err := Shutdown(); err != nil {
+			log.Printf("Error shutting down the worker: %v\n", err)
+		}
+	}
+
+	wc, err := em.factory(em.state.RootURL, &em.state.Credentials)
+	if err != nil {
+		log.Printf("Error instanciating worker-manager client: %v\n", err)
+		shutdown()
+	}
+
+	if err = wc.RemoveWorker(em.state.WorkerPoolID, em.state.WorkerGroup, em.state.WorkerID); err != nil {
+		log.Printf("Error removing the worker: %v\n", err)
+		shutdown()
+	}
+}
+
+// Make a new ExitManager object
+func New(runnercfg *cfg.RunnerConfig, state *run.State) *ExitManager {
+	return new(runnercfg, state, nil)
+}
+
+// Private constructor allowing injection of a fake factory
+func new(runnercfg *cfg.RunnerConfig, state *run.State, factory tc.WorkerManagerClientFactory) *ExitManager {
+	if factory == nil {
+		factory = func(rootURL string, credentials *taskcluster.Credentials) (tc.WorkerManager, error) {
+			prov := tcworkermanager.New(credentials, rootURL)
+			return prov, nil
+		}
+	}
+
+	return &ExitManager{
+		runnercfg: runnercfg,
+		state:     state,
+		factory:   factory,
+	}
+}

--- a/tools/worker-runner/exit/exit_test.go
+++ b/tools/worker-runner/exit/exit_test.go
@@ -1,0 +1,76 @@
+package exit
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/taskcluster/taskcluster/v31/internal/workerproto"
+	ptesting "github.com/taskcluster/taskcluster/v31/internal/workerproto/testing"
+	"github.com/taskcluster/taskcluster/v31/tools/worker-runner/cfg"
+	"github.com/taskcluster/taskcluster/v31/tools/worker-runner/run"
+	"github.com/taskcluster/taskcluster/v31/tools/worker-runner/tc"
+)
+
+func TestShutdownMessage(t *testing.T) {
+	wkr := ptesting.NewFakeWorkerWithCapabilities("shutdown")
+	defer wkr.Close()
+
+	runnercfg := cfg.RunnerConfig{}
+	runnercfg.Provider.ProviderType = "azure"
+	state := run.State{
+		WorkerPoolID: "w/p",
+		WorkerGroup:  "wg",
+		WorkerID:     "wid",
+	}
+	em := new(&runnercfg, &state, tc.FakeWorkerManagerClientFactory)
+
+	em.SetProtocol(wkr.RunnerProtocol)
+	wkr.RunnerProtocol.Start(false)
+	wkr.RunnerProtocol.WaitUntilInitialized()
+	wkr.WorkerProtocol.Start(true)
+
+	wkr.WorkerProtocol.Send(workerproto.Message{
+		Type:       "shutdown",
+		Properties: map[string]interface{}{},
+	})
+	wkr.FlushMessagesToRunner()
+
+	removals := tc.FakeWorkerManagerWorkerRemovals()
+	require.Equal(t, len(removals), 1)
+	removal := removals[0]
+	require.Equal(t, removal.WorkerPoolID, state.WorkerPoolID)
+	require.Equal(t, removal.WorkerGroup, state.WorkerGroup)
+	require.Equal(t, removal.WorkerID, state.WorkerID)
+}
+
+func TestShutdownDynamic(t *testing.T) {
+	runnercfg := cfg.RunnerConfig{}
+	runnercfg.Provider.ProviderType = "azure"
+	state := run.State{
+		WorkerPoolID: "w/p",
+		WorkerGroup:  "wg",
+		WorkerID:     "wid",
+	}
+	em := new(&runnercfg, &state, tc.FakeWorkerManagerClientFactory)
+
+	em.shutdown()
+
+	removals := tc.FakeWorkerManagerWorkerRemovals()
+	require.Equal(t, len(removals), 1)
+	removal := removals[0]
+	require.Equal(t, removal.WorkerPoolID, state.WorkerPoolID)
+	require.Equal(t, removal.WorkerGroup, state.WorkerGroup)
+	require.Equal(t, removal.WorkerID, state.WorkerID)
+}
+
+func TestShutdownStatic(t *testing.T) {
+	runnercfg := cfg.RunnerConfig{}
+	runnercfg.Provider.ProviderType = "static"
+	state := run.State{}
+	em := new(&runnercfg, &state, tc.FakeWorkerManagerClientFactory)
+
+	em.shutdown()
+
+	removals := tc.FakeWorkerManagerWorkerRemovals()
+	require.Equal(t, len(removals), 0)
+}

--- a/tools/worker-runner/exit/shutdown_unix.go
+++ b/tools/worker-runner/exit/shutdown_unix.go
@@ -1,6 +1,6 @@
 // +build linux darwin freebsd
 
-package provider
+package exit
 
 import "os/exec"
 

--- a/tools/worker-runner/exit/shutdown_windows.go
+++ b/tools/worker-runner/exit/shutdown_windows.go
@@ -1,4 +1,4 @@
-package provider
+package exit
 
 import "golang.org/x/sys/windows"
 

--- a/tools/worker-runner/provider/aws/awsprovider.go
+++ b/tools/worker-runner/provider/aws/awsprovider.go
@@ -122,12 +122,6 @@ func (p *AWSProvider) checkTerminationTime() bool {
 func (p *AWSProvider) WorkerStarted(state *run.State) error {
 	// start polling for graceful shutdown
 	p.terminationTicker = time.NewTicker(30 * time.Second)
-	p.proto.Register("shutdown", func(msg workerproto.Message) {
-		if err := provider.RemoveWorker(state, p.workerManagerClientFactory); err != nil {
-			log.Printf("Shutdown error: %v\n", err)
-		}
-	})
-	p.proto.AddCapability("shutdown")
 	p.proto.AddCapability("graceful-termination")
 
 	go func() {
@@ -143,7 +137,7 @@ func (p *AWSProvider) WorkerStarted(state *run.State) error {
 
 func (p *AWSProvider) WorkerFinished(state *run.State) error {
 	p.terminationTicker.Stop()
-	return provider.RemoveWorker(state, p.workerManagerClientFactory)
+	return nil
 }
 
 func clientFactory(rootURL string, credentials *tcclient.Credentials) (tc.WorkerManager, error) {

--- a/tools/worker-runner/provider/aws/awsprovider.go
+++ b/tools/worker-runner/provider/aws/awsprovider.go
@@ -127,7 +127,6 @@ func (p *AWSProvider) WorkerStarted(state *run.State) error {
 			log.Printf("Shutdown error: %v\n", err)
 		}
 	})
-	p.proto.AddCapability("error-report")
 	p.proto.AddCapability("shutdown")
 	p.proto.AddCapability("graceful-termination")
 

--- a/tools/worker-runner/provider/aws/awsprovider_test.go
+++ b/tools/worker-runner/provider/aws/awsprovider_test.go
@@ -66,14 +66,13 @@ func TestAWSConfigureRun(t *testing.T) {
 	require.Equal(t, "us-west-2", state.WorkerLocation["region"])
 	require.Equal(t, "us-west-2a", state.WorkerLocation["availabilityZone"])
 
-	wkr := ptesting.NewFakeWorkerWithCapabilities("shutdown")
+	wkr := ptesting.NewFakeWorkerWithCapabilities()
 	defer wkr.Close()
 
 	p.SetProtocol(wkr.RunnerProtocol)
 	require.NoError(t, p.WorkerStarted(&state))
 	wkr.RunnerProtocol.Start(false)
 	wkr.RunnerProtocol.WaitUntilInitialized()
-	require.True(t, wkr.RunnerProtocol.Capable("shutdown"))
 
 	proof, err := p.GetWorkerIdentityProof()
 	require.NoError(t, err)

--- a/tools/worker-runner/provider/azure/azure.go
+++ b/tools/worker-runner/provider/azure/azure.go
@@ -144,13 +144,6 @@ func (p *AzureProvider) checkTerminationTime() bool {
 }
 
 func (p *AzureProvider) WorkerStarted(state *run.State) error {
-	p.proto.Register("shutdown", func(msg workerproto.Message) {
-		err := provider.RemoveWorker(state, p.workerManagerClientFactory)
-		if err != nil {
-			log.Printf("Shutdown error: %v\n", err)
-		}
-	})
-	p.proto.AddCapability("shutdown")
 	p.proto.AddCapability("graceful-termination")
 
 	// start polling for graceful shutdown

--- a/tools/worker-runner/provider/azure/azure_test.go
+++ b/tools/worker-runner/provider/azure/azure_test.go
@@ -98,14 +98,13 @@ func TestConfigureRun(t *testing.T) {
 	require.Equal(t, "azure", state.WorkerLocation["cloud"])
 	require.Equal(t, "uswest", state.WorkerLocation["region"])
 
-	wkr := ptesting.NewFakeWorkerWithCapabilities("shutdown")
+	wkr := ptesting.NewFakeWorkerWithCapabilities()
 	defer wkr.Close()
 
 	p.SetProtocol(wkr.RunnerProtocol)
 	require.NoError(t, p.WorkerStarted(&state))
 	wkr.RunnerProtocol.Start(false)
 	wkr.RunnerProtocol.WaitUntilInitialized()
-	require.True(t, wkr.RunnerProtocol.Capable("shutdown"))
 
 	proof, err := p.GetWorkerIdentityProof()
 	require.NoError(t, err)

--- a/tools/worker-runner/provider/google/google.go
+++ b/tools/worker-runner/provider/google/google.go
@@ -2,7 +2,6 @@ package google
 
 import (
 	"fmt"
-	"log"
 	"strings"
 
 	tcclient "github.com/taskcluster/taskcluster/v31/clients/client-go"
@@ -106,20 +105,13 @@ func (p *GoogleProvider) SetProtocol(proto *workerproto.Protocol) {
 }
 
 func (p *GoogleProvider) WorkerStarted(state *run.State) error {
-	p.proto.Register("shutdown", func(msg workerproto.Message) {
-		err := provider.RemoveWorker(state, p.workerManagerClientFactory)
-		if err != nil {
-			log.Printf("Shutdown error: %v\n", err)
-		}
-	})
-	p.proto.AddCapability("shutdown")
 	p.proto.AddCapability("graceful-termination")
 
 	return nil
 }
 
 func (p *GoogleProvider) WorkerFinished(state *run.State) error {
-	return provider.RemoveWorker(state, p.workerManagerClientFactory)
+	return nil
 }
 
 func clientFactory(rootURL string, credentials *tcclient.Credentials) (tc.WorkerManager, error) {

--- a/tools/worker-runner/provider/google/google_test.go
+++ b/tools/worker-runner/provider/google/google_test.go
@@ -70,14 +70,13 @@ func TestGoogleConfigureRun(t *testing.T) {
 	require.Equal(t, "in-central1", state.WorkerLocation["region"])
 	require.Equal(t, "in-central1-b", state.WorkerLocation["zone"])
 
-	wkr := ptesting.NewFakeWorkerWithCapabilities("shutdown")
+	wkr := ptesting.NewFakeWorkerWithCapabilities()
 	defer wkr.Close()
 
 	p.SetProtocol(wkr.RunnerProtocol)
 	require.NoError(t, p.WorkerStarted(&state))
 	wkr.RunnerProtocol.Start(false)
 	wkr.RunnerProtocol.WaitUntilInitialized()
-	require.True(t, wkr.RunnerProtocol.Capable("shutdown"))
 
 	proof, err := p.GetWorkerIdentityProof()
 	require.NoError(t, err)

--- a/tools/worker-runner/provider/provider/common.go
+++ b/tools/worker-runner/provider/provider/common.go
@@ -1,42 +1,6 @@
 package provider
 
-import (
-	"log"
-
-	"github.com/taskcluster/taskcluster/v31/tools/worker-runner/run"
-	"github.com/taskcluster/taskcluster/v31/tools/worker-runner/tc"
-)
-
 // WorkerInfo contains the information to identify the worker
 type WorkerInfo struct {
 	WorkerPoolID, WorkerGroup, WorkerID string
-}
-
-// RemoveWorker will request worker-manager to terminate the given worker, if it
-// fails, it shuts down us.  This is to be called *without* a lock on state
-func RemoveWorker(state *run.State, factory tc.WorkerManagerClientFactory) error {
-	state.Lock()
-	defer state.Unlock()
-
-	shutdown := func() error {
-		log.Printf("Falling back to system shutdown")
-		if err := Shutdown(); err != nil {
-			log.Printf("Error shutting down the worker: %v\n", err)
-			return err
-		}
-		return nil
-	}
-
-	wc, err := factory(state.RootURL, &state.Credentials)
-	if err != nil {
-		log.Printf("Error instanciating worker-manager client: %v\n", err)
-		return shutdown()
-	}
-
-	if err = wc.RemoveWorker(state.WorkerPoolID, state.WorkerGroup, state.WorkerID); err != nil {
-		log.Printf("Error removing the worker: %v\n", err)
-		return shutdown()
-	}
-
-	return err
 }

--- a/tools/worker-runner/runner/run.go
+++ b/tools/worker-runner/runner/run.go
@@ -50,6 +50,7 @@ func Run(configFile string) (state run.State, err error) {
 	}
 
 	reg := registration.New(runnercfg, &state)
+	er := errorreport.New(&state)
 
 	if !runCached {
 		log.Printf("Configuring with provider %s", runnercfg.Provider.ProviderType)
@@ -159,9 +160,7 @@ func Run(configFile string) (state run.State, err error) {
 	provider.SetProtocol(proto)
 	worker.SetProtocol(proto)
 	reg.SetProtocol(proto)
-
-	// configure error reporting
-	errorreport.Setup(proto, &state)
+	er.SetProtocol(proto)
 
 	// call the WorkerStarted methods before starting the proto so that there
 	// are no race conditions around the capabilities negotiation


### PR DESCRIPTION
..and some other refactors while I was in there.

On the refactors: I have been mulling the idea of having a bunch of component structs and a Component interface with `SetProtocol(..)`, `WorkerStarted(..)`, `WorkerFinished(..)`, etc.,  Then the runner would basically construct a bunch of components and, for each phase of the run, call the corresponding method on each component.  It would move the tool from a big long "run" method that does a bunch of stuff to a series of well-defined phases.  So this refactor of errorreport into an object is leading toward that design.

Github Bug/Issue: Fixes #3093