### PR TITLE
include renovate package updates in changelog

### DIFF
--- a/changelog/issue-4012.md
+++ b/changelog/issue-4012.md
@@ -1,0 +1,4 @@
+audience: general
+level: silent
+reference: issue 4012
+---

--- a/infrastructure/tooling/src/utils/git.js
+++ b/infrastructure/tooling/src/utils/git.js
@@ -177,3 +177,17 @@ exports.gitPush = async ({ dir, remote, refs, force, utils }) => {
   const opts = { cwd: dir };
   await exec('git', ['push', ...(force ? ['-f'] : []), remote, ...refs], opts);
 };
+
+/**
+ * Run `git log` and return the results in an array of lines.
+ *
+ * - dir -- directory to run in
+ * - args -- arguments to `git log`
+ */
+exports.gitLog = async ({ dir, args }) => {
+  const opts = { cwd: dir };
+  const res = await exec('git', ['log', ...args], opts);
+  return res.stdout
+    .split(/\n/)
+    .filter(l => l !== '');
+};


### PR DESCRIPTION
Result:

---

### GENERAL

▶ [patch] [#4059](https://github.com/taskcluster/taskcluster/issues/4059)
Fixed an issue fetching GitHub metadata when using a Taskcluster instance without the anonymous role.

This presented as unexpected 'Failed to get your artifact.' errors.

### USERS

▶ [minor] [#4006](https://github.com/taskcluster/taskcluster/issues/4006)
The `takscluster-client-web` library is no longer installable from a `<script>` tag.
Instead, it should be incorporated into the build process of the consuming application, like any other library.

▶ [patch] 
Improved error messages related to fetching artifacts for GitHub checks.

▶ [patch] [#4061](https://github.com/taskcluster/taskcluster/issues/4061)
This version fixes an issue with the "actions" button not appearing for task groups.

### DEVELOPERS

▶ [patch] [#3939](https://github.com/taskcluster/taskcluster/issues/3939)
The object service now supports `uploadId` in the upload process.

### OTHER

▶ Additional changes not described here: [#3951](https://github.com/taskcluster/taskcluster/issues/3951), [#3999](https://github.com/taskcluster/taskcluster/issues/3999), [#4012](https://github.com/taskcluster/taskcluster/issues/4012), [#4036](https://github.com/taskcluster/taskcluster/issues/4036).

### Automated Package Updates

<details>
<summary>23 Renovate updates</summary>

* Update dependency karma-firefox-launcher to v2.1.0 (2d025d202)
* Update dependency js-yaml to v3.14.1 (3fbd371e0)
* Update dependency cronstrue to v1.106.0 (816766a75)
* Update dependency eslint to v7.15.0 (81ccaea25)
* Update dependency highlight.js to v10.4.1 (f6ea972f7)
* Update dependency email-templates to v8.0.2 (f251a8132)
* Update dependency cross-env to v7.0.3 (d0f2b8a72)
* Update dependency dexie to v3.0.3 (a079077a5)
* Update dependency cronstrue to v1.105.0 (ab2d1485c)
* Update dependency cron-parser to v2.18.0 (4f0fd24d5)
* Update dependency codemirror to v5.58.3 (8e4113f14)
* Update dependency camel-case to v4.1.2 (a51ce83a5)
* Update dependency bufferutil to v4.0.2 (d98f2048b)
* Update dependency apollo-server-express to v2.19.0 (756d38eac)
* Update dependency @octokit/rest to v18.0.12 (1f537d19c)
* Update dependency @octokit/core to v3.2.4 (77474a99b)
* Update dependency @octokit/plugin-retry to v3.0.6 (e93965600)
* Update dependency @slack/web-api to v5.14.0 (6919f928d)
* Update dependency @octokit/plugin-throttling to v3.3.4 (d245672bc)
* Update dependency taskcluster-client to v39 (494942a91)
* Update dependency @octokit/rest to v18.0.10 (d8846df47)
* Update dependency @octokit/plugin-retry to v3.0.5 (5ddc535a1)
* Update dependency @octokit/core to v3.2.2 (7b6c948ba)

</details>

---

Github Bug/Issue: Fixes #4012
