### PR TITLE
feat(worker-manager): Immediate worker provisioning for Azure

### DIFF
--- a/changelog/issue-4999.md
+++ b/changelog/issue-4999.md
@@ -1,0 +1,9 @@
+audience: worker-deployers
+level: minor
+reference: issue 4999
+---
+
+Trigger immediate resource provisioning for Azure.
+
+Since operations are already async, this shouldn't slow down provisioning loop.
+It is done in attempt to prevent azure workers stay in 'Requested' state until the next `workerScannerAzure` loop picks it up.

--- a/services/worker-manager/README.md
+++ b/services/worker-manager/README.md
@@ -94,8 +94,9 @@ subgraph provision loop
     poolIterateStart[Iterate worker pools] --> takeWorkerPool
     takeWorkerPool[Get next worker pool] --> estimator
     estimator[Estimate number of workers to spawn] --> hasToSpawn{To spawn > 0 ?}
-    hasToSpawn -- Yes, Azure --> requestAzure[Request azure: create DB record only<br>Rest handled by worker scanner]
-    requestAzure --> requestWorker[(Create worker with config <br>state: Requested)]
+    hasToSpawn -- Yes, Azure --> requestAzure[Request azure: create DB record]
+    requestAzure --> checkWorker[(Create worker with config <br>state: Requested)]
+    checkWorker --> requestWorker([Start provisioning<br>See Azure checkWorker below])
     hasToSpawn -- Yes, Google --> requestGoogle([Create instance: compute.instances.insert])
     requestGoogle --> createWorker1[(new workers)]
     hasToSpawn -- Yes, AWS --> requestAWS([Create instance: ec2.runInstances])

--- a/services/worker-manager/src/providers/azure/index.js
+++ b/services/worker-manager/src/providers/azure/index.js
@@ -172,6 +172,9 @@ class AzureProvider extends Provider {
     this.configSchema = 'config-azure';
     this.providerConfig = providerConfig;
     this.downloadTimeout = 5000; // 5 seconds
+
+    this.seen = {};
+    this.errors = {};
   }
 
   // Add a PEM-encoded root certificate rootCertPem
@@ -437,6 +440,10 @@ class AzureProvider extends Provider {
         },
       });
       await worker.create(this.db);
+
+      // Start requesting resources immediately
+      // it will only provision at most one resource, as they are done async
+      await this.checkWorker({ worker });
     }));
   }
 

--- a/services/worker-manager/test/provider_azure_test.js
+++ b/services/worker-manager/test/provider_azure_test.js
@@ -50,6 +50,35 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
     monitor = await helper.load('monitor');
   });
 
+  const assertProvisioningState = async (expectations) => {
+    // re-fetch the worker, since it should have been updated
+    const workers = await helper.getWorkers();
+    assert.equal(workers.length, 1);
+    const worker = workers[0];
+
+    for (let resourceType of ['ip', 'vm', 'nic']) {
+      const name = worker.providerData[resourceType].name;
+      switch (expectations[resourceType]) {
+        case 'none':
+          assert(!worker.providerData[resourceType].operation);
+          assert(!worker.providerData[resourceType].id);
+          break;
+        case 'inprogress':
+          assert.equal(worker.providerData[resourceType].operation, `op/${resourceType}/rgrp/${name}`);
+          assert(!worker.providerData[resourceType].id);
+          break;
+        case 'allocated':
+          assert(!worker.providerData[resourceType].operation);
+          assert.equal(worker.providerData[resourceType].id, `id/${name}`);
+          break;
+        case undefined: // caller doesn't care about state of this resource
+          break;
+        default:
+          assert(false, `invalid expectation ${resourceType}: ${expectations[resourceType]}`);
+      }
+    }
+  };
+
   // This is the intermediate certificate that azure_signature_good is signed
   // with; to figure out which this is, print the certificate in
   // `registerWorker`.  It will be one of the certs on on
@@ -118,7 +147,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
     await provider.setup();
   });
 
-  const makeWorkerPool = async (overrides = {}) => {
+  const makeWorkerPool = async (overrides = {}, launchConfigOverrides = {}) => {
     let workerPool = WorkerPool.fromApi({
       workerPoolId,
       providerId,
@@ -145,6 +174,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
               osDisk: {},
               dataDisks: [{}],
             },
+            ...launchConfigOverrides,
           },
         ],
       },
@@ -430,37 +460,9 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       sandbox.restore();
     });
 
