### PR TITLE
Fix changelog generation to not include whitespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,12 +16,12 @@ These were added to comply with the [Dockerflow standard](https://github.com/moz
 ▶ [patch] [#5247](https://github.com/taskcluster/taskcluster/issues/5247)
 Pagination and filters shown conditionally
 
-▶ [patch] 
+▶ [patch]
 Fix the badge generation when using the badge API. It now works when deployed through helm too
 
 ### DEVELOPERS
 
-▶ [patch] 
+▶ [patch]
 Introduces `dev:ensure:db` and `dev:ensure:rabbit` commands to ensure postgres and rabbit have necessary user accounts and permissions.
 Updated `dev-deployment.md` with instructions how to set up own rabbitmq/posgres for testing/dev puropses.
 

--- a/changelog/ScVIcRDORtCC1NdlPyhsQQ.md
+++ b/changelog/ScVIcRDORtCC1NdlPyhsQQ.md
@@ -1,0 +1,3 @@
+audience: general
+level: silent
+---

--- a/infrastructure/tooling/src/changelog/index.js
+++ b/infrastructure/tooling/src/changelog/index.js
@@ -161,9 +161,9 @@ class ChangeLog {
     }
 
     const levelLabels = {
-      'major': '[MAJOR] ',
-      'minor': '[minor] ',
-      'patch': '[patch] ',
+      'major': '[MAJOR]',
+      'minor': '[minor]',
+      'patch': '[patch]',
     };
 
     const silent = this.snippets.filter(sn => sn.level === 'silent' && sn.reference);
@@ -194,7 +194,7 @@ class ChangeLog {
         const snippets = categorizedSnippets[audience]
           .map(({ level, reference, body }) => (
             '▶ ' + levelLabels[level] +
-            (reference ? reference : '') + '\n' +
+            (reference ? ' ' + reference : '') + '\n' +
             body.trim()
           ))
           .join('\n\n');


### PR DESCRIPTION
https://github.com/taskcluster/taskcluster/commit/09391656a8e448071121b9226318903c22807315 fails pre-commit ci checks because of whitespace created in the changelog. This removes that from happening again.