### PR TITLE
Use github's own jwt auth stuff instead of ours

### DIFF
--- a/changelog/issue-4074.md
+++ b/changelog/issue-4074.md
@@ -1,0 +1,5 @@
+audience: developers
+level: patch
+reference: issue 4074
+---
+We now use github's library for generating app jwt tokens instead of making our own tokens

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "@azure/ms-rest-azure-js": "^2.0.1",
     "@azure/ms-rest-js": "^2.0.5",
     "@azure/ms-rest-nodeauth": "^3.0.5",
+    "@octokit/auth-app": "^2.10.5",
     "@octokit/core": "^3.0.0",
     "@octokit/plugin-retry": "^3.0.4",
     "@octokit/plugin-throttling": "^3.3.3",
@@ -232,9 +233,14 @@
         "prPriority": 1
       },
       {
-        "updateTypes": ["minor", "patch"],
+        "updateTypes": [
+          "minor",
+          "patch"
+        ],
         "matchCurrentVersion": "!/^0/",
-        "paths": ["+(package.json)"],
+        "paths": [
+          "+(package.json)"
+        ],
         "automerge": true
       }
     ],

--- a/services/github/src/github-auth.js
+++ b/services/github/src/github-auth.js
@@ -1,5 +1,5 @@
-const jwt = require('jsonwebtoken');
 const { Octokit } = require('@octokit/rest');
+const { createAppAuth } = require("@octokit/auth-app");
 const { throttling } = require("@octokit/plugin-throttling");
 const { retry } = require("@octokit/plugin-retry");
 
@@ -50,14 +50,12 @@ module.exports = async ({ cfg, monitor }) => {
   };
 
   const getAppGithub = async () => {
-    const inteToken = jwt.sign(
-      { iss: cfg.github.credentials.appId },
-      privatePEM,
-      { algorithm: 'RS256', expiresIn: '1m' },
-    );
-
     return new PluggedOctokit({
-      auth: `bearer ${inteToken}`,
+      authStrategy: createAppAuth,
+      auth: {
+        appId: cfg.github.credentials.appId,
+        privateKey: privatePEM,
+      },
       ...OctokitOptions,
     });
   };

--- a/yarn.lock
+++ b/yarn.lock
@@ -270,6 +270,20 @@
   dependencies:
     methods "^1.1.2"
 
+"@octokit/auth-app@^2.10.5":
+  version "2.10.5"
+  resolved "https://registry.yarnpkg.com/@octokit/auth-app/-/auth-app-2.10.5.tgz#85d69cb96818f5da34bf0b81bb637d3675ad4e9a"
+  integrity sha512-6yXyjtcBWpuPYSdZN8z8IIjGSqkPmiJzdmCdod8at41ANB1FtaKbUIDL5+IkG+svv68NIYs+XORbhBRFXYB3bw==
+  dependencies:
+    "@octokit/request" "^5.4.11"
+    "@octokit/request-error" "^2.0.0"
+    "@octokit/types" "^6.0.3"
+    "@types/lru-cache" "^5.1.0"
+    deprecation "^2.3.1"
+    lru-cache "^6.0.0"
+    universal-github-app-jwt "^1.0.1"
+    universal-user-agent "^6.0.0"
+
 "@octokit/auth-token@^2.4.4":
   version "2.4.4"
   resolved "https://registry.yarnpkg.com/@octokit/auth-token/-/auth-token-2.4.4.tgz#ee31c69b01d0378c12fd3ffe406030f3d94d3b56"
@@ -357,7 +371,7 @@
     deprecation "^2.0.0"
     once "^1.4.0"
 
-"@octokit/request@^5.3.0", "@octokit/request@^5.4.12":
+"@octokit/request@^5.3.0", "@octokit/request@^5.4.11", "@octokit/request@^5.4.12":
   version "5.4.12"
   resolved "https://registry.yarnpkg.com/@octokit/request/-/request-5.4.12.tgz#b04826fa934670c56b135a81447be2c1723a2ffc"
   integrity sha512-MvWYdxengUWTGFpfpefBBpVmmEYfkwMoxonIB3sUGp5rhdgwjXL1ejo6JbgzG/QD9B/NYt/9cJX1pxXeSIUCkg==
