### PR TITLE
Tweak description of task dependents

### DIFF
--- a/changelog/eXGDsq4nRgqskTNEugAbCg.md
+++ b/changelog/eXGDsq4nRgqskTNEugAbCg.md
@@ -1,0 +1,3 @@
+audience: general
+level: silent
+---

--- a/ui/src/components/TaskDetailsCard/index.jsx
+++ b/ui/src/components/TaskDetailsCard/index.jsx
@@ -318,7 +318,7 @@ export default class TaskDetailsCard extends Component {
                   <ListItem>
                     <ListItemText
                       primary="Dependents"
-                      secondary="This task blocks the following tasks from being scheduled."
+                      secondary="The following tasks depend on this task resolving successfully."
                     />
                   </ListItem>
                   <ConnectionDataTable


### PR DESCRIPTION
Minor wording change for description of dependent tasks. Now I've submitted it, I'm not sure it is any better, so it isn't preferred, I'm ok with closing and not merging. My feeling was that the term "blocks" might make it sound like this task prevents the other tasks from being scheduled.