### PR TITLE
Remove explit build constraints that are already implied by filename

### DIFF
--- a/changelog/Ke9Borz8TjuPzMIJu_X9TA.md
+++ b/changelog/Ke9Borz8TjuPzMIJu_X9TA.md
@@ -1,0 +1,3 @@
+audience: general
+level: silent
+---

--- a/workers/generic-worker/loopback_audio_darwin.go
+++ b/workers/generic-worker/loopback_audio_darwin.go
@@ -1,5 +1,3 @@
-//go:build darwin
-
 package main
 
 import "fmt"

--- a/workers/generic-worker/loopback_audio_darwin_test.go
+++ b/workers/generic-worker/loopback_audio_darwin_test.go
@@ -1,5 +1,3 @@
-//go:build darwin
-
 package main
 
 import (

--- a/workers/generic-worker/loopback_audio_freebsd.go
+++ b/workers/generic-worker/loopback_audio_freebsd.go
@@ -1,5 +1,3 @@
-//go:build freebsd
-
 package main
 
 import "fmt"

--- a/workers/generic-worker/loopback_audio_freebsd_test.go
+++ b/workers/generic-worker/loopback_audio_freebsd_test.go
@@ -1,5 +1,3 @@
-//go:build freebsd
-
 package main
 
 import (

--- a/workers/generic-worker/loopback_audio_linux.go
+++ b/workers/generic-worker/loopback_audio_linux.go
@@ -1,5 +1,3 @@
-//go:build linux
-
 package main
 
 import (

--- a/workers/generic-worker/loopback_audio_linux_test.go
+++ b/workers/generic-worker/loopback_audio_linux_test.go
@@ -1,5 +1,3 @@
-//go:build linux
-
 package main
 
 import (

--- a/workers/generic-worker/loopback_video_darwin.go
+++ b/workers/generic-worker/loopback_video_darwin.go
@@ -1,5 +1,3 @@
-//go:build darwin
-
 package main
 
 import (

--- a/workers/generic-worker/loopback_video_darwin_test.go
+++ b/workers/generic-worker/loopback_video_darwin_test.go
@@ -1,5 +1,3 @@
-//go:build darwin
-
 package main
 
 import (

--- a/workers/generic-worker/loopback_video_freebsd.go
+++ b/workers/generic-worker/loopback_video_freebsd.go
@@ -1,5 +1,3 @@
-//go:build freebsd
-
 package main
 
 import (

--- a/workers/generic-worker/loopback_video_freebsd_test.go
+++ b/workers/generic-worker/loopback_video_freebsd_test.go
@@ -1,5 +1,3 @@
-//go:build freebsd
-
 package main
 
 import (

--- a/workers/generic-worker/loopback_video_linux.go
+++ b/workers/generic-worker/loopback_video_linux.go
@@ -1,5 +1,3 @@
-//go:build linux
-
 package main
 
 import (

--- a/workers/generic-worker/loopback_video_linux_test.go
+++ b/workers/generic-worker/loopback_video_linux_test.go
@@ -1,5 +1,3 @@
-//go:build linux
-
 package main
 
 import (

--- a/workers/generic-worker/payload_darwin.go
+++ b/workers/generic-worker/payload_darwin.go
@@ -1,5 +1,3 @@
-//go:build darwin
-
 package main
 
 import "fmt"

--- a/workers/generic-worker/payload_freebsd.go
+++ b/workers/generic-worker/payload_freebsd.go
@@ -1,5 +1,3 @@
-//go:build freebsd
-
 package main
 
 import "fmt"

--- a/workers/generic-worker/payload_linux.go
+++ b/workers/generic-worker/payload_linux.go
@@ -1,5 +1,3 @@
-//go:build linux
-
 package main
 
 import (

--- a/workers/generic-worker/payload_windows.go
+++ b/workers/generic-worker/payload_windows.go
@@ -1,5 +1,3 @@
-//go:build windows
-
 package main
 
 import "fmt"


### PR DESCRIPTION
Looks like some unnecessary build constraints slipped in. Go already applies a platform build constraint if the platform is specified in the filename.