### PR TITLE
chore(ci): retry docker worker chunk tasks

### DIFF
--- a/changelog/HwVqACuzTlGplHg8EfGEkA.md
+++ b/changelog/HwVqACuzTlGplHg8EfGEkA.md
@@ -1,0 +1,3 @@
+audience: general
+level: silent
+---

--- a/taskcluster/ci/docker-worker/kind.yml
+++ b/taskcluster/ci/docker-worker/kind.yml
@@ -28,6 +28,16 @@ task-defaults:
     loopback-audio: true
     max-run-time: 10800
     docker-image: {taskcluster: worker-ci}
+    retry-exit-status:
+      - 1
+      - 4
+      - 8
+      - 10
+      - 11
+      - 12
+      - 14
+      - 16
+      - 17
     env:
       DEBUG: ""
       WORKER_CI: '1'


### PR DESCRIPTION
The past handful of new version commits fail the CI due to the docker worker chunk tasks relying on the new livelog version being published. These are the error codes that return in these cases. Would be nice to have a ✅ next to each commit to `main`...