### PR TITLE
Remove duplicate ingress paths

### DIFF
--- a/changelog/QYv_97qTRVO61yND4sGtqQ.md
+++ b/changelog/QYv_97qTRVO61yND4sGtqQ.md
@@ -1,0 +1,5 @@
+audience: general
+level: patch
+---
+
+Remove duplicate ingres paths as redundant

--- a/infrastructure/k8s/templates/ingress.yaml
+++ b/infrastructure/k8s/templates/ingress.yaml
@@ -32,21 +32,7 @@ spec:
                 name: taskcluster-ui
                 port:
                   number: 80
-          - path: '{{ if eq .Values.ingressType "nginx" }}{{ trimSuffix "*" "/references" }}{{ else }}/references{{ end }}'
-            pathType: Prefix
-            backend:
-              service:
-                name: taskcluster-references
-                port:
-                  number: 80
           - path: '{{ if eq .Values.ingressType "nginx" }}{{ trimSuffix "*" "/references/*" }}{{ else }}/references/*{{ end }}'
-            pathType: Prefix
-            backend:
-              service:
-                name: taskcluster-references
-                port:
-                  number: 80
-          - path: '{{ if eq .Values.ingressType "nginx" }}{{ trimSuffix "*" "/schemas" }}{{ else }}/schemas{{ end }}'
             pathType: Prefix
             backend:
               service:
@@ -121,13 +107,6 @@ spec:
             backend:
               service:
                 name: taskcluster-secrets
-                port:
-                  number: 80
-          - path: '{{ if eq .Values.ingressType "nginx" }}{{ trimSuffix "*" "/login" }}{{ else }}/login{{ end }}'
-            pathType: Prefix
-            backend:
-              service:
-                name: taskcluster-web-server
                 port:
                   number: 80
           - path: '{{ if eq .Values.ingressType "nginx" }}{{ trimSuffix "*" "/login/*" }}{{ else }}/login/*{{ end }}'

--- a/infrastructure/tooling/src/generate/generators/k8s.js
+++ b/infrastructure/tooling/src/generate/generators/k8s.js
@@ -248,9 +248,7 @@ const extras = {
         type: 'web',
         readinessPath: '/references/',
         paths: [
-          '/references',
           '/references/*',
-          '/schemas',
           '/schemas/*',
         ],
       },

--- a/services/web-server/procs.yml
+++ b/services/web-server/procs.yml
@@ -3,7 +3,6 @@ web:
   command: node services/web-server/src/main.js server
   readinessPath: .well-known/apollo/server-health
   paths:
-    - '/login'
     - '/login/*'
     - '/subscription'
     - '/graphql'


### PR DESCRIPTION
Google load balancer uses Url Maps, and having wildcard in path is mandatory to match all sub-paths.
Default k8s ingress and nginx-ingress do not use wildcard in paths, so it should be removed.

Tested on dev