### PR TITLE
enable auto-merge for top-level packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -216,6 +216,7 @@
     "semanticCommits": "disabled",
     "packageRules": [
       {
+        "_comment": "packages which get very frequent updates are limited to once per week",
         "packagePatterns": [
           "^googleapis$",
           "^aws-sdk$",
@@ -226,10 +227,18 @@
         ]
       },
       {
+        "_comment": "major updates get higher prority than minor/patch version bumps",
         "updateTypes": [
           "major"
         ],
         "prPriority": 1
+      },
+      {
+        "_comment": "automerge minor PRs for top-level package.json, as it is well-tested",
+        "updateTypes": ["minor", "patch"],
+        "matchCurrentVersion": "!/^0/",
+        "paths": ["+(package.json)"],
+        "automerge": true
       }
     ],
     "enabledManagers": [


### PR DESCRIPTION
I assume this will need further tweaking.  I'm not sure automerging will work with our current GitHub settings (in particular, I think renovate can't merge with pending reviews, so we may need to solve that).  And I'm not sure this is the right way to express this in renovate config anyway.  Hopefully the addition of `_comment` doesn't cause errors and helps understanding the intent.

Github Bug/Issue: Fixes #4011