### PR TITLE
Fix code-scanning #318: possible overflow

### DIFF
--- a/changelog/A3EkBRJlRkSxwkS-Ke50BA.md
+++ b/changelog/A3EkBRJlRkSxwkS-Ke50BA.md
@@ -1,0 +1,3 @@
+audience: general
+level: silent
+---

--- a/tools/d2g/d2g.go
+++ b/tools/d2g/d2g.go
@@ -418,16 +418,14 @@ func podmanEnvMappings(dwPayload *dockerworker.DockerWorkerPayload) string {
 		dwManagedEnvVars = append(dwManagedEnvVars, "TASKCLUSTER_PROXY_URL")
 	}
 
-	envVarNames := make([]string, len(dwPayload.Env)+len(dwManagedEnvVars))
-	env := make(map[string]string, len(envVarNames))
-	i := 0
+	envVarNames := []string{}
+	env := map[string]string{}
 	for envVarName, envVarValue := range dwPayload.Env {
-		envVarNames[i] = envVarName
+		envVarNames = append(envVarNames, envVarName)
 		env[envVarName] = envVarValue
-		i++
 	}
-	for j, envVarName := range dwManagedEnvVars {
-		envVarNames[i+j] = envVarName
+	for _, envVarName := range dwManagedEnvVars {
+		envVarNames = append(envVarNames, envVarName)
 		env[envVarName] = "${" + envVarName + "}"
 	}
 	sort.Strings(envVarNames)


### PR DESCRIPTION
Fixes: https://github.com/taskcluster/taskcluster/security/code-scanning/318

Note, this updated implementation is marginally less efficient, but removes the warning, which is kind of bogus, since practically I don't think it would be possible to hit the limits with a real payload, as the payload would have to be so big, I suspect some other limit would prevent such a task being created anyway.