### PR TITLE
chore(db): allow for pg v15

### DIFF
--- a/changelog/issue-5514.md
+++ b/changelog/issue-5514.md
@@ -1,0 +1,9 @@
+audience: deployers
+level: minor
+reference: issue 5514
+---
+Adds support for postgres version 15.
+
+Note: if you want to migrate your local dev db to pg15, you'll need to either erase the existing db with `docker volume rm taskcluster_db-data` before you migrate, or, if you'd prefer to keep your local dev data, you'll need to manually dump the db contents and then import them into the upgraded db.
+
+Support for postgres v11 will be dropped from Taskcluster on November 9, 2023 (v11 EoL date) and that will be a breaking change.

--- a/db/README.md
+++ b/db/README.md
@@ -270,5 +270,5 @@ This approach is slower, but is appropriate for testing.
 
 ## Development
 
-To test this library, you will need a Postgres database, running the latest release of Postgres 11.
+To test this library, you will need a Postgres database, running the latest release of Postgres 11 or 15.
 The easiest and best way to do this is to use docker, as described in the [Development Process docs](../dev-docs/development-process.md).

--- a/db/test-setup.sh
+++ b/db/test-setup.sh
@@ -6,14 +6,14 @@ if [ -z "${TASK_ID}" ]; then
 fi
 
 # (redundant to the same script in the docker image; this can be removed a day or two after #3116 lands)
-pg_version=11
+pg_version=15
 echo 'local all all trust' > /etc/postgresql/$pg_version/main/pg_hba.conf
 echo 'host all all 127.0.0.1/32 trust' >> /etc/postgresql/$pg_version/main/pg_hba.conf
 echo 'host all all ::1/128 trust' >> /etc/postgresql/$pg_version/main/pg_hba.conf
 
 # start the server
 echo "Starting pg server.."
-pg_ctlcluster 11 main start
+pg_ctlcluster 15 main start
 
 # if necessary, create the required users
 if [ "$1" = "--users" ]; then

