### PR TITLE
chore: bump browerslist

### DIFF
--- a/changelog/GoL9LrUTTtqMYziO_MWEBA.md
+++ b/changelog/GoL9LrUTTtqMYziO_MWEBA.md
@@ -1,0 +1,4 @@
+audience: general
+level: patch
+---
+Bump caniuse-lite version with `npx update-browserslist-db@latest` due to outdated warning.

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -3803,9 +3803,9 @@ camelcase@^6.0.0:
   integrity sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==
 
 caniuse-lite@^1.0.30001400:
-  version "1.0.30001431"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001431.tgz#e7c59bd1bc518fae03a4656be442ce6c4887a795"
-  integrity sha512-zBUoFU0ZcxpvSt9IU66dXVT/3ctO1cy4y9cscs1szkPlcWb6pasYM144GqrUygUbT+k7cmUCW61cvskjcv0enQ==
+  version "1.0.30001486"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001486.tgz#56a08885228edf62cbe1ac8980f2b5dae159997e"
+  integrity sha512-uv7/gXuHi10Whlj0pp5q/tsK/32J2QSqVRKQhs2j8VsDCjgyruAh/eEXHF822VqO9yT6iZKw3nRwZRSPBE9OQg==
 
 capture-exit@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
>Bump caniuse-lite version with `npx update-browserslist-db@latest` due to outdated warning.