### PR TITLE
Bug 1711612 - fix queue.createArtifact's idempotency

### DIFF
--- a/changelog/bug-1711612.md
+++ b/changelog/bug-1711612.md
@@ -1,0 +1,5 @@
+audience: users
+level: patch
+reference: bug 1711612
+---
+Retried calls to `queue.createArtifact` will now work correctly, allowing both retries and the documented updates.


### PR DESCRIPTION
The existing `ok = ok && ..` was completely bogus.  When in doubt,
factor into a function and test it within an inch of its life.

Github Bug/Issue: Fixes #1711612