### PR TITLE
feat(generic-worker): add `copy-to-temp-file` subcommand

### DIFF
--- a/changelog/bug-1855653.md
+++ b/changelog/bug-1855653.md
@@ -1,0 +1,7 @@
+audience: general
+level: major
+reference: bug 1855653
+---
+Generic Worker: The `generic-worker` binary _must be_ readable and executable by the task user. If it's not, artifact uploads _will fail_.
+
+Generic Worker: Add `copy-to-temp-file` subcommand to `generic-worker` to copy a file (`--copy-file`) to a temporary file.

--- a/clients/client-go/tcqueue/types.go
+++ b/clients/client-go/tcqueue/types.go
@@ -234,6 +234,7 @@ type (
 		//   * "file-missing-on-worker"
 		//   * "invalid-resource-on-worker"
 		//   * "too-large-file-on-worker"
+		//   * "file-not-readable-on-worker"
 		Reason string `json:"reason"`
 
 		// Artifact storage type, in this case `error`

--- a/generated/references.json
+++ b/generated/references.json
@@ -3981,7 +3981,8 @@
               "enum": [
                 "file-missing-on-worker",
                 "invalid-resource-on-worker",
-                "too-large-file-on-worker"
+                "too-large-file-on-worker",
+                "file-not-readable-on-worker"
               ],
               "type": "string"
             },

--- a/services/queue/schemas/v1/post-artifact-request.yml
+++ b/services/queue/schemas/v1/post-artifact-request.yml
@@ -173,6 +173,7 @@ oneOf:
           - file-missing-on-worker
           - invalid-resource-on-worker
           - too-large-file-on-worker
+          - file-not-readable-on-worker
       message:
         description: |
           Human readable explanation of why the artifact is missing

--- a/tools/d2g/d2gtest/testdata/testcases/env_escaping_test.yml
+++ b/tools/d2g/d2gtest/testdata/testcases/env_escaping_test.yml
@@ -28,9 +28,6 @@ testSuite:
               ubuntu 'echo "Hello world"'
         env:
           ' test123 --help  ; whoami ; ': testing
-        features:
-          backingLog: true
-          liveLog: true
         maxRunTime: 3600
         onExitStatus:
           retry:

--- a/ui/docs/reference/workers/generic-worker/installing.mdx
+++ b/ui/docs/reference/workers/generic-worker/installing.mdx
@@ -9,6 +9,9 @@ The following instructions should be considered more as a guide rather than
 concrete requirements.  In particular, it does not use
 worker-runner, and contains some outdated references to the
 "legacy" deployment of Taskcluster at https://taskcluster.net.
+A critical instruction to follow is to ensure that the generic-worker
+binary is readable and executable by the task user. Make sure it's not only the
+root user who can read and execute the binary.
 
 They document _possible_ (and simple) ways to install and run generic-worker on
 various platforms. Real life production deployments may be integrated quite

--- a/workers/generic-worker/README.md
+++ b/workers/generic-worker/README.md
@@ -21,6 +21,7 @@ and reports back results to the queue.
                                             [--worker-runner-protocol-pipe PIPE]
     generic-worker show-payload-schema
     generic-worker new-ed25519-keypair      --file ED25519-PRIVATE-KEY-FILE
+    generic-worker copy-to-temp-file        --copy-file COPY-FILE
     generic-worker --help
     generic-worker --version
 
@@ -38,6 +39,9 @@ and reports back results to the queue.
                                             compliant private/public key pair. The public
                                             key will be written to stdout and the private
                                             key will be written to the specified file.
+    copy-to-temp-file                       This will copy the specified file to a temporary
+                                            location and will return the temporary file path
+                                            to stdout. Intended for internal use.
 
   Options:
     --config CONFIG-FILE                    Json configuration file to use. See
@@ -56,6 +60,7 @@ and reports back results to the queue.
                                             to. The parent directory must already exist.
                                             If the file exists it will be overwritten,
                                             otherwise it will be created.
+    --copy-file COPY-FILE                   The path to the file to copy.
     --help                                  Display this help text.
     --version                               The release version of the generic-worker.
 

