### PR TITLE
Fix broken link in dev-docs README.md

### DIFF
--- a/dev-docs/README.md
+++ b/dev-docs/README.md
@@ -24,7 +24,7 @@ Developers should be familiar with the incidents that have occurred in the past 
 
 # Further Reading
 
-* [Design Principles](principles.md)
-* [Idempotency](idempotency.md)
-* [Best Practices](best-practices.md)
-* [Releasing](releasing.md)
+- [Design Principles](principles.md)
+- [Idempotency](idempotency.md)
+- [Best Practices](best-practices)
+- [Releasing](releasing.md)


### PR DESCRIPTION
<!-- Did you remember to add a changelog snippet? See
     https://github.com/taskcluster/taskcluster/blob/main/dev-docs/best-practices/changelog.md

     If this is related to a Bugzilla bug, please begin your title with [Bug XXXXX]
     and update this link.  Otherwise, just remove it from your PR comment.  -->



<!-- If this is related to a GitHub Bug/Issue, Please write Issue Number after # in the next line. Otherwise, just remove it from your PR comment. -->

Observed that the Best Practices link in the dev-docs README.md was landing on a 404 page. 
Made a slight edit so that it now lands in the best-practices directory. 