### PR TITLE
Kubernetes config improvements

### DIFF
--- a/changelog/issue-6759.md
+++ b/changelog/issue-6759.md
@@ -1,0 +1,6 @@
+audience: deployers
+level: major
+reference: issue 6759
+---
+
+Kubernetes pods use liveness probe instead of unconditionally killing containers daily.

--- a/infrastructure/k8s/templates/taskcluster-auth-deployment-web.yaml
+++ b/infrastructure/k8s/templates/taskcluster-auth-deployment-web.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       serviceAccountName: taskcluster-auth
       imagePullSecrets: {{ if .Values.imagePullSecret }}{{ toJson (list (dict "name" .Values.imagePullSecret)) }}{{ else }}[]{{ end }}
-      terminationGracePeriodSeconds: 45
+      terminationGracePeriodSeconds: 120
       containers:
         - name: taskcluster-auth-web
           image: '{{ .Values.dockerImage }}'
@@ -50,20 +50,18 @@ spec:
               port: 80
             timeoutSeconds: 5
             periodSeconds: 10
-            initialDelaySeconds: 3
+            initialDelaySeconds: 6
           livenessProbe:
-            exec:
-              command:
-                - /bin/sh
-                - '-c'
-                - exit $(awk 'BEGIN{srand(); print (rand() > 0.3)}')
-            initialDelaySeconds: 86400
-            periodSeconds: 60
-            failureThreshold: 1
+            httpGet:
+              path: /api/auth/v1/ping
+              port: 80
+            timeoutSeconds: 3
+            initialDelaySeconds: 15
+            periodSeconds: 30
           lifecycle:
             preStop:
               exec:
                 command:
                   - /bin/sh
                   - '-c'
-                  - sleep 30
+                  - sleep 10

--- a/infrastructure/k8s/templates/taskcluster-built-in-workers-deployment-server.yaml
+++ b/infrastructure/k8s/templates/taskcluster-built-in-workers-deployment-server.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       serviceAccountName: taskcluster-built-in-workers
       imagePullSecrets: {{ if .Values.imagePullSecret }}{{ toJson (list (dict "name" .Values.imagePullSecret)) }}{{ else }}[]{{ end }}
-      terminationGracePeriodSeconds: 45
+      terminationGracePeriodSeconds: 120
       containers:
         - name: taskcluster-built-in-workers-server
           image: '{{ .Values.dockerImage }}'
@@ -47,6 +47,6 @@ spec:
                 - /bin/sh
                 - '-c'
                 - exit $(awk 'BEGIN{srand(); print (rand() > 0.3)}')
-            initialDelaySeconds: 86400
+            initialDelaySeconds: 432000
             periodSeconds: 60
             failureThreshold: 1

--- a/infrastructure/k8s/templates/taskcluster-github-deployment-web.yaml
+++ b/infrastructure/k8s/templates/taskcluster-github-deployment-web.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       serviceAccountName: taskcluster-github
       imagePullSecrets: {{ if .Values.imagePullSecret }}{{ toJson (list (dict "name" .Values.imagePullSecret)) }}{{ else }}[]{{ end }}
-      terminationGracePeriodSeconds: 45
+      terminationGracePeriodSeconds: 120
       containers:
         - name: taskcluster-github-web
           image: '{{ .Values.dockerImage }}'
@@ -50,20 +50,18 @@ spec:
               port: 80
             timeoutSeconds: 5
             periodSeconds: 10
-            initialDelaySeconds: 3
+            initialDelaySeconds: 6
           livenessProbe:
-            exec:
-              command:
-                - /bin/sh
-                - '-c'
-                - exit $(awk 'BEGIN{srand(); print (rand() > 0.3)}')
-            initialDelaySeconds: 86400
-            periodSeconds: 60
-            failureThreshold: 1
+            httpGet:
+              path: /api/github/v1/ping
+              port: 80
+            timeoutSeconds: 3
+            initialDelaySeconds: 15
+            periodSeconds: 30
           lifecycle:
             preStop:
               exec:
                 command:
                   - /bin/sh
                   - '-c'
-                  - sleep 30
+                  - sleep 10

