### PR TITLE
Build taskcluster/taskcluster-proxy with a v in the tag

### DIFF
--- a/changelog/issue-3342.md
+++ b/changelog/issue-3342.md
@@ -1,0 +1,4 @@
+audience: general
+level: silent
+reference: issue 3342
+---

--- a/infrastructure/tooling/src/build/tasks/taskcluster-proxy.js
+++ b/infrastructure/tooling/src/build/tasks/taskcluster-proxy.js
@@ -38,7 +38,7 @@ module.exports = ({tasks, cmdOptions, credentials, baseDir, logsDir}) => {
     run: async (requirements, utils) => {
       utils.step({title: 'Check Repository'});
 
-      const tag = `taskcluster/taskcluster-proxy:${requirements['release-version']}`;
+      const tag = `taskcluster/taskcluster-proxy:v${requirements['release-version']}`;
       const provides = {'taskcluster-proxy-docker-image': tag};
 
       utils.step({title: 'Building taskcluster-proxy'});


### PR DESCRIPTION
Docker-worker already expects this tag.  Generic-worker uses the
executable.

Github Bug/Issue: Fixes #3342
