### PR TITLE
Make the whole row clickable in the secrets table

### DIFF
--- a/changelog/issue-5027.md
+++ b/changelog/issue-5027.md
@@ -1,0 +1,5 @@
+audience: users
+level: patch
+reference: issue 5027
+---
+Clicking on a secret row now works outside of the text part as well

--- a/ui/src/components/SecretsTable/index.jsx
+++ b/ui/src/components/SecretsTable/index.jsx
@@ -40,6 +40,9 @@ const iconSize = 16;
   secretIdContainer: {
     flexGrow: 1,
   },
+  nameLink: {
+    display: 'flex',
+  },
 }))
 /**
  * Display secrets in a table.
@@ -144,7 +147,9 @@ export default class SecretsTable extends Component {
               <TableCellItem dense button>
                 <Box className={classes.secretContainer}>
                   <Box className={classes.secretIdContainer}>
-                    <Link to={`/secrets/${encodeURIComponent(name)}`}>
+                    <Link
+                      className={classes.nameLink}
+                      to={`/secrets/${encodeURIComponent(name)}`}>
                       {name}
                     </Link>
                   </Box>


### PR DESCRIPTION
Fixes #5027