### PR TITLE
Add timestamp field to the worker related events

### DIFF
--- a/changelog/issue-7085.md
+++ b/changelog/issue-7085.md
@@ -1,0 +1,6 @@
+audience: users
+level: patch
+reference: issue 7085
+---
+
+Adds `timestamp` to the worker related pulse events that were added in #7085.

--- a/clients/client-go/tcworkermanagerevents/types.go
+++ b/clients/client-go/tcworkermanagerevents/types.go
@@ -2,6 +2,10 @@
 
 package tcworkermanagerevents
 
+import (
+	tcclient "github.com/taskcluster/taskcluster/v67/clients/client-go"
+)
+
 type (
 	// The message that is emitted when workers requested/running/stopped.
 	WorkerPulseMessage struct {
@@ -20,6 +24,9 @@ type (
 		// Min length: 1
 		// Max length: 38
 		ProviderID string `json:"providerId"`
+
+		// Date and time when this event occurred
+		Timestamp tcclient.Time `json:"timestamp"`
 
 		// Worker group to which this worker belongs
 		//
@@ -66,6 +73,9 @@ type (
 		// - operation expired
 		// - any other error encountered
 		Reason string `json:"reason"`
+
+		// Date and time when this event occurred
+		Timestamp tcclient.Time `json:"timestamp"`
 
 		// Worker group to which this worker belongs
 		//
@@ -139,6 +149,9 @@ type (
 		// Min length: 1
 		// Max length: 38
 		ProviderID string `json:"providerId"`
+
+		// Date and time when this event occurred
+		Timestamp tcclient.Time `json:"timestamp"`
 
 		// A human-readable version of `kind`.
 		//

--- a/generated/references.json
+++ b/generated/references.json
@@ -1321,6 +1321,12 @@
           "title": "Reason",
           "type": "string"
         },
+        "timestamp": {
+          "description": "Date and time when this event occurred",
+          "format": "date-time",
+          "title": "Event timestamp",
+          "type": "string"
+        },
         "workerGroup": {
           "$ref": "worker-full.json#/properties/workerGroup"
         },
@@ -1337,7 +1343,8 @@
         "workerId",
         "workerGroup",
         "capacity",
-        "reason"
+        "reason",
+        "timestamp"
       ],
       "title": "Worker Removed Pulse Message",
       "type": "object"
@@ -1391,6 +1398,12 @@
         "providerId": {
           "$ref": "worker-pool-full.json#/properties/providerId"
         },
+        "timestamp": {
+          "description": "Date and time when this event occurred",
+          "format": "date-time",
+          "title": "Event timestamp",
+          "type": "string"
+        },
         "title": {
           "$ref": "worker-pool-error.json#/properties/title"
         },
@@ -1409,7 +1422,8 @@
         "providerId",
         "errorId",
         "kind",
-        "title"
+        "title",
+        "timestamp"
       ],
       "title": "WorkerType Pulse Message",
       "type": "object"
@@ -1429,6 +1443,12 @@
         "providerId": {
           "$ref": "worker-pool-full.json#/properties/providerId"
         },
+        "timestamp": {
+          "description": "Date and time when this event occurred",
+          "format": "date-time",
+          "title": "Event timestamp",
+          "type": "string"
+        },
         "workerGroup": {
           "$ref": "worker-full.json#/properties/workerGroup"
         },
@@ -1444,7 +1464,8 @@
         "providerId",
         "workerId",
         "workerGroup",
-        "capacity"
+        "capacity",
+        "timestamp"
       ],
       "title": "Worker Pulse Message",
       "type": "object"

--- a/services/worker-manager/schemas/v1/pulse-worker-message.yml
+++ b/services/worker-manager/schemas/v1/pulse-worker-message.yml
@@ -8,6 +8,12 @@ properties:
   workerId: {$ref: "worker-full.json#/properties/workerId"}
   workerGroup: {$ref: "worker-full.json#/properties/workerGroup"}
   capacity: {$ref: "worker-full.json#/properties/capacity"}
+  timestamp:
+    title: Event timestamp
+    description: Date and time when this event occurred
+    type: string
+    format: date-time
+
 additionalProperties: false
 required:
   - workerPoolId
@@ -15,3 +21,4 @@ required:
   - workerId
   - workerGroup
   - capacity
+  - timestamp

--- a/services/worker-manager/schemas/v1/pulse-worker-pool-error-message.yml
+++ b/services/worker-manager/schemas/v1/pulse-worker-pool-error-message.yml
@@ -11,6 +11,11 @@ properties:
   errorId: {$ref: "worker-pool-error.json#/properties/errorId"}
   kind: {$ref: "worker-pool-error.json#/properties/kind"}
   title: {$ref: "worker-pool-error.json#/properties/title"}
+  timestamp:
+    title: Event timestamp
+    description: Date and time when this event occurred
+    type: string
+    format: date-time
 additionalProperties: false
 required:
   - workerPoolId
@@ -18,3 +23,4 @@ required:
   - errorId
   - kind
   - title
+  - timestamp

--- a/services/worker-manager/schemas/v1/pulse-worker-removed-message.yml
+++ b/services/worker-manager/schemas/v1/pulse-worker-removed-message.yml
@@ -18,6 +18,11 @@ properties:
       - terminateAfter time exceeded
       - operation expired
       - any other error encountered
+  timestamp:
+    title: Event timestamp
+    description: Date and time when this event occurred
+    type: string
+    format: date-time
 additionalProperties: false
 required:
   - workerPoolId
@@ -26,3 +31,4 @@ required:
   - workerGroup
   - capacity
   - reason
+  - timestamp

--- a/services/worker-manager/src/providers/provider.js
+++ b/services/worker-manager/src/providers/provider.js
@@ -140,6 +140,7 @@ export class Provider {
       workerId: worker.workerId,
       workerGroup: worker.workerGroup,
       capacity: worker.capacity,
+      timestamp: new Date().toJSON(),
       ...extraPublish,
     });
   }
@@ -255,6 +256,7 @@ export class Provider {
         errorId,
         kind,
         title,
+        timestamp: new Date().toJSON(),
         workerId: extra?.workerId,
         workerGroup: extra?.workerGroup,
       });

--- a/services/worker-manager/test/api_test.js
+++ b/services/worker-manager/test/api_test.js
@@ -865,6 +865,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function (mock, skipping) {
       });
     });
 
+    const beforeTime = new Date();
     await helper.workerManager.reportWorkerError(workerPoolId, {
       workerGroup: 'wg',
       workerId: 'wi',
@@ -901,6 +902,9 @@ helper.secrets.mockSuite(testing.suiteName(), [], function (mock, skipping) {
     assert.equal(messages[0].exchange, 'exchange/taskcluster-worker-manager/v1/worker-pool-error');
     assert.equal(messages[0].routingKey, 'primary.testing1.foobar.baz.wg.wi._');
     let { errorId, ...msgData } = messages[0].data;
+    assert(new Date(msgData.timestamp) > beforeTime.getTime() - 1);
+
+    msgData.timestamp = 'xx';
     assert.deepEqual(msgData, {
       workerPoolId,
       providerId: 'testing1',
@@ -908,6 +912,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function (mock, skipping) {
       title: 'Something is Wrong',
       workerId: 'wi',
       workerGroup: 'wg',
+      timestamp: 'xx',
     });
   });
 


### PR DESCRIPTION
So far payloads didn't contain time information inside, so if someone would to process events async, not in real-time, it would be impossible to know when a particular event happened.

This is an addition to #7085
