### PR TITLE
feat(ui): Fixes broken "Create Worker Pool" page

### DIFF
--- a/changelog/issue-7025.md
+++ b/changelog/issue-7025.md
@@ -1,0 +1,7 @@
+audience: users
+level: patch
+reference: issue 7025
+---
+
+Fixes JavaScript error in "Create Worker Pool" page that was introduced in the last release.
+Adds link to "Errors" in workers navigation bar.

--- a/ui/src/components/WMWorkerPoolEditor/index.jsx
+++ b/ui/src/components/WMWorkerPoolEditor/index.jsx
@@ -169,7 +169,7 @@ export default class WMWorkerPoolEditor extends Component {
 
   static propTypes = {
     workerPool: WorkerManagerWorkerPoolSummary.isRequired,
-    errorStats: WorkerManagerWorkerPoolErrorStats.isRequired,
+    errorStats: WorkerManagerWorkerPoolErrorStats,
     providers: providersArray.isRequired,
     saveRequest: func.isRequired,
     isNewWorkerPool: bool,

--- a/ui/src/components/WorkersNavbar/index.jsx
+++ b/ui/src/components/WorkersNavbar/index.jsx
@@ -6,6 +6,7 @@ import WorkerIcon from 'mdi-react/WorkerIcon';
 import ProgressClockIcon from 'mdi-react/ProgressClockIcon';
 import HourglassIcon from 'mdi-react/HourglassIcon';
 import HexagonSlice4 from 'mdi-react/HexagonSlice4Icon';
+import MessageAlertIcon from 'mdi-react/MessageAlertIcon';
 import Link from '../../utils/Link';
 import { splitWorkerPoolId } from '../../utils/workerPool';
 
@@ -17,6 +18,16 @@ import { splitWorkerPoolId } from '../../utils/workerPool';
 
     [theme.breakpoints.down('sm')]: {
       marginTop: theme.spacing(1),
+    },
+
+    '& .MuiChip-root': {
+      paddingLeft: theme.spacing(0.5),
+      paddingRight: theme.spacing(0.5),
+
+      [theme.breakpoints.up('lg')]: {
+        paddingLeft: theme.spacing(1),
+        paddingRight: theme.spacing(1),
+      },
     },
 
     '& .MuiChip-label': {
@@ -131,10 +142,17 @@ export default class WorkersNavbar extends Component {
         to: `/worker-manager/${encodeURIComponent(workerPoolId)}`,
         hint: 'Show worker pool definition',
       },
+      {
+        icon: MessageAlertIcon,
+        label: 'Errors',
+        to: `/worker-manager/${encodeURIComponent(workerPoolId)}/errors`,
+        hint: 'Worker-manager errors',
+      },
     ];
 
     if (!this.props.hasWorkerPool) {
       // worker pool definition and worker-manager view would be empty otherwise
+      items.pop();
       items.pop();
       items.splice(1, 1);
     }

--- a/ui/src/views/WorkerManager/WMEditWorkerPool/index.jsx
+++ b/ui/src/views/WorkerManager/WMEditWorkerPool/index.jsx
@@ -25,7 +25,7 @@ import WorkersNavbar from '../../../components/WorkersNavbar';
   options: ({ match: { params } }) => ({
     fetchPolicy: 'network-only',
     variables: {
-      workerPoolId: decodeURIComponent(params.workerPoolId),
+      workerPoolId: decodeURIComponent(params?.workerPoolId),
     },
   }),
 })
@@ -121,8 +121,7 @@ export default class WMEditWorkerPool extends Component {
       (!isNewWorkerPool && (!data || !data.WorkerPool || data.loading));
     const error =
       (providersData && providersData.error) || (data && data.error);
-    const workerPoolId = decodeURIComponent(match.params.workerPoolId);
-    const { provisionerId, workerType } = splitWorkerPoolId(workerPoolId);
+    const workerPoolId = decodeURIComponent(match.params.workerPoolId ?? '');
 
     return (
       <Dashboard
@@ -130,7 +129,7 @@ export default class WMEditWorkerPool extends Component {
         title={
           isNewWorkerPool
             ? 'Create Worker Pool'
-            : `Worker Pool "${decodeURIComponent(match.params.workerPoolId)}"`
+            : `Worker Pool "${workerPoolId}"`
         }>
         <Box
           marginBottom={2}
@@ -146,13 +145,15 @@ export default class WMEditWorkerPool extends Component {
                 <Typography variant="body2">Worker Manager</Typography>
               </Link>
               <Typography variant="body2" color="textSecondary">
-                {decodeURIComponent(match.params.workerPoolId)}
+                {workerPoolId}
               </Typography>
-              <WorkersNavbar
-                provisionerId={provisionerId}
-                workerType={workerType}
-                hasWorkerPool
-              />
+              {workerPoolId && (
+                <WorkersNavbar
+                  provisionerId={splitWorkerPoolId(workerPoolId).provisionerId}
+                  workerType={splitWorkerPoolId(workerPoolId).workerType}
+                  hasWorkerPool
+                />
+              )}
             </Breadcrumbs>
           </div>
         </Box>

--- a/ui/src/views/WorkerManager/WMViewErrors/index.jsx
+++ b/ui/src/views/WorkerManager/WMViewErrors/index.jsx
@@ -12,6 +12,7 @@ import Search from '../../../components/Search';
 import WorkerManagerErrorsSummary from '../../../components/WMErrorsSummary';
 import Breadcrumbs from '../../../components/Breadcrumbs';
 import Link from '../../../utils/Link';
+import WorkersNavbar from '../../../components/WorkersNavbar';
 
 @graphql(errorsQuery, {
   options: props => ({
@@ -96,9 +97,11 @@ export default class WMViewErrors extends Component {
                 {decodeURIComponent(workerPoolId)}
               </Typography>
             </Link>
-            <Typography variant="body2" color="textSecondary">
-              Errors
-            </Typography>
+
+            <WorkersNavbar
+              workerPoolId={decodeURIComponent(workerPoolId)}
+              hasWorkerPool
+            />
           </Breadcrumbs>
         </div>
 


### PR DESCRIPTION
1. Fixes issue introduced in previous release where worker pool info was requested with graphql query.
One of the parameters was passed as `encodeURIComponent(workerPoolId)` which becomes string `"undefined"` when its value is `undefined`
2. Adds "Errors" link to the workers/worker-manager navigation bar for consistency and easier navigation between related pages

Fixes #7025
