### PR TITLE
fix(d2g): auto retry on exit code 128

### DIFF
--- a/changelog/issue-6762.md
+++ b/changelog/issue-6762.md
@@ -1,0 +1,5 @@
+audience: general
+level: patch
+reference: issue 6762
+---
+Generic Worker: Tasks internally translated by D2G will add exit code 128 to the retry exit status array for retrying on an intermittent docker image pull issue.

--- a/taskcluster/src/transforms/__init__.py
+++ b/taskcluster/src/transforms/__init__.py
@@ -135,7 +135,10 @@ def podman_run(config, tasks):
         # An error sometimes occurs while pulling the docker image:
         # Error: reading blob sha256:<SHA>: Get "<URL>": remote error: tls: handshake failure
         # And this exits 125, so we'd like to retry.
-        task["worker"].setdefault("retry-exit-status", []).append(125)
+        # Another error sometimes occurs while pulling the docker image:
+        # error: RPC failed; curl 92 HTTP/2 stream 5 was not closed cleanly: CANCEL (err 8)
+        # And this exits 128, so we'd like to retry.
+        task["worker"].setdefault("retry-exit-status", []).extend([125, 128])
 
         yield task
 

--- a/tools/d2g/d2gtest/testdata/testcases/artifacts_test.yml
+++ b/tools/d2g/d2gtest/testdata/testcases/artifacts_test.yml
@@ -53,4 +53,5 @@ testSuite:
         onExitStatus:
           retry:
             - 125
+            - 128
   taskDefTests: []

--- a/tools/d2g/d2gtest/testdata/testcases/decision_task_tests.yml
+++ b/tools/d2g/d2gtest/testdata/testcases/decision_task_tests.yml
@@ -57,6 +57,7 @@ testSuite:
         onExitStatus:
           retry:
             - 125
+            - 128
           purgeCaches:
             - 123
             - 456
@@ -153,6 +154,7 @@ testSuite:
         onExitStatus:
           retry:
             - 125
+            - 128
           purgeCaches:
             - 123
             - 456

--- a/tools/d2g/d2gtest/testdata/testcases/devices_tests.yml
+++ b/tools/d2g/d2gtest/testdata/testcases/devices_tests.yml
@@ -30,6 +30,7 @@ testSuite:
         onExitStatus:
           retry:
             - 125
+            - 128
 
     - name: KVM
       description: >-
@@ -58,6 +59,7 @@ testSuite:
         onExitStatus:
           retry:
             - 125
+            - 128
         osGroups:
           - kvm
 
@@ -90,6 +92,7 @@ testSuite:
         onExitStatus:
           retry:
             - 125
+            - 128
 
     - name: Audio Loopback
       description: >-
@@ -120,4 +123,5 @@ testSuite:
         onExitStatus:
           retry:
             - 125
+            - 128
   taskDefTests: []

--- a/tools/d2g/d2gtest/testdata/testcases/docker_image_tests.yml
+++ b/tools/d2g/d2gtest/testdata/testcases/docker_image_tests.yml
@@ -25,6 +25,7 @@ testSuite:
         onExitStatus:
           retry:
             - 125
+            - 128
 
     - name: NamedDockerImage
       description: Test NamedDockerImage
@@ -50,6 +51,7 @@ testSuite:
         onExitStatus:
           retry:
             - 125
+            - 128
 
     - name: IndexedDockerImage
       description: Test IndexedDockerImage
@@ -83,6 +85,7 @@ testSuite:
         onExitStatus:
           retry:
             - 125
+            - 128
 
     - name: IndexedDockerImage with .lz4 extension
       description: Test IndexedDockerImage with .lz4 extension
@@ -117,6 +120,7 @@ testSuite:
         onExitStatus:
           retry:
             - 125
+            - 128
 
     - name: IndexedDockerImage with .zst extension
       description: Test IndexedDockerImage with .zst extension
@@ -151,6 +155,7 @@ testSuite:
         onExitStatus:
           retry:
             - 125
+            - 128
 
     - name: DockerImageArtifact
       description: Test DockerImageArtifact
@@ -182,6 +187,7 @@ testSuite:
         onExitStatus:
           retry:
             - 125
+            - 128
 
     - name: DockerImageArtifact with .lz4 extension
       description: Test DockerImageArtifact with .lz4 extension
@@ -214,6 +220,7 @@ testSuite:
         onExitStatus:
           retry:
             - 125
+            - 128
 
     - name: DockerImageArtifact with .zst extension
       description: Test DockerImageArtifact with .zst extension
@@ -246,4 +253,5 @@ testSuite:
         onExitStatus:
           retry:
             - 125
+            - 128
   taskDefTests: []

--- a/tools/d2g/d2gtest/testdata/testcases/dw_features_tests.yml
+++ b/tools/d2g/d2gtest/testdata/testcases/dw_features_tests.yml
@@ -28,4 +28,5 @@ testSuite:
         onExitStatus:
           retry:
             - 125
+            - 128
   taskDefTests: []

--- a/tools/d2g/d2gtest/testdata/testcases/env_escaping_test.yml
+++ b/tools/d2g/d2gtest/testdata/testcases/env_escaping_test.yml
@@ -32,4 +32,5 @@ testSuite:
         onExitStatus:
           retry:
             - 125
+            - 128
   taskDefTests: []

--- a/tools/d2g/d2gtest/testdata/testcases/no_artifacts_test.yml
+++ b/tools/d2g/d2gtest/testdata/testcases/no_artifacts_test.yml
@@ -36,4 +36,5 @@ testSuite:
         onExitStatus:
           retry:
             - 125
+            - 128
   taskDefTests: []

--- a/tools/d2g/d2gtest/testdata/testcases/task_def_test.yml
+++ b/tools/d2g/d2gtest/testdata/testcases/task_def_test.yml
@@ -69,6 +69,7 @@ testSuite:
           onExitStatus:
             retry:
             - 125
+            - 128
           osGroups:
             - kvm
         priority: lowest
@@ -151,6 +152,7 @@ testSuite:
           onExitStatus:
             retry:
             - 125
+            - 128
           osGroups:
             - kvm
         priority: lowest
@@ -235,6 +237,7 @@ testSuite:
           onExitStatus:
             retry:
             - 125
+            - 128
           osGroups:
             - kvm
         priority: lowest


### PR DESCRIPTION
Fixes https://github.com/taskcluster/taskcluster/issues/6762.

>Generic Worker: Tasks internally translated by D2G will add exit code 128 to the retry exit status array for retrying on an intermittent docker image pull issue.