### PR TITLE
fix(build): clean up old cloudbuild images

### DIFF
--- a/changelog/fo9GU7tCSi6RnqqWH_GHqQ.md
+++ b/changelog/fo9GU7tCSi6RnqqWH_GHqQ.md
@@ -1,0 +1,3 @@
+audience: general
+level: silent
+---

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -66,7 +66,7 @@ steps:
   - name: gcr.io/cloud-builders/gcloud
     args:
       - '-c'
-      - gcloud container images list-tags ${_IMAGE_NAME} --filter='-tags:*' --format='get(digest)' --limit=unlimited | xargs -I {sha} gcloud container images delete "${_IMAGE_NAME}@{sha}"
+      - gcloud container images list-tags ${_IMAGE_NAME} --filter='-tags:latest' --format='get(digest)' --limit=unlimited | xargs -I {sha} gcloud container images delete "${_IMAGE_NAME}@{sha}" && gcloud container images list-tags ${_DEPLOY_IMAGE_NAME} --filter='-tags:latest' --format='get(digest)' --limit=unlimited | xargs -I {sha} gcloud container images delete "${_DEPLOY_IMAGE_NAME}@{sha}"
     id: Delete old images
     entrypoint: bash
   - name: node:${_NODE_VERSION}


### PR DESCRIPTION
This PR makes it so that old GCP CloudBuild images are cleaned up after a successful deploy.