### PR TITLE
#3502 - get more data when scopes is not an array

### DIFF
--- a/changelog/issue-3502.md
+++ b/changelog/issue-3502.md
@@ -1,0 +1,4 @@
+audience: general
+level: silent
+reference: issue 3502
+---

--- a/services/auth/src/scoperesolver.js
+++ b/services/auth/src/scoperesolver.js
@@ -1,4 +1,5 @@
 const _ = require('lodash');
+const util = require('util');
 const assert = require('assert');
 const taskcluster = require('taskcluster-client');
 const events = require('events');
@@ -317,6 +318,11 @@ class ScopeResolver extends events.EventEmitter {
       let scopes = this.resolve(client.unexpandedScopes);
       client.scopes = scopes; // for createSignatureValidator compatibility
       client.expandedScopes = scopes;
+    }
+
+    // check for https://github.com/taskcluster/taskcluster/issues/3502
+    if (!Array.isArray(client.scopes)) {
+      assert(false, `Got non-array client.scopes=${util.inspect(client.scopes)} (see #3502)`);
     }
 
     if (client.updateLastUsed) {


### PR DESCRIPTION
If my hunch is correct that `client.scopes` is being set to a non-array and then returned from the clientLoader, then this will show what type it has at that point.  If we see schema-validation error again without this assertion failing, then my hunch is incorrect.  Divide and conquer!

Github Bug/Issue: Refs #3502