### PR TITLE
fix(worker-runner): use a hanging GET for GCP spot termination detection

### DIFF
--- a/changelog/issue-6802.md
+++ b/changelog/issue-6802.md
@@ -1,0 +1,5 @@
+audience: worker-deployers
+level: patch
+reference: issue 6802
+---
+Worker Runner no longer polls the metadata service for the Google provider. Instead, we've added `?wait_for_change=true` to the endpoint to perform a hanging GET request that'll return as soon as the metadata has changed and the VM has been preempted.

--- a/tools/worker-runner/provider/google/google_test.go
+++ b/tools/worker-runner/provider/google/google_test.go
@@ -87,7 +87,7 @@ func TestGoogleConfigureRun(t *testing.T) {
 }
 
 func TestCheckTerminationTime(t *testing.T) {
-	test := func(t *testing.T, proto *workerproto.Protocol, hasCapability bool) {
+	test := func(t *testing.T, proto *workerproto.Protocol) {
 		t.Helper()
 
 		userData := &UserData{
@@ -114,7 +114,7 @@ func TestCheckTerminationTime(t *testing.T) {
 			workerManagerClientFactory: nil,
 			metadataService:            mds,
 			proto:                      proto,
-			terminationTicker:          nil,
+			terminationMsgSent:         false,
 		}
 
 		proto.AddCapability("graceful-termination")
@@ -123,7 +123,7 @@ func TestCheckTerminationTime(t *testing.T) {
 		// not time yet..
 		require.False(t, p.checkTerminationTime())
 
-		metaData["/instance/preempted"] = "TRUE"
+		metaData["/instance/preempted?wait_for_change=true"] = "TRUE"
 		require.True(t, p.checkTerminationTime())
 	}
 
@@ -133,7 +133,7 @@ func TestCheckTerminationTime(t *testing.T) {
 
 		gotTerm := wkr.MessageReceivedFunc("graceful-termination", nil)
 
-		test(t, wkr.RunnerProtocol, false)
+		test(t, wkr.RunnerProtocol)
 
 		require.False(t, gotTerm())
 	})
@@ -144,7 +144,7 @@ func TestCheckTerminationTime(t *testing.T) {
 
 		gotTerm := wkr.MessageReceivedFunc("graceful-termination", nil)
 
-		test(t, wkr.RunnerProtocol, false)
+		test(t, wkr.RunnerProtocol)
 
 		require.True(t, gotTerm())
 	})


### PR DESCRIPTION
Fixes #6802.

>Worker Runner no longer polls the metadata service for the Google provider. Instead, we've added `?wait_for_change=true` to the endpoint to perform a hanging GET request that'll return as soon as the metadata has changed and the VM has been preempted.