### PR TITLE
Add some debug-level logging to built-in-workers

### DIFF
--- a/changelog/SDee64D8SxCBdpFAoid7SQ.md
+++ b/changelog/SDee64D8SxCBdpFAoid7SQ.md
@@ -1,0 +1,3 @@
+audience: general
+level: silent
+---

--- a/services/built-in-workers/src/main.js
+++ b/services/built-in-workers/src/main.js
@@ -41,13 +41,13 @@ const load = loader({
   },
 
   succeedTaskQueue: {
-    requires: ['queue', 'cfg'],
-    setup: ({ cfg, queue }) => new taskqueue.TaskQueue(cfg, queue, 'succeed'),
+    requires: ['queue', 'cfg', 'monitor'],
+    setup: ({ cfg, queue, monitor }) => new taskqueue.TaskQueue(cfg, queue, monitor.childMonitor('succeed'), 'succeed'),
   },
 
   failTaskQueue: {
-    requires: ['queue', 'cfg'],
-    setup: ({ cfg, queue }) => new taskqueue.TaskQueue(cfg, queue, 'fail'),
+    requires: ['queue', 'cfg', 'monitor'],
+    setup: ({ cfg, queue, monitor }) => new taskqueue.TaskQueue(cfg, queue, monitor.childMonitor('fail'), 'fail'),
   },
 
   server: {


### PR DESCRIPTION
I added this while debugging an issue that turned out to be something completely different, but this is still useful: with level=DEBUG, it means that this service will log things periodically, confirming it's alive.