### PR TITLE
Prevent actions.json from being uploaded to artifacts.

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -198,7 +198,8 @@ tasks:
                         --head-repository='${repoUrl}'
                         --head-ref='${head_ref}'
                         --head-rev='${head_sha}'
-                        --head-tag='${head_tag}'
+                        --head-tag='${head_tag}' &&
+                        rm artifacts/actions.json # taskcluster is not using actions.json
                   artifacts:
                       'public':
                           type: 'directory'

--- a/changelog/issue-4950.md
+++ b/changelog/issue-4950.md
@@ -1,0 +1,6 @@
+audience: developers
+level: patch
+reference: issue 4950
+---
+
+Remove auto-generated `actions.json` which is not properly configured and is not used in this repo.


### PR DESCRIPTION
This file is auto-generated by taskgraph but is not configured and is not used in taskcluster repository. It relies on the hooks that should be created by third-party tools on every change of .taskcluster.yml.


Fixes #4950 