### PR TITLE
Call the async versions of upload and download from their sync versions in python client

### DIFF
--- a/changelog/issue-4698.md
+++ b/changelog/issue-4698.md
@@ -1,0 +1,5 @@
+audience: users
+level: patch
+reference: issue 4698
+---
+Uploading functions in the Python client have been renamed to use camel-case instead of underscores.

--- a/clients/client-py/taskcluster/aio/asyncutils.py
+++ b/clients/client-py/taskcluster/aio/asyncutils.py
@@ -117,8 +117,20 @@ async def putFile(filename, url, contentType, session=None):
         }, session=session)
 
 
+def runAsync(coro):
+    """
+    Replacement of asyncio.run, as it doesn't exist in python<3.7.
+    """
+    asyncio.set_event_loop(asyncio.new_event_loop())
+    loop = asyncio.get_event_loop()
+    result = loop.run_until_complete(coro)
+    loop.close()
+    return result
+
+
 def ensureCoro(func):
-    """If func is a regular function, execute in a thread and return an
+    """
+    If func is a regular function, execute in a thread and return an
     async version of it. If func is already an async function, return
     it without change.
     """

--- a/clients/client-py/taskcluster/aio/download.py
+++ b/clients/client-py/taskcluster/aio/download.py
@@ -21,6 +21,7 @@ if six.PY2:
 
 import aiohttp
 
+from .asyncutils import ensureCoro
 from .reader_writer import streamingCopy, BufferWriter, FileWriter
 from .retry import retry
 
@@ -66,7 +67,7 @@ async def download(*, name, maxRetries=5, objectService, writerFactory):
     upload.  Returns the content-type.
     """
     async with aiohttp.ClientSession() as session:
