### PR TITLE
Migrate from gliderlabs/alpine:<various> to alpine:latest docker images

### DIFF
--- a/changelog/JYE4RIaXTImQ8YhzVd8fDA.md
+++ b/changelog/JYE4RIaXTImQ8YhzVd8fDA.md
@@ -1,0 +1,3 @@
+audience: general
+level: silent
+---

--- a/workers/docker-worker/test/image_manager_test.js
+++ b/workers/docker-worker/test/image_manager_test.js
@@ -26,7 +26,7 @@ helper.secrets.mockSuite(suiteName(), ['docker'], function(mock, skipping) {
   }
 
   test('download docker image from registry', async () => {
-    let image = 'gliderlabs/alpine:latest';
+    let image = 'alpine:latest';
     await dockerUtils.removeImageIfExists(docker, image);
     let runtime = {
       docker: docker,

--- a/workers/docker-worker/test/images/dind-test/Dockerfile
+++ b/workers/docker-worker/test/images/dind-test/Dockerfile
@@ -1,5 +1,5 @@
-FROM        gliderlabs/alpine:3.2
-MAINTAINER  Jonas Finnemann Jensen <jopsen@gmail.com>
+FROM        alpine:latest
+MAINTAINER  Taskcluster <taskcluster-accounts+docker-maintainer@mozilla.com>
 
 # Install dependencies
 RUN         apk-install docker

--- a/workers/docker-worker/test/integration/pull_image_test.js
+++ b/workers/docker-worker/test/integration/pull_image_test.js
@@ -16,7 +16,7 @@ helper.secrets.mockSuite(suiteName(), ['docker', 'ci-creds'], function(mock, ski
   }
 
   test('ensure docker image can be pulled', async () => {
-    let image = 'gliderlabs/alpine:latest';
+    let image = 'alpine:latest';
     await removeImage(docker, image);
 
     let result = await testworker({


### PR DESCRIPTION
CI started failing due to a seemingly no longer maintained base docker image (gliderlabs/alpine).

This PR switches our CI tests to the latest vanilla alpine docker image.