### PR TITLE
Wait 7 days before proposing node upgrades

### DIFF
--- a/changelog/issue-4209.md
+++ b/changelog/issue-4209.md
@@ -1,0 +1,4 @@
+audience: general
+level: silent
+reference: issue 4209
+---

--- a/package.json
+++ b/package.json
@@ -215,6 +215,12 @@
     "packageRules": [
       {
         "packagePatterns": [
+          "node"
+        ],
+        "stabilityDays": 7
+      },
+      {
+        "packagePatterns": [
           "^googleapis$",
           "^aws-sdk$",
           "^golang.org/x/.*"


### PR DESCRIPTION
We depend on upstream docker images that lag the official Node releases.
