### PR TITLE
fix(worker-runner): use a hanging GET for GCP spot termination detection

### DIFF
--- a/changelog/issue-6802.md
+++ b/changelog/issue-6802.md
@@ -1,0 +1,5 @@
+audience: worker-deployers
+level: patch
+reference: issue 6802
+---
+Worker Runner no longer polls the metadata service for the Google provider. Instead, we've added `?wait_for_change=true` to the endpoint to perform a hanging GET request that'll return as soon as the metadata has changed and the VM has been preempted.

--- a/tools/worker-runner/provider/google/google.go
+++ b/tools/worker-runner/provider/google/google.go
@@ -111,7 +111,7 @@ func (p *GoogleProvider) SetProtocol(proto *workerproto.Protocol) {
 }
 
 func (p *GoogleProvider) checkTerminationTime() bool {
-	value, err := p.metadataService.queryMetadata(TERMINATION_PATH)
+	value, err := p.metadataService.queryMetadata(TERMINATION_PATH + "?wait_for_change=true")
 	// if the file exists and contains TRUE, it's time to go away
 	if err == nil && value == "TRUE" {
 		log.Println("GCP Metadata Service says termination is imminent")
@@ -130,13 +130,10 @@ func (p *GoogleProvider) checkTerminationTime() bool {
 }
 
 func (p *GoogleProvider) WorkerStarted(state *run.State) error {
-	// start polling for graceful shutdown
-	p.terminationTicker = time.NewTicker(15 * time.Second)
 	p.proto.AddCapability("graceful-termination")
 
 	go func() {
 		for {
-			<-p.terminationTicker.C
 			log.Println("polling for termination-time")
 			p.checkTerminationTime()
 		}

--- a/tools/worker-runner/provider/google/google_test.go
+++ b/tools/worker-runner/provider/google/google_test.go
@@ -123,7 +123,7 @@ func TestCheckTerminationTime(t *testing.T) {
 		// not time yet..
 		require.False(t, p.checkTerminationTime())
 
-		metaData["/instance/preempted"] = "TRUE"
+		metaData["/instance/preempted?wait_for_change=true"] = "TRUE"
 		require.True(t, p.checkTerminationTime())
 	}
 

--- a/tools/worker-runner/provider/google/metadata.go
+++ b/tools/worker-runner/provider/google/metadata.go
@@ -5,6 +5,7 @@ package google
 import (
 	"encoding/json"
 	"io"
+	"log"
 	"net/http"
 
 	"github.com/taskcluster/httpbackoff/v3"
@@ -55,11 +56,13 @@ func (mds *realMetadataService) queryMetadata(path string) (string, error) {
 	// google's metadata service requires this header
 	req.Header.Set("Metadata-Flavor", "Google")
 
+	log.Println("Requesting metadata:", path)
 	resp, _, err := httpbackoff.ClientDo(&client, req)
 	if err != nil {
 		return "", err
 	}
 	defer resp.Body.Close()
 	content, err := io.ReadAll(resp.Body)
+	log.Println("Got metadata response:", string(content))
 	return string(content), err
 }


### PR DESCRIPTION
Will test on a staging pool to see if this helps with #6802.

>Worker Runner no longer polls the metadata service for the Google provider. Instead, we've added `?wait_for_change=true` to the endpoint to perform a hanging GET request that'll return as soon as the metadata has changed and the VM has been preempted.