### PR TITLE
feat(docker): Move image names into .env file

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,3 @@
+IMAGE=taskcluster/taskcluster:v56.0.3
+IMAGE_DEV=taskcluster/taskcluster:v56.0.3-devel
+IMAGE_GENERIC_WORKER=taskcluster/generic-worker:v56.0.3

--- a/changelog/RxEk8HJ3QDKaVsXGGYga1w.md
+++ b/changelog/RxEk8HJ3QDKaVsXGGYga1w.md
@@ -1,0 +1,5 @@
+audience: developers
+level: patch
+---
+
+Move docker compose image names to `.env` file to keep compose files unchanged between releases.

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -18,21 +18,21 @@ services:
       - ./ui:/app/ui
       - ./CHANGELOG.md:/app/CHANGELOG.md
   generic-worker-standalone:
-    image: taskcluster/generic-worker:v56.0.3
+    image: ${IMAGE_GENERIC_WORKER}
     networks:
       - local
     build:
       context: .
       dockerfile: generic-worker.Dockerfile
   generic-worker-static:
-    image: taskcluster/generic-worker:v56.0.3
+    image: ${IMAGE_GENERIC_WORKER}
     networks:
       - local
     build:
       context: .
       dockerfile: generic-worker.Dockerfile
   auth-web:
-    image: taskcluster/taskcluster:v56.0.3-devel
+    image: ${IMAGE_DEV}
     environment:
       NODE_ENV: development
       DEBUG: '*'
@@ -45,7 +45,7 @@ services:
     command: ''
     entrypoint: /bin/sh -c "nodemon --delay 3 --watch services --watch libraries --watch services/auth services/auth/src/main.js server"
   auth-cron-purgeExpiredClients:
-    image: taskcluster/taskcluster:v56.0.3-devel
+    image: ${IMAGE_DEV}
     environment:
       NODE_ENV: development
       DEBUG: '*'
@@ -62,7 +62,7 @@ services:
     command: ''
     entrypoint: /bin/sh -c "nodemon --delay 3 --watch services --watch libraries --watch services/auth services/auth/src/main.js purge-expired-clients"
   built-in-workers-server:
-    image: taskcluster/taskcluster:v56.0.3-devel
+    image: ${IMAGE_DEV}
     environment:
       NODE_ENV: development
       DEBUG: '*'
@@ -75,7 +75,7 @@ services:
     command: ''
     entrypoint: /bin/sh -c "nodemon --delay 3 --watch services --watch libraries --watch services/built-in-workers services/built-in-workers/src/main.js server"
   github-web:
-    image: taskcluster/taskcluster:v56.0.3-devel
+    image: ${IMAGE_DEV}
     environment:
       NODE_ENV: development
       DEBUG: '*'
@@ -88,7 +88,7 @@ services:
     command: ''
     entrypoint: /bin/sh -c "nodemon --delay 3 --watch services --watch libraries --watch services/github services/github/src/main.js server"
   github-background-worker:
-    image: taskcluster/taskcluster:v56.0.3-devel
+    image: ${IMAGE_DEV}
     environment:
       NODE_ENV: development
       DEBUG: '*'
@@ -105,7 +105,7 @@ services:
     command: ''
     entrypoint: /bin/sh -c "nodemon --delay 3 --watch services --watch libraries --watch services/github services/github/src/main.js worker"
   github-cron-sync:
-    image: taskcluster/taskcluster:v56.0.3-devel
+    image: ${IMAGE_DEV}
     environment:
       NODE_ENV: development
       DEBUG: '*'
@@ -122,7 +122,7 @@ services:
     command: ''
     entrypoint: /bin/sh -c "nodemon --delay 3 --watch services --watch libraries --watch services/github services/github/src/main.js syncInstallations"
   hooks-web:
-    image: taskcluster/taskcluster:v56.0.3-devel
+    image: ${IMAGE_DEV}
     environment:
       NODE_ENV: development
       DEBUG: '*'
@@ -135,7 +135,7 @@ services:
     command: ''
     entrypoint: /bin/sh -c "nodemon --delay 3 --watch services --watch libraries --watch services/hooks services/hooks/src/main.js server"
   hooks-background-scheduler:
-    image: taskcluster/taskcluster:v56.0.3-devel
+    image: ${IMAGE_DEV}
     environment:
       NODE_ENV: development
       DEBUG: '*'
