### PR TITLE
build(deps-dev): bump karma from 6.4.1 to 6.4.2 in /clients/client-web

### DIFF
--- a/clients/client-web/package.json
+++ b/clients/client-web/package.json
@@ -19,7 +19,7 @@
     "crypto-js": "^4.0.0",
     "dotenv": "^16.3.1",
     "eslint": "^8.41.0",
-    "karma": "^6.4.1",
+    "karma": "^6.4.2",
     "karma-cli": "^2.0.0",
     "karma-coverage": "^2.2.0",
     "karma-firefox-launcher": "^2.0.0",

--- a/clients/client-web/yarn.lock
+++ b/clients/client-web/yarn.lock
@@ -2541,10 +2541,10 @@ karma-webpack@^4.0.2:
     source-map "^0.7.3"
     webpack-dev-middleware "^3.7.0"
 
-karma@^6.4.1:
-  version "6.4.1"
-  resolved "https://registry.yarnpkg.com/karma/-/karma-6.4.1.tgz#f2253716dd3a41aaa813fa9f54b6ee047e1127d9"
-  integrity sha512-Cj57NKOskK7wtFWSlMvZf459iX+kpYIPXmkNUzP2WAFcA7nhr/ALn5R7sw3w+1udFDcpMx/tuB8d5amgm3ijaA==
+karma@^6.4.2:
+  version "6.4.2"
+  resolved "https://registry.yarnpkg.com/karma/-/karma-6.4.2.tgz#a983f874cee6f35990c4b2dcc3d274653714de8e"
+  integrity sha512-C6SU/53LB31BEgRg+omznBEMY4SjHU3ricV6zBcAe1EeILKkeScr+fZXtaI5WyDbkVowJxxAI6h73NcFPmXolQ==
   dependencies:
     "@colors/colors" "1.5.0"
     body-parser "^1.19.0"


### PR DESCRIPTION
Identical to #6291 but this description does not include those magical words that prevent the CI from running. I won't mention what they are here...