### PR TITLE
Update sift

### DIFF
--- a/changelog/issue-4199.md
+++ b/changelog/issue-4199.md
@@ -1,0 +1,5 @@
+audience: users
+level: patch
+reference: issue 4199
+---
+The `sift` dependency has been updated again, to a version that does not cause #4061.

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "sanitize-html": "^2.0.0",
     "sentry-api": "^0.2.0",
     "serialize-error": "^7.0.0",
-    "sift": "8.x",
+    "sift": "^13.5.0",
     "slugid": "^2.0.0",
     "subscriptions-transport-ws": "^0.9.7",
     "superagent": "^6.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5978,10 +5978,10 @@ shebang-regex@^3.0.0:
   resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-3.0.0.tgz#ae16f1644d873ecad843b0307b143362d4c42172"
   integrity sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==
 
-sift@8.x:
-  version "8.5.1"
-  resolved "https://registry.yarnpkg.com/sift/-/sift-8.5.1.tgz#22a29e1a3332e8f8d372dc5999f5cc3093778fe8"
-  integrity sha512-um2rEdXrc4YcRMzIliuip4i2o92mJONh5W1VD9vJlm1e0apVqMK4P2ZUijz8BIe1/oYLWmXwXaKFM+fOaO3Ysg==
+sift@^13.5.0:
+  version "13.5.0"
+  resolved "https://registry.yarnpkg.com/sift/-/sift-13.5.0.tgz#0f46fd0b2432bd516307d2c32bff3b142a8ab530"
+  integrity sha512-YoS8hmXbmJcf1Gde5bR7+pq69+Nvfv5eHTyv4B00YxJAejTEfzvamG8LHzb0jAFFciMkY05K7GG3P7n/gm0+gg==
 
 signal-exit@^3.0.2, signal-exit@^3.0.3:
   version "3.0.3"


### PR DESCRIPTION
Version ^13.4.0 does not suffer from the bug that caused #4061.

Fixes #4199.