### PR TITLE
ci: build/test gw (multiuser) on macOS 13 on arm64

### DIFF
--- a/changelog/ATiAPN9YTSa2nWrYeK0ugA.md
+++ b/changelog/ATiAPN9YTSa2nWrYeK0ugA.md
@@ -1,0 +1,4 @@
+audience: general
+level: patch
+---
+Builds and tests generic worker (multiuser) on macOS Ventura 13 on new, arm64 machines.

--- a/workers/generic-worker/gw-decision-task/tasks.yml
+++ b/workers/generic-worker/gw-decision-task/tasks.yml
@@ -44,6 +44,9 @@ Tasks:
     - WorkerPool: proj-taskcluster/gw-ci-macos-10-14
       Env:
         ENGINE: multiuser
+    - WorkerPool: proj-taskcluster/gw-ci-macos-13
+      Env:
+        ENGINE: multiuser
     - WorkerPool: proj-taskcluster/gw-ci-ubuntu-22-04
       Env:
         ENGINE: multiuser
@@ -64,6 +67,10 @@ WorkerPools:
     Platform: macOS Mojave 10.14
     OS: darwin
     Arch: amd64
+  proj-taskcluster/gw-ci-macos-13:
+    Platform: macOS Ventura 13 (arm64)
+    OS: darwin
+    Arch: arm64
   proj-taskcluster/gw-ci-raspbian-stretch:
     Platform: Raspbian GNU/Linux 9 (stretch)
     OS: linux
@@ -278,6 +285,7 @@ Mounts:
         arm64:
           url: https://storage.googleapis.com/golang/go1.19.7.darwin-arm64.tar.gz
           sha256: be85d929f390351212d1fde21c460102983b6341349811bc449bd278fe8f8180
+          format: tar.gz
       linux:
         armv6l:
           url: https://storage.googleapis.com/golang/go1.19.7.linux-armv6l.tar.gz

--- a/workers/generic-worker/gw-decision-task/tasks.yml
+++ b/workers/generic-worker/gw-decision-task/tasks.yml
@@ -41,9 +41,6 @@ Types:
     MaxRunTime: 3600
 Tasks:
   BuildAndTest:
-    - WorkerPool: proj-taskcluster/gw-ci-macos-10-14
-      Env:
-        ENGINE: multiuser
     - WorkerPool: proj-taskcluster/gw-ci-macos-13
       Env:
         ENGINE: multiuser
@@ -63,10 +60,6 @@ Tasks:
   FormatSource:
     - WorkerPool: proj-taskcluster/gw-ci-ubuntu-22-04
 WorkerPools:
-  proj-taskcluster/gw-ci-macos-10-14:
-    Platform: macOS Mojave 10.14
-    OS: darwin
-    Arch: amd64
   proj-taskcluster/gw-ci-macos-13:
     Platform: macOS Ventura 13 (arm64)
     OS: darwin


### PR DESCRIPTION
>Builds and tests generic worker (multiuser) on macOS Ventura 13 on new, arm64 machines.