### PR TITLE
Fix the `latest` endpoint in the Github service when using checks

### DIFF
--- a/changelog/issue-5395.md
+++ b/changelog/issue-5395.md
@@ -1,0 +1,5 @@
+audience: users
+level: patch
+reference: issue 5395
+---
+Fixed exception in Github service's latest endpoint when using checks reporting

--- a/services/github/src/api.js
+++ b/services/github/src/api.js
@@ -541,13 +541,13 @@ builder.declare({
 
     // Next inspect the checks API. This will be set if consumer repos have
     // opted into the checks-v2 reporting.
-    const checks = await findTCChecks(instGithub, owner, repo, branch, this.cfg);
+    const checkRuns = await findTCChecks(instGithub, owner, repo, branch, this.cfg);
 
-    if (checks.length > 0) {
-      // If there are multiple checks we can't redirect to all of them, so just
-      // pick the first one in the array.
-      let check = checks[0];
-      return res.redirect(check.repository.html_url + "/runs/" + check.id);
+    if (checkRuns.length > 0) {
+      // Sort the array of runs from smallest to largest id, this should yield
+      // the Decision task.
+      let run = checkRuns.sort((a, b) => a.id - b.id)[0];
+      return res.redirect(run.html_url);
     }
 
     // Otherwise there is no status available for the given branch.

--- a/services/github/test/api_test.js
+++ b/services/github/test/api_test.js
@@ -119,9 +119,9 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       repo: 'checksRepo',
       ref: 'success',
       info: [
-        { id: 123, name: "check1", conclusion: 'success', app: { id: 66666 }, repository: { html_url: "https://github.com/abc123/checksRepo" } },
-        { name: "check2", conclusion: 'success', app: { id: 66666 } },
-        { name: "check3", conclusion: 'failure', app: { id: 12345 } },
+        { id: 1, name: "check1", conclusion: 'failure', app: { id: 12345 }, html_url: "https://example.com/abc123/checksRepo/runs/1" },
+        { id: 3, name: "check3", conclusion: 'success', app: { id: 66666 }, html_url: "https://example.com/abc123/checksRepo/runs/3" },
+        { id: 2, name: "check2", conclusion: 'success', app: { id: 66666 }, html_url: "https://example.com/abc123/checksRepo/runs/2" },
       ],
     });
     github.inst(9090).setChecks({
@@ -495,7 +495,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       } catch (e) {
         console.log(`Test for redirecting to correct page failed. Error: ${JSON.stringify(e)}`);
       }
-      assert.equal(res.body, 'Found. Redirecting to https://github.com/abc123/checksRepo/runs/123');
+      assert.equal(res.body, 'Found. Redirecting to https://example.com/abc123/checksRepo/runs/2');
     });
   });
 


### PR DESCRIPTION
I had implemented this endpoint under the assumption that the
`findTCChecks` function was calling Github's `check-suites` API, when in
fact it was using the `check-runs` API.

Since check-runs points to individual tasks, I grab the run with the
smallest id, which should correlate to the Decision task. Even if it
doesn't, it's not a big deal as all tasks are easily accessible on the
side.

Fixes #5395
