### PR TITLE
Expand Azure register warning context

### DIFF
--- a/changelog/issue-4999.md
+++ b/changelog/issue-4999.md
@@ -1,10 +1,10 @@
 audience: admins
-level: minor
+level: patch
 reference: issue 4999
 ---
-Add workerPoolId, providerId, and workerId to registration-error-warning
-context, logged from the Azure provider's register() function in
-worker-manager.
+The registration-error-warning, logged from the Azure provider's register()
+function in worker-manager, now includes workerPoolId, providerID, and
+workerID in its context.
 
-Add workerState to the warning context when the state is not REQUESTED,
-to help diagnose registration with an unexpected state.
+When register-error-warning is due to the state not being REQUESTED,
+the workerState is also in the context.

--- a/changelog/issue-4999.md
+++ b/changelog/issue-4999.md
@@ -1,0 +1,10 @@
+audience: admins
+level: minor
+reference: issue 4999
+---
+Add workerPoolId, providerId, and workerId to registration-error-warning
+context, logged from the Azure provider's register() function in
+worker-manager.
+
+Add workerState to the warning context when the state is not REQUESTED,
+to help diagnose registration with an unexpected state.

--- a/generated/references.json
+++ b/generated/references.json
@@ -12390,7 +12390,10 @@
           "description": "Something has tried to register as a worker but failed. This could indicate either a bug\nor that somebody is trying to impersonate a worker.",
           "fields": {
             "error": "Error message from cloud that triggered this",
-            "message": "Description of this error from the taskcluster side"
+            "message": "Description of this error from the taskcluster side",
+            "providerId": "The provider that did the work for this worker pool.",
+            "workerId": "The worker that failed",
+            "workerPoolId": "The worker pool ID"
           },
           "level": "warning",
           "name": "registrationErrorWarning",

--- a/services/worker-manager/src/monitor.js
+++ b/services/worker-manager/src/monitor.js
@@ -169,6 +169,9 @@ MonitorManager.register({
   fields: {
     message: 'Description of this error from the taskcluster side',
     error: 'Error message from cloud that triggered this',
+    workerPoolId: 'The worker pool ID',
+    providerId: 'The provider that did the work for this worker pool.',
+    workerId: 'The worker that failed',
   },
 });
 


### PR DESCRIPTION
Add ``workerPoolId``, ``providerId``, and ``workerId`` to ``registration-error-warning`` context, logged from the Azure provider's ``register()`` function in worker-manager.

Add ``workerState`` to the warning context when the ``state`` is not ``REQUESTED``, to help diagnose registration with an unexpected state.

Github Bug/Issue: #4999 (helps diagnose, doesn't yet fix)
