### PR TITLE
Add taskQueueId and projectId to the UI and docs

### DIFF
--- a/changelog/issue-4269.md
+++ b/changelog/issue-4269.md
@@ -1,0 +1,5 @@
+audience: users
+level: patch
+reference: issue 4269
+---
+The task properties `projectId` and `taskQueueId` are now displayed in the Taskcluster UI, and referenced appropriately in the documentation.

--- a/generated/docs-search.json
+++ b/generated/docs-search.json
@@ -1267,13 +1267,6 @@
     "title": "Manipulating Tasks"
   },
   {
-    "element": "h2",
-    "id": "choosing-a-kind",
-    "path": "/manual/using/actions",
-    "subtitle": "Choosing a Kind",
-    "title": null
-  },
-  {
     "element": "h1",
     "id": "deployment-administration",
     "path": "/manual/using/administration",
@@ -2850,16 +2843,9 @@
   },
   {
     "element": "h2",
-    "id": "provisioners",
+    "id": "worker-pools-and-task-queues",
     "path": "/reference/platform/queue/worker-hierarchy",
-    "subtitle": "Provisioners",
-    "title": "Worker Hierarchy"
-  },
-  {
-    "element": "h2",
-    "id": "worker-types",
-    "path": "/reference/platform/queue/worker-hierarchy",
-    "subtitle": "Worker Types",
+    "subtitle": "Worker Pools and Task Queues",
     "title": "Worker Hierarchy"
   },
   {

--- a/generated/docs-search.json
+++ b/generated/docs-search.json
@@ -1267,6 +1267,13 @@
     "title": "Manipulating Tasks"
   },
   {
+    "element": "h2",
+    "id": "rerunning",
+    "path": "/manual/tasks/manipulating",
+    "subtitle": "Rerunning",
+    "title": "Manipulating Tasks"
+  },
+  {
     "element": "h1",
     "id": "deployment-administration",
     "path": "/manual/using/administration",

--- a/generated/docs-table-of-contents.json
+++ b/generated/docs-table-of-contents.json
@@ -163,13 +163,35 @@
             },
             "name": "taskgroupid-schedulerid",
             "next": {
-              "path": "manual/tasks/manipulating",
-              "title": "Manipulating Tasks"
+              "path": "manual/tasks/projectId",
+              "title": "The projectId property"
             },
             "path": "manual/tasks/taskgroupid-schedulerid",
             "prev": {
               "path": "manual/tasks/dependencies",
               "title": "Dependencies and Task Graphs"
+            },
+            "up": {
+              "path": "manual/tasks",
+              "title": "Tasks"
+            }
+          },
+          {
+            "children": [
+            ],
+            "data": {
+              "order": 46,
+              "title": "The projectId property"
+            },
+            "name": "projectId",
+            "next": {
+              "path": "manual/tasks/manipulating",
+              "title": "Manipulating Tasks"
+            },
+            "path": "manual/tasks/projectId",
+            "prev": {
+              "path": "manual/tasks/taskgroupid-schedulerid",
+              "title": "The taskGroupId and schedulerId properties"
             },
             "up": {
               "path": "manual/tasks",
@@ -191,8 +213,8 @@
             },
             "path": "manual/tasks/manipulating",
             "prev": {
-              "path": "manual/tasks/taskgroupid-schedulerid",
-              "title": "The taskGroupId and schedulerId properties"
+              "path": "manual/tasks/projectId",
+              "title": "The projectId property"
             },
             "up": {
               "path": "manual/tasks",

--- a/generated/docs-table-of-contents.json
+++ b/generated/docs-table-of-contents.json
@@ -26,7 +26,7 @@
             "name": "times",
             "next": {
               "path": "manual/tasks/workertypes",
-              "title": "Worker Types"
+              "title": "Worker Pools"
             },
             "path": "manual/tasks/times",
             "prev": {
@@ -44,7 +44,7 @@
             "data": {
               "filename": "tasks/workertypes.mdx",
               "order": 20,
-              "title": "Worker Types"
+              "title": "Worker Pools"
             },
             "name": "workertypes",
             "next": {
@@ -77,7 +77,7 @@
             "path": "manual/tasks/priority",
             "prev": {
               "path": "manual/tasks/workertypes",
-              "title": "Worker Types"
+              "title": "Worker Pools"
             },
             "up": {
               "path": "manual/tasks",

--- a/services/web-server/src/graphql/Tasks.graphql
+++ b/services/web-server/src/graphql/Tasks.graphql
@@ -81,6 +81,9 @@ type Task {
   # This scope is necessary to _schedule_ a defined task, or _rerun_ a task.
   schedulerId: String!
 
+  # Identifier for this task's project
+  projectId: String!
+
   # Identifier for a group of tasks scheduled together with this task,
   # by the scheduler identified by `schedulerId`. For tasks scheduled by the
   # task-graph scheduler, this is the `taskGraphId`.

--- a/services/web-server/src/graphql/Tasks.graphql
+++ b/services/web-server/src/graphql/Tasks.graphql
@@ -65,11 +65,14 @@ type Task {
   # stripped of `=` padding.
   taskId: ID!
 
-  # Unique identifier for a provisioner, that can supply a specified `workerType`.
+  # Deprecated first half of the taskQueueId
   provisionerId: String!
 
-  # Unique identifier for a worker-type within a specific provisioner.
+  # Deprecated second half of the taskQueueId
   workerType: String!
+
+  # Task Queue containing this task
+  taskQueueId: String!
 
   # Identifier for the scheduler that _defined_ this task.
   # This can be an identifier for a user or a service like `"task-graph-scheduler"`.

--- a/ui/docs/manual/design/conventions/actions/guidelines.mdx
+++ b/ui/docs/manual/design/conventions/actions/guidelines.mdx
@@ -28,7 +28,7 @@ inputs that it requires. For example, a hook to re-trigger a task with
 allowing only those minimal inputs in an appropriate form (avoiding quoting
 vulnerabilities), and if possible add additional checks within the task itself
 -- for example, check that the task to be re-triggered has the expected
-schedulerId, workerType and provsionerId,
+schedulerId, and taskQueueId,
 
 Then consider who should be allowed to trigger the hook, and distribute the
 `hooks:trigger-hook` scope accordingly. Note that even if this scope is

--- a/ui/docs/manual/design/conventions/actions/spec.mdx
+++ b/ui/docs/manual/design/conventions/actions/spec.mdx
@@ -247,7 +247,7 @@ timestamps and dump input JSON into environment variables:
         }
       },
       "task": {
-        "workerType": "my-worker",
+        "taskQueueId": "my/worker",
         "payload": {
           "created": {"$fromNow": ""},
           "deadline": {"$fromNow": "1 hour 15 minutes"},

--- a/ui/docs/manual/tasks/README.mdx
+++ b/ui/docs/manual/tasks/README.mdx
@@ -20,8 +20,7 @@ documentation](/docs/reference/platform/queue/task-schema), but a
 simple task might look like this:
 
 ```yaml
-provisionerId:      proj-getting-started
-workerType:         tutorial
+taskQueueId:        proj-getting-started/tutorial
 created:            2020-01-04T04:18.084Z
 deadline:           2020-01-05T04:18.084Z
 metadata:

--- a/ui/docs/manual/tasks/manipulating.mdx
+++ b/ui/docs/manual/tasks/manipulating.mdx
@@ -10,7 +10,18 @@ For the most part, once a task is created it is left to run to its final
 resolution. However, there are a few API methods available to modify its
 behavior after creation.
 
-Permission for these methods is based on the task's `schedulerId`.
+Permission for these methods is based on the task's `projectId`.
+There are also legacy scopes relating to the `schedulerId`, but experience has shown that these scopes are not a practical way to control access.
+
+## Rerunning
+
+"Rerunning" a task is possible when the task is completed, but not yet past its deadline.
+A rerun entails adding a new run to the task.
+This is most often used for tasks that failed due to some intermittent issue, as the result of the last run is reflected in the result of the task.
+
+However, note that task dependencies operate on the first resolution of a task.
+That is, when a task fails, any tasks depending on it are executed (or not) accordingly.
+Subsequent reruns do not affect those dependent tasks.
 
 ## Force Scheduling
 

--- a/ui/docs/manual/tasks/projectId.mdx
+++ b/ui/docs/manual/tasks/projectId.mdx
@@ -1,0 +1,15 @@
+---
+title: The projectId property
+order: 46
+---
+
+Each task has a `projectId`.
+The intent of this identifier is to associate the task with a particular usage of the deployment.
+For example, in an organization building and testing several apps, the `projectId` might correspond to the app name.
+The `projectId` can be a `/`-separated, scoped identifier, for example `<department>/<app>`.
+
+Permissions to [manipulate](manipulating) a task are controlled by `projectId`.
+In a simple case, this means that developers of an app can be given scopes containing that app's `projectId`, allowing them to manipulate their own tasks but not those of other teams.
+
+Project IDs can also be used to track resource usage.
+Tasks using the object service for artifact storage require that the `projectId` of the artifact objects match that of the parent task.

--- a/ui/docs/manual/tasks/taskgroupid-schedulerid.mdx
+++ b/ui/docs/manual/tasks/taskgroupid-schedulerid.mdx
@@ -21,5 +21,6 @@ Tasks also have a `schedulerId`. All tasks in a task group must have the same
    `createTask` must have a scope related to the `schedulerId` of the task
    group (more about scopes later); and
 
- * it controls who can [manipulate tasks](manipulating), again by requiring
-   `schedulerId`-related scopes.
+ * it can control who can [manipulate tasks](manipulating), again by requiring
+   `schedulerId`-related scopes, although this is more easily accomplished
+   with `projectId`.

--- a/ui/docs/manual/tasks/workertypes.mdx
+++ b/ui/docs/manual/tasks/workertypes.mdx
@@ -1,21 +1,16 @@
 ---
 filename: tasks/workertypes.mdx
-title: Worker Types
+title: Worker Pools
 order: 20
 ---
 import Warning from 'taskcluster-ui/views/Documentation/components/Warning';
 
 Workers execute tasks, but there are many types of workers. A task specifies a
-single "worker type" by which it should be executed, using the two-part
-namespace `<provisionerId>/<workerType>`.  The naming of the identifiers can be
-a bit confusing: when we refer to a worker type, it is to the combination of
-both identifiers. Thus `gcp-provisioner/persona-build` and
-`rackspace-provisioner/persona-build` are completely different worker types,
-despite sharing the same `workerType` identifier.
+single "task queue" to which it should be added.
 
 <Warning>
-[RFC#145](https://github.com/taskcluster/taskcluster-rfcs/pull/145) addresses this confusion by introducing the term `taskQueueId` to name the queue in which a task is stored.
-This RFC is not yet fully implemented, so the Queue API still uses identifiers `provisionerId` and `workerType`.
+[RFC#145](https://github.com/taskcluster/taskcluster-rfcs/pull/145) introduced the term `taskQueueId`.
+Prior to Taskcluster version 41, this was referred to as `provisionerId`/`workerType`, and those names, while deprecated, still appear in historical tasks.
 </Warning>
 
 Workers of the same worker type all consume tasks from a single queue, as

--- a/ui/docs/manual/using/actions.mdx
+++ b/ui/docs/manual/using/actions.mdx
@@ -13,38 +13,4 @@ Common actions are:
 Actions are defined in-tree, so they are specific to the software being built and can be modified through the usual review process.
 Taskcluster defines a [convention](/docs/manual/conventions/actions) which allows user interfaces to connect users to these actions.
 
-## Choosing a Kind
-
-The "task" kind requires that the user invoking the task has all of the scopes
-necessary to run the action task (and to create any further tasks). Granting
-such scopes allows a user to perform undesirable actions with the Taskcluster
-API.
-
-The "hook" kind allows more control over users' permissions. The key
-observation is that `hooks.triggerHook` is governed by a scope of the form
-`hooks:trigger-hook:<hookGroupId>/<hookId>`, but the task it creates uses role
-`hook-id:<hookGroupId>/<hookId>`. The method also verifies its payload against
-the hook's `triggerSchema`.  This allows a controlled privilege escalation:
-only clients with the appropriate `trigger-hook` scope may trigger a hook, and
-only if they provide a payload matching the `triggerSchema`. If both of those
-conditions are met, then the resulting task may execute with permissions the
-originating client does not posses.
-
-To design a hook-based action, start with the hook and consider the minimal
-inputs that it requires. For example, a hook to re-trigger a task with
-`DEBUG=*` needs only a taskId. Construct the hook with a `triggerSchema`
-allowing only those minimal inputs in an appropriate form (avoiding quoting
-vulnerabilities), and if possible add additional checks within the task itself
--- for example, check that the task to be re-triggered has the expected
-schedulerId, workerType and provsionerId,
-
-Then consider who should be allowed to trigger the hook, and distribute the
-`hooks:trigger-hook` scope accordingly. Note that even if this scope is
-available only to a few users or clients, it is best to limit inputs carefully
-to avoid those users being "tricked" into running a malicious action.
-
-Once the hook is complete and functional, only then should you design the
-`actions.json` entry to trigger it.  At this point you should remember that the
-schema is only for documentation, and you cannot rely on the integrity of
-`actions.json`.  A "hook" action is just a template for how to call
-`hooks.triggerHook` and does not offer any level of security.
+See [Implementation Guidelines](/docs/manual/design/conventions/actions/guidelines) for more information on defining actions.

--- a/ui/docs/manual/using/caching.mdx
+++ b/ui/docs/manual/using/caching.mdx
@@ -20,7 +20,7 @@ Their use can result in a dramatic increase in task efficiency.
 Caches can be of arbitrary size (limited by the disk space available on the worker itself), but can be garbage-collected by the worker implementation between tasks, if necessary.
 Caching is most effective when "most" of the tasks executing on a worker use the same caches.
 Too great a variety of caches results in frequent garbage collection and a low hit rate.
-As such, caches aren't terribly useful on shared workerTypes such as `github-worker`.
+As such, caches aren't terribly useful on worker pools shared by many different kinds of tasks.
 
 ## Configuration
 

--- a/ui/docs/manual/using/scheduled-tasks.mdx
+++ b/ui/docs/manual/using/scheduled-tasks.mdx
@@ -27,11 +27,11 @@ The scopes available to a hook are given by a role. This allows separation of
 hook management from scope management, and the full generality of scope
 expansion. The role for a hook is named `hook-id:<hookGroupId>/<hookId>`. The
 role must include all of the scopes required to create the task, including
-`queue:create-task:<provisionerId>/<workerType>`.
+`queue:create-task:<taskQueueId>`.
 
 The scopes actually used by the hook's task are, of course, defined in
 `task.scopes`, which must be satisfied by the hook's role. These need not
-include `queue:create-task:<provisionerId>/<workerType>` unless the task will
+include `queue:create-task:<taskQueueId>` unless the task will
 be creating more tasks (for example, a [decision task](/docs/manual/conventions/decision-task)).
 
 For example, at one time the Taskcluster documentation was updated by a hook named `taskcluster/docs-update`.

--- a/ui/docs/reference/core/notify/usage.mdx
+++ b/ui/docs/reference/core/notify/usage.mdx
@@ -128,40 +128,29 @@ Finally, an example to tie it all together. This is the as-of-this-writing ``.ta
 
 
 ```yaml
-version: 0
+taskQueueId: tutorial/docker-worker
+routes:
+  - "notify.email.user@example.com.on-resolved"
+  - "notify.matrix-room.!whDRjjSmICCgrhFHsQ:mozilla.org.on-failed"
+  - "notify.matrix-room.!whDRjjSmICCgrhFHsQ:mozilla.org.on-exception"
+extra:
+  notify:
+    email:
+      content: 'Things worked in ${status.taskId}',
+  github:
+    env: true
+    events:
+      - pull_request.opened
+      - pull_request.synchronize
+      - pull_request.reopened
+      - push
+payload:
+  maxRunTime: 3600
+  image: "node:5"
+  command: ...
 metadata:
   name: "Taskcluster GitHub Tests"
-  description: "All non-integration tests for taskcluster github"
-  owner: "{{ event.head.user.email }}"
-  source: "{{ event.head.repo.url }}"
-tasks:
-  - provisionerId: "{{ taskcluster.docker.provisionerId }}"
-    workerType: "{{ taskcluster.docker.workerType }}"
-    routes:
-      - "notify.email.{{event.head.user.email}}.on-resolved"
-      - "notify.matrix-room.!whDRjjSmICCgrhFHsQ:mozilla.org.on-failed"
-      - "notify.matrix-room.!whDRjjSmICCgrhFHsQ:mozilla.org.on-exception"
-    extra:
-      notify:
-        email:
-          content: 'Things worked in ${status.taskId}',
-      github:
-        env: true
-        events:
-          - pull_request.opened
-          - pull_request.synchronize
-          - pull_request.reopened
-          - push
-    payload:
-      maxRunTime: 3600
-      image: "node:5"
-      command:
-        - "/bin/bash"
-        - "-lc"
-        - "git clone {{event.head.repo.url}} repo && cd repo && git checkout {{event.head.sha}} && npm install . && npm test"
-    metadata:
-      name: "Taskcluster GitHub Tests"
-      description: "All non-integration tests"
-      owner: "{{ event.head.user.email }}"
-      source: "{{ event.head.repo.url }}"
+  description: "All non-integration tests"
+  owner: "user@example.com"
+  source: "https://git.example.com"
 ```

--- a/ui/docs/reference/core/purge-cache/README.mdx
+++ b/ui/docs/reference/core/purge-cache/README.mdx
@@ -8,5 +8,5 @@ Many taskcluster workers implements some generic form cache folders.
 These cache often have a `name` that identifies them, for example a task that builds code may have a cache folder called `object-directory` which stores object directory for the latest changes to the `main` branch.
 Note, your organization maybe have different naming scheme.
 
-This service provides a broker for requests to purge these caches across all workers of a specific `provisionerId`/`workerType`.
+This service provides a broker for requests to purge these caches across all workers of a specific worker pool.
 It provides a method to add a new request, and a method for workers to poll for relevant purge requests since the last time they checked.

--- a/ui/docs/reference/integrations/github/taskcluster-yml-v1.mdx
+++ b/ui/docs/reference/integrations/github/taskcluster-yml-v1.mdx
@@ -84,8 +84,7 @@ The result looks like this:
     "tasks": [
         {
             "taskId": "fOF8Cqj0QPKbvczC2dnXiQ", // probably generated with as_slugid(..)
-            "provisionerId": "..",
-            "workerType": "..",
+            "taskQueueId": "..",
             "payload": {
                 // ..
             },
@@ -234,8 +233,7 @@ tasks:
   $match:
     'tasks_for == "github-pull-request" && event["action"] in ["opened", "reopened", "synchronize"]':
       taskId: {$eval: as_slugid("pr_task")}
-      provisionerId: proj-taskcluster
-      workerType: ci
+      taskQueueId: proj-taskcluster/ci
       scopes:
         - secrets:get:project/taskcluster/testing/taskcluster-github
       payload:
@@ -256,8 +254,7 @@ tasks:
         source: ${event.repository.url}
     'tasks_for == "github-push"':
       taskId: {$eval: as_slugid("push_task")}
-      provisionerId: proj-taskcluster
-      workerType: ci
+      taskQueueId: proj-taskcluster/ci
       scopes:
         - secrets:get:project/taskcluster/testing/taskcluster-github
       payload:

--- a/ui/docs/reference/platform/queue/task-life-cycle.mdx
+++ b/ui/docs/reference/platform/queue/task-life-cycle.mdx
@@ -50,7 +50,7 @@ and by implication the task, will be resolved as _exception_. The same happens
 if the task is canceled.
 
 The queue exposes an approximate number of pending tasks for each
-`provisionerId`/`workerType` combination, for use by provisioners that are able
+task queue, for use by provisioners that are able
 to dynamically scale up the number of workers.
 
 ## Running Tasks

--- a/ui/docs/reference/platform/queue/worker-hierarchy.mdx
+++ b/ui/docs/reference/platform/queue/worker-hierarchy.mdx
@@ -7,27 +7,13 @@ order: 30
 
 The queue defines a hierarchy of resources that consume tasks from queues:
 
-## Provisioners
+## Worker Pools and Task Queues
 
-[Provisioners](/docs/manual/task-execution/provisioning), identified with a
-`provisionerId`, are responsible for groups of worker types. While some
-provisioners, such as the AWS provisioner, are active software components,
-others are simply identifiers within the Queue service's data structures.
+A task queue contains tasks that expect to be executed in a specific environment, where "environment" means worker implementation, base operating system, host configuration, and so on.
+A worker pool contains workers that all provide the same evironment.
 
-Provisioners can be declared, and metadata associated with them, via the
-[declareProvisioner](/docs/reference/platform/queue/api#declareProvisioner)
-API method.
-
-## Worker Types
-
-[Worker Types](/docs/manual/tasks/workertypes), identified by
-`provisionerId/workerType`, are nested under a single provisioner and gather
-interchangeable workers that can all perform the same work. Tasks are queued
-for a specific worker type, and workers claim work for a single worker type.
-
-Worker types can be declared, and metadata associated with them, via the
-[declareWorkerType](/docs/reference/platform/queue/api#declareWorkerType)
-API method.
+Task queues are identified by `taskQueueId`, while worker pools are identified by `workerPoolId`.
+These are two sides of the same coin: tasks in a task queue are executed by workers in a worker pool of the same name.
 
 ## Workers
 

--- a/ui/docs/reference/platform/queue/worker-interaction.mdx
+++ b/ui/docs/reference/platform/queue/worker-interaction.mdx
@@ -21,10 +21,10 @@ termination, sections here outline how to handle all these cases.
 ## Claiming Pending Tasks
 A worker must at a minimum have the following configuration to claim tasks:
  * A `workerGroup` and `workerId` that uniquely identifies the worker,
- * A `provisionerId` and `workerType` that the identifies the pool of workers
+ * A `workerPoolId` that the identifies the pool of workers
    the worker belongs to, and,
  * Credentials with the following scopes
-   * `queue:claim-work:<provisionerId>/<workerType>`, and,
+   * `queue:claim-work:<workerPoolId>`, and,
    * `queue:worker-id:<workerGroup>/<workerId>`.
 
 Notice that the credentials may be temporary, this allows provisioners in

--- a/ui/docs/reference/workers/built-in-workers/README.mdx
+++ b/ui/docs/reference/workers/built-in-workers/README.mdx
@@ -4,8 +4,8 @@ import ReferenceLinks from 'taskcluster-ui/components/ReferenceLinks';
 
 # Built-In Workers Service
 
-This service implements the `built-in/succeed` and `built-in/fail` workerTypes, which simply succeed or fail immediately.
-Such workerTypes are useful the same way the `true` and `false` commands are useful in UNIX.
+This service implements the `built-in/succeed` and `built-in/fail` worker pools, which simply succeed or fail immediately.
+Such worker pools are useful the same way the `true` and `false` commands are useful in UNIX.
 For example, sometimes when testing a large combination of tasks, it's helpful to replace a task that's not relevant to your work with `built-in/succeed` to avoid wasting time and energy running that task.
 
 ## Usage
@@ -13,10 +13,11 @@ For example, sometimes when testing a large combination of tasks, it's helpful t
 To use this service, create a task with
 
 ```yaml
-provisionerId: built-in
-workerType: succeed  # or fail
+taskQueueId: built-in/succeed
 payload: {}
 ```
+
+Note that the names end in an imperative-mood verb ("succeed" and "fail").
 
 That's it!
 When the task executes (which may not be immediately, for example if it has dependencies), it will resolve immediately as successful or failed.

--- a/ui/docs/reference/workers/generic-worker/installing.mdx
+++ b/ui/docs/reference/workers/generic-worker/installing.mdx
@@ -168,7 +168,7 @@ __These instructions require macOS Mojave version 10.14.x__
       "disableReboots": false,
       "downloadsDir": "/Library/Caches/generic-worker/downloads",
       "ed25519SigningKeyLocation": "/etc/generic-worker/ed25519_key",
-      "provisionerId": "my-dear-provisioner",
+      "workerPoolId": "my/worker-pool",
       "publicIP": "1.2.3.4",
       "requiredDiskSpaceMegabytes": 2048,
       "rootURL": "https://my-root-url.com",
@@ -180,7 +180,6 @@ __These instructions require macOS Mojave version 10.14.x__
       "tasksDir": "/Users",
       "workerGroup": "my-worker-group",
       "workerId": "my-lovely-computer",
-      "workerType": "my-special-worker-type",
       "wstAudience": "taskcluster-net",
       "wstServerURL": "https://websocktunnel.tasks.build"
     }
@@ -378,11 +377,10 @@ Once you have been granted the above scope:
     "clientId":                   "<client ID of your permanent credentials>",
     "ed25519SigningKeyLocation":  "<file location you wrote ed25519 private key to>",
     "livelogSecret":              "<anything you like>",
-    "provisionerId":              "test-provisioner",
+    "workerPoolId":               "test/worker-pool",
     "publicIP":                   "<ideally an IP address of one of your network interfaces>",
     "workerGroup":                "test-worker-group",
     "workerId":                   "test-worker-id",
-    "workerType":                 "<a unique name that only you will use for your test worker(s)>"
 }
 ```
 
@@ -402,7 +400,7 @@ where `<config file>` is the generic worker config file you created above.
 
 Go to https://tools.taskcluster.net/task-creator/ and create a task to run on your generic worker.
 
-Use [this example](worker_types/win2012r2/task-definition.json) as a template, but make sure to edit `provisionerId` and `workerType` values so that they match what you set in your config file.
+Use [this example](worker_types/win2012r2/task-definition.json) as a template, but make sure to edit `taskQueueId` values so that they match what you set in your config file.
 
 Don't forget to submit the task by clicking the *Create Task* icon.
 

--- a/ui/docs/tutorial/create-task-via-api.mdx
+++ b/ui/docs/tutorial/create-task-via-api.mdx
@@ -25,14 +25,14 @@ payload for that method is:
 <SchemaTable schema="/schemas/queue/v1/create-task-request.json#" />
 
 As evident from the schema there are a few _required_ properties, such as:
-`provisionerId`, `workerType`, `created`, `deadline`, `payload` and `metadata`.
+`taskQueueId`, `created`, `deadline`, `payload` and `metadata`.
 The rest of the properties are optional and defaults should be documented.  It
 should, however, be noted that default values may change over time, so it is
 recommended provide those you rely on. More information about these fields and
 on tasks in general are available in the [manual](/docs/manual/tasks).
 
-All tasks have a `workerType` and `provisionerId` which together uniquely
-identify the worker pool you are submitting you task to. For the purpose of
+All tasks have a `taskQueueId` which uniquely
+identifies the task queue you are submitting you task to. For the purpose of
 this tutorial we shall refer to the `tutorial/docker-worker` worker pool, but
 you should substitute the details you determined in the "Hello World" step.
 
@@ -53,8 +53,7 @@ let taskcluster = require('taskcluster-client');
 let payload = {}; // worker specific payload - we'll add it later
 let task = {
   // Required properties
-  provisionerId:      'tutorial',
-  workerType:         'docker-worker',
+  taskQueueId:        'tutorial/docker-worker',
   created:            (new Date()).toJSON(),  // or taskcluster.fromNowJSON('0 seconds')
   deadline:           taskcluster.fromNowJSON('2 days 3 hours'),
   metadata: {
@@ -193,9 +192,8 @@ let payload = {
 };
 
 let task = {
-  // Required properties
-  provisionerId:      'my-provisioner-id', // \_ use the same values here as when you
-  workerType:         'my-worker-type',    // /  created a task in the web interface
+  // use the same value here as when you created a task in the web interface
+  taskQueueId:        'tutorial/docker-worker',
   created:            taskcluster.fromNowJSON('0 seconds'),
   deadline:           taskcluster.fromNowJSON('2 days 3 hours'),
   metadata: {

--- a/ui/docs/tutorial/hello-world.mdx
+++ b/ui/docs/tutorial/hello-world.mdx
@@ -34,7 +34,7 @@ Click the userpic in the upper-right corner and choose "Account", and look for s
 These represent permissions to run tasks.
 Look for one that seems general-purpose, or ask the folks who administer your deployment.
 For example, you might see `queue:create-task:highest:tutorial/docker-worker`.
-This grants access to workerPool `tutorial/docker-worker`, also known as provisionerId `tutorial` and workerType `docker-worker`.
+This grants access to workerPool `tutorial/docker-worker`.
 If possible, choose one that is running docker-worker.
 
 <SiteSpecific>
@@ -47,8 +47,7 @@ Now that you've got a worker pool in mind, go to "Create a task" on the navigati
 What you see in the resulting text box is a bare-bones task description, looking something like this (the details may evolve as features are added):
 
 ```yaml
-provisionerId: something
-workerType: something-else
+taskQueueId: some/worker-pool
 created: '2020-09-27T15:24:45.442Z'
 deadline: '2020-09-27T18:24:45.443Z'
 payload:
@@ -66,12 +65,12 @@ metadata:
 ```
 
 Happily, this is already set up to print "hello world"!
-Update the provisionerId and workerType according to your discoveries above (the worker pool is in the form `provisionerId / workerType`).
+Update the `taskQueueId` according to your discoveries above (the same as the `workerPoolId`).
 Submitting the task will load the task inspector while the task is scheduled and run.
 
 The fields in the task description are explained in greater detail throughout the rest of this documentation, but briefly:
 
- * `provisionerId` and `workerType` together identify the Taskcluster pool of workers that will execute the task.
+ * `taskQueueId` identifies the Taskcluster queue for the task, connected to the pool of workers that will execute the task.
 
  * `created` and `deadline` give a time boundary for the task.
    If the task is not completed by its deadline, it will be resolved as `exception` with reason `"deadline-exceeded"`.

--- a/ui/src/components/TaskDetailsCard/index.jsx
+++ b/ui/src/components/TaskDetailsCard/index.jsx
@@ -24,6 +24,7 @@ import DateDistance from '../DateDistance';
 import StatusLabel from '../StatusLabel';
 import { DEPENDENTS_PAGE_SIZE } from '../../utils/constants';
 import { pageInfo, task } from '../../utils/prop-types';
+import splitTaskQueueId from '../../utils/splitTaskQueueId';
 import Link from '../../utils/Link';
 
 @withStyles(theme => ({
@@ -149,6 +150,7 @@ export default class TaskDetailsCard extends Component {
     const { showPayload, showMore } = this.state;
     const isExternal = task.metadata.source.startsWith('https://');
     const payload = deepSortObject(task.payload);
+    const { provisionerId, workerType } = splitTaskQueueId(task.taskQueueId);
 
     return (
       <Card raised>
@@ -175,21 +177,15 @@ export default class TaskDetailsCard extends Component {
                 primary="Created"
                 secondary={<DateDistance from={task.created} />}
               />
-              <ListItem>
-                <ListItemText
-                  primary="Provisioner"
-                  secondary={task.provisionerId}
-                />
-              </ListItem>
               <Link
-                to={`/provisioners/${task.provisionerId}/worker-types/${task.workerType}`}>
+                to={`/provisioners/${provisionerId}/worker-types/${workerType}`}>
                 <ListItem
                   title="View Workers"
                   button
                   className={classes.listItemButton}>
                   <ListItemText
-                    primary="Worker Type"
-                    secondary={task.workerType}
+                    primary="Task Queue ID"
+                    secondary={task.taskQueueId}
                   />
                   <LinkIcon />
                 </ListItem>

--- a/ui/src/components/TaskDetailsCard/index.jsx
+++ b/ui/src/components/TaskDetailsCard/index.jsx
@@ -411,10 +411,14 @@ export default class TaskDetailsCard extends Component {
                 )}
                 <ListItem>
                   <ListItemText
+                    primary="Project ID"
+                    secondary={task.projectId}
+                  />
+                </ListItem>
+                <ListItem>
+                  <ListItemText
                     primary="Scheduler ID"
-                    secondary={
-                      task.schedulerId === '-' ? <em>n/a</em> : task.schedulerId
-                    }
+                    secondary={task.schedulerId}
                   />
                 </ListItem>
                 <ListItem>

--- a/ui/src/components/TaskRunsCard/index.jsx
+++ b/ui/src/components/TaskRunsCard/index.jsx
@@ -33,6 +33,7 @@ import { ARTIFACTS_PAGE_SIZE } from '../../utils/constants';
 import { runs } from '../../utils/prop-types';
 import { withAuth } from '../../utils/Auth';
 import { getArtifactUrl } from '../../utils/getArtifactUrl';
+import splitTaskQueueId from '../../utils/splitTaskQueueId';
 import Link from '../../utils/Link';
 
 const DOTS_VARIANT_LIMIT = 5;
@@ -133,13 +134,9 @@ export default class TaskRunsCard extends Component {
      */
     runs: runs.isRequired,
     /**
-     * The worker type associated with the runs' task.
+     * The taskQueueId for the tas
      */
-    workerType: string.isRequired,
-    /**
-     * The provisioner ID associated with the runs' task.
-     */
-    provisionerId: string.isRequired,
+    taskQueueId: string.isRequired,
     /**
      * The current selected run index to display in the card. Paging through
      * runs will trigger a history change, for which the `selectedRunId` can be
@@ -326,14 +323,7 @@ export default class TaskRunsCard extends Component {
   };
 
   render() {
-    const {
-      classes,
-      runs,
-      selectedRunId,
-      provisionerId,
-      workerType,
-      theme,
-    } = this.props;
+    const { classes, runs, selectedRunId, taskQueueId, theme } = this.props;
     const { showMore } = this.state;
     const run = this.getCurrentRun();
     const liveLogArtifact = this.getLiveLogArtifactFromRun(run);
@@ -341,6 +331,7 @@ export default class TaskRunsCard extends Component {
     const liveLogInfo = liveLogArtifact
       ? this.getArtifactInfo(liveLogArtifact)
       : {};
+    const { provisionerId, workerType } = splitTaskQueueId(taskQueueId);
 
     return (
       <Card raised>

--- a/ui/src/utils/splitTaskQueueId.js
+++ b/ui/src/utils/splitTaskQueueId.js
@@ -1,0 +1,5 @@
+export default function splitTaskQueueId(taskQueueId) {
+  const split = taskQueueId.split('/');
+
+  return { provisionerId: split[0], workerType: split[1] };
+}

--- a/ui/src/views/Quickstart/index.jsx
+++ b/ui/src/views/Quickstart/index.jsx
@@ -71,10 +71,9 @@ const getTaskDefinition = state => {
     taskName,
     taskDescription,
   } = state;
-  const tutorialWorkerPool =
+  const taskQueueId =
     siteSpecificVariable('tutorial_worker_pool_id') ||
     'proj-getting-started/tutorial';
-  const [provisionerId, workerType] = tutorialWorkerPool.split('/');
 
   return dump({
     version: 1,
@@ -99,8 +98,7 @@ const getTaskDefinition = state => {
           [condition]: {
             taskId: { $eval: 'as_slugid("test")' },
             deadline: { $fromNow: '1 day' },
-            provisionerId,
-            workerType,
+            taskQueueId,
             metadata: {
               name: taskName,
               description: taskDescription,

--- a/ui/src/views/Tasks/CreateTask/index.jsx
+++ b/ui/src/views/Tasks/CreateTask/index.jsx
@@ -49,8 +49,7 @@ const tutorialWorkerPoolId =
   window.env.SITE_SPECIFIC.tutorial_worker_pool_id ||
   'proj-getting-started/tutorial';
 const defaultTask = {
-  provisionerId: tutorialWorkerPoolId.split('/')[0],
-  workerType: tutorialWorkerPoolId.split('/')[1],
+  taskQueueId: tutorialWorkerPoolId,
   schedulerId: UI_SCHEDULER_ID,
   created: new Date().toISOString(),
   deadline: toDate(addHours(new Date(), 3)).toISOString(),
@@ -331,7 +330,7 @@ export default class CreateTask extends Component {
               variations.
               <SiteSpecific>
                 If you are just getting started, `%tutorial_worker_pool_id%` is
-                a good choice for `provisionerId` / `workerType`.
+                a good choice for `taskQueueId`.
               </SiteSpecific>
             </Typography>
           </HelpView>

--- a/ui/src/views/Tasks/TaskGroup/taskGroup.graphql
+++ b/ui/src/views/Tasks/TaskGroup/taskGroup.graphql
@@ -22,8 +22,7 @@ query TaskGroup($taskGroupId: ID!, $taskGroupConnection: PageConnection, $filter
   }
 
   task(taskId: $taskGroupId) {
-    provisionerId
-    workerType
+    taskQueueId
     schedulerId
     taskId
     taskGroupId

--- a/ui/src/views/Tasks/TaskRedirect/task.graphql
+++ b/ui/src/views/Tasks/TaskRedirect/task.graphql
@@ -1,7 +1,6 @@
 query Task($taskId: ID!) {
   task(taskId: $taskId) {
-    provisionerId
-    workerType
+    taskQueueId
     schedulerId
     decisionTask
     dependencies

--- a/ui/src/views/Tasks/ViewTask/index.jsx
+++ b/ui/src/views/Tasks/ViewTask/index.jsx
@@ -35,6 +35,7 @@ import SpeedDialAction from '../../../components/SpeedDialAction';
 import DialogAction from '../../../components/DialogAction';
 import TaskActionForm from '../../../components/TaskActionForm';
 import Breadcrumbs from '../../../components/Breadcrumbs';
+import splitTaskQueueId from '../../../utils/splitTaskQueueId';
 import {
   ACTIONS_JSON_KNOWN_KINDS,
   ARTIFACTS_PAGE_SIZE,
@@ -634,7 +635,9 @@ export default class ViewTask extends Component {
   };
 
   purgeWorkerCache = async () => {
-    const { provisionerId, workerType } = this.props.data.task;
+    const { provisionerId, workerType } = splitTaskQueueId(
+      this.props.data.task.taskQueueId
+    );
     const { selectedCaches } = this.state;
 
     this.preRunningAction();
@@ -912,8 +915,7 @@ export default class ViewTask extends Component {
                       : Math.max(task.status.runs.length - 1, 0)
                   }
                   runs={task.status.runs}
-                  workerType={task.workerType}
-                  provisionerId={task.provisionerId}
+                  taskQueueId={task.taskQueueId}
                   onArtifactsPageChange={this.handleArtifactsPageChange}
                 />
               </Grid>

--- a/ui/src/views/Tasks/ViewTask/task.graphql
+++ b/ui/src/views/Tasks/ViewTask/task.graphql
@@ -11,6 +11,7 @@ query Task($taskId: ID!, $artifactsConnection: PageConnection, $dependentsConnec
     priority
     taskQueueId
     schedulerId
+    projectId
     tags
     requires
     scopes

--- a/ui/src/views/Tasks/ViewTask/task.graphql
+++ b/ui/src/views/Tasks/ViewTask/task.graphql
@@ -9,8 +9,7 @@ query Task($taskId: ID!, $artifactsConnection: PageConnection, $dependentsConnec
     deadline
     expires
     priority
-    provisionerId
-    workerType
+    taskQueueId
     schedulerId
     tags
     requires


### PR DESCRIPTION
Github Bug/Issue: Fixes #4269

This updates docs, too, and also makes some drive-by docs fixes for old/awkward stuff.  Hopefully most of those diffs are self-explanatory, such as removing the v0 `.taskcluster.yml` from the notify docs.