### PR TITLE
Fix timing for a docker-worker test

### DIFF
--- a/changelog/KAP_TpnwQEupodrRoTjqwA.md
+++ b/changelog/KAP_TpnwQEupodrRoTjqwA.md
@@ -1,0 +1,3 @@
+audience: general
+level: silent
+---

--- a/workers/docker-worker/test/garbage_collection_test.js
+++ b/workers/docker-worker/test/garbage_collection_test.js
@@ -342,6 +342,7 @@ helper.secrets.mockSuite(suiteName(), ['docker'], function(mock, skipping) {
         monitor: monitor,
       });
 
+      let start = Date.now();
       let container = await docker.createContainer({ Image: imageId,
         Cmd: ['/bin/bash', '-c', 'echo "hello"'],
       });
@@ -352,7 +353,6 @@ helper.secrets.mockSuite(suiteName(), ['docker'], function(mock, skipping) {
       let removedIds = [];
       gc.on('gc:container:removed', msg => { removedIds.push(msg.id); });
 
-      let start = Date.now();
       while (!removedIds.includes(containerId)) {
         await gc.sweep();
       }


### PR DESCRIPTION
This starts the 1-second timer *before* creating the container, so that
the timer will always measure more time than the container's expiration.

https://community-tc.services.mozilla.com/tasks/PuHyD99MQlG1dJZo3WshOw/runs/0/logs/public/logs/live.log