### PR TITLE
[generic-worker] Do not fail if tasks-resolved-count.txt is empty

### DIFF
--- a/changelog/issue-4340.md
+++ b/changelog/issue-4340.md
@@ -1,0 +1,4 @@
+audience: general
+level: silent
+reference: issue 4340
+---

--- a/workers/generic-worker/main.go
+++ b/workers/generic-worker/main.go
@@ -288,11 +288,14 @@ func setupExposer() (err error) {
 func ReadTasksResolvedFile() uint {
 	b, err := ioutil.ReadFile("tasks-resolved-count.txt")
 	if err != nil {
+		log.Printf("could not open tasks-resolved-count.txt: %s (ignored)", err)
 		return 0
 	}
 	i, err := strconv.Atoi(string(b))
 	if err != nil {
-		panic(err)
+		// treat an invalid (usually empty) file as nonexistent
+		log.Printf("could not parse content of tasks-resolved-count.txt: %s (ignored)", err)
+		return 0
 	}
 	return uint(i)
 }


### PR DESCRIPTION
Github Bug/Issue: Fixes #4340
