### PR TITLE
feat(github): Avoid TypeErrors for cron tasks

### DIFF
--- a/changelog/issue-5391.md
+++ b/changelog/issue-5391.md
@@ -1,0 +1,8 @@
+audience: developers
+level: patch
+reference: issue 5391
+---
+
+Skip github checks if github build is unkown.
+This happens in periodic and manual hooks that are doing some periodic operations on github repo.
+Those operations are not initiated by github, so there is no new build/check suite created for those events.

--- a/services/github/src/handlers/status.js
+++ b/services/github/src/handlers/status.js
@@ -16,6 +16,10 @@ async function statusHandler(message) {
   let conclusion = CONCLUSIONS[reasonResolved || state];
 
   let [build] = await this.context.db.fns.get_github_build(taskGroupId);
+  if (!build) {
+    debug(`No github build is associated with task group ${taskGroupId}. Most likely this was triggered by periodic cron hook, which doesn't require github event / check suite.`);
+    return false;
+  }
 
   let { organization, repository, sha, event_id, event_type, installation_id } = build;
 

--- a/services/github/test/handler_test.js
+++ b/services/github/test/handler_test.js
@@ -754,7 +754,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
     }
 
     function assertStatusCreate(state) {
-      assert(github.inst(9988).checks.create.called, 'checks. create was not called');
+      assert(github.inst(9988).checks.create.called, 'checks.create was not called');
 
       github.inst(9988).checks.create.firstCall.args.forEach(args => {
         if (args.state === state) {
@@ -968,6 +968,18 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       monitor.manager.reset();
       sinon.restore();
     });
+
+    test('skip status update when build is not defined', async function () {
+      // Some tasks will be create without github events, like periodic cron hooks
+      await simulateExchangeMessage({
+        taskGroupId: TASKGROUPID,
+        exchange: 'exchange/taskcluster-queue/v1/task-completed',
+        routingKey: 'route.checks',
+        taskId: TASKID,
+      });
+      assert.equal(false, github.inst(9988).checks.update.called);
+      assert.equal(false, github.inst(9988).checks.create.called);
+    });
   });
 
   suite('Statuses API: initial status handler', function() {
@@ -1051,6 +1063,17 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
         taskId: TASKID,
       });
       assertStatusCreate('pending');
+    });
+
+    test('skip check when build is not defined', async function () {
+      // Some tasks will be create without github events, like periodic cron hooks
+      await simulateExchangeMessage({
+        taskGroupId: TASKGROUPID,
+        exchange: 'exchange/taskcluster-queue/v1/task-defined',
+        routingKey: 'route.checks',
+        taskId: TASKID,
+      });
+      assert.equal(false, github.inst(9988).checks.create.called);
     });
   });
 


### PR DESCRIPTION
Skip github checks if github build is unkown.
This happens in periodic and manual hooks that are doing some periodic operations on github repo.
Those operations are not initiated by github, so there is no new build/check suite created for those events.

Fixes #5391
