### PR TITLE
Generic Worker: exit with exit code 82 if chain of trust key missing

### DIFF
--- a/changelog/issue-6785.md
+++ b/changelog/issue-6785.md
@@ -1,0 +1,5 @@
+audience: worker-deployers
+level: minor
+reference: issue 6785
+---
+Generic Worker now exits with exit code 82 if the chain of trust key is missing.

--- a/workers/generic-worker/README.md
+++ b/workers/generic-worker/README.md
@@ -307,6 +307,7 @@ and reports back results to the queue.
     79     Not able to create file at --create-file path.
     80     Not able to create directory at --create-dir path.
     81     Not able to unarchive --archive-src to --archive-dst.
+    82     Missing ed25519 private key. Did you run generic-worker new-ed25519-keypair?
 ```
 <!-- HELP END -->
 

--- a/workers/generic-worker/chain_of_trust.go
+++ b/workers/generic-worker/chain_of_trust.go
@@ -65,6 +65,14 @@ type ChainOfTrustTaskFeature struct {
 	disabled       bool
 }
 
+type MissingED25519PrivateKey struct {
+	Err error
+}
+
+func (m *MissingED25519PrivateKey) Error() string {
+	return fmt.Sprintf("Missing ED25519 Private Key: %v", m.Err)
+}
+
 func (feature *ChainOfTrustFeature) Name() string {
 	return "Chain of Trust"
 }
@@ -76,7 +84,9 @@ func (feature *ChainOfTrustFeature) PersistState() error {
 func (feature *ChainOfTrustFeature) Initialise() (err error) {
 	feature.Ed25519PrivateKey, err = readEd25519PrivateKeyFromFile(config.Ed25519SigningKeyLocation)
 	if err != nil {
-		return
+		return &MissingED25519PrivateKey{
+			Err: err,
+		}
 	}
 
 	// platform-specific mechanism to lock down file permissions

--- a/workers/generic-worker/chain_of_trust_test.go
+++ b/workers/generic-worker/chain_of_trust_test.go
@@ -1,0 +1,16 @@
+//go:build multiuser
+
+package main
+
+import (
+	"testing"
+)
+
+func TestExitCodeMissingChainOfTrustKey(t *testing.T) {
+	setup(t)
+	config.Ed25519SigningKeyLocation = "some bad path"
+	exitCode := RunWorker()
+	if exitCode != MISSING_ED25519_PRIVATE_KEY {
+		t.Fatalf("Was expecting exit code %v but got exit code %v", MISSING_ED25519_PRIVATE_KEY, exitCode)
+	}
+}

--- a/workers/generic-worker/main.go
+++ b/workers/generic-worker/main.go
@@ -397,7 +397,7 @@ func RunWorker() (exitCode ExitCode) {
 
 	err = initialiseFeatures()
 	if err != nil {
-		panic(err)
+		return featureInitFailure(err)
 	}
 	defer func() {
 		err := persistFeaturesState()

--- a/workers/generic-worker/multiuser.go
+++ b/workers/generic-worker/multiuser.go
@@ -266,3 +266,14 @@ func CreateFileAsTaskUser(file string) (*os.File, error) {
 	}
 	return os.OpenFile(file, os.O_RDWR, 0600)
 }
+
+func featureInitFailure(err error) (exitCode ExitCode) {
+	switch err.(type) {
+	case *MissingED25519PrivateKey:
+		exitCode = MISSING_ED25519_PRIVATE_KEY
+	default:
+		panic(err)
+	}
+	log.Print(err)
+	return
+}

--- a/workers/generic-worker/simple.go
+++ b/workers/generic-worker/simple.go
@@ -180,3 +180,7 @@ func (task *TaskRun) EnvVars() []string {
 	log.Printf("Environment: %#v", taskEnvArray)
 	return taskEnvArray
 }
+
+func featureInitFailure(err error) ExitCode {
+	panic(err)
+}

--- a/workers/generic-worker/usage.go
+++ b/workers/generic-worker/usage.go
@@ -319,6 +319,6 @@ and reports back results to the queue.
     78     Not able to connect to --worker-runner-protocol-pipe.
     79     Not able to create file at --create-file path.
     80     Not able to create directory at --create-dir path.
-    81     Not able to unarchive --archive-src to --archive-dst.
+    81     Not able to unarchive --archive-src to --archive-dst.` + exitCode82() + `
 `
 }

--- a/workers/generic-worker/usage_multiuser.go
+++ b/workers/generic-worker/usage_multiuser.go
@@ -3,7 +3,8 @@
 package main
 
 const (
-	CANT_SECURE_CONFIG ExitCode = 77
+	CANT_SECURE_CONFIG          ExitCode = 77
+	MISSING_ED25519_PRIVATE_KEY ExitCode = 82
 )
 
 func runTasksAsCurrentUserUsage() string {
@@ -16,4 +17,9 @@ func exitCode77() string {
 	return `
     77     Not able to apply required file access permissions to the generic-worker config
            file so that task users can't read from or write to it.`
+}
+
+func exitCode82() string {
+	return `
+    82     Missing ed25519 private key. Did you run generic-worker new-ed25519-keypair?`
 }

--- a/workers/generic-worker/usage_simple.go
+++ b/workers/generic-worker/usage_simple.go
@@ -9,3 +9,7 @@ func runTasksAsCurrentUserUsage() string {
 func exitCode77() string {
 	return ""
 }
+
+func exitCode82() string {
+	return ""
+}


### PR DESCRIPTION
Github Bug/Issue: Fixes #6785 
