### PR TITLE
feat(d2g): use gw indexed artifact type

### DIFF
--- a/changelog/Y3Q62wgKQpGVDp06fZF5xg.md
+++ b/changelog/Y3Q62wgKQpGVDp06fZF5xg.md
@@ -1,0 +1,4 @@
+audience: general
+level: patch
+---
+D2G now uses the native, Generic Worker Indexed Artifact type instead of manually fetching them using the Taskcluster API.

--- a/changelog/Y3Q62wgKQpGVDp06fZF5xg.md
+++ b/changelog/Y3Q62wgKQpGVDp06fZF5xg.md
@@ -1,4 +1,5 @@
 audience: general
 level: patch
 ---
-D2G now uses the native, Generic Worker Indexed Artifact type instead of manually fetching them using the Taskcluster API.
+D2G now takes advantage of Generic Worker Indexed Artifacts, introduced in Generic Worker 51.0.0. D2G translates Indexed Docker Images into Generic Worker mounted Indexed Artifacts. Previously, D2G generated commands to query the taskcluster Index and fetch the docker image.
+With this improvement, docker images are now cached on workers, docker image dependencies between tasks are declarative (and thus inspectable), and generated Generic Worker task payloads are simpler and easier to understand.

--- a/tools/d2g/d2g.go
+++ b/tools/d2g/d2g.go
@@ -24,7 +24,6 @@ type (
 	NamedDockerImage    dockerworker.NamedDockerImage
 	DockerImageArtifact dockerworker.DockerImageArtifact
 	Image               interface {
-		PrepareCommands() []string
 		FileMounts() ([]genericworker.FileMount, error)
 		String() (string, error)
 	}
@@ -166,15 +165,15 @@ func command(dwPayload *dockerworker.DockerWorkerPayload, dwImage Image, gwArtif
 		containerName = "taskcontainer"
 	}
 
-	podmanPrepareCommands := dwImage.PrepareCommands()
+	commands := []string{}
 
 	podmanRunString, err := podmanRunCommand(containerName, dwPayload, dwImage, gwWritableDirectoryCaches)
 	if err != nil {
 		return nil, fmt.Errorf("could not form podman run command: %w", err)
 	}
 
-	commands := append(
-		podmanPrepareCommands,
+	commands = append(
+		commands,
 		podmanRunString,
 	)
 

--- a/tools/d2g/d2gtest/testdata/testcases/docker_image_tests.yml
+++ b/tools/d2g/d2gtest/testdata/testcases/docker_image_tests.yml
@@ -62,15 +62,16 @@ testSuite:
           - - bash
             - '-cx'
             - >-
-              curl -fsSL -o path "${TASKCLUSTER_PROXY_URL}/index/v1/task/test.namespace/artifacts/test/path"
-
-              IMAGE_NAME=$(podman load -i path | sed -n '1s/.*: //p')
-
               podman run -t --rm
               -e RUN_ID -e TASKCLUSTER_ROOT_URL -e
               TASKCLUSTER_WORKER_LOCATION -e TASK_ID
-              "${IMAGE_NAME}" 'echo "Hello world"'
+              docker-archive:path 'echo "Hello world"'
         maxRunTime: 3600
+        mounts:
+          - content:
+              artifact: test/path
+              namespace: test.namespace
+            file: path
         features:
           taskclusterProxy: true
         onExitStatus:
@@ -92,19 +93,16 @@ testSuite:
           - - bash
             - '-cx'
             - >-
-              curl -fsSL -o path.lz4 "${TASKCLUSTER_PROXY_URL}/index/v1/task/test.namespace/artifacts/test/path.lz4"
-
-              unlz4 'path.lz4'
-
-              rm 'path.lz4'
-
-              IMAGE_NAME=$(podman load -i path | sed -n '1s/.*: //p')
-
               podman run -t --rm
               -e RUN_ID -e TASKCLUSTER_ROOT_URL -e
               TASKCLUSTER_WORKER_LOCATION -e TASK_ID
-              "${IMAGE_NAME}" 'echo "Hello world"'
+              docker-archive:path.lz4 'echo "Hello world"'
         maxRunTime: 3600
+        mounts:
+          - content:
+              artifact: test/path.lz4
+              namespace: test.namespace
+            file: path.lz4
         features:
           taskclusterProxy: true
         onExitStatus:
@@ -126,19 +124,16 @@ testSuite:
           - - bash
             - '-cx'
             - >-
-              curl -fsSL -o path.zst "${TASKCLUSTER_PROXY_URL}/index/v1/task/test.namespace/artifacts/test/path.zst"
-
-              unzstd 'path.zst'
-
-              rm 'path.zst'
-
-              IMAGE_NAME=$(podman load -i path | sed -n '1s/.*: //p')
-
               podman run -t --rm
               -e RUN_ID -e TASKCLUSTER_ROOT_URL -e
               TASKCLUSTER_WORKER_LOCATION -e TASK_ID
-              "${IMAGE_NAME}" 'echo "Hello world"'
+              docker-archive:path.zst 'echo "Hello world"'
         maxRunTime: 3600
+        mounts:
+          - content:
+              artifact: test/path.zst
+              namespace: test.namespace
+            file: path.zst
         features:
           taskclusterProxy: true
         onExitStatus:
@@ -160,12 +155,10 @@ testSuite:
           - - bash
             - '-cx'
             - >-
-              IMAGE_NAME=$(podman load -i path | sed -n '1s/.*: //p')
-
               podman run -t --rm
               -e RUN_ID -e TASKCLUSTER_ROOT_URL -e
               TASKCLUSTER_WORKER_LOCATION -e TASK_ID
-              "${IMAGE_NAME}" 'echo "Hello world"'
+              docker-archive:path 'echo "Hello world"'
         mounts:
           - content:
               artifact: public/test/path
@@ -191,16 +184,10 @@ testSuite:
           - - bash
             - '-cx'
             - >-
-              unlz4 'path.lz4'
-
-              rm 'path.lz4'
-
-              IMAGE_NAME=$(podman load -i path | sed -n '1s/.*: //p')
-
               podman run -t --rm
               -e RUN_ID -e TASKCLUSTER_ROOT_URL -e
               TASKCLUSTER_WORKER_LOCATION -e TASK_ID
-              "${IMAGE_NAME}" 'echo "Hello world"'
+              docker-archive:path.lz4 'echo "Hello world"'
         mounts:
           - content:
               artifact: public/test/path.lz4
@@ -226,16 +213,10 @@ testSuite:
           - - bash
             - '-cx'
             - >-
-              unzstd 'path.zst'
-
-              rm 'path.zst'
-
-              IMAGE_NAME=$(podman load -i path | sed -n '1s/.*: //p')
-
               podman run -t --rm
               -e RUN_ID -e TASKCLUSTER_ROOT_URL -e
               TASKCLUSTER_WORKER_LOCATION -e TASK_ID
-              "${IMAGE_NAME}" 'echo "Hello world"'
+              docker-archive:path.zst 'echo "Hello world"'
         mounts:
           - content:
               artifact: public/test/path.zst

--- a/tools/d2g/d2gtest/testdata/testcases/docker_image_tests.yml
+++ b/tools/d2g/d2gtest/testdata/testcases/docker_image_tests.yml
@@ -65,13 +65,13 @@ testSuite:
               podman run -t --rm
               -e RUN_ID -e TASKCLUSTER_ROOT_URL -e
               TASKCLUSTER_WORKER_LOCATION -e TASK_ID
-              docker-archive:path 'echo "Hello world"'
+              docker-archive:dockerimage 'echo "Hello world"'
         maxRunTime: 3600
         mounts:
           - content:
               artifact: test/path
               namespace: test.namespace
-            file: path
+            file: dockerimage
         features:
           taskclusterProxy: true
         onExitStatus:
@@ -96,13 +96,14 @@ testSuite:
               podman run -t --rm
               -e RUN_ID -e TASKCLUSTER_ROOT_URL -e
               TASKCLUSTER_WORKER_LOCATION -e TASK_ID
-              docker-archive:path.lz4 'echo "Hello world"'
+              docker-archive:dockerimage 'echo "Hello world"'
         maxRunTime: 3600
         mounts:
           - content:
               artifact: test/path.lz4
               namespace: test.namespace
-            file: path.lz4
+            file: dockerimage
+            format: lz4
         features:
           taskclusterProxy: true
         onExitStatus:
@@ -127,13 +128,14 @@ testSuite:
               podman run -t --rm
               -e RUN_ID -e TASKCLUSTER_ROOT_URL -e
               TASKCLUSTER_WORKER_LOCATION -e TASK_ID
-              docker-archive:path.zst 'echo "Hello world"'
+              docker-archive:dockerimage 'echo "Hello world"'
         maxRunTime: 3600
         mounts:
           - content:
               artifact: test/path.zst
               namespace: test.namespace
-            file: path.zst
+            file: dockerimage
+            format: zst
         features:
           taskclusterProxy: true
         onExitStatus:
@@ -158,12 +160,12 @@ testSuite:
               podman run -t --rm
               -e RUN_ID -e TASKCLUSTER_ROOT_URL -e
               TASKCLUSTER_WORKER_LOCATION -e TASK_ID
-              docker-archive:path 'echo "Hello world"'
+              docker-archive:dockerimage 'echo "Hello world"'
         mounts:
           - content:
               artifact: public/test/path
               taskId: 2JGiKFtpRnGbVczc6-OJ1Q
-            file: path
+            file: dockerimage
         maxRunTime: 3600
         onExitStatus:
           retry:
@@ -187,12 +189,13 @@ testSuite:
               podman run -t --rm
               -e RUN_ID -e TASKCLUSTER_ROOT_URL -e
               TASKCLUSTER_WORKER_LOCATION -e TASK_ID
-              docker-archive:path.lz4 'echo "Hello world"'
+              docker-archive:dockerimage 'echo "Hello world"'
         mounts:
           - content:
               artifact: public/test/path.lz4
               taskId: 2JGiKFtpRnGbVczc6-OJ1Q
-            file: path.lz4
+            file: dockerimage
+            format: lz4
         maxRunTime: 3600
         onExitStatus:
           retry:
@@ -216,12 +219,13 @@ testSuite:
               podman run -t --rm
               -e RUN_ID -e TASKCLUSTER_ROOT_URL -e
               TASKCLUSTER_WORKER_LOCATION -e TASK_ID
-              docker-archive:path.zst 'echo "Hello world"'
+              docker-archive:dockerimage 'echo "Hello world"'
         mounts:
           - content:
               artifact: public/test/path.zst
               taskId: 2JGiKFtpRnGbVczc6-OJ1Q
-            file: path.zst
+            file: dockerimage
+            format: zst
         maxRunTime: 3600
         onExitStatus:
           retry:

--- a/tools/d2g/dockerimageartifact.go
+++ b/tools/d2g/dockerimageartifact.go
@@ -20,8 +20,12 @@ func (dia *DockerImageArtifact) FileMounts() ([]genericworker.FileMount, error) 
 	return []genericworker.FileMount{
 		{
 			Content: json.RawMessage(raw),
-			File:    "dockerimage",
-			Format:  fileExtension(dia.Path),
+			// Instead of trying to preserve the artifact filename, we use a
+			// hardcoded name to prevent filename collisions.
+			// This _may_ cause issues once concurrent tasks are supported
+			// on generic worker (see https://bugzil.la/1609102).
+			File:   "dockerimage",
+			Format: fileExtension(dia.Path),
 		},
 	}, nil
 }

--- a/tools/d2g/dockerimageartifact.go
+++ b/tools/d2g/dockerimageartifact.go
@@ -3,7 +3,6 @@ package d2g
 import (
 	"encoding/json"
 	"fmt"
-	"path/filepath"
 
 	"github.com/taskcluster/taskcluster/v55/tools/d2g/genericworker"
 )
@@ -21,12 +20,12 @@ func (dia *DockerImageArtifact) FileMounts() ([]genericworker.FileMount, error) 
 	return []genericworker.FileMount{
 		{
 			Content: json.RawMessage(raw),
-			// TODO check if this could conflict with other files(?)
-			File: filepath.Base(dia.Path),
+			File:    "dockerimage",
+			Format:  fileExtension(dia.Path),
 		},
 	}, nil
 }
 
 func (dia *DockerImageArtifact) String() (string, error) {
-	return fmt.Sprintf("docker-archive:%s", filepath.Base(dia.Path)), nil
+	return "docker-archive:dockerimage", nil
 }

