### PR TITLE
Publishing worker related events to pulse

### DIFF
--- a/changelog/issue-7085.md
+++ b/changelog/issue-7085.md
@@ -1,0 +1,10 @@
+audience: users
+level: minor
+reference: issue 7085
+---
+
+Worker-manager publishes more events to new exchanges in Pulse:
+- `worker-pool-error`
+- `worker-requested`
+- `worker-running`
+- `worker-stopped`

--- a/clients/client-go/tcworkermanagerevents/tcworkermanagerevents.go
+++ b/clients/client-go/tcworkermanagerevents/tcworkermanagerevents.go
@@ -44,11 +44,18 @@ import (
 	"strings"
 )
 
-// Whenever the api receives a request to create aworker pool, a message is posted to this exchange anda provider can act upon it.
+// Whenever the api receives a request to create a
+// worker pool, a message is posted to this exchange and
+// a provider can act upon it.
 //
 // See #workerPoolCreated
 type WorkerPoolCreated struct {
 	RoutingKeyKind string `mwords:"*"`
+	ProviderID     string `mwords:"*"`
+	ProvisionerID  string `mwords:"*"`
+	WorkerType     string `mwords:"*"`
+	WorkerGroup    string `mwords:"*"`
+	WorkerID       string `mwords:"*"`
 	Reserved       string `mwords:"#"`
 }
 
@@ -64,11 +71,18 @@ func (binding WorkerPoolCreated) NewPayloadObject() interface{} {
 	return new(WorkerTypePulseMessage)
 }
 
-// Whenever the api receives a request to update aworker pool, a message is posted to this exchange anda provider can act upon it.
+// Whenever the api receives a request to update a
+// worker pool, a message is posted to this exchange and
+// a provider can act upon it.
 //
 // See #workerPoolUpdated
 type WorkerPoolUpdated struct {
 	RoutingKeyKind string `mwords:"*"`
+	ProviderID     string `mwords:"*"`
+	ProvisionerID  string `mwords:"*"`
+	WorkerType     string `mwords:"*"`
+	WorkerGroup    string `mwords:"*"`
+	WorkerID       string `mwords:"*"`
 	Reserved       string `mwords:"#"`
 }
 
