### PR TITLE
Issue 5634: build livelog docker image FROM scratch

### DIFF
--- a/changelog/ejVAaJPFTT2p5sOMcqC-7A.md
+++ b/changelog/ejVAaJPFTT2p5sOMcqC-7A.md
@@ -1,0 +1,12 @@
+audience: general
+level: patch
+---
+The azure library has been removed that was used by the following (removed) endpoints:
+
+  * `auth.azureCredentials`
+  * `auth.azureTables`
+  * `auth.azureTablesSAS`
+  * `auth.azureContainers`
+  * `auth.azureContainersSAS`
+
+ which were removed in release .

--- a/changelog/issue-5634.md
+++ b/changelog/issue-5634.md
@@ -1,0 +1,7 @@
+audience: worker-deployers
+level: patch
+reference: issue 5634
+---
+The livelog docker image used by docker-worker now is not based on busybox, but
+contains only the livelog binary, /etc/ssl/certs/ca-certificates.crt and an
+empty /tmp directory. This effectively reverses the change from #3866.

--- a/infrastructure/tooling/src/build/tasks/livelog.js
+++ b/infrastructure/tooling/src/build/tasks/livelog.js
@@ -72,9 +72,15 @@ module.exports = ({ tasks, cmdOptions, credentials, baseDir, logsDir }) => {
       // this simple Dockerfile just packages the binary into a Docker image
       const dockerfile = path.join(contextDir, 'Dockerfile');
       fs.writeFileSync(dockerfile, [
-        'FROM busybox', // We use busybox rather than scratch to have `/tmp` and such things
+        'FROM ubuntu:latest AS certs',
+        'apt-get update',
+        'apt-get upgrade -y',
+        'apt-get install -y ca-certificates',
+        'FROM scratch',
         'EXPOSE 60023',
         'EXPOSE 60022',
+        'RUN mkdir /tmp'
+        'COPY --from=certs /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt',
         'COPY version.json /app/version.json',
         'COPY livelog /livelog',
         'ENTRYPOINT ["/livelog"]',


### PR DESCRIPTION
Github Bug/Issue: Fixes #5634

I'm not really sure why the Dockerfile is generated on the fly, rather than being a static file in the repo.

I've also spotted that `livelog` is built _outside_ of the docker container, and then copied in. I'm not sure why this is. This won't work for multiarch builds, so I think it would make more sense to build the go app inside the docker container in the first stage, and copy it into the second stage.

I can't see how to reference the go version in the Dockerfile so I can have something like:

```
FROM golang:1.18.5
```

in the first stage, where the version number comes from the `.go-version` file. There is [go-version.js](https://github.com/taskcluster/taskcluster/tree/from-scratch-again/infrastructure/tooling/src/generate/generators/go-version.js) but I'm not sure that currently sets any variable that can be referenced from the context of [livelog.js](https://github.com/taskcluster/taskcluster/tree/from-scratch-again/infrastructure/tooling/src/build/tasks/livelog.js) but I'm looking into it. Therefore keeping this as draft for now, so I can fix that too.