### PR TITLE
Allow projectId in hooks.triggerHook

### DIFF
--- a/changelog/issue-4417.md
+++ b/changelog/issue-4417.md
@@ -1,0 +1,5 @@
+audience: users
+level: patch
+reference: issue 4417
+---
+In a followup to a bug partially fixed in v41.0.1, the `hooks.triggerHook` function no longer crashes due to the `projectId` property from `queue.createTask`.

--- a/clients/client-go/tchooks/types.go
+++ b/clients/client-go/tchooks/types.go
@@ -290,6 +290,18 @@ type (
 		// must have an expiration that is no later than this.
 		Expires tcclient.Time `json:"expires"`
 
+		// The name for the "project" with which this task is associated.  This
+		// value can be used to control permission to manipulate tasks as well as
+		// for usage reporting.  Project ids are typically simple identifiers,
+		// optionally in a hierarchical namespace separated by `/` characters.
+		// This value defaults to `none`.
+		//
+		// Default:    "none"
+		// Syntax:     ^([a-zA-Z0-9._/-]*)$
+		// Min length: 1
+		// Max length: 500
+		ProjectID string `json:"projectId,omitempty"`
+
 		// Unique identifier for the provisioner that this task must be scheduled on
 		//
 		// Syntax:     ^([a-zA-Z0-9-_]*)$

--- a/generated/references.json
+++ b/generated/references.json
@@ -5134,6 +5134,15 @@
               "title": "Expiration",
               "type": "string"
             },
+            "projectId": {
+              "default": "none",
+              "description": "The name for the \"project\" with which this task is associated.  This\nvalue can be used to control permission to manipulate tasks as well as\nfor usage reporting.  Project ids are typically simple identifiers,\noptionally in a hierarchical namespace separated by `/` characters.\nThis value defaults to `none`.\n",
+              "maxLength": 500,
+              "minLength": 1,
+              "pattern": "^([a-zA-Z0-9._/-]*)$",
+              "title": "Project Identifier",
+              "type": "string"
+            },
             "provisionerId": {
               "description": "Unique identifier for the provisioner that this task must be scheduled on\n",
               "maxLength": 38,

--- a/services/hooks/schemas/constants.yml
+++ b/services/hooks/schemas/constants.yml
@@ -28,6 +28,10 @@ slugid-pattern:  "^[A-Za-z0-9_-]{8}[Q-T][A-Za-z0-9_-][CGKOSWaeimquy26-][A-Za-z0-
 # Pattern for scope names, for when-ever that is useful
 scope-pattern:   "^[\\x20-\\x7e]*$"
 
+projectId-pattern:     ^([a-zA-Z0-9._/-]*)$
+projectId-min-length:  1
+projectId-max-length:  500
+
 # Run identifier limitations, these are also somewhat founded in RabbitMQ
 # routing key limitations
 min-run-id:     0

--- a/services/hooks/schemas/v1/task-status.yml
+++ b/services/hooks/schemas/v1/task-status.yml
@@ -3,6 +3,10 @@ title:              "Task Status Structure"
 description: |
   A representation of **task status** as known by the queue
 type:               object
+
+# NOTE: this is a copy of the schema for the response to `queue.createTask`,
+# and should be maintained in concert with that schema.
+
 properties:
   status:
     type: object
@@ -37,6 +41,19 @@ properties:
           Unique identifier for a task queue
         type:           string
         pattern:        {$const: taskqueueid-pattern}
+      projectId:
+        title:          "Project Identifier"
+        description: |
+          The name for the "project" with which this task is associated.  This
+          value can be used to control permission to manipulate tasks as well as
+          for usage reporting.  Project ids are typically simple identifiers,
+          optionally in a hierarchical namespace separated by `/` characters.
+          This value defaults to `none`.
+        type:           string
+        default:        'none'
+        minLength:      {$const: projectId-min-length}
+        maxLength:      {$const: projectId-max-length}
+        pattern:        {$const: projectId-pattern}
       schedulerId:
         title:          "Scheduler Identifier"
         description: |

--- a/services/hooks/src/taskcreator.js
+++ b/services/hooks/src/taskcreator.js
@@ -208,6 +208,7 @@ class MockTaskCreator extends TaskCreator {
         provisionerId: hook.task.provisionerId,
         workerType: hook.task.workerType,
         taskQueueId: `${hook.task.provisionerId}/${hook.task.workerType}`,
+        projectId: 'none',
         schedulerId: '-',
         taskGroupId: taskcluster.slugid(),
         deadline: '2015-10-18T22:32:59.706Z',

--- a/services/queue/schemas/v1/task-status.yml
+++ b/services/queue/schemas/v1/task-status.yml
@@ -3,6 +3,10 @@ title:              "Task Status Structure"
 description: |
   A representation of **task status** as known by the queue
 type:               object
+
+# NOTE: updates to this schema should be refected in
+# services/hooks/schemas/v1/task-status.yml as well.
+
 properties:
   taskId: {$const: "taskId"}
   provisionerId: {$ref: "task.json#/properties/provisionerId"}


### PR DESCRIPTION
A few other options turned out to be difficult or impossible:
 * `$ref` between services' schemas aren't allowed (and changing this would be hard)
 * Just copying `task-status.yml` from `services/queue` to `services/hooks` does not work since it uses `$ref` to pull in lots of other queue schemas
 * Switching the `triggerHook` response body to just `{type: "object", additionalProperties: true, description: "This is the response from queue.createTask.."}` would change the Golang API incompatibly, requiring a major version bump and potentially doing more harm than a bugfix should.
 * Setting `additionalProperties: true` but keeping all of the defined properties also changes the Golang API incompatibly (replacing the whole thing with `json.RawMessage`.

Github Bug/Issue: Fixes #4417
