### PR TITLE
feat(k8s): Add sufficient timeouts and delays for 502 issue

### DIFF
--- a/changelog/S9g9IeHnRVGoyV0E1TTK6g.md
+++ b/changelog/S9g9IeHnRVGoyV0E1TTK6g.md
@@ -1,0 +1,5 @@
+audience: deployers
+level: patch
+---
+
+Kubernetes lifecycle timeouts correctly set to avoid having 502s.

--- a/infrastructure/k8s/templates/taskcluster-auth-deployment-web.yaml
+++ b/infrastructure/k8s/templates/taskcluster-auth-deployment-web.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       serviceAccountName: taskcluster-auth
       imagePullSecrets: {{ if .Values.imagePullSecret }}{{ toJson (list (dict "name" .Values.imagePullSecret)) }}{{ else }}[]{{ end }}
-      terminationGracePeriodSeconds: 120
+      terminationGracePeriodSeconds: 210
       containers:
         - name: taskcluster-auth-web
           image: '{{ .Values.dockerImage }}'
@@ -64,4 +64,4 @@ spec:
                 command:
                   - /bin/sh
                   - '-c'
-                  - sleep 10
+                  - sleep 120

--- a/infrastructure/k8s/templates/taskcluster-built-in-workers-deployment-server.yaml
+++ b/infrastructure/k8s/templates/taskcluster-built-in-workers-deployment-server.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       serviceAccountName: taskcluster-built-in-workers
       imagePullSecrets: {{ if .Values.imagePullSecret }}{{ toJson (list (dict "name" .Values.imagePullSecret)) }}{{ else }}[]{{ end }}
-      terminationGracePeriodSeconds: 120
+      terminationGracePeriodSeconds: 210
       containers:
         - name: taskcluster-built-in-workers-server
           image: '{{ .Values.dockerImage }}'

--- a/infrastructure/k8s/templates/taskcluster-github-deployment-web.yaml
+++ b/infrastructure/k8s/templates/taskcluster-github-deployment-web.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       serviceAccountName: taskcluster-github
       imagePullSecrets: {{ if .Values.imagePullSecret }}{{ toJson (list (dict "name" .Values.imagePullSecret)) }}{{ else }}[]{{ end }}
-      terminationGracePeriodSeconds: 120
+      terminationGracePeriodSeconds: 210
       containers:
         - name: taskcluster-github-web
           image: '{{ .Values.dockerImage }}'
@@ -64,4 +64,4 @@ spec:
                 command:
                   - /bin/sh
                   - '-c'
-                  - sleep 10
+                  - sleep 120

--- a/infrastructure/k8s/templates/taskcluster-github-deployment-worker.yaml
+++ b/infrastructure/k8s/templates/taskcluster-github-deployment-worker.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       serviceAccountName: taskcluster-github
       imagePullSecrets: {{ if .Values.imagePullSecret }}{{ toJson (list (dict "name" .Values.imagePullSecret)) }}{{ else }}[]{{ end }}
-      terminationGracePeriodSeconds: 120
+      terminationGracePeriodSeconds: 210
       containers:
         - name: taskcluster-github-worker
           image: '{{ .Values.dockerImage }}'

--- a/infrastructure/k8s/templates/taskcluster-hooks-deployment-listeners.yaml
+++ b/infrastructure/k8s/templates/taskcluster-hooks-deployment-listeners.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       serviceAccountName: taskcluster-hooks
       imagePullSecrets: {{ if .Values.imagePullSecret }}{{ toJson (list (dict "name" .Values.imagePullSecret)) }}{{ else }}[]{{ end }}
-      terminationGracePeriodSeconds: 120
+      terminationGracePeriodSeconds: 210
       containers:
         - name: taskcluster-hooks-listeners
           image: '{{ .Values.dockerImage }}'

--- a/infrastructure/k8s/templates/taskcluster-hooks-deployment-scheduler.yaml
+++ b/infrastructure/k8s/templates/taskcluster-hooks-deployment-scheduler.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       serviceAccountName: taskcluster-hooks
       imagePullSecrets: {{ if .Values.imagePullSecret }}{{ toJson (list (dict "name" .Values.imagePullSecret)) }}{{ else }}[]{{ end }}
-      terminationGracePeriodSeconds: 120
+      terminationGracePeriodSeconds: 210
       containers:
         - name: taskcluster-hooks-scheduler
           image: '{{ .Values.dockerImage }}'

--- a/infrastructure/k8s/templates/taskcluster-hooks-deployment-web.yaml
+++ b/infrastructure/k8s/templates/taskcluster-hooks-deployment-web.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       serviceAccountName: taskcluster-hooks
       imagePullSecrets: {{ if .Values.imagePullSecret }}{{ toJson (list (dict "name" .Values.imagePullSecret)) }}{{ else }}[]{{ end }}