--- a/infrastructure/k8s/templates/taskcluster-github-deployment-worker.yaml
+++ b/infrastructure/k8s/templates/taskcluster-github-deployment-worker.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       serviceAccountName: taskcluster-github
       imagePullSecrets: {{ if .Values.imagePullSecret }}{{ toJson (list (dict "name" .Values.imagePullSecret)) }}{{ else }}[]{{ end }}
-      terminationGracePeriodSeconds: 45
+      terminationGracePeriodSeconds: 120
       containers:
         - name: taskcluster-github-worker
           image: '{{ .Values.dockerImage }}'
@@ -47,6 +47,6 @@ spec:
                 - /bin/sh
                 - '-c'
                 - exit $(awk 'BEGIN{srand(); print (rand() > 0.3)}')
-            initialDelaySeconds: 86400
+            initialDelaySeconds: 432000
             periodSeconds: 60
             failureThreshold: 1

--- a/infrastructure/k8s/templates/taskcluster-hooks-deployment-listeners.yaml
+++ b/infrastructure/k8s/templates/taskcluster-hooks-deployment-listeners.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       serviceAccountName: taskcluster-hooks
       imagePullSecrets: {{ if .Values.imagePullSecret }}{{ toJson (list (dict "name" .Values.imagePullSecret)) }}{{ else }}[]{{ end }}
-      terminationGracePeriodSeconds: 45
+      terminationGracePeriodSeconds: 120
       containers:
         - name: taskcluster-hooks-listeners
           image: '{{ .Values.dockerImage }}'
@@ -47,6 +47,6 @@ spec:
                 - /bin/sh
                 - '-c'
                 - exit $(awk 'BEGIN{srand(); print (rand() > 0.3)}')
-            initialDelaySeconds: 86400
+            initialDelaySeconds: 432000
             periodSeconds: 60
             failureThreshold: 1

--- a/infrastructure/k8s/templates/taskcluster-hooks-deployment-scheduler.yaml
+++ b/infrastructure/k8s/templates/taskcluster-hooks-deployment-scheduler.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       serviceAccountName: taskcluster-hooks
       imagePullSecrets: {{ if .Values.imagePullSecret }}{{ toJson (list (dict "name" .Values.imagePullSecret)) }}{{ else }}[]{{ end }}
-      terminationGracePeriodSeconds: 45
+      terminationGracePeriodSeconds: 120
       containers:
         - name: taskcluster-hooks-scheduler
           image: '{{ .Values.dockerImage }}'
@@ -47,6 +47,6 @@ spec:
                 - /bin/sh
                 - '-c'
                 - exit $(awk 'BEGIN{srand(); print (rand() > 0.3)}')
-            initialDelaySeconds: 86400
+            initialDelaySeconds: 432000
             periodSeconds: 60
             failureThreshold: 1

--- a/infrastructure/k8s/templates/taskcluster-hooks-deployment-web.yaml
+++ b/infrastructure/k8s/templates/taskcluster-hooks-deployment-web.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       serviceAccountName: taskcluster-hooks
       imagePullSecrets: {{ if .Values.imagePullSecret }}{{ toJson (list (dict "name" .Values.imagePullSecret)) }}{{ else }}[]{{ end }}
-      terminationGracePeriodSeconds: 45
+      terminationGracePeriodSeconds: 120
       containers:
         - name: taskcluster-hooks-web
           image: '{{ .Values.dockerImage }}'
@@ -50,20 +50,18 @@ spec:
               port: 80
             timeoutSeconds: 5
             periodSeconds: 10
-            initialDelaySeconds: 3
+            initialDelaySeconds: 6
           livenessProbe:
-            exec:
-              command:
-                - /bin/sh
-                - '-c'
-                - exit $(awk 'BEGIN{srand(); print (rand() > 0.3)}')
-            initialDelaySeconds: 86400
-            periodSeconds: 60
-            failureThreshold: 1
+            httpGet:
+              path: /api/hooks/v1/ping
+              port: 80
+            timeoutSeconds: 3
+            initialDelaySeconds: 15
+            periodSeconds: 30
           lifecycle:
             preStop:
               exec:
                 command:
                   - /bin/sh
                   - '-c'
-                  - sleep 30
+                  - sleep 10

--- a/infrastructure/k8s/templates/taskcluster-index-deployment-handlers.yaml
+++ b/infrastructure/k8s/templates/taskcluster-index-deployment-handlers.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       serviceAccountName: taskcluster-index
       imagePullSecrets: {{ if .Values.imagePullSecret }}{{ toJson (list (dict "name" .Values.imagePullSecret)) }}{{ else }}[]{{ end }}
