### PR TITLE
Don't allow writing on the websocket twice at the same time

### DIFF
--- a/changelog/S2l2EKSATh2TGiafzqHXxw.md
+++ b/changelog/S2l2EKSATh2TGiafzqHXxw.md
@@ -1,0 +1,3 @@
+audience: users
+level: silent
+---


### PR DESCRIPTION
Because the websocket library isn't thread safe and an error can occur and try to write the error to the websocket at the same time as the process outputs something, we have to lock the websocket while we're writing to it
