### PR TITLE
docker-worker: Un-gzip images with gzip content-encoding

### DIFF
--- a/changelog/issue-3899.md
+++ b/changelog/issue-3899.md
@@ -1,0 +1,5 @@
+audience: users
+level: patch
+reference: issue 3899
+---
+Docker-worker now decompresses downloaded images when they have a compressed content-encoding, as artifacts produced by docker-worker now have.

--- a/workers/docker-worker/test/fixtures/image_artifacts.js
+++ b/workers/docker-worker/test/fixtures/image_artifacts.js
@@ -4,6 +4,9 @@
 
 const IMAGE_TASK_ID = 'csTL863FQYCK82XEFjMhMw';
 
+// a second task created to add more artifacts..
+const SECOND_TASK_ID = 'W6tr_zwCT1u7XR68BFY5Fw';
+
 module.exports = {
   // the taskcluster instance containing all of these resources
   ROOT_URL: 'https://community-tc.services.mozilla.com',
@@ -21,4 +24,7 @@ module.exports = {
 
   // Zstandard compressed impage
   ZSTD_TASK_ID: IMAGE_TASK_ID,
+
+  // same as the .tar file from TASK_ID, but with Content-Encoding: gzip
+  GZIP_CONTENT_ENCODING_TASK_ID: SECOND_TASK_ID,
 };


### PR DESCRIPTION
Github Bug/Issue: Fixes #3899.
