### PR TITLE
Add a GCS backend based on the AWS backend

### DIFF
--- a/changelog/issue-3718.md
+++ b/changelog/issue-3718.md
@@ -1,0 +1,6 @@
+audience: deployers
+level: silent
+reference: issue 3718
+---
+Provides support for using Google Cloud Storage as a back end for the Object Service. Under the hood this uses the S3 protocol via the interoperability API.
+See more at https://cloud.google.com/storage/docs/interoperability.

--- a/generated/docs-search.json
+++ b/generated/docs-search.json
@@ -372,9 +372,9 @@
   },
   {
     "element": "h3",
-    "id": "aws",
+    "id": "aws-for-aws-_and_-google",
     "path": "/manual/deploying/object-service",
-    "subtitle": "AWS",
+    "subtitle": "AWS (for AWS _and_ Google!)",
     "title": "Object Service"
   },
   {
@@ -2633,17 +2633,17 @@
   },
   {
     "element": "h1",
-    "id": "aws-backend-type",
+    "id": "aws-backend-type-for-aws-_and_-google-cloud",
     "path": "/reference/platform/object/aws-backend",
     "subtitle": null,
-    "title": "AWS Backend Type"
+    "title": "AWS Backend Type (for AWS _and_ Google Cloud!)"
   },
   {
     "element": "h2",
     "id": "deployment-configuration",
     "path": "/reference/platform/object/aws-backend",
     "subtitle": "Deployment Configuration",
-    "title": "AWS Backend Type"
+    "title": "AWS Backend Type (for AWS _and_ Google Cloud!)"
   },
   {
     "element": "h1",

--- a/services/object/src/backends/aws.js
+++ b/services/object/src/backends/aws.js
@@ -18,8 +18,15 @@ class AwsBackend extends Backend {
       accessKeyId: this.config.accessKeyId,
       secretAccessKey: this.config.secretAccessKey,
     };
-    this.region = await getBucketRegion({ bucket: this.config.bucket, credentials });
-    this.s3 = new aws.S3({ region: this.region, ...credentials });
+    // only include endpoint if included, since included for gcp backend but not needed for aws backend
+    let options = { ...credentials };
+    if ('endpoint' in this.config) {
+      options.endpoint = new aws.Endpoint(this.config.endpoint);
+    } else {
+      this.region = await getBucketRegion({ bucket: this.config.bucket, endpoint: this.config.endpoint, credentials });
+      options.region = this.region;
+    }
+    this.s3 = new aws.S3(options);
   }
 
   async temporaryUpload(object, data) {
@@ -64,19 +71,29 @@ class AwsBackend extends Backend {
     // When an object is being expired, we first delete the object from S3.  Even if lifecycle
     // or other S3 policies would accomplish the same thing, this serves as a backstop to
     // prevent removing the database record while the object itself is still on S3, thereby
-    // leaking storage.  Note that s3.deleteObject is idempotent: this will not fail if the
-    // object does not exist.
-    await this.s3.deleteObject({
-      Bucket: this.config.bucket,
-      Key: object.name,
-    }).promise();
-
+    // leaking storage.  Note that s3.deleteObject is idempotent in AWS, but not in Google,
+    // and since we don't care about objects that couldn't be deleted, we swallow any errors.
+    try {
+      await this.s3.deleteObject({
+        Bucket: this.config.bucket,
+        Key: object.name,
+      }).promise();
+    } catch (error) {
+      // This can happen if object expired between the time the object metadata was retrieved
+      // and the delete was executed, or if there was a network blip that caused a retry to
+      // occur.  In no case do we really care if an object couldn't be deleted, as this
+      // expiration process is only a backstop to e.g. a bucket level expiration policy.
+    }
     return true;
   }
 }
 
