### PR TITLE
Bump priority of lint-golang since tasks depend on it

### DIFF
--- a/changelog/dTx71WX3RdaLJRMuTdAcYg.md
+++ b/changelog/dTx71WX3RdaLJRMuTdAcYg.md
@@ -1,0 +1,3 @@
+audience: general
+level: silent
+---

--- a/taskcluster/kinds/lint/kind.yml
+++ b/taskcluster/kinds/lint/kind.yml
@@ -25,6 +25,7 @@ tasks:
         yarn lint
   golang:
     description: go lint
+    priority: very-high
     docker-image: taskcluster/ci-image:node{node_version}-pg{pg_version}-go{go_version}
     run:
       command: >-


### PR DESCRIPTION
See https://github.com/taskcluster/taskgraph/issues/532
