### PR TITLE
Fix rendering of tc-github badges.

### DIFF
--- a/changelog/issue-3358.md
+++ b/changelog/issue-3358.md
@@ -1,0 +1,5 @@
+audience: users
+level: patch
+reference: issue 3358
+---
+The "badge" SVGs provided by the GitHub service now render correctly instead of as black shapes.

--- a/services/github/src/api.js
+++ b/services/github/src/api.js
@@ -380,6 +380,7 @@ builder.declare({
     root: __dirname + '/../assets/',
     headers: {
       'Cache-Control': 'no-cache, no-store, must-revalidate',
+      'Content-Security-Policy': "default-source 'none'; style-source 'unsafe-inline'",
     },
   };
 


### PR DESCRIPTION
The sitewide content-security-policy evalutes to `style-source: 'none'`,
but these icons set their colors with bits like `style="fill:#333333"`.
This is harmless and the content is static, so the fix is to adjust the
CSP to allow inline styles.


Github Bug/Issue: Fixes #3358