### PR TITLE
feat(github): provide log tail in gh checks ui

### DIFF
--- a/changelog/issue-5217.md
+++ b/changelog/issue-5217.md
@@ -1,0 +1,5 @@
+audience: developers
+level: patch
+reference: issue 5217
+---
+This patch gets a tail of the last 250 lines of the `live.log` file and provides it in the GitHub checks view without having to visit the Taskcluster UI.

--- a/services/github/src/constants.js
+++ b/services/github/src/constants.js
@@ -48,6 +48,7 @@ module.exports = {
   },
   CHECKLOGS_TEXT: 'View logs in Taskcluster',
   CHECKRUN_TEXT: 'View task in Taskcluster',
+  LIVE_LOG_ARTIFACT_NAME: 'public/logs/live.log',
   CUSTOM_CHECKRUN_TEXT_ARTIFACT_NAME: 'public/github/customCheckRunText.md',
   CUSTOM_CHECKRUN_ANNOTATIONS_ARTIFACT_NAME: 'public/github/customCheckRunAnnotations.json',
 };

--- a/services/github/src/handlers/status.js
+++ b/services/github/src/handlers/status.js
@@ -1,4 +1,4 @@
-const { CONCLUSIONS, CHECKLOGS_TEXT, CHECKRUN_TEXT, CUSTOM_CHECKRUN_TEXT_ARTIFACT_NAME, CUSTOM_CHECKRUN_ANNOTATIONS_ARTIFACT_NAME, CHECK_RUN_STATES, TASK_STATE_TO_CHECK_RUN_STATE } = require('../constants');
+const { CONCLUSIONS, CHECKLOGS_TEXT, CHECKRUN_TEXT, LIVE_LOG_ARTIFACT_NAME, CUSTOM_CHECKRUN_TEXT_ARTIFACT_NAME, CUSTOM_CHECKRUN_ANNOTATIONS_ARTIFACT_NAME, CHECK_RUN_STATES, TASK_STATE_TO_CHECK_RUN_STATE } = require('../constants');
 const { requestArtifact } = require('./requestArtifact');
 const { taskUI, makeDebug, taskLogUI } = require('./utils');
 
@@ -79,6 +79,15 @@ async function statusHandler(message) {
         taskDefinition.extra.github.customCheckRun.annotationsArtifactName || CUSTOM_CHECKRUN_ANNOTATIONS_ARTIFACT_NAME;
     }
 
+    const liveLogText = await requestArtifact.call(this, LIVE_LOG_ARTIFACT_NAME, {
+      taskId,
+      runId,
+      debug,
+      instGithub,
+      build,
+      scopes: taskDefinition.scopes,
+    });
+
     const customCheckRunText = await requestArtifact.call(this, textArtifactName, {
       taskId,
       runId,
@@ -127,6 +136,7 @@ async function statusHandler(message) {
       text: [
         `[${CHECKRUN_TEXT}](${taskUI(this.context.cfg.taskcluster.rootUrl, taskGroupId, taskId)})`,
         `[${CHECKLOGS_TEXT}](${taskLogUI(this.context.cfg.taskcluster.rootUrl, runId, taskId)})`,
+        liveLogText ? `\n\`\`\`bash\n${liveLogText.split('\n').slice(-250).join('\n')}\n\`\`\`` : '', // tails the last 250 lines of the log
         customCheckRunText || '',
       ].join('\n'),
       annotations: customCheckRunAnnotations,


### PR DESCRIPTION
Addresses #5217.

> This patch gets a tail of the last 250 lines of the `live.log` file and provides it in the GitHub checks view without having to visit the Taskcluster UI.