### PR TITLE
Bug 1564512 - service/github: Do not ignore if no .taskcluster.yml in default branch

### DIFF
--- a/changelog/issue-4561.md
+++ b/changelog/issue-4561.md
@@ -1,0 +1,5 @@
+audience: deployers
+level: patch
+reference: issue 4561
+---
+The GitHub service now allows collaborators to test out a `.taskcluster.yml` in a PR, when there is no such file in the default branch initialized yet.

--- a/services/github/src/handlers.js
+++ b/services/github/src/handlers.js
@@ -766,7 +766,9 @@ async function jobHandler(message) {
 
     if (!defaultBranchYml) {
       debug(`${organization}/${repository} has no '.taskcluster.yml' at ${defaultBranch}.`);
-      return;
+      
+      // If the repository does not contain a '.taskcluster.yml' file, collaborators should be able to test before initializing.
+      defaultBranchYml = {version: 1, policy: {pullRequests: 'collaborators_quiet'}};
     }
 
     if (this.getRepoPolicy(defaultBranchYml).startsWith('collaborators')) {

--- a/services/github/src/handlers.js
+++ b/services/github/src/handlers.js
@@ -766,9 +766,10 @@ async function jobHandler(message) {
 
     if (!defaultBranchYml) {
       debug(`${organization}/${repository} has no '.taskcluster.yml' at ${defaultBranch}.`);
-      
-      // If the repository does not contain a '.taskcluster.yml' file, collaborators should be able to test before initializing.
-      defaultBranchYml = {version: 1, policy: {pullRequests: 'collaborators_quiet'}};
+
+      // If the repository does not contain a '.taskcluster.yml' file, collaborators should be able to test before
+      // initializing.
+      defaultBranchYml = { version: 1, policy: { pullRequests: 'collaborators_quiet' } };
     }
 
     if (this.getRepoPolicy(defaultBranchYml).startsWith('collaborators')) {

--- a/services/github/test/handler_test.js
+++ b/services/github/test/handler_test.js
@@ -617,7 +617,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       });
       await simulateJobMessage({ user: 'imbstack', eventType: 'release' });
 
-      assert(github.inst(5828).repos.createCommitComment.callCount === 1);
+      assert(github.inst(5828).repos.createCommitComment.callCount === 0);
     });
 
     test('no .taskcluster.yml, using collaborators policy', async function() {

--- a/services/github/test/handler_test.js
+++ b/services/github/test/handler_test.js
@@ -640,7 +640,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       });
       await simulateJobMessage({ user: 'goodBuddy', eventType: 'pull_request.opened' });
 
-      assert(github.inst(5828).repos.createCommitComment.callCount === 1);
+      assert(handlers.createTasks.calledWith({ scopes: sinon.match.array, tasks: sinon.match.array }));
     });
   });
 

--- a/services/github/test/handler_test.js
+++ b/services/github/test/handler_test.js
@@ -619,6 +619,24 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
 
       assert(github.inst(5828).repos.createCommitComment.callCount === 0);
     });
+
+    test('no .taskcluster.yml, using collaborators policy', async function() {
+      github.inst(5828).setTaskclusterYml({
+        owner: 'TaskclusterRobot',
+	repo: 'hooks-testing',
+	ref: '03e9577bc1ec60f2ff0929d5f1554de36b8f48cf',
+	content: require('./data/yml/valid-yaml.json'),
+      });
+      github.inst(5828).setTaskclusterYml({
+        owner: 'TaskclusterRobot',
+	repo: 'hooks-testing',
+	ref: 'development', // default branch
+	content: null,
+      });
+      await simulateJobMessage({user: 'imbstack', eventType: 'pull_request.opened'});
+
+      assert(github.inst(5828).repos.createCommitComment.callCount === 0);
+    });
   });
 
   suite('Statuses API: result status handler', function() {

--- a/services/github/test/handler_test.js
+++ b/services/github/test/handler_test.js
@@ -617,25 +617,30 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       });
       await simulateJobMessage({ user: 'imbstack', eventType: 'release' });
 
-      assert(github.inst(5828).repos.createCommitComment.callCount === 0);
+      assert(github.inst(5828).repos.createCommitComment.callCount === 1);
     });
 
     test('no .taskcluster.yml, using collaborators policy', async function() {
-      github.inst(5828).setTaskclusterYml({
+      github.inst(5828).setRepoCollaborator({
         owner: 'TaskclusterRobot',
-	repo: 'hooks-testing',
-	ref: '03e9577bc1ec60f2ff0929d5f1554de36b8f48cf',
-	content: require('./data/yml/valid-yaml.json'),
+        repo: 'hooks-testing',
+        username: 'goodBuddy',
       });
       github.inst(5828).setTaskclusterYml({
         owner: 'TaskclusterRobot',
-	repo: 'hooks-testing',
-	ref: 'development', // default branch
-	content: null,
+        repo: 'hooks-testing',
+        ref: '03e9577bc1ec60f2ff0929d5f1554de36b8f48cf',
+        content: require('./data/yml/valid-yaml.json'),
       });
-      await simulateJobMessage({user: 'imbstack', eventType: 'pull_request.opened'});
+      github.inst(5828).setTaskclusterYml({
+        owner: 'TaskclusterRobot',
+        repo: 'hooks-testing',
+        ref: 'development', // default branch
+        content: null,
+      });
+      await simulateJobMessage({ user: 'goodBuddy', eventType: 'pull_request.opened' });
 
-      assert(github.inst(5828).repos.createCommitComment.callCount === 0);
+      assert(github.inst(5828).repos.createCommitComment.callCount === 1);
     });
   });
 


### PR DESCRIPTION
If the the repo has no `taskcluster.yml`, create a pseudo object for `defaultBranchYml` containing the necessary entries needed by the following collaborator checks. The Policy is set to `collaborators_quiet` since the issue comment created by `collaborators` does not reflect this case.

Bugzilla Bug: [1564512](https://bugzilla.mozilla.org/show_bug.cgi?id=1564512)

Github Bug/Issue: Fixes #3927 