### PR TITLE
Client-node rewritten to ESModules

### DIFF
--- a/changelog/SpXAnuHoR-eCCnQRLNqCGQ.md
+++ b/changelog/SpXAnuHoR-eCCnQRLNqCGQ.md
@@ -1,0 +1,5 @@
+audience: developers
+level: major
+---
+
+Upgrades client-node library to ESModules and upgrades `got` library

--- a/clients/client-test/package.json
+++ b/clients/client-test/package.json
@@ -11,7 +11,6 @@
     "http-proxy": "^1.18.0",
     "mocha": "^10.2.0",
     "nock": "^13.0.0",
-    "stream-buffers": "^3.0.2",
     "taskcluster-client": "link:../client",
     "taskcluster-db": "link:db",
     "taskcluster-lib-api": "link:../libraries/api",

--- a/clients/client-test/yarn.lock
+++ b/clients/client-test/yarn.lock
@@ -1298,13 +1298,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"stream-buffers@npm:^3.0.2":
-  version: 3.0.2
-  resolution: "stream-buffers@npm:3.0.2"
-  checksum: 10c0/5f12f5a3af4d2012b4f5386a05667b16710fdfc3d9c9db12ec64c44d9f0f831b10cf8c941afd5398b6f47ddb3db692894a16e0f82a8a22b43a5ecb424064ce40
-  languageName: node
-  linkType: hard
-
 "string-width@npm:^1.0.2 || 2 || 3 || 4, string-width@npm:^4.1.0, string-width@npm:^4.2.0, string-width@npm:^4.2.3":
   version: 4.2.3
   resolution: "string-width@npm:4.2.3"
@@ -1380,7 +1373,6 @@ __metadata:
     http-proxy: "npm:^1.18.0"
     mocha: "npm:^10.2.0"
     nock: "npm:^13.0.0"
-    stream-buffers: "npm:^3.0.2"
     taskcluster-client: "link:../client"
     taskcluster-db: "link:db"
     taskcluster-lib-api: "link:../libraries/api"

--- a/clients/client/package.json
+++ b/clients/client/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "debug": "^4.1.1",
-    "got": "^11.8.1",
+    "got": "^14.2.1",
     "hawk": "^9.0.1",
     "lodash": "^4.17.4",
     "slugid": "^5.0.1",
@@ -26,6 +26,7 @@
   "engines": {
     "node": "18.19.1"
   },
+  "type": "module",
   "files": [
     "src"
   ],

