### PR TITLE
Minify some of the docker-worker dependencies

### DIFF
--- a/infrastructure/tooling/src/generate/generators/yarn-minify.js
+++ b/infrastructure/tooling/src/generate/generators/yarn-minify.js
@@ -111,7 +111,6 @@ const IGNORE = {
     'ajv',
     'brace-expansion',
     'chownr',
-    'debug',
     'end-of-stream',
     'glob',
     'inherits',

--- a/infrastructure/tooling/src/generate/generators/yarn-minify.js
+++ b/infrastructure/tooling/src/generate/generators/yarn-minify.js
@@ -114,7 +114,6 @@ const IGNORE = {
     'glob',
     'inherits',
     'ipaddr.js',
-    'js-yaml',
     'mime-types',
     'minimatch',
     'readable-stream',

--- a/infrastructure/tooling/src/generate/generators/yarn-minify.js
+++ b/infrastructure/tooling/src/generate/generators/yarn-minify.js
@@ -108,7 +108,6 @@ const IGNORE = {
     'ws',
   ].includes(pkg),
   'workers/docker-worker/yarn.lock': pkg => [
-    'ajv',
     'brace-expansion',
     'chownr',
     'end-of-stream',

--- a/workers/docker-worker/package.json
+++ b/workers/docker-worker/package.json
@@ -54,7 +54,6 @@
     "mz": "^2.0.0",
     "nock": "^11.3.5",
     "object-factory": "^0.1.2",
-    "promise": "^7.0.3",
     "promise-retry": "^1.1.1",
     "promisepipe": "^3.0.0",
     "query-string": "^6.1.0",

--- a/workers/docker-worker/yarn.lock
+++ b/workers/docker-worker/yarn.lock
@@ -1804,7 +1804,7 @@ promise-retry@^1.1.1:
     err-code "^1.0.0"
     retry "^0.10.0"
 
-promise@^7.0.1, promise@^7.0.3:
+promise@^7.0.1:
   version "7.3.1"
   resolved "https://registry.yarnpkg.com/promise/-/promise-7.3.1.tgz#064b72602b18f90f29192b8b1bc418ffd1ebd3bf"
   integrity sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==

--- a/workers/docker-worker/yarn.lock
+++ b/workers/docker-worker/yarn.lock
@@ -1226,14 +1226,14 @@ isurl@^1.0.0-alpha5:
     has-to-string-tag-x "^1.2.0"
     is-object "^1.0.1"
 
-js-yaml@3.13.1, js-yaml@^3.12.0:
+js-yaml@3.13.1:
   version "3.13.1"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.13.1.tgz#aff151b30bfdfa8e49e05da22e7415e9dfa37847"
   dependencies:
     argparse "^1.0.7"
     esprima "^4.0.0"
 
-js-yaml@^3.13.1:
+js-yaml@^3.12.0, js-yaml@^3.13.1:
   version "3.14.0"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.14.0.tgz#a7a34170f26a21bb162424d8adacb4113a69e482"
   integrity sha512-/4IbIeHcD9VMHFqDR/gQ7EdZdLimOvW2DdcxFjdyyZ9NsbS+ccrXqVWDtab/lRl5AlUqmpBx8EhPaWR+OtY17A==

--- a/workers/docker-worker/yarn.lock
+++ b/workers/docker-worker/yarn.lock
@@ -70,21 +70,12 @@ agent-base@^4.1.0:
   dependencies:
     es6-promisify "^5.0.0"
 
-ajv@^6.10.2:
+ajv@^6.10.2, ajv@^6.5.5:
   version "6.12.5"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.12.5.tgz#19b0e8bae8f476e5ba666300387775fb1a00a4da"
   integrity sha512-lRF8RORchjpKG50/WFf8xmg7sgCLFiYNNnqdKflk63whMQcWR5ngGjiSXkL9bjxy6B2npOK2HSMN49jEBMSkag==
   dependencies:
     fast-deep-equal "^3.1.1"
-    fast-json-stable-stringify "^2.0.0"
-    json-schema-traverse "^0.4.1"
-    uri-js "^4.2.2"
-
-ajv@^6.5.5:
-  version "6.10.2"
-  resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.10.2.tgz#d3cea04d6b017b2894ad69040fec8b623eb4bd52"
-  dependencies:
-    fast-deep-equal "^2.0.1"
     fast-json-stable-stringify "^2.0.0"
     json-schema-traverse "^0.4.1"
     uri-js "^4.2.2"

--- a/workers/docker-worker/yarn.lock
+++ b/workers/docker-worker/yarn.lock
@@ -444,9 +444,9 @@ dashdash@^1.12.0:
   dependencies:
     assert-plus "^1.0.0"
 
-debug@*, debug@3.2.6, debug@^3.1.0:
-  version "3.2.6"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.6.tgz#e83d17de16d8a7efb7717edbe5fb10135eee629b"
+debug@*, debug@^4.0.0, debug@^4.1.0, debug@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.1.1.tgz#3b72260255109c6b589cee050f1d516139664791"
   dependencies:
     ms "^2.1.1"
 
@@ -460,9 +460,9 @@ debug@2.6.9:
   dependencies:
     ms "2.0.0"
 
-debug@^4.0.0, debug@^4.1.0, debug@^4.1.1:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-4.1.1.tgz#3b72260255109c6b589cee050f1d516139664791"
+debug@3.2.6, debug@^3.1.0:
+  version "3.2.6"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.6.tgz#e83d17de16d8a7efb7717edbe5fb10135eee629b"
   dependencies:
     ms "^2.1.1"
 


### PR DESCRIPTION
I cherry-picked a few non-minified requirements to remove, as a way of chipping away at the list.