--- a/tools/d2g/dockerimageartifact.go
+++ b/tools/d2g/dockerimageartifact.go
@@ -8,16 +8,6 @@ import (
 	"github.com/taskcluster/taskcluster/v55/tools/d2g/genericworker"
 )
 
-func (dia *DockerImageArtifact) PrepareCommands() []string {
-	commands := []string{}
-	filename := filepath.Base(dia.Path)
-	handleFileExtentions(filename, &commands)
-	// if filepath.Ext(strings.ToLower(filename)) != ".tar" {
-	//	return fmt.Errorf("docker image artifact %q has an unsupported file extension - only support .tar, .tar.lz4, .tar.zst", dia.Path)
-	// }
-	return commands
-}
-
 func (dia *DockerImageArtifact) FileMounts() ([]genericworker.FileMount, error) {
 	artifactContent := genericworker.ArtifactContent{
 		Artifact: dia.Path,
@@ -38,5 +28,5 @@ func (dia *DockerImageArtifact) FileMounts() ([]genericworker.FileMount, error) 
 }
 
 func (dia *DockerImageArtifact) String() (string, error) {
-	return `"${IMAGE_NAME}"`, nil
+	return fmt.Sprintf("docker-archive:%s", filepath.Base(dia.Path)), nil
 }

--- a/tools/d2g/dockerimagename.go
+++ b/tools/d2g/dockerimagename.go
@@ -6,10 +6,6 @@ import (
 	"github.com/taskcluster/taskcluster/v55/tools/d2g/genericworker"
 )
 
-func (din *DockerImageName) PrepareCommands() []string {
-	return []string{}
-}
-
 func (din *DockerImageName) FileMounts() ([]genericworker.FileMount, error) {
 	return []genericworker.FileMount{}, nil
 }

--- a/tools/d2g/indexeddockerimage.go
+++ b/tools/d2g/indexeddockerimage.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"path/filepath"
+	"strings"
 
 	"github.com/taskcluster/taskcluster/v55/tools/d2g/genericworker"
 )
