### PR TITLE
support signing URLs synchronously when not using credentialAgent

### DIFF
--- a/changelog/NOQU5PRYRqm7B93a5wiiPw.md
+++ b/changelog/NOQU5PRYRqm7B93a5wiiPw.md
@@ -1,0 +1,4 @@
+audience: users
+level: patch
+---
+The `taskcluster-client-web` library client classes now have a `buildSignedUrlSync` method.

--- a/clients/client-web/README.md
+++ b/clients/client-web/README.md
@@ -211,6 +211,7 @@ queue
 ```
 
 **NOTE**: This method returns a promise, unlike in [taskcluster-client](https://yarnpkg.com/en/package/taskcluster-client).
+If you are not using a credentials agent, but have passed `credentials` to the client constructor, you can use the synchronous `buildSignedUrlSync` instead.
 
 Please note that the `payload` parameter cannot be encoded in the signed URL
 and must be sent as request payload. This should work fine, just remember that

--- a/clients/client-web/src/Client.js
+++ b/clients/client-web/src/Client.js
@@ -201,6 +201,20 @@ export default class Client {
   }
 
   async buildSignedUrl(method, ...args) {
+    const credentials = this.options.credentialAgent
+      ? await this.options.credentialAgent.getCredentials()
+      : this.options.credentials;
+    return this._buildSignedUrlSync(method, credentials, args);
+  }
+
+  buildSignedUrlSync(method, ...args) {
+    if (this.options.credentialAgent) {
+      throw new Error('buildSignedUrlSync cannot be used with a credentialAgent');
+    }
+    return this._buildSignedUrlSync(method, this.options.credentials, args);
+  }
+
+  _buildSignedUrlSync(method, credentials, args) {
     if (!method) {
       throw new Error('buildSignedUrl is missing required `method` argument');
     }
@@ -234,9 +248,6 @@ export default class Client {
     }
 
     const url = this.buildUrl(method, ...args);
-    const credentials = this.options.credentialAgent
-      ? await this.options.credentialAgent.getCredentials()
-      : this.options.credentials;
 
     if (!credentials) {
       throw new Error('buildSignedUrl missing required credentials');

--- a/clients/client-web/test/buildUrl_test.js
+++ b/clients/client-web/test/buildUrl_test.js
@@ -49,6 +49,11 @@ describe('Building URLs', function() {
       .to.eventually.match(signed('https://tc-tests\\.example\\.com/api/fake/v1/get-test'));
   });
 
+  it('should build signed URL synchronously', () => {
+    return expect(client.buildSignedUrlSync(client.get))
+      .to.match(signed('https://tc-tests\\.example\\.com/api/fake/v1/get-test'));
+  });
+
   it('should build URL with parameter', () => {
     expect(client.buildUrl(client.param, 'test'))
       .to.equal('https://tc-tests.example.com/api/fake/v1/url-param/test/list');


### PR DESCRIPTION
This is broken out from #4111.  I think this will need to land first and be released so that the `ui/` directory can require `taskcluster-client-web` from the package registry, rather than using the local copy.