### PR TITLE
Fix duplicate CORS header issues

### DIFF
--- a/changelog/c2yKFTwySzu3DTvhI6Zo4w.md
+++ b/changelog/c2yKFTwySzu3DTvhI6Zo4w.md
@@ -1,0 +1,5 @@
+audience: users
+level: patch
+---
+
+Fixes UI redirect where query parameters were not preserved. This broke changelog link from the sidebar.

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -22,6 +22,12 @@ http {
       proxy_pass $pass;
       proxy_hide_header Content-Security-Policy;
       proxy_set_header Host taskcluster;
+
+      # remove original headers to avoid multiple CORS headers
+      proxy_hide_header 'Access-Control-Allow-Origin';
+      proxy_hide_header 'Access-Control-Allow-Credentials';
+      proxy_hide_header 'Access-Control-Allow-Headers';
+
       add_header 'Access-Control-Allow-Origin' '*';
       add_header 'Access-Control-Allow-Credentials' 'true';
       add_header 'Access-Control-Allow-Headers' 'Authorization,Content-Type,Accept-Language';
@@ -31,6 +37,12 @@ http {
       proxy_pass $pass;
       proxy_hide_header Content-Security-Policy;
       proxy_set_header Host taskcluster;
+
+      # remove original headers to avoid multiple CORS headers
+      proxy_hide_header 'Access-Control-Allow-Origin';
+      proxy_hide_header 'Access-Control-Allow-Credentials';
+      proxy_hide_header 'Access-Control-Allow-Headers';
+
       add_header 'Access-Control-Allow-Origin' '*';
       add_header 'Access-Control-Allow-Credentials' 'true';
       add_header 'Access-Control-Allow-Headers' 'Authorization,Content-Type,Accept-Language';
@@ -40,6 +52,12 @@ http {
       proxy_pass $pass;
       proxy_hide_header Content-Security-Policy;
       proxy_set_header Host taskcluster;
+
+      # remove original headers to avoid multiple CORS headers
+      proxy_hide_header 'Access-Control-Allow-Origin';
+      proxy_hide_header 'Access-Control-Allow-Credentials';
+      proxy_hide_header 'Access-Control-Allow-Headers';
+
       add_header 'Access-Control-Allow-Origin' '*';
       add_header 'Access-Control-Allow-Credentials' 'true';
       add_header 'Access-Control-Allow-Headers' 'Authorization,Content-Type,Accept-Language';
@@ -49,6 +67,12 @@ http {
       proxy_pass $pass;
       proxy_hide_header Content-Security-Policy;
       proxy_set_header Host taskcluster;
+
+      # remove original headers to avoid multiple CORS headers
+      proxy_hide_header 'Access-Control-Allow-Origin';
+      proxy_hide_header 'Access-Control-Allow-Credentials';
+      proxy_hide_header 'Access-Control-Allow-Headers';
+
       add_header 'Access-Control-Allow-Origin' '*';
       add_header 'Access-Control-Allow-Credentials' 'true';
       add_header 'Access-Control-Allow-Headers' 'Authorization,Content-Type,Accept-Language';
@@ -58,6 +82,12 @@ http {
       proxy_pass $pass;
       proxy_hide_header Content-Security-Policy;
       proxy_set_header Host taskcluster;
+
+      # remove original headers to avoid multiple CORS headers
+      proxy_hide_header 'Access-Control-Allow-Origin';
+      proxy_hide_header 'Access-Control-Allow-Credentials';
+      proxy_hide_header 'Access-Control-Allow-Headers';
+
       add_header 'Access-Control-Allow-Origin' '*';
       add_header 'Access-Control-Allow-Credentials' 'true';
       add_header 'Access-Control-Allow-Headers' 'Authorization,Content-Type,Accept-Language';
@@ -67,6 +97,12 @@ http {
       proxy_pass $pass;
       proxy_hide_header Content-Security-Policy;
       proxy_set_header Host taskcluster;
+
+      # remove original headers to avoid multiple CORS headers
+      proxy_hide_header 'Access-Control-Allow-Origin';
+      proxy_hide_header 'Access-Control-Allow-Credentials';
+      proxy_hide_header 'Access-Control-Allow-Headers';
+
       add_header 'Access-Control-Allow-Origin' '*';
       add_header 'Access-Control-Allow-Credentials' 'true';
       add_header 'Access-Control-Allow-Headers' 'Authorization,Content-Type,Accept-Language';
@@ -92,6 +128,12 @@ http {
       proxy_pass $pass;
       proxy_hide_header Content-Security-Policy;
       proxy_set_header Host taskcluster;
+
+      # remove original headers to avoid multiple CORS headers
+      proxy_hide_header 'Access-Control-Allow-Origin';
+      proxy_hide_header 'Access-Control-Allow-Credentials';
+      proxy_hide_header 'Access-Control-Allow-Headers';
+
       add_header 'Access-Control-Allow-Origin' '*';
       add_header 'Access-Control-Allow-Credentials' 'true';
       add_header 'Access-Control-Allow-Headers' 'Authorization,Content-Type,Accept-Language';
@@ -102,6 +144,12 @@ http {
       proxy_pass $pass;
       proxy_hide_header Content-Security-Policy;
       proxy_set_header Host taskcluster;
+
+      # remove original headers to avoid multiple CORS headers
+      proxy_hide_header 'Access-Control-Allow-Origin';
+      proxy_hide_header 'Access-Control-Allow-Credentials';
+      proxy_hide_header 'Access-Control-Allow-Headers';
+
       add_header 'Access-Control-Allow-Origin' '*';
       add_header 'Access-Control-Allow-Credentials' 'true';
       add_header 'Access-Control-Allow-Headers' 'Authorization,Content-Type,Accept-Language';
@@ -112,6 +160,12 @@ http {
       proxy_pass $pass;
       proxy_hide_header Content-Security-Policy;
       proxy_set_header Host taskcluster;
+
+      # remove original headers to avoid multiple CORS headers
+      proxy_hide_header 'Access-Control-Allow-Origin';
+      proxy_hide_header 'Access-Control-Allow-Credentials';
+      proxy_hide_header 'Access-Control-Allow-Headers';
+
       add_header 'Access-Control-Allow-Origin' '*';
       add_header 'Access-Control-Allow-Credentials' 'true';
       add_header 'Access-Control-Allow-Headers' 'Authorization,Content-Type,Accept-Language';
@@ -122,6 +176,12 @@ http {
       proxy_pass $pass;
       proxy_hide_header Content-Security-Policy;
       proxy_set_header Host taskcluster;
+
+      # remove original headers to avoid multiple CORS headers
+      proxy_hide_header 'Access-Control-Allow-Origin';
+      proxy_hide_header 'Access-Control-Allow-Credentials';
+      proxy_hide_header 'Access-Control-Allow-Headers';
+
       add_header 'Access-Control-Allow-Origin' '*';
       add_header 'Access-Control-Allow-Credentials' 'true';
       add_header 'Access-Control-Allow-Headers' 'Authorization,Content-Type,Accept-Language';
@@ -132,6 +192,12 @@ http {
       proxy_pass $pass;
       proxy_hide_header Content-Security-Policy;
       proxy_set_header Host taskcluster;
+
+      # remove original headers to avoid multiple CORS headers
+      proxy_hide_header 'Access-Control-Allow-Origin';
+      proxy_hide_header 'Access-Control-Allow-Credentials';
+      proxy_hide_header 'Access-Control-Allow-Headers';
+
       add_header 'Access-Control-Allow-Origin' '*';
       add_header 'Access-Control-Allow-Credentials' 'true';
       add_header 'Access-Control-Allow-Headers' 'Authorization,Content-Type,Accept-Language';
@@ -142,6 +208,12 @@ http {
       proxy_pass $pass;
       proxy_hide_header Content-Security-Policy;
       proxy_set_header Host taskcluster;
+
+      # remove original headers to avoid multiple CORS headers
+      proxy_hide_header 'Access-Control-Allow-Origin';
+      proxy_hide_header 'Access-Control-Allow-Credentials';
+      proxy_hide_header 'Access-Control-Allow-Headers';
+
       add_header 'Access-Control-Allow-Origin' '*';
       add_header 'Access-Control-Allow-Credentials' 'true';
       add_header 'Access-Control-Allow-Headers' 'Authorization,Content-Type,Accept-Language';
@@ -152,6 +224,12 @@ http {
       proxy_pass $pass;
       proxy_hide_header Content-Security-Policy;
       proxy_set_header Host taskcluster;
+
+      # remove original headers to avoid multiple CORS headers
+      proxy_hide_header 'Access-Control-Allow-Origin';
+      proxy_hide_header 'Access-Control-Allow-Credentials';
+      proxy_hide_header 'Access-Control-Allow-Headers';
+
       add_header 'Access-Control-Allow-Origin' '*';
       add_header 'Access-Control-Allow-Credentials' 'true';
       add_header 'Access-Control-Allow-Headers' 'Authorization,Content-Type,Accept-Language';
@@ -162,6 +240,12 @@ http {
       proxy_pass $pass;
       proxy_hide_header Content-Security-Policy;
       proxy_set_header Host taskcluster;
+
+      # remove original headers to avoid multiple CORS headers
+      proxy_hide_header 'Access-Control-Allow-Origin';
+      proxy_hide_header 'Access-Control-Allow-Credentials';
+      proxy_hide_header 'Access-Control-Allow-Headers';
+
       add_header 'Access-Control-Allow-Origin' '*';
       add_header 'Access-Control-Allow-Credentials' 'true';
       add_header 'Access-Control-Allow-Headers' 'Authorization,Content-Type,Accept-Language';
@@ -172,6 +256,12 @@ http {
       proxy_pass $pass;
       proxy_hide_header Content-Security-Policy;
       proxy_set_header Host taskcluster;
+
+      # remove original headers to avoid multiple CORS headers
+      proxy_hide_header 'Access-Control-Allow-Origin';
+      proxy_hide_header 'Access-Control-Allow-Credentials';
+      proxy_hide_header 'Access-Control-Allow-Headers';
+
       add_header 'Access-Control-Allow-Origin' '*';
       add_header 'Access-Control-Allow-Credentials' 'true';
       add_header 'Access-Control-Allow-Headers' 'Authorization,Content-Type,Accept-Language';
@@ -182,6 +272,12 @@ http {
       proxy_pass $pass;
       proxy_hide_header Content-Security-Policy;
       proxy_set_header Host taskcluster;
+
+      # remove original headers to avoid multiple CORS headers
+      proxy_hide_header 'Access-Control-Allow-Origin';
+      proxy_hide_header 'Access-Control-Allow-Credentials';
+      proxy_hide_header 'Access-Control-Allow-Headers';
+
       add_header 'Access-Control-Allow-Origin' '*';
       add_header 'Access-Control-Allow-Credentials' 'true';
       add_header 'Access-Control-Allow-Headers' 'Authorization,Content-Type,Accept-Language';
@@ -192,6 +288,12 @@ http {
       proxy_pass $pass;
       proxy_hide_header Content-Security-Policy;
       proxy_set_header Host taskcluster;
+
+      # remove original headers to avoid multiple CORS headers
+      proxy_hide_header 'Access-Control-Allow-Origin';
+      proxy_hide_header 'Access-Control-Allow-Credentials';
+      proxy_hide_header 'Access-Control-Allow-Headers';
+
       add_header 'Access-Control-Allow-Origin' '*';
       add_header 'Access-Control-Allow-Credentials' 'true';
       add_header 'Access-Control-Allow-Headers' 'Authorization,Content-Type,Accept-Language';

--- a/infrastructure/tooling/src/generate/generators/docker-compose.js
+++ b/infrastructure/tooling/src/generate/generators/docker-compose.js
@@ -547,6 +547,12 @@ exports.tasks.push({
   run: async (requirements, utils) => {
     const extraDirectives = `proxy_hide_header Content-Security-Policy;
       proxy_set_header Host taskcluster;
+
+      # remove original headers to avoid multiple CORS headers
+      proxy_hide_header 'Access-Control-Allow-Origin';
+      proxy_hide_header 'Access-Control-Allow-Credentials';
+      proxy_hide_header 'Access-Control-Allow-Headers';
+
       add_header 'Access-Control-Allow-Origin' '*';
       add_header 'Access-Control-Allow-Credentials' 'true';
       add_header 'Access-Control-Allow-Headers' 'Authorization,Content-Type,Accept-Language';`;

--- a/ui/src/views/SwitchEntryPoint/index.jsx
+++ b/ui/src/views/SwitchEntryPoint/index.jsx
@@ -1,6 +1,6 @@
-export default ({ match: { url } }) => {
+export default ({ match: { url }, location: { search, hash } }) => {
   // Switching entry points cannot be handled by react-router-dom
-  window.location.href = url;
+  window.location.href = `${url}${search}${hash}`;
 
   return null;
 };


### PR DESCRIPTION
Wanted to fix #6330 but couldn't reproduce it.

* Fixes duplicate CORS headers issue
* Fix UI redirect where `/docs?version=x` redirect was not preserving query parameters