### PR TITLE
[client-py] remove asyncclient retry debug log

### DIFF
--- a/changelog/issue-4944.md
+++ b/changelog/issue-4944.md
@@ -1,0 +1,4 @@
+audience: general
+level: silent
+reference: issue 4944
+---

--- a/clients/client-py/taskcluster/aio/asyncclient.py
+++ b/clients/client-py/taskcluster/aio/asyncclient.py
@@ -141,7 +141,6 @@ class AsyncBaseClient(BaseClient):
                 # outside this loop.
                 headers['Content-Type'] = 'application/json'
 
-            log.debug('Making attempt %d', retry)
             try:
                 response = await asyncutils.makeSingleHttpRequest(
                     method, url, payload, headers, session=self.session


### PR DESCRIPTION
This appears to be a copy of this line [1] from the synchronous python
`client.py`. However, in that file, `retry` is an integer tracking which
attempt number we're on [2].

In the `asyncclient`, `retry` is a function [3], and does not format
into a %d. We likely didn't catch this because python logging doesn't
format % strings format % strings unless the log level includes the log
message to output. Because this is in a `log.debug` call and we probably
don't run with debug logging enabled, we haven't caught this issue.

We can rename `retry`, or import it under a different name, or track the
attempt under a different variable name and log that. Removing the
logging line seemed like the most expedient fix.

[1] https://github.com/taskcluster/taskcluster/blob/797867c78082986e0814639b505c5b00eb43d735/clients/client-py/taskcluster/client.py#L489
[2] https://github.com/taskcluster/taskcluster/blob/797867c78082986e0814639b505c5b00eb43d735/clients/client-py/taskcluster/client.py#L458
[3] https://github.com/taskcluster/taskcluster/blob/797867c78082986e0814639b505c5b00eb43d735/clients/client-py/taskcluster/aio/asyncclient.py#L16

Github Bug/Issue: Fixes #4944
