### PR TITLE
Fix github checks updates

### DIFF
--- a/changelog/issue-5653.md
+++ b/changelog/issue-5653.md
@@ -1,0 +1,12 @@
+audience: general
+level: patch
+reference: issue 5653
+---
+Fix a bug with github status checks not being updated.
+
+In 44.19.1 release github service started tracking additional task
+state changes, and this resulted in a race condition between "taskDefined"
+and "status" handlers where both of them would create new check run at
+the same time. Wrong check run would later get all status updates, while
+Github UI will be showing a different check run which didn't receive all
+the updates.

--- a/services/github/src/handlers/taskDefined.js
+++ b/services/github/src/handlers/taskDefined.js
@@ -40,7 +40,7 @@ async function taskDefinedHandler(message) {
 
   let [checkRun] = await this.context.db.fns.get_github_check_by_task_id(taskId);
   if (!checkRun) {
-    const checkRun = await instGithub.checks.create({
+    checkRun = await instGithub.checks.create({
       owner: organization,
       repo: repository,
       name: `${taskDefinition.metadata.name}`,


### PR DESCRIPTION
Since 44.19.1 release github service started tracking additional task state changes, and this resulted in a race condition between "taskDefined" and "status" handlers where both of them would create new check run at the same time. Wrong check run would later get all status updates, while Github UI will be showing a different check run which didn't receive all the updates.

Fixes #5653 

Description of the issue:
task status handler was doing roughly this:
1. get `checkRun` from db
2. do several calls to queue to fetch several artifacts (this may take couple of seconds!)
3. create new `checkRun` if it didn't exist yet

And in the same time `taskDefined` would be creating initial check run when task was initially defined.

So depending on luck and network latency there might be several concurrent routines calling check run create and resulting in multiple check runs being created for the same task.

Fix here is to update status handler to group calls together and swap steps 1. and 2.