### PR TITLE
remove redundant hawk requirement in devDependencies

### DIFF
--- a/clients/client-web/package.json
+++ b/clients/client-web/package.json
@@ -19,7 +19,6 @@
     "crypto-js": "^4.0.0",
     "dotenv": "^8.0.0",
     "eslint": "^7.0.0",
-    "hawk": "^9.0.0",
     "karma": "^5.2.3",
     "karma-cli": "^2.0.0",
     "karma-coverage": "^2.0.3",
@@ -34,7 +33,7 @@
   },
   "dependencies": {
     "crypto-js": "^4.0.0",
-    "hawk": "<9.0.1",
+    "hawk": "^9.0.0",
     "query-string": "^6.1.0",
     "taskcluster-lib-urls": "^13.0.0"
   }

--- a/clients/client-web/yarn.lock
+++ b/clients/client-web/yarn.lock
@@ -2034,7 +2034,7 @@ hash.js@^1.0.0, hash.js@^1.0.3:
     inherits "^2.0.3"
     minimalistic-assert "^1.0.1"
 
-hawk@<9.0.1:
+hawk@^9.0.0:
   version "9.0.0"
   resolved "https://registry.yarnpkg.com/hawk/-/hawk-9.0.0.tgz#406a1f2f92dd6948a50620e5cafd5491007764de"
   integrity sha512-xTkUIwwAI6d5//1ofvWCDM7YYAEAo/mFqhEW7S/m9+nLZqkOzSz8lTLKk6cHvJGax3UrbljfP8P+PFPybGcxZA==

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -6396,12 +6396,7 @@ inherits@2.0.3:
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
   integrity sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=
 
-ini@^1.3.4:
-  version "1.3.5"
-  resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.5.tgz#eee25f56db1c9ec6085e0c22778083f596abf927"
-  integrity sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==
-
-ini@^1.3.5:
+ini@^1.3.4, ini@^1.3.5:
   version "1.3.8"
   resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.8.tgz#a29da425b48806f34767a4efce397269af28432c"
   integrity sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==


### PR DESCRIPTION
Spotted this after a warning from `yarn`.