### PR TITLE
Use `base64.encodebytes` in Python 3.

### DIFF
--- a/changelog/FuHmLyHZS--UbHLntDvDRw.md
+++ b/changelog/FuHmLyHZS--UbHLntDvDRw.md
@@ -1,0 +1,4 @@
+audience: developers
+level: silent
+---
+Remove deprecated base64 API call for Python 3, which is removed in 3.9. Python client is now tested in Python 3.8 and 3.9

--- a/clients/client-py/taskcluster/utils.py
+++ b/clients/client-py/taskcluster/utils.py
@@ -172,7 +172,11 @@ def encodeStringForB64Header(s):
     """ HTTP Headers can't have new lines in them, let's """
     if isinstance(s, six.text_type):
         s = s.encode()
-    return base64.encodestring(s).strip().replace(b'\n', b'')
+    if six.PY3:
+        b64str = base64.encodebytes(s)
+    else:
+        b64str = base64.encodestring(s)
+    return b64str.strip().replace(b'\n', b'')
 
 
 def slugId():

--- a/clients/client-py/tox.ini
+++ b/clients/client-py/tox.ini
@@ -3,6 +3,8 @@ envlist =
     py27
     py36
     py37
+    py38
+    py39
 
 [testenv:py27]
 setenv =

--- a/taskcluster/ci/client/kind.yml
+++ b/taskcluster/ci/client/kind.yml
@@ -87,3 +87,25 @@ jobs:
           /sandbox/bin/pip install tox
       command: >-
           TOXENV=py37 /sandbox/bin/tox
+  py38:
+    description: python3.8 client tests
+    worker:
+      docker-image: python:3.8
+    run:
+      install: >-
+          cd clients/client-py &&
+          python3 -mvenv /sandbox &&
+          /sandbox/bin/pip install tox
+      command: >-
+          TOXENV=py38 /sandbox/bin/tox
+  py39:
+    description: python3.9 client tests
+    worker:
+      docker-image: python:3.9
+    run:
+      install: >-
+          cd clients/client-py &&
+          python3 -mvenv /sandbox &&
+          /sandbox/bin/pip install tox
+      command: >-
+          TOXENV=py39 /sandbox/bin/tox


### PR DESCRIPTION
This replaces `base64.encodestring` which was [deprecated in 3.1 and removed in 3.9](https://bugs.python.org/issue39351). This is the only change I had to make to run `tc-admin` with Python 3.9.
