### PR TITLE
Issue 3908 - make groupHref in the notify handler use task.taskGroupId

### DIFF
--- a/changelog/issue-3908.md
+++ b/changelog/issue-3908.md
@@ -1,0 +1,5 @@
+audience: users
+level: patch
+reference: issue 3908
+---
+E-mail and Slack notifications should now correctly link to the group when the group ID does not match the task ID.

--- a/services/notify/src/handler.js
+++ b/services/notify/src/handler.js
@@ -95,7 +95,7 @@ class Handler {
     let taskId = status.taskId;
     let task = await this.queue.task(taskId);
     let href = libUrls.ui(this.rootUrl, `tasks/${taskId}`);
-    let groupHref = libUrls.ui(this.rootUrl, `tasks/groups/${taskId}/tasks`);
+    let groupHref = libUrls.ui(this.rootUrl, `tasks/groups/${task.taskGroupId}/tasks`);
     let runCount = status.runs.length;
 
     await Promise.allSettled(message.routes.map(async entry => {


### PR DESCRIPTION
Github Bug/Issue: Fixes #3908
