### PR TITLE
fix(generic-worker): upload artifacts in parallel to speed up graceful shutdowns

### DIFF
--- a/changelog/issue-6972.md
+++ b/changelog/issue-6972.md
@@ -1,0 +1,9 @@
+audience: worker-deployers
+level: patch
+reference: issue 6972
+---
+Generic Worker now uploads task payload artifacts in parallel to decrease graceful termination time in the event of a spot termination.
+
+The `insecure` engine no longer performs a file copy command as the task user before the artifact upload process happens to help speed up the process.
+
+Generic Worker (posix only) now tries to put an exclusive file lock on artifacts before upload to prevent the file from being written to by any other process. This is done in lieu of copying the file to a temporary location which was achieving the same thing. If putting the lock on the file fails, Generic Worker will fallback to copying the file.

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/elastic/go-sysinfo v1.13.1
 	github.com/fatih/camelcase v1.0.0
 	github.com/getsentry/raven-go v0.2.0
+	github.com/gofrs/flock v0.8.1
 	github.com/golang-jwt/jwt/v4 v4.5.0
 	github.com/gorilla/mux v1.8.1
 	github.com/gorilla/websocket v1.5.1
@@ -43,7 +44,7 @@ require (
 	github.com/xeipuuv/gojsonschema v1.2.0
 	golang.org/x/crypto v0.21.0
 	golang.org/x/net v0.23.0
-	golang.org/x/sys v0.18.0
+	golang.org/x/sys v0.19.0
 	golang.org/x/tools v0.19.0
 	gopkg.in/yaml.v2 v2.4.0
 	gopkg.in/yaml.v3 v3.0.1

--- a/go.sum
+++ b/go.sum
@@ -99,6 +99,8 @@ github.com/getsentry/raven-go v0.2.0/go.mod h1:KungGk8q33+aIAZUIVWZDr2OfAEBsO49P
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20200222043503-6f7a984d4dc4/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
+github.com/gofrs/flock v0.8.1 h1:+gYjHKf32LDeiEEFhQaotPbLuUXjY5ZqxKgXy7n59aw=
+github.com/gofrs/flock v0.8.1/go.mod h1:F1TvTiK9OcQqauNUHlbJvyl9Qa1QvF/gOUDKA14jxHU=
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
 github.com/golang-jwt/jwt/v4 v4.5.0 h1:7cYmW1XlMY7h7ii7UhUyChSgS5wUJEnm9uZVTGqOWzg=
@@ -431,8 +433,8 @@ golang.org/x/sys v0.0.0-20210423185535-09eb48e85fd7/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210616045830-e2b7044e8c71/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.18.0 h1:DBdB3niSjOA/O0blCZBqDefyWNYveAYMNF1Wum0DYQ4=
-golang.org/x/sys v0.18.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+golang.org/x/sys v0.19.0 h1:q5f1RH2jigJ1MoAWp2KTp3gm5zAGFUTarQZ5U386+4o=
+golang.org/x/sys v0.19.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/workers/generic-worker/artifacts_insecure.go
+++ b/workers/generic-worker/artifacts_insecure.go
@@ -2,11 +2,6 @@
 
 package main
 
-import (
-	"github.com/taskcluster/taskcluster/v64/workers/generic-worker/process"
-	gwruntime "github.com/taskcluster/taskcluster/v64/workers/generic-worker/runtime"
-)
-
-func gwCopyToTempFile(filePath string) (*process.Command, error) {
-	return process.NewCommand([]string{gwruntime.GenericWorkerBinary(), "copy-to-temp-file", "--copy-file", filePath}, "", []string{})
+func gwCopyToTempFile(filePath string) (string, error) {
+	return filePath, nil
 }

--- a/workers/generic-worker/artifacts_multiuser.go
+++ b/workers/generic-worker/artifacts_multiuser.go
@@ -3,10 +3,23 @@
 package main
 
 import (
+	"fmt"
+	"strings"
+
 	"github.com/taskcluster/taskcluster/v64/workers/generic-worker/process"
 	gwruntime "github.com/taskcluster/taskcluster/v64/workers/generic-worker/runtime"
 )
 
-func gwCopyToTempFile(filePath string) (*process.Command, error) {
-	return process.NewCommandNoOutputStreams([]string{gwruntime.GenericWorkerBinary(), "copy-to-temp-file", "--copy-file", filePath}, taskContext.TaskDir, []string{}, taskContext.pd)
+func gwCopyToTempFile(filePath string) (string, error) {
+	cmd, err := process.NewCommandNoOutputStreams([]string{gwruntime.GenericWorkerBinary(), "copy-to-temp-file", "--copy-file", filePath}, taskContext.TaskDir, []string{}, taskContext.pd)
+	if err != nil {
+		return "", fmt.Errorf("failed to create new command to copy file %s to temporary location as task user: %v", filePath, err)
+	}
+
+	output, err := cmd.Output()
+	if err != nil {
+		return "", fmt.Errorf("failed to copy file %s to temporary location as task user: %v", filePath, err)
+	}
+
+	return strings.TrimSpace(string(output)), nil
 }

--- a/workers/generic-worker/chain_of_trust.go
+++ b/workers/generic-worker/chain_of_trust.go
@@ -147,6 +147,7 @@ func (feature *ChainOfTrustTaskFeature) Stop(err *ExecutionErrors) {
 	}
 	err.add(feature.task.uploadLog(certifiedLogName, filepath.Join(taskContext.TaskDir, certifiedLogPath)))
 	artifactHashes := map[string]ArtifactHash{}
+	feature.task.artifactsMux.RLock()
 	for _, artifact := range feature.task.Artifacts {
 		// make sure SHA256 is calculated
 		switch a := artifact.(type) {
@@ -168,6 +169,7 @@ func (feature *ChainOfTrustTaskFeature) Stop(err *ExecutionErrors) {
 			}
 		}
 	}
+	feature.task.artifactsMux.RUnlock()
 
 	cotCert := &ChainOfTrustData{
 		Version:     1,

--- a/workers/generic-worker/model.go
+++ b/workers/generic-worker/model.go
@@ -23,9 +23,10 @@ type (
 		Definition          tcqueue.TaskDefinitionResponse `json:"-"`
 		Payload             GenericWorkerPayload           `json:"-"`
 		// Artifacts is a map from artifact name to artifact
-		Artifacts map[string]artifacts.TaskArtifact `json:"-"`
-		Status    TaskStatus                        `json:"-"`
-		Commands  []*process.Command                `json:"-"`
+		Artifacts    map[string]artifacts.TaskArtifact `json:"-"`
+		artifactsMux sync.RWMutex
+		Status       TaskStatus         `json:"-"`
+		Commands     []*process.Command `json:"-"`
 		// not exported
 		logMux         sync.RWMutex
 		logWriter      io.Writer


### PR DESCRIPTION
Should help with and/or fix #6972.

>Generic Worker now uploads task payload artifacts in parallel to decrease graceful termination time in the event of a spot termination.
>
>The `insecure` engine no longer performs a file copy command as the task user before the artifact upload process happens to help speed up the process.
>
>Generic Worker (posix only) now tries to put an exclusive file lock on artifacts before upload to prevent the file from being written to by any other process. This is done in lieu of copying the file to a temporary location which was achieving the same thing. If putting the lock on the file fails, Generic Worker will fallback to copying the file.