### PR TITLE
fix(graphql): return `lastDateActive` from `queue.listWorkers()` so response isn't null

### DIFF
--- a/changelog/EbfyiZ5QRdexiZdSHqndjA.md
+++ b/changelog/EbfyiZ5QRdexiZdSHqndjA.md
@@ -1,0 +1,4 @@
+audience: general
+level: patch
+---
+Return `lastDateActive` from `queue.listWorkers()`.

--- a/services/queue/src/api.js
+++ b/services/queue/src/api.js
@@ -1994,6 +1994,7 @@ builder.declare({
         workerGroup: worker.workerGroup,
         workerId: worker.workerId,
         firstClaim: worker.firstClaim.toJSON(),
+        lastDateActive: worker.lastDateActive.toJSON(),
       };
       if (worker.recentTasks.length > 0) {
         entry.latestTask = worker.recentTasks[worker.recentTasks.length - 1];

--- a/services/queue/test/workerinfo_test.js
+++ b/services/queue/test/workerinfo_test.js
@@ -262,6 +262,9 @@ helper.secrets.mockSuite(testing.suiteName(), ['aws'], function(mock, skipping) 
     assert(
       new Date(result.workers[0].firstClaim).getTime() === worker.firstClaim.getTime(), `expected ${worker.firstClaim}`,
     );
+    assert(
+      new Date(result.workers[0].lastDateActive).getTime() === worker.lastDateActive.getTime(), `expected ${worker.lastDateActive}`,
+    );
   });
 
   test('queue.listWorkers returns quarantined workers even after expiration', async () => {
@@ -609,6 +612,7 @@ helper.secrets.mockSuite(testing.suiteName(), ['aws'], function(mock, skipping) 
     assert(result.workerId === worker.workerId, `expected ${worker.workerId}`);
     assert(new Date(result.expires).getTime() === worker.expires.getTime(), `expected ${worker.expires}`);
     assert(new Date(result.firstClaim).getTime() === worker.firstClaim.getTime(), `expected ${worker.firstClaim}`);
+    assert(new Date(result.lastDateActive).getTime() === worker.lastDateActive.getTime(), `expected ${worker.lastDateActive}`);
     assert(result.recentTasks[0].taskId === taskId, `expected ${taskId}`);
     assert(result.recentTasks[0].runId === 0, 'expected 0');
     assert(result.recentTasks[1].taskId === taskId, `expected ${taskId}`);


### PR DESCRIPTION
> Return `lastDateActive` from `queue.listWorkers()`.

Related to the work done in https://github.com/taskcluster/taskcluster/pull/5370 and https://github.com/taskcluster/taskcluster/pull/5365.