### PR TITLE
Make sure to get the hash of the uncompressed file

### DIFF
--- a/changelog/bug-1637302.md
+++ b/changelog/bug-1637302.md
@@ -1,0 +1,5 @@
+audience: general
+level: patch
+reference: bug 1637302
+---
+Fixes hashing of compressed files

--- a/changelog/bug-1637302.md
+++ b/changelog/bug-1637302.md
@@ -1,5 +1,5 @@
-audience: general
+audience: worker-deployers
 level: patch
 reference: bug 1637302
 ---
-Fixes hashing of compressed files
+Docker-worker now correctly calculates artifacts hashes for chain-of-trust before compressing them.


### PR DESCRIPTION
Bugzilla Bug: [1637302](https://bugzilla.mozilla.org/show_bug.cgi?id=1637302)

Fix hashing of compressed files so that we hash the uncompressed file