### PR TITLE
Change references to taskcluster.github.io for JSON-e documentation

### DIFF
--- a/changelog/HItnC6sATOGBZnB41eiffw.md
+++ b/changelog/HItnC6sATOGBZnB41eiffw.md
@@ -1,0 +1,3 @@
+audience: users
+level: silent
+---

--- a/clients/client-go/tchooks/types.go
+++ b/clients/client-go/tchooks/types.go
@@ -66,7 +66,7 @@ type (
 		// Note that tasks may not be created at exactly the time specified.
 		Schedule []string `json:"schedule,omitempty"`
 
-		// Template for the task definition.  This is rendered using [JSON-e](https://taskcluster.github.io/json-e/)
+		// Template for the task definition.  This is rendered using [JSON-e](https://json-e.js.org/)
 		// as described in [firing hooks](/docs/reference/core/hooks/firing-hooks) to produce
 		// a task definition that is submitted to the Queue service.
 		//
@@ -109,7 +109,7 @@ type (
 		// See [cron-parser on npm](https://www.npmjs.com/package/cron-parser).
 		Schedule []string `json:"schedule"`
 
-		// Template for the task definition.  This is rendered using [JSON-e](https://taskcluster.github.io/json-e/)
+		// Template for the task definition.  This is rendered using [JSON-e](https://json-e.js.org/)
 		// as described in [firing hooks](/docs/reference/core/hooks/firing-hooks) to produce
 		// a task definition that is submitted to the Queue service.
 		//

--- a/generated/references.json
+++ b/generated/references.json
@@ -6344,7 +6344,7 @@
           "$ref": "schedule.json#"
         },
         "task": {
-          "description": "Template for the task definition.  This is rendered using [JSON-e](https://taskcluster.github.io/json-e/)\nas described in [firing hooks](/docs/reference/core/hooks/firing-hooks) to produce\na task definition that is submitted to the Queue service.\n",
+          "description": "Template for the task definition.  This is rendered using [JSON-e](https://json-e.js.org/)\nas described in [firing hooks](/docs/reference/core/hooks/firing-hooks) to produce\na task definition that is submitted to the Queue service.\n",
           "title": "Task Template",
           "type": "object"
         },
@@ -6403,7 +6403,7 @@
           "uniqueItems": true
         },
         "task": {
-          "description": "Template for the task definition.  This is rendered using [JSON-e](https://taskcluster.github.io/json-e/)\nas described in [firing hooks](/docs/reference/core/hooks/firing-hooks) to produce\na task definition that is submitted to the Queue service.\n",
+          "description": "Template for the task definition.  This is rendered using [JSON-e](https://json-e.js.org/)\nas described in [firing hooks](/docs/reference/core/hooks/firing-hooks) to produce\na task definition that is submitted to the Queue service.\n",
           "title": "Task Template",
           "type": "object"
         },

--- a/services/hooks/schemas/v1/create-hook-request.yml
+++ b/services/hooks/schemas/v1/create-hook-request.yml
@@ -27,7 +27,7 @@ properties:
   task:
     title:                "Task Template"
     description: |
-      Template for the task definition.  This is rendered using [JSON-e](https://taskcluster.github.io/json-e/)
+      Template for the task definition.  This is rendered using [JSON-e](https://json-e.js.org/)
       as described in [firing hooks](/docs/reference/core/hooks/firing-hooks) to produce
       a task definition that is submitted to the Queue service.
     type:                 object

--- a/services/hooks/schemas/v1/hook-definition.yml
+++ b/services/hooks/schemas/v1/hook-definition.yml
@@ -12,7 +12,7 @@ properties:
   task:
     title:                "Task Template"
     description: |
-      Template for the task definition.  This is rendered using [JSON-e](https://taskcluster.github.io/json-e/)
+      Template for the task definition.  This is rendered using [JSON-e](https://json-e.js.org/)
       as described in [firing hooks](/docs/reference/core/hooks/firing-hooks) to produce
       a task definition that is submitted to the Queue service.
     type:                 object

--- a/ui/docs/reference/core/hooks/firing-hooks.mdx
+++ b/ui/docs/reference/core/hooks/firing-hooks.mdx
@@ -21,7 +21,7 @@ task's `taskId`.
 ## JSON-e Rendering
 
 A hook definition's `task` property is, in fact, a
-[JSON-e](https://taskcluster.github.io/json-e/) template.  When a hook is
+[JSON-e](https://json-e.js.org/) template.  When a hook is
 fired, that template is rendered and the result is submitted to
 `Queue.createTask`.
 

--- a/ui/docs/reference/core/notify/usage.mdx
+++ b/ui/docs/reference/core/notify/usage.mdx
@@ -79,7 +79,7 @@ channel ID will be the last URL segment. Public channels start with a capital C.
 
 ### Setting Custom Messages
 
-In matrix and email you can set custom messages by adding fields to your task definition. The fields will be rendered with [jsone](https://taskcluster.github.io/json-e/)
+In matrix and email you can set custom messages by adding fields to your task definition. The fields will be rendered with [jsone](https://json-e.js.org/)
 given a context of the [task definition](/docs/reference/platform/queue/api#get-task-definition)
 and the `status` section of [task status](/docs/reference/platform/queue/references/events#message-payload-4).
 The task definition is in the context under the key `task` and the status is in the context under the key `status`. `taskId` is also provided.

--- a/ui/src/components/HookForm/index.jsx
+++ b/ui/src/components/HookForm/index.jsx
@@ -740,7 +740,7 @@ export default class HookForm extends Component {
                     <span>
                       When the hook fires, this template is rendered with{' '}
                       <a
-                        href="https://taskcluster.github.io/json-e/"
+                        href="https://json-e.js.org/"
                         target="_blank"
                         rel="noopener noreferrer">
                         JSON-e


### PR DESCRIPTION
The previous link is dead and following the repo trail brings us here
https://github.com/json-e/json-e with documentation at
https://json-e.js.org/