### PR TITLE
d2g: log full task definition rather than just task payload

### DIFF
--- a/changelog/issue-6521.md
+++ b/changelog/issue-6521.md
@@ -1,0 +1,6 @@
+audience: users
+level: patch
+reference: issue 6521
+---
+Generic Worker now outputs a warning in the task log if a Docker Worker payload is supplied, together with the
+d2g-converted task definition, in order to help users migrate their tasks to native Generic Worker format.

--- a/workers/generic-worker/d2g_test.go
+++ b/workers/generic-worker/d2g_test.go
@@ -34,6 +34,7 @@ func TestWithValidDockerWorkerPayload(t *testing.T) {
 	default:
 		_ = submitAndAssert(t, td, payload, "exception", "malformed-payload")
 	}
+	t.Log(LogText(t))
 }
 
 func TestWithInvalidDockerWorkerPayload(t *testing.T) {

--- a/workers/generic-worker/main.go
+++ b/workers/generic-worker/main.go
@@ -597,7 +597,6 @@ func (task *TaskRun) validatePayload() *CommandExecutionError {
 		panic(err)
 	}
 	if _, exists := payload["image"]; exists {
-		task.Info("Docker Worker payload detected. Converting to a Generic Worker payload using d2g.")
 		err := task.convertDockerWorkerPayload()
 		if err != nil {
 			return err

--- a/workers/generic-worker/payload_linux.go
+++ b/workers/generic-worker/payload_linux.go
@@ -9,6 +9,9 @@ import (
 	"github.com/mcuadros/go-defaults"
 	"github.com/taskcluster/taskcluster/v55/tools/d2g"
 	"github.com/taskcluster/taskcluster/v55/tools/d2g/dockerworker"
+	"github.com/taskcluster/taskcluster/v55/tools/jsonschema2go/text"
+
+	"sigs.k8s.io/yaml"
 )
 
 func (task *TaskRun) convertDockerWorkerPayload() *CommandExecutionError {
@@ -30,23 +33,48 @@ func (task *TaskRun) convertDockerWorkerPayload() *CommandExecutionError {
 	task.Definition.Scopes = d2g.Scopes(task.Definition.Scopes)
 
 	// Convert gwPayload to JSON
-	formattedActualGWPayload, err := json.MarshalIndent(*gwPayload, "", "  ")
+	d2gConvertedPayloadJSON, err := json.MarshalIndent(*gwPayload, "", "  ")
 	if err != nil {
 		return executionError(malformedPayload, errored, fmt.Errorf("cannot convert Generic Worker payload %#v to JSON: %s", *gwPayload, err))
 	}
 
 	// Validate the JSON output against the schema
-	validateErr := task.validateJSON(formattedActualGWPayload, JSONSchema())
+	validateErr := task.validateJSON(d2gConvertedPayloadJSON, JSONSchema())
 	if validateErr != nil {
 		return executionError(malformedPayload, errored, fmt.Errorf("d2g output validation failed: %v", validateErr))
 	}
 
-	err = json.Unmarshal(formattedActualGWPayload, &task.Payload)
+	err = json.Unmarshal(d2gConvertedPayloadJSON, &task.Payload)
 	if err != nil {
 		return MalformedPayloadError(err)
 	}
 
-	task.Infof("Generic Worker Payload:\n%s", string(formattedActualGWPayload))
+	task.Definition.Payload = json.RawMessage(d2gConvertedPayloadJSON)
+
+	// Convert full task definition to JSON
+	d2gConvertedTaskDefinitionJSON, err := json.MarshalIndent(task.Definition, "", "  ")
+	if err != nil {
+		return executionError(malformedPayload, errored, fmt.Errorf("cannot marshal d2g converted task definition %#v to JSON: %s", task.Definition, err))
+	}
+
+	d2gConvertedTaskDefinitionYAML, err := yaml.JSONToYAML(d2gConvertedTaskDefinitionJSON)
+	if err != nil {
+		return executionError(internalError, errored, fmt.Errorf("Could not convert task definition from JSON to YAML: %v\n", err))
+	}
+
+	task.Warn("This task was designed to run under Docker Worker. Docker Worker is a worker implementation")
+	task.Warn("that is _no longer_ maintained.")
+	task.Warn("In order to execute this task, it is being converted to a Generic Worker task, using the D2G")
+	task.Warn("utility (Docker worker 2 Generic worker):")
+	task.Warn("    https://github.com/taskcluster/taskcluster/tree/main/tools/d2g")
+	task.Warn("")
+	task.Warn("We recommend that you convert all your Docker Worker tasks to Generic Worker tasks, to ensure")
+	task.Warn("continued support. For this task, see the converted payload below. If you have many tasks that")
+	task.Warn("require conversion, consider using the d2g tool (above) directly. It simply takes a Docker")
+	task.Warn("Worker task payload as input, and outputs a Generic Worker task payload. It can also convert")
+	task.Warn("Docker Worker scopes to equivalent Generic Worker scopes.")
+	task.Warn("")
+	task.Warn("Converted task definition (conversion performed by d2g):\n---\n" + text.Indent(string(d2gConvertedTaskDefinitionYAML), "  "))
 
 	return nil
 }


### PR DESCRIPTION
This is a follow on from [#6491](https://github.com/taskcluster/taskcluster/pull/6491#pullrequestreview-1602787612) to include full task definition when showing the output of the internal d2g conversion process.