### PR TITLE
Issue 6470: D2G now properly escapes artifact path in podman cp commands

### DIFF
--- a/changelog/issue-6470.md
+++ b/changelog/issue-6470.md
@@ -1,0 +1,5 @@
+audience: users
+level: patch
+reference: issue 6470
+---
+D2G now properly escapes artifact paths in generated `podman cp` commands.

--- a/tools/d2g/d2g.go
+++ b/tools/d2g/d2g.go
@@ -240,6 +240,7 @@ func podmanRunCommand(containerName string, dwPayload *dockerworker.DockerWorker
 	if err != nil {
 		return "", fmt.Errorf("could not form docker image string: %w", err)
 	}
+	// note, dockerImageString is already shell escaped
 	command.WriteString(" " + dockerImageString)
 	command.WriteString(" " + shell.Escape(dwPayload.Command...))
 	return command.String(), nil
@@ -258,7 +259,7 @@ func podmanCopyArtifacts(containerName string, dwPayload *dockerworker.DockerWor
 		if _, ok := dwPayload.Artifacts[gwArtifacts[i].Name]; !ok {
 			continue
 		}
-		commands = append(commands, fmt.Sprintf("podman cp '%s:%s' %s", containerName, dwPayload.Artifacts[gwArtifacts[i].Name].Path, gwArtifacts[i].Path))
+		commands = append(commands, fmt.Sprintf("podman cp %s:%s %s", containerName, shell.Escape(dwPayload.Artifacts[gwArtifacts[i].Name].Path), shell.Escape(gwArtifacts[i].Path)))
 	}
 	return commands
 }

--- a/tools/d2g/d2gtest/testdata/testcases/artifacts_test.yml
+++ b/tools/d2g/d2gtest/testdata/testcases/artifacts_test.yml
@@ -11,31 +11,33 @@ testSuite:
           public/fred:
             type: file
             path: /home/worker/artifacts/fred.txt
+          # Issue #6470
+          public/build.tar.gz:
+            path: /etc/passwd' artifact0; whoami; echo foo > /root/bar; cp 'foo
+            expires: '2024-05-28T16:12:56.693817Z'
+            type: file
         command:
           - echo "Hello world"
         image: ubuntu
         maxRunTime: 3600
       genericWorkerTaskPayload:
         artifacts:
-          - expires: '0001-01-01T00:00:00.000Z'
-            name: public/fred
-            path: artifact0.txt
+          - expires: '2024-05-28T16:12:56.693Z'
+            name: public/build.tar.gz
+            path: artifact0
+            type: file
+          - name: public/fred
+            path: artifact1.txt
             type: file
         command:
           - - bash
             - '-cx'
-            - >-
-              podman run -t --name taskcontainer
-              -e RUN_ID -e TASKCLUSTER_ROOT_URL -e
-              TASKCLUSTER_WORKER_LOCATION -e
-              TASK_ID ubuntu 'echo "Hello world"'
-
+            - |-
+              podman run -t --name taskcontainer -e RUN_ID -e TASKCLUSTER_ROOT_URL -e TASKCLUSTER_WORKER_LOCATION -e TASK_ID ubuntu 'echo "Hello world"'
               exit_code=$?
-
-              podman cp 'taskcontainer:/home/worker/artifacts/fred.txt' artifact0.txt
-
+              podman cp taskcontainer:'/etc/passwd'\'' artifact0; whoami; echo foo > /root/bar; cp '\''foo' artifact0
+              podman cp taskcontainer:'/home/worker/artifacts/fred.txt' 'artifact1.txt'
               podman rm taskcontainer
-
               exit "${exit_code}"
         maxRunTime: 3600
         onExitStatus:

--- a/tools/d2g/d2gtest/testdata/testcases/decision_task_tests.yml
+++ b/tools/d2g/d2gtest/testdata/testcases/decision_task_tests.yml
@@ -73,8 +73,7 @@ testSuite:
             name: public/docker-contexts
             path: artifact1
             type: directory
-          - expires: '0001-01-01T00:00:00.000Z'
-            name: public/dockerImage.tar.gz
+          - name: public/dockerImage.tar.gz
             path: image.tar.gz
             type: file
         command:
@@ -110,10 +109,10 @@ testSuite:
 
               exit_code=$?
 
-              podman cp 'taskcontainer:/builds/worker/artifacts' artifact0
+              podman cp taskcontainer:/builds/worker/artifacts artifact0
 
               podman cp
-              'taskcontainer:/builds/worker/checkouts/gecko/docker-contexts'
+              taskcontainer:/builds/worker/checkouts/gecko/docker-contexts
               artifact1
 
               podman commit taskcontainer taskcontainer


### PR DESCRIPTION
Fixes #6470