### PR TITLE
Fix profile name handling in UI

### DIFF
--- a/changelog/issue-5773.md
+++ b/changelog/issue-5773.md
@@ -1,0 +1,6 @@
+audience: users
+level: minor
+reference: issue 5773
+---
+
+Fix UI bug when user profile was missing and causing whole page to crash.

--- a/changelog/issue-5773.md
+++ b/changelog/issue-5773.md
@@ -1,5 +1,5 @@
 audience: users
-level: minor
+level: patch
 reference: issue 5773
 ---
 

--- a/ui/src/components/UserMenu/UserMenuButton.jsx
+++ b/ui/src/components/UserMenu/UserMenuButton.jsx
@@ -9,6 +9,7 @@ import Button from '../Button';
 import SignInDialog from '../SignInDialog';
 import { withAuth } from '../../utils/Auth';
 import getPictureFromUser from '../../utils/getPictureFromUser';
+import username from '../../utils/username';
 
 @withAuth
 @withApollo
@@ -66,6 +67,8 @@ export default class UserMenuButton extends Component {
       );
     }
 
+    const profileName = username(user);
+
     return (
       <IconButton
         className={classNames(classes.avatarButton, className)}
@@ -76,14 +79,10 @@ export default class UserMenuButton extends Component {
         onClick={onMenuClick}
         {...props}>
         {avatarSrc ? (
-          <Avatar
-            alt={user.profile.displayName}
-            src={avatarSrc}
-            {...avatarProps}
-          />
+          <Avatar alt={profileName} src={avatarSrc} {...avatarProps} />
         ) : (
-          <Avatar alt={user.profile.displayName} {...avatarProps}>
-            {user.profile.displayName[0]}
+          <Avatar alt={profileName} {...avatarProps}>
+            {profileName[0]}
           </Avatar>
         )}
       </IconButton>

--- a/ui/src/components/UserMenu/UserMenuList.jsx
+++ b/ui/src/components/UserMenu/UserMenuList.jsx
@@ -10,6 +10,7 @@ import AccountCircleIcon from 'mdi-react/AccountCircleIcon';
 import SignInDialog from '../SignInDialog';
 import { withAuth } from '../../utils/Auth';
 import getPictureFromUser from '../../utils/getPictureFromUser';
+import username from '../../utils/username';
 
 @withAuth
 @withApollo
@@ -76,6 +77,8 @@ export default class UserMenuList extends Component {
       );
     }
 
+    const profileName = username(user);
+
     return (
       <Fragment>
         <List component="nav">
@@ -87,16 +90,14 @@ export default class UserMenuList extends Component {
             aria-label="user menu"
             onClick={onMenuClick}>
             {avatarSrc ? (
-              <Avatar alt={user.profile.displayName} src={avatarSrc} />
+              <Avatar alt={profileName} src={avatarSrc} />
             ) : (
-              <Avatar alt={user.profile.displayName}>
-                {user.profile.displayName[0]}
-              </Avatar>
+              <Avatar alt={profileName}>{profileName[0]}</Avatar>
             )}
             <ListItemText
-              primary={user.profile.displayName}
+              primary={profileName}
               primaryTypographyProps={{ className: classes.username }}
-              title={user.profile.displayName}
+              title={profileName}
             />
           </ListItem>
         </List>

--- a/ui/src/utils/getPictureFromUser.js
+++ b/ui/src/utils/getPictureFromUser.js
@@ -2,7 +2,7 @@
  * Given a user profile, return a picture if any.
  */
 export default user => {
-  if (!user) {
+  if (!user?.profile) {
     return null;
   }
 

--- a/ui/src/utils/getPictureFromUser.test.js
+++ b/ui/src/utils/getPictureFromUser.test.js
@@ -1,6 +1,11 @@
 import getPictureFromUser from './getPictureFromUser';
 
 describe('get picture from user', () => {
+  it('should return empty when profile missing', () => {
+    expect(getPictureFromUser()).toEqual(null);
+    expect(getPictureFromUser({})).toEqual(null);
+    expect(getPictureFromUser({ profile: null })).toEqual(null);
+  });
   it('should fetch mozilla-auth', () => {
     const user = {
       identityProviderId: 'mozilla-auth0',

--- a/ui/src/utils/username.js
+++ b/ui/src/utils/username.js
@@ -1,0 +1,5 @@
+export default user => {
+  return (
+    user?.profile?.displayName || user?.profile?.username || 'unknown hero'
+  );
+};

--- a/ui/src/utils/username.test.js
+++ b/ui/src/utils/username.test.js
@@ -1,0 +1,20 @@
+import username from './username';
+
+describe('username', () => {
+  it('should return name', () => {
+    expect(
+      username({ profile: { displayName: 'Üniсоде', username: 'ignored' } })
+    ).toEqual('Üniсоде');
+    expect(
+      username({ profile: { displayName: 'John Doe', username: 'ignored' } })
+    ).toEqual('John Doe');
+
+    expect(username({ profile: { username: 'John Doe' } })).toEqual('John Doe');
+
+    expect(username({ profile: { displayName: '', username: '' } })).toEqual(
+      'unknown hero'
+    );
+    expect(username({ profile: null })).toEqual('unknown hero');
+    expect(username({})).toEqual('unknown hero');
+  });
+});

--- a/ui/src/views/Dashboard/index.jsx
+++ b/ui/src/views/Dashboard/index.jsx
@@ -12,6 +12,7 @@ import { withAuth } from '../../utils/Auth';
 import { DOCS_PATH_PREFIX } from '../../utils/constants';
 import Link from '../../utils/Link';
 import StatsFetcher from '../../components/StatusDashboard/StatsFetcher';
+import username from '../../utils/username';
 
 @withStyles(theme => ({
   buttonIcon: {
@@ -33,7 +34,7 @@ export default class DashboardView extends Component {
         <Grid container spacing={2}>
           <Grid item xs={12}>
             <Typography variant="h4" className={classes.title}>
-              Hello, {user.profile.displayName}!
+              Hello, {username(user)}!
             </Typography>
           </Grid>
           <Grid item xs={12} sm={6} lg={3}>

--- a/ui/src/views/Profile/index.jsx
+++ b/ui/src/views/Profile/index.jsx
@@ -11,6 +11,7 @@ import DateDistance from '../../components/DateDistance';
 import { withAuth } from '../../utils/Auth';
 import ErrorPanel from '../../components/ErrorPanel';
 import profileQuery from './profile.graphql';
+import username from '../../utils/username';
 
 @withAuth
 @graphql(profileQuery, {
@@ -48,7 +49,7 @@ export default class Profile extends Component {
               <ListItem>
                 <ListItemText
                   primary="Signed In As"
-                  secondary={user.profile.displayName}
+                  secondary={username(user)}
                 />
               </ListItem>
               <ListItem>


### PR DESCRIPTION
In some rear scenarios #5773 `user.profile` or `user` objects became `undefined` or `null`. 

Although the root cause of this issue remains unclear and cannot be reproduced, enhancing the UI's resilience can prevent pages from crashing when such instances occur

Fixes #5773 
