### PR TITLE
fix workermanager.updateWorker for static provider with static secret

### DIFF
--- a/changelog/issue-3561.md
+++ b/changelog/issue-3561.md
@@ -1,0 +1,5 @@
+audience: worker-deployers
+level: patch
+reference: issue 3561
+---
+Bug fix: calls to workermanager.updateWorker for the static provider have been fixed.

--- a/services/worker-manager/src/providers/static.js
+++ b/services/worker-manager/src/providers/static.js
@@ -50,7 +50,7 @@ class StaticProvider extends Provider {
       worker.capacity = input.capacity;
       worker.providerData = {
         ...worker.providerData,
-        staticSecret: input.providerData.staticSecret,
+        staticSecret: input.providerInfo.staticSecret,
       };
     });
     return worker;

--- a/services/worker-manager/test/provider_static_test.js
+++ b/services/worker-manager/test/provider_static_test.js
@@ -79,7 +79,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       input: {
         expires,
         capacity: 7,
-        providerData: { staticSecret: 'new-secret' },
+        providerInfo: { staticSecret: 'new-secret' },
       },
     });
 


### PR DESCRIPTION
Sentry issue: [9644729](https://sentry.prod.mozaws.net/operations/taskcluster-community/issues/9644729/?referrer=alert_email)

It looks like the request body gets passed in to the provider updateWorker call as:

```js
    worker = await provider.updateWorker({
      workerPool,
      worker,
      input: {
        capacity: 1,
        ...req.body,
      },    
    }); 
```

So the request body is included in `input`.

Then in the static provider:

```js
  async updateWorker({ workerPool, worker, input }) {
    await worker.update(this.db, worker => {
      worker.expires = input.expires;
      worker.capacity = input.capacity;
      worker.providerData = { 
        ...worker.providerData,
        staticSecret: input.providerData.staticSecret,
      };  
    }); 
    return worker;
  }
```

So it looks for `input.providerData.staticSecret` but that should be `input.providerInfo.staticSecret` according to the json schema.