### PR TITLE
Github: add 'collaborators_quiet' to the schema.

### DIFF
--- a/changelog/KMtFPmGnQaG6m-dUIL2Y8w.md
+++ b/changelog/KMtFPmGnQaG6m-dUIL2Y8w.md
@@ -1,0 +1,5 @@
+audience: users
+level: patch
+---
+
+Enables missing `collaborators_quiet` policy to the schema validation of `.taskcluster.yml`.

--- a/generated/references.json
+++ b/generated/references.json
@@ -6644,7 +6644,8 @@
               "enum": [
                 "public",
                 "public_restricted",
-                "collaborators"
+                "collaborators",
+                "collaborators_quiet"
               ],
               "type": "string"
             }

--- a/services/github/schemas/v1/taskcluster-github-config.v1.yml
+++ b/services/github/schemas/v1/taskcluster-github-config.v1.yml
@@ -22,6 +22,7 @@ properties:
           - public
           - public_restricted
           - collaborators
+          - collaborators_quiet
     additionalProperties: false
     required: [pullRequests]
   reporting:

--- a/services/github/test/handler_test.js
+++ b/services/github/test/handler_test.js
@@ -747,6 +747,19 @@ helper.secrets.mockSuite(testing.suiteName(), [], function (mock, skipping) {
 
       assert(handlers.createTasks.calledWith({ scopes: sinon.match.array, tasks: sinon.match.array }));
     });
+
+    test('using collaborators_quiet policy should not create comment', async function () {
+      github.inst(5828).setTaskclusterYml({
+        owner: 'TaskclusterRobot',
+        repo: 'hooks-testing',
+        ref: 'development', // default branch
+        content: { version: 1, policy: { pullRequests: 'collaborators_quiet' } },
+      });
+      await simulateJobMessage({ user: 'not-a-collaborator', eventType: 'pull_request.opened' });
+
+      assert(github.inst(5828).repos.createCommitStatus.callCount === 0);
+      assert(github.inst(5828).issues.createComment.callCount === 0);
+    });
   });
 
   suite('Statuses API: result status handler', function () {

--- a/ui/docs/reference/integrations/github/taskcluster-yml-v1.mdx
+++ b/ui/docs/reference/integrations/github/taskcluster-yml-v1.mdx
@@ -41,7 +41,7 @@ The `pullRequests` policy controls this behavior:
   Please note that only user who *created* the pull request and the user owning the head repository are being checked, even if the event itself comes from the actions of another user.
   For example, if a collaborator modifies the assignee for or re-opens a PR filed by a non-collaborator, tasks will not be started.
 
-* `collaborators_quiet` -- tasks are created if the user who made the pull request is a collaborator on the repository. we don't make any comment on the pull request if the user is not a collaborator, which we are doing in **collaborators** policy.
+* `collaborators_quiet` -- this setting ensures that tasks are only generated when the pull request's author is a collaborator on the repository. In this mode, no comments will be added to the pull request if the author is not a collaborator, as handled by the **collaborators** policy. The purpose of this option is to maintain a quieter interaction when dealing with non-collaborator users while still enabling task creation for collaborators.
 
 Github [defines collaborators](https://developer.github.com/v3/repos/collaborators/#list-collaborators) as "outside collaborators, organization members with access through team memberships, organization members with access through default organization permissions, and organization owners."
 


### PR DESCRIPTION
It looks like this was forgotten during initial implementations in #327 and #572 of the <https://bugzilla.mozilla.org/show_bug.cgi?id=1446768>
