### PR TITLE
Introduce `paginatedIterator` and use it

### DIFF
--- a/changelog/issue-3184.md
+++ b/changelog/issue-3184.md
@@ -1,0 +1,4 @@
+audience: developers
+level: silent
+reference: issue 3184
+---

--- a/libraries/postgres/src/index.js
+++ b/libraries/postgres/src/index.js
@@ -1,7 +1,10 @@
+const util = require('./util');
+
 module.exports = {
   Schema: require('./Schema'),
   Database: require('./Database'),
   ...require('./constants'),
   Keyring: require('./Keyring'),
-  ignorePgErrors: require('./util').ignorePgErrors,
+  ignorePgErrors: util.ignorePgErrors,
+  paginatedIterator: util.paginatedIterator,
 };

--- a/libraries/postgres/test/util_test.js
+++ b/libraries/postgres/test/util_test.js
@@ -1,4 +1,5 @@
-const {dollarQuote} = require('../src/util');
+const {range} = require('lodash');
+const {dollarQuote, paginatedIterator} = require('../src/util');
 const assert = require('assert');
 const path = require('path');
 
@@ -10,6 +11,53 @@ suite(path.basename(__filename), function() {
 
     test('string containing $$', function() {
       assert.equal(dollarQuote('pre $$abcd$$ post'), '$x$pre $$abcd$$ post$x$');
+    });
+  });
+
+  suite('paginatedIterator', function() {
+    test('iterate in a few batches', async function() {
+      const calls = [];
+      const fetch = async (size, offset) => {
+        calls.push([size, offset]);
+        return range(1000).slice(offset, offset + size);
+      };
+
+      const got = [];
+      for await (let v of paginatedIterator({fetch, size: 13})) {
+        got.push(v);
+      }
+
+      assert.deepEqual(got, range(1000));
+      assert.deepEqual(calls, range(0, 1000, 13).map(i => [13, i]).concat([[13, 1000]]));
+    });
+
+    test('batch size smaller than requested', async function() {
+      const fetch = async (size, offset) => {
+        return range(1000).slice(offset, offset + 10);
+      };
+
+      const got = [];
+      for await (let v of paginatedIterator({fetch, size: 100})) {
+        got.push(v);
+      }
+
+      assert.deepEqual(got, range(1000));
+    });
+
+    test('fetch fails', async function() {
+      const fetch = async (size, offset) => {
+        if (offset > 300) {
+          throw new Error('oh noes');
+        }
+        return range(1000).slice(offset, offset + 10);
+      };
+
+      assert.rejects(async () => {
+        const got = [];
+        for await (let v of paginatedIterator({fetch, size: 100})) {
+          got.push(v);
+        }
+      }, /oh noes/);
     });
   });
 });

--- a/services/hooks/src/utils.js
+++ b/services/hooks/src/utils.js
@@ -1,47 +1,4 @@
 const _ = require('lodash');
