### PR TITLE
feat(ui): Using consistent UI navigation across worker pages

### DIFF
--- a/changelog/issue-6117-1.md
+++ b/changelog/issue-6117-1.md
@@ -1,0 +1,7 @@
+audience: users
+level: patch
+reference: issue 6117
+---
+
+Workers in UI use consistent navigation element that allows to switch between worker pool definition,
+workers, pending and claimed tasks.

--- a/ui/src/components/WMWorkerPoolEditor/index.jsx
+++ b/ui/src/components/WMWorkerPoolEditor/index.jsx
@@ -10,7 +10,6 @@ import {
   FormControlLabel,
   MenuItem,
   Typography,
-  Chip,
   ListItemText,
   ListItem,
   ListSubheader,
@@ -25,7 +24,6 @@ import purple from '@material-ui/core/colors/purple';
 import red from '@material-ui/core/colors/red';
 import { titleCase } from 'title-case';
 import classNames from 'classnames';
-import WorkerIcon from 'mdi-react/WorkerIcon';
 import MessageAlertIcon from 'mdi-react/MessageAlertIcon';
 import ContentSaveIcon from 'mdi-react/ContentSaveIcon';
 import DeleteIcon from 'mdi-react/DeleteIcon';
@@ -35,7 +33,6 @@ import MarkdownTextArea from '../MarkdownTextArea';
 import DialogAction from '../DialogAction';
 import Button from '../Button';
 import isWorkerTypeNameValid from '../../utils/isWorkerTypeNameValid';
-import Link from '../../utils/Link';
 import {
   WorkerManagerWorkerPoolSummary,
   WorkerManagerWorkerPoolErrorStats,
@@ -90,9 +87,6 @@ import SpeedDial from '../SpeedDial';
   },
   ownerEmailListItem: {
     display: 'block',
-  },
-  metadata: {
-    marginRight: theme.spacing(1),
   },
   overviewList: {
     alignItems: 'center',
@@ -159,9 +153,6 @@ import SpeedDial from '../SpeedDial';
     '&:hover': {
       backgroundColor: red[600],
     },
-  },
-  extraLinks: {
-    marginLeft: theme.spacing(3),
   },
 }))
 export default class WMWorkerPoolEditor extends Component {
@@ -501,26 +492,6 @@ export default class WMWorkerPoolEditor extends Component {
                 }
               )}
             </Paper>
-            <div className={classes.extraLinks}>
-              <Chip
-                size="medium"
-                className={classes.metadata}
-                icon={<WorkerIcon />}
-                label="Workers (Queue View)"
-                component={Link}
-                clickable
-                to={workerTypeUrl}
-              />
-              <Chip
-                size="medium"
-                className={classes.metadata}
-                icon={<WorkerIcon />}
-                label="Workers (Worker Manager View)"
-                component={Link}
-                clickable
-                to={`${workerPoolUrl}/workers`}
-              />
-            </div>
           </Fragment>
         )}
         <List>

