### PR TITLE
Issue 6881: google cloud workers workerGroup set to zone rather than region

### DIFF
--- a/changelog/issue-6881.md
+++ b/changelog/issue-6881.md
@@ -1,0 +1,9 @@
+audience: users
+level: major
+reference: issue 6881
+---
+Google cloud workers spawned by Worker Manager now have `workerGroup` set to
+the Google Cloud _Zone_ (e.g. `us-east1-d`) rather than the Google Cloud
+_Region_ (e.g. `us-east1`). This makes it easier to issue api requests against
+an instance, e.g. `gcloud compute instances delete <workerId>
+--zone=<workerGroup>`.

--- a/services/worker-manager/src/providers/google.js
+++ b/services/worker-manager/src/providers/google.js
@@ -228,7 +228,11 @@ export class GoogleProvider extends Provider {
       // workers in taskcluster.
       const poolName = workerPoolId.replace(/[\/_]/g, '-').slice(0, 38);
       const instanceName = `${poolName}-${slugid.nice().replace(/_/g, '-').toLowerCase()}`;
-      const workerGroup = cfg.region;
+      // Historically we set workerGroup to cfg.region (e.g. 'us-east1') but
+      // cfg.zone (e.g. 'us-east1-d') is more specific, and required for e.g.
+      // terminating instances with:
+      //   `gcloud compute instances delete <workerId> --zone=<workerGroup>`
+      const workerGroup = cfg.zone;
       const labels = {
         'created-by': `taskcluster-wm-${this.providerId}`.replace(/[^a-zA-Z0-9-]/g, '-'),
         'managed-by': 'taskcluster',

--- a/services/worker-manager/test/provider_google_test.js
+++ b/services/worker-manager/test/provider_google_test.js
@@ -140,7 +140,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       const worker = workers[0];
 
       assert.equal(worker.workerPoolId, workerPoolId, 'Worker was created for a wrong worker pool');
-      assert.equal(worker.workerGroup, defaultLaunchConfig.region, 'Worker group should be region');
+      assert.equal(worker.workerGroup, defaultLaunchConfig.zone, 'Worker group should be zone');
       assert.equal(worker.state, Worker.states.REQUESTED, 'Worker should be marked as requested');
       assert.equal(worker.providerData.zone, defaultLaunchConfig.zone, 'Zone should come from the chosen config');
       assert.deepEqual(worker.providerData.workerConfig, {});
@@ -169,7 +169,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       assert.deepEqual(tcmeta, {
         workerPoolId,
         providerId,
-        workerGroup: defaultLaunchConfig.region,
+        workerGroup: defaultLaunchConfig.zone,
         rootUrl: helper.rootUrl,
         workerConfig: {},
       });
@@ -378,7 +378,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
     const workerId = '12345';
     const worker = await makeWorker({
       workerPoolId,
-      workerGroup: 'us-east1',
+      workerGroup: 'us-east1-a',
       workerId,
       providerId,
       created: taskcluster.fromNow('0 seconds'),
@@ -398,7 +398,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
     const suiteMakeWorker = async (overrides) => {
       return await makeWorker({
         workerPoolId,
-        workerGroup: 'us-east1',
+        workerGroup: 'us-east1-a',
         workerId,
         providerId,
         created: taskcluster.fromNow('-2 weeks'),
@@ -593,7 +593,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
   });
 
   suite('registerWorker', function() {
-    const workerGroup = 'us-east1';
+    const workerGroup = 'us-east1-a';
     const workerId = 'abc123';
 
     const defaultWorker = {

--- a/ui/docs/reference/core/worker-manager/google.mdx
+++ b/ui/docs/reference/core/worker-manager/google.mdx
@@ -20,7 +20,7 @@ The provider starts workers with an instance attribute named `taskcluster` conta
 
 * `workerPoolId` -- worker pool for this worker
 * `providerId` -- provider ID that started the worker
-* `workerGroup` -- the worker's region (taken from the launchConfig used to start the worker)
+* `workerGroup` -- the worker's zone
 * `rootUrl` -- [root URL](/docs/manual/using/root-urls) for the Taskcluster deployment
 * `workerConfig` -- worker configuration supplied as part of the worker pool configuration (deprecated; use the result of `registerWorker` instead)
 


### PR DESCRIPTION
Fixes #6881

Note, `zone` is a [required](https://github.com/taskcluster/taskcluster/blob/d34967f798d91ec794bcec4556682e1f932fda55/services/worker-manager/schemas/v1/config-google.yml#L94) property in launch config, so no risk that only `region` is specified in worker pool definition. This is different to AWS, where `region` [is specified](https://github.com/taskcluster/taskcluster/blob/4c9c284a8afda18ec3e163a8be198450128a3ef0/services/worker-manager/schemas/v1/config-aws.yml#L66), but `availabilityZone` is not.