### PR TITLE
Fix UI tests by mocking the date in the TaskDetailsCard snapshot test

### DIFF
--- a/changelog/SVPvge_iRTORSeHNGxP0Cw.md
+++ b/changelog/SVPvge_iRTORSeHNGxP0Cw.md
@@ -1,0 +1,3 @@
+audience: developers
+level: silent
+---

--- a/ui/src/components/TaskDetailsCard/index.test.jsx
+++ b/ui/src/components/TaskDetailsCard/index.test.jsx
@@ -3,6 +3,8 @@ import { render } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import TaskDetailsCard from './index';
 
+jest.useFakeTimers('modern').setSystemTime(new Date('2022-02-17').getTime());
+
 it('should render TaskDetailsCard', () => {
   const { asFragment } = render(
     <MemoryRouter keyLength={0}>


### PR DESCRIPTION
There's an `X days ago` in there that would break all the time
otherwise.
