### PR TITLE
Bugzilla 1753249 task id clickable field

### DIFF
--- a/changelog/issue-1753249.md
+++ b/changelog/issue-1753249.md
@@ -1,0 +1,5 @@
+audience: users
+level: silent
+reference: issue 1753249
+---
+TaskID is now a copyable field on the Task Details page

--- a/ui/.gitignore
+++ b/ui/.gitignore
@@ -13,3 +13,13 @@ src/static/env.js
 coverage
 test/e2e/cypress/screenshots/
 test/e2e/cypress/videos/
+
+
+# yarn package manager
+.yarn/*
+!.yarn/cache
+!.yarn/patches
+!.yarn/plugins
+!.yarn/releases
+!.yarn/sdks
+!.yarn/versions

--- a/ui/.gitignore
+++ b/ui/.gitignore
@@ -13,13 +13,3 @@ src/static/env.js
 coverage
 test/e2e/cypress/screenshots/
 test/e2e/cypress/videos/
-
-
-# yarn package manager
-.yarn/*
-!.yarn/cache
-!.yarn/patches
-!.yarn/plugins
-!.yarn/releases
-!.yarn/sdks
-!.yarn/versions

--- a/ui/src/components/TaskDetailsCard/__snapshots__/index.test.jsx.snap
+++ b/ui/src/components/TaskDetailsCard/__snapshots__/index.test.jsx.snap
@@ -51,6 +51,42 @@ exports[`should render TaskDetailsCard 1`] = `
             class="MuiButtonBase-root MuiListItem-root makeStyles-listItemButtonRoot-24 MuiListItem-gutters MuiListItem-button"
             role="button"
             tabindex="0"
+            title="taskId (Copy)"
+          >
+            <div
+              class="MuiListItemText-root MuiListItemText-multiline"
+            >
+              <span
+                class="MuiTypography-root MuiListItemText-primary MuiTypography-body1 MuiTypography-displayBlock"
+              >
+                Task ID
+              </span>
+              <p
+                class="MuiTypography-root MuiListItemText-secondary MuiTypography-body2 MuiTypography-colorTextSecondary MuiTypography-displayBlock"
+              >
+                taskId
+              </p>
+            </div>
+            <svg
+              class="mdi-icon "
+              fill="currentColor"
+              height="24"
+              viewBox="0 0 24 24"
+              width="24"
+            >
+              <path
+                d="M19,21H8V7H19M19,5H8A2,2 0 0,0 6,7V21A2,2 0 0,0 8,23H19A2,2 0 0,0 21,21V7A2,2 0 0,0 19,5M16,1H4A2,2 0 0,0 2,3V17H4V3H16V1Z"
+              />
+            </svg>
+            <span
+              class="MuiTouchRipple-root"
+            />
+          </div>
+          <div
+            aria-disabled="false"
+            class="MuiButtonBase-root MuiListItem-root makeStyles-listItemButtonRoot-24 MuiListItem-gutters MuiListItem-button"
+            role="button"
+            tabindex="0"
             title="2022-02-15T12:00:00.000Z (Copy)"
           >
             <div

--- a/ui/src/components/TaskDetailsCard/index.jsx
+++ b/ui/src/components/TaskDetailsCard/index.jsx
@@ -160,6 +160,12 @@ export default class TaskDetailsCard extends Component {
                 />
               </ListItem>
               <CopyToClipboardListItem
+                tooltipTitle={task.taskId}
+                textToCopy={task.taskId}
+                primary="Task ID"
+                secondary={task.taskId}
+              />
+              <CopyToClipboardListItem
                 tooltipTitle={task.created}
                 textToCopy={task.created}
                 primary="Created"


### PR DESCRIPTION
Bugzilla Bug: [1753249](https://bugzilla.mozilla.org/show_bug.cgi?id=1753249)

- [x] Makes TaskID a click-to-copy field on the Task Details Page
- [x]  Regenerates Jest snapshot
- [x] Updates the .gitignore for the UI project per [Yarn](https://yarnpkg.com/getting-started/qa#which-files-should-be-gitignored) package manager's recommendation

<img width="492" alt="Screen Shot 2023-02-15 at 10 49 05 PM" src="https://user-images.githubusercontent.com/16469141/219289582-a4d6afb3-daac-42b0-a93a-4b99682ebc12.png">
