### PR TITLE
Remove hardcoded ingress, use latest ingress nginx support.

### DIFF
--- a/changelog/W83WYfXqReGqudzT57c-zg.md
+++ b/changelog/W83WYfXqReGqudzT57c-zg.md
@@ -1,0 +1,3 @@
+audience: general
+level: silent
+---

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,5 +1,11 @@
 steps:
   - name: gcr.io/cloud-builders/docker
+    id: Prefetch deploy image
+    entrypoint: bash
+    args:
+      - '-c'
+      - docker pull ${_DEPLOY_IMAGE_NAME}:latest || exit 0
+  - name: gcr.io/cloud-builders/docker
     args:
       - build
       - '--build-arg'
@@ -13,18 +19,36 @@ steps:
       - push
       - ${_IMAGE_NAME}:${_IMAGE_VERSION}
     id: Push
+  - name: gcr.io/cloud-builders/docker
+    id: Build deploy image using cache from previous build
+    entrypoint: bash
+    args:
+      - '-c'
+      - |
+        docker build -t ${_DEPLOY_IMAGE_NAME}:${_IMAGE_VERSION} --cache-from ${_DEPLOY_IMAGE_NAME}:latest -<<EOF
+        FROM node:${_NODE_VERSION}
+        RUN curl https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
+        RUN curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
+        RUN install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl
+        RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] http://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list
+        RUN curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key --keyring /usr/share/keyrings/cloud.google.gpg add -
+        RUN apt-get update -y && apt-get install google-cloud-cli google-cloud-sdk-gke-gcloud-auth-plugin -y
+        EOF
   - name: bash
     args:
       - '-c'
-      - echo "$$DEV_CONFIG" > /workspace/dev-config.yml && echo "$$INGRESS" > /workspace/infrastructure/k8s/templates/ingress.yaml
+      - echo "$$DEV_CONFIG" > /workspace/dev-config.yml
     id: Get secrets
     secretEnv:
       - DEV_CONFIG
-      - INGRESS
-  - name: node:${_NODE_VERSION}
+  - name: ${_DEPLOY_IMAGE_NAME}
     args:
       - '-c'
-      - curl https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash && curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl" && install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl && echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] http://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list && curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key --keyring /usr/share/keyrings/cloud.google.gpg add - && apt-get update -y && apt-get install google-cloud-cli google-cloud-sdk-gke-gcloud-auth-plugin -y && gcloud container clusters get-credentials ${PROJECT_ID} --region us-east1 --project ${PROJECT_ID} && yarn && yarn dev:db:upgrade && yarn dev:apply
+      - |
+        gcloud container clusters get-credentials ${PROJECT_ID} --region us-east1 --project ${PROJECT_ID} \
+        && yarn \
+        && yarn dev:db:upgrade \
+        && yarn dev:apply
     id: Deploy
     entrypoint: bash
   - name: gcr.io/cloud-builders/gcloud
@@ -36,16 +60,17 @@ steps:
 timeout: 1800s
 images:
   - ${_IMAGE_NAME}:${_IMAGE_VERSION}
+  - ${_DEPLOY_IMAGE_NAME}:${_IMAGE_VERSION}
 options:
   dynamicSubstitutions: true
+  machineType: E2_HIGHCPU_8
 substitutions:
   _NODE_VERSION: 16.16.0
   _VERSION: '{"version":"${BRANCH_NAME}_${SHORT_SHA}","commit":"${SHORT_SHA}","source":"https://github.com/taskcluster/taskcluster","build":"${BUILD_ID}"}'
   _IMAGE_NAME: gcr.io/${PROJECT_ID}/${PROJECT_ID}/${BRANCH_NAME}
+  _DEPLOY_IMAGE_NAME: gcr.io/${PROJECT_ID}/${PROJECT_ID}/${BRANCH_NAME}-deploy
   _IMAGE_VERSION: latest
 availableSecrets:
   secretManager:
     - versionName: projects/${PROJECT_ID}/secrets/dev-config/versions/latest
       env: DEV_CONFIG
-    - versionName: projects/${PROJECT_ID}/secrets/ingress/versions/latest
-      env: INGRESS


### PR DESCRIPTION
Cloudbuild improvements:

* using #5613 ingress nginx support to replace hardcoded ingress.yml
* Adding intermediate deployment image for faster deployments - will be built first time and then reused in later builds.
* Switching to higher CPU machines for faster builds (suggested by google cloud)
