### PR TITLE
chore(schema): fix copy/paste error in generic worker schema

### DIFF
--- a/changelog/BR8hGDKyQh-21RNB_u0t8w.md
+++ b/changelog/BR8hGDKyQh-21RNB_u0t8w.md
@@ -1,0 +1,3 @@
+audience: general
+level: silent
+---

--- a/generated/references.json
+++ b/generated/references.json
@@ -7708,7 +7708,7 @@
             },
             "interactive": {
               "description": "This allows you to interactively run commands from within the worker\nas the task user. This may be useful for debugging purposes.\nCan be used for SSH-like access to the running worker.\nNote that this feature works differently from the `interactive` feature\nin docker worker, which `docker exec`s into the running container.\nSince tasks on generic worker are not guaranteed to be running in a\ncontainer, a bash shell is started on the task user's account.\nA user can then `docker exec` into the a running container, if there\nis one.\n\nSince: generic-worker 49.2.0",
-              "title": "Docker Exec Interactive",
+              "title": "Interactive shell",
               "type": "boolean"
             },
             "liveLog": {
@@ -8557,7 +8557,7 @@
             },
             "interactive": {
               "description": "This allows you to interactively run commands from within the worker\nas the task user. This may be useful for debugging purposes.\nCan be used for SSH-like access to the running worker.\nNote that this feature works differently from the `interactive` feature\nin docker worker, which `docker exec`s into the running container.\nSince tasks on generic worker are not guaranteed to be running in a\ncontainer, a bash shell is started on the task user's account.\nA user can then `docker exec` into the a running container, if there\nis one.\n\nSince: generic-worker 49.2.0",
-              "title": "Docker Exec Interactive",
+              "title": "Interactive shell",
               "type": "boolean"
             },
             "liveLog": {

--- a/workers/generic-worker/generated_multiuser_darwin.go
+++ b/workers/generic-worker/generated_multiuser_darwin.go
@@ -766,7 +766,7 @@ func taskPayloadSchema() string {
         },
         "interactive": {
           "description": "This allows you to interactively run commands from within the worker\nas the task user. This may be useful for debugging purposes.\nCan be used for SSH-like access to the running worker.\nNote that this feature works differently from the ` + "`" + `interactive` + "`" + ` feature\nin docker worker, which ` + "`" + `docker exec` + "`" + `s into the running container.\nSince tasks on generic worker are not guaranteed to be running in a\ncontainer, a bash shell is started on the task user's account.\nA user can then ` + "`" + `docker exec` + "`" + ` into the a running container, if there\nis one.\n\nSince: generic-worker 49.2.0",
-          "title": "Docker Exec Interactive",
+          "title": "Interactive shell",
           "type": "boolean"
         },
         "liveLog": {

--- a/workers/generic-worker/generated_multiuser_linux.go
+++ b/workers/generic-worker/generated_multiuser_linux.go
@@ -766,7 +766,7 @@ func taskPayloadSchema() string {
         },
         "interactive": {
           "description": "This allows you to interactively run commands from within the worker\nas the task user. This may be useful for debugging purposes.\nCan be used for SSH-like access to the running worker.\nNote that this feature works differently from the ` + "`" + `interactive` + "`" + ` feature\nin docker worker, which ` + "`" + `docker exec` + "`" + `s into the running container.\nSince tasks on generic worker are not guaranteed to be running in a\ncontainer, a bash shell is started on the task user's account.\nA user can then ` + "`" + `docker exec` + "`" + ` into the a running container, if there\nis one.\n\nSince: generic-worker 49.2.0",
-          "title": "Docker Exec Interactive",
+          "title": "Interactive shell",
           "type": "boolean"
         },
         "liveLog": {

--- a/workers/generic-worker/generated_simple_darwin.go
+++ b/workers/generic-worker/generated_simple_darwin.go
@@ -741,7 +741,7 @@ func taskPayloadSchema() string {
         },
         "interactive": {
           "description": "This allows you to interactively run commands from within the worker\nas the task user. This may be useful for debugging purposes.\nCan be used for SSH-like access to the running worker.\nNote that this feature works differently from the ` + "`" + `interactive` + "`" + ` feature\nin docker worker, which ` + "`" + `docker exec` + "`" + `s into the running container.\nSince tasks on generic worker are not guaranteed to be running in a\ncontainer, a bash shell is started on the task user's account.\nA user can then ` + "`" + `docker exec` + "`" + ` into the a running container, if there\nis one.\n\nSince: generic-worker 49.2.0",
-          "title": "Docker Exec Interactive",
+          "title": "Interactive shell",
           "type": "boolean"
         },
         "liveLog": {

--- a/workers/generic-worker/generated_simple_freebsd.go
+++ b/workers/generic-worker/generated_simple_freebsd.go
@@ -741,7 +741,7 @@ func taskPayloadSchema() string {
         },
         "interactive": {
           "description": "This allows you to interactively run commands from within the worker\nas the task user. This may be useful for debugging purposes.\nCan be used for SSH-like access to the running worker.\nNote that this feature works differently from the ` + "`" + `interactive` + "`" + ` feature\nin docker worker, which ` + "`" + `docker exec` + "`" + `s into the running container.\nSince tasks on generic worker are not guaranteed to be running in a\ncontainer, a bash shell is started on the task user's account.\nA user can then ` + "`" + `docker exec` + "`" + ` into the a running container, if there\nis one.\n\nSince: generic-worker 49.2.0",
-          "title": "Docker Exec Interactive",
+          "title": "Interactive shell",
           "type": "boolean"
         },
         "liveLog": {

--- a/workers/generic-worker/generated_simple_linux.go
+++ b/workers/generic-worker/generated_simple_linux.go
@@ -741,7 +741,7 @@ func taskPayloadSchema() string {
         },
         "interactive": {
           "description": "This allows you to interactively run commands from within the worker\nas the task user. This may be useful for debugging purposes.\nCan be used for SSH-like access to the running worker.\nNote that this feature works differently from the ` + "`" + `interactive` + "`" + ` feature\nin docker worker, which ` + "`" + `docker exec` + "`" + `s into the running container.\nSince tasks on generic worker are not guaranteed to be running in a\ncontainer, a bash shell is started on the task user's account.\nA user can then ` + "`" + `docker exec` + "`" + ` into the a running container, if there\nis one.\n\nSince: generic-worker 49.2.0",
-          "title": "Docker Exec Interactive",
+          "title": "Interactive shell",
           "type": "boolean"
         },
         "liveLog": {

--- a/workers/generic-worker/schemas/multiuser_posix.yml
+++ b/workers/generic-worker/schemas/multiuser_posix.yml
@@ -234,7 +234,7 @@ properties:
         default: true
       interactive:
         type: boolean
-        title: Docker Exec Interactive
+        title: Interactive shell
         description: |-
           This allows you to interactively run commands from within the worker
           as the task user. This may be useful for debugging purposes.

--- a/workers/generic-worker/schemas/simple_posix.yml
+++ b/workers/generic-worker/schemas/simple_posix.yml
@@ -212,7 +212,7 @@ properties:
         default: true
       interactive:
         type: boolean
-        title: Docker Exec Interactive
+        title: Interactive shell
         description: |-
           This allows you to interactively run commands from within the worker
           as the task user. This may be useful for debugging purposes.


### PR DESCRIPTION
Copy/paste from the docker worker schema that I forgot to update :)