### PR TITLE
chore: upgrade fetch-metadata action to remove node v16 usage

### DIFF
--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -8,7 +8,7 @@ jobs:
     steps:
       - name: Dependabot metadata
         id: metadata
-        uses: dependabot/fetch-metadata@v1.6.0
+        uses: dependabot/fetch-metadata@v2.0.0
         with:
           github-token: "${{ secrets.DEPENDABOT_AUTOMERGE_TOKEN }}"
       - name: Approve a PR

--- a/changelog/JWSqSOBOSo693R2Nm6wJDg.md
+++ b/changelog/JWSqSOBOSo693R2Nm6wJDg.md
@@ -1,0 +1,3 @@
+audience: general
+level: silent
+---


### PR DESCRIPTION
Gets rid of these warnings https://github.com/taskcluster/taskcluster/actions/runs/8509082081

>Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: dependabot/fetch-metadata@v1.6.0. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.