### PR TITLE
Move http://godoc.org links to https://pkg.go.dev and include version in path

### DIFF
--- a/changelog/PMBzq5oKTVOV6usMDCeJ_g.md
+++ b/changelog/PMBzq5oKTVOV6usMDCeJ_g.md
@@ -1,0 +1,3 @@
+audience: general
+level: silent
+---

--- a/clients/client-go/README.md
+++ b/clients/client-go/README.md
@@ -18,41 +18,41 @@ This library provides the following packages to interface with Taskcluster:
 ### HTTP APIs
 
 <!--HTTP-API-start-->
-* http://godoc.org/github.com/taskcluster/taskcluster/clients/client-go/tcauthevents
+* https://pkg.go.dev/github.com/taskcluster/taskcluster/v42/clients/client-go/tcauthevents
 
-* http://godoc.org/github.com/taskcluster/taskcluster/clients/client-go/tcgithubevents
+* https://pkg.go.dev/github.com/taskcluster/taskcluster/v42/clients/client-go/tcgithubevents
 
-* http://godoc.org/github.com/taskcluster/taskcluster/clients/client-go/tchooksevents
+* https://pkg.go.dev/github.com/taskcluster/taskcluster/v42/clients/client-go/tchooksevents
 
-* http://godoc.org/github.com/taskcluster/taskcluster/clients/client-go/tcnotifyevents
+* https://pkg.go.dev/github.com/taskcluster/taskcluster/v42/clients/client-go/tcnotifyevents
 
-* http://godoc.org/github.com/taskcluster/taskcluster/clients/client-go/tcqueueevents
+* https://pkg.go.dev/github.com/taskcluster/taskcluster/v42/clients/client-go/tcqueueevents
 
-* http://godoc.org/github.com/taskcluster/taskcluster/clients/client-go/tcworkermanagerevents
+* https://pkg.go.dev/github.com/taskcluster/taskcluster/v42/clients/client-go/tcworkermanagerevents
  <!--HTTP-API-end-->
 
 ### AMQP APIs
 
 <!--AMQP-API-start-->
-* http://godoc.org/github.com/taskcluster/taskcluster/clients/client-go/tcauth
+* https://pkg.go.dev/github.com/taskcluster/taskcluster/v42/clients/client-go/tcauth
 
-* http://godoc.org/github.com/taskcluster/taskcluster/clients/client-go/tcgithub
+* https://pkg.go.dev/github.com/taskcluster/taskcluster/v42/clients/client-go/tcgithub
 
-* http://godoc.org/github.com/taskcluster/taskcluster/clients/client-go/tchooks
+* https://pkg.go.dev/github.com/taskcluster/taskcluster/v42/clients/client-go/tchooks
 
-* http://godoc.org/github.com/taskcluster/taskcluster/clients/client-go/tcindex
+* https://pkg.go.dev/github.com/taskcluster/taskcluster/v42/clients/client-go/tcindex
 
-* http://godoc.org/github.com/taskcluster/taskcluster/clients/client-go/tcnotify
+* https://pkg.go.dev/github.com/taskcluster/taskcluster/v42/clients/client-go/tcnotify
 
-* http://godoc.org/github.com/taskcluster/taskcluster/clients/client-go/tcobject
+* https://pkg.go.dev/github.com/taskcluster/taskcluster/v42/clients/client-go/tcobject
 
-* http://godoc.org/github.com/taskcluster/taskcluster/clients/client-go/tcpurgecache
+* https://pkg.go.dev/github.com/taskcluster/taskcluster/v42/clients/client-go/tcpurgecache
 
-* http://godoc.org/github.com/taskcluster/taskcluster/clients/client-go/tcqueue
+* https://pkg.go.dev/github.com/taskcluster/taskcluster/v42/clients/client-go/tcqueue
 
-* http://godoc.org/github.com/taskcluster/taskcluster/clients/client-go/tcsecrets
+* https://pkg.go.dev/github.com/taskcluster/taskcluster/v42/clients/client-go/tcsecrets
 
-* http://godoc.org/github.com/taskcluster/taskcluster/clients/client-go/tcworkermanager
+* https://pkg.go.dev/github.com/taskcluster/taskcluster/v42/clients/client-go/tcworkermanager
  <!--AMQP-API-end-->
 
 ### Setup

--- a/clients/client-go/codegenerator/model/model.go
+++ b/clients/client-go/codegenerator/model/model.go
@@ -256,10 +256,10 @@ func (apiDefs APIDefinitions) GenerateCode(goOutputDir string) {
 
 	for i := range apiDefs {
 		if strings.Contains(apiDefs[i].PackageName, "events") {
-			amqpApiLinks += "\n" + "* http://godoc.org/github.com/taskcluster/taskcluster/clients/client-go/" + apiDefs[i].PackageName + "\n"
+			amqpApiLinks += "\n" + "* https://pkg.go.dev/github.com/taskcluster/taskcluster/v42/clients/client-go/" + apiDefs[i].PackageName + "\n"
 
 		} else {
-			httpApiLinks += "\n" + "* http://godoc.org/github.com/taskcluster/taskcluster/clients/client-go/" + apiDefs[i].PackageName + "\n"
+			httpApiLinks += "\n" + "* https://pkg.go.dev/github.com/taskcluster/taskcluster/v42/clients/client-go/" + apiDefs[i].PackageName + "\n"
 
 		}
 	}


### PR DESCRIPTION
Originated from https://github.com/taskcluster/taskcluster/pull/4493#discussion_r600833582