### PR TITLE
Change `adduser/deluser` usage to `useradd/userdel`

### DIFF
--- a/changelog/PUMDkmd0RlmEMQJWef3qVQ.md
+++ b/changelog/PUMDkmd0RlmEMQJWef3qVQ.md
@@ -1,0 +1,8 @@
+audience: worker-deployers
+level: minor
+---
+Change `adduser` usage to `useradd`
+
+`adduser` is a debian specific wrapper around `useradd` and friends. By
+changing to `useradd`, we allow workers to be deployed on non debian
+derivative distributions.

--- a/workers/generic-worker/runtime/runtime_linux.go
+++ b/workers/generic-worker/runtime/runtime_linux.go
@@ -17,7 +17,8 @@ func (user *OSUser) CreateNew(okIfExists bool) (err error) {
 		homedir="/home/${0}"
 		password="${1}"
 		echo "Creating user '${username}' with home directory '${homedir}' and password '${password}'..."
-		/usr/sbin/adduser --disabled-password --gecos "" --debug --home "${homedir}" "${username}"
+		/usr/sbin/useradd -m -d "${homedir}" "${username}"
+		/usr/sbin/chfn -f "${username}"
 		echo "${username}:${password}" | /usr/sbin/chpasswd
 	`
 

--- a/workers/generic-worker/runtime/runtime_linux.go
+++ b/workers/generic-worker/runtime/runtime_linux.go
@@ -26,11 +26,5 @@ func (user *OSUser) CreateNew(okIfExists bool) (err error) {
 }
 
 func DeleteUser(username string) (err error) {
-	// We used to use `--remove-all-files` here instead of `--remove-home`.
-	// This caused issues with multiuser generic-worker, and ended up
-	// deleting mounts stored outside of the home directory which were
-	// meant to be preserved across tasks.
-	// See https://github.com/taskcluster/taskcluster/issues/7128 for
-	// additional background.
-	return host.Run("/usr/sbin/deluser", "--force", "--remove-home", username)
+	return host.Run("/usr/sbin/userdel", "--force", "-r", username)
 }


### PR DESCRIPTION
`adduser/deluser` are debian specific wrappers around `useradd/userdel` and friends. By changing to `useradd/userdel`, we allow workers to be deployed on non debian derivative distributions. Tested on archlinux.

Flag mapping for useradd:

`--disabled-password`: Disables password prompting and disables the password for the user. `useradd` does that by default.

`--gecos ""`: This sets the GECOS flag for the user to "". Maps to `chfn -f ${username}`

`--debug`: Makes adduser output what commands it runs. Irrelevant here.

`--home ${homedir}`: Creates the home directory at `${homedir}`. `-m` Creates the user home directory and `-d ${homedir}` defines it as being `${homedir}`.

Flag mapping for userdel:

`--remove-home`: This removes the user's home directory when deleting the user. Maps to `-r` which has the same behavior.