### PR TITLE
fix(changelog): small formatting fix [skip ci]

### DIFF
--- a/infrastructure/tooling/src/changelog/index.js
+++ b/infrastructure/tooling/src/changelog/index.js
@@ -119,7 +119,7 @@ class ChangeLog {
     const lastVersion = await this.lastVersion();
     this.updates = await gitLog({
       dir: REPO_ROOT,
-      args: [`v${lastVersion}..HEAD`, '--author=dependabot', '--author=renovate', "--pretty='%s (%h)'"],
+      args: [`v${lastVersion}..HEAD`, '--author=dependabot', '--author=renovate', "--pretty=%s (%h)"],
     });
   }
 


### PR DESCRIPTION
I shouldn't have changed the formatting in https://github.com/taskcluster/taskcluster/pull/6431/files#diff-cadf460b1bafdecb8698d80a7010dbfdd292ed039b1c0c1570a3c3c34e7e1612R122, it was literally putting `'` around each line item update.