### PR TITLE
Revert "Quarantine worker on removeWorker"

### DIFF
--- a/changelog/issue-6247.md
+++ b/changelog/issue-6247.md
@@ -1,0 +1,6 @@
+audience: admins
+level: minor
+reference: issue 6247
+---
+
+Revert worker-manager from quarantining workers on removal that was introduced in [PR 6267](https://github.com/taskcluster/taskcluster/pull/6267).

--- a/services/auth/src/static-scopes.json
+++ b/services/auth/src/static-scopes.json
@@ -93,7 +93,6 @@
       "notify:email:*",
       "queue:claim-work:*",
       "queue:pending-count:*",
-      "queue:quarantine-worker:*",
       "queue:worker-id:*",
       "secrets:get:worker-pool:*",
       "secrets:get:worker-type:*",

--- a/services/worker-manager/scopes.yml
+++ b/services/worker-manager/scopes.yml
@@ -8,6 +8,5 @@
 - queue:claim-work:*
 - queue:worker-id:*
 - queue:pending-count:*
-- queue:quarantine-worker:*
 - worker-manager:remove-worker:*
 - worker-manager:reregister-worker:*

--- a/services/worker-manager/src/api.js
+++ b/services/worker-manager/src/api.js
@@ -33,7 +33,6 @@ let builder = new APIBuilder({
     'publisher',
     'monitor',
     'notify',
-    'queue',
   ],
 });
 