-const getBucketRegion = async ({ bucket, ...credentials }) => {
-  const s3 = new aws.S3(credentials);
+const getBucketRegion = async ({ bucket, endpoint, ...credentials }) => {
+  let options = credentials;
+  if (endpoint) {
+    options.endpoint = new aws.Endpoint(endpoint);
+  }
+  const s3 = new aws.S3(options);
   const { LocationConstraint } = await s3.getBucketLocation({
     Bucket: bucket,
   }).promise();

--- a/services/object/test/backends/google_test.js
+++ b/services/object/test/backends/google_test.js
@@ -1,0 +1,173 @@
+const helper = require('../helper');
+const assert = require('assert');
+const aws = require('aws-sdk');
+const testing = require('taskcluster-lib-testing');
+const taskcluster = require('taskcluster-client');
+
+helper.secrets.mockSuite(testing.suiteName(), ['google'], function(mock, skipping) {
+  if (mock) {
+    // tests for this backend require real google cloud storage access, and
+    // aren't even defined for the mock case
+    return;
+  }
+
+  helper.withDb(mock, skipping);
+  helper.withBackends(mock, skipping);
+
+  let secret, s3;
+
+  // unique object name prefix for this test run
+  const prefix = taskcluster.slugid() + '/';
+
+  suiteSetup(async function() {
+    await helper.load('cfg');
+
+    secret = helper.secrets.get('google');
+
+    const credentials = {
+      accessKeyId: secret.accessKeyId,
+      secretAccessKey: secret.secretAccessKey,
+    };
+    const endpoint = new aws.Endpoint('https://storage.googleapis.com');
+    s3 = new aws.S3({ endpoint, ...credentials });
+
+    // set up a backend with a public bucket, and separately with a private
+    // bucket; these are in fact the same bucket, and we'll just check that the
+    // URLs have a signature for the non-public version.  S3 verifies
+    // signatures if they are present, even if the signature is not required.
+    helper.load.cfg('backends', {
+      googlePrivate: {
+        backendType: 'aws',
+        accessKeyId: secret.accessKeyId,
+        secretAccessKey: secret.secretAccessKey,
+        bucket: secret.testBucket,
+        signGetUrls: true,
+        endpoint: 'https://storage.googleapis.com',
+      },
+      googlePublic: {
+        backendType: 'aws',
+        accessKeyId: secret.accessKeyId,
+        secretAccessKey: secret.secretAccessKey,
+        bucket: secret.testBucket,
+        signGetUrls: false,
+        endpoint: 'https://storage.googleapis.com',
+      },
+    });
+    helper.load.cfg('backendMap', []);
+  });
+
+  const makeObject = async ({ name, data }) => {
+    const projectId = 'test-proj';
+    const expires = taskcluster.fromNow('1 hour');
+    const uploadId = taskcluster.slugid();
+
+    await helper.db.fns.create_object_for_upload(name, projectId, 'google', uploadId, expires, {}, expires);
+    const [object] = await helper.db.fns.get_object_with_upload(name);
+
+    await s3.putObject({
+      Bucket: secret.testBucket,
+      Key: name,
+      Body: data,
+    }).promise();
+
+    await helper.db.fns.object_upload_complete(name, uploadId);
+
+    return object;
+  };
+
+  const cleanup = async () => {
+    await helper.resetTables();
+
+    // delete all objects with this prefix
+    const objects = await s3.listObjects({
+      Bucket: secret.testBucket,
+      Prefix: prefix,
+    }).promise();
+    for(let obj of objects.Contents) {
+      await s3.deleteObject({
+        Bucket: secret.testBucket,
+        Key: obj.Key,
+      }).promise();
+    }
+  };
+
+  helper.testSimpleDownloadMethod({
+    mock, skipping, prefix,
+    title: 'public bucket',
+    backendId: 'googlePublic',
+    makeObject,
+    async checkUrl({ name, url }) {
+      // *not* signed
+      assert(!url.match(/AccessKeyId=/), `got ${url}`);
+      assert(!url.match(/Signature=/), `got ${url}`);
+    },
+  }, async function() {
+    teardown(cleanup);
+  });
+
+  helper.testSimpleDownloadMethod({
+    mock, skipping, prefix,
+    title: 'private bucket',
+    backendId: 'googlePrivate',
+    makeObject,
+    async checkUrl({ name, url }) {
+      // ..contains S3 signature query args (note that testSimpleDownloadMethod
+      // will verify that the URL actually works; this just verifies that it
+      // is not un-signed).
+      assert(url.match(/AccessKeyId=/), `got ${url}`);
+      assert(url.match(/Signature=/), `got ${url}`);
+    },
+  }, async function() {
+    teardown(cleanup);
+  });
+
+  helper.testTemporaryUpload({
+    mock, skipping, prefix,
+    backendId: 'googlePrivate',
+    async getObjectContent({ name }) {
+      const res = await s3.getObject({
+        Bucket: secret.testBucket,
+        Key: name,
+      }).promise();
+      return res.Body;
+    },
+  }, async function() {
+    teardown(cleanup);
+  });
+
+  suite('expireObject', function() {
+    teardown(cleanup);
+
+    test('expires an object', async function() {
+      const name = 'some/object';
+      const object = await makeObject({ name, data: Buffer.from('abc') });
+
+      const backends = await helper.load('backends');
+      const backend = backends.get('googlePrivate');
+
+      assert(await backend.expireObject(object));
+
+      // object should now be gone
+      await assert.rejects(() => s3.getObject({
+        Bucket: secret.testBucket,
+        Key: name,
+      }).promise(),
+      err => err.code === 'NoSuchKey');
+    });
+
+    test('succeeds for an object that no longer exists', async function() {
+      const name = 'some/object';
+      const uploadId = taskcluster.slugid();
+      await helper.db.fns.create_object_for_upload(
+        name, 'test-proj', 'google', uploadId,
+        taskcluster.fromNow('1 hour'), {}, taskcluster.fromNow('1 hour'));
+      await helper.db.fns.object_upload_complete(name, uploadId);
+      const [object] = await helper.db.fns.get_object_with_upload(name);
+
+      const backends = await helper.load('backends');
+      const backend = backends.get('googlePrivate');
+
+      assert(await backend.expireObject(object));
+    });
+  });
+});

--- a/services/object/test/helper/google.js
+++ b/services/object/test/helper/google.js
@@ -1,0 +1,23 @@
+/**
+ * The google test bucket was set up manually.
+ * The taskcluster-dev project was manually configured to be the default project.
+ * The test bucket has bucket-level permissions.
+ * There is no retention policy, since tests need to delete objects almost immediately.
+ *
+ * Console view:
+ *   https://console.cloud.google.com/storage/browser/taskcluster-test
+ *
+ * Access control
+ *   Uniform: No object-level ACLs enabled
+ *
+ * Permissions
+ *   allUsers: Storage Object Viewer
+ *   Editors of project taskcluster-dev: [Storage Legacy Bucket Owner, Storage Legacy Object Owner]
+ *   Owners of project taskcluster-dev: [Storage Legacy Bucket Owner, Storage Legacy Object Owner]
+ *   Viewers of project taskcluster-dev: [Storage Legacy Bucket Reader, Storage Legacy Object Reader]
+ */
+exports.secret = [
+  { env: 'GOOGLE_ACCESS_KEY_ID', name: 'accessKeyId' },
+  { env: 'GOOGLE_SECRET_ACCESS_KEY', name: 'secretAccessKey' },
+  { env: 'GOOGLE_TEST_BUCKET', name: 'testBucket' },
+];

--- a/services/object/test/helper/index.js
+++ b/services/object/test/helper/index.js
@@ -8,6 +8,7 @@ const { MIDDLEWARE_TYPES } = require('../../src/middleware');
 const { TestBackend } = require('../../src/backends/test');
 const { TestMiddleware } = require('../../src/middleware/test');
 const aws = require('./aws');
+const google = require('./google');
 
 Object.assign(exports, require('./simple-download'));
 Object.assign(exports, require('./temporary-upload'));
@@ -28,6 +29,7 @@ exports.secrets = new Secrets({
   ],
   secrets: {
     aws: aws.secret,
+    google: google.secret,
   },
   load: exports.load,
 });

--- a/ui/docs/manual/deploying/object-service.mdx
+++ b/ui/docs/manual/deploying/object-service.mdx
@@ -31,7 +31,7 @@ backends:
     backendType: aws
     # ...
   proj-fuzzing:
-    backendType: google
+    backendType: aws
     # ...
 ```
 
@@ -75,9 +75,13 @@ backend_map:
 
 ## Backend Types
 
-### AWS
+### AWS (for AWS _and_ Google!)
 
-The `aws` backend type stores objects in an S3 bucket.
+The `aws` backend type stores objects using the AWS S3 protocol.
+
+Since Google Cloud provides an S3-interoperability API, this means the AWS
+Backend can _also_ be used to persist objects in Google Cloud Storage.
+
 Objects are stored in the bucket using their full name.
 
 Each backend has the following configuration parameters:
@@ -85,6 +89,12 @@ Each backend has the following configuration parameters:
  * `accessKeyId`
  * `secretAccessKey`
  * `signGetUrls` (optional, default false)
+ * `endpoint` (optional, default null)
+
+To use Google Cloud Storage, set `endpoint` to `https://storage.googleapis.com`
+and follow the [Simple Migration
+Guide](https://cloud.google.com/storage/docs/migrating#migration-simple) to set
+up appropriate HMAC key and configure your Google Cloud project appropriately.
 
 The bucket parameter names the bucket in which to store the objects.
 You must pre-create the bucket in the appropriate region.

--- a/ui/docs/reference/platform/object/aws-backend.mdx
+++ b/ui/docs/reference/platform/object/aws-backend.mdx
@@ -3,9 +3,11 @@ order: 40
 title: AWS Backend Type
 ---
 
-# AWS Backend Type
+# AWS Backend Type (for AWS _and_ Google Cloud!)
 
-The AWS backend type supports storing objects in the AWS S3 service.
+The AWS backend type supports storing objects in the AWS S3 service, _and_ Google Cloud Storage service.
+
+Google cloud support is possible thanks to the [interoperability API](https://cloud.google.com/storage/docs/interoperability).
 
 The backend type stores object data in a single S3 bucket.
 The S3 Key name is identical to the object name.
@@ -27,6 +29,7 @@ backends:
     secretAccessKey: "<aws secret access key>"
     bucket: "<bucket name>"
     signGetUrls: false # or true
+    endpoint: "https://storage.googleapis.com" # for Google, or do not specify for AWS
 ```
 
 The provided AWS credentials should have the following policy (with `<BUCKET_NAME>` replaced by the bucket name):
@@ -61,6 +64,8 @@ The provided AWS credentials should have the following policy (with `<BUCKET_NAM
     ]
 }
 ```
+
+For Google Cloud, the provided credentials should have "Storage Legacy Bucket Owner" and "Storage Legacy Object Owner".
 
 The use of `signGetUrls` is described above.
 If this configuration value is `false`, then the bucket should be configured to allow public read access.


### PR DESCRIPTION
Github Bug/Issue: Fixes #3718 

I've successfully configured a GCS bucket and uploaded and downloaded objects to it using the AWS client.

I spent some time with @helfi92 trying to get tests to work but haven't yet been successful, so some guidance here would be helpful.

Just as when using a real AWS S3 backend with the object service, an access key ID and a secret access key are both needed. However, additionally, the endpoint URI is required as configuration, and needs to be set to `https://storage.googleapis.com`. More information is available at https://cloud.google.com/storage/docs/interoperability.

Under the `pmoore-dev` project of our gcloud account, I was able to create a bucket `pmoore-potatoes`, create an HMAC and service account, and configure my local s3 client to use them, and then was able to upload and download objects...

```
pmoore@pmoore-laptop:~/git/taskcluster issue3718 $ aws s3 --endpoint-url https://storage.googleapis.com cp ~/Desktop/2880px-Miles_Gordon_Technology_Logo.svg.png s3://pmoore-potatoes
pmoore@pmoore-laptop:~/git/taskcluster issue3718 $ aws s3 --endpoint-url https://storage.googleapis.com ls pmoore-potatoes
2020-12-04 15:54:08      88854 2880px-Miles_Gordon_Technology_Logo.svg.png
2020-12-01 16:17:58     177348 WhatsApp Image 2020-11-27 at 11.49.22.jpeg
pmoore@pmoore-laptop:~/git/taskcluster issue3718 $ 
```

The changes to the code are in fact slight: we simply needed to add the capability to support a different S3 endpoint, in order to have the requests sent to GCS rather than S3.

The problems we are having running the tests seem to be related to the helper methods that create the private and public buckets, and I suspect there are some API calls somewhere in the test harness that also need to be updated to use the endpoint url that we've added to the service code.

For now, we've left the backend name as aws, rather than creating a new one called gcs or google, since the code is identical. Our assumption is that a running taskcluster service would use only one backend at a time, as a configuration setting, rather than uploading some objects to s3 and some to gcs. This is also because the object service API does not provide a means for a request to specify a specific backend, so our assumption is that all object service requests will be serviced by the same backend, which would be a deployment configuration setting.

Please let us know what additional testing we should do, if any, or if this is ok to ship as it is.

Many thanks!