### PR TITLE
Fix rust client version number (caused by #5028)

### DIFF
--- a/changelog/AJArSGy7RO--XMAKDZoduQ.md
+++ b/changelog/AJArSGy7RO--XMAKDZoduQ.md
@@ -1,0 +1,3 @@
+audience: general
+level: silent
+---

--- a/clients/client-rust/Cargo.lock
+++ b/clients/client-rust/Cargo.lock
@@ -1275,7 +1275,7 @@ dependencies = [
 
 [[package]]
 name = "taskcluster"
-version = "44.2.2"
+version = "44.3.0"
 dependencies = [
  "anyhow",
  "backoff",
@@ -1295,7 +1295,7 @@ dependencies = [
 
 [[package]]
 name = "taskcluster-download"
-version = "44.2.2"
+version = "44.3.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1329,7 +1329,7 @@ dependencies = [
 
 [[package]]
 name = "taskcluster-upload"
-version = "44.2.2"
+version = "44.3.0"
 dependencies = [
  "anyhow",
  "async-trait",


### PR DESCRIPTION
This is an immediate fix to the broken state that `yarn release` left the repo in. Issue #5028 separately needs to be fixed to prevent this happening in future releases too, but this PR does not fix that.