### PR TITLE
Generic Worker: Use system copy command for better logging

### DIFF
--- a/changelog/djZWGa-3S2O7AJWcR_aKfA.md
+++ b/changelog/djZWGa-3S2O7AJWcR_aKfA.md
@@ -1,0 +1,3 @@
+audience: general
+level: silent
+---

--- a/workers/generic-worker/artifacts.go
+++ b/workers/generic-worker/artifacts.go
@@ -328,7 +328,7 @@ func (task *TaskRun) uploadArtifact(artifact artifacts.TaskArtifact) *CommandExe
 	if e != nil {
 		panic(e)
 	}
-	e = artifact.ProcessResponse(resp, task, serviceFactory, config)
+	e = artifact.ProcessResponse(resp, task, serviceFactory, config, taskContext.TaskDir, taskContext.pd)
 	if e != nil {
 		task.Errorf("Error uploading artifact: %v", e)
 		return ResourceUnavailable(e)

--- a/workers/generic-worker/artifacts/artifacts.go
+++ b/workers/generic-worker/artifacts/artifacts.go
@@ -4,6 +4,7 @@ import (
 	tcclient "github.com/taskcluster/taskcluster/v55/clients/client-go"
 	"github.com/taskcluster/taskcluster/v55/internal/mocktc/tc"
 	"github.com/taskcluster/taskcluster/v55/workers/generic-worker/gwconfig"
+	"github.com/taskcluster/taskcluster/v55/workers/generic-worker/process"
 )
 
 type (
@@ -38,7 +39,7 @@ type (
 		//
 		// ProcessResponse can be an empty method if no post
 		// tcqueue.CreateArtifact steps are required.
-		ProcessResponse(response interface{}, logger Logger, serviceFactory tc.ServiceFactory, config *gwconfig.Config) error
+		ProcessResponse(response interface{}, logger Logger, serviceFactory tc.ServiceFactory, config *gwconfig.Config, directory string, pd *process.PlatformData) error
 
 		// FinishArtifact calls queue.FinishArtifact if necessary for the artifact type
 		FinishArtifact(response interface{}, queue tc.Queue, taskID, runID, name string) error

--- a/workers/generic-worker/artifacts/error.go
+++ b/workers/generic-worker/artifacts/error.go
@@ -6,6 +6,7 @@ import (
 	"github.com/taskcluster/taskcluster/v55/clients/client-go/tcqueue"
 	"github.com/taskcluster/taskcluster/v55/internal/mocktc/tc"
 	"github.com/taskcluster/taskcluster/v55/workers/generic-worker/gwconfig"
+	"github.com/taskcluster/taskcluster/v55/workers/generic-worker/process"
 )
 
 type ErrorArtifact struct {
@@ -15,7 +16,7 @@ type ErrorArtifact struct {
 	Reason  string
 }
 
-func (errArtifact *ErrorArtifact) ProcessResponse(response interface{}, logger Logger, serviceFactory tc.ServiceFactory, config *gwconfig.Config) error {
+func (errArtifact *ErrorArtifact) ProcessResponse(response interface{}, logger Logger, serviceFactory tc.ServiceFactory, config *gwconfig.Config, directory string, pd *process.PlatformData) error {
 	logger.Errorf("Uploading error artifact %v from file %v with message %q, reason %q and expiry %v", errArtifact.Name, errArtifact.Path, errArtifact.Message, errArtifact.Reason, errArtifact.Expires)
 	// TODO: process error response
 	return nil

--- a/workers/generic-worker/artifacts/link.go
+++ b/workers/generic-worker/artifacts/link.go
@@ -4,6 +4,7 @@ import (
 	"github.com/taskcluster/taskcluster/v55/clients/client-go/tcqueue"
 	"github.com/taskcluster/taskcluster/v55/internal/mocktc/tc"
 	"github.com/taskcluster/taskcluster/v55/workers/generic-worker/gwconfig"
+	"github.com/taskcluster/taskcluster/v55/workers/generic-worker/process"
 )
 
 type LinkArtifact struct {
@@ -12,7 +13,7 @@ type LinkArtifact struct {
 	ContentType string
 }
 
-func (linkArtifact *LinkArtifact) ProcessResponse(response interface{}, logger Logger, serviceFactory tc.ServiceFactory, config *gwconfig.Config) error {
+func (linkArtifact *LinkArtifact) ProcessResponse(response interface{}, logger Logger, serviceFactory tc.ServiceFactory, config *gwconfig.Config, directory string, pd *process.PlatformData) error {
 	logger.Infof("Uploading link artifact %v to artifact %v with expiry %v", linkArtifact.Name, linkArtifact.Artifact, linkArtifact.Expires)
 	// nothing to do
 	return nil

--- a/workers/generic-worker/artifacts/object.go
+++ b/workers/generic-worker/artifacts/object.go
@@ -8,6 +8,7 @@ import (
 	"github.com/taskcluster/taskcluster/v55/clients/client-go/tcqueue"
 	"github.com/taskcluster/taskcluster/v55/internal/mocktc/tc"
 	"github.com/taskcluster/taskcluster/v55/workers/generic-worker/gwconfig"
+	"github.com/taskcluster/taskcluster/v55/workers/generic-worker/process"
 )
 
 type ObjectArtifact struct {
@@ -31,7 +32,7 @@ func (a *ObjectArtifact) ResponseObject() interface{} {
 	return new(tcqueue.ObjectArtifactResponse)
 }
 
-func (a *ObjectArtifact) ProcessResponse(resp interface{}, logger Logger, serviceFactory tc.ServiceFactory, config *gwconfig.Config) (err error) {
+func (a *ObjectArtifact) ProcessResponse(resp interface{}, logger Logger, serviceFactory tc.ServiceFactory, config *gwconfig.Config, directory string, pd *process.PlatformData) (err error) {
 	response := resp.(*tcqueue.ObjectArtifactResponse)
 	logger.Infof("Uploading artifact %v from file %v with content type %q and expiry %v", a.Name, a.Path, a.ContentType, a.Expires)
 	creds := tcclient.Credentials{

--- a/workers/generic-worker/artifacts/redirect.go
+++ b/workers/generic-worker/artifacts/redirect.go
@@ -4,6 +4,7 @@ import (
 	"github.com/taskcluster/taskcluster/v55/clients/client-go/tcqueue"
 	"github.com/taskcluster/taskcluster/v55/internal/mocktc/tc"
 	"github.com/taskcluster/taskcluster/v55/workers/generic-worker/gwconfig"
+	"github.com/taskcluster/taskcluster/v55/workers/generic-worker/process"
 )
 
 type RedirectArtifact struct {
@@ -12,7 +13,7 @@ type RedirectArtifact struct {
 	ContentType string
 }
 
-func (redirectArtifact *RedirectArtifact) ProcessResponse(response interface{}, logger Logger, serviceFactory tc.ServiceFactory, config *gwconfig.Config) error {
+func (redirectArtifact *RedirectArtifact) ProcessResponse(response interface{}, logger Logger, serviceFactory tc.ServiceFactory, config *gwconfig.Config, directory string, pd *process.PlatformData) error {
 	logger.Infof("Uploading redirect artifact %v to URL %v with mime type %q and expiry %v", redirectArtifact.Name, redirectArtifact.URL, redirectArtifact.ContentType, redirectArtifact.Expires)
 	// nothing to do
 	return nil

--- a/workers/generic-worker/artifacts/s3.go
+++ b/workers/generic-worker/artifacts/s3.go
@@ -14,57 +14,119 @@ import (
 	"github.com/taskcluster/taskcluster/v55/clients/client-go/tcqueue"
 	"github.com/taskcluster/taskcluster/v55/internal/mocktc/tc"
 	"github.com/taskcluster/taskcluster/v55/workers/generic-worker/gwconfig"
+	"github.com/taskcluster/taskcluster/v55/workers/generic-worker/process"
 )
 
 type S3Artifact struct {
 	*BaseArtifact
-	// Path is the filename of the file containing the data
+	// Path is the filename of the original file containing the data
 	// for this artifact.
 	Path            string
 	ContentEncoding string
 	ContentType     string
+	// File is copied to a temp location, so that the content is frozen and
+	// can't change during file upload etc
+	TempCopyPath string
 }
 
-// createTempFileForPUTBody gzip-compresses the file at Path and
-// writes it to a temporary file in the same directory. The file path of the
-// generated temporary file is returned.  It is the responsibility of the
-// caller to delete the temporary file.
-func (s3Artifact *S3Artifact) createTempFileForPUTBody() string {
+func (s3Artifact *S3Artifact) copyToTempFile(directory string, pd *process.PlatformData) (err error) {
 	baseName := filepath.Base(s3Artifact.Path)
-	tmpFile, err := os.CreateTemp("", baseName)
+	var tempFile *os.File
+	tempFile, err = os.CreateTemp("", "stage1-"+baseName)
 	if err != nil {
-		panic(err)
+		return
 	}
-	defer tmpFile.Close()
-	var target io.Writer = tmpFile
-	if s3Artifact.ContentEncoding == "gzip" {
-		gzipLogWriter := gzip.NewWriter(tmpFile)
-		defer gzipLogWriter.Close()
-		gzipLogWriter.Name = baseName
-		target = gzipLogWriter
-	}
-	source, err := os.Open(s3Artifact.Path)
+	defer func() {
+		err2 := tempFile.Close()
+		if err == nil {
+			err = err2
+		}
+	}()
+	s3Artifact.TempCopyPath = tempFile.Name()
+	var source *os.File
+	source, err = os.Open(s3Artifact.Path)
 	if err != nil {
-		panic(err)
+		return
 	}
-	defer source.Close()
-	_, _ = io.Copy(target, source)
-	return tmpFile.Name()
+	defer func() {
+		err2 := source.Close()
+		if err == nil {
+			err = err2
+		}
+	}()
+	_, err = io.Copy(tempFile, source)
+	return
 }
 
-func (s3Artifact *S3Artifact) ProcessResponse(resp interface{}, logger Logger, serviceFactory tc.ServiceFactory, config *gwconfig.Config) (err error) {
+func (s3Artifact *S3Artifact) writeTransferContentToFile() (err error) {
+	if s3Artifact.ContentEncoding != "gzip" {
+		return
+	}
+	oldTempFile := s3Artifact.TempCopyPath
+	baseName := filepath.Base(s3Artifact.Path)
+	newTempFile, err := os.CreateTemp("", "stage2-"+baseName)
+	if err != nil {
+		return
+	}
+	defer func() {
+		err2 := newTempFile.Close()
+		if err == nil {
+			err = err2
+		}
+	}()
+	gzipLogWriter := gzip.NewWriter(newTempFile)
+	defer func() {
+		err2 := gzipLogWriter.Close()
+		if err == nil {
+			err = err2
+		}
+	}()
+	gzipLogWriter.Name = baseName
+	source, err := os.Open(oldTempFile)
+	if err != nil {
+		return
+	}
+	defer func() {
+		err2 := source.Close()
+		if err == nil {
+			err = err2
+		}
+		s3Artifact.TempCopyPath = newTempFile.Name()
+		err3 := os.Remove(oldTempFile)
+		if err == nil {
+			err = err3
+		}
+	}()
+	_, err = io.Copy(gzipLogWriter, source)
+	return
+}
+
+func (s3Artifact *S3Artifact) ProcessResponse(resp interface{}, logger Logger, serviceFactory tc.ServiceFactory, config *gwconfig.Config, directory string, pd *process.PlatformData) (err error) {
 	response := resp.(*tcqueue.S3ArtifactResponse)
 
 	logger.Infof("Uploading artifact %v from file %v with content encoding %q, mime type %q and expiry %v", s3Artifact.Name, s3Artifact.Path, s3Artifact.ContentEncoding, s3Artifact.ContentType, s3Artifact.Expires)
 
-	transferContentFile := s3Artifact.createTempFileForPUTBody()
-	defer os.Remove(transferContentFile)
+	err = s3Artifact.copyToTempFile(directory, pd)
+	if err != nil {
+		return
+	}
+	defer func(s3Artifact *S3Artifact) {
+		err2 := os.Remove(s3Artifact.TempCopyPath)
+		if err == nil {
+			err = err2
+		}
+	}(s3Artifact)
+
+	err = s3Artifact.writeTransferContentToFile()
+	if err != nil {
+		return
+	}
 
 	// perform http PUT to upload to S3...
 	httpClient := &http.Client{}
 	httpCall := func() (putResp *http.Response, tempError error, permError error) {
 		var transferContent *os.File
-		transferContent, permError = os.Open(transferContentFile)
+		transferContent, permError = os.Open(s3Artifact.TempCopyPath)
 		if permError != nil {
 			return
 		}
@@ -104,7 +166,9 @@ func (s3Artifact *S3Artifact) ProcessResponse(resp interface{}, logger Logger, s
 		}
 		return
 	}
-	putResp, putAttempts, err := httpbackoff.Retry(httpCall)
+	var putResp *http.Response
+	var putAttempts int
+	putResp, putAttempts, err = httpbackoff.Retry(httpCall)
 	log.Printf("%v put requests issued to %v", putAttempts, response.PutURL)
 	if putResp != nil {
 		defer putResp.Body.Close()
@@ -116,7 +180,7 @@ func (s3Artifact *S3Artifact) ProcessResponse(resp interface{}, logger Logger, s
 			log.Print(string(respBody))
 		}
 	}
-	return err
+	return
 }
 
 func (s3Artifact *S3Artifact) RequestObject() interface{} {


### PR DESCRIPTION
System commands such as copy (Windows) or cp (Linux/macOS/FreeBSD) provide useful output when commands fail. Elsewhere we have been using system commands for such things, let's do this for copying files too.

This is part 1, which separates out the optional gzip compression from the file copy, in preparation for using the system copy command in future.