### PR TITLE
fix(worker-runner azure): don't gracefully terminate on `Freeze` event

### DIFF
--- a/changelog/issue-6900.md
+++ b/changelog/issue-6900.md
@@ -1,0 +1,5 @@
+audience: worker-deployers
+level: patch
+reference: issue 6900
+---
+Worker Runner on Azure no longer sends a `graceful-termination` message if the scheduled event type is `Freeze`. It will continue to send the message for all other event types: `Reboot`, `Redeploy`, `Preempt`, and `Terminate`.

--- a/workers/generic-worker/README.md
+++ b/workers/generic-worker/README.md
@@ -296,7 +296,7 @@ and reports back results to the queue.
            this worker environment is no longer up-to-date. Typcially workers should
            terminate.
     71     The worker was terminated via an interrupt signal (e.g. Ctrl-C pressed).
-    72     The worker is running on spot infrastructure in AWS EC2 and has been served a
+    72     The worker is running on spot infrastructure and has been served a
            spot termination notice, and therefore has shut down.
     73     The config provided to the worker is invalid.
     75     Not able to create an ed25519 key pair.

--- a/workers/generic-worker/usage.go
+++ b/workers/generic-worker/usage.go
@@ -311,7 +311,7 @@ and reports back results to the queue.
            this worker environment is no longer up-to-date. Typcially workers should
            terminate.
     71     The worker was terminated via an interrupt signal (e.g. Ctrl-C pressed).
-    72     The worker is running on spot infrastructure in AWS EC2 and has been served a
+    72     The worker is running on spot infrastructure and has been served a
            spot termination notice, and therefore has shut down.
     73     The config provided to the worker is invalid.` + exitCode74() + `
     75     Not able to create an ed25519 key pair.


### PR DESCRIPTION
Fixes https://github.com/taskcluster/taskcluster/issues/6900.

>Worker Runner on Azure no longer sends a `graceful-termination` message if the scheduled event type is `Freeze`. It will continue to send the message for all other event types: `Reboot`, `Redeploy`, `Preempt`, and `Terminate`.