### PR TITLE
feat(ui): Show errors only when no worker info exists

### DIFF
--- a/changelog/DJWkVnx1QnCXp6E1yLgKlg.md
+++ b/changelog/DJWkVnx1QnCXp6E1yLgKlg.md
@@ -1,0 +1,5 @@
+audience: users
+level: patch
+---
+
+Fixes UI issue in worker view where error was shown despite worker being found.

--- a/ui/src/views/Provisioners/ViewWorker/index.jsx
+++ b/ui/src/views/Provisioners/ViewWorker/index.jsx
@@ -436,8 +436,9 @@ export default class ViewWorker extends Component {
     const {
       data: { loading, error, worker, WorkerManagerWorker },
     } = this.props;
-    // we hide graphql errors if we have worker-manager worker data
-    const graphqlError = !WorkerManagerWorker && this.getError(error);
+    // we hide graphql errors if we have any worker data
+    const graphqlError =
+      !WorkerManagerWorker && !worker && this.getError(error);
 
     return (
       <Dashboard title="Worker">


### PR DESCRIPTION
Since we might have queue only view, worker-manager only view, both views or none, we only want to show errors, when there were zero records found for both queue and worker-manager
