### PR TITLE
Azure provision NIC always

### DIFF
--- a/changelog/issue-4987.md
+++ b/changelog/issue-4987.md
@@ -1,0 +1,6 @@
+audience: worker-deployers
+level: minor
+reference: issue 4987
+---
+
+Skip public network creation for Azure workers that only have generic worker config.

--- a/changelog/issue-4987.md
+++ b/changelog/issue-4987.md
@@ -1,6 +1,7 @@
 audience: worker-deployers
-level: minor
+level: patch
 reference: issue 4987
 ---
 
-Skip public network creation for Azure workers that only have generic worker config.
+Azure cannot create VMs without with Network interface. We create network interface always, but skip provisioning of public IP when it's not needed.
+There might be a case where public IP is needed for RDP though.

--- a/services/worker-manager/test/fakes/schemas/azure-nic.yml
+++ b/services/worker-manager/test/fakes/schemas/azure-nic.yml
@@ -23,7 +23,10 @@ properties:
         publicIPAddress:
           type: object
           properties:
-            id: {type: string}
+            id:
+              oneOf:
+                - {type: string}
+                - {enum: [false]}
           additionalProperties: false
           required: [id]
       additionalProperties: false

--- a/services/worker-manager/test/provider_azure_test.js
+++ b/services/worker-manager/test/provider_azure_test.js
@@ -635,16 +635,21 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       assert(provider.removeWorker.called);
     });
 
-    test('successful provisioning of VM without public network', async function() {
+    test('successful provisioning of VM without public ip', async function() {
       await assertProvisioningState({ ip: 'none', nic: 'none', vm: 'none' });
 
-      worker.providerData.skipPublicNetwork = true;
+      worker.providerData.skipPublicIp = true;
       await provider.provisionResources({ worker, monitor });
-      await assertProvisioningState({ vm: 'inprogress' });
+      await assertProvisioningState({ nic: 'inprogress' });
+
+      debug('NIC creation succeeds');
+      fake.networkClient.networkInterfaces.fakeFinishRequest('rgrp', nicName);
+      await provider.provisionResources({ worker, monitor });
+      await assertProvisioningState({ nic: 'allocated' });
 
       fake.computeClient.virtualMachines.fakeFinishRequest('rgrp', vmName);
       await provider.provisionResources({ worker, monitor });
-      await assertProvisioningState({ vm: 'allocated', ip: 'none', nic: 'none' });
+      await assertProvisioningState({ vm: 'allocated', ip: 'none', nic: 'allocated' });
 
       assert(!provider.removeWorker.called);
     });


### PR DESCRIPTION
Azure cannot launch VM without attached network interface. Public IP should be still optional.
Unless it's needed for RDP