### PR TITLE
Doc that the artifact.contentType is informational

### DIFF
--- a/changelog/epN9o-WkS4a2zI9R9OxYbA.md
+++ b/changelog/epN9o-WkS4a2zI9R9OxYbA.md
@@ -1,0 +1,3 @@
+audience: general
+level: silent
+---

--- a/clients/client-go/tcqueue/types.go
+++ b/clients/client-go/tcqueue/types.go
@@ -90,7 +90,10 @@ type (
 	// Information about an artifact for the given `taskId` and `runId`.
 	Artifact struct {
 
-		// Mimetype for the artifact that was created.
+		// Expected content-type of the artifact.  This is informational only:
+		// it is suitable for use to choose an icon for the artifact, for example.
+		// The accurate content-type of the artifact can only be determined by
+		// downloading it.
 		//
 		// Max length: 255
 		ContentType string `json:"contentType"`
@@ -524,10 +527,10 @@ type (
 	// Clients will not apply any form of authentication to that URL.
 	RedirectArtifactRequest struct {
 
-		// Artifact mime-type for the resource to which the queue should
-		// redirect. Please use the same `Content-Type`, consistently using
-		// the correct mime-type make tooling a lot easier, specifically,
-		// always using `application/json` for JSON artifacts.
+		// Expected content-type of the artifact.  This is informational only:
+		// it is suitable for use to choose an icon for the artifact, for example.
+		// The accurate content-type of the artifact can only be determined by
+		// downloading it.
 		//
 		// Max length: 255
 		ContentType string `json:"contentType"`

--- a/clients/client-go/tcqueueevents/types.go
+++ b/clients/client-go/tcqueueevents/types.go
@@ -10,9 +10,10 @@ type (
 	// Information about the artifact that was created
 	Artifact struct {
 
-		// Mimetype for the artifact that was created (NOTE: deprecated; this
-		// value is not checked and may not correspond to the content-type of
-		// the final artifact)
+		// Expected content-type of the artifact.  This is informational only:
+		// it is suitable for use to choose an icon for the artifact, for example.
+		// The accurate content-type of the artifact can only be determined by
+		// downloading it.
 		//
 		// Max length: 255
 		ContentType string `json:"contentType"`

--- a/generated/references.json
+++ b/generated/references.json
@@ -3043,7 +3043,7 @@
           "description": "Request the queue to redirect fetches for this artifact to a URL.  An\nexisting artifact can be replaced with a RedirectArtifact as long as the\ntask is still executing.  When a RedirectArtifact is fetched, the URL is\nreturned verbatim as a Location header in a 303 (See Other) response.\nClients will not apply any form of authentication to that URL.\n",
           "properties": {
             "contentType": {
-              "description": "Artifact mime-type for the resource to which the queue should\nredirect. Please use the same `Content-Type`, consistently using\nthe correct mime-type make tooling a lot easier, specifically,\nalways using `application/json` for JSON artifacts.\n",
+              "description": "Expected content-type of the artifact.  This is informational only:\nit is suitable for use to choose an icon for the artifact, for example.\nThe accurate content-type of the artifact can only be determined by\ndownloading it.\n",
               "maxLength": 255,
               "type": "string"
             },
@@ -3615,7 +3615,7 @@
             "description": "Information about an artifact for the given `taskId` and `runId`.\n",
             "properties": {
               "contentType": {
-                "description": "Mimetype for the artifact that was created.\n",
+                "description": "Expected content-type of the artifact.  This is informational only:\nit is suitable for use to choose an icon for the artifact, for example.\nThe accurate content-type of the artifact can only be determined by\ndownloading it.\n",
                 "maxLength": 255,
                 "title": "Content-Type",
                 "type": "string"
@@ -3914,7 +3914,7 @@
           "description": "Information about the artifact that was created\n",
           "properties": {
             "contentType": {
-              "description": "Mimetype for the artifact that was created (NOTE: deprecated; this\nvalue is not checked and may not correspond to the content-type of\nthe final artifact)\n",
+              "description": "Expected content-type of the artifact.  This is informational only:\nit is suitable for use to choose an icon for the artifact, for example.\nThe accurate content-type of the artifact can only be determined by\ndownloading it.\n",
               "maxLength": 255,
               "title": "Content-Type",
               "type": "string"

--- a/services/queue/schemas/v1/artifact-created-message.yml
+++ b/services/queue/schemas/v1/artifact-created-message.yml
@@ -62,9 +62,10 @@ properties:
       contentType:
         title:    "Content-Type"
         description: |
-          Mimetype for the artifact that was created (NOTE: deprecated; this
-          value is not checked and may not correspond to the content-type of
-          the final artifact)
+          Expected content-type of the artifact.  This is informational only:
+          it is suitable for use to choose an icon for the artifact, for example.
+          The accurate content-type of the artifact can only be determined by
+          downloading it.
         type:         string
         maxLength:    255
     additionalProperties: false

--- a/services/queue/schemas/v1/list-artifacts-response.yml
+++ b/services/queue/schemas/v1/list-artifacts-response.yml
@@ -44,7 +44,10 @@ properties:
         contentType:
           title:    "Content-Type"
           description: |
-            Mimetype for the artifact that was created.
+            Expected content-type of the artifact.  This is informational only:
+            it is suitable for use to choose an icon for the artifact, for example.
+            The accurate content-type of the artifact can only be determined by
+            downloading it.
           type:         string
           maxLength:    255
       additionalProperties: false

--- a/services/queue/schemas/v1/post-artifact-request.yml
+++ b/services/queue/schemas/v1/post-artifact-request.yml
@@ -60,10 +60,10 @@ oneOf:
         format:     date-time
       contentType:
         description: |
-          Artifact mime-type for the resource to which the queue should
-          redirect. Please use the same `Content-Type`, consistently using
-          the correct mime-type make tooling a lot easier, specifically,
-          always using `application/json` for JSON artifacts.
+          Expected content-type of the artifact.  This is informational only:
+          it is suitable for use to choose an icon for the artifact, for example.
+          The accurate content-type of the artifact can only be determined by
+          downloading it.
         type:       string
         maxLength:  255
       url:


### PR DESCRIPTION
This value is used by the UI to select an icon, and that purpose is just
fine.  But it is redundant to the content-type of the actual data in the
artifact, and it's important to be clear about which value is
authoritative.

I had previously marked this value as deprecated, but that's not quite right.