### PR TITLE
Add completions for other shells

### DIFF
--- a/changelog/issue-4534.md
+++ b/changelog/issue-4534.md
@@ -2,3 +2,4 @@ audience: general
 level: minor
 reference: issue 4534
 ---
+Add completions for other shells

--- a/changelog/issue-4534.md
+++ b/changelog/issue-4534.md
@@ -1,0 +1,4 @@
+audience: general
+level: minor
+reference: issue 4534
+---

--- a/clients/client-shell/cmds/completions/completions.go
+++ b/clients/client-shell/cmds/completions/completions.go
@@ -71,13 +71,13 @@ func genCompletion(shell string) func(*cobra.Command, []string) error {
 
 		switch shell {
 		case "bash":
-			root.Command.GenBashCompletionFile(filename)
+			return root.Command.GenBashCompletionFile(filename)
 		case "fish":
-			root.Command.GenFishCompletionFile(filename, false)
+			return root.Command.GenFishCompletionFile(filename, false)
 		case "powershell":
-			root.Command.GenPowerShellCompletionFile(filename)
+			return root.Command.GenPowerShellCompletionFile(filename)
 		case "zsh":
-			root.Command.GenZshCompletionFile(filename)
+			return root.Command.GenZshCompletionFile(filename)
 		}
 
 		return nil

--- a/clients/client-shell/cmds/completions/completions.go
+++ b/clients/client-shell/cmds/completions/completions.go
@@ -68,6 +68,18 @@ func genCompletion(shell string) func(*cobra.Command, []string) error {
 		if len(args) > 0 {
 			filename = args[0]
 		}
-		return root.Command.GenBashCompletionFile(filename)
+
+		switch shell {
+		case "bash":
+			root.Command.GenBashCompletionFile(filename)
+		case "fish":
+			root.Command.GenFishCompletionFile(filename, false)
+		case "powershell":
+			root.Command.GenPowerShellCompletionFile(filename)
+		case "zsh":
+			root.Command.GenZshCompletionFile(filename)
+		}
+
+		return nil
 	}
 }


### PR DESCRIPTION
In addition to bash completions, add completions for fish, powershell, and zsh.

The [default Cobra completion command](https://pkg.go.dev/github.com/spf13/cobra#CompletionOptions) is still in place though. It can probably be removed in a separate (breaking?) update if necessary.

Github Bug/Issue: Fixes #4534
