### PR TITLE
Disable minor and patch updates of the TC clients

### DIFF
--- a/package.json
+++ b/package.json
@@ -238,6 +238,16 @@
         "prPriority": 1
       },
       {
+        "packagePatterns": [
+          "^taskcluster-client.*"
+        ],
+        "updateTypes": [
+            "minor",
+            "patch"
+        ],
+        "enabled": false
+      },
+      {
         "updateTypes": [
           "minor",
           "patch"


### PR DESCRIPTION
Docker-worker requires taskcluster-client, and the UI requires
taskcluster-client-web.  In neither case can we make the build process
work correctly linking to those within the monorepo, so we import them
from the registry, and rely on renovate to bump them.  But, that bumping
doesn't need to happen on every minor version -- just major versions.

(refs #4433)