-const assert = require('assert').strict;
-
-const lastFireUtils = {
-  //  Get last Fires using a handler function.
-  // This is also to avoid loading all rows in memory.
-  async getLastFires(db, {hookGroupId, hookId}, handler) {
-    assert(handler instanceof Function, 'handler must be a function');
-    const pageSize = 1000;
-    let pageOffset = 0;
-
-    while (true) {
-      const rows = await db.fns.get_last_fires(hookGroupId, hookId, pageSize, pageOffset);
-      const entries = rows.map(row => ({
-        hookGroupId: row.hook_group_id,
-        hookId: row.hook_id,
-        firedBy: row.fired_by,
-        taskId: row.task_id,
-        taskCreateTime: row.task_create_time,
-        result: row.result,
-        error: row.error,
-      }));
-      await Promise.all(entries.map((item) => handler.call(item, item)));
-      pageOffset = pageOffset + pageSize;
-
-      if (!rows.length) {
-        break;
-      }
-    }
-  },
-  definition(lastFire) {
-    return {
-      hookGroupId: lastFire.hookGroupId,
-      hookId: lastFire.hookId,
-      firedBy: lastFire.firedBy,
-      taskId: lastFire.taskId,
-      taskCreateTime: lastFire.taskCreateTime,
-      result: lastFire.result,
-      error: lastFire.error,
-    };
-  },
-};
-
-exports.lastFireUtils = lastFireUtils;
 
 const queueUtils = {
   // Create a single instance from a DB row
@@ -79,24 +36,6 @@ const hookUtils = {
       nextScheduledDate: row.next_scheduled_date,
       triggerSchema: row.trigger_schema,
     };
-  },
-  //  Get hooks using a handler function.
-  // This is also to avoid loading all rows in memory.
-  async getHooks(db, {hookGroupId}, handler) {
-    assert(handler instanceof Function, 'handler must be a function');
-    const pageSize = 1000;
-    let pageOffset = 0;
-
-    while (true) {
-      const rows = await db.fns.get_hooks(hookGroupId, pageSize, pageOffset);
-      const entries = rows.map(exports.hookUtils.fromDb);
-      await Promise.all(entries.map((item) => handler.call(item, item)));
-      pageOffset = pageOffset + pageSize;
-
-      if (!rows.length) {
-        break;
-      }
-    }
   },
   definition(hook) {
     return {

--- a/services/worker-manager/src/worker-scanner.js
+++ b/services/worker-manager/src/worker-scanner.js
@@ -1,4 +1,5 @@
 const Iterate = require('taskcluster-lib-iterate');
+const {paginatedIterator} = require('taskcluster-lib-postgres');
 const { Worker } = require('./data');
 
 /**
@@ -46,23 +47,24 @@ class WorkerScanner {
 
   async scan() {
     await this.providers.forAll(p => p.scanPrepare());
-    await Worker.getWorkers(this.db, {}, {
-      handler: async worker => {
-        if (worker.state !== Worker.states.STOPPED) {
-          const provider = this.providers.get(worker.providerId);
-          if (provider) {
-            try {
-              await provider.checkWorker({worker});
-            } catch (err) {
-              this.monitor.reportError(err); // Just report it and move on so this doesn't block other providers
-            }
-          } else {
-            this.monitor.info(
-              `Worker ${worker.workerGroup}/${worker.workerId} has unknown providerId ${worker.providerId} (ignoring)`);
+
+    const fetch = async (size, offset) => await this.db.fns.get_workers(null, null, null, null, size, offset);
+    for await (let row of paginatedIterator({fetch})) {
+      const worker = Worker.fromDb(row);
+      if (worker.state !== Worker.states.STOPPED) {
+        const provider = this.providers.get(worker.providerId);
+        if (provider) {
+          try {
+            await provider.checkWorker({worker});
+          } catch (err) {
+            this.monitor.reportError(err); // Just report it and move on so this doesn't block other providers
           }
+        } else {
+          this.monitor.info(
+            `Worker ${worker.workerGroup}/${worker.workerId} has unknown providerId ${worker.providerId} (ignoring)`);
         }
-      },
-    });
+      }
+    }
 
     await this.providers.forAll(p => p.scanCleanup());
   }

--- a/services/worker-manager/test/expiration_test.js
+++ b/services/worker-manager/test/expiration_test.js
@@ -111,7 +111,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
     };
 
     const checkWPE = async (workerPoolId = 'pp/wt', errorId = eid) => {
-      return (await WorkerPoolError.getWorkerPoolErrors(helper.db, {errorId: eid, workerPoolId: 'pp/wt'})).rows;
+      return await helper.db.fns.get_worker_pool_errors_for_worker_pool(eid, 'pp/wt', null, null);
     };
 
     setup(function() {

--- a/services/worker-manager/test/helper.js
+++ b/services/worker-manager/test/helper.js
@@ -1,5 +1,6 @@
 const taskcluster = require('taskcluster-client');
 const {FakeEC2, FakeAzure, FakeGoogle} = require('./fakes');
+const {Worker} = require('../src/data');
 const {stickyLoader, Secrets, withEntity, fakeauth, withMonitor, withPulse, withDb, resetTables} = require('taskcluster-lib-testing');
 const builder = require('../src/api');
 const load = require('../src/main');
@@ -242,6 +243,12 @@ const stubbedNotify = () => {
 
   return notify;
 };
+
+/**
+ * Get all workers
+ */
+exports.getWorkers = async () =>
+  (await exports.db.fns.get_workers(null, null, null, null, null, null)).map(r => Worker.fromDb(r));
 
 exports.resetTables = (mock, skipping) => {
   setup('reset tables', async function() {

--- a/services/worker-manager/test/provider_aws_test.js
+++ b/services/worker-manager/test/provider_aws_test.js
@@ -122,8 +122,8 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
         const workerPool = await makeWorkerPool({config});
         const workerInfo = {existingCapacity: 0, requestedCapacity: 0};
         await provider.provision({workerPool, workerInfo});
-        const workers = await Worker.getWorkers(helper.db, {});
-        assert.equal(workers.rows.length, expectedWorkers);
+        const workers = await helper.getWorkers();
+        assert.equal(workers.length, expectedWorkers);
         await check(workers);
       });
     };
@@ -140,14 +140,14 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       expectedWorkers: 1,
     }, async function(workers) {
       const now = Date.now();
-      workers.rows.forEach(w => {
+      workers.forEach(w => {
         assert.strictEqual(w.workerPoolId, workerPoolId, 'Worker was created for a wrong worker pool');
         assert.strictEqual(w.workerGroup, 'us-west-2', 'Worker group should be az');
         assert.strictEqual(w.state, Worker.states.REQUESTED, 'Worker should be marked as requested');
         assert.strictEqual(w.providerData.region, defaultLaunchConfig.region, 'Region should come from the chosen config');
         // Check that this is setting times correctly to within a second or so to allow for some time
         // for the provisioning loop
-        assert(workers.rows[0].providerData.terminateAfter - now - (6000 * 1000) < 5000);
+        assert(workers[0].providerData.terminateAfter - now - (6000 * 1000) < 5000);
       });
       assert.deepEqual(fake.rgn('us-west-2').runInstancesCalls.map(({MinCount}) => MinCount), [1]);
       assertHasTag(fake.rgn('us-west-2').runInstancesCalls[0], 'instance', 'CreatedBy', 'taskcluster-wm-aws');
@@ -439,9 +439,9 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       provider.seen = {};
       await provider.checkWorker({worker: worker});
 
-      const workers = await Worker.getWorkers(helper.db, {});
-      assert.notStrictEqual(workers.rows.length, 0);
-      workers.rows.forEach(w =>
+      const workers = await helper.getWorkers();
+      assert.notStrictEqual(workers.length, 0);
+      workers.forEach(w =>
         assert.strictEqual(w.state, Worker.states.STOPPED));
       assert.strictEqual(provider.seen[worker.workerPoolId], 0);
     });
@@ -458,9 +458,9 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       provider.seen = {};
       await provider.checkWorker({worker: worker});
 
-      const workers = await Worker.getWorkers(helper.db, {});
-      assert.notStrictEqual(workers.rows.length, 0);
-      workers.rows.forEach(w =>
+      const workers = await helper.getWorkers();
+      assert.notStrictEqual(workers.length, 0);
+      workers.forEach(w =>
         assert.strictEqual(w.state, Worker.states.REQUESTED));
       assert.strictEqual(provider.seen[worker.workerPoolId], 1);
     });
@@ -491,9 +491,9 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       provider.seen = {};
       await provider.checkWorker({worker: worker});
 
-      const workers = await Worker.getWorkers(helper.db, {});
-      assert.notStrictEqual(workers.rows.length, 0);
-      workers.rows.forEach(w =>
+      const workers = await helper.getWorkers();
+      assert.notStrictEqual(workers.length, 0);
+      workers.forEach(w =>
         assert.strictEqual(w.state, Worker.states.STOPPED));
       assert.strictEqual(provider.seen[worker.workerPoolId], 0);
     });

--- a/services/worker-manager/test/provider_azure_test.js
+++ b/services/worker-manager/test/provider_azure_test.js
@@ -154,9 +154,9 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
         requestedCapacity: 0,
       };
       await provider.provision({workerPool, workerInfo});
