### PR TITLE
Add `imagePullSecrets` to all helm charts that pull a docker containers

### DIFF
--- a/changelog/Pn46CTBsQ-qH-pKCgUC-mg.md
+++ b/changelog/Pn46CTBsQ-qH-pKCgUC-mg.md
@@ -1,0 +1,4 @@
+audience: deployers
+level: minor
+---
+Added `imagePullSecrets` to the helm chart configuration to allow private docker repositories for deployment

--- a/infrastructure/k8s/templates/taskcluster-auth-cron-purgeExpiredClients.yaml
+++ b/infrastructure/k8s/templates/taskcluster-auth-cron-purgeExpiredClients.yaml
@@ -19,6 +19,10 @@ spec:
         metadata:
           labels: *ref_0
         spec:
+        {{- with.Values.imagePullSecrets }}
+          imagePullSecrets:
+            {{- toYaml . | nindent 12 }}
+        {{- end }}
           restartPolicy: OnFailure
           containers:
             - name: taskcluster-auth-purgeexpiredclients

--- a/infrastructure/k8s/templates/taskcluster-auth-deployment-web.yaml
+++ b/infrastructure/k8s/templates/taskcluster-auth-deployment-web.yaml
@@ -17,6 +17,10 @@ spec:
         checksum/secret: '{{ include (print $.Template.BasePath "/taskcluster-auth-secret.yaml") . | sha256sum }}'
       labels: *ref_0
     spec:
+    {{- with.Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
       serviceAccountName: taskcluster-auth
       containers:
         - name: taskcluster-auth-web

--- a/infrastructure/k8s/templates/taskcluster-built-in-workers-deployment-server.yaml
+++ b/infrastructure/k8s/templates/taskcluster-built-in-workers-deployment-server.yaml
@@ -17,6 +17,10 @@ spec:
         checksum/secret: '{{ include (print $.Template.BasePath "/taskcluster-built-in-workers-secret.yaml") . | sha256sum }}'
       labels: *ref_0
     spec:
+    {{- with.Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
       serviceAccountName: taskcluster-built-in-workers
       containers:
         - name: taskcluster-built-in-workers-server

--- a/infrastructure/k8s/templates/taskcluster-github-cron-sync.yaml
+++ b/infrastructure/k8s/templates/taskcluster-github-cron-sync.yaml
@@ -19,6 +19,10 @@ spec:
         metadata:
           labels: *ref_0
         spec:
+        {{- with.Values.imagePullSecrets }}
+          imagePullSecrets:
+            {{- toYaml . | nindent 12 }}
+        {{- end }}
           restartPolicy: OnFailure
           containers:
             - name: taskcluster-github-sync

--- a/infrastructure/k8s/templates/taskcluster-github-deployment-web.yaml
+++ b/infrastructure/k8s/templates/taskcluster-github-deployment-web.yaml
@@ -17,6 +17,10 @@ spec:
         checksum/secret: '{{ include (print $.Template.BasePath "/taskcluster-github-secret.yaml") . | sha256sum }}'
       labels: *ref_0
     spec:
+    {{- with.Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
       serviceAccountName: taskcluster-github
       containers:
         - name: taskcluster-github-web

--- a/infrastructure/k8s/templates/taskcluster-github-deployment-worker.yaml
+++ b/infrastructure/k8s/templates/taskcluster-github-deployment-worker.yaml
@@ -17,6 +17,10 @@ spec:
         checksum/secret: '{{ include (print $.Template.BasePath "/taskcluster-github-secret.yaml") . | sha256sum }}'
       labels: *ref_0
     spec:
+    {{- with.Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
       serviceAccountName: taskcluster-github
       containers:
         - name: taskcluster-github-worker

--- a/infrastructure/k8s/templates/taskcluster-hooks-cron-expires.yaml
+++ b/infrastructure/k8s/templates/taskcluster-hooks-cron-expires.yaml
@@ -19,6 +19,10 @@ spec:
         metadata:
           labels: *ref_0
         spec:
+        {{- with.Values.imagePullSecrets }}
+          imagePullSecrets:
+            {{- toYaml . | nindent 12 }}
+        {{- end }}
           restartPolicy: OnFailure
           containers:
             - name: taskcluster-hooks-expires

--- a/infrastructure/k8s/templates/taskcluster-hooks-deployment-listeners.yaml
+++ b/infrastructure/k8s/templates/taskcluster-hooks-deployment-listeners.yaml
@@ -17,6 +17,10 @@ spec:
         checksum/secret: '{{ include (print $.Template.BasePath "/taskcluster-hooks-secret.yaml") . | sha256sum }}'
       labels: *ref_0
     spec:
+    {{- with.Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
       serviceAccountName: taskcluster-hooks
       containers:
         - name: taskcluster-hooks-listeners

--- a/infrastructure/k8s/templates/taskcluster-hooks-deployment-scheduler.yaml
+++ b/infrastructure/k8s/templates/taskcluster-hooks-deployment-scheduler.yaml
@@ -17,6 +17,10 @@ spec:
         checksum/secret: '{{ include (print $.Template.BasePath "/taskcluster-hooks-secret.yaml") . | sha256sum }}'
       labels: *ref_0
     spec:
+    {{- with.Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
       serviceAccountName: taskcluster-hooks
       containers:
         - name: taskcluster-hooks-scheduler

--- a/infrastructure/k8s/templates/taskcluster-hooks-deployment-web.yaml
+++ b/infrastructure/k8s/templates/taskcluster-hooks-deployment-web.yaml
@@ -17,6 +17,10 @@ spec:
         checksum/secret: '{{ include (print $.Template.BasePath "/taskcluster-hooks-secret.yaml") . | sha256sum }}'
       labels: *ref_0
     spec:
+      {{- with.Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       serviceAccountName: taskcluster-hooks
       containers:
         - name: taskcluster-hooks-web

--- a/infrastructure/k8s/templates/taskcluster-index-cron-expire.yaml
+++ b/infrastructure/k8s/templates/taskcluster-index-cron-expire.yaml
@@ -19,6 +19,10 @@ spec:
         metadata:
           labels: *ref_0
         spec:
+        {{- with.Values.imagePullSecrets }}
+          imagePullSecrets:
+            {{- toYaml . | nindent 12 }}
+        {{- end }}
           restartPolicy: OnFailure
           containers:
             - name: taskcluster-index-expire

--- a/infrastructure/k8s/templates/taskcluster-index-deployment-handlers.yaml
+++ b/infrastructure/k8s/templates/taskcluster-index-deployment-handlers.yaml
@@ -17,6 +17,10 @@ spec:
         checksum/secret: '{{ include (print $.Template.BasePath "/taskcluster-index-secret.yaml") . | sha256sum }}'
       labels: *ref_0
     spec:
+    {{- with.Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
       serviceAccountName: taskcluster-index
       containers:
         - name: taskcluster-index-handlers

--- a/infrastructure/k8s/templates/taskcluster-index-deployment-web.yaml
+++ b/infrastructure/k8s/templates/taskcluster-index-deployment-web.yaml
@@ -17,6 +17,10 @@ spec:
         checksum/secret: '{{ include (print $.Template.BasePath "/taskcluster-index-secret.yaml") . | sha256sum }}'
       labels: *ref_0
     spec:
+    {{- with.Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
       serviceAccountName: taskcluster-index
       containers:
         - name: taskcluster-index-web

--- a/infrastructure/k8s/templates/taskcluster-notify-deployment-handler.yaml
+++ b/infrastructure/k8s/templates/taskcluster-notify-deployment-handler.yaml
@@ -17,6 +17,10 @@ spec:
         checksum/secret: '{{ include (print $.Template.BasePath "/taskcluster-notify-secret.yaml") . | sha256sum }}'
       labels: *ref_0
     spec:
+    {{- with.Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
       serviceAccountName: taskcluster-notify
       containers:
         - name: taskcluster-notify-handler

--- a/infrastructure/k8s/templates/taskcluster-notify-deployment-web.yaml
+++ b/infrastructure/k8s/templates/taskcluster-notify-deployment-web.yaml
@@ -17,6 +17,10 @@ spec:
         checksum/secret: '{{ include (print $.Template.BasePath "/taskcluster-notify-secret.yaml") . | sha256sum }}'
       labels: *ref_0
     spec:
+    {{- with.Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
       serviceAccountName: taskcluster-notify
       containers:
         - name: taskcluster-notify-web

--- a/infrastructure/k8s/templates/taskcluster-object-cron-expire.yaml
+++ b/infrastructure/k8s/templates/taskcluster-object-cron-expire.yaml
@@ -19,6 +19,10 @@ spec:
         metadata:
           labels: *ref_0
         spec:
+        {{- with.Values.imagePullSecrets }}
+          imagePullSecrets:
+            {{- toYaml . | nindent 12 }}
+        {{- end }}
           restartPolicy: OnFailure
           containers:
             - name: taskcluster-object-expire

--- a/infrastructure/k8s/templates/taskcluster-object-deployment-web.yaml
+++ b/infrastructure/k8s/templates/taskcluster-object-deployment-web.yaml
@@ -17,6 +17,10 @@ spec:
         checksum/secret: '{{ include (print $.Template.BasePath "/taskcluster-object-secret.yaml") . | sha256sum }}'
       labels: *ref_0
     spec:
+    {{- with.Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
       serviceAccountName: taskcluster-object
       containers:
         - name: taskcluster-object-web

--- a/infrastructure/k8s/templates/taskcluster-purge-cache-cron-expireCachePurges.yaml
+++ b/infrastructure/k8s/templates/taskcluster-purge-cache-cron-expireCachePurges.yaml
@@ -19,6 +19,10 @@ spec:
         metadata:
           labels: *ref_0
         spec:
+        {{- with.Values.imagePullSecrets }}
+          imagePullSecrets:
+            {{- toYaml . | nindent 12 }}
+        {{- end }}
           restartPolicy: OnFailure
           containers:
             - name: taskcluster-purge-cache-expirecachepurges

--- a/infrastructure/k8s/templates/taskcluster-purge-cache-deployment-web.yaml
+++ b/infrastructure/k8s/templates/taskcluster-purge-cache-deployment-web.yaml
@@ -17,6 +17,10 @@ spec:
         checksum/secret: '{{ include (print $.Template.BasePath "/taskcluster-purge-cache-secret.yaml") . | sha256sum }}'
       labels: *ref_0
     spec:
+    {{- with.Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
       serviceAccountName: taskcluster-purge-cache
       containers:
         - name: taskcluster-purge-cache-web

--- a/infrastructure/k8s/templates/taskcluster-queue-cron-expireArtifacts.yaml
+++ b/infrastructure/k8s/templates/taskcluster-queue-cron-expireArtifacts.yaml
@@ -19,6 +19,10 @@ spec:
         metadata:
           labels: *ref_0
         spec:
+        {{- with.Values.imagePullSecrets }}
+          imagePullSecrets:
+            {{- toYaml . | nindent 12 }}
+        {{- end }}
           restartPolicy: OnFailure
           containers:
             - name: taskcluster-queue-expireartifacts

--- a/infrastructure/k8s/templates/taskcluster-queue-cron-expireQueueMessages.yaml
+++ b/infrastructure/k8s/templates/taskcluster-queue-cron-expireQueueMessages.yaml
@@ -19,6 +19,10 @@ spec:
         metadata:
           labels: *ref_0
         spec:
+        {{- with.Values.imagePullSecrets }}
+          imagePullSecrets:
+            {{- toYaml . | nindent 12 }}
+        {{- end }}
           restartPolicy: OnFailure
           containers:
             - name: taskcluster-queue-expirequeuemessages

--- a/infrastructure/k8s/templates/taskcluster-queue-cron-expireTask.yaml
+++ b/infrastructure/k8s/templates/taskcluster-queue-cron-expireTask.yaml
@@ -19,6 +19,10 @@ spec:
         metadata:
           labels: *ref_0
         spec:
+        {{- with.Values.imagePullSecrets }}
+          imagePullSecrets:
+            {{- toYaml . | nindent 12 }}
+        {{- end }}
           restartPolicy: OnFailure
           containers:
             - name: taskcluster-queue-expiretask

--- a/infrastructure/k8s/templates/taskcluster-queue-cron-expireTaskDependency.yaml
+++ b/infrastructure/k8s/templates/taskcluster-queue-cron-expireTaskDependency.yaml
@@ -19,6 +19,10 @@ spec:
         metadata:
           labels: *ref_0
         spec:
+        {{- with.Values.imagePullSecrets }}
+          imagePullSecrets:
+            {{- toYaml . | nindent 12 }}
+        {{- end }}
           restartPolicy: OnFailure
           containers:
             - name: taskcluster-queue-expiretaskdependency

--- a/infrastructure/k8s/templates/taskcluster-queue-cron-expireTaskGroups.yaml
+++ b/infrastructure/k8s/templates/taskcluster-queue-cron-expireTaskGroups.yaml
@@ -19,6 +19,10 @@ spec:
         metadata:
           labels: *ref_0
         spec:
+        {{- with.Values.imagePullSecrets }}
+          imagePullSecrets:
+            {{- toYaml . | nindent 12 }}
+        {{- end }}
           restartPolicy: OnFailure
           containers:
             - name: taskcluster-queue-expiretaskgroups

--- a/infrastructure/k8s/templates/taskcluster-queue-cron-expireWorkerInfo.yaml
+++ b/infrastructure/k8s/templates/taskcluster-queue-cron-expireWorkerInfo.yaml
@@ -19,6 +19,10 @@ spec:
         metadata:
           labels: *ref_0
         spec:
+        {{- with.Values.imagePullSecrets }}
+          imagePullSecrets:
+            {{- toYaml . | nindent 12 }}
+        {{- end }}
           restartPolicy: OnFailure
           containers:
             - name: taskcluster-queue-expireworkerinfo

--- a/infrastructure/k8s/templates/taskcluster-queue-deployment-claimResolver.yaml
+++ b/infrastructure/k8s/templates/taskcluster-queue-deployment-claimResolver.yaml
@@ -17,6 +17,10 @@ spec:
         checksum/secret: '{{ include (print $.Template.BasePath "/taskcluster-queue-secret.yaml") . | sha256sum }}'
       labels: *ref_0
     spec:
+    {{- with.Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
       serviceAccountName: taskcluster-queue
       containers:
         - name: taskcluster-queue-claimresolver

--- a/infrastructure/k8s/templates/taskcluster-queue-deployment-deadlineResolver.yaml
+++ b/infrastructure/k8s/templates/taskcluster-queue-deployment-deadlineResolver.yaml
@@ -17,6 +17,10 @@ spec:
         checksum/secret: '{{ include (print $.Template.BasePath "/taskcluster-queue-secret.yaml") . | sha256sum }}'
       labels: *ref_0
     spec:
+    {{- with.Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
       serviceAccountName: taskcluster-queue
       containers:
         - name: taskcluster-queue-deadlineresolver

--- a/infrastructure/k8s/templates/taskcluster-queue-deployment-dependencyResolver.yaml
+++ b/infrastructure/k8s/templates/taskcluster-queue-deployment-dependencyResolver.yaml
@@ -17,6 +17,10 @@ spec:
         checksum/secret: '{{ include (print $.Template.BasePath "/taskcluster-queue-secret.yaml") . | sha256sum }}'
       labels: *ref_0
     spec:
+    {{- with.Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
       serviceAccountName: taskcluster-queue
       containers:
         - name: taskcluster-queue-dependencyresolver

--- a/infrastructure/k8s/templates/taskcluster-queue-deployment-web.yaml
+++ b/infrastructure/k8s/templates/taskcluster-queue-deployment-web.yaml
@@ -17,6 +17,10 @@ spec:
         checksum/secret: '{{ include (print $.Template.BasePath "/taskcluster-queue-secret.yaml") . | sha256sum }}'
       labels: *ref_0
     spec:
+    {{- with.Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
       serviceAccountName: taskcluster-queue
       containers:
         - name: taskcluster-queue-web

--- a/infrastructure/k8s/templates/taskcluster-references-deployment-web.yaml
+++ b/infrastructure/k8s/templates/taskcluster-references-deployment-web.yaml
@@ -17,6 +17,10 @@ spec:
         checksum/secret: '{{ include (print $.Template.BasePath "/taskcluster-references-secret.yaml") . | sha256sum }}'
       labels: *ref_0
     spec:
+    {{- with.Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
       serviceAccountName: taskcluster-references
       containers:
         - name: taskcluster-references-web

--- a/infrastructure/k8s/templates/taskcluster-secrets-cron-expire.yaml
+++ b/infrastructure/k8s/templates/taskcluster-secrets-cron-expire.yaml
@@ -19,6 +19,10 @@ spec:
         metadata:
           labels: *ref_0
         spec:
+        {{- with.Values.imagePullSecrets }}
+          imagePullSecrets:
+            {{- toYaml . | nindent 12 }}
+        {{- end }}
           restartPolicy: OnFailure
           containers:
             - name: taskcluster-secrets-expire

--- a/infrastructure/k8s/templates/taskcluster-secrets-deployment-web.yaml
+++ b/infrastructure/k8s/templates/taskcluster-secrets-deployment-web.yaml
@@ -17,6 +17,10 @@ spec:
         checksum/secret: '{{ include (print $.Template.BasePath "/taskcluster-secrets-secret.yaml") . | sha256sum }}'
       labels: *ref_0
     spec:
+    {{- with.Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
       serviceAccountName: taskcluster-secrets
       containers:
         - name: taskcluster-secrets-web

--- a/infrastructure/k8s/templates/taskcluster-ui-deployment-web.yaml
+++ b/infrastructure/k8s/templates/taskcluster-ui-deployment-web.yaml
@@ -17,6 +17,10 @@ spec:
         checksum/secret: '{{ include (print $.Template.BasePath "/taskcluster-ui-secret.yaml") . | sha256sum }}'
       labels: *ref_0
     spec:
+    {{- with.Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
       serviceAccountName: taskcluster-ui
       containers:
         - name: taskcluster-ui-web

--- a/infrastructure/k8s/templates/taskcluster-web-server-cron-cleanup-expire-access-tokens.yaml
+++ b/infrastructure/k8s/templates/taskcluster-web-server-cron-cleanup-expire-access-tokens.yaml
@@ -19,6 +19,10 @@ spec:
         metadata:
           labels: *ref_0
         spec:
+        {{- with.Values.imagePullSecrets }}
+          imagePullSecrets:
+            {{- toYaml . | nindent 12 }}
+        {{- end }}
           restartPolicy: OnFailure
           containers:
             - name: taskcluster-web-server-cleanup-expire-access-tokens

--- a/infrastructure/k8s/templates/taskcluster-web-server-cron-cleanup-expire-auth-codes.yaml
+++ b/infrastructure/k8s/templates/taskcluster-web-server-cron-cleanup-expire-auth-codes.yaml
@@ -19,6 +19,10 @@ spec:
         metadata:
           labels: *ref_0
         spec:
+        {{- with.Values.imagePullSecrets }}
+          imagePullSecrets:
+            {{- toYaml . | nindent 12 }}
+        {{- end }}
           restartPolicy: OnFailure
           containers:
             - name: taskcluster-web-server-cleanup-expire-auth-codes

--- a/infrastructure/k8s/templates/taskcluster-web-server-cron-scanner.yaml
+++ b/infrastructure/k8s/templates/taskcluster-web-server-cron-scanner.yaml
@@ -19,6 +19,10 @@ spec:
         metadata:
           labels: *ref_0
         spec:
+        {{- with.Values.imagePullSecrets }}
+          imagePullSecrets:
+            {{- toYaml . | nindent 12 }}
+        {{- end }}
           restartPolicy: OnFailure
           containers:
             - name: taskcluster-web-server-scanner

--- a/infrastructure/k8s/templates/taskcluster-web-server-deployment-web.yaml
+++ b/infrastructure/k8s/templates/taskcluster-web-server-deployment-web.yaml
@@ -17,6 +17,10 @@ spec:
         checksum/secret: '{{ include (print $.Template.BasePath "/taskcluster-web-server-secret.yaml") . | sha256sum }}'
       labels: *ref_0
     spec:
+    {{- with.Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
       serviceAccountName: taskcluster-web-server
       containers:
         - name: taskcluster-web-server-web

--- a/infrastructure/k8s/templates/taskcluster-worker-manager-cron-expire-errors.yaml
+++ b/infrastructure/k8s/templates/taskcluster-worker-manager-cron-expire-errors.yaml
@@ -19,6 +19,10 @@ spec:
         metadata:
           labels: *ref_0
         spec:
+        {{- with.Values.imagePullSecrets }}
+          imagePullSecrets:
+            {{- toYaml . | nindent 12 }}
+        {{- end }}
           restartPolicy: OnFailure
           containers:
             - name: taskcluster-worker-manager-expire-errors

--- a/infrastructure/k8s/templates/taskcluster-worker-manager-cron-expire-worker-pools.yaml
+++ b/infrastructure/k8s/templates/taskcluster-worker-manager-cron-expire-worker-pools.yaml
@@ -19,6 +19,10 @@ spec:
         metadata:
           labels: *ref_0
         spec:
+        {{- with.Values.imagePullSecrets }}
+          imagePullSecrets:
+            {{- toYaml . | nindent 12 }}
+        {{- end }}
           restartPolicy: OnFailure
           containers:
             - name: taskcluster-worker-manager-expire-worker-pools

--- a/infrastructure/k8s/templates/taskcluster-worker-manager-cron-expire-workers.yaml
+++ b/infrastructure/k8s/templates/taskcluster-worker-manager-cron-expire-workers.yaml
@@ -19,6 +19,10 @@ spec:
         metadata:
           labels: *ref_0
         spec:
+        {{- with.Values.imagePullSecrets }}
+          imagePullSecrets:
+            {{- toYaml . | nindent 12 }}
+        {{- end }}
           restartPolicy: OnFailure
           containers:
             - name: taskcluster-worker-manager-expire-workers

--- a/infrastructure/k8s/templates/taskcluster-worker-manager-deployment-provisioner.yaml
+++ b/infrastructure/k8s/templates/taskcluster-worker-manager-deployment-provisioner.yaml
@@ -17,6 +17,10 @@ spec:
         checksum/secret: '{{ include (print $.Template.BasePath "/taskcluster-worker-manager-secret.yaml") . | sha256sum }}'
       labels: *ref_0
     spec:
+    {{- with.Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
       serviceAccountName: taskcluster-worker-manager
       containers:
         - name: taskcluster-worker-manager-provisioner

--- a/infrastructure/k8s/templates/taskcluster-worker-manager-deployment-web.yaml
+++ b/infrastructure/k8s/templates/taskcluster-worker-manager-deployment-web.yaml
@@ -17,6 +17,10 @@ spec:
         checksum/secret: '{{ include (print $.Template.BasePath "/taskcluster-worker-manager-secret.yaml") . | sha256sum }}'
       labels: *ref_0
     spec:
+    {{- with.Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
       serviceAccountName: taskcluster-worker-manager
       containers:
         - name: taskcluster-worker-manager-web

--- a/infrastructure/k8s/templates/taskcluster-worker-manager-deployment-workerscanner.yaml
+++ b/infrastructure/k8s/templates/taskcluster-worker-manager-deployment-workerscanner.yaml
@@ -17,6 +17,10 @@ spec:
         checksum/secret: '{{ include (print $.Template.BasePath "/taskcluster-worker-manager-secret.yaml") . | sha256sum }}'
       labels: *ref_0
     spec:
+    {{- with.Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
       serviceAccountName: taskcluster-worker-manager
       containers:
         - name: taskcluster-worker-manager-workerscanner

--- a/infrastructure/k8s/values.schema.json
+++ b/infrastructure/k8s/values.schema.json
@@ -7,6 +7,10 @@
       "description": "The name of this deployment of Taskcluster.",
       "type": "string"
     },
+    "imagePullSecrets": {
+      "description": "Secrets to get the docker image",
+      "type": "array"
+    },
     "auth": {
       "additionalProperties": false,
       "properties": {

--- a/infrastructure/k8s/values.yaml
+++ b/infrastructure/k8s/values.yaml
@@ -1,4 +1,5 @@
 dockerImage: taskcluster/taskcluster:v44.4.0
+imagePullSecrets: []
 trustProxy: true
 forceSSL: false
 nodeEnv: production


### PR DESCRIPTION
This allows using a private docker repository with the helm chart.

