### PR TITLE
feat(github): Fix ans2txt parsing of sequence codes

### DIFF
--- a/changelog/issue-5807.md
+++ b/changelog/issue-5807.md
@@ -1,0 +1,6 @@
+audience: users
+level: patch
+reference: issue 5807
+---
+
+Fixes escape sequence parsing in logs that are attached to github check runs.

--- a/services/github/src/utils.js
+++ b/services/github/src/utils.js
@@ -95,7 +95,7 @@ const shouldSkipPullRequest = ({ pull_request }) => {
  */
 const ansi2txt = (src) => {
   // eslint-disable-next-line no-control-regex
-  const regex = /\x1B\[([0-9]{1,3}(;[0-9]{1,2})?)?[mGK]/gm;
+  const regex = /\x1B(\[[0-9;]*[JKGmsu]|\(B)/gm;
   return src.replace(regex, '');
 };
 

--- a/services/github/test/utils_test.js
+++ b/services/github/test/utils_test.js
@@ -173,10 +173,14 @@ suite(testing.suiteName(), function() {
       const src = [
         '[0m[7m[1m[32m PASS [39m[22m[27m[0m [2msrc/utils/[22m[1misDateWithin.test.js[22m',
         '[2K[1G[2m$ webpack --mode production[22m',
+        'test factory::test::file_reader_twice ... [31mFAILED(B[m',
+        '[0m[0m[1m[31merror[0m[1m:[0m test failed, to rerun pass `-p taskcluster-upload --lib`',
       ];
       const expected = [
         ' PASS  src/utils/isDateWithin.test.js',
         '$ webpack --mode production',
+        'test factory::test::file_reader_twice ... FAILED',
+        'error: test failed, to rerun pass `-p taskcluster-upload --lib`',
       ];
       assert.equal(expected.join('\n'), ansi2txt(src.join('\n')));
     });


### PR DESCRIPTION
Some sequences (sgr0) where not parsed and appeared raw in github logs that we attach to check runs. Later that output was being likely incorrectly hashed which causes checksum mismatches for the github events.

this possibly fixes #5807 
