### PR TITLE
add .lz4 to the list of extensions docker-worker will not try to compress

### DIFF
--- a/changelog/issue-3899.md
+++ b/changelog/issue-3899.md
@@ -1,0 +1,5 @@
+audience: users
+level: patch
+reference: issue 3899
+---
+Docker-worker now skips gzipping artifacts with an `.lz4` extension, in addition to the [existing list of extensions](https://github.com/taskcluster/taskcluster/blob/main/workers/docker-worker/config.yml#L160-L164).

--- a/workers/docker-worker/config.yml
+++ b/workers/docker-worker/config.yml
@@ -160,7 +160,7 @@ defaults:
     skipCompressionExtensions: [
       '.7z', '.bz2', '.dmg', '.flv', '.gif', '.gz', '.jpeg', '.jpg', '.png',
       '.swf', '.tbz', '.tgz', '.webp', '.whl', '.woff', '.woff2',
-      '.xz', '.zip', '.zst',
+      '.xz', '.zip', '.zst', 'lz4',
     ]
 
   dockerSave:


### PR DESCRIPTION

Github Bug/Issue: Refs #3899