### PR TITLE
Rename dependabot groups

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,7 +13,7 @@ updates:
     rebase-strategy: "disabled"
     groups:
       # Groups together all minor/patch version updates for dependencies
-      deps-dev:
+      deps:
         patterns:
           - "*"
         update-types:
@@ -28,7 +28,7 @@ updates:
     rebase-strategy: "disabled"
     groups:
       # Groups together all minor/patch version updates for dependencies
-      deps-dev:
+      deps:
         patterns:
           - "*"
         update-types:
@@ -43,7 +43,7 @@ updates:
     rebase-strategy: "disabled"
     groups:
       # Groups together all minor/patch version updates for dependencies
-      deps-dev:
+      deps:
         patterns:
           - "*"
         update-types:
@@ -58,7 +58,7 @@ updates:
     rebase-strategy: "disabled"
     groups:
       # Groups together all minor/patch version updates for dependencies
-      deps-dev:
+      deps:
         patterns:
           - "*"
         update-types:
@@ -73,7 +73,7 @@ updates:
     rebase-strategy: "disabled"
     groups:
       # Groups together all minor/patch version updates for dependencies
-      deps-dev:
+      deps:
         patterns:
           - "*"
         update-types:
@@ -88,7 +88,7 @@ updates:
     rebase-strategy: "disabled"
     groups:
       # Groups together all minor/patch version updates for dependencies
-      deps-dev:
+      deps:
         patterns:
           - "*"
         update-types:
@@ -103,7 +103,7 @@ updates:
     rebase-strategy: "disabled"
     groups:
       # Groups together all minor/patch version updates for dependencies
-      deps-dev:
+      deps:
         patterns:
           - "*"
         update-types:
@@ -118,7 +118,7 @@ updates:
     rebase-strategy: "disabled"
     groups:
       # Groups together all minor/patch version updates for dependencies
-      deps-dev:
+      deps:
         patterns:
           - "*"
         update-types:
@@ -133,7 +133,7 @@ updates:
     rebase-strategy: "disabled"
     groups:
       # Groups together all minor/patch version updates for dependencies
-      deps-dev:
+      deps:
         patterns:
           - "*"
         update-types:

--- a/changelog/OdCDYxRzSsaA8ACNx6LeDw.md
+++ b/changelog/OdCDYxRzSsaA8ACNx6LeDw.md
@@ -1,0 +1,3 @@
+audience: general
+level: silent
+---


### PR DESCRIPTION
I felt like `build(deps-dev): bump the deps-dev group in /clients/client with 1 update` sounded a little strange for a PR title, so dropped the `-dev` part so it'll read, `build(deps-dev): bump the deps group in /clients/client with 1 update` in future PRs.