### PR TITLE
feat(cli): integrate `d2g` into taskcluster cli

### DIFF
--- a/changelog/JIdME6vOQiq7Yr6nXJf4EQ.md
+++ b/changelog/JIdME6vOQiq7Yr6nXJf4EQ.md
@@ -1,0 +1,39 @@
+audience: users
+level: minor
+
+---
+
+This change adds the `d2g` subcommand to the `taskcluster` cli.
+
+It can be used to translate a Docker Worker payload to a Generic Worker payload.
+Both the input and output are JSON. You can either pass the input as a file or pipe it in to the command.
+
+View help with:
+
+```shell
+taskcluster d2g -h
+```
+
+Example usages:
+
+```shell
+taskcluster d2g -f /path/to/input.json
+```
+
+_OR_
+
+```shell
+taskcluster d2g --file /path/to/input.json
+```
+
+_OR_
+
+```shell
+cat /path/to/input.json | taskcluster d2g
+```
+
+_OR_
+
+```shell
+echo '{"image": "ubuntu", "command": ["bash", "-c", "echo hello world"], "maxRunTime": 300}' | taskcluster d2g
+```

--- a/clients/client-shell/README.md
+++ b/clients/client-shell/README.md
@@ -116,6 +116,33 @@ To generate a nice slugid:
 taskcluster slugid generate -n
 ```
 
+### Translating Docker Worker Payloads to Generic Worker Payloads
+
+The `taskcluster d2g` subcommand can be used to translate a Docker Worker payload to a Generic Worker payload.
+Both the input and output are JSON. You can either pass the input as a file or pipe it in to the command.
+
+```shell
+taskcluster d2g -f /path/to/input.json
+```
+
+_OR_
+
+```shell
+taskcluster d2g --file /path/to/input.json
+```
+
+_OR_
+
+```shell
+cat /path/to/input.json | taskcluster d2g
+```
+
+_OR_
+
+```shell
+echo '{"image": "ubuntu", "command": ["bash", "-c", "echo hello world"], "maxRunTime": 300}' | taskcluster d2g
+```
+
 ### Task and Task Group Commands
 
 The following higher-level commands can be useful in day-to-day operations.

--- a/clients/client-shell/cmds/d2g/d2g.go
+++ b/clients/client-shell/cmds/d2g/d2g.go
@@ -1,34 +1,60 @@
-package main
+package d2g
 
 import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"log"
 	"os"
 	"strings"
 
 	"github.com/mcuadros/go-defaults"
+	"github.com/taskcluster/taskcluster/v54/clients/client-shell/cmds/root"
 	"github.com/taskcluster/taskcluster/v54/tools/d2g"
 	"github.com/taskcluster/taskcluster/v54/tools/d2g/dockerworker"
 	"github.com/taskcluster/taskcluster/v54/tools/d2g/genericworker"
 	"github.com/xeipuuv/gojsonschema"
+
+	"github.com/spf13/cobra"
 )
 
-func main() {
-	log.SetFlags(0)
-	log.SetPrefix("d2g: ")
+func init() {
+	cmd := &cobra.Command{
+		Use:   "d2g",
+		Short: "Converts a docker-worker payload (JSON) to a generic-worker payload (JSON).",
+		RunE:  convert,
+	}
+	cmd.Flags().StringP("file", "f", "", "Path to a .json file containing a docker-worker payload.")
+	root.Command.AddCommand(cmd)
+}
 
-	// Read the JSON input from standard input
-	input, err := io.ReadAll(os.Stdin)
-	if err != nil {
-		log.Fatal("Failed to read input:", err)
+func convert(cmd *cobra.Command, args []string) (err error) {
+	var input []byte
+
+	filePath, _ := cmd.Flags().GetString("file")
+	if filePath != "" {
+		// Read input from file
+		input, err = os.ReadFile(filePath)
+		if err != nil {
+			return fmt.Errorf("failed to read input file: %v", err)
+		}
+	} else {
+		// Check if input is piped
+		stat, _ := os.Stdin.Stat()
+		if (stat.Mode() & os.ModeCharDevice) == 0 {
+			// Read input from pipe
+			input, err = io.ReadAll(os.Stdin)
+			if err != nil {
+				return fmt.Errorf("failed to read input: %v", err)
+			}
+		} else {
+			return fmt.Errorf("no input provided")
+		}
 	}
 
 	// Validate the JSON input against the schema
 	err = validateJSON(input, dockerworker.JSONSchema())
 	if err != nil {
-		log.Fatalf("Input validation failed: %v", err)
+		return fmt.Errorf("input validation failed: %v", err)
 	}
 
 	// Convert the validated JSON input
@@ -36,26 +62,30 @@ func main() {
 	defaults.SetDefaults(dwPayload)
 	err = json.Unmarshal(input, &dwPayload)
 	if err != nil {
-		log.Fatalf("Failed to convert input to a docker worker payload definition: %v", err)
+		return fmt.Errorf("failed to convert input to a docker worker payload definition: %v", err)
 	}
 
+	// Convert dwPayload to gwPayload
 	gwPayload, err := d2g.Convert(dwPayload)
 	if err != nil {
-		log.Fatal(err)
+		return fmt.Errorf("conversion error: %v", err)
 	}
 
+	// Convert gwPayload to JSON
 	formattedActualGWPayload, err := json.MarshalIndent(*gwPayload, "", "  ")
 	if err != nil {
-		log.Fatalf("Cannot convert Generic Worker payload %#v to JSON: %s", *gwPayload, err)
+		return fmt.Errorf("cannot convert Generic Worker payload %#v to JSON: %s", *gwPayload, err)
 	}
 
 	// Validate the JSON output against the schema
 	err = validateJSON(formattedActualGWPayload, genericworker.JSONSchema())
 	if err != nil {
-		log.Fatalf("Output validation failed: %v", err)
+		return fmt.Errorf("output validation failed: %v", err)
 	}
 
-	fmt.Println(string(formattedActualGWPayload))
+	fmt.Fprintln(cmd.OutOrStdout(), string(formattedActualGWPayload))
+
+	return nil
 }
 
 func validateJSON(input []byte, schema string) error {

--- a/clients/client-shell/subtree_imports.go
+++ b/clients/client-shell/subtree_imports.go
@@ -7,6 +7,7 @@ import (
 	_ "github.com/taskcluster/taskcluster/v54/clients/client-shell/apis"
 	_ "github.com/taskcluster/taskcluster/v54/clients/client-shell/cmds/completions"
 	_ "github.com/taskcluster/taskcluster/v54/clients/client-shell/cmds/config"
+	_ "github.com/taskcluster/taskcluster/v54/clients/client-shell/cmds/d2g"
 	_ "github.com/taskcluster/taskcluster/v54/clients/client-shell/cmds/download"
 	_ "github.com/taskcluster/taskcluster/v54/clients/client-shell/cmds/from-now"
 	_ "github.com/taskcluster/taskcluster/v54/clients/client-shell/cmds/group"


### PR DESCRIPTION
>This change adds the `d2g` subcommand to the `taskcluster` cli.
>
>It can be used to translate a Docker Worker payload to a Generic Worker payload.
>Both the input and output are JSON. You can either pass the input as a file or pipe it in to the command.
>
>View help with:
>
>```shell
>taskcluster d2g -h
>```
>
>Example usages:
>
>```shell
>taskcluster d2g -f /path/to/input.json
>```
>
>_OR_
>
>```shell
>taskcluster d2g --file /path/to/input.json
>```
>
>_OR_
>
>```shell
>cat /path/to/input.json | taskcluster d2g
>```
>
>_OR_
>
>```shell
>echo '{"image": "ubuntu", "command": ["bash", "-c", "echo hello world"], "maxRunTime": 300}' | taskcluster d2g
>```