### PR TITLE
Issue #3116 - Enforce en_US.UTF8

### DIFF
--- a/changelog/issue-3116.md
+++ b/changelog/issue-3116.md
@@ -1,0 +1,6 @@
+audience: deployers
+level: patch
+reference: issue 3116
+---
+The db upgrade and downgrade scripts now verify that the default database collation is `en_US.UTF8`.  No other collation is allowed.
+Unfortunately, changing the default collation requires dumping and re-creating the database.

--- a/db/test-setup.sh
+++ b/db/test-setup.sh
@@ -5,9 +5,11 @@ if [ -z "${TASK_ID}" ]; then
     exit 1;
 fi
 
-# add an HBA entry to allow any user, not just postgres, to connect
-echo 'host all all 127.0.0.1/32 trust' >> /etc/postgresql/11/main/pg_hba.conf
-echo 'host all all ::1/128 trust' >> /etc/postgresql/11/main/pg_hba.conf
+# (redundant to the same script in the docker image; this can be removed a day or two after #3116 lands)
+pg_version=11
+echo 'local all all trust' > /etc/postgresql/$pg_version/main/pg_hba.conf
+echo 'host all all 127.0.0.1/32 trust' >> /etc/postgresql/$pg_version/main/pg_hba.conf
+echo 'host all all ::1/128 trust' >> /etc/postgresql/$pg_version/main/pg_hba.conf
 
 # start the server
 echo "Starting pg server.."

--- a/dev-docs/development-process.md
+++ b/dev-docs/development-process.md
@@ -30,7 +30,7 @@ Do not run these tests against a database instance that contains any useful data
 To start the server using Docker:
 
 ```shell
-docker run -ti -p 127.0.0.1:5432:5432 -e POSTGRES_HOST_AUTH_METHOD=trust --rm postgres:11
+docker run -ti -p 127.0.0.1:5432:5432 -e POSTGRES_HOST_AUTH_METHOD=trust -e LC_COLLATE=en_US.UTF8 -e LC_CTYPE=en_US.UTF8 --rm postgres:11
 ```
 
 This will run Docker in the foreground in that terminal (so you'll need to use another terminal for your work, or add the `-d` flag to daemonize the container) and make that available on TCP port 5432, the "normal" Postgres port.
@@ -38,7 +38,7 @@ This will run Docker in the foreground in that terminal (so you'll need to use a
 It can be helpful to log all queries run by the test suite:
 
 ```shell
-docker run -ti -p 127.0.0.1:5432:5432 -e POSTGRES_HOST_AUTH_METHOD=trust --rm postgres:11 -c log_statement=all
+docker run -ti -p 127.0.0.1:5432:5432 -e POSTGRES_HOST_AUTH_METHOD=trust -e LC_COLLATE=en_US.UTF8 -e LC_CTYPE=en_US.UTF8 --rm postgres:11 -c log_statement=all
 ```
 
 However you decide to run Postgres, you will need a DB URL, as defined by [node-postgres](https://node-postgres.com/features/connecting).

--- a/infrastructure/docker-images/build-node-and-pg.sh
+++ b/infrastructure/docker-images/build-node-and-pg.sh
@@ -23,9 +23,20 @@ echo "deb http://apt.postgresql.org/pub/repos/apt/ stretch-pgdg main" > /etc/apt
 apt-get update
 apt-get install -y postgresql-$pg_version
 
+# add the en_US.UTF8 locale to the system
+apt-get install -y --no-install-recommends locales
+rm -rf /var/lib/apt/lists/*
+localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
+
+# drop and re-create the default cluster with the appropriate locale
+pg_dropcluster 11 main
+pg_createcluster 11 main --lc-collate=en_US.UTF8 --lc-ctype=en_US.UTF8
+
 # allow postgres to connect locally with no auth -- this is for testing!
-echo 'local all postgres trust' > /etc/postgresql/$pg_version/main/pg_hba.conf
-echo 'host all postgres 127.0.0.1/32 trust' >> /etc/postgresql/$pg_version/main/pg_hba.conf
+echo 'local all all trust' > /etc/postgresql/$pg_version/main/pg_hba.conf
+echo 'host all all 127.0.0.1/32 trust' >> /etc/postgresql/$pg_version/main/pg_hba.conf
+echo 'host all all ::1/128 trust' >> /etc/postgresql/$pg_version/main/pg_hba.conf
+
 EOF
 
 cat > ${tmpdir}/Dockerfile <<EOF

--- a/ui/docs/manual/deploying/database.mdx
+++ b/ui/docs/manual/deploying/database.mdx
@@ -12,6 +12,12 @@ A single database is shared among all services.
 Taskcluster assumes that it "owns" the database, but can share a single server with other users.
 For production purposes we recommend a dedicated server, due to the possibility of contention for server resources, but sharing a server acceptable for non-production environments.
 
+The default collation (sort order) for the database must be `en_US.UTF8`.
+This can be achieved by setting `LC_CTYPE=en_US.UTF8 LC_COLLATE=en_US.UTF8` when creating the database, using `createdb` option `-l`, or invoking `CREATE DATABASE` with `LC_CTYPE 'en_US.UTF8' LC_COLLATE 'en_US.UTF8'`.
+The choice of en_US is an accident of history, and not meant to demonstrate a preference for that locale over any other.
+Since most sorting is performed on identifiers such as slugIds, `C` would have been a more appropriate choice, but all large production deployments were already using `en_US` as of discovery of this issue, and the default collation cannot be changed after the fact.
+In practice, the difference is minor and only visible when sorting identifiers that differ in case.
+
 ## DB Users
 
 Each service uses its own Postgres user to access the database, and Taskcluster uses this functionality internally to isolate services from one another.


### PR DESCRIPTION
This implements the "enforce" option from #3116.

Github Bug/Issue: Fixes #3116