### PR TITLE
Issue 3659 - Notification Task Group URL correction

### DIFF
--- a/changelog/issue-3659.md
+++ b/changelog/issue-3659.md
@@ -2,4 +2,4 @@ audience: general
 level: patch
 reference: issue 3659
 ---
-Fixed the Task Group URL being incorrect on Slack and Email notifications.
+Slack and Email notifications' Task Group URLs are now correct (containing `/tasks`).

--- a/changelog/issue-3659.md
+++ b/changelog/issue-3659.md
@@ -1,0 +1,5 @@
+audience: general
+level: patch
+reference: issue 3659
+---
+Fixed the Task Group URL being incorrect on Slack and Email notifications.

--- a/services/notify/src/handler.js
+++ b/services/notify/src/handler.js
@@ -71,7 +71,7 @@ class Handler {
     let taskId = status.taskId;
     let task = await this.queue.task(taskId);
     let href = libUrls.ui(this.rootUrl, `tasks/${taskId}`);
-    let groupHref = libUrls.ui(this.rootUrl, `groups/${taskId}/tasks`);
+    let groupHref = libUrls.ui(this.rootUrl, `tasks/groups/${taskId}/tasks`);
     let runCount = status.runs.length;
 
     await Promise.allSettled(message.routes.map(async entry => {


### PR DESCRIPTION
Github Bug/Issue: Fixes #3659 

I suspect this is a hangover from the old taskcluster.net URLs but this should correct links to the task group in Email & Slack notifications. (I'm just ashamed I didn't notice the link was broken during testing.)

Should I add a test for this? I could technically scrape the Slack or Email outputs from the tests to see if the URL appears.