### PR TITLE
(hotfix) fix got invocation in image-build process

### DIFF
--- a/changelog/DOrI5ptoQYG7I2dsMK_ndA.md
+++ b/changelog/DOrI5ptoQYG7I2dsMK_ndA.md
@@ -1,0 +1,3 @@
+audience: developers
+level: silent
+---

--- a/infrastructure/tooling/src/utils/docker.js
+++ b/infrastructure/tooling/src/utils/docker.js
@@ -227,7 +227,7 @@ exports.dockerRegistryCheck = async ({ tag }) => {
   const [repo, imagetag] = tag.split(/:/);
   try {
     // Access the registry API directly to see if this tag already exists, and do not push if so.
-    const res = await got(`https://index.docker.io/v1/repositories/${repo}/tags`, { json: true });
+    const res = await got(`https://index.docker.io/v1/repositories/${repo}/tags`, { responseType: 'json' });
     if (!res.body) {
       throw new Error('invalid response from index.docker.io');
     }


### PR DESCRIPTION
I missed testing this when looking for `got` invocations that changed in the major version upgrade.