### PR TITLE
Exclude .git from dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,3 @@
-.git
-
 # build specific
 **/node_modules
 .eslintcache

--- a/Dockerfile
+++ b/Dockerfile
@@ -52,6 +52,7 @@ WORKDIR /base/app
 
 # clean up some unnecessary and potentially large stuff
 RUN /bin/bash -c "\
+    rm -rf .git; \
     rm -rf clients/client-{go,py,web}; \
     rm -rf {services,libraries}/*/test; \
     rm -rf db/test db/versions; \

--- a/changelog/THAtLb7vRvSlEg4wcg5EWw.md
+++ b/changelog/THAtLb7vRvSlEg4wcg5EWw.md
@@ -1,0 +1,5 @@
+audience: general
+level: patch
+---
+
+Small fix to dockerignore and release process.

--- a/infrastructure/tooling/src/build/tasks/client-shell.js
+++ b/infrastructure/tooling/src/build/tasks/client-shell.js
@@ -27,7 +27,7 @@ module.exports = ({ tasks, cmdOptions, credentials, baseDir, logsDir }) => {
       if (cmdOptions.staging || !cmdOptions.push) {
         // --snapshot will generate an unversioned snapshot release,
         // skipping all validations and without publishing any artifacts
-        goreleaserCmd = goreleaserCmd.push('--snapshot');
+        goreleaserCmd.push('--snapshot');
       }
 
       await execCommand({


### PR DESCRIPTION
Some of the docker images rely on the presence of .git folder during release