### PR TITLE
Rename object.fetchObjectMetadata to object.startDownload

### DIFF
--- a/changelog/UweKfAv0Q6iDvhuDhosUlA.md
+++ b/changelog/UweKfAv0Q6iDvhuDhosUlA.md
@@ -1,0 +1,3 @@
+audience: general
+level: silent
+---

--- a/clients/client-go/tcobject/tcobject.go
+++ b/clients/client-go/tcobject/tcobject.go
@@ -116,8 +116,9 @@ func (object *Object) UploadObject(name string, payload *UploadObjectRequest) er
 
 // Stability: *** EXPERIMENTAL ***
 //
-// Get information on how to download an object.  Call this endpoint with a list of acceptable
+// Start the process of downloading an object's data.  Call this endpoint with a list of acceptable
 // download methods, and the server will select a method and return the corresponding payload.
+//
 // Returns a 406 error if none of the given download methods are available.
 //
 // See [Download Methods](https://docs.taskcluster.net/docs/reference/platform/object/download-methods) for more detail.
@@ -125,10 +126,10 @@ func (object *Object) UploadObject(name string, payload *UploadObjectRequest) er
 // Required scopes:
 //   object:download:<name>
 //
-// See #fetchObjectMetadata
-func (object *Object) FetchObjectMetadata(name string, payload *DownloadObjectRequest) (*DownloadObjectResponse, error) {
+// See #startDownload
+func (object *Object) StartDownload(name string, payload *DownloadObjectRequest) (*DownloadObjectResponse, error) {
 	cd := tcclient.Client(*object)
-	responseObject, _, err := (&cd).APICall(payload, "PUT", "/download-object/"+url.QueryEscape(name), new(DownloadObjectResponse), nil)
+	responseObject, _, err := (&cd).APICall(payload, "PUT", "/start-download/"+url.QueryEscape(name), new(DownloadObjectResponse), nil)
 	return responseObject.(*DownloadObjectResponse), err
 }
 
@@ -144,7 +145,7 @@ func (object *Object) FetchObjectMetadata(name string, payload *DownloadObjectRe
 // This method is limited by the common capabilities of HTTP, so it may not be
 // the most efficient, resilient, or featureful way to retrieve an artifact.
 // Situations where such functionality is required should ues the
-// `fetchObjectMetadata` API endpoint.
+// `startDownload` API endpoint.
 //
 // See [Simple Downloads](https://docs.taskcluster.net/docs/reference/platform/object/simple-downloads) for more detail.
 //

--- a/clients/client-py/taskcluster/generated/aio/object.py
+++ b/clients/client-py/taskcluster/generated/aio/object.py
@@ -44,12 +44,13 @@ class Object(AsyncBaseClient):
 
         return await self._makeApiCall(self.funcinfo["uploadObject"], *args, **kwargs)
 
-    async def fetchObjectMetadata(self, *args, **kwargs):
+    async def startDownload(self, *args, **kwargs):
         """
         Download object data
 
-        Get information on how to download an object.  Call this endpoint with a list of acceptable
+        Start the process of downloading an object's data.  Call this endpoint with a list of acceptable
         download methods, and the server will select a method and return the corresponding payload.
+
         Returns a 406 error if none of the given download methods are available.
 
         See [Download Methods](https://docs.taskcluster.net/docs/reference/platform/object/download-methods) for more detail.
@@ -57,7 +58,7 @@ class Object(AsyncBaseClient):
         This method is ``experimental``
         """
 
-        return await self._makeApiCall(self.funcinfo["fetchObjectMetadata"], *args, **kwargs)
+        return await self._makeApiCall(self.funcinfo["startDownload"], *args, **kwargs)
 
     async def download(self, *args, **kwargs):
         """
@@ -73,7 +74,7 @@ class Object(AsyncBaseClient):
         This method is limited by the common capabilities of HTTP, so it may not be
         the most efficient, resilient, or featureful way to retrieve an artifact.
         Situations where such functionality is required should ues the
-        `fetchObjectMetadata` API endpoint.
+        `startDownload` API endpoint.
 
         See [Simple Downloads](https://docs.taskcluster.net/docs/reference/platform/object/simple-downloads) for more detail.
 
@@ -90,21 +91,21 @@ class Object(AsyncBaseClient):
             'route': '/download/<name>',
             'stability': 'experimental',
         },
-        "fetchObjectMetadata": {
-            'args': ['name'],
-            'input': 'v1/download-object-request.json#',
-            'method': 'put',
-            'name': 'fetchObjectMetadata',
-            'output': 'v1/download-object-response.json#',
-            'route': '/download-object/<name>',
-            'stability': 'experimental',
-        },
         "ping": {
             'args': [],
             'method': 'get',
             'name': 'ping',
             'route': '/ping',
             'stability': 'stable',
+        },
+        "startDownload": {
+            'args': ['name'],
+            'input': 'v1/download-object-request.json#',
+            'method': 'put',
+            'name': 'startDownload',
+            'output': 'v1/download-object-response.json#',
+            'route': '/start-download/<name>',
+            'stability': 'experimental',
         },
         "uploadObject": {
             'args': ['name'],

--- a/clients/client-py/taskcluster/generated/object.py
+++ b/clients/client-py/taskcluster/generated/object.py
@@ -44,12 +44,13 @@ class Object(BaseClient):
 
         return self._makeApiCall(self.funcinfo["uploadObject"], *args, **kwargs)
 
-    def fetchObjectMetadata(self, *args, **kwargs):
+    def startDownload(self, *args, **kwargs):
         """
         Download object data
 
-        Get information on how to download an object.  Call this endpoint with a list of acceptable
+        Start the process of downloading an object's data.  Call this endpoint with a list of acceptable
         download methods, and the server will select a method and return the corresponding payload.
+
         Returns a 406 error if none of the given download methods are available.
 
         See [Download Methods](https://docs.taskcluster.net/docs/reference/platform/object/download-methods) for more detail.
@@ -57,7 +58,7 @@ class Object(BaseClient):
         This method is ``experimental``
         """
 
-        return self._makeApiCall(self.funcinfo["fetchObjectMetadata"], *args, **kwargs)
+        return self._makeApiCall(self.funcinfo["startDownload"], *args, **kwargs)
 
     def download(self, *args, **kwargs):
         """
@@ -73,7 +74,7 @@ class Object(BaseClient):
         This method is limited by the common capabilities of HTTP, so it may not be
         the most efficient, resilient, or featureful way to retrieve an artifact.
         Situations where such functionality is required should ues the
-        `fetchObjectMetadata` API endpoint.
+        `startDownload` API endpoint.
 
         See [Simple Downloads](https://docs.taskcluster.net/docs/reference/platform/object/simple-downloads) for more detail.
 
@@ -90,21 +91,21 @@ class Object(BaseClient):
             'route': '/download/<name>',
             'stability': 'experimental',
         },
-        "fetchObjectMetadata": {
-            'args': ['name'],
-            'input': 'v1/download-object-request.json#',
-            'method': 'put',
-            'name': 'fetchObjectMetadata',
-            'output': 'v1/download-object-response.json#',
-            'route': '/download-object/<name>',
-            'stability': 'experimental',
-        },
         "ping": {
             'args': [],
             'method': 'get',
             'name': 'ping',
             'route': '/ping',
             'stability': 'stable',
+        },
+        "startDownload": {
+            'args': ['name'],
+            'input': 'v1/download-object-request.json#',
+            'method': 'put',
+            'name': 'startDownload',
+            'output': 'v1/download-object-response.json#',
+            'route': '/start-download/<name>',
+            'stability': 'experimental',
         },
         "uploadObject": {
             'args': ['name'],

--- a/clients/client-rust/src/generated/object.rs
+++ b/clients/client-rust/src/generated/object.rs
@@ -77,22 +77,23 @@ impl Object {
 
     /// Download object data
     /// 
-    /// Get information on how to download an object.  Call this endpoint with a list of acceptable
+    /// Start the process of downloading an object's data.  Call this endpoint with a list of acceptable
     /// download methods, and the server will select a method and return the corresponding payload.
+    /// 
     /// Returns a 406 error if none of the given download methods are available.
     /// 
     /// See [Download Methods](https://docs.taskcluster.net/docs/reference/platform/object/download-methods) for more detail.
-    pub async fn fetchObjectMetadata(&self, name: &str, payload: &Value) -> Result<Value, Error> {
+    pub async fn startDownload(&self, name: &str, payload: &Value) -> Result<Value, Error> {
         let method = "PUT";
-        let (path, query) = Self::fetchObjectMetadata_details(name);
+        let (path, query) = Self::startDownload_details(name);
         let body = Some(payload);
         let resp = self.0.request(method, &path, query, body).await?;
         Ok(resp.json().await?)
     }
 
-    /// Determine the HTTP request details for fetchObjectMetadata
-    fn fetchObjectMetadata_details<'a>(name: &'a str) -> (String, Option<Vec<(&'static str, &'a str)>>) {
-        let path = format!("download-object/{}", urlencode(name));
+    /// Determine the HTTP request details for startDownload
+    fn startDownload_details<'a>(name: &'a str) -> (String, Option<Vec<(&'static str, &'a str)>>) {
+        let path = format!("start-download/{}", urlencode(name));
         let query = None;
 
         (path, query)
@@ -110,7 +111,7 @@ impl Object {
     /// This method is limited by the common capabilities of HTTP, so it may not be
     /// the most efficient, resilient, or featureful way to retrieve an artifact.
     /// Situations where such functionality is required should ues the
-    /// `fetchObjectMetadata` API endpoint.
+    /// `startDownload` API endpoint.
     /// 
     /// See [Simple Downloads](https://docs.taskcluster.net/docs/reference/platform/object/simple-downloads) for more detail.
     pub async fn download(&self, name: &str) -> Result<(), Error> {

--- a/clients/client-shell/apis/services.go
+++ b/clients/client-shell/apis/services.go
@@ -931,12 +931,12 @@ var services = map[string]definitions.Service{
 				Input: "v1/upload-object-request.json#",
 			},
 			definitions.Entry{
-				Name:        "fetchObjectMetadata",
+				Name:        "startDownload",
 				Title:       "Download object data",
-				Description: "Get information on how to download an object.  Call this endpoint with a list of acceptable\ndownload methods, and the server will select a method and return the corresponding payload.\nReturns a 406 error if none of the given download methods are available.\n\nSee [Download Methods](https://docs.taskcluster.net/docs/reference/platform/object/download-methods) for more detail.",
+				Description: "Start the process of downloading an object's data.  Call this endpoint with a list of acceptable\ndownload methods, and the server will select a method and return the corresponding payload.\n\nReturns a 406 error if none of the given download methods are available.\n\nSee [Download Methods](https://docs.taskcluster.net/docs/reference/platform/object/download-methods) for more detail.",
 				Stability:   "experimental",
 				Method:      "put",
-				Route:       "/download-object/<name>",
+				Route:       "/start-download/<name>",
 				Args: []string{
 					"name",
 				},
@@ -946,7 +946,7 @@ var services = map[string]definitions.Service{
 			definitions.Entry{
 				Name:        "download",
 				Title:       "Get an object's data",
-				Description: "Get the data in an object directly.  This method does not return a JSON body, but\nredirects to a location that will serve the object content directly.\n\nURLs for this endpoint, perhaps with attached authentication (`?bewit=..`),\nare typically used for downloads of objects by simple HTTP clients such as\nweb browsers, curl, or wget.\n\nThis method is limited by the common capabilities of HTTP, so it may not be\nthe most efficient, resilient, or featureful way to retrieve an artifact.\nSituations where such functionality is required should ues the\n`fetchObjectMetadata` API endpoint.\n\nSee [Simple Downloads](https://docs.taskcluster.net/docs/reference/platform/object/simple-downloads) for more detail.",
+				Description: "Get the data in an object directly.  This method does not return a JSON body, but\nredirects to a location that will serve the object content directly.\n\nURLs for this endpoint, perhaps with attached authentication (`?bewit=..`),\nare typically used for downloads of objects by simple HTTP clients such as\nweb browsers, curl, or wget.\n\nThis method is limited by the common capabilities of HTTP, so it may not be\nthe most efficient, resilient, or featureful way to retrieve an artifact.\nSituations where such functionality is required should ues the\n`startDownload` API endpoint.\n\nSee [Simple Downloads](https://docs.taskcluster.net/docs/reference/platform/object/simple-downloads) for more detail.",
 				Stability:   "experimental",
 				Method:      "get",
 				Route:       "/download/<name>",

--- a/clients/client-web/src/clients/Object.js
+++ b/clients/client-web/src/clients/Object.js
@@ -12,7 +12,7 @@ export default class Object extends Client {
     });
     this.ping.entry = {"args":[],"category":"Ping Server","method":"get","name":"ping","query":[],"route":"/ping","stability":"stable","type":"function"}; // eslint-disable-line
     this.uploadObject.entry = {"args":["name"],"category":"Upload","input":true,"method":"put","name":"uploadObject","query":[],"route":"/upload/<name>","scopes":"object:upload:<projectId>:<name>","stability":"experimental","type":"function"}; // eslint-disable-line
-    this.fetchObjectMetadata.entry = {"args":["name"],"category":"Download","input":true,"method":"put","name":"fetchObjectMetadata","output":true,"query":[],"route":"/download-object/<name>","scopes":"object:download:<name>","stability":"experimental","type":"function"}; // eslint-disable-line
+    this.startDownload.entry = {"args":["name"],"category":"Download","input":true,"method":"put","name":"startDownload","output":true,"query":[],"route":"/start-download/<name>","scopes":"object:download:<name>","stability":"experimental","type":"function"}; // eslint-disable-line
     this.download.entry = {"args":["name"],"category":"Download","method":"get","name":"download","query":[],"route":"/download/<name>","scopes":"object:download:<name>","stability":"experimental","type":"function"}; // eslint-disable-line
   }
   /* eslint-disable max-len */
@@ -33,15 +33,15 @@ export default class Object extends Client {
     return this.request(this.uploadObject.entry, args);
   }
   /* eslint-disable max-len */
-  // Get information on how to download an object.  Call this endpoint with a list of acceptable
+  // Start the process of downloading an object's data.  Call this endpoint with a list of acceptable
   // download methods, and the server will select a method and return the corresponding payload.
   // Returns a 406 error if none of the given download methods are available.
   // See [Download Methods](https://docs.taskcluster.net/docs/reference/platform/object/download-methods) for more detail.
   /* eslint-enable max-len */
-  fetchObjectMetadata(...args) {
-    this.validate(this.fetchObjectMetadata.entry, args);
+  startDownload(...args) {
+    this.validate(this.startDownload.entry, args);
 
-    return this.request(this.fetchObjectMetadata.entry, args);
+    return this.request(this.startDownload.entry, args);
   }
   /* eslint-disable max-len */
   // Get the data in an object directly.  This method does not return a JSON body, but
@@ -52,7 +52,7 @@ export default class Object extends Client {
   // This method is limited by the common capabilities of HTTP, so it may not be
   // the most efficient, resilient, or featureful way to retrieve an artifact.
   // Situations where such functionality is required should ues the
-  // `fetchObjectMetadata` API endpoint.
+  // `startDownload` API endpoint.
   // See [Simple Downloads](https://docs.taskcluster.net/docs/reference/platform/object/simple-downloads) for more detail.
   /* eslint-enable max-len */
   download(...args) {

--- a/clients/client/src/apis.js
+++ b/clients/client/src/apis.js
@@ -1636,14 +1636,14 @@ module.exports = {
             "name"
           ],
           "category": "Download",
-          "description": "Get information on how to download an object.  Call this endpoint with a list of acceptable\ndownload methods, and the server will select a method and return the corresponding payload.\nReturns a 406 error if none of the given download methods are available.\n\nSee [Download Methods](https://docs.taskcluster.net/docs/reference/platform/object/download-methods) for more detail.",
+          "description": "Start the process of downloading an object's data.  Call this endpoint with a list of acceptable\ndownload methods, and the server will select a method and return the corresponding payload.\n\nReturns a 406 error if none of the given download methods are available.\n\nSee [Download Methods](https://docs.taskcluster.net/docs/reference/platform/object/download-methods) for more detail.",
           "input": "v1/download-object-request.json#",
           "method": "put",
-          "name": "fetchObjectMetadata",
+          "name": "startDownload",
           "output": "v1/download-object-response.json#",
           "query": [
           ],
-          "route": "/download-object/<name>",
+          "route": "/start-download/<name>",
           "scopes": "object:download:<name>",
           "stability": "experimental",
           "title": "Download object data",
@@ -1654,7 +1654,7 @@ module.exports = {
             "name"
           ],
           "category": "Download",
-          "description": "Get the data in an object directly.  This method does not return a JSON body, but\nredirects to a location that will serve the object content directly.\n\nURLs for this endpoint, perhaps with attached authentication (`?bewit=..`),\nare typically used for downloads of objects by simple HTTP clients such as\nweb browsers, curl, or wget.\n\nThis method is limited by the common capabilities of HTTP, so it may not be\nthe most efficient, resilient, or featureful way to retrieve an artifact.\nSituations where such functionality is required should ues the\n`fetchObjectMetadata` API endpoint.\n\nSee [Simple Downloads](https://docs.taskcluster.net/docs/reference/platform/object/simple-downloads) for more detail.",
+          "description": "Get the data in an object directly.  This method does not return a JSON body, but\nredirects to a location that will serve the object content directly.\n\nURLs for this endpoint, perhaps with attached authentication (`?bewit=..`),\nare typically used for downloads of objects by simple HTTP clients such as\nweb browsers, curl, or wget.\n\nThis method is limited by the common capabilities of HTTP, so it may not be\nthe most efficient, resilient, or featureful way to retrieve an artifact.\nSituations where such functionality is required should ues the\n`startDownload` API endpoint.\n\nSee [Simple Downloads](https://docs.taskcluster.net/docs/reference/platform/object/simple-downloads) for more detail.",
           "method": "get",
           "name": "download",
           "query": [

--- a/generated/references.json
+++ b/generated/references.json
@@ -15461,14 +15461,14 @@
             "name"
           ],
           "category": "Download",
-          "description": "Get information on how to download an object.  Call this endpoint with a list of acceptable\ndownload methods, and the server will select a method and return the corresponding payload.\nReturns a 406 error if none of the given download methods are available.\n\nSee [Download Methods](https://docs.taskcluster.net/docs/reference/platform/object/download-methods) for more detail.",
+          "description": "Start the process of downloading an object's data.  Call this endpoint with a list of acceptable\ndownload methods, and the server will select a method and return the corresponding payload.\n\nReturns a 406 error if none of the given download methods are available.\n\nSee [Download Methods](https://docs.taskcluster.net/docs/reference/platform/object/download-methods) for more detail.",
           "input": "v1/download-object-request.json#",
           "method": "put",
-          "name": "fetchObjectMetadata",
+          "name": "startDownload",
           "output": "v1/download-object-response.json#",
           "query": [
           ],
-          "route": "/download-object/<name>",
+          "route": "/start-download/<name>",
           "scopes": "object:download:<name>",
           "stability": "experimental",
           "title": "Download object data",
@@ -15479,7 +15479,7 @@
             "name"
           ],
           "category": "Download",
-          "description": "Get the data in an object directly.  This method does not return a JSON body, but\nredirects to a location that will serve the object content directly.\n\nURLs for this endpoint, perhaps with attached authentication (`?bewit=..`),\nare typically used for downloads of objects by simple HTTP clients such as\nweb browsers, curl, or wget.\n\nThis method is limited by the common capabilities of HTTP, so it may not be\nthe most efficient, resilient, or featureful way to retrieve an artifact.\nSituations where such functionality is required should ues the\n`fetchObjectMetadata` API endpoint.\n\nSee [Simple Downloads](https://docs.taskcluster.net/docs/reference/platform/object/simple-downloads) for more detail.",
+          "description": "Get the data in an object directly.  This method does not return a JSON body, but\nredirects to a location that will serve the object content directly.\n\nURLs for this endpoint, perhaps with attached authentication (`?bewit=..`),\nare typically used for downloads of objects by simple HTTP clients such as\nweb browsers, curl, or wget.\n\nThis method is limited by the common capabilities of HTTP, so it may not be\nthe most efficient, resilient, or featureful way to retrieve an artifact.\nSituations where such functionality is required should ues the\n`startDownload` API endpoint.\n\nSee [Simple Downloads](https://docs.taskcluster.net/docs/reference/platform/object/simple-downloads) for more detail.",
           "method": "get",
           "name": "download",
           "query": [

--- a/services/object/src/api.js
+++ b/services/object/src/api.js
@@ -86,8 +86,8 @@ builder.declare({
 
 builder.declare({
   method: 'put',
-  route: '/download-object/:name(*)', // name TBD; https://github.com/taskcluster/taskcluster/issues/3940
-  name: 'fetchObjectMetadata',
+  route: '/start-download/:name(*)',
+  name: 'startDownload',
   input: 'download-object-request.yml',
   output: 'download-object-response.yml',
   stability: 'experimental',
@@ -95,8 +95,9 @@ builder.declare({
   scopes: 'object:download:<name>',
   title: 'Download object data',
   description: [
-    'Get information on how to download an object.  Call this endpoint with a list of acceptable',
+    'Start the process of downloading an object\'s data.  Call this endpoint with a list of acceptable',
     'download methods, and the server will select a method and return the corresponding payload.',
+    '',
     'Returns a 406 error if none of the given download methods are available.',
     '',
     'See [Download Methods](https://docs.taskcluster.net/docs/reference/platform/object/download-methods) for more detail.',
@@ -129,11 +130,11 @@ builder.declare({
   const params = acceptDownloadMethods[method];
 
   // apply middleware
-  if (!await this.middleware.fetchObjectMetadataRequest(req, res, object, method, params)) {
+  if (!await this.middleware.startDownloadRequest(req, res, object, method, params)) {
     return;
   }
 
-  const result = await backend.fetchObjectMetadata(object, method, params);
+  const result = await backend.startDownload(object, method, params);
 
   return res.reply(result);
 });
@@ -157,7 +158,7 @@ builder.declare({
     'This method is limited by the common capabilities of HTTP, so it may not be',
     'the most efficient, resilient, or featureful way to retrieve an artifact.',
     'Situations where such functionality is required should ues the',
-    '`fetchObjectMetadata` API endpoint.',
+    '`startDownload` API endpoint.',
     '',
     'See [Simple Downloads](https://docs.taskcluster.net/docs/reference/platform/object/simple-downloads) for more detail.',
   ].join('\n'),
@@ -186,7 +187,7 @@ builder.declare({
     return;
   }
 
-  const result = await backend.fetchObjectMetadata(object, method, true);
+  const result = await backend.startDownload(object, method, true);
 
   return res.redirect(303, result.url);
 });

--- a/services/object/src/backends/aws.js
+++ b/services/object/src/backends/aws.js
@@ -41,7 +41,7 @@ class AwsBackend extends Backend {
     return ['simple'];
   }
 
-  async fetchObjectMetadata(object, method, params) {
+  async startDownload(object, method, params) {
     switch (method){
       case 'simple': {
         let url;

--- a/services/object/src/backends/base.js
+++ b/services/object/src/backends/base.js
@@ -38,7 +38,7 @@ class Backend {
 
   /**
    * Return the backend-specific details required for a client to retrieve the
-   * object.  The result is returned directly from the `fetchObjectMetadata` API
+   * object.  The result is returned directly from the `startDownload` API
    * endpoint.
    *
    * The `method` argument is the selected method, and `params` is the value
@@ -46,8 +46,8 @@ class Backend {
    *
    * Subclasses should override this.
    */
-  async fetchObjectMetadata(object, method, params) {
-    throw new Error('fetchObjectMetadata is not implemented for this backend');
+  async startDownload(object, method, params) {
+    throw new Error('startDownload is not implemented for this backend');
   }
 
   /**

--- a/services/object/src/backends/test.js
+++ b/services/object/src/backends/test.js
@@ -24,7 +24,7 @@ class TestBackend extends Backend {
     return ['simple', 'HTTP:GET'];
   }
 
-  async fetchObjectMetadata(object, method, params) {
+  async startDownload(object, method, params) {
     assert(this.data.has(object.name));
     switch (method){
       case 'simple': {

--- a/services/object/src/middleware/base.js
+++ b/services/object/src/middleware/base.js
@@ -13,10 +13,10 @@ class Middleware {
   }
 
   /**
-   * Intercept the fetchObjectMetadata API method.
+   * Intercept the startDownload API method.
    *
    * The object, method, and params arguments are those that would
-   * be passed to `backend.fetchObjectMetadata`.
+   * be passed to `backend.startDownload`.
    *
    * If this method returns `false`, then the API implementation will
    * return immediately without further action; this indicates that the
@@ -26,12 +26,12 @@ class Middleware {
    *
    * Subclasses may override this method; the default does nothing.
    */
-  async fetchObjectMetadataRequest(req, res, object, method, params) {
+  async startDownloadRequest(req, res, object, method, params) {
     return true;
   }
 
   /**
-   * Similar to fetchObjectMetadataRequest, but for the simple-download API.
+   * Similar to startDownloadRequest, but for the simple-download API.
    */
   async downloadRequest(req, res, object) {
     return true;

--- a/services/object/src/middleware/index.js
+++ b/services/object/src/middleware/index.js
@@ -33,15 +33,15 @@ class Middleware {
   }
 
   /**
-   * Intercept the fetchObjectMetadata API method.  This calls the function
+   * Intercept the startDownload API method.  This calls the function
    * of the same name on all middleware objects, in order, until one
    * returns false.
    *
    * See the middleware base class for more details.
    */
-  async fetchObjectMetadataRequest(req, res, object, method, params) {
+  async startDownloadRequest(req, res, object, method, params) {
     for (let mw of this.instances) {
-      if (!await mw.fetchObjectMetadataRequest(req, res, object, method, params)) {
+      if (!await mw.startDownloadRequest(req, res, object, method, params)) {
         return false;
       }
     }
@@ -50,7 +50,7 @@ class Middleware {
   }
 
   /**
-   * Similar to fetchObjectMetadataRequest, but for the simple-download API.
+   * Similar to startDownloadRequest, but for the simple-download API.
    */
   async downloadRequest(req, res, object) {
     for (let mw of this.instances) {

--- a/services/object/src/middleware/test.js
+++ b/services/object/src/middleware/test.js
@@ -6,7 +6,7 @@ class TestMiddleware extends Middleware {
     this.config = options.config;
   }
 
-  async fetchObjectMetadataRequest(req, res, object, method, params) {
+  async startDownloadRequest(req, res, object, method, params) {
     switch (object.name) {
       case 'dl/intercept': {
         res.reply({

--- a/services/object/test/api_test.js
+++ b/services/object/test/api_test.js
@@ -114,8 +114,8 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
     });
   });
 
-  suite('fetchObjectMetadata method', function() {
-    test('fetchObjectMetadata for simple method succeeds', async function() {
+  suite('startDownload method', function() {
+    test('startDownload for simple method succeeds', async function() {
       const data = crypto.randomBytes(128);
       await helper.apiClient.uploadObject('public/foo', {
         projectId: 'x',
@@ -123,7 +123,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
         uploadId: taskcluster.slugid(),
         expires: fromNow('1 year'),
       });
-      const res = await helper.apiClient.fetchObjectMetadata('public/foo', {
+      const res = await helper.apiClient.startDownload('public/foo', {
         acceptDownloadMethods: { 'simple': true },
       });
       assert.deepEqual(res, {
@@ -132,7 +132,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       });
     });
 
-    test('fetchObjectMetadata for a supported method succeeds', async function() {
+    test('startDownload for a supported method succeeds', async function() {
       const data = crypto.randomBytes(128);
       await helper.apiClient.uploadObject('public/foo', {
         projectId: 'x',
@@ -140,7 +140,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
         uploadId: taskcluster.slugid(),
         expires: fromNow('1 year'),
       });
-      const res = await helper.apiClient.fetchObjectMetadata('public/foo', {
+      const res = await helper.apiClient.startDownload('public/foo', {
         acceptDownloadMethods: { 'HTTP:GET': true },
       });
       assert.deepEqual(res, {
@@ -151,7 +151,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       });
     });
 
-    test('fetchObjectMetadata handles middleware', async function() {
+    test('startDownload handles middleware', async function() {
       const data = crypto.randomBytes(128);
       await helper.apiClient.uploadObject('dl/intercept', {
         projectId: 'x',
@@ -160,7 +160,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
         expires: fromNow('1 year'),
       });
 
-      const res = await helper.apiClient.fetchObjectMetadata('dl/intercept', {
+      const res = await helper.apiClient.startDownload('dl/intercept', {
         acceptDownloadMethods: { 'simple': true },
       });
 
@@ -170,7 +170,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       });
     });
 
-    test('fetchObjectMetadata for an unsupported method returns 406', async function() {
+    test('startDownload for an unsupported method returns 406', async function() {
       const data = crypto.randomBytes(128);
       await helper.apiClient.uploadObject('has/no/methods', {
         projectId: 'x',
@@ -179,7 +179,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
         expires: fromNow('1 year'),
       });
       await assert.rejects(
-        () => helper.apiClient.fetchObjectMetadata('has/no/methods', {
+        () => helper.apiClient.startDownload('has/no/methods', {
           acceptDownloadMethods: { simple: true, 'HTTP:GET': true },
         }),
         err => err.code === 'NoMatchingMethod' && err.statusCode === 406,

--- a/services/object/test/helper/simple-download.js
+++ b/services/object/test/helper/simple-download.js
@@ -52,7 +52,7 @@ exports.testSimpleDownloadMethod = ({
       assert(methods.includes('simple'));
 
       // call the backend
-      const { method, url } = await backend.fetchObjectMetadata(object, 'simple', true);
+      const { method, url } = await backend.startDownload(object, 'simple', true);
       assert.equal(method, 'simple');
       checkUrl({ name, url });
 

--- a/services/object/test/middleware_test.js
+++ b/services/object/test/middleware_test.js
@@ -4,18 +4,18 @@ const testing = require('taskcluster-lib-testing');
 
 helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
   helper.withMiddleware(mock, skipping, [
-    { 'middlewareType': 'test', fetchObjectMetadata: { intercept: 'dl' } },
+    { 'middlewareType': 'test', startDownload: { intercept: 'dl' } },
     { 'middlewareType': 'test', download: { intercept: 'simple' } },
   ]);
 
-  test('calls middleware for fetchObjectMetadataRequest', async function() {
+  test('calls middleware for startDownloadRequest', async function() {
     const middleware = await helper.load('middleware');
 
     let reply;
     const res = { reply: x => reply = x };
     const object = { name: 'dl/intercept' };
 
-    assert(!await middleware.fetchObjectMetadataRequest({}, res, object, 'meth', {}));
+    assert(!await middleware.startDownloadRequest({}, res, object, 'meth', {}));
     assert.deepEqual(reply, { method: 'simple', url: 'http://intercepted' });
   });
 

--- a/ui/docs/reference/platform/object/download-methods.mdx
+++ b/ui/docs/reference/platform/object/download-methods.mdx
@@ -19,7 +19,7 @@ See ["Simple Downloads"](/simple-downloads) for details of the simple process.
 
 ## Full Downloads
 
-The full download process involves making a request to the object service, via the `object.downloadObject` endpoint.
+The full download process involves making a request to the object service, via the `object.startDownload` endpoint.
 The response to this request contains the information required to download the object data.
 
 Taskcluster will provide libraries to support this interaction.
@@ -31,12 +31,12 @@ This negotiation accomplishes two things:
  * decouples download clients from the object service, allowing new, more advanced methods to be defined while maintaining support for older methods; and
  * allows the use of "unusual" technology when all parties support it -- for example, AWS supports Bittorrent downloads.
 
-The `downloadObject` request contains a list of methods that the caller supports.
+The `startDownload` request contains a list of methods that the caller supports.
 The object service determines the methods that it can support for the requested object and which are also supported by the client, then chooses the "best" of the matching methods.
 The service then calculates a response for that method and returns it to the caller.
 
-The `downloadObject` request can contain additional parameters, specific to the chosen method, but those are not considered in the negotiation.
-The `acceptDownloadMethods` property in the `downloadObject` request contains all supported methods as properties, with their parameters as values.
+The `startDownload` request can contain additional parameters, specific to the chosen method, but those are not considered in the negotiation.
+The `acceptDownloadMethods` property in the `startDownload` request contains all supported methods as properties, with their parameters as values.
 Methods that do not need parameters simply use `true`.
 For example, a request that can use either the `simple` or `superFancy` methods might look like:
 
@@ -59,7 +59,7 @@ The known methods are defined below.
 The `simple` method implements [simple downloads](/simple-downloads).
 The response contains a URL against which a `GET` request can be made to retrieve the object's data.
 
-To use the simple method with `downloadObject`, pass the following payload:
+To use the simple method with `startDownload`, pass the following payload:
 
 ```javascript
 acceptDownloadMethods: {


### PR DESCRIPTION
This name matches the `createUpload` method (#4334) a little better, and doesn't sound like a "get" method.