### PR TITLE
Lint all the generic-worker engines, not just multiuser

### DIFF
--- a/changelog/Rm385PxBThimb_W5zJt3ag.md
+++ b/changelog/Rm385PxBThimb_W5zJt3ag.md
@@ -1,0 +1,3 @@
+audience: general
+level: silent
+---

--- a/test/go-lint.sh
+++ b/test/go-lint.sh
@@ -10,3 +10,5 @@ fi
 
 echo "Running golangci-lint.."
 golangci-lint run --build-tags multiuser
+golangci-lint run --build-tags simple
+golangci-lint run --build-tags docker


### PR DESCRIPTION
Simple update to lint tests to make sure all generic-worker engines are linted, not just multiuser engine.