### PR TITLE
Give tc-gh handler queue client some scopes

### DIFF
--- a/changelog/issue-3867.md
+++ b/changelog/issue-3867.md
@@ -1,0 +1,10 @@
+audience: general
+level: patch
+reference: issue 3867
+---
+Taskcluster-Github should now function correctly in a deployment with no scopes in the `anonymous` role.
+
+If you have a locked-down deployment without allowing public artifacts fetching in your `anonymous` role, you must add
+`queue:get-artifact:public/github/customCheckRunText.md` and `queue:get-artifact:public/github/customCheckRunAnnotations.json`
+to the scopes of your task to avoid an error comment being added to your
+commits. Note that this will change if you choose a custom artifact name (see custom artifact docs for more)

--- a/services/github/test/handler_test.js
+++ b/services/github/test/handler_test.js
@@ -127,6 +127,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       listTaskGroup: async () => ({ tasks: [] }),
       use: () => ({
         getArtifact: async() => CUSTOM_CHECKRUN_TEXT,
+        buildUrl: async() => 'http://example.com',
       }),
       buildUrl: () => 'url',
     };

--- a/ui/docs/reference/integrations/github/checks.mdx
+++ b/ui/docs/reference/integrations/github/checks.mdx
@@ -6,14 +6,21 @@ At the moment, the feature is in beta. If you would like to try it out:
 * Add `reporting: checks-v1` line at the root level of your `.taskcluster.yml`
 * You will need `queue:route:checks` scope for your `repo:github.com/org/repo:<action>` role.
 * If you are using a decision task, make sure you add `route.checks` to the `routes` of your tasks
+* If you have a locked-down deployment without allowing public artifacts fetching in your `anonymous` role, you must add
+  `queue:get-artifact:public/github/customCheckRunText.md` and `queue:get-artifact:public/github/customCheckRunAnnotations.json`
+  to the scopes of your task (`task.scopes`) to avoid an error comment being added to your
+  commits. Note that this will change if you choose a custom artifact name (see below)
 
 ## Custom Text Output in Checks
 
- When a task completes, the Taskcluster-GitHub service can optionally include task-specific information in the check run
- displayed in the GitHub checks tab.  To do so, it looks for an artifact on the task named
- `public/github/customCheckRunText.md` and uses the artifact content as the check run text.
- The artifact name can be customized by setting `task.extra.github.customCheckRun.textArtifactName` in the task definition.
- For example:
+When a task completes, the Taskcluster-GitHub service can optionally include task-specific information in the check run
+displayed in the GitHub checks tab.  To do so, it looks for an artifact on the task named
+`public/github/customCheckRunText.md` and uses the artifact content as the check run text.
+The artifact name can be customized by setting `task.extra.github.customCheckRun.textArtifactName` in the task definition.
+Whichever name you choose must be included in the `task.scopes` (`queue:get-artifact:<textArtifactName>`) as mentioned above if
+it is not included in the `anonymous` role.
+
+For example:
 ```
 payload:
   ...
@@ -42,6 +49,8 @@ task:
 When a task completes, the Taskcluster-GitHub service can optionally include task-specific [annotations](https://developer.github.com/v3/checks/runs/#annotations-object)
 in the check run. To do so, it looks for an artifact on the task named `public/github/customCheckRunAnnotations.json` and uses the artifact content as the check run annotation.
 The artifact name can be customized by setting `task.extra.github.customCheckRun.annotationsArtifactName` in the task definition.
+Whichever name you choose must be included in `task.scopes` (`queue:get-artifact:<annotationsArtifactName>`) as mentioned above if
+it is not included in the `anonymous` role.
 The json in that file will be passed along unchanged to Github and should be in their annotation format defined in the link above.
 
 For example:


### PR DESCRIPTION
I believe this should solve this issue in the most direct way possible.

What we're doing here is giving the queue client in tc-gh's handler creds so that it
can use its own scopes and then limiting it to only a task's scopes when it is
acting on behalf of a task in a way that the task can alter what it does.

This should not break anything in community/firefoxci because those have `anonymous`
roles and so it will work without this fix even.

Github Bug/Issue: Fixes #3867
