### PR TITLE
Add note for 44.2.1

### DIFF
--- a/changelog/BfpJ0vR7SNOFBAEU37elaw.md
+++ b/changelog/BfpJ0vR7SNOFBAEU37elaw.md
@@ -1,0 +1,5 @@
+audience: deployers
+level: patch
+---
+No changes. Deployment failed on 44.2.0 due to intermittent network issue.
+<!-- replace this text with your changelog entry.  See dev-docs/best-practices/changelog.md for help writing changelog entries. -->


### PR DESCRIPTION
The release for 44.2.0 failed when uploading the monoimage. Adding a note for the changelog.