### PR TITLE
fix(generic-worker): check for graceful termination before claiming work

### DIFF
--- a/changelog/issue-6987.md
+++ b/changelog/issue-6987.md
@@ -1,0 +1,7 @@
+audience: users
+level: patch
+reference: issue 6987
+---
+Generic Worker now checks if a graceful termination was requested from worker runner _before_ calling `queue.claimWork()`.
+
+This helps fix a race condition where a preemption occurs right after Generic Worker starts up, but before the graceful termination handler to abort the task has been initialized.

--- a/workers/generic-worker/main.go
+++ b/workers/generic-worker/main.go
@@ -441,6 +441,10 @@ func RunWorker() (exitCode ExitCode) {
 			panic(err)
 		}
 
+		if graceful.TerminationRequested() {
+			return WORKER_SHUTDOWN
+		}
+
 		task := ClaimWork()
 
 		// make sure at least 5 seconds pass between tcqueue.ClaimWork API calls
@@ -516,10 +520,6 @@ func RunWorker() (exitCode ExitCode) {
 				}
 				log.Printf("No task claimed. Idle for %v%v.%v", idleTime, remainingIdleTimeText, remainingTaskCountText)
 			}
-		}
-
-		if graceful.TerminationRequested() {
-			return WORKER_SHUTDOWN
 		}
 
 		// To avoid hammering queue, make sure there is at least 5 seconds


### PR DESCRIPTION
Fixes #6987.

>Generic Worker now checks if a graceful termination was requested from worker runner _before_ calling `queue.claimWork()`.
>
>This helps fix a race condition where a preemption occurs right after Generic Worker starts up, but before the graceful termination handler to abort the task has been initialized.