### PR TITLE
Fix: fail task if decision task fails

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -166,7 +166,7 @@ tasks:
                   # exist in tree so we must hard code the hash of the mozillareleases/taskgraph-decision docker image
                   command:
                       - - bash
-                        - "-cx"
+                        - "-cxe"
                         - |-
                           podman run --name taskcontainer --add-host=taskcluster:127.0.0.1 --net=host \
                               -e "REPOSITORIES={\"taskcluster\":\"taskcluster\"}" \
@@ -189,7 +189,7 @@ tasks:
                                   --taskcluster-checkout=/builds/worker/checkouts/src \
                                   --task-cwd=/builds/worker/checkouts/src \
                                   -- \
-                                  bash -cx '
+                                  bash -cxe '
                                       ln -s /builds/worker/artifacts artifacts
                                       ~/.local/bin/taskgraph decision \
                                           --pushlog-id='\''0'\'' \

--- a/changelog/eKrFAszJQ0aX0oR4-P7QvA.md
+++ b/changelog/eKrFAszJQ0aX0oR4-P7QvA.md
@@ -1,0 +1,3 @@
+audience: general
+level: silent
+---


### PR DESCRIPTION
I happened to notice that a decision task was resolved as successful, even though it failed (unfortunately I've lost the reference to the task/github check) and it was because the exit code was from the `rm artifacts/actions.json` command rather than the `~/.local/bin/taskgraph decision` command.

The fix is to make sure `bash` runs with the `-e` option.