### PR TITLE
feat(github): Skip updating statuses when task is running

### DIFF
--- a/changelog/bug-1590886.md
+++ b/changelog/bug-1590886.md
@@ -1,0 +1,5 @@
+audience: users
+level: patch
+reference: bug 1590886
+---
+Fix Github statuses: skip unnecessary API updates when task starts running.

--- a/services/github/test/handler_test.js
+++ b/services/github/test/handler_test.js
@@ -838,6 +838,18 @@ helper.secrets.mockSuite(testing.suiteName(), [], function (mock, skipping) {
       await assertStatusUpdate('pending');
       await assertBuildState('pending');
     });
+    test('task running not changing state if it is pending', async function() {
+      await addBuild({ state: 'pending', taskGroupId: TASKGROUPID });
+      await simulateExchangeMessage({
+        taskGroupId: TASKGROUPID,
+        exchange: 'exchange/taskcluster-queue/v1/task-running',
+        routingKey: 'route.statuses',
+        runId: 0,
+        state: 'running',
+      });
+      assert(github.inst(9988).repos.createCommitStatus.calledOnce === false);
+      await assertBuildState('pending');
+    });
   });
 
   suite('Checks API: result status handler', function () {


### PR DESCRIPTION
Patching https://github.com/taskcluster/taskcluster/pull/6129 that was released in 48.2.0

Since new event was added to that handler, it was invoked too often and resulted in unnecessary status api updates.
When task starts running  it is only worth updating status if whole build was already fail/success. 
Initial `pending` state is handled by a different handler, so safe to skip it here