### PR TITLE
Fix sorting in ConnectionDataTable

### DIFF
--- a/changelog/issue-3837.md
+++ b/changelog/issue-3837.md
@@ -1,0 +1,4 @@
+audience: general
+level: silent
+reference: issue 3837
+---

--- a/ui/src/components/ConnectionDataTable/index.jsx
+++ b/ui/src/components/ConnectionDataTable/index.jsx
@@ -156,9 +156,11 @@ export default class ConnectionDataTable extends Component {
     };
   }
 
-  handleHeaderClick = ({ target }) => {
-    if (this.props.onHeaderClick) {
-      this.props.onHeaderClick(target.id);
+  handleHeaderClick = header => {
+    const { onHeaderClick } = this.props;
+
+    if (onHeaderClick) {
+      onHeaderClick(header);
     }
   };
 
@@ -254,7 +256,7 @@ export default class ConnectionDataTable extends Component {
                         id={header}
                         active={header === sortByHeader}
                         direction={sortDirection || 'desc'}
-                        onClick={this.handleHeaderClick}>
+                        onClick={() => this.handleHeaderClick(header)}>
                         {header}
                       </TableSortLabel>
                     </TableCell>


### PR DESCRIPTION
This modifies the handleHeaderClick to return the header, just like
DataTable does.  Returning `target.id` didn't work reliably because the
potential event targets do not all have the correct id.

Github Bug/Issue: Fixes #3837.