### PR TITLE
fix: `Follow Log` enabled by default to automatically load to bottom …

### DIFF
--- a/changelog/issue-5274.md
+++ b/changelog/issue-5274.md
@@ -1,0 +1,5 @@
+audience: users
+level: patch
+reference: issue 5274
+---
+fix: `Follow Log` enabled by default to automatically load to bottom of log file.

--- a/ui/src/components/Log/index.jsx
+++ b/ui/src/components/Log/index.jsx
@@ -162,7 +162,7 @@ export default class Log extends Component {
 
   state = {
     lineNumber: null,
-    follow: null,
+    follow: true,
     followPref: null,
   };
 


### PR DESCRIPTION
Github Bug/Issue: Fixes #5274