-      terminationGracePeriodSeconds: 45
+      terminationGracePeriodSeconds: 120
       containers:
         - name: taskcluster-index-handlers
           image: '{{ .Values.dockerImage }}'
@@ -47,6 +47,6 @@ spec:
                 - /bin/sh
                 - '-c'
                 - exit $(awk 'BEGIN{srand(); print (rand() > 0.3)}')
-            initialDelaySeconds: 86400
+            initialDelaySeconds: 432000
             periodSeconds: 60
             failureThreshold: 1

--- a/infrastructure/k8s/templates/taskcluster-index-deployment-web.yaml
+++ b/infrastructure/k8s/templates/taskcluster-index-deployment-web.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       serviceAccountName: taskcluster-index
       imagePullSecrets: {{ if .Values.imagePullSecret }}{{ toJson (list (dict "name" .Values.imagePullSecret)) }}{{ else }}[]{{ end }}
-      terminationGracePeriodSeconds: 45
+      terminationGracePeriodSeconds: 120
       containers:
         - name: taskcluster-index-web
           image: '{{ .Values.dockerImage }}'
@@ -50,20 +50,18 @@ spec:
               port: 80
             timeoutSeconds: 5
             periodSeconds: 10
-            initialDelaySeconds: 3
+            initialDelaySeconds: 6
           livenessProbe:
-            exec:
-              command:
-                - /bin/sh
-                - '-c'
-                - exit $(awk 'BEGIN{srand(); print (rand() > 0.3)}')
-            initialDelaySeconds: 86400
-            periodSeconds: 60
-            failureThreshold: 1
+            httpGet:
+              path: /api/index/v1/ping
+              port: 80
+            timeoutSeconds: 3
+            initialDelaySeconds: 15
+            periodSeconds: 30
           lifecycle:
             preStop:
               exec:
                 command:
                   - /bin/sh
                   - '-c'
-                  - sleep 30
+                  - sleep 10

--- a/infrastructure/k8s/templates/taskcluster-notify-deployment-handler.yaml
+++ b/infrastructure/k8s/templates/taskcluster-notify-deployment-handler.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       serviceAccountName: taskcluster-notify
       imagePullSecrets: {{ if .Values.imagePullSecret }}{{ toJson (list (dict "name" .Values.imagePullSecret)) }}{{ else }}[]{{ end }}
-      terminationGracePeriodSeconds: 45
+      terminationGracePeriodSeconds: 120
       containers:
         - name: taskcluster-notify-handler
           image: '{{ .Values.dockerImage }}'
@@ -47,6 +47,6 @@ spec:
                 - /bin/sh
                 - '-c'
                 - exit $(awk 'BEGIN{srand(); print (rand() > 0.3)}')
-            initialDelaySeconds: 86400
+            initialDelaySeconds: 432000
             periodSeconds: 60
             failureThreshold: 1

--- a/infrastructure/k8s/templates/taskcluster-notify-deployment-web.yaml
+++ b/infrastructure/k8s/templates/taskcluster-notify-deployment-web.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       serviceAccountName: taskcluster-notify
       imagePullSecrets: {{ if .Values.imagePullSecret }}{{ toJson (list (dict "name" .Values.imagePullSecret)) }}{{ else }}[]{{ end }}
-      terminationGracePeriodSeconds: 45
+      terminationGracePeriodSeconds: 120
       containers:
         - name: taskcluster-notify-web
           image: '{{ .Values.dockerImage }}'
@@ -50,20 +50,18 @@ spec:
               port: 80
             timeoutSeconds: 5
             periodSeconds: 10
-            initialDelaySeconds: 3
+            initialDelaySeconds: 6
           livenessProbe:
-            exec:
-              command:
-                - /bin/sh
-                - '-c'
-                - exit $(awk 'BEGIN{srand(); print (rand() > 0.3)}')
-            initialDelaySeconds: 86400
-            periodSeconds: 60
-            failureThreshold: 1
+            httpGet:
+              path: /api/notify/v1/ping
+              port: 80
+            timeoutSeconds: 3
+            initialDelaySeconds: 15
+            periodSeconds: 30
           lifecycle:
             preStop:
               exec:
                 command:
                   - /bin/sh
                   - '-c'