--- a/ui/src/components/WorkersNavbar/index.jsx
+++ b/ui/src/components/WorkersNavbar/index.jsx
@@ -1,0 +1,163 @@
+import React, { Component } from 'react';
+import { string, bool } from 'prop-types';
+import { Chip } from '@material-ui/core';
+import { withStyles } from '@material-ui/core/styles';
+import WorkerIcon from 'mdi-react/WorkerIcon';
+import ProgressClockIcon from 'mdi-react/ProgressClockIcon';
+import HourglassIcon from 'mdi-react/HourglassIcon';
+import HexagonSlice4 from 'mdi-react/HexagonSlice4Icon';
+import Link from '../../utils/Link';
+import { splitWorkerPoolId } from '../../utils/workerPool';
+
+@withStyles(theme => ({
+  navbar: {
+    display: 'flex',
+    flexWrap: 'wrap',
+    flex: 1,
+
+    [theme.breakpoints.down('sm')]: {
+      marginTop: theme.spacing(1),
+    },
+
+    '& .MuiChip-label': {
+      paddingRight: 6,
+      paddingLeft: 6,
+
+      color: theme.palette.text.secondary,
+
+      '&:hover': {
+        color: theme.palette.text.primary,
+      },
+
+      [theme.breakpoints.up('lg')]: {
+        paddingRight: 12,
+        paddingLeft: 12,
+      },
+    },
+  },
+  active: {
+    backgroundColor: theme.palette.secondary.main,
+    '& .MuiChip-label': {
+      color: theme.palette.common.white,
+    },
+  },
+}))
+export default class WorkersNavbar extends Component {
+  static propTypes = {
+    provisionerId: string,
+    workerType: string,
+    workerPoolId: string,
+    hasWorkerPool: bool,
+  };
+
+  static defaultProps = {
+    provisionerId: null,
+    workerType: null,
+    workerPoolId: null,
+    hasWorkerPool: false,
+  };
+
+  get workerPoolId() {
+    if (this.props.workerPoolId) {
+      return this.props.workerPoolId;
+    }
+
+    if (this.props.provisionerId && this.props.workerType) {
+      return `${this.props.provisionerId}/${this.props.workerType}`;
+    }
+
+    throw new Error(
+      'workerPoolId, provisionerId and workerType are all missing'
+    );
+  }
+
+  get workerType() {
+    if (this.props.workerType) {
+      return this.props.workerType;
+    }
+
+    if (this.props.workerPoolId) {
+      return splitWorkerPoolId(this.props.workerPoolId).workerType;
+    }
+
+    throw new Error('workerType and workerPoolId are both missing');
+  }
+
+  get provisionerId() {
+    if (this.props.provisionerId) {
+      return this.props.provisionerId;
+    }
+
+    if (this.props.workerPoolId) {
+      return splitWorkerPoolId(this.props.workerPoolId).provisionerId;
+    }
+
+    throw new Error('provisionerId and workerPoolId are both missing');
+  }
+
+  render() {
+    const { classes } = this.props;
+    const { workerPoolId, provisionerId, workerType } = this;
+    const workerTypeUrl = `/provisioners/${provisionerId}/worker-types/${workerType}`;
+    const workerPoolUrl = `/worker-manager/${encodeURIComponent(workerPoolId)}`;
+    const items = [
+      {
+        icon: WorkerIcon,
+        label: 'Queue Workers',
+        to: workerTypeUrl,
+        hint: 'Show workers as seen by queue',
+      },
+      {
+        icon: WorkerIcon,
+        label: 'W-M Workers',
+        to: `${workerPoolUrl}/workers`,
+        hint: 'Show workers as seen by worker manager',
+      },
+      {
+        icon: HourglassIcon,
+        label: 'Pending Tasks',
+        to: `/provisioners/${provisionerId}/worker-types/${workerType}/pending-tasks`,
+        hint: 'Show pending tasks',
+      },
+      {
+        icon: ProgressClockIcon,
+        label: 'Claimed Tasks',
+        to: `/provisioners/${provisionerId}/worker-types/${workerType}/claimed-tasks`,
+        hint: 'Show claimed tasks',
+      },
+      {
+        icon: HexagonSlice4,
+        label: 'Worker Pool',
+        to: `/worker-manager/${encodeURIComponent(workerPoolId)}`,
+        hint: 'Show worker pool definition',
+      },
+    ];
+
+    if (!this.props.hasWorkerPool) {
+      // worker pool definition and worker-manager view would be empty otherwise
+      items.pop();
+      items.splice(1, 1);
+    }
+
+    return (
+      <div className={classes.navbar}>
+        {items.map(item => (
+          <Chip
+            key={item.to}
+            size="medium"
+            icon={<item.icon />}
+            label={item.label}
+            title={item.hint}
+            component={Link}
+            color="primary"
+            nav
+            activeClassName={classes.active}
+            isActive={() => window.location.pathname === item.to}
+            clickable
+            to={item.to}
+          />
+        ))}
+      </div>
+    );
+  }
+}

--- a/ui/src/views/Provisioners/ClaimedTasks/claimedTasks.graphql
+++ b/ui/src/views/Provisioners/ClaimedTasks/claimedTasks.graphql
@@ -30,4 +30,8 @@ query WorkerPoolClaimedTasks($taskQueueId: String!, $connection: PageConnection)
       }
     }
   }
