### PR TITLE
Fix the putUrl response body, where headers must be strings

### DIFF
--- a/changelog/NXTIXhw6RlSrbdRh-zDaGA.md
+++ b/changelog/NXTIXhw6RlSrbdRh-zDaGA.md
@@ -1,0 +1,3 @@
+audience: general
+level: silent
+---

--- a/services/object/src/backends/aws.js
+++ b/services/object/src/backends/aws.js
@@ -80,7 +80,7 @@ class AwsBackend extends Backend {
         expires: expires.toJSON(),
         headers: {
           'Content-Type': contentType,
-          'Content-Length': contentLength,
+          'Content-Length': contentLength.toString(),
         },
       },
     };

--- a/services/object/test/helper/data-inline-upload.js
+++ b/services/object/test/helper/data-inline-upload.js
@@ -51,7 +51,7 @@ exports.testDataInlineUpload = ({
         dataInline: { contentType: 'application/random-bytes', objectData: data.toString('base64') },
       });
 
-      helper.assertSatisfiesSchema(res, responseSchema);
+      await helper.assertSatisfiesSchema(res, responseSchema);
       assert.deepEqual(res, { dataInline: true });
 
       await helper.db.fns.object_upload_complete(name, uploadId);

--- a/services/object/test/helper/put-url-upload.js
+++ b/services/object/test/helper/put-url-upload.js
@@ -52,7 +52,7 @@ exports.testPutUrlUpload = ({
         putUrl: { contentType: 'application/random-bytes', contentLength: data.length },
       });
 
-      helper.assertSatisfiesSchema(res, responseSchema);
+      await helper.assertSatisfiesSchema(res, responseSchema);
 
       return { name, data, res, uploadId };
     };


### PR DESCRIPTION
The missing `await` meant that the schema verification wasn't actually verifying.

I have now checked that it actually fails when the value does not match the schema.  I had done so in the last PR as well, but before factoring out the `helper.assertSatisfiesSchema` function.