### PR TITLE
fix web-server inputs

### DIFF
--- a/services/web-server/config.yml
+++ b/services/web-server/config.yml
@@ -52,6 +52,7 @@ defaults:
   postgres:
     readDbUrl: !env READ_DB_URL
     writeDbUrl: !env WRITE_DB_URL
+    dbCryptoKeys: !env:json:optional DB_CRYPTO_KEYS
 
   # Pulse credentials
   pulse:

--- a/services/web-server/src/main.js
+++ b/services/web-server/src/main.js
@@ -192,6 +192,8 @@ const load = loader(
         serviceName: 'web_server',
         monitor: monitor.childMonitor('db'),
         statementTimeout: process === 'server' ? 30000 : 0,
+        azureCryptoKey: cfg.azure.cryptoKey,
+        dbCryptoKeys: cfg.postgres.dbCryptoKeys,
       }),
     },
 


### PR DESCRIPTION
This is the basis of the one-off image we're running for v35.0.0 -- `taskcluster/taskcluster:v35.0.0-1-g6d5b0c70b`.

The PR is just a bookmark so we know what's running.