-                  - sleep 30
+                  - sleep 10

--- a/infrastructure/k8s/templates/taskcluster-object-deployment-web.yaml
+++ b/infrastructure/k8s/templates/taskcluster-object-deployment-web.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       serviceAccountName: taskcluster-object
       imagePullSecrets: {{ if .Values.imagePullSecret }}{{ toJson (list (dict "name" .Values.imagePullSecret)) }}{{ else }}[]{{ end }}
-      terminationGracePeriodSeconds: 45
+      terminationGracePeriodSeconds: 120
       containers:
         - name: taskcluster-object-web
           image: '{{ .Values.dockerImage }}'
@@ -50,20 +50,18 @@ spec:
               port: 80
             timeoutSeconds: 5
             periodSeconds: 10
-            initialDelaySeconds: 3
+            initialDelaySeconds: 6
           livenessProbe:
-            exec:
-              command:
-                - /bin/sh
-                - '-c'
-                - exit $(awk 'BEGIN{srand(); print (rand() > 0.3)}')
-            initialDelaySeconds: 86400
-            periodSeconds: 60
-            failureThreshold: 1
+            httpGet:
+              path: /api/object/v1/ping
+              port: 80
+            timeoutSeconds: 3
+            initialDelaySeconds: 15
+            periodSeconds: 30
           lifecycle:
             preStop:
               exec:
                 command:
                   - /bin/sh
                   - '-c'
-                  - sleep 30
+                  - sleep 10

--- a/infrastructure/k8s/templates/taskcluster-purge-cache-deployment-web.yaml
+++ b/infrastructure/k8s/templates/taskcluster-purge-cache-deployment-web.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       serviceAccountName: taskcluster-purge-cache
       imagePullSecrets: {{ if .Values.imagePullSecret }}{{ toJson (list (dict "name" .Values.imagePullSecret)) }}{{ else }}[]{{ end }}
-      terminationGracePeriodSeconds: 45
+      terminationGracePeriodSeconds: 120
       containers:
         - name: taskcluster-purge-cache-web
           image: '{{ .Values.dockerImage }}'
@@ -50,20 +50,18 @@ spec:
               port: 80
             timeoutSeconds: 5
             periodSeconds: 10
-            initialDelaySeconds: 3
+            initialDelaySeconds: 6
           livenessProbe:
-            exec:
-              command:
-                - /bin/sh
-                - '-c'
-                - exit $(awk 'BEGIN{srand(); print (rand() > 0.3)}')
-            initialDelaySeconds: 86400
-            periodSeconds: 60
-            failureThreshold: 1
+            httpGet:
+              path: /api/purge-cache/v1/ping
+              port: 80
+            timeoutSeconds: 3
+            initialDelaySeconds: 15
+            periodSeconds: 30
           lifecycle:
             preStop:
               exec:
                 command:
                   - /bin/sh
                   - '-c'
-                  - sleep 30
+                  - sleep 10

--- a/infrastructure/k8s/templates/taskcluster-queue-deployment-claimResolver.yaml
+++ b/infrastructure/k8s/templates/taskcluster-queue-deployment-claimResolver.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       serviceAccountName: taskcluster-queue
       imagePullSecrets: {{ if .Values.imagePullSecret }}{{ toJson (list (dict "name" .Values.imagePullSecret)) }}{{ else }}[]{{ end }}
-      terminationGracePeriodSeconds: 45
+      terminationGracePeriodSeconds: 120
       containers:
         - name: taskcluster-queue-claimresolver
           image: '{{ .Values.dockerImage }}'
@@ -47,6 +47,6 @@ spec:
                 - /bin/sh
                 - '-c'
                 - exit $(awk 'BEGIN{srand(); print (rand() > 0.3)}')
-            initialDelaySeconds: 86400
+            initialDelaySeconds: 432000
             periodSeconds: 60
             failureThreshold: 1

--- a/infrastructure/k8s/templates/taskcluster-queue-deployment-deadlineResolver.yaml
+++ b/infrastructure/k8s/templates/taskcluster-queue-deployment-deadlineResolver.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       serviceAccountName: taskcluster-queue
       imagePullSecrets: {{ if .Values.imagePullSecret }}{{ toJson (list (dict "name" .Values.imagePullSecret)) }}{{ else }}[]{{ end }}
