### PR TITLE
Remove pending from the status listeners

### DIFF
--- a/changelog/H42TyvckS0qTGG5vL07qHw.md
+++ b/changelog/H42TyvckS0qTGG5vL07qHw.md
@@ -1,0 +1,3 @@
+audience: developers
+level: silent
+---

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -66,7 +66,7 @@ steps:
   - name: gcr.io/cloud-builders/gcloud
     args:
       - '-c'
-      - gcloud container images list-tags ${_IMAGE_NAME} --filter='-tags:latest' --format='get(digest)' --limit=unlimited | xargs -I {sha} gcloud container images delete "${_IMAGE_NAME}@{sha}" && gcloud container images list-tags ${_DEPLOY_IMAGE_NAME} --filter='-tags:latest' --format='get(digest)' --limit=unlimited | xargs -I {sha} gcloud container images delete "${_DEPLOY_IMAGE_NAME}@{sha}"
+      - gcloud container images list-tags ${_IMAGE_NAME} --filter='-tags:latest' --format='get(digest)' --limit=unlimited | xargs -I {sha} gcloud container images delete "${_IMAGE_NAME}@{sha}" --force-delete-tags && gcloud container images list-tags ${_DEPLOY_IMAGE_NAME} --filter='-tags:latest' --format='get(digest)' --limit=unlimited | xargs -I {sha} gcloud container images delete "${_DEPLOY_IMAGE_NAME}@{sha}" --force-delete-tags
     id: Delete old images
     entrypoint: bash
   - name: node:${_NODE_VERSION}

--- a/services/github/src/handlers/index.js
+++ b/services/github/src/handlers/index.js
@@ -110,7 +110,6 @@ class Handlers {
       queueEvents.taskFailed(`route.${this.context.cfg.app.checkTaskRoute}`),
       queueEvents.taskException(`route.${this.context.cfg.app.checkTaskRoute}`),
       queueEvents.taskCompleted(`route.${this.context.cfg.app.checkTaskRoute}`),
-      queueEvents.taskPending(`route.${this.context.cfg.app.checkTaskRoute}`),
       queueEvents.taskRunning(`route.${this.context.cfg.app.checkTaskRoute}`),
     ];
 

--- a/services/github/src/handlers/status.js
+++ b/services/github/src/handlers/status.js
@@ -145,7 +145,7 @@ async function statusHandler(message) {
     let [checkRun] = await this.context.db.fns.get_github_check_by_task_id(taskId);
 
     if (checkRun) {
-      if (checkRunStatus === CHECK_RUN_STATES.QUEUED && runId > 0) {
+      if (checkRunStatus === CHECK_RUN_STATES.IN_PROGRESS && runId > 0) {
         // If check run was previously completed, it is not possible to change state by updating check run
         // instead, we should call `rerequestRun` for a given check run
         // This will reset status, and trigger `rerequested` event, which will be ignored, as it was triggered by us

--- a/services/github/test/handler_test.js
+++ b/services/github/test/handler_test.js
@@ -1148,18 +1148,18 @@ helper.secrets.mockSuite(testing.suiteName(), [], function (mock, skipping) {
       assert.equal(args.check_run_id, '22222');
     }
 
-    test('task is pending gets a queued check result', async function () {
-      await addBuild({ state: 'pending', taskGroupId: TASKGROUPID });
+    test('task is running gets a queued check result', async function () {
+      await addBuild({ state: 'running', taskGroupId: TASKGROUPID });
       await addCheckRun({ taskGroupId: TASKGROUPID, taskId: TASKID });
       await simulateExchangeMessage({
         taskGroupId: TASKGROUPID,
-        exchange: 'exchange/taskcluster-queue/v1/task-pending',
+        exchange: 'exchange/taskcluster-queue/v1/task-running',
         routingKey: 'route.checks',
         taskId: TASKID,
         runId: 0,
-        state: 'pending',
+        state: 'running',
       });
-      await assertCheckRunStatus('queued');
+      await assertCheckRunStatus('in_progress');
     });
 
     test('task is running gets a in_progress check result', async function () {
@@ -1176,18 +1176,18 @@ helper.secrets.mockSuite(testing.suiteName(), [], function (mock, skipping) {
     });
 
     test('task is rerun and queued gets a queued check result and rerequested run', async function () {
-      await addBuild({ state: 'pending', taskGroupId: TASKGROUPID });
+      await addBuild({ state: 'running', taskGroupId: TASKGROUPID });
       await addCheckRun({ taskGroupId: TASKGROUPID, taskId: TASKID });
       await simulateExchangeMessage({
         taskGroupId: TASKGROUPID,
-        exchange: 'exchange/taskcluster-queue/v1/task-pending',
+        exchange: 'exchange/taskcluster-queue/v1/task-running',
         routingKey: 'route.checks',
         taskId: TASKID,
-        state: 'pending',
+        state: 'running',
         runId: 1, // means task was already completed, rerequest is expected
       });
       await assertCheckRerequestRun();
-      await assertCheckRunStatus('queued');
+      await assertCheckRunStatus('in_progress');
     });
 
     test('task is completed after rerun', async function () {


### PR DESCRIPTION
Pending happens at the same time as taskDefined so it is enough for taskDefined to take the initiative and create the check run 
Otherwise they create two check runs on the github side and store outdated records in the db

According to the [exchanges doc](https://firefox-ci-tc.services.mozilla.com/docs/reference/platform/queue/exchanges#taskDefined) both `taskDefined` and `taskPending` happens at the same time, so to avoid it, only `taskDefined` is being used 
