### PR TITLE
Pass an actual reason code to task.abort()

### DIFF
--- a/changelog/issue-3483.md
+++ b/changelog/issue-3483.md
@@ -1,0 +1,5 @@
+audience: worker-deployers
+level: patch
+reference: issue 3483
+---
+Faced with an error reclaiming a task, docker-worker will now correctly call `reportException` with reason `internal-error`.

--- a/workers/docker-worker/src/lib/task.js
+++ b/workers/docker-worker/src/lib/task.js
@@ -295,7 +295,9 @@ class Reclaimer {
       if (e.statusCode === 409) {
         this.task.cancel('canceled', errorMessage);
       } else {
-        this.task.abort(errorMessage);
+        // if this is a permissions error, then this call is unlikely to work,
+        // but let's give it a shot!
+        this.task.abort('internal-error');
       }
 
       return;


### PR DESCRIPTION
This rarely happens, and is unlikely to succeed even with this fix when it does happen, but it was an easy fix anyway.

Github Bug/Issue: Fixes #3483