### PR TITLE
Allow specifying `0` as a value for `onExitStatus.purgeCaches`

### DIFF
--- a/changelog/cBmAFvklRfu3hYByRUiRGA.md
+++ b/changelog/cBmAFvklRfu3hYByRUiRGA.md
@@ -1,0 +1,4 @@
+audience: users
+level: patch
+---
+Allow specifying `0` as a value for `onExitStatus.purgeCaches`.

--- a/generated/references.json
+++ b/generated/references.json
@@ -8036,7 +8036,7 @@
             "purgeCaches": {
               "description": "If the task exits with a purge caches exit status, all caches\nassociated with the task will be purged.\n\nSince: generic-worker 49.0.0",
               "items": {
-                "minimum": 1,
+                "minimum": 0,
                 "title": "Exit statuses",
                 "type": "integer"
               },
@@ -8489,7 +8489,7 @@
             "purgeCaches": {
               "description": "If the task exits with a purge caches exit status, all caches\nassociated with the task will be purged.\n\nSince: generic-worker 49.0.0",
               "items": {
-                "minimum": 1,
+                "minimum": 0,
                 "title": "Exit statuses",
                 "type": "integer"
               },
@@ -8991,7 +8991,7 @@
                 "purgeCaches": {
                   "description": "If the task exits with a purge caches exit status, all caches\nassociated with the task will be purged.\n\nSince: generic-worker 49.0.0",
                   "items": {
-                    "minimum": 1,
+                    "minimum": 0,
                     "title": "Exit statuses",
                     "type": "integer"
                   },

--- a/tools/d2g/genericworker/generated_types.go
+++ b/tools/d2g/genericworker/generated_types.go
@@ -300,7 +300,7 @@ type (
 		// Since: generic-worker 49.0.0
 		//
 		// Array items:
-		// Mininum:    1
+		// Mininum:    0
 		PurgeCaches []int64 `json:"purgeCaches,omitempty"`
 
 		// Exit codes for any command in the task payload to cause this task to
@@ -1185,7 +1185,7 @@ func JSONSchema() string {
             "purgeCaches": {
               "description": "If the task exits with a purge caches exit status, all caches\nassociated with the task will be purged.\n\nSince: generic-worker 49.0.0",
               "items": {
-                "minimum": 1,
+                "minimum": 0,
                 "title": "Exit statuses",
                 "type": "integer"
               },

--- a/workers/generic-worker/generated_multiuser_darwin.go
+++ b/workers/generic-worker/generated_multiuser_darwin.go
@@ -302,7 +302,7 @@ type (
 		// Since: generic-worker 49.0.0
 		//
 		// Array items:
-		// Mininum:    1
+		// Mininum:    0
 		PurgeCaches []int64 `json:"purgeCaches,omitempty"`
 
 		// Exit codes for any command in the task payload to cause this task to
@@ -1187,7 +1187,7 @@ func JSONSchema() string {
             "purgeCaches": {
               "description": "If the task exits with a purge caches exit status, all caches\nassociated with the task will be purged.\n\nSince: generic-worker 49.0.0",
               "items": {
-                "minimum": 1,
+                "minimum": 0,
                 "title": "Exit statuses",
                 "type": "integer"
               },

--- a/workers/generic-worker/generated_multiuser_freebsd.go
+++ b/workers/generic-worker/generated_multiuser_freebsd.go
@@ -302,7 +302,7 @@ type (
 		// Since: generic-worker 49.0.0
 		//
 		// Array items:
-		// Mininum:    1
+		// Mininum:    0
 		PurgeCaches []int64 `json:"purgeCaches,omitempty"`
 
 		// Exit codes for any command in the task payload to cause this task to
@@ -1187,7 +1187,7 @@ func JSONSchema() string {
             "purgeCaches": {
               "description": "If the task exits with a purge caches exit status, all caches\nassociated with the task will be purged.\n\nSince: generic-worker 49.0.0",
               "items": {
-                "minimum": 1,
+                "minimum": 0,
                 "title": "Exit statuses",
                 "type": "integer"
               },

--- a/workers/generic-worker/generated_multiuser_linux.go
+++ b/workers/generic-worker/generated_multiuser_linux.go
@@ -302,7 +302,7 @@ type (
 		// Since: generic-worker 49.0.0
 		//
 		// Array items:
-		// Mininum:    1
+		// Mininum:    0
 		PurgeCaches []int64 `json:"purgeCaches,omitempty"`
 
 		// Exit codes for any command in the task payload to cause this task to
@@ -1187,7 +1187,7 @@ func JSONSchema() string {
             "purgeCaches": {
               "description": "If the task exits with a purge caches exit status, all caches\nassociated with the task will be purged.\n\nSince: generic-worker 49.0.0",
               "items": {
-                "minimum": 1,
+                "minimum": 0,
                 "title": "Exit statuses",
                 "type": "integer"
               },

--- a/workers/generic-worker/generated_multiuser_windows.go
+++ b/workers/generic-worker/generated_multiuser_windows.go
@@ -139,7 +139,7 @@ type (
 		// Since: generic-worker 49.0.0
 		//
 		// Array items:
-		// Mininum:    1
+		// Mininum:    0
 		PurgeCaches []int64 `json:"purgeCaches,omitempty"`
 
 		// Exit codes for any command in the task payload to cause this task to
@@ -920,7 +920,7 @@ func JSONSchema() string {
         "purgeCaches": {
           "description": "If the task exits with a purge caches exit status, all caches\nassociated with the task will be purged.\n\nSince: generic-worker 49.0.0",
           "items": {
-            "minimum": 1,
+            "minimum": 0,
             "title": "Exit statuses",
             "type": "integer"
           },

--- a/workers/generic-worker/generated_simple_darwin.go
+++ b/workers/generic-worker/generated_simple_darwin.go
@@ -140,7 +140,7 @@ type (
 		// Since: generic-worker 49.0.0
 		//
 		// Array items:
-		// Mininum:    1
+		// Mininum:    0
 		PurgeCaches []int64 `json:"purgeCaches,omitempty"`
 
 		// Exit codes for any command in the task payload to cause this task to
@@ -916,7 +916,7 @@ func JSONSchema() string {
         "purgeCaches": {
           "description": "If the task exits with a purge caches exit status, all caches\nassociated with the task will be purged.\n\nSince: generic-worker 49.0.0",
           "items": {
-            "minimum": 1,
+            "minimum": 0,
             "title": "Exit statuses",
             "type": "integer"
           },

--- a/workers/generic-worker/generated_simple_freebsd.go
+++ b/workers/generic-worker/generated_simple_freebsd.go
@@ -140,7 +140,7 @@ type (
 		// Since: generic-worker 49.0.0
 		//
 		// Array items:
-		// Mininum:    1
+		// Mininum:    0
 		PurgeCaches []int64 `json:"purgeCaches,omitempty"`
 
 		// Exit codes for any command in the task payload to cause this task to
@@ -916,7 +916,7 @@ func JSONSchema() string {
         "purgeCaches": {
           "description": "If the task exits with a purge caches exit status, all caches\nassociated with the task will be purged.\n\nSince: generic-worker 49.0.0",
           "items": {
-            "minimum": 1,
+            "minimum": 0,
             "title": "Exit statuses",
             "type": "integer"
           },

--- a/workers/generic-worker/generated_simple_linux.go
+++ b/workers/generic-worker/generated_simple_linux.go
@@ -140,7 +140,7 @@ type (
 		// Since: generic-worker 49.0.0
 		//
 		// Array items:
-		// Mininum:    1
+		// Mininum:    0
 		PurgeCaches []int64 `json:"purgeCaches,omitempty"`
 
 		// Exit codes for any command in the task payload to cause this task to
@@ -916,7 +916,7 @@ func JSONSchema() string {
         "purgeCaches": {
           "description": "If the task exits with a purge caches exit status, all caches\nassociated with the task will be purged.\n\nSince: generic-worker 49.0.0",
           "items": {
-            "minimum": 1,
+            "minimum": 0,
             "title": "Exit statuses",
             "type": "integer"
           },

--- a/workers/generic-worker/purge_caches_test.go
+++ b/workers/generic-worker/purge_caches_test.go
@@ -267,7 +267,7 @@ func TestPurgeCachesNegativeExitCode(t *testing.T) {
 	_ = submitAndAssert(t, td, payload, "exception", "malformed-payload")
 
 	logtext := LogText(t)
-	substring := "onExitStatus.purgeCaches.0: Must be greater than or equal to 1"
+	substring := "onExitStatus.purgeCaches.0: Must be greater than or equal to 0"
 	if !strings.Contains(logtext, substring) {
 		t.Log(logtext)
 		t.Fatalf("Was expecting log to contain string %v.", substring)

--- a/workers/generic-worker/schemas/multiuser_posix.yml
+++ b/workers/generic-worker/schemas/multiuser_posix.yml
@@ -358,7 +358,7 @@ oneOf:
           items:
             title: Exit statuses
             type: integer
-            minimum: 1
+            minimum: 0
     logs:
       title: Logs
       description: |-

--- a/workers/generic-worker/schemas/multiuser_windows.yml
+++ b/workers/generic-worker/schemas/multiuser_windows.yml
@@ -316,7 +316,7 @@ properties:
         items:
           title: Exit statuses
           type: integer
-          minimum: 1
+          minimum: 0
   rdpInfo:
     type: string
     title: RDP Info

--- a/workers/generic-worker/schemas/simple_posix.yml
+++ b/workers/generic-worker/schemas/simple_posix.yml
@@ -336,7 +336,7 @@ properties:
         items:
           title: Exit statuses
           type: integer
-          minimum: 1
+          minimum: 0
   logs:
     title: Logs
     description: |-


### PR DESCRIPTION
I was trying to abuse the caching system to download a binary that I was developing on another machine to run in a task. Took me by surprise that it didn't allow automatically purging the cache when the command succeeded. As far as I can tell, docker-worker did not have such a limit and I don't see why there should be one anyway.
