### PR TITLE
Ensure 'taskGroup' is always defined when fetching scopes for submitting an action task

### DIFF
--- a/changelog/N39Wr4udTH-1jL1N6rTggw.md
+++ b/changelog/N39Wr4udTH-1jL1N6rTggw.md
@@ -1,0 +1,5 @@
+audience: users
+level: patch
+---
+
+Action tasks now work correctly for task groups created by another action task.

--- a/ui/src/views/Tasks/submitTaskAction.js
+++ b/ui/src/views/Tasks/submitTaskAction.js
@@ -13,7 +13,19 @@ import ajv from '../../utils/ajv';
 
 export default async ({ task, form, action, apolloClient, taskActions }) => {
   const actions = removeKeys(cloneDeep(taskActions), ['__typename']);
-  const taskGroup = task.taskId === task.taskGroupId ? task : task.decisionTask;
+  // We need to source scopes from somewhere. Typically these come from the
+  // task we're given, which is either a regular decision task or an action
+  // task. Decision tasks are easily identified, because their taskId matches
+  // the taskGroupId that they are in. Action tasks do not have such a
+  // mapping. Instead, we're simply going to try our best by falling back to
+  // `task` if `task.decisionTask` is null or undefined. At the time of
+  // writing, it's not clear whether the `task.decisionTask` case is even
+  // valid anymore, but it's being kept for the time being because verifying
+  // that is not a trivial matter.
+  const taskGroup =
+    task.taskId === task.taskGroupId || !task.decisionTask
+      ? task
+      : task.decisionTask;
   const input = load(form);
   const validate = ajv.compile(action.schema || {});
   const valid = validate(input);


### PR DESCRIPTION
This is in support of making actions like "Cancel All" work on task groups that have been created by an Action Task (see https://github.com/mozilla/firefox-translations-training/issues/250).

In an ideal world I'd like to understanding how `task.decisionTask` fits into things a bit more, and see if it could be removed...but that's more work than I'm willing to put in at the moment. I think this is a fairly safe fix to take in the meantime.