### PR TITLE
remove lerna.json

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,0 @@
-{
-  "version": "0.0.0",
-  "npmClient": "yarn",
-  "useWorkspaces": true
-}


### PR DESCRIPTION
This seems to be distracting renovate, and now that we've imported everything I think we don't actually use lerna anymore.  Please yell if I'm wrong!