### PR TITLE
fix(github): use checks API to fulfill latest endpoint

### DIFF
--- a/changelog/issue-5364.md
+++ b/changelog/issue-5364.md
@@ -1,0 +1,5 @@
+audience: users
+level: patch
+reference: issue 5364
+---
+The `github/v1/repository/<owner>/<repo>/<branch>/latest` endpoint now supports projects using `checks-v2` reporting.

--- a/services/github/test/api_test.js
+++ b/services/github/test/api_test.js
@@ -119,7 +119,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       repo: 'checksRepo',
       ref: 'success',
       info: [
-        { name: "check1", conclusion: 'success', app: { id: 66666 } },
+        { id: 123, name: "check1", conclusion: 'success', app: { id: 66666 }, repository: { html_url: "https://github.com/abc123/checksRepo" } },
         { name: "check2", conclusion: 'success', app: { id: 66666 } },
         { name: "check3", conclusion: 'failure', app: { id: 12345 } },
       ],
@@ -467,7 +467,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       err => err.code === 'InsufficientScopes');
   });
 
-  test('link for clickable badges', async function() {
+  test('link for clickable badges with status', async function() {
     let res;
 
     await testing.fakeauth.withAnonymousScopes(['github:latest-status:abc123:*'], async () => {
@@ -480,6 +480,22 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
         console.log(`Test for redirecting to correct page failed. Error: ${JSON.stringify(e)}`);
       }
       assert.equal(res.body, 'Found. Redirecting to Wonderland');
+    });
+  });
+
+  test('link for clickable badges with checks', async function() {
+    let res;
+
+    await testing.fakeauth.withAnonymousScopes(['github:latest-status:abc123:*'], async () => {
+      // check if the function returns a correct link
+      try {
+        res = await got(
+          helper.apiClient.buildUrl(helper.apiClient.latest, 'abc123', 'checksRepo', 'success'),
+          { followRedirect: false });
+      } catch (e) {
+        console.log(`Test for redirecting to correct page failed. Error: ${JSON.stringify(e)}`);
+      }
+      assert.equal(res.body, 'Found. Redirecting to https://github.com/abc123/checksRepo/runs/123');
     });
   });
 


### PR DESCRIPTION
The `/repository/<owner>/<repo>/<branch>/latest` endpoint relies on the
Github `statuses` API to retrieve the link to the task group of a
commit. But for some reason most repositories I've tested, seem to
return an empty list of statuses for this API, rending the latest
endpoint useless. Practically speaking, this means the badge links for
most projects are busted.

This PR tweaks the endpoint to use the Github `checks` API to build the URL
instead. Unfortunately this API does not contain the task group id
anywhere, so linking to the task group is not possible. Instead, this
links to the run id of the check in question.

Fixes #5364 