### PR TITLE
Provide a script to remove all unused taskcluster images locally

### DIFF
--- a/changelog/IqAgAVXDQyWlJus1Tgdp4A.md
+++ b/changelog/IqAgAVXDQyWlJus1Tgdp4A.md
@@ -1,0 +1,3 @@
+audience: developers
+level: silent
+---

--- a/dev-docs/development-process.md
+++ b/dev-docs/development-process.md
@@ -373,6 +373,16 @@ yarn start notify-background-handler
 >
 > This way using exported environment variable makes compose behaviour more intuitive.
 
+## Cleaning up unused docker images
+
+With each new Taskcluster release, new docker images are created. Over time this may lead to a large number of unused images. To clean up unused images, run the following command:
+
+```sh
+./docker/cleanup-images.sh
+```
+
+This will find all `taskcluster/` images that are referenced in `docker-compose.yml` and for each one will remove all other images with the same name but different tag.
+
 ## Running tasks with local generic-worker
 
 `generic-worker` is configured to automatically start with `docker compose` and connect to taskcluster using `docker-compose/generic-worker` task queue id.

--- a/docker/cleanup-images.sh
+++ b/docker/cleanup-images.sh
@@ -1,0 +1,16 @@
+#/bin/bash
+
+if [ ! -f docker-compose.yml ]; then
+  echo "docker-compose.yml not found"
+  exit 1
+fi
+
+# find all "taskcluster/" images that are currently used in docker-compose.yml
+for line in $(grep "image:" docker-compose.yml | grep taskcluster |sort | uniq | sed -n "s/^.*image:\s*\(\S*\)/\1/p"); do
+  IFS=":" read -r repo tag <<< "$line"
+  echo "\nRemoving all $repo images except the used one: $tag "
+  # display the list of images to be removed
+  docker images --format '{{.Size}}\t{{.Repository}}:{{.Tag}}' | grep "$repo" | grep -v "$tag"
+  # remove the images
+  docker images --format '{{.Repository}}:{{.Tag}}' | grep "$repo" | grep -v "$tag" | xargs -I {} docker rmi {}
+done


### PR DESCRIPTION
I realised that we do releases very often, and each new release bring new image version. 
Over time they pile up and may take 10gb+ of disk space on local development machine.

This is only for the images that are referenced in `docker-compose.yml`