### PR TITLE
Add a putUrl upload method, supported in AWS and Google

### DIFF
--- a/changelog/issue-4274.md
+++ b/changelog/issue-4274.md
@@ -1,0 +1,4 @@
+audience: general
+level: silent
+reference: issue 4274
+---

--- a/clients/client-go/tcobject/types.go
+++ b/clients/client-go/tcobject/types.go
@@ -127,6 +127,37 @@ type (
 		// the payload grows. In general, this is useful for testing and for metadata objects such as
 		// separate cryptographic signatures.
 		DataInline DataInlineUploadRequest `json:"dataInline,omitempty"`
+
+		// Request a URL to which a PUT request can be made.
+		Puturl PutURLUploadRequest `json:"puturl,omitempty"`
+	}
+
+	// Request a URL to which a PUT request can be made.
+	PutURLUploadRequest struct {
+
+		// Length, in bytes, of the uploaded data.
+		ContentLength float64 `json:"contentLength"`
+
+		// Content-type of the data to be uploaded.
+		ContentType string `json:"contentType"`
+	}
+
+	// Response containing a URL to which to PUT the data.
+	PutURLUploadResponse struct {
+
+		// Expiration time for the URL.  After this time, the client must
+		// call `createUpload` again to get a fresh URL.
+		Expires tcclient.Time `json:"expires"`
+
+		// Headers which must be included with the PUT request.  In many
+		// cases, these are included in a signature embedded in the URL,
+		// and must be provided verbatim.
+		//
+		// Map entries:
+		Headers map[string]string `json:"headers"`
+
+		// URL to which a PUT request should be made.
+		URL string `json:"url"`
 	}
 
 	// The selected upload method, from those contained in the request.  At most one
@@ -138,6 +169,9 @@ type (
 		//
 		// Constant value: %!q(bool=true)
 		DataInline bool `json:"dataInline,omitempty"`
+
+		// Response containing a URL to which to PUT the data.
+		PutURL PutURLUploadResponse `json:"putUrl,omitempty"`
 	}
 
 	// A simple download returns a URL to which the caller should make a GET request.

