### PR TITLE
Add Copy URL  button for artifacts, rows filtering in tables

### DIFF
--- a/changelog/issue-5181.md
+++ b/changelog/issue-5181.md
@@ -1,0 +1,8 @@
+audience: users
+level: patch
+reference: issue 5181
+---
+
+Added "Copy URL" to the artifacts table.
+
+Added filter row functionality for big tables.

--- a/ui/.neutrinorc.js
+++ b/ui/.neutrinorc.js
@@ -61,9 +61,11 @@ module.exports = {
         proxy: {
           '/login': {
             target: 'http://localhost:3050',
+            changeOrigin: true,
           },
           '/graphql': {
             target: 'http://localhost:3050',
+            changeOrigin: true,
           },
           '/subscription': {
             ws: true,

--- a/ui/src/components/ClientsTable/index.jsx
+++ b/ui/src/components/ClientsTable/index.jsx
@@ -103,6 +103,10 @@ export default class ClientsTable extends Component {
         sortDirection={sortDirection}
         onHeaderClick={this.handleHeaderClick}
         onPageChange={onPageChange}
+        allowFilter
+        filterFunc={({ node: client }, filterValue) =>
+          String(client.clientId).includes(filterValue)
+        }
         renderRow={({ node: client }) => (
           <TableRow key={client.clientId}>
             <TableCell width="100%">

--- a/ui/src/components/RolesTable/index.jsx
+++ b/ui/src/components/RolesTable/index.jsx
@@ -132,6 +132,10 @@ export default class RolesTable extends Component {
         headers={tableHeaders}
         sortByHeader={sortBy}
         sortDirection={sortDirection}
+        allowFilter
+        filterFunc={({ node: role }, filterValue) =>
+          String(role.roleId).includes(filterValue)
+        }
         renderRow={({ node: role }) => (
           <TableRow key={role.roleId}>
             <TableCell>

--- a/ui/src/components/SecretsTable/index.jsx
+++ b/ui/src/components/SecretsTable/index.jsx
@@ -140,6 +140,10 @@ export default class SecretsTable extends Component {
         sortDirection={sortDirection}
         onHeaderClick={this.handleHeaderClick}
         onPageChange={onPageChange}
+        allowFilter
+        filterFunc={({ node: { name } }, filterValue) =>
+          String(name).includes(filterValue)
+        }
         headers={['Secret ID']}
         renderRow={({ node: { name } }) => (
           <TableRow key={name}>

--- a/ui/src/components/TaskDetailsCard/index.jsx
+++ b/ui/src/components/TaskDetailsCard/index.jsx
@@ -328,6 +328,10 @@ export default class TaskDetailsCard extends Component {
                     sortByHeader={null}
                     sortDirection="desc"
                     onPageChange={onDependentsPageChange}
+                    allowFilter
+                    filterFunc={({ node: metadata }, filterValue) =>
+                      String(metadata.name).includes(filterValue)
+                    }
                     renderRow={({
                       node: {
                         taskId,

--- a/ui/src/components/WMWorkerPoolsTable/index.jsx
+++ b/ui/src/components/WMWorkerPoolsTable/index.jsx
@@ -296,6 +296,12 @@ export default class WorkerManagerWorkerPoolsTable extends Component {
           onPageChange={onPageChange}
           onHeaderClick={this.handleHeaderClick}
           renderRow={this.renderRow}
+          allowFilter
+          filterFunc={({ node: workerPool }, filterValue) =>
+            String(workerPool.workerPoolId).includes(filterValue) ||
+            String(workerPool.providerId).includes(filterValue) ||
+            String(workerPool.owner).includes(filterValue)
+          }
         />
         <DialogAction
           open={open}


### PR DESCRIPTION
Resolves #5181

- [x] Adds "Copy" button to copy artifact url without `bewit` parameter
- [x] Adds "Filter rows" functionality to "long tables"

<img width="686" alt="image" src="https://user-images.githubusercontent.com/83861/155692460-106bb4b5-a2c4-481f-8361-946dd5b0c582.png">

<img width="1409" alt="image" src="https://user-images.githubusercontent.com/83861/155692569-aeb179df-9e05-4e42-841b-6abb82051771.png">



There's a performance issue with the tables itself, which makes filtering slower. Will be addressed in #5179 