### PR TITLE
read client-library secrets into env vars for all client-library tasks

### DIFF
--- a/changelog/YD2eFNQKSDyzU8ngS3vmng.md
+++ b/changelog/YD2eFNQKSDyzU8ngS3vmng.md
@@ -1,0 +1,3 @@
+audience: general
+level: silent
+---

--- a/taskcluster/ci/client/kind.yml
+++ b/taskcluster/ci/client/kind.yml
@@ -13,6 +13,9 @@ job-defaults:
     using: bare
   worker:
     max-run-time: 600
+    taskcluster-proxy: true
+  scopes:
+    - secrets:get:project/taskcluster/testing/client-libraries
 
 jobs:
   nodejs:
@@ -32,14 +35,18 @@ jobs:
     worker:
       docker-image: {taskcluster: ci-image}
     run:
-      install: cd clients/client-go
+      install: >-
+        eval $(python test/client-library-secrets.py) &&
+        cd clients/client-go
       command: go test -v -race ./...
   shell:
     description: cli tests
     worker:
       docker-image: {taskcluster: ci-image}
     run:
-      install: cd clients/client-shell
+      install: >-
+        eval $(python test/client-library-secrets.py) &&
+        cd clients/client-shell
       command: go test -v -race ./...
   web:
     description: web js tests
@@ -60,6 +67,7 @@ jobs:
       docker-image: python:2.7
     run:
       install: >-
+          eval $(python test/client-library-secrets.py) &&
           cd clients/client-py &&
           virtualenv /sandbox &&
           /sandbox/bin/pip install tox
@@ -71,6 +79,7 @@ jobs:
       docker-image: python:3.6
     run:
       install: >-
+          eval $(python test/client-library-secrets.py) &&
           cd clients/client-py &&
           python3 -mvenv /sandbox &&
           /sandbox/bin/pip install tox
@@ -82,6 +91,7 @@ jobs:
       docker-image: python:3.7
     run:
       install: >-
+          eval $(python test/client-library-secrets.py) &&
           cd clients/client-py &&
           python3 -mvenv /sandbox &&
           /sandbox/bin/pip install tox
@@ -93,6 +103,7 @@ jobs:
       docker-image: python:3.8
     run:
       install: >-
+          eval $(python test/client-library-secrets.py) &&
           cd clients/client-py &&
           python3 -mvenv /sandbox &&
           /sandbox/bin/pip install tox
@@ -104,6 +115,7 @@ jobs:
       docker-image: python:3.9
     run:
       install: >-
+          eval $(python test/client-library-secrets.py) &&
           cd clients/client-py &&
           python3 -mvenv /sandbox &&
           /sandbox/bin/pip install tox
@@ -114,7 +126,9 @@ jobs:
     worker:
       docker-image: rust:1.49.0
     run:
-      install: cd clients/client-rust
+      install: >-
+        eval $(python test/client-library-secrets.py) &&
+        cd clients/client-rust
       command: >-
         cargo test &&
         cargo build --release &&

--- a/test/client-library-secrets.py
+++ b/test/client-library-secrets.py
@@ -1,0 +1,31 @@
+#! /usr/bin/python
+
+# Python is the common scripting language between the docker images used to
+# test the various Taskcluster client libraries.  This fetches the
+# `testing/client-libraries` secret and writes out shell-compatible export
+# statements for each value it contains.
+
+try:
+    import urllib.request
+    PY27 = False
+except ImportError:
+    import urllib
+    PY27 = True
+import os
+import json
+
+proxy_url = os.environ['TASKCLUSTER_PROXY_URL'].rstrip('/')
+
+secret_url = proxy_url + '/api/secrets/v1/secret/project/taskcluster/testing/client-libraries'
+if PY27:
+    response = urllib.urlopen(secret_url)
+    if response.getcode() != 200:
+        raise RuntimeError('non-200 response from ' + secret_url)
+    secret = json.load(response)
+else:
+    with urllib.request.urlopen(secret_url) as response:
+        if response.status != 200:
+            raise RuntimeError('non-200 response from ' + secret_url)
+        secret = json.load(response)
+for k, v in secret['secret'].items():
+    print('export %s="%s"' % (k, v))

--- a/test/client-library-secrets.py
+++ b/test/client-library-secrets.py
@@ -4,6 +4,9 @@
 # test the various Taskcluster client libraries.  This fetches the
 # `testing/client-libraries` secret and writes out shell-compatible export
 # statements for each value it contains.
+#
+# This secret contains a client ID and access token for a TC client in the
+# current deployment, used for integration tests in the client libraries.
 
 try:
     import urllib.request
@@ -28,4 +31,7 @@ else:
             raise RuntimeError('non-200 response from ' + secret_url)
         secret = json.load(response)
 for k, v in secret['secret'].items():
+    # NOTE: this does not escape the values!  For typical values (client-id, access token)
+    # this is not necessary; but if this grows to handle other values, better escaping may
+    # be required.
     print('export %s="%s"' % (k, v))


### PR DESCRIPTION
This adds credentials from a secret for all client-library tasks.  This will be necessary for the upload/download functionality.