### PR TITLE
Migrate CI from Ubuntu 22.04 to Ubuntu 24.04 worker pools

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -124,7 +124,7 @@ tasks:
                 name: Decision Task (${tasks_for})
                 description: Load, transform, optimize, and submit other tasks
               provisionerId: proj-taskcluster
-              workerType: gw-ubuntu-22-04
+              workerType: gw-ubuntu-24-04
               scopes:
                   # `https://` is 8 characters so, ${repoUrl[8:]} is the repository without the protocol.
                   $if: 'tasks_for == "github-push" && event["ref"][:11] != "refs/tags/v"'

--- a/changelog/H0Ct7_leTvejnaMekiKJOw.md
+++ b/changelog/H0Ct7_leTvejnaMekiKJOw.md
@@ -1,0 +1,3 @@
+audience: general
+level: silent
+---

--- a/taskcluster/config.yml
+++ b/taskcluster/config.yml
@@ -16,11 +16,11 @@ workers:
       os: linux
       implementation: generic-worker
       worker-type: release
-    gw-ubuntu-22-04:
+    gw-ubuntu-24-04:
       provisioner: proj-taskcluster
       os: linux
       implementation: generic-worker
-      worker-type: gw-ubuntu-22-04
+      worker-type: gw-ubuntu-24-04
     gw-ci-ubuntu-22-04:
       provisioner: proj-taskcluster
       os: linux

--- a/taskcluster/kinds/client/kind.yml
+++ b/taskcluster/kinds/client/kind.yml
@@ -9,7 +9,7 @@ transforms:
   - taskgraph.transforms.task:transforms
 
 task-defaults:
-  worker-type: gw-ubuntu-22-04
+  worker-type: gw-ubuntu-24-04
   run:
     using: bare
   worker:

--- a/taskcluster/kinds/db/kind.yml
+++ b/taskcluster/kinds/db/kind.yml
@@ -8,7 +8,7 @@ transforms:
   - taskgraph.transforms.task:transforms
 
 task-defaults:
-  worker-type: gw-ubuntu-22-04
+  worker-type: gw-ubuntu-24-04
   run:
     using: bare
   worker:

--- a/taskcluster/kinds/generic-worker/kind.yml
+++ b/taskcluster/kinds/generic-worker/kind.yml
@@ -58,7 +58,7 @@ tasks:
         for more information)
       * `go fmt` to ensure that go source code is formatted
       * `goimports` to ensure that imports are specified in their canonical form
-    worker-type: gw-ubuntu-22-04
+    worker-type: gw-ubuntu-24-04
     worker:
       max-run-time: 300
       mounts:

--- a/taskcluster/kinds/go/kind.yml
+++ b/taskcluster/kinds/go/kind.yml
@@ -9,7 +9,7 @@ transforms:
   - taskgraph.transforms.task:transforms
 
 task-defaults:
-  worker-type: gw-ubuntu-22-04
+  worker-type: gw-ubuntu-24-04
   run:
     using: bare
     install:

--- a/taskcluster/kinds/library/kind.yml
+++ b/taskcluster/kinds/library/kind.yml
@@ -12,7 +12,7 @@ workspace: libraries
 prefix: 'lib-'
 
 task-defaults:
-  worker-type: gw-ubuntu-22-04
+  worker-type: gw-ubuntu-24-04
   run:
     using: bare
   scopes:

--- a/taskcluster/kinds/lint/kind.yml
+++ b/taskcluster/kinds/lint/kind.yml
@@ -8,7 +8,7 @@ transforms:
   - taskgraph.transforms.task:transforms
 
 task-defaults:
-  worker-type: gw-ubuntu-22-04
+  worker-type: gw-ubuntu-24-04
   run:
     using: bare
   worker:

--- a/taskcluster/kinds/meta/kind.yml
+++ b/taskcluster/kinds/meta/kind.yml
@@ -12,7 +12,7 @@ kind-dependencies:
   - lint
 
 task-defaults:
-  worker-type: gw-ubuntu-22-04
+  worker-type: gw-ubuntu-24-04
   run:
     using: bare
   worker:

--- a/taskcluster/kinds/service/kind.yml
+++ b/taskcluster/kinds/service/kind.yml
@@ -11,7 +11,7 @@ transforms:
 workspace: services
 
 task-defaults:
