### PR TITLE
Some further cleanup from generic-worker move to monorepo

### DIFF
--- a/changelog/V0_EcwTuQ9WhJwllOcK9xg.md
+++ b/changelog/V0_EcwTuQ9WhJwllOcK9xg.md
@@ -1,0 +1,3 @@
+audience: general
+level: silent
+---

--- a/infrastructure/tooling/src/release/tasks.js
+++ b/infrastructure/tooling/src/release/tasks.js
@@ -207,6 +207,7 @@ module.exports = ({ tasks, cmdOptions, credentials }) => {
         'workers/generic-worker/**.go',
         'workers/generic-worker/**.yml',
         'workers/generic-worker/**.sh',
+        'workers/generic-worker/**.cmd',
       ];
       for (let file of await gitLsFiles({ patterns: goFiles })) {
         await modifyRepoFile(file, contents =>

--- a/workers/generic-worker/build.cmd
+++ b/workers/generic-worker/build.cmd
@@ -23,5 +23,12 @@ git rev-parse HEAD > revision.txt
 set /p REVISION=< revision.txt
 del revision.txt
 set GORACE=history_size=7
-go test -ldflags "-X github.com/taskcluster/taskcluster/workers/generic-worker.revision=%REVISION%" ./... || exit /b %ERRORLEVEL%
+
+::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
+:: The version number in this line is automatically updated by
+:: infrastructure/tooling/src/release/tasks.js
+:: when a new major release is made.
+::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
+go test -ldflags "-X github.com/taskcluster/taskcluster/v44/workers/generic-worker.revision=%REVISION%" ./... || exit /b %ERRORLEVEL%
+
 ineffassign . || exit /b %ERRORLEVEL%

--- a/workers/generic-worker/build.sh
+++ b/workers/generic-worker/build.sh
@@ -123,6 +123,11 @@ fi
 ls -1 "$OUTPUT_DIR"/generic-worker-*
 
 CGO_ENABLED=0 go get \
+####################################################################
+# The version number in these lines is automatically updated by
+#   infrastructure/tooling/src/release/tasks.js
+# when a new major release is made.
+####################################################################
   github.com/taskcluster/taskcluster/v44/tools/livelog \
   github.com/taskcluster/taskcluster/v44/tools/taskcluster-proxy \
   golang.org/x/lint/golint \
@@ -133,9 +138,19 @@ CGO_ENABLED=0 go get \
 go mod tidy
 
 if $TEST; then
+####################################################################
+# The version number in this line is automatically updated by
+#   infrastructure/tooling/src/release/tasks.js
+# when a new major release is made.
+####################################################################
   CGO_ENABLED=1 GORACE="history_size=7" go test -v -tags simple -ldflags "-X github.com/taskcluster/taskcluster/v44/workers/generic-worker.revision=$(git rev-parse HEAD)" -race -timeout 1h ./...
   MYGOHOSTOS="$(go env GOHOSTOS)"
   if [ "${MYGOHOSTOS}" == "linux" ] || [ "${MYGOHOSTOS}" == "darwin" ]; then
+####################################################################
+# The version number in this line is automatically updated by
+#   infrastructure/tooling/src/release/tasks.js
+# when a new major release is made.
+####################################################################
     CGO_ENABLED=1 GORACE="history_size=7" go test -v -tags docker -ldflags "-X github.com/taskcluster/taskcluster/v44/workers/generic-worker.revision=$(git rev-parse HEAD)" -race -timeout 1h ./...
   fi
   golint $(go list ./...) | sed "s*${PWD}/**"

--- a/workers/generic-worker/main.go
+++ b/workers/generic-worker/main.go
@@ -6,7 +6,7 @@
 //go:generate go run ./gw-codegen file://schemas/multiuser_posix.yml    generated_multiuser_darwin.go    multiuser
 //go:generate go run ./gw-codegen file://schemas/multiuser_posix.yml    generated_multiuser_linux.go     multiuser
 //go:generate go run ./gw-codegen file://schemas/multiuser_windows.yml  generated_multiuser_windows.go   multiuser
-// //go:generate gw-codegen https://raw.githubusercontent.com/taskcluster/taskcluster/4c9c284a8afda18ec3e163a8be198450128a3ef0/workers/docker-worker/schemas/v1/payload.yml dockerworker/payload.go
+// //go:generate go run ./gw-codegen file://../docker-worker/schemas/v1/payload.yml dockerworker/payload.go
 
 package main
 

--- a/workers/generic-worker/main_test.go
+++ b/workers/generic-worker/main_test.go
@@ -47,9 +47,12 @@ func TestIdleWithoutCrash(t *testing.T) {
 // number in build.sh.
 func TestRevisionNumberStored(t *testing.T) {
 	if !regexp.MustCompile("^[0-9a-f]{40}$").MatchString(revision) {
+
+		// The version number in this error message is automatically updated on release by infrastructure/tooling/src/release/tasks.js
+
 		t.Fatalf("Git revision could not be determined - got '%v' but expected to match regular expression '^[0-9a-f](40)$'\n"+
-			"Did you specify `-ldflags \"-X github.com/taskcluster/generic-worker.revision=<GIT REVISION>\"` in your go test command?\n"+
-			"Try using build.sh / build.cmd in root directory of generic-worker source code repository.", revision)
+			"Did you specify `-ldflags \"-X github.com/taskcluster/taskcluster/v44/workers/generic-worker.revision=<GIT REVISION>\"` in your go test command?\n"+
+			"Try building generic-worker using the /workers/generic-worker/build.(sh|cmd) script in the taskcluster monorepo.", revision)
 	}
 	t.Logf("Git revision successfully retrieved: %v", revision)
 }


### PR DESCRIPTION
Some minor cleanup in generic-worker (mostly related to migration of project into monorepo).