### PR TITLE
Hard-code the CloudFront host to use for artifacts

### DIFF
--- a/taskcluster/ci/docker-worker/kind.yml
+++ b/taskcluster/ci/docker-worker/kind.yml
@@ -16,7 +16,8 @@ job-defaults:
   run:
     using: bare
     clone: false
-    install: '"( cd ../..; yarn install --frozen-lockfile ) && yarn install --frozen-lockfile && ./build.sh"'
+    # XXX temporarily hard-code the IP of the community artifacts CDN - https://github.com/taskcluster/taskcluster/issues/4673
+    install: '"( cd ../..; yarn install --frozen-lockfile ) && yarn install --frozen-lockfile && echo 13.226.201.35 community.taskcluster-artifacts.net >> /etc/hosts && ./build.sh"'
   worker:
     taskcluster-proxy: true
     privileged: true


### PR DESCRIPTION
..in docker-worker tests only

This is pretty silly, but should get us back to passing tests while AWS sorts itself out.

Github Bug/Issue: Refs #4673