### PR TITLE
Issue 5716 - bump matrix-js-sdk from 15.6.0 to 20.0.2 avoiding matrix-org/matrix-js-sdk#2415

### DIFF
--- a/changelog/issue-5716.md
+++ b/changelog/issue-5716.md
@@ -1,0 +1,5 @@
+audience: users
+level: patch
+reference: issue 5716
+---
+Bump matrix-js-sdk from 15.6.0 to 20.0.2 with fix (workaround) for https://github.com/matrix-org/matrix-js-sdk/issues/2415.

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "lodash": "4.17.21",
     "loglevel": "^1.6.7",
     "marked": "^4.0.16",
-    "matrix-js-sdk": "^15.0.0",
+    "matrix-js-sdk": "^20.0.2",
     "memorystore": "^1.6.1",
     "mkdirp": "^1.0.0",
     "netmask": "^2.0.0",

--- a/services/notify/src/main.js
+++ b/services/notify/src/main.js
@@ -23,6 +23,11 @@ const tcdb = require('taskcluster-db');
 
 require('./monitor');
 
+// see https://github.com/matrix-org/matrix-js-sdk/issues/2415#issuecomment-1141246410
+const matrixcs = require("matrix-js-sdk/lib/matrix");
+const request = require("request");
+matrixcs.request(request);
+
 // Create component loader
 const load = loader({
   cfg: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1581,12 +1581,10 @@ balanced-match@^1.0.0:
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.2.tgz#e83e3a7e3f300b34cb9d87f615fa0cbf357690ee"
   integrity sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==
 
-base-x@^3.0.2:
-  version "3.0.9"
-  resolved "https://registry.yarnpkg.com/base-x/-/base-x-3.0.9.tgz#6349aaabb58526332de9f60995e548a53fe21320"
-  integrity sha512-H7JU6iBHTal1gp56aKoaa//YUxEaAOUiydvrV/pILqIHXTtqxSkATOnDA2u+jZ/61sD+L/412+7kzXRtWukhpQ==
-  dependencies:
-    safe-buffer "^5.0.1"
+base-x@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/base-x/-/base-x-4.0.0.tgz#d0e3b7753450c73f8ad2389b5c018a4af7b2224a"
+  integrity sha512-FuwxlW4H5kh37X/oW59pwTzzTKRzfrrQwhmyspRM7swOEZcHtDZSCt45U6oKgtuFE+WYPblePMVIPR4RZrh/hw==
 
 base64-js@^1.0.2, base64-js@^1.3.0, base64-js@^1.3.1:
   version "1.5.1"
@@ -1733,12 +1731,12 @@ browser-stdout@1.3.1:
   resolved "https://registry.yarnpkg.com/browser-stdout/-/browser-stdout-1.3.1.tgz#baa559ee14ced73452229bad7326467c61fabd60"
   integrity sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==
 
-bs58@^4.0.1:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/bs58/-/bs58-4.0.1.tgz#be161e76c354f6f788ae4071f63f34e8c4f0a42a"
-  integrity sha512-Ok3Wdf5vOIlBrgCvTq96gBkJw+JUEzdBgyaza5HLtPm7yTHkjRy8+JzNyHF7BHa0bNWOQIp3m5YF0nnFcOIKLw==
+bs58@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/bs58/-/bs58-5.0.0.tgz#865575b4d13c09ea2a84622df6c8cbeb54ffc279"
+  integrity sha512-r+ihvQJvahgYT50JD05dyJNKlmmSlMoOGwn1lCcEzanPglg7TxYjioQUYehQ9mAR/+hOSd2jRc/Z2y5UxBymvQ==
   dependencies:
-    base-x "^3.0.2"
+    base-x "^4.0.0"
 
 btoa-lite@^1.0.0:
   version "1.0.0"
@@ -4484,19 +4482,19 @@ matrix-events-sdk@^0.0.1-beta.7:
   resolved "https://registry.yarnpkg.com/matrix-events-sdk/-/matrix-events-sdk-0.0.1-beta.7.tgz#5ffe45eba1f67cc8d7c2377736c728b322524934"
   integrity sha512-9jl4wtWanUFSy2sr2lCjErN/oC8KTAtaeaozJtrgot1JiQcEI4Rda9OLgQ7nLKaqb4Z/QUx/fR3XpDzm5Jy1JA==
 
-matrix-js-sdk@^15.0.0:
-  version "15.6.0"
-  resolved "https://registry.yarnpkg.com/matrix-js-sdk/-/matrix-js-sdk-15.6.0.tgz#de29a75c5407801c95940d68ef4a22e9756c623d"
-  integrity sha512-jxx2jiuFVs6Vn76/Nm4+9+mLRW8NJMnA8XhFPtG9gzLpAOq5NQeRvr8mvGQqOQp2F85wthGVd0EkiP6cC1JXuw==
+matrix-js-sdk@^20.0.2:
+  version "20.0.2"
+  resolved "https://registry.yarnpkg.com/matrix-js-sdk/-/matrix-js-sdk-20.0.2.tgz#2d3c1bf3aa1efa867c10c94ec059b3d917ea96fd"
+  integrity sha512-PZMiLQHtmV+c5wZxS7EyWUKgHMJ/Syad7S5RxZVg80wug3qlX3oXkfyxZwrcMK4T1xE31upizspTZLm5Bkl2Vw==
   dependencies:
     "@babel/runtime" "^7.12.5"
     another-json "^0.2.0"
     browser-request "^0.3.3"
-    bs58 "^4.0.1"
+    bs58 "^5.0.0"
     content-type "^1.0.4"
     loglevel "^1.7.1"
     matrix-events-sdk "^0.0.1-beta.7"
-    p-retry "^4.5.0"
+    p-retry "4"
     qs "^6.9.6"
     request "^2.88.2"
     unhomoglyph "^1.0.6"
@@ -5069,7 +5067,7 @@ p-queue@^6.6.1, p-queue@^6.6.2:
     eventemitter3 "^4.0.4"
     p-timeout "^3.2.0"
 
-p-retry@^4.0.0, p-retry@^4.5.0:
+p-retry@4, p-retry@^4.0.0:
   version "4.6.2"
   resolved "https://registry.yarnpkg.com/p-retry/-/p-retry-4.6.2.tgz#9baae7184057edd4e17231cee04264106e092a16"
   integrity sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==
@@ -5552,7 +5550,7 @@ qlobber@^5.0.3:
   resolved "https://registry.yarnpkg.com/qlobber/-/qlobber-5.0.3.tgz#24728d6ba5382d502c7e09f6860b95a9c71615cd"
   integrity sha512-wW4GTZPePyh0RgOsM18oDyOUlXfurVRgoNyJfS+y7VWPyd0GYhQp5T2tycZFZjonH+hngxIfklGJhTP/ghidgQ==
 
-qs@6.10.3, qs@^6.7.0, qs@^6.9.4:
+qs@6.10.3:
   version "6.10.3"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.10.3.tgz#d6cde1b2ffca87b5aa57889816c5f81535e22e8e"
   integrity sha512-wr7M2E0OFRfIfJZjKGieI8lBKb7fRCH4Fv5KNPEs7gJ8jadvotdsS08PzOKR7opXhZ/Xkjtt3WF9g38drmyRqQ==


### PR DESCRIPTION
Github Bug/Issue: Fixes #5716

Hope this will work (but not really sure). Based on [this workaround](https://github.com/matrix-org/matrix-js-sdk/issues/2415#issuecomment-1141246410).