@@ -82,6 +96,142 @@ func (binding WorkerPoolUpdated) ExchangeName() string {
 
 func (binding WorkerPoolUpdated) NewPayloadObject() interface{} {
 	return new(WorkerTypePulseMessage)
+}
+
+// Whenever a worker reports an error
+// or provisioner encounters an error while
+// provisioning a worker pool, a message is posted to this
+// exchange.
+//
+// See #workerPoolError
+type WorkerPoolError struct {
+	RoutingKeyKind string `mwords:"*"`
+	ProviderID     string `mwords:"*"`
+	ProvisionerID  string `mwords:"*"`
+	WorkerType     string `mwords:"*"`
+	WorkerGroup    string `mwords:"*"`
+	WorkerID       string `mwords:"*"`
+	Reserved       string `mwords:"#"`
+}
+
+func (binding WorkerPoolError) RoutingKey() string {
+	return generateRoutingKey(&binding)
+}
+
+func (binding WorkerPoolError) ExchangeName() string {
+	return "exchange/taskcluster-worker-manager/v1/worker-pool-error"
+}
+
+func (binding WorkerPoolError) NewPayloadObject() interface{} {
+	return new(WorkerTypePulseMessage1)
+}
+
+// Whenever a worker is requested, a message is posted
+// to this exchange.
+//
+// See #workerRequested
+type WorkerRequested struct {
+	RoutingKeyKind string `mwords:"*"`
+	ProviderID     string `mwords:"*"`
+	ProvisionerID  string `mwords:"*"`
+	WorkerType     string `mwords:"*"`
+	WorkerGroup    string `mwords:"*"`
+	WorkerID       string `mwords:"*"`
+	Reserved       string `mwords:"#"`
+}
+
+func (binding WorkerRequested) RoutingKey() string {
+	return generateRoutingKey(&binding)
+}
+
+func (binding WorkerRequested) ExchangeName() string {
+	return "exchange/taskcluster-worker-manager/v1/worker-requested"
+}
+
+func (binding WorkerRequested) NewPayloadObject() interface{} {
+	return new(WorkerPulseMessage)
+}
+
+// Whenever a worker has registered, a message is posted
+// to this exchange. This means that worker started
+// successfully and is ready to claim work.
+//
+// See #workerRunning
+type WorkerRunning struct {
+	RoutingKeyKind string `mwords:"*"`
+	ProviderID     string `mwords:"*"`
+	ProvisionerID  string `mwords:"*"`
+	WorkerType     string `mwords:"*"`
+	WorkerGroup    string `mwords:"*"`
+	WorkerID       string `mwords:"*"`
+	Reserved       string `mwords:"#"`
+}
+
+func (binding WorkerRunning) RoutingKey() string {
+	return generateRoutingKey(&binding)
+}
+
+func (binding WorkerRunning) ExchangeName() string {
+	return "exchange/taskcluster-worker-manager/v1/worker-running"
+}
+
+func (binding WorkerRunning) NewPayloadObject() interface{} {
+	return new(WorkerPulseMessage)
+}
+
+// Whenever a worker has stopped, a message is posted
+// to this exchange. This means that instance was
+// either terminated or stopped gracefully.
+//
+// See #workerStopped
+type WorkerStopped struct {
+	RoutingKeyKind string `mwords:"*"`
+	ProviderID     string `mwords:"*"`
+	ProvisionerID  string `mwords:"*"`
+	WorkerType     string `mwords:"*"`
+	WorkerGroup    string `mwords:"*"`
+	WorkerID       string `mwords:"*"`
+	Reserved       string `mwords:"#"`
+}
+
+func (binding WorkerStopped) RoutingKey() string {
+	return generateRoutingKey(&binding)
+}
+
+func (binding WorkerStopped) ExchangeName() string {
+	return "exchange/taskcluster-worker-manager/v1/worker-stopped"
+}
+
+func (binding WorkerStopped) NewPayloadObject() interface{} {
+	return new(WorkerPulseMessage)
+}
+
+// Whenever a worker is removed, a message is posted to this exchange.
+// This occurs when a worker is requested to be removed via an API call
+// or when a worker is terminated by the worker manager.
+// The reason for the removal is included in the message.
+//
+// See #workerRemoved
+type WorkerRemoved struct {
+	RoutingKeyKind string `mwords:"*"`
+	ProviderID     string `mwords:"*"`
+	ProvisionerID  string `mwords:"*"`
+	WorkerType     string `mwords:"*"`
+	WorkerGroup    string `mwords:"*"`
+	WorkerID       string `mwords:"*"`
+	Reserved       string `mwords:"#"`
+}
+
+func (binding WorkerRemoved) RoutingKey() string {
+	return generateRoutingKey(&binding)
+}
+
+func (binding WorkerRemoved) ExchangeName() string {
+	return "exchange/taskcluster-worker-manager/v1/worker-removed"
+}
+
+func (binding WorkerRemoved) NewPayloadObject() interface{} {
+	return new(WorkerRemovedPulseMessage)
 }
 
 func generateRoutingKey(x interface{}) string {

--- a/clients/client-go/tcworkermanagerevents/types.go
+++ b/clients/client-go/tcworkermanagerevents/types.go
@@ -3,6 +3,90 @@
 package tcworkermanagerevents
 
 type (
+	// The message that is emitted when workers requested/running/stopped.
+	WorkerPulseMessage struct {
+
+		// Number of tasks this worker can handle at once
+		//
+		// Mininum:    1
+		Capacity int64 `json:"capacity"`
+
+		// The provider responsible for managing this worker pool.
+		//
+		// If this value is `"null-provider"`, then the worker pool is pending deletion
+		// once all existing workers have terminated.
+		//
+		// Syntax:     ^([a-zA-Z0-9-_]*)$
+		// Min length: 1
+		// Max length: 38
+		ProviderID string `json:"providerId"`
+
+		// Worker group to which this worker belongs
+		//
+		// Syntax:     ^([a-zA-Z0-9-_]*)$
+		// Min length: 1
+		// Max length: 38
+		WorkerGroup string `json:"workerGroup"`
+
+		// Worker ID
+		//
+		// Syntax:     ^([a-zA-Z0-9-_]*)$
+		// Min length: 1
+		// Max length: 38
+		WorkerID string `json:"workerId"`
+
+		// The ID of this worker pool (of the form `providerId/workerType` for compatibility)
+		//
+		// Syntax:     ^[a-zA-Z0-9-_]{1,38}/[a-z]([-a-z0-9]{0,36}[a-z0-9])?$
+		WorkerPoolID string `json:"workerPoolId"`
+	}
+
+	// The message that is emitted when workers are being removed.
+	WorkerRemovedPulseMessage struct {
+
+		// Number of tasks this worker can handle at once
+		//
+		// Mininum:    1
+		Capacity int64 `json:"capacity"`
+
+		// The provider responsible for managing this worker pool.
+		//
+		// If this value is `"null-provider"`, then the worker pool is pending deletion
+		// once all existing workers have terminated.
+		//
+		// Syntax:     ^([a-zA-Z0-9-_]*)$
+		// Min length: 1
+		// Max length: 38
+		ProviderID string `json:"providerId"`
+
+		// The reason the worker was removed. It can be one of the following:
+		//
+		// - workerManager.removeWorker API call
+		// - terminateAfter time exceeded
+		// - operation expired
+		// - any other error encountered
+		Reason string `json:"reason"`
+
+		// Worker group to which this worker belongs
+		//
+		// Syntax:     ^([a-zA-Z0-9-_]*)$
+		// Min length: 1
+		// Max length: 38
+		WorkerGroup string `json:"workerGroup"`
+
+		// Worker ID
+		//
+		// Syntax:     ^([a-zA-Z0-9-_]*)$
+		// Min length: 1
+		// Max length: 38
+		WorkerID string `json:"workerId"`
+
+		// The ID of this worker pool (of the form `providerId/workerType` for compatibility)
+		//
+		// Syntax:     ^[a-zA-Z0-9-_]{1,38}/[a-z]([-a-z0-9]{0,36}[a-z0-9])?$
+		WorkerPoolID string `json:"workerPoolId"`
+	}
+
 	// The message that is emitted when worker pools are created/changed/deleted.
 	WorkerTypePulseMessage struct {
 
@@ -25,6 +109,55 @@ type (
 		// Min length: 1
 		// Max length: 38
 		ProviderID string `json:"providerId"`
+
+		// The ID of this worker pool (of the form `providerId/workerType` for compatibility)
+		//
+		// Syntax:     ^[a-zA-Z0-9-_]{1,38}/[a-z]([-a-z0-9]{0,36}[a-z0-9])?$
+		WorkerPoolID string `json:"workerPoolId"`
+	}
+
+	// The message that is emitted when worker pools are created/changed/deleted.
+	WorkerTypePulseMessage1 struct {
+
+		// An arbitary unique identifier for this error
+		//
+		// Syntax:     ^[A-Za-z0-9_-]{8}[Q-T][A-Za-z0-9_-][CGKOSWaeimquy26-][A-Za-z0-9_-]{10}[AQgw]$
+		ErrorID string `json:"errorId"`
+
+		// A general machine-readable way to identify this sort of error.
+		//
+		// Syntax:     [-a-z0-9]+
+		// Max length: 128
+		Kind string `json:"kind"`
+
+		// The provider responsible for managing this worker pool.
+		//
+		// If this value is `"null-provider"`, then the worker pool is pending deletion
+		// once all existing workers have terminated.
+		//
+		// Syntax:     ^([a-zA-Z0-9-_]*)$
+		// Min length: 1
+		// Max length: 38
+		ProviderID string `json:"providerId"`
+
+		// A human-readable version of `kind`.
+		//
+		// Max length: 128
+		Title string `json:"title"`
+
+		// Worker group to which this worker belongs
+		//
+		// Syntax:     ^([a-zA-Z0-9-_]*)$
+		// Min length: 1
+		// Max length: 38
+		WorkerGroup string `json:"workerGroup,omitempty"`
+
+		// Worker ID
+		//
+		// Syntax:     ^([a-zA-Z0-9-_]*)$
+		// Min length: 1
+		// Max length: 38
+		WorkerID string `json:"workerId,omitempty"`
 
 		// The ID of this worker pool (of the form `providerId/workerType` for compatibility)
 		//

--- a/clients/client-py/taskcluster/generated/aio/workermanagerevents.py
+++ b/clients/client-py/taskcluster/generated/aio/workermanagerevents.py
@@ -26,11 +26,23 @@ class WorkerManagerEvents(AsyncBaseClient):
         """
         Worker Pool Created Messages
 
-        Whenever the api receives a request to create aworker pool, a message is posted to this exchange anda provider can act upon it.
+        Whenever the api receives a request to create a
+        worker pool, a message is posted to this exchange and
+        a provider can act upon it.
 
         This exchange takes the following keys:
 
          * routingKeyKind: Identifier for the routing-key kind. This is always `'primary'` for the formalized routing key. (required)
+
+         * providerId: Provider.
+
+         * provisionerId: First part of the workerPoolId.
+
+         * workerType: Second part of the workerPoolId.
+
+         * workerGroup: Worker group of the worker (region or location)
+
+         * workerId: Worker ID
 
          * reserved: Space reserved for future routing-key entries, you should always match this entry with `#`. As automatically done by our tooling, if not specified.
         """
@@ -45,6 +57,26 @@ class WorkerManagerEvents(AsyncBaseClient):
                     'name': 'routingKeyKind',
                 },
                 {
+                    'multipleWords': False,
+                    'name': 'providerId',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'provisionerId',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'workerType',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'workerGroup',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'workerId',
+                },
+                {
                     'multipleWords': True,
                     'name': 'reserved',
                 },
@@ -57,11 +89,23 @@ class WorkerManagerEvents(AsyncBaseClient):
         """
         Worker Pool Updated Messages
 
-        Whenever the api receives a request to update aworker pool, a message is posted to this exchange anda provider can act upon it.
+        Whenever the api receives a request to update a
+        worker pool, a message is posted to this exchange and
+        a provider can act upon it.
 
         This exchange takes the following keys:
 
          * routingKeyKind: Identifier for the routing-key kind. This is always `'primary'` for the formalized routing key. (required)
+
+         * providerId: Provider.
+
+         * provisionerId: First part of the workerPoolId.
+
+         * workerType: Second part of the workerPoolId.
+
+         * workerGroup: Worker group of the worker (region or location)
+
+         * workerId: Worker ID
 
          * reserved: Space reserved for future routing-key entries, you should always match this entry with `#`. As automatically done by our tooling, if not specified.
         """
@@ -76,11 +120,347 @@ class WorkerManagerEvents(AsyncBaseClient):
                     'name': 'routingKeyKind',
                 },
                 {
+                    'multipleWords': False,
+                    'name': 'providerId',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'provisionerId',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'workerType',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'workerGroup',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'workerId',
+                },
+                {
                     'multipleWords': True,
                     'name': 'reserved',
                 },
             ],
             'schema': 'v1/pulse-worker-pool-message.json#',
+        }
+        return self._makeTopicExchange(ref, *args, **kwargs)
+
+    def workerPoolError(self, *args, **kwargs):
+        """
+        Worker Pool Provisioning Error Messages
+
+        Whenever a worker reports an error
+        or provisioner encounters an error while
+        provisioning a worker pool, a message is posted to this
+        exchange.
+
+        This exchange takes the following keys:
+
+         * routingKeyKind: Identifier for the routing-key kind. This is always `'primary'` for the formalized routing key. (required)
+
+         * providerId: Provider.
+
+         * provisionerId: First part of the workerPoolId.
+
+         * workerType: Second part of the workerPoolId.
+
+         * workerGroup: Worker group of the worker (region or location)
+
+         * workerId: Worker ID
+
+         * reserved: Space reserved for future routing-key entries, you should always match this entry with `#`. As automatically done by our tooling, if not specified.
+        """
+
+        ref = {
+            'exchange': 'worker-pool-error',
+            'name': 'workerPoolError',
+            'routingKey': [
+                {
+                    'constant': 'primary',
+                    'multipleWords': False,
+                    'name': 'routingKeyKind',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'providerId',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'provisionerId',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'workerType',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'workerGroup',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'workerId',
+                },
+                {
+                    'multipleWords': True,
+                    'name': 'reserved',
+                },
+            ],
+            'schema': 'v1/pulse-worker-pool-error-message.json#',
+        }
+        return self._makeTopicExchange(ref, *args, **kwargs)
+
+    def workerRequested(self, *args, **kwargs):
+        """
+        Worker Requested Messages
+
+        Whenever a worker is requested, a message is posted
+        to this exchange.
+
+        This exchange takes the following keys:
+
+         * routingKeyKind: Identifier for the routing-key kind. This is always `'primary'` for the formalized routing key. (required)
+
+         * providerId: Provider. (required)
+
+         * provisionerId: First part of the workerPoolId. (required)
+
+         * workerType: Second part of the workerPoolId. (required)
+
+         * workerGroup: Worker group of the worker (region or location) (required)
+
+         * workerId: Worker ID (required)
+
+         * reserved: Space reserved for future routing-key entries, you should always match this entry with `#`. As automatically done by our tooling, if not specified.
+        """
+
+        ref = {
+            'exchange': 'worker-requested',
+            'name': 'workerRequested',
+            'routingKey': [
+                {
+                    'constant': 'primary',
+                    'multipleWords': False,
+                    'name': 'routingKeyKind',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'providerId',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'provisionerId',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'workerType',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'workerGroup',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'workerId',
+                },
+                {
+                    'multipleWords': True,
+                    'name': 'reserved',
+                },
+            ],
+            'schema': 'v1/pulse-worker-message.json#',
+        }
+        return self._makeTopicExchange(ref, *args, **kwargs)
+
+    def workerRunning(self, *args, **kwargs):
+        """
+        Worker Running Messages
+
+        Whenever a worker has registered, a message is posted
+        to this exchange. This means that worker started
+        successfully and is ready to claim work.
+
+        This exchange takes the following keys:
+
+         * routingKeyKind: Identifier for the routing-key kind. This is always `'primary'` for the formalized routing key. (required)
+
+         * providerId: Provider. (required)
+
+         * provisionerId: First part of the workerPoolId. (required)
+
+         * workerType: Second part of the workerPoolId. (required)
+
+         * workerGroup: Worker group of the worker (region or location) (required)
+
+         * workerId: Worker ID (required)
+
+         * reserved: Space reserved for future routing-key entries, you should always match this entry with `#`. As automatically done by our tooling, if not specified.
+        """
+
+        ref = {
+            'exchange': 'worker-running',
+            'name': 'workerRunning',
+            'routingKey': [
+                {
+                    'constant': 'primary',
+                    'multipleWords': False,
+                    'name': 'routingKeyKind',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'providerId',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'provisionerId',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'workerType',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'workerGroup',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'workerId',
+                },
+                {
+                    'multipleWords': True,
+                    'name': 'reserved',
+                },
+            ],
+            'schema': 'v1/pulse-worker-message.json#',
+        }
+        return self._makeTopicExchange(ref, *args, **kwargs)
+
+    def workerStopped(self, *args, **kwargs):
+        """
+        Worker Stopped Messages
+
+        Whenever a worker has stopped, a message is posted
+        to this exchange. This means that instance was
+        either terminated or stopped gracefully.
+
+        This exchange takes the following keys:
+
+         * routingKeyKind: Identifier for the routing-key kind. This is always `'primary'` for the formalized routing key. (required)
+
+         * providerId: Provider. (required)
+
+         * provisionerId: First part of the workerPoolId. (required)
+
+         * workerType: Second part of the workerPoolId. (required)
+
+         * workerGroup: Worker group of the worker (region or location) (required)
+
+         * workerId: Worker ID (required)
+
+         * reserved: Space reserved for future routing-key entries, you should always match this entry with `#`. As automatically done by our tooling, if not specified.
+        """
+
+        ref = {
+            'exchange': 'worker-stopped',
+            'name': 'workerStopped',
+            'routingKey': [
+                {
+                    'constant': 'primary',
+                    'multipleWords': False,
+                    'name': 'routingKeyKind',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'providerId',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'provisionerId',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'workerType',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'workerGroup',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'workerId',
+                },
+                {
+                    'multipleWords': True,
+                    'name': 'reserved',
+                },
+            ],
+            'schema': 'v1/pulse-worker-message.json#',
+        }
+        return self._makeTopicExchange(ref, *args, **kwargs)
+
+    def workerRemoved(self, *args, **kwargs):
+        """
+        Worker Removed Messages
+
+        Whenever a worker is removed, a message is posted to this exchange.
+        This occurs when a worker is requested to be removed via an API call
+        or when a worker is terminated by the worker manager.
+        The reason for the removal is included in the message.
+
+        This exchange takes the following keys:
+
+         * routingKeyKind: Identifier for the routing-key kind. This is always `'primary'` for the formalized routing key. (required)
+
+         * providerId: Provider. (required)
+
+         * provisionerId: First part of the workerPoolId. (required)
+
+         * workerType: Second part of the workerPoolId. (required)
+
+         * workerGroup: Worker group of the worker (region or location) (required)
+
+         * workerId: Worker ID (required)
+
+         * reserved: Space reserved for future routing-key entries, you should always match this entry with `#`. As automatically done by our tooling, if not specified.
+        """
+
+        ref = {
+            'exchange': 'worker-removed',
+            'name': 'workerRemoved',
+            'routingKey': [
+                {
+                    'constant': 'primary',
+                    'multipleWords': False,
+                    'name': 'routingKeyKind',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'providerId',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'provisionerId',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'workerType',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'workerGroup',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'workerId',
+                },
+                {
+                    'multipleWords': True,
+                    'name': 'reserved',
+                },
+            ],
+            'schema': 'v1/pulse-worker-removed-message.json#',
         }
         return self._makeTopicExchange(ref, *args, **kwargs)
 

--- a/clients/client-py/taskcluster/generated/workermanagerevents.py
+++ b/clients/client-py/taskcluster/generated/workermanagerevents.py
@@ -26,11 +26,23 @@ class WorkerManagerEvents(BaseClient):
         """
         Worker Pool Created Messages
 
-        Whenever the api receives a request to create aworker pool, a message is posted to this exchange anda provider can act upon it.
+        Whenever the api receives a request to create a
+        worker pool, a message is posted to this exchange and
+        a provider can act upon it.
 
         This exchange takes the following keys:
 
          * routingKeyKind: Identifier for the routing-key kind. This is always `'primary'` for the formalized routing key. (required)
+
+         * providerId: Provider.
+
+         * provisionerId: First part of the workerPoolId.
+
+         * workerType: Second part of the workerPoolId.
+
+         * workerGroup: Worker group of the worker (region or location)
+
+         * workerId: Worker ID
 
          * reserved: Space reserved for future routing-key entries, you should always match this entry with `#`. As automatically done by our tooling, if not specified.
         """
@@ -45,6 +57,26 @@ class WorkerManagerEvents(BaseClient):
                     'name': 'routingKeyKind',
                 },
                 {
+                    'multipleWords': False,
+                    'name': 'providerId',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'provisionerId',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'workerType',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'workerGroup',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'workerId',
+                },
+                {
                     'multipleWords': True,
                     'name': 'reserved',
                 },
