### PR TITLE
Add pre-commit badge

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,3 +27,6 @@ exclude: |
         ^ui/src/components/TaskDetailsCard/__snapshots__/|
         ^services/worker-manager/test/fixtures/
     )
+
+ci:
+    skip: [taskcluster_yml]

--- a/README.md
+++ b/README.md
@@ -22,6 +22,9 @@
   <a href="https://app.netlify.com/sites/taskcluster-web/deploys">
     <img src="https://api.netlify.com/api/v1/badges/bc284a9a-8986-4ba4-b91a-3ede1a56e5a4/deploy-status" alt="netlify" />
   </a>
+  <a href="https://results.pre-commit.ci/latest/github/taskcluster/taskcluster/main">
+    <img src="https://results.pre-commit.ci/badge/github/taskcluster/taskcluster/main.svg" alt="pre-commit" />
+  </a>
 </p>
 
 <hr/>

--- a/changelog/Or0UB2kBRAOKTG4-toN6zw.md
+++ b/changelog/Or0UB2kBRAOKTG4-toN6zw.md
@@ -1,0 +1,3 @@
+audience: general
+level: silent
+---


### PR DESCRIPTION
Also, skip the `taskcluster_yml` hook on ci because it appears outgoing traffic is blocked and it cannot reach the schema to do validations.