### PR TITLE
UI: Handle dependencies that have expired

### DIFF
--- a/changelog/issue-3983.md
+++ b/changelog/issue-3983.md
@@ -1,0 +1,5 @@
+audience: users
+level: patch
+reference: issue 3983
+---
+The UI will no longer fail when viewing a task with dependencies that have expired.

--- a/services/web-server/src/graphql/Tasks.graphql
+++ b/services/web-server/src/graphql/Tasks.graphql
@@ -299,6 +299,15 @@ enum TaskSubscriptions {
   tasksException
 }
 
+# A dependent task may be expired, in which case it will only have a taskId.
+type DependentTask {
+  taskId: ID!
+
+  # status, if this task still exists
+  status(taskId: ID = taskId): TaskStatus
+  metadata: TaskMetadata
+}
+
 extend type Query {
   # Definition of a task that can be scheduled.
   # _A task definition may have been modified by the queue._
@@ -307,7 +316,7 @@ extend type Query {
   task(taskId: ID!): Task
 
   # Query the dependent tasks of this task via its dependencies' task IDs.
-  dependentTasks(taskId: ID!): [Task]
+  dependentTasks(taskId: ID!): [DependentTask]
 
   # List tasks that depend on the given `taskId`.
   dependents(taskId: ID!, connection: PageConnection, filter: JSON): TasksConnection

--- a/ui/src/components/TaskDetailsCard/index.jsx
+++ b/ui/src/components/TaskDetailsCard/index.jsx
@@ -109,7 +109,8 @@ export default class TaskDetailsCard extends Component {
      */
     dependentTasks: arrayOf(
       shape({
-        taskId: string,
+        taskId: string.isRequired,
+        // note that status and metadata may be missing
         status: shape({
           state: string,
         }),
@@ -319,16 +320,20 @@ export default class TaskDetailsCard extends Component {
                     </ListItem>
                     <List disablePadding>
                       {dependentTasks.map(task => (
+                        // note that the task might not exist, if it has
+                        // expired
                         <Link key={task.taskId} to={`/tasks/${task.taskId}`}>
                           <ListItem
                             button
                             className={classes.listItemButton}
                             title="View Task">
-                            <StatusLabel state={task.status.state} />
+                            <StatusLabel
+                              state={task.status?.state || 'EXPIRED'}
+                            />
                             <ListItemText
                               primaryTypographyProps={{ variant: 'body2' }}
                               className={classes.listItemText}
-                              primary={task.metadata.name}
+                              primary={task.metadata?.name || task.taskId}
                             />
                             <LinkIcon />
                           </ListItem>

--- a/ui/src/utils/labels.js
+++ b/ui/src/utils/labels.js
@@ -34,6 +34,7 @@ export default {
   MULTI_KEY: 'error',
   AND: 'info',
   OR: 'info',
+  EXPIRED: 'warning',
   SUCCESS: 'success',
   ERROR: 'error',
   EMERG: 'error',


### PR DESCRIPTION
This introduces a new DependentTask type that may have a null status and
metadata, and adjusts the UI to handle that case.

Github Bug/Issue: Fixes #3983