### PR TITLE
Tweaking numbers and adding `preStop` hook to make sure no connections are lost

### DIFF
--- a/changelog/issue-6716.md
+++ b/changelog/issue-6716.md
@@ -1,0 +1,6 @@
+audience: deployers
+level: patch
+reference: issue 6716
+---
+
+Adds lifecycle preStop hook for services to allow graceful termination of pods in kubernetes without loss of connections.

--- a/infrastructure/k8s/templates/taskcluster-auth-deployment-web.yaml
+++ b/infrastructure/k8s/templates/taskcluster-auth-deployment-web.yaml
@@ -19,7 +19,14 @@ spec:
     spec:
       serviceAccountName: taskcluster-auth
       imagePullSecrets: {{ if .Values.imagePullSecret }}{{ toJson (list (dict "name" .Values.imagePullSecret)) }}{{ else }}[]{{ end }}
-      terminationGracePeriodSeconds: 120
+      terminationGracePeriodSeconds: 45
+      lifecycle:
+        preStop:
+          exec:
+            command:
+              - /bin/sh
+              - '-c'
+              - sleep 30
       containers:
         - name: taskcluster-auth-web
           image: '{{ .Values.dockerImage }}'

--- a/infrastructure/k8s/templates/taskcluster-built-in-workers-deployment-server.yaml
+++ b/infrastructure/k8s/templates/taskcluster-built-in-workers-deployment-server.yaml
@@ -19,7 +19,14 @@ spec:
     spec:
       serviceAccountName: taskcluster-built-in-workers
       imagePullSecrets: {{ if .Values.imagePullSecret }}{{ toJson (list (dict "name" .Values.imagePullSecret)) }}{{ else }}[]{{ end }}
-      terminationGracePeriodSeconds: 120
+      terminationGracePeriodSeconds: 45
+      lifecycle:
+        preStop:
+          exec:
+            command:
+              - /bin/sh
+              - '-c'
+              - sleep 30
       containers:
         - name: taskcluster-built-in-workers-server
           image: '{{ .Values.dockerImage }}'

--- a/infrastructure/k8s/templates/taskcluster-github-deployment-web.yaml
+++ b/infrastructure/k8s/templates/taskcluster-github-deployment-web.yaml
@@ -19,7 +19,14 @@ spec:
     spec:
       serviceAccountName: taskcluster-github
       imagePullSecrets: {{ if .Values.imagePullSecret }}{{ toJson (list (dict "name" .Values.imagePullSecret)) }}{{ else }}[]{{ end }}
-      terminationGracePeriodSeconds: 120
+      terminationGracePeriodSeconds: 45
+      lifecycle:
+        preStop:
+          exec:
+            command:
+              - /bin/sh
+              - '-c'
+              - sleep 30
       containers:
         - name: taskcluster-github-web
           image: '{{ .Values.dockerImage }}'

--- a/infrastructure/k8s/templates/taskcluster-github-deployment-worker.yaml
+++ b/infrastructure/k8s/templates/taskcluster-github-deployment-worker.yaml
@@ -19,7 +19,14 @@ spec:
     spec:
       serviceAccountName: taskcluster-github
       imagePullSecrets: {{ if .Values.imagePullSecret }}{{ toJson (list (dict "name" .Values.imagePullSecret)) }}{{ else }}[]{{ end }}
-      terminationGracePeriodSeconds: 120
+      terminationGracePeriodSeconds: 45
+      lifecycle:
+        preStop:
+          exec:
+            command:
+              - /bin/sh
+              - '-c'
+              - sleep 30
       containers:
         - name: taskcluster-github-worker
           image: '{{ .Values.dockerImage }}'

--- a/infrastructure/k8s/templates/taskcluster-hooks-deployment-listeners.yaml
+++ b/infrastructure/k8s/templates/taskcluster-hooks-deployment-listeners.yaml
@@ -19,7 +19,14 @@ spec:
     spec:
       serviceAccountName: taskcluster-hooks
       imagePullSecrets: {{ if .Values.imagePullSecret }}{{ toJson (list (dict "name" .Values.imagePullSecret)) }}{{ else }}[]{{ end }}
-      terminationGracePeriodSeconds: 120
+      terminationGracePeriodSeconds: 45
+      lifecycle:
+        preStop:
+          exec:
+            command:
+              - /bin/sh
+              - '-c'
+              - sleep 30
       containers:
         - name: taskcluster-hooks-listeners
           image: '{{ .Values.dockerImage }}'

