### PR TITLE
Issue #6779 - generic-worker (interactive feature): fix data race of cmd.ProcessState

### DIFF
--- a/changelog/issue-6779.md
+++ b/changelog/issue-6779.md
@@ -1,0 +1,5 @@
+audience: worker-deployers
+level: patch
+reference: issue 6779
+---
+Interactive feature data race fixed, whereby an error could cause a concurrent read and write of process state in different go routines.

--- a/workers/generic-worker/interactive/interactivejob.go
+++ b/workers/generic-worker/interactive/interactivejob.go
@@ -77,11 +77,12 @@ func CreateInteractiveJob(createCmd CreateInteractiveProcess, conn *websocket.Co
 }
 
 func (itj *InteractiveJob) Terminate() (err error) {
-	if itj.cmd.ProcessState != nil {
+	select {
+	case <-itj.done:
 		return nil
+	default:
+		return itj.cmd.Process.Kill()
 	}
-
-	return itj.cmd.Process.Kill()
 }
 
 func (itj *InteractiveJob) copyCommandOutputStream() {


### PR DESCRIPTION
Github Bug/Issue: Fixes #6779