### PR TITLE
enable the renovate dependencyDashboard

### DIFF
--- a/package.json
+++ b/package.json
@@ -208,6 +208,7 @@
       "config:base",
       "schedule:daily"
     ],
+    "dependencyDashboard": true,
     "rebaseConflictedPrs": false,
     "prHourlyLimit": 0,
     "prConcurrentLimit": 9,


### PR DESCRIPTION
See https://docs.renovatebot.com/configuration-options/#dependencydashboard

Per advice in https://github.com/renovatebot/config-help/issues/912.