### PR TITLE
worker-manager: take stopping instances into account for desired capacity

### DIFF
--- a/changelog/issue-6641.md
+++ b/changelog/issue-6641.md
@@ -1,0 +1,5 @@
+audience: deployers
+level: patch
+reference: issue 6641
+---
+Worker-manager no longer counts "stopping" instances as part of the existing capacity when estimating the number of workers to start (although they are still counted towards maxCapacity).

--- a/services/worker-manager/src/estimator.js
+++ b/services/worker-manager/src/estimator.js
@@ -8,15 +8,23 @@ export class Estimator {
     const { pendingTasks } = await this.queue.pendingTasks(workerPoolId);
     const { existingCapacity, stoppingCapacity = 0, requestedCapacity = 0 } = workerInfo;
 
+    // Due to the fact that workers could fail to start on azure, deprovisioning will take significant amount of time
+    // and on the next provision loop, those workers wouldn't be considered as requested or existing capacity
+    // so worker manager would try to provision for this pool again
+    // workers in stopping state would keep growing, and deprovisioning takes many calls, even though it wasn't created
+    // to avoid this situation we would take into account stopping capacity and don't allow worker pool
+    // to have existing + stopping capacity > max capacity to prevent affected pool start extra instances
+    const totalNonStopped = existingCapacity + stoppingCapacity;
+
     // First we find the amount of capacity we want. This is a very simple approximation
-    // We add existingCapacity here to represent existing workers and subtract it later.
+    // We add totalNonStopped here to represent existing workers and subtract it later.
     // We scale up based on the scaling ratio and number of pending tasks.
     // We ask to spawn as much capacity as the scaling ratio dictates to cover all
     // pending tasks at any time unless it would create more than maxCapacity instances
     const desiredCapacity = Math.max(
       minCapacity,
       // only scale as high as maxCapacity
-      Math.min(pendingTasks * scalingRatio + existingCapacity, maxCapacity),
+      Math.min(pendingTasks * scalingRatio + totalNonStopped, maxCapacity),
     );
     const estimatorInfo = {
       workerPoolId,
@@ -48,14 +56,6 @@ export class Estimator {
     if (overProvisioned) {
       this.monitor.reportError(new Error('Estimated existing capacity (pending and running) is much greater than max capacity'), estimatorInfo);
     }
-
-    // due to the fact that workers could fail to start on azure, deprovisioning will take significant amount of time
-    // and on the next provision loop, those workers wouldn't be considered as requested or existing capacity
-    // so worker manager would try to provision for this pool again
-    // workers in stopping state would keep growing, and deprovisioning takes many calls, even though it wasn't created
-    // to avoid this situation we would take into account stopping capacity and don't allow worker pool
-    // to have existing + stopping capacity > max capacity to prevent affected pool start extra instances
-    const totalNonStopped = existingCapacity + stoppingCapacity;
 
     // Workers turn themselves off so we just return a positive number for
     // how many extra we want if we do want any

--- a/services/worker-manager/test/estimator_test.js
+++ b/services/worker-manager/test/estimator_test.js
@@ -247,4 +247,23 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
     assert.strictEqual(monitor.manager.messages.length, 1);
     assert(monitor.manager.messages.some(({ Type, Severity }) => Type === 'simple-estimate' && Severity === 5));
   });
+  test('stopping + requested capacity exceeds pending', async function () {
+    const workerInfo = {
+      existingCapacity: 0,
+      requestedCapacity: 10,
+      stoppingCapacity: 10,
+    };
+    helper.queue.setPending('foo/bar', 20);
+    const estimate = await estimator.simple({
+      workerPoolId: 'foo/bar',
+      maxCapacity: 50,
+      minCapacity: 0,
+      scalingRatio: 1,
+      workerInfo,
+    });
+
+    assert.strictEqual(estimate, 10);
+    assert.strictEqual(monitor.manager.messages.length, 1);
+    assert(monitor.manager.messages.some(({ Type, Severity }) => Type === 'simple-estimate' && Severity === 5));
+  });
 });


### PR DESCRIPTION
The estimator subtracts stopping workers from the desired capacity, but they're not actually useful capacity.  So we now also count them as part of the desired capacity, to make sure not to exceed maxCapacity while not otherwise preventing the spawning of new workers.

Github Bug/Issue: Fixes #6641 
