### PR TITLE
[client-js] Add upload/download functionality

### DIFF
--- a/changelog/issue-4423.md
+++ b/changelog/issue-4423.md
@@ -1,0 +1,4 @@
+audience: general
+level: silent
+reference: issue 4423
+---

--- a/clients/client/README.md
+++ b/clients/client/README.md
@@ -354,6 +354,72 @@ const taskId = taskcluster.slugid();
 
 The generates _nice_ random slugids, refer to slugid module for further details.
 
+### Uploading and Downloading
+
+The Object service provides an API for reliable uploads and downloads of large objects.
+This library provides convenience methods to implement the client portion of those APIs, providing well-tested, resilient upload and download functionality.
+These methods will negotiate the appropriate method with the object service and perform the required steps to transfer the data.
+
+In either case, you will need to provide a configured `Object` instance with appropriate credentials for the operation.
+You must also provide a `streamFactory` which, on each call, returns a Readable or Writable stream to handle the object data.
+This function may be async (return a Promise).
+In the event of retries, this function may be called several times, and should return a fresh stream on each invocation.
+
+Both `upload` and `download` support the same retry configuration as clients, as described above, with the same defaults.
+Note that these parameters apply only to the data-transfer portion of the process.
+The calls to Object service endpoints will be governed by the retry configuration of the given `Object` instance.
+
+For upload:
+
+```javascript
+await taskcluster.upload({
+  // paramters for the createObject endpoint
+  projectId,
+  name,
+  expires,
+
+  // metadata about the data being uploaded
+  contentType,
+  contentLength,
+
+  // see above
+  object,
+  streamFactory,
+  retries.,
+  delayFactor.,
+  randomizationFactor.,
+  maxDelay.,
+});
+```
+
+For download, which returns the content type:
+
+```javascript
+let contentType = await taskcluster.download({
+  // the object to download
+  name,
+
+  // see above
+  object,
+  streamFactory,
+  retries.,
+  delayFactor.,
+  randomizationFactor.,
+  maxDelay.,
+});
+```
+
+For example:
+
+```javascript
+const object = new taskcluster.Object(taskcluster.fromEnvVars());
+const contentType = await taskcluster.download({
+  name: 'testing/data.tgz',
+  object,
+  streamFactory: () => fs.createWriteStream('data.tgz'),
+});
+```
+
 ### Inspecting Credentials
 
 Your users may find the options for Taskcluster credentials overwhelming.  You

