### PR TITLE
feat(ui): display last date active in the worker detail view

### DIFF
--- a/changelog/issue-4366.md
+++ b/changelog/issue-4366.md
@@ -1,0 +1,5 @@
+audience: users
+level: patch
+reference: issue 4366
+---
+Display last date active in the worker detail view.

--- a/services/web-server/src/graphql/Workers.graphql
+++ b/services/web-server/src/graphql/Workers.graphql
@@ -49,6 +49,14 @@ type Worker {
 
   # A list of most recent tasks claimed by the worker.
   latestTasks: [Task]!
+
+  # Date of the last time this worker was seen active. Updated each time a worker calls
+  # `queue.claimWork`, `queue.reclaimTask`, and `queue.declareWorker` for this task queue.
+  # `lastDateActive` is updated every half hour but may be off by up-to half an hour.
+  # Nonetheless, `lastDateActive` is a good indicator of when the worker was last seen active.
+  # This defaults to null in the database, and is set to the current time when the worker
+  # is first seen.
+  lastDateActive: DateTime
 }
 
 input WorkerQuarantine {

--- a/ui/src/components/WorkerDetailsCard/index.jsx
+++ b/ui/src/components/WorkerDetailsCard/index.jsx
@@ -17,11 +17,19 @@ export default class WorkerDetailsCard extends Component {
 
   render() {
     const {
-      worker: { quarantineUntil, firstClaim },
+      worker: { quarantineUntil, firstClaim, lastDateActive },
     } = this.props;
 
     return (
       <List>
+        <ListItem>
+          <ListItemText
+            primary="Last Active"
+            secondary={
+              lastDateActive ? <DateDistance from={lastDateActive} /> : 'n/a'
+            }
+          />
+        </ListItem>
         <ListItem>
           <ListItemText
             primary="First Claim"

--- a/ui/src/views/Provisioners/ViewWorker/worker.graphql
+++ b/ui/src/views/Provisioners/ViewWorker/worker.graphql
@@ -7,6 +7,7 @@ query ViewWorker($provisionerId: String!, $workerType: String!, $workerGroup: St
     quarantineUntil
     expires
     firstClaim
+    lastDateActive
     recentTasks {
       taskId
       run {


### PR DESCRIPTION
Related to https://github.com/taskcluster/taskcluster/issues/4366

Added last date active to the worker detail view as well - https://firefox-ci-tc.services.mozilla.com/provisioners/gecko-t/worker-types/win10-64-2004/workers/centralus/vm-a0k3byryqdmvkezxamergb0rdop81rzwkrt.