### PR TITLE
Default k8s replicas for the object service to 1

### DIFF
--- a/changelog/b8nrp5qFTiqJqIE6Rkd8CA.md
+++ b/changelog/b8nrp5qFTiqJqIE6Rkd8CA.md
@@ -1,0 +1,4 @@
+audience: deployers
+level: patch
+---
+The object service now defaults to 1 replica, not 0.  The service will not start if it is not properly configured, and we recommend setting the service up at this time, as in the next major release workers will begin uploading objects to the queue.

--- a/infrastructure/k8s/values.yaml
+++ b/infrastructure/k8s/values.yaml
@@ -91,7 +91,7 @@ notify:
 object:
   procs:
     web:
-      replicas: 0
+      replicas: 1
       cpu: 50m
       memory: 100Mi
     expire:

--- a/services/object/procs.yml
+++ b/services/object/procs.yml
@@ -1,7 +1,6 @@
 web:
   type: web
   command: node services/object/src/main.js server
-  defaultReplicas: 0
 expire:
   type: cron
   schedule: '0 0 * * *'


### PR DESCRIPTION
I missed this in #4746.  It's not marked major because it won't actually cause anything that's already working to fail -- it will just create a new k8s deployment that fails.