--- a/generated/references.json
+++ b/generated/references.json
@@ -4191,6 +4191,66 @@
   },
   {
     "content": {
+      "$id": "/schemas/object/v1/upload-method-put-url.json#",
+      "$schema": "/schemas/common/metaschema.json#",
+      "definitions": {
+        "request": {
+          "additionalProperties": false,
+          "description": "Request a URL to which a PUT request can be made.",
+          "properties": {
+            "contentLength": {
+              "description": "Length, in bytes, of the uploaded data.",
+              "type": "number"
+            },
+            "contentType": {
+              "description": "Content-type of the data to be uploaded.",
+              "type": "string"
+            }
+          },
+          "required": [
+            "contentType",
+            "contentLength"
+          ],
+          "title": "`putUrl` upload request",
+          "type": "object"
+        },
+        "response": {
+          "additionalProperties": false,
+          "description": "Response containing a URL to which to PUT the data.",
+          "properties": {
+            "expires": {
+              "description": "Expiration time for the URL.  After this time, the client must\ncall `createUpload` again to get a fresh URL.",
+              "format": "date-time",
+              "type": "string"
+            },
+            "headers": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "description": "Headers which must be included with the PUT request.  In many\ncases, these are included in a signature embedded in the URL,\nand must be provided verbatim.",
+              "type": "object"
+            },
+            "url": {
+              "description": "URL to which a PUT request should be made.",
+              "formt": "uri",
+              "type": "string"
+            }
+          },
+          "required": [
+            "url",
+            "expires",
+            "headers"
+          ],
+          "title": "`putUrl` upload response",
+          "type": "object"
+        }
+      },
+      "title": "putUrl upload method"
+    },
+    "filename": "schemas/object/v1/upload-method-put-url.json"
+  },
+  {
+    "content": {
       "$id": "/schemas/object/v1/upload-method-data-inline.json#",
       "$schema": "/schemas/common/metaschema.json#",
       "definitions": {
@@ -4413,6 +4473,9 @@
           "properties": {
             "dataInline": {
               "$ref": "upload-method-data-inline.json#/definitions/response"
+            },
+            "putUrl": {
+              "$ref": "upload-method-put-url.json#/definitions/response"
             }
           },
           "required": [
@@ -4459,6 +4522,9 @@
           "properties": {
             "dataInline": {
               "$ref": "upload-method-data-inline.json#/definitions/request"
+            },
+            "puturl": {
+              "$ref": "upload-method-put-url.json#/definitions/request"
             }
           },
           "required": [

--- a/services/object/schemas/v1/create-upload-request.yml
+++ b/services/object/schemas/v1/create-upload-request.yml
@@ -39,6 +39,7 @@ properties:
       discretion.
     properties:
       dataInline: {$ref: "upload-method-data-inline.json#/definitions/request"}
+      puturl: {$ref: "upload-method-put-url.json#/definitions/request"}
     additionalProperties: false
     required: []
 additionalProperties: false

--- a/services/object/schemas/v1/create-upload-response.yml
+++ b/services/object/schemas/v1/create-upload-response.yml
@@ -28,6 +28,7 @@ properties:
       then none of the proposed methods were selected.
     properties:
       dataInline: {$ref: "upload-method-data-inline.json#/definitions/response"}
+      putUrl: {$ref: "upload-method-put-url.json#/definitions/response"}
     minProperties: 0
     maxProperties: 1
     additionalProperties: false

--- a/services/object/schemas/v1/upload-method-put-url.yml
+++ b/services/object/schemas/v1/upload-method-put-url.yml
@@ -1,0 +1,45 @@
+$schema: "/schemas/common/metaschema.json#"
+title: "putUrl upload method"
+definitions:
+
+  request:
+    title: "`putUrl` upload request"
+    description: |-
+      Request a URL to which a PUT request can be made.
+    type: object
+    properties:
+      contentType:
+        type: string
+        description: Content-type of the data to be uploaded.
+      contentLength:
+        type: number
+        description: Length, in bytes, of the uploaded data.
+    additionalProperties: false
+    required: [contentType, contentLength]
+
+  response:
+    title: "`putUrl` upload response"
+    description: |-
+      Response containing a URL to which to PUT the data.
+    type: object
+    properties:
+      url:
+        type: string
+        formt: uri
+        description: URL to which a PUT request should be made.
+      expires:
+        type: string
+        format: date-time
+        description: |-
+          Expiration time for the URL.  After this time, the client must
+          call `createUpload` again to get a fresh URL.
+      headers:
+        type: object
+        description: |-
+          Headers which must be included with the PUT request.  In many
+          cases, these are included in a signature embedded in the URL,
+          and must be provided verbatim.
+        additionalProperties:
+          type: string
+    additionalProperties: false
+    required: [url, expires, headers]

--- a/services/object/test/backends/aws_test.js
+++ b/services/object/test/backends/aws_test.js
@@ -136,6 +136,20 @@ helper.secrets.mockSuite(testing.suiteName(), ['aws'], function(mock, skipping) 
     teardown(cleanup);
   });
 
+  helper.testPutUrlUpload({
+    mock, skipping, prefix,
+    backendId: 'awsPrivate',
+    async getObjectContent({ name }) {
+      const res = await s3.getObject({
+        Bucket: secret.testBucket,
+        Key: name,
+      }).promise();
+      return { data: res.Body, contentType: res.ContentType };
+    },
+  }, async function() {
+    teardown(cleanup);
+  });
+
   suite('expireObject', function() {
     teardown(cleanup);
 

--- a/services/object/test/backends/google_test.js
+++ b/services/object/test/backends/google_test.js
@@ -135,6 +135,20 @@ helper.secrets.mockSuite(testing.suiteName(), ['google'], function(mock, skippin
     teardown(cleanup);
   });
 
+  helper.testPutUrlUpload({
+    mock, skipping, prefix,
+    backendId: 'googlePrivate',
+    async getObjectContent({ name }) {
+      const res = await s3.getObject({
+        Bucket: secret.testBucket,
+        Key: name,
+      }).promise();
+      return { data: res.Body, contentType: res.ContentType };
+    },
+  }, async function() {
+    teardown(cleanup);
+  });
+
   suite('expireObject', function() {
     teardown(cleanup);
 

--- a/services/object/test/helper/data-inline-upload.js
+++ b/services/object/test/helper/data-inline-upload.js
@@ -38,7 +38,7 @@ exports.testDataInlineUpload = ({
 
     test('upload an object', async function() {
       const data = crypto.randomBytes(256);
-      const name = `${prefix}test!obj%ect/slash`;
+      const name = `${prefix}test!obj%ect/slash/data-inline`;
       const expires = taskcluster.fromNow('1 hour');
       const uploadId = taskcluster.slugid();
 

--- a/services/object/test/helper/index.js
+++ b/services/object/test/helper/index.js
@@ -12,6 +12,7 @@ const google = require('./google');
 
 Object.assign(exports, require('./simple-download'));
 Object.assign(exports, require('./data-inline-upload'));
+Object.assign(exports, require('./put-url-upload'));
 
 exports.load = stickyLoader(load);
 

--- a/services/object/test/helper/put-url-upload.js
+++ b/services/object/test/helper/put-url-upload.js
@@ -39,7 +39,7 @@ exports.testPutUrlUpload = ({
 
     const makeUpload = async () => {
       const data = crypto.randomBytes(256);
-      const name = `${prefix}test!obj%ect/slash`;
+      const name = `${prefix}test!obj%ect/slash?put-url`;
       const expires = taskcluster.fromNow('1 hour');
       const uploadId = taskcluster.slugid();
 

--- a/services/object/test/helper/put-url-upload.js
+++ b/services/object/test/helper/put-url-upload.js
@@ -1,0 +1,90 @@
+const taskcluster = require('taskcluster-client');
+const request = require('superagent');
+const crypto = require('crypto');
+const assert = require('assert');
+const helper = require('../helper');
+
+/**
+ * Test the put-url upload method on the given backend.  This defines a suite
+ * of tests.
+ */
+exports.testPutUrlUpload = ({
+  mock, skipping,
+
+  // optional title suffix
+  title,
+
+  // a prefix for object names, so that concurrent runs do not modify the
+  // same objects in the "real" storage backend
+  prefix,
+
+  // the backend to test; this will be loaded from the loader, so its configuration
+  // should be set up in suiteSetup.
+  backendId,
+
+  // an async function({name}) to get the data for a given object.
+  getObjectContent,
+
+  // suiteDefinition defines the suite; add suiteSetup, suiteTeardown here, if
+  // necessary, and any extra tests
+}, suiteDefinition) => {
+  suite(`put-url upload method API${title ? `: ${title}` : ''}`, function() {
+    (suiteDefinition || (() => {})).call(this);
+
+    let backend;
+    suiteSetup(async function() {
+      const backends = await helper.load('backends');
+      backend = backends.get(backendId);
+    });
+
+    const makeUpload = async () => {
+      const data = crypto.randomBytes(256);
+      const name = `${prefix}test!obj%ect/slash`;
+      const expires = taskcluster.fromNow('1 hour');
+      const uploadId = taskcluster.slugid();
+
+      await helper.db.fns.create_object_for_upload(name, 'test-proj', backendId, uploadId, expires, {}, expires);
+      const [object] = await helper.db.fns.get_object_with_upload(name);
+
+      const res = await backend.createUpload(object, {
+        putUrl: { contentType: 'application/random-bytes', contentLength: data.length },
+      });
+
+      return { name, data, res, uploadId };
+    };
+
+    test('upload an object', async function() {
+      const { name, data, res, uploadId } = await makeUpload();
+
+      assert(new Date(res.expires) > new Date());
+
+      let req = request.put(res.url);
+      for (let [h, v] of Object.entries(res.headers)) {
+        req = req.set(h, v);
+      }
+      const putRes = await req.send(data);
+      assert(putRes.ok, putRes);
+
+      await helper.db.fns.object_upload_complete(name, uploadId);
+
+      const stored = await getObjectContent({ name });
+      assert.equal(stored.contentType, 'application/random-bytes');
+      assert.deepEqual(stored.data, data);
+    });
+
+    test('upload an object with a bad Content-Type', async function() {
+      const { data, res } = await makeUpload();
+
+      let req = request.put(res.url);
+      for (let [h, v] of Object.entries(res.headers)) {
+        req = req.set(h, v);
+      }
+      req.set('Content-Type', 'some-other/content-type');
+      req.ok(res => res.status < 500);
+      const putRes = await req.send(data);
+
+      // this request should fail, somehow (how depends on the backend)
+      assert(!putRes.ok);
+    });
+  });
+};

--- a/ui/docs/reference/platform/object/upload-methods.mdx
+++ b/ui/docs/reference/platform/object/upload-methods.mdx
@@ -33,7 +33,16 @@ This is a universal method that supports upload of small objects (less that 8k) 
 
 ### `putUrl` Upload Method
 
-(TBD: similar to the the existing 's3' queue artifact type)
+This is a universal method which supports uploads via a `PUT` request to the given URL, containing the given headers.
+This is meant to be a "plain", broadly-compatible upload method, with optimizations implemented in other methods.
+
+The response contains a `putUrl` as well as an object containing headers (mapping name to value).
+The caller is expected to make a `PUT` request to the given URL, with the given headers.
+
+This request must begin before the expiration time given in the response.
+If retries extend beyond this time, then the client should make a new `createUpload` call to get a fresh URL.
+
+For this upload method, the content encoding _must_ be `identity` (the default value for the `Content-Encoding` header).
 
 ### `s3Multipart` Upload Method
 


### PR DESCRIPTION
This is the bicycle of upload methods: not fast, but it will always
work.

Github Bug/Issue: Fixes #4274