-      terminationGracePeriodSeconds: 120
+      terminationGracePeriodSeconds: 210
       containers:
         - name: taskcluster-hooks-web
           image: '{{ .Values.dockerImage }}'
@@ -64,4 +64,4 @@ spec:
                 command:
                   - /bin/sh
                   - '-c'
-                  - sleep 10
+                  - sleep 120

--- a/infrastructure/k8s/templates/taskcluster-index-deployment-handlers.yaml
+++ b/infrastructure/k8s/templates/taskcluster-index-deployment-handlers.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       serviceAccountName: taskcluster-index
       imagePullSecrets: {{ if .Values.imagePullSecret }}{{ toJson (list (dict "name" .Values.imagePullSecret)) }}{{ else }}[]{{ end }}
-      terminationGracePeriodSeconds: 120
+      terminationGracePeriodSeconds: 210
       containers:
         - name: taskcluster-index-handlers
           image: '{{ .Values.dockerImage }}'

--- a/infrastructure/k8s/templates/taskcluster-index-deployment-web.yaml
+++ b/infrastructure/k8s/templates/taskcluster-index-deployment-web.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       serviceAccountName: taskcluster-index
       imagePullSecrets: {{ if .Values.imagePullSecret }}{{ toJson (list (dict "name" .Values.imagePullSecret)) }}{{ else }}[]{{ end }}
-      terminationGracePeriodSeconds: 120
+      terminationGracePeriodSeconds: 210
       containers:
         - name: taskcluster-index-web
           image: '{{ .Values.dockerImage }}'
@@ -64,4 +64,4 @@ spec:
                 command:
                   - /bin/sh
                   - '-c'
-                  - sleep 10
+                  - sleep 120

--- a/infrastructure/k8s/templates/taskcluster-notify-deployment-handler.yaml
+++ b/infrastructure/k8s/templates/taskcluster-notify-deployment-handler.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       serviceAccountName: taskcluster-notify
       imagePullSecrets: {{ if .Values.imagePullSecret }}{{ toJson (list (dict "name" .Values.imagePullSecret)) }}{{ else }}[]{{ end }}
-      terminationGracePeriodSeconds: 120
+      terminationGracePeriodSeconds: 210
       containers:
         - name: taskcluster-notify-handler
           image: '{{ .Values.dockerImage }}'

--- a/infrastructure/k8s/templates/taskcluster-notify-deployment-web.yaml
+++ b/infrastructure/k8s/templates/taskcluster-notify-deployment-web.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       serviceAccountName: taskcluster-notify
       imagePullSecrets: {{ if .Values.imagePullSecret }}{{ toJson (list (dict "name" .Values.imagePullSecret)) }}{{ else }}[]{{ end }}
-      terminationGracePeriodSeconds: 120
+      terminationGracePeriodSeconds: 210
       containers:
         - name: taskcluster-notify-web
           image: '{{ .Values.dockerImage }}'
@@ -64,4 +64,4 @@ spec:
                 command:
                   - /bin/sh
                   - '-c'
-                  - sleep 10
+                  - sleep 120

--- a/infrastructure/k8s/templates/taskcluster-object-deployment-web.yaml
+++ b/infrastructure/k8s/templates/taskcluster-object-deployment-web.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       serviceAccountName: taskcluster-object
       imagePullSecrets: {{ if .Values.imagePullSecret }}{{ toJson (list (dict "name" .Values.imagePullSecret)) }}{{ else }}[]{{ end }}
-      terminationGracePeriodSeconds: 120
+      terminationGracePeriodSeconds: 210
       containers:
         - name: taskcluster-object-web
           image: '{{ .Values.dockerImage }}'
@@ -64,4 +64,4 @@ spec:
                 command:
                   - /bin/sh
                   - '-c'
-                  - sleep 10
+                  - sleep 120

--- a/infrastructure/k8s/templates/taskcluster-purge-cache-deployment-web.yaml
+++ b/infrastructure/k8s/templates/taskcluster-purge-cache-deployment-web.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       serviceAccountName: taskcluster-purge-cache
       imagePullSecrets: {{ if .Values.imagePullSecret }}{{ toJson (list (dict "name" .Values.imagePullSecret)) }}{{ else }}[]{{ end }}
-      terminationGracePeriodSeconds: 120
+      terminationGracePeriodSeconds: 210
       containers:
         - name: taskcluster-purge-cache-web
           image: '{{ .Values.dockerImage }}'
@@ -64,4 +64,4 @@ spec:
                 command:
                   - /bin/sh
                   - '-c'
-                  - sleep 10
+                  - sleep 120

