### PR TITLE
jsonschema2go: Add SHA, KVM as initialisms

### DIFF
--- a/changelog/IBhqsY4ZR1qLSobQrzU4tQ.md
+++ b/changelog/IBhqsY4ZR1qLSobQrzU4tQ.md
@@ -1,0 +1,9 @@
+audience: developers
+level: major
+---
+The jsonschema2go tool now considers `SHA` and `KVM` to be words that should be
+capitalised when generating go type names.
+
+As a consequence, the taskcluster go client is backwardly incomaptible with the
+previous release, since the `tcgithub.Build` struct member `Sha` has been
+renamed to `SHA`.

--- a/clients/client-go/tcgithub/types.go
+++ b/clients/client-go/tcgithub/types.go
@@ -43,7 +43,7 @@ type (
 		//
 		// Min length: 40
 		// Max length: 40
-		Sha string `json:"sha"`
+		SHA string `json:"sha"`
 
 		// Github status associated with the build.
 		//

--- a/clients/client-go/tcobject/types.go
+++ b/clients/client-go/tcobject/types.go
@@ -35,11 +35,11 @@ type (
 		//
 		//  	// Syntax:     ^[a-z0-9]{64}$
 		//  	//
-		//		//  	Sha256 string `json:"sha256,omitempty"`
+		//		//  	SHA256 string `json:"sha256,omitempty"`
 		//
 		//  	// Syntax:     ^[a-z0-9]{128}$
 		//  	//
-		//		//  	Sha512 string `json:"sha512,omitempty"`
+		//		//  	SHA512 string `json:"sha512,omitempty"`
 		//  }
 		//
 		// Additional properties allowed
@@ -135,11 +135,11 @@ type (
 		//
 		//  	// Syntax:     ^[a-z0-9]{64}$
 		//  	//
-		//		//  	Sha256 string `json:"sha256,omitempty"`
+		//		//  	SHA256 string `json:"sha256,omitempty"`
 		//
 		//  	// Syntax:     ^[a-z0-9]{128}$
 		//  	//
-		//		//  	Sha512 string `json:"sha512,omitempty"`
+		//		//  	SHA512 string `json:"sha512,omitempty"`
 		//  }
 		//
 		// Additional properties allowed
@@ -192,11 +192,11 @@ type (
 		//
 		//  	// Syntax:     ^[a-z0-9]{64}$
 		//  	//
-		//		//  	Sha256 string `json:"sha256,omitempty"`
+		//		//  	SHA256 string `json:"sha256,omitempty"`
 		//
 		//  	// Syntax:     ^[a-z0-9]{128}$
 		//  	//
-		//		//  	Sha512 string `json:"sha512,omitempty"`
+		//		//  	SHA512 string `json:"sha512,omitempty"`
 		//  }
 		//
 		// Additional properties allowed
@@ -226,11 +226,11 @@ type (
 	//
 	//  	// Syntax:     ^[a-z0-9]{64}$
 	//  	//
-	//	//  	Sha256 string `json:"sha256,omitempty"`
+	//	//  	SHA256 string `json:"sha256,omitempty"`
 	//
 	//  	// Syntax:     ^[a-z0-9]{128}$
 	//  	//
-	//	//  	Sha512 string `json:"sha512,omitempty"`
+	//	//  	SHA512 string `json:"sha512,omitempty"`
 	//  }
 	//
 	// Additional properties allowed
@@ -246,11 +246,11 @@ type (
 	//
 	//  	// Syntax:     ^[a-z0-9]{64}$
 	//  	//
-	//	//  	Sha256 string `json:"sha256,omitempty"`
+	//	//  	SHA256 string `json:"sha256,omitempty"`
 	//
 	//  	// Syntax:     ^[a-z0-9]{128}$
 	//  	//
-	//	//  	Sha512 string `json:"sha512,omitempty"`
+	//	//  	SHA512 string `json:"sha512,omitempty"`
 	//  }
 	//
 	// Additional properties allowed
@@ -270,11 +270,11 @@ type (
 		//
 		//  	// Syntax:     ^[a-z0-9]{64}$
 		//  	//
-		//		//  	Sha256 string `json:"sha256,omitempty"`
+		//		//  	SHA256 string `json:"sha256,omitempty"`
 		//
 		//  	// Syntax:     ^[a-z0-9]{128}$
 		//  	//
-		//		//  	Sha512 string `json:"sha512,omitempty"`
+		//		//  	SHA512 string `json:"sha512,omitempty"`
 		//  }
 		//
 		// Additional properties allowed

--- a/tools/jsonschema2go/text/text.go
+++ b/tools/jsonschema2go/text/text.go
@@ -39,7 +39,8 @@ var reservedKeyWords = map[string]bool{
 	"var":         true,
 }
 
-// taken from https://github.com/golang/lint/blob/32a87160691b3c96046c0c678fe57c5bef761456/lint.go#L702
+// originally taken from https://github.com/golang/lint/blob/32a87160691b3c96046c0c678fe57c5bef761456/lint.go#L702
+// and then adapted to include extra terms
 var commonInitialisms = map[string]bool{
 	"API":   true,
 	"ASCII": true,
@@ -54,12 +55,14 @@ var commonInitialisms = map[string]bool{
 	"ID":    true,
 	"IP":    true,
 	"JSON":  true,
+	"KVM":   true,
 	"LHS":   true,
 	"OS":    true,
 	"QPS":   true,
 	"RAM":   true,
 	"RHS":   true,
 	"RPC":   true,
+	"SHA":   true,
 	"SLA":   true,
 	"SMTP":  true,
 	"SQL":   true,

--- a/workers/generic-worker/generated_multiuser_darwin.go
+++ b/workers/generic-worker/generated_multiuser_darwin.go
@@ -108,7 +108,7 @@ type (
 		// Since: generic-worker 10.8.0
 		//
 		// Syntax:     ^[a-f0-9]{64}$
-		Sha256 string `json:"sha256,omitempty"`
+		SHA256 string `json:"sha256,omitempty"`
 
 		// Syntax:     ^[A-Za-z0-9_-]{8}[Q-T][A-Za-z0-9_-][CGKOSWaeimquy26-][A-Za-z0-9_-]{10}[AQgw]$
 		TaskID string `json:"taskId"`
@@ -400,7 +400,7 @@ type (
 		// Since: generic-worker 10.8.0
 		//
 		// Syntax:     ^[a-f0-9]{64}$
-		Sha256 string `json:"sha256,omitempty"`
+		SHA256 string `json:"sha256,omitempty"`
 
 		// URL to download content from.
 		//

--- a/workers/generic-worker/generated_multiuser_freebsd.go
+++ b/workers/generic-worker/generated_multiuser_freebsd.go
@@ -108,7 +108,7 @@ type (
 		// Since: generic-worker 10.8.0
 		//
 		// Syntax:     ^[a-f0-9]{64}$
-		Sha256 string `json:"sha256,omitempty"`
+		SHA256 string `json:"sha256,omitempty"`
 
 		// Syntax:     ^[A-Za-z0-9_-]{8}[Q-T][A-Za-z0-9_-][CGKOSWaeimquy26-][A-Za-z0-9_-]{10}[AQgw]$
 		TaskID string `json:"taskId"`
@@ -400,7 +400,7 @@ type (
 		// Since: generic-worker 10.8.0
 		//
 		// Syntax:     ^[a-f0-9]{64}$
-		Sha256 string `json:"sha256,omitempty"`
+		SHA256 string `json:"sha256,omitempty"`
 
 		// URL to download content from.
 		//

--- a/workers/generic-worker/generated_multiuser_linux.go
+++ b/workers/generic-worker/generated_multiuser_linux.go
@@ -108,7 +108,7 @@ type (
 		// Since: generic-worker 10.8.0
 		//
 		// Syntax:     ^[a-f0-9]{64}$
-		Sha256 string `json:"sha256,omitempty"`
+		SHA256 string `json:"sha256,omitempty"`
 
 		// Syntax:     ^[A-Za-z0-9_-]{8}[Q-T][A-Za-z0-9_-][CGKOSWaeimquy26-][A-Za-z0-9_-]{10}[AQgw]$
 		TaskID string `json:"taskId"`
@@ -400,7 +400,7 @@ type (
 		// Since: generic-worker 10.8.0
 		//
 		// Syntax:     ^[a-f0-9]{64}$
-		Sha256 string `json:"sha256,omitempty"`
+		SHA256 string `json:"sha256,omitempty"`
 
 		// URL to download content from.
 		//

--- a/workers/generic-worker/generated_multiuser_windows.go
+++ b/workers/generic-worker/generated_multiuser_windows.go
@@ -107,7 +107,7 @@ type (
 		// Since: generic-worker 10.8.0
 		//
 		// Syntax:     ^[a-f0-9]{64}$
-		Sha256 string `json:"sha256,omitempty"`
+		SHA256 string `json:"sha256,omitempty"`
 
 		// Syntax:     ^[A-Za-z0-9_-]{8}[Q-T][A-Za-z0-9_-][CGKOSWaeimquy26-][A-Za-z0-9_-]{10}[AQgw]$
 		TaskID string `json:"taskId"`
@@ -433,7 +433,7 @@ type (
 		// Since: generic-worker 10.8.0
 		//
 		// Syntax:     ^[a-f0-9]{64}$
-		Sha256 string `json:"sha256,omitempty"`
+		SHA256 string `json:"sha256,omitempty"`
 
 		// URL to download content from.
 		//

--- a/workers/generic-worker/generated_simple_darwin.go
+++ b/workers/generic-worker/generated_simple_darwin.go
@@ -108,7 +108,7 @@ type (
 		// Since: generic-worker 10.8.0
 		//
 		// Syntax:     ^[a-f0-9]{64}$
-		Sha256 string `json:"sha256,omitempty"`
+		SHA256 string `json:"sha256,omitempty"`
 
 		// Syntax:     ^[A-Za-z0-9_-]{8}[Q-T][A-Za-z0-9_-][CGKOSWaeimquy26-][A-Za-z0-9_-]{10}[AQgw]$
 		TaskID string `json:"taskId"`
@@ -380,7 +380,7 @@ type (
 		// Since: generic-worker 10.8.0
 		//
 		// Syntax:     ^[a-f0-9]{64}$
-		Sha256 string `json:"sha256,omitempty"`
+		SHA256 string `json:"sha256,omitempty"`
 
 		// URL to download content from.
 		//

--- a/workers/generic-worker/generated_simple_freebsd.go
+++ b/workers/generic-worker/generated_simple_freebsd.go
@@ -108,7 +108,7 @@ type (
 		// Since: generic-worker 10.8.0
 		//
 		// Syntax:     ^[a-f0-9]{64}$
-		Sha256 string `json:"sha256,omitempty"`
+		SHA256 string `json:"sha256,omitempty"`
 
 		// Syntax:     ^[A-Za-z0-9_-]{8}[Q-T][A-Za-z0-9_-][CGKOSWaeimquy26-][A-Za-z0-9_-]{10}[AQgw]$
 		TaskID string `json:"taskId"`
@@ -380,7 +380,7 @@ type (
 		// Since: generic-worker 10.8.0
 		//
 		// Syntax:     ^[a-f0-9]{64}$
-		Sha256 string `json:"sha256,omitempty"`
+		SHA256 string `json:"sha256,omitempty"`
 
 		// URL to download content from.
 		//

--- a/workers/generic-worker/generated_simple_linux.go
+++ b/workers/generic-worker/generated_simple_linux.go
@@ -108,7 +108,7 @@ type (
 		// Since: generic-worker 10.8.0
 		//
 		// Syntax:     ^[a-f0-9]{64}$
-		Sha256 string `json:"sha256,omitempty"`
+		SHA256 string `json:"sha256,omitempty"`
 
 		// Syntax:     ^[A-Za-z0-9_-]{8}[Q-T][A-Za-z0-9_-][CGKOSWaeimquy26-][A-Za-z0-9_-]{10}[AQgw]$
 		TaskID string `json:"taskId"`
@@ -380,7 +380,7 @@ type (
 		// Since: generic-worker 10.8.0
 		//
 		// Syntax:     ^[a-f0-9]{64}$
-		Sha256 string `json:"sha256,omitempty"`
+		SHA256 string `json:"sha256,omitempty"`
 
 		// URL to download content from.
 		//

--- a/workers/generic-worker/mounts.go
+++ b/workers/generic-worker/mounts.go
@@ -786,7 +786,7 @@ func (ac *ArtifactContent) UniqueKey() string {
 }
 
 func (ac *ArtifactContent) RequiredSHA256() string {
-	return ac.Sha256
+	return ac.SHA256
 }
 
 func (ac *ArtifactContent) TaskDependencies() []string {
@@ -812,7 +812,7 @@ func (uc *URLContent) UniqueKey() string {
 }
 
 func (uc *URLContent) RequiredSHA256() string {
-	return uc.Sha256
+	return uc.SHA256
 }
 
 func (uc *URLContent) TaskDependencies() []string {


### PR DESCRIPTION
The jsonschema2go tool now considers `SHA` and `KVM` to be words that should be
capitalised when generating go type names.

As a consequence, the taskcluster go client is backwardly incomaptible with the
previous release, since the `tcgithub.Build` struct member `Sha` has been
renamed to `SHA`.