### PR TITLE
Issue 5666: do not dereference nil pointer

### DIFF
--- a/changelog/issue-5666.md
+++ b/changelog/issue-5666.md
@@ -1,0 +1,5 @@
+audience: worker-deployers
+level: patch
+reference: issue 5666
+---
+The generic-worker no longer panics if it gets no HTTP responses from Queue for over 15 minutes.

--- a/clients/client-go/http.go
+++ b/clients/client-go/http.go
@@ -252,15 +252,15 @@ func (client *Client) APICall(payload interface{}, method, route string, result 
 
 		// httpbackoff considers a 3xx response to be an error, but the client
 		// treats it as success, so do not return an error in that case.
-		if callSummary.HTTPResponse.StatusCode >= 400 {
+		if callSummary.HTTPResponse != nil && callSummary.HTTPResponse.StatusCode < 400 {
+			err = nil
+		} else {
 			return result,
 				callSummary,
 				&APICallException{
 					CallSummary: callSummary,
 					RootCause:   err,
 				}
-		} else {
-			err = nil
 		}
 	}
 	// if result is passed in as nil, it means the API defines no response body


### PR DESCRIPTION
Github Bug/Issue: Fixes #5666 

Note, the `main.ClaimWork()` function returns `main.TaskRun(nil)` in [both of the following cases](https://github.com/taskcluster/taskcluster/blob/826df87beab373476f6cb793846cd2343f27b36a/workers/generic-worker/main.go#L541-L549):

  * when [`func (queue *Queue) ClaimWork(taskQueueId string, payload *ClaimWorkRequest) (*ClaimWorkResponse, error)`](https://pkg.go.dev/github.com/taskcluster/taskcluster/v44@v44.20.4/clients/client-go/tcqueue#Queue.ClaimWork) returns an `error`
  * when there are no tasks to run (when the Queue has no tasks for the worker to execute)

Therefore, a Queue service outage is equivalent to the Queue returning no tasks to execute, from the workers' perspective. The worker may exit if there is an idle timeout configured, for example, but now it will not panic.

The `panic` was due to a bug in the go client library, that assumed a `tcclient.CallSummary` always had a non-nil `HTTPResponse` member, which is not the case if all [`queue.claimWork`](https://docs.taskcluster.net/docs/reference/platform/queue/api#claimWork) attempts (over 15 minute period) fail to fetch an HTTP response.