@@ -20,12 +21,25 @@ func (idi *IndexedDockerImage) FileMounts() ([]genericworker.FileMount, error) {
 	return []genericworker.FileMount{
 		{
 			Content: json.RawMessage(raw),
-			// TODO check if this could conflict with other files(?)
-			File: filepath.Base(idi.Path),
+			File:    "dockerimage",
+			Format:  fileExtension(idi.Path),
 		},
 	}, nil
 }
 
 func (idi *IndexedDockerImage) String() (string, error) {
-	return fmt.Sprintf("docker-archive:%s", filepath.Base(idi.Path)), nil
+	return "docker-archive:dockerimage", nil
+}
+
+func fileExtension(path string) string {
+	extensionFormats := map[string]string{
+		".bz2": "bz2",
+		".gz":  "gz",
+		".lz4": "lz4",
+		".xz":  "xz",
+		".zst": "zst",
+	}
+
+	lowerExt := strings.ToLower(filepath.Ext(path))
+	return extensionFormats[lowerExt]
 }

--- a/tools/d2g/indexeddockerimage.go
+++ b/tools/d2g/indexeddockerimage.go
@@ -1,59 +1,31 @@
 package d2g
 
 import (
+	"encoding/json"
 	"fmt"
 	"path/filepath"
-	"strings"
 
-	"github.com/taskcluster/shell"
 	"github.com/taskcluster/taskcluster/v55/tools/d2g/genericworker"
 )
 
