### PR TITLE
Issue 3639 - Make sure taskDefined messages are marked unscheduled

### DIFF
--- a/changelog/issue-3639.md
+++ b/changelog/issue-3639.md
@@ -1,0 +1,5 @@
+audience: general
+level: patch
+reference: issue 3639
+---
+`taskDefined` messages will now always have an unscheduled status.

--- a/services/queue/src/api.js
+++ b/services/queue/src/api.js
@@ -535,6 +535,12 @@ builder.declare({
   );
 
   let task = Task.fromApi(taskId, taskDef);
+
+  // Fetch the status of the task before creation, so that `taskDefined` messages
+  // have a default status. This can't be run after create, since create is
+  // idempotent and does a DB fetch.
+  let initialStatus = task.status();
+
   try {
     await task.create(this.db);
   } catch (err) {
@@ -570,20 +576,19 @@ builder.declare({
     tags: task.tags,
   };
 
-  // If first run isn't unscheduled or pending, all message must have been
-  // published before, this can happen if we came from the catch-branch
-  // (it's unlikely to happen). But no need to publish messages again
-  let runZeroState = (task.runs[0] || { state: 'unscheduled' }).state;
-  if (runZeroState !== 'unscheduled' && runZeroState !== 'pending') {
-    return res.reply({ status });
+  // If the first run status is not unscheduled, then we are not the first
+  // call to create this task (due to idempotency). That call will have sent
+  // the `taskDefined` message. (This can happen when two identical calls are
+  // made to createTask in quick succession, but it is very unlikely.)
+  if (initialStatus.state === 'unscheduled') {
+    // Publish task-defined message, we want this arriving before the
+    // task-pending message, so we have to await publication here
+    await this.publisher.taskDefined({ status: initialStatus, task: taskPulseContents }, task.routes);
+    this.monitor.log.taskDefined({ taskId });
   }
 
-  // Publish task-defined message, we want this arriving before the
-  // task-pending message, so we have to await publication here
-  await this.publisher.taskDefined({ status, task: taskPulseContents }, task.routes);
-  this.monitor.log.taskDefined({ taskId });
-
-  // If first run is pending we publish messages about this
+  // Same as above but for tasks with no dependencies, scheduling the first run.
+  let runZeroState = (task.runs[0] || { state: 'unscheduled' }).state;
   if (runZeroState === 'pending') {
     await Promise.all([
       // Put message into the task pending queue

--- a/services/queue/test/createtask_test.js
+++ b/services/queue/test/createtask_test.js
@@ -84,7 +84,7 @@ helper.secrets.mockSuite(testing.suiteName(), ['aws'], function(mock, skipping) 
 
     debug('### Wait for defined message');
     helper.assertPulseMessage('task-defined', m => (
-      _.isEqual(m.payload.status, r1.status) &&
+      _.isEqual(m.payload.status.state, 'unscheduled') &&
       _.isEqual(m.payload.task.tags, taskDef.tags)));
 
     debug('### Wait for pending message');
@@ -269,7 +269,7 @@ helper.secrets.mockSuite(testing.suiteName(), ['aws'], function(mock, skipping) 
 
     debug('### Creating task');
     const r1 = await helper.queue.createTask(taskId, taskDef);
-    helper.assertPulseMessage('task-defined', m => _.isEqual(m.payload.status, r1.status));
+    helper.assertPulseMessage('task-defined', m => _.isEqual(m.payload.status.state, 'unscheduled'));
     helper.assertPulseMessage('task-pending', m => _.isEqual(m.payload.status, r1.status));
 
     const r2 = helper.checkDates(await helper.queue.status(taskId));
@@ -287,7 +287,7 @@ helper.secrets.mockSuite(testing.suiteName(), ['aws'], function(mock, skipping) 
 
     debug('### Creating task');
     const r1 = await helper.queue.createTask(taskId, taskDef);
-    helper.assertPulseMessage('task-defined', m => _.isEqual(m.payload.status, r1.status));
+    helper.assertPulseMessage('task-defined', m => _.isEqual(m.payload.status.state, 'unscheduled'));
     helper.assertPulseMessage('task-pending', m => _.isEqual(m.payload.status, r1.status));
 
     const r2 = helper.checkDates(await helper.queue.status(taskId));


### PR DESCRIPTION
This change prefetches an initial empty status which is used in taskDefined messages. This means that taskDefined messages always has a state of 'unscheduled'.

Github Bug/Issue: Fixes #3639

This ended up being slightly more wiry than I hoped because 