+
+  WorkerPool(workerPoolId: $taskQueueId) {
+    workerPoolId
+  }
 }

--- a/ui/src/views/Provisioners/ClaimedTasks/index.jsx
+++ b/ui/src/views/Provisioners/ClaimedTasks/index.jsx
@@ -1,10 +1,8 @@
 import React, { Component } from 'react';
 import { graphql } from 'react-apollo';
 import dotProp from 'dot-prop-immutable';
-import { TableRow, TableCell, Chip, Box, Typography } from '@material-ui/core';
+import { TableRow, TableCell, Box, Typography } from '@material-ui/core';
 import LinkIcon from 'mdi-react/LinkIcon';
-import HourglassIcon from 'mdi-react/HourglassIcon';
-import WorkerIcon from 'mdi-react/WorkerIcon';
 import Spinner from '../../../components/Spinner';
 import Dashboard from '../../../components/Dashboard';
 import { VIEW_WORKER_POOL_PENDING_TASKS_PAGE_SIZE } from '../../../utils/constants';
@@ -15,11 +13,16 @@ import TableCellItem from '../../../components/TableCellItem';
 import DateDistance from '../../../components/DateDistance';
 import Breadcrumbs from '../../../components/Breadcrumbs';
 import ErrorPanel from '../../../components/ErrorPanel';
