### PR TITLE
Issue 3901 - fix forbidden error when using actions with public artifact URL signing

### DIFF
--- a/changelog/issue-3901.md
+++ b/changelog/issue-3901.md
@@ -1,0 +1,5 @@
+audience: general
+level: patch
+reference: issue 3901
+---
+Fixed a bug where signing public S3 artifacts would result in Forbidden errors on the task and task group views.

--- a/services/web-server/src/loaders/tasks.js
+++ b/services/web-server/src/loaders/tasks.js
@@ -54,9 +54,6 @@ module.exports = ({ queue, index }, isAuthed, rootUrl, monitor, strategies, req,
           const raw = await fetch(url, {
             headers: {
               'x-taskcluster-skip-cache': true,
-              // This is required because by default we send Content-Type: application/json,
-              // which a potential S3 URL was not signed for.
-              'Content-Type': '',
             },
           });
 

--- a/services/web-server/src/loaders/tasks.js
+++ b/services/web-server/src/loaders/tasks.js
@@ -54,6 +54,9 @@ module.exports = ({ queue, index }, isAuthed, rootUrl, monitor, strategies, req,
           const raw = await fetch(url, {
             headers: {
               'x-taskcluster-skip-cache': true,
+              // This is required because by default we send Content-Type: application/json,
+              // which a potential S3 URL was not signed for.
+              'Content-Type': '',
             },
           });
 

--- a/services/web-server/src/utils/fetch.js
+++ b/services/web-server/src/utils/fetch.js
@@ -14,6 +14,7 @@ const defaults = {
     'Content-Type': 'application/json',
   },
   method: 'GET',
+  body: null,
 };
 const handleResponse = response =>
   Promise.resolve(response)
@@ -44,11 +45,14 @@ module.exports = (url, opts = {}) => {
   const options = {
     ...defaults,
     ...opts,
-    headers: {
-      ...defaults.headers,
-      ...opts.headers,
-    },
   };
+
+  // Only include the default headers on requests with a body, since
+  // Content-Type only makes sense with a body and otherwise causes
+  // issues with AWS signed URLs.
+  const defaultHeaders = (options.body !== null) ? defaults.headers : {};
+  options.headers = { ...defaultHeaders, ...opts.headers };
+
   const { delayFactor, randomizationFactor, maxDelay, retries } = options;
 
   return new Promise((resolve, reject) => {


### PR DESCRIPTION
Github Bug/Issue: Fixes #3901

This issue was caused by `node-fetch` passing headers to further redirects, including the eventual S3 signed URL. In particular Taskcluster's `fetch()` sets `Content-Type` by default, which is a header which must be included in the signature.