### PR TITLE
Fix: generic-worker: indexed content now unmarshaled into IndexedContent go type

### DIFF
--- a/changelog/JSKb0tL-RparNBUHNdVf0A.md
+++ b/changelog/JSKb0tL-RparNBUHNdVf0A.md
@@ -1,0 +1,4 @@
+audience: users
+level: patch
+---
+The new (unused in production) indexed artifacts feature of Generic Worker was broken in release 51.0.0. This has (hopefully) been fixed.

--- a/workers/generic-worker/mounts.go
+++ b/workers/generic-worker/mounts.go
@@ -784,7 +784,10 @@ func FSContentFrom(c json.RawMessage) (FSContent, error) {
 		return nil, err
 	}
 	switch {
-	case m["artifact"] != nil:
+	// Select property names unique to a single type wherever possible.
+	// Reordering the cases or changing property names to match on could break
+	// things if property names are common to multiple types, so be careful!
+	case m["taskId"] != nil:
 		return UnmarshalInto(c, &ArtifactContent{})
 	case m["namespace"] != nil:
 		return UnmarshalInto(c, &IndexedContent{})


### PR DESCRIPTION
Both Artifact Content and the new Indexed Content type contain an "artifact" property. Indexed Content was incorrectly being unmarshaled into ArtifactContent, since the presence of "artifact" was assumed (in the past) to mean that the content was Artifact Content. I've changed the check so that a "taskId" property implies Artifact Content (the only type which contains this property), and "namespace" continues to imply Indexed Content (also unique to this type). I've also added a comment to highlight that when making changes to this switch statement, extreme care needs to be taken to check that previous conditions still hold.

I will add tests for this, but in the meantime, here is an emergency fix.

Currently not used in production.