### PR TITLE
Only update `googleapis` once a week

### DIFF
--- a/package.json
+++ b/package.json
@@ -216,6 +216,7 @@
     "packageRules": [
       {
         "packagePatterns": [
+          "^googleapis$",
           "^aws-sdk$",
           "^golang.org/x/.*"
         ],


### PR DESCRIPTION
We just updated to v64 and v65 is out already..