### PR TITLE
Add listTaskQueues and getTaskQueue to queue service api

### DIFF
--- a/changelog/issue-3578-1.md
+++ b/changelog/issue-3578-1.md
@@ -1,0 +1,5 @@
+audience: users
+level: patch
+reference: issue 3578
+---
+There are two new API methods for the queue service: `listTaskQueues` and `getTaskQueue`

--- a/clients/client-go/tcqueue/tcqueue.go
+++ b/clients/client-go/tcqueue/tcqueue.go
@@ -1038,6 +1038,71 @@ func (queue *Queue) DeclareWorkerType(provisionerId, workerType string, payload 
 	return responseObject.(*WorkerTypeResponse), err
 }
 
+// Get all active task queues.
+//
+// The response is paged. If this end-point returns a `continuationToken`, you
+// should call the end-point again with the `continuationToken` as a query-string
+// option. By default this end-point will list up to 1000 task queues in a single
+// page. You may limit this with the query-string parameter `limit`.
+//
+// Required scopes:
+//   queue:list-task-queues
+//
+// See #listTaskQueues
+func (queue *Queue) ListTaskQueues(continuationToken, limit string) (*ListTaskQueuesResponse, error) {
+	v := url.Values{}
+	if continuationToken != "" {
+		v.Add("continuationToken", continuationToken)
+	}
+	if limit != "" {
+		v.Add("limit", limit)
+	}
+	cd := tcclient.Client(*queue)
+	responseObject, _, err := (&cd).APICall(nil, "GET", "/task-queues", new(ListTaskQueuesResponse), v)
+	return responseObject.(*ListTaskQueuesResponse), err
+}
+
+// Returns a signed URL for ListTaskQueues, valid for the specified duration.
+//
+// Required scopes:
+//   queue:list-task-queues
+//
+// See ListTaskQueues for more details.
+func (queue *Queue) ListTaskQueues_SignedURL(continuationToken, limit string, duration time.Duration) (*url.URL, error) {
+	v := url.Values{}
+	if continuationToken != "" {
+		v.Add("continuationToken", continuationToken)
+	}
+	if limit != "" {
+		v.Add("limit", limit)
+	}
+	cd := tcclient.Client(*queue)
+	return (&cd).SignedURL("/task-queues", v, duration)
+}
+
+// Get a task queue.
+//
+// Required scopes:
+//   queue:get-task-queue:<taskQueueId>
+//
+// See #getTaskQueue
+func (queue *Queue) GetTaskQueue(taskQueueId string) (*TaskQueueResponse, error) {
+	cd := tcclient.Client(*queue)
+	responseObject, _, err := (&cd).APICall(nil, "GET", "/task-queues/"+url.QueryEscape(taskQueueId), new(TaskQueueResponse), nil)
+	return responseObject.(*TaskQueueResponse), err
+}
+
+// Returns a signed URL for GetTaskQueue, valid for the specified duration.
+//
+// Required scopes:
+//   queue:get-task-queue:<taskQueueId>
+//
+// See GetTaskQueue for more details.
+func (queue *Queue) GetTaskQueue_SignedURL(taskQueueId string, duration time.Duration) (*url.URL, error) {
+	cd := tcclient.Client(*queue)
+	return (&cd).SignedURL("/task-queues/"+url.QueryEscape(taskQueueId), nil, duration)
+}
+
 // Stability: *** EXPERIMENTAL ***
 //
 // Get a list of all active workers of a workerType.

