### PR TITLE
feat(cli): Add an option to output short-version only for all cli tools

### DIFF
--- a/changelog/issue-7073.md
+++ b/changelog/issue-7073.md
@@ -1,0 +1,12 @@
+audience: worker-deployers
+level: patch
+reference: issue 7073
+---
+
+CLI tools and generic-worker now returns short-version string if executed with `--short-version` argument:
+
+- `generic-worker --short-version`
+- `livelog --short-version`
+- `websocktunnel --short-version`
+- `start-worker --short-version`
+- `taskcluster version --short-version`

--- a/clients/client-shell/cmds/version/version.go
+++ b/clients/client-shell/cmds/version/version.go
@@ -47,14 +47,24 @@ var (
 	VersionNumber = "67.0.1"
 )
 
+var (
+	// short version flag
+	shortVersion bool
+)
+
 var log = root.Logger
 
 func init() {
 	root.Command.AddCommand(Command)
 	root.Command.AddCommand(Updcommand)
+	Command.Flags().BoolVarP(&shortVersion, "short-version", "s", false, "Prints the version number only")
 }
 
 func printVersion(cmd *cobra.Command, _ []string) {
+	if shortVersion {
+		fmt.Fprintf(cmd.OutOrStdout(), "%s\n", VersionNumber)
+		return
+	}
 	fmt.Fprintf(cmd.OutOrStdout(), "taskcluster version %s\n", VersionNumber)
 }
 

--- a/tools/livelog/main.go
+++ b/tools/livelog/main.go
@@ -10,6 +10,8 @@ import (
 	"strconv"
 	"sync"
 
+	docopt "github.com/docopt/docopt-go"
+	"github.com/taskcluster/taskcluster/v67/internal"
 	stream "github.com/taskcluster/taskcluster/v67/tools/livelog/writer"
 )
 
@@ -17,6 +19,21 @@ const (
 	DEFAULT_PUT_PORT = 60022
 	DEFAULT_GET_PORT = 60023
 )
+
+const usage = `Livelog
+
+Usage: livelog [-h | --help | --short-version | --version]
+
+Environment:
+ LIVELOG_GET_PORT (required)	port on which to listen for GET requests to serve logs
+ LIVELOG_PUT_PORT (required)	port on which to listen for PUT requests to receive logs
+ ACCESS_TOKEN			an arbitrary url-safe string
+ SERVER_CRT_FILE		path to a file containing a certificate, if not provided, the server will run without TLS
+ SERVER_KEY_FILE		path to a file containing a key, if not provided, the server will run without TLS
+
+Options:
+-h --help       Show help
+--short-version Show only the semantic version`
 
 // Run an http.Server.  In production this is just `ListenAndServe`, but
 // is overridden in testing to use ephemeral ports and ensure servers are
