### PR TITLE
feat(ui): Worker Manager shows worker page properly when queue data is missing

### DIFF
--- a/changelog/issue-6117.md
+++ b/changelog/issue-6117.md
@@ -1,0 +1,7 @@
+audience: users
+level: patch
+reference: issue 6117
+---
+
+Fixes Worker page when queue information was missing and error was displayed.
+If worker-manager data exists for this worker, it would be displayed instead.

--- a/services/web-server/src/graphql/WorkerManager.graphql
+++ b/services/web-server/src/graphql/WorkerManager.graphql
@@ -124,6 +124,8 @@ extend type Query {
     WorkerManagerProviders(connection: PageConnection, filter: JSON): WorkerManagerProvidersConnection!
 
     WorkerManagerWorkers(workerPoolId: String!, state: String, connection: PageConnection): WorkerManagerWorkerConnection!
+
+    WorkerManagerWorker(workerPoolId: String!, workerGroup: String!, workerId: ID!): WMWorker
 }
 
 extend type Mutation {

--- a/services/web-server/src/loaders/workerManager.js
+++ b/services/web-server/src/loaders/workerManager.js
@@ -19,6 +19,11 @@ export default ({ workerManager }, isAuthed, rootUrl, monitor, strategies, req, 
     return await workerManager.workerPool(workerPoolId);
   })));
 
