### PR TITLE
Handle the case where a worker pool has no launch configs

### DIFF
--- a/changelog/GQ7vBictTQK3Ti_GiH3M1A.md
+++ b/changelog/GQ7vBictTQK3Ti_GiH3M1A.md
@@ -1,0 +1,4 @@
+audience: worker-deployers
+level: patch
+---
+A worker pool with no launch configs will no longer cause errors (although it will also not create any workers!)

--- a/services/worker-manager/src/providers/aws.js
+++ b/services/worker-manager/src/providers/aws.js
@@ -97,8 +97,9 @@ class AwsProvider extends Provider {
       maxCapacity: workerPool.config.maxCapacity,
       workerInfo,
     });
-    if (toSpawn === 0) {
-      return;
+
+    if (toSpawn === 0 || workerPool.config.launchConfigs.length === 0) {
+      return; // Nothing to do
     }
 
     const {terminateAfter, reregistrationTimeout} = Provider.interpretLifecycle(workerPool.config);

--- a/services/worker-manager/src/providers/azure.js
+++ b/services/worker-manager/src/providers/azure.js
@@ -126,7 +126,7 @@ class AzureProvider extends Provider {
       workerInfo,
     });
 
-    if (toSpawn === 0) {
+    if (toSpawn === 0 || workerPool.config.launchConfigs.length === 0) {
       return; // Nothing to do
     }
 

--- a/services/worker-manager/src/providers/google.js
+++ b/services/worker-manager/src/providers/google.js
@@ -207,7 +207,7 @@ class GoogleProvider extends Provider {
       workerInfo,
     });
 
-    if (toSpawn === 0) {
+    if (toSpawn === 0 || workerPool.config.launchConfigs.length === 0) {
       return; // Nothing to do
     }
 


### PR DESCRIPTION
https://sentry.prod.mozaws.net/operations/taskcluster-cloudops-stage/issues/8766602/

Fixes #3054 (which was already fixed??)