### PR TITLE
Increase ts_skew for client-rs test

### DIFF
--- a/changelog/issue-4346.md
+++ b/changelog/issue-4346.md
@@ -1,0 +1,4 @@
+audience: general
+level: silent
+reference: issue 4346
+---

--- a/clients/client-rust/src/client.rs
+++ b/clients/client-rust/src/client.rs
@@ -480,7 +480,9 @@ mod tests {
 
             let key = hawk::Key::new(&self.0.access_token, hawk::SHA256).unwrap();
 
-            if !hawk_req.validate_header(&auth_header, &key, Duration::from_secs(1)) {
+            // this ts_skew duration needs to be large -- in CI, somehow 1s can elapse between
+            // a request and the invocation of a matcher.
+            if !hawk_req.validate_header(&auth_header, &key, Duration::from_secs(60)) {
                 println!("Validation failed");
                 return false;
             }


### PR DESCRIPTION
This should help with the intermittency.

Github Bug/Issue: Fixes #4346