### PR TITLE
feat(logs): make provision failed log searchable

### DIFF
--- a/changelog/VbwHlWIoRiSpUjyjwY025g.md
+++ b/changelog/VbwHlWIoRiSpUjyjwY025g.md
@@ -1,0 +1,4 @@
+audience: general
+level: patch
+---
+This patch adds a new field to be logged out on a failed provision call. This field will be used to measure the provisioning failed count.

--- a/services/worker-manager/src/provisioner.js
+++ b/services/worker-manager/src/provisioner.js
@@ -159,7 +159,12 @@ class Provisioner {
           };
           await provider.provision({ workerPool, workerInfo });
         } catch (err) {
-          this.monitor.reportError(err, { providerId: workerPool.providerId }); // Just report this and move on
+          this.monitor.reportError(err,
+            {
+              providerId: workerPool.providerId,
+              type: 'provisioning-failed',
+            },
+          ); // Just report this and move on
         }
 
         await Promise.all(previousProviderIds.map(async pId => {


### PR DESCRIPTION
> This patch adds a new field to be logged out on a failed provision call. This field will be used to measure the provisioning failed count.