### PR TITLE
Add redirect to /docs/ for netlify deployment

### DIFF
--- a/changelog/IHQLaOuaRza29g6XB87x-A.md
+++ b/changelog/IHQLaOuaRza29g6XB87x-A.md
@@ -1,0 +1,3 @@
+audience: general
+level: silent
+---

--- a/netlify.toml
+++ b/netlify.toml
@@ -25,6 +25,6 @@
 
 # Rule for Single Page Applications (app)
 [[redirects]]
-  from = "/*"
-  to = "/index.html"
-  status = 200
+  from = "/"
+  to = "/docs/"
+  status = 301


### PR DESCRIPTION
We would serve docs.taskcluster.net from netlify deployment, and it should forward all to `/docs`
