### PR TITLE
feat(generic-worker): add loopbackAudio support

### DIFF
--- a/changelog/issue-5995.md
+++ b/changelog/issue-5995.md
@@ -1,0 +1,9 @@
+audience: users
+level: minor
+reference: issue 5995
+---
+Generic Worker: Adds `task.payload.feature.loopbackAudio` for loopback audio device support on Linux.
+
+The `snd-aloop` kernel module must be installed on the host system for this feature to work, although it does not _need_ to be loaded. Generic Worker loads the module with `modprobe` and generates the virtual audio device with a `snd-aloop` command. Under the multiuser engine, it also manages file ownership of the device with `chown` to ensure that only tasks with suitable scopes have read/write access to the virtual device.
+
+For tasks that enable the feature, the virtual audio device will be found at `/dev/snd`. Devices inside that directory will take the form `/dev/snd/controlC<DEVICE_NUMBER>`, `/dev/snd/pcmC<DEVICE_NUMBER>D0c`, `/dev/snd/pcmC<DEVICE_NUMBER>D0p`, `/dev/snd/pcmC<DEVICE_NUMBER>D1c`, and `/dev/snd/pcmC<DEVICE_NUMBER>D1p`, where `<DEVICE_NUMBER>` is an integer between 0 and 31, inclusive. The Generic Worker config setting `loopbackAudioDeviceNumber` may be used to change the device number in case the default value (`16`) conflicts with another audio device on the worker. Future releases of Generic Worker may provide the capability of having more than one virtual audio device; currently only one virtual audio device is supported.

--- a/generated/references.json
+++ b/generated/references.json
@@ -7956,6 +7956,11 @@
               "title": "Enable [livelog](https://github.com/taskcluster/taskcluster/tree/main/tools/livelog)",
               "type": "boolean"
             },
