### PR TITLE
Align `go mod tidy` usage with current go semantics

### DIFF
--- a/changelog/Poh6dB8NQ5S_-IAOgyYoew.md
+++ b/changelog/Poh6dB8NQ5S_-IAOgyYoew.md
@@ -1,0 +1,3 @@
+audience: general
+level: silent
+---

--- a/taskcluster/ci/generic-worker/kind.yml
+++ b/taskcluster/ci/generic-worker/kind.yml
@@ -84,9 +84,8 @@ tasks:
         - go mod tidy
         - git diff
         - test $(git status --porcelain | wc -l) == 0
-        - go install golang.org/x/tools/cmd/goimports
+        - go install golang.org/x/tools/cmd/goimports@latest
         - '"$(go env GOPATH)/bin/goimports" -w .'
-        - git checkout -f go.mod go.sum
         - git diff
         - test $(git status --porcelain | wc -l) == 0
   build/test-multiuser-ubuntu-22.04-amd64:
@@ -156,11 +155,6 @@ tasks:
           git clean -fdx
           git checkout -B tmp -t "X${{TASK_ID}}"
           cd workers/generic-worker
-          # go.mod and go.sum will be affected by above go get commands, so
-          # tidy them before checking for changes. Not needed in go 1.14:
-          # https://github.com/golang/go/issues/30515#issuecomment-581984371
-          # TODO: use go get -modfile instead when running go 1.14, and remove
-          # go mod tidy command
           go mod tidy
           git status
           # output of wc command can contain spaces on darwin, so no quotes around expression
@@ -298,13 +292,7 @@ tasks:
         - git clean -fdx
         - git checkout -B tmp -t "X%TASK_ID%"
         - cd workers\generic-worker
-        - |
-          :: go.mod and go.sum will be affected by above go get commands, so
-          :: tidy them before checking for changes. Not needed in go 1.14:
-          :: https://github.com/golang/go/issues/30515#issuecomment-581984371
-          :: TODO: use go get -modfile instead when running go 1.14, and remove
-          :: go mod tidy command
-          go mod tidy
+        - go mod tidy
         - |
           :: this counts the number of lines returned by git status
           :: dump temp file outside of repo, otherwise git status reports the tmp1.txt file!


### PR DESCRIPTION
As per `go help install`:

> If the arguments have version suffixes (like @latest or @v1.0.0), "go install"
> builds packages in module-aware mode, ignoring the go.mod file in the current
> directory or any parent directory, if there is one. This is useful for
> installing executables without affecting the dependencies of the main module.

By adding `@latest` to go install commands, we should ensure that installing dev tools (such as goimports) will not modify `go.mod` and `go.sum` files.

By continuing to check that running `go mod tidy` does not alter the contents of `go.mod` or `go.sum`, we also ensure that these files are consistent with the go code.