### PR TITLE
 Add a capability disableSeccomp to disable seccomp system call filter.

### DIFF
--- a/changelog/d-w-seccomp.md
+++ b/changelog/d-w-seccomp.md
@@ -1,0 +1,10 @@
+audience: general
+level: minor
+---
+
+Add a docker-worker capability `disableSeccomp` to disable the seccomp
+system call filter.
+
+It allows significant information leakage, and its use should not be
+considered secure. This is required to run `rr` inside a container, as
+described here: https://github.com/mozilla/rr/wiki/Docker

--- a/generated/references.json
+++ b/generated/references.json
@@ -8719,6 +8719,12 @@
               "title": "Devices to be attached to task containers",
               "type": "object"
             },
+            "disableSeccomp": {
+              "default": false,
+              "description": "Allows a task to run without seccomp, similar to running docker with `--security-opt seccomp=unconfined`.  This only works for worker-types configured to enable it.",
+              "title": "Container does not have a seccomp profile set.",
+              "type": "boolean"
+            },
             "privileged": {
               "default": false,
               "description": "Allows a task to run in a privileged container, similar to running docker with `--privileged`.  This only works for worker-types configured to enable it.",

--- a/workers/docker-worker/config.yml
+++ b/workers/docker-worker/config.yml
@@ -48,6 +48,10 @@ defaults:
     delayFactor: 15000
     # Value between 0 and 1
     randomizationFactor: 0.25
+    # Disable the seccomp system call filter. This is useful for some tasks
+    # (eg. using `rr`) but it allows significant information leakage, and its
+    # use should not be considered secure.
+    disableSeccomp: false
   ssl:
     certificate: '/etc/star_taskcluster-worker_net.crt'
     key: '/etc/star_taskcluster-worker_net.key'
@@ -204,6 +208,7 @@ test:
     maxAttempts: 5
     delayFactor: 100
     randomizationFactor: 0.25
+    disableSeccomp: false
 
   taskQueue:
     pollInterval: 1000

--- a/workers/docker-worker/config.yml
+++ b/workers/docker-worker/config.yml
@@ -51,7 +51,7 @@ defaults:
     # Disable the seccomp system call filter. This is useful for some tasks
     # (eg. using `rr`) but it allows significant information leakage, and its
     # use should not be considered secure.
-    disableSeccomp: false
+    allowDisableSeccomp: false
   ssl:
     certificate: '/etc/star_taskcluster-worker_net.crt'
     key: '/etc/star_taskcluster-worker_net.key'
@@ -208,7 +208,7 @@ test:
     maxAttempts: 5
     delayFactor: 100
     randomizationFactor: 0.25
-    disableSeccomp: false
+    allowDisableSeccomp: false
 
   taskQueue:
     pollInterval: 1000

--- a/workers/docker-worker/schemas/v1/payload.yml
+++ b/workers/docker-worker/schemas/v1/payload.yml
@@ -104,6 +104,14 @@ properties:
           configured to enable it.
         type: boolean
         default: false
+      disableSeccomp:
+        title: Container does not have a seccomp profile set.
+        description: >-
+          Allows a task to run without seccomp, similar to running docker with
+          `--security-opt seccomp=unconfined`.  This only works for worker-types
+          configured to enable it.
+        type: boolean
+        default: false
       devices:
         title: Devices to be attached to task containers
         description: >-

--- a/workers/docker-worker/test/integration/disable_seccomp_containers_test.js
+++ b/workers/docker-worker/test/integration/disable_seccomp_containers_test.js
@@ -1,0 +1,115 @@
+const assert = require('assert');
+const settings = require('../settings');
+const DockerWorker = require('../dockerworker');
+const TestWorker = require('../testworker');
+
+suite('disableSeccomp capability', () => {
+  let worker;
+
+  setup(async () => {
+    settings.cleanup();
+  });
+
+  teardown(async () => {
+    settings.cleanup();
+    if (worker) {
+      await worker.terminate();
+    }
+    worker = null;
+  });
+
+  test('task error when necessary scopes missing', async () => {
+    settings.configure({
+      dockerConfig: {
+        disableSeccomp: true,
+      },
+    });
+
+    worker = new TestWorker(DockerWorker);
+    await worker.launch();
+    let result = await worker.postToQueue({
+      payload: {
+        image: 'taskcluster/test-ubuntu',
+        command: [
+          '/bin/bash',
+          '-c',
+          'sleep 1',
+        ],
+        capabilities: {
+          disableSeccomp: true,
+        },
+        maxRunTime: 5 * 60,
+      },
+    });
+
+    let errorMessage = 'Insufficient scopes to run task without seccomp';
+    assert.ok(result.log.indexOf(errorMessage) !== -1);
+    assert.equal(result.run.state, 'failed', 'task should not be successful');
+    assert.equal(result.run.reasonResolved, 'failed', 'task should not be successful');
+  });
+
+  test('task error when disableSeccomp requested but not enabled in worker', async () => {
+    worker = new TestWorker(DockerWorker);
+    await worker.launch();
+    let result = await worker.postToQueue({
+      scopes: ['docker-worker:capability:disableSeccomp'],
+      payload: {
+        image: 'taskcluster/test-ubuntu',
+        command: [
+          '/bin/bash',
+          '-c',
+          'sleep 1',
+        ],
+        capabilities: {
+          disableSeccomp: true,
+        },
+        maxRunTime: 5 * 60,
+      },
+    });
+
+    let errorMessage = 'Error: Cannot run task using docker without a seccomp profile';
+    assert.ok(result.log.indexOf(errorMessage) !== -1);
+    assert.equal(result.run.state, 'failed', 'task should not be successful');
+    assert.equal(result.run.reasonResolved, 'failed', 'task should not be successful');
+  });
+
+  test('use performance counter in a container without disableSeccomp -- task should fail', async () => {
+    worker = new TestWorker(DockerWorker);
+    await worker.launch();
+    let result = await worker.postToQueue({
+      payload: {
+        image: 'alpine',
+        command: ['/bin/sh', '-c', 'apk add perf; perf stat ls'],
+        maxRunTime: 5 * 60,
+      },
+    });
+
+    assert(result.run.state === 'failed', 'task should fail');
+    assert(result.run.reasonResolved === 'failed', 'task should fail');
+  });
+
+  test('use performance counter in a container with disableSeccomp -- task should succeed', async () => {
+    settings.configure({
+      dockerConfig: {
+        disableSeccomp: true,
+      },
+    });
+
+    worker = new TestWorker(DockerWorker);
+    await worker.launch();
+    let result = await worker.postToQueue({
+      scopes: ['docker-worker:capability:disableSeccomp'],
+      payload: {
+        image: 'alpine',
+        command: ['/bin/sh', '-c', 'apk add perf; perf stat ls'],
+        capabilities: {
+          disableSeccomp: true,
+        },
+        maxRunTime: 5 * 60,
+      },
+    });
+
+    assert(result.run.state === 'completed', 'task should not fail');
+    assert(result.run.reasonResolved === 'completed', 'task should not fail');
+  });
+});

--- a/workers/docker-worker/test/integration/disable_seccomp_containers_test.js
+++ b/workers/docker-worker/test/integration/disable_seccomp_containers_test.js
@@ -21,7 +21,7 @@ suite('disableSeccomp capability', () => {
   test('task error when necessary scopes missing', async () => {
     settings.configure({
       dockerConfig: {
-        disableSeccomp: true,
+        allowDisableSeccomp: true,
       },
     });
 
@@ -91,7 +91,7 @@ suite('disableSeccomp capability', () => {
   test('use performance counter in a container with disableSeccomp -- task should succeed', async () => {
     settings.configure({
       dockerConfig: {
-        disableSeccomp: true,
+        allowDisableSeccomp: true,
       },
     });
 


### PR DESCRIPTION
This is required to run `rr` inside a container, as described here: [Docker (rr wiki)](https://github.com/mozilla/rr/wiki/Docker)

This was previously opened as https://github.com/taskcluster/docker-worker/pull/532, but stalled during testing.