### PR TITLE
Use `*bool` instead of `bool` in jsonschema in go

### DIFF
--- a/changelog/MTgMbz1CQNixwcs5AnOyEQ.md
+++ b/changelog/MTgMbz1CQNixwcs5AnOyEQ.md
@@ -1,0 +1,4 @@
+audience: general
+level: patch
+---
+Go code now maps the jsonschema boolean type to `*bool` rather than `bool` in order to differentiate between an unspecified value and `false`.

--- a/clients/client-go/README.md
+++ b/clients/client-go/README.md
@@ -342,6 +342,8 @@ import (
 	"github.com/taskcluster/taskcluster/v48/clients/client-go/tcqueue"
 )
 
+var _false = false
+
 // *********************************************************
 // These type definitions are copied from:
 // https://github.com/taskcluster/generic-worker/blob/5cb2876624ce43974b1e1f96205535b037d63953/generated_windows.go#L11-L377
@@ -743,7 +745,7 @@ func main() {
 		},
 		Env: env,
 		Features: FeatureFlags{
-			ChainOfTrust: false,
+			ChainOfTrust: &_false,
 		},
 		MaxRunTime: 60,
 		Mounts:     []json.RawMessage{},

--- a/clients/client-go/codegenerator/model/types.go
+++ b/clients/client-go/codegenerator/model/types.go
@@ -269,13 +269,13 @@ type (
 		Constant string `json:"constant,omitempty"`
 
 		// True, if key may contain dots, which AMQP will consider as words. This determines if `#` or `*` should be used in client libraries
-		MultipleWords bool `json:"multipleWords"`
+		MultipleWords *bool `json:"multipleWords"`
 
 		// Identifier usable in client libraries
 		Name string `json:"name"`
 
 		// True, if the key is always present, if `false` the value `_` will be used in place when no appropriate value is available for the key.
-		Required bool `json:"required"`
+		Required *bool `json:"required"`
 
 		// Short description of key in markdown
 		Summary string `json:"summary"`

--- a/clients/client-go/tcauth/types.go
+++ b/clients/client-go/tcauth/types.go
@@ -164,7 +164,7 @@ type (
 		// it cannot be used for authentication in that state.
 		//
 		// Default:    false
-		DeleteOnExpiration bool `json:"deleteOnExpiration,omitempty"`
+		DeleteOnExpiration *bool `json:"deleteOnExpiration,omitempty"`
 
 		// Description of what these credentials are used for in markdown.
 		// Should include who is the owner, point of contact.
@@ -206,7 +206,7 @@ type (
 		// If `true`, the service may delete this client after it has expired.  If
 		// `false`, the client will remain after expiration, although it cannot be
 		// used for authentication in that state.
-		DeleteOnExpiration bool `json:"deleteOnExpiration"`
+		DeleteOnExpiration *bool `json:"deleteOnExpiration"`
 
 		// Description of what these credentials are used for in markdown.
 		// Should include who is the owner, point of contact.
@@ -216,7 +216,7 @@ type (
 
 		// If true, this client is disabled and cannot be used.  This usually occurs when the
 		// scopes available to the user owning the client no longer satisfy the client.
-		Disabled bool `json:"disabled"`
+		Disabled *bool `json:"disabled"`
 
 		// List of scopes granted to this client by matching roles, including the
 		// client's scopes and the implicit role `client-id:<clientId>`.
@@ -335,7 +335,7 @@ type (
 		// If `true`, the service may delete this client after it has expired.  If
 		// `false`, the client will remain after expiration, although it cannot be
 		// used for authentication in that state.
-		DeleteOnExpiration bool `json:"deleteOnExpiration"`
+		DeleteOnExpiration *bool `json:"deleteOnExpiration"`
 
 		// Description of what these credentials are used for in markdown.
 		// Should include who is the owner, point of contact.
@@ -345,7 +345,7 @@ type (
 
 		// If true, this client is disabled and cannot be used.  This usually occurs when the
 		// scopes available to the user owning the client no longer satisfy the client.
-		Disabled bool `json:"disabled"`
+		Disabled *bool `json:"disabled"`
 
 		// List of scopes granted to this client by matching roles.  Scopes must be
 		// composed of printable ASCII characters and spaces.

--- a/clients/client-go/tcgithub/types.go
+++ b/clients/client-go/tcgithub/types.go
@@ -110,7 +110,7 @@ type (
 	RepositoryResponse struct {
 
 		// True if integration is installed, False otherwise.
-		Installed bool `json:"installed"`
+		Installed *bool `json:"installed"`
 	}
 
 	// The GitHub webhook deliveryId. Extracted from the header 'X-GitHub-Delivery'

--- a/clients/client-go/tchooks/types.go
+++ b/clients/client-go/tchooks/types.go
@@ -142,7 +142,7 @@ type (
 		// Whether to email the owner on an error creating the task.
 		//
 		// Default:    true
-		EmailOnError bool `json:"emailOnError,omitempty"`
+		EmailOnError *bool `json:"emailOnError,omitempty"`
 
 		// Human readable name of the hook
 		//

--- a/clients/client-go/tcobject/download.go
+++ b/clients/client-go/tcobject/download.go
@@ -76,10 +76,11 @@ func (object *Object) getUrlDownload(rawResponse *DownloadObjectResponse, name s
 		// if the URL has expired, fetch a new one, verifying that each response
 		// is used at least once to avoid infinitely re-fetching
 		if responseUsed && time.Time(downloadResponse.Expires).Before(time.Now()) {
+			_true := true
 			rawResponse, err = object.StartDownload(
 				name,
 				&DownloadObjectRequest{
-					AcceptDownloadMethods: SupportedDownloadMethods{GetURL: true},
+					AcceptDownloadMethods: SupportedDownloadMethods{GetURL: &_true},
 				},
 			)
 			if err != nil {
@@ -201,11 +202,12 @@ func verifyHashes(hashingWriter *hashingWriteSeeker, expectedHashes map[string]s
 // writes it to writeSeeker, retrying if intermittent errors occur. Returns
 // the Content-Type and Content-Length of the downloaded object.
 func (object *Object) DownloadToWriteSeeker(name string, writeSeeker io.WriteSeeker) (contentType string, contentLength int64, err error) {
+	_true := true
 	downloadObjectResponse, err := object.StartDownload(
 		name,
 		&DownloadObjectRequest{
 			AcceptDownloadMethods: SupportedDownloadMethods{
-				GetURL: true,
+				GetURL: &_true,
 			},
 		},
 	)

--- a/clients/client-go/tcobject/types.go
+++ b/clients/client-go/tcobject/types.go
@@ -344,7 +344,7 @@ type (
 		// Indication that the data has been uploaded.
 		//
 		// Constant value: %!q(bool=true)
-		DataInline bool `json:"dataInline,omitempty"`
+		DataInline *bool `json:"dataInline,omitempty"`
 
 		// Response containing a URL to which to PUT the data.
 		PutURL PutURLUploadResponse `json:"putUrl,omitempty"`
@@ -365,10 +365,10 @@ type (
 	SupportedDownloadMethods struct {
 
 		// Constant value: %!q(bool=true)
-		GetURL bool `json:"getUrl,omitempty"`
+		GetURL *bool `json:"getUrl,omitempty"`
 
 		// Constant value: %!q(bool=true)
-		Simple bool `json:"simple,omitempty"`
+		Simple *bool `json:"simple,omitempty"`
 	}
 )
 

--- a/clients/client-go/tcobject/upload.go
+++ b/clients/client-go/tcobject/upload.go
@@ -109,7 +109,7 @@ func (object *Object) UploadFromReadSeeker(projectID string, name string, conten
 	}()
 
 	switch {
-	case uploadResp.UploadMethod.DataInline:
+	case uploadResp.UploadMethod.DataInline != nil && *uploadResp.UploadMethod.DataInline:
 		// data is already uploaded -- nothing to do
 		return nil
 	case uploadResp.UploadMethod.PutURL.URL != "":

--- a/clients/client-go/tcworkermanager/types.go
+++ b/clients/client-go/tcworkermanager/types.go
@@ -616,7 +616,7 @@ type (
 		Description string `json:"description"`
 
 		// If true, the owner should be emailed on provisioning errors
-		EmailOnError bool `json:"emailOnError"`
+		EmailOnError *bool `json:"emailOnError"`
 
 		// An email address to notify when there are provisioning errors for this
 		// worker pool.
@@ -655,7 +655,7 @@ type (
 		Description string `json:"description"`
 
 		// If true, the owner should be emailed on provisioning errors
-		EmailOnError bool `json:"emailOnError"`
+		EmailOnError *bool `json:"emailOnError"`
 
 		// Ignored on update
 		LastModified tcclient.Time `json:"lastModified,omitempty"`
@@ -752,7 +752,7 @@ type (
 		Description string `json:"description"`
 
 		// If true, the owner should be emailed on provisioning errors
-		EmailOnError bool `json:"emailOnError"`
+		EmailOnError *bool `json:"emailOnError"`
 
 		// Date and time when this worker pool was last updated
 		LastModified tcclient.Time `json:"lastModified"`

--- a/internal/mocktc/object.go
+++ b/internal/mocktc/object.go
@@ -38,7 +38,8 @@ func (object *Object) CreateUpload(name string, payload *tcobject.CreateUploadRe
 
 	um := tcobject.SelectedUploadMethodOrNone{}
 	if payload.ProposedUploadMethods.DataInline.ContentType != "" {
-		um.DataInline = true
+		_true := true
+		um.DataInline = &_true
 	} else {
 		um.PutURL = tcobject.PutURLUploadResponse{
 			Expires: tcclient.Time(time.Now().Add(1 * time.Hour)),
@@ -102,7 +103,7 @@ func (object *Object) StartDownload(name string, payload *tcobject.DownloadObjec
 	var dor tcobject.DownloadObjectResponse
 	var resp interface{}
 	switch {
-	case payload.AcceptDownloadMethods.Simple:
+	case payload.AcceptDownloadMethods.Simple != nil && *payload.AcceptDownloadMethods.Simple:
 		if o.onMockS3 {
 			resp = tcobject.SimpleDownloadResponse{
 				Method: "simple",
@@ -115,7 +116,7 @@ func (object *Object) StartDownload(name string, payload *tcobject.DownloadObjec
 				URL:    object.baseURL + "/simple",
 			}
 		}
-	case payload.AcceptDownloadMethods.GetURL:
+	case payload.AcceptDownloadMethods.GetURL != nil && *payload.AcceptDownloadMethods.GetURL:
 		resp = tcobject.GetURLDownloadResponse{
 			Method: "getUrl",
 			// return a URL pointing to the mockS3 server

--- a/test/go-lint.sh
+++ b/test/go-lint.sh
@@ -9,6 +9,7 @@ if [ -n "${unformatted_files}" ]; then
 fi
 
 echo "Running golangci-lint.."
+set -x
 golangci-lint run --build-tags multiuser
 golangci-lint run --build-tags simple
 golangci-lint run --build-tags docker

--- a/tools/jsonschema2go/jsonschema.go
+++ b/tools/jsonschema2go/jsonschema.go
@@ -430,7 +430,7 @@ func (jsonSubSchema *JsonSubSchema) typeDefinition(disableNested bool, topLevel 
 	case "integer":
 		typ = "int64"
 	case "boolean":
-		typ = "bool"
+		typ = "*bool"
 	// json type string maps to go type string, so only need to test case of when
 	// string is a json date-time, so we can convert to go type Time...
 	case "string":

--- a/workers/generic-worker/artifacts_multiuser_test.go
+++ b/workers/generic-worker/artifacts_multiuser_test.go
@@ -15,6 +15,9 @@ import (
 	"golang.org/x/crypto/ed25519"
 )
 
+// useful for when we need an explicit pointer to the `true` value
+var _true = true
+
 func TestChainOfTrustUpload(t *testing.T) {
 
 	setup(t)
@@ -42,7 +45,7 @@ func TestChainOfTrustUpload(t *testing.T) {
 			},
 		},
 		Features: FeatureFlags{
-			ChainOfTrust: true,
+			ChainOfTrust: &_true,
 		},
 	}
 	td := testTask(t)
@@ -270,7 +273,7 @@ func TestProtectedArtifactsReplaced(t *testing.T) {
 			},
 		},
 		Features: FeatureFlags{
-			ChainOfTrust: true,
+			ChainOfTrust: &_true,
 		},
 	}
 	td := testTask(t)

--- a/workers/generic-worker/chain_of_trust.go
+++ b/workers/generic-worker/chain_of_trust.go
@@ -86,7 +86,7 @@ func (feature *ChainOfTrustFeature) Initialise() (err error) {
 }
 
 func (feature *ChainOfTrustFeature) IsEnabled(task *TaskRun) bool {
-	return task.Payload.Features.ChainOfTrust
+	return task.Payload.Features.ChainOfTrust != nil && *task.Payload.Features.ChainOfTrust
 }
 
 func (feature *ChainOfTrustFeature) NewTaskFeature(task *TaskRun) TaskFeature {

--- a/workers/generic-worker/generated_docker_darwin.go
+++ b/workers/generic-worker/generated_docker_darwin.go
@@ -159,14 +159,14 @@ type (
 		// for the artifacts produced by the task and the environment it ran in.
 		//
 		// Since: generic-worker 5.3.0
-		ChainOfTrust bool `json:"chainOfTrust,omitempty"`
+		ChainOfTrust *bool `json:"chainOfTrust,omitempty"`
 
 		// The taskcluster proxy provides an easy and safe way to make authenticated
 		// taskcluster requests within the scope(s) of a particular task. See
 		// [the github project](https://github.com/taskcluster/taskcluster/tree/main/tools/taskcluster-proxy) for more information.
 		//
 		// Since: generic-worker 10.6.0
-		TaskclusterProxy bool `json:"taskclusterProxy,omitempty"`
+		TaskclusterProxy *bool `json:"taskclusterProxy,omitempty"`
 	}
 
 	FileMount struct {

--- a/workers/generic-worker/generated_docker_linux.go
+++ b/workers/generic-worker/generated_docker_linux.go
@@ -159,14 +159,14 @@ type (
 		// for the artifacts produced by the task and the environment it ran in.
 		//
 		// Since: generic-worker 5.3.0
-		ChainOfTrust bool `json:"chainOfTrust,omitempty"`
+		ChainOfTrust *bool `json:"chainOfTrust,omitempty"`
 
 		// The taskcluster proxy provides an easy and safe way to make authenticated
 		// taskcluster requests within the scope(s) of a particular task. See
 		// [the github project](https://github.com/taskcluster/taskcluster/tree/main/tools/taskcluster-proxy) for more information.
 		//
 		// Since: generic-worker 10.6.0
-		TaskclusterProxy bool `json:"taskclusterProxy,omitempty"`
+		TaskclusterProxy *bool `json:"taskclusterProxy,omitempty"`
 	}
 
 	FileMount struct {

--- a/workers/generic-worker/generated_multiuser_darwin.go
+++ b/workers/generic-worker/generated_multiuser_darwin.go
@@ -159,14 +159,14 @@ type (
 		// for the artifacts produced by the task and the environment it ran in.
 		//
 		// Since: generic-worker 5.3.0
-		ChainOfTrust bool `json:"chainOfTrust,omitempty"`
+		ChainOfTrust *bool `json:"chainOfTrust,omitempty"`
 
 		// The taskcluster proxy provides an easy and safe way to make authenticated
 		// taskcluster requests within the scope(s) of a particular task. See
 		// [the github project](https://github.com/taskcluster/taskcluster/tree/main/tools/taskcluster-proxy) for more information.
 		//
 		// Since: generic-worker 10.6.0
-		TaskclusterProxy bool `json:"taskclusterProxy,omitempty"`
+		TaskclusterProxy *bool `json:"taskclusterProxy,omitempty"`
 	}
 
 	FileMount struct {

--- a/workers/generic-worker/generated_multiuser_linux.go
+++ b/workers/generic-worker/generated_multiuser_linux.go
@@ -159,14 +159,14 @@ type (
 		// for the artifacts produced by the task and the environment it ran in.
 		//
 		// Since: generic-worker 5.3.0
-		ChainOfTrust bool `json:"chainOfTrust,omitempty"`
+		ChainOfTrust *bool `json:"chainOfTrust,omitempty"`
 
 		// The taskcluster proxy provides an easy and safe way to make authenticated
 		// taskcluster requests within the scope(s) of a particular task. See
 		// [the github project](https://github.com/taskcluster/taskcluster/tree/main/tools/taskcluster-proxy) for more information.
 		//
 		// Since: generic-worker 10.6.0
-		TaskclusterProxy bool `json:"taskclusterProxy,omitempty"`
+		TaskclusterProxy *bool `json:"taskclusterProxy,omitempty"`
 	}
 
 	FileMount struct {

--- a/workers/generic-worker/generated_multiuser_windows.go
+++ b/workers/generic-worker/generated_multiuser_windows.go
@@ -158,7 +158,7 @@ type (
 		// for the artifacts produced by the task and the environment it ran in.
 		//
 		// Since: generic-worker 5.3.0
-		ChainOfTrust bool `json:"chainOfTrust,omitempty"`
+		ChainOfTrust *bool `json:"chainOfTrust,omitempty"`
 
 		// Runs commands with UAC elevation. Only set to true when UAC is
 		// enabled on the worker and Administrative privileges are required by
@@ -178,14 +178,14 @@ type (
 		// `generic-worker:run-as-administrator:<provisionerId>/<workerType>`.
 		//
 		// Since: generic-worker 10.11.0
-		RunAsAdministrator bool `json:"runAsAdministrator,omitempty"`
+		RunAsAdministrator *bool `json:"runAsAdministrator,omitempty"`
 
 		// The taskcluster proxy provides an easy and safe way to make authenticated
 		// taskcluster requests within the scope(s) of a particular task. See
 		// [the github project](https://github.com/taskcluster/taskcluster/tree/main/tools/taskcluster-proxy) for more information.
 		//
 		// Since: generic-worker 10.6.0
-		TaskclusterProxy bool `json:"taskclusterProxy,omitempty"`
+		TaskclusterProxy *bool `json:"taskclusterProxy,omitempty"`
 	}
 
 	FileMount struct {

--- a/workers/generic-worker/generated_simple_darwin.go
+++ b/workers/generic-worker/generated_simple_darwin.go
@@ -158,7 +158,7 @@ type (
 		// [the github project](https://github.com/taskcluster/taskcluster/tree/main/tools/taskcluster-proxy) for more information.
 		//
 		// Since: generic-worker 10.6.0
-		TaskclusterProxy bool `json:"taskclusterProxy,omitempty"`
+		TaskclusterProxy *bool `json:"taskclusterProxy,omitempty"`
 	}
 
 	FileMount struct {

--- a/workers/generic-worker/generated_simple_freebsd.go
+++ b/workers/generic-worker/generated_simple_freebsd.go
@@ -158,7 +158,7 @@ type (
 		// [the github project](https://github.com/taskcluster/taskcluster/tree/main/tools/taskcluster-proxy) for more information.
 		//
 		// Since: generic-worker 10.6.0
-		TaskclusterProxy bool `json:"taskclusterProxy,omitempty"`
+		TaskclusterProxy *bool `json:"taskclusterProxy,omitempty"`
 	}
 
 	FileMount struct {

--- a/workers/generic-worker/generated_simple_linux.go
+++ b/workers/generic-worker/generated_simple_linux.go
@@ -158,7 +158,7 @@ type (
 		// [the github project](https://github.com/taskcluster/taskcluster/tree/main/tools/taskcluster-proxy) for more information.
 		//
 		// Since: generic-worker 10.6.0
-		TaskclusterProxy bool `json:"taskclusterProxy,omitempty"`
+		TaskclusterProxy *bool `json:"taskclusterProxy,omitempty"`
 	}
 
 	FileMount struct {

--- a/workers/generic-worker/runasadministrator_windows.go
+++ b/workers/generic-worker/runasadministrator_windows.go
@@ -23,7 +23,7 @@ func (feature *RunAsAdministratorFeature) PersistState() error {
 }
 
 func (feature *RunAsAdministratorFeature) IsEnabled(task *TaskRun) bool {
-	return task.Payload.Features.RunAsAdministrator
+	return task.Payload.Features.RunAsAdministrator != nil && *task.Payload.Features.RunAsAdministrator
 }
 
 type RunAsAdministratorTask struct {

--- a/workers/generic-worker/runasadministrator_windows_test.go
+++ b/workers/generic-worker/runasadministrator_windows_test.go
@@ -4,6 +4,9 @@ import (
 	"testing"
 )
 
+// useful for when we need an explicit pointer to the `false` value
+var _false = false
+
 func TestRunAsAdministratorDisabled(t *testing.T) {
 	setup(t)
 	if config.RunTasksAsCurrentUser {
@@ -39,7 +42,7 @@ func TestRunAsAdministratorEnabledMissingScopes(t *testing.T) {
 		},
 		MaxRunTime: 10,
 		Features: FeatureFlags{
-			RunAsAdministrator: true,
+			RunAsAdministrator: &_true,
 		},
 		OSGroups: []string{
 			"Administrators",
@@ -69,7 +72,7 @@ func TestRunAsAdministratorMissingOSGroup(t *testing.T) {
 		MaxRunTime: 10,
 		OSGroups:   []string{}, // Administrators not included!
 		Features: FeatureFlags{
-			RunAsAdministrator: true,
+			RunAsAdministrator: &_true,
 		},
 	}
 	td := testTask(t)
@@ -95,8 +98,8 @@ func TestChainOfTrustWithRunAsAdministrator(t *testing.T) {
 		MaxRunTime: 5,
 		OSGroups:   []string{"Administrators"},
 		Features: FeatureFlags{
-			ChainOfTrust:       true,
-			RunAsAdministrator: true,
+			ChainOfTrust:       &_true,
+			RunAsAdministrator: &_true,
 		},
 	}
 	td := testTask(t)
@@ -129,8 +132,8 @@ func TestChainOfTrustWithoutRunAsAdministrator(t *testing.T) {
 		MaxRunTime: 5,
 		OSGroups:   []string{"Administrators"},
 		Features: FeatureFlags{
-			ChainOfTrust:       true,
-			RunAsAdministrator: false, // FALSE !!!!
+			ChainOfTrust:       &_true,
+			RunAsAdministrator: &_false, // FALSE !!!!
 		},
 	}
 	td := testTask(t)
@@ -170,7 +173,7 @@ func TestRunAsAdministratorEnabled(t *testing.T) {
 		},
 		MaxRunTime: 10,
 		Features: FeatureFlags{
-			RunAsAdministrator: true,
+			RunAsAdministrator: &_true,
 		},
 		OSGroups: []string{
 			"Administrators",

--- a/workers/generic-worker/taskcluster_proxy.go
+++ b/workers/generic-worker/taskcluster_proxy.go
@@ -28,7 +28,7 @@ func (feature *TaskclusterProxyFeature) PersistState() error {
 }
 
 func (feature *TaskclusterProxyFeature) IsEnabled(task *TaskRun) bool {
-	return task.Payload.Features.TaskclusterProxy
+	return task.Payload.Features.TaskclusterProxy != nil && *task.Payload.Features.TaskclusterProxy
 }
 
 type TaskclusterProxyTask struct {

--- a/workers/generic-worker/taskcluster_proxy_broken_on_docker_test.go
+++ b/workers/generic-worker/taskcluster_proxy_broken_on_docker_test.go
@@ -25,6 +25,8 @@ func TestTaskclusterProxy(t *testing.T) {
 		[]byte("TASKCLUSTER_PROXY_URL/queue/v1/task/" + taskID + "/artifacts/SampleArtifacts%2F_%2FX.txt"),
 	)
 
+	_true := true
+
 	payload := GenericWorkerPayload{
 		Command: append(
 			append(
@@ -40,7 +42,7 @@ func TestTaskclusterProxy(t *testing.T) {
 		MaxRunTime: 180,
 		Env:        map[string]string{},
 		Features: FeatureFlags{
-			TaskclusterProxy: true,
+			TaskclusterProxy: &_true,
 		},
 	}
 	for _, envVar := range []string{


### PR DESCRIPTION
>Go code now maps the jsonschema boolean type to `*bool` rather than `bool` in order to differentiate between an unspecified value and `false`.