### PR TITLE
remove special-case in go for retrying 400s on upload

### DIFF
--- a/changelog/issue-4623.md
+++ b/changelog/issue-4623.md
@@ -1,0 +1,4 @@
+audience: general
+level: silent
+reference: issue 4623
+---

--- a/clients/client-go/tcobject/upload.go
+++ b/clients/client-go/tcobject/upload.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/base64"
 	"errors"
-	"fmt"
 	"io"
 	"io/ioutil"
 	"net/http"
@@ -144,12 +143,6 @@ func putURLUpload(httpBackoffClient *httpbackoff.Client, uploadMethod SelectedUp
 		putResp, tempError = httpClient.Do(httpRequest)
 		if tempError != nil {
 			return
-		}
-		// bug 1394557: s3 incorrectly returns HTTP 400 for connection
-		// inactivity, so make this a temp error rather than a permanent error
-		// if it occurs, in case this is a put request to s3
-		if putResp.StatusCode == 400 {
-			tempError = fmt.Errorf("Status code 400 which might be an intermittent issue - see https://bugzilla.mozilla.org/show_bug.cgi?id=1394557")
 		}
 		return
 	}


### PR DESCRIPTION
I can't reproduce this error, so for the moment we'll make all upload operations behave the same way and not retry on 400's.

Github Bug/Issue: Fixes #4623
