### PR TITLE
Chore: simplify dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -7,3 +7,5 @@ dev-config.yml
 artifacts
 **/.nyc_output
 clients/client-rust/target
+ui/build
+temp

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,18 +23,8 @@ RUN cp -r /base/yarn/node_modules /base/app/
 RUN cp -r /base/yarn-ui/node_modules /base/app/ui/
 
 # copy the repository into the image, including the entrypoint
-COPY / /base/repo
-
-# We have to do this rather than git clone because
-# git won't let us clone into a non-empty repo
-# We do this git stuff at all so that we don't
-# make images with things people have in their
-# personal gitignores, etc
 WORKDIR /base/app
-RUN git init
-RUN git remote add origin /base/repo
-RUN git pull --tags origin HEAD
-
+COPY . /base/app
 RUN chmod +x entrypoint
 
 # Write out the DockerFlow-compatible version.json file
@@ -42,7 +32,7 @@ ARG DOCKER_FLOW_VERSION
 RUN if [ -n "${DOCKER_FLOW_VERSION}" ]; then \
     echo "${DOCKER_FLOW_VERSION}" > version.json; \
 else \
-    echo \{\"version\": \"$(git describe --tags --always --match v*.*.*)\", \"commit\": \"$(git rev-parse HEAD)\", \"source\": \"https://github.com/taskcluster/taskcluster\", \"build\": \"NONE\"\} > version.json; \
+    echo \{\"version\": \"44.16.3\", \"commit\": \"local\", \"source\": \"https://github.com/taskcluster/taskcluster\", \"build\": \"NONE\"\} > version.json; \
 fi
 
 # Build the UI and discard everything else in that directory

--- a/changelog/SJGgNo-aRKqg50gsxBZ7Bw.md
+++ b/changelog/SJGgNo-aRKqg50gsxBZ7Bw.md
@@ -1,0 +1,3 @@
+audience: developers
+level: silent
+---

--- a/infrastructure/tooling/src/release/tasks.js
+++ b/infrastructure/tooling/src/release/tasks.js
@@ -215,6 +215,13 @@ module.exports = ({ tasks, cmdOptions, credentials }) => {
         changed.push(file);
       }
 
+      utils.status({ message: 'Dockerfile' });
+      await modifyRepoFile('Dockerfile',
+        contents => contents.replace(
+          /\\"version\\":\s*\\"([0-9]{1,2}\.[0-9]{1,2}\.[0-9]{1,2})/gm,
+          `\\"version\\": \\"${requirements['release-version']}`));
+      changed.push('Dockerfile');
+
       return { 'version-updated': changed };
     },
   });


### PR DESCRIPTION
Git init/pull steps inside Dockerfile are redundant, as build task is making sure that folder is clean.
This will also allow to build image with external integration tools (google cloud build).
Release task is updating version inside Dockerfile
