### PR TITLE
tc-proxy: avoid using ServeMux, as it mangles URLs

### DIFF
--- a/changelog/issue-2721.md
+++ b/changelog/issue-2721.md
@@ -1,0 +1,5 @@
+audience: users
+level: patch
+reference: issue 2721
+---
+Taskcluster-proxy now correctly proxies "non-canonical" URLs, such as those containing `//` or urlencoded values.

--- a/tools/taskcluster-proxy/main.go
+++ b/tools/taskcluster-proxy/main.go
@@ -48,9 +48,8 @@ func main() {
 		log.Fatalf("%v", err)
 	}
 
-	mux := setupMux(&routes)
 	server := &http.Server{
-		Handler: mux,
+		Handler: &routes,
 		// Only listen on loopback interface to reduce attack surface. If we later
 		// wish to make this service available over the network, we could add
 		// configuration settings for this, but for now, let's lock it down.
@@ -61,15 +60,6 @@ func main() {
 	if startError != nil {
 		log.Fatal(startError)
 	}
-}
-
-func setupMux(routes *Routes) *http.ServeMux {
-	mux := http.NewServeMux()
-	mux.HandleFunc("/bewit", routes.BewitHandler)
-	mux.HandleFunc("/credentials", routes.CredentialsHandler)
-	mux.HandleFunc("/api/", routes.APIHandler)
-	mux.HandleFunc("/", routes.RootHandler)
-	return mux
 }
 
 // Fetch a task by TaskID.  This is broken out to allow testing.

--- a/tools/taskcluster-proxy/routes.go
+++ b/tools/taskcluster-proxy/routes.go
@@ -79,6 +79,22 @@ func (routes *Routes) setHeaders(res http.ResponseWriter) {
 	}
 }
 
+// Implement the Handler interface, dispatching requests to the various
+// *Handler methods.  Note that we cannot use ServeMux for this as it mangles
+// URLs and sends redircts.
+func (routes *Routes) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	url := r.URL.String()
+	if strings.HasPrefix(url, "/bewit") {
+		routes.BewitHandler(w, r)
+	} else if strings.HasPrefix(url, "/credentials") {
+		routes.CredentialsHandler(w, r)
+	} else if strings.HasPrefix(url, "/api") {
+		routes.APIHandler(w, r)
+	} else {
+		routes.RootHandler(w, r)
+	}
+}
+
 // BewitHandler is the http handler that provides Hawk signed urls (bewits)
 func (routes *Routes) BewitHandler(res http.ResponseWriter, req *http.Request) {
 	// Using ReadAll could be sketchy here since we are reading unbounded data

--- a/tools/taskcluster-proxy/routes_test.go
+++ b/tools/taskcluster-proxy/routes_test.go
@@ -43,7 +43,7 @@ func TestHttpRedirects(t *testing.T) {
 
 	// see how it gets handled..
 	res := httptest.NewRecorder()
-	routes.RootHandler(res, req)
+	routes.ServeHTTP(res, req)
 
 	// it should have returned the 303 directly, along with its body
 	assert.Equal(t, 303, res.Code)
@@ -71,7 +71,6 @@ func TestNonCanonicalUrls(t *testing.T) {
 			},
 		},
 	)
-	mux := setupMux(&routes)
 
 	// create a fake request to the proxy
 	req, err := http.NewRequest(
@@ -83,11 +82,11 @@ func TestNonCanonicalUrls(t *testing.T) {
 
 	// see how it gets handled..
 	res := httptest.NewRecorder()
-	mux.ServeHTTP(res, req)
+	routes.ServeHTTP(res, req)
 
 	// it should have returned the path with `/api` but otherwise unchanged
 	assert.Equal(t, 200, res.Code)
 	respBody, err := ioutil.ReadAll(res.Body)
 	assert.NoError(t, err)
-	assert.Equal(t, "/api/queue/v1/double//slash/encode1%2F/encode2%252F/encode3%25252F\n", string(respBody))
+	assert.Equal(t, "/api/queue/v1/double//slash/encode1%2F/encode2%252F/encode3%25252F", string(respBody))
 }

--- a/tools/taskcluster-proxy/routes_test.go
+++ b/tools/taskcluster-proxy/routes_test.go
@@ -36,7 +36,7 @@ func TestHttpRedirects(t *testing.T) {
 	// create a fake request to the proxy
 	req, err := http.NewRequest(
 		"GET",
-		"http://localhost:60024/api/redirector/v1/redirect-me",
+		"http://localhost:60024/redirector/v1/redirect-me",
 		new(bytes.Buffer),
 	)
 	assert.NoError(t, err)
@@ -50,4 +50,44 @@ func TestHttpRedirects(t *testing.T) {
 	respBody, err := ioutil.ReadAll(res.Body)
 	assert.NoError(t, err)
 	assert.Equal(t, "{}\n", string(respBody))
+}
+
+func TestNonCanonicalUrls(t *testing.T) {
+	// set up an upstream server that returns its path
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(200)
+		fmt.Fprintf(w, "%s", r.URL)
+	}))
+	defer ts.Close()
+
+	// set up a routes object to test, using the test server as RootURL
+	routes := NewRoutes(
+		tcclient.Client{
+			Authenticate: true,
+			RootURL:      ts.URL,
+			Credentials: &tcclient.Credentials{
+				ClientID:    "some-client",
+				AccessToken: "doesn't-matter",
+			},
+		},
+	)
+	mux := setupMux(&routes)
+
+	// create a fake request to the proxy
+	req, err := http.NewRequest(
+		"GET",
+		"http://localhost:60024/queue/v1/double//slash/encode1%2F/encode2%252F/encode3%25252F",
+		new(bytes.Buffer),
+	)
+	assert.NoError(t, err)
+
+	// see how it gets handled..
+	res := httptest.NewRecorder()
+	mux.ServeHTTP(res, req)
+
+	// it should have returned the path with `/api` but otherwise unchanged
+	assert.Equal(t, 200, res.Code)
+	respBody, err := ioutil.ReadAll(res.Body)
+	assert.NoError(t, err)
+	assert.Equal(t, "/api/queue/v1/double//slash/encode1%2F/encode2%252F/encode3%25252F\n", string(respBody))
 }


### PR DESCRIPTION
Github Bug/Issue: Fixes #2721
