### PR TITLE
fix(schema): don't require additional wm fields

### DIFF
--- a/changelog/WEXGTNjNQYaDFU7YuJjiDQ.md
+++ b/changelog/WEXGTNjNQYaDFU7YuJjiDQ.md
@@ -1,0 +1,4 @@
+audience: users
+level: patch
+---
+Fix output schema validation error when calling `workerManager.listWorkers()` and `workerManager.getWorker()` methods by not requiring additional worker manager fields.

--- a/clients/client-go/tcworkermanager/types.go
+++ b/clients/client-go/tcworkermanager/types.go
@@ -322,7 +322,7 @@ type (
 		// Number of tasks this worker can handle at once
 		//
 		// Mininum:    1
-		Capacity int64 `json:"capacity"`
+		Capacity int64 `json:"capacity,omitempty"`
 
 		// Date of the first time this worker claimed a task.
 		FirstClaim tcclient.Time `json:"firstClaim"`
@@ -344,7 +344,7 @@ type (
 		// Syntax:     ^([a-zA-Z0-9-_]*)$
 		// Min length: 1
 		// Max length: 38
-		ProviderID string `json:"providerId"`
+		ProviderID string `json:"providerId,omitempty"`
 
 		// Quarantining a worker allows the machine to remain alive but not accept jobs.
 		// Once the quarantineUntil time has elapsed, the worker resumes accepting jobs.
@@ -365,7 +365,7 @@ type (
 		//   * "running"
 		//   * "stopping"
 		//   * "stopped"
-		State string `json:"state"`
+		State string `json:"state,omitempty"`
 
 		// Identifier for the worker group containing this worker.
 		//
@@ -846,7 +846,7 @@ type (
 		// Number of tasks this worker can handle at once
 		//
 		// Mininum:    1
-		Capacity int64 `json:"capacity"`
+		Capacity int64 `json:"capacity,omitempty"`
 
 		// Date and time after which the worker will be automatically
 		// deleted by the queue.
@@ -869,7 +869,7 @@ type (
 		// Syntax:     ^([a-zA-Z0-9-_]*)$
 		// Min length: 1
 		// Max length: 38
-		ProviderID string `json:"providerId"`
+		ProviderID string `json:"providerId,omitempty"`
 
 		// Unique identifier for a provisioner, that can supply specified
 		// `workerType`. Deprecation is planned for this property as it
@@ -901,7 +901,7 @@ type (
 		//   * "running"
 		//   * "stopping"
 		//   * "stopped"
-		State string `json:"state"`
+		State string `json:"state,omitempty"`
 
 		// Identifier for group that worker who executes this run is a part of,
 		// this identifier is mainly used for efficient routing.

--- a/generated/references.json
+++ b/generated/references.json
@@ -157,10 +157,7 @@
         "recentTasks",
         "expires",
         "firstClaim",
-        "actions",
-        "state",
-        "capacity",
-        "providerId"
+        "actions"
       ],
       "title": "Worker Response",
       "type": "object"
@@ -1335,10 +1332,7 @@
             "required": [
               "workerGroup",
               "workerId",
-              "firstClaim",
-              "state",
-              "capacity",
-              "providerId"
+              "firstClaim"
             ],
             "title": "Worker",
             "type": "object"

--- a/services/worker-manager/schemas/v1/list-workers-response.yml
+++ b/services/worker-manager/schemas/v1/list-workers-response.yml
@@ -92,9 +92,6 @@ properties:
         - workerGroup
         - workerId
         - firstClaim
-        - state
-        - capacity
-        - providerId
   continuationToken:
     type:           string
     title:          "Continuation Token"

--- a/services/worker-manager/schemas/v1/worker-response.yml
+++ b/services/worker-manager/schemas/v1/worker-response.yml
@@ -151,6 +151,3 @@ required:
   - expires
   - firstClaim
   - actions
-  - state
-  - capacity
-  - providerId


### PR DESCRIPTION
Fixes this error:

```
"Output schema validation error: 
Schema Validation Failed!
Rejecting Schema: https://stage.taskcluster.nonprod.cloudops.mozgcp.net/schemas/worker-manager/v1/list-workers-response.json#
Errors:
  * data/workers/0 should have required property 'state'
  * data/workers/0 should have required property 'capacity'
  * data/workers/0 should have required property 'providerId'"
```

> Fix output schema validation error when calling `workerManager.listWorkers()` and `workerManager.getWorker()` methods by not requiring additional worker manager fields.