--- a/services/worker-manager/src/main.js
+++ b/services/worker-manager/src/main.js
@@ -125,7 +125,7 @@ let load = loader({
   api: {
     requires: [
       'cfg', 'db', 'schemaset', 'monitor', 'providers',
-      'publisher', 'notify', 'queue'],
+      'publisher', 'notify'],
     setup: async ({
       cfg,
       db,
@@ -134,7 +134,6 @@ let load = loader({
       providers,
       publisher,
       notify,
-      queue,
     }) => builder.build({
       rootUrl: cfg.taskcluster.rootUrl,
       context: {
@@ -144,7 +143,6 @@ let load = loader({
         providers,
         publisher,
         notify,
-        queue,
       },
       monitor: monitor.childMonitor('api'),
       schemaset,
@@ -178,10 +176,10 @@ let load = loader({
   },
 
   providers: {
-    requires: ['cfg', 'monitor', 'notify', 'db', 'estimator', 'schemaset', 'queue'],
-    setup: async ({ cfg, monitor, notify, db, estimator, schemaset, queue }) =>
+    requires: ['cfg', 'monitor', 'notify', 'db', 'estimator', 'schemaset'],
+    setup: async ({ cfg, monitor, notify, db, estimator, schemaset }) =>
       new Providers().setup({
-        cfg, monitor, notify, db, estimator, queue,
+        cfg, monitor, notify, db, estimator,
         validator: await schemaset.validator(cfg.taskcluster.rootUrl),
       }),
   },

--- a/services/worker-manager/src/providers/aws.js
+++ b/services/worker-manager/src/providers/aws.js
@@ -20,7 +20,6 @@ class AwsProvider extends Provider {
     notify,
     db,
     providerConfig,
-    queue,
   }) {
     super({
       providerId,
@@ -33,7 +32,6 @@ class AwsProvider extends Provider {
       notify,
       db,
       providerConfig,
-      queue,
     });
     this.configSchema = 'config-aws';
     this.ec2iid_RSA_key = fs.readFileSync(path.resolve(__dirname, 'aws-keys/RSA-key-forSignature')).toString();
@@ -419,9 +417,8 @@ class AwsProvider extends Provider {
           `Unexpected error: expected to shut down instance ${worker.workerId} but got ${ti.CurrentState.Name} state for ${ti.InstanceId} instance instead`,
         );
       }
-    });
 
-    await this.quarantineWorker({ worker, reason });
+    });
   }
 
   async scanPrepare() {

--- a/services/worker-manager/src/providers/azure/index.js
+++ b/services/worker-manager/src/providers/azure/index.js
@@ -1326,8 +1326,6 @@ class AzureProvider extends Provider {
         worker.state = Worker.states.STOPPING;
       }
     });
-
-    await this.quarantineWorker({ worker, reason });
   }
 
   /*

--- a/services/worker-manager/src/providers/google.js
+++ b/services/worker-manager/src/providers/google.js
@@ -190,8 +190,6 @@ class GoogleProvider extends Provider {
       }
       throw err;
     }
-
-    await this.quarantineWorker({ worker, reason });
   }
 
   async provision({ workerPool, workerInfo }) {

--- a/services/worker-manager/src/providers/index.js
+++ b/services/worker-manager/src/providers/index.js
@@ -27,7 +27,7 @@ const setSetupRetryInterval = i => SETUP_RETRY_INTERVAL = i;
  * properly by never returning a failed provider.
  */
 class Providers {
-  async setup({ cfg, monitor, notify, db, estimator, Worker, WorkerPoolError, validator, queue }) {
+  async setup({ cfg, monitor, notify, db, estimator, Worker, WorkerPoolError, validator }) {
     this.monitor = monitor;
     this._providers = {};
 
@@ -56,7 +56,6 @@ class Providers {
         validator,
         providerConfig,
         providerType: providerConfig.providerType,
-        queue,
       });
       this._providers[providerId] = provider;
 

--- a/services/worker-manager/src/providers/provider.js
+++ b/services/worker-manager/src/providers/provider.js
@@ -3,8 +3,6 @@ const libUrls = require('taskcluster-lib-urls');
 const slugid = require('slugid');
 const yaml = require('js-yaml');
 const { Worker, WorkerPoolError } = require('../data.js');
-const { splitWorkerPoolId } = require('../util.js');
-const taskcluster = require('taskcluster-client');
 
 /**
  * The parent class for all providers.
@@ -22,7 +20,6 @@ class Provider {
     validator,
     providerConfig,
     providerType,
-    queue,
   }) {
     this.providerId = providerId;
     this.monitor = monitor;
@@ -34,7 +31,6 @@ class Provider {
     this.Worker = Worker;
     this.WorkerPoolError = WorkerPoolError;
     this.providerType = providerType;
-    this.queue = queue;
   }
 
   async setup() {
@@ -86,20 +82,6 @@ class Provider {
 
   async removeWorker({ worker, reason }) {
     throw new ApiError('not supported for this provider');
-  }
-
-  async quarantineWorker({ worker, reason = 'worker-manager: worker removed' }) {
-    const { provisionerId, workerType } = splitWorkerPoolId(worker.workerPoolId);
-    await this.queue.quarantineWorker(
-      provisionerId,
-      workerType,
-      worker.workerGroup,
-      worker.workerId,
-      {
-        quarantineUntil: taskcluster.fromNow('1 day'),
-        quarantineInfo: reason,
-      },
-    );
   }
 
   /**

--- a/services/worker-manager/src/providers/static.js
+++ b/services/worker-manager/src/providers/static.js
@@ -67,8 +67,6 @@ class StaticProvider extends Provider {
     await worker.update(this.db, worker => {
       worker.state = Worker.states.STOPPED;
     });
-
-    await this.quarantineWorker({ worker, reason });
   }
 
   async registerWorker({ worker, workerPool, workerIdentityProof }) {

--- a/services/worker-manager/src/providers/testing.js
+++ b/services/worker-manager/src/providers/testing.js
@@ -87,7 +87,7 @@ class TestingProvider extends Provider {
     return worker;
   }
 
-  async removeWorker({ worker, reason }) {
+  async removeWorker({ worker }) {
     if (!worker.providerData.allowRemoveWorker) {
       throw new ApiError('removing workers is not supported for testing provider');
     }
@@ -97,8 +97,6 @@ class TestingProvider extends Provider {
 
       return worker;
     });
-
-    await this.quarantineWorker({ worker, reason });
   }
 }
 

--- a/services/worker-manager/test/api_test.js
+++ b/services/worker-manager/test/api_test.js
@@ -11,7 +11,6 @@ helper.secrets.mockSuite(testing.suiteName(), [], function (mock, skipping) {
   helper.withDb(mock, skipping);
   helper.withPulse(mock, skipping);
   helper.withProviders(mock, skipping);
-  helper.withFakeQueue(mock, skipping);
   helper.withServer(mock, skipping);
   helper.resetTables(mock, skipping);
 
@@ -841,19 +840,6 @@ helper.secrets.mockSuite(testing.suiteName(), [], function (mock, skipping) {
       await helper.workerManager.removeWorker(workerPoolId, workerGroup, workerId);
       const worker = await Worker.get(helper.db, { workerPoolId, workerGroup, workerId });
       assert.equal(worker.state, 'stopped');
-    });
-    test('remove a worker also quarantines it', async function () {
-      await createWorker({
-        providerData: { allowRemoveWorker: true },
-      });
-      await helper.workerManager.removeWorker(workerPoolId, workerGroup, workerId);
-      const lastQuarantine = helper.queue.quarantines[helper.queue.quarantines.length - 1];
-
-      assert.equal(lastQuarantine.provisionerId, workerPoolId.split('/')[0]);
-      assert.equal(lastQuarantine.workerType, workerPoolId.split('/')[1]);
-      assert.equal(lastQuarantine.workerGroup, workerGroup);
-      assert.equal(lastQuarantine.workerId, workerId);
-      assert.equal(lastQuarantine.payload.quarantineInfo, 'workerManager.removeWorker API call');
     });
   });
 

--- a/services/worker-manager/test/helper.js
+++ b/services/worker-manager/test/helper.js
@@ -187,7 +187,6 @@ exports.withServer = (mock, skipping) => {
  */
 const stubbedQueue = () => {
   const taskQueues = {};
-  const quarantines = [];
   const queue = new taskcluster.Queue({
     rootUrl: exports.rootUrl,
     credentials: {
@@ -208,20 +207,9 @@ const stubbedQueue = () => {
           workerType,
         };
       },
-      quarantineWorker: async (provisionerId, workerType, workerGroup, workerId, payload) => {
-        quarantines.push({ provisionerId, workerType, workerGroup, workerId, payload });
-        return {
-          provisionerId,
-          workerType,
-          workerGroup,
-          workerId,
-          payload,
-        };
-      },
     },
   });
 
-  queue.quarantines = quarantines;
   queue.setPending = function(taskQueueId, pending) {
     taskQueues[taskQueueId] = pending;
   };

--- a/services/worker-manager/test/provider_aws_test.js
+++ b/services/worker-manager/test/provider_aws_test.js
@@ -74,7 +74,6 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
           secretAccessKey: 'topsecret',
         },
       },
-      queue: helper.queue,
     });
 
     await helper.db.fns.delete_worker_pool(workerPoolId);