--- a/workers/generic-worker/artifacts.go
+++ b/workers/generic-worker/artifacts.go
@@ -328,7 +328,7 @@ func (task *TaskRun) uploadArtifact(artifact artifacts.TaskArtifact) *CommandExe
 	if e != nil {
 		panic(e)
 	}
-	e = artifact.ProcessResponse(resp, task, serviceFactory, config, taskContext.TaskDir, taskContext.pd)
+	e = artifact.ProcessResponse(resp, task, serviceFactory, config)
 	if e != nil {
 		task.Errorf("Error uploading artifact: %v", e)
 		return ResourceUnavailable(e)

--- a/workers/generic-worker/artifacts/artifacts.go
+++ b/workers/generic-worker/artifacts/artifacts.go
@@ -4,7 +4,6 @@ import (
 	tcclient "github.com/taskcluster/taskcluster/v57/clients/client-go"
 	"github.com/taskcluster/taskcluster/v57/internal/mocktc/tc"
 	"github.com/taskcluster/taskcluster/v57/workers/generic-worker/gwconfig"
-	"github.com/taskcluster/taskcluster/v57/workers/generic-worker/process"
 )
 
 type (
@@ -39,7 +38,7 @@ type (
 		//
 		// ProcessResponse can be an empty method if no post
 		// tcqueue.CreateArtifact steps are required.
-		ProcessResponse(response interface{}, logger Logger, serviceFactory tc.ServiceFactory, config *gwconfig.Config, directory string, pd *process.PlatformData) error
+		ProcessResponse(response interface{}, logger Logger, serviceFactory tc.ServiceFactory, config *gwconfig.Config) error
 
 		// FinishArtifact calls queue.FinishArtifact if necessary for the artifact type
 		FinishArtifact(response interface{}, queue tc.Queue, taskID, runID, name string) error

--- a/workers/generic-worker/artifacts/error.go
+++ b/workers/generic-worker/artifacts/error.go
@@ -6,7 +6,6 @@ import (
 	"github.com/taskcluster/taskcluster/v57/clients/client-go/tcqueue"
 	"github.com/taskcluster/taskcluster/v57/internal/mocktc/tc"
 	"github.com/taskcluster/taskcluster/v57/workers/generic-worker/gwconfig"
-	"github.com/taskcluster/taskcluster/v57/workers/generic-worker/process"
 )
 
 type ErrorArtifact struct {
@@ -16,7 +15,7 @@ type ErrorArtifact struct {
 	Reason  string
 }
 
-func (errArtifact *ErrorArtifact) ProcessResponse(response interface{}, logger Logger, serviceFactory tc.ServiceFactory, config *gwconfig.Config, directory string, pd *process.PlatformData) error {
+func (errArtifact *ErrorArtifact) ProcessResponse(response interface{}, logger Logger, serviceFactory tc.ServiceFactory, config *gwconfig.Config) error {
 	logger.Errorf("Uploading error artifact %v from file %v with message %q, reason %q and expiry %v", errArtifact.Name, errArtifact.Path, errArtifact.Message, errArtifact.Reason, errArtifact.Expires)
 	// TODO: process error response
 	return nil

--- a/workers/generic-worker/artifacts/link.go
+++ b/workers/generic-worker/artifacts/link.go
@@ -4,7 +4,6 @@ import (
 	"github.com/taskcluster/taskcluster/v57/clients/client-go/tcqueue"
 	"github.com/taskcluster/taskcluster/v57/internal/mocktc/tc"
 	"github.com/taskcluster/taskcluster/v57/workers/generic-worker/gwconfig"
-	"github.com/taskcluster/taskcluster/v57/workers/generic-worker/process"
 )
 
 type LinkArtifact struct {
@@ -13,7 +12,7 @@ type LinkArtifact struct {
 	ContentType string
 }
 
-func (linkArtifact *LinkArtifact) ProcessResponse(response interface{}, logger Logger, serviceFactory tc.ServiceFactory, config *gwconfig.Config, directory string, pd *process.PlatformData) error {
+func (linkArtifact *LinkArtifact) ProcessResponse(response interface{}, logger Logger, serviceFactory tc.ServiceFactory, config *gwconfig.Config) error {
 	logger.Infof("Uploading link artifact %v to artifact %v with expiry %v", linkArtifact.Name, linkArtifact.Artifact, linkArtifact.Expires)
 	// nothing to do
 	return nil

--- a/workers/generic-worker/artifacts/object.go
+++ b/workers/generic-worker/artifacts/object.go
@@ -8,7 +8,6 @@ import (
 	"github.com/taskcluster/taskcluster/v57/clients/client-go/tcqueue"
 	"github.com/taskcluster/taskcluster/v57/internal/mocktc/tc"
 	"github.com/taskcluster/taskcluster/v57/workers/generic-worker/gwconfig"
-	"github.com/taskcluster/taskcluster/v57/workers/generic-worker/process"
 )
 
 type ObjectArtifact struct {
@@ -32,7 +31,7 @@ func (a *ObjectArtifact) ResponseObject() interface{} {
 	return new(tcqueue.ObjectArtifactResponse)
 }
 
-func (a *ObjectArtifact) ProcessResponse(resp interface{}, logger Logger, serviceFactory tc.ServiceFactory, config *gwconfig.Config, directory string, pd *process.PlatformData) (err error) {
+func (a *ObjectArtifact) ProcessResponse(resp interface{}, logger Logger, serviceFactory tc.ServiceFactory, config *gwconfig.Config) (err error) {
 	response := resp.(*tcqueue.ObjectArtifactResponse)
 	logger.Infof("Uploading artifact %v from file %v with content type %q and expiry %v", a.Name, a.Path, a.ContentType, a.Expires)
 	creds := tcclient.Credentials{

--- a/workers/generic-worker/artifacts/redirect.go
+++ b/workers/generic-worker/artifacts/redirect.go
@@ -4,7 +4,6 @@ import (
 	"github.com/taskcluster/taskcluster/v57/clients/client-go/tcqueue"
 	"github.com/taskcluster/taskcluster/v57/internal/mocktc/tc"
 	"github.com/taskcluster/taskcluster/v57/workers/generic-worker/gwconfig"
-	"github.com/taskcluster/taskcluster/v57/workers/generic-worker/process"
 )
 
 type RedirectArtifact struct {
@@ -13,7 +12,7 @@ type RedirectArtifact struct {
 	ContentType string
 }
 
-func (redirectArtifact *RedirectArtifact) ProcessResponse(response interface{}, logger Logger, serviceFactory tc.ServiceFactory, config *gwconfig.Config, directory string, pd *process.PlatformData) error {
+func (redirectArtifact *RedirectArtifact) ProcessResponse(response interface{}, logger Logger, serviceFactory tc.ServiceFactory, config *gwconfig.Config) error {
 	logger.Infof("Uploading redirect artifact %v to URL %v with mime type %q and expiry %v", redirectArtifact.Name, redirectArtifact.URL, redirectArtifact.ContentType, redirectArtifact.Expires)
 	// nothing to do
 	return nil

--- a/workers/generic-worker/artifacts_multiuser.go
+++ b/workers/generic-worker/artifacts_multiuser.go
@@ -1,0 +1,9 @@
+//go:build multiuser
+
+package main
+
+import "github.com/taskcluster/taskcluster/v57/workers/generic-worker/process"
+
+func gwCopyToTempFile(exe, filePath string) (*process.Command, error) {
+	return process.NewCommandNoOutputStreams([]string{exe, "copy-to-temp-file", "--copy-file", filePath}, taskContext.TaskDir, []string{}, taskContext.pd)
+}

--- a/workers/generic-worker/artifacts_simple.go
+++ b/workers/generic-worker/artifacts_simple.go
@@ -1,0 +1,9 @@
+//go:build simple
+
+package main
+
+import "github.com/taskcluster/taskcluster/v57/workers/generic-worker/process"
+
+func gwCopyToTempFile(exe, filePath string) (*process.Command, error) {
+	return process.NewCommand([]string{exe, "copy-to-temp-file", "--copy-file", filePath}, taskContext.TaskDir, []string{})
+}

--- a/workers/generic-worker/artifacts_test.go
+++ b/workers/generic-worker/artifacts_test.go
@@ -41,6 +41,17 @@ func validateArtifacts(t *testing.T, payloadArtifacts []Artifact, expected []art
 	tr.Payload.Artifacts = append(tr.Payload.Artifacts, payloadArtifacts...)
 	got := tr.PayloadArtifacts()
 
+	// remove the ContentPath field from the got artifacts
+	// if it's of type S3Artifact. We can't compare this
+	// as it's non-deterministic
+	for _, a := range got {
+		s3Artifact, ok := a.(*artifacts.S3Artifact)
+		if !ok {
+			continue
+		}
+		s3Artifact.ContentPath = ""
+	}
+
 	if !reflect.DeepEqual(got, expected) {
 		t.Fatalf("Expected different artifacts to be generated...\nExpected:\n%q\nActual:\n%q", expected, got)
 	}

--- a/workers/generic-worker/chain_of_trust.go
+++ b/workers/generic-worker/chain_of_trust.go
@@ -203,6 +203,7 @@ func (feature *ChainOfTrustTaskFeature) Stop(err *ExecutionErrors) {
 				Expires: feature.task.Definition.Expires,
 			},
 			filepath.Join(taskContext.TaskDir, ed25519SignedCertPath),
+			filepath.Join(taskContext.TaskDir, ed25519SignedCertPath),
 			"application/octet-stream",
 			"gzip",
 		),

--- a/workers/generic-worker/fileutil/fileutil.go
+++ b/workers/generic-worker/fileutil/fileutil.go
@@ -52,7 +52,7 @@ func Copy(dst, src string) (nBytes int64, err error) {
 		return
 	}
 	if !sourceFileStat.Mode().IsRegular() {
-		err = fmt.Errorf("Cannot copy %s to %s: %s is not a regular file", src, dst, src)
+		err = fmt.Errorf("cannot copy %s to %s: %s is not a regular file", src, dst, src)
 		return
 	}
 	var source *os.File
@@ -74,5 +74,23 @@ func Copy(dst, src string) (nBytes int64, err error) {
 	}
 	defer closeFile(destination)
 	nBytes, err = io.Copy(destination, source)
+	return
+}
+
+func CopyToTempFile(src string) (tempFilePath string, err error) {
+	baseName := filepath.Base(src)
+	var tempFile *os.File
+	tempFile, err = os.CreateTemp("", baseName)
+	if err != nil {
+		return
+	}
+	defer func() {
+		err2 := tempFile.Close()
+		if err == nil {
+			err = err2
+		}
+	}()
+	tempFilePath = tempFile.Name()
+	_, err = Copy(tempFilePath, src)
 	return
 }

--- a/workers/generic-worker/helper_multiuser_test.go
+++ b/workers/generic-worker/helper_multiuser_test.go
@@ -6,6 +6,8 @@ import (
 	"testing"
 
 	"github.com/taskcluster/taskcluster/v57/clients/client-go/tcqueue"
+	"github.com/taskcluster/taskcluster/v57/workers/generic-worker/gwconfig"
+	"github.com/taskcluster/taskcluster/v57/workers/generic-worker/process"
 )
 
 func expectChainOfTrustKeyNotSecureMessage(t *testing.T, td *tcqueue.TaskDefinitionRequest, payload GenericWorkerPayload) {
@@ -30,4 +32,12 @@ func expectChainOfTrustKeyNotSecureMessage(t *testing.T, td *tcqueue.TaskDefinit
 	}
 
 	expectedArtifacts.Validate(t, taskID, 0)
+}
+
+func newPlatformData(conf *gwconfig.Config) (pd *process.PlatformData) {
+	pd, err := process.NewPlatformData(conf.RunTasksAsCurrentUser)
+	if err != nil {
+		panic(err)
+	}
+	return
 }

--- a/workers/generic-worker/helper_simple_test.go
+++ b/workers/generic-worker/helper_simple_test.go
@@ -2,7 +2,14 @@
 
 package main
 
-import "github.com/taskcluster/taskcluster/v57/workers/generic-worker/gwconfig"
+import (
+	"github.com/taskcluster/taskcluster/v57/workers/generic-worker/gwconfig"
+	"github.com/taskcluster/taskcluster/v57/workers/generic-worker/process"
+)
 
 func setConfigRunTasksAsCurrentUser(*gwconfig.Config) {
+}
+
+func newPlatformData(conf *gwconfig.Config) *process.PlatformData {
+	return &process.PlatformData{}
 }

--- a/workers/generic-worker/helper_test.go
+++ b/workers/generic-worker/helper_test.go
@@ -444,6 +444,7 @@ func GWTest(t *testing.T) *Test {
 	// but test methods/functions directly
 	taskContext = &TaskContext{
 		TaskDir: testdataDir,
+		pd:      newPlatformData(testConfig),
 	}
 
 	// useful for expiry dates of tasks

--- a/workers/generic-worker/main.go
+++ b/workers/generic-worker/main.go
@@ -184,6 +184,10 @@ func main() {
 	case arguments["new-ed25519-keypair"]:
 		err := generateEd25519Keypair(arguments["--file"].(string))
 		exitOnError(CANT_CREATE_ED25519_KEYPAIR, err, "Error generating ed25519 keypair %v for worker", arguments["--file"].(string))
+	case arguments["copy-to-temp-file"]:
+		tempFilePath, err := fileutil.CopyToTempFile(arguments["--copy-file"].(string))
+		exitOnError(CANT_COPY_TO_TEMP_FILE, err, "Error copying file %v to temp file", arguments["--copy-file"].(string))
+		fmt.Println(tempFilePath)
 	default:
 		// platform specific...
 		os.Exit(int(platformTargets(arguments)))

--- a/workers/generic-worker/rdp_windows.go
+++ b/workers/generic-worker/rdp_windows.go
@@ -101,6 +101,7 @@ func (l *RDPTask) uploadRDPArtifact() *CommandExecutionError {
 				Expires: tcclient.Time(time.Now().Add(time.Hour * 24)),
 			},
 			filepath.Join(taskContext.TaskDir, rdpInfoPath),
+			filepath.Join(taskContext.TaskDir, rdpInfoPath),
 			"application/json",
 			"gzip",
 		),

--- a/workers/generic-worker/usage.go
+++ b/workers/generic-worker/usage.go
@@ -17,6 +17,7 @@ const (
 	WORKER_SHUTDOWN             ExitCode = 72
 	INVALID_CONFIG              ExitCode = 73
 	CANT_CREATE_ED25519_KEYPAIR ExitCode = 75
+	CANT_COPY_TO_TEMP_FILE      ExitCode = 76
 	CANT_CONNECT_PROTOCOL_PIPE  ExitCode = 78
 )
 
@@ -34,6 +35,7 @@ and reports back results to the queue.
                                             [--worker-runner-protocol-pipe PIPE]` + installServiceSummary() + `
     generic-worker show-payload-schema
     generic-worker new-ed25519-keypair      --file ED25519-PRIVATE-KEY-FILE` + customTargetsSummary() + `
+    generic-worker copy-to-temp-file        --copy-file COPY-FILE
     generic-worker --help
     generic-worker --version
 
@@ -51,6 +53,9 @@ and reports back results to the queue.
                                             compliant private/public key pair. The public
                                             key will be written to stdout and the private
                                             key will be written to the specified file.` + customTargets() + `
+    copy-to-temp-file                       This will copy the specified file to a temporary
+                                            location and will return the temporary file path
+                                            to stdout. Intended for internal use.
 
   Options:
     --config CONFIG-FILE                    Json configuration file to use. See
@@ -69,6 +74,7 @@ and reports back results to the queue.
                                             to. The parent directory must already exist.
                                             If the file exists it will be overwritten,
                                             otherwise it will be created.` + sidSID() + `
+    --copy-file COPY-FILE                   The path to the file to copy.
     --help                                  Display this help text.
     --version                               The release version of the generic-worker.
 


### PR DESCRIPTION
Fixes Bugzilla Bug 1855653.

>Generic Worker: The `generic-worker` binary _must be_ readable and executable by the task user. If it's not, artifact uploads _will fail_.
>
>Generic Worker: Add `copy-to-temp-file` subcommand to `generic-worker` to copy a file (`--copy-file`) to a temporary file.