--- a/infrastructure/k8s/templates/taskcluster-queue-deployment-claimResolver.yaml
+++ b/infrastructure/k8s/templates/taskcluster-queue-deployment-claimResolver.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       serviceAccountName: taskcluster-queue
       imagePullSecrets: {{ if .Values.imagePullSecret }}{{ toJson (list (dict "name" .Values.imagePullSecret)) }}{{ else }}[]{{ end }}
-      terminationGracePeriodSeconds: 120
+      terminationGracePeriodSeconds: 210
       containers:
         - name: taskcluster-queue-claimresolver
           image: '{{ .Values.dockerImage }}'

--- a/infrastructure/k8s/templates/taskcluster-queue-deployment-deadlineResolver.yaml
+++ b/infrastructure/k8s/templates/taskcluster-queue-deployment-deadlineResolver.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       serviceAccountName: taskcluster-queue
       imagePullSecrets: {{ if .Values.imagePullSecret }}{{ toJson (list (dict "name" .Values.imagePullSecret)) }}{{ else }}[]{{ end }}
-      terminationGracePeriodSeconds: 120
+      terminationGracePeriodSeconds: 210
       containers:
         - name: taskcluster-queue-deadlineresolver
           image: '{{ .Values.dockerImage }}'

--- a/infrastructure/k8s/templates/taskcluster-queue-deployment-dependencyResolver.yaml
+++ b/infrastructure/k8s/templates/taskcluster-queue-deployment-dependencyResolver.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       serviceAccountName: taskcluster-queue
       imagePullSecrets: {{ if .Values.imagePullSecret }}{{ toJson (list (dict "name" .Values.imagePullSecret)) }}{{ else }}[]{{ end }}
-      terminationGracePeriodSeconds: 120
+      terminationGracePeriodSeconds: 210
       containers:
         - name: taskcluster-queue-dependencyresolver
           image: '{{ .Values.dockerImage }}'

--- a/infrastructure/k8s/templates/taskcluster-queue-deployment-web.yaml
+++ b/infrastructure/k8s/templates/taskcluster-queue-deployment-web.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       serviceAccountName: taskcluster-queue
       imagePullSecrets: {{ if .Values.imagePullSecret }}{{ toJson (list (dict "name" .Values.imagePullSecret)) }}{{ else }}[]{{ end }}
-      terminationGracePeriodSeconds: 120
+      terminationGracePeriodSeconds: 210
       containers:
         - name: taskcluster-queue-web
           image: '{{ .Values.dockerImage }}'
@@ -64,4 +64,4 @@ spec:
                 command:
                   - /bin/sh
                   - '-c'
-                  - sleep 10
+                  - sleep 120

--- a/infrastructure/k8s/templates/taskcluster-references-deployment-web.yaml
+++ b/infrastructure/k8s/templates/taskcluster-references-deployment-web.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       serviceAccountName: taskcluster-references
       imagePullSecrets: {{ if .Values.imagePullSecret }}{{ toJson (list (dict "name" .Values.imagePullSecret)) }}{{ else }}[]{{ end }}
-      terminationGracePeriodSeconds: 120
+      terminationGracePeriodSeconds: 210
       containers:
         - name: taskcluster-references-web
           image: '{{ .Values.dockerImage }}'
@@ -64,4 +64,4 @@ spec:
                 command:
                   - /bin/sh
                   - '-c'
-                  - sleep 10
+                  - sleep 120

--- a/infrastructure/k8s/templates/taskcluster-secrets-deployment-web.yaml
+++ b/infrastructure/k8s/templates/taskcluster-secrets-deployment-web.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       serviceAccountName: taskcluster-secrets
       imagePullSecrets: {{ if .Values.imagePullSecret }}{{ toJson (list (dict "name" .Values.imagePullSecret)) }}{{ else }}[]{{ end }}
-      terminationGracePeriodSeconds: 120
+      terminationGracePeriodSeconds: 210
       containers:
         - name: taskcluster-secrets-web
           image: '{{ .Values.dockerImage }}'
@@ -64,4 +64,4 @@ spec:
                 command:
                   - /bin/sh
                   - '-c'
-                  - sleep 10
+                  - sleep 120

--- a/infrastructure/k8s/templates/taskcluster-ui-deployment-web.yaml
+++ b/infrastructure/k8s/templates/taskcluster-ui-deployment-web.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       serviceAccountName: taskcluster-ui
       imagePullSecrets: {{ if .Values.imagePullSecret }}{{ toJson (list (dict "name" .Values.imagePullSecret)) }}{{ else }}[]{{ end }}
-      terminationGracePeriodSeconds: 120
+      terminationGracePeriodSeconds: 210
       containers:
         - name: taskcluster-ui-web
           image: '{{ .Values.dockerImage }}'
