### PR TITLE
Fix error message when postgres collation is bad

### DIFF
--- a/changelog/LFAj1M-IT9-jSqryiOxE-Q.md
+++ b/changelog/LFAj1M-IT9-jSqryiOxE-Q.md
@@ -1,0 +1,3 @@
+audience: general
+level: silent
+---

--- a/libraries/postgres/src/Database.js
+++ b/libraries/postgres/src/Database.js
@@ -431,7 +431,8 @@ class Database {
             WHERE datname = current_database()`);
           const collation = res.rows[0].collation;
           throw new Error([
-            'Postgres database must have default collation en_US.utf8 (and in particular be case-insensitive for ASCII letters);',
+            'Postgres database must have default collation en_US.utf8 (and in particular sort',
+            '`0` < `a` < `A` < `b` < `B`, for proper slugid ordering);',
             `this database is using ${collation}, and sorts '${pair[0]}' > '${pair[1]}'.`,
           ].join(' '));
         }


### PR DESCRIPTION
The sorting is not "case-insensitive", as that would only be a partial
order.  The important thing for sorting slugids is that different cases
of the same letter be sorted together, which is not what the C collation
does.