--- a/infrastructure/k8s/templates/taskcluster-hooks-deployment-scheduler.yaml
+++ b/infrastructure/k8s/templates/taskcluster-hooks-deployment-scheduler.yaml
@@ -19,7 +19,14 @@ spec:
     spec:
       serviceAccountName: taskcluster-hooks
       imagePullSecrets: {{ if .Values.imagePullSecret }}{{ toJson (list (dict "name" .Values.imagePullSecret)) }}{{ else }}[]{{ end }}
-      terminationGracePeriodSeconds: 120
+      terminationGracePeriodSeconds: 45
+      lifecycle:
+        preStop:
+          exec:
+            command:
+              - /bin/sh
+              - '-c'
+              - sleep 30
       containers:
         - name: taskcluster-hooks-scheduler
           image: '{{ .Values.dockerImage }}'

--- a/infrastructure/k8s/templates/taskcluster-hooks-deployment-web.yaml
+++ b/infrastructure/k8s/templates/taskcluster-hooks-deployment-web.yaml
@@ -19,7 +19,14 @@ spec:
     spec:
       serviceAccountName: taskcluster-hooks
       imagePullSecrets: {{ if .Values.imagePullSecret }}{{ toJson (list (dict "name" .Values.imagePullSecret)) }}{{ else }}[]{{ end }}
-      terminationGracePeriodSeconds: 120
+      terminationGracePeriodSeconds: 45
+      lifecycle:
+        preStop:
+          exec:
+            command:
+              - /bin/sh
+              - '-c'
+              - sleep 30
       containers:
         - name: taskcluster-hooks-web
           image: '{{ .Values.dockerImage }}'

--- a/infrastructure/k8s/templates/taskcluster-index-deployment-handlers.yaml
+++ b/infrastructure/k8s/templates/taskcluster-index-deployment-handlers.yaml
@@ -19,7 +19,14 @@ spec:
     spec:
       serviceAccountName: taskcluster-index
       imagePullSecrets: {{ if .Values.imagePullSecret }}{{ toJson (list (dict "name" .Values.imagePullSecret)) }}{{ else }}[]{{ end }}
-      terminationGracePeriodSeconds: 120
+      terminationGracePeriodSeconds: 45
+      lifecycle:
+        preStop:
+          exec:
+            command:
+              - /bin/sh
+              - '-c'
+              - sleep 30
       containers:
         - name: taskcluster-index-handlers
           image: '{{ .Values.dockerImage }}'

--- a/infrastructure/k8s/templates/taskcluster-index-deployment-web.yaml
+++ b/infrastructure/k8s/templates/taskcluster-index-deployment-web.yaml
@@ -19,7 +19,14 @@ spec:
     spec:
       serviceAccountName: taskcluster-index
       imagePullSecrets: {{ if .Values.imagePullSecret }}{{ toJson (list (dict "name" .Values.imagePullSecret)) }}{{ else }}[]{{ end }}
-      terminationGracePeriodSeconds: 120
+      terminationGracePeriodSeconds: 45
+      lifecycle:
+        preStop:
+          exec:
+            command:
+              - /bin/sh
+              - '-c'
+              - sleep 30
       containers:
         - name: taskcluster-index-web
           image: '{{ .Values.dockerImage }}'

--- a/infrastructure/k8s/templates/taskcluster-notify-deployment-handler.yaml
+++ b/infrastructure/k8s/templates/taskcluster-notify-deployment-handler.yaml
@@ -19,7 +19,14 @@ spec:
     spec:
       serviceAccountName: taskcluster-notify
       imagePullSecrets: {{ if .Values.imagePullSecret }}{{ toJson (list (dict "name" .Values.imagePullSecret)) }}{{ else }}[]{{ end }}
-      terminationGracePeriodSeconds: 120
+      terminationGracePeriodSeconds: 45
+      lifecycle:
+        preStop:
+          exec:
+            command:
+              - /bin/sh
+              - '-c'
+              - sleep 30
       containers:
         - name: taskcluster-notify-handler
           image: '{{ .Values.dockerImage }}'