@@ -442,7 +441,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       await worker.create(helper.db);
 
       provider.seen = {};
-      await provider.checkWorker({ worker });
+      await provider.checkWorker({ worker: worker });
 
       const workers = await helper.getWorkers();
       assert.notStrictEqual(workers.length, 0);
@@ -461,7 +460,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       await worker.create(helper.db);
 
       provider.seen = {};
-      await provider.checkWorker({ worker });
+      await provider.checkWorker({ worker: worker });
 
       const workers = await helper.getWorkers();
       assert.notStrictEqual(workers.length, 0);
@@ -480,7 +479,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       await worker.create(helper.db);
 
       provider.seen = {};
-      await assert.rejects(provider.checkWorker({ worker }));
+      await assert.rejects(provider.checkWorker({ worker: worker }));
       assert.strictEqual(provider.seen[worker.workerPoolId], 0);
     });
 
@@ -494,7 +493,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       await worker.create(helper.db);
 
       provider.seen = {};
-      await provider.checkWorker({ worker });
+      await provider.checkWorker({ worker: worker });
 
       const workers = await helper.getWorkers();
       assert.notStrictEqual(workers.length, 0);
@@ -516,7 +515,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       });
       await worker.create(helper.db);
       provider.seen = {};
-      await provider.checkWorker({ worker });
+      await provider.checkWorker({ worker: worker });
       assert.deepEqual(fake.rgn('us-west-2').terminatedInstances, ['i-123']);
     });
 
@@ -533,7 +532,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       });
       await worker.create(helper.db);
       provider.seen = {};
-      await provider.checkWorker({ worker });
+      await provider.checkWorker({ worker: worker });
       assert.deepEqual(fake.rgn('us-west-2').terminatedInstances, []);
     });
 
@@ -554,7 +553,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
         this.providerData.terminateAfter = Date.now() + 1000;
       };
 
-      await provider.checkWorker({ worker });
+      await provider.checkWorker({ worker: worker });
       assert.deepEqual(fake.rgn('us-west-2').terminatedInstances, []);
     });
 
@@ -571,7 +570,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       });
       await worker.create(helper.db);
       provider.seen = {};
-      await provider.checkWorker({ worker });
+      await provider.checkWorker({ worker: worker });
       assert.deepEqual(fake.rgn('us-west-2').terminatedInstances, ['i-123']);
     });
 
@@ -588,7 +587,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       });
       await worker.create(helper.db);
       provider.seen = {};
-      await provider.checkWorker({ worker });
+      await provider.checkWorker({ worker: worker });
       assert.deepEqual(fake.rgn('us-west-2').terminatedInstances, []);
     });
   });
@@ -602,25 +601,8 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
           ...defaultWorker.providerData,
           region: 'us-west-2',
         },
-        workerId: 'i-123',
       };
-      await assert.doesNotReject(provider.removeWorker({ worker, reason: 'removed' }));
-    });
-
-    test('calls quarantineWorker', async function() {
-      const worker = {
-        ...defaultWorker,
-        providerData: {
-          ...defaultWorker.providerData,
-          region: 'us-west-2',
-        },
-        workerId: 'i-123',
-      };
-      await provider.removeWorker({ worker, reason: 'removed' });
-
-      const lastQuarantine = helper.queue.quarantines[helper.queue.quarantines.length - 1];
-      assert.equal(lastQuarantine.workerId, 'i-123');
-      assert.equal(lastQuarantine.payload.quarantineInfo, 'removed');
+      await assert.doesNotReject(provider.removeWorker({ worker }));
     });
 
   });

