### PR TITLE
feat(generic-worker): add `artifacts` feature to be able to disable uploads

### DIFF
--- a/changelog/issue-5987.md
+++ b/changelog/issue-5987.md
@@ -1,0 +1,7 @@
+audience: users
+level: minor
+reference: issue 5987
+---
+Adds `task.payload.features.artifacts` feature to generic worker to bring to parity with an existing docker worker feature.
+
+This feature allows a user to disable all artifact uploads. It defaults to `true` so it's not a breaking change.

--- a/generated/references.json
+++ b/generated/references.json
@@ -7700,6 +7700,12 @@
           "additionalProperties": false,
           "description": "Feature flags enable additional functionality.\n\nSince: generic-worker 5.3.0",
           "properties": {
+            "artifacts": {
+              "default": true,
+              "description": "This allows you to disable artifact uploads for a task.\n\nSince: generic-worker 50.1.0",
+              "title": "Enable artifact uploads",
+              "type": "boolean"
+            },
             "backingLog": {
               "default": true,
               "description": "The backing log feature publishes a task artifact containing the complete\nstderr and stdout of the task.\n\nSince: generic-worker 48.2.0",
@@ -8115,6 +8121,12 @@
           "additionalProperties": false,
           "description": "Feature flags enable additional functionality.\n\nSince: generic-worker 5.3.0",
           "properties": {
+            "artifacts": {
+              "default": true,
+              "description": "This allows you to disable artifact uploads for a task.\n\nSince: generic-worker 50.1.0",
+              "title": "Enable artifact uploads",
+              "type": "boolean"
+            },
             "backingLog": {
               "default": true,
               "description": "The backing log feature publishes a task artifact containing the complete\nstderr and stdout of the task.\n\nSince: generic-worker 48.2.0",
@@ -8544,6 +8556,12 @@
           "additionalProperties": false,
           "description": "Feature flags enable additional functionality.\n\nSince: generic-worker 5.3.0",
           "properties": {
+            "artifacts": {
+              "default": true,
+              "description": "This allows you to disable artifact uploads for a task.\n\nSince: generic-worker 50.1.0",
+              "title": "Enable artifact uploads",
+              "type": "boolean"
+            },
             "backingLog": {
               "default": true,
               "description": "The backing log feature publishes a task artifact containing the complete\nstderr and stdout of the task.\n\nSince: generic-worker 48.2.0",

--- a/workers/generic-worker/artifacts.go
+++ b/workers/generic-worker/artifacts.go
@@ -246,6 +246,11 @@ func (task *TaskRun) uploadLog(name, path string) *CommandExecutionError {
 }
 
 func (task *TaskRun) uploadArtifact(artifact artifacts.TaskArtifact) *CommandExecutionError {
+	if !task.Payload.Features.Artifacts {
+		task.Infof("Skipping upload of artifact %v as artifacts feature is not enabled", artifact.Base().Name)
+		return nil
+	}
+
 	task.Artifacts[artifact.Base().Name] = artifact
 	payload, err := json.Marshal(artifact.RequestObject())
 	if err != nil {

--- a/workers/generic-worker/artifacts_test.go
+++ b/workers/generic-worker/artifacts_test.go
@@ -1000,6 +1000,30 @@ func TestDirectoryArtifactHasNoExpiry(t *testing.T) {
 	t.Fatalf("Could not find artifact public/build/X.txt in task run 0 of task %v", taskID)
 }
 
+func TestArtifactsAreNotUploaded(t *testing.T) {
+	setup(t)
+
+	payload := GenericWorkerPayload{
+		Command:    returnExitCode(0),
+		MaxRunTime: 10,
+	}
+	defaults.SetDefaults(&payload)
+	payload.Features.Artifacts = false
+
+	td := testTask(t)
+
+	taskID := submitAndAssert(t, td, payload, "completed", "completed")
+
+	queue := serviceFactory.Queue(nil, config.RootURL)
+	lar, err := queue.ListArtifacts(taskID, "0", "", "")
+	if err != nil {
+		t.Fatalf("Error listing artifacts of task %v: %v", taskID, err)
+	}
+	if len(lar.Artifacts) != 0 {
+		t.Fatalf("Expected no artifacts, but got %v", lar.Artifacts)
+	}
+}
+
 func TestObjectArtifact(t *testing.T) {
 
 	setup(t)

--- a/workers/generic-worker/generated_multiuser_darwin.go
+++ b/workers/generic-worker/generated_multiuser_darwin.go
@@ -162,6 +162,13 @@ type (
 	// Since: generic-worker 5.3.0
 	FeatureFlags struct {
 
+		// This allows you to disable artifact uploads for a task.
+		//
+		// Since: generic-worker 50.1.0
+		//
+		// Default:    true
+		Artifacts bool `json:"artifacts" default:"true"`
+
 		// The backing log feature publishes a task artifact containing the complete
 		// stderr and stdout of the task.
 		//
@@ -753,6 +760,12 @@ func taskPayloadSchema() string {
       "additionalProperties": false,
       "description": "Feature flags enable additional functionality.\n\nSince: generic-worker 5.3.0",
       "properties": {
+        "artifacts": {
+          "default": true,
+          "description": "This allows you to disable artifact uploads for a task.\n\nSince: generic-worker 50.1.0",
+          "title": "Enable artifact uploads",
+          "type": "boolean"
+        },
         "backingLog": {
           "default": true,
           "description": "The backing log feature publishes a task artifact containing the complete\nstderr and stdout of the task.\n\nSince: generic-worker 48.2.0",

--- a/workers/generic-worker/generated_multiuser_freebsd.go
+++ b/workers/generic-worker/generated_multiuser_freebsd.go
@@ -162,6 +162,13 @@ type (
 	// Since: generic-worker 5.3.0
 	FeatureFlags struct {
 
+		// This allows you to disable artifact uploads for a task.
+		//
+		// Since: generic-worker 50.1.0
+		//
+		// Default:    true
+		Artifacts bool `json:"artifacts" default:"true"`
+
 		// The backing log feature publishes a task artifact containing the complete
 		// stderr and stdout of the task.
 		//
@@ -753,6 +760,12 @@ func taskPayloadSchema() string {
       "additionalProperties": false,
       "description": "Feature flags enable additional functionality.\n\nSince: generic-worker 5.3.0",
       "properties": {
+        "artifacts": {
+          "default": true,
+          "description": "This allows you to disable artifact uploads for a task.\n\nSince: generic-worker 50.1.0",
+          "title": "Enable artifact uploads",
+          "type": "boolean"
+        },
         "backingLog": {
           "default": true,
           "description": "The backing log feature publishes a task artifact containing the complete\nstderr and stdout of the task.\n\nSince: generic-worker 48.2.0",

--- a/workers/generic-worker/generated_multiuser_linux.go
+++ b/workers/generic-worker/generated_multiuser_linux.go
@@ -162,6 +162,13 @@ type (
 	// Since: generic-worker 5.3.0
 	FeatureFlags struct {
 
+		// This allows you to disable artifact uploads for a task.
+		//
+		// Since: generic-worker 50.1.0
+		//
+		// Default:    true
+		Artifacts bool `json:"artifacts" default:"true"`
+
 		// The backing log feature publishes a task artifact containing the complete
 		// stderr and stdout of the task.
 		//
@@ -753,6 +760,12 @@ func taskPayloadSchema() string {
       "additionalProperties": false,
       "description": "Feature flags enable additional functionality.\n\nSince: generic-worker 5.3.0",
       "properties": {
+        "artifacts": {
+          "default": true,
+          "description": "This allows you to disable artifact uploads for a task.\n\nSince: generic-worker 50.1.0",
+          "title": "Enable artifact uploads",
+          "type": "boolean"
+        },
         "backingLog": {
           "default": true,
           "description": "The backing log feature publishes a task artifact containing the complete\nstderr and stdout of the task.\n\nSince: generic-worker 48.2.0",

--- a/workers/generic-worker/generated_multiuser_windows.go
+++ b/workers/generic-worker/generated_multiuser_windows.go
@@ -161,6 +161,13 @@ type (
 	// Since: generic-worker 5.3.0
 	FeatureFlags struct {
 
+		// This allows you to disable artifact uploads for a task.
+		//
+		// Since: generic-worker 50.1.0
+		//
+		// Default:    true
+		Artifacts bool `json:"artifacts" default:"true"`
+
 		// The backing log feature publishes a task artifact containing the complete
 		// stderr and stdout of the task.
 		//
@@ -781,6 +788,12 @@ func taskPayloadSchema() string {
       "additionalProperties": false,
       "description": "Feature flags enable additional functionality.\n\nSince: generic-worker 5.3.0",
       "properties": {
+        "artifacts": {
+          "default": true,
+          "description": "This allows you to disable artifact uploads for a task.\n\nSince: generic-worker 50.1.0",
+          "title": "Enable artifact uploads",
+          "type": "boolean"
+        },
         "backingLog": {
           "default": true,
           "description": "The backing log feature publishes a task artifact containing the complete\nstderr and stdout of the task.\n\nSince: generic-worker 48.2.0",

--- a/workers/generic-worker/generated_simple_darwin.go
+++ b/workers/generic-worker/generated_simple_darwin.go
@@ -162,6 +162,13 @@ type (
 	// Since: generic-worker 5.3.0
 	FeatureFlags struct {
 
+		// This allows you to disable artifact uploads for a task.
+		//
+		// Since: generic-worker 50.1.0
+		//
+		// Default:    true
+		Artifacts bool `json:"artifacts" default:"true"`
+
 		// The backing log feature publishes a task artifact containing the complete
 		// stderr and stdout of the task.
 		//
@@ -733,6 +740,12 @@ func taskPayloadSchema() string {
       "additionalProperties": false,
       "description": "Feature flags enable additional functionality.\n\nSince: generic-worker 5.3.0",
       "properties": {
+        "artifacts": {
+          "default": true,
+          "description": "This allows you to disable artifact uploads for a task.\n\nSince: generic-worker 50.1.0",
+          "title": "Enable artifact uploads",
+          "type": "boolean"
+        },
         "backingLog": {
           "default": true,
           "description": "The backing log feature publishes a task artifact containing the complete\nstderr and stdout of the task.\n\nSince: generic-worker 48.2.0",

--- a/workers/generic-worker/generated_simple_freebsd.go
+++ b/workers/generic-worker/generated_simple_freebsd.go
@@ -162,6 +162,13 @@ type (
 	// Since: generic-worker 5.3.0
 	FeatureFlags struct {
 
+		// This allows you to disable artifact uploads for a task.
+		//
+		// Since: generic-worker 50.1.0
+		//
+		// Default:    true
+		Artifacts bool `json:"artifacts" default:"true"`
+
 		// The backing log feature publishes a task artifact containing the complete
 		// stderr and stdout of the task.
 		//
@@ -733,6 +740,12 @@ func taskPayloadSchema() string {
       "additionalProperties": false,
       "description": "Feature flags enable additional functionality.\n\nSince: generic-worker 5.3.0",
       "properties": {
+        "artifacts": {
+          "default": true,
+          "description": "This allows you to disable artifact uploads for a task.\n\nSince: generic-worker 50.1.0",
+          "title": "Enable artifact uploads",
+          "type": "boolean"
+        },
         "backingLog": {
           "default": true,
           "description": "The backing log feature publishes a task artifact containing the complete\nstderr and stdout of the task.\n\nSince: generic-worker 48.2.0",

--- a/workers/generic-worker/generated_simple_linux.go
+++ b/workers/generic-worker/generated_simple_linux.go
@@ -162,6 +162,13 @@ type (
 	// Since: generic-worker 5.3.0
 	FeatureFlags struct {
 
+		// This allows you to disable artifact uploads for a task.
+		//
+		// Since: generic-worker 50.1.0
+		//
+		// Default:    true
+		Artifacts bool `json:"artifacts" default:"true"`
+
 		// The backing log feature publishes a task artifact containing the complete
 		// stderr and stdout of the task.
 		//
@@ -733,6 +740,12 @@ func taskPayloadSchema() string {
       "additionalProperties": false,
       "description": "Feature flags enable additional functionality.\n\nSince: generic-worker 5.3.0",
       "properties": {
+        "artifacts": {
+          "default": true,
+          "description": "This allows you to disable artifact uploads for a task.\n\nSince: generic-worker 50.1.0",
+          "title": "Enable artifact uploads",
+          "type": "boolean"
+        },
         "backingLog": {
           "default": true,
           "description": "The backing log feature publishes a task artifact containing the complete\nstderr and stdout of the task.\n\nSince: generic-worker 48.2.0",

--- a/workers/generic-worker/schemas/multiuser_posix.yml
+++ b/workers/generic-worker/schemas/multiuser_posix.yml
@@ -247,6 +247,14 @@ properties:
           is one.
 
           Since: generic-worker 49.2.0
+      artifacts:
+        type: boolean
+        title: Enable artifact uploads
+        description: |-
+          This allows you to disable artifact uploads for a task.
+
+          Since: generic-worker 50.1.0
+        default: true
   mounts:
     type: array
     description: |-

--- a/workers/generic-worker/schemas/multiuser_windows.yml
+++ b/workers/generic-worker/schemas/multiuser_windows.yml
@@ -249,6 +249,14 @@ properties:
 
           Since: generic-worker 48.2.0
         default: true
+      artifacts:
+        type: boolean
+        title: Enable artifact uploads
+        description: |-
+          This allows you to disable artifact uploads for a task.
+
+          Since: generic-worker 50.1.0
+        default: true
   mounts:
     type: array
     description: |-

--- a/workers/generic-worker/schemas/simple_posix.yml
+++ b/workers/generic-worker/schemas/simple_posix.yml
@@ -225,6 +225,14 @@ properties:
           is one.
 
           Since: generic-worker 49.2.0
+      artifacts:
+        type: boolean
+        title: Enable artifact uploads
+        description: |-
+          This allows you to disable artifact uploads for a task.
+
+          Since: generic-worker 50.1.0
+        default: true
   mounts:
     type: array
     description: |-


### PR DESCRIPTION
>Adds `task.payload.features.artifacts` feature to generic worker to bring to parity with an existing docker worker feature.
>
>This feature allows a user to disable all artifact uploads. It defaults to `true` so it's not a breaking change.