### PR TITLE
changelog audience=deployers for DB migrations

### DIFF
--- a/changelog/issue-2937.md
+++ b/changelog/issue-2937.md
@@ -1,4 +1,4 @@
-audience: developers
+audience: deployers
 level: minor
 reference: issue 2937
 ---


### PR DESCRIPTION
The audience is a little vague, to be honest, but for the major changes, the audience was deployers, so let's be consistent.