### PR TITLE
Remove unnecessary logging of HTTP headers in livelog

### DIFF
--- a/changelog/Lb224mAkRF28OgKo1sZ36Q.md
+++ b/changelog/Lb224mAkRF28OgKo1sZ36Q.md
@@ -1,0 +1,3 @@
+audience: general
+level: silent
+---

--- a/tools/livelog/main.go
+++ b/tools/livelog/main.go
@@ -112,8 +112,6 @@ func getLog(
 	writer.Header().Set("Access-Control-Allow-Origin", "*")
 	writer.Header().Set("Access-Control-Expose-Headers", "Transfer-Encoding")
 
-	log.Printf("%v", req.Header)
-
 	// Send headers so its clear what we are trying to do...
 	writer.WriteHeader(200)
 	log.Print("wrote headers...")

--- a/workers/generic-worker/artifacts.go
+++ b/workers/generic-worker/artifacts.go
@@ -466,7 +466,6 @@ func (task *TaskRun) uploadArtifact(artifact TaskArtifact) *CommandExecutionErro
 	if err != nil {
 		switch t := err.(type) {
 		case *tcclient.APICallException:
-			log.Print(t.CallSummary.String())
 			switch rootCause := t.RootCause.(type) {
 			case httpbackoff.BadHttpResponseCode:
 				if rootCause.HttpResponseCode/100 == 5 {


### PR DESCRIPTION
(based on an issue found by GitHub's code-scanning)