### PR TITLE
Fix schema for the simple download method

### DIFF
--- a/changelog/YpDp67kpSfKLguKjO-lQ-Q.md
+++ b/changelog/YpDp67kpSfKLguKjO-lQ-Q.md
@@ -1,0 +1,3 @@
+audience: general
+level: silent
+---

--- a/clients/client-go/tcobject/types.go
+++ b/clients/client-go/tcobject/types.go
@@ -14,10 +14,6 @@ type (
 		URL string `json:"url"`
 	}
 
-	Details1 struct {
-		URL string `json:"url"`
-	}
-
 	// See [Download Methods](https://docs.taskcluster.net/docs/docs/reference/platform/object/download-methods) for details.
 	DownloadObjectRequest struct {
 
@@ -43,10 +39,11 @@ type (
 	// A simple download returns a URL to which the caller should make a GET request.
 	// See [Simple Downloads](https://docs.taskcluster.net/docs/docs/reference/platform/object/simple-downloads) for details.
 	SimpleDownloadResponse struct {
-		Details Details1 `json:"details"`
 
 		// Constant value: "simple"
 		Method string `json:"method"`
+
+		URL string `json:"url"`
 	}
 
 	// Download methods that the caller can suport, together with parameters for each method.

--- a/generated/references.json
+++ b/generated/references.json
@@ -4173,27 +4173,18 @@
           "additionalProperties": false,
           "description": "A simple download returns a URL to which the caller should make a GET request.\nSee [Simple Downloads](https://docs.taskcluster.net/docs/docs/reference/platform/object/simple-downloads) for details.",
           "properties": {
-            "details": {
-              "additionalProperties": false,
-              "properties": {
-                "url": {
-                  "format": "uri",
-                  "type": "string"
-                }
-              },
-              "required": [
-                "url"
-              ],
-              "type": "object"
-            },
             "method": {
               "const": "simple",
+              "type": "string"
+            },
+            "url": {
+              "format": "uri",
               "type": "string"
             }
           },
           "required": [
             "method",
-            "details"
+            "url"
           ],
           "title": "simple Download Response",
           "type": "object"

--- a/services/object/schemas/v1/download-method-simple.yml
+++ b/services/object/schemas/v1/download-method-simple.yml
@@ -16,16 +16,10 @@ definitions:
       method:
         type: string
         const: 'simple'
-      details:
-        type: object
-        properties:
-          url:
-            type: string
-            format: uri
-        additionalProperties: false
-        required:
-          - url
+      url:
+        type: string
+        format: uri
     additionalProperties: false
     required:
       - method
-      - details
+      - url

--- a/services/object/src/middleware/test.js
+++ b/services/object/src/middleware/test.js
@@ -11,7 +11,7 @@ class TestMiddleware extends Middleware {
       case 'dl/intercept': {
         res.reply({
           method: 'simple',
-          details: { url: 'http://intercepted' },
+          url: 'http://intercepted',
         });
         return false;
       }

--- a/services/object/test/api_test.js
+++ b/services/object/test/api_test.js
@@ -51,6 +51,22 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
   });
 
   suite('downloadObject method', function() {
+    test('downloadObject for simple method succeeds', async function() {
+      const data = crypto.randomBytes(128);
+      await helper.apiClient.uploadObject('public/foo', {
+        projectId: 'x',
+        data: data.toString('base64'),
+        expires: fromNow('1 year'),
+      });
+      const res = await helper.apiClient.downloadObject('public/foo', {
+        acceptDownloadMethods: { 'simple': true },
+      });
+      assert.deepEqual(res, {
+        method: 'simple',
+        url: toDataUrl(data),
+      });
+    });
+
     test('downloadObject for a supported method succeeds', async function() {
       const data = crypto.randomBytes(128);
       await helper.apiClient.uploadObject('public/foo', {
@@ -83,7 +99,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
 
       assert.deepEqual(res, {
         method: 'simple',
-        details: { url: 'http://intercepted' },
+        url: 'http://intercepted',
       });
     });
 

--- a/services/object/test/middleware_test.js
+++ b/services/object/test/middleware_test.js
@@ -21,7 +21,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
     const object = { name: 'dl/intercept' };
 
     assert(!await middleware.downloadObjectRequest({}, res, object, 'meth', {}));
-    assert.deepEqual(reply, { method: 'simple', details: { url: 'http://intercepted' } });
+    assert.deepEqual(reply, { method: 'simple', url: 'http://intercepted' });
   });
 
   test('calls middleware for simpleDownloadRequest', async function() {


### PR DESCRIPTION
The schema included a `details` object, which is not necessary for this
method and was not what the backends returned.