### PR TITLE
Add get-task scope to notify service

### DIFF
--- a/changelog/issue-3874.md
+++ b/changelog/issue-3874.md
@@ -1,0 +1,5 @@
+audience: general
+level: patch
+reference: issue 3874
+---
+The notify service now has enough scopes to handle notifications on Taskcluster instances without the anonymous role.

--- a/services/auth/src/static-scopes.json
+++ b/services/auth/src/static-scopes.json
@@ -36,6 +36,7 @@
   {
     "clientId": "static/taskcluster/notify",
     "scopes": [
+      "queue:get-task:*"
     ]
   },
   {

--- a/services/notify/scopes.yml
+++ b/services/notify/scopes.yml
@@ -1,0 +1,1 @@
+- queue:get-task:*


### PR DESCRIPTION
Github Bug/Issue: Fixes #3874

This adds `queue:get-task:*` to the notify service, which lets the handler run without `get-task` being public. I've tested that this is the only required scope by adding just this to anonymous on our testing TC.