### PR TITLE
Automerge in all package.json's

### DIFF
--- a/package.json
+++ b/package.json
@@ -261,7 +261,7 @@
         ],
         "matchCurrentVersion": "!/^0/",
         "paths": [
-          "+(package.json)"
+          "package.json"
         ],
         "automerge": true
       }


### PR DESCRIPTION
This change causes renovate to match any path containing package.json
and enable automerge.  We had previously wanted to avoid this, since
`ui/` and `workers/docker-worker` are poorly tested, but in practice
we're merging those anyway.  And in fact, the build process for `ui/`
ends up catching most issues with things like Babel, so tihs has done
quite well.

This should further reduce the team's required toill.