### PR TITLE
Generic Worker: fix nil pointer dereference in Evict(*TaskMount)

### DIFF
--- a/changelog/issue-6540.md
+++ b/changelog/issue-6540.md
@@ -1,0 +1,5 @@
+audience: worker-deployers
+level: patch
+reference: issue 6540
+---
+Generic Worker panicked when evicting caches to free up space on workers. This was reported via sentry [here](https://mozilla.sentry.io/issues/4044685700/?project=6462337).

--- a/workers/generic-worker/mounts.go
+++ b/workers/generic-worker/mounts.go
@@ -79,11 +79,11 @@ func (cache *Cache) Rating() float64 {
 }
 
 func (cache *Cache) Evict(taskMount *TaskMount) error {
-	if taskMount.task != nil {
+	if taskMount != nil {
 		taskMount.Infof("Removing cache %v from cache table", cache.Key)
 	}
 	delete(cache.Owner, cache.Key)
-	if taskMount.task != nil {
+	if taskMount != nil {
 		taskMount.Infof("Deleting cache %v file(s) at %v", cache.Key, cache.Location)
 	}
 	// delete the cache on the file system

--- a/workers/generic-worker/mounts_test.go
+++ b/workers/generic-worker/mounts_test.go
@@ -1014,3 +1014,32 @@ func TestInvalidSHADoesNotPreventMountedMountsFromBeingUnmounted(t *testing.T) {
 	// (which can happen if it wasn't unmounted after first task failed)
 	_ = submitAndAssert(t, td, payload, "completed", "completed")
 }
+
+func TestEvictNext(t *testing.T) {
+	r := Resources(
+		[]Resource{
+			&Cache{
+				Key: "apple",
+			},
+			&Cache{
+				Key: "banana",
+			},
+			&Cache{
+				Key: "pear",
+			},
+		},
+	)
+	err := r.EvictNext()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(r) != 2 {
+		t.Fatalf("Was expecting cache to have two entries (banana and pear), because apple should have been evicted; however cache has %v entries", len(r))
+	}
+	if key := r[0].(*Cache).Key; key != "banana" {
+		t.Fatalf("Was expecting first cache item to be \"banana\" because \"apple\" should have been evicted, but it is %q", key)
+	}
+	if key := r[1].(*Cache).Key; key != "pear" {
+		t.Fatalf("Was expecting second cache item to be \"pear\" because \"apple\" should have been evicted, but it is %q", key)
+	}
+}


### PR DESCRIPTION
Fixes #6540