### PR TITLE
fix(generic-worker): return error if worker config not set for interactive

### DIFF
--- a/changelog/issue-6208.md
+++ b/changelog/issue-6208.md
@@ -1,0 +1,5 @@
+audience: users
+level: patch
+reference: issue 6208
+---
+Return a malformed payload error if `task.payload.features.interactive` is enabled, while the `enableInteractive` worker config is false.

--- a/changelog/issue-6208.md
+++ b/changelog/issue-6208.md
@@ -2,4 +2,10 @@ audience: users
 level: patch
 reference: issue 6208
 ---
-Return a malformed payload error if `task.payload.features.interactive` is enabled, while the `enableInteractive` worker config is false.
+Return a malformed payload error if `payload.features.interactive` is enabled in the task definition, while the `enableInteractive` worker config is false.
+
+If you _do not_ require an interactive task, remove `payload.features.interactive` from the task definition.
+
+If you _do_ require an interactive task, either:
+* Contact the owner of worker pool and ask for interactive tasks to be enabled
+* Use a worker pool that already allows interactive tasks (search for "enableInteractive: true" in the worker pool definition)

--- a/workers/generic-worker/helper_test.go
+++ b/workers/generic-worker/helper_test.go
@@ -358,7 +358,6 @@ func GWTest(t *testing.T) *Test {
 			// directory-caches.json and file-caches.json are not per-test.
 			DownloadsDir:              filepath.Join(cwd, "downloads"),
 			Ed25519SigningKeyLocation: filepath.Join(testdataDir, "ed25519_private_key"),
-			EnableInteractive:         os.Getenv("ENABLE_INTERACTIVE") == "true",
 			IdleTimeoutSecs:           60,
 			InstanceID:                "test-instance-id",
 			InstanceType:              "p3.enormous",

--- a/workers/generic-worker/helper_test.go
+++ b/workers/generic-worker/helper_test.go
@@ -358,7 +358,7 @@ func GWTest(t *testing.T) *Test {
 			// directory-caches.json and file-caches.json are not per-test.
 			DownloadsDir:              filepath.Join(cwd, "downloads"),
 			Ed25519SigningKeyLocation: filepath.Join(testdataDir, "ed25519_private_key"),
-			EnableInteractive:         true,
+			EnableInteractive:         os.Getenv("ENABLE_INTERACTIVE") == "true",
 			IdleTimeoutSecs:           60,
 			InstanceID:                "test-instance-id",
 			InstanceType:              "p3.enormous",

--- a/workers/generic-worker/interactive.go
+++ b/workers/generic-worker/interactive.go
@@ -63,7 +63,13 @@ func (it *InteractiveTask) ReservedArtifacts() []string {
 
 func (it *InteractiveTask) Start() *CommandExecutionError {
 	if !config.EnableInteractive {
-		return MalformedPayloadError(fmt.Errorf("`enableInteractive` worker config is not set to `true`"))
+		workerPoolID := config.WorkerGroup + "/" + config.WorkerType
+		workerManagerURL := config.RootURL + "/worker-manager/" + url.PathEscape(workerPoolID)
+		return MalformedPayloadError(fmt.Errorf(`This task has payload.features.interactive set to true, but enableInteractive is not enabled on this worker pool (%s)
+If you do not require an interactive task, remove payload.features.interactive from the task definition.
+If you do require an interactive task, please do one of two things:
+	1. Contact the owner of the worker pool %s (see %s) and ask for interactive tasks to be enabled.
+	2. Use a worker pool that already allows interactive tasks (search for "enableInteractive": "true" in the worker pool definition)`, workerPoolID, workerPoolID, workerManagerURL))
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())

--- a/workers/generic-worker/interactive.go
+++ b/workers/generic-worker/interactive.go
@@ -4,6 +4,7 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"net/url"
 	"path"
 	"strconv"
@@ -32,7 +33,7 @@ func (feature *InteractiveFeature) PersistState() error {
 }
 
 func (feature *InteractiveFeature) IsEnabled(task *TaskRun) bool {
-	return config.EnableInteractive && task.Payload.Features.Interactive
+	return task.Payload.Features.Interactive
 }
 
 type InteractiveTask struct {
@@ -61,6 +62,10 @@ func (it *InteractiveTask) ReservedArtifacts() []string {
 }
 
 func (it *InteractiveTask) Start() *CommandExecutionError {
+	if !config.EnableInteractive {
+		return MalformedPayloadError(fmt.Errorf("`enableInteractive` worker config is not set to `true`"))
+	}
+
 	ctx, cancel := context.WithCancel(context.Background())
 	cmd, err := it.task.generateInteractiveCommand(ctx)
 	if err != nil {

--- a/workers/generic-worker/interactive_test.go
+++ b/workers/generic-worker/interactive_test.go
@@ -13,8 +13,8 @@ import (
 )
 
 func TestInteractiveArtifact(t *testing.T) {
-	os.Setenv("ENABLE_INTERACTIVE", "true")
 	setup(t)
+	config.EnableInteractive = true
 	payload := GenericWorkerPayload{
 		Command:    returnExitCode(0),
 		MaxRunTime: 10,
@@ -52,8 +52,8 @@ func TestInteractiveArtifact(t *testing.T) {
 }
 
 func TestInteractiveCommand(t *testing.T) {
-	os.Setenv("ENABLE_INTERACTIVE", "true")
 	setup(t)
+	config.EnableInteractive = true
 	payload := GenericWorkerPayload{
 		Command:    sleep(5),
 		MaxRunTime: 10,
@@ -128,8 +128,8 @@ func TestInteractiveCommand(t *testing.T) {
 }
 
 func TestInteractiveWrongSecret(t *testing.T) {
-	os.Setenv("ENABLE_INTERACTIVE", "true")
 	setup(t)
+	config.EnableInteractive = true
 	payload := GenericWorkerPayload{
 		Command:    sleep(5),
 		MaxRunTime: 10,
@@ -170,8 +170,8 @@ func TestInteractiveWrongSecret(t *testing.T) {
 }
 
 func TestInteractiveNoConfigSetMalformedPayload(t *testing.T) {
-	os.Setenv("ENABLE_INTERACTIVE", "false")
 	setup(t)
+	config.EnableInteractive = false
 	payload := GenericWorkerPayload{
 		Command:    returnExitCode(0),
 		MaxRunTime: 10,

--- a/workers/generic-worker/interactive_test.go
+++ b/workers/generic-worker/interactive_test.go
@@ -13,6 +13,7 @@ import (
 )
 
 func TestInteractiveArtifact(t *testing.T) {
+	os.Setenv("ENABLE_INTERACTIVE", "true")
 	setup(t)
 	payload := GenericWorkerPayload{
 		Command:    returnExitCode(0),
@@ -51,6 +52,7 @@ func TestInteractiveArtifact(t *testing.T) {
 }
 
 func TestInteractiveCommand(t *testing.T) {
+	os.Setenv("ENABLE_INTERACTIVE", "true")
 	setup(t)
 	payload := GenericWorkerPayload{
 		Command:    sleep(5),
@@ -126,6 +128,7 @@ func TestInteractiveCommand(t *testing.T) {
 }
 
 func TestInteractiveWrongSecret(t *testing.T) {
+	os.Setenv("ENABLE_INTERACTIVE", "true")
 	setup(t)
 	payload := GenericWorkerPayload{
 		Command:    sleep(5),
@@ -164,4 +167,20 @@ func TestInteractiveWrongSecret(t *testing.T) {
 			}
 		}
 	}
+}
+
+func TestInteractiveNoConfigSetMalformedPayload(t *testing.T) {
+	os.Setenv("ENABLE_INTERACTIVE", "false")
+	setup(t)
+	payload := GenericWorkerPayload{
+		Command:    returnExitCode(0),
+		MaxRunTime: 10,
+		Features: FeatureFlags{
+			Interactive: true,
+		},
+	}
+	defaults.SetDefaults(&payload)
+	td := testTask(t)
+
+	_ = submitAndAssert(t, td, payload, "exception", "malformed-payload")
 }


### PR DESCRIPTION
Fixes https://github.com/taskcluster/taskcluster/issues/6208.

>Return a malformed payload error if `task.payload.features.interactive` is enabled, while the `enableInteractive` worker config is false.