-    const assertProvisioningState = async (expectations) => {
-      // re-fetch the worker, since it should have been updated
-      const workers = await helper.getWorkers();
-      assert.equal(workers.length, 1);
-      worker = workers[0];
-
-      for (let resourceType of ['ip', 'vm', 'nic']) {
-        const name = worker.providerData[resourceType].name;
-        switch (expectations[resourceType]) {
-          case 'none':
-            assert(!worker.providerData[resourceType].operation);
-            assert(!worker.providerData[resourceType].id);
-            break;
-          case 'inprogress':
-            assert.equal(worker.providerData[resourceType].operation, `op/${resourceType}/rgrp/${name}`);
-            assert(!worker.providerData[resourceType].id);
-            break;
-          case 'allocated':
-            assert(!worker.providerData[resourceType].operation);
-            assert.equal(worker.providerData[resourceType].id, `id/${name}`);
-            break;
-          case undefined: // caller doesn't care about state of this resource
-            break;
-          default:
-            assert(false, `invalid expectation ${resourceType}: ${expectations[resourceType]}`);
-        }
-      }
-    };
-
     test('successful provisioning process', async function() {
-      await assertProvisioningState({ ip: 'none' });
+      // Ip provisioning should have already started inside the provision() call
+      await assertProvisioningState({ ip: 'inprogress' });
       const ipName = worker.providerData.ip.name;
       const nicName = worker.providerData.nic.name;
       const vmName = worker.providerData.vm.name;
@@ -548,8 +550,6 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
     });
 
     test('provisioning process fails creating IP', async function() {
-      await assertProvisioningState({ ip: 'none' });
-
       debug('first call');
       await provider.provisionResources({ worker, monitor });
       await assertProvisioningState({ ip: 'inprogress' });
@@ -564,8 +564,6 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
     });
 
     test('provisioning process fails creating IP with provisioningState=Failed', async function() {
-      await assertProvisioningState({ ip: 'none' });
-
       debug('first call');
       await provider.provisionResources({ worker, monitor });
       await assertProvisioningState({ ip: 'inprogress' });
@@ -583,8 +581,6 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
     });
 
     test('provisioning process fails creating NIC', async function() {
-      await assertProvisioningState({ ip: 'none' });
-
       debug('first call');
       await provider.provisionResources({ worker, monitor });
       await assertProvisioningState({ ip: 'inprogress' });
@@ -606,8 +602,6 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
     });
 
     test('provisioning process fails creating VM', async function() {
-      await assertProvisioningState({ ip: 'none' });
-
       debug('first call');
       await provider.provisionResources({ worker, monitor });
       await assertProvisioningState({ ip: 'inprogress' });
@@ -634,11 +628,46 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       await assertProvisioningState({ ip: 'allocated', nic: 'allocated', vm: 'none' });
       assert(provider.removeWorker.called);
     });
+  });
+
+  suite('provisionResources without public IP', function() {
+    let worker, nicName, vmName;
+    const sandbox = sinon.createSandbox({});
+
+    setup('create un-provisioned worker', async function() {
+      const workerPool = await makeWorkerPool({}, {
+        workerConfig: {
+          genericWorker: {
+            description: 'this should skip IP provisioning',
+          },
+        },
+      });
+      const workerInfo = {
+        existingCapacity: 0,
+        requestedCapacity: 0,
+      };
+      await provider.provision({ workerPool, workerInfo });
+      const workers = await helper.getWorkers();
+      assert.equal(workers.length, 1);
+      worker = workers[0];
+
+      nicName = worker.providerData.nic.name;
+      vmName = worker.providerData.vm.name;
+
+      // stub for removeWorker, for failure cases
+      sandbox.stub(provider, 'removeWorker').returns('stopped');
+
+      // reset the state of the provisioner such that we can call its
+      // scanning-related methods
+      await provider.scanPrepare();
+      provider.errors[workerPoolId] = [];
+    });
+
+    teardown(function() {
+      sandbox.restore();
+    });
 
     test('successful provisioning of VM without public ip', async function() {
-      await assertProvisioningState({ ip: 'none', nic: 'none', vm: 'none' });
-
-      worker.providerData.skipPublicIp = true;
       await provider.provisionResources({ worker, monitor });
       await assertProvisioningState({ nic: 'inprogress' });
 
@@ -657,13 +686,22 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
 
   suite('removeWorker', function() {
     let worker, ipName, nicName, vmName;
+    const sandbox = sinon.createSandbox({});
+
     setup('create un-provisioned worker', async function() {
       const workerPool = await makeWorkerPool();
       const workerInfo = {
         existingCapacity: 0,
         requestedCapacity: 0,
       };
+
+      // prevent the worker from being immediately provisioned
+      sandbox.stub(provider, 'checkWorker').returns('ok');
+
       await provider.provision({ workerPool, workerInfo });
+
+      sandbox.restore();
+
       const workers = await helper.getWorkers();
       assert.equal(workers.length, 1);
       worker = workers[0];


### PR DESCRIPTION
Further improve worker manager Azure provisioning. 

Till now, Azure was the only provider that was not actually doing any cloud api calls in the `provisioner` loop, and only created worker record in `REQUESTED` state, that was later picked by `workerScannerAzure`.
This sometimes can take 10-20 minutes, and, considering overall provisioning slowness, it often ends with worker being terminated, as they fail to start within given time (`terminateAfter`) (Leading to errors seen in #4999)


Related to #4999
