### PR TITLE
fix(worker-runner): check for Google spot instance termination on provider startup

### DIFF
--- a/changelog/beo_hKEkRr25Ph8pVPtaew.md
+++ b/changelog/beo_hKEkRr25Ph8pVPtaew.md
@@ -1,0 +1,10 @@
+audience: worker-deployers
+level: patch
+---
+Worker Runner now checks for termination notice when starting the Google provider.
+
+When Worker Runner runs, the instance may already be scheduled to be shutdown. So on Google provider startup, we now check for this case.
+
+This functionality mimics what's already in place for AWS.
+
+This change also decreases the time Worker Runner checks to see if the instance is scheduled to be shutdown from 30 seconds to 15 seconds on the Google and Azure providers, as they each have a 30 second notice before a hard-shutdown Google: https://cloud.google.com/compute/docs/instances/spot#preemption-process Azure: https://learn.microsoft.com/en-us/azure/virtual-machines/spot-vms.

--- a/tools/worker-runner/provider/azure/azure.go
+++ b/tools/worker-runner/provider/azure/azure.go
@@ -147,7 +147,7 @@ func (p *AzureProvider) WorkerStarted(state *run.State) error {
 	p.proto.AddCapability("graceful-termination")
 
 	// start polling for graceful shutdown
-	p.terminationTicker = time.NewTicker(30 * time.Second)
+	p.terminationTicker = time.NewTicker(15 * time.Second)
 	go func() {
 		for {
 			<-p.terminationTicker.C


### PR DESCRIPTION
>Worker Runner now checks for termination notice when starting the Google provider.
>
>When Worker Runner runs, the instance may already be scheduled to be shutdown. So on Google provider startup, we now check for this case.
>
>This functionality mimics what's already in place for AWS.
>
>This change also decreases the time Worker Runner checks to see if the instance is scheduled to be shutdown from 30 seconds to 15 seconds on the Google and Azure providers, as they each have a 30 second notice before a hard-shutdown Google: https://cloud.google.com/compute/docs/instances/spot#preemption-process Azure: https://learn.microsoft.com/en-us/azure/virtual-machines/spot-vms.