### PR TITLE
Mount the changelog in the UI container in dev mode

### DIFF
--- a/changelog/JzuKhYjZTTy3hvABhImD9Q.md
+++ b/changelog/JzuKhYjZTTy3hvABhImD9Q.md
@@ -1,0 +1,3 @@
+audience: developers
+level: silent
+---

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -15,6 +15,7 @@ services:
       - ./generated:/app/generated
       - .all-contributorsrc:/app/.all-contributorsrc
       - ./ui:/app/ui
+      - ./CHANGELOG.md:/app/CHANGELOG.md
   generic-worker-standalone:
     image: taskcluster/generic-worker:v50.1.3
     networks:

--- a/infrastructure/tooling/src/generate/generators/docker-compose.js
+++ b/infrastructure/tooling/src/generate/generators/docker-compose.js
@@ -405,6 +405,7 @@ exports.tasks.push({
             './generated:/app/generated',
             '.all-contributorsrc:/app/.all-contributorsrc',
             './ui:/app/ui',
+            './CHANGELOG.md:/app/CHANGELOG.md',
           ],
         },
       },


### PR DESCRIPTION
The changelog is necessary to be able to compile
`ui/src/views/Documentation/Changelog/index.jsx` and needs to be at the root of the app.
