### PR TITLE
Issue 3640 - More notify states

### DIFF
--- a/changelog/issue-3640.md
+++ b/changelog/issue-3640.md
@@ -5,5 +5,5 @@ reference: issue 3640
 Notify routes can now include `on-defined`, `on-pending` and `on-running`.
 
 `on-any` is now deprecated and there are two new alternatives:
-- `on-transition` for any state transition
-- `on-resolved` for terminal state (completed, failed and exception).
+- `on-transition` for any state transition.
+- `on-resolved` for terminal states (completed, failed and exception).

--- a/changelog/issue-3640.md
+++ b/changelog/issue-3640.md
@@ -1,0 +1,9 @@
+audience: general
+level: minor
+reference: issue 3640
+---
+Notify routes can now include `on-defined`, `on-pending` and `on-running`.
+
+`on-any` is now deprecated and there are two new alternatives:
+- `on-transition` for any state transition
+- `on-resolved` for terminal state (completed, failed and exception).

--- a/services/notify/src/handler.js
+++ b/services/notify/src/handler.js
@@ -26,12 +26,24 @@ class Handler {
 
     this.pulseClient = pulseClient;
     this.bindings = [
+      queueEvents.taskDefined(`route.${routePrefix}.#.on-defined.#`),
+      queueEvents.taskDefined(`route.${routePrefix}.#.on-transition.#`),
+      queueEvents.taskPending(`route.${routePrefix}.#.on-pending.#`),
+      queueEvents.taskPending(`route.${routePrefix}.#.on-transition.#`),
+      queueEvents.taskRunning(`route.${routePrefix}.#.on-running.#`),
+      queueEvents.taskRunning(`route.${routePrefix}.#.on-transition.#`),
       queueEvents.taskCompleted(`route.${routePrefix}.#.on-completed.#`),
-      queueEvents.taskCompleted(`route.${routePrefix}.#.on-any.#`),
+      queueEvents.taskCompleted(`route.${routePrefix}.#.on-any.#`), // deprecated
+      queueEvents.taskCompleted(`route.${routePrefix}.#.on-resolved.#`),
+      queueEvents.taskCompleted(`route.${routePrefix}.#.on-transition.#`),
       queueEvents.taskFailed(`route.${routePrefix}.#.on-failed.#`),
-      queueEvents.taskFailed(`route.${routePrefix}.#.on-any.#`),
+      queueEvents.taskFailed(`route.${routePrefix}.#.on-any.#`), // deprecated
+      queueEvents.taskFailed(`route.${routePrefix}.#.on-resolved.#`),
+      queueEvents.taskFailed(`route.${routePrefix}.#.on-transition.#`),
       queueEvents.taskException(`route.${routePrefix}.#.on-exception.#`),
-      queueEvents.taskException(`route.${routePrefix}.#.on-any.#`),
+      queueEvents.taskException(`route.${routePrefix}.#.on-any.#`), // deprecated
+      queueEvents.taskException(`route.${routePrefix}.#.on-resolved.#`),
+      queueEvents.taskException(`route.${routePrefix}.#.on-transition.#`),
     ];
   }
 
@@ -57,6 +69,18 @@ class Handler {
     }
   }
 
