### PR TITLE
fix: map uid/gid of user running podman into useful uids/gids in podman containers

### DIFF
--- a/changelog/issue-7128-1.md
+++ b/changelog/issue-7128-1.md
@@ -1,0 +1,6 @@
+audience: users
+level: patch
+reference: issue 7128
+---
+
+Generic Worker / D2G partial bug fix: support has been improved for running Docker Worker tasks with caches under Generic Worker. Previously, caches from a Docker Worker task running under Generic Worker containing files owned by a user other than root would not be owned by the same (container) user when the cache was mounted in a future task. D2G now consistently maps container uids and gids to host subuids and subgids (when caches are used) in order that cache file ownership, as seen from inside the container, is maintained across task runs. However, this fix does not apply when the privileged capability is enabled in the Docker Worker payload, since privileged tasks are executed under docker rather than podman. This fix only applies when podman is used.

--- a/tools/d2g/d2gtest/testdata/testcases/docker_image_tests.yml
+++ b/tools/d2g/d2gtest/testdata/testcases/docker_image_tests.yml
@@ -270,4 +270,46 @@ testSuite:
           retry:
             - 125
             - 128
+
+    - name: DockerImage with cache
+      description: Test DockerImage with cache
+      dockerWorkerTaskPayload:
+        cache:
+          gecko-level-3-checkouts-sparse-v3: /builds/worker/checkouts
+        command:
+          - echo "Hello world"
+        image:
+          path: public/test/path.zst
+          taskId: 2JGiKFtpRnGbVczc6-OJ1Q
+          type: task-image
+        maxRunTime: 3600
+      genericWorkerTaskPayload:
+        command:
+          - - bash
+            - '-cx'
+            - >-
+              podman run -t --rm --memory-swap -1 --pids-limit -1 --ulimit host
+              --uidmap 1000:0:1 --uidmap 0:1:1000 --uidmap 1001:1001:64536
+              --gidmap 1000:0:1 --gidmap 0:1:1000 --gidmap 1001:1001:64536
+              -v "$(pwd)/cache0:/builds/worker/checkouts"
+              -e RUN_ID
+              -e TASKCLUSTER_INSTANCE_TYPE
+              -e TASKCLUSTER_ROOT_URL
+              -e TASKCLUSTER_WORKER_LOCATION
+              -e TASK_GROUP_ID
+              -e TASK_ID
+              docker-archive:dockerimage 'echo "Hello world"'
+        mounts:
+          - cacheName: gecko-level-3-checkouts-sparse-v3
+            directory: cache0
+          - content:
+              artifact: public/test/path.zst
+              taskId: 2JGiKFtpRnGbVczc6-OJ1Q
+            file: dockerimage
+            format: zst
+        maxRunTime: 3600
+        onExitStatus:
+          retry:
+            - 125
+            - 128
   taskDefTests: []


### PR DESCRIPTION
This patch maps uids and gids from the host system into containers that run with Podman, which helps to avoid permission issues within the container on mounted volumes.