### PR TITLE
github: Return correct status code for the latest status

### DIFF
--- a/changelog/issue-5851.md
+++ b/changelog/issue-5851.md
@@ -1,0 +1,6 @@
+audience: general
+level: patch
+reference: issue 5851
+---
+
+Fix incorrect status reported by github service for unknown branches.

--- a/services/github/src/api.js
+++ b/services/github/src/api.js
@@ -156,7 +156,8 @@ async function findTCStatus(github, owner, repo, branch, configuration) {
   try {
     statuses = (await github.repos.listCommitStatusesForRef({ owner, repo, ref: branch })).data;
   } catch (e) {
-    if (e.code === 404) {
+    // github sends 422 when branch doesn't exist
+    if (e.code === 404 || e.code === 422) {
       return undefined;
     }
     throw e;
@@ -614,10 +615,9 @@ builder.declare({
       let run = checkRuns.sort((a, b) => a.id - b.id)[0];
       return res.redirect(run.html_url);
     }
-
-    // Otherwise there is no status available for the given branch.
-    return res.reportError('ResourceNotFound', 'Status not found', {});
   }
+
+  return res.reportError('ResourceNotFound', 'Status not found', {});
 });
 
 builder.declare({

--- a/services/github/test/api_test.js
+++ b/services/github/test/api_test.js
@@ -507,6 +507,22 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
     });
   });
 
+  test('link for clickable badges when no branch exists', async function() {
+    await testing.fakeauth.withAnonymousScopes(['github:latest-status:abc123:*'], async () => {
+      await assert.rejects(() => got(
+        helper.apiClient.buildUrl(helper.apiClient.latest, 'abc123', 'checksRepo', 'noSuchBranch'),
+        { followRedirect: false }), err => err.response.statusCode === 404);
+    });
+  });
+
+  test('link for clickable badges when no installation exists', async function() {
+    await testing.fakeauth.withAnonymousScopes(['github:latest-status:noSuchOwner:*'], async () => {
+      await assert.rejects(() => got(
+        helper.apiClient.buildUrl(helper.apiClient.latest, 'noSuchOwner', 'noSuchRepo', 'noSuchBranch'),
+        { followRedirect: false }), err => err.response.statusCode === 404);
+    });
+  });
+
   test('latest link without scopes', async function() {
     const client = new helper.GithubClient({ rootUrl: helper.rootUrl });
     await assert.rejects(
@@ -549,7 +565,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
     assert.equal(status.context, 'customContext');
   });
 
-  test('status creation where integraiton lacks permission', async function() {
+  test('status creation where integration lacks permission', async function() {
     try {
       await helper.apiClient.createStatus('abc123', 'no-permission', 'master', {
         state: 'failure',


### PR DESCRIPTION
This fixes scenario when check run was not found for a given branch or installation didn't exist.

Fixes #5851 
