### PR TITLE
Docker worker json schema payload has been tweaked for cleaner go code generation.

### DIFF
--- a/changelog/dPeI-3ufTsq51tIXcflv6A.md
+++ b/changelog/dPeI-3ufTsq51tIXcflv6A.md
@@ -1,0 +1,4 @@
+audience: general
+level: patch
+---
+Docker worker json schema payload has been tweaked for cleaner go code generation. No functional impact anticipated.

--- a/generated/references.json
+++ b/generated/references.json
@@ -8972,12 +8972,12 @@
           "type": "string"
         },
         "maxRunTime": {
-          "description": "Maximum time the task container can run in seconds.  Maximum is one week, as a sanity-check.  A task that takes so long is unlikely to succeed!",
-          "maximum": 604800,
+          "description": "Maximum time the task container can run in seconds.",
+          "maximum": 86400,
           "minimum": 1,
           "multipleOf": 1,
           "title": "Maximum run time in seconds",
-          "type": "number"
+          "type": "integer"
         },
         "onExitStatus": {
           "additionalProperties": false,

--- a/workers/docker-worker/schemas/v1/payload.yml
+++ b/workers/docker-worker/schemas/v1/payload.yml
@@ -153,14 +153,13 @@ properties:
     additionalProperties:
       type: string
   maxRunTime:
-    type: number
+    type: integer
     title: Maximum run time in seconds
-    description: >-
-      Maximum time the task container can run in seconds.  Maximum is one week,
-      as a sanity-check.  A task that takes so long is unlikely to succeed!
+    description: |-
+      Maximum time the task container can run in seconds.
     multipleOf: 1
     minimum: 1
-    maximum: 604800
+    maximum: 86400
   onExitStatus:
     title: Exit status handling
     description: >-

--- a/workers/docker-worker/test/validate_schema_test.js
+++ b/workers/docker-worker/test/validate_schema_test.js
@@ -30,7 +30,7 @@ suite('validate_schema_test.js', function() {
       image: 'abc/def',
       maxRunTime: false,
     }, { expires: new Date() }, schema);
-    assert(payloadErrors.some(e => e.match(/data\/maxRunTime should be number/)));
+    assert(payloadErrors.some(e => e.match(/data\/maxRunTime should be integer/)));
   });
 
   test('validatePayload with artifact expiring after task', function() {


### PR DESCRIPTION
See #6020 for context.

 No functional impact anticipated.

This is useful for the d2g project where docker worker payload is mapped to native go types. The type was changed from `number` to `integer` in the json schema, but since the property `multipleOf` was already set to `1`, it was already effectively validated as an integer, even if the type was "looser".