### PR TITLE
feat(worker-manager): Fixes error code detection in AWS checkWorker

### DIFF
--- a/changelog/issue-6983.md
+++ b/changelog/issue-6983.md
@@ -1,0 +1,6 @@
+audience: worker-deployers
+level: patch
+reference: issue 6983
+---
+
+AWS provider correctly detects `InvalidInstanceID.NotFound` error and marks worker as stopped.

--- a/services/worker-manager/src/providers/aws.js
+++ b/services/worker-manager/src/providers/aws.js
@@ -375,7 +375,7 @@ export class AwsProvider extends Provider {
         await this.removeWorker({ worker, reason });
       }
     } catch (e) {
-      if (e.code !== 'InvalidInstanceID.NotFound') { // aws throws this error for instances that had been terminated, too
+      if (![e.code, e.Code].includes('InvalidInstanceID.NotFound')) { // aws throws this error for instances that had been terminated, too
         throw e;
       }
       monitor.debug('instance status not found');

--- a/services/worker-manager/test/fakes/aws.js
+++ b/services/worker-manager/test/fakes/aws.js
@@ -124,6 +124,12 @@ export class FakeEC2 extends FakeCloud {
     this.mock
       .on(DescribeInstanceStatusCommand)
       .callsFake(({ InstanceIds }) => {
+        if (InstanceIds[0] === 'i-amgone') {
+          const err = new Error('Instance not found');
+          err.Code = 'InvalidInstanceID.NotFound';
+          throw err;
+        }
+
         return {
           InstanceStatuses: InstanceIds.map(InstanceId => {
             const state = this.mock.instanceStatuses[InstanceId];


### PR DESCRIPTION
Error code can be sent as both "code" and "Code", better to check both

Fixes #6983 