### PR TITLE
Serialize errors for logging more succinctly

### DIFF
--- a/changelog/issue-4807.md
+++ b/changelog/issue-4807.md
@@ -1,0 +1,4 @@
+audience: general
+level: silent
+reference: issue 4807
+---

--- a/libraries/monitor/test/monitor_test.js
+++ b/libraries/monitor/test/monitor_test.js
@@ -348,6 +348,23 @@ suite(testing.suiteName(), function() {
         'uhoh\nsomething went wrong\n..again');
     });
 
+    test('should record top-level string or numeric fields of errors, but no more', function() {
+      const err = new Error('uhoh');
+      err.color = "prussian blue";
+      err.temperature = 290.8; // Kelvin, obviously
+      err.count = 13;
+      err.object = { x: 10 };
+      err.array = [1, 2];
+      monitor.reportError(err);
+      assert.equal(monitorManager.messages.length, 1);
+      assert(monitorManager.messages[0].message.startsWith("Error: uhoh\n"));
+      assert.equal(monitorManager.messages[0].Fields.color, "prussian blue");
+      assert.equal(monitorManager.messages[0].Fields.temperature, 290.8);
+      assert.equal(monitorManager.messages[0].Fields.count, 13);
+      assert.equal(monitorManager.messages[0].Fields.object, undefined); // omitted
+      assert.equal(monitorManager.messages[0].Fields.array, undefined); // omitted
+    });
+
     test('should record errors with extra', function() {
       monitor.reportError(new Error('oh no'), { foo: 5 });
       assert.equal(monitorManager.messages.length, 1);

--- a/package.json
+++ b/package.json
@@ -94,7 +94,6 @@
     "rimraf": "^3.0.0",
     "sanitize-html": "^2.0.0",
     "sentry-api": "^0.2.0",
-    "serialize-error": "^8.0.0",
     "sift": "^13.5.0",
     "slugid": "^2.0.0",
     "subscriptions-transport-ws": "^0.9.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5939,13 +5939,6 @@ sentry-api@^0.2.0:
     debug "^4.1.1"
     request "^2.65.0"
 
-serialize-error@^8.0.0:
-  version "8.1.0"
-  resolved "https://registry.yarnpkg.com/serialize-error/-/serialize-error-8.1.0.tgz#3a069970c712f78634942ddd50fbbc0eaebe2f67"
-  integrity sha512-3NnuWfM6vBYoy5gZFvHiYsVbafvI9vZv/+jlIigFn4oP4zjNPK3LhcY0xSCgeb1a5L8jO71Mit9LlNoi2UfDDQ==
-  dependencies:
-    type-fest "^0.20.2"
-
 serialize-javascript@5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-5.0.1.tgz#7886ec848049a462467a97d3d918ebb2aaf934f4"
@@ -6361,47 +6354,52 @@ tar-stream@^2.0.0:
     readable-stream "^3.1.1"
 
 "taskcluster-client@link:clients/client":
-  version "43.2.0"
-  dependencies:
-    debug "^4.1.1"
-    got "^11.8.1"
-    hawk "^9.0.0"
-    lodash "^4.17.4"
-    slugid "^2.0.0"
-    taskcluster-lib-urls "^13.0.0"
+  version "0.0.0"
+  uid ""
 
 "taskcluster-db@link:db":
-  version "43.2.0"
+  version "0.0.0"
+  uid ""
 
 "taskcluster-lib-api@link:libraries/api":
-  version "43.2.0"
+  version "0.0.0"
+  uid ""
 
 "taskcluster-lib-app@link:libraries/app":
-  version "43.2.0"
+  version "0.0.0"
+  uid ""
 
 "taskcluster-lib-azqueue@link:libraries/azqueue":
-  version "43.2.0"
+  version "0.0.0"
+  uid ""
 
 "taskcluster-lib-config@link:libraries/config":
-  version "43.2.0"
+  version "0.0.0"
+  uid ""
 
 "taskcluster-lib-iterate@link:libraries/iterate":
-  version "43.2.0"
+  version "0.0.0"
+  uid ""
 
 "taskcluster-lib-loader@link:libraries/loader":
-  version "43.2.0"
+  version "0.0.0"
+  uid ""
 
 "taskcluster-lib-monitor@link:libraries/monitor":
-  version "43.2.0"
+  version "0.0.0"
+  uid ""
 
 "taskcluster-lib-postgres@link:libraries/postgres":
-  version "43.2.0"
+  version "0.0.0"
+  uid ""
 
 "taskcluster-lib-pulse@link:libraries/pulse":
-  version "43.2.0"
+  version "0.0.0"
+  uid ""
 
 "taskcluster-lib-references@link:libraries/references":
-  version "43.2.0"
+  version "0.0.0"
+  uid ""
 
 taskcluster-lib-scopes@^11.0.0:
   version "11.0.0"
@@ -6411,7 +6409,8 @@ taskcluster-lib-scopes@^11.0.0:
     fast-json-stable-stringify "^2.1.0"
 
 "taskcluster-lib-testing@link:libraries/testing":
-  version "43.2.0"
+  version "0.0.0"
+  uid ""
 
 taskcluster-lib-urls@^13.0.0:
   version "13.0.1"
@@ -6419,7 +6418,8 @@ taskcluster-lib-urls@^13.0.0:
   integrity sha512-WrhKMbiWmpPrB0vbzLZq4W35mhdPVLklZY+qrBoI7KQzFAjO/qsgS8ssHL6eYmvBf4fE7C+C9ZFxQpQOUynQvg==
 
 "taskcluster-lib-validate@link:libraries/validate":
-  version "43.2.0"
+  version "0.0.0"
+  uid ""
 
 temporary@^1.0.0:
   version "1.1.0"


### PR DESCRIPTION
This avoids issues with errors that have helpful details like an HTTP
request attached.  In practice, most error logging contains only
top-level strings, so this should not be a problem.

<!-- Did you remember to add a changelog snippet? See
     https://github.com/taskcluster/taskcluster/blob/main/dev-docs/best-practices/changelog.md

     If this is related to a Bugzilla bug, please begin your title with [Bug XXXXX]
     and update this link.  Otherwise, just remove it from your PR comment.  -->

Bugzilla Bug: [XXXXX](https://bugzilla.mozilla.org/show_bug.cgi?id=XXXXX)

<!-- If this is related to a GitHub Bug/Issue, Please write Issue Number after # in the next line. Otherwise, just remove it from your PR comment. -->

Github Bug/Issue: Fixes #4807
