### PR TITLE
Handle external dependencies in .taskcluster.yml

### DIFF
--- a/changelog/issue-4502.md
+++ b/changelog/issue-4502.md
@@ -1,0 +1,5 @@
+audience: users
+level: patch
+reference: issue 4502
+---
+The GitHub service now correctly handles tasks that depend on other tasks not defined in `.taskcluster.yml`.

--- a/services/github/src/tc-yaml.js
+++ b/services/github/src/tc-yaml.js
@@ -292,7 +292,7 @@ class VersionOne extends TcYaml {
         };
       });
 
-      config.tasks = tsort.sort().reverse().map(id => taskMap[id]);
+      config.tasks = tsort.sort().reverse().filter(id => taskMap[id]).map(id => taskMap[id]);
 
     }
     return this.createScopes(cfg, config, payload);

--- a/services/github/test/data/configs/taskcluster.external-dep.v1.yml
+++ b/services/github/test/data/configs/taskcluster.external-dep.v1.yml
@@ -1,0 +1,10 @@
+version: 1
+tasks:
+  - taskId: {$eval: as_slugid('banana')}
+    provisionerId: aprovisioner
+    workerType: worker
+    created: {$eval: 'now'}
+    deadline: {$fromNow: '1 hour'}
+    dependencies: ['NmOU83KwRJGjk-btMbOOPA'] # taskId not in this set
+    payload: {}
+    metadata: {}

--- a/services/github/test/intree_test.js
+++ b/services/github/test/intree_test.js
@@ -329,6 +329,19 @@ suite(testing.suiteName(), function() {
     });
 
   buildConfigTest(
+    'Push Event with a task dependency not in the set of generated tasks (#4502)',
+    configPath + 'taskcluster.external-dep.v1.yml',
+    {
+      payload: buildMessage({
+        details: { 'event.type': 'push' },
+        body: require('./data/webhooks/webhook.push.json').body,
+        tasks_for: 'github-push',
+        branch: 'master',
+      }),
+    },
+    { 'tasks[0].task.workerType': 'worker' });
+
+  buildConfigTest(
     'Push Event, Single Task Config, v1',
     configPath + 'taskcluster.single.v1.yml',
     {


### PR DESCRIPTION
Handle the case where .taskcluster.yml specifies a dependency on a task
not defined in that file.


Github Bug/Issue: Fixes #4502
