### PR TITLE
Drop support for a darwin/386 taskcluster-proxy image

### DIFF
--- a/tools/taskcluster-proxy/dockerbuild.sh
+++ b/tools/taskcluster-proxy/dockerbuild.sh
@@ -17,7 +17,6 @@ build() {
 echo "Building tc-proxy:"
 build windows 386
 build windows amd64
-build darwin 386
 build darwin amd64
 build linux 386
 build linux amd64


### PR DESCRIPTION
This arch is no longer supported by Golang

