### PR TITLE
chore(py-client): clean up deprecation warnings

### DIFF
--- a/changelog/MslfLmhuTVKCrrLwQm2ejA.md
+++ b/changelog/MslfLmhuTVKCrrLwQm2ejA.md
@@ -1,0 +1,4 @@
+audience: general
+level: patch
+---
+This patch cleans up some of the python client and client test code of deprecation warnings.

--- a/clients/client-py/taskcluster/aio/asyncutils.py
+++ b/clients/client-py/taskcluster/aio/asyncutils.py
@@ -51,7 +51,7 @@ async def makeHttpRequest(method, url, payload, headers, retries=utils.MAX_RETRI
                     response = await makeSingleHttpRequest(method, url, payload, headers, session)
             except aiohttp.ClientError as rerr:
                 if retry < retries:
-                    log.warn('Retrying because of: %s' % rerr)
+                    log.warning('Retrying because of: %s' % rerr)
                     continue
                 # raise a connection exception
                 raise rerr

--- a/clients/client-py/taskcluster/client.py
+++ b/clients/client-py/taskcluster/client.py
@@ -490,7 +490,7 @@ class BaseClient(object):
                 response = utils.makeSingleHttpRequest(method, url, payload, headers)
             except requests.exceptions.RequestException as rerr:
                 if retry < retries:
-                    log.warn('Retrying because of: %s' % rerr)
+                    log.warning('Retrying because of: %s' % rerr)
                     continue
                 # raise a connection exception
                 raise exceptions.TaskclusterConnectionError(
@@ -506,7 +506,7 @@ class BaseClient(object):
             # Catch retryable errors and go to the beginning of the loop
             # to do the retry
             if 500 <= status and status < 600 and retry < retries:
-                log.warn('Retrying because of a %s status code' % status)
+                log.warning('Retrying because of a %s status code' % status)
                 continue
 
             # Throw errors for non-retryable errors

--- a/clients/client-py/taskcluster/utils.py
+++ b/clients/client-py/taskcluster/utils.py
@@ -261,7 +261,7 @@ def makeHttpRequest(method, url, payload, headers, retries=MAX_RETRIES, session=
             response = makeSingleHttpRequest(method, url, payload, headers, session)
         except requests.exceptions.RequestException as rerr:
             if retry < retries:
-                log.warn('Retrying because of: %s' % rerr)
+                log.warning('Retrying because of: %s' % rerr)
                 continue
             # raise a connection exception
             raise rerr

--- a/clients/client-py/test/test_client.py
+++ b/clients/client-py/test/test_client.py
@@ -27,7 +27,7 @@ pytestmark = [
 REAL_TIME_SLEEP = time.sleep
 
 
-@pytest.yield_fixture(scope='function')
+@pytest.fixture(scope='function')
 def apiRef(mocker):
     subject.config['credentials'] = {
         'clientId': 'clientId',
@@ -54,19 +54,19 @@ def apiRef(mocker):
     yield apiRef
 
 
-@pytest.yield_fixture(scope='function')
+@pytest.fixture(scope='function')
 def clientClass(apiRef):
     clientClass = subject.createApiClient('testApi', apiRef)
     yield clientClass
 
 
-@pytest.yield_fixture(scope='function')
+@pytest.fixture(scope='function')
 def client(clientClass):
     client = clientClass({'rootUrl': base.TEST_ROOT_URL})
     yield client
 
 
-@pytest.yield_fixture(scope='function')
+@pytest.fixture(scope='function')
 def patcher(client):
     patcher = mock.patch.object(client, 'NEVER_CALL_ME')
     yield patcher


### PR DESCRIPTION
> This patch cleans up some of the python client and client test code of deprecation warnings.

See warnings in https://community-tc.services.mozilla.com/tasks/ENn4rmShRU6ukAgXCNpO-A