--- a/infrastructure/k8s/templates/taskcluster-notify-deployment-web.yaml
+++ b/infrastructure/k8s/templates/taskcluster-notify-deployment-web.yaml
@@ -19,7 +19,14 @@ spec:
     spec:
       serviceAccountName: taskcluster-notify
       imagePullSecrets: {{ if .Values.imagePullSecret }}{{ toJson (list (dict "name" .Values.imagePullSecret)) }}{{ else }}[]{{ end }}
-      terminationGracePeriodSeconds: 120
+      terminationGracePeriodSeconds: 45
+      lifecycle:
+        preStop:
+          exec:
+            command:
+              - /bin/sh
+              - '-c'
+              - sleep 30
       containers:
         - name: taskcluster-notify-web
           image: '{{ .Values.dockerImage }}'

--- a/infrastructure/k8s/templates/taskcluster-object-deployment-web.yaml
+++ b/infrastructure/k8s/templates/taskcluster-object-deployment-web.yaml
@@ -19,7 +19,14 @@ spec:
     spec:
       serviceAccountName: taskcluster-object
       imagePullSecrets: {{ if .Values.imagePullSecret }}{{ toJson (list (dict "name" .Values.imagePullSecret)) }}{{ else }}[]{{ end }}
-      terminationGracePeriodSeconds: 120
+      terminationGracePeriodSeconds: 45
+      lifecycle:
+        preStop:
+          exec:
+            command:
+              - /bin/sh
+              - '-c'
+              - sleep 30
       containers:
         - name: taskcluster-object-web
           image: '{{ .Values.dockerImage }}'

--- a/infrastructure/k8s/templates/taskcluster-purge-cache-deployment-web.yaml
+++ b/infrastructure/k8s/templates/taskcluster-purge-cache-deployment-web.yaml
@@ -19,7 +19,14 @@ spec:
     spec:
       serviceAccountName: taskcluster-purge-cache
       imagePullSecrets: {{ if .Values.imagePullSecret }}{{ toJson (list (dict "name" .Values.imagePullSecret)) }}{{ else }}[]{{ end }}
-      terminationGracePeriodSeconds: 120
+      terminationGracePeriodSeconds: 45
+      lifecycle:
+        preStop:
+          exec:
+            command:
+              - /bin/sh
+              - '-c'
+              - sleep 30
       containers:
         - name: taskcluster-purge-cache-web
           image: '{{ .Values.dockerImage }}'

--- a/infrastructure/k8s/templates/taskcluster-queue-deployment-claimResolver.yaml
+++ b/infrastructure/k8s/templates/taskcluster-queue-deployment-claimResolver.yaml
@@ -19,7 +19,14 @@ spec:
     spec:
       serviceAccountName: taskcluster-queue
       imagePullSecrets: {{ if .Values.imagePullSecret }}{{ toJson (list (dict "name" .Values.imagePullSecret)) }}{{ else }}[]{{ end }}
-      terminationGracePeriodSeconds: 120
+      terminationGracePeriodSeconds: 45
+      lifecycle:
+        preStop:
+          exec:
+            command:
+              - /bin/sh
+              - '-c'
+              - sleep 30
       containers:
         - name: taskcluster-queue-claimresolver
           image: '{{ .Values.dockerImage }}'

--- a/infrastructure/k8s/templates/taskcluster-queue-deployment-deadlineResolver.yaml
+++ b/infrastructure/k8s/templates/taskcluster-queue-deployment-deadlineResolver.yaml
@@ -19,7 +19,14 @@ spec:
     spec:
       serviceAccountName: taskcluster-queue
       imagePullSecrets: {{ if .Values.imagePullSecret }}{{ toJson (list (dict "name" .Values.imagePullSecret)) }}{{ else }}[]{{ end }}
-      terminationGracePeriodSeconds: 120
+      terminationGracePeriodSeconds: 45
+      lifecycle:
+        preStop:
+          exec:
+            command:
+              - /bin/sh
+              - '-c'
+              - sleep 30
       containers:
         - name: taskcluster-queue-deadlineresolver
           image: '{{ .Values.dockerImage }}'

--- a/infrastructure/k8s/templates/taskcluster-queue-deployment-dependencyResolver.yaml
+++ b/infrastructure/k8s/templates/taskcluster-queue-deployment-dependencyResolver.yaml
@@ -19,7 +19,14 @@ spec:
     spec:
       serviceAccountName: taskcluster-queue
       imagePullSecrets: {{ if .Values.imagePullSecret }}{{ toJson (list (dict "name" .Values.imagePullSecret)) }}{{ else }}[]{{ end }}
