### PR TITLE
chore: remove docker engine reference

### DIFF
--- a/changelog/AX4UCxG0RqGeqDU4poPqwQ.md
+++ b/changelog/AX4UCxG0RqGeqDU4poPqwQ.md
@@ -1,0 +1,3 @@
+audience: general
+level: silent
+---

--- a/ui/src/utils/constants.js
+++ b/ui/src/utils/constants.js
@@ -338,13 +338,4 @@ export const TASK_PAYLOAD_SCHEMAS = {
       maxRunTime: 600 + 30,
     },
   },
-  'generic-docker-posix': {
-    label: 'Generic worker docker posix',
-    type: 'generic-worker',
-    schema: 'docker_posix.json',
-    samplePayload: {
-      command: [payloadCommand],
-      maxRunTime: 600 + 30,
-    },
-  },
 };


### PR DESCRIPTION
This is no longer a valid schema to validate against in the create task view on the UI.