### PR TITLE
Remove unneeded nginx config

### DIFF
--- a/changelog/AS6MhZGnRdW8zamjRloJdw.md
+++ b/changelog/AS6MhZGnRdW8zamjRloJdw.md
@@ -1,0 +1,4 @@
+audience: general
+level: patch
+---
+Remove unneeded nginx config, `tcp_nopush` as it's already set in the default config by nginx.

--- a/infrastructure/references/nginx.conf
+++ b/infrastructure/references/nginx.conf
@@ -1,6 +1,5 @@
 charset utf-8;
 
-tcp_nopush on;
 client_header_timeout 10s;
 client_body_timeout 10s;
 reset_timedout_connection on;


### PR DESCRIPTION
nginx is failing to startup with error: `nginx: [emerg] "tcp_nopush" directive is duplicate in /etc/nginx/http.d/default.conf:3`

I tested this change locally and there are no more duplicates between the default config nginx ships with and our custom config.