### PR TITLE
[generic-worker] Don't require mounted task artifacts to be present in dependencies.

### DIFF
--- a/changelog/no-mount-depedencies.md
+++ b/changelog/no-mount-depedencies.md
@@ -1,0 +1,5 @@
+audience: users
+level: minor
+---
+Generic worker no longer requires tasks from which artifacts are mounted to be
+dependencies of the running task.

--- a/workers/generic-worker/mounts.go
+++ b/workers/generic-worker/mounts.go
@@ -313,16 +313,6 @@ func (taskMount *TaskMount) initReferencedTaskIDs() {
 			}
 		}
 	}
-	taskDependencies := map[string]bool{}
-	for _, taskID := range taskMount.task.Definition.Dependencies {
-		taskDependencies[taskID] = true
-	}
-	for taskID := range taskMount.referencedTaskIDs {
-		if !taskDependencies[taskID] {
-			taskMount.payloadError = fmt.Errorf("[mounts] task.dependencies needs to include %v since one or more of its artifacts are mounted", taskID)
-			return
-		}
-	}
 }
 
 // Here the order is important. We want to delete file caches before we delete


### PR DESCRIPTION
This is annoying when using the edit-task functionality in the UI, as it drops
dependencies when you edit a task, and generic worker forces you to re-add
them.