--- a/clients/client-go/tcqueue/types.go
+++ b/clients/client-go/tcqueue/types.go
@@ -1235,14 +1235,14 @@ type (
 		// Description of the task queue.
 		Description string `json:"description"`
 
-		// Date and time after which the worker-type will be automatically
+		// Date and time after which the task queue will be automatically
 		// deleted by the queue.
 		Expires tcclient.Time `json:"expires"`
 
 		// Date and time where the task queue was last seen active
 		LastDateActive tcclient.Time `json:"lastDateActive"`
 
-		// This is the stability of the worker-type. Accepted values:
+		// This is the stability of the task queue. Accepted values:
 		//  * `experimental`
 		//  * `stable`
 		//  * `deprecated`

--- a/clients/client-go/tcqueue/types.go
+++ b/clients/client-go/tcqueue/types.go
@@ -286,6 +286,22 @@ type (
 		Tasks []TaskDefinitionAndStatus `json:"tasks"`
 	}
 
+	// Response from a `listTaskQueues` request.
+	ListTaskQueuesResponse struct {
+
+		// Opaque `continuationToken` to be given as query-string option to get the
+		// next set of task-queues.
+		// This property is only present if another request is necessary to fetch all
+		// results. In practice the next request with a `continuationToken` may not
+		// return additional results, but it can. Thus, you can only be sure to have
+		// all the results if you've called `listTaskQueues` with `continuationToken`
+		// until you get a result without a `continuationToken`.
+		ContinuationToken string `json:"continuationToken,omitempty"`
+
+		// List of all task-queues.
+		TaskQueues []TaskQueue `json:"taskQueues"`
+	}
+
 	// Response from a `listWorkerTypes` request.
 	ListWorkerTypesResponse struct {
 
@@ -1212,6 +1228,67 @@ type (
 		// Syntax:     ^(https?|ssh)://
 		// Max length: 4096
 		Source string `json:"source"`
+	}
+
+	TaskQueue struct {
+
+		// Description of the task queue.
+		Description string `json:"description"`
+
+		// Date and time after which the worker-type will be automatically
+		// deleted by the queue.
+		Expires tcclient.Time `json:"expires"`
+
+		// Date and time where the task queue was last seen active
+		LastDateActive tcclient.Time `json:"lastDateActive"`
+
+		// This is the stability of the worker-type. Accepted values:
+		//  * `experimental`
+		//  * `stable`
+		//  * `deprecated`
+		//
+		// Possible values:
+		//   * "experimental"
+		//   * "stable"
+		//   * "deprecated"
+		Stability string `json:"stability"`
+
+		// Unique identifier for a task-queue
+		//
+		// Syntax:     ^[a-zA-Z0-9-_]{1,38}/[a-z]([-a-z0-9]{0,36}[a-z0-9])?$
+		TaskQueueID string `json:"taskQueueId"`
+	}
+
+	// Response to a task queue request from a provisioner.
+	TaskQueueResponse struct {
+
+		// Description of the task queue.
+		Description string `json:"description"`
+
+		// Date and time after which the task queue will be automatically
+		// deleted by the queue.
+		Expires tcclient.Time `json:"expires"`
+
+		// Date of the last time this task queue was seen active. `lastDateActive` is updated every 6 hours
+		// but may be off by up-to 6 hours. Nonetheless, `lastDateActive` is a good indicator
+		// of when the task queue was last seen active.
+		LastDateActive tcclient.Time `json:"lastDateActive"`
+
+		// This is the stability of the worker-type. Accepted values:
+		//   * `experimental`
+		//   * `stable`
+		//   * `deprecated`
+		//
+		// Possible values:
+		//   * "experimental"
+		//   * "stable"
+		//   * "deprecated"
+		Stability string `json:"stability"`
+
+		// Unique identifier for a task-queue
+		//
+		// Syntax:     ^[a-zA-Z0-9-_]{1,38}/[a-z]([-a-z0-9]{0,36}[a-z0-9])?$
+		TaskQueueID string `json:"taskQueueId"`
 	}
 
 	// Response to a successful task claim

--- a/clients/client-go/tcqueue/types.go
+++ b/clients/client-go/tcqueue/types.go
@@ -1274,7 +1274,7 @@ type (
 		// of when the task queue was last seen active.
 		LastDateActive tcclient.Time `json:"lastDateActive"`
 
-		// This is the stability of the worker-type. Accepted values:
+		// This is the stability of the task queue. Accepted values:
 		//   * `experimental`
 		//   * `stable`
 		//   * `deprecated`
@@ -1285,7 +1285,7 @@ type (
 		//   * "deprecated"
 		Stability string `json:"stability"`
 
-		// Unique identifier for a task-queue
+		// Unique identifier for a task queue
 		//
 		// Syntax:     ^[a-zA-Z0-9-_]{1,38}/[a-z]([-a-z0-9]{0,36}[a-z0-9])?$
 		TaskQueueID string `json:"taskQueueId"`

--- a/clients/client-py/taskcluster/generated/aio/queue.py
+++ b/clients/client-py/taskcluster/generated/aio/queue.py
@@ -659,6 +659,33 @@ class Queue(AsyncBaseClient):
 
         return await self._makeApiCall(self.funcinfo["declareWorkerType"], *args, **kwargs)
 
+    async def listTaskQueues(self, *args, **kwargs):
+        """
+        Get a list of all active worker-types
+
+        Get all active task queues.
+
+        The response is paged. If this end-point returns a `continuationToken`, you
+        should call the end-point again with the `continuationToken` as a query-string
+        option. By default this end-point will list up to 1000 task queues in a single
+        page. You may limit this with the query-string parameter `limit`.
+
+        This method is ``stable``
+        """
+
+        return await self._makeApiCall(self.funcinfo["listTaskQueues"], *args, **kwargs)
+
+    async def getTaskQueue(self, *args, **kwargs):
+        """
+        Get a task queue
+
+        Get a task queue.
+
+        This method is ``stable``
+        """
+
+        return await self._makeApiCall(self.funcinfo["getTaskQueue"], *args, **kwargs)
+
     async def listWorkers(self, *args, **kwargs):
         """
         Get a list of all active workers of a workerType
@@ -809,6 +836,14 @@ class Queue(AsyncBaseClient):
             'route': '/provisioners/<provisionerId>',
             'stability': 'deprecated',
         },
+        "getTaskQueue": {
+            'args': ['taskQueueId'],
+            'method': 'get',
+            'name': 'getTaskQueue',
+            'output': 'v1/taskqueue-response.json#',
+            'route': '/task-queues/<taskQueueId>',
+            'stability': 'stable',
+        },
         "getWorker": {
             'args': ['provisionerId', 'workerType', 'workerGroup', 'workerId'],
             'method': 'get',
@@ -868,6 +903,15 @@ class Queue(AsyncBaseClient):
             'output': 'v1/list-task-group-response.json#',
             'query': ['continuationToken', 'limit'],
             'route': '/task-group/<taskGroupId>/list',
+            'stability': 'stable',
+        },
+        "listTaskQueues": {
+            'args': [],
+            'method': 'get',
+            'name': 'listTaskQueues',
+            'output': 'v1/list-taskqueues-response.json#',
+            'query': ['continuationToken', 'limit'],
+            'route': '/task-queues',
             'stability': 'stable',
         },
         "listWorkerTypes": {

--- a/clients/client-py/taskcluster/generated/aio/queue.py
+++ b/clients/client-py/taskcluster/generated/aio/queue.py
@@ -661,7 +661,7 @@ class Queue(AsyncBaseClient):
 
     async def listTaskQueues(self, *args, **kwargs):
         """
-        Get a list of all active worker-types
+        Get a list of all active task queues
 
         Get all active task queues.
 

--- a/clients/client-py/taskcluster/generated/queue.py
+++ b/clients/client-py/taskcluster/generated/queue.py
@@ -659,6 +659,33 @@ class Queue(BaseClient):
 
         return self._makeApiCall(self.funcinfo["declareWorkerType"], *args, **kwargs)
 
+    def listTaskQueues(self, *args, **kwargs):
+        """
+        Get a list of all active worker-types
+
+        Get all active task queues.
+
+        The response is paged. If this end-point returns a `continuationToken`, you
+        should call the end-point again with the `continuationToken` as a query-string
+        option. By default this end-point will list up to 1000 task queues in a single
+        page. You may limit this with the query-string parameter `limit`.
+
+        This method is ``stable``
+        """
+
+        return self._makeApiCall(self.funcinfo["listTaskQueues"], *args, **kwargs)
+
+    def getTaskQueue(self, *args, **kwargs):
+        """
+        Get a task queue
+
+        Get a task queue.
+
+        This method is ``stable``
+        """
+
+        return self._makeApiCall(self.funcinfo["getTaskQueue"], *args, **kwargs)
+
     def listWorkers(self, *args, **kwargs):
         """
         Get a list of all active workers of a workerType
@@ -809,6 +836,14 @@ class Queue(BaseClient):
             'route': '/provisioners/<provisionerId>',
             'stability': 'deprecated',
         },
+        "getTaskQueue": {
+            'args': ['taskQueueId'],
+            'method': 'get',
+            'name': 'getTaskQueue',
+            'output': 'v1/taskqueue-response.json#',
+            'route': '/task-queues/<taskQueueId>',
+            'stability': 'stable',
+        },
         "getWorker": {
             'args': ['provisionerId', 'workerType', 'workerGroup', 'workerId'],
             'method': 'get',
@@ -868,6 +903,15 @@ class Queue(BaseClient):
             'output': 'v1/list-task-group-response.json#',
             'query': ['continuationToken', 'limit'],
             'route': '/task-group/<taskGroupId>/list',
+            'stability': 'stable',
+        },
+        "listTaskQueues": {
+            'args': [],
+            'method': 'get',
+            'name': 'listTaskQueues',
+            'output': 'v1/list-taskqueues-response.json#',
+            'query': ['continuationToken', 'limit'],
+            'route': '/task-queues',
             'stability': 'stable',
         },
         "listWorkerTypes": {

--- a/clients/client-py/taskcluster/generated/queue.py
+++ b/clients/client-py/taskcluster/generated/queue.py
@@ -661,7 +661,7 @@ class Queue(BaseClient):
 
     def listTaskQueues(self, *args, **kwargs):
         """
-        Get a list of all active worker-types
+        Get a list of all active task queues
 
         Get all active task queues.
 

--- a/clients/client-shell/apis/services.go
+++ b/clients/client-shell/apis/services.go
@@ -1407,7 +1407,7 @@ var services = map[string]definitions.Service{
 			},
 			definitions.Entry{
 				Name:        "listTaskQueues",
-				Title:       "Get a list of all active worker-types",
+				Title:       "Get a list of all active task queues",
 				Description: "Get all active task queues.\n\nThe response is paged. If this end-point returns a `continuationToken`, you\nshould call the end-point again with the `continuationToken` as a query-string\noption. By default this end-point will list up to 1000 task queues in a single\npage. You may limit this with the query-string parameter `limit`.",
 				Stability:   "stable",
 				Method:      "get",

--- a/clients/client-shell/apis/services.go
+++ b/clients/client-shell/apis/services.go
@@ -1406,6 +1406,33 @@ var services = map[string]definitions.Service{
 				Input: "v1/update-workertype-request.json#",
 			},
 			definitions.Entry{
+				Name:        "listTaskQueues",
+				Title:       "Get a list of all active worker-types",
+				Description: "Get all active task queues.\n\nThe response is paged. If this end-point returns a `continuationToken`, you\nshould call the end-point again with the `continuationToken` as a query-string\noption. By default this end-point will list up to 1000 task queues in a single\npage. You may limit this with the query-string parameter `limit`.",
+				Stability:   "stable",
+				Method:      "get",
+				Route:       "/task-queues",
+				Args:        []string{},
+				Query: []string{
+					"continuationToken",
+					"limit",
+				},
+				Input: "",
+			},
+			definitions.Entry{
+				Name:        "getTaskQueue",
+				Title:       "Get a task queue",
+				Description: "Get a task queue.",
+				Stability:   "stable",
+				Method:      "get",
+				Route:       "/task-queues/<taskQueueId>",
+				Args: []string{
+					"taskQueueId",
+				},
+				Query: []string{},
+				Input: "",
+			},
+			definitions.Entry{
 				Name:        "listWorkers",
 				Title:       "Get a list of all active workers of a workerType",
 				Description: "Get a list of all active workers of a workerType.\n\n`listWorkers` allows a response to be filtered by quarantined and non quarantined workers.\nTo filter the query, you should call the end-point with `quarantined` as a query-string option with a\ntrue or false value.\n\nThe response is paged. If this end-point returns a `continuationToken`, you\nshould call the end-point again with the `continuationToken` as a query-string\noption. By default this end-point will list up to 1000 workers in a single\npage. You may limit this with the query-string parameter `limit`.",

--- a/clients/client-web/src/clients/Queue.js
+++ b/clients/client-web/src/clients/Queue.js
@@ -37,6 +37,8 @@ export default class Queue extends Client {
     this.listWorkerTypes.entry = {"args":["provisionerId"],"category":"Worker Metadata","method":"get","name":"listWorkerTypes","output":true,"query":["continuationToken","limit"],"route":"/provisioners/<provisionerId>/worker-types","scopes":"queue:list-worker-types:<provisionerId>","stability":"deprecated","type":"function"}; // eslint-disable-line
     this.getWorkerType.entry = {"args":["provisionerId","workerType"],"category":"Worker Metadata","method":"get","name":"getWorkerType","output":true,"query":[],"route":"/provisioners/<provisionerId>/worker-types/<workerType>","scopes":"queue:get-worker-type:<provisionerId>/<workerType>","stability":"deprecated","type":"function"}; // eslint-disable-line
     this.declareWorkerType.entry = {"args":["provisionerId","workerType"],"category":"Worker Metadata","input":true,"method":"put","name":"declareWorkerType","output":true,"query":[],"route":"/provisioners/<provisionerId>/worker-types/<workerType>","scopes":{"AllOf":[{"each":"queue:declare-worker-type:<provisionerId>/<workerType>#<property>","for":"property","in":"properties"}]},"stability":"deprecated","type":"function"}; // eslint-disable-line
+    this.listTaskQueues.entry = {"args":[],"category":"Worker Metadata","method":"get","name":"listTaskQueues","output":true,"query":["continuationToken","limit"],"route":"/task-queues","scopes":"queue:list-task-queues","stability":"stable","type":"function"}; // eslint-disable-line
+    this.getTaskQueue.entry = {"args":["taskQueueId"],"category":"Worker Metadata","method":"get","name":"getTaskQueue","output":true,"query":[],"route":"/task-queues/<taskQueueId>","scopes":"queue:get-task-queue:<taskQueueId>","stability":"stable","type":"function"}; // eslint-disable-line
     this.listWorkers.entry = {"args":["provisionerId","workerType"],"category":"Worker Metadata","method":"get","name":"listWorkers","output":true,"query":["continuationToken","limit","quarantined"],"route":"/provisioners/<provisionerId>/worker-types/<workerType>/workers","scopes":"queue:list-workers:<provisionerId>/<workerType>","stability":"experimental","type":"function"}; // eslint-disable-line
     this.getWorker.entry = {"args":["provisionerId","workerType","workerGroup","workerId"],"category":"Worker Metadata","method":"get","name":"getWorker","output":true,"query":[],"route":"/provisioners/<provisionerId>/worker-types/<workerType>/workers/<workerGroup>/<workerId>","scopes":"queue:get-worker:<provisionerId>/<workerType>/<workerGroup>/<workerId>","stability":"experimental","type":"function"}; // eslint-disable-line
     this.quarantineWorker.entry = {"args":["provisionerId","workerType","workerGroup","workerId"],"category":"Worker Metadata","input":true,"method":"put","name":"quarantineWorker","output":true,"query":[],"route":"/provisioners/<provisionerId>/worker-types/<workerType>/workers/<workerGroup>/<workerId>","scopes":{"AllOf":["queue:quarantine-worker:<provisionerId>/<workerType>/<workerGroup>/<workerId>"]},"stability":"experimental","type":"function"}; // eslint-disable-line
@@ -533,6 +535,26 @@ export default class Queue extends Client {
     this.validate(this.declareWorkerType.entry, args);
 
     return this.request(this.declareWorkerType.entry, args);
+  }
+  /* eslint-disable max-len */
+  // Get all active task queues.
+  // The response is paged. If this end-point returns a `continuationToken`, you
+  // should call the end-point again with the `continuationToken` as a query-string
+  // option. By default this end-point will list up to 1000 task queues in a single
+  // page. You may limit this with the query-string parameter `limit`.
+  /* eslint-enable max-len */
+  listTaskQueues(...args) {
+    this.validate(this.listTaskQueues.entry, args);
+
+    return this.request(this.listTaskQueues.entry, args);
+  }
+  /* eslint-disable max-len */
+  // Get a task queue.
+  /* eslint-enable max-len */
+  getTaskQueue(...args) {
+    this.validate(this.getTaskQueue.entry, args);
+
+    return this.request(this.getTaskQueue.entry, args);
   }
   /* eslint-disable max-len */
   // Get a list of all active workers of a workerType.

--- a/clients/client/src/apis.js
+++ b/clients/client/src/apis.js
@@ -2416,7 +2416,7 @@ module.exports = {
           "route": "/task-queues",
           "scopes": "queue:list-task-queues",
           "stability": "stable",
-          "title": "Get a list of all active worker-types",
+          "title": "Get a list of all active task queues",
           "type": "function"
         },
         {

--- a/clients/client/src/apis.js
+++ b/clients/client/src/apis.js
@@ -2403,6 +2403,41 @@ module.exports = {
         },
         {
           "args": [
+          ],
+          "category": "Worker Metadata",
+          "description": "Get all active task queues.\n\nThe response is paged. If this end-point returns a `continuationToken`, you\nshould call the end-point again with the `continuationToken` as a query-string\noption. By default this end-point will list up to 1000 task queues in a single\npage. You may limit this with the query-string parameter `limit`.",
+          "method": "get",
+          "name": "listTaskQueues",
+          "output": "v1/list-taskqueues-response.json#",
+          "query": [
+            "continuationToken",
+            "limit"
+          ],
+          "route": "/task-queues",
+          "scopes": "queue:list-task-queues",
+          "stability": "stable",
+          "title": "Get a list of all active worker-types",
+          "type": "function"
+        },
+        {
+          "args": [
+            "taskQueueId"
+          ],
+          "category": "Worker Metadata",
+          "description": "Get a task queue.",
+          "method": "get",
+          "name": "getTaskQueue",
+          "output": "v1/taskqueue-response.json#",
+          "query": [
+          ],
+          "route": "/task-queues/<taskQueueId>",
+          "scopes": "queue:get-task-queue:<taskQueueId>",
+          "stability": "stable",
+          "title": "Get a task queue",
+          "type": "function"
+        },
+        {
+          "args": [
             "provisionerId",
             "workerType"
           ],

--- a/generated/references.json
+++ b/generated/references.json
@@ -1756,7 +1756,7 @@
           "type": "string"
         },
         "stability": {
-          "description": "This is the stability of the worker-type. Accepted values:\n  * `experimental`\n  * `stable`\n  * `deprecated`\n",
+          "description": "This is the stability of the task queue. Accepted values:\n  * `experimental`\n  * `stable`\n  * `deprecated`\n",
           "enum": [
             "experimental",
             "stable",
@@ -1766,7 +1766,7 @@
           "type": "string"
         },
         "taskQueueId": {
-          "description": "Unique identifier for a task-queue\n",
+          "description": "Unique identifier for a task queue\n",
           "pattern": "^[a-zA-Z0-9-_]{1,38}/[a-z]([-a-z0-9]{0,36}[a-z0-9])?$",
           "title": "Task Queue Id",
           "type": "string"

--- a/generated/references.json
+++ b/generated/references.json
@@ -3338,7 +3338,7 @@
                 "type": "string"
               },
               "expires": {
-                "description": "Date and time after which the worker-type will be automatically\ndeleted by the queue.\n",
+                "description": "Date and time after which the task queue will be automatically\ndeleted by the queue.\n",
                 "format": "date-time",
                 "title": "Task queue Expiration",
                 "type": "string"
@@ -3350,7 +3350,7 @@
                 "type": "string"
               },
               "stability": {
-                "description": "This is the stability of the worker-type. Accepted values:\n * `experimental`\n * `stable`\n * `deprecated`\n",
+                "description": "This is the stability of the task queue. Accepted values:\n * `experimental`\n * `stable`\n * `deprecated`\n",
                 "enum": [
                   "experimental",
                   "stable",
@@ -14742,7 +14742,7 @@
           "route": "/task-queues",
           "scopes": "queue:list-task-queues",
           "stability": "stable",
-          "title": "Get a list of all active worker-types",
+          "title": "Get a list of all active task queues",
           "type": "function"
         },
         {

--- a/generated/references.json
+++ b/generated/references.json
@@ -1733,6 +1733,59 @@
   },
   {
     "content": {
+      "$id": "/schemas/queue/v1/taskqueue-response.json#",
+      "$schema": "/schemas/common/metaschema.json#",
+      "additionalProperties": false,
+      "description": "Response to a task queue request from a provisioner.\n",
+      "properties": {
+        "description": {
+          "description": "Description of the task queue.\n",
+          "title": "Description",
+          "type": "string"
+        },
+        "expires": {
+          "description": "Date and time after which the task queue will be automatically\ndeleted by the queue.\n",
+          "format": "date-time",
+          "title": "Task queue Expiration",
+          "type": "string"
+        },
+        "lastDateActive": {
+          "description": "Date of the last time this task queue was seen active. `lastDateActive` is updated every 6 hours\nbut may be off by up-to 6 hours. Nonetheless, `lastDateActive` is a good indicator\nof when the task queue was last seen active.\n",
+          "format": "date-time",
+          "title": "Task queue Last Date Active",
+          "type": "string"
+        },
+        "stability": {
+          "description": "This is the stability of the worker-type. Accepted values:\n  * `experimental`\n  * `stable`\n  * `deprecated`\n",
+          "enum": [
+            "experimental",
+            "stable",
+            "deprecated"
+          ],
+          "title": "Stability",
+          "type": "string"
+        },
+        "taskQueueId": {
+          "description": "Unique identifier for a task-queue\n",
+          "pattern": "^[a-zA-Z0-9-_]{1,38}/[a-z]([-a-z0-9]{0,36}[a-z0-9])?$",
+          "title": "Task Queue Id",
+          "type": "string"
+        }
+      },
+      "required": [
+        "taskQueueId",
+        "description",
+        "stability",
+        "expires",
+        "lastDateActive"
+      ],
+      "title": "Task queue Response",
+      "type": "object"
+    },
+    "filename": "schemas/queue/v1/taskqueue-response.json"
+  },
+  {
+    "content": {
       "$id": "/schemas/queue/v1/task.json#",
       "$schema": "/schemas/common/metaschema.json#",
       "additionalProperties": false,
@@ -3261,6 +3314,80 @@
       "type": "object"
     },
     "filename": "schemas/queue/v1/list-workers-response.json"
+  },
+  {
+    "content": {
+      "$id": "/schemas/queue/v1/list-taskqueues-response.json#",
+      "$schema": "/schemas/common/metaschema.json#",
+      "additionalProperties": false,
+      "description": "Response from a `listTaskQueues` request.\n",
+      "properties": {
+        "continuationToken": {
+          "description": "Opaque `continuationToken` to be given as query-string option to get the\nnext set of task-queues.\nThis property is only present if another request is necessary to fetch all\nresults. In practice the next request with a `continuationToken` may not\nreturn additional results, but it can. Thus, you can only be sure to have\nall the results if you've called `listTaskQueues` with `continuationToken`\nuntil you get a result without a `continuationToken`.\n",
+          "title": "Continuation Token",
+          "type": "string"
+        },
+        "taskQueues": {
+          "description": "List of all task-queues.\n",
+          "items": {
+            "additionalProperties": false,
+            "properties": {
+              "description": {
+                "description": "Description of the task queue.\n",
+                "title": "Description",
+                "type": "string"
+              },
+              "expires": {
+                "description": "Date and time after which the worker-type will be automatically\ndeleted by the queue.\n",
+                "format": "date-time",
+                "title": "Task queue Expiration",
+                "type": "string"
+              },
+              "lastDateActive": {
+                "description": "Date and time where the task queue was last seen active\n",
+                "format": "date-time",
+                "title": "Task queue Last Date Active",
+                "type": "string"
+              },
+              "stability": {
+                "description": "This is the stability of the worker-type. Accepted values:\n * `experimental`\n * `stable`\n * `deprecated`\n",
+                "enum": [
+                  "experimental",
+                  "stable",
+                  "deprecated"
+                ],
+                "title": "Stability",
+                "type": "string"
+              },
+              "taskQueueId": {
+                "description": "Unique identifier for a task-queue\n",
+                "pattern": "^[a-zA-Z0-9-_]{1,38}/[a-z]([-a-z0-9]{0,36}[a-z0-9])?$",
+                "title": "Task Queue Id",
+                "type": "string"
+              }
+            },
+            "required": [
+              "taskQueueId",
+              "stability",
+              "description",
+              "expires",
+              "lastDateActive"
+            ],
+            "title": "Task Queue",
+            "type": "object"
+          },
+          "title": "taskQueues",
+          "type": "array",
+          "uniqueItems": true
+        }
+      },
+      "required": [
+        "taskQueues"
+      ],
+      "title": "List Task-Queues Response",
+      "type": "object"
+    },
+    "filename": "schemas/queue/v1/list-taskqueues-response.json"
   },
   {
     "content": {
@@ -14598,6 +14725,41 @@
           },
           "stability": "deprecated",
           "title": "Update a worker-type",
+          "type": "function"
+        },
+        {
+          "args": [
+          ],
+          "category": "Worker Metadata",
+          "description": "Get all active task queues.\n\nThe response is paged. If this end-point returns a `continuationToken`, you\nshould call the end-point again with the `continuationToken` as a query-string\noption. By default this end-point will list up to 1000 task queues in a single\npage. You may limit this with the query-string parameter `limit`.",
+          "method": "get",
+          "name": "listTaskQueues",
+          "output": "v1/list-taskqueues-response.json#",
+          "query": [
+            "continuationToken",
+            "limit"
+          ],
+          "route": "/task-queues",
+          "scopes": "queue:list-task-queues",
+          "stability": "stable",
+          "title": "Get a list of all active worker-types",
+          "type": "function"
+        },
+        {
+          "args": [
+            "taskQueueId"
+          ],
+          "category": "Worker Metadata",
+          "description": "Get a task queue.",
+          "method": "get",
+          "name": "getTaskQueue",
+          "output": "v1/taskqueue-response.json#",
+          "query": [
+          ],
+          "route": "/task-queues/<taskQueueId>",
+          "scopes": "queue:get-task-queue:<taskQueueId>",
+          "stability": "stable",
+          "title": "Get a task queue",
           "type": "function"
         },
         {

--- a/services/queue/schemas/constants.yml
+++ b/services/queue/schemas/constants.yml
@@ -37,6 +37,8 @@ identifier-max-length:  38
 # required.
 provisionerid-pattern: '^[a-zA-Z0-9-_]{1,38}$'
 workertype-pattern: '^[a-z]([-a-z0-9]{0,36}[a-z0-9])?$'
+# taskQueueId that will replace provisionerId / workerType in new hierarchy
+taskqueueid-pattern: '^[a-zA-Z0-9-_]{1,38}/[a-z]([-a-z0-9]{0,36}[a-z0-9])?$'
 
 # Run identifier limitations, these are also somewhat founded in RabbitMQ
 # routing key limitations

--- a/services/queue/schemas/v1/list-taskqueues-response.yml
+++ b/services/queue/schemas/v1/list-taskqueues-response.yml
@@ -23,7 +23,7 @@ properties:
         stability:
           title:        "Stability"
           description: |
-            This is the stability of the worker-type. Accepted values:
+            This is the stability of the task queue. Accepted values:
              * `experimental`
              * `stable`
              * `deprecated`
@@ -37,7 +37,7 @@ properties:
         expires:
           title:        "Task queue Expiration"
           description: |
-            Date and time after which the worker-type will be automatically
+            Date and time after which the task queue will be automatically
             deleted by the queue.
           type:         string
           format:       date-time

--- a/services/queue/schemas/v1/list-taskqueues-response.yml
+++ b/services/queue/schemas/v1/list-taskqueues-response.yml
@@ -1,0 +1,70 @@
+$schema: "/schemas/common/metaschema.json#"
+title:              "List Task-Queues Response"
+description: |
+  Response from a `listTaskQueues` request.
+type:               object
+properties:
+  taskQueues:
+    type:           array
+    title:          "taskQueues"
+    description: |
+      List of all task-queues.
+    uniqueItems: true
+    items:
+      type:         object
+      title:        "Task Queue"
+      properties:
+        taskQueueId:
+          title:          "Task Queue Id"
+          description: |
+            Unique identifier for a task-queue
+          type:           string
+          pattern:        {$const: taskqueueid-pattern}
+        stability:
+          title:        "Stability"
+          description: |
+            This is the stability of the worker-type. Accepted values:
+             * `experimental`
+             * `stable`
+             * `deprecated`
+          type:         string
+          enum:         ["experimental", "stable", "deprecated"]
+        description:
+          title:        "Description"
+          description: |
+            Description of the task queue.
+          type:         string
+        expires:
+          title:        "Task queue Expiration"
+          description: |
+            Date and time after which the worker-type will be automatically
+            deleted by the queue.
+          type:         string
+          format:       date-time
+        lastDateActive:
+          title:        "Task queue Last Date Active"
+          description: |
+            Date and time where the task queue was last seen active
+          type:         string
+          format:       date-time
+      additionalProperties: false
+      required:
+        - taskQueueId
+        - stability
+        - description
+        - expires
+        - lastDateActive
+  continuationToken:
+    type:               string
+    title:              "Continuation Token"
+    description: |
+      Opaque `continuationToken` to be given as query-string option to get the
+      next set of task-queues.
+      This property is only present if another request is necessary to fetch all
+      results. In practice the next request with a `continuationToken` may not
+      return additional results, but it can. Thus, you can only be sure to have
+      all the results if you've called `listTaskQueues` with `continuationToken`
+      until you get a result without a `continuationToken`.
+additionalProperties: false
+required:
+ - taskQueues

--- a/services/queue/schemas/v1/taskqueue-response.yml
+++ b/services/queue/schemas/v1/taskqueue-response.yml
@@ -7,13 +7,13 @@ properties:
   taskQueueId:
     title:          "Task Queue Id"
     description: |
-      Unique identifier for a task-queue
+      Unique identifier for a task queue
     type:           string
     pattern:        {$const: taskqueueid-pattern}
   stability:
     title:        "Stability"
     description: |
-      This is the stability of the worker-type. Accepted values:
+      This is the stability of the task queue. Accepted values:
         * `experimental`
         * `stable`
         * `deprecated`

--- a/services/queue/schemas/v1/taskqueue-response.yml
+++ b/services/queue/schemas/v1/taskqueue-response.yml
@@ -1,0 +1,49 @@
+$schema: "/schemas/common/metaschema.json#"
+title:          "Task queue Response"
+description: |
+  Response to a task queue request from a provisioner.
+type:           object
+properties:
+  taskQueueId:
+    title:          "Task Queue Id"
+    description: |
+      Unique identifier for a task-queue
+    type:           string
+    pattern:        {$const: taskqueueid-pattern}
+  stability:
+    title:        "Stability"
+    description: |
+      This is the stability of the worker-type. Accepted values:
+        * `experimental`
+        * `stable`
+        * `deprecated`
+    type:         string
+    enum:         ["experimental", "stable", "deprecated"]
+  description:
+    title:        "Description"
+    description: |
+      Description of the task queue.
+    type:         string
+  expires:
+    title:        "Task queue Expiration"
+    description: |
+      Date and time after which the task queue will be automatically
+      deleted by the queue.
+    type:         string
+    format:       date-time
+  lastDateActive:
+    title:        "Task queue Last Date Active"
+    description: |
+      Date of the last time this task queue was seen active. `lastDateActive` is updated every 6 hours
+      but may be off by up-to 6 hours. Nonetheless, `lastDateActive` is a good indicator
+      of when the task queue was last seen active.
+    type:         string
+    format:       date-time
+additionalProperties: false
+required:
+  - taskQueueId
+  - description
+  - stability
+  - expires
+  - lastDateActive
+

--- a/services/queue/src/api.js
+++ b/services/queue/src/api.js
@@ -1833,7 +1833,7 @@ builder.declare({
   category: 'Worker Metadata',
   stability: APIBuilder.stability.stable,
   output: 'list-taskqueues-response.yml',
-  title: 'Get a list of all active worker-types',
+  title: 'Get a list of all active task queues',
   description: [
     'Get all active task queues.',
     '',


### PR DESCRIPTION

Github Bug/Issue: Fixes #3578 (part 2)

Follow-up to #3641 to add `listTaskQueues` and `getTaskQueue` methods to the queue service API, mapping to the future hierarchy of using taskQueueId in place of the pair provisionerId / workerType.

@djmitche Hopefully I understood this correctly :smiley:.
