### PR TITLE
fix(release): prepare `docker-worker-chunk` for `release-publish` dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,6 @@ next-task-user.json
 
 # Rust ignores
 /clients/client-rust/target/
+
+# output from taskgraph cli
+__pycache__

--- a/changelog/cS1OSo2wRuSyqtrFaM7V-w.md
+++ b/changelog/cS1OSo2wRuSyqtrFaM7V-w.md
@@ -1,4 +1,4 @@
 audience: developers
-level: patch
+level: silent
 ---
-`docker-worker-chunk-{1,2,3,4,5}` tasks would non-deterministically fail during releases due to them depending on the `release-publish` task passing successfully before they run. This was fixed by setting a dependency on `release-publish` in the `docker-worker-chunk-{1,2,3,4,5}` tasks.
+`docker-worker-chunk-{1,2,3,4,5}` tasks would non-deterministically fail during releases due to them depending on the `release-publish` task passing successfully before they run. This will be fixed by setting a dependency on `release-publish` in the `docker-worker-chunk-{1,2,3,4,5}` tasks. For now, on releases, two task groups are created, making it impossible to define a dependency on `release-publish` in the `docker-worker-chunk-{1,2,3,4,5}` tasks. Once we combine the two task groups to one, on release, this dependency can be set to fix the issue.

--- a/changelog/cS1OSo2wRuSyqtrFaM7V-w.md
+++ b/changelog/cS1OSo2wRuSyqtrFaM7V-w.md
@@ -1,0 +1,4 @@
+audience: developers
+level: patch
+---
+`docker-worker-chunk-{1,2,3,4,5}` tasks would non-deterministically fail during releases due to them depending on the `release-publish` task passing successfully before they run. This was fixed by setting a dependency on `release-publish` in the `docker-worker-chunk-{1,2,3,4,5}` tasks.

--- a/taskcluster/ci/docker-worker/kind.yml
+++ b/taskcluster/ci/docker-worker/kind.yml
@@ -4,8 +4,12 @@ loader: taskgraph.loader.transform:loader
 transforms:
   - src.transforms:taskcluster_images
   - src.transforms:add_task_env
+  - src.transforms:docker_worker_chunk
   - taskgraph.transforms.job:transforms
   - taskgraph.transforms.task:transforms
+
+kind-dependencies:
+  - release
 
 job-defaults:
   worker-type: dw-ci
@@ -32,23 +36,7 @@ job-defaults:
       DOCKER_TESTS: '1'
 
 jobs:
-  chunk-1:
-    description: 'docker-worker test chunk #1'
+  chunk:
+    description: 'docker-worker test chunk'
     run:
-      command: ./test/docker-worker-test --this-chunk 1 --total-chunks 5
-  chunk-2:
-    description: 'docker-worker test chunk #2'
-    run:
-      command: ./test/docker-worker-test --this-chunk 2 --total-chunks 5
-  chunk-3:
-    description: 'docker-worker test chunk #3'
-    run:
-      command: ./test/docker-worker-test --this-chunk 3 --total-chunks 5
-  chunk-4:
-    description: 'docker-worker test chunk #4'
-    run:
-      command: ./test/docker-worker-test --this-chunk 4 --total-chunks 5
-  chunk-5:
-    description: 'docker-worker test chunk #5'
-    run:
-      command: ./test/docker-worker-test --this-chunk 5 --total-chunks 5
+      command: ./test/docker-worker-test

--- a/taskcluster/ci/docker-worker/kind.yml
+++ b/taskcluster/ci/docker-worker/kind.yml
@@ -38,5 +38,6 @@ job-defaults:
 jobs:
   chunk:
     description: 'docker-worker test chunk'
+    chunks: 5
     run:
       command: ./test/docker-worker-test

--- a/taskcluster/ci/lint/kind.yml
+++ b/taskcluster/ci/lint/kind.yml
@@ -28,7 +28,7 @@ jobs:
   python:
     description: python flake8
     worker:
-      docker-image: python:2.7
+      docker-image: python:3.10
     run:
       install: pip install flake8
       command: sh test/py-lint.sh

--- a/taskcluster/src/transforms/__init__.py
+++ b/taskcluster/src/transforms/__init__.py
@@ -109,17 +109,19 @@ def parameterize_mounts(config, jobs):
 
 
 @transforms.add
-def docker_worker_chunk(config, jobs):
-    total_chunks = 5
-    for job in jobs:
+def docker_worker_chunk(config, tasks):
+    for task in tasks:
+        total_chunks = task.pop("chunks", 5)
         for chunk in range(1, total_chunks + 1):
-            c_task = copy.deepcopy(job)
+            c_task = copy.deepcopy(task)
             c_task["name"] += f"-{chunk}"
             c_task["description"] += f" #{chunk}"
             c_task["run"]["command"] += f" --this-chunk {chunk} --total-chunks {total_chunks}"
 
-            # include release-publish dependency in the case of a release
-            if config.params["tasks_for"] == "github-push":
-                c_task["dependencies"] = dict(release="release-publish")
+            # TODO: uncomment this block to add dependency to the release-publish
+            # task once we combine the two task graphs into one during release.
+            # # include release-publish dependency in the case of a release
+            # if config.params["tasks_for"] == "github-push":
+            #     c_task["dependencies"] = dict(release="release-publish")
 
             yield c_task

--- a/taskcluster/test/params/main-repo-pull-request.yml
+++ b/taskcluster/test/params/main-repo-pull-request.yml
@@ -1,0 +1,20 @@
+base_repository: https://github.com/taskcluster/taskcluster
+build_date: 1651514599
+do_not_optimize: []
+existing_tasks: {}
+filters:
+  - target_tasks_method
+head_ref: matt-boris/dockerWorkerReleasePublishDepencency
+head_repository: https://github.com/taskcluster/taskcluster
+head_rev: 2829821fed0eed5540866094fe41df79a580381b
+head_tag: ""
+level: "1"
+moz_build_date: "20220502180319"
+optimize_target_tasks: true
+owner: taskcluster-internal@mozilla.com
+project: taskcluster
+pushdate: 0
+pushlog_id: "0"
+repository_type: git
+target_tasks_method: taskcluster-branches
+tasks_for: github-pull-request

--- a/taskcluster/test/params/main-repo-push.yml
+++ b/taskcluster/test/params/main-repo-push.yml
@@ -1,0 +1,20 @@
+base_repository: https://github.com/taskcluster/taskcluster
+build_date: 1651244454
+do_not_optimize: []
+existing_tasks: {}
+filters:
+  - target_tasks_method
+head_ref: refs/tags/v44.13.0
+head_repository: https://github.com/taskcluster/taskcluster
+head_rev: b5981a652d254267cf972461ff337b689cab2351
+head_tag: ""
+level: "1"
+moz_build_date: "20220429150054"
+optimize_target_tasks: true
+owner: taskcluster-internal@mozilla.com
+project: taskcluster
+pushdate: 0
+pushlog_id: "0"
+repository_type: git
+target_tasks_method: taskcluster-branches
+tasks_for: github-push


### PR DESCRIPTION
> `docker-worker-chunk-{1,2,3,4,5}` tasks would non-deterministically fail during releases due to them depending on the `release-publish` task passing successfully before they run. This will be fixed by setting a dependency on `release-publish` in the `docker-worker-chunk-{1,2,3,4,5}` tasks. For now, on releases, two task groups are created, making it impossible to define a dependency on `release-publish` in the `docker-worker-chunk-{1,2,3,4,5}` tasks. Once we combine the two task groups to one, on release, this dependency can be set to fix the issue.