-func (idi *IndexedDockerImage) PrepareCommands() []string {
-	findArtifactURL := fmt.Sprintf("${TASKCLUSTER_PROXY_URL}/index/v1/task/%s/artifacts/%s", idi.Namespace, idi.Path)
-	filename := filepath.Base(idi.Path)
-	commands := []string{
-		fmt.Sprintf(`curl -fsSL -o %s "%s"`, filename, findArtifactURL),
-	}
-
-	handleFileExtentions(filename, &commands)
-
-	return commands
-}
-
 func (idi *IndexedDockerImage) FileMounts() ([]genericworker.FileMount, error) {
-	return []genericworker.FileMount{}, nil
+	indexedContent := genericworker.IndexedContent{
+		Artifact:  idi.Path,
+		Namespace: idi.Namespace,
+	}
+	raw, err := json.MarshalIndent(&indexedContent, "", "  ")
+	if err != nil {
+		return nil, fmt.Errorf("cannot marshal indexed content %#v into json: %w", indexedContent, err)
+	}
+	return []genericworker.FileMount{
+		{
+			Content: json.RawMessage(raw),
+			// TODO check if this could conflict with other files(?)
+			File: filepath.Base(idi.Path),
+		},
+	}, nil
 }
 
 func (idi *IndexedDockerImage) String() (string, error) {
-	return `"${IMAGE_NAME}"`, nil
-}
-
-func handleFileExtentions(filename string, commands *[]string) {
-	switch lowerExt := strings.ToLower(filepath.Ext(filename)); lowerExt {
-	case ".lz4":
-		*commands = append(
-			*commands,
-			// TODO handle spaces in file name
-			"unlz4 "+shell.Escape(filename),
-			// TODO handle spaces in file name
-			"rm "+shell.Escape(filename),
-		)
-		filename = filename[:len(filename)-len(lowerExt)]
-	case ".zst":
-		*commands = append(
-			*commands,
-			// TODO handle spaces in file name
-			"unzstd "+shell.Escape(filename),
-			// TODO handle spaces in file name
-			"rm "+shell.Escape(filename),
-		)
-		filename = filename[:len(filename)-len(lowerExt)]
-	}
-
-	*commands = append(
-		*commands,
-		// TODO handle spaces in file name
-		"IMAGE_NAME=$(podman load -i "+shell.Escape(filename)+" | sed -n '1s/.*: //p')",
-	)
+	return fmt.Sprintf("docker-archive:%s", filepath.Base(idi.Path)), nil
 }

