### PR TITLE
Run renovate daily

### DIFF
--- a/package.json
+++ b/package.json
@@ -203,7 +203,7 @@
   "renovate": {
     "extends": [
       "config:base",
-      "schedule:earlyMondays"
+      "schedule:daily"
     ],
     "rebaseConflictedPrs": false,
     "prHourlyLimit": 0,


### PR DESCRIPTION
This should help us keep up with the number of updates required (we've
fallen behind) without getting PRs filed at all hours, and without ever
opening more than 9 at a time.