### PR TITLE
Remove maxRunTime limitations for d2g payloads

### DIFF
--- a/changelog/C7wI7jeHQHe41TMMOOrVYA.md
+++ b/changelog/C7wI7jeHQHe41TMMOOrVYA.md
@@ -1,0 +1,4 @@
+audience: users
+level: minor
+---
+Remove maxRunTime limitations for docker payloads in generic worker (d2g)

--- a/generated/references.json
+++ b/generated/references.json
@@ -9157,7 +9157,6 @@
             },
             "maxRunTime": {
               "description": "Maximum time the task container can run in seconds.",
-              "maximum": 86400,
               "minimum": 1,
               "multipleOf": 1,
               "title": "Maximum run time in seconds",
@@ -9944,7 +9943,6 @@
         },
         "maxRunTime": {
           "description": "Maximum time the task container can run in seconds.",
-          "maximum": 86400,
           "minimum": 1,
           "multipleOf": 1,
           "title": "Maximum run time in seconds",

--- a/tools/d2g/dockerworker/generated_types.go
+++ b/tools/d2g/dockerworker/generated_types.go
@@ -118,7 +118,6 @@ type (
 		// Maximum time the task container can run in seconds.
 		//
 		// Mininum:    1
-		// Maximum:    86400
 		MaxRunTime int64 `json:"maxRunTime"`
 
 		// By default docker-worker will fail a task with a non-zero exit status without retrying.  This payload property allows a task owner to define certain exit statuses that will be marked as a retriable exception.
@@ -490,7 +489,6 @@ func JSONSchema() string {
     },
     "maxRunTime": {
       "description": "Maximum time the task container can run in seconds.",
-      "maximum": 86400,
       "minimum": 1,
       "multipleOf": 1,
       "title": "Maximum run time in seconds",

--- a/tools/d2g/genericworker/generated_types.go
+++ b/tools/d2g/genericworker/generated_types.go
@@ -283,7 +283,6 @@ type (
 		// Maximum time the task container can run in seconds.
 		//
 		// Mininum:    1
-		// Maximum:    86400
 		MaxRunTime int64 `json:"maxRunTime"`
 
 		// By default docker-worker will fail a task with a non-zero exit status without retrying.  This payload property allows a task owner to define certain exit statuses that will be marked as a retriable exception.
@@ -1472,7 +1471,6 @@ func JSONSchema() string {
         },
         "maxRunTime": {
           "description": "Maximum time the task container can run in seconds.",
-          "maximum": 86400,
           "minimum": 1,
           "multipleOf": 1,
           "title": "Maximum run time in seconds",

--- a/workers/docker-worker/schemas/v1/payload.yml
+++ b/workers/docker-worker/schemas/v1/payload.yml
@@ -176,7 +176,6 @@ properties:
       Maximum time the task container can run in seconds.
     multipleOf: 1
     minimum: 1
-    maximum: 86400
   onExitStatus:
     title: Exit status handling
     description: >-

--- a/workers/generic-worker/generated_multiuser_darwin.go
+++ b/workers/generic-worker/generated_multiuser_darwin.go
@@ -285,7 +285,6 @@ type (
 		// Maximum time the task container can run in seconds.
 		//
 		// Mininum:    1
-		// Maximum:    86400
 		MaxRunTime int64 `json:"maxRunTime"`
 
 		// By default docker-worker will fail a task with a non-zero exit status without retrying.  This payload property allows a task owner to define certain exit statuses that will be marked as a retriable exception.
@@ -1474,7 +1473,6 @@ func JSONSchema() string {
         },
         "maxRunTime": {
           "description": "Maximum time the task container can run in seconds.",
-          "maximum": 86400,
           "minimum": 1,
           "multipleOf": 1,
           "title": "Maximum run time in seconds",

--- a/workers/generic-worker/generated_multiuser_freebsd.go
+++ b/workers/generic-worker/generated_multiuser_freebsd.go
@@ -285,7 +285,6 @@ type (
 		// Maximum time the task container can run in seconds.
 		//
 		// Mininum:    1
-		// Maximum:    86400
 		MaxRunTime int64 `json:"maxRunTime"`
 
 		// By default docker-worker will fail a task with a non-zero exit status without retrying.  This payload property allows a task owner to define certain exit statuses that will be marked as a retriable exception.
@@ -1474,7 +1473,6 @@ func JSONSchema() string {
         },
         "maxRunTime": {
           "description": "Maximum time the task container can run in seconds.",
-          "maximum": 86400,
           "minimum": 1,
           "multipleOf": 1,
           "title": "Maximum run time in seconds",

--- a/workers/generic-worker/generated_multiuser_linux.go
+++ b/workers/generic-worker/generated_multiuser_linux.go
@@ -285,7 +285,6 @@ type (
 		// Maximum time the task container can run in seconds.
 		//
 		// Mininum:    1
-		// Maximum:    86400
 		MaxRunTime int64 `json:"maxRunTime"`
 
 		// By default docker-worker will fail a task with a non-zero exit status without retrying.  This payload property allows a task owner to define certain exit statuses that will be marked as a retriable exception.
@@ -1474,7 +1473,6 @@ func JSONSchema() string {
         },
         "maxRunTime": {
           "description": "Maximum time the task container can run in seconds.",
-          "maximum": 86400,
           "minimum": 1,
           "multipleOf": 1,
           "title": "Maximum run time in seconds",

--- a/workers/generic-worker/schemas/multiuser_posix.yml
+++ b/workers/generic-worker/schemas/multiuser_posix.yml
@@ -529,7 +529,6 @@ oneOf:
         Maximum time the task container can run in seconds.
       multipleOf: 1
       minimum: 1
-      maximum: 86400
     onExitStatus:
       title: Exit status handling
       description: >-


### PR DESCRIPTION
We added support for configurable maxRunTime in generic worker in https://github.com/taskcluster/taskcluster/pull/6465. We're now converting our existing docker-worker tasks over to d2g/generic-worker, some of which require a higher maxRunTime than generic-worker's docker-worker schema allows for. I believe this patch will fix that.

I did notice that there's also the same limit in https://github.com/taskcluster/taskcluster/blob/main/workers/docker-worker/schemas/v1/payload.yml, but seeing as docker-worker is deprecated, I don't think it's worthwhile to make any changes there.

(And for completeness: the docker worker maxRunTime was _reduced_ in https://github.com/taskcluster/taskcluster/pull/6019/files, but the version we're running allows for the old `604800` limit, which is how we have tasks configured that high.)