### PR TITLE
UI: Refactor service schema loading and validation

### DIFF
--- a/changelog/PcHmdF8uQ6ef6GxEusgNQw.md
+++ b/changelog/PcHmdF8uQ6ef6GxEusgNQw.md
@@ -1,0 +1,5 @@
+audience: users
+level: patch
+---
+
+UI: Refactors how validation schemas are loaded, to ensure they are only fetched and added once to prevent duplicate schema exceptions.

--- a/ui/src/utils/ajv.js
+++ b/ui/src/utils/ajv.js
@@ -1,18 +1,40 @@
 import Ajv from 'ajv';
 import addFormats from 'ajv-formats';
 import metaSchema from 'ajv/lib/refs/json-schema-draft-06.json';
+import urls from './urls';
 
 const ajv = new Ajv({ validateFormats: true, verbose: true, allErrors: true });
 
 addFormats(ajv);
 ajv.addMetaSchema(metaSchema);
 
-ajv.addSchemaOnce = (schema, key) => {
-  const uniqueKey = key || schema.$id;
+const schemaCache = {};
+const fetchSchema = async (service, schema) => {
+  const url = urls.schema(service, schema);
 
-  if (!ajv.getSchema(uniqueKey)) {
-    ajv.addSchema(schema, uniqueKey);
+  if (schemaCache[url]) {
+    return schemaCache[url];
   }
+
+  const doc = await (await fetch(url)).json();
+
+  schemaCache[url] = doc;
+
+  return doc;
+};
+
+ajv.loadServiceSchema = async (service, schema, alias) => {
+  const doc = await fetchSchema(service, schema);
+
+  if (!ajv.getSchema(doc.$id)) {
+    ajv.addSchema(doc);
+  }
+
+  if (alias && !ajv.getSchema(alias)) {
+    ajv.addSchema(doc, alias);
+  }
+
+  return doc;
 };
 
 export default ajv;

--- a/ui/src/utils/ajv.test.js
+++ b/ui/src/utils/ajv.test.js
@@ -1,7 +1,7 @@
-import ajv from './ajv';
-
 describe('ajv', () => {
   it('should validate', () => {
+    const ajv = require('./ajv').default; // eslint-disable-line global-require
+
     const schema = {
       type: 'object',
       properties: {
@@ -15,5 +15,35 @@ describe('ajv', () => {
     };
 
     expect(ajv.validate(schema, data)).toBe(true);
+  });
+
+  describe('loadServiceSchema', () => {
+    beforeAll(() => {
+      window.fetch = jest.fn().mockImplementation(url => {
+        return {
+          json: () =>
+            Promise.resolve({
+              $id: new URL(url).pathname,
+            }),
+        };
+      });
+    });
+
+    it('should add schema once', async () => {
+      const ajv = require('./ajv').default; // eslint-disable-line global-require
+
+      await ajv.loadServiceSchema('svc', 'schema1');
+      expect(ajv.getSchema('/schemas/svc/schema1')).toBeDefined();
+      ajv.loadServiceSchema('svc', 'schema1');
+      ajv.loadServiceSchema('svc', 'schema1');
+      expect(window.fetch).toHaveBeenCalledTimes(1);
+
+      await ajv.loadServiceSchema('svc2', 'schema2', 'alias');
+      expect(ajv.getSchema('/schemas/svc2/schema2')).toBeDefined();
+      expect(ajv.getSchema('alias')).toBeDefined();
+      ajv.loadServiceSchema('svc2', 'schema2');
+      ajv.loadServiceSchema('svc2', 'schema2');
+      expect(window.fetch).toHaveBeenCalledTimes(2);
+    });
   });
 });

--- a/ui/src/utils/validateTaskPayloadSchemas.js
+++ b/ui/src/utils/validateTaskPayloadSchemas.js
@@ -1,17 +1,17 @@
 import ajv from './ajv';
-import urls from './urls';
-
-const schemas = {};
-const fetchSchema = async (service, schema) => {
-  const res = await fetch(urls.schema(service, schema));
-
-  return res.json();
-};
 
 const prefetch = async () => {
-  ajv.addSchemaOnce(await fetchSchema('common', 'metaschema.json'));
-  ajv.addSchemaOnce(await fetchSchema('queue', 'v1/task.json'));
-  ajv.addSchemaOnce(await fetchSchema('queue', 'v1/task-metadata.json'));
+  // metaschema needs to be loaded first as other schemas depend on it
+  await ajv.loadServiceSchema('common', 'metaschema.json');
+  await Promise.all([
+    ajv.loadServiceSchema('queue', 'v1/task.json'),
+    ajv.loadServiceSchema('queue', 'v1/task-metadata.json'),
+    ajv.loadServiceSchema(
+      'queue',
+      'v1/create-task-request.json',
+      'create-task'
+    ),
+  ]);
 };
 
 const prefetchPromise = prefetch();
@@ -31,15 +31,8 @@ export const formatErrorDetails = error => {
 export default async (value, service, schema) => {
   await prefetchPromise;
 
-  if (!schemas['create-task']) {
-    schemas['create-task'] = await fetchSchema(
-      'queue',
-      'v1/create-task-request.json'
-    );
-  }
-
   const errors = [];
-  const taskValidation = ajv.validate(schemas['create-task'], value);
+  const taskValidation = ajv.validate('create-task', value);
 
   if (!taskValidation) {
     (ajv.errors || []).forEach(error => {
@@ -49,11 +42,8 @@ export default async (value, service, schema) => {
 
   // allow to validate create task payload only when schema is not provided
   if (service && schema) {
-    if (!schemas[schema]) {
-      schemas[schema] = await fetchSchema(service, schema);
-    }
-
-    const validation = ajv.validate(schemas[schema], value.payload);
+    const doc = await ajv.loadServiceSchema(service, schema);
+    const validation = ajv.validate(doc.$id, value.payload);
 
     if (!validation) {
       (ajv.errors || []).forEach(error => {

--- a/ui/src/views/TcYamlDebug/index.jsx
+++ b/ui/src/views/TcYamlDebug/index.jsx
@@ -12,7 +12,6 @@ import TextField from '../../components/TextField';
 import CodeEditor from '../../components/CodeEditor';
 import Dashboard from '../../components/Dashboard';
 import Button from '../../components/Button';
-import urls from '../../utils/urls';
 import { siteSpecificVariable } from '../../utils/siteSpecific';
 import ajv from '../../utils/ajv';
 import scrollToHash from '../../utils/scrollToHash';
@@ -20,32 +19,26 @@ import githubQuery from './github.graphql';
 import JsonDisplay from '../../components/JsonDisplay';
 
 const prefetchSchema = async () => {
-  ajv.addSchemaOnce(
-    await (await fetch(urls.schema('common', 'metaschema.json'))).json()
-  );
-  ajv.addSchemaOnce(
-    await (
-      await fetch(urls.schema('github', 'v1/taskcluster-github-config.json'))
-    ).json(),
-    'github-v0'
-  );
-  ajv.addSchemaOnce(
-    await (
-      await fetch(urls.schema('github', 'v1/taskcluster-github-config.v1.json'))
-    ).json(),
-    'github-v1'
-  );
-  ajv.addSchemaOnce(
-    await (await fetch(urls.schema('queue', 'v1/task-metadata.json'))).json()
-  );
-  ajv.addSchemaOnce(
-    await (await fetch(urls.schema('queue', 'v1/task.json'))).json()
-  );
-  ajv.addSchemaOnce(
-    await (
-      await fetch(urls.schema('queue', 'v1/create-task-request.json'))
-    ).json()
-  );
+  await ajv.loadServiceSchema('common', 'metaschema.json');
+  await Promise.all([
+    ajv.loadServiceSchema(
+      'github',
+      'v1/taskcluster-github-config.json',
+      'github-v0'
+    ),
+    ajv.loadServiceSchema(
+      'github',
+      'v1/taskcluster-github-config.v1.json',
+      'github-v1'
+    ),
+    ajv.loadServiceSchema('queue', 'v1/task-metadata.json'),
+    ajv.loadServiceSchema('queue', 'v1/task.json'),
+    ajv.loadServiceSchema(
+      'queue',
+      'v1/create-task-request.json',
+      'create-task'
+    ),
+  ]);
 };
 
 prefetchSchema();


### PR DESCRIPTION
Previously same schema was used on two different pages/components and there were errors if both pages would be loaded, saying that schema was already loading.
This refactoring adds single `loadServiceSchema()` function that loads resource once and adds it to `ajv` once to avoid those issues.