@@ -152,7 +152,7 @@ services:
     command: ''
     entrypoint: /bin/sh -c "nodemon --delay 3 --watch services --watch libraries --watch services/hooks services/hooks/src/main.js scheduler"
   hooks-background-listeners:
-    image: taskcluster/taskcluster:v56.0.3-devel
+    image: ${IMAGE_DEV}
     environment:
       NODE_ENV: development
       DEBUG: '*'
@@ -169,7 +169,7 @@ services:
     command: ''
     entrypoint: /bin/sh -c "nodemon --delay 3 --watch services --watch libraries --watch services/hooks services/hooks/src/main.js listeners"
   hooks-cron-expires:
-    image: taskcluster/taskcluster:v56.0.3-devel
+    image: ${IMAGE_DEV}
     environment:
       NODE_ENV: development
       DEBUG: '*'
@@ -186,7 +186,7 @@ services:
     command: ''
     entrypoint: /bin/sh -c "nodemon --delay 3 --watch services --watch libraries --watch services/hooks services/hooks/src/main.js expires"
   index-web:
-    image: taskcluster/taskcluster:v56.0.3-devel
+    image: ${IMAGE_DEV}
     environment:
       NODE_ENV: development
       DEBUG: '*'
@@ -199,7 +199,7 @@ services:
     command: ''
     entrypoint: /bin/sh -c "nodemon --delay 3 --watch services --watch libraries --watch services/index services/index/src/main.js server"
   index-background-handlers:
-    image: taskcluster/taskcluster:v56.0.3-devel
+    image: ${IMAGE_DEV}
     environment:
       NODE_ENV: development
       DEBUG: '*'
@@ -216,7 +216,7 @@ services:
     command: ''
     entrypoint: /bin/sh -c "nodemon --delay 3 --watch services --watch libraries --watch services/index services/index/src/main.js handlers"
   index-cron-expire:
-    image: taskcluster/taskcluster:v56.0.3-devel
+    image: ${IMAGE_DEV}
     environment:
       NODE_ENV: development
       DEBUG: '*'
@@ -233,7 +233,7 @@ services:
     command: ''
     entrypoint: /bin/sh -c "nodemon --delay 3 --watch services --watch libraries --watch services/index services/index/src/main.js expire"
   notify-web:
-    image: taskcluster/taskcluster:v56.0.3-devel
+    image: ${IMAGE_DEV}
     environment:
       NODE_ENV: development
       DEBUG: '*'
@@ -246,7 +246,7 @@ services:
     command: ''
     entrypoint: /bin/sh -c "nodemon --delay 3 --watch services --watch libraries --watch services/notify services/notify/src/main.js server"
   notify-background-handler:
-    image: taskcluster/taskcluster:v56.0.3-devel
+    image: ${IMAGE_DEV}
     environment:
       NODE_ENV: development
       DEBUG: '*'
@@ -263,7 +263,7 @@ services:
     command: ''
     entrypoint: /bin/sh -c "nodemon --delay 3 --watch services --watch libraries --watch services/notify services/notify/src/main.js handler"
   object-web:
-    image: taskcluster/taskcluster:v56.0.3-devel
+    image: ${IMAGE_DEV}
     environment:
       NODE_ENV: development
       DEBUG: '*'
@@ -276,7 +276,7 @@ services:
     command: ''
     entrypoint: /bin/sh -c "nodemon --delay 3 --watch services --watch libraries --watch services/object services/object/src/main.js server"
   object-cron-expire:
-    image: taskcluster/taskcluster:v56.0.3-devel
+    image: ${IMAGE_DEV}
     environment:
       NODE_ENV: development
       DEBUG: '*'
@@ -293,7 +293,7 @@ services:
     command: ''
     entrypoint: /bin/sh -c "nodemon --delay 3 --watch services --watch libraries --watch services/object services/object/src/main.js expire"
   purge-cache-web:
-    image: taskcluster/taskcluster:v56.0.3-devel
+    image: ${IMAGE_DEV}
     environment:
       NODE_ENV: development
       DEBUG: '*'
@@ -306,7 +306,7 @@ services:
     command: ''
     entrypoint: /bin/sh -c "nodemon --delay 3 --watch services --watch libraries --watch services/purge-cache services/purge-cache/src/main.js server"
   purge-cache-cron-expireCachePurges:
