### PR TITLE
fix(generic-worker): validate the task user can read/execute the generic-worker binary

### DIFF
--- a/changelog/cNPiQAqZTEeqDmtRcz-kKQ.md
+++ b/changelog/cNPiQAqZTEeqDmtRcz-kKQ.md
@@ -1,0 +1,4 @@
+audience: general
+level: patch
+---
+Generic Worker: Adds validation that the task user is able to read and execute the generic-worker binary on startup of the worker. If the task user is not able to read and execute the binary, the worker will exit with exit code 69, internal error.

--- a/ui/docs/reference/workers/generic-worker/installing.mdx
+++ b/ui/docs/reference/workers/generic-worker/installing.mdx
@@ -11,7 +11,9 @@ worker-runner, and contains some outdated references to the
 "legacy" deployment of Taskcluster at https://taskcluster.net.
 A critical instruction to follow is to ensure that the generic-worker
 binary is readable and executable by the task user. Make sure it's not only the
-root user who can read and execute the binary.
+root user who can read and execute the binary. If the generic-worker binary
+is not readable and executable by the task user, the worker will exit
+with exit code 69, internal error.
 
 They document _possible_ (and simple) ways to install and run generic-worker on
 various platforms. Real life production deployments may be integrated quite

--- a/workers/generic-worker/artifacts.go
+++ b/workers/generic-worker/artifacts.go
@@ -12,7 +12,6 @@ import (
 	"runtime"
 	"strconv"
 	"strings"
-	"testing"
 	"time"
 
 	"github.com/taskcluster/httpbackoff/v3"
@@ -360,23 +359,7 @@ func (task *TaskRun) uploadArtifact(artifact artifacts.TaskArtifact) *CommandExe
 }
 
 func copyToTempFileAsTaskUser(filePath string) (tempFilePath string, err error) {
-	// We want to run generic-worker, which is os.Args[0] if we are running generic-worker, but if
-	// we are running tests, os.Args[0] will be the test executable, so then we use relative path to
-	// installed binary. This hack will go if we can impersonate the logged on user.
-	var exe string
-	if testing.Testing() {
-		exe = os.Getenv("GOPATH")
-		switch runtime.GOOS {
-		case "windows":
-			exe += `\bin\generic-worker.exe`
-		default:
-			exe += "/bin/generic-worker"
-		}
-	} else {
-		exe = os.Args[0]
-	}
-
-	cmd, err := gwCopyToTempFile(exe, filePath)
+	cmd, err := gwCopyToTempFile(filePath)
 	if err != nil {
 		return "", fmt.Errorf("Failed to create new command to copy file %s to temporary location as task user: %v", filePath, err)
 	}

--- a/workers/generic-worker/artifacts_multiuser.go
+++ b/workers/generic-worker/artifacts_multiuser.go
@@ -2,8 +2,11 @@
 
 package main
 
-import "github.com/taskcluster/taskcluster/v58/workers/generic-worker/process"
+import (
+	"github.com/taskcluster/taskcluster/v58/workers/generic-worker/process"
+	"github.com/taskcluster/taskcluster/v58/workers/generic-worker/runtime"
+)
 
-func gwCopyToTempFile(exe, filePath string) (*process.Command, error) {
-	return process.NewCommandNoOutputStreams([]string{exe, "copy-to-temp-file", "--copy-file", filePath}, taskContext.TaskDir, []string{}, taskContext.pd)
+func gwCopyToTempFile(filePath string) (*process.Command, error) {
+	return process.NewCommandNoOutputStreams([]string{runtime.GenericWorkerBinary(), "copy-to-temp-file", "--copy-file", filePath}, taskContext.TaskDir, []string{}, taskContext.pd)
 }

--- a/workers/generic-worker/artifacts_simple.go
+++ b/workers/generic-worker/artifacts_simple.go
@@ -2,8 +2,11 @@
 
 package main
 
-import "github.com/taskcluster/taskcluster/v58/workers/generic-worker/process"
+import (
+	"github.com/taskcluster/taskcluster/v58/workers/generic-worker/process"
+	"github.com/taskcluster/taskcluster/v58/workers/generic-worker/runtime"
+)
 
-func gwCopyToTempFile(exe, filePath string) (*process.Command, error) {
-	return process.NewCommand([]string{exe, "copy-to-temp-file", "--copy-file", filePath}, taskContext.TaskDir, []string{})
+func gwCopyToTempFile(filePath string) (*process.Command, error) {
+	return process.NewCommand([]string{runtime.GenericWorkerBinary(), "copy-to-temp-file", "--copy-file", filePath}, taskContext.TaskDir, []string{})
 }

--- a/workers/generic-worker/fileutil/fileutil_posix.go
+++ b/workers/generic-worker/fileutil/fileutil_posix.go
@@ -4,6 +4,7 @@ package fileutil
 
 import (
 	"fmt"
+	"io/fs"
 	"os"
 	"strconv"
 	"strings"
@@ -56,15 +57,25 @@ func SecureFiles(filepaths ...string) (err error) {
 	return nil
 }
 
-func UnsecureFiles(filepaths ...string) (err error) {
-	for _, path := range filepaths {
-		err = os.Chmod(
-			path,
-			0777,
-		)
-		if err != nil {
-			return
-		}
+func ResetPermissions(path string, permissions fs.FileMode) error {
+	return os.Chmod(
+		path,
+		permissions,
+	)
+}
+
+func GetPermissionsString(path string) (string, error) {
+	fileMode, err := GetPermissions(path)
+	if err != nil {
+		return "", err
 	}
-	return
+	return fileMode.String(), nil
+}
+
+func GetPermissions(path string) (fs.FileMode, error) {
+	fileInfo, err := os.Stat(path)
+	if err != nil {
+		return 0, err
+	}
+	return fileInfo.Mode().Perm(), nil
 }

--- a/workers/generic-worker/fileutil/fileutil_posix.go
+++ b/workers/generic-worker/fileutil/fileutil_posix.go
@@ -55,3 +55,16 @@ func SecureFiles(filepaths ...string) (err error) {
 	}
 	return nil
 }
+
+func UnsecureFiles(filepaths ...string) (err error) {
+	for _, path := range filepaths {
+		err = os.Chmod(
+			path,
+			0777,
+		)
+		if err != nil {
+			return
+		}
+	}
+	return
+}

--- a/workers/generic-worker/fileutil/fileutil_windows.go
+++ b/workers/generic-worker/fileutil/fileutil_windows.go
@@ -1,6 +1,9 @@
 package fileutil
 
 import (
+	"fmt"
+	"io/fs"
+
 	"github.com/taskcluster/taskcluster/v58/workers/generic-worker/host"
 )
 
@@ -17,12 +20,14 @@ func SecureFiles(filepaths ...string) (err error) {
 	return
 }
 
-func UnsecureFiles(filepaths ...string) (err error) {
-	for _, path := range filepaths {
-		err = host.Run("icacls", path, "/reset", "/t")
-		if err != nil {
-			return
-		}
-	}
-	return
+func ResetPermissions(path string, permissions fs.FileMode) error {
+	return host.Run("icacls", path, "/reset", "/t")
+}
+
+func GetPermissionsString(path string) (string, error) {
+	return host.CombinedOutput("icacls", path)
+}
+
+func GetPermissions(path string) (fs.FileMode, error) {
+	return 0, fmt.Errorf("GetPermissions not implemented on Windows")
 }

--- a/workers/generic-worker/fileutil/fileutil_windows.go
+++ b/workers/generic-worker/fileutil/fileutil_windows.go
@@ -16,3 +16,13 @@ func SecureFiles(filepaths ...string) (err error) {
 	}
 	return
 }
+
+func UnsecureFiles(filepaths ...string) (err error) {
+	for _, path := range filepaths {
+		err = host.Run("icacls", path, "/reset", "/t")
+		if err != nil {
+			return
+		}
+	}
+	return
+}

--- a/workers/generic-worker/main.go
+++ b/workers/generic-worker/main.go
@@ -696,10 +696,17 @@ func (task *TaskRun) validateJSON(input []byte, schema string) *CommandExecution
 	return MalformedPayloadError(fmt.Errorf("Validation of payload failed for task %v", task.TaskID))
 }
 
+// validateGenericWorkerBinary runs `generic-worker --version` as the
+// task user to ensure that the binary is readable and executable before
+// the worker claims any tasks. This is useful to test that the task user
+// has permissions to run generic-worker subcommands, which are used
+// internally during the artifact upload process. The version string
+// is not returned, since it is not needed. A non-nil error is returned
+// if the `generic-worker --version` command cannot be run successfully.
 func validateGenericWorkerBinary() error {
 	cmd, err := gwVersion()
 	if err != nil {
-		return fmt.Errorf("could not determine generic-worker binary version: %v", err)
+		panic(fmt.Errorf("could not create command to determine generic-worker binary version: %v", err))
 	}
 
 	result := cmd.Execute()

--- a/workers/generic-worker/process/multiuser_windows.go
+++ b/workers/generic-worker/process/multiuser_windows.go
@@ -9,10 +9,10 @@ import (
 	"os/exec"
 	"strconv"
 	"syscall"
-	"testing"
 	"time"
 
 	"github.com/taskcluster/taskcluster/v58/workers/generic-worker/host"
+	"github.com/taskcluster/taskcluster/v58/workers/generic-worker/runtime"
 	"github.com/taskcluster/taskcluster/v58/workers/generic-worker/win32"
 )
 
@@ -171,16 +171,7 @@ func GrantSIDWinstaAccess(sid string, pd *PlatformData) {
 	} else {
 		log.Printf("SID %v NOT found in %#v - granting access...", sid, sidsThatCanControlDesktopAndWindowsStation)
 
-		// We want to run generic-worker exe, which is os.Args[0] if we are running generic-worker, but if
-		// we are running tests, os.Args[0] will be the test executable, so then we use relative path to
-		// installed binary. This hack will go if we can use ImpersonateLoggedOnUser / RevertToSelf instead.
-		var exe string
-		if testing.Testing() {
-			exe = os.Getenv("GOPATH") + `\bin\generic-worker.exe`
-		} else {
-			exe = os.Args[0]
-		}
-		cmd, err := NewCommand([]string{exe, "grant-winsta-access", "--sid", sid}, ".", []string{}, pd)
+		cmd, err := NewCommand([]string{runtime.GenericWorkerBinary(), "grant-winsta-access", "--sid", sid}, ".", []string{}, pd)
 		cmd.DirectOutput(os.Stdout)
 		log.Printf("About to run command: %#v", *(cmd.Cmd))
 		if err != nil {

--- a/workers/generic-worker/runtime/runtime.go
+++ b/workers/generic-worker/runtime/runtime.go
@@ -1,6 +1,11 @@
 package runtime
 
 import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
 	"github.com/dchest/uniuri"
 )
 
@@ -15,4 +20,21 @@ import (
 // should not be reproducible.
 func GeneratePassword() string {
 	return "pWd0_" + uniuri.NewLen(24)
+}
+
+func GenericWorkerBinary() string {
+	// We want to run generic-worker, which is os.Args[0] if we are running generic-worker, but if
+	// we are running tests, os.Args[0] will be the test executable, so then we use relative path to
+	// installed binary. This hack will go if we can impersonate the logged on user.
+	var exe string
+	if testing.Testing() {
+		exe = filepath.Join(os.Getenv("GOPATH"), "bin", "generic-worker")
+		if runtime.GOOS == "windows" {
+			exe += ".exe"
+		}
+	} else {
+		exe = os.Args[0]
+	}
+
+	return exe
 }

--- a/workers/generic-worker/runtime_multiuser.go
+++ b/workers/generic-worker/runtime_multiuser.go
@@ -1,0 +1,14 @@
+//go:build multiuser
+
+package main
+
+import (
+	"github.com/taskcluster/taskcluster/v58/workers/generic-worker/process"
+	"github.com/taskcluster/taskcluster/v58/workers/generic-worker/runtime"
+)
+
+// This is executed as the task user to ensure that the
+// generic-worker binary is readable/executable.
+func gwVersion() (*process.Command, error) {
+	return process.NewCommand([]string{runtime.GenericWorkerBinary(), "--version"}, taskContext.TaskDir, []string{}, taskContext.pd)
+}

--- a/workers/generic-worker/runtime_multiuser.go
+++ b/workers/generic-worker/runtime_multiuser.go
@@ -7,8 +7,11 @@ import (
 	"github.com/taskcluster/taskcluster/v58/workers/generic-worker/runtime"
 )
 
-// This is executed as the task user to ensure that the
-// generic-worker binary is readable/executable.
+// gwVersion returns a command that will run the
+// `generic-worker --version` command as the task user.
+// This is used during the startup of the worker to
+// ensure that the generic-worker binary is readable/executable
+// by the task user.
 func gwVersion() (*process.Command, error) {
 	return process.NewCommand([]string{runtime.GenericWorkerBinary(), "--version"}, taskContext.TaskDir, []string{}, taskContext.pd)
 }

--- a/workers/generic-worker/runtime_simple.go
+++ b/workers/generic-worker/runtime_simple.go
@@ -1,0 +1,14 @@
+//go:build simple
+
+package main
+
+import (
+	"github.com/taskcluster/taskcluster/v58/workers/generic-worker/process"
+	"github.com/taskcluster/taskcluster/v58/workers/generic-worker/runtime"
+)
+
+// This is executed as the task user to ensure that the
+// generic-worker binary is readable/executable.
+func gwVersion() (*process.Command, error) {
+	return process.NewCommand([]string{runtime.GenericWorkerBinary(), "--version"}, taskContext.TaskDir, []string{})
+}

--- a/workers/generic-worker/runtime_simple.go
+++ b/workers/generic-worker/runtime_simple.go
@@ -7,8 +7,11 @@ import (
 	"github.com/taskcluster/taskcluster/v58/workers/generic-worker/runtime"
 )
 
-// This is executed as the task user to ensure that the
-// generic-worker binary is readable/executable.
+// gwVersion returns a command that will run the
+// `generic-worker --version` command as the task user.
+// This is used during the startup of the worker to
+// ensure that the generic-worker binary is readable/executable
+// by the task user.
 func gwVersion() (*process.Command, error) {
 	return process.NewCommand([]string{runtime.GenericWorkerBinary(), "--version"}, taskContext.TaskDir, []string{})
 }


### PR DESCRIPTION
As a follow-up to https://github.com/taskcluster/taskcluster/pull/6673, this change will check to ensure that the generic-worker binary is readable and executable by the task user. If not, the worker will exit with exit code 69, internal error.

>Generic Worker: Adds validation that the task user is able to read and execute the generic-worker binary on startup of the worker. If the task user is not able to read and execute the binary, the worker will exit with exit code 69, internal error.