### PR TITLE
Issue 6488 - Generic Worker no longer panics on IO errors while scanning file system for artifacts

### DIFF
--- a/changelog/issue-6488.md
+++ b/changelog/issue-6488.md
@@ -1,0 +1,5 @@
+audience: users
+level: patch
+reference: issue 6488
+---
+Generic Worker no longer panics if an IO error occurs while scanning the filesystem for artifacts.


### PR DESCRIPTION
Fixes #6488