### PR TITLE
feat(w-m): place disk labels inside `initializeParams`

### DIFF
--- a/changelog/issue-6946.md
+++ b/changelog/issue-6946.md
@@ -1,0 +1,6 @@
+audience: deployers
+level: patch
+reference: issue 6946
+---
+
+Worker-manager properly attaches disk labels for GCP provider.

--- a/services/worker-manager/src/providers/google.js
+++ b/services/worker-manager/src/providers/google.js
@@ -245,7 +245,16 @@ export class GoogleProvider extends Provider {
         ...(cfg.disks || {}),
       ];
       for (let disk of disks) {
-        disk.labels = { ...disk.labels, ...labels };
+        const initializeParams = disk.initializeParams || {};
+        disk.initializeParams = {
+          ...initializeParams,
+          labels: {
+            ...initializeParams.labels,
+            ...disk.labels,
+            ...labels,
+          },
+        };
+        delete disk.labels;
       }
 
       try {

--- a/services/worker-manager/test/fakes/schemas/google-instance.yml
+++ b/services/worker-manager/test/fakes/schemas/google-instance.yml
@@ -41,7 +41,12 @@ properties:
         items:
           type: object
           properties:
-            labels: {$ref: "#/definitions/labels"}
+            initializeParams:
+              type: object
+              properties:
+                labels: {$ref: "#/definitions/labels"}
+              additionalProperties: false
+              required: []
             testProperty: {}
           additionalProperties: false
           required: []

--- a/services/worker-manager/test/provider_google_test.js
+++ b/services/worker-manager/test/provider_google_test.js
@@ -245,12 +245,41 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       assert.deepEqual(parameters.requestBody.disks, [
         {
           testProperty: 'bar',
-          labels: {
-            'created-by': 'taskcluster-wm-' + providerId,
-            'managed-by': 'taskcluster',
-            'worker-pool-id': workerPoolId.replace('/', '-'),
-            'owner': 'whatever-example-com',
-            'color': 'purple',
+          initializeParams: {
+            labels: {
+              'created-by': 'taskcluster-wm-' + providerId,
+              'managed-by': 'taskcluster',
+              'worker-pool-id': workerPoolId.replace('/', '-'),
+              'owner': 'whatever-example-com',
+              'color': 'purple',
+            },
+          },
+        },
+      ]);
+    });
+
+    provisionTest('disk labels preserved', {
+      config: {
+        ...config,
+        launchConfigs: [{
+          ...defaultLaunchConfig,
+          disks: [{ testProperty: 'bar', initializeParams: { labels: { color: 'purple' } } }],
+        }],
+      },
+      expectedWorkers: 1,
+    }, async workers => {
+      const parameters = fake.compute.instances.insertCalls[0];
+      assert.deepEqual(parameters.requestBody.disks, [
+        {
+          testProperty: 'bar',
+          initializeParams: {
+            labels: {
+              'created-by': 'taskcluster-wm-' + providerId,
+              'managed-by': 'taskcluster',
+              'worker-pool-id': workerPoolId.replace('/', '-'),
+              'owner': 'whatever-example-com',
+              'color': 'purple',
+            },
           },
         },
       ]);


### PR DESCRIPTION
Likely schema got changed, or it was not placed correctly intially.

[instances.insert](https://cloud.google.com/compute/docs/reference/rest/v1/instances/insert) say that disk labels should be placed inside `disks[].initializeParams.labels`


Fixes #6946 
