### PR TITLE
add site-specific details for notify

### DIFF
--- a/changelog/issue-3739.md
+++ b/changelog/issue-3739.md
@@ -1,0 +1,4 @@
+audience: general
+level: silent
+reference: issue 3739
+---

--- a/ui/docs/manual/deploying/ui.mdx
+++ b/ui/docs/manual/deploying/ui.mdx
@@ -24,6 +24,11 @@ ui:
     github_app_url: ..
     # A workerPoolId that most people have access to, for use in the documentation tutorial
     tutorial_worker_pool_id: ..
+    # user-visible usernames for notify
+    notify_email_sender: ..
+    notify_matrix_bot_name: ..
+    notify_slack_bot_name: ..
+
 ```
 
 These values are also used occasionally elsewhere in the UI.

--- a/ui/docs/manual/using/task-notifications.mdx
+++ b/ui/docs/manual/using/task-notifications.mdx
@@ -4,6 +4,8 @@ title: Task Notifications
 order: 80
 ---
 
+import SiteSpecific from 'taskcluster-ui/components/SiteSpecific';
+
 There are two ways to have Taskcluster send notifications on your behalf.
 
 The first is by specifying certain routes in the task definition, for example:
@@ -31,3 +33,15 @@ async function notify() {
     await notify.matrix({roomId: 'whDRjjSmICCgrhFHsQ:mozilla.org', body: 'the build is stil running, hang tight'});
 }
 ```
+
+<SiteSpecific>
+This deployment sends notification emails from `%notify_email_sender%`.
+</SiteSpecific>
+
+<SiteSpecific>
+This deployment uses a Slack bot with username `%notify_slack_bot_name%`.
+</SiteSpecific>
+
+<SiteSpecific>
+This deployment uses a Matrix bot with username `%notify_matrix_bot_name%`.
+</SiteSpecific>

--- a/ui/docs/reference/core/notify/usage.mdx
+++ b/ui/docs/reference/core/notify/usage.mdx
@@ -12,11 +12,23 @@ There are four types of notifications and four types of filters possible on thes
 
 __Email:__ We can you both nicely formatted or plain text emails depending on which email client you want to use. You can send to any email address, so long as you have the correct scopes (we'll discuss scopes later).
 
+<SiteSpecific>
+This deployment sends notification emails from `%notify_email_sender%`.
+</SiteSpecific>
+
 __Pulse:__ We can also send a Pulse message that is documented [on this page](/docs/reference/core/notify/exchanges). The message is  pretty much just the status of the task.
 
 __Matrix:__ If a deployment of taskcluster is configured with credentials for a Matrix instance, it can post to Matrix rooms. *Note: The taskcluster user must be invited to a room before it can post there*
 
+<SiteSpecific>
+This deployment uses a Matrix bot with username `%notify_matrix_bot_name%`.
+</SiteSpecific>
+
 __Slack:__ If a Taskcluster deployment has Slack credentials, you can post to it likewise. *Note: Either the Slack App must be invited to channels, or granted `chat:write.public` and be posting to a public channel.*
+
+<SiteSpecific>
+This deployment uses a Slack bot with username `%notify_slack_bot_name%`.
+</SiteSpecific>
 
 ### Filters
 

--- a/ui/src/components/SiteSpecific/index.jsx
+++ b/ui/src/components/SiteSpecific/index.jsx
@@ -26,6 +26,9 @@ const SITE_SPECIFIC_VARS = new Set([
   // See that file for descriptions of each variable.
   'github_app_url',
   'tutorial_worker_pool_id',
+  'notify_email_sender',
+  'notify_matrix_bot_name',
+  'notify_slack_bot_name',
 ]);
 // apply a simple templating language here, translating
 // %IDENTIFIER% into a lookup of that identifier, and


### PR DESCRIPTION
This should help users find the bots.

Note that the github bot is already adequately documented with SiteSpecific -- there's no need for users to know its github username.

Github Bug/Issue: Fixes #3739.
