### PR TITLE
chore(db)!: remove pg11 support

### DIFF
--- a/changelog/issue-5514.md
+++ b/changelog/issue-5514.md
@@ -1,0 +1,5 @@
+audience: deployers
+level: major
+reference: issue 5514
+---
+Removes postgres v11 support.

--- a/db/README.md
+++ b/db/README.md
@@ -270,5 +270,5 @@ This approach is slower, but is appropriate for testing.
 
 ## Development
 
-To test this library, you will need a Postgres database, running the latest release of Postgres 11 or 15.
+To test this library, you will need a Postgres database, running the latest release of Postgres 15.
 The easiest and best way to do this is to use docker, as described in the [Development Process docs](../dev-docs/development-process.md).

--- a/dev-docs/best-practices/db.md
+++ b/dev-docs/best-practices/db.md
@@ -16,7 +16,7 @@ have isolated these into utility functions and tested them thoroughly.  If you
 find a need for more utility functions, add them, but be careful to test lots
 of cases, including backslashes.  In particular, note that there is an
 "alternative" string-escaping syntax `E'..'` documented at
-https://www.postgresql.org/docs/11/sql-syntax-lexical.html#SQL-SYNTAX-CONSTANTS.
+https://www.postgresql.org/docs/15/sql-syntax-lexical.html#SQL-SYNTAX-CONSTANTS.
 
 **Avoid Selecting Star**.  Using `select * from`, from a table which may someday
 grow additional columns, is likely to lead to unhappy surprises when data
@@ -27,7 +27,7 @@ timezone, so it could mean anything!  Use `timestamptz` instead.  This is
 enforced in CI.
 
 **Transactions Aren't Magic**. Bookmark [this mind-blowing
-page](https://www.postgresql.org/docs/11/transaction-iso.html), noting that
+page](https://www.postgresql.org/docs/15/transaction-iso.html), noting that
 *read committed* is the default and what we use for all transactions.  That
 means that even inside a transaction, two read operations may return different
 data.  Where necessary, use locking primitives such as `select .. for update`
@@ -37,7 +37,7 @@ regard.
 
 **Prefer JSONB over JSON**.  Use JSONB data types, and where possible use `jsonb_`
 utility functions.  The
-[docs](https://www.postgresql.org/docs/11/datatype-json.html) provide a good
+[docs](https://www.postgresql.org/docs/15/datatype-json.html) provide a good
 description of the difference between the types.
 
 **Always Use Objects for JSON data**.  The node-pg library has no context to

--- a/dev-docs/dev-deployment.md
+++ b/dev-docs/dev-deployment.md
@@ -16,7 +16,7 @@ You will need to have the following
 * A RabbitMQ cluster running the latest available version. (see also [install RabbitMQ](#own-rabbitmq-in-cluster))
   The deployment process requires administrative access (the RabbitMQ management API) and creates multiple users.
   The free levels of CloudAMQP's service do not support this.
-* A Postgres server running Postgres 11.x or 15.x (see below for Google Cloud SQL, or use another provider). (see also [install Postgres](#own-postgres-in-cluster))
+* A Postgres server running Postgres 15.x (see below for Google Cloud SQL, or use another provider). (see also [install Postgres](#own-postgres-in-cluster))
   The Postgres server must be initialized with the `en_US.utf8` locale; see [the deployment docs](../ui/docs/manual/deploying/database.mdx).
 * An AWS account and an IAM user in that account
   Set up your `aws` command-line to use the IAM user (`aws configure`).

--- a/dev-docs/development-process.md
+++ b/dev-docs/development-process.md
@@ -29,7 +29,7 @@ The currently-required version of Rust is in `rust-toolchain`.
 
 ### Postgres
 
-All Taskcluster services require a Postgres 11 or 15 server to run.
+All Taskcluster services require a Postgres 15 server to run.
 The easiest and best way to do this is to use docker, but if you prefer you can install a Postgres server locally.
 *NOTE* the test suites repeatedly drop the `public` schema and re-create it, effectively deleting all data in the database.
 Do not run these tests against a database instance that contains any useful data!

--- a/libraries/postgres/README.md
+++ b/libraries/postgres/README.md
@@ -502,5 +502,5 @@ Note that the return promise does not carry a value on success, as that success 
 
 ## Development
 
-To test this library, you will need a Postgres database, running the latest release of Postgres 11 or 15.
+To test this library, you will need a Postgres database, running the latest release of Postgres 15.
 The easiest and best way to do this is to use docker, as described in the [Development Process docs](../dev-docs/development-process.md).

--- a/libraries/postgres/src/Database.js
+++ b/libraries/postgres/src/Database.js
@@ -443,8 +443,8 @@ class Database {
       `);
       const ver = version.rows[0].current_setting;
       const majorVersion = Math.floor(ver / 10000);
-      if (majorVersion !== 11 && majorVersion !== 15) {
-        throw new Error("Postgres version is not 11.x or 15.x. Please upgrade to 11.x or 15.x");
+      if (majorVersion !== 15) {
+        throw new Error("Postgres version is not 15.x. Please change to 15.x");
       }
     });
   }

--- a/ui/docs/manual/deploying/database.mdx
+++ b/ui/docs/manual/deploying/database.mdx
@@ -6,7 +6,7 @@ import Warning from 'taskcluster-ui/views/Documentation/components/Warning';
 
 # Database Configuration
 
-Taskcluster uses a Postgres 11 or 15 database for its backend storage.
+Taskcluster uses a Postgres 15 database for its backend storage.
 A single database is shared among all services.
 
 Taskcluster assumes that it "owns" the database, but can share a single server with other users.


### PR DESCRIPTION
Related to #5514. Now that we've upgraded all of our deployments' pg databases to v15, we can drop v11.

>Removes postgres v11 support.