### PR TITLE
Fix build of generic-worker docker image for dev deployments

### DIFF
--- a/changelog/Weif8TmwSvyp-dxVV4Ns0Q.md
+++ b/changelog/Weif8TmwSvyp-dxVV4Ns0Q.md
@@ -1,0 +1,3 @@
+audience: general
+level: silent
+---

--- a/generic-worker.Dockerfile
+++ b/generic-worker.Dockerfile
@@ -14,7 +14,6 @@ RUN cd tools/taskcluster-proxy && go build -o /taskcluster-proxy && cd ..
 RUN cd clients/client-shell && go build -o /taskcluster && cd ../..
 RUN cd workers/generic-worker && \
   ./build.sh && \
-  mv generic-worker-docker-* /generic-worker-docker && \
   mv generic-worker-multiuser-* /generic-worker-multiuser && \
   mv generic-worker-simple-* /generic-worker
 


### PR DESCRIPTION
This is a fix for the release process that was discovered in the following staging release: https://github.com/taskcluster/staging-releases/tree/staging-release/v50.0.0