### PR TITLE
Push docker images on release

### DIFF
--- a/changelog/EQ5GAP53RziRnNw_ZicrAg.md
+++ b/changelog/EQ5GAP53RziRnNw_ZicrAg.md
@@ -1,0 +1,3 @@
+audience: general
+level: silent
+---

--- a/infrastructure/tooling/src/build/index.js
+++ b/infrastructure/tooling/src/build/index.js
@@ -152,7 +152,7 @@ class Publish extends Base {
       // always build from scratch
       cache: false,
       // to be safe, set push=false for staging runs
-      push: cmdOptions.staging ? false : cmdOptions.push,
+      push: cmdOptions.staging ? false : true,
     });
   }
 

--- a/infrastructure/tooling/src/build/tasks/common.js
+++ b/infrastructure/tooling/src/build/tasks/common.js
@@ -33,7 +33,7 @@ module.exports = ({tasks, cmdOptions, credentials, baseDir, logsDir}) => {
       });
 
       return {
-        'docker-flow-version': {
+        'docker-flow-version': JSON.stringify({
           version: requirements['release-version'],
           commit: requirements['release-revision'],
           source: 'https://github.com/taskcluster/taskcluster',
@@ -44,7 +44,7 @@ module.exports = ({tasks, cmdOptions, credentials, baseDir, logsDir}) => {
           build: process.env.TASK_ID ?
             `${process.env.TASKCLUSTER_ROOT_URL}/tasks/${process.env.TASK_ID}` :
             'NONE',
-        },
+        }, null, 2),
       };
     },
   });

--- a/infrastructure/tooling/src/build/tasks/monoimage.js
+++ b/infrastructure/tooling/src/build/tasks/monoimage.js
@@ -213,13 +213,14 @@ const generateMonoimageTasks = ({tasks, baseDir, cmdOptions, credentials, logsDi
     ],
     run: async (requirements, utils) => {
       const tag = requirements[`monoimage-devel-docker-image`];
+      const provides = {[`monoimage-devel-push`]: tag};
 
       if (!cmdOptions.push) {
-        return utils.skip({reason: "--push not present"});
+        return utils.skip(provides);
       }
 
       if (requirements[`monoimage-devel-image-on-registry`]) {
-        return utils.skip({reason: "already on registry"});
+        return utils.skip(provides);
       }
 
       const dockerPushOptions = {};

--- a/infrastructure/tooling/src/build/tasks/monoimage.js
+++ b/infrastructure/tooling/src/build/tasks/monoimage.js
@@ -50,6 +50,7 @@ const generateMonoimageTasks = ({tasks, baseDir, cmdOptions, credentials, logsDi
       const imageLocal = (await dockerImages({baseDir}))
         .some(image => image.RepoTags && image.RepoTags.indexOf(tag) !== -1);
       const imageOnRegistry = await dockerRegistryCheck({tag});
+      utils.status({message: `Image does ${imageOnRegistry ? '' : 'not '} exist on registry`});
 
       const provides = {
         'monoimage-docker-image': tag,
@@ -113,6 +114,7 @@ const generateMonoimageTasks = ({tasks, baseDir, cmdOptions, credentials, logsDi
       const imageLocal = (await dockerImages({baseDir}))
         .some(image => image.RepoTags && image.RepoTags.indexOf(tag) !== -1);
       const imageOnRegistry = await dockerRegistryCheck({tag});
+      utils.status({message: `Image does ${imageOnRegistry ? '' : 'not '} exist on registry`});
 
       const provides = {
         'monoimage-devel-docker-image': tag,

--- a/infrastructure/tooling/src/utils/docker.js
+++ b/infrastructure/tooling/src/utils/docker.js
@@ -228,7 +228,10 @@ exports.dockerRegistryCheck = async ({tag}) => {
   try {
     // Access the registry API directly to see if this tag already exists, and do not push if so.
     const res = await got(`https://index.docker.io/v1/repositories/${repo}/tags`, {json: true});
-    if (res.body && res.body.map(l => l.name).includes(imagetag)) {
+    if (!res.body) {
+      throw new Error('invalid response from index.docker.io');
+    }
+    if (res.body.map(l => l.name).includes(imagetag)) {
       return true;
     }
   } catch (err) {


### PR DESCRIPTION
This fixes:
 * not pushing docker images since v31.0.0 (I've pushed them manually)
 * missing monoimage-devel image tag in output at the end
 * `version.json` containing `[Object object]`