### PR TITLE
websocktunnel local dev improvements

### DIFF
--- a/changelog/websocktunnel-dev.md
+++ b/changelog/websocktunnel-dev.md
@@ -1,0 +1,5 @@
+audience: developers
+level: patch
+---
+
+Added helper script to make it easier to run websocktunnel locally.

--- a/tools/websocktunnel/.gitignore
+++ b/tools/websocktunnel/.gitignore
@@ -1,5 +1,5 @@
 #wsmux
-./websocktunnel
+websocktunnel
 main
 certs/
 cmd/client/client

--- a/tools/websocktunnel/Dockerfile
+++ b/tools/websocktunnel/Dockerfile
@@ -1,0 +1,4 @@
+# Dockerfile for easy local development. For production builds see /infrastructure/tooling/src/build/tasks/release.js
+FROM scratch
+COPY websocktunnel /websocktunnel
+ENTRYPOINT ["/websocktunnel"]

--- a/tools/websocktunnel/README.md
+++ b/tools/websocktunnel/README.md
@@ -24,7 +24,7 @@ index 3153ab63f..b2e679230 100644
  	n, err := copyAndFlush(wf, resp.Body, 100*time.Millisecond)
  	p.logf(id, r.RemoteAddr, "data transfered over request: %d bytes, error: %v", n, err)
  }
- 
+
  // validate jwt
  // jwt signing and verification algorithm must be HMAC
  func (p *proxy) validateJWT(id string, tokenString string) error {
@@ -37,7 +37,7 @@ index 3153ab63f..b2e679230 100644
  		ValidMethods:         []string{"HS256"},
  		SkipClaimsValidation: true, // Claims will be verified if token can be decoded using secret
  	}
- 
+
 ```
 
 For the latter, a patch like this to generic-worker is recommended:
@@ -47,7 +47,7 @@ index 51bd3eb8f..b3efac30f 100644
 --- a/workers/generic-worker/artifacts.go
 +++ b/workers/generic-worker/artifacts.go
 @@ -280,16 +280,17 @@ func (task *TaskRun) uploadLog(name, path string) *CommandExecutionError {
- 
+
  func (task *TaskRun) uploadArtifact(artifact artifacts.TaskArtifact) *CommandExecutionError {
  	task.Artifacts[artifact.Base().Name] = artifact
  	payload, err := json.Marshal(artifact.RequestObject())

--- a/tools/websocktunnel/README.md
+++ b/tools/websocktunnel/README.md
@@ -7,3 +7,66 @@ See https://docs.taskcluster.net/docs/reference/workers/websocktunnel for docume
 ## Development
 
 To hack on this service, follow the instructions in the `dev-docs` directory of this repository.
+
+## Using a local websocktunnel with an existing Taskcluster deployment
+
+You can test websocktunnel with an existing Taskcluster deployment by running your own websocktunnel process, and your own worker which points at it. There are some caveats:
+* You will need to patch websocktunnel to accept any auth (because you most likely do not have access to the correct secret)
+* Links provided by the existing deployment's UI will not work (you'll need to pull the links out of your worker logs instead)
+
+For the former, you can return early from the `validateJWT` method, eg:
+```
+index 3153ab63f..b2e679230 100644
+--- a/tools/websocktunnel/wsproxy/proxy.go
++++ b/tools/websocktunnel/wsproxy/proxy.go
+@@ -327,16 +327,18 @@ func (p *proxy) serveRequest(w http.ResponseWriter, r *http.Request, id string,
+ 	wf := &threadSafeWriteFlusher{w: w, f: flusher}
+ 	n, err := copyAndFlush(wf, resp.Body, 100*time.Millisecond)
+ 	p.logf(id, r.RemoteAddr, "data transfered over request: %d bytes, error: %v", n, err)
+ }
+ 
+ // validate jwt
+ // jwt signing and verification algorithm must be HMAC
+ func (p *proxy) validateJWT(id string, tokenString string) error {
++	return nil;
++
+ 	// parse jwt token
+ 	// default parser verifies iat token if present. This can be a problem because of clocks not being
+ 	// in sync.
+ 	parser := &jwt.Parser{
+ 		ValidMethods:         []string{"HS256"},
+ 		SkipClaimsValidation: true, // Claims will be verified if token can be decoded using secret
+ 	}
+ 
+```
+
+For the latter, a patch like this to generic-worker is recommended:
+```
+diff --git a/workers/generic-worker/artifacts.go b/workers/generic-worker/artifacts.go
+index 51bd3eb8f..b3efac30f 100644
+--- a/workers/generic-worker/artifacts.go
++++ b/workers/generic-worker/artifacts.go
+@@ -280,16 +280,17 @@ func (task *TaskRun) uploadLog(name, path string) *CommandExecutionError {
+ 
+ func (task *TaskRun) uploadArtifact(artifact artifacts.TaskArtifact) *CommandExecutionError {
+ 	task.Artifacts[artifact.Base().Name] = artifact
+ 	payload, err := json.Marshal(artifact.RequestObject())
+ 	if err != nil {
+ 		panic(err)
+ 	}
+ 	par := tcqueue.PostArtifactRequest(json.RawMessage(payload))
++	log.Print(string(payload));
+ 	task.queueMux.RLock()
+ 	parsp, err := task.Queue.CreateArtifact(
+ 		task.TaskID,
+ 		strconv.Itoa(int(task.RunID)),
+ 		artifact.Base().Name,
+ 		&par,
+ 	)
+ 	task.queueMux.RUnlock()
+```
+
+With that applied you should messages similar to the following when a task begins to execute on your worker:
+```
+2024/01/12 20:19:36Z {"contentType":"text/plain; charset=utf-8","expires":"2024-01-12T21:34:36.541Z","storageType":"reference","url":"http://localhost:1080/test-worker-group.bhearsum.60099/log/GiOHKockQCK57rBYmo2ntA"}
+```

--- a/tools/websocktunnel/cmd/wst-client/main.go
+++ b/tools/websocktunnel/cmd/wst-client/main.go
@@ -178,6 +178,7 @@ func (f *forwarder) forward() {
 	// just to be sure
 	defer f.kill()
 	if err != nil {
+		log.Error(err)
 		return
 	}
 

--- a/tools/websocktunnel/start-dev.sh
+++ b/tools/websocktunnel/start-dev.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+set -e
+
+# Disables syslog/json log formatting - output will be human readable text on stdout
+ENV="localdev"
+TASKCLUSTER_PROXY_SECRET_A="foobar"
+TASKCLUSTER_PROXY_SECRET_B="barfoo"
+PORT="1080"
+URL_PREFIX="http://localhost:${PORT}"
+
+CGO_ENABLED=0 go build -o . ./cmd/websocktunnel
+
+docker build -t websocktunnel:dev .
+
+docker run --rm \
+    -e URL_PREFIX="${URL_PREFIX}" \
+    -e ENV="${ENV}" \
+    -e TASKCLUSTER_PROXY_SECRET_A="${TASKCLUSTER_PROXY_SECRET_A}" \
+    -e TASKCLUSTER_PROXY_SECRET_B="${TASKCLUSTER_PROXY_SECRET_B}" \
+    -e PORT="${PORT}" \
+    -p "${PORT}:${PORT}" \
+    -it \
+    websocktunnel:dev


### PR DESCRIPTION
I managed to get a local websocktunnel and generic worker talking to each other with these instructions. (I used the firefox ci staging taskcluster deployment for the core services - hence the necessary hacks around auth.)