### PR TITLE
continue to look at other worker pools after one has an invalid providerId

### DIFF
--- a/changelog/A4XwOeGIT8eVqiGOQP-yeQ.md
+++ b/changelog/A4XwOeGIT8eVqiGOQP-yeQ.md
@@ -1,0 +1,4 @@
+audience: worker-deployers
+level: patch
+---
+This version fixes an error where a worker pool with an invalid providerId would cause all worker provisioning to cease.

--- a/services/worker-manager/src/provisioner.js
+++ b/services/worker-manager/src/provisioner.js
@@ -164,7 +164,7 @@ class Provisioner {
         if (!provider) {
           this.monitor.warning(
             `Worker pool ${workerPool.workerPoolId} has unknown providerId ${workerPool.providerId}`);
-          return;
+          continue;
         }
 
         if (!poolsByProvider.has(providerId)) {


### PR DESCRIPTION
I suspect this was introduced when refactoring a `providers.forEach(..)` into a `for` loop.  It caused an issue for me in my dev env.