### PR TITLE
Fix failure in /provisioners when no sortBy

### DIFF
--- a/changelog/issue-3873.md
+++ b/changelog/issue-3873.md
@@ -1,0 +1,5 @@
+audience: users
+level: patch
+reference: issue 3873
+---
+The `/provisioners/<worker-type>` view now works correctly, fixing the error about reading property `replace` of `null`.

--- a/ui/src/components/WorkerTypesTable/index.jsx
+++ b/ui/src/components/WorkerTypesTable/index.jsx
@@ -73,11 +73,11 @@ export default class WorkerTypesTable extends Component {
 
   createSortedWorkerTypesConnection = memoize(
     (workerTypesConnection, sortBy, sortDirection) => {
-      const sortByProperty = camelCase(sortBy);
-
       if (!sortBy) {
         return workerTypesConnection;
       }
+
+      const sortByProperty = camelCase(sortBy);
 
       return {
         ...workerTypesConnection,


### PR DESCRIPTION
This was caused by the upgrade to change-case, when functions like
`camelCase` stopped returning `''` when givien `undefined`, and started
failing instead.  I spotted most cases where this was an issue but
missed this one.

Github Bug/Issue: Fixes #3873 