### PR TITLE
Upgrade an old, indirect highlight.js dep

### DIFF
--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -3575,19 +3575,14 @@ di@^0.0.1:
   integrity sha1-gGZJMmzqp8qjMG112YXqJ0i6kTw=
 
 diff2html@^3.1.6:
-  version "3.4.1"
-  resolved "https://registry.yarnpkg.com/diff2html/-/diff2html-3.4.1.tgz#397616cddd75c1d6a3b9de2ecf8c9a5c887c974c"
-  integrity sha512-vvNtMknDOiDPNMhsgZnGzW79FhTM0Sz4DaFYJIrNnFVpRz+Z9YVh1t7pg2vdK66ppjMIq5rLtQen09m/QgT7Rg==
+  version "3.4.2"
+  resolved "https://registry.yarnpkg.com/diff2html/-/diff2html-3.4.2.tgz#f5eaa1a19b430e8e1bb21058c6ab4d61b9b9baa3"
+  integrity sha512-3H4gFSnyf+TI6hM+AIF1Y2Hk3RZ5/Rb+/IpafgDDX0loc/klLS8iQxbx7+ByfRccb09E+pTVt+g9UEM2L9ebPw==
   dependencies:
-    diff "4.0.2"
+    diff "5.0.0"
     hogan.js "3.0.2"
   optionalDependencies:
-    highlight.js "10.4.1"
-
-diff@4.0.2:
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/diff/-/diff-4.0.2.tgz#60f3aecb89d5fae520c11aa19efc2bb982aade7d"
-  integrity sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==
+    highlight.js "10.7.1"
 
 diff@5.0.0:
   version "5.0.0"
@@ -5106,17 +5101,12 @@ header-case@^1.0.0:
   resolved "https://registry.yarnpkg.com/heap/-/heap-0.2.6.tgz#087e1f10b046932fc8594dd9e6d378afc9d1e5ac"
   integrity sha1-CH4fELBGky/IWU3Z5tN4r8nR5aw=
 
-highlight.js@10.4.1:
-  version "10.4.1"
-  resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-10.4.1.tgz#d48fbcf4a9971c4361b3f95f302747afe19dbad0"
-  integrity sha512-yR5lWvNz7c85OhVAEAeFhVCc/GV4C30Fjzc/rCP0aCWzc1UUOPUk55dK/qdwTZHBvMZo+eZ2jpk62ndX/xMFlg==
-
-highlight.js@^10.2.0:
+highlight.js@10.7.1:
   version "10.7.1"
   resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-10.7.1.tgz#a8ec4152db24ea630c90927d6cae2a45f8ecb955"
   integrity sha512-S6G97tHGqJ/U8DsXcEdnACbirtbx58Bx9CzIVeYli8OuswCfYI/LsXH2EiGcoGio1KAC3x4mmUwulOllJ2ZyRA==
 
-highlight.js@^10.4.0:
+highlight.js@^10.2.0, highlight.js@^10.4.0:
   version "10.7.2"
   resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-10.7.2.tgz#89319b861edc66c48854ed1e6da21ea89f847360"
   integrity sha512-oFLl873u4usRM9K63j4ME9u3etNF0PLiJhSQ8rdfuL51Wn3zkD6drf9ZW0dOzjnZI22YYG24z30JcmfCZjMgYg==


### PR DESCRIPTION
Fixes a dependabot alert (-- one that's not especially critical).