### PR TITLE
Issue 5006 - add troubleshooting information

### DIFF
--- a/changelog/issue-5006.md
+++ b/changelog/issue-5006.md
@@ -1,0 +1,5 @@
+audience: worker-deployers
+level: patch
+reference: issue 5006
+---
+Generic Worker on macOS now dumps the output of the `last` command when it is not able to determine the logged in console user. This doesn't solve issue 5006 but it may provide additional troubleshooting information.

--- a/workers/generic-worker/runtime/runtime_darwin.go
+++ b/workers/generic-worker/runtime/runtime_darwin.go
@@ -98,6 +98,12 @@ func WaitForLoginCompletion(timeout time.Duration) error {
 		return nil
 	}
 	log.Print("Timed out waiting for user login")
+	output, err := host.CombinedOutput("/usr/bin/last")
+	if err != nil {
+		log.Printf("Not able to execute /usr/bin/last due to %v", err)
+	} else {
+		log.Print(output)
+	}
 	return errors.New("No user logged in with console session")
 }
 


### PR DESCRIPTION
If Generic Worker under macOS (multiuser engine) can't determine logged in console user, dump output of `last` command to worker logs.

This adds troubleshooting information for Issue #5006 but does not contain a fix for it.