-      terminationGracePeriodSeconds: 45
+      terminationGracePeriodSeconds: 120
       containers:
         - name: taskcluster-queue-deadlineresolver
           image: '{{ .Values.dockerImage }}'
@@ -47,6 +47,6 @@ spec:
                 - /bin/sh
                 - '-c'
                 - exit $(awk 'BEGIN{srand(); print (rand() > 0.3)}')
-            initialDelaySeconds: 86400
+            initialDelaySeconds: 432000
             periodSeconds: 60
             failureThreshold: 1

--- a/infrastructure/k8s/templates/taskcluster-queue-deployment-dependencyResolver.yaml
+++ b/infrastructure/k8s/templates/taskcluster-queue-deployment-dependencyResolver.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       serviceAccountName: taskcluster-queue
       imagePullSecrets: {{ if .Values.imagePullSecret }}{{ toJson (list (dict "name" .Values.imagePullSecret)) }}{{ else }}[]{{ end }}
-      terminationGracePeriodSeconds: 45
+      terminationGracePeriodSeconds: 120
       containers:
         - name: taskcluster-queue-dependencyresolver
           image: '{{ .Values.dockerImage }}'
@@ -47,6 +47,6 @@ spec:
                 - /bin/sh
                 - '-c'
                 - exit $(awk 'BEGIN{srand(); print (rand() > 0.3)}')
-            initialDelaySeconds: 86400
+            initialDelaySeconds: 432000
             periodSeconds: 60
             failureThreshold: 1

--- a/infrastructure/k8s/templates/taskcluster-queue-deployment-web.yaml
+++ b/infrastructure/k8s/templates/taskcluster-queue-deployment-web.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       serviceAccountName: taskcluster-queue
       imagePullSecrets: {{ if .Values.imagePullSecret }}{{ toJson (list (dict "name" .Values.imagePullSecret)) }}{{ else }}[]{{ end }}
-      terminationGracePeriodSeconds: 45
+      terminationGracePeriodSeconds: 120
       containers:
         - name: taskcluster-queue-web
           image: '{{ .Values.dockerImage }}'
@@ -50,20 +50,18 @@ spec:
               port: 80
             timeoutSeconds: 5
             periodSeconds: 10
-            initialDelaySeconds: 3
+            initialDelaySeconds: 6
           livenessProbe:
-            exec:
-              command:
-                - /bin/sh
-                - '-c'
-                - exit $(awk 'BEGIN{srand(); print (rand() > 0.3)}')
-            initialDelaySeconds: 86400
-            periodSeconds: 60
-            failureThreshold: 1
+            httpGet:
+              path: /api/queue/v1/ping
+              port: 80
+            timeoutSeconds: 3
+            initialDelaySeconds: 15
+            periodSeconds: 30
           lifecycle:
             preStop:
               exec:
                 command:
                   - /bin/sh
                   - '-c'
-                  - sleep 30
+                  - sleep 10

--- a/infrastructure/k8s/templates/taskcluster-references-deployment-web.yaml
+++ b/infrastructure/k8s/templates/taskcluster-references-deployment-web.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       serviceAccountName: taskcluster-references
       imagePullSecrets: {{ if .Values.imagePullSecret }}{{ toJson (list (dict "name" .Values.imagePullSecret)) }}{{ else }}[]{{ end }}
-      terminationGracePeriodSeconds: 45
+      terminationGracePeriodSeconds: 120
       containers:
         - name: taskcluster-references-web
           image: '{{ .Values.dockerImage }}'
@@ -50,20 +50,18 @@ spec:
               port: 80
             timeoutSeconds: 5
             periodSeconds: 10
-            initialDelaySeconds: 3
+            initialDelaySeconds: 6
           livenessProbe:
-            exec:
-              command:
-                - /bin/sh
-                - '-c'
-                - exit $(awk 'BEGIN{srand(); print (rand() > 0.3)}')
-            initialDelaySeconds: 86400
-            periodSeconds: 60
-            failureThreshold: 1
+            httpGet:
+              path: /references/
+              port: 80
+            timeoutSeconds: 3
+            initialDelaySeconds: 15
+            periodSeconds: 30
           lifecycle:
             preStop:
               exec:
                 command:
                   - /bin/sh
                   - '-c'
-                  - sleep 30
+                  - sleep 10

