### PR TITLE
fix(changelog): correctly filter on git log author

### DIFF
--- a/changelog/VJk2Ow6nQXKOZVg-HbA3ZQ.md
+++ b/changelog/VJk2Ow6nQXKOZVg-HbA3ZQ.md
@@ -1,0 +1,3 @@
+audience: general
+level: silent
+---

--- a/infrastructure/tooling/src/changelog/index.js
+++ b/infrastructure/tooling/src/changelog/index.js
@@ -119,7 +119,7 @@ class ChangeLog {
     const lastVersion = await this.lastVersion();
     this.updates = await gitLog({
       dir: REPO_ROOT,
-      args: [`v${lastVersion}..HEAD`, "--author='\(dependabot\|renovate\)\[bot\]'", "--pretty=%s (%h)"],
+      args: [`v${lastVersion}..HEAD`, '--author=dependabot', '--author=renovate', "--pretty='%s (%h)'"],
     });
   }
 


### PR DESCRIPTION
Though, the previous arguments technically worked on a local machine, it seems like the regex filtering doesn't work when running the `child_process.execFile()` function (what is used to call `git log ...`).