### PR TITLE
fix(d2g): disable memory, pid, or ulimits in d2g (fixes #7120)

### DIFF
--- a/changelog/issue-7120.md
+++ b/changelog/issue-7120.md
@@ -1,0 +1,6 @@
+audience: users
+level: patch
+reference: issue 7120
+---
+
+Removed memory, pid, and ulimits for d2g payloads.

--- a/tools/d2g/d2g.go
+++ b/tools/d2g/d2g.go
@@ -306,6 +306,15 @@ func runCommand(containerName string, dwPayload *dockerworker.DockerWorkerPayloa
 	default:
 		command.WriteString(fmt.Sprintf("timeout %v %v run -t --name %v", dwPayload.MaxRunTime, tool, containerName))
 	}
+	// Do not limit resource usage by the containerName. See
+	// https://docs.podman.io/en/latest/markdown/podman-run.1.html
+	// and https://docs.docker.com/reference/cli/docker/container/run/
+	command.WriteString(" --memory-swap -1 --pids-limit -1")
+	// Only podman supports inheriting host ulimits. `docker` uses docker
+	// daemon settings by default.
+	if tool == "podman" {
+		command.WriteString(" --ulimit host")
+	}
 	// Sometimes --privileged is needed under podman, even where there are no
 	// capabilities defined. Therefore always add it under podman, regardless.
 	// See e.g.  https://github.com/taskcluster/taskcluster/issues/6888

--- a/tools/d2g/d2gtest/testdata/testcases/artifacts_test.yml
+++ b/tools/d2g/d2gtest/testdata/testcases/artifacts_test.yml
@@ -33,7 +33,8 @@ testSuite:
           - - bash
             - '-cx'
             - >-
-              timeout 3600 podman run -t --name taskcontainer --privileged
+              timeout 3600 podman run -t --name taskcontainer
+              --memory-swap -1 --pids-limit -1 --ulimit host --privileged
               -e RUN_ID
               -e TASKCLUSTER_INSTANCE_TYPE
               -e TASKCLUSTER_ROOT_URL

--- a/tools/d2g/d2gtest/testdata/testcases/decision_task_tests.yml
+++ b/tools/d2g/d2gtest/testdata/testcases/decision_task_tests.yml
@@ -81,8 +81,9 @@ testSuite:
           - - bash
             - '-cx'
             - >-
-              timeout 3600 docker run -t --name taskcontainer --privileged -v
-              "$(pwd)/cache0:/builds/worker/checkouts"
+              timeout 3600 docker run -t --name taskcontainer
+              --memory-swap -1 --pids-limit -1 --privileged
+              -v "$(pwd)/cache0:/builds/worker/checkouts"
               --add-host=taskcluster:127.0.0.1 --net=host
               -e GECKO_BASE_REPOSITORY
               -e GECKO_BASE_REV

--- a/tools/d2g/d2gtest/testdata/testcases/devices_tests.yml
+++ b/tools/d2g/d2gtest/testdata/testcases/devices_tests.yml
@@ -19,7 +19,7 @@ testSuite:
           - - bash
             - '-cx'
             - >-
-              podman run -t --rm --privileged
+              podman run -t --rm --memory-swap -1 --pids-limit -1 --ulimit host --privileged
               -v /dev/shm:/dev/shm
               -e RUN_ID
               -e TASKCLUSTER_INSTANCE_TYPE
@@ -49,7 +49,7 @@ testSuite:
           - - bash
             - '-cx'
             - >-
-              podman run -t --rm --privileged
+              podman run -t --rm --memory-swap -1 --pids-limit -1 --ulimit host --privileged
               -v /dev/kvm:/dev/kvm
               -e RUN_ID
               -e TASKCLUSTER_INSTANCE_TYPE
@@ -82,7 +82,7 @@ testSuite:
           - - bash
             - '-cx'
             - >-
-              podman run -t --rm --privileged
+              podman run -t --rm --memory-swap -1 --pids-limit -1 --ulimit host --privileged
               -v "${TASKCLUSTER_VIDEO_DEVICE}:${TASKCLUSTER_VIDEO_DEVICE}"
               -e RUN_ID
               -e TASKCLUSTER_INSTANCE_TYPE
@@ -114,7 +114,7 @@ testSuite:
           - - bash
             - '-cx'
             - >-
-              podman run -t --rm --privileged
+              podman run -t --rm --memory-swap -1 --pids-limit -1 --ulimit host --privileged
               -v /dev/snd:/dev/snd
               -e RUN_ID
               -e TASKCLUSTER_INSTANCE_TYPE

--- a/tools/d2g/d2gtest/testdata/testcases/docker_image_tests.yml
+++ b/tools/d2g/d2gtest/testdata/testcases/docker_image_tests.yml
@@ -15,7 +15,7 @@ testSuite:
           - - bash
             - '-cx'
             - >-
-              podman run -t --rm --privileged
+              podman run -t --rm --memory-swap -1 --pids-limit -1 --ulimit host --privileged
               -e RUN_ID
               -e TASKCLUSTER_INSTANCE_TYPE
               -e TASKCLUSTER_ROOT_URL
@@ -42,7 +42,7 @@ testSuite:
           - - bash
             - '-cx'
             - >-
-              podman run -t --rm --privileged
+              podman run -t --rm --memory-swap -1 --pids-limit -1 --ulimit host --privileged
               -e RUN_ID
               -e TASKCLUSTER_INSTANCE_TYPE
               -e TASKCLUSTER_ROOT_URL
@@ -70,7 +70,7 @@ testSuite:
           - - bash
             - '-cx'
             - >-
-              podman run -t --rm --privileged
+              podman run -t --rm --memory-swap -1 --pids-limit -1 --ulimit host --privileged
               -e RUN_ID
               -e TASKCLUSTER_INSTANCE_TYPE
               -e TASKCLUSTER_ROOT_URL
@@ -105,7 +105,7 @@ testSuite:
           - - bash
             - '-cx'
             - >-
-              podman run -t --rm --privileged
+              podman run -t --rm --memory-swap -1 --pids-limit -1 --ulimit host --privileged
               -e RUN_ID
               -e TASKCLUSTER_INSTANCE_TYPE
               -e TASKCLUSTER_ROOT_URL
@@ -141,7 +141,7 @@ testSuite:
           - - bash
             - '-cx'
             - >-
-              podman run -t --rm --privileged
+              podman run -t --rm --memory-swap -1 --pids-limit -1 --ulimit host --privileged
               -e RUN_ID
               -e TASKCLUSTER_INSTANCE_TYPE
               -e TASKCLUSTER_ROOT_URL
@@ -177,7 +177,7 @@ testSuite:
           - - bash
             - '-cx'
             - >-
-              podman run -t --rm --privileged
+              podman run -t --rm --memory-swap -1 --pids-limit -1 --ulimit host --privileged
               -e RUN_ID
               -e TASKCLUSTER_INSTANCE_TYPE
               -e TASKCLUSTER_ROOT_URL
@@ -210,7 +210,7 @@ testSuite:
           - - bash
             - '-cx'
             - >-
-              podman run -t --rm --privileged
+              podman run -t --rm --memory-swap -1 --pids-limit -1 --ulimit host --privileged
               -e RUN_ID
               -e TASKCLUSTER_INSTANCE_TYPE
               -e TASKCLUSTER_ROOT_URL
@@ -244,7 +244,7 @@ testSuite:
           - - bash
             - '-cx'
             - >-
-              podman run -t --rm --privileged
+              podman run -t --rm --memory-swap -1 --pids-limit -1 --ulimit host --privileged
               -e RUN_ID
               -e TASKCLUSTER_INSTANCE_TYPE
               -e TASKCLUSTER_ROOT_URL

--- a/tools/d2g/d2gtest/testdata/testcases/env_escaping_test.yml
+++ b/tools/d2g/d2gtest/testdata/testcases/env_escaping_test.yml
@@ -19,7 +19,7 @@ testSuite:
           - - bash
             - '-cx'
             - >-
-              podman run -t --rm --privileged
+              podman run -t --rm --memory-swap -1 --pids-limit -1 --ulimit host --privileged
               -e ' test123 --help  ; whoami ; '
               -e RUN_ID
               -e TASKCLUSTER_INSTANCE_TYPE

--- a/tools/d2g/d2gtest/testdata/testcases/fuzzing_tests.yml
+++ b/tools/d2g/d2gtest/testdata/testcases/fuzzing_tests.yml
@@ -39,7 +39,8 @@ testSuite:
         - - bash
           - "-cx"
           - "IMAGE_ID=$(docker load --input dockerimage | sed -n '0,/^Loaded image: /s/^Loaded image:
-            //p')\ntimeout 14400 docker run -t --name taskcontainer --privileged --security-opt=seccomp=unconfined
+            //p')\ntimeout 14400 docker run -t --name taskcontainer
+            --memory-swap -1 --pids-limit -1 --privileged --security-opt=seccomp=unconfined
             -v /dev/shm:/dev/shm -v /dev/snd:/dev/snd --add-host=taskcluster:127.0.0.1 --net=host
             -e BUG_ACTION -e MONITOR_ARTIFACT -e PROCESSOR_ARTIFACT -e RUN_ID -e TASKCLUSTER_INSTANCE_TYPE
             -e TASKCLUSTER_PROXY_URL -e TASKCLUSTER_ROOT_URL -e TASKCLUSTER_WORKER_LOCATION -e TASK_ID

--- a/tools/d2g/d2gtest/testdata/testcases/no_artifacts_test.yml
+++ b/tools/d2g/d2gtest/testdata/testcases/no_artifacts_test.yml
@@ -23,7 +23,7 @@ testSuite:
           - - bash
             - '-cx'
             - >-
-              podman run -t --rm --privileged
+              podman run -t --rm --memory-swap -1 --pids-limit -1 --ulimit host --privileged
               -e RUN_ID
               -e TASKCLUSTER_INSTANCE_TYPE
               -e TASKCLUSTER_ROOT_URL

--- a/tools/d2g/d2gtest/testdata/testcases/task_def_test.yml
+++ b/tools/d2g/d2gtest/testdata/testcases/task_def_test.yml
@@ -56,7 +56,7 @@ testSuite:
           command:
           - - bash
             - -cx
-            - podman run -t --rm --privileged -v /dev/kvm:/dev/kvm -e RUN_ID -e TASKCLUSTER_INSTANCE_TYPE
+            - podman run -t --rm --memory-swap -1 --pids-limit -1 --ulimit host --privileged -v /dev/kvm:/dev/kvm -e RUN_ID -e TASKCLUSTER_INSTANCE_TYPE
               -e TASKCLUSTER_ROOT_URL -e TASKCLUSTER_WORKER_LOCATION -e TASK_ID ubuntu:latest /bin/bash -c
               'for ((i=1;i<=600;i++)); do echo $i; sleep 1; done'
           features:
@@ -140,7 +140,7 @@ testSuite:
           command:
           - - bash
             - -cx
-            - podman run -t --rm --privileged -v /dev/kvm:/dev/kvm -e RUN_ID -e TASKCLUSTER_INSTANCE_TYPE
+            - podman run -t --rm --memory-swap -1 --pids-limit -1 --ulimit host --privileged -v /dev/kvm:/dev/kvm -e RUN_ID -e TASKCLUSTER_INSTANCE_TYPE
               -e TASKCLUSTER_ROOT_URL -e TASKCLUSTER_WORKER_LOCATION -e TASK_ID ubuntu:latest /bin/bash -c
               'for ((i=1;i<=600;i++)); do echo $i; sleep 1; done'
           features:
@@ -227,7 +227,7 @@ testSuite:
           command:
           - - bash
             - -cx
-            - podman run -t --rm --privileged -v /dev/kvm:/dev/kvm -e RUN_ID -e TASKCLUSTER_INSTANCE_TYPE
+            - podman run -t --rm --memory-swap -1 --pids-limit -1 --ulimit host --privileged -v /dev/kvm:/dev/kvm -e RUN_ID -e TASKCLUSTER_INSTANCE_TYPE
               -e TASKCLUSTER_ROOT_URL -e TASKCLUSTER_WORKER_LOCATION -e TASK_ID ubuntu:latest /bin/bash -c
               'for ((i=1;i<=600;i++)); do echo $i; sleep 1; done'
           features:


### PR DESCRIPTION
These seem to be the key ones in the cases that I've had issues. I also looked at:
- Removing CPU limits - but after a reread of the docs, it looks like that only applies when multiple containers are competing for resources, which is something that rarely happens in practice, and there's no way to "disable" them (you need to set limits and shares for each container, which d2g can't do intelligently)>
- Setting shm size. I didn't change this in the end because there's no way to make it unlimited, and unless we have a reason to believe it needs to be increased, it may as well stay as the default.

Github Bug/Issue: Fixes #7120 