### PR TITLE
Update object service enpoint names to be more descriptive

### DIFF
--- a/changelog/issue-3940.md
+++ b/changelog/issue-3940.md
@@ -1,0 +1,4 @@
+audience: general
+level: silent
+reference: issue 3940
+---

--- a/clients/client-go/tcobject/tcobject.go
+++ b/clients/client-go/tcobject/tcobject.go
@@ -125,8 +125,8 @@ func (object *Object) UploadObject(name string, payload *UploadObjectRequest) er
 // Required scopes:
 //   object:download:<name>
 //
-// See #downloadObject
-func (object *Object) DownloadObject(name string, payload *DownloadObjectRequest) (*DownloadObjectResponse, error) {
+// See #fetchObjectMetadata
+func (object *Object) FetchObjectMetadata(name string, payload *DownloadObjectRequest) (*DownloadObjectResponse, error) {
 	cd := tcclient.Client(*object)
 	responseObject, _, err := (&cd).APICall(payload, "PUT", "/download-object/"+url.QueryEscape(name), new(DownloadObjectResponse), nil)
 	return responseObject.(*DownloadObjectResponse), err
@@ -144,7 +144,7 @@ func (object *Object) DownloadObject(name string, payload *DownloadObjectRequest
 // This method is limited by the common capabilities of HTTP, so it may not be
 // the most efficient, resilient, or featureful way to retrieve an artifact.
 // Situations where such functionality is required should ues the
-// `downloadObject` API endpoint.
+// `fetchObjectMetadata` API endpoint.
 //
 // See [Simple Downloads](https://docs.taskcluster.net/docs/reference/platform/object/simple-downloads) for more detail.
 //

--- a/clients/client-py/taskcluster/generated/aio/object.py
+++ b/clients/client-py/taskcluster/generated/aio/object.py
@@ -44,7 +44,7 @@ class Object(AsyncBaseClient):
 
         return await self._makeApiCall(self.funcinfo["uploadObject"], *args, **kwargs)
 
-    async def downloadObject(self, *args, **kwargs):
+    async def fetchObjectMetadata(self, *args, **kwargs):
         """
         Download object data
 
@@ -57,7 +57,7 @@ class Object(AsyncBaseClient):
         This method is ``experimental``
         """
 
-        return await self._makeApiCall(self.funcinfo["downloadObject"], *args, **kwargs)
+        return await self._makeApiCall(self.funcinfo["fetchObjectMetadata"], *args, **kwargs)
 
     async def download(self, *args, **kwargs):
         """
@@ -73,7 +73,7 @@ class Object(AsyncBaseClient):
         This method is limited by the common capabilities of HTTP, so it may not be
         the most efficient, resilient, or featureful way to retrieve an artifact.
         Situations where such functionality is required should ues the
-        `downloadObject` API endpoint.
+        `fetchObjectMetadata` API endpoint.
 
         See [Simple Downloads](https://docs.taskcluster.net/docs/reference/platform/object/simple-downloads) for more detail.
 
@@ -90,11 +90,11 @@ class Object(AsyncBaseClient):
             'route': '/download/<name>',
             'stability': 'experimental',
         },
-        "downloadObject": {
+        "fetchObjectMetadata": {
             'args': ['name'],
             'input': 'v1/download-object-request.json#',
             'method': 'put',
-            'name': 'downloadObject',
+            'name': 'fetchObjectMetadata',
             'output': 'v1/download-object-response.json#',
             'route': '/download-object/<name>',
             'stability': 'experimental',

--- a/clients/client-py/taskcluster/generated/object.py
+++ b/clients/client-py/taskcluster/generated/object.py
@@ -44,7 +44,7 @@ class Object(BaseClient):
 
         return self._makeApiCall(self.funcinfo["uploadObject"], *args, **kwargs)
 
-    def downloadObject(self, *args, **kwargs):
+    def fetchObjectMetadata(self, *args, **kwargs):
         """
         Download object data
 
@@ -57,7 +57,7 @@ class Object(BaseClient):
         This method is ``experimental``
         """
 
-        return self._makeApiCall(self.funcinfo["downloadObject"], *args, **kwargs)
+        return self._makeApiCall(self.funcinfo["fetchObjectMetadata"], *args, **kwargs)
 
     def download(self, *args, **kwargs):
         """
@@ -73,7 +73,7 @@ class Object(BaseClient):
         This method is limited by the common capabilities of HTTP, so it may not be
         the most efficient, resilient, or featureful way to retrieve an artifact.
         Situations where such functionality is required should ues the
-        `downloadObject` API endpoint.
+        `fetchObjectMetadata` API endpoint.
 
         See [Simple Downloads](https://docs.taskcluster.net/docs/reference/platform/object/simple-downloads) for more detail.
 
@@ -90,11 +90,11 @@ class Object(BaseClient):
             'route': '/download/<name>',
             'stability': 'experimental',
         },
-        "downloadObject": {
+        "fetchObjectMetadata": {
             'args': ['name'],
             'input': 'v1/download-object-request.json#',
             'method': 'put',
-            'name': 'downloadObject',
+            'name': 'fetchObjectMetadata',
             'output': 'v1/download-object-response.json#',
             'route': '/download-object/<name>',
             'stability': 'experimental',

--- a/clients/client-shell/apis/services.go
+++ b/clients/client-shell/apis/services.go
@@ -942,7 +942,7 @@ var services = map[string]definitions.Service{
 				Input: "v1/upload-object-request.json#",
 			},
 			definitions.Entry{
-				Name:        "downloadObject",
+				Name:        "fetchObjectMetadata",
 				Title:       "Download object data",
 				Description: "Get information on how to download an object.  Call this endpoint with a list of acceptable\ndownload methods, and the server will select a method and return the corresponding payload.\nReturns a 406 error if none of the given download methods are available.\n\nSee [Download Methods](https://docs.taskcluster.net/docs/reference/platform/object/download-methods) for more detail.",
 				Stability:   "experimental",
@@ -957,7 +957,7 @@ var services = map[string]definitions.Service{
 			definitions.Entry{
 				Name:        "download",
 				Title:       "Get an object's data",
-				Description: "Get the data in an object directly.  This method does not return a JSON body, but\nredirects to a location that will serve the object content directly.\n\nURLs for this endpoint, perhaps with attached authentication (`?bewit=..`),\nare typically used for downloads of objects by simple HTTP clients such as\nweb browsers, curl, or wget.\n\nThis method is limited by the common capabilities of HTTP, so it may not be\nthe most efficient, resilient, or featureful way to retrieve an artifact.\nSituations where such functionality is required should ues the\n`downloadObject` API endpoint.\n\nSee [Simple Downloads](https://docs.taskcluster.net/docs/reference/platform/object/simple-downloads) for more detail.",
+				Description: "Get the data in an object directly.  This method does not return a JSON body, but\nredirects to a location that will serve the object content directly.\n\nURLs for this endpoint, perhaps with attached authentication (`?bewit=..`),\nare typically used for downloads of objects by simple HTTP clients such as\nweb browsers, curl, or wget.\n\nThis method is limited by the common capabilities of HTTP, so it may not be\nthe most efficient, resilient, or featureful way to retrieve an artifact.\nSituations where such functionality is required should ues the\n`fetchObjectMetadata` API endpoint.\n\nSee [Simple Downloads](https://docs.taskcluster.net/docs/reference/platform/object/simple-downloads) for more detail.",
 				Stability:   "experimental",
 				Method:      "get",
 				Route:       "/download/<name>",

--- a/clients/client-web/src/clients/Object.js
+++ b/clients/client-web/src/clients/Object.js
@@ -12,7 +12,7 @@ export default class Object extends Client {
     });
     this.ping.entry = {"args":[],"category":"Ping Server","method":"get","name":"ping","query":[],"route":"/ping","stability":"stable","type":"function"}; // eslint-disable-line
     this.uploadObject.entry = {"args":["name"],"category":"Upload","input":true,"method":"put","name":"uploadObject","query":[],"route":"/upload/<name>","scopes":"object:upload:<projectId>:<name>","stability":"experimental","type":"function"}; // eslint-disable-line
-    this.downloadObject.entry = {"args":["name"],"category":"Download","input":true,"method":"put","name":"downloadObject","output":true,"query":[],"route":"/download-object/<name>","scopes":"object:download:<name>","stability":"experimental","type":"function"}; // eslint-disable-line
+    this.fetchObjectMetadata.entry = {"args":["name"],"category":"Download","input":true,"method":"put","name":"fetchObjectMetadata","output":true,"query":[],"route":"/download-object/<name>","scopes":"object:download:<name>","stability":"experimental","type":"function"}; // eslint-disable-line
     this.download.entry = {"args":["name"],"category":"Download","method":"get","name":"download","query":[],"route":"/download/<name>","scopes":"object:download:<name>","stability":"experimental","type":"function"}; // eslint-disable-line
   }
   /* eslint-disable max-len */
@@ -38,10 +38,10 @@ export default class Object extends Client {
   // Returns a 406 error if none of the given download methods are available.
   // See [Download Methods](https://docs.taskcluster.net/docs/reference/platform/object/download-methods) for more detail.
   /* eslint-enable max-len */
-  downloadObject(...args) {
-    this.validate(this.downloadObject.entry, args);
+  fetchObjectMetadata(...args) {
+    this.validate(this.fetchObjectMetadata.entry, args);
 
-    return this.request(this.downloadObject.entry, args);
+    return this.request(this.fetchObjectMetadata.entry, args);
   }
   /* eslint-disable max-len */
   // Get the data in an object directly.  This method does not return a JSON body, but
@@ -52,7 +52,7 @@ export default class Object extends Client {
   // This method is limited by the common capabilities of HTTP, so it may not be
   // the most efficient, resilient, or featureful way to retrieve an artifact.
   // Situations where such functionality is required should ues the
-  // `downloadObject` API endpoint.
+  // `fetchObjectMetadata` API endpoint.
   // See [Simple Downloads](https://docs.taskcluster.net/docs/reference/platform/object/simple-downloads) for more detail.
   /* eslint-enable max-len */
   download(...args) {

--- a/clients/client/src/apis.js
+++ b/clients/client/src/apis.js
@@ -1673,7 +1673,7 @@ module.exports = {
           "description": "Get information on how to download an object.  Call this endpoint with a list of acceptable\ndownload methods, and the server will select a method and return the corresponding payload.\nReturns a 406 error if none of the given download methods are available.\n\nSee [Download Methods](https://docs.taskcluster.net/docs/reference/platform/object/download-methods) for more detail.",
           "input": "v1/download-object-request.json#",
           "method": "put",
-          "name": "downloadObject",
+          "name": "fetchObjectMetadata",
           "output": "v1/download-object-response.json#",
           "query": [
           ],
@@ -1688,7 +1688,7 @@ module.exports = {
             "name"
           ],
           "category": "Download",
-          "description": "Get the data in an object directly.  This method does not return a JSON body, but\nredirects to a location that will serve the object content directly.\n\nURLs for this endpoint, perhaps with attached authentication (`?bewit=..`),\nare typically used for downloads of objects by simple HTTP clients such as\nweb browsers, curl, or wget.\n\nThis method is limited by the common capabilities of HTTP, so it may not be\nthe most efficient, resilient, or featureful way to retrieve an artifact.\nSituations where such functionality is required should ues the\n`downloadObject` API endpoint.\n\nSee [Simple Downloads](https://docs.taskcluster.net/docs/reference/platform/object/simple-downloads) for more detail.",
+          "description": "Get the data in an object directly.  This method does not return a JSON body, but\nredirects to a location that will serve the object content directly.\n\nURLs for this endpoint, perhaps with attached authentication (`?bewit=..`),\nare typically used for downloads of objects by simple HTTP clients such as\nweb browsers, curl, or wget.\n\nThis method is limited by the common capabilities of HTTP, so it may not be\nthe most efficient, resilient, or featureful way to retrieve an artifact.\nSituations where such functionality is required should ues the\n`fetchObjectMetadata` API endpoint.\n\nSee [Simple Downloads](https://docs.taskcluster.net/docs/reference/platform/object/simple-downloads) for more detail.",
           "method": "get",
           "name": "download",
           "query": [

--- a/generated/references.json
+++ b/generated/references.json
@@ -15453,7 +15453,7 @@
           "description": "Get information on how to download an object.  Call this endpoint with a list of acceptable\ndownload methods, and the server will select a method and return the corresponding payload.\nReturns a 406 error if none of the given download methods are available.\n\nSee [Download Methods](https://docs.taskcluster.net/docs/reference/platform/object/download-methods) for more detail.",
           "input": "v1/download-object-request.json#",
           "method": "put",
-          "name": "downloadObject",
+          "name": "fetchObjectMetadata",
           "output": "v1/download-object-response.json#",
           "query": [
           ],
@@ -15468,7 +15468,7 @@
             "name"
           ],
           "category": "Download",
-          "description": "Get the data in an object directly.  This method does not return a JSON body, but\nredirects to a location that will serve the object content directly.\n\nURLs for this endpoint, perhaps with attached authentication (`?bewit=..`),\nare typically used for downloads of objects by simple HTTP clients such as\nweb browsers, curl, or wget.\n\nThis method is limited by the common capabilities of HTTP, so it may not be\nthe most efficient, resilient, or featureful way to retrieve an artifact.\nSituations where such functionality is required should ues the\n`downloadObject` API endpoint.\n\nSee [Simple Downloads](https://docs.taskcluster.net/docs/reference/platform/object/simple-downloads) for more detail.",
+          "description": "Get the data in an object directly.  This method does not return a JSON body, but\nredirects to a location that will serve the object content directly.\n\nURLs for this endpoint, perhaps with attached authentication (`?bewit=..`),\nare typically used for downloads of objects by simple HTTP clients such as\nweb browsers, curl, or wget.\n\nThis method is limited by the common capabilities of HTTP, so it may not be\nthe most efficient, resilient, or featureful way to retrieve an artifact.\nSituations where such functionality is required should ues the\n`fetchObjectMetadata` API endpoint.\n\nSee [Simple Downloads](https://docs.taskcluster.net/docs/reference/platform/object/simple-downloads) for more detail.",
           "method": "get",
           "name": "download",
           "query": [

--- a/services/object/src/api.js
+++ b/services/object/src/api.js
@@ -87,7 +87,7 @@ builder.declare({
 builder.declare({
   method: 'put',
   route: '/download-object/:name(*)', // name TBD; https://github.com/taskcluster/taskcluster/issues/3940
-  name: 'downloadObject',
+  name: 'fetchObjectMetadata',
   input: 'download-object-request.yml',
   output: 'download-object-response.yml',
   stability: 'experimental',
@@ -129,11 +129,11 @@ builder.declare({
   const params = acceptDownloadMethods[method];
 
   // apply middleware
-  if (!await this.middleware.downloadObjectRequest(req, res, object, method, params)) {
+  if (!await this.middleware.fetchObjectMetadataRequest(req, res, object, method, params)) {
     return;
   }
 
-  const result = await backend.downloadObject(object, method, params);
+  const result = await backend.fetchObjectMetadata(object, method, params);
 
   return res.reply(result);
 });
@@ -157,7 +157,7 @@ builder.declare({
     'This method is limited by the common capabilities of HTTP, so it may not be',
     'the most efficient, resilient, or featureful way to retrieve an artifact.',
     'Situations where such functionality is required should ues the',
-    '`downloadObject` API endpoint.',
+    '`fetchObjectMetadata` API endpoint.',
     '',
     'See [Simple Downloads](https://docs.taskcluster.net/docs/reference/platform/object/simple-downloads) for more detail.',
   ].join('\n'),
@@ -182,11 +182,11 @@ builder.declare({
   }
 
   // apply middleware
-  if (!await this.middleware.simpleDownloadRequest(req, res, object)) {
+  if (!await this.middleware.downloadRequest(req, res, object)) {
     return;
   }
 
-  const result = await backend.downloadObject(object, method, true);
+  const result = await backend.fetchObjectMetadata(object, method, true);
 
   return res.redirect(303, result.url);
 });

--- a/services/object/src/backends/aws.js
+++ b/services/object/src/backends/aws.js
@@ -34,7 +34,7 @@ class AwsBackend extends Backend {
     return ['simple'];
   }
 
-  async downloadObject(object, method, params) {
+  async fetchObjectMetadata(object, method, params) {
     switch (method){
       case 'simple': {
         let url;

--- a/services/object/src/backends/base.js
+++ b/services/object/src/backends/base.js
@@ -38,7 +38,7 @@ class Backend {
 
   /**
    * Return the backend-specific details required for a client to retrieve the
-   * object.  The result is returned directly from the `downloadObject` API
+   * object.  The result is returned directly from the `fetchObjectMetadata` API
    * endpoint.
    *
    * The `method` argument is the selected method, and `params` is the value
@@ -46,8 +46,8 @@ class Backend {
    *
    * Subclasses should override this.
    */
-  async downloadObject(object, method, params) {
-    throw new Error('downloadObject is not implemented for this backend');
+  async fetchObjectMetadata(object, method, params) {
+    throw new Error('fetchObjectMetadata is not implemented for this backend');
   }
 
   /**

--- a/services/object/src/backends/test.js
+++ b/services/object/src/backends/test.js
@@ -24,7 +24,7 @@ class TestBackend extends Backend {
     return ['simple', 'HTTP:GET'];
   }
 
-  async downloadObject(object, method, params) {
+  async fetchObjectMetadata(object, method, params) {
     assert(this.data.has(object.name));
     switch (method){
       case 'simple': {

--- a/services/object/src/middleware/base.js
+++ b/services/object/src/middleware/base.js
@@ -13,10 +13,10 @@ class Middleware {
   }
 
   /**
-   * Intercept the downloadObject API method.
+   * Intercept the fetchObjectMetadata API method.
    *
    * The object, method, and params arguments are those that would
-   * be passed to `backend.downloadObject`.
+   * be passed to `backend.fetchObjectMetadata`.
    *
    * If this method returns `false`, then the API implementation will
    * return immediately without further action; this indicates that the
@@ -26,14 +26,14 @@ class Middleware {
    *
    * Subclasses may override this method; the default does nothing.
    */
-  async downloadObjectRequest(req, res, object, method, params) {
+  async fetchObjectMetadataRequest(req, res, object, method, params) {
     return true;
   }
 
   /**
-   * Similar to downloadObjectRequest, but for the simple-download API.
+   * Similar to fetchObjectMetadataRequest, but for the simple-download API.
    */
-  async simpleDownloadRequest(req, res, object) {
+  async downloadRequest(req, res, object) {
     return true;
   }
 }

--- a/services/object/src/middleware/cdn.js
+++ b/services/object/src/middleware/cdn.js
@@ -12,7 +12,7 @@ class CdnMiddleware extends Middleware {
     this.baseUrl = config.baseUrl;
   }
 
-  async simpleDownloadRequest(req, res, object) {
+  async downloadRequest(req, res, object) {
     // If the regular expression matches, then redirect to the CDN URL instead of
     // allowing the backend URL to serve this request.
     if (this.regexp.test(object.name)) {

--- a/services/object/src/middleware/index.js
+++ b/services/object/src/middleware/index.js
@@ -33,15 +33,15 @@ class Middleware {
   }
 
   /**
-   * Intercept the downloadObject API method.  This calls the function
+   * Intercept the fetchObjectMetadata API method.  This calls the function
    * of the same name on all middleware objects, in order, until one
    * returns false.
    *
    * See the middleware base class for more details.
    */
-  async downloadObjectRequest(req, res, object, method, params) {
+  async fetchObjectMetadataRequest(req, res, object, method, params) {
     for (let mw of this.instances) {
-      if (!await mw.downloadObjectRequest(req, res, object, method, params)) {
+      if (!await mw.fetchObjectMetadataRequest(req, res, object, method, params)) {
         return false;
       }
     }
@@ -50,11 +50,11 @@ class Middleware {
   }
 
   /**
-   * Similar to downloadObjectRequest, but for the simple-download API.
+   * Similar to fetchObjectMetadataRequest, but for the simple-download API.
    */
-  async simpleDownloadRequest(req, res, object) {
+  async downloadRequest(req, res, object) {
     for (let mw of this.instances) {
-      if (!await mw.simpleDownloadRequest(req, res, object)) {
+      if (!await mw.downloadRequest(req, res, object)) {
         return false;
       }
     }

--- a/services/object/src/middleware/test.js
+++ b/services/object/src/middleware/test.js
@@ -6,7 +6,7 @@ class TestMiddleware extends Middleware {
     this.config = options.config;
   }
 
-  async downloadObjectRequest(req, res, object, method, params) {
+  async fetchObjectMetadataRequest(req, res, object, method, params) {
     switch (object.name) {
       case 'dl/intercept': {
         res.reply({
@@ -20,7 +20,7 @@ class TestMiddleware extends Middleware {
     }
   }
 
-  async simpleDownloadRequest(req, res, object) {
+  async downloadRequest(req, res, object) {
     switch (object.name) {
       case 'simple/intercept': {
         res.redirect(303, 'http://intercepted');

--- a/services/object/test/api_test.js
+++ b/services/object/test/api_test.js
@@ -114,8 +114,8 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
     });
   });
 
-  suite('downloadObject method', function() {
-    test('downloadObject for simple method succeeds', async function() {
+  suite('fetchObjectMetadata method', function() {
+    test('fetchObjectMetadata for simple method succeeds', async function() {
       const data = crypto.randomBytes(128);
       await helper.apiClient.uploadObject('public/foo', {
         projectId: 'x',
@@ -123,7 +123,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
         uploadId: taskcluster.slugid(),
         expires: fromNow('1 year'),
       });
-      const res = await helper.apiClient.downloadObject('public/foo', {
+      const res = await helper.apiClient.fetchObjectMetadata('public/foo', {
         acceptDownloadMethods: { 'simple': true },
       });
       assert.deepEqual(res, {
@@ -132,7 +132,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       });
     });
 
-    test('downloadObject for a supported method succeeds', async function() {
+    test('fetchObjectMetadata for a supported method succeeds', async function() {
       const data = crypto.randomBytes(128);
       await helper.apiClient.uploadObject('public/foo', {
         projectId: 'x',
@@ -140,7 +140,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
         uploadId: taskcluster.slugid(),
         expires: fromNow('1 year'),
       });
-      const res = await helper.apiClient.downloadObject('public/foo', {
+      const res = await helper.apiClient.fetchObjectMetadata('public/foo', {
         acceptDownloadMethods: { 'HTTP:GET': true },
       });
       assert.deepEqual(res, {
@@ -151,7 +151,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       });
     });
 
-    test('downloadObject handles middleware', async function() {
+    test('fetchObjectMetadata handles middleware', async function() {
       const data = crypto.randomBytes(128);
       await helper.apiClient.uploadObject('dl/intercept', {
         projectId: 'x',
@@ -160,7 +160,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
         expires: fromNow('1 year'),
       });
 
-      const res = await helper.apiClient.downloadObject('dl/intercept', {
+      const res = await helper.apiClient.fetchObjectMetadata('dl/intercept', {
         acceptDownloadMethods: { 'simple': true },
       });
 
@@ -170,7 +170,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       });
     });
 
-    test('downloadObject for an unsupported method returns 406', async function() {
+    test('fetchObjectMetadata for an unsupported method returns 406', async function() {
       const data = crypto.randomBytes(128);
       await helper.apiClient.uploadObject('has/no/methods', {
         projectId: 'x',
@@ -179,7 +179,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
         expires: fromNow('1 year'),
       });
       await assert.rejects(
-        () => helper.apiClient.downloadObject('has/no/methods', {
+        () => helper.apiClient.fetchObjectMetadata('has/no/methods', {
           acceptDownloadMethods: { simple: true, 'HTTP:GET': true },
         }),
         err => err.code === 'NoMatchingMethod' && err.statusCode === 406,

--- a/services/object/test/helper/simple-download.js
+++ b/services/object/test/helper/simple-download.js
@@ -52,7 +52,7 @@ exports.testSimpleDownloadMethod = ({
       assert(methods.includes('simple'));
 
       // call the backend
-      const { method, url } = await backend.downloadObject(object, 'simple', true);
+      const { method, url } = await backend.fetchObjectMetadata(object, 'simple', true);
       assert.equal(method, 'simple');
       checkUrl({ name, url });
 

--- a/services/object/test/middleware_test.js
+++ b/services/object/test/middleware_test.js
@@ -4,29 +4,29 @@ const testing = require('taskcluster-lib-testing');
 
 helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
   helper.withMiddleware(mock, skipping, [
-    { 'middlewareType': 'test', downloadObject: { intercept: 'dl' } },
-    { 'middlewareType': 'test', simpleDownload: { intercept: 'simple' } },
+    { 'middlewareType': 'test', fetchObjectMetadata: { intercept: 'dl' } },
+    { 'middlewareType': 'test', download: { intercept: 'simple' } },
   ]);
 
-  test('calls middleware for downloadObjectRequest', async function() {
+  test('calls middleware for fetchObjectMetadataRequest', async function() {
     const middleware = await helper.load('middleware');
 
     let reply;
     const res = { reply: x => reply = x };
     const object = { name: 'dl/intercept' };
 
-    assert(!await middleware.downloadObjectRequest({}, res, object, 'meth', {}));
+    assert(!await middleware.fetchObjectMetadataRequest({}, res, object, 'meth', {}));
     assert.deepEqual(reply, { method: 'simple', url: 'http://intercepted' });
   });
 
-  test('calls middleware for simpleDownloadRequest', async function() {
+  test('calls middleware for downloadRequest', async function() {
     const middleware = await helper.load('middleware');
 
     let redirect;
     const res = { redirect: (x, y) => redirect = [x, y] };
     const object = { name: 'simple/intercept' };
 
-    assert(!await middleware.simpleDownloadRequest({}, res, object));
+    assert(!await middleware.downloadRequest({}, res, object));
     assert.deepEqual(redirect, [303, 'http://intercepted']);
   });
 });


### PR DESCRIPTION
Silent changelog just because this is an "unreleased" service. I can add a real one if that's not a good assumption.

Github Bug/Issue: Fixes #3940
