### PR TITLE
Don't force the interactive process to exit

### DIFF
--- a/changelog/Ql7JTgMMTYq6vzHdD1CncQ.md
+++ b/changelog/Ql7JTgMMTYq6vzHdD1CncQ.md
@@ -1,0 +1,3 @@
+audience: developers
+level: silent
+---

--- a/workers/generic-worker/interactive/interactive_test.go
+++ b/workers/generic-worker/interactive/interactive_test.go
@@ -37,7 +37,7 @@ func TestInteractive(t *testing.T) {
 	const SENTINEL = "S3ntin3lValue"
 
 	// Send some input to the interactive session
-	input := fmt.Sprintf("\x01echo %s\nexit\n", SENTINEL)
+	input := fmt.Sprintf("\x01echo %s\n", SENTINEL)
 	err = conn.WriteMessage(websocket.TextMessage, []byte(input))
 	if err != nil {
 		t.Fatal("write error:", err)

--- a/workers/generic-worker/interactive_test.go
+++ b/workers/generic-worker/interactive_test.go
@@ -88,7 +88,7 @@ func TestInteractiveCommand(t *testing.T) {
 			url := fmt.Sprintf("ws://localhost:%v/shell/%v", config.InteractivePort, os.Getenv("INTERACTIVE_ACCESS_TOKEN"))
 			conn, _, err = websocket.DefaultDialer.Dial(url, nil)
 			if err == nil {
-				err = conn.WriteMessage(websocket.TextMessage, []byte(fmt.Sprintf("\x01echo %s\nexit\n", SENTINEL)))
+				err = conn.WriteMessage(websocket.TextMessage, []byte(fmt.Sprintf("\x01echo %s\n", SENTINEL)))
 				if err != nil {
 					t.Fatalf("write error: %v", err)
 				}


### PR DESCRIPTION
I added that when fixing test failures in
dca2377bc8a27cdc6e4ee928a95058b7f53ca528 and
i6026a3fa263175550cda877a6d7b9123301becc7 in the hope that it would make tests fail faster instead of deadlocking should something go wrong with my patch.

Turns out it added a new kind of intermittent test failure because the interactive process could exit before we finish, signal it, close the server-side websocket before the test is done reading from it.