### PR TITLE
Remove yarn cache after installing all packages

### DIFF
--- a/changelog/dvL-x41MQkyo1qq8x8VI4g.md
+++ b/changelog/dvL-x41MQkyo1qq8x8VI4g.md
@@ -1,0 +1,3 @@
+audience: general
+level: silent
+---

--- a/infrastructure/tooling/src/build/tasks/monoimage.js
+++ b/infrastructure/tooling/src/build/tasks/monoimage.js
@@ -150,7 +150,7 @@ const generateMonoimageTasks = ({ tasks, baseDir, cmdOptions, credentials, logsD
       await writeRepoFile('temp/devel-image/Dockerfile', [
         `FROM ${requirements['monoimage-docker-image']}`,
         'RUN npm install --global nodemon',
-        'RUN yarn install',
+        'RUN yarn install && yarn cache clean --all',
       ].join('\n'));
 
       try {


### PR DESCRIPTION
yarn used cache folder in /usr/local which stored extra ~500mb of cached deps