@@ -136,6 +153,13 @@ func attachProfiler(router *http.ServeMux) {
 }
 
 func main() {
+	opts, _ := docopt.ParseArgs(usage, nil, "livelog "+internal.Version)
+
+	if opts["--short-version"].(bool) {
+		fmt.Println(internal.Version)
+		os.Exit(0)
+	}
+
 	// TODO: Right now this is a collection of hacks until we build out something
 	// nice which can handle multiple log connections. Right now the intent is to
 	// use this as a process per task (which has overhead) but should be fairly

--- a/tools/taskcluster-proxy/main.go
+++ b/tools/taskcluster-proxy/main.go
@@ -26,10 +26,12 @@ task id.
     taskcluster-proxy [options] [<scope>...]
     taskcluster-proxy -h|--help
     taskcluster-proxy --version
+    taskcluster-proxy --short-version
 
   Options:
     -h --help                       Show this help screen.
     --version                       Show the taskcluster-proxy version number.
+    --short-version                 Show only the semantic version.
     -p --port <port>                Port to bind the proxy server to [default: 8080].
     -i --ip-address <address>       IPv4 or IPv6 address of network interface to bind listener to.
                                     If not provided, will bind listener to all available network
@@ -82,6 +84,11 @@ func ParseCommandArgs(argv []string, exit bool) (routes Routes, address string, 
 	arguments, err = docopt.ParseArgs(usage, argv, fullversion)
 	if err != nil {
 		return
+	}
+
+	if arguments["--short-version"].(bool) {
+		fmt.Println(version)
+		os.Exit(0)
 	}
 
 	log.Printf("Version: %v", fullversion)

--- a/tools/websocktunnel/cmd/websocktunnel/main.go
+++ b/tools/websocktunnel/cmd/websocktunnel/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"crypto/tls"
 	"encoding/base64"
+	"fmt"
 	"log/syslog"
 	"net/http"
 	"os"
@@ -18,7 +19,7 @@ import (
 
 const usage = `Websocketunnel Server
 
-Usage: websocktunnel [-h | --help]
+Usage: websocktunnel [-h | --help | --short-version | --version]
 
 Environment:
  URL_PREFIX (required)								URL prefix (http(s)://hostname(:port)) at which
@@ -32,10 +33,16 @@ Environment:
  AUDIENCE											JWT 'audience' claim
 
 Options:
--h --help       Show help`
+-h --help       Show help
+--short-version Show only the semantic version`
 
 func main() {
-	_, _ = docopt.ParseArgs(usage, nil, "websocktunnel "+internal.Version)
+	opts, _ := docopt.ParseArgs(usage, nil, "websocktunnel "+internal.Version)
+
+	if opts["--short-version"].(bool) {
+		fmt.Printf("%s\n", internal.Version)
+		os.Exit(0)
+	}
 
 	urlPrefix := os.Getenv("URL_PREFIX")
 	if urlPrefix == "" {

--- a/tools/worker-runner/cmd/start-worker/main.go
+++ b/tools/worker-runner/cmd/start-worker/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"log"
 	"os"
 
@@ -19,6 +20,8 @@ deployment for details on how to use this tool.
 
 Usage:
 	start-worker <runnerConfig>
+	start-worker --version
+	start-worker --short-version
 `
 }
 
@@ -33,6 +36,11 @@ func main() {
 	if err != nil {
 		log.Printf("Error parsing command-line arguments: %s", err)
 		os.Exit(1)
+	}
+
+	if opts["--short-version"].(bool) {
+		fmt.Println(internal.Version)
+		os.Exit(0)
 	}
 
 	filename := opts["<runnerConfig>"].(string)

--- a/workers/generic-worker/README.md
+++ b/workers/generic-worker/README.md
@@ -27,6 +27,7 @@ and reports back results to the queue.
     generic-worker unarchive                --archive-src ARCHIVE-SRC --archive-dst ARCHIVE-DST --archive-fmt ARCHIVE-FMT
     generic-worker --help
     generic-worker --version
+    generic-worker --short-version
 
   Targets:
     run                                     Runs the generic-worker.  Pass --with-worker-runner if
@@ -79,6 +80,7 @@ and reports back results to the queue.
     --archive-fmt ARCHIVE-FMT               The format of the archive file to unarchive.
     --help                                  Display this help text.
     --version                               The release version of the generic-worker.
+    --short-version                         Only the semantic version of generic-worker.
 
 
   Configuring the generic worker:

--- a/workers/generic-worker/main.go
+++ b/workers/generic-worker/main.go
@@ -117,6 +117,8 @@ func main() {
 	switch {
 	case arguments["show-payload-schema"]:
 		fmt.Println(JSONSchema())
+	case arguments["--short-version"]:
+		fmt.Println(version)
 
 	case arguments["run"]:
 		withWorkerRunner := arguments["--with-worker-runner"].(bool)

--- a/workers/generic-worker/usage.go
+++ b/workers/generic-worker/usage.go
@@ -44,6 +44,7 @@ and reports back results to the queue.
     generic-worker unarchive                --archive-src ARCHIVE-SRC --archive-dst ARCHIVE-DST --archive-fmt ARCHIVE-FMT
     generic-worker --help
     generic-worker --version
+    generic-worker --short-version
 
   Targets:
     run                                     Runs the generic-worker.  Pass --with-worker-runner if
@@ -96,6 +97,7 @@ and reports back results to the queue.
     --archive-fmt ARCHIVE-FMT               The format of the archive file to unarchive.
     --help                                  Display this help text.
     --version                               The release version of the generic-worker.
+    --short-version                         Only the semantic version of generic-worker.
 
 
   Configuring the generic worker:


### PR DESCRIPTION
CLI tools and generic-worker now returns short-version string if executed with `--short-version` argument:

- `generic-worker --short-version`
- `livelog --short-version`
- `websocktunnel --short-version`
- `start-worker --short-version`
- `taskcluster version --short-version`


Fixes #7073