--- a/tools/d2g/indexeddockerimage.go
+++ b/tools/d2g/indexeddockerimage.go
@@ -21,8 +21,12 @@ func (idi *IndexedDockerImage) FileMounts() ([]genericworker.FileMount, error) {
 	return []genericworker.FileMount{
 		{
 			Content: json.RawMessage(raw),
-			File:    "dockerimage",
-			Format:  fileExtension(idi.Path),
+			// Instead of trying to preserve the artifact filename, we use a
+			// hardcoded name to prevent filename collisions.
+			// This _may_ cause issues once concurrent tasks are supported
+			// on generic worker (see https://bugzil.la/1609102).
+			File:   "dockerimage",
+			Format: fileExtension(idi.Path),
 		},
 	}, nil
 }

--- a/tools/d2g/nameddockerimage.go
+++ b/tools/d2g/nameddockerimage.go
@@ -5,10 +5,6 @@ import (
 	"github.com/taskcluster/taskcluster/v55/tools/d2g/genericworker"
 )
 
-func (ndi *NamedDockerImage) PrepareCommands() []string {
-	return []string{}
-}
-
 func (ndi *NamedDockerImage) FileMounts() ([]genericworker.FileMount, error) {
 	return []genericworker.FileMount{}, nil
 }


### PR DESCRIPTION
>D2G now takes advantage of Generic Worker Indexed Artifacts, introduced in Generic Worker 51.0.0. D2G translates Indexed Docker Images into Generic Worker mounted Indexed Artifacts. Previously, D2G generated commands to query the taskcluster Index and fetch the docker image.
>With this improvement, docker images are now cached on workers, docker image dependencies between tasks are declarative (and thus inspectable), and generated Generic Worker task payloads are simpler and easier to understand.