@@ -57,11 +89,23 @@ class WorkerManagerEvents(BaseClient):
         """
         Worker Pool Updated Messages
 
-        Whenever the api receives a request to update aworker pool, a message is posted to this exchange anda provider can act upon it.
+        Whenever the api receives a request to update a
+        worker pool, a message is posted to this exchange and
+        a provider can act upon it.
 
         This exchange takes the following keys:
 
          * routingKeyKind: Identifier for the routing-key kind. This is always `'primary'` for the formalized routing key. (required)
+
+         * providerId: Provider.
+
+         * provisionerId: First part of the workerPoolId.
+
+         * workerType: Second part of the workerPoolId.
+
+         * workerGroup: Worker group of the worker (region or location)
+
+         * workerId: Worker ID
 
          * reserved: Space reserved for future routing-key entries, you should always match this entry with `#`. As automatically done by our tooling, if not specified.
         """
@@ -76,11 +120,347 @@ class WorkerManagerEvents(BaseClient):
                     'name': 'routingKeyKind',
                 },
                 {
+                    'multipleWords': False,
+                    'name': 'providerId',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'provisionerId',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'workerType',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'workerGroup',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'workerId',
+                },
+                {
                     'multipleWords': True,
                     'name': 'reserved',
                 },
             ],
             'schema': 'v1/pulse-worker-pool-message.json#',
