### PR TITLE
chore(docs): add brew installation docs

### DIFF
--- a/changelog/csJB1kjqSw6D0SDWxeSrWg.md
+++ b/changelog/csJB1kjqSw6D0SDWxeSrWg.md
@@ -1,0 +1,3 @@
+audience: general
+level: silent
+---

--- a/clients/client-shell/README.md
+++ b/clients/client-shell/README.md
@@ -11,13 +11,22 @@ scripts.  It provides utilities ranging from direct calls to the specific API
 endpoints to more complex and _practical_ tasks like listing and cancelling
 scheduled runs.
 
-### Installation
+## Installation
 
-To install, Linux users should download the `taskcluster` binary for the latest release your
+### Homebrew (recommended)
+
+```bash
+brew install taskcluster/tap/taskcluster
+```
+Link to the Homebrew Tap: [taskcluster/homebrew-tap](https://github.com/taskcluster/homebrew-tap).
+
+### Curl
+
+Linux users should download the `taskcluster` binary for the latest release your
 platform, run `chmod +x` and run it!
 
 MacOS users run the following command:
-```shell
+```bash
 curl -L https://github.com/taskcluster/taskcluster/releases/download/v44.17.2/taskcluster-darwin-amd64 --output taskcluster
 ```
 This is to ensure the binary is not quarantined by MacOS.
@@ -26,6 +35,7 @@ course.
 
  * [linux-amd64](https://github.com/taskcluster/taskcluster/releases/download/v44.17.2/taskcluster-linux-amd64)
  * [darwin-amd64](https://github.com/taskcluster/taskcluster/releases/download/v44.17.2/taskcluster-darwin-amd64)
+ * [darwin-arm64](https://github.com/taskcluster/taskcluster/releases/download/v44.17.2/taskcluster-darwin-arm64)
 
 ## Usage
 


### PR DESCRIPTION
This PR adds homebrew installation instructions to the docs for the `taskcluster` cli.

[Rendered view](https://github.com/taskcluster/taskcluster/blob/79cce9987c4e4326a1337cd6a8c23c3c87fb0b91/clients/client-shell/README.md#taskcluster-client-for-shell)