### PR TITLE
Fail early on upgrade if a --db-version does not exist

### DIFF
--- a/changelog/issue-3170.md
+++ b/changelog/issue-3170.md
@@ -1,0 +1,4 @@
+audience: general
+level: silent
+reference: issue 3170
+---

--- a/libraries/postgres/src/Database.js
+++ b/libraries/postgres/src/Database.js
@@ -151,7 +151,11 @@ class Database {
     try {
       // perform any necessary upgrades..
       const dbVersion = await db.currentVersion();
-      const stopAt = toVersion === undefined ? schema.latestVersion().version : toVersion;
+      const latestVersion = schema.latestVersion().version;
+      const stopAt = toVersion === undefined ? latestVersion : toVersion;
+      if (stopAt > latestVersion) {
+        throw new Error(`no such version ${stopAt}; latest known version is ${latestVersion}`);
+      }
       if (dbVersion < stopAt) {
         // run each of the upgrade scripts
         for (let v = dbVersion + 1; v <= stopAt; v++) {


### PR DESCRIPTION
Github Bug/Issue: Fixes #3170