### PR TITLE
feat(worker): add `task.payload.logs` and `task.payload.features.{liveLog,backingLog}` fields to generic worker

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,7 +25,8 @@ exclude: |
         ^clients/client-rust/integration_tests/src/lib.rs|
         ^ui/src/components/AuthConsent/__snapshots__/|
         ^ui/src/components/TaskDetailsCard/__snapshots__/|
-        ^services/worker-manager/test/fixtures/
+        ^services/worker-manager/test/fixtures/|
+        ^ui/src/components/TaskRunsCard/__snapshots__
     )
 
 ci:

--- a/changelog/issue-5993.md
+++ b/changelog/issue-5993.md
@@ -1,0 +1,6 @@
+audience: developers
+level: minor
+reference: issue 5993
+---
+Adds the `liveLog` and `backingLog` feature flags to the generic worker payload so they can be disabled for a task. These are enabled by default.
+Adds the `logs` property to the generic worker payload allowing customization of the live and backing log artifact names.

--- a/clients/client-go/tcauth/types.go
+++ b/clients/client-go/tcauth/types.go
@@ -164,7 +164,7 @@ type (
 		// it cannot be used for authentication in that state.
 		//
 		// Default:    false
-		DeleteOnExpiration bool `json:"deleteOnExpiration,omitempty" default:"false"`
+		DeleteOnExpiration bool `json:"deleteOnExpiration" default:"false"`
 
 		// Description of what these credentials are used for in markdown.
 		// Should include who is the owner, point of contact.

--- a/clients/client-go/tcauth/types.go
+++ b/clients/client-go/tcauth/types.go
@@ -164,7 +164,7 @@ type (
 		// it cannot be used for authentication in that state.
 		//
 		// Default:    false
-		DeleteOnExpiration bool `json:"deleteOnExpiration" default:"false"`
+		DeleteOnExpiration bool `json:"deleteOnExpiration,omitempty"`
 
 		// Description of what these credentials are used for in markdown.
 		// Should include who is the owner, point of contact.

--- a/clients/client-go/tchooks/types.go
+++ b/clients/client-go/tchooks/types.go
@@ -142,7 +142,7 @@ type (
 		// Whether to email the owner on an error creating the task.
 		//
 		// Default:    true
-		EmailOnError bool `json:"emailOnError,omitempty" default:"true"`
+		EmailOnError bool `json:"emailOnError" default:"true"`
 
 		// Human readable name of the hook
 		//

--- a/clients/client-go/tchooks/types.go
+++ b/clients/client-go/tchooks/types.go
@@ -142,7 +142,7 @@ type (
 		// Whether to email the owner on an error creating the task.
 		//
 		// Default:    true
-		EmailOnError bool `json:"emailOnError" default:"true"`
+		EmailOnError bool `json:"emailOnError,omitempty"`
 
 		// Human readable name of the hook
 		//

--- a/clients/client-go/tcnotify/types.go
+++ b/clients/client-go/tcnotify/types.go
@@ -92,7 +92,7 @@ type (
 		//   * "fullscreen"
 		//
 		// Default:    "simple"
-		Template string `json:"template" default:"simple"`
+		Template string `json:"template,omitempty"`
 	}
 
 	// Request to send a Matrix notice. Many of these fields are better understood by
@@ -120,7 +120,7 @@ type (
 		//   * "m.emote"
 		//
 		// Default:    "m.notice"
-		Msgtype string `json:"msgtype" default:"m.notice"`
+		Msgtype string `json:"msgtype,omitempty"`
 
 		// The fully qualified room name, such as `!whDRjjSmICCgrhFHsQ:mozilla.org`
 		// If you are using riot, you can find this under the advanced settings for a room.

--- a/clients/client-go/tcnotify/types.go
+++ b/clients/client-go/tcnotify/types.go
@@ -92,7 +92,7 @@ type (
 		//   * "fullscreen"
 		//
 		// Default:    "simple"
-		Template string `json:"template,omitempty" default:"simple"`
+		Template string `json:"template" default:"simple"`
 	}
 
 	// Request to send a Matrix notice. Many of these fields are better understood by
@@ -120,7 +120,7 @@ type (
 		//   * "m.emote"
 		//
 		// Default:    "m.notice"
-		Msgtype string `json:"msgtype,omitempty" default:"m.notice"`
+		Msgtype string `json:"msgtype" default:"m.notice"`
 
 		// The fully qualified room name, such as `!whDRjjSmICCgrhFHsQ:mozilla.org`
 		// If you are using riot, you can find this under the advanced settings for a room.

--- a/clients/client-go/tcqueue/types.go
+++ b/clients/client-go/tcqueue/types.go
@@ -1141,7 +1141,7 @@ type (
 		//   * "normal"
 		//
 		// Default:    "lowest"
-		Priority string `json:"priority" default:"lowest"`
+		Priority string `json:"priority,omitempty"`
 
 		// The name for the "project" with which this task is associated.  This
 		// value can be used to control permission to manipulate tasks as well as
@@ -1153,7 +1153,7 @@ type (
 		// Syntax:     ^([a-zA-Z0-9._/-]*)$
 		// Min length: 1
 		// Max length: 500
-		ProjectID string `json:"projectId" default:"none"`
+		ProjectID string `json:"projectId,omitempty"`
 
 		// Unique identifier for a provisioner, that can supply specified
 		// `workerType`. Deprecation is planned for this property as it
@@ -1175,7 +1175,7 @@ type (
 		//   * "all-resolved"
 		//
 		// Default:    "all-completed"
-		Requires string `json:"requires" default:"all-completed"`
+		Requires string `json:"requires,omitempty"`
 
 		// Number of times to retry the task in case of infrastructure issues.
 		// An _infrastructure issue_ is a worker node that crashes or is shutdown,
@@ -1216,7 +1216,7 @@ type (
 		// Syntax:     ^([a-zA-Z0-9-_]*)$
 		// Min length: 1
 		// Max length: 38
-		SchedulerID string `json:"schedulerId" default:"-"`
+		SchedulerID string `json:"schedulerId,omitempty"`
 
 		// List of scopes that the task is authorized to use during its execution.
 		//
@@ -1334,7 +1334,7 @@ type (
 		//   * "normal"
 		//
 		// Default:    "lowest"
-		Priority string `json:"priority" default:"lowest"`
+		Priority string `json:"priority"`
 
 		// The name for the "project" with which this task is associated.  This
 		// value can be used to control permission to manipulate tasks as well as
@@ -1346,7 +1346,7 @@ type (
 		// Syntax:     ^([a-zA-Z0-9._/-]*)$
 		// Min length: 1
 		// Max length: 500
-		ProjectID string `json:"projectId" default:"none"`
+		ProjectID string `json:"projectId,omitempty"`
 
 		// Unique identifier for a provisioner, that can supply specified
 		// `workerType`. Deprecation is planned for this property as it
@@ -1368,7 +1368,7 @@ type (
 		//   * "all-resolved"
 		//
 		// Default:    "all-completed"
-		Requires string `json:"requires" default:"all-completed"`
+		Requires string `json:"requires"`
 
 		// Number of times to retry the task in case of infrastructure issues.
 		// An _infrastructure issue_ is a worker node that crashes or is shutdown,
@@ -1409,7 +1409,7 @@ type (
 		// Syntax:     ^([a-zA-Z0-9-_]*)$
 		// Min length: 1
 		// Max length: 38
-		SchedulerID string `json:"schedulerId" default:"-"`
+		SchedulerID string `json:"schedulerId"`
 
 		// List of scopes that the task is authorized to use during its execution.
 		//
@@ -1759,7 +1759,7 @@ type (
 		// Syntax:     ^([a-zA-Z0-9-_]*)$
 		// Min length: 1
 		// Max length: 38
-		SchedulerID string `json:"schedulerId" default:"-"`
+		SchedulerID string `json:"schedulerId"`
 
 		// State of this task. This is just an auxiliary property derived from state
 		// of latests run, or `unscheduled` if none.

--- a/clients/client-go/tcqueue/types.go
+++ b/clients/client-go/tcqueue/types.go
@@ -1141,7 +1141,7 @@ type (
 		//   * "normal"
 		//
 		// Default:    "lowest"
-		Priority string `json:"priority,omitempty" default:"lowest"`
+		Priority string `json:"priority" default:"lowest"`
 
 		// The name for the "project" with which this task is associated.  This
 		// value can be used to control permission to manipulate tasks as well as
@@ -1153,7 +1153,7 @@ type (
 		// Syntax:     ^([a-zA-Z0-9._/-]*)$
 		// Min length: 1
 		// Max length: 500
-		ProjectID string `json:"projectId,omitempty" default:"none"`
+		ProjectID string `json:"projectId" default:"none"`
 
 		// Unique identifier for a provisioner, that can supply specified
 		// `workerType`. Deprecation is planned for this property as it
@@ -1175,7 +1175,7 @@ type (
 		//   * "all-resolved"
 		//
 		// Default:    "all-completed"
-		Requires string `json:"requires,omitempty" default:"all-completed"`
+		Requires string `json:"requires" default:"all-completed"`
 
 		// Number of times to retry the task in case of infrastructure issues.
 		// An _infrastructure issue_ is a worker node that crashes or is shutdown,
@@ -1216,7 +1216,7 @@ type (
 		// Syntax:     ^([a-zA-Z0-9-_]*)$
 		// Min length: 1
 		// Max length: 38
-		SchedulerID string `json:"schedulerId,omitempty" default:"-"`
+		SchedulerID string `json:"schedulerId" default:"-"`
 
 		// List of scopes that the task is authorized to use during its execution.
 		//
@@ -1346,7 +1346,7 @@ type (
 		// Syntax:     ^([a-zA-Z0-9._/-]*)$
 		// Min length: 1
 		// Max length: 500
-		ProjectID string `json:"projectId,omitempty" default:"none"`
+		ProjectID string `json:"projectId" default:"none"`
 
 		// Unique identifier for a provisioner, that can supply specified
 		// `workerType`. Deprecation is planned for this property as it

--- a/clients/client-go/tcqueueevents/types.go
+++ b/clients/client-go/tcqueueevents/types.go
@@ -512,7 +512,7 @@ type (
 		// Syntax:     ^([a-zA-Z0-9-_]*)$
 		// Min length: 1
 		// Max length: 38
-		SchedulerID string `json:"schedulerId" default:"-"`
+		SchedulerID string `json:"schedulerId"`
 
 		// State of this task. This is just an auxiliary property derived from state
 		// of latests run, or `unscheduled` if none.

--- a/generated/references.json
+++ b/generated/references.json
@@ -7561,6 +7561,18 @@
           "additionalProperties": false,
           "description": "Feature flags enable additional functionality.\n\nSince: generic-worker 5.3.0",
           "properties": {
+            "backingLog": {
+              "default": true,
+              "description": "The backing log feature publishes a task artifact containing the complete\nstderr and stdout of the task.\n\nSince: generic-worker 48.2.0",
+              "title": "Enable backing log",
+              "type": "boolean"
+            },
+            "liveLog": {
+              "default": true,
+              "description": "The live log feature streams the combined stderr and stdout to a task artifact\nso that the output is available while the task is running.\n\nSince: generic-worker 48.2.0",
+              "title": "Enable [livelog](https://github.com/taskcluster/taskcluster/tree/main/tools/livelog)",
+              "type": "boolean"
+            },
             "taskclusterProxy": {
               "description": "The taskcluster proxy provides an easy and safe way to make authenticated\ntaskcluster requests within the scope(s) of a particular task. See\n[the github project](https://github.com/taskcluster/taskcluster/tree/main/tools/taskcluster-proxy) for more information.\n\nSince: generic-worker 10.6.0",
               "title": "Run [taskcluster-proxy](https://github.com/taskcluster/taskcluster/tree/main/tools/taskcluster-proxy) to allow tasks to dynamically proxy requests to taskcluster services",
@@ -7570,6 +7582,28 @@
           "required": [
           ],
           "title": "Feature flags",
+          "type": "object"
+        },
+        "logs": {
+          "additionalProperties": false,
+          "description": "Configuration for task logs.\n\nSince: generic-worker 48.2.0",
+          "properties": {
+            "backing": {
+              "default": "public/logs/live_backing.log",
+              "description": "Specifies a custom name for the backing log artifact.\nThis is only used if `features.backingLog` is `true`.\n\nSince: generic-worker 48.2.0",
+              "title": "Backing log artifact name",
+              "type": "string"
+            },
+            "live": {
+              "default": "public/logs/live.log",
+              "description": "Specifies a custom name for the live log artifact.\nThis is only used if `features.liveLog` is `true`.\n\nSince: generic-worker 48.2.0",
+              "title": "Live log artifact name",
+              "type": "string"
+            }
+          },
+          "required": [
+          ],
+          "title": "Logs",
           "type": "object"
         },
         "maxRunTime": {
@@ -7926,9 +7960,21 @@
           "additionalProperties": false,
           "description": "Feature flags enable additional functionality.\n\nSince: generic-worker 5.3.0",
           "properties": {
+            "backingLog": {
+              "default": true,
+              "description": "The backing log feature publishes a task artifact containing the complete\nstderr and stdout of the task.\n\nSince: generic-worker 48.2.0",
+              "title": "Enable backing log",
+              "type": "boolean"
+            },
             "chainOfTrust": {
               "description": "Artifacts named `public/chain-of-trust.json` and\n`public/chain-of-trust.json.sig` should be generated which will\ninclude information for downstream tasks to build a level of trust\nfor the artifacts produced by the task and the environment it ran in.\n\nSince: generic-worker 5.3.0",
               "title": "Enable generation of signed Chain of Trust artifacts",
+              "type": "boolean"
+            },
+            "liveLog": {
+              "default": true,
+              "description": "The live log feature streams the combined stderr and stdout to a task artifact\nso that the output is available while the task is running.\n\nSince: generic-worker 48.2.0",
+              "title": "Enable [livelog](https://github.com/taskcluster/taskcluster/tree/main/tools/livelog)",
               "type": "boolean"
             },
             "runAsAdministrator": {
@@ -7945,6 +7991,28 @@
           "required": [
           ],
           "title": "Feature flags",
+          "type": "object"
+        },
+        "logs": {
+          "additionalProperties": false,
+          "description": "Configuration for task logs.\n\nSince: generic-worker 48.2.0",
+          "properties": {
+            "backing": {
+              "default": "public/logs/live_backing.log",
+              "description": "Specifies a custom name for the backing log artifact.\nThis is only used if `features.backingLog` is `true`.\n\nSince: generic-worker 48.2.0",
+              "title": "Backing log artifact name",
+              "type": "string"
+            },
+            "live": {
+              "default": "public/logs/live.log",
+              "description": "Specifies a custom name for the live log artifact.\nThis is only used if `features.liveLog` is `true`.\n\nSince: generic-worker 48.2.0",
+              "title": "Live log artifact name",
+              "type": "string"
+            }
+          },
+          "required": [
+          ],
+          "title": "Logs",
           "type": "object"
         },
         "maxRunTime": {
@@ -8310,9 +8378,21 @@
           "additionalProperties": false,
           "description": "Feature flags enable additional functionality.\n\nSince: generic-worker 5.3.0",
           "properties": {
+            "backingLog": {
+              "default": true,
+              "description": "The backing log feature publishes a task artifact containing the complete\nstderr and stdout of the task.\n\nSince: generic-worker 48.2.0",
+              "title": "Enable backing log",
+              "type": "boolean"
+            },
             "chainOfTrust": {
               "description": "Artifacts named `public/chain-of-trust.json` and\n`public/chain-of-trust.json.sig` should be generated which will\ninclude information for downstream tasks to build a level of trust\nfor the artifacts produced by the task and the environment it ran in.\n\nSince: generic-worker 5.3.0",
               "title": "Enable generation of signed Chain of Trust artifacts",
+              "type": "boolean"
+            },
+            "liveLog": {
+              "default": true,
+              "description": "The live log feature streams the combined stderr and stdout to a task artifact\nso that the output is available while the task is running.\n\nSince: generic-worker 48.2.0",
+              "title": "Enable [livelog](https://github.com/taskcluster/taskcluster/tree/main/tools/livelog)",
               "type": "boolean"
             },
             "taskclusterProxy": {
@@ -8324,6 +8404,28 @@
           "required": [
           ],
           "title": "Feature flags",
+          "type": "object"
+        },
+        "logs": {
+          "additionalProperties": false,
+          "description": "Configuration for task logs.\n\nSince: generic-worker 48.2.0",
+          "properties": {
+            "backing": {
+              "default": "public/logs/live_backing.log",
+              "description": "Specifies a custom name for the backing log artifact.\nThis is only used if `features.backingLog` is `true`.\n\nSince: generic-worker 48.2.0",
+              "title": "Backing log artifact name",
+              "type": "string"
+            },
+            "live": {
+              "default": "public/logs/live.log",
+              "description": "Specifies a custom name for the live log artifact.\nThis is only used if `features.liveLog` is `true`.\n\nSince: generic-worker 48.2.0",
+              "title": "Live log artifact name",
+              "type": "string"
+            }
+          },
+          "required": [
+          ],
+          "title": "Logs",
           "type": "object"
         },
         "maxRunTime": {
@@ -8685,9 +8787,21 @@
           "additionalProperties": false,
           "description": "Feature flags enable additional functionality.\n\nSince: generic-worker 5.3.0",
           "properties": {
+            "backingLog": {
+              "default": true,
+              "description": "The backing log feature publishes a task artifact containing the complete\nstderr and stdout of the task.\n\nSince: generic-worker 48.2.0",
+              "title": "Enable backing log",
+              "type": "boolean"
+            },
             "chainOfTrust": {
               "description": "Artifacts named `public/chain-of-trust.json` and\n`public/chain-of-trust.json.sig` should be generated which will\ninclude information for downstream tasks to build a level of trust\nfor the artifacts produced by the task and the environment it ran in.\n\nSince: generic-worker 5.3.0",
               "title": "Enable generation of signed Chain of Trust artifacts",
+              "type": "boolean"
+            },
+            "liveLog": {
+              "default": true,
+              "description": "The live log feature streams the combined stderr and stdout to a task artifact\nso that the output is available while the task is running.\n\nSince: generic-worker 48.2.0",
+              "title": "Enable [livelog](https://github.com/taskcluster/taskcluster/tree/main/tools/livelog)",
               "type": "boolean"
             },
             "taskclusterProxy": {
@@ -8699,6 +8813,28 @@
           "required": [
           ],
           "title": "Feature flags",
+          "type": "object"
+        },
+        "logs": {
+          "additionalProperties": false,
+          "description": "Configuration for task logs.\n\nSince: generic-worker 48.2.0",
+          "properties": {
+            "backing": {
+              "default": "public/logs/live_backing.log",
+              "description": "Specifies a custom name for the backing log artifact.\nThis is only used if `features.backingLog` is `true`.\n\nSince: generic-worker 48.2.0",
+              "title": "Backing log artifact name",
+              "type": "string"
+            },
+            "live": {
+              "default": "public/logs/live.log",
+              "description": "Specifies a custom name for the live log artifact.\nThis is only used if `features.liveLog` is `true`.\n\nSince: generic-worker 48.2.0",
+              "title": "Live log artifact name",
+              "type": "string"
+            }
+          },
+          "required": [
+          ],
+          "title": "Logs",
           "type": "object"
         },
         "maxRunTime": {
@@ -9014,8 +9150,9 @@
           "title": "Docker image."
         },
         "log": {
-          "description": "Specifies a custom location for the livelog artifact",
-          "title": "Custom log location",
+          "default": "public/logs/live.log",
+          "description": "Specifies a custom name for the livelog artifact. Note that this is also used in determining the name of the backing log artifact name. Backing log artifact name matches livelog artifact name with `_backing` appended, prior to the file extension (if present). For example, `apple/banana.log.txt` results in livelog artifact `apple/banana.log.txt` and backing log artifact `apple/banana.log_backing.txt`. Defaults to `public/logs/live.log`.",
+          "title": "Livelog artifact name",
           "type": "string"
         },
         "maxRunTime": {

--- a/services/github/package.json
+++ b/services/github/package.json
@@ -6,6 +6,6 @@
     "coverage": "c8 yarn test",
     "coverage:report": "c8 yarn test && c8 report --temp-directory ./coverage/tmp --reporter json --report-dir ../../artifacts",
     "lint": "eslint src/*.js test/*.js",
-    "test": "mocha test/*_test.js"
+    "test": "export NODE_OPTIONS=--dns-result-order=ipv4first && mocha test/*_test.js"
   }
 }

--- a/services/github/src/handlers/status.js
+++ b/services/github/src/handlers/status.js
@@ -159,7 +159,17 @@ async function statusHandler(message) {
     });
     const output = githubCheck.output;
     output.addText(markdownAnchor(CHECKRUN_TEXT, taskUI(this.context.cfg.taskcluster.rootUrl, taskGroupId, taskId)));
-    output.addText(markdownAnchor(CHECKLOGS_TEXT, taskLogUI(this.context.cfg.taskcluster.rootUrl, runId, taskId)));
+    output.addText(markdownAnchor(
+      CHECKLOGS_TEXT,
+      taskLogUI(
+        this.context.cfg.taskcluster.rootUrl,
+        runId,
+        taskId,
+        // docker worker uses `task.payload.log` while
+        // generic worker uses `task.payload.logs.live`
+        taskDefinition.payload?.logs?.live || taskDefinition.payload?.log,
+      ),
+    ));
     if (customCheckRunText) {
       output.addText(customCheckRunText);
     }

--- a/services/github/src/handlers/utils.js
+++ b/services/github/src/handlers/utils.js
@@ -1,3 +1,4 @@
+const path = require('path');
 const libUrls = require('taskcluster-lib-urls');
 const { CHECK_RUN_STATES } = require('../constants');
 
@@ -5,9 +6,8 @@ const taskUI = (rootUrl, taskGroupId, taskId) =>
   libUrls.ui(rootUrl, rootUrl === 'https://taskcluster.net' ? `/groups/${taskGroupId}/tasks/${taskId}/details` : `/tasks/${taskId}`);
 const taskGroupUI = (rootUrl, taskGroupId) =>
   libUrls.ui(rootUrl, `${rootUrl === 'https://taskcluster.net' ? '' : '/tasks'}/groups/${taskGroupId}`);
-const taskLogUI = (rootUrl, runId, taskId) =>
-  libUrls.ui(rootUrl, `/tasks/${taskId}/runs/${runId}/logs/live/public/logs/live.log`);
-
+const taskLogUI = (rootUrl, runId, taskId, liveLogName = 'public/logs/live.log') =>
+  libUrls.ui(rootUrl, path.join(`/tasks/${taskId}/runs/${runId}/logs/live/`, liveLogName));
 let debugCounter = 0;
 
 /**

--- a/test/go-lint.sh
+++ b/test/go-lint.sh
@@ -8,7 +8,7 @@ if [ -n "${unformatted_files}" ]; then
     exit 1;
 fi
 
-echo "Running golangci-lint.."
-golangci-lint run --build-tags multiuser
-golangci-lint run --build-tags simple
-golangci-lint run --build-tags docker
+for engine in multiuser simple docker; do
+  echo "Running golangci-lint for ${engine} engine.."
+  golangci-lint run --build-tags "${engine}"
+done

--- a/tools/jsonschema2go/jsonschema.go
+++ b/tools/jsonschema2go/jsonschema.go
@@ -1086,6 +1086,11 @@ func (s *Properties) AsStruct(disableNested bool, extraPackages StringSet, rawMe
 				// when more types are needed
 				case string, bool:
 					defaultStructTag = fmt.Sprintf(` default:"%v"`, *def)
+					// remove omitempty since a default value is provided
+					// if user provides an empty string or false,
+					// json.Marshal will disregard the default value if
+					// omitempty is present
+					jsonStructTagOptions = ""
 				}
 			}
 			// struct member name and type, as part of struct definition

--- a/tools/jsonschema2go/jsonschema.go
+++ b/tools/jsonschema2go/jsonschema.go
@@ -213,6 +213,7 @@ type (
 		SkipCodeGen          bool
 		TypeNameBlacklist    StringSet
 		DisableNestedStructs bool
+		EnableDefaults       bool
 	}
 
 	Result struct {
@@ -268,12 +269,12 @@ func (subSchema JsonSubSchema) String() string {
 	return string(b)
 }
 
-func (jsonSubSchema *JsonSubSchema) typeDefinition(disableNested bool, topLevel bool, extraPackages StringSet, rawMessageTypes StringSet) (comment, typ string) {
+func (jsonSubSchema *JsonSubSchema) typeDefinition(disableNested bool, enableDefaults bool, topLevel bool, extraPackages StringSet, rawMessageTypes StringSet) (comment, typ string) {
 	// Ignore all other properties if this has a $ref, and only redirect to the referened schema.
 	// See https://tools.ietf.org/html/draft-handrews-json-schema-01#section-8.3:
 	//   `All other properties in a "$ref" object MUST be ignored.`
 	if p := jsonSubSchema.RefSubSchema; p != nil {
-		return p.typeDefinition(disableNested, topLevel, extraPackages, rawMessageTypes)
+		return p.typeDefinition(disableNested, enableDefaults, topLevel, extraPackages, rawMessageTypes)
 	}
 	comment = "\n"
 	if d := jsonSubSchema.Description; d != nil {
@@ -371,7 +372,7 @@ func (jsonSubSchema *JsonSubSchema) typeDefinition(disableNested bool, topLevel 
 	case "array":
 		typ = "[]interface{}"
 		if jsonSubSchema.Items != nil {
-			arrayComment, arrayType := jsonSubSchema.Items.typeDefinition(disableNested, false, extraPackages, rawMessageTypes)
+			arrayComment, arrayType := jsonSubSchema.Items.typeDefinition(disableNested, enableDefaults, false, extraPackages, rawMessageTypes)
 			typ = "[]" + arrayType
 			// only add array comments if target schema is a primitive type
 			if jsonSubSchema.Items.TargetSchema().TypeName == "" {
@@ -392,13 +393,13 @@ func (jsonSubSchema *JsonSubSchema) typeDefinition(disableNested bool, topLevel 
 			if !topLevel && disableNested {
 				typ = jsonSubSchema.getTypeName()
 			} else {
-				typ = jsonSubSchema.Properties.AsStruct(disableNested, extraPackages, rawMessageTypes)
+				typ = jsonSubSchema.Properties.AsStruct(disableNested, enableDefaults, extraPackages, rawMessageTypes)
 			}
 		} else if ap != nil && ap.Properties != nil && jsonSubSchema.Properties == nil {
 			// In the special case no properties have been specified, but
 			// additionalProperties is an object, we can create a
 			// map[string]<additionalProperties definition>.
-			subComment, subType := ap.Properties.typeDefinition(disableNested, false, extraPackages, rawMessageTypes)
+			subComment, subType := ap.Properties.typeDefinition(disableNested, enableDefaults, false, extraPackages, rawMessageTypes)
 			typ = "map[string]" + subType
 			// only add subcomments if target schema is a primitive type
 			if ap.Properties.TargetSchema().TypeName == "" {
@@ -413,11 +414,11 @@ func (jsonSubSchema *JsonSubSchema) typeDefinition(disableNested bool, topLevel 
 			// both listed properties and additional properties.
 			if s := jsonSubSchema.Properties; s != nil {
 				comment += "//\n// Defined properties:\n//\n"
-				comment += text.Indent(s.AsStruct(disableNested, extraPackages, rawMessageTypes), "//  ") + "\n"
+				comment += text.Indent(s.AsStruct(disableNested, enableDefaults, extraPackages, rawMessageTypes), "//  ") + "\n"
 			}
 			if ap != nil && ap.Properties != nil {
 				comment += "//\n// Additional properties:\n"
-				subComment, subType := ap.Properties.typeDefinition(disableNested, true, extraPackages, rawMessageTypes)
+				subComment, subType := ap.Properties.typeDefinition(disableNested, enableDefaults, true, extraPackages, rawMessageTypes)
 				comment += text.Indent(subComment, "//  ")
 				comment += text.Indent(subType, "//  ") + "\n"
 			} else {
@@ -933,7 +934,7 @@ func (job *Job) cacheJsonSchema(url string) (*JsonSubSchema, error) {
 // Returns the generated code content, and a map of keys of extra packages to import, e.g.
 // a generated type might use time.Time, so if not imported, this would have to be added.
 // using a map of strings -> bool to simulate a set - true => include
-func generateGoTypes(disableNested bool, schemaSet *SchemaSet) (string, StringSet, StringSet) {
+func generateGoTypes(disableNested bool, enableDefaults bool, schemaSet *SchemaSet) (string, StringSet, StringSet) {
 	extraPackages := make(StringSet)
 	rawMessageTypes := make(StringSet)
 	content := "type (" // intentionally no \n here since each type starts with one already
@@ -943,7 +944,7 @@ func generateGoTypes(disableNested bool, schemaSet *SchemaSet) (string, StringSe
 	for _, i := range schemaSet.used {
 		log.Printf("Type name: '%v' - %v", i.getTypeName(), i.SourceURL)
 		var newComment, newType string
-		newComment, newType = i.typeDefinition(disableNested, true, extraPackages, rawMessageTypes)
+		newComment, newType = i.typeDefinition(disableNested, enableDefaults, true, extraPackages, rawMessageTypes)
 		typeDefinitions[i.TypeName] = text.Indent(newComment+i.TypeName+" "+newType, "\t")
 		typeNames = append(typeNames, i.getTypeName())
 	}
@@ -1001,7 +1002,7 @@ func (job *Job) Execute() (*Result, error) {
 	if job.SkipCodeGen {
 		return job.result, err
 	}
-	types, extraPackages, rawMessageTypes := generateGoTypes(job.DisableNestedStructs, job.result.SchemaSet)
+	types, extraPackages, rawMessageTypes := generateGoTypes(job.DisableNestedStructs, job.EnableDefaults, job.result.SchemaSet)
 	content := `// This source code file is AUTO-GENERATED by github.com/taskcluster/jsonschema2go
 
 package ` + job.Package + `
@@ -1066,20 +1067,20 @@ func jsonRawMessageImplementors(rawMessageTypes StringSet) string {
 	return content
 }
 
-func (s *Properties) AsStruct(disableNested bool, extraPackages StringSet, rawMessageTypes StringSet) (typ string) {
+func (s *Properties) AsStruct(disableNested bool, enableDefaults bool, extraPackages StringSet, rawMessageTypes StringSet) (typ string) {
 	typ = "struct {\n"
 	if s != nil {
 		for _, j := range s.SortedPropertyNames {
 			// recursive call to build structs inside structs
 			var subComment, subType string
 			subMember := s.MemberNames[j]
-			subComment, subType = s.Properties[j].typeDefinition(disableNested, false, extraPackages, rawMessageTypes)
+			subComment, subType = s.Properties[j].typeDefinition(disableNested, enableDefaults, false, extraPackages, rawMessageTypes)
 			jsonStructTagOptions := ""
 			if !s.Properties[j].IsRequired {
 				jsonStructTagOptions = ",omitempty"
 			}
 			defaultStructTag := ""
-			if def := s.Properties[j].Default; def != nil {
+			if def := s.Properties[j].Default; enableDefaults && (def != nil) {
 				switch (*def).(type) {
 				// for now, let's keep this simple, and limit support to types
 				// that currently have a default; we can expand on this if and

--- a/ui/docs/manual/using/artifacts.mdx
+++ b/ui/docs/manual/using/artifacts.mdx
@@ -9,8 +9,10 @@ import Warning from 'taskcluster-ui/views/Documentation/components/Warning';
 
 ## Creating Artifacts
 
-Most workers automatically produce a conventional `public/logs/live.log`
-artifact containing the main log of the artifact.
+Workers conventionally create a `public/logs/live.log`
+artifact containing the main task log. This default path can be overridden
+in Generic Worker task payloads using the `logs.live` property and the
+`log` property for Docker Worker task payloads.
 
 Workers also generally provide a way to specify, in the task description, the
 files and directories that should be uploaded as artifacts after the task

--- a/ui/src/components/TaskRunsCard/__snapshots__/index.test.jsx.snap
+++ b/ui/src/components/TaskRunsCard/__snapshots__/index.test.jsx.snap
@@ -39,7 +39,7 @@ exports[`should render TaskRunsCard 1`] = `
             class="MuiMobileStepper-dots"
           >
             <div
-              class="MuiMobileStepper-dot"
+              class="MuiMobileStepper-dot MuiMobileStepper-dotActive"
             />
           </div>
           <button
@@ -69,35 +69,634 @@ exports[`should render TaskRunsCard 1`] = `
         <h5
           class="MuiTypography-root TaskRunsCard-headline-1 MuiTypography-h5"
         >
-          Task Run
+          Task Run 0
         </h5>
-        <div
-          class="TaskRunsCard-boxVariant-9"
+        <ul
+          class="MuiList-root MuiList-padding"
         >
-          <svg
-            class="TaskRunsCard-boxVariantIcon-8"
-            height="24px"
-            version="1.1"
-            viewBox="0 0 24 24"
-            width="24px"
-            xmlns="http://www.w3.org/2000/svg"
+          <li
+            class="MuiListItem-root MuiListItem-gutters"
           >
-            <path
-              d="M2,10.96C1.5,10.68 1.35,10.07 1.63,9.59L3.13,7C3.24,6.8 3.41,6.66 3.6,6.58L11.43,2.18C11.59,2.06 11.79,2 12,2C12.21,2 12.41,2.06 12.57,2.18L20.47,6.62C20.66,6.72 20.82,6.88 20.91,7.08L22.36,9.6C22.64,10.08 22.47,10.69 22,10.96L21,11.54V16.5C21,16.88 20.79,17.21 20.47,17.38L12.57,21.82C12.41,21.94 12.21,22 12,22C11.79,22 11.59,21.94 11.43,21.82L3.53,17.38C3.21,17.21 3,16.88 3,16.5V10.96C2.7,11.13 2.32,11.14 2,10.96M12,4.15V4.15L12,10.85V10.85L17.96,7.5L12,4.15M5,15.91L11,19.29V12.58L5,9.21V15.91M19,15.91V12.69L14,15.59C13.67,15.77 13.3,15.76 13,15.6V19.29L19,15.91M13.85,13.36L20.13,9.73L19.55,8.72L13.27,12.35L13.85,13.36Z"
-              fill="rgba(0, 0, 0, 0.87)"
-              opacity="0.05"
+            <div
+              class="MuiListItemText-root MuiListItemText-multiline"
+            >
+              <span
+                class="MuiTypography-root MuiListItemText-primary MuiTypography-body1 MuiTypography-displayBlock"
+              >
+                State
+              </span>
+              <p
+                class="MuiTypography-root MuiListItemText-secondary MuiTypography-body2 MuiTypography-colorTextSecondary MuiTypography-displayBlock"
+              >
+                <button
+                  class="MuiButtonBase-root MuiButton-root MuiButton-text Label-mini-22 MuiButton-textSizeSmall MuiButton-sizeSmall Label-dense-21 Mui-disabled Label-success-25 Label-disabled-23 Mui-disabled"
+                  disabled=""
+                  tabindex="-1"
+                  type="button"
+                >
+                  <span
+                    class="MuiButton-label"
+                  >
+                    COMPLETED
+                  </span>
+                </button>
+              </p>
+            </div>
+          </li>
+          <a
+            href="/tasks/eR1kMya2SruyMaRMZguROg/runs/0/logs/apple/banana.log"
+          >
+            <div
+              aria-disabled="false"
+              class="MuiButtonBase-root MuiListItem-root TaskRunsCard-listItemButton-4 MuiListItem-gutters MuiListItem-button"
+              role="button"
+              tabindex="0"
+            >
+              <div
+                class="MuiListItemText-root MuiListItemText-multiline"
+              >
+                <span
+                  class="MuiTypography-root MuiListItemText-primary MuiTypography-body1 MuiTypography-displayBlock"
+                >
+                  View Live Log 
+                  <button
+                    class="MuiButtonBase-root MuiButton-root MuiButton-text TaskRunsCard-liveLogLabel-15 Label-mini-22 MuiButton-textSizeSmall MuiButton-sizeSmall Label-dense-21 Mui-disabled Label-info-28 Label-disabled-23 Mui-disabled"
+                    disabled=""
+                    tabindex="-1"
+                    type="button"
+                  >
+                    <span
+                      class="MuiButton-label"
+                    >
+                      LOG
+                    </span>
+                  </button>
+                </span>
+                <p
+                  class="MuiTypography-root MuiListItemText-secondary MuiTypography-body2 MuiTypography-colorTextSecondary MuiTypography-displayBlock"
+                >
+                  apple/banana.log
+                </p>
+              </div>
+              <svg
+                class="mdi-icon "
+                fill="currentColor"
+                height="24"
+                viewBox="0 0 24 24"
+                width="24"
+              >
+                <path
+                  d="M3.9,12C3.9,10.29 5.29,8.9 7,8.9H11V7H7A5,5 0 0,0 2,12A5,5 0 0,0 7,17H11V15.1H7C5.29,15.1 3.9,13.71 3.9,12M8,13H16V11H8V13M17,7H13V8.9H17C18.71,8.9 20.1,10.29 20.1,12C20.1,13.71 18.71,15.1 17,15.1H13V17H17A5,5 0 0,0 22,12A5,5 0 0,0 17,7Z"
+                />
+              </svg>
+              <span
+                class="MuiTouchRipple-root"
+              />
+            </div>
+          </a>
+          <div
+            aria-disabled="false"
+            class="MuiButtonBase-root MuiListItem-root TaskRunsCard-listItemButton-4 MuiListItem-gutters MuiListItem-button"
+            role="button"
+            tabindex="0"
+          >
+            <div
+              class="MuiListItemText-root"
+            >
+              <span
+                class="MuiTypography-root MuiListItemText-primary MuiTypography-body1 MuiTypography-displayBlock"
+              >
+                Artifacts (3)
+              </span>
+            </div>
+            <span
+              class="MuiTouchRipple-root"
             />
-          </svg>
-          <h6
-            class="MuiTypography-root TaskRunsCard-boxVariantText-10 MuiTypography-h6"
+          </div>
+          <div
+            class="MuiCollapse-root MuiCollapse-entered"
+            style="min-height: 0px;"
           >
-            No Runs
-          </h6>
-          <p
-            class="MuiTypography-root TaskRunsCard-boxVariantText-10 MuiTypography-body2"
+            <div
+              class="MuiCollapse-wrapper"
+            >
+              <div
+                class="MuiCollapse-wrapperInner"
+              >
+                <div
+                  class="MuiList-root"
+                >
+                  <div
+                    class="MuiListItem-root TaskRunsCard-artifactsListItemContainer-7"
+                  >
+                    <div
+                      class="ConnectionDataTable-tableWrapper-31"
+                    >
+                      <table
+                        class="MuiTable-root"
+                      >
+                        <tbody
+                          class="MuiTableBody-root"
+                        >
+                          <tr
+                            class="MuiTableRow-root TaskRunsCard-listItemButton-4 TaskRunsCard-artifactTableRow-12 TaskRunsCard-pointer-5 MuiTableRow-hover"
+                          >
+                            <td
+                              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall"
+                            >
+                              <a
+                                class="TaskRunsCard-artifactLink-11"
+                                href="/tasks/eR1kMya2SruyMaRMZguROg/runs/0/logs/public/logs/live_backing.log"
+                              >
+                                <div
+                                  class="TaskRunsCard-iconDiv-18"
+                                >
+                                  <svg
+                                    class="mdi-icon "
+                                    fill="currentColor"
+                                    height="24"
+                                    viewBox="0 0 24 24"
+                                    width="24"
+                                  >
+                                    <path
+                                      d="M13,9H18.5L13,3.5V9M6,2H14L20,8V20A2,2 0 0,1 18,22H6C4.89,22 4,21.1 4,20V4C4,2.89 4.89,2 6,2M15,18V16H6V18H15M18,14V12H6V14H18Z"
+                                    />
+                                  </svg>
+                                </div>
+                                <div
+                                  class="TaskRunsCard-artifactNameWrapper-13"
+                                >
+                                  <button
+                                    class="MuiButtonBase-root MuiButton-root MuiButton-text TaskRunsCard-logButton-6 Label-mini-22 MuiButton-textSizeSmall MuiButton-sizeSmall Label-dense-21 Mui-disabled Label-info-28 Label-disabled-23 Mui-disabled"
+                                    disabled=""
+                                    tabindex="-1"
+                                    type="button"
+                                  >
+                                    <span
+                                      class="MuiButton-label"
+                                    >
+                                      LOG
+                                    </span>
+                                  </button>
+                                  <div
+                                    class="TaskRunsCard-artifactName-14"
+                                  >
+                                    public/logs/live_backing.log
+                                  </div>
+                                </div>
+                                <div>
+                                  <svg
+                                    class="mdi-icon "
+                                    fill="currentColor"
+                                    height="24"
+                                    viewBox="0 0 24 24"
+                                    width="24"
+                                  >
+                                    <path
+                                      d="M3.9,12C3.9,10.29 5.29,8.9 7,8.9H11V7H7A5,5 0 0,0 2,12A5,5 0 0,0 7,17H11V15.1H7C5.29,15.1 3.9,13.71 3.9,12M8,13H16V11H8V13M17,7H13V8.9H17C18.71,8.9 20.1,10.29 20.1,12C20.1,13.71 18.71,15.1 17,15.1H13V17H17A5,5 0 0,0 22,12A5,5 0 0,0 17,7Z"
+                                    />
+                                  </svg>
+                                </div>
+                              </a>
+                            </td>
+                            <td
+                              class="MuiTableCell-root MuiTableCell-body TaskRunsCard-copyButton-19 MuiTableCell-sizeSmall"
+                            >
+                              <svg
+                                class="mdi-icon "
+                                fill="currentColor"
+                                height="24"
+                                title="Artifact URL (Copied!)"
+                                viewBox="0 0 24 24"
+                                width="24"
+                              >
+                                <path
+                                  d="M19,21H8V7H19M19,5H8A2,2 0 0,0 6,7V21A2,2 0 0,0 8,23H19A2,2 0 0,0 21,21V7A2,2 0 0,0 19,5M16,1H4A2,2 0 0,0 2,3V17H4V3H16V1Z"
+                                />
+                              </svg>
+                            </td>
+                          </tr>
+                          <tr
+                            class="MuiTableRow-root TaskRunsCard-listItemButton-4 TaskRunsCard-artifactTableRow-12 TaskRunsCard-pointer-5 MuiTableRow-hover"
+                          >
+                            <td
+                              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall"
+                            >
+                              <a
+                                class="TaskRunsCard-artifactLink-11"
+                                href="https://taskcluster.net/api/queue/v1/task/eR1kMya2SruyMaRMZguROg/runs/0/artifacts/public%2Fcoverage-final.json"
+                                rel="noopener noreferrer"
+                                target="_blank"
+                              >
+                                <div
+                                  class="TaskRunsCard-iconDiv-18"
+                                >
+                                  <svg
+                                    class="mdi-icon "
+                                    fill="currentColor"
+                                    height="24"
+                                    viewBox="0 0 24 24"
+                                    width="24"
+                                  >
+                                    <path
+                                      d="M13,9H18.5L13,3.5V9M6,2H14L20,8V20A2,2 0 0,1 18,22H6C4.89,22 4,21.1 4,20V4C4,2.89 4.89,2 6,2M6.12,15.5L9.86,19.24L11.28,17.83L8.95,15.5L11.28,13.17L9.86,11.76L6.12,15.5M17.28,15.5L13.54,11.76L12.12,13.17L14.45,15.5L12.12,17.83L13.54,19.24L17.28,15.5Z"
+                                    />
+                                  </svg>
+                                </div>
+                                <div
+                                  class="TaskRunsCard-artifactNameWrapper-13"
+                                >
+                                  <div
+                                    class="TaskRunsCard-artifactName-14"
+                                  >
+                                    public/coverage-final.json
+                                  </div>
+                                </div>
+                                <div>
+                                  <svg
+                                    class="mdi-icon "
+                                    fill="currentColor"
+                                    height="24"
+                                    viewBox="0 0 24 24"
+                                    width="24"
+                                  >
+                                    <path
+                                      d="M14,3V5H17.59L7.76,14.83L9.17,16.24L19,6.41V10H21V3M19,19H5V5H12V3H5C3.89,3 3,3.9 3,5V19A2,2 0 0,0 5,21H19A2,2 0 0,0 21,19V12H19V19Z"
+                                    />
+                                  </svg>
+                                </div>
+                              </a>
+                            </td>
+                            <td
+                              class="MuiTableCell-root MuiTableCell-body TaskRunsCard-copyButton-19 MuiTableCell-sizeSmall"
+                            >
+                              <svg
+                                class="mdi-icon "
+                                fill="currentColor"
+                                height="24"
+                                title="Artifact URL (Copied!)"
+                                viewBox="0 0 24 24"
+                                width="24"
+                              >
+                                <path
+                                  d="M19,21H8V7H19M19,5H8A2,2 0 0,0 6,7V21A2,2 0 0,0 8,23H19A2,2 0 0,0 21,21V7A2,2 0 0,0 19,5M16,1H4A2,2 0 0,0 2,3V17H4V3H16V1Z"
+                                />
+                              </svg>
+                            </td>
+                          </tr>
+                          <tr
+                            class="MuiTableRow-root TaskRunsCard-listItemButton-4 TaskRunsCard-artifactTableRow-12 TaskRunsCard-pointer-5 MuiTableRow-hover"
+                          >
+                            <td
+                              class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall"
+                            >
+                              <a
+                                class="TaskRunsCard-artifactLink-11"
+                                href="/tasks/eR1kMya2SruyMaRMZguROg/runs/0/logs/apple/banana.log"
+                              >
+                                <div
+                                  class="TaskRunsCard-iconDiv-18"
+                                >
+                                  <svg
+                                    class="mdi-icon "
+                                    fill="currentColor"
+                                    height="24"
+                                    viewBox="0 0 24 24"
+                                    width="24"
+                                  >
+                                    <path
+                                      d="M13,9H18.5L13,3.5V9M6,2H14L20,8V20A2,2 0 0,1 18,22H6C4.89,22 4,21.1 4,20V4C4,2.89 4.89,2 6,2M15,18V16H6V18H15M18,14V12H6V14H18Z"
+                                    />
+                                  </svg>
+                                </div>
+                                <div
+                                  class="TaskRunsCard-artifactNameWrapper-13"
+                                >
+                                  <button
+                                    class="MuiButtonBase-root MuiButton-root MuiButton-text TaskRunsCard-logButton-6 Label-mini-22 MuiButton-textSizeSmall MuiButton-sizeSmall Label-dense-21 Mui-disabled Label-info-28 Label-disabled-23 Mui-disabled"
+                                    disabled=""
+                                    tabindex="-1"
+                                    type="button"
+                                  >
+                                    <span
+                                      class="MuiButton-label"
+                                    >
+                                      LOG
+                                    </span>
+                                  </button>
+                                  <div
+                                    class="TaskRunsCard-artifactName-14"
+                                  >
+                                    apple/banana.log
+                                  </div>
+                                </div>
+                                <div>
+                                  <svg
+                                    class="mdi-icon "
+                                    fill="currentColor"
+                                    height="24"
+                                    viewBox="0 0 24 24"
+                                    width="24"
+                                  >
+                                    <path
+                                      d="M3.9,12C3.9,10.29 5.29,8.9 7,8.9H11V7H7A5,5 0 0,0 2,12A5,5 0 0,0 7,17H11V15.1H7C5.29,15.1 3.9,13.71 3.9,12M8,13H16V11H8V13M17,7H13V8.9H17C18.71,8.9 20.1,10.29 20.1,12C20.1,13.71 18.71,15.1 17,15.1H13V17H17A5,5 0 0,0 22,12A5,5 0 0,0 17,7Z"
+                                    />
+                                  </svg>
+                                </div>
+                              </a>
+                            </td>
+                            <td
+                              class="MuiTableCell-root MuiTableCell-body TaskRunsCard-copyButton-19 MuiTableCell-sizeSmall"
+                            >
+                              <svg
+                                class="mdi-icon "
+                                fill="currentColor"
+                                height="24"
+                                title="Artifact URL (Copied!)"
+                                viewBox="0 0 24 24"
+                                width="24"
+                              >
+                                <path
+                                  d="M19,21H8V7H19M19,5H8A2,2 0 0,0 6,7V21A2,2 0 0,0 8,23H19A2,2 0 0,0 21,21V7A2,2 0 0,0 19,5M16,1H4A2,2 0 0,0 2,3V17H4V3H16V1Z"
+                                />
+                              </svg>
+                            </td>
+                          </tr>
+                        </tbody>
+                      </table>
+                    </div>
+                    <hr
+                      class="MuiDivider-root"
+                    />
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <li
+            class="MuiListItem-root MuiListItem-gutters"
           >
-            A run will be created when the task gets scheduled.
-          </p>
+            <div
+              class="MuiListItemText-root MuiListItemText-multiline"
+            >
+              <span
+                class="MuiTypography-root MuiListItemText-primary MuiTypography-body1 MuiTypography-displayBlock"
+              >
+                Reason Resolved
+              </span>
+              <p
+                class="MuiTypography-root MuiListItemText-secondary MuiTypography-body2 MuiTypography-colorTextSecondary MuiTypography-displayBlock"
+              >
+                <button
+                  class="MuiButtonBase-root MuiButton-root MuiButton-text Label-mini-22 MuiButton-textSizeSmall MuiButton-sizeSmall Label-dense-21 Mui-disabled Label-default-27 Label-disabled-23 Mui-disabled"
+                  disabled=""
+                  tabindex="-1"
+                  type="button"
+                >
+                  <span
+                    class="MuiButton-label"
+                  >
+                    COMPLETED
+                  </span>
+                </button>
+              </p>
+            </div>
+          </li>
+          <div
+            aria-disabled="false"
+            class="MuiButtonBase-root MuiListItem-root makeStyles-listItemButtonRoot-35 MuiListItem-gutters MuiListItem-button"
+            role="button"
+            tabindex="0"
+            title="2022-02-03T14:41:19.706Z (Copy)"
+          >
+            <div
+              class="MuiListItemText-root MuiListItemText-multiline"
+            >
+              <span
+                class="MuiTypography-root MuiListItemText-primary MuiTypography-body1 MuiTypography-displayBlock"
+              >
+                Scheduled
+              </span>
+              <p
+                class="MuiTypography-root MuiListItemText-secondary MuiTypography-body2 MuiTypography-colorTextSecondary MuiTypography-displayBlock"
+              >
+                14 days ago
+              </p>
+            </div>
+            <svg
+              class="mdi-icon "
+              fill="currentColor"
+              height="24"
+              viewBox="0 0 24 24"
+              width="24"
+            >
+              <path
+                d="M19,21H8V7H19M19,5H8A2,2 0 0,0 6,7V21A2,2 0 0,0 8,23H19A2,2 0 0,0 21,21V7A2,2 0 0,0 19,5M16,1H4A2,2 0 0,0 2,3V17H4V3H16V1Z"
+              />
+            </svg>
+            <span
+              class="MuiTouchRipple-root"
+            />
+          </div>
+          <div
+            aria-disabled="false"
+            class="MuiButtonBase-root MuiListItem-root makeStyles-listItemButtonRoot-35 MuiListItem-gutters MuiListItem-button"
+            role="button"
+            tabindex="0"
+            title="2022-02-03T14:43:54.086Z (Copy)"
+          >
+            <div
+              class="MuiListItemText-root MuiListItemText-multiline"
+            >
+              <span
+                class="MuiTypography-root MuiListItemText-primary MuiTypography-body1 MuiTypography-displayBlock"
+              >
+                Started
+              </span>
+              <p
+                class="MuiTypography-root MuiListItemText-secondary MuiTypography-body2 MuiTypography-colorTextSecondary MuiTypography-displayBlock"
+              >
+                14 days ago (3 minutes later)
+              </p>
+            </div>
+            <svg
+              class="mdi-icon "
+              fill="currentColor"
+              height="24"
+              viewBox="0 0 24 24"
+              width="24"
+            >
+              <path
+                d="M19,21H8V7H19M19,5H8A2,2 0 0,0 6,7V21A2,2 0 0,0 8,23H19A2,2 0 0,0 21,21V7A2,2 0 0,0 19,5M16,1H4A2,2 0 0,0 2,3V17H4V3H16V1Z"
+              />
+            </svg>
+            <span
+              class="MuiTouchRipple-root"
+            />
+          </div>
+          <div
+            aria-disabled="false"
+            class="MuiButtonBase-root MuiListItem-root makeStyles-listItemButtonRoot-35 MuiListItem-gutters MuiListItem-button"
+            role="button"
+            tabindex="0"
+            title="2022-02-03T14:45:28.396Z (Copy)"
+          >
+            <div
+              class="MuiListItemText-root MuiListItemText-multiline"
+            >
+              <span
+                class="MuiTypography-root MuiListItemText-primary MuiTypography-body1 MuiTypography-displayBlock"
+              >
+                Resolved
+              </span>
+              <p
+                class="MuiTypography-root MuiListItemText-secondary MuiTypography-body2 MuiTypography-colorTextSecondary MuiTypography-displayBlock"
+              >
+                14 days ago (2 minutes later)
+              </p>
+            </div>
+            <svg
+              class="mdi-icon "
+              fill="currentColor"
+              height="24"
+              viewBox="0 0 24 24"
+              width="24"
+            >
+              <path
+                d="M19,21H8V7H19M19,5H8A2,2 0 0,0 6,7V21A2,2 0 0,0 8,23H19A2,2 0 0,0 21,21V7A2,2 0 0,0 19,5M16,1H4A2,2 0 0,0 2,3V17H4V3H16V1Z"
+              />
+            </svg>
+            <span
+              class="MuiTouchRipple-root"
+            />
+          </div>
+        </ul>
+        <div
+          class="MuiList-root"
+        >
+          <li
+            class="MuiListItem-root MuiListItem-gutters"
+          >
+            <div
+              class="MuiListItemText-root MuiListItemText-multiline"
+            >
+              <span
+                class="MuiTypography-root MuiListItemText-primary MuiTypography-body1 MuiTypography-displayBlock"
+              >
+                Reason Created
+              </span>
+              <p
+                class="MuiTypography-root MuiListItemText-secondary MuiTypography-body2 MuiTypography-colorTextSecondary MuiTypography-displayBlock"
+              >
+                <button
+                  class="MuiButtonBase-root MuiButton-root MuiButton-text Label-mini-22 MuiButton-textSizeSmall MuiButton-sizeSmall Label-dense-21 Mui-disabled Label-default-27 Label-disabled-23 Mui-disabled"
+                  disabled=""
+                  tabindex="-1"
+                  type="button"
+                >
+                  <span
+                    class="MuiButton-label"
+                  >
+                    SCHEDULED
+                  </span>
+                </button>
+              </p>
+            </div>
+          </li>
+          <li
+            class="MuiListItem-root MuiListItem-gutters"
+          >
+            <div
+              class="MuiListItemText-root MuiListItemText-multiline"
+            >
+              <span
+                class="MuiTypography-root MuiListItemText-primary MuiTypography-body1 MuiTypography-displayBlock"
+              >
+                Worker Group
+              </span>
+              <p
+                class="MuiTypography-root MuiListItemText-secondary MuiTypography-body2 MuiTypography-colorTextSecondary MuiTypography-displayBlock"
+              >
+                us-east1
+              </p>
+            </div>
+          </li>
+          <a
+            href="/provisioners/task/worker-types/queueId/workers/us-east1/7421215367664916236"
+          >
+            <div
+              aria-disabled="false"
+              class="MuiButtonBase-root MuiListItem-root TaskRunsCard-listItemButton-4 MuiListItem-gutters MuiListItem-button"
+              role="button"
+              tabindex="0"
+              title="View Worker"
+            >
+              <div
+                class="MuiListItemText-root MuiListItemText-multiline"
+              >
+                <span
+                  class="MuiTypography-root MuiListItemText-primary MuiTypography-body1 MuiTypography-displayBlock"
+                >
+                  Worker ID
+                </span>
+                <p
+                  class="MuiTypography-root MuiListItemText-secondary MuiTypography-body2 MuiTypography-colorTextSecondary MuiTypography-displayBlock"
+                >
+                  7421215367664916236
+                </p>
+              </div>
+              <svg
+                class="mdi-icon "
+                fill="currentColor"
+                height="24"
+                viewBox="0 0 24 24"
+                width="24"
+              >
+                <path
+                  d="M3.9,12C3.9,10.29 5.29,8.9 7,8.9H11V7H7A5,5 0 0,0 2,12A5,5 0 0,0 7,17H11V15.1H7C5.29,15.1 3.9,13.71 3.9,12M8,13H16V11H8V13M17,7H13V8.9H17C18.71,8.9 20.1,10.29 20.1,12C20.1,13.71 18.71,15.1 17,15.1H13V17H17A5,5 0 0,0 22,12A5,5 0 0,0 17,7Z"
+                />
+              </svg>
+              <span
+                class="MuiTouchRipple-root"
+              />
+            </div>
+          </a>
+          <div
+            aria-disabled="false"
+            class="MuiButtonBase-root MuiListItem-root makeStyles-listItemButtonRoot-35 MuiListItem-gutters MuiListItem-button"
+            role="button"
+            tabindex="0"
+            title="2022-02-03T15:03:54.082Z (Copy)"
+          >
+            <div
+              class="MuiListItemText-root MuiListItemText-multiline"
+            >
+              <span
+                class="MuiTypography-root MuiListItemText-primary MuiTypography-body1 MuiTypography-displayBlock"
+              >
+                Taken Until
+              </span>
+              <p
+                class="MuiTypography-root MuiListItemText-secondary MuiTypography-body2 MuiTypography-colorTextSecondary MuiTypography-displayBlock"
+              >
+                14 days ago
+              </p>
+            </div>
+            <svg
+              class="mdi-icon "
+              fill="currentColor"
+              height="24"
+              viewBox="0 0 24 24"
+              width="24"
+            >
+              <path
+                d="M19,21H8V7H19M19,5H8A2,2 0 0,0 6,7V21A2,2 0 0,0 8,23H19A2,2 0 0,0 21,21V7A2,2 0 0,0 19,5M16,1H4A2,2 0 0,0 2,3V17H4V3H16V1Z"
+              />
+            </svg>
+            <span
+              class="MuiTouchRipple-root"
+            />
+          </div>
         </div>
       </div>
     </div>

--- a/ui/src/components/TaskRunsCard/index.jsx
+++ b/ui/src/components/TaskRunsCard/index.jsx
@@ -151,6 +151,13 @@ export default class TaskRunsCard extends Component {
      * Execute a function to load new artifacts when paging through them.
      */
     onArtifactsPageChange: func.isRequired,
+    /**
+     * A custom live log name given in the task.payload.logs.live field
+     * in generic worker payloads and in the task.payload.log field
+     * in docker worker payloads.
+     * Defaults to `public/logs/live.log`.
+     */
+    liveLogName: string,
   };
 
   state = {
@@ -231,8 +238,9 @@ export default class TaskRunsCard extends Component {
   };
 
   getLiveLogArtifactFromRun = run => {
+    const { liveLogName = 'public/logs/live.log' } = this.props;
     const artifact = run?.artifacts?.edges?.find(
-      ({ node: { name } }) => name === 'public/logs/live.log'
+      ({ node: { name } }) => name === liveLogName
     );
 
     if (!artifact) {

--- a/ui/src/components/TaskRunsCard/index.test.jsx
+++ b/ui/src/components/TaskRunsCard/index.test.jsx
@@ -8,6 +8,7 @@ it('should render TaskRunsCard', () => {
     <MemoryRouter keyLength={0}>
       <TaskRunsCard
         taskQueueId="task/queueId"
+        liveLogName="apple/banana.log"
         task={{
           taskId: 'taskId',
           status: {
@@ -37,7 +38,7 @@ it('should render TaskRunsCard', () => {
           },
           extra: {},
         }}
-        selectedRunId=""
+        selectedRunId={0}
         runs={[
           {
             taskId: 'eR1kMya2SruyMaRMZguROg',
@@ -79,7 +80,7 @@ it('should render TaskRunsCard', () => {
                 },
                 {
                   node: {
-                    name: 'public/logs/live.log',
+                    name: 'apple/banana.log',
                     contentType: 'text/plain; charset=utf-8',
                     __typename: 'Artifact',
                   },

--- a/ui/src/views/Tasks/ViewTask/index.jsx
+++ b/ui/src/views/Tasks/ViewTask/index.jsx
@@ -969,6 +969,9 @@ export default class ViewTask extends Component {
                   runs={task.status.runs}
                   taskQueueId={task.taskQueueId}
                   onArtifactsPageChange={this.handleArtifactsPageChange}
+                  // docker worker uses `task.payload.log` while
+                  // generic worker uses `task.payload.logs.live`
+                  liveLogName={task.payload?.logs?.live || task.payload?.log}
                 />
               </Grid>
             </Grid>

--- a/workers/docker-worker/schemas/v1/payload.yml
+++ b/workers/docker-worker/schemas/v1/payload.yml
@@ -26,9 +26,17 @@ definitions:
       - path
 properties:
   log:
-    title: Custom log location
-    description: Specifies a custom location for the livelog artifact
+    title: Livelog artifact name
+    description: >-
+      Specifies a custom name for the livelog artifact. Note that this is
+      also used in determining the name of the backing log artifact name.
+      Backing log artifact name matches livelog artifact name with `_backing`
+      appended, prior to the file extension (if present). For example,
+      `apple/banana.log.txt` results in livelog artifact `apple/banana.log.txt`
+      and backing log artifact `apple/banana.log_backing.txt`.
+      Defaults to `public/logs/live.log`.
     type: string
+    default: public/logs/live.log
   image:
     title: Docker image.
     description: >-

--- a/workers/generic-worker/artifacts_broken_on_docker_test.go
+++ b/workers/generic-worker/artifacts_broken_on_docker_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/mcuadros/go-defaults"
 	tcclient "github.com/taskcluster/taskcluster/v48/clients/client-go"
 )
 
@@ -28,6 +29,7 @@ func TestPublicDirectoryArtifact(t *testing.T) {
 			},
 		},
 	}
+	defaults.SetDefaults(&payload)
 	td := testTask(t)
 
 	taskID := submitAndAssert(t, td, payload, "completed", "completed")
@@ -40,7 +42,7 @@ func TestPublicDirectoryArtifact(t *testing.T) {
 	}
 
 	if l := len(artifacts.Artifacts); l != 3 {
-		t.Fatalf("Was expecting 3 artifacts, but got %v", l)
+		t.Fatalf("Was expecting 3 artifacts, but got %v: %#v", l, artifacts)
 	}
 
 	// use the artifact names as keys in a map, so we can look up that each key exists
@@ -82,6 +84,7 @@ func TestConflictingFileArtifactsInPayload(t *testing.T) {
 			},
 		},
 	}
+	defaults.SetDefaults(&payload)
 	td := testTask(t)
 
 	taskID := submitAndAssert(t, td, payload, "exception", "malformed-payload")
@@ -94,7 +97,7 @@ func TestConflictingFileArtifactsInPayload(t *testing.T) {
 	}
 
 	if l := len(artifacts.Artifacts); l != 3 {
-		t.Fatalf("Was expecting 3 artifacts, but got %v", l)
+		t.Fatalf("Was expecting 3 artifacts, but got %v: %#v", l, artifacts)
 	}
 
 	// use the artifact names as keys in a map, so we can look up that each key exists
@@ -135,6 +138,7 @@ func TestFileArtifactTwiceInPayload(t *testing.T) {
 			},
 		},
 	}
+	defaults.SetDefaults(&payload)
 	td := testTask(t)
 
 	_ = submitAndAssert(t, td, payload, "exception", "malformed-payload")
@@ -166,6 +170,7 @@ func TestArtifactIncludedAsFileAndDirectoryInPayload(t *testing.T) {
 			},
 		},
 	}
+	defaults.SetDefaults(&payload)
 	td := testTask(t)
 
 	taskID := submitAndAssert(t, td, payload, "completed", "completed")
@@ -178,7 +183,7 @@ func TestArtifactIncludedAsFileAndDirectoryInPayload(t *testing.T) {
 	}
 
 	if l := len(artifacts.Artifacts); l != 3 {
-		t.Fatalf("Was expecting 3 artifacts, but got %v", l)
+		t.Fatalf("Was expecting 3 artifacts, but got %v: %#v", l, artifacts)
 	}
 
 	// use the artifact names as keys in a map, so we can look up that each key exists
@@ -208,6 +213,7 @@ func TestFileArtifactHasNoExpiry(t *testing.T) {
 			},
 		},
 	}
+	defaults.SetDefaults(&payload)
 
 	td := testTask(t)
 
@@ -246,6 +252,7 @@ func TestDirectoryArtifactHasNoExpiry(t *testing.T) {
 			},
 		},
 	}
+	defaults.SetDefaults(&payload)
 
 	td := testTask(t)
 
@@ -285,6 +292,7 @@ func TestObjectArtifact(t *testing.T) {
 			},
 		},
 	}
+	defaults.SetDefaults(&payload)
 
 	td := testTask(t)
 	_ = submitAndAssert(t, td, payload, "completed", "completed")

--- a/workers/generic-worker/artifacts_multiuser_test.go
+++ b/workers/generic-worker/artifacts_multiuser_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/mcuadros/go-defaults"
 	tcclient "github.com/taskcluster/taskcluster/v48/clients/client-go"
 	"golang.org/x/crypto/ed25519"
 )
@@ -45,6 +46,7 @@ func TestChainOfTrustUpload(t *testing.T) {
 			ChainOfTrust: true,
 		},
 	}
+	defaults.SetDefaults(&payload)
 	td := testTask(t)
 
 	// Chain of trust is not allowed when running as current user
@@ -273,6 +275,7 @@ func TestProtectedArtifactsReplaced(t *testing.T) {
 			ChainOfTrust: true,
 		},
 	}
+	defaults.SetDefaults(&payload)
 	td := testTask(t)
 
 	// Chain of trust is not allowed when running as current user

--- a/workers/generic-worker/artifacts_test.go
+++ b/workers/generic-worker/artifacts_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/mcuadros/go-defaults"
 	"github.com/taskcluster/slugid-go/slugid"
 	tcclient "github.com/taskcluster/taskcluster/v48/clients/client-go"
 	"github.com/taskcluster/taskcluster/v48/clients/client-go/tcqueue"
@@ -25,13 +26,16 @@ func validateArtifacts(
 	payloadArtifacts []Artifact,
 	expected []artifacts.TaskArtifact) {
 
+	payload := GenericWorkerPayload{
+		Artifacts: []Artifact{},
+	}
+	defaults.SetDefaults(&payload)
+
 	// to test, create a dummy task run with given artifacts
 	// and then call Artifacts() method to see what
 	// artifacts would get uploaded...
 	tr := &TaskRun{
-		Payload: GenericWorkerPayload{
-			Artifacts: []Artifact{},
-		},
+		Payload: payload,
 		Definition: tcqueue.TaskDefinitionResponse{
 			Expires: inAnHour,
 		},
@@ -626,6 +630,7 @@ func TestMissingArtifactFailsTest(t *testing.T) {
 			},
 		},
 	}
+	defaults.SetDefaults(&payload)
 
 	td := testTask(t)
 
@@ -654,6 +659,7 @@ func TestInvalidContentEncoding(t *testing.T) {
 			},
 		},
 	}
+	defaults.SetDefaults(&payload)
 	td := testTask(t)
 
 	_ = submitAndAssert(t, td, payload, "exception", "malformed-payload")
@@ -687,6 +693,7 @@ func TestInvalidContentEncodingBlacklisted(t *testing.T) {
 			},
 		},
 	}
+	defaults.SetDefaults(&payload)
 	td := testTask(t)
 
 	_ = submitAndAssert(t, td, payload, "exception", "malformed-payload")

--- a/workers/generic-worker/chain_of_trust.go
+++ b/workers/generic-worker/chain_of_trust.go
@@ -10,12 +10,11 @@ import (
 	"os"
 	"path/filepath"
 
-	"golang.org/x/crypto/ed25519"
-
 	"github.com/taskcluster/taskcluster/v48/clients/client-go/tcqueue"
 	"github.com/taskcluster/taskcluster/v48/internal/scopes"
 	"github.com/taskcluster/taskcluster/v48/workers/generic-worker/artifacts"
 	"github.com/taskcluster/taskcluster/v48/workers/generic-worker/fileutil"
+	"golang.org/x/crypto/ed25519"
 )
 
 const (

--- a/workers/generic-worker/chain_of_trust.go
+++ b/workers/generic-worker/chain_of_trust.go
@@ -62,6 +62,7 @@ type ChainOfTrustData struct {
 type ChainOfTrustTaskFeature struct {
 	task           *TaskRun
 	ed25519PrivKey ed25519.PrivateKey
+	disabled       bool
 }
 
 func (feature *ChainOfTrustFeature) Name() string {
@@ -116,12 +117,16 @@ func (feature *ChainOfTrustTaskFeature) Start() *CommandExecutionError {
 	// runTasksAsCurrentUser enabled).
 	err := feature.ensureTaskUserCantReadPrivateCotKey()
 	if err != nil {
+		feature.disabled = true
 		return MalformedPayloadError(err)
 	}
 	return nil
 }
 
 func (feature *ChainOfTrustTaskFeature) Stop(err *ExecutionErrors) {
+	if feature.disabled {
+		return
+	}
 	logFile := filepath.Join(taskContext.TaskDir, logPath)
 	certifiedLogFile := filepath.Join(taskContext.TaskDir, certifiedLogPath)
 	unsignedCert := filepath.Join(taskContext.TaskDir, unsignedCertPath)

--- a/workers/generic-worker/envvars_broken_on_docker_test.go
+++ b/workers/generic-worker/envvars_broken_on_docker_test.go
@@ -4,6 +4,8 @@ package main
 
 import (
 	"testing"
+
+	"github.com/mcuadros/go-defaults"
 )
 
 func TestWorkerLocation(t *testing.T) {
@@ -41,6 +43,7 @@ func TestWorkerLocation(t *testing.T) {
 		),
 		MaxRunTime: 180,
 	}
+	defaults.SetDefaults(&payload)
 
 	td := testTask(t)
 

--- a/workers/generic-worker/expose/local.go
+++ b/workers/generic-worker/expose/local.go
@@ -3,7 +3,6 @@ package expose
 import (
 	"fmt"
 	"net"
-
 	"net/url"
 )
 

--- a/workers/generic-worker/expose/wst.go
+++ b/workers/generic-worker/expose/wst.go
@@ -11,7 +11,6 @@ package expose
 
 import (
 	"fmt"
-
 	"net/http"
 	"net/url"
 

--- a/workers/generic-worker/generated_docker_darwin.go
+++ b/workers/generic-worker/generated_docker_darwin.go
@@ -153,6 +153,14 @@ type (
 	// Since: generic-worker 5.3.0
 	FeatureFlags struct {
 
+		// The backing log feature publishes a task artifact containing the complete
+		// stderr and stdout of the task.
+		//
+		// Since: generic-worker 48.2.0
+		//
+		// Default:    true
+		BackingLog bool `json:"backingLog,omitempty" default:"true"`
+
 		// Artifacts named `public/chain-of-trust.json` and
 		// `public/chain-of-trust.json.sig` should be generated which will
 		// include information for downstream tasks to build a level of trust
@@ -160,6 +168,14 @@ type (
 		//
 		// Since: generic-worker 5.3.0
 		ChainOfTrust bool `json:"chainOfTrust,omitempty"`
+
+		// The live log feature streams the combined stderr and stdout to a task artifact
+		// so that the output is available while the task is running.
+		//
+		// Since: generic-worker 48.2.0
+		//
+		// Default:    true
+		LiveLog bool `json:"liveLog,omitempty" default:"true"`
 
 		// The taskcluster proxy provides an easy and safe way to make authenticated
 		// taskcluster requests within the scope(s) of a particular task. See
@@ -234,6 +250,11 @@ type (
 		// Since: generic-worker 5.3.0
 		Features FeatureFlags `json:"features,omitempty"`
 
+		// Configuration for task logs.
+		//
+		// Since: generic-worker 48.2.0
+		Logs Logs `json:"logs,omitempty"`
+
 		// Maximum time the task container can run in seconds.
 		//
 		// Since: generic-worker 0.0.1
@@ -270,6 +291,28 @@ type (
 
 		// This property is allowed for backward compatibility, but is unused.
 		SupersederURL string `json:"supersederUrl,omitempty"`
+	}
+
+	// Configuration for task logs.
+	//
+	// Since: generic-worker 48.2.0
+	Logs struct {
+
+		// Specifies a custom name for the backing log artifact.
+		// This is only used if `features.backingLog` is `true`.
+		//
+		// Since: generic-worker 48.2.0
+		//
+		// Default:    "public/logs/live_backing.log"
+		Backing string `json:"backing,omitempty" default:"public/logs/live_backing.log"`
+
+		// Specifies a custom name for the live log artifact.
+		// This is only used if `features.liveLog` is `true`.
+		//
+		// Since: generic-worker 48.2.0
+		//
+		// Default:    "public/logs/live.log"
+		Live string `json:"live,omitempty" default:"public/logs/live.log"`
 	}
 
 	// Byte-for-byte literal inline content of file/archive, up to 64KB in size.
@@ -676,9 +719,21 @@ func taskPayloadSchema() string {
       "additionalProperties": false,
       "description": "Feature flags enable additional functionality.\n\nSince: generic-worker 5.3.0",
       "properties": {
+        "backingLog": {
+          "default": true,
+          "description": "The backing log feature publishes a task artifact containing the complete\nstderr and stdout of the task.\n\nSince: generic-worker 48.2.0",
+          "title": "Enable backing log",
+          "type": "boolean"
+        },
         "chainOfTrust": {
           "description": "Artifacts named ` + "`" + `public/chain-of-trust.json` + "`" + ` and\n` + "`" + `public/chain-of-trust.json.sig` + "`" + ` should be generated which will\ninclude information for downstream tasks to build a level of trust\nfor the artifacts produced by the task and the environment it ran in.\n\nSince: generic-worker 5.3.0",
           "title": "Enable generation of signed Chain of Trust artifacts",
+          "type": "boolean"
+        },
+        "liveLog": {
+          "default": true,
+          "description": "The live log feature streams the combined stderr and stdout to a task artifact\nso that the output is available while the task is running.\n\nSince: generic-worker 48.2.0",
+          "title": "Enable [livelog](https://github.com/taskcluster/taskcluster/tree/main/tools/livelog)",
           "type": "boolean"
         },
         "taskclusterProxy": {
@@ -689,6 +744,27 @@ func taskPayloadSchema() string {
       },
       "required": [],
       "title": "Feature flags",
+      "type": "object"
+    },
+    "logs": {
+      "additionalProperties": false,
+      "description": "Configuration for task logs.\n\nSince: generic-worker 48.2.0",
+      "properties": {
+        "backing": {
+          "default": "public/logs/live_backing.log",
+          "description": "Specifies a custom name for the backing log artifact.\nThis is only used if ` + "`" + `features.backingLog` + "`" + ` is ` + "`" + `true` + "`" + `.\n\nSince: generic-worker 48.2.0",
+          "title": "Backing log artifact name",
+          "type": "string"
+        },
+        "live": {
+          "default": "public/logs/live.log",
+          "description": "Specifies a custom name for the live log artifact.\nThis is only used if ` + "`" + `features.liveLog` + "`" + ` is ` + "`" + `true` + "`" + `.\n\nSince: generic-worker 48.2.0",
+          "title": "Live log artifact name",
+          "type": "string"
+        }
+      },
+      "required": [],
+      "title": "Logs",
       "type": "object"
     },
     "maxRunTime": {

--- a/workers/generic-worker/generated_docker_darwin.go
+++ b/workers/generic-worker/generated_docker_darwin.go
@@ -159,7 +159,7 @@ type (
 		// Since: generic-worker 48.2.0
 		//
 		// Default:    true
-		BackingLog bool `json:"backingLog,omitempty" default:"true"`
+		BackingLog bool `json:"backingLog" default:"true"`
 
 		// Artifacts named `public/chain-of-trust.json` and
 		// `public/chain-of-trust.json.sig` should be generated which will
@@ -175,7 +175,7 @@ type (
 		// Since: generic-worker 48.2.0
 		//
 		// Default:    true
-		LiveLog bool `json:"liveLog,omitempty" default:"true"`
+		LiveLog bool `json:"liveLog" default:"true"`
 
 		// The taskcluster proxy provides an easy and safe way to make authenticated
 		// taskcluster requests within the scope(s) of a particular task. See
@@ -304,7 +304,7 @@ type (
 		// Since: generic-worker 48.2.0
 		//
 		// Default:    "public/logs/live_backing.log"
-		Backing string `json:"backing,omitempty" default:"public/logs/live_backing.log"`
+		Backing string `json:"backing" default:"public/logs/live_backing.log"`
 
 		// Specifies a custom name for the live log artifact.
 		// This is only used if `features.liveLog` is `true`.
@@ -312,7 +312,7 @@ type (
 		// Since: generic-worker 48.2.0
 		//
 		// Default:    "public/logs/live.log"
-		Live string `json:"live,omitempty" default:"public/logs/live.log"`
+		Live string `json:"live" default:"public/logs/live.log"`
 	}
 
 	// Byte-for-byte literal inline content of file/archive, up to 64KB in size.

--- a/workers/generic-worker/generated_docker_linux.go
+++ b/workers/generic-worker/generated_docker_linux.go
@@ -153,6 +153,14 @@ type (
 	// Since: generic-worker 5.3.0
 	FeatureFlags struct {
 
+		// The backing log feature publishes a task artifact containing the complete
+		// stderr and stdout of the task.
+		//
+		// Since: generic-worker 48.2.0
+		//
+		// Default:    true
+		BackingLog bool `json:"backingLog,omitempty" default:"true"`
+
 		// Artifacts named `public/chain-of-trust.json` and
 		// `public/chain-of-trust.json.sig` should be generated which will
 		// include information for downstream tasks to build a level of trust
@@ -160,6 +168,14 @@ type (
 		//
 		// Since: generic-worker 5.3.0
 		ChainOfTrust bool `json:"chainOfTrust,omitempty"`
+
+		// The live log feature streams the combined stderr and stdout to a task artifact
+		// so that the output is available while the task is running.
+		//
+		// Since: generic-worker 48.2.0
+		//
+		// Default:    true
+		LiveLog bool `json:"liveLog,omitempty" default:"true"`
 
 		// The taskcluster proxy provides an easy and safe way to make authenticated
 		// taskcluster requests within the scope(s) of a particular task. See
@@ -234,6 +250,11 @@ type (
 		// Since: generic-worker 5.3.0
 		Features FeatureFlags `json:"features,omitempty"`
 
+		// Configuration for task logs.
+		//
+		// Since: generic-worker 48.2.0
+		Logs Logs `json:"logs,omitempty"`
+
 		// Maximum time the task container can run in seconds.
 		//
 		// Since: generic-worker 0.0.1
@@ -270,6 +291,28 @@ type (
 
 		// This property is allowed for backward compatibility, but is unused.
 		SupersederURL string `json:"supersederUrl,omitempty"`
+	}
+
+	// Configuration for task logs.
+	//
+	// Since: generic-worker 48.2.0
+	Logs struct {
+
+		// Specifies a custom name for the backing log artifact.
+		// This is only used if `features.backingLog` is `true`.
+		//
+		// Since: generic-worker 48.2.0
+		//
+		// Default:    "public/logs/live_backing.log"
+		Backing string `json:"backing,omitempty" default:"public/logs/live_backing.log"`
+
+		// Specifies a custom name for the live log artifact.
+		// This is only used if `features.liveLog` is `true`.
+		//
+		// Since: generic-worker 48.2.0
+		//
+		// Default:    "public/logs/live.log"
+		Live string `json:"live,omitempty" default:"public/logs/live.log"`
 	}
 
 	// Byte-for-byte literal inline content of file/archive, up to 64KB in size.
@@ -676,9 +719,21 @@ func taskPayloadSchema() string {
       "additionalProperties": false,
       "description": "Feature flags enable additional functionality.\n\nSince: generic-worker 5.3.0",
       "properties": {
+        "backingLog": {
+          "default": true,
+          "description": "The backing log feature publishes a task artifact containing the complete\nstderr and stdout of the task.\n\nSince: generic-worker 48.2.0",
+          "title": "Enable backing log",
+          "type": "boolean"
+        },
         "chainOfTrust": {
           "description": "Artifacts named ` + "`" + `public/chain-of-trust.json` + "`" + ` and\n` + "`" + `public/chain-of-trust.json.sig` + "`" + ` should be generated which will\ninclude information for downstream tasks to build a level of trust\nfor the artifacts produced by the task and the environment it ran in.\n\nSince: generic-worker 5.3.0",
           "title": "Enable generation of signed Chain of Trust artifacts",
+          "type": "boolean"
+        },
+        "liveLog": {
+          "default": true,
+          "description": "The live log feature streams the combined stderr and stdout to a task artifact\nso that the output is available while the task is running.\n\nSince: generic-worker 48.2.0",
+          "title": "Enable [livelog](https://github.com/taskcluster/taskcluster/tree/main/tools/livelog)",
           "type": "boolean"
         },
         "taskclusterProxy": {
@@ -689,6 +744,27 @@ func taskPayloadSchema() string {
       },
       "required": [],
       "title": "Feature flags",
+      "type": "object"
+    },
+    "logs": {
+      "additionalProperties": false,
+      "description": "Configuration for task logs.\n\nSince: generic-worker 48.2.0",
+      "properties": {
+        "backing": {
+          "default": "public/logs/live_backing.log",
+          "description": "Specifies a custom name for the backing log artifact.\nThis is only used if ` + "`" + `features.backingLog` + "`" + ` is ` + "`" + `true` + "`" + `.\n\nSince: generic-worker 48.2.0",
+          "title": "Backing log artifact name",
+          "type": "string"
+        },
+        "live": {
+          "default": "public/logs/live.log",
+          "description": "Specifies a custom name for the live log artifact.\nThis is only used if ` + "`" + `features.liveLog` + "`" + ` is ` + "`" + `true` + "`" + `.\n\nSince: generic-worker 48.2.0",
+          "title": "Live log artifact name",
+          "type": "string"
+        }
+      },
+      "required": [],
+      "title": "Logs",
       "type": "object"
     },
     "maxRunTime": {

--- a/workers/generic-worker/generated_docker_linux.go
+++ b/workers/generic-worker/generated_docker_linux.go
@@ -159,7 +159,7 @@ type (
 		// Since: generic-worker 48.2.0
 		//
 		// Default:    true
-		BackingLog bool `json:"backingLog,omitempty" default:"true"`
+		BackingLog bool `json:"backingLog" default:"true"`
 
 		// Artifacts named `public/chain-of-trust.json` and
 		// `public/chain-of-trust.json.sig` should be generated which will
@@ -175,7 +175,7 @@ type (
 		// Since: generic-worker 48.2.0
 		//
 		// Default:    true
-		LiveLog bool `json:"liveLog,omitempty" default:"true"`
+		LiveLog bool `json:"liveLog" default:"true"`
 
 		// The taskcluster proxy provides an easy and safe way to make authenticated
 		// taskcluster requests within the scope(s) of a particular task. See
@@ -304,7 +304,7 @@ type (
 		// Since: generic-worker 48.2.0
 		//
 		// Default:    "public/logs/live_backing.log"
-		Backing string `json:"backing,omitempty" default:"public/logs/live_backing.log"`
+		Backing string `json:"backing" default:"public/logs/live_backing.log"`
 
 		// Specifies a custom name for the live log artifact.
 		// This is only used if `features.liveLog` is `true`.
@@ -312,7 +312,7 @@ type (
 		// Since: generic-worker 48.2.0
 		//
 		// Default:    "public/logs/live.log"
-		Live string `json:"live,omitempty" default:"public/logs/live.log"`
+		Live string `json:"live" default:"public/logs/live.log"`
 	}
 
 	// Byte-for-byte literal inline content of file/archive, up to 64KB in size.

--- a/workers/generic-worker/generated_multiuser_darwin.go
+++ b/workers/generic-worker/generated_multiuser_darwin.go
@@ -153,6 +153,14 @@ type (
 	// Since: generic-worker 5.3.0
 	FeatureFlags struct {
 
+		// The backing log feature publishes a task artifact containing the complete
+		// stderr and stdout of the task.
+		//
+		// Since: generic-worker 48.2.0
+		//
+		// Default:    true
+		BackingLog bool `json:"backingLog,omitempty" default:"true"`
+
 		// Artifacts named `public/chain-of-trust.json` and
 		// `public/chain-of-trust.json.sig` should be generated which will
 		// include information for downstream tasks to build a level of trust
@@ -160,6 +168,14 @@ type (
 		//
 		// Since: generic-worker 5.3.0
 		ChainOfTrust bool `json:"chainOfTrust,omitempty"`
+
+		// The live log feature streams the combined stderr and stdout to a task artifact
+		// so that the output is available while the task is running.
+		//
+		// Since: generic-worker 48.2.0
+		//
+		// Default:    true
+		LiveLog bool `json:"liveLog,omitempty" default:"true"`
 
 		// The taskcluster proxy provides an easy and safe way to make authenticated
 		// taskcluster requests within the scope(s) of a particular task. See
@@ -246,6 +262,11 @@ type (
 		// Since: generic-worker 5.3.0
 		Features FeatureFlags `json:"features,omitempty"`
 
+		// Configuration for task logs.
+		//
+		// Since: generic-worker 48.2.0
+		Logs Logs `json:"logs,omitempty"`
+
 		// Maximum time the task container can run in seconds.
 		//
 		// Since: generic-worker 0.0.1
@@ -282,6 +303,28 @@ type (
 
 		// This property is allowed for backward compatibility, but is unused.
 		SupersederURL string `json:"supersederUrl,omitempty"`
+	}
+
+	// Configuration for task logs.
+	//
+	// Since: generic-worker 48.2.0
+	Logs struct {
+
+		// Specifies a custom name for the backing log artifact.
+		// This is only used if `features.backingLog` is `true`.
+		//
+		// Since: generic-worker 48.2.0
+		//
+		// Default:    "public/logs/live_backing.log"
+		Backing string `json:"backing,omitempty" default:"public/logs/live_backing.log"`
+
+		// Specifies a custom name for the live log artifact.
+		// This is only used if `features.liveLog` is `true`.
+		//
+		// Since: generic-worker 48.2.0
+		//
+		// Default:    "public/logs/live.log"
+		Live string `json:"live,omitempty" default:"public/logs/live.log"`
 	}
 
 	// Byte-for-byte literal inline content of file/archive, up to 64KB in size.
@@ -688,9 +731,21 @@ func taskPayloadSchema() string {
       "additionalProperties": false,
       "description": "Feature flags enable additional functionality.\n\nSince: generic-worker 5.3.0",
       "properties": {
+        "backingLog": {
+          "default": true,
+          "description": "The backing log feature publishes a task artifact containing the complete\nstderr and stdout of the task.\n\nSince: generic-worker 48.2.0",
+          "title": "Enable backing log",
+          "type": "boolean"
+        },
         "chainOfTrust": {
           "description": "Artifacts named ` + "`" + `public/chain-of-trust.json` + "`" + ` and\n` + "`" + `public/chain-of-trust.json.sig` + "`" + ` should be generated which will\ninclude information for downstream tasks to build a level of trust\nfor the artifacts produced by the task and the environment it ran in.\n\nSince: generic-worker 5.3.0",
           "title": "Enable generation of signed Chain of Trust artifacts",
+          "type": "boolean"
+        },
+        "liveLog": {
+          "default": true,
+          "description": "The live log feature streams the combined stderr and stdout to a task artifact\nso that the output is available while the task is running.\n\nSince: generic-worker 48.2.0",
+          "title": "Enable [livelog](https://github.com/taskcluster/taskcluster/tree/main/tools/livelog)",
           "type": "boolean"
         },
         "taskclusterProxy": {
@@ -701,6 +756,27 @@ func taskPayloadSchema() string {
       },
       "required": [],
       "title": "Feature flags",
+      "type": "object"
+    },
+    "logs": {
+      "additionalProperties": false,
+      "description": "Configuration for task logs.\n\nSince: generic-worker 48.2.0",
+      "properties": {
+        "backing": {
+          "default": "public/logs/live_backing.log",
+          "description": "Specifies a custom name for the backing log artifact.\nThis is only used if ` + "`" + `features.backingLog` + "`" + ` is ` + "`" + `true` + "`" + `.\n\nSince: generic-worker 48.2.0",
+          "title": "Backing log artifact name",
+          "type": "string"
+        },
+        "live": {
+          "default": "public/logs/live.log",
+          "description": "Specifies a custom name for the live log artifact.\nThis is only used if ` + "`" + `features.liveLog` + "`" + ` is ` + "`" + `true` + "`" + `.\n\nSince: generic-worker 48.2.0",
+          "title": "Live log artifact name",
+          "type": "string"
+        }
+      },
+      "required": [],
+      "title": "Logs",
       "type": "object"
     },
     "maxRunTime": {

--- a/workers/generic-worker/generated_multiuser_darwin.go
+++ b/workers/generic-worker/generated_multiuser_darwin.go
@@ -159,7 +159,7 @@ type (
 		// Since: generic-worker 48.2.0
 		//
 		// Default:    true
-		BackingLog bool `json:"backingLog,omitempty" default:"true"`
+		BackingLog bool `json:"backingLog" default:"true"`
 
 		// Artifacts named `public/chain-of-trust.json` and
 		// `public/chain-of-trust.json.sig` should be generated which will
@@ -175,7 +175,7 @@ type (
 		// Since: generic-worker 48.2.0
 		//
 		// Default:    true
-		LiveLog bool `json:"liveLog,omitempty" default:"true"`
+		LiveLog bool `json:"liveLog" default:"true"`
 
 		// The taskcluster proxy provides an easy and safe way to make authenticated
 		// taskcluster requests within the scope(s) of a particular task. See
@@ -316,7 +316,7 @@ type (
 		// Since: generic-worker 48.2.0
 		//
 		// Default:    "public/logs/live_backing.log"
-		Backing string `json:"backing,omitempty" default:"public/logs/live_backing.log"`
+		Backing string `json:"backing" default:"public/logs/live_backing.log"`
 
 		// Specifies a custom name for the live log artifact.
 		// This is only used if `features.liveLog` is `true`.
@@ -324,7 +324,7 @@ type (
 		// Since: generic-worker 48.2.0
 		//
 		// Default:    "public/logs/live.log"
-		Live string `json:"live,omitempty" default:"public/logs/live.log"`
+		Live string `json:"live" default:"public/logs/live.log"`
 	}
 
 	// Byte-for-byte literal inline content of file/archive, up to 64KB in size.

--- a/workers/generic-worker/generated_multiuser_linux.go
+++ b/workers/generic-worker/generated_multiuser_linux.go
@@ -153,6 +153,14 @@ type (
 	// Since: generic-worker 5.3.0
 	FeatureFlags struct {
 
+		// The backing log feature publishes a task artifact containing the complete
+		// stderr and stdout of the task.
+		//
+		// Since: generic-worker 48.2.0
+		//
+		// Default:    true
+		BackingLog bool `json:"backingLog,omitempty" default:"true"`
+
 		// Artifacts named `public/chain-of-trust.json` and
 		// `public/chain-of-trust.json.sig` should be generated which will
 		// include information for downstream tasks to build a level of trust
@@ -160,6 +168,14 @@ type (
 		//
 		// Since: generic-worker 5.3.0
 		ChainOfTrust bool `json:"chainOfTrust,omitempty"`
+
+		// The live log feature streams the combined stderr and stdout to a task artifact
+		// so that the output is available while the task is running.
+		//
+		// Since: generic-worker 48.2.0
+		//
+		// Default:    true
+		LiveLog bool `json:"liveLog,omitempty" default:"true"`
 
 		// The taskcluster proxy provides an easy and safe way to make authenticated
 		// taskcluster requests within the scope(s) of a particular task. See
@@ -246,6 +262,11 @@ type (
 		// Since: generic-worker 5.3.0
 		Features FeatureFlags `json:"features,omitempty"`
 
+		// Configuration for task logs.
+		//
+		// Since: generic-worker 48.2.0
+		Logs Logs `json:"logs,omitempty"`
+
 		// Maximum time the task container can run in seconds.
 		//
 		// Since: generic-worker 0.0.1
@@ -282,6 +303,28 @@ type (
 
 		// This property is allowed for backward compatibility, but is unused.
 		SupersederURL string `json:"supersederUrl,omitempty"`
+	}
+
+	// Configuration for task logs.
+	//
+	// Since: generic-worker 48.2.0
+	Logs struct {
+
+		// Specifies a custom name for the backing log artifact.
+		// This is only used if `features.backingLog` is `true`.
+		//
+		// Since: generic-worker 48.2.0
+		//
+		// Default:    "public/logs/live_backing.log"
+		Backing string `json:"backing,omitempty" default:"public/logs/live_backing.log"`
+
+		// Specifies a custom name for the live log artifact.
+		// This is only used if `features.liveLog` is `true`.
+		//
+		// Since: generic-worker 48.2.0
+		//
+		// Default:    "public/logs/live.log"
+		Live string `json:"live,omitempty" default:"public/logs/live.log"`
 	}
 
 	// Byte-for-byte literal inline content of file/archive, up to 64KB in size.
@@ -688,9 +731,21 @@ func taskPayloadSchema() string {
       "additionalProperties": false,
       "description": "Feature flags enable additional functionality.\n\nSince: generic-worker 5.3.0",
       "properties": {
+        "backingLog": {
+          "default": true,
+          "description": "The backing log feature publishes a task artifact containing the complete\nstderr and stdout of the task.\n\nSince: generic-worker 48.2.0",
+          "title": "Enable backing log",
+          "type": "boolean"
+        },
         "chainOfTrust": {
           "description": "Artifacts named ` + "`" + `public/chain-of-trust.json` + "`" + ` and\n` + "`" + `public/chain-of-trust.json.sig` + "`" + ` should be generated which will\ninclude information for downstream tasks to build a level of trust\nfor the artifacts produced by the task and the environment it ran in.\n\nSince: generic-worker 5.3.0",
           "title": "Enable generation of signed Chain of Trust artifacts",
+          "type": "boolean"
+        },
+        "liveLog": {
+          "default": true,
+          "description": "The live log feature streams the combined stderr and stdout to a task artifact\nso that the output is available while the task is running.\n\nSince: generic-worker 48.2.0",
+          "title": "Enable [livelog](https://github.com/taskcluster/taskcluster/tree/main/tools/livelog)",
           "type": "boolean"
         },
         "taskclusterProxy": {
@@ -701,6 +756,27 @@ func taskPayloadSchema() string {
       },
       "required": [],
       "title": "Feature flags",
+      "type": "object"
+    },
+    "logs": {
+      "additionalProperties": false,
+      "description": "Configuration for task logs.\n\nSince: generic-worker 48.2.0",
+      "properties": {
+        "backing": {
+          "default": "public/logs/live_backing.log",
+          "description": "Specifies a custom name for the backing log artifact.\nThis is only used if ` + "`" + `features.backingLog` + "`" + ` is ` + "`" + `true` + "`" + `.\n\nSince: generic-worker 48.2.0",
+          "title": "Backing log artifact name",
+          "type": "string"
+        },
+        "live": {
+          "default": "public/logs/live.log",
+          "description": "Specifies a custom name for the live log artifact.\nThis is only used if ` + "`" + `features.liveLog` + "`" + ` is ` + "`" + `true` + "`" + `.\n\nSince: generic-worker 48.2.0",
+          "title": "Live log artifact name",
+          "type": "string"
+        }
+      },
+      "required": [],
+      "title": "Logs",
       "type": "object"
     },
     "maxRunTime": {

--- a/workers/generic-worker/generated_multiuser_linux.go
+++ b/workers/generic-worker/generated_multiuser_linux.go
@@ -159,7 +159,7 @@ type (
 		// Since: generic-worker 48.2.0
 		//
 		// Default:    true
-		BackingLog bool `json:"backingLog,omitempty" default:"true"`
+		BackingLog bool `json:"backingLog" default:"true"`
 
 		// Artifacts named `public/chain-of-trust.json` and
 		// `public/chain-of-trust.json.sig` should be generated which will
@@ -175,7 +175,7 @@ type (
 		// Since: generic-worker 48.2.0
 		//
 		// Default:    true
-		LiveLog bool `json:"liveLog,omitempty" default:"true"`
+		LiveLog bool `json:"liveLog" default:"true"`
 
 		// The taskcluster proxy provides an easy and safe way to make authenticated
 		// taskcluster requests within the scope(s) of a particular task. See
@@ -316,7 +316,7 @@ type (
 		// Since: generic-worker 48.2.0
 		//
 		// Default:    "public/logs/live_backing.log"
-		Backing string `json:"backing,omitempty" default:"public/logs/live_backing.log"`
+		Backing string `json:"backing" default:"public/logs/live_backing.log"`
 
 		// Specifies a custom name for the live log artifact.
 		// This is only used if `features.liveLog` is `true`.
@@ -324,7 +324,7 @@ type (
 		// Since: generic-worker 48.2.0
 		//
 		// Default:    "public/logs/live.log"
-		Live string `json:"live,omitempty" default:"public/logs/live.log"`
+		Live string `json:"live" default:"public/logs/live.log"`
 	}
 
 	// Byte-for-byte literal inline content of file/archive, up to 64KB in size.

--- a/workers/generic-worker/generated_multiuser_windows.go
+++ b/workers/generic-worker/generated_multiuser_windows.go
@@ -152,6 +152,14 @@ type (
 	// Since: generic-worker 5.3.0
 	FeatureFlags struct {
 
+		// The backing log feature publishes a task artifact containing the complete
+		// stderr and stdout of the task.
+		//
+		// Since: generic-worker 48.2.0
+		//
+		// Default:    true
+		BackingLog bool `json:"backingLog,omitempty" default:"true"`
+
 		// Artifacts named `public/chain-of-trust.json` and
 		// `public/chain-of-trust.json.sig` should be generated which will
 		// include information for downstream tasks to build a level of trust
@@ -159,6 +167,14 @@ type (
 		//
 		// Since: generic-worker 5.3.0
 		ChainOfTrust bool `json:"chainOfTrust,omitempty"`
+
+		// The live log feature streams the combined stderr and stdout to a task artifact
+		// so that the output is available while the task is running.
+		//
+		// Since: generic-worker 48.2.0
+		//
+		// Default:    true
+		LiveLog bool `json:"liveLog,omitempty" default:"true"`
 
 		// Runs commands with UAC elevation. Only set to true when UAC is
 		// enabled on the worker and Administrative privileges are required by
@@ -264,6 +280,11 @@ type (
 		// Since: generic-worker 5.3.0
 		Features FeatureFlags `json:"features,omitempty"`
 
+		// Configuration for task logs.
+		//
+		// Since: generic-worker 48.2.0
+		Logs Logs `json:"logs,omitempty"`
+
 		// Maximum time the task container can run in seconds.
 		//
 		// Since: generic-worker 0.0.1
@@ -328,6 +349,28 @@ type (
 
 		// This property is allowed for backward compatibility, but is unused.
 		SupersederURL string `json:"supersederUrl,omitempty"`
+	}
+
+	// Configuration for task logs.
+	//
+	// Since: generic-worker 48.2.0
+	Logs struct {
+
+		// Specifies a custom name for the backing log artifact.
+		// This is only used if `features.backingLog` is `true`.
+		//
+		// Since: generic-worker 48.2.0
+		//
+		// Default:    "public/logs/live_backing.log"
+		Backing string `json:"backing,omitempty" default:"public/logs/live_backing.log"`
+
+		// Specifies a custom name for the live log artifact.
+		// This is only used if `features.liveLog` is `true`.
+		//
+		// Since: generic-worker 48.2.0
+		//
+		// Default:    "public/logs/live.log"
+		Live string `json:"live,omitempty" default:"public/logs/live.log"`
 	}
 
 	// Byte-for-byte literal inline content of file/archive, up to 64KB in size.
@@ -729,9 +772,21 @@ func taskPayloadSchema() string {
       "additionalProperties": false,
       "description": "Feature flags enable additional functionality.\n\nSince: generic-worker 5.3.0",
       "properties": {
+        "backingLog": {
+          "default": true,
+          "description": "The backing log feature publishes a task artifact containing the complete\nstderr and stdout of the task.\n\nSince: generic-worker 48.2.0",
+          "title": "Enable backing log",
+          "type": "boolean"
+        },
         "chainOfTrust": {
           "description": "Artifacts named ` + "`" + `public/chain-of-trust.json` + "`" + ` and\n` + "`" + `public/chain-of-trust.json.sig` + "`" + ` should be generated which will\ninclude information for downstream tasks to build a level of trust\nfor the artifacts produced by the task and the environment it ran in.\n\nSince: generic-worker 5.3.0",
           "title": "Enable generation of signed Chain of Trust artifacts",
+          "type": "boolean"
+        },
+        "liveLog": {
+          "default": true,
+          "description": "The live log feature streams the combined stderr and stdout to a task artifact\nso that the output is available while the task is running.\n\nSince: generic-worker 48.2.0",
+          "title": "Enable [livelog](https://github.com/taskcluster/taskcluster/tree/main/tools/livelog)",
           "type": "boolean"
         },
         "runAsAdministrator": {
@@ -747,6 +802,27 @@ func taskPayloadSchema() string {
       },
       "required": [],
       "title": "Feature flags",
+      "type": "object"
+    },
+    "logs": {
+      "additionalProperties": false,
+      "description": "Configuration for task logs.\n\nSince: generic-worker 48.2.0",
+      "properties": {
+        "backing": {
+          "default": "public/logs/live_backing.log",
+          "description": "Specifies a custom name for the backing log artifact.\nThis is only used if ` + "`" + `features.backingLog` + "`" + ` is ` + "`" + `true` + "`" + `.\n\nSince: generic-worker 48.2.0",
+          "title": "Backing log artifact name",
+          "type": "string"
+        },
+        "live": {
+          "default": "public/logs/live.log",
+          "description": "Specifies a custom name for the live log artifact.\nThis is only used if ` + "`" + `features.liveLog` + "`" + ` is ` + "`" + `true` + "`" + `.\n\nSince: generic-worker 48.2.0",
+          "title": "Live log artifact name",
+          "type": "string"
+        }
+      },
+      "required": [],
+      "title": "Logs",
       "type": "object"
     },
     "maxRunTime": {

--- a/workers/generic-worker/generated_multiuser_windows.go
+++ b/workers/generic-worker/generated_multiuser_windows.go
@@ -158,7 +158,7 @@ type (
 		// Since: generic-worker 48.2.0
 		//
 		// Default:    true
-		BackingLog bool `json:"backingLog,omitempty" default:"true"`
+		BackingLog bool `json:"backingLog" default:"true"`
 
 		// Artifacts named `public/chain-of-trust.json` and
 		// `public/chain-of-trust.json.sig` should be generated which will
@@ -174,7 +174,7 @@ type (
 		// Since: generic-worker 48.2.0
 		//
 		// Default:    true
-		LiveLog bool `json:"liveLog,omitempty" default:"true"`
+		LiveLog bool `json:"liveLog" default:"true"`
 
 		// Runs commands with UAC elevation. Only set to true when UAC is
 		// enabled on the worker and Administrative privileges are required by
@@ -362,7 +362,7 @@ type (
 		// Since: generic-worker 48.2.0
 		//
 		// Default:    "public/logs/live_backing.log"
-		Backing string `json:"backing,omitempty" default:"public/logs/live_backing.log"`
+		Backing string `json:"backing" default:"public/logs/live_backing.log"`
 
 		// Specifies a custom name for the live log artifact.
 		// This is only used if `features.liveLog` is `true`.
@@ -370,7 +370,7 @@ type (
 		// Since: generic-worker 48.2.0
 		//
 		// Default:    "public/logs/live.log"
-		Live string `json:"live,omitempty" default:"public/logs/live.log"`
+		Live string `json:"live" default:"public/logs/live.log"`
 	}
 
 	// Byte-for-byte literal inline content of file/archive, up to 64KB in size.

--- a/workers/generic-worker/generated_simple_darwin.go
+++ b/workers/generic-worker/generated_simple_darwin.go
@@ -159,7 +159,7 @@ type (
 		// Since: generic-worker 48.2.0
 		//
 		// Default:    true
-		BackingLog bool `json:"backingLog,omitempty" default:"true"`
+		BackingLog bool `json:"backingLog" default:"true"`
 
 		// The live log feature streams the combined stderr and stdout to a task artifact
 		// so that the output is available while the task is running.
@@ -167,7 +167,7 @@ type (
 		// Since: generic-worker 48.2.0
 		//
 		// Default:    true
-		LiveLog bool `json:"liveLog,omitempty" default:"true"`
+		LiveLog bool `json:"liveLog" default:"true"`
 
 		// The taskcluster proxy provides an easy and safe way to make authenticated
 		// taskcluster requests within the scope(s) of a particular task. See
@@ -296,7 +296,7 @@ type (
 		// Since: generic-worker 48.2.0
 		//
 		// Default:    "public/logs/live_backing.log"
-		Backing string `json:"backing,omitempty" default:"public/logs/live_backing.log"`
+		Backing string `json:"backing" default:"public/logs/live_backing.log"`
 
 		// Specifies a custom name for the live log artifact.
 		// This is only used if `features.liveLog` is `true`.
@@ -304,7 +304,7 @@ type (
 		// Since: generic-worker 48.2.0
 		//
 		// Default:    "public/logs/live.log"
-		Live string `json:"live,omitempty" default:"public/logs/live.log"`
+		Live string `json:"live" default:"public/logs/live.log"`
 	}
 
 	// Byte-for-byte literal inline content of file/archive, up to 64KB in size.

--- a/workers/generic-worker/generated_simple_darwin.go
+++ b/workers/generic-worker/generated_simple_darwin.go
@@ -153,6 +153,22 @@ type (
 	// Since: generic-worker 5.3.0
 	FeatureFlags struct {
 
+		// The backing log feature publishes a task artifact containing the complete
+		// stderr and stdout of the task.
+		//
+		// Since: generic-worker 48.2.0
+		//
+		// Default:    true
+		BackingLog bool `json:"backingLog,omitempty" default:"true"`
+
+		// The live log feature streams the combined stderr and stdout to a task artifact
+		// so that the output is available while the task is running.
+		//
+		// Since: generic-worker 48.2.0
+		//
+		// Default:    true
+		LiveLog bool `json:"liveLog,omitempty" default:"true"`
+
 		// The taskcluster proxy provides an easy and safe way to make authenticated
 		// taskcluster requests within the scope(s) of a particular task. See
 		// [the github project](https://github.com/taskcluster/taskcluster/tree/main/tools/taskcluster-proxy) for more information.
@@ -226,6 +242,11 @@ type (
 		// Since: generic-worker 5.3.0
 		Features FeatureFlags `json:"features,omitempty"`
 
+		// Configuration for task logs.
+		//
+		// Since: generic-worker 48.2.0
+		Logs Logs `json:"logs,omitempty"`
+
 		// Maximum time the task container can run in seconds.
 		//
 		// Since: generic-worker 0.0.1
@@ -262,6 +283,28 @@ type (
 
 		// This property is allowed for backward compatibility, but is unused.
 		SupersederURL string `json:"supersederUrl,omitempty"`
+	}
+
+	// Configuration for task logs.
+	//
+	// Since: generic-worker 48.2.0
+	Logs struct {
+
+		// Specifies a custom name for the backing log artifact.
+		// This is only used if `features.backingLog` is `true`.
+		//
+		// Since: generic-worker 48.2.0
+		//
+		// Default:    "public/logs/live_backing.log"
+		Backing string `json:"backing,omitempty" default:"public/logs/live_backing.log"`
+
+		// Specifies a custom name for the live log artifact.
+		// This is only used if `features.liveLog` is `true`.
+		//
+		// Since: generic-worker 48.2.0
+		//
+		// Default:    "public/logs/live.log"
+		Live string `json:"live,omitempty" default:"public/logs/live.log"`
 	}
 
 	// Byte-for-byte literal inline content of file/archive, up to 64KB in size.
@@ -668,6 +711,18 @@ func taskPayloadSchema() string {
       "additionalProperties": false,
       "description": "Feature flags enable additional functionality.\n\nSince: generic-worker 5.3.0",
       "properties": {
+        "backingLog": {
+          "default": true,
+          "description": "The backing log feature publishes a task artifact containing the complete\nstderr and stdout of the task.\n\nSince: generic-worker 48.2.0",
+          "title": "Enable backing log",
+          "type": "boolean"
+        },
+        "liveLog": {
+          "default": true,
+          "description": "The live log feature streams the combined stderr and stdout to a task artifact\nso that the output is available while the task is running.\n\nSince: generic-worker 48.2.0",
+          "title": "Enable [livelog](https://github.com/taskcluster/taskcluster/tree/main/tools/livelog)",
+          "type": "boolean"
+        },
         "taskclusterProxy": {
           "description": "The taskcluster proxy provides an easy and safe way to make authenticated\ntaskcluster requests within the scope(s) of a particular task. See\n[the github project](https://github.com/taskcluster/taskcluster/tree/main/tools/taskcluster-proxy) for more information.\n\nSince: generic-worker 10.6.0",
           "title": "Run [taskcluster-proxy](https://github.com/taskcluster/taskcluster/tree/main/tools/taskcluster-proxy) to allow tasks to dynamically proxy requests to taskcluster services",
@@ -676,6 +731,27 @@ func taskPayloadSchema() string {
       },
       "required": [],
       "title": "Feature flags",
+      "type": "object"
+    },
+    "logs": {
+      "additionalProperties": false,
+      "description": "Configuration for task logs.\n\nSince: generic-worker 48.2.0",
+      "properties": {
+        "backing": {
+          "default": "public/logs/live_backing.log",
+          "description": "Specifies a custom name for the backing log artifact.\nThis is only used if ` + "`" + `features.backingLog` + "`" + ` is ` + "`" + `true` + "`" + `.\n\nSince: generic-worker 48.2.0",
+          "title": "Backing log artifact name",
+          "type": "string"
+        },
+        "live": {
+          "default": "public/logs/live.log",
+          "description": "Specifies a custom name for the live log artifact.\nThis is only used if ` + "`" + `features.liveLog` + "`" + ` is ` + "`" + `true` + "`" + `.\n\nSince: generic-worker 48.2.0",
+          "title": "Live log artifact name",
+          "type": "string"
+        }
+      },
+      "required": [],
+      "title": "Logs",
       "type": "object"
     },
     "maxRunTime": {

--- a/workers/generic-worker/generated_simple_freebsd.go
+++ b/workers/generic-worker/generated_simple_freebsd.go
@@ -159,7 +159,7 @@ type (
 		// Since: generic-worker 48.2.0
 		//
 		// Default:    true
-		BackingLog bool `json:"backingLog,omitempty" default:"true"`
+		BackingLog bool `json:"backingLog" default:"true"`
 
 		// The live log feature streams the combined stderr and stdout to a task artifact
 		// so that the output is available while the task is running.
@@ -167,7 +167,7 @@ type (
 		// Since: generic-worker 48.2.0
 		//
 		// Default:    true
-		LiveLog bool `json:"liveLog,omitempty" default:"true"`
+		LiveLog bool `json:"liveLog" default:"true"`
 
 		// The taskcluster proxy provides an easy and safe way to make authenticated
 		// taskcluster requests within the scope(s) of a particular task. See
@@ -296,7 +296,7 @@ type (
 		// Since: generic-worker 48.2.0
 		//
 		// Default:    "public/logs/live_backing.log"
-		Backing string `json:"backing,omitempty" default:"public/logs/live_backing.log"`
+		Backing string `json:"backing" default:"public/logs/live_backing.log"`
 
 		// Specifies a custom name for the live log artifact.
 		// This is only used if `features.liveLog` is `true`.
@@ -304,7 +304,7 @@ type (
 		// Since: generic-worker 48.2.0
 		//
 		// Default:    "public/logs/live.log"
-		Live string `json:"live,omitempty" default:"public/logs/live.log"`
+		Live string `json:"live" default:"public/logs/live.log"`
 	}
 
 	// Byte-for-byte literal inline content of file/archive, up to 64KB in size.

--- a/workers/generic-worker/generated_simple_freebsd.go
+++ b/workers/generic-worker/generated_simple_freebsd.go
@@ -153,6 +153,22 @@ type (
 	// Since: generic-worker 5.3.0
 	FeatureFlags struct {
 
+		// The backing log feature publishes a task artifact containing the complete
+		// stderr and stdout of the task.
+		//
+		// Since: generic-worker 48.2.0
+		//
+		// Default:    true
+		BackingLog bool `json:"backingLog,omitempty" default:"true"`
+
+		// The live log feature streams the combined stderr and stdout to a task artifact
+		// so that the output is available while the task is running.
+		//
+		// Since: generic-worker 48.2.0
+		//
+		// Default:    true
+		LiveLog bool `json:"liveLog,omitempty" default:"true"`
+
 		// The taskcluster proxy provides an easy and safe way to make authenticated
 		// taskcluster requests within the scope(s) of a particular task. See
 		// [the github project](https://github.com/taskcluster/taskcluster/tree/main/tools/taskcluster-proxy) for more information.
@@ -226,6 +242,11 @@ type (
 		// Since: generic-worker 5.3.0
 		Features FeatureFlags `json:"features,omitempty"`
 
+		// Configuration for task logs.
+		//
+		// Since: generic-worker 48.2.0
+		Logs Logs `json:"logs,omitempty"`
+
 		// Maximum time the task container can run in seconds.
 		//
 		// Since: generic-worker 0.0.1
@@ -262,6 +283,28 @@ type (
 
 		// This property is allowed for backward compatibility, but is unused.
 		SupersederURL string `json:"supersederUrl,omitempty"`
+	}
+
+	// Configuration for task logs.
+	//
+	// Since: generic-worker 48.2.0
+	Logs struct {
+
+		// Specifies a custom name for the backing log artifact.
+		// This is only used if `features.backingLog` is `true`.
+		//
+		// Since: generic-worker 48.2.0
+		//
+		// Default:    "public/logs/live_backing.log"
+		Backing string `json:"backing,omitempty" default:"public/logs/live_backing.log"`
+
+		// Specifies a custom name for the live log artifact.
+		// This is only used if `features.liveLog` is `true`.
+		//
+		// Since: generic-worker 48.2.0
+		//
+		// Default:    "public/logs/live.log"
+		Live string `json:"live,omitempty" default:"public/logs/live.log"`
 	}
 
 	// Byte-for-byte literal inline content of file/archive, up to 64KB in size.
@@ -668,6 +711,18 @@ func taskPayloadSchema() string {
       "additionalProperties": false,
       "description": "Feature flags enable additional functionality.\n\nSince: generic-worker 5.3.0",
       "properties": {
+        "backingLog": {
+          "default": true,
+          "description": "The backing log feature publishes a task artifact containing the complete\nstderr and stdout of the task.\n\nSince: generic-worker 48.2.0",
+          "title": "Enable backing log",
+          "type": "boolean"
+        },
+        "liveLog": {
+          "default": true,
+          "description": "The live log feature streams the combined stderr and stdout to a task artifact\nso that the output is available while the task is running.\n\nSince: generic-worker 48.2.0",
+          "title": "Enable [livelog](https://github.com/taskcluster/taskcluster/tree/main/tools/livelog)",
+          "type": "boolean"
+        },
         "taskclusterProxy": {
           "description": "The taskcluster proxy provides an easy and safe way to make authenticated\ntaskcluster requests within the scope(s) of a particular task. See\n[the github project](https://github.com/taskcluster/taskcluster/tree/main/tools/taskcluster-proxy) for more information.\n\nSince: generic-worker 10.6.0",
           "title": "Run [taskcluster-proxy](https://github.com/taskcluster/taskcluster/tree/main/tools/taskcluster-proxy) to allow tasks to dynamically proxy requests to taskcluster services",
@@ -676,6 +731,27 @@ func taskPayloadSchema() string {
       },
       "required": [],
       "title": "Feature flags",
+      "type": "object"
+    },
+    "logs": {
+      "additionalProperties": false,
+      "description": "Configuration for task logs.\n\nSince: generic-worker 48.2.0",
+      "properties": {
+        "backing": {
+          "default": "public/logs/live_backing.log",
+          "description": "Specifies a custom name for the backing log artifact.\nThis is only used if ` + "`" + `features.backingLog` + "`" + ` is ` + "`" + `true` + "`" + `.\n\nSince: generic-worker 48.2.0",
+          "title": "Backing log artifact name",
+          "type": "string"
+        },
+        "live": {
+          "default": "public/logs/live.log",
+          "description": "Specifies a custom name for the live log artifact.\nThis is only used if ` + "`" + `features.liveLog` + "`" + ` is ` + "`" + `true` + "`" + `.\n\nSince: generic-worker 48.2.0",
+          "title": "Live log artifact name",
+          "type": "string"
+        }
+      },
+      "required": [],
+      "title": "Logs",
       "type": "object"
     },
     "maxRunTime": {

--- a/workers/generic-worker/generated_simple_linux.go
+++ b/workers/generic-worker/generated_simple_linux.go
@@ -159,7 +159,7 @@ type (
 		// Since: generic-worker 48.2.0
 		//
 		// Default:    true
-		BackingLog bool `json:"backingLog,omitempty" default:"true"`
+		BackingLog bool `json:"backingLog" default:"true"`
 
 		// The live log feature streams the combined stderr and stdout to a task artifact
 		// so that the output is available while the task is running.
@@ -167,7 +167,7 @@ type (
 		// Since: generic-worker 48.2.0
 		//
 		// Default:    true
-		LiveLog bool `json:"liveLog,omitempty" default:"true"`
+		LiveLog bool `json:"liveLog" default:"true"`
 
 		// The taskcluster proxy provides an easy and safe way to make authenticated
 		// taskcluster requests within the scope(s) of a particular task. See
@@ -296,7 +296,7 @@ type (
 		// Since: generic-worker 48.2.0
 		//
 		// Default:    "public/logs/live_backing.log"
-		Backing string `json:"backing,omitempty" default:"public/logs/live_backing.log"`
+		Backing string `json:"backing" default:"public/logs/live_backing.log"`
 
 		// Specifies a custom name for the live log artifact.
 		// This is only used if `features.liveLog` is `true`.
@@ -304,7 +304,7 @@ type (
 		// Since: generic-worker 48.2.0
 		//
 		// Default:    "public/logs/live.log"
-		Live string `json:"live,omitempty" default:"public/logs/live.log"`
+		Live string `json:"live" default:"public/logs/live.log"`
 	}
 
 	// Byte-for-byte literal inline content of file/archive, up to 64KB in size.

--- a/workers/generic-worker/generated_simple_linux.go
+++ b/workers/generic-worker/generated_simple_linux.go
@@ -153,6 +153,22 @@ type (
 	// Since: generic-worker 5.3.0
 	FeatureFlags struct {
 
+		// The backing log feature publishes a task artifact containing the complete
+		// stderr and stdout of the task.
+		//
+		// Since: generic-worker 48.2.0
+		//
+		// Default:    true
+		BackingLog bool `json:"backingLog,omitempty" default:"true"`
+
+		// The live log feature streams the combined stderr and stdout to a task artifact
+		// so that the output is available while the task is running.
+		//
+		// Since: generic-worker 48.2.0
+		//
+		// Default:    true
+		LiveLog bool `json:"liveLog,omitempty" default:"true"`
+
 		// The taskcluster proxy provides an easy and safe way to make authenticated
 		// taskcluster requests within the scope(s) of a particular task. See
 		// [the github project](https://github.com/taskcluster/taskcluster/tree/main/tools/taskcluster-proxy) for more information.
@@ -226,6 +242,11 @@ type (
 		// Since: generic-worker 5.3.0
 		Features FeatureFlags `json:"features,omitempty"`
 
+		// Configuration for task logs.
+		//
+		// Since: generic-worker 48.2.0
+		Logs Logs `json:"logs,omitempty"`
+
 		// Maximum time the task container can run in seconds.
 		//
 		// Since: generic-worker 0.0.1
@@ -262,6 +283,28 @@ type (
 
 		// This property is allowed for backward compatibility, but is unused.
 		SupersederURL string `json:"supersederUrl,omitempty"`
+	}
+
+	// Configuration for task logs.
+	//
+	// Since: generic-worker 48.2.0
+	Logs struct {
+
+		// Specifies a custom name for the backing log artifact.
+		// This is only used if `features.backingLog` is `true`.
+		//
+		// Since: generic-worker 48.2.0
+		//
+		// Default:    "public/logs/live_backing.log"
+		Backing string `json:"backing,omitempty" default:"public/logs/live_backing.log"`
+
+		// Specifies a custom name for the live log artifact.
+		// This is only used if `features.liveLog` is `true`.
+		//
+		// Since: generic-worker 48.2.0
+		//
+		// Default:    "public/logs/live.log"
+		Live string `json:"live,omitempty" default:"public/logs/live.log"`
 	}
 
 	// Byte-for-byte literal inline content of file/archive, up to 64KB in size.
@@ -668,6 +711,18 @@ func taskPayloadSchema() string {
       "additionalProperties": false,
       "description": "Feature flags enable additional functionality.\n\nSince: generic-worker 5.3.0",
       "properties": {
+        "backingLog": {
+          "default": true,
+          "description": "The backing log feature publishes a task artifact containing the complete\nstderr and stdout of the task.\n\nSince: generic-worker 48.2.0",
+          "title": "Enable backing log",
+          "type": "boolean"
+        },
+        "liveLog": {
+          "default": true,
+          "description": "The live log feature streams the combined stderr and stdout to a task artifact\nso that the output is available while the task is running.\n\nSince: generic-worker 48.2.0",
+          "title": "Enable [livelog](https://github.com/taskcluster/taskcluster/tree/main/tools/livelog)",
+          "type": "boolean"
+        },
         "taskclusterProxy": {
           "description": "The taskcluster proxy provides an easy and safe way to make authenticated\ntaskcluster requests within the scope(s) of a particular task. See\n[the github project](https://github.com/taskcluster/taskcluster/tree/main/tools/taskcluster-proxy) for more information.\n\nSince: generic-worker 10.6.0",
           "title": "Run [taskcluster-proxy](https://github.com/taskcluster/taskcluster/tree/main/tools/taskcluster-proxy) to allow tasks to dynamically proxy requests to taskcluster services",
@@ -676,6 +731,27 @@ func taskPayloadSchema() string {
       },
       "required": [],
       "title": "Feature flags",
+      "type": "object"
+    },
+    "logs": {
+      "additionalProperties": false,
+      "description": "Configuration for task logs.\n\nSince: generic-worker 48.2.0",
+      "properties": {
+        "backing": {
+          "default": "public/logs/live_backing.log",
+          "description": "Specifies a custom name for the backing log artifact.\nThis is only used if ` + "`" + `features.backingLog` + "`" + ` is ` + "`" + `true` + "`" + `.\n\nSince: generic-worker 48.2.0",
+          "title": "Backing log artifact name",
+          "type": "string"
+        },
+        "live": {
+          "default": "public/logs/live.log",
+          "description": "Specifies a custom name for the live log artifact.\nThis is only used if ` + "`" + `features.liveLog` + "`" + ` is ` + "`" + `true` + "`" + `.\n\nSince: generic-worker 48.2.0",
+          "title": "Live log artifact name",
+          "type": "string"
+        }
+      },
+      "required": [],
+      "title": "Logs",
       "type": "object"
     },
     "maxRunTime": {

--- a/workers/generic-worker/gw-codegen/main.go
+++ b/workers/generic-worker/gw-codegen/main.go
@@ -10,11 +10,10 @@ import (
 	"regexp"
 	"strings"
 
-	"golang.org/x/tools/imports"
-
 	"github.com/kr/text"
 	"github.com/taskcluster/taskcluster/v48/internal/jsontest"
 	"github.com/taskcluster/taskcluster/v48/tools/jsonschema2go"
+	"golang.org/x/tools/imports"
 	"sigs.k8s.io/yaml"
 )
 

--- a/workers/generic-worker/gw-codegen/main.go
+++ b/workers/generic-worker/gw-codegen/main.go
@@ -65,6 +65,7 @@ func generateTypes(input, output, constraint string) []byte {
 		URLs:                 []string{input},
 		SkipCodeGen:          false,
 		DisableNestedStructs: true,
+		EnableDefaults:       true,
 	}
 	result, err := job.Execute()
 	if err != nil {

--- a/workers/generic-worker/helper_broken_on_docker_test.go
+++ b/workers/generic-worker/helper_broken_on_docker_test.go
@@ -86,46 +86,49 @@ func (expectedArtifacts ExpectedArtifacts) Validate(t *testing.T, taskID string,
 		t.Fatalf("Error listing artifacts: %v", err)
 	}
 
-	actualArtifacts := make(map[string]struct {
-		ContentType string        `json:"contentType"`
-		Expires     tcclient.Time `json:"expires"`
-		Name        string        `json:"name"`
-		StorageType string        `json:"storageType"`
-	}, len(artifacts.Artifacts))
+	// Artifacts we find that we were not expecting, mapped by artifact name. Initially set to all artifacts
+	// found, and then later remove all of the ones we were expecting.
+	unexpectedArtifacts := make(map[string]tcqueue.Artifact, len(artifacts.Artifacts))
 
 	for _, actualArtifact := range artifacts.Artifacts {
-		actualArtifacts[actualArtifact.Name] = actualArtifact
+		unexpectedArtifacts[actualArtifact.Name] = actualArtifact
 	}
 
-	for artifact, expected := range expectedArtifacts {
-		if actual, ok := actualArtifacts[artifact]; ok {
-			// link artifacts do not have content types
-			if actual.StorageType != "link" {
-				if actual.ContentType != expected.ContentType {
-					t.Errorf("Artifact %s should have mime type '%v' but has '%s'", artifact, expected.ContentType, actual.ContentType)
-				}
-			}
-			if !time.Time(expected.Expires).IsZero() {
-				if actual.Expires.String() != expected.Expires.String() {
-					t.Errorf("Artifact %s should have expiry '%s' but has '%s'", artifact, expected.Expires, actual.Expires)
-				}
-			}
-		} else {
-			t.Errorf("Artifact '%s' not created", artifact)
+	for artifactName, expected := range expectedArtifacts {
+		if _, ok := unexpectedArtifacts[artifactName]; !ok {
+			t.Errorf("Artifact '%s' not created", artifactName)
+			continue
 		}
-		b, rawResp, resp, url := getArtifactContentWithResponses(t, taskID, artifact)
+		actual := unexpectedArtifacts[artifactName]
+		// link artifacts do not have content types
+		if actual.StorageType != "link" {
+			if actual.ContentType != expected.ContentType {
+				t.Errorf("Artifact %s should have mime type '%v' but has '%s'", artifactName, expected.ContentType, actual.ContentType)
+			}
+		}
+		if !time.Time(expected.Expires).IsZero() {
+			if actual.Expires.String() != expected.Expires.String() {
+				t.Errorf("Artifact %s should have expiry '%s' but has '%s'", artifactName, expected.Expires, actual.Expires)
+			}
+		}
+		b, rawResp, resp, url := getArtifactContentWithResponses(t, taskID, artifactName)
 		defer resp.Body.Close()
 		for _, requiredSubstring := range expected.Extracts {
 			if !strings.Contains(string(b), requiredSubstring) {
-				t.Errorf("Artifact '%s': Could not find substring %q in '%s'", artifact, requiredSubstring, string(b))
+				t.Errorf("Artifact '%s': Could not find substring %q in '%s'", artifactName, requiredSubstring, string(b))
 			}
 		}
 		if actualContentEncoding := rawResp.Header.Get("Content-Encoding"); actualContentEncoding != expected.ContentEncoding {
-			t.Fatalf("Expected Content-Encoding %q but got Content-Encoding %q for artifact %q from url %v", expected.ContentEncoding, actualContentEncoding, artifact, url)
+			t.Errorf("Expected Content-Encoding %q but got Content-Encoding %q for artifact %q from url %v", expected.ContentEncoding, actualContentEncoding, artifactName, url)
 		}
 		if actualContentType := resp.Header.Get("Content-Type"); actualContentType != expected.ContentType {
-			t.Fatalf("Content-Type in Signed URL %v response (%v) does not match Content-Type of artifact (%v)", url, actualContentType, expected.ContentType)
+			t.Errorf("Content-Type in Signed URL %v response (%v) does not match Content-Type of artifact (%v)", url, actualContentType, expected.ContentType)
 		}
+		delete(unexpectedArtifacts, artifactName) // artifact expected, so remove from unexpected artifacts map
+	}
+
+	if len(unexpectedArtifacts) > 0 {
+		t.Errorf("%v unexpected aritfacts found: %#v", len(unexpectedArtifacts), unexpectedArtifacts)
 	}
 }
 

--- a/workers/generic-worker/helper_broken_on_docker_test.go
+++ b/workers/generic-worker/helper_broken_on_docker_test.go
@@ -14,6 +14,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/mcuadros/go-defaults"
 	"github.com/taskcluster/httpbackoff/v3"
 	tcclient "github.com/taskcluster/taskcluster/v48/clients/client-go"
 	"github.com/taskcluster/taskcluster/v48/clients/client-go/tcqueue"
@@ -42,6 +43,7 @@ func CancelTask(t *testing.T) (td *tcqueue.TaskDefinitionRequest, payload Generi
 		Command:    command,
 		MaxRunTime: 300,
 	}
+	defaults.SetDefaults(&payload)
 	fullCreds := config.Credentials()
 	td = testTask(t)
 	tempCreds, err := fullCreds.CreateNamedTemporaryCredentials("project/taskcluster:generic-worker-tester/"+t.Name(), time.Minute, "queue:cancel-task:"+td.SchedulerID+"/"+td.TaskGroupID+"/*")

--- a/workers/generic-worker/helper_multiuser_test.go
+++ b/workers/generic-worker/helper_multiuser_test.go
@@ -19,6 +19,13 @@ func expectChainOfTrustKeyNotSecureMessage(t *testing.T, td *tcqueue.TaskDefinit
 			ContentType:     "text/plain; charset=utf-8",
 			ContentEncoding: "gzip",
 		},
+		"public/logs/live.log": {
+			Extracts: []string{
+				ChainOfTrustKeyNotSecureMessage,
+			},
+			ContentType:     "text/plain; charset=utf-8",
+			ContentEncoding: "gzip",
+		},
 	}
 
 	expectedArtifacts.Validate(t, taskID, 0)

--- a/workers/generic-worker/helper_posix_test.go
+++ b/workers/generic-worker/helper_posix_test.go
@@ -4,7 +4,6 @@ package main
 
 import (
 	"fmt"
-
 	"path/filepath"
 )
 

--- a/workers/generic-worker/helper_test.go
+++ b/workers/generic-worker/helper_test.go
@@ -18,6 +18,7 @@ import (
 	"time"
 
 	"github.com/gorilla/mux"
+	"github.com/mcuadros/go-defaults"
 	"github.com/pborman/uuid"
 	"github.com/taskcluster/httpbackoff/v3"
 	"github.com/taskcluster/slugid-go/slugid"
@@ -277,6 +278,7 @@ func CreateArtifactFromFile(t *testing.T, path string, name string) (taskID stri
 							},
 						},
 					}
+					defaults.SetDefaults(&payload)
 					td := testTask(t)
 					// Set 6 month expiry
 					td.Expires = tcclient.Time(time.Now().AddDate(0, 6, 0))

--- a/workers/generic-worker/intermittent_task_test.go
+++ b/workers/generic-worker/intermittent_task_test.go
@@ -3,6 +3,8 @@ package main
 import (
 	"strings"
 	"testing"
+
+	"github.com/mcuadros/go-defaults"
 )
 
 // Exit codes specified in OnExitStatus should resolve as itermittent
@@ -15,6 +17,7 @@ func TestIntermittentCodeCommandIntermittent(t *testing.T) {
 			Retry: []int64{123},
 		},
 	}
+	defaults.SetDefaults(&payload)
 	td := testTask(t)
 
 	_ = submitAndAssert(t, td, payload, "exception", "intermittent-task")
@@ -33,6 +36,7 @@ func TestIntermittentCodeCommandFailure(t *testing.T) {
 			Retry: []int64{123},
 		},
 	}
+	defaults.SetDefaults(&payload)
 	td := testTask(t)
 
 	_ = submitAndAssert(t, td, payload, "failed", "failed")
@@ -48,6 +52,7 @@ func TestIntermittentCodeCommandSuccess(t *testing.T) {
 			Retry: []int64{780},
 		},
 	}
+	defaults.SetDefaults(&payload)
 	td := testTask(t)
 
 	_ = submitAndAssert(t, td, payload, "completed", "completed")
@@ -63,6 +68,7 @@ func TestIntermittentListCommandIntermittent(t *testing.T) {
 			Retry: []int64{780, 10, 2},
 		},
 	}
+	defaults.SetDefaults(&payload)
 	td := testTask(t)
 
 	_ = submitAndAssert(t, td, payload, "exception", "intermittent-task")
@@ -81,6 +87,7 @@ func TestIntermittentEmptyListCommandSuccess(t *testing.T) {
 			Retry: []int64{},
 		},
 	}
+	defaults.SetDefaults(&payload)
 	td := testTask(t)
 
 	_ = submitAndAssert(t, td, payload, "completed", "completed")
@@ -96,6 +103,7 @@ func TestIntermittentEmptyListCommandFailure(t *testing.T) {
 			Retry: []int64{},
 		},
 	}
+	defaults.SetDefaults(&payload)
 	td := testTask(t)
 
 	_ = submitAndAssert(t, td, payload, "failed", "failed")
@@ -111,6 +119,7 @@ func TestIntermittentNegativeExitCode(t *testing.T) {
 			Retry: []int64{-1},
 		},
 	}
+	defaults.SetDefaults(&payload)
 	td := testTask(t)
 
 	_ = submitAndAssert(t, td, payload, "exception", "malformed-payload")

--- a/workers/generic-worker/livelog_test.go
+++ b/workers/generic-worker/livelog_test.go
@@ -5,6 +5,8 @@ package main
 import (
 	"strings"
 	"testing"
+
+	"github.com/mcuadros/go-defaults"
 )
 
 func TestCustomLogPaths(t *testing.T) {
@@ -21,6 +23,7 @@ func TestCustomLogPaths(t *testing.T) {
 			Live:    customLiveLogName,
 		},
 	}
+	defaults.SetDefaults(&payload)
 	td := testTask(t)
 
 	taskID := submitAndAssert(t, td, payload, "completed", "completed")
@@ -44,24 +47,27 @@ func TestDisableLiveLogFeature(t *testing.T) {
 	payload := GenericWorkerPayload{
 		Command:    helloGoodbye(),
 		MaxRunTime: 30,
-		Features: FeatureFlags{
-			LiveLog: false,
-		},
 	}
+	defaults.SetDefaults(&payload)
+
+	// this has to be set _after_ setting defaults, since we are explicitly setting to the zero value!
+	payload.Features.LiveLog = false
+
 	td := testTask(t)
 
 	taskID := submitAndAssert(t, td, payload, "completed", "completed")
 
-	bytes := getArtifactContent(t, taskID, "public/logs/live_backing.log")
-	logtext := string(bytes)
-	if !strings.Contains(logtext, "goodbye world!") {
-		t.Fatalf("Was expecting backing log file to contain 'goodbye world!' but it doesn't")
+	// some required substrings - not all, just a selection
+	expectedArtifacts := ExpectedArtifacts{
+		"public/logs/live_backing.log": {
+			Extracts: []string{
+				"hello world!",
+				"goodbye world!",
+			},
+			ContentType:     "text/plain; charset=utf-8",
+			ContentEncoding: "gzip",
+			Expires:         td.Expires,
+		},
 	}
-
-	// TODO: this should be a 404, handle
-	bytes = getArtifactContent(t, taskID, "public/logs/live.log")
-	logtext = string(bytes)
-	if !strings.Contains(logtext, "hello world!") {
-		t.Fatalf("Was expecting live log file to contain 'hello world!' but it doesn't")
-	}
+	expectedArtifacts.Validate(t, taskID, 0)
 }

--- a/workers/generic-worker/livelog_test.go
+++ b/workers/generic-worker/livelog_test.go
@@ -38,12 +38,15 @@ func TestCustomLogPaths(t *testing.T) {
 	}
 }
 
-func TestDefaultLogPaths(t *testing.T) {
+func TestDisableLiveLogFeature(t *testing.T) {
 	setup(t)
 
 	payload := GenericWorkerPayload{
 		Command:    helloGoodbye(),
 		MaxRunTime: 30,
+		Features: FeatureFlags{
+			LiveLog: false,
+		},
 	}
 	td := testTask(t)
 
@@ -55,6 +58,7 @@ func TestDefaultLogPaths(t *testing.T) {
 		t.Fatalf("Was expecting backing log file to contain 'goodbye world!' but it doesn't")
 	}
 
+	// TODO: this should be a 404, handle
 	bytes = getArtifactContent(t, taskID, "public/logs/live.log")
 	logtext = string(bytes)
 	if !strings.Contains(logtext, "hello world!") {

--- a/workers/generic-worker/livelog_test.go
+++ b/workers/generic-worker/livelog_test.go
@@ -1,0 +1,63 @@
+//go:build !docker
+
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestCustomLogPaths(t *testing.T) {
+	setup(t)
+
+	customLiveLogName := "public/banana.log"
+	customBackingLogName := "public/banana_backing.log"
+
+	payload := GenericWorkerPayload{
+		Command:    helloGoodbye(),
+		MaxRunTime: 30,
+		Logs: Logs{
+			Backing: customBackingLogName,
+			Live:    customLiveLogName,
+		},
+	}
+	td := testTask(t)
+
+	taskID := submitAndAssert(t, td, payload, "completed", "completed")
+
+	bytes := getArtifactContent(t, taskID, customBackingLogName)
+	logtext := string(bytes)
+	if !strings.Contains(logtext, "goodbye world!") {
+		t.Fatalf("Was expecting backing log file to contain 'goodbye world!' but it doesn't")
+	}
+
+	bytes = getArtifactContent(t, taskID, customLiveLogName)
+	logtext = string(bytes)
+	if !strings.Contains(logtext, "hello world!") {
+		t.Fatalf("Was expecting live log file to contain 'hello world!' but it doesn't")
+	}
+}
+
+func TestDefaultLogPaths(t *testing.T) {
+	setup(t)
+
+	payload := GenericWorkerPayload{
+		Command:    helloGoodbye(),
+		MaxRunTime: 30,
+	}
+	td := testTask(t)
+
+	taskID := submitAndAssert(t, td, payload, "completed", "completed")
+
+	bytes := getArtifactContent(t, taskID, "public/logs/live_backing.log")
+	logtext := string(bytes)
+	if !strings.Contains(logtext, "goodbye world!") {
+		t.Fatalf("Was expecting backing log file to contain 'goodbye world!' but it doesn't")
+	}
+
+	bytes = getArtifactContent(t, taskID, "public/logs/live.log")
+	logtext = string(bytes)
+	if !strings.Contains(logtext, "hello world!") {
+		t.Fatalf("Was expecting live log file to contain 'hello world!' but it doesn't")
+	}
+}

--- a/workers/generic-worker/main_broken_on_docker_test.go
+++ b/workers/generic-worker/main_broken_on_docker_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/mcuadros/go-defaults"
 	"github.com/taskcluster/slugid-go/slugid"
 )
 
@@ -33,6 +34,7 @@ func TestAbortAfterMaxRunTime(t *testing.T) {
 		),
 		MaxRunTime: 5,
 	}
+	defaults.SetDefaults(&payload)
 	td := testTask(t)
 	td.Scopes = []string{"generic-worker:cache:banana-cache"}
 
@@ -73,6 +75,7 @@ func TestNonExistentCommandFailsTask(t *testing.T) {
 		Command:    singleCommandNoArgs(slugid.Nice()),
 		MaxRunTime: 10,
 	}
+	defaults.SetDefaults(&payload)
 	td := testTask(t)
 
 	_ = submitAndAssert(t, td, payload, "failed", "failed")

--- a/workers/generic-worker/main_test.go
+++ b/workers/generic-worker/main_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/mcuadros/go-defaults"
 	"github.com/stretchr/testify/require"
 )
 
@@ -20,6 +21,7 @@ func TestFailureResolvesAsFailure(t *testing.T) {
 		Command:    returnExitCode(1),
 		MaxRunTime: 10,
 	}
+	defaults.SetDefaults(&payload)
 	td := testTask(t)
 
 	_ = submitAndAssert(t, td, payload, "failed", "failed")
@@ -154,6 +156,7 @@ func TestNonExecutableBinaryFailsTask(t *testing.T) {
 		Command:    commands,
 		MaxRunTime: 10,
 	}
+	defaults.SetDefaults(&payload)
 	td := testTask(t)
 
 	_ = submitAndAssert(t, td, payload, "failed", "failed")

--- a/workers/generic-worker/mounts_broken_on_docker_test.go
+++ b/workers/generic-worker/mounts_broken_on_docker_test.go
@@ -8,6 +8,8 @@ import (
 	"path/filepath"
 	"strconv"
 	"testing"
+
+	"github.com/mcuadros/go-defaults"
 )
 
 func TestMounts(t *testing.T) {
@@ -123,6 +125,7 @@ func TestMounts(t *testing.T) {
 		},
 		MaxRunTime: 180,
 	}
+	defaults.SetDefaults(&payload)
 
 	td := testTask(t)
 	td.Dependencies = []string{
@@ -199,6 +202,7 @@ func TestCachesCanBeModified(t *testing.T) {
 		Command:    incrementCounterInCache(),
 		MaxRunTime: 180,
 	}
+	defaults.SetDefaults(&payload)
 
 	execute := func() {
 		td := testTask(t)
@@ -277,6 +281,12 @@ func TestCacheMoved(t *testing.T) {
 		`Could not unmount task `+taskID+` artifact public/build/unknown_issuer_app_1.zip due to: 'Could not persist cache "banana-cache" due to .*'`,
 	)
 
+	payload := GenericWorkerPayload{
+		Command:    goRun("move-file.go", t.Name(), "MovedCache"),
+		MaxRunTime: 100,
+	}
+	defaults.SetDefaults(&payload)
+
 	LogTest(
 		&MountsLoggingTestCase{
 			Test: t,
@@ -295,11 +305,8 @@ func TestCacheMoved(t *testing.T) {
 			Dependencies: []string{
 				taskID,
 			},
-			Scopes: []string{"generic-worker:cache:banana-cache"},
-			Payload: &GenericWorkerPayload{
-				Command:    goRun("move-file.go", t.Name(), "MovedCache"),
-				MaxRunTime: 180,
-			},
+			Scopes:                 []string{"generic-worker:cache:banana-cache"},
+			Payload:                &payload,
 			TaskRunResolutionState: "failed",
 			TaskRunReasonResolved:  "failed",
 			PerTaskRunLogExcerpts: [][]string{
@@ -419,6 +426,7 @@ func TestInvalidSHADoesNotPreventMountedMountsFromBeingUnmounted(t *testing.T) {
 		Command:    helloGoodbye(),
 		MaxRunTime: 180,
 	}
+	defaults.SetDefaults(&payload)
 
 	td := testTask(t)
 	td.Dependencies = []string{
@@ -443,6 +451,7 @@ func TestInvalidSHADoesNotPreventMountedMountsFromBeingUnmounted(t *testing.T) {
 		Command:    helloGoodbye(),
 		MaxRunTime: 180,
 	}
+	defaults.SetDefaults(&payload)
 
 	td = testTask(t)
 	td.Scopes = []string{

--- a/workers/generic-worker/mounts_test.go
+++ b/workers/generic-worker/mounts_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/mcuadros/go-defaults"
 	"github.com/taskcluster/slugid-go/slugid"
 	"github.com/taskcluster/taskcluster/v48/workers/generic-worker/gwconfig"
 )
@@ -39,6 +40,7 @@ func TestMissingScopes(t *testing.T) {
 		Command:    helloGoodbye(),
 		MaxRunTime: 180,
 	}
+	defaults.SetDefaults(&payload)
 
 	td := testTask(t)
 	td.Dependencies = []string{
@@ -80,6 +82,7 @@ func TestMissingMountsDependency(t *testing.T) {
 		Command:    helloGoodbye(),
 		MaxRunTime: 180,
 	}
+	defaults.SetDefaults(&payload)
 
 	td := testTask(t)
 	td.Scopes = []string{
@@ -128,6 +131,7 @@ func TestCorruptZipDoesntCrashWorker(t *testing.T) {
 		Command:    helloGoodbye(),
 		MaxRunTime: 180,
 	}
+	defaults.SetDefaults(&payload)
 
 	td := testTask(t)
 	td.Dependencies = []string{
@@ -175,6 +179,7 @@ func TestNonExistentArtifact(t *testing.T) {
 		Command:    helloGoodbye(),
 		MaxRunTime: 180,
 	}
+	defaults.SetDefaults(&payload)
 
 	td := testTask(t)
 	td.Dependencies = []string{
@@ -218,6 +223,7 @@ func LogTest(m *MountsLoggingTestCase) {
 			Command:    helloGoodbye(),
 			MaxRunTime: 180,
 		}
+		defaults.SetDefaults(payload)
 	}
 	payload.Mounts = toMountArray(m.Test, &m.Mounts)
 
@@ -550,6 +556,7 @@ func TestHardLinksInArchive(t *testing.T) {
 		Command:    helloGoodbye(),
 		MaxRunTime: 180,
 	}
+	defaults.SetDefaults(&payload)
 
 	td := testTask(t)
 

--- a/workers/generic-worker/multiuser_test.go
+++ b/workers/generic-worker/multiuser_test.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/mcuadros/go-defaults"
 	"github.com/taskcluster/slugid-go/slugid"
 	"github.com/taskcluster/taskcluster/v48/workers/generic-worker/gwconfig"
 )
@@ -48,6 +49,7 @@ func TestWhoAmI(t *testing.T) {
 		Command:    goRun("whoami.go", strconv.FormatBool(config.RunTasksAsCurrentUser)),
 		MaxRunTime: 180,
 	}
+	defaults.SetDefaults(&payload)
 
 	td := testTask(t)
 

--- a/workers/generic-worker/multiuser_windows_test.go
+++ b/workers/generic-worker/multiuser_windows_test.go
@@ -5,6 +5,8 @@ package main
 import (
 	"os"
 	"testing"
+
+	"github.com/mcuadros/go-defaults"
 )
 
 // Test APPDATA / LOCALAPPDATA folder are not shared between tasks
@@ -34,6 +36,7 @@ func TestAppDataNotShared(t *testing.T) {
 		},
 		MaxRunTime: 10,
 	}
+	defaults.SetDefaults(&payload1)
 	td1 := testTask(t)
 
 	_ = submitAndAssert(t, td1, payload1, "completed", "completed")
@@ -52,6 +55,7 @@ func TestAppDataNotShared(t *testing.T) {
 		},
 		MaxRunTime: 10,
 	}
+	defaults.SetDefaults(&payload2)
 	td2 := testTask(t)
 
 	_ = submitAndAssert(t, td2, payload2, "completed", "completed")
@@ -91,6 +95,7 @@ func TestNoCreateFileMappingError(t *testing.T) {
 		},
 		MaxRunTime: 120,
 	}
+	defaults.SetDefaults(&payload)
 	td := testTask(t)
 
 	_ = submitAndAssert(t, td, payload, "completed", "completed")
@@ -116,6 +121,7 @@ func TestDesktopResizeAndMovePointer(t *testing.T) {
 			"PATH": os.Getenv("PATH"),
 		},
 	}
+	defaults.SetDefaults(&payload)
 	td := testTask(t)
 
 	_ = submitAndAssert(t, td, payload, "completed", "completed")

--- a/workers/generic-worker/os_groups_posix_test.go
+++ b/workers/generic-worker/os_groups_posix_test.go
@@ -5,6 +5,8 @@ package main
 import (
 	"strings"
 	"testing"
+
+	"github.com/mcuadros/go-defaults"
 )
 
 func TestEmptyOSGroups(t *testing.T) {
@@ -14,6 +16,7 @@ func TestEmptyOSGroups(t *testing.T) {
 		MaxRunTime: 30,
 		OSGroups:   []string{},
 	}
+	defaults.SetDefaults(&payload)
 	td := testTask(t)
 
 	_ = submitAndAssert(t, td, payload, "completed", "completed")
@@ -26,6 +29,7 @@ func TestNonEmptyOSGroups(t *testing.T) {
 		MaxRunTime: 30,
 		OSGroups:   []string{"abc"},
 	}
+	defaults.SetDefaults(&payload)
 	td := testTask(t)
 
 	_ = submitAndAssert(t, td, payload, "exception", "malformed-payload")

--- a/workers/generic-worker/os_groups_windows_test.go
+++ b/workers/generic-worker/os_groups_windows_test.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"strings"
 	"testing"
+
+	"github.com/mcuadros/go-defaults"
 )
 
 func TestMissingScopesOSGroups(t *testing.T) {
@@ -13,6 +15,7 @@ func TestMissingScopesOSGroups(t *testing.T) {
 		MaxRunTime: 30,
 		OSGroups:   []string{"abc", "def"},
 	}
+	defaults.SetDefaults(&payload)
 	td := testTask(t)
 
 	// don't set any scopes
@@ -31,6 +34,7 @@ func TestOSGroupsRespected(t *testing.T) {
 		MaxRunTime: 30,
 		OSGroups:   []string{"abc", "def"},
 	}
+	defaults.SetDefaults(&payload)
 	td := testTask(t)
 	td.Scopes = []string{
 		"generic-worker:os-group:" + td.ProvisionerID + "/" + td.WorkerType + "/abc",

--- a/workers/generic-worker/runasadministrator_windows_test.go
+++ b/workers/generic-worker/runasadministrator_windows_test.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"testing"
+
+	"github.com/mcuadros/go-defaults"
 )
 
 func TestRunAsAdministratorDisabled(t *testing.T) {
@@ -19,6 +21,7 @@ func TestRunAsAdministratorDisabled(t *testing.T) {
 		},
 		MaxRunTime: 10,
 	}
+	defaults.SetDefaults(&payload)
 	td := testTask(t)
 
 	_ = submitAndAssert(t, td, payload, "failed", "failed")
@@ -45,6 +48,7 @@ func TestRunAsAdministratorEnabledMissingScopes(t *testing.T) {
 			"Administrators",
 		},
 	}
+	defaults.SetDefaults(&payload)
 	td := testTask(t)
 	td.Scopes = []string{
 		"generic-worker:os-group:" + td.ProvisionerID + "/" + td.WorkerType + "/Administrators",
@@ -72,6 +76,7 @@ func TestRunAsAdministratorMissingOSGroup(t *testing.T) {
 			RunAsAdministrator: true,
 		},
 	}
+	defaults.SetDefaults(&payload)
 	td := testTask(t)
 	td.Scopes = []string{
 		"generic-worker:run-as-administrator:" + td.ProvisionerID + "/" + td.WorkerType,
@@ -99,6 +104,7 @@ func TestChainOfTrustWithRunAsAdministrator(t *testing.T) {
 			RunAsAdministrator: true,
 		},
 	}
+	defaults.SetDefaults(&payload)
 	td := testTask(t)
 	td.Scopes = []string{
 		"generic-worker:run-as-administrator:" + td.ProvisionerID + "/" + td.WorkerType,
@@ -133,6 +139,7 @@ func TestChainOfTrustWithoutRunAsAdministrator(t *testing.T) {
 			RunAsAdministrator: false, // FALSE !!!!
 		},
 	}
+	defaults.SetDefaults(&payload)
 	td := testTask(t)
 	td.Scopes = []string{
 		"generic-worker:run-as-administrator:" + td.ProvisionerID + "/" + td.WorkerType,
@@ -176,6 +183,7 @@ func TestRunAsAdministratorEnabled(t *testing.T) {
 			"Administrators",
 		},
 	}
+	defaults.SetDefaults(&payload)
 	td := testTask(t)
 	td.Scopes = []string{
 		"generic-worker:run-as-administrator:" + td.ProvisionerID + "/" + td.WorkerType,

--- a/workers/generic-worker/schemas/docker_posix.yml
+++ b/workers/generic-worker/schemas/docker_posix.yml
@@ -202,6 +202,24 @@ properties:
           [the github project](https://github.com/taskcluster/taskcluster/tree/main/tools/taskcluster-proxy) for more information.
 
           Since: generic-worker 10.6.0
+      liveLog:
+        type: boolean
+        title: Enable [livelog](https://github.com/taskcluster/taskcluster/tree/main/tools/livelog)
+        description: |-
+          The live log feature streams the combined stderr and stdout to a task artifact
+          so that the output is available while the task is running.
+
+          Since: generic-worker 48.2.0
+        default: true
+      backingLog:
+        type: boolean
+        title: Enable backing log
+        description: |-
+          The backing log feature publishes a task artifact containing the complete
+          stderr and stdout of the task.
+
+          Since: generic-worker 48.2.0
+        default: true
   mounts:
     type: array
     description: |-
@@ -257,6 +275,34 @@ properties:
           title: Exit codes
           type: integer
           minimum: 1
+  logs:
+    title: Logs
+    description: |-
+      Configuration for task logs.
+
+      Since: generic-worker 48.2.0
+    type: object
+    additionalProperties: false
+    required: []
+    properties:
+      live:
+        title: Live log artifact name
+        description: |-
+          Specifies a custom name for the live log artifact.
+          This is only used if `features.liveLog` is `true`.
+
+          Since: generic-worker 48.2.0
+        type: string
+        default: public/logs/live.log
+      backing:
+        title: Backing log artifact name
+        description: |-
+          Specifies a custom name for the backing log artifact.
+          This is only used if `features.backingLog` is `true`.
+
+          Since: generic-worker 48.2.0
+        type: string
+        default: public/logs/live_backing.log
 definitions:
   mount:
     title: Mount

--- a/workers/generic-worker/schemas/multiuser_posix.yml
+++ b/workers/generic-worker/schemas/multiuser_posix.yml
@@ -214,6 +214,24 @@ properties:
           [the github project](https://github.com/taskcluster/taskcluster/tree/main/tools/taskcluster-proxy) for more information.
 
           Since: generic-worker 10.6.0
+      liveLog:
+        type: boolean
+        title: Enable [livelog](https://github.com/taskcluster/taskcluster/tree/main/tools/livelog)
+        description: |-
+          The live log feature streams the combined stderr and stdout to a task artifact
+          so that the output is available while the task is running.
+
+          Since: generic-worker 48.2.0
+        default: true
+      backingLog:
+        type: boolean
+        title: Enable backing log
+        description: |-
+          The backing log feature publishes a task artifact containing the complete
+          stderr and stdout of the task.
+
+          Since: generic-worker 48.2.0
+        default: true
   mounts:
     type: array
     description: |-
@@ -269,6 +287,34 @@ properties:
           title: Exit codes
           type: integer
           minimum: 1
+  logs:
+    title: Logs
+    description: |-
+      Configuration for task logs.
+
+      Since: generic-worker 48.2.0
+    type: object
+    additionalProperties: false
+    required: []
+    properties:
+      live:
+        title: Live log artifact name
+        description: |-
+          Specifies a custom name for the live log artifact.
+          This is only used if `features.liveLog` is `true`.
+
+          Since: generic-worker 48.2.0
+        type: string
+        default: public/logs/live.log
+      backing:
+        title: Backing log artifact name
+        description: |-
+          Specifies a custom name for the backing log artifact.
+          This is only used if `features.backingLog` is `true`.
+
+          Since: generic-worker 48.2.0
+        type: string
+        default: public/logs/live_backing.log
 definitions:
   mount:
     title: Mount

--- a/workers/generic-worker/schemas/multiuser_windows.yml
+++ b/workers/generic-worker/schemas/multiuser_windows.yml
@@ -231,6 +231,24 @@ properties:
           `generic-worker:run-as-administrator:<provisionerId>/<workerType>`.
 
           Since: generic-worker 10.11.0
+      liveLog:
+        type: boolean
+        title: Enable [livelog](https://github.com/taskcluster/taskcluster/tree/main/tools/livelog)
+        description: |-
+          The live log feature streams the combined stderr and stdout to a task artifact
+          so that the output is available while the task is running.
+
+          Since: generic-worker 48.2.0
+        default: true
+      backingLog:
+        type: boolean
+        title: Enable backing log
+        description: |-
+          The backing log feature publishes a task artifact containing the complete
+          stderr and stdout of the task.
+
+          Since: generic-worker 48.2.0
+        default: true
   mounts:
     type: array
     description: |-
@@ -315,6 +333,34 @@ properties:
       should rely on this value.
 
       Since: generic-worker 10.5.0
+  logs:
+    title: Logs
+    description: |-
+      Configuration for task logs.
+
+      Since: generic-worker 48.2.0
+    type: object
+    additionalProperties: false
+    required: []
+    properties:
+      live:
+        title: Live log artifact name
+        description: |-
+          Specifies a custom name for the live log artifact.
+          This is only used if `features.liveLog` is `true`.
+
+          Since: generic-worker 48.2.0
+        type: string
+        default: public/logs/live.log
+      backing:
+        title: Backing log artifact name
+        description: |-
+          Specifies a custom name for the backing log artifact.
+          This is only used if `features.backingLog` is `true`.
+
+          Since: generic-worker 48.2.0
+        type: string
+        default: public/logs/live_backing.log
 definitions:
   mount:
     title: Mount

--- a/workers/generic-worker/schemas/simple_posix.yml
+++ b/workers/generic-worker/schemas/simple_posix.yml
@@ -192,6 +192,24 @@ properties:
           [the github project](https://github.com/taskcluster/taskcluster/tree/main/tools/taskcluster-proxy) for more information.
 
           Since: generic-worker 10.6.0
+      liveLog:
+        type: boolean
+        title: Enable [livelog](https://github.com/taskcluster/taskcluster/tree/main/tools/livelog)
+        description: |-
+          The live log feature streams the combined stderr and stdout to a task artifact
+          so that the output is available while the task is running.
+
+          Since: generic-worker 48.2.0
+        default: true
+      backingLog:
+        type: boolean
+        title: Enable backing log
+        description: |-
+          The backing log feature publishes a task artifact containing the complete
+          stderr and stdout of the task.
+
+          Since: generic-worker 48.2.0
+        default: true
   mounts:
     type: array
     description: |-
@@ -247,6 +265,34 @@ properties:
           title: Exit codes
           type: integer
           minimum: 1
+  logs:
+    title: Logs
+    description: |-
+      Configuration for task logs.
+
+      Since: generic-worker 48.2.0
+    type: object
+    additionalProperties: false
+    required: []
+    properties:
+      live:
+        title: Live log artifact name
+        description: |-
+          Specifies a custom name for the live log artifact.
+          This is only used if `features.liveLog` is `true`.
+
+          Since: generic-worker 48.2.0
+        type: string
+        default: public/logs/live.log
+      backing:
+        title: Backing log artifact name
+        description: |-
+          Specifies a custom name for the backing log artifact.
+          This is only used if `features.backingLog` is `true`.
+
+          Since: generic-worker 48.2.0
+        type: string
+        default: public/logs/live_backing.log
 definitions:
   mount:
     title: Mount

--- a/workers/generic-worker/simple_docker_test.go
+++ b/workers/generic-worker/simple_docker_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -29,23 +30,29 @@ func TestNewTaskDirectoryForEachTask(t *testing.T) {
 	// scan task directories, to make sure there are three unique backing log files,
 	// implying that each task ran in its own directory
 
-	var backingLogsFound uint = 0
+	var taskDirs uint = 0
+	visitedRootDir := false
 	err := filepath.Walk(config.TasksDir, func(path string, info os.FileInfo, err error) error {
-		if info.IsDir() {
-			t.Logf("Found dir %v", path)
+		// filepath.Walk guarantees lexical ordering and therefore, first entry is root directory
+		if !visitedRootDir {
+			visitedRootDir = true
 			return nil
 		}
-		t.Logf("Found file %v", path)
-		if info.Name() != "live_backing.log" {
-			return fmt.Errorf("Discovered file with name %q but was expecting %q", info.Name(), "live_backing.log")
+		if !info.IsDir() {
+			t.Logf("Found file %v", path)
+			return nil
 		}
-		backingLogsFound++
+		t.Logf("Found directory %v", path)
+		if !strings.HasPrefix(info.Name(), "task_") && info.Name() != "generic-worker" {
+			return fmt.Errorf("Discovered directory with name %q but was expecting it to start with `task_`", info.Name())
+		}
+		taskDirs++
 		return nil
 	})
 	if err != nil {
 		t.Fatalf("%v", err)
 	}
-	if backingLogsFound != config.NumberOfTasksToRun {
-		t.Fatalf("Expected to find %v backing logs, but found %v", config.NumberOfTasksToRun, backingLogsFound)
+	if taskDirs != config.NumberOfTasksToRun*2 {
+		t.Fatalf("Expected to find %v directories in total, but found %v", config.NumberOfTasksToRun*2, taskDirs)
 	}
 }

--- a/workers/generic-worker/simple_docker_test.go
+++ b/workers/generic-worker/simple_docker_test.go
@@ -8,6 +8,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/mcuadros/go-defaults"
 )
 
 // Note we don't want to set config.NumberOfTasksToRun on multiuser engine
@@ -20,6 +22,7 @@ func TestNewTaskDirectoryForEachTask(t *testing.T) {
 		Command:    returnExitCode(0),
 		MaxRunTime: 10,
 	}
+	defaults.SetDefaults(&payload)
 	td := testTask(t)
 	for i := uint(0); i < config.NumberOfTasksToRun; i++ {
 		_ = scheduleTask(t, td, payload)

--- a/workers/generic-worker/taskcluster_proxy_broken_on_docker_test.go
+++ b/workers/generic-worker/taskcluster_proxy_broken_on_docker_test.go
@@ -6,6 +6,8 @@ import (
 	"encoding/base64"
 	"os"
 	"testing"
+
+	"github.com/mcuadros/go-defaults"
 )
 
 func TestTaskclusterProxy(t *testing.T) {
@@ -43,6 +45,12 @@ func TestTaskclusterProxy(t *testing.T) {
 			TaskclusterProxy: true,
 		},
 	}
+	defaults.SetDefaults(&payload)
+
+	// need to set _after_ setting defaults, since this is the zero value
+	// so setting it before would cause SetDefaults to change it to true
+	payload.Features.LiveLog = false
+
 	for _, envVar := range []string{
 		"PATH",
 		"GOPATH",

--- a/workers/generic-worker/taskstatus_broken_on_docker_test.go
+++ b/workers/generic-worker/taskstatus_broken_on_docker_test.go
@@ -29,6 +29,7 @@ func TestReclaimCancelledTask(t *testing.T) {
 	td.Scopes = []string{"generic-worker:cache:banana-cache"}
 	payload.Command = append(payload.Command, sleep(300)...)
 	payload.Mounts = toMountArray(t, &mounts)
+	payload.Features.LiveLog = false
 	reclaimEvery5Seconds = true
 	defer func() {
 		reclaimEvery5Seconds = false


### PR DESCRIPTION
Fixes https://github.com/taskcluster/taskcluster/issues/5993

Work to follow will happen in [taskcluster/d2g](https://github.com/taskcluster/d2g) which will address https://github.com/taskcluster/taskcluster/issues/5978.

>Adds the `liveLog` and `backingLog` feature flags to the generic worker payload so they can be disabled for a task. These are enabled by default.
Adds the `logs` property to the generic worker payload allowing customization of the live and backing log artifact names.

Note: PR is easier to review commit by commit, as they're chunked up into which part of the monorepo I edited: generic worker, github service, and ui.