### PR TITLE
Test for collation by behavior, rather than name

### DIFF
--- a/changelog/QwlDxmO1Qwm6c2h6tIYTpw.md
+++ b/changelog/QwlDxmO1Qwm6c2h6tIYTpw.md
@@ -1,0 +1,4 @@
+audience: developers
+level: patch
+---
+The taskcluster-lib-postgres library now allows any Postgres collation that sorts ASCII characters correctly.

--- a/libraries/postgres/src/Database.js
+++ b/libraries/postgres/src/Database.js
@@ -387,15 +387,20 @@ class Database {
 
   async _checkDbSettings() {
     await this._withClient('admin', async client => {
-      const res = await client.query(`
-        SELECT datcollate AS collation
-        FROM pg_database 
-        WHERE datname = current_database()`);
-      const collation = res.rows[0].collation;
-      if (collation !== 'en_US.utf8' && collation !== 'en_US.UTF8') {
-        throw new Error(
-          `Postgres database must have default collation en_US.utf8 or en_US.UTF8; this database is using ${collation}.`,
-        );
+      // check the DB collation by its behavior, rather than by name, as names seem to vary.
+      for (const pair of ['aA', 'ab', 'Ab', 'aB', 'AB', '0a', '0A']) {
+        const res = await client.query(`select 1 where $1 >= $2`, [pair[0], pair[1]]);
+        if (res.rows.length > 0) {
+          const res = await client.query(`
+            SELECT datcollate AS collation
+            FROM pg_database 
+            WHERE datname = current_database()`);
+          const collation = res.rows[0].collation;
+          throw new Error([
+            'Postgres database must have default collation en_US.utf8 (and in particular be case-insensitive for ASCII letters);',
+            `this database is using ${collation}, and sorts '${pair[0]}' >= '${pair[1]}'.`,
+          ].join(' '));
+        }
       }
     });
   }


### PR DESCRIPTION
I don't really know what's going on here, but my docker image suddenly started spelling this `en_US.UTF-8`.

```
     Error: Postgres database must have default collation en_US.utf8 or en_US.UTF8; this database is using en_US.UTF-8.
```

The [docs](https://www.postgresql.org/docs/11/collation.html) do say "By design, ICU will accept almost any string as a locale name and match it to the closest locale it can provide, using the fallback procedure described in its documentation."   But `en_US.UTF8` is a libc collation:

```
postgres=# \dOS+
...
 pg_catalog | en_US                  | en_US.utf8       | en_US.utf8       | libc     | yes            | 
 pg_catalog | en_US.utf8             | en_US.utf8       | en_US.utf8       | libc     | yes            | 
```

also, on the same DB that gave the error above, I don't see `en_US.UTF-8`.

```
postgres=# SELECT datcollate AS collation
postgres-#         FROM pg_database 
postgres-#         WHERE datname = current_database();
  collation  
-------------
 en_US.UTF-8
(1 row)
postgres=# SELECT * FROM pg_collation where collname ilike '%UTF%';
  collname  | collnamespace | collowner | collprovider | collencoding | collcollate | collctype  | collversion 
------------+---------------+-----------+--------------+--------------+-------------+------------+-------------
 C.UTF-8    |            11 |        10 | c            |            6 | C.UTF-8     | C.UTF-8    | 
 en_US.utf8 |            11 |        10 | c            |            6 | en_US.utf8  | en_US.utf8 | 
(2 rows)
```

something's weird here.  So let's just test that it gets the necessary bits right.  We really don't care about sorting of `ß`, for example, just of the ascii characters that we allow in identifiers and most critically in slugids.