### PR TITLE
Update d-w and scope resolution

### DIFF
--- a/changelog/issue-3843.md
+++ b/changelog/issue-3843.md
@@ -1,0 +1,10 @@
+audience: general
+level: patch
+reference: issue 3843
+---
+Two bugs were fixed that together made it so that tasks could not use indexed images.
+
+First is that docker-worker now correctly uses the task's credentials rather than
+its own to query the index.
+Second is that scopes are now expanded prior to limiting them with `authorizedScopes`
+in addition to afterward.

--- a/services/auth/test/signaturevalidator_test.js
+++ b/services/auth/test/signaturevalidator_test.js
@@ -1,6 +1,6 @@
 const hawk = require('hawk');
 const _ = require('lodash');
-const assume = require('assume');
+const assert = require('assert');
 const slugid = require('slugid');
 const crypto = require('crypto');
 const taskcluster = require('taskcluster-client');
@@ -113,12 +113,12 @@ suite(testing.suiteName(), function() {
       }
 
       let got = await validator(input);
-      assume(got).to.deeply.equal(expected);
+      assert.deepStrictEqual(expected, got);
 
       // *any* successful request should be returning `anonscope`, no matter
       // what, so check that
       if (got.status !== 'auth-failed') {
-        assume(utils.satisfiesExpression(got.scopes, 'anonscope')).is.ok();
+        assert(utils.satisfiesExpression(got.scopes, 'anonscope'));
       }
     });
   };
@@ -447,7 +447,7 @@ suite(testing.suiteName(), function() {
     'Supplied credentials do not satisfy authorizedScopes; credentials have scopes:',
     '',
     '```',
-    clients.unpriv.scopes.join('\n'),
+    ['anonscope', 'assume:anonymous', ...clients.unpriv.scopes].join('\n'),
     '```',
     '',
     'authorizedScopes are:',

--- a/workers/docker-worker/src/lib/docker/indexed_image.js
+++ b/workers/docker-worker/src/lib/docker/indexed_image.js
@@ -49,7 +49,7 @@ module.exports = class IndexedImage extends ArtifactImage {
 
     const index = new taskcluster.Index({
       rootUrl: this.runtime.rootUrl,
-      credentials: this.runtime.taskcluster,
+      credentials: this.task.claim.credentials,
       authorizedScopes: this.taskScopes,
     });
 

--- a/workers/docker-worker/test/image_manager_test.js
+++ b/workers/docker-worker/test/image_manager_test.js
@@ -72,6 +72,9 @@ helper.secrets.mockSuite(suiteName(), ['docker'], function(mock, skipping) {
         credentials: undefined,
         scopes: [],
       }),
+      claim: {
+        credentials: undefined,
+      },
     };
 
     let im = new ImageManager(runtime);
@@ -115,6 +118,9 @@ helper.secrets.mockSuite(suiteName(), ['docker'], function(mock, skipping) {
         credentials: undefined,
         scopes: [],
       }),
+      claim: {
+        credentials: undefined,
+      },
     };
 
     let im = new ImageManager(runtime);
@@ -156,6 +162,9 @@ helper.secrets.mockSuite(suiteName(), ['docker'], function(mock, skipping) {
         credentials: undefined,
         scopes: [],
       }),
+      claim: {
+        credentials: undefined,
+      },
     };
 
     let im = new ImageManager(runtime);
@@ -200,6 +209,9 @@ helper.secrets.mockSuite(suiteName(), ['docker'], function(mock, skipping) {
         credentials: undefined,
         scopes: [],
       }),
+      claim: {
+        credentials: undefined,
+      },
     };
 
     let im = new ImageManager(runtime);
@@ -231,6 +243,9 @@ helper.secrets.mockSuite(suiteName(), ['docker'], function(mock, skipping) {
         credentials: undefined,
         scopes: [],
       }),
+      claim: {
+        credentials: undefined,
+      },
     };
 
     let im = new ImageManager(runtime);
@@ -268,6 +283,9 @@ helper.secrets.mockSuite(suiteName(), ['docker'], function(mock, skipping) {
         credentials: undefined,
         scopes: [],
       }),
+      claim: {
+        credentials: undefined,
+      },
     };
 
     let im = new ImageManager(runtime);
@@ -304,6 +322,9 @@ helper.secrets.mockSuite(suiteName(), ['docker'], function(mock, skipping) {
         credentials: undefined,
         scopes: [],
       }),
+      claim: {
+        credentials: undefined,
+      },
     };
 
     let im = new ImageManager(runtime);
@@ -359,6 +380,9 @@ helper.secrets.mockSuite(suiteName(), ['docker'], function(mock, skipping) {
 
       let task = {
         queue: new taskcluster.Queue(helper.optionsFromCiCreds()),
+        claim: {
+          credentials: undefined,
+        },
       };
 
       let im = new ImageManager(runtime);


### PR DESCRIPTION
Basic summary:

1.  d-w was using its own creds instead of the task's creds to talk to index service for indexed images. That wasn't a problem before rfc 165 since it was public before.
2. We need to expand scopes _before_ we limit them with `authorizedScopes` because a client that is granted a scope that is in `authorizedScopes` by virtue of it being in `assume:anonymous` must have it at that time. Not doing this results in the error seen in the linked bug. I believe to keep the behavior we've decided for rfc 165 we actually have to apply `assume:anonymous` and expand scopes _again_ after limiting to `authorizedScopes` because otherwise anything limited in that fashion will not have those scopes. This is a bit of a more confusing situation however, happy to debate/change/etc.

Github Bug/Issue: Fixes #3843
