### PR TITLE
Slashes not allowed in index paths documentation addition to  api.js and index/README.mdx

### DIFF
--- a/changelog/issue-3721.md
+++ b/changelog/issue-3721.md
@@ -1,0 +1,4 @@
+audience: general
+level: silent
+reference: issue 3721
+---

--- a/clients/client-go/tcindex/tcindex.go
+++ b/clients/client-go/tcindex/tcindex.go
@@ -13,6 +13,8 @@
 // As described in the service documentation, tasks are typically indexed via Pulse
 // messages, so the most common use of API methods is to read from the index.
 //
+// Slashes (`/`) aren't allowed in index paths.
+//
 // See:
 //
 // How to use this package

--- a/clients/client-py/taskcluster/generated/aio/index.py
+++ b/clients/client-py/taskcluster/generated/aio/index.py
@@ -18,6 +18,8 @@ class Index(AsyncBaseClient):
 
     As described in the service documentation, tasks are typically indexed via Pulse
     messages, so the most common use of API methods is to read from the index.
+
+    Slashes (`/`) aren't allowed in index paths.
     """
 
     classOptions = {

--- a/clients/client-py/taskcluster/generated/index.py
+++ b/clients/client-py/taskcluster/generated/index.py
@@ -18,6 +18,8 @@ class Index(BaseClient):
 
     As described in the service documentation, tasks are typically indexed via Pulse
     messages, so the most common use of API methods is to read from the index.
+
+    Slashes (`/`) aren't allowed in index paths.
     """
 
     classOptions = {

--- a/clients/client-shell/apis/services.go
+++ b/clients/client-shell/apis/services.go
@@ -714,7 +714,7 @@ var services = map[string]definitions.Service{
 		APIVersion:  "v1",
 		ServiceName: "index",
 		Title:       "Task Index API Documentation",
-		Description: "The index service is responsible for indexing tasks. The service ensures that\ntasks can be located by user-defined names.\n\nAs described in the service documentation, tasks are typically indexed via Pulse\nmessages, so the most common use of API methods is to read from the index.",
+		Description: "The index service is responsible for indexing tasks. The service ensures that\ntasks can be located by user-defined names.\n\nAs described in the service documentation, tasks are typically indexed via Pulse\nmessages, so the most common use of API methods is to read from the index.\n\nSlashes (`/`) aren't allowed in index paths.",
 		Entries: []definitions.Entry{
 			definitions.Entry{
 				Name:        "ping",

--- a/clients/client/src/apis.js
+++ b/clients/client/src/apis.js
@@ -1300,7 +1300,7 @@ module.exports = {
     "reference": {
       "$schema": "/schemas/common/api-reference-v0.json#",
       "apiVersion": "v1",
-      "description": "The index service is responsible for indexing tasks. The service ensures that\ntasks can be located by user-defined names.\n\nAs described in the service documentation, tasks are typically indexed via Pulse\nmessages, so the most common use of API methods is to read from the index.",
+      "description": "The index service is responsible for indexing tasks. The service ensures that\ntasks can be located by user-defined names.\n\nAs described in the service documentation, tasks are typically indexed via Pulse\nmessages, so the most common use of API methods is to read from the index.\n\nSlashes (`/`) aren't allowed in index paths.",
       "entries": [
         {
           "args": [

--- a/generated/references.json
+++ b/generated/references.json
@@ -15531,7 +15531,7 @@
     "content": {
       "$schema": "/schemas/common/api-reference-v0.json#",
       "apiVersion": "v1",
-      "description": "The index service is responsible for indexing tasks. The service ensures that\ntasks can be located by user-defined names.\n\nAs described in the service documentation, tasks are typically indexed via Pulse\nmessages, so the most common use of API methods is to read from the index.",
+      "description": "The index service is responsible for indexing tasks. The service ensures that\ntasks can be located by user-defined names.\n\nAs described in the service documentation, tasks are typically indexed via Pulse\nmessages, so the most common use of API methods is to read from the index.\n\nSlashes (`/`) aren't allowed in index paths.",
       "entries": [
         {
           "args": [

--- a/services/index/src/api.js
+++ b/services/index/src/api.js
@@ -17,6 +17,8 @@ let builder = new APIBuilder({
     '',
     'As described in the service documentation, tasks are typically indexed via Pulse',
     'messages, so the most common use of API methods is to read from the index.',
+    '',
+    'Slashes (`/`) aren\'t allowed in index paths.',
   ].join('\n'),
   projectName: 'taskcluster-index',
   serviceName: 'index',

--- a/ui/docs/reference/core/index/README.mdx
+++ b/ui/docs/reference/core/index/README.mdx
@@ -48,6 +48,7 @@ Observe that this is URL-safe and that if you strictly want to put another chara
 Tasks can be indexed using the `insertTask` API method, but the most common way to index tasks is adding a custom route to `task.routes` of the form `index.<namespace>`.
 This will result in a Pulse message with routing-key `route.index.<namespace>`.
 In order to add this route to a task you'll need the scope `queue:route:index.<namespace>`.
+Note that slashes (`/`) aren’t allowed in index paths.
 When a task has this route, it will be indexed when the task is **completed successfully**.
 The task will be indexed with `rank`, `data` and `expires` as specified in `task.extra.index`.
 For example:


### PR DESCRIPTION
Github Bug/Issue: Fixes #3721 
I have not done yarn generate. ( there is some problem with OS: ubuntu installation. I am trying to set up the environment from the past 3 days; hoping it to resolve soon)
