### PR TITLE
docker-compose several improvements

### DIFF
--- a/changelog/NkBUdjnRQ3GpKq1bG41CbA.md
+++ b/changelog/NkBUdjnRQ3GpKq1bG41CbA.md
@@ -1,0 +1,3 @@
+audience: developers
+level: silent
+---

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -81,7 +81,14 @@ services:
     depends_on:
       s3:
         condition: service_healthy
-    entrypoint: /bin/sh -c "/usr/bin/mc config host rm local;/usr/bin/mc config host add --quiet --api s3v4 local http://s3:9000 minioadmin miniopassword;/usr/bin/mc rb --force local/public-bucket/;/usr/bin/mc mb --quiet local/public-bucket/;/usr/bin/mc policy set public local/public-bucket;/usr/bin/mc rb --force local/private-bucket/;/usr/bin/mc mb --quiet local/private-bucket/;/usr/bin/mc policy set public local/public-bucket;"
+    entrypoint: |-
+      /bin/sh -c "
+      /usr/bin/mc config host rm local;
+      /usr/bin/mc config host add --quiet --api s3v4 local http://s3:9000 minioadmin miniopassword;
+      (/usr/bin/mc ls local/public-bucket/ || /usr/bin/mc mb --quiet local/public-bucket/);
+      (/usr/bin/mc ls local/private-bucket/ || /usr/bin/mc mb --quiet local/private-bucket/);
+      /usr/bin/mc policy set public local/public-bucket;
+      "
     environment:
       MINIO_ENDPOINT: http://s3:9000
       MINIO_ROOT_USER: minioadmin
@@ -132,7 +139,10 @@ services:
       TASKCLUSTER_ROOT_URL: http://taskcluster
       TASKCLUSTER_CLIENT_ID: static/taskcluster/root
       TASKCLUSTER_ACCESS_TOKEN: j2Z6zW2QSLehailBXlosdw9e2Ti8R_Qh2M4buAEQfsMA
-    entrypoint: /bin/sh -c " echo 'Applying config'; tc-admin apply ||true; "
+    entrypoint: |-
+      /bin/sh -c "
+      echo 'Applying config'; tc-admin apply ||true;
+      "
     depends_on:
       auth-web:
         condition: service_healthy

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -55,7 +55,7 @@ http {
       proxy_set_header Upgrade $http_upgrade; # websocket
       proxy_set_header Connection "Upgrade"; # websocket
     }
-    location ~* /(public|private)-bucket/ {
+    location ~* /(public|private)-bucket {
       proxy_set_header X-Real-IP $remote_addr;
       proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
       proxy_set_header X-Forwarded-Proto $scheme;

--- a/infrastructure/tooling/src/utils/repo.js
+++ b/infrastructure/tooling/src/utils/repo.js
@@ -124,6 +124,6 @@ exports.readRepoYAML = async filename => {
 /**
  * Asynchronously write a yaml file to the current working copy
  */
-exports.writeRepoYAML = async (filename, data) => {
-  return await writeFile(filename, yaml.dump(data, { lineWidth: -1 }), { encoding: 'utf8' });
+exports.writeRepoYAML = async (filename, data, yamlOpts = {}) => {
+  return await writeFile(filename, yaml.dump(data, { ...yamlOpts, lineWidth: -1 }), { encoding: 'utf8' });
 };


### PR DESCRIPTION
* `s3_init_buckets:` doesn't remove and create buckets if they exist.
* added multi-line yaml for docker-compose files for readability 
* `nginx.conf` fixed bucket urls to support POST operations on a bucket. Trailing slash was not matched on `"POST /public-bucket?delete"` action

First one was very annoying to debug anything on cron job level, as those services depend on `s3_init_buckets` which removed all contents before service starts, thus making it hard to tell if deletion through API really works or was it this startup script :) 