### PR TITLE
fix(ui): fix quarantine value to ignore past dates

### DIFF
--- a/changelog/issue-5517.md
+++ b/changelog/issue-5517.md
@@ -1,0 +1,5 @@
+audience: users
+level: patch
+reference: issue 5517
+---
+This patch fixes the quarantined value on the workers table to be `n/a` if the quarantined value is in the past. This issue was first noticed in v44.16.3.

--- a/ui/src/components/WorkersTable/index.jsx
+++ b/ui/src/components/WorkersTable/index.jsx
@@ -317,7 +317,8 @@ export default class WorkersTable extends Component {
                 <TableCell>n/a</TableCell>
               )}
               <TableCell>
-                {quarantineUntil ? (
+                {quarantineUntil &&
+                parseISO(quarantineUntil).getTime() > new Date().getTime() ? (
                   formatDistanceStrict(new Date(), parseISO(quarantineUntil), {
                     unit: 'day',
                   })


### PR DESCRIPTION
Addresses #5517.

> This patch fixes the quarantined value on the workers table to be `n/a` if the quarantined value is in the past. This issue was first noticed in v44.16.3.