### PR TITLE
Don't close the websocket when invalid UTF-8 is output by an interactive session

### DIFF
--- a/changelog/issue-6848.md
+++ b/changelog/issue-6848.md
@@ -1,0 +1,6 @@
+audience: users
+level: patch
+reference: issue 6848
+---
+
+Fix an issue where an interactive session would close up when the shell would output invalid UTF-8.

--- a/workers/generic-worker/interactive/interactivejob.go
+++ b/workers/generic-worker/interactive/interactivejob.go
@@ -104,7 +104,7 @@ func (itj *InteractiveJob) copyCommandOutputStream() {
 			if n == 0 {
 				continue
 			}
-			if err := itj.writeWsMessage(websocket.TextMessage, buf[:n]); err != nil {
+			if err := itj.writeWsMessage(websocket.BinaryMessage, buf[:n]); err != nil {
 				itj.errors <- err
 				return
 			}
@@ -163,7 +163,7 @@ func (itj *InteractiveJob) handleWebsocketMessages() {
 
 func (itj *InteractiveJob) reportError(errorMessage string) {
 	log.Println(errorMessage)
-	err := itj.writeWsMessage(websocket.TextMessage, []byte(errorMessage))
+	err := itj.writeWsMessage(websocket.BinaryMessage, []byte(errorMessage))
 	if err != nil {
 		log.Println("Error while reporting error to client")
 	}


### PR DESCRIPTION
There's 2 parts to this. First, the worker was using a `TextMessage` for websockets which would assume the message was valid UTF-8. This ended up being the main issue, it would just close the websocket when it saw invalid UTF-8.

The second part was the DECODER (which wasn't used in version 2 of interactive sessions until now), which was spamming the console with errors when it received invalid UTF-8.

Fixing both of those allows one to see invalid UTF-8 output in their interactive sessions.

I kept backwards compatibility with generic-worker which are still sending `TextMessage` messages by checking that the received data is a string and kept the old behavior in that case.

Fixes #6848