-    image: taskcluster/taskcluster:v56.0.3-devel
+    image: ${IMAGE_DEV}
     environment:
       NODE_ENV: development
       DEBUG: '*'
@@ -323,7 +323,7 @@ services:
     command: ''
     entrypoint: /bin/sh -c "nodemon --delay 3 --watch services --watch libraries --watch services/purge-cache services/purge-cache/src/main.js expire-cache-purges"
   queue-web:
-    image: taskcluster/taskcluster:v56.0.3-devel
+    image: ${IMAGE_DEV}
     environment:
       NODE_ENV: development
       DEBUG: '*'
@@ -336,7 +336,7 @@ services:
     command: ''
     entrypoint: /bin/sh -c "nodemon --delay 3 --watch services --watch libraries --watch services/queue services/queue/src/main.js server"
   queue-background-claimResolver:
-    image: taskcluster/taskcluster:v56.0.3-devel
+    image: ${IMAGE_DEV}
     environment:
       NODE_ENV: development
       DEBUG: '*'
@@ -353,7 +353,7 @@ services:
     command: ''
     entrypoint: /bin/sh -c "nodemon --delay 3 --watch services --watch libraries --watch services/queue services/queue/src/main.js claim-resolver"
   queue-background-deadlineResolver:
-    image: taskcluster/taskcluster:v56.0.3-devel
+    image: ${IMAGE_DEV}
     environment:
       NODE_ENV: development
       DEBUG: '*'
@@ -370,7 +370,7 @@ services:
     command: ''
     entrypoint: /bin/sh -c "nodemon --delay 3 --watch services --watch libraries --watch services/queue services/queue/src/main.js deadline-resolver"
   queue-background-dependencyResolver:
-    image: taskcluster/taskcluster:v56.0.3-devel
+    image: ${IMAGE_DEV}
     environment:
       NODE_ENV: development
       DEBUG: '*'
@@ -387,7 +387,7 @@ services:
     command: ''
     entrypoint: /bin/sh -c "nodemon --delay 3 --watch services --watch libraries --watch services/queue services/queue/src/main.js dependency-resolver"
   queue-cron-expireArtifacts:
-    image: taskcluster/taskcluster:v56.0.3-devel
+    image: ${IMAGE_DEV}
     environment:
       NODE_ENV: development
       DEBUG: '*'
@@ -404,7 +404,7 @@ services:
     command: ''
     entrypoint: /bin/sh -c "nodemon --delay 3 --watch services --watch libraries --watch services/queue services/queue/src/main.js expire-artifacts"
   queue-cron-expireTask:
-    image: taskcluster/taskcluster:v56.0.3-devel
+    image: ${IMAGE_DEV}
     environment:
       NODE_ENV: development
       DEBUG: '*'
@@ -421,7 +421,7 @@ services:
     command: ''
     entrypoint: /bin/sh -c "nodemon --delay 3 --watch services --watch libraries --watch services/queue services/queue/src/main.js expire-tasks"
   queue-cron-expireTaskGroups:
-    image: taskcluster/taskcluster:v56.0.3-devel
+    image: ${IMAGE_DEV}
     environment:
       NODE_ENV: development
       DEBUG: '*'
@@ -438,7 +438,7 @@ services:
     command: ''
     entrypoint: /bin/sh -c "nodemon --delay 3 --watch services --watch libraries --watch services/queue services/queue/src/main.js expire-task-groups"
   queue-cron-expireTaskDependency:
-    image: taskcluster/taskcluster:v56.0.3-devel
+    image: ${IMAGE_DEV}
     environment:
       NODE_ENV: development
       DEBUG: '*'
@@ -455,7 +455,7 @@ services:
     command: ''
     entrypoint: /bin/sh -c "nodemon --delay 3 --watch services --watch libraries --watch services/queue services/queue/src/main.js expire-task-dependency"
   queue-cron-expireQueueMessages:
-    image: taskcluster/taskcluster:v56.0.3-devel
+    image: ${IMAGE_DEV}
     environment:
       NODE_ENV: development
       DEBUG: '*'
@@ -472,7 +472,7 @@ services:
     command: ''
     entrypoint: /bin/sh -c "nodemon --delay 3 --watch services --watch libraries --watch services/queue services/queue/src/main.js expire-queue-messages"
   queue-cron-expireWorkerInfo:
-    image: taskcluster/taskcluster:v56.0.3-devel
+    image: ${IMAGE_DEV}
     environment:
       NODE_ENV: development
       DEBUG: '*'
@@ -489,7 +489,7 @@ services:
     command: ''
     entrypoint: /bin/sh -c "nodemon --delay 3 --watch services --watch libraries --watch services/queue services/queue/src/main.js expire-worker-info"
   secrets-web:
-    image: taskcluster/taskcluster:v56.0.3-devel
+    image: ${IMAGE_DEV}
     environment:
       NODE_ENV: development
       DEBUG: '*'
@@ -502,7 +502,7 @@ services:
     command: ''
     entrypoint: /bin/sh -c "nodemon --delay 3 --watch services --watch libraries --watch services/secrets services/secrets/src/main.js server"
   secrets-cron-expire:
-    image: taskcluster/taskcluster:v56.0.3-devel
+    image: ${IMAGE_DEV}
     environment:
       NODE_ENV: development
       DEBUG: '*'
@@ -519,7 +519,7 @@ services:
     command: ''
     entrypoint: /bin/sh -c "nodemon --delay 3 --watch services --watch libraries --watch services/secrets services/secrets/src/main.js expire"
   web-server-web:
-    image: taskcluster/taskcluster:v56.0.3-devel
+    image: ${IMAGE_DEV}
     environment:
       NODE_ENV: development
       DEBUG: '*'
@@ -532,7 +532,7 @@ services:
     command: ''
     entrypoint: /bin/sh -c "nodemon --delay 3 --watch services --watch libraries --watch services/web-server services/web-server/src/main.js server"
   web-server-cron-scanner:
-    image: taskcluster/taskcluster:v56.0.3-devel
+    image: ${IMAGE_DEV}
     environment:
       NODE_ENV: development
       DEBUG: '*'
@@ -549,7 +549,7 @@ services:
     command: ''
     entrypoint: /bin/sh -c "nodemon --delay 3 --watch services --watch libraries --watch services/web-server services/web-server/src/main.js scanner"
   web-server-cron-cleanup-expire-auth-codes:
-    image: taskcluster/taskcluster:v56.0.3-devel
+    image: ${IMAGE_DEV}
     environment:
       NODE_ENV: development
       DEBUG: '*'
@@ -566,7 +566,7 @@ services:
     command: ''
     entrypoint: /bin/sh -c "nodemon --delay 3 --watch services --watch libraries --watch services/web-server services/web-server/src/main.js cleanup-expire-auth-codes"
   web-server-cron-cleanup-expire-access-tokens:
-    image: taskcluster/taskcluster:v56.0.3-devel
+    image: ${IMAGE_DEV}
     environment:
       NODE_ENV: development
       DEBUG: '*'
@@ -583,7 +583,7 @@ services:
     command: ''
     entrypoint: /bin/sh -c "nodemon --delay 3 --watch services --watch libraries --watch services/web-server services/web-server/src/main.js cleanup-expire-access-tokens"
   worker-manager-web:
-    image: taskcluster/taskcluster:v56.0.3-devel
+    image: ${IMAGE_DEV}
     environment:
       NODE_ENV: development
       DEBUG: '*'
@@ -596,7 +596,7 @@ services:
     command: ''
     entrypoint: /bin/sh -c "nodemon --delay 3 --watch services --watch libraries --watch services/worker-manager services/worker-manager/src/main.js server"
   worker-manager-background-provisioner:
-    image: taskcluster/taskcluster:v56.0.3-devel
+    image: ${IMAGE_DEV}
     environment:
       NODE_ENV: development
       DEBUG: '*'
@@ -613,7 +613,7 @@ services:
     command: ''
     entrypoint: /bin/sh -c "nodemon --delay 3 --watch services --watch libraries --watch services/worker-manager services/worker-manager/src/main.js runProvisioner"
   worker-manager-background-workerscanner:
-    image: taskcluster/taskcluster:v56.0.3-devel
+    image: ${IMAGE_DEV}
     environment:
       NODE_ENV: development
       DEBUG: '*'
@@ -630,7 +630,7 @@ services:
     command: ''
     entrypoint: /bin/sh -c "nodemon --delay 3 --watch services --watch libraries --watch services/worker-manager services/worker-manager/src/main.js workerScanner"
   worker-manager-background-workerscanner-azure:
