### PR TITLE
Allow github client to seal and cancel task groups

### DIFF
--- a/changelog/issue-5621.md
+++ b/changelog/issue-5621.md
@@ -1,0 +1,7 @@
+audience: admins
+level: patch
+reference: issue 5621
+---
+
+Extend `static/taskcluster/github` client with two scopes that are necessary to seal and cancel previously created task groups: `queue:cancel-task-group:taskcluster-github` and `queue:seal-task-group:taskcluster-github`.
+When github repository is using a different schedulerId than `taskcluster-github`, then it might be necessary to update corresponding `repo:github.com/` roles with correct scopes.

--- a/services/auth/src/static-scopes.json
+++ b/services/auth/src/static-scopes.json
@@ -11,10 +11,12 @@
     "scopes": [
       "assume:repo:github.com/*",
       "assume:scheduler-id:taskcluster-github/*",
+      "queue:cancel-task-group:taskcluster-github/*",
       "queue:list-task-group:*",
       "queue:route:checks",
       "queue:route:statuses",
-      "queue:scheduler-id:taskcluster-github"
+      "queue:scheduler-id:taskcluster-github",
+      "queue:seal-task-group:taskcluster-github/*"
     ]
   },
   {

--- a/services/github/scopes.yml
+++ b/services/github/scopes.yml
@@ -4,3 +4,5 @@
 - queue:route:checks
 - assume:scheduler-id:taskcluster-github/*
 - queue:list-task-group:*
+- queue:seal-task-group:taskcluster-github/*
+- queue:cancel-task-group:taskcluster-github/*

--- a/services/github/src/handlers/index.js
+++ b/services/github/src/handlers/index.js
@@ -274,9 +274,9 @@ class Handlers {
       ).map(build => build.task_group_id);
       if (taskGroupIds.length > 0) {
         debug(`Found running task groups: ${taskGroupIds.join(', ')}. Sealing and cancelling`);
-        await Promise.allSettled(taskGroupIds.map(taskGroupId => this.queueClient.sealTaskGroup(taskGroupId)));
-        await Promise.allSettled(taskGroupIds.map(taskGroupId => this.queueClient.cancelTaskGroup(taskGroupId)));
-        await Promise.allSettled(taskGroupIds.map(taskGroupId => this.context.db.fns.set_github_build_state(taskGroupId, 'cancelled')));
+        await Promise.all(taskGroupIds.map(taskGroupId => this.queueClient.sealTaskGroup(taskGroupId)));
+        await Promise.all(taskGroupIds.map(taskGroupId => this.queueClient.cancelTaskGroup(taskGroupId)));
+        await Promise.all(taskGroupIds.map(taskGroupId => this.context.db.fns.set_github_build_state(taskGroupId, 'cancelled')));
       }
     } catch (err) {
       debug(`Error while canceling previous task groups: ${err.message}`);


### PR DESCRIPTION
This is a followup on #5621 to give extra scopes for github client, as it currently cannot cancel own task groups. 

Github client will get following scopes:
- `queue:seal-task-group:taskcluster-github/*`
- `queue:cancel-task-group:taskcluster-github/*`

When some repository is using different `schedulerId` then corresponding `repo:github.com/` role should be updated to have adjusted roles (to make github client capable of stopping previous builds)