### PR TITLE
Fix GitHub service producing errors without the anonymous role

### DIFF
--- a/changelog/issue-4059.md
+++ b/changelog/issue-4059.md
@@ -1,0 +1,7 @@
+audience: general
+level: patch
+reference: issue 4059
+---
+Fixed an issue fetching GitHub metadata when using a Taskcluster instance without the anonymous role.
+
+This presented as unexpected 'Failed to get your artifact.' errors.

--- a/services/github/src/handlers.js
+++ b/services/github/src/handlers.js
@@ -458,24 +458,24 @@ async function requestArtifact(artifactName, { taskId, runId, debug, instGithub,
     const limitedQueueClient = this.queueClient.use({
       authorizedScopes: scopes,
     });
-    const url = limitedQueueClient.buildUrl(limitedQueueClient.getArtifact, taskId, runId, artifactName);
+    const url = limitedQueueClient.buildSignedUrl(limitedQueueClient.getArtifact, taskId, runId, artifactName);
     const res = await utils.throttleRequest({ url, method: 'GET' });
 
     if (res.status >= 400 && res.status !== 404) {
       let errorMessage = "Failed to get your artifact.\n";
       switch (res.status) {
         case 403:
-          errorMessage.concat("Make sure your artifact is public. See the documentation on the artifact naming.");
+          errorMessage = errorMessage.concat("Make sure your artifact is public. See the documentation on the artifact naming.");
           break;
         case 404:
-          errorMessage.concat("Make sure the artifact exists, and there are no typos in its name.");
+          errorMessage = errorMessage.concat("Make sure the artifact exists, and there are no typos in its name.");
           break;
         case 424:
-          errorMessage.concat("Make sure the artifact exists on the worker or other location.");
+          errorMessage = errorMessage.concat("Make sure the artifact exists on the worker or other location.");
           break;
         default:
           if (res.response && res.response.error & res.response.error.message) {
-            errorMessage.concat(res.response.error.message);
+            errorMessage = errorMessage.concat(res.response.error.message);
           }
           break;
       }

--- a/services/github/test/handler_test.js
+++ b/services/github/test/handler_test.js
@@ -127,9 +127,8 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       listTaskGroup: async () => ({ tasks: [] }),
       use: () => ({
         getArtifact: async() => CUSTOM_CHECKRUN_TEXT,
-        buildUrl: async() => 'http://example.com',
+        buildSignedUrl: async() => 'http://example.com',
       }),
-      buildUrl: () => 'url',
     };
 
     // set up the allowPullRequests key


### PR DESCRIPTION
Github Bug/Issue: Fixes #4059

This changes `requestArtifact` to use `buildSignedUrl` so that it works properly without the anonymous role and also fixes some of the error body being omitted.