### PR TITLE
fix(generic-worker): set defaults before validating payload

### DIFF
--- a/changelog/issue-6237.md
+++ b/changelog/issue-6237.md
@@ -1,0 +1,5 @@
+audience: general
+level: patch
+reference: issue 6237
+---
+Fix the case where a generic worker won't upload its log on a malformed payload error. This has been broken since v48.2.0 from PR [#6107](https://github.com/taskcluster/taskcluster/pull/6107).

--- a/workers/generic-worker/main.go
+++ b/workers/generic-worker/main.go
@@ -584,6 +584,11 @@ func ClaimWork() *TaskRun {
 
 func (task *TaskRun) validatePayload() *CommandExecutionError {
 	jsonPayload := task.Definition.Payload
+	defaults.SetDefaults(&task.Payload)
+	err := json.Unmarshal(jsonPayload, &task.Payload)
+	if err != nil {
+		return MalformedPayloadError(err)
+	}
 	schemaLoader := gojsonschema.NewStringLoader(JSONSchema())
 	docLoader := gojsonschema.NewStringLoader(string(jsonPayload))
 	result, err := gojsonschema.Validate(schemaLoader, docLoader)
@@ -625,11 +630,6 @@ func (task *TaskRun) validatePayload() *CommandExecutionError {
 		// happened before or after the execution of task specific Turing
 		// complete code.
 		return MalformedPayloadError(fmt.Errorf("Validation of payload failed for task %v", task.TaskID))
-	}
-	defaults.SetDefaults(&task.Payload)
-	err = json.Unmarshal(jsonPayload, &task.Payload)
-	if err != nil {
-		return MalformedPayloadError(err)
 	}
 	for _, artifact := range task.Payload.Artifacts {
 		// The default artifact expiry is task expiry, but is only applied when


### PR DESCRIPTION
Fixes #6237.

>This patch fixes the case where a generic worker won't upload its log on a malformed payload error. This has been broken since v48.2.0 from PR [#6107](https://github.com/taskcluster/taskcluster/pull/6107).