### PR TITLE
Fix Livelog TLS Support

### DIFF
--- a/changelog/issue-3865.md
+++ b/changelog/issue-3865.md
@@ -1,0 +1,5 @@
+audience: users
+level: patch
+reference: issue 3865
+---
+Livelog TLS support is now functional.

--- a/infrastructure/tooling/src/build/tasks/livelog.js
+++ b/infrastructure/tooling/src/build/tasks/livelog.js
@@ -72,7 +72,7 @@ module.exports = ({ tasks, cmdOptions, credentials, baseDir, logsDir }) => {
       // this simple Dockerfile just packages the binary into a Docker image
       const dockerfile = path.join(contextDir, 'Dockerfile');
       fs.writeFileSync(dockerfile, [
-        'FROM scratch',
+        'FROM busybox', // We use busybox rather than scratch to have `/tmp` and such things
         'EXPOSE 60023',
         'EXPOSE 60022',
         'COPY version.json /app/version.json',

--- a/tools/livelog/main.go
+++ b/tools/livelog/main.go
@@ -168,7 +168,11 @@ func main() {
 
 	runServer = func(server *http.Server, addr, crtFile, keyFile string) error {
 		server.Addr = addr
-		return server.ListenAndServe()
+		if crtFile != "" && keyFile != "" {
+			return server.ListenAndServeTLS(crtFile, keyFile)
+		} else {
+			return server.ListenAndServe()
+		}
 	}
 
 	serve(putAddr, getAddr)


### PR DESCRIPTION
- Use busybox for livelog image in order to get /tmp back
- Support TLS in livelog again

This feels like a sorta hacky way to make it work but the whole thing is a hack so whatever.

Github Bug/Issue: Fixes #3865
