### PR TITLE
UI: reload task on updates, show recent run on rerun

### DIFF
--- a/changelog/Xs1ReEpFQ0qsbwZfapWt6Q.md
+++ b/changelog/Xs1ReEpFQ0qsbwZfapWt6Q.md
@@ -1,0 +1,5 @@
+audience: users
+level: patch
+---
+
+UI: Pulse Messages autocompletes known exchanges

--- a/changelog/f0LQ1YkwQNGEq8F6z1UuJg.md
+++ b/changelog/f0LQ1YkwQNGEq8F6z1UuJg.md
@@ -1,0 +1,5 @@
+audience: developers
+level: patch
+---
+
+Docker compose: static worker not started by default.

--- a/changelog/issue-5046.md
+++ b/changelog/issue-5046.md
@@ -1,0 +1,7 @@
+audience: users
+level: patch
+reference: issue 5046
+---
+
+UI automatically goes to the latest run on rerun action.
+Task page listens to updates on task status and updates the page.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -189,6 +189,8 @@ services:
       TASKCLUSTER_ROOT_URL: http://taskcluster
       TASKCLUSTER_CLIENT_ID: static/generic-worker-compose-client
       TASKCLUSTER_ACCESS_TOKEN: j2Z6zW2QSLehailBXlosdw9e2Ti8R_Qh2M4buAEQfsMA
+    profiles:
+      - workers
     depends_on:
       rabbitmq:
         condition: service_healthy

