### PR TITLE
Allow --no-issue in yarn changelog

### DIFF
--- a/changelog/KP27G54ETjCRPvXdlgfnAQ.md
+++ b/changelog/KP27G54ETjCRPvXdlgfnAQ.md
@@ -1,0 +1,4 @@
+audience: developers
+level: silent
+---
+`yarn changelog` can now take `--no-issue`, meaning the same as `--no-bug`.

--- a/infrastructure/tooling/src/changelog/index.js
+++ b/infrastructure/tooling/src/changelog/index.js
@@ -282,7 +282,7 @@ const add = async (options) => {
   } else if (options.bug) {
     name = `bug-${options.bug}`;
     reference = `reference: bug ${options.bug}\n`;
-  } else if (options.bug === false) {
+  } else if (options.bug === false || options.issue === false) {
     name = taskcluster.slugid();
     reference = '';
   } else {
@@ -292,7 +292,7 @@ const add = async (options) => {
       reference = `reference: ${m[1]} ${m[2]}\n`;
       name = `${m[1]}-${m[2]}`;
     } else {
-      console.log('Must specify one of --issue, --bug, or --no-bug');
+      console.log('Must specify one of --issue, --bug, --no-issue, or --no-bug');
       bad = true;
     }
   }

--- a/infrastructure/tooling/src/main.js
+++ b/infrastructure/tooling/src/main.js
@@ -102,7 +102,8 @@ program.command('changelog')
   .option('--general', 'Add a changelog entry that does not fit into other categories')
   .option('--issue <issue>', 'Reference this issue # in the added changelog')
   .option('--bug <bug>', 'Reference this Bugzilla bug in the added changelog')
-  .option('--no-bug', 'This change does not reference a bug or an issue')
+  .option('--no-bug', 'This change does not reference a bug')
+  .option('--no-issue', 'This change does not reference an issue')
   .action((...options) => {
     if (options.length !== 1) {
       console.error('unexpected command-line arguments');


### PR DESCRIPTION
..since I keep typing this, now that we're tracking things on GitHub and not Bugzilla.