### PR TITLE
Retry auth failures in smoketests

### DIFF
--- a/changelog/issue-3224.md
+++ b/changelog/issue-3224.md
@@ -1,0 +1,4 @@
+audience: general
+level: silent
+reference: issue 3224
+---

--- a/infrastructure/tooling/src/smoketest/index.js
+++ b/infrastructure/tooling/src/smoketest/index.js
@@ -2,6 +2,7 @@ const {checks, scopeExpression} = require('./checks');
 const taskcluster = require('taskcluster-client');
 const libScopes = require('taskcluster-lib-scopes');
 const {TaskGraph} = require('console-taskgraph');
+const chalk = require('chalk');
 
 const main = async (options) => {
   if (!process.env.TASKCLUSTER_ROOT_URL ||
@@ -35,8 +36,11 @@ const main = async (options) => {
   }
 
   const target = options.target ? [`target-${options.target}`] : undefined;
-  const taskgraph = new TaskGraph(checks, {target});
-  await taskgraph.run();
+  const taskgraph = new TaskGraph( checks, {target});
+  const results = await taskgraph.run();
+  if (results['deployment-version']) {
+    console.log(chalk`{bold ${process.env.TASKCLUSTER_ROOT_URL} is running Taskcluster version:} {yellow ${results['deployment-version']}}`);
+  }
 };
 
 module.exports = {main};

--- a/infrastructure/tooling/src/smoketest/util.js
+++ b/infrastructure/tooling/src/smoketest/util.js
@@ -1,0 +1,23 @@
+/**
+ * Retry assertion failures in the given async function, waiting 100ms
+ * between tries.  This is useful for testing the auth service, which does
+ * not offer immediate use-after-write consistency for clients and roles.
+ */
+exports.retryAssertionFailures = async (times, utils, fn) => {
+  for (let tries = 1; tries <= times; tries++) {
+    try {
+      await fn();
+    } catch (err) {
+      if (tries === times || err.code !== 'ERR_ASSERTION') {
+        throw err;
+      }
+
+      utils.status({message: `Try ${tries} failed; waiting 100ms`});
+      await new Promise(res => setTimeout(res, 100));
+      continue;
+    }
+
+    // success!
+    break;
+  }
+};


### PR DESCRIPTION
As the comments in the diff indicate, auth doesn't guarantee you can use a role or client immediately on changing it -- there's a small delay while all the web processes get notified via pulse and update their resolvers.  So, retry enough to last that out.

Github Bug/Issue: Fixes #3224