### PR TITLE
chore: clean up unreachable code

### DIFF
--- a/changelog/OTS0C0L3Sumu_0ZiHkKDLg.md
+++ b/changelog/OTS0C0L3Sumu_0ZiHkKDLg.md
@@ -1,0 +1,3 @@
+audience: general
+level: silent
+---

--- a/ui/src/components/WorkersTable/index.jsx
+++ b/ui/src/components/WorkersTable/index.jsx
@@ -337,11 +337,7 @@ export default class WorkersTable extends Component {
                       workerGroup,
                       workerId
                     )}
-                    tooltipProps={{
-                      title: ['static', 'none'].includes(providerId)
-                        ? 'Cannot Terminate Static/Standalone Worker'
-                        : 'Terminate Worker',
-                    }}>
+                    tooltipProps={{ title: 'Terminate Worker' }}>
                     Terminate
                   </Button>
                 )}


### PR DESCRIPTION
Left a tiny chunk of unreachable code in https://github.com/taskcluster/taskcluster/pull/5505. This removes it. It's not needed anymore because a terminate button is not even visible due to the `enableTerminate()` check. https://github.com/taskcluster/taskcluster/blob/eaa8a1c8672b27bc60a1c46e558bae1efbafa7fb/ui/src/components/WorkersTable/index.jsx#L329