### PR TITLE
fix yaml.safe{Load,Dump} in ui

### DIFF
--- a/changelog/issue-4239.md
+++ b/changelog/issue-4239.md
@@ -1,0 +1,5 @@
+audience: users
+level: patch
+reference: issue 4239
+---
+This version fixes a bug in the user-interface causing messages about `yaml.safeDump` having been removed.  The developers regret te error.

--- a/ui/src/components/HookForm/index.jsx
+++ b/ui/src/components/HookForm/index.jsx
@@ -11,7 +11,7 @@ import List from '@material-ui/core/List';
 import ListItem from '@material-ui/core/ListItem';
 import ListItemText from '@material-ui/core/ListItemText';
 import Switch from '@material-ui/core/Switch';
-import { safeLoad, safeDump } from 'js-yaml';
+import { load, dump } from 'js-yaml';
 import FormGroup from '@material-ui/core/FormGroup';
 import FormControlLabel from '@material-ui/core/FormControlLabel';
 import Grid from '@material-ui/core/Grid';
@@ -244,9 +244,9 @@ export default class HookForm extends Component {
       hook: props.hook,
       hookLastFires: props.hookLastFires,
       previousHook: props.hook,
-      taskInput: safeDump(removeKeys(cloneDeep(hook.task), ['__typename'])),
-      triggerSchemaInput: safeDump(hook.triggerSchema),
-      triggerContextInput: safeDump({}),
+      taskInput: dump(removeKeys(cloneDeep(hook.task), ['__typename'])),
+      triggerSchemaInput: dump(hook.triggerSchema),
+      triggerContextInput: dump({}),
       scheduleTextField: '',
       taskValidYaml: true,
       triggerSchemaValidYaml: true,
@@ -350,7 +350,7 @@ export default class HookForm extends Component {
     try {
       this.setState({
         taskInput: value,
-        hook: assocPath(['task'], safeLoad(value), hook),
+        hook: assocPath(['task'], load(value), hook),
         taskValidYaml: true,
       });
     } catch (err) {
@@ -375,7 +375,7 @@ export default class HookForm extends Component {
     return onTriggerHook({
       hookId,
       hookGroupId,
-      payload: safeLoad(triggerContextInput),
+      payload: load(triggerContextInput),
     });
   };
 
@@ -383,7 +383,7 @@ export default class HookForm extends Component {
     try {
       this.setState({
         triggerSchemaInput: value,
-        hook: assocPath(['triggerSchema'], safeLoad(value), this.state.hook),
+        hook: assocPath(['triggerSchema'], load(value), this.state.hook),
         triggerSchemaValidYaml: true,
       });
     } catch (err) {
@@ -893,7 +893,7 @@ export default class HookForm extends Component {
                       Schema
                     </Typography>
                     <Code language="yaml" className={classes.code}>
-                      {safeDump(hook.triggerSchema)}
+                      {dump(hook.triggerSchema)}
                     </Code>
                   </Grid>
                 </Grid>

--- a/ui/src/components/SecretForm/index.jsx
+++ b/ui/src/components/SecretForm/index.jsx
@@ -2,7 +2,7 @@ import React, { Component, Fragment } from 'react';
 import { oneOfType, object, string, func, bool } from 'prop-types';
 import classNames from 'classnames';
 import { addYears } from 'date-fns';
-import { safeDump, safeLoad } from 'js-yaml';
+import { dump, load } from 'js-yaml';
 import CodeEditor from '@mozilla-frontend-infra/components/CodeEditor';
 import { withStyles } from '@material-ui/core/styles';
 import List from '@material-ui/core/List';
@@ -109,9 +109,7 @@ export default class SecretForm extends Component {
     expires: this.props.isNewSecret
       ? addYears(new Date(), 1000)
       : this.props.secret.expires,
-    editorValue: this.props.isNewSecret
-      ? ''
-      : safeDump(this.props.secret.secret),
+    editorValue: this.props.isNewSecret ? '' : dump(this.props.secret.secret),
     showSecret: this.props.isNewSecret,
   };
 
@@ -138,7 +136,7 @@ export default class SecretForm extends Component {
 
     this.props.onSaveSecret(secretName, {
       expires,
-      secret: safeLoad(editorValue),
+      secret: load(editorValue),
     });
   };
 
@@ -146,7 +144,7 @@ export default class SecretForm extends Component {
     const { editorValue, secretName, expires } = this.state;
 
     try {
-      safeLoad(editorValue);
+      load(editorValue);
 
       return secretName && expires && editorValue;
     } catch (err) {
@@ -175,7 +173,7 @@ export default class SecretForm extends Component {
     const isSecretDirty =
       isNewSecret ||
       secretName !== secret.name ||
-      editorValue !== safeDump(secret.secret) ||
+      editorValue !== dump(secret.secret) ||
       expires !== secret.expires;
 
     return (

--- a/ui/src/components/TaskActionForm/index.jsx
+++ b/ui/src/components/TaskActionForm/index.jsx
@@ -5,7 +5,7 @@ import Typography from '@material-ui/core/Typography';
 import Grid from '@material-ui/core/Grid';
 import CodeEditor from '@mozilla-frontend-infra/components/CodeEditor';
 import Code from '@mozilla-frontend-infra/components/Code';
-import { safeDump } from 'js-yaml';
+import { dump } from 'js-yaml';
 import ErrorPanel from '../ErrorPanel';
 import Markdown from '../Markdown';
 
@@ -77,7 +77,7 @@ export default class TaskActionForm extends Component {
                 Schema
               </Typography>
               <Code language="yaml" className={classes.code}>
-                {safeDump(action.schema || {})}
+                {dump(action.schema || {})}
               </Code>
             </Grid>
           </Grid>

--- a/ui/src/views/Quickstart/index.jsx
+++ b/ui/src/views/Quickstart/index.jsx
@@ -17,7 +17,7 @@ import FormControlLabel from '@material-ui/core/FormControlLabel';
 import AlertCircleOutlineIcon from 'mdi-react/AlertCircleOutlineIcon';
 import CheckIcon from 'mdi-react/CheckIcon';
 import RestartIcon from 'mdi-react/RestartIcon';
-import { safeDump } from 'js-yaml';
+import { dump } from 'js-yaml';
 import debounce from 'lodash.debounce';
 import TextField from '../../components/TextField';
 import Dashboard from '../../components/Dashboard';
@@ -76,7 +76,7 @@ const getTaskDefinition = state => {
     'proj-getting-started/tutorial';
   const [provisionerId, workerType] = tutorialWorkerPool.split('/');
 
-  return safeDump({
+  return dump({
     version: 1,
     policy: {
       pullRequests: access,

--- a/ui/src/views/Tasks/CreateTask/index.jsx
+++ b/ui/src/views/Tasks/CreateTask/index.jsx
@@ -5,7 +5,7 @@ import { parse, stringify } from 'qs';
 import { withApollo } from 'react-apollo';
 import storage from 'localforage';
 import merge from 'deepmerge';
-import { safeLoad, safeDump } from 'js-yaml';
+import { load, dump } from 'js-yaml';
 import { bool } from 'prop-types';
 import {
   toDate,
@@ -187,7 +187,7 @@ export default class CreateTask extends Component {
 
     if (task) {
       const taskId = nice();
-      let payload = safeLoad(task);
+      let payload = load(task);
 
       db.taskDefinitions.put(payload);
 
@@ -244,7 +244,7 @@ export default class CreateTask extends Component {
 
   handleTaskChange = value => {
     try {
-      safeLoad(value);
+      load(value);
       this.setState({ invalid: false, task: value });
     } catch (err) {
       this.setState({ invalid: true, task: value });
@@ -254,7 +254,7 @@ export default class CreateTask extends Component {
   handleUpdateTimestamps = () =>
     this.setState({
       createdTaskError: null,
-      task: this.parameterizeTask(safeLoad(this.state.task)),
+      task: this.parameterizeTask(load(this.state.task)),
     });
 
   parameterizeTask(task) {
@@ -284,7 +284,7 @@ export default class CreateTask extends Component {
       }
     };
 
-    return `${safeDump(iter(task), { noCompatMode: true, noRefs: true })}`;
+    return `${dump(iter(task), { noCompatMode: true, noRefs: true })}`;
   }
 
   render() {

--- a/ui/src/views/Tasks/TaskGroup/index.jsx
+++ b/ui/src/views/Tasks/TaskGroup/index.jsx
@@ -6,7 +6,7 @@ import dotProp from 'dot-prop-immutable';
 import { sum, isEmpty } from 'ramda';
 import { paramCase } from 'param-case';
 import jsonSchemaDefaults from 'json-schema-defaults';
-import { safeDump } from 'js-yaml';
+import { dump } from 'js-yaml';
 import { withStyles } from '@material-ui/core/styles';
 import Spinner from '@mozilla-frontend-infra/components/Spinner';
 import Badge from '@material-ui/core/Badge';
@@ -144,9 +144,7 @@ export default class TaskGroup extends Component {
           // don't consider this version
           if (!groupActions.some(({ name }) => name === action.name)) {
             groupActions.push(action);
-            actionInputs[action.name] = safeDump(
-              jsonSchemaDefaults(schema) || {}
-            );
+            actionInputs[action.name] = dump(jsonSchemaDefaults(schema) || {});
             actionData[action.name] = {
               action,
             };

--- a/ui/src/views/Tasks/ViewTask/index.jsx
+++ b/ui/src/views/Tasks/ViewTask/index.jsx
@@ -13,7 +13,7 @@ import ListItem from '@material-ui/core/ListItem';
 import Checkbox from '@material-ui/core/Checkbox';
 import dotProp from 'dot-prop-immutable';
 import jsonSchemaDefaults from 'json-schema-defaults';
-import { safeDump } from 'js-yaml';
+import { dump } from 'js-yaml';
 import HammerIcon from 'mdi-react/HammerIcon';
 import CreationIcon from 'mdi-react/CreationIcon';
 import PencilIcon from 'mdi-react/PencilIcon';
@@ -156,9 +156,7 @@ export default class ViewTask extends Component {
             return;
           }
 
-          actionInputs[action.name] = safeDump(
-            jsonSchemaDefaults(schema) || {}
-          );
+          actionInputs[action.name] = dump(jsonSchemaDefaults(schema) || {});
           actionData[action.name] = {
             action,
           };

--- a/ui/src/views/Tasks/submitTaskAction.js
+++ b/ui/src/views/Tasks/submitTaskAction.js
@@ -2,7 +2,7 @@ import merge from 'deepmerge';
 import { satisfiesExpression } from 'taskcluster-lib-scopes';
 import cloneDeep from 'lodash.clonedeep';
 import jsone from 'json-e';
-import { safeLoad } from 'js-yaml';
+import { load } from 'js-yaml';
 import removeKeys from '../../utils/removeKeys';
 import { nice } from '../../utils/slugid';
 import expandScopesQuery from './expandScopes.graphql';
@@ -15,7 +15,7 @@ import formatTaskMutation from '../../utils/formatTaskMutation';
 export default async ({ task, form, action, apolloClient, taskActions }) => {
   const actions = removeKeys(cloneDeep(taskActions), ['__typename']);
   const taskGroup = task.taskId === task.taskGroupId ? task : task.decisionTask;
-  const input = safeLoad(form);
+  const input = load(form);
   const validate = ajv.compile(action.schema || {});
   const valid = validate(input);
   const validateActionsJsonInstance = await validateActionsJson();


### PR DESCRIPTION
🤦🏽 

I think Webpack didn't because safeLoad and safeDump are still *deifned*, they are just functions that throw an error.  Typescript would hopefully have caught this?

Github Bug/Issue: Fixes #4239 