### PR TITLE
Restore existing tc-proxy behavior of adding content-type header when it is missing

### DIFF
--- a/changelog/issue-3521.md
+++ b/changelog/issue-3521.md
@@ -2,4 +2,6 @@ audience: users
 level: minor
 reference: issue 3521
 ---
-Taskcluster-proxy now adds a `Content-Type` header to proxied requests lacking one.  While this behavior is not desirable, it matches the behavior of older versions and real tasks depend on it.
+Taskcluster-proxy now adds a `Content-Type` header to proxied requests lacking one.  While this behavior is not desirable, it matches the behavior of older versions and real tasks depend on it.  A future version of Taskcluster will drop this behavior.
+
+When this occurs, the worker will log a message containing the string "Adding missing Content-Type header".  Use this logging to find tasks that fail to include the `Content-Type` header and adjust accordingly.

--- a/changelog/issue-3521.md
+++ b/changelog/issue-3521.md
@@ -1,0 +1,5 @@
+audience: users
+level: minor
+reference: issue 3521
+---
+Taskcluster-proxy now adds a `Content-Type` header to proxied requests lacking one.  While this behavior is not desirable, it matches the behavior of older versions and real tasks depend on it.

--- a/tools/taskcluster-proxy/routes.go
+++ b/tools/taskcluster-proxy/routes.go
@@ -145,7 +145,6 @@ func (routes *Routes) RootHandler(res http.ResponseWriter, req *http.Request) {
 	routes.lock.RLock()
 	defer routes.lock.RUnlock()
 
-	fmt.Printf("root handler %s\n", req.URL)
 	targetPath, err := routes.services.ConvertPath(req.URL)
 
 	// Unkown service which we are trying to hit...
@@ -167,7 +166,6 @@ func (routes *Routes) APIHandler(res http.ResponseWriter, req *http.Request) {
 	defer routes.lock.RUnlock()
 
 	rawPath := req.URL.EscapedPath()
-	fmt.Printf("api handler %s\n", rawPath)
 
 	query := req.URL.RawQuery
 	if query != "" {

--- a/tools/taskcluster-proxy/routes.go
+++ b/tools/taskcluster-proxy/routes.go
@@ -236,6 +236,13 @@ func (routes *Routes) commonHandler(res http.ResponseWriter, req *http.Request, 
 			proxyreq.Header[k] = v
 		}
 
+		// for compatibility, if there is no request Content-Type and the body
+		// has nonzero length, we add a Content-Type header.  See #3521.
+		if _, ok := req.Header["Content-Type"]; !ok && len(body) != 0 {
+			log.Printf("Adding missing Content-Type header (#3521)")
+			proxyreq.Header["Content-Type"] = []string{"application/json"}
+		}
+
 		// Refresh Authorization header with each call...
 		err = routes.Credentials.SignRequest(proxyreq)
 		if err != nil {

--- a/workers/docker-worker/src/lib/features/taskcluster_proxy.js
+++ b/workers/docker-worker/src/lib/features/taskcluster_proxy.js
@@ -70,13 +70,9 @@ class TaskclusterProxy {
     // Terrible hack to get container promise proxy.
     this.container = docker.getContainer(this.container.id);
 
-    // XXX: Temporary work around to get errors from the container.  Replace this
-    // with a more general purpose way of logging things from sidecar containers.
-    let debugLevel = process.env.DEBUG || '';
-    if (debugLevel.includes(this.featureName) || debugLevel === '*') {
-      let stream = await this.container.attach({ stream: true, stdout: true, stderr: true });
-      stream.pipe(process.stdout);
-    }
+    // Stream output from the container to the worker logs.
+    let stream = await this.container.attach({ stream: true, stdout: true, stderr: true });
+    stream.pipe(process.stdout);
 
     await this.container.start({});
 


### PR DESCRIPTION
Github Bug/Issue: Refs #3521.

Once this is done, we can park #3521 until we want to remove this support.