### PR TITLE
cloudbuild: Use commit SHA instead of latest to trigger redeployment

### DIFF
--- a/changelog/E4bduEqrT_yEseRzgmPIYw.md
+++ b/changelog/E4bduEqrT_yEseRzgmPIYw.md
@@ -1,0 +1,3 @@
+audience: developers
+level: silent
+---

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -12,12 +12,15 @@ steps:
       - DOCKER_FLOW_VERSION=${_VERSION}
       - '-t'
       - ${_IMAGE_NAME}:${_IMAGE_VERSION}
+      - '-t'
+      - ${_IMAGE_NAME}:latest
       - .
     id: Build
   - name: gcr.io/cloud-builders/docker
     args:
       - push
-      - ${_IMAGE_NAME}:${_IMAGE_VERSION}
+      - '-a'
+      - ${_IMAGE_NAME}
     id: Push
   - name: gcr.io/cloud-builders/docker
     id: Build deploy image using cache from previous build
@@ -25,7 +28,7 @@ steps:
     args:
       - '-c'
       - |
-        docker build -t ${_DEPLOY_IMAGE_NAME}:${_IMAGE_VERSION} --cache-from ${_DEPLOY_IMAGE_NAME}:latest -<<EOF
+        docker build -t ${_DEPLOY_IMAGE_NAME}:latest --cache-from ${_DEPLOY_IMAGE_NAME}:latest -<<EOF
         FROM node:${_NODE_VERSION}
         RUN curl https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
         RUN curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
@@ -37,7 +40,8 @@ steps:
   - name: bash
     args:
       - '-c'
-      - echo "$$DEV_CONFIG" > /workspace/dev-config.yml
+      - |
+        echo "$$DEV_CONFIG" | sed -E "s|dockerImage:.+$|dockerImage: ${_IMAGE_NAME}:${_IMAGE_VERSION}|" > /workspace/dev-config.yml
     id: Get secrets
     secretEnv:
       - DEV_CONFIG
@@ -78,8 +82,7 @@ steps:
       - TASKCLUSTER_ACCESS_TOKEN
 timeout: 1800s
 images:
-  - ${_IMAGE_NAME}:${_IMAGE_VERSION}
-  - ${_DEPLOY_IMAGE_NAME}:${_IMAGE_VERSION}
+  - ${_DEPLOY_IMAGE_NAME}:latest
 options:
   dynamicSubstitutions: true
   machineType: E2_HIGHCPU_8
@@ -88,7 +91,7 @@ substitutions:
   _VERSION: '{"version":"${BRANCH_NAME}_${SHORT_SHA}","commit":"${SHORT_SHA}","source":"https://github.com/taskcluster/taskcluster","build":"${BUILD_ID}"}'
   _IMAGE_NAME: gcr.io/${PROJECT_ID}/${PROJECT_ID}/${BRANCH_NAME}
   _DEPLOY_IMAGE_NAME: gcr.io/${PROJECT_ID}/${PROJECT_ID}/${BRANCH_NAME}-deploy
-  _IMAGE_VERSION: latest
+  _IMAGE_VERSION: ${SHORT_SHA}
 availableSecrets:
   secretManager:
     - versionName: projects/${PROJECT_ID}/secrets/dev-config/versions/latest


### PR DESCRIPTION
Problem with using ":latest" is that deployment configuration doesn't change, so the pods are not being restarted
