### PR TITLE
Fix validation error for hooks page

### DIFF
--- a/changelog/AuLw2QSJTYishObr92Sz7A.md
+++ b/changelog/AuLw2QSJTYishObr92Sz7A.md
@@ -1,0 +1,5 @@
+audience: users
+level: patch
+---
+
+Fixes graphql validation rules for hooks groups query.

--- a/services/web-server/src/main.js
+++ b/services/web-server/src/main.js
@@ -150,7 +150,7 @@ const load = loader(
           validationRules: [
             queryLimit(1000),
             depthLimit(10),
-            createComplexityLimitRule(1000),
+            createComplexityLimitRule(4500),
           ],
         });
         await server.start();

--- a/services/web-server/test/graphql/validation_test.js
+++ b/services/web-server/test/graphql/validation_test.js
@@ -1,0 +1,62 @@
+import assert from 'assert';
+import gql from 'graphql-tag';
+import testing from 'taskcluster-lib-testing';
+import helper from '../helper.js';
+
+helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
+  helper.withDb(mock, skipping);
+  helper.withClients(mock, skipping);
+  helper.withServer(mock, skipping);
+  helper.resetTables(mock, skipping);
+
+  suite('GraphQL Validation', function() {
+    test('max tokens in request', async function() {
+      const client = helper.getHttpClient({ suppressErrors: true });
+
+      try {
+        await client.query({
+          query: gql`
+            query {
+              ${' a '.repeat(100000)}
+            }
+          `,
+        });
+      } catch (err) {
+        assert.equal('PayloadTooLargeError', err.networkError.result.name);
+        assert.ok(err.networkError.statusCode >= 400);
+      }
+    });
+    test('max queries in request', async function() {
+      const client = helper.getHttpClient({ suppressErrors: true });
+
+      try {
+        await client.query({
+          query: gql`
+            query {
+              ${' a '.repeat(1000)}
+            }
+          `,
+        });
+      } catch (err) {
+        assert.ok(err.networkError.statusCode >= 400);
+        assert.ok(/validation errors/.test(JSON.stringify(err.networkError.result)));
+      }
+    });
+    test('max depth in request', async function() {
+      const client = helper.getHttpClient({ suppressErrors: true });
+
+      try {
+        await client.query({
+          query: gql`
+            query {
+              ${ Array(20).fill('').reduce((child, _) => `a { ${child} }`, 'a') }
+            }
+          `,
+        });
+      } catch (err) {
+        assert.ok(err.networkError.statusCode >= 400);
+        assert.ok(/exceeds maximum operation depth/.test(JSON.stringify(err.networkError.result)));
+      }
+    });
+  });
+});

--- a/services/web-server/test/helper.js
+++ b/services/web-server/test/helper.js
@@ -246,7 +246,7 @@ helper.withGithubClient = () => {
   });
 };
 
-helper.getHttpClient = () => {
+helper.getHttpClient = (clientOptions = {}) => {
   const gotFetch = async (url, options) => {
     // Map Fetch API options to Got options
     const gotOptions = {
@@ -277,7 +277,7 @@ helper.getHttpClient = () => {
     };
 
     // useful to debug real errors before HttpLink throws obfuscated errors
-    if (!fetchResponse.ok || response.body?.errors) {
+    if (!clientOptions.suppressErrors && (!fetchResponse.ok || response.body?.errors)) {
       console.error(`Error from ${url}: \n${await fetchResponse.text()}`);
     }
 


### PR DESCRIPTION
Since validationRules property was misplaced before, it didn't do anything, so this problem wasn't caught. After it complained about hooksGroup query validation complexity. As that query includes lists and queries external entities with additional queries, complexity rises to ~4000.
