### PR TITLE
fix(changelog): correctly filter for dependabot/renovate updates

### DIFF
--- a/changelog/L3z8Vpo3TxyOP00mQ1oRvg.md
+++ b/changelog/L3z8Vpo3TxyOP00mQ1oRvg.md
@@ -1,0 +1,3 @@
+audience: general
+level: silent
+---

--- a/infrastructure/tooling/src/changelog/index.js
+++ b/infrastructure/tooling/src/changelog/index.js
@@ -49,7 +49,7 @@ const strcmp = (a, b) => {
  * Representation of the as-yet-unreleased changelog snippets
  *
  * options: {
- *   skipUpdates: if true, don't load renovate updates
+ *   skipUpdates: if true, don't load dependabot/renovate updates
  * }
  */
 class ChangeLog {
@@ -119,7 +119,7 @@ class ChangeLog {
     const lastVersion = await this.lastVersion();
     this.updates = await gitLog({
       dir: REPO_ROOT,
-      args: [`v${lastVersion}..HEAD`, "--author=bot@renovateapp.com", "--pretty=%s (%h)"],
+      args: [`v${lastVersion}..HEAD`, "--author='\(dependabot\|renovate\)\[bot\]'", "--pretty=%s (%h)"],
     });
   }
 
@@ -207,7 +207,7 @@ class ChangeLog {
         '### Automated Package Updates',
         '',
         '<details>',
-        `<summary>${this.updates.length} Renovate updates</summary>`,
+        `<summary>${this.updates.length} Dependabot/Renovate updates</summary>`,
         '', // without this newline, the list will not render correctly
       ]
         .concat(this.updates.map(u => `* ${u}`))


### PR DESCRIPTION
Example changelog of this last working https://github.com/taskcluster/taskcluster/blob/main/CHANGELOG.md#automated-package-updates