### PR TITLE
chore(generic-worker): extra d2g log

### DIFF
--- a/changelog/YwSnRwj5QSO-5EIvR50r5A.md
+++ b/changelog/YwSnRwj5QSO-5EIvR50r5A.md
@@ -1,0 +1,4 @@
+audience: users
+level: patch
+---
+Adds a task log letting the user know their Docker Worker payload is being converted to a Generic Worker payload using d2g.

--- a/workers/generic-worker/main.go
+++ b/workers/generic-worker/main.go
@@ -595,6 +595,7 @@ func (task *TaskRun) validatePayload() *CommandExecutionError {
 		panic(err)
 	}
 	if _, exists := payload["image"]; exists {
+		task.Info("Docker Worker payload detected. Converting to a Generic Worker payload using d2g.")
 		err := task.convertDockerWorkerPayload()
 		if err != nil {
 			return err


### PR DESCRIPTION
>Adds a task log letting the user know their Docker Worker payload is being converted to a Generic Worker payload using d2g.