### PR TITLE
Remove discontinued and unneeded disableSeccomp capability from dw-ci

### DIFF
--- a/changelog/C0wbR7wOQ8WP3HThfO44Yw.md
+++ b/changelog/C0wbR7wOQ8WP3HThfO44Yw.md
@@ -1,0 +1,3 @@
+audience: general
+level: silent
+---

--- a/taskcluster/ci/docker-worker/kind.yml
+++ b/taskcluster/ci/docker-worker/kind.yml
@@ -24,7 +24,6 @@ task-defaults:
   worker:
     taskcluster-proxy: true
     privileged: true
-    disable-seccomp: true
     loopback-video: true
     loopback-audio: true
     max-run-time: 10800


### PR DESCRIPTION
The `disableSeccomp` capability feature was removed from Docker Worker in #5800 after being deemed [superfluous](https://github.com/taskcluster/taskcluster/pull/5800#issuecomment-1330766821). This removes its use from the Docker Worker CI tests too.