### PR TITLE
Support serializing / deserializing creds in rust client

### DIFF
--- a/changelog/issue-4889.md
+++ b/changelog/issue-4889.md
@@ -1,0 +1,4 @@
+audience: general
+level: silent
+reference: issue 4889
+---


### PR DESCRIPTION
This is useful since API methods often pass credentials around.

Github Bug/Issue: Fixes #4889 
