### PR TITLE
fix(ui): Fix graphql filter query for TaskGroup

### DIFF
--- a/changelog/issue-6124.md
+++ b/changelog/issue-6124.md
@@ -1,0 +1,7 @@
+audience: users
+level: patch
+reference: issue 6124
+---
+
+Fix a bug in UI where TaskGroup page would show "Malformed query" warning.
+This was due to the `sift` library getting upgraded which changed the behaviour of filters.

--- a/ui/src/views/Tasks/TaskGroup/index.jsx
+++ b/ui/src/views/Tasks/TaskGroup/index.jsx
@@ -96,9 +96,7 @@ const updateTaskGroupIdHistory = id => {
         kind: {
           $in: ACTIONS_JSON_KNOWN_KINDS,
         },
-        context: {
-          $or: [{ $size: 0 }, { $size: 1 }],
-        },
+        $or: [{ context: { $size: 0 } }, { context: { $size: 1 } }],
       },
     },
   }),
@@ -520,9 +518,7 @@ export default class TaskGroup extends Component {
           kind: {
             $in: ACTIONS_JSON_KNOWN_KINDS,
           },
-          context: {
-            $or: [{ $size: 0 }, { $size: 1 }],
-          },
+          $or: [{ context: { $size: 0 } }, { context: { $size: 1 } }],
         },
       },
       updateQuery: (previousResult = {}, { fetchMoreResult, variables }) => {


### PR DESCRIPTION
This error wasn't showing up on community-tc because we don’t use `actions.json` artifact.. but on fxci it is being used, so when it is not empty, graphql loader is trying to filter those actions with broken filter (filter that might be working with old library, but is not with the new one)

Fixes #6124 