### PR TITLE
feat(generic-worker): integrate `d2g` to interpret docker worker payloads

### DIFF
--- a/changelog/issue-5967.md
+++ b/changelog/issue-5967.md
@@ -1,0 +1,5 @@
+audience: users
+level: minor
+reference: issue 5967
+---
+This change integrates the `d2g` tool into Generic Worker so that it can accept a valid, Docker Worker payload.

--- a/clients/client-go/codegenerator/model/api.go
+++ b/clients/client-go/codegenerator/model/api.go
@@ -467,64 +467,64 @@ func (rs *RequiredScope) String() string {
 
 // MarshalJSON calls json.RawMessage method of the same name. Required since
 // ScopeExpressionTemplate is of type json.RawMessage...
-func (this *ScopeExpressionTemplate) MarshalJSON() ([]byte, error) {
-	return (this.RawMessage).MarshalJSON()
+func (m *ScopeExpressionTemplate) MarshalJSON() ([]byte, error) {
+	return (m.RawMessage).MarshalJSON()
 }
 
 // UnmarshalJSON identifies the data structure at runtime, and unmarshals in
 // the appropriate type
-func (this *ScopeExpressionTemplate) UnmarshalJSON(data []byte) error {
-	if this == nil {
+func (m *ScopeExpressionTemplate) UnmarshalJSON(data []byte) error {
+	if m == nil {
 		return errors.New("ScopeExpressionTemplate: UnmarshalJSON on nil pointer")
 	}
-	this.RawMessage = append((this.RawMessage)[0:0], data...)
+	m.RawMessage = append((m.RawMessage)[0:0], data...)
 	var tempObj interface{}
-	err := json.Unmarshal(this.RawMessage, &tempObj)
+	err := json.Unmarshal(m.RawMessage, &tempObj)
 	if err != nil {
 		panic("Internal error: " + err.Error())
 	}
 	switch t := tempObj.(type) {
 	case string:
-		this.Type = "RequiredScope"
-		this.RequiredScope = new(RequiredScope)
-		*(this.RequiredScope) = RequiredScope(t)
+		m.Type = "RequiredScope"
+		m.RequiredScope = new(RequiredScope)
+		*(m.RequiredScope) = RequiredScope(t)
 	case map[string]interface{}:
 		j, err := json.Marshal(t)
 		if err != nil {
 			panic("Internal error: " + err.Error())
 		}
 		if _, exists := t["AnyOf"]; exists {
-			this.Type = "AnyOf"
-			this.AnyOf = new(Disjunction)
-			err = json.Unmarshal(j, this.AnyOf)
+			m.Type = "AnyOf"
+			m.AnyOf = new(Disjunction)
+			err = json.Unmarshal(j, m.AnyOf)
 		}
 		if _, exists := t["AllOf"]; exists {
-			this.Type = "AllOf"
-			this.AllOf = new(Conjunction)
-			err = json.Unmarshal(j, this.AllOf)
+			m.Type = "AllOf"
+			m.AllOf = new(Conjunction)
+			err = json.Unmarshal(j, m.AllOf)
 		}
 		if _, exists := t["if"]; exists {
-			this.Type = "IfThen"
-			this.IfThen = new(Conditional)
-			err = json.Unmarshal(j, this.IfThen)
+			m.Type = "IfThen"
+			m.IfThen = new(Conditional)
+			err = json.Unmarshal(j, m.IfThen)
 		}
 		if _, exists := t["for"]; exists {
-			this.Type = "ForEachIn"
-			this.ForEachIn = new(ForAll)
-			err = json.Unmarshal(j, this.ForEachIn)
+			m.Type = "ForEachIn"
+			m.ForEachIn = new(ForAll)
+			err = json.Unmarshal(j, m.ForEachIn)
 		}
 		if err != nil {
 			panic("Internal error: " + err.Error())
 		}
 	// for old style scopesets [][]string (normal disjunctive form)
 	case []interface{}:
-		this.Type = "AnyOf"
-		this.AnyOf = &Disjunction{
+		m.Type = "AnyOf"
+		m.AnyOf = &Disjunction{
 			AnyOf: make([]ScopeExpressionTemplate, len(t)),
 		}
 		for i, j := range t {
 			allOf := j.([]interface{})
-			this.AnyOf.AnyOf[i] = ScopeExpressionTemplate{
+			m.AnyOf.AnyOf[i] = ScopeExpressionTemplate{
 				Type: "AllOf",
 				AllOf: &Conjunction{
 					AllOf: make([]ScopeExpressionTemplate, len(allOf)),
@@ -532,7 +532,7 @@ func (this *ScopeExpressionTemplate) UnmarshalJSON(data []byte) error {
 			}
 			for k, l := range allOf {
 				rs := RequiredScope(l.(string))
-				this.AnyOf.AnyOf[i].AllOf.AllOf[k] = ScopeExpressionTemplate{
+				m.AnyOf.AnyOf[i].AllOf.AllOf[k] = ScopeExpressionTemplate{
 					Type:          "RequiredScope",
 					RequiredScope: &rs,
 				}

--- a/clients/client-go/tcauth/types.go
+++ b/clients/client-go/tcauth/types.go
@@ -675,16 +675,16 @@ type (
 
 // MarshalJSON calls json.RawMessage method of the same name. Required since
 // HawkSignatureAuthenticationResponse is of type json.RawMessage...
-func (this *HawkSignatureAuthenticationResponse) MarshalJSON() ([]byte, error) {
-	x := json.RawMessage(*this)
+func (m *HawkSignatureAuthenticationResponse) MarshalJSON() ([]byte, error) {
+	x := json.RawMessage(*m)
 	return (&x).MarshalJSON()
 }
 
 // UnmarshalJSON is a copy of the json.RawMessage implementation.
-func (this *HawkSignatureAuthenticationResponse) UnmarshalJSON(data []byte) error {
-	if this == nil {
+func (m *HawkSignatureAuthenticationResponse) UnmarshalJSON(data []byte) error {
+	if m == nil {
 		return errors.New("HawkSignatureAuthenticationResponse: UnmarshalJSON on nil pointer")
 	}
-	*this = append((*this)[0:0], data...)
+	*m = append((*m)[0:0], data...)
 	return nil
 }

--- a/clients/client-go/tchooks/types.go
+++ b/clients/client-go/tchooks/types.go
@@ -313,32 +313,32 @@ type (
 
 // MarshalJSON calls json.RawMessage method of the same name. Required since
 // TriggerHookRequest is of type json.RawMessage...
-func (this *TriggerHookRequest) MarshalJSON() ([]byte, error) {
-	x := json.RawMessage(*this)
+func (m *TriggerHookRequest) MarshalJSON() ([]byte, error) {
+	x := json.RawMessage(*m)
 	return (&x).MarshalJSON()
 }
 
 // UnmarshalJSON is a copy of the json.RawMessage implementation.
-func (this *TriggerHookRequest) UnmarshalJSON(data []byte) error {
-	if this == nil {
+func (m *TriggerHookRequest) UnmarshalJSON(data []byte) error {
+	if m == nil {
 		return errors.New("TriggerHookRequest: UnmarshalJSON on nil pointer")
 	}
-	*this = append((*this)[0:0], data...)
+	*m = append((*m)[0:0], data...)
 	return nil
 }
 
 // MarshalJSON calls json.RawMessage method of the same name. Required since
 // TriggerHookResponse is of type json.RawMessage...
-func (this *TriggerHookResponse) MarshalJSON() ([]byte, error) {
-	x := json.RawMessage(*this)
+func (m *TriggerHookResponse) MarshalJSON() ([]byte, error) {
+	x := json.RawMessage(*m)
 	return (&x).MarshalJSON()
 }
 
 // UnmarshalJSON is a copy of the json.RawMessage implementation.
-func (this *TriggerHookResponse) UnmarshalJSON(data []byte) error {
-	if this == nil {
+func (m *TriggerHookResponse) UnmarshalJSON(data []byte) error {
+	if m == nil {
 		return errors.New("TriggerHookResponse: UnmarshalJSON on nil pointer")
 	}
-	*this = append((*this)[0:0], data...)
+	*m = append((*m)[0:0], data...)
 	return nil
 }

--- a/clients/client-go/tchooksevents/types.go
+++ b/clients/client-go/tchooksevents/types.go
@@ -29,16 +29,16 @@ type (
 
 // MarshalJSON calls json.RawMessage method of the same name. Required since
 // HookChangedMessage is of type json.RawMessage...
-func (this *HookChangedMessage) MarshalJSON() ([]byte, error) {
-	x := json.RawMessage(*this)
+func (m *HookChangedMessage) MarshalJSON() ([]byte, error) {
+	x := json.RawMessage(*m)
 	return (&x).MarshalJSON()
 }
 
 // UnmarshalJSON is a copy of the json.RawMessage implementation.
-func (this *HookChangedMessage) UnmarshalJSON(data []byte) error {
-	if this == nil {
+func (m *HookChangedMessage) UnmarshalJSON(data []byte) error {
+	if m == nil {
 		return errors.New("HookChangedMessage: UnmarshalJSON on nil pointer")
 	}
-	*this = append((*this)[0:0], data...)
+	*m = append((*m)[0:0], data...)
 	return nil
 }

--- a/clients/client-go/tcobject/types.go
+++ b/clients/client-go/tcobject/types.go
@@ -374,48 +374,48 @@ type (
 
 // MarshalJSON calls json.RawMessage method of the same name. Required since
 // DownloadObjectResponse is of type json.RawMessage...
-func (this *DownloadObjectResponse) MarshalJSON() ([]byte, error) {
-	x := json.RawMessage(*this)
+func (m *DownloadObjectResponse) MarshalJSON() ([]byte, error) {
+	x := json.RawMessage(*m)
 	return (&x).MarshalJSON()
 }
 
 // UnmarshalJSON is a copy of the json.RawMessage implementation.
-func (this *DownloadObjectResponse) UnmarshalJSON(data []byte) error {
-	if this == nil {
+func (m *DownloadObjectResponse) UnmarshalJSON(data []byte) error {
+	if m == nil {
 		return errors.New("DownloadObjectResponse: UnmarshalJSON on nil pointer")
 	}
-	*this = append((*this)[0:0], data...)
+	*m = append((*m)[0:0], data...)
 	return nil
 }
 
 // MarshalJSON calls json.RawMessage method of the same name. Required since
 // ObjectContentHashes is of type json.RawMessage...
-func (this *ObjectContentHashes) MarshalJSON() ([]byte, error) {
-	x := json.RawMessage(*this)
+func (m *ObjectContentHashes) MarshalJSON() ([]byte, error) {
+	x := json.RawMessage(*m)
 	return (&x).MarshalJSON()
 }
 
 // UnmarshalJSON is a copy of the json.RawMessage implementation.
-func (this *ObjectContentHashes) UnmarshalJSON(data []byte) error {
-	if this == nil {
+func (m *ObjectContentHashes) UnmarshalJSON(data []byte) error {
+	if m == nil {
 		return errors.New("ObjectContentHashes: UnmarshalJSON on nil pointer")
 	}
-	*this = append((*this)[0:0], data...)
+	*m = append((*m)[0:0], data...)
 	return nil
 }
 
 // MarshalJSON calls json.RawMessage method of the same name. Required since
 // ObjectContentHashesForDownload is of type json.RawMessage...
-func (this *ObjectContentHashesForDownload) MarshalJSON() ([]byte, error) {
-	x := json.RawMessage(*this)
+func (m *ObjectContentHashesForDownload) MarshalJSON() ([]byte, error) {
+	x := json.RawMessage(*m)
 	return (&x).MarshalJSON()
 }
 
 // UnmarshalJSON is a copy of the json.RawMessage implementation.
-func (this *ObjectContentHashesForDownload) UnmarshalJSON(data []byte) error {
-	if this == nil {
+func (m *ObjectContentHashesForDownload) UnmarshalJSON(data []byte) error {
+	if m == nil {
 		return errors.New("ObjectContentHashesForDownload: UnmarshalJSON on nil pointer")
 	}
-	*this = append((*this)[0:0], data...)
+	*m = append((*m)[0:0], data...)
 	return nil
 }

--- a/clients/client-go/tcqueue/types.go
+++ b/clients/client-go/tcqueue/types.go
@@ -2223,48 +2223,48 @@ type (
 
 // MarshalJSON calls json.RawMessage method of the same name. Required since
 // GetArtifactContentResponse is of type json.RawMessage...
-func (this *GetArtifactContentResponse) MarshalJSON() ([]byte, error) {
-	x := json.RawMessage(*this)
+func (m *GetArtifactContentResponse) MarshalJSON() ([]byte, error) {
+	x := json.RawMessage(*m)
 	return (&x).MarshalJSON()
 }
 
 // UnmarshalJSON is a copy of the json.RawMessage implementation.
-func (this *GetArtifactContentResponse) UnmarshalJSON(data []byte) error {
-	if this == nil {
+func (m *GetArtifactContentResponse) UnmarshalJSON(data []byte) error {
+	if m == nil {
 		return errors.New("GetArtifactContentResponse: UnmarshalJSON on nil pointer")
 	}
-	*this = append((*this)[0:0], data...)
+	*m = append((*m)[0:0], data...)
 	return nil
 }
 
 // MarshalJSON calls json.RawMessage method of the same name. Required since
 // PostArtifactRequest is of type json.RawMessage...
-func (this *PostArtifactRequest) MarshalJSON() ([]byte, error) {
-	x := json.RawMessage(*this)
+func (m *PostArtifactRequest) MarshalJSON() ([]byte, error) {
+	x := json.RawMessage(*m)
 	return (&x).MarshalJSON()
 }
 
 // UnmarshalJSON is a copy of the json.RawMessage implementation.
-func (this *PostArtifactRequest) UnmarshalJSON(data []byte) error {
-	if this == nil {
+func (m *PostArtifactRequest) UnmarshalJSON(data []byte) error {
+	if m == nil {
 		return errors.New("PostArtifactRequest: UnmarshalJSON on nil pointer")
 	}
-	*this = append((*this)[0:0], data...)
+	*m = append((*m)[0:0], data...)
 	return nil
 }
 
 // MarshalJSON calls json.RawMessage method of the same name. Required since
 // PostArtifactResponse is of type json.RawMessage...
-func (this *PostArtifactResponse) MarshalJSON() ([]byte, error) {
-	x := json.RawMessage(*this)
+func (m *PostArtifactResponse) MarshalJSON() ([]byte, error) {
+	x := json.RawMessage(*m)
 	return (&x).MarshalJSON()
 }
 
 // UnmarshalJSON is a copy of the json.RawMessage implementation.
-func (this *PostArtifactResponse) UnmarshalJSON(data []byte) error {
-	if this == nil {
+func (m *PostArtifactResponse) UnmarshalJSON(data []byte) error {
+	if m == nil {
 		return errors.New("PostArtifactResponse: UnmarshalJSON on nil pointer")
 	}
-	*this = append((*this)[0:0], data...)
+	*m = append((*m)[0:0], data...)
 	return nil
 }

--- a/generated/references.json
+++ b/generated/references.json
@@ -8502,8 +8502,35 @@
     "content": {
       "$id": "/schemas/generic-worker/multiuser_posix.json#",
       "$schema": "/schemas/common/metaschema.json#",
-      "additionalProperties": false,
       "definitions": {
+        "artifact": {
+          "additionalProperties": false,
+          "properties": {
+            "expires": {
+              "format": "date-time",
+              "title": "Date when artifact should expire must be in the future.",
+              "type": "string"
+            },
+            "path": {
+              "title": "Location of artifact in container, as an absolute path.",
+              "type": "string"
+            },
+            "type": {
+              "enum": [
+                "file",
+                "directory"
+              ],
+              "title": "Artifact upload type.",
+              "type": "string"
+            }
+          },
+          "required": [
+            "type",
+            "path"
+          ],
+          "title": "Docker Worker Artifact",
+          "type": "object"
+        },
         "content": {
           "oneOf": [
             {
@@ -8729,222 +8756,509 @@
           "type": "object"
         }
       },
-      "description": "This schema defines the structure of the `payload` property referred to in a\nTaskcluster Task definition.",
-      "properties": {
-        "artifacts": {
-          "description": "Artifacts to be published.\n\nSince: generic-worker 1.0.0",
-          "items": {
-            "additionalProperties": false,
-            "properties": {
-              "contentEncoding": {
-                "description": "Content-Encoding for the artifact. If not provided, `gzip` will be used, except for the\nfollowing file extensions, where `identity` will be used, since they are already\ncompressed:\n\n* 7z\n* bz2\n* deb\n* dmg\n* flv\n* gif\n* gz\n* jpeg\n* jpg\n* png\n* swf\n* tbz\n* tgz\n* webp\n* whl\n* woff\n* woff2\n* xz\n* zip\n* zst\n\nNote, setting `contentEncoding` on a directory artifact will apply the same content\nencoding to all the files contained in the directory.\n\nSince: generic-worker 16.2.0",
-                "enum": [
-                  "identity",
-                  "gzip"
-                ],
-                "title": "Content-Encoding header when serving artifact over HTTP.",
-                "type": "string"
-              },
-              "contentType": {
-                "description": "Explicitly set the value of the HTTP `Content-Type` response header when the artifact(s)\nis/are served over HTTP(S). If not provided (this property is optional) the worker will\nguess the content type of artifacts based on the filename extension of the file storing\nthe artifact content. It does this by looking at the system filename-to-mimetype mappings\ndefined in multiple `mime.types` files located under `/etc`. Note, setting `contentType`\non a directory artifact will apply the same contentType to all files contained in the\ndirectory.\n\nSee [mime.TypeByExtension](https://pkg.go.dev/mime#TypeByExtension).\n\nSince: generic-worker 10.4.0",
-                "title": "Content-Type header when serving artifact over HTTP",
-                "type": "string"
-              },
-              "expires": {
-                "description": "Date when artifact should expire must be in the future, no earlier than task deadline, but\nno later than task expiry. If not set, defaults to task expiry.\n\nSince: generic-worker 1.0.0",
-                "format": "date-time",
-                "title": "Expiry date and time",
-                "type": "string"
-              },
-              "name": {
-                "description": "Name of the artifact, as it will be published. If not set, `path` will be used.\nConventionally (although not enforced) path elements are forward slash separated. Example:\n`public/build/a/house`. Note, no scopes are required to read artifacts beginning `public/`.\nArtifact names not beginning `public/` are scope-protected (caller requires scopes to\ndownload the artifact). See the Queue documentation for more information.\n\nSince: generic-worker 8.1.0",
-                "title": "Name of the artifact",
-                "type": "string"
-              },
-              "path": {
-                "description": "Relative path of the file/directory from the task directory. Note this is not an absolute\npath as is typically used in docker-worker, since the absolute task directory name is not\nknown when the task is submitted. Example: `dist\\regedit.exe`. It doesn't matter if\nforward slashes or backslashes are used.\n\nSince: generic-worker 1.0.0",
-                "title": "Artifact location",
-                "type": "string"
-              },
-              "type": {
-                "description": "Artifacts can be either an individual `file` or a `directory` containing\npotentially multiple files with recursively included subdirectories.\n\nSince: generic-worker 1.0.0",
-                "enum": [
-                  "file",
-                  "directory"
-                ],
-                "title": "Artifact upload type.",
-                "type": "string"
-              }
-            },
-            "required": [
-              "type",
-              "path"
-            ],
-            "title": "Artifact",
-            "type": "object"
-          },
-          "title": "Artifacts to be published",
-          "type": "array",
-          "uniqueItems": true
-        },
-        "command": {
-          "description": "One array per command (each command is an array of arguments). Several arrays\nfor several commands.\n\nSince: generic-worker 0.0.1",
-          "items": {
-            "items": {
-              "type": "string"
-            },
-            "minItems": 1,
-            "type": "array",
-            "uniqueItems": false
-          },
-          "minItems": 1,
-          "title": "Commands to run",
-          "type": "array",
-          "uniqueItems": false
-        },
-        "env": {
-          "additionalProperties": {
-            "type": "string"
-          },
-          "description": "Env vars must be string to __string__ mappings (not number or boolean). For example:\n```\n{\n  \"PATH\": \"/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin\",\n  \"GOOS\": \"darwin\",\n  \"FOO_ENABLE\": \"true\",\n  \"BAR_TOTAL\": \"3\"\n}\n```\n\nNote, the following environment variables will automatically be set in the task\ncommands, but may be overridden by environment variables in the task payload:\n  * `HOME` - the home directory of the task user\n  * `PATH` - `/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin`\n  * `USER` - the name of the task user\n\nThe following environment variables will automatically be set in the task\ncommands, and may not be overridden by environment variables in the task payload:\n  * `DISPLAY` - `:0` (Linux only)\n  * `TASK_ID` - the task ID of the currently running task\n  * `RUN_ID` - the run ID of the currently running task\n  * `TASKCLUSTER_ROOT_URL` - the root URL of the taskcluster deployment\n  * `TASKCLUSTER_PROXY_URL` (if taskcluster proxy feature enabled) - the\n     taskcluster authentication proxy for making unauthenticated taskcluster\n     API calls\n  * `TASK_USER_CREDENTIALS` (if config property `runTasksAsCurrentUser` set to\n    `true` in `generic-worker.config` file - the absolute file location of a\n    json file containing the current task OS user account name and password.\n    This is only useful for the generic-worker multiuser CI tasks, where\n    `runTasksAsCurrentUser` is set to `true`.\n  * `TASKCLUSTER_WORKER_LOCATION`. See\n    [RFC #0148](https://github.com/taskcluster/taskcluster-rfcs/blob/master/rfcs/0148-taskcluster-worker-location.md)\n    for details.\n\nSince: generic-worker 0.0.1",
-          "title": "Env vars",
-          "type": "object"
-        },
-        "features": {
+      "oneOf": [
+        {
           "additionalProperties": false,
-          "description": "Feature flags enable additional functionality.\n\nSince: generic-worker 5.3.0",
+          "description": "This schema defines the structure of the `payload` property referred to in a\nTaskcluster Task definition.",
           "properties": {
-            "backingLog": {
-              "default": true,
-              "description": "The backing log feature publishes a task artifact containing the complete\nstderr and stdout of the task.\n\nSince: generic-worker 48.2.0",
-              "title": "Enable backing log",
-              "type": "boolean"
+            "artifacts": {
+              "description": "Artifacts to be published.\n\nSince: generic-worker 1.0.0",
+              "items": {
+                "additionalProperties": false,
+                "properties": {
+                  "contentEncoding": {
+                    "description": "Content-Encoding for the artifact. If not provided, `gzip` will be used, except for the\nfollowing file extensions, where `identity` will be used, since they are already\ncompressed:\n\n* 7z\n* bz2\n* deb\n* dmg\n* flv\n* gif\n* gz\n* jpeg\n* jpg\n* png\n* swf\n* tbz\n* tgz\n* webp\n* whl\n* woff\n* woff2\n* xz\n* zip\n* zst\n\nNote, setting `contentEncoding` on a directory artifact will apply the same content\nencoding to all the files contained in the directory.\n\nSince: generic-worker 16.2.0",
+                    "enum": [
+                      "identity",
+                      "gzip"
+                    ],
+                    "title": "Content-Encoding header when serving artifact over HTTP.",
+                    "type": "string"
+                  },
+                  "contentType": {
+                    "description": "Explicitly set the value of the HTTP `Content-Type` response header when the artifact(s)\nis/are served over HTTP(S). If not provided (this property is optional) the worker will\nguess the content type of artifacts based on the filename extension of the file storing\nthe artifact content. It does this by looking at the system filename-to-mimetype mappings\ndefined in multiple `mime.types` files located under `/etc`. Note, setting `contentType`\non a directory artifact will apply the same contentType to all files contained in the\ndirectory.\n\nSee [mime.TypeByExtension](https://pkg.go.dev/mime#TypeByExtension).\n\nSince: generic-worker 10.4.0",
+                    "title": "Content-Type header when serving artifact over HTTP",
+                    "type": "string"
+                  },
+                  "expires": {
+                    "description": "Date when artifact should expire must be in the future, no earlier than task deadline, but\nno later than task expiry. If not set, defaults to task expiry.\n\nSince: generic-worker 1.0.0",
+                    "format": "date-time",
+                    "title": "Expiry date and time",
+                    "type": "string"
+                  },
+                  "name": {
+                    "description": "Name of the artifact, as it will be published. If not set, `path` will be used.\nConventionally (although not enforced) path elements are forward slash separated. Example:\n`public/build/a/house`. Note, no scopes are required to read artifacts beginning `public/`.\nArtifact names not beginning `public/` are scope-protected (caller requires scopes to\ndownload the artifact). See the Queue documentation for more information.\n\nSince: generic-worker 8.1.0",
+                    "title": "Name of the artifact",
+                    "type": "string"
+                  },
+                  "path": {
+                    "description": "Relative path of the file/directory from the task directory. Note this is not an absolute\npath as is typically used in docker-worker, since the absolute task directory name is not\nknown when the task is submitted. Example: `dist\\regedit.exe`. It doesn't matter if\nforward slashes or backslashes are used.\n\nSince: generic-worker 1.0.0",
+                    "title": "Artifact location",
+                    "type": "string"
+                  },
+                  "type": {
+                    "description": "Artifacts can be either an individual `file` or a `directory` containing\npotentially multiple files with recursively included subdirectories.\n\nSince: generic-worker 1.0.0",
+                    "enum": [
+                      "file",
+                      "directory"
+                    ],
+                    "title": "Artifact upload type.",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "type",
+                  "path"
+                ],
+                "title": "Artifact",
+                "type": "object"
+              },
+              "title": "Artifacts to be published",
+              "type": "array",
+              "uniqueItems": true
             },
-            "chainOfTrust": {
-              "description": "Artifacts named `public/chain-of-trust.json` and\n`public/chain-of-trust.json.sig` should be generated which will\ninclude information for downstream tasks to build a level of trust\nfor the artifacts produced by the task and the environment it ran in.\n\nSince: generic-worker 5.3.0",
-              "title": "Enable generation of signed Chain of Trust artifacts",
-              "type": "boolean"
+            "command": {
+              "description": "One array per command (each command is an array of arguments). Several arrays\nfor several commands.\n\nSince: generic-worker 0.0.1",
+              "items": {
+                "items": {
+                  "type": "string"
+                },
+                "minItems": 1,
+                "type": "array",
+                "uniqueItems": false
+              },
+              "minItems": 1,
+              "title": "Commands to run",
+              "type": "array",
+              "uniqueItems": false
             },
-            "interactive": {
-              "description": "This allows you to interactively run commands from within the worker\nas the task user. This may be useful for debugging purposes.\nCan be used for SSH-like access to the running worker.\nNote that this feature works differently from the `interactive` feature\nin docker worker, which `docker exec`s into the running container.\nSince tasks on generic worker are not guaranteed to be running in a\ncontainer, a bash shell is started on the task user's account.\nA user can then `docker exec` into the a running container, if there\nis one.\n\nSince: generic-worker 49.2.0",
-              "title": "Interactive shell",
-              "type": "boolean"
+            "env": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "description": "Env vars must be string to __string__ mappings (not number or boolean). For example:\n```\n{\n  \"PATH\": \"/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin\",\n  \"GOOS\": \"darwin\",\n  \"FOO_ENABLE\": \"true\",\n  \"BAR_TOTAL\": \"3\"\n}\n```\n\nNote, the following environment variables will automatically be set in the task\ncommands, but may be overridden by environment variables in the task payload:\n  * `HOME` - the home directory of the task user\n  * `PATH` - `/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin`\n  * `USER` - the name of the task user\n\nThe following environment variables will automatically be set in the task\ncommands, and may not be overridden by environment variables in the task payload:\n  * `DISPLAY` - `:0` (Linux only)\n  * `TASK_ID` - the task ID of the currently running task\n  * `RUN_ID` - the run ID of the currently running task\n  * `TASKCLUSTER_ROOT_URL` - the root URL of the taskcluster deployment\n  * `TASKCLUSTER_PROXY_URL` (if taskcluster proxy feature enabled) - the\n    taskcluster authentication proxy for making unauthenticated taskcluster\n    API calls\n  * `TASK_USER_CREDENTIALS` (if config property `runTasksAsCurrentUser` set to\n    `true` in `generic-worker.config` file - the absolute file location of a\n    json file containing the current task OS user account name and password.\n    This is only useful for the generic-worker multiuser CI tasks, where\n    `runTasksAsCurrentUser` is set to `true`.\n  * `TASKCLUSTER_WORKER_LOCATION`. See\n    [RFC #0148](https://github.com/taskcluster/taskcluster-rfcs/blob/master/rfcs/0148-taskcluster-worker-location.md)\n    for details.\n\nSince: generic-worker 0.0.1",
+              "title": "Env vars",
+              "type": "object"
             },
-            "liveLog": {
-              "default": true,
-              "description": "The live log feature streams the combined stderr and stdout to a task artifact\nso that the output is available while the task is running.\n\nSince: generic-worker 48.2.0",
-              "title": "Enable [livelog](https://github.com/taskcluster/taskcluster/tree/main/tools/livelog)",
-              "type": "boolean"
+            "features": {
+              "additionalProperties": false,
+              "description": "Feature flags enable additional functionality.\n\nSince: generic-worker 5.3.0",
+              "properties": {
+                "backingLog": {
+                  "default": true,
+                  "description": "The backing log feature publishes a task artifact containing the complete\nstderr and stdout of the task.\n\nSince: generic-worker 48.2.0",
+                  "title": "Enable backing log",
+                  "type": "boolean"
+                },
+                "chainOfTrust": {
+                  "description": "Artifacts named `public/chain-of-trust.json` and\n`public/chain-of-trust.json.sig` should be generated which will\ninclude information for downstream tasks to build a level of trust\nfor the artifacts produced by the task and the environment it ran in.\n\nSince: generic-worker 5.3.0",
+                  "title": "Enable generation of signed Chain of Trust artifacts",
+                  "type": "boolean"
+                },
+                "interactive": {
+                  "description": "This allows you to interactively run commands from within the worker\nas the task user. This may be useful for debugging purposes.\nCan be used for SSH-like access to the running worker.\nNote that this feature works differently from the `interactive` feature\nin docker worker, which `docker exec`s into the running container.\nSince tasks on generic worker are not guaranteed to be running in a\ncontainer, a bash shell is started on the task user's account.\nA user can then `docker exec` into the a running container, if there\nis one.\n\nSince: generic-worker 49.2.0",
+                  "title": "Interactive shell",
+                  "type": "boolean"
+                },
+                "liveLog": {
+                  "default": true,
+                  "description": "The live log feature streams the combined stderr and stdout to a task artifact\nso that the output is available while the task is running.\n\nSince: generic-worker 48.2.0",
+                  "title": "Enable [livelog](https://github.com/taskcluster/taskcluster/tree/main/tools/livelog)",
+                  "type": "boolean"
+                },
+                "loopbackVideo": {
+                  "description": "Video loopback device created using v4l2loopback.\nA video device will be available for the task. Its\nlocation will be passed to the task via environment\nvariable `TASKCLUSTER_VIDEO_DEVICE`. The\nlocation will be `/dev/video<N>` where `<N>` is\nan integer between 0 and 255. The value of `<N>`\nis not static, and therefore either the environment\nvariable should be used, or `/dev` should be\nscanned in order to determine the correct location.\nTasks should not assume a constant value.\n\nThis feature is only available on Linux. If a task\nis submitted with this feature enabled on a non-Linux,\nposix platform (FreeBSD, macOS), the task will resolve as\n`exception/malformed-payload`.\n\nSince: generic-worker 53.1.0",
+                  "title": "Loopback Video device",
+                  "type": "boolean"
+                },
+                "taskclusterProxy": {
+                  "description": "The taskcluster proxy provides an easy and safe way to make authenticated\ntaskcluster requests within the scope(s) of a particular task. See\n[the github project](https://github.com/taskcluster/taskcluster/tree/main/tools/taskcluster-proxy) for more information.\n\nSince: generic-worker 10.6.0",
+                  "title": "Run [taskcluster-proxy](https://github.com/taskcluster/taskcluster/tree/main/tools/taskcluster-proxy) to allow tasks to dynamically proxy requests to taskcluster services",
+                  "type": "boolean"
+                }
+              },
+              "required": [
+              ],
+              "title": "Feature flags",
+              "type": "object"
             },
-            "loopbackVideo": {
-              "description": "Video loopback device created using v4l2loopback.\nA video device will be available for the task. Its\nlocation will be passed to the task via environment\nvariable `TASKCLUSTER_VIDEO_DEVICE`. The\nlocation will be `/dev/video<N>` where `<N>` is\nan integer between 0 and 255. The value of `<N>`\nis not static, and therefore either the environment\nvariable should be used, or `/dev` should be\nscanned in order to determine the correct location.\nTasks should not assume a constant value.\n\nThis feature is only available on Linux. If a task\nis submitted with this feature enabled on a non-Linux,\nposix platform (FreeBSD, macOS), the task will resolve as\n`exception/malformed-payload`.\n\nSince: generic-worker 53.1.0",
-              "title": "Loopback Video device",
-              "type": "boolean"
+            "logs": {
+              "additionalProperties": false,
+              "description": "Configuration for task logs.\n\nSince: generic-worker 48.2.0",
+              "properties": {
+                "backing": {
+                  "default": "public/logs/live_backing.log",
+                  "description": "Specifies a custom name for the backing log artifact.\nThis is only used if `features.backingLog` is `true`.\n\nSince: generic-worker 48.2.0",
+                  "title": "Backing log artifact name",
+                  "type": "string"
+                },
+                "live": {
+                  "default": "public/logs/live.log",
+                  "description": "Specifies a custom name for the live log artifact.\nThis is only used if `features.liveLog` is `true`.\n\nSince: generic-worker 48.2.0",
+                  "title": "Live log artifact name",
+                  "type": "string"
+                }
+              },
+              "required": [
+              ],
+              "title": "Logs",
+              "type": "object"
             },
-            "taskclusterProxy": {
-              "description": "The taskcluster proxy provides an easy and safe way to make authenticated\ntaskcluster requests within the scope(s) of a particular task. See\n[the github project](https://github.com/taskcluster/taskcluster/tree/main/tools/taskcluster-proxy) for more information.\n\nSince: generic-worker 10.6.0",
-              "title": "Run [taskcluster-proxy](https://github.com/taskcluster/taskcluster/tree/main/tools/taskcluster-proxy) to allow tasks to dynamically proxy requests to taskcluster services",
-              "type": "boolean"
+            "maxRunTime": {
+              "description": "Maximum time the task container can run in seconds.\n\nSince: generic-worker 0.0.1",
+              "maximum": 86400,
+              "minimum": 1,
+              "multipleOf": 1,
+              "title": "Maximum run time in seconds",
+              "type": "integer"
+            },
+            "mounts": {
+              "description": "Directories and/or files to be mounted.\n\nSince: generic-worker 5.4.0",
+              "items": {
+                "$ref": "#/definitions/mount",
+                "title": "Mount"
+              },
+              "type": "array",
+              "uniqueItems": false
+            },
+            "onExitStatus": {
+              "additionalProperties": false,
+              "description": "By default tasks will be resolved with `state/reasonResolved`: `completed/completed`\nif all task commands have a zero exit code, or `failed/failed` if any command has a\nnon-zero exit code. This payload property allows customsation of the task resolution\nbased on exit code of task commands.",
+              "properties": {
+                "purgeCaches": {
+                  "description": "If the task exists with a purge caches exit status, all caches\nassociated with the task will be purged.\n\nSince: generic-worker 49.0.0",
+                  "items": {
+                    "minimum": 1,
+                    "title": "Exit statuses",
+                    "type": "integer"
+                  },
+                  "title": "Purge caches exit status",
+                  "type": "array",
+                  "uniqueItems": true
+                },
+                "retry": {
+                  "description": "Exit codes for any command in the task payload to cause this task to\nbe resolved as `exception/intermittent-task`. Typically the Queue\nwill then schedule a new run of the existing `taskId` (rerun) if not\nall task runs have been exhausted.\n\nSee [itermittent tasks](https://docs.taskcluster.net/docs/reference/platform/taskcluster-queue/docs/worker-interaction#intermittent-tasks) for more detail.\n\nSince: generic-worker 10.10.0",
+                  "items": {
+                    "minimum": 1,
+                    "title": "Exit codes",
+                    "type": "integer"
+                  },
+                  "title": "Intermittent task exit codes",
+                  "type": "array",
+                  "uniqueItems": true
+                }
+              },
+              "required": [
+              ],
+              "title": "Exit code handling",
+              "type": "object"
+            },
+            "osGroups": {
+              "description": "A list of OS Groups that the task user should be a member of. Not yet implemented on\nnon-Windows platforms, therefore this optional property may only be an empty array if\nprovided.\n\nSince: generic-worker 6.0.0",
+              "items": {
+                "type": "string"
+              },
+              "maxItems": 0,
+              "title": "OS Groups",
+              "type": "array",
+              "uniqueItems": false
+            },
+            "supersederUrl": {
+              "description": "This property is allowed for backward compatibility, but is unused.",
+              "title": "unused",
+              "type": "string"
             }
           },
           "required": [
+            "command",
+            "maxRunTime"
           ],
-          "title": "Feature flags",
+          "title": "Generic worker payload",
           "type": "object"
         },
-        "logs": {
+        {
           "additionalProperties": false,
-          "description": "Configuration for task logs.\n\nSince: generic-worker 48.2.0",
+          "description": "`.payload` field of the queue.",
           "properties": {
-            "backing": {
-              "default": "public/logs/live_backing.log",
-              "description": "Specifies a custom name for the backing log artifact.\nThis is only used if `features.backingLog` is `true`.\n\nSince: generic-worker 48.2.0",
-              "title": "Backing log artifact name",
-              "type": "string"
+            "artifacts": {
+              "additionalProperties": {
+                "$ref": "#/definitions/artifact"
+              },
+              "description": "Artifact upload map example: ```{\"public/build.tar.gz\": {\"path\": \"/home/worker/build.tar.gz\", \"expires\": \"2016-05-28T16:12:56.693817Z\", \"type\": \"file\"}}```",
+              "title": "Artifacts",
+              "type": "object"
             },
-            "live": {
+            "cache": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "description": "Caches are mounted within the docker container at the mount point specified. Example: ```{ \"CACHE NAME\": \"/mount/path/in/container\" }```",
+              "title": "Caches to mount point mapping.",
+              "type": "object"
+            },
+            "capabilities": {
+              "additionalProperties": false,
+              "description": "Set of capabilities that must be enabled or made available to the task container Example: ```{ \"capabilities\": { \"privileged\": true }```",
+              "properties": {
+                "devices": {
+                  "additionalProperties": false,
+                  "description": "Allows devices from the host system to be attached to a task container similar to using `--device` in docker.",
+                  "properties": {
+                    "hostSharedMemory": {
+                      "description": "Mount /dev/shm from the host in the container.",
+                      "title": "Host shared memory device (Experimental)",
+                      "type": "boolean"
+                    },
+                    "kvm": {
+                      "description": "Mount /dev/kvm from the host in the container.",
+                      "title": "/dev/kvm device (Experimental)",
+                      "type": "boolean"
+                    },
+                    "loopbackAudio": {
+                      "description": "Audio loopback device created using snd-aloop",
+                      "title": "Loopback Audio device",
+                      "type": "boolean"
+                    },
+                    "loopbackVideo": {
+                      "description": "Video loopback device created using v4l2loopback.",
+                      "title": "Loopback Video device",
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                  ],
+                  "title": "Devices to be attached to task containers",
+                  "type": "object"
+                },
+                "privileged": {
+                  "default": false,
+                  "description": "Allows a task to run in a privileged container, similar to running docker with `--privileged`.  This only works for worker-types configured to enable it.",
+                  "title": "Privileged container",
+                  "type": "boolean"
+                }
+              },
+              "required": [
+              ],
+              "title": "Capabilities that must be available/enabled for the task container.",
+              "type": "object"
+            },
+            "command": {
+              "default": [
+              ],
+              "description": "Example: `['/bin/bash', '-c', 'ls']`.",
+              "items": {
+                "type": "string"
+              },
+              "title": "Docker command to run (see docker api).",
+              "type": "array"
+            },
+            "env": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "description": "Example: ```\n{\n  \"PATH\": '/borked/path'\n  \"ENV_NAME\": \"VALUE\"\n}\n```",
+              "title": "Environment variable mappings.",
+              "type": "object"
+            },
+            "features": {
+              "additionalProperties": false,
+              "description": "Used to enable additional functionality.",
+              "properties": {
+                "allowPtrace": {
+                  "default": false,
+                  "description": "This allows you to use the Linux ptrace functionality inside the container; it is otherwise disallowed by Docker's security policy.",
+                  "title": "Allow ptrace within the container",
+                  "type": "boolean"
+                },
+                "artifacts": {
+                  "default": true,
+                  "description": "",
+                  "title": "Artifact uploads",
+                  "type": "boolean"
+                },
+                "bulkLog": {
+                  "default": true,
+                  "description": "Useful if live logging is not interesting but the overalllog is later on",
+                  "title": "Bulk upload the task log into a single artifact",
+                  "type": "boolean"
+                },
+                "chainOfTrust": {
+                  "default": false,
+                  "description": "Artifacts named chain-of-trust.json and chain-of-trust.json.sig should be generated which will include information for downstream tasks to build a level of trust for the artifacts produced by the task and the environment it ran in.",
+                  "title": "Enable generation of ed25519-signed Chain of Trust artifacts",
+                  "type": "boolean"
+                },
+                "dind": {
+                  "default": false,
+                  "description": "Runs docker-in-docker and binds `/var/run/docker.sock` into the container. Doesn't allow privileged mode, capabilities or host volume mounts.",
+                  "title": "Docker in Docker",
+                  "type": "boolean"
+                },
+                "dockerSave": {
+                  "default": false,
+                  "description": "Uploads docker images as artifacts",
+                  "title": "Docker save",
+                  "type": "boolean"
+                },
+                "interactive": {
+                  "default": false,
+                  "description": "This allows you to interactively run commands inside the container and attaches you to the stdin/stdout/stderr over a websocket. Can be used for SSH-like access to docker containers.",
+                  "title": "Docker Exec Interactive",
+                  "type": "boolean"
+                },
+                "localLiveLog": {
+                  "default": true,
+                  "description": "Logs are stored on the worker during the duration of tasks and available via http chunked streaming then uploaded to s3",
+                  "title": "Enable live logging (worker local)",
+                  "type": "boolean"
+                },
+                "taskclusterProxy": {
+                  "default": false,
+                  "description": "The auth proxy allows making requests to taskcluster/queue and taskcluster/scheduler directly from your task with the same scopes as set in the task. This can be used to make api calls via the [client](https://github.com/taskcluster/taskcluster-client) CURL, etc... Without embedding credentials in the task.",
+                  "title": "Taskcluster auth proxy service",
+                  "type": "boolean"
+                }
+              },
+              "required": [
+              ],
+              "title": "Docker Worker feature flags",
+              "type": "object"
+            },
+            "image": {
+              "description": "Image to use for the task.  Images can be specified as an image tag as used by a docker registry, or as an object declaring type and name/namespace",
+              "oneOf": [
+                {
+                  "title": "Docker image name",
+                  "type": "string"
+                },
+                {
+                  "additionalProperties": false,
+                  "properties": {
+                    "name": {
+                      "type": "string"
+                    },
+                    "type": {
+                      "enum": [
+                        "docker-image"
+                      ],
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "type",
+                    "name"
+                  ],
+                  "title": "Named docker image",
+                  "type": "object"
+                },
+                {
+                  "additionalProperties": false,
+                  "properties": {
+                    "namespace": {
+                      "type": "string"
+                    },
+                    "path": {
+                      "type": "string"
+                    },
+                    "type": {
+                      "enum": [
+                        "indexed-image"
+                      ],
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "type",
+                    "namespace",
+                    "path"
+                  ],
+                  "title": "Indexed docker image",
+                  "type": "object"
+                },
+                {
+                  "additionalProperties": false,
+                  "properties": {
+                    "path": {
+                      "type": "string"
+                    },
+                    "taskId": {
+                      "type": "string"
+                    },
+                    "type": {
+                      "enum": [
+                        "task-image"
+                      ],
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "type",
+                    "taskId",
+                    "path"
+                  ],
+                  "title": "Docker image artifact",
+                  "type": "object"
+                }
+              ],
+              "title": "Docker image."
+            },
+            "log": {
               "default": "public/logs/live.log",
-              "description": "Specifies a custom name for the live log artifact.\nThis is only used if `features.liveLog` is `true`.\n\nSince: generic-worker 48.2.0",
-              "title": "Live log artifact name",
+              "description": "Specifies a custom name for the livelog artifact. Note that this is also used in determining the name of the backing log artifact name. Backing log artifact name matches livelog artifact name with `_backing` appended, prior to the file extension (if present). For example, `apple/banana.log.txt` results in livelog artifact `apple/banana.log.txt` and backing log artifact `apple/banana.log_backing.txt`. Defaults to `public/logs/live.log`.",
+              "title": "Livelog artifact name",
+              "type": "string"
+            },
+            "maxRunTime": {
+              "description": "Maximum time the task container can run in seconds.",
+              "maximum": 86400,
+              "minimum": 1,
+              "multipleOf": 1,
+              "title": "Maximum run time in seconds",
+              "type": "integer"
+            },
+            "onExitStatus": {
+              "additionalProperties": false,
+              "description": "By default docker-worker will fail a task with a non-zero exit status without retrying.  This payload property allows a task owner to define certain exit statuses that will be marked as a retriable exception.",
+              "properties": {
+                "purgeCaches": {
+                  "description": "If the task exists with a purge caches exit status, all caches associated with the task will be purged.",
+                  "items": {
+                    "title": "Exit statuses",
+                    "type": "integer"
+                  },
+                  "title": "Purge caches exit status",
+                  "type": "array"
+                },
+                "retry": {
+                  "description": "If the task exists with a retriable exit status, the task will be marked as an exception and a new run created.",
+                  "items": {
+                    "title": "Exit statuses",
+                    "type": "integer"
+                  },
+                  "title": "Retriable exit statuses",
+                  "type": "array"
+                }
+              },
+              "required": [
+              ],
+              "title": "Exit status handling",
+              "type": "object"
+            },
+            "supersederUrl": {
+              "description": "Maintained for backward compatibility, but no longer used",
+              "title": "(unused)",
               "type": "string"
             }
           },
           "required": [
+            "image",
+            "maxRunTime"
           ],
-          "title": "Logs",
+          "title": "Docker worker payload",
           "type": "object"
-        },
-        "maxRunTime": {
-          "description": "Maximum time the task container can run in seconds.\n\nSince: generic-worker 0.0.1",
-          "maximum": 86400,
-          "minimum": 1,
-          "multipleOf": 1,
-          "title": "Maximum run time in seconds",
-          "type": "integer"
-        },
-        "mounts": {
-          "description": "Directories and/or files to be mounted.\n\nSince: generic-worker 5.4.0",
-          "items": {
-            "$ref": "#/definitions/mount",
-            "title": "Mount"
-          },
-          "type": "array",
-          "uniqueItems": false
-        },
-        "onExitStatus": {
-          "additionalProperties": false,
-          "description": "By default tasks will be resolved with `state/reasonResolved`: `completed/completed`\nif all task commands have a zero exit code, or `failed/failed` if any command has a\nnon-zero exit code. This payload property allows customsation of the task resolution\nbased on exit code of task commands.",
-          "properties": {
-            "purgeCaches": {
-              "description": "If the task exists with a purge caches exit status, all caches\nassociated with the task will be purged.\n\nSince: generic-worker 49.0.0",
-              "items": {
-                "minimum": 1,
-                "title": "Exit statuses",
-                "type": "integer"
-              },
-              "title": "Purge caches exit status",
-              "type": "array",
-              "uniqueItems": true
-            },
-            "retry": {
-              "description": "Exit codes for any command in the task payload to cause this task to\nbe resolved as `exception/intermittent-task`. Typically the Queue\nwill then schedule a new run of the existing `taskId` (rerun) if not\nall task runs have been exhausted.\n\nSee [itermittent tasks](https://docs.taskcluster.net/docs/reference/platform/taskcluster-queue/docs/worker-interaction#intermittent-tasks) for more detail.\n\nSince: generic-worker 10.10.0",
-              "items": {
-                "minimum": 1,
-                "title": "Exit codes",
-                "type": "integer"
-              },
-              "title": "Intermittent task exit codes",
-              "type": "array",
-              "uniqueItems": true
-            }
-          },
-          "required": [
-          ],
-          "title": "Exit code handling",
-          "type": "object"
-        },
-        "osGroups": {
-          "description": "A list of OS Groups that the task user should be a member of. Not yet implemented on\nnon-Windows platforms, therefore this optional property may only be an empty array if\nprovided.\n\nSince: generic-worker 6.0.0",
-          "items": {
-            "type": "string"
-          },
-          "maxItems": 0,
-          "title": "OS Groups",
-          "type": "array",
-          "uniqueItems": false
-        },
-        "supersederUrl": {
-          "description": "This property is allowed for backward compatibility, but is unused.",
-          "title": "unused",
-          "type": "string"
         }
-      },
-      "required": [
-        "command",
-        "maxRunTime"
       ],
-      "title": "Generic worker payload - multiuser, posix",
-      "type": "object"
+      "title": "Payload - multiuser, posix"
     },
     "filename": "schemas/generic-worker/multiuser_posix.json"
   },

--- a/taskcluster/ci/go/kind.yml
+++ b/taskcluster/ci/go/kind.yml
@@ -64,7 +64,6 @@ tasks:
           go test -v ./...
           ../../golangci-lint/golangci-lint-$GOLANGCI_LINT_VERSION-*/golangci-lint run --timeout=5m
           cd d2g
-          go install github.com/taskcluster/taskcluster/v54/workers/generic-worker/gw-codegen@latest
           go generate ./...
           go mod tidy
           git status

--- a/tools/d2g/d2g.go
+++ b/tools/d2g/d2g.go
@@ -1,5 +1,5 @@
-//go:generate gw-codegen file://../../workers/docker-worker/schemas/v1/payload.yml dockerworker/generated_types.go
-//go:generate gw-codegen file://../../workers/generic-worker/schemas/multiuser_posix.yml genericworker/generated_types.go
+//go:generate go run ../../workers/generic-worker/gw-codegen file://../../workers/docker-worker/schemas/v1/payload.yml dockerworker/generated_types.go
+//go:generate go run ../../workers/generic-worker/gw-codegen file://../../workers/generic-worker/schemas/multiuser_posix.yml genericworker/generated_types.go
 
 package d2g
 

--- a/tools/d2g/d2gtest/d2g_test.go
+++ b/tools/d2g/d2gtest/d2g_test.go
@@ -1,4 +1,4 @@
-//go:generate gw-codegen file://schemas/test_suites.yml generated_types.go
+//go:generate go run ../../../workers/generic-worker/gw-codegen file://schemas/test_suites.yml generated_types.go
 
 package d2gtest
 

--- a/tools/jsonschema2go/jsonschema.go
+++ b/tools/jsonschema2go/jsonschema.go
@@ -1050,17 +1050,17 @@ func jsonRawMessageImplementors(rawMessageTypes StringSet) string {
 
 	// MarshalJSON calls json.RawMessage method of the same name. Required since
 	// ` + goType + ` is of type json.RawMessage...
-	func (this *` + goType + `) MarshalJSON() ([]byte, error) {
-		x := json.RawMessage(*this)
+	func (m *` + goType + `) MarshalJSON() ([]byte, error) {
+		x := json.RawMessage(*m)
 		return (&x).MarshalJSON()
 	}
 
 	// UnmarshalJSON is a copy of the json.RawMessage implementation.
-	func (this *` + goType + `) UnmarshalJSON(data []byte) error {
-		if this == nil {
+	func (m *` + goType + `) UnmarshalJSON(data []byte) error {
+		if m == nil {
 			return errors.New("` + goType + `: UnmarshalJSON on nil pointer")
 		}
-		*this = append((*this)[0:0], data...)
+		*m = append((*m)[0:0], data...)
 		return nil
 	}`
 	}

--- a/ui/docs/reference/workers/generic-worker/README.mdx
+++ b/ui/docs/reference/workers/generic-worker/README.mdx
@@ -17,7 +17,7 @@ Depending on the operating system of the worker, and the generic-worker engine t
 Please see the following pages for guidance:
 
 <!-- BEGIN PAYLOAD LINKS -->
- * [Generic worker payload - multiuser, posix](/docs/reference/workers/generic-worker/multiuser-posix-payload)
+ * [Payload - multiuser, posix](/docs/reference/workers/generic-worker/multiuser-posix-payload)
  * [Generic worker payload - multiuser, windows](/docs/reference/workers/generic-worker/multiuser-windows-payload)
  * [Generic worker payload - simple, posix](/docs/reference/workers/generic-worker/simple-posix-payload)
 <!-- END PAYLOAD LINKS -->

--- a/workers/generic-worker/d2g_test.go
+++ b/workers/generic-worker/d2g_test.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"runtime"
+	"testing"
+
+	"github.com/mcuadros/go-defaults"
+	"github.com/taskcluster/taskcluster/v54/tools/d2g/dockerworker"
+)
+
+func TestWithValidDockerWorkerPayload(t *testing.T) {
+	setup(t)
+	image := map[string]interface{}{
+		"name": "ubuntu:latest",
+		"type": "docker-image",
+	}
+	imageBytes, err := json.Marshal(image)
+	if err != nil {
+		t.Fatalf("Error marshaling JSON: %v", err)
+	}
+	payload := dockerworker.DockerWorkerPayload{
+		Command:    []string{"/bin/bash", "-c", "echo hello world"},
+		Image:      json.RawMessage(imageBytes),
+		MaxRunTime: 10,
+	}
+	defaults.SetDefaults(&payload)
+	td := testTask(t)
+
+	switch fmt.Sprintf("%s:%s", runtime.GOOS, engine) {
+	case "linux:multiuser":
+		_ = submitAndAssert(t, td, payload, "completed", "completed")
+	default:
+		_ = submitAndAssert(t, td, payload, "exception", "malformed-payload")
+	}
+}
+
+func TestWithInvalidDockerWorkerPayload(t *testing.T) {
+	setup(t)
+	image := map[string]interface{}{
+		"name": "ubuntu:latest",
+		"type": "docker-image",
+	}
+	imageBytes, err := json.Marshal(image)
+	if err != nil {
+		t.Fatalf("Error marshaling JSON: %v", err)
+	}
+	payload := dockerworker.DockerWorkerPayload{
+		Command: []string{"/bin/bash", "-c", "echo hello world"},
+		Image:   json.RawMessage(imageBytes),
+	}
+	defaults.SetDefaults(&payload)
+	td := testTask(t)
+
+	_ = submitAndAssert(t, td, payload, "exception", "malformed-payload")
+}

--- a/workers/generic-worker/generated_multiuser_darwin.go
+++ b/workers/generic-worker/generated_multiuser_darwin.go
@@ -6,6 +6,7 @@ package main
 
 import (
 	"encoding/json"
+	"errors"
 
 	tcclient "github.com/taskcluster/taskcluster/v54/clients/client-go"
 )
@@ -128,6 +129,167 @@ type (
 		Base64 string `json:"base64"`
 	}
 
+	// Set of capabilities that must be enabled or made available to the task container Example: ```{ "capabilities": { "privileged": true }```
+	Capabilities struct {
+
+		// Allows devices from the host system to be attached to a task container similar to using `--device` in docker.
+		Devices Devices `json:"devices,omitempty"`
+
+		// Allows a task to run in a privileged container, similar to running docker with `--privileged`.  This only works for worker-types configured to enable it.
+		//
+		// Default:    false
+		Privileged bool `json:"privileged" default:"false"`
+	}
+
+	// Allows devices from the host system to be attached to a task container similar to using `--device` in docker.
+	Devices struct {
+
+		// Mount /dev/shm from the host in the container.
+		HostSharedMemory bool `json:"hostSharedMemory,omitempty"`
+
+		// Mount /dev/kvm from the host in the container.
+		KVM bool `json:"kvm,omitempty"`
+
+		// Audio loopback device created using snd-aloop
+		LoopbackAudio bool `json:"loopbackAudio,omitempty"`
+
+		// Video loopback device created using v4l2loopback.
+		LoopbackVideo bool `json:"loopbackVideo,omitempty"`
+	}
+
+	// Image to use for the task.  Images can be specified as an image tag as used by a docker registry, or as an object declaring type and name/namespace
+	DockerImageArtifact struct {
+		Path string `json:"path"`
+
+		TaskID string `json:"taskId"`
+
+		// Possible values:
+		//   * "task-image"
+		Type string `json:"type"`
+	}
+
+	// Image to use for the task.  Images can be specified as an image tag as used by a docker registry, or as an object declaring type and name/namespace
+	DockerImageName string
+
+	DockerWorkerArtifact struct {
+		Expires tcclient.Time `json:"expires,omitempty"`
+
+		Path string `json:"path"`
+
+		// Possible values:
+		//   * "file"
+		//   * "directory"
+		Type string `json:"type"`
+	}
+
+	// Used to enable additional functionality.
+	DockerWorkerFeatureFlags struct {
+
+		// This allows you to use the Linux ptrace functionality inside the container; it is otherwise disallowed by Docker's security policy.
+		//
+		// Default:    false
+		AllowPtrace bool `json:"allowPtrace" default:"false"`
+
+		// Default:    true
+		Artifacts bool `json:"artifacts" default:"true"`
+
+		// Useful if live logging is not interesting but the overalllog is later on
+		//
+		// Default:    true
+		BulkLog bool `json:"bulkLog" default:"true"`
+
+		// Artifacts named chain-of-trust.json and chain-of-trust.json.sig should be generated which will include information for downstream tasks to build a level of trust for the artifacts produced by the task and the environment it ran in.
+		//
+		// Default:    false
+		ChainOfTrust bool `json:"chainOfTrust" default:"false"`
+
+		// Runs docker-in-docker and binds `/var/run/docker.sock` into the container. Doesn't allow privileged mode, capabilities or host volume mounts.
+		//
+		// Default:    false
+		Dind bool `json:"dind" default:"false"`
+
+		// Uploads docker images as artifacts
+		//
+		// Default:    false
+		DockerSave bool `json:"dockerSave" default:"false"`
+
+		// This allows you to interactively run commands inside the container and attaches you to the stdin/stdout/stderr over a websocket. Can be used for SSH-like access to docker containers.
+		//
+		// Default:    false
+		Interactive bool `json:"interactive" default:"false"`
+
+		// Logs are stored on the worker during the duration of tasks and available via http chunked streaming then uploaded to s3
+		//
+		// Default:    true
+		LocalLiveLog bool `json:"localLiveLog" default:"true"`
+
+		// The auth proxy allows making requests to taskcluster/queue and taskcluster/scheduler directly from your task with the same scopes as set in the task. This can be used to make api calls via the [client](https://github.com/taskcluster/taskcluster-client) CURL, etc... Without embedding credentials in the task.
+		//
+		// Default:    false
+		TaskclusterProxy bool `json:"taskclusterProxy" default:"false"`
+	}
+
+	// `.payload` field of the queue.
+	DockerWorkerPayload struct {
+
+		// Artifact upload map example: ```{"public/build.tar.gz": {"path": "/home/worker/build.tar.gz", "expires": "2016-05-28T16:12:56.693817Z", "type": "file"}}```
+		Artifacts map[string]DockerWorkerArtifact `json:"artifacts,omitempty"`
+
+		// Caches are mounted within the docker container at the mount point specified. Example: ```{ "CACHE NAME": "/mount/path/in/container" }```
+		//
+		// Map entries:
+		Cache map[string]string `json:"cache,omitempty"`
+
+		// Set of capabilities that must be enabled or made available to the task container Example: ```{ "capabilities": { "privileged": true }```
+		Capabilities Capabilities `json:"capabilities,omitempty"`
+
+		// Example: `['/bin/bash', '-c', 'ls']`.
+		//
+		// Default:    []
+		//
+		// Array items:
+		Command []string `json:"command,omitempty"`
+
+		// Example: ```
+		// {
+		//   "PATH": '/borked/path'
+		//   "ENV_NAME": "VALUE"
+		// }
+		// ```
+		//
+		// Map entries:
+		Env map[string]string `json:"env,omitempty"`
+
+		// Used to enable additional functionality.
+		Features DockerWorkerFeatureFlags `json:"features,omitempty"`
+
+		// Image to use for the task.  Images can be specified as an image tag as used by a docker registry, or as an object declaring type and name/namespace
+		//
+		// One of:
+		//   * DockerImageName
+		//   * NamedDockerImage
+		//   * IndexedDockerImage
+		//   * DockerImageArtifact
+		Image json.RawMessage `json:"image"`
+
+		// Specifies a custom name for the livelog artifact. Note that this is also used in determining the name of the backing log artifact name. Backing log artifact name matches livelog artifact name with `_backing` appended, prior to the file extension (if present). For example, `apple/banana.log.txt` results in livelog artifact `apple/banana.log.txt` and backing log artifact `apple/banana.log_backing.txt`. Defaults to `public/logs/live.log`.
+		//
+		// Default:    "public/logs/live.log"
+		Log string `json:"log" default:"public/logs/live.log"`
+
+		// Maximum time the task container can run in seconds.
+		//
+		// Mininum:    1
+		// Maximum:    86400
+		MaxRunTime int64 `json:"maxRunTime"`
+
+		// By default docker-worker will fail a task with a non-zero exit status without retrying.  This payload property allows a task owner to define certain exit statuses that will be marked as a retriable exception.
+		OnExitStatus ExitStatusHandling `json:"onExitStatus,omitempty"`
+
+		// Maintained for backward compatibility, but no longer used
+		SupersederURL string `json:"supersederUrl,omitempty"`
+	}
+
 	// By default tasks will be resolved with `state/reasonResolved`: `completed/completed`
 	// if all task commands have a zero exit code, or `failed/failed` if any command has a
 	// non-zero exit code. This payload property allows customsation of the task resolution
@@ -154,6 +316,20 @@ type (
 		//
 		// Array items:
 		// Mininum:    1
+		Retry []int64 `json:"retry,omitempty"`
+	}
+
+	// By default docker-worker will fail a task with a non-zero exit status without retrying.  This payload property allows a task owner to define certain exit statuses that will be marked as a retriable exception.
+	ExitStatusHandling struct {
+
+		// If the task exists with a purge caches exit status, all caches associated with the task will be purged.
+		//
+		// Array items:
+		PurgeCaches []int64 `json:"purgeCaches,omitempty"`
+
+		// If the task exists with a retriable exit status, the task will be marked as an exception and a new run created.
+		//
+		// Array items:
 		Retry []int64 `json:"retry,omitempty"`
 	}
 
@@ -283,8 +459,8 @@ type (
 		//   * `RUN_ID` - the run ID of the currently running task
 		//   * `TASKCLUSTER_ROOT_URL` - the root URL of the taskcluster deployment
 		//   * `TASKCLUSTER_PROXY_URL` (if taskcluster proxy feature enabled) - the
-		//      taskcluster authentication proxy for making unauthenticated taskcluster
-		//      API calls
+		//     taskcluster authentication proxy for making unauthenticated taskcluster
+		//     API calls
 		//   * `TASK_USER_CREDENTIALS` (if config property `runTasksAsCurrentUser` set to
 		//     `true` in `generic-worker.config` file - the absolute file location of a
 		//     json file containing the current task OS user account name and password.
@@ -359,6 +535,17 @@ type (
 		Namespace string `json:"namespace"`
 	}
 
+	// Image to use for the task.  Images can be specified as an image tag as used by a docker registry, or as an object declaring type and name/namespace
+	IndexedDockerImage struct {
+		Namespace string `json:"namespace"`
+
+		Path string `json:"path"`
+
+		// Possible values:
+		//   * "indexed-image"
+		Type string `json:"type"`
+	}
+
 	// Configuration for task logs.
 	//
 	// Since: generic-worker 48.2.0
@@ -380,6 +567,20 @@ type (
 		// Default:    "public/logs/live.log"
 		Live string `json:"live" default:"public/logs/live.log"`
 	}
+
+	// Image to use for the task.  Images can be specified as an image tag as used by a docker registry, or as an object declaring type and name/namespace
+	NamedDockerImage struct {
+		Name string `json:"name"`
+
+		// Possible values:
+		//   * "docker-image"
+		Type string `json:"type"`
+	}
+
+	// One of:
+	//   * GenericWorkerPayload
+	//   * DockerWorkerPayload
+	Payload json.RawMessage
 
 	// Byte-for-byte literal inline content of file/archive, up to 64KB in size.
 	//
@@ -479,6 +680,22 @@ type (
 	}
 )
 
+// MarshalJSON calls json.RawMessage method of the same name. Required since
+// Payload is of type json.RawMessage...
+func (m *Payload) MarshalJSON() ([]byte, error) {
+	x := json.RawMessage(*m)
+	return (&x).MarshalJSON()
+}
+
+// UnmarshalJSON is a copy of the json.RawMessage implementation.
+func (m *Payload) UnmarshalJSON(data []byte) error {
+	if m == nil {
+		return errors.New("Payload: UnmarshalJSON on nil pointer")
+	}
+	*m = append((*m)[0:0], data...)
+	return nil
+}
+
 // Returns json schema for the payload part of the task definition. Please
 // note we use a go string and do not load an external file, since we want this
 // to be *part of the compiled executable*. If this sat in another file that
@@ -495,8 +712,35 @@ func JSONSchema() string {
 	return `{
   "$id": "/schemas/generic-worker/multiuser_posix.json#",
   "$schema": "/schemas/common/metaschema.json#",
-  "additionalProperties": false,
   "definitions": {
+    "artifact": {
+      "additionalProperties": false,
+      "properties": {
+        "expires": {
+          "format": "date-time",
+          "title": "Date when artifact should expire must be in the future.",
+          "type": "string"
+        },
+        "path": {
+          "title": "Location of artifact in container, as an absolute path.",
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "file",
+            "directory"
+          ],
+          "title": "Artifact upload type.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "type",
+        "path"
+      ],
+      "title": "Docker Worker Artifact",
+      "type": "object"
+    },
     "content": {
       "oneOf": [
         {
@@ -722,218 +966,500 @@ func JSONSchema() string {
       "type": "object"
     }
   },
-  "description": "This schema defines the structure of the ` + "`" + `payload` + "`" + ` property referred to in a\nTaskcluster Task definition.",
-  "properties": {
-    "artifacts": {
-      "description": "Artifacts to be published.\n\nSince: generic-worker 1.0.0",
-      "items": {
-        "additionalProperties": false,
-        "properties": {
-          "contentEncoding": {
-            "description": "Content-Encoding for the artifact. If not provided, ` + "`" + `gzip` + "`" + ` will be used, except for the\nfollowing file extensions, where ` + "`" + `identity` + "`" + ` will be used, since they are already\ncompressed:\n\n* 7z\n* bz2\n* deb\n* dmg\n* flv\n* gif\n* gz\n* jpeg\n* jpg\n* png\n* swf\n* tbz\n* tgz\n* webp\n* whl\n* woff\n* woff2\n* xz\n* zip\n* zst\n\nNote, setting ` + "`" + `contentEncoding` + "`" + ` on a directory artifact will apply the same content\nencoding to all the files contained in the directory.\n\nSince: generic-worker 16.2.0",
-            "enum": [
-              "identity",
-              "gzip"
-            ],
-            "title": "Content-Encoding header when serving artifact over HTTP.",
-            "type": "string"
-          },
-          "contentType": {
-            "description": "Explicitly set the value of the HTTP ` + "`" + `Content-Type` + "`" + ` response header when the artifact(s)\nis/are served over HTTP(S). If not provided (this property is optional) the worker will\nguess the content type of artifacts based on the filename extension of the file storing\nthe artifact content. It does this by looking at the system filename-to-mimetype mappings\ndefined in multiple ` + "`" + `mime.types` + "`" + ` files located under ` + "`" + `/etc` + "`" + `. Note, setting ` + "`" + `contentType` + "`" + `\non a directory artifact will apply the same contentType to all files contained in the\ndirectory.\n\nSee [mime.TypeByExtension](https://pkg.go.dev/mime#TypeByExtension).\n\nSince: generic-worker 10.4.0",
-            "title": "Content-Type header when serving artifact over HTTP",
-            "type": "string"
-          },
-          "expires": {
-            "description": "Date when artifact should expire must be in the future, no earlier than task deadline, but\nno later than task expiry. If not set, defaults to task expiry.\n\nSince: generic-worker 1.0.0",
-            "format": "date-time",
-            "title": "Expiry date and time",
-            "type": "string"
-          },
-          "name": {
-            "description": "Name of the artifact, as it will be published. If not set, ` + "`" + `path` + "`" + ` will be used.\nConventionally (although not enforced) path elements are forward slash separated. Example:\n` + "`" + `public/build/a/house` + "`" + `. Note, no scopes are required to read artifacts beginning ` + "`" + `public/` + "`" + `.\nArtifact names not beginning ` + "`" + `public/` + "`" + ` are scope-protected (caller requires scopes to\ndownload the artifact). See the Queue documentation for more information.\n\nSince: generic-worker 8.1.0",
-            "title": "Name of the artifact",
-            "type": "string"
-          },
-          "path": {
-            "description": "Relative path of the file/directory from the task directory. Note this is not an absolute\npath as is typically used in docker-worker, since the absolute task directory name is not\nknown when the task is submitted. Example: ` + "`" + `dist\\regedit.exe` + "`" + `. It doesn't matter if\nforward slashes or backslashes are used.\n\nSince: generic-worker 1.0.0",
-            "title": "Artifact location",
-            "type": "string"
-          },
-          "type": {
-            "description": "Artifacts can be either an individual ` + "`" + `file` + "`" + ` or a ` + "`" + `directory` + "`" + ` containing\npotentially multiple files with recursively included subdirectories.\n\nSince: generic-worker 1.0.0",
-            "enum": [
-              "file",
-              "directory"
-            ],
-            "title": "Artifact upload type.",
-            "type": "string"
-          }
-        },
-        "required": [
-          "type",
-          "path"
-        ],
-        "title": "Artifact",
-        "type": "object"
-      },
-      "title": "Artifacts to be published",
-      "type": "array",
-      "uniqueItems": true
-    },
-    "command": {
-      "description": "One array per command (each command is an array of arguments). Several arrays\nfor several commands.\n\nSince: generic-worker 0.0.1",
-      "items": {
-        "items": {
-          "type": "string"
-        },
-        "minItems": 1,
-        "type": "array",
-        "uniqueItems": false
-      },
-      "minItems": 1,
-      "title": "Commands to run",
-      "type": "array",
-      "uniqueItems": false
-    },
-    "env": {
-      "additionalProperties": {
-        "type": "string"
-      },
-      "description": "Env vars must be string to __string__ mappings (not number or boolean). For example:\n` + "`" + `` + "`" + `` + "`" + `\n{\n  \"PATH\": \"/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin\",\n  \"GOOS\": \"darwin\",\n  \"FOO_ENABLE\": \"true\",\n  \"BAR_TOTAL\": \"3\"\n}\n` + "`" + `` + "`" + `` + "`" + `\n\nNote, the following environment variables will automatically be set in the task\ncommands, but may be overridden by environment variables in the task payload:\n  * ` + "`" + `HOME` + "`" + ` - the home directory of the task user\n  * ` + "`" + `PATH` + "`" + ` - ` + "`" + `/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin` + "`" + `\n  * ` + "`" + `USER` + "`" + ` - the name of the task user\n\nThe following environment variables will automatically be set in the task\ncommands, and may not be overridden by environment variables in the task payload:\n  * ` + "`" + `DISPLAY` + "`" + ` - ` + "`" + `:0` + "`" + ` (Linux only)\n  * ` + "`" + `TASK_ID` + "`" + ` - the task ID of the currently running task\n  * ` + "`" + `RUN_ID` + "`" + ` - the run ID of the currently running task\n  * ` + "`" + `TASKCLUSTER_ROOT_URL` + "`" + ` - the root URL of the taskcluster deployment\n  * ` + "`" + `TASKCLUSTER_PROXY_URL` + "`" + ` (if taskcluster proxy feature enabled) - the\n     taskcluster authentication proxy for making unauthenticated taskcluster\n     API calls\n  * ` + "`" + `TASK_USER_CREDENTIALS` + "`" + ` (if config property ` + "`" + `runTasksAsCurrentUser` + "`" + ` set to\n    ` + "`" + `true` + "`" + ` in ` + "`" + `generic-worker.config` + "`" + ` file - the absolute file location of a\n    json file containing the current task OS user account name and password.\n    This is only useful for the generic-worker multiuser CI tasks, where\n    ` + "`" + `runTasksAsCurrentUser` + "`" + ` is set to ` + "`" + `true` + "`" + `.\n  * ` + "`" + `TASKCLUSTER_WORKER_LOCATION` + "`" + `. See\n    [RFC #0148](https://github.com/taskcluster/taskcluster-rfcs/blob/master/rfcs/0148-taskcluster-worker-location.md)\n    for details.\n\nSince: generic-worker 0.0.1",
-      "title": "Env vars",
-      "type": "object"
-    },
-    "features": {
+  "oneOf": [
+    {
       "additionalProperties": false,
-      "description": "Feature flags enable additional functionality.\n\nSince: generic-worker 5.3.0",
+      "description": "This schema defines the structure of the ` + "`" + `payload` + "`" + ` property referred to in a\nTaskcluster Task definition.",
       "properties": {
-        "backingLog": {
-          "default": true,
-          "description": "The backing log feature publishes a task artifact containing the complete\nstderr and stdout of the task.\n\nSince: generic-worker 48.2.0",
-          "title": "Enable backing log",
-          "type": "boolean"
+        "artifacts": {
+          "description": "Artifacts to be published.\n\nSince: generic-worker 1.0.0",
+          "items": {
+            "additionalProperties": false,
+            "properties": {
+              "contentEncoding": {
+                "description": "Content-Encoding for the artifact. If not provided, ` + "`" + `gzip` + "`" + ` will be used, except for the\nfollowing file extensions, where ` + "`" + `identity` + "`" + ` will be used, since they are already\ncompressed:\n\n* 7z\n* bz2\n* deb\n* dmg\n* flv\n* gif\n* gz\n* jpeg\n* jpg\n* png\n* swf\n* tbz\n* tgz\n* webp\n* whl\n* woff\n* woff2\n* xz\n* zip\n* zst\n\nNote, setting ` + "`" + `contentEncoding` + "`" + ` on a directory artifact will apply the same content\nencoding to all the files contained in the directory.\n\nSince: generic-worker 16.2.0",
+                "enum": [
+                  "identity",
+                  "gzip"
+                ],
+                "title": "Content-Encoding header when serving artifact over HTTP.",
+                "type": "string"
+              },
+              "contentType": {
+                "description": "Explicitly set the value of the HTTP ` + "`" + `Content-Type` + "`" + ` response header when the artifact(s)\nis/are served over HTTP(S). If not provided (this property is optional) the worker will\nguess the content type of artifacts based on the filename extension of the file storing\nthe artifact content. It does this by looking at the system filename-to-mimetype mappings\ndefined in multiple ` + "`" + `mime.types` + "`" + ` files located under ` + "`" + `/etc` + "`" + `. Note, setting ` + "`" + `contentType` + "`" + `\non a directory artifact will apply the same contentType to all files contained in the\ndirectory.\n\nSee [mime.TypeByExtension](https://pkg.go.dev/mime#TypeByExtension).\n\nSince: generic-worker 10.4.0",
+                "title": "Content-Type header when serving artifact over HTTP",
+                "type": "string"
+              },
+              "expires": {
+                "description": "Date when artifact should expire must be in the future, no earlier than task deadline, but\nno later than task expiry. If not set, defaults to task expiry.\n\nSince: generic-worker 1.0.0",
+                "format": "date-time",
+                "title": "Expiry date and time",
+                "type": "string"
+              },
+              "name": {
+                "description": "Name of the artifact, as it will be published. If not set, ` + "`" + `path` + "`" + ` will be used.\nConventionally (although not enforced) path elements are forward slash separated. Example:\n` + "`" + `public/build/a/house` + "`" + `. Note, no scopes are required to read artifacts beginning ` + "`" + `public/` + "`" + `.\nArtifact names not beginning ` + "`" + `public/` + "`" + ` are scope-protected (caller requires scopes to\ndownload the artifact). See the Queue documentation for more information.\n\nSince: generic-worker 8.1.0",
+                "title": "Name of the artifact",
+                "type": "string"
+              },
+              "path": {
+                "description": "Relative path of the file/directory from the task directory. Note this is not an absolute\npath as is typically used in docker-worker, since the absolute task directory name is not\nknown when the task is submitted. Example: ` + "`" + `dist\\regedit.exe` + "`" + `. It doesn't matter if\nforward slashes or backslashes are used.\n\nSince: generic-worker 1.0.0",
+                "title": "Artifact location",
+                "type": "string"
+              },
+              "type": {
+                "description": "Artifacts can be either an individual ` + "`" + `file` + "`" + ` or a ` + "`" + `directory` + "`" + ` containing\npotentially multiple files with recursively included subdirectories.\n\nSince: generic-worker 1.0.0",
+                "enum": [
+                  "file",
+                  "directory"
+                ],
+                "title": "Artifact upload type.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "type",
+              "path"
+            ],
+            "title": "Artifact",
+            "type": "object"
+          },
+          "title": "Artifacts to be published",
+          "type": "array",
+          "uniqueItems": true
         },
-        "chainOfTrust": {
-          "description": "Artifacts named ` + "`" + `public/chain-of-trust.json` + "`" + ` and\n` + "`" + `public/chain-of-trust.json.sig` + "`" + ` should be generated which will\ninclude information for downstream tasks to build a level of trust\nfor the artifacts produced by the task and the environment it ran in.\n\nSince: generic-worker 5.3.0",
-          "title": "Enable generation of signed Chain of Trust artifacts",
-          "type": "boolean"
+        "command": {
+          "description": "One array per command (each command is an array of arguments). Several arrays\nfor several commands.\n\nSince: generic-worker 0.0.1",
+          "items": {
+            "items": {
+              "type": "string"
+            },
+            "minItems": 1,
+            "type": "array",
+            "uniqueItems": false
+          },
+          "minItems": 1,
+          "title": "Commands to run",
+          "type": "array",
+          "uniqueItems": false
         },
-        "interactive": {
-          "description": "This allows you to interactively run commands from within the worker\nas the task user. This may be useful for debugging purposes.\nCan be used for SSH-like access to the running worker.\nNote that this feature works differently from the ` + "`" + `interactive` + "`" + ` feature\nin docker worker, which ` + "`" + `docker exec` + "`" + `s into the running container.\nSince tasks on generic worker are not guaranteed to be running in a\ncontainer, a bash shell is started on the task user's account.\nA user can then ` + "`" + `docker exec` + "`" + ` into the a running container, if there\nis one.\n\nSince: generic-worker 49.2.0",
-          "title": "Interactive shell",
-          "type": "boolean"
+        "env": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Env vars must be string to __string__ mappings (not number or boolean). For example:\n` + "`" + `` + "`" + `` + "`" + `\n{\n  \"PATH\": \"/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin\",\n  \"GOOS\": \"darwin\",\n  \"FOO_ENABLE\": \"true\",\n  \"BAR_TOTAL\": \"3\"\n}\n` + "`" + `` + "`" + `` + "`" + `\n\nNote, the following environment variables will automatically be set in the task\ncommands, but may be overridden by environment variables in the task payload:\n  * ` + "`" + `HOME` + "`" + ` - the home directory of the task user\n  * ` + "`" + `PATH` + "`" + ` - ` + "`" + `/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin` + "`" + `\n  * ` + "`" + `USER` + "`" + ` - the name of the task user\n\nThe following environment variables will automatically be set in the task\ncommands, and may not be overridden by environment variables in the task payload:\n  * ` + "`" + `DISPLAY` + "`" + ` - ` + "`" + `:0` + "`" + ` (Linux only)\n  * ` + "`" + `TASK_ID` + "`" + ` - the task ID of the currently running task\n  * ` + "`" + `RUN_ID` + "`" + ` - the run ID of the currently running task\n  * ` + "`" + `TASKCLUSTER_ROOT_URL` + "`" + ` - the root URL of the taskcluster deployment\n  * ` + "`" + `TASKCLUSTER_PROXY_URL` + "`" + ` (if taskcluster proxy feature enabled) - the\n    taskcluster authentication proxy for making unauthenticated taskcluster\n    API calls\n  * ` + "`" + `TASK_USER_CREDENTIALS` + "`" + ` (if config property ` + "`" + `runTasksAsCurrentUser` + "`" + ` set to\n    ` + "`" + `true` + "`" + ` in ` + "`" + `generic-worker.config` + "`" + ` file - the absolute file location of a\n    json file containing the current task OS user account name and password.\n    This is only useful for the generic-worker multiuser CI tasks, where\n    ` + "`" + `runTasksAsCurrentUser` + "`" + ` is set to ` + "`" + `true` + "`" + `.\n  * ` + "`" + `TASKCLUSTER_WORKER_LOCATION` + "`" + `. See\n    [RFC #0148](https://github.com/taskcluster/taskcluster-rfcs/blob/master/rfcs/0148-taskcluster-worker-location.md)\n    for details.\n\nSince: generic-worker 0.0.1",
+          "title": "Env vars",
+          "type": "object"
         },
-        "liveLog": {
-          "default": true,
-          "description": "The live log feature streams the combined stderr and stdout to a task artifact\nso that the output is available while the task is running.\n\nSince: generic-worker 48.2.0",
-          "title": "Enable [livelog](https://github.com/taskcluster/taskcluster/tree/main/tools/livelog)",
-          "type": "boolean"
+        "features": {
+          "additionalProperties": false,
+          "description": "Feature flags enable additional functionality.\n\nSince: generic-worker 5.3.0",
+          "properties": {
+            "backingLog": {
+              "default": true,
+              "description": "The backing log feature publishes a task artifact containing the complete\nstderr and stdout of the task.\n\nSince: generic-worker 48.2.0",
+              "title": "Enable backing log",
+              "type": "boolean"
+            },
+            "chainOfTrust": {
+              "description": "Artifacts named ` + "`" + `public/chain-of-trust.json` + "`" + ` and\n` + "`" + `public/chain-of-trust.json.sig` + "`" + ` should be generated which will\ninclude information for downstream tasks to build a level of trust\nfor the artifacts produced by the task and the environment it ran in.\n\nSince: generic-worker 5.3.0",
+              "title": "Enable generation of signed Chain of Trust artifacts",
+              "type": "boolean"
+            },
+            "interactive": {
+              "description": "This allows you to interactively run commands from within the worker\nas the task user. This may be useful for debugging purposes.\nCan be used for SSH-like access to the running worker.\nNote that this feature works differently from the ` + "`" + `interactive` + "`" + ` feature\nin docker worker, which ` + "`" + `docker exec` + "`" + `s into the running container.\nSince tasks on generic worker are not guaranteed to be running in a\ncontainer, a bash shell is started on the task user's account.\nA user can then ` + "`" + `docker exec` + "`" + ` into the a running container, if there\nis one.\n\nSince: generic-worker 49.2.0",
+              "title": "Interactive shell",
+              "type": "boolean"
+            },
+            "liveLog": {
+              "default": true,
+              "description": "The live log feature streams the combined stderr and stdout to a task artifact\nso that the output is available while the task is running.\n\nSince: generic-worker 48.2.0",
+              "title": "Enable [livelog](https://github.com/taskcluster/taskcluster/tree/main/tools/livelog)",
+              "type": "boolean"
+            },
+            "loopbackVideo": {
+              "description": "Video loopback device created using v4l2loopback.\nA video device will be available for the task. Its\nlocation will be passed to the task via environment\nvariable ` + "`" + `TASKCLUSTER_VIDEO_DEVICE` + "`" + `. The\nlocation will be ` + "`" + `/dev/video\u003cN\u003e` + "`" + ` where ` + "`" + `\u003cN\u003e` + "`" + ` is\nan integer between 0 and 255. The value of ` + "`" + `\u003cN\u003e` + "`" + `\nis not static, and therefore either the environment\nvariable should be used, or ` + "`" + `/dev` + "`" + ` should be\nscanned in order to determine the correct location.\nTasks should not assume a constant value.\n\nThis feature is only available on Linux. If a task\nis submitted with this feature enabled on a non-Linux,\nposix platform (FreeBSD, macOS), the task will resolve as\n` + "`" + `exception/malformed-payload` + "`" + `.\n\nSince: generic-worker 53.1.0",
+              "title": "Loopback Video device",
+              "type": "boolean"
+            },
+            "taskclusterProxy": {
+              "description": "The taskcluster proxy provides an easy and safe way to make authenticated\ntaskcluster requests within the scope(s) of a particular task. See\n[the github project](https://github.com/taskcluster/taskcluster/tree/main/tools/taskcluster-proxy) for more information.\n\nSince: generic-worker 10.6.0",
+              "title": "Run [taskcluster-proxy](https://github.com/taskcluster/taskcluster/tree/main/tools/taskcluster-proxy) to allow tasks to dynamically proxy requests to taskcluster services",
+              "type": "boolean"
+            }
+          },
+          "required": [],
+          "title": "Feature flags",
+          "type": "object"
         },
-        "loopbackVideo": {
-          "description": "Video loopback device created using v4l2loopback.\nA video device will be available for the task. Its\nlocation will be passed to the task via environment\nvariable ` + "`" + `TASKCLUSTER_VIDEO_DEVICE` + "`" + `. The\nlocation will be ` + "`" + `/dev/video\u003cN\u003e` + "`" + ` where ` + "`" + `\u003cN\u003e` + "`" + ` is\nan integer between 0 and 255. The value of ` + "`" + `\u003cN\u003e` + "`" + `\nis not static, and therefore either the environment\nvariable should be used, or ` + "`" + `/dev` + "`" + ` should be\nscanned in order to determine the correct location.\nTasks should not assume a constant value.\n\nThis feature is only available on Linux. If a task\nis submitted with this feature enabled on a non-Linux,\nposix platform (FreeBSD, macOS), the task will resolve as\n` + "`" + `exception/malformed-payload` + "`" + `.\n\nSince: generic-worker 53.1.0",
-          "title": "Loopback Video device",
-          "type": "boolean"
+        "logs": {
+          "additionalProperties": false,
+          "description": "Configuration for task logs.\n\nSince: generic-worker 48.2.0",
+          "properties": {
+            "backing": {
+              "default": "public/logs/live_backing.log",
+              "description": "Specifies a custom name for the backing log artifact.\nThis is only used if ` + "`" + `features.backingLog` + "`" + ` is ` + "`" + `true` + "`" + `.\n\nSince: generic-worker 48.2.0",
+              "title": "Backing log artifact name",
+              "type": "string"
+            },
+            "live": {
+              "default": "public/logs/live.log",
+              "description": "Specifies a custom name for the live log artifact.\nThis is only used if ` + "`" + `features.liveLog` + "`" + ` is ` + "`" + `true` + "`" + `.\n\nSince: generic-worker 48.2.0",
+              "title": "Live log artifact name",
+              "type": "string"
+            }
+          },
+          "required": [],
+          "title": "Logs",
+          "type": "object"
         },
-        "taskclusterProxy": {
-          "description": "The taskcluster proxy provides an easy and safe way to make authenticated\ntaskcluster requests within the scope(s) of a particular task. See\n[the github project](https://github.com/taskcluster/taskcluster/tree/main/tools/taskcluster-proxy) for more information.\n\nSince: generic-worker 10.6.0",
-          "title": "Run [taskcluster-proxy](https://github.com/taskcluster/taskcluster/tree/main/tools/taskcluster-proxy) to allow tasks to dynamically proxy requests to taskcluster services",
-          "type": "boolean"
+        "maxRunTime": {
+          "description": "Maximum time the task container can run in seconds.\n\nSince: generic-worker 0.0.1",
+          "maximum": 86400,
+          "minimum": 1,
+          "multipleOf": 1,
+          "title": "Maximum run time in seconds",
+          "type": "integer"
+        },
+        "mounts": {
+          "description": "Directories and/or files to be mounted.\n\nSince: generic-worker 5.4.0",
+          "items": {
+            "$ref": "#/definitions/mount",
+            "title": "Mount"
+          },
+          "type": "array",
+          "uniqueItems": false
+        },
+        "onExitStatus": {
+          "additionalProperties": false,
+          "description": "By default tasks will be resolved with ` + "`" + `state/reasonResolved` + "`" + `: ` + "`" + `completed/completed` + "`" + `\nif all task commands have a zero exit code, or ` + "`" + `failed/failed` + "`" + ` if any command has a\nnon-zero exit code. This payload property allows customsation of the task resolution\nbased on exit code of task commands.",
+          "properties": {
+            "purgeCaches": {
+              "description": "If the task exists with a purge caches exit status, all caches\nassociated with the task will be purged.\n\nSince: generic-worker 49.0.0",
+              "items": {
+                "minimum": 1,
+                "title": "Exit statuses",
+                "type": "integer"
+              },
+              "title": "Purge caches exit status",
+              "type": "array",
+              "uniqueItems": true
+            },
+            "retry": {
+              "description": "Exit codes for any command in the task payload to cause this task to\nbe resolved as ` + "`" + `exception/intermittent-task` + "`" + `. Typically the Queue\nwill then schedule a new run of the existing ` + "`" + `taskId` + "`" + ` (rerun) if not\nall task runs have been exhausted.\n\nSee [itermittent tasks](https://docs.taskcluster.net/docs/reference/platform/taskcluster-queue/docs/worker-interaction#intermittent-tasks) for more detail.\n\nSince: generic-worker 10.10.0",
+              "items": {
+                "minimum": 1,
+                "title": "Exit codes",
+                "type": "integer"
+              },
+              "title": "Intermittent task exit codes",
+              "type": "array",
+              "uniqueItems": true
+            }
+          },
+          "required": [],
+          "title": "Exit code handling",
+          "type": "object"
+        },
+        "osGroups": {
+          "description": "A list of OS Groups that the task user should be a member of. Not yet implemented on\nnon-Windows platforms, therefore this optional property may only be an empty array if\nprovided.\n\nSince: generic-worker 6.0.0",
+          "items": {
+            "type": "string"
+          },
+          "maxItems": 0,
+          "title": "OS Groups",
+          "type": "array",
+          "uniqueItems": false
+        },
+        "supersederUrl": {
+          "description": "This property is allowed for backward compatibility, but is unused.",
+          "title": "unused",
+          "type": "string"
         }
       },
-      "required": [],
-      "title": "Feature flags",
+      "required": [
+        "command",
+        "maxRunTime"
+      ],
+      "title": "Generic worker payload",
       "type": "object"
     },
-    "logs": {
+    {
       "additionalProperties": false,
-      "description": "Configuration for task logs.\n\nSince: generic-worker 48.2.0",
+      "description": "` + "`" + `.payload` + "`" + ` field of the queue.",
       "properties": {
-        "backing": {
-          "default": "public/logs/live_backing.log",
-          "description": "Specifies a custom name for the backing log artifact.\nThis is only used if ` + "`" + `features.backingLog` + "`" + ` is ` + "`" + `true` + "`" + `.\n\nSince: generic-worker 48.2.0",
-          "title": "Backing log artifact name",
-          "type": "string"
+        "artifacts": {
+          "additionalProperties": {
+            "$ref": "#/definitions/artifact"
+          },
+          "description": "Artifact upload map example: ` + "`" + `` + "`" + `` + "`" + `{\"public/build.tar.gz\": {\"path\": \"/home/worker/build.tar.gz\", \"expires\": \"2016-05-28T16:12:56.693817Z\", \"type\": \"file\"}}` + "`" + `` + "`" + `` + "`" + `",
+          "title": "Artifacts",
+          "type": "object"
         },
-        "live": {
+        "cache": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Caches are mounted within the docker container at the mount point specified. Example: ` + "`" + `` + "`" + `` + "`" + `{ \"CACHE NAME\": \"/mount/path/in/container\" }` + "`" + `` + "`" + `` + "`" + `",
+          "title": "Caches to mount point mapping.",
+          "type": "object"
+        },
+        "capabilities": {
+          "additionalProperties": false,
+          "description": "Set of capabilities that must be enabled or made available to the task container Example: ` + "`" + `` + "`" + `` + "`" + `{ \"capabilities\": { \"privileged\": true }` + "`" + `` + "`" + `` + "`" + `",
+          "properties": {
+            "devices": {
+              "additionalProperties": false,
+              "description": "Allows devices from the host system to be attached to a task container similar to using ` + "`" + `--device` + "`" + ` in docker.",
+              "properties": {
+                "hostSharedMemory": {
+                  "description": "Mount /dev/shm from the host in the container.",
+                  "title": "Host shared memory device (Experimental)",
+                  "type": "boolean"
+                },
+                "kvm": {
+                  "description": "Mount /dev/kvm from the host in the container.",
+                  "title": "/dev/kvm device (Experimental)",
+                  "type": "boolean"
+                },
+                "loopbackAudio": {
+                  "description": "Audio loopback device created using snd-aloop",
+                  "title": "Loopback Audio device",
+                  "type": "boolean"
+                },
+                "loopbackVideo": {
+                  "description": "Video loopback device created using v4l2loopback.",
+                  "title": "Loopback Video device",
+                  "type": "boolean"
+                }
+              },
+              "required": [],
+              "title": "Devices to be attached to task containers",
+              "type": "object"
+            },
+            "privileged": {
+              "default": false,
+              "description": "Allows a task to run in a privileged container, similar to running docker with ` + "`" + `--privileged` + "`" + `.  This only works for worker-types configured to enable it.",
+              "title": "Privileged container",
+              "type": "boolean"
+            }
+          },
+          "required": [],
+          "title": "Capabilities that must be available/enabled for the task container.",
+          "type": "object"
+        },
+        "command": {
+          "default": [],
+          "description": "Example: ` + "`" + `['/bin/bash', '-c', 'ls']` + "`" + `.",
+          "items": {
+            "type": "string"
+          },
+          "title": "Docker command to run (see docker api).",
+          "type": "array"
+        },
+        "env": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Example: ` + "`" + `` + "`" + `` + "`" + `\n{\n  \"PATH\": '/borked/path'\n  \"ENV_NAME\": \"VALUE\"\n}\n` + "`" + `` + "`" + `` + "`" + `",
+          "title": "Environment variable mappings.",
+          "type": "object"
+        },
+        "features": {
+          "additionalProperties": false,
+          "description": "Used to enable additional functionality.",
+          "properties": {
+            "allowPtrace": {
+              "default": false,
+              "description": "This allows you to use the Linux ptrace functionality inside the container; it is otherwise disallowed by Docker's security policy.",
+              "title": "Allow ptrace within the container",
+              "type": "boolean"
+            },
+            "artifacts": {
+              "default": true,
+              "description": "",
+              "title": "Artifact uploads",
+              "type": "boolean"
+            },
+            "bulkLog": {
+              "default": true,
+              "description": "Useful if live logging is not interesting but the overalllog is later on",
+              "title": "Bulk upload the task log into a single artifact",
+              "type": "boolean"
+            },
+            "chainOfTrust": {
+              "default": false,
+              "description": "Artifacts named chain-of-trust.json and chain-of-trust.json.sig should be generated which will include information for downstream tasks to build a level of trust for the artifacts produced by the task and the environment it ran in.",
+              "title": "Enable generation of ed25519-signed Chain of Trust artifacts",
+              "type": "boolean"
+            },
+            "dind": {
+              "default": false,
+              "description": "Runs docker-in-docker and binds ` + "`" + `/var/run/docker.sock` + "`" + ` into the container. Doesn't allow privileged mode, capabilities or host volume mounts.",
+              "title": "Docker in Docker",
+              "type": "boolean"
+            },
+            "dockerSave": {
+              "default": false,
+              "description": "Uploads docker images as artifacts",
+              "title": "Docker save",
+              "type": "boolean"
+            },
+            "interactive": {
+              "default": false,
+              "description": "This allows you to interactively run commands inside the container and attaches you to the stdin/stdout/stderr over a websocket. Can be used for SSH-like access to docker containers.",
+              "title": "Docker Exec Interactive",
+              "type": "boolean"
+            },
+            "localLiveLog": {
+              "default": true,
+              "description": "Logs are stored on the worker during the duration of tasks and available via http chunked streaming then uploaded to s3",
+              "title": "Enable live logging (worker local)",
+              "type": "boolean"
+            },
+            "taskclusterProxy": {
+              "default": false,
+              "description": "The auth proxy allows making requests to taskcluster/queue and taskcluster/scheduler directly from your task with the same scopes as set in the task. This can be used to make api calls via the [client](https://github.com/taskcluster/taskcluster-client) CURL, etc... Without embedding credentials in the task.",
+              "title": "Taskcluster auth proxy service",
+              "type": "boolean"
+            }
+          },
+          "required": [],
+          "title": "Docker Worker feature flags",
+          "type": "object"
+        },
+        "image": {
+          "description": "Image to use for the task.  Images can be specified as an image tag as used by a docker registry, or as an object declaring type and name/namespace",
+          "oneOf": [
+            {
+              "title": "Docker image name",
+              "type": "string"
+            },
+            {
+              "additionalProperties": false,
+              "properties": {
+                "name": {
+                  "type": "string"
+                },
+                "type": {
+                  "enum": [
+                    "docker-image"
+                  ],
+                  "type": "string"
+                }
+              },
+              "required": [
+                "type",
+                "name"
+              ],
+              "title": "Named docker image",
+              "type": "object"
+            },
+            {
+              "additionalProperties": false,
+              "properties": {
+                "namespace": {
+                  "type": "string"
+                },
+                "path": {
+                  "type": "string"
+                },
+                "type": {
+                  "enum": [
+                    "indexed-image"
+                  ],
+                  "type": "string"
+                }
+              },
+              "required": [
+                "type",
+                "namespace",
+                "path"
+              ],
+              "title": "Indexed docker image",
+              "type": "object"
+            },
+            {
+              "additionalProperties": false,
+              "properties": {
+                "path": {
+                  "type": "string"
+                },
+                "taskId": {
+                  "type": "string"
+                },
+                "type": {
+                  "enum": [
+                    "task-image"
+                  ],
+                  "type": "string"
+                }
+              },
+              "required": [
+                "type",
+                "taskId",
+                "path"
+              ],
+              "title": "Docker image artifact",
+              "type": "object"
+            }
+          ],
+          "title": "Docker image."
+        },
+        "log": {
           "default": "public/logs/live.log",
-          "description": "Specifies a custom name for the live log artifact.\nThis is only used if ` + "`" + `features.liveLog` + "`" + ` is ` + "`" + `true` + "`" + `.\n\nSince: generic-worker 48.2.0",
-          "title": "Live log artifact name",
+          "description": "Specifies a custom name for the livelog artifact. Note that this is also used in determining the name of the backing log artifact name. Backing log artifact name matches livelog artifact name with ` + "`" + `_backing` + "`" + ` appended, prior to the file extension (if present). For example, ` + "`" + `apple/banana.log.txt` + "`" + ` results in livelog artifact ` + "`" + `apple/banana.log.txt` + "`" + ` and backing log artifact ` + "`" + `apple/banana.log_backing.txt` + "`" + `. Defaults to ` + "`" + `public/logs/live.log` + "`" + `.",
+          "title": "Livelog artifact name",
+          "type": "string"
+        },
+        "maxRunTime": {
+          "description": "Maximum time the task container can run in seconds.",
+          "maximum": 86400,
+          "minimum": 1,
+          "multipleOf": 1,
+          "title": "Maximum run time in seconds",
+          "type": "integer"
+        },
+        "onExitStatus": {
+          "additionalProperties": false,
+          "description": "By default docker-worker will fail a task with a non-zero exit status without retrying.  This payload property allows a task owner to define certain exit statuses that will be marked as a retriable exception.",
+          "properties": {
+            "purgeCaches": {
+              "description": "If the task exists with a purge caches exit status, all caches associated with the task will be purged.",
+              "items": {
+                "title": "Exit statuses",
+                "type": "integer"
+              },
+              "title": "Purge caches exit status",
+              "type": "array"
+            },
+            "retry": {
+              "description": "If the task exists with a retriable exit status, the task will be marked as an exception and a new run created.",
+              "items": {
+                "title": "Exit statuses",
+                "type": "integer"
+              },
+              "title": "Retriable exit statuses",
+              "type": "array"
+            }
+          },
+          "required": [],
+          "title": "Exit status handling",
+          "type": "object"
+        },
+        "supersederUrl": {
+          "description": "Maintained for backward compatibility, but no longer used",
+          "title": "(unused)",
           "type": "string"
         }
       },
-      "required": [],
-      "title": "Logs",
+      "required": [
+        "image",
+        "maxRunTime"
+      ],
+      "title": "Docker worker payload",
       "type": "object"
-    },
-    "maxRunTime": {
-      "description": "Maximum time the task container can run in seconds.\n\nSince: generic-worker 0.0.1",
-      "maximum": 86400,
-      "minimum": 1,
-      "multipleOf": 1,
-      "title": "Maximum run time in seconds",
-      "type": "integer"
-    },
-    "mounts": {
-      "description": "Directories and/or files to be mounted.\n\nSince: generic-worker 5.4.0",
-      "items": {
-        "$ref": "#/definitions/mount",
-        "title": "Mount"
-      },
-      "type": "array",
-      "uniqueItems": false
-    },
-    "onExitStatus": {
-      "additionalProperties": false,
-      "description": "By default tasks will be resolved with ` + "`" + `state/reasonResolved` + "`" + `: ` + "`" + `completed/completed` + "`" + `\nif all task commands have a zero exit code, or ` + "`" + `failed/failed` + "`" + ` if any command has a\nnon-zero exit code. This payload property allows customsation of the task resolution\nbased on exit code of task commands.",
-      "properties": {
-        "purgeCaches": {
-          "description": "If the task exists with a purge caches exit status, all caches\nassociated with the task will be purged.\n\nSince: generic-worker 49.0.0",
-          "items": {
-            "minimum": 1,
-            "title": "Exit statuses",
-            "type": "integer"
-          },
-          "title": "Purge caches exit status",
-          "type": "array",
-          "uniqueItems": true
-        },
-        "retry": {
-          "description": "Exit codes for any command in the task payload to cause this task to\nbe resolved as ` + "`" + `exception/intermittent-task` + "`" + `. Typically the Queue\nwill then schedule a new run of the existing ` + "`" + `taskId` + "`" + ` (rerun) if not\nall task runs have been exhausted.\n\nSee [itermittent tasks](https://docs.taskcluster.net/docs/reference/platform/taskcluster-queue/docs/worker-interaction#intermittent-tasks) for more detail.\n\nSince: generic-worker 10.10.0",
-          "items": {
-            "minimum": 1,
-            "title": "Exit codes",
-            "type": "integer"
-          },
-          "title": "Intermittent task exit codes",
-          "type": "array",
-          "uniqueItems": true
-        }
-      },
-      "required": [],
-      "title": "Exit code handling",
-      "type": "object"
-    },
-    "osGroups": {
-      "description": "A list of OS Groups that the task user should be a member of. Not yet implemented on\nnon-Windows platforms, therefore this optional property may only be an empty array if\nprovided.\n\nSince: generic-worker 6.0.0",
-      "items": {
-        "type": "string"
-      },
-      "maxItems": 0,
-      "title": "OS Groups",
-      "type": "array",
-      "uniqueItems": false
-    },
-    "supersederUrl": {
-      "description": "This property is allowed for backward compatibility, but is unused.",
-      "title": "unused",
-      "type": "string"
     }
-  },
-  "required": [
-    "command",
-    "maxRunTime"
   ],
-  "title": "Generic worker payload",
-  "type": "object"
+  "title": "Payload"
 }`
 }

--- a/workers/generic-worker/generated_multiuser_freebsd.go
+++ b/workers/generic-worker/generated_multiuser_freebsd.go
@@ -6,6 +6,7 @@ package main
 
 import (
 	"encoding/json"
+	"errors"
 
 	tcclient "github.com/taskcluster/taskcluster/v54/clients/client-go"
 )
@@ -128,6 +129,167 @@ type (
 		Base64 string `json:"base64"`
 	}
 
+	// Set of capabilities that must be enabled or made available to the task container Example: ```{ "capabilities": { "privileged": true }```
+	Capabilities struct {
+
+		// Allows devices from the host system to be attached to a task container similar to using `--device` in docker.
+		Devices Devices `json:"devices,omitempty"`
+
+		// Allows a task to run in a privileged container, similar to running docker with `--privileged`.  This only works for worker-types configured to enable it.
+		//
+		// Default:    false
+		Privileged bool `json:"privileged" default:"false"`
+	}
+
+	// Allows devices from the host system to be attached to a task container similar to using `--device` in docker.
+	Devices struct {
+
+		// Mount /dev/shm from the host in the container.
+		HostSharedMemory bool `json:"hostSharedMemory,omitempty"`
+
+		// Mount /dev/kvm from the host in the container.
+		KVM bool `json:"kvm,omitempty"`
+
+		// Audio loopback device created using snd-aloop
+		LoopbackAudio bool `json:"loopbackAudio,omitempty"`
+
+		// Video loopback device created using v4l2loopback.
+		LoopbackVideo bool `json:"loopbackVideo,omitempty"`
+	}
+
+	// Image to use for the task.  Images can be specified as an image tag as used by a docker registry, or as an object declaring type and name/namespace
+	DockerImageArtifact struct {
+		Path string `json:"path"`
+
+		TaskID string `json:"taskId"`
+
+		// Possible values:
+		//   * "task-image"
+		Type string `json:"type"`
+	}
+
+	// Image to use for the task.  Images can be specified as an image tag as used by a docker registry, or as an object declaring type and name/namespace
+	DockerImageName string
+
+	DockerWorkerArtifact struct {
+		Expires tcclient.Time `json:"expires,omitempty"`
+
+		Path string `json:"path"`
+
+		// Possible values:
+		//   * "file"
+		//   * "directory"
+		Type string `json:"type"`
+	}
+
+	// Used to enable additional functionality.
+	DockerWorkerFeatureFlags struct {
+
+		// This allows you to use the Linux ptrace functionality inside the container; it is otherwise disallowed by Docker's security policy.
+		//
+		// Default:    false
+		AllowPtrace bool `json:"allowPtrace" default:"false"`
+
+		// Default:    true
+		Artifacts bool `json:"artifacts" default:"true"`
+
+		// Useful if live logging is not interesting but the overalllog is later on
+		//
+		// Default:    true
+		BulkLog bool `json:"bulkLog" default:"true"`
+
+		// Artifacts named chain-of-trust.json and chain-of-trust.json.sig should be generated which will include information for downstream tasks to build a level of trust for the artifacts produced by the task and the environment it ran in.
+		//
+		// Default:    false
+		ChainOfTrust bool `json:"chainOfTrust" default:"false"`
+
+		// Runs docker-in-docker and binds `/var/run/docker.sock` into the container. Doesn't allow privileged mode, capabilities or host volume mounts.
+		//
+		// Default:    false
+		Dind bool `json:"dind" default:"false"`
+
+		// Uploads docker images as artifacts
+		//
+		// Default:    false
+		DockerSave bool `json:"dockerSave" default:"false"`
+
+		// This allows you to interactively run commands inside the container and attaches you to the stdin/stdout/stderr over a websocket. Can be used for SSH-like access to docker containers.
+		//
+		// Default:    false
+		Interactive bool `json:"interactive" default:"false"`
+
+		// Logs are stored on the worker during the duration of tasks and available via http chunked streaming then uploaded to s3
+		//
+		// Default:    true
+		LocalLiveLog bool `json:"localLiveLog" default:"true"`
+
+		// The auth proxy allows making requests to taskcluster/queue and taskcluster/scheduler directly from your task with the same scopes as set in the task. This can be used to make api calls via the [client](https://github.com/taskcluster/taskcluster-client) CURL, etc... Without embedding credentials in the task.
+		//
+		// Default:    false
+		TaskclusterProxy bool `json:"taskclusterProxy" default:"false"`
+	}
+
+	// `.payload` field of the queue.
+	DockerWorkerPayload struct {
+
+		// Artifact upload map example: ```{"public/build.tar.gz": {"path": "/home/worker/build.tar.gz", "expires": "2016-05-28T16:12:56.693817Z", "type": "file"}}```
+		Artifacts map[string]DockerWorkerArtifact `json:"artifacts,omitempty"`
+
+		// Caches are mounted within the docker container at the mount point specified. Example: ```{ "CACHE NAME": "/mount/path/in/container" }```
+		//
+		// Map entries:
+		Cache map[string]string `json:"cache,omitempty"`
+
+		// Set of capabilities that must be enabled or made available to the task container Example: ```{ "capabilities": { "privileged": true }```
+		Capabilities Capabilities `json:"capabilities,omitempty"`
+
+		// Example: `['/bin/bash', '-c', 'ls']`.
+		//
+		// Default:    []
+		//
+		// Array items:
+		Command []string `json:"command,omitempty"`
+
+		// Example: ```
+		// {
+		//   "PATH": '/borked/path'
+		//   "ENV_NAME": "VALUE"
+		// }
+		// ```
+		//
+		// Map entries:
+		Env map[string]string `json:"env,omitempty"`
+
+		// Used to enable additional functionality.
+		Features DockerWorkerFeatureFlags `json:"features,omitempty"`
+
+		// Image to use for the task.  Images can be specified as an image tag as used by a docker registry, or as an object declaring type and name/namespace
+		//
+		// One of:
+		//   * DockerImageName
+		//   * NamedDockerImage
+		//   * IndexedDockerImage
+		//   * DockerImageArtifact
+		Image json.RawMessage `json:"image"`
+
+		// Specifies a custom name for the livelog artifact. Note that this is also used in determining the name of the backing log artifact name. Backing log artifact name matches livelog artifact name with `_backing` appended, prior to the file extension (if present). For example, `apple/banana.log.txt` results in livelog artifact `apple/banana.log.txt` and backing log artifact `apple/banana.log_backing.txt`. Defaults to `public/logs/live.log`.
+		//
+		// Default:    "public/logs/live.log"
+		Log string `json:"log" default:"public/logs/live.log"`
+
+		// Maximum time the task container can run in seconds.
+		//
+		// Mininum:    1
+		// Maximum:    86400
+		MaxRunTime int64 `json:"maxRunTime"`
+
+		// By default docker-worker will fail a task with a non-zero exit status without retrying.  This payload property allows a task owner to define certain exit statuses that will be marked as a retriable exception.
+		OnExitStatus ExitStatusHandling `json:"onExitStatus,omitempty"`
+
+		// Maintained for backward compatibility, but no longer used
+		SupersederURL string `json:"supersederUrl,omitempty"`
+	}
+
 	// By default tasks will be resolved with `state/reasonResolved`: `completed/completed`
 	// if all task commands have a zero exit code, or `failed/failed` if any command has a
 	// non-zero exit code. This payload property allows customsation of the task resolution
@@ -154,6 +316,20 @@ type (
 		//
 		// Array items:
 		// Mininum:    1
+		Retry []int64 `json:"retry,omitempty"`
+	}
+
+	// By default docker-worker will fail a task with a non-zero exit status without retrying.  This payload property allows a task owner to define certain exit statuses that will be marked as a retriable exception.
+	ExitStatusHandling struct {
+
+		// If the task exists with a purge caches exit status, all caches associated with the task will be purged.
+		//
+		// Array items:
+		PurgeCaches []int64 `json:"purgeCaches,omitempty"`
+
+		// If the task exists with a retriable exit status, the task will be marked as an exception and a new run created.
+		//
+		// Array items:
 		Retry []int64 `json:"retry,omitempty"`
 	}
 
@@ -283,8 +459,8 @@ type (
 		//   * `RUN_ID` - the run ID of the currently running task
 		//   * `TASKCLUSTER_ROOT_URL` - the root URL of the taskcluster deployment
 		//   * `TASKCLUSTER_PROXY_URL` (if taskcluster proxy feature enabled) - the
-		//      taskcluster authentication proxy for making unauthenticated taskcluster
-		//      API calls
+		//     taskcluster authentication proxy for making unauthenticated taskcluster
+		//     API calls
 		//   * `TASK_USER_CREDENTIALS` (if config property `runTasksAsCurrentUser` set to
 		//     `true` in `generic-worker.config` file - the absolute file location of a
 		//     json file containing the current task OS user account name and password.
@@ -359,6 +535,17 @@ type (
 		Namespace string `json:"namespace"`
 	}
 
+	// Image to use for the task.  Images can be specified as an image tag as used by a docker registry, or as an object declaring type and name/namespace
+	IndexedDockerImage struct {
+		Namespace string `json:"namespace"`
+
+		Path string `json:"path"`
+
+		// Possible values:
+		//   * "indexed-image"
+		Type string `json:"type"`
+	}
+
 	// Configuration for task logs.
 	//
 	// Since: generic-worker 48.2.0
@@ -380,6 +567,20 @@ type (
 		// Default:    "public/logs/live.log"
 		Live string `json:"live" default:"public/logs/live.log"`
 	}
+
+	// Image to use for the task.  Images can be specified as an image tag as used by a docker registry, or as an object declaring type and name/namespace
+	NamedDockerImage struct {
+		Name string `json:"name"`
+
+		// Possible values:
+		//   * "docker-image"
+		Type string `json:"type"`
+	}
+
+	// One of:
+	//   * GenericWorkerPayload
+	//   * DockerWorkerPayload
+	Payload json.RawMessage
 
 	// Byte-for-byte literal inline content of file/archive, up to 64KB in size.
 	//
@@ -479,6 +680,22 @@ type (
 	}
 )
 
+// MarshalJSON calls json.RawMessage method of the same name. Required since
+// Payload is of type json.RawMessage...
+func (m *Payload) MarshalJSON() ([]byte, error) {
+	x := json.RawMessage(*m)
+	return (&x).MarshalJSON()
+}
+
+// UnmarshalJSON is a copy of the json.RawMessage implementation.
+func (m *Payload) UnmarshalJSON(data []byte) error {
+	if m == nil {
+		return errors.New("Payload: UnmarshalJSON on nil pointer")
+	}
+	*m = append((*m)[0:0], data...)
+	return nil
+}
+
 // Returns json schema for the payload part of the task definition. Please
 // note we use a go string and do not load an external file, since we want this
 // to be *part of the compiled executable*. If this sat in another file that
@@ -495,8 +712,35 @@ func JSONSchema() string {
 	return `{
   "$id": "/schemas/generic-worker/multiuser_posix.json#",
   "$schema": "/schemas/common/metaschema.json#",
-  "additionalProperties": false,
   "definitions": {
+    "artifact": {
+      "additionalProperties": false,
+      "properties": {
+        "expires": {
+          "format": "date-time",
+          "title": "Date when artifact should expire must be in the future.",
+          "type": "string"
+        },
+        "path": {
+          "title": "Location of artifact in container, as an absolute path.",
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "file",
+            "directory"
+          ],
+          "title": "Artifact upload type.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "type",
+        "path"
+      ],
+      "title": "Docker Worker Artifact",
+      "type": "object"
+    },
     "content": {
       "oneOf": [
         {
@@ -722,218 +966,500 @@ func JSONSchema() string {
       "type": "object"
     }
   },
-  "description": "This schema defines the structure of the ` + "`" + `payload` + "`" + ` property referred to in a\nTaskcluster Task definition.",
-  "properties": {
-    "artifacts": {
-      "description": "Artifacts to be published.\n\nSince: generic-worker 1.0.0",
-      "items": {
-        "additionalProperties": false,
-        "properties": {
-          "contentEncoding": {
-            "description": "Content-Encoding for the artifact. If not provided, ` + "`" + `gzip` + "`" + ` will be used, except for the\nfollowing file extensions, where ` + "`" + `identity` + "`" + ` will be used, since they are already\ncompressed:\n\n* 7z\n* bz2\n* deb\n* dmg\n* flv\n* gif\n* gz\n* jpeg\n* jpg\n* png\n* swf\n* tbz\n* tgz\n* webp\n* whl\n* woff\n* woff2\n* xz\n* zip\n* zst\n\nNote, setting ` + "`" + `contentEncoding` + "`" + ` on a directory artifact will apply the same content\nencoding to all the files contained in the directory.\n\nSince: generic-worker 16.2.0",
-            "enum": [
-              "identity",
-              "gzip"
-            ],
-            "title": "Content-Encoding header when serving artifact over HTTP.",
-            "type": "string"
-          },
-          "contentType": {
-            "description": "Explicitly set the value of the HTTP ` + "`" + `Content-Type` + "`" + ` response header when the artifact(s)\nis/are served over HTTP(S). If not provided (this property is optional) the worker will\nguess the content type of artifacts based on the filename extension of the file storing\nthe artifact content. It does this by looking at the system filename-to-mimetype mappings\ndefined in multiple ` + "`" + `mime.types` + "`" + ` files located under ` + "`" + `/etc` + "`" + `. Note, setting ` + "`" + `contentType` + "`" + `\non a directory artifact will apply the same contentType to all files contained in the\ndirectory.\n\nSee [mime.TypeByExtension](https://pkg.go.dev/mime#TypeByExtension).\n\nSince: generic-worker 10.4.0",
-            "title": "Content-Type header when serving artifact over HTTP",
-            "type": "string"
-          },
-          "expires": {
-            "description": "Date when artifact should expire must be in the future, no earlier than task deadline, but\nno later than task expiry. If not set, defaults to task expiry.\n\nSince: generic-worker 1.0.0",
-            "format": "date-time",
-            "title": "Expiry date and time",
-            "type": "string"
-          },
-          "name": {
-            "description": "Name of the artifact, as it will be published. If not set, ` + "`" + `path` + "`" + ` will be used.\nConventionally (although not enforced) path elements are forward slash separated. Example:\n` + "`" + `public/build/a/house` + "`" + `. Note, no scopes are required to read artifacts beginning ` + "`" + `public/` + "`" + `.\nArtifact names not beginning ` + "`" + `public/` + "`" + ` are scope-protected (caller requires scopes to\ndownload the artifact). See the Queue documentation for more information.\n\nSince: generic-worker 8.1.0",
-            "title": "Name of the artifact",
-            "type": "string"
-          },
-          "path": {
-            "description": "Relative path of the file/directory from the task directory. Note this is not an absolute\npath as is typically used in docker-worker, since the absolute task directory name is not\nknown when the task is submitted. Example: ` + "`" + `dist\\regedit.exe` + "`" + `. It doesn't matter if\nforward slashes or backslashes are used.\n\nSince: generic-worker 1.0.0",
-            "title": "Artifact location",
-            "type": "string"
-          },
-          "type": {
-            "description": "Artifacts can be either an individual ` + "`" + `file` + "`" + ` or a ` + "`" + `directory` + "`" + ` containing\npotentially multiple files with recursively included subdirectories.\n\nSince: generic-worker 1.0.0",
-            "enum": [
-              "file",
-              "directory"
-            ],
-            "title": "Artifact upload type.",
-            "type": "string"
-          }
-        },
-        "required": [
-          "type",
-          "path"
-        ],
-        "title": "Artifact",
-        "type": "object"
-      },
-      "title": "Artifacts to be published",
-      "type": "array",
-      "uniqueItems": true
-    },
-    "command": {
-      "description": "One array per command (each command is an array of arguments). Several arrays\nfor several commands.\n\nSince: generic-worker 0.0.1",
-      "items": {
-        "items": {
-          "type": "string"
-        },
-        "minItems": 1,
-        "type": "array",
-        "uniqueItems": false
-      },
-      "minItems": 1,
-      "title": "Commands to run",
-      "type": "array",
-      "uniqueItems": false
-    },
-    "env": {
-      "additionalProperties": {
-        "type": "string"
-      },
-      "description": "Env vars must be string to __string__ mappings (not number or boolean). For example:\n` + "`" + `` + "`" + `` + "`" + `\n{\n  \"PATH\": \"/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin\",\n  \"GOOS\": \"darwin\",\n  \"FOO_ENABLE\": \"true\",\n  \"BAR_TOTAL\": \"3\"\n}\n` + "`" + `` + "`" + `` + "`" + `\n\nNote, the following environment variables will automatically be set in the task\ncommands, but may be overridden by environment variables in the task payload:\n  * ` + "`" + `HOME` + "`" + ` - the home directory of the task user\n  * ` + "`" + `PATH` + "`" + ` - ` + "`" + `/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin` + "`" + `\n  * ` + "`" + `USER` + "`" + ` - the name of the task user\n\nThe following environment variables will automatically be set in the task\ncommands, and may not be overridden by environment variables in the task payload:\n  * ` + "`" + `DISPLAY` + "`" + ` - ` + "`" + `:0` + "`" + ` (Linux only)\n  * ` + "`" + `TASK_ID` + "`" + ` - the task ID of the currently running task\n  * ` + "`" + `RUN_ID` + "`" + ` - the run ID of the currently running task\n  * ` + "`" + `TASKCLUSTER_ROOT_URL` + "`" + ` - the root URL of the taskcluster deployment\n  * ` + "`" + `TASKCLUSTER_PROXY_URL` + "`" + ` (if taskcluster proxy feature enabled) - the\n     taskcluster authentication proxy for making unauthenticated taskcluster\n     API calls\n  * ` + "`" + `TASK_USER_CREDENTIALS` + "`" + ` (if config property ` + "`" + `runTasksAsCurrentUser` + "`" + ` set to\n    ` + "`" + `true` + "`" + ` in ` + "`" + `generic-worker.config` + "`" + ` file - the absolute file location of a\n    json file containing the current task OS user account name and password.\n    This is only useful for the generic-worker multiuser CI tasks, where\n    ` + "`" + `runTasksAsCurrentUser` + "`" + ` is set to ` + "`" + `true` + "`" + `.\n  * ` + "`" + `TASKCLUSTER_WORKER_LOCATION` + "`" + `. See\n    [RFC #0148](https://github.com/taskcluster/taskcluster-rfcs/blob/master/rfcs/0148-taskcluster-worker-location.md)\n    for details.\n\nSince: generic-worker 0.0.1",
-      "title": "Env vars",
-      "type": "object"
-    },
-    "features": {
+  "oneOf": [
+    {
       "additionalProperties": false,
-      "description": "Feature flags enable additional functionality.\n\nSince: generic-worker 5.3.0",
+      "description": "This schema defines the structure of the ` + "`" + `payload` + "`" + ` property referred to in a\nTaskcluster Task definition.",
       "properties": {
-        "backingLog": {
-          "default": true,
-          "description": "The backing log feature publishes a task artifact containing the complete\nstderr and stdout of the task.\n\nSince: generic-worker 48.2.0",
-          "title": "Enable backing log",
-          "type": "boolean"
+        "artifacts": {
+          "description": "Artifacts to be published.\n\nSince: generic-worker 1.0.0",
+          "items": {
+            "additionalProperties": false,
+            "properties": {
+              "contentEncoding": {
+                "description": "Content-Encoding for the artifact. If not provided, ` + "`" + `gzip` + "`" + ` will be used, except for the\nfollowing file extensions, where ` + "`" + `identity` + "`" + ` will be used, since they are already\ncompressed:\n\n* 7z\n* bz2\n* deb\n* dmg\n* flv\n* gif\n* gz\n* jpeg\n* jpg\n* png\n* swf\n* tbz\n* tgz\n* webp\n* whl\n* woff\n* woff2\n* xz\n* zip\n* zst\n\nNote, setting ` + "`" + `contentEncoding` + "`" + ` on a directory artifact will apply the same content\nencoding to all the files contained in the directory.\n\nSince: generic-worker 16.2.0",
+                "enum": [
+                  "identity",
+                  "gzip"
+                ],
+                "title": "Content-Encoding header when serving artifact over HTTP.",
+                "type": "string"
+              },
+              "contentType": {
+                "description": "Explicitly set the value of the HTTP ` + "`" + `Content-Type` + "`" + ` response header when the artifact(s)\nis/are served over HTTP(S). If not provided (this property is optional) the worker will\nguess the content type of artifacts based on the filename extension of the file storing\nthe artifact content. It does this by looking at the system filename-to-mimetype mappings\ndefined in multiple ` + "`" + `mime.types` + "`" + ` files located under ` + "`" + `/etc` + "`" + `. Note, setting ` + "`" + `contentType` + "`" + `\non a directory artifact will apply the same contentType to all files contained in the\ndirectory.\n\nSee [mime.TypeByExtension](https://pkg.go.dev/mime#TypeByExtension).\n\nSince: generic-worker 10.4.0",
+                "title": "Content-Type header when serving artifact over HTTP",
+                "type": "string"
+              },
+              "expires": {
+                "description": "Date when artifact should expire must be in the future, no earlier than task deadline, but\nno later than task expiry. If not set, defaults to task expiry.\n\nSince: generic-worker 1.0.0",
+                "format": "date-time",
+                "title": "Expiry date and time",
+                "type": "string"
+              },
+              "name": {
+                "description": "Name of the artifact, as it will be published. If not set, ` + "`" + `path` + "`" + ` will be used.\nConventionally (although not enforced) path elements are forward slash separated. Example:\n` + "`" + `public/build/a/house` + "`" + `. Note, no scopes are required to read artifacts beginning ` + "`" + `public/` + "`" + `.\nArtifact names not beginning ` + "`" + `public/` + "`" + ` are scope-protected (caller requires scopes to\ndownload the artifact). See the Queue documentation for more information.\n\nSince: generic-worker 8.1.0",
+                "title": "Name of the artifact",
+                "type": "string"
+              },
+              "path": {
+                "description": "Relative path of the file/directory from the task directory. Note this is not an absolute\npath as is typically used in docker-worker, since the absolute task directory name is not\nknown when the task is submitted. Example: ` + "`" + `dist\\regedit.exe` + "`" + `. It doesn't matter if\nforward slashes or backslashes are used.\n\nSince: generic-worker 1.0.0",
+                "title": "Artifact location",
+                "type": "string"
+              },
+              "type": {
+                "description": "Artifacts can be either an individual ` + "`" + `file` + "`" + ` or a ` + "`" + `directory` + "`" + ` containing\npotentially multiple files with recursively included subdirectories.\n\nSince: generic-worker 1.0.0",
+                "enum": [
+                  "file",
+                  "directory"
+                ],
+                "title": "Artifact upload type.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "type",
+              "path"
+            ],
+            "title": "Artifact",
+            "type": "object"
+          },
+          "title": "Artifacts to be published",
+          "type": "array",
+          "uniqueItems": true
         },
-        "chainOfTrust": {
-          "description": "Artifacts named ` + "`" + `public/chain-of-trust.json` + "`" + ` and\n` + "`" + `public/chain-of-trust.json.sig` + "`" + ` should be generated which will\ninclude information for downstream tasks to build a level of trust\nfor the artifacts produced by the task and the environment it ran in.\n\nSince: generic-worker 5.3.0",
-          "title": "Enable generation of signed Chain of Trust artifacts",
-          "type": "boolean"
+        "command": {
+          "description": "One array per command (each command is an array of arguments). Several arrays\nfor several commands.\n\nSince: generic-worker 0.0.1",
+          "items": {
+            "items": {
+              "type": "string"
+            },
+            "minItems": 1,
+            "type": "array",
+            "uniqueItems": false
+          },
+          "minItems": 1,
+          "title": "Commands to run",
+          "type": "array",
+          "uniqueItems": false
         },
-        "interactive": {
-          "description": "This allows you to interactively run commands from within the worker\nas the task user. This may be useful for debugging purposes.\nCan be used for SSH-like access to the running worker.\nNote that this feature works differently from the ` + "`" + `interactive` + "`" + ` feature\nin docker worker, which ` + "`" + `docker exec` + "`" + `s into the running container.\nSince tasks on generic worker are not guaranteed to be running in a\ncontainer, a bash shell is started on the task user's account.\nA user can then ` + "`" + `docker exec` + "`" + ` into the a running container, if there\nis one.\n\nSince: generic-worker 49.2.0",
-          "title": "Interactive shell",
-          "type": "boolean"
+        "env": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Env vars must be string to __string__ mappings (not number or boolean). For example:\n` + "`" + `` + "`" + `` + "`" + `\n{\n  \"PATH\": \"/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin\",\n  \"GOOS\": \"darwin\",\n  \"FOO_ENABLE\": \"true\",\n  \"BAR_TOTAL\": \"3\"\n}\n` + "`" + `` + "`" + `` + "`" + `\n\nNote, the following environment variables will automatically be set in the task\ncommands, but may be overridden by environment variables in the task payload:\n  * ` + "`" + `HOME` + "`" + ` - the home directory of the task user\n  * ` + "`" + `PATH` + "`" + ` - ` + "`" + `/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin` + "`" + `\n  * ` + "`" + `USER` + "`" + ` - the name of the task user\n\nThe following environment variables will automatically be set in the task\ncommands, and may not be overridden by environment variables in the task payload:\n  * ` + "`" + `DISPLAY` + "`" + ` - ` + "`" + `:0` + "`" + ` (Linux only)\n  * ` + "`" + `TASK_ID` + "`" + ` - the task ID of the currently running task\n  * ` + "`" + `RUN_ID` + "`" + ` - the run ID of the currently running task\n  * ` + "`" + `TASKCLUSTER_ROOT_URL` + "`" + ` - the root URL of the taskcluster deployment\n  * ` + "`" + `TASKCLUSTER_PROXY_URL` + "`" + ` (if taskcluster proxy feature enabled) - the\n    taskcluster authentication proxy for making unauthenticated taskcluster\n    API calls\n  * ` + "`" + `TASK_USER_CREDENTIALS` + "`" + ` (if config property ` + "`" + `runTasksAsCurrentUser` + "`" + ` set to\n    ` + "`" + `true` + "`" + ` in ` + "`" + `generic-worker.config` + "`" + ` file - the absolute file location of a\n    json file containing the current task OS user account name and password.\n    This is only useful for the generic-worker multiuser CI tasks, where\n    ` + "`" + `runTasksAsCurrentUser` + "`" + ` is set to ` + "`" + `true` + "`" + `.\n  * ` + "`" + `TASKCLUSTER_WORKER_LOCATION` + "`" + `. See\n    [RFC #0148](https://github.com/taskcluster/taskcluster-rfcs/blob/master/rfcs/0148-taskcluster-worker-location.md)\n    for details.\n\nSince: generic-worker 0.0.1",
+          "title": "Env vars",
+          "type": "object"
         },
-        "liveLog": {
-          "default": true,
-          "description": "The live log feature streams the combined stderr and stdout to a task artifact\nso that the output is available while the task is running.\n\nSince: generic-worker 48.2.0",
-          "title": "Enable [livelog](https://github.com/taskcluster/taskcluster/tree/main/tools/livelog)",
-          "type": "boolean"
+        "features": {
+          "additionalProperties": false,
+          "description": "Feature flags enable additional functionality.\n\nSince: generic-worker 5.3.0",
+          "properties": {
+            "backingLog": {
+              "default": true,
+              "description": "The backing log feature publishes a task artifact containing the complete\nstderr and stdout of the task.\n\nSince: generic-worker 48.2.0",
+              "title": "Enable backing log",
+              "type": "boolean"
+            },
+            "chainOfTrust": {
+              "description": "Artifacts named ` + "`" + `public/chain-of-trust.json` + "`" + ` and\n` + "`" + `public/chain-of-trust.json.sig` + "`" + ` should be generated which will\ninclude information for downstream tasks to build a level of trust\nfor the artifacts produced by the task and the environment it ran in.\n\nSince: generic-worker 5.3.0",
+              "title": "Enable generation of signed Chain of Trust artifacts",
+              "type": "boolean"
+            },
+            "interactive": {
+              "description": "This allows you to interactively run commands from within the worker\nas the task user. This may be useful for debugging purposes.\nCan be used for SSH-like access to the running worker.\nNote that this feature works differently from the ` + "`" + `interactive` + "`" + ` feature\nin docker worker, which ` + "`" + `docker exec` + "`" + `s into the running container.\nSince tasks on generic worker are not guaranteed to be running in a\ncontainer, a bash shell is started on the task user's account.\nA user can then ` + "`" + `docker exec` + "`" + ` into the a running container, if there\nis one.\n\nSince: generic-worker 49.2.0",
+              "title": "Interactive shell",
+              "type": "boolean"
+            },
+            "liveLog": {
+              "default": true,
+              "description": "The live log feature streams the combined stderr and stdout to a task artifact\nso that the output is available while the task is running.\n\nSince: generic-worker 48.2.0",
+              "title": "Enable [livelog](https://github.com/taskcluster/taskcluster/tree/main/tools/livelog)",
+              "type": "boolean"
+            },
+            "loopbackVideo": {
+              "description": "Video loopback device created using v4l2loopback.\nA video device will be available for the task. Its\nlocation will be passed to the task via environment\nvariable ` + "`" + `TASKCLUSTER_VIDEO_DEVICE` + "`" + `. The\nlocation will be ` + "`" + `/dev/video\u003cN\u003e` + "`" + ` where ` + "`" + `\u003cN\u003e` + "`" + ` is\nan integer between 0 and 255. The value of ` + "`" + `\u003cN\u003e` + "`" + `\nis not static, and therefore either the environment\nvariable should be used, or ` + "`" + `/dev` + "`" + ` should be\nscanned in order to determine the correct location.\nTasks should not assume a constant value.\n\nThis feature is only available on Linux. If a task\nis submitted with this feature enabled on a non-Linux,\nposix platform (FreeBSD, macOS), the task will resolve as\n` + "`" + `exception/malformed-payload` + "`" + `.\n\nSince: generic-worker 53.1.0",
+              "title": "Loopback Video device",
+              "type": "boolean"
+            },
+            "taskclusterProxy": {
+              "description": "The taskcluster proxy provides an easy and safe way to make authenticated\ntaskcluster requests within the scope(s) of a particular task. See\n[the github project](https://github.com/taskcluster/taskcluster/tree/main/tools/taskcluster-proxy) for more information.\n\nSince: generic-worker 10.6.0",
+              "title": "Run [taskcluster-proxy](https://github.com/taskcluster/taskcluster/tree/main/tools/taskcluster-proxy) to allow tasks to dynamically proxy requests to taskcluster services",
+              "type": "boolean"
+            }
+          },
+          "required": [],
+          "title": "Feature flags",
+          "type": "object"
         },
-        "loopbackVideo": {
-          "description": "Video loopback device created using v4l2loopback.\nA video device will be available for the task. Its\nlocation will be passed to the task via environment\nvariable ` + "`" + `TASKCLUSTER_VIDEO_DEVICE` + "`" + `. The\nlocation will be ` + "`" + `/dev/video\u003cN\u003e` + "`" + ` where ` + "`" + `\u003cN\u003e` + "`" + ` is\nan integer between 0 and 255. The value of ` + "`" + `\u003cN\u003e` + "`" + `\nis not static, and therefore either the environment\nvariable should be used, or ` + "`" + `/dev` + "`" + ` should be\nscanned in order to determine the correct location.\nTasks should not assume a constant value.\n\nThis feature is only available on Linux. If a task\nis submitted with this feature enabled on a non-Linux,\nposix platform (FreeBSD, macOS), the task will resolve as\n` + "`" + `exception/malformed-payload` + "`" + `.\n\nSince: generic-worker 53.1.0",
-          "title": "Loopback Video device",
-          "type": "boolean"
+        "logs": {
+          "additionalProperties": false,
+          "description": "Configuration for task logs.\n\nSince: generic-worker 48.2.0",
+          "properties": {
+            "backing": {
+              "default": "public/logs/live_backing.log",
+              "description": "Specifies a custom name for the backing log artifact.\nThis is only used if ` + "`" + `features.backingLog` + "`" + ` is ` + "`" + `true` + "`" + `.\n\nSince: generic-worker 48.2.0",
+              "title": "Backing log artifact name",
+              "type": "string"
+            },
+            "live": {
+              "default": "public/logs/live.log",
+              "description": "Specifies a custom name for the live log artifact.\nThis is only used if ` + "`" + `features.liveLog` + "`" + ` is ` + "`" + `true` + "`" + `.\n\nSince: generic-worker 48.2.0",
+              "title": "Live log artifact name",
+              "type": "string"
+            }
+          },
+          "required": [],
+          "title": "Logs",
+          "type": "object"
         },
-        "taskclusterProxy": {
-          "description": "The taskcluster proxy provides an easy and safe way to make authenticated\ntaskcluster requests within the scope(s) of a particular task. See\n[the github project](https://github.com/taskcluster/taskcluster/tree/main/tools/taskcluster-proxy) for more information.\n\nSince: generic-worker 10.6.0",
-          "title": "Run [taskcluster-proxy](https://github.com/taskcluster/taskcluster/tree/main/tools/taskcluster-proxy) to allow tasks to dynamically proxy requests to taskcluster services",
-          "type": "boolean"
+        "maxRunTime": {
+          "description": "Maximum time the task container can run in seconds.\n\nSince: generic-worker 0.0.1",
+          "maximum": 86400,
+          "minimum": 1,
+          "multipleOf": 1,
+          "title": "Maximum run time in seconds",
+          "type": "integer"
+        },
+        "mounts": {
+          "description": "Directories and/or files to be mounted.\n\nSince: generic-worker 5.4.0",
+          "items": {
+            "$ref": "#/definitions/mount",
+            "title": "Mount"
+          },
+          "type": "array",
+          "uniqueItems": false
+        },
+        "onExitStatus": {
+          "additionalProperties": false,
+          "description": "By default tasks will be resolved with ` + "`" + `state/reasonResolved` + "`" + `: ` + "`" + `completed/completed` + "`" + `\nif all task commands have a zero exit code, or ` + "`" + `failed/failed` + "`" + ` if any command has a\nnon-zero exit code. This payload property allows customsation of the task resolution\nbased on exit code of task commands.",
+          "properties": {
+            "purgeCaches": {
+              "description": "If the task exists with a purge caches exit status, all caches\nassociated with the task will be purged.\n\nSince: generic-worker 49.0.0",
+              "items": {
+                "minimum": 1,
+                "title": "Exit statuses",
+                "type": "integer"
+              },
+              "title": "Purge caches exit status",
+              "type": "array",
+              "uniqueItems": true
+            },
+            "retry": {
+              "description": "Exit codes for any command in the task payload to cause this task to\nbe resolved as ` + "`" + `exception/intermittent-task` + "`" + `. Typically the Queue\nwill then schedule a new run of the existing ` + "`" + `taskId` + "`" + ` (rerun) if not\nall task runs have been exhausted.\n\nSee [itermittent tasks](https://docs.taskcluster.net/docs/reference/platform/taskcluster-queue/docs/worker-interaction#intermittent-tasks) for more detail.\n\nSince: generic-worker 10.10.0",
+              "items": {
+                "minimum": 1,
+                "title": "Exit codes",
+                "type": "integer"
+              },
+              "title": "Intermittent task exit codes",
+              "type": "array",
+              "uniqueItems": true
+            }
+          },
+          "required": [],
+          "title": "Exit code handling",
+          "type": "object"
+        },
+        "osGroups": {
+          "description": "A list of OS Groups that the task user should be a member of. Not yet implemented on\nnon-Windows platforms, therefore this optional property may only be an empty array if\nprovided.\n\nSince: generic-worker 6.0.0",
+          "items": {
+            "type": "string"
+          },
+          "maxItems": 0,
+          "title": "OS Groups",
+          "type": "array",
+          "uniqueItems": false
+        },
+        "supersederUrl": {
+          "description": "This property is allowed for backward compatibility, but is unused.",
+          "title": "unused",
+          "type": "string"
         }
       },
-      "required": [],
-      "title": "Feature flags",
+      "required": [
+        "command",
+        "maxRunTime"
+      ],
+      "title": "Generic worker payload",
       "type": "object"
     },
-    "logs": {
+    {
       "additionalProperties": false,
-      "description": "Configuration for task logs.\n\nSince: generic-worker 48.2.0",
+      "description": "` + "`" + `.payload` + "`" + ` field of the queue.",
       "properties": {
-        "backing": {
-          "default": "public/logs/live_backing.log",
-          "description": "Specifies a custom name for the backing log artifact.\nThis is only used if ` + "`" + `features.backingLog` + "`" + ` is ` + "`" + `true` + "`" + `.\n\nSince: generic-worker 48.2.0",
-          "title": "Backing log artifact name",
-          "type": "string"
+        "artifacts": {
+          "additionalProperties": {
+            "$ref": "#/definitions/artifact"
+          },
+          "description": "Artifact upload map example: ` + "`" + `` + "`" + `` + "`" + `{\"public/build.tar.gz\": {\"path\": \"/home/worker/build.tar.gz\", \"expires\": \"2016-05-28T16:12:56.693817Z\", \"type\": \"file\"}}` + "`" + `` + "`" + `` + "`" + `",
+          "title": "Artifacts",
+          "type": "object"
         },
-        "live": {
+        "cache": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Caches are mounted within the docker container at the mount point specified. Example: ` + "`" + `` + "`" + `` + "`" + `{ \"CACHE NAME\": \"/mount/path/in/container\" }` + "`" + `` + "`" + `` + "`" + `",
+          "title": "Caches to mount point mapping.",
+          "type": "object"
+        },
+        "capabilities": {
+          "additionalProperties": false,
+          "description": "Set of capabilities that must be enabled or made available to the task container Example: ` + "`" + `` + "`" + `` + "`" + `{ \"capabilities\": { \"privileged\": true }` + "`" + `` + "`" + `` + "`" + `",
+          "properties": {
+            "devices": {
+              "additionalProperties": false,
+              "description": "Allows devices from the host system to be attached to a task container similar to using ` + "`" + `--device` + "`" + ` in docker.",
+              "properties": {
+                "hostSharedMemory": {
+                  "description": "Mount /dev/shm from the host in the container.",
+                  "title": "Host shared memory device (Experimental)",
+                  "type": "boolean"
+                },
+                "kvm": {
+                  "description": "Mount /dev/kvm from the host in the container.",
+                  "title": "/dev/kvm device (Experimental)",
+                  "type": "boolean"
+                },
+                "loopbackAudio": {
+                  "description": "Audio loopback device created using snd-aloop",
+                  "title": "Loopback Audio device",
+                  "type": "boolean"
+                },
+                "loopbackVideo": {
+                  "description": "Video loopback device created using v4l2loopback.",
+                  "title": "Loopback Video device",
+                  "type": "boolean"
+                }
+              },
+              "required": [],
+              "title": "Devices to be attached to task containers",
+              "type": "object"
+            },
+            "privileged": {
+              "default": false,
+              "description": "Allows a task to run in a privileged container, similar to running docker with ` + "`" + `--privileged` + "`" + `.  This only works for worker-types configured to enable it.",
+              "title": "Privileged container",
+              "type": "boolean"
+            }
+          },
+          "required": [],
+          "title": "Capabilities that must be available/enabled for the task container.",
+          "type": "object"
+        },
+        "command": {
+          "default": [],
+          "description": "Example: ` + "`" + `['/bin/bash', '-c', 'ls']` + "`" + `.",
+          "items": {
+            "type": "string"
+          },
+          "title": "Docker command to run (see docker api).",
+          "type": "array"
+        },
+        "env": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Example: ` + "`" + `` + "`" + `` + "`" + `\n{\n  \"PATH\": '/borked/path'\n  \"ENV_NAME\": \"VALUE\"\n}\n` + "`" + `` + "`" + `` + "`" + `",
+          "title": "Environment variable mappings.",
+          "type": "object"
+        },
+        "features": {
+          "additionalProperties": false,
+          "description": "Used to enable additional functionality.",
+          "properties": {
+            "allowPtrace": {
+              "default": false,
+              "description": "This allows you to use the Linux ptrace functionality inside the container; it is otherwise disallowed by Docker's security policy.",
+              "title": "Allow ptrace within the container",
+              "type": "boolean"
+            },
+            "artifacts": {
+              "default": true,
+              "description": "",
+              "title": "Artifact uploads",
+              "type": "boolean"
+            },
+            "bulkLog": {
+              "default": true,
+              "description": "Useful if live logging is not interesting but the overalllog is later on",
+              "title": "Bulk upload the task log into a single artifact",
+              "type": "boolean"
+            },
+            "chainOfTrust": {
+              "default": false,
+              "description": "Artifacts named chain-of-trust.json and chain-of-trust.json.sig should be generated which will include information for downstream tasks to build a level of trust for the artifacts produced by the task and the environment it ran in.",
+              "title": "Enable generation of ed25519-signed Chain of Trust artifacts",
+              "type": "boolean"
+            },
+            "dind": {
+              "default": false,
+              "description": "Runs docker-in-docker and binds ` + "`" + `/var/run/docker.sock` + "`" + ` into the container. Doesn't allow privileged mode, capabilities or host volume mounts.",
+              "title": "Docker in Docker",
+              "type": "boolean"
+            },
+            "dockerSave": {
+              "default": false,
+              "description": "Uploads docker images as artifacts",
+              "title": "Docker save",
+              "type": "boolean"
+            },
+            "interactive": {
+              "default": false,
+              "description": "This allows you to interactively run commands inside the container and attaches you to the stdin/stdout/stderr over a websocket. Can be used for SSH-like access to docker containers.",
+              "title": "Docker Exec Interactive",
+              "type": "boolean"
+            },
+            "localLiveLog": {
+              "default": true,
+              "description": "Logs are stored on the worker during the duration of tasks and available via http chunked streaming then uploaded to s3",
+              "title": "Enable live logging (worker local)",
+              "type": "boolean"
+            },
+            "taskclusterProxy": {
+              "default": false,
+              "description": "The auth proxy allows making requests to taskcluster/queue and taskcluster/scheduler directly from your task with the same scopes as set in the task. This can be used to make api calls via the [client](https://github.com/taskcluster/taskcluster-client) CURL, etc... Without embedding credentials in the task.",
+              "title": "Taskcluster auth proxy service",
+              "type": "boolean"
+            }
+          },
+          "required": [],
+          "title": "Docker Worker feature flags",
+          "type": "object"
+        },
+        "image": {
+          "description": "Image to use for the task.  Images can be specified as an image tag as used by a docker registry, or as an object declaring type and name/namespace",
+          "oneOf": [
+            {
+              "title": "Docker image name",
+              "type": "string"
+            },
+            {
+              "additionalProperties": false,
+              "properties": {
+                "name": {
+                  "type": "string"
+                },
+                "type": {
+                  "enum": [
+                    "docker-image"
+                  ],
+                  "type": "string"
+                }
+              },
+              "required": [
+                "type",
+                "name"
+              ],
+              "title": "Named docker image",
+              "type": "object"
+            },
+            {
+              "additionalProperties": false,
+              "properties": {
+                "namespace": {
+                  "type": "string"
+                },
+                "path": {
+                  "type": "string"
+                },
+                "type": {
+                  "enum": [
+                    "indexed-image"
+                  ],
+                  "type": "string"
+                }
+              },
+              "required": [
+                "type",
+                "namespace",
+                "path"
+              ],
+              "title": "Indexed docker image",
+              "type": "object"
+            },
+            {
+              "additionalProperties": false,
+              "properties": {
+                "path": {
+                  "type": "string"
+                },
+                "taskId": {
+                  "type": "string"
+                },
+                "type": {
+                  "enum": [
+                    "task-image"
+                  ],
+                  "type": "string"
+                }
+              },
+              "required": [
+                "type",
+                "taskId",
+                "path"
+              ],
+              "title": "Docker image artifact",
+              "type": "object"
+            }
+          ],
+          "title": "Docker image."
+        },
+        "log": {
           "default": "public/logs/live.log",
-          "description": "Specifies a custom name for the live log artifact.\nThis is only used if ` + "`" + `features.liveLog` + "`" + ` is ` + "`" + `true` + "`" + `.\n\nSince: generic-worker 48.2.0",
-          "title": "Live log artifact name",
+          "description": "Specifies a custom name for the livelog artifact. Note that this is also used in determining the name of the backing log artifact name. Backing log artifact name matches livelog artifact name with ` + "`" + `_backing` + "`" + ` appended, prior to the file extension (if present). For example, ` + "`" + `apple/banana.log.txt` + "`" + ` results in livelog artifact ` + "`" + `apple/banana.log.txt` + "`" + ` and backing log artifact ` + "`" + `apple/banana.log_backing.txt` + "`" + `. Defaults to ` + "`" + `public/logs/live.log` + "`" + `.",
+          "title": "Livelog artifact name",
+          "type": "string"
+        },
+        "maxRunTime": {
+          "description": "Maximum time the task container can run in seconds.",
+          "maximum": 86400,
+          "minimum": 1,
+          "multipleOf": 1,
+          "title": "Maximum run time in seconds",
+          "type": "integer"
+        },
+        "onExitStatus": {
+          "additionalProperties": false,
+          "description": "By default docker-worker will fail a task with a non-zero exit status without retrying.  This payload property allows a task owner to define certain exit statuses that will be marked as a retriable exception.",
+          "properties": {
+            "purgeCaches": {
+              "description": "If the task exists with a purge caches exit status, all caches associated with the task will be purged.",
+              "items": {
+                "title": "Exit statuses",
+                "type": "integer"
+              },
+              "title": "Purge caches exit status",
+              "type": "array"
+            },
+            "retry": {
+              "description": "If the task exists with a retriable exit status, the task will be marked as an exception and a new run created.",
+              "items": {
+                "title": "Exit statuses",
+                "type": "integer"
+              },
+              "title": "Retriable exit statuses",
+              "type": "array"
+            }
+          },
+          "required": [],
+          "title": "Exit status handling",
+          "type": "object"
+        },
+        "supersederUrl": {
+          "description": "Maintained for backward compatibility, but no longer used",
+          "title": "(unused)",
           "type": "string"
         }
       },
-      "required": [],
-      "title": "Logs",
+      "required": [
+        "image",
+        "maxRunTime"
+      ],
+      "title": "Docker worker payload",
       "type": "object"
-    },
-    "maxRunTime": {
-      "description": "Maximum time the task container can run in seconds.\n\nSince: generic-worker 0.0.1",
-      "maximum": 86400,
-      "minimum": 1,
-      "multipleOf": 1,
-      "title": "Maximum run time in seconds",
-      "type": "integer"
-    },
-    "mounts": {
-      "description": "Directories and/or files to be mounted.\n\nSince: generic-worker 5.4.0",
-      "items": {
-        "$ref": "#/definitions/mount",
-        "title": "Mount"
-      },
-      "type": "array",
-      "uniqueItems": false
-    },
-    "onExitStatus": {
-      "additionalProperties": false,
-      "description": "By default tasks will be resolved with ` + "`" + `state/reasonResolved` + "`" + `: ` + "`" + `completed/completed` + "`" + `\nif all task commands have a zero exit code, or ` + "`" + `failed/failed` + "`" + ` if any command has a\nnon-zero exit code. This payload property allows customsation of the task resolution\nbased on exit code of task commands.",
-      "properties": {
-        "purgeCaches": {
-          "description": "If the task exists with a purge caches exit status, all caches\nassociated with the task will be purged.\n\nSince: generic-worker 49.0.0",
-          "items": {
-            "minimum": 1,
-            "title": "Exit statuses",
-            "type": "integer"
-          },
-          "title": "Purge caches exit status",
-          "type": "array",
-          "uniqueItems": true
-        },
-        "retry": {
-          "description": "Exit codes for any command in the task payload to cause this task to\nbe resolved as ` + "`" + `exception/intermittent-task` + "`" + `. Typically the Queue\nwill then schedule a new run of the existing ` + "`" + `taskId` + "`" + ` (rerun) if not\nall task runs have been exhausted.\n\nSee [itermittent tasks](https://docs.taskcluster.net/docs/reference/platform/taskcluster-queue/docs/worker-interaction#intermittent-tasks) for more detail.\n\nSince: generic-worker 10.10.0",
-          "items": {
-            "minimum": 1,
-            "title": "Exit codes",
-            "type": "integer"
-          },
-          "title": "Intermittent task exit codes",
-          "type": "array",
-          "uniqueItems": true
-        }
-      },
-      "required": [],
-      "title": "Exit code handling",
-      "type": "object"
-    },
-    "osGroups": {
-      "description": "A list of OS Groups that the task user should be a member of. Not yet implemented on\nnon-Windows platforms, therefore this optional property may only be an empty array if\nprovided.\n\nSince: generic-worker 6.0.0",
-      "items": {
-        "type": "string"
-      },
-      "maxItems": 0,
-      "title": "OS Groups",
-      "type": "array",
-      "uniqueItems": false
-    },
-    "supersederUrl": {
-      "description": "This property is allowed for backward compatibility, but is unused.",
-      "title": "unused",
-      "type": "string"
     }
-  },
-  "required": [
-    "command",
-    "maxRunTime"
   ],
-  "title": "Generic worker payload",
-  "type": "object"
+  "title": "Payload"
 }`
 }

--- a/workers/generic-worker/generated_multiuser_linux.go
+++ b/workers/generic-worker/generated_multiuser_linux.go
@@ -6,6 +6,7 @@ package main
 
 import (
 	"encoding/json"
+	"errors"
 
 	tcclient "github.com/taskcluster/taskcluster/v54/clients/client-go"
 )
@@ -128,6 +129,167 @@ type (
 		Base64 string `json:"base64"`
 	}
 
+	// Set of capabilities that must be enabled or made available to the task container Example: ```{ "capabilities": { "privileged": true }```
+	Capabilities struct {
+
+		// Allows devices from the host system to be attached to a task container similar to using `--device` in docker.
+		Devices Devices `json:"devices,omitempty"`
+
+		// Allows a task to run in a privileged container, similar to running docker with `--privileged`.  This only works for worker-types configured to enable it.
+		//
+		// Default:    false
+		Privileged bool `json:"privileged" default:"false"`
+	}
+
+	// Allows devices from the host system to be attached to a task container similar to using `--device` in docker.
+	Devices struct {
+
+		// Mount /dev/shm from the host in the container.
+		HostSharedMemory bool `json:"hostSharedMemory,omitempty"`
+
+		// Mount /dev/kvm from the host in the container.
+		KVM bool `json:"kvm,omitempty"`
+
+		// Audio loopback device created using snd-aloop
+		LoopbackAudio bool `json:"loopbackAudio,omitempty"`
+
+		// Video loopback device created using v4l2loopback.
+		LoopbackVideo bool `json:"loopbackVideo,omitempty"`
+	}
+
+	// Image to use for the task.  Images can be specified as an image tag as used by a docker registry, or as an object declaring type and name/namespace
+	DockerImageArtifact struct {
+		Path string `json:"path"`
+
+		TaskID string `json:"taskId"`
+
+		// Possible values:
+		//   * "task-image"
+		Type string `json:"type"`
+	}
+
+	// Image to use for the task.  Images can be specified as an image tag as used by a docker registry, or as an object declaring type and name/namespace
+	DockerImageName string
+
+	DockerWorkerArtifact struct {
+		Expires tcclient.Time `json:"expires,omitempty"`
+
+		Path string `json:"path"`
+
+		// Possible values:
+		//   * "file"
+		//   * "directory"
+		Type string `json:"type"`
+	}
+
+	// Used to enable additional functionality.
+	DockerWorkerFeatureFlags struct {
+
+		// This allows you to use the Linux ptrace functionality inside the container; it is otherwise disallowed by Docker's security policy.
+		//
+		// Default:    false
+		AllowPtrace bool `json:"allowPtrace" default:"false"`
+
+		// Default:    true
+		Artifacts bool `json:"artifacts" default:"true"`
+
+		// Useful if live logging is not interesting but the overalllog is later on
+		//
+		// Default:    true
+		BulkLog bool `json:"bulkLog" default:"true"`
+
+		// Artifacts named chain-of-trust.json and chain-of-trust.json.sig should be generated which will include information for downstream tasks to build a level of trust for the artifacts produced by the task and the environment it ran in.
+		//
+		// Default:    false
+		ChainOfTrust bool `json:"chainOfTrust" default:"false"`
+
+		// Runs docker-in-docker and binds `/var/run/docker.sock` into the container. Doesn't allow privileged mode, capabilities or host volume mounts.
+		//
+		// Default:    false
+		Dind bool `json:"dind" default:"false"`
+
+		// Uploads docker images as artifacts
+		//
+		// Default:    false
+		DockerSave bool `json:"dockerSave" default:"false"`
+
+		// This allows you to interactively run commands inside the container and attaches you to the stdin/stdout/stderr over a websocket. Can be used for SSH-like access to docker containers.
+		//
+		// Default:    false
+		Interactive bool `json:"interactive" default:"false"`
+
+		// Logs are stored on the worker during the duration of tasks and available via http chunked streaming then uploaded to s3
+		//
+		// Default:    true
+		LocalLiveLog bool `json:"localLiveLog" default:"true"`
+
+		// The auth proxy allows making requests to taskcluster/queue and taskcluster/scheduler directly from your task with the same scopes as set in the task. This can be used to make api calls via the [client](https://github.com/taskcluster/taskcluster-client) CURL, etc... Without embedding credentials in the task.
+		//
+		// Default:    false
+		TaskclusterProxy bool `json:"taskclusterProxy" default:"false"`
+	}
+
+	// `.payload` field of the queue.
+	DockerWorkerPayload struct {
+
+		// Artifact upload map example: ```{"public/build.tar.gz": {"path": "/home/worker/build.tar.gz", "expires": "2016-05-28T16:12:56.693817Z", "type": "file"}}```
+		Artifacts map[string]DockerWorkerArtifact `json:"artifacts,omitempty"`
+
+		// Caches are mounted within the docker container at the mount point specified. Example: ```{ "CACHE NAME": "/mount/path/in/container" }```
+		//
+		// Map entries:
+		Cache map[string]string `json:"cache,omitempty"`
+
+		// Set of capabilities that must be enabled or made available to the task container Example: ```{ "capabilities": { "privileged": true }```
+		Capabilities Capabilities `json:"capabilities,omitempty"`
+
+		// Example: `['/bin/bash', '-c', 'ls']`.
+		//
+		// Default:    []
+		//
+		// Array items:
+		Command []string `json:"command,omitempty"`
+
+		// Example: ```
+		// {
+		//   "PATH": '/borked/path'
+		//   "ENV_NAME": "VALUE"
+		// }
+		// ```
+		//
+		// Map entries:
+		Env map[string]string `json:"env,omitempty"`
+
+		// Used to enable additional functionality.
+		Features DockerWorkerFeatureFlags `json:"features,omitempty"`
+
+		// Image to use for the task.  Images can be specified as an image tag as used by a docker registry, or as an object declaring type and name/namespace
+		//
+		// One of:
+		//   * DockerImageName
+		//   * NamedDockerImage
+		//   * IndexedDockerImage
+		//   * DockerImageArtifact
+		Image json.RawMessage `json:"image"`
+
+		// Specifies a custom name for the livelog artifact. Note that this is also used in determining the name of the backing log artifact name. Backing log artifact name matches livelog artifact name with `_backing` appended, prior to the file extension (if present). For example, `apple/banana.log.txt` results in livelog artifact `apple/banana.log.txt` and backing log artifact `apple/banana.log_backing.txt`. Defaults to `public/logs/live.log`.
+		//
+		// Default:    "public/logs/live.log"
+		Log string `json:"log" default:"public/logs/live.log"`
+
+		// Maximum time the task container can run in seconds.
+		//
+		// Mininum:    1
+		// Maximum:    86400
+		MaxRunTime int64 `json:"maxRunTime"`
+
+		// By default docker-worker will fail a task with a non-zero exit status without retrying.  This payload property allows a task owner to define certain exit statuses that will be marked as a retriable exception.
+		OnExitStatus ExitStatusHandling `json:"onExitStatus,omitempty"`
+
+		// Maintained for backward compatibility, but no longer used
+		SupersederURL string `json:"supersederUrl,omitempty"`
+	}
+
 	// By default tasks will be resolved with `state/reasonResolved`: `completed/completed`
 	// if all task commands have a zero exit code, or `failed/failed` if any command has a
 	// non-zero exit code. This payload property allows customsation of the task resolution
@@ -154,6 +316,20 @@ type (
 		//
 		// Array items:
 		// Mininum:    1
+		Retry []int64 `json:"retry,omitempty"`
+	}
+
+	// By default docker-worker will fail a task with a non-zero exit status without retrying.  This payload property allows a task owner to define certain exit statuses that will be marked as a retriable exception.
+	ExitStatusHandling struct {
+
+		// If the task exists with a purge caches exit status, all caches associated with the task will be purged.
+		//
+		// Array items:
+		PurgeCaches []int64 `json:"purgeCaches,omitempty"`
+
+		// If the task exists with a retriable exit status, the task will be marked as an exception and a new run created.
+		//
+		// Array items:
 		Retry []int64 `json:"retry,omitempty"`
 	}
 
@@ -283,8 +459,8 @@ type (
 		//   * `RUN_ID` - the run ID of the currently running task
 		//   * `TASKCLUSTER_ROOT_URL` - the root URL of the taskcluster deployment
 		//   * `TASKCLUSTER_PROXY_URL` (if taskcluster proxy feature enabled) - the
-		//      taskcluster authentication proxy for making unauthenticated taskcluster
-		//      API calls
+		//     taskcluster authentication proxy for making unauthenticated taskcluster
+		//     API calls
 		//   * `TASK_USER_CREDENTIALS` (if config property `runTasksAsCurrentUser` set to
 		//     `true` in `generic-worker.config` file - the absolute file location of a
 		//     json file containing the current task OS user account name and password.
@@ -359,6 +535,17 @@ type (
 		Namespace string `json:"namespace"`
 	}
 
+	// Image to use for the task.  Images can be specified as an image tag as used by a docker registry, or as an object declaring type and name/namespace
+	IndexedDockerImage struct {
+		Namespace string `json:"namespace"`
+
+		Path string `json:"path"`
+
+		// Possible values:
+		//   * "indexed-image"
+		Type string `json:"type"`
+	}
+
 	// Configuration for task logs.
 	//
 	// Since: generic-worker 48.2.0
@@ -380,6 +567,20 @@ type (
 		// Default:    "public/logs/live.log"
 		Live string `json:"live" default:"public/logs/live.log"`
 	}
+
+	// Image to use for the task.  Images can be specified as an image tag as used by a docker registry, or as an object declaring type and name/namespace
+	NamedDockerImage struct {
+		Name string `json:"name"`
+
+		// Possible values:
+		//   * "docker-image"
+		Type string `json:"type"`
+	}
+
+	// One of:
+	//   * GenericWorkerPayload
+	//   * DockerWorkerPayload
+	Payload json.RawMessage
 
 	// Byte-for-byte literal inline content of file/archive, up to 64KB in size.
 	//
@@ -479,6 +680,22 @@ type (
 	}
 )
 
+// MarshalJSON calls json.RawMessage method of the same name. Required since
+// Payload is of type json.RawMessage...
+func (m *Payload) MarshalJSON() ([]byte, error) {
+	x := json.RawMessage(*m)
+	return (&x).MarshalJSON()
+}
+
+// UnmarshalJSON is a copy of the json.RawMessage implementation.
+func (m *Payload) UnmarshalJSON(data []byte) error {
+	if m == nil {
+		return errors.New("Payload: UnmarshalJSON on nil pointer")
+	}
+	*m = append((*m)[0:0], data...)
+	return nil
+}
+
 // Returns json schema for the payload part of the task definition. Please
 // note we use a go string and do not load an external file, since we want this
 // to be *part of the compiled executable*. If this sat in another file that
@@ -495,8 +712,35 @@ func JSONSchema() string {
 	return `{
   "$id": "/schemas/generic-worker/multiuser_posix.json#",
   "$schema": "/schemas/common/metaschema.json#",
-  "additionalProperties": false,
   "definitions": {
+    "artifact": {
+      "additionalProperties": false,
+      "properties": {
+        "expires": {
+          "format": "date-time",
+          "title": "Date when artifact should expire must be in the future.",
+          "type": "string"
+        },
+        "path": {
+          "title": "Location of artifact in container, as an absolute path.",
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "file",
+            "directory"
+          ],
+          "title": "Artifact upload type.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "type",
+        "path"
+      ],
+      "title": "Docker Worker Artifact",
+      "type": "object"
+    },
     "content": {
       "oneOf": [
         {
@@ -722,218 +966,500 @@ func JSONSchema() string {
       "type": "object"
     }
   },
-  "description": "This schema defines the structure of the ` + "`" + `payload` + "`" + ` property referred to in a\nTaskcluster Task definition.",
-  "properties": {
-    "artifacts": {
-      "description": "Artifacts to be published.\n\nSince: generic-worker 1.0.0",
-      "items": {
-        "additionalProperties": false,
-        "properties": {
-          "contentEncoding": {
-            "description": "Content-Encoding for the artifact. If not provided, ` + "`" + `gzip` + "`" + ` will be used, except for the\nfollowing file extensions, where ` + "`" + `identity` + "`" + ` will be used, since they are already\ncompressed:\n\n* 7z\n* bz2\n* deb\n* dmg\n* flv\n* gif\n* gz\n* jpeg\n* jpg\n* png\n* swf\n* tbz\n* tgz\n* webp\n* whl\n* woff\n* woff2\n* xz\n* zip\n* zst\n\nNote, setting ` + "`" + `contentEncoding` + "`" + ` on a directory artifact will apply the same content\nencoding to all the files contained in the directory.\n\nSince: generic-worker 16.2.0",
-            "enum": [
-              "identity",
-              "gzip"
-            ],
-            "title": "Content-Encoding header when serving artifact over HTTP.",
-            "type": "string"
-          },
-          "contentType": {
-            "description": "Explicitly set the value of the HTTP ` + "`" + `Content-Type` + "`" + ` response header when the artifact(s)\nis/are served over HTTP(S). If not provided (this property is optional) the worker will\nguess the content type of artifacts based on the filename extension of the file storing\nthe artifact content. It does this by looking at the system filename-to-mimetype mappings\ndefined in multiple ` + "`" + `mime.types` + "`" + ` files located under ` + "`" + `/etc` + "`" + `. Note, setting ` + "`" + `contentType` + "`" + `\non a directory artifact will apply the same contentType to all files contained in the\ndirectory.\n\nSee [mime.TypeByExtension](https://pkg.go.dev/mime#TypeByExtension).\n\nSince: generic-worker 10.4.0",
-            "title": "Content-Type header when serving artifact over HTTP",
-            "type": "string"
-          },
-          "expires": {
-            "description": "Date when artifact should expire must be in the future, no earlier than task deadline, but\nno later than task expiry. If not set, defaults to task expiry.\n\nSince: generic-worker 1.0.0",
-            "format": "date-time",
-            "title": "Expiry date and time",
-            "type": "string"
-          },
-          "name": {
-            "description": "Name of the artifact, as it will be published. If not set, ` + "`" + `path` + "`" + ` will be used.\nConventionally (although not enforced) path elements are forward slash separated. Example:\n` + "`" + `public/build/a/house` + "`" + `. Note, no scopes are required to read artifacts beginning ` + "`" + `public/` + "`" + `.\nArtifact names not beginning ` + "`" + `public/` + "`" + ` are scope-protected (caller requires scopes to\ndownload the artifact). See the Queue documentation for more information.\n\nSince: generic-worker 8.1.0",
-            "title": "Name of the artifact",
-            "type": "string"
-          },
-          "path": {
-            "description": "Relative path of the file/directory from the task directory. Note this is not an absolute\npath as is typically used in docker-worker, since the absolute task directory name is not\nknown when the task is submitted. Example: ` + "`" + `dist\\regedit.exe` + "`" + `. It doesn't matter if\nforward slashes or backslashes are used.\n\nSince: generic-worker 1.0.0",
-            "title": "Artifact location",
-            "type": "string"
-          },
-          "type": {
-            "description": "Artifacts can be either an individual ` + "`" + `file` + "`" + ` or a ` + "`" + `directory` + "`" + ` containing\npotentially multiple files with recursively included subdirectories.\n\nSince: generic-worker 1.0.0",
-            "enum": [
-              "file",
-              "directory"
-            ],
-            "title": "Artifact upload type.",
-            "type": "string"
-          }
-        },
-        "required": [
-          "type",
-          "path"
-        ],
-        "title": "Artifact",
-        "type": "object"
-      },
-      "title": "Artifacts to be published",
-      "type": "array",
-      "uniqueItems": true
-    },
-    "command": {
-      "description": "One array per command (each command is an array of arguments). Several arrays\nfor several commands.\n\nSince: generic-worker 0.0.1",
-      "items": {
-        "items": {
-          "type": "string"
-        },
-        "minItems": 1,
-        "type": "array",
-        "uniqueItems": false
-      },
-      "minItems": 1,
-      "title": "Commands to run",
-      "type": "array",
-      "uniqueItems": false
-    },
-    "env": {
-      "additionalProperties": {
-        "type": "string"
-      },
-      "description": "Env vars must be string to __string__ mappings (not number or boolean). For example:\n` + "`" + `` + "`" + `` + "`" + `\n{\n  \"PATH\": \"/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin\",\n  \"GOOS\": \"darwin\",\n  \"FOO_ENABLE\": \"true\",\n  \"BAR_TOTAL\": \"3\"\n}\n` + "`" + `` + "`" + `` + "`" + `\n\nNote, the following environment variables will automatically be set in the task\ncommands, but may be overridden by environment variables in the task payload:\n  * ` + "`" + `HOME` + "`" + ` - the home directory of the task user\n  * ` + "`" + `PATH` + "`" + ` - ` + "`" + `/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin` + "`" + `\n  * ` + "`" + `USER` + "`" + ` - the name of the task user\n\nThe following environment variables will automatically be set in the task\ncommands, and may not be overridden by environment variables in the task payload:\n  * ` + "`" + `DISPLAY` + "`" + ` - ` + "`" + `:0` + "`" + ` (Linux only)\n  * ` + "`" + `TASK_ID` + "`" + ` - the task ID of the currently running task\n  * ` + "`" + `RUN_ID` + "`" + ` - the run ID of the currently running task\n  * ` + "`" + `TASKCLUSTER_ROOT_URL` + "`" + ` - the root URL of the taskcluster deployment\n  * ` + "`" + `TASKCLUSTER_PROXY_URL` + "`" + ` (if taskcluster proxy feature enabled) - the\n     taskcluster authentication proxy for making unauthenticated taskcluster\n     API calls\n  * ` + "`" + `TASK_USER_CREDENTIALS` + "`" + ` (if config property ` + "`" + `runTasksAsCurrentUser` + "`" + ` set to\n    ` + "`" + `true` + "`" + ` in ` + "`" + `generic-worker.config` + "`" + ` file - the absolute file location of a\n    json file containing the current task OS user account name and password.\n    This is only useful for the generic-worker multiuser CI tasks, where\n    ` + "`" + `runTasksAsCurrentUser` + "`" + ` is set to ` + "`" + `true` + "`" + `.\n  * ` + "`" + `TASKCLUSTER_WORKER_LOCATION` + "`" + `. See\n    [RFC #0148](https://github.com/taskcluster/taskcluster-rfcs/blob/master/rfcs/0148-taskcluster-worker-location.md)\n    for details.\n\nSince: generic-worker 0.0.1",
-      "title": "Env vars",
-      "type": "object"
-    },
-    "features": {
+  "oneOf": [
+    {
       "additionalProperties": false,
-      "description": "Feature flags enable additional functionality.\n\nSince: generic-worker 5.3.0",
+      "description": "This schema defines the structure of the ` + "`" + `payload` + "`" + ` property referred to in a\nTaskcluster Task definition.",
       "properties": {
-        "backingLog": {
-          "default": true,
-          "description": "The backing log feature publishes a task artifact containing the complete\nstderr and stdout of the task.\n\nSince: generic-worker 48.2.0",
-          "title": "Enable backing log",
-          "type": "boolean"
+        "artifacts": {
+          "description": "Artifacts to be published.\n\nSince: generic-worker 1.0.0",
+          "items": {
+            "additionalProperties": false,
+            "properties": {
+              "contentEncoding": {
+                "description": "Content-Encoding for the artifact. If not provided, ` + "`" + `gzip` + "`" + ` will be used, except for the\nfollowing file extensions, where ` + "`" + `identity` + "`" + ` will be used, since they are already\ncompressed:\n\n* 7z\n* bz2\n* deb\n* dmg\n* flv\n* gif\n* gz\n* jpeg\n* jpg\n* png\n* swf\n* tbz\n* tgz\n* webp\n* whl\n* woff\n* woff2\n* xz\n* zip\n* zst\n\nNote, setting ` + "`" + `contentEncoding` + "`" + ` on a directory artifact will apply the same content\nencoding to all the files contained in the directory.\n\nSince: generic-worker 16.2.0",
+                "enum": [
+                  "identity",
+                  "gzip"
+                ],
+                "title": "Content-Encoding header when serving artifact over HTTP.",
+                "type": "string"
+              },
+              "contentType": {
+                "description": "Explicitly set the value of the HTTP ` + "`" + `Content-Type` + "`" + ` response header when the artifact(s)\nis/are served over HTTP(S). If not provided (this property is optional) the worker will\nguess the content type of artifacts based on the filename extension of the file storing\nthe artifact content. It does this by looking at the system filename-to-mimetype mappings\ndefined in multiple ` + "`" + `mime.types` + "`" + ` files located under ` + "`" + `/etc` + "`" + `. Note, setting ` + "`" + `contentType` + "`" + `\non a directory artifact will apply the same contentType to all files contained in the\ndirectory.\n\nSee [mime.TypeByExtension](https://pkg.go.dev/mime#TypeByExtension).\n\nSince: generic-worker 10.4.0",
+                "title": "Content-Type header when serving artifact over HTTP",
+                "type": "string"
+              },
+              "expires": {
+                "description": "Date when artifact should expire must be in the future, no earlier than task deadline, but\nno later than task expiry. If not set, defaults to task expiry.\n\nSince: generic-worker 1.0.0",
+                "format": "date-time",
+                "title": "Expiry date and time",
+                "type": "string"
+              },
+              "name": {
+                "description": "Name of the artifact, as it will be published. If not set, ` + "`" + `path` + "`" + ` will be used.\nConventionally (although not enforced) path elements are forward slash separated. Example:\n` + "`" + `public/build/a/house` + "`" + `. Note, no scopes are required to read artifacts beginning ` + "`" + `public/` + "`" + `.\nArtifact names not beginning ` + "`" + `public/` + "`" + ` are scope-protected (caller requires scopes to\ndownload the artifact). See the Queue documentation for more information.\n\nSince: generic-worker 8.1.0",
+                "title": "Name of the artifact",
+                "type": "string"
+              },
+              "path": {
+                "description": "Relative path of the file/directory from the task directory. Note this is not an absolute\npath as is typically used in docker-worker, since the absolute task directory name is not\nknown when the task is submitted. Example: ` + "`" + `dist\\regedit.exe` + "`" + `. It doesn't matter if\nforward slashes or backslashes are used.\n\nSince: generic-worker 1.0.0",
+                "title": "Artifact location",
+                "type": "string"
+              },
+              "type": {
+                "description": "Artifacts can be either an individual ` + "`" + `file` + "`" + ` or a ` + "`" + `directory` + "`" + ` containing\npotentially multiple files with recursively included subdirectories.\n\nSince: generic-worker 1.0.0",
+                "enum": [
+                  "file",
+                  "directory"
+                ],
+                "title": "Artifact upload type.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "type",
+              "path"
+            ],
+            "title": "Artifact",
+            "type": "object"
+          },
+          "title": "Artifacts to be published",
+          "type": "array",
+          "uniqueItems": true
         },
-        "chainOfTrust": {
-          "description": "Artifacts named ` + "`" + `public/chain-of-trust.json` + "`" + ` and\n` + "`" + `public/chain-of-trust.json.sig` + "`" + ` should be generated which will\ninclude information for downstream tasks to build a level of trust\nfor the artifacts produced by the task and the environment it ran in.\n\nSince: generic-worker 5.3.0",
-          "title": "Enable generation of signed Chain of Trust artifacts",
-          "type": "boolean"
+        "command": {
+          "description": "One array per command (each command is an array of arguments). Several arrays\nfor several commands.\n\nSince: generic-worker 0.0.1",
+          "items": {
+            "items": {
+              "type": "string"
+            },
+            "minItems": 1,
+            "type": "array",
+            "uniqueItems": false
+          },
+          "minItems": 1,
+          "title": "Commands to run",
+          "type": "array",
+          "uniqueItems": false
         },
-        "interactive": {
-          "description": "This allows you to interactively run commands from within the worker\nas the task user. This may be useful for debugging purposes.\nCan be used for SSH-like access to the running worker.\nNote that this feature works differently from the ` + "`" + `interactive` + "`" + ` feature\nin docker worker, which ` + "`" + `docker exec` + "`" + `s into the running container.\nSince tasks on generic worker are not guaranteed to be running in a\ncontainer, a bash shell is started on the task user's account.\nA user can then ` + "`" + `docker exec` + "`" + ` into the a running container, if there\nis one.\n\nSince: generic-worker 49.2.0",
-          "title": "Interactive shell",
-          "type": "boolean"
+        "env": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Env vars must be string to __string__ mappings (not number or boolean). For example:\n` + "`" + `` + "`" + `` + "`" + `\n{\n  \"PATH\": \"/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin\",\n  \"GOOS\": \"darwin\",\n  \"FOO_ENABLE\": \"true\",\n  \"BAR_TOTAL\": \"3\"\n}\n` + "`" + `` + "`" + `` + "`" + `\n\nNote, the following environment variables will automatically be set in the task\ncommands, but may be overridden by environment variables in the task payload:\n  * ` + "`" + `HOME` + "`" + ` - the home directory of the task user\n  * ` + "`" + `PATH` + "`" + ` - ` + "`" + `/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin` + "`" + `\n  * ` + "`" + `USER` + "`" + ` - the name of the task user\n\nThe following environment variables will automatically be set in the task\ncommands, and may not be overridden by environment variables in the task payload:\n  * ` + "`" + `DISPLAY` + "`" + ` - ` + "`" + `:0` + "`" + ` (Linux only)\n  * ` + "`" + `TASK_ID` + "`" + ` - the task ID of the currently running task\n  * ` + "`" + `RUN_ID` + "`" + ` - the run ID of the currently running task\n  * ` + "`" + `TASKCLUSTER_ROOT_URL` + "`" + ` - the root URL of the taskcluster deployment\n  * ` + "`" + `TASKCLUSTER_PROXY_URL` + "`" + ` (if taskcluster proxy feature enabled) - the\n    taskcluster authentication proxy for making unauthenticated taskcluster\n    API calls\n  * ` + "`" + `TASK_USER_CREDENTIALS` + "`" + ` (if config property ` + "`" + `runTasksAsCurrentUser` + "`" + ` set to\n    ` + "`" + `true` + "`" + ` in ` + "`" + `generic-worker.config` + "`" + ` file - the absolute file location of a\n    json file containing the current task OS user account name and password.\n    This is only useful for the generic-worker multiuser CI tasks, where\n    ` + "`" + `runTasksAsCurrentUser` + "`" + ` is set to ` + "`" + `true` + "`" + `.\n  * ` + "`" + `TASKCLUSTER_WORKER_LOCATION` + "`" + `. See\n    [RFC #0148](https://github.com/taskcluster/taskcluster-rfcs/blob/master/rfcs/0148-taskcluster-worker-location.md)\n    for details.\n\nSince: generic-worker 0.0.1",
+          "title": "Env vars",
+          "type": "object"
         },
-        "liveLog": {
-          "default": true,
-          "description": "The live log feature streams the combined stderr and stdout to a task artifact\nso that the output is available while the task is running.\n\nSince: generic-worker 48.2.0",
-          "title": "Enable [livelog](https://github.com/taskcluster/taskcluster/tree/main/tools/livelog)",
-          "type": "boolean"
+        "features": {
+          "additionalProperties": false,
+          "description": "Feature flags enable additional functionality.\n\nSince: generic-worker 5.3.0",
+          "properties": {
+            "backingLog": {
+              "default": true,
+              "description": "The backing log feature publishes a task artifact containing the complete\nstderr and stdout of the task.\n\nSince: generic-worker 48.2.0",
+              "title": "Enable backing log",
+              "type": "boolean"
+            },
+            "chainOfTrust": {
+              "description": "Artifacts named ` + "`" + `public/chain-of-trust.json` + "`" + ` and\n` + "`" + `public/chain-of-trust.json.sig` + "`" + ` should be generated which will\ninclude information for downstream tasks to build a level of trust\nfor the artifacts produced by the task and the environment it ran in.\n\nSince: generic-worker 5.3.0",
+              "title": "Enable generation of signed Chain of Trust artifacts",
+              "type": "boolean"
+            },
+            "interactive": {
+              "description": "This allows you to interactively run commands from within the worker\nas the task user. This may be useful for debugging purposes.\nCan be used for SSH-like access to the running worker.\nNote that this feature works differently from the ` + "`" + `interactive` + "`" + ` feature\nin docker worker, which ` + "`" + `docker exec` + "`" + `s into the running container.\nSince tasks on generic worker are not guaranteed to be running in a\ncontainer, a bash shell is started on the task user's account.\nA user can then ` + "`" + `docker exec` + "`" + ` into the a running container, if there\nis one.\n\nSince: generic-worker 49.2.0",
+              "title": "Interactive shell",
+              "type": "boolean"
+            },
+            "liveLog": {
+              "default": true,
+              "description": "The live log feature streams the combined stderr and stdout to a task artifact\nso that the output is available while the task is running.\n\nSince: generic-worker 48.2.0",
+              "title": "Enable [livelog](https://github.com/taskcluster/taskcluster/tree/main/tools/livelog)",
+              "type": "boolean"
+            },
+            "loopbackVideo": {
+              "description": "Video loopback device created using v4l2loopback.\nA video device will be available for the task. Its\nlocation will be passed to the task via environment\nvariable ` + "`" + `TASKCLUSTER_VIDEO_DEVICE` + "`" + `. The\nlocation will be ` + "`" + `/dev/video\u003cN\u003e` + "`" + ` where ` + "`" + `\u003cN\u003e` + "`" + ` is\nan integer between 0 and 255. The value of ` + "`" + `\u003cN\u003e` + "`" + `\nis not static, and therefore either the environment\nvariable should be used, or ` + "`" + `/dev` + "`" + ` should be\nscanned in order to determine the correct location.\nTasks should not assume a constant value.\n\nThis feature is only available on Linux. If a task\nis submitted with this feature enabled on a non-Linux,\nposix platform (FreeBSD, macOS), the task will resolve as\n` + "`" + `exception/malformed-payload` + "`" + `.\n\nSince: generic-worker 53.1.0",
+              "title": "Loopback Video device",
+              "type": "boolean"
+            },
+            "taskclusterProxy": {
+              "description": "The taskcluster proxy provides an easy and safe way to make authenticated\ntaskcluster requests within the scope(s) of a particular task. See\n[the github project](https://github.com/taskcluster/taskcluster/tree/main/tools/taskcluster-proxy) for more information.\n\nSince: generic-worker 10.6.0",
+              "title": "Run [taskcluster-proxy](https://github.com/taskcluster/taskcluster/tree/main/tools/taskcluster-proxy) to allow tasks to dynamically proxy requests to taskcluster services",
+              "type": "boolean"
+            }
+          },
+          "required": [],
+          "title": "Feature flags",
+          "type": "object"
         },
-        "loopbackVideo": {
-          "description": "Video loopback device created using v4l2loopback.\nA video device will be available for the task. Its\nlocation will be passed to the task via environment\nvariable ` + "`" + `TASKCLUSTER_VIDEO_DEVICE` + "`" + `. The\nlocation will be ` + "`" + `/dev/video\u003cN\u003e` + "`" + ` where ` + "`" + `\u003cN\u003e` + "`" + ` is\nan integer between 0 and 255. The value of ` + "`" + `\u003cN\u003e` + "`" + `\nis not static, and therefore either the environment\nvariable should be used, or ` + "`" + `/dev` + "`" + ` should be\nscanned in order to determine the correct location.\nTasks should not assume a constant value.\n\nThis feature is only available on Linux. If a task\nis submitted with this feature enabled on a non-Linux,\nposix platform (FreeBSD, macOS), the task will resolve as\n` + "`" + `exception/malformed-payload` + "`" + `.\n\nSince: generic-worker 53.1.0",
-          "title": "Loopback Video device",
-          "type": "boolean"
+        "logs": {
+          "additionalProperties": false,
+          "description": "Configuration for task logs.\n\nSince: generic-worker 48.2.0",
+          "properties": {
+            "backing": {
+              "default": "public/logs/live_backing.log",
+              "description": "Specifies a custom name for the backing log artifact.\nThis is only used if ` + "`" + `features.backingLog` + "`" + ` is ` + "`" + `true` + "`" + `.\n\nSince: generic-worker 48.2.0",
+              "title": "Backing log artifact name",
+              "type": "string"
+            },
+            "live": {
+              "default": "public/logs/live.log",
+              "description": "Specifies a custom name for the live log artifact.\nThis is only used if ` + "`" + `features.liveLog` + "`" + ` is ` + "`" + `true` + "`" + `.\n\nSince: generic-worker 48.2.0",
+              "title": "Live log artifact name",
+              "type": "string"
+            }
+          },
+          "required": [],
+          "title": "Logs",
+          "type": "object"
         },
-        "taskclusterProxy": {
-          "description": "The taskcluster proxy provides an easy and safe way to make authenticated\ntaskcluster requests within the scope(s) of a particular task. See\n[the github project](https://github.com/taskcluster/taskcluster/tree/main/tools/taskcluster-proxy) for more information.\n\nSince: generic-worker 10.6.0",
-          "title": "Run [taskcluster-proxy](https://github.com/taskcluster/taskcluster/tree/main/tools/taskcluster-proxy) to allow tasks to dynamically proxy requests to taskcluster services",
-          "type": "boolean"
+        "maxRunTime": {
+          "description": "Maximum time the task container can run in seconds.\n\nSince: generic-worker 0.0.1",
+          "maximum": 86400,
+          "minimum": 1,
+          "multipleOf": 1,
+          "title": "Maximum run time in seconds",
+          "type": "integer"
+        },
+        "mounts": {
+          "description": "Directories and/or files to be mounted.\n\nSince: generic-worker 5.4.0",
+          "items": {
+            "$ref": "#/definitions/mount",
+            "title": "Mount"
+          },
+          "type": "array",
+          "uniqueItems": false
+        },
+        "onExitStatus": {
+          "additionalProperties": false,
+          "description": "By default tasks will be resolved with ` + "`" + `state/reasonResolved` + "`" + `: ` + "`" + `completed/completed` + "`" + `\nif all task commands have a zero exit code, or ` + "`" + `failed/failed` + "`" + ` if any command has a\nnon-zero exit code. This payload property allows customsation of the task resolution\nbased on exit code of task commands.",
+          "properties": {
+            "purgeCaches": {
+              "description": "If the task exists with a purge caches exit status, all caches\nassociated with the task will be purged.\n\nSince: generic-worker 49.0.0",
+              "items": {
+                "minimum": 1,
+                "title": "Exit statuses",
+                "type": "integer"
+              },
+              "title": "Purge caches exit status",
+              "type": "array",
+              "uniqueItems": true
+            },
+            "retry": {
+              "description": "Exit codes for any command in the task payload to cause this task to\nbe resolved as ` + "`" + `exception/intermittent-task` + "`" + `. Typically the Queue\nwill then schedule a new run of the existing ` + "`" + `taskId` + "`" + ` (rerun) if not\nall task runs have been exhausted.\n\nSee [itermittent tasks](https://docs.taskcluster.net/docs/reference/platform/taskcluster-queue/docs/worker-interaction#intermittent-tasks) for more detail.\n\nSince: generic-worker 10.10.0",
+              "items": {
+                "minimum": 1,
+                "title": "Exit codes",
+                "type": "integer"
+              },
+              "title": "Intermittent task exit codes",
+              "type": "array",
+              "uniqueItems": true
+            }
+          },
+          "required": [],
+          "title": "Exit code handling",
+          "type": "object"
+        },
+        "osGroups": {
+          "description": "A list of OS Groups that the task user should be a member of. Not yet implemented on\nnon-Windows platforms, therefore this optional property may only be an empty array if\nprovided.\n\nSince: generic-worker 6.0.0",
+          "items": {
+            "type": "string"
+          },
+          "maxItems": 0,
+          "title": "OS Groups",
+          "type": "array",
+          "uniqueItems": false
+        },
+        "supersederUrl": {
+          "description": "This property is allowed for backward compatibility, but is unused.",
+          "title": "unused",
+          "type": "string"
         }
       },
-      "required": [],
-      "title": "Feature flags",
+      "required": [
+        "command",
+        "maxRunTime"
+      ],
+      "title": "Generic worker payload",
       "type": "object"
     },
-    "logs": {
+    {
       "additionalProperties": false,
-      "description": "Configuration for task logs.\n\nSince: generic-worker 48.2.0",
+      "description": "` + "`" + `.payload` + "`" + ` field of the queue.",
       "properties": {
-        "backing": {
-          "default": "public/logs/live_backing.log",
-          "description": "Specifies a custom name for the backing log artifact.\nThis is only used if ` + "`" + `features.backingLog` + "`" + ` is ` + "`" + `true` + "`" + `.\n\nSince: generic-worker 48.2.0",
-          "title": "Backing log artifact name",
-          "type": "string"
+        "artifacts": {
+          "additionalProperties": {
+            "$ref": "#/definitions/artifact"
+          },
+          "description": "Artifact upload map example: ` + "`" + `` + "`" + `` + "`" + `{\"public/build.tar.gz\": {\"path\": \"/home/worker/build.tar.gz\", \"expires\": \"2016-05-28T16:12:56.693817Z\", \"type\": \"file\"}}` + "`" + `` + "`" + `` + "`" + `",
+          "title": "Artifacts",
+          "type": "object"
         },
-        "live": {
+        "cache": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Caches are mounted within the docker container at the mount point specified. Example: ` + "`" + `` + "`" + `` + "`" + `{ \"CACHE NAME\": \"/mount/path/in/container\" }` + "`" + `` + "`" + `` + "`" + `",
+          "title": "Caches to mount point mapping.",
+          "type": "object"
+        },
+        "capabilities": {
+          "additionalProperties": false,
+          "description": "Set of capabilities that must be enabled or made available to the task container Example: ` + "`" + `` + "`" + `` + "`" + `{ \"capabilities\": { \"privileged\": true }` + "`" + `` + "`" + `` + "`" + `",
+          "properties": {
+            "devices": {
+              "additionalProperties": false,
+              "description": "Allows devices from the host system to be attached to a task container similar to using ` + "`" + `--device` + "`" + ` in docker.",
+              "properties": {
+                "hostSharedMemory": {
+                  "description": "Mount /dev/shm from the host in the container.",
+                  "title": "Host shared memory device (Experimental)",
+                  "type": "boolean"
+                },
+                "kvm": {
+                  "description": "Mount /dev/kvm from the host in the container.",
+                  "title": "/dev/kvm device (Experimental)",
+                  "type": "boolean"
+                },
+                "loopbackAudio": {
+                  "description": "Audio loopback device created using snd-aloop",
+                  "title": "Loopback Audio device",
+                  "type": "boolean"
+                },
+                "loopbackVideo": {
+                  "description": "Video loopback device created using v4l2loopback.",
+                  "title": "Loopback Video device",
+                  "type": "boolean"
+                }
+              },
+              "required": [],
+              "title": "Devices to be attached to task containers",
+              "type": "object"
+            },
+            "privileged": {
+              "default": false,
+              "description": "Allows a task to run in a privileged container, similar to running docker with ` + "`" + `--privileged` + "`" + `.  This only works for worker-types configured to enable it.",
+              "title": "Privileged container",
+              "type": "boolean"
+            }
+          },
+          "required": [],
+          "title": "Capabilities that must be available/enabled for the task container.",
+          "type": "object"
+        },
+        "command": {
+          "default": [],
+          "description": "Example: ` + "`" + `['/bin/bash', '-c', 'ls']` + "`" + `.",
+          "items": {
+            "type": "string"
+          },
+          "title": "Docker command to run (see docker api).",
+          "type": "array"
+        },
+        "env": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Example: ` + "`" + `` + "`" + `` + "`" + `\n{\n  \"PATH\": '/borked/path'\n  \"ENV_NAME\": \"VALUE\"\n}\n` + "`" + `` + "`" + `` + "`" + `",
+          "title": "Environment variable mappings.",
+          "type": "object"
+        },
+        "features": {
+          "additionalProperties": false,
+          "description": "Used to enable additional functionality.",
+          "properties": {
+            "allowPtrace": {
+              "default": false,
+              "description": "This allows you to use the Linux ptrace functionality inside the container; it is otherwise disallowed by Docker's security policy.",
+              "title": "Allow ptrace within the container",
+              "type": "boolean"
+            },
+            "artifacts": {
+              "default": true,
+              "description": "",
+              "title": "Artifact uploads",
+              "type": "boolean"
+            },
+            "bulkLog": {
+              "default": true,
+              "description": "Useful if live logging is not interesting but the overalllog is later on",
+              "title": "Bulk upload the task log into a single artifact",
+              "type": "boolean"
+            },
+            "chainOfTrust": {
+              "default": false,
+              "description": "Artifacts named chain-of-trust.json and chain-of-trust.json.sig should be generated which will include information for downstream tasks to build a level of trust for the artifacts produced by the task and the environment it ran in.",
+              "title": "Enable generation of ed25519-signed Chain of Trust artifacts",
+              "type": "boolean"
+            },
+            "dind": {
+              "default": false,
+              "description": "Runs docker-in-docker and binds ` + "`" + `/var/run/docker.sock` + "`" + ` into the container. Doesn't allow privileged mode, capabilities or host volume mounts.",
+              "title": "Docker in Docker",
+              "type": "boolean"
+            },
+            "dockerSave": {
+              "default": false,
+              "description": "Uploads docker images as artifacts",
+              "title": "Docker save",
+              "type": "boolean"
+            },
+            "interactive": {
+              "default": false,
+              "description": "This allows you to interactively run commands inside the container and attaches you to the stdin/stdout/stderr over a websocket. Can be used for SSH-like access to docker containers.",
+              "title": "Docker Exec Interactive",
+              "type": "boolean"
+            },
+            "localLiveLog": {
+              "default": true,
+              "description": "Logs are stored on the worker during the duration of tasks and available via http chunked streaming then uploaded to s3",
+              "title": "Enable live logging (worker local)",
+              "type": "boolean"
+            },
+            "taskclusterProxy": {
+              "default": false,
+              "description": "The auth proxy allows making requests to taskcluster/queue and taskcluster/scheduler directly from your task with the same scopes as set in the task. This can be used to make api calls via the [client](https://github.com/taskcluster/taskcluster-client) CURL, etc... Without embedding credentials in the task.",
+              "title": "Taskcluster auth proxy service",
+              "type": "boolean"
+            }
+          },
+          "required": [],
+          "title": "Docker Worker feature flags",
+          "type": "object"
+        },
+        "image": {
+          "description": "Image to use for the task.  Images can be specified as an image tag as used by a docker registry, or as an object declaring type and name/namespace",
+          "oneOf": [
+            {
+              "title": "Docker image name",
+              "type": "string"
+            },
+            {
+              "additionalProperties": false,
+              "properties": {
+                "name": {
+                  "type": "string"
+                },
+                "type": {
+                  "enum": [
+                    "docker-image"
+                  ],
+                  "type": "string"
+                }
+              },
+              "required": [
+                "type",
+                "name"
+              ],
+              "title": "Named docker image",
+              "type": "object"
+            },
+            {
+              "additionalProperties": false,
+              "properties": {
+                "namespace": {
+                  "type": "string"
+                },
+                "path": {
+                  "type": "string"
+                },
+                "type": {
+                  "enum": [
+                    "indexed-image"
+                  ],
+                  "type": "string"
+                }
+              },
+              "required": [
+                "type",
+                "namespace",
+                "path"
+              ],
+              "title": "Indexed docker image",
+              "type": "object"
+            },
+            {
+              "additionalProperties": false,
+              "properties": {
+                "path": {
+                  "type": "string"
+                },
+                "taskId": {
+                  "type": "string"
+                },
+                "type": {
+                  "enum": [
+                    "task-image"
+                  ],
+                  "type": "string"
+                }
+              },
+              "required": [
+                "type",
+                "taskId",
+                "path"
+              ],
+              "title": "Docker image artifact",
+              "type": "object"
+            }
+          ],
+          "title": "Docker image."
+        },
+        "log": {
           "default": "public/logs/live.log",
-          "description": "Specifies a custom name for the live log artifact.\nThis is only used if ` + "`" + `features.liveLog` + "`" + ` is ` + "`" + `true` + "`" + `.\n\nSince: generic-worker 48.2.0",
-          "title": "Live log artifact name",
+          "description": "Specifies a custom name for the livelog artifact. Note that this is also used in determining the name of the backing log artifact name. Backing log artifact name matches livelog artifact name with ` + "`" + `_backing` + "`" + ` appended, prior to the file extension (if present). For example, ` + "`" + `apple/banana.log.txt` + "`" + ` results in livelog artifact ` + "`" + `apple/banana.log.txt` + "`" + ` and backing log artifact ` + "`" + `apple/banana.log_backing.txt` + "`" + `. Defaults to ` + "`" + `public/logs/live.log` + "`" + `.",
+          "title": "Livelog artifact name",
+          "type": "string"
+        },
+        "maxRunTime": {
+          "description": "Maximum time the task container can run in seconds.",
+          "maximum": 86400,
+          "minimum": 1,
+          "multipleOf": 1,
+          "title": "Maximum run time in seconds",
+          "type": "integer"
+        },
+        "onExitStatus": {
+          "additionalProperties": false,
+          "description": "By default docker-worker will fail a task with a non-zero exit status without retrying.  This payload property allows a task owner to define certain exit statuses that will be marked as a retriable exception.",
+          "properties": {
+            "purgeCaches": {
+              "description": "If the task exists with a purge caches exit status, all caches associated with the task will be purged.",
+              "items": {
+                "title": "Exit statuses",
+                "type": "integer"
+              },
+              "title": "Purge caches exit status",
+              "type": "array"
+            },
+            "retry": {
+              "description": "If the task exists with a retriable exit status, the task will be marked as an exception and a new run created.",
+              "items": {
+                "title": "Exit statuses",
+                "type": "integer"
+              },
+              "title": "Retriable exit statuses",
+              "type": "array"
+            }
+          },
+          "required": [],
+          "title": "Exit status handling",
+          "type": "object"
+        },
+        "supersederUrl": {
+          "description": "Maintained for backward compatibility, but no longer used",
+          "title": "(unused)",
           "type": "string"
         }
       },
-      "required": [],
-      "title": "Logs",
+      "required": [
+        "image",
+        "maxRunTime"
+      ],
+      "title": "Docker worker payload",
       "type": "object"
-    },
-    "maxRunTime": {
-      "description": "Maximum time the task container can run in seconds.\n\nSince: generic-worker 0.0.1",
-      "maximum": 86400,
-      "minimum": 1,
-      "multipleOf": 1,
-      "title": "Maximum run time in seconds",
-      "type": "integer"
-    },
-    "mounts": {
-      "description": "Directories and/or files to be mounted.\n\nSince: generic-worker 5.4.0",
-      "items": {
-        "$ref": "#/definitions/mount",
-        "title": "Mount"
-      },
-      "type": "array",
-      "uniqueItems": false
-    },
-    "onExitStatus": {
-      "additionalProperties": false,
-      "description": "By default tasks will be resolved with ` + "`" + `state/reasonResolved` + "`" + `: ` + "`" + `completed/completed` + "`" + `\nif all task commands have a zero exit code, or ` + "`" + `failed/failed` + "`" + ` if any command has a\nnon-zero exit code. This payload property allows customsation of the task resolution\nbased on exit code of task commands.",
-      "properties": {
-        "purgeCaches": {
-          "description": "If the task exists with a purge caches exit status, all caches\nassociated with the task will be purged.\n\nSince: generic-worker 49.0.0",
-          "items": {
-            "minimum": 1,
-            "title": "Exit statuses",
-            "type": "integer"
-          },
-          "title": "Purge caches exit status",
-          "type": "array",
-          "uniqueItems": true
-        },
-        "retry": {
-          "description": "Exit codes for any command in the task payload to cause this task to\nbe resolved as ` + "`" + `exception/intermittent-task` + "`" + `. Typically the Queue\nwill then schedule a new run of the existing ` + "`" + `taskId` + "`" + ` (rerun) if not\nall task runs have been exhausted.\n\nSee [itermittent tasks](https://docs.taskcluster.net/docs/reference/platform/taskcluster-queue/docs/worker-interaction#intermittent-tasks) for more detail.\n\nSince: generic-worker 10.10.0",
-          "items": {
-            "minimum": 1,
-            "title": "Exit codes",
-            "type": "integer"
-          },
-          "title": "Intermittent task exit codes",
-          "type": "array",
-          "uniqueItems": true
-        }
-      },
-      "required": [],
-      "title": "Exit code handling",
-      "type": "object"
-    },
-    "osGroups": {
-      "description": "A list of OS Groups that the task user should be a member of. Not yet implemented on\nnon-Windows platforms, therefore this optional property may only be an empty array if\nprovided.\n\nSince: generic-worker 6.0.0",
-      "items": {
-        "type": "string"
-      },
-      "maxItems": 0,
-      "title": "OS Groups",
-      "type": "array",
-      "uniqueItems": false
-    },
-    "supersederUrl": {
-      "description": "This property is allowed for backward compatibility, but is unused.",
-      "title": "unused",
-      "type": "string"
     }
-  },
-  "required": [
-    "command",
-    "maxRunTime"
   ],
-  "title": "Generic worker payload",
-  "type": "object"
+  "title": "Payload"
 }`
 }

--- a/workers/generic-worker/helper_test.go
+++ b/workers/generic-worker/helper_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/taskcluster/taskcluster/v54/clients/client-go/tcqueue"
 	"github.com/taskcluster/taskcluster/v54/internal/mocktc"
 	"github.com/taskcluster/taskcluster/v54/internal/mocktc/tc"
+	"github.com/taskcluster/taskcluster/v54/tools/d2g/dockerworker"
 	"github.com/taskcluster/taskcluster/v54/workers/generic-worker/fileutil"
 	"github.com/taskcluster/taskcluster/v54/workers/generic-worker/gwconfig"
 )
@@ -58,14 +59,14 @@ func testWorkerType() string {
 	return "test-" + strings.ToLower(strings.Replace(slugid.Nice(), "_", "", -1)) + "-a"
 }
 
-func scheduleTask(t *testing.T, td *tcqueue.TaskDefinitionRequest, payload GenericWorkerPayload) (taskID string) {
+func scheduleTask[P GenericWorkerPayload | dockerworker.DockerWorkerPayload](t *testing.T, td *tcqueue.TaskDefinitionRequest, payload P) (taskID string) {
 	t.Helper()
 	taskID = slugid.Nice()
 	scheduleNamedTask(t, td, payload, taskID)
 	return
 }
 
-func scheduleNamedTask(t *testing.T, td *tcqueue.TaskDefinitionRequest, payload GenericWorkerPayload, taskID string) {
+func scheduleNamedTask[P GenericWorkerPayload | dockerworker.DockerWorkerPayload](t *testing.T, td *tcqueue.TaskDefinitionRequest, payload P, taskID string) {
 	t.Helper()
 	if td.Payload == nil {
 		b, err := json.Marshal(&payload)
@@ -199,7 +200,7 @@ func LogText(t *testing.T) string {
 	return string(bytes)
 }
 
-func submitAndAssert(t *testing.T, td *tcqueue.TaskDefinitionRequest, payload GenericWorkerPayload, state, reason string) (taskID string) {
+func submitAndAssert[P GenericWorkerPayload | dockerworker.DockerWorkerPayload](t *testing.T, td *tcqueue.TaskDefinitionRequest, payload P, state, reason string) (taskID string) {
 	t.Helper()
 	taskID = scheduleTask(t, td, payload)
 	ensureResolution(t, taskID, state, reason)

--- a/workers/generic-worker/payload_darwin.go
+++ b/workers/generic-worker/payload_darwin.go
@@ -1,0 +1,9 @@
+//go:build darwin
+
+package main
+
+import "fmt"
+
+func (task *TaskRun) convertDockerWorkerPayload() *CommandExecutionError {
+	return executionError(malformedPayload, errored, fmt.Errorf("Docker Worker payload conversion using d2g is not supported on macOS"))
+}

--- a/workers/generic-worker/payload_freebsd.go
+++ b/workers/generic-worker/payload_freebsd.go
@@ -1,0 +1,9 @@
+//go:build freebsd
+
+package main
+
+import "fmt"
+
+func (task *TaskRun) convertDockerWorkerPayload() *CommandExecutionError {
+	return executionError(malformedPayload, errored, fmt.Errorf("Docker Worker payload conversion using d2g is not supported on FreeBSD"))
+}

--- a/workers/generic-worker/payload_linux.go
+++ b/workers/generic-worker/payload_linux.go
@@ -1,0 +1,50 @@
+//go:build linux
+
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/mcuadros/go-defaults"
+	"github.com/taskcluster/taskcluster/v54/tools/d2g"
+	"github.com/taskcluster/taskcluster/v54/tools/d2g/dockerworker"
+)
+
+func (task *TaskRun) convertDockerWorkerPayload() *CommandExecutionError {
+	jsonPayload := task.Definition.Payload
+
+	// Convert the validated JSON input
+	dwPayload := new(dockerworker.DockerWorkerPayload)
+	defaults.SetDefaults(dwPayload)
+	err := json.Unmarshal(jsonPayload, &dwPayload)
+	if err != nil {
+		return MalformedPayloadError(err)
+	}
+
+	// Convert dwPayload to gwPayload
+	gwPayload, err := d2g.Convert(dwPayload)
+	if err != nil {
+		return executionError(internalError, errored, fmt.Errorf("failed to convert docker worker payload to a generic worker payload: %v", err))
+	}
+	task.Definition.Scopes = d2g.Scopes(task.Definition.Scopes)
+
+	// Convert gwPayload to JSON
+	formattedActualGWPayload, err := json.Marshal(*gwPayload)
+	if err != nil {
+		return executionError(malformedPayload, errored, fmt.Errorf("cannot convert Generic Worker payload %#v to JSON: %s", *gwPayload, err))
+	}
+
+	// Validate the JSON output against the schema
+	validateErr := task.validateJSON(formattedActualGWPayload, JSONSchema())
+	if validateErr != nil {
+		return executionError(malformedPayload, errored, fmt.Errorf("d2g output validation failed: %v", validateErr))
+	}
+
+	err = json.Unmarshal(formattedActualGWPayload, &task.Payload)
+	if err != nil {
+		return MalformedPayloadError(err)
+	}
+
+	return nil
+}

--- a/workers/generic-worker/payload_windows.go
+++ b/workers/generic-worker/payload_windows.go
@@ -1,0 +1,9 @@
+//go:build windows
+
+package main
+
+import "fmt"
+
+func (task *TaskRun) convertDockerWorkerPayload() *CommandExecutionError {
+	return executionError(malformedPayload, errored, fmt.Errorf("Docker Worker payload conversion using d2g is not supported on Windows"))
+}

--- a/workers/generic-worker/schemas/multiuser_posix.yml
+++ b/workers/generic-worker/schemas/multiuser_posix.yml
@@ -1,369 +1,604 @@
+---
 $schema: "/schemas/common/metaschema.json#"
 $id: "/schemas/generic-worker/multiuser_posix.json#"
-title: Generic worker payload
-description: |-
-  This schema defines the structure of the `payload` property referred to in a
-  Taskcluster Task definition.
-type: object
-required:
-- command
-- maxRunTime
-additionalProperties: false
-properties:
-  command:
-    title: Commands to run
-    type: array
-    minItems: 1
-    uniqueItems: false
-    items:
+title: Payload
+oneOf:
+- title: Generic worker payload
+  description: |-
+    This schema defines the structure of the `payload` property referred to in a
+    Taskcluster Task definition.
+  type: object
+  required:
+  - command
+  - maxRunTime
+  additionalProperties: false
+  properties:
+    command:
+      title: Commands to run
       type: array
       minItems: 1
       uniqueItems: false
       items:
-        type: string
-    description: |-
-      One array per command (each command is an array of arguments). Several arrays
-      for several commands.
+        type: array
+        minItems: 1
+        uniqueItems: false
+        items:
+          type: string
+      description: |-
+        One array per command (each command is an array of arguments). Several arrays
+        for several commands.
 
-      Since: generic-worker 0.0.1
-  env:
-    title: Env vars
-    description: |-
-      Env vars must be string to __string__ mappings (not number or boolean). For example:
-      ```
-      {
-        "PATH": "/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin",
-        "GOOS": "darwin",
-        "FOO_ENABLE": "true",
-        "BAR_TOTAL": "3"
-      }
-      ```
+        Since: generic-worker 0.0.1
+    env:
+      title: Env vars
+      description: |-
+        Env vars must be string to __string__ mappings (not number or boolean). For example:
+        ```
+        {
+          "PATH": "/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin",
+          "GOOS": "darwin",
+          "FOO_ENABLE": "true",
+          "BAR_TOTAL": "3"
+        }
+        ```
 
-      Note, the following environment variables will automatically be set in the task
-      commands, but may be overridden by environment variables in the task payload:
-        * `HOME` - the home directory of the task user
-        * `PATH` - `/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin`
-        * `USER` - the name of the task user
+        Note, the following environment variables will automatically be set in the task
+        commands, but may be overridden by environment variables in the task payload:
+          * `HOME` - the home directory of the task user
+          * `PATH` - `/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin`
+          * `USER` - the name of the task user
 
-      The following environment variables will automatically be set in the task
-      commands, and may not be overridden by environment variables in the task payload:
-        * `DISPLAY` - `:0` (Linux only)
-        * `TASK_ID` - the task ID of the currently running task
-        * `RUN_ID` - the run ID of the currently running task
-        * `TASKCLUSTER_ROOT_URL` - the root URL of the taskcluster deployment
-        * `TASKCLUSTER_PROXY_URL` (if taskcluster proxy feature enabled) - the
-           taskcluster authentication proxy for making unauthenticated taskcluster
-           API calls
-        * `TASK_USER_CREDENTIALS` (if config property `runTasksAsCurrentUser` set to
-          `true` in `generic-worker.config` file - the absolute file location of a
-          json file containing the current task OS user account name and password.
-          This is only useful for the generic-worker multiuser CI tasks, where
-          `runTasksAsCurrentUser` is set to `true`.
-        * `TASKCLUSTER_WORKER_LOCATION`. See
-          [RFC #0148](https://github.com/taskcluster/taskcluster-rfcs/blob/master/rfcs/0148-taskcluster-worker-location.md)
-          for details.
+        The following environment variables will automatically be set in the task
+        commands, and may not be overridden by environment variables in the task payload:
+          * `DISPLAY` - `:0` (Linux only)
+          * `TASK_ID` - the task ID of the currently running task
+          * `RUN_ID` - the run ID of the currently running task
+          * `TASKCLUSTER_ROOT_URL` - the root URL of the taskcluster deployment
+          * `TASKCLUSTER_PROXY_URL` (if taskcluster proxy feature enabled) - the
+            taskcluster authentication proxy for making unauthenticated taskcluster
+            API calls
+          * `TASK_USER_CREDENTIALS` (if config property `runTasksAsCurrentUser` set to
+            `true` in `generic-worker.config` file - the absolute file location of a
+            json file containing the current task OS user account name and password.
+            This is only useful for the generic-worker multiuser CI tasks, where
+            `runTasksAsCurrentUser` is set to `true`.
+          * `TASKCLUSTER_WORKER_LOCATION`. See
+            [RFC #0148](https://github.com/taskcluster/taskcluster-rfcs/blob/master/rfcs/0148-taskcluster-worker-location.md)
+            for details.
 
-      Since: generic-worker 0.0.1
-    type: object
-    additionalProperties:
-      type: string
-  maxRunTime:
-    type: integer
-    title: Maximum run time in seconds
-    description: |-
-      Maximum time the task container can run in seconds.
-
-      Since: generic-worker 0.0.1
-    multipleOf: 1
-    minimum: 1
-    maximum: 86400
-  artifacts:
-    type: array
-    title: Artifacts to be published
-    description: |-
-      Artifacts to be published.
-
-      Since: generic-worker 1.0.0
-    uniqueItems: true
-    items:
+        Since: generic-worker 0.0.1
       type: object
-      title: Artifact
-      additionalProperties: false
-      properties:
-        type:
-          title: Artifact upload type.
-          type: string
-          enum:
-          - file
-          - directory
-          description: |-
-            Artifacts can be either an individual `file` or a `directory` containing
-            potentially multiple files with recursively included subdirectories.
+      additionalProperties:
+        type: string
+    maxRunTime:
+      type: integer
+      title: Maximum run time in seconds
+      description: |-
+        Maximum time the task container can run in seconds.
 
-            Since: generic-worker 1.0.0
-        path:
-          title: Artifact location
-          type: string
-          description: |-
-            Relative path of the file/directory from the task directory. Note this is not an absolute
-            path as is typically used in docker-worker, since the absolute task directory name is not
-            known when the task is submitted. Example: `dist\regedit.exe`. It doesn't matter if
-            forward slashes or backslashes are used.
+        Since: generic-worker 0.0.1
+      multipleOf: 1
+      minimum: 1
+      maximum: 86400
+    artifacts:
+      type: array
+      title: Artifacts to be published
+      description: |-
+        Artifacts to be published.
 
-            Since: generic-worker 1.0.0
-        name:
-          title: Name of the artifact
-          type: string
-          description: |-
-            Name of the artifact, as it will be published. If not set, `path` will be used.
-            Conventionally (although not enforced) path elements are forward slash separated. Example:
-            `public/build/a/house`. Note, no scopes are required to read artifacts beginning `public/`.
-            Artifact names not beginning `public/` are scope-protected (caller requires scopes to
-            download the artifact). See the Queue documentation for more information.
+        Since: generic-worker 1.0.0
+      uniqueItems: true
+      items:
+        type: object
+        title: Artifact
+        additionalProperties: false
+        properties:
+          type:
+            title: Artifact upload type.
+            type: string
+            enum:
+            - file
+            - directory
+            description: |-
+              Artifacts can be either an individual `file` or a `directory` containing
+              potentially multiple files with recursively included subdirectories.
 
-            Since: generic-worker 8.1.0
-        expires:
-          title: Expiry date and time
-          type: string
-          format: date-time
-          description: |-
-            Date when artifact should expire must be in the future, no earlier than task deadline, but
-            no later than task expiry. If not set, defaults to task expiry.
+              Since: generic-worker 1.0.0
+          path:
+            title: Artifact location
+            type: string
+            description: |-
+              Relative path of the file/directory from the task directory. Note this is not an absolute
+              path as is typically used in docker-worker, since the absolute task directory name is not
+              known when the task is submitted. Example: `dist\regedit.exe`. It doesn't matter if
+              forward slashes or backslashes are used.
 
-            Since: generic-worker 1.0.0
-        contentType:
-          title: Content-Type header when serving artifact over HTTP
-          type: string
-          description: |-
-            Explicitly set the value of the HTTP `Content-Type` response header when the artifact(s)
-            is/are served over HTTP(S). If not provided (this property is optional) the worker will
-            guess the content type of artifacts based on the filename extension of the file storing
-            the artifact content. It does this by looking at the system filename-to-mimetype mappings
-            defined in multiple `mime.types` files located under `/etc`. Note, setting `contentType`
-            on a directory artifact will apply the same contentType to all files contained in the
-            directory.
+              Since: generic-worker 1.0.0
+          name:
+            title: Name of the artifact
+            type: string
+            description: |-
+              Name of the artifact, as it will be published. If not set, `path` will be used.
+              Conventionally (although not enforced) path elements are forward slash separated. Example:
+              `public/build/a/house`. Note, no scopes are required to read artifacts beginning `public/`.
+              Artifact names not beginning `public/` are scope-protected (caller requires scopes to
+              download the artifact). See the Queue documentation for more information.
 
-            See [mime.TypeByExtension](https://pkg.go.dev/mime#TypeByExtension).
+              Since: generic-worker 8.1.0
+          expires:
+            title: Expiry date and time
+            type: string
+            format: date-time
+            description: |-
+              Date when artifact should expire must be in the future, no earlier than task deadline, but
+              no later than task expiry. If not set, defaults to task expiry.
 
-            Since: generic-worker 10.4.0
-        contentEncoding:
-          title: Content-Encoding header when serving artifact over HTTP.
-          type: string
-          enum:
+              Since: generic-worker 1.0.0
+          contentType:
+            title: Content-Type header when serving artifact over HTTP
+            type: string
+            description: |-
+              Explicitly set the value of the HTTP `Content-Type` response header when the artifact(s)
+              is/are served over HTTP(S). If not provided (this property is optional) the worker will
+              guess the content type of artifacts based on the filename extension of the file storing
+              the artifact content. It does this by looking at the system filename-to-mimetype mappings
+              defined in multiple `mime.types` files located under `/etc`. Note, setting `contentType`
+              on a directory artifact will apply the same contentType to all files contained in the
+              directory.
+
+              See [mime.TypeByExtension](https://pkg.go.dev/mime#TypeByExtension).
+
+              Since: generic-worker 10.4.0
+          contentEncoding:
+            title: Content-Encoding header when serving artifact over HTTP.
+            type: string
+            enum:
             - identity
             - gzip
+            description: |-
+              Content-Encoding for the artifact. If not provided, `gzip` will be used, except for the
+              following file extensions, where `identity` will be used, since they are already
+              compressed:
+
+              * 7z
+              * bz2
+              * deb
+              * dmg
+              * flv
+              * gif
+              * gz
+              * jpeg
+              * jpg
+              * png
+              * swf
+              * tbz
+              * tgz
+              * webp
+              * whl
+              * woff
+              * woff2
+              * xz
+              * zip
+              * zst
+
+              Note, setting `contentEncoding` on a directory artifact will apply the same content
+              encoding to all the files contained in the directory.
+
+              Since: generic-worker 16.2.0
+        required:
+        - type
+        - path
+    features:
+      title: Feature flags
+      description: |-
+        Feature flags enable additional functionality.
+
+        Since: generic-worker 5.3.0
+      type: object
+      additionalProperties: false
+      required: []
+      properties:
+        chainOfTrust:
+          type: boolean
+          title: Enable generation of signed Chain of Trust artifacts
           description: |-
-            Content-Encoding for the artifact. If not provided, `gzip` will be used, except for the
-            following file extensions, where `identity` will be used, since they are already
-            compressed:
+            Artifacts named `public/chain-of-trust.json` and
+            `public/chain-of-trust.json.sig` should be generated which will
+            include information for downstream tasks to build a level of trust
+            for the artifacts produced by the task and the environment it ran in.
 
-            * 7z
-            * bz2
-            * deb
-            * dmg
-            * flv
-            * gif
-            * gz
-            * jpeg
-            * jpg
-            * png
-            * swf
-            * tbz
-            * tgz
-            * webp
-            * whl
-            * woff
-            * woff2
-            * xz
-            * zip
-            * zst
+            Since: generic-worker 5.3.0
+        taskclusterProxy:
+          type: boolean
+          title: Run [taskcluster-proxy](https://github.com/taskcluster/taskcluster/tree/main/tools/taskcluster-proxy) to allow tasks to dynamically proxy requests to taskcluster services
+          description: |-
+            The taskcluster proxy provides an easy and safe way to make authenticated
+            taskcluster requests within the scope(s) of a particular task. See
+            [the github project](https://github.com/taskcluster/taskcluster/tree/main/tools/taskcluster-proxy) for more information.
 
-            Note, setting `contentEncoding` on a directory artifact will apply the same content
-            encoding to all the files contained in the directory.
+            Since: generic-worker 10.6.0
+        liveLog:
+          type: boolean
+          title: Enable [livelog](https://github.com/taskcluster/taskcluster/tree/main/tools/livelog)
+          description: |-
+            The live log feature streams the combined stderr and stdout to a task artifact
+            so that the output is available while the task is running.
 
-            Since: generic-worker 16.2.0
-      required:
-      - type
-      - path
-  features:
-    title: Feature flags
-    description: |-
-      Feature flags enable additional functionality.
+            Since: generic-worker 48.2.0
+          default: true
+        backingLog:
+          type: boolean
+          title: Enable backing log
+          description: |-
+            The backing log feature publishes a task artifact containing the complete
+            stderr and stdout of the task.
 
-      Since: generic-worker 5.3.0
-    type: object
-    additionalProperties: false
-    required: []
-    properties:
-      chainOfTrust:
-        type: boolean
-        title: Enable generation of signed Chain of Trust artifacts
-        description: |-
-          Artifacts named `public/chain-of-trust.json` and
-          `public/chain-of-trust.json.sig` should be generated which will
-          include information for downstream tasks to build a level of trust
-          for the artifacts produced by the task and the environment it ran in.
+            Since: generic-worker 48.2.0
+          default: true
+        interactive:
+          type: boolean
+          title: Interactive shell
+          description: |-
+            This allows you to interactively run commands from within the worker
+            as the task user. This may be useful for debugging purposes.
+            Can be used for SSH-like access to the running worker.
+            Note that this feature works differently from the `interactive` feature
+            in docker worker, which `docker exec`s into the running container.
+            Since tasks on generic worker are not guaranteed to be running in a
+            container, a bash shell is started on the task user's account.
+            A user can then `docker exec` into the a running container, if there
+            is one.
 
-          Since: generic-worker 5.3.0
-      taskclusterProxy:
-        type: boolean
-        title: Run [taskcluster-proxy](https://github.com/taskcluster/taskcluster/tree/main/tools/taskcluster-proxy) to allow tasks to dynamically proxy requests to taskcluster services
-        description: |-
-          The taskcluster proxy provides an easy and safe way to make authenticated
-          taskcluster requests within the scope(s) of a particular task. See
-          [the github project](https://github.com/taskcluster/taskcluster/tree/main/tools/taskcluster-proxy) for more information.
+            Since: generic-worker 49.2.0
+        loopbackVideo:
+          type: boolean
+          title: Loopback Video device
+          description: |-
+            Video loopback device created using v4l2loopback.
+            A video device will be available for the task. Its
+            location will be passed to the task via environment
+            variable `TASKCLUSTER_VIDEO_DEVICE`. The
+            location will be `/dev/video<N>` where `<N>` is
+            an integer between 0 and 255. The value of `<N>`
+            is not static, and therefore either the environment
+            variable should be used, or `/dev` should be
+            scanned in order to determine the correct location.
+            Tasks should not assume a constant value.
 
-          Since: generic-worker 10.6.0
-      liveLog:
-        type: boolean
-        title: Enable [livelog](https://github.com/taskcluster/taskcluster/tree/main/tools/livelog)
-        description: |-
-          The live log feature streams the combined stderr and stdout to a task artifact
-          so that the output is available while the task is running.
+            This feature is only available on Linux. If a task
+            is submitted with this feature enabled on a non-Linux,
+            posix platform (FreeBSD, macOS), the task will resolve as
+            `exception/malformed-payload`.
 
-          Since: generic-worker 48.2.0
-        default: true
-      backingLog:
-        type: boolean
-        title: Enable backing log
-        description: |-
-          The backing log feature publishes a task artifact containing the complete
-          stderr and stdout of the task.
+            Since: generic-worker 53.1.0
+    mounts:
+      type: array
+      description: |-
+        Directories and/or files to be mounted.
 
-          Since: generic-worker 48.2.0
-        default: true
-      interactive:
-        type: boolean
-        title: Interactive shell
-        description: |-
-          This allows you to interactively run commands from within the worker
-          as the task user. This may be useful for debugging purposes.
-          Can be used for SSH-like access to the running worker.
-          Note that this feature works differently from the `interactive` feature
-          in docker worker, which `docker exec`s into the running container.
-          Since tasks on generic worker are not guaranteed to be running in a
-          container, a bash shell is started on the task user's account.
-          A user can then `docker exec` into the a running container, if there
-          is one.
+        Since: generic-worker 5.4.0
+      uniqueItems: false
+      items:
+        title: Mount
+        "$ref": "#/definitions/mount"
+    osGroups:
+      type: array
+      title: OS Groups
+      description: |-
+        A list of OS Groups that the task user should be a member of. Not yet implemented on
+        non-Windows platforms, therefore this optional property may only be an empty array if
+        provided.
 
-          Since: generic-worker 49.2.0
-      loopbackVideo:
-        type: boolean
-        title: Loopback Video device
-        description: |-
-          Video loopback device created using v4l2loopback.
-          A video device will be available for the task. Its
-          location will be passed to the task via environment
-          variable `TASKCLUSTER_VIDEO_DEVICE`. The
-          location will be `/dev/video<N>` where `<N>` is
-          an integer between 0 and 255. The value of `<N>`
-          is not static, and therefore either the environment
-          variable should be used, or `/dev` should be
-          scanned in order to determine the correct location.
-          Tasks should not assume a constant value.
-
-          This feature is only available on Linux. If a task
-          is submitted with this feature enabled on a non-Linux,
-          posix platform (FreeBSD, macOS), the task will resolve as
-          `exception/malformed-payload`.
-
-          Since: generic-worker 53.1.0
-  mounts:
-    type: array
-    description: |-
-      Directories and/or files to be mounted.
-
-      Since: generic-worker 5.4.0
-    uniqueItems: false
-    items:
-      title: Mount
-      "$ref": "#/definitions/mount"
-  osGroups:
-    type: array
-    title: OS Groups
-    description: |-
-      A list of OS Groups that the task user should be a member of. Not yet implemented on
-      non-Windows platforms, therefore this optional property may only be an empty array if
-      provided.
-
-      Since: generic-worker 6.0.0
-    uniqueItems: false
-    items:
+        Since: generic-worker 6.0.0
+      uniqueItems: false
+      items:
+        type: string
+      maxItems: 0
+    supersederUrl:
       type: string
-    maxItems: 0
-  supersederUrl:
-    type: string
-    title: unused
-    description: This property is allowed for backward compatibility, but is unused.
-  onExitStatus:
-    title: Exit code handling
-    description: |-
-      By default tasks will be resolved with `state/reasonResolved`: `completed/completed`
-      if all task commands have a zero exit code, or `failed/failed` if any command has a
-      non-zero exit code. This payload property allows customsation of the task resolution
-      based on exit code of task commands.
-    type: object
-    additionalProperties: false
-    required: []
-    properties:
-      retry:
-        title: Intermittent task exit codes
-        description: |-
-          Exit codes for any command in the task payload to cause this task to
-          be resolved as `exception/intermittent-task`. Typically the Queue
-          will then schedule a new run of the existing `taskId` (rerun) if not
-          all task runs have been exhausted.
+      title: unused
+      description: This property is allowed for backward compatibility, but is unused.
+    onExitStatus:
+      title: Exit code handling
+      description: |-
+        By default tasks will be resolved with `state/reasonResolved`: `completed/completed`
+        if all task commands have a zero exit code, or `failed/failed` if any command has a
+        non-zero exit code. This payload property allows customsation of the task resolution
+        based on exit code of task commands.
+      type: object
+      additionalProperties: false
+      required: []
+      properties:
+        retry:
+          title: Intermittent task exit codes
+          description: |-
+            Exit codes for any command in the task payload to cause this task to
+            be resolved as `exception/intermittent-task`. Typically the Queue
+            will then schedule a new run of the existing `taskId` (rerun) if not
+            all task runs have been exhausted.
 
-          See [itermittent tasks](https://docs.taskcluster.net/docs/reference/platform/taskcluster-queue/docs/worker-interaction#intermittent-tasks) for more detail.
+            See [itermittent tasks](https://docs.taskcluster.net/docs/reference/platform/taskcluster-queue/docs/worker-interaction#intermittent-tasks) for more detail.
 
-          Since: generic-worker 10.10.0
-        type: array
-        uniqueItems: true
-        items:
-          title: Exit codes
-          type: integer
-          minimum: 1
-      purgeCaches:
-        title: Purge caches exit status
-        description: |-
-          If the task exists with a purge caches exit status, all caches
-          associated with the task will be purged.
+            Since: generic-worker 10.10.0
+          type: array
+          uniqueItems: true
+          items:
+            title: Exit codes
+            type: integer
+            minimum: 1
+        purgeCaches:
+          title: Purge caches exit status
+          description: |-
+            If the task exists with a purge caches exit status, all caches
+            associated with the task will be purged.
 
-          Since: generic-worker 49.0.0
-        type: array
-        uniqueItems: true
-        items:
-          title: Exit statuses
-          type: integer
-          minimum: 1
-  logs:
-    title: Logs
-    description: |-
-      Configuration for task logs.
+            Since: generic-worker 49.0.0
+          type: array
+          uniqueItems: true
+          items:
+            title: Exit statuses
+            type: integer
+            minimum: 1
+    logs:
+      title: Logs
+      description: |-
+        Configuration for task logs.
 
-      Since: generic-worker 48.2.0
-    type: object
-    additionalProperties: false
-    required: []
-    properties:
-      live:
-        title: Live log artifact name
-        description: |-
-          Specifies a custom name for the live log artifact.
-          This is only used if `features.liveLog` is `true`.
+        Since: generic-worker 48.2.0
+      type: object
+      additionalProperties: false
+      required: []
+      properties:
+        live:
+          title: Live log artifact name
+          description: |-
+            Specifies a custom name for the live log artifact.
+            This is only used if `features.liveLog` is `true`.
 
-          Since: generic-worker 48.2.0
+            Since: generic-worker 48.2.0
+          type: string
+          default: public/logs/live.log
+        backing:
+          title: Backing log artifact name
+          description: |-
+            Specifies a custom name for the backing log artifact.
+            This is only used if `features.backingLog` is `true`.
+
+            Since: generic-worker 48.2.0
+          type: string
+          default: public/logs/live_backing.log
+- title: Docker worker payload
+  description: "`.payload` field of the queue."
+  type: object
+  properties:
+    log:
+      title: Livelog artifact name
+      description: >-
+        Specifies a custom name for the livelog artifact. Note that this is also used in determining the name of the backing log artifact name. Backing log artifact name matches livelog artifact name with `_backing` appended, prior to the file extension (if present). For example, `apple/banana.log.txt` results in livelog artifact `apple/banana.log.txt` and backing log artifact `apple/banana.log_backing.txt`. Defaults to `public/logs/live.log`.
+      type: string
+      default: public/logs/live.log
+    image:
+      title: Docker image.
+      description: >-
+        Image to use for the task.  Images can be specified as an image tag as used by a docker registry, or as an object declaring type and name/namespace
+      oneOf:
+      - title: Docker image name
         type: string
-        default: public/logs/live.log
-      backing:
-        title: Backing log artifact name
-        description: |-
-          Specifies a custom name for the backing log artifact.
-          This is only used if `features.backingLog` is `true`.
-
-          Since: generic-worker 48.2.0
+      - type: object
+        title: Named docker image
+        properties:
+          type:
+            type: string
+            enum:
+            - docker-image
+          name:
+            type: string
+        additionalProperties: false
+        required:
+        - type
+        - name
+      - type: object
+        title: Indexed docker image
+        properties:
+          type:
+            type: string
+            enum:
+            - indexed-image
+          namespace:
+            type: string
+          path:
+            type: string
+        additionalProperties: false
+        required:
+        - type
+        - namespace
+        - path
+      - type: object
+        title: Docker image artifact
+        properties:
+          type:
+            type: string
+            enum:
+            - task-image
+          taskId:
+            type: string
+          path:
+            type: string
+        additionalProperties: false
+        required:
+        - type
+        - taskId
+        - path
+    cache:
+      title: Caches to mount point mapping.
+      description: >-
+        Caches are mounted within the docker container at the mount point specified. Example: ```{ "CACHE NAME": "/mount/path/in/container" }```
+      type: object
+      additionalProperties:
         type: string
-        default: public/logs/live_backing.log
+    capabilities:
+      title: Capabilities that must be available/enabled for the task container.
+      description: >-
+        Set of capabilities that must be enabled or made available to the task container Example: ```{ "capabilities": { "privileged": true }```
+      type: object
+      properties:
+        privileged:
+          title: Privileged container
+          description: >-
+            Allows a task to run in a privileged container, similar to running docker with `--privileged`.  This only works for worker-types configured to enable it.
+          type: boolean
+          default: false
+        devices:
+          title: Devices to be attached to task containers
+          description: >-
+            Allows devices from the host system to be attached to a task container similar to using `--device` in docker.
+          type: object
+          properties:
+            loopbackVideo:
+              title: Loopback Video device
+              description: Video loopback device created using v4l2loopback.
+              type: boolean
+            loopbackAudio:
+              title: Loopback Audio device
+              description: Audio loopback device created using snd-aloop
+              type: boolean
+            hostSharedMemory:
+              title: Host shared memory device (Experimental)
+              description: Mount /dev/shm from the host in the container.
+              type: boolean
+            kvm:
+              title: /dev/kvm device (Experimental)
+              description: Mount /dev/kvm from the host in the container.
+              type: boolean
+          required: []
+          additionalProperties: false
+      required: []
+      additionalProperties: false
+    command:
+      title: Docker command to run (see docker api).
+      type: array
+      items:
+        type: string
+      default: []
+      description: "Example: `['/bin/bash', '-c', 'ls']`."
+    env:
+      title: Environment variable mappings.
+      description: |-
+        Example: ```
+        {
+          "PATH": '/borked/path'
+          "ENV_NAME": "VALUE"
+        }
+        ```
+      type: object
+      additionalProperties:
+        type: string
+    maxRunTime:
+      type: integer
+      title: Maximum run time in seconds
+      description: |-
+        Maximum time the task container can run in seconds.
+      multipleOf: 1
+      minimum: 1
+      maximum: 86400
+    onExitStatus:
+      title: Exit status handling
+      description: >-
+        By default docker-worker will fail a task with a non-zero exit status without retrying.  This payload property allows a task owner to define certain exit statuses that will be marked as a retriable exception.
+      type: object
+      properties:
+        retry:
+          title: Retriable exit statuses
+          description: >-
+            If the task exists with a retriable exit status, the task will be marked as an exception and a new run created.
+          type: array
+          items:
+            title: Exit statuses
+            type: integer
+        purgeCaches:
+          title: Purge caches exit status
+          description: >-
+            If the task exists with a purge caches exit status, all caches associated with the task will be purged.
+          type: array
+          items:
+            title: Exit statuses
+            type: integer
+      required: []
+      additionalProperties: false
+    artifacts:
+      type: object
+      title: Artifacts
+      description: >-
+        Artifact upload map example: ```{"public/build.tar.gz": {"path": "/home/worker/build.tar.gz", "expires": "2016-05-28T16:12:56.693817Z", "type": "file"}}```
+      additionalProperties:
+        $ref: "#/definitions/artifact"
+    supersederUrl:
+      title: (unused)
+      description: Maintained for backward compatibility, but no longer used
+      type: string
+    features:
+      title: Docker Worker feature flags
+      description: Used to enable additional functionality.
+      type: object
+      properties:
+        localLiveLog:
+          type: boolean
+          title: Enable live logging (worker local)
+          description: >-
+            Logs are stored on the worker during the duration of tasks and available via http chunked streaming then uploaded to s3
+          default: true
+        bulkLog:
+          type: boolean
+          title: Bulk upload the task log into a single artifact
+          description: >-
+            Useful if live logging is not interesting but the overalllog is later on
+          default: true
+        taskclusterProxy:
+          type: boolean
+          title: Taskcluster auth proxy service
+          description: >-
+            The auth proxy allows making requests to taskcluster/queue and taskcluster/scheduler directly from your task with the same scopes as set in the task. This can be used to make api calls via the [client](https://github.com/taskcluster/taskcluster-client) CURL, etc... Without embedding credentials in the task.
+          default: false
+        artifacts:
+          type: boolean
+          title: Artifact uploads
+          description: ""
+          default: true
+        dind:
+          type: boolean
+          title: Docker in Docker
+          description: >-
+            Runs docker-in-docker and binds `/var/run/docker.sock` into the container. Doesn't allow privileged mode, capabilities or host volume mounts.
+          default: false
+        dockerSave:
+          type: boolean
+          title: Docker save
+          description: Uploads docker images as artifacts
+          default: false
+        interactive:
+          type: boolean
+          title: Docker Exec Interactive
+          description: >-
+            This allows you to interactively run commands inside the container and attaches you to the stdin/stdout/stderr over a websocket. Can be used for SSH-like access to docker containers.
+          default: false
+        allowPtrace:
+          type: boolean
+          title: Allow ptrace within the container
+          description: >-
+            This allows you to use the Linux ptrace functionality inside the container; it is otherwise disallowed by Docker's security policy.
+          default: false
+        chainOfTrust:
+          type: boolean
+          title: Enable generation of ed25519-signed Chain of Trust artifacts
+          description: >-
+            Artifacts named chain-of-trust.json and chain-of-trust.json.sig should be generated which will include information for downstream tasks to build a level of trust for the artifacts produced by the task and the environment it ran in.
+          default: false
+      required: []
+      additionalProperties: false
+  additionalProperties: false
+  required:
+  - image
+  - maxRunTime
 definitions:
   mount:
     title: Mount
@@ -503,7 +738,7 @@ definitions:
             If provided, the required SHA256 of the content body.
 
             Since: generic-worker 10.8.0
-          pattern: '^[a-f0-9]{64}$'
+          pattern: "^[a-f0-9]{64}$"
       additionalProperties: false
       required:
       - taskId
@@ -547,7 +782,7 @@ definitions:
             If provided, the required SHA256 of the content body.
 
             Since: generic-worker 10.8.0
-          pattern: '^[a-f0-9]{64}$'
+          pattern: "^[a-f0-9]{64}$"
       additionalProperties: false
       required:
       - url
@@ -584,7 +819,28 @@ definitions:
             Base64 encoded content of file/archive, up to 64KB (encoded) in size.
 
             Since: generic-worker 11.1.0
-          pattern: '^[A-Za-z0-9/+]+[=]{0,2}$'
+          pattern: "^[A-Za-z0-9/+]+[=]{0,2}$"
       additionalProperties: false
       required:
       - base64
+  artifact:
+    type: object
+    title: Docker Worker Artifact
+    properties:
+      type:
+        title: Artifact upload type.
+        type: string
+        enum:
+        - file
+        - directory
+      path:
+        title: Location of artifact in container, as an absolute path.
+        type: string
+      expires:
+        title: Date when artifact should expire must be in the future.
+        type: string
+        format: date-time
+    additionalProperties: false
+    required:
+    - type
+    - path

--- a/workers/generic-worker/schemas/multiuser_windows.yml
+++ b/workers/generic-worker/schemas/multiuser_windows.yml
@@ -1,3 +1,4 @@
+---
 $schema: "/schemas/common/metaschema.json#"
 $id: "/schemas/generic-worker/multiuser_windows.json#"
 title: Generic worker payload
@@ -145,8 +146,8 @@ properties:
           title: Content-Encoding header when serving artifact over HTTP.
           type: string
           enum:
-            - identity
-            - gzip
+          - identity
+          - gzip
           description: |-
             Content-Encoding for the artifact. If not provided, `gzip` will be used, except for the
             following file extensions, where `identity` will be used, since they are already
@@ -513,7 +514,7 @@ definitions:
             If provided, the required SHA256 of the content body.
 
             Since: generic-worker 10.8.0
-          pattern: '^[a-f0-9]{64}$'
+          pattern: "^[a-f0-9]{64}$"
       additionalProperties: false
       required:
       - taskId
@@ -557,7 +558,7 @@ definitions:
             If provided, the required SHA256 of the content body.
 
             Since: generic-worker 10.8.0
-          pattern: '^[a-f0-9]{64}$'
+          pattern: "^[a-f0-9]{64}$"
       additionalProperties: false
       required:
       - url
@@ -594,7 +595,7 @@ definitions:
             Base64 encoded content of file/archive, up to 64KB (encoded) in size.
 
             Since: generic-worker 11.1.0
-          pattern: '^[A-Za-z0-9/+]+[=]{0,2}$'
+          pattern: "^[A-Za-z0-9/+]+[=]{0,2}$"
       additionalProperties: false
       required:
       - base64

--- a/workers/generic-worker/schemas/simple_posix.yml
+++ b/workers/generic-worker/schemas/simple_posix.yml
@@ -1,3 +1,4 @@
+---
 $schema: "/schemas/common/metaschema.json#"
 $id: "/schemas/generic-worker/simple_posix.json#"
 title: Generic worker payload
@@ -138,8 +139,8 @@ properties:
           title: Content-Encoding header when serving artifact over HTTP.
           type: string
           enum:
-            - identity
-            - gzip
+          - identity
+          - gzip
           description: |-
             Content-Encoding for the artifact. If not provided, `gzip` will be used, except for the
             following file extensions, where `identity` will be used, since they are already
@@ -481,7 +482,7 @@ definitions:
             If provided, the required SHA256 of the content body.
 
             Since: generic-worker 10.8.0
-          pattern: '^[a-f0-9]{64}$'
+          pattern: "^[a-f0-9]{64}$"
       additionalProperties: false
       required:
       - taskId
@@ -525,7 +526,7 @@ definitions:
             If provided, the required SHA256 of the content body.
 
             Since: generic-worker 10.8.0
-          pattern: '^[a-f0-9]{64}$'
+          pattern: "^[a-f0-9]{64}$"
       additionalProperties: false
       required:
       - url
@@ -562,7 +563,7 @@ definitions:
             Base64 encoded content of file/archive, up to 64KB (encoded) in size.
 
             Since: generic-worker 11.1.0
-          pattern: '^[A-Za-z0-9/+]+[=]{0,2}$'
+          pattern: "^[A-Za-z0-9/+]+[=]{0,2}$"
       additionalProperties: false
       required:
       - base64


### PR DESCRIPTION
Fixes #5967.

>This change integrates the `d2g` tool into Generic Worker so that it can accept a valid, Docker Worker payload.