### PR TITLE
Worker Runner: Use IMDSv2 in EC2 instead of IMDSv1

### DIFF
--- a/changelog/issue-7076.md
+++ b/changelog/issue-7076.md
@@ -1,0 +1,5 @@
+audience: worker-deployers
+level: minor
+reference: issue 7076
+---
+Worker Runner now uses IMDSv2 instead of IMDSv1 in EC2. IMDSv1 is being phased out by Amazon.

--- a/tools/worker-runner/provider/aws/metadata.go
+++ b/tools/worker-runner/provider/aws/metadata.go
@@ -3,11 +3,19 @@ package aws
 import (
 	"encoding/json"
 	"io"
+	"net/http"
+	"strconv"
+	"sync"
+	"time"
 
 	"github.com/taskcluster/httpbackoff/v3"
 )
 
-var EC2MetadataBaseURL = "http://169.254.169.254/latest"
+var (
+	EC2MetadataBaseURL = "http://169.254.169.254/latest"
+	TokenURL           = "http://169.254.169.254/latest/api/token"
+	TokenTTL           = 21600
+)
 
 type UserData struct {
 	WorkerPoolId string `json:"workerPoolId"`
@@ -40,7 +48,11 @@ type MetadataService interface {
 	queryMetadata(path string) (string, error)
 }
 
-type realMetadataService struct{}
+type realMetadataService struct {
+	mu     sync.Mutex
+	Token  string
+	Expiry time.Time
+}
 
 func (mds *realMetadataService) queryUserData() (*UserData, error) {
 	// http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html#instancedata-user-data-retrieval
@@ -53,10 +65,51 @@ func (mds *realMetadataService) queryUserData() (*UserData, error) {
 	return userData, err
 }
 
+func (mds *realMetadataService) ensureIMDSv2Token(tokenURL string, tokenTTL int) error {
+	mds.mu.Lock()
+	defer mds.mu.Unlock()
+	if mds.Token != "" && mds.Expiry.After(time.Now().Add(15*time.Minute)) {
+		return nil
+	}
+	client := &http.Client{
+		Timeout: 2 * time.Second,
+	}
+	req, err := http.NewRequest("PUT", tokenURL, nil)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("X-aws-ec2-metadata-token-ttl-seconds", strconv.Itoa(tokenTTL))
+
+	resp, _, err := httpbackoff.ClientDo(client, req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	token, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return err
+	}
+	mds.Token = string(token)
+	mds.Expiry = time.Now().Add(time.Second * time.Duration(TokenTTL))
+	return nil
+}
+
 func (mds *realMetadataService) queryMetadata(path string) (string, error) {
 	// http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html#instancedata-data-retrieval
 	// call http://169.254.169.254/latest/meta-data/instance-id with httpbackoff
-	resp, _, err := httpbackoff.Get(EC2MetadataBaseURL + path)
+	err := mds.ensureIMDSv2Token(TokenURL, TokenTTL)
+	if err != nil {
+		return "", err
+	}
+	client := &http.Client{
+		Timeout: 2 * time.Second,
+	}
+	req, err := http.NewRequest("GET", EC2MetadataBaseURL+path, nil)
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("X-aws-ec2-metadata-token", mds.Token)
+	resp, _, err := httpbackoff.ClientDo(client, req)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
Fixes #7076
