### PR TITLE
docker-worker: add a timer for task setup, defaulting to 10 minutes

### DIFF
--- a/changelog/bug-1824937.md
+++ b/changelog/bug-1824937.md
@@ -1,0 +1,5 @@
+audience: users
+level: patch
+reference: bug 1824937
+---
+Limit the amount of time docker-worker can spend setting up the container for the task, to 10 minutes by default

--- a/workers/docker-worker/config.yml
+++ b/workers/docker-worker/config.yml
@@ -113,6 +113,9 @@ defaults:
     # Tasks should be removed from the queue if they have been dequeued a lot.
     # Possible signs that the task is bad
     dequeueCount: 15
+    # Maximum amount of time to wait for the task setup (e.g. downloading
+    # docker images), in seconds
+    maxSetupTime: 600
 
   taskQueue:
     # Task queue will be polled on a frequent interval for new pending tasks

--- a/workers/docker-worker/src/task.js
+++ b/workers/docker-worker/src/task.js
@@ -811,6 +811,13 @@ class Task extends EventEmitter {
       );
     }
 
+    let maxSetupTimeMS = this.runtime.task.maxSetupTime * 1000;
+    let setupTimeoutId = setTimeout(async function() {
+      await this.abortRun(fmtErrorLog(
+        'Task setup timeout after %d seconds. Aborting.',
+        this.runtime.task.maxSetupTime));
+    }.bind(this), maxSetupTimeMS);
+
     // Download the docker image needed for this task... This may fail in
     // unexpected ways and should be handled gracefully to indicate to the user
     // that their task has failed due to a image specific problem rather then
@@ -871,6 +878,8 @@ class Task extends EventEmitter {
     dockerProc.stdout.pipe(this.stream, {
       end: false,
     });
+
+    clearTimeout(setupTimeoutId);
 
     let runtimeTimeoutId = this.setRuntimeTimeout(this.task.payload.maxRunTime);
 

--- a/workers/docker-worker/test/integration/setup_timeout_test.js
+++ b/workers/docker-worker/test/integration/setup_timeout_test.js
@@ -1,0 +1,43 @@
+const assert = require('assert');
+const slugid = require('slugid');
+const settings = require('../settings');
+const DockerWorker = require('../dockerworker');
+const TestWorker = require('../testworker');
+const { suiteName } = require('taskcluster-lib-testing');
+const helper = require('../helper');
+
+helper.secrets.mockSuite(suiteName(), ['docker', 'ci-creds'], function(mock, skipping) {
+  if (mock) {
+    return; // no fake equivalent for integration tests
+  }
+
+  test('setup timeout', async () => {
+    settings.configure({
+      task: {
+        maxSetupTime: 0.01, // 10ms
+      },
+    });
+
+    let task = {
+      payload: {
+        image: 'taskcluster/test-ubuntu',
+        command: [
+          '/bin/bash', '-c', 'echo "Hello"; sleep 60; echo "done";',
+        ],
+        features: {
+          localLiveLog: false,
+        },
+        maxRunTime: 60 * 60,
+      },
+    };
+    let taskId = slugid.v4();
+    let worker = new TestWorker(DockerWorker);
+    let abortedTask;
+    worker.on('task aborted', () => abortedTask = true);
+    await worker.launch();
+    let result = await worker.postToQueue(task, taskId);
+    await worker.terminate();
+    assert.ok(abortedTask, 'task execution should have been aborted');
+    assert.equal(result.run.reasonResolved, 'aborted', 'Task not marked as aborted');
+  });
+});


### PR DESCRIPTION
Limit the amount of time we can spend setting up the docker container for the task.
    
Bugzilla Bug: [1824937](https://bugzilla.mozilla.org/show_bug.cgi?id=1824937)