### PR TITLE
Moved dockerfile to tc-admin repository

### DIFF
--- a/changelog/MXt8cGWOTfyVFTCtxhdHhA.md
+++ b/changelog/MXt8cGWOTfyVFTCtxhdHhA.md
@@ -1,0 +1,3 @@
+audience: users
+level: silent
+---

--- a/docker/tc-admin/Dockerfile
+++ b/docker/tc-admin/Dockerfile
@@ -1,4 +1,0 @@
-# taskcluster/tc-admin image with tc-admin
-
-FROM python:3.11-slim
-RUN pip3 install tc-admin~=4.0.0


### PR DESCRIPTION
Moved dockerfile to `tc-admin` where it should have been since start

https://github.com/taskcluster/tc-admin/pull/232

Tc-admin update broke local dev env, as `tc-admin:3.2.0` was published manually ~year ago.