### PR TITLE
Hooks page improvements:

### DIFF
--- a/changelog/AD0QORFPR-KxRAyAVxT9fg.md
+++ b/changelog/AD0QORFPR-KxRAyAVxT9fg.md
@@ -1,0 +1,5 @@
+audience: users
+level: patch
+---
+
+Hooks page improvements: extra schedule and exchanges displayed as Badge with a proper tooltip.

--- a/ui/src/components/HooksListTable/index.jsx
+++ b/ui/src/components/HooksListTable/index.jsx
@@ -6,6 +6,7 @@ import { any, arrayOf, string } from 'prop-types';
 import LinkIcon from 'mdi-react/LinkIcon';
 import TableRow from '@material-ui/core/TableRow';
 import TableCell from '@material-ui/core/TableCell';
+import { Badge, Tooltip } from '@material-ui/core';
 import DataTable from '../DataTable';
 import TableCellItem from '../TableCellItem';
 import Link from '../../utils/Link';
@@ -114,7 +115,19 @@ export default class HooksListTable extends Component {
               <TableCellItem>
                 {<code>{schedule[0]}</code>}
                 {schedule.length > 1 && (
-                  <span title={schedule.join(', ')}>+{schedule.length}</span>
+                  <Tooltip
+                    title={
+                      <React.Fragment>
+                        {schedule.slice(1, 10).map(b => (
+                          <pre key={b}>{b}</pre>
+                        ))}
+                      </React.Fragment>
+                    }>
+                    <Badge
+                      badgeContent={`+${schedule.length - 1}`}
+                      color="secondary"
+                    />
+                  </Tooltip>
                 )}
               </TableCellItem>
             </Link>
@@ -130,9 +143,19 @@ export default class HooksListTable extends Component {
                   </code>
                 }
                 {bindings.length > 1 && (
-                  <span title={bindings.map(b => b.exchange).join(', ')}>
-                    +{bindings.length}
-                  </span>
+                  <Tooltip
+                    title={
+                      <React.Fragment>
+                        {bindings.slice(1, 10).map(b => (
+                          <pre key={b.exchange}>{b.exchange}</pre>
+                        ))}
+                      </React.Fragment>
+                    }>
+                    <Badge
+                      badgeContent={`+${bindings.length - 1}`}
+                      color="secondary"
+                    />
+                  </Tooltip>
                 )}
               </TableCellItem>
             </Link>


### PR DESCRIPTION
Extra schedule/exchanges displayed as Badge with Tooltips

And fixes `+n` logic

<img width="1821" alt="image" src="https://github.com/taskcluster/taskcluster/assets/83861/fe8781bf-dc7a-4020-a81f-87ba63072b43">