### PR TITLE
Allow for git ssh source URLs

### DIFF
--- a/changelog/issue-6481.md
+++ b/changelog/issue-6481.md
@@ -1,0 +1,5 @@
+audience: users
+level: patch
+reference: issue 6481
+---
+Allow git SSH urls in `metadata.source`.

--- a/clients/client-go/tcqueue/types.go
+++ b/clients/client-go/tcqueue/types.go
@@ -1612,7 +1612,7 @@ type (
 		// repository. This should be place someone can go an do a git/hg blame
 		// to who came up with recipe for this task.
 		//
-		// Syntax:     ^(https?|ssh)://
+		// Syntax:     ^(https?://|ssh://|git@)
 		// Max length: 4096
 		Source string `json:"source"`
 	}

--- a/clients/client-go/tcqueueevents/types.go
+++ b/clients/client-go/tcqueueevents/types.go
@@ -391,7 +391,7 @@ type (
 		// repository. This should be place someone can go an do a git/hg blame
 		// to who came up with recipe for this task.
 		//
-		// Syntax:     ^(https?|ssh)://
+		// Syntax:     ^(https?://|ssh://|git@)
 		// Max length: 4096
 		Source string `json:"source"`
 	}

--- a/clients/client-go/tcworkermanager/types.go
+++ b/clients/client-go/tcworkermanager/types.go
@@ -301,7 +301,7 @@ type (
 		// repository. This should be place someone can go an do a git/hg blame
 		// to who came up with recipe for this task.
 		//
-		// Syntax:     ^(https?|ssh)://
+		// Syntax:     ^(https?://|ssh://|git@)
 		// Max length: 4096
 		Source string `json:"source"`
 	}

--- a/generated/references.json
+++ b/generated/references.json
@@ -743,7 +743,7 @@
               "description": "Link to source of this task, should specify a file, revision and\nrepository. This should be place someone can go an do a git/hg blame\nto who came up with recipe for this task.\n",
               "format": "uri",
               "maxLength": 4096,
-              "pattern": "^(https?|ssh)://",
+              "pattern": "^(https?://|ssh://|git@)",
               "title": "Source",
               "type": "string"
             }
@@ -3129,7 +3129,7 @@
           "description": "Link to source of this task, should specify a file, revision and\nrepository. This should be place someone can go an do a git/hg blame\nto who came up with recipe for this task.\n",
           "format": "uri",
           "maxLength": 4096,
-          "pattern": "^(https?|ssh)://",
+          "pattern": "^(https?://|ssh://|git@)",
           "title": "Source",
           "type": "string"
         }

--- a/services/queue/schemas/constants.yml
+++ b/services/queue/schemas/constants.yml
@@ -113,7 +113,7 @@ scope:
     pattern: "^[\x20-\x7e]*$"
 
 # Pattern for source URLs; this rules out insecure URLs like data: or javascript:
-source-pattern: "^(https?|ssh)://"
+source-pattern: "^(https?:\/\/|ssh:\/\/|git@)"
 
 # Maximum number of dependencies a single task can have
 max-task-dependencies: 100

--- a/services/worker-manager/schemas/constants.yml
+++ b/services/worker-manager/schemas/constants.yml
@@ -115,7 +115,7 @@ scope:
     pattern: "^[\x20-\x7e]*$"
 
 # Pattern for source URLs; this rules out insecure URLs like data: or javascript:
-source-pattern: "^(https?|ssh)://"
+source-pattern: "^(https?:\/\/|ssh:\/\/|git@)"
 
 # Maximum number of dependencies a single task can have
 max-task-dependencies: 100


### PR DESCRIPTION
Fixes https://github.com/taskcluster/taskcluster/issues/6481.

>Allow git SSH urls in `metadata.source`.