### PR TITLE
pg_dump used inside docker if versions mismatch

### DIFF
--- a/changelog/issue-6567.md
+++ b/changelog/issue-6567.md
@@ -1,0 +1,6 @@
+audience: developers
+level: patch
+reference: issue 6567
+---
+
+`yarn generate` commands will attempt to run `pg_dump` inside the docker container if local binary is missing or its version is different from the server version.

--- a/dev-docs/development-process.md
+++ b/dev-docs/development-process.md
@@ -34,6 +34,9 @@ The easiest and best way to do this is to use docker, but if you prefer you can 
 *NOTE* the test suites repeatedly drop the `public` schema and re-create it, effectively deleting all data in the database.
 Do not run these tests against a database instance that contains any useful data!
 
+`pg_dump` is being used to detect schema changes. If it is not present on your system,
+`yarn generate` might attempt to run this inside the `postgres` docker container, which is one of the `docker-compose.yml` services.
+
 To start the server using Docker:
 
 ```shell


### PR DESCRIPTION
This adds `pg_dump` in development process documentation and fixes some of the problems around `yarn generate`.

Generate command expects database to be running so that its schema could be checked with the help of `pg_dump`. 
Sometimes it might result in local `pg_dump` version being different from postgres's server version, in such case `pg_dump` throws an error. 
Sometimes you might not have `pg_dump` installed at all.

Plus local development environment is being built around `docker compose` which always run the required version of `postgres` db.

This fix is trivial and will first run native `pg_dump` and in case of any error will attempt to run it with `docker compose`. If both fail, the generation process will also fail.


Fixes #6567
Fixes #6079
