### PR TITLE
feat(release): add exponential backoff retries to `dockerPush` function used in `release-publish` task

### DIFF
--- a/changelog/issue-5459.md
+++ b/changelog/issue-5459.md
@@ -1,0 +1,5 @@
+audience: general
+level: patch
+reference: issue 5459
+---
+Add exponential backoff retries to the `dockerPush` function to help alleviate intermittent failures in the `release-publish` task.

--- a/infrastructure/tooling/src/utils/command.js
+++ b/infrastructure/tooling/src/utils/command.js
@@ -54,7 +54,7 @@ exports.execCommand = async ({
   }
 
   await utils.waitFor(stream);
-  return await new Promise((resolve, reject) => {
+  return new Promise((resolve, reject) => {
     cp.once('close', code => {
       if (code === 0 || ignoreReturn) {
         resolve(output);


### PR DESCRIPTION
Addresses https://github.com/taskcluster/taskcluster/issues/5459.

> Add exponential backoff retries to the `dockerPush` function to help alleviate intermittent failures in the `release-publish` task.