### PR TITLE
fix(generic-worker): fix gwVersion check on simple engine

### DIFF
--- a/changelog/issue-6701.md
+++ b/changelog/issue-6701.md
@@ -1,0 +1,5 @@
+audience: general
+level: patch
+reference: issue 6701
+---
+Generic Worker: Fixes `permission denied` error while checking if `generic-worker` binary is executable by the task user for simple engine.

--- a/workers/generic-worker/runtime_simple.go
+++ b/workers/generic-worker/runtime_simple.go
@@ -13,5 +13,5 @@ import (
 // ensure that the generic-worker binary is readable/executable
 // by the task user.
 func gwVersion() (*process.Command, error) {
-	return process.NewCommand([]string{runtime.GenericWorkerBinary(), "--version"}, taskContext.TaskDir, []string{})
+	return process.NewCommand([]string{runtime.GenericWorkerBinary(), "--version"}, "", []string{})
 }


### PR DESCRIPTION
Fixes #6701.

>Generic Worker: Fixes `permission denied` error while checking if `generic-worker` binary is executable by the task user for simple engine.