### PR TITLE
Issue 3779 - generic-worker: reasonable default for simple and docker engines tasksDir

### DIFF
--- a/changelog/issue-3779.md
+++ b/changelog/issue-3779.md
@@ -1,0 +1,5 @@
+audience: worker-deployers
+level: major
+reference: issue 3779
+---
+Generic-worker simple/docker engine now have a default tasks directory of `tasks`, relative to the working directory. This is a breaking change from previous behaviour.

--- a/workers/generic-worker/simple_docker.go
+++ b/workers/generic-worker/simple_docker.go
@@ -97,9 +97,8 @@ func RenameCrossDevice(oldpath, newpath string) (err error) {
 }
 
 func defaultTasksDir() string {
-	// assume all user home directories are all in same folder, i.e. the parent
-	// folder of the current user's home folder
-	return filepath.Dir(os.Getenv("HOME"))
+	// Issue 3779; default tasks directory is `tasks` relative to working directory
+	return "tasks"
 }
 
 func rebootBetweenTasks() bool {


### PR DESCRIPTION
Github Bug/Issue: Fixes #3779 

Note, in the code it looks as if the directory is created when it does not exist. I wonder if the failure to create the directory in #3779 was due to the user not having write permission for the parent folder?