### PR TITLE
Document db fn is_task_group_active

### DIFF
--- a/db/fns.md
+++ b/db/fns.md
@@ -1792,7 +1792,13 @@ Return true if the task has remaining un-satisfied dependencies.
 * *Returns*: `boolean`
 * *Last defined on version*: 28
 
-temp, removed in next commit
+Determine whether a task group is currently active.  An "active" task
+group is one with one or more tasks that has never been resolved.
+
+An unsealed, inactive task group can become active if a new task is
+added, so this value may change from tue to false or false to true at any
+time unless a task group is sealed.
+
 
 ### mark_task_ever_resolved
 

--- a/db/versions/0028.yml
+++ b/db/versions/0028.yml
@@ -83,7 +83,13 @@ methods:
         end if;
       end
   is_task_group_active:
-    description: temp, removed in next commit
+    description: |
+      Determine whether a task group is currently active.  An "active" task
+      group is one with one or more tasks that has never been resolved.
+
+      An unsealed, inactive task group can become active if a new task is
+      added, so this value may change from tue to false or false to true at any
+      time unless a task group is sealed.
     mode: read
     serviceName: queue
     args: task_group_id_in text

--- a/generated/db-schema.json
+++ b/generated/db-schema.json
@@ -3587,7 +3587,7 @@
           "args": "task_group_id_in text",
           "body": "begin\n  perform true\n  from tasks\n  where\n    task_group_id = task_group_id_in and\n    not ever_resolved\n  limit 1;\n  return found;\nend",
           "deprecated": false,
-          "description": "temp, removed in next commit",
+          "description": "Determine whether a task group is currently active.  An \"active\" task\ngroup is one with one or more tasks that has never been resolved.\n\nAn unsealed, inactive task group can become active if a new task is\nadded, so this value may change from tue to false or false to true at any\ntime unless a task group is sealed.\n",
           "mode": "read",
           "returns": "boolean",
           "serviceName": "queue"


### PR DESCRIPTION
It looks like this got here through a revert in #3243.