-      terminationGracePeriodSeconds: 120
+      terminationGracePeriodSeconds: 45
+      lifecycle:
+        preStop:
+          exec:
+            command:
+              - /bin/sh
+              - '-c'
+              - sleep 30
       containers:
         - name: taskcluster-queue-dependencyresolver
           image: '{{ .Values.dockerImage }}'

--- a/infrastructure/k8s/templates/taskcluster-queue-deployment-web.yaml
+++ b/infrastructure/k8s/templates/taskcluster-queue-deployment-web.yaml
@@ -19,7 +19,14 @@ spec:
     spec:
       serviceAccountName: taskcluster-queue
       imagePullSecrets: {{ if .Values.imagePullSecret }}{{ toJson (list (dict "name" .Values.imagePullSecret)) }}{{ else }}[]{{ end }}
-      terminationGracePeriodSeconds: 120
+      terminationGracePeriodSeconds: 45
+      lifecycle:
+        preStop:
+          exec:
+            command:
+              - /bin/sh
+              - '-c'
+              - sleep 30
       containers:
         - name: taskcluster-queue-web
           image: '{{ .Values.dockerImage }}'

--- a/infrastructure/k8s/templates/taskcluster-references-deployment-web.yaml
+++ b/infrastructure/k8s/templates/taskcluster-references-deployment-web.yaml
@@ -19,7 +19,14 @@ spec:
     spec:
       serviceAccountName: taskcluster-references
       imagePullSecrets: {{ if .Values.imagePullSecret }}{{ toJson (list (dict "name" .Values.imagePullSecret)) }}{{ else }}[]{{ end }}
-      terminationGracePeriodSeconds: 120
+      terminationGracePeriodSeconds: 45
+      lifecycle:
+        preStop:
+          exec:
+            command:
+              - /bin/sh
+              - '-c'
+              - sleep 30
       containers:
         - name: taskcluster-references-web
           image: '{{ .Values.dockerImage }}'

--- a/infrastructure/k8s/templates/taskcluster-secrets-deployment-web.yaml
+++ b/infrastructure/k8s/templates/taskcluster-secrets-deployment-web.yaml
@@ -19,7 +19,14 @@ spec:
     spec:
       serviceAccountName: taskcluster-secrets
       imagePullSecrets: {{ if .Values.imagePullSecret }}{{ toJson (list (dict "name" .Values.imagePullSecret)) }}{{ else }}[]{{ end }}
-      terminationGracePeriodSeconds: 120
+      terminationGracePeriodSeconds: 45
+      lifecycle:
+        preStop:
+          exec:
+            command:
+              - /bin/sh
+              - '-c'
+              - sleep 30
       containers:
         - name: taskcluster-secrets-web
           image: '{{ .Values.dockerImage }}'

--- a/infrastructure/k8s/templates/taskcluster-ui-deployment-web.yaml
+++ b/infrastructure/k8s/templates/taskcluster-ui-deployment-web.yaml
@@ -19,7 +19,14 @@ spec:
     spec:
       serviceAccountName: taskcluster-ui
       imagePullSecrets: {{ if .Values.imagePullSecret }}{{ toJson (list (dict "name" .Values.imagePullSecret)) }}{{ else }}[]{{ end }}
-      terminationGracePeriodSeconds: 120
+      terminationGracePeriodSeconds: 45
+      lifecycle:
+        preStop:
+          exec:
+            command:
+              - /bin/sh
+              - '-c'
+              - sleep 30
       containers:
         - name: taskcluster-ui-web
           image: '{{ .Values.dockerImage }}'

--- a/infrastructure/k8s/templates/taskcluster-web-server-deployment-web.yaml
+++ b/infrastructure/k8s/templates/taskcluster-web-server-deployment-web.yaml
@@ -19,7 +19,14 @@ spec:
     spec:
       serviceAccountName: taskcluster-web-server
       imagePullSecrets: {{ if .Values.imagePullSecret }}{{ toJson (list (dict "name" .Values.imagePullSecret)) }}{{ else }}[]{{ end }}
-      terminationGracePeriodSeconds: 120
+      terminationGracePeriodSeconds: 45
+      lifecycle:
+        preStop:
+          exec:
+            command:
+              - /bin/sh
+              - '-c'
+              - sleep 30
       containers:
         - name: taskcluster-web-server-web
           image: '{{ .Values.dockerImage }}'