--- a/dev-docs/dev-deployment.md
+++ b/dev-docs/dev-deployment.md
@@ -16,7 +16,7 @@ You will need to have the following
 * A RabbitMQ cluster running the latest available version. (see also [install RabbitMQ](#own-rabbitmq-in-cluster))
   The deployment process requires administrative access (the RabbitMQ management API) and creates multiple users.
   The free levels of CloudAMQP's service do not support this.
-* A Postgres server running Postgres 11.x (see below for Google Cloud SQL, or use another provider). (see also [install Postgres](#own-postgres-in-cluster))
+* A Postgres server running Postgres 11.x or 15.x (see below for Google Cloud SQL, or use another provider). (see also [install Postgres](#own-postgres-in-cluster))
   The Postgres server must be initialized with the `en_US.utf8` locale; see [the deployment docs](../ui/docs/manual/deploying/database.mdx).
 * An AWS account and an IAM user in that account
   Set up your `aws` command-line to use the IAM user (`aws configure`).
@@ -368,7 +368,7 @@ Warning: by using this approach, you are responsible for maintenance and backups
       enabled: true
 
    image:
-      tag: 11  # Taskcluster currently supports version 11
+      tag: 15  # Taskcluster currently supports version 11 and 15
    ```
 
    More details at <https://github.com/bitnami/charts/tree/master/bitnami/postgresql>

--- a/dev-docs/development-process.md
+++ b/dev-docs/development-process.md
@@ -29,7 +29,7 @@ The currently-required version of Rust is in `rust-toolchain`.
 
 ### Postgres
 
-All Taskcluster services require a Postgres 11 server to run.
+All Taskcluster services require a Postgres 11 or 15 server to run.
 The easiest and best way to do this is to use docker, but if you prefer you can install a Postgres server locally.
 *NOTE* the test suites repeatedly drop the `public` schema and re-create it, effectively deleting all data in the database.
 Do not run these tests against a database instance that contains any useful data!
@@ -37,7 +37,7 @@ Do not run these tests against a database instance that contains any useful data
 To start the server using Docker:
 
 ```shell
-docker run -ti -p 127.0.0.1:5432:5432 -e POSTGRES_HOST_AUTH_METHOD=trust -e LC_COLLATE=en_US.UTF8 -e LC_CTYPE=en_US.UTF8 --rm postgres:11
+docker run -ti -p 127.0.0.1:5432:5432 -e POSTGRES_HOST_AUTH_METHOD=trust -e LC_COLLATE=en_US.UTF8 -e LC_CTYPE=en_US.UTF8 --rm postgres:15
 ```
 
 This will run Docker in the foreground in that terminal (so you'll need to use another terminal for your work, or add the `-d` flag to daemonize the container) and make that available on TCP port 5432, the "normal" Postgres port.
@@ -45,7 +45,7 @@ This will run Docker in the foreground in that terminal (so you'll need to use a
 It can be helpful to log all queries run by the test suite:
 
 ```shell
-docker run -ti -p 127.0.0.1:5432:5432 -e POSTGRES_HOST_AUTH_METHOD=trust -e LC_COLLATE=en_US.UTF8 -e LC_CTYPE=en_US.UTF8 --rm postgres:11 -c log_statement=all
+docker run -ti -p 127.0.0.1:5432:5432 -e POSTGRES_HOST_AUTH_METHOD=trust -e LC_COLLATE=en_US.UTF8 -e LC_CTYPE=en_US.UTF8 --rm postgres:15 -c log_statement=all
 ```
 
 However you decide to run Postgres, you will need a DB URL, as defined by [node-postgres](https://node-postgres.com/features/connecting).

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,7 +23,7 @@ services:
       RABBITMQ_DEFAULT_PASS: admin
       RABBITMQ_DEFAULT_VHOST: local
   postgres:
-    image: postgres:11
+    image: postgres:15
     networks:
       - local
     volumes:

--- a/infrastructure/docker-images/build-ci-image.sh
+++ b/infrastructure/docker-images/build-ci-image.sh
@@ -15,7 +15,7 @@ if [ -z "${go_version}" ]; then
     exit 1
 fi
 
-pg_version=11
+pg_version=15
 
 tmpdir=$(mktemp -d)
 trap "cd /; rm -rf ${tmpdir}" EXIT
@@ -37,8 +37,8 @@ rm -rf /var/lib/apt/lists/*
 localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
 
 # drop and re-create the default cluster with the appropriate locale
-pg_dropcluster 11 main
-pg_createcluster 11 main --lc-collate=en_US.UTF8 --lc-ctype=en_US.UTF8
+pg_dropcluster 15 main
+pg_createcluster 15 main --lc-collate=en_US.UTF8 --lc-ctype=en_US.UTF8
 
 # allow postgres to connect locally with no auth -- this is for testing!
 echo 'local all all trust' > /etc/postgresql/$pg_version/main/pg_hba.conf

--- a/infrastructure/tooling/src/generate/generators/docker-compose.js
+++ b/infrastructure/tooling/src/generate/generators/docker-compose.js
@@ -275,7 +275,7 @@ exports.tasks.push({
           },
         }),
         postgres: serviceDefinition('postgres', {
-          image: 'postgres:11',
+          image: 'postgres:15',
           volumes: [
             'db-data:/var/lib/postgresql/data',
             './docker/postgres/init.sql:/docker-entrypoint-initdb.d/init.sql',

--- a/libraries/azqueue/test/slow_test.js
+++ b/libraries/azqueue/test/slow_test.js
@@ -11,7 +11,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
   suiteSetup(function() {
     // HINT: run these tests with the following to see explains in the logs:
     //
-    // docker run -ti -p 127.0.0.1:5432:5432  --rm postgres:11 \
+    // docker run -ti -p 127.0.0.1:5432:5432  --rm postgres:15 \
     //   -c log_statement=all \
     //   -c session_preload_libraries=auto_explain \
     //   -c auto_explain.log_min_duration=0s \

--- a/libraries/postgres/README.md
+++ b/libraries/postgres/README.md
@@ -484,7 +484,7 @@ Because all configuration for a service is stored in memory, there is no additio
 ## Error Constants
 
 This module also defines a number of constants for Postgres's otherwise-cryptic SQLSTATE codes.
-The symbol names and values are drawn from [PostgreSQL Error Codes](https://www.postgresql.org/docs/11/errcodes-appendix.html).
+The symbol names and values are drawn from [PostgreSQL Error Codes](https://www.postgresql.org/docs/15/errcodes-appendix.html).
 For example `tcLibPg.UNDEFINED_TABLE` is `"42P01"`.
 Feel free to add any additional constants required in [`src/constants.js`](./src/constants.js).
 
@@ -502,5 +502,5 @@ Note that the return promise does not carry a value on success, as that success 
 
 ## Development
 
-To test this library, you will need a Postgres database, running the latest release of Postgres 11.
+To test this library, you will need a Postgres database, running the latest release of Postgres 11 or 15.
 The easiest and best way to do this is to use docker, as described in the [Development Process docs](../dev-docs/development-process.md).

--- a/libraries/postgres/src/Database.js
+++ b/libraries/postgres/src/Database.js
@@ -434,11 +434,9 @@ class Database {
         SELECT current_setting('server_version_num');
       `);
       const ver = version.rows[0].current_setting;
-      if (ver < 110000) {
-        throw new Error("Postgres version is less than 11. Please upgrade to 11.x");
-      }
-      if (ver >= 120000) {
-        throw new Error("Postgres version is greater than 11. Please downgrade to 11.x");
+      const majorVersion = Math.floor(ver / 10000);
+      if (majorVersion !== 11 && majorVersion !== 15) {
+        throw new Error("Postgres version is not 11.x or 15.x. Please upgrade to 11.x or 15.x");
       }
     });
   }

--- a/libraries/postgres/src/constants.js
+++ b/libraries/postgres/src/constants.js
@@ -2,7 +2,7 @@ module.exports = {
   READ: 'read',
   WRITE: 'write',
 
-  // see https://www.postgresql.org/docs/11/errcodes-appendix.html
+  // see https://www.postgresql.org/docs/15/errcodes-appendix.html
   DUPLICATE_OBJECT: '42710',
   DUPLICATE_TABLE: '42P07',
   NUMERIC_VALUE_OUT_OF_RANGE: '22003',

--- a/taskcluster/src/transforms/__init__.py
+++ b/taskcluster/src/transforms/__init__.py
@@ -7,7 +7,7 @@ transforms = TransformSequence()
 
 
 def _dependency_versions():
-    pg_version = 11
+    pg_version = 15
     with open('clients/client-rust/rust-toolchain', 'r') as f:
         rust_version = f.read().strip()
     with open('package.json', 'r') as pkg:

--- a/ui/docs/manual/deploying/database.mdx
+++ b/ui/docs/manual/deploying/database.mdx
@@ -6,7 +6,7 @@ import Warning from 'taskcluster-ui/views/Documentation/components/Warning';
 
 # Database Configuration
 
-Taskcluster uses a Postgres 11 database for its backend storage.
+Taskcluster uses a Postgres 11 or 15 database for its backend storage.
 A single database is shared among all services.
 
 Taskcluster assumes that it "owns" the database, but can share a single server with other users.


### PR DESCRIPTION
Fixes https://github.com/taskcluster/taskcluster/issues/5514.

Note, once this lands, we will upgrade our dev cluster's db to pg15 and ensure things are working. From there, we'll do community tc, then let SREs know about the ending support of v11. At that time, it might be best for them to make a copy of the pg11 db, and perform the upgrade to v15, just to see what the expected downtime might be while running the upgrade on Firefox CI.

>Adds support for postgres version 15.
>
>Note: if you want to migrate your local dev db to pg15, you'll need to either erase the existing db with `docker volume rm taskcluster_db-data` before you migrate, or, if you'd prefer to keep your local dev data, you'll need to manually dump the db contents and then import them into the upgraded db.
>
>Support for postgres v11 will be dropped from Taskcluster on November 9, 2023 (v11 EoL date) and that will be a breaking change.