-    image: taskcluster/taskcluster:v56.0.3-devel
+    image: ${IMAGE_DEV}
     environment:
       NODE_ENV: development
       DEBUG: '*'
@@ -647,7 +647,7 @@ services:
     command: ''
     entrypoint: /bin/sh -c "nodemon --delay 3 --watch services --watch libraries --watch services/worker-manager services/worker-manager/src/main.js workerScannerAzure"
   worker-manager-cron-expire-workers:
-    image: taskcluster/taskcluster:v56.0.3-devel
+    image: ${IMAGE_DEV}
     environment:
       NODE_ENV: development
       DEBUG: '*'
@@ -664,7 +664,7 @@ services:
     command: ''
     entrypoint: /bin/sh -c "nodemon --delay 3 --watch services --watch libraries --watch services/worker-manager services/worker-manager/src/main.js expireWorkers"
   worker-manager-cron-expire-worker-pools:
-    image: taskcluster/taskcluster:v56.0.3-devel
+    image: ${IMAGE_DEV}
     environment:
       NODE_ENV: development
       DEBUG: '*'
@@ -681,7 +681,7 @@ services:
     command: ''
     entrypoint: /bin/sh -c "nodemon --delay 3 --watch services --watch libraries --watch services/worker-manager services/worker-manager/src/main.js expireWorkerPools"
   worker-manager-cron-expire-errors:
-    image: taskcluster/taskcluster:v56.0.3-devel
+    image: ${IMAGE_DEV}
     environment:
       NODE_ENV: development
       DEBUG: '*'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,7 +43,7 @@ services:
       retries: 100
       start_period: 3s
   pg_init_db:
-    image: taskcluster/taskcluster:v56.0.3
+    image: ${IMAGE}
     networks:
       - local
     x-info: Run this first to bring database up to date
@@ -94,7 +94,7 @@ services:
       MINIO_ROOT_USER: minioadmin
       MINIO_ROOT_PASSWORD: miniopassword
   ui:
-    image: taskcluster/taskcluster:v56.0.3
+    image: ${IMAGE}
     networks:
       - local
     env_file: ./docker/env/.ui
@@ -104,7 +104,7 @@ services:
     ports:
       - '3022:80'
   references:
-    image: taskcluster/taskcluster:v56.0.3
+    image: ${IMAGE}
     networks:
       - local
     command: references/web
@@ -159,7 +159,7 @@ services:
       taskcluster:
         condition: service_healthy
   generic-worker-standalone:
-    image: taskcluster/generic-worker:v56.0.3
+    image: ${IMAGE_GENERIC_WORKER}
     networks:
       - local
     restart: unless-stopped
@@ -185,7 +185,7 @@ services:
     ports:
       - '59999:59999'
   generic-worker-static:
-    image: taskcluster/generic-worker:v56.0.3
+    image: ${IMAGE_GENERIC_WORKER}
     networks:
       - local
     restart: unless-stopped
@@ -213,7 +213,7 @@ services:
     ports:
       - '59999:59999'
   auth-web:
-    image: taskcluster/taskcluster:v56.0.3
+    image: ${IMAGE}
     networks:
       - local
     env_file: ./docker/env/.auth
@@ -233,7 +233,7 @@ services:
     ports:
       - '3011:80'
   auth-cron-purgeExpiredClients:
-    image: taskcluster/taskcluster:v56.0.3
+    image: ${IMAGE}
     networks:
       - local
     env_file: ./docker/env/.auth
@@ -249,7 +249,7 @@ services:
       - auth
       - auth-cron
   built-in-workers-server:
-    image: taskcluster/taskcluster:v56.0.3
+    image: ${IMAGE}
     networks:
       - local
     env_file: ./docker/env/.built-in-workers
@@ -263,7 +263,7 @@ services:
       queue-web:
         condition: service_healthy
   github-web:
-    image: taskcluster/taskcluster:v56.0.3
+    image: ${IMAGE}
     networks:
       - local
     env_file: ./docker/env/.github
@@ -283,7 +283,7 @@ services:
     ports:
       - '3012:80'
   github-background-worker:
-    image: taskcluster/taskcluster:v56.0.3
+    image: ${IMAGE}
     networks:
       - local
     env_file: ./docker/env/.github
@@ -299,7 +299,7 @@ services:
       - github
       - github-background
   github-cron-sync:
