### PR TITLE
chore: fix CodeQL autobuild for go

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -55,6 +55,12 @@ jobs:
         # Run extended queries including queries using machine learning
         queries: security-extended
 
+    - name: Set up Go
+      if: matrix.language == 'go'
+      uses: actions/setup-go@v5
+      with:
+        go-version-file: go.mod
+
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild

--- a/changelog/TLgA6zOvTbOdLlQpFuUUAw.md
+++ b/changelog/TLgA6zOvTbOdLlQpFuUUAw.md
@@ -1,0 +1,3 @@
+audience: general
+level: silent
+---


### PR DESCRIPTION
Fixes this https://github.com/taskcluster/taskcluster/security/code-scanning/tools/CodeQL/status/configurations/actions-FZTWS5DIOVRC653POJVWM3DPO5ZS6Y3PMRSXC3BOPFWWY/405aa96584f48822b00d6c0830c4a80093f1384ddb9dbab00cd29577f4fc4f1e.

<img width="1232" alt="Screenshot 2024-02-06 at 11 22 05 AM" src="https://github.com/taskcluster/taskcluster/assets/92693437/fe76851b-77b6-48c8-b92e-895509cd0ecc">