### PR TITLE
fix(generic-worker): disallow relative paths in file mounts

### DIFF
--- a/changelog/bug-1858424.md
+++ b/changelog/bug-1858424.md
@@ -1,0 +1,5 @@
+audience: general
+level: major
+reference: bug 1858424
+---
+Generic Worker: Disallow relative file mounts. All relative file paths will result in the mount happening from within the task user's directory.

--- a/workers/generic-worker/mounts.go
+++ b/workers/generic-worker/mounts.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strings"
 	"time"
 
 	"github.com/mholt/archiver/v3"
@@ -631,6 +632,15 @@ func (f *FileMount) Mount(taskMount *TaskMount) error {
 		return err
 	}
 
+	// We need to trim prefix and clean the path
+	// twice to cover edge cases. For example:
+	// ../../foo/bar.txt --> /foo/bar.txt
+	// ./../foo/bar.txt --> /foo/bar.txt
+	// ././../foo/bar.txt --> /foo/bar.txt
+	for i := 0; i < 2; i++ {
+		f.File = strings.TrimPrefix(f.File, "..")
+		f.File = filepath.Clean(f.File)
+	}
 	file := filepath.Join(taskContext.TaskDir, f.File)
 	err = decompress(fsContent, f.Format, file, taskMount)
 	if err != nil {


### PR DESCRIPTION
Fixes bugzilla bug 1858424.

>Generic Worker: Disallow relative file mounts. All relative file paths will result in the mount happening from within the task user's directory.