### PR TITLE
fix(generic-worker): only purge task caches

### DIFF
--- a/changelog/ead5aXzMSNWdGmLGD9nU0Q.md
+++ b/changelog/ead5aXzMSNWdGmLGD9nU0Q.md
@@ -1,0 +1,4 @@
+audience: general
+level: patch
+---
+Generic worker feature `task.Payload.OnExitStatus.PurgeCaches` now only purges caches related to the task, instead of all caches on the worker.

--- a/workers/generic-worker/main.go
+++ b/workers/generic-worker/main.go
@@ -733,24 +733,6 @@ func (task *TaskRun) IsIntermittentExitCode(c int64) bool {
 	return false
 }
 
-func (task *TaskRun) purgeCachesIfRequested(c int64) {
-	for _, code := range task.Payload.OnExitStatus.PurgeCaches {
-		if c == code {
-			task.Infof("Purging caches as requested by exit code %v in task.Payload.OnExitStatus.PurgeCaches array", c)
-			task.purgeCaches()
-			break
-		}
-	}
-}
-
-func (task *TaskRun) purgeCaches() {
-	for _, cache := range directoryCaches {
-		if err := cache.Evict(task); err != nil {
-			task.Warnf("Failed to purge cache %v: %v", cache.Location, err)
-		}
-	}
-}
-
 func (task *TaskRun) ExecuteCommand(index int) *CommandExecutionError {
 	task.Infof("Executing command %v: %v", index, task.formatCommand(index))
 	log.Print("Executing command " + strconv.Itoa(index) + ": " + task.Commands[index].String())
@@ -759,16 +741,15 @@ func (task *TaskRun) ExecuteCommand(index int) *CommandExecutionError {
 		panic(cee)
 	}
 	result := task.Commands[index].Execute()
+	task.exitCode = int64(result.ExitCode())
 	if ae := task.StatusManager.AbortException(); ae != nil {
 		return ae
 	}
 	task.Infof("%v", result)
 
-	task.purgeCachesIfRequested(int64(result.ExitCode()))
-
 	switch {
 	case result.Failed():
-		if task.IsIntermittentExitCode(int64(result.ExitCode())) {
+		if task.IsIntermittentExitCode(task.exitCode) {
 			return &CommandExecutionError{
 				Cause:      fmt.Errorf("Task appears to have failed intermittently - exit code %v found in task payload.onExitStatus list", result.ExitCode()),
 				Reason:     intermittentTask,

--- a/workers/generic-worker/model.go
+++ b/workers/generic-worker/model.go
@@ -30,6 +30,7 @@ type (
 		logMux         sync.RWMutex
 		logWriter      io.Writer
 		queueMux       sync.RWMutex
+		exitCode       int64
 		Queue          tc.Queue           `json:"-"`
 		StatusManager  *TaskStatusManager `json:"-"`
 		LocalClaimTime time.Time          `json:"-"`

--- a/workers/generic-worker/model.go
+++ b/workers/generic-worker/model.go
@@ -30,7 +30,7 @@ type (
 		logMux         sync.RWMutex
 		logWriter      io.Writer
 		queueMux       sync.RWMutex
-		exitCode       int64
+		result         *process.Result
 		Queue          tc.Queue           `json:"-"`
 		StatusManager  *TaskStatusManager `json:"-"`
 		LocalClaimTime time.Time          `json:"-"`

--- a/workers/generic-worker/mounts.go
+++ b/workers/generic-worker/mounts.go
@@ -379,8 +379,16 @@ func (taskMount *TaskMount) Start() *CommandExecutionError {
 
 // called when a task has completed
 func (taskMount *TaskMount) Stop(err *ExecutionErrors) {
+	purgeCaches := taskMount.purgeCachesIfRequested()
 	// loop through all mounts described in payload
 	for i, mount := range taskMount.mounted {
+		if purgeCaches {
+			switch cache := mount.(type) {
+			case *WritableDirectoryCache:
+				err.add(Failure(directoryCaches[cache.CacheName].Evict(taskMount.task)))
+				continue
+			}
+		}
 		e := mount.Unmount(taskMount.task)
 		if e != nil {
 			fsc, errfsc := mount.FSContent()
@@ -392,6 +400,17 @@ func (taskMount *TaskMount) Stop(err *ExecutionErrors) {
 			err.add(Failure(e))
 		}
 	}
+}
+
+func (taskMount *TaskMount) purgeCachesIfRequested() bool {
+	for _, code := range taskMount.task.Payload.OnExitStatus.PurgeCaches {
+		if taskMount.task.exitCode == code {
+			taskMount.task.Infof("Purging caches as requested by exit code %v in task.Payload.OnExitStatus.PurgeCaches array", taskMount.task.exitCode)
+			return true
+		}
+	}
+
+	return false
 }
 
 // Writable caches require scope generic-worker:cache:<cacheName>. Preloaded
@@ -490,11 +509,6 @@ func (w *WritableDirectoryCache) Mount(task *TaskRun) error {
 
 func (w *WritableDirectoryCache) Unmount(task *TaskRun) error {
 	cache := directoryCaches[w.CacheName]
-	// no need to unmount and preserve cache since it was evicted because of
-	// task exit status code in task.payload.onExitStatus.purgeCaches
-	if cache == nil {
-		return nil
-	}
 	cacheDir := cache.Location
 	taskCacheDir := filepath.Join(taskContext.TaskDir, w.Directory)
 	task.Infof("[mounts] Preserving cache: Moving %q to %q", taskCacheDir, cacheDir)

--- a/workers/generic-worker/mounts.go
+++ b/workers/generic-worker/mounts.go
@@ -379,7 +379,7 @@ func (taskMount *TaskMount) Start() *CommandExecutionError {
 
 // called when a task has completed
 func (taskMount *TaskMount) Stop(err *ExecutionErrors) {
-	purgeCaches := taskMount.purgeCachesIfRequested()
+	purgeCaches := taskMount.shouldPurgeCaches()
 	// loop through all mounts described in payload
 	for i, mount := range taskMount.mounted {
 		if purgeCaches {
@@ -402,10 +402,10 @@ func (taskMount *TaskMount) Stop(err *ExecutionErrors) {
 	}
 }
 
-func (taskMount *TaskMount) purgeCachesIfRequested() bool {
+func (taskMount *TaskMount) shouldPurgeCaches() bool {
 	for _, code := range taskMount.task.Payload.OnExitStatus.PurgeCaches {
-		if taskMount.task.exitCode == code {
-			taskMount.task.Infof("Purging caches as requested by exit code %v in task.Payload.OnExitStatus.PurgeCaches array", taskMount.task.exitCode)
+		if int64(taskMount.task.result.ExitCode()) == code {
+			taskMount.task.Infof("Purging caches since last command had exit code %v which is listed in task.Payload.OnExitStatus.PurgeCaches array", taskMount.task.result.ExitCode())
 			return true
 		}
 	}

--- a/workers/generic-worker/purge_caches_test.go
+++ b/workers/generic-worker/purge_caches_test.go
@@ -273,3 +273,71 @@ func TestPurgeCachesNegativeExitCode(t *testing.T) {
 		t.Fatalf("Was expecting log to contain string %v.", substring)
 	}
 }
+
+// Exit codes specified in OnExitStatus.PurgeCaches should only purge task caches
+func TestPurgeTaskCaches(t *testing.T) {
+	setup(t)
+	mounts := []MountEntry{
+		// requires scope "generic-worker:cache:apple-cache"
+		&WritableDirectoryCache{
+			CacheName: "apple-cache",
+			Directory: filepath.Join("my-task-caches", "apples"),
+		},
+	}
+	payload := GenericWorkerPayload{
+		Command:    returnExitCode(0),
+		MaxRunTime: 30,
+		Mounts:     toMountArray(t, mounts),
+	}
+	defaults.SetDefaults(&payload)
+	td := testTask(t)
+	td.Scopes = []string{"generic-worker:cache:apple-cache"}
+
+	_ = submitAndAssert(t, td, payload, "completed", "completed")
+
+	ensureDirContainsNFiles(t, cachesDir, 1)
+
+	mounts = []MountEntry{
+		// requires scope "generic-worker:cache:banana-cache"
+		&WritableDirectoryCache{
+			CacheName: "banana-cache",
+			Directory: filepath.Join("my-task-caches", "bananas"),
+		},
+	}
+	payload = GenericWorkerPayload{
+		Command:    returnExitCode(123),
+		MaxRunTime: 30,
+		Mounts:     toMountArray(t, mounts),
+		OnExitStatus: ExitCodeHandling{
+			PurgeCaches: []int64{123},
+		},
+	}
+	defaults.SetDefaults(&payload)
+	td = testTask(t)
+	td.Scopes = []string{"generic-worker:cache:banana-cache"}
+
+	_ = submitAndAssert(t, td, payload, "failed", "failed")
+
+	logtext := LogText(t)
+	substring := "[mounts] Removing cache banana-cache from cache table"
+	if !strings.Contains(logtext, substring) {
+		t.Log(logtext)
+		t.Fatalf("Was expecting log to contain string %v.", substring)
+	}
+
+	substring = "[mounts] Deleting cache banana-cache file(s) at"
+	if !strings.Contains(logtext, substring) {
+		t.Log(logtext)
+		t.Fatalf("Was expecting log to contain string %v.", substring)
+	}
+
+	// WritableDirectoryCache should not be unmounted and moved to the cache dir
+	substring = "[mounts] Preserving cache: Moving"
+	if strings.Contains(logtext, substring) {
+		t.Log(logtext)
+		t.Fatalf("Was not expecting log to contain string %v.", substring)
+	}
+
+	// ensure task cache from previous task is still present
+	ensureDirContainsNFiles(t, cachesDir, 1)
+}


### PR DESCRIPTION
https://github.com/taskcluster/taskcluster/pull/6148 incorrectly would purge _all_ caches on the worker. This patch makes it so only caches related to the task run get purged. I ensured that the new test that I added fails on the `main` branch.

>Generic worker feature `task.Payload.OnExitStatus.PurgeCaches` now only purges caches related to the task, instead of all caches on the worker.