### PR TITLE
Expand scopes in between pulling them from cert and checking authorizedScopes

### DIFF
--- a/changelog/issue-3903.md
+++ b/changelog/issue-3903.md
@@ -1,0 +1,6 @@
+audience: general
+level: patch
+reference: issue 3903
+---
+Scopes are now expanded in between using a certificate's scopes and checking `authorizedScopes`
+as well.


### PR DESCRIPTION
This is pretty much a return to how things
worked before rfc165 here. We now expand no matter what before checking
`authorizedScopes`.

Github Bug/Issue: Fixes #3903
