### PR TITLE
Add "cdn" middleware to the object service.

### DIFF
--- a/generated/docs-search.json
+++ b/generated/docs-search.json
@@ -399,6 +399,13 @@
     "title": "Object Service"
   },
   {
+    "element": "h3",
+    "id": "cdn",
+    "path": "/manual/deploying/object-service",
+    "subtitle": "CDN",
+    "title": "Object Service"
+  },
+  {
     "element": "h2",
     "id": "middleware-types",
     "path": "/manual/deploying/object-service",

--- a/services/object/src/middleware/cdn.js
+++ b/services/object/src/middleware/cdn.js
@@ -1,0 +1,27 @@
+const assert = require('assert');
+const { Middleware } = require('./base.js');
+
+class CdnMiddleware extends Middleware {
+  constructor(options) {
+    super(options);
+    const { config } = options;
+    assert(config.regexp, 'regexp is required for cdn middleware');
+    this.regexp = new RegExp(config.regexp);
+
+    assert(config.baseUrl, 'baseUrl is required for cdn middleware');
+    this.baseUrl = config.baseUrl;
+  }
+
+  async simpleDownloadRequest(req, res, object) {
+    // If the regular expression matches, then redirect to the CDN URL instead of
+    // allowing the backend URL to serve this request.
+    if (this.regexp.test(object.name)) {
+      res.redirect(303, this.baseUrl + object.name);
+      return false;
+    }
+
+    return true;
+  }
+}
+
+module.exports = { CdnMiddleware };

--- a/services/object/src/middleware/index.js
+++ b/services/object/src/middleware/index.js
@@ -1,4 +1,7 @@
+const { CdnMiddleware } = require('./cdn');
+
 const MIDDLEWARE_TYPES = {
+  cdn: CdnMiddleware,
 };
 
 /**

--- a/services/object/test/api_test.js
+++ b/services/object/test/api_test.js
@@ -10,6 +10,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
   helper.withDb(mock, skipping);
   helper.resetTables(mock, skipping);
   helper.withBackends(mock, skipping);
+  helper.withMiddleware(mock, skipping);
   helper.withServer(mock, skipping);
 
   test('ping', async function() {

--- a/services/object/test/helper/index.js
+++ b/services/object/test/helper/index.js
@@ -48,9 +48,8 @@ exports.withBackends = (mock, skipping) => {
       return;
     }
 
-    // add the 'test' backend and middleware types only for testing
+    // add the 'test' backend type only for testing
     BACKEND_TYPES['test'] = TestBackend;
-    MIDDLEWARE_TYPES['test'] = TestMiddleware;
 
     await exports.load('cfg');
     exports.load.cfg('middleware', [
@@ -67,6 +66,25 @@ exports.withBackends = (mock, skipping) => {
 
   suiteTeardown('withBackends', async function() {
     delete BACKEND_TYPES['test'];
+  });
+};
+
+exports.withMiddleware = (mock, skipping, config) => {
+  suiteSetup('withMiddleware', async function() {
+    if (skipping()) {
+      return;
+    }
+
+    // add the 'test' middleware type only for testing
+    MIDDLEWARE_TYPES['test'] = TestMiddleware;
+
+    await exports.load('cfg');
+    exports.load.cfg('middleware', config || [
+      { middlewareType: 'test' },
+    ]);
+  });
+
+  suiteTeardown('withMiddleware', async function() {
     delete MIDDLEWARE_TYPES['test'];
   });
 };

--- a/services/object/test/middleware/cdn_test.js
+++ b/services/object/test/middleware/cdn_test.js
@@ -1,0 +1,41 @@
+const assert = require('assert');
+const helper = require('../helper');
+const testing = require('taskcluster-lib-testing');
+const request = require('superagent');
+const crypto = require('crypto');
+const { fromNow } = require('taskcluster-client');
+
+helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
+  helper.withDb(mock, skipping);
+  helper.resetTables(mock, skipping);
+  helper.withBackends(mock, skipping);
+  helper.withMiddleware(mock, skipping, [
+    { 'middlewareType': 'cdn', regexp: "^public/.*", baseUrl: "https://cdn.example.com/" },
+  ]);
+  helper.withServer(mock, skipping);
+
+  const makeObject = async name => {
+    const data = crypto.randomBytes(128);
+    await helper.apiClient.uploadObject(name, {
+      projectId: 'x',
+      data: data.toString('base64'),
+      expires: fromNow('1 year'),
+    });
+  };
+
+  test('intercepts matching simple downloads', async function() {
+    await makeObject('public/foo/bar');
+    const downloadUrl = helper.apiClient.externalBuildSignedUrl(helper.apiClient.download, 'public/foo/bar');
+    const res = await request.get(downloadUrl).redirects(0).ok(res => res.status < 400);
+    assert.equal(res.statusCode, 303);
+    assert.equal(res.headers.location, "https://cdn.example.com/public/foo/bar");
+  });
+
+  test('ignores non-matching simple downloads', async function() {
+    await makeObject('private/foo/bar');
+    const downloadUrl = helper.apiClient.externalBuildSignedUrl(helper.apiClient.download, 'private/foo/bar');
+    const res = await request.get(downloadUrl).redirects(0).ok(res => res.status < 400);
+    assert.equal(res.statusCode, 303);
+    assert(!res.headers.location.startsWith("https://cdn"));
+  });
+});

--- a/services/object/test/middleware_test.js
+++ b/services/object/test/middleware_test.js
@@ -3,15 +3,10 @@ const helper = require('./helper');
 const testing = require('taskcluster-lib-testing');
 
 helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
-  helper.withBackends(mock, skipping);
-
-  setup(async function() {
-    await helper.load('cfg');
-    helper.load.cfg('middleware', [
-      { 'middlewareType': 'test', downloadObject: { intercept: 'dl' } },
-      { 'middlewareType': 'test', simpleDownload: { intercept: 'simple' } },
-    ]);
-  });
+  helper.withMiddleware(mock, skipping, [
+    { 'middlewareType': 'test', downloadObject: { intercept: 'dl' } },
+    { 'middlewareType': 'test', simpleDownload: { intercept: 'simple' } },
+  ]);
 
   test('calls middleware for downloadObjectRequest', async function() {
     const middleware = await helper.load('middleware');

--- a/ui/docs/manual/deploying/object-service.mdx
+++ b/ui/docs/manual/deploying/object-service.mdx
@@ -132,4 +132,19 @@ Each is a JSON object that must have at least a `middlewareType` giving the type
 
 ## Middleware Types
 
-No middleware types are defined yet!
+### CDN
+
+The `cdn` middleware supports redirecting simple download requests to fetch instead from a CDN.
+Its configuration has `middlewareType` `"cdn"` and
+
+ * `regexp` - a regular expression over object names, matching objects that should be redirected
+ * `baseUrl` the base URL to which the object name should be suffixed to generate the CDN URL.
+
+For example:
+
+```yaml
+middleware:
+  - { middlewareType: "cdn", regexp: "^public/.*", baseUrl: "https://d111111abcdef8.cloudfront.net/" }
+```
+
+This configuration would redirect all objects beginning with `public/` to be served at URLs like `https://d111111abcdef8.cloudfront.net/public/some/object`.


### PR DESCRIPTION
This is *super* basic!  I can imagine we might eventually want to be able to "filter" more precisely.  Like, maybe we want to use a CDN for only some projects, or different object names on different projects.  Maybe we should find a way to generalize the backendMap functionality into a kind of filtering expression that could be used here, too.

I can also imagine that some CDNs might need something more complex than just "append the object name here".  Maybe we'll want some kind of regexp / replace functionality.

In any case, I think this is good for now but I'm happy to be told otherwise.

Github Bug/Issue: Fixes #3951