-  worker-type: gw-ubuntu-22-04
+  worker-type: gw-ubuntu-24-04
   run:
     using: bare
   scopes:

--- a/taskcluster/kinds/ui/kind.yml
+++ b/taskcluster/kinds/ui/kind.yml
@@ -9,7 +9,7 @@ transforms:
   - taskgraph.transforms.task:transforms
 
 task-defaults:
-  worker-type: gw-ubuntu-22-04
+  worker-type: gw-ubuntu-24-04
   run:
     using: bare
   worker:

--- a/tools/d2g/d2gtest/testdata/testcases/task_def_test.yml
+++ b/tools/d2g/d2gtest/testdata/testcases/task_def_test.yml
@@ -9,8 +9,8 @@ testSuite:
         into a valid Generic Worker task definition
       dockerWorkerTaskDefinition:
         provisionerId: proj-taskcluster
-        workerType: gw-ubuntu-22-04
-        taskQueueId: proj-taskcluster/gw-ubuntu-22-04
+        workerType: gw-ubuntu-24-04
+        taskQueueId: proj-taskcluster/gw-ubuntu-24-04
         schedulerId: taskcluster-ui
         projectId: none
         taskGroupId: PIxhISDQSDa98W9ppGUNsw
@@ -84,8 +84,8 @@ testSuite:
           - generic-worker:apples
         tags: {}
         taskGroupId: PIxhISDQSDa98W9ppGUNsw
-        taskQueueId: proj-taskcluster/gw-ubuntu-22-04
-        workerType: gw-ubuntu-22-04
+        taskQueueId: proj-taskcluster/gw-ubuntu-24-04
+        workerType: gw-ubuntu-24-04
     - name: Task definition test without taskQueueId set
       description: >-
         d2g should properly translate this Docker Worker task definition
@@ -93,7 +93,7 @@ testSuite:
         is not set
       dockerWorkerTaskDefinition:
         provisionerId: proj-taskcluster
-        workerType: gw-ubuntu-22-04
+        workerType: gw-ubuntu-24-04
         schedulerId: taskcluster-ui
         projectId: none
         taskGroupId: PIxhISDQSDa98W9ppGUNsw
@@ -166,11 +166,11 @@ testSuite:
         schedulerId: taskcluster-ui
         scopes:
           - generic-worker:apples
-          - generic-worker:os-group:proj-taskcluster/gw-ubuntu-22-04/kvm
-          - generic-worker:os-group:proj-taskcluster/gw-ubuntu-22-04/libvirt
+          - generic-worker:os-group:proj-taskcluster/gw-ubuntu-24-04/kvm
+          - generic-worker:os-group:proj-taskcluster/gw-ubuntu-24-04/libvirt
         tags: {}
         taskGroupId: PIxhISDQSDa98W9ppGUNsw
-        workerType: gw-ubuntu-22-04
+        workerType: gw-ubuntu-24-04
     - name: Task definition test with a new, fake field set, foo
       description: >-
         d2g should properly translate this Docker Worker task definition
@@ -179,8 +179,8 @@ testSuite:
       dockerWorkerTaskDefinition:
         foo: bar
         provisionerId: proj-taskcluster
-        workerType: gw-ubuntu-22-04
-        taskQueueId: proj-taskcluster/gw-ubuntu-22-04
+        workerType: gw-ubuntu-24-04
+        taskQueueId: proj-taskcluster/gw-ubuntu-24-04
         schedulerId: taskcluster-ui
         projectId: none
         taskGroupId: PIxhISDQSDa98W9ppGUNsw
@@ -255,6 +255,6 @@ testSuite:
           - generic-worker:apples
         tags: {}
         taskGroupId: PIxhISDQSDa98W9ppGUNsw
-        taskQueueId: proj-taskcluster/gw-ubuntu-22-04
-        workerType: gw-ubuntu-22-04
+        taskQueueId: proj-taskcluster/gw-ubuntu-24-04
+        workerType: gw-ubuntu-24-04
   payloadTests: []


### PR DESCRIPTION
This migrates the taskcluster CI workloads from Ubuntu 22.04 to Ubuntu 24.04.