### PR TITLE
fix(d2g): add `kvm` OS group for KVM feature

### DIFF
--- a/changelog/issue-6472.md
+++ b/changelog/issue-6472.md
@@ -1,0 +1,5 @@
+audience: users
+level: patch
+reference: issue 6472
+---
+D2G: Add the `kvm` OS group to the Generic Worker payload if the KVM device is enabled in the Docker Worker payload.

--- a/tools/d2g/d2gtest/d2g_test.go
+++ b/tools/d2g/d2gtest/d2g_test.go
@@ -33,7 +33,11 @@ func ExampleScopes_mixture() {
 		"docker-worker:capability:device:loopbackVideo:x/y/z",
 		"docker-worker:capability:device:kvm:x/y/z",
 	}
-	gwScopes := d2g.Scopes(dwScopes)
+	gwScopes, err := d2g.Scopes(dwScopes, nil)
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
 	for _, s := range gwScopes {
 		fmt.Printf("\t%#v\n", s)
 	}

--- a/tools/d2g/d2gtest/testdata/testcases/devices_tests.yml
+++ b/tools/d2g/d2gtest/testdata/testcases/devices_tests.yml
@@ -58,6 +58,8 @@ testSuite:
         onExitStatus:
           retry:
             - 125
+        osGroups:
+          - kvm
 
     - name: Video Loopback
       description: >-

--- a/tools/d2g/d2gtest/testdata/testcases/task_def_test.yml
+++ b/tools/d2g/d2gtest/testdata/testcases/task_def_test.yml
@@ -24,7 +24,7 @@ testSuite:
         deadline: '2023-10-26T17:06:09.867Z'
         expires: '2024-10-26T17:06:09.867Z'
         scopes:
-          - docker-worker:*
+          - docker-worker:apples
         payload:
           image: ubuntu:latest
           command:
@@ -32,6 +32,9 @@ testSuite:
             - '-c'
             - for ((i=1;i<=600;i++)); do echo $i; sleep 1; done
           maxRunTime: 630
+          capabilities:
+            devices:
+              kvm: true
         metadata:
           name: example-task
           owner: name@example.com
@@ -54,7 +57,7 @@ testSuite:
           command:
           - - bash
             - -cx
-            - podman run -t --rm -e RUN_ID -e TASKCLUSTER_ROOT_URL -e TASKCLUSTER_WORKER_LOCATION
+            - podman run -t --rm --device=/dev/kvm -e RUN_ID -e TASKCLUSTER_ROOT_URL -e TASKCLUSTER_WORKER_LOCATION
               -e TASK_ID ubuntu:latest /bin/bash -c 'for ((i=1;i<=600;i++)); do echo $i; sleep
               1; done'
           features:
@@ -67,6 +70,8 @@ testSuite:
           onExitStatus:
             retry:
             - 125
+          osGroups:
+            - kvm
         priority: lowest
         projectId: none
         provisionerId: proj-taskcluster
@@ -75,7 +80,8 @@ testSuite:
         routes: []
         schedulerId: taskcluster-ui
         scopes:
-          - generic-worker:*
+          - generic-worker:apples
+          - generic-worker:os-group:proj-taskcluster/gw-ubuntu-22-04/kvm
         tags: {}
         taskGroupId: PIxhISDQSDa98W9ppGUNsw
         taskQueueId: proj-taskcluster/gw-ubuntu-22-04

--- a/workers/generic-worker/payload_linux.go
+++ b/workers/generic-worker/payload_linux.go
@@ -30,7 +30,11 @@ func (task *TaskRun) convertDockerWorkerPayload() *CommandExecutionError {
 	if err != nil {
 		return executionError(internalError, errored, fmt.Errorf("failed to convert docker worker payload to a generic worker payload: %v", err))
 	}
-	task.Definition.Scopes = d2g.Scopes(task.Definition.Scopes)
+	jsonTaskDef, err := json.Marshal(task.Definition)
+	if err != nil {
+		return executionError(internalError, errored, fmt.Errorf("failed to marshal task definition to JSON: %v", err))
+	}
+	task.Definition.Scopes, err = d2g.Scopes(task.Definition.Scopes, json.RawMessage(jsonTaskDef))
 
 	// Convert gwPayload to JSON
 	d2gConvertedPayloadJSON, err := json.MarshalIndent(*gwPayload, "", "  ")


### PR DESCRIPTION
Fixes https://github.com/taskcluster/taskcluster/issues/6472.

>D2G: Add the `kvm` OS group to the Generic Worker payload if the KVM device is enabled in the Docker Worker payload.

Keeping in WIP for now until we can get a working test to prove we need the task user added to these groups.