### PR TITLE
Disable testing the simple engine on macos

### DIFF
--- a/changelog/CxWEWKD_Rx6GXxX-vqDtWQ.md
+++ b/changelog/CxWEWKD_Rx6GXxX-vqDtWQ.md
@@ -1,0 +1,3 @@
+audience: general
+level: silent
+---

--- a/workers/generic-worker/gw-decision-task/tasks.yml
+++ b/workers/generic-worker/gw-decision-task/tasks.yml
@@ -47,9 +47,10 @@ Tasks:
     - WorkerPool: 'proj-taskcluster/gw-ci-macos'
       Env:
         ENGINE: 'multiuser'
-    - WorkerPool: 'proj-taskcluster/gw-ci-macos'
-      Env:
-        ENGINE: 'simple'
+# disabled due to lack of mac capacity
+#    - WorkerPool: 'proj-taskcluster/gw-ci-macos'
+#      Env:
+#        ENGINE: 'simple'
     - WorkerPool: 'proj-taskcluster/gw-ci-ubuntu-18-04'
       Env:
         ENGINE: 'multiuser'


### PR DESCRIPTION
The single mac worker we have is by far the slowest worker, and its
slowness causes delays to merging PRs, especially Renovate PRs.  This
will cut its load by 50% and hopefully allow it to keep up.