### PR TITLE
Fix for 'unsupported docker v2s2 media type: application/vnd.oci.image.manifest.v1+json'

### DIFF
--- a/changelog/VvP2TgMtQ5Sjk-HEI4gjjg.md
+++ b/changelog/VvP2TgMtQ5Sjk-HEI4gjjg.md
@@ -1,0 +1,3 @@
+audience: general
+level: silent
+---

--- a/workers/generic-worker/process/docker.go
+++ b/workers/generic-worker/process/docker.go
@@ -56,7 +56,12 @@ func (c *Command) Execute() (r *Result) {
 		podmanPath = "/usr/bin/podman"
 		log.Printf("Could not find podman in PATH, defaulting to %v", podmanPath)
 	}
-	image := "ubuntu"
+	// Frozen version specified, since we hit the issue:
+	//  unsupported docker v2s2 media type: "application/vnd.oci.image.manifest.v1+json"
+	// when ubuntu:latest was pointed at ubuntu:jammy-20230126. This is the previous
+	// version, which worked without issue. Note, docker engine is soon to be deprecated
+	// and isn't used anywhere in production, so freezing here should be fine.
+	image := "ubuntu:jammy-20221130"
 
 	// TODO scary injection potential here
 	cmd := exec.CommandContext(c.ctx, podmanPath, append([]string{"run", image}, c.cmd...)...)


### PR DESCRIPTION
This is plaguing our CI at the moment, and all CI runs are currently failing due to this issue. The issue is that generic-worker docker engine was running tasks under `ubuntu:latest` using podman, but since ubuntu:latest was updated 21 hours ago, we are getting the error:

```
unsupported docker v2s2 media type: application/vnd.oci.image.manifest.v1+json
```

The "fix" here is to freeze the ubuntu version to the previous working version. We intend to drop support for the docker engine at some point, or replace it internally with the new d2g translation layer, therefore freezing this version, for something that isn't used in any production system, should be fine.