### PR TITLE
Fix function names in client-py's readme

### DIFF
--- a/changelog/Re2MUtpfTGqwz0sZgbkqHg.md
+++ b/changelog/Re2MUtpfTGqwz0sZgbkqHg.md
@@ -1,0 +1,3 @@
+audience: general
+level: silent
+---

--- a/clients/client-py/README.md
+++ b/clients/client-py/README.md
@@ -363,11 +363,11 @@ To download, use any of the following:
 
 * `await taskcluster.aio.download.downloadToBuf(name=.., maxRetries=.., objectService=..)` - asynchronously download an object to an in-memory buffer, returning a tuple (buffer, content-type).
   If the file is larger than available memory, this will crash.
-* `await taskcluster.aio.download.downloadToBuf(name=.., maxRetries=.., objectService=.., file=..)` - asynchronously download an object to a standard Python file, returning the content type.
+* `await taskcluster.aio.download.downloadToFile(name=.., maxRetries=.., objectService=.., file=..)` - asynchronously download an object to a standard Python file, returning the content type.
 * `await taskcluster.aio.download.download(name=.., maxRetries=.., objectService=.., writerFactory=..)` - asynchronously download an object to an async writer factory, returning the content type.
 * `taskcluster.download.downloadToBuf(name=.., maxRetries=.., objectService=..)` - download an object to an in-memory buffer, returning a tuple (buffer, content-type).
   If the file is larger than available memory, this will crash.
-* `taskcluster.download.downloadToBuf(name=.., maxRetries=.., objectService=.., file=..)` - download an object to a standard Python file, returning the content type.
+* `taskcluster.download.downloadToFile(name=.., maxRetries=.., objectService=.., file=..)` - download an object to a standard Python file, returning the content type.
 * `taskcluster.download.download(name=.., maxRetries=.., objectService=.., writerFactory=..)` - download an object to a sync writer factory, returning the content type.
 
 A "writer" is an object with a `write(data)` method which writes the given data, async for the async functions and sync for the remainder.


### PR DESCRIPTION
I found this, which looks like a mistake, while having a quick look at the python client docs (as I was having a look at maybe working on #4698). 