### PR TITLE
Only grant SID Winsta Access when refreshing access token

### DIFF
--- a/changelog/issue-6058.md
+++ b/changelog/issue-6058.md
@@ -1,0 +1,7 @@
+audience: users
+level: patch
+reference: issue 6058
+---
+Generic Worker no longer modifies the Access Control Lists of the Interactive Desktop and the associated Windows Station unless additional OS groups have been specified in the task payload `osGroups` property. Previously Generic Worker would modify the ACLs of these objects even if the access token it was using for launching task command processes already had suitable permissions. This patch is a workaround for a more general issue, which is that the ACL modifications seem not to be appropriate in all cases when a new access token is needed. See https://bugzilla.mozilla.org/show_bug.cgi?id=1815711.
+
+There is a likely to be a follow up fix for the ACL modifications that occur when a new access token is required, once it is understood why the current modifications are not always sufficient.

--- a/workers/generic-worker/process/multiuser_windows.go
+++ b/workers/generic-worker/process/multiuser_windows.go
@@ -43,6 +43,7 @@ func TaskUserPlatformData() (pd *PlatformData, err error) {
 		return
 	}
 	pd.CommandAccessToken = pd.LoginInfo.AccessToken()
+	win32.DumpTokenInfo(pd.CommandAccessToken)
 	return
 }
 

--- a/workers/generic-worker/process/multiuser_windows.go
+++ b/workers/generic-worker/process/multiuser_windows.go
@@ -33,10 +33,6 @@ func NewPlatformData(currentUser bool) (pd *PlatformData, err error) {
 	if err != nil {
 		return
 	}
-	// This is the SID of "Everyone" group
-	// TODO: we should probably change this to the logon SID of the user
-	sid := "S-1-1-0"
-	GrantSIDWinstaAccess(sid, pd)
 	return
 }
 
@@ -134,6 +130,10 @@ func (pd *PlatformData) RefreshLoginSession(user, pass string) {
 	if err != nil {
 		panic(err)
 	}
+	// This is the SID of "Everyone" group
+	// TODO: we should probably change this to the logon SID of the user
+	sid := "S-1-1-0"
+	GrantSIDWinstaAccess(sid, pd)
 	pd.LoginInfo, err = NewLoginInfo(user, pass)
 	if err != nil {
 		// implies a serious bug


### PR DESCRIPTION
Bugzilla Bug: [1815711](https://bugzilla.mozilla.org/show_bug.cgi?id=1815711)

This is a partial fix for #6058. It should workaround the issue for the specific case raised, but will not work if custom `osGroups` entries are specified in the task payload.