### PR TITLE
refactor!: drop support for python 3.6

### DIFF
--- a/changelog/Trjdzsg9Sbyt4rHD-N-aBw.md
+++ b/changelog/Trjdzsg9Sbyt4rHD-N-aBw.md
@@ -1,0 +1,6 @@
+audience: users
+level: major
+---
+Remove python 3.6 support as it's past its end-of-life date.
+
+Add python 3.10 and python 3.11 support.

--- a/clients/client-py/setup.py
+++ b/clients/client-py/setup.py
@@ -58,8 +58,8 @@ class Tox(TestCommand):
         errno = tox.cmdline(args=args)
         sys.exit(errno)
 
-if sys.version_info[0] == 3 and sys.version_info[:2] < (3, 5):
-    raise Exception('This library does not support Python 3 versions below 3.5')
+if sys.version_info[0] == 3 and sys.version_info[:2] < (3, 6):
+    raise Exception('This library does not support Python 3 versions below 3.6')
 
 with open('README.md', encoding='utf8') as f:
     long_description = f.read()
@@ -89,9 +89,10 @@ if __name__ == '__main__':
         cmdclass={'test': Tox},
         zip_safe=False,
         classifiers=[
-            'Programming Language :: Python :: 3.6',
             'Programming Language :: Python :: 3.7',
             'Programming Language :: Python :: 3.8',
             'Programming Language :: Python :: 3.9',
+            'Programming Language :: Python :: 3.10',
+            'Programming Language :: Python :: 3.11',
         ],
     )

--- a/clients/client-py/tox.ini
+++ b/clients/client-py/tox.ini
@@ -1,9 +1,10 @@
 [tox]
 envlist =
-    py36
     py37
     py38
     py39
+    py310
+    py311
 
 [testenv]
 passenv =

--- a/services/github/test/data/configs/taskcluster.dependencies.v1.yml
+++ b/services/github/test/data/configs/taskcluster.dependencies.v1.yml
@@ -6,8 +6,9 @@ tasks:
   then:
     - taskId: "docker_build"
       dependencies:
-      - "py36"
       - "py37"
+      - "py38"
+      - "py39"
       provisionerId: test-provisioner
       workerType: releng-svc
       created: {$fromNow: ''}
@@ -18,22 +19,6 @@ tasks:
       metadata:
         name: docker build
         description: build latest docker image
-        owner: owner
-        source: source
-
-    - taskId: "py36"
-      provisionerId: test-provisioner
-      workerType: github-worker
-      created: {$fromNow: ''}
-      deadline: {$fromNow: '1 hour'}
-      payload:
-        maxRunTime: 3600
-        image: python:3.6
-        command:
-          - sh
-      metadata:
-        name: tox py36
-        description: code linting & unit tests on py36
         owner: owner
         source: source
 
@@ -66,5 +51,37 @@ tasks:
       metadata:
         name: tox py37
         description: code linting & unit tests on py37
+        owner: owner
+        source: source
+
+    - taskId: "py38"
+      provisionerId: test-provisioner
+      workerType: github-worker
+      created: {$fromNow: ''}
+      deadline: {$fromNow: '1 hour'}
+      payload:
+        maxRunTime: 3600
+        image: python:3.8
+        command:
+          - sh
+      metadata:
+        name: tox py38
+        description: code linting & unit tests on py38
+        owner: owner
+        source: source
+
+    - taskId: "py39"
+      provisionerId: test-provisioner
+      workerType: github-worker
+      created: {$fromNow: ''}
+      deadline: {$fromNow: '1 hour'}
+      payload:
+        maxRunTime: 3600
+        image: python:3.9
+        command:
+          - sh
+      metadata:
+        name: tox py37
+        description: code linting & unit tests on py39
         owner: owner
         source: source

--- a/services/github/test/intree_test.js
+++ b/services/github/test/intree_test.js
@@ -527,10 +527,11 @@ suite(testing.suiteName(), function() {
       }),
     },
     {
-      'tasks[0].taskId': 'py36',
-      'tasks[1].taskId': 'py37',
-      'tasks[2].taskId': 'docker_build',
-      'tasks[3].taskId': 'docker_push',
+      'tasks[0].taskId': 'py37',
+      'tasks[1].taskId': 'py38',
+      'tasks[2].taskId': 'py39',
+      'tasks[3].taskId': 'docker_build',
+      'tasks[4].taskId': 'docker_push',
     },
   );
 });

--- a/taskcluster/ci/client/kind.yml
+++ b/taskcluster/ci/client/kind.yml
@@ -62,18 +62,6 @@ tasks:
           {{ Xvfb :99 -screen 0 640x480x8 -nolisten tcp & }} &&
           sleep 2 &&
           CHROME_BIN=firefox DISPLAY=:99 yarn test
-  py36:
-    description: python3.6 client tests
-    worker:
-      docker-image: python:3.6
-    run:
-      install: >-
-          eval $(python test/client-library-secrets.py) &&
-          cd clients/client-py &&
-          python3 -mvenv /sandbox &&
-          /sandbox/bin/pip install tox
-      command: >-
-          TOXENV=py36 /sandbox/bin/tox
   py37:
     description: python3.7 client tests
     worker:
@@ -110,6 +98,30 @@ tasks:
           /sandbox/bin/pip install tox
       command: >-
           TOXENV=py39 /sandbox/bin/tox
+  py310:
+    description: python3.10 client tests
+    worker:
+      docker-image: python:3.10
+    run:
+      install: >-
+          eval $(python test/client-library-secrets.py) &&
+          cd clients/client-py &&
+          python3 -mvenv /sandbox &&
+          /sandbox/bin/pip install tox
+      command: >-
+          TOXENV=py310 /sandbox/bin/tox
+  py311:
+    description: python3.11 client tests
+    worker:
+      docker-image: python:3.11
+    run:
+      install: >-
+          eval $(python test/client-library-secrets.py) &&
+          cd clients/client-py &&
+          python3 -mvenv /sandbox &&
+          /sandbox/bin/pip install tox
+      command: >-
+          TOXENV=py311 /sandbox/bin/tox
   rust:
     description: rust client tests
     worker:

--- a/taskcluster/ci/lint/kind.yml
+++ b/taskcluster/ci/lint/kind.yml
@@ -28,7 +28,7 @@ tasks:
   python:
     description: python flake8
     worker:
-      docker-image: python:3.10
+      docker-image: python:3.11
     run:
       install: pip install flake8
       command: sh test/py-lint.sh


### PR DESCRIPTION
Python 3.6 is no longer a [supported version](https://devguide.python.org/versions/#supported-versions). This also adds python 3.10 and 3.11 support.

>Remove python 3.6 support as it's past its end-of-life date.
>
>Add python 3.10 and python 3.11 support.