### PR TITLE
Don't run generic-worker decision task and worker runner tests as root user

### DIFF
--- a/changelog/SH9GLDhmS86nZh2mY3JzTw.md
+++ b/changelog/SH9GLDhmS86nZh2mY3JzTw.md
@@ -1,0 +1,3 @@
+audience: general
+level: silent
+---

--- a/taskcluster/ci/config.yml
+++ b/taskcluster/ci/config.yml
@@ -26,13 +26,13 @@ workers:
       os: linux
       implementation: generic-worker
       worker-type: release
-    gw-ci-ubuntu-22-04:
+    gw-ubuntu-22-04:
       provisioner: proj-taskcluster
       os: linux
       implementation: generic-worker
-      worker-type: gw-ci-ubuntu-22-04
-    gw-ci-windows-2022:
+      worker-type: gw-ubuntu-22-04
+    gw-windows-2022:
       provisioner: proj-taskcluster
       os: windows
       implementation: generic-worker
-      worker-type: gw-ci-windows-2022
+      worker-type: gw-windows-2022

--- a/taskcluster/ci/generic-worker/kind.yml
+++ b/taskcluster/ci/generic-worker/kind.yml
@@ -16,7 +16,7 @@ task-defaults:
 tasks:
   windows-worker-runner:
     description: 'test worker-runner under windows as well'
-    worker-type: gw-ci-windows-2022
+    worker-type: gw-windows-2022
     worker:
       mounts:
         - content:
@@ -45,12 +45,12 @@ tasks:
         - go test -v ./...
   decision-task:
     description: 'decision task for generic-worker tasks'
-    worker-type: gw-ci-ubuntu-22-04
+    worker-type: gw-ubuntu-22-04
     scopes:
       - generic-worker:cache:generic-worker-checkout
       - secrets:get:project/taskcluster/testing/generic-worker/ci-creds
       - queue:scheduler-id:taskcluster-level-1
-      - queue:create-task:highest:proj-taskcluster/gw-ci-*
+      - queue:create-task:highest:proj-taskcluster/*
       - queue:route:checks
     worker:
       taskcluster-proxy: true


### PR DESCRIPTION
We have two distinct types of worker pools in proj-taskcluster:

* proj-taskcluster/gw-ci-\<platform\> (privileged - tasks run as root/LocalSystem)
* proj-taskcluster/gw-\<platform\> (regular - tasks run as regular task users)

The first type is intended for generic-worker CI, which when testing generic worker, needs to be able to create OS users on-the-fly.

The second type is for regular tasks that don't require the additional privileges. The generic-worker decision task and worker runner tests don't require these privileges, so in this PR I am moving them to the regular (less privileged) worker pools.
