### PR TITLE
Omit renovate information from changelogs except in release

### DIFF
--- a/changelog/BBFlJRFnRuyYVf-i9Ukg-g.md
+++ b/changelog/BBFlJRFnRuyYVf-i9Ukg-g.md
@@ -1,0 +1,3 @@
+audience: general
+level: silent
+---

--- a/infrastructure/tooling/src/changelog/index.js
+++ b/infrastructure/tooling/src/changelog/index.js
@@ -47,17 +47,24 @@ const strcmp = (a, b) => {
 
 /**
  * Representation of the as-yet-unreleased changelog snippets
+ *
+ * options: {
+ *   skipUpdates: if true, don't load renovate updates
+ * }
  */
 class ChangeLog {
-  constructor() {
+  constructor(options = {}) {
     this.loaded = false;
     this.snippets = [];
     this.updates = [];
+    this.options = options;
   }
 
   async load() {
     await this.loadSnippets();
-    await this.loadUpdates();
+    if (!this.options.skipUpdates) {
+      await this.loadUpdates();
+    }
   }
 
   async loadSnippets() {
@@ -364,7 +371,7 @@ const add = async (options) => {
 };
 
 const show = async (options) => {
-  const cl = new ChangeLog();
+  const cl = new ChangeLog({ skipUpdates: true });
   await cl.load();
   console.log(`${chalk.bold.cyan('Level:')}        ${cl.level()}`);
   console.log(`${chalk.bold.cyan('Next Version:')} ${await cl.nextVersion()}`);
@@ -373,7 +380,7 @@ const show = async (options) => {
 };
 
 const check = async (options) => {
-  const cl = new ChangeLog();
+  const cl = new ChangeLog({ skipUpdates: true });
   await cl.load();
   console.log(chalk.bold.green('Changelog OK'));
 


### PR DESCRIPTION
CI runs use shallow clones, within which the latest release tag may not
be available, so generation of the renovate updates doesn't work.  We
don't need them in that context, so just skip it.  It's also distracting
in `yarn changelog:show`, so omitted there.

This showed up in #4109.