### PR TITLE
Require content-encoding: identity for putUrl uploads.

### DIFF
--- a/changelog/issue-4610.md
+++ b/changelog/issue-4610.md
@@ -1,0 +1,4 @@
+audience: general
+level: silent
+reference: issue 4610
+---

--- a/services/object/src/backends/aws.js
+++ b/services/object/src/backends/aws.js
@@ -81,6 +81,7 @@ class AwsBackend extends Backend {
         headers: {
           'Content-Type': contentType,
           'Content-Length': contentLength.toString(),
+          'Content-Encoding': 'identity',
         },
       },
     };

--- a/ui/docs/reference/platform/object/upload-methods.mdx
+++ b/ui/docs/reference/platform/object/upload-methods.mdx
@@ -42,7 +42,7 @@ The caller is expected to make a `PUT` request to the given URL, with the given 
 This request must begin before the expiration time given in the response.
 If retries extend beyond this time, then the client should make a new `createUpload` call to get a fresh URL.
 
-For this upload method, the content encoding _must_ be `identity` (the default value for the `Content-Encoding` header).
+For this method, the content encoding _must_ be `identity`, and this is reflected in the `headers` property in the response body.
 
 ### `s3Multipart` Upload Method
 


### PR DESCRIPTION
There's room for some nuance here -- if this header *isn't* set, then a backend might support other content-encodings.  But, which?  For example, GCS only supports `gzip`.  Instead of trying to address that here, let's leave the `putUrl` method simple, and always require `identity`.  The more advanced, cloud-specific upload methods can be more specific.

Github Bug/Issue: Fixes #4610