### PR TITLE
Allow generic-worker livelog ports to be configured

### DIFF
--- a/changelog/issue-4691.md
+++ b/changelog/issue-4691.md
@@ -1,0 +1,5 @@
+audience: worker-deployers
+level: patch
+reference: issue 4691
+---
+Added a generic-worker config parameter (`livelogPortBase`) to allow configuring which ports are used for live logging.

--- a/workers/generic-worker/README.md
+++ b/workers/generic-worker/README.md
@@ -136,6 +136,9 @@ and reports back results to the queue.
           livelogExecutable                 Filepath of LiveLog executable to use; see
                                             https://github.com/taskcluster/livelog
                                             [default: "livelog"]
+          livelogPortBase                   Set the base port number for livelog. Livelog requires two
+                                            ports: livelogPortBase & livelogPortBase + 1 are used.
+                                            [default: 60098]
           numberOfTasksToRun                If zero, run tasks indefinitely. Otherwise, after
                                             this many tasks, exit. [default: 0]
           privateIP                         The private IP of the worker, used by chain of trust.

--- a/workers/generic-worker/gwconfig/config.go
+++ b/workers/generic-worker/gwconfig/config.go
@@ -40,6 +40,7 @@ type (
 		InstanceID                     string                 `json:"instanceId"`
 		InstanceType                   string                 `json:"instanceType"`
 		LiveLogExecutable              string                 `json:"livelogExecutable"`
+		LiveLogPortBase                uint16                 `json:"livelogPortBase"`
 		NumberOfTasksToRun             uint                   `json:"numberOfTasksToRun"`
 		PrivateIP                      net.IP                 `json:"privateIP"`
 		ProvisionerID                  string                 `json:"provisionerId"`

--- a/workers/generic-worker/helper_test.go
+++ b/workers/generic-worker/helper_test.go
@@ -308,8 +308,6 @@ func CreateArtifactFromFile(t *testing.T, path string, name string) (taskID stri
 type Test struct {
 	t                  *testing.T
 	Config             *gwconfig.Config
-	OldInternalPUTPort uint16
-	OldInternalGETPort uint16
 	OldConfigureForGCP bool
 	srv                *http.Server
 	router             *mux.Router
@@ -339,6 +337,7 @@ func GWTest(t *testing.T) *Test {
 			InstanceID:                "test-instance-id",
 			InstanceType:              "p3.enormous",
 			LiveLogExecutable:         "livelog",
+			LiveLogPortBase:           30583,
 			NumberOfTasksToRun:        1,
 			PrivateIP:                 net.ParseIP("87.65.43.21"),
 			ProvisionerID:             "test-provisioner",
@@ -440,17 +439,9 @@ func GWTest(t *testing.T) *Test {
 
 	serviceFactory = mocktc.NewServiceFactory(t)
 
-	// we need to use a non-default port for the livelog internalGETPort, so
-	// that we don't conflict with a generic-worker in which the tests are
-	// running
-	internalPUTPort = 30584
-	internalGETPort = 30583
-
 	return &Test{
 		t:                  t,
 		Config:             testConfig,
-		OldInternalPUTPort: internalPUTPort,
-		OldInternalGETPort: internalGETPort,
 		srv:                srv,
 		router:             r,
 	}
@@ -470,8 +461,6 @@ func (gwtest *Test) Setup() error {
 }
 
 func (gwtest *Test) Teardown() {
-	internalPUTPort = gwtest.OldInternalPUTPort
-	internalGETPort = gwtest.OldInternalGETPort
 	gwtest.t.Logf("Removing test directory %v...", filepath.Join(testdataDir, gwtest.t.Name()))
 	err := os.RemoveAll(filepath.Join(testdataDir, gwtest.t.Name()))
 	if err != nil {

--- a/workers/generic-worker/helper_test.go
+++ b/workers/generic-worker/helper_test.go
@@ -337,6 +337,9 @@ func GWTest(t *testing.T) *Test {
 			InstanceID:                "test-instance-id",
 			InstanceType:              "p3.enormous",
 			LiveLogExecutable:         "livelog",
+			// The base port on which the livelog process listens locally. (Livelog uses this and the next port.)
+			// These ports are not exposed outside of the host. However, in CI they must differ from those of the
+			// generic-worker instance running the test suite.
 			LiveLogPortBase:           30583,
 			NumberOfTasksToRun:        1,
 			PrivateIP:                 net.ParseIP("87.65.43.21"),

--- a/workers/generic-worker/helper_test.go
+++ b/workers/generic-worker/helper_test.go
@@ -340,12 +340,12 @@ func GWTest(t *testing.T) *Test {
 			// The base port on which the livelog process listens locally. (Livelog uses this and the next port.)
 			// These ports are not exposed outside of the host. However, in CI they must differ from those of the
 			// generic-worker instance running the test suite.
-			LiveLogPortBase:           30583,
-			NumberOfTasksToRun:        1,
-			PrivateIP:                 net.ParseIP("87.65.43.21"),
-			ProvisionerID:             "test-provisioner",
-			PublicIP:                  net.ParseIP("12.34.56.78"),
-			Region:                    "test-worker-group",
+			LiveLogPortBase:    30583,
+			NumberOfTasksToRun: 1,
+			PrivateIP:          net.ParseIP("87.65.43.21"),
+			ProvisionerID:      "test-provisioner",
+			PublicIP:           net.ParseIP("12.34.56.78"),
+			Region:             "test-worker-group",
 			// should be enough for tests, and travis-ci.org CI environments don't
 			// have a lot of free disk
 			RequiredDiskSpaceMegabytes:     16,
@@ -443,10 +443,10 @@ func GWTest(t *testing.T) *Test {
 	serviceFactory = mocktc.NewServiceFactory(t)
 
 	return &Test{
-		t:                  t,
-		Config:             testConfig,
-		srv:                srv,
-		router:             r,
+		t:      t,
+		Config: testConfig,
+		srv:    srv,
+		router: r,
 	}
 }
 

--- a/workers/generic-worker/livelog.go
+++ b/workers/generic-worker/livelog.go
@@ -16,12 +16,6 @@ import (
 
 var (
 	livelogName = "public/logs/live.log"
-
-	// The ports on which the livelog process listens locally.  These ports are not exposed
-	// outside of the host.  However, in CI they must differ from those of the generic-worker
-	// instance running the test suite.
-	internalPUTPort uint16 = 60098
-	internalGETPort uint16 = 60099
 )
 
 type LiveLogFeature struct {
@@ -69,7 +63,7 @@ func (l *LiveLogTask) RequiredScopes() scopes.Required {
 }
 
 func (l *LiveLogTask) Start() *CommandExecutionError {
-	liveLog, err := livelog.New(config.LiveLogExecutable, internalPUTPort, internalGETPort)
+	liveLog, err := livelog.New(config.LiveLogExecutable, config.LiveLogPortBase, config.LiveLogPortBase + 1)
 	if err != nil {
 		log.Printf("WARNING: could not create livelog: %s", err)
 		// then run without livelog, is only a "best effort" service
@@ -164,7 +158,7 @@ func (l *LiveLogTask) reinstateBackingLog() {
 
 func (l *LiveLogTask) uploadLiveLogArtifact() error {
 	var err error
-	l.exposure, err = exposer.ExposeHTTP(internalGETPort)
+	l.exposure, err = exposer.ExposeHTTP(config.LiveLogPortBase + 1)
 	if err != nil {
 		return err
 	}

--- a/workers/generic-worker/livelog.go
+++ b/workers/generic-worker/livelog.go
@@ -63,7 +63,7 @@ func (l *LiveLogTask) RequiredScopes() scopes.Required {
 }
 
 func (l *LiveLogTask) Start() *CommandExecutionError {
-	liveLog, err := livelog.New(config.LiveLogExecutable, config.LiveLogPortBase, config.LiveLogPortBase + 1)
+	liveLog, err := livelog.New(config.LiveLogExecutable, config.LiveLogPortBase, config.LiveLogPortBase+1)
 	if err != nil {
 		log.Printf("WARNING: could not create livelog: %s", err)
 		// then run without livelog, is only a "best effort" service

--- a/workers/generic-worker/main.go
+++ b/workers/generic-worker/main.go
@@ -207,6 +207,10 @@ func loadConfig(configFile *gwconfig.File) error {
 			DownloadsDir:                   "downloads",
 			IdleTimeoutSecs:                0,
 			LiveLogExecutable:              "livelog",
+			// The ports on which the livelog process listens locally.  These ports are not exposed
+			// outside of the host.  However, in CI they must differ from those of the generic-worker
+			// instance running the test suite.
+			LiveLogPortBase:                60098,
 			NumberOfTasksToRun:             0,
 			ProvisionerID:                  "test-provisioner",
 			RequiredDiskSpaceMegabytes:     10240,

--- a/workers/generic-worker/main.go
+++ b/workers/generic-worker/main.go
@@ -207,9 +207,6 @@ func loadConfig(configFile *gwconfig.File) error {
 			DownloadsDir:                   "downloads",
 			IdleTimeoutSecs:                0,
 			LiveLogExecutable:              "livelog",
-			// The ports on which the livelog process listens locally.  These ports are not exposed
-			// outside of the host.  However, in CI they must differ from those of the generic-worker
-			// instance running the test suite.
 			LiveLogPortBase:                60098,
 			NumberOfTasksToRun:             0,
 			ProvisionerID:                  "test-provisioner",

--- a/workers/generic-worker/usage.go
+++ b/workers/generic-worker/usage.go
@@ -150,7 +150,7 @@ and reports back results to the queue.
                                             https://github.com/taskcluster/livelog
                                             [default: "livelog"]
           livelogPortBase                   Set the base port number for livelog. Livelog requires two
-                                            ports.
+                                            ports: livelogPortBase & livelogPortBase + 1 are used.
                                             [default: 60098]
           numberOfTasksToRun                If zero, run tasks indefinitely. Otherwise, after
                                             this many tasks, exit. [default: 0]

--- a/workers/generic-worker/usage.go
+++ b/workers/generic-worker/usage.go
@@ -149,6 +149,9 @@ and reports back results to the queue.
           livelogExecutable                 Filepath of LiveLog executable to use; see
                                             https://github.com/taskcluster/livelog
                                             [default: "livelog"]
+          livelogPortBase                   Set the base port number for livelog. Livelog requires two
+                                            ports.
+                                            [default: 60098]
           numberOfTasksToRun                If zero, run tasks indefinitely. Otherwise, after
                                             this many tasks, exit. [default: 0]
           privateIP                         The private IP of the worker, used by chain of trust.


### PR DESCRIPTION
Github Bug/Issue: Fixes #4691 

Not sure if it's appropriate to use a unit test for this. I've updated the existing ones to use the config field for setting the ports they use, so in some means it is tested.

If this isn't appropriate, give me a shout. :smile: 