+        }
+        return self._makeTopicExchange(ref, *args, **kwargs)
+
+    def workerPoolError(self, *args, **kwargs):
+        """
+        Worker Pool Provisioning Error Messages
+
+        Whenever a worker reports an error
+        or provisioner encounters an error while
+        provisioning a worker pool, a message is posted to this
+        exchange.
+
+        This exchange takes the following keys:
+
+         * routingKeyKind: Identifier for the routing-key kind. This is always `'primary'` for the formalized routing key. (required)
+
+         * providerId: Provider.
+
+         * provisionerId: First part of the workerPoolId.
+
+         * workerType: Second part of the workerPoolId.
+
+         * workerGroup: Worker group of the worker (region or location)
+
+         * workerId: Worker ID
+
+         * reserved: Space reserved for future routing-key entries, you should always match this entry with `#`. As automatically done by our tooling, if not specified.
+        """
+
+        ref = {
+            'exchange': 'worker-pool-error',
+            'name': 'workerPoolError',
+            'routingKey': [
+                {
+                    'constant': 'primary',
+                    'multipleWords': False,
+                    'name': 'routingKeyKind',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'providerId',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'provisionerId',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'workerType',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'workerGroup',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'workerId',
+                },
+                {
+                    'multipleWords': True,
+                    'name': 'reserved',
+                },
+            ],
+            'schema': 'v1/pulse-worker-pool-error-message.json#',
+        }
+        return self._makeTopicExchange(ref, *args, **kwargs)
+
+    def workerRequested(self, *args, **kwargs):
+        """
+        Worker Requested Messages
+
+        Whenever a worker is requested, a message is posted
+        to this exchange.
+
+        This exchange takes the following keys:
+
+         * routingKeyKind: Identifier for the routing-key kind. This is always `'primary'` for the formalized routing key. (required)
+
+         * providerId: Provider. (required)
+
+         * provisionerId: First part of the workerPoolId. (required)
+
+         * workerType: Second part of the workerPoolId. (required)
+
+         * workerGroup: Worker group of the worker (region or location) (required)
+
+         * workerId: Worker ID (required)
+
+         * reserved: Space reserved for future routing-key entries, you should always match this entry with `#`. As automatically done by our tooling, if not specified.
+        """
+
+        ref = {
+            'exchange': 'worker-requested',
+            'name': 'workerRequested',
+            'routingKey': [
+                {
+                    'constant': 'primary',
+                    'multipleWords': False,
+                    'name': 'routingKeyKind',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'providerId',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'provisionerId',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'workerType',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'workerGroup',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'workerId',
+                },
+                {
+                    'multipleWords': True,
+                    'name': 'reserved',
+                },
+            ],
+            'schema': 'v1/pulse-worker-message.json#',
+        }
+        return self._makeTopicExchange(ref, *args, **kwargs)
+
+    def workerRunning(self, *args, **kwargs):
+        """
+        Worker Running Messages
+
+        Whenever a worker has registered, a message is posted
+        to this exchange. This means that worker started
+        successfully and is ready to claim work.
+
+        This exchange takes the following keys:
+
+         * routingKeyKind: Identifier for the routing-key kind. This is always `'primary'` for the formalized routing key. (required)
+
+         * providerId: Provider. (required)
+
+         * provisionerId: First part of the workerPoolId. (required)
+
+         * workerType: Second part of the workerPoolId. (required)
+
+         * workerGroup: Worker group of the worker (region or location) (required)
+
+         * workerId: Worker ID (required)
+
+         * reserved: Space reserved for future routing-key entries, you should always match this entry with `#`. As automatically done by our tooling, if not specified.
+        """
+
+        ref = {
+            'exchange': 'worker-running',
+            'name': 'workerRunning',
+            'routingKey': [
+                {
+                    'constant': 'primary',
+                    'multipleWords': False,
+                    'name': 'routingKeyKind',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'providerId',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'provisionerId',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'workerType',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'workerGroup',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'workerId',
+                },
+                {
+                    'multipleWords': True,
+                    'name': 'reserved',
+                },
+            ],
+            'schema': 'v1/pulse-worker-message.json#',
+        }
+        return self._makeTopicExchange(ref, *args, **kwargs)
+
+    def workerStopped(self, *args, **kwargs):
+        """
+        Worker Stopped Messages
+
+        Whenever a worker has stopped, a message is posted
+        to this exchange. This means that instance was
+        either terminated or stopped gracefully.
+
+        This exchange takes the following keys:
+
+         * routingKeyKind: Identifier for the routing-key kind. This is always `'primary'` for the formalized routing key. (required)
+
+         * providerId: Provider. (required)
+
+         * provisionerId: First part of the workerPoolId. (required)
+
+         * workerType: Second part of the workerPoolId. (required)
+
+         * workerGroup: Worker group of the worker (region or location) (required)
+
+         * workerId: Worker ID (required)
+
+         * reserved: Space reserved for future routing-key entries, you should always match this entry with `#`. As automatically done by our tooling, if not specified.
+        """
+
+        ref = {
+            'exchange': 'worker-stopped',
+            'name': 'workerStopped',
+            'routingKey': [
+                {
+                    'constant': 'primary',
+                    'multipleWords': False,
+                    'name': 'routingKeyKind',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'providerId',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'provisionerId',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'workerType',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'workerGroup',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'workerId',
+                },
+                {
+                    'multipleWords': True,
+                    'name': 'reserved',
+                },
+            ],
+            'schema': 'v1/pulse-worker-message.json#',
+        }
+        return self._makeTopicExchange(ref, *args, **kwargs)
+
+    def workerRemoved(self, *args, **kwargs):
+        """
+        Worker Removed Messages
+
+        Whenever a worker is removed, a message is posted to this exchange.
+        This occurs when a worker is requested to be removed via an API call
+        or when a worker is terminated by the worker manager.
+        The reason for the removal is included in the message.
+
+        This exchange takes the following keys:
+
+         * routingKeyKind: Identifier for the routing-key kind. This is always `'primary'` for the formalized routing key. (required)
+
+         * providerId: Provider. (required)
+
+         * provisionerId: First part of the workerPoolId. (required)
+
+         * workerType: Second part of the workerPoolId. (required)
+
+         * workerGroup: Worker group of the worker (region or location) (required)
+
+         * workerId: Worker ID (required)
+
+         * reserved: Space reserved for future routing-key entries, you should always match this entry with `#`. As automatically done by our tooling, if not specified.
+        """
+
+        ref = {
+            'exchange': 'worker-removed',
+            'name': 'workerRemoved',
+            'routingKey': [
+                {
+                    'constant': 'primary',
+                    'multipleWords': False,
+                    'name': 'routingKeyKind',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'providerId',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'provisionerId',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'workerType',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'workerGroup',
+                },
+                {
+                    'multipleWords': False,
+                    'name': 'workerId',
+                },
+                {
+                    'multipleWords': True,
+                    'name': 'reserved',
+                },
+            ],
+            'schema': 'v1/pulse-worker-removed-message.json#',
         }
         return self._makeTopicExchange(ref, *args, **kwargs)
 

--- a/clients/client-web/src/clients/WorkerManagerEvents.js
+++ b/clients/client-web/src/clients/WorkerManagerEvents.js
@@ -12,18 +12,73 @@ export default class WorkerManagerEvents extends Client {
     });
   }
   /* eslint-disable max-len */
-  // Whenever the api receives a request to create aworker pool, a message is posted to this exchange anda provider can act upon it.
+  // Whenever the api receives a request to create a
+  // worker pool, a message is posted to this exchange and
+  // a provider can act upon it.
   /* eslint-enable max-len */
   workerPoolCreated(pattern) {
-    const entry = {"exchange":"worker-pool-created","name":"workerPoolCreated","routingKey":[{"constant":"primary","multipleWords":false,"name":"routingKeyKind","required":true},{"multipleWords":true,"name":"reserved","required":false}],"schema":"v1/pulse-worker-pool-message.json#","type":"topic-exchange"}; // eslint-disable-line
+    const entry = {"exchange":"worker-pool-created","name":"workerPoolCreated","routingKey":[{"constant":"primary","multipleWords":false,"name":"routingKeyKind","required":true},{"multipleWords":false,"name":"providerId","required":false},{"multipleWords":false,"name":"provisionerId","required":false},{"multipleWords":false,"name":"workerType","required":false},{"multipleWords":false,"name":"workerGroup","required":false},{"multipleWords":false,"name":"workerId","required":false},{"multipleWords":true,"name":"reserved","required":false}],"schema":"v1/pulse-worker-pool-message.json#","type":"topic-exchange"}; // eslint-disable-line
 
     return this.normalizePattern(entry, pattern);
   }
   /* eslint-disable max-len */
-  // Whenever the api receives a request to update aworker pool, a message is posted to this exchange anda provider can act upon it.
+  // Whenever the api receives a request to update a
+  // worker pool, a message is posted to this exchange and
+  // a provider can act upon it.
   /* eslint-enable max-len */
   workerPoolUpdated(pattern) {
-    const entry = {"exchange":"worker-pool-updated","name":"workerPoolUpdated","routingKey":[{"constant":"primary","multipleWords":false,"name":"routingKeyKind","required":true},{"multipleWords":true,"name":"reserved","required":false}],"schema":"v1/pulse-worker-pool-message.json#","type":"topic-exchange"}; // eslint-disable-line
+    const entry = {"exchange":"worker-pool-updated","name":"workerPoolUpdated","routingKey":[{"constant":"primary","multipleWords":false,"name":"routingKeyKind","required":true},{"multipleWords":false,"name":"providerId","required":false},{"multipleWords":false,"name":"provisionerId","required":false},{"multipleWords":false,"name":"workerType","required":false},{"multipleWords":false,"name":"workerGroup","required":false},{"multipleWords":false,"name":"workerId","required":false},{"multipleWords":true,"name":"reserved","required":false}],"schema":"v1/pulse-worker-pool-message.json#","type":"topic-exchange"}; // eslint-disable-line
+
+    return this.normalizePattern(entry, pattern);
+  }
+  /* eslint-disable max-len */
+  // Whenever a worker reports an error
+  // or provisioner encounters an error while
+  // provisioning a worker pool, a message is posted to this
+  // exchange.
+  /* eslint-enable max-len */
+  workerPoolError(pattern) {
+    const entry = {"exchange":"worker-pool-error","name":"workerPoolError","routingKey":[{"constant":"primary","multipleWords":false,"name":"routingKeyKind","required":true},{"multipleWords":false,"name":"providerId","required":false},{"multipleWords":false,"name":"provisionerId","required":false},{"multipleWords":false,"name":"workerType","required":false},{"multipleWords":false,"name":"workerGroup","required":false},{"multipleWords":false,"name":"workerId","required":false},{"multipleWords":true,"name":"reserved","required":false}],"schema":"v1/pulse-worker-pool-error-message.json#","type":"topic-exchange"}; // eslint-disable-line
+
+    return this.normalizePattern(entry, pattern);
+  }
+  /* eslint-disable max-len */
+  // Whenever a worker is requested, a message is posted
+  // to this exchange.
+  /* eslint-enable max-len */
+  workerRequested(pattern) {
+    const entry = {"exchange":"worker-requested","name":"workerRequested","routingKey":[{"constant":"primary","multipleWords":false,"name":"routingKeyKind","required":true},{"multipleWords":false,"name":"providerId","required":true},{"multipleWords":false,"name":"provisionerId","required":true},{"multipleWords":false,"name":"workerType","required":true},{"multipleWords":false,"name":"workerGroup","required":true},{"multipleWords":false,"name":"workerId","required":true},{"multipleWords":true,"name":"reserved","required":false}],"schema":"v1/pulse-worker-message.json#","type":"topic-exchange"}; // eslint-disable-line
+
+    return this.normalizePattern(entry, pattern);
+  }
+  /* eslint-disable max-len */
+  // Whenever a worker has registered, a message is posted
+  // to this exchange. This means that worker started
+  // successfully and is ready to claim work.
+  /* eslint-enable max-len */
+  workerRunning(pattern) {
+    const entry = {"exchange":"worker-running","name":"workerRunning","routingKey":[{"constant":"primary","multipleWords":false,"name":"routingKeyKind","required":true},{"multipleWords":false,"name":"providerId","required":true},{"multipleWords":false,"name":"provisionerId","required":true},{"multipleWords":false,"name":"workerType","required":true},{"multipleWords":false,"name":"workerGroup","required":true},{"multipleWords":false,"name":"workerId","required":true},{"multipleWords":true,"name":"reserved","required":false}],"schema":"v1/pulse-worker-message.json#","type":"topic-exchange"}; // eslint-disable-line
+
+    return this.normalizePattern(entry, pattern);
+  }
+  /* eslint-disable max-len */
+  // Whenever a worker has stopped, a message is posted
+  // to this exchange. This means that instance was
+  // either terminated or stopped gracefully.
+  /* eslint-enable max-len */
+  workerStopped(pattern) {
+    const entry = {"exchange":"worker-stopped","name":"workerStopped","routingKey":[{"constant":"primary","multipleWords":false,"name":"routingKeyKind","required":true},{"multipleWords":false,"name":"providerId","required":true},{"multipleWords":false,"name":"provisionerId","required":true},{"multipleWords":false,"name":"workerType","required":true},{"multipleWords":false,"name":"workerGroup","required":true},{"multipleWords":false,"name":"workerId","required":true},{"multipleWords":true,"name":"reserved","required":false}],"schema":"v1/pulse-worker-message.json#","type":"topic-exchange"}; // eslint-disable-line
+
+    return this.normalizePattern(entry, pattern);
+  }
+  /* eslint-disable max-len */
+  // Whenever a worker is removed, a message is posted to this exchange.
+  // This occurs when a worker is requested to be removed via an API call
+  // or when a worker is terminated by the worker manager.
+  // The reason for the removal is included in the message.
+  /* eslint-enable max-len */
+  workerRemoved(pattern) {
+    const entry = {"exchange":"worker-removed","name":"workerRemoved","routingKey":[{"constant":"primary","multipleWords":false,"name":"routingKeyKind","required":true},{"multipleWords":false,"name":"providerId","required":true},{"multipleWords":false,"name":"provisionerId","required":true},{"multipleWords":false,"name":"workerType","required":true},{"multipleWords":false,"name":"workerGroup","required":true},{"multipleWords":false,"name":"workerId","required":true},{"multipleWords":true,"name":"reserved","required":false}],"schema":"v1/pulse-worker-removed-message.json#","type":"topic-exchange"}; // eslint-disable-line
 
     return this.normalizePattern(entry, pattern);
   }

