### PR TITLE
Bug 1635730 - clean up /private/var/folders on macOS multiuser

### DIFF
--- a/changelog/bug-1635730.md
+++ b/changelog/bug-1635730.md
@@ -1,0 +1,5 @@
+audience: worker-deployers
+level: patch
+reference: bug 1635730
+---
+generic-worker multiuser engine running on macOS will now attempt to cleanup /private/var/folders when deleting a task OS user account.

--- a/workers/generic-worker/runtime/runtime_darwin.go
+++ b/workers/generic-worker/runtime/runtime_darwin.go
@@ -44,6 +44,10 @@ func (user *OSUser) CreateNew(okIfExists bool) (err error) {
 }
 
 func DeleteUser(username string) (err error) {
+	err = host.Run("/usr/bin/find", "/private/var/folders", "-user", username, "-delete")
+	if err != nil {
+		log.Printf("WARNING: Error when trying to delete files under /private/var/folders belonging to %v: %v", username, err)
+	}
 	err = host.Run("/bin/bash", "-c", `/usr/bin/sudo dscl . -delete '/Users/`+username+`'`)
 	if err != nil {
 		return fmt.Errorf("Error when trying to delete user account %v: %v", username, err)


### PR DESCRIPTION
Bugzilla Bug: [1635730](https://bugzilla.mozilla.org/show_bug.cgi?id=1635730)

Note, this should be tested on a real macOS worker. It may be that the root user won't have permission to do this cleanup, so the code won't fail if the delete fails, it will simply report the failure.