### PR TITLE
Fix check for "no hooks defined" on /hooks

### DIFF
--- a/changelog/issue-4946.md
+++ b/changelog/issue-4946.md
@@ -1,0 +1,5 @@
+audience: admins
+level: patch
+reference: issue 4946
+---
+On the UI page /hooks, fix the "no hooks" detection so that hook groups are displayed.

--- a/ui/src/views/Hooks/ListHooks/index.jsx
+++ b/ui/src/views/Hooks/ListHooks/index.jsx
@@ -141,7 +141,7 @@ export default class ListHooks extends Component {
         {!hookGroups && loading && <Spinner loading />}
         <ErrorPanel fixed error={error} />
         {!loading &&
-          (tree.length ? (
+          (hookGroups.length ? (
             <TreeView
               {...{ expanded, selected }}
               onNodeToggle={this.toggleState('expanded')}


### PR DESCRIPTION
Github Bug/Issue: Fixes #4946 

Follow-on work from PR #4921, which switched to the built-in material-ui/treeview, but always detected that there were no hook defined. 

Screenshot of /hooks page with this PR, against community-tc API:

<img width="899" alt="fixed hooks" src="https://user-images.githubusercontent.com/286017/128547618-13bc9c6e-eeb1-48b6-9553-a5b677fbbeed.png">

