### PR TITLE
feat(generic-worker): log out d2g translated payload

### DIFF
--- a/changelog/U4SFSYxkTWW283bMcwZdbg.md
+++ b/changelog/U4SFSYxkTWW283bMcwZdbg.md
@@ -1,0 +1,4 @@
+audience: users
+level: patch
+---
+Generic Worker: If a Docker Worker payload is received, the resulting, d2g-translated Generic Worker payload will be logged out to the user.

--- a/workers/generic-worker/payload_linux.go
+++ b/workers/generic-worker/payload_linux.go
@@ -30,7 +30,7 @@ func (task *TaskRun) convertDockerWorkerPayload() *CommandExecutionError {
 	task.Definition.Scopes = d2g.Scopes(task.Definition.Scopes)
 
 	// Convert gwPayload to JSON
-	formattedActualGWPayload, err := json.Marshal(*gwPayload)
+	formattedActualGWPayload, err := json.MarshalIndent(*gwPayload, "", "  ")
 	if err != nil {
 		return executionError(malformedPayload, errored, fmt.Errorf("cannot convert Generic Worker payload %#v to JSON: %s", *gwPayload, err))
 	}
@@ -45,6 +45,8 @@ func (task *TaskRun) convertDockerWorkerPayload() *CommandExecutionError {
 	if err != nil {
 		return MalformedPayloadError(err)
 	}
+
+	task.Infof("Generic Worker Payload:\n%s", string(formattedActualGWPayload))
 
 	return nil
 }


### PR DESCRIPTION
>Generic Worker: If a Docker Worker payload is received, the resulting, d2g-translated Generic Worker payload will be logged out to the user.