### PR TITLE
do not rely on auth.taskcluster.net for tests

### DIFF
--- a/changelog/J4NBGYcFStS4-s4PSBL-jw.md
+++ b/changelog/J4NBGYcFStS4-s4PSBL-jw.md
@@ -1,0 +1,3 @@
+audience: general
+level: silent
+---

--- a/clients/client-py/test/base/__init__.py
+++ b/clients/client-py/test/base/__init__.py
@@ -9,7 +9,7 @@ _sleep = time.sleep
 
 TEST_ROOT_URL = "https://tc-tests.example.com"
 # rootUrl of a real deployment (that needs no pre-configuration)
-REAL_ROOT_URL = 'https://taskcluster.net'
+REAL_ROOT_URL = os.environ.get('TASKCLUSTER_ROOT_URL', 'https://community-tc.services.mozilla.com/')
 
 log = logging.getLogger(__name__)
 log.setLevel(logging.DEBUG)

--- a/clients/client/test/creds_test.js
+++ b/clients/client/test/creds_test.js
@@ -11,7 +11,7 @@ suite(testing.suiteName(), function() {
   let client = function(options) {
     options = _.defaults({}, options || {}, {
       credentials: {},
-      rootUrl: 'https://taskcluster.net',
+      rootUrl: process.env['TASKCLUSTER_ROOT_URL'] || 'https://community-tc.services.mozilla.com/',
     });
     options.credentials = _.defaults({}, options.credentials, {
       clientId: 'tester',
@@ -349,7 +349,7 @@ suite(testing.suiteName(), function() {
     // Ensure the client is removed from the require cache so it can be
     // reloaded from scratch.
     setup(() => {
-      process.env.TASKCLUSTER_ROOT_URL = 'https://taskcluster.net';
+      process.env.TASKCLUSTER_ROOT_URL = ROOT_URL || 'https://community-tc.services.mozilla.com/';
       process.env.TASKCLUSTER_CLIENT_ID = 'tester';
       process.env.TASKCLUSTER_ACCESS_TOKEN = 'no-secret';
     });
@@ -365,7 +365,7 @@ suite(testing.suiteName(), function() {
       delete process.env.TASKCLUSTER_CLIENT_ID;
       delete process.env.TASKCLUSTER_ACCESS_TOKEN;
       assert.deepEqual(taskcluster.fromEnvVars(),
-        {rootUrl: 'https://taskcluster.net'});
+        {rootUrl: process.env.TASKCLUSTER_ROOT_URL});
     });
 
     test('fromEnvVars with only accessToken', async () => {


### PR DESCRIPTION
Now that auth.taskcluster.net is shut down, we need to stop using it for tests :)