### PR TITLE
docker-worker: set a timeout when downloading artifact

### DIFF
--- a/changelog/bug-1824937-0.md
+++ b/changelog/bug-1824937-0.md
@@ -1,0 +1,5 @@
+audience: users
+level: patch
+reference: bug 1824937
+---
+docker-worker no longer waits indefinitely when downloading an image artifact, and will retry if the connection is idle for 60s

--- a/workers/docker-worker/src/util/artifact_download.js
+++ b/workers/docker-worker/src/util/artifact_download.js
@@ -42,6 +42,7 @@ module.exports = async function(queue, stream, taskId, artifactPath, destination
         method: 'GET',
         url: artifactUrl,
         gzip: true,
+        timeout: 60 * 1000,
       });
       req.on('response', (res) => {
         // measure the expected HTTP response body size and actual, to compare later


### PR DESCRIPTION
If the connection to download the docker image hangs for whatever reason, we could wait indefinitely, and because the maxRunTime timer isn't set up by that point, we'd only stop when hitting the task's deadline and failing to reclaim it.
Instead, time out the connection if it stays idle for 60 seconds, so we can properly retry the download.

<!-- Did you remember to add a changelog snippet? See
     https://github.com/taskcluster/taskcluster/blob/main/dev-docs/best-practices/changelog.md

     If this is related to a Bugzilla bug, please begin your title with [Bug XXXXX]
     and update this link.  Otherwise, just remove it from your PR comment.  -->

Bugzilla Bug: [1824937](https://bugzilla.mozilla.org/show_bug.cgi?id=1824937)