### PR TITLE
Handle GCS expire artifacts errors

### DIFF
--- a/changelog/issue-6405.md
+++ b/changelog/issue-6405.md
@@ -1,0 +1,6 @@
+audience: admins
+level: patch
+reference: issue 6405
+---
+
+Expire artifacts handles the case where the artifact is not found during deletion. GCS behaves differently to S3 here, as it will throw an error if the artifact is not found, where S3 would always return 204.

--- a/services/queue/test/expireartifacts_test.js
+++ b/services/queue/test/expireartifacts_test.js
@@ -87,13 +87,19 @@ helper.secrets.mockSuite(testing.suiteName(), ['aws'], function (mock, skipping)
     }),
   );
 
-  test('expire s3 artifacts but handle missing ones', async () => {
+  [
+    ['expire s3 artifacts handle missing ones using bulk delete', true],
+    ['expire s3 artifacts handle missing ones using single delete', false],
+  ].forEach(([name, useBulkDelete]) => test(name, async () => {
     const yesterday = taskcluster.fromNow('-1 day');
     const today = new Date();
     const taskId = slugid.nice();
     const bucket = await helper.load('publicArtifactBucket');
 
-    const maxUploads = Math.round(MAX_ARTIFACTS / 2);
+    await helper.load('cfg');
+    helper.load.cfg('aws.useBulkDelete', useBulkDelete);
+
+    const maxUploads = 1;
 
     for (let i = 0; i < MAX_ARTIFACTS; i++) {
       await helper.db.fns.create_queue_artifact(
@@ -109,16 +115,13 @@ helper.secrets.mockSuite(testing.suiteName(), ['aws'], function (mock, skipping)
         false,
         yesterday,
       );
-
-      if (i < maxUploads) {
-        // create mock s3 object
-        await bucket.s3.putObject({
-          Bucket: bucket.bucket,
-          Key: `${taskId}/${i}/log.log`,
-          Body: 'hello',
-        }).promise();
-      }
     }
+    // don't "upload" all files, just one to make them all fail during deletion
+    await bucket.s3.putObject({
+      Bucket: bucket.bucket,
+      Key: `${taskId}/1/log.log`,
+      Body: 'there can be only one',
+    }).promise();
 
     // check that the s3 objects exist
     let objects = await bucket.s3.listObjects({
@@ -148,7 +151,7 @@ helper.secrets.mockSuite(testing.suiteName(), ['aws'], function (mock, skipping)
       Prefix: `${taskId}/`,
     }).promise();
     assume(objects.Contents.length).equals(0);
-  });
+  }));
 
   test('expire non s3 artifacts', async () => {
     const yesterday = taskcluster.fromNow('-1 day');
@@ -185,5 +188,176 @@ helper.secrets.mockSuite(testing.suiteName(), ['aws'], function (mock, skipping)
       page_size_in: 1000,
     });
     assume(rows.length).equals(0);
+  });
+});
+
+// GCS specific mock
+helper.secrets.mockSuite(testing.suiteName(), ['aws'], function (mock, skipping) {
+  if (!mock) {
+    // see https://github.com/taskcluster/taskcluster/issues/6416 for details
+    // at the moment real tests are done against AWS S3 and those patches would make no sense
+    // errors would not be thrown, so they wouldn't be seen here
+    return;
+  }
+
+  helper.withDb(mock, skipping);
+  helper.withAmazonIPRanges(mock, skipping);
+  helper.withPulse(mock, skipping);
+  helper.withGCS(mock, skipping);
+  helper.withQueueService(mock, skipping);
+  helper.withServer(mock, skipping);
+  helper.resetTables(mock, skipping);
+
+  const MAX_ARTIFACTS = 5;
+
+  let monitor;
+  suiteSetup(async function () {
+    monitor = await helper.load('monitor');
+  });
+
+  test('using bulk delete objects on GCS should fail', async () => {
+    const yesterday = taskcluster.fromNow('-1 day');
+    const today = new Date();
+    const taskId = slugid.nice();
+    const bucket = await helper.load('publicArtifactBucket');
+
+    await helper.load('cfg');
+    helper.load.cfg('aws.useBulkDelete', true);
+
+    const artifactsToRemove = [];
+
+    for (let i = 0; i < MAX_ARTIFACTS; i++) {
+      await helper.db.fns.create_queue_artifact(
+        taskId,
+        i,
+        `name-${i}`,
+        's3',
+        'content-type',
+        {
+          bucket: bucket.bucket,
+          prefix: `${taskId}/${i}/log.log`,
+        },
+        false,
+        yesterday,
+      );
+      artifactsToRemove.push({ task_id: taskId, run_id: i, name: `name-${i}` });
+    }
+    // create only one mock s3 object
+    await bucket.s3.putObject({
+      Bucket: bucket.bucket,
+      Key: `${taskId}/1/log.log`,
+      Body: 'hello',
+    }).promise();
+
+    // check that the s3 objects exist
+    let objects = await bucket.s3.listObjects({
+      Bucket: bucket.bucket,
+      Prefix: `${taskId}/`,
+    }).promise();
+    assume(objects.Contents.length).equals(1);
+
+    let rows = await helper.db.fns.get_expired_artifacts_for_deletion({
+      expires_in: today,
+      page_size_in: 1000,
+    });
+    assume(rows.length).equals(MAX_ARTIFACTS);
+
+    // would log errors through monitor
+    await helper.runExpiration('expire-artifacts');
+    const errors = monitor.manager.messages.filter(m => m.Type === 'monitor.error');
+    assume(errors.length).equals(1);
+    assume(errors[0].Fields.message).matches(/InvalidArgument/);
+    monitor.manager.reset();
+
+    rows = await helper.db.fns.get_expired_artifacts_for_deletion({
+      expires_in: today,
+      page_size_in: 1000,
+    });
+    // nothing should be deleted since bulk delete will fail
+    assume(rows.length).equals(MAX_ARTIFACTS);
+
+    // check that the s3 objects are gone
+    objects = await bucket.s3.listObjects({
+      Bucket: bucket.bucket,
+      Prefix: `${taskId}/`,
+    }).promise();
+    assume(objects.Contents.length).equals(1);
+
+    // clean up artifacts that were not removed
+    await helper.db.fns.delete_queue_artifacts(
+      JSON.stringify(artifactsToRemove),
+    );
+  });
+
+  test('using single delete object on missing GCS artifacts should fail', async () => {
+    const yesterday = taskcluster.fromNow('-1 day');
+    const today = new Date();
+    const taskId = slugid.nice();
+    const bucket = await helper.load('publicArtifactBucket');
+
+    await helper.load('cfg');
+    helper.load.cfg('aws.useBulkDelete', false);
+
+    for (let i = 0; i < MAX_ARTIFACTS; i++) {
+      await helper.db.fns.create_queue_artifact(
+        taskId,
+        i,
+        `name-${i}`,
+        's3',
+        'content-type',
+        {
+          bucket: bucket.bucket,
+          prefix: `${taskId}/${i}/log.log`,
+        },
+        false,
+        yesterday,
+      );
+    }
+    // only upload one file
+    await bucket.s3.putObject({
+      Bucket: bucket.bucket,
+      Key: `${taskId}/1/log.log`,
+      Body: 'hello',
+    }).promise();
+
+    // check that the s3 objects exist
+    let objects = await bucket.s3.listObjects({
+      Bucket: bucket.bucket,
+      Prefix: `${taskId}/`,
+    }).promise();
+    assume(objects.Contents.length).equals(1); // we only upload one file
+
+    let rows = await helper.db.fns.get_expired_artifacts_for_deletion({
+      expires_in: today,
+      page_size_in: 1000,
+    });
+    assume(rows.length).equals(MAX_ARTIFACTS);
+
+    // would log errors through monitor
+    await helper.runExpiration('expire-artifacts');
+    const errors = monitor.manager.messages.filter(m => m.Type === 'monitor.error');
+    assume(errors.length).equals(4);
+    assume(errors.map(e => e.Fields.prefix).sort()).deep.equals([
+      `${taskId}/0/log.log`,
+      `${taskId}/2/log.log`,
+      `${taskId}/3/log.log`,
+      `${taskId}/4/log.log`,
+    ]);
+    assume(errors[0].Fields.bucket).equals('fake-public');
+    monitor.manager.reset();
+
+    rows = await helper.db.fns.get_expired_artifacts_for_deletion({
+      expires_in: today,
+      page_size_in: 1000,
+    });
+    // all should be gone after
+    assume(rows.length).equals(0);
+
+    // check that the s3 objects are gone
+    objects = await bucket.s3.listObjects({
+      Bucket: bucket.bucket,
+      Prefix: `${taskId}/`,
+    }).promise();
+    assume(objects.Contents.length).equals(0);
   });
 });


### PR DESCRIPTION
GCS throws `NoSuchKey` errors when artifact is not found during deletion, whereas S3 would always say 204.

Added separate tests for GCS-like S3 implementation with no `deleteObjects` support and different `deleteObject` behaviour

Fixes #6405
