### PR TITLE
potential bugfix: #4962

### DIFF
--- a/ui/src/components/RolesTable/index.jsx
+++ b/ui/src/components/RolesTable/index.jsx
@@ -132,29 +132,29 @@ export default class RolesTable extends Component {
         renderRow={({ node: role }) => (
           <TableRow key={role.roleId}>
             <TableCell>
-              <TableCellItem dense button>
-                <Box className={classes.roleContainer}>
-                  <Box className={classes.roleIdContainer}>
-                    <Link to={`/auth/roles/${encodeURIComponent(role.roleId)}`}>
-                      {role.roleId}
-                    </Link>
+              <Link to={`/auth/roles/${encodeURIComponent(role.roleId)}`}>
+                {role.roleId}
+                <TableCellItem dense button>
+                  <Box className={classes.roleContainer}>
+                    <Box className={classes.roleIdContainer}>
+                    </Box>
+                    <Box className={classes.roleLinkContainer}>
+                      <Link
+                        to={`/auth/roles/${encodeURIComponent(role.roleId)}`}
+                        className={classes.roleLinkIcon}>
+                        <LinkIcon size={iconSize} />
+                      </Link>
+                    </Box>
+                    <Button
+                      requiresAuth
+                      tooltipProps={{ title: 'Delete Role' }}
+                      size="small"
+                      onClick={() => onDialogActionOpen(role.roleId)}>
+                      <DeleteIcon size={iconSize} />
+                    </Button>
                   </Box>
-                  <Box className={classes.roleLinkContainer}>
-                    <Link
-                      to={`/auth/roles/${encodeURIComponent(role.roleId)}`}
-                      className={classes.roleLinkIcon}>
-                      <LinkIcon size={iconSize} />
-                    </Link>
-                  </Box>
-                  <Button
-                    requiresAuth
-                    tooltipProps={{ title: 'Delete Role' }}
-                    size="small"
-                    onClick={() => onDialogActionOpen(role.roleId)}>
-                    <DeleteIcon size={iconSize} />
-                  </Button>
-                </Box>
-              </TableCellItem>
+                </TableCellItem>
+              </Link>
             </TableCell>
           </TableRow>
         )}


### PR DESCRIPTION
https://github.com/taskcluster/taskcluster/issues/4962

Github Bug/Issue: Fixes #4962

For the life of me, I could not set up the environment and make the app run locally on my machine. Obviously a bit beyond my abilities and knowledge. Still, here is my potential fix after inspecting both views in browsers and comparing codes.

Compared both views: Roles vs. Task Index - Namespace. Roles being the buggy one.
Roles had the link only inside the last Box, making it effectively only the link for the text, while Namespace had the link right after TableCell, covering the whole button. Moved the Link in RolesTable outwards.

Relevant files:
- RolesTable: https://github.com/taskcluster/taskcluster/blob/main/ui/src/components/RolesTable/index.jsx
- TaskIndex/ListNamespaces: https://github.com/taskcluster/taskcluster/blob/main/ui/src/views/Tasks/TaskIndex/ListNamespaces/index.jsx

Hopefully, I made someones life a bit easier, by at least finding the relevant components.


P.S.: The link icons are useless across all the lists if every item is clickable in itself.


