### PR TITLE
long migrations should be flagged as major

### DIFF
--- a/dev-docs/best-practices/changelog.md
+++ b/dev-docs/best-practices/changelog.md
@@ -70,6 +70,7 @@ For example:
  * major: Breaking changes for deployment of Taskcluster
  * major: Breaking changes for administration of Taskcluster
  * major: Breaking changes for users of Taskcluster
+ * major: Any change that adds a DB version that may take more than a few seconds to run (with notes to the deployers as to how long)
  * minor: New feature users want to know about and take advantage of
  * minor: Any change that adds a new version to the database
  * patch: Bug fix users are waiting on


### PR DESCRIPTION
For example, https://github.com/taskcluster/taskcluster/releases/tag/v40.0.0 should have had

> [MAJOR] #3578
> The queue service now uses taskQueueId internally instead of the pair provisionerId/workerType for tasks.
> This involves an online database migration that scans each row in the `queue_tasks` table and thus might take considerable time for a production deployment.  A well-equipped database can scan about 600 rows per second.