### PR TITLE
update kind-of for clients/client-web and ui

### DIFF
--- a/changelog/f-9bI23DQn2GElKxqVdIuA.md
+++ b/changelog/f-9bI23DQn2GElKxqVdIuA.md
@@ -1,0 +1,3 @@
+audience: general
+level: silent
+---

--- a/clients/client-web/yarn.lock
+++ b/clients/client-web/yarn.lock
@@ -3631,9 +3631,9 @@ kind-of@^5.0.0:
   integrity sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==
 
 kind-of@^6.0.0, kind-of@^6.0.2:
-  version "6.0.2"
-  resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-6.0.2.tgz#01146b36a6218e64e58f3a8d66de5d7fc6f6d051"
-  integrity sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==
+  version "6.0.3"
+  resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-6.0.3.tgz#07c05034a6c349fa06e24fa35aa76db4580ce4dd"
+  integrity sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==
 
 lcid@^2.0.0:
   version "2.0.0"

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -8408,9 +8408,9 @@ kind-of@^5.0.0:
   integrity sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==
 
 kind-of@^6.0.0, kind-of@^6.0.2:
-  version "6.0.2"
-  resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-6.0.2.tgz#01146b36a6218e64e58f3a8d66de5d7fc6f6d051"
-  integrity sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==
+  version "6.0.3"
+  resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-6.0.3.tgz#07c05034a6c349fa06e24fa35aa76db4580ce4dd"
+  integrity sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==
 
 kleur@^2.0.1:
   version "2.0.2"


### PR DESCRIPTION
Addresses GHSA-6c8f-qphg-qjgp
```
lamport ~/p/taskcluster [kindof-update] $ yarn why kind-of
yarn why v1.22.4
[1/4] Why do we have the module "kind-of"...?
[2/4] Initialising dependency graph...
[3/4] Finding dependency...
[4/4] Calculating file sizes...
=> Found "kind-of@6.0.3"
info Has been hoisted to "kind-of"
info Reasons this module exists
   - "workspace-aggregator-a034b6db-003d-4feb-9abc-59b27859136b" depends on it
   - Hoisted from "_project_#md-directory#gray-matter#kind-of"
   - Hoisted from "_project_#md-directory#gray-matter#section-matter#kind-of"
info Disk size without dependencies: "32KB"
info Disk size with unique dependencies: "32KB"
info Disk size with transitive dependencies: "32KB"
info Number of shared dependencies: 0
=> Found "align-text#kind-of@3.2.2"
info This module exists because "_project_#email-templates#preview-email#pug#pug-filters#uglify-js#yargs#cliui#right-align#align-text" depends on it.
info Disk size without dependencies: "20KB"
info Disk size with unique dependencies: "36KB"
info Disk size with transitive dependencies: "36KB"
info Number of shared dependencies: 1
Done in 0.76s.
```
the old 3.2.2 is not vulnerable.