### PR TITLE
Handle GCP preemption notifications

### DIFF
--- a/changelog/issue-6530.md
+++ b/changelog/issue-6530.md
@@ -1,0 +1,6 @@
+audience: worker-deployers
+level: patch
+reference: issue 6530
+---
+Workers deployed in GCP as spot instances or preemptible VMs now
+handle instance termination gracefully.


### PR DESCRIPTION
Add polling for GCP preemption notifications of spot and preemptible VMs. This allows graceful termination of tasks.

Github Bug/Issue: Fixes #6930
