### PR TITLE
fix(hooks): allow for 1000 characters in `hookGroupId` and `hookId`

### DIFF
--- a/changelog/issue-6569.md
+++ b/changelog/issue-6569.md
@@ -1,0 +1,5 @@
+audience: users
+level: patch
+reference: issue 6569
+---
+This patch updates the regex for the `hookGroupId` and `hookId` params for the hooks API to allow for up to 1000 characters.

--- a/services/hooks/src/api.js
+++ b/services/hooks/src/api.js
@@ -17,8 +17,8 @@ const builder = new APIBuilder({
   serviceName: 'hooks',
   apiVersion: 'v1',
   params: {
-    hookGroupId: /^[a-zA-Z0-9-_]{1,64}$/,
-    hookId: /^[a-zA-Z0-9-_\/]{1,64}$/,
+    hookGroupId: /^[a-zA-Z0-9-_]{1,1000}$/,
+    hookId: /^[a-zA-Z0-9-_\/]{1,1000}$/,
   },
   context: ['db', 'taskcreator', 'publisher', 'denylist'],
 });


### PR DESCRIPTION
Fixes https://github.com/taskcluster/taskcluster/issues/6569.

>This patch updates the regex for the `hookGroupId` and `hookId` params for the hooks API to allow for up to 1000 characters.

cc @ahal