### PR TITLE
fix(generic-worker): fix `file-not-readable-on-worker` artifact upload error for simple engine

### DIFF
--- a/changelog/issue-6733.md
+++ b/changelog/issue-6733.md
@@ -1,0 +1,5 @@
+audience: general
+level: patch
+reference: issue 6733
+---
+Generic Worker: fixes `file-not-readable-on-worker` error while uploading artifacts with the simple engine.

--- a/workers/generic-worker/artifacts.go
+++ b/workers/generic-worker/artifacts.go
@@ -166,7 +166,7 @@ func resolve(base *artifacts.BaseArtifact, artifactType string, path string, con
 	if err != nil {
 		return &artifacts.ErrorArtifact{
 			BaseArtifact: base,
-			Message:      fmt.Sprintf("Could not copy file '%s' to temporary location as task user", fullPath),
+			Message:      fmt.Sprintf("Could not copy file '%s' to temporary location as task user: %v", fullPath, err),
 			Reason:       "file-not-readable-on-worker",
 			Path:         path,
 		}

--- a/workers/generic-worker/artifacts_simple.go
+++ b/workers/generic-worker/artifacts_simple.go
@@ -8,5 +8,5 @@ import (
 )
 
 func gwCopyToTempFile(filePath string) (*process.Command, error) {
-	return process.NewCommand([]string{gwruntime.GenericWorkerBinary(), "copy-to-temp-file", "--copy-file", filePath}, taskContext.TaskDir, []string{})
+	return process.NewCommand([]string{gwruntime.GenericWorkerBinary(), "copy-to-temp-file", "--copy-file", filePath}, "", []string{})
 }


### PR DESCRIPTION
Fixes #6733.

>Generic Worker: fixes `file-not-readable-on-worker` error while uploading artifacts with the simple engine.