### PR TITLE
Dashboard displays stopping capacity, values autoreloaded.

### DIFF
--- a/changelog/SJ8XbCO5RE6EPQLrqgmn-g.md
+++ b/changelog/SJ8XbCO5RE6EPQLrqgmn-g.md
@@ -1,0 +1,5 @@
+audience: users
+level: patch
+---
+
+Dashboard displays worker manager provisioning stats separately. Values are being automatically reloaded every 30 seconds.

--- a/ui/src/components/StatusDashboard/StatsFetcher.jsx
+++ b/ui/src/components/StatusDashboard/StatsFetcher.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useRef } from 'react';
 import { useQuery } from 'react-apollo';
 import StatusDashboard from '.';
 import clientsQuery from './clients.graphql';
@@ -15,6 +15,16 @@ export default function StatsFetcher() {
   const clients = useQuery(clientsQuery);
   const roles = useQuery(rolesQuery);
   const secrets = useQuery(secretsQuery);
+  const refreshInterval = 30 * 1000;
+  const intervalRef = useRef();
+
+  useEffect(() => {
+    intervalRef.current = setInterval(() => {
+      workerPools.refetch();
+    }, refreshInterval);
+
+    return () => clearInterval(intervalRef.current);
+  }, [workerPools, refreshInterval]);
 
   return (
     <StatusDashboard

--- a/ui/src/components/StatusDashboard/index.jsx
+++ b/ui/src/components/StatusDashboard/index.jsx
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React, { Component, useState, useEffect } from 'react';
 import { object } from 'prop-types';
 import { Grid, Paper, withStyles, Typography } from '@material-ui/core';
 import { Link } from 'react-router-dom';
@@ -16,26 +16,35 @@ const Item = ({
   hint,
   error,
   altColor = false,
-}) => (
-  <Paper className={classMain}>
-    <Typography variant="h5">
-      {title}
-      {hint && (
-        <abbr title={hint} style={{ marginLeft: 5 }}>
-          ?
-        </abbr>
-      )}
-    </Typography>
-    <abbr title={error}>
-      <Typography
-        className={classValue}
-        style={altColor ? { color: '#51e9f1' } : {}}
-        variant={getLength(value) < 10 ? 'h2' : 'h4'}>
-        {value}
+}) => {
+  const [styles, setStyles] = useState({});
+
+  useEffect(() => {
+    setStyles({ backgroundColor: '#A459D1' });
+    setTimeout(() => setStyles({}), 2000);
+  }, [value]);
+
+  return (
+    <Paper className={classMain} style={styles}>
+      <Typography variant="h5">
+        {title}
+        {hint && (
+          <abbr title={hint} style={{ marginLeft: 5 }}>
+            ?
+          </abbr>
+        )}
       </Typography>
-    </abbr>
-  </Paper>
-);
+      <abbr title={error}>
+        <Typography
+          className={classValue}
+          style={altColor ? { color: '#51e9f1' } : {}}
+          variant={getLength(value) < 10 ? 'h2' : 'h4'}>
+          {value}
+        </Typography>
+      </abbr>
+    </Paper>
+  );
+};
 
 @withStyles(theme => ({
   grid: {
@@ -50,6 +59,7 @@ const Item = ({
       theme.palette.type === 'dark'
         ? theme.palette.text.primary
         : theme.palette.text.secondary,
+    transition: 'all 0.8s ease-in-out',
   },
   itemValue: {
     color: theme.palette.warning.main,
@@ -91,8 +101,11 @@ export default class StatusDashboard extends Component {
     const filterAvailable = items =>
       items.filter(item => !item.loading && !item.error);
     const widgets = {
+      'Worker Manager Provisioning': filterAvailable(
+        summarizeWorkerPools(workerPools, 'provisioning')
+      ),
       'Worker Manager Stats': filterAvailable(
-        summarizeWorkerPools(workerPools)
+        summarizeWorkerPools(workerPools, 'stats')
       ),
       'Worker Provisioners': filterAvailable(
         summarizeProvisioners(provisioners)
@@ -113,7 +126,7 @@ export default class StatusDashboard extends Component {
                 <Typography variant="h5">{group}</Typography>
               </Grid>
               {widgets[group].map(props => (
-                <Grid item xs={12} sm={6} md={4} key={props.title}>
+                <Grid item xs={12} sm={6} md={3} key={props.title}>
                   {props.link ? (
                     <Link to={props.link}>
                       <Item

--- a/ui/src/components/StatusDashboard/summarizeWorkerPools.js
+++ b/ui/src/components/StatusDashboard/summarizeWorkerPools.js
@@ -1,14 +1,14 @@
 import format from './format';
 
-export default workerPools => {
+export default (workerPools, metrics) => {
   let totalPools = 0;
   let poolsWithWorkers = 0;
   let pendingTasks = 0;
-  let requestedCount = 0;
   let stoppedCount = 0;
   let runningCount = 0;
   let requestedCapacity = 0;
   let runningCapacity = 0;
+  let stoppingCapacity = 0;
   const providers = new Set();
 
   if (!workerPools.error && !workerPools.loading) {
@@ -27,10 +27,10 @@ export default workerPools => {
 
         pendingTasks += node.pendingTasks;
         runningCount += node.runningCount;
-        requestedCount += node.requestedCount;
         requestedCapacity += node.requestedCapacity;
         runningCapacity += node.runningCapacity;
         stoppedCount += node.stoppedCount;
+        stoppingCapacity += node.stoppingCapacity;
       }
     );
   }
@@ -44,6 +44,7 @@ export default workerPools => {
       link,
       error: workerPools.error?.message,
       loading: workerPools.loading,
+      metrics: 'stats',
     },
     {
       title: 'Total Pools',
@@ -51,6 +52,7 @@ export default workerPools => {
       link,
       error: workerPools.error?.message,
       loading: workerPools.loading,
+      metrics: 'stats',
     },
     {
       title: 'Total Pools with Workers',
@@ -58,6 +60,7 @@ export default workerPools => {
       link,
       error: workerPools.error?.message,
       loading: workerPools.loading,
+      metrics: 'stats',
     },
     {
       title: 'Workers Running',
@@ -65,13 +68,7 @@ export default workerPools => {
       link,
       error: workerPools.error?.message,
       loading: workerPools.loading,
-    },
-    {
-      title: 'Workers Requested',
-      value: format(requestedCount),
-      link,
-      error: workerPools.error?.message,
-      loading: workerPools.loading,
+      metrics: 'stats',
     },
     {
       title: 'Stopped Workers',
@@ -79,6 +76,7 @@ export default workerPools => {
       link,
       error: workerPools.error?.message,
       loading: workerPools.loading,
+      metrics: 'stats',
     },
     {
       title: 'Pending Tasks',
@@ -87,14 +85,7 @@ export default workerPools => {
       error: workerPools.error?.message,
       loading: workerPools.loading,
       altColor: true,
-    },
-    {
-      title: 'Running Capacity',
-      value: format(runningCapacity),
-      link,
-      error: workerPools.error?.message,
-      loading: workerPools.loading,
-      altColor: true,
+      metrics: 'provisioning',
     },
     {
       title: 'Requested Capacity',
@@ -103,6 +94,25 @@ export default workerPools => {
       error: workerPools.error?.message,
       loading: workerPools.loading,
       altColor: true,
+      metrics: 'provisioning',
     },
-  ];
+    {
+      title: 'Running Capacity',
+      value: format(runningCapacity),
+      link,
+      error: workerPools.error?.message,
+      loading: workerPools.loading,
+      altColor: true,
+      metrics: 'provisioning',
+    },
+    {
+      title: 'Stopping Capacity',
+      value: format(stoppingCapacity),
+      link,
+      error: workerPools.error?.message,
+      loading: workerPools.loading,
+      altColor: true,
+      metrics: 'provisioning',
+    },
+  ].filter(item => !metrics || item.metrics === metrics);
 };

--- a/ui/src/components/StatusDashboard/summarizeWorkerPools.test.js
+++ b/ui/src/components/StatusDashboard/summarizeWorkerPools.test.js
@@ -26,38 +26,75 @@ describe('summarizeWorkerPools', () => {
     expect(out[2].error).toEqual('wrong');
     expect(out[5].error).toEqual('wrong');
   });
-  it('should return counts', () => {
-    const out = summarizeWorkerPools({
-      data: {
-        WorkerManagerWorkerPoolSummaries: {
-          edges: [
-            {
-              node: {
-                providerId: 'prov1',
-                currentCapacity: 1,
-                pendingTasks: 9,
-                runningCount: 1,
-                requestedCount: 1,
-                requestedCapacity: 1,
-                runningCapacity: 1,
-                stoppedCount: 3,
+
+  const widgetByTitle = (widgets, title) =>
+    widgets.find(widget => widget.title === title);
+
+  it('should return counts for stats', () => {
+    const out = summarizeWorkerPools(
+      {
+        data: {
+          WorkerManagerWorkerPoolSummaries: {
+            edges: [
+              {
+                node: {
+                  providerId: 'prov1',
+                  currentCapacity: 1,
+                  pendingTasks: 9,
+                  runningCount: 1,
+                  requestedCount: 1,
+                  requestedCapacity: 1,
+                  runningCapacity: 1,
+                  stoppedCount: 3,
+                },
               },
-            },
-          ],
+            ],
+          },
         },
       },
-    });
+      'stats'
+    );
 
-    expect(out.length).toEqual(9);
-    expect(out[0].value).toEqual('1');
-    expect(out[1].value).toEqual('1');
-    expect(out[2].value).toEqual('1');
-    expect(out[3].value).toEqual('1');
-    expect(out[3].value).toEqual('1');
-    expect(out[4].value).toEqual('1');
-    expect(out[5].value).toEqual('3');
-    expect(out[6].value).toEqual('9');
-    expect(out[7].value).toEqual('1');
-    expect(out[8].value).toEqual('1');
+    expect(out.length).toEqual(5);
+
+    expect(widgetByTitle(out, 'Providers').value).toEqual('1');
+    expect(widgetByTitle(out, 'Total Pools').value).toEqual('1');
+    expect(widgetByTitle(out, 'Total Pools with Workers').value).toEqual('1');
+    expect(widgetByTitle(out, 'Workers Running').value).toEqual('1');
+    expect(widgetByTitle(out, 'Stopped Workers').value).toEqual('3');
+  });
+
+  it('should return counts for provisioning', () => {
+    const out = summarizeWorkerPools(
+      {
+        data: {
+          WorkerManagerWorkerPoolSummaries: {
+            edges: [
+              {
+                node: {
+                  providerId: 'prov1',
+                  currentCapacity: 1,
+                  pendingTasks: 9,
+                  runningCount: 1,
+                  requestedCount: 1,
+                  requestedCapacity: 1,
+                  runningCapacity: 1,
+                  stoppedCount: 3,
+                  stoppingCapacity: 4,
+                },
+              },
+            ],
+          },
+        },
+      },
+      'provisioning'
+    );
+
+    expect(out.length).toEqual(4);
+
+    expect(widgetByTitle(out, 'Pending Tasks').value).toEqual('9');
+    expect(widgetByTitle(out, 'Requested Capacity').value).toEqual('1');
+    expect(widgetByTitle(out, 'Running Capacity').value).toEqual('1');
+    expect(widgetByTitle(out, 'Stopping Capacity').value).toEqual('4');
   });
 });


### PR DESCRIPTION
Few updates to the dashboard:

* `stoppingCapacity` is being displayed, since worker manager uses it during provisioning
* Values are being grouped by provisioning and general stats
* worker manager stats are being refreshed every 30s
* visual animations when values change

<img width="894" alt="image" src="https://user-images.githubusercontent.com/83861/226345513-76d74c8b-2b05-4978-81fd-eac8391c9c77.png">