-    image: taskcluster/taskcluster:v56.0.3
+    image: ${IMAGE}
     networks:
       - local
     env_file: ./docker/env/.github
@@ -315,7 +315,7 @@ services:
       - github
       - github-cron
   hooks-web:
-    image: taskcluster/taskcluster:v56.0.3
+    image: ${IMAGE}
     networks:
       - local
     env_file: ./docker/env/.hooks
@@ -335,7 +335,7 @@ services:
     ports:
       - '3013:80'
   hooks-background-scheduler:
-    image: taskcluster/taskcluster:v56.0.3
+    image: ${IMAGE}
     networks:
       - local
     env_file: ./docker/env/.hooks
@@ -351,7 +351,7 @@ services:
       - hooks
       - hooks-background
   hooks-background-listeners:
-    image: taskcluster/taskcluster:v56.0.3
+    image: ${IMAGE}
     networks:
       - local
     env_file: ./docker/env/.hooks
@@ -367,7 +367,7 @@ services:
       - hooks
       - hooks-background
   hooks-cron-expires:
-    image: taskcluster/taskcluster:v56.0.3
+    image: ${IMAGE}
     networks:
       - local
     env_file: ./docker/env/.hooks
@@ -383,7 +383,7 @@ services:
       - hooks
       - hooks-cron
   index-web:
-    image: taskcluster/taskcluster:v56.0.3
+    image: ${IMAGE}
     networks:
       - local
     env_file: ./docker/env/.index
@@ -403,7 +403,7 @@ services:
     ports:
       - '3014:80'
   index-background-handlers:
-    image: taskcluster/taskcluster:v56.0.3
+    image: ${IMAGE}
     networks:
       - local
     env_file: ./docker/env/.index
@@ -419,7 +419,7 @@ services:
       - index
       - index-background
   index-cron-expire:
-    image: taskcluster/taskcluster:v56.0.3
+    image: ${IMAGE}
     networks:
       - local
     env_file: ./docker/env/.index
@@ -435,7 +435,7 @@ services:
       - index
       - index-cron
   notify-web:
-    image: taskcluster/taskcluster:v56.0.3
+    image: ${IMAGE}
     networks:
       - local
     env_file: ./docker/env/.notify
@@ -455,7 +455,7 @@ services:
     ports:
       - '3015:80'
   notify-background-handler:
-    image: taskcluster/taskcluster:v56.0.3
+    image: ${IMAGE}
     networks:
       - local
     env_file: ./docker/env/.notify
@@ -471,7 +471,7 @@ services:
       - notify
       - notify-background
   object-web:
-    image: taskcluster/taskcluster:v56.0.3
+    image: ${IMAGE}
     networks:
       - local
     env_file: ./docker/env/.object
@@ -493,7 +493,7 @@ services:
     ports:
       - '3016:80'
   object-cron-expire:
-    image: taskcluster/taskcluster:v56.0.3
+    image: ${IMAGE}
     networks:
       - local
     env_file: ./docker/env/.object
@@ -511,7 +511,7 @@ services:
       - object
       - object-cron
   purge-cache-web:
-    image: taskcluster/taskcluster:v56.0.3
+    image: ${IMAGE}
     networks:
       - local
     env_file: ./docker/env/.purge-cache
@@ -531,7 +531,7 @@ services:
     ports:
       - '3017:80'
   purge-cache-cron-expireCachePurges:
-    image: taskcluster/taskcluster:v56.0.3
+    image: ${IMAGE}
     networks:
       - local
     env_file: ./docker/env/.purge-cache
@@ -547,7 +547,7 @@ services:
       - purge-cache
       - purge-cache-cron
   queue-web:
-    image: taskcluster/taskcluster:v56.0.3
+    image: ${IMAGE}
     networks:
       - local
     env_file: ./docker/env/.queue
@@ -569,7 +569,7 @@ services:
     ports:
       - '3018:80'
   queue-background-claimResolver:
-    image: taskcluster/taskcluster:v56.0.3
+    image: ${IMAGE}
     networks:
       - local
     env_file: ./docker/env/.queue
@@ -587,7 +587,7 @@ services:
       - queue
       - queue-background
   queue-background-deadlineResolver:
-    image: taskcluster/taskcluster:v56.0.3
+    image: ${IMAGE}
     networks:
       - local
     env_file: ./docker/env/.queue
