### PR TITLE
re-introduce the `yarn release` command

### DIFF
--- a/changelog/issue-3147.md
+++ b/changelog/issue-3147.md
@@ -1,0 +1,4 @@
+audience: general
+level: silent
+reference: issue 3147
+---

--- a/infrastructure/tooling/src/main.js
+++ b/infrastructure/tooling/src/main.js
@@ -30,6 +30,19 @@ program.command('build')
     run(main, options[0]);
   });
 
+program.command('release')
+  .description('tag a release and push it to GitHub')
+  .option('--dry-run', 'Do not run any tasks, but generate the list of tasks')
+  .option('--no-push', 'Do not push the git commit + tags (but your local repo is still modified)')
+  .action((...options) => {
+    if (options.length !== 1) {
+      console.error('unexpected command-line arguments');
+      process.exit(1);
+    }
+    const {release} = require('./release');
+    run(release, options[0]);
+  });
+
 program.command('staging-release')
   // note that this is not `release --staging` to avoid danger of accidentally doing a real release
   .description('make a staging release')

--- a/infrastructure/tooling/src/release/index.js
+++ b/infrastructure/tooling/src/release/index.js
@@ -48,7 +48,7 @@ class Release {
   }
 }
 
-const main = async (options) => {
+const release = async (options) => {
   const release = new Release(options);
   await release.run(false);
 };
@@ -58,4 +58,4 @@ const stagingRelease = async (options) => {
   await release.run(true);
 };
 
-module.exports = {main, stagingRelease, Release};
+module.exports = {release, stagingRelease, Release};


### PR DESCRIPTION
This was accidentally deleted when adding `yarn staging-release`

Github Bug/Issue: Fixes #3147