### PR TITLE
fix: remove .yarn COPY commands

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,15 +9,12 @@ ENV YARN_CACHE_FOLDER=/base/cache
 # prepare top level dependencies
 RUN mkdir -p /base/yarn
 COPY /yarn.lock /.yarnrc.yml /package.json /base/yarn/
-COPY /.yarn /base/yarn/.yarn/
 # prepare ui dependencies
 RUN mkdir -p /base/yarn-ui
 COPY /ui/yarn.lock /.yarnrc.yml /ui/package.json /base/yarn-ui/
-COPY /.yarn /base/yarn-ui/.yarn/
 # prepare clients/client dependencies
 RUN mkdir -p /base/yarn-client
 COPY /clients/client/yarn.lock /.yarnrc.yml /clients/client/package.json /base/yarn-client/
-COPY /.yarn /base/yarn-client/.yarn/
 
 # install all dependencies
 WORKDIR /base/yarn-client

--- a/changelog/issue-6636-1.md
+++ b/changelog/issue-6636-1.md
@@ -1,0 +1,5 @@
+audience: general
+level: patch
+reference: issue 6636
+---
+Fix Dockerfile from PR #6646. The `.yarn` directory does not exist anymore, so it shouldn't be copied.


### PR DESCRIPTION
This should've been removed in #6646.

Found this issue in https://github.com/taskcluster/taskcluster/runs/18228850091.

>Fix Dockerfile from PR #6646. The `.yarn` directory does not exist anymore, so it shouldn't be copied.