--- a/infrastructure/tooling/src/generate/generators/docker-compose.js
+++ b/infrastructure/tooling/src/generate/generators/docker-compose.js
@@ -394,6 +394,7 @@ exports.tasks.push({
           TASKCLUSTER_CLIENT_ID: 'static/generic-worker-compose-client',
           TASKCLUSTER_ACCESS_TOKEN: getTokenByService('generic-worker'),
         },
+        ...(type === 'static' ? { profiles: ['workers'] } : {}), // start only standalone by default
         depends_on: {
           rabbitmq: { condition: 'service_healthy' },
           'auth-web': { condition: 'service_healthy' },

--- a/services/web-server/src/graphql/Tasks.graphql
+++ b/services/web-server/src/graphql/Tasks.graphql
@@ -301,4 +301,6 @@ extend type Mutation {
 extend type Subscription {
   # Subscribe to multiple task group subscriptions.
   tasksSubscriptions(taskGroupId: ID!, subscriptions: [TaskSubscriptions]!): TaskStatus
+  # Subscribe to single task
+  taskSubscriptions(taskId: ID!, subscriptions: [TaskSubscriptions]!): TaskStatus
 }

--- a/ui/.neutrinorc.js
+++ b/ui/.neutrinorc.js
@@ -73,6 +73,10 @@ module.exports = {
             target: proxyTarget,
             changeOrigin: true,
           },
+          '/references': {
+            target: proxyTarget,
+            changeOrigin: true,
+          },
           '/subscription': {
             ws: true,
             changeOrigin: true,

--- a/ui/src/components/PulseBindings/index.jsx
+++ b/ui/src/components/PulseBindings/index.jsx
@@ -6,6 +6,7 @@ import List from '@material-ui/core/List';
 import ListItem from '@material-ui/core/ListItem';
 import ListItemText from '@material-ui/core/ListItemText';
 import Tooltip from '@material-ui/core/Tooltip';
+import Autocomplete from '@material-ui/lab/Autocomplete';
 import Typography from '@material-ui/core/Typography';
 import IconButton from '@material-ui/core/IconButton';
 import PlusIcon from 'mdi-react/PlusIcon';
@@ -47,6 +48,7 @@ export default class PulseBindings extends Component {
     onBindingRemove: func.isRequired,
     onRoutingKeyPatternChange: func.isRequired,
     onPulseExchangeChange: func.isRequired,
+    exchangesDictionary: arrayOf(string),
   };
 
   render() {
@@ -59,20 +61,42 @@ export default class PulseBindings extends Component {
       onBindingRemove,
       onRoutingKeyPatternChange,
       onPulseExchangeChange,
+      exchangesDictionary,
     } = this.props;
+    const onKeyHandler = ev => {
+      if (ev.key === 'Enter') {
+        setTimeout(onBindingAdd, 1); // wait for onChange event to update value
+        ev.preventDefault();
+      }
+    };
 
     return (
       <Fragment>
         <div className={classes.inputWrapper}>
           <div className={classes.inputList}>
-            <TextField
-              required
-              label="Pulse Exchange"
-              name="pulseExchange"
-              placeholder="exchange/<username>/some-exchange-name"
-              onChange={onPulseExchangeChange}
-              fullWidth
-              value={pulseExchange}
+            <Autocomplete
+              freeSolo
+              options={exchangesDictionary}
+              inputValue={pulseExchange}
+              onInputChange={(event, newValue) =>
+                onPulseExchangeChange({
+                  target: {
+                    name: 'pulseExchange',
+                    value: newValue,
+                  },
+                })
+              }
+              renderInput={params => (
+                <TextField
+                  {...params}
+                  required
+                  label="Pulse Exchange"
+                  name="pulseExchange"
+                  placeholder="exchange/<username>/some-exchange-name"
+                  onKeyPress={onKeyHandler}
+                  fullWidth
+                />
+              )}
             />
             <TextField
               margin="normal"
@@ -81,6 +105,7 @@ export default class PulseBindings extends Component {
               placeholder="#.some-interesting-key.#"
               name="pattern"
               onChange={onRoutingKeyPatternChange}
+              onKeyPress={onKeyHandler}
               fullWidth
               value={pattern}
             />

--- a/ui/src/utils/constants.js
+++ b/ui/src/utils/constants.js
@@ -76,9 +76,11 @@ export const INTERACTIVE_TASK_STATUS = {
   RESOLVED: 'RESOLVED',
   READY: 'READY',
 };
-export const INTERACTIVE_CONNECT_TASK_POLL_INTERVAL = 10000; // 10 seconds
-export const TASK_POLL_INTERVAL = 30000; // 30 seconds
-export const VNC_DISPLAYS_POLLING_INTERVAL = 10000; // 10 seconds
+const SECOND = 1000;
+
+export const INTERACTIVE_CONNECT_TASK_POLL_INTERVAL = 10 * SECOND;
+export const TASK_POLL_INTERVAL = 60 * SECOND;
+export const VNC_DISPLAYS_POLLING_INTERVAL = 10 * SECOND;
 export const INITIAL_CURSOR = '$$FIRST$$';
 export const INITIAL_TASK_GROUP_NOTIFICATION_PREFERENCES = {
   groupNotifyTaskFailed: false,

--- a/ui/src/utils/exchangesList.js
+++ b/ui/src/utils/exchangesList.js
@@ -1,0 +1,30 @@
+import urls from 'taskcluster-lib-urls';
+
+const exchanges = [];
+const fetchExchanges = async (service, version) => {
+  const res = await fetch(urls.exchangeReference('', service, version));
+  const data = await res.json();
+
+  data.entries?.forEach(entry => {
+    exchanges.push(`${data.exchangePrefix}${entry.exchange}`);
+  });
+
+  return data;
+};
+
+const prefetch = async () => {
+  await fetchExchanges('auth', 'v1');
+  await fetchExchanges('queue', 'v1');
+  await fetchExchanges('github', 'v1');
+  await fetchExchanges('hooks', 'v1');
+  await fetchExchanges('notify', 'v1');
+  await fetchExchanges('worker-manager', 'v1');
+};
+
+const prefetchPromise = prefetch();
+
+export default async () => {
+  await prefetchPromise;
+
+  return exchanges;
+};

--- a/ui/src/utils/exchangesList.test.js
+++ b/ui/src/utils/exchangesList.test.js
@@ -1,0 +1,30 @@
+describe('exchangesList', () => {
+  beforeAll(() => {
+    window.fetch = jest.fn().mockImplementation(url => {
+      return {
+        json: () =>
+          Promise.resolve({
+            $id: url,
+            exchangePrefix: url.replace('.json', '/').substr(1),
+            entries: [
+              {
+                exchange: 'exchange1',
+              },
+            ],
+          }),
+      };
+    });
+  });
+
+  it('should return list of entries', async () => {
+    const fetchList = require('./exchangesList').default; // eslint-disable-line global-require
+
+    const exchanges = await fetchList();
+
+    expect(exchanges).toBeDefined();
+    expect(
+      exchanges.includes('references/auth/v1/exchanges/exchange1')
+    ).toBeTruthy();
+    expect(window.fetch).toHaveBeenCalled();
+  });
+});

--- a/ui/src/views/PulseMessages/index.jsx
+++ b/ui/src/views/PulseMessages/index.jsx
@@ -28,6 +28,7 @@ import DataTable from '../../components/DataTable';
 import PulseBindings from '../../components/PulseBindings';
 import pulseMessagesQuery from './pulseMessages.graphql';
 import removeKeys from '../../utils/removeKeys';
+import exchangesList from '../../utils/exchangesList';
 
 const getBindingsFromProps = props => {
   const query = parse(props.location.search.slice(1));
@@ -106,7 +107,14 @@ export default class PulseMessages extends Component {
       drawerOpen: false,
       drawerMessage: null,
       downloadLink: 'data:application/json;base64,IkJyb3dzZXIgSXNzdWUi',
+      exchangesDictionary: null,
     };
+  }
+
+  async componentDidMount() {
+    this.setState({
+      exchangesDictionary: await exchangesList(),
+    });
   }
 
   componentWillUnmount() {
@@ -217,6 +225,7 @@ export default class PulseMessages extends Component {
       error,
       drawerOpen,
       drawerMessage,
+      exchangesDictionary,
     } = this.state;
     const iconSize = 16;
     const description = `Bind to Pulse exchanges in your browser, observe messages arriving and inspect
@@ -261,6 +270,7 @@ export default class PulseMessages extends Component {
             onPulseExchangeChange={this.handlePulseExchangeChange}
             pulseExchange={pulseExchange}
             pattern={pattern}
+            exchangesDictionary={exchangesDictionary}
           />
           <List>
             <Toolbar>

--- a/ui/src/views/Tasks/ViewTask/index.jsx
+++ b/ui/src/views/Tasks/ViewTask/index.jsx
@@ -54,6 +54,7 @@ import { nice } from '../../../utils/slugid';
 import Link from '../../../utils/Link';
 import submitTaskAction from '../submitTaskAction';
 import taskQuery from './task.graphql';
+import taskSubscription from './taskSubscription.graphql';
 import scheduleTaskQuery from './scheduleTask.graphql';
 import rerunTaskQuery from './rerunTask.graphql';
 import cancelTaskQuery from './cancelTask.graphql';
@@ -100,7 +101,7 @@ const getCachesFromTask = task =>
 @graphql(taskQuery, {
   options: props => ({
     fetchPolicy: 'network-only',
-    pollInterval: TASK_POLL_INTERVAL,
+    pollInterval: TASK_POLL_INTERVAL * 10,
     errorPolicy: 'all',
     variables: {
       taskId: props.match.params.taskId,
@@ -189,6 +190,64 @@ export default class ViewTask extends Component {
     caches: null,
     selectedCaches: null,
   };
+
+  listener = null;
+
+  componentDidUpdate(prevProps) {
+    const taskId = prevProps.match.params.taskId || '';
+    const {
+      data: { task, subscribeToMore, refetch },
+    } = this.props;
+
+    if (task && taskId !== task) {
+      this.subscribe(task.taskId, subscribeToMore, refetch);
+    }
+  }
+
+  componentWillUnmount() {
+    this.unsubscribe();
+  }
+
+  subscribe(taskId, subscribeToMore, refetch) {
+    if (this.listener) {
+      if (this.listener.taskId === taskId) {
+        return this.listener;
+      }
+
+      this.unsubscribe();
+    }
+
+    const unsubscribe = subscribeToMore({
+      document: taskSubscription,
+      variables: {
+        taskId,
+        subscriptions: [
+          'tasksDefined',
+          'tasksPending',
+          'tasksRunning',
+          'tasksCompleted',
+          'tasksFailed',
+          'tasksException',
+        ],
+      },
+      // refetch everything as subscription event holds incomplete task data
+      updateQuery: refetch,
+    });
+
+    this.listener = {
+      taskId,
+      unsubscribe,
+    };
+  }
+
+  unsubscribe() {
+    if (!this.listener) {
+      return;
+    }
+
+    this.listener.unsubscribe();
+    this.listener = null;
+  }
 
   handleActionClick = name => () => {
     const { action } = this.state.actionData[name];
@@ -661,6 +720,7 @@ export default class ViewTask extends Component {
 
   rerunTask = async () => {
     const { taskId } = this.props.match.params;
+    const { history, location } = this.props;
 
     this.preRunningAction();
 
@@ -671,6 +731,9 @@ export default class ViewTask extends Component {
           taskId,
         },
       });
+      // make sure location doesn't include previous runId,
+      // so the UI will show the latest run automatically
+      history.push(`/tasks/${taskId}${location.hash}`);
     } catch (error) {
       this.postRunningFailedAction(error);
       throw error;

--- a/ui/src/views/Tasks/ViewTask/index.jsx
+++ b/ui/src/views/Tasks/ViewTask/index.jsx
@@ -101,7 +101,7 @@ const getCachesFromTask = task =>
 @graphql(taskQuery, {
   options: props => ({
     fetchPolicy: 'network-only',
-    pollInterval: TASK_POLL_INTERVAL * 10,
+    pollInterval: TASK_POLL_INTERVAL,
     errorPolicy: 'all',
     variables: {
       taskId: props.match.params.taskId,

--- a/ui/src/views/Tasks/ViewTask/taskSubscription.graphql
+++ b/ui/src/views/Tasks/ViewTask/taskSubscription.graphql
@@ -1,0 +1,17 @@
+subscription TaskSubscription($taskId: ID!, $subscriptions: [TaskSubscriptions]!) {
+  taskSubscriptions(taskId: $taskId, subscriptions: $subscriptions) {
+    state
+    runs {
+      # Required to properly update the cache
+      runId
+    }
+    taskId
+    task {
+      taskId
+      metadata {
+        name
+      }
+      taskId
+    }
+  }
+}


### PR DESCRIPTION
* UI: Task page: subscribe to task real-time updates to display latest status and run information
* UI: Task page: automatically show latest run after triggering "Rerun" 
* Docker compose: only run `standalone` generic worker on start, `static` can be run with `COMPOSE_PROFILES=workers`
* UI: Pulse messages: autocomplete known exchanges + submit on enter

<img width="846" alt="image" src="https://user-images.githubusercontent.com/83861/185173532-8242d77f-6a5f-4055-88b6-560659b2b1ae.png">

This should help quickly subscribe to known exchanges without thinking  long for the correct format of the exchange name. It only fetches exchange names of the taskcluster services

Github Bug/Issue: Fixes #5046