--- a/infrastructure/k8s/templates/taskcluster-secrets-deployment-web.yaml
+++ b/infrastructure/k8s/templates/taskcluster-secrets-deployment-web.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       serviceAccountName: taskcluster-secrets
       imagePullSecrets: {{ if .Values.imagePullSecret }}{{ toJson (list (dict "name" .Values.imagePullSecret)) }}{{ else }}[]{{ end }}
-      terminationGracePeriodSeconds: 45
+      terminationGracePeriodSeconds: 120
       containers:
         - name: taskcluster-secrets-web
           image: '{{ .Values.dockerImage }}'
@@ -50,20 +50,18 @@ spec:
               port: 80
             timeoutSeconds: 5
             periodSeconds: 10
-            initialDelaySeconds: 3
+            initialDelaySeconds: 6
           livenessProbe:
-            exec:
-              command:
-                - /bin/sh
-                - '-c'
-                - exit $(awk 'BEGIN{srand(); print (rand() > 0.3)}')
-            initialDelaySeconds: 86400
-            periodSeconds: 60
-            failureThreshold: 1
+            httpGet:
+              path: /api/secrets/v1/ping
+              port: 80
+            timeoutSeconds: 3
+            initialDelaySeconds: 15
+            periodSeconds: 30
           lifecycle:
             preStop:
               exec:
                 command:
                   - /bin/sh
                   - '-c'
-                  - sleep 30
+                  - sleep 10

--- a/infrastructure/k8s/templates/taskcluster-ui-deployment-web.yaml
+++ b/infrastructure/k8s/templates/taskcluster-ui-deployment-web.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       serviceAccountName: taskcluster-ui
       imagePullSecrets: {{ if .Values.imagePullSecret }}{{ toJson (list (dict "name" .Values.imagePullSecret)) }}{{ else }}[]{{ end }}
-      terminationGracePeriodSeconds: 45
+      terminationGracePeriodSeconds: 120
       containers:
         - name: taskcluster-ui-web
           image: '{{ .Values.dockerImage }}'
@@ -50,20 +50,18 @@ spec:
               port: 80
             timeoutSeconds: 5
             periodSeconds: 10
-            initialDelaySeconds: 3
+            initialDelaySeconds: 6
           livenessProbe:
-            exec:
-              command:
-                - /bin/sh
-                - '-c'
-                - exit $(awk 'BEGIN{srand(); print (rand() > 0.3)}')
-            initialDelaySeconds: 86400
-            periodSeconds: 60
-            failureThreshold: 1
+            httpGet:
+              path: /
+              port: 80
+            timeoutSeconds: 3
+            initialDelaySeconds: 15
+            periodSeconds: 30
           lifecycle:
             preStop:
               exec:
                 command:
                   - /bin/sh
                   - '-c'
-                  - sleep 30
+                  - sleep 10

--- a/infrastructure/k8s/templates/taskcluster-web-server-deployment-web.yaml
+++ b/infrastructure/k8s/templates/taskcluster-web-server-deployment-web.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       serviceAccountName: taskcluster-web-server
       imagePullSecrets: {{ if .Values.imagePullSecret }}{{ toJson (list (dict "name" .Values.imagePullSecret)) }}{{ else }}[]{{ end }}
-      terminationGracePeriodSeconds: 45
+      terminationGracePeriodSeconds: 120
       containers:
         - name: taskcluster-web-server-web
           image: '{{ .Values.dockerImage }}'
@@ -50,20 +50,18 @@ spec:
               port: 80
             timeoutSeconds: 5
             periodSeconds: 10
-            initialDelaySeconds: 3
+            initialDelaySeconds: 6
           livenessProbe:
-            exec:
-              command:
-                - /bin/sh
-                - '-c'
-                - exit $(awk 'BEGIN{srand(); print (rand() > 0.3)}')
-            initialDelaySeconds: 86400
-            periodSeconds: 60
-            failureThreshold: 1
+            httpGet:
+              path: .well-known/apollo/server-health
+              port: 80
+            timeoutSeconds: 3
+            initialDelaySeconds: 15
+            periodSeconds: 30
           lifecycle:
             preStop:
               exec:
                 command:
                   - /bin/sh
                   - '-c'
-                  - sleep 30
+                  - sleep 10

