### PR TITLE
push events are no longer cancelled, only pull_request

### DIFF
--- a/changelog/issue-6616.md
+++ b/changelog/issue-6616.md
@@ -1,0 +1,9 @@
+audience: users
+level: patch
+reference: issue 6616
+---
+
+Github service no longer cancels builds for the same SHA for `push` events.
+Only `pull_request` events would cancel running builds for the same pull request if they exist.
+
+This is to avoid canceling same commit pushed to different branches.

--- a/services/github/test/handler_test.js
+++ b/services/github/test/handler_test.js
@@ -369,8 +369,9 @@ helper.secrets.mockSuite(testing.suiteName(), [], function (mock, skipping) {
         },
       });
 
-      assert.deepEqual(sealedTaskGroups, ['aa', 'cc']);
-      assert.deepEqual(cancelledTaskGroups, ['aa', 'cc']);
+      // tasks should not cancelled for push events
+      assert.deepEqual(sealedTaskGroups, []);
+      assert.deepEqual(cancelledTaskGroups, []);
     });
 
     test('respects same event types for pull_request', async function () {
@@ -395,30 +396,6 @@ helper.secrets.mockSuite(testing.suiteName(), [], function (mock, skipping) {
       });
       assert.deepEqual(sealedTaskGroups, ['aa']);
       assert.deepEqual(cancelledTaskGroups, ['aa']);
-    });
-
-    test('respects same event types for push', async function () {
-      await addBuild({ state: 'pending', taskGroupId: 'aa', pullNumber: 3, eventType: 'pull_request.opened' });
-      await addBuild({ state: 'pending', taskGroupId: 'bb', pullNumber: 3, eventType: 'pull_request.synchronize' });
-      await addBuild({ state: 'pending', taskGroupId: 'cc', pullNumber: 3, eventType: 'pull_request.closed' });
-      await addBuild({ state: 'pending', taskGroupId: 'dd', pullNumber: 3, eventType: 'pull_request.assigned' });
-      await addBuild({ state: 'pending', taskGroupId: 'ee', pullNumber: null, eventType: 'tag' });
-      await addBuild({ state: 'pending', taskGroupId: 'ff', pullNumber: null, eventType: 'push' });
-
-      await handlers.realCancelPreviousTaskGroups({
-        instGithub: sinon.stub(),
-        debug: sinon.stub(),
-        newBuild: {
-          sha: COMMIT_SHA,
-          task_group_id: 'gg',
-          organization: 'TaskclusterRobot',
-          repository: 'hooks-testing',
-          event_type: 'push',
-        },
-      });
-
-      assert.deepEqual(sealedTaskGroups, ['ff']);
-      assert.deepEqual(cancelledTaskGroups, ['ff']);
     });
 
     test('cancels nothing on release event', async function () {

--- a/ui/docs/reference/integrations/github/taskcluster-yml-v1.mdx
+++ b/ui/docs/reference/integrations/github/taskcluster-yml-v1.mdx
@@ -33,7 +33,7 @@ Policies are not rendered as a part of a task.
 
 The `autoCancelPreviousChecks` property controls whether or not to automatically cancel previous builds when a new build is triggered.
 This is useful for example when a new commit is pushed to a pull request, and you want to cancel the previous build for that pull request.
-This only works on non-default branches.
+This only works on pull requests.
 
 It is set to `true` by default.
 


### PR DESCRIPTION
This is to prevent cancelling builds two builds for the same commit, as they might belong to different branches.

And to keep it simple we only cancel `pull_request` events.


Fixes #6616
