### PR TITLE
feat(github): Fixes 404 handling when task group doesn't exist

### DIFF
--- a/changelog/issue-7080.md
+++ b/changelog/issue-7080.md
@@ -1,0 +1,7 @@
+audience: developers
+level: patch
+reference: issue 7080
+---
+
+Fixes github service issue during cancellation of the previous runs that were not created.
+Response code was not checked properly which resulted in sending same error for each new build.

--- a/services/github/src/handlers/index.js
+++ b/services/github/src/handlers/index.js
@@ -312,7 +312,7 @@ class Handlers {
           await Promise.all(taskGroupIds.map(taskGroupId => limitedQueueClient.sealTaskGroup(taskGroupId)));
           await Promise.all(taskGroupIds.map(taskGroupId => limitedQueueClient.cancelTaskGroup(taskGroupId)));
         } catch (queueErr) {
-          if (queueErr.errorCode !== 'ResourceNotFound' || queueErr.statusCode !== 404) {
+          if (queueErr.code !== 'ResourceNotFound' || queueErr.statusCode !== 404) {
             throw queueErr;
           }
           // we can ignore task groups that were not yet created on queue side, and simply mark as cancelled in the db
@@ -324,7 +324,7 @@ class Handlers {
         )));
       }
     } catch (err) {
-      debug(`Error while canceling previous task groups: ${err.message} scopes used: ${scopes.join(', ')}`);
+      debug(`Error while canceling previous task groups: ${err.message}\nscopes used: ${scopes.join(', ')}`);
       err.message = [
         'Taskcluster-GitHub attempted to cancel previously created task groups with following scopes:',
         '',

--- a/services/github/test/handler_test.js
+++ b/services/github/test/handler_test.js
@@ -349,7 +349,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function (mock, skipping) {
 
     test('non-existent task groups queue.sealTask/cancelTaskGroup group are ignored', async function () {
       const err = new Error('ResourceNotFound');
-      err.errorCode = 'ResourceNotFound';
+      err.code = 'ResourceNotFound';
       err.statusCode = 404;
       handlers.queueClient = new taskcluster.Queue({
         rootUrl: 'https://tc.example.com',


### PR DESCRIPTION
Previously incorrect property was checked for an error code, which resulted in same error being sent to github comments

Fixes #7080 