### PR TITLE
pass azureCryptoKeys to db setup

### DIFF
--- a/changelog/UqMeg67CQvmStJVJND1veg.md
+++ b/changelog/UqMeg67CQvmStJVJND1veg.md
@@ -1,0 +1,3 @@
+audience: general
+level: silent
+---

--- a/services/hooks/src/main.js
+++ b/services/hooks/src/main.js
@@ -45,6 +45,7 @@ const load = loader({
       serviceName: 'hooks',
       monitor: monitor.childMonitor('db'),
       statementTimeout: process === 'server' ? 30000 : 0,
+      azureCryptoKey: cfg.azure.cryptoKey,
       dbCryptoKeys: cfg.postgres.dbCryptoKeys,
     }),
   },

--- a/services/web-server/src/main.js
+++ b/services/web-server/src/main.js
@@ -189,6 +189,7 @@ const load = loader(
         serviceName: 'web_server',
         monitor: monitor.childMonitor('db'),
         statementTimeout: process === 'server' ? 30000 : 0,
+        azureCryptoKey: cfg.azure.cryptoKey,
         dbCryptoKeys: cfg.postgres.dbCryptoKeys,
       }),
     },


### PR DESCRIPTION
This was missed for these two services.  @imbstack just pointed out I missed it in #3234, so I'm confident it will be remembered in the secrets service :)

This causes a minor issue for v35.0.0, which included the github access tokens table.  It won't start without DB_CRYPTO_KEYS set.  I updated the relase notes in the GitHub release appropriately.  It was a major release, so that's probably enough.