### PR TITLE
fix(d2g): only pass env var name

### DIFF
--- a/changelog/issue-6543.md
+++ b/changelog/issue-6543.md
@@ -1,0 +1,5 @@
+audience: general
+level: patch
+reference: issue 6543
+---
+Generic Worker: d2g no longer passes the environment variable values to the `podman run` command. Instead, just the variable name is passed as `-e VAR` which tells podman to take the value from the host. This will tidy up the run command and will help with any escaping issues users may have been having.

--- a/tools/d2g/d2gtest/testdata/testcases/artifacts_test.yml
+++ b/tools/d2g/d2gtest/testdata/testcases/artifacts_test.yml
@@ -26,11 +26,9 @@ testSuite:
             - '-cx'
             - >-
               podman run -t --name taskcontainer
-              -e "RUN_ID=${RUN_ID}" -e
-              "TASKCLUSTER_ROOT_URL=${TASKCLUSTER_ROOT_URL}" -e
-              "TASKCLUSTER_WORKER_LOCATION=${TASKCLUSTER_WORKER_LOCATION}" -e
-              "TASK_ID=${TASK_ID}"
-              ubuntu 'echo "Hello world"'
+              -e RUN_ID -e TASKCLUSTER_ROOT_URL -e
+              TASKCLUSTER_WORKER_LOCATION -e
+              TASK_ID ubuntu 'echo "Hello world"'
 
               exit_code=$?
 

--- a/tools/d2g/d2gtest/testdata/testcases/decision_task_tests.yml
+++ b/tools/d2g/d2gtest/testdata/testcases/decision_task_tests.yml
@@ -84,19 +84,13 @@ testSuite:
               podman run -t --name taskcontainer --privileged -v
               "$(pwd)/cache0:/builds/worker/checkouts"
               --add-host=taskcluster:127.0.0.1 --net=host -e
-              "GECKO_BASE_REPOSITORY=https://hg.mozilla.org/mozilla-unified" -e
-              "GECKO_BASE_REV=330c69218a931b3504d44c867539ed6083521be5" -e
-              "GECKO_HEAD_REF=ca2873779214f6109ffe1b23e1455350294ac325" -e
-              "GECKO_HEAD_REPOSITORY=https://hg.mozilla.org/mozilla-central" -e
-              "GECKO_HEAD_REV=ca2873779214f6109ffe1b23e1455350294ac325" -e
-              "HG_STORE_PATH=/builds/worker/checkouts/hg-store" -e
-              "MOZ_AUTOMATION=1" -e "PYTHONDONTWRITEBYTECODE=1" -e
-              "RUN_ID=${RUN_ID}" -e
-              "TASKCLUSTER_CACHES=/builds/worker/checkouts" -e
-              "TASKCLUSTER_PROXY_URL=${TASKCLUSTER_PROXY_URL}" -e
-              "TASKCLUSTER_ROOT_URL=${TASKCLUSTER_ROOT_URL}" -e
-              "TASKCLUSTER_WORKER_LOCATION=${TASKCLUSTER_WORKER_LOCATION}" -e
-              "TASK_ID=${TASK_ID}"
+              GECKO_BASE_REPOSITORY -e GECKO_BASE_REV -e
+              GECKO_HEAD_REF -e GECKO_HEAD_REPOSITORY -e
+              GECKO_HEAD_REV -e HG_STORE_PATH -e
+              MOZ_AUTOMATION -e PYTHONDONTWRITEBYTECODE -e
+              RUN_ID -e TASKCLUSTER_CACHES -e
+              TASKCLUSTER_PROXY_URL -e TASKCLUSTER_ROOT_URL -e
+              TASKCLUSTER_WORKER_LOCATION -e TASK_ID
               'mozillareleases/gecko_decision:4.0.0@sha256:9f69fe08c28e3cb3cc296451f0a2735df6e25d0e3c877ea735ef1b7f0b345b06'
               /builds/worker/bin/run-task
               --gecko-checkout=/builds/worker/checkouts/gecko
@@ -129,6 +123,16 @@ testSuite:
               podman rm taskcontainer
 
               exit "${exit_code}"
