### PR TITLE
Highlight links in schema documentation

### DIFF
--- a/changelog/issue-6945.md
+++ b/changelog/issue-6945.md
@@ -1,0 +1,6 @@
+audience: users
+level: patch
+reference: issue 6945
+---
+
+Fix schema styles in documentation - links are properly highlighted.

--- a/ui/src/views/Documentation/index.jsx
+++ b/ui/src/views/Documentation/index.jsx
@@ -27,6 +27,9 @@ import PageMeta from './PageMeta';
   theme => ({
     documentation: {
       fontFamily: theme.typography.fontFamily,
+      '& a': {
+        ...theme.mixins.link,
+      },
     },
   }),
   { withTheme: true }


### PR DESCRIPTION

<img width="856" alt="image" src="https://github.com/taskcluster/taskcluster/assets/83861/31b713ae-f008-485e-af59-16f59e26e7e1">

Fixes #6945