+  const WorkerManagerWorker = new DataLoader(queries => Promise.all(queries.map(
+    async ({ workerPoolId, workerGroup, workerId }) => {
+      return await workerManager.worker(workerPoolId, workerGroup, workerId);
+    })));
+
   const WorkerManagerWorkers = new ConnectionLoader(
     async ({ workerPoolId, state, options }) => {
       if (state) {
@@ -70,5 +75,6 @@ export default ({ workerManager }, isAuthed, rootUrl, monitor, strategies, req, 
     WorkerPool,
     WorkerManagerProviders,
     WorkerManagerWorkers,
+    WorkerManagerWorker,
   };
 };

--- a/services/web-server/src/resolvers/WorkerManager.js
+++ b/services/web-server/src/resolvers/WorkerManager.js
@@ -23,6 +23,9 @@ export default {
     WorkerPool(parent, { workerPoolId }, { loaders }) {
       return loaders.WorkerPool.load({ workerPoolId });
     },
+    WorkerManagerWorker(parent, { workerPoolId, workerGroup, workerId }, { loaders }) {
+      return loaders.WorkerManagerWorker.load({ workerPoolId, workerGroup, workerId });
+    },
     WorkerManagerWorkers(parent, { workerPoolId, state, connection }, { loaders }) {
       return loaders.WorkerManagerWorkers.load({ workerPoolId, state, connection });
     },

--- a/services/worker-manager/src/data.js
+++ b/services/worker-manager/src/data.js
@@ -454,7 +454,7 @@ export class Worker {
       lastModified: this.lastModified?.toJSON(),
       lastChecked: this.lastChecked?.toJSON(),
       firstClaim: this.firstClaim?.toJSON(),
-      recentTasks: _.cloneDeep(this.recentTasks),
+      recentTasks: _.cloneDeep(this.recentTasks) || [],
       lastDateActive: this.lastDateActive?.toJSON(),
       quarantineUntil: this.quarantineUntil?.toJSON(),
       quarantineDetails: this.quarantineDetails || [],

--- a/ui/src/components/WorkerDetailsCard/index.jsx
+++ b/ui/src/components/WorkerDetailsCard/index.jsx
@@ -1,6 +1,12 @@
 import React, { Component, Fragment } from 'react';
 import { format, parseISO } from 'date-fns';
-import { List, ListItem, ListItemText, Typography } from '@material-ui/core';
+import {
+  List,
+  ListItem,
+  ListItemText,
+  Typography,
+  Grid,
+} from '@material-ui/core';
 import DateDistance from '../DateDistance';
 import Label from '../Label';
 import StatusLabel from '../StatusLabel';
@@ -26,6 +32,10 @@ export default class WorkerDetailsCard extends Component {
         quarantineDetails,
         firstClaim,
         lastDateActive,
+        created,
+        expires,
+        lastModified,
+        lastChecked,
         state,
       },
     } = this.props;
@@ -33,84 +43,132 @@ export default class WorkerDetailsCard extends Component {
     return (
       <Fragment>
         <List>
-          <ListItem>
-            <ListItemText
-              primary="Last Active"
-              secondary={
-                lastDateActive ? <DateDistance from={lastDateActive} /> : 'n/a'
-              }
-            />
-          </ListItem>
-          <ListItem>
-            <ListItemText
-              primary="First Claim"
-              secondary={<DateDistance from={firstClaim} />}
-            />
-          </ListItem>
-          <ListItem>
-            <ListItemText
-              primary="Quarantine Until"
-              secondary={
-                quarantineUntil
-                  ? format(parseISO(quarantineUntil), 'yyyy/MM/dd')
-                  : 'n/a'
-              }
-            />
-          </ListItem>
-          {quarantineDetails?.length > 0 && (
-            <ListItem>
-              <ListItemText
-                primary="Quarantine History"
-                secondary={
-                  <ul>
-                    {quarantineDetails.map(
-                      ({
-                        clientId,
-                        updatedAt,
-                        quarantineUntil,
-                        quarantineInfo,
-                      }) => (
-                        <li key={updatedAt}>
-                          {clientId} on{' '}
-                          <em>
-                            {format(parseISO(updatedAt), 'yyyy/MM/dd HH:ii')}
-                          </em>
-                          {' | '}
-                          Until:{' '}
-                          {format(
-                            parseISO(quarantineUntil),
-                            'yyyy/MM/dd'
-                          )}:{' '}
-                          <Typography variant="body2" component="em">
-                            {quarantineInfo}
-                          </Typography>
-                        </li>
-                      )
-                    )}
-                  </ul>
-                }
-              />
-            </ListItem>
-          )}
-          <ListItem>
-            <ListItemText
-              primary="Worker State"
-              secondary={
-                state ? (
-                  <StatusLabel state={state.toUpperCase()} />
-                ) : (
-                  <em>n/a</em>
-                )
-              }
-            />
-          </ListItem>
-          {state === 'stopping' && (
-            <ListItem>
-              <Label mini status="warning">
-                Scheduled for termination
-              </Label>
-            </ListItem>
-          )}
+          <Grid container spacing={2}>
+            <Grid item xs={6}>
+              <ListItem>
+                <ListItemText
+                  primary="Last Active"
+                  secondary={
+                    lastDateActive ? (
+                      <DateDistance from={lastDateActive} />
+                    ) : (
+                      'n/a'
+                    )
+                  }
+                />
+              </ListItem>
+              <ListItem>
+                <ListItemText
+                  primary="First Claim"
+                  secondary={
+                    firstClaim ? <DateDistance from={firstClaim} /> : 'n/a'
+                  }
+                />
+              </ListItem>
+              <ListItem>
+                <ListItemText
+                  primary="Quarantine Until"
+                  secondary={
+                    quarantineUntil
+                      ? format(parseISO(quarantineUntil), 'yyyy/MM/dd')
+                      : 'n/a'
+                  }
+                />
+              </ListItem>
+              {quarantineDetails?.length > 0 && (
+                <ListItem>
+                  <ListItemText
+                    primary="Quarantine History"
+                    secondary={
+                      <ul>
+                        {quarantineDetails.map(
+                          ({
+                            clientId,
+                            updatedAt,
+                            quarantineUntil,
+                            quarantineInfo,
+                          }) => (
+                            <li key={updatedAt}>
+                              {clientId} on{' '}
+                              <em>
+                                {format(
+                                  parseISO(updatedAt),
+                                  'yyyy/MM/dd HH:ii'
+                                )}
+                              </em>
+                              {' | '}
+                              Until:{' '}
+                              {format(
+                                parseISO(quarantineUntil),
+                                'yyyy/MM/dd'
+                              )}:{' '}
+                              <Typography variant="body2" component="em">
+                                {quarantineInfo}
+                              </Typography>
+                            </li>
+                          )
+                        )}
+                      </ul>
+                    }
+                  />
+                </ListItem>
+              )}
+              <ListItem>
+                <ListItemText
+                  primary="Worker State"
+                  secondary={
+                    state ? (
+                      <StatusLabel state={state.toUpperCase()} />
+                    ) : (
+                      <em>n/a</em>
+                    )
+                  }
+                />
+              </ListItem>
+              {state === 'stopping' && (
+                <ListItem>
+                  <Label mini status="warning">
+                    Scheduled for termination
+                  </Label>
+                </ListItem>
+              )}
+            </Grid>
+            <Grid item xs={6}>
+              {/* worker-manager view specific info */}
+              {created && (
+                <ListItem>
+                  <ListItemText
+                    primary="Worker created"
+                    secondary={<DateDistance from={created} />}
+                  />
+                </ListItem>
+              )}
+              {expires && (
+                <ListItem>
+                  <ListItemText
+                    primary="Worker expires"
+                    secondary={<DateDistance from={expires} />}
+                  />
+                </ListItem>
+              )}
+              {lastModified && (
+                <ListItem>
+                  <ListItemText
+                    primary="Worker last modified"
+                    secondary={<DateDistance from={lastModified} />}
+                  />
+                </ListItem>
+              )}
+              {lastChecked && (
+                <ListItem>
+                  <ListItemText
+                    primary="Last checked by worker-manager"
+                    secondary={<DateDistance from={lastChecked} />}
+                  />
+                </ListItem>
+              )}
+            </Grid>
+          </Grid>
         </List>
       </Fragment>
     );

--- a/ui/src/views/Provisioners/ViewWorker/worker.graphql
+++ b/ui/src/views/Provisioners/ViewWorker/worker.graphql
@@ -1,4 +1,4 @@
-query ViewWorker($provisionerId: String!, $workerType: String!, $workerGroup: String!, $workerId: ID!, $workerTypesConnection: PageConnection) {
+query ViewWorker($provisionerId: String!, $workerType: String!, $workerGroup: String!, $workerId: ID!, $workerPoolId: String!, $workerTypesConnection: PageConnection) {
   worker(provisionerId: $provisionerId, workerType: $workerType, workerGroup: $workerGroup, workerId: $workerId) {
     provisionerId
     workerType
@@ -44,6 +44,19 @@ query ViewWorker($provisionerId: String!, $workerType: String!, $workerGroup: St
       url
       description
     }
+  }
+
+  WorkerManagerWorker(workerPoolId: $workerPoolId, workerGroup: $workerGroup, workerId: $workerId) {
+    workerPoolId
+    workerGroup
+    workerId
+    providerId
+    state
+    created
+    expires
+    capacity
+    lastModified
+    lastChecked
   }
 
   workerTypes(provisionerId: $provisionerId, connection: $workerTypesConnection) {

--- a/ui/src/views/WorkerManager/WMViewWorkers/index.jsx
+++ b/ui/src/views/WorkerManager/WMViewWorkers/index.jsx
@@ -169,7 +169,8 @@ export default class WMViewWorkers extends Component {
 
     return (
       <Dashboard
-        title={`Workers for ${decodeURIComponent(params.workerPoolId)}`}>
+        disableTitleFormatting
+        title={`Workers for "${decodeURIComponent(params.workerPoolId)}"`}>
         <ErrorPanel fixed error={this.state.error || error} />
 
         <div>


### PR DESCRIPTION
When only worker-manager data is available, page no longer shows error and gives 404, but displays available info

<img width="1298" alt="image" src="https://github.com/taskcluster/taskcluster/assets/83861/b03f311d-d70b-462c-b49c-ffd63c1da90a">

