### PR TITLE
fix(generic-worker): set default payload fields

### DIFF
--- a/changelog/issue-6420.md
+++ b/changelog/issue-6420.md
@@ -1,0 +1,5 @@
+audience: general
+level: patch
+reference: issue 6420
+---
+Fixes generic worker issue where artifacts were no longer being uploaded.

--- a/workers/generic-worker/main.go
+++ b/workers/generic-worker/main.go
@@ -25,6 +25,7 @@ import (
 
 	docopt "github.com/docopt/docopt-go"
 	sysinfo "github.com/elastic/go-sysinfo"
+	"github.com/mcuadros/go-defaults"
 	tcclient "github.com/taskcluster/taskcluster/v54/clients/client-go"
 	"github.com/taskcluster/taskcluster/v54/clients/client-go/tcqueue"
 	"github.com/taskcluster/taskcluster/v54/internal"
@@ -576,6 +577,7 @@ func ClaimWork() *TaskRun {
 			featureArtifacts:  map[string]string{},
 			LocalClaimTime:    localClaimTime,
 		}
+		defaults.SetDefaults(&task.Payload)
 		task.StatusManager = NewTaskStatusManager(task)
 		return task
 	}


### PR DESCRIPTION
Fixes #6420.

>Fixes generic worker issue where artifacts were no longer being uploaded.

Introduced in https://github.com/taskcluster/taskcluster/pull/6355.