### PR TITLE
docker-worker: stringify scope expressions in error message

### DIFF
--- a/changelog/Akx0pTXSTUuwG6T9qqHxBA.md
+++ b/changelog/Akx0pTXSTUuwG6T9qqHxBA.md
@@ -1,0 +1,4 @@
+audience: users
+level: patch
+---
+docker-worker: fix error message when a task is missing scopes for cache volumes

--- a/workers/docker-worker/src/task.js
+++ b/workers/docker-worker/src/task.js
@@ -111,11 +111,11 @@ async function buildVolumeBindings(runtime, taskVolumeBindings, volumeCache, exp
       'The task is missing the following scopes:',
       '',
       '```',
-      `${unsatisfied}`,
+      JSON.stringify(unsatisfied),
       '```',
       'This requested devices requires the task scopes to satisfy the following scope expression:',
       '```',
-      `${scopeExpression}`,
+      JSON.stringify(scopeExpression),
       '```',
     ].join('\n'));
   }


### PR DESCRIPTION
It turns out seeing `[object Object]` in the task log isn't too helpful.

This is untested, and rather academic as we're not deploying updated docker-workers, but maybe it's trivial enough that it's still worth it?