### PR TITLE
feat(ui): show last active in queue workers view

### DIFF
--- a/changelog/issue-4366-1.md
+++ b/changelog/issue-4366-1.md
@@ -1,0 +1,5 @@
+audience: users
+level: minor
+reference: issue 4366
+---
+Display the last date active in the queue workers view.

--- a/services/web-server/src/graphql/Workers.graphql
+++ b/services/web-server/src/graphql/Workers.graphql
@@ -7,6 +7,7 @@ type LatestTask {
 type WorkerCompact {
   workerId: ID!
   workerGroup: String!
+  lastDateActive: DateTime
   firstClaim: DateTime!
   latestTask: LatestTask
   quarantineUntil: DateTime

--- a/ui/src/components/WorkersTable/index.jsx
+++ b/ui/src/components/WorkersTable/index.jsx
@@ -106,6 +106,7 @@ export default class WorkersTable extends Component {
     const mapping = {
       'Worker Group': node.workerGroup,
       'Worker ID': node.workerId,
+      'Last Active': node.lastDateActive,
       'First Claim': node.firstClaim,
       'Most Recent Task': node.latestTask?.run?.taskId,
       'Task State': node.latestTask?.run?.state,
@@ -152,6 +153,7 @@ export default class WorkersTable extends Component {
             latestTask,
             firstClaim,
             quarantineUntil,
+            lastDateActive,
           },
         }) => (
           <TableRow key={workerId}>
@@ -165,6 +167,17 @@ export default class WorkersTable extends Component {
                 </TableCellItem>
               </Link>
             </TableCell>
+            {lastDateActive ? (
+              <CopyToClipboardTableCell
+                tooltipTitle={lastDateActive}
+                textToCopy={lastDateActive}
+                text={<DateDistance from={lastDateActive} />}
+              />
+            ) : (
+              <TableCell>
+                <em>n/a</em>
+              </TableCell>
+            )}
             <CopyToClipboardTableCell
               tooltipTitle={firstClaim}
               textToCopy={firstClaim}
@@ -222,6 +235,7 @@ export default class WorkersTable extends Component {
         headers={[
           'Worker Group',
           'Worker ID',
+          'Last Active',
           'First Claim',
           'Most Recent Task',
           'Task State',


### PR DESCRIPTION
Addresses UI part of #4366.

note: as more and more columns are added to this table, I feel like the UX is worse and worse, as horizontal scrolling is then needed. We may need to address this as more columns will be added from https://github.com/taskcluster/taskcluster/issues/3060.