### PR TITLE
Separate generated code comments from generated package docs with bla…

### DIFF
--- a/changelog/FCNfBJq1Rr20YdlQQNXHcQ.md
+++ b/changelog/FCNfBJq1Rr20YdlQQNXHcQ.md
@@ -1,0 +1,3 @@
+audience: general
+level: silent
+---

--- a/clients/client-go/codegenerator/model/model.go
+++ b/clients/client-go/codegenerator/model/model.go
@@ -241,7 +241,7 @@ func (apiDefs APIDefinitions) GenerateCode(goOutputDir string) {
 // making sure that ` + "`${GOPATH}/bin` is in your `PATH`" + `:
 //
 // go install && go generate
-//
+
 // This package was generated from the schema defined at
 // ` + apiDefs[i].URL + `
 `

--- a/clients/client-go/tcauth/tcauth.go
+++ b/clients/client-go/tcauth/tcauth.go
@@ -4,7 +4,7 @@
 // making sure that `${GOPATH}/bin` is in your `PATH`:
 //
 // go install && go generate
-//
+
 // This package was generated from the schema defined at
 // /references/auth/v1/api.json
 // Authentication related API end-points for Taskcluster and related

--- a/clients/client-go/tcauthevents/tcauthevents.go
+++ b/clients/client-go/tcauthevents/tcauthevents.go
@@ -4,7 +4,7 @@
 // making sure that `${GOPATH}/bin` is in your `PATH`:
 //
 // go install && go generate
-//
+
 // This package was generated from the schema defined at
 // /references/auth/v1/exchanges.json
 // The auth service is responsible for storing credentials, managing

--- a/clients/client-go/tcgithub/tcgithub.go
+++ b/clients/client-go/tcgithub/tcgithub.go
@@ -4,7 +4,7 @@
 // making sure that `${GOPATH}/bin` is in your `PATH`:
 //
 // go install && go generate
-//
+
 // This package was generated from the schema defined at
 // /references/github/v1/api.json
 // The github service is responsible for creating tasks in response

--- a/clients/client-go/tcgithubevents/tcgithubevents.go
+++ b/clients/client-go/tcgithubevents/tcgithubevents.go
@@ -4,7 +4,7 @@
 // making sure that `${GOPATH}/bin` is in your `PATH`:
 //
 // go install && go generate
-//
+
 // This package was generated from the schema defined at
 // /references/github/v1/exchanges.json
 // The github service publishes a pulse

--- a/clients/client-go/tchooks/tchooks.go
+++ b/clients/client-go/tchooks/tchooks.go
@@ -4,7 +4,7 @@
 // making sure that `${GOPATH}/bin` is in your `PATH`:
 //
 // go install && go generate
-//
+
 // This package was generated from the schema defined at
 // /references/hooks/v1/api.json
 // The hooks service provides a mechanism for creating tasks in response to events.

--- a/clients/client-go/tchooksevents/tchooksevents.go
+++ b/clients/client-go/tchooksevents/tchooksevents.go
@@ -4,7 +4,7 @@
 // making sure that `${GOPATH}/bin` is in your `PATH`:
 //
 // go install && go generate
-//
+
 // This package was generated from the schema defined at
 // /references/hooks/v1/exchanges.json
 // The hooks service is responsible for creating tasks at specific times orin .  response to webhooks and API calls.Using this exchange allows us tomake hooks which repsond to particular pulse messagesThese exchanges provide notifications when a hook is created, updatedor deleted. This is so that the listener running in a different hooks process at the other end can direct another listener specified by`hookGroupId` and `hookId` to synchronize its bindings. But you are ofcourse welcome to use these for other purposes, monitoring changes for example.

--- a/clients/client-go/tcindex/tcindex.go
+++ b/clients/client-go/tcindex/tcindex.go
@@ -4,7 +4,7 @@
 // making sure that `${GOPATH}/bin` is in your `PATH`:
 //
 // go install && go generate
-//
+
 // This package was generated from the schema defined at
 // /references/index/v1/api.json
 // The index service is responsible for indexing tasks. The service ensures that

--- a/clients/client-go/tcnotify/tcnotify.go
+++ b/clients/client-go/tcnotify/tcnotify.go
@@ -4,7 +4,7 @@
 // making sure that `${GOPATH}/bin` is in your `PATH`:
 //
 // go install && go generate
-//
+
 // This package was generated from the schema defined at
 // /references/notify/v1/api.json
 // The notification service listens for tasks with associated notifications

--- a/clients/client-go/tcnotifyevents/tcnotifyevents.go
+++ b/clients/client-go/tcnotifyevents/tcnotifyevents.go
@@ -4,7 +4,7 @@
 // making sure that `${GOPATH}/bin` is in your `PATH`:
 //
 // go install && go generate
-//
+
 // This package was generated from the schema defined at
 // /references/notify/v1/exchanges.json
 // This pretty much only contains the simple free-form

--- a/clients/client-go/tcobject/tcobject.go
+++ b/clients/client-go/tcobject/tcobject.go
@@ -4,7 +4,7 @@
 // making sure that `${GOPATH}/bin` is in your `PATH`:
 //
 // go install && go generate
-//
+
 // This package was generated from the schema defined at
 // /references/object/v1/api.json
 // The object service provides HTTP-accessible storage for large blobs of data.

--- a/clients/client-go/tcpurgecache/tcpurgecache.go
+++ b/clients/client-go/tcpurgecache/tcpurgecache.go
@@ -4,7 +4,7 @@
 // making sure that `${GOPATH}/bin` is in your `PATH`:
 //
 // go install && go generate
-//
+
 // This package was generated from the schema defined at
 // /references/purge-cache/v1/api.json
 // The purge-cache service is responsible for tracking cache-purge requests.

--- a/clients/client-go/tcqueue/tcqueue.go
+++ b/clients/client-go/tcqueue/tcqueue.go
@@ -4,7 +4,7 @@
 // making sure that `${GOPATH}/bin` is in your `PATH`:
 //
 // go install && go generate
-//
+
 // This package was generated from the schema defined at
 // /references/queue/v1/api.json
 // The queue service is responsible for accepting tasks and track their state

--- a/clients/client-go/tcqueueevents/tcqueueevents.go
+++ b/clients/client-go/tcqueueevents/tcqueueevents.go
@@ -4,7 +4,7 @@
 // making sure that `${GOPATH}/bin` is in your `PATH`:
 //
 // go install && go generate
-//
+
 // This package was generated from the schema defined at
 // /references/queue/v1/exchanges.json
 // The queue service is responsible for accepting tasks and track their state

--- a/clients/client-go/tcsecrets/tcsecrets.go
+++ b/clients/client-go/tcsecrets/tcsecrets.go
@@ -4,7 +4,7 @@
 // making sure that `${GOPATH}/bin` is in your `PATH`:
 //
 // go install && go generate
-//
+
 // This package was generated from the schema defined at
 // /references/secrets/v1/api.json
 // The secrets service provides a simple key/value store for small bits of secret

--- a/clients/client-go/tcworkermanager/tcworkermanager.go
+++ b/clients/client-go/tcworkermanager/tcworkermanager.go
@@ -4,7 +4,7 @@
 // making sure that `${GOPATH}/bin` is in your `PATH`:
 //
 // go install && go generate
-//
+
 // This package was generated from the schema defined at
 // /references/worker-manager/v1/api.json
 // This service manages workers, including provisioning for dynamic worker pools.

--- a/clients/client-go/tcworkermanagerevents/tcworkermanagerevents.go
+++ b/clients/client-go/tcworkermanagerevents/tcworkermanagerevents.go
@@ -4,7 +4,7 @@
 // making sure that `${GOPATH}/bin` is in your `PATH`:
 //
 // go install && go generate
-//
+
 // This package was generated from the schema defined at
 // /references/worker-manager/v1/exchanges.json
 // These exchanges provide notifications when a worker pool is created or updated.This is so that the provisioner running in a differentprocess at the other end can synchronize to the changes. But you are ofcourse welcome to use these for other purposes, monitoring changes for example.


### PR DESCRIPTION
The go client godocs contained spurious code comments which were not intended to be part of the package docs.

This PR introduces a blank line between the generated code comments and generated package comments, so that the code comments are not included in the package docs.