### PR TITLE
Move RabbitMQ management URL in dev-config.yml

### DIFF
--- a/changelog/issue-4934.md
+++ b/changelog/issue-4934.md
@@ -1,0 +1,9 @@
+audience: developers
+level: patch
+reference: issue 4934
+---
+When running ``yarn dev:init``, store the RabbitMQ cluster management API
+origin at ``meta.rabbitAdminManagementOrigin`` rather than the root key
+``rabbitAdminManagementOrigin``.  This avoids a schema validation error when
+running ``yarn dev:apply``. If you've already run ``yarn dev:init``, then you
+can manually move ``rabbitAdminManagementOrigin`` in ``dev-config.yml``.

--- a/infrastructure/tooling/src/dev/rabbit.js
+++ b/infrastructure/tooling/src/dev/rabbit.js
@@ -64,7 +64,7 @@ const rabbitPrompts = ({ userConfig, prompts, configTmpl }) => {
     type: 'input',
     when: () => setupNeeded.length,
     default: () => userConfig.pulseHostname ? `https://${userConfig.pulseHostname}` : '',
-    name: 'rabbitAdminManagementOrigin',
+    name: 'meta.rabbitAdminManagementOrigin',
     message: 'Now the origin of the management API for that RabbitMQ cluster (http? different port?).',
   });
 };
@@ -82,7 +82,7 @@ const rabbitResources = async ({ userConfig, answer, configTmpl }) => {
   // remove it from the answers
   delete answer.rabbitAdminPassword;
 
-  const apiUrl = `${answer.rabbitAdminManagementOrigin || userConfig.rabbitAdminManagementOrigin}/api`;
+  const apiUrl = `${answer.meta?.rabbitAdminManagementOrigin || userConfig.meta?.rabbitAdminManagementOrigin}/api`;
   const agent = request.agent().auth(answer.meta?.rabbitAdminUser, rabbitAdminPassword).type('json');
   const vhost = answer.pulseVhost || userConfig.pulseVhost;
   console.log(`(Re-)creating RabbitMQ vhost ${vhost}`);


### PR DESCRIPTION
When running ``yarn dev:init``, place the RabbitMQ admin management origin (like ``https://rabbitmq.hostname.com``) at the key ``meta.rabbitAdminManagementOrigin``, rather than at the root key ``rabbitAdminManagementOrigin``. This avoids a schema validation failure when later running ``yarn dev:apply``.

If a user has already run ``yarn dev:init`` successfully, then they will need to manually update ``dev-config.yml``.

Fixes #4934, at least for future devs.
