### PR TITLE
Fix hover bug

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -876,6 +876,15 @@
       ]
     },
     {
+      "login": "ahmedDevs",
+      "name": "Ahmed A.",
+      "avatar_url": "https://avatars.githubusercontent.com/u/102767737?v=4",
+      "profile": "https://github.com/ahmedDevs",
+      "contributions": [
+        "code"
+      ]
+    },
+    {
       "login": "matt-boris",
       "name": "Matt Boris",
       "avatar_url": "https://avatars.githubusercontent.com/u/92693437?v=4",

--- a/changelog/issue-5295.md
+++ b/changelog/issue-5295.md
@@ -1,0 +1,5 @@
+audience: developers
+level: minor
+reference: issue 5295
+---
+When hovering over a task in a group task, the background color changes for the whole row, now. As opposed to a portion of the row. 

--- a/changelog/issue-5295.md
+++ b/changelog/issue-5295.md
@@ -2,4 +2,4 @@ audience: developers
 level: minor
 reference: issue 5295
 ---
-When hovering over a task in a group task, the background color changes for the whole row, now. As opposed to a portion of the row. 
+When hovering over a task in a group task, the background color changes for the whole row, now. As opposed to a portion of the row.

--- a/ui/src/components/TaskGroupTable/index.jsx
+++ b/ui/src/components/TaskGroupTable/index.jsx
@@ -92,7 +92,6 @@ const createSortedTasks = memoize(
     alignItems: 'center',
     padding: theme.spacing(1),
     textDecoration: 'none',
-    ...theme.mixins.hover,
     ...theme.mixins.listItemButton,
   },
   taskGroupName: {
@@ -129,6 +128,7 @@ const createSortedTasks = memoize(
   },
   tableRow: {
     display: 'flex',
+    ...theme.mixins.hover,
   },
   tableFirstCell: {
     width: '60%',


### PR DESCRIPTION

Fix incomplete background colour change when hovering over a row at the group task page.

Issue was causing the background colour to change only for half the row when hovering over a row at the group task page, which was causing confusion  for users with wider screens as to what row is being hovered. 

Github Bug/Issue: Fixes #5295 
