### PR TITLE
Log rather noisily when pulse blocks startup

### DIFF
--- a/changelog/issue-4646.md
+++ b/changelog/issue-4646.md
@@ -1,0 +1,4 @@
+audience: general
+level: silent
+reference: issue 4646
+---


### PR DESCRIPTION
We came across this in #4631, and I think that's not the first time I've been left puzzling about this.  It's really the only reason that a process would *hang* on startup and not crash.  I think this bit of logging should at least make that hang visible.

Github Bug/Issue: Fixes #4646