### PR TITLE
Issue 6864: D2G: pass --privileged to podman run when passing --device=/dev/shm

### DIFF
--- a/changelog/issue-6864.md
+++ b/changelog/issue-6864.md
@@ -1,0 +1,10 @@
+audience: users
+level: patch
+reference: issue 6864
+---
+D2G now passes `--privileged` flag to the generated `podman run` command when
+Docker Worker payload enables device capability `hostSharedMemory`.  Without
+this option, the podman container could not successfully access the shared
+memory, despite the inclusion of argument `--device=/dev/shm`. With both
+arguments present (`--privileged` and `--device=/dev/shm`), shared memory now
+appears to be available inside the podman container.

--- a/tools/d2g/d2g.go
+++ b/tools/d2g/d2g.go
@@ -292,7 +292,7 @@ func podmanRunCommand(containerName string, dwPayload *dockerworker.DockerWorker
 	default:
 		command.WriteString(fmt.Sprintf("timeout %v podman run -t --name %v", dwPayload.MaxRunTime, containerName))
 	}
-	if dwPayload.Capabilities.Privileged || dwPayload.Features.Dind {
+	if dwPayload.Capabilities.Privileged || dwPayload.Features.Dind || dwPayload.Capabilities.Devices.HostSharedMemory {
 		command.WriteString(" --privileged")
 	}
 	if dwPayload.Capabilities.DisableSeccomp {

--- a/tools/d2g/d2gtest/testdata/testcases/devices_tests.yml
+++ b/tools/d2g/d2gtest/testdata/testcases/devices_tests.yml
@@ -19,7 +19,7 @@ testSuite:
           - - bash
             - '-cx'
             - >-
-              podman run -t --rm
+              podman run -t --rm --privileged
               --device=/dev/shm
               -e RUN_ID
               -e TASKCLUSTER_ROOT_URL


### PR DESCRIPTION
Fixes #6864