### PR TITLE
Build livelog image from scratch

### DIFF
--- a/changelog/issue-3176.md
+++ b/changelog/issue-3176.md
@@ -1,0 +1,4 @@
+audience: general
+level: silent
+reference: issue 3176
+---

--- a/infrastructure/tooling/src/build/tasks/livelog.js
+++ b/infrastructure/tooling/src/build/tasks/livelog.js
@@ -72,7 +72,7 @@ module.exports = ({tasks, cmdOptions, credentials, baseDir, logsDir}) => {
       // this simple Dockerfile just packages the binary into a Docker image
       const dockerfile = path.join(contextDir, 'Dockerfile');
       fs.writeFileSync(dockerfile, [
-        'FROM progrium/busybox',
+        'FROM scratch',
         'EXPOSE 60023',
         'EXPOSE 60022',
         'COPY version.json /app/version.json',


### PR DESCRIPTION
Github Bug/Issue: Fixes #3176

I built this locally and ran it.  The binary is statically linked, and doesn't execute anything, so it doesn't need any other files in the image.