### PR TITLE
Allow undefined properties in per-request context

### DIFF
--- a/changelog/GEGO8q6FRH-kZ4EmCpn4NA.md
+++ b/changelog/GEGO8q6FRH-kZ4EmCpn4NA.md
@@ -1,0 +1,3 @@
+audience: general
+level: silent
+---

--- a/libraries/api/src/middleware/per-request-context.js
+++ b/libraries/api/src/middleware/per-request-context.js
@@ -8,7 +8,7 @@ const perRequestContext = ({entry, context}) => {
     req.tcContext = new Proxy(context, {
       get(target, prop) {
         const val = target[prop];
-        if (!val) {
+        if (val === undefined) {
           return undefined;
         }
         if (val.taskclusterPerRequestInstance === undefined) {

--- a/libraries/api/src/middleware/per-request-context.js
+++ b/libraries/api/src/middleware/per-request-context.js
@@ -8,6 +8,9 @@ const perRequestContext = ({entry, context}) => {
     req.tcContext = new Proxy(context, {
       get(target, prop) {
         const val = target[prop];
+        if (!val) {
+          return undefined;
+        }
         if (val.taskclusterPerRequestInstance === undefined) {
           return val;
         }


### PR DESCRIPTION
This gives a much clearer error for things like `ctx.Foo`.
