### PR TITLE
Include a card with links to reference docs

### DIFF
--- a/changelog/issue-2398.md
+++ b/changelog/issue-2398.md
@@ -1,0 +1,4 @@
+audience: general
+level: silent
+reference: issue 2398
+---

--- a/ui/docs/reference/core/hooks/README.mdx
+++ b/ui/docs/reference/core/hooks/README.mdx
@@ -1,3 +1,7 @@
+import ReferenceLinks from 'taskcluster-ui/components/ReferenceLinks';
+
+<ReferenceLinks api exchanges logs />
+
 # Hooks Service
 
 This service creates tasks in response to events.

--- a/ui/docs/reference/core/index/README.mdx
+++ b/ui/docs/reference/core/index/README.mdx
@@ -1,3 +1,7 @@
+import ReferenceLinks from 'taskcluster-ui/components/ReferenceLinks';
+
+<ReferenceLinks api logs />
+
 # Index Service
 
 The index service provides a service that indexes successfully completed tasks.

--- a/ui/docs/reference/core/notify/README.mdx
+++ b/ui/docs/reference/core/notify/README.mdx
@@ -1,4 +1,7 @@
+import ReferenceLinks from 'taskcluster-ui/components/ReferenceLinks';
 import Warning from 'taskcluster-ui/views/Documentation/components/Warning';
+
+<ReferenceLinks api exchanges logs />
 
 # Notify Service
 

--- a/ui/docs/reference/core/purge-cache/README.mdx
+++ b/ui/docs/reference/core/purge-cache/README.mdx
@@ -1,3 +1,7 @@
+import ReferenceLinks from 'taskcluster-ui/components/ReferenceLinks';
+
+<ReferenceLinks api logs />
+
 # Purge-Cache Service
 
 Many taskcluster workers implements some generic form cache folders.

--- a/ui/docs/reference/core/secrets/README.mdx
+++ b/ui/docs/reference/core/secrets/README.mdx
@@ -1,3 +1,7 @@
+import ReferenceLinks from 'taskcluster-ui/components/ReferenceLinks';
+
+<ReferenceLinks api logs />
+
 # Secrets Service
 
 The secrets service provides a simple key/value store for small bits of secret data.

--- a/ui/docs/reference/core/web-server/README.mdx
+++ b/ui/docs/reference/core/web-server/README.mdx
@@ -1,3 +1,7 @@
+import ReferenceLinks from 'taskcluster-ui/components/ReferenceLinks';
+
+<ReferenceLinks logs />
+
 # Web Server
 
 The "web-server" service provides the backend for the Taskcluster UI.

--- a/ui/docs/reference/core/worker-manager/README.mdx
+++ b/ui/docs/reference/core/worker-manager/README.mdx
@@ -1,3 +1,7 @@
+import ReferenceLinks from 'taskcluster-ui/components/ReferenceLinks';
+
+<ReferenceLinks api logs />
+
 # Worker Manager
 
 The worker manager service manages workers, including interacting with cloud services to create new workers on demand.

--- a/ui/docs/reference/integrations/github/README.mdx
+++ b/ui/docs/reference/integrations/github/README.mdx
@@ -1,3 +1,7 @@
+import ReferenceLinks from 'taskcluster-ui/components/ReferenceLinks';
+
+<ReferenceLinks api exchanges logs />
+
 # Github Service
 
 import Warning from 'taskcluster-ui/views/Documentation/components/Warning';

--- a/ui/docs/reference/platform/auth/README.mdx
+++ b/ui/docs/reference/platform/auth/README.mdx
@@ -1,3 +1,7 @@
+import ReferenceLinks from 'taskcluster-ui/components/ReferenceLinks';
+
+<ReferenceLinks api exchanges logs />
+
 # Auth Service
 
 The auth service manages permissions and credentials in a Taskcluster deployment.

--- a/ui/docs/reference/platform/object/README.mdx
+++ b/ui/docs/reference/platform/object/README.mdx
@@ -1,3 +1,7 @@
+import ReferenceLinks from 'taskcluster-ui/components/ReferenceLinks';
+
+<ReferenceLinks api logs />
+
 # Object Service
 
 The object service handles storage of large quantities of data.

--- a/ui/docs/reference/platform/queue/README.mdx
+++ b/ui/docs/reference/platform/queue/README.mdx
@@ -1,3 +1,7 @@
+import ReferenceLinks from 'taskcluster-ui/components/ReferenceLinks';
+
+<ReferenceLinks api exchanges logs />
+
 # Queue Service
 
 This is the central queue coordinating execution of tasks in the Taskcluster setup.

--- a/ui/docs/reference/workers/built-in-workers/README.mdx
+++ b/ui/docs/reference/workers/built-in-workers/README.mdx
@@ -1,3 +1,7 @@
+import ReferenceLinks from 'taskcluster-ui/components/ReferenceLinks';
+
+<ReferenceLinks logs />
+
 # Built-In Workers Service
 
 This service implements the `built-in/succeed` and `built-in/fail` workerTypes, which simply succeed or fail immediately.

--- a/ui/src/components/ReferenceLinks/index.jsx
+++ b/ui/src/components/ReferenceLinks/index.jsx
@@ -1,0 +1,53 @@
+import React from 'react';
+import { boolean } from 'prop-types';
+import { withStyles } from '@material-ui/core/styles';
+import Card from '@material-ui/core/Card';
+import Typography from '@material-ui/core/Typography';
+import Link from '../../utils/Link';
+
+const styles = withStyles(theme => ({
+  card: {
+    float: 'right',
+    padding: theme.spacing(3),
+    margin: theme.spacing(2),
+  },
+  unorderedList: {
+    ...theme.mixins.unorderedList,
+  },
+}));
+// A card containing links to the api, log, and exchange references.  This is
+// intended only for use in docs/reference/<tier>/<service>/README.mdx, as it
+// uses relative links that are only valid from that document.
+const ReferenceLinks = ({ classes, api, exchanges, logs }) => {
+  return (
+    <Card raised className={classes.card}>
+      <Typography variant="h6">Reference Links</Typography>
+      <ul className={classes.unorderedList}>
+        {api && (
+          <Typography variant="body2" component="li">
+            <Link to="./api">REST API</Link>
+          </Typography>
+        )}
+        {exchanges && (
+          <Typography variant="body2" component="li">
+            <Link to="./exchanges">Pulse Exchanges</Link>
+          </Typography>
+        )}
+        {logs && (
+          <Typography variant="body2" component="li">
+            <Link to="./logs">Log Messages</Link>
+          </Typography>
+        )}
+      </ul>
+    </Card>
+  );
+};
+
+ReferenceLinks.propTypes = {
+  // each property is true if a link to that reference should be included
+  api: boolean,
+  exchanges: boolean,
+  logs: boolean,
+};
+
+export default styles(ReferenceLinks);


### PR DESCRIPTION
This should make the API specs, etc. a bit more discoverable.

Github Bug/Issue: Fixes #2398