### PR TITLE
fix(schema, graphql): use explicit values when a worker is not known by worker manager, add better descriptions, update graphql queries

### DIFF
--- a/changelog/DJkOOynvQVSVLNN5jOj3xg.md
+++ b/changelog/DJkOOynvQVSVLNN5jOj3xg.md
@@ -1,0 +1,4 @@
+audience: general
+level: patch
+---
+Don't allow additional properties in `worker-response.yml` schema. Updated descriptions in `worker-response.yml` and `list-workers-response.yml` schemas to explain some default values that may occur in the case where the queue knows about the worker, but worker manager does not. Also, updated the GraphQL queries to extract additional needed data.

--- a/generated/references.json
+++ b/generated/references.json
@@ -3,7 +3,7 @@
     "content": {
       "$id": "/schemas/worker-manager/v1/worker-response.json#",
       "$schema": "/schemas/common/metaschema.json#",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "description": "Response containing information about a worker.\n",
       "properties": {
         "actions": {
@@ -66,7 +66,7 @@
           "uniqueItems": false
         },
         "capacity": {
-          "description": "Number of tasks this worker can handle at once",
+          "description": "Number of tasks this worker can handle at once. A worker capacity of 0 means\nthe worker is not managed by worker manager and is only known to the queue, the\ntrue capacity is not known.\n",
           "minimum": 0,
           "title": "Worker Capacity",
           "type": "integer"
@@ -90,8 +90,9 @@
           "type": "string"
         },
         "providerId": {
-          "description": "The provider that had started the worker and responsible for managing it.\nCan be different from the provider that's currently in the worker pool config.\n",
+          "description": "The provider that had started the worker and responsible for managing it.\nCan be different from the provider that's currently in the worker pool config.\nA providerId of \"none\" is used when the worker is not managed by worker manager.\n",
           "maxLength": 38,
+          "minLength": 1,
           "pattern": "^([a-zA-Z0-9-_]*)$",
           "title": "Provider",
           "type": "string"
@@ -115,13 +116,13 @@
           "uniqueItems": false
         },
         "state": {
-          "description": "A string specifying the state this worker is in so far as worker-manager knows.\nA \"requested\" worker is in the process of starting up, and if successful will enter\nthe \"running\" state once it has registered with the `registerWorker` API method.  A\n\"stopping\" worker is in the process of shutting down and deleting resources, while\na \"stopped\" worker is completely stopped.  Stopped workers are kept for historical\npurposes and are purged when they expire.  Note that some providers transition workers\ndirectly from \"running\" to \"stopped\".\n",
+          "description": "A string specifying the state this worker is in so far as worker-manager knows.\nA \"requested\" worker is in the process of starting up, and if successful will enter\nthe \"running\" state once it has registered with the `registerWorker` API method.  A\n\"stopping\" worker is in the process of shutting down and deleting resources, while\na \"stopped\" worker is completely stopped.  Stopped workers are kept for historical\npurposes and are purged when they expire.  Note that some providers transition workers\ndirectly from \"running\" to \"stopped\".\nAn \"unmanaged\" worker is a worker that is not managed by worker-manager, these workers\nare only known by the queue.\n",
           "enum": [
             "requested",
             "running",
             "stopping",
             "stopped",
-            ""
+            "unmanaged"
           ],
           "title": "State",
           "type": "string"
@@ -479,7 +480,7 @@
     "content": {
       "$id": "/schemas/worker-manager/v1/worker-full.json#",
       "$schema": "/schemas/common/metaschema.json#",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "description": "A complete worker definition.",
       "properties": {
         "capacity": {
@@ -1267,7 +1268,7 @@
             "additionalProperties": false,
             "properties": {
               "capacity": {
-                "description": "Number of tasks this worker can handle at once",
+                "description": "Number of tasks this worker can handle at once. A worker capacity of 0 means\nthe worker is not managed by worker manager and is only known to the queue, the\ntrue capacity is not known.\n",
                 "minimum": 0,
                 "title": "Worker Capacity",
                 "type": "integer"
@@ -1290,8 +1291,9 @@
                 "title": "Most Recent Task"
               },
               "providerId": {
-                "description": "The provider that had started the worker and responsible for managing it.\nCan be different from the provider that's currently in the worker pool config.\n",
+                "description": "The provider that had started the worker and responsible for managing it.\nCan be different from the provider that's currently in the worker pool config.\nA providerId of \"none\" is used when the worker is not managed by worker manager.\n",
                 "maxLength": 38,
+                "minLength": 1,
                 "pattern": "^([a-zA-Z0-9-_]*)$",
                 "title": "Provider",
                 "type": "string"
@@ -1303,13 +1305,13 @@
                 "type": "string"
               },
               "state": {
-                "description": "A string specifying the state this worker is in so far as worker-manager knows.\nA \"requested\" worker is in the process of starting up, and if successful will enter\nthe \"running\" state once it has registered with the `registerWorker` API method.  A\n\"stopping\" worker is in the process of shutting down and deleting resources, while\na \"stopped\" worker is completely stopped.  Stopped workers are kept for historical\npurposes and are purged when they expire.  Note that some providers transition workers\ndirectly from \"running\" to \"stopped\".\n",
+                "description": "A string specifying the state this worker is in so far as worker-manager knows.\nA \"requested\" worker is in the process of starting up, and if successful will enter\nthe \"running\" state once it has registered with the `registerWorker` API method.  A\n\"stopping\" worker is in the process of shutting down and deleting resources, while\na \"stopped\" worker is completely stopped.  Stopped workers are kept for historical\npurposes and are purged when they expire.  Note that some providers transition workers\ndirectly from \"running\" to \"stopped\".\nAn \"unmanaged\" worker is a worker that is not managed by worker-manager, these workers\nare only known by the queue.\n",
                 "enum": [
                   "requested",
                   "running",
                   "stopping",
                   "stopped",
-                  ""
+                  "unmanaged"
                 ],
                 "title": "State",
                 "type": "string"

--- a/services/web-server/src/graphql/Workers.graphql
+++ b/services/web-server/src/graphql/Workers.graphql
@@ -13,6 +13,10 @@ type WorkerCompact {
   quarantineUntil: DateTime
   provisionerId: String!
   workerType: String!
+  state: String
+  capacity: Int
+  providerId: String
+  workerPoolId: String
 }
 
 # Definition of a worker
@@ -59,7 +63,7 @@ type Worker {
   lastDateActive: DateTime
 
   # The current state of the worker.
-  # One of [`requested`, `running`, `stopping`, `stopped`].
+  # One of [`requested`, `running`, `stopping`, `stopped`, `unmanaged`].
   state: String
 
   # The current capacity of the worker.

--- a/services/worker-manager/schemas/v1/list-workers-response.yml
+++ b/services/worker-manager/schemas/v1/list-workers-response.yml
@@ -70,11 +70,16 @@ properties:
             a "stopped" worker is completely stopped.  Stopped workers are kept for historical
             purposes and are purged when they expire.  Note that some providers transition workers
             directly from "running" to "stopped".
+            An "unmanaged" worker is a worker that is not managed by worker-manager, these workers
+            are only known by the queue.
           type: string
-          enum: ["requested", "running", "stopping", "stopped", ""]
+          enum: ["requested", "running", "stopping", "stopped", "unmanaged"]
         capacity:
           title: Worker Capacity
-          description: Number of tasks this worker can handle at once
+          description: |
+            Number of tasks this worker can handle at once. A worker capacity of 0 means
+            the worker is not managed by worker manager and is only known to the queue, the
+            true capacity is not known.
           type: integer
           minimum: 0
         providerId:
@@ -82,11 +87,13 @@ properties:
           type: string
           # note that this is typically used as the workerGroup for workers,
           # so its format should match that for workerGroup.
+          minLength: {$const: identifier-min-length}
           maxLength: {$const: identifier-max-length}
           pattern: {$const: identifier-pattern}
           description: |
             The provider that had started the worker and responsible for managing it.
             Can be different from the provider that's currently in the worker pool config.
+            A providerId of "none" is used when the worker is not managed by worker manager.
       additionalProperties: false
       required:
         - workerGroup

--- a/services/worker-manager/schemas/v1/worker-full.yml
+++ b/services/worker-manager/schemas/v1/worker-full.yml
@@ -80,7 +80,7 @@ properties:
     type: integer
     minimum: 1
 
-additionalProperties: true
+additionalProperties: false
 required:
   - workerPoolId
   - workerGroup

--- a/services/worker-manager/schemas/v1/worker-response.yml
+++ b/services/worker-manager/schemas/v1/worker-response.yml
@@ -123,11 +123,16 @@ properties:
       a "stopped" worker is completely stopped.  Stopped workers are kept for historical
       purposes and are purged when they expire.  Note that some providers transition workers
       directly from "running" to "stopped".
+      An "unmanaged" worker is a worker that is not managed by worker-manager, these workers
+      are only known by the queue.
     type: string
-    enum: ["requested", "running", "stopping", "stopped", ""]
+    enum: ["requested", "running", "stopping", "stopped", "unmanaged"]
   capacity:
     title: Worker Capacity
-    description: Number of tasks this worker can handle at once
+    description: |
+      Number of tasks this worker can handle at once. A worker capacity of 0 means
+      the worker is not managed by worker manager and is only known to the queue, the
+      true capacity is not known.
     type: integer
     minimum: 0
   providerId:
@@ -135,12 +140,14 @@ properties:
     type: string
     # note that this is typically used as the workerGroup for workers,
     # so its format should match that for workerGroup.
+    minLength: {$const: identifier-min-length}
     maxLength: {$const: identifier-max-length}
     pattern: {$const: identifier-pattern}
     description: |
       The provider that had started the worker and responsible for managing it.
       Can be different from the provider that's currently in the worker pool config.
-additionalProperties: true
+      A providerId of "none" is used when the worker is not managed by worker manager.
+additionalProperties: false
 required:
   - provisionerId
   - workerType

--- a/services/worker-manager/src/api.js
+++ b/services/worker-manager/src/api.js
@@ -415,7 +415,7 @@ builder.declare({
   });
 
   return res.reply({
-    workers: rows.map(w => Worker.fromDb(w).serializable()),
+    workers: rows.map(w => Worker.fromDb(w).serializable({ removeQueueData: true })),
     continuationToken,
   });
 });
@@ -439,7 +439,7 @@ builder.declare({
   if (!worker) {
     return res.reportError('ResourceNotFound', 'Worker not found', {});
   }
-  res.reply(worker.serializable());
+  res.reply(worker.serializable({ removeQueueData: true }));
 });
 
 let cleanCreatePayload = payload => {
@@ -511,7 +511,7 @@ builder.declare({
   }
   assert(worker, 'Provider createWorker did not return a worker');
 
-  return res.reply(worker.serializable());
+  return res.reply(worker.serializable({ removeQueueData: true }));
 });
 
 builder.declare({
@@ -579,7 +579,7 @@ builder.declare({
   }
   assert(worker, 'Provider updateWorker did not return a worker');
 
-  return res.reply(worker.serializable());
+  return res.reply(worker.serializable({ removeQueueData: true }));
 });
 
 builder.declare({
@@ -663,7 +663,7 @@ builder.declare({
   });
 
   return res.reply({
-    workers: rows.map(w => Worker.fromDb(w).serializable()),
+    workers: rows.map(w => Worker.fromDb(w).serializable({ removeQueueData: true })),
     continuationToken,
   });
 });
@@ -902,9 +902,9 @@ builder.declare({
         firstClaim: worker.firstClaim?.toJSON(),
         lastDateActive: worker.lastDateActive?.toJSON(),
         workerPoolId: worker.workerPoolId,
-        state: worker.state || '',
+        state: worker.state || 'unmanaged',
         capacity: worker.capacity || 0,
-        providerId: worker.providerId || '',
+        providerId: worker.providerId || 'none',
       };
       if (worker.recentTasks.length > 0) {
         entry.latestTask = worker.recentTasks[worker.recentTasks.length - 1];
@@ -961,7 +961,7 @@ builder.declare({
     );
   }
 
-  let workerResult = worker.serializable();
+  let workerResult = worker.serializable({ removeWorkerManagerData: true });
   workerResult = { ...workerResult, provisionerId, workerType };
 
   const actions = [];

--- a/services/worker-manager/src/data.js
+++ b/services/worker-manager/src/data.js
@@ -417,15 +417,15 @@ class Worker {
 
   // Create a serializable representation of this worker suitable for response
   // from an API method.
-  serializable() {
-    return {
+  serializable({ removeQueueData = false, removeWorkerManagerData = false } = {}) {
+    const worker = {
       workerPoolId: this.workerPoolId,
       workerGroup: this.workerGroup,
       workerId: this.workerId,
-      providerId: this.providerId || '',
+      providerId: this.providerId || 'none',
       created: this.created?.toJSON(),
       expires: this.expires?.toJSON(),
-      state: this.state || '',
+      state: this.state || 'unmanaged',
       capacity: this.capacity || 0,
       lastModified: this.lastModified?.toJSON(),
       lastChecked: this.lastChecked?.toJSON(),
@@ -433,6 +433,27 @@ class Worker {
       recentTasks: _.cloneDeep(this.recentTasks),
       lastDateActive: this.lastDateActive?.toJSON(),
     };
+
+    // Remove properties that should not be in this response schema.
+    // These properties are used in the `worker-response.yml` schema
+    // which is used in the `getWorker` API.
+    if (removeQueueData) {
+      delete worker.firstClaim;
+      delete worker.recentTasks;
+      delete worker.lastDateActive;
+    }
+
+    // Remove properties that should not be in this response schema.
+    // These properties are used in the `worker-full.yml` schema
+    // which is used in the `worker`, `createWorker`, and `updateWorker`
+    // APIs.
+    if (removeWorkerManagerData) {
+      delete worker.created;
+      delete worker.lastModified;
+      delete worker.lastChecked;
+    }
+
+    return worker;
   }
 
   // Calls db.update_worker given a modifier.

--- a/ui/src/utils/labels.js
+++ b/ui/src/utils/labels.js
@@ -11,6 +11,7 @@ export default {
   REQUESTED: 'default',
   STOPPING: 'warning',
   STOPPED: 'error',
+  UNMANAGED: 'info',
   // deprecated, but still supported for old tasks
   SUPERSEDED: 'default',
   CLAIM_EXPIRED: 'info',

--- a/ui/src/views/Provisioners/ViewWorker/worker.graphql
+++ b/ui/src/views/Provisioners/ViewWorker/worker.graphql
@@ -8,6 +8,9 @@ query ViewWorker($provisionerId: String!, $workerType: String!, $workerGroup: St
     expires
     firstClaim
     lastDateActive
+    state
+    capacity
+    providerId
     workerPoolId
     recentTasks {
       taskId

--- a/ui/src/views/Provisioners/ViewWorkers/workers.graphql
+++ b/ui/src/views/Provisioners/ViewWorkers/workers.graphql
@@ -23,6 +23,10 @@ query ViewWorkers($provisionerId: String!, $workerType: String!, $workersConnect
         firstClaim
         quarantineUntil
         lastDateActive
+        state
+        capacity
+        providerId
+        workerPoolId
       }
     }
   }


### PR DESCRIPTION
Addresses PR comments from @petemoore on #5491.

> Don't allow additional properties in `worker-response.yml` schema. Updated descriptions in `worker-response.yml` and `list-workers-response.yml` schemas to explain some default values that may occur in the case where the queue knows about the worker, but worker manager does not. Also, updated the GraphQL queries to extract additional needed data.