### PR TITLE
Fix docker worker shell UI to set row/cols properly

### DIFF
--- a/changelog/d_PriigFRCas7ER_z3UwpA.md
+++ b/changelog/d_PriigFRCas7ER_z3UwpA.md
@@ -1,0 +1,5 @@
+audience: users
+level: patch
+---
+
+Fix docker worker interactive shell UI rows/cols settings.

--- a/ui/src/components/Shell/index.jsx
+++ b/ui/src/components/Shell/index.jsx
@@ -92,10 +92,12 @@ export default class Shell extends Component {
           });
 
           this.client.resize(
-            terminal.screenSize.width,
-            terminal.screenSize.height
+            terminal.screenSize.height,
+            terminal.screenSize.width
           );
-          io.onTerminalResize = (c, r) => this.client.resize(c, r);
+          // onTerminalResize provides width then height;
+          // DockerExecClient.resize needs height then width
+          io.onTerminalResize = (cols, rows) => this.client.resize(rows, cols);
           this.client.stdout.on('data', data =>
             io.writeUTF8(DECODER.decode(data))
           );


### PR DESCRIPTION
It looks like this is broken on first load, due to the second `resize` call, as well as on resize (onTerminalResize and DockerExecClient.resize's arg order doesn't match).

There's an initial `this.client.resize.apply` call which is correct...and seems like it doesn't need to exist...but this is working fine so it seems best not to try to remove it.