### PR TITLE
Revert "Issue 3598 - fix db collation check"

### DIFF
--- a/changelog/issue-3599.md
+++ b/changelog/issue-3599.md
@@ -1,4 +1,4 @@
 audience: general
 level: silent
-reference: issue 3598
+reference: issue 3599
 ---

--- a/libraries/postgres/src/Database.js
+++ b/libraries/postgres/src/Database.js
@@ -423,7 +423,7 @@ class Database {
     await this._withClient('admin', async client => {
       // check the DB collation by its behavior, rather than by name, as names seem to vary.
       for (const pair of ['aA', 'ab', 'Ab', 'aB', 'AB', '0a', '0A']) {
-        const res = await client.query(`select 1 where $1 > $2`, [pair[0], pair[1]]);
+        const res = await client.query(`select 1 where $1 >= $2`, [pair[0], pair[1]]);
         if (res.rows.length > 0) {
           const res = await client.query(`
             SELECT datcollate AS collation
@@ -433,7 +433,7 @@ class Database {
           throw new Error([
             'Postgres database must have default collation en_US.utf8 (and in particular sort',
             '`0` < `a` < `A` < `b` < `B`, for proper slugid ordering);',
-            `this database is using ${collation}, and sorts '${pair[0]}' > '${pair[1]}'.`,
+            `this database is using ${collation}, and sorts '${pair[0]}' >= '${pair[1]}'.`,
           ].join(' '));
         }
       }


### PR DESCRIPTION
This reverts commit 0404810a36f2a3dddd0d56780a229415e589a77f (PR 3599).

See https://github.com/taskcluster/taskcluster/issues/3598#issuecomment-701315161 for context.