### PR TITLE
Fix early killing of interactive feature

### DIFF
--- a/changelog/RD53QBBsRLiaWl_XfNFLag.md
+++ b/changelog/RD53QBBsRLiaWl_XfNFLag.md
@@ -1,0 +1,3 @@
+audience: general
+level: silent
+---

--- a/workers/docker-worker/src/features/interactive.js
+++ b/workers/docker-worker/src/features/interactive.js
@@ -379,10 +379,10 @@ class WebsocketServer {
   }
 
   async killed (task) {
-    if (this.vnc.httpServ) {
+    if (this.vnc && this.vnc.httpServ) {
       this.vnc.httpServ.close();
     }
-    if (this.ssh.httpServ) {
+    if (this.ssh && this.ssh.httpServ) {
       this.ssh.httpServ.close();
     }
     if(this.shellServer) {


### PR DESCRIPTION
This addresses a failure seen in tests:

https://community-tc.services.mozilla.com/tasks/eaeauS32Rge3V1QvBF1CdQ
```
  error: "Could not kill states properly. Error: Error: Error calling 'killed' for dockerInteractive : TypeError: Cannot read property 'httpServ' of undefined\n" +
    '    at WebsocketServer.killed (/worker/src/features/interactive.js:382:18)\n' +
    '    at /worker/src/states.js:50:28\n' +
    '    at Array.map (<anonymous>)\n' +
    '    at States._invoke (/worker/src/states.js:49:13)\n' +
    '    at States.killed (/worker/src/states.js:158:17)\n' +
    '    at Task.abortRun (/worker/src/task.js:562:25)\n' +
    '    at processTicksAndRejections (internal/process/task_queues.js:93:5)\n' +
    '    at Task.run (/worker/src/task.js:934:14)\n' +
    '    at Task.start (/worker/src/task.js:758:17)\n' +
    '    at TaskListener.runTaskset (/worker/src/task_listener.js:572:9)\n' +
    '    at /worker/src/states.js:58:15\n' +
    '    at processTicksAndRejections (internal/process/task_queues.js:93:5)\n' +
    '    at Task.abortRun (/worker/src/task.js:562:7)\n' +
    '    at Task.run (/worker/src/task.js:934:14)\n' +
    '    at Task.start (/worker/src/task.js:758:17)\n' +
    '    at TaskListener.runTaskset (/worker/src/task_listener.js:572:9)\n' +
    '    at async Promise.all (index 0)'
```

however, this error occurs because it's aborting the task very early, and doing so because of another error.  So this won't get tests passing again.