### PR TITLE
Update client-web test to avoid using env variables in regexp

### DIFF
--- a/changelog/Z0bho1tfSzCbOXmaShDFFg.md
+++ b/changelog/Z0bho1tfSzCbOXmaShDFFg.md
@@ -1,0 +1,3 @@
+audience: general
+level: silent
+---

--- a/clients/client-web/test/Auth_test.js
+++ b/clients/client-web/test/Auth_test.js
@@ -34,7 +34,7 @@ describe('Auth', function() {
     });
 
     expect(auth.buildSignedUrl(auth.client, 'test'))
-      .to.eventually.match(new RegExp(`^${process.env.BASE_URL}/auth/v1/clients/test\\?bewit`));
+      .to.eventually.match(new RegExp(`^${helper.rootUrl}/auth/v1/clients/test\\?bewit`));
   });
 
   it('should request from signed URL', () => {


### PR DESCRIPTION
Resolves https://github.com/taskcluster/taskcluster/security/code-scanning/312 