### PR TITLE
fix(changelog): don't require changelog on dep upgrades

### DIFF
--- a/changelog/P0y1fNy1QyGmCr69tnBdyA.md
+++ b/changelog/P0y1fNy1QyGmCr69tnBdyA.md
@@ -1,0 +1,3 @@
+audience: general
+level: silent
+---

--- a/infrastructure/tooling/src/changelog/index.js
+++ b/infrastructure/tooling/src/changelog/index.js
@@ -245,6 +245,8 @@ const check_pr = async (pr) => {
   const boringFiles = [
     /yarn\.lock$/,
     /package\.json$/,
+    /requirements\.txt$/,
+    /Cargo\.(lock|toml)$/,
     /^go\.(mod|sum)$/,
     /^\.yarn$/,
     /^README.md$/,


### PR DESCRIPTION
This will fix it so that `meta-changelog-pr` tasks in `client-rust` and `taskgraph` dependency upgrades won't fail like they are in https://github.com/taskcluster/taskcluster/pull/5904 and https://github.com/taskcluster/taskcluster/pull/5908.