### PR TITLE
Parameterized role doc fixes

### DIFF
--- a/changelog/OjoTb8YJSOKqGJaeMM-gKQ.md
+++ b/changelog/OjoTb8YJSOKqGJaeMM-gKQ.md
@@ -1,0 +1,3 @@
+audience: general
+level: silent
+---

--- a/ui/docs/manual/using/namespaces.mdx
+++ b/ui/docs/manual/using/namespaces.mdx
@@ -219,7 +219,8 @@ The `project-admin:*` parameterized role then grants the following scopes:
 
  * `assume:hook-id:project-<..>/*`
  * `assume:project:<..>:*`
- * `assume:worker-type:proj-<..>/*`
+ * `assume:worker-id:proj-<..>/*`
+ * `assume:worker-pool:proj-<..>/*`
  * `auth:create-client:project/<..>/*`
  * `auth:create-role:hook-id:project-<..>/*`
  * `auth:create-role:project:<..>:*`
@@ -236,20 +237,25 @@ The `project-admin:*` parameterized role then grants the following scopes:
  * `hooks:trigger-hook:project-<..>/*`
  * `index:insert-task:project.<..>.*`
  * `project:<..>:*`
+ * `purge-cache:proj-<..>/*`
  * `queue:claim-work:proj-<..>/*`
- * `queue:create-task:highest:proj-<..>/*`
  * `queue:create-task:high:proj-<..>/*`
- * `queue:create-task:lowest:proj-<..>/*`
+ * `queue:create-task:highest:proj-<..>/*`
  * `queue:create-task:low:proj-<..>/*`
+ * `queue:create-task:lowest:proj-<..>/*`
  * `queue:create-task:medium:proj-<..>/*`
  * `queue:create-task:very-high:proj-<..>/*`
  * `queue:create-task:very-low:proj-<..>/*`
  * `queue:get-artifact:project/<..>/*`
  * `queue:quarantine-worker:proj-<..>/*`
  * `queue:route:index.project.<..>.*`
- * `queue:worker-id:proj-<..>/*`
  * `secrets:get:project/<..>/*`
+ * `secrets:get:worker-pool:proj-<..>/*`
  * `secrets:set:project/<..>/*`
+ * `secrets:set:worker-pool:proj-<..>/*`
+ * `worker-manager:create-worker:proj-<..>/*`
+ * `worker-manager:manage-worker-pool:proj-<..>/*`
+ * `worker-manager:remove-worker:proj-<..>/*`
 
 Project admins may then delegate portions of these scopes as desired.
 The scopes cover:
@@ -257,9 +263,9 @@ The scopes cover:
 * scopes `project:<project>:…`
 * clients `project/<project>/*`
 * roles `project:<project>:*`
-* artifacts `project/<project/*`
+* artifacts `project/<project>/*`
 * hooks `project-<project>/*`
-* worker pools `project-<project>/*`
+* worker pools `proj-<project>/*`
 * secrets `project/<project>/*`
 * index namespaces `project.<project>.*`
 


### PR DESCRIPTION
Some doc fixes.

Note, we should probably auto generate this doc based on the `project-admin:*` role, since they easily get out of sync with each other. However, it is specific to community-tc, and is a convention rather than a requirement, so that might not be so straightforward. I also noticed that role has some non-project scopes in there, which doesn't seem right, but I will look at that in a separate PR (presumably configured in community-tc-config repo, so a PR for that repo instead).