### PR TITLE
Fix reregistrationTimeout

### DIFF
--- a/changelog/issue-4125-1.md
+++ b/changelog/issue-4125-1.md
@@ -1,0 +1,5 @@
+audience: worker-deployers
+level: patch
+reference: issue 4125
+---
+Workerpools now correctly understand the `reregistrationTimeout` option.

--- a/services/worker-manager/src/api.js
+++ b/services/worker-manager/src/api.js
@@ -773,8 +773,10 @@ builder.declare({
   }
 
   // defaults to 96 hours if reregistrationTimeout is not defined
+  // make sure to turn milliseconds into seconds here since we store it in millieconds
+  // after the first interpretation.
   const { terminateAfter } = Provider.interpretLifecycle({ lifecycle: {
-    reregistrationTimeout: worker.providerData && worker.providerData.reregistrationTimeout,
+    reregistrationTimeout: worker.providerData && (worker.providerData.reregistrationTimeout / 1000),
   } });
   const expires = new Date(terminateAfter);
 


### PR DESCRIPTION
This should make this field interpreted correctly. I hope to never multiply or divide a time
by 1000 again. This whole bit of w-m could use a re-work at some point.
Github Bug/Issue: Fixes #4125
