### PR TITLE
balance load.{save,restore} in obj-service tests

### DIFF
--- a/changelog/eVBfVTX-Rimj_U4C4Ik9SA.md
+++ b/changelog/eVBfVTX-Rimj_U4C4Ik9SA.md
@@ -1,0 +1,3 @@
+audience: general
+level: silent
+---

--- a/services/object/test/helper/index.js
+++ b/services/object/test/helper/index.js
@@ -60,11 +60,11 @@ exports.withBackends = (mock, skipping) => {
   ];
 
   suiteSetup('withBackends', async function() {
-    exports.load.save();
-
     if (skipping()) {
       return;
     }
+
+    exports.load.save();
 
     // add the 'test' backend type only for testing
     BACKEND_TYPES['test'] = TestBackend;
@@ -95,6 +95,10 @@ exports.withBackends = (mock, skipping) => {
   });
 
   suiteTeardown('withBackends', async function() {
+    if (skipping()) {
+      return;
+    }
+
     exports.load.restore();
     delete BACKEND_TYPES['test'];
     delete exports.setBackendConfig;


### PR DESCRIPTION
This fixes a bug I introduced yesterday that caused failures in the condition where there are no AWS/GCP credentials available.
