### PR TITLE
Quarantine worker on removeWorker

### DIFF
--- a/changelog/issue-6247.md
+++ b/changelog/issue-6247.md
@@ -1,0 +1,8 @@
+audience: admins
+level: minor
+reference: issue 6247
+---
+
+Worker manager now also quarantines worker on `removeWorker` call. This is used to prevent some race conditions when worker is still polling for new work and is removed/shutdown at the same time.
+
+This also requires configuration changes so that `static/taskcluster/worker-manager` client would be able to quarantine workers: adding `queue:quarantine-worker:<..>/*` scope to the `worker-type:*` role should be enough.

--- a/changelog/issue-6247.md
+++ b/changelog/issue-6247.md
@@ -4,5 +4,3 @@ reference: issue 6247
 ---
 
 Worker manager now also quarantines worker on `removeWorker` call. This is used to prevent some race conditions when worker is still polling for new work and is removed/shutdown at the same time.
-
-This also requires configuration changes so that `static/taskcluster/worker-manager` client would be able to quarantine workers: adding `queue:quarantine-worker:<..>/*` scope to the `worker-type:*` role should be enough.

--- a/services/auth/src/static-scopes.json
+++ b/services/auth/src/static-scopes.json
@@ -93,6 +93,7 @@
       "notify:email:*",
       "queue:claim-work:*",
       "queue:pending-count:*",
+      "queue:quarantine-worker:*",
       "queue:worker-id:*",
       "secrets:get:worker-pool:*",
       "secrets:get:worker-type:*",

--- a/services/worker-manager/scopes.yml
+++ b/services/worker-manager/scopes.yml
@@ -8,5 +8,6 @@
 - queue:claim-work:*
 - queue:worker-id:*
 - queue:pending-count:*
+- queue:quarantine-worker:*
 - worker-manager:remove-worker:*
 - worker-manager:reregister-worker:*

--- a/services/worker-manager/src/api.js
+++ b/services/worker-manager/src/api.js
@@ -4,8 +4,9 @@ const assert = require('assert');
 const { ApiError, Provider } = require('./providers/provider');
 const { UNIQUE_VIOLATION } = require('taskcluster-lib-postgres');
 const { WorkerPool, WorkerPoolError, Worker } = require('./data');
-const { createCredentials, joinWorkerPoolId, sanitizeRegisterWorkerPayload } = require('./util');
+const { createCredentials, joinWorkerPoolId, sanitizeRegisterWorkerPayload, splitWorkerPoolId } = require('./util');
 const { TaskQueue } = require('./queue-data');
