### PR TITLE
Add explicit dependency on 's3' for the 'taskcluster' service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -115,6 +115,7 @@ services:
     networks:
       - local
     depends_on:
+      - s3
       - ui
       - web-server-web
     volumes:


### PR DESCRIPTION
`taskcluster` doesn't start without `s3`, so AFAICT this is strictly necessary.