### PR TITLE
fix(generic-worker): fix malformed payload log when enabling interactive task

### DIFF
--- a/changelog/Ap0wKwVAT-CSQUTGw7gOtw.md
+++ b/changelog/Ap0wKwVAT-CSQUTGw7gOtw.md
@@ -1,4 +1,4 @@
 audience: users
 level: patch
 ---
-Generic Worker: fixed incorrect log line when an Interactive Task fails due to the worker pool config not being set.
+Generic Worker now correctly reports the Worker Pool ID when an interactive task is attempted on a worker pool with the interactive feature disabled. Previously the task log would report the Worker Pool ID in the `exception/malformed-payload` task run as `<workerGroup>/<workerType>`; now it correctly reports it as `<provisionerId>/<workerType>`. The Interactive feature is considered disabled when Generic Worker config setting `enableInteractive` is either absent or explicitly set to `false` in the Generic Worker config.

--- a/changelog/Ap0wKwVAT-CSQUTGw7gOtw.md
+++ b/changelog/Ap0wKwVAT-CSQUTGw7gOtw.md
@@ -1,0 +1,4 @@
+audience: users
+level: patch
+---
+Generic Worker: fixed incorrect log line when an Interactive Task fails due to the worker pool config not being set.

--- a/workers/generic-worker/interactive.go
+++ b/workers/generic-worker/interactive.go
@@ -64,7 +64,7 @@ func (it *InteractiveTask) ReservedArtifacts() []string {
 
 func (it *InteractiveTask) Start() *CommandExecutionError {
 	if !config.EnableInteractive {
-		workerPoolID := config.WorkerGroup + "/" + config.WorkerType
+		workerPoolID := config.ProvisionerID + "/" + config.WorkerType
 		workerManagerURL := config.RootURL + "/worker-manager/" + url.PathEscape(workerPoolID)
 		return MalformedPayloadError(fmt.Errorf(`this task has payload.features.interactive set to true, but enableInteractive is not enabled on this worker pool (%s)
 If you do not require an interactive task, remove payload.features.interactive from the task definition.


### PR DESCRIPTION
>Generic Worker: fixed incorrect log line when an Interactive Task fails due to the worker pool config not being set.