+  shouldNotifyOnDecider(decider, state) {
+    if (decider === 'transition') {
+      return true;
+    }
+
+    if ((decider === 'any' || decider === 'resolved') && ['completed', 'failed', 'exception'].includes(state)) {
+      return true;
+    }
+
+    return decider === state;
+  }
+
   async onMessage(message) {
     let { status } = message.payload;
 
@@ -79,7 +103,7 @@ class Handler {
 
       // convert from on- syntax to state. e.g. on-exception -> exception
       let decider = _.join(_.slice(route[route.length - 1], 3), '');
-      if (decider !== 'any' && status.state !== decider) {
+      if (!this.shouldNotifyOnDecider(decider, status.state)) {
         return;
       }
 

--- a/services/notify/test/handler_test.js
+++ b/services/notify/test/handler_test.js
@@ -80,7 +80,7 @@ helper.secrets.mockSuite(testing.suiteName(), ['aws'], function(mock, skipping) 
 
   ['canceled', 'deadline-exceeded'].forEach(reasonResolved => {
     test(`does not publish for ${reasonResolved}`, async () => {
-      const route = 'test-notify.pulse.notify-test.on-any';
+      const route = 'test-notify.pulse.notify-test.on-transition';
       helper.queue.addTask(baseStatus.taskId, makeTask([route]));
       const status = _.cloneDeep(baseStatus);
       status.state = 'exception';
@@ -101,13 +101,13 @@ helper.secrets.mockSuite(testing.suiteName(), ['aws'], function(mock, skipping) 
   });
 
   test('pulse', async () => {
-    const route = 'test-notify.pulse.notify-test.on-any';
+    const route = 'test-notify.pulse.notify-test.on-transition';
     helper.queue.addTask(baseStatus.taskId, makeTask([route]));
     await helper.fakePulseMessage({
       payload: {
         status: baseStatus,
       },
-      exchange: 'exchange/taskcluster-queue/v1/task-completed',
+      exchange: 'exchange/taskcluster-queue/v1/task-defined',
       routingKey: 'doesnt-matter',
       routes: [route],
     });
@@ -115,7 +115,7 @@ helper.secrets.mockSuite(testing.suiteName(), ['aws'], function(mock, skipping) 
   });
 
   test('pulse denylisted', async () => {
-    const route = 'test-notify.pulse.notify-test-denied.on-any';
+    const route = 'test-notify.pulse.notify-test-denied.on-transition';
     helper.queue.addTask(baseStatus.taskId, makeTask([route]));
     await helper.fakePulseMessage({
       payload: {
@@ -129,13 +129,13 @@ helper.secrets.mockSuite(testing.suiteName(), ['aws'], function(mock, skipping) 
   });
 
   test('email', async () => {
-    const route = 'test-notify.email.success@simulator.amazonses.com.on-any';
+    const route = 'test-notify.email.success@simulator.amazonses.com.on-transition';
     helper.queue.addTask(baseStatus.taskId, makeTask([route]));
     await helper.fakePulseMessage({
       payload: {
         status: baseStatus,
       },
-      exchange: 'exchange/taskcluster-queue/v1/task-completed',
+      exchange: 'exchange/taskcluster-queue/v1/task-failed',
       routingKey: 'doesnt-matter',
       routes: [route],
     });
@@ -145,7 +145,7 @@ helper.secrets.mockSuite(testing.suiteName(), ['aws'], function(mock, skipping) 
   });
 
   test('irc', async () => {
-    const route = 'test-notify.irc-channel.#taskcluster-test.on-any';
+    const route = 'test-notify.irc-channel.#taskcluster-test.on-transition';
     const task = makeTask([route]);
     task.extra = { notify: { ircChannelMessage: 'it worked with taskid ${status.taskId}' } };
     helper.queue.addTask(baseStatus.taskId, task);
@@ -165,7 +165,7 @@ helper.secrets.mockSuite(testing.suiteName(), ['aws'], function(mock, skipping) 
   });
 
   test('matrix', async () => {
-    const route = 'test-notify.matrix-room.!gBxblkbeeBSadzOniu:mozilla.org.on-any';
+    const route = 'test-notify.matrix-room.!gBxblkbeeBSadzOniu:mozilla.org.on-transition';
     const task = makeTask([route]);
     task.extra = { notify: { matrixFormat: 'matrix.foo', matrixBody: '${taskId}', matrixFormattedBody: '<h1>${taskId}</h1>', matrixMsgtype: 'm.text' } };
     helper.queue.addTask(baseStatus.taskId, task);
@@ -173,7 +173,7 @@ helper.secrets.mockSuite(testing.suiteName(), ['aws'], function(mock, skipping) 
       payload: {
         status: baseStatus,
       },
-      exchange: 'exchange/taskcluster-queue/v1/task-completed',
+      exchange: 'exchange/taskcluster-queue/v1/task-running',
       routingKey: 'doesnt-matter',
       routes: [route],
     });
@@ -188,7 +188,7 @@ helper.secrets.mockSuite(testing.suiteName(), ['aws'], function(mock, skipping) 
   });
 
   test('matrix (default notice)', async () => {
-    const route = 'test-notify.matrix-room.!gBxblkbeeBSadzOniu:mozilla.org.on-any';
+    const route = 'test-notify.matrix-room.!gBxblkbeeBSadzOniu:mozilla.org.on-transition';
     const task = makeTask([route]);
     task.extra = { notify: { matrixFormat: 'matrix.foo', matrixBody: '${taskId}', matrixFormattedBody: '<h1>${taskId}</h1>' } };
     helper.queue.addTask(baseStatus.taskId, task);
@@ -196,7 +196,7 @@ helper.secrets.mockSuite(testing.suiteName(), ['aws'], function(mock, skipping) 
       payload: {
         status: baseStatus,
       },
-      exchange: 'exchange/taskcluster-queue/v1/task-completed',
+      exchange: 'exchange/taskcluster-queue/v1/task-exception',
       routingKey: 'doesnt-matter',
       routes: [route],
     });
@@ -211,7 +211,7 @@ helper.secrets.mockSuite(testing.suiteName(), ['aws'], function(mock, skipping) 
   });
 
   test('matrix (rejected)', async () => {
-    const route = 'test-notify.matrix-room.!rejected:mozilla.org.on-any';
+    const route = 'test-notify.matrix-room.!rejected:mozilla.org.on-transition';
     const task = makeTask([route]);
     helper.queue.addTask(baseStatus.taskId, task);
     await helper.fakePulseMessage({
@@ -228,7 +228,7 @@ helper.secrets.mockSuite(testing.suiteName(), ['aws'], function(mock, skipping) 
   });
 
   test('slack', async () => {
-    const route = 'test-notify.slack-channel.C123456.on-any';
+    const route = 'test-notify.slack-channel.C123456.on-transition';
     const task = makeTask([route]);
     task.extra = { notify: { slackText: 'hey hey ${taskId}', slackBlocks: [{}], slackAttachments: [{}, {}] } };
     helper.queue.addTask(baseStatus.taskId, task);


### PR DESCRIPTION
This change adds support for all task lifecycle states to notify. It also creates two new pseudostates: 'on-resolved' to replace 'on-any' and 'on-transition' which covers all states.

'on-any' is now deprecated.

Github Bug/Issue: Fixes #3640