### PR TITLE
Fixes taskcluster.yml rendering for some payloads

### DIFF
--- a/changelog/issue-7202.md
+++ b/changelog/issue-7202.md
@@ -1,0 +1,6 @@
+audience: general
+level: patch
+reference: issue 7202
+---
+
+Fixes `github.renderTaskclusterYml` rendering error for the payloads including invalid params

--- a/services/github/src/fake-payloads.js
+++ b/services/github/src/fake-payloads.js
@@ -745,7 +745,7 @@ export const getEventPayload = function getEventPayload(type, action, organizati
     mapping[type]
       .replaceAll('$ORGANIZATION', organization)
       .replaceAll('$REPOSITORY', repository)
-      .replaceAll('$BRANCH', branch)
+      .replaceAll('$BRANCH', encodeURI(branch))
   );
 
   return { ...event, action, ...overrides };

--- a/services/github/test/api_test.js
+++ b/services/github/test/api_test.js
@@ -747,5 +747,18 @@ tasks:
         ]);
       }),
     );
+    test('invalid branch name is properly escaped', async function () {
+      const tcYaml = `version: 1
+reporting: checks-v1
+tasks: []
+`;
+      const { tasks } = await helper.apiClient.renderTaskclusterYml({
+        body: tcYaml,
+        fakeEvent: { type: 'github-push', overrides: { branch: 'lol", "this"' } },
+        repository: 'repo',
+        organization: 'org',
+      });
+      assert.deepEqual(tasks, []);
+    });
   });
 });


### PR DESCRIPTION
In some payloads `branch` value was not properly escaped which resulted in invalid json

Fixes #7202
