### PR TITLE
Add missing rerun scope for github handler.

### DIFF
--- a/changelog/issue-5503.md
+++ b/changelog/issue-5503.md
@@ -1,0 +1,6 @@
+audience: users
+level: patch
+reference: issue 5503
+---
+
+Add missing task-rerun scope to github handler.

--- a/services/github/src/handlers/index.js
+++ b/services/github/src/handlers/index.js
@@ -196,7 +196,7 @@ class Handlers {
         bindings: rerunBindings,
         queueName: this.rerunQueueName,
       },
-      this.monitor.timedHandler('tasklistener', callHandler('rerun', rerunHandler).bind(this)),
+      this.monitor.timedHandler('rerunlistener', callHandler('rerun', rerunHandler).bind(this)),
     );
 
   }

--- a/services/github/src/handlers/rerun.js
+++ b/services/github/src/handlers/rerun.js
@@ -2,6 +2,9 @@ const { makeDebug } = require('./utils');
 
 /**
  * Github events that request a task rerun.
+ *
+ * To be able to rerun a task, client will assume `repo:github.com/<owner>/<repo>:rerun` role.
+ * This role needs to be defined and should include scopes necessary to call `queue.rerunTask`
  **/
 async function rerunHandler(message) {
   const { checkRunId, checkSuiteId, organization, eventId, installationId, details } = message.payload;
@@ -32,7 +35,7 @@ async function rerunHandler(message) {
 
   try {
     const limitedQueueClient = this.queueClient.use({
-      authorizedScopes: [`assume:repo:github.com/${organization}/${repo}`],
+      authorizedScopes: [`assume:repo:github.com/${organization}/${repo}:rerun`],
     });
     const taskStatus = await limitedQueueClient.rerunTask(taskId);
     debug('Response', { taskStatus });

--- a/services/github/test/handler_test.js
+++ b/services/github/test/handler_test.js
@@ -1162,7 +1162,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       assert.equal(reruns.length, 1);
       assert.equal(reruns[0], taskId);
       assert.deepEqual(usedScopes, [{
-        authorizedScopes: ['assume:repo:github.com/taskcluster/taskcluster'],
+        authorizedScopes: ['assume:repo:github.com/taskcluster/taskcluster:rerun'],
       }]);
     });
     test('do nothing if invalid payload is provided', async function () {


### PR DESCRIPTION
Fixes #5503

To be able to use `re-run` events, github project must be set up properly.
Github handler will assume `repo:github.com:/$org/$repo:pull-request` role when calling `queue.rerunTask()`
This means this role needs to be defined, and it should include necessary scopes to make that call:  

https://github.com/taskcluster/taskcluster/blob/cc0c17e2601075ad328ae5d2af2ce2edcf71d266/services/queue/src/api.js#L761-L767
