### PR TITLE
Rewrite browser-side auth to fetch credentials on-demand

### DIFF
--- a/changelog/issue-3836.md
+++ b/changelog/issue-3836.md
@@ -1,0 +1,5 @@
+audience: users
+level: patch
+reference: issue 3836
+---
+The web UI no longer fails with "ext.certificate.expiry < now".


### PR DESCRIPTION
The previous solution was an attempt to renew credentials on a schedule,
synchronized across tabs.  It had some pretty bad race conditions, one
of which was between page-load and renewal when the existing creds had
expired.

This switches to a simpler model, where credentials are fetched if
necessary (if they're expired) before making a GraphQL query.

Github Bug/Issue: Fixes #3836