### PR TITLE
Support getUrl downloads in clients

### DIFF
--- a/changelog/issue-4624.md
+++ b/changelog/issue-4624.md
@@ -1,0 +1,9 @@
+audience: developers
+level: minor
+reference: issue 4624
+---
+
+All language clients now use the getUrl download method to download objects,
+including verifying hashes provided when the objects were uploaded.  However,
+note that 's3' artifacts are still not verified -- the deployment must use
+'object' artifacts to benefit from hash verification.

--- a/clients/client-go/tcobject/download.go
+++ b/clients/client-go/tcobject/download.go
@@ -2,11 +2,16 @@ package tcobject
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
+	"net/http"
 	"os"
+	"time"
 
+	"github.com/cenkalti/backoff/v3"
 	"github.com/orcaman/writerseeker"
+	"github.com/taskcluster/httpbackoff/v3"
 	"github.com/taskcluster/taskcluster/v46/clients/client-go/internal"
 )
 
@@ -44,6 +49,154 @@ func (object *Object) DownloadToFile(name string, filepath string) (contentType 
 	return object.DownloadToWriteSeeker(name, writeSeeker)
 }
 
+// getUrlDownload implements the getUrl download method.
+func (object *Object) getUrlDownload(rawResponse *DownloadObjectResponse, name string, writeSeeker io.WriteSeeker) (contentType string, contentLength int64, err error) {
+	downloadResponse := GetURLDownloadResponse{}
+	responseUsed := false
+	err = json.Unmarshal(*rawResponse, &downloadResponse)
+	if err != nil {
+		return
+	}
+
+	// wrap the writeSeeker so that we can get the hashes of the received data
+	hashingWriter := newHashingWriteSeeker(writeSeeker)
+
+	retryFunc := func() (resp *http.Response, tempError error, permError error) {
+		// Explicitly seek to start here, rather than only after a temp error,
+		// since not all temporary errors are caught by this code (e.g. status
+		// codes 500-599 are handled by httpbackoff library implicitly).
+		_, permError = hashingWriter.Seek(0, io.SeekStart)
+		if permError != nil {
+			// not being able to seek to start is a problem that is unlikely to
+			// be solved with retries with exponential backoff, so give up
+			// straight away
+			return
+		}
+
+		// if the URL has expired, fetch a new one, verifying that each response
+		// is used at least once to avoid infinitely re-fetching
+		if responseUsed && time.Time(downloadResponse.Expires).Before(time.Now()) {
+			rawResponse, err = object.StartDownload(
+				name,
+				&DownloadObjectRequest{
+					AcceptDownloadMethods: SupportedDownloadMethods{GetURL: true},
+				},
+			)
+			if err != nil {
+				return
+			}
+			err = json.Unmarshal(*rawResponse, &downloadResponse)
+			if err != nil {
+				return
+			}
+			if downloadResponse.Method != "getUrl" {
+				err = fmt.Errorf("Got unexpected download method %v", downloadResponse.Method)
+				return
+			}
+			responseUsed = false
+		}
+
+		// Get the URL.  Note that this adds `Acccept-Encoding: gzip` and will
+		// automatically un-gzip a response if necessary.
+		responseUsed = true
+		resp, tempError = http.Get(downloadResponse.URL)
+
+		// httpbackoff handles http status codes, so we can consider all errors worth retrying here
+		if tempError != nil || resp.StatusCode != 200 {
+			// temporary error!
+			return
+		}
+		defer resp.Body.Close()
+		contentType = resp.Header.Get("Content-Type")
+		contentLength, tempError = io.Copy(hashingWriter, resp.Body)
+		return
+	}
+	var resp *http.Response
+	// HTTP status codes handled here automatically
+	client := object.HTTPBackoffClient
+	if client == nil {
+		client = &httpbackoff.Client{
+			BackOffSettings: backoff.NewExponentialBackOff(),
+		}
+	}
+	var attempts int
+	resp, attempts, err = client.Retry(retryFunc)
+	if err != nil {
+		err = HTTPRetryError{
+			Attempts: attempts,
+			Err:      err,
+		}
+	}
+	resp.Body.Close()
+	if err != nil {
+		return
+	}
+
+	// verify hashes if no error has occurred so far.  Note that the download is not
+	// retried if hash verification fails.
+	if err == nil {
+		var hashes map[string]string
+		hashes, err = unmarshalHashes(downloadResponse.Hashes)
+		if err != nil {
+			err = HTTPRetryError{
+				Attempts: attempts,
+				Err:      err,
+			}
+			return
+		}
+		err = verifyHashes(hashingWriter, hashes)
+		if err != nil {
+			err = HTTPRetryError{
+				Attempts: attempts,
+				Err:      err,
+			}
+			return
+		}
+	}
+
+	// if there is an error, empty everything else out so that callers do not use the
+	// untrusted returned data
+	if err != nil {
+		contentType = ""
+		contentLength = 0
+		_, _ = hashingWriter.Seek(0, io.SeekStart)
+		return
+	}
+	return
+}
+
+// verifyHashes verifies that the hashes observed by the hashingWriter match
+// those in hashes, where present, and that at least one is present.
+func verifyHashes(hashingWriter *hashingWriteSeeker, expectedHashes map[string]string) error {
+	observedHashes, err := hashingWriter.hashes()
+	if err != nil {
+		return err
+	}
+
+	// this will be set to true when an acceptable (that is, not deprecated) hash
+	// algorithm is found with a valid hash.
+	var someValidAcceptableHash bool
+
+	for algo, oh := range observedHashes {
+		if eh, ok := expectedHashes[algo]; ok {
+			if oh != eh {
+				return fmt.Errorf("Validation of object data's %s hash failed", algo)
+			}
+			for _, a := range ACCEPTABLE_HASHES {
+				if algo == a {
+					someValidAcceptableHash = true
+				}
+			}
+		}
+	}
+
+	if !someValidAcceptableHash {
+		return errors.New("No acceptable hashes found in object metadata")
+	}
+
+	return nil
+}
+
 // DownloadToWriteSeeker downloads the named object from the object service and
 // writes it to writeSeeker, retrying if intermittent errors occur. Returns
 // the Content-Type and Content-Length of the downloaded object.
@@ -52,7 +205,7 @@ func (object *Object) DownloadToWriteSeeker(name string, writeSeeker io.WriteSee
 		name,
 		&DownloadObjectRequest{
 			AcceptDownloadMethods: SupportedDownloadMethods{
-				Simple: true,
+				GetURL: true,
 			},
 		},
 	)
@@ -60,16 +213,15 @@ func (object *Object) DownloadToWriteSeeker(name string, writeSeeker io.WriteSee
 		return "", 0, err
 	}
 
-	resp := SimpleDownloadResponse{}
-	err = json.Unmarshal(*downloadObjectResponse, &resp)
+	var bareResp struct{ Method string }
+	err = json.Unmarshal(*downloadObjectResponse, &bareResp)
 	if err != nil {
 		return "", 0, err
 	}
 
-	switch resp.Method {
-	case "simple":
-		url := resp.URL
-		return internal.GetURL(object.HTTPBackoffClient, url, writeSeeker)
+	switch bareResp.Method {
+	case "getUrl":
+		return object.getUrlDownload(downloadObjectResponse, name, writeSeeker)
 	}
-	return "", 0, fmt.Errorf("Unknown download method %q in response to object.StartDownload call for object %q with \"acceptDownloadMethods\":{\"simple\":true}", resp.Method, name)
+	return "", 0, fmt.Errorf("Unknown download method %q for object %q", bareResp.Method, name)
 }

--- a/clients/client-go/tcobject/hashes.go
+++ b/clients/client-go/tcobject/hashes.go
@@ -1,0 +1,31 @@
+package tcobject
+
+import "encoding/json"
+
+// The subset of hashes supported by hashing{read,write}stream which are
+// "accepted" as per the object service's schemas.
+var ACCEPTABLE_HASHES = []string{
+	"sha256",
+	"sha512",
+}
+
+// marshalHashes marshals a map of hashes as returned from the hashing
+// read/write seekers into JSON.
+func marshalHashes(hashes map[string]string) json.RawMessage {
+	if hashes == nil {
+		hashes = map[string]string{}
+	}
+	// marshalling a (non-null) map cannot fail
+	msg, _ := json.Marshal(hashes)
+	return msg
+}
+
+// unmarshalHashes unmarshals a JSON message into a map of hashes.
+func unmarshalHashes(msg json.RawMessage) (map[string]string, error) {
+	var hashes map[string]string
+	err := json.Unmarshal(msg, &hashes)
+	if err != nil {
+		return nil, err
+	}
+	return hashes, nil
+}

