### PR TITLE
Azure CI worker pools no longer have -azure suffix

### DIFF
--- a/changelog/coke9jDbTnSkucqYxJXSTg.md
+++ b/changelog/coke9jDbTnSkucqYxJXSTg.md
@@ -1,0 +1,3 @@
+audience: general
+level: silent
+---

--- a/taskcluster/config.yml
+++ b/taskcluster/config.yml
@@ -31,13 +31,13 @@ workers:
       os: macosx
       implementation: generic-worker
       worker-type: gw-ci-macos-13
-    gw-windows-2022-azure:
+    gw-windows-2022:
       provisioner: proj-taskcluster
       os: windows
       implementation: generic-worker
-      worker-type: gw-windows-2022-azure
-    gw-ci-windows-2022-azure:
+      worker-type: gw-windows-2022
+    gw-ci-windows-2022:
       provisioner: proj-taskcluster
       os: windows
       implementation: generic-worker
-      worker-type: gw-ci-windows-2022-azure
+      worker-type: gw-ci-windows-2022

--- a/taskcluster/kinds/generic-worker/kind.yml
+++ b/taskcluster/kinds/generic-worker/kind.yml
@@ -23,7 +23,7 @@ task-defaults:
 tasks:
   windows-worker-runner:
     description: 'test worker-runner under windows as well'
-    worker-type: gw-windows-2022-azure
+    worker-type: gw-windows-2022
     worker:
       mounts:
         - content:
@@ -278,7 +278,7 @@ tasks:
     copy-command-from: build/test-multiuser-ubuntu-22.04-amd64
   build/test-multiuser-windows-server-2022-amd64:
     description: This builds and tests the amd64 version of generic-worker (multiuser engine) on Windows Server 2022
-    worker-type: gw-ci-windows-2022-azure
+    worker-type: gw-ci-windows-2022
     scopes:
       - generic-worker:cache:generic-worker-checkout
       - secrets:get:project/taskcluster/testing/generic-worker/ci-creds
@@ -377,7 +377,7 @@ tasks:
           )
   build/test-multiuser-current-user-windows-server-2022-amd64:
     description: This builds and tests the amd64 version of generic-worker (multiuser engine) on Windows Server 2022 as the current user
-    worker-type: gw-ci-windows-2022-azure
+    worker-type: gw-ci-windows-2022
     scopes:
       - generic-worker:cache:generic-worker-checkout
       - secrets:get:project/taskcluster/testing/generic-worker/ci-creds


### PR DESCRIPTION
See https://github.com/taskcluster/community-tc-config/pull/740 for context.