### PR TITLE
fix(d2g): shell escape env var names

### DIFF
--- a/changelog/issue-6656.md
+++ b/changelog/issue-6656.md
@@ -1,0 +1,5 @@
+audience: general
+level: patch
+reference: issue 6656
+---
+D2G now shell escapes environment variable key names in case they contain spaces or special characters that would previously mess up the `podman run...` command.

--- a/tools/d2g/d2g.go
+++ b/tools/d2g/d2g.go
@@ -451,7 +451,7 @@ func createVolumeMountsString(dwPayload *dockerworker.DockerWorkerPayload, wdcs 
 }
 
 func podmanEnvSetting(envVarName string) string {
-	return fmt.Sprintf(" -e %s", envVarName)
+	return fmt.Sprintf(" -e %s", shell.Escape(envVarName))
 }
 
 func imageObject(payloadImage *json.RawMessage) (Image, error) {

--- a/tools/d2g/d2gtest/testdata/testcases/env_escaping_test.yml
+++ b/tools/d2g/d2gtest/testdata/testcases/env_escaping_test.yml
@@ -13,21 +13,21 @@ testSuite:
         image: ubuntu
         maxRunTime: 3600
         env:
-          test123 --help ; whoami ;: testing
+          ' test123 --help  ; whoami ; ': testing
       genericWorkerTaskPayload:
         command:
           - - bash
             - '-cx'
             - >-
               podman run -t --rm
+              -e ' test123 --help  ; whoami ; '
               -e RUN_ID
               -e TASKCLUSTER_ROOT_URL
               -e TASKCLUSTER_WORKER_LOCATION
               -e TASK_ID
-              -e 'test123 --help ; whoami ;'
               ubuntu 'echo "Hello world"'
         env:
-          test123 --help ; whoami ;: testing
+          ' test123 --help  ; whoami ; ': testing
         features:
           backingLog: true
           liveLog: true

--- a/tools/d2g/d2gtest/testdata/testcases/env_escaping_test.yml
+++ b/tools/d2g/d2gtest/testdata/testcases/env_escaping_test.yml
@@ -1,0 +1,38 @@
+---
+testSuite:
+  name: Environment variable escaping test
+  description: Test that environment variables are properly escaped.
+  payloadTests:
+    - name: Env escaping test
+      description: >-
+        If an environment variable contains spaces or special characters,
+        it should be escaped before passing to the podman run command.
+      dockerWorkerTaskPayload:
+        command:
+          - echo "Hello world"
+        image: ubuntu
+        maxRunTime: 3600
+        env:
+          test123 --help ; whoami ;: testing
+      genericWorkerTaskPayload:
+        command:
+          - - bash
+            - '-cx'
+            - >-
+              podman run -t --rm
+              -e RUN_ID
+              -e TASKCLUSTER_ROOT_URL
+              -e TASKCLUSTER_WORKER_LOCATION
+              -e TASK_ID
+              -e 'test123 --help ; whoami ;'
+              ubuntu 'echo "Hello world"'
+        env:
+          test123 --help ; whoami ;: testing
+        features:
+          backingLog: true
+          liveLog: true
+        maxRunTime: 3600
+        onExitStatus:
+          retry:
+            - 125
+  taskDefTests: []


### PR DESCRIPTION
Fixes https://github.com/taskcluster/taskcluster/issues/6656.

>D2G now shell escapes environment variable key names in case they contain spaces or special characters that would previously mess up the `podman run...` command.