@@ -747,6 +761,13 @@
   resolved "https://registry.yarnpkg.com/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.3.tgz#4ba8ddb720221f432e443bd5f9117fd22cfd4762"
   integrity sha512-sz7iLqvVUg1gIedBOvlkxPlc8/uVzyS5OwGz1cKjXzkl3FpL3al0crU8YGU1WoHkxn0Wxbw5tyi6hvzJKNzFsw==
 
+"@types/jsonwebtoken@^8.3.3":
+  version "8.5.0"
+  resolved "https://registry.yarnpkg.com/@types/jsonwebtoken/-/jsonwebtoken-8.5.0.tgz#2531d5e300803aa63279b232c014acf780c981c5"
+  integrity sha512-9bVao7LvyorRGZCw0VmH/dr7Og+NdjYSsKAxB43OQoComFbBgsEpoR9JW6+qSq/ogwVBg8GI2MfAlk4SYI4OLg==
+  dependencies:
+    "@types/node" "*"
+
 "@types/keygrip@*":
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/@types/keygrip/-/keygrip-1.0.2.tgz#513abfd256d7ad0bf1ee1873606317b33b1b2a72"
@@ -784,6 +805,11 @@
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/@types/long/-/long-4.0.1.tgz#459c65fa1867dafe6a8f322c4c51695663cc55e9"
   integrity sha512-5tXH6Bx/kNGd3MgffdmP4dy2Z+G4eaXw0SE81Tq3BNadtnMR5/ySMzX4SLEzHJzSmPNn4HIdpQsBvXMUykr58w==
+
+"@types/lru-cache@^5.1.0":
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/@types/lru-cache/-/lru-cache-5.1.0.tgz#57f228f2b80c046b4a1bd5cac031f81f207f4f03"
+  integrity sha512-RaE0B+14ToE4l6UqdarKPnXwVDuigfFv+5j9Dze/Nqr23yyuqdNvzcZi3xB+3Agvi5R4EOgAksfv3lXX4vBt9w==
 
 "@types/mime@*":
   version "2.0.3"
@@ -6652,6 +6678,14 @@ unicode-progress@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/unicode-progress/-/unicode-progress-1.0.0.tgz#b22db563e983fd39cd5f46c4d53e91861776e7bf"
   integrity sha512-c3eSB/iVvnc30doyOKokQ0xm5BOmbO5APWGL9P8/avVg00xFai+zZ5WDuzjpwJ7BKRbhmGoCMlEhTXJh9+rW/Q==
+
+universal-github-app-jwt@^1.0.1:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/universal-github-app-jwt/-/universal-github-app-jwt-1.1.0.tgz#0abaa876101cdf1d3e4c546be2768841c0c1b514"
+  integrity sha512-3b+ocAjjz4JTyqaOT+NNBd5BtTuvJTxWElIoeHSVelUV9J3Jp7avmQTdLKCaoqi/5Ox2o/q+VK19TJ233rVXVQ==
+  dependencies:
+    "@types/jsonwebtoken" "^8.3.3"
+    jsonwebtoken "^8.5.1"
 
 universal-user-agent@^6.0.0:
   version "6.0.0"


### PR DESCRIPTION
Github Bug/Issue: Fixes #4074 and Fixes #4054 

Still going to test this in my dev but this is their recommended way of doing things now. In particular in [their README](https://github.com/octokit/auth-app.js#implementation-details) they say

> When creating a JSON Web Token, it sets the "issued at time" (iat) to 30s in the past as we have seen people running situations where the GitHub API claimed the iat would be in future. It turned out the clocks on the different machine were not in sync.

Which sounds a lot like what we're seeing here. I'm honestly surprised we got away with this for so long. We could fix it directly ourselves but I figure this is a nicer long-term fix.
