### PR TITLE
Upgrade CronJobs to use latest batch/v1 api

### DIFF
--- a/changelog/issue-6534.md
+++ b/changelog/issue-6534.md
@@ -1,0 +1,6 @@
+audience: deployers
+level: patch
+reference: issue 6534
+---
+
+Upgrades kubernetes cronjob api version to `batch/v1`.

--- a/infrastructure/k8s/templates/taskcluster-auth-cron-purgeExpiredClients.yaml
+++ b/infrastructure/k8s/templates/taskcluster-auth-cron-purgeExpiredClients.yaml
@@ -1,4 +1,4 @@
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: taskcluster-auth-purgeexpiredclients

--- a/infrastructure/k8s/templates/taskcluster-github-cron-sync.yaml
+++ b/infrastructure/k8s/templates/taskcluster-github-cron-sync.yaml
@@ -1,4 +1,4 @@
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: taskcluster-github-sync

--- a/infrastructure/k8s/templates/taskcluster-hooks-cron-expires.yaml
+++ b/infrastructure/k8s/templates/taskcluster-hooks-cron-expires.yaml
@@ -1,4 +1,4 @@
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: taskcluster-hooks-expires

--- a/infrastructure/k8s/templates/taskcluster-index-cron-expire.yaml
+++ b/infrastructure/k8s/templates/taskcluster-index-cron-expire.yaml
@@ -1,4 +1,4 @@
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: taskcluster-index-expire

--- a/infrastructure/k8s/templates/taskcluster-object-cron-expire.yaml
+++ b/infrastructure/k8s/templates/taskcluster-object-cron-expire.yaml
@@ -1,4 +1,4 @@
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: taskcluster-object-expire

--- a/infrastructure/k8s/templates/taskcluster-purge-cache-cron-expireCachePurges.yaml
+++ b/infrastructure/k8s/templates/taskcluster-purge-cache-cron-expireCachePurges.yaml
@@ -1,4 +1,4 @@
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: taskcluster-purge-cache-expirecachepurges

--- a/infrastructure/k8s/templates/taskcluster-queue-cron-expireArtifacts.yaml
+++ b/infrastructure/k8s/templates/taskcluster-queue-cron-expireArtifacts.yaml
@@ -1,4 +1,4 @@
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: taskcluster-queue-expireartifacts

--- a/infrastructure/k8s/templates/taskcluster-queue-cron-expireQueueMessages.yaml
+++ b/infrastructure/k8s/templates/taskcluster-queue-cron-expireQueueMessages.yaml
@@ -1,4 +1,4 @@
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: taskcluster-queue-expirequeuemessages

--- a/infrastructure/k8s/templates/taskcluster-queue-cron-expireTask.yaml
+++ b/infrastructure/k8s/templates/taskcluster-queue-cron-expireTask.yaml
@@ -1,4 +1,4 @@
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: taskcluster-queue-expiretask

--- a/infrastructure/k8s/templates/taskcluster-queue-cron-expireTaskDependency.yaml
+++ b/infrastructure/k8s/templates/taskcluster-queue-cron-expireTaskDependency.yaml
@@ -1,4 +1,4 @@
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: taskcluster-queue-expiretaskdependency

--- a/infrastructure/k8s/templates/taskcluster-queue-cron-expireTaskGroups.yaml
+++ b/infrastructure/k8s/templates/taskcluster-queue-cron-expireTaskGroups.yaml
@@ -1,4 +1,4 @@
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: taskcluster-queue-expiretaskgroups

--- a/infrastructure/k8s/templates/taskcluster-queue-cron-expireWorkerInfo.yaml
+++ b/infrastructure/k8s/templates/taskcluster-queue-cron-expireWorkerInfo.yaml
@@ -1,4 +1,4 @@
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: taskcluster-queue-expireworkerinfo

--- a/infrastructure/k8s/templates/taskcluster-secrets-cron-expire.yaml
+++ b/infrastructure/k8s/templates/taskcluster-secrets-cron-expire.yaml
@@ -1,4 +1,4 @@
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: taskcluster-secrets-expire

--- a/infrastructure/k8s/templates/taskcluster-web-server-cron-cleanup-expire-access-tokens.yaml
+++ b/infrastructure/k8s/templates/taskcluster-web-server-cron-cleanup-expire-access-tokens.yaml
@@ -1,4 +1,4 @@
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: taskcluster-web-server-cleanup-expire-access-tokens

--- a/infrastructure/k8s/templates/taskcluster-web-server-cron-cleanup-expire-auth-codes.yaml
+++ b/infrastructure/k8s/templates/taskcluster-web-server-cron-cleanup-expire-auth-codes.yaml
@@ -1,4 +1,4 @@
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: taskcluster-web-server-cleanup-expire-auth-codes

--- a/infrastructure/k8s/templates/taskcluster-web-server-cron-scanner.yaml
+++ b/infrastructure/k8s/templates/taskcluster-web-server-cron-scanner.yaml
@@ -1,4 +1,4 @@
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: taskcluster-web-server-scanner

--- a/infrastructure/k8s/templates/taskcluster-worker-manager-cron-expire-errors.yaml
+++ b/infrastructure/k8s/templates/taskcluster-worker-manager-cron-expire-errors.yaml
@@ -1,4 +1,4 @@
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: taskcluster-worker-manager-expire-errors

--- a/infrastructure/k8s/templates/taskcluster-worker-manager-cron-expire-worker-pools.yaml
+++ b/infrastructure/k8s/templates/taskcluster-worker-manager-cron-expire-worker-pools.yaml
@@ -1,4 +1,4 @@
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: taskcluster-worker-manager-expire-worker-pools

--- a/infrastructure/k8s/templates/taskcluster-worker-manager-cron-expire-workers.yaml
+++ b/infrastructure/k8s/templates/taskcluster-worker-manager-cron-expire-workers.yaml
@@ -1,4 +1,4 @@
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: taskcluster-worker-manager-expire-workers

--- a/infrastructure/tooling/templates/k8s/cron.yaml
+++ b/infrastructure/tooling/templates/k8s/cron.yaml
@@ -1,4 +1,4 @@
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: ${projectName}-${lowercase(procName)}


### PR DESCRIPTION
This is also preventing production clusters from being upgraded to 1.25

Fixes #6534 
