### PR TITLE
Bug 1711921 - remove superfluous `/` in docker-worker artifact names

### DIFF
--- a/changelog/bug-1711921.md
+++ b/changelog/bug-1711921.md
@@ -1,0 +1,5 @@
+audience: users
+level: patch
+reference: bug 1711921
+---
+When a docker-worker's payload specifies an artifact name ending with `/`, it has historically produced an artifact containing `//`.  That is now normalized to a single `/`.

--- a/workers/docker-worker/src/features/artifacts.js
+++ b/workers/docker-worker/src/features/artifacts.js
@@ -79,7 +79,9 @@ class Artifacts {
       let entryPath = header.name.split('/');
       entryPath.shift();
       if (entryPath.length && entryPath[0]) {
-        entryName += '/' + entryPath.join('/');
+        // the trimEnd here avoids superfluous `/` when the artifact key in the
+        // task payload contains a trailing `/`.
+        entryName = entryName.trimEnd('/') + '/' + entryPath.join('/');
       }
 
       // The first item in the tar should always match the intended artifact


### PR DESCRIPTION
Bugzilla Bug: [1711921](https://bugzilla.mozilla.org/show_bug.cgi?id=1711921)
