### PR TITLE
fix: look for `chfn` in `/usr/bin` instead of `/usr/sbin`

### DIFF
--- a/changelog/PUMDkmd0RlmEMQJWef3qVQ.md
+++ b/changelog/PUMDkmd0RlmEMQJWef3qVQ.md
@@ -6,3 +6,14 @@ Change `adduser` usage to `useradd`
 `adduser` is a debian specific wrapper around `useradd` and friends. By
 changing to `useradd`, we allow workers to be deployed on non debian
 derivative distributions.
+
+Generic Worker multiuser engine on Linux/FreeBSD now depends on:
+
+  * /usr/bin/chfn
+  * /usr/sbin/useradd
+  * /usr/sbin/userdel
+
+and no longer depends on:
+
+  * /usr/sbin/adduser
+  * /usr/sbin/deluser

--- a/workers/generic-worker/runtime/runtime_linux.go
+++ b/workers/generic-worker/runtime/runtime_linux.go
@@ -18,7 +18,7 @@ func (user *OSUser) CreateNew(okIfExists bool) (err error) {
 		password="${1}"
 		echo "Creating user '${username}' with home directory '${homedir}' and password '${password}'..."
 		/usr/sbin/useradd -m -d "${homedir}" "${username}"
-		/usr/sbin/chfn -f "${username}"
+		/usr/bin/chfn -f "${username}"
 		echo "${username}:${password}" | /usr/sbin/chpasswd
 	`
 


### PR DESCRIPTION
The latter doesn't exist on Debian based distributions.

Github Bug/Issue: Fixes #7168