--- a/services/worker-manager/test/provider_azure_test.js
+++ b/services/worker-manager/test/provider_azure_test.js
@@ -140,7 +140,6 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
         storageAccountName: 'storage123',
         _backoffDelay: 1,
       },
-      queue: helper.queue,
     });
 
     // So that checked-in certs are still valid
@@ -869,11 +868,6 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       await provider.deprovisionResources({ worker, monitor });
       await assertRemovalState({ ip: 'none', nic: 'none', disks: ['none', 'none'], vm: 'none' });
       assert.equal(worker.state, 'stopped');
-
-      debug('quarantineWorker was called');
-      const lastQuarantine = helper.queue.quarantines[helper.queue.quarantines.length - 1];
-      assert.equal(lastQuarantine.workerId, worker.workerId);
-      assert.equal(lastQuarantine.payload.quarantineInfo, 'test');
     });
 
     test('vm removal fails (keeps waiting)', async function() {

--- a/services/worker-manager/test/provider_google_test.js
+++ b/services/worker-manager/test/provider_google_test.js
@@ -11,7 +11,6 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
   helper.withPulse(mock, skipping);
   helper.withFakeQueue(mock, skipping);
   helper.withFakeNotify(mock, skipping);
-  helper.withFakeQueue(mock, skipping);
   helper.resetTables(mock, skipping);
 
   let provider;
@@ -38,7 +37,6 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
         workerServiceAccountId: '12345',
         _backoffDelay: 1,
       },
-      queue: helper.queue,
     });
 
     await helper.db.fns.delete_worker_pool(workerPoolId);
@@ -378,36 +376,8 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       state: 'requested',
       providerData: { zone: 'us-east1-a' },
     });
-    await provider.removeWorker({ worker, reason: 'meh' });
+    await provider.removeWorker({ worker });
     assert(fake.compute.instances.delete_called);
-
-    assert.equal(helper.queue.quarantines.length, 0); // instance not found, so no call
-  });
-
-  test('removeWorker quarantines it', async function() {
-    const workerId = '12345';
-    const worker = await makeWorker({
-      workerPoolId,
-      workerGroup: 'us-east1',
-      workerId,
-      providerId,
-      created: taskcluster.fromNow('0 seconds'),
-      lastModified: taskcluster.fromNow('0 seconds'),
-      lastChecked: taskcluster.fromNow('0 seconds'),
-      expires: taskcluster.fromNow('90 seconds'),
-      capacity: 1,
-      state: 'requested',
-      providerData: { zone: 'us-east1-a' },
-    });
-    fake.compute.instances.setFakeInstanceStatus(
-      project, 'us-east1-a', workerId,
-      'RUNNING');
-    await provider.removeWorker({ worker, reason: 'meh' });
-    assert(fake.compute.instances.delete_called);
-
-    const lastQuarantine = helper.queue.quarantines[helper.queue.quarantines.length - 1];
-    assert.equal(lastQuarantine.workerId, workerId);
-    assert.equal(lastQuarantine.payload.quarantineInfo, 'meh');
   });
 
   suite('checkWorker', function() {

--- a/services/worker-manager/test/provider_static_test.js
+++ b/services/worker-manager/test/provider_static_test.js
@@ -47,7 +47,6 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       WorkerPool: helper.WorkerPool,
       WorkerPoolError: helper.WorkerPoolError,
       providerConfig: {},
-      queue: helper.queue,
     });
     workerPool = WorkerPool.fromApi({
       workerPoolId,
@@ -93,7 +92,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
     ]);
   });
 
-  test('removeWorker marks the worker as stopped and calls quarantineWorker', async function() {
+  test('removeWorker marks the worker as stopped', async function() {
     const worker = Worker.fromApi(defaultWorker);
     await worker.create(helper.db);
 
@@ -103,10 +102,6 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
     assert.deepEqual(rows.map(({ worker_id, state }) => ([worker_id, state])), [
       ['abc123', 'stopped'],
     ]);
-
-    const lastQuarantine = helper.queue.quarantines[helper.queue.quarantines.length - 1];
-    assert.equal(lastQuarantine.workerId, workerId);
-    assert.equal(lastQuarantine.payload.quarantineInfo, 'uhoh');
   });
 
   suite('registerWorker', function() {


### PR DESCRIPTION
Reverts taskcluster/taskcluster#6267


it is a temporary (experimental) fix in attempt to reduce `claim-expired` exceptions. 
It was released with `51.1.0`.
If it doesn't give us the desire effect and amount of `claim-expired` wouldn't go down, we should revert this pull request https://github.com/taskcluster/taskcluster/pull/6267 


Upd:
Evidence suggests that there was no significant impact on the `claim-expired` exceptions number, so no need to keep that longer in codebase