### PR TITLE
Add default content-type to tc-proxy requests

### DIFF
--- a/changelog/issue-3521.md
+++ b/changelog/issue-3521.md
@@ -1,0 +1,6 @@
+audience: users
+level: patch
+reference: issue 3521
+---
+Taskcluster proxy now automatically adds a `Content-Type: application/json` header if none is specified. This is to match legacy behavior and should be
+unnoticed by users.

--- a/tools/taskcluster-proxy/routes.go
+++ b/tools/taskcluster-proxy/routes.go
@@ -236,6 +236,10 @@ func (routes *Routes) commonHandler(res http.ResponseWriter, req *http.Request, 
 			proxyreq.Header[k] = v
 		}
 
+		if proxyreq.Header.Get("content-type") == "" {
+			proxyreq.Header.Set("content-type", "application/json")
+		}
+
 		// Refresh Authorization header with each call...
 		err = routes.Credentials.SignRequest(proxyreq)
 		if err != nil {


### PR DESCRIPTION
This seems to be the easiest way to restore what we believe legacy behavior was. Still pretty amateurish at go so please feel free to trash this review!

Github Bug/Issue: Fixes #3521
