### PR TITLE
chore(ci): Upgrade CI images to use windows2022

### DIFF
--- a/changelog/QE-LV6FARYKtvKcdj7tmFQ.md
+++ b/changelog/QE-LV6FARYKtvKcdj7tmFQ.md
@@ -1,0 +1,4 @@
+audience: developers
+level: patch
+---
+This patch switches running CI tasks on generic-worker-windows2012r2 worker pool to the new, windows 2022 worker pool.

--- a/taskcluster/ci/config.yml
+++ b/taskcluster/ci/config.yml
@@ -31,8 +31,8 @@ workers:
       os: linux
       implementation: generic-worker
       worker-type: gw-ci-ubuntu-22-04
-    gw-ci-windows2012r2-amd64:
+    gw-ci-windows-2022:
       provisioner: proj-taskcluster
       os: windows
       implementation: generic-worker
-      worker-type: gw-ci-windows2012r2-amd64
+      worker-type: gw-ci-windows-2022

--- a/taskcluster/ci/generic-worker/kind.yml
+++ b/taskcluster/ci/generic-worker/kind.yml
@@ -16,7 +16,7 @@ task-defaults:
 tasks:
   windows-worker-runner:
     description: 'test worker-runner under windows as well'
-    worker-type: gw-ci-windows2012r2-amd64
+    worker-type: gw-ci-windows-2022
     worker:
       mounts:
         - content:

--- a/workers/generic-worker/gw-decision-task/tasks.yml
+++ b/workers/generic-worker/gw-decision-task/tasks.yml
@@ -62,7 +62,7 @@ Tasks:
     - WorkerPool: 'proj-taskcluster/gw-ci-ubuntu-22-04'
       Env:
         ENGINE: 'docker'
-    - WorkerPool: 'proj-taskcluster/gw-ci-windows2012r2-amd64'
+    - WorkerPool: 'proj-taskcluster/gw-ci-windows-2022'
       Env:
         ENGINE: 'multiuser'
         # We must set here since this worker type does not have a Z: drive
@@ -122,8 +122,8 @@ WorkerPools:
     # There is no arm release for go 1.19.3 on windows, but 386 release works
     # through emulation provided by the host OS.
     Arch: '386'
-  proj-taskcluster/gw-ci-windows2012r2-amd64:
-    Platform: 'Windows Server 2012 R2 (amd64)'
+  proj-taskcluster/gw-ci-windows-2022:
+    Platform: 'Windows Server 2022 (amd64)'
     OS: 'windows'
     Arch: 'amd64'
   proj-taskcluster/gw-ci-windows7-386:


### PR DESCRIPTION
> This patch switches running CI tasks on generic-worker-windows2012r2 worker pool to the new, windows 2022 worker pool.