### PR TITLE
Avoid generic-worker gzipping zstandard-compressed files

### DIFF
--- a/workers/generic-worker/artifacts.go
+++ b/workers/generic-worker/artifacts.go
@@ -404,6 +404,7 @@ func resolve(base *BaseArtifact, artifactType string, path string, contentType s
 			".tbz": true,
 			".whl": true, // Python wheel are already zip file
 			".xz":  true,
+			".zst": true,
 			// Flash
 			".swf": true,
 			".flv": true,


### PR DESCRIPTION
This matches docker-worker per https://github.com/taskcluster/taskcluster/blob/067b1e076d804dd4342a6b47d29f943746841710/workers/docker-worker/src/lib/features/artifacts.js#L140