### PR TITLE
guard against integer overflow

### DIFF
--- a/changelog/WtoPEfpQR_eS8iaOo3pZRg.md
+++ b/changelog/WtoPEfpQR_eS8iaOo3pZRg.md
@@ -1,0 +1,3 @@
+audience: general
+level: silent
+---

--- a/tools/worker-runner/cfg/workerconfig.go
+++ b/tools/worker-runner/cfg/workerconfig.go
@@ -102,6 +102,10 @@ func merge(v1, v2 interface{}) interface{} {
 	arr1, arr1ok := v1.([]interface{})
 	arr2, arr2ok := v2.([]interface{})
 	if arr1ok && arr2ok {
+		// check for overflow
+		if len(arr1) > 2*1024*1024*1024 || len(arr2) > 2*1024*1024*1024 {
+			panic("arrays too large (>2**30 items)")
+		}
 		res := make([]interface{}, 0, len(arr1)+len(arr2))
 		res = append(res, arr1...)
 		res = append(res, arr2...)


### PR DESCRIPTION
This should silence a CodeQL warning that appeared out of nowhere today.