### PR TITLE
Handle indexed tasks created during insertTask

### DIFF
--- a/changelog/issue-3463.md
+++ b/changelog/issue-3463.md
@@ -1,0 +1,10 @@
+audience: users
+level: patch
+reference: issue 3463
+---
+This release fixes a bug that may occur when a new task is quickly inserted
+twice into the index service. When the bug is triggered, one of the insert
+calls would fail with a server error. With this fix, the UNIQUE_VIOLATION error
+is caught, and the previously failed insert will update the task if the rank is
+higher.
+This bug was first seen in v37.3.0

--- a/services/index/README.md
+++ b/services/index/README.md
@@ -7,7 +7,7 @@ Development
 
 No special configuration is required for development.
 
-Run `yarn workspace taskcluster-index test` to run the tess.
+Run `yarn workspace taskcluster-index test` to run the tests.
 Some of the tests will be skipped without additional credentials, but it is fine to make a pull request as long as no tests fail.
 
 To run *all* tests, you will need appropriate Taskcluster credentials.


### PR DESCRIPTION
In ``insertTask``, when a task is asynchronously created between loading it and creating it, a ``UNIQUE_VIOLATION`` is raised. Catch the error, load the task, and proceed to check if it needs updating.

I borrowed the error-handling technique from ``ensureNamespace`` later in ``helper.js``. It appears that this and other database error handlers are untested, so I did not add tests.

For the changelog entry, I guessed what the API caller would see when the bug was triggered. Please let me know if you have a better guess or know what the response would be.

Github Bug/Issue: Fixes #3463