### PR TITLE
Extra check before worker is terminated on terminateAfter time exceeded.

### DIFF
--- a/changelog/issue-6186.md
+++ b/changelog/issue-6186.md
@@ -1,0 +1,6 @@
+audience: worker-deployers
+level: patch
+reference: issue 6186
+---
+
+Worker-manager refreshes worker from database before calling removeWorker on terminateAfter time exceeded to prevent from stopping workers that were already registered and running since worker scanner has started.

--- a/services/worker-manager/config.yml
+++ b/services/worker-manager/config.yml
@@ -1,6 +1,5 @@
 defaults:
   app:
-    errorsExpirationDelay: '-4 days' # Anything older than a few days goes away
     provisionerIterateConfig: !env:json:optional PROVISIONER_ITERATE_CONFIG
     workerScannerIterateConfig: !env:json:optional WORKER_SCANNER_ITERATE_CONFIG
   monitoring:
@@ -39,8 +38,6 @@ test:
     trustProxy: false
   taskcluster:
     rootUrl: "https://tc.example.com"
-  app:
-    errorsExpirationDelay: '-1 hour'
   postgres:
     dbCryptoKeys:
       - id: 'worker-manager'

--- a/services/worker-manager/src/providers/aws.js
+++ b/services/worker-manager/src/providers/aws.js
@@ -353,7 +353,11 @@ class AwsProvider extends Provider {
         }
       }
       if (worker.providerData.terminateAfter && worker.providerData.terminateAfter < Date.now()) {
-        await this.removeWorker({ worker, reason: 'terminateAfter time exceeded' });
+        // reload the worker to make sure we have the latest data
+        await worker.reload(this.db);
+        if (worker.providerData.terminateAfter < Date.now()) {
+          await this.removeWorker({ worker, reason: 'terminateAfter time exceeded' });
+        }
       }
     } catch (e) {
       if (e.code !== 'InvalidInstanceID.NotFound') { // aws throws this error for instances that had been terminated, too

--- a/services/worker-manager/src/worker-scanner.js
+++ b/services/worker-manager/src/worker-scanner.js
@@ -56,7 +56,7 @@ class WorkerScanner {
     const fetch =
       async (size, offset) => await this.db.fns.get_non_stopped_workers_quntil_providers(
         null, null, null, this.providersFilter.cond, this.providersFilter.value, size, offset);
-    for await (let row of paginatedIterator({ fetch })) {
+    for await (let row of paginatedIterator({ fetch, size: 500 })) {
       const worker = Worker.fromDb(row);
       const provider = this.providers.get(worker.providerId);
       if (provider) {

--- a/services/worker-manager/test/provider_google_test.js
+++ b/services/worker-manager/test/provider_google_test.js
@@ -507,6 +507,21 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       assert(!fake.compute.instances.delete_called);
       assert.equal(worker.state, 'running');
     });
+    test('do not remove registered workers with stale terminateAfter', async function () {
+      const terminateAfter = Date.now() - 1000;
+      let worker = await suiteMakeWorker({ providerData: { terminateAfter } });
+      fake.compute.instances.setFakeInstanceStatus(
+        project, 'us-east1-a', workerId,
+        'RUNNING');
+
+      worker.reload = function () {
+        this.providerData.terminateAfter = Date.now() + 1000;
+      };
+
+      worker = await runCheckWorker(worker);
+      assert(!fake.compute.instances.delete_called);
+      assert.equal(worker.state, 'running');
+    });
   });
 
   suite('registerWorker', function() {


### PR DESCRIPTION
This is an attempt to reduce the amount of workers that are being stopped even after they were registered and started claiming work. In some conditions, especially for Azure workers, scan loops can take 10-20 minutes. And since all records are being fetched in memory once, it may happen that worker record was updated. We simply reload the record before finally removing worker.

Fixes #6186 


I'm only 99% confident this is the main cause why normally working workers are being removed, because `update_worker_2` function is actually checking `etag` of the record when doing an update, so it's not clear how it can overwrite something that was already updated. But maybe not all updates are being handled with try/catch or are not being logged. 
From the investigation into 2k of killed workers, 85% of those were already registered and working for 2-8 minutes before being killed by worker-scanner. 