### PR TITLE
docs: update Github deployment docs for new Github interface

### DIFF
--- a/changelog/ND-XyXVjQwimxc4dCTtQ1A.md
+++ b/changelog/ND-XyXVjQwimxc4dCTtQ1A.md
@@ -1,0 +1,3 @@
+audience: deployers
+level: silent
+---

--- a/ui/docs/manual/deploying/github.mdx
+++ b/ui/docs/manual/deploying/github.mdx
@@ -16,21 +16,22 @@ To create such an app, use the docs at https://developer.github.com/apps/buildin
 * Setup URL should link to your taskcluster instance's quickstart guide, `/quickstart` on your deployment's root URL
 * Webhook URL should link to `/api/github/v1/github` on your deployment's root URL
 * Set the secret to an arbitrary value that you also configure in your Taskcluster instance's settings.
-* Set permissions as follows:
-  * repo administration: read-only
-  * checks: read & write
-  * repo contents: read-only
-  * content references, deployments: No access
-  * issues: read & write
-  * repo metadata: read-only
-  * pages: no access
-  * pull requests: read & write
-  * repo webhooks, projects, security alerts, & single file: no access
-  * commit statuses: read & write
-  * organization members: read only
-  * blocking org users, org projects, team discussions, org administration, org hooks, org plan: No access
-  * user permissions: No access for any
-  * subscribe to events: Pull request, Push, Release
+* Under `Repository permissions` set:
+  * Administration: Read-only
+  * Checks: Read and write
+  * Commit statuses: Read and write
+  * Contents: Read-only
+  * Issues: Read and write
+  * Metadata: Read-only
+  * Pull requests: Read and write
+  * Leave everything else set to `No access`
+* Under `Organization permissions` set:
+  * Members: Read-only
+  * Leave everything else set to `No access`
+* Under `Subscribe to events` check the following boxes:
+  * Pull request
+  * Push
+  * Release
 
 ## Taskcluster Configuration
 


### PR DESCRIPTION
I noticed that the strings mentioned in the deployment docs don't quite match up with what exists in Github when creating a new app. It's not too hard to figure out which options are *meant* to be set, but figured it would be better if the docs mentioned the exact permission strings visible in the Github interface.
