### PR TITLE
Check upload return values

### DIFF
--- a/changelog/Up1Pcx-6SdeGj-NOjCSVVw.md
+++ b/changelog/Up1Pcx-6SdeGj-NOjCSVVw.md
@@ -1,0 +1,3 @@
+audience: general
+level: silent
+---

--- a/libraries/validate/src/index.js
+++ b/libraries/validate/src/index.js
@@ -118,10 +118,12 @@ class SchemaSet {
     return (obj, id) => {
       id = id.replace(/#$/, '');
       id = id.replace(/\.ya?ml$/, '.json');
-      if (!_.endsWith(id, '.json')) {
-        id += '.json';
+      if (!/#/.test(id)) {
+        if (!_.endsWith(id, '.json')) {
+          id += '.json';
+        }
+        id += '#';
       }
-      id += '#';
       ajv.validate(id, obj);
       if (ajv.errors) {
         _.forEach(ajv.errors, function(error) {

--- a/libraries/validate/test/validate_test.js
+++ b/libraries/validate/test/validate_test.js
@@ -32,6 +32,13 @@ suite(testing.suiteName(), () => {
     assert.equal(error, null);
   });
 
+  test('sub-schemas', () => {
+    let error = validate(
+      42,
+      libUrls.schema(rootUrl, 'whatever', '/v1/test-schema.json#/properties/value'));
+    assert.equal(error, null);
+  });
+
   test('load yaml', () => {
     let error = validate(
       { value: 42 },

--- a/services/object/src/backends/aws.js
+++ b/services/object/src/backends/aws.js
@@ -75,10 +75,12 @@ class AwsBackend extends Backend {
     });
 
     return {
-      url,
-      expires,
-      headers: {
-        'Content-Type': contentType,
+      putUrl: {
+        url,
+        expires: expires.toJSON(),
+        headers: {
+          'Content-Type': contentType,
+        },
       },
     };
   }

--- a/services/object/test/helper/data-inline-upload.js
+++ b/services/object/test/helper/data-inline-upload.js
@@ -3,6 +3,8 @@ const crypto = require('crypto');
 const assert = require('assert');
 const helper = require('../helper');
 
+const responseSchema = 'https://tc-testing.example.com/schemas/object/v1/create-upload-response.json#/properties/uploadMethod';
+
 /**
  * Test the data-inline upload method on the given backend.  This defines a suite
  * of tests.
@@ -48,6 +50,8 @@ exports.testDataInlineUpload = ({
       const res = await backend.createUpload(object, {
         dataInline: { contentType: 'application/random-bytes', objectData: data.toString('base64') },
       });
+
+      helper.assertSatisfiesSchema(res, responseSchema);
       assert.deepEqual(res, { dataInline: true });
 
       await helper.db.fns.object_upload_complete(name, uploadId);

--- a/services/object/test/helper/index.js
+++ b/services/object/test/helper/index.js
@@ -1,3 +1,4 @@
+const assert = require('assert').strict;
 const taskcluster = require('taskcluster-client');
 const { fakeauth, stickyLoader, Secrets, withMonitor, resetTables } = require('taskcluster-lib-testing');
 const load = require('../../src/main');
@@ -149,4 +150,17 @@ exports.resetTables = (mock, skipping) => {
       tableNames: ['objects'],
     });
   });
+};
+
+let validator;
+exports.assertSatisfiesSchema = async (data, id) => {
+  if (!validator) {
+    const schemaset = await exports.load('schemaset');
+    validator = await schemaset.validator('https://tc-testing.example.com');
+  }
+
+  const validator_error = validator(data, id);
+  if (validator_error) {
+    assert(false, "validation error:\n" + validator_error);
+  }
 };

--- a/services/object/test/helper/put-url-upload.js
+++ b/services/object/test/helper/put-url-upload.js
@@ -4,6 +4,8 @@ const crypto = require('crypto');
 const assert = require('assert');
 const helper = require('../helper');
 
+const responseSchema = 'https://tc-testing.example.com/schemas/object/v1/create-upload-response.json#/properties/uploadMethod';
+
 /**
  * Test the put-url upload method on the given backend.  This defines a suite
  * of tests.
@@ -50,16 +52,18 @@ exports.testPutUrlUpload = ({
         putUrl: { contentType: 'application/random-bytes', contentLength: data.length },
       });
 
+      helper.assertSatisfiesSchema(res, responseSchema);
+
       return { name, data, res, uploadId };
     };
 
     test('upload an object', async function() {
       const { name, data, res, uploadId } = await makeUpload();
 
-      assert(new Date(res.expires) > new Date());
+      assert(new Date(res.putUrl.expires) > new Date());
 
-      let req = request.put(res.url);
-      for (let [h, v] of Object.entries(res.headers)) {
+      let req = request.put(res.putUrl.url);
+      for (let [h, v] of Object.entries(res.putUrl.headers)) {
         req = req.set(h, v);
       }
       const putRes = await req.send(data);
@@ -75,8 +79,8 @@ exports.testPutUrlUpload = ({
     test('upload an object with a bad Content-Type', async function() {
       const { data, res } = await makeUpload();
 
-      let req = request.put(res.url);
-      for (let [h, v] of Object.entries(res.headers)) {
+      let req = request.put(res.putUrl.url);
+      for (let [h, v] of Object.entries(res.putUrl.headers)) {
         req = req.set(h, v);
       }
       req.set('Content-Type', 'some-other/content-type');


### PR DESCRIPTION
I discovered that the AWS backend's `putUrl` impl was returning data in the wrong format.  The fix is one-line, but this also adds some tests to avoid this in the future.