### PR TITLE
Add auto-release to github status handlers

### DIFF
--- a/changelog/issue-5728.md
+++ b/changelog/issue-5728.md
@@ -1,0 +1,6 @@
+audience: general
+level: patch
+reference: issue 5728
+---
+
+Adds auto release lock functionality to queued locks to prevent some handlers to run forever and keep the queue locked.

--- a/changelog/issue-5728.md
+++ b/changelog/issue-5728.md
@@ -3,4 +3,4 @@ level: patch
 reference: issue 5728
 ---
 
-Adds auto release lock functionality to queued locks to prevent some handlers to run forever and keep the queue locked.
+Adds auto release lock functionality to queued locks to prevent some GitHub handlers to run forever and keep the queue locked.

--- a/services/github/src/handlers/status.js
+++ b/services/github/src/handlers/status.js
@@ -18,7 +18,7 @@ const { taskUI, makeDebug, taskLogUI, GithubCheck } = require('./utils');
  * because it took him longer to reach update calls.
  */
 const qLock = new QueueLock({
-  maxLockTimeMs: 5 * 60 * 1000, // sometimes queue and github calls get delayed
+  maxLockTimeMs: 60 * 1000, // sometimes queue and github calls get delayed
 });
 
 /**

--- a/services/github/src/handlers/status.js
+++ b/services/github/src/handlers/status.js
@@ -17,7 +17,9 @@ const { taskUI, makeDebug, taskLogUI, GithubCheck } = require('./utils');
  * This can lead to situations where newer event is being overwritten by an older one,
  * because it took him longer to reach update calls.
  */
-const qLock = new QueueLock();
+const qLock = new QueueLock({
+  maxLockTimeMs: 5 * 60 * 1000, // sometimes queue and github calls get delayed
+});
 
 /**
  * Post updates to GitHub, when task is being created or its status changes.
@@ -38,7 +40,7 @@ async function statusHandler(message) {
   const { reasonResolved } = runs[runId] || {};
   const taskDefined = state === undefined;
 
-  await qLock.acquire(taskId);
+  const releaseLock = await qLock.acquire(taskId);
 
   let debug = makeDebug(this.monitor, { taskGroupId, taskId });
   debug(`Handling state change for task ${taskId} in group ${taskGroupId}, reason=${reasonResolved || state || 'taskDefined'}`, { exchange: message.exchange });
@@ -49,7 +51,7 @@ async function statusHandler(message) {
   let [build] = await this.context.db.fns.get_github_build(taskGroupId);
   if (!build) {
     debug(`No github build is associated with task group ${taskGroupId}. Most likely this was triggered by periodic cron hook, which doesn't require github event / check suite.`);
-    qLock.release(taskId);
+    releaseLock();
     return false;
   }
 
@@ -192,7 +194,7 @@ async function statusHandler(message) {
     e.sha = build.sha;
     throw e;
   } finally {
-    qLock.release(taskId);
+    releaseLock();
   }
 }
 

--- a/services/github/src/queue-lock.js
+++ b/services/github/src/queue-lock.js
@@ -1,44 +1,104 @@
+const assert = require('assert');
+const debug = require('debug')('queue-lock');
+
 /**
  * Implements locked queue to allow one routine running at a time
  */
 class QueueLock {
-  constructor() {
+  constructor({
+    maxLockTimeMs = 0, // if > 0, lock will be auto released after given ms
+  } = {}) {
+    assert(maxLockTimeMs >= 0, 'negative max time lock');
+
     this.locks = new Map();
     this.queue = {};
+    this.maxLockTimeMs = maxLockTimeMs;
   }
 
+  /**
+   * Acquire an exclusive lock for a given named queue
+   * Returns promise that resolves with release function
+   *
+   * @param {string} name Name of the queue
+   * @returns {Promise}
+   */
   acquire(name) {
     if (!this.queue[name]) {
       this.queue[name] = [];
     }
 
-    const [ promise, resolver ] = this._createPromise();
+    const promise = this._createPromise(name);
 
     if (!this.locks.has(name)) {
       this.locks.set(name, true);
-      resolver();
+      promise.resolve();
     } else {
-      this.queue[name].push(resolver);
+      this.queue[name].push(promise);
     }
 
-    return promise;
+    return promise.promise;
   }
 
-  release(name) {
-    const nextResolver = this.queue[name].shift();
-    if (nextResolver) {
-      nextResolver();
+  /**
+   * Takes next client and resolves its 'acquire' promise
+   * All listeners are being processed sequentially
+   * in the order they acquired their locks
+   *
+   * @internal
+   * @param {string} name
+   */
+  _release(name) {
+    const next = this.queue[name].shift();
+    if (next) {
+      next.resolve();
     } else {
       this.locks.delete(name);
     }
   }
 
-  _createPromise() {
+  /**
+   * Create a promise and a resolve function
+   * Resolve function will return `releaseLock()` function
+   * that should be called by the client code
+   *
+   * If `maxLockTimeMs` is set, additional auto release timeout will be set
+   * Lock will be released at most once in this case, either by timeout or
+   * by client calling release directly.
+   * This is to ensure that auto-release is only releasing own lock
+   *
+   * @internal
+   * @param {*} name
+   * @returns {Object} { promise, resolve }
+   */
+  _createPromise(name) {
     let resolver;
-    return [
-      new Promise((resolve) => { resolver = resolve; }),
-      resolver,
-    ];
+    let autoRelease;
+    let alreadyReleased = false;
+
+    const promise = new Promise((resolve) => { resolver = resolve; });
+    const release = () => {
+      if (alreadyReleased) {
+        return;
+      }
+
+      if (autoRelease) {
+        clearInterval(autoRelease);
+      }
+      alreadyReleased = true;
+      this._release(name);
+    };
+
+    if (this.maxLockTimeMs) {
+      autoRelease = setTimeout(() => {
+        debug(`Auto-release ${name}`);
+        release();
+      }, this.maxLockTimeMs);
+    }
+
+    return {
+      promise,
+      resolve: () => resolver(release),
+    };
   }
 }
 


### PR DESCRIPTION
Logs show that few github handlers might error or hang without releasing own lock. `maxLockTimeMs` for QueueLock will ensure that handlers do not run beyond given time, and forces their lock to be released. This will allow next waiting handlers to start work.
