### PR TITLE
Update vnc-test image to use a newer alpine

### DIFF
--- a/changelog/issue-3954.md
+++ b/changelog/issue-3954.md
@@ -1,0 +1,4 @@
+audience: general
+level: silent
+reference: issue 3954
+---

--- a/workers/docker-worker/test/images/vnc-test/Dockerfile
+++ b/workers/docker-worker/test/images/vnc-test/Dockerfile
@@ -1,5 +1,5 @@
-FROM        gliderlabs/alpine:3.2
+FROM        alpine:3.12
 MAINTAINER  Jonas Finnemann Jensen <jopsen@gmail.com>
 
 # Install dependencies
-RUN         apk-install xvfb
+RUN         apk add xvfb


### PR DESCRIPTION
Docker-hub deleted the older version, and installs on alpine-3.2 no
longer work.

Github Bug/Issue: Fixes #3954