### PR TITLE
gw-codegen: rename taskPayloadSchema -> JSONSchema

### DIFF
--- a/changelog/Dfv-PelkQBKeV3RzGheTcw.md
+++ b/changelog/Dfv-PelkQBKeV3RzGheTcw.md
@@ -1,0 +1,3 @@
+audience: developers
+level: silent
+---

--- a/workers/generic-worker/generated_multiuser_darwin.go
+++ b/workers/generic-worker/generated_multiuser_darwin.go
@@ -472,7 +472,7 @@ type (
 //
 // Run `generic-worker show-payload-schema` to output this schema to standard
 // out.
-func taskPayloadSchema() string {
+func JSONSchema() string {
 	return `{
   "$id": "/schemas/generic-worker/multiuser_posix.json#",
   "$schema": "/schemas/common/metaschema.json#",

--- a/workers/generic-worker/generated_multiuser_freebsd.go
+++ b/workers/generic-worker/generated_multiuser_freebsd.go
@@ -472,7 +472,7 @@ type (
 //
 // Run `generic-worker show-payload-schema` to output this schema to standard
 // out.
-func taskPayloadSchema() string {
+func JSONSchema() string {
 	return `{
   "$id": "/schemas/generic-worker/multiuser_posix.json#",
   "$schema": "/schemas/common/metaschema.json#",

--- a/workers/generic-worker/generated_multiuser_linux.go
+++ b/workers/generic-worker/generated_multiuser_linux.go
@@ -472,7 +472,7 @@ type (
 //
 // Run `generic-worker show-payload-schema` to output this schema to standard
 // out.
-func taskPayloadSchema() string {
+func JSONSchema() string {
 	return `{
   "$id": "/schemas/generic-worker/multiuser_posix.json#",
   "$schema": "/schemas/common/metaschema.json#",

--- a/workers/generic-worker/generated_multiuser_windows.go
+++ b/workers/generic-worker/generated_multiuser_windows.go
@@ -505,7 +505,7 @@ type (
 //
 // Run `generic-worker show-payload-schema` to output this schema to standard
 // out.
-func taskPayloadSchema() string {
+func JSONSchema() string {
 	return `{
   "$id": "/schemas/generic-worker/multiuser_windows.json#",
   "$schema": "/schemas/common/metaschema.json#",

--- a/workers/generic-worker/generated_simple_darwin.go
+++ b/workers/generic-worker/generated_simple_darwin.go
@@ -452,7 +452,7 @@ type (
 //
 // Run `generic-worker show-payload-schema` to output this schema to standard
 // out.
-func taskPayloadSchema() string {
+func JSONSchema() string {
 	return `{
   "$id": "/schemas/generic-worker/simple_posix.json#",
   "$schema": "/schemas/common/metaschema.json#",

--- a/workers/generic-worker/generated_simple_freebsd.go
+++ b/workers/generic-worker/generated_simple_freebsd.go
@@ -452,7 +452,7 @@ type (
 //
 // Run `generic-worker show-payload-schema` to output this schema to standard
 // out.
-func taskPayloadSchema() string {
+func JSONSchema() string {
 	return `{
   "$id": "/schemas/generic-worker/simple_posix.json#",
   "$schema": "/schemas/common/metaschema.json#",

--- a/workers/generic-worker/generated_simple_linux.go
+++ b/workers/generic-worker/generated_simple_linux.go
@@ -452,7 +452,7 @@ type (
 //
 // Run `generic-worker show-payload-schema` to output this schema to standard
 // out.
-func taskPayloadSchema() string {
+func JSONSchema() string {
 	return `{
   "$id": "/schemas/generic-worker/simple_posix.json#",
   "$schema": "/schemas/common/metaschema.json#",

--- a/workers/generic-worker/gw-codegen/main.go
+++ b/workers/generic-worker/gw-codegen/main.go
@@ -112,7 +112,7 @@ func generateFunctions(ymlFile string) []byte {
 //
 // Run ` + "`generic-worker show-payload-schema`" + ` to output this schema to standard
 // out.
-func taskPayloadSchema() string {
+func JSONSchema() string {
     return ` + escapedJSON + `
 }`
 	return []byte(response)

--- a/workers/generic-worker/main.go
+++ b/workers/generic-worker/main.go
@@ -113,7 +113,7 @@ func main() {
 
 	switch {
 	case arguments["show-payload-schema"]:
-		fmt.Println(taskPayloadSchema())
+		fmt.Println(JSONSchema())
 
 	case arguments["run"]:
 		withWorkerRunner := arguments["--with-worker-runner"].(bool)
@@ -583,14 +583,14 @@ func ClaimWork() *TaskRun {
 
 func (task *TaskRun) validatePayload() *CommandExecutionError {
 	jsonPayload := task.Definition.Payload
-	schemaLoader := gojsonschema.NewStringLoader(taskPayloadSchema())
+	schemaLoader := gojsonschema.NewStringLoader(JSONSchema())
 	docLoader := gojsonschema.NewStringLoader(string(jsonPayload))
 	result, err := gojsonschema.Validate(schemaLoader, docLoader)
 	if err != nil {
 		return MalformedPayloadError(err)
 	}
 	if !result.Valid() {
-		task.Errorf("Task payload for this worker type must conform to the following jsonschema:\n%s", taskPayloadSchema())
+		task.Errorf("Task payload for this worker type must conform to the following jsonschema:\n%s", JSONSchema())
 		task.Error("TASK FAIL since the task payload is invalid. See errors:")
 		for _, desc := range result.Errors() {
 			task.Errorf("- %s", desc)

--- a/workers/generic-worker/payload_test.go
+++ b/workers/generic-worker/payload_test.go
@@ -48,7 +48,7 @@ func ensureMalformedPayload(t *testing.T, task *TaskRun) {
 
 // Test that the burned in payload schema is a valid json schema
 func TestPayloadSchemaValid(t *testing.T) {
-	payloadSchema := taskPayloadSchema()
+	payloadSchema := JSONSchema()
 	schemaLoader := gojsonschema.NewStringLoader(payloadSchema)
 	_, err := gojsonschema.NewSchema(schemaLoader)
 	if err != nil {


### PR DESCRIPTION
The rename is for three reasons:

1) In general it is useful when generating go types via jsonschema2go, to also generate a method which contains the jsonschema which was used to generate the methods, since any code that uses the generated code will invariably want to unmarshal data into the generated go types from a JSON data source that conforms to the schema it used to generate the go types. However, it will typically want to validate that the input data conforms to the schema, before it unmarshals it into the generated go types. Therefore this is a generally useful feature for any user of jsonschema2go.
2) Now the function name is capitalised, thus exported, which means that the generated code can live in a different package to the code that calls it. It also means it will appear in the go docs of the generated code, which is also useful.
3) The code is not influenced by the fact that the schema happened to be a task payload schema, so the name JSONSchema rather than taskPayloadSchema is better, since it can be used now for any code-generation-from-json-schemas. It just so happened that in Generic Worker it was run against a task payload, but it could be run against a JSON schema for something completely different.

Note, the tool is currently called gw-codegen since it was intended to be specific to Generic Worker at the time it was created, but we may wish to rename it at some point, since it is essentially an extension of jsonschema2go for the common case of library users wanting to be able to validate json inputs for the schema they generated code from.

Note, at the time we rename it from being gw-codegen, we should probably adapt the generated comments for the JSONSchema function to be something more generic too! Currently the generated comments refer to generic-worker, which is fine for now, as we are only using it internally.