### PR TITLE
API graceful query handling for pagination

### DIFF
--- a/changelog/issue-7083.md
+++ b/changelog/issue-7083.md
@@ -1,0 +1,6 @@
+audience: users
+level: patch
+reference: issue 7083
+---
+
+Fixes query validation in pagination queries that were throwing `500 InternalServerError` instead of `400 InputError`

--- a/libraries/api/test/pagination_test.js
+++ b/libraries/api/test/pagination_test.js
@@ -47,6 +47,13 @@ suite(testing.suiteName(), function() {
         await paginateResults({ query: { limit: 2, continuationToken }, fetch: fetcher(7) }),
         { rows: _.range(3, 5), continuationToken: hashids.encode(5) });
     });
+
+    test('paginate with invalid continuationToken throws error', async function() {
+      const continuationToken = 'this-is-rubbish';
+      await assert.rejects(
+        () => paginateResults({ query: { limit: 2, continuationToken }, fetch: fetcher(7) }),
+        /Invalid continuation token/);
+    });
   });
 
   suite('index-based', function() {


### PR DESCRIPTION
Used hashids library throws an error if decoded token contains invalid characters. API in such case would throw `500 InternalServerError` error. However, this should be a client error - `400 InvalidInput`.

Fixes #7083
