### PR TITLE
Update nginx config path

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -62,7 +62,7 @@ RUN rm -rf ui/node_modules ui/src
 # build the final image
 
 FROM node:16.14.0-alpine as image
-RUN apk --no-cache add --update  nginx bash
+RUN apk --no-cache add --update nginx bash
 COPY --from=build /base/app /app
 ENV HOME=/app
 WORKDIR /app

--- a/changelog/bC1vCkgnREWrPpkpqu-dgA.md
+++ b/changelog/bC1vCkgnREWrPpkpqu-dgA.md
@@ -1,0 +1,5 @@
+audience: general
+level: patch
+---
+Updated nginx user config location due to node LTS upgrade changing paths from `/etc/nginx/conf.d/default.conf` to `/etc/nginx/http.d/default.conf`.
+Also, added `__heartbeat__` config back to `nginx.conf` to continue to serve 200s until work in https://github.com/taskcluster/taskcluster/issues/4597 is complete.

--- a/infrastructure/references/nginx.conf
+++ b/infrastructure/references/nginx.conf
@@ -40,6 +40,11 @@ server {
     try_files $uri @rewrites;
   }
 
+  location = /__heartbeat__ {
+    default_type application/json;
+    return 200 "{}";
+  }
+
   location = /__lbheartbeat__ {
     default_type application/json;
     return 200 "{}";

--- a/infrastructure/references/references.sh
+++ b/infrastructure/references/references.sh
@@ -7,5 +7,5 @@ cd /app
 node infrastructure/references/relativize generated/references.json /references
 
 # start nginx
-cp infrastructure/references/nginx.conf /etc/nginx/conf.d/default.conf
+cp infrastructure/references/nginx.conf /etc/nginx/http.d/default.conf
 exec nginx -g 'daemon off;'

--- a/ui/web-ui-nginx-site.conf
+++ b/ui/web-ui-nginx-site.conf
@@ -48,6 +48,11 @@ http {
         try_files $uri @rewrites;
       }
 
+      location = /__heartbeat__ {
+        default_type application/json;
+        return 200 "{}";
+      }
+
       location = /__lbheartbeat__ {
         default_type application/json;
         return 200 "{}";

--- a/ui/web-ui-nginx-site.conf
+++ b/ui/web-ui-nginx-site.conf
@@ -1,7 +1,7 @@
 user  nginx;
 worker_processes  1;
 
-error_log  /var/log/nginx/error.log warn;
+error_log  stderr;
 pid        /var/run/nginx.pid;
 
 
@@ -18,7 +18,7 @@ http {
                       '$status $body_bytes_sent "$http_referer" '
                       '"$http_user_agent" "$http_x_forwarded_for"';
 
-    access_log  /var/log/nginx/access.log  main;
+    access_log  /dev/stdout  main;
 
     sendfile        on;
 


### PR DESCRIPTION
Updated nginx user config location due to node LTS upgrade changing paths from `/etc/nginx/conf.d/default.conf` to `/etc/nginx/http.d/default.conf`.

Also, added `__heartbeat__` config back to `nginx.conf` to continue to serve 200s until work in https://github.com/taskcluster/taskcluster/issues/4597 is complete.

Previous image (`node:14.17.5-alpine`) used alpine v3.11.11, while new image (`node:16.14.0-alpine`) uses alpine v3.15.0.

In [alpine v3.14.0](https://alpinelinux.org/posts/Alpine-3.14.0-released.html), you'll see this changelog:
> NGINX package changed the default directory for the vhost configs from /etc/nginx/conf.d to /etc/nginx/http.d

More info [here](https://gitlab.alpinelinux.org/alpine/aports/-/commit/383ba9c0a200ed1f4b11d7db74207526ad90bbe3).