### PR TITLE
send content-length: 0 for empty-bodied requests

### DIFF
--- a/changelog/issue-4890.md
+++ b/changelog/issue-4890.md
@@ -1,0 +1,5 @@
+audience: users
+level: patch
+reference: issue 4890
+---
+This version fixes a bug in the rust client where API methods with method POST but without a request payload would result in 411 errors due to a missing Content-Length header.

--- a/clients/client-rust/client/src/client.rs
+++ b/clients/client-rust/client/src/client.rs
@@ -318,7 +318,14 @@ impl Client {
 
         let meth = reqwest::Method::from_str(method)?;
 
-        let req = self.client.request(meth, url);
+        let mut req = self.client.request(meth, url);
+
+        // pass content-length: 0 if there is no body.  This is implicit for GET requests,
+        // but not for methods that typically have a body.  Most other HTTP clients do this
+        // automatically!
+        if body.is_none() {
+            req = req.header("Content-Length", "0");
+        }
 
         let req = match body {
             Some(b) => req.json(&b),

--- a/clients/client-rust/integration_tests/tests/against_real_deployment.rs
+++ b/clients/client-rust/integration_tests/tests/against_real_deployment.rs
@@ -55,6 +55,24 @@ async fn test_no_such_client() -> Result<()> {
     Ok(())
 }
 
+/// Test that a POST request with no payload doesn't give a 411 (#4890).
+#[tokio::test]
+async fn test_empty_post() -> Result<()> {
+    if let Some(root_url) = get_root_url() {
+        let auth = Auth::new(ClientBuilder::new(&root_url))?;
+        let res = auth.resetAccessToken("no/such/client/for/rust/tests").await;
+        let status_code = err_status_code(&res.err().unwrap());
+
+        // if we had no credentials, this should be FORBIDDEN, but in case the credentials were
+        // valid it will return 404.  Anything else is not good!
+        if status_code != Some(StatusCode::NOT_FOUND) && status_code != Some(StatusCode::FORBIDDEN)
+        {
+            panic!("Got unexpected status code {:?}", status_code);
+        }
+    }
+    Ok(())
+}
+
 /// Test a call with a query
 #[tokio::test]
 async fn test_auth_list_clients_paginated() -> Result<()> {


### PR DESCRIPTION
Github Bug/Issue: Fixes #4890