@@ -605,7 +605,7 @@ services:
       - queue
       - queue-background
   queue-background-dependencyResolver:
-    image: taskcluster/taskcluster:v56.0.3
+    image: ${IMAGE}
     networks:
       - local
     env_file: ./docker/env/.queue
@@ -623,7 +623,7 @@ services:
       - queue
       - queue-background
   queue-cron-expireArtifacts:
-    image: taskcluster/taskcluster:v56.0.3
+    image: ${IMAGE}
     networks:
       - local
     env_file: ./docker/env/.queue
@@ -641,7 +641,7 @@ services:
       - queue
       - queue-cron
   queue-cron-expireTask:
-    image: taskcluster/taskcluster:v56.0.3
+    image: ${IMAGE}
     networks:
       - local
     env_file: ./docker/env/.queue
@@ -659,7 +659,7 @@ services:
       - queue
       - queue-cron
   queue-cron-expireTaskGroups:
-    image: taskcluster/taskcluster:v56.0.3
+    image: ${IMAGE}
     networks:
       - local
     env_file: ./docker/env/.queue
@@ -677,7 +677,7 @@ services:
       - queue
       - queue-cron
   queue-cron-expireTaskDependency:
-    image: taskcluster/taskcluster:v56.0.3
+    image: ${IMAGE}
     networks:
       - local
     env_file: ./docker/env/.queue
@@ -695,7 +695,7 @@ services:
       - queue
       - queue-cron
   queue-cron-expireQueueMessages:
-    image: taskcluster/taskcluster:v56.0.3
+    image: ${IMAGE}
     networks:
       - local
     env_file: ./docker/env/.queue
@@ -713,7 +713,7 @@ services:
       - queue
       - queue-cron
   queue-cron-expireWorkerInfo:
-    image: taskcluster/taskcluster:v56.0.3
+    image: ${IMAGE}
     networks:
       - local
     env_file: ./docker/env/.queue
@@ -731,7 +731,7 @@ services:
       - queue
       - queue-cron
   secrets-web:
-    image: taskcluster/taskcluster:v56.0.3
+    image: ${IMAGE}
     networks:
       - local
     env_file: ./docker/env/.secrets
@@ -751,7 +751,7 @@ services:
     ports:
       - '3019:80'
   secrets-cron-expire:
-    image: taskcluster/taskcluster:v56.0.3
+    image: ${IMAGE}
     networks:
       - local
     env_file: ./docker/env/.secrets
@@ -767,7 +767,7 @@ services:
       - secrets
       - secrets-cron
   web-server-web:
-    image: taskcluster/taskcluster:v56.0.3
+    image: ${IMAGE}
     networks:
       - local
     env_file: ./docker/env/.web-server
@@ -787,7 +787,7 @@ services:
     ports:
       - '3050:3050'
   web-server-cron-scanner:
-    image: taskcluster/taskcluster:v56.0.3
+    image: ${IMAGE}
     networks:
       - local
     env_file: ./docker/env/.web-server
@@ -803,7 +803,7 @@ services:
       - web-server
       - web-server-cron
   web-server-cron-cleanup-expire-auth-codes:
-    image: taskcluster/taskcluster:v56.0.3
+    image: ${IMAGE}
     networks:
       - local
     env_file: ./docker/env/.web-server
@@ -819,7 +819,7 @@ services:
       - web-server
       - web-server-cron
   web-server-cron-cleanup-expire-access-tokens:
-    image: taskcluster/taskcluster:v56.0.3
+    image: ${IMAGE}
     networks:
       - local
     env_file: ./docker/env/.web-server
@@ -835,7 +835,7 @@ services:
       - web-server
       - web-server-cron
   worker-manager-web:
-    image: taskcluster/taskcluster:v56.0.3
+    image: ${IMAGE}
     networks:
       - local
     env_file: ./docker/env/.worker-manager
@@ -855,7 +855,7 @@ services:
     ports:
       - '3020:80'
   worker-manager-background-provisioner:
-    image: taskcluster/taskcluster:v56.0.3
+    image: ${IMAGE}
     networks:
       - local
     env_file: ./docker/env/.worker-manager
@@ -871,7 +871,7 @@ services:
       - worker-manager
       - worker-manager-background
   worker-manager-background-workerscanner:
-    image: taskcluster/taskcluster:v56.0.3
+    image: ${IMAGE}
     networks:
       - local
     env_file: ./docker/env/.worker-manager
@@ -887,7 +887,7 @@ services:
       - worker-manager
       - worker-manager-background
   worker-manager-background-workerscanner-azure:
-    image: taskcluster/taskcluster:v56.0.3
+    image: ${IMAGE}
     networks:
       - local
     env_file: ./docker/env/.worker-manager
@@ -903,7 +903,7 @@ services:
       - worker-manager
       - worker-manager-background
   worker-manager-cron-expire-workers:
-    image: taskcluster/taskcluster:v56.0.3
+    image: ${IMAGE}
     networks:
       - local
     env_file: ./docker/env/.worker-manager
@@ -919,7 +919,7 @@ services:
       - worker-manager
       - worker-manager-cron
   worker-manager-cron-expire-worker-pools:
-    image: taskcluster/taskcluster:v56.0.3
+    image: ${IMAGE}
     networks:
       - local
     env_file: ./docker/env/.worker-manager
@@ -935,7 +935,7 @@ services:
       - worker-manager
       - worker-manager-cron
   worker-manager-cron-expire-errors:
-    image: taskcluster/taskcluster:v56.0.3
+    image: ${IMAGE}
     networks:
       - local
     env_file: ./docker/env/.worker-manager

--- a/docker/cleanup-images.sh
+++ b/docker/cleanup-images.sh
@@ -1,12 +1,12 @@
 #/bin/bash
 
-if [ ! -f docker-compose.yml ]; then
-  echo "docker-compose.yml not found"
+if [ ! -f .env ]; then
+  echo ".env not found"
   exit 1
 fi
 
 # find all "taskcluster/" images that are currently used in docker-compose.yml
-for line in $(grep "image:" docker-compose.yml | grep taskcluster |sort | uniq | sed -n "s/^.*image:\s*\(\S*\)/\1/p"); do
+for line in $(grep "IMAGE" .env | grep taskcluster |sort | uniq | sed -n "s/^IMAGE.*=\s*\(\S*\)/\1/p"); do
   IFS=":" read -r repo tag <<< "$line"
   echo "\nRemoving all $repo images except the used one: $tag "
   # display the list of images to be removed

--- a/infrastructure/tooling/src/release/tasks.js
+++ b/infrastructure/tooling/src/release/tasks.js
@@ -233,21 +233,13 @@ export default ({ tasks, cmdOptions, credentials }) => {
           `\\"version\\": \\"${requirements['release-version']}`));
       changed.push('generic-worker.Dockerfile');
 
-      const dockerCompose = 'docker-compose.yml';
-      utils.status({ message: `Update ${dockerCompose}` });
-      await modifyRepoFile(dockerCompose, contents =>
-        contents.replace(/taskcluster\/taskcluster:v[0-9.]*/g, releaseImage));
-      await modifyRepoFile(dockerCompose, contents =>
-        contents.replace(/taskcluster\/generic-worker:v[0-9.]*/g, releaseImageGenericWorker));
-      changed.push(dockerCompose);
-
-      const dockerComposeDev = 'docker-compose.dev.yml';
-      utils.status({ message: `Update ${dockerComposeDev}` });
-      await modifyRepoFile(dockerComposeDev, contents =>
-        contents.replace(/taskcluster\/taskcluster:v[0-9.]*/g, releaseImage));
-      await modifyRepoFile(dockerComposeDev, contents =>
-        contents.replace(/taskcluster\/generic-worker:v[0-9.]*/g, releaseImageGenericWorker));
-      changed.push(dockerComposeDev);
+      const dockerEnv = '.env';
+      utils.status({ message: `Update ${dockerEnv}` });
+      await modifyRepoFile(dockerEnv, contents =>
+        contents.replace(/taskcluster\/taskcluster:v[0-9.]*/g, releaseImage)
+          .replace(/taskcluster\/generic-worker:v[0-9.]*/g, releaseImageGenericWorker),
+      );
+      changed.push(dockerEnv);
 
       return { 'version-updated': changed };
     },


### PR DESCRIPTION
Version tags were changed after each release which resulted in all compose files being changed. 
This introduces unnecessary changes in history.

This will keep changing versions in `.env` file and `docker-compose*` files would reference it using `image: ${IMAGE}` format, as `docker` by default reads variables from `.env` file