### PR TITLE
Refreshes raw log url before opening it

### DIFF
--- a/changelog/issue-6795.md
+++ b/changelog/issue-6795.md
@@ -1,0 +1,6 @@
+audience: users
+level: patch
+reference: issue 6795
+---
+
+Fixes "Raw Log" button in UI that can point to an expired artifact.

--- a/ui/src/views/Tasks/TaskLog/index.jsx
+++ b/ui/src/views/Tasks/TaskLog/index.jsx
@@ -74,6 +74,14 @@ export default class TaskLog extends Component {
     return getArtifactUrl({ user, taskId, runId, name });
   }
 
+  goToLog() {
+    // as log url contains bewit, the link could expire
+    // raw logs will be opened in new tab/window
+    const url = this.getLogUrl();
+
+    window.open(url, '_blank', 'noopener noreferrer');
+  }
+
   render() {
     const {
       classes,
@@ -117,15 +125,14 @@ export default class TaskLog extends Component {
                   <ArrowLeftIcon />
                 </Button>
               </Link>
-              <Link to={url}>
-                <Button
-                  spanProps={{ className: classes.rawLog }}
-                  tooltipProps={{ title: 'Raw Log' }}
-                  variant="round"
-                  color="secondary">
-                  <OpenInNewIcon size={20} />
-                </Button>
-              </Link>
+              <Button
+                onClick={() => this.goToLog()}
+                spanProps={{ className: classes.rawLog }}
+                tooltipProps={{ title: 'Raw Log' }}
+                variant="round"
+                color="secondary">
+                <OpenInNewIcon size={20} />
+              </Button>
             </Fragment>
           }
         />


### PR DESCRIPTION
To avoid seeing link expired errors we  need to refresh it

Fixes #6795 
Fixes #5033 