### PR TITLE
Set status back to pending as soon as task restarts

### DIFF
--- a/changelog/bug-1590886.md
+++ b/changelog/bug-1590886.md
@@ -1,0 +1,6 @@
+audience: users
+level: patch
+reference: bug 1590886
+---
+
+Github status handler listens to both `taskPending` and `taskRunning` events.

--- a/services/github/src/handlers/deprecatedStatus.js
+++ b/services/github/src/handlers/deprecatedStatus.js
@@ -49,7 +49,7 @@ async function deprecatedStatusHandler(message) {
     } while (params.continuationToken && state === 'success');
   } else if ([exchangeNames.taskException, exchangeNames.taskFailed].includes(message.exchange)) {
     state = 'failure';
-  } else if (message.exchange === exchangeNames.taskRunning) {
+  } else if ([exchangeNames.taskRunning, exchangeNames.taskPending].includes(message.exchange)) {
     // if build is not pending, it means it was already resolved as success or failure
     // seeing a running task means it was retried, so we should set the status back to pending
     if (build.state !== 'pending') {

--- a/services/github/src/handlers/index.js
+++ b/services/github/src/handlers/index.js
@@ -110,6 +110,7 @@ class Handlers {
       taskFailed: queueEvents.taskFailed().exchange,
       taskException: queueEvents.taskException().exchange,
       taskCompleted: queueEvents.taskCompleted().exchange,
+      taskPending: queueEvents.taskPending().exchange,
       taskRunning: queueEvents.taskRunning().exchange,
       taskGroupResolved: queueEvents.taskGroupResolved().exchange,
     };
@@ -128,6 +129,7 @@ class Handlers {
     // tasks. We wait for the entire group to be resolved before checking
     // for success.
     const deprecatedResultStatusBindings = [
+      queueEvents.taskPending(`route.${this.context.cfg.app.statusTaskRoute}`),
       queueEvents.taskRunning(`route.${this.context.cfg.app.statusTaskRoute}`),
       queueEvents.taskFailed(`route.${this.context.cfg.app.statusTaskRoute}`),
       queueEvents.taskException(`route.${this.context.cfg.app.statusTaskRoute}`),

--- a/services/github/test/handler_test.js
+++ b/services/github/test/handler_test.js
@@ -827,7 +827,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function (mock, skipping) {
       await assertStatusUpdate('failure');
       await assertBuildState('failure');
     });
-    test('task rerun sets status back from success to pending', async function() {
+    test('task rerun sets status to pending from running', async function() {
       await addBuild({ state: 'success', taskGroupId: TASKGROUPID });
       await simulateExchangeMessage({
         taskGroupId: TASKGROUPID,
@@ -835,6 +835,18 @@ helper.secrets.mockSuite(testing.suiteName(), [], function (mock, skipping) {
         routingKey: 'route.statuses',
         runId: 0,
         state: 'running',
+      });
+      await assertStatusUpdate('pending');
+      await assertBuildState('pending');
+    });
+    test('task rerun sets status to pending', async function() {
+      await addBuild({ state: 'success', taskGroupId: TASKGROUPID });
+      await simulateExchangeMessage({
+        taskGroupId: TASKGROUPID,
+        exchange: 'exchange/taskcluster-queue/v1/task-pending',
+        routingKey: 'route.statuses',
+        runId: 1,
+        state: 'pending',
       });
       await assertStatusUpdate('pending');
       await assertBuildState('pending');


### PR DESCRIPTION
Before it was only listening to `taskRunning` and it took some time to switch github state after rerun, as it takes time to get scheduled and start running

Bugzilla Bug: [1590886](https://bugzilla.mozilla.org/show_bug.cgi?id=1590886)
