### PR TITLE
Simpler markdown yaml json

### DIFF
--- a/changelog/bug-1735159.md
+++ b/changelog/bug-1735159.md
@@ -1,0 +1,5 @@
+audience: general
+level: patch
+reference: bug 1735159
+---
+Simplify rendering of markdown/json/yaml content.

--- a/ui/src/components/Code/index.jsx
+++ b/ui/src/components/Code/index.jsx
@@ -40,12 +40,10 @@ export default class Code extends Component {
       ignoreIllegals: true,
     }).value;
 
-    /* eslint-disable react/no-danger */
     return (
       <pre className={classNames(`language-${language}`, className)} {...props}>
-        {code && <code dangerouslySetInnerHTML={{ __html: code }} />}
+        {code && <code>{code}</code>}
       </pre>
     );
-    /* eslint-enable react/no-danger */
   }
 }

--- a/ui/src/components/Markdown/index.jsx
+++ b/ui/src/components/Markdown/index.jsx
@@ -200,16 +200,10 @@ export default class Markdown extends Component {
   render() {
     const { classes, children, className, ...props } = this.props;
 
-    /* eslint-disable react/no-danger */
     return (
-      <span
-        className={classNames(classes.root, className)}
-        dangerouslySetInnerHTML={{
-          __html: markdown.render(children),
-        }}
-        {...props}
-      />
+      <span className={classNames(classes.root, className)} {...props}>
+        {markdown.render(children)}
+      </span>
     );
-    /* eslint-enable react/no-danger */
   }
 }


### PR DESCRIPTION
Bugzilla Bug: [1735159](https://bugzilla.mozilla.org/show_bug.cgi?id=1735159)

Simplifies rendering code for markdown / json / yaml content.