### PR TITLE
Add got to special imports because `link:` doesn't install it

### DIFF
--- a/package.json
+++ b/package.json
@@ -200,7 +200,8 @@
       "c8",
       "cross-env",
       "ejs",
-      "@octokit/core"
+      "@octokit/core",
+      "got"
     ]
   },
   "renovate": {


### PR DESCRIPTION
<!-- Did you remember to add a changelog snippet? See
     https://github.com/taskcluster/taskcluster/blob/main/dev-docs/best-practices/changelog.md

     If this is related to a Bugzilla bug, please begin your title with [Bug XXXXX]
     and update this link.  Otherwise, just remove it from your PR comment.  -->

Bugzilla Bug: [XXXXX](https://bugzilla.mozilla.org/show_bug.cgi?id=XXXXX)

<!-- If this is related to a GitHub Bug/Issue, Please write Issue Number after # in the next line. Otherwise, just remove it from your PR comment. -->

Github Bug/Issue: Fixes #XXXX
