### PR TITLE
Fix usage of `temporary.writeFile` in docker worker

### DIFF
--- a/changelog/FmCD7dK1QHu5JV-IfSdRBw.md
+++ b/changelog/FmCD7dK1QHu5JV-IfSdRBw.md
@@ -1,0 +1,4 @@
+audience: developers
+level: patch
+---
+Fix usage of `temporary.writeFile` in `uploadToS3` for docker-worker

--- a/workers/docker-worker/src/upload_to_s3.js
+++ b/workers/docker-worker/src/upload_to_s3.js
@@ -50,7 +50,7 @@ module.exports = async function uploadToS3 (
     // write the source out to a temporary file so that it can be
     // re-read into the request repeatedly
     if (typeof source === 'string') {
-      await tmp.writeFile(source);
+      tmp.writeFileSync(source);
       hash.update(source);
     } else {
       let stream = fs.createWriteStream(tmp.path);


### PR DESCRIPTION
That function called was not an `async` one so awaiting had no effect.
If anyone used that function and was unlucky, they would end up with an
empty tmp file instead of one containing the string.
