### PR TITLE
no-op: simplify string replacement expression in gw-codegen

### DIFF
--- a/changelog/QdL_EujxRpqk_Q5V_eKAfA.md
+++ b/changelog/QdL_EujxRpqk_Q5V_eKAfA.md
@@ -1,0 +1,3 @@
+audience: general
+level: silent
+---

--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,6 @@ require (
 	github.com/gorilla/websocket v1.5.0
 	github.com/iancoleman/strcase v0.3.0
 	github.com/johncgriffin/overflow v0.0.0-20211019200055-46fa312c352c
-	github.com/kr/text v0.2.0
 	github.com/mcuadros/go-defaults v1.2.0
 	github.com/mholt/archiver/v3 v3.5.1
 	github.com/mitchellh/go-homedir v1.1.0
@@ -63,6 +62,7 @@ require (
 	github.com/joeshaw/multierror v0.0.0-20140124173710-69b34d4ec901 // indirect
 	github.com/klauspost/compress v1.16.7 // indirect
 	github.com/klauspost/pgzip v1.2.6 // indirect
+	github.com/kr/text v0.2.0 // indirect
 	github.com/nwaples/rardecode v1.1.3 // indirect
 	github.com/pierrec/lz4/v4 v4.1.18 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect

--- a/workers/generic-worker/gw-codegen/main.go
+++ b/workers/generic-worker/gw-codegen/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"fmt"
 	"go/build"
 	"go/format"
 	"log"
@@ -10,7 +9,6 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/kr/text"
 	"github.com/taskcluster/taskcluster/v55/internal/jsontest"
 	"github.com/taskcluster/taskcluster/v55/tools/jsonschema2go"
 	"golang.org/x/tools/imports"
@@ -97,7 +95,7 @@ func generateFunctions(ymlFile string) []byte {
 	}
 
 	// the following strings.Replace function call safely escapes backticks (`) in rawJSON
-	escapedJSON := "`" + strings.Replace(text.Indent(fmt.Sprintf("%v", string(rawJSON)), ""), "`", "` + \"`\" + `", -1) + "`"
+	escapedJSON := "`" + strings.Replace(string(rawJSON), "`", "` + \"`\" + `", -1) + "`"
 
 	response := `
 // Returns json schema for the payload part of the task definition. Please


### PR DESCRIPTION
This is just a trivial simplification, I don't know why I used the more complicated form originally, quite bizarre.
