### PR TITLE
feat(ui): Fix empty error message for hook last fire

### DIFF
--- a/changelog/issue-5804-2.md
+++ b/changelog/issue-5804-2.md
@@ -1,0 +1,6 @@
+audience: users
+level: patch
+reference: issue 5804
+---
+
+Fix empty error message for hooks last fire.

--- a/ui/src/components/ErrorPanel/index.jsx
+++ b/ui/src/components/ErrorPanel/index.jsx
@@ -138,8 +138,27 @@ export default class ErrorPanel extends Component {
         `Network Error (${error.networkError.statusCode ||
           'no status code'}): ${error.networkError}`
       );
-    } else {
+    } else if (error.message) {
       message.push(error.message);
+    } else {
+      // error can be a JSON serialized object
+      try {
+        const obj = JSON.parse(error);
+
+        if (obj?.body?.code) {
+          message.push(`API Error: ${obj.body.code}`);
+        }
+
+        if (obj?.body?.message) {
+          message.push(obj.body.message);
+        }
+      } catch {
+        // ignore
+      }
+
+      if (!message.length) {
+        message.push(error);
+      }
     }
 
     return (

--- a/ui/src/components/TaskGroupStats/index.jsx
+++ b/ui/src/components/TaskGroupStats/index.jsx
@@ -149,7 +149,7 @@ export default class TaskGroupStats extends Component {
       searchTerm,
       graphAll ? +Infinity : maxTasksInGraph
     );
-    const width = (sampledTasks.length + 1) * barWidth;
+    const width = (Math.max(25, sampledTasks.length) + 1) * barWidth;
     const relativeHeight = d => Math.max(1, (height * d) / maxDuration);
     const median = quantile(durations, 0.5);
     const q75 = quantile(durations, 0.75);


### PR DESCRIPTION
Fixes in this PR:

* Extend ErrorPanel component to display errors that look like json serialized API response error.  In hooks last fires it was showing empty red panel.
* Task group stats adds safe min width for the graph, so group with few tasks wouldn't have really wide bars on it. Looks better
