### PR TITLE
Add a proper `TERM` environment variable to interactive sessions

### DIFF
--- a/changelog/issue-6850.md
+++ b/changelog/issue-6850.md
@@ -1,0 +1,5 @@
+audience: users
+level: patch
+reference: issue 6850
+---
+Add a proper TERM environment variable to interative sessions. This helps with some ncurses apps and tmux for example.

--- a/workers/generic-worker/multiuser_posix.go
+++ b/workers/generic-worker/multiuser_posix.go
@@ -66,10 +66,13 @@ func (task *TaskRun) generateInteractiveCommand(ctx context.Context) (*exec.Cmd,
 	var processCmd *process.Command
 	var err error
 
+	var envVars = task.EnvVars()
+	envVars = append(envVars, "TERM=hterm-256color")
+
 	if ctx == nil {
-		processCmd, err = process.NewCommand([]string{"bash"}, taskContext.TaskDir, task.EnvVars(), taskContext.pd)
+		processCmd, err = process.NewCommand([]string{"bash"}, taskContext.TaskDir, envVars, taskContext.pd)
 	} else {
-		processCmd, err = process.NewCommandContext(ctx, []string{"bash"}, taskContext.TaskDir, task.EnvVars(), taskContext.pd)
+		processCmd, err = process.NewCommandContext(ctx, []string{"bash"}, taskContext.TaskDir, envVars, taskContext.pd)
 	}
 
 	return processCmd.Cmd, err

--- a/workers/generic-worker/simple.go
+++ b/workers/generic-worker/simple.go
@@ -37,10 +37,13 @@ func (task *TaskRun) generateInteractiveCommand(ctx context.Context) (*exec.Cmd,
 	var processCmd *process.Command
 	var err error
 
+	var envVars = task.EnvVars()
+	envVars = append(envVars, "TERM=hterm-256color")
+
 	if ctx == nil {
-		processCmd, err = process.NewCommand([]string{"bash"}, taskContext.TaskDir, task.EnvVars())
+		processCmd, err = process.NewCommand([]string{"bash"}, taskContext.TaskDir, envVars)
 	} else {
-		processCmd, err = process.NewCommandContext(ctx, []string{"bash"}, taskContext.TaskDir, task.EnvVars())
+		processCmd, err = process.NewCommandContext(ctx, []string{"bash"}, taskContext.TaskDir, envVars)
 	}
 
 	return processCmd.Cmd, err


### PR DESCRIPTION
The `TERM` environment variable is used to indicate the capabilities of the current terminal emulator. Applications use it to know whether they can use some features or not. An example of that is tmux which looks for the `clear` capability which is missing from the default `TERM` assigned by bash (`dumb`).
Thankfully this was fairly easy as `hterm` is a supported terminal.

Github Bug/Issue: Fixes #6850