--- a/infrastructure/k8s/templates/taskcluster-worker-manager-deployment-provisioner.yaml
+++ b/infrastructure/k8s/templates/taskcluster-worker-manager-deployment-provisioner.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       serviceAccountName: taskcluster-worker-manager
       imagePullSecrets: {{ if .Values.imagePullSecret }}{{ toJson (list (dict "name" .Values.imagePullSecret)) }}{{ else }}[]{{ end }}
-      terminationGracePeriodSeconds: 45
+      terminationGracePeriodSeconds: 120
       containers:
         - name: taskcluster-worker-manager-provisioner
           image: '{{ .Values.dockerImage }}'
@@ -47,6 +47,6 @@ spec:
                 - /bin/sh
                 - '-c'
                 - exit $(awk 'BEGIN{srand(); print (rand() > 0.3)}')
-            initialDelaySeconds: 86400
+            initialDelaySeconds: 432000
             periodSeconds: 60
             failureThreshold: 1

--- a/infrastructure/k8s/templates/taskcluster-worker-manager-deployment-web.yaml
+++ b/infrastructure/k8s/templates/taskcluster-worker-manager-deployment-web.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       serviceAccountName: taskcluster-worker-manager
       imagePullSecrets: {{ if .Values.imagePullSecret }}{{ toJson (list (dict "name" .Values.imagePullSecret)) }}{{ else }}[]{{ end }}
-      terminationGracePeriodSeconds: 45
+      terminationGracePeriodSeconds: 120
       containers:
         - name: taskcluster-worker-manager-web
           image: '{{ .Values.dockerImage }}'
@@ -50,20 +50,18 @@ spec:
               port: 80
             timeoutSeconds: 5
             periodSeconds: 10
-            initialDelaySeconds: 3
+            initialDelaySeconds: 6
           livenessProbe:
-            exec:
-              command:
-                - /bin/sh
-                - '-c'
-                - exit $(awk 'BEGIN{srand(); print (rand() > 0.3)}')
-            initialDelaySeconds: 86400
-            periodSeconds: 60
-            failureThreshold: 1
+            httpGet:
+              path: /api/worker-manager/v1/ping
+              port: 80
+            timeoutSeconds: 3
+            initialDelaySeconds: 15
+            periodSeconds: 30
           lifecycle:
             preStop:
               exec:
                 command:
                   - /bin/sh
                   - '-c'
-                  - sleep 30
+                  - sleep 10

--- a/infrastructure/k8s/templates/taskcluster-worker-manager-deployment-workerscanner-azure.yaml
+++ b/infrastructure/k8s/templates/taskcluster-worker-manager-deployment-workerscanner-azure.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       serviceAccountName: taskcluster-worker-manager
       imagePullSecrets: {{ if .Values.imagePullSecret }}{{ toJson (list (dict "name" .Values.imagePullSecret)) }}{{ else }}[]{{ end }}
-      terminationGracePeriodSeconds: 45
+      terminationGracePeriodSeconds: 120
       containers:
         - name: taskcluster-worker-manager-workerscanner-azure
           image: '{{ .Values.dockerImage }}'
@@ -47,6 +47,6 @@ spec:
                 - /bin/sh
                 - '-c'
                 - exit $(awk 'BEGIN{srand(); print (rand() > 0.3)}')
-            initialDelaySeconds: 86400
+            initialDelaySeconds: 432000
             periodSeconds: 60
             failureThreshold: 1

--- a/infrastructure/k8s/templates/taskcluster-worker-manager-deployment-workerscanner.yaml
+++ b/infrastructure/k8s/templates/taskcluster-worker-manager-deployment-workerscanner.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       serviceAccountName: taskcluster-worker-manager
       imagePullSecrets: {{ if .Values.imagePullSecret }}{{ toJson (list (dict "name" .Values.imagePullSecret)) }}{{ else }}[]{{ end }}
-      terminationGracePeriodSeconds: 45
+      terminationGracePeriodSeconds: 120
       containers:
         - name: taskcluster-worker-manager-workerscanner
           image: '{{ .Values.dockerImage }}'
@@ -47,6 +47,6 @@ spec:
                 - /bin/sh
                 - '-c'
                 - exit $(awk 'BEGIN{srand(); print (rand() > 0.3)}')
-            initialDelaySeconds: 86400
+            initialDelaySeconds: 432000
             periodSeconds: 60
             failureThreshold: 1

