### PR TITLE
fix: allPurgeRequests returns a continuationToken when there's nothing left

### DIFF
--- a/changelog/issue-3789.md
+++ b/changelog/issue-3789.md
@@ -1,4 +1,5 @@
-audience: general
-level: silent
+audience: developers
+level: patch
 reference: issue 3789
 ---
+Fixed an issue where when there's no more data, the continuationToken property was not being omitted, but being returned as just an empty string. Depending on implementation, that could cause a caller to loop endlessly calling the purge cache endpoint.

--- a/changelog/issue-3789.md
+++ b/changelog/issue-3789.md
@@ -1,0 +1,4 @@
+audience: general
+level: silent
+reference: issue 3789
+---

--- a/services/purge-cache/src/api.js
+++ b/services/purge-cache/src/api.js
@@ -90,7 +90,7 @@ builder.declare({
     fetch: (size, offset) => this.db.fns.all_purge_requests_wpid(size, offset),
   });
   return res.reply({
-    continuationToken: continuationToken || '',
+    continuationToken: continuationToken,
     requests: _.map(rows, entry => {
       const { provisionerId, workerType } = splitWorkerPoolId(entry.worker_pool_id);
       return {

--- a/services/purge-cache/test/purgecache_test.js
+++ b/services/purge-cache/test/purgecache_test.js
@@ -31,7 +31,8 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
     // We should have no purge-cache requests to start with
     let openRequests = await helper.apiClient.allPurgeRequests();
     assume(openRequests.requests).is.empty();
-
+    // We should have no continuation token to start with
+    assume(openRequests.continuationToken).doesnt.exist();
     // Request a purge-cache message
     await helper.apiClient.purgeCache('dummy-provisioner-extended-extended', 'dummy-worker-extended-extended', {
       cacheName: 'my-test-cache',


### PR DESCRIPTION
fixes #3789

@djmitche do you think this needs a changelog?
Also, does it look ok?