--- a/infrastructure/k8s/templates/taskcluster-worker-manager-deployment-provisioner.yaml
+++ b/infrastructure/k8s/templates/taskcluster-worker-manager-deployment-provisioner.yaml
@@ -19,7 +19,14 @@ spec:
     spec:
       serviceAccountName: taskcluster-worker-manager
       imagePullSecrets: {{ if .Values.imagePullSecret }}{{ toJson (list (dict "name" .Values.imagePullSecret)) }}{{ else }}[]{{ end }}
-      terminationGracePeriodSeconds: 120
+      terminationGracePeriodSeconds: 45
+      lifecycle:
+        preStop:
+          exec:
+            command:
+              - /bin/sh
+              - '-c'
+              - sleep 30
       containers:
         - name: taskcluster-worker-manager-provisioner
           image: '{{ .Values.dockerImage }}'

--- a/infrastructure/k8s/templates/taskcluster-worker-manager-deployment-web.yaml
+++ b/infrastructure/k8s/templates/taskcluster-worker-manager-deployment-web.yaml
@@ -19,7 +19,14 @@ spec:
     spec:
       serviceAccountName: taskcluster-worker-manager
       imagePullSecrets: {{ if .Values.imagePullSecret }}{{ toJson (list (dict "name" .Values.imagePullSecret)) }}{{ else }}[]{{ end }}
-      terminationGracePeriodSeconds: 120
+      terminationGracePeriodSeconds: 45
+      lifecycle:
+        preStop:
+          exec:
+            command:
+              - /bin/sh
+              - '-c'
+              - sleep 30
       containers:
         - name: taskcluster-worker-manager-web
           image: '{{ .Values.dockerImage }}'

--- a/infrastructure/k8s/templates/taskcluster-worker-manager-deployment-workerscanner-azure.yaml
+++ b/infrastructure/k8s/templates/taskcluster-worker-manager-deployment-workerscanner-azure.yaml
@@ -19,7 +19,14 @@ spec:
     spec:
       serviceAccountName: taskcluster-worker-manager
       imagePullSecrets: {{ if .Values.imagePullSecret }}{{ toJson (list (dict "name" .Values.imagePullSecret)) }}{{ else }}[]{{ end }}
-      terminationGracePeriodSeconds: 120
+      terminationGracePeriodSeconds: 45
+      lifecycle:
+        preStop:
+          exec:
+            command:
+              - /bin/sh
+              - '-c'
+              - sleep 30
       containers:
         - name: taskcluster-worker-manager-workerscanner-azure
           image: '{{ .Values.dockerImage }}'

--- a/infrastructure/k8s/templates/taskcluster-worker-manager-deployment-workerscanner.yaml
+++ b/infrastructure/k8s/templates/taskcluster-worker-manager-deployment-workerscanner.yaml
@@ -19,7 +19,14 @@ spec:
     spec:
       serviceAccountName: taskcluster-worker-manager
       imagePullSecrets: {{ if .Values.imagePullSecret }}{{ toJson (list (dict "name" .Values.imagePullSecret)) }}{{ else }}[]{{ end }}
-      terminationGracePeriodSeconds: 120
+      terminationGracePeriodSeconds: 45
+      lifecycle:
+        preStop:
+          exec:
+            command:
+              - /bin/sh
+              - '-c'
+              - sleep 30
       containers:
         - name: taskcluster-worker-manager-workerscanner
           image: '{{ .Values.dockerImage }}'

--- a/infrastructure/tooling/templates/k8s/deployment.yaml
+++ b/infrastructure/tooling/templates/k8s/deployment.yaml
@@ -18,7 +18,11 @@ spec:
       # allow server to terminate gracefully while still serving existing connections
       # new connections would be rejected as server will be closed
       # and under normal conditions pod will stop faster than this timeout
-      terminationGracePeriodSeconds: 120
+      terminationGracePeriodSeconds: 45
+      lifecycle:
+        preStop:
+          exec:
+            command: ['/bin/sh', '-c', 'sleep 30']
       containers:
       - name: ${projectName}-${lowercase(procName)}
         image: '{{ .Values.dockerImage }}'


### PR DESCRIPTION
Tested on dev and this seems to give best result with zero connections being lost after manually scaling up and down during load testing. Without lifecycle hook connections were still dropping, but with it none.
