### PR TITLE
fix(generic-worker): use --remove-home instead of --remove-all-files …

### DIFF
--- a/changelog/issue-7128.md
+++ b/changelog/issue-7128.md
@@ -3,4 +3,4 @@ level: patch
 reference: issue 7128
 ---
 
-Use `--remove-home` instead of `--remove-all-files` when deleting a user on Linux. This ensures that caches that may still be owned (in whole or in part) by the task user are not deleted.
+Use `/usr/sbin/deluser --remove-home` instead of `/usr/sbin/deluser --remove-all-files` when deleting a user on Linux. This ensures that caches that may still be owned (in whole or in part) by the task user are not deleted.

--- a/changelog/issue-7128.md
+++ b/changelog/issue-7128.md
@@ -3,4 +3,4 @@ level: patch
 reference: issue 7128
 ---
 
-Use `/usr/sbin/deluser --remove-home` instead of `/usr/sbin/deluser --remove-all-files` when deleting a user on Linux. This ensures that caches that may still be owned (in whole or in part) by the task user are not deleted.
+Generic Worker multiuser engine on Linux now uses `/usr/sbin/deluser --remove-home` instead of `/usr/sbin/deluser --remove-all-files` when deleting previous task users. This ensures that caches that may still be owned (in whole or in part) by the task user are not deleted.

--- a/changelog/issue-7128.md
+++ b/changelog/issue-7128.md
@@ -1,0 +1,6 @@
+audience: users
+level: patch
+reference: issue 7128
+---
+
+Use `--remove-home` instead of `--remove-all-files` when deleting a user on Linux. This ensures that caches that may still be owned (in whole or in part) by the task user are not deleted.

--- a/workers/generic-worker/runtime/runtime_linux.go
+++ b/workers/generic-worker/runtime/runtime_linux.go
@@ -25,5 +25,11 @@ func (user *OSUser) CreateNew(okIfExists bool) (err error) {
 }
 
 func DeleteUser(username string) (err error) {
-	return host.Run("/usr/sbin/deluser", "--force", "--remove-all-files", username)
+	// We used to use `--remove-all-files` here instead of `--remove-home`.
+	// This caused issues with multiuser generic-worker, and ended up
+	// deleting mounts stored outside of the home directory which were
+	// meant to be preserved across tasks.
+	// See https://github.com/taskcluster/taskcluster/issues/7128 for
+	// additional background.
+	return host.Run("/usr/sbin/deluser", "--force", "--remove-home", username)
 }


### PR DESCRIPTION
…when deleting a user on Linux

Partially fixes #7128. We also need some additional work to ensure caches have correct ownership when they are restored for a subsequent task. Ideally this should wait until that fix is ready before being merged, as this fix alone causes worse problems than we're seeing right now with tasks run through taskgraph's `run-task`.