### PR TITLE
fix(queue): Emit pulse message to 'task-exception' regardless of retr…

### DIFF
--- a/changelog/issue-7174.md
+++ b/changelog/issue-7174.md
@@ -1,0 +1,5 @@
+audience: users
+level: major
+reference: issue 7174
+---
+Queue service now emits pulse messages to the `exchange/taskcluster-queue/v1/task-exception` exchange when a task has an exception that is automatically retried.

--- a/services/queue/src/claimresolver.js
+++ b/services/queue/src/claimresolver.js
@@ -145,6 +145,15 @@ class ClaimResolver {
 
     let status = task.status();
 
+    // Publish message about task exception
+    await this.publisher.taskException({
+      status: status,
+      runId: runId,
+      workerGroup: run.workerGroup,
+      workerId: run.workerId,
+    }, task.routes);
+    this.monitor.log.taskException({ taskId, runId });
+
     // If a newRun was created and it is a retry with state pending then we
     // better publish messages about it
     let newRun = task.runs[runId + 1];
@@ -163,15 +172,6 @@ class ClaimResolver {
     } else {
       // Update dependencyTracker
       await this.dependencyTracker.resolveTask(taskId, task.taskGroupId, task.schedulerId, 'exception');
-
-      // Publish message about task exception
-      await this.publisher.taskException({
-        status: status,
-        runId: runId,
-        workerGroup: run.workerGroup,
-        workerId: run.workerId,
-      }, task.routes);
-      this.monitor.log.taskException({ taskId, runId });
     }
 
     return remove();

--- a/services/queue/test/resolvetask_test.js
+++ b/services/queue/test/resolvetask_test.js
@@ -360,8 +360,7 @@ helper.secrets.mockSuite(testing.suiteName(), ['aws'], function(mock, skipping) 
     assume(r1.status.runs[1].state).equals('pending');
     assume(r1.status.runs[1].reasonCreated).equals('retry');
 
-    // no exception message, just right back to pending
-    helper.assertNoPulseMessage('task-exception');
+    helper.assertPulseMessage('task-exception');
     helper.assertPulseMessage('task-pending', m => (
       _.isEqual(m.payload.status, r1.status) &&
       m.payload.runId === 1));
@@ -370,7 +369,7 @@ helper.secrets.mockSuite(testing.suiteName(), ['aws'], function(mock, skipping) 
     await helper.queue.reportException(taskId, 0, {
       reason: 'worker-shutdown',
     });
-    helper.assertNoPulseMessage('task-exception');
+    helper.assertPulseMessage('task-exception');
     helper.assertPulseMessage('task-pending');
     helper.clearPulseMessages();
 

--- a/services/queue/test/retry_test.js
+++ b/services/queue/test/retry_test.js
@@ -56,8 +56,7 @@ helper.secrets.mockSuite(testing.suiteName(), ['aws'], function(mock, skipping) 
         m.payload.status.runs[0].state === 'exception' &&
         m.payload.status.runs[0].reasonResolved === 'claim-expired'));
     }, 100, 250);
-    // there should be no task-exception message in this case
-    helper.assertNoPulseMessage('task-exception');
+    helper.assertPulseMessage('task-exception');
     helper.clearPulseMessages();
 
     debug('### Stop claimResolver');

--- a/ui/docs/reference/platform/queue/task-life-cycle.mdx
+++ b/ui/docs/reference/platform/queue/task-life-cycle.mdx
@@ -88,10 +88,12 @@ For example, exceptions with reason `malformed-payload` will never be retried.
 A task may also enter the exception state, if it is canceled, the deadline is
 exceeded or the worker disappears and retries have been exhausted.
 
-Whenever, a task is immediately retried, the _run_ will be resolved _exception_,
-but the _task_ never enters the _exception_ state, and no message is published
-about the _run_ that is resolved _exception_. A message signaling _exception_
-will only be published if no automatic retry is initiated.
+Some types of exceptions trigger an automatic retry. When this happens the
+_run_ will be resolved _exception_, but the _task_ will re-enter the _pending_
+state. A message is published about the _run_ that is resolved _exception_
+regardless of whether or not it was automatically retried. To determine whether
+there was an automatic retry, inspect whether there exists a following _run_
+with a `reasonCreated` of `retry`.
 
 ## Task Expiration
 When a task is resolved, _completed_, _failed_, or _exception_, it will sit


### PR DESCRIPTION
…y state

Previously, we were only emitting a message if the run was not being retried. This is a bug as we need to be able to track all runs of a task.

I moved the publish logic above the call to `task-pending` as this matches the order of events (first the old run had an exception, then the new run is pending).

Github Bug/Issue: Fixes #7174 
