### PR TITLE
Fix auto cancel github builds

### DIFF
--- a/changelog/T3Tq0beoR7uea9qUvlaGXg.md
+++ b/changelog/T3Tq0beoR7uea9qUvlaGXg.md
@@ -1,0 +1,4 @@
+audience: general
+level: patch
+---
+Patches an issue in github service cancelling task groups for non-push/pull-request events

--- a/services/github/src/handlers/index.js
+++ b/services/github/src/handlers/index.js
@@ -268,7 +268,13 @@ class Handlers {
   async cancelPreviousTaskGroups({ instGithub, debug, newBuild }) {
     const { organization, repository, sha, pull_number: pullNumber,
       task_group_id: newTaskGroupId, event_type: eventType } = newBuild;
-    debug(`canceling previous task groups for ${organization}/${repository} newTaskGroupId=${newTaskGroupId} sha=${sha} PR=${pullNumber} if they exist`);
+    debug(`canceling previous task groups for ${organization}/${repository} eventType=${eventType} newTaskGroupId=${newTaskGroupId} sha=${sha} PR=${pullNumber} if they exist`);
+
+    // avoid performing cancellation for non-push and non-pull-request events
+    if (!eventType || !['push', 'pull_request'].includes(eventType.split('.')[0])) {
+      debug(`event type ${eventType} is not supported. skipping cancelPreviousTaskGroups`);
+      return;
+    }
 
     const scopes = [
       `assume:repo:github.com/${organization}/${repository}:*`,


### PR DESCRIPTION
Events were not properly checked correctly inside the cancelPreviousTaskGroup routine, assuming the caller would decided. Added check inside to make sure we don't cancel more than we should, especially since
[RFC](https://github.com/taskcluster/taskcluster-rfcs/pull/177) said we would only cancel `push` and `pull_request` events

This patch ensures only `push` and `pull_request` are cancelled