-        downloadResp = await objectService.startDownload(name, {
+        downloadResp = await ensureCoro(objectService.startDownload)(name, {
             "acceptDownloadMethods": {
                 "simple": True,
             },

--- a/clients/client-py/taskcluster/aio/upload.py
+++ b/clients/client-py/taskcluster/aio/upload.py
@@ -33,7 +33,7 @@ from .retry import retry
 DATA_INLINE_MAX_SIZE = 8192
 
 
-async def upload_from_buf(*, data, **kwargs):
+async def uploadFromBuf(*, data, **kwargs):
     """
     Convenience method to upload data from an in-memory buffer.  Arguments are the same
     as `upload` except that `readerFactory` should not be supplied.
@@ -44,7 +44,7 @@ async def upload_from_buf(*, data, **kwargs):
     await upload(**kwargs, readerFactory=readerFactory)
 
 
-async def upload_from_file(*, file, **kwargs):
+async def uploadFromFile(*, file, **kwargs):
     """
     Convenience method to upload data from a a file.  The file should be open
     for reading, in binary mode, and be seekable (`f.seek`).  Remaining

--- a/clients/client-py/taskcluster/download.py
+++ b/clients/client-py/taskcluster/download.py
@@ -11,16 +11,14 @@ be called more than once.
 This module provides several pre-defined writers and writer factories for
 common cases.
 """
+import functools
 import six
 
 if six.PY2:
     raise ImportError("download is only supported in Python 3")
 
-import io
-
-import requests
-
-from .retry import retry
+from .aio import download as aio_download
+from .aio.asyncutils import ensureCoro, runAsync
 
 
 def downloadToBuf(**kwargs):
@@ -29,15 +27,7 @@ def downloadToBuf(**kwargs):
     downloaded data.  Arguments are the same as `download`, except that
     `writerFactory` should not be supplied.  Returns a tuple (buffer, contentType).
     """
-    writer = None
-
-    def writerFactory():
-        nonlocal writer
-        writer = io.BytesIO()
-        return writer
-
-    contentType = download(writerFactory=writerFactory, **kwargs)
-    return writer.getbuffer(), contentType
+    return runAsync(aio_download.downloadToBuf(**kwargs))
 
 
 def downloadToFile(file, **kwargs):
@@ -47,15 +37,10 @@ def downloadToFile(file, **kwargs):
     (`f.truncate`) to support retries.  Arguments are the same as `download`,
     except that `writerFactory` should not be supplied.  Returns the content-type.
     """
-    def writerFactory():
-        file.seek(0)
-        file.truncate()
-        return file
-
-    return download(writerFactory=writerFactory, **kwargs)
+    return runAsync(aio_download.downloadToFile(file=file, **kwargs))
 
 
-def download(*, name, maxRetries=5, objectService, writerFactory):
+def download(*, writerFactory, **kwargs):
     """
     Download the named object from the object service, using a writer returned
     from `writerFactory` to write the data.  The `maxRetries` parameter has
@@ -63,49 +48,16 @@ def download(*, name, maxRetries=5, objectService, writerFactory):
     an instance of the Object class, configured with credentials for the
     upload.  Returns the content-type.
     """
-    with requests.Session() as session:
-        downloadResp = objectService.startDownload(name, {
-            "acceptDownloadMethods": {
-                "simple": True,
-            },
-        })
-
-        method = downloadResp["method"]
-
-        def tryDownload(retryFor):
-            try:
-                if method == "simple":
-                    writer = writerFactory()
-                    return _doSimpleDownload(downloadResp, writer, session)
-                else:
-                    raise RuntimeError(f'Unknown download method {method}')
-            except requests.HTTPError as exc:
-                # treat 4xx's as fatal, and retry others
-                if hasattr(exc, 'response') and 400 <= exc.response.status_code < 500:
-                    print("no retry")
-                    raise exc
-                return retryFor(exc)
-            except requests.RequestException as exc:
-                # retry for all other requests errors
-                return retryFor(exc)
-            # .. anything else is considered fatal
-
-        return retry(maxRetries, tryDownload)
+    wrappedWriterFactory = _wrapSyncWriterFactory(writerFactory)
+    return runAsync(aio_download.download(writerFactory=wrappedWriterFactory, **kwargs))
 
 
-def _streamResponseToWriter(response, writer):
-    "Copy data from a requests Response to a writer"
-    chunk_size = 64 * 1024
+def _wrapSyncWriterFactory(writerFactory):
+    """Modify the reader returned by readerFactory to have an async read."""
+    @functools.wraps(writerFactory)
+    async def wrappedFactory():
+        writer = writerFactory()
+        writer.write = ensureCoro(writer.write)
+        return writer
 
-    for chunk in response.iter_content(chunk_size):
-        writer.write(chunk)
-
-
-def _doSimpleDownload(downloadResp, writer, session):
-    url = downloadResp['url']
-    with session.get(url, stream=True) as resp:
-        contentType = resp.headers.get('content-type', 'application/octet-stream')
-        resp.raise_for_status()
-        _streamResponseToWriter(resp, writer)
-
-    return contentType
+    return wrappedFactory

--- a/clients/client-py/taskcluster/upload.py
+++ b/clients/client-py/taskcluster/upload.py
@@ -25,22 +25,22 @@ from .aio.asyncutils import ensureCoro, runAsync
 DATA_INLINE_MAX_SIZE = 8192
 
 
-def upload_from_buf(*, data, **kwargs):
+def uploadFromBuf(*, data, **kwargs):
     """
     Convenience method to upload data from an in-memory buffer.  Arguments are the same
     as `upload` except that `readerFactory` should not be supplied.
     """
-    return runAsync(aio_upload.upload_from_buf(data=data, **kwargs))
+    return runAsync(aio_upload.uploadFromBuf(data=data, **kwargs))
 
 
-def upload_from_file(*, file, **kwargs):
+def uploadFromFile(*, file, **kwargs):
     """
     Convenience method to upload data from a a file.  The file should be open
     for reading, in binary mode, and be seekable (`f.seek`).  Remaining
     arguments are the same as `upload` except that `readerFactory` should not
     be supplied.
     """
-    return runAsync(aio_upload.upload_from_file(file=file, **kwargs))
+    return runAsync(aio_upload.uploadFromFile(file=file, **kwargs))
 
 
 def upload(*, readerFactory, **kwargs):

--- a/clients/client-py/taskcluster/upload.py
+++ b/clients/client-py/taskcluster/upload.py
@@ -17,9 +17,8 @@ import six
 if six.PY2:
     raise ImportError("upload is only supported in Python 3")
 
-import asyncio
-
 from .aio import upload as aio_upload
+from .aio.asyncutils import runAsync
 
 
 DATA_INLINE_MAX_SIZE = 8192
@@ -30,7 +29,7 @@ def upload_from_buf(*, data, **kwargs):
     Convenience method to upload data from an in-memory buffer.  Arguments are the same
     as `upload` except that `readerFactory` should not be supplied.
     """
-    return asyncio.run(aio_upload.upload_from_buf(data=data, **kwargs))
+    return runAsync(aio_upload.upload_from_buf(data=data, **kwargs))
 
 
 def upload_from_file(*, file, **kwargs):
@@ -40,7 +39,7 @@ def upload_from_file(*, file, **kwargs):
     arguments are the same as `upload` except that `readerFactory` should not
     be supplied.
     """
-    return asyncio.run(aio_upload.upload_from_file(file=file, **kwargs))
+    return runAsync(aio_upload.upload_from_file(file=file, **kwargs))
 
 
 def upload(**kwargs):
@@ -50,4 +49,4 @@ def upload(**kwargs):
     The `objectService` parameter is an instance of the Object class,
     configured with credentials for the upload.
     """
-    return asyncio.run(aio_upload.upload(**kwargs))
+    return runAsync(aio_upload.upload(**kwargs))

--- a/clients/client-py/taskcluster/upload.py
+++ b/clients/client-py/taskcluster/upload.py
@@ -17,15 +17,10 @@ import six
 if six.PY2:
     raise ImportError("upload is only supported in Python 3")
 
-import base64
-from shutil import copyfileobj
-import io
-import hashlib
+import asyncio
 
-import requests
+from .aio import upload as aio_upload
 
-import taskcluster
-from .retry import retry
 
 DATA_INLINE_MAX_SIZE = 8192
 
@@ -35,10 +30,7 @@ def upload_from_buf(*, data, **kwargs):
     Convenience method to upload data from an in-memory buffer.  Arguments are the same
     as `upload` except that `readerFactory` should not be supplied.
     """
-    def readerFactory():
-        return io.BytesIO(data)
-
-    upload(**kwargs, readerFactory=readerFactory)
+    return asyncio.run(aio_upload.upload_from_buf(data=data, **kwargs))
 
 
 def upload_from_file(*, file, **kwargs):
@@ -48,120 +40,14 @@ def upload_from_file(*, file, **kwargs):
     arguments are the same as `upload` except that `readerFactory` should not
     be supplied.
     """
-    def readerFactory():
-        file.seek(0)
-        return file
-
-    upload(**kwargs, readerFactory=readerFactory)
+    return asyncio.run(aio_upload.upload_from_file(file=file, **kwargs))
 
 
-def upload(*, projectId, name, contentType, contentLength, expires,
-           readerFactory, maxRetries=5, objectService):
+def upload(**kwargs):
     """
     Upload the given data to the object service with the given metadata.
     The `maxRetries` parameter has the same meaning as for service clients.
     The `objectService` parameter is an instance of the Object class,
     configured with credentials for the upload.
     """
-    # wrap the readerFactory with one that will also hash the data
-    hashingReader = None
-
-    def hashingReaderFactory():
-        nonlocal hashingReader
-        hashingReader = HashingReader(readerFactory())
-        return hashingReader
-
-    with requests.Session() as session:
-        uploadId = taskcluster.slugid.v4()
-        proposedUploadMethods = {}
-
-        if contentLength < DATA_INLINE_MAX_SIZE:
-            reader = hashingReaderFactory()
-            writer = io.BytesIO()
-            copyfileobj(reader, writer)
-            encoded = base64.b64encode(writer.getbuffer())
-            proposedUploadMethods['dataInline'] = {
-                "contentType": contentType,
-                "objectData": encoded,
-            }
-
-        proposedUploadMethods['putUrl'] = {
-            "contentType": contentType,
-            "contentLength": contentLength,
-        }
-
-        uploadResp = objectService.createUpload(name, {
-            "expires": expires,
-            "projectId": projectId,
-            "uploadId": uploadId,
-            "proposedUploadMethods": proposedUploadMethods,
-        })
-
-        def tryUpload(retryFor):
-            try:
-                uploadMethod = uploadResp["uploadMethod"]
-                if 'dataInline' in uploadMethod:
-                    # data is already uploaded -- nothing to do
-                    pass
-                elif 'putUrl' in uploadMethod:
-                    reader = hashingReaderFactory()
-                    _putUrlUpload(uploadMethod['putUrl'], reader, session)
-                else:
-                    raise RuntimeError("Could not negotiate an upload method")
-            except requests.HTTPError as exc:
-                # treat 4xx's as fatal, and retry others
-                if hasattr(exc, 'response') and 400 <= exc.response.status_code < 500:
-                    raise exc
-                print("1", exc)
-                return retryFor(exc)
-            except requests.RequestException as exc:
-                # retry for all other requests errors
-                print("2", exc)
-                return retryFor(exc)
-            # .. anything else is considered fatal
-
-        retry(maxRetries, tryUpload)
-
-        # TODO: pass this value to finishUpload when the deployed instance supports it
-        # https://github.com/taskcluster/taskcluster/issues/4714
-        hashingReader.hashes(contentLength)
-
-        objectService.finishUpload(name, {
-            "projectId": projectId,
-            "uploadId": uploadId,
-        })
-
-
-def _putUrlUpload(method, reader, session):
-    resp = session.put(method['url'], headers=method['headers'], data=reader)
-    resp.raise_for_status()
-
-
-class HashingReader:
-    """A Reader implementation that hashes contents as they are read."""
-
-    def __init__(self, inner):
-        self.inner = inner
-        self.sha256 = hashlib.sha256()
-        self.sha512 = hashlib.sha512()
-        self.bytes = 0
-
-    def read(self, max_size):
-        chunk = self.inner.read(max_size)
-        self.update(chunk)
-        return chunk
-
-    def update(self, chunk):
-        self.sha256.update(chunk)
-        self.sha512.update(chunk)
-        self.bytes += len(chunk)
-
-    def hashes(self, contentLength):
-        """Return the hsahes in a format suitable for finishUpload, first checking that all the bytes
-        in the content were hashed."""
-        if contentLength != self.bytes:
-            raise RuntimeError(f"hashed {self.bytes} bytes but content length is {contentLength}")
-        return {
-            "sha256": self.sha256.hexdigest(),
-            "sha512": self.sha512.hexdigest(),
-        }
+    return asyncio.run(aio_upload.upload(**kwargs))

--- a/clients/client-py/test/aio/test_upload_download.py
+++ b/clients/client-py/test/aio/test_upload_download.py
@@ -59,11 +59,8 @@ class FakeObject:
         return {}
 
 
-@pytest.mark.parametrize(
-    "reader_factory",
-    [BufferReader, io.BytesIO])
-async def test_hashing_reader_hashes(reader_factory):
-    hashingReader = upload.HashingReader(reader_factory(b"some data"))
+async def test_hashing_reader_hashes():
+    hashingReader = upload.HashingReader(BufferReader(b"some data"))
     assert(await hashingReader.read(4) == b"some")
     assert(await hashingReader.read(1) == b" ")
     assert(await hashingReader.read(16) == b"data")
@@ -81,35 +78,6 @@ async def test_hashing_reader_hashes(reader_factory):
 
     with pytest.raises(RuntimeError):
         hashingReader.hashes(999)
-
-
-async def test_hashing_reader_hashes_aiofile(tmp_path):
-    src = tmp_path / "src"
-    with open(src, "wb") as f:
-        f.write(b"some data")
-
-    async with async_open(src, "rb") as file:
-        file.seek(0)
-        reader = file
-
-        hashingReader = upload.HashingReader(reader)
-        assert(await hashingReader.read(4) == b"some")
-        assert(await hashingReader.read(1) == b" ")
-        assert(await hashingReader.read(16) == b"data")
-        assert(await hashingReader.read(16) == b"")
-
-        exp = {}
-        h = hashlib.sha256()
-        h.update(b"some data")
-        exp["sha256"] = h.hexdigest()
-        h = hashlib.sha512()
-        h.update(b"some data")
-        exp["sha512"] = h.hexdigest()
-
-        assert(hashingReader.hashes(9) == exp)
-
-        with pytest.raises(RuntimeError):
-            hashingReader.hashes(999)
 
 
 async def test_simple_download_fails():

--- a/clients/client-py/test/aio/test_upload_download.py
+++ b/clients/client-py/test/aio/test_upload_download.py
@@ -1,13 +1,10 @@
 """
 Tests of uploads and downloads using local fakes and requiring no credentials.
 """
-import io
-
 import pytest
 import httptest
 import aiohttp
 import hashlib
-from aiofiles import open as async_open
 
 import taskcluster
 from taskcluster.aio import upload, download
@@ -167,7 +164,7 @@ async def test_putUrl_upload_fails(randbytes):
     with httptest.Server(Server) as ts:
         objectService = FakeObject(ts)
         with pytest.raises(aiohttp.ClientResponseError):
-            await upload.upload_from_buf(
+            await upload.uploadFromBuf(
                 projectId="taskcluster",
                 expires=taskcluster.fromNow('1 hour'),
                 contentType="text/plain",
@@ -194,7 +191,7 @@ async def test_putUrl_upload_fails_retried(randbytes):
     with httptest.Server(Server) as ts:
         objectService = FakeObject(ts)
         with pytest.raises(aiohttp.ClientResponseError):
-            await upload.upload_from_buf(
+            await upload.uploadFromBuf(
                 projectId="taskcluster",
                 expires=taskcluster.fromNow('1 hour'),
                 contentType="text/plain",
@@ -225,7 +222,7 @@ async def test_putUrl_upload_fails_retried_succeeds(randbytes):
 
     with httptest.Server(Server) as ts:
         objectService = FakeObject(ts)
-        await upload.upload_from_buf(
+        await upload.uploadFromBuf(
             projectId="taskcluster",
             expires=taskcluster.fromNow('1 hour'),
             contentType="text/plain",

--- a/clients/client-py/test/aio/test_upload_download_real.py
+++ b/clients/client-py/test/aio/test_upload_download_real.py
@@ -67,7 +67,7 @@ async def test_large_upload_download(objectService):
 async def do_over_wire_buf_test(data, objectService):
     """We can upload a small amount of literal data"""
     name = f"taskcluster/test/client-py/{taskcluster.slugid.v4()}"
-    await upload.upload_from_buf(
+    await upload.uploadFromBuf(
         projectId="taskcluster",
         name=name,
         contentType="text/plain",
@@ -94,7 +94,7 @@ async def test_file_upload_download(objectService, tmp_path):
 
     name = f"taskcluster/test/client-py/{taskcluster.slugid.v4()}"
     with open(src, "rb") as file:
-        await upload.upload_from_file(
+        await upload.uploadFromFile(
             projectId="taskcluster",
             name=name,
             contentType="text/plain",

--- a/clients/client-py/test/test_upload_download.py
+++ b/clients/client-py/test/test_upload_download.py
@@ -143,7 +143,7 @@ def test_putUrl_upload_fails(randbytes):
     with httptest.Server(Server) as ts:
         objectService = FakeObject(ts)
         with pytest.raises(aiohttp.ClientResponseError):
-            upload.upload_from_buf(
+            upload.uploadFromBuf(
                 projectId="taskcluster",
                 expires=taskcluster.fromNow('1 hour'),
                 contentType="text/plain",
@@ -172,7 +172,7 @@ def test_putUrl_upload_fails_retried(randbytes):
     with httptest.Server(Server) as ts:
         objectService = FakeObject(ts)
         with pytest.raises(aiohttp.ClientResponseError):
-            upload.upload_from_buf(
+            upload.uploadFromBuf(
                 projectId="taskcluster",
                 expires=taskcluster.fromNow('1 hour'),
                 contentType="text/plain",
@@ -206,7 +206,7 @@ def test_putUrl_upload_fails_retried_succeeds(randbytes):
 
     with httptest.Server(Server) as ts:
         objectService = FakeObject(ts)
-        upload.upload_from_buf(
+        upload.uploadFromBuf(
             projectId="taskcluster",
             expires=taskcluster.fromNow('1 hour'),
             contentType="text/plain",

--- a/clients/client-py/test/test_upload_download.py
+++ b/clients/client-py/test/test_upload_download.py
@@ -4,9 +4,8 @@ Tests of uploads and downloads using local fakes and requiring no credentials.
 
 import pytest
 import httptest
+import aiohttp
 import requests
-import io
-import hashlib
 
 import taskcluster
 from taskcluster import upload, download
@@ -50,27 +49,6 @@ class FakeObject:
         assert payload["projectId"] == self.lastProjectId
 
         return {}
-
-
-def test_hashing_reader_hashes():
-    hashingReader = upload.HashingReader(io.BytesIO(b"some data"))
-    assert(hashingReader.read(4) == b"some")
-    assert(hashingReader.read(1) == b" ")
-    assert(hashingReader.read(16) == b"data")
-    assert(hashingReader.read(16) == b"")
-
-    exp = {}
-    h = hashlib.sha256()
-    h.update(b"some data")
-    exp["sha256"] = h.hexdigest()
-    h = hashlib.sha512()
-    h.update(b"some data")
-    exp["sha512"] = h.hexdigest()
-
-    assert(hashingReader.hashes(9) == exp)
-
-    with pytest.raises(RuntimeError):
-        hashingReader.hashes(999)
 
 
 def test_simple_download_fails():
@@ -163,7 +141,7 @@ def test_putUrl_upload_fails(randbytes):
 
     with httptest.Server(Server) as ts:
         objectService = FakeObject(ts)
-        with pytest.raises(requests.RequestException):
+        with pytest.raises(aiohttp.ClientResponseError):
             upload.upload_from_buf(
                 projectId="taskcluster",
                 expires=taskcluster.fromNow('1 hour'),
@@ -192,7 +170,7 @@ def test_putUrl_upload_fails_retried(randbytes):
 
     with httptest.Server(Server) as ts:
         objectService = FakeObject(ts)
-        with pytest.raises(requests.RequestException):
+        with pytest.raises(aiohttp.ClientResponseError):
             upload.upload_from_buf(
                 projectId="taskcluster",
                 expires=taskcluster.fromNow('1 hour'),

--- a/clients/client-py/test/test_upload_download_real.py
+++ b/clients/client-py/test/test_upload_download_real.py
@@ -65,7 +65,7 @@ def test_large_upload_download(objectService):
 def do_over_wire_buf_test(data, objectService):
     """We can upload a small amount of literal data"""
     name = f"taskcluster/test/client-py/{taskcluster.slugid.v4()}"
-    upload.upload_from_buf(
+    upload.uploadFromBuf(
         projectId="taskcluster",
         name=name,
         contentType="text/plain",
@@ -92,7 +92,7 @@ def test_file_upload_download(objectService, tmp_path):
 
     name = f"taskcluster/test/client-py/{taskcluster.slugid.v4()}"
     with open(src, "rb") as file:
-        upload.upload_from_file(
+        upload.uploadFromFile(
             projectId="taskcluster",
             name=name,
             contentType="text/plain",


### PR DESCRIPTION
Github Bug/Issue: Fixes #4698 

I've started by doing the upload part; I'm hoping to get feedback of whether this looks right, as doing the download part is almost the same.

This would probably benefit from more thorough tests to be confident that it does what it has to.
