### PR TITLE
Issue 5781 part 2: specify package(s) name when calling go test to suppress stdout/stderr in passing tests

### DIFF
--- a/changelog/JpzzjXzuTkqyZ_ekVL8EjA.md
+++ b/changelog/JpzzjXzuTkqyZ_ekVL8EjA.md
@@ -1,0 +1,3 @@
+audience: general
+level: silent
+---

--- a/workers/generic-worker/gw-decision-task/tasks.yml
+++ b/workers/generic-worker/gw-decision-task/tasks.yml
@@ -230,7 +230,7 @@ Commands:
             cp "${TASK_USER_CREDENTIALS}" next-task-user.json
             # IMPORTANT - run go test with GW_TESTS_RUN_AS_CURRENT_USER=true *before* running it without
             # otherwise tests that call `go run ....` will write go object files to .cache as root
-            GW_TESTS_RUN_AS_CURRENT_USER=true GORACE=history_size=7 CGO_ENABLED=1 go test -tags "${ENGINE}" -failfast -timeout 45m -ldflags "-X github.com/taskcluster/taskcluster/v45/workers/generic-worker.revision=${GITHUB_SHA}" ${RACE} ${VET}
+            GW_TESTS_RUN_AS_CURRENT_USER=true GORACE=history_size=7 CGO_ENABLED=1 go test -tags "${ENGINE}" -failfast -timeout 45m -ldflags "-X github.com/taskcluster/taskcluster/v45/workers/generic-worker.revision=${GITHUB_SHA}" ${RACE} ${VET} .
           fi
           GORACE=history_size=7 CGO_ENABLED=${CGO_ENABLED_TESTS} go test -tags "${ENGINE}" -failfast -timeout 45m -ldflags "-X github.com/taskcluster/taskcluster/v45/workers/generic-worker.revision=${GITHUB_SHA}" ${RACE} ${VET} ./...
 
@@ -302,9 +302,11 @@ Commands:
       - set CGO_ENABLED=%CGO_ENABLED_TESTS%
       - set GORACE=history_size=7
       - copy "%TASK_USER_CREDENTIALS%" "%CD%\next-task-user.json"
-      - 'go test -tags "%ENGINE%" -failfast -timeout 45m -ldflags "-X github.com/taskcluster/taskcluster/v45/workers/generic-worker.revision=%GITHUB_SHA%" %RACE% %VET% ./...'
+      # Run with GW_TESTS_RUN_AS_CURRENT_USER=true first, to be consistent with Linux/macOS tasks
       - set GW_TESTS_RUN_AS_CURRENT_USER=true
-      - 'go test -tags "%ENGINE%" -failfast -timeout 45m -ldflags "-X github.com/taskcluster/taskcluster/v45/workers/generic-worker.revision=%GITHUB_SHA%" %RACE% %VET%'
+      - 'go test -tags "%ENGINE%" -failfast -timeout 45m -ldflags "-X github.com/taskcluster/taskcluster/v45/workers/generic-worker.revision=%GITHUB_SHA%" %RACE% %VET% .'
+      - set GW_TESTS_RUN_AS_CURRENT_USER=
+      - 'go test -tags "%ENGINE%" -failfast -timeout 45m -ldflags "-X github.com/taskcluster/taskcluster/v45/workers/generic-worker.revision=%GITHUB_SHA%" %RACE% %VET% ./...'
 
       ################################################################################
       # This entire section is edited by infrastructure/tooling/src/generate/generators/golangci-lint-version.js to update the golangci-lint version number.


### PR DESCRIPTION
I hadn't spotted that my changes in PR #5782 were not enough to implement issue #5781. This is a follow-on that should hopefully put the issue to bed.

This time I'll also check the output of the affected CI tasks to make sure that the intended changes are effective before merging! (whoops)