-      const workers = await Worker.getWorkers(helper.db, {});
-      assert.equal(workers.rows.length, 1);
-      const worker = workers.rows[0];
+      const workers = await helper.getWorkers();
+      assert.equal(workers.length, 1);
+      const worker = workers[0];
 
       // check that the VM config is correct since this suite does not
       // go all the way to creating the VM
@@ -332,9 +332,9 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
         requestedCapacity: 0,
       };
       await provider.provision({workerPool, workerInfo});
-      const workers = await Worker.getWorkers(helper.db, {});
-      assert.equal(workers.rows.length, 1);
-      worker = workers.rows[0];
+      const workers = await helper.getWorkers();
+      assert.equal(workers.length, 1);
+      worker = workers[0];
 
       ipName = worker.providerData.ip.name;
       nicName = worker.providerData.nic.name;
@@ -355,9 +355,9 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
 
     const assertProvisioningState = async (expectations) => {
       // re-fetch the worker, since it should have been updated
-      const workers = await Worker.getWorkers(helper.db, {});
-      assert.equal(workers.rows.length, 1);
-      worker = workers.rows[0];
+      const workers = await helper.getWorkers();
+      assert.equal(workers.length, 1);
+      worker = workers[0];
 
       for (let resourceType of ['ip', 'vm', 'nic']) {
         const name = worker.providerData[resourceType].name;
@@ -568,9 +568,9 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
         requestedCapacity: 0,
       };
       await provider.provision({workerPool, workerInfo});
-      const workers = await Worker.getWorkers(helper.db, {});
-      assert.equal(workers.rows.length, 1);
-      worker = workers.rows[0];
+      const workers = await helper.getWorkers();
+      assert.equal(workers.length, 1);
+      worker = workers[0];
 
       ipName = worker.providerData.ip.name;
       nicName = worker.providerData.nic.name;
@@ -579,9 +579,9 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
 
     const assertRemovalState = async (expectations) => {
       // re-fetch the worker, since it should have been updated
-      const workers = await Worker.getWorkers(helper.db, {});
-      assert.equal(workers.rows.length, 1);
-      worker = workers.rows[0];
+      const workers = await helper.getWorkers();
+      assert.equal(workers.length, 1);
+      worker = workers[0];
 
       let checkResourceExpectation = (expectation, resourceType, typeData, index) => {
         const client = clientForResourceType(resourceType);

--- a/services/worker-manager/test/provider_test.js
+++ b/services/worker-manager/test/provider_test.js
@@ -107,9 +107,9 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
         WorkerPoolError: WorkerPoolError,
       });
 
-      const errors = await WorkerPoolError.getWorkerPoolErrors(helper.db, {workerPoolId: 'ww/tt'});
-      assert.equal(errors.rows.length, 1);
-      assert.equal(errors.rows[0].workerPoolId, 'ww/tt');
+      const errors = await helper.db.fns.get_worker_pool_errors_for_worker_pool(null, 'ww/tt', null, null);
+      assert.equal(errors.length, 1);
+      assert.equal(errors[0].worker_pool_id, 'ww/tt');
 
       assert.equal(helper.notify.emails.length, 0);
     });
