### PR TITLE
Include 'Content-Length' in putUrl headers for AWS

### DIFF
--- a/changelog/issue-4444.md
+++ b/changelog/issue-4444.md
@@ -1,0 +1,4 @@
+audience: general
+level: silent
+reference: issue 4444
+---

--- a/clients/client-go/tcobject/types.go
+++ b/clients/client-go/tcobject/types.go
@@ -153,6 +153,11 @@ type (
 		// cases, these are included in a signature embedded in the URL,
 		// and must be provided verbatim.
 		//
+		// The `Content-Length` header may be included here.  Many HTTP client
+		// libraries will also set this directly when the length is known.  In
+		// this case, the values should be identical, and the header should only
+		// be specified once.
+		//
 		// Map entries:
 		Headers map[string]string `json:"headers"`
 

--- a/generated/references.json
+++ b/generated/references.json
@@ -4232,7 +4232,7 @@
               "additionalProperties": {
                 "type": "string"
               },
-              "description": "Headers which must be included with the PUT request.  In many\ncases, these are included in a signature embedded in the URL,\nand must be provided verbatim.",
+              "description": "Headers which must be included with the PUT request.  In many\ncases, these are included in a signature embedded in the URL,\nand must be provided verbatim.\n\nThe `Content-Length` header may be included here.  Many HTTP client\nlibraries will also set this directly when the length is known.  In\nthis case, the values should be identical, and the header should only\nbe specified once.",
               "type": "object"
             },
             "url": {

--- a/services/object/schemas/v1/upload-method-put-url.yml
+++ b/services/object/schemas/v1/upload-method-put-url.yml
@@ -39,6 +39,11 @@ definitions:
           Headers which must be included with the PUT request.  In many
           cases, these are included in a signature embedded in the URL,
           and must be provided verbatim.
+
+          The `Content-Length` header may be included here.  Many HTTP client
+          libraries will also set this directly when the length is known.  In
+          this case, the values should be identical, and the header should only
+          be specified once.
         additionalProperties:
           type: string
     additionalProperties: false

--- a/services/object/src/backends/aws.js
+++ b/services/object/src/backends/aws.js
@@ -64,7 +64,7 @@ class AwsBackend extends Backend {
     return { dataInline: true };
   }
 
-  async createPutUrlUpload(object, { contentType }) {
+  async createPutUrlUpload(object, { contentType, contentLength }) {
     const expires = taskcluster.fromNow(`${PUT_URL_EXPIRES_SECONDS} s`);
     const url = await this.s3.getSignedUrlPromise('putObject', {
       Bucket: this.config.bucket,
@@ -80,6 +80,7 @@ class AwsBackend extends Backend {
         expires: expires.toJSON(),
         headers: {
           'Content-Type': contentType,
+          'Content-Length': contentLength,
         },
       },
     };


### PR DESCRIPTION
If this header is omitted, AWS responds with a 501 error, which is not
very helpful.  Although some clients do automatically set this header,
not all do, so this commit chooses to err on the side of including a
possibly-duplicative header instead of omitting it.

Github Bug/Issue: Fixes #4444