### PR TITLE
Ignore missing task groups on auto-cancel

### DIFF
--- a/changelog/issue-6761.md
+++ b/changelog/issue-6761.md
@@ -1,0 +1,7 @@
+audience: developers
+level: patch
+reference: issue 6984
+---
+
+Github auto-cancel gracefully ignores missing task groups and doesn't log errors in github comments.
+This can happen when decision task failed on previous runs.


### PR DESCRIPTION
This can happen when decision task of a previous run failed

Fixes #6984 
