### PR TITLE
refactor!: drop support for python 3.7

### DIFF
--- a/changelog/JJPL-qvEQaalv3ZidxyoWw.md
+++ b/changelog/JJPL-qvEQaalv3ZidxyoWw.md
@@ -1,0 +1,6 @@
+audience: users
+level: major
+---
+Remove python 3.7 support as it's hit the EoL date, 2023-06-27.
+
+More info on the python 3.7 release schedule can be found [here](https://peps.python.org/pep-0537/).

--- a/clients/client-py/Makefile
+++ b/clients/client-py/Makefile
@@ -1,4 +1,4 @@
-TOX_ENV ?= py37
+TOX_ENV ?= py311
 VENV := .tox/$(TOX_ENV)
 PYTHON := $(VENV)/bin/python
 APIS_JSON=$(PWD)/apis.json

--- a/clients/client-py/setup.py
+++ b/clients/client-py/setup.py
@@ -58,8 +58,8 @@ class Tox(TestCommand):
         errno = tox.cmdline(args=args)
         sys.exit(errno)
 
-if sys.version_info[0] == 3 and sys.version_info[:2] < (3, 6):
-    raise Exception('This library does not support Python 3 versions below 3.6')
+if sys.version_info[0] == 3 and sys.version_info[:2] < (3, 8):
+    raise Exception('This library does not support Python 3 versions below 3.8')
 
 with open('README.md', encoding='utf8') as f:
     long_description = f.read()
@@ -89,7 +89,6 @@ if __name__ == '__main__':
         cmdclass={'test': Tox},
         zip_safe=False,
         classifiers=[
-            'Programming Language :: Python :: 3.7',
             'Programming Language :: Python :: 3.8',
             'Programming Language :: Python :: 3.9',
             'Programming Language :: Python :: 3.10',

--- a/clients/client-py/tox.ini
+++ b/clients/client-py/tox.ini
@@ -1,6 +1,5 @@
 [tox]
 envlist =
-    py37
     py38
     py39
     py310

--- a/docker/tc-admin/Dockerfile
+++ b/docker/tc-admin/Dockerfile
@@ -1,4 +1,4 @@
 # taskcluster/tc-admin image with tc-admin
 
-FROM python:3.7-slim
+FROM python:3.11-slim
 RUN pip3 install tc-admin==3.2.0

--- a/services/github/test/data/configs/taskcluster.dependencies.v1.yml
+++ b/services/github/test/data/configs/taskcluster.dependencies.v1.yml
@@ -6,7 +6,6 @@ tasks:
   then:
     - taskId: "docker_build"
       dependencies:
-      - "py37"
       - "py38"
       - "py39"
       provisionerId: test-provisioner
@@ -38,22 +37,6 @@ tasks:
         owner: owner
         source: source
 
-    - taskId: "py37"
-      provisionerId: test-provisioner
-      workerType: github-worker
-      created: {$fromNow: ''}
-      deadline: {$fromNow: '1 hour'}
-      payload:
-        maxRunTime: 3600
-        image: python:3.7
-        command:
-          - sh
-      metadata:
-        name: tox py37
-        description: code linting & unit tests on py37
-        owner: owner
-        source: source
-
     - taskId: "py38"
       provisionerId: test-provisioner
       workerType: github-worker
@@ -81,7 +64,7 @@ tasks:
         command:
           - sh
       metadata:
-        name: tox py37
+        name: tox py39
         description: code linting & unit tests on py39
         owner: owner
         source: source

--- a/services/github/test/intree_test.js
+++ b/services/github/test/intree_test.js
@@ -527,11 +527,10 @@ suite(testing.suiteName(), function() {
       }),
     },
     {
-      'tasks[0].taskId': 'py37',
-      'tasks[1].taskId': 'py38',
-      'tasks[2].taskId': 'py39',
-      'tasks[3].taskId': 'docker_build',
-      'tasks[4].taskId': 'docker_push',
+      'tasks[0].taskId': 'py38',
+      'tasks[1].taskId': 'py39',
+      'tasks[2].taskId': 'docker_build',
+      'tasks[3].taskId': 'docker_push',
     },
   );
 });

--- a/taskcluster/ci/client/kind.yml
+++ b/taskcluster/ci/client/kind.yml
@@ -57,16 +57,6 @@ tasks:
         {{ Xvfb :99 -screen 0 640x480x8 -nolisten tcp & }} &&
         sleep 2 &&
         CHROME_BIN=firefox DISPLAY=:99 yarn test
-  py37:
-    description: python3.7 client tests
-    docker-image: python:3.7
-    run:
-      command: >-
-        eval $(python test/client-library-secrets.py) &&
-        cd clients/client-py &&
-        python3 -mvenv /sandbox &&
-        /sandbox/bin/pip install tox &&
-        TOXENV=py37 /sandbox/bin/tox
   py38:
     description: python3.8 client tests
     docker-image: python:3.8


### PR DESCRIPTION
>Remove python 3.7 support as it's hit the EoL date, 2023-06-27.
>
>More info on the python 3.7 release schedule can be found [here](https://peps.python.org/pep-0537/).