### PR TITLE
fix: migrate to `process.hrtime.bigint()`

### DIFF
--- a/changelog/issue-5319.md
+++ b/changelog/issue-5319.md
@@ -1,0 +1,6 @@
+audience: general
+level: patch
+reference: issue 5319
+---
+This patch migrates the legacy, `process.hrtime([time])` to the new, `process.hrtime.bigint()`.
+See [Node Docs](https://nodejs.org/docs/latest-v16.x/api/process.html#processhrtimetime) for more information.

--- a/libraries/api/src/middleware/logging.js
+++ b/libraries/api/src/middleware/logging.js
@@ -1,4 +1,5 @@
 const { MonitorManager } = require('taskcluster-lib-monitor');
+const { hrtime } = require('process');
 
 MonitorManager.register({
   name: 'apiMethod',
@@ -51,7 +52,7 @@ MonitorManager.register({
 const logRequest = ({ builder, entry }) => {
   return (req, res, next) => {
     let sent = false;
-    const start = process.hrtime();
+    const start = hrtime.bigint();
     const send = async () => {
       // Avoid sending twice
       if (sent) {
@@ -73,7 +74,7 @@ const logRequest = ({ builder, entry }) => {
         query['bewit'] = '...';
       }
 
-      const d = process.hrtime(start);
+      const end = hrtime.bigint();
 
       req.tcContext.monitor.log.apiMethod({
         name: entry.name,
@@ -93,7 +94,7 @@ const logRequest = ({ builder, entry }) => {
         sourceIp: req.ip,
         satisfyingScopes: req.satisfyingScopes ? req.satisfyingScopes : [],
         statusCode: res.statusCode,
-        duration: d[0] * 1000 + d[1] / 1000000,
+        duration: Number(end - start) / 1e6, // in ms
       });
     };
     res.once('finish', send);

--- a/libraries/iterate/src/index.js
+++ b/libraries/iterate/src/index.js
@@ -1,6 +1,7 @@
 const WatchDog = require('./watchdog');
 const debug = require('debug')('iterate');
 const events = require('events');
+const { hrtime } = require('process');
 
 /**
  * The Iterate Class.  See README.md for explanation of constructor
@@ -128,14 +129,14 @@ class Iterate extends events.EventEmitter {
 
       this.emit('iteration-start');
 
-      const start = process.hrtime();
+      const start = hrtime.bigint();
       try {
         await this.single_iteration();
       } catch (err) {
         iterError = err;
       }
-      const d = process.hrtime(start);
-      const duration = d[0] * 1000 + d[1] / 1000000;
+      const end = hrtime.bigint();
+      const duration = Number(end - start) / 1e6; // in ms
 
       this.emit(iterError ? 'iteration-failure' : 'iteration-success');
 

--- a/libraries/monitor/src/monitor.js
+++ b/libraries/monitor/src/monitor.js
@@ -2,6 +2,7 @@ const _ = require('lodash');
 const assert = require('assert');
 const { Logger } = require('./logger');
 const TimeKeeper = require('./timekeeper');
+const { hrtime } = require('process');
 
 class Monitor {
   constructor({
@@ -113,12 +114,12 @@ class Monitor {
    * The most basic timer.
    */
   timer(key, funcOrPromise) {
-    const start = process.hrtime();
-    const done = (x) => {
-      const d = process.hrtime(start);
+    const start = hrtime.bigint();
+    const done = () => {
+      const end = hrtime.bigint();
       this.log.basicTimer({
         key,
-        duration: d[0] * 1000 + d[1] / 1000000,
+        duration: Number(end - start) / 1e6, // in ms
       });
     };
     if (funcOrPromise instanceof Function) {
@@ -141,7 +142,7 @@ class Monitor {
    */
   timedHandler(name, handler) {
     return async (message) => {
-      const start = process.hrtime();
+      const start = hrtime.bigint();
       let success = 'success';
       try {
         await handler(message);
@@ -149,11 +150,11 @@ class Monitor {
         success = 'error';
         throw e;
       } finally {
-        const d = process.hrtime(start);
+        const end = hrtime.bigint();
         this.log.handlerTimer({
           name,
           status: success,
-          duration: d[0] * 1000 + d[1] / 1000000,
+          duration: Number(end - start) / 1e6, // in ms
         });
       }
     };
@@ -193,7 +194,7 @@ class Monitor {
    */
   async oneShot(name, fn) {
     let exitStatus = 0;
-    const start = process.hrtime();
+    const start = hrtime.bigint();
     try {
       assert.equal(typeof name, 'string');
       assert.equal(typeof fn, 'function');
@@ -203,10 +204,10 @@ class Monitor {
       this.reportError(err);
       exitStatus = 1;
     } finally {
-      const d = process.hrtime(start);
+      const end = hrtime.bigint();
       this.log.periodic({
         name,
-        duration: d[0] * 1000 + d[1] / 1000000,
+        duration: Number(end - start) / 1e6, // in ms
         status: exitStatus ? 'exception' : 'success',
       }, { level: exitStatus ? 'err' : 'notice' });
       if (!this.fake || this.fake.allowExit) {

--- a/libraries/monitor/src/timekeeper.js
+++ b/libraries/monitor/src/timekeeper.js
@@ -1,3 +1,5 @@
+const { hrtime } = require('process');
+
 /**
  * A TimeKeeper is used for measuring arbitrary times.  This is nice when the
  * action to time does not fit neatly into a single function or promise.  A
@@ -13,7 +15,7 @@ class TimeKeeper {
   constructor(monitor, name) {
     this.monitor = monitor;
     this.name = name;
-    this.start = process.hrtime();
+    this.start = hrtime.bigint();
     this.submitted = false;
   }
 
@@ -26,10 +28,10 @@ class TimeKeeper {
       throw new Error('Cannot submit measurement twice for ' + this.monitor.prefix + ' ' + this.name);
     }
     this.submitted = true;
-    const d = process.hrtime(this.start);
+    const end = hrtime.bigint();
     this.monitor.log.timekeeper(Object.assign({
       key: this.name,
-      duration: d[0] * 1000 + d[1] / 1000000,
+      duration: Number(end - this.start) / 1e6, // in ms
     }, extra));
   }
 }

--- a/workers/docker-worker/src/features/artifacts.js
+++ b/workers/docker-worker/src/features/artifacts.js
@@ -9,6 +9,7 @@ const mime = require('mime');
 const tarStream = require('tar-stream');
 const Debug = require('debug');
 const assert = require('assert');
+const { hrtime } = require('process');
 
 const { fmtLog, fmtErrorLog } = require('../log');
 const uploadToS3 = require('../upload_to_s3');
@@ -149,14 +150,14 @@ class Artifacts {
         assert.ok(region);
 
         let monitor = taskHandler.runtime.monitor;
-        let start = process.hrtime();
+        const start = hrtime.bigint();
 
         let { digest, size } = await uploadToS3(taskHandler.queue, taskId, runId, stream,
           entryName, expiry, headers, null, null, compress);
 
         // save the time taken to upload the artifact
-        let elapsedTime = process.hrtime(start);
-        let uploadTime = elapsedTime[0] * 1e3 + elapsedTime[1] / 1e6; // in miliseconds
+        const end = hrtime.bigint();
+        let uploadTime = Number(end - start) / 1e6; // in ms
 
         // report metrics globally...
         monitor.measure('artifacts.global.size', size);

--- a/workers/docker-worker/src/monitor/timekeeper.js
+++ b/workers/docker-worker/src/monitor/timekeeper.js
@@ -1,3 +1,5 @@
+const { hrtime } = require('process');
+
 /**
  * A TimeKeeper is used for measuring arbitrary times.  This is nice when the
  * action to time does not fit neatly into a single function or promise.  A
@@ -13,7 +15,7 @@ class TimeKeeper {
   constructor(monitor, name) {
     this.monitor = monitor;
     this.name = name;
-    this.start = process.hrtime();
+    this.start = hrtime.bigint();
     this.submitted = false;
   }
 
@@ -26,10 +28,10 @@ class TimeKeeper {
       throw new Error('Cannot submit measurement twice for ' + this.monitor.prefix + ' ' + this.name);
     }
     this.submitted = true;
-    const d = process.hrtime(this.start);
+    const end = hrtime.bigint();
     this.monitor.log.timekeeper(Object.assign({
       key: this.name,
-      duration: d[0] * 1000 + d[1] / 1000000,
+      duration: Number(end - this.start) / 1e6, // in ms
     }, extra));
   }
 }


### PR DESCRIPTION
Addresses https://github.com/taskcluster/taskcluster/issues/5319.

> This patch migrates the legacy, `process.hrtime([time])` to the new, `process.hrtime.bigint()`.
See [Node Docs](https://nodejs.org/docs/latest-v16.x/api/process.html#processhrtimetime) for more information.