### PR TITLE
build: stop other ongoing cloudbuild jobs

### DIFF
--- a/changelog/LwnyEDC-TQm3po3mdXNJsg.md
+++ b/changelog/LwnyEDC-TQm3po3mdXNJsg.md
@@ -1,0 +1,4 @@
+audience: general
+level: patch
+---
+Adjust GCP CloudBuild config to cancel other ongoing jobs, so that the latest job is the only one that runs and no race conditions will occur with deploying to dev.

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,4 +1,17 @@
 steps:
+  - name: gcr.io/cloud-builders/gcloud
+    entrypoint: bash
+    id: Stop other ongoing builds
+    args:
+      - '-c'
+      - |
+        on_going_build=($(gcloud builds list --ongoing --format='value(id)' --filter="substitutions.TRIGGER_NAME=$TRIGGER_NAME" | xargs))
+        for (( i=0; i<${#on_going_build[@]}; i++ )); do
+          if [ "$i" -gt "0" ]; then # skip current
+            echo "Cancelling build ${on_going_build[i]}"
+            gcloud builds cancel ${on_going_build[i]} --quiet > /dev/null
+          fi
+        done
   - name: gcr.io/cloud-builders/docker
     id: Prefetch deploy image
     entrypoint: bash


### PR DESCRIPTION
> Adjust GCP CloudBuild config to cancel other ongoing jobs, so that the latest job is the only one that runs and no race conditions will occur with deploying to dev.