### PR TITLE
Improve changelog rendering.

### DIFF
--- a/changelog/issue-6495.md
+++ b/changelog/issue-6495.md
@@ -1,0 +1,6 @@
+audience: users
+level: minor
+reference: issue 6495
+---
+
+Improve changelog rendering in UI

--- a/ui/src/components/Markdown/index.jsx
+++ b/ui/src/components/Markdown/index.jsx
@@ -8,13 +8,16 @@ import { alpha, withStyles } from '@material-ui/core/styles';
 import 'highlight.js/styles/atom-one-dark.css';
 
 const markdown = parser({ linkify: true });
+const markdownHtml = parser({ html: true, linkify: true });
 
-markdown.use(highlighter);
-markdown.use(linkAttributes, {
-  attrs: {
-    target: '_blank',
-    rel: 'noopener noreferrer',
-  },
+[markdown, markdownHtml].forEach(md => {
+  md.use(highlighter);
+  md.use(linkAttributes, {
+    attrs: {
+      target: '_blank',
+      rel: 'noopener noreferrer',
+    },
+  });
 });
 
 @withStyles(theme => ({
@@ -197,14 +200,15 @@ export default class Markdown extends Component {
   };
 
   render() {
-    const { classes, children, className, ...props } = this.props;
+    const { classes, children, className, allowHtml, ...props } = this.props;
+    const md = allowHtml ? markdownHtml : markdown;
 
     /* eslint-disable react/no-danger */
     return (
       <span
         className={classNames(classes.root, className)}
         dangerouslySetInnerHTML={{
-          __html: markdown.render(children),
+          __html: md.render(children),
         }}
         {...props}
       />

--- a/ui/src/views/Documentation/Changelog/index.jsx
+++ b/ui/src/views/Documentation/Changelog/index.jsx
@@ -59,6 +59,12 @@ const FILTERS = ['version', 'from', 'to', 'q', 'all', 'audience'];
       background: theme.palette.secondary.main,
       fontWeight: 'bold',
     },
+    '& summary': {
+      cursor: 'pointer',
+    },
+    '& summary::marker': {
+      color: theme.palette.secondary.main,
+    },
   },
   cbx: {
     marginTop: theme.spacing(2),
@@ -243,16 +249,18 @@ export default class Changelog extends Component {
                 onClick={() => onToggleFilter('version', section.version)}>
                 {section.version}
               </span>
-              <Chip
-                className={classes.chip}
-                size="small"
-                color="primary"
-                label={section.audience}
-                clickable
-                onClick={() => onToggleFilter('audience', section.audience)}
-              />
+              {section.audience && (
+                <Chip
+                  className={classes.chip}
+                  size="small"
+                  color="primary"
+                  label={section.audience}
+                  clickable
+                  onClick={() => onToggleFilter('audience', section.audience)}
+                />
+              )}
             </h1>
-            <Markdown className={classes.md}>
+            <Markdown allowHtml className={classes.md}>
               {maybeHighlight(section.html, this.state.q)}
             </Markdown>
           </Grid>


### PR DESCRIPTION
Rendering <details><summary> blocks

<img width="1308" alt="image" src="https://github.com/taskcluster/taskcluster/assets/83861/0fbe7f4d-a266-4542-ab09-bdfd5a752cd0">



Fixes #6495
