### PR TITLE
Remove unneeded build constraint

### DIFF
--- a/changelog/IRI3DiqKST2KvPcZvMmjtA.md
+++ b/changelog/IRI3DiqKST2KvPcZvMmjtA.md
@@ -1,0 +1,3 @@
+audience: general
+level: silent
+---

--- a/workers/generic-worker/process/process.go
+++ b/workers/generic-worker/process/process.go
@@ -1,5 +1,3 @@
-//go:build multiuser || simple
-
 package process
 
 import (


### PR DESCRIPTION
Without docker engine, this build constraint is no longer necessary.