### PR TITLE
include setuptools_rust for pypi cryptography project

### DIFF
--- a/changelog/issue-4388.md
+++ b/changelog/issue-4388.md
@@ -1,0 +1,4 @@
+audience: general
+level: silent
+reference: issue 4388
+---

--- a/clients/client-py/release.sh
+++ b/clients/client-py/release.sh
@@ -23,7 +23,8 @@ rm -rf .release
 mkdir -p .release
 
 python3 -mvenv .release/py3
-.release/py3/bin/pip install -U setuptools twine wheel
+.release/py3/bin/pip install -U pip
+.release/py3/bin/pip install -U setuptools setuptools_rust twine wheel
 .release/py3/bin/python setup.py sdist
 .release/py3/bin/python setup.py bdist_wheel
 


### PR DESCRIPTION
I pushed a fixed 41.0.0 release to pypi manually.

Github Bug/Issue: Fixes #4388