### PR TITLE
feat(ui): Fix empty last fires response

### DIFF
--- a/changelog/issue-5804-1.md
+++ b/changelog/issue-5804-1.md
@@ -1,0 +1,6 @@
+audience: users
+level: patch
+reference: issue 5804
+---
+
+Fix graphql endpoint for hook without last fires.

--- a/services/web-server/src/loaders/hooks.js
+++ b/services/web-server/src/loaders/hooks.js
@@ -64,7 +64,10 @@ module.exports = ({ hooks }, isAuthed, rootUrl, monitor, strategies, req, cfg, r
           items: raw.lastFires,
         };
       } catch (err) {
-        if (err.statusCode === 404 || err.statusCode === 424) {
+        if (err.statusCode === 404) {
+          // hooks last fires will return 404 when there are no last fires yet
+          return { items: [] };
+        } else if (err.statusCode === 424) {
           return null;
         }
 


### PR DESCRIPTION
Hooks api sends 404 when there are no last fires for the given hook.
