### PR TITLE
Add docker-compose-override.yml to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,3 +77,4 @@ __pycache__
 
 # docker-compose artifacts
 /docker/buckets
+docker-compose.override.yml

--- a/changelog/RL_V3EpeSC-YafwwUKM7HA.md
+++ b/changelog/RL_V3EpeSC-YafwwUKM7HA.md
@@ -1,0 +1,3 @@
+audience: general
+level: silent
+---


### PR DESCRIPTION
If I've understood correctly from [here](https://github.com/taskcluster/taskcluster/blob/main/dev-docs/development-process.md#development-and-debugging-using-docker-compose), we should never commit a `docker-compose-override.yml` file to the repository, so this should help avoid that we do. I believe this filename is fixed (or at least the default), so that it is unlikely you would override settings with a filename of a different name. If that isn't the case, maybe this PR isn't useful and we can close it.

Thanks!