### PR TITLE
Go client doc fix - some more fallout from #2666

### DIFF
--- a/changelog/ZFQORwwvQTeyGaX83Csyag.md
+++ b/changelog/ZFQORwwvQTeyGaX83Csyag.md
@@ -1,0 +1,3 @@
+audience: general
+level: silent
+---

--- a/clients/client-go/codegenerator/model/model.go
+++ b/clients/client-go/codegenerator/model/model.go
@@ -233,18 +233,31 @@ func (apiDefs APIDefinitions) GenerateCode(goOutputDir string) {
 		FormatSourceAndSave(typesSourceFile, result.SourceCode)
 
 		fmt.Printf("Generating functions and methods for %s\n", job.Package)
-		content := `
-// The following code is AUTO-GENERATED. Please DO NOT edit.
-// To update this generated code, run the following command:
-// in the /codegenerator/model subdirectory of this project,
-// making sure that ` + "`${GOPATH}/bin` is in your `PATH`" + `:
-//
-// go install && go generate
+		content := strings.Join(
+			[]string{
+				"// The following code is AUTO-GENERATED. Please DO NOT edit.",
+				"// To update this generated code, run `go generate` in the",
+				"// clients/client-go/codegenerator/model subdirectory of the",
+				"// taskcluster git repository.",
+				"",
+				"// This package was generated from the reference schema of",
+				"// the " + apiDefs[i].Data.Name() + " service, which is also published here:",
+				"//",
+				"//   * ${TASKCLUSTER_ROOT_URL}" + apiDefs[i].URL,
+				"//",
+				"// where ${TASKCLUSTER_ROOT_URL} points to the root URL of",
+				"// your taskcluster deployment.",
+				// This following blank line is intentional, so that the above
+				// comments are not included in the generated go docs. They are
+				// useful in the file so a developer can see not to modify the
+				// content, but consumers of the API are not concerned with the
+				// above information.
+				"",
+				apiDefs[i].generateAPICode(),
+			},
+			"\n",
+		)
 
-// This package was generated from the schema defined at
-// ` + apiDefs[i].URL + `
-`
-		content += apiDefs[i].generateAPICode()
 		sourceFile := filepath.Join(apiDefs[i].PackagePath, apiDefs[i].PackageName+".go")
 		FormatSourceAndSave(sourceFile, []byte(content))
 

--- a/clients/client-go/tcauth/tcauth.go
+++ b/clients/client-go/tcauth/tcauth.go
@@ -1,12 +1,16 @@
 // The following code is AUTO-GENERATED. Please DO NOT edit.
-// To update this generated code, run the following command:
-// in the /codegenerator/model subdirectory of this project,
-// making sure that `${GOPATH}/bin` is in your `PATH`:
-//
-// go install && go generate
+// To update this generated code, run `go generate` in the
+// clients/client-go/codegenerator/model subdirectory of the
+// taskcluster git repository.
 
-// This package was generated from the schema defined at
-// /references/auth/v1/api.json
+// This package was generated from the reference schema of
+// the Auth service, which is also published here:
+//
+//   * ${TASKCLUSTER_ROOT_URL}/references/auth/v1/api.json
+//
+// where ${TASKCLUSTER_ROOT_URL} points to the root URL of
+// your taskcluster deployment.
+
 // Authentication related API end-points for Taskcluster and related
 // services. These API end-points are of interest if you wish to:
 //   - Authorize a request signed with Taskcluster credentials,

--- a/clients/client-go/tcauthevents/tcauthevents.go
+++ b/clients/client-go/tcauthevents/tcauthevents.go
@@ -1,12 +1,16 @@
 // The following code is AUTO-GENERATED. Please DO NOT edit.
-// To update this generated code, run the following command:
-// in the /codegenerator/model subdirectory of this project,
-// making sure that `${GOPATH}/bin` is in your `PATH`:
-//
-// go install && go generate
+// To update this generated code, run `go generate` in the
+// clients/client-go/codegenerator/model subdirectory of the
+// taskcluster git repository.
 
-// This package was generated from the schema defined at
-// /references/auth/v1/exchanges.json
+// This package was generated from the reference schema of
+// the AuthEvents service, which is also published here:
+//
+//   * ${TASKCLUSTER_ROOT_URL}/references/auth/v1/exchanges.json
+//
+// where ${TASKCLUSTER_ROOT_URL} points to the root URL of
+// your taskcluster deployment.
+
 // The auth service is responsible for storing credentials, managing
 // assignment of scopes, and validation of request signatures from other
 // services.

--- a/clients/client-go/tcgithub/tcgithub.go
+++ b/clients/client-go/tcgithub/tcgithub.go
@@ -1,12 +1,16 @@
 // The following code is AUTO-GENERATED. Please DO NOT edit.
-// To update this generated code, run the following command:
-// in the /codegenerator/model subdirectory of this project,
-// making sure that `${GOPATH}/bin` is in your `PATH`:
-//
-// go install && go generate
+// To update this generated code, run `go generate` in the
+// clients/client-go/codegenerator/model subdirectory of the
+// taskcluster git repository.
 
-// This package was generated from the schema defined at
-// /references/github/v1/api.json
+// This package was generated from the reference schema of
+// the Github service, which is also published here:
+//
+//   * ${TASKCLUSTER_ROOT_URL}/references/github/v1/api.json
+//
+// where ${TASKCLUSTER_ROOT_URL} points to the root URL of
+// your taskcluster deployment.
+
 // The github service is responsible for creating tasks in response
 // to GitHub events, and posting results to the GitHub UI.
 //

--- a/clients/client-go/tcgithubevents/tcgithubevents.go
+++ b/clients/client-go/tcgithubevents/tcgithubevents.go
@@ -1,12 +1,16 @@
 // The following code is AUTO-GENERATED. Please DO NOT edit.
-// To update this generated code, run the following command:
-// in the /codegenerator/model subdirectory of this project,
-// making sure that `${GOPATH}/bin` is in your `PATH`:
-//
-// go install && go generate
+// To update this generated code, run `go generate` in the
+// clients/client-go/codegenerator/model subdirectory of the
+// taskcluster git repository.
 
-// This package was generated from the schema defined at
-// /references/github/v1/exchanges.json
+// This package was generated from the reference schema of
+// the GithubEvents service, which is also published here:
+//
+//   * ${TASKCLUSTER_ROOT_URL}/references/github/v1/exchanges.json
+//
+// where ${TASKCLUSTER_ROOT_URL} points to the root URL of
+// your taskcluster deployment.
+
 // The github service publishes a pulse
 // message for supported github events, translating Github webhook
 // events into pulse messages.

--- a/clients/client-go/tchooks/tchooks.go
+++ b/clients/client-go/tchooks/tchooks.go
@@ -1,12 +1,16 @@
 // The following code is AUTO-GENERATED. Please DO NOT edit.
-// To update this generated code, run the following command:
-// in the /codegenerator/model subdirectory of this project,
-// making sure that `${GOPATH}/bin` is in your `PATH`:
-//
-// go install && go generate
+// To update this generated code, run `go generate` in the
+// clients/client-go/codegenerator/model subdirectory of the
+// taskcluster git repository.
 
-// This package was generated from the schema defined at
-// /references/hooks/v1/api.json
+// This package was generated from the reference schema of
+// the Hooks service, which is also published here:
+//
+//   * ${TASKCLUSTER_ROOT_URL}/references/hooks/v1/api.json
+//
+// where ${TASKCLUSTER_ROOT_URL} points to the root URL of
+// your taskcluster deployment.
+
 // The hooks service provides a mechanism for creating tasks in response to events.
 //
 // See:

--- a/clients/client-go/tchooksevents/tchooksevents.go
+++ b/clients/client-go/tchooksevents/tchooksevents.go
@@ -1,12 +1,16 @@
 // The following code is AUTO-GENERATED. Please DO NOT edit.
-// To update this generated code, run the following command:
-// in the /codegenerator/model subdirectory of this project,
-// making sure that `${GOPATH}/bin` is in your `PATH`:
-//
-// go install && go generate
+// To update this generated code, run `go generate` in the
+// clients/client-go/codegenerator/model subdirectory of the
+// taskcluster git repository.
 
-// This package was generated from the schema defined at
-// /references/hooks/v1/exchanges.json
+// This package was generated from the reference schema of
+// the HooksEvents service, which is also published here:
+//
+//   * ${TASKCLUSTER_ROOT_URL}/references/hooks/v1/exchanges.json
+//
+// where ${TASKCLUSTER_ROOT_URL} points to the root URL of
+// your taskcluster deployment.
+
 // The hooks service is responsible for creating tasks at specific times orin .  response to webhooks and API calls.Using this exchange allows us tomake hooks which repsond to particular pulse messagesThese exchanges provide notifications when a hook is created, updatedor deleted. This is so that the listener running in a different hooks process at the other end can direct another listener specified by`hookGroupId` and `hookId` to synchronize its bindings. But you are ofcourse welcome to use these for other purposes, monitoring changes for example.
 //
 // See:

--- a/clients/client-go/tcindex/tcindex.go
+++ b/clients/client-go/tcindex/tcindex.go
@@ -1,12 +1,16 @@
 // The following code is AUTO-GENERATED. Please DO NOT edit.
-// To update this generated code, run the following command:
-// in the /codegenerator/model subdirectory of this project,
-// making sure that `${GOPATH}/bin` is in your `PATH`:
-//
-// go install && go generate
+// To update this generated code, run `go generate` in the
+// clients/client-go/codegenerator/model subdirectory of the
+// taskcluster git repository.
 
-// This package was generated from the schema defined at
-// /references/index/v1/api.json
+// This package was generated from the reference schema of
+// the Index service, which is also published here:
+//
+//   * ${TASKCLUSTER_ROOT_URL}/references/index/v1/api.json
+//
+// where ${TASKCLUSTER_ROOT_URL} points to the root URL of
+// your taskcluster deployment.
+
 // The index service is responsible for indexing tasks. The service ensures that
 // tasks can be located by user-defined names.
 //

--- a/clients/client-go/tcnotify/tcnotify.go
+++ b/clients/client-go/tcnotify/tcnotify.go
@@ -1,12 +1,16 @@
 // The following code is AUTO-GENERATED. Please DO NOT edit.
-// To update this generated code, run the following command:
-// in the /codegenerator/model subdirectory of this project,
-// making sure that `${GOPATH}/bin` is in your `PATH`:
-//
-// go install && go generate
+// To update this generated code, run `go generate` in the
+// clients/client-go/codegenerator/model subdirectory of the
+// taskcluster git repository.
 
-// This package was generated from the schema defined at
-// /references/notify/v1/api.json
+// This package was generated from the reference schema of
+// the Notify service, which is also published here:
+//
+//   * ${TASKCLUSTER_ROOT_URL}/references/notify/v1/api.json
+//
+// where ${TASKCLUSTER_ROOT_URL} points to the root URL of
+// your taskcluster deployment.
+
 // The notification service listens for tasks with associated notifications
 // and handles requests to send emails and post pulse messages.
 //

--- a/clients/client-go/tcnotifyevents/tcnotifyevents.go
+++ b/clients/client-go/tcnotifyevents/tcnotifyevents.go
@@ -1,12 +1,16 @@
 // The following code is AUTO-GENERATED. Please DO NOT edit.
-// To update this generated code, run the following command:
-// in the /codegenerator/model subdirectory of this project,
-// making sure that `${GOPATH}/bin` is in your `PATH`:
-//
-// go install && go generate
+// To update this generated code, run `go generate` in the
+// clients/client-go/codegenerator/model subdirectory of the
+// taskcluster git repository.
 
-// This package was generated from the schema defined at
-// /references/notify/v1/exchanges.json
+// This package was generated from the reference schema of
+// the NotifyEvents service, which is also published here:
+//
+//   * ${TASKCLUSTER_ROOT_URL}/references/notify/v1/exchanges.json
+//
+// where ${TASKCLUSTER_ROOT_URL} points to the root URL of
+// your taskcluster deployment.
+
 // This pretty much only contains the simple free-form
 // message that can be published from this service from a request
 // by anybody with the proper scopes.

--- a/clients/client-go/tcobject/tcobject.go
+++ b/clients/client-go/tcobject/tcobject.go
@@ -1,12 +1,16 @@
 // The following code is AUTO-GENERATED. Please DO NOT edit.
-// To update this generated code, run the following command:
-// in the /codegenerator/model subdirectory of this project,
-// making sure that `${GOPATH}/bin` is in your `PATH`:
-//
-// go install && go generate
+// To update this generated code, run `go generate` in the
+// clients/client-go/codegenerator/model subdirectory of the
+// taskcluster git repository.
 
-// This package was generated from the schema defined at
-// /references/object/v1/api.json
+// This package was generated from the reference schema of
+// the Object service, which is also published here:
+//
+//   * ${TASKCLUSTER_ROOT_URL}/references/object/v1/api.json
+//
+// where ${TASKCLUSTER_ROOT_URL} points to the root URL of
+// your taskcluster deployment.
+
 // The object service provides HTTP-accessible storage for large blobs of data.
 //
 // Objects can be uploaded and downloaded, with the object data flowing directly

--- a/clients/client-go/tcpurgecache/tcpurgecache.go
+++ b/clients/client-go/tcpurgecache/tcpurgecache.go
@@ -1,12 +1,16 @@
 // The following code is AUTO-GENERATED. Please DO NOT edit.
-// To update this generated code, run the following command:
-// in the /codegenerator/model subdirectory of this project,
-// making sure that `${GOPATH}/bin` is in your `PATH`:
-//
-// go install && go generate
+// To update this generated code, run `go generate` in the
+// clients/client-go/codegenerator/model subdirectory of the
+// taskcluster git repository.
 
-// This package was generated from the schema defined at
-// /references/purge-cache/v1/api.json
+// This package was generated from the reference schema of
+// the PurgeCache service, which is also published here:
+//
+//   * ${TASKCLUSTER_ROOT_URL}/references/purge-cache/v1/api.json
+//
+// where ${TASKCLUSTER_ROOT_URL} points to the root URL of
+// your taskcluster deployment.
+
 // The purge-cache service is responsible for tracking cache-purge requests.
 //
 // User create purge requests for specific caches on specific workers, and

--- a/clients/client-go/tcqueue/tcqueue.go
+++ b/clients/client-go/tcqueue/tcqueue.go
@@ -1,12 +1,16 @@
 // The following code is AUTO-GENERATED. Please DO NOT edit.
-// To update this generated code, run the following command:
-// in the /codegenerator/model subdirectory of this project,
-// making sure that `${GOPATH}/bin` is in your `PATH`:
-//
-// go install && go generate
+// To update this generated code, run `go generate` in the
+// clients/client-go/codegenerator/model subdirectory of the
+// taskcluster git repository.
 
-// This package was generated from the schema defined at
-// /references/queue/v1/api.json
+// This package was generated from the reference schema of
+// the Queue service, which is also published here:
+//
+//   * ${TASKCLUSTER_ROOT_URL}/references/queue/v1/api.json
+//
+// where ${TASKCLUSTER_ROOT_URL} points to the root URL of
+// your taskcluster deployment.
+
 // The queue service is responsible for accepting tasks and tracking their state
 // as they are executed by workers, in order to ensure they are eventually
 // resolved.

--- a/clients/client-go/tcqueueevents/tcqueueevents.go
+++ b/clients/client-go/tcqueueevents/tcqueueevents.go
@@ -1,12 +1,16 @@
 // The following code is AUTO-GENERATED. Please DO NOT edit.
-// To update this generated code, run the following command:
-// in the /codegenerator/model subdirectory of this project,
-// making sure that `${GOPATH}/bin` is in your `PATH`:
-//
-// go install && go generate
+// To update this generated code, run `go generate` in the
+// clients/client-go/codegenerator/model subdirectory of the
+// taskcluster git repository.
 
-// This package was generated from the schema defined at
-// /references/queue/v1/exchanges.json
+// This package was generated from the reference schema of
+// the QueueEvents service, which is also published here:
+//
+//   * ${TASKCLUSTER_ROOT_URL}/references/queue/v1/exchanges.json
+//
+// where ${TASKCLUSTER_ROOT_URL} points to the root URL of
+// your taskcluster deployment.
+
 // The queue service is responsible for accepting tasks and track their state
 // as they are executed by workers. In order ensure they are eventually
 // resolved.

--- a/clients/client-go/tcsecrets/tcsecrets.go
+++ b/clients/client-go/tcsecrets/tcsecrets.go
@@ -1,12 +1,16 @@
 // The following code is AUTO-GENERATED. Please DO NOT edit.
-// To update this generated code, run the following command:
-// in the /codegenerator/model subdirectory of this project,
-// making sure that `${GOPATH}/bin` is in your `PATH`:
-//
-// go install && go generate
+// To update this generated code, run `go generate` in the
+// clients/client-go/codegenerator/model subdirectory of the
+// taskcluster git repository.
 
-// This package was generated from the schema defined at
-// /references/secrets/v1/api.json
+// This package was generated from the reference schema of
+// the Secrets service, which is also published here:
+//
+//   * ${TASKCLUSTER_ROOT_URL}/references/secrets/v1/api.json
+//
+// where ${TASKCLUSTER_ROOT_URL} points to the root URL of
+// your taskcluster deployment.
+
 // The secrets service provides a simple key/value store for small bits of secret
 // data.  Access is limited by scopes, so values can be considered secret from
 // those who do not have the relevant scopes.

--- a/clients/client-go/tcworkermanager/tcworkermanager.go
+++ b/clients/client-go/tcworkermanager/tcworkermanager.go
@@ -1,12 +1,16 @@
 // The following code is AUTO-GENERATED. Please DO NOT edit.
-// To update this generated code, run the following command:
-// in the /codegenerator/model subdirectory of this project,
-// making sure that `${GOPATH}/bin` is in your `PATH`:
-//
-// go install && go generate
+// To update this generated code, run `go generate` in the
+// clients/client-go/codegenerator/model subdirectory of the
+// taskcluster git repository.
 
-// This package was generated from the schema defined at
-// /references/worker-manager/v1/api.json
+// This package was generated from the reference schema of
+// the WorkerManager service, which is also published here:
+//
+//   * ${TASKCLUSTER_ROOT_URL}/references/worker-manager/v1/api.json
+//
+// where ${TASKCLUSTER_ROOT_URL} points to the root URL of
+// your taskcluster deployment.
+
 // This service manages workers, including provisioning for dynamic worker pools.
 //
 // Methods interacting with a provider may return a 503 response if that provider has

--- a/clients/client-go/tcworkermanagerevents/tcworkermanagerevents.go
+++ b/clients/client-go/tcworkermanagerevents/tcworkermanagerevents.go
@@ -1,12 +1,16 @@
 // The following code is AUTO-GENERATED. Please DO NOT edit.
-// To update this generated code, run the following command:
-// in the /codegenerator/model subdirectory of this project,
-// making sure that `${GOPATH}/bin` is in your `PATH`:
-//
-// go install && go generate
+// To update this generated code, run `go generate` in the
+// clients/client-go/codegenerator/model subdirectory of the
+// taskcluster git repository.
 
-// This package was generated from the schema defined at
-// /references/worker-manager/v1/exchanges.json
+// This package was generated from the reference schema of
+// the WorkerManagerEvents service, which is also published here:
+//
+//   * ${TASKCLUSTER_ROOT_URL}/references/worker-manager/v1/exchanges.json
+//
+// where ${TASKCLUSTER_ROOT_URL} points to the root URL of
+// your taskcluster deployment.
+
 // These exchanges provide notifications when a worker pool is created or updated.This is so that the provisioner running in a differentprocess at the other end can synchronize to the changes. But you are ofcourse welcome to use these for other purposes, monitoring changes for example.
 //
 // See:


### PR DESCRIPTION
This line break was removed in #2666 but was intentionally included so that the comment about auto-generation is a code comment, not a package comment. It has no value for users to see this comment in the generated go docs. They simply wish to know how to use the package, and do not care that the docs are auto-generated. Developers care, because they need to know they should not be making manual changes to the file, which is why it is included as a code comment, and should not be part of the go docs.