### PR TITLE
Add options for jsonschema2go cli for nested structs and defaults

### DIFF
--- a/changelog/J-Yz6b4tRtSddILhruvtkA.md
+++ b/changelog/J-Yz6b4tRtSddILhruvtkA.md
@@ -1,0 +1,4 @@
+audience: developers
+level: patch
+---
+jsonschema2go cli now has options for generating nested structs, and including default values as struct tags.

--- a/tools/jsonschema2go/jsonschema2go/cli.go
+++ b/tools/jsonschema2go/jsonschema2go/cli.go
@@ -58,11 +58,13 @@ The go type names will be "normalised" from the json subschema Title element.
     cat urls.txt | jsonschema2go -o main
 
   Usage:
-    jsonschema2go -o GO-PACKAGE-NAME
+    jsonschema2go [-d] [-n] -o GO-PACKAGE-NAME
     jsonschema2go --help
 
   Options:
     -h --help               Display this help text.
+    -d                      Enable defaults.
+    -n                      Nested structs.
     -o GO-PACKAGE-NAME      The package name to use in the generated file.
 `
 )
@@ -75,7 +77,8 @@ func main() {
 		Package:              arguments["-o"].(string),
 		ExportTypes:          true,
 		URLs:                 parseStandardIn(),
-		DisableNestedStructs: true,
+		EnableDefaults:       arguments["-d"].(bool),
+		DisableNestedStructs: !arguments["-n"].(bool),
 	}
 	result, err := job.Execute()
 	if err != nil {


### PR DESCRIPTION
This adds some optional arguments to the jsonschema2go cli for:

* outputting nested structs
* outputting default struct tags

This is needed by d2g. In that project, the docker worker payload schema has some features which are `true` by default (such as `payload.features.bulkLog`). In order for an absent value to be interpreted as `true` rather than `false`, the default will need to be specified in the generated go type as a default struct tag.