### PR TITLE
Wrap error handling for release checks

### DIFF
--- a/changelog/Kd63czIOSqmtb38S_OmW_g.md
+++ b/changelog/Kd63czIOSqmtb38S_OmW_g.md
@@ -1,0 +1,5 @@
+audience: general
+level: patch
+---
+
+Add error handling for docker image release process.

--- a/infrastructure/tooling/src/build/tasks/monoimage.js
+++ b/infrastructure/tooling/src/build/tasks/monoimage.js
@@ -57,8 +57,14 @@ const generateMonoimageTasks = ({ tasks, baseDir, cmdOptions, credentials, logsD
 
       const imageLocal = (await dockerImages({ baseDir }))
         .some(image => image.RepoTags && image.RepoTags.indexOf(tag) !== -1);
-      const imageOnRegistry = await dockerRegistryCheck({ tag });
-      utils.status({ message: `Image does ${imageOnRegistry ? '' : 'not '} exist on registry` });
+
+      let imageOnRegistry;
+      try {
+        imageOnRegistry = await dockerRegistryCheck({ tag });
+        utils.status({ message: `Image does ${imageOnRegistry ? '' : 'not '} exist on registry` });
+      } catch (err) {
+        utils.status({ message: `Error fetching image on registry: ${err.message}` });
+      }
 
       const provides = {
         'monoimage-docker-image': tag,
@@ -120,7 +126,14 @@ const generateMonoimageTasks = ({ tasks, baseDir, cmdOptions, credentials, logsD
 
       const imageLocal = (await dockerImages({ baseDir }))
         .some(image => image.RepoTags && image.RepoTags.indexOf(tag) !== -1);
-      const imageOnRegistry = await dockerRegistryCheck({ tag });
+
+      let imageOnRegistry;
+      try {
+        imageOnRegistry = await dockerRegistryCheck({ tag });
+        utils.status({ message: `Image does ${imageOnRegistry ? '' : 'not '} exist on registry` });
+      } catch (err) {
+        utils.status({ message: `Error fetching image on registry: ${err.message}` });
+      }
       utils.status({ message: `Image does ${imageOnRegistry ? '' : 'not '} exist on registry` });
 
       const provides = {

--- a/infrastructure/tooling/src/utils/docker.js
+++ b/infrastructure/tooling/src/utils/docker.js
@@ -225,11 +225,12 @@ exports.dockerImages = async ({ baseDir }) => {
  */
 exports.dockerRegistryCheck = async ({ tag }) => {
   const [repo, imagetag] = tag.split(/:/);
+
   try {
     // Access the registry API directly to see if this tag already exists, and do not push if so.
     const res = await got(`https://hub.docker.com/v2/repositories/taskcluster/${repo}/tags`, { responseType: 'json' });
     if (!res.body) {
-      throw new Error('invalid response from index.docker.io');
+      throw new Error('invalid response from hub.docker.com');
     }
     if (res.body.map(l => l.name).includes(imagetag)) {
       return true;


### PR DESCRIPTION
We found during releases that check registry tag failed with 503 for some unknown reason:

```
HTTPError: Response code 503 (Service Unavailable) (while executing task Build Taskcluster Devel Docker Image)
    at Request.<anonymous> (/task_167707000275458/taskcluster/node_modules/got/dist/source/as-promise/index.js:118:42)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5) {
  code: 'ERR_NON_2XX_3XX_RESPONSE',
  timings: {
    start: 1677070518700,
    socket: 1677070518701,
    lookup: 1677070518701,
    connect: 1677070518763,
    secureConnect: 1677070518826,
    upload: 1677070518826,
    response: 1677070518900,
    end: 1677070518901,
    error: undefined,
    abort: undefined,
    phases: {
      wait: 1,
      dns: 0,
      tcp: 62,
      tls: 63,
      request: 0,
      firstByte: 74,
      download: 1,
      total: 201
    }
  }
}
```

This fix does only wrapping. This doesn't fix the root cause, which is still unknown, but allows to continue with releases.
I presume this check was added at the times when releases were done manually, so it is safe to skip in case of random server errors