### PR TITLE
Private artifact links in UI

### DIFF
--- a/changelog/issue-2992.md
+++ b/changelog/issue-2992.md
@@ -1,0 +1,5 @@
+audience: users
+level: patch
+reference: issue 2992
+---
+Private artifacts are now accessable via the UI.

--- a/ui/src/components/TaskRunsCard/index.jsx
+++ b/ui/src/components/TaskRunsCard/index.jsx
@@ -172,7 +172,16 @@ export default class TaskRunsCard extends Component {
     const { taskId, runId } = this.getCurrentRun();
 
     if (isLog) {
-      const encoded = encodeURIComponent(url);
+      // react-router decodes its params (via `decodeURI`)
+      // so something like '%252F' and '%2F' in the URL both become '%2F'
+      // we should be able to remove `encodeURI` once
+      // https://github.com/ReactTraining/history/issues/745 has been resolved.
+      //
+      // Context: In order to create the URIs for private artifacts we use
+      // `queue.externalBuildSignedUrl`. Internally, that method uses
+      // `decodeURIComponent` so when an artifact name has a slash in it
+      // the URI will have '`%2F'.
+      const encoded = encodeURI(encodeURIComponent(url));
 
       return this.isLiveLog()
         ? `/tasks/${taskId}/runs/${runId}/logs/live/${encoded}`


### PR DESCRIPTION
`public/logs/live_backing.log` is reachable via `https://community.taskcluster-artifacts.net/a3TRMvMERZuRwCGHb9dpcA/0/public/logs/live_backing.log` but in order to access a private log, it looks like the artifact name is encoded rather than nested (e.g., `../debug-logs%2Flivelog-docker-push.log?bewit=...` rather than `.../debug-logs/livelog-docker-push.log?bewit=...`)?

The log viewer grabs the URL to render from the UI which means the URL is encoded (e.g., `https%3A%2F%2Fcommunity-tc.services.mozilla.com%2Fapi%2Fqueue%2Fv1%2Ftask%2Fa3TRMvMERZuRwCGHb9dpcA%2Fruns%2F0%2Fartifacts%2Fdebug-logs%2Ftaskcluster-proxy-docker-build.log%3Fbewit%3D...`). Upon decoding it, `%2F` becomes `/` so then it will try to access the artifact `debug-logs/taskcluster-proxy-docker-build.log` which doesn't  exist.

It looks like when artifacts are stored, some are encoded (e.g., `debug-logs%2Flivelog-docker-push.log`) and some aren't (e.g., `public/logs/live_backing.log
`). The current PR is a hack to fix this but probably not ideal.

Refers to https://github.com/taskcluster/taskcluster/issues/2992.


---

If this is the right direction we want to take, should this be a major bump? Should we bother adding redirects from the old URL to the new one?


