### PR TITLE
Slack notification fix

### DIFF
--- a/changelog/issue-6801.md
+++ b/changelog/issue-6801.md
@@ -1,0 +1,7 @@
+audience: users
+level: patch
+reference: issue 6801
+---
+
+Fixes a bug in notify service where multiple messages to the same channel were not sent.
+Adds `204` status code to the email, matrix, pulse, slack endoints when message was detected to be duplicate and was not sent.

--- a/clients/client-go/tcnotify/tcnotify.go
+++ b/clients/client-go/tcnotify/tcnotify.go
@@ -128,6 +128,9 @@ func (notify *Notify) Version() error {
 // email. If a link is included, it will be rendered to a nice button in the
 // HTML version of the email
 //
+// In case when duplicate message has been detected and no email was sent,
+// this endpoint will return 204 status code.
+//
 // Required scopes:
 //
 //	notify:email:<address>
@@ -142,6 +145,8 @@ func (notify *Notify) Email(payload *SendEmailRequest) error {
 // Stability: *** EXPERIMENTAL ***
 //
 // Publish a message on pulse with the given `routingKey`.
+//
+// # Endpoint will return 204 when duplicate message has been detected
 //
 // Required scopes:
 //
@@ -164,6 +169,9 @@ func (notify *Notify) Pulse(payload *PostPulseMessageRequest) error {
 // Note that the matrix client used by taskcluster must be invited to a room before
 // it can post there!
 //
+// In case when duplicate message has been detected and no message was sent,
+// this endpoint will return 204 status code.
+//
 // Required scopes:
 //
 //	notify:matrix-room:<roomId>
@@ -183,6 +191,9 @@ func (notify *Notify) Matrix(payload *SendMatrixNoticeRequest) error {
 //
 // The Slack app can post into public channels by default but will need to be added
 // to private channels before it can post messages there.
+//
+// In case when duplicate message has been detected and no message was sent,
+// this endpoint will return 204 status code.
 //
 // Required scopes:
 //

--- a/clients/client-py/taskcluster/generated/aio/notify.py
+++ b/clients/client-py/taskcluster/generated/aio/notify.py
@@ -67,6 +67,9 @@ class Notify(AsyncBaseClient):
         email. If a link is included, it will be rendered to a nice button in the
         HTML version of the email
 
+        In case when duplicate message has been detected and no email was sent,
+        this endpoint will return 204 status code.
+
         This method is ``experimental``
         """
 
@@ -77,6 +80,8 @@ class Notify(AsyncBaseClient):
         Publish a Pulse Message
 
         Publish a message on pulse with the given `routingKey`.
+
+        Endpoint will return 204 when duplicate message has been detected
 
         This method is ``experimental``
         """
@@ -95,6 +100,9 @@ class Notify(AsyncBaseClient):
         Note that the matrix client used by taskcluster must be invited to a room before
         it can post there!
 
+        In case when duplicate message has been detected and no message was sent,
+        this endpoint will return 204 status code.
+
         This method is ``experimental``
         """
 
@@ -110,6 +118,9 @@ class Notify(AsyncBaseClient):
 
         The Slack app can post into public channels by default but will need to be added
         to private channels before it can post messages there.
+
+        In case when duplicate message has been detected and no message was sent,
+        this endpoint will return 204 status code.
 
         This method is ``experimental``
         """

--- a/clients/client-py/taskcluster/generated/notify.py
+++ b/clients/client-py/taskcluster/generated/notify.py
@@ -67,6 +67,9 @@ class Notify(BaseClient):
         email. If a link is included, it will be rendered to a nice button in the
         HTML version of the email
 
+        In case when duplicate message has been detected and no email was sent,
+        this endpoint will return 204 status code.
+
         This method is ``experimental``
         """
 
@@ -77,6 +80,8 @@ class Notify(BaseClient):
         Publish a Pulse Message
 
         Publish a message on pulse with the given `routingKey`.
+
+        Endpoint will return 204 when duplicate message has been detected
 
         This method is ``experimental``
         """
@@ -95,6 +100,9 @@ class Notify(BaseClient):
         Note that the matrix client used by taskcluster must be invited to a room before
         it can post there!
 
+        In case when duplicate message has been detected and no message was sent,
+        this endpoint will return 204 status code.
+
         This method is ``experimental``
         """
 
@@ -110,6 +118,9 @@ class Notify(BaseClient):
 
         The Slack app can post into public channels by default but will need to be added
         to private channels before it can post messages there.
+
+        In case when duplicate message has been detected and no message was sent,
+        this endpoint will return 204 status code.
 
         This method is ``experimental``
         """

--- a/clients/client-rust/client/src/generated/notify.rs
+++ b/clients/client-rust/client/src/generated/notify.rs
@@ -133,6 +133,9 @@ impl Notify {
     /// to HTML, but both the HTML and raw markdown text will be sent in the
     /// email. If a link is included, it will be rendered to a nice button in the
     /// HTML version of the email
+    ///
+    /// In case when duplicate message has been detected and no email was sent,
+    /// this endpoint will return 204 status code.
     pub async fn email(&self, payload: &Value) -> Result<(), Error> {
         let method = "POST";
         let (path, query) = Self::email_details();
@@ -153,6 +156,8 @@ impl Notify {
     /// Publish a Pulse Message
     ///
     /// Publish a message on pulse with the given `routingKey`.
+    ///
+    /// Endpoint will return 204 when duplicate message has been detected
     pub async fn pulse(&self, payload: &Value) -> Result<(), Error> {
         let method = "POST";
         let (path, query) = Self::pulse_details();
@@ -179,6 +184,9 @@ impl Notify {
     ///
     /// Note that the matrix client used by taskcluster must be invited to a room before
     /// it can post there!
+    ///
+    /// In case when duplicate message has been detected and no message was sent,
+    /// this endpoint will return 204 status code.
     pub async fn matrix(&self, payload: &Value) -> Result<(), Error> {
         let method = "POST";
         let (path, query) = Self::matrix_details();
@@ -204,6 +212,9 @@ impl Notify {
     ///
     /// The Slack app can post into public channels by default but will need to be added
     /// to private channels before it can post messages there.
+    ///
+    /// In case when duplicate message has been detected and no message was sent,
+    /// this endpoint will return 204 status code.
     pub async fn slack(&self, payload: &Value) -> Result<(), Error> {
         let method = "POST";
         let (path, query) = Self::slack_details();

--- a/clients/client-shell/apis/services.go
+++ b/clients/client-shell/apis/services.go
@@ -1021,7 +1021,7 @@ var services = map[string]definitions.Service{
 			definitions.Entry{
 				Name:        "email",
 				Title:       "Send an Email",
-				Description: "Send an email to `address`. The content is markdown and will be rendered\nto HTML, but both the HTML and raw markdown text will be sent in the\nemail. If a link is included, it will be rendered to a nice button in the\nHTML version of the email",
+				Description: "Send an email to `address`. The content is markdown and will be rendered\nto HTML, but both the HTML and raw markdown text will be sent in the\nemail. If a link is included, it will be rendered to a nice button in the\nHTML version of the email\n\nIn case when duplicate message has been detected and no email was sent,\nthis endpoint will return 204 status code.",
 				Stability:   "experimental",
 				Method:      "post",
 				Route:       "/email",
@@ -1032,7 +1032,7 @@ var services = map[string]definitions.Service{
 			definitions.Entry{
 				Name:        "pulse",
 				Title:       "Publish a Pulse Message",
-				Description: "Publish a message on pulse with the given `routingKey`.",
+				Description: "Publish a message on pulse with the given `routingKey`.\n\nEndpoint will return 204 when duplicate message has been detected",
 				Stability:   "experimental",
 				Method:      "post",
 				Route:       "/pulse",
@@ -1043,7 +1043,7 @@ var services = map[string]definitions.Service{
 			definitions.Entry{
 				Name:        "matrix",
 				Title:       "Post Matrix Message",
-				Description: "Post a message to a room in Matrix. Optionally includes formatted message.\n\nThe `roomId` in the scopes is a fully formed `roomId` with leading `!` such\nas `!foo:bar.com`.\n\nNote that the matrix client used by taskcluster must be invited to a room before\nit can post there!",
+				Description: "Post a message to a room in Matrix. Optionally includes formatted message.\n\nThe `roomId` in the scopes is a fully formed `roomId` with leading `!` such\nas `!foo:bar.com`.\n\nNote that the matrix client used by taskcluster must be invited to a room before\nit can post there!\n\nIn case when duplicate message has been detected and no message was sent,\nthis endpoint will return 204 status code.",
 				Stability:   "experimental",
 				Method:      "post",
 				Route:       "/matrix",
@@ -1054,7 +1054,7 @@ var services = map[string]definitions.Service{
 			definitions.Entry{
 				Name:        "slack",
 				Title:       "Post Slack Message",
-				Description: "Post a message to a Slack channel.\n\nThe `channelId` in the scopes is a Slack channel ID, starting with a capital C.\n\nThe Slack app can post into public channels by default but will need to be added\nto private channels before it can post messages there.",
+				Description: "Post a message to a Slack channel.\n\nThe `channelId` in the scopes is a Slack channel ID, starting with a capital C.\n\nThe Slack app can post into public channels by default but will need to be added\nto private channels before it can post messages there.\n\nIn case when duplicate message has been detected and no message was sent,\nthis endpoint will return 204 status code.",
 				Stability:   "experimental",
 				Method:      "post",
 				Route:       "/slack",

--- a/clients/client-web/src/clients/Notify.js
+++ b/clients/client-web/src/clients/Notify.js
@@ -54,6 +54,8 @@ export default class Notify extends Client {
   // to HTML, but both the HTML and raw markdown text will be sent in the
   // email. If a link is included, it will be rendered to a nice button in the
   // HTML version of the email
+  // In case when duplicate message has been detected and no email was sent,
+  // this endpoint will return 204 status code.
   /* eslint-enable max-len */
   email(...args) {
     this.validate(this.email.entry, args);
@@ -62,6 +64,7 @@ export default class Notify extends Client {
   }
   /* eslint-disable max-len */
   // Publish a message on pulse with the given `routingKey`.
+  // Endpoint will return 204 when duplicate message has been detected
   /* eslint-enable max-len */
   pulse(...args) {
     this.validate(this.pulse.entry, args);
@@ -74,6 +77,8 @@ export default class Notify extends Client {
   // as `!foo:bar.com`.
   // Note that the matrix client used by taskcluster must be invited to a room before
   // it can post there!
+  // In case when duplicate message has been detected and no message was sent,
+  // this endpoint will return 204 status code.
   /* eslint-enable max-len */
   matrix(...args) {
     this.validate(this.matrix.entry, args);
@@ -85,6 +90,8 @@ export default class Notify extends Client {
   // The `channelId` in the scopes is a Slack channel ID, starting with a capital C.
   // The Slack app can post into public channels by default but will need to be added
   // to private channels before it can post messages there.
+  // In case when duplicate message has been detected and no message was sent,
+  // this endpoint will return 204 status code.
   /* eslint-enable max-len */
   slack(...args) {
     this.validate(this.slack.entry, args);

--- a/clients/client/src/apis.js
+++ b/clients/client/src/apis.js
@@ -1722,7 +1722,7 @@ module.exports = {
           "args": [
           ],
           "category": "Notifications",
-          "description": "Send an email to `address`. The content is markdown and will be rendered\nto HTML, but both the HTML and raw markdown text will be sent in the\nemail. If a link is included, it will be rendered to a nice button in the\nHTML version of the email",
+          "description": "Send an email to `address`. The content is markdown and will be rendered\nto HTML, but both the HTML and raw markdown text will be sent in the\nemail. If a link is included, it will be rendered to a nice button in the\nHTML version of the email\n\nIn case when duplicate message has been detected and no email was sent,\nthis endpoint will return 204 status code.",
           "input": "v1/email-request.json#",
           "method": "post",
           "name": "email",
@@ -1738,7 +1738,7 @@ module.exports = {
           "args": [
           ],
           "category": "Notifications",
-          "description": "Publish a message on pulse with the given `routingKey`.",
+          "description": "Publish a message on pulse with the given `routingKey`.\n\nEndpoint will return 204 when duplicate message has been detected",
           "input": "v1/pulse-request.json#",
           "method": "post",
           "name": "pulse",
@@ -1754,7 +1754,7 @@ module.exports = {
           "args": [
           ],
           "category": "Notifications",
-          "description": "Post a message to a room in Matrix. Optionally includes formatted message.\n\nThe `roomId` in the scopes is a fully formed `roomId` with leading `!` such\nas `!foo:bar.com`.\n\nNote that the matrix client used by taskcluster must be invited to a room before\nit can post there!",
+          "description": "Post a message to a room in Matrix. Optionally includes formatted message.\n\nThe `roomId` in the scopes is a fully formed `roomId` with leading `!` such\nas `!foo:bar.com`.\n\nNote that the matrix client used by taskcluster must be invited to a room before\nit can post there!\n\nIn case when duplicate message has been detected and no message was sent,\nthis endpoint will return 204 status code.",
           "input": "v1/matrix-request.json#",
           "method": "post",
           "name": "matrix",
@@ -1770,7 +1770,7 @@ module.exports = {
           "args": [
           ],
           "category": "Notifications",
-          "description": "Post a message to a Slack channel.\n\nThe `channelId` in the scopes is a Slack channel ID, starting with a capital C.\n\nThe Slack app can post into public channels by default but will need to be added\nto private channels before it can post messages there.",
+          "description": "Post a message to a Slack channel.\n\nThe `channelId` in the scopes is a Slack channel ID, starting with a capital C.\n\nThe Slack app can post into public channels by default but will need to be added\nto private channels before it can post messages there.\n\nIn case when duplicate message has been detected and no message was sent,\nthis endpoint will return 204 status code.",
           "input": "v1/slack-request.json#",
           "method": "post",
           "name": "slack",

--- a/generated/references.json
+++ b/generated/references.json
@@ -18302,7 +18302,7 @@
           "args": [
           ],
           "category": "Notifications",
-          "description": "Send an email to `address`. The content is markdown and will be rendered\nto HTML, but both the HTML and raw markdown text will be sent in the\nemail. If a link is included, it will be rendered to a nice button in the\nHTML version of the email",
+          "description": "Send an email to `address`. The content is markdown and will be rendered\nto HTML, but both the HTML and raw markdown text will be sent in the\nemail. If a link is included, it will be rendered to a nice button in the\nHTML version of the email\n\nIn case when duplicate message has been detected and no email was sent,\nthis endpoint will return 204 status code.",
           "input": "v1/email-request.json#",
           "method": "post",
           "name": "email",
@@ -18318,7 +18318,7 @@
           "args": [
           ],
           "category": "Notifications",
-          "description": "Publish a message on pulse with the given `routingKey`.",
+          "description": "Publish a message on pulse with the given `routingKey`.\n\nEndpoint will return 204 when duplicate message has been detected",
           "input": "v1/pulse-request.json#",
           "method": "post",
           "name": "pulse",
@@ -18334,7 +18334,7 @@
           "args": [
           ],
           "category": "Notifications",
-          "description": "Post a message to a room in Matrix. Optionally includes formatted message.\n\nThe `roomId` in the scopes is a fully formed `roomId` with leading `!` such\nas `!foo:bar.com`.\n\nNote that the matrix client used by taskcluster must be invited to a room before\nit can post there!",
+          "description": "Post a message to a room in Matrix. Optionally includes formatted message.\n\nThe `roomId` in the scopes is a fully formed `roomId` with leading `!` such\nas `!foo:bar.com`.\n\nNote that the matrix client used by taskcluster must be invited to a room before\nit can post there!\n\nIn case when duplicate message has been detected and no message was sent,\nthis endpoint will return 204 status code.",
           "input": "v1/matrix-request.json#",
           "method": "post",
           "name": "matrix",
@@ -18350,7 +18350,7 @@
           "args": [
           ],
           "category": "Notifications",
-          "description": "Post a message to a Slack channel.\n\nThe `channelId` in the scopes is a Slack channel ID, starting with a capital C.\n\nThe Slack app can post into public channels by default but will need to be added\nto private channels before it can post messages there.",
+          "description": "Post a message to a Slack channel.\n\nThe `channelId` in the scopes is a Slack channel ID, starting with a capital C.\n\nThe Slack app can post into public channels by default but will need to be added\nto private channels before it can post messages there.\n\nIn case when duplicate message has been detected and no message was sent,\nthis endpoint will return 204 status code.",
           "input": "v1/slack-request.json#",
           "method": "post",
           "name": "slack",

--- a/libraries/pulse/src/publisher.js
+++ b/libraries/pulse/src/publisher.js
@@ -283,7 +283,7 @@ export class PulsePublisher {
   }
 
   /**
-   * Declare the publishing methods based on the exchagnes.declare(..) calls
+   * Declare the publishing methods based on the exchanges.declare(..) calls
    * made earlier.
    */
   async _declareMethods() {

--- a/services/notify/src/api.js
+++ b/services/notify/src/api.js
@@ -33,6 +33,9 @@ builder.declare({
     'to HTML, but both the HTML and raw markdown text will be sent in the',
     'email. If a link is included, it will be rendered to a nice button in the',
     'HTML version of the email',
+    '',
+    'In case when duplicate message has been detected and no email was sent,',
+    'this endpoint will return 204 status code.',
   ].join('\n'),
 }, async function(req, res) {
   await req.authorize(req.body);
@@ -41,8 +44,8 @@ builder.declare({
     return res.reportError('DenylistedAddress', `Email ${req.body.address} is denylisted`, {});
   }
 
-  await this.notifier.email(req.body);
-  res.sendStatus(200);
+  const result = await this.notifier.email(req.body);
+  res.sendStatus(result ? 200 : 204);
 });
 
 builder.declare({
@@ -55,6 +58,8 @@ builder.declare({
   title: 'Publish a Pulse Message',
   description: [
     'Publish a message on pulse with the given `routingKey`.',
+    '',
+    'Endpoint will return 204 when duplicate message has been detected',
   ].join('\n'),
 }, async function(req, res) {
   await req.authorize({ routingKey: req.body.routingKey });
@@ -63,8 +68,8 @@ builder.declare({
     return res.reportError('DenylistedAddress', `Pulse routing key pattern ${req.body.routingKey} is denylisted`, {});
   }
 
-  await this.notifier.pulse(req.body);
-  res.sendStatus(200);
+  const result = await this.notifier.pulse(req.body);
+  res.sendStatus(result ? 200 : 204);
 });
 
 builder.declare({
@@ -83,6 +88,9 @@ builder.declare({
     '',
     'Note that the matrix client used by taskcluster must be invited to a room before',
     'it can post there!',
+    '',
+    'In case when duplicate message has been detected and no message was sent,',
+    'this endpoint will return 204 status code.',
   ].join('\n'),
 }, async function(req, res) {
   await req.authorize({
@@ -94,8 +102,8 @@ builder.declare({
   }
 
   try {
-    await this.notifier.matrix(req.body);
-    res.sendStatus(200);
+    const result = await this.notifier.matrix(req.body);
+    res.sendStatus(result ? 200 : 204);
   } catch (err) {
     // This just means that we haven't been invited to the room yet
     if (err.errcode === 'M_FORBIDDEN') {
@@ -120,6 +128,9 @@ builder.declare({
     '',
     'The Slack app can post into public channels by default but will need to be added',
     'to private channels before it can post messages there.',
+    '',
+    'In case when duplicate message has been detected and no message was sent,',
+    'this endpoint will return 204 status code.',
   ].join('\n'),
 }, async function(req, res) {
   await req.authorize({
@@ -130,8 +141,8 @@ builder.declare({
     return res.reportError('DenylistedAddress', `Slack channel ${req.body.channelId} is denylisted`, {});
   }
 
-  await this.notifier.slack(req.body);
-  res.sendStatus(200);
+  const result = await this.notifier.slack(req.body);
+  res.sendStatus(result ? 200 : 204);
 });
 
 builder.declare({

--- a/services/notify/test/notifier_test.js
+++ b/services/notify/test/notifier_test.js
@@ -1,0 +1,100 @@
+import _ from 'lodash';
+import assert from 'assert';
+import helper from './helper.js';
+import testing from 'taskcluster-lib-testing';
+
+helper.secrets.mockSuite(testing.suiteName(), ['aws'], function(mock, skipping) {
+  if (!mock) {
+    return;
+  }
+
+  helper.withDenier(mock, skipping);
+  helper.withFakeQueue(mock, skipping);
+  helper.withFakeMatrix(mock, skipping);
+  helper.withFakeSlack(mock, skipping);
+  helper.withSES(mock, skipping);
+  helper.withPulse(mock, skipping);
+
+  test('isDuplicate', async () => {
+    const notifier = await helper.load('notifier');
+
+    const a = 'valueA';
+    const b = 8;
+    const c = { key: 'valueC' };
+
+    assert.equal(false, notifier.isDuplicate(a, b, c));
+    notifier.markSent(a, b, c);
+    assert.equal(true, notifier.isDuplicate(a, b, c));
+  });
+
+  test('email', async () => {
+    const notifier = await helper.load('notifier');
+
+    const address = 'test@taskcluster.net';
+    const subject = 'Test Subject';
+    const content = 'Test Content';
+    const link = 'https://taskcluster.net';
+    const replyTo = 'test@taskcluster.net';
+    const template = 'simple';
+
+    assert.ok(await notifier.email({ address, subject, content, link, replyTo, template }));
+    assert.equal(false, await notifier.email({ address, subject, content, link, replyTo, template }));
+
+    // denied email
+    assert.equal(false, await notifier.email({
+      address: 'test+denied@taskcluster.net',
+      subject, content, link, replyTo, template }));
+  });
+
+  test('pulse', async () => {
+    const notifier = await helper.load('notifier');
+
+    const routingKey = 'test.routing.key';
+    const message = {
+      version: 1,
+      message: {
+        title: 'Test',
+        description: 'No comments',
+      },
+    };
+
+    assert.ok(await notifier.pulse({ routingKey, message }));
+    assert.equal(false, await notifier.pulse({ routingKey, message }));
+
+    assert.equal(false, await notifier.pulse({
+      routingKey: 'test.denied.routing.key',
+      message }));
+  });
+
+  test('matrix', async () => {
+    const notifier = await helper.load('notifier');
+
+    const roomId = '!gBxblkbeeBSadzOniu:mozilla.org';
+    const body = 'Test Body';
+    const formattedBody = '<h1>Test Body</h1>';
+    const msgtype = 'm.text';
+
+    assert.ok(await notifier.matrix({ roomId, body, formattedBody, msgtype }));
+    assert.equal(false, await notifier.matrix({ roomId, body, formattedBody, msgtype }));
+
+    assert.equal(false, await notifier.matrix({
+      roomId: '!denied:mozilla.org',
+      body, formattedBody, msgtype }));
+  });
+
+  test('slack', async () => {
+    const notifier = await helper.load('notifier');
+
+    const channelId = 'test-channel-id';
+    const text = 'Test Text';
+    const blocks = [{ type: 'header', text: { type: 'plain_text', text: 'Test Blocks' } }];
+    const attachments = [];
+
+    assert.ok(await notifier.slack({ channelId, text, blocks, attachments }));
+    assert.equal(false, await notifier.slack({ channelId, text, blocks, attachments }));
+
+    assert.equal(false, await notifier.slack({
+      channelId: 'denied-channel-id',
+      text, blocks, attachments }));
+  });
+});


### PR DESCRIPTION
Sending multiple messages to the same channel would fail if it contained same `text` but different `blocks` or `attachments` because they were considered to be duplicate.

This also introduces `204` status code to give clients information that this particular call did not result in actual sending of the message, as it was detected to be duplicate.

Fixes #6801