--- a/clients/client/src/apis.js
+++ b/clients/client/src/apis.js
@@ -4370,7 +4370,7 @@ export default {
       "description": "These exchanges provide notifications when a worker pool is created or updated.This is so that the provisioner running in a differentprocess at the other end can synchronize to the changes. But you are ofcourse welcome to use these for other purposes, monitoring changes for example.",
       "entries": [
         {
-          "description": "Whenever the api receives a request to create aworker pool, a message is posted to this exchange anda provider can act upon it.",
+          "description": "Whenever the api receives a request to create a\nworker pool, a message is posted to this exchange and\na provider can act upon it.",
           "exchange": "worker-pool-created",
           "name": "workerPoolCreated",
           "routingKey": [
@@ -4380,6 +4380,36 @@ export default {
               "name": "routingKeyKind",
               "required": true,
               "summary": "Identifier for the routing-key kind. This is always `'primary'` for the formalized routing key."
+            },
+            {
+              "multipleWords": false,
+              "name": "providerId",
+              "required": false,
+              "summary": "Provider."
+            },
+            {
+              "multipleWords": false,
+              "name": "provisionerId",
+              "required": false,
+              "summary": "First part of the workerPoolId."
+            },
+            {
+              "multipleWords": false,
+              "name": "workerType",
+              "required": false,
+              "summary": "Second part of the workerPoolId."
+            },
+            {
+              "multipleWords": false,
+              "name": "workerGroup",
+              "required": false,
+              "summary": "Worker group of the worker (region or location)"
+            },
+            {
+              "multipleWords": false,
+              "name": "workerId",
+              "required": false,
+              "summary": "Worker ID"
             },
             {
               "multipleWords": true,
@@ -4393,7 +4423,7 @@ export default {
           "type": "topic-exchange"
         },
         {
-          "description": "Whenever the api receives a request to update aworker pool, a message is posted to this exchange anda provider can act upon it.",
+          "description": "Whenever the api receives a request to update a\nworker pool, a message is posted to this exchange and\na provider can act upon it.",
           "exchange": "worker-pool-updated",
           "name": "workerPoolUpdated",
           "routingKey": [
@@ -4405,6 +4435,36 @@ export default {
               "summary": "Identifier for the routing-key kind. This is always `'primary'` for the formalized routing key."
             },
             {
+              "multipleWords": false,
+              "name": "providerId",
+              "required": false,
+              "summary": "Provider."
+            },
+            {
+              "multipleWords": false,
+              "name": "provisionerId",
+              "required": false,
+              "summary": "First part of the workerPoolId."
+            },
+            {
+              "multipleWords": false,
+              "name": "workerType",
+              "required": false,
+              "summary": "Second part of the workerPoolId."
+            },
+            {
+              "multipleWords": false,
+              "name": "workerGroup",
+              "required": false,
+              "summary": "Worker group of the worker (region or location)"
+            },
+            {
+              "multipleWords": false,
+              "name": "workerId",
+              "required": false,
+              "summary": "Worker ID"
+            },
+            {
               "multipleWords": true,
               "name": "reserved",
               "required": false,
@@ -4413,6 +4473,271 @@ export default {
           ],
           "schema": "v1/pulse-worker-pool-message.json#",
           "title": "Worker Pool Updated Messages",
+          "type": "topic-exchange"
+        },
+        {
+          "description": "Whenever a worker reports an error\nor provisioner encounters an error while\nprovisioning a worker pool, a message is posted to this\nexchange.",
+          "exchange": "worker-pool-error",
+          "name": "workerPoolError",
+          "routingKey": [
+            {
+              "constant": "primary",
+              "multipleWords": false,
+              "name": "routingKeyKind",
+              "required": true,
+              "summary": "Identifier for the routing-key kind. This is always `'primary'` for the formalized routing key."
+            },
+            {
+              "multipleWords": false,
+              "name": "providerId",
+              "required": false,
+              "summary": "Provider."
+            },
+            {
+              "multipleWords": false,
+              "name": "provisionerId",
+              "required": false,
+              "summary": "First part of the workerPoolId."
+            },
+            {
+              "multipleWords": false,
+              "name": "workerType",
+              "required": false,
+              "summary": "Second part of the workerPoolId."
+            },
+            {
+              "multipleWords": false,
+              "name": "workerGroup",
+              "required": false,
+              "summary": "Worker group of the worker (region or location)"
+            },
+            {
+              "multipleWords": false,
+              "name": "workerId",
+              "required": false,
+              "summary": "Worker ID"
+            },
+            {
+              "multipleWords": true,
+              "name": "reserved",
+              "required": false,
+              "summary": "Space reserved for future routing-key entries, you should always match this entry with `#`. As automatically done by our tooling, if not specified."
+            }
+          ],
+          "schema": "v1/pulse-worker-pool-error-message.json#",
+          "title": "Worker Pool Provisioning Error Messages",
+          "type": "topic-exchange"
+        },
+        {
+          "description": "Whenever a worker is requested, a message is posted\nto this exchange.",
+          "exchange": "worker-requested",
+          "name": "workerRequested",
+          "routingKey": [
+            {
+              "constant": "primary",
+              "multipleWords": false,
+              "name": "routingKeyKind",
+              "required": true,
+              "summary": "Identifier for the routing-key kind. This is always `'primary'` for the formalized routing key."
+            },
+            {
+              "multipleWords": false,
+              "name": "providerId",
+              "required": true,
+              "summary": "Provider."
+            },
+            {
+              "multipleWords": false,
+              "name": "provisionerId",
+              "required": true,
+              "summary": "First part of the workerPoolId."
+            },
+            {
+              "multipleWords": false,
+              "name": "workerType",
+              "required": true,
+              "summary": "Second part of the workerPoolId."
+            },
+            {
+              "multipleWords": false,
+              "name": "workerGroup",
+              "required": true,
+              "summary": "Worker group of the worker (region or location)"
+            },
+            {
+              "multipleWords": false,
+              "name": "workerId",
+              "required": true,
+              "summary": "Worker ID"
+            },
+            {
+              "multipleWords": true,
+              "name": "reserved",
+              "required": false,
+              "summary": "Space reserved for future routing-key entries, you should always match this entry with `#`. As automatically done by our tooling, if not specified."
+            }
+          ],
+          "schema": "v1/pulse-worker-message.json#",
+          "title": "Worker Requested Messages",
+          "type": "topic-exchange"
+        },
+        {
+          "description": "Whenever a worker has registered, a message is posted\nto this exchange. This means that worker started\nsuccessfully and is ready to claim work.",
+          "exchange": "worker-running",
+          "name": "workerRunning",
+          "routingKey": [
+            {
+              "constant": "primary",
+              "multipleWords": false,
+              "name": "routingKeyKind",
+              "required": true,
+              "summary": "Identifier for the routing-key kind. This is always `'primary'` for the formalized routing key."
+            },
+            {
+              "multipleWords": false,
+              "name": "providerId",
+              "required": true,
+              "summary": "Provider."
+            },
+            {
+              "multipleWords": false,
+              "name": "provisionerId",
+              "required": true,
+              "summary": "First part of the workerPoolId."
+            },
+            {
+              "multipleWords": false,
+              "name": "workerType",
+              "required": true,
+              "summary": "Second part of the workerPoolId."
+            },
+            {
+              "multipleWords": false,
+              "name": "workerGroup",
+              "required": true,
+              "summary": "Worker group of the worker (region or location)"
+            },
+            {
+              "multipleWords": false,
+              "name": "workerId",
+              "required": true,
+              "summary": "Worker ID"
+            },
+            {
+              "multipleWords": true,
+              "name": "reserved",
+              "required": false,
+              "summary": "Space reserved for future routing-key entries, you should always match this entry with `#`. As automatically done by our tooling, if not specified."
+            }
+          ],
+          "schema": "v1/pulse-worker-message.json#",
+          "title": "Worker Running Messages",
+          "type": "topic-exchange"
+        },
+        {
+          "description": "Whenever a worker has stopped, a message is posted\nto this exchange. This means that instance was\neither terminated or stopped gracefully.",
+          "exchange": "worker-stopped",
+          "name": "workerStopped",
+          "routingKey": [
+            {
+              "constant": "primary",
+              "multipleWords": false,
+              "name": "routingKeyKind",
+              "required": true,
+              "summary": "Identifier for the routing-key kind. This is always `'primary'` for the formalized routing key."
+            },
+            {
+              "multipleWords": false,
+              "name": "providerId",
+              "required": true,
+              "summary": "Provider."
+            },
+            {
+              "multipleWords": false,
+              "name": "provisionerId",
+              "required": true,
+              "summary": "First part of the workerPoolId."
+            },
+            {
+              "multipleWords": false,
+              "name": "workerType",
+              "required": true,
+              "summary": "Second part of the workerPoolId."
+            },
+            {
+              "multipleWords": false,
+              "name": "workerGroup",
+              "required": true,
+              "summary": "Worker group of the worker (region or location)"
+            },
+            {
+              "multipleWords": false,
+              "name": "workerId",
+              "required": true,
+              "summary": "Worker ID"
+            },
+            {
+              "multipleWords": true,
+              "name": "reserved",
+              "required": false,
+              "summary": "Space reserved for future routing-key entries, you should always match this entry with `#`. As automatically done by our tooling, if not specified."
+            }
+          ],
+          "schema": "v1/pulse-worker-message.json#",
+          "title": "Worker Stopped Messages",
+          "type": "topic-exchange"
+        },
+        {
+          "description": "Whenever a worker is removed, a message is posted to this exchange.\nThis occurs when a worker is requested to be removed via an API call\nor when a worker is terminated by the worker manager.\nThe reason for the removal is included in the message.",
+          "exchange": "worker-removed",
+          "name": "workerRemoved",
+          "routingKey": [
+            {
+              "constant": "primary",
+              "multipleWords": false,
+              "name": "routingKeyKind",
+              "required": true,
+              "summary": "Identifier for the routing-key kind. This is always `'primary'` for the formalized routing key."
+            },
+            {
+              "multipleWords": false,
+              "name": "providerId",
+              "required": true,
+              "summary": "Provider."
+            },
+            {
+              "multipleWords": false,
+              "name": "provisionerId",
+              "required": true,
+              "summary": "First part of the workerPoolId."
+            },
+            {
+              "multipleWords": false,
+              "name": "workerType",
+              "required": true,
+              "summary": "Second part of the workerPoolId."
+            },
+            {
+              "multipleWords": false,
+              "name": "workerGroup",
+              "required": true,
+              "summary": "Worker group of the worker (region or location)"
+            },
+            {
+              "multipleWords": false,
+              "name": "workerId",
+              "required": true,
+              "summary": "Worker ID"
+            },
+            {
+              "multipleWords": true,
+              "name": "reserved",
+              "required": false,
+              "summary": "Space reserved for future routing-key entries, you should always match this entry with `#`. As automatically done by our tooling, if not specified."
+            }
+          ],
+          "schema": "v1/pulse-worker-removed-message.json#",
+          "title": "Worker Removed Messages",
           "type": "topic-exchange"
         }
       ],

--- a/generated/references.json
+++ b/generated/references.json
@@ -1305,6 +1305,47 @@
   },
   {
     "content": {
+      "$id": "/schemas/worker-manager/v1/pulse-worker-removed-message.json#",
+      "$schema": "/schemas/common/metaschema.json#",
+      "additionalProperties": false,
+      "description": "The message that is emitted when workers are being removed.",
+      "properties": {
+        "capacity": {
+          "$ref": "worker-full.json#/properties/capacity"
+        },
+        "providerId": {
+          "$ref": "worker-pool-full.json#/properties/providerId"
+        },
+        "reason": {
+          "description": "The reason the worker was removed. It can be one of the following:\n\n- workerManager.removeWorker API call\n- terminateAfter time exceeded\n- operation expired\n- any other error encountered\n",
+          "title": "Reason",
+          "type": "string"
+        },
+        "workerGroup": {
+          "$ref": "worker-full.json#/properties/workerGroup"
+        },
+        "workerId": {
+          "$ref": "worker-full.json#/properties/workerId"
+        },
+        "workerPoolId": {
+          "$ref": "worker-pool-full.json#/properties/workerPoolId"
+        }
+      },
+      "required": [
+        "workerPoolId",
+        "providerId",
+        "workerId",
+        "workerGroup",
+        "capacity",
+        "reason"
+      ],
+      "title": "Worker Removed Pulse Message",
+      "type": "object"
+    },
+    "filename": "schemas/worker-manager/v1/pulse-worker-removed-message.json"
+  },
+  {
+    "content": {
       "$id": "/schemas/worker-manager/v1/pulse-worker-pool-message.json#",
       "$schema": "/schemas/common/metaschema.json#",
       "additionalProperties": false,
@@ -1333,6 +1374,82 @@
       "type": "object"
     },
     "filename": "schemas/worker-manager/v1/pulse-worker-pool-message.json"
+  },
+  {
+    "content": {
+      "$id": "/schemas/worker-manager/v1/pulse-worker-pool-error-message.json#",
+      "$schema": "/schemas/common/metaschema.json#",
+      "additionalProperties": false,
+      "description": "The message that is emitted when worker pools are created/changed/deleted.",
+      "properties": {
+        "errorId": {
+          "$ref": "worker-pool-error.json#/properties/errorId"
+        },
+        "kind": {
+          "$ref": "worker-pool-error.json#/properties/kind"
+        },
+        "providerId": {
+          "$ref": "worker-pool-full.json#/properties/providerId"
+        },
+        "title": {
+          "$ref": "worker-pool-error.json#/properties/title"
+        },
+        "workerGroup": {
+          "$ref": "worker-full.json#/properties/workerGroup"
+        },
+        "workerId": {
+          "$ref": "worker-full.json#/properties/workerId"
+        },
+        "workerPoolId": {
+          "$ref": "worker-pool-full.json#/properties/workerPoolId"
+        }
+      },
+      "required": [
+        "workerPoolId",
+        "providerId",
+        "errorId",
+        "kind",
+        "title"
+      ],
+      "title": "WorkerType Pulse Message",
+      "type": "object"
+    },
+    "filename": "schemas/worker-manager/v1/pulse-worker-pool-error-message.json"
+  },
+  {
+    "content": {
+      "$id": "/schemas/worker-manager/v1/pulse-worker-message.json#",
+      "$schema": "/schemas/common/metaschema.json#",
+      "additionalProperties": false,
+      "description": "The message that is emitted when workers requested/running/stopped.",
+      "properties": {
+        "capacity": {
+          "$ref": "worker-full.json#/properties/capacity"
+        },
+        "providerId": {
+          "$ref": "worker-pool-full.json#/properties/providerId"
+        },
+        "workerGroup": {
+          "$ref": "worker-full.json#/properties/workerGroup"
+        },
+        "workerId": {
+          "$ref": "worker-full.json#/properties/workerId"
+        },
+        "workerPoolId": {
+          "$ref": "worker-pool-full.json#/properties/workerPoolId"
+        }
+      },
+      "required": [
+        "workerPoolId",
+        "providerId",
+        "workerId",
+        "workerGroup",
+        "capacity"
+      ],
+      "title": "Worker Pulse Message",
+      "type": "object"
+    },
+    "filename": "schemas/worker-manager/v1/pulse-worker-message.json"
   },
   {
     "content": {
@@ -14736,7 +14853,7 @@
       "description": "These exchanges provide notifications when a worker pool is created or updated.This is so that the provisioner running in a differentprocess at the other end can synchronize to the changes. But you are ofcourse welcome to use these for other purposes, monitoring changes for example.",
       "entries": [
         {
-          "description": "Whenever the api receives a request to create aworker pool, a message is posted to this exchange anda provider can act upon it.",
+          "description": "Whenever the api receives a request to create a\nworker pool, a message is posted to this exchange and\na provider can act upon it.",
           "exchange": "worker-pool-created",
           "name": "workerPoolCreated",
           "routingKey": [
@@ -14746,6 +14863,36 @@
               "name": "routingKeyKind",
               "required": true,
               "summary": "Identifier for the routing-key kind. This is always `'primary'` for the formalized routing key."
+            },
+            {
+              "multipleWords": false,
+              "name": "providerId",
+              "required": false,
+              "summary": "Provider."
+            },
+            {
+              "multipleWords": false,
+              "name": "provisionerId",
+              "required": false,
+              "summary": "First part of the workerPoolId."
+            },
+            {
+              "multipleWords": false,
+              "name": "workerType",
+              "required": false,
+              "summary": "Second part of the workerPoolId."
+            },
+            {
+              "multipleWords": false,
+              "name": "workerGroup",
+              "required": false,
+              "summary": "Worker group of the worker (region or location)"
+            },
+            {
+              "multipleWords": false,
+              "name": "workerId",
+              "required": false,
+              "summary": "Worker ID"
             },
             {
               "multipleWords": true,
@@ -14759,7 +14906,7 @@
           "type": "topic-exchange"
         },
         {
-          "description": "Whenever the api receives a request to update aworker pool, a message is posted to this exchange anda provider can act upon it.",
+          "description": "Whenever the api receives a request to update a\nworker pool, a message is posted to this exchange and\na provider can act upon it.",
           "exchange": "worker-pool-updated",
           "name": "workerPoolUpdated",
           "routingKey": [
@@ -14771,6 +14918,36 @@
               "summary": "Identifier for the routing-key kind. This is always `'primary'` for the formalized routing key."
             },
             {
+              "multipleWords": false,
+              "name": "providerId",
+              "required": false,
+              "summary": "Provider."
+            },
+            {
+              "multipleWords": false,
+              "name": "provisionerId",
+              "required": false,
+              "summary": "First part of the workerPoolId."
+            },
+            {
+              "multipleWords": false,
+              "name": "workerType",
+              "required": false,
+              "summary": "Second part of the workerPoolId."
+            },
+            {
+              "multipleWords": false,
+              "name": "workerGroup",
+              "required": false,
+              "summary": "Worker group of the worker (region or location)"
+            },
+            {
+              "multipleWords": false,
+              "name": "workerId",
+              "required": false,
+              "summary": "Worker ID"
+            },
+            {
               "multipleWords": true,
               "name": "reserved",
               "required": false,
@@ -14779,6 +14956,271 @@
           ],
           "schema": "v1/pulse-worker-pool-message.json#",
           "title": "Worker Pool Updated Messages",
+          "type": "topic-exchange"
+        },
+        {
+          "description": "Whenever a worker reports an error\nor provisioner encounters an error while\nprovisioning a worker pool, a message is posted to this\nexchange.",
+          "exchange": "worker-pool-error",
+          "name": "workerPoolError",
+          "routingKey": [
+            {
+              "constant": "primary",
+              "multipleWords": false,
+              "name": "routingKeyKind",
+              "required": true,
+              "summary": "Identifier for the routing-key kind. This is always `'primary'` for the formalized routing key."
+            },
+            {
+              "multipleWords": false,
+              "name": "providerId",
+              "required": false,
+              "summary": "Provider."
+            },
+            {
+              "multipleWords": false,
+              "name": "provisionerId",
+              "required": false,
+              "summary": "First part of the workerPoolId."
+            },
+            {
+              "multipleWords": false,
+              "name": "workerType",
+              "required": false,
+              "summary": "Second part of the workerPoolId."
+            },
+            {
+              "multipleWords": false,
+              "name": "workerGroup",
+              "required": false,
+              "summary": "Worker group of the worker (region or location)"
+            },
+            {
+              "multipleWords": false,
+              "name": "workerId",
+              "required": false,
+              "summary": "Worker ID"
+            },
+            {
+              "multipleWords": true,
+              "name": "reserved",
+              "required": false,
+              "summary": "Space reserved for future routing-key entries, you should always match this entry with `#`. As automatically done by our tooling, if not specified."
+            }
+          ],
+          "schema": "v1/pulse-worker-pool-error-message.json#",
+          "title": "Worker Pool Provisioning Error Messages",
+          "type": "topic-exchange"
+        },
+        {
+          "description": "Whenever a worker is requested, a message is posted\nto this exchange.",
+          "exchange": "worker-requested",
+          "name": "workerRequested",
+          "routingKey": [
+            {
+              "constant": "primary",
+              "multipleWords": false,
+              "name": "routingKeyKind",
+              "required": true,
+              "summary": "Identifier for the routing-key kind. This is always `'primary'` for the formalized routing key."
+            },
+            {
+              "multipleWords": false,
+              "name": "providerId",
+              "required": true,
+              "summary": "Provider."
+            },
+            {
+              "multipleWords": false,
+              "name": "provisionerId",
+              "required": true,
+              "summary": "First part of the workerPoolId."
+            },
+            {
+              "multipleWords": false,
+              "name": "workerType",
+              "required": true,
+              "summary": "Second part of the workerPoolId."
+            },
+            {
+              "multipleWords": false,
+              "name": "workerGroup",
+              "required": true,
+              "summary": "Worker group of the worker (region or location)"
+            },
+            {
+              "multipleWords": false,
+              "name": "workerId",
+              "required": true,
+              "summary": "Worker ID"
+            },
+            {
+              "multipleWords": true,
+              "name": "reserved",
+              "required": false,
+              "summary": "Space reserved for future routing-key entries, you should always match this entry with `#`. As automatically done by our tooling, if not specified."
+            }
+          ],
+          "schema": "v1/pulse-worker-message.json#",
+          "title": "Worker Requested Messages",
+          "type": "topic-exchange"
+        },
+        {
+          "description": "Whenever a worker has registered, a message is posted\nto this exchange. This means that worker started\nsuccessfully and is ready to claim work.",
+          "exchange": "worker-running",
+          "name": "workerRunning",
+          "routingKey": [
+            {
+              "constant": "primary",
+              "multipleWords": false,
+              "name": "routingKeyKind",
+              "required": true,
+              "summary": "Identifier for the routing-key kind. This is always `'primary'` for the formalized routing key."
+            },
+            {
+              "multipleWords": false,
+              "name": "providerId",
+              "required": true,
+              "summary": "Provider."
+            },
+            {
+              "multipleWords": false,
+              "name": "provisionerId",
+              "required": true,
+              "summary": "First part of the workerPoolId."
+            },
+            {
+              "multipleWords": false,
+              "name": "workerType",
+              "required": true,
+              "summary": "Second part of the workerPoolId."
+            },
+            {
+              "multipleWords": false,
+              "name": "workerGroup",
+              "required": true,
+              "summary": "Worker group of the worker (region or location)"
+            },
+            {
+              "multipleWords": false,
+              "name": "workerId",
+              "required": true,
+              "summary": "Worker ID"
+            },
+            {
+              "multipleWords": true,
+              "name": "reserved",
+              "required": false,
+              "summary": "Space reserved for future routing-key entries, you should always match this entry with `#`. As automatically done by our tooling, if not specified."
+            }
+          ],
+          "schema": "v1/pulse-worker-message.json#",
+          "title": "Worker Running Messages",
+          "type": "topic-exchange"
+        },
+        {
+          "description": "Whenever a worker has stopped, a message is posted\nto this exchange. This means that instance was\neither terminated or stopped gracefully.",
+          "exchange": "worker-stopped",
+          "name": "workerStopped",
+          "routingKey": [
+            {
+              "constant": "primary",
+              "multipleWords": false,
+              "name": "routingKeyKind",
+              "required": true,
+              "summary": "Identifier for the routing-key kind. This is always `'primary'` for the formalized routing key."
+            },
+            {
+              "multipleWords": false,
+              "name": "providerId",
+              "required": true,
+              "summary": "Provider."
+            },
+            {
+              "multipleWords": false,
+              "name": "provisionerId",
+              "required": true,
+              "summary": "First part of the workerPoolId."
+            },
+            {
+              "multipleWords": false,
+              "name": "workerType",
+              "required": true,
+              "summary": "Second part of the workerPoolId."
+            },
+            {
+              "multipleWords": false,
+              "name": "workerGroup",
+              "required": true,
+              "summary": "Worker group of the worker (region or location)"
+            },
+            {
+              "multipleWords": false,
+              "name": "workerId",
+              "required": true,
+              "summary": "Worker ID"
+            },
+            {
+              "multipleWords": true,
+              "name": "reserved",
+              "required": false,
+              "summary": "Space reserved for future routing-key entries, you should always match this entry with `#`. As automatically done by our tooling, if not specified."
+            }
+          ],
+          "schema": "v1/pulse-worker-message.json#",
+          "title": "Worker Stopped Messages",
+          "type": "topic-exchange"
+        },
+        {
+          "description": "Whenever a worker is removed, a message is posted to this exchange.\nThis occurs when a worker is requested to be removed via an API call\nor when a worker is terminated by the worker manager.\nThe reason for the removal is included in the message.",
+          "exchange": "worker-removed",
+          "name": "workerRemoved",
+          "routingKey": [
+            {
+              "constant": "primary",
+              "multipleWords": false,
+              "name": "routingKeyKind",
+              "required": true,
+              "summary": "Identifier for the routing-key kind. This is always `'primary'` for the formalized routing key."
+            },
+            {
+              "multipleWords": false,
+              "name": "providerId",
+              "required": true,
+              "summary": "Provider."
+            },
+            {
+              "multipleWords": false,
+              "name": "provisionerId",
+              "required": true,
+              "summary": "First part of the workerPoolId."
+            },
+            {
+              "multipleWords": false,
+              "name": "workerType",
+              "required": true,
+              "summary": "Second part of the workerPoolId."
+            },
+            {
+              "multipleWords": false,
+              "name": "workerGroup",
+              "required": true,
+              "summary": "Worker group of the worker (region or location)"
+            },
+            {
+              "multipleWords": false,
+              "name": "workerId",
+              "required": true,
+              "summary": "Worker ID"
+            },
+            {
+              "multipleWords": true,
+              "name": "reserved",
+              "required": false,
+              "summary": "Space reserved for future routing-key entries, you should always match this entry with `#`. As automatically done by our tooling, if not specified."
+            }
+          ],
+          "schema": "v1/pulse-worker-removed-message.json#",
+          "title": "Worker Removed Messages",
           "type": "topic-exchange"
         }
       ],

--- a/services/worker-manager/schemas/v1/pulse-worker-message.yml
+++ b/services/worker-manager/schemas/v1/pulse-worker-message.yml
@@ -1,0 +1,17 @@
+$schema: "/schemas/common/metaschema.json#"
+title: Worker Pulse Message
+description: The message that is emitted when workers requested/running/stopped.
+type: object
+properties:
+  workerPoolId: {$ref: "worker-pool-full.json#/properties/workerPoolId"}
+  providerId: {$ref: "worker-pool-full.json#/properties/providerId"}
+  workerId: {$ref: "worker-full.json#/properties/workerId"}
+  workerGroup: {$ref: "worker-full.json#/properties/workerGroup"}
+  capacity: {$ref: "worker-full.json#/properties/capacity"}
+additionalProperties: false
+required:
+  - workerPoolId
+  - providerId
+  - workerId
+  - workerGroup
+  - capacity

--- a/services/worker-manager/schemas/v1/pulse-worker-pool-error-message.yml
+++ b/services/worker-manager/schemas/v1/pulse-worker-pool-error-message.yml
@@ -1,0 +1,20 @@
+$schema: "/schemas/common/metaschema.json#"
+title: WorkerType Pulse Message
+description: The message that is emitted when worker pools are created/changed/deleted.
+type: object
+properties:
+  workerPoolId: {$ref: "worker-pool-full.json#/properties/workerPoolId"}
+  providerId: {$ref: "worker-pool-full.json#/properties/providerId"}
+  # workerId can be null if error happened at provision time
+  workerId: {$ref: "worker-full.json#/properties/workerId"}
+  workerGroup: {$ref: "worker-full.json#/properties/workerGroup"}
+  errorId: {$ref: "worker-pool-error.json#/properties/errorId"}
+  kind: {$ref: "worker-pool-error.json#/properties/kind"}
+  title: {$ref: "worker-pool-error.json#/properties/title"}
+additionalProperties: false
+required:
+  - workerPoolId
+  - providerId
+  - errorId
+  - kind
+  - title

--- a/services/worker-manager/schemas/v1/pulse-worker-removed-message.yml
+++ b/services/worker-manager/schemas/v1/pulse-worker-removed-message.yml
@@ -1,0 +1,28 @@
+$schema: "/schemas/common/metaschema.json#"
+title: Worker Removed Pulse Message
+description: The message that is emitted when workers are being removed.
+type: object
+properties:
+  workerPoolId: {$ref: "worker-pool-full.json#/properties/workerPoolId"}
+  providerId: {$ref: "worker-pool-full.json#/properties/providerId"}
+  workerId: {$ref: "worker-full.json#/properties/workerId"}
+  workerGroup: {$ref: "worker-full.json#/properties/workerGroup"}
+  capacity: {$ref: "worker-full.json#/properties/capacity"}
+  reason:
+    title: Reason
+    type: string
+    description: |
+      The reason the worker was removed. It can be one of the following:
+
+      - workerManager.removeWorker API call
+      - terminateAfter time exceeded
+      - operation expired
+      - any other error encountered
+additionalProperties: false
+required:
+  - workerPoolId
+  - providerId
+  - workerId
+  - workerGroup
+  - capacity
+  - reason

--- a/services/worker-manager/src/main.js
+++ b/services/worker-manager/src/main.js
@@ -178,13 +178,15 @@ let load = loader({
     }),
   },
 
+  validator: {
+    requires: ['cfg', 'schemaset'],
+    setup: async ({ cfg, schemaset }) => await schemaset.validator(cfg.taskcluster.rootUrl),
+  },
+
   providers: {
-    requires: ['cfg', 'monitor', 'notify', 'db', 'estimator', 'schemaset'],
-    setup: async ({ cfg, monitor, notify, db, estimator, schemaset }) =>
-      new Providers().setup({
-        cfg, monitor, notify, db, estimator,
-        validator: await schemaset.validator(cfg.taskcluster.rootUrl),
-      }),
+    requires: ['cfg', 'monitor', 'notify', 'db', 'estimator', 'schemaset', 'publisher', 'validator'],
+    setup: async ({ cfg, monitor, notify, db, estimator, schemaset, publisher, validator }) =>
+      new Providers().setup({ cfg, monitor, notify, db, estimator, publisher, validator }),
   },
 
   azureProviderIds: {

--- a/services/worker-manager/src/providers/index.js
+++ b/services/worker-manager/src/providers/index.js
@@ -27,7 +27,7 @@ export const setSetupRetryInterval = i => SETUP_RETRY_INTERVAL = i;
  * properly by never returning a failed provider.
  */
 export class Providers {
-  async setup({ cfg, monitor, notify, db, estimator, Worker, WorkerPoolError, validator }) {
+  async setup({ cfg, monitor, notify, db, estimator, Worker, WorkerPoolError, validator, publisher }) {
     this.monitor = monitor;
     this._providers = {};
 
@@ -56,6 +56,7 @@ export class Providers {
         validator,
         providerConfig,
         providerType: providerConfig.providerType,
+        publisher,
       });
       this._providers[providerId] = provider;
 

--- a/services/worker-manager/test/fakes/google.js
+++ b/services/worker-manager/test/fakes/google.js
@@ -148,7 +148,8 @@ export class Instances {
     }
     return {
       data: {
-        targetId: `instance-${parameters.requestBody.name}`,
+        // workerIds have a max length of 38
+        targetId: `i-${parameters.requestBody.name}`.substring(0, 38),
         ...this.fake.compute.zoneOperations.fakeOperation({
           zone: parameters.zone,
           status: 'RUNNING',

--- a/services/worker-manager/test/provider_static_test.js
+++ b/services/worker-manager/test/provider_static_test.js
@@ -41,6 +41,8 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       notify: await helper.load('notify'),
       monitor: (await helper.load('monitor')).childMonitor('google'),
       estimator: await helper.load('estimator'),
+      validator: await helper.load('validator'),
+      publisher: await helper.load('publisher'),
       fakeCloudApis: {},
       rootUrl: helper.rootUrl,
       Worker: helper.Worker,

--- a/services/worker-manager/test/provider_test.js
+++ b/services/worker-manager/test/provider_test.js
@@ -8,6 +8,7 @@ import { LEVELS } from 'taskcluster-lib-monitor';
 
 helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
   helper.withDb(mock, skipping);
+  helper.withPulse(mock, skipping);
   helper.withFakeNotify(mock, skipping);
   helper.resetTables(mock, skipping);
 
@@ -162,7 +163,9 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
         db: helper.db,
         monitor,
         WorkerPoolError: WorkerPoolError,
-        // other stuff omitted..
+        estimator: await helper.load('estimator'),
+        validator: await helper.load('validator'),
+        publisher: await helper.load('publisher'),
       });
     });
 

--- a/services/worker-manager/test/providers_test.js
+++ b/services/worker-manager/test/providers_test.js
@@ -5,6 +5,7 @@ import { setSetupRetryInterval } from '../src/providers/index.js';
 
 helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
   helper.withDb(mock, skipping);
+  helper.withPulse(mock, skipping);
   helper.withFakeNotify(mock, skipping);
   helper.withProviders(mock, skipping);
   helper.resetTables(mock, skipping);


### PR DESCRIPTION
Following exchanges would have events published:

- `worker-pool-error`
- `worker-requested`
- `worker-running`
- `worker-removed` + reason
- `worker-stopped`


Worker events would contain following payload fields:

- `workerPoolId`
- `providerId`
- `workerId`
- `workerGroup`
- `capacity`
- `reason` Only for the `worker-removed` event

Routing would be extended to include: `providerId`, `provisionerId`, `workerType`, `workerGroup`, `workerId` so one could subscribe to specific worker pool

`#.providerId.provisioner.workerType.workerGroup.workerId.#`



Fixes #7085 
