### PR TITLE
fix: use `standalone` over `unmanaged`

### DIFF
--- a/changelog/Ot8d0idDQ5-8wEglwamz_g.md
+++ b/changelog/Ot8d0idDQ5-8wEglwamz_g.md
@@ -1,0 +1,4 @@
+audience: general
+level: patch
+---
+This fixes the default worker state of a worker not known by worker manager to be `standalone` as opposed to `unmanaged` to be consistent with the rest of the project. This issue was first brought up in v44.16.0

--- a/clients/client-go/tcworkermanager/types.go
+++ b/clients/client-go/tcworkermanager/types.go
@@ -361,7 +361,7 @@ type (
 		// a "stopped" worker is completely stopped.  Stopped workers are kept for historical
 		// purposes and are purged when they expire.  Note that some providers transition workers
 		// directly from "running" to "stopped".
-		// An "unmanaged" worker is a worker that is not managed by worker-manager, these workers
+		// An "standalone" worker is a worker that is not managed by worker-manager, these workers
 		// are only known by the queue.
 		//
 		// Possible values:
@@ -369,7 +369,7 @@ type (
 		//   * "running"
 		//   * "stopping"
 		//   * "stopped"
-		//   * "unmanaged"
+		//   * "standalone"
 		State string `json:"state,omitempty"`
 
 		// Identifier for the worker group containing this worker.
@@ -892,7 +892,7 @@ type (
 		// a "stopped" worker is completely stopped.  Stopped workers are kept for historical
 		// purposes and are purged when they expire.  Note that some providers transition workers
 		// directly from "running" to "stopped".
-		// An "unmanaged" worker is a worker that is not managed by worker-manager, these workers
+		// An "standalone" worker is a worker that is not managed by worker-manager, these workers
 		// are only known by the queue.
 		//
 		// Possible values:
@@ -900,7 +900,7 @@ type (
 		//   * "running"
 		//   * "stopping"
 		//   * "stopped"
-		//   * "unmanaged"
+		//   * "standalone"
 		State string `json:"state,omitempty"`
 
 		// Identifier for group that worker who executes this run is a part of,

--- a/generated/references.json
+++ b/generated/references.json
@@ -116,13 +116,13 @@
           "uniqueItems": false
         },
         "state": {
-          "description": "A string specifying the state this worker is in so far as worker-manager knows.\nA \"requested\" worker is in the process of starting up, and if successful will enter\nthe \"running\" state once it has registered with the `registerWorker` API method.  A\n\"stopping\" worker is in the process of shutting down and deleting resources, while\na \"stopped\" worker is completely stopped.  Stopped workers are kept for historical\npurposes and are purged when they expire.  Note that some providers transition workers\ndirectly from \"running\" to \"stopped\".\nAn \"unmanaged\" worker is a worker that is not managed by worker-manager, these workers\nare only known by the queue.\n",
+          "description": "A string specifying the state this worker is in so far as worker-manager knows.\nA \"requested\" worker is in the process of starting up, and if successful will enter\nthe \"running\" state once it has registered with the `registerWorker` API method.  A\n\"stopping\" worker is in the process of shutting down and deleting resources, while\na \"stopped\" worker is completely stopped.  Stopped workers are kept for historical\npurposes and are purged when they expire.  Note that some providers transition workers\ndirectly from \"running\" to \"stopped\".\nAn \"standalone\" worker is a worker that is not managed by worker-manager, these workers\nare only known by the queue.\n",
           "enum": [
             "requested",
             "running",
             "stopping",
             "stopped",
-            "unmanaged"
+            "standalone"
           ],
           "title": "State",
           "type": "string"
@@ -1305,13 +1305,13 @@
                 "type": "string"
               },
               "state": {
-                "description": "A string specifying the state this worker is in so far as worker-manager knows.\nA \"requested\" worker is in the process of starting up, and if successful will enter\nthe \"running\" state once it has registered with the `registerWorker` API method.  A\n\"stopping\" worker is in the process of shutting down and deleting resources, while\na \"stopped\" worker is completely stopped.  Stopped workers are kept for historical\npurposes and are purged when they expire.  Note that some providers transition workers\ndirectly from \"running\" to \"stopped\".\nAn \"unmanaged\" worker is a worker that is not managed by worker-manager, these workers\nare only known by the queue.\n",
+                "description": "A string specifying the state this worker is in so far as worker-manager knows.\nA \"requested\" worker is in the process of starting up, and if successful will enter\nthe \"running\" state once it has registered with the `registerWorker` API method.  A\n\"stopping\" worker is in the process of shutting down and deleting resources, while\na \"stopped\" worker is completely stopped.  Stopped workers are kept for historical\npurposes and are purged when they expire.  Note that some providers transition workers\ndirectly from \"running\" to \"stopped\".\nAn \"standalone\" worker is a worker that is not managed by worker-manager, these workers\nare only known by the queue.\n",
                 "enum": [
                   "requested",
                   "running",
                   "stopping",
                   "stopped",
-                  "unmanaged"
+                  "standalone"
                 ],
                 "title": "State",
                 "type": "string"

--- a/services/web-server/src/graphql/Workers.graphql
+++ b/services/web-server/src/graphql/Workers.graphql
@@ -63,7 +63,7 @@ type Worker {
   lastDateActive: DateTime
 
   # The current state of the worker.
-  # One of [`requested`, `running`, `stopping`, `stopped`, `unmanaged`].
+  # One of [`requested`, `running`, `stopping`, `stopped`, `standalone`].
   state: String
 
   # The current capacity of the worker.

--- a/services/worker-manager/schemas/v1/list-workers-response.yml
+++ b/services/worker-manager/schemas/v1/list-workers-response.yml
@@ -70,10 +70,10 @@ properties:
             a "stopped" worker is completely stopped.  Stopped workers are kept for historical
             purposes and are purged when they expire.  Note that some providers transition workers
             directly from "running" to "stopped".
-            An "unmanaged" worker is a worker that is not managed by worker-manager, these workers
+            An "standalone" worker is a worker that is not managed by worker-manager, these workers
             are only known by the queue.
           type: string
-          enum: ["requested", "running", "stopping", "stopped", "unmanaged"]
+          enum: ["requested", "running", "stopping", "stopped", "standalone"]
         capacity:
           title: Worker Capacity
           description: |

--- a/services/worker-manager/schemas/v1/worker-response.yml
+++ b/services/worker-manager/schemas/v1/worker-response.yml
@@ -123,10 +123,10 @@ properties:
       a "stopped" worker is completely stopped.  Stopped workers are kept for historical
       purposes and are purged when they expire.  Note that some providers transition workers
       directly from "running" to "stopped".
-      An "unmanaged" worker is a worker that is not managed by worker-manager, these workers
+      An "standalone" worker is a worker that is not managed by worker-manager, these workers
       are only known by the queue.
     type: string
-    enum: ["requested", "running", "stopping", "stopped", "unmanaged"]
+    enum: ["requested", "running", "stopping", "stopped", "standalone"]
   capacity:
     title: Worker Capacity
     description: |

--- a/services/worker-manager/src/api.js
+++ b/services/worker-manager/src/api.js
@@ -902,7 +902,7 @@ builder.declare({
         firstClaim: worker.firstClaim?.toJSON(),
         lastDateActive: worker.lastDateActive?.toJSON(),
         workerPoolId: worker.workerPoolId,
-        state: worker.state || 'unmanaged',
+        state: worker.state || 'standalone',
         capacity: worker.capacity || 0,
         providerId: worker.providerId || 'none',
       };

--- a/services/worker-manager/src/data.js
+++ b/services/worker-manager/src/data.js
@@ -425,7 +425,7 @@ class Worker {
       providerId: this.providerId || 'none',
       created: this.created?.toJSON(),
       expires: this.expires?.toJSON(),
-      state: this.state || 'unmanaged',
+      state: this.state || 'standalone',
       capacity: this.capacity || 0,
       lastModified: this.lastModified?.toJSON(),
       lastChecked: this.lastChecked?.toJSON(),

--- a/ui/src/utils/labels.js
+++ b/ui/src/utils/labels.js
@@ -11,7 +11,7 @@ export default {
   REQUESTED: 'default',
   STOPPING: 'warning',
   STOPPED: 'error',
-  UNMANAGED: 'info',
+  STANDALONE: 'info',
   // deprecated, but still supported for old tasks
   SUPERSEDED: 'default',
   CLAIM_EXPIRED: 'info',


### PR DESCRIPTION
> This fixes the default worker state of a worker not known by worker manager to be `standalone` as opposed to `unmanaged` to be consistent with the rest of the project. This issue was first brought up in v44.16.0

Thanks @djmitche for pointing this out to us!