### PR TITLE
Bump taskgraph code and image

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -7,7 +7,7 @@ tasks:
     - $let:
           taskgraph:
               branch: taskgraph
-              revision: cab4565345d0d0effa66f18fe91335dd6d744031
+              revision: cb3ae27ca34714e8d94b700bfb6b2166a7d4e15e
           trustDomain: taskcluster
       in:
           $let:
@@ -138,7 +138,7 @@ tasks:
                       # Note: This task is built server side without the context or tooling that
                       # exist in tree so we must hard code the hash
                       image:
-                          mozillareleases/taskgraph:decision-d9fab4448ee5e00b0a29825c3f0609af957279daf102547d715414782710ef06
+                          mozillareleases/taskgraph:decision-e035c4bb24e3a05bcd666518756aa69fac302ed1e73fd39d39cd182fc4470818
 
                       maxRunTime: 600
 
@@ -151,8 +151,8 @@ tasks:
                           - bash
                           - -cx
                           - >
-                            PIP_IGNORE_INSTALLED=0 pip install --user /builds/worker/checkouts/taskgraph &&
-                            PIP_IGNORE_INSTALLED=0 pip install --user arrow taskcluster pyyaml &&
+                            PIP_IGNORE_INSTALLED=0 pip3 install --user /builds/worker/checkouts/taskgraph &&
+                            PIP_IGNORE_INSTALLED=0 pip3 install --user arrow taskcluster pyyaml &&
                             ln -s /builds/worker/artifacts artifacts &&
                             ~/.local/bin/taskgraph decision
                             --pushlog-id='0'

--- a/changelog/issue-5070.md
+++ b/changelog/issue-5070.md
@@ -6,3 +6,5 @@ The CI tasks now use the latest versions of the taskgraph code (cb3ae27,
 committed 2022-01-19) and the mozillareleases/taskgraph image (e035c4bb, pushed
 2021-07-19), as well as pip3, to ensure Python 3 instead of
 Python 2.7 is used.
+
+taskcluster/src/*.py has been (partially?) converted to Python 3.

--- a/changelog/issue-5070.md
+++ b/changelog/issue-5070.md
@@ -1,0 +1,8 @@
+audience: developers
+level: patch
+reference: issue 5070
+---
+The CI tasks now use the latest versions of the taskgraph code (cb3ae27,
+committed 2022-01-19) and the mozillareleases/taskgraph image (e035c4bb, pushed
+2021-07-19), as well as pip3, to ensure Python 3 instead of
+Python 2.7 is used.

--- a/changelog/issue-5070.md
+++ b/changelog/issue-5070.md
@@ -1,5 +1,5 @@
 audience: developers
-level: patch
+level: silent
 reference: issue 5070
 ---
 The CI tasks now use the latest versions of the taskgraph code (cb3ae27,

--- a/taskcluster/src/job.py
+++ b/taskcluster/src/job.py
@@ -5,8 +5,8 @@ from voluptuous import Required, Optional, Extra, Any
 
 bare_schema = Schema({
     Required("using"): "bare",
-    Required("command"): Any(basestring, [basestring]),
-    Optional("install"): Any(basestring, [basestring]),
+    Required("command"): Any(str, [str]),
+    Optional("install"): Any(str, [str]),
     Optional("clone"): bool,
     Extra: object
     })

--- a/taskcluster/src/loader/__init__.py
+++ b/taskcluster/src/loader/__init__.py
@@ -1,6 +1,5 @@
 import logging
-
-from pathlib2 import Path
+from pathlib import Path
 
 from taskgraph.util.templates import merge
 

--- a/taskcluster/src/target_tasks.py
+++ b/taskcluster/src/target_tasks.py
@@ -13,4 +13,4 @@ def target_tasks_taskcluster_branches(full_task_graph, parameters, graph_config)
     def filter(task):
         return standard_filter(task, parameters) and task.attributes.get("only-on", "all") == only_on
 
-    return [label for label, t in full_task_graph.tasks.iteritems() if filter(t)]
+    return [label for label, t in full_task_graph.tasks.items() if filter(t)]

--- a/taskcluster/src/transforms/__init__.py
+++ b/taskcluster/src/transforms/__init__.py
@@ -22,7 +22,7 @@ def taskcluster_images(config, jobs):
     node_version, go_version, rust_version, pg_version = _dependency_versions()
     for job in jobs:
         image = job["worker"]["docker-image"]
-        if isinstance(image, dict) and image.keys()[0] == "taskcluster":
+        if isinstance(image, dict) and tuple(image.keys())[0] == "taskcluster":
             repo = image["taskcluster"]
             if (repo == "ci-image"):
                 image = "taskcluster/ci-image:node{node_version}-pg{pg_version}-{go_version}"


### PR DESCRIPTION
Use the latest version of the [taskgraph code](https://hg.mozilla.org/ci/taskgraph) and the [mozillareleases/taskgraph images](https://hub.docker.com/r/mozillareleases/taskgraph/tags):

* taskgraph cb3ae27 - commited 2022-01-19
* mozillareleases/taskgraph e035c4bb - pushed 2021-07-19

Additionally:
* Specify pip3 to ensure the Python 3 version runs.
* Update `taskcluster/src` to Python 3

Fixes #5070
