### PR TITLE
fix(release): upgrade to v2 Dockerhub API

### DIFF
--- a/changelog/issue-5663.md
+++ b/changelog/issue-5663.md
@@ -1,0 +1,6 @@
+audience: developers
+level: patch
+reference: issue 5663
+---
+This patch upgrades to the new, v2 Docker Hub APIs.
+v1 APIs were deprecated as of September 5, 2022 - see [here](https://www.docker.com/blog/docker-hub-v1-api-deprecation/) for more info.

--- a/infrastructure/tooling/src/utils/docker.js
+++ b/infrastructure/tooling/src/utils/docker.js
@@ -227,7 +227,7 @@ exports.dockerRegistryCheck = async ({ tag }) => {
   const [repo, imagetag] = tag.split(/:/);
   try {
     // Access the registry API directly to see if this tag already exists, and do not push if so.
-    const res = await got(`https://index.docker.io/v1/repositories/${repo}/tags`, { responseType: 'json' });
+    const res = await got(`https://hub.docker.com/v2/repositories/taskcluster/${repo}/tags`, { responseType: 'json' });
     if (!res.body) {
       throw new Error('invalid response from index.docker.io');
     }


### PR DESCRIPTION
Fixes #5663.

> This patch upgrades to the new, v2 Docker Hub APIs.
v1 APIs were deprecated as of September 5, 2022 - see [here](https://www.docker.com/blog/docker-hub-v1-api-deprecation/) for more info.