### PR TITLE
Do not include Rust's build directory in Docker context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -6,3 +6,4 @@
 dev-config.yml
 artifacts
 **/.nyc_output
+clients/client-rust/target

--- a/changelog/OfHN0QMdR1OlhOS81xevrA.md
+++ b/changelog/OfHN0QMdR1OlhOS81xevrA.md
@@ -1,0 +1,3 @@
+audience: general
+level: silent
+---


### PR DESCRIPTION
This saves a good 7GB on my system!