### PR TITLE
feat(ui): improvements to provisioners ViewWorkers

### DIFF
--- a/changelog/issue-5433.md
+++ b/changelog/issue-5433.md
@@ -1,0 +1,5 @@
+audience: users
+level: patch
+reference: issue 5433
+---
+Show workers from last recently active. Also, removed the deprecated prop `onChangePage` and replaced with `onPageChange`.

--- a/ui/src/components/ConnectionDataTable/index.jsx
+++ b/ui/src/components/ConnectionDataTable/index.jsx
@@ -247,7 +247,7 @@ export default class ConnectionDataTable extends Component {
         nextIconButtonProps={{
           'aria-label': 'Next Page',
         }}
-        onChangePage={this.handlePageChange}
+        onPageChange={this.handlePageChange}
       />
     );
   };

--- a/ui/src/components/DataTable/index.jsx
+++ b/ui/src/components/DataTable/index.jsx
@@ -199,7 +199,7 @@ export default class DataTable extends Component {
             nextIconButtonProps={{
               'aria-label': 'Next Page',
             }}
-            onChangePage={this.handlePageChange}
+            onPageChange={this.handlePageChange}
           />
         )}
       </Fragment>

--- a/ui/src/components/WorkersTable/index.jsx
+++ b/ui/src/components/WorkersTable/index.jsx
@@ -118,11 +118,24 @@ export default class WorkersTable extends Component {
     return mapping[query.sortBy];
   }
 
+  componentDidMount() {
+    const query = parse(this.props.location.search.slice(1));
+
+    if (query.sortBy) return;
+
+    this.props.history.replace({
+      search: stringify(
+        { sortBy: 'Last Active', sortDirection: 'desc' },
+        { addQueryPrefix: true }
+      ),
+    });
+  }
+
   render() {
     const query = parse(this.props.location.search.slice(1));
     const { sortBy, sortDirection } = query.sortBy
       ? query
-      : { sortBy: null, sortDirection: null };
+      : { sortBy: 'Last Active', sortDirection: 'desc' };
     const {
       provisionerId,
       workerType,


### PR DESCRIPTION
Addresses https://github.com/taskcluster/taskcluster/issues/5433.

> Show workers from last recently active. Also, removed the deprecated prop `onChangePage` and replaced with `onPageChange`.