### PR TITLE
chore(generic-worker): use `filepath.WalkDir`

### DIFF
--- a/changelog/XqmVDnNSQeaUj-43ZuK1Sw.md
+++ b/changelog/XqmVDnNSQeaUj-43ZuK1Sw.md
@@ -1,0 +1,8 @@
+audience: general
+level: patch
+---
+Generic Worker now utilizes `filepath.WalkDir` instead of `filepath.Walk`.
+
+`filepath.WalkDir` was introduced in go1.16 and is more performant and efficient over `filepath.Walk`.
+
+This _may_ help with race conditions during artifact uploads, where a file was initially seen, but then became unavailable at upload time.

--- a/workers/generic-worker/artifacts.go
+++ b/workers/generic-worker/artifacts.go
@@ -57,7 +57,7 @@ func (task *TaskRun) PayloadArtifacts() []artifacts.TaskArtifact {
 				payloadArtifacts = append(payloadArtifacts, errArtifact)
 				continue
 			}
-			walkFn := func(path string, info os.FileInfo, incomingErr error) error {
+			walkFn := func(path string, d os.DirEntry, incomingErr error) error {
 				subPath, err := filepath.Rel(taskContext.TaskDir, path)
 				if err != nil {
 					// this indicates a bug in the code
@@ -93,7 +93,7 @@ func (task *TaskRun) PayloadArtifacts() []artifacts.TaskArtifact {
 							Path:         subPath,
 						},
 					)
-				case info.IsDir():
+				case d.IsDir():
 					if errArtifact := resolve(b, "directory", subPath, artifact.ContentType, artifact.ContentEncoding); errArtifact != nil {
 						payloadArtifacts = append(payloadArtifacts, errArtifact)
 					}
@@ -104,7 +104,7 @@ func (task *TaskRun) PayloadArtifacts() []artifacts.TaskArtifact {
 			}
 			// Any error returned here should already have been handled by
 			// walkFn, so should be safe to ignore.
-			_ = filepath.Walk(filepath.Join(taskContext.TaskDir, basePath), walkFn)
+			_ = filepath.WalkDir(filepath.Join(taskContext.TaskDir, basePath), walkFn)
 		}
 	}
 	return payloadArtifacts

--- a/workers/generic-worker/multiuser_windows.go
+++ b/workers/generic-worker/multiuser_windows.go
@@ -294,7 +294,7 @@ func RenameCrossDevice(oldpath, newpath string) (err error) {
 
 func RenameFolderCrossDevice(oldpath, newpath string) (err error) {
 	// recursively move files
-	moveFile := func(path string, info os.FileInfo, inErr error) (outErr error) {
+	moveFile := func(path string, d os.DirEntry, inErr error) (outErr error) {
 		if inErr != nil {
 			return inErr
 		}
@@ -304,14 +304,19 @@ func RenameFolderCrossDevice(oldpath, newpath string) (err error) {
 			return
 		}
 		targetPath := filepath.Join(newpath, relPath)
-		if info.IsDir() {
+		if d.IsDir() {
+			var info os.FileInfo
+			info, outErr = d.Info()
+			if outErr != nil {
+				return
+			}
 			outErr = os.Mkdir(targetPath, info.Mode())
 		} else {
 			outErr = RenameCrossDevice(path, targetPath)
 		}
 		return
 	}
-	err = filepath.Walk(oldpath, moveFile)
+	err = filepath.WalkDir(oldpath, moveFile)
 	if err != nil {
 		return
 	}

--- a/workers/generic-worker/simple_test.go
+++ b/workers/generic-worker/simple_test.go
@@ -35,19 +35,19 @@ func TestNewTaskDirectoryForEachTask(t *testing.T) {
 
 	var taskDirs uint = 0
 	visitedRootDir := false
-	err := filepath.Walk(config.TasksDir, func(path string, info os.FileInfo, err error) error {
-		// filepath.Walk guarantees lexical ordering and therefore, first entry is root directory
+	err := filepath.WalkDir(config.TasksDir, func(path string, d os.DirEntry, err error) error {
+		// filepath.WalkDir guarantees lexical ordering and therefore, first entry is root directory
 		if !visitedRootDir {
 			visitedRootDir = true
 			return nil
 		}
-		if !info.IsDir() {
+		if !d.IsDir() {
 			t.Logf("Found file %v", path)
 			return nil
 		}
 		t.Logf("Found directory %v", path)
-		if !strings.HasPrefix(info.Name(), "task_") && info.Name() != "generic-worker" {
-			return fmt.Errorf("Discovered directory with name %q but was expecting it to start with `task_`", info.Name())
+		if !strings.HasPrefix(d.Name(), "task_") && d.Name() != "generic-worker" {
+			return fmt.Errorf("Discovered directory with name %q but was expecting it to start with `task_`", d.Name())
 		}
 		taskDirs++
 		return nil


### PR DESCRIPTION
>Generic Worker now utilizes `filepath.WalkDir` instead of `filepath.Walk`.
>
>`filepath.WalkDir` was introduced in go1.16 and is more performant and efficient over `filepath.Walk`.
>
>This _may_ help with race conditions during artifact uploads, where a file was initially seen, but then became unavailable at upload time.

From https://pkg.go.dev/path/filepath#Walk:
>Walk is less efficient than [WalkDir](https://pkg.go.dev/path/filepath#WalkDir), introduced in Go 1.16, which avoids calling os.Lstat on every visited file or directory.