### PR TITLE
Issue 6021: tighten docker-worker payload to enforce cache is string to string mapping

### DIFF
--- a/changelog/issue-6021.md
+++ b/changelog/issue-6021.md
@@ -1,0 +1,5 @@
+audience: users
+level: patch
+reference: issue 6021
+---
+Docker Worker payload has been tightened to enforce that Docker Worker caches are string to string mappings, rather than string to anything mappings.

--- a/generated/references.json
+++ b/generated/references.json
@@ -8762,6 +8762,9 @@
           "type": "object"
         },
         "cache": {
+          "additionalProperties": {
+            "type": "string"
+          },
           "description": "Caches are mounted within the docker container at the mount point specified. Example: ```{ \"CACHE NAME\": \"/mount/path/in/container\" }```",
           "title": "Caches to mount point mapping.",
           "type": "object"

--- a/workers/docker-worker/schemas/v1/payload.yml
+++ b/workers/docker-worker/schemas/v1/payload.yml
@@ -89,6 +89,8 @@ properties:
       Caches are mounted within the docker container at the mount point
       specified. Example: ```{ "CACHE NAME": "/mount/path/in/container" }```
     type: object
+    additionalProperties:
+      type: string
   capabilities:
     title: Capabilities that must be available/enabled for the task container.
     description: >-


### PR DESCRIPTION
Fixes #6021
