### PR TITLE
Generic Worker log to stderr, not stdout

### DIFF
--- a/changelog/issue-7073.md
+++ b/changelog/issue-7073.md
@@ -1,0 +1,5 @@
+audience: worker-deployers
+level: major
+reference: issue 7073
+---
+Generic Worker now logs to standard error instead of standard out. This is a bug fix, it seems it has always been logging to standard out.

--- a/workers/generic-worker/logging.go
+++ b/workers/generic-worker/logging.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"log"
+	"os"
 	"time"
 )
 
@@ -17,5 +18,5 @@ type logWriter struct {
 }
 
 func (writer logWriter) Write(bytes []byte) (int, error) {
-	return fmt.Print(time.Now().UTC().Format("2006/01/02 15:04:05Z ") + string(bytes))
+	return fmt.Fprint(os.Stderr, time.Now().UTC().Format("2006/01/02 15:04:05Z ")+string(bytes))
 }


### PR DESCRIPTION
Fixes #7073