### PR TITLE
Bug 1680064 - Allow findTask to search for indexes that contain /

### DIFF
--- a/changelog/bug-1680064.md
+++ b/changelog/bug-1680064.md
@@ -1,0 +1,5 @@
+audience: users
+level: patch
+reference: bug 1680064
+---
+Allow findTask to search for indexes that contain /

--- a/services/index/src/helpers.js
+++ b/services/index/src/helpers.js
@@ -4,7 +4,7 @@ const { paginateResults } = require('taskcluster-lib-api');
 const { UNIQUE_VIOLATION } = require('taskcluster-lib-postgres');
 
 /** Regular expression for valid namespaces */
-exports.namespaceFormat = /^([a-zA-Z0-9_!~*'()%-]+\.)*[a-zA-Z0-9_!~*'()%-]+$/;
+exports.namespaceFormat = /^([a-zA-Z0-9_!~*'()%-/]+\.)*[a-zA-Z0-9_!~*'()%-/]+$/;
 
 const makeError = (message, code, statusCode) => {
   const err = new Error(message);


### PR DESCRIPTION
Bugzilla Bug: [1680064](https://bugzilla.mozilla.org/show_bug.cgi?id=1680064)

The new regex has been tested on https://regex101.com/ against `mobile.v2.fenix.branch.releases/v84.0.0.revision.707dd46284878c4081e8f1e194f61e189f88af0f.taskgraph.decision`. This index is not visible on https://firefox-ci-tc.services.mozilla.com/tasks/index/mobile.v2.fenix.branch, although it was accepted when the task was submitted https://firefox-ci-tc.services.mozilla.com/tasks/UUiXNj-pS56IqghasEbkRA 
