### PR TITLE
Revert web server anonymous scopes

### DIFF
--- a/changelog/issue-3704.md
+++ b/changelog/issue-3704.md
@@ -1,0 +1,4 @@
+audience: general
+level: silent
+reference: issue 3704
+---

--- a/services/auth/src/static-scopes.json
+++ b/services/auth/src/static-scopes.json
@@ -56,7 +56,6 @@
   {
     "clientId": "static/taskcluster/web-server",
     "scopes": [
-      "assume:anonymous",
       "assume:github-org-admin:*",
       "assume:github-team:*",
       "assume:login-identity:*",

--- a/services/web-server/scopes.yml
+++ b/services/web-server/scopes.yml
@@ -15,4 +15,3 @@
 - auth:reset-access-token:github/*
 - auth:update-client:github/*
 - assume:login-identity:*
-- assume:anonymous

--- a/services/web-server/src/login/User.js
+++ b/services/web-server/src/login/User.js
@@ -37,7 +37,6 @@ module.exports = class User {
     let scopes = this.roles.map(role => 'assume:' + role);
     // the `login-identity:*` role defines what each user gets access to.
     scopes.push(`assume:login-identity:${this.identity}`);
-    scopes.push('assume:anonymous');
 
     return scopes;
   }

--- a/services/web-server/test/login_strategies_github_test.js
+++ b/services/web-server/test/login_strategies_github_test.js
@@ -108,14 +108,5 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       assert(helper.githubFixtures.orgs.octocat.some(org => org.role !== 'admin'));
       assert.deepEqual(user.roles.filter(role => role.startsWith('github-org-')), ['github-org-admin:taskcluster'].sort());
     });
-
-    test('user has anonymous scope', async function () {
-      const userId = String(helper.githubFixtures.users.octocat);
-      const strategy = getStrategy();
-      await makeUser(userId);
-      const user = await strategy.userFromIdentity(`github/${userId}|octocat`);
-
-      assert(user.scopes().includes('assume:anonymous'));
-    });
   });
 });

--- a/services/web-server/test/login_strategies_mozilla_auth0_test.js
+++ b/services/web-server/test/login_strategies_mozilla_auth0_test.js
@@ -177,11 +177,5 @@ suite(testing.suiteName(), () => {
       const user = await strategy.userFromIdentity('mozilla-auth0/oauth2|firefoxaccounts|012345abcdef');
       assert.deepEqual(user.roles, []);
     });
-
-    test('user has anonymous scope', async function () {
-      const user = await strategy.userFromIdentity('mozilla-auth0/ad|Mozilla-LDAP|tcperson');
-
-      assert(user.scopes().includes('assume:anonymous'));
-    });
   });
 });


### PR DESCRIPTION
As described in #3704, the anonymous scopes are implicitly included everywhere, so there's no need to do so explicitly.