+        env:
+          GECKO_BASE_REPOSITORY: 'https://hg.mozilla.org/mozilla-unified'
+          GECKO_BASE_REV: 330c69218a931b3504d44c867539ed6083521be5
+          GECKO_HEAD_REF: ca2873779214f6109ffe1b23e1455350294ac325
+          GECKO_HEAD_REPOSITORY: 'https://hg.mozilla.org/mozilla-central'
+          GECKO_HEAD_REV: ca2873779214f6109ffe1b23e1455350294ac325
+          HG_STORE_PATH: /builds/worker/checkouts/hg-store
+          MOZ_AUTOMATION: '1'
+          PYTHONDONTWRITEBYTECODE: '1'
+          TASKCLUSTER_CACHES: /builds/worker/checkouts
         features:
           chainOfTrust: true
           taskclusterProxy: true

--- a/tools/d2g/d2gtest/testdata/testcases/devices_tests.yml
+++ b/tools/d2g/d2gtest/testdata/testcases/devices_tests.yml
@@ -21,10 +21,8 @@ testSuite:
             - >-
               podman run -t --rm
               --device=/dev/shm
-              -e "RUN_ID=${RUN_ID}" -e
-              "TASKCLUSTER_ROOT_URL=${TASKCLUSTER_ROOT_URL}" -e
-              "TASKCLUSTER_WORKER_LOCATION=${TASKCLUSTER_WORKER_LOCATION}" -e
-              "TASK_ID=${TASK_ID}"
+              -e RUN_ID -e TASKCLUSTER_ROOT_URL -e
+              TASKCLUSTER_WORKER_LOCATION -e TASK_ID
               ubuntu 'echo "Hello world"'
         maxRunTime: 3600
         onExitStatus:
@@ -49,10 +47,8 @@ testSuite:
             - >-
               podman run -t --rm
               --device=/dev/kvm
-              -e "RUN_ID=${RUN_ID}" -e
-              "TASKCLUSTER_ROOT_URL=${TASKCLUSTER_ROOT_URL}" -e
-              "TASKCLUSTER_WORKER_LOCATION=${TASKCLUSTER_WORKER_LOCATION}" -e
-              "TASK_ID=${TASK_ID}"
+              -e RUN_ID -e TASKCLUSTER_ROOT_URL -e
+              TASKCLUSTER_WORKER_LOCATION -e TASK_ID
               ubuntu 'echo "Hello world"'
         maxRunTime: 3600
         onExitStatus:
@@ -77,10 +73,8 @@ testSuite:
             - >-
               podman run -t --rm
               --device="${TASKCLUSTER_VIDEO_DEVICE}"
-              -e "RUN_ID=${RUN_ID}" -e
-              "TASKCLUSTER_ROOT_URL=${TASKCLUSTER_ROOT_URL}" -e
-              "TASKCLUSTER_WORKER_LOCATION=${TASKCLUSTER_WORKER_LOCATION}" -e
-              "TASK_ID=${TASK_ID}"
+              -e RUN_ID -e TASKCLUSTER_ROOT_URL -e
+              TASKCLUSTER_WORKER_LOCATION -e TASK_ID
               ubuntu 'echo "Hello world"'
         features:
           loopbackVideo: true
@@ -107,10 +101,8 @@ testSuite:
             - >-
               podman run -t --rm
               --device=/dev/snd
-              -e "RUN_ID=${RUN_ID}" -e
-              "TASKCLUSTER_ROOT_URL=${TASKCLUSTER_ROOT_URL}" -e
-              "TASKCLUSTER_WORKER_LOCATION=${TASKCLUSTER_WORKER_LOCATION}" -e
-              "TASK_ID=${TASK_ID}"
+              -e RUN_ID -e TASKCLUSTER_ROOT_URL -e
+              TASKCLUSTER_WORKER_LOCATION -e TASK_ID
               ubuntu 'echo "Hello world"'
         features:
           loopbackAudio: true

--- a/tools/d2g/d2gtest/testdata/testcases/docker_image_tests.yml
+++ b/tools/d2g/d2gtest/testdata/testcases/docker_image_tests.yml
@@ -16,10 +16,8 @@ testSuite:
             - '-cx'
             - >-
               podman run -t --rm
