### PR TITLE
Publish rust client

### DIFF
--- a/changelog/issue-4298.md
+++ b/changelog/issue-4298.md
@@ -1,0 +1,4 @@
+audience: general
+level: silent
+reference: issue 4298
+---

--- a/clients/client-rust/Cargo.toml
+++ b/clients/client-rust/Cargo.toml
@@ -3,6 +3,8 @@ name = "taskcluster"
 version = "40.0.3"
 authors = ["Wander Lairson Costa <wander.lairson@gmail.com>"]
 edition = "2018"
+license = "MPL-2.0"
+description = "API client for Taskcluster"
 
 [dependencies]
 anyhow = "1.0"

--- a/infrastructure/tooling/src/build/index.js
+++ b/infrastructure/tooling/src/build/index.js
@@ -174,6 +174,7 @@ class Publish extends Base {
     expectedVars.push('GH_TOKEN');
     if (!this.cmdOptions.staging) {
       expectedVars.push('NPM_TOKEN');
+      expectedVars.push('CRATESIO_TOKEN');
       expectedVars.push('PYPI_USERNAME');
       expectedVars.push('PYPI_PASSWORD');
       expectedVars.push('DOCKER_USERNAME');
@@ -189,6 +190,7 @@ class Publish extends Base {
     return {
       ghToken: process.env.GH_TOKEN,
       npmToken: process.env.NPM_TOKEN,
+      cratesioToken: process.env.CRATESIO_TOKEN,
       pypiUsername: process.env.PYPI_USERNAME,
       pypiPassword: process.env.PYPI_PASSWORD,
       dockerUsername: process.env.DOCKER_USERNAME,

--- a/infrastructure/tooling/src/build/tasks/release.js
+++ b/infrastructure/tooling/src/build/tasks/release.js
@@ -5,6 +5,7 @@ const path = require('path');
 const {
   ensureTask,
   npmPublish,
+  cargoPublish,
   execCommand,
   pyClientRelease,
   readRepoFile,
@@ -287,6 +288,24 @@ module.exports = ({ tasks, cmdOptions, credentials, baseDir, logsDir }) => {
   });
 
   ensureTask(tasks, {
+    title: `Publish clients/client-rust to crates.io`,
+    requires: [
+      'github-release', // to make sure the release finishes first..
+    ],
+    provides: [
+      `publish-clients/client-rust`,
+    ],
+    run: async (requirements, utils) => {
+      await cargoPublish({
+        dir: path.join(REPO_ROOT, 'clients', 'client-rust'),
+        token: credentials.cratesioToken,
+        push: cmdOptions.push && !cmdOptions.staging,
+        logfile: path.join(logsDir, 'publish-client-rust.log'),
+        utils });
+    },
+  });
+
+  ensureTask(tasks, {
     title: 'Publish Complete',
     requires: [
       'release-version',
@@ -295,6 +314,7 @@ module.exports = ({ tasks, cmdOptions, credentials, baseDir, logsDir }) => {
       'publish-clients/client',
       'publish-clients/client-web',
       'publish-clients/client-py',
+      'publish-clients/client-rust',
     ],
     provides: [
       'target-publish',

--- a/infrastructure/tooling/src/utils/crates.js
+++ b/infrastructure/tooling/src/utils/crates.js
@@ -1,0 +1,68 @@
+const fs = require('fs');
+const util = require('util');
+const path = require('path');
+const rimraf = util.promisify(require('rimraf'));
+const mkdirp = require('mkdirp');
+const child_process = require('child_process');
+const Observable = require('zen-observable');
+const taskcluster = require('taskcluster-client');
+const { REPO_ROOT } = require('./repo');
+
+/**
+ * Set up Cargo credentials and call `cargo publish`
+ *
+ * - dir -- directory to publish from
+ * - token -- crates.io token to use (if not set, no auth is set up)
+ * - push -- if true, actually publish (otherwise --dry-run)
+ * - logfile -- name of the file to write the log to
+ * - utils -- taskgraph utils (waitFor, etc.)
+ */
+exports.cargoPublish = async ({ dir, token, push, logfile, utils }) => {
+  // override HOME so this doesn't use the user's credentials
+  const homeDir = path.join(REPO_ROOT, 'temp', taskcluster.slugid());
+
+  // set up the cargo credentials
+  if (token) {
+    await mkdirp(path.join(homeDir, '.cargo'));
+    await fs.writeFileSync(path.join(homeDir, '.cargo', 'credentials'), `[registry]\ntoken = "${token}"\n`);
+  }
+
+  try {
+    await utils.waitFor(new Observable(observer => {
+      const cmd = ['publish'];
+      // the crate has been through CI already, so just publish it as-is (this saves a bunch of time
+      // building all of the dependent crates)
+      cmd.push('--no-verify');
+      if (!push) {
+        cmd.push('--dry-run');
+      }
+      const proc = child_process.spawn('cargo', cmd, {
+        env: {
+          ...process.env,
+          HOME: homeDir,
+        },
+        cwd: dir,
+      });
+
+      if (logfile) {
+        const logStream = fs.createWriteStream(logfile);
+        proc.stdout.pipe(logStream);
+        proc.stderr.pipe(logStream);
+      }
+
+      const loglines = data =>
+        data.toString('utf-8').trimRight().split(/[\r\n]+/).forEach(l => observer.next(l));
+      proc.stdout.on('data', loglines);
+      proc.stderr.on('data', loglines);
+      proc.on('close', code => {
+        if (code !== 0) {
+          observer.error(new Error(`release.sh exited with code ${code}; see ${logfile} for details`));
+        } else {
+          observer.complete();
+        }
+      });
+    }));
+  } finally {
+    await rimraf(homeDir);
+  }
+};

--- a/infrastructure/tooling/src/utils/index.js
+++ b/infrastructure/tooling/src/utils/index.js
@@ -5,6 +5,7 @@ module.exports = {
   ...require('./docker'),
   ...require('./command'),
   ...require('./config'),
+  ...require('./crates'),
   ...require('./npm'),
   ...require('./pypi'),
   ...require('./dockerflow'),

--- a/taskcluster/ci/release/kind.yml
+++ b/taskcluster/ci/release/kind.yml
@@ -21,6 +21,10 @@ job-defaults:
           url: 'https://storage.googleapis.com/golang/{go_version}.linux-amd64.tar.gz'
         directory: 'go'
         format: tar.gz
+      - content:
+          url: 'https://static.rust-lang.org/dist/rust-{rust_version}-x86_64-unknown-linux-gnu.tar.gz'
+        directory: 'rust'
+        format: tar.gz
   description: Perform an actual taskcluster release
   run:
     using: bare
@@ -33,6 +37,8 @@ job-defaults:
       - go version
       # set up gox
       - go get github.com/mitchellh/gox
+      # set up rust, based on the mounted tarball
+      - "./rust/rust-$RUST_VERSION-x86_64-unknown-linux-gnu/install.sh"
       # set up Node, using nvm (generic-worker does not support .xz, so we can't use mounts)
       - curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.35.2/install.sh | bash
       - . ~/.nvm/nvm.sh


### PR DESCRIPTION
Github Bug/Issue: Fixes #4298

There's no good way to stage the upload part, unfortunately.  As-is, it does a dry run without building the crate, which amounts to not much more than exercising the JS code that calls `cargo publish`.

See https://docs.rs/taskcluster/40.0.3/taskcluster/ for the docs :)