### PR TITLE
Allow taskQueueId in task definitions

### DIFF
--- a/changelog/issue-3580.md
+++ b/changelog/issue-3580.md
@@ -1,0 +1,7 @@
+audience: users
+level: minor
+reference: issue 3580
+---
+The queue service API responses will now include the taskQueueId, which will match provisionerId/workerType,
+which are also returned. Also, it is now possible to create tasks supplying a taskQueueId instead of the
+separate provisionerId and workerType identifiers.

--- a/clients/client-go/tcqueue/types.go
+++ b/clients/client-go/tcqueue/types.go
@@ -168,6 +168,11 @@ type (
 		// Syntax:     ^[a-zA-Z0-9-_]{1,38}$
 		ProvisionerID string `json:"provisionerId"`
 
+		// Unique identifier for a task queue
+		//
+		// Syntax:     ^[a-zA-Z0-9-_]{1,38}/[a-z]([-a-z0-9]{0,36}[a-z0-9])?$
+		TaskQueueID string `json:"taskQueueId"`
+
 		// Unique identifier for a worker-type within a specific provisioner
 		//
 		// Syntax:     ^[a-z]([-a-z0-9]{0,36}[a-z0-9])?$

--- a/clients/client-go/tcqueue/types.go
+++ b/clients/client-go/tcqueue/types.go
@@ -163,7 +163,9 @@ type (
 		PendingTasks int64 `json:"pendingTasks"`
 
 		// Unique identifier for a provisioner, that can supply specified
-		// `workerType`
+		// `workerType`. Deprecation is planned for this property as it
+		// will be replaced, together with `workerType`, by the new
+		// identifier `taskQueueId`.
 		//
 		// Syntax:     ^[a-zA-Z0-9-_]{1,38}$
 		ProvisionerID string `json:"provisionerId"`
@@ -173,7 +175,10 @@ type (
 		// Syntax:     ^[a-zA-Z0-9-_]{1,38}/[a-z]([-a-z0-9]{0,36}[a-z0-9])?$
 		TaskQueueID string `json:"taskQueueId"`
 
-		// Unique identifier for a worker-type within a specific provisioner
+		// Unique identifier for a worker-type within a specific
+		// provisioner. Deprecation is planned for this property as it will
+		// be replaced, together with `provisionerId`, by the new
+		// identifier `taskQueueId`.
 		//
 		// Syntax:     ^[a-z]([-a-z0-9]{0,36}[a-z0-9])?$
 		WorkerType string `json:"workerType"`
@@ -406,7 +411,9 @@ type (
 		LastDateActive tcclient.Time `json:"lastDateActive"`
 
 		// Unique identifier for a provisioner, that can supply specified
-		// `workerType`
+		// `workerType`. Deprecation is planned for this property as it
+		// will be replaced, together with `workerType`, by the new
+		// identifier `taskQueueId`.
 		//
 		// Syntax:     ^[a-zA-Z0-9-_]{1,38}$
 		ProvisionerID string `json:"provisionerId"`
@@ -467,7 +474,9 @@ type (
 		LastDateActive tcclient.Time `json:"lastDateActive"`
 
 		// Unique identifier for a provisioner, that can supply specified
-		// `workerType`
+		// `workerType`. Deprecation is planned for this property as it
+		// will be replaced, together with `workerType`, by the new
+		// identifier `taskQueueId`.
 		//
 		// Syntax:     ^[a-zA-Z0-9-_]{1,38}$
 		ProvisionerID string `json:"provisionerId"`
@@ -914,7 +923,9 @@ type (
 		Priority string `json:"priority,omitempty"`
 
 		// Unique identifier for a provisioner, that can supply specified
-		// `workerType`
+		// `workerType`. Deprecation is planned for this property as it
+		// will be replaced, together with `workerType`, by the new
+		// identifier `taskQueueId`.
 		//
 		// Syntax:     ^[a-zA-Z0-9-_]{1,38}$
 		ProvisionerID string `json:"provisionerId"`
@@ -1006,7 +1017,10 @@ type (
 		// Syntax:     ^[A-Za-z0-9_-]{8}[Q-T][A-Za-z0-9_-][CGKOSWaeimquy26-][A-Za-z0-9_-]{10}[AQgw]$
 		TaskGroupID string `json:"taskGroupId,omitempty"`
 
-		// Unique identifier for a worker-type within a specific provisioner
+		// Unique identifier for a worker-type within a specific
+		// provisioner. Deprecation is planned for this property as it will
+		// be replaced, together with `provisionerId`, by the new
+		// identifier `taskQueueId`.
 		//
 		// Syntax:     ^[a-z]([-a-z0-9]{0,36}[a-z0-9])?$
 		WorkerType string `json:"workerType"`
@@ -1085,7 +1099,9 @@ type (
 		Priority string `json:"priority"`
 
 		// Unique identifier for a provisioner, that can supply specified
-		// `workerType`
+		// `workerType`. Deprecation is planned for this property as it
+		// will be replaced, together with `workerType`, by the new
+		// identifier `taskQueueId`.
 		//
 		// Syntax:     ^[a-zA-Z0-9-_]{1,38}$
 		ProvisionerID string `json:"provisionerId"`
@@ -1182,7 +1198,10 @@ type (
 		// Syntax:     ^[a-zA-Z0-9-_]{1,38}/[a-z]([-a-z0-9]{0,36}[a-z0-9])?$
 		TaskQueueID string `json:"taskQueueId"`
 
-		// Unique identifier for a worker-type within a specific provisioner
+		// Unique identifier for a worker-type within a specific
+		// provisioner. Deprecation is planned for this property as it will
+		// be replaced, together with `provisionerId`, by the new
+		// identifier `taskQueueId`.
 		//
 		// Syntax:     ^[a-z]([-a-z0-9]{0,36}[a-z0-9])?$
 		WorkerType string `json:"workerType"`
@@ -1290,7 +1309,7 @@ type (
 		//   * "deprecated"
 		Stability string `json:"stability"`
 
-		// Unique identifier for a task-queue
+		// Unique identifier for a task queue
 		//
 		// Syntax:     ^[a-zA-Z0-9-_]{1,38}/[a-z]([-a-z0-9]{0,36}[a-z0-9])?$
 		TaskQueueID string `json:"taskQueueId"`
@@ -1415,7 +1434,9 @@ type (
 		Expires tcclient.Time `json:"expires"`
 
 		// Unique identifier for a provisioner, that can supply specified
-		// `workerType`
+		// `workerType`. Deprecation is planned for this property as it
+		// will be replaced, together with `workerType`, by the new
+		// identifier `taskQueueId`.
 		//
 		// Syntax:     ^[a-zA-Z0-9-_]{1,38}$
 		ProvisionerID string `json:"provisionerId"`
@@ -1479,7 +1500,10 @@ type (
 		// Syntax:     ^[a-zA-Z0-9-_]{1,38}/[a-z]([-a-z0-9]{0,36}[a-z0-9])?$
 		TaskQueueID string `json:"taskQueueId"`
 
-		// Unique identifier for a worker-type within a specific provisioner
+		// Unique identifier for a worker-type within a specific
+		// provisioner. Deprecation is planned for this property as it will
+		// be replaced, together with `provisionerId`, by the new
+		// identifier `taskQueueId`.
 		//
 		// Syntax:     ^[a-z]([-a-z0-9]{0,36}[a-z0-9])?$
 		WorkerType string `json:"workerType"`
@@ -1602,7 +1626,9 @@ type (
 		FirstClaim tcclient.Time `json:"firstClaim"`
 
 		// Unique identifier for a provisioner, that can supply specified
-		// `workerType`
+		// `workerType`. Deprecation is planned for this property as it
+		// will be replaced, together with `workerType`, by the new
+		// identifier `taskQueueId`.
 		//
 		// Syntax:     ^[a-zA-Z0-9-_]{1,38}$
 		ProvisionerID string `json:"provisionerId"`
@@ -1637,7 +1663,10 @@ type (
 		// Max length: 38
 		WorkerID string `json:"workerId"`
 
-		// Unique identifier for a worker-type within a specific provisioner
+		// Unique identifier for a worker-type within a specific
+		// provisioner. Deprecation is planned for this property as it will
+		// be replaced, together with `provisionerId`, by the new
+		// identifier `taskQueueId`.
 		//
 		// Syntax:     ^[a-z]([-a-z0-9]{0,36}[a-z0-9])?$
 		WorkerType string `json:"workerType"`
@@ -1656,7 +1685,9 @@ type (
 		LastDateActive tcclient.Time `json:"lastDateActive"`
 
 		// Unique identifier for a provisioner, that can supply specified
-		// `workerType`
+		// `workerType`. Deprecation is planned for this property as it
+		// will be replaced, together with `workerType`, by the new
+		// identifier `taskQueueId`.
 		//
 		// Syntax:     ^[a-zA-Z0-9-_]{1,38}$
 		ProvisionerID string `json:"provisionerId"`
@@ -1677,7 +1708,10 @@ type (
 		// Syntax:     ^[a-zA-Z0-9-_]{1,38}/[a-z]([-a-z0-9]{0,36}[a-z0-9])?$
 		TaskQueueID string `json:"taskQueueId"`
 
-		// Unique identifier for a worker-type within a specific provisioner
+		// Unique identifier for a worker-type within a specific
+		// provisioner. Deprecation is planned for this property as it will
+		// be replaced, together with `provisionerId`, by the new
+		// identifier `taskQueueId`.
 		//
 		// Syntax:     ^[a-z]([-a-z0-9]{0,36}[a-z0-9])?$
 		WorkerType string `json:"workerType"`
@@ -1790,7 +1824,9 @@ type (
 		LastDateActive tcclient.Time `json:"lastDateActive"`
 
 		// Unique identifier for a provisioner, that can supply specified
-		// `workerType`
+		// `workerType`. Deprecation is planned for this property as it
+		// will be replaced, together with `workerType`, by the new
+		// identifier `taskQueueId`.
 		//
 		// Syntax:     ^[a-zA-Z0-9-_]{1,38}$
 		ProvisionerID string `json:"provisionerId"`
@@ -1811,7 +1847,10 @@ type (
 		// Syntax:     ^[a-zA-Z0-9-_]{1,38}/[a-z]([-a-z0-9]{0,36}[a-z0-9])?$
 		TaskQueueID string `json:"taskQueueId"`
 
-		// Unique identifier for a worker-type within a specific provisioner
+		// Unique identifier for a worker-type within a specific
+		// provisioner. Deprecation is planned for this property as it will
+		// be replaced, together with `provisionerId`, by the new
+		// identifier `taskQueueId`.
 		//
 		// Syntax:     ^[a-z]([-a-z0-9]{0,36}[a-z0-9])?$
 		WorkerType string `json:"workerType"`

--- a/clients/client-go/tcqueue/types.go
+++ b/clients/client-go/tcqueue/types.go
@@ -1469,6 +1469,11 @@ type (
 		// Syntax:     ^[A-Za-z0-9_-]{8}[Q-T][A-Za-z0-9_-][CGKOSWaeimquy26-][A-Za-z0-9_-]{10}[AQgw]$
 		TaskID string `json:"taskId"`
 
+		// Unique identifier for a task queue
+		//
+		// Syntax:     ^[a-zA-Z0-9-_]{1,38}/[a-z]([-a-z0-9]{0,36}[a-z0-9])?$
+		TaskQueueID string `json:"taskQueueId"`
+
 		// Unique identifier for a worker-type within a specific provisioner
 		//
 		// Syntax:     ^[a-z]([-a-z0-9]{0,36}[a-z0-9])?$

--- a/clients/client-go/tcqueue/types.go
+++ b/clients/client-go/tcqueue/types.go
@@ -1172,6 +1172,11 @@ type (
 		// Syntax:     ^[A-Za-z0-9_-]{8}[Q-T][A-Za-z0-9_-][CGKOSWaeimquy26-][A-Za-z0-9_-]{10}[AQgw]$
 		TaskGroupID string `json:"taskGroupId"`
 
+		// Unique identifier for a task queue
+		//
+		// Syntax:     ^[a-zA-Z0-9-_]{1,38}/[a-z]([-a-z0-9]{0,36}[a-z0-9])?$
+		TaskQueueID string `json:"taskQueueId"`
+
 		// Unique identifier for a worker-type within a specific provisioner
 		//
 		// Syntax:     ^[a-z]([-a-z0-9]{0,36}[a-z0-9])?$
@@ -1601,6 +1606,11 @@ type (
 		// List of 20 most recent tasks claimed by the worker.
 		RecentTasks []TaskRun `json:"recentTasks"`
 
+		// Unique identifier for a task queue
+		//
+		// Syntax:     ^[a-zA-Z0-9-_]{1,38}/[a-z]([-a-z0-9]{0,36}[a-z0-9])?$
+		TaskQueueID string `json:"taskQueueId,omitempty"`
+
 		// Identifier for group that worker who executes this run is a part of,
 		// this identifier is mainly used for efficient routing.
 		//
@@ -1651,6 +1661,11 @@ type (
 		//   * "stable"
 		//   * "deprecated"
 		Stability string `json:"stability"`
+
+		// Unique identifier for a task queue
+		//
+		// Syntax:     ^[a-zA-Z0-9-_]{1,38}/[a-z]([-a-z0-9]{0,36}[a-z0-9])?$
+		TaskQueueID string `json:"taskQueueId"`
 
 		// Unique identifier for a worker-type within a specific provisioner
 		//
@@ -1780,6 +1795,11 @@ type (
 		//   * "stable"
 		//   * "deprecated"
 		Stability string `json:"stability"`
+
+		// Unique identifier for a task queue
+		//
+		// Syntax:     ^[a-zA-Z0-9-_]{1,38}/[a-z]([-a-z0-9]{0,36}[a-z0-9])?$
+		TaskQueueID string `json:"taskQueueId"`
 
 		// Unique identifier for a worker-type within a specific provisioner
 		//

--- a/clients/client-go/tcqueue/types.go
+++ b/clients/client-go/tcqueue/types.go
@@ -851,7 +851,14 @@ type (
 	}
 
 	// Definition of a task that can be scheduled
-	TaskDefinitionRequest struct {
+	//
+	// Any of:
+	//   * TaskDefinitionRequest1
+	//   * TaskDefinitionRequest2
+	TaskDefinitionRequest json.RawMessage
+
+	// Definition of a task that can be scheduled
+	TaskDefinitionRequest1 struct {
 
 		// Creation time of task
 		Created tcclient.Time `json:"created"`
@@ -1016,6 +1023,192 @@ type (
 		//
 		// Syntax:     ^[A-Za-z0-9_-]{8}[Q-T][A-Za-z0-9_-][CGKOSWaeimquy26-][A-Za-z0-9_-]{10}[AQgw]$
 		TaskGroupID string `json:"taskGroupId,omitempty"`
+
+		// Unique identifier for a task queue
+		//
+		// Syntax:     ^[a-zA-Z0-9-_]{1,38}/[a-z]([-a-z0-9]{0,36}[a-z0-9])?$
+		TaskQueueID string `json:"taskQueueId"`
+
+		// Unique identifier for a worker-type within a specific
+		// provisioner. Deprecation is planned for this property as it will
+		// be replaced, together with `provisionerId`, by the new
+		// identifier `taskQueueId`.
+		//
+		// Syntax:     ^[a-z]([-a-z0-9]{0,36}[a-z0-9])?$
+		WorkerType string `json:"workerType"`
+	}
+
+	// Definition of a task that can be scheduled
+	TaskDefinitionRequest2 struct {
+
+		// Creation time of task
+		Created tcclient.Time `json:"created"`
+
+		// Deadline of the task, by which this task must be complete. `pending` and
+		// `running` runs are resolved as **exception** if not resolved by other means
+		// before the deadline. After the deadline, a task is immutable. Note,
+		// deadline cannot be more than 5 days into the future
+		Deadline tcclient.Time `json:"deadline"`
+
+		// List of dependent tasks. These must either be _completed_ or _resolved_
+		// before this task is scheduled. See `requires` for semantics.
+		//
+		// Default:    []
+		//
+		// Array items:
+		// The `taskId` of a task that must be resolved before this task is
+		// scheduled.
+		//
+		// Syntax:     ^[A-Za-z0-9_-]{8}[Q-T][A-Za-z0-9_-][CGKOSWaeimquy26-][A-Za-z0-9_-]{10}[AQgw]$
+		Dependencies []string `json:"dependencies,omitempty"`
+
+		// Task expiration, time at which task definition and status is deleted.
+		// Notice that all artifacts for the task must have an expiration that is no
+		// later than this. If this property isn't it will be set to `deadline`
+		// plus one year (this default may change).
+		Expires tcclient.Time `json:"expires,omitempty"`
+
+		// Object with properties that can hold any kind of extra data that should be
+		// associated with the task. This can be data for the task which doesn't
+		// fit into `payload`, or it can supplementary data for use in services
+		// listening for events from this task. For example this could be details to
+		// display on dashboard, or information for indexing the task. Please, try
+		// to put all related information under one property, so `extra` data keys
+		// don't conflict.  **Warning**, do not stuff large data-sets in here --
+		// task definitions should not take-up multiple MiBs.
+		//
+		// Default:    {}
+		//
+		// Additional properties allowed
+		Extra json.RawMessage `json:"extra,omitempty"`
+
+		// Required task metadata
+		Metadata TaskMetadata `json:"metadata"`
+
+		// Task-specific payload following worker-specific format.
+		// Refer to the documentation for the worker implementing
+		// `<provisionerId>/<workerType>` for details.
+		//
+		// Additional properties allowed
+		Payload json.RawMessage `json:"payload"`
+
+		// Priority of task. This defaults to `lowest` and the scope
+		// `queue:create-task:<priority>/<provisionerId>/<workerType>` is required
+		// to define a task with `<priority>`. The `normal` priority is treated as
+		// `lowest`.
+		//
+		// Possible values:
+		//   * "highest"
+		//   * "very-high"
+		//   * "high"
+		//   * "medium"
+		//   * "low"
+		//   * "very-low"
+		//   * "lowest"
+		//   * "normal"
+		//
+		// Default:    "lowest"
+		Priority string `json:"priority,omitempty"`
+
+		// Unique identifier for a provisioner, that can supply specified
+		// `workerType`. Deprecation is planned for this property as it
+		// will be replaced, together with `workerType`, by the new
+		// identifier `taskQueueId`.
+		//
+		// Syntax:     ^[a-zA-Z0-9-_]{1,38}$
+		ProvisionerID string `json:"provisionerId"`
+
+		// The tasks relation to its dependencies. This property specifies the
+		// semantics of the `task.dependencies` property.
+		// If `all-completed` is given the task will be scheduled when all
+		// dependencies are resolved _completed_ (successful resolution).
+		// If `all-resolved` is given the task will be scheduled when all dependencies
+		// have been resolved, regardless of what their resolution is.
+		//
+		// Possible values:
+		//   * "all-completed"
+		//   * "all-resolved"
+		//
+		// Default:    "all-completed"
+		Requires string `json:"requires,omitempty"`
+
+		// Number of times to retry the task in case of infrastructure issues.
+		// An _infrastructure issue_ is a worker node that crashes or is shutdown,
+		// these events are to be expected.
+		//
+		// Default:    5
+		// Mininum:    0
+		// Maximum:    49
+		Retries int64 `json:"retries,omitempty"`
+
+		// List of task-specific routes. Pulse messages about the task will be CC'ed to
+		// `route.<value>` for each `<value>` in this array.
+		//
+		// This array has a maximum size due to a limitation of the AMQP protocol,
+		// over which Pulse runs.  All routes must fit in the same "frame" of this
+		// protocol, and the frames have a fixed maximum size (typically 128k).
+		//
+		// Default:    []
+		//
+		// Array items:
+		// A task specific route.
+		//
+		// Min length: 1
+		// Max length: 249
+		Routes []string `json:"routes,omitempty"`
+
+		// All tasks in a task group must have the same `schedulerId`. This is used for several purposes:
+		//
+		// * it can represent the entity that created the task;
+		// * it can limit addition of new tasks to a task group: the caller of
+		//     `createTask` must have a scope related to the `schedulerId` of the task
+		//     group;
+		// * it controls who can manipulate tasks, again by requiring
+		//     `schedulerId`-related scopes; and
+		// * it appears in the routing key for Pulse messages about the task.
+		//
+		// Default:    "-"
+		// Syntax:     ^([a-zA-Z0-9-_]*)$
+		// Min length: 1
+		// Max length: 38
+		SchedulerID string `json:"schedulerId,omitempty"`
+
+		// List of scopes that the task is authorized to use during its execution.
+		//
+		// Array items:
+		// A single scope. A scope must be composed of
+		// printable ASCII characters and spaces.  Scopes ending in more than
+		// one `*` character are forbidden.
+		//
+		// Syntax:     ^[ -~]*$
+		Scopes []string `json:"scopes,omitempty"`
+
+		// Arbitrary key-value tags (only strings limited to 4k). These can be used
+		// to attach informal metadata to a task. Use this for informal tags that
+		// tasks can be classified by. You can also think of strings here as
+		// candidates for formal metadata. Something like
+		// `purpose: 'build' || 'test'` is a good example.
+		//
+		// Default:    {}
+		//
+		// Map entries:
+		// Max length: 4096
+		Tags map[string]string `json:"tags,omitempty"`
+
+		// Identifier for a group of tasks scheduled together with this task.
+		// Generally, all tasks related to a single event such as a version-control
+		// push or a nightly build have the same `taskGroupId`.  This property
+		// defaults to `taskId` if it isn't specified.  Tasks with `taskId` equal to
+		// the `taskGroupId` are, [by convention](/docs/manual/using/task-graph),
+		// decision tasks.
+		//
+		// Syntax:     ^[A-Za-z0-9_-]{8}[Q-T][A-Za-z0-9_-][CGKOSWaeimquy26-][A-Za-z0-9_-]{10}[AQgw]$
+		TaskGroupID string `json:"taskGroupId,omitempty"`
+
+		// Unique identifier for a task queue
+		//
+		// Syntax:     ^[a-zA-Z0-9-_]{1,38}/[a-z]([-a-z0-9]{0,36}[a-z0-9])?$
+		TaskQueueID string `json:"taskQueueId"`
 
 		// Unique identifier for a worker-type within a specific
 		// provisioner. Deprecation is planned for this property as it will
@@ -1884,6 +2077,22 @@ func (this *PostArtifactResponse) MarshalJSON() ([]byte, error) {
 func (this *PostArtifactResponse) UnmarshalJSON(data []byte) error {
 	if this == nil {
 		return errors.New("PostArtifactResponse: UnmarshalJSON on nil pointer")
+	}
+	*this = append((*this)[0:0], data...)
+	return nil
+}
+
+// MarshalJSON calls json.RawMessage method of the same name. Required since
+// TaskDefinitionRequest is of type json.RawMessage...
+func (this *TaskDefinitionRequest) MarshalJSON() ([]byte, error) {
+	x := json.RawMessage(*this)
+	return (&x).MarshalJSON()
+}
+
+// UnmarshalJSON is a copy of the json.RawMessage implementation.
+func (this *TaskDefinitionRequest) UnmarshalJSON(data []byte) error {
+	if this == nil {
+		return errors.New("TaskDefinitionRequest: UnmarshalJSON on nil pointer")
 	}
 	*this = append((*this)[0:0], data...)
 	return nil

--- a/clients/client-go/tcqueue/types.go
+++ b/clients/client-go/tcqueue/types.go
@@ -851,14 +851,7 @@ type (
 	}
 
 	// Definition of a task that can be scheduled
-	//
-	// Any of:
-	//   * TaskDefinitionRequest1
-	//   * TaskDefinitionRequest2
-	TaskDefinitionRequest json.RawMessage
-
-	// Definition of a task that can be scheduled
-	TaskDefinitionRequest1 struct {
+	TaskDefinitionRequest struct {
 
 		// Creation time of task
 		Created tcclient.Time `json:"created"`
@@ -935,7 +928,7 @@ type (
 		// identifier `taskQueueId`.
 		//
 		// Syntax:     ^[a-zA-Z0-9-_]{1,38}$
-		ProvisionerID string `json:"provisionerId"`
+		ProvisionerID string `json:"provisionerId,omitempty"`
 
 		// The tasks relation to its dependencies. This property specifies the
 		// semantics of the `task.dependencies` property.
@@ -1027,7 +1020,7 @@ type (
 		// Unique identifier for a task queue
 		//
 		// Syntax:     ^[a-zA-Z0-9-_]{1,38}/[a-z]([-a-z0-9]{0,36}[a-z0-9])?$
-		TaskQueueID string `json:"taskQueueId"`
+		TaskQueueID string `json:"taskQueueId,omitempty"`
 
 		// Unique identifier for a worker-type within a specific
 		// provisioner. Deprecation is planned for this property as it will
@@ -1035,188 +1028,7 @@ type (
 		// identifier `taskQueueId`.
 		//
 		// Syntax:     ^[a-z]([-a-z0-9]{0,36}[a-z0-9])?$
-		WorkerType string `json:"workerType"`
-	}
-
-	// Definition of a task that can be scheduled
-	TaskDefinitionRequest2 struct {
-
-		// Creation time of task
-		Created tcclient.Time `json:"created"`
-
-		// Deadline of the task, by which this task must be complete. `pending` and
-		// `running` runs are resolved as **exception** if not resolved by other means
-		// before the deadline. After the deadline, a task is immutable. Note,
-		// deadline cannot be more than 5 days into the future
-		Deadline tcclient.Time `json:"deadline"`
-
-		// List of dependent tasks. These must either be _completed_ or _resolved_
-		// before this task is scheduled. See `requires` for semantics.
-		//
-		// Default:    []
-		//
-		// Array items:
-		// The `taskId` of a task that must be resolved before this task is
-		// scheduled.
-		//
-		// Syntax:     ^[A-Za-z0-9_-]{8}[Q-T][A-Za-z0-9_-][CGKOSWaeimquy26-][A-Za-z0-9_-]{10}[AQgw]$
-		Dependencies []string `json:"dependencies,omitempty"`
-
-		// Task expiration, time at which task definition and status is deleted.
-		// Notice that all artifacts for the task must have an expiration that is no
-		// later than this. If this property isn't it will be set to `deadline`
-		// plus one year (this default may change).
-		Expires tcclient.Time `json:"expires,omitempty"`
-
-		// Object with properties that can hold any kind of extra data that should be
-		// associated with the task. This can be data for the task which doesn't
-		// fit into `payload`, or it can supplementary data for use in services
-		// listening for events from this task. For example this could be details to
-		// display on dashboard, or information for indexing the task. Please, try
-		// to put all related information under one property, so `extra` data keys
-		// don't conflict.  **Warning**, do not stuff large data-sets in here --
-		// task definitions should not take-up multiple MiBs.
-		//
-		// Default:    {}
-		//
-		// Additional properties allowed
-		Extra json.RawMessage `json:"extra,omitempty"`
-
-		// Required task metadata
-		Metadata TaskMetadata `json:"metadata"`
-
-		// Task-specific payload following worker-specific format.
-		// Refer to the documentation for the worker implementing
-		// `<provisionerId>/<workerType>` for details.
-		//
-		// Additional properties allowed
-		Payload json.RawMessage `json:"payload"`
-
-		// Priority of task. This defaults to `lowest` and the scope
-		// `queue:create-task:<priority>/<provisionerId>/<workerType>` is required
-		// to define a task with `<priority>`. The `normal` priority is treated as
-		// `lowest`.
-		//
-		// Possible values:
-		//   * "highest"
-		//   * "very-high"
-		//   * "high"
-		//   * "medium"
-		//   * "low"
-		//   * "very-low"
-		//   * "lowest"
-		//   * "normal"
-		//
-		// Default:    "lowest"
-		Priority string `json:"priority,omitempty"`
-
-		// Unique identifier for a provisioner, that can supply specified
-		// `workerType`. Deprecation is planned for this property as it
-		// will be replaced, together with `workerType`, by the new
-		// identifier `taskQueueId`.
-		//
-		// Syntax:     ^[a-zA-Z0-9-_]{1,38}$
-		ProvisionerID string `json:"provisionerId"`
-
-		// The tasks relation to its dependencies. This property specifies the
-		// semantics of the `task.dependencies` property.
-		// If `all-completed` is given the task will be scheduled when all
-		// dependencies are resolved _completed_ (successful resolution).
-		// If `all-resolved` is given the task will be scheduled when all dependencies
-		// have been resolved, regardless of what their resolution is.
-		//
-		// Possible values:
-		//   * "all-completed"
-		//   * "all-resolved"
-		//
-		// Default:    "all-completed"
-		Requires string `json:"requires,omitempty"`
-
-		// Number of times to retry the task in case of infrastructure issues.
-		// An _infrastructure issue_ is a worker node that crashes or is shutdown,
-		// these events are to be expected.
-		//
-		// Default:    5
-		// Mininum:    0
-		// Maximum:    49
-		Retries int64 `json:"retries,omitempty"`
-
-		// List of task-specific routes. Pulse messages about the task will be CC'ed to
-		// `route.<value>` for each `<value>` in this array.
-		//
-		// This array has a maximum size due to a limitation of the AMQP protocol,
-		// over which Pulse runs.  All routes must fit in the same "frame" of this
-		// protocol, and the frames have a fixed maximum size (typically 128k).
-		//
-		// Default:    []
-		//
-		// Array items:
-		// A task specific route.
-		//
-		// Min length: 1
-		// Max length: 249
-		Routes []string `json:"routes,omitempty"`
-
-		// All tasks in a task group must have the same `schedulerId`. This is used for several purposes:
-		//
-		// * it can represent the entity that created the task;
-		// * it can limit addition of new tasks to a task group: the caller of
-		//     `createTask` must have a scope related to the `schedulerId` of the task
-		//     group;
-		// * it controls who can manipulate tasks, again by requiring
-		//     `schedulerId`-related scopes; and
-		// * it appears in the routing key for Pulse messages about the task.
-		//
-		// Default:    "-"
-		// Syntax:     ^([a-zA-Z0-9-_]*)$
-		// Min length: 1
-		// Max length: 38
-		SchedulerID string `json:"schedulerId,omitempty"`
-
-		// List of scopes that the task is authorized to use during its execution.
-		//
-		// Array items:
-		// A single scope. A scope must be composed of
-		// printable ASCII characters and spaces.  Scopes ending in more than
-		// one `*` character are forbidden.
-		//
-		// Syntax:     ^[ -~]*$
-		Scopes []string `json:"scopes,omitempty"`
-
-		// Arbitrary key-value tags (only strings limited to 4k). These can be used
-		// to attach informal metadata to a task. Use this for informal tags that
-		// tasks can be classified by. You can also think of strings here as
-		// candidates for formal metadata. Something like
-		// `purpose: 'build' || 'test'` is a good example.
-		//
-		// Default:    {}
-		//
-		// Map entries:
-		// Max length: 4096
-		Tags map[string]string `json:"tags,omitempty"`
-
-		// Identifier for a group of tasks scheduled together with this task.
-		// Generally, all tasks related to a single event such as a version-control
-		// push or a nightly build have the same `taskGroupId`.  This property
-		// defaults to `taskId` if it isn't specified.  Tasks with `taskId` equal to
-		// the `taskGroupId` are, [by convention](/docs/manual/using/task-graph),
-		// decision tasks.
-		//
-		// Syntax:     ^[A-Za-z0-9_-]{8}[Q-T][A-Za-z0-9_-][CGKOSWaeimquy26-][A-Za-z0-9_-]{10}[AQgw]$
-		TaskGroupID string `json:"taskGroupId,omitempty"`
-
-		// Unique identifier for a task queue
-		//
-		// Syntax:     ^[a-zA-Z0-9-_]{1,38}/[a-z]([-a-z0-9]{0,36}[a-z0-9])?$
-		TaskQueueID string `json:"taskQueueId"`
-
-		// Unique identifier for a worker-type within a specific
-		// provisioner. Deprecation is planned for this property as it will
-		// be replaced, together with `provisionerId`, by the new
-		// identifier `taskQueueId`.
-		//
-		// Syntax:     ^[a-z]([-a-z0-9]{0,36}[a-z0-9])?$
-		WorkerType string `json:"workerType"`
+		WorkerType string `json:"workerType,omitempty"`
 	}
 
 	// Definition of a task that can be scheduled
@@ -2077,22 +1889,6 @@ func (this *PostArtifactResponse) MarshalJSON() ([]byte, error) {
 func (this *PostArtifactResponse) UnmarshalJSON(data []byte) error {
 	if this == nil {
 		return errors.New("PostArtifactResponse: UnmarshalJSON on nil pointer")
-	}
-	*this = append((*this)[0:0], data...)
-	return nil
-}
-
-// MarshalJSON calls json.RawMessage method of the same name. Required since
-// TaskDefinitionRequest is of type json.RawMessage...
-func (this *TaskDefinitionRequest) MarshalJSON() ([]byte, error) {
-	x := json.RawMessage(*this)
-	return (&x).MarshalJSON()
-}
-
-// UnmarshalJSON is a copy of the json.RawMessage implementation.
-func (this *TaskDefinitionRequest) UnmarshalJSON(data []byte) error {
-	if this == nil {
-		return errors.New("TaskDefinitionRequest: UnmarshalJSON on nil pointer")
 	}
 	*this = append((*this)[0:0], data...)
 	return nil

--- a/clients/client-go/tcqueueevents/types.go
+++ b/clients/client-go/tcqueueevents/types.go
@@ -512,6 +512,11 @@ type (
 		// Syntax:     ^[A-Za-z0-9_-]{8}[Q-T][A-Za-z0-9_-][CGKOSWaeimquy26-][A-Za-z0-9_-]{10}[AQgw]$
 		TaskID string `json:"taskId"`
 
+		// Unique identifier for a task queue
+		//
+		// Syntax:     ^[a-zA-Z0-9-_]{1,38}/[a-z]([-a-z0-9]{0,36}[a-z0-9])?$
+		TaskQueueID string `json:"taskQueueId"`
+
 		// Unique identifier for a worker-type within a specific provisioner
 		//
 		// Syntax:     ^[a-z]([-a-z0-9]{0,36}[a-z0-9])?$

--- a/clients/client-go/tcqueueevents/types.go
+++ b/clients/client-go/tcqueueevents/types.go
@@ -453,7 +453,9 @@ type (
 		Expires tcclient.Time `json:"expires"`
 
 		// Unique identifier for a provisioner, that can supply specified
-		// `workerType`
+		// `workerType`. Deprecation is planned for this property as it
+		// will be replaced, together with `workerType`, by the new
+		// identifier `taskQueueId`.
 		//
 		// Syntax:     ^[a-zA-Z0-9-_]{1,38}$
 		ProvisionerID string `json:"provisionerId"`
@@ -517,7 +519,10 @@ type (
 		// Syntax:     ^[a-zA-Z0-9-_]{1,38}/[a-z]([-a-z0-9]{0,36}[a-z0-9])?$
 		TaskQueueID string `json:"taskQueueId"`
 
-		// Unique identifier for a worker-type within a specific provisioner
+		// Unique identifier for a worker-type within a specific
+		// provisioner. Deprecation is planned for this property as it will
+		// be replaced, together with `provisionerId`, by the new
+		// identifier `taskQueueId`.
 		//
 		// Syntax:     ^[a-z]([-a-z0-9]{0,36}[a-z0-9])?$
 		WorkerType string `json:"workerType"`

--- a/generated/references.json
+++ b/generated/references.json
@@ -1486,6 +1486,9 @@
           "title": "Stability",
           "type": "string"
         },
+        "taskQueueId": {
+          "$ref": "task.json#/properties/taskQueueId"
+        },
         "workerType": {
           "$ref": "task.json#/properties/workerType"
         }
@@ -1493,6 +1496,7 @@
       "required": [
         "workerType",
         "provisionerId",
+        "taskQueueId",
         "description",
         "stability",
         "expires",
@@ -1599,6 +1603,9 @@
           "title": "Most Recent Tasks",
           "type": "array",
           "uniqueItems": false
+        },
+        "taskQueueId": {
+          "$ref": "task.json#/properties/taskQueueId"
         },
         "workerGroup": {
           "description": "Identifier for group that worker who executes this run is a part of,\nthis identifier is mainly used for efficient routing.\n",
@@ -1933,6 +1940,12 @@
           "title": "Task-Group Identifier",
           "type": "string"
         },
+        "taskQueueId": {
+          "description": "Unique identifier for a task queue\n",
+          "pattern": "^[a-zA-Z0-9-_]{1,38}/[a-z]([-a-z0-9]{0,36}[a-z0-9])?$",
+          "title": "Task Queue Id",
+          "type": "string"
+        },
         "workerType": {
           "description": "Unique identifier for a worker-type within a specific provisioner\n",
           "pattern": "^[a-z]([-a-z0-9]{0,36}[a-z0-9])?$",
@@ -1943,6 +1956,7 @@
       "required": [
         "provisionerId",
         "workerType",
+        "taskQueueId",
         "schedulerId",
         "taskGroupId",
         "dependencies",
@@ -3263,6 +3277,9 @@
                 "title": "Stability",
                 "type": "string"
               },
+              "taskQueueId": {
+                "$ref": "task.json#/properties/taskQueueId"
+              },
               "workerType": {
                 "$ref": "task.json#/properties/workerType"
               }
@@ -3270,6 +3287,7 @@
             "required": [
               "workerType",
               "provisionerId",
+              "taskQueueId",
               "stability",
               "description",
               "expires",

--- a/generated/references.json
+++ b/generated/references.json
@@ -3676,19 +3676,6 @@
       "$id": "/schemas/queue/v1/create-task-request.json#",
       "$schema": "/schemas/common/metaschema.json#",
       "additionalProperties": false,
-      "anyOf": [
-        {
-          "required": [
-            "provisionerId",
-            "workerType"
-          ]
-        },
-        {
-          "required": [
-            "taskQueueId"
-          ]
-        }
-      ],
       "description": "Definition of a task that can be scheduled\n",
       "properties": {
         "created": {

--- a/generated/references.json
+++ b/generated/references.json
@@ -1773,10 +1773,7 @@
           "type": "string"
         },
         "taskQueueId": {
-          "description": "Unique identifier for a task queue\n",
-          "pattern": "^[a-zA-Z0-9-_]{1,38}/[a-z]([-a-z0-9]{0,36}[a-z0-9])?$",
-          "title": "Task Queue Id",
-          "type": "string"
+          "$ref": "task.json#/properties/taskQueueId"
         }
       },
       "required": [
@@ -1863,7 +1860,7 @@
           "type": "string"
         },
         "provisionerId": {
-          "description": "Unique identifier for a provisioner, that can supply specified\n`workerType`\n",
+          "description": "Unique identifier for a provisioner, that can supply specified\n`workerType`. Deprecation is planned for this property as it\nwill be replaced, together with `workerType`, by the new\nidentifier `taskQueueId`.\n",
           "pattern": "^[a-zA-Z0-9-_]{1,38}$",
           "title": "Provisioner Id",
           "type": "string"
@@ -1947,7 +1944,7 @@
           "type": "string"
         },
         "workerType": {
-          "description": "Unique identifier for a worker-type within a specific provisioner\n",
+          "description": "Unique identifier for a worker-type within a specific\nprovisioner. Deprecation is planned for this property as it will\nbe replaced, together with `provisionerId`, by the new\nidentifier `taskQueueId`.\n",
           "pattern": "^[a-z]([-a-z0-9]{0,36}[a-z0-9])?$",
           "title": "Worker Type",
           "type": "string"
@@ -3432,10 +3429,7 @@
                 "type": "string"
               },
               "taskQueueId": {
-                "description": "Unique identifier for a task-queue\n",
-                "pattern": "^[a-zA-Z0-9-_]{1,38}/[a-z]([-a-z0-9]{0,36}[a-z0-9])?$",
-                "title": "Task Queue Id",
-                "type": "string"
+                "$ref": "task.json#/properties/taskQueueId"
               }
             },
             "required": [

--- a/generated/references.json
+++ b/generated/references.json
@@ -3676,6 +3676,19 @@
       "$id": "/schemas/queue/v1/create-task-request.json#",
       "$schema": "/schemas/common/metaschema.json#",
       "additionalProperties": false,
+      "anyOf": [
+        {
+          "required": [
+            "provisionerId",
+            "workerType"
+          ]
+        },
+        {
+          "required": [
+            "taskQueueId"
+          ]
+        }
+      ],
       "description": "Definition of a task that can be scheduled\n",
       "properties": {
         "created": {
@@ -3748,13 +3761,14 @@
         "taskGroupId": {
           "$ref": "task.json#/properties/taskGroupId"
         },
+        "taskQueueId": {
+          "$ref": "task.json#/properties/taskQueueId"
+        },
         "workerType": {
           "$ref": "task.json#/properties/workerType"
         }
       },
       "required": [
-        "provisionerId",
-        "workerType",
         "created",
         "deadline",
         "payload",

--- a/generated/references.json
+++ b/generated/references.json
@@ -2141,6 +2141,9 @@
           "title": "Task Identifier",
           "type": "string"
         },
+        "taskQueueId": {
+          "$ref": "task.json#/properties/taskQueueId"
+        },
         "workerType": {
           "$ref": "task.json#/properties/workerType"
         }
@@ -2149,6 +2152,7 @@
         "taskId",
         "provisionerId",
         "workerType",
+        "taskQueueId",
         "schedulerId",
         "taskGroupId",
         "deadline",

--- a/generated/references.json
+++ b/generated/references.json
@@ -3220,6 +3220,9 @@
         "provisionerId": {
           "$ref": "task.json#/properties/provisionerId"
         },
+        "taskQueueId": {
+          "$ref": "task.json#/properties/taskQueueId"
+        },
         "workerType": {
           "$ref": "task.json#/properties/workerType"
         }
@@ -3227,6 +3230,7 @@
       "required": [
         "provisionerId",
         "workerType",
+        "taskQueueId",
         "pendingTasks"
       ],
       "title": "Count Pending Tasks Response",

--- a/services/queue/schemas/v1/create-task-request.yml
+++ b/services/queue/schemas/v1/create-task-request.yml
@@ -30,9 +30,3 @@ required:
   - deadline
   - payload
   - metadata
-anyOf:
-  - required:
-      - provisionerId
-      - workerType
-  - required:
-      - taskQueueId

--- a/services/queue/schemas/v1/create-task-request.yml
+++ b/services/queue/schemas/v1/create-task-request.yml
@@ -8,6 +8,7 @@ properties:
   # they must be specified here as wel
   provisionerId: {$ref: "task.json#/properties/provisionerId"}
   workerType: {$ref: "task.json#/properties/workerType"}
+  taskQueueId: {$ref: "task.json#/properties/taskQueueId"}
   schedulerId: {$ref: "task.json#/properties/schedulerId", default: '-'}
   taskGroupId: {$ref: "task.json#/properties/taskGroupId"}
   dependencies: {$ref: "task.json#/properties/dependencies", default: []}
@@ -25,9 +26,13 @@ properties:
   extra: {$ref: "task.json#/properties/extra", default: {}}
 additionalProperties: false
 required:
-  - provisionerId
-  - workerType
   - created
   - deadline
   - payload
   - metadata
+anyOf:
+  - required:
+      - provisionerId
+      - workerType
+  - required:
+      - taskQueueId

--- a/services/queue/schemas/v1/list-taskqueues-response.yml
+++ b/services/queue/schemas/v1/list-taskqueues-response.yml
@@ -14,12 +14,7 @@ properties:
       type:         object
       title:        "Task Queue"
       properties:
-        taskQueueId:
-          title:          "Task Queue Id"
-          description: |
-            Unique identifier for a task-queue
-          type:           string
-          pattern:        {$const: taskqueueid-pattern}
+        taskQueueId: {$ref: "task.json#/properties/taskQueueId"}
         stability:
           title:        "Stability"
           description: |

--- a/services/queue/schemas/v1/list-workertypes-response.yml
+++ b/services/queue/schemas/v1/list-workertypes-response.yml
@@ -16,6 +16,7 @@ properties:
       properties:
         provisionerId: {$ref: "task.json#/properties/provisionerId"}
         workerType: {$ref: "task.json#/properties/workerType"}
+        taskQueueId: {$ref: "task.json#/properties/taskQueueId"}
         stability:
           title:        "Stability"
           description: |
@@ -47,6 +48,7 @@ properties:
       required:
         - workerType
         - provisionerId
+        - taskQueueId
         - stability
         - description
         - expires

--- a/services/queue/schemas/v1/pending-tasks-response.yml
+++ b/services/queue/schemas/v1/pending-tasks-response.yml
@@ -7,6 +7,7 @@ type:               object
 properties:
   provisionerId: {$ref: "task.json#/properties/provisionerId"}
   workerType: {$ref: "task.json#/properties/workerType"}
+  taskQueueId: {$ref: "task.json#/properties/taskQueueId"}
   pendingTasks:
     type:           integer
     minimum:        0
@@ -21,4 +22,5 @@ additionalProperties: false
 required:
   - provisionerId
   - workerType
+  - taskQueueId
   - pendingTasks

--- a/services/queue/schemas/v1/task-status.yml
+++ b/services/queue/schemas/v1/task-status.yml
@@ -7,6 +7,7 @@ properties:
   taskId: {$const: "taskId"}
   provisionerId: {$ref: "task.json#/properties/provisionerId"}
   workerType: {$ref: "task.json#/properties/workerType"}
+  taskQueueId: {$ref: "task.json#/properties/taskQueueId"}
   schedulerId: {$ref: "task.json#/properties/schedulerId", default: '-'}
   taskGroupId: {$ref: "task.json#/properties/taskGroupId"}
   deadline:         {$const: deadline}
@@ -159,6 +160,7 @@ required:
   - taskId
   - provisionerId
   - workerType
+  - taskQueueId
   - schedulerId
   - taskGroupId
   - deadline

--- a/services/queue/schemas/v1/task.yml
+++ b/services/queue/schemas/v1/task.yml
@@ -8,13 +8,18 @@ properties:
     title:          "Provisioner Id"
     description: |
       Unique identifier for a provisioner, that can supply specified
-      `workerType`
+      `workerType`. Deprecation is planned for this property as it
+      will be replaced, together with `workerType`, by the new
+      identifier `taskQueueId`.
     type:           string
     pattern:        {$const: provisionerid-pattern}
   workerType:
     title:          "Worker Type"
     description: |
-      Unique identifier for a worker-type within a specific provisioner
+      Unique identifier for a worker-type within a specific
+      provisioner. Deprecation is planned for this property as it will
+      be replaced, together with `provisionerId`, by the new
+      identifier `taskQueueId`.
     type:           string
     pattern:        {$const: workertype-pattern}
   taskQueueId:

--- a/services/queue/schemas/v1/task.yml
+++ b/services/queue/schemas/v1/task.yml
@@ -17,6 +17,12 @@ properties:
       Unique identifier for a worker-type within a specific provisioner
     type:           string
     pattern:        {$const: workertype-pattern}
+  taskQueueId:
+    title:          "Task Queue Id"
+    description: |
+      Unique identifier for a task queue
+    type:           string
+    pattern:        {$const: taskqueueid-pattern}
   schedulerId:
     title:          "Scheduler Identifier"
     description: |
@@ -177,6 +183,7 @@ additionalProperties: false
 required:
   - provisionerId
   - workerType
+  - taskQueueId
   - schedulerId
   - taskGroupId
   - dependencies

--- a/services/queue/schemas/v1/taskqueue-response.yml
+++ b/services/queue/schemas/v1/taskqueue-response.yml
@@ -4,12 +4,7 @@ description: |
   Response to a task queue request from a provisioner.
 type:           object
 properties:
-  taskQueueId:
-    title:          "Task Queue Id"
-    description: |
-      Unique identifier for a task queue
-    type:           string
-    pattern:        {$const: taskqueueid-pattern}
+  taskQueueId: {$ref: "task.json#/properties/taskQueueId"}
   stability:
     title:        "Stability"
     description: |

--- a/services/queue/schemas/v1/worker-response.yml
+++ b/services/queue/schemas/v1/worker-response.yml
@@ -6,6 +6,7 @@ type:           object
 properties:
   provisionerId: {$ref: "task.json#/properties/provisionerId"}
   workerType: {$ref: "task.json#/properties/workerType"}
+  taskQueueId: {$ref: "task.json#/properties/taskQueueId"}
   workerGroup:
     title:        "Worker Group"
     description: |

--- a/services/queue/schemas/v1/workertype-response.yml
+++ b/services/queue/schemas/v1/workertype-response.yml
@@ -6,6 +6,7 @@ type:           object
 properties:
   provisionerId: {$ref: "task.json#/properties/provisionerId"}
   workerType: {$ref: "task.json#/properties/workerType"}
+  taskQueueId: {$ref: "task.json#/properties/taskQueueId"}
   stability:
     title:        "Stability"
     description: |
@@ -86,6 +87,7 @@ additionalProperties: false
 required:
   - workerType
   - provisionerId
+  - taskQueueId
   - description
   - stability
   - expires

--- a/services/queue/src/api.js
+++ b/services/queue/src/api.js
@@ -1680,16 +1680,16 @@ builder.declare({
 }, async function(req, res) {
   let provisionerId = req.params.provisionerId;
   let workerType = req.params.workerType;
+  let taskQueueId = joinTaskQueueId(provisionerId, workerType);
 
   // Get number of pending message
-  let count = await this.queueService.countPendingMessages(
-    joinTaskQueueId(provisionerId, workerType),
-  );
+  let count = await this.queueService.countPendingMessages(taskQueueId);
 
   // Reply to call with count `pendingTasks`
   return res.reply({
     provisionerId: provisionerId,
     workerType: workerType,
+    taskQueueId: taskQueueId,
     pendingTasks: count,
   });
 });

--- a/services/queue/src/api.js
+++ b/services/queue/src/api.js
@@ -528,8 +528,12 @@ builder.declare({
     }
   } else if (taskDef.provisionerId && taskDef.workerType) {
     taskDef.taskQueueId = joinTaskQueueId(taskDef.provisionerId, taskDef.workerType);
-  } else {
+  } else if (taskDef.taskQueueId) {
     addSplitFields(taskDef);
+  } else {
+    return res.reportError('InputError',
+      'at least a provisionerId and a workerType or a taskQueueId must be provided"',
+      {});
   }
 
   await authorizeTaskCreation(req, taskId, taskDef);

--- a/services/queue/src/api.js
+++ b/services/queue/src/api.js
@@ -4,7 +4,7 @@ const { APIBuilder, paginateResults } = require('taskcluster-lib-api');
 const taskCreds = require('./task-creds');
 const { UNIQUE_VIOLATION } = require('taskcluster-lib-postgres');
 const { Task, Worker, TaskQueue, Provisioner } = require('./data');
-const { useSplitFields, useSingleField, joinTaskQueueId, splitTaskQueueId } = require('./utils');
+const { addSplitFields, useSingleField, joinTaskQueueId, splitTaskQueueId } = require('./utils');
 
 // Maximum number runs allowed
 const MAX_RUNS_ALLOWED = 50;
@@ -1736,7 +1736,7 @@ builder.declare({
     result.continuationToken = continuationToken;
   }
 
-  result.workerTypes.forEach(useSplitFields);
+  result.workerTypes.forEach(addSplitFields);
   return res.reply(result);
 });
 
@@ -1770,7 +1770,7 @@ builder.declare({
   }
 
   const tqResult = tQueue.serialize();
-  useSplitFields(tqResult);
+  addSplitFields(tqResult);
 
   const actions = [];
   return res.reply(Object.assign({}, tqResult, { actions }));
@@ -1820,7 +1820,7 @@ builder.declare({
   });
 
   const tqResult = tQueue.serialize();
-  useSplitFields(tqResult);
+  addSplitFields(tqResult);
 
   const actions = [];
   return res.reply(Object.assign({}, tqResult, { actions }));
@@ -2008,7 +2008,7 @@ builder.declare({
   }
 
   const workerResult = worker.serialize();
-  useSplitFields(workerResult);
+  addSplitFields(workerResult);
 
   const actions = [];
   return res.reply(Object.assign({}, workerResult, { actions }));
@@ -2056,7 +2056,7 @@ builder.declare({
   worker = Worker.fromDbRows(result);
 
   const workerResult = worker.serialize();
-  useSplitFields(workerResult);
+  addSplitFields(workerResult);
 
   const actions = [];
   return res.reply(Object.assign({}, workerResult, { actions }));
@@ -2104,7 +2104,7 @@ builder.declare({
   ]);
 
   const workerResult = worker.serialize();
-  useSplitFields(workerResult);
+  addSplitFields(workerResult);
 
   const actions = [];
   return res.reply(Object.assign({}, workerResult, { actions }));

--- a/services/queue/src/data.js
+++ b/services/queue/src/data.js
@@ -115,6 +115,7 @@ class Task {
     return {
       provisionerId: provisionerId,
       workerType: workerType,
+      taskQueueId: this.taskQueueId,
       schedulerId: this.schedulerId,
       taskGroupId: this.taskGroupId,
       dependencies: _.cloneDeep(this.dependencies),

--- a/services/queue/src/data.js
+++ b/services/queue/src/data.js
@@ -149,6 +149,7 @@ class Task {
       taskId: this.taskId,
       provisionerId: provisionerId,
       workerType: workerType,
+      taskQueueId: this.taskQueueId,
       schedulerId: this.schedulerId,
       taskGroupId: this.taskGroupId,
       deadline: this.deadline.toJSON(),

--- a/services/queue/src/utils.js
+++ b/services/queue/src/utils.js
@@ -151,14 +151,13 @@ exports.joinTaskQueueId = joinTaskQueueId;
  * Add the provisionerId, workerType fields to an object that has a
  * taskQueueId field to maintain public interface compatibility
  */
-const useSplitFields = (obj) => {
+const addSplitFields = (obj) => {
   assert(Object.prototype.hasOwnProperty.call(obj, 'taskQueueId'), 'object is missing property `taskQueueId`');
   const { provisionerId, workerType } = splitTaskQueueId(obj.taskQueueId);
   obj.provisionerId = provisionerId;
   obj.workerType = workerType;
-  delete obj.taskQueueId;
 };
-exports.useSplitFields = useSplitFields;
+exports.addSplitFields = addSplitFields;
 
 /**
  * Replace provisionerId and workerType fields in an object with the

--- a/services/queue/src/utils.js
+++ b/services/queue/src/utils.js
@@ -163,7 +163,7 @@ exports.addSplitFields = addSplitFields;
  * Replace provisionerId and workerType fields in an object with the
  * equivalent taskQueueId.
  */
-const useSingleField = (obj) => {
+const useOnlyTaskQueueId = (obj) => {
   assert(Object.prototype.hasOwnProperty.call(obj, 'provisionerId'), 'object is missing property `provisionerId`');
   assert(Object.prototype.hasOwnProperty.call(obj, 'workerType'), 'object is missing property `workerType`');
   const taskQueueId = joinTaskQueueId(obj.provisionerId, obj.workerType);
@@ -171,4 +171,4 @@ const useSingleField = (obj) => {
   delete obj.provisionerId;
   delete obj.workerType;
 };
-exports.useSingleField = useSingleField;
+exports.useOnlyTaskQueueId = useOnlyTaskQueueId;

--- a/services/queue/test/artifact_test.js
+++ b/services/queue/test/artifact_test.js
@@ -67,8 +67,7 @@ helper.secrets.mockSuite(testing.suiteName(), ['aws'], function(mock, skipping) 
 
   // Use the same task definition for everything
   const taskDef = {
-    provisionerId: 'no-provisioner',
-    workerType: 'test-worker',
+    taskQueueId: 'no-provisioner/test-worker',
     schedulerId: 'my-scheduler',
     taskGroupId: 'dSlITZ4yQgmvxxAi4A8fHQ',
     routes: [],

--- a/services/queue/test/canceltask_test.js
+++ b/services/queue/test/canceltask_test.js
@@ -17,8 +17,7 @@ helper.secrets.mockSuite(testing.suiteName(), ['aws'], function(mock, skipping) 
 
   // Use the same task definition for everything
   const taskDef = {
-    provisionerId: 'no-provisioner-extended-extended',
-    workerType: 'test-worker-extended-extended',
+    taskQueueId: 'no-provisioner-extended-extended/test-worker-extended-extended',
     schedulerId: 'my-scheduler-extended-extended',
     taskGroupId: 'dSlITZ4yQgmvxxAi4A8fHQ',
     routes: [],

--- a/services/queue/test/claimtask_test.js
+++ b/services/queue/test/claimtask_test.js
@@ -16,8 +16,7 @@ helper.secrets.mockSuite(testing.suiteName(), ['aws'], function(mock, skipping) 
 
   // Use the same task definition for everything
   const taskDef = () => ({
-    provisionerId: 'no-provisioner-extended-extended',
-    workerType: 'test-worker-extended-extended',
+    taskQueueId: 'no-provisioner-extended-extended/test-worker-extended-extended',
     schedulerId: 'my-scheduler-extended-extended',
     taskGroupId: 'dSlITZ4yQgmvxxAi4A8fHQ',
     routes: [],

--- a/services/queue/test/deadline_test.js
+++ b/services/queue/test/deadline_test.js
@@ -20,8 +20,7 @@ helper.secrets.mockSuite(testing.suiteName(), ['aws'], function(mock, skipping) 
   // Use the same task definition for everything
   const makeTask = () => {
     const task = {
-      provisionerId: 'no-provisioner-extended-extended',
-      workerType: 'test-worker-extended-extended',
+      taskQueueId: 'no-provisioner-extended-extended/test-worker-extended-extended',
       // Legal because we allow a small bit of clock drift
       created: taskcluster.fromNowJSON('- 5 seconds'),
       deadline: taskcluster.fromNowJSON('5 seconds'),

--- a/services/queue/test/dependency_test.js
+++ b/services/queue/test/dependency_test.js
@@ -19,8 +19,7 @@ helper.secrets.mockSuite(testing.suiteName(), ['aws'], function(mock, skipping) 
   helper.resetTables(mock, skipping);
 
   const taskDef = () => ({
-    provisionerId: 'no-provisioner-extended-extendeda',
-    workerType: 'test-worker-extended-extended',
+    taskQueueId: 'no-provisioner-extended-extended/test-worker-extended-extended',
     created: taskcluster.fromNowJSON(),
     deadline: taskcluster.fromNowJSON('1 days'),
     expires: taskcluster.fromNowJSON('2 days'),

--- a/services/queue/test/expiretask_test.js
+++ b/services/queue/test/expiretask_test.js
@@ -17,8 +17,7 @@ helper.secrets.mockSuite(testing.suiteName(), ['aws'], function(mock, skipping) 
   // Use the same task definition for everything
   const makeTask = (expiration) => {
     const task = {
-      provisionerId: 'no-provisioner-extended-extended',
-      workerType: 'test-worker-extended-extended',
+      taskQueueId: 'no-provisioner-extended-extended/test-worker-extended-extended',
       created: taskcluster.fromNowJSON(),
       deadline: taskcluster.fromNowJSON('1 day'),
       // Notice that in config/test.js we've configured

--- a/services/queue/test/gettask_test.js
+++ b/services/queue/test/gettask_test.js
@@ -51,6 +51,8 @@ helper.secrets.mockSuite(testing.suiteName(), ['aws'], function(mock, skipping) 
   test('task(taskId) is correct', async () => {
     helper.scopes(`queue:get-task:${taskId}`);
     const taskDef2 = await helper.queue.task(taskId);
+    assume(taskDef2.taskQueueId).equals(`${taskDef.provisionerId}/${taskDef.workerType}`);
+    delete taskDef2.taskQueueId;
     assume(taskDef2).deep.equals(taskDef);
   });
 

--- a/services/queue/test/gettask_test.js
+++ b/services/queue/test/gettask_test.js
@@ -15,8 +15,7 @@ helper.secrets.mockSuite(testing.suiteName(), ['aws'], function(mock, skipping) 
   helper.resetTables(mock, skipping);
 
   const taskDef = {
-    provisionerId: 'no-provisioner-extended-extended',
-    workerType: 'test-worker-extended-extended',
+    taskQueueId: 'no-provisioner-extended-extended/test-worker-extended-extended',
     schedulerId: 'my-scheduler-extended-extended',
     taskGroupId: 'dSlITZ4yQgmvxxAi4A8fHQ',
     dependencies: [],
@@ -51,8 +50,9 @@ helper.secrets.mockSuite(testing.suiteName(), ['aws'], function(mock, skipping) 
   test('task(taskId) is correct', async () => {
     helper.scopes(`queue:get-task:${taskId}`);
     const taskDef2 = await helper.queue.task(taskId);
-    assume(taskDef2.taskQueueId).equals(`${taskDef.provisionerId}/${taskDef.workerType}`);
-    delete taskDef2.taskQueueId;
+    assume(`${taskDef2.provisionerId}/${taskDef2.workerType}`).equals(taskDef.taskQueueId);
+    delete taskDef2.provisionerId;
+    delete taskDef2.workerType;
     assume(taskDef2).deep.equals(taskDef);
   });
 
@@ -74,4 +74,5 @@ helper.secrets.mockSuite(testing.suiteName(), ['aws'], function(mock, skipping) 
     helper.scopes(`queue:status:${taskId}`);
     await helper.queue.status(taskId); // doesn't fail..
   });
+
 });

--- a/services/queue/test/querytasks_test.js
+++ b/services/queue/test/querytasks_test.js
@@ -17,8 +17,7 @@ helper.secrets.mockSuite(testing.suiteName(), ['aws'], function(mock, skipping) 
 
   test('pendingTasks >= 1', async () => {
     const taskDef = {
-      provisionerId: 'no-provisioner-extended-extended',
-      workerType: 'query-test-worker-extended-extended',
+      taskQueueId: 'no-provisioner-extended-extended/query-test-worker-extended-extended',
       schedulerId: 'my-scheduler',
       taskGroupId: 'dSlITZ4yQgmvxxAi4A8fHQ',
       routes: [],

--- a/services/queue/test/reruntask_test.js
+++ b/services/queue/test/reruntask_test.js
@@ -16,8 +16,7 @@ helper.secrets.mockSuite(testing.suiteName(), ['aws'], function(mock, skipping) 
 
   // Use the same task definition for everything
   const taskDef = {
-    provisionerId: 'no-provisioner-extended-extended',
-    workerType: 'test-worker-extended-extended',
+    taskQueueId: 'no-provisioner-extended-extended/test-worker-extended-extended',
     schedulerId: 'my-scheduler-extended-extended',
     taskGroupId: 'dSlITZ4yQgmvxxAi4A8fHQ',
     routes: [],

--- a/services/queue/test/resolvetask_test.js
+++ b/services/queue/test/resolvetask_test.js
@@ -19,8 +19,7 @@ helper.secrets.mockSuite(testing.suiteName(), ['aws'], function(mock, skipping) 
 
   // Use the same task definition for everything
   const taskDef = {
-    provisionerId: 'no-provisioner-extended-extended',
-    workerType: 'test-worker-extended-extended',
+    taskQueueId: 'no-provisioner-extended-extended/test-worker-extended-extended',
     schedulerId: 'my-scheduler-extended-extended',
     taskGroupId: 'dSlITZ4yQgmvxxAi4A8fHQ',
     routes: [],

--- a/services/queue/test/retry_test.js
+++ b/services/queue/test/retry_test.js
@@ -17,8 +17,7 @@ helper.secrets.mockSuite(testing.suiteName(), ['aws'], function(mock, skipping) 
 
   // Use the same task definition for everything
   const taskDef = {
-    provisionerId: 'no-provisioner-extended-extended',
-    workerType: 'test-worker-extended-extended',
+    taskQueueId: 'no-provisioner-extended-extended/test-worker-extended-extended',
     created: taskcluster.fromNowJSON(),
     deadline: taskcluster.fromNowJSON('3 days'),
     retries: 1,

--- a/services/queue/test/taskgroup_test.js
+++ b/services/queue/test/taskgroup_test.js
@@ -19,8 +19,7 @@ helper.secrets.mockSuite(testing.suiteName(), ['aws'], function(mock, skipping) 
 
   // Use the same task definition for everything
   const taskDef = {
-    provisionerId: 'no-provisioner-extended-extended',
-    workerType: 'test-worker-extended-extended',
+    taskQueueId: 'no-provisioner-extended-extended/test-worker-extended-extended',
     schedulerId: 'dummy-scheduler-extended-extended',
     created: taskcluster.fromNowJSON(),
     deadline: taskcluster.fromNowJSON('1 days'),


### PR DESCRIPTION
Github Bug/Issue: Fixes #3580

I'm not completely sure of all the places that taskQueueId should appear alongside the old identifiers.

I'm guessing that other than what I've done so far I should add it to task statuses as well?
