### PR TITLE
Ensure docker worker env var values are strings

### DIFF
--- a/changelog/issue-6014.md
+++ b/changelog/issue-6014.md
@@ -1,0 +1,5 @@
+audience: users
+level: patch
+reference: issue 6014
+---
+Bug fix: docker worker no longer accepts non-strings for env var values in task payloads.

--- a/generated/references.json
+++ b/generated/references.json
@@ -8823,6 +8823,9 @@
           "type": "array"
         },
         "env": {
+          "additionalProperties": {
+            "type": "string"
+          },
           "description": "Example: ```\n{\n  \"PATH\": '/borked/path'\n  \"ENV_NAME\": \"VALUE\"\n}\n```",
           "title": "Environment variable mappings.",
           "type": "object"

--- a/workers/docker-worker/schemas/v1/payload.yml
+++ b/workers/docker-worker/schemas/v1/payload.yml
@@ -148,6 +148,8 @@ properties:
       }
       ```
     type: object
+    additionalProperties:
+      type: string
   maxRunTime:
     type: number
     title: Maximum run time in seconds


### PR DESCRIPTION
Spotted this issue when looking at docker-worker to generic-worker conversion mechanics. I have a nasty feeling I saw this once before, and there was tasks in the wild that were setting env vars to bools or ints unintentionally - I think this is reasonable, and will probably never reach production fxci since we are not intending on deploying updated docker-workers in fxci from now on. If tasks do break though, they should be very easy to fix.

Fixes #6014.