### PR TITLE
Fix docker compose sometimes not starting up the ingress container

### DIFF
--- a/changelog/TY9RHwsbTDC4afWvLixzoQ.md
+++ b/changelog/TY9RHwsbTDC4afWvLixzoQ.md
@@ -1,0 +1,4 @@
+audience: developers
+level: patch
+---
+Fix docker compose sometimes not starting the ingress container

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -16,88 +16,103 @@ http {
     server_name _;
 
     location / {
-      proxy_pass http://ui;
+      set $pass http://ui;
+      proxy_pass $pass;
       proxy_hide_header Content-Security-Policy;
       proxy_set_header Host ingress;
     }
     location /login {
-      proxy_pass http://web-server-web:3050;
+      set $pass http://web-server-web:3050;
+      proxy_pass $pass;
       proxy_hide_header Content-Security-Policy;
       proxy_set_header Host ingress;
     }
     location /graphql {
-      proxy_pass http://web-server-web:3050;
+      set $pass http://web-server-web:3050;
+      proxy_pass $pass;
       proxy_hide_header Content-Security-Policy;
       proxy_set_header Host ingress;
     }
     location /subscription {
-      proxy_pass http://web-server-web:3050;
+      set $pass http://web-server-web:3050;
+      proxy_pass $pass;
       proxy_hide_header Content-Security-Policy;
       proxy_set_header Host ingress;
     }
 
     location /api/auth {
-      proxy_pass http://auth-web;
+      set $pass http://auth-web;
+      proxy_pass $pass;
       proxy_hide_header Content-Security-Policy;
       proxy_set_header Host ingress;
     }
 
     location /api/github {
-      proxy_pass http://github-web;
+      set $pass http://github-web;
+      proxy_pass $pass;
       proxy_hide_header Content-Security-Policy;
       proxy_set_header Host ingress;
     }
 
     location /api/hooks {
-      proxy_pass http://hooks-web;
+      set $pass http://hooks-web;
+      proxy_pass $pass;
       proxy_hide_header Content-Security-Policy;
       proxy_set_header Host ingress;
     }
 
     location /api/index {
-      proxy_pass http://index-web;
+      set $pass http://index-web;
+      proxy_pass $pass;
       proxy_hide_header Content-Security-Policy;
       proxy_set_header Host ingress;
     }
 
     location /api/notify {
-      proxy_pass http://notify-web;
+      set $pass http://notify-web;
+      proxy_pass $pass;
       proxy_hide_header Content-Security-Policy;
       proxy_set_header Host ingress;
     }
 
     location /api/object {
-      proxy_pass http://object-web;
+      set $pass http://object-web;
+      proxy_pass $pass;
       proxy_hide_header Content-Security-Policy;
       proxy_set_header Host ingress;
     }
 
     location /api/purge-cache {
-      proxy_pass http://purge-cache-web;
+      set $pass http://purge-cache-web;
+      proxy_pass $pass;
       proxy_hide_header Content-Security-Policy;
       proxy_set_header Host ingress;
     }
 
     location /api/queue {
-      proxy_pass http://queue-web;
+      set $pass http://queue-web;
+      proxy_pass $pass;
       proxy_hide_header Content-Security-Policy;
       proxy_set_header Host ingress;
     }
 
     location /api/secrets {
-      proxy_pass http://secrets-web;
+      set $pass http://secrets-web;
+      proxy_pass $pass;
       proxy_hide_header Content-Security-Policy;
       proxy_set_header Host ingress;
     }
 
     location /api/web-server {
-      proxy_pass http://web-server-web;
+      set $pass http://web-server-web;
+      proxy_pass $pass;
       proxy_hide_header Content-Security-Policy;
       proxy_set_header Host ingress;
     }
 
     location /api/worker-manager {
-      proxy_pass http://worker-manager-web;
+      set $pass http://worker-manager-web;
+      proxy_pass $pass;
       proxy_hide_header Content-Security-Policy;
       proxy_set_header Host ingress;
     }

--- a/infrastructure/tooling/src/generate/generators/docker-compose.js
+++ b/infrastructure/tooling/src/generate/generators/docker-compose.js
@@ -375,24 +375,29 @@ http {
     server_name _;
 
     location / {
-      proxy_pass http://ui;
+      set $pass http://ui;
+      proxy_pass $pass;
       ${extraDirectives}
     }
     location /login {
-      proxy_pass http://web-server-web:${serviceHostPort('web-server')};
+      set $pass http://web-server-web:${serviceHostPort('web-server')};
+      proxy_pass $pass;
       ${extraDirectives}
     }
     location /graphql {
-      proxy_pass http://web-server-web:${serviceHostPort('web-server')};
+      set $pass http://web-server-web:${serviceHostPort('web-server')};
+      proxy_pass $pass;
       ${extraDirectives}
     }
     location /subscription {
-      proxy_pass http://web-server-web:${serviceHostPort('web-server')};
+      set $pass http://web-server-web:${serviceHostPort('web-server')};
+      proxy_pass $pass;
       ${extraDirectives}
     }
 ${SERVICES.filter(name => !!ports[name]).map(name => `
     location /api/${name} {
-      proxy_pass http://${name}-web;
+      set $pass http://${name}-web;
+      proxy_pass $pass;
       ${extraDirectives}
     }`).join('\n')}
   }


### PR DESCRIPTION
The issue here is that `proxy_pass http://something` will always try to
resolves `something` as soon as nginx starts. By using an intermediate
variable, we force nginx to resolve it later at runtime [1].
Because the `github-web` container exits without any extra config, it
would becomes unresolvable DNS wise and prevent nginx from starting.
Same with other containers if they took too long to start up.

1: https://forum.nginx.org/read.php?2,215830,215832#msg-215832