+import { joinWorkerPoolId } from '../../../utils/workerPool';
+import WorkersNavbar from '../../../components/WorkersNavbar';
 
 @graphql(claimedTasks, {
   options: props => ({
     variables: {
-      taskQueueId: `${props.match.params.provisionerId}/${props.match.params.workerType}`,
+      taskQueueId: joinWorkerPoolId(
+        props.match.params.provisionerId,
+        props.match.params.workerType
+      ),
       connection: {
         limit: VIEW_WORKER_POOL_PENDING_TASKS_PAGE_SIZE,
       },
@@ -91,7 +94,7 @@ export default class WMViewClaimedTasks extends Component {
 
   render() {
     const {
-      data: { loading, error, listClaimedTasks },
+      data: { loading, error, listClaimedTasks, WorkerPool },
     } = this.props;
     const { provisionerId, workerType } = this.props.match.params;
 
@@ -118,29 +121,12 @@ export default class WMViewClaimedTasks extends Component {
                 to={`/provisioners/${provisionerId}/worker-types/${workerType}`}>
                 <Typography variant="body2">{workerType}</Typography>
               </Link>
-              <Typography variant="body2" color="textSecondary">
-                Claimed Tasks
-              </Typography>
+              <WorkersNavbar
+                provisionerId={provisionerId}
+                workerType={workerType}
+                hasWorkerPool={!!WorkerPool?.workerPoolId}
+              />
             </Breadcrumbs>
-          </div>
-          <div>
-            <Chip
-              size="medium"
-              icon={<HourglassIcon />}
-              label="View Pending Tasks"
-              component={Link}
-              clickable
-              to={`${this.workersLink}/pending-tasks`}
-              style={{ marginRight: 4 }}
-            />
-            <Chip
-              size="medium"
-              icon={<WorkerIcon />}
-              label="Workers (Queue View)"
-              component={Link}
-              clickable
-              to={this.workersLink}
-            />
           </div>
         </Box>
         {loading && <Spinner loading />}

--- a/ui/src/views/Provisioners/PendingTasks/index.jsx
+++ b/ui/src/views/Provisioners/PendingTasks/index.jsx
@@ -1,10 +1,8 @@
 import React, { Component } from 'react';
 import { graphql } from 'react-apollo';
 import dotProp from 'dot-prop-immutable';
-import { TableRow, TableCell, Chip, Box, Typography } from '@material-ui/core';
+import { TableRow, TableCell, Box, Typography } from '@material-ui/core';
 import LinkIcon from 'mdi-react/LinkIcon';
-import WorkerIcon from 'mdi-react/WorkerIcon';
-import ProgressClockIcon from 'mdi-react/ProgressClockIcon';
 import Spinner from '../../../components/Spinner';
 import Dashboard from '../../../components/Dashboard';
 import { VIEW_WORKER_POOL_PENDING_TASKS_PAGE_SIZE } from '../../../utils/constants';
@@ -16,11 +14,16 @@ import DateDistance from '../../../components/DateDistance';
 import Label from '../../../components/Label';
 import Breadcrumbs from '../../../components/Breadcrumbs';
 import ErrorPanel from '../../../components/ErrorPanel';
+import { joinWorkerPoolId } from '../../../utils/workerPool';
+import WorkersNavbar from '../../../components/WorkersNavbar';
 
 @graphql(pendingTasks, {
   options: props => ({
     variables: {
-      taskQueueId: `${props.match.params.provisionerId}/${props.match.params.workerType}`,
+      taskQueueId: joinWorkerPoolId(
+        props.match.params.provisionerId,
+        props.match.params.workerType
+      ),
       connection: {
         limit: VIEW_WORKER_POOL_PENDING_TASKS_PAGE_SIZE,
       },
@@ -88,7 +91,7 @@ export default class WMViewPendingTasks extends Component {
 
   render() {
     const {
-      data: { loading, error, listPendingTasks },
+      data: { loading, error, listPendingTasks, WorkerPool },
     } = this.props;
     const { provisionerId, workerType } = this.props.match.params;
 
@@ -115,29 +118,12 @@ export default class WMViewPendingTasks extends Component {
                 to={`/provisioners/${provisionerId}/worker-types/${workerType}`}>
                 <Typography variant="body2">{workerType}</Typography>
               </Link>
-              <Typography variant="body2" color="textSecondary">
-                Pending Tasks
-              </Typography>
+              <WorkersNavbar
+                provisionerId={provisionerId}
+                workerType={workerType}
+                hasWorkerPool={!!WorkerPool?.workerPoolId}
+              />
             </Breadcrumbs>
-          </div>
-          <div>
-            <Chip
-              size="medium"
-              icon={<ProgressClockIcon />}
-              label="View Claimed Tasks"
-              component={Link}
-              clickable
-              to={`${this.workersLink}/claimed-tasks`}
-              style={{ marginRight: 4 }}
-            />
-            <Chip
-              size="medium"
-              icon={<WorkerIcon />}
-              label="Workers (Queue View)"
-              component={Link}
-              clickable
-              to={this.workersLink}
-            />
           </div>
         </Box>
 

--- a/ui/src/views/Provisioners/PendingTasks/pendingTasks.graphql
+++ b/ui/src/views/Provisioners/PendingTasks/pendingTasks.graphql
@@ -28,4 +28,8 @@ query WorkerPoolPendingTasks($taskQueueId: String!, $connection: PageConnection)
       }
     }
   }
+
+  WorkerPool(workerPoolId: $taskQueueId) {
+    workerPoolId
+  }
 }

--- a/ui/src/views/Provisioners/ViewWorkers/index.jsx
+++ b/ui/src/views/Provisioners/ViewWorkers/index.jsx
@@ -7,10 +7,7 @@ import Typography from '@material-ui/core/Typography';
 import { withStyles } from '@material-ui/core/styles';
 import MenuItem from '@material-ui/core/MenuItem';
 import HammerIcon from 'mdi-react/HammerIcon';
-import ProgressClockIcon from 'mdi-react/ProgressClockIcon';
-import HourglassIcon from 'mdi-react/HourglassIcon';
-import HexagonSlice4 from 'mdi-react/HexagonSlice4Icon';
-import { Box, Chip } from '@material-ui/core';
+import { Box } from '@material-ui/core';
 import Spinner from '../../../components/Spinner';
 import TextField from '../../../components/TextField';
 import SpeedDial from '../../../components/SpeedDial';
@@ -25,6 +22,7 @@ import ErrorPanel from '../../../components/ErrorPanel';
 import Breadcrumbs from '../../../components/Breadcrumbs';
 import Link from '../../../utils/Link';
 import workersQuery from './workers.graphql';
+import WorkersNavbar from '../../../components/WorkersNavbar';
 
 const STATES = {
   requested: 'requested',
@@ -240,7 +238,7 @@ export default class ViewWorkers extends Component {
           {shouldIgnoreGraphqlError && this.state.error && (
             <ErrorPanel fixed error={this.state.error} />
           )}
-          <div className={classes.bar}>
+          <Box className={classes.bar}>
             <Breadcrumbs classes={{ paper: classes.breadcrumbsPaper }}>
               <Link to="/provisioners">
                 <Typography variant="body2" className={classes.link}>
@@ -255,38 +253,12 @@ export default class ViewWorkers extends Component {
               <Typography variant="body2" color="textSecondary">
                 {`${params.workerType}`}
               </Typography>
-            </Breadcrumbs>
-
-            {WorkerPool && (
-              <Chip
-                size="medium"
-                icon={<HexagonSlice4 />}
-                label="Worker Pool"
-                component={Link}
-                clickable
-                to={`/worker-manager/${encodeURIComponent(
-                  WorkerPool.workerPoolId
-                )}`}
+              <WorkersNavbar
+                provisionerId={params.provisionerId}
+                workerType={params.workerType}
+                hasWorkerPool={!!WorkerPool?.workerPoolId}
               />
-            )}
-
-            <Chip
-              size="medium"
-              icon={<HourglassIcon />}
-              label="View Pending Tasks"
-              component={Link}
-              clickable
-              to={`/provisioners/${params.provisionerId}/worker-types/${params.workerType}/pending-tasks`}
-            />
-
-            <Chip
-              size="medium"
-              icon={<ProgressClockIcon />}
-              label="View Claimed Tasks"
-              component={Link}
-              clickable
-              to={`/provisioners/${params.provisionerId}/worker-types/${params.workerType}/claimed-tasks`}
-            />
+            </Breadcrumbs>
 
             <Box marginTop={-2}>
               <TextField
@@ -306,7 +278,7 @@ export default class ViewWorkers extends Component {
                 <MenuItem value="stopped">Stopped</MenuItem>
               </TextField>
             </Box>
-          </div>
+          </Box>
           <br />
           <WorkersTable
             workersConnection={workers}

--- a/ui/src/views/WorkerManager/WMEditWorkerPool/index.jsx
+++ b/ui/src/views/WorkerManager/WMEditWorkerPool/index.jsx
@@ -13,6 +13,8 @@ import WMWorkerPoolEditor from '../../../components/WMWorkerPoolEditor';
 import ErrorPanel from '../../../components/ErrorPanel';
 import Breadcrumbs from '../../../components/Breadcrumbs';
 import Link from '../../../utils/Link';
+import { splitWorkerPoolId } from '../../../utils/workerPool';
+import WorkersNavbar from '../../../components/WorkersNavbar';
 
 @withApollo
 @graphql(providersQuery, {
@@ -119,6 +121,8 @@ export default class WMEditWorkerPool extends Component {
       (!isNewWorkerPool && (!data || !data.WorkerPool || data.loading));
     const error =
       (providersData && providersData.error) || (data && data.error);
+    const workerPoolId = decodeURIComponent(match.params.workerPoolId);
+    const { provisionerId, workerType } = splitWorkerPoolId(workerPoolId);
 
     return (
       <Dashboard
@@ -128,15 +132,29 @@ export default class WMEditWorkerPool extends Component {
             ? 'Create Worker Pool'
             : `Worker Pool "${decodeURIComponent(match.params.workerPoolId)}"`
         }>
-        <Box marginBottom={2}>
-          <Breadcrumbs>
-            <Link to="/worker-manager">
-              <Typography variant="body2">Worker Manager</Typography>
-            </Link>
-            <Typography variant="body2" color="textSecondary">
-              {decodeURIComponent(match.params.workerPoolId)}
-            </Typography>
-          </Breadcrumbs>
+        <Box
+          marginBottom={2}
+          sx={{
+            display: 'flex',
+            width: '100%',
+            flexWrap: 'wrap',
+            alignItems: 'center',
+          }}>
+          <div style={{ flexGrow: 1, marginRight: 8 }}>
+            <Breadcrumbs style={{ flexGrow: 1, marginRight: 8 }}>
+              <Link to="/worker-manager">
+                <Typography variant="body2">Worker Manager</Typography>
+              </Link>
+              <Typography variant="body2" color="textSecondary">
+                {decodeURIComponent(match.params.workerPoolId)}
+              </Typography>
+              <WorkersNavbar
+                provisionerId={provisionerId}
+                workerType={workerType}
+                hasWorkerPool
+              />
+            </Breadcrumbs>
+          </div>
         </Box>
 
         <ErrorPanel fixed error={error} />

--- a/ui/src/views/WorkerManager/WMViewWorkers/index.jsx
+++ b/ui/src/views/WorkerManager/WMViewWorkers/index.jsx
@@ -4,7 +4,13 @@ import { withRouter } from 'react-router-dom';
 import dotProp from 'dot-prop-immutable';
 import Tab from '@material-ui/core/Tab/Tab';
 import Tabs from '@material-ui/core/Tabs/Tabs';
-import { TableCell, TableRow, Tooltip, Typography } from '@material-ui/core';
+import {
+  TableCell,
+  TableRow,
+  Tooltip,
+  Typography,
+  Box,
+} from '@material-ui/core';
 import LinkIcon from 'mdi-react/LinkIcon';
 import Spinner from '../../../components/Spinner';
 import Dashboard from '../../../components/Dashboard';
@@ -17,6 +23,7 @@ import { VIEW_WORKERS_PAGE_SIZE } from '../../../utils/constants';
 import Label from '../../../components/Label';
 import DateDistance from '../../../components/DateDistance';
 import Breadcrumbs from '../../../components/Breadcrumbs';
+import WorkersNavbar from '../../../components/WorkersNavbar';
 
 const stateToLabel = {
   requested: 'default',
@@ -173,21 +180,30 @@ export default class WMViewWorkers extends Component {
         title={`Workers for "${decodeURIComponent(params.workerPoolId)}"`}>
         <ErrorPanel fixed error={this.state.error || error} />
 
-        <div>
-          <Breadcrumbs>
-            <Link to="/worker-manager">
-              <Typography variant="body2">Worker Manager</Typography>
-            </Link>
-            <Link to={`/worker-manager/${params.workerPoolId}`}>
-              <Typography variant="body2">
-                {decodeURIComponent(params.workerPoolId)}
-              </Typography>
-            </Link>
-            <Typography variant="body2" color="textSecondary">
-              Workers
-            </Typography>
-          </Breadcrumbs>
-        </div>
+        <Box
+          sx={{
+            display: 'flex',
+            flexWrap: 'wrap',
+            alignItems: 'center',
+            width: '100%',
+          }}>
+          <div style={{ flexGrow: 1, marginRight: 8 }}>
+            <Breadcrumbs>
+              <Link to="/worker-manager">
+                <Typography variant="body2">Worker Manager</Typography>
+              </Link>
+              <Link to={`/worker-manager/${params.workerPoolId}`}>
+                <Typography variant="body2">
+                  {decodeURIComponent(params.workerPoolId)}
+                </Typography>
+              </Link>
+              <WorkersNavbar
+                workerPoolId={decodeURIComponent(params.workerPoolId)}
+                hasWorkerPool
+              />
+            </Breadcrumbs>
+          </div>
+        </Box>
 
         <Tabs value={currentTab} onChange={this.handleTabChange}>
           {this.tabs.map(tab => (


### PR DESCRIPTION
This is a refactoring of navigation components.
Worker manager pages and worker pages use same component

<img width="1451" alt="image" src="https://github.com/taskcluster/taskcluster/assets/83861/e6abfddc-cb11-4fa1-92d2-a58af67de962">

<img width="1453" alt="image" src="https://github.com/taskcluster/taskcluster/assets/83861/dc80fab9-0437-493f-84e8-6411b8763dec">

<img width="1453" alt="image" src="https://github.com/taskcluster/taskcluster/assets/83861/8f12617f-c15d-49dd-bdf3-7e996eca46f2">

<img width="1451" alt="image" src="https://github.com/taskcluster/taskcluster/assets/83861/85df45f6-0686-46ac-afdc-287ecca77ac5">

<img width="1441" alt="image" src="https://github.com/taskcluster/taskcluster/assets/83861/b3d875cd-7462-4149-b9af-a83b434a558a">

<img width="1776" alt="image" src="https://github.com/taskcluster/taskcluster/assets/83861/ebe168a3-c2b5-4edb-bbfb-a6b76772ec61">
