### PR TITLE
dependabot: remove docker worker config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -42,12 +42,6 @@ updates:
     schedule:
       interval: "monthly"
 
-  # Maintain node dependencies for docker-worker
-  - package-ecosystem: "npm"
-    directory: "/workers/docker-worker"
-    schedule:
-      interval: "monthly"
-
   # Maintain go dependencies
   - package-ecosystem: "gomod"
     directory: "/"

--- a/changelog/dyG9QgtwTLevqu-z-B4BfA.md
+++ b/changelog/dyG9QgtwTLevqu-z-B4BfA.md
@@ -1,0 +1,3 @@
+audience: general
+level: silent
+---


### PR DESCRIPTION
No longer monitor deps for docker worker.