### PR TITLE
feat(worker-manager): Azure provider logs extra information

### DIFF
--- a/changelog/issue-4999.md
+++ b/changelog/issue-4999.md
@@ -1,0 +1,4 @@
+audience: general
+level: silent
+reference: issue 4999
+---

--- a/generated/references.json
+++ b/generated/references.json
@@ -12533,6 +12533,7 @@
           "description": "A worker has been requested from a cloud api",
           "fields": {
             "providerId": "The provider that did the work for this worker pool.",
+            "terminateAfter": "Time after which worker should be terminated",
             "workerGroup": "The worker group for this worker",
             "workerId": "The worker that was created",
             "workerPoolId": "The worker pool ID"

--- a/services/worker-manager/src/monitor.js
+++ b/services/worker-manager/src/monitor.js
@@ -25,6 +25,7 @@ MonitorManager.register({
     providerId: 'The provider that did the work for this worker pool.',
     workerGroup: 'The worker group for this worker',
     workerId: 'The worker that was created',
+    terminateAfter: 'Time after which worker should be terminated',
   },
 });
 

--- a/services/worker-manager/src/providers/aws.js
+++ b/services/worker-manager/src/providers/aws.js
@@ -228,6 +228,7 @@ class AwsProvider extends Provider {
           providerId: this.providerId,
           workerGroup: config.region,
           workerId: i.InstanceId,
+          terminateAfter,
         });
         const worker = Worker.fromApi({
           workerPoolId,

--- a/services/worker-manager/src/providers/azure/index.js
+++ b/services/worker-manager/src/providers/azure/index.js
@@ -415,6 +415,7 @@ class AzureProvider extends Provider {
         providerId: this.providerId,
         workerGroup,
         workerId: virtualMachineName,
+        terminateAfter,
       });
       const worker = Worker.fromApi({
         workerPoolId,

--- a/services/worker-manager/src/providers/google.js
+++ b/services/worker-manager/src/providers/google.js
@@ -313,6 +313,7 @@ class GoogleProvider extends Provider {
         providerId: this.providerId,
         workerGroup,
         workerId: op.targetId,
+        terminateAfter,
       });
       const worker = Worker.fromApi({
         workerPoolId,


### PR DESCRIPTION
Required to debug #4999 where worker is being terminated before/during
it is being started.

