### PR TITLE
[client-py] for `upload_artifact` let `contet` be `bytes` or `str`.

### DIFF
--- a/changelog/issue-5021.md
+++ b/changelog/issue-5021.md
@@ -1,0 +1,5 @@
+audience: developers
+level: minor
+reference: issue 5021
+---
+for `upload_artifact` from `client-py` let `contet` be `bytes` or `str`.

--- a/clients/client-py/taskcluster/helper.py
+++ b/clients/client-py/taskcluster/helper.py
@@ -154,7 +154,8 @@ def upload_artifact(queue_service, artifact_path, content, content_type, ttl):
     run_id = os.environ.get("RUN_ID")
     proxy = os.environ.get("TASKCLUSTER_PROXY_URL")
     assert task_id and run_id and proxy, "Can only run in Taskcluster tasks with proxy"
-    assert isinstance(content, str)
+    # Contet can be str or bytes
+    assert isinstance(content, str) or isinstance(content, bytes)
     assert isinstance(ttl, datetime.timedelta)
 
     # Create S3 artifact on Taskcluster


### PR DESCRIPTION
As discussed on the matrix `taskcluster` channel we should also be able to send bytes.
Closes #5022
