### PR TITLE
Fix `claimWork` returning `500`

### DIFF
--- a/changelog/issue-6634.md
+++ b/changelog/issue-6634.md
@@ -1,0 +1,6 @@
+audience: general
+level: patch
+reference: issue 6634
+---
+
+Fixes `queue.claimWork` endpoint returning `500` in some rare conditions.

--- a/services/queue/src/workclaimer.js
+++ b/services/queue/src/workclaimer.js
@@ -53,17 +53,17 @@ class WorkClaimer extends events.EventEmitter {
   async claim(taskQueueId, workerGroup, workerId, count, aborted) {
     let claims = [];
     let done = false;
-
-    const hintPoller = this.getHintPoller(taskQueueId);
+    let hintPoller;
 
     aborted.then(() => done = true);
     // As soon as we have claims we return so work can get started.
     // We don't try to claim up to the count, that could take time and we risk
     // dropping the claims in case of server crash.
     while (claims.length === 0 && !done) {
+      hintPoller = this.getHintPoller(taskQueueId);
+
       // Poll for hints (messages saying a task may be pending)
       let hints = await hintPoller.requestClaim(count, aborted);
-
       // Try to claim all the hints
       claims = await Promise.all(hints.map(async (hint) => {
         try {

--- a/services/queue/test/hintpoller_test.js
+++ b/services/queue/test/hintpoller_test.js
@@ -108,6 +108,8 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
     });
 
     const aborted = new Promise(resolve => setTimeout(resolve, 100));
+    // we request 1 but pollPendingQueue returns 2
+    // so second one would be released back
     await hintPoller.requestClaim(1, aborted);
     assume(pollCalls).equals(1);
     assume(released).equals(true);

--- a/services/queue/test/hintpoller_test.js
+++ b/services/queue/test/hintpoller_test.js
@@ -1,0 +1,120 @@
+import assume from 'assume';
+import HintPoller from '../src/hintpoller.js';
+import helper from './helper.js';
+import testing from 'taskcluster-lib-testing';
+
+helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
+  test('calls pollPendingQueue', async () => {
+    const monitor = await helper.load('monitor');
+
+    let pollCalls = 0;
+    const pollPendingQueue = async (count) => {
+      pollCalls += count;
+      return [count];
+    };
+
+    const hintPoller = new HintPoller('taskQueue/Id', {
+      monitor,
+      pollPendingQueue,
+      onError: err => console.error(err),
+      onDestroy: () => {},
+    });
+
+    const aborted = new Promise(resolve => setTimeout(resolve, 100));
+    const hints = await hintPoller.requestClaim(1, aborted);
+
+    assume(hints).deep.equals([1]);
+    assume(pollCalls).equals(1);
+  });
+
+  test('cannot request claim after destroy', async () => {
+    const monitor = await helper.load('monitor');
+
+    let pollCalls = 0;
+    const pollPendingQueue = async (count) => {
+      pollCalls += count;
+      return [count];
+    };
+
+    let destroyCalled = false;
+
+    const hintPoller = new HintPoller('taskQueue/Id', {
+      monitor,
+      pollPendingQueue,
+      onError: err => console.error(err),
+      onDestroy: () => destroyCalled = true,
+    });
+
+    const aborted = new Promise(resolve => setTimeout(resolve, 1000));
+
+    hintPoller.destroy();
+    try {
+      await hintPoller.requestClaim(1, aborted);
+      assume(true).equals(false); // this should not happen
+    } catch (err) {
+      assume(err.message).equals('requestClaim() called after destroy()');
+    }
+    assume(pollCalls).equals(0);
+    assume(destroyCalled).equals(true);
+  });
+
+  test('multiple listeners', async () => {
+    const monitor = await helper.load('monitor');
+
+    let pollCalls = 0;
+    const pollPendingQueue = async (count) => {
+      pollCalls += 1;
+      return [count];
+    };
+
+    const hintPoller = new HintPoller('taskQueue/Id', {
+      monitor,
+      pollPendingQueue,
+      onError: err => console.error(err),
+      onDestroy: () => {},
+    });
+
+    const aborted = new Promise(resolve => setTimeout(resolve, 100));
+    const hints1 = await hintPoller.requestClaim(1, aborted);
+    const hints2 = await hintPoller.requestClaim(1, aborted);
+
+    assume(hints1).deep.equals([1]);
+    assume(hints2).deep.equals([1]);
+    assume(pollCalls).equals(2);
+  });
+
+  test('releases unused hints', async () => {
+    const monitor = await helper.load('monitor');
+
+    let pollCalls = 0;
+    let released = false;
+    const pollPendingQueue = async (count) => {
+      pollCalls += 1;
+      return [{
+        count,
+        // first hint will be claimed
+      }, {
+        count,
+        // second hint will be released
+        release: () => released = true,
+      }];
+    };
+
+    const hintPoller = new HintPoller('taskQueue/Id', {
+      monitor,
+      pollPendingQueue,
+      onError: err => console.error(err),
+      onDestroy: () => {},
+    });
+
+    const aborted = new Promise(resolve => setTimeout(resolve, 100));
+    await hintPoller.requestClaim(1, aborted);
+    assume(pollCalls).equals(1);
+    assume(released).equals(true);
+
+    released = false;
+    await hintPoller.requestClaim(2, aborted);
+    assume(pollCalls).equals(2);
+    assume(released).equals(false); // since 2 were requested
+  });
+});

--- a/services/queue/test/workclaimer_test.js
+++ b/services/queue/test/workclaimer_test.js
@@ -1,0 +1,139 @@
+import assume from 'assume';
+import slugid from 'slugid';
+import helper from './helper.js';
+import testing from 'taskcluster-lib-testing';
+import taskcluster from 'taskcluster-client';
+import WorkClaimer from '../src/workclaimer.js';
+
+helper.secrets.mockSuite(testing.suiteName(), ['aws'], function (mock, skipping) {
+  helper.withDb(mock, skipping);
+  helper.withPulse(mock, skipping);
+  helper.withS3(mock, skipping);
+  helper.withServer(mock, skipping);
+  helper.resetTables(mock, skipping);
+
+  const taskDef = () => ({
+    taskGroupId: slugid.v4(),
+    taskQueueId: 'taskQueue/id',
+    schedulerId: 'dummy-scheduler',
+    created: taskcluster.fromNowJSON(),
+    deadline: taskcluster.fromNowJSON('1 days'),
+    expires: taskcluster.fromNowJSON('2 days'),
+    payload: {},
+    metadata: {
+      name: 'Unit testing task',
+      description: 'Task created during unit tests',
+      owner: 'yarik@mozilla.com',
+      source: 'https://github.com/taskcluster/taskcluster-queue',
+    },
+  });
+
+  test('getHintPoller', () => {
+    const fakeClaimer = new WorkClaimer({
+      db: {},
+      monitor: {},
+      publisher: {},
+      queueService: {},
+      claimTimeout: 1000,
+      credentials: {},
+    });
+    assume(Object.keys(fakeClaimer._hintPollers).length).equals(0);
+
+    let poller = fakeClaimer.getHintPoller('taskQueue/queue1');
+    assume(Object.keys(fakeClaimer._hintPollers).length).equals(1);
+
+    fakeClaimer.getHintPoller('taskQueue/queue2');
+    assume(Object.keys(fakeClaimer._hintPollers).length).equals(2);
+
+    // get poller for same queue
+    poller = fakeClaimer.getHintPoller('taskQueue/queue1');
+    assume(Object.keys(fakeClaimer._hintPollers).length).equals(2);
+
+    // destroy poller
+    poller.destroy();
+    process.nextTick(() => {
+      // should be removed from cache
+      assume(Object.keys(fakeClaimer._hintPollers).length).equals(1);
+    });
+  });
+
+  test('claims something', async () => {
+    const taskId = slugid.v4();
+    const monitor = await helper.load('monitor');
+    const publisher = await helper.load('publisher');
+    const db = await helper.load('db');
+    const cfg = await helper.load('cfg');
+
+    const workClaimer = new WorkClaimer({
+      db,
+      monitor,
+      publisher,
+      queueService: {
+        pollPendingQueue: (taskQueueId) => () => [{
+          taskId,
+          runId: 0,
+          hintId: 'hint1',
+          release: async () => { },
+          remove: async () => { },
+        }],
+        putClaimMessage: () => { },
+      },
+      claimTimeout: 1000,
+      credentials: cfg.taskcluster.credentials,
+    });
+
+    await helper.queue.createTask(taskId, taskDef(taskId));
+    await helper.queue.scheduleTask(taskId);
+
+    const aborted = new Promise(resolve => setTimeout(resolve, 1000));
+    const claims = await workClaimer.claim('taskQueue/Id', 'workerGroup', 'workerId', 1, aborted);
+    assume(claims.length).equal(1);
+    assume(claims[0].status.taskId).equal(taskId);
+  });
+
+  test('hint poller errors are recovered', async () => {
+    const taskId = slugid.v4();
+    const monitor = await helper.load('monitor');
+    const publisher = await helper.load('publisher');
+    const db = await helper.load('db');
+    const cfg = await helper.load('cfg');
+
+    let calls = 0;
+
+    const workClaimer = new WorkClaimer({
+      db,
+      monitor,
+      publisher,
+      queueService: {
+        pollPendingQueue: (taskQueueId) => () => {
+          calls++;
+          if (calls < 3) {
+            throw new Error('error');
+          }
+          return [];
+        },
+        putClaimMessage: () => { },
+      },
+      claimTimeout: 1000,
+      credentials: cfg.taskcluster.credentials,
+    });
+
+    await helper.queue.createTask(taskId, taskDef(taskId));
+    await helper.queue.scheduleTask(taskId);
+
+    const tryCall = async () => {
+      try {
+        return await workClaimer.claim('taskQueue/Id', 'workerGroup', 'workerId', 3, new Promise(resolve => setTimeout(resolve, 1000)));
+      } catch (err) {
+        return 0;
+      }
+    };
+
+    await tryCall();
+    await tryCall();
+    await tryCall();
+
+    const res = await tryCall();
+    assume(res).deep.equal([]);
+  });
+});


### PR DESCRIPTION
In some rare conditions, `queue.claimWork` was throwing `500` errors.

This happened because of the changes introduced in recent [queue internals refactoring](https://github.com/taskcluster/taskcluster/commit/3cdec1d6a1c92201cecc5da244f21f05ea67d357#diff-07d1f6e8072664349e5c609273873df2ca0904b88f917517eec8ba91e4ec6a26 )

Adding tests for `HintPoller` and `WorkerClaimer` and making sure destroyed hint poller doesn't interfere with other calls

Fixes #6634 