### PR TITLE
Generic Worker multiuser engine on macOS/Linux/FreeBSD: fix tasksDir default

### DIFF
--- a/changelog/E0xwqIBzTh-KsBPNQO-c1w.md
+++ b/changelog/E0xwqIBzTh-KsBPNQO-c1w.md
@@ -1,0 +1,12 @@
+audience: worker-deployers
+level: major
+reference: issue 7017
+---
+Generic Worker multiuser engine now places task directories under `/home`
+(Linux and FreeBSD) and `/Users` on macOS. Previously it was placing them under
+`/` by default on all three platforms, unless either `HOME` was set to a
+non-standard value in the process launching Generic Worker multiuser engine, or
+if `tasksDir` was explicitly set in Generic Worker config.
+
+This is a bug fix, but due to being a significant change in behaviour, is being
+released as a major change to trigger a major version bump.

--- a/workers/generic-worker/multiuser_darwin.go
+++ b/workers/generic-worker/multiuser_darwin.go
@@ -1,0 +1,7 @@
+//go:build multiuser
+
+package main
+
+func defaultTasksDir() string {
+	return "/Users"
+}

--- a/workers/generic-worker/multiuser_freebsd.go
+++ b/workers/generic-worker/multiuser_freebsd.go
@@ -1,0 +1,7 @@
+//go:build multiuser
+
+package main
+
+func defaultTasksDir() string {
+	return "/home"
+}

--- a/workers/generic-worker/multiuser_linux.go
+++ b/workers/generic-worker/multiuser_linux.go
@@ -1,0 +1,7 @@
+//go:build multiuser
+
+package main
+
+func defaultTasksDir() string {
+	return "/home"
+}

--- a/workers/generic-worker/multiuser_posix.go
+++ b/workers/generic-worker/multiuser_posix.go
@@ -101,12 +101,6 @@ func RenameCrossDevice(oldpath, newpath string) error {
 	return os.Rename(oldpath, newpath)
 }
 
-func defaultTasksDir() string {
-	// assume all user home directories are all in same folder, i.e. the parent
-	// folder of the current user's home folder
-	return filepath.Dir(os.Getenv("HOME"))
-}
-
 func rebootBetweenTasks() bool {
 	return true
 }


### PR DESCRIPTION
Fixes #7017