--- a/infrastructure/tooling/templates/k8s/deployment.yaml
+++ b/infrastructure/tooling/templates/k8s/deployment.yaml
@@ -18,7 +18,7 @@ spec:
       # allow server to terminate gracefully while still serving existing connections
       # new connections would be rejected as server will be closed
       # and under normal conditions pod will stop faster than this timeout
-      terminationGracePeriodSeconds: 45
+      terminationGracePeriodSeconds: 120
       containers:
       - name: ${projectName}-${lowercase(procName)}
         image: '{{ .Values.dockerImage }}'
@@ -55,23 +55,29 @@ spec:
               port: 80
             timeoutSeconds: 5
             periodSeconds: 10
-            initialDelaySeconds: 3
-        # After 24 hours, we start randomly deciding to exit the container.
-        # Taskcluster services are created with the assumption that they will
-        # not run indefinitely.
+            initialDelaySeconds: 6
         livenessProbe:
-          exec:
-            command:
-            - /bin/sh
-            - -c
-            - exit $(awk 'BEGIN{srand(); print (rand() > 0.3)}')
-          initialDelaySeconds: 86400
-          periodSeconds: 60
-          failureThreshold: 1
+          $if: 'needsService'
+          then:
+            httpGet:
+              path: ${readinessPath}
+              port: 80
+            timeoutSeconds: 3
+            initialDelaySeconds: 15
+            periodSeconds: 30
+          else:
+            exec:
+              command:
+              - /bin/sh
+              - -c
+              - exit $(awk 'BEGIN{srand(); print (rand() > 0.3)}')
+            initialDelaySeconds: 432000 # 5 days
+            periodSeconds: 60
+            failureThreshold: 1
         # allow graceful termination of existing connections and let them finish
         lifecycle:
           $if: 'needsService'
           then:
             preStop:
               exec:
-                command: ['/bin/sh', '-c', 'sleep 30']
+                command: ['/bin/sh', '-c', 'sleep 10']

--- a/libraries/app/src/index.js
+++ b/libraries/app/src/index.js
@@ -66,6 +66,7 @@ const createServer = function() {
       });
   }
   process.on('SIGTERM', shutdown);
+  process.on('SIGINT', shutdown);
 
   return new Promise((accept, reject) => {
     // Launch HTTP server
@@ -73,11 +74,13 @@ const createServer = function() {
 
     // Add a little method to help kill the server
     server.terminate = () => {
+      debug('Terminating server');
       // tell existing connections to close
       server.on('request', (req, res) => {
         if (!res.headersSent) {
           res.setHeader('Connection', 'close');
         }
+        res.on('finish', () => req.socket.destroy());
       });
 
       return new Promise((accept, reject) => {


### PR DESCRIPTION
This changes container lifecycle in kubernetes, therefor a major version.

- web containers no longer killed daily and will be running as long as process responds to `livenessProbe`. (There are no indications that containers leak memory or use large amounts of CPU when running longer than few days)
- non-web containers keep the old logic, but will be terminated after 5 days instead (experiment to see if this can be removed or better not)
- tweaks `initialDelaySeconds` for readiness probe, as `3` was too short and caused too many errors to be logged.
- additionally listens to `SIGINT`
- grace termination period increased to `120s` (k8s will not kill stopping pod for so long)
- `lifecycle.preStop` sleep timeout reduced to `10s` because this happens before container's process receives `SIGTERM`, and thus no `server.close()` is being called

Documentation is not yet updated as this is still an experiment to figure out proper combination of timeouts and calls.


How it should work theoretically:
- pod is being created and starts serving requests
- once it is being terminated (by autoscaler or deployment) k8s will run `lifecycle.preStop` hook, it will wait 10s and then main process would receive `SIGTERM`. (This delay is needed, I believe, to give enough time to `kubelet` and `kubelet-proxy` to exclude this pod from network endpoints and stop sending new traffic). 
- `SIGTERM` should be handled by main process, and `server.close()` would be invoked that, in theory, should wait until all open connections will be closed. Additionally, it would tell all open connections (keepalive) to close connection and destroy socket 
- when all connections will be closed, `server.close()` would terminate process and container should be finally killed
- this should all happen within `terminationGracePeriodSeconds`



Fixes #6759 
