### PR TITLE
Fix styling of label on GitHub Quickstart Page

### DIFF
--- a/changelog/XxH2bNQ-TcuEpA4qOxk07w.md
+++ b/changelog/XxH2bNQ-TcuEpA4qOxk07w.md
@@ -1,0 +1,3 @@
+audience: general
+level: silent
+---

--- a/ui/src/views/Quickstart/index.jsx
+++ b/ui/src/views/Quickstart/index.jsx
@@ -473,7 +473,7 @@ export default class QuickStart extends Component {
             </ListItem>
             <ListItem>
               <FormControl component="fieldset">
-                <FormLabel component="legend">
+                <FormLabel component="legend" focused={false}>
                   This task should run on
                 </FormLabel>
                 <div className={classes.taskShouldRunFlex}>


### PR DESCRIPTION
## Before

* Visit https://community-tc.services.mozilla.com/quickstart

<img width="623" alt="Screen Shot 2022-01-21 at 11 00 44 AM" src="https://user-images.githubusercontent.com/92693437/150559260-7a903a5f-1f4b-487b-8bcc-75f90877d607.png">

* Select/De-select any of the checkbox options show
* Observe label becomes nearly unreadable due to styling change

<img width="623" alt="Screen Shot 2022-01-21 at 11 03 37 AM" src="https://user-images.githubusercontent.com/92693437/150559693-f547694f-6bc4-4f9d-9cbb-722385876fa4.png">

## After

* Label does not change style anymore when checkboxes are clicked