-              -e "RUN_ID=${RUN_ID}" -e
-              "TASKCLUSTER_ROOT_URL=${TASKCLUSTER_ROOT_URL}" -e
-              "TASKCLUSTER_WORKER_LOCATION=${TASKCLUSTER_WORKER_LOCATION}" -e
-              "TASK_ID=${TASK_ID}"
+              -e RUN_ID -e TASKCLUSTER_ROOT_URL -e
+              TASKCLUSTER_WORKER_LOCATION -e TASK_ID
               ubuntu 'echo "Hello world"'
         maxRunTime: 3600
         onExitStatus:
@@ -41,10 +39,8 @@ testSuite:
             - '-cx'
             - >-
               podman run -t --rm
-              -e "RUN_ID=${RUN_ID}" -e
-              "TASKCLUSTER_ROOT_URL=${TASKCLUSTER_ROOT_URL}" -e
-              "TASKCLUSTER_WORKER_LOCATION=${TASKCLUSTER_WORKER_LOCATION}" -e
-              "TASK_ID=${TASK_ID}"
+              -e RUN_ID -e TASKCLUSTER_ROOT_URL -e
+              TASKCLUSTER_WORKER_LOCATION -e TASK_ID
               ubuntu 'echo "Hello world"'
         maxRunTime: 3600
         onExitStatus:
@@ -71,10 +67,8 @@ testSuite:
               IMAGE_NAME=$(podman load -i path | sed -n 's/.*: //p')
 
               podman run -t --rm
-              -e "RUN_ID=${RUN_ID}" -e
-              "TASKCLUSTER_ROOT_URL=${TASKCLUSTER_ROOT_URL}" -e
-              "TASKCLUSTER_WORKER_LOCATION=${TASKCLUSTER_WORKER_LOCATION}" -e
-              "TASK_ID=${TASK_ID}"
+              -e RUN_ID -e TASKCLUSTER_ROOT_URL -e
+              TASKCLUSTER_WORKER_LOCATION -e TASK_ID
               "${IMAGE_NAME}" 'echo "Hello world"'
         maxRunTime: 3600
         features:
@@ -107,10 +101,8 @@ testSuite:
               IMAGE_NAME=$(podman load -i path | sed -n 's/.*: //p')
 
               podman run -t --rm
-              -e "RUN_ID=${RUN_ID}" -e
-              "TASKCLUSTER_ROOT_URL=${TASKCLUSTER_ROOT_URL}" -e
-              "TASKCLUSTER_WORKER_LOCATION=${TASKCLUSTER_WORKER_LOCATION}" -e
-              "TASK_ID=${TASK_ID}"
+              -e RUN_ID -e TASKCLUSTER_ROOT_URL -e
+              TASKCLUSTER_WORKER_LOCATION -e TASK_ID
               "${IMAGE_NAME}" 'echo "Hello world"'
         maxRunTime: 3600
         features:
@@ -143,10 +135,8 @@ testSuite:
               IMAGE_NAME=$(podman load -i path | sed -n 's/.*: //p')
 
               podman run -t --rm
-              -e "RUN_ID=${RUN_ID}" -e
-              "TASKCLUSTER_ROOT_URL=${TASKCLUSTER_ROOT_URL}" -e
-              "TASKCLUSTER_WORKER_LOCATION=${TASKCLUSTER_WORKER_LOCATION}" -e
-              "TASK_ID=${TASK_ID}"
+              -e RUN_ID -e TASKCLUSTER_ROOT_URL -e
+              TASKCLUSTER_WORKER_LOCATION -e TASK_ID
               "${IMAGE_NAME}" 'echo "Hello world"'
         maxRunTime: 3600
         features:
@@ -173,10 +163,8 @@ testSuite:
               IMAGE_NAME=$(podman load -i path | sed -n 's/.*: //p')
 
               podman run -t --rm
-              -e "RUN_ID=${RUN_ID}" -e
-              "TASKCLUSTER_ROOT_URL=${TASKCLUSTER_ROOT_URL}" -e
-              "TASKCLUSTER_WORKER_LOCATION=${TASKCLUSTER_WORKER_LOCATION}" -e
-              "TASK_ID=${TASK_ID}"
+              -e RUN_ID -e TASKCLUSTER_ROOT_URL -e
+              TASKCLUSTER_WORKER_LOCATION -e TASK_ID
               "${IMAGE_NAME}" 'echo "Hello world"'
         mounts:
           - content:
