### PR TITLE
Fix an intermittent test failure in client-rust

### DIFF
--- a/changelog/issue-6280.md
+++ b/changelog/issue-6280.md
@@ -1,0 +1,4 @@
+audience: general
+level: silent
+reference: issue 6280
+---

--- a/clients/client-rust/upload/src/factory.rs
+++ b/clients/client-rust/upload/src/factory.rs
@@ -81,7 +81,12 @@ mod test {
     #[tokio::test]
     async fn file_reader_twice() -> Result<()> {
         let mut file: File = tempfile()?.into();
+
         file.write_all(DATA).await?;
+        // This file will be cloned before it is read by the factory, so flush
+        // any buffered data before doing so. Tokio internally buffers the write
+        // and completes it in another thread.
+        file.flush().await?;
 
         let mut factory = FileReaderFactory::new(file);
         assert_eq!(&copy_from_factory(&mut factory).await?, DATA);


### PR DESCRIPTION
This is due to a tokio bug where `try_clone` does not wait for pending operations to finish.

I wasn't able to reproduce after making this fix.

Github Bug/Issue: Fixes #6280 
