### PR TITLE
Fix pg_dump usage in yarn generate

### DIFF
--- a/changelog/V3z_1AjJTOeFS6wU-kzxYA.md
+++ b/changelog/V3z_1AjJTOeFS6wU-kzxYA.md
@@ -1,0 +1,3 @@
+audience: users
+level: silent
+---

--- a/infrastructure/tooling/src/utils/command.js
+++ b/infrastructure/tooling/src/utils/command.js
@@ -1,6 +1,9 @@
 import fs from 'fs';
+import { promisify } from 'util';
 import child_process from 'child_process';
 import { Transform } from 'stream';
+
+const execCommandNative = promisify(child_process.exec);
 
 /**
  * Run a command and display its output.
@@ -65,4 +68,14 @@ export const execCommand = async ({
     });
     cp.once('error', reject);
   });
+};
+
+export const checkExecutableExists = async (executable) => {
+  const command = process.platform === 'win32' ? 'where' : 'which';
+  try {
+    await execCommandNative(`${command} ${executable}`);
+    return true;
+  } catch (error) {
+    return false;
+  }
 };


### PR DESCRIPTION
Previous error handling wasn't sufficient as missing binary would be a fatal error and docker compose wouldn't even run.
New approach detects first if executable exists.
It also prefers to run pg_dump from the same docker container that db is running in. If there are any docker processes with postgres running, generator will execute pg_dump inside that container.

Also instead of only checking `docker compose`, it should also run if postgres is run as a  standalone container, as mentioned in docs.
