### PR TITLE
feat(auth): Proper handling of unicode in profile

### DIFF
--- a/changelog/issue-5282.md
+++ b/changelog/issue-5282.md
@@ -1,0 +1,9 @@
+audience: users
+level: patch
+reference: issue 5282
+---
+
+Fix issue with unicode characters in user profile.
+
+Using Github as oauth provider encodes user profile using base64 encoding,
+which, if contains unicode characters, is not decoded properly by `atob()`.

--- a/ui/src/auth/UserSession.js
+++ b/ui/src/auth/UserSession.js
@@ -1,3 +1,5 @@
+import { b64DecodeUnicode } from '../utils/base64';
+
 /**
  * UserSessions are immutable -- when anything about the session changes,
  * a new instance should replace the old.
@@ -20,7 +22,7 @@ export default class UserSession {
     let { encodedProfile } = options;
 
     if (encodedProfile) {
-      encodedProfile = JSON.parse(atob(encodedProfile));
+      encodedProfile = JSON.parse(b64DecodeUnicode(encodedProfile));
 
       return new UserSession({ ...options, profile: encodedProfile });
     }

--- a/ui/src/auth/UserSession.test.js
+++ b/ui/src/auth/UserSession.test.js
@@ -1,0 +1,33 @@
+import UserSession from './UserSession';
+
+describe('UserSession', () => {
+  it('should create user session', () => {
+    const userSession = UserSession.create({
+      identityProviderId: 'test-provider',
+      encodedProfile:
+        'eyJuYW1lIjoiVMOpc3QgTsOibcOoIiwiZW1haWwiOiJ0ZXN0QG1haWwifQ==',
+    });
+
+    expect(userSession.identityProviderId).toEqual('test-provider');
+    expect(userSession).toHaveProperty('profile');
+    expect(userSession.profile).toHaveProperty('name', 'Tést Nâmè');
+    expect(userSession.profile).toHaveProperty('email', 'test@mail');
+  });
+
+  it('should serialize and deserialize session', () => {
+    const userSession = UserSession.create({
+      identityProviderId: 'test-provider',
+      encodedProfile:
+        'eyJuYW1lIjoiVMOpc3QgTsOibcOoIiwiZW1haWwiOiJ0ZXN0QG1haWwifQ==',
+    });
+    const serialized = userSession.serialize();
+
+    expect(typeof serialized).toBe('string');
+    const deserialized = UserSession.deserialize(serialized);
+
+    expect(deserialized.identityProviderId).toEqual('test-provider');
+    expect(deserialized).toHaveProperty('profile');
+    expect(deserialized.profile).toHaveProperty('name', 'Tést Nâmè');
+    expect(deserialized.profile).toHaveProperty('email', 'test@mail');
+  });
+});

--- a/ui/src/utils/base64.js
+++ b/ui/src/utils/base64.js
@@ -1,0 +1,28 @@
+// eslint-disable-next-line max-len
+// https://stackoverflow.com/questions/30106476/using-javascripts-atob-to-decode-base64-doesnt-properly-decode-utf-8-strings
+// Using atob() with string that contain non-ascii
+// characters will not work as expected
+// We need to additionally decode the string to Unicode characters
+export function b64DecodeUnicode(str) {
+  // Going backwards: from bytestream, to percent-encoding, to original string.
+  return decodeURIComponent(
+    atob(str)
+      .split('')
+      .map(c => `%${`00${c.charCodeAt(0).toString(16)}`.slice(-2)}`)
+      .join('')
+  );
+}
+
+export function b64EncodeUnicode(str) {
+  // first we use encodeURIComponent to get percent-encoded UTF-8,
+  // then we convert the percent encodings into raw bytes which
+  // can be fed into btoa.
+  return btoa(
+    encodeURIComponent(str).replace(/%([0-9A-F]{2})/g, function toSolidBytes(
+      match,
+      p1
+    ) {
+      return String.fromCharCode(`0x${p1}`);
+    })
+  );
+}

--- a/ui/src/utils/base64.test.js
+++ b/ui/src/utils/base64.test.js
@@ -1,0 +1,13 @@
+import { b64DecodeUnicode, b64EncodeUnicode } from './base64';
+
+describe('base64', () => {
+  it('should decode ascii and non-ascii strings', () => {
+    const testWords = ['', 'ū', 'foo', 'ûnicödë', '123-{}-456', 'юникод'];
+
+    testWords.forEach(word => {
+      const encoded = b64EncodeUnicode(word);
+
+      expect(b64DecodeUnicode(encoded)).toEqual(word);
+    });
+  });
+});


### PR DESCRIPTION
Using Github as oauth provider encodes user profile using base64 encoding,
which, if contains unicode characters, is not decoded properly by `atob()`.

Fixes Bug #5282 

<img width="517" alt="image" src="https://user-images.githubusercontent.com/83861/159247234-7665eab1-d749-4a50-a06c-c0663b9ee6bc.png">

