### PR TITLE
Require a docker repo to build

### DIFF
--- a/changelog/issue-4649.md
+++ b/changelog/issue-4649.md
@@ -1,0 +1,4 @@
+audience: developers
+level: silent
+reference: issue 4649
+---

--- a/infrastructure/tooling/src/build/index.js
+++ b/infrastructure/tooling/src/build/index.js
@@ -153,6 +153,8 @@ class Publish extends Base {
       cache: false,
       // to be safe, set push=false for staging runs
       push: cmdOptions.staging ? false : true,
+      // always push to the "official" Taskcluster repo on publish
+      dockerRepo: 'taskcluster/taskcluster',
     });
   }
 

--- a/infrastructure/tooling/src/main.js
+++ b/infrastructure/tooling/src/main.js
@@ -32,7 +32,8 @@ const actFn = fn => (...args) => {
 program.version(version);
 program.name('yarn'); // these commands are invoked via yarn
 program.command('build')
-  .option('-p, --push', 'Push images to docker hub')
+  .option('-p, --push', 'Push images to a Docker registry')
+  .option('--docker-repo <monoimage-docker-repo>', 'docker repository to which monoimage should be pushed')
   .option('--base-dir <base-dir>', 'Base directory for build (fast and big!; default /tmp/taskcluster-builder-build)')
   .option('--no-cache', 'Do not use any cached state, instead building everything from scratch')
   .option('--dry-run', 'Do not run any tasks, but generate the list of tasks')

--- a/infrastructure/tooling/src/utils/docker.js
+++ b/infrastructure/tooling/src/utils/docker.js
@@ -235,7 +235,7 @@ exports.dockerRegistryCheck = async ({ tag }) => {
       return true;
     }
   } catch (err) {
-    if (err.statusCode !== 404) {
+    if (err.response.statusCode !== 404) {
       throw err;
     }
   }

--- a/ui/docs/manual/deploying/smoketests.mdx
+++ b/ui/docs/manual/deploying/smoketests.mdx
@@ -31,12 +31,12 @@ $ node infrastructure/tooling/src/main.js smoketest
 ...
 ```
 
-Alternately, the `taskcluster/taskcluster-devel` docker image can be used:
+Alternately, the devel docker image can be used:
 
 ```
 $ docker run -ti --rm \
   -e TASKCLUSTER_ROOT_URL -e TASKCLUSTER_ACCESS_TOKEN -e TASKCLUSTER_CLIENT_ID \
-  taskcluster/taskcluster-devel:v1.2.3 script/smoketest
+  taskcluster/taskcluster:v1.2.3-devel script/smoketest
 yarn run v1.19.1
 $ node infrastructure/tooling/src/main.js smoketest
 ✔ Ping health endpoint for web-server


### PR DESCRIPTION
This will leave only "official" releases in the
`taskcluster/taskcluster` repo.

This also moves devel images (typically only built on release) to a
different tag in the same repo.


Github Bug/Issue: Fixes #4649 