### PR TITLE
Also change the version in generic worker CI files on release

### DIFF
--- a/changelog/issue-6513.md
+++ b/changelog/issue-6513.md
@@ -1,0 +1,4 @@
+audience: developers
+level: silent
+reference: issue 6513
+---

--- a/infrastructure/tooling/src/release/tasks.js
+++ b/infrastructure/tooling/src/release/tasks.js
@@ -201,6 +201,7 @@ module.exports = ({ tasks, cmdOptions, credentials }) => {
         'clients/client-go/**',
         'clients/client-shell/**',
         'internal/**',
+        'taskcluster/ci/generic-worker/**',
         'tools/**',
         'ui/docs/reference/workers/websocktunnel.mdx',
         // Provide explicit list of allowed file extensions so that

--- a/taskcluster/ci/generic-worker/kind.yml
+++ b/taskcluster/ci/generic-worker/kind.yml
@@ -167,9 +167,9 @@ tasks:
             cp "${{TASK_USER_CREDENTIALS}}" next-task-user.json
             # IMPORTANT - run go test with GW_TESTS_RUN_AS_CURRENT_USER=true *before* running it without
             # otherwise tests that call `go run ....` will write go object files to .cache as root
-            GW_TESTS_RUN_AS_CURRENT_USER=true GORACE=history_size=7 CGO_ENABLED=1 go test -tags "${{ENGINE}}" -failfast -timeout 20m -ldflags "-X github.com/taskcluster/taskcluster/v54/workers/generic-worker.revision=${{GITHUB_SHA}}" ${{RACE}} ${{VET}} .
+            GW_TESTS_RUN_AS_CURRENT_USER=true GORACE=history_size=7 CGO_ENABLED=1 go test -tags "${{ENGINE}}" -failfast -timeout 20m -ldflags "-X github.com/taskcluster/taskcluster/v55/workers/generic-worker.revision=${{GITHUB_SHA}}" ${{RACE}} ${{VET}} .
           fi
-          GORACE=history_size=7 CGO_ENABLED=${{CGO_ENABLED_TESTS}} go test -tags "${{ENGINE}}" -failfast -timeout 20m -ldflags "-X github.com/taskcluster/taskcluster/v54/workers/generic-worker.revision=${{GITHUB_SHA}}" ${{RACE}} ${{VET}} ./...
+          GORACE=history_size=7 CGO_ENABLED=${{CGO_ENABLED_TESTS}} go test -tags "${{ENGINE}}" -failfast -timeout 20m -ldflags "-X github.com/taskcluster/taskcluster/v55/workers/generic-worker.revision=${{GITHUB_SHA}}" ${{RACE}} ${{VET}} ./...
           # The next line is edited by infrastructure/tooling/src/generate/generators/golangci-lint-version.js
           #   DO NOT CHANGE HERE!
           ../../../golangci-lint/golangci-lint-$GOLANGCI_LINT_VERSION-*/golangci-lint run --build-tags "${{ENGINE}}" --timeout=5m
@@ -311,9 +311,9 @@ tasks:
         - set GORACE=history_size=7
         - copy "%TASK_USER_CREDENTIALS%" "%CD%\next-task-user.json"
         - set GW_TESTS_RUN_AS_CURRENT_USER=true
-        - go test -tags "%ENGINE%" -failfast -timeout 20m -ldflags "-X github.com/taskcluster/taskcluster/v54/workers/generic-worker.revision=%GITHUB_SHA%" %RACE% %VET% .
+        - go test -tags "%ENGINE%" -failfast -timeout 20m -ldflags "-X github.com/taskcluster/taskcluster/v55/workers/generic-worker.revision=%GITHUB_SHA%" %RACE% %VET% .
         - set GW_TESTS_RUN_AS_CURRENT_USER=
-        - go test -tags "%ENGINE%" -failfast -timeout 20m -ldflags "-X github.com/taskcluster/taskcluster/v54/workers/generic-worker.revision=%GITHUB_SHA%" %RACE% %VET% ./...
+        - go test -tags "%ENGINE%" -failfast -timeout 20m -ldflags "-X github.com/taskcluster/taskcluster/v55/workers/generic-worker.revision=%GITHUB_SHA%" %RACE% %VET% ./...
         - |
           :: assumption here is that if something inside the if fails, we'll get a non zero exit code
           :: i've also made it an if/else so that one of them has to run, as there should always be a


### PR DESCRIPTION
The CI file for generic-worker was moved in https://github.com/taskcluster/taskcluster/commit/13c21c268bfc62726064ece7740b7ad92d70e21b
but the release script wasn't updated to accomodate that. One of the
command needs the version to match the current release and was
automatically updated by the release script. After the path change, that
version fell out of sync leading to CI failures because some linker
argument was wrong and it wasn't setting the `revision` parameter.

<!-- If this is related to a GitHub Bug/Issue, Please write Issue Number after # in the next line. Otherwise, just remove it from your PR comment. -->

Github Bug/Issue: Fixes #6513
