### PR TITLE
Fix use of deprecated github pagination functions

### DIFF
--- a/changelog/issue-3982.md
+++ b/changelog/issue-3982.md
@@ -1,0 +1,5 @@
+audience: users
+level: patch
+reference: issue 3982
+---
+The quickstart now correctly shows whether the GitHub integration is enabled for a repository.

--- a/services/github/src/api.js
+++ b/services/github/src/api.js
@@ -432,20 +432,15 @@ builder.declare({
 
   if (instGithub) {
     try {
-      let reposList = await instGithub.apps.listReposAccessibleToInstallation({});
-
-      while (true) {
-        let installed = reposList.data.repositories.map(repo => repo.name).indexOf(repo);
+      for await (const response of instGithub.paginate.iterator(
+        instGithub.apps.listReposAccessibleToInstallation, {})) {
+        let installed = response.data.map(repo => repo.name).indexOf(repo);
         if (installed !== -1) {
           return res.reply({ installed: true });
         }
-        if (instGithub.hasNextPage(reposList)) {
-          reposList = await instGithub.getNextPage(reposList);
-        } else {
-          return res.reply({ installed: false });
-        }
       }
-
+      // no early return -> not installed
+      return res.reply({ installed: false });
     } catch (e) {
       if (e.code > 400 && e.code < 500) {
         return res.reply({ installed: false });

--- a/services/github/test/github-auth.js
+++ b/services/github/test/github-auth.js
@@ -171,6 +171,18 @@ class FakeGithub {
         return await (implementation || (() => {}))(options);
       });
     });
+    // super-hacky version of the pagination plugin.  See https://github.com/taskcluster/taskcluster/issues/3985
+    this.paginate = {
+      iterator: async function*(stub, options) {
+        const response = await stub(options);
+        // ugh, seriously?
+        // see https://github.com/octokit/plugin-paginate-rest.js/blob/master/src/normalize-paginated-list-response.ts
+        if (response.data.repositories) {
+          response.data = response.data.repositories;
+        }
+        yield response;
+      },
+    };
   }
 
   setTaskclusterYml({ owner, repo, ref, content }) {

--- a/ui/src/views/Quickstart/index.jsx
+++ b/ui/src/views/Quickstart/index.jsx
@@ -436,8 +436,13 @@ export default class QuickStart extends Component {
           {installedState === 'error' && (
             <Fragment>
               <ErrorPanel
+                warning
                 className={classes.errorPanels}
-                error="The integration has not been set up for this repository."
+                error={
+                  new Error(
+                    'The integration has not been set up for this repository.'
+                  )
+                }
               />
               <SiteSpecific>
                 To use Taskcluster on this repository, add [this


### PR DESCRIPTION
This replaces the deprecated pagination functions.  The new function is rather hard to mock correctly, so I've double-checked this in development.  I also tested the UI change by hand.

Github Bug/Issue: Fixes #3982
