### PR TITLE
fix(release): use `go install` with go1.18

### DIFF
--- a/changelog/PDAjqa-dSv69kv9lf36SvA.md
+++ b/changelog/PDAjqa-dSv69kv9lf36SvA.md
@@ -1,0 +1,4 @@
+audience: general
+level: patch
+---
+`go get` no longer builds or installs packages in module-aware mode, so replacing with `go install`.

--- a/infrastructure/tooling/src/build/tasks/client-shell.js
+++ b/infrastructure/tooling/src/build/tasks/client-shell.js
@@ -14,7 +14,7 @@ module.exports = ({ tasks, cmdOptions, credentials, baseDir, logsDir }) => {
       const artifactsDir = requirements['clean-artifacts-dir'];
       await execCommand({
         dir: artifactsDir,
-        command: ['go', 'get', '-u', 'github.com/mitchellh/gox'],
+        command: ['go', 'install', 'github.com/mitchellh/gox@latest'],
         utils,
       });
 

--- a/taskcluster/ci/release/kind.yml
+++ b/taskcluster/ci/release/kind.yml
@@ -36,7 +36,7 @@ job-defaults:
       - export PATH="${{GOROOT}}/bin:${{GOPATH}}/bin:${{PATH}}"
       - go version
       # set up gox
-      - go get github.com/mitchellh/gox
+      - go install github.com/mitchellh/gox@latest
       # set up rust, based on the mounted tarball
       - "./rust/rust-$RUST_VERSION-x86_64-unknown-linux-gnu/install.sh"
       # set up Node, using nvm (generic-worker does not support .xz, so we can't use mounts)


### PR DESCRIPTION
> `go get` no longer builds or installs packages in module-aware mode, so replacing with `go install`.

I tested this using `yarn staging-release` https://github.com/taskcluster/staging-releases/runs/6131472369