### PR TITLE
Fix quarantine worker payload schema

### DIFF
--- a/changelog/issue-6185.md
+++ b/changelog/issue-6185.md
@@ -1,0 +1,6 @@
+audience: users
+level: patch
+reference: issue 6185
+---
+
+Fixed quarantine worker 'reason' field schema to be optional.

--- a/clients/client-go/tcqueue/types.go
+++ b/clients/client-go/tcqueue/types.go
@@ -760,7 +760,7 @@ type (
 		// A message to be included in the worker's quarantine details. This message will be
 		// appended to the existing quarantine details to keep a history of the worker's quarantine.
 		//
-		// Min length: 1
+		// Min length: 0
 		// Max length: 4000
 		QuarantineInfo string `json:"quarantineInfo,omitempty"`
 

--- a/generated/references.json
+++ b/generated/references.json
@@ -3581,7 +3581,7 @@
         "quarantineInfo": {
           "description": "A message to be included in the worker's quarantine details. This message will be\nappended to the existing quarantine details to keep a history of the worker's quarantine.\n",
           "maxLength": 4000,
-          "minLength": 1,
+          "minLength": 0,
           "title": "Worker Quarantine Info",
           "type": "string"
         },

--- a/services/queue/schemas/v1/quarantine-worker-request.yml
+++ b/services/queue/schemas/v1/quarantine-worker-request.yml
@@ -19,7 +19,7 @@ properties:
       A message to be included in the worker's quarantine details. This message will be
       appended to the existing quarantine details to keep a history of the worker's quarantine.
     type:       string
-    minLength:  1
+    minLength:  0
     maxLength:  4000
 additionalProperties: false
 required: [quarantineUntil]


### PR DESCRIPTION
Reason field was marked as optional, but validation required min length 1

Fixes #6185