--- a/clients/client/package.json
+++ b/clients/client/package.json
@@ -20,7 +20,8 @@
   "devDependencies": {
     "http-proxy": "^1.18.0",
     "mocha": "^8.0.0",
-    "nock": "^13.0.0"
+    "nock": "^13.0.0",
+    "stream-buffers": "^3.0.2"
   },
   "engines": {
     "node": ">=v8.17.0"

--- a/clients/client/src/download.js
+++ b/clients/client/src/download.js
@@ -1,0 +1,51 @@
+const got = require('got');
+const util = require('util');
+const pipeline = util.promisify(require('stream').pipeline);
+const retry = require('./retry');
+
+const simple = async ({ download, streamFactory, retryCfg }) => {
+  const { url } = download;
+
+  return await retry(retryCfg, async (retriableError, attempt) => {
+    let contentType = 'application/binary';
+    try {
+      const src = got.stream(url, { retry: false });
+      src.on('response', res => {
+        contentType = res.headers['content-type'] || contentType;
+      });
+      const dest = await streamFactory();
+      await pipeline(src, dest);
+      return contentType;
+    } catch (err) {
+      // treat non-500 HTTP responses as fatal errors, and retry everything else
+      if (err instanceof got.HTTPError && err.response.statusCode < 500) {
+        throw err;
+      }
+      return retriableError(err);
+    }
+  });
+};
+
+const download = async ({ name, object, streamFactory, retries, delayFactor, randomizationFactor, maxDelay }) => {
+  // apply default retry config
+  const retryCfg = {
+    retries: retries === undefined ? 5 : retries,
+    delayFactor: delayFactor === undefined ? 100 : delayFactor,
+    randomizationFactor: randomizationFactor === undefined ? randomizationFactor : 0.25,
+    maxDelay: maxDelay === undefined ? 30 * 1000 : maxDelay,
+  };
+
+  const acceptDownloadMethods = {
+    simple: true,
+  };
+
+  const download = await object.startDownload(name, { acceptDownloadMethods });
+
+  if (download.method === 'simple') {
+    return await simple({ download, streamFactory, retryCfg });
+  } else {
+    throw new Error("Could not negotiate a download method");
+  }
+};
+
+module.exports = { download };

--- a/clients/client/src/index.js
+++ b/clients/client/src/index.js
@@ -4,8 +4,10 @@
 
 let _ = require('lodash');
 
-// Export methods and classes from lib/
+// Export methods and classes from other files
 _.defaults(exports,
   require('./client'),
   require('./utils'),
+  require('./upload'),
+  require('./download'),
 );

--- a/clients/client/src/retry.js
+++ b/clients/client/src/retry.js
@@ -1,0 +1,39 @@
+/**
+ * Call the given function based on the given retry configuration.  Each call to the
+ * function is given a `retriableError` callback.  For retriable failures, call this
+ * callback with an Error object (in case retries are exhausted) and return.  For
+ * fatal errors, simply throw the error as usual.  The second argument is the attempt number.
+ *
+ * Note that as per the existing API, `retries` is the number of retries after the first
+ * try; that is, a `retries` value of 3 means that `func` will be called 4 times.
+ */
+module.exports = async ({ retries, delayFactor, randomizationFactor, maxDelay }, func) => {
+  let attempt = 0;
+
+  while (true) {
+    attempt += 1;
+
+    let retriableError = null;
+
+    const rv = await func(err => retriableError = err, attempt);
+    if (!retriableError) {
+      // success!
+      return rv;
+    }
+
+    if (attempt > retries) {
+      throw retriableError;
+    }
+
+    // Sleep for 2 * delayFactor on the first attempt, and 2x as long
+    // each time thereafter
+    let delay = Math.pow(2, attempt) * delayFactor;
+    // Apply randomization factor
+    let rf = randomizationFactor;
+    delay *= Math.random() * 2 * rf + 1 - rf;
+    // Always limit with a maximum delay
+    delay = Math.min(delay, maxDelay);
+    // Sleep before looping again
+    await new Promise(accept => setTimeout(accept, delay));
+  }
+};

--- a/clients/client/src/upload.js
+++ b/clients/client/src/upload.js
@@ -1,0 +1,88 @@
+const got = require('got');
+const { slugid } = require('./utils');
+const retry = require('./retry');
+
+const DATA_INLINE_MAX_SIZE = 8192;
+
+const putUrl = async ({ streamFactory, contentLength, uploadMethod, retryCfg }) => {
+  const { url, headers } = uploadMethod.putUrl;
+  await retry(retryCfg, async (retriableError, attempt) => {
+    try {
+      await got.put(url, {
+        headers,
+        retry: false, // use our own retry logic
+        body: await streamFactory(),
+      });
+    } catch (err) {
+      // treat non-500 HTTP responses as fatal errors, and retry everything else
+      if (err instanceof got.HTTPError && err.response.statusCode < 500) {
+        throw err;
+      }
+      return retriableError(err);
+    }
+  });
+};
+
+const readFullStream = stream => {
+  const chunks = [];
+  return new Promise((accept, reject) => {
+    stream.on('data', chunk => chunks.push(chunk));
+    stream.on('error', err => reject(err));
+    stream.on('end', () => accept(Buffer.concat(chunks)));
+  });
+};
+
+const upload = async ({
+  projectId,
+  name,
+  contentType,
+  contentLength,
+  expires,
+  object,
+  streamFactory,
+  retries,
+  delayFactor,
+  randomizationFactor,
+  maxDelay,
+}) => {
+  const uploadId = slugid();
+
+  // apply default retry config
+  const retryCfg = {
+    retries: retries === undefined ? 5 : retries,
+    delayFactor: delayFactor === undefined ? 100 : delayFactor,
+    randomizationFactor: randomizationFactor === undefined ? randomizationFactor : 0.25,
+    maxDelay: maxDelay === undefined ? 30 * 1000 : maxDelay,
+  };
+
+  const proposedUploadMethods = {};
+
+  if (contentLength < DATA_INLINE_MAX_SIZE) {
+    // get the (small) data as a buffer to include in the request
+    const data = await readFullStream(await streamFactory());
+
+    proposedUploadMethods.dataInline = {
+      contentType,
+      objectData: data.toString('base64'),
+    };
+  }
+
+  proposedUploadMethods.putUrl = {
+    contentType,
+    contentLength,
+  };
+
+  const res = await object.createUpload(name, { expires, projectId, uploadId, proposedUploadMethods });
+
+  if (res.uploadMethod.dataInline) {
+    // nothing to do
+  } else if (res.uploadMethod.putUrl) {
+    await putUrl({ streamFactory, contentLength, uploadMethod: res.uploadMethod, retryCfg });
+  } else {
+    throw new Error("Could not negotiate an upload method");
+  }
+
+  await object.finishUpload(name, { projectId, uploadId });
+};
+
+module.exports = { upload };

--- a/clients/client/test/creds_test.js
+++ b/clients/client/test/creds_test.js
@@ -3,8 +3,11 @@ const assert = require('assert');
 const request = require('superagent');
 const _ = require('lodash');
 const testing = require('taskcluster-lib-testing');
+const helper = require('./helper');
 
 suite(testing.suiteName(), function() {
+  helper.withRestoredEnvVars();
+
   // This suite exercises the credential-handling functionality of the client
   // against a the auth service's testAuthenticate endpoint.
 
@@ -342,23 +345,10 @@ suite(testing.suiteName(), function() {
   });
 
   suite('Get with credentials from environment variables', async () => {
-    let ROOT_URL = process.env.TASKCLUSTER_ROOT_URL;
-    let CLIENT_ID = process.env.TASKCLUSTER_CLIENT_ID;
-    let ACCESS_TOKEN = process.env.TASKCLUSTER_ACCESS_TOKEN;
-
-    // Ensure the client is removed from the require cache so it can be
-    // reloaded from scratch.
     setup(() => {
-      process.env.TASKCLUSTER_ROOT_URL = ROOT_URL || 'https://community-tc.services.mozilla.com/';
+      process.env.TASKCLUSTER_ROOT_URL = process.env.TASKCLUSTER_ROOT_URL || 'https://community-tc.services.mozilla.com/';
       process.env.TASKCLUSTER_CLIENT_ID = 'tester';
       process.env.TASKCLUSTER_ACCESS_TOKEN = 'no-secret';
-    });
-
-    // Be a good citizen and cleanup after this test so we don't leak state.
-    teardown(() => {
-      process.env.TASKCLUSTER_ROOT_URL = ROOT_URL;
-      process.env.TASKCLUSTER_CLIENT_ID = CLIENT_ID;
-      process.env.TASKCLUSTER_ACCESS_TOKEN = ACCESS_TOKEN;
     });
 
     test('fromEnvVars with only rootUrl', async () => {

--- a/clients/client/test/helper.js
+++ b/clients/client/test/helper.js
@@ -1,0 +1,25 @@
+// Restore TASKCLUSTER_* env vars after this test suite runs, to the values they
+// had when it began.
+exports.withRestoredEnvVars = () => {
+  const vars = ['TASKCLUSTER_CLIENT_ID', 'TASKCLUSTER_ROOT_URL', 'TASKCLUSTER_ACCESS_TOKEN'];
+
+  let values;
+  suiteSetup('save TASKCLUSTER_* env vars', function() {
+    values = {};
+    for (let v of vars) {
+      if (process.env[v]) {
+        values[v] = process.env[v];
+      }
+    }
+  });
+
+  suiteTeardown('restore TASKCLUSTER_* env vars', function() {
+    for (let v of vars) {
+      if (values[v]) {
+        process.env[v] = values[v];
+      } else {
+        delete process.env[v];
+      }
+    }
+  });
+};

--- a/clients/client/test/retry_test.js
+++ b/clients/client/test/retry_test.js
@@ -5,6 +5,7 @@ const { APIBuilder } = require('taskcluster-lib-api');
 const testing = require('taskcluster-lib-testing');
 const { App } = require('taskcluster-lib-app');
 const { monitorManager, monitor } = require('./monitor');
+const retry = require('../src/retry');
 
 const rootUrl = `http://localhost:60526`;
 
@@ -253,4 +254,48 @@ suite(testing.suiteName(), function() {
       assert(monitorManager.messages.length > 0);
     });
   });
+});
+
+suite('retry function', function() {
+  let failures;
+  const retriableFailEveryTime = (retriableError, attempt) => {
+    failures++;
+    assert.equal(attempt, failures);
+    retriableError(new Error('uhoh, retriable'));
+  };
+
+  const fatalFailEveryTime = (retriableError, attempt) => {
+    failures++;
+    assert.equal(attempt, failures);
+    throw new Error('uhoh, forever');
+  };
+
+  const cfg = { retries: 0, delayFactor: 1, randomizationFactor: 0, maxDelay: 100 };
+
+  setup(function() {
+    failures = 0;
+  });
+
+  test('tries once if retries is zero', async function() {
+    await assert.rejects(
+      retry(cfg, retriableFailEveryTime),
+      /uhoh/);
+    assert.equal(failures, 1);
+  });
+
+  test('tries six times if retries is five', async function() {
+    await assert.rejects(
+      retry({ ...cfg, retries: 5 }, retriableFailEveryTime),
+      /uhoh/);
+    assert.equal(failures, 6);
+  });
+
+  test('no retry for a fatal error', async function() {
+    await assert.rejects(
+      retry({ ...cfg, retries: 5 }, fatalFailEveryTime),
+      /uhoh/);
+    assert.equal(failures, 1);
+  });
+
+  // delayFactor, randomizationFactor, and maxDelay are tested in the previous suite
 });

--- a/clients/client/test/upload_download_test.js
+++ b/clients/client/test/upload_download_test.js
@@ -1,0 +1,218 @@
+const taskcluster = require('../');
+const nock = require('nock');
+const crypto = require('crypto');
+const assert = require('assert').strict;
+const testing = require('taskcluster-lib-testing');
+const { WritableStreamBuffer, ReadableStreamBuffer } = require('stream-buffers');
+const helper = require('./helper');
+
+suite(testing.suiteName(), function() {
+  helper.withRestoredEnvVars();
+
+  /**
+   * These tests require credentials with the scopes shown in authorizedScopes, below.
+   */
+  let object;
+  suiteSetup(function() {
+    const haveConfig =
+      process.env.TASKCLUSTER_ROOT_URL &&
+      process.env.TASKCLUSTER_CLIENT_ID &&
+      process.env.TASKCLUSTER_ACCESS_TOKEN;
+    if (haveConfig) {
+      object = new taskcluster.Object({
+        ...taskcluster.fromEnvVars(),
+        retries: 0,
+        authorizedScopes: [
+          "object:upload:taskcluster:taskcluster/test/client/*",
+          "object:download:taskcluster/test/client/*",
+        ],
+      });
+    } else if (process.env.NO_TEST_SKIP) {
+      throw new Error("NO_TEST_SKIP is set but credentials are not available");
+    } else {
+      this.skip();
+    }
+  });
+
+  const tryUploadAndDownload = async data => {
+    const name = "taskcluster/test/client/" + taskcluster.slugid();
+    const expires = taskcluster.fromNow('1 hour');
+
+    await taskcluster.upload({
+      projectId: "taskcluster",
+      name,
+      contentType: 'application/random',
+      contentLength: data.length,
+      expires,
+      object,
+      streamFactory: async () => {
+        const stream = new ReadableStreamBuffer({ initialSize: data.length, frequency: 0 });
+        stream.put(data);
+        stream.stop();
+        return stream;
+      },
+    });
+
+    let stream;
+    let contentType = await taskcluster.download({
+      name,
+      object,
+      streamFactory: async () => {
+        stream = new WritableStreamBuffer();
+        return stream;
+      },
+    });
+
+    assert(stream.getContents().equals(data));
+    assert(contentType === "application/random");
+  };
+
+  test('upload and download a small object (dataInline)', async function() {
+    await tryUploadAndDownload(Buffer.from("hello, world", "utf-8"));
+  });
+
+  test('upload and download a large object (putUrl)', async function() {
+    const data = crypto.randomBytes(10240);
+    await tryUploadAndDownload(data);
+  });
+
+  test('download of a nonexistent file fails', async function() {
+    const name = "taskcluster/test/client/" + taskcluster.slugid();
+    await assert.rejects(
+      () => taskcluster.download({ name, object }),
+      err => err.statusCode === 404);
+  });
+
+  const nockSuccessfulObjectApi = () => {
+    nock(process.env.TASKCLUSTER_ROOT_URL)
+      .put('/api/object/v1/upload/some-object')
+      .reply(200, {
+        expires: taskcluster.fromNow('1 hour'),
+        projectId: 'taskcluster',
+        uploadId: 'not checked',
+        uploadMethod: {
+          putUrl: {
+            expires: taskcluster.fromNow('1 hour'),
+            headers: {
+              'X-Test-Header': 'test-value',
+            },
+            url: 'http://testing.example.com/upload',
+          },
+        },
+      });
+    nock(process.env.TASKCLUSTER_ROOT_URL)
+      .post('/api/object/v1/finish-upload/some-object')
+      .reply(200, {});
+    nock(process.env.TASKCLUSTER_ROOT_URL)
+      .put('/api/object/v1/start-download/some-object')
+      .reply(200, {
+        method: 'simple',
+        url: 'http://testing.example.com/download',
+      });
+  };
+
+  const callUpload = async (overrides = {}) => {
+    const data = Buffer.from('hello world');
+    await taskcluster.upload({
+      projectId: "taskcluster",
+      name: 'some-object',
+      contentType: 'application/binary',
+      contentLength: data.length,
+      expires: taskcluster.fromNow('1 hour'),
+      object,
+      streamFactory: async () => {
+        const stream = new ReadableStreamBuffer({ initialSize: data.length, frequency: 0 });
+        stream.put(data);
+        stream.stop();
+        return stream;
+      },
+      ...overrides,
+    });
+  };
+
+  test('simple download that encounters a 500 error retries', async function() {
+    try {
+      nockSuccessfulObjectApi();
+      nock('http://testing.example.com')
+        .get('/download')
+        .reply(500, 'uhoh!');
+      nock('http://testing.example.com')
+        .get('/download')
+        .reply(200, 'HeLlOwOrLd');
+
+      await taskcluster.download({
+        name: 'some-object',
+        object,
+        streamFactory: async () => new WritableStreamBuffer(),
+      });
+    } finally {
+      nock.cleanAll();
+    }
+  });
+
+  test('simple download that encounters a 400 error fails immediately', async function() {
+    try {
+      nockSuccessfulObjectApi();
+      nock('http://testing.example.com')
+        .get('/download')
+        .reply(403, 'not great');
+
+      await assert.rejects(() => taskcluster.download({
+        name: 'some-object',
+        object,
+        streamFactory: async () => new WritableStreamBuffer(),
+      }),
+      /403/);
+    } finally {
+      nock.cleanAll();
+    }
+  });
+
+  test('putUrl upload that encounters a 500 error retries', async function() {
+    try {
+      nockSuccessfulObjectApi();
+      nock('http://testing.example.com')
+        .put('/upload')
+        .reply(500, 'aws is being aws');
+      nock('http://testing.example.com')
+        .put('/upload')
+        .reply(200, 'sweet!');
+
+      await callUpload();
+    } finally {
+      nock.cleanAll();
+    }
+  });
+
+  test('putUrl upload that encounters a 400 error fails right away', async function() {
+    try {
+      nockSuccessfulObjectApi();
+      nock('http://testing.example.com')
+        .put('/upload')
+        .reply(400, 'ya messed up that request');
+
+      await assert.rejects(callUpload, /400/);
+    } finally {
+      nock.cleanAll();
+    }
+  });
+
+  test('putUrl upload that encounters many 500 errors fails', async function() {
+    try {
+      nockSuccessfulObjectApi();
+      nock('http://testing.example.com')
+        .put('/upload')
+        .reply(500, 'nope');
+      nock('http://testing.example.com')
+        .put('/upload')
+        .reply(500, 'still nope');
+      nock('http://testing.example.com')
+        .put('/upload')
+        .reply(501, 'more nope');
+
+      await assert.rejects(() => callUpload({ retries: 2, delayFactor: 1 }), /501/);
+    } finally {
+      nock.cleanAll();
+    }
+  });
+});

--- a/clients/client/yarn.lock
+++ b/clients/client/yarn.lock
@@ -717,6 +717,11 @@ slugid@^2.0.0:
     uuid "^3.2.1"
     uuid-parse "^1.0.0"
 
+stream-buffers@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/stream-buffers/-/stream-buffers-3.0.2.tgz#5249005a8d5c2d00b3a32e6e0a6ea209dc4f3521"
+  integrity sha512-DQi1h8VEBA/lURbSwFtEHnSTb9s2/pwLEaFuNhXwy1Dx3Sa0lOuYT2yNUr4/j2fs8oCAMANtrZ5OrPZtyVs3MQ==
+
 "string-width@^1.0.2 || 2":
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-2.1.1.tgz#ab93f27a8dc13d28cac815c462143a6d9012ae9e"

--- a/taskcluster/ci/client/kind.yml
+++ b/taskcluster/ci/client/kind.yml
@@ -25,6 +25,7 @@ jobs:
     run:
       install: >-
         {{ yarn --frozen-lockfile || exit 99; }} &&
+        eval $(python test/client-library-secrets.py) &&
         cd clients/client &&
         {{ yarn --frozen-lockfile || exit 99; }}
       command: >-


### PR DESCRIPTION
This works against a "real" deployment (mine) but won't work against the current deployment, so left as a draft.

This API is good for now, but I can imagine cases where we will need more sophisticated support, such as for parallel uploads and downloads.  The `streamFactory` means that we can only read or write sequentially.  We can address that when we support such a thing!

Github Bug/Issue: Fixes #4423
