### PR TITLE
Don't enforce but log application/json content type requirement

### DIFF
--- a/changelog/ATCfXe_aSC2qOvX--uDKjw.md
+++ b/changelog/ATCfXe_aSC2qOvX--uDKjw.md
@@ -1,0 +1,4 @@
+audience: deployers
+level: minor
+---
+Taskcluster services no longer require Content-Type to be application/json for incoming requests, but will log cases when content type is not application/json. Previously taskcluster-proxy implicitly set the header, so this allows deployers to capture illegal usage, and fix it, before a future time when this will be enforced again.

--- a/libraries/api/src/middleware/schema.js
+++ b/libraries/api/src/middleware/schema.js
@@ -46,7 +46,7 @@ const validateSchemas = ({ validator, absoluteSchemas, rootUrl, serviceName, ent
     if (input) {
       if (!typeis(req, 'application/json')) {
         debug(
-          'Payload must have content-type application/json not ' + req.headers['content-type'] || 'none'
+          'Payload must have content-type application/json not ' + req.headers['content-type'] || 'none',
         );
       }
       const error = validator(req.body, input);

--- a/libraries/api/src/middleware/schema.js
+++ b/libraries/api/src/middleware/schema.js
@@ -45,12 +45,9 @@ const validateSchemas = ({ validator, absoluteSchemas, rootUrl, serviceName, ent
     // If input schema is defined we need to validate the input
     if (input) {
       if (!typeis(req, 'application/json')) {
-        return res.reportError(
-          'MalformedPayload',
-          'Payload must be JSON with content-type: application/json ' +
-          'got content-type: {{contentType}}', {
-            contentType: req.headers['content-type'] || null,
-          });
+        debug(
+          'Payload must have content-type application/json not ' + req.headers['content-type'] || 'none'
+        );
       }
       const error = validator(req.body, input);
       if (error) {


### PR DESCRIPTION
In order to capture when Content-Type header is not set on incoming requests, but allow it at the same time, this changes the error response to an internal logging call, in order that we can determine which API calls currently do not explicitly set the Content-Type header correctly, that previously succeeded by using the taskcluster-proxy that set it implicitly.

After we've determined all the sources and fixed them, we can enforce the application/json content-type again.

CC @djmitche  @jwhitlock @imbstack