### PR TITLE
Rework the interactive feature for generic worker

### DIFF
--- a/changelog/dZvtWFeQSKO9cn3iVU3GhA.md
+++ b/changelog/dZvtWFeQSKO9cn3iVU3GhA.md
@@ -1,0 +1,4 @@
+audience: users
+level: major
+---
+Rework the interactive feature for generic worker allowing to run interactive commands in it

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/Flaque/filet v0.0.0-20201012163910-45f684403088
 	github.com/Microsoft/go-winio v0.6.1
 	github.com/cenkalti/backoff/v3 v3.2.2
+	github.com/creack/pty v1.1.18
 	github.com/dchest/uniuri v1.2.0
 	github.com/deckarep/golang-set v1.8.0
 	github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815

--- a/go.sum
+++ b/go.sum
@@ -12,6 +12,8 @@ github.com/certifi/gocertifi v0.0.0-20210507211836-431795d63e8d h1:S2NE3iHSwP0XV
 github.com/certifi/gocertifi v0.0.0-20210507211836-431795d63e8d/go.mod h1:sGbDF6GwGcLpkNXPUTkMRoywsNa/ol15pxFe6ERfguA=
 github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
+github.com/creack/pty v1.1.18 h1:n56/Zwd5o6whRC5PMGretI4IdRLlmBXYNjScPaBgsbY=
+github.com/creack/pty v1.1.18/go.mod h1:MOBLtS5ELjhRRrroQr9kyvTxUAFNvYEK993ew/Vr4O4=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/workers/generic-worker/interactive/interactive.go
+++ b/workers/generic-worker/interactive/interactive.go
@@ -4,16 +4,13 @@
 package interactive
 
 import (
-	"bufio"
 	"context"
 	"fmt"
-	"io"
 	"log"
 	"net/http"
 	"os"
 	"os/exec"
 	"strings"
-	"sync"
 
 	"github.com/gorilla/websocket"
 	"github.com/taskcluster/slugid-go/slugid"
@@ -26,68 +23,25 @@ var upgrader = &websocket.Upgrader{
 }
 
 type Interactive struct {
-	TCPPort   uint16
-	GetURL    string
-	secret    string
-	conn      *websocket.Conn
-	connMutex *sync.Mutex
-	stdin     io.WriteCloser
-	stdout    io.ReadCloser
-	stderr    io.ReadCloser
-	cmd       *exec.Cmd
-	done      chan struct{}
-	errors    chan error
-	ctx       context.Context
+	TCPPort uint16
+	GetURL  string
+	secret  string
+	ctx     context.Context
+	cmd     CreateInteractiveProcess
 }
 
-func New(port uint16, cmd *exec.Cmd, ctx context.Context) (it *Interactive, err error) {
+type CreateInteractiveProcess func() (*exec.Cmd, error)
+
+func New(port uint16, cmd CreateInteractiveProcess, ctx context.Context) (it *Interactive, err error) {
 	it = &Interactive{
 		TCPPort: port,
 		secret:  slugid.Nice(),
 		cmd:     cmd,
-		done:    make(chan struct{}),
-		// size of 3 is because there
-		// are only ever 3 goroutines
-		// who write to this channel
-		// and we don't want to block
-		errors: make(chan error, 3),
-		ctx:    ctx,
+		ctx:     ctx,
 	}
 
 	it.setRequestURL()
-
 	os.Setenv("INTERACTIVE_ACCESS_TOKEN", it.secret)
-
-	it.stdin, err = it.cmd.StdinPipe()
-	if err != nil {
-		log.Printf("StdinPipe error: %v", err)
-		return nil, err
-	}
-
-	it.stdout, err = it.cmd.StdoutPipe()
-	if err != nil {
-		log.Printf("StdoutPipe error: %v", err)
-		return nil, err
-	}
-
-	it.stderr, err = it.cmd.StderrPipe()
-	if err != nil {
-		log.Printf("StderrPipe error: %v", err)
-		return nil, err
-	}
-
-	go it.copyCommandOutputStream(it.stdout)
-	go it.copyCommandOutputStream(it.stderr)
-
-	if err = it.cmd.Start(); err != nil {
-		log.Printf("Command start error: %v", err)
-		return
-	}
-
-	go func() {
-		it.errors <- it.cmd.Wait()
-		close(it.done)
-	}()
 
 	return
 }
@@ -108,89 +62,22 @@ func (it *Interactive) Handler(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "WebSocket upgrade error", http.StatusInternalServerError)
 		return
 	}
-	it.conn = conn
-	it.connMutex = &sync.Mutex{}
+
+	itj, err := CreateInteractiveJob(it.cmd, conn, it.ctx)
+	if err != nil {
+		log.Printf("Error while spawning interactive job: %v", err)
+		return
+	}
+
 	defer func() {
-		it.connMutex.Lock()
-		defer it.connMutex.Unlock()
-		if err := it.conn.Close(); err != nil {
+		if err := conn.Close(); err != nil {
 			log.Printf("WebSocket close error: %v", err)
 		}
 	}()
 
-	msgChan := make(chan []byte, 1)
-	go it.handleWebsocketMessages(msgChan)
-
 	select {
 	case <-it.ctx.Done():
-	case <-it.done:
-	}
-}
-
-func (it *Interactive) handleWebsocketMessages(msgChan chan []byte) {
-	for {
-		select {
-		case <-it.ctx.Done():
-			return
-		case <-it.done:
-			return
-		case err := <-it.errors:
-			if err != nil {
-				if websocket.IsCloseError(err, websocket.CloseNormalClosure) {
-					return
-				} else {
-					log.Printf("streamError occured: %v", err)
-					return
-				}
-			}
-		case msg := <-msgChan:
-			if _, err := it.stdin.Write(msg); err != nil {
-				log.Printf("Write error: %v", err)
-				return
-			}
-		default:
-			msgType, msg, err := it.conn.ReadMessage()
-			if err != nil {
-				if websocket.IsCloseError(err, websocket.CloseNormalClosure) {
-					return
-				} else {
-					log.Printf("ReadMessage error: %v", err)
-					return
-				}
-			}
-			if msgType != websocket.TextMessage {
-				continue
-			}
-			msgChan <- msg
-		}
-	}
-}
-
-func (it *Interactive) copyCommandOutputStream(stream io.ReadCloser) {
-	reader := bufio.NewReader(stream)
-	for {
-		select {
-		case <-it.ctx.Done():
-			return
-		case <-it.done:
-			return
-		default:
-			msg, err := reader.ReadString('\n')
-			if err != nil {
-				if err == io.EOF {
-					continue
-				}
-				it.errors <- err
-				return
-			}
-			it.connMutex.Lock()
-			if err := it.conn.WriteMessage(websocket.TextMessage, []byte(msg)); err != nil {
-				it.connMutex.Unlock()
-				it.errors <- err
-				return
-			}
-			it.connMutex.Unlock()
-		}
+	case <-itj.done:
 	}
 }
 
@@ -210,35 +97,13 @@ func (it *Interactive) ListenAndServe(ctx context.Context) error {
 		}
 	}()
 
