### PR TITLE
chore(ci): use updated worker pools

### DIFF
--- a/changelog/QE-LV6FARYKtvKcdj7tmFQ.md
+++ b/changelog/QE-LV6FARYKtvKcdj7tmFQ.md
@@ -1,0 +1,4 @@
+audience: developers
+level: patch
+---
+This patch switches running CI tasks on generic-worker-windows2012r2 worker pool to the new, windows 2022 worker pool.

--- a/changelog/fJpkNU2fTIC0nHl0LxjIRg.md
+++ b/changelog/fJpkNU2fTIC0nHl0LxjIRg.md
@@ -1,0 +1,4 @@
+audience: general
+level: patch
+---
+Use updated gw-ci-macos-10-14 worker pool.

--- a/taskcluster/ci/config.yml
+++ b/taskcluster/ci/config.yml
@@ -31,8 +31,8 @@ workers:
       os: linux
       implementation: generic-worker
       worker-type: gw-ci-ubuntu-22-04
-    gw-ci-windows2012r2-amd64:
+    gw-ci-windows-2022:
       provisioner: proj-taskcluster
       os: windows
       implementation: generic-worker
-      worker-type: gw-ci-windows2012r2-amd64
+      worker-type: gw-ci-windows-2022

--- a/taskcluster/ci/generic-worker/kind.yml
+++ b/taskcluster/ci/generic-worker/kind.yml
@@ -16,7 +16,7 @@ task-defaults:
 tasks:
   windows-worker-runner:
     description: 'test worker-runner under windows as well'
-    worker-type: gw-ci-windows2012r2-amd64
+    worker-type: gw-ci-windows-2022
     worker:
       mounts:
         - content:

--- a/workers/generic-worker/gw-decision-task/tasks.yml
+++ b/workers/generic-worker/gw-decision-task/tasks.yml
@@ -46,11 +46,11 @@ Types:
 
 Tasks:
   BuildAndTest:
-    - WorkerPool: 'proj-taskcluster/gw-ci-macos'
+    - WorkerPool: 'proj-taskcluster/gw-ci-macos-10-14'
       Env:
         ENGINE: 'multiuser'
 # disabled due to lack of mac capacity
-#    - WorkerPool: 'proj-taskcluster/gw-ci-macos'
+#    - WorkerPool: 'proj-taskcluster/gw-ci-macos-10-14'
 #      Env:
 #        ENGINE: 'simple'
     - WorkerPool: 'proj-taskcluster/gw-ci-ubuntu-22-04'
@@ -96,7 +96,7 @@ Tasks:
     - WorkerPool: 'proj-taskcluster/gw-ci-ubuntu-22-04'
 
 WorkerPools:
-  proj-taskcluster/gw-ci-macos:
+  proj-taskcluster/gw-ci-macos-10-14:
     Platform: 'macOS Mojave 10.14'
     OS: 'darwin'
     Arch: 'amd64'

--- a/workers/generic-worker/gw-decision-task/tasks.yml
+++ b/workers/generic-worker/gw-decision-task/tasks.yml
@@ -62,7 +62,7 @@ Tasks:
     - WorkerPool: 'proj-taskcluster/gw-ci-ubuntu-22-04'
       Env:
         ENGINE: 'docker'
-    - WorkerPool: 'proj-taskcluster/gw-ci-windows2012r2-amd64'
+    - WorkerPool: 'proj-taskcluster/gw-ci-windows-2022'
       Env:
         ENGINE: 'multiuser'
         # We must set here since this worker type does not have a Z: drive
@@ -122,8 +122,8 @@ WorkerPools:
     # There is no arm release for go 1.19.4 on windows, but 386 release works
     # through emulation provided by the host OS.
     Arch: '386'
-  proj-taskcluster/gw-ci-windows2012r2-amd64:
-    Platform: 'Windows Server 2012 R2 (amd64)'
+  proj-taskcluster/gw-ci-windows-2022:
+    Platform: 'Windows Server 2022 (amd64)'
     OS: 'windows'
     Arch: 'amd64'
   proj-taskcluster/gw-ci-windows7-386:


### PR DESCRIPTION
> This patch switches running CI tasks on generic-worker-windows2012r2 worker pool to the new, windows 2022 worker pool.

> Use updated gw-ci-macos-10-14 worker pool.