### PR TITLE
Set up PulseEngine before setting onConnected hook

### DIFF
--- a/changelog/W3n9_fEuQ5e1rxWHfTqxyg.md
+++ b/changelog/W3n9_fEuQ5e1rxWHfTqxyg.md
@@ -1,0 +1,3 @@
+audience: general
+level: silent
+---

--- a/services/web-server/src/PulseEngine/index.js
+++ b/services/web-server/src/PulseEngine/index.js
@@ -28,11 +28,12 @@ module.exports = class PulseEngine {
       return;
     }
 
-    this.reset();
-    this.client.onConnected(conn => this.connected(conn));
-
     const sync = pSynchronize();
     this.innerReconcileSubscriptions = sync(() => this._innerReconcileSubscriptions());
+
+    this.reset();
+    // note that this may callback right away, so do it last-thing in the constructor.
+    this.client.onConnected(conn => this.connected(conn));
   }
 
   reset() {


### PR DESCRIPTION
This fixes an (apparently harmless?) error that appears in the UI when
viewing the TaskGroup page, as noted in #3831.

