### PR TITLE
Issue 6979 - Explicitly set XDG_RUNTIME_DIR in Linux/Multiuser

### DIFF
--- a/changelog/EdA3XVyRQlGVGNjJlRW6yw.md
+++ b/changelog/EdA3XVyRQlGVGNjJlRW6yw.md
@@ -1,0 +1,5 @@
+audience: worker-deployers
+level: minor
+reference: issue 6979
+---
+Generic Worker multiuser engine on Linux now sets environment variable`XDG_RUNTIME_DIR` to `/run/user/<UID>` in task command processes (unless Generic Worker config setting `runTasksAsCurrentUser` is set to `true`).

--- a/workers/generic-worker/multiuser_posix.go
+++ b/workers/generic-worker/multiuser_posix.go
@@ -151,6 +151,9 @@ func (task *TaskRun) EnvVars() []string {
 	}
 	if runtime.GOOS == "linux" {
 		taskEnv["DISPLAY"] = ":0"
+		if !config.RunTasksAsCurrentUser {
+			taskEnv["XDG_RUNTIME_DIR"] = "/run/user/" + strconv.Itoa(int(taskContext.pd.SysProcAttr.Credential.Uid))
+		}
 	}
 	if config.WorkerLocation != "" {
 		taskEnv["TASKCLUSTER_WORKER_LOCATION"] = config.WorkerLocation


### PR DESCRIPTION
Github Bug/Issue: Fixes #6979

Spent the entire day looking at this to see if there is a comfortable way to generate the env vars that would be set in the gnome desktop environment and pass them to Generic Worker, but after a full day of trying (and with the help of @Eijebong) decided this was the most sensible solution. We had some successes with systemd-run but it all got very complicated, and only set 3 or 4 env vars compared to what would be seen in a full graphical session, so this seemed like the most pragmatic solution.

It isn't ideal having Generic Worker care about desktop settings, but it also isn't currently trivial for a task to launch a desktop session of its own, so this seems like a reasonable compromise.