### PR TITLE
Expire artifacts don't report errors on each missing object

### DIFF
--- a/changelog/issue-6405.md
+++ b/changelog/issue-6405.md
@@ -1,0 +1,6 @@
+audience: admins
+level: patch
+reference: issue 6405
+---
+
+Expire artifacts job no longer logs errors for each missing artifact. Instead it reports the number of missing artifacts at the end of the job.

--- a/generated/references.json
+++ b/generated/references.json
@@ -15111,13 +15111,14 @@
           "description": "Reports progress of expired artifacts removal.",
           "fields": {
             "count": "Count of artifacts removed.",
+            "errorsCount": "Count of errors encountered (most likely missing objects)",
             "expires": "Expiration date of artifacts removed."
           },
           "level": "notice",
           "name": "expiredArtifactsRemoved",
           "title": "Expired Artifacts Removed",
           "type": "expired-artifacts-removed",
-          "version": 1
+          "version": 2
         },
         {
           "description": "An internal type for logging simple messages. No required fields.",

--- a/services/queue/src/main.js
+++ b/services/queue/src/main.js
@@ -309,7 +309,7 @@ let load = loader({
         debug('Expiring artifacts at: %s, from before %s, useBulkDelete: %s, batchSize: %d',
           new Date(), now, useBulkDelete, expireArtifactsBatchSize);
 
-        const count = await artifactUtils.expire({
+        const { count, errorsCount } = await artifactUtils.expire({
           db,
           publicBucket: publicArtifactBucket,
           privateBucket: privateArtifactBucket,
@@ -319,8 +319,8 @@ let load = loader({
           expireArtifactsBatchSize,
           useBulkDelete,
         });
-        debug('Expired %s artifacts', count);
-        monitor.log.expiredArtifactsRemoved({ count, expires: now });
+        debug('Expired %s artifacts (%s errors)', count, errorsCount);
+        monitor.log.expiredArtifactsRemoved({ count, errorsCount, expires: now });
       });
     },
   },

--- a/services/queue/src/monitor.js
+++ b/services/queue/src/monitor.js
@@ -192,11 +192,12 @@ MonitorManager.register({
   name: 'expiredArtifactsRemoved',
   title: 'Expired Artifacts Removed',
   type: 'expired-artifacts-removed',
-  version: 1,
+  version: 2,
   level: 'notice',
   description: `Reports progress of expired artifacts removal.`,
   fields: {
     count: 'Count of artifacts removed.',
     expires: 'Expiration date of artifacts removed.',
+    errorsCount: 'Count of errors encountered (most likely missing objects)',
   },
 });

--- a/services/queue/test/expireartifacts_test.js
+++ b/services/queue/test/expireartifacts_test.js
@@ -335,15 +335,9 @@ helper.secrets.mockSuite(testing.suiteName(), ['aws'], function (mock, skipping)
 
     // would log errors through monitor
     await helper.runExpiration('expire-artifacts');
-    const errors = monitor.manager.messages.filter(m => m.Type === 'monitor.error');
-    assume(errors.length).equals(4);
-    assume(errors.map(e => e.Fields.prefix).sort()).deep.equals([
-      `${taskId}/0/log.log`,
-      `${taskId}/2/log.log`,
-      `${taskId}/3/log.log`,
-      `${taskId}/4/log.log`,
-    ]);
-    assume(errors[0].Fields.bucket).equals('fake-public');
+    const [ result ] = monitor.manager.messages.filter(m => m.Type === 'expired-artifacts-removed');
+    assume(result.Fields.count).equals(5);
+    assume(result.Fields.errorsCount).equals(4);
     monitor.manager.reset();
 
     rows = await helper.db.fns.get_expired_artifacts_for_deletion({


### PR DESCRIPTION
Instead, debug level is used and total errors count is added to the resulting log message.

This is because GCS throws errors unlike AWS when deleted object is missing, which results in millions of reported objects (which were removed manually before migration)

follow up on #6405 