### PR TITLE
Support tagging S3 objects

### DIFF
--- a/changelog/issue-3948.md
+++ b/changelog/issue-3948.md
@@ -1,0 +1,4 @@
+audience: general
+level: silent
+reference: issue 3948
+---

--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
     "passport-github": "^1.1.0",
     "pg": "^8.0.0",
     "pg-connection-string": "^2.3.0",
+    "qs": "^6.10.1",
     "quick-lru": "^5.0.0",
     "regex-escape": "^3.4.8",
     "request-ip": "^2.0.2",

--- a/services/object/src/backends/aws.js
+++ b/services/object/src/backends/aws.js
@@ -35,6 +35,15 @@ class AwsBackend extends Backend {
 
     // determine whether we are talking to a genuine AWS S3, or an emulation of it
     this.isAws = !this.config.endpoint;
+
+    if (this.isAws) {
+      this.tags = this.config.tags || {};
+      if (Object.entries(this.tags).some(([k, v]) => typeof v !== 'string')) {
+        throw new Error(`backend ${this.backendId} has invalid 'tags' configuration`);
+      }
+    } else if (this.config.tags) {
+      throw new Error('tags are only supported on the real AWS S3');
+    }
   }
 
   async createUpload(object, proposedUploadMethods) {
@@ -170,6 +179,7 @@ class AwsBackend extends Backend {
    */
   _objectTags(object) {
     return {
+      ...this.tags,
       ProjectId: object.project_id,
     };
   }

--- a/services/object/src/backends/base.js
+++ b/services/object/src/backends/base.js
@@ -31,6 +31,19 @@ class Backend {
   }
 
   /**
+   * Finish an upload for the given object.  This is called during the
+   * `finishUpload` API method, and is intended to support any finalization of
+   * the data the caller uploaded.  It is *not* intended to be a validation
+   * step: in general we assume that the caller has done the right thing, and
+   * that anything it has done wrong will result in an object that can't be
+   * downloaded.  But, implementations may use taskcluster-lib-api's
+   * `reportError` method to report errors.
+   */
+  async finishUpload(object) {
+    return;
+  }
+
+  /**
    * Get the set of download methods available for this object.  All backends
    * must support at least the `simple` method.
    *

--- a/ui/docs/manual/deploying/object-service.mdx
+++ b/ui/docs/manual/deploying/object-service.mdx
@@ -83,6 +83,7 @@ Since Google Cloud provides an S3-interoperability API, this means the AWS backe
 
 Objects are stored in the bucket using their full name.
 S3 Objects are tagged with the object's `projectId`, to assist with cost accounting and other cloud-usage analysis.
+Additional tags can be added with the `tags` configuration shown below.
 Note that GCS does not support tagging.
 
 Each backend has the following configuration parameters:
@@ -91,6 +92,7 @@ Each backend has the following configuration parameters:
  * `secretAccessKey`
  * `signGetUrls` (optional, default false)
  * `endpoint` (optional, default null)
+ * `tags` (optional, default `{}`)
 
  For example:
 
@@ -103,6 +105,7 @@ backends:
     bucket: "my-objects"
     signGetUrls: false
     endpoint: "https://storage.googleapis.com" # (for Google)
+    tags: {Visibility: 'public'}
 ```
 
 #### AWS Configuration

--- a/ui/docs/manual/deploying/object-service.mdx
+++ b/ui/docs/manual/deploying/object-service.mdx
@@ -79,10 +79,11 @@ backend_map:
 
 The `aws` backend type stores objects using the AWS S3 protocol.
 
-Since Google Cloud provides an S3-interoperability API, this means the AWS
-Backend can _also_ be used to persist objects in Google Cloud Storage.
+Since Google Cloud provides an S3-interoperability API, this means the AWS backend can _also_ be used to persist objects in Google Cloud Storage (GCS); see below.
 
 Objects are stored in the bucket using their full name.
+S3 Objects are tagged with the object's `projectId`, to assist with cost accounting and other cloud-usage analysis.
+Note that GCS does not support tagging.
 
 Each backend has the following configuration parameters:
  * `bucket`

--- a/yarn.lock
+++ b/yarn.lock
@@ -5552,7 +5552,7 @@ qs@6.7.0:
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.7.0.tgz#41dc1a015e3d581f1621776be31afb2876a9b1bc"
   integrity sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ==
 
-qs@^6.7.0, qs@^6.9.4, qs@^6.9.6:
+qs@^6.10.1, qs@^6.7.0, qs@^6.9.4, qs@^6.9.6:
   version "6.10.1"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.10.1.tgz#4931482fa8d647a5aab799c5271d2133b981fb6a"
   integrity sha512-M528Hph6wsSVOBiYUnGf+K/7w0hNshs/duGsNXPUCLH5XAqjEtiPGwNONLV0tBH8NoGb0mvD5JubnUTrujKDTg==
@@ -6321,47 +6321,52 @@ tar-stream@^2.0.0:
     readable-stream "^3.1.1"
 
 "taskcluster-client@link:clients/client":
-  version "42.1.1"
-  dependencies:
-    debug "^4.1.1"
-    got "^11.8.1"
-    hawk "^9.0.0"
-    lodash "^4.17.4"
-    slugid "^2.0.0"
-    taskcluster-lib-urls "^13.0.0"
+  version "0.0.0"
+  uid ""
 
 "taskcluster-db@link:db":
-  version "42.1.1"
+  version "0.0.0"
+  uid ""
 
 "taskcluster-lib-api@link:libraries/api":
-  version "42.1.1"
+  version "0.0.0"
+  uid ""
 
 "taskcluster-lib-app@link:libraries/app":
-  version "42.1.1"
+  version "0.0.0"
+  uid ""
 
 "taskcluster-lib-azqueue@link:libraries/azqueue":
-  version "42.1.1"
+  version "0.0.0"
+  uid ""
 
 "taskcluster-lib-config@link:libraries/config":
-  version "42.1.1"
+  version "0.0.0"
+  uid ""
 
 "taskcluster-lib-iterate@link:libraries/iterate":
-  version "42.1.1"
+  version "0.0.0"
+  uid ""
 
 "taskcluster-lib-loader@link:libraries/loader":
-  version "42.1.1"
+  version "0.0.0"
+  uid ""
 
 "taskcluster-lib-monitor@link:libraries/monitor":
-  version "42.1.1"
+  version "0.0.0"
+  uid ""
 
 "taskcluster-lib-postgres@link:libraries/postgres":
-  version "42.1.1"
+  version "0.0.0"
+  uid ""
 
 "taskcluster-lib-pulse@link:libraries/pulse":
-  version "42.1.1"
+  version "0.0.0"
+  uid ""
 
 "taskcluster-lib-references@link:libraries/references":
-  version "42.1.1"
+  version "0.0.0"
+  uid ""
 
 taskcluster-lib-scopes@^11.0.0:
   version "11.0.0"
@@ -6371,7 +6376,8 @@ taskcluster-lib-scopes@^11.0.0:
     fast-json-stable-stringify "^2.1.0"
 
 "taskcluster-lib-testing@link:libraries/testing":
-  version "42.1.1"
+  version "0.0.0"
+  uid ""
 
 taskcluster-lib-urls@^13.0.0:
   version "13.0.1"
@@ -6379,7 +6385,8 @@ taskcluster-lib-urls@^13.0.0:
   integrity sha512-WrhKMbiWmpPrB0vbzLZq4W35mhdPVLklZY+qrBoI7KQzFAjO/qsgS8ssHL6eYmvBf4fE7C+C9ZFxQpQOUynQvg==
 
 "taskcluster-lib-validate@link:libraries/validate":
-  version "42.1.1"
+  version "0.0.0"
+  uid ""
 
 temporary@^1.0.0:
   version "1.1.0"


### PR DESCRIPTION
This automatically tags objects with the ProjectId, and allows deployers to add other custom tags on a per-backend basis.

Github Bug/Issue: Fixes #3948