### PR TITLE
Recreate postgres users in `yarn dev:init`

### DIFF
--- a/changelog/bNGK5OD7RqyIBnEpkgeamA.md
+++ b/changelog/bNGK5OD7RqyIBnEpkgeamA.md
@@ -1,0 +1,4 @@
+audience: developers
+level: silent
+---
+When running `yarn dev:init`, delete any existing accounts before creating them.

--- a/infrastructure/tooling/src/dev/postgres.js
+++ b/infrastructure/tooling/src/dev/postgres.js
@@ -131,9 +131,10 @@ const postgresResources = async ({ userConfig, answer, configTmpl }) => {
         username, password,
         dbname: dbName,
       });
-      console.log(`Creating DB user ${username}`);
+      console.log(`(Re)creating DB user ${username}`);
       // this is all user-generated content without `'`, so including it literally
       // in the SQL is OK
+      await client.query(`drop user if exists ${username}`);
       await client.query(`create user ${username} password '${password}'`);
       userConfig[serviceName].read_db_url = url;
       userConfig[serviceName].write_db_url = url;


### PR DESCRIPTION
When running `yarn dev:init`, drop any existing postgres user accounts before (re-)creating them.