### PR TITLE
Update the k8s ingress API to `networking.k8s.io/v1`

### DIFF
--- a/changelog/PYWd2pgrRBaWwlC6COdFCA.md
+++ b/changelog/PYWd2pgrRBaWwlC6COdFCA.md
@@ -1,0 +1,4 @@
+audience: deployers
+level: patch
+---
+Updated k8s ingress API from deprecated `extensions/v1beta1` to `networking.k8s.io/v1` allowing usage of k8s 1.22+

--- a/infrastructure/k8s/templates/ingress.yaml
+++ b/infrastructure/k8s/templates/ingress.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: taskcluster-ingress
@@ -16,82 +16,142 @@ spec:
       http:
         paths:
           - path: /*
+            pathType: Prefix
             backend:
-              servicePort: 80
-              serviceName: taskcluster-ui
+              service:
+                name: taskcluster-ui
+                port:
+                  number: 80
           - path: /references
+            pathType: Prefix
             backend:
-              servicePort: 80
-              serviceName: taskcluster-references
+              service:
+                name: taskcluster-references
+                port:
+                  number: 80
           - path: /references/*
+            pathType: Prefix
             backend:
-              servicePort: 80
-              serviceName: taskcluster-references
+              service:
+                name: taskcluster-references
+                port:
+                  number: 80
           - path: /schemas
+            pathType: Prefix
             backend:
-              servicePort: 80
-              serviceName: taskcluster-references
+              service:
+                name: taskcluster-references
+                port:
+                  number: 80
           - path: /schemas/*
+            pathType: Prefix
             backend:
-              servicePort: 80
-              serviceName: taskcluster-references
+              service:
+                name: taskcluster-references
+                port:
+                  number: 80
           - path: /api/auth/*
+            pathType: Prefix
             backend:
-              servicePort: 80
-              serviceName: taskcluster-auth
+              service:
+                name: taskcluster-auth
+                port:
+                  number: 80
           - path: /api/github/*
+            pathType: Prefix
             backend:
-              servicePort: 80
-              serviceName: taskcluster-github
+              service:
+                name: taskcluster-github
+                port:
+                  number: 80
           - path: /api/hooks/*
+            pathType: Prefix
             backend:
-              servicePort: 80
-              serviceName: taskcluster-hooks
+              service:
+                name: taskcluster-hooks
+                port:
+                  number: 80
           - path: /api/index/*
+            pathType: Prefix
             backend:
-              servicePort: 80
-              serviceName: taskcluster-index
+              service:
+                name: taskcluster-index
+                port:
+                  number: 80
           - path: /api/notify/*
+            pathType: Prefix
             backend:
-              servicePort: 80
-              serviceName: taskcluster-notify
+              service:
+                name: taskcluster-notify
+                port:
+                  number: 80
           - path: /api/object/*
+            pathType: Prefix
             backend:
-              servicePort: 80
-              serviceName: taskcluster-object
+              service:
+                name: taskcluster-object
+                port:
+                  number: 80
           - path: /api/purge-cache/*
+            pathType: Prefix
             backend:
-              servicePort: 80
-              serviceName: taskcluster-purge-cache
+              service:
+                name: taskcluster-purge-cache
+                port:
+                  number: 80
           - path: /api/queue/*
+            pathType: Prefix
             backend:
-              servicePort: 80
-              serviceName: taskcluster-queue
+              service:
+                name: taskcluster-queue
+                port:
+                  number: 80
           - path: /api/secrets/*
+            pathType: Prefix
             backend:
-              servicePort: 80
-              serviceName: taskcluster-secrets
+              service:
+                name: taskcluster-secrets
+                port:
+                  number: 80
           - path: /login
+            pathType: Prefix
             backend:
-              servicePort: 80
-              serviceName: taskcluster-web-server
+              service:
+                name: taskcluster-web-server
+                port:
+                  number: 80
           - path: /login/*
+            pathType: Prefix
             backend:
-              servicePort: 80
-              serviceName: taskcluster-web-server
+              service:
+                name: taskcluster-web-server
+                port:
+                  number: 80
           - path: /subscription
+            pathType: Prefix
             backend:
-              servicePort: 80
-              serviceName: taskcluster-web-server
+              service:
+                name: taskcluster-web-server
+                port:
+                  number: 80
           - path: /graphql
+            pathType: Prefix
             backend:
-              servicePort: 80
-              serviceName: taskcluster-web-server
+              service:
+                name: taskcluster-web-server
+                port:
+                  number: 80
           - path: /api/web-server/*
+            pathType: Prefix
             backend:
-              servicePort: 80
-              serviceName: taskcluster-web-server
+              service:
+                name: taskcluster-web-server
+                port:
+                  number: 80
           - path: /api/worker-manager/*
+            pathType: Prefix
             backend:
-              servicePort: 80
-              serviceName: taskcluster-worker-manager
+              service:
+                name: taskcluster-worker-manager
+                port:
+                  number: 80

--- a/infrastructure/tooling/templates/k8s/ingress.yaml
+++ b/infrastructure/tooling/templates/k8s/ingress.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: taskcluster-ingress
@@ -14,6 +14,9 @@ spec:
         $map: {$eval: ingresses}
         each(i):
           path: '${i.path}'
+          pathType: Prefix
           backend:
-            servicePort: 80
-            serviceName: ${i.projectName}
+            service:
+              name: ${i.projectName}
+              port:
+                number: 80


### PR DESCRIPTION
The `extensions/v1beta1` API was deprecated in kubernetes 1.16 [1] and
removed in 1.22 [2].

[1]: https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/
[2]: https://kubernetes.io/blog/2021/08/04/kubernetes-1-22-release-announcement/#removal-of-several-deprecated-beta-apis

