### PR TITLE
web server returns correct error code instead of 500

### DIFF
--- a/changelog/bug-1907075.md
+++ b/changelog/bug-1907075.md
@@ -1,0 +1,6 @@
+audience: general
+level: patch
+reference: bug 1907075
+---
+
+Web server graphql endpoints return 413 instead of 500 error.

--- a/services/web-server/src/servers/createApp.js
+++ b/services/web-server/src/servers/createApp.js
@@ -168,12 +168,17 @@ export default async ({ cfg, strategies, auth, monitor, db }) => {
   app.use((err, req, res, next) => {
     // Minimize the amount of information we disclose. The err could potentially disclose something to an attacker.
     const error = { code: err.code, name: err.name };
+    let statusCode = 500;
 
     if (err.name === 'InputError') {
       Object.assign(error, { message: err.message });
     }
+    if (err.name === 'PayloadTooLargeError') {
+      Object.assign(error, { code: 413, message: 'Payload too large' });
+      statusCode = 413;
+    }
 
-    res.status(500).json(error);
+    res.status(statusCode).json(error);
   });
 
   return app;

--- a/services/web-server/test/graphql/validation_test.js
+++ b/services/web-server/test/graphql/validation_test.js
@@ -23,7 +23,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
         });
       } catch (err) {
         assert.equal('PayloadTooLargeError', err.networkError.result.name);
-        assert.ok(err.networkError.statusCode >= 400);
+        assert.ok(err.networkError.statusCode === 413);
       }
     });
     test('max queries in request', async function() {


### PR DESCRIPTION
Instead of sending 500 always, we return appropriate code from the error or 413 

Bugzilla Bug: [1907075](https://bugzilla.mozilla.org/show_bug.cgi?id=1907075)

