### PR TITLE
chore(ci): add deps to help not waste resources

### DIFF
--- a/changelog/issue-6621.md
+++ b/changelog/issue-6621.md
@@ -1,0 +1,4 @@
+audience: general
+level: silent
+reference: issue 6621
+---

--- a/taskcluster/ci/generic-worker/kind.yml
+++ b/taskcluster/ci/generic-worker/kind.yml
@@ -9,7 +9,12 @@ transforms:
   - taskgraph.transforms.job:transforms
   - taskgraph.transforms.task:transforms
 
+kind-dependencies:
+  - lint
+
 task-defaults:
+  dependencies:
+    lint: lint-golang
   run:
     using: bare
   worker:

--- a/taskcluster/ci/meta/kind.yml
+++ b/taskcluster/ci/meta/kind.yml
@@ -8,6 +8,9 @@ transforms:
   - taskgraph.transforms.job:transforms
   - taskgraph.transforms.task:transforms
 
+kind-dependencies:
+  - lint
+
 task-defaults:
   worker-type: gw-ubuntu-22-04
   run:
@@ -24,6 +27,8 @@ tasks:
         yarn &&
         set -o pipefail && yarn test:meta | cat
   generate:
+    dependencies:
+      lint: lint-golang
     description: check that `yarn generate` was run
     run:
       command: >-

--- a/taskcluster/src/transforms/__init__.py
+++ b/taskcluster/src/transforms/__init__.py
@@ -141,14 +141,6 @@ def podman_run(config, tasks):
 
 
 @transforms.add
-def direct_dependencies(config, tasks):
-    for task in tasks:
-        task.setdefault("soft-dependencies", [])
-        task["soft-dependencies"] += [task.label for task in config.kind_dependencies_tasks]
-        yield task
-
-
-@transforms.add
 def parameterize_mounts(config, tasks):
     node_version, go_version, golangci_lint_version, rust_version, _ = _dependency_versions()
     for task in tasks:


### PR DESCRIPTION
Fixes #6621.

This only applied to the go tasks, as they'd fail if there was a lint error.