### PR TITLE
feat(cli): build taskcluster cli with goreleaser

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -79,3 +79,6 @@ __pycache__
 # docker-compose artifacts
 /docker/buckets
 docker-compose.override.yml
+
+dist/
+.DS_Store

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,89 @@
+builds:
+  - main: ./clients/client-shell
+    id: taskcluster
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - darwin
+      - linux
+      - windows
+    goarch:
+      - amd64
+      - arm64
+
+archives:
+  - id: taskcluster
+
+    # Archive name template.
+    name_template: "taskcluster-{{ .Os }}-{{ .Arch }}"
+
+    # Can be used to change the archive formats for specific GOOSs.
+    # Most common use case is to archive as zip on Windows.
+    # Default is empty.
+    format_overrides:
+      - goos: windows
+        format: zip
+
+    files:
+      - none*
+
+release:
+  # You can disable this pipe in order to not create the release on any SCM.
+  # Keep in mind that this might also break things that depend on the release
+  # URL, for instance, homebrew taps.
+  #
+  # Defaults to false.
+  disable: true
+
+changelog:
+  # Set this to true if you don't want any changelog at all.
+  # Warning: this will also ignore any changelog files passed via `--release-notes`,
+  # and will render an empty changelog.
+  # This may result in an empty release notes on GitHub/GitLab/Gitea.
+  skip: true
+
+checksum:
+  # Disable the generation/upload of the checksum file.
+  # Default is false.
+  disable: true
+
+brews:
+  - name: taskcluster
+
+    tap:
+      owner: taskcluster
+      name: homebrew-tap
+
+      # Optionally a token can be provided, if it differs from the token
+      # provided to GoReleaser
+      token: "{{ .Env.GH_TOKEN }}"
+
+    # Allows you to set a custom download strategy. Note that you'll need
+    # to implement the strategy and add it to your tap repository.
+    # Example: https://docs.brew.sh/Formula-Cookbook#specifying-the-download-strategy-explicitly
+    # Default is empty.
+    download_strategy: CurlDownloadStrategy
+
+    # The project name and current git tag are used in the format string.
+    commit_msg_template: "Brew formula update for taskcluster version {{ .Tag }}"
+
+    # Folder inside the repository to put the formula.
+    # Default is the root folder.
+    folder: Formula
+
+    # Your app's homepage.
+    # Default is empty.
+    homepage: "https://github.com/taskcluster/taskcluster/tree/main/clients/client-shell"
+
+    # Template of your app's description.
+    # Default is empty.
+    description: "A Taskcluster client library for the command line"
+
+    # SPDX identifier of your app's license.
+    # Default is empty.
+    license: "MPL-2.0"
+
+    # So you can `brew test` your formula.
+    # Default is empty.
+    test: |
+      system "#{bin}/taskcluster version"

--- a/changelog/FtfvrZ_XTgiXV-Dh-U0BEg.md
+++ b/changelog/FtfvrZ_XTgiXV-Dh-U0BEg.md
@@ -1,0 +1,10 @@
+audience: developers
+level: patch
+---
+This patch makes it so the taskcluster shell client (cli) is built with `goreleaser`.
+
+`goreleaser` also will automatically keep our [homebrew-tap](https://github.com/taskcluster/homebrew-tap/blob/main/Formula/taskcluster.rb) formula up-to-date during the release process.
+
+GitHub releases will now also contain zipped Windows executables of this cli supporting both amd64 and arm64. arm64 binaries for linux have been added as well.
+
+The darwin and linux binaries are now tarballs.

--- a/infrastructure/tooling/src/build/tasks/client-shell.js
+++ b/infrastructure/tooling/src/build/tasks/client-shell.js
@@ -18,13 +18,21 @@ module.exports = ({ tasks, cmdOptions, credentials, baseDir, logsDir }) => {
         utils,
       });
 
+      let goreleaserCmd = [
+        'goreleaser',
+        'release',
+        '--rm-dist',
+      ];
+
+      if (cmdOptions.staging || !cmdOptions.push) {
+        // --snapshot will generate an unversioned snapshot release,
+        // skipping all validations and without publishing any artifacts
+        goreleaserCmd = goreleaserCmd.push('--snapshot');
+      }
+
       await execCommand({
         dir: REPO_ROOT,
-        command: [
-          'goreleaser',
-          'release',
-          '--rm-dist',
-        ],
+        command: goreleaserCmd,
         utils,
       });
 


### PR DESCRIPTION
This fixes https://github.com/taskcluster/homebrew-tap/issues/2.

> This patch makes it so the taskcluster shell client (cli) is built with `goreleaser`.
>
> `goreleaser` also will automatically keep our [homebrew-tap](https://github.com/taskcluster/homebrew-tap/blob/main/Formula/taskcluster.rb) formula up-to-date during the release process.
>
> GitHub releases will now also contain zipped Windows executables of this cli supporting both amd64 and arm64. arm64 binaries for linux have been added as well.
>
> The darwin and linux binaries are now tarballs.

Followed https://goreleaser.com/customization/homebrew/ as well as many of their other docs.

This tool is incredibly powerful. We can use it to publish to chocolatey and snap, for example. I think all of our go builds could be migrated over to this. It handles archiving and also can create a checksum file for each file.