### PR TITLE
fix(release): replace deprecated goreleaser config

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -52,7 +52,7 @@ checksum:
 brews:
   - name: taskcluster
 
-    tap:
+    repository:
       owner: taskcluster
       name: homebrew-tap
 

--- a/changelog/issue-6571.md
+++ b/changelog/issue-6571.md
@@ -1,0 +1,4 @@
+audience: general
+level: silent
+reference: issue 6571
+---

--- a/infrastructure/tooling/src/build/tasks/client-shell.js
+++ b/infrastructure/tooling/src/build/tasks/client-shell.js
@@ -14,14 +14,14 @@ module.exports = ({ tasks, cmdOptions, credentials, baseDir, logsDir }) => {
       const artifactsDir = requirements['clean-artifacts-dir'];
       await execCommand({
         dir: artifactsDir,
-        command: ['go', 'install', 'github.com/goreleaser/goreleaser@latest'],
+        command: ['go', 'install', 'github.com/goreleaser/goreleaser@v1.20.0'],
         utils,
       });
 
       let goreleaserCmd = [
         'goreleaser',
         'release',
-        '--rm-dist',
+        '--clean',
       ];
 
       if (cmdOptions.staging || !cmdOptions.push) {


### PR DESCRIPTION
Fixes #6571. View issue to see deprecation notices.

This also pins `goreleaser` to the latest version that worked on our most recent release, v1.20.0.