### PR TITLE
run renovate during more hours

### DIFF
--- a/package.json
+++ b/package.json
@@ -212,6 +212,7 @@
     "prHourlyLimit": 0,
     "prConcurrentLimit": 9,
     "rangeStrategy": "update-lockfile",
+    "semanticCommits": "disabled",
     "packageRules": [
       {
         "packageNames": [

--- a/package.json
+++ b/package.json
@@ -205,8 +205,7 @@
   },
   "renovate": {
     "extends": [
-      "config:base",
-      "schedule:daily"
+      "config:base"
     ],
     "dependencyDashboard": true,
     "rebaseConflictedPrs": false,


### PR DESCRIPTION
Per advice from Rhys, this lets renovate run for 8 hours every day.  The [dependency dashboard](https://github.com/taskcluster/taskcluster/issues/3630) shows that we're missing lots of upgrades because they are not scheduled.