### PR TITLE
fix(ui): don't remove task dependencies on edit/retrigger

### DIFF
--- a/changelog/issue-6438.md
+++ b/changelog/issue-6438.md
@@ -1,0 +1,5 @@
+audience: users
+level: patch
+reference: issue 6438
+---
+`dependencies` are no longer removed from the task definition when you `Edit` or `Retrigger` a task.

--- a/ui/src/views/Tasks/ViewTask/index.jsx
+++ b/ui/src/views/Tasks/ViewTask/index.jsx
@@ -384,7 +384,6 @@ export default class ViewTask extends Component {
           'taskGroupId',
           'schedulerId',
           'priority',
-          'dependencies',
           'requires',
         ],
         task
@@ -588,7 +587,6 @@ export default class ViewTask extends Component {
                 <li>
                   Update deadlines and other timestamps for the current time
                 </li>
-                <li>Strip self-dependencies from the task definition</li>
                 <li>
                   Set number of <code>retries</code> to zero
                 </li>
@@ -778,7 +776,7 @@ export default class ViewTask extends Component {
 
   retriggerTask = async () => {
     const taskId = nice();
-    const task = omit('dependencies', gqlTaskToApi(this.props.data.task));
+    const task = gqlTaskToApi(this.props.data.task);
     const now = Date.now();
     const created = Date.parse(task.created);
 


### PR DESCRIPTION
Fixes https://github.com/taskcluster/taskcluster/issues/6438.

>`dependencies` are no longer removed from the task definition when you `Edit` or `Retrigger` a task.