### PR TITLE
Fix python client tests

### DIFF
--- a/changelog/DehbA-CwSziOtiWg2rFZkg.md
+++ b/changelog/DehbA-CwSziOtiWg2rFZkg.md
@@ -1,0 +1,5 @@
+audience: general
+level: patch
+---
+
+Patch python client tests to allow lint script.

--- a/clients/client-py/tox.ini
+++ b/clients/client-py/tox.ini
@@ -14,6 +14,7 @@ passenv =
     TASKCLUSTER_ACCESS_TOKEN
 extras = test
 usedevelop = true
+allowlist_externals = ./lint.sh
 
 commands =
     pip freeze


### PR DESCRIPTION
Python tests were failing [py38](https://github.com/taskcluster/taskcluster/pull/5854/checks?check_run_id=9995796033)

According to [documentation](https://tox.wiki/en/4.0.3/config.html) external tools needs to be whitelisted