@@ -126,43 +126,12 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
         WorkerPoolError: WorkerPoolError,
       });
 
-      const errors = await WorkerPoolError.getWorkerPoolErrors(helper.db, {workerPoolId: 'ww/tt'});
-      assert.equal(errors.rows.length, 1);
-      assert.equal(errors.rows[0].workerPoolId, 'ww/tt');
+      const errors = await helper.db.fns.get_worker_pool_errors_for_worker_pool(null, 'ww/tt', null, null);
+      assert.equal(errors.length, 1);
+      assert.equal(errors[0].worker_pool_id, 'ww/tt');
 
       assert.equal(helper.notify.emails.length, 1);
       assert.equal(helper.notify.emails[0].address, 'whatever@example.com');
-    });
-
-    test('getWorkerPoolErrors pagination', async function() {
-      const workerPool = await createWP({emailOnError: true});
-      for (let i = 0; i < 110; i++) {
-        await provider.reportError({
-          workerPool,
-          kind: 'something-error',
-          title: 'And Error about Something',
-          description: 'WHO KNOWS',
-          notify: helper.notify,
-          WorkerPoolError: WorkerPoolError,
-          extra: {
-            foo: `bar-${i}`,
-          },
-        });
-      }
-      let pages = 0;
-      let errorIds = [];
-      const query = {limit: 1};
-      while (true) {
-        const res = await WorkerPoolError.getWorkerPoolErrors(helper.db, {}, {query});
-        pages += 1;
-        res.rows.forEach(({errorId}) => errorIds.push(errorId));
-        if (res.continuationToken) {
-          query.continuationToken = res.continuationToken;
-        } else {
-          break;
-        }
-      }
-      assert.equal(pages, 110);
     });
 
     test('report errors (w/ email and extraInfo)', async function() {
@@ -180,9 +149,9 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
         },
       });
 
-      const errors = await WorkerPoolError.getWorkerPoolErrors(helper.db, {});
-      assert.equal(errors.rows.length, 1);
-      assert.equal(errors.rows[0].workerPoolId, 'ww/tt');
+      const errors = await helper.db.fns.get_worker_pool_errors_for_worker_pool(null, 'ww/tt', null, null);
+      assert.equal(errors.length, 1);
+      assert.equal(errors[0].worker_pool_id, 'ww/tt');
 
       assert.equal(helper.notify.emails.length, 1);
       assert.equal(helper.notify.emails[0].address, 'whatever@example.com');


### PR DESCRIPTION
This function calls paginated DB functions and translates the results
into an async iterator of rows.

Github Bug/Issue: Fixes #3184

I changed most custom pagination functions to use this.  The one I didn't change is the function scanning for expiration of artifacts, which has a workaround for #3278 in place.  So let's wait until that issue is fixed to change that function.