### PR TITLE
Fixes local docker-compose environment for public artifacts

### DIFF
--- a/changelog/issue-6395.md
+++ b/changelog/issue-6395.md
@@ -1,0 +1,6 @@
+audience: developers
+level: patch
+reference: issue 6395
+---
+
+Fixed local development environment where artifacts could not be loaded in the UI. This was caused by not using pinned `minio/*` images.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ networks:
     driver: bridge
 services:
   rabbitmq:
-    image: rabbitmq:3.11.16-management
+    image: rabbitmq:3.12.1-management
     networks:
       - local
     healthcheck:
@@ -56,7 +56,7 @@ services:
       USERNAME_PREFIX: taskcluster
       ADMIN_DB_URL: postgresql://postgres@postgres:5432/taskcluster
   s3:
-    image: minio/minio
+    image: minio/minio:RELEASE.2023-07-11T21-29-34Z
     networks:
       - local
     command: server /data --console-address :9001
@@ -75,7 +75,7 @@ services:
       retries: 100
       start_period: 3s
   s3_init_buckets:
-    image: minio/mc
+    image: minio/mc:RELEASE.2023-07-11T23-30-44Z
     networks:
       - local
     depends_on:
@@ -87,7 +87,7 @@ services:
       /usr/bin/mc config host add --quiet --api s3v4 local http://s3:9000 minioadmin miniopassword;
       (/usr/bin/mc ls local/public-bucket/ || /usr/bin/mc mb --quiet local/public-bucket/);
       (/usr/bin/mc ls local/private-bucket/ || /usr/bin/mc mb --quiet local/private-bucket/);
-      /usr/bin/mc policy set public local/public-bucket;
+      /usr/bin/mc anonymous set public local/public-bucket;
       "
     environment:
       MINIO_ENDPOINT: http://s3:9000

--- a/infrastructure/tooling/src/generate/generators/docker-compose.js
+++ b/infrastructure/tooling/src/generate/generators/docker-compose.js
@@ -262,7 +262,7 @@ exports.tasks.push({
       },
       services: {
         rabbitmq: serviceDefinition('rabbitmq', {
-          image: 'rabbitmq:3.11.16-management',
+          image: 'rabbitmq:3.12.1-management',
           healthcheck: healthcheck('rabbitmq-diagnostics ping'),
           ports: [
             '5672:5672',
@@ -303,7 +303,7 @@ exports.tasks.push({
           },
         }),
         s3: serviceDefinition('s3', {
-          image: 'minio/minio',
+          image: 'minio/minio:RELEASE.2023-07-11T21-29-34Z',
           command: 'server /data --console-address :9001',
           ports: ['3090:9000', '3091:9001'],
           volumes: [
@@ -316,7 +316,7 @@ exports.tasks.push({
           healthcheck: healthcheck('curl -I http://localhost:9000/minio/health/cluster'),
         }),
         s3_init_buckets: serviceDefinition('s3_init_buckets', {
-          image: 'minio/mc',
+          image: 'minio/mc:RELEASE.2023-07-11T23-30-44Z',
           depends_on: {
             s3: {
               condition: 'service_healthy',
@@ -328,7 +328,7 @@ exports.tasks.push({
             '/usr/bin/mc config host add --quiet --api s3v4 local http://s3:9000 minioadmin miniopassword;',
             '(/usr/bin/mc ls local/public-bucket/ || /usr/bin/mc mb --quiet local/public-bucket/);',
             '(/usr/bin/mc ls local/private-bucket/ || /usr/bin/mc mb --quiet local/private-bucket/);',
-            '/usr/bin/mc policy set public local/public-bucket;',
+            '/usr/bin/mc anonymous set public local/public-bucket;',
             '"',
           ].join('\n'),
           environment: {


### PR DESCRIPTION
Pinned `minio/minio`, `minio/mc` images to avoid having breaking changes in future.
Rabbitmq version was also upgraded.


Fixes #6395 