+            "loopbackAudio": {
+              "description": "Audio loopback device created using snd-aloop.\nAn audio device will be available for the task. Its\nlocation will be `/dev/snd`. Devices inside that directory\nwill take the form `/dev/snd/controlC<N>`,\n`/dev/snd/pcmC<N>D0c`, `/dev/snd/pcmC<N>D0p`,\n`/dev/snd/pcmC<N>D1c`, and `/dev/snd/pcmC<N>D1p`,\nwhere <N> is an integer between 0 and 31, inclusive.\nThe Generic Worker config setting `loopbackAudioDeviceNumber`\nmay be used to change the device number in case the\ndefault value (`16`) conflicts with another\naudio device on the worker.\n\nThis feature is only available on Linux. If a task\nis submitted with this feature enabled on a non-Linux,\nposix platform (FreeBSD, macOS), the task will resolve as\n`exception/malformed-payload`.\n\nSince: generic-worker 54.5.0",
+              "title": "Loopback Audio device",
+              "type": "boolean"
+            },
             "loopbackVideo": {
               "description": "Video loopback device created using v4l2loopback.\nA video device will be available for the task. Its\nlocation will be passed to the task via environment\nvariable `TASKCLUSTER_VIDEO_DEVICE`. The\nlocation will be `/dev/video<N>` where `<N>` is\nan integer between 0 and 255. The value of `<N>`\nis not static, and therefore either the environment\nvariable should be used, or `/dev` should be\nscanned in order to determine the correct location.\nTasks should not assume a constant value.\n\nThis feature is only available on Linux. If a task\nis submitted with this feature enabled on a non-Linux,\nposix platform (FreeBSD, macOS), the task will resolve as\n`exception/malformed-payload`.\n\nSince: generic-worker 53.1.0",
               "title": "Loopback Video device",
@@ -8876,6 +8881,11 @@
                   "default": true,
                   "description": "The live log feature streams the combined stderr and stdout to a task artifact\nso that the output is available while the task is running.\n\nSince: generic-worker 48.2.0",
                   "title": "Enable [livelog](https://github.com/taskcluster/taskcluster/tree/main/tools/livelog)",
+                  "type": "boolean"
+                },
+                "loopbackAudio": {
+                  "description": "Audio loopback device created using snd-aloop.\nAn audio device will be available for the task. Its\nlocation will be `/dev/snd`. Devices inside that directory\nwill take the form `/dev/snd/controlC<N>`,\n`/dev/snd/pcmC<N>D0c`, `/dev/snd/pcmC<N>D0p`,\n`/dev/snd/pcmC<N>D1c`, and `/dev/snd/pcmC<N>D1p`,\nwhere <N> is an integer between 0 and 31, inclusive.\nThe Generic Worker config setting `loopbackAudioDeviceNumber`\nmay be used to change the device number in case the\ndefault value (`16`) conflicts with another\naudio device on the worker.\n\nThis feature is only available on Linux. If a task\nis submitted with this feature enabled on a non-Linux,\nposix platform (FreeBSD, macOS), the task will resolve as\n`exception/malformed-payload`.\n\nSince: generic-worker 54.5.0",
+                  "title": "Loopback Audio device",
                   "type": "boolean"
                 },
                 "loopbackVideo": {

--- a/tools/d2g/d2g.go
+++ b/tools/d2g/d2g.go
@@ -42,6 +42,10 @@ func Scopes(dwScopes []string) (gwScopes []string) {
 			gwScopes[i] = "generic-worker:loopback-video:*"
 		case strings.HasPrefix(s, "docker-worker:capability:device:loopbackVideo:"):
 			gwScopes[i] = "generic-worker:loopback-video:" + s[len("docker-worker:capability:device:loopbackVideo:"):]
+		case s == "docker-worker:capability:device:loopbackAudio":
+			gwScopes[i] = "generic-worker:loopback-audio:*"
+		case strings.HasPrefix(s, "docker-worker:capability:device:loopbackAudio:"):
+			gwScopes[i] = "generic-worker:loopback-audio:" + s[len("docker-worker:capability:device:loopbackAudio:"):]
 		case strings.HasPrefix(s, "docker-worker:"):
 			gwScopes[i] = "generic-worker:" + s[len("docker-worker:"):]
 		default:
@@ -264,6 +268,7 @@ func setFeatures(dwPayload *dockerworker.DockerWorkerPayload, gwPayload *generic
 	gwPayload.Features.TaskclusterProxy = gwPayload.Features.TaskclusterProxy || dwPayload.Features.TaskclusterProxy
 	gwPayload.Features.Interactive = dwPayload.Features.Interactive
 	gwPayload.Features.LoopbackVideo = dwPayload.Capabilities.Devices.LoopbackVideo
+	gwPayload.Features.LoopbackAudio = dwPayload.Capabilities.Devices.LoopbackAudio
 
 	switch dwPayload.Features.Artifacts {
 	case true:
@@ -349,13 +354,16 @@ func createVolumeMountsString(dwPayload *dockerworker.DockerWorkerPayload, wdcs 
 		volumeMounts.WriteString(` -v "$(pwd)/` + wdc.Directory + ":" + dwPayload.Cache[wdc.CacheName] + `"`)
 	}
 	if dwPayload.Capabilities.Devices.KVM {
-		volumeMounts.WriteString(" -v /dev/kvm:/dev/kvm")
+		volumeMounts.WriteString(" --device=/dev/kvm")
 	}
 	if dwPayload.Capabilities.Devices.HostSharedMemory {
-		volumeMounts.WriteString(" -v /dev/shm:/dev/shm")
+		volumeMounts.WriteString(" --device=/dev/shm")
 	}
 	if dwPayload.Capabilities.Devices.LoopbackVideo {
-		volumeMounts.WriteString(` -v "${TASKCLUSTER_VIDEO_DEVICE}:/dev/video0"`)
+		volumeMounts.WriteString(` --device="${TASKCLUSTER_VIDEO_DEVICE}"`)
+	}
+	if dwPayload.Capabilities.Devices.LoopbackAudio {
+		volumeMounts.WriteString(" --device=/dev/snd")
 	}
 	return volumeMounts.String()
 }

--- a/tools/d2g/d2gtest/testdata/testcases/devices_tests.yml
+++ b/tools/d2g/d2gtest/testdata/testcases/devices_tests.yml
@@ -20,7 +20,7 @@ testSuite:
             - '-cx'
             - >-
               podman run -t --rm
-              -v /dev/shm:/dev/shm
+              --device=/dev/shm
               -e "RUN_ID=${RUN_ID}" -e
               "TASKCLUSTER_ROOT_URL=${TASKCLUSTER_ROOT_URL}" -e
               "TASKCLUSTER_WORKER_LOCATION=${TASKCLUSTER_WORKER_LOCATION}" -e
@@ -48,7 +48,7 @@ testSuite:
             - '-cx'
             - >-
               podman run -t --rm
-              -v /dev/kvm:/dev/kvm
+              --device=/dev/kvm
               -e "RUN_ID=${RUN_ID}" -e
               "TASKCLUSTER_ROOT_URL=${TASKCLUSTER_ROOT_URL}" -e
               "TASKCLUSTER_WORKER_LOCATION=${TASKCLUSTER_WORKER_LOCATION}" -e
@@ -76,7 +76,7 @@ testSuite:
             - '-cx'
             - >-
               podman run -t --rm
-              -v "${TASKCLUSTER_VIDEO_DEVICE}:/dev/video0"
+              --device="${TASKCLUSTER_VIDEO_DEVICE}"
               -e "RUN_ID=${RUN_ID}" -e
               "TASKCLUSTER_ROOT_URL=${TASKCLUSTER_ROOT_URL}" -e
               "TASKCLUSTER_WORKER_LOCATION=${TASKCLUSTER_WORKER_LOCATION}" -e
@@ -84,6 +84,36 @@ testSuite:
               ubuntu 'echo "Hello world"'
         features:
           loopbackVideo: true
+        maxRunTime: 3600
+        onExitStatus:
+          retry:
+            - 125
+
+    - name: Audio Loopback
+      description: >-
+        Tests that loopbackAudio _capability_ in Docker Worker maps to Generic Worker _feature_ of the same name.
+      dockerWorkerTaskPayload:
+        command:
+          - echo "Hello world"
+        capabilities:
+          devices:
+            loopbackAudio: true
+        image: ubuntu
+        maxRunTime: 3600
+      genericWorkerTaskPayload:
+        command:
+          - - bash
+            - '-cx'
+            - >-
+              podman run -t --rm
+              --device=/dev/snd
+              -e "RUN_ID=${RUN_ID}" -e
+              "TASKCLUSTER_ROOT_URL=${TASKCLUSTER_ROOT_URL}" -e
+              "TASKCLUSTER_WORKER_LOCATION=${TASKCLUSTER_WORKER_LOCATION}" -e
+              "TASK_ID=${TASK_ID}"
+              ubuntu 'echo "Hello world"'
+        features:
+          loopbackAudio: true
         maxRunTime: 3600
         onExitStatus:
           retry:

--- a/tools/d2g/genericworker/generated_types.go
+++ b/tools/d2g/genericworker/generated_types.go
@@ -373,6 +373,26 @@ type (
 		// Default:    true
 		LiveLog bool `json:"liveLog" default:"true"`
 
+		// Audio loopback device created using snd-aloop.
+		// An audio device will be available for the task. Its
+		// location will be `/dev/snd`. Devices inside that directory
+		// will take the form `/dev/snd/controlC<N>`,
+		// `/dev/snd/pcmC<N>D0c`, `/dev/snd/pcmC<N>D0p`,
+		// `/dev/snd/pcmC<N>D1c`, and `/dev/snd/pcmC<N>D1p`,
+		// where <N> is an integer between 0 and 31, inclusive.
+		// The Generic Worker config setting `loopbackAudioDeviceNumber`
+		// may be used to change the device number in case the
+		// default value (`16`) conflicts with another
+		// audio device on the worker.
+		//
+		// This feature is only available on Linux. If a task
+		// is submitted with this feature enabled on a non-Linux,
+		// posix platform (FreeBSD, macOS), the task will resolve as
+		// `exception/malformed-payload`.
+		//
+		// Since: generic-worker 54.5.0
+		LoopbackAudio bool `json:"loopbackAudio,omitempty"`
+
 		// Video loopback device created using v4l2loopback.
 		// A video device will be available for the task. Its
 		// location will be passed to the task via environment
@@ -1071,6 +1091,11 @@ func JSONSchema() string {
               "default": true,
               "description": "The live log feature streams the combined stderr and stdout to a task artifact\nso that the output is available while the task is running.\n\nSince: generic-worker 48.2.0",
               "title": "Enable [livelog](https://github.com/taskcluster/taskcluster/tree/main/tools/livelog)",
+              "type": "boolean"
+            },
+            "loopbackAudio": {
+              "description": "Audio loopback device created using snd-aloop.\nAn audio device will be available for the task. Its\nlocation will be ` + "`" + `/dev/snd` + "`" + `. Devices inside that directory\nwill take the form ` + "`" + `/dev/snd/controlC\u003cN\u003e` + "`" + `,\n` + "`" + `/dev/snd/pcmC\u003cN\u003eD0c` + "`" + `, ` + "`" + `/dev/snd/pcmC\u003cN\u003eD0p` + "`" + `,\n` + "`" + `/dev/snd/pcmC\u003cN\u003eD1c` + "`" + `, and ` + "`" + `/dev/snd/pcmC\u003cN\u003eD1p` + "`" + `,\nwhere \u003cN\u003e is an integer between 0 and 31, inclusive.\nThe Generic Worker config setting ` + "`" + `loopbackAudioDeviceNumber` + "`" + `\nmay be used to change the device number in case the\ndefault value (` + "`" + `16` + "`" + `) conflicts with another\naudio device on the worker.\n\nThis feature is only available on Linux. If a task\nis submitted with this feature enabled on a non-Linux,\nposix platform (FreeBSD, macOS), the task will resolve as\n` + "`" + `exception/malformed-payload` + "`" + `.\n\nSince: generic-worker 54.5.0",
+              "title": "Loopback Audio device",
               "type": "boolean"
             },
             "loopbackVideo": {

--- a/workers/generic-worker/README.md
+++ b/workers/generic-worker/README.md
@@ -153,6 +153,15 @@ and reports back results to the queue.
           livelogExposePort                 When not using websocktunnel, livelog would be exposed using this port.
                                             If it is set to 0, logs would be exposed using a random port.
                                             [default: 0]
+          loopbackAudioDeviceNumber         The audio loopback device number. The resulting devices inside /dev/snd
+                                            will take the form controlC<DEVICE_NUMBER>, pcmC<DEVICE_NUMBER>D0c,
+                                            pcmC<DEVICE_NUMBER>D0p, pcmC<DEVICE_NUMBER>D1c, pcmC<DEVICE_NUMBER>D1p
+                                            where <DEVICE_NUMBER> is an integer between 0 and 31.
+                                            [default: 16]
+          loopbackVideoDeviceNumber         The video loopback device number. Its value will take the form
+                                            /dev/video<DEVICE_NUMBER> where <DEVICE_NUMBER> is an integer
+                                            between 0 and 255. This setting may be used to change it.
+                                            [default: 0]
           maxTaskRunTime                    The maximum value allowed for maxRunTime on generic-worker payloads.
                                             [default: 86400]
           numberOfTasksToRun                If zero, run tasks indefinitely. Otherwise, after

--- a/workers/generic-worker/generated_multiuser_darwin.go
+++ b/workers/generic-worker/generated_multiuser_darwin.go
@@ -375,6 +375,26 @@ type (
 		// Default:    true
 		LiveLog bool `json:"liveLog" default:"true"`
 
+		// Audio loopback device created using snd-aloop.
+		// An audio device will be available for the task. Its
+		// location will be `/dev/snd`. Devices inside that directory
+		// will take the form `/dev/snd/controlC<N>`,
+		// `/dev/snd/pcmC<N>D0c`, `/dev/snd/pcmC<N>D0p`,
+		// `/dev/snd/pcmC<N>D1c`, and `/dev/snd/pcmC<N>D1p`,
+		// where <N> is an integer between 0 and 31, inclusive.
+		// The Generic Worker config setting `loopbackAudioDeviceNumber`
+		// may be used to change the device number in case the
+		// default value (`16`) conflicts with another
+		// audio device on the worker.
+		//
+		// This feature is only available on Linux. If a task
+		// is submitted with this feature enabled on a non-Linux,
+		// posix platform (FreeBSD, macOS), the task will resolve as
+		// `exception/malformed-payload`.
+		//
+		// Since: generic-worker 54.5.0
+		LoopbackAudio bool `json:"loopbackAudio,omitempty"`
+
 		// Video loopback device created using v4l2loopback.
 		// A video device will be available for the task. Its
 		// location will be passed to the task via environment
@@ -1073,6 +1093,11 @@ func JSONSchema() string {
               "default": true,
               "description": "The live log feature streams the combined stderr and stdout to a task artifact\nso that the output is available while the task is running.\n\nSince: generic-worker 48.2.0",
               "title": "Enable [livelog](https://github.com/taskcluster/taskcluster/tree/main/tools/livelog)",
+              "type": "boolean"
+            },
+            "loopbackAudio": {
+              "description": "Audio loopback device created using snd-aloop.\nAn audio device will be available for the task. Its\nlocation will be ` + "`" + `/dev/snd` + "`" + `. Devices inside that directory\nwill take the form ` + "`" + `/dev/snd/controlC\u003cN\u003e` + "`" + `,\n` + "`" + `/dev/snd/pcmC\u003cN\u003eD0c` + "`" + `, ` + "`" + `/dev/snd/pcmC\u003cN\u003eD0p` + "`" + `,\n` + "`" + `/dev/snd/pcmC\u003cN\u003eD1c` + "`" + `, and ` + "`" + `/dev/snd/pcmC\u003cN\u003eD1p` + "`" + `,\nwhere \u003cN\u003e is an integer between 0 and 31, inclusive.\nThe Generic Worker config setting ` + "`" + `loopbackAudioDeviceNumber` + "`" + `\nmay be used to change the device number in case the\ndefault value (` + "`" + `16` + "`" + `) conflicts with another\naudio device on the worker.\n\nThis feature is only available on Linux. If a task\nis submitted with this feature enabled on a non-Linux,\nposix platform (FreeBSD, macOS), the task will resolve as\n` + "`" + `exception/malformed-payload` + "`" + `.\n\nSince: generic-worker 54.5.0",
+              "title": "Loopback Audio device",
               "type": "boolean"
             },
             "loopbackVideo": {

--- a/workers/generic-worker/generated_multiuser_freebsd.go
+++ b/workers/generic-worker/generated_multiuser_freebsd.go
@@ -375,6 +375,26 @@ type (
 		// Default:    true
 		LiveLog bool `json:"liveLog" default:"true"`
 
+		// Audio loopback device created using snd-aloop.
+		// An audio device will be available for the task. Its
+		// location will be `/dev/snd`. Devices inside that directory
+		// will take the form `/dev/snd/controlC<N>`,
+		// `/dev/snd/pcmC<N>D0c`, `/dev/snd/pcmC<N>D0p`,
+		// `/dev/snd/pcmC<N>D1c`, and `/dev/snd/pcmC<N>D1p`,
+		// where <N> is an integer between 0 and 31, inclusive.
+		// The Generic Worker config setting `loopbackAudioDeviceNumber`
+		// may be used to change the device number in case the
+		// default value (`16`) conflicts with another
+		// audio device on the worker.
+		//
+		// This feature is only available on Linux. If a task
+		// is submitted with this feature enabled on a non-Linux,
+		// posix platform (FreeBSD, macOS), the task will resolve as
+		// `exception/malformed-payload`.
+		//
+		// Since: generic-worker 54.5.0
+		LoopbackAudio bool `json:"loopbackAudio,omitempty"`
+
 		// Video loopback device created using v4l2loopback.
 		// A video device will be available for the task. Its
 		// location will be passed to the task via environment
@@ -1073,6 +1093,11 @@ func JSONSchema() string {
               "default": true,
               "description": "The live log feature streams the combined stderr and stdout to a task artifact\nso that the output is available while the task is running.\n\nSince: generic-worker 48.2.0",
               "title": "Enable [livelog](https://github.com/taskcluster/taskcluster/tree/main/tools/livelog)",
+              "type": "boolean"
+            },
+            "loopbackAudio": {
+              "description": "Audio loopback device created using snd-aloop.\nAn audio device will be available for the task. Its\nlocation will be ` + "`" + `/dev/snd` + "`" + `. Devices inside that directory\nwill take the form ` + "`" + `/dev/snd/controlC\u003cN\u003e` + "`" + `,\n` + "`" + `/dev/snd/pcmC\u003cN\u003eD0c` + "`" + `, ` + "`" + `/dev/snd/pcmC\u003cN\u003eD0p` + "`" + `,\n` + "`" + `/dev/snd/pcmC\u003cN\u003eD1c` + "`" + `, and ` + "`" + `/dev/snd/pcmC\u003cN\u003eD1p` + "`" + `,\nwhere \u003cN\u003e is an integer between 0 and 31, inclusive.\nThe Generic Worker config setting ` + "`" + `loopbackAudioDeviceNumber` + "`" + `\nmay be used to change the device number in case the\ndefault value (` + "`" + `16` + "`" + `) conflicts with another\naudio device on the worker.\n\nThis feature is only available on Linux. If a task\nis submitted with this feature enabled on a non-Linux,\nposix platform (FreeBSD, macOS), the task will resolve as\n` + "`" + `exception/malformed-payload` + "`" + `.\n\nSince: generic-worker 54.5.0",
+              "title": "Loopback Audio device",
               "type": "boolean"
             },
             "loopbackVideo": {

--- a/workers/generic-worker/generated_multiuser_linux.go
+++ b/workers/generic-worker/generated_multiuser_linux.go
@@ -375,6 +375,26 @@ type (
 		// Default:    true
 		LiveLog bool `json:"liveLog" default:"true"`
 
+		// Audio loopback device created using snd-aloop.
+		// An audio device will be available for the task. Its
+		// location will be `/dev/snd`. Devices inside that directory
+		// will take the form `/dev/snd/controlC<N>`,
+		// `/dev/snd/pcmC<N>D0c`, `/dev/snd/pcmC<N>D0p`,
+		// `/dev/snd/pcmC<N>D1c`, and `/dev/snd/pcmC<N>D1p`,
+		// where <N> is an integer between 0 and 31, inclusive.
+		// The Generic Worker config setting `loopbackAudioDeviceNumber`
+		// may be used to change the device number in case the
+		// default value (`16`) conflicts with another
+		// audio device on the worker.
+		//
+		// This feature is only available on Linux. If a task
+		// is submitted with this feature enabled on a non-Linux,
+		// posix platform (FreeBSD, macOS), the task will resolve as
+		// `exception/malformed-payload`.
+		//
+		// Since: generic-worker 54.5.0
+		LoopbackAudio bool `json:"loopbackAudio,omitempty"`
+
 		// Video loopback device created using v4l2loopback.
 		// A video device will be available for the task. Its
 		// location will be passed to the task via environment
@@ -1073,6 +1093,11 @@ func JSONSchema() string {
               "default": true,
               "description": "The live log feature streams the combined stderr and stdout to a task artifact\nso that the output is available while the task is running.\n\nSince: generic-worker 48.2.0",
               "title": "Enable [livelog](https://github.com/taskcluster/taskcluster/tree/main/tools/livelog)",
+              "type": "boolean"
+            },
+            "loopbackAudio": {
+              "description": "Audio loopback device created using snd-aloop.\nAn audio device will be available for the task. Its\nlocation will be ` + "`" + `/dev/snd` + "`" + `. Devices inside that directory\nwill take the form ` + "`" + `/dev/snd/controlC\u003cN\u003e` + "`" + `,\n` + "`" + `/dev/snd/pcmC\u003cN\u003eD0c` + "`" + `, ` + "`" + `/dev/snd/pcmC\u003cN\u003eD0p` + "`" + `,\n` + "`" + `/dev/snd/pcmC\u003cN\u003eD1c` + "`" + `, and ` + "`" + `/dev/snd/pcmC\u003cN\u003eD1p` + "`" + `,\nwhere \u003cN\u003e is an integer between 0 and 31, inclusive.\nThe Generic Worker config setting ` + "`" + `loopbackAudioDeviceNumber` + "`" + `\nmay be used to change the device number in case the\ndefault value (` + "`" + `16` + "`" + `) conflicts with another\naudio device on the worker.\n\nThis feature is only available on Linux. If a task\nis submitted with this feature enabled on a non-Linux,\nposix platform (FreeBSD, macOS), the task will resolve as\n` + "`" + `exception/malformed-payload` + "`" + `.\n\nSince: generic-worker 54.5.0",
+              "title": "Loopback Audio device",
               "type": "boolean"
             },
             "loopbackVideo": {

--- a/workers/generic-worker/generated_simple_darwin.go
+++ b/workers/generic-worker/generated_simple_darwin.go
@@ -191,6 +191,26 @@ type (
 		// Default:    true
 		LiveLog bool `json:"liveLog" default:"true"`
 
+		// Audio loopback device created using snd-aloop.
+		// An audio device will be available for the task. Its
+		// location will be `/dev/snd`. Devices inside that directory
+		// will take the form `/dev/snd/controlC<N>`,
+		// `/dev/snd/pcmC<N>D0c`, `/dev/snd/pcmC<N>D0p`,
+		// `/dev/snd/pcmC<N>D1c`, and `/dev/snd/pcmC<N>D1p`,
+		// where <N> is an integer between 0 and 31, inclusive.
+		// The Generic Worker config setting `loopbackAudioDeviceNumber`
+		// may be used to change the device number in case the
+		// default value (`16`) conflicts with another
+		// audio device on the worker.
+		//
+		// This feature is only available on Linux. If a task
+		// is submitted with this feature enabled on a non-Linux,
+		// posix platform (FreeBSD, macOS), the task will resolve as
+		// `exception/malformed-payload`.
+		//
+		// Since: generic-worker 54.5.0
+		LoopbackAudio bool `json:"loopbackAudio,omitempty"`
+
 		// Video loopback device created using v4l2loopback.
 		// A video device will be available for the task. Its
 		// location will be passed to the task via environment
@@ -802,6 +822,11 @@ func JSONSchema() string {
           "default": true,
           "description": "The live log feature streams the combined stderr and stdout to a task artifact\nso that the output is available while the task is running.\n\nSince: generic-worker 48.2.0",
           "title": "Enable [livelog](https://github.com/taskcluster/taskcluster/tree/main/tools/livelog)",
+          "type": "boolean"
+        },
+        "loopbackAudio": {
+          "description": "Audio loopback device created using snd-aloop.\nAn audio device will be available for the task. Its\nlocation will be ` + "`" + `/dev/snd` + "`" + `. Devices inside that directory\nwill take the form ` + "`" + `/dev/snd/controlC\u003cN\u003e` + "`" + `,\n` + "`" + `/dev/snd/pcmC\u003cN\u003eD0c` + "`" + `, ` + "`" + `/dev/snd/pcmC\u003cN\u003eD0p` + "`" + `,\n` + "`" + `/dev/snd/pcmC\u003cN\u003eD1c` + "`" + `, and ` + "`" + `/dev/snd/pcmC\u003cN\u003eD1p` + "`" + `,\nwhere \u003cN\u003e is an integer between 0 and 31, inclusive.\nThe Generic Worker config setting ` + "`" + `loopbackAudioDeviceNumber` + "`" + `\nmay be used to change the device number in case the\ndefault value (` + "`" + `16` + "`" + `) conflicts with another\naudio device on the worker.\n\nThis feature is only available on Linux. If a task\nis submitted with this feature enabled on a non-Linux,\nposix platform (FreeBSD, macOS), the task will resolve as\n` + "`" + `exception/malformed-payload` + "`" + `.\n\nSince: generic-worker 54.5.0",
+          "title": "Loopback Audio device",
           "type": "boolean"
         },
         "loopbackVideo": {

--- a/workers/generic-worker/generated_simple_freebsd.go
+++ b/workers/generic-worker/generated_simple_freebsd.go
@@ -191,6 +191,26 @@ type (
 		// Default:    true
 		LiveLog bool `json:"liveLog" default:"true"`
 
+		// Audio loopback device created using snd-aloop.
+		// An audio device will be available for the task. Its
+		// location will be `/dev/snd`. Devices inside that directory
+		// will take the form `/dev/snd/controlC<N>`,
+		// `/dev/snd/pcmC<N>D0c`, `/dev/snd/pcmC<N>D0p`,
+		// `/dev/snd/pcmC<N>D1c`, and `/dev/snd/pcmC<N>D1p`,
+		// where <N> is an integer between 0 and 31, inclusive.
+		// The Generic Worker config setting `loopbackAudioDeviceNumber`
+		// may be used to change the device number in case the
+		// default value (`16`) conflicts with another
+		// audio device on the worker.
+		//
+		// This feature is only available on Linux. If a task
+		// is submitted with this feature enabled on a non-Linux,
+		// posix platform (FreeBSD, macOS), the task will resolve as
+		// `exception/malformed-payload`.
+		//
+		// Since: generic-worker 54.5.0
+		LoopbackAudio bool `json:"loopbackAudio,omitempty"`
+
 		// Video loopback device created using v4l2loopback.
 		// A video device will be available for the task. Its
 		// location will be passed to the task via environment
@@ -802,6 +822,11 @@ func JSONSchema() string {
           "default": true,
           "description": "The live log feature streams the combined stderr and stdout to a task artifact\nso that the output is available while the task is running.\n\nSince: generic-worker 48.2.0",
           "title": "Enable [livelog](https://github.com/taskcluster/taskcluster/tree/main/tools/livelog)",
+          "type": "boolean"
+        },
+        "loopbackAudio": {
+          "description": "Audio loopback device created using snd-aloop.\nAn audio device will be available for the task. Its\nlocation will be ` + "`" + `/dev/snd` + "`" + `. Devices inside that directory\nwill take the form ` + "`" + `/dev/snd/controlC\u003cN\u003e` + "`" + `,\n` + "`" + `/dev/snd/pcmC\u003cN\u003eD0c` + "`" + `, ` + "`" + `/dev/snd/pcmC\u003cN\u003eD0p` + "`" + `,\n` + "`" + `/dev/snd/pcmC\u003cN\u003eD1c` + "`" + `, and ` + "`" + `/dev/snd/pcmC\u003cN\u003eD1p` + "`" + `,\nwhere \u003cN\u003e is an integer between 0 and 31, inclusive.\nThe Generic Worker config setting ` + "`" + `loopbackAudioDeviceNumber` + "`" + `\nmay be used to change the device number in case the\ndefault value (` + "`" + `16` + "`" + `) conflicts with another\naudio device on the worker.\n\nThis feature is only available on Linux. If a task\nis submitted with this feature enabled on a non-Linux,\nposix platform (FreeBSD, macOS), the task will resolve as\n` + "`" + `exception/malformed-payload` + "`" + `.\n\nSince: generic-worker 54.5.0",
+          "title": "Loopback Audio device",
           "type": "boolean"
         },
         "loopbackVideo": {

--- a/workers/generic-worker/generated_simple_linux.go
+++ b/workers/generic-worker/generated_simple_linux.go
@@ -191,6 +191,26 @@ type (
 		// Default:    true
 		LiveLog bool `json:"liveLog" default:"true"`
 
+		// Audio loopback device created using snd-aloop.
+		// An audio device will be available for the task. Its
+		// location will be `/dev/snd`. Devices inside that directory
+		// will take the form `/dev/snd/controlC<N>`,
+		// `/dev/snd/pcmC<N>D0c`, `/dev/snd/pcmC<N>D0p`,
+		// `/dev/snd/pcmC<N>D1c`, and `/dev/snd/pcmC<N>D1p`,
+		// where <N> is an integer between 0 and 31, inclusive.
+		// The Generic Worker config setting `loopbackAudioDeviceNumber`
+		// may be used to change the device number in case the
+		// default value (`16`) conflicts with another
+		// audio device on the worker.
+		//
+		// This feature is only available on Linux. If a task
+		// is submitted with this feature enabled on a non-Linux,
+		// posix platform (FreeBSD, macOS), the task will resolve as
+		// `exception/malformed-payload`.
+		//
+		// Since: generic-worker 54.5.0
+		LoopbackAudio bool `json:"loopbackAudio,omitempty"`
+
 		// Video loopback device created using v4l2loopback.
 		// A video device will be available for the task. Its
 		// location will be passed to the task via environment
@@ -802,6 +822,11 @@ func JSONSchema() string {
           "default": true,
           "description": "The live log feature streams the combined stderr and stdout to a task artifact\nso that the output is available while the task is running.\n\nSince: generic-worker 48.2.0",
           "title": "Enable [livelog](https://github.com/taskcluster/taskcluster/tree/main/tools/livelog)",
+          "type": "boolean"
+        },
+        "loopbackAudio": {
+          "description": "Audio loopback device created using snd-aloop.\nAn audio device will be available for the task. Its\nlocation will be ` + "`" + `/dev/snd` + "`" + `. Devices inside that directory\nwill take the form ` + "`" + `/dev/snd/controlC\u003cN\u003e` + "`" + `,\n` + "`" + `/dev/snd/pcmC\u003cN\u003eD0c` + "`" + `, ` + "`" + `/dev/snd/pcmC\u003cN\u003eD0p` + "`" + `,\n` + "`" + `/dev/snd/pcmC\u003cN\u003eD1c` + "`" + `, and ` + "`" + `/dev/snd/pcmC\u003cN\u003eD1p` + "`" + `,\nwhere \u003cN\u003e is an integer between 0 and 31, inclusive.\nThe Generic Worker config setting ` + "`" + `loopbackAudioDeviceNumber` + "`" + `\nmay be used to change the device number in case the\ndefault value (` + "`" + `16` + "`" + `) conflicts with another\naudio device on the worker.\n\nThis feature is only available on Linux. If a task\nis submitted with this feature enabled on a non-Linux,\nposix platform (FreeBSD, macOS), the task will resolve as\n` + "`" + `exception/malformed-payload` + "`" + `.\n\nSince: generic-worker 54.5.0",
+          "title": "Loopback Audio device",
           "type": "boolean"
         },
         "loopbackVideo": {

--- a/workers/generic-worker/gwconfig/config.go
+++ b/workers/generic-worker/gwconfig/config.go
@@ -44,6 +44,7 @@ type (
 		LiveLogExecutable              string                 `json:"livelogExecutable"`
 		LiveLogPortBase                uint16                 `json:"livelogPortBase"`
 		LiveLogExposePort              uint16                 `json:"livelogExposePort"`
+		LoopbackAudioDeviceNumber      uint8                  `json:"loopbackAudioDeviceNumber"`
 		LoopbackVideoDeviceNumber      uint8                  `json:"loopbackVideoDeviceNumber"`
 		MaxTaskRunTime                 uint32                 `json:"maxTaskRunTime"`
 		NumberOfTasksToRun             uint                   `json:"numberOfTasksToRun"`

--- a/workers/generic-worker/loopback_audio_darwin.go
+++ b/workers/generic-worker/loopback_audio_darwin.go
@@ -1,0 +1,13 @@
+//go:build darwin
+
+package main
+
+import "fmt"
+
+func (lat *LoopbackAudioTask) setupAudioDevice() *CommandExecutionError {
+	return executionError(malformedPayload, errored, fmt.Errorf("Loopback audio device is not supported on macOS"))
+}
+
+func (lat *LoopbackAudioTask) resetAudioDevice() *CommandExecutionError {
+	return nil
+}

--- a/workers/generic-worker/loopback_audio_darwin_test.go
+++ b/workers/generic-worker/loopback_audio_darwin_test.go
@@ -1,0 +1,28 @@
+//go:build darwin
+
+package main
+
+import (
+	"testing"
+
+	"github.com/mcuadros/go-defaults"
+)
+
+func TestLoopbackAudioReturnsMalformedPayload(t *testing.T) {
+	setup(t)
+
+	payload := GenericWorkerPayload{
+		Command:    helloGoodbye(),
+		MaxRunTime: 30,
+		Features: FeatureFlags{
+			LoopbackAudio: true,
+		},
+	}
+	defaults.SetDefaults(&payload)
+	td := testTask(t)
+	td.Scopes = append(td.Scopes, "generic-worker:loopback-audio")
+
+	// This test is expected to fail with malformed payload
+	// because loopback audio is not supported on macOS
+	_ = submitAndAssert(t, td, payload, "exception", "malformed-payload")
+}

--- a/workers/generic-worker/loopback_audio_freebsd.go
+++ b/workers/generic-worker/loopback_audio_freebsd.go
@@ -1,0 +1,13 @@
+//go:build freebsd
+
+package main
+
+import "fmt"
+
+func (lat *LoopbackAudioTask) setupAudioDevice() *CommandExecutionError {
+	return executionError(malformedPayload, errored, fmt.Errorf("Loopback audio device is not supported on FreeBSD"))
+}
+
+func (lat *LoopbackAudioTask) resetAudioDevice() *CommandExecutionError {
+	return nil
+}

--- a/workers/generic-worker/loopback_audio_freebsd_test.go
+++ b/workers/generic-worker/loopback_audio_freebsd_test.go
@@ -1,0 +1,28 @@
+//go:build freebsd
+
+package main
+
+import (
+	"testing"
+
+	"github.com/mcuadros/go-defaults"
+)
+
+func TestLoopbackAudioReturnsMalformedPayload(t *testing.T) {
+	setup(t)
+
+	payload := GenericWorkerPayload{
+		Command:    helloGoodbye(),
+		MaxRunTime: 30,
+		Features: FeatureFlags{
+			LoopbackAudio: true,
+		},
+	}
+	defaults.SetDefaults(&payload)
+	td := testTask(t)
+	td.Scopes = append(td.Scopes, "generic-worker:loopback-audio:freebsd/loopback-audio")
+
+	// This test is expected to fail with malformed payload
+	// because loopback audio is not supported on FreeBSD
+	_ = submitAndAssert(t, td, payload, "exception", "malformed-payload")
+}

--- a/workers/generic-worker/loopback_audio_linux.go
+++ b/workers/generic-worker/loopback_audio_linux.go
@@ -1,0 +1,51 @@
+//go:build linux
+
+package main
+
+import (
+	"fmt"
+
+	"github.com/taskcluster/taskcluster/v54/workers/generic-worker/host"
+)
+
+func (lat *LoopbackAudioTask) setupAudioDevice() *CommandExecutionError {
+	opts := fmt.Sprintf("options snd-aloop enable=1 index=%d", config.LoopbackAudioDeviceNumber)
+	out, err := host.CombinedOutput("/usr/bin/env", "bash", "-c", fmt.Sprintf("/usr/bin/echo %s > /etc/modprobe.d/snd-aloop.conf", opts))
+	if err != nil {
+		return executionError(internalError, errored, fmt.Errorf("Could not set snd-aloop kernel module options. Output: %s. Error: %v.", out, err))
+	}
+
+	out, err = host.CombinedOutput("/usr/sbin/modprobe", "snd-aloop")
+	if err != nil {
+		return executionError(internalError, errored, fmt.Errorf("Could not load the snd-aloop kernel module. Output: %s. Error: %v.", out, err))
+	}
+
+	for _, devicePath := range lat.devicePaths {
+		out, err = host.CombinedOutput("/bin/chmod", "660", devicePath)
+		if err != nil {
+			return executionError(internalError, errored, fmt.Errorf("Could not chmod 660 the %s device. Output: %s. Error: %v.", devicePath, out, err))
+		}
+	}
+
+	for _, devicePath := range lat.devicePaths {
+		err = makeFileOrDirReadWritableForUser(false, devicePath, taskContext.User)
+		if err != nil {
+			return executionError(internalError, errored, fmt.Errorf("Could make the %s device readwritable for task user: %v", devicePath, err))
+		}
+	}
+
+	lat.task.Infof("Loopback audio devices are available at %v", lat.devicePaths)
+
+	return nil
+}
+
+func (lat *LoopbackAudioTask) resetAudioDevice() *CommandExecutionError {
+	for _, devicePath := range lat.devicePaths {
+		chownErr := makeDirUnreadableForUser(devicePath, taskContext.User)
+		if chownErr != nil {
+			return executionError(internalError, errored, fmt.Errorf("Could not remove %s's access from the %s device: %v", taskContext.User.Name, devicePath, chownErr))
+		}
+	}
+
+	return nil
+}

--- a/workers/generic-worker/loopback_audio_linux_test.go
+++ b/workers/generic-worker/loopback_audio_linux_test.go
@@ -1,0 +1,152 @@
+//go:build linux
+
+package main
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/mcuadros/go-defaults"
+)
+
+func TestLoopbackAudio(t *testing.T) {
+	setup(t)
+
+	devicePaths := []string{
+		fmt.Sprintf("/dev/snd/controlC%d", config.LoopbackAudioDeviceNumber),
+		fmt.Sprintf("/dev/snd/pcmC%dD0c", config.LoopbackAudioDeviceNumber),
+		fmt.Sprintf("/dev/snd/pcmC%dD0p", config.LoopbackAudioDeviceNumber),
+		fmt.Sprintf("/dev/snd/pcmC%dD1c", config.LoopbackAudioDeviceNumber),
+		fmt.Sprintf("/dev/snd/pcmC%dD1p", config.LoopbackAudioDeviceNumber),
+	}
+	payload := GenericWorkerPayload{
+		Command: [][]string{
+			{"ls", "-l", devicePaths[0]},
+			{"ls", "-l", devicePaths[1]},
+			{"ls", "-l", devicePaths[2]},
+			{"ls", "-l", devicePaths[3]},
+			{"ls", "-l", devicePaths[4]},
+		},
+		MaxRunTime: 30,
+		Features: FeatureFlags{
+			LoopbackAudio: true,
+		},
+	}
+	defaults.SetDefaults(&payload)
+	td := testTask(t)
+	td.Scopes = append(td.Scopes, "generic-worker:loopback-audio")
+
+	_ = submitAndAssert(t, td, payload, "completed", "completed")
+
+	logText := LogText(t)
+	if !strings.Contains(logText, "crw-rw----") {
+		t.Fatalf("Expected log to contain 'crw-rw----', but it didn't\n%s", logText)
+	}
+}
+
+func TestIncorrectLoopbackAudioScopes(t *testing.T) {
+	setup(t)
+
+	payload := GenericWorkerPayload{
+		Command:    returnExitCode(0),
+		MaxRunTime: 30,
+		Features: FeatureFlags{
+			LoopbackAudio: true,
+		},
+	}
+	defaults.SetDefaults(&payload)
+	td := testTask(t)
+
+	// don't set any scopes
+	_ = submitAndAssert(t, td, payload, "exception", "malformed-payload")
+
+	logtext := LogText(t)
+	if !strings.Contains(logtext, "generic-worker:loopback-audio:"+td.ProvisionerID+"/"+td.WorkerType) || !strings.Contains(logtext, "generic-worker:loopback-audio") {
+		t.Fatalf("Expected log file to contain missing scopes, but it didn't\n%s", logtext)
+	}
+}
+
+func TestLoopbackAudioNotOwnedByTaskUser(t *testing.T) {
+	setup(t)
+
+	devicePaths := []string{
+		fmt.Sprintf("/dev/snd/controlC%d", config.LoopbackAudioDeviceNumber),
+		fmt.Sprintf("/dev/snd/pcmC%dD0c", config.LoopbackAudioDeviceNumber),
+		fmt.Sprintf("/dev/snd/pcmC%dD0p", config.LoopbackAudioDeviceNumber),
+		fmt.Sprintf("/dev/snd/pcmC%dD1c", config.LoopbackAudioDeviceNumber),
+		fmt.Sprintf("/dev/snd/pcmC%dD1p", config.LoopbackAudioDeviceNumber),
+	}
+	payload := GenericWorkerPayload{
+		Command: [][]string{
+			{"ls", "-l", devicePaths[0]},
+		},
+		MaxRunTime: 30,
+		Features: FeatureFlags{
+			// run once with loopback audio feature enabled,
+			// so that we can ensure tbe device has been created
+			// on the host
+			LoopbackAudio: true,
+		},
+	}
+	defaults.SetDefaults(&payload)
+	td := testTask(t)
+	td.Scopes = append(td.Scopes, "generic-worker:loopback-audio")
+
+	_ = submitAndAssert(t, td, payload, "completed", "completed")
+
+	payload = GenericWorkerPayload{
+		Command: [][]string{
+			{"ls", "-l", devicePaths[0]},
+		},
+		MaxRunTime: 30,
+		Features: FeatureFlags{
+			// run a second time with the feature disabled
+			// to test that the device is not owned by the
+			// task user
+			LoopbackAudio: false,
+		},
+	}
+	defaults.SetDefaults(&payload)
+	td = testTask(t)
+	td.Scopes = append(td.Scopes, "generic-worker:loopback-audio")
+
+	_ = submitAndAssert(t, td, payload, "completed", "completed")
+
+	logtext := LogText(t)
+	if strings.Contains(logtext, "task_") {
+		t.Fatalf("Was not expecting `ls` on device %s to be owned by task user, but it was", devicePaths[0])
+	}
+}
+
+func TestLoopbackAudioInvalidDeviceNumber(t *testing.T) {
+	setup(t)
+
+	config.LoopbackAudioDeviceNumber = 32
+
+	devicePaths := []string{
+		fmt.Sprintf("/dev/snd/controlC%d", config.LoopbackAudioDeviceNumber),
+		fmt.Sprintf("/dev/snd/pcmC%dD0c", config.LoopbackAudioDeviceNumber),
+		fmt.Sprintf("/dev/snd/pcmC%dD0p", config.LoopbackAudioDeviceNumber),
+		fmt.Sprintf("/dev/snd/pcmC%dD1c", config.LoopbackAudioDeviceNumber),
+		fmt.Sprintf("/dev/snd/pcmC%dD1p", config.LoopbackAudioDeviceNumber),
+	}
+	payload := GenericWorkerPayload{
+		Command: [][]string{
+			{"ls", "-l", devicePaths[0]},
+			{"ls", "-l", devicePaths[1]},
+			{"ls", "-l", devicePaths[2]},
+			{"ls", "-l", devicePaths[3]},
+			{"ls", "-l", devicePaths[4]},
+		},
+		MaxRunTime: 30,
+		Features: FeatureFlags{
+			LoopbackAudio: true,
+		},
+	}
+	defaults.SetDefaults(&payload)
+	td := testTask(t)
+	td.Scopes = append(td.Scopes, "generic-worker:loopback-audio")
+
+	_ = submitAndAssert(t, td, payload, "exception", "internal-error")
+}

--- a/workers/generic-worker/loopback_audio_posix.go
+++ b/workers/generic-worker/loopback_audio_posix.go
@@ -1,0 +1,69 @@
+//go:build darwin || linux || freebsd
+
+package main
+
+import (
+	"fmt"
+
+	"github.com/taskcluster/taskcluster/v54/internal/scopes"
+)
+
+type LoopbackAudioFeature struct {
+}
+
+func (feature *LoopbackAudioFeature) Name() string {
+	return "LoopbackAudio"
+}
+
+func (feature *LoopbackAudioFeature) Initialise() error {
+	return nil
+}
+
+func (feature *LoopbackAudioFeature) PersistState() error {
+	return nil
+}
+
+func (feature *LoopbackAudioFeature) IsEnabled(task *TaskRun) bool {
+	return task.Payload.Features.LoopbackAudio
+}
+
+func (feature *LoopbackAudioFeature) NewTaskFeature(task *TaskRun) TaskFeature {
+	return &LoopbackAudioTask{
+		task: task,
+		devicePaths: []string{
+			fmt.Sprintf("/dev/snd/controlC%d", config.LoopbackAudioDeviceNumber),
+			fmt.Sprintf("/dev/snd/pcmC%dD0c", config.LoopbackAudioDeviceNumber),
+			fmt.Sprintf("/dev/snd/pcmC%dD0p", config.LoopbackAudioDeviceNumber),
+			fmt.Sprintf("/dev/snd/pcmC%dD1c", config.LoopbackAudioDeviceNumber),
+			fmt.Sprintf("/dev/snd/pcmC%dD1p", config.LoopbackAudioDeviceNumber),
+		},
+	}
+}
+
+type LoopbackAudioTask struct {
+	task        *TaskRun
+	devicePaths []string
+}
+
+func (lat *LoopbackAudioTask) RequiredScopes() scopes.Required {
+	return scopes.Required{
+		{"generic-worker:loopback-audio:" + config.ProvisionerID + "/" + config.WorkerType},
+		{"generic-worker:loopback-audio"},
+	}
+}
+
+func (lat *LoopbackAudioTask) ReservedArtifacts() []string {
+	return []string{}
+}
+
+func (lat *LoopbackAudioTask) Start() *CommandExecutionError {
+	if config.LoopbackAudioDeviceNumber > 31 {
+		return executionError(internalError, errored, fmt.Errorf("LoopbackAudioDeviceNumber must be between 0 and 31, inclusive."))
+	}
+
+	return lat.setupAudioDevice()
+}
+
+func (lat *LoopbackAudioTask) Stop(err *ExecutionErrors) {
+	err.add(lat.resetAudioDevice())
+}

--- a/workers/generic-worker/main.go
+++ b/workers/generic-worker/main.go
@@ -209,6 +209,7 @@ func loadConfig(configFile *gwconfig.File) error {
 			InteractivePort:                53654,
 			LiveLogExecutable:              "livelog",
 			LiveLogPortBase:                60098,
+			LoopbackAudioDeviceNumber:      16,
 			LoopbackVideoDeviceNumber:      0,
 			MaxTaskRunTime:                 86400, // 86400s is 24 hours
 			NumberOfTasksToRun:             0,

--- a/workers/generic-worker/multiuser_posix.go
+++ b/workers/generic-worker/multiuser_posix.go
@@ -25,6 +25,7 @@ func (task *TaskRun) formatCommand(index int) string {
 func platformFeatures() []Feature {
 	return []Feature{
 		&InteractiveFeature{},
+		&LoopbackAudioFeature{},
 		&LoopbackVideoFeature{},
 		// keep chain of trust as low down as possible, as it checks permissions
 		// of signing key file, and a feature could change them, so we want these

--- a/workers/generic-worker/schemas/multiuser_posix.yml
+++ b/workers/generic-worker/schemas/multiuser_posix.yml
@@ -271,6 +271,28 @@ oneOf:
             `exception/malformed-payload`.
 
             Since: generic-worker 53.1.0
+        loopbackAudio:
+          type: boolean
+          title: Loopback Audio device
+          description: |-
+            Audio loopback device created using snd-aloop.
+            An audio device will be available for the task. Its
+            location will be `/dev/snd`. Devices inside that directory
+            will take the form `/dev/snd/controlC<N>`,
+            `/dev/snd/pcmC<N>D0c`, `/dev/snd/pcmC<N>D0p`,
+            `/dev/snd/pcmC<N>D1c`, and `/dev/snd/pcmC<N>D1p`,
+            where <N> is an integer between 0 and 31, inclusive.
+            The Generic Worker config setting `loopbackAudioDeviceNumber`
+            may be used to change the device number in case the
+            default value (`16`) conflicts with another
+            audio device on the worker.
+
+            This feature is only available on Linux. If a task
+            is submitted with this feature enabled on a non-Linux,
+            posix platform (FreeBSD, macOS), the task will resolve as
+            `exception/malformed-payload`.
+
+            Since: generic-worker 54.5.0
     mounts:
       type: array
       description: |-

--- a/workers/generic-worker/schemas/simple_posix.yml
+++ b/workers/generic-worker/schemas/simple_posix.yml
@@ -247,6 +247,28 @@ properties:
           `exception/malformed-payload`.
 
           Since: generic-worker 53.1.0
+      loopbackAudio:
+          type: boolean
+          title: Loopback Audio device
+          description: |-
+            Audio loopback device created using snd-aloop.
+            An audio device will be available for the task. Its
+            location will be `/dev/snd`. Devices inside that directory
+            will take the form `/dev/snd/controlC<N>`,
+            `/dev/snd/pcmC<N>D0c`, `/dev/snd/pcmC<N>D0p`,
+            `/dev/snd/pcmC<N>D1c`, and `/dev/snd/pcmC<N>D1p`,
+            where <N> is an integer between 0 and 31, inclusive.
+            The Generic Worker config setting `loopbackAudioDeviceNumber`
+            may be used to change the device number in case the
+            default value (`16`) conflicts with another
+            audio device on the worker.
+
+            This feature is only available on Linux. If a task
+            is submitted with this feature enabled on a non-Linux,
+            posix platform (FreeBSD, macOS), the task will resolve as
+            `exception/malformed-payload`.
+
+            Since: generic-worker 54.5.0
   mounts:
     type: array
     description: |-

--- a/workers/generic-worker/simple.go
+++ b/workers/generic-worker/simple.go
@@ -24,6 +24,7 @@ const (
 func platformFeatures() []Feature {
 	return []Feature{
 		&InteractiveFeature{},
+		&LoopbackAudioFeature{},
 		&LoopbackVideoFeature{},
 	}
 }

--- a/workers/generic-worker/usage.go
+++ b/workers/generic-worker/usage.go
@@ -166,6 +166,15 @@ and reports back results to the queue.
           livelogExposePort                 When not using websocktunnel, livelog would be exposed using this port.
                                             If it is set to 0, logs would be exposed using a random port.
                                             [default: 0]
+          loopbackAudioDeviceNumber         The audio loopback device number. The resulting devices inside /dev/snd
+                                            will take the form controlC<DEVICE_NUMBER>, pcmC<DEVICE_NUMBER>D0c,
+                                            pcmC<DEVICE_NUMBER>D0p, pcmC<DEVICE_NUMBER>D1c, pcmC<DEVICE_NUMBER>D1p
+                                            where <DEVICE_NUMBER> is an integer between 0 and 31.
+                                            [default: 16]
+          loopbackVideoDeviceNumber         The video loopback device number. Its value will take the form
+                                            /dev/video<DEVICE_NUMBER> where <DEVICE_NUMBER> is an integer
+                                            between 0 and 255. This setting may be used to change it.
+                                            [default: 0]
           maxTaskRunTime                    The maximum value allowed for maxRunTime on generic-worker payloads.
                                             [default: 86400]
           numberOfTasksToRun                If zero, run tasks indefinitely. Otherwise, after


### PR DESCRIPTION
Fixes #5995.

>Generic Worker: Adds `task.payload.feature.loopbackAudio` for loopback audio device support on Linux.
>
>The `snd-aloop` kernel module must be installed on the host system for this feature to work, although it does not _need_ to be loaded. Generic Worker loads the module with `modprobe` and generates the virtual audio device with a `snd-aloop` command. Under the multiuser engine, it also manages file ownership of the device with `chown` to ensure that only tasks with suitable scopes have read/write access to the virtual device.
>
>For tasks that enable the feature, the virtual audio device will be found at `/dev/snd`. Devices inside that directory will take the form `/dev/snd/controlC<DEVICE_NUMBER>`, `/dev/snd/pcmC<DEVICE_NUMBER>D0c`, `/dev/snd/pcmC<DEVICE_NUMBER>D0p`, `/dev/snd/pcmC<DEVICE_NUMBER>D1c`, and `/dev/snd/pcmC<DEVICE_NUMBER>D1p`, where `<DEVICE_NUMBER>` is an integer between 0 and 31, inclusive. The Generic Worker config setting `loopbackAudioDeviceNumber` may be used to change the device number in case the default value (`16`) conflicts with another audio device on the worker. Future releases of Generic Worker may provide the capability of having more than one virtual audio device; currently only one virtual audio device is supported.