### PR TITLE
 Assume different role for pre-release event.

### DIFF
--- a/changelog/issue-5518.md
+++ b/changelog/issue-5518.md
@@ -1,0 +1,6 @@
+audience: admins
+level: major
+reference: issue 5518
+---
+
+Assumes different role for github pre-release event: `assume:repo:github.com/<owner>/<repo>:release:<action>`, where `action` is one of the [release actions](https://docs.github.com/developers/webhooks-and-events/webhooks/webhook-events-and-payloads?actionType=published#release)

--- a/services/github/src/api.js
+++ b/services/github/src/api.js
@@ -1,7 +1,7 @@
 const crypto = require('crypto');
 const { APIBuilder, paginateResults } = require('taskcluster-lib-api');
 const _ = require('lodash');
-const { EVENT_TYPES, CHECK_RUN_ACTIONS, PUBLISHERS } = require('./constants');
+const { EVENT_TYPES, CHECK_RUN_ACTIONS, PUBLISHERS, GITHUB_TASKS_FOR } = require('./constants');
 const { shouldSkipCommit, shouldSkipPullRequest } = require('./utils');
 
 // Strips/replaces undesirable characters which GitHub allows in
@@ -293,7 +293,7 @@ builder.declare({
         msg.details = getPullRequestDetails(body);
         msg.installationId = installationId;
         publisherKey = PUBLISHERS.PULL_REQUEST;
-        msg.tasks_for = 'github-pull-request';
+        msg.tasks_for = GITHUB_TASKS_FOR.PULL_REQUEST;
         msg.branch = body.pull_request.head.ref;
         break;
 
@@ -309,7 +309,7 @@ builder.declare({
         msg.details = getPushDetails(body);
         msg.installationId = installationId;
         publisherKey = PUBLISHERS.PUSH;
-        msg.tasks_for = 'github-push';
+        msg.tasks_for = GITHUB_TASKS_FOR.PUSH;
         msg.branch = body.ref.split('/').slice(2).join('/');
         break;
 
@@ -321,7 +321,7 @@ builder.declare({
         msg.details = getReleaseDetails(body);
         msg.installationId = installationId;
         publisherKey = PUBLISHERS.RELEASE;
-        msg.tasks_for = 'github-release';
+        msg.tasks_for = GITHUB_TASKS_FOR.RELEASE;
         msg.branch = body.release.target_commitish;
         break;
 
@@ -354,7 +354,7 @@ builder.declare({
         publisherKey = PUBLISHERS.RERUN;
         msg.organization = sanitizeGitHubField(body.repository.owner.login);
         msg.details = getRerunDetails(body);
-        msg.tasks_for = 'github-push';
+        msg.tasks_for = GITHUB_TASKS_FOR.PUSH;
         msg.installationId = installationId;
         msg.checkRunId = body.check_run.id;
         msg.checkSuiteId = body.check_run.check_suite.id;

--- a/services/github/src/constants.js
+++ b/services/github/src/constants.js
@@ -18,6 +18,17 @@ const GITHUB_TASKS_FOR = {
   PULL_REQUEST_UNTRUSTED: 'github-pull-request-untrusted',
 };
 
+// https://docs.github.com/developers/webhooks-and-events/webhooks/webhook-events-and-payloads?actionType=released#release
+const GITHUB_RELEASE_ACTION = {
+  CREATED: 'created',
+  DELETED: 'deleted',
+  EDITED: 'edited',
+  PRERELEASED: 'prereleased',
+  PUBLISHED: 'published',
+  RELEASED: 'released',
+  UNPUBLISHED: 'unpublished',
+};
+
 module.exports = {
   CONCLUSIONS: { // maps status communicated by the queue service to github checkrun conclusions
     'completed': 'success',
@@ -56,6 +67,7 @@ module.exports = {
     RERUN: 'rerun',
   },
   GITHUB_TASKS_FOR,
+  GITHUB_RELEASE_ACTION,
   CHECKLOGS_TEXT: 'View logs in Taskcluster',
   CHECKRUN_TEXT: 'View task in Taskcluster',
   LIVE_BACKING_LOG_ARTIFACT_NAME: 'public/logs/live_backing.log',

--- a/services/github/src/constants.js
+++ b/services/github/src/constants.js
@@ -11,6 +11,13 @@ const TASK_STATE_TO_CHECK_RUN_STATE = {
   completed: CHECK_RUN_STATES.COMPLETED,
 };
 
+const GITHUB_TASKS_FOR = {
+  PUSH: 'github-push',
+  RELEASE: 'github-release',
+  PULL_REQUEST: 'github-pull-request',
+  PULL_REQUEST_UNTRUSTED: 'github-pull-request-untrusted',
+};
+
 module.exports = {
   CONCLUSIONS: { // maps status communicated by the queue service to github checkrun conclusions
     'completed': 'success',
@@ -48,6 +55,7 @@ module.exports = {
     RELEASE: 'release',
     RERUN: 'rerun',
   },
+  GITHUB_TASKS_FOR,
   CHECKLOGS_TEXT: 'View logs in Taskcluster',
   CHECKRUN_TEXT: 'View task in Taskcluster',
   LIVE_BACKING_LOG_ARTIFACT_NAME: 'public/logs/live_backing.log',

--- a/services/github/src/handlers/job.js
+++ b/services/github/src/handlers/job.js
@@ -4,6 +4,7 @@ const libUrls = require('taskcluster-lib-urls');
 const { UNIQUE_VIOLATION } = require('taskcluster-lib-postgres');
 const { makeDebug } = require('./utils');
 const { POLICIES } = require('./policies');
+const { GITHUB_TASKS_FOR } = require('../constants');
 
 /**
  * If a .taskcluster.yml exists, attempt to turn it into a taskcluster
@@ -157,7 +158,7 @@ async function jobHandler(message) {
         debug(`This user is not a collaborator on ${organization}/${repository} and can't make PR@${sha}. Exiting...`);
         return;
       } else if (repoPolicy === POLICIES.PUBLIC_RESTRICTED) {
-        message.payload.tasks_for = "github-pull-request-untrusted";
+        message.payload.tasks_for = GITHUB_TASKS_FOR.PULL_REQUEST_UNTRUSTED;
       }
     }
   }

--- a/services/github/src/tc-yaml.js
+++ b/services/github/src/tc-yaml.js
@@ -49,7 +49,7 @@ class VersionZero extends TcYaml {
       ];
     } else if (payload.details['event.type'] === 'release') {
       config.scopes = [
-        `assume:repo:github.com/${ payload.organization }/${ payload.repository }:release`,
+        `assume:repo:github.com/${ payload.organization }/${ payload.repository }:release:published`,
       ];
     } else if (payload.details['event.type'] === 'tag') {
       let prefix = `assume:repo:github.com/${ payload.organization }/${ payload.repository }:tag:`;
@@ -201,8 +201,10 @@ class VersionOne extends TcYaml {
         ];
       }
     } else if (payload.tasks_for === GITHUB_TASKS_FOR.RELEASE) {
+      // role name would include release action
+      const action = payload?.body?.action || 'published';
       config.scopes = [
-        `assume:repo:github.com/${ payload.organization }/${ payload.repository }:release`,
+        `assume:repo:github.com/${payload.organization}/${payload.repository}:release:${action}`,
       ];
     }
 

--- a/services/github/src/tc-yaml.js
+++ b/services/github/src/tc-yaml.js
@@ -4,6 +4,7 @@ const slugid = require('slugid');
 const jsone = require('json-e');
 const tc = require('taskcluster-client');
 const TopoSort = require('topo-sort');
+const { GITHUB_TASKS_FOR } = require('./constants');
 
 // Assert that only scope-valid characters are in branches
 const branchTest = branch => {
@@ -179,15 +180,15 @@ class VersionOne extends TcYaml {
   createScopes(cfg, config, payload) {
     config.scopes = [];
 
-    if (payload.tasks_for === 'github-pull-request') {
+    if (payload.tasks_for === GITHUB_TASKS_FOR.PULL_REQUEST) {
       config.scopes = [
         `assume:repo:github.com/${ payload.organization }/${ payload.repository }:pull-request`,
       ];
-    } else if (payload.tasks_for === 'github-pull-request-untrusted') {
+    } else if (payload.tasks_for === GITHUB_TASKS_FOR.PULL_REQUEST_UNTRUSTED) {
       config.scopes = [
         `assume:repo:github.com/${ payload.organization }/${ payload.repository }:pull-request-untrusted`,
       ];
-    } else if (payload.tasks_for === 'github-push') {
+    } else if (payload.tasks_for === GITHUB_TASKS_FOR.PUSH) {
       if (payload.body.ref.split('/')[1] === 'tags') {
         let prefix = `assume:repo:github.com/${ payload.organization }/${ payload.repository }:tag:`;
         config.scopes = [
@@ -199,7 +200,7 @@ class VersionOne extends TcYaml {
           prefix + payload.details['event.base.repo.branch'],
         ];
       }
-    } else if (payload.tasks_for === 'github-release') {
+    } else if (payload.tasks_for === GITHUB_TASKS_FOR.RELEASE) {
       config.scopes = [
         `assume:repo:github.com/${ payload.organization }/${ payload.repository }:release`,
       ];

--- a/services/github/test/intree_test.js
+++ b/services/github/test/intree_test.js
@@ -233,7 +233,7 @@ suite(testing.suiteName(), function() {
       'tasks[0].task.extra.github.events': ['release'],
       'metadata.owner': 'test@test.com',
       scopes: [
-        'assume:repo:github.com/testorg/testrepo:release',
+        'assume:repo:github.com/testorg/testrepo:release:published',
         'queue:route:statuses',
         'queue:scheduler-id:tc-gh-devel',
       ],
@@ -249,7 +249,7 @@ suite(testing.suiteName(), function() {
       'tasks[0].task.extra.github.events': ['release'],
       'metadata.owner': 'test@test.com',
       scopes: [
-        'assume:repo:github.com/testorg/testrepo:release',
+        'assume:repo:github.com/testorg/testrepo:release:published',
         'queue:route:statuses',
         'queue:scheduler-id:tc-gh-devel',
       ],
@@ -454,7 +454,7 @@ suite(testing.suiteName(), function() {
       'tasks[0].task.metadata.owner': 'test@test.com',
       'tasks[0].task.metadata.source': 'http://mrrrgn.com',
       scopes: [
-        'assume:repo:github.com/testorg/testrepo:release',
+        'assume:repo:github.com/testorg/testrepo:release:published',
         'queue:route:statuses',
         'queue:scheduler-id:tc-gh-devel',
       ],
@@ -475,7 +475,7 @@ suite(testing.suiteName(), function() {
       'tasks[0].task.metadata.owner': 'test@test.com',
       'tasks[0].task.metadata.source': 'http://mrrrgn.com',
       scopes: [
-        'assume:repo:github.com/testorg/testrepo:release',
+        'assume:repo:github.com/testorg/testrepo:release:published',
         'queue:route:statuses',
         'queue:scheduler-id:tc-gh-devel',
       ],

--- a/services/github/test/tc-yaml_test.js
+++ b/services/github/test/tc-yaml_test.js
@@ -78,7 +78,7 @@ suite(testing.suiteName(), function() {
         details: { 'event.type': 'release' },
       }, now);
       assume(config.scopes.sort()).to.deeply.equal([
-        'assume:repo:github.com/org/repo:release',
+        'assume:repo:github.com/org/repo:release:published',
         'queue:route:statuses-queue',
         'queue:scheduler-id:test-sched',
       ]);
@@ -280,9 +280,30 @@ suite(testing.suiteName(), function() {
           tasks_for: 'github-release',
           organization: 'org',
           repository: 'repo',
+          body: {},
         }, now);
         assume(config.scopes.sort()).to.deeply.equal([
-          'assume:repo:github.com/org/repo:release',
+          'assume:repo:github.com/org/repo:release:published',
+          'queue:route:statuses-queue',
+          'queue:scheduler-id:test-sched',
+        ]);
+      });
+
+      test('compileTasks for a pre-release sets scopes correctly', function() {
+        const config = {
+          tasks: [{}],
+        };
+
+        tcyaml.compileTasks(config, cfg, {
+          tasks_for: 'github-release',
+          body: {
+            action: 'prereleased',
+          },
+          organization: 'org',
+          repository: 'repo',
+        }, now);
+        assume(config.scopes.sort()).to.deeply.equal([
+          'assume:repo:github.com/org/repo:release:prereleased',
           'queue:route:statuses-queue',
           'queue:scheduler-id:test-sched',
         ]);

--- a/ui/docs/reference/integrations/github/taskcluster-yml-v0.mdx
+++ b/ui/docs/reference/integrations/github/taskcluster-yml-v0.mdx
@@ -105,7 +105,7 @@ Pushes, pull requests, and releases all are given access to [scopes](/docs/manua
 
 * `Push` -- `assume:repo:github.com/<organization>/<repository>:branch:<branch>`
 * `Pull Request` -- `assume:repo:github.com/<organization>/<repository>:pull-request`
-* `Release` -- `assume:repo:github.com/<organization>/<repository>:release`
+* `Release` -- `assume:repo:github.com/<organization>/<repository>:release:published`
 * `Tag` -- `assume:repo:github.com/<organization>/<repository>:tag:<tag>`
 
 In the Roles tool (under Authorization), you can set up roles however you like. To give permissions to every event in your repository, you can make a role `repo:github.com/<organization>/<repository>:*` or you can give fine-grained permissions to only releases or specific branches, etc. [Read more](/docs/manual/design/apis/hawk/scopes) about how scopes and roles work to see what you can do.

--- a/ui/docs/reference/integrations/github/taskcluster-yml-v1.mdx
+++ b/ui/docs/reference/integrations/github/taskcluster-yml-v1.mdx
@@ -219,7 +219,7 @@ You need to know which provisioner and which worker type you want to use to run 
 * `assume:repo:github.com/<owner>/<repo>:branch:<branch>` for a push event
 * `assume:repo:github.com/<owner>/<repo>:pull-request` for a pull request
 * `assume:repo:github.com/<owner>/<repo>:rerun` for failed task re-run request
-* `assume:repo:github.com/<owner>/<repo>:release` for a release event
+* `assume:repo:github.com/<owner>/<repo>:release:<action>` for a release event
 * `assume:repo:github.com/<organization>/<repository>:tag:<tag>` for a tag event
 
 In the Roles tool (under Authorization), you can set up roles however you like. To give permissions to every event in your repository, you can make a role `repo:github.com/<organization>/<repository>:*` or you can give fine-grained permissions to specific github events or specific branches.


### PR DESCRIPTION
This adds new variable 'action' for release payload that includes type of the release: [github docs](https://docs.github.com/developers/webhooks-and-events/webhooks/webhook-events-and-payloads?actionType=released#release)

In case of `prereleased` action `<>:pre-release` role would be assumed instead of `<>:release`.

Fixes #5518

This is possibly a breaking change if some repositories relied on different workflows?