### PR TITLE
fix(notify): Ensure pulse routes use custom topics from routing key

### DIFF
--- a/changelog/Myg7o2toQHmLeZ3QCOGwug.md
+++ b/changelog/Myg7o2toQHmLeZ3QCOGwug.md
@@ -1,0 +1,6 @@
+audience: users
+level: patch
+---
+Tasks using `notify.pulse.<topic>.on-<event>` routes now send out messages
+using the specified topic. This means it's now possible to subscribe to
+specific topics.

--- a/clients/client-go/tcnotifyevents/tcnotifyevents.go
+++ b/clients/client-go/tcnotifyevents/tcnotifyevents.go
@@ -57,7 +57,7 @@ import (
 // See #notify
 type Notify struct {
 	RoutingKeyKind string `mwords:"*"`
-	Reserved       string `mwords:"#"`
+	Topic          string `mwords:"#"`
 }
 
 func (binding Notify) RoutingKey() string {

--- a/clients/client-py/taskcluster/generated/aio/notifyevents.py
+++ b/clients/client-py/taskcluster/generated/aio/notifyevents.py
@@ -40,7 +40,7 @@ class NotifyEvents(AsyncBaseClient):
 
          * routingKeyKind: Identifier for the routing-key kind. This is always `'primary'` for the formalized routing key. (required)
 
-         * reserved: Space reserved for future routing-key entries, you should always match this entry with `#`. As automatically done by our tooling, if not specified.
+         * topic: Custom topic. This is the <topic> portion of the `notify.pulse.<topic>.on-<event>` routes. (required)
         """
 
         ref = {
@@ -54,7 +54,7 @@ class NotifyEvents(AsyncBaseClient):
                 },
                 {
                     'multipleWords': True,
-                    'name': 'reserved',
+                    'name': 'topic',
                 },
             ],
             'schema': 'v1/notification-message.json#',

--- a/clients/client-py/taskcluster/generated/notifyevents.py
+++ b/clients/client-py/taskcluster/generated/notifyevents.py
@@ -40,7 +40,7 @@ class NotifyEvents(BaseClient):
 
          * routingKeyKind: Identifier for the routing-key kind. This is always `'primary'` for the formalized routing key. (required)
 
-         * reserved: Space reserved for future routing-key entries, you should always match this entry with `#`. As automatically done by our tooling, if not specified.
+         * topic: Custom topic. This is the <topic> portion of the `notify.pulse.<topic>.on-<event>` routes. (required)
         """
 
         ref = {
@@ -54,7 +54,7 @@ class NotifyEvents(BaseClient):
                 },
                 {
                     'multipleWords': True,
-                    'name': 'reserved',
+                    'name': 'topic',
                 },
             ],
             'schema': 'v1/notification-message.json#',

--- a/clients/client-web/src/clients/NotifyEvents.js
+++ b/clients/client-web/src/clients/NotifyEvents.js
@@ -20,7 +20,7 @@ export default class NotifyEvents extends Client {
   // when we notice a task is complete.
   /* eslint-enable max-len */
   notify(pattern) {
-    const entry = {"exchange":"notification","name":"notify","routingKey":[{"constant":"primary","multipleWords":false,"name":"routingKeyKind","required":true},{"multipleWords":true,"name":"reserved","required":false}],"schema":"v1/notification-message.json#","type":"topic-exchange"}; // eslint-disable-line
+    const entry = {"exchange":"notification","name":"notify","routingKey":[{"constant":"primary","multipleWords":false,"name":"routingKeyKind","required":true},{"multipleWords":true,"name":"topic","required":true}],"schema":"v1/notification-message.json#","type":"topic-exchange"}; // eslint-disable-line
 
     return this.normalizePattern(entry, pattern);
   }

--- a/clients/client/src/apis.js
+++ b/clients/client/src/apis.js
@@ -1899,9 +1899,9 @@ export default {
             },
             {
               "multipleWords": true,
-              "name": "reserved",
-              "required": false,
-              "summary": "Space reserved for future routing-key entries, you should always match this entry with `#`. As automatically done by our tooling, if not specified."
+              "name": "topic",
+              "required": true,
+              "summary": "Custom topic. This is the <topic> portion of the `notify.pulse.<topic>.on-<event>` routes."
             }
           ],
           "schema": "v1/notification-message.json#",

--- a/generated/references.json
+++ b/generated/references.json
@@ -18755,9 +18755,9 @@
             },
             {
               "multipleWords": true,
-              "name": "reserved",
-              "required": false,
-              "summary": "Space reserved for future routing-key entries, you should always match this entry with `#`. As automatically done by our tooling, if not specified."
+              "name": "topic",
+              "required": true,
+              "summary": "Custom topic. This is the <topic> portion of the `notify.pulse.<topic>.on-<event>` routes."
             }
           ],
           "schema": "v1/notification-message.json#",

--- a/services/notify/src/exchanges.js
+++ b/services/notify/src/exchanges.js
@@ -28,12 +28,12 @@ const buildCommonRoutingKey = function(options) {
       constant: 'primary',
       required: true,
     }, {
-      name: 'reserved',
-      summary: 'Space reserved for future routing-key entries, you ' +
-                        'should always match this entry with `#`. As ' +
-                        'automatically done by our tooling, if not specified.',
+      name: 'topic',
+      summary: 'Custom topic. This is the <topic> portion of the ' +
+                        '`notify.pulse.<topic>.on-<event>` routes.',
+      maxSize: 100,
       multipleWords: true,
-      maxSize: 1,
+      required: true,
     },
   ];
 };
@@ -46,7 +46,9 @@ const commonMessageBuilder = function(message) {
 
 /** Build a message from message */
 const commonRoutingKeyBuilder = function(message, routing) {
-  return {};
+  return {
+    topic: routing[0],
+  };
 };
 
 /** Build list of routing keys to CC */


### PR DESCRIPTION
The notify service supports sending notifications out through a pulse exchange. Tasks can make use of this via routes like:

    notify.pulse.some.custom.topic.on-resolved

However, the notify service currently does not use `some.custom.topic` in the routing key it emits. This results in *all* messages using the same routing key, which ends up being `primary._`.

This defeats the purpose of using the notify service's pulse exchange, as consumers need to manually sift through *all* messages sent out over this exchange.

<!-- Did you remember to add a changelog snippet? See
     https://github.com/taskcluster/taskcluster/blob/main/dev-docs/best-practices/changelog.md

     If this is related to a Bugzilla bug, please begin your title with [Bug XXXXX]
     and update this link.  Otherwise, just remove it from your PR comment.  -->