+const taskcluster = require('taskcluster-client');
 
 let builder = new APIBuilder({
   title: 'Worker Manager Service',
@@ -33,6 +34,7 @@ let builder = new APIBuilder({
     'publisher',
     'monitor',
     'notify',
+    'queue',
   ],
 });
 
@@ -635,6 +637,18 @@ builder.declare({
 
   try {
     await provider.removeWorker({ worker, reason: 'workerManager.removeWorker API call' });
+
+    // To make sure that queue service will not serve any tasks to this worker we quarantine it
+    const { provisionerId, workerType } = splitWorkerPoolId(workerPoolId);
+    await this.queue.quarantineWorker(
+      provisionerId,
+      workerType,
+      workerGroup,
+      workerId,
+      {
+        quarantineUntil: taskcluster.fromNow('1 day'),
+        quarantineInfo: 'workerManager.removeWorker API call',
+      });
   } catch (err) {
     if (!(err instanceof ApiError)) {
       throw err;

--- a/services/worker-manager/src/main.js
+++ b/services/worker-manager/src/main.js
@@ -178,10 +178,10 @@ let load = loader({
   },
 
   providers: {
-    requires: ['cfg', 'monitor', 'notify', 'db', 'estimator', 'schemaset'],
-    setup: async ({ cfg, monitor, notify, db, estimator, schemaset }) =>
+    requires: ['cfg', 'monitor', 'notify', 'db', 'estimator', 'schemaset', 'queue'],
+    setup: async ({ cfg, monitor, notify, db, estimator, schemaset, queue }) =>
       new Providers().setup({
-        cfg, monitor, notify, db, estimator,
+        cfg, monitor, notify, db, estimator, queue,
         validator: await schemaset.validator(cfg.taskcluster.rootUrl),
       }),
   },

--- a/services/worker-manager/src/main.js
+++ b/services/worker-manager/src/main.js
@@ -125,7 +125,7 @@ let load = loader({
   api: {
     requires: [
       'cfg', 'db', 'schemaset', 'monitor', 'providers',
-      'publisher', 'notify'],
+      'publisher', 'notify', 'queue'],
     setup: async ({
       cfg,
       db,
@@ -134,6 +134,7 @@ let load = loader({
       providers,
       publisher,
       notify,
+      queue,
     }) => builder.build({
       rootUrl: cfg.taskcluster.rootUrl,
       context: {
@@ -143,6 +144,7 @@ let load = loader({
         providers,
         publisher,
         notify,
+        queue,
       },
       monitor: monitor.childMonitor('api'),
       schemaset,

--- a/services/worker-manager/src/providers/aws.js
+++ b/services/worker-manager/src/providers/aws.js
@@ -20,6 +20,7 @@ class AwsProvider extends Provider {
     notify,
     db,
     providerConfig,
+    queue,
   }) {
     super({
       providerId,
@@ -32,6 +33,7 @@ class AwsProvider extends Provider {
       notify,
       db,
       providerConfig,
+      queue,
     });
     this.configSchema = 'config-aws';
     this.ec2iid_RSA_key = fs.readFileSync(path.resolve(__dirname, 'aws-keys/RSA-key-forSignature')).toString();
@@ -417,8 +419,9 @@ class AwsProvider extends Provider {
           `Unexpected error: expected to shut down instance ${worker.workerId} but got ${ti.CurrentState.Name} state for ${ti.InstanceId} instance instead`,
         );
       }
-
     });
+
+    await this.quarantineWorker({ worker, reason });
   }
 
   async scanPrepare() {

--- a/services/worker-manager/src/providers/azure/index.js
+++ b/services/worker-manager/src/providers/azure/index.js
@@ -1326,6 +1326,8 @@ class AzureProvider extends Provider {
         worker.state = Worker.states.STOPPING;
       }
     });
+
+    await this.quarantineWorker({ worker, reason });
   }
 
   /*

--- a/services/worker-manager/src/providers/google.js
+++ b/services/worker-manager/src/providers/google.js
@@ -190,6 +190,8 @@ class GoogleProvider extends Provider {
       }
       throw err;
     }
+
+    await this.quarantineWorker({ worker, reason });
   }
 
   async provision({ workerPool, workerInfo }) {

--- a/services/worker-manager/src/providers/index.js
+++ b/services/worker-manager/src/providers/index.js
@@ -27,7 +27,7 @@ const setSetupRetryInterval = i => SETUP_RETRY_INTERVAL = i;
  * properly by never returning a failed provider.
  */
 class Providers {
-  async setup({ cfg, monitor, notify, db, estimator, Worker, WorkerPoolError, validator }) {
+  async setup({ cfg, monitor, notify, db, estimator, Worker, WorkerPoolError, validator, queue }) {
     this.monitor = monitor;
     this._providers = {};
 
@@ -56,6 +56,7 @@ class Providers {
         validator,
         providerConfig,
         providerType: providerConfig.providerType,
+        queue,
       });
       this._providers[providerId] = provider;
 

--- a/services/worker-manager/src/providers/static.js
+++ b/services/worker-manager/src/providers/static.js
@@ -67,6 +67,8 @@ class StaticProvider extends Provider {
     await worker.update(this.db, worker => {
       worker.state = Worker.states.STOPPED;
     });
+
+    await this.quarantineWorker({ worker, reason });
   }
 
   async registerWorker({ worker, workerPool, workerIdentityProof }) {

--- a/services/worker-manager/src/providers/testing.js
+++ b/services/worker-manager/src/providers/testing.js
@@ -87,7 +87,7 @@ class TestingProvider extends Provider {
     return worker;
   }
 
-  async removeWorker({ worker }) {
+  async removeWorker({ worker, reason }) {
     if (!worker.providerData.allowRemoveWorker) {
       throw new ApiError('removing workers is not supported for testing provider');
     }
@@ -97,6 +97,8 @@ class TestingProvider extends Provider {
 
       return worker;
     });
+
+    await this.quarantineWorker({ worker, reason });
   }
 }
 

--- a/services/worker-manager/test/api_test.js
+++ b/services/worker-manager/test/api_test.js
@@ -11,6 +11,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function (mock, skipping) {
   helper.withDb(mock, skipping);
   helper.withPulse(mock, skipping);
   helper.withProviders(mock, skipping);
+  helper.withFakeQueue(mock, skipping);
   helper.withServer(mock, skipping);
   helper.resetTables(mock, skipping);
 
@@ -840,6 +841,19 @@ helper.secrets.mockSuite(testing.suiteName(), [], function (mock, skipping) {
       await helper.workerManager.removeWorker(workerPoolId, workerGroup, workerId);
       const worker = await Worker.get(helper.db, { workerPoolId, workerGroup, workerId });
       assert.equal(worker.state, 'stopped');
+    });
+    test('remove a worker also quarantines it', async function () {
+      await createWorker({
+        providerData: { allowRemoveWorker: true },
+      });
+      await helper.workerManager.removeWorker(workerPoolId, workerGroup, workerId);
+      const lastQuarantine = helper.queue.quarantines[helper.queue.quarantines.length - 1];
+
+      assert.equal(lastQuarantine.provisionerId, workerPoolId.split('/')[0]);
+      assert.equal(lastQuarantine.workerType, workerPoolId.split('/')[1]);
+      assert.equal(lastQuarantine.workerGroup, workerGroup);
+      assert.equal(lastQuarantine.workerId, workerId);
+      assert.equal(lastQuarantine.payload.quarantineInfo, 'workerManager.removeWorker API call');
     });
   });
 

--- a/services/worker-manager/test/helper.js
+++ b/services/worker-manager/test/helper.js
@@ -187,6 +187,7 @@ exports.withServer = (mock, skipping) => {
  */
 const stubbedQueue = () => {
   const taskQueues = {};
+  const quarantines = [];
   const queue = new taskcluster.Queue({
     rootUrl: exports.rootUrl,
     credentials: {
@@ -207,9 +208,20 @@ const stubbedQueue = () => {
           workerType,
         };
       },
+      quarantineWorker: async (provisionerId, workerType, workerGroup, workerId, payload) => {
+        quarantines.push({ provisionerId, workerType, workerGroup, workerId, payload });
+        return {
+          provisionerId,
+          workerType,
+          workerGroup,
+          workerId,
+          payload,
+        };
+      },
     },
   });
 
+  queue.quarantines = quarantines;
   queue.setPending = function(taskQueueId, pending) {
     taskQueues[taskQueueId] = pending;
   };

--- a/services/worker-manager/test/provider_azure_test.js
+++ b/services/worker-manager/test/provider_azure_test.js
@@ -140,6 +140,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
         storageAccountName: 'storage123',
         _backoffDelay: 1,
       },
+      queue: helper.queue,
     });
 
     // So that checked-in certs are still valid
@@ -868,6 +869,11 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       await provider.deprovisionResources({ worker, monitor });
       await assertRemovalState({ ip: 'none', nic: 'none', disks: ['none', 'none'], vm: 'none' });
       assert.equal(worker.state, 'stopped');
+
+      debug('quarantineWorker was called');
+      const lastQuarantine = helper.queue.quarantines[helper.queue.quarantines.length - 1];
+      assert.equal(lastQuarantine.workerId, worker.workerId);
+      assert.equal(lastQuarantine.payload.quarantineInfo, 'test');
     });
 
     test('vm removal fails (keeps waiting)', async function() {

--- a/services/worker-manager/test/provider_static_test.js
+++ b/services/worker-manager/test/provider_static_test.js
@@ -47,6 +47,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       WorkerPool: helper.WorkerPool,
       WorkerPoolError: helper.WorkerPoolError,
       providerConfig: {},
+      queue: helper.queue,
     });
     workerPool = WorkerPool.fromApi({
       workerPoolId,
@@ -92,7 +93,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
     ]);
   });
 
-  test('removeWorker marks the worker as stopped', async function() {
+  test('removeWorker marks the worker as stopped and calls quarantineWorker', async function() {
     const worker = Worker.fromApi(defaultWorker);
     await worker.create(helper.db);
 
@@ -102,6 +103,10 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
     assert.deepEqual(rows.map(({ worker_id, state }) => ([worker_id, state])), [
       ['abc123', 'stopped'],
     ]);
+
+    const lastQuarantine = helper.queue.quarantines[helper.queue.quarantines.length - 1];
+    assert.equal(lastQuarantine.workerId, workerId);
+    assert.equal(lastQuarantine.payload.quarantineInfo, 'uhoh');
   });
 
   suite('registerWorker', function() {


### PR DESCRIPTION
This patch should theoretically lower the number of `claim-expired` exceptions when `queue` service serves tasks to the workers that were requested to be removed. 

Queue service already checks quarantine field to avoid giving tasks to such workers, so this approach doesn't make any changes to the queue itself, only uses existing functionality

It will not solve all race conditions, as `claimWork` is waiting for up to 20s on each call, so worker could be already making this call, when instance would be removed by worker-runner.

Fixes #6247
