### PR TITLE
update link to generic-worker and docker-worker;

### DIFF
--- a/ui/docs/manual/task-execution/workers.mdx
+++ b/ui/docs/manual/task-execution/workers.mdx
@@ -64,8 +64,8 @@ developed by Mozilla's release engineering to run release-related scripts in a l
 secure context.
 
 The Taskcluster-provided worker implementations, including their payload formats, are described in:
-* [generic-worker](https://github.com/taskcluster/generic-worker/blob/master/README.md)
-* [docker-worker](https://github.com/taskcluster/docker-worker/blob/master/README.md)
+* [generic-worker](https://github.com/taskcluster/taskcluster/blob/master/workers/generic-worker/README.md)
+* [docker-worker](https://github.com/taskcluster/taskcluster/blob/master/workers/docker-worker/README.md)
 
 The protocol for interacting with the Queue service is described in
 [Queue-Worker

--- a/ui/docs/manual/task-execution/workers.mdx
+++ b/ui/docs/manual/task-execution/workers.mdx
@@ -64,8 +64,8 @@ developed by Mozilla's release engineering to run release-related scripts in a l
 secure context.
 
 The Taskcluster-provided worker implementations, including their payload formats, are described in:
-* [generic-worker](https://github.com/taskcluster/taskcluster/blob/master/workers/generic-worker/README.md)
-* [docker-worker](https://github.com/taskcluster/taskcluster/blob/master/workers/docker-worker/README.md)
+* [generic-worker](/docs/reference/workers/generic-worker)
+* [docker-worker](/docs/reference/workers/docker-worker)
 
 The protocol for interacting with the Queue service is described in
 [Queue-Worker


### PR DESCRIPTION
Update link pointing to the archived generic-worker/docker-worker directories.