### PR TITLE
feat(cd): use cloudbuild for CD to a dev env

### DIFF
--- a/changelog/issue-5553.md
+++ b/changelog/issue-5553.md
@@ -1,0 +1,5 @@
+audience: developers
+level: patch
+reference: issue 5553
+---
+This change adds continuous deployment support to the `cloudbuild.yaml` file so that each change to `main` results in a new deployment to [`https://dev.alpha.taskcluster-dev.net/`](https://dev.alpha.taskcluster-dev.net/).

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -40,7 +40,7 @@ options:
   dynamicSubstitutions: true
 substitutions:
   _NODE_VERSION: 16.16.0
-  _VERSION: '{"version":"${BRANCH_NAME}_dev","commit":"${SHORT_SHA}","source":"https://github.com/taskcluster/taskcluster","build":"${BUILD_ID}"}'
+  _VERSION: '{"version":"${BRANCH_NAME}_${SHORT_SHA}","commit":"${SHORT_SHA}","source":"https://github.com/taskcluster/taskcluster","build":"${BUILD_ID}"}'
   _IMAGE_NAME: gcr.io/${PROJECT_ID}/${PROJECT_ID}/${BRANCH_NAME}
   _IMAGE_VERSION: latest
 availableSecrets:

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -3,16 +3,49 @@ steps:
     args:
       - build
       - '--build-arg'
-      - 'DOCKER_FLOW_VERSION=${_VERSION}'
+      - DOCKER_FLOW_VERSION=${_VERSION}
       - '-t'
-      - '${_IMAGE_NAME}'
+      - ${_IMAGE_NAME}:${_IMAGE_VERSION}
       - .
-timeout: 1500s
+    id: Build
+  - name: gcr.io/cloud-builders/docker
+    args:
+      - push
+      - ${_IMAGE_NAME}:${_IMAGE_VERSION}
+    id: Push
+  - name: bash
+    args:
+      - '-c'
+      - echo "$$DEV_CONFIG" > /workspace/dev-config.yml && echo "$$INGRESS" > /workspace/infrastructure/k8s/templates/ingress.yaml
+    id: Get secrets
+    secretEnv:
+      - DEV_CONFIG
+      - INGRESS
+  - name: node:${_NODE_VERSION}
+    args:
+      - '-c'
+      - curl https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash && curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl" && install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl && echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] http://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list && curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key --keyring /usr/share/keyrings/cloud.google.gpg add - && apt-get update -y && apt-get install google-cloud-cli google-cloud-sdk-gke-gcloud-auth-plugin -y && gcloud container clusters get-credentials ${PROJECT_ID} --region us-east1 --project ${PROJECT_ID} && yarn && yarn dev:db:upgrade && yarn dev:apply
+    id: Deploy
+    entrypoint: bash
+  - name: gcr.io/cloud-builders/gcloud
+    args:
+      - '-c'
+      - gcloud container images list-tags ${_IMAGE_NAME} --filter='-tags:*' --format='get(digest)' --limit=unlimited | xargs -I {sha} gcloud container images delete "${_IMAGE_NAME}@{sha}"
+    id: Delete old images
+    entrypoint: bash
+timeout: 1800s
 images:
-  - '${_IMAGE_NAME}'
+  - ${_IMAGE_NAME}:${_IMAGE_VERSION}
 options:
   dynamicSubstitutions: true
 substitutions:
-  _IMAGE_NAME: 'gcr.io/taskcluster-dev/${PROJECT_ID}/${BRANCH_NAME}:latest'
-  _VERSION: >-
-    {"version":"${BRANCH_NAME}_dev","commit":"${SHORT_SHA}","source":"https://github.com/taskcluster/taskcluster","build":"${BUILD_ID}"}
+  _NODE_VERSION: 16.16.0
+  _VERSION: '{"version":"${BRANCH_NAME}_dev","commit":"${SHORT_SHA}","source":"https://github.com/taskcluster/taskcluster","build":"${BUILD_ID}"}'
+  _IMAGE_NAME: gcr.io/${PROJECT_ID}/${PROJECT_ID}/${BRANCH_NAME}
+  _IMAGE_VERSION: latest
+availableSecrets:
+  secretManager:
+    - versionName: projects/${PROJECT_ID}/secrets/dev-config/versions/latest
+      env: DEV_CONFIG
+    - versionName: projects/${PROJECT_ID}/secrets/ingress/versions/latest
+      env: INGRESS

--- a/dev-docs/dev-deployment.md
+++ b/dev-docs/dev-deployment.md
@@ -353,3 +353,9 @@ Warning: by using this approach, you are responsible for maintenance and backups
    Once users are set, you can run `yarn dev:db:upgrade` (with running port-forward) to create db schema and stored functions
 
 Now it should be possible to use postgres for dev purposes inside the cluster. Make sure to make backups.
+
+## GCP Cloud Build
+
+Commits that land on `main` trigger a build on GCP Cloud Build. This build is configured by the [`cloudbuild.yaml` file](../cloudbuild.yaml). Here's a link to Google's docs on the build config file schema for cloud build: https://cloud.google.com/build/docs/build-config-file-schema.
+
+A couple secrets are used in the config and they are both stored in GCP Secret Manager. Follow [these docs](https://cloud.google.com/build/docs/securing-builds/use-secrets) to create more secrets or edit the current secrets. A new version needs to be created each time you change the secrets. The current cloudbuild config points to the latest version of the secrets, so any edits to these secrets will be automatically picked up.

--- a/infrastructure/tooling/src/generate/generators/node-version.js
+++ b/infrastructure/tooling/src/generate/generators/node-version.js
@@ -1,4 +1,4 @@
-const { readRepoFile, modifyRepoFile, writeRepoFile, modifyRepoJSON } = require('../../utils');
+const { readRepoFile, modifyRepoFile, writeRepoFile, modifyRepoJSON, modifyRepoYAML } = require('../../utils');
 
 /**
  * Update the node version to match everywhere, treating that in `package.json`
@@ -64,6 +64,13 @@ exports.tasks = [{
     await modifyRepoJSON('workers/docker-worker/package.json',
       contents => {
         contents.engines.node = nodeVersion;
+        return contents;
+      });
+
+    utils.status({ message: 'cloudbuild.yaml' });
+    await modifyRepoYAML('cloudbuild.yaml',
+      contents => {
+        contents.substitutions._NODE_VERSION = nodeVersion;
         return contents;
       });
   },


### PR DESCRIPTION
Fixes #5553.

> This change adds continuous deployment support to the `cloudbuild.yaml` file so that each change to `main` results in a new deployment to [`https://dev.alpha.taskcluster-dev.net/`](https://dev.alpha.taskcluster-dev.net/).