### PR TITLE
fix(ui): Pagination and filters shown conditionally

### DIFF
--- a/changelog/issue-5247.md
+++ b/changelog/issue-5247.md
@@ -1,0 +1,6 @@
+audience: users
+level: patch
+reference: issue 5247
+---
+
+Pagination and filters shown conditionally

--- a/ui/src/components/ConnectionDataTable/index.jsx
+++ b/ui/src/components/ConnectionDataTable/index.jsx
@@ -213,8 +213,16 @@ export default class ConnectionDataTable extends Component {
   };
 
   renderTablePagination = (colSpan, count) => {
-    const { classes, pageSize } = this.props;
+    const { classes, connection, pageSize } = this.props;
     const { loading, page } = this.state;
+
+    if (
+      !connection?.pageInfo?.hasNextPage &&
+      !connection?.pageInfo?.hasPreviousPage
+    ) {
+      // no pagination needed
+      return null;
+    }
 
     if (loading) {
       return (
@@ -268,11 +276,12 @@ export default class ConnectionDataTable extends Component {
       allowFilter && filterFunc
         ? edges.filter(row => filterFunc(row, filterValue))
         : edges;
+    const showFilter = allowFilter && edges.length > 10;
 
     return (
       <Fragment>
         {!withoutTopPagination && this.renderTablePagination(colSpan, count)}
-        {allowFilter && (
+        {showFilter && (
           <TextField
             className={classes.filter}
             hiddenLabel


### PR DESCRIPTION
Pagination not shown when table doesn't have next and previous pages.
Filter is shown when there are more than 10 items in a table.

Fixes #5247 #5246 
