### PR TITLE
Fix determination of annotationsArtifactName

### DIFF
--- a/changelog/issue-3191.md
+++ b/changelog/issue-3191.md
@@ -1,0 +1,5 @@
+audience: users
+level: patch
+reference: issue 3191
+---
+The `task.extra.github.customCheckRun.annotationsArtifactName` property is now correctly consulted for the name of the annotations artifact, as documented.

--- a/services/github/src/handlers.js
+++ b/services/github/src/handlers.js
@@ -533,7 +533,7 @@ async function statusHandler(message) {
 
     let annotationsArtifactName = CUSTOM_CHECKRUN_ANNOTATIONS_ARTIFACT_NAME;
     if (taskDefinition.extra && taskDefinition.extra.github && taskDefinition.extra.github.customCheckRun) {
-      textArtifactName =
+      annotationsArtifactName =
         taskDefinition.extra.github.customCheckRun.annotationsArtifactName || CUSTOM_CHECKRUN_ANNOTATIONS_ARTIFACT_NAME;
     }
 


### PR DESCRIPTION
Github Bug/Issue: Fixes #3191

This probably should have tests, but better to have the fix now than to wait until it's slotted into a sprint later.