### PR TITLE
Worker manager considers stoppingCapacity in estimator

### DIFF
--- a/changelog/issue-6067.md
+++ b/changelog/issue-6067.md
@@ -1,0 +1,6 @@
+audience: deployers
+level: patch
+reference: issue 6067
+---
+
+Worker-manager now considers `stoppingCapacity` when estimating the required number of workers to start, preventing failed to start workers from growing beyond `maxCapacity` and slowing down the scanner loop.

--- a/generated/references.json
+++ b/generated/references.json
@@ -13321,13 +13321,14 @@
             "pendingTasks": "The number of tasks the queue reports are pending for this worker pool",
             "requestedCapacity": "Amount of capacity that this estimator thinks we should add",
             "scalingRatio": "The ratio of workers to spawn per pending task for this worker pool.",
+            "stoppingCapacity": "Amount of capacity being stopped",
             "workerPoolId": "The worker pool name"
           },
           "level": "any",
           "name": "simpleEstimate",
           "title": "Simple Estimate Provided",
           "type": "simple-estimate",
-          "version": 3
+          "version": 4
         },
         {
           "description": "A simple timekeeper for measuring arbitrary time spans.",

--- a/services/worker-manager/src/monitor.js
+++ b/services/worker-manager/src/monitor.js
@@ -80,7 +80,7 @@ MonitorManager.register({
   name: 'simpleEstimate',
   title: 'Simple Estimate Provided',
   type: 'simple-estimate',
-  version: 3,
+  version: 4,
   level: 'any',
   description: 'The simple estimator has decided that we need some number of instances.',
   fields: {
@@ -92,6 +92,7 @@ MonitorManager.register({
     existingCapacity: 'Amount of currently requested and available capacity',
     desiredCapacity: 'Amount of capacity that this estimator thinks we should have',
     requestedCapacity: 'Amount of capacity that this estimator thinks we should add',
+    stoppingCapacity: 'Amount of capacity being stopped',
   },
 });
 

--- a/services/worker-manager/test/estimator_test.js
+++ b/services/worker-manager/test/estimator_test.js
@@ -17,6 +17,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
     const workerInfo = {
       existingCapacity: 0,
       requestedCapacity: 0,
+      stoppingCapacity: 0,
     };
     const estimate = await estimator.simple({
       workerPoolId: 'foo/bar',
@@ -35,6 +36,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
     const workerInfo = {
       existingCapacity: 0,
       requestedCapacity: 0,
+      stoppingCapacity: 0,
     };
     const estimate = await estimator.simple({
       workerPoolId: 'foo/bar',
@@ -52,6 +54,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
     const workerInfo = {
       existingCapacity: 0,
       requestedCapacity: 1,
+      stoppingCapacity: 0,
     };
     const estimate = await estimator.simple({
       workerPoolId: 'foo/bar',
@@ -69,6 +72,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
     const workerInfo = {
       existingCapacity: 0,
       requestedCapacity: 0,
+      stoppingCapacity: 0,
     };
     helper.queue.setPending('foo/bar', 100);
     const estimate = await estimator.simple({
@@ -88,6 +92,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
     const workerInfo = {
       existingCapacity: 0,
       requestedCapacity: 0,
+      stoppingCapacity: 0,
     };
     helper.queue.setPending('foo/bar', 100);
     const estimate = await estimator.simple({
@@ -107,6 +112,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
     const workerInfo = {
       existingCapacity: 0,
       requestedCapacity: 0,
+      stoppingCapacity: 0,
     };
     helper.queue.setPending('foo/bar', 100);
     const estimate = await estimator.simple({
@@ -126,6 +132,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
     const workerInfo = {
       existingCapacity: 25,
       requestedCapacity: 0,
+      stoppingCapacity: 0,
     };
     helper.queue.setPending('foo/bar', 100);
     const estimate = await estimator.simple({
@@ -145,6 +152,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
     const workerInfo = {
       existingCapacity: 50,
       requestedCapacity: 0,
+      stoppingCapacity: 0,
     };
     const estimate = await estimator.simple({
       workerPoolId: 'foo/bar',
@@ -169,6 +177,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
     const workerInfo = {
       existingCapacity: 5,
       requestedCapacity: 0,
+      stoppingCapacity: 0,
     };
     const estimate = await estimator.simple({
       workerPoolId: 'foo/bar',
@@ -181,5 +190,61 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
     assert.strictEqual(monitor.manager.messages.length, 1);
     assert(monitor.manager.messages.some(({ Type, Severity }) => Type === 'simple-estimate' && Severity === 5));
     monitor.manager.reset();
+  });
+
+  test('empty estimation', async function () {
+    const workerInfo = {
+      existingCapacity: 0,
+      requestedCapacity: 0,
+      stoppingCapacity: 0,
+    };
+    const estimate = await estimator.simple({
+      workerPoolId: 'foo/bar',
+      maxCapacity: 0,
+      minCapacity: 0,
+      scalingRatio: 1,
+      workerInfo,
+    });
+
+    assert.strictEqual(estimate, 0);
+    assert.strictEqual(monitor.manager.messages.length, 1);
+    assert(monitor.manager.messages.some(({ Type, Severity }) => Type === 'simple-estimate' && Severity === 5));
+  });
+
+  test('stopping capacity non zero', async function () {
+    const workerInfo = {
+      existingCapacity: 10,
+      requestedCapacity: 10,
+      stoppingCapacity: 10,
+    };
+    const estimate = await estimator.simple({
+      workerPoolId: 'foo/bar',
+      maxCapacity: 50,
+      minCapacity: 0,
+      scalingRatio: 1,
+      workerInfo,
+    });
+
+    assert.strictEqual(estimate, 20);
+    assert.strictEqual(monitor.manager.messages.length, 1);
+    assert(monitor.manager.messages.some(({ Type, Severity }) => Type === 'simple-estimate' && Severity === 5));
+  });
+  test('stopping capacity exceeds max capacity', async function () {
+    const workerInfo = {
+      existingCapacity: 10,
+      requestedCapacity: 10,
+      stoppingCapacity: 100,
+    };
+    const estimate = await estimator.simple({
+      workerPoolId: 'foo/bar',
+      maxCapacity: 50,
+      minCapacity: 0,
+      scalingRatio: 1,
+      workerInfo,
+    });
+
+    assert.strictEqual(estimate, 0);
+    assert.strictEqual(monitor.manager.messages.length, 1);
+    assert(monitor.manager.messages.some(({ Type, Severity }) => Type === 'simple-estimate' && Severity === 5));
   });
 });

--- a/services/worker-manager/test/provisioner_test.js
+++ b/services/worker-manager/test/provisioner_test.js
@@ -77,6 +77,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
               workerInfo: {
                 existingCapacity: wp.existingCapacity,
                 requestedCapacity: msg.Fields.workerInfo.requestedCapacity,
+                stoppingCapacity: wp.stoppingCapacity || 0,
               },
             },
             Severity: LEVELS.notice,
@@ -160,6 +161,39 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
         {
           workerPoolId: 'ff/ee',
           existingCapacity: 0, // quarantined worker is not considered "existing"
+          input: {
+            providerId: 'testing1',
+            description: 'bar',
+            config: {},
+            owner: 'example@example.com',
+            emailOnError: false,
+          },
+        },
+      ],
+    }));
+
+    test('single worker pool (with stopping worker)', () => testCase({
+      workers: [
+        {
+          workerPoolId: 'ff/ee',
+          workerGroup: 'whatever',
+          workerId: 'test-stopping',
+          providerId: 'testing1',
+          created: new Date(),
+          lastModified: new Date(),
+          lastChecked: new Date(),
+          expires: taskcluster.fromNow('1 hour'),
+          capacity: 1,
+          state: Worker.states.STOPPING,
+          providerData: {},
+          quarantineUntil: taskcluster.fromNow('1 hour'),
+        },
+      ],
+      workerPools: [
+        {
+          workerPoolId: 'ff/ee',
+          existingCapacity: 0,
+          stoppingCapacity: 1,
           input: {
             providerId: 'testing1',
             description: 'bar',
@@ -421,6 +455,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
             workerInfo: {
               existingCapacity: 0,
               requestedCapacity: 0,
+              stoppingCapacity: 0,
             },
           },
           Severity: LEVELS.notice,
@@ -466,6 +501,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
             workerInfo: {
               existingCapacity: 0,
               requestedCapacity: 0,
+              stoppingCapacity: 0,
             },
           },
           Severity: LEVELS.notice,
@@ -495,6 +531,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
             workerInfo: {
               existingCapacity: 0,
               requestedCapacity: 0,
+              stoppingCapacity: 0,
             },
           },
           Severity: LEVELS.notice,


### PR DESCRIPTION
Stopping workers require multiple calls for Azure to deprovision. When Workers that fail to start immediately due to the configuration or cloud availability error, go into stopping mode. Next provisioner loop doesn't count those against total capacity and keeps spawning them. This leads to the situations where stopping capacity grows significantly over short period of time and blocks scanning loop.

Fixes #6067