--- a/clients/client/package.json
+++ b/clients/client/package.json
@@ -20,8 +20,7 @@
   "devDependencies": {
     "http-proxy": "^1.18.0",
     "mocha": "^10.2.0",
-    "nock": "^13.0.0",
-    "stream-buffers": "^3.0.2"
+    "nock": "^13.0.0"
   },
   "engines": {
     "node": "18.19.1"

--- a/clients/client/src/apis.js
+++ b/clients/client/src/apis.js
@@ -1,5 +1,5 @@
 /* eslint-disable */
-module.exports = {
+export default {
   "Auth": {
     "reference": {
       "$schema": "/schemas/common/api-reference-v0.json#",

--- a/clients/client/src/client.js
+++ b/clients/client/src/client.js
@@ -466,6 +466,7 @@ export const createClient = function(reference, name) {
             routingKeyPattern === null) {
           routingKeyPattern = {};
         }
+
         // Check that the routing key pattern is an object
         assert(routingKeyPattern instanceof Object,
           'routingKeyPattern must be an object');
@@ -664,22 +665,24 @@ export const createClient = function(reference, name) {
 // Load data from apis.js
 import apis from './apis.js';
 
-export const Auth = createClient(apis.Auth.reference, "Auth");
-export const AuthEvents = createClient(apis.AuthEvents.reference, "AuthEvents");
-export const Github = createClient(apis.Github.reference, "Github");
-export const GithubEvents = createClient(apis.GithubEvents.reference, "GithubEvents");
-export const Hooks = createClient(apis.Hooks.reference, "Hooks");
-export const HooksEvents = createClient(apis.HooksEvents.reference, "HooksEvents");
-export const Index = createClient(apis.Index.reference, "Index");
-export const Notify = createClient(apis.Notify.reference, "Notify");
-export const NotifyEvents = createClient(apis.NotifyEvents.reference, "NotifyEvents");
-export const Object = createClient(apis.Object.reference, "Object");
-export const PurgeCache = createClient(apis.PurgeCache.reference, "PurgeCache");
-export const Queue = createClient(apis.Queue.reference, "Queue");
-export const QueueEvents = createClient(apis.QueueEvents.reference, "QueueEvents");
-export const Secrets = createClient(apis.Secrets.reference, "Secrets");
-export const WorkerManager = createClient(apis.WorkerManager.reference, "WorkerManager");
-export const WorkerManagerEvents = createClient(apis.WorkerManagerEvents.reference, "WorkerManagerEvents");
+export const clients = {
+  Auth: createClient(apis.Auth.reference, "Auth"),
+  AuthEvents: createClient(apis.AuthEvents.reference, "AuthEvents"),
+  Github: createClient(apis.Github.reference, "Github"),
+  GithubEvents: createClient(apis.GithubEvents.reference, "GithubEvents"),
+  Hooks: createClient(apis.Hooks.reference, "Hooks"),
+  HooksEvents: createClient(apis.HooksEvents.reference, "HooksEvents"),
+  Index: createClient(apis.Index.reference, "Index"),
+  Notify: createClient(apis.Notify.reference, "Notify"),
+  NotifyEvents: createClient(apis.NotifyEvents.reference, "NotifyEvents"),
+  Object: createClient(apis.Object.reference, "Object"),
+  PurgeCache: createClient(apis.PurgeCache.reference, "PurgeCache"),
+  Queue: createClient(apis.Queue.reference, "Queue"),
+  QueueEvents: createClient(apis.QueueEvents.reference, "QueueEvents"),
+  Secrets: createClient(apis.Secrets.reference, "Secrets"),
+  WorkerManager: createClient(apis.WorkerManager.reference, "WorkerManager"),
+  WorkerManagerEvents: createClient(apis.WorkerManagerEvents.reference, "WorkerManagerEvents"),
+};
 
 /**
  * Update default configuration
@@ -860,7 +863,7 @@ export const credentialInformation = function(rootUrl, credentials) {
     result.type = 'permanent';
   }
 
-  let anonClient = new Auth({ rootUrl });
+  let anonClient = new clients.Auth({ rootUrl });
   let clientLookup = anonClient.client(issuer).then(function(client) {
     let expires = new Date(client.expires);
     if (!result.expiry || result.expiry > expires) {
@@ -871,7 +874,7 @@ export const credentialInformation = function(rootUrl, credentials) {
     }
   });
 
-  let credClient = new Auth({ rootUrl, credentials });
+  let credClient = new clients.Auth({ rootUrl, credentials });
   let scopeLookup = credClient.currentScopes().then(function(response) {
     result.scopes = response.scopes;
   });

--- a/clients/client/src/client.js
+++ b/clients/client/src/client.js
@@ -2,19 +2,21 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-let got = require('got');
-let debug = require('debug')('taskcluster-client');
-let _ = require('lodash');
-let assert = require('assert');
-let hawk = require('hawk');
-let url = require('url');
-let crypto = require('crypto');
-let slugid = require('slugid');
-let http = require('http');
-let https = require('https');
-let querystring = require('querystring');
-let tcUrl = require('taskcluster-lib-urls');
-let retry = require('./retry');
+import got from 'got';
+
+import debugFactory from 'debug';
+const debug = debugFactory('taskcluster-client');
+import _ from 'lodash';
+import assert from 'assert';
+import hawk from 'hawk';
+import url from 'url';
+import crypto from 'crypto';
+import slugid from 'slugid';
+import http from 'http';
+import https from 'https';
+import querystring from 'querystring';
+import tcUrl from 'taskcluster-lib-urls';
+import retry from './retry.js';
 
 /** Default options for our http/https global agents */
 let AGENT_OPTIONS = {
@@ -36,7 +38,7 @@ let DEFAULT_AGENTS = {
 // Exports agents, consumers can provide their own default agents and tests
 // can call taskcluster.agents.http.destroy() when running locally, otherwise
 // tests won't terminate (if they are configured with keepAlive)
-exports.agents = DEFAULT_AGENTS;
+export const agents = DEFAULT_AGENTS;
 
 // By default, all requests to a service go the the rootUrl and
 // are load-balanced to services from there. However, if running
@@ -48,7 +50,8 @@ exports.agents = DEFAULT_AGENTS;
 // request to `my-svc` and it will route correctly
 const SERVICE_DISCOVERY_SCHEMES = ['default', 'k8s-dns'];
 let DEFAULT_SERVICE_DISCOVERY_SCHEME = 'default';
-exports.setServiceDiscoveryScheme = scheme => {
+
+export const setServiceDiscoveryScheme = scheme => {
   DEFAULT_SERVICE_DISCOVERY_SCHEME = scheme;
 };
 
@@ -90,7 +93,7 @@ let _defaultOptions = {
 };
 
 /** Make a request for a Client instance */
-const makeRequest = exports.makeRequest = async function(client, method, url, payload, query) {
+export const makeRequest = async function(client, method, url, payload, query) {
   // Add query to url if present
   if (query) {
     query = querystring.stringify(query);
@@ -183,7 +186,7 @@ const makeRequest = exports.makeRequest = async function(client, method, url, pa
  *
  * `rootUrl` and `baseUrl` are mutually exclusive.
  */
-exports.createClient = function(reference, name) {
+export const createClient = function(reference, name) {
   if (!name || typeof name !== 'string') {
     name = 'Unknown';
   }
@@ -653,23 +656,35 @@ exports.createClient = function(reference, name) {
 };
 
 // Load data from apis.js
-let apis = require('./apis');
+import apis from './apis.js';
 
-// Instantiate clients
-_.forIn(apis, function(api, name) {
-  exports[name] = exports.createClient(api.reference, name);
-});
+export const Auth = createClient(apis.Auth.reference, "Auth");
+export const AuthEvents = createClient(apis.AuthEvents.reference, "AuthEvents");
+export const Github = createClient(apis.Github.reference, "Github");
+export const GithubEvents = createClient(apis.GithubEvents.reference, "GithubEvents");
+export const Hooks = createClient(apis.Hooks.reference, "Hooks");
+export const HooksEvents = createClient(apis.HooksEvents.reference, "HooksEvents");
+export const Index = createClient(apis.Index.reference, "Index");
+export const Notify = createClient(apis.Notify.reference, "Notify");
+export const NotifyEvents = createClient(apis.NotifyEvents.reference, "NotifyEvents");
+export const Object = createClient(apis.Object.reference, "Object");
+export const PurgeCache = createClient(apis.PurgeCache.reference, "PurgeCache");
+export const Queue = createClient(apis.Queue.reference, "Queue");
+export const QueueEvents = createClient(apis.QueueEvents.reference, "QueueEvents");
+export const Secrets = createClient(apis.Secrets.reference, "Secrets");
+export const WorkerManager = createClient(apis.WorkerManager.reference, "WorkerManager");
+export const WorkerManagerEvents = createClient(apis.WorkerManagerEvents.reference, "WorkerManagerEvents");
 
 /**
  * Update default configuration
  *
  * Example: `Client.config({credentials: {...}});`
  */
-exports.config = function(options) {
+export const config = function(options) {
   _defaultOptions = _.defaults({}, options, _defaultOptions);
 };
 
-exports.fromEnvVars = function() {
+export const fromEnvVars = function() {
   let results = {};
   for (let { env, path } of [
     { env: 'TASKCLUSTER_ROOT_URL', path: 'rootUrl' },
@@ -705,7 +720,7 @@ exports.fromEnvVars = function() {
  *
  * Returns an object on the form: {clientId, accessToken, certificate}
  */
-exports.createTemporaryCredentials = function(options) {
+export const createTemporaryCredentials = function(options) {
   assert(options, 'options are required');
 
   let now = new Date();
@@ -808,7 +823,7 @@ exports.createTemporaryCredentials = function(options) {
  *    scopes: [...],        // associated scopes (if available)
  * }
  */
-exports.credentialInformation = function(rootUrl, credentials) {
+export const credentialInformation = function(rootUrl, credentials) {
   let result = {};
   let issuer = credentials.clientId;
 
@@ -839,7 +854,7 @@ exports.credentialInformation = function(rootUrl, credentials) {
     result.type = 'permanent';
   }
 
-  let anonClient = new exports.Auth({ rootUrl });
+  let anonClient = new Auth({ rootUrl });
   let clientLookup = anonClient.client(issuer).then(function(client) {
     let expires = new Date(client.expires);
     if (!result.expiry || result.expiry > expires) {
@@ -850,7 +865,7 @@ exports.credentialInformation = function(rootUrl, credentials) {
     }
   });
 
-  let credClient = new exports.Auth({ rootUrl, credentials });
+  let credClient = new Auth({ rootUrl, credentials });
   let scopeLookup = credClient.currentScopes().then(function(response) {
     result.scopes = response.scopes;
   });

--- a/clients/client/src/client.js
+++ b/clients/client/src/client.js
@@ -65,9 +65,7 @@ let _defaultOptions = {
   // Request time out (defaults to 30 seconds)
   timeout: 30 * 1000,
   // Max number of request retries
-  retries: {
-    limit: 5,
-  },
+  retries: 5,
   // Multiplier for computation of retry delay: 2 ^ retry * delayFactor,
   // 100 ms is solid for servers, and 500ms - 1s is suitable for background
   // processes

--- a/clients/client/src/download.js
+++ b/clients/client/src/download.js
@@ -1,8 +1,7 @@
-const got = require('got');
-const util = require('util');
-const pipeline = util.promisify(require('stream').pipeline);
-const retry = require('./retry');
-const { HashStream, ACCEPTABLE_HASHES } = require('./hashstream');
+import got from 'got';
+import { pipeline } from 'node:stream/promises';
+import retry from './retry.js';
+import { HashStream, ACCEPTABLE_HASHES } from './hashstream.js';
 
 // apply default retry config
 const makeRetryCfg = ({ retries, delayFactor, randomizationFactor, maxDelay }) => ({
@@ -149,4 +148,4 @@ const downloadArtifact = async ({
   }
 };
 
-module.exports = { download, downloadArtifact };
+export default { download, downloadArtifact };

--- a/clients/client/src/download.js
+++ b/clients/client/src/download.js
@@ -2,6 +2,7 @@ import got, { HTTPError } from 'got';
 import { pipeline } from 'node:stream/promises';
 import retry from './retry.js';
 import { HashStream, ACCEPTABLE_HASHES } from './hashstream.js';
+import { clients } from './client.js';
 
 // apply default retry config
 const makeRetryCfg = ({ retries, delayFactor, randomizationFactor, maxDelay }) => ({
@@ -128,10 +129,7 @@ export const downloadArtifact = async ({
     }
 
     case "object": {
-      // `taskcluster.Object` is created at runtime, so we cannot require this
-      // at the top level.
-      const taskcluster = await import('./index.js');
-      const object = new taskcluster.Object({
+      const object = new clients.Object({
         rootUrl: queue._options._trueRootUrl,
         credentials: artifact.credentials,
       });

--- a/clients/client/src/hashstream.js
+++ b/clients/client/src/hashstream.js
@@ -1,14 +1,14 @@
-const { Transform } = require('stream');
-const { createHash } = require('crypto');
+import { Transform } from 'stream';
+import { createHash } from 'crypto';
 
 // The subset of hashes supported by HashStream which are "accepted" as per the
 // object service's schemas.
-const ACCEPTABLE_HASHES = new Set(["sha256", "sha512"]);
+export const ACCEPTABLE_HASHES = new Set(["sha256", "sha512"]);
 
 /**
  * A stream that hashes the bytes passing through it
  */
-class HashStream extends Transform {
+export class HashStream extends Transform {
   constructor() {
     super();
     this.sha256 = createHash('sha256');
@@ -35,5 +35,3 @@ class HashStream extends Transform {
     };
   }
 }
-
-module.exports = { HashStream, ACCEPTABLE_HASHES };

--- a/clients/client/src/index.js
+++ b/clients/client/src/index.js
@@ -14,6 +14,7 @@ import * as download from './download.js';
 
 export default {
   ...client,
+  ...client.clients,
   ...utils,
   ...upload,
   ...download,

--- a/clients/client/src/index.js
+++ b/clients/client/src/index.js
@@ -1,13 +1,20 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+* License, v. 2.0. If a copy of the MPL was not distributed with this
+* file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-let _ = require('lodash');
+export * from './client.js';
+export * from './utils.js';
+export * from './upload.js';
+export * from './download.js';
 
-// Export methods and classes from other files
-_.defaults(exports,
-  require('./client'),
-  require('./utils'),
-  require('./upload'),
-  require('./download'),
-);
+import * as client from './client.js';
+import * as utils from './utils.js';
+import * as upload from './upload.js';
+import * as download from './download.js';
+
+export default {
+  ...client,
+  ...utils,
+  ...upload,
+  ...download,
+};

--- a/clients/client/src/parsetime.js
+++ b/clients/client/src/parsetime.js
@@ -34,4 +34,4 @@ let parseTime = function(str) {
 };
 
 // Export parseTime
-module.exports = parseTime;
+export default parseTime;

--- a/clients/client/src/retry.js
+++ b/clients/client/src/retry.js
@@ -7,7 +7,7 @@
  * Note that as per the existing API, `retries` is the number of retries after the first
  * try; that is, a `retries` value of 3 means that `func` will be called 4 times.
  */
-module.exports = async ({ retries, delayFactor, randomizationFactor, maxDelay }, func) => {
+export default async ({ retries, delayFactor, randomizationFactor, maxDelay }, func) => {
   let attempt = 0;
 
   while (true) {

--- a/clients/client/src/retry.js
+++ b/clients/client/src/retry.js
@@ -9,7 +9,6 @@
  */
 export default async ({ retries, delayFactor, randomizationFactor, maxDelay }, func) => {
   let attempt = 0;
-  const totalRetries = Number.isInteger(retries) ? retries : retries?.limit;
 
   while (true) {
     attempt += 1;
@@ -22,7 +21,7 @@ export default async ({ retries, delayFactor, randomizationFactor, maxDelay }, f
       return rv;
     }
 
-    if (attempt > totalRetries) {
+    if (attempt > retries) {
       throw retriableError;
     }
 

--- a/clients/client/src/retry.js
+++ b/clients/client/src/retry.js
@@ -9,6 +9,7 @@
  */
 export default async ({ retries, delayFactor, randomizationFactor, maxDelay }, func) => {
   let attempt = 0;
+  const totalRetries = Number.isInteger(retries) ? retries : retries?.limit;
 
   while (true) {
     attempt += 1;
@@ -21,7 +22,7 @@ export default async ({ retries, delayFactor, randomizationFactor, maxDelay }, f
       return rv;
     }
 
-    if (attempt > retries) {
+    if (attempt > totalRetries) {
       throw retriableError;
     }
 

--- a/clients/client/src/upload.js
+++ b/clients/client/src/upload.js
@@ -1,7 +1,7 @@
-const got = require('got');
-const { slugid } = require('./utils');
-const retry = require('./retry');
-const { HashStream } = require('./hashstream');
+import got from 'got';
+import { slugid } from './utils.js';
+import retry from './retry.js';
+import { HashStream } from './hashstream.js';
 
 const DATA_INLINE_MAX_SIZE = 8192;
 
@@ -33,7 +33,7 @@ const readFullStream = stream => {
   });
 };
 
-const upload = async ({
+export const upload = async ({
   projectId,
   name,
   contentType,
@@ -98,4 +98,4 @@ const upload = async ({
   await object.finishUpload(name, { projectId, uploadId, hashes });
 };
 
-module.exports = { upload };
+export default upload;

--- a/clients/client/src/upload.js
+++ b/clients/client/src/upload.js
@@ -1,4 +1,4 @@
-import got from 'got';
+import got, { HTTPError } from 'got';
 import { slugid } from './utils.js';
 import retry from './retry.js';
 import { HashStream } from './hashstream.js';
@@ -11,12 +11,12 @@ const putUrl = async ({ streamFactory, contentLength, uploadMethod, retryCfg }) 
     try {
       await got.put(url, {
         headers,
-        retry: false, // use our own retry logic
+        retry: { limit: 0 }, // use our own retry logic
         body: await streamFactory(),
       });
     } catch (err) {
       // treat non-500 HTTP responses as fatal errors, and retry everything else
-      if (err instanceof got.HTTPError && err.response.statusCode < 500) {
+      if (err instanceof HTTPError && err.response.statusCode < 500) {
         throw err;
       }
       return retriableError(err);

--- a/clients/client/src/upload.js
+++ b/clients/client/src/upload.js
@@ -62,7 +62,7 @@ export const upload = async ({
   const retryCfg = {
     retries: retries === undefined ? 5 : retries,
     delayFactor: delayFactor === undefined ? 100 : delayFactor,
-    randomizationFactor: randomizationFactor === undefined ? randomizationFactor : 0.25,
+    randomizationFactor: randomizationFactor === undefined ? 0.25 : randomizationFactor,
     maxDelay: maxDelay === undefined ? 30 * 1000 : maxDelay,
   };
 

--- a/clients/client/src/utils.js
+++ b/clients/client/src/utils.js
@@ -1,5 +1,5 @@
-let parseTime = require('./parsetime');
-let slugid = require('slugid');
+import parseTime from './parsetime.js';
+import sluglib from 'slugid';
 
 /**
  * Create a Date object offset = '1d 2h 3min' into the future
@@ -10,7 +10,7 @@ let slugid = require('slugid');
  * short hand `1d2h3min`, it's fairly tolerant of different spelling forms and
  * whitespace. But only really meant to be used with constants.
  */
-let fromNow = function(offset, reference) {
+export const fromNow = function(offset, reference) {
   if (reference === undefined) {
     reference = new Date();
   }
@@ -32,9 +32,6 @@ let fromNow = function(offset, reference) {
   return retval;
 };
 
-// Export fromNow
-exports.fromNow = fromNow;
-
 /**
  * Create an ISO 8601 time stamp offset = '1d 2h 3min' into the future
  *
@@ -48,14 +45,9 @@ exports.fromNow = fromNow;
  * short hand `1d2h3min`, it's fairly tolerant of different spelling forms and
  * whitespace. But only really meant to be used with constants.
  */
-let fromNowJSON = function(offset, reference) {
+export const fromNowJSON = function(offset, reference) {
   return fromNow(offset, reference).toJSON();
 };
 
-// Export fromNowJSON
-exports.fromNowJSON = fromNowJSON;
-
 // Export function to generate _nice_ slugids
-exports.slugid = function() {
-  return slugid.nice();
-};
+export const slugid = () => sluglib.nice();

--- a/clients/client/test/client_test.js
+++ b/clients/client/test/client_test.js
@@ -1,9 +1,9 @@
-const taskcluster = require('../');
-const assert = require('assert');
-const path = require('path');
-const nock = require('nock');
-const net = require('net');
-const testing = require('./helper');
+import taskcluster from '../src/index.js';
+import assert from 'assert';
+import path from 'path';
+import nock from 'nock';
+import net from 'net';
+import testing from './helper.js';
 
 suite(testing.suiteName(), function() {
   testing.withRestoredEnvVars();

--- a/clients/client/test/client_test.js
+++ b/clients/client/test/client_test.js
@@ -5,6 +5,8 @@ import nock from 'nock';
 import net from 'net';
 import testing from './helper.js';
 
+const __dirname = new URL('.', import.meta.url).pathname;
+
 suite(testing.suiteName(), function() {
   testing.withRestoredEnvVars();
 
@@ -147,7 +149,7 @@ suite(testing.suiteName(), function() {
       Fake: taskcluster.createClient(referenceNameStyle),
       rootUrl: 'https://whatever.net',
       serviceDiscoveryScheme: 'k8s-dns',
-      makeClient: () => {
+      makeClient: async () => {
         const Fake = taskcluster.createClient(referenceNameStyle);
         return new Fake({
           rootUrl: 'https://example.not-there',
@@ -166,7 +168,7 @@ suite(testing.suiteName(), function() {
       Fake: taskcluster.createClient(referenceNameStyle),
       rootUrl: 'https://whatever.net',
       serviceDiscoveryScheme: 'k8s-dns',
-      makeClient: () => {
+      makeClient: async () => {
         const Fake = taskcluster.createClient(referenceNameStyle);
         taskcluster.setServiceDiscoveryScheme('k8s-dns');
         const clnt = new Fake({
@@ -185,7 +187,7 @@ suite(testing.suiteName(), function() {
       urlPrefix: 'https://whatever.net/api/fake2',
       Fake: taskcluster.createClient(referenceNameStyle),
       rootUrl: 'https://whatever.net',
-      makeClient: () => {
+      makeClient: async () => {
         const Fake = taskcluster.createClient(referenceNameStyle);
         return new Fake({
           rootUrl: 'https://whatever.net',
@@ -201,7 +203,7 @@ suite(testing.suiteName(), function() {
       urlPrefix: 'https://whatever.net/taskcluster/api/fake2',
       Fake: taskcluster.createClient(referenceNameStyle),
       rootUrl: 'https://whatever.net/taskcluster',
-      makeClient: () => {
+      makeClient: async () => {
         const Fake = taskcluster.createClient(referenceNameStyle);
         return new Fake({
           rootUrl: 'https://whatever.net/taskcluster',
@@ -217,7 +219,7 @@ suite(testing.suiteName(), function() {
       urlPrefix: 'https://foo.whatever.net/taskcluster/api/fake2',
       Fake: taskcluster.createClient(referenceNameStyle),
       rootUrl: 'https://foo.whatever.net/taskcluster',
-      makeClient: () => {
+      makeClient: async () => {
         const Fake = taskcluster.createClient(referenceNameStyle);
         return new Fake({
           rootUrl: 'https://foo.whatever.net/taskcluster',
@@ -233,11 +235,10 @@ suite(testing.suiteName(), function() {
       urlPrefix: 'https://whatever.net/api/fake2',
       Fake: taskcluster.createClient(referenceNameStyle),
       rootUrl: 'https://whatever.net',
-      makeClient: () => {
+      makeClient: async () => {
         process.env.TASKCLUSTER_ROOT_URL = 'https://whatever.net';
         const clientPath = path.resolve(__dirname, '..', 'src', 'client.js');
-        delete require.cache[clientPath];
-        const cleanClient = require(clientPath);
+        const cleanClient = await import(clientPath);
         const Fake = cleanClient.createClient(referenceNameStyle);
         const fake = new Fake(Object.assign({},
           taskcluster.fromEnvVars(), {
@@ -282,8 +283,8 @@ suite(testing.suiteName(), function() {
     const { name, urlPrefix, trueUrlPrefix, makeClient, Fake, rootUrl, serviceDiscoveryScheme } = subjects[subject];
     suite(name, () => {
       let client;
-      suiteSetup('create client', function() {
-        client = makeClient();
+      suiteSetup('create client', async function() {
+        client = await makeClient();
       });
 
       test('Simple GET', async () => {

--- a/clients/client/test/credinfo_test.js
+++ b/clients/client/test/credinfo_test.js
@@ -1,7 +1,7 @@
-const taskcluster = require('../');
-const assert = require('assert');
-const nock = require('nock');
-const testing = require('./helper');
+import taskcluster from '../src/index.js';
+import assert from 'assert';
+import nock from 'nock';
+import testing from './helper.js';
 
 suite(testing.suiteName(), function() {
   teardown(function() {

--- a/clients/client/test/creds_test.js
+++ b/clients/client/test/creds_test.js
@@ -1,8 +1,8 @@
-const taskcluster = require('../');
-const assert = require('assert');
-const request = require('superagent');
-const _ = require('lodash');
-const testing = require('./helper');
+import taskcluster from '../src/index.js';
+import assert from 'assert';
+import request from 'superagent';
+import _ from 'lodash';
+import testing from './helper.js';
 
 suite(testing.suiteName(), function() {
   testing.withRestoredEnvVars();

--- a/clients/client/test/helper.js
+++ b/clients/client/test/helper.js
@@ -1,9 +1,9 @@
-const errorStackParser = require('error-stack-parser');
-const path = require('path');
+import errorStackParser from 'error-stack-parser';
+import path from 'path';
 
 // Restore TASKCLUSTER_* env vars after this test suite runs, to the values they
 // had when it began.
-exports.withRestoredEnvVars = () => {
+export const withRestoredEnvVars = () => {
   const vars = ['TASKCLUSTER_CLIENT_ID', 'TASKCLUSTER_ROOT_URL', 'TASKCLUSTER_ACCESS_TOKEN'];
 
   let values;
@@ -27,16 +27,21 @@ exports.withRestoredEnvVars = () => {
   });
 };
 
-const ROOT_DIR = path.resolve(__dirname, '../../..');
-const suiteName = () => {
+const ROOT_DIR = new URL('../../..', import.meta.url).pathname;
+export const suiteName = () => {
   const o = {}; Error.captureStackTrace(o, suiteName);
   const stack = errorStackParser.parse(o);
   return path.relative(ROOT_DIR, stack[0].fileName);
 };
-exports.suiteName = suiteName;
 
-exports.sleep = function (delay) {
+export const sleep = function (delay) {
   return new Promise(function (accept) {
     setTimeout(accept, delay);
   });
+};
+
+export default {
+  withRestoredEnvVars,
+  suiteName,
+  sleep,
 };

--- a/clients/client/test/upload_download_test.js
+++ b/clients/client/test/upload_download_test.js
@@ -237,7 +237,7 @@ suite(testing.suiteName(), function() {
         .reply(500, 'uhoh!'); // fail the first time
       nock('http://testing.example.com')
         .get('/download')
-        .reply(200, 'HeLlOwOrLd', { 'Content-Length': '10' }); // succed the second time
+        .reply(200, 'HeLlOwOrLd', { 'Content-Length': '10' }); // succeed the second time
 
       await taskcluster.download({
         name: 'some-object',

--- a/clients/client/test/upload_download_test.js
+++ b/clients/client/test/upload_download_test.js
@@ -1,9 +1,9 @@
-const taskcluster = require('../');
-const nock = require('nock');
-const crypto = require('crypto');
-const assert = require('assert').strict;
-const { WritableStreamBuffer, ReadableStreamBuffer } = require('stream-buffers');
-const testing = require('./helper');
+import taskcluster from '../src/index.js';
+import nock from 'nock';
+import crypto from 'crypto';
+import { strict as assert } from 'assert';
+import { WritableStreamBuffer, ReadableStreamBuffer } from 'stream-buffers';
+import testing from './helper.js';
 
 suite(testing.suiteName(), function() {
   testing.withRestoredEnvVars();
@@ -320,6 +320,7 @@ suite(testing.suiteName(), function() {
     let artifact;
 
     suiteSetup(function() {
+      nock.cleanAll();
       // for testing artifact downloads, we use a fake queue but a real object service.
       queue = new taskcluster.Queue({
         ...taskcluster.fromEnvVars(),

--- a/clients/client/test/utils_test.js
+++ b/clients/client/test/utils_test.js
@@ -1,7 +1,7 @@
-const taskcluster = require('../');
-const parseTime = require('../src/parsetime');
-const assert = require('assert');
-const testing = require('./helper');
+import taskcluster from '../src/index.js';
+import parseTime from '../src/parsetime.js';
+import assert from 'assert';
+import testing from './helper.js';
 
 suite(testing.suiteName(), function() {
   test('parseTime 1 year', function() {

--- a/clients/client/yarn.lock
+++ b/clients/client/yarn.lock
@@ -82,65 +82,26 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@sindresorhus/is@npm:^4.0.0":
-  version: 4.6.0
-  resolution: "@sindresorhus/is@npm:4.6.0"
-  checksum: 10c0/33b6fb1d0834ec8dd7689ddc0e2781c2bfd8b9c4e4bacbcb14111e0ae00621f2c264b8a7d36541799d74888b5dccdf422a891a5cb5a709ace26325eedc81e22e
+"@sindresorhus/is@npm:^6.1.0":
+  version: 6.2.0
+  resolution: "@sindresorhus/is@npm:6.2.0"
+  checksum: 10c0/81b0bf8857bf97c1b47dfc1aceabc7ebc5fb36fc0cabdc10ac80d497eac05d7d4d43de1bc02bf8bfac947d592ad416b8791d051f5eb343af7fe28b103a3f226b
   languageName: node
   linkType: hard
 
-"@szmarczak/http-timer@npm:^4.0.5":
-  version: 4.0.6
-  resolution: "@szmarczak/http-timer@npm:4.0.6"
+"@szmarczak/http-timer@npm:^5.0.1":
+  version: 5.0.1
+  resolution: "@szmarczak/http-timer@npm:5.0.1"
   dependencies:
-    defer-to-connect: "npm:^2.0.0"
-  checksum: 10c0/73946918c025339db68b09abd91fa3001e87fc749c619d2e9c2003a663039d4c3cb89836c98a96598b3d47dec2481284ba85355392644911f5ecd2336536697f
+    defer-to-connect: "npm:^2.0.1"
+  checksum: 10c0/4629d2fbb2ea67c2e9dc03af235c0991c79ebdddcbc19aed5d5732fb29ce01c13331e9b1a491584b9069bd6ecde6581dcbf871f11b7eefdebbab34de6cf2197e
   languageName: node
   linkType: hard
 
-"@types/cacheable-request@npm:^6.0.1":
-  version: 6.0.3
-  resolution: "@types/cacheable-request@npm:6.0.3"
-  dependencies:
-    "@types/http-cache-semantics": "npm:*"
-    "@types/keyv": "npm:^3.1.4"
-    "@types/node": "npm:*"
-    "@types/responselike": "npm:^1.0.0"
-  checksum: 10c0/10816a88e4e5b144d43c1d15a81003f86d649776c7f410c9b5e6579d0ad9d4ca71c541962fb403077388b446e41af7ae38d313e46692144985f006ac5e11fa03
-  languageName: node
-  linkType: hard
-
-"@types/http-cache-semantics@npm:*":
+"@types/http-cache-semantics@npm:^4.0.2":
   version: 4.0.4
   resolution: "@types/http-cache-semantics@npm:4.0.4"
   checksum: 10c0/51b72568b4b2863e0fe8d6ce8aad72a784b7510d72dc866215642da51d84945a9459fa89f49ec48f1e9a1752e6a78e85a4cda0ded06b1c73e727610c925f9ce6
-  languageName: node
-  linkType: hard
-
-"@types/keyv@npm:^3.1.4":
-  version: 3.1.4
-  resolution: "@types/keyv@npm:3.1.4"
-  dependencies:
-    "@types/node": "npm:*"
-  checksum: 10c0/ff8f54fc49621210291f815fe5b15d809fd7d032941b3180743440bd507ecdf08b9e844625fa346af568c84bf34114eb378dcdc3e921a08ba1e2a08d7e3c809c
-  languageName: node
-  linkType: hard
-
-"@types/node@npm:*":
-  version: 20.9.0
-  resolution: "@types/node@npm:20.9.0"
-  dependencies:
-    undici-types: "npm:~5.26.4"
-  checksum: 10c0/755d07de735eafda4e20af75ad9d03bdbfddef327d790e9a896142eac7493db5d8501591376e1c8227aa12eeb88e522bc727c6024504842ed40e539e8a466db9
-  languageName: node
-  linkType: hard
-
-"@types/responselike@npm:^1.0.0":
-  version: 1.0.3
-  resolution: "@types/responselike@npm:1.0.3"
-  dependencies:
-    "@types/node": "npm:*"
-  checksum: 10c0/a58ba341cb9e7d74f71810a88862da7b2a6fa42e2a1fc0ce40498f6ea1d44382f0640117057da779f74c47039f7166bf48fad02dc876f94e005c7afa50f5e129
   languageName: node
   linkType: hard
 
@@ -283,25 +244,25 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cacheable-lookup@npm:^5.0.3":
-  version: 5.0.4
-  resolution: "cacheable-lookup@npm:5.0.4"
-  checksum: 10c0/a6547fb4954b318aa831cbdd2f7b376824bc784fb1fa67610e4147099e3074726072d9af89f12efb69121415a0e1f2918a8ddd4aafcbcf4e91fbeef4a59cd42c
+"cacheable-lookup@npm:^7.0.0":
+  version: 7.0.0
+  resolution: "cacheable-lookup@npm:7.0.0"
+  checksum: 10c0/63a9c144c5b45cb5549251e3ea774c04d63063b29e469f7584171d059d3a88f650f47869a974e2d07de62116463d742c287a81a625e791539d987115cb081635
   languageName: node
   linkType: hard
 
-"cacheable-request@npm:^7.0.2":
-  version: 7.0.4
-  resolution: "cacheable-request@npm:7.0.4"
+"cacheable-request@npm:^10.2.14":
+  version: 10.2.14
+  resolution: "cacheable-request@npm:10.2.14"
   dependencies:
-    clone-response: "npm:^1.0.2"
-    get-stream: "npm:^5.1.0"
-    http-cache-semantics: "npm:^4.0.0"
-    keyv: "npm:^4.0.0"
-    lowercase-keys: "npm:^2.0.0"
-    normalize-url: "npm:^6.0.1"
-    responselike: "npm:^2.0.0"
-  checksum: 10c0/0834a7d17ae71a177bc34eab06de112a43f9b5ad05ebe929bec983d890a7d9f2bc5f1aa8bb67ea2b65e07a3bc74bea35fa62dd36dbac52876afe36fdcf83da41
+    "@types/http-cache-semantics": "npm:^4.0.2"
+    get-stream: "npm:^6.0.1"
+    http-cache-semantics: "npm:^4.1.1"
+    keyv: "npm:^4.5.3"
+    mimic-response: "npm:^4.0.0"
+    normalize-url: "npm:^8.0.0"
+    responselike: "npm:^3.0.0"
+  checksum: 10c0/41b6658db369f20c03128227ecd219ca7ac52a9d24fc0f499cc9aa5d40c097b48b73553504cebd137024d957c0ddb5b67cf3ac1439b136667f3586257763f88d
   languageName: node
   linkType: hard
 
@@ -366,15 +327,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"clone-response@npm:^1.0.2":
-  version: 1.0.3
-  resolution: "clone-response@npm:1.0.3"
-  dependencies:
-    mimic-response: "npm:^1.0.0"
-  checksum: 10c0/06a2b611824efb128810708baee3bd169ec9a1bf5976a5258cd7eb3f7db25f00166c6eee5961f075c7e38e194f373d4fdf86b8166ad5b9c7e82bbd2e333a6087
-  languageName: node
-  linkType: hard
-
 "color-convert@npm:^2.0.1":
   version: 2.0.1
   resolution: "color-convert@npm:2.0.1"
@@ -430,7 +382,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"defer-to-connect@npm:^2.0.0":
+"defer-to-connect@npm:^2.0.1":
   version: 2.0.1
   resolution: "defer-to-connect@npm:2.0.1"
   checksum: 10c0/625ce28e1b5ad10cf77057b9a6a727bf84780c17660f6644dab61dd34c23de3001f03cedc401f7d30a4ed9965c2e8a7336e220a329146f2cf85d4eddea429782
@@ -471,15 +423,6 @@ __metadata:
   dependencies:
     iconv-lite: "npm:^0.6.2"
   checksum: 10c0/36d938712ff00fe1f4bac88b43bcffb5930c1efa57bbcdca9d67e1d9d6c57cfb1200fb01efe0f3109b2ce99b231f90779532814a81370a1bd3274a0f58585039
-  languageName: node
-  linkType: hard
-
-"end-of-stream@npm:^1.1.0":
-  version: 1.4.4
-  resolution: "end-of-stream@npm:1.4.4"
-  dependencies:
-    once: "npm:^1.4.0"
-  checksum: 10c0/870b423afb2d54bb8d243c63e07c170409d41e20b47eeef0727547aea5740bd6717aca45597a9f2745525667a6b804c1e7bede41f856818faee5806dd9ff3975
   languageName: node
   linkType: hard
 
@@ -573,6 +516,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"form-data-encoder@npm:^4.0.2":
+  version: 4.0.2
+  resolution: "form-data-encoder@npm:4.0.2"
+  checksum: 10c0/559d3130e265316452434eaf68d68560fb36392ff4d04614683419de4fb43c3dbe152dc303599fae382ce24d3451a6d3d289d3bcc182ae3d8ad32e7ce8e35e53
+  languageName: node
+  linkType: hard
+
 "fs-minipass@npm:^2.0.0":
   version: 2.1.0
   resolution: "fs-minipass@npm:2.1.0"
@@ -624,12 +574,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"get-stream@npm:^5.1.0":
-  version: 5.2.0
-  resolution: "get-stream@npm:5.2.0"
-  dependencies:
-    pump: "npm:^3.0.0"
-  checksum: 10c0/43797ffd815fbb26685bf188c8cfebecb8af87b3925091dd7b9a9c915993293d78e3c9e1bce125928ff92f2d0796f3889b92b5ec6d58d1041b574682132e0a80
+"get-stream@npm:^6.0.1":
+  version: 6.0.1
+  resolution: "get-stream@npm:6.0.1"
+  checksum: 10c0/49825d57d3fd6964228e6200a58169464b8e8970489b3acdc24906c782fb7f01f9f56f8e6653c4a50713771d6658f7cfe051e5eb8c12e334138c9c918b296341
+  languageName: node
+  linkType: hard
+
+"get-stream@npm:^8.0.1":
+  version: 8.0.1
+  resolution: "get-stream@npm:8.0.1"
+  checksum: 10c0/5c2181e98202b9dae0bb4a849979291043e5892eb40312b47f0c22b9414fc9b28a3b6063d2375705eb24abc41ecf97894d9a51f64ff021511b504477b27b4290
   languageName: node
   linkType: hard
 
@@ -670,22 +625,22 @@ __metadata:
   languageName: node
   linkType: hard
 
-"got@npm:^11.8.1":
-  version: 11.8.6
-  resolution: "got@npm:11.8.6"
+"got@npm:^14.2.1":
+  version: 14.2.1
+  resolution: "got@npm:14.2.1"
   dependencies:
-    "@sindresorhus/is": "npm:^4.0.0"
-    "@szmarczak/http-timer": "npm:^4.0.5"
-    "@types/cacheable-request": "npm:^6.0.1"
-    "@types/responselike": "npm:^1.0.0"
-    cacheable-lookup: "npm:^5.0.3"
-    cacheable-request: "npm:^7.0.2"
+    "@sindresorhus/is": "npm:^6.1.0"
+    "@szmarczak/http-timer": "npm:^5.0.1"
+    cacheable-lookup: "npm:^7.0.0"
+    cacheable-request: "npm:^10.2.14"
     decompress-response: "npm:^6.0.0"
-    http2-wrapper: "npm:^1.0.0-beta.5.2"
-    lowercase-keys: "npm:^2.0.0"
-    p-cancelable: "npm:^2.0.0"
-    responselike: "npm:^2.0.0"
-  checksum: 10c0/754dd44877e5cf6183f1e989ff01c648d9a4719e357457bd4c78943911168881f1cfb7b2cb15d885e2105b3ad313adb8f017a67265dd7ade771afdb261ee8cb1
+    form-data-encoder: "npm:^4.0.2"
+    get-stream: "npm:^8.0.1"
+    http2-wrapper: "npm:^2.2.1"
+    lowercase-keys: "npm:^3.0.0"
+    p-cancelable: "npm:^4.0.1"
+    responselike: "npm:^3.0.0"
+  checksum: 10c0/6592f70d570d988ace9f3c7ecd4e01d34c96ff5fc2896abce1b820b1e48c6661690c5a692495ad1334054e6051efcfa056165bc863b1d90dd3659bdf0ec9421f
   languageName: node
   linkType: hard
 
@@ -724,7 +679,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"http-cache-semantics@npm:^4.0.0, http-cache-semantics@npm:^4.1.1":
+"http-cache-semantics@npm:^4.1.1":
   version: 4.1.1
   resolution: "http-cache-semantics@npm:4.1.1"
   checksum: 10c0/ce1319b8a382eb3cbb4a37c19f6bfe14e5bb5be3d09079e885e8c513ab2d3cd9214902f8a31c9dc4e37022633ceabfc2d697405deeaf1b8f3552bb4ed996fdfc
@@ -752,13 +707,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"http2-wrapper@npm:^1.0.0-beta.5.2":
-  version: 1.0.3
-  resolution: "http2-wrapper@npm:1.0.3"
+"http2-wrapper@npm:^2.2.1":
+  version: 2.2.1
+  resolution: "http2-wrapper@npm:2.2.1"
   dependencies:
     quick-lru: "npm:^5.1.1"
-    resolve-alpn: "npm:^1.0.0"
-  checksum: 10c0/6a9b72a033e9812e1476b9d776ce2f387bc94bc46c88aea0d5dab6bd47d0a539b8178830e77054dd26d1142c866d515a28a4dc7c3ff4232c88ff2ebe4f5d12d1
+    resolve-alpn: "npm:^1.2.0"
+  checksum: 10c0/7207201d3c6e53e72e510c9b8912e4f3e468d3ecc0cf3bf52682f2aac9cd99358b896d1da4467380adc151cf97c412bedc59dc13dae90c523f42053a7449eedb
   languageName: node
   linkType: hard
 
@@ -931,7 +886,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"keyv@npm:^4.0.0":
+"keyv@npm:^4.5.3":
   version: 4.5.4
   resolution: "keyv@npm:4.5.4"
   dependencies:
@@ -966,10 +921,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lowercase-keys@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "lowercase-keys@npm:2.0.0"
-  checksum: 10c0/f82a2b3568910509da4b7906362efa40f5b54ea14c2584778ddb313226f9cbf21020a5db35f9b9a0e95847a9b781d548601f31793d736b22a2b8ae8eb9ab1082
+"lowercase-keys@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "lowercase-keys@npm:3.0.0"
+  checksum: 10c0/ef62b9fa5690ab0a6e4ef40c94efce68e3ed124f583cc3be38b26ff871da0178a28b9a84ce0c209653bb25ca135520ab87fea7cd411a54ac4899cb2f30501430
   languageName: node
   linkType: hard
 
@@ -1008,17 +963,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"mimic-response@npm:^1.0.0":
-  version: 1.0.1
-  resolution: "mimic-response@npm:1.0.1"
-  checksum: 10c0/c5381a5eae997f1c3b5e90ca7f209ed58c3615caeee850e85329c598f0c000ae7bec40196580eef1781c60c709f47258131dab237cad8786f8f56750594f27fa
-  languageName: node
-  linkType: hard
-
 "mimic-response@npm:^3.1.0":
   version: 3.1.0
   resolution: "mimic-response@npm:3.1.0"
   checksum: 10c0/0d6f07ce6e03e9e4445bee655202153bdb8a98d67ee8dc965ac140900d7a2688343e6b4c9a72cfc9ef2f7944dfd76eef4ab2482eb7b293a68b84916bac735362
+  languageName: node
+  linkType: hard
+
+"mimic-response@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "mimic-response@npm:4.0.0"
+  checksum: 10c0/761d788d2668ae9292c489605ffd4fad220f442fbae6832adce5ebad086d691e906a6d5240c290293c7a11e99fbdbbef04abbbed498bf8699a4ee0f31315e3fb
   languageName: node
   linkType: hard
 
@@ -1243,14 +1198,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"normalize-url@npm:^6.0.1":
-  version: 6.1.0
-  resolution: "normalize-url@npm:6.1.0"
-  checksum: 10c0/95d948f9bdd2cfde91aa786d1816ae40f8262946e13700bf6628105994fe0ff361662c20af3961161c38a119dc977adeb41fc0b41b1745eb77edaaf9cb22db23
+"normalize-url@npm:^8.0.0":
+  version: 8.0.1
+  resolution: "normalize-url@npm:8.0.1"
+  checksum: 10c0/eb439231c4b84430f187530e6fdac605c5048ef4ec556447a10c00a91fc69b52d8d8298d9d608e68d3e0f7dc2d812d3455edf425e0f215993667c3183bcab1ef
   languageName: node
   linkType: hard
 
-"once@npm:^1.3.0, once@npm:^1.3.1, once@npm:^1.4.0":
+"once@npm:^1.3.0":
   version: 1.4.0
   resolution: "once@npm:1.4.0"
   dependencies:
@@ -1259,10 +1214,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"p-cancelable@npm:^2.0.0":
-  version: 2.1.1
-  resolution: "p-cancelable@npm:2.1.1"
-  checksum: 10c0/8c6dc1f8dd4154fd8b96a10e55a3a832684c4365fb9108056d89e79fbf21a2465027c04a59d0d797b5ffe10b54a61a32043af287d5c4860f1e996cbdbc847f01
+"p-cancelable@npm:^4.0.1":
+  version: 4.0.1
+  resolution: "p-cancelable@npm:4.0.1"
+  checksum: 10c0/12636623f46784ba962b6fe7a1f34d021f1d9a2cc12c43e270baa715ea872d5c8c7d9f086ed420b8b9817e91d9bbe92c14c90e5dddd4a9968c81a2a7aef7089d
   languageName: node
   linkType: hard
 
@@ -1348,16 +1303,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"pump@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "pump@npm:3.0.0"
-  dependencies:
-    end-of-stream: "npm:^1.1.0"
-    once: "npm:^1.3.1"
-  checksum: 10c0/bbdeda4f747cdf47db97428f3a135728669e56a0ae5f354a9ac5b74556556f5446a46f720a8f14ca2ece5be9b4d5d23c346db02b555f46739934cc6c093a5478
-  languageName: node
-  linkType: hard
-
 "quick-lru@npm:^5.1.1":
   version: 5.1.1
   resolution: "quick-lru@npm:5.1.1"
@@ -1397,19 +1342,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"resolve-alpn@npm:^1.0.0":
+"resolve-alpn@npm:^1.2.0":
   version: 1.2.1
   resolution: "resolve-alpn@npm:1.2.1"
   checksum: 10c0/b70b29c1843bc39781ef946c8cd4482e6d425976599c0f9c138cec8209e4e0736161bf39319b01676a847000085dfdaf63583c6fb4427bf751a10635bd2aa0c4
   languageName: node
   linkType: hard
 
-"responselike@npm:^2.0.0":
-  version: 2.0.1
-  resolution: "responselike@npm:2.0.1"
+"responselike@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "responselike@npm:3.0.0"
   dependencies:
-    lowercase-keys: "npm:^2.0.0"
-  checksum: 10c0/360b6deb5f101a9f8a4174f7837c523c3ec78b7ca8a7c1d45a1062b303659308a23757e318b1e91ed8684ad1205721142dd664d94771cd63499353fd4ee732b5
+    lowercase-keys: "npm:^3.0.0"
+  checksum: 10c0/8af27153f7e47aa2c07a5f2d538cb1e5872995f0e9ff77def858ecce5c3fe677d42b824a62cde502e56d275ab832b0a8bd350d5cd6b467ac0425214ac12ae658
   languageName: node
   linkType: hard
 
@@ -1614,7 +1559,7 @@ __metadata:
   resolution: "taskcluster-client@workspace:."
   dependencies:
     debug: "npm:^4.1.1"
-    got: "npm:^11.8.1"
+    got: "npm:^14.2.1"
     hawk: "npm:^9.0.1"
     http-proxy: "npm:^1.18.0"
     lodash: "npm:^4.17.4"
@@ -1639,13 +1584,6 @@ __metadata:
   dependencies:
     is-number: "npm:^7.0.0"
   checksum: 10c0/487988b0a19c654ff3e1961b87f471702e708fa8a8dd02a298ef16da7206692e8552a0250e8b3e8759270f62e9d8314616f6da274734d3b558b1fc7b7724e892
-  languageName: node
-  linkType: hard
-
-"undici-types@npm:~5.26.4":
-  version: 5.26.5
-  resolution: "undici-types@npm:5.26.5"
-  checksum: 10c0/bb673d7876c2d411b6eb6c560e0c571eef4a01c1c19925175d16e3a30c4c428181fb8d7ae802a261f283e4166a0ac435e2f505743aa9e45d893f9a3df017b501
   languageName: node
   linkType: hard
 

--- a/clients/client/yarn.lock
+++ b/clients/client/yarn.lock
@@ -1468,13 +1468,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"stream-buffers@npm:^3.0.2":
-  version: 3.0.2
-  resolution: "stream-buffers@npm:3.0.2"
-  checksum: 10c0/5f12f5a3af4d2012b4f5386a05667b16710fdfc3d9c9db12ec64c44d9f0f831b10cf8c941afd5398b6f47ddb3db692894a16e0f82a8a22b43a5ecb424064ce40
-  languageName: node
-  linkType: hard
-
 "string-width-cjs@npm:string-width@^4.2.0, string-width@npm:^4.1.0, string-width@npm:^4.2.0":
   version: 4.2.3
   resolution: "string-width@npm:4.2.3"
@@ -1566,7 +1559,6 @@ __metadata:
     mocha: "npm:^10.2.0"
     nock: "npm:^13.0.0"
     slugid: "npm:^5.0.1"
-    stream-buffers: "npm:^3.0.2"
     taskcluster-lib-urls: "npm:^13.0.0"
   languageName: unknown
   linkType: soft

--- a/infrastructure/tooling/src/generate/generators/tc-client.js
+++ b/infrastructure/tooling/src/generate/generators/tc-client.js
@@ -9,7 +9,7 @@ export const tasks = [{
     const apis = requirements['apis'];
 
     await writeRepoFile('clients/client/src/apis.js',
-      '/* eslint-disable */\nmodule.exports = ' + stringify(apis, { space: 2 }) + ';\n');
+      '/* eslint-disable */\nexport default ' + stringify(apis, { space: 2 }) + ';\n');
 
     // update client tests to include all exposed apis
     const clientsTest = `// This file is auto-generated, don't edit

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "fast-json-stable-stringify": "^2.0.0",
     "generate-password": "^1.5.0",
     "googleapis": "^73.0.0",
-    "got": "^11.7.0",
+    "got": "^14.2.1",
     "graphql": "^16.8.1",
     "graphql-depth-limit": "^1.1.0",
     "graphql-playground-middleware-express": "^1.7.23",

--- a/services/worker-manager/src/providers/azure/index.js
+++ b/services/worker-manager/src/providers/azure/index.js
@@ -215,7 +215,9 @@ export class AzureProvider extends Provider {
     return await got(url, {
       responseType: 'buffer',
       resolveBodyOnly: true,
-      timeout: this.downloadTimeout,
+      timeout: {
+        request: this.downloadTimeout,
+      },
       followRedirect: false,
     });
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2382,10 +2382,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@sindresorhus/is@npm:^4.0.0":
-  version: 4.6.0
-  resolution: "@sindresorhus/is@npm:4.6.0"
-  checksum: 10c0/33b6fb1d0834ec8dd7689ddc0e2781c2bfd8b9c4e4bacbcb14111e0ae00621f2c264b8a7d36541799d74888b5dccdf422a891a5cb5a709ace26325eedc81e22e
+"@sindresorhus/is@npm:^6.1.0":
+  version: 6.2.0
+  resolution: "@sindresorhus/is@npm:6.2.0"
+  checksum: 10c0/81b0bf8857bf97c1b47dfc1aceabc7ebc5fb36fc0cabdc10ac80d497eac05d7d4d43de1bc02bf8bfac947d592ad416b8791d051f5eb343af7fe28b103a3f226b
   languageName: node
   linkType: hard
 
@@ -3142,12 +3142,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@szmarczak/http-timer@npm:^4.0.5":
-  version: 4.0.6
-  resolution: "@szmarczak/http-timer@npm:4.0.6"
+"@szmarczak/http-timer@npm:^5.0.1":
+  version: 5.0.1
+  resolution: "@szmarczak/http-timer@npm:5.0.1"
   dependencies:
-    defer-to-connect: "npm:^2.0.0"
-  checksum: 10c0/73946918c025339db68b09abd91fa3001e87fc749c619d2e9c2003a663039d4c3cb89836c98a96598b3d47dec2481284ba85355392644911f5ecd2336536697f
+    defer-to-connect: "npm:^2.0.1"
+  checksum: 10c0/4629d2fbb2ea67c2e9dc03af235c0991c79ebdddcbc19aed5d5732fb29ce01c13331e9b1a491584b9069bd6ecde6581dcbf871f11b7eefdebbab34de6cf2197e
   languageName: node
   linkType: hard
 
@@ -3165,18 +3165,6 @@ __metadata:
   version: 1.0.1
   resolution: "@types/btoa-lite@npm:1.0.1"
   checksum: 10c0/aea1f5ecf0c7d4e2637dfdfe8fc893d2f1e187613c2712fa903c979c5cb648110bac9f0978b9529cd532236428bd849995c34284441af466984d0254d2e7db1d
-  languageName: node
-  linkType: hard
-
-"@types/cacheable-request@npm:^6.0.1":
-  version: 6.0.3
-  resolution: "@types/cacheable-request@npm:6.0.3"
-  dependencies:
-    "@types/http-cache-semantics": "npm:*"
-    "@types/keyv": "npm:^3.1.4"
-    "@types/node": "npm:*"
-    "@types/responselike": "npm:^1.0.0"
-  checksum: 10c0/10816a88e4e5b144d43c1d15a81003f86d649776c7f410c9b5e6579d0ad9d4ca71c541962fb403077388b446e41af7ae38d313e46692144985f006ac5e11fa03
   languageName: node
   linkType: hard
 
@@ -3244,10 +3232,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/http-cache-semantics@npm:*":
-  version: 4.0.3
-  resolution: "@types/http-cache-semantics@npm:4.0.3"
-  checksum: 10c0/46e8e4d9ff8d032f0a12d08fb7250fc67ede0d566f9a5b3d92384098fb46a3892d3ec377600a1d73ea8a67a979b882f7b9ff5e29524fb76b8e1c44a0dbe04ecf
+"@types/http-cache-semantics@npm:^4.0.2":
+  version: 4.0.4
+  resolution: "@types/http-cache-semantics@npm:4.0.4"
+  checksum: 10c0/51b72568b4b2863e0fe8d6ce8aad72a784b7510d72dc866215642da51d84945a9459fa89f49ec48f1e9a1752e6a78e85a4cda0ded06b1c73e727610c925f9ce6
   languageName: node
   linkType: hard
 
@@ -3289,15 +3277,6 @@ __metadata:
   dependencies:
     "@types/node": "npm:*"
   checksum: 10c0/5fe728b8b295c6955857ffb1782e050447e607e97983fa854e84ad3458243ae9066729e161723066326fafa3377e0eb5c71afd9019b50796f0f9d281023f3c33
-  languageName: node
-  linkType: hard
-
-"@types/keyv@npm:^3.1.4":
-  version: 3.1.4
-  resolution: "@types/keyv@npm:3.1.4"
-  dependencies:
-    "@types/node": "npm:*"
-  checksum: 10c0/ff8f54fc49621210291f815fe5b15d809fd7d032941b3180743440bd507ecdf08b9e844625fa346af568c84bf34114eb378dcdc3e921a08ba1e2a08d7e3c809c
   languageName: node
   linkType: hard
 
@@ -3359,15 +3338,6 @@ __metadata:
   version: 1.2.6
   resolution: "@types/range-parser@npm:1.2.6"
   checksum: 10c0/46e7fffc54cdacc8fb0cd576f8f9a6436453f0176205d6ec55434a460c7677e78e688673426d5db5e480501b2943ba08a16ececa3a354c222093551c7217fb8f
-  languageName: node
-  linkType: hard
-
-"@types/responselike@npm:^1.0.0":
-  version: 1.0.2
-  resolution: "@types/responselike@npm:1.0.2"
-  dependencies:
-    "@types/node": "npm:*"
-  checksum: 10c0/57bbb8753a38c4b6361ca920a73139acd6518565b57cb7a70b6ed58a57dbc565adba0cdd35f68bd49122745eb3b0ea80574a8696bee67e964c40c340f69fd0e2
   languageName: node
   linkType: hard
 
@@ -4352,25 +4322,25 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cacheable-lookup@npm:^5.0.3":
-  version: 5.0.4
-  resolution: "cacheable-lookup@npm:5.0.4"
-  checksum: 10c0/a6547fb4954b318aa831cbdd2f7b376824bc784fb1fa67610e4147099e3074726072d9af89f12efb69121415a0e1f2918a8ddd4aafcbcf4e91fbeef4a59cd42c
+"cacheable-lookup@npm:^7.0.0":
+  version: 7.0.0
+  resolution: "cacheable-lookup@npm:7.0.0"
+  checksum: 10c0/63a9c144c5b45cb5549251e3ea774c04d63063b29e469f7584171d059d3a88f650f47869a974e2d07de62116463d742c287a81a625e791539d987115cb081635
   languageName: node
   linkType: hard
 
-"cacheable-request@npm:^7.0.2":
-  version: 7.0.4
-  resolution: "cacheable-request@npm:7.0.4"
+"cacheable-request@npm:^10.2.14":
+  version: 10.2.14
+  resolution: "cacheable-request@npm:10.2.14"
   dependencies:
-    clone-response: "npm:^1.0.2"
-    get-stream: "npm:^5.1.0"
-    http-cache-semantics: "npm:^4.0.0"
-    keyv: "npm:^4.0.0"
-    lowercase-keys: "npm:^2.0.0"
-    normalize-url: "npm:^6.0.1"
-    responselike: "npm:^2.0.0"
-  checksum: 10c0/0834a7d17ae71a177bc34eab06de112a43f9b5ad05ebe929bec983d890a7d9f2bc5f1aa8bb67ea2b65e07a3bc74bea35fa62dd36dbac52876afe36fdcf83da41
+    "@types/http-cache-semantics": "npm:^4.0.2"
+    get-stream: "npm:^6.0.1"
+    http-cache-semantics: "npm:^4.1.1"
+    keyv: "npm:^4.5.3"
+    mimic-response: "npm:^4.0.0"
+    normalize-url: "npm:^8.0.0"
+    responselike: "npm:^3.0.0"
+  checksum: 10c0/41b6658db369f20c03128227ecd219ca7ac52a9d24fc0f499cc9aa5d40c097b48b73553504cebd137024d957c0ddb5b67cf3ac1439b136667f3586257763f88d
   languageName: node
   linkType: hard
 
@@ -4596,15 +4566,6 @@ __metadata:
     strip-ansi: "npm:^6.0.1"
     wrap-ansi: "npm:^7.0.0"
   checksum: 10c0/4bda0f09c340cbb6dfdc1ed508b3ca080f12992c18d68c6be4d9cf51756033d5266e61ec57529e610dacbf4da1c634423b0c1b11037709cc6b09045cbd815df5
-  languageName: node
-  linkType: hard
-
-"clone-response@npm:^1.0.2":
-  version: 1.0.3
-  resolution: "clone-response@npm:1.0.3"
-  dependencies:
-    mimic-response: "npm:^1.0.0"
-  checksum: 10c0/06a2b611824efb128810708baee3bd169ec9a1bf5976a5258cd7eb3f7db25f00166c6eee5961f075c7e38e194f373d4fdf86b8166ad5b9c7e82bbd2e333a6087
   languageName: node
   linkType: hard
 
@@ -5122,7 +5083,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"defer-to-connect@npm:^2.0.0":
+"defer-to-connect@npm:^2.0.1":
   version: 2.0.1
   resolution: "defer-to-connect@npm:2.0.1"
   checksum: 10c0/625ce28e1b5ad10cf77057b9a6a727bf84780c17660f6644dab61dd34c23de3001f03cedc401f7d30a4ed9965c2e8a7336e220a329146f2cf85d4eddea429782
@@ -6314,6 +6275,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"form-data-encoder@npm:^4.0.2":
+  version: 4.0.2
+  resolution: "form-data-encoder@npm:4.0.2"
+  checksum: 10c0/559d3130e265316452434eaf68d68560fb36392ff4d04614683419de4fb43c3dbe152dc303599fae382ce24d3451a6d3d289d3bcc182ae3d8ad32e7ce8e35e53
+  languageName: node
+  linkType: hard
+
 "form-data@npm:^2.5.0":
   version: 2.5.1
   resolution: "form-data@npm:2.5.1"
@@ -6516,19 +6484,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"get-stream@npm:^5.1.0":
-  version: 5.2.0
-  resolution: "get-stream@npm:5.2.0"
-  dependencies:
-    pump: "npm:^3.0.0"
-  checksum: 10c0/43797ffd815fbb26685bf188c8cfebecb8af87b3925091dd7b9a9c915993293d78e3c9e1bce125928ff92f2d0796f3889b92b5ec6d58d1041b574682132e0a80
-  languageName: node
-  linkType: hard
-
-"get-stream@npm:^6.0.0":
+"get-stream@npm:^6.0.0, get-stream@npm:^6.0.1":
   version: 6.0.1
   resolution: "get-stream@npm:6.0.1"
   checksum: 10c0/49825d57d3fd6964228e6200a58169464b8e8970489b3acdc24906c782fb7f01f9f56f8e6653c4a50713771d6658f7cfe051e5eb8c12e334138c9c918b296341
+  languageName: node
+  linkType: hard
+
+"get-stream@npm:^8.0.1":
+  version: 8.0.1
+  resolution: "get-stream@npm:8.0.1"
+  checksum: 10c0/5c2181e98202b9dae0bb4a849979291043e5892eb40312b47f0c22b9414fc9b28a3b6063d2375705eb24abc41ecf97894d9a51f64ff021511b504477b27b4290
   languageName: node
   linkType: hard
 
@@ -6678,22 +6644,22 @@ __metadata:
   languageName: node
   linkType: hard
 
-"got@npm:^11.7.0":
-  version: 11.8.6
-  resolution: "got@npm:11.8.6"
+"got@npm:^14.2.1":
+  version: 14.2.1
+  resolution: "got@npm:14.2.1"
   dependencies:
-    "@sindresorhus/is": "npm:^4.0.0"
-    "@szmarczak/http-timer": "npm:^4.0.5"
-    "@types/cacheable-request": "npm:^6.0.1"
-    "@types/responselike": "npm:^1.0.0"
-    cacheable-lookup: "npm:^5.0.3"
-    cacheable-request: "npm:^7.0.2"
+    "@sindresorhus/is": "npm:^6.1.0"
+    "@szmarczak/http-timer": "npm:^5.0.1"
+    cacheable-lookup: "npm:^7.0.0"
+    cacheable-request: "npm:^10.2.14"
     decompress-response: "npm:^6.0.0"
-    http2-wrapper: "npm:^1.0.0-beta.5.2"
-    lowercase-keys: "npm:^2.0.0"
-    p-cancelable: "npm:^2.0.0"
-    responselike: "npm:^2.0.0"
-  checksum: 10c0/754dd44877e5cf6183f1e989ff01c648d9a4719e357457bd4c78943911168881f1cfb7b2cb15d885e2105b3ad313adb8f017a67265dd7ade771afdb261ee8cb1
+    form-data-encoder: "npm:^4.0.2"
+    get-stream: "npm:^8.0.1"
+    http2-wrapper: "npm:^2.2.1"
+    lowercase-keys: "npm:^3.0.0"
+    p-cancelable: "npm:^4.0.1"
+    responselike: "npm:^3.0.0"
+  checksum: 10c0/6592f70d570d988ace9f3c7ecd4e01d34c96ff5fc2896abce1b820b1e48c6661690c5a692495ad1334054e6051efcfa056165bc863b1d90dd3659bdf0ec9421f
   languageName: node
   linkType: hard
 
@@ -7020,7 +6986,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"http-cache-semantics@npm:^4.0.0, http-cache-semantics@npm:^4.1.1":
+"http-cache-semantics@npm:^4.1.1":
   version: 4.1.1
   resolution: "http-cache-semantics@npm:4.1.1"
   checksum: 10c0/ce1319b8a382eb3cbb4a37c19f6bfe14e5bb5be3d09079e885e8c513ab2d3cd9214902f8a31c9dc4e37022633ceabfc2d697405deeaf1b8f3552bb4ed996fdfc
@@ -7061,13 +7027,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"http2-wrapper@npm:^1.0.0-beta.5.2":
-  version: 1.0.3
-  resolution: "http2-wrapper@npm:1.0.3"
+"http2-wrapper@npm:^2.2.1":
+  version: 2.2.1
+  resolution: "http2-wrapper@npm:2.2.1"
   dependencies:
     quick-lru: "npm:^5.1.1"
-    resolve-alpn: "npm:^1.0.0"
-  checksum: 10c0/6a9b72a033e9812e1476b9d776ce2f387bc94bc46c88aea0d5dab6bd47d0a539b8178830e77054dd26d1142c866d515a28a4dc7c3ff4232c88ff2ebe4f5d12d1
+    resolve-alpn: "npm:^1.2.0"
+  checksum: 10c0/7207201d3c6e53e72e510c9b8912e4f3e468d3ecc0cf3bf52682f2aac9cd99358b896d1da4467380adc151cf97c412bedc59dc13dae90c523f42053a7449eedb
   languageName: node
   linkType: hard
 
@@ -7840,7 +7806,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"keyv@npm:^4.0.0, keyv@npm:^4.5.3":
+"keyv@npm:^4.5.3":
   version: 4.5.4
   resolution: "keyv@npm:4.5.4"
   dependencies:
@@ -8131,10 +8097,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lowercase-keys@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "lowercase-keys@npm:2.0.0"
-  checksum: 10c0/f82a2b3568910509da4b7906362efa40f5b54ea14c2584778ddb313226f9cbf21020a5db35f9b9a0e95847a9b781d548601f31793d736b22a2b8ae8eb9ab1082
+"lowercase-keys@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "lowercase-keys@npm:3.0.0"
+  checksum: 10c0/ef62b9fa5690ab0a6e4ef40c94efce68e3ed124f583cc3be38b26ff871da0178a28b9a84ce0c209653bb25ca135520ab87fea7cd411a54ac4899cb2f30501430
   languageName: node
   linkType: hard
 
@@ -8468,17 +8434,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"mimic-response@npm:^1.0.0":
-  version: 1.0.1
-  resolution: "mimic-response@npm:1.0.1"
-  checksum: 10c0/c5381a5eae997f1c3b5e90ca7f209ed58c3615caeee850e85329c598f0c000ae7bec40196580eef1781c60c709f47258131dab237cad8786f8f56750594f27fa
-  languageName: node
-  linkType: hard
-
 "mimic-response@npm:^3.1.0":
   version: 3.1.0
   resolution: "mimic-response@npm:3.1.0"
   checksum: 10c0/0d6f07ce6e03e9e4445bee655202153bdb8a98d67ee8dc965ac140900d7a2688343e6b4c9a72cfc9ef2f7944dfd76eef4ab2482eb7b293a68b84916bac735362
+  languageName: node
+  linkType: hard
+
+"mimic-response@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "mimic-response@npm:4.0.0"
+  checksum: 10c0/761d788d2668ae9292c489605ffd4fad220f442fbae6832adce5ebad086d691e906a6d5240c290293c7a11e99fbdbbef04abbbed498bf8699a4ee0f31315e3fb
   languageName: node
   linkType: hard
 
@@ -8964,10 +8930,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"normalize-url@npm:^6.0.1":
-  version: 6.1.0
-  resolution: "normalize-url@npm:6.1.0"
-  checksum: 10c0/95d948f9bdd2cfde91aa786d1816ae40f8262946e13700bf6628105994fe0ff361662c20af3961161c38a119dc977adeb41fc0b41b1745eb77edaaf9cb22db23
+"normalize-url@npm:^8.0.0":
+  version: 8.0.1
+  resolution: "normalize-url@npm:8.0.1"
+  checksum: 10c0/eb439231c4b84430f187530e6fdac605c5048ef4ec556447a10c00a91fc69b52d8d8298d9d608e68d3e0f7dc2d812d3455edf425e0f215993667c3183bcab1ef
   languageName: node
   linkType: hard
 
@@ -9192,10 +9158,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"p-cancelable@npm:^2.0.0":
-  version: 2.1.1
-  resolution: "p-cancelable@npm:2.1.1"
-  checksum: 10c0/8c6dc1f8dd4154fd8b96a10e55a3a832684c4365fb9108056d89e79fbf21a2465027c04a59d0d797b5ffe10b54a61a32043af287d5c4860f1e996cbdbc847f01
+"p-cancelable@npm:^4.0.1":
+  version: 4.0.1
+  resolution: "p-cancelable@npm:4.0.1"
+  checksum: 10c0/12636623f46784ba962b6fe7a1f34d021f1d9a2cc12c43e270baa715ea872d5c8c7d9f086ed420b8b9817e91d9bbe92c14c90e5dddd4a9968c81a2a7aef7089d
   languageName: node
   linkType: hard
 
@@ -10264,7 +10230,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"resolve-alpn@npm:^1.0.0":
+"resolve-alpn@npm:^1.2.0":
   version: 1.2.1
   resolution: "resolve-alpn@npm:1.2.1"
   checksum: 10c0/b70b29c1843bc39781ef946c8cd4482e6d425976599c0f9c138cec8209e4e0736161bf39319b01676a847000085dfdaf63583c6fb4427bf751a10635bd2aa0c4
@@ -10311,12 +10277,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"responselike@npm:^2.0.0":
-  version: 2.0.1
-  resolution: "responselike@npm:2.0.1"
+"responselike@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "responselike@npm:3.0.0"
   dependencies:
-    lowercase-keys: "npm:^2.0.0"
-  checksum: 10c0/360b6deb5f101a9f8a4174f7837c523c3ec78b7ca8a7c1d45a1062b303659308a23757e318b1e91ed8684ad1205721142dd664d94771cd63499353fd4ee732b5
+    lowercase-keys: "npm:^3.0.0"
+  checksum: 10c0/8af27153f7e47aa2c07a5f2d538cb1e5872995f0e9ff77def858ecce5c3fe677d42b824a62cde502e56d275ab832b0a8bd350d5cd6b467ac0425214ac12ae658
   languageName: node
   linkType: hard
 
@@ -11608,7 +11574,7 @@ __metadata:
     github-slugger: "npm:^1.2.1"
     glob: "npm:^8.0.3"
     googleapis: "npm:^73.0.0"
-    got: "npm:^11.7.0"
+    got: "npm:^14.2.1"
     graphql: "npm:^16.8.1"
     graphql-depth-limit: "npm:^1.1.0"
     graphql-playground-middleware-express: "npm:^1.7.23"


### PR DESCRIPTION
Having CJS only was blocking some of the dependency upgrades which switched to ESM only distributions

`stream-buffers` was removed since it was only used in tests and could be rewritten using Readable/Writable streams from stdlib