### PR TITLE
chore: use full go version in go.mod

### DIFF
--- a/changelog/fjesG933Q0GogV5uMABoOQ.md
+++ b/changelog/fjesG933Q0GogV5uMABoOQ.md
@@ -1,0 +1,3 @@
+audience: general
+level: silent
+---

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module github.com/taskcluster/taskcluster/v64
 
 // DO NOT MODIFY THIS LINE - automatically updated by infrastructure/tooling/src/generate/generators/go-version.js
-go 1.22
+go 1.22.2
 
 require (
 	github.com/Flaque/filet v0.0.0-20201012163910-45f684403088

--- a/infrastructure/tooling/src/generate/generators/go-version.js
+++ b/infrastructure/tooling/src/generate/generators/go-version.js
@@ -52,7 +52,7 @@ export const tasks = [{
     await modifyRepoFile('go.mod',
       contents => contents.replace(
         /^go [0-9.]+$/m,
-        `go ${goVersionMajor}.${goVersionMinor}`));
+        `go ${goVersionMajor}.${goVersionMinor}.${goVersionBugfix}`));
 
     utils.status({ message: 'workers/generic-worker/build.sh' });
     await modifyRepoFile('workers/generic-worker/build.sh',


### PR DESCRIPTION
As suggested in https://github.com/github/codeql/issues/15647 to fix the below issue:
<img width="957" alt="Screenshot 2024-04-29 at 12 41 11 PM" src="https://github.com/taskcluster/taskcluster/assets/92693437/ffee0439-2fbb-4183-8163-3b3b263531b8">