### PR TITLE
Hook service display 'unknown' state when task doesn't exist anymore

### DIFF
--- a/changelog/G8Sjop3gSmqQSIC3xgPbuQ.md
+++ b/changelog/G8Sjop3gSmqQSIC3xgPbuQ.md
@@ -1,0 +1,5 @@
+audience: users
+level: patch
+---
+
+Hooks last fires display `unknown` as task state if task is missing or not scheduled. This can happen with task was expired and removed but last run information still exist.

--- a/clients/client-go/tchooks/types.go
+++ b/clients/client-go/tchooks/types.go
@@ -298,9 +298,10 @@ type (
 
 		// Task state derived from tasks last run status.
 		// This value can change through time as tasks are being scheduled, run and re-run.
-		// If task doesn't exist or was just created, this value will default to `unscheduled`.
+		// If task doesn't exist or was just created, this value will default to `unknown`.
 		//
 		// Possible values:
+		//   * "unknown"
 		//   * "unscheduled"
 		//   * "pending"
 		//   * "running"

--- a/generated/references.json
+++ b/generated/references.json
@@ -6388,8 +6388,9 @@
                 "type": "string"
               },
               "taskState": {
-                "description": "Task state derived from tasks last run status.\nThis value can change through time as tasks are being scheduled, run and re-run.\nIf task doesn't exist or was just created, this value will default to `unscheduled`.\n",
+                "description": "Task state derived from tasks last run status.\nThis value can change through time as tasks are being scheduled, run and re-run.\nIf task doesn't exist or was just created, this value will default to `unknown`.\n",
                 "enum": [
+                  "unknown",
                   "unscheduled",
                   "pending",
                   "running",

--- a/services/hooks/.babelrc
+++ b/services/hooks/.babelrc
@@ -1,4 +1,0 @@
-{
-    "stage": 1,
-    "loose": "all"
-}

--- a/services/hooks/schemas/v1/list-lastFires-response.yml
+++ b/services/hooks/schemas/v1/list-lastFires-response.yml
@@ -42,9 +42,10 @@ properties:
           description: |
             Task state derived from tasks last run status.
             This value can change through time as tasks are being scheduled, run and re-run.
-            If task doesn't exist or was just created, this value will default to `unscheduled`.
+            If task doesn't exist or was just created, this value will default to `unknown`.
           type: string
           enum:
+            - unknown
             - unscheduled
             - pending
             - running

--- a/services/hooks/src/api.js
+++ b/services/hooks/src/api.js
@@ -691,7 +691,7 @@ builder.declare({
       taskCreateTime: row.task_create_time.toJSON(),
       result: row.result,
       error: row.error,
-      taskState: row.task_state || 'unscheduled',
+      taskState: row.task_state || 'unknown',
     })),
     continuationToken,
   });

--- a/services/hooks/test/api_test.js
+++ b/services/hooks/test/api_test.js
@@ -878,6 +878,21 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       assume(taskIds).eql(dataTaskIds);
       assume(lastFires[0].taskState).equals('completed');
     });
+    test('lists lastfires and reports "unknown" for task status', async () => {
+      const taskIds = [];
+      taskIds.push(lastFire.taskId);
+      await appendLastFire(lastFire);
+      for (let i = 1;i <= 2;i++) {
+        taskIds.push(taskcluster.slugid());
+        await appendLastFire({ ...lastFire,
+          taskId: taskIds[i],
+          taskCreateTime: new Date(),
+        });
+      }
+      const { lastFires } = await helper.hooks.listLastFires(lastFire.hookGroupId, lastFire.hookId);
+      assume(lastFires[0].taskState).equals('unknown');
+      assume(lastFires[1].taskState).equals('unknown');
+    });
   });
 
   suite('pulseHooks', function() {


### PR DESCRIPTION
This [hook](https://firefox-ci-tc.services.mozilla.com/hooks/project-releng/cron-task-mozilla-central%2Fship-geckoview) has tasks that expire after 7d, so no longer available. Displaying `"unscheduled"` as its state might not be accurate, as they were scheduled at that time.