--- a/clients/client-go/tcobject/hashingreadseeker_test.go
+++ b/clients/client-go/tcobject/hashingreadseeker_test.go
@@ -2,17 +2,11 @@ package tcobject
 
 import (
 	"bytes"
-	"encoding/json"
 	"io"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 )
-
-type hashes struct {
-	Sha256 string
-	Sha512 string
-}
 
 func TestHashingReadSeekerOnce(t *testing.T) {
 	inner := bytes.NewReader([]byte("fake content"))
@@ -23,15 +17,11 @@ func TestHashingReadSeekerOnce(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, []byte("fake content"), content)
 
-	hashesJson, err := h.hashes(12)
+	hashes, err := h.hashes(12)
 	require.NoError(t, err)
 
-	var hashes hashes
-	err = json.Unmarshal(hashesJson, &hashes)
-	require.NoError(t, err)
-
-	require.Equal(t, "98b1ae45059b004178a8eee0c1f6179dcea139c0fd8a69ee47a6f02d97af1f17", hashes.Sha256)
-	require.Equal(t, "e0ea5ae6e392bb46d27eebabf5e7eb817d242505a960079cd9871559eaa94c613aff4034b709ea3cbd7747b304e7da5564083df50ea51f389cddcb942d2a4a09", hashes.Sha512)
+	require.Equal(t, "98b1ae45059b004178a8eee0c1f6179dcea139c0fd8a69ee47a6f02d97af1f17", hashes["sha256"])
+	require.Equal(t, "e0ea5ae6e392bb46d27eebabf5e7eb817d242505a960079cd9871559eaa94c613aff4034b709ea3cbd7747b304e7da5564083df50ea51f389cddcb942d2a4a09", hashes["sha512"])
 }
 
 func TestHashingReadSeekerTwice(t *testing.T) {
@@ -50,15 +40,11 @@ func TestHashingReadSeekerTwice(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, []byte("fake content"), content)
 
-	hashesJson, err := h.hashes(12)
+	hashes, err := h.hashes(12)
 	require.NoError(t, err)
 
-	var hashes hashes
-	err = json.Unmarshal(hashesJson, &hashes)
-	require.NoError(t, err)
-
-	require.Equal(t, "98b1ae45059b004178a8eee0c1f6179dcea139c0fd8a69ee47a6f02d97af1f17", hashes.Sha256)
-	require.Equal(t, "e0ea5ae6e392bb46d27eebabf5e7eb817d242505a960079cd9871559eaa94c613aff4034b709ea3cbd7747b304e7da5564083df50ea51f389cddcb942d2a4a09", hashes.Sha512)
+	require.Equal(t, "98b1ae45059b004178a8eee0c1f6179dcea139c0fd8a69ee47a6f02d97af1f17", hashes["sha256"])
+	require.Equal(t, "e0ea5ae6e392bb46d27eebabf5e7eb817d242505a960079cd9871559eaa94c613aff4034b709ea3cbd7747b304e7da5564083df50ea51f389cddcb942d2a4a09", hashes["sha512"])
 }
 
 func TestHashingReadSeekerBadContentLength(t *testing.T) {

--- a/clients/client-go/tcobject/hashingwriteseeker_test.go
+++ b/clients/client-go/tcobject/hashingwriteseeker_test.go
@@ -1,0 +1,65 @@
+package tcobject
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+type writeSeekingBuffer struct {
+	bytes.Buffer
+}
+
+func (w *writeSeekingBuffer) Seek(offset int64, whence int) (pos int64, err error) {
+	if whence != io.SeekStart || offset != 0 {
+		err = errors.New("only seek(0, io.SeekStart) is supported")
+		return
+	}
+	w.Buffer = bytes.Buffer{}
+	return 0, nil
+}
+
+func TestHashingWriteSeekerOnce(t *testing.T) {
+	inner := &writeSeekingBuffer{}
+	h := newHashingWriteSeeker(inner)
+
+	source := bytes.NewReader([]byte("fake content"))
+	count, err := io.Copy(h, source)
+	require.NoError(t, err)
+	require.Equal(t, int64(12), count)
+	require.Equal(t, []byte("fake content"), inner.Bytes())
+
+	hashes, err := h.hashes()
+	require.NoError(t, err)
+
+	require.Equal(t, "98b1ae45059b004178a8eee0c1f6179dcea139c0fd8a69ee47a6f02d97af1f17", hashes["sha256"])
+	require.Equal(t, "e0ea5ae6e392bb46d27eebabf5e7eb817d242505a960079cd9871559eaa94c613aff4034b709ea3cbd7747b304e7da5564083df50ea51f389cddcb942d2a4a09", hashes["sha512"])
+}
+
+func TestHashingWriteSeekerTwice(t *testing.T) {
+	inner := &writeSeekingBuffer{}
+	h := newHashingWriteSeeker(inner)
+
+	source := bytes.NewReader([]byte("fake")) // truncated read
+	_, err := io.Copy(h, source)
+	require.NoError(t, err)
+
+	n, err := h.Seek(0, io.SeekStart)
+	require.NoError(t, err)
+	require.Equal(t, int64(0), n)
+
+	source = bytes.NewReader([]byte("fake content"))
+	count, err := io.Copy(h, source)
+	require.NoError(t, err)
+	require.Equal(t, int64(12), count)
+	require.Equal(t, []byte("fake content"), inner.Bytes())
+
+	hashes, err := h.hashes()
+	require.NoError(t, err)
+
+	require.Equal(t, "98b1ae45059b004178a8eee0c1f6179dcea139c0fd8a69ee47a6f02d97af1f17", hashes["sha256"])
+	require.Equal(t, "e0ea5ae6e392bb46d27eebabf5e7eb817d242505a960079cd9871559eaa94c613aff4034b709ea3cbd7747b304e7da5564083df50ea51f389cddcb942d2a4a09", hashes["sha512"])
+}

--- a/clients/client-go/tcobject/upload.go
+++ b/clients/client-go/tcobject/upload.go
@@ -100,7 +100,7 @@ func (object *Object) UploadFromReadSeeker(projectID string, name string, conten
 			&FinishUploadRequest{
 				ProjectID: projectID,
 				UploadID:  uploadID,
-				Hashes:    hashes,
+				Hashes:    marshalHashes(hashes),
 			},
 		)
 		if err != nil {

--- a/clients/client-go/tcobject/upload_download_test.go
+++ b/clients/client-go/tcobject/upload_download_test.go
@@ -1,6 +1,8 @@
 package tcobject_test
 
 import (
+	"compress/gzip"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -11,19 +13,21 @@ import (
 	"github.com/cenkalti/backoff/v3"
 	"github.com/gorilla/mux"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/taskcluster/httpbackoff/v3"
 	"github.com/taskcluster/taskcluster/v46/clients/client-go/tcobject"
 	"github.com/taskcluster/taskcluster/v46/internal/mocktc"
 )
 
-func mockObjectServer(t *testing.T) (*httptest.Server, *mux.Router, *tcobject.Object) {
+func mockObjectServer(t *testing.T) (*httptest.Server, *mux.Router, *tcobject.Object, *mocktc.Object) {
 	r := mux.NewRouter().UseEncodedPath()
 	r.NotFoundHandler = http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		w.WriteHeader(404)
 		_, _ = w.Write([]byte(fmt.Sprintf("URL %v with method %v NOT FOUND\n", req.URL, req.Method)))
 	})
 	srv := httptest.NewServer(r)
-	mocktc.NewObjectProvider(mocktc.NewObject(t, srv.URL)).RegisterService(r)
+	mockobj := mocktc.NewObject(t, srv.URL)
+	mocktc.NewObjectProvider(mockobj).RegisterService(r)
 	object := tcobject.New(nil, srv.URL)
 	settings := &backoff.ExponentialBackOff{
 		InitialInterval:     5 * time.Millisecond,
@@ -37,17 +41,17 @@ func mockObjectServer(t *testing.T) (*httptest.Server, *mux.Router, *tcobject.Ob
 	object.HTTPBackoffClient = &httpbackoff.Client{
 		BackOffSettings: settings,
 	}
-	return srv, r, object
+	return srv, r, object, mockobj
 }
 
-// TestSimpleDownloadFails400 tests that when a simple download's GET fails
+// TestGetURLDownloadFails400 tests that when a getUrl download's GET fails
 // with a 400 HTTP status code, that a httpbackoff.BadHttpResponseCode error is
 // returned and the download isn't (non-intermittent status code).
-func TestSimpleDownloadFails400(t *testing.T) {
-	srv, r, object := mockObjectServer(t)
+func TestGetURLDownloadFails400(t *testing.T) {
+	srv, r, object, _ := mockObjectServer(t)
 	defer srv.Close()
 
-	r.HandleFunc("/simple",
+	r.HandleFunc("/s3/obj/some/object",
 		http.HandlerFunc(
 			func(w http.ResponseWriter, r *http.Request) {
 				w.WriteHeader(400)
@@ -62,20 +66,20 @@ func TestSimpleDownloadFails400(t *testing.T) {
 	_, _, _, err = object.DownloadToBuf("some/object")
 
 	// make sure we got 400 status code for download URL
-	assert.IsType(t, tcobject.HTTPRetryError{}, err)
+	assert.IsType(t, tcobject.HTTPRetryError{}, err, err)
 	assert.IsType(t, httpbackoff.BadHttpResponseCode{}, err.(tcobject.HTTPRetryError).Err)
 	assert.Equal(t, 400, err.(tcobject.HTTPRetryError).Err.(httpbackoff.BadHttpResponseCode).HttpResponseCode)
 	assert.Equal(t, 1, err.(tcobject.HTTPRetryError).Attempts)
 }
 
-// TestSimpleDownloadFailsRetried tests that when a simple download's GET fails
+// TestGetURLDownloadFailsRetried tests that when a getUrl download's GET fails
 // with a 500 HTTP status code, that a httpbackoff.BadHttpResponseCode error is
 // returned and the download is retried twice (intermittent status code).
-func TestSimpleDownloadFailsRetried(t *testing.T) {
-	srv, r, object := mockObjectServer(t)
+func TestGetURLDownloadFailsRetried(t *testing.T) {
+	srv, r, object, _ := mockObjectServer(t)
 	defer srv.Close()
 
-	r.HandleFunc("/simple",
+	r.HandleFunc("/s3/obj/some/object",
 		http.HandlerFunc(
 			func(w http.ResponseWriter, r *http.Request) {
 				w.WriteHeader(500)
@@ -98,36 +102,178 @@ func TestSimpleDownloadFailsRetried(t *testing.T) {
 
 type testHandler struct {
 	mu       sync.Mutex
-	attempts uint8
+	t        *testing.T
+	content  []byte
+	gzipped  bool
+	failures uint8
 }
 
 func (th *testHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	th.mu.Lock()
 	defer th.mu.Unlock()
-	switch th.attempts {
-	case 0:
+	if th.failures > 0 {
+		th.failures -= 1
 		w.WriteHeader(500)
-	default:
-		_, _ = w.Write([]byte("fake content"))
+		return
 	}
-	th.attempts += 1
+	w.Header().Set("Content-Type", "text/plain")
+	var n int
+	var err error
+	if th.gzipped {
+		require.Equal(th.t, "gzip", r.Header.Get("Accept-Encoding"))
+		w.Header().Set("Content-Encoding", "gzip")
+		compressor := gzip.NewWriter(w)
+		n, err = compressor.Write(th.content)
+		if err == nil {
+			err = compressor.Close()
+		}
+	} else {
+		n, err = w.Write(th.content)
+	}
+	if err != nil {
+		th.t.Fatal(err)
+	}
+	if n < len(th.content) {
+		th.t.Fatal("incopmlete write")
+	}
 }
 
-// TestSimpleDownloadFailsRetrySucceeds tests that when a simple download's GET
+var (
+	content = []byte("object data")
+)
+
+// TestGetURLDownloadFailsRetrySucceeds tests that when a getUrl download's GET
 // fails with a 500 HTTP status code, and then succeeds, that no error is
 // returned and the correct object data is returned.
-func TestSimpleDownloadFailsRetrySucceeds(t *testing.T) {
-	srv, r, object := mockObjectServer(t)
+func TestGetURLDownloadFailsRetrySucceeds(t *testing.T) {
+	srv, r, object, mockobject := mockObjectServer(t)
 	defer srv.Close()
 
-	th := testHandler{}
-	r.Handle("/simple", &th).Methods("GET")
+	th := testHandler{t: t, failures: 1, content: content}
+	r.Handle("/s3/obj/some/object", &th).Methods("GET")
 
 	_, err := object.CreateUpload("some/object", &tcobject.CreateUploadRequest{})
 	assert.NoError(t, err)
-	err = object.FinishUpload("some/object", &tcobject.FinishUploadRequest{})
+	contentHashesMap := map[string]string{
+		"sha256": "05c98fa0c442debfec682dc25eb255911264c2f3b0c671c218730da7890ed940",
+		"sha512": "87ebe61a26c4a8da246bf965f8d5d1a65f01391f85c2851340d23283ce1db970e2e69e7c328e5604b2e78a2d0be647e72b87e7337d70918d0cb1f65cc81a8987",
+	}
+	contentHashes, err := json.Marshal(contentHashesMap)
+	require.NoError(t, err)
+	err = object.FinishUpload("some/object", &tcobject.FinishUploadRequest{Hashes: contentHashes})
 	assert.NoError(t, err)
-	_, _, _, err = object.DownloadToBuf("some/object")
+	buf, contentType, contentLength, err := object.DownloadToBuf("some/object")
 
+	require.NoError(t, err)
+	assert.Equal(t, content, buf)
+	assert.Equal(t, "text/plain", contentType)
+	assert.Equal(t, int64(len(content)), contentLength)
+
+	// response from StartDownload expires immediately, so this will have called
+	// StartDownload twice
+	assert.Less(t, 1, mockobject.StartDownloadCount())
+}
+
+// TestGetURLSuccessIdentityEncoding tests a getUrl download with an identity
+// encoding.
+func TestGetURLSuccessIdentityEncoding(t *testing.T) {
+	srv, r, object, _ := mockObjectServer(t)
+	defer srv.Close()
+
+	content := []byte("some object data")
+	th := testHandler{t: t, gzipped: false, content: content}
+	r.Handle("/s3/obj/some/object", &th).Methods("GET")
+
+	_, err := object.CreateUpload("some/object", &tcobject.CreateUploadRequest{})
 	assert.NoError(t, err)
+	contentHashesMap := map[string]string{
+		"sha256": "b763426fc2acc4490490247a756a3fe1c4748f8558cbefa65a5ecf7315b2dee6",
+		"sha512": "871eb1e5d438061e164727fec9d68617e32921ffad4756ca493ad31cba2e967a2415a015bf1995a3d355e1f3c098e29cc87b978a2b43484fa27a22e142b2c277",
+	}
+	contentHashes, err := json.Marshal(contentHashesMap)
+	require.NoError(t, err)
+	err = object.FinishUpload("some/object", &tcobject.FinishUploadRequest{Hashes: contentHashes})
+	assert.NoError(t, err)
+	buf, contentType, contentLength, err := object.DownloadToBuf("some/object")
+
+	require.NoError(t, err)
+	assert.Equal(t, content, buf)
+	assert.Equal(t, "text/plain", contentType)
+	assert.Equal(t, int64(len(content)), contentLength)
+}
+
+// TestGetURLSuccessGzipEncoding tests a getUrl download with a gzip encoding.
+func TestGetURLSuccessGzipEncoding(t *testing.T) {
+	srv, r, object, _ := mockObjectServer(t)
+	defer srv.Close()
+
+	content := []byte("some object data")
+	th := testHandler{t: t, gzipped: true, content: content}
+	r.Handle("/s3/obj/some/object", &th).Methods("GET")
+
+	_, err := object.CreateUpload("some/object", &tcobject.CreateUploadRequest{})
+	assert.NoError(t, err)
+	contentHashesMap := map[string]string{
+		"sha256": "b763426fc2acc4490490247a756a3fe1c4748f8558cbefa65a5ecf7315b2dee6",
+		"sha512": "871eb1e5d438061e164727fec9d68617e32921ffad4756ca493ad31cba2e967a2415a015bf1995a3d355e1f3c098e29cc87b978a2b43484fa27a22e142b2c277",
+	}
+	contentHashes, err := json.Marshal(contentHashesMap)
+	require.NoError(t, err)
+	err = object.FinishUpload("some/object", &tcobject.FinishUploadRequest{Hashes: contentHashes})
+	assert.NoError(t, err)
+	buf, contentType, contentLength, err := object.DownloadToBuf("some/object")
+
+	require.NoError(t, err)
+	assert.Equal(t, content, buf)
+	assert.Equal(t, "text/plain", contentType)
+	assert.Equal(t, int64(len(content)), contentLength)
+}
+
+// TestGetURLNoHashes verifies that when an object has no hashes of acceptable algos,
+// the download fails.
+func TestGetURLNoHashes(t *testing.T) {
+	srv, r, object, _ := mockObjectServer(t)
+	defer srv.Close()
+
+	content := []byte("some object data")
+	th := testHandler{t: t, gzipped: false, content: content}
+	r.Handle("/s3/obj/some/object", &th).Methods("GET")
+
+	_, err := object.CreateUpload("some/object", &tcobject.CreateUploadRequest{})
+	assert.NoError(t, err)
+	contentHashesMap := map[string]string{
+		"md5": "not-acceptable",
+	}
+	contentHashes, err := json.Marshal(contentHashesMap)
+	require.NoError(t, err)
+	err = object.FinishUpload("some/object", &tcobject.FinishUploadRequest{Hashes: contentHashes})
+	assert.NoError(t, err)
+
+	_, _, _, err = object.DownloadToBuf("some/object")
+	assert.Error(t, err)
+}
+
+// TestGetURLBadHash verifies that when an object's hash does not match that in the service,
+// the download fails.
+func TestGetURLBadHash(t *testing.T) {
+	srv, r, object, _ := mockObjectServer(t)
+	defer srv.Close()
+
+	content := []byte("some object data")
+	th := testHandler{t: t, gzipped: false, content: content}
+	r.Handle("/s3/obj/some/object", &th).Methods("GET")
+
+	_, err := object.CreateUpload("some/object", &tcobject.CreateUploadRequest{})
+	assert.NoError(t, err)
+	contentHashesMap := map[string]string{
+		"sha256": "9999999999999999999999999999999999999999999999999999999999999999",
+		"sha512": "87ebe61a26c4a8da246bf965f8d5d1a65f01391f85c2851340d23283ce1db970e2e69e7c328e5604b2e78a2d0be647e72b87e7337d70918d0cb1f65cc81a8987",
+	}
+	contentHashes, err := json.Marshal(contentHashesMap)
+	require.NoError(t, err)
+	err = object.FinishUpload("some/object", &tcobject.FinishUploadRequest{Hashes: contentHashes})
+	assert.NoError(t, err)
+
+	_, _, _, err = object.DownloadToBuf("some/object")
+	assert.Error(t, err)
 }

--- a/clients/client-go/tcqueue/download_test.go
+++ b/clients/client-go/tcqueue/download_test.go
@@ -117,8 +117,10 @@ func TestDownloadObjectArtifactToBuf(t *testing.T) {
 	taskId := slugid.Nice()
 
 	m.queueService.FakeObjectArtifact(taskId, "0", "some/thing.txt", "text/plain")
-	m.objectService.FakeObject(fmt.Sprintf("t/%s/0/some/thing.txt", taskId))
-	m.s3.FakeObject(fmt.Sprintf("t/%s/0/some/thing.txt", taskId), "text/plain", []byte("hello, world"))
+	m.objectService.FakeObject(fmt.Sprintf("t/%s/0/some/thing.txt", taskId), map[string]string{
+		"sha256": "09ca7e4eaa6e8ae9c7d261167129184883644d07dfba7cbfbc4c8a2e08360d5b",
+	})
+	m.s3.FakeObject(fmt.Sprintf("obj/t/%s/0/some/thing.txt", taskId), "text/plain", []byte("hello, world"))
 
 	buf, contentType, contentLength, err := m.queue.DownloadArtifactToBuf(taskId, 0, "some/thing.txt")
 	require.NoError(t, err)

--- a/clients/client-py/setup.py
+++ b/clients/client-py/setup.py
@@ -19,7 +19,6 @@ tests_require = [
     'hypothesis',
     'tox',
     'coverage',
-    'python-dateutil',
     'aiofiles',
     'httptest',
 ]
@@ -29,6 +28,7 @@ tests_require = [
 install_requires = [
     'requests>=2.4.3',
     'mohawk>=0.3.4',
+    'python-dateutil>=2.8.2',
     'slugid>=2',
     'taskcluster-urls>=12.1.0',
     'aiohttp>=3.7.4',

--- a/clients/client-py/taskcluster/aio/download.py
+++ b/clients/client-py/taskcluster/aio/download.py
@@ -16,12 +16,20 @@ common cases.
 """
 import aiohttp
 import contextlib
+import datetime
+import hashlib
+
+from dateutil.parser import parse as dateparse
 
 from .asyncutils import ensureCoro
 from .reader_writer import streamingCopy, BufferWriter, FileWriter
 from .retry import retry
 from . import Object
-from ..exceptions import TaskclusterArtifactError, TaskclusterFailure
+from ..exceptions import TaskclusterArtifactError, TaskclusterFailure, ObjectHashVerificationError
+
+# The subset of hashes supported by HashingWriter which are "accepted" as per
+# the object service's schemas.
+ACCEPTABLE_HASHES = set(['sha256', 'sha512'])
 
 
 async def downloadToBuf(**kwargs):
@@ -67,22 +75,58 @@ async def download(*, name, maxRetries=5, objectService, writerFactory):
     async with aiohttp.ClientSession() as session:
         downloadResp = await ensureCoro(objectService.startDownload)(name, {
             "acceptDownloadMethods": {
-                "simple": True,
+                "getUrl": True,
             },
         })
 
         method = downloadResp["method"]
 
-        if method == "simple":
-            async def tryDownload(retryFor):
-                with _maybeRetryHttpRequest(retryFor):
-                    writer = await writerFactory()
-                    url = downloadResp['url']
-                    return await _doSimpleDownload(url, writer, session)
-
-            return await retry(maxRetries, tryDownload)
+        if method == "getUrl":
+            return await _getUrlDownload(name, downloadResp, objectService, writerFactory, session, maxRetries)
         else:
             raise RuntimeError(f'Unknown download method {method}')
+
+
+async def _getUrlDownload(name, downloadResp, objectService, writerFactory, session, maxRetries):
+    """
+    Implementation of the getUrl download method.
+    """
+    downloadRespUsed = False
+
+    async def tryDownload(retryFor):
+        nonlocal downloadResp
+        nonlocal downloadRespUsed
+
+        with _maybeRetryHttpRequest(retryFor):
+            writer = HashingWriter(await writerFactory())
+
+            # if the downloadResp has been used at least once and has now expired,
+            # get a new one before proceeding
+            if downloadRespUsed and dateparse(downloadResp["expires"]) < datetime.datetime.utcnow():
+                downloadResp = await ensureCoro(objectService.startDownload)(name, {
+                    "acceptDownloadMethods": {
+                        "getUrl": True,
+                    },
+                })
+                downloadRespUsed = False
+
+            downloadRespUsed = True
+            async with session.get(downloadResp["url"]) as resp:
+                contentType = resp.content_type
+                resp.raise_for_status()
+                # note that `resp.content` is a StreamReader and satisfies the
+                # requirements of a reader in this case
+                await streamingCopy(resp.content, writer)
+
+            # having completed the download, verify the hashes.  Note that a
+            # hash verification failure is not retried.
+            observedHashes = writer.hashes()
+            expectedHashes = downloadResp["hashes"]
+            verifyHashes(observedHashes, expectedHashes)
+
+            return contentType
+
+    return await retry(maxRetries, tryDownload)
 
 
 async def downloadArtifactToBuf(**kwargs):
@@ -132,13 +176,7 @@ async def downloadArtifact(*, taskId, name, runId=None, maxRetries=5, queueServi
 
     if artifact["storageType"] == 's3' or artifact["storageType"] == 'reference':
         async with aiohttp.ClientSession() as session:
-
-            async def tryDownload(retryFor):
-                with _maybeRetryHttpRequest(retryFor):
-                    writer = await writerFactory()
-                    return await _doSimpleDownload(artifact["url"], writer, session)
-
-            return await retry(maxRetries, tryDownload)
+            return await _s3Download(artifact["url"], writerFactory, session, maxRetries)
 
     elif artifact["storageType"] == 'object':
         objectService = Object({
@@ -159,6 +197,26 @@ async def downloadArtifact(*, taskId, name, runId=None, maxRetries=5, queueServi
         raise TaskclusterFailure(f"Unknown storageType f{artifact['storageType']}")
 
 
+async def _s3Download(url, writerFactory, session, maxRetries):
+    """
+    Perform a download from the given S3 URL, including retrying.
+    """
+    async def tryDownload(retryFor):
+        with _maybeRetryHttpRequest(retryFor):
+            writer = await writerFactory()
+
+            async with session.get(url) as resp:
+                contentType = resp.content_type
+                resp.raise_for_status()
+                # note that `resp.content` is a StreamReader and satisfies the
+                # requirements of a reader in this case
+                await streamingCopy(resp.content, writer)
+
+            return contentType
+
+    return await retry(maxRetries, tryDownload)
+
+
 @contextlib.contextmanager
 def _maybeRetryHttpRequest(retryFor):
     "Catch errors from an aiohttp request and retry the retriable responses."
@@ -175,12 +233,43 @@ def _maybeRetryHttpRequest(retryFor):
     # .. anything else is considered fatal
 
 
-async def _doSimpleDownload(url, writer, session):
-    async with session.get(url) as resp:
-        contentType = resp.content_type
-        resp.raise_for_status()
-        # note that `resp.content` is a StreamReader and satisfies the
-        # requirements of a reader in this case
-        await streamingCopy(resp.content, writer)
+def verifyHashes(observed, expected):
+    """Verify that the hashes observed on the data stream match those provided
+    by the object API, where present, and that at least one acceptable
+    algorithm is present."""
+    someValidAcceptableHash = False
 
-    return contentType
+    for algo, oh in observed.items():
+        if algo in expected:
+            eh = expected[algo]
+            if oh != eh:
+                raise ObjectHashVerificationError(f"Validation of object data's {algo} hash failed")
+            if algo in ACCEPTABLE_HASHES:
+                someValidAcceptableHash = True
+
+    if not someValidAcceptableHash:
+        raise ObjectHashVerificationError("No acceptable hashes found in object metadata")
+
+
+class HashingWriter:
+    """A Writer implementation that hashes contents as they are written."""
+
+    def __init__(self, inner):
+        self.inner = inner
+        self.sha256 = hashlib.sha256()
+        self.sha512 = hashlib.sha512()
+
+    async def write(self, chunk):
+        await self.inner.write(chunk)
+        self.update(chunk)
+
+    def update(self, chunk):
+        self.sha256.update(chunk)
+        self.sha512.update(chunk)
+
+    def hashes(self):
+        """Return the hashes in a format like that used in he object API."""
+        return {
+            "sha256": self.sha256.hexdigest(),
+            "sha512": self.sha512.hexdigest(),
+        }

--- a/clients/client-py/taskcluster/exceptions.py
+++ b/clients/client-py/taskcluster/exceptions.py
@@ -41,3 +41,8 @@ class TaskclusterArtifactError(TaskclusterFailure):
     def __init__(self, message, reason):
         TaskclusterFailure.__init__(self, message)
         self.reason = reason
+
+
+class ObjectHashVerificationError(TaskclusterFailure):
+    """Raised when the downloading an object that does not match its hashes."""
+    pass

--- a/clients/client-rust/Cargo.lock
+++ b/clients/client-rust/Cargo.lock
@@ -1068,18 +1068,18 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.148"
+version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e53f64bb4ba0191d6d0676e1b141ca55047d83b74f5607e6d8eb88126c52c2dc"
+checksum = "256b9932320c590e707b94576e3cc1f7c9024d0ee6612dfbcf1cb106cbe8e055"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.148"
+version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a55492425aa53521babf6137309e7d34c20bbfbbfcfe2c7f3a047fd1f6b92c0c"
+checksum = "b4eae9b04cbffdfd550eb462ed33bc6a1b68c935127d008b27444d08380f94e4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1197,7 +1197,9 @@ dependencies = [
  "futures-util",
  "httptest",
  "reqwest",
+ "serde",
  "serde_json",
+ "sha2",
  "taskcluster",
  "tempfile",
  "tokio",

--- a/clients/client-rust/download/Cargo.toml
+++ b/clients/client-rust/download/Cargo.toml
@@ -13,9 +13,11 @@ anyhow = "1.0"
 async-trait = "0.1"
 reqwest = { version = "0.11", features = ["json", "stream", "gzip", "brotli"] }
 serde_json = "1.0.48"
+serde = "1.0.149"
 tokio = { version = "1.2", features = ["macros", "time", "fs"] }
 tokio-util = { version = "0.7.2", features = ["codec", "io"] }
 futures-util = "0.3"
+sha2 = "0.10.2"
 
 [dev-dependencies]
 httptest = "0.15.3"

--- a/clients/client-rust/download/src/hashing.rs
+++ b/clients/client-rust/download/src/hashing.rs
@@ -1,0 +1,119 @@
+use super::factory::AsyncWriterFactory;
+use anyhow::Result;
+use sha2::{Digest, Sha256, Sha512};
+use std::collections::HashMap;
+use std::pin::Pin;
+use std::sync::{Arc, Mutex};
+use std::task::{Context, Poll};
+use tokio::io::AsyncWrite;
+
+/// A hasher reader factory wraps an AsyncWriterFactory in such a way that it will capture hashes of
+/// the content, making those hashes available once at least one complete read-through of the data
+/// is complete.
+pub(super) struct HasherAsyncWriterFactory<'f, AWF: AsyncWriterFactory> {
+    /// the underlying writer factory
+    writer_factory: &'f mut AWF,
+
+    /// the latest hasher, created in the last `writer_factory` call.
+    latest_hasher: Option<Arc<Hasher>>,
+}
+
+impl<'f, AWF: AsyncWriterFactory> HasherAsyncWriterFactory<'f, AWF> {
+    pub(super) fn new(writer_factory: &'f mut AWF) -> Self {
+        Self {
+            writer_factory,
+            latest_hasher: None,
+        }
+    }
+
+    pub(super) async fn get_writer<'a>(&'a mut self) -> Result<Box<dyn AsyncWrite + Unpin + 'a>> {
+        let writer = self.writer_factory.get_writer().await?;
+        let hasher = Arc::new(Hasher::new());
+        self.latest_hasher = Some(hasher.clone());
+
+        Ok(Box::new(HashingAsyncWrite {
+            inner: writer,
+            hasher,
+        }))
+    }
+
+    /// Get the hashes determined from the latest writer.
+    ///
+    /// ## Panics
+    ///
+    /// This function should only be called after a successful upload from a writer.  It will panic
+    /// if called without first calling `get_writer`.
+    pub(super) fn hashes(&self) -> HashMap<String, String> {
+        let hasher = self
+            .latest_hasher
+            .as_ref()
+            .expect("no previous calls to get_writer");
+        hasher.hashes()
+    }
+}
+
+/// A hasher hashes data and makes the results available as a HashMap
+struct Hasher(Mutex<HasherInner>);
+
+struct HasherInner {
+    sha256: Sha256,
+    sha512: Sha512,
+}
+
+impl Hasher {
+    fn new() -> Self {
+        Self(Mutex::new(HasherInner {
+            sha256: Sha256::new(),
+            sha512: Sha512::new(),
+        }))
+    }
+
+    fn update(&self, buf: &[u8]) {
+        let mut inner = self.0.lock().unwrap();
+        inner.sha256.update(buf);
+        inner.sha512.update(buf);
+    }
+
+    fn hashes(&self) -> HashMap<String, String> {
+        let mut inner = self.0.lock().unwrap();
+
+        let mut result = HashMap::new();
+        result.insert(
+            "sha256".into(),
+            format!("{:x}", inner.sha256.finalize_reset()),
+        );
+        result.insert(
+            "sha512".into(),
+            format!("{:x}", inner.sha512.finalize_reset()),
+        );
+        result
+    }
+}
+
+/// Wraper for an AsyncWrite that will also call a hasher with every chunk written
+struct HashingAsyncWrite<AW: AsyncWrite + Unpin> {
+    inner: AW,
+    hasher: Arc<Hasher>,
+}
+
+impl<AW: AsyncWrite + Unpin> AsyncWrite for HashingAsyncWrite<AW> {
+    fn poll_write(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<std::io::Result<usize>> {
+        let res = Pin::new(&mut self.inner).poll_write(cx, buf);
+        if let Poll::Ready(Ok(size)) = res {
+            // update the hashes with the bytes successfully written
+            self.hasher.update(&buf[..size]);
+        }
+        res
+    }
+
+    fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
+        Pin::new(&mut self.inner).poll_flush(cx)
+    }
+    fn poll_shutdown(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
+        Pin::new(&mut self.inner).poll_shutdown(cx)
+    }
+}

--- a/clients/client-rust/download/src/lib.rs
+++ b/clients/client-rust/download/src/lib.rs
@@ -35,6 +35,7 @@ Users for whom the supplied convenience functions are inadequate can add their o
 mod artifact;
 mod factory;
 mod geturl;
+mod hashing;
 mod object;
 mod service;
 

--- a/clients/client-rust/download/src/object.rs
+++ b/clients/client-rust/download/src/object.rs
@@ -1,11 +1,18 @@
 use crate::factory::{AsyncWriterFactory, CursorWriterFactory, FileWriterFactory};
-use crate::geturl::{get_url, RetriableResult};
+use crate::geturl::{get_url, FetchMetadata, RetriableResult};
+use crate::hashing::HasherAsyncWriterFactory;
 use crate::service::ObjectService;
-use anyhow::{anyhow, Context, Result};
+use anyhow::{anyhow, bail, Context, Result};
 use serde_json::json;
+use std::collections::HashMap;
+use taskcluster::chrono::{DateTime, Utc};
 use taskcluster::retry::{Backoff, Retry};
 use taskcluster::Object;
 use tokio::fs::File;
+
+/// The subset of hashes supported by hashing{read,write}stream which are
+/// "accepted" as per the object service's schemas.
+const ACCEPTABLE_HASHES: &'static [&'static str] = &["sha256", "sha512"];
 
 /// Download an object to a [Vec<u8>] and return that.  If the object is unexpectedly
 /// large, this may exhaust system memory and panic.  Returns (data, content_type)
@@ -75,35 +82,72 @@ pub(crate) async fn download_impl<O: ObjectService, AWF: AsyncWriterFactory>(
             name,
             &json!({
                 "acceptDownloadMethods": {
-                    "simple": true,
+                    "getUrl": true,
                 },
             }),
         )
         .await?;
 
-    // assume the response is a simple download, as that's the only current option
-    let content_type = simple_download(&response, retry, writer_factory).await?;
-    Ok(content_type)
+    let method = response
+        .get("method")
+        .map(|o| o.as_str())
+        .flatten()
+        .ok_or_else(|| anyhow!("invalid response from startDownload"))?;
+
+    match method {
+        "getUrl" => {
+            Ok(geturl_download(response, name, object_service, retry, writer_factory).await?)
+        }
+        _ => bail!("unknown method {} in response from startDownload", method),
+    }
 }
 
-async fn simple_download<AWF: AsyncWriterFactory>(
-    start_download_response: &serde_json::Value,
+async fn geturl_download<O: ObjectService, AWF: AsyncWriterFactory>(
+    mut response_json: serde_json::Value,
+    name: &str,
+    object_service: &O,
     retry: &Retry,
     writer_factory: &mut AWF,
 ) -> Result<String> {
-    // simple method is simple!
-    let url = start_download_response
-        .get("url")
-        .and_then(|v| v.as_str())
-        .ok_or_else(|| anyhow!("invalid simple download response"))?;
+    // tracking for whether the URL in start_download_response has been used
+    // at least once, to avoid looping infinitely.
+    let mut response_used = false;
+    #[derive(serde::Deserialize)]
+    struct GetUrlStartDownloadResponse {
+        url: String,
+        hashes: HashMap<String, String>,
+        expires: DateTime<Utc>,
+    }
+
+    let mut start_download_response: GetUrlStartDownloadResponse =
+        serde_json::from_value(response_json)?;
+
+    // wrap the given writer factory with one that will hash
+    let mut writer_factory = HasherAsyncWriterFactory::new(writer_factory);
 
     let mut backoff = Backoff::new(retry);
     let mut attempts = 0;
 
-    loop {
+    let fetchmeta = loop {
+        if response_used && start_download_response.expires <= Utc::now() {
+            response_json = object_service
+                .startDownload(
+                    name,
+                    &json!({
+                        "acceptDownloadMethods": {
+                            "getUrl": true,
+                        },
+                    }),
+                )
+                .await?;
+            start_download_response = serde_json::from_value(response_json)?;
+        }
+
+        response_used = true;
         attempts += 1;
-        match get_url(url, writer_factory).await {
-            RetriableResult::Ok(content_type) => return Ok(content_type),
+        let mut writer = writer_factory.get_writer().await?;
+        match get_url(start_download_response.url.as_ref(), writer.as_mut()).await {
+            RetriableResult::Ok(fetchmeta) => break Ok::<FetchMetadata, anyhow::Error>(fetchmeta),
             RetriableResult::Retriable(err) => match backoff.next_backoff() {
                 Some(duration) => {
                     tokio::time::sleep(duration).await;
@@ -117,7 +161,40 @@ async fn simple_download<AWF: AsyncWriterFactory>(
                 return Err(err);
             }
         }
+    }?;
+
+    // Verify the hashes after a successful download.  Note that verification failure will
+    // not result in a retry.
+    verify_hashes(start_download_response.hashes, writer_factory.hashes())?;
+
+    Ok(fetchmeta.content_type)
+}
+
+/// Validate that the observed hashes match the expected hashes: all hashes with known algorithms
+/// present in both maps are valid, and at least one "accepted" hash algorithm is present.
+///
+/// If the validation fails, this returns an appropriate error.
+fn verify_hashes(
+    exp_hashes: HashMap<String, String>,
+    observed_hashes: HashMap<String, String>,
+) -> Result<()> {
+    let mut some_valid_acceptable_hash = false;
+
+    for (alg, ov) in &observed_hashes {
+        if let Some(ev) = exp_hashes.get(alg) {
+            if ov != ev {
+                bail!("Object hashes for {} differ", alg);
+            }
+            if ACCEPTABLE_HASHES.iter().any(|acc_alg| alg == acc_alg) {
+                some_valid_acceptable_hash = true;
+            }
+        }
     }
+
+    if !some_valid_acceptable_hash {
+        bail!("No acceptable hashes found in object metadata");
+    }
+    Ok(())
 }
 
 #[cfg(test)]
@@ -126,18 +203,23 @@ mod test {
     use crate::test_helpers::{FakeDataServer, FakeObjectService, Logger};
     use serde_json::json;
     use std::io::SeekFrom;
+    use taskcluster::chrono::{Duration, Utc};
     use tempfile::tempfile;
     use tokio::io::{AsyncReadExt, AsyncSeekExt};
 
     #[tokio::test]
-    async fn simple_download() -> Result<()> {
+    async fn download_success() -> Result<()> {
         let server = FakeDataServer::new(false, &[200]);
         let logger = Logger::default();
         let object_service = FakeObjectService {
             logger: logger.clone(),
             response: json!({
-                "method": "simple",
+                "method": "getUrl",
                 "url": server.data_url(),
+                "hashes": {
+                    "sha256":"09ca7e4eaa6e8ae9c7d261167129184883644d07dfba7cbfbc4c8a2e08360d5b",
+                },
+                "expires": Utc::now() + Duration::hours(2),
             }),
         };
 
@@ -152,7 +234,7 @@ mod test {
 
         logger.assert(vec![format!(
             "startDownload some/object {}",
-            json!({"simple": true})
+            json!({"getUrl": true})
         )]);
 
         assert_eq!(&content_type, "text/plain");
@@ -166,14 +248,18 @@ mod test {
     }
 
     #[tokio::test]
-    async fn simple_download_with_retries_for_500s_success() -> Result<()> {
+    async fn download_with_retries_for_500s_success() -> Result<()> {
         let server = FakeDataServer::new(false, &[500, 500, 200]);
         let logger = Logger::default();
         let object_service = FakeObjectService {
             logger: logger.clone(),
             response: json!({
-                "method": "simple",
+                "method": "getUrl",
                 "url": server.data_url(),
+                "hashes": {
+                    "sha256":"09ca7e4eaa6e8ae9c7d261167129184883644d07dfba7cbfbc4c8a2e08360d5b",
+                },
+                "expires": Utc::now() + Duration::hours(2),
             }),
         };
         let retry = Retry {
@@ -186,7 +272,7 @@ mod test {
 
         logger.assert(vec![format!(
             "startDownload some/object {}",
-            json!({"simple": true})
+            json!({"getUrl": true})
         )]);
 
         let data = factory.into_inner();
@@ -198,14 +284,16 @@ mod test {
     }
 
     #[tokio::test]
-    async fn simple_download_with_failure_for_400s() -> Result<()> {
+    async fn download_with_failure_for_400s() -> Result<()> {
         let server = FakeDataServer::new(false, &[400, 200]);
         let logger = Logger::default();
         let object_service = FakeObjectService {
             logger: logger.clone(),
             response: json!({
-                "method": "simple",
+                "method": "getUrl",
                 "url": server.data_url(),
+                "hashes": {},
+                "expires": Utc::now() + Duration::hours(2),
             }),
         };
         let retry = Retry::default();
@@ -219,7 +307,7 @@ mod test {
 
         logger.assert(vec![format!(
             "startDownload some/object {}",
-            json!({"simple": true})
+            json!({"getUrl": true})
         )]);
 
         let data = factory.into_inner();
@@ -231,14 +319,16 @@ mod test {
     }
 
     #[tokio::test]
-    async fn simple_download_with_retries_for_500s_failure() -> Result<()> {
+    async fn download_with_retries_for_500s_failure() -> Result<()> {
         let server = FakeDataServer::new(false, &[500, 500, 500, 200]);
         let logger = Logger::default();
         let object_service = FakeObjectService {
             logger: logger.clone(),
             response: json!({
-                "method": "simple",
+                "method": "getUrl",
                 "url": server.data_url(),
+                "hashes": {},
+                "expires": Utc::now() + Duration::hours(2),
             }),
         };
         let retry = Retry {
@@ -255,7 +345,7 @@ mod test {
 
         logger.assert(vec![format!(
             "startDownload some/object {}",
-            json!({"simple": true})
+            json!({"getUrl": true})
         )]);
 
         let data = factory.into_inner();
@@ -267,14 +357,57 @@ mod test {
     }
 
     #[tokio::test]
-    async fn simple_download_to_file() -> Result<()> {
+    async fn download_calls_start_download_when_expired() -> Result<()> {
+        let server = FakeDataServer::new(false, &[500, 200]);
+        let logger = Logger::default();
+        let object_service = FakeObjectService {
+            logger: logger.clone(),
+            response: json!({
+                "method": "getUrl",
+                "url": server.data_url(),
+                "hashes": {},
+                "expires": Utc::now(), // download_impl will try the url once
+            }),
+        };
+        let retry = Retry {
+            retries: 2, // but, need 3 to succeed!
+            ..Retry::default()
+        };
+
+        let mut factory = CursorWriterFactory::new();
+        assert!(
+            download_impl("some/object", &retry, &object_service, &mut factory)
+                .await
+                .is_err()
+        );
+
+        logger.assert(vec![
+            // calls startDownload twice
+            format!("startDownload some/object {}", json!({"getUrl": true})),
+            format!("startDownload some/object {}", json!({"getUrl": true})),
+        ]);
+
+        let data = factory.into_inner();
+        assert_eq!(&data, b"hello, world");
+
+        drop(object_service);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn download_to_file() -> Result<()> {
         let server = FakeDataServer::new(false, &[200]);
         let logger = Logger::default();
         let object_service = FakeObjectService {
             logger: logger.clone(),
             response: json!({
-                "method": "simple",
+                "method": "getUrl",
                 "url": server.data_url(),
+                "hashes": {
+                    "sha256":"09ca7e4eaa6e8ae9c7d261167129184883644d07dfba7cbfbc4c8a2e08360d5b",
+                },
+                "expires": Utc::now() + Duration::hours(2),
             }),
         };
 
@@ -289,7 +422,7 @@ mod test {
 
         logger.assert(vec![format!(
             "startDownload some/object {}",
-            json!({"simple": true})
+            json!({"getUrl": true})
         )]);
 
         let mut file = factory.into_inner().await?;
@@ -301,5 +434,48 @@ mod test {
         drop(object_service); // ..and with it, server, which refs data
 
         Ok(())
+    }
+
+    macro_rules! strmap {
+		($( $key:literal : $val:expr ),*) => {
+			{
+				let mut m: HashMap::<String, String> = HashMap::new();
+				$(
+				m.insert($key.into(), $val.into());
+				)*
+				m
+			}
+		};
+		($( $key:literal : $val:expr ),* ,) => {
+            strmap!($( $key : $val ,)*)
+        };
+	}
+
+    #[test]
+    fn verify_hashes_valid() {
+        assert!(verify_hashes(
+            strmap!("sha256": "abc", "sha512": "def", "md5": "ignored"),
+            strmap!("sha256": "abc", "sha512": "def", "sha1024": "ignored")
+        )
+        .is_ok());
+    }
+
+    #[test]
+    fn verify_hashes_not_acceptable() {
+        assert!(verify_hashes(strmap!("md5": "abc"), strmap!("md5": "abc")).is_err());
+    }
+
+    #[test]
+    fn verify_hashes_not_matching() {
+        assert!(verify_hashes(strmap!("sha512": "abc"), strmap!("sha512": "def")).is_err());
+    }
+
+    #[test]
+    fn verify_hashes_not_acceptable_not_matching() {
+        assert!(verify_hashes(
+            strmap!("md5": "good", "sha512": "abc"),
+            strmap!("md5": "good", "sha512": "def")
+        )
+        .is_err());
     }
 }

--- a/clients/client-rust/download/src/test_helpers.rs
+++ b/clients/client-rust/download/src/test_helpers.rs
@@ -46,7 +46,7 @@ impl Logger {
     }
 }
 
-/// Fake implementation of the Object service, that supports the simple method
+/// Fake implementation of the Object service, that supports the getUrl method
 pub(crate) struct FakeObjectService {
     pub(crate) logger: Logger,
     pub(crate) response: Value,

--- a/clients/client/src/download.js
+++ b/clients/client/src/download.js
@@ -2,8 +2,17 @@ const got = require('got');
 const util = require('util');
 const pipeline = util.promisify(require('stream').pipeline);
 const retry = require('./retry');
+const { HashStream, ACCEPTABLE_HASHES } = require('./hashstream');
 
-const simple = async ({ url, streamFactory, retryCfg }) => {
+// apply default retry config
+const makeRetryCfg = ({ retries, delayFactor, randomizationFactor, maxDelay }) => ({
+  retries: retries === undefined ? 5 : retries,
+  delayFactor: delayFactor === undefined ? 100 : delayFactor,
+  randomizationFactor: randomizationFactor === undefined ? randomizationFactor : 0.25,
+  maxDelay: maxDelay === undefined ? 30 * 1000 : maxDelay,
+});
+
+const s3 = async ({ url, streamFactory, retryCfg }) => {
   return await retry(retryCfg, async (retriableError, attempt) => {
     let contentType = 'application/binary';
     try {
@@ -24,25 +33,82 @@ const simple = async ({ url, streamFactory, retryCfg }) => {
   });
 };
 
-// apply default retry config
-const makeRetryCfg = ({ retries, delayFactor, randomizationFactor, maxDelay }) => ({
-  retries: retries === undefined ? 5 : retries,
-  delayFactor: delayFactor === undefined ? 100 : delayFactor,
-  randomizationFactor: randomizationFactor === undefined ? randomizationFactor : 0.25,
-  maxDelay: maxDelay === undefined ? 30 * 1000 : maxDelay,
-});
+const getUrl = async ({ object, name, resp, streamFactory, retryCfg }) => {
+  let responseUsed = false;
+  let hashStream;
+  let contentType = 'application/binary';
+
+  await retry(retryCfg, async (retriableError, attempt) => {
+    // renew the download URL if necessary (note that we assume the object-sevice
+    // credentials are good for long enough)
+    if (responseUsed && new Date(resp.expires) < new Date()) {
+      resp = await object.startDownload(name, { acceptDownloadMethods: { getUrl: true } });
+      responseUsed = false;
+    }
+
+    try {
+      responseUsed = true;
+      const src = got.stream(resp.url, { retry: false });
+      src.on('response', res => {
+        contentType = res.headers['content-type'] || contentType;
+      });
+      const dest = await streamFactory();
+      hashStream = new HashStream();
+      await pipeline(src, hashStream, dest);
+
+      return;
+    } catch (err) {
+      // treat non-500 HTTP responses as fatal errors, and retry everything else
+      if (err instanceof got.HTTPError && err.response.statusCode < 500) {
+        throw err;
+      }
+      return retriableError(err);
+    }
+  });
+
+  // now that the download is complete, check the hashes.  Note that a hash
+  // verification failure does not result in a retry.
+  const observedHashes = hashStream.hashes();
+  verifyHashes(observedHashes, resp.hashes);
+
+  return contentType;
+};
+
+// verify that all known hashes match, and that at least one of them is an
+// "acceptable" hash algorithm.  Throws an exception on verification failure.
+const verifyHashes = (observedHashes, expectedHashes) => {
+  let someValidAcceptableHash = false;
+  for (let algo of Object.keys(expectedHashes)) {
+    const computed = observedHashes[algo];
+    if (!computed) {
+      // ignore unknown hash algorithms
+      continue;
+    }
+    if (computed !== expectedHashes[algo]) {
+      throw new Error(`Computed ${algo} hash does not match that from object service`);
+    }
+
+    if (ACCEPTABLE_HASHES.has(algo)) {
+      someValidAcceptableHash = true;
+    }
+  }
+
+  if (!someValidAcceptableHash) {
+    throw new Error("No acceptable hash algorithm found");
+  }
+};
 
 const download = async ({ name, object, streamFactory, retries, delayFactor, randomizationFactor, maxDelay }) => {
   const retryCfg = makeRetryCfg({ retries, delayFactor, randomizationFactor, maxDelay });
 
   const acceptDownloadMethods = {
-    simple: true,
+    getUrl: true,
   };
 
-  const download = await object.startDownload(name, { acceptDownloadMethods });
+  const resp = await object.startDownload(name, { acceptDownloadMethods });
 
-  if (download.method === 'simple') {
-    return await simple({ url: download.url, streamFactory, retryCfg });
+  if (resp.method === 'getUrl') {
+    return await getUrl({ object, name, resp, streamFactory, retryCfg });
   } else {
     throw new Error("Could not negotiate a download method");
   }
@@ -58,8 +124,7 @@ const downloadArtifact = async ({
   switch (artifact.storageType) {
     case "reference":
     case "s3": {
-      // downloading these artifact types is identical to a simple download
-      return await simple({ url: artifact.url, streamFactory, retryCfg });
+      return await s3({ url: artifact.url, streamFactory, retryCfg });
     }
 
     case "object": {

--- a/clients/client/src/hashstream.js
+++ b/clients/client/src/hashstream.js
@@ -1,0 +1,39 @@
+const { Transform } = require('stream');
+const { createHash } = require('crypto');
+
+// The subset of hashes supported by HashStream which are "accepted" as per the
+// object service's schemas.
+const ACCEPTABLE_HASHES = new Set(["sha256", "sha512"]);
+
+/**
+ * A stream that hashes the bytes passing through it
+ */
+class HashStream extends Transform {
+  constructor() {
+    super();
+    this.sha256 = createHash('sha256');
+    this.sha512 = createHash('sha512');
+    this.bytes = 0;
+  }
+
+  _transform(chunk, enc, cb) {
+    this.sha256.update(chunk);
+    this.sha512.update(chunk);
+    this.bytes += chunk.length;
+    cb(null, chunk);
+  }
+
+  // Return the calculated hashes in a format suitable for finishUpload,
+  // checking that the content length matches the bytes hashed, if given.
+  hashes(contentLength) {
+    if (contentLength !== undefined && contentLength !== this.bytes) {
+      throw new Error(`Hashed ${this.bytes} bytes but content length is ${contentLength}`);
+    }
+    return {
+      sha256: this.sha256.digest('hex'),
+      sha512: this.sha512.digest('hex'),
+    };
+  }
+}
+
+module.exports = { HashStream, ACCEPTABLE_HASHES };

--- a/internal/mocktc/object.go
+++ b/internal/mocktc/object.go
@@ -16,6 +16,8 @@ type (
 		// map from name to object
 		objects map[string]Obj
 		baseURL string
+		// startDownloadCount is the number of
+		startDownloadCount int
 	}
 	Obj struct {
 		uploadRequest  *tcobject.CreateUploadRequest
@@ -23,15 +25,17 @@ type (
 		// if true, then assume this object is on mocks3; otherwise, serve
 		// simple downloads from <baseUrl>/simple
 		onMockS3 bool
+		hashes   map[string]string
 	}
 )
 
 /////////////////////////////////////////////////
 
 func (object *Object) CreateUpload(name string, payload *tcobject.CreateUploadRequest) (*tcobject.CreateUploadResponse, error) {
-	object.objects[name] = Obj{
+	o := Obj{
 		uploadRequest: payload,
 	}
+
 	um := tcobject.SelectedUploadMethodOrNone{}
 	if payload.ProposedUploadMethods.DataInline.ContentType != "" {
 		um.DataInline = true
@@ -39,9 +43,22 @@ func (object *Object) CreateUpload(name string, payload *tcobject.CreateUploadRe
 		um.PutURL = tcobject.PutURLUploadResponse{
 			Expires: tcclient.Time(time.Now().Add(1 * time.Hour)),
 			Headers: map[string]string{"header1": "value1"},
-			URL:     object.baseURL + "/upload",
+			// return a URL pointing to the mockS3 server
+			URL: fmt.Sprintf("%s/s3/obj/%s", object.baseURL, name),
 		}
 	}
+
+	if payload.Hashes != nil {
+		err := json.Unmarshal(payload.Hashes, &o.hashes)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		o.hashes = map[string]string{}
+	}
+
+	object.objects[name] = o
+
 	return &tcobject.CreateUploadResponse{
 		Expires:      payload.Expires,
 		ProjectID:    payload.ProjectID,
@@ -56,14 +73,31 @@ func (object *Object) FinishUpload(name string, payload *tcobject.FinishUploadRe
 		return fmt.Errorf("Cannot finish upload for %v (not found)", name)
 	}
 	o.uploadFinished = true
+
+	if payload.Hashes != nil {
+		var newHashes map[string]string
+		err := json.Unmarshal(payload.Hashes, &newHashes)
+		if err != nil {
+			return err
+		}
+
+		for k, v := range newHashes {
+			o.hashes[k] = v
+		}
+	}
+
 	return nil
 }
 
 func (object *Object) StartDownload(name string, payload *tcobject.DownloadObjectRequest) (*tcobject.DownloadObjectResponse, error) {
+	object.startDownloadCount++
 	o, exists := object.objects[name]
 	if !exists {
 		return nil, fmt.Errorf("Cannot start download for upload ID %v (not found)", name)
 	}
+
+	hashesJson, _ := json.Marshal(o.hashes)
+
 	var err error
 	var dor tcobject.DownloadObjectResponse
 	var resp interface{}
@@ -72,13 +106,22 @@ func (object *Object) StartDownload(name string, payload *tcobject.DownloadObjec
 		if o.onMockS3 {
 			resp = tcobject.SimpleDownloadResponse{
 				Method: "simple",
-				URL:    fmt.Sprintf("%s/s3/%s", object.baseURL, name),
+				// return a URL pointing to the mockS3 server
+				URL: fmt.Sprintf("%s/s3/%s", object.baseURL, name),
 			}
 		} else {
 			resp = tcobject.SimpleDownloadResponse{
 				Method: "simple",
 				URL:    object.baseURL + "/simple",
 			}
+		}
+	case payload.AcceptDownloadMethods.GetURL:
+		resp = tcobject.GetURLDownloadResponse{
+			Method: "getUrl",
+			// return a URL pointing to the mockS3 server
+			URL:     fmt.Sprintf("%s/s3/obj/%s", object.baseURL, name),
+			Expires: tcclient.Time(time.Now()), // expires immediately, resulting in multiple calls (expected)
+			Hashes:  hashesJson,
 		}
 	}
 	dor, err = json.Marshal(resp)
@@ -99,12 +142,18 @@ func (object *Object) UploadFromFile(projectID string, name string, contentType 
 // FakeS3Object creates a fake object which is assumed to be stored in mocks3
 // at an object of the same name.  It is up to the caller to create the object
 // in mocks3 if necesary.
-func (object *Object) FakeObject(name string) {
+func (object *Object) FakeObject(name string, hashes map[string]string) {
 	object.objects[name] = Obj{
 		uploadRequest:  &tcobject.CreateUploadRequest{},
 		uploadFinished: true,
 		onMockS3:       true,
+		hashes:         hashes,
 	}
+}
+
+// StartDownloadCount returns the number of times StartDownload has been called
+func (object *Object) StartDownloadCount() int {
+	return object.startDownloadCount
 }
 
 /////////////////////////////////////////////////


### PR DESCRIPTION
In fact, the clients no longer use simple downloads, meaning that all downloads performed via a client will verify hashes on the downloaded content.

Github Bug/Issue: Fixes #4624
