### PR TITLE
fix(graphql): add `workerPoolId` field to `Worker`

### DIFF
--- a/changelog/DDq2rs66QBeeC0BvCTZZ8g.md
+++ b/changelog/DDq2rs66QBeeC0BvCTZZ8g.md
@@ -1,0 +1,4 @@
+audience: users
+level: patch
+---
+Fix `GRAPHQL_VALIDATION_FAILED` error on ViewWorker query.

--- a/services/web-server/src/graphql/Workers.graphql
+++ b/services/web-server/src/graphql/Workers.graphql
@@ -67,6 +67,9 @@ type Worker {
 
   # The worker's provider-specific ID.
   providerId: String
+
+  # Unique identifier for a worker pool.
+  workerPoolId: String
 }
 
 input WorkerQuarantine {


### PR DESCRIPTION
> Fix `GRAPHQL_VALIDATION_FAILED` error on ViewWorker query.

```
{
  "errors": [
    {
      "message": "Cannot query field \"workerPoolId\" on type \"Worker\". Did you mean \"workerId\" or \"workerGroup\"?",
      "locations": [{ "line": 16, "column": 5 }],
      "extensions": { "code": "GRAPHQL_VALIDATION_FAILED" }
    }
  ]
}
```