### PR TITLE
`yarn generate` uses any postgres container to run pg_dump

### DIFF
--- a/changelog/YrTfUOV0SKiBQXopdCv9aA.md
+++ b/changelog/YrTfUOV0SKiBQXopdCv9aA.md
@@ -1,0 +1,3 @@
+audience: developers
+level: silent
+---

--- a/infrastructure/tooling/src/generate/generators/db-schema-dump.js
+++ b/infrastructure/tooling/src/generate/generators/db-schema-dump.js
@@ -45,7 +45,7 @@ export const tasks = [{
       // check if docker process is running
       const dockerProcessId = await execCommand({
         dir: REPO_ROOT,
-        command: ['docker', 'ps', '-q', '--filter', 'name=postgres'],
+        command: ['docker', 'ps', '-q', '--filter', 'ancestor=postgres:15'],
         keepAllOutput: true,
         utils,
       });


### PR DESCRIPTION
If postgres was started without the compose, it might have random name. Better to filter by image name


