### PR TITLE
fix: always return `quarantineUntil` field in worker manager X queue methods

### DIFF
--- a/changelog/WFqYtmKPQfuMVMkhEKU9ug.md
+++ b/changelog/WFqYtmKPQfuMVMkhEKU9ug.md
@@ -1,0 +1,4 @@
+audience: general
+level: patch
+---
+This patch returns up the `quarantineUntil` field in the `workerManager.getWorker` and `workerManager.listWorkers` methods. This issue was first noticed in v44.15.0.

--- a/services/worker-manager/src/api.js
+++ b/services/worker-manager/src/api.js
@@ -905,12 +905,10 @@ builder.declare({
         state: worker.state || 'standalone',
         capacity: worker.capacity || 0,
         providerId: worker.providerId || 'none',
+        quarantineUntil: worker.quarantineUntil?.toJSON(),
       };
       if (worker.recentTasks.length > 0) {
         entry.latestTask = worker.recentTasks[worker.recentTasks.length - 1];
-      }
-      if (worker.quarantineUntil?.getTime() > now.getTime()) {
-        entry.quarantineUntil = worker.quarantineUntil.toJSON();
       }
       return entry;
     }),

--- a/services/worker-manager/src/data.js
+++ b/services/worker-manager/src/data.js
@@ -432,6 +432,7 @@ class Worker {
       firstClaim: this.firstClaim?.toJSON(),
       recentTasks: _.cloneDeep(this.recentTasks),
       lastDateActive: this.lastDateActive?.toJSON(),
+      quarantineUntil: this.quarantineUntil?.toJSON(),
     };
 
     // Remove properties that should not be in this response schema.
@@ -441,6 +442,7 @@ class Worker {
       delete worker.firstClaim;
       delete worker.recentTasks;
       delete worker.lastDateActive;
+      delete worker.quarantineUntil;
     }
 
     // Remove properties that should not be in this response schema.

--- a/services/worker-manager/test/api_test.js
+++ b/services/worker-manager/test/api_test.js
@@ -683,11 +683,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       workerGroup: input.workerGroup,
       workerId: input.workerId,
     });
-    const expected = worker.serializable();
-    // remove properties that come from queue_workers table
-    delete expected.firstClaim;
-    delete expected.recentTasks;
-    delete expected.lastDateActive;
+    const expected = worker.serializable({ removeQueueData: true });
 
     assert(!('secret' in data));
     assert.deepStrictEqual(data, expected);


### PR DESCRIPTION
> This patch returns up the `quarantineUntil` field in the `workerManager.getWorker` and `workerManager.listWorkers` methods. This issue was first noticed in v44.15.0.