### PR TITLE
Track whether a provider is set up correctly

### DIFF
--- a/changelog/issue-4276.md
+++ b/changelog/issue-4276.md
@@ -1,0 +1,5 @@
+audience: deployers
+level: patch
+reference: issue 4276
+---
+The worker-manager service will now start up even if one of its providers is down or misconfigured.  Worker pools using that provider will not be provisioned, but other pools will continue to operate normally.

--- a/clients/client-go/tcworkermanager/tcworkermanager.go
+++ b/clients/client-go/tcworkermanager/tcworkermanager.go
@@ -9,6 +9,10 @@
 // /references/worker-manager/v1/api.json
 // This service manages workers, including provisioning for dynamic worker pools.
 //
+// Methods interacting with a provider may return a 503 response if that provider has
+// not been able to start up, such as if the service to which it interfaces has an
+// outage.  Such requests can be retried as for any other 5xx response.
+//
 // See:
 //
 // How to use this package

--- a/clients/client-py/taskcluster/generated/aio/workermanager.py
+++ b/clients/client-py/taskcluster/generated/aio/workermanager.py
@@ -14,6 +14,10 @@ _defaultConfig = config
 class WorkerManager(AsyncBaseClient):
     """
     This service manages workers, including provisioning for dynamic worker pools.
+
+    Methods interacting with a provider may return a 503 response if that provider has
+    not been able to start up, such as if the service to which it interfaces has an
+    outage.  Such requests can be retried as for any other 5xx response.
     """
 
     classOptions = {

--- a/clients/client-py/taskcluster/generated/workermanager.py
+++ b/clients/client-py/taskcluster/generated/workermanager.py
@@ -14,6 +14,10 @@ _defaultConfig = config
 class WorkerManager(BaseClient):
     """
     This service manages workers, including provisioning for dynamic worker pools.
+
+    Methods interacting with a provider may return a 503 response if that provider has
+    not been able to start up, such as if the service to which it interfaces has an
+    outage.  Such requests can be retried as for any other 5xx response.
     """
 
     classOptions = {

--- a/clients/client-rust/src/generated/workermanager.rs
+++ b/clients/client-rust/src/generated/workermanager.rs
@@ -10,6 +10,10 @@ use crate::util::urlencode;
 /// Worker Manager Service
 ///
 /// This service manages workers, including provisioning for dynamic worker pools.
+///
+/// Methods interacting with a provider may return a 503 response if that provider has
+/// not been able to start up, such as if the service to which it interfaces has an
+/// outage.  Such requests can be retried as for any other 5xx response.
 pub struct WorkerManager (Client);
 
 #[allow(non_snake_case)]

--- a/clients/client-shell/apis/services.go
+++ b/clients/client-shell/apis/services.go
@@ -1578,7 +1578,7 @@ var services = map[string]definitions.Service{
 		APIVersion:  "v1",
 		ServiceName: "worker-manager",
 		Title:       "Worker Manager Service",
-		Description: "This service manages workers, including provisioning for dynamic worker pools.",
+		Description: "This service manages workers, including provisioning for dynamic worker pools.\n\nMethods interacting with a provider may return a 503 response if that provider has\nnot been able to start up, such as if the service to which it interfaces has an\noutage.  Such requests can be retried as for any other 5xx response.",
 		Entries: []definitions.Entry{
 			definitions.Entry{
 				Name:        "ping",

--- a/clients/client/src/apis.js
+++ b/clients/client/src/apis.js
@@ -3183,7 +3183,7 @@ module.exports = {
     "reference": {
       "$schema": "/schemas/common/api-reference-v0.json#",
       "apiVersion": "v1",
-      "description": "This service manages workers, including provisioning for dynamic worker pools.",
+      "description": "This service manages workers, including provisioning for dynamic worker pools.\n\nMethods interacting with a provider may return a 503 response if that provider has\nnot been able to start up, such as if the service to which it interfaces has an\noutage.  Such requests can be retried as for any other 5xx response.",
       "entries": [
         {
           "args": [

--- a/generated/references.json
+++ b/generated/references.json
@@ -12415,7 +12415,7 @@
     "content": {
       "$schema": "/schemas/common/api-reference-v0.json#",
       "apiVersion": "v1",
-      "description": "This service manages workers, including provisioning for dynamic worker pools.",
+      "description": "This service manages workers, including provisioning for dynamic worker pools.\n\nMethods interacting with a provider may return a 503 response if that provider has\nnot been able to start up, such as if the service to which it interfaces has an\noutage.  Such requests can be retried as for any other 5xx response.",
       "entries": [
         {
           "args": [

--- a/services/worker-manager/docs/providers.md
+++ b/services/worker-manager/docs/providers.md
@@ -107,10 +107,6 @@ Providers may manage worker-pool-specific resources.
 For example, a provider for a cloud might isolate workers for each worker pool in a dedicated network.
 Such resources should be named after the `workerPoolId`.
 
-When a new worker pool is created, or a worker pool's provider ID is changed, the provider's `createResources` method is called.
-When a worker pool is modified, its provider's `updateResources` method is called.
-When a previous provider for a worker pool no longer has any running workers, its `removeResources` method is called.
-
 Each WorkerPool entity has a `providerData` property.
 This property is shared among all providers, so each provider should use a sub-object named after the `providerId`.
 Thus data should be accessed as `workerPool.providerData[this.providerId].propName`.

--- a/services/worker-manager/src/api.js
+++ b/services/worker-manager/src/api.js
@@ -10,6 +10,10 @@ let builder = new APIBuilder({
   title: 'Worker Manager Service',
   description: [
     'This service manages workers, including provisioning for dynamic worker pools.',
+    '',
+    'Methods interacting with a provider may return a 503 response if that provider has',
+    'not been able to start up, such as if the service to which it interfaces has an',
+    'outage.  Such requests can be retried as for any other 5xx response.',
   ].join('\n'),
   serviceName: 'worker-manager',
   apiVersion: 'v1',
@@ -17,6 +21,9 @@ let builder = new APIBuilder({
     workerPoolId: /^[a-zA-Z0-9-_]{1,38}\/[a-z]([-a-z0-9]{0,36}[a-z0-9])?$/,
     workerGroup: /^([a-zA-Z0-9-_]{1,38})$/,
     workerId: /^([a-zA-Z0-9-_]{1,38})$/,
+  },
+  errorCodes: {
+    ProviderSetupFailed: 503,
   },
   context: [
     'cfg',
@@ -93,6 +100,10 @@ builder.declare({
       providerId,
       validProviderIds: this.providers.validProviderIds(),
     });
+  } else if (provider.setupFailed) {
+    return res.reportError('ProviderSetupFailed', 'Provider backend may be down or misconfigured', {
+      providerId,
+    });
   }
 
   // This has been validated at the api level to ensure that it
@@ -152,6 +163,10 @@ builder.declare({
     return res.reportError('InputError', 'Invalid Provider', {
       providerId,
       validProviderIds: this.providers.validProviderIds(),
+    });
+  } else if (provider.setupFailed) {
+    return res.reportError('ProviderSetupFailed', 'Provider backend may be down or misconfigured', {
+      providerId,
     });
   }
 
@@ -319,6 +334,15 @@ builder.declare({
   // worker.  If this distinction becomes important, this can be changed to get
   // the worker and use its providerId instead of workerPool.providerId.
   const provider = await this.providers.get(workerPool.providerId);
+  if (!provider) {
+    return res.reportError('InputError', 'Invalid Provider', {
+      providerId: workerPool.providerId,
+    });
+  } else if (provider.setupFailed) {
+    return res.reportError('ProviderSetupFailed', 'Provider backend may be down or misconfigured', {
+      providerId: workerPool.providerId,
+    });
+  }
 
   const wpe = await provider.reportError({
     workerPool,
@@ -460,6 +484,10 @@ builder.declare({
   if (!provider) {
     return res.reportError('ResourceNotFound',
       `Provider ${workerPool.providerId} for worker pool ${workerPoolId} does not exist`, {});
+  } else if (provider.setupFailed) {
+    return res.reportError('ProviderSetupFailed', 'Provider backend may be down or misconfigured', {
+      providerId: workerPool.providerId,
+    });
   }
 
   let worker;
@@ -521,6 +549,10 @@ builder.declare({
   if (!provider) {
     return res.reportError('ResourceNotFound',
       `Provider ${workerPool.providerId} for worker pool ${workerPoolId} does not exist`, {});
+  } else if (provider.setupFailed) {
+    return res.reportError('ProviderSetupFailed', 'Provider backend may be down or misconfigured', {
+      providerId: workerPool.providerId,
+    });
   }
 
   let worker = await Worker.get(this.db, { workerPoolId, workerGroup, workerId });
@@ -577,6 +609,10 @@ builder.declare({
   if (!provider) {
     return res.reportError('ResourceNotFound',
       `Provider ${worker.providerId} for this worker does not exist`, {});
+  } else if (provider.setupFailed) {
+    return res.reportError('ProviderSetupFailed', 'Provider backend may be down or misconfigured', {
+      providerId: worker.providerId,
+    });
   }
 
   try {
@@ -671,6 +707,10 @@ builder.declare({
   if (!provider) {
     return res.reportError('ResourceNotFound',
       `Provider ${providerId} does not exist`, {});
+  } else if (provider.setupFailed) {
+    return res.reportError('ProviderSetupFailed', 'Provider backend may be down or misconfigured', {
+      providerId,
+    });
   }
 
   if (workerPool.providerId !== providerId && !workerPool.previousProviderIds.includes(providerId)) {

--- a/services/worker-manager/src/main.js
+++ b/services/worker-manager/src/main.js
@@ -200,14 +200,13 @@ let load = loader({
   },
 
   provisioner: {
-    requires: ['cfg', 'monitor', 'providers', 'notify', 'pulseClient', 'reference', 'db'],
-    setup: async ({ cfg, monitor, providers, notify, pulseClient, reference, db }, ownName) => {
+    requires: ['cfg', 'monitor', 'providers', 'notify', 'reference', 'db'],
+    setup: async ({ cfg, monitor, providers, notify, reference, db }, ownName) => {
       return new Provisioner({
         ownName,
         monitor: monitor.childMonitor('provisioner'),
         providers,
         notify,
-        pulseClient,
         db,
         reference,
         rootUrl: cfg.taskcluster.rootUrl,

--- a/services/worker-manager/src/providers/google.js
+++ b/services/worker-manager/src/providers/google.js
@@ -164,9 +164,6 @@ class GoogleProvider extends Provider {
     // nothing to do: we just wait for workers to terminate themselves
   }
 
-  async removeResources({ workerPool }) {
-  }
-
   async removeWorker({ worker, reason }) {
     this.monitor.log.workerRemoved({
       workerPoolId: worker.workerPoolId,

--- a/services/worker-manager/src/providers/index.js
+++ b/services/worker-manager/src/providers/index.js
@@ -14,12 +14,21 @@ const PROVIDER_TYPES = {
   azure: AzureProvider,
 };
 
+// sleep for 60 between trying the `setup` method of providers
+let SETUP_RETRY_INTERVAL = 60 * 1000;
+
+// for tests..
+const setSetupRetryInterval = i => SETUP_RETRY_INTERVAL = i;
+
 /**
  * Load all of the providers in the configuration, including loading
- * their providerType implementation as required
+ * their providerType implementation as required.  This class also tracks
+ * which providers have successfully been set up, and handles failed setup
+ * properly by never returning a failed provider.
  */
 class Providers {
   async setup({ cfg, monitor, notify, db, estimator, Worker, WorkerPoolError, validator }) {
+    this.monitor = monitor;
     this._providers = {};
 
     if (cfg.providers['null-provider']) {
@@ -48,40 +57,70 @@ class Providers {
         providerConfig,
       });
       this._providers[providerId] = provider;
-      await provider.setup();
+
+      // await the first attempt at setting up the provider
+      await this.setupProvider(providerId, provider);
     }
 
     // return self to make this easier to use in a loader component
     return this;
   }
 
+  // Try *once* to set up the provider, returning either with success or
+  // having marked the provider as `provider.setupFailed = true` with a
+  // retry scheduled.
+  async setupProvider(providerId, provider) {
+    try {
+      await provider.setup();
+      provider.setupFailed = false;
+    } catch (err) {
+      // if an error occurs in setup, mark the provider as having failed its
+      // setup, report the error, and then try again after a delay.  Note that
+      // this (async) function returns before that retry completes.
+      provider.setupFailed = true;
+      this.monitor.reportError(err, { providerId });
+      setTimeout(() => this.setupProvider(providerId, provider), SETUP_RETRY_INTERVAL);
+    }
+  }
+
   /**
-   * Get a list of valid providerIds
+   * Get a list of valid providerIds (including those whose setup has failed)
    */
   validProviderIds() {
     return Object.keys(this._providers);
   }
 
   /**
-   * Run the async callback for all providers
+   * Run the async callback for all providers that have been setup successfully
    */
   forAll(cb) {
-    return Promise.all(Object.values(this._providers).map(cb));
+    return Promise.all(
+      Object.values(this._providers)
+        .filter(p => !p.setupFailed)
+        .map(cb));
   }
 
   /**
-   * Return true if this providerId is defined
+   * Return true if this providerId is defined (regardless of whether its setup failed)
    */
   has(providerId) {
     return Boolean(this._providers[providerId]);
   }
 
   /**
-   * Get the named provider instance.
+   * Get the named provider instance.  If no such provider exists, this returns null;
+   * if the provider is not yet set up, it returns an object with `{setupFailed: true}`
+   * It is up to the caller to verify this property.
    */
   get(providerId) {
-    return this._providers[providerId];
+    const p = this._providers[providerId];
+    if (p && p.setupFailed) {
+      // If setup failed, we do not return the provider, but just an empty object.  This
+      // avoids mistakes where the caller does not check for failed setup.
+      return { setupFailed: true };
+    }
+    return p;
   }
 }
 
-module.exports = { Providers };
+module.exports = { Providers, setSetupRetryInterval };

--- a/services/worker-manager/src/providers/provider.js
+++ b/services/worker-manager/src/providers/provider.js
@@ -82,15 +82,6 @@ class Provider {
     throw new ApiError('not supported for this provider');
   }
 
-  async createResources({ workerPool }) {
-  }
-
-  async updateResources({ workerPool }) {
-  }
-
-  async removeResources({ workerPool }) {
-  }
-
   /**
    * Takes a lifecycle block as defined in the schema and returns
    * a date when the worker should be destroyed if the provider

--- a/services/worker-manager/src/providers/testing.js
+++ b/services/worker-manager/src/providers/testing.js
@@ -6,6 +6,14 @@ class TestingProvider extends Provider {
   constructor(conf) {
     super(conf);
     this.configSchema = 'config-testing';
+    this.setupFailure = conf.providerConfig.setupFailure;
+  }
+
+  async setup() {
+    if (this.setupFailure > 0) {
+      this.setupFailure--;
+      throw new Error('setup failure');
+    }
   }
 
   async createResources({ workerPool }) {

--- a/services/worker-manager/src/providers/testing.js
+++ b/services/worker-manager/src/providers/testing.js
@@ -16,24 +16,6 @@ class TestingProvider extends Provider {
     }
   }
 
-  async createResources({ workerPool }) {
-    this.monitor.notice('create-resource', { workerPoolId: workerPool.workerPoolId });
-  }
-
-  async updateResources({ workerPool }) {
-    this.monitor.notice('update-resource', { workerPoolId: workerPool.workerPoolId });
-  }
-
-  async removeResources({ workerPool }) {
-    this.monitor.notice('remove-resource', { workerPoolId: workerPool.workerPoolId });
-    if (workerPool.providerData.failRemoveResources) {
-      workerPool.providerData.failRemoveResources -= 1;
-      await this.db.fns.update_worker_pool_provider_data(
-        workerPool.workerPoolId, this.providerId, workerPool.providerData);
-      throw new Error('uhoh removing resources');
-    }
-  }
-
   async provision({ workerPool, workerInfo }) {
     this.monitor.notice('test-provision', { workerPoolId: workerPool.workerPoolId, workerInfo });
   }

--- a/services/worker-manager/src/provisioner.js
+++ b/services/worker-manager/src/provisioner.js
@@ -1,6 +1,4 @@
-const taskcluster = require('taskcluster-client');
 const Iterate = require('taskcluster-lib-iterate');
-const { consume } = require('taskcluster-lib-pulse');
 const { paginatedIterator } = require('taskcluster-lib-postgres');
 const { WorkerPool, Worker } = require('./data');
 
@@ -9,27 +7,19 @@ const { WorkerPool, Worker } = require('./data');
  */
 class Provisioner {
   constructor({ providers, iterateConf, Worker, WorkerPool,
-    monitor, notify, pulseClient, db, reference,
+    monitor, notify, db, reference,
     rootUrl, ownName }) {
     this.providers = providers;
     this.WorkerPool = WorkerPool;
     this.Worker = Worker;
     this.monitor = monitor;
     this.notify = notify;
-    this.pulseClient = pulseClient;
     this.db = db;
 
     // lib-iterate will have loops stand on top of each other
     // so we will explicitly grab a mutex in each loop to ensure
     // we're the only one going at any given time
     this.provisioningLoopAlive = false;
-
-    const WorkerManagerEvents = taskcluster.createClient(reference);
-    const workerManagerEvents = new WorkerManagerEvents({ rootUrl });
-    this.bindings = [
-      workerManagerEvents.workerPoolCreated(),
-      workerManagerEvents.workerPoolUpdated(),
-    ];
 
     this.iterate = new Iterate({
       maxFailures: 10,
@@ -55,14 +45,6 @@ class Provisioner {
   async initiate() {
     await this.providers.forAll(p => p.initiate());
     await this.iterate.start();
-
-    this.pq = await consume({
-      client: this.pulseClient,
-      bindings: this.bindings,
-      queueName: 'workerPoolUpdates',
-    },
-    this.monitor.timedHandler('notification', this.onMessage.bind(this)),
-    );
   }
 
   /**
@@ -75,42 +57,6 @@ class Provisioner {
     }
     await this.iterate.stop();
     await this.providers.forAll(p => p.terminate());
-  }
-
-  async onMessage({ exchange, payload }) {
-    const { workerPoolId, providerId, previousProviderId } = payload;
-    const workerPool = await WorkerPool.get(this.db, workerPoolId);
-    const provider = this.providers.get(providerId);
-
-    if (!workerPool || !provider) {
-      // ignore messages for unknown worker pools and providers
-      return;
-    }
-
-    if (provider.setupFailed) {
-      // if setup has failed for this provider, there's not much we can do:
-      // the message cannot remain queued forever.  These messages occur
-      // when an API operation such as createWorkerPool is called, and those
-      // methods will fail if provider setup has failed, so we ignore such
-      // messages in hopes that they rarely or never occur.
-      return;
-    }
-
-    switch (exchange.split('/').pop()) {
-      case 'worker-pool-created': {
-        await provider.createResources({ workerPool });
-        break;
-      }
-      case 'worker-pool-updated': {
-        if (providerId === previousProviderId) {
-          await provider.updateResources({ workerPool });
-        } else {
-          await provider.createResources({ workerPool });
-        }
-        break;
-      }
-      default: throw new Error(`Unknown exchange: ${exchange}`);
-    }
   }
 
   /**
@@ -219,17 +165,8 @@ class Provisioner {
           }
 
           // Now if this provider is no longer a provider for any workers that exist
-          // in this pool, we allow it to clean up any resources it has and then we remove
-          // it from the previous providers list
+          // in this pool, remove it from the previous providers list
           if (!providerByPool.providers.has(pId)) {
-            try {
-              await provider.removeResources({ workerPool });
-            } catch (err) {
-              // report error and try again next time..
-              this.monitor.reportError(err, { workerPoolId, providerId: pId });
-              return;
-            }
-            // the provider is done with this pool, so remove it from the list of previous providers
             await this.db.fns.remove_worker_pool_previous_provider_id(workerPoolId, pId);
           }
 

--- a/services/worker-manager/src/worker-scanner.js
+++ b/services/worker-manager/src/worker-scanner.js
@@ -54,6 +54,11 @@ class WorkerScanner {
       const worker = Worker.fromDb(row);
       const provider = this.providers.get(worker.providerId);
       if (provider) {
+        if (provider.setupFailed) {
+          // if setup has failed for this provider, just do nothing with the worker
+          // until it's up and running
+          continue;
+        }
         try {
           await provider.checkWorker({ worker });
         } catch (err) {

--- a/services/worker-manager/test/provider_google_test.js
+++ b/services/worker-manager/test/provider_google_test.js
@@ -361,15 +361,6 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
     assert(workerPool.previousProviderIds.includes('google'));
   });
 
-  test('removeResources', async function() {
-    const workerPool = await makeWorkerPool({
-      providerData: { google: {} },
-    });
-    await provider.removeResources({ workerPool });
-    // nothing has changed..
-    assert.deepEqual(workerPool.providerData.google, {});
-  });
-
   test('removeWorker', async function() {
     const workerId = '12345';
     const worker = await makeWorker({

--- a/services/worker-manager/test/providers_test.js
+++ b/services/worker-manager/test/providers_test.js
@@ -1,0 +1,60 @@
+const assert = require('assert');
+const helper = require('./helper');
+const testing = require('taskcluster-lib-testing');
+const { setSetupRetryInterval } = require('../src/providers');
+
+helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
+  helper.withDb(mock, skipping);
+  helper.withFakeNotify(mock, skipping);
+  helper.withProviders(mock, skipping);
+  helper.resetTables(mock, skipping);
+
+  suite('failing provider setup', function() {
+    let monitor;
+    setup(async function() {
+      monitor = await helper.load('monitor');
+
+      setSetupRetryInterval(100); // 100ms by default, to avoid providers retrying for too long
+
+      // load cfg so that helper.load.cfg(..) works later
+      await helper.load('cfg');
+
+      // reset the 'providers' component after each test
+      helper.load.remove('providers');
+    });
+
+    teardown(function() {
+      // check for and flush the errors about the provider starting up
+      assert(
+        monitor.manager.messages.every(
+          msg => msg.Type === 'monitor.error' && msg.Fields.message === 'setup failure'));
+      monitor.manager.reset();
+    });
+
+    test('failed provider is not included in forAll, but has returns true', async function() {
+      helper.load.cfg('providers.testing1.setupFailure', 1);
+      const providers = await helper.load('providers');
+      await providers.forAll(prov => assert.notEqual(prov.providerId, 'testing1'));
+      assert(providers.has('testing1'));
+    });
+
+    test('failed provider is returned by get with `setupFailed` property', async function() {
+      helper.load.cfg('providers.testing1.setupFailure', 1);
+      const providers = await helper.load('providers');
+      assert.deepEqual(providers.get('testing1'), { setupFailed: true });
+    });
+
+    test('provider is returned by get once it succeeds', async function() {
+      setSetupRetryInterval(5); // very short, since we want this to recover quickly
+      helper.load.cfg('providers.testing1.setupFailure', 2);
+      const providers = await helper.load('providers');
+      let loops = 0;
+      while (loops < 100 && providers.get('testing1').setupFailed) {
+        loops++;
+        await testing.sleep(3);
+      }
+      assert(loops > 0);
+      assert(!providers.get('testing1').setupFailed);
+    });
+  });
+});


### PR DESCRIPTION
This allows the failure of one provider, or a provider backend such as a
cloud provider, from causing the entire process to fail a startup.

Github Bug/Issue: Fixes #4276
