### PR TITLE
fix(queue): add null check to `lastDateActive` in queue workers `serialize()` func

### DIFF
--- a/changelog/f6AHYFu-T2WrY1g4RYvvaA.md
+++ b/changelog/f6AHYFu-T2WrY1g4RYvvaA.md
@@ -1,0 +1,4 @@
+audience: general
+level: patch
+---
+Add null check to `lastDateActive` in queue workers serialize() func.

--- a/services/queue/src/data.js
+++ b/services/queue/src/data.js
@@ -525,7 +525,7 @@ class Worker {
       expires: this.expires.toJSON(),
       firstClaim: this.firstClaim.toJSON(),
       recentTasks: _.cloneDeep(this.recentTasks),
-      lastDateActive: this.lastDateActive.toJSON(),
+      lastDateActive: this.lastDateActive?.toJSON(),
     };
   }
 


### PR DESCRIPTION
> Add null check to `lastDateActive` in queue workers serialize() func.

Got this sentry issue when releasing to FxCI: https://sentry.prod.mozaws.net/operations/taskcluster-firefox-ci/issues/19477419/