-	select {
-	case <-it.ctx.Done():
-	case <-it.done:
-	}
+	<-it.ctx.Done()
 
 	if err := server.Shutdown(ctx); err != nil {
 		return fmt.Errorf("server shutdown failed: %v", err)
 	}
 
 	return nil
-}
-
-func (it *Interactive) Terminate() error {
-	if err := it.stdout.Close(); err != nil {
-		log.Printf("StdoutPipe close error: %v", err)
-	}
-	if err := it.stderr.Close(); err != nil {
-		log.Printf("StderrPipe close error: %v", err)
-	}
-	if err := it.stdin.Close(); err != nil {
-		log.Printf("StdinPipe close error: %v", err)
-	}
-
-	// no process is running, so there is nothing to terminate
-	if it.cmd.Process == nil {
-		return nil
-	}
-
-	return it.cmd.Process.Kill()
 }
 
 func (it *Interactive) setRequestURL() {

--- a/workers/generic-worker/interactive/interactivejob.go
+++ b/workers/generic-worker/interactive/interactivejob.go
@@ -1,0 +1,162 @@
+//go:build darwin || linux || freebsd
+
+package interactive
+
+import (
+	"context"
+	"encoding/binary"
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"os/exec"
+	"syscall"
+
+	"github.com/creack/pty"
+	"github.com/gorilla/websocket"
+)
+
+const (
+	MsgStdin  = 1
+	MsgResize = 2
+)
+
+type InteractiveJob struct {
+	pty    *os.File
+	cmd    *exec.Cmd
+	errors chan error
+	done   chan struct{}
+	conn   *websocket.Conn
+	ctx    context.Context
+}
+
+func CreateInteractiveJob(createCmd CreateInteractiveProcess, conn *websocket.Conn, ctx context.Context) (itj *InteractiveJob, err error) {
+	itj = &InteractiveJob{
+		// size of 3 is because there
+		// are only ever 3 goroutines
+		// who write to this channel
+		// and we don't want to block
+		errors: make(chan error, 3),
+		done:   make(chan struct{}),
+		conn:   conn,
+		ctx:    ctx,
+	}
+
+	cmd, err := createCmd()
+	if err != nil {
+		itj.reportError(fmt.Sprintf("Error while getting command %v", err))
+		return
+	}
+	cmd.SysProcAttr = &syscall.SysProcAttr{}
+	cmd.SysProcAttr.Setsid = true
+	itj.cmd = cmd
+
+	pty, err := pty.StartWithAttrs(cmd, nil, cmd.SysProcAttr)
+	if err != nil {
+		itj.reportError(fmt.Sprintf("Error while spawning command %v", err))
+		return
+	}
+	itj.pty = pty
+
+	go func() {
+		itj.errors <- cmd.Wait()
+		close(itj.done)
+	}()
+
+	go itj.copyCommandOutputStream()
+	go itj.handleWebsocketMessages()
+
+	return itj, err
+}
+
+func (itj *InteractiveJob) Terminate() (err error) {
+	if itj.cmd.ProcessState != nil {
+		return nil
+	}
+
+	return itj.cmd.Process.Kill()
+}
+
+func (itj *InteractiveJob) copyCommandOutputStream() {
+	buf := make([]byte, 4096)
+	for {
+		select {
+		case <-itj.ctx.Done():
+			return
+		case <-itj.done:
+			return
+		default:
+			n, err := itj.pty.Read(buf)
+			if err != nil {
+				if err == io.EOF {
+					continue
+				}
+				return
+			}
+			if n == 0 {
+				continue
+			}
+			if err := itj.conn.WriteMessage(websocket.TextMessage, buf[:n]); err != nil {
+				itj.errors <- err
+				return
+			}
+		}
+	}
+}
+
+func (itj *InteractiveJob) handleWebsocketMessages() {
+	for {
+		select {
+		case <-itj.ctx.Done():
+			return
+		case <-itj.done:
+			return
+		case err := <-itj.errors:
+			if err != nil {
+				if !websocket.IsCloseError(err, websocket.CloseNormalClosure, websocket.CloseGoingAway) {
+					itj.reportError(fmt.Sprintf("Error occured: %v", err))
+				}
+			}
+			err = itj.Terminate()
+			if err != nil {
+				log.Printf("Error while terminating process: %v", err)
+			}
+			return
+		default:
+			_, msg, err := itj.conn.ReadMessage()
+			if err != nil {
+				itj.errors <- err
+				continue
+			}
+
+			if len(msg) == 0 {
+				return
+			}
+
+			switch msg[0] {
+			case MsgStdin:
+				if _, err := itj.pty.Write(msg[1:]); err != nil {
+					itj.errors <- err
+				}
+			case MsgResize:
+				width := binary.LittleEndian.Uint16(msg[1:3])
+				height := binary.LittleEndian.Uint16(msg[3:])
+				sz := pty.Winsize{Rows: width, Cols: height}
+				err := pty.Setsize(itj.pty, &sz)
+				if err != nil {
+					itj.errors <- err
+				}
+			default:
+				log.Printf("Unknown message code received from interactive task")
+			}
+		}
+	}
+}
+
+func (itj *InteractiveJob) reportError(errorMessage string) {
+	log.Println(errorMessage)
+	err := itj.conn.WriteMessage(websocket.TextMessage, []byte(errorMessage))
+	if err != nil {
+		log.Println("Error while reporting error to client")
+	}
+}


### PR DESCRIPTION
Instead of sending commands line by line and reading responses the same way, present the pty to the client through a websocket. This allows for interactive applications to run as well as displaying things as they would be in a normal terminal emulator. This includes support for resizing which means the PTY will adjust to the window size of the user.

This changes how interactive commands work on a fundamental level. Instead of running one command that everyone attaches to, this spawns one command per connection. That means that a command is spawned when a websocket opens instead of when the task starts running.

To be able to handle resizing, we need to distinguish resize requests coming from the client. Since we only have one websocket, we use the first byte of every message to distinguish whether the remaining of the message is data to be put on the PTY or a size request.

