### PR TITLE
Improve monoimage by removing unnecessary files and fixing RUN commands

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,18 +1,46 @@
+# build specific
 **/node_modules
 .eslintcache
+**/.coverage
+**/coverage.report
+__pycache__
+
 **.log
-.idea
 **/user-config.yml
-dev-config.yml
-artifacts
 **/.nyc_output
+
+# IDE stuff
+.idea
+.vscode
+
+# top level files that should not be inside the container
+cloudbuild.yaml
+docker-compose*.yml
+netlify.toml
+generic-worker.Dockerfile
+dev-config.yml
+
+# top level folders that are not needed
+# docker files specific to local development
+docker
+# dev docs
+dev-docs
+# ci config
+taskcluster
+test
+artifacts
+
 clients/client-rust/target
+
 ui/build
-temp
+dist
+
+# generic worker artifacts
 workers/generic-worker/generic-worker-*
 workers/generic-worker/generic-worker
 workers/generic-worker/testdata/Test*
 tools/worker-runner/start-worker
 tools/worker-runner/start-worker-*-*
 tools/taskcluster-proxy/taskcluster-proxy
+tools/taskcluster-proxy/target
 tools/livelog/livelog

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,21 +6,31 @@ FROM node:16.19.0 as build
 RUN mkdir -p /base/cache
 ENV YARN_CACHE_FOLDER=/base/cache
 
+# prepare top level dependencies
 RUN mkdir -p /base/yarn
 COPY /yarn.lock /.yarnrc /package.json /base/yarn/
 COPY /.yarn /base/yarn/.yarn/
+# prepare ui dependencies
 RUN mkdir -p /base/yarn-ui
 COPY /ui/yarn.lock /.yarnrc /ui/package.json /base/yarn-ui/
 COPY /.yarn /base/yarn-ui/.yarn/
+# prepare clients/client dependencies
+RUN mkdir -p /base/yarn-client
+COPY /clients/client/yarn.lock /.yarnrc /clients/client/package.json /base/yarn-client/
+COPY /.yarn /base/yarn-client/.yarn/
 
+# install all dependencies
+WORKDIR /base/yarn-client
+RUN yarn install --production --frozen-lockfile
 WORKDIR /base/yarn
 RUN yarn install --production --frozen-lockfile
 WORKDIR /base/yarn-ui
 RUN yarn install --frozen-lockfile
 
-RUN mkdir -p /base/app/ui
+RUN mkdir -p /base/app/ui /base/app/clients/client
 RUN cp -r /base/yarn/node_modules /base/app/
 RUN cp -r /base/yarn-ui/node_modules /base/app/ui/
+RUN cp -r /base/yarn-client/node_modules /base/app/clients/client/
 
 # copy the repository into the image, including the entrypoint
 WORKDIR /base/app
@@ -41,12 +51,12 @@ RUN yarn build
 WORKDIR /base/app
 
 # clean up some unnecessary and potentially large stuff
-RUN rm -rf .git
-RUN rm -rf .node-gyp ui/.node-gyp
-RUN rm -rf clients/client-{go,py,web}
-RUN rm -rf {services,libraries}/*/test
-RUN rm -rf db/test db/versions
-RUN rm -rf ui/node_modules ui/src
+RUN /bin/bash -c "\
+    rm -rf clients/client-{go,py,web}; \
+    rm -rf {services,libraries}/*/test; \
+    rm -rf db/test db/versions; \
+    rm -rf ui/node_modules ui/src ui/test; \
+    "
 
 ##
 # build the final image

--- a/changelog/P7Ks2AE_SSGiOju6vezbzg.md
+++ b/changelog/P7Ks2AE_SSGiOju6vezbzg.md
@@ -1,0 +1,5 @@
+audience: developers
+level: patch
+---
+
+Reduce monoimage size by excluding unnecessary files.


### PR DESCRIPTION
* tidy-up `.dockerignore` file to add few more entries that don't belong in resulting monoimage
* install dependencies for `clients/client` to match the expected behavior from other workflows
* fixes issue with `rm -rf` that used bash expansion which doesn't work since RUN doesn't use bash