### PR TITLE
Better handling of defaults and undefined

### DIFF
--- a/changelog/issue-7172.md
+++ b/changelog/issue-7172.md
@@ -1,0 +1,6 @@
+audience: general
+level: patch
+reference: issue 7172
+---
+
+Fixes UI js error on dashboard on some deployments

--- a/ui/src/components/StatusDashboard/summarizeWorkerPoolsStats.js
+++ b/ui/src/components/StatusDashboard/summarizeWorkerPoolsStats.js
@@ -16,7 +16,7 @@ export default (wmStats, link = '/worker-manager/errors') => {
     {
       title: 'Total errors 7d',
       hint: 'Usually means last 7 days, as errors are being deleted after that',
-      value: loading ? '...' : format(stats?.total),
+      value: loading ? '...' : format(stats?.total || 0),
       link,
       error: error?.message,
       loading,
@@ -24,7 +24,7 @@ export default (wmStats, link = '/worker-manager/errors') => {
     {
       title: 'Last 7 days',
       type: 'graph',
-      value: loading ? [] : Object.values(stats?.daily),
+      value: loading ? [] : Object.values(stats?.daily || {}),
       link,
       error: error?.message,
       loading,
@@ -39,7 +39,7 @@ export default (wmStats, link = '/worker-manager/errors') => {
     {
       title: 'Last 24 hours',
       type: 'graph',
-      value: loading ? [] : Object.values(stats?.hourly),
+      value: loading ? [] : Object.values(stats?.hourly || {}),
       link,
       error: error?.message,
       loading,

--- a/ui/src/components/StatusDashboard/summarizeWorkerPoolsStats.test.js
+++ b/ui/src/components/StatusDashboard/summarizeWorkerPoolsStats.test.js
@@ -1,0 +1,46 @@
+import summarizeWorkerPoolStats from './summarizeWorkerPoolsStats';
+
+describe('summarizeWorkerPoolStats ', () => {
+  it('should return empty values', () => {
+    const out = summarizeWorkerPoolStats({ data: {} });
+
+    expect(out.length).toEqual(4);
+    expect(out[0].value).toEqual('0');
+    expect(out[1].value).toEqual([]);
+    expect(out[2].value).toEqual('0');
+    expect(out[3].value).toEqual([]);
+  });
+  it('Should populate values', () => {
+    const out = summarizeWorkerPoolStats({
+      data: {
+        WorkerManagerErrorsStats: {
+          totals: {
+            total: 10,
+            daily: {
+              '2021-01-01': 1,
+              '2021-01-02': 2,
+              '2021-01-03': 3,
+              '2021-01-04': 4,
+              '2021-01-05': 5,
+              '2021-01-06': 6,
+              '2021-01-07': 7,
+            },
+            hourly: {
+              '2021-01-07T00:00:00.000Z': 1,
+              '2021-01-07T01:00:00.000Z': 2,
+              '2021-01-07T02:00:00.000Z': 3,
+              '2021-01-07T03:00:00.000Z': 4,
+              '2021-01-07T04:00:00.000Z': 5,
+            },
+          },
+        },
+      },
+    });
+
+    expect(out.length).toEqual(4);
+    expect(out[0].value).toEqual('10');
+    expect(out[1].value).toEqual([1, 2, 3, 4, 5, 6, 7]);
+    expect(out[2].value).toEqual('15');
+    expect(out[3].value).toEqual([1, 2, 3, 4, 5]);
+  });
+});


### PR DESCRIPTION
In minified version of `Object.values(obj?.prop)` it got compiled into `void 0` if property doesn't exist which results in `Object.values(undefined)` and "Can't convert undefined to object" error

Fixes #7172
