### PR TITLE
fix(w-m): only apply `initializeParams.labels` to `PERSISTENT` disks on GCP

### DIFF
--- a/changelog/issue-6958.md
+++ b/changelog/issue-6958.md
@@ -1,0 +1,7 @@
+audience: general
+level: patch
+reference: issue 6958
+---
+Worker Manager now only applies GCP disk labels to `PERSISTENT` disk types.
+
+This fixes an issue in v64.2.2 where `initializeParams.labels` was being set on all disk types and caused GCP to error on local SSDs (`SCRATCH` type disks).

--- a/services/worker-manager/src/providers/google.js
+++ b/services/worker-manager/src/providers/google.js
@@ -245,6 +245,10 @@ export class GoogleProvider extends Provider {
         ...(cfg.disks || {}),
       ];
       for (let disk of disks) {
+        if (disk.type !== 'PERSISTENT') {
+          delete disk.labels;
+          continue;
+        }
         const initializeParams = disk.initializeParams || {};
         disk.initializeParams = {
           ...initializeParams,

--- a/services/worker-manager/test/fakes/schemas/google-instance.yml
+++ b/services/worker-manager/test/fakes/schemas/google-instance.yml
@@ -41,12 +41,10 @@ properties:
         items:
           type: object
           properties:
-            initializeParams:
-              type: object
-              properties:
-                labels: {$ref: "#/definitions/labels"}
-              additionalProperties: false
-              required: []
+            initializeParams: {}
+            type:
+              type: string
+              enum: [PERSISTENT, SCRATCH]
             testProperty: {}
           additionalProperties: false
           required: []

--- a/services/worker-manager/test/provider_google_test.js
+++ b/services/worker-manager/test/provider_google_test.js
@@ -231,12 +231,16 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       });
     });
 
-    provisionTest('disks', {
+    provisionTest('disks (persistent)', {
       config: {
         ...config,
         launchConfigs: [{
           ...defaultLaunchConfig,
-          disks: [{ testProperty: 'bar', labels: { color: 'purple' } }],
+          disks: [{
+            testProperty: 'bar',
+            type: 'PERSISTENT',
+            labels: { color: 'purple' },
+          }],
         }],
       },
       expectedWorkers: 1,
@@ -245,6 +249,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       assert.deepEqual(parameters.requestBody.disks, [
         {
           testProperty: 'bar',
+          type: 'PERSISTENT',
           initializeParams: {
             labels: {
               'created-by': 'taskcluster-wm-' + providerId,
@@ -258,12 +263,16 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       ]);
     });
 
-    provisionTest('disk labels preserved', {
+    provisionTest('disks (scratch)', {
       config: {
         ...config,
         launchConfigs: [{
           ...defaultLaunchConfig,
-          disks: [{ testProperty: 'bar', initializeParams: { labels: { color: 'purple' } } }],
+          disks: [{
+            testProperty: 'bar',
+            type: 'SCRATCH',
+            labels: { color: 'purple' },
+          }],
         }],
       },
       expectedWorkers: 1,
@@ -272,6 +281,30 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       assert.deepEqual(parameters.requestBody.disks, [
         {
           testProperty: 'bar',
+          type: 'SCRATCH',
+        },
+      ]);
+    });
+
+    provisionTest('disk labels preserved', {
+      config: {
+        ...config,
+        launchConfigs: [{
+          ...defaultLaunchConfig,
+          disks: [{
+            testProperty: 'bar',
+            type: 'PERSISTENT',
+            initializeParams: { labels: { color: 'purple' } },
+          }],
+        }],
+      },
+      expectedWorkers: 1,
+    }, async workers => {
+      const parameters = fake.compute.instances.insertCalls[0];
+      assert.deepEqual(parameters.requestBody.disks, [
+        {
+          testProperty: 'bar',
+          type: 'PERSISTENT',
           initializeParams: {
             labels: {
               'created-by': 'taskcluster-wm-' + providerId,


### PR DESCRIPTION
Fixes https://github.com/taskcluster/taskcluster/issues/6958.

>Worker Manager now only applies GCP disk labels to `PERSISTENT` disk types.
>
>This fixes an issue in v64.2.2 where `initializeParams.labels` was being set on all disk types and caused GCP to error on local SSDs (`SCRATCH` type disks).