### PR TITLE
feat(release): build and publish the generic worker simple engine binary

### DIFF
--- a/changelog/Ts4yf7zsS7Wjjo0rwDJViw.md
+++ b/changelog/Ts4yf7zsS7Wjjo0rwDJViw.md
@@ -1,0 +1,6 @@
+audience: general
+level: minor
+---
+This essentially reverts the change in [#6279](https://github.com/taskcluster/taskcluster/pull/6279).
+
+We learned from RelOps that the simple engine is useful for running generic worker inside a VM and inside of docker containers.

--- a/infrastructure/tooling/src/build/tasks/generic-worker.js
+++ b/infrastructure/tooling/src/build/tasks/generic-worker.js
@@ -20,7 +20,7 @@ module.exports = ({ tasks, cmdOptions, credentials, baseDir, logsDir }) => {
         utils,
       });
 
-      const artifacts = glob.sync('generic-worker-multiuser-*', { cwd: artifactsDir });
+      const artifacts = glob.sync('generic-worker-*', { cwd: artifactsDir });
 
       return {
         'generic-worker-artifacts': artifacts,


### PR DESCRIPTION
>This essentially reverts the change in [#6279](https://github.com/taskcluster/taskcluster/pull/6279).
>
>We learned from RelOps that the simple engine is useful for running generic worker inside a VM and inside of docker containers.

@aerickson thanks for bringing this to our attention 👍🏻