### PR TITLE
fix(generic-worker): ensure workerPoolID contains slash

### DIFF
--- a/changelog/issue-6130.md
+++ b/changelog/issue-6130.md
@@ -1,0 +1,5 @@
+audience: worker-deployers
+level: patch
+reference: issue 6130
+---
+This patch ensures that the worker pool ID passed to generic worker contains a slash (`/`) and will error out describing the issue as opposed to panicing when an `index out of range` error.

--- a/tools/worker-runner/worker/genericworker/genericworker.go
+++ b/tools/worker-runner/worker/genericworker/genericworker.go
@@ -73,6 +73,11 @@ func (d *genericworker) ConfigureRun(state *run.State) error {
 	// split to workerType and provisionerId
 	splitWorkerPoolID := strings.SplitAfterN(state.WorkerPoolID, "/", 2)
 
+	// ensure that the workerPoolID has a slash in it
+	if len(splitWorkerPoolID) != 2 {
+		return fmt.Errorf("workerPoolID %q does not contain a slash", state.WorkerPoolID)
+	}
+
 	// required settings
 	// see https://docs.taskcluster.net/docs/reference/workers/generic-worker/installing#set-up-your-env
 	set("rootURL", state.RootURL)


### PR DESCRIPTION
Fixes https://github.com/taskcluster/taskcluster/issues/6130