@@ -64,4 +64,4 @@ spec:
                 command:
                   - /bin/sh
                   - '-c'
-                  - sleep 10
+                  - sleep 120

--- a/infrastructure/k8s/templates/taskcluster-web-server-deployment-web.yaml
+++ b/infrastructure/k8s/templates/taskcluster-web-server-deployment-web.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       serviceAccountName: taskcluster-web-server
       imagePullSecrets: {{ if .Values.imagePullSecret }}{{ toJson (list (dict "name" .Values.imagePullSecret)) }}{{ else }}[]{{ end }}
-      terminationGracePeriodSeconds: 120
+      terminationGracePeriodSeconds: 210
       containers:
         - name: taskcluster-web-server-web
           image: '{{ .Values.dockerImage }}'
@@ -64,4 +64,4 @@ spec:
                 command:
                   - /bin/sh
                   - '-c'
-                  - sleep 10
+                  - sleep 120

--- a/infrastructure/k8s/templates/taskcluster-worker-manager-deployment-provisioner.yaml
+++ b/infrastructure/k8s/templates/taskcluster-worker-manager-deployment-provisioner.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       serviceAccountName: taskcluster-worker-manager
       imagePullSecrets: {{ if .Values.imagePullSecret }}{{ toJson (list (dict "name" .Values.imagePullSecret)) }}{{ else }}[]{{ end }}
-      terminationGracePeriodSeconds: 120
+      terminationGracePeriodSeconds: 210
       containers:
         - name: taskcluster-worker-manager-provisioner
           image: '{{ .Values.dockerImage }}'

--- a/infrastructure/k8s/templates/taskcluster-worker-manager-deployment-web.yaml
+++ b/infrastructure/k8s/templates/taskcluster-worker-manager-deployment-web.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       serviceAccountName: taskcluster-worker-manager
       imagePullSecrets: {{ if .Values.imagePullSecret }}{{ toJson (list (dict "name" .Values.imagePullSecret)) }}{{ else }}[]{{ end }}
-      terminationGracePeriodSeconds: 120
+      terminationGracePeriodSeconds: 210
       containers:
         - name: taskcluster-worker-manager-web
           image: '{{ .Values.dockerImage }}'
@@ -64,4 +64,4 @@ spec:
                 command:
                   - /bin/sh
                   - '-c'
-                  - sleep 10
+                  - sleep 120

--- a/infrastructure/k8s/templates/taskcluster-worker-manager-deployment-workerscanner-azure.yaml
+++ b/infrastructure/k8s/templates/taskcluster-worker-manager-deployment-workerscanner-azure.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       serviceAccountName: taskcluster-worker-manager
       imagePullSecrets: {{ if .Values.imagePullSecret }}{{ toJson (list (dict "name" .Values.imagePullSecret)) }}{{ else }}[]{{ end }}
-      terminationGracePeriodSeconds: 120
+      terminationGracePeriodSeconds: 210
       containers:
         - name: taskcluster-worker-manager-workerscanner-azure
           image: '{{ .Values.dockerImage }}'

--- a/infrastructure/k8s/templates/taskcluster-worker-manager-deployment-workerscanner.yaml
+++ b/infrastructure/k8s/templates/taskcluster-worker-manager-deployment-workerscanner.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       serviceAccountName: taskcluster-worker-manager
       imagePullSecrets: {{ if .Values.imagePullSecret }}{{ toJson (list (dict "name" .Values.imagePullSecret)) }}{{ else }}[]{{ end }}
-      terminationGracePeriodSeconds: 120
+      terminationGracePeriodSeconds: 210
       containers:
         - name: taskcluster-worker-manager-workerscanner
           image: '{{ .Values.dockerImage }}'

--- a/infrastructure/tooling/templates/k8s/deployment.yaml
+++ b/infrastructure/tooling/templates/k8s/deployment.yaml
@@ -18,7 +18,7 @@ spec:
       # allow server to terminate gracefully while still serving existing connections
       # new connections would be rejected as server will be closed
       # and under normal conditions pod will stop faster than this timeout
-      terminationGracePeriodSeconds: 120
+      terminationGracePeriodSeconds: 210
       containers:
       - name: ${projectName}-${lowercase(procName)}
         image: '{{ .Values.dockerImage }}'
@@ -80,4 +80,4 @@ spec:
           then:
             preStop:
               exec:
-                command: ['/bin/sh', '-c', 'sleep 10']
+                command: ['/bin/sh', '-c', 'sleep 120']


### PR DESCRIPTION
This combination has proven to be efficient for kubernetes which reduces significantly all (or most of) 502s

Those numbers were applied on the cluster directly during experimentation period, and this is simply to have them configured in the code
