### PR TITLE
feat(ui): Add Task Group link from the indexed tasks

### DIFF
--- a/changelog/bug-1768667.md
+++ b/changelog/bug-1768667.md
@@ -1,0 +1,7 @@
+audience: users
+level: patch
+reference: bug 1768667
+---
+
+Adds Task Group link in UI for indexed tasks.
+Introduces new route to redirect to the Task Group view: `/tasks/index/:namespace/:indexTask/task-group`

--- a/ui/src/components/IndexTaskNamespaceTable/index.jsx
+++ b/ui/src/components/IndexTaskNamespaceTable/index.jsx
@@ -102,7 +102,7 @@ export default class IndexTaskNamespaceTable extends Component {
         sortDirection={sortDirection}
         onHeaderClick={this.handleHeaderClick}
         onPageChange={onPageChange}
-        headers={['Name']}
+        headers={['Name', 'Task Group']}
         renderRow={({ node: { namespace } }) => (
           <TableRow key={namespace}>
             <TableCell>
@@ -115,6 +115,20 @@ export default class IndexTaskNamespaceTable extends Component {
                 )}/${this.taskFromNamespace(namespace)}`}>
                 <TableCellItem button>
                   {this.taskFromNamespace(namespace)}
+                  <LinkIcon size={iconSize} />
+                </TableCellItem>
+              </Link>
+            </TableCell>
+            <TableCell size="medium">
+              <Link
+                to={`/tasks/index/${encodeURIComponent(
+                  namespace
+                    .split('.')
+                    .slice(0, -1)
+                    .join('.')
+                )}/${this.taskFromNamespace(namespace)}/task-group`}>
+                <TableCellItem button>
+                  Task Group
                   <LinkIcon size={iconSize} />
                 </TableCellItem>
               </Link>

--- a/ui/src/components/IndexedEntry/index.jsx
+++ b/ui/src/components/IndexedEntry/index.jsx
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import { arrayOf, func, shape } from 'prop-types';
+import { arrayOf, func, shape, string } from 'prop-types';
 import classNames from 'classnames';
 import { withStyles } from '@material-ui/core/styles';
 import TableCell from '@material-ui/core/TableCell';
@@ -78,6 +78,7 @@ export default class IndexedEntry extends Component {
       pageInfo,
     }).isRequired,
     onArtifactsPageChange: func.isRequired,
+    taskGroupId: string,
   };
 
   handleHeaderClick = sortBy => {
@@ -160,7 +161,7 @@ export default class IndexedEntry extends Component {
   }
 
   render() {
-    const { classes, created, indexedTask } = this.props;
+    const { classes, created, indexedTask, taskGroupId } = this.props;
 
     return (
       <List>
@@ -179,10 +180,18 @@ export default class IndexedEntry extends Component {
         </ListItem>
         <Link to={`/tasks/${indexedTask.taskId}`}>
           <ListItem button className={classes.listItemButton}>
-            <ListItemText primary="View task" />
+            <ListItemText primary="View task" secondary={indexedTask.taskId} />
             <LinkIcon />
           </ListItem>
         </Link>
+        {taskGroupId && (
+          <Link to={`/tasks/groups/${taskGroupId}`}>
+            <ListItem button className={classes.listItemButton}>
+              <ListItemText primary="View task group" secondary={taskGroupId} />
+              <LinkIcon />
+            </ListItem>
+          </Link>
+        )}
         <ListItem component="div">
           <ListItemText
             primary="Data"

--- a/ui/src/views/Tasks/TaskIndex/IndexedTask/artifacts.graphql
+++ b/ui/src/views/Tasks/TaskIndex/IndexedTask/artifacts.graphql
@@ -17,5 +17,6 @@ query IndexEntry($taskId: ID!, $entryConnection: PageConnection, $skip: Boolean!
 
   task(taskId: $taskId) @skip(if: $skip) {
     created
+    taskGroupId
   }
 }

--- a/ui/src/views/Tasks/TaskIndex/IndexedTask/index.jsx
+++ b/ui/src/views/Tasks/TaskIndex/IndexedTask/index.jsx
@@ -167,13 +167,12 @@ export default class IndexedTask extends Component {
                 )
               )}
             </Breadcrumbs>
-            <br />
-            <br />
             <IndexedEntry
               onArtifactsPageChange={this.handleArtifactsPageChange}
               latestArtifactsConnection={latestArtifacts}
               indexedTask={indexedTask}
               created={task.created}
+              taskGroupId={task.taskGroupId}
             />
           </Fragment>
         )}

--- a/ui/src/views/Tasks/TaskIndex/IndexedTask/taskGroupRedirect.jsx
+++ b/ui/src/views/Tasks/TaskIndex/IndexedTask/taskGroupRedirect.jsx
@@ -1,0 +1,58 @@
+import React, { Component } from 'react';
+import { Redirect } from 'react-router-dom';
+import { graphql } from 'react-apollo';
+import Spinner from '../../../../components/Spinner';
+import Dashboard from '../../../../components/Dashboard';
+import ErrorPanel from '../../../../components/ErrorPanel';
+import artifactsQuery from './artifacts.graphql';
+import indexedTaskQuery from './indexedTask.graphql';
+
+@graphql(indexedTaskQuery, {
+  name: 'indexedTaskData',
+  options: props => ({
+    variables: {
+      indexPath: `${props.match.params.namespace}.${props.match.params.namespaceTaskId}`,
+    },
+  }),
+})
+@graphql(artifactsQuery, {
+  name: 'latestArtifactsData',
+  options: ({ indexedTaskData }) => ({
+    variables: {
+      skip: !indexedTaskData.indexedTask,
+      taskId: indexedTaskData.indexedTask && indexedTaskData.indexedTask.taskId,
+      entryConnection: {
+        limit: 1, // we don't need much for redirect, but we need the task
+      },
+    },
+  }),
+})
+export default class IndexedTaskTaskGroupRedirect extends Component {
+  render() {
+    const {
+      latestArtifactsData: {
+        task,
+        error: latestArtifactsError,
+        loading: latestArtifactsLoading,
+      },
+      indexedTaskData: {
+        indexedTask,
+        error: indexedTaskError,
+        loading: indexedTaskLoading,
+      },
+    } = this.props;
+    const loading = latestArtifactsLoading || indexedTaskLoading;
+
+    return (
+      <Dashboard title="Index Task Group Redirect">
+        {loading && <Spinner loading />}
+        {!loading && (
+          <ErrorPanel fixed error={indexedTaskError || latestArtifactsError} />
+        )}
+        {indexedTask && task?.taskGroupId && (
+          <Redirect to={`/tasks/groups/${task.taskGroupId}`} />
+        )}
+      </Dashboard>
+    );
+  }
+}

--- a/ui/src/views/Tasks/TaskIndex/routes.js
+++ b/ui/src/views/Tasks/TaskIndex/routes.js
@@ -6,10 +6,20 @@ const ListNamespaces = lazy(() =>
 const IndexedTask = lazy(() =>
   import(/* webpackChunkName: 'TaskIndex.IndexedTask' */ './IndexedTask')
 );
+const IndexedTaskTaskGroupRedirect = lazy(() =>
+  import(
+    /* webpackChunkName: 'TaskIndex.IndexedTaskTaskGroupRedirect' */ './IndexedTask/taskGroupRedirect'
+  )
+);
 const taskIndexDescription =
   'The generic index browser lets you browse through the hierarchy of namespaces in the index, and discover indexed tasks.';
 
 export default path => [
+  {
+    component: IndexedTaskTaskGroupRedirect,
+    description: taskIndexDescription,
+    path: `${path}/:namespace/:namespaceTaskId/task-group`,
+  },
   {
     component: IndexedTask,
     description: taskIndexDescription,


### PR DESCRIPTION
1. Adds link to the Task Group from the indexed namespaces view: 
<img width="1215" alt="image" src="https://github.com/taskcluster/taskcluster/assets/83861/8a0837a5-b396-405e-8b72-655f62b6862d">

2. Displays Task Group link from inside the indexed task view:
<img width="1222" alt="image" src="https://github.com/taskcluster/taskcluster/assets/83861/6d5d8ffc-779d-4c08-bfdc-c697533cdcc6">

3. Introduces a link that will redirect to the task group view in the UI by using indexed namespace and indexed tasks as parameters:
`/tasks/index/indexed.namespace/indexedtask/task-group`


Bugzilla Bug: [1768667](https://bugzilla.mozilla.org/show_bug.cgi?id=1768667)
