### PR TITLE
Poll more frequently for EC2 spot interruption

### DIFF
--- a/changelog/issue-7167.md
+++ b/changelog/issue-7167.md
@@ -1,0 +1,5 @@
+audience: deployers
+level: patch
+reference: issue 7167
+---
+Change the polling period for EC2 spot instance interruption notices to 5 seconds, as recommended by AWS documentation.

--- a/tools/worker-runner/provider/aws/awsprovider.go
+++ b/tools/worker-runner/provider/aws/awsprovider.go
@@ -121,7 +121,7 @@ func (p *AWSProvider) checkTerminationTime() bool {
 
 func (p *AWSProvider) WorkerStarted(state *run.State) error {
 	// start polling for graceful shutdown
-	p.terminationTicker = time.NewTicker(30 * time.Second)
+	p.terminationTicker = time.NewTicker(5 * time.Second)
 	p.proto.AddCapability("graceful-termination")
 
 	go func() {


### PR DESCRIPTION
Change the polling period for EC2 spot instance interruption notices to 5 seconds, as recommended by [AWS documentation](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/spot-instance-termination-notices.html).


Github Bug/Issue: Fixes #7167
