### PR TITLE
Load schemas once

### DIFF
--- a/changelog/issue-6330.md
+++ b/changelog/issue-6330.md
@@ -1,0 +1,6 @@
+audience: users
+level: patch
+reference: issue 6330
+---
+
+Fixes UI errors on pages that were loading metaschema twice.

--- a/ui/src/utils/ajv.js
+++ b/ui/src/utils/ajv.js
@@ -7,4 +7,12 @@ const ajv = new Ajv({ validateFormats: true, verbose: true, allErrors: true });
 addFormats(ajv);
 ajv.addMetaSchema(metaSchema);
 
+ajv.addSchemaOnce = (schema, key) => {
+  const uniqueKey = key || schema.$id;
+
+  if (!ajv.getSchema(uniqueKey)) {
+    ajv.addSchema(schema, uniqueKey);
+  }
+};
+
 export default ajv;

--- a/ui/src/utils/exchangesList.js
+++ b/ui/src/utils/exchangesList.js
@@ -1,8 +1,8 @@
-import urls from 'taskcluster-lib-urls';
+import urls from './urls';
 
 const exchanges = [];
 const fetchExchanges = async (service, version) => {
-  const res = await fetch(urls.exchangeReference('', service, version));
+  const res = await fetch(urls.exchangeReference(service, version));
   const data = await res.json();
 
   data.entries?.forEach(entry => {

--- a/ui/src/utils/exchangesList.test.js
+++ b/ui/src/utils/exchangesList.test.js
@@ -5,7 +5,7 @@ describe('exchangesList', () => {
         json: () =>
           Promise.resolve({
             $id: url,
-            exchangePrefix: url.replace('.json', '/').substr(1),
+            exchangePrefix: url.replace('.json', '/'),
             entries: [
               {
                 exchange: 'exchange1',
@@ -23,7 +23,9 @@ describe('exchangesList', () => {
 
     expect(exchanges).toBeDefined();
     expect(
-      exchanges.includes('references/auth/v1/exchanges/exchange1')
+      exchanges.includes(
+        'https://taskcluster.net/references/auth/v1/exchanges/exchange1'
+      )
     ).toBeTruthy();
     expect(window.fetch).toHaveBeenCalled();
   });

--- a/ui/src/utils/validateTaskPayloadSchemas.js
+++ b/ui/src/utils/validateTaskPayloadSchemas.js
@@ -1,17 +1,17 @@
-import urls from 'taskcluster-lib-urls';
 import ajv from './ajv';
+import urls from './urls';
 
 const schemas = {};
 const fetchSchema = async (service, schema) => {
-  const res = await fetch(urls.schema('', service, schema));
+  const res = await fetch(urls.schema(service, schema));
 
   return res.json();
 };
 
 const prefetch = async () => {
-  ajv.addSchema(await fetchSchema('common', 'metaschema.json'));
-  ajv.addSchema(await fetchSchema('queue', 'v1/task.json'));
-  ajv.addSchema(await fetchSchema('queue', 'v1/task-metadata.json'));
+  ajv.addSchemaOnce(await fetchSchema('common', 'metaschema.json'));
+  ajv.addSchemaOnce(await fetchSchema('queue', 'v1/task.json'));
+  ajv.addSchemaOnce(await fetchSchema('queue', 'v1/task-metadata.json'));
 };
 
 const prefetchPromise = prefetch();

--- a/ui/src/views/TcYamlDebug/index.jsx
+++ b/ui/src/views/TcYamlDebug/index.jsx
@@ -20,34 +20,31 @@ import githubQuery from './github.graphql';
 import JsonDisplay from '../../components/JsonDisplay';
 
 const prefetchSchema = async () => {
-  ajv.addSchema(
+  ajv.addSchemaOnce(
     await (await fetch(urls.schema('common', 'metaschema.json'))).json()
   );
-  ajv.addSchema(
+  ajv.addSchemaOnce(
     await (
       await fetch(urls.schema('github', 'v1/taskcluster-github-config.json'))
     ).json(),
     'github-v0'
   );
-  ajv.addSchema(
+  ajv.addSchemaOnce(
     await (
       await fetch(urls.schema('github', 'v1/taskcluster-github-config.v1.json'))
     ).json(),
     'github-v1'
   );
-  ajv.addSchema(
-    await (await fetch(urls.schema('queue', 'v1/task-metadata.json'))).json(),
-    'task-metadata.json'
+  ajv.addSchemaOnce(
+    await (await fetch(urls.schema('queue', 'v1/task-metadata.json'))).json()
   );
-  ajv.addSchema(
-    await (await fetch(urls.schema('queue', 'v1/task.json'))).json(),
-    'task.json'
+  ajv.addSchemaOnce(
+    await (await fetch(urls.schema('queue', 'v1/task.json'))).json()
   );
-  ajv.addSchema(
+  ajv.addSchemaOnce(
     await (
       await fetch(urls.schema('queue', 'v1/create-task-request.json'))
-    ).json(),
-    'create-task'
+    ).json()
   );
 };
 


### PR DESCRIPTION
This happened on the production build only as whole code was living in the shared scope. 
Multiple pages were adding same schema twice which caused an exception to be thrown in console. 
To avoid this, we only load those schemas once.

Also refactored lib-url usage across pages

Fixes #6330 
