### PR TITLE
Change the access token input to be a password field

### DIFF
--- a/changelog/ZKSl9L0dQMKI1pu5VUaMlQ.md
+++ b/changelog/ZKSl9L0dQMKI1pu5VUaMlQ.md
@@ -1,0 +1,4 @@
+audience: users
+level: patch
+---
+Set the `key` field on the login window to a password field instead of a text one

--- a/ui/src/components/SignInDialog/CredentialsDialog.jsx
+++ b/ui/src/components/SignInDialog/CredentialsDialog.jsx
@@ -86,6 +86,7 @@ export default class CredentialsDialog extends Component {
               value={accessToken}
               onChange={this.handleFieldChange}
               error={!accessToken && accessToken !== ''}
+              type="password"
               required
               fullWidth
             />


### PR DESCRIPTION
It doesn't much sense to have what is essentially a password be
displayed in plain text.
This also makes it so a password manager would recognize the form as a
login form and is able to automatically fill it.