@@ -210,10 +198,8 @@ testSuite:
               IMAGE_NAME=$(podman load -i path | sed -n 's/.*: //p')
 
               podman run -t --rm
-              -e "RUN_ID=${RUN_ID}" -e
-              "TASKCLUSTER_ROOT_URL=${TASKCLUSTER_ROOT_URL}" -e
-              "TASKCLUSTER_WORKER_LOCATION=${TASKCLUSTER_WORKER_LOCATION}" -e
-              "TASK_ID=${TASK_ID}"
+              -e RUN_ID -e TASKCLUSTER_ROOT_URL -e
+              TASKCLUSTER_WORKER_LOCATION -e TASK_ID
               "${IMAGE_NAME}" 'echo "Hello world"'
         mounts:
           - content:
@@ -247,10 +233,8 @@ testSuite:
               IMAGE_NAME=$(podman load -i path | sed -n 's/.*: //p')
 
               podman run -t --rm
-              -e "RUN_ID=${RUN_ID}" -e
-              "TASKCLUSTER_ROOT_URL=${TASKCLUSTER_ROOT_URL}" -e
-              "TASKCLUSTER_WORKER_LOCATION=${TASKCLUSTER_WORKER_LOCATION}" -e
-              "TASK_ID=${TASK_ID}"
+              -e RUN_ID -e TASKCLUSTER_ROOT_URL -e
+              TASKCLUSTER_WORKER_LOCATION -e TASK_ID
               "${IMAGE_NAME}" 'echo "Hello world"'
         mounts:
           - content:

--- a/tools/d2g/d2gtest/testdata/testcases/dw_features_tests.yml
+++ b/tools/d2g/d2gtest/testdata/testcases/dw_features_tests.yml
@@ -17,8 +17,11 @@ testSuite:
         command:
           - - bash
             - "-cx"
-            - |-
-              podman run -t --rm --cap-add=SYS_PTRACE -e "RUN_ID=${RUN_ID}" -e "TASKCLUSTER_ROOT_URL=${TASKCLUSTER_ROOT_URL}" -e "TASKCLUSTER_WORKER_LOCATION=${TASKCLUSTER_WORKER_LOCATION}" -e "TASK_ID=${TASK_ID}" ubuntu 'echo "Hello world"'
+            - >-
+              podman run -t --rm --cap-add=SYS_PTRACE -e
+              RUN_ID -e TASKCLUSTER_ROOT_URL -e
+              TASKCLUSTER_WORKER_LOCATION -e TASK_ID
+              ubuntu 'echo "Hello world"'
         maxRunTime: 3600
         onExitStatus:
           retry:

--- a/tools/d2g/d2gtest/testdata/testcases/no_artifacts_test.yml
+++ b/tools/d2g/d2gtest/testdata/testcases/no_artifacts_test.yml
@@ -24,10 +24,8 @@ testSuite:
             - '-cx'
             - >-
               podman run -t --rm
-              -e "RUN_ID=${RUN_ID}" -e
-              "TASKCLUSTER_ROOT_URL=${TASKCLUSTER_ROOT_URL}" -e
-              "TASKCLUSTER_WORKER_LOCATION=${TASKCLUSTER_WORKER_LOCATION}" -e
-              "TASK_ID=${TASK_ID}"
+              -e RUN_ID -e TASKCLUSTER_ROOT_URL -e
+              TASKCLUSTER_WORKER_LOCATION -e TASK_ID
               ubuntu 'echo "Hello world"'
         features:
           backingLog: false


### PR DESCRIPTION
Fixes https://github.com/taskcluster/taskcluster/issues/6543. Thanks for the suggestion @jschwartzentruber!

>Generic Worker: d2g no longer passes the environment variable values to the `podman run` command. Instead, just the variable name is passed as `-e VAR` which tells podman to take the value from the host. This will tidy up the run command and will help with any escaping issues users may have been having.