### PR TITLE
fix(cloudbuild): add `--ignore-scripts` flag to yarn install to skip preinstall

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ COPY /ui/yarn.lock /.yarnrc /ui/package.json /base/yarn-ui/
 COPY /.yarn /base/yarn-ui/.yarn/
 
 WORKDIR /base/yarn
-RUN yarn install --production --frozen-lockfile
+RUN yarn install --production --frozen-lockfile --ignore-scripts
 WORKDIR /base/yarn-ui
 RUN yarn install --frozen-lockfile
 

--- a/changelog/VmYrW6fORn-_YIdldfu4gA.md
+++ b/changelog/VmYrW6fORn-_YIdldfu4gA.md
@@ -1,0 +1,3 @@
+audience: general
+level: silent
+---


### PR DESCRIPTION
Cloudbuild starting [failing](https://github.com/taskcluster/taskcluster/runs/10259231223) after https://github.com/taskcluster/taskcluster/pull/5920 landed.

Adding in [this flag](https://classic.yarnpkg.com/en/docs/cli/install#yarn-install---ignore-scripts-) will skip the new, `preinstall` script.

Example of it running with and without the flag:

```bash
➜  taskcluster git:(main) yarn                 
yarn install v1.22.19
$ cd clients/client && yarn --frozen-lockfile
yarn install v1.22.19
[1/5] 🔍  Validating package.json...
[2/5] 🔍  Resolving packages...
success Already up-to-date.
✨  Done in 0.06s.
[1/5] 🔍  Validating package.json...
[2/5] 🔍  Resolving packages...
[3/5] 🚚  Fetching packages...
[4/5] 🔗  Linking dependencies...
[5/5] 🔨  Building fresh packages...

✨  Done in 1.92s.
➜  taskcluster git:(main) yarn --ignore-scripts
yarn install v1.22.19
[1/5] 🔍  Validating package.json...
[2/5] 🔍  Resolving packages...
[3/5] 🚚  Fetching packages...
[4/5] 🔗  Linking dependencies...
[5/5] 🔨  Building fresh packages...
warning Ignored scripts due to flag.
✨  Done in 1.31s.
```