### PR TITLE
Fix two broken links in docs

### DIFF
--- a/changelog/aaOoe-xeS9WD-D1jdIwv2A.md
+++ b/changelog/aaOoe-xeS9WD-D1jdIwv2A.md
@@ -1,0 +1,3 @@
+audience: general
+level: silent
+---

--- a/ui/docs/manual/deploying/README.mdx
+++ b/ui/docs/manual/deploying/README.mdx
@@ -30,8 +30,8 @@ A Taskcluster deployment's configuration comes in the form of a set of Helm "val
 In addition to the sections below, see:
  * [Static Clients](/docs/manual/deploying/static-clients)
  * [Helm Configuration Schema](/docs/manual/deploying/schema)
- * [Anonymous Role](/docs/manual/anonymous-role)
- * [Queue Configuration](/docs/manual/queue-config)
+ * [Anonymous Role](/docs/manual/deploying/anonymous-role)
+ * [Queue Configuration](/docs/manual/deploying/queue-config)
 
 ## Database
 


### PR DESCRIPTION
Saw this when responding in https://bugzilla.mozilla.org/show_bug.cgi?id=1724628#c8
