### PR TITLE
Try to make the `TestInteractiveCommand` test less flaky

### DIFF
--- a/changelog/N0qj4KetRryG1haEqGnbUA.md
+++ b/changelog/N0qj4KetRryG1haEqGnbUA.md
@@ -1,0 +1,3 @@
+audience: developers
+level: silent
+---


### PR DESCRIPTION
Try to make the `TestInteractiveCommand` test less flaky

Instead of expecting the command to just output what it's supposed to,
use a value that would never be output by anything else and count it in
the complete command output. The reason we expect the test to have the
sentinel value 3 times is:
- 1) We get the "echo" from the shell so that a user could see
  themselves typing
- 2) The shell accepts the command and rewrites the current line with
  the PS1 and the command
- 3) We get the command output

It looks something like this:

```
echo S3ntin3lValue
[eijebong@plutonium task_169081350731892]$ echo S3ntin3lValue
S3ntin3lValue
[eijebong@plutonium task_169081350731892]$
```

This is useful in cases the shell complains about something happening
like zsh being the default shell and the fact that you shouldn't be used
*looking at you macOS*.

This means that we can stop discarding the first message which might
have contained the whole output if we were unlucky which ended up
deadlocking the test...

This change also forces the shell to exit after the echo happens so we
make sure we can't stay blocked on a read during the test.

Fixes #6444 
