### PR TITLE
build(github-actions): update github-actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -41,3 +41,9 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
+
+  # Set update schedule for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"

--- a/changelog/LCtKn9bmSsShpKp8qZuI4A.md
+++ b/changelog/LCtKn9bmSsShpKp8qZuI4A.md
@@ -1,0 +1,3 @@
+audience: general
+level: silent
+---


### PR DESCRIPTION
Dependabot will then auto-upgrade the deprecated github actions that are currently being used.

See warnings here: https://github.com/taskcluster/taskcluster/actions/runs/2429516124

Docs: https://github.blog/changelog/2022-04-27-code-scanning-deprecation-of-codeql-action-v1/