### PR TITLE
Go client doc fix

### DIFF
--- a/changelog/SVcOpPCVQ3OUmfcb69qt7A.md
+++ b/changelog/SVcOpPCVQ3OUmfcb69qt7A.md
@@ -1,0 +1,3 @@
+audience: general
+level: silent
+---

--- a/clients/client-go/README.md
+++ b/clients/client-go/README.md
@@ -19,22 +19,6 @@ This library provides the following packages to interface with Taskcluster:
 ### HTTP APIs
 
 <!--HTTP-API-start-->
-* https://pkg.go.dev/github.com/taskcluster/taskcluster/v60/clients/client-go/tcauthevents
-
-* https://pkg.go.dev/github.com/taskcluster/taskcluster/v60/clients/client-go/tcgithubevents
-
-* https://pkg.go.dev/github.com/taskcluster/taskcluster/v60/clients/client-go/tchooksevents
-
-* https://pkg.go.dev/github.com/taskcluster/taskcluster/v60/clients/client-go/tcnotifyevents
-
-* https://pkg.go.dev/github.com/taskcluster/taskcluster/v60/clients/client-go/tcqueueevents
-
-* https://pkg.go.dev/github.com/taskcluster/taskcluster/v60/clients/client-go/tcworkermanagerevents
- <!--HTTP-API-end-->
-
-### AMQP APIs
-
-<!--AMQP-API-start-->
 * https://pkg.go.dev/github.com/taskcluster/taskcluster/v60/clients/client-go/tcauth
 
 * https://pkg.go.dev/github.com/taskcluster/taskcluster/v60/clients/client-go/tcgithub
@@ -54,6 +38,22 @@ This library provides the following packages to interface with Taskcluster:
 * https://pkg.go.dev/github.com/taskcluster/taskcluster/v60/clients/client-go/tcsecrets
 
 * https://pkg.go.dev/github.com/taskcluster/taskcluster/v60/clients/client-go/tcworkermanager
+ <!--HTTP-API-end-->
+
+### AMQP APIs
+
+<!--AMQP-API-start-->
+* https://pkg.go.dev/github.com/taskcluster/taskcluster/v60/clients/client-go/tcauthevents
+
+* https://pkg.go.dev/github.com/taskcluster/taskcluster/v60/clients/client-go/tcgithubevents
+
+* https://pkg.go.dev/github.com/taskcluster/taskcluster/v60/clients/client-go/tchooksevents
+
+* https://pkg.go.dev/github.com/taskcluster/taskcluster/v60/clients/client-go/tcnotifyevents
+
+* https://pkg.go.dev/github.com/taskcluster/taskcluster/v60/clients/client-go/tcqueueevents
+
+* https://pkg.go.dev/github.com/taskcluster/taskcluster/v60/clients/client-go/tcworkermanagerevents
  <!--AMQP-API-end-->
 
 ### Setup

--- a/clients/client-go/codegenerator/model/model.go
+++ b/clients/client-go/codegenerator/model/model.go
@@ -64,14 +64,14 @@ func GenerateGodocLinkInReadme(amqpLinks string, httpLinks string) {
 	}
 
 	httpAPI := `<!--HTTP-API-start-->` +
-		amqpLinks +
+		httpLinks +
 		` <!--HTTP-API-end-->`
 
-	AmqpAPI := `<!--AMQP-API-start-->` +
-		httpLinks +
+	amqpAPI := `<!--AMQP-API-start-->` +
+		amqpLinks +
 		` <!--AMQP-API-end-->`
 
-	formattedContent = regexp.MustCompile(`(<!--(AMQP-API-start:?(\w*?):?(\w*?)?)-->)([\s\S]*?)(<!--AMQP-API-end-->)`).ReplaceAll(formattedContent, []byte(AmqpAPI))
+	formattedContent = regexp.MustCompile(`(<!--(AMQP-API-start:?(\w*?):?(\w*?)?)-->)([\s\S]*?)(<!--AMQP-API-end-->)`).ReplaceAll(formattedContent, []byte(amqpAPI))
 	exitOnFail(os.WriteFile(path, formattedContent, 0644))
 	formattedContent = regexp.MustCompile(`(<!--(HTTP-API-start:?(\w*?):?(\w*?)?)-->)([\s\S]*?)(<!--HTTP-API-end-->)`).ReplaceAll(formattedContent, []byte(httpAPI))
 	exitOnFail(os.WriteFile(path, formattedContent, 0644))


### PR DESCRIPTION
AMQP API links were in HTTP section, HTTP API links were in AMQP section 😬

Introduced in #2666.