### PR TITLE
chore(generic-worker): update help text

### DIFF
--- a/changelog/issue-6739.md
+++ b/changelog/issue-6739.md
@@ -1,0 +1,5 @@
+audience: worker-deployers
+level: patch
+reference: issue 6739
+---
+Generic Worker: Updates `--help` text to include missing exit codes (76, 79, and 80).

--- a/workers/generic-worker/README.md
+++ b/workers/generic-worker/README.md
@@ -293,9 +293,12 @@ and reports back results to the queue.
            spot termination notice, and therefore has shut down.
     73     The config provided to the worker is invalid.
     75     Not able to create an ed25519 key pair.
+    76     Not able to copy --copy-file to a temporary file.
     77     Not able to apply required file access permissions to the generic-worker config
            file so that task users can't read from or write to it.
     78     Not able to connect to --worker-runner-protocol-pipe.
+    79     Not able to create file at --create-file path.
+    80     Not able to create directory at --create-dir path.
 ```
 <!-- HELP END -->
 

--- a/workers/generic-worker/usage.go
+++ b/workers/generic-worker/usage.go
@@ -306,7 +306,10 @@ and reports back results to the queue.
     72     The worker is running on spot infrastructure in AWS EC2 and has been served a
            spot termination notice, and therefore has shut down.
     73     The config provided to the worker is invalid.` + exitCode74() + `
-    75     Not able to create an ed25519 key pair.` + exitCode77() + `
+    75     Not able to create an ed25519 key pair.
+    76     Not able to copy --copy-file to a temporary file.` + exitCode77() + `
     78     Not able to connect to --worker-runner-protocol-pipe.
+    79     Not able to create file at --create-file path.
+    80     Not able to create directory at --create-dir path.
 `
 }


### PR DESCRIPTION
Fixes https://github.com/taskcluster/taskcluster/issues/6739.

>Generic Worker: Updates `--help` text to include missing exit codes (76, 79, and 80).