### PR TITLE
Livelog working in local dev env

### DIFF
--- a/changelog/issue-6395-1.md
+++ b/changelog/issue-6395-1.md
@@ -3,4 +3,4 @@ level: patch
 reference: issue 6395
 ---
 
-Local development environment supports livelogging of the running tasks in the UI.
+Local development environment now supports live log.

--- a/changelog/issue-6395-1.md
+++ b/changelog/issue-6395-1.md
@@ -1,0 +1,6 @@
+audience: developers
+level: patch
+reference: issue 6395
+---
+
+Local development environment supports livelogging of the running tasks in the UI.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -180,6 +180,8 @@ services:
         condition: service_started
       tc_admin_init:
         condition: service_completed_successfully
+    ports:
+      - '59999:59999'
   generic-worker-static:
     image: taskcluster/generic-worker:v54.1.4
     networks:
@@ -206,6 +208,8 @@ services:
         condition: service_started
       tc_admin_init:
         condition: service_completed_successfully
+    ports:
+      - '59999:59999'
   auth-web:
     image: taskcluster/taskcluster:v54.1.4
     networks:

--- a/docker/generic-worker-config.json
+++ b/docker/generic-worker-config.json
@@ -8,5 +8,7 @@
   "workerType": "generic-worker",
   "livelogExecutable": "/usr/local/bin/livelog",
   "taskclusterProxyExecutable": "/usr/local/bin/taskcluster-proxy",
-  "publicIP": "127.1.2.3"
+  "publicIP": "127.0.0.1",
+  "livelogPortBase": 60000,
+  "livelogExposePort": 59999
 }

--- a/infrastructure/tooling/src/generate/generators/docker-compose.js
+++ b/infrastructure/tooling/src/generate/generators/docker-compose.js
@@ -433,6 +433,7 @@ exports.tasks.push({
           taskcluster: { condition: 'service_started' },
           tc_admin_init: { condition: 'service_completed_successfully' },
         },
+        ports: ['59999:59999'],
       });
 
       // allow rebuild

--- a/workers/generic-worker/README.md
+++ b/workers/generic-worker/README.md
@@ -150,6 +150,9 @@ and reports back results to the queue.
           livelogPortBase                   Set the base port number for livelog. Livelog requires two
                                             ports: livelogPortBase & livelogPortBase + 1 are used.
                                             [default: 60098]
+          livelogExposePort                 When not using websocktunnel, livelog would be exposed using this port.
+                                            If it is set to 0, logs would be exposed using a random port.
+                                            [default: 0]
           numberOfTasksToRun                If zero, run tasks indefinitely. Otherwise, after
                                             this many tasks, exit. [default: 0]
           privateIP                         The private IP of the worker, used by chain of trust.

--- a/workers/generic-worker/expose/local.go
+++ b/workers/generic-worker/expose/local.go
@@ -8,13 +8,14 @@ import (
 
 type localExposer struct {
 	publicIP net.IP
+	port     uint16
 }
 
 // Create a local exposer implementation.  Local exposers are useful for local
 // testing, and simply exposes the URL as given, or (for ExposeTCPPort) proxies
 // a websocket on localhost to the port.
-func NewLocal(publicIP net.IP) (Exposer, error) {
-	return &localExposer{publicIP}, nil
+func NewLocal(publicIP net.IP, port uint16) (Exposer, error) {
+	return &localExposer{publicIP, port}, nil
 }
 
 func (exposer *localExposer) ExposeHTTP(targetPort uint16) (Exposure, error) {
@@ -53,8 +54,9 @@ type localHTTPExposure struct {
 }
 
 func (exposure *localHTTPExposure) start() error {
-	// allocate a port dynamically by specifying :0
-	listener, err := net.Listen("tcp", ":0")
+	// port can be allocated dynamically `:0`
+	// or passed as predefined port which could be used for testing or local development
+	listener, err := net.Listen("tcp", fmt.Sprintf(":%d", exposure.exposer.port))
 	if err != nil {
 		return err
 	}

--- a/workers/generic-worker/expose/local_test.go
+++ b/workers/generic-worker/expose/local_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 func TestConstructor(t *testing.T) {
-	exposer, err := NewLocal(net.ParseIP("127.0.0.1"))
+	exposer, err := NewLocal(net.ParseIP("127.0.0.1"), 0)
 	if err != nil {
 		t.Fatalf("Constructor returned an error: %v", err)
 	}
@@ -26,7 +26,7 @@ func TestConstructor(t *testing.T) {
 
 func makeLocalExposer(t *testing.T) Exposer {
 	t.Helper()
-	exposer, err := NewLocal(net.ParseIP("127.0.0.1"))
+	exposer, err := NewLocal(net.ParseIP("127.0.0.1"), 0)
 	if err != nil {
 		t.Fatalf("Constructor returned an error: %v", err)
 	}

--- a/workers/generic-worker/gwconfig/config.go
+++ b/workers/generic-worker/gwconfig/config.go
@@ -43,6 +43,7 @@ type (
 		InteractivePort                uint16                 `json:"interactivePort"`
 		LiveLogExecutable              string                 `json:"livelogExecutable"`
 		LiveLogPortBase                uint16                 `json:"livelogPortBase"`
+		LiveLogExposePort              uint16                 `json:"livelogExposePort"`
 		LoopbackVideoDeviceNumber      uint8                  `json:"loopbackVideoDeviceNumber"`
 		NumberOfTasksToRun             uint                   `json:"numberOfTasksToRun"`
 		PrivateIP                      net.IP                 `json:"privateIP"`

--- a/workers/generic-worker/main.go
+++ b/workers/generic-worker/main.go
@@ -283,7 +283,7 @@ func setupExposer() (err error) {
 			authClientFactory,
 		)
 	} else {
-		exposer, err = expose.NewLocal(config.PublicIP)
+		exposer, err = expose.NewLocal(config.PublicIP, config.LiveLogExposePort)
 	}
 	return err
 }

--- a/workers/generic-worker/usage.go
+++ b/workers/generic-worker/usage.go
@@ -163,6 +163,9 @@ and reports back results to the queue.
           livelogPortBase                   Set the base port number for livelog. Livelog requires two
                                             ports: livelogPortBase & livelogPortBase + 1 are used.
                                             [default: 60098]
+          livelogExposePort                 When not using websocktunnel, livelog would be exposed using this port.
+                                            If it is set to 0, logs would be exposed using a random port.
+                                            [default: 0]
           numberOfTasksToRun                If zero, run tasks indefinitely. Otherwise, after
                                             this many tasks, exit. [default: 0]
           privateIP                         The private IP of the worker, used by chain of trust.


### PR DESCRIPTION
By default it will remain `0` and so port would be allocated dynamically.

But for local development environment where generic-worker runs inside the container, and `livelog` binary is executed within same container, assigning ports dynamically would make it hard to expose it using static `docker-compose.yml` file. 

This way we provide predefined port that will be used to expose livelog, which then could be accessed on the host and in the UI.


generic worker config may look like this:
```json
  "publicIP": "127.0.0.1",
  "livelogPortBase": 60000,
  "livelogExposePort": 59999
```

This means it would run `livelog` with `60000`, `60001` ports, and read port would be exposed on `59999` port, which will be used for the reference artifact, and would make it accessible in the UI.

Fixes #6395
