### PR TITLE
feat(cli): add scheduleTask support to the shell client

### DIFF
--- a/clients/client-shell/cmds/task/actors_test.go
+++ b/clients/client-shell/cmds/task/actors_test.go
@@ -63,6 +63,24 @@ func claimTaskHandler(w http.ResponseWriter, _ *http.Request) {
 	_, _ = io.WriteString(w, status)
 }
 
+// returns the test status on request
+func scheduleHandler(w http.ResponseWriter, _ *http.Request) {
+	status := `{
+				  "status": {
+				  	"workerType": "tutorial",
+				    "state": "pending",
+				    "runs": [
+				      {
+				        "runId": 0,
+				        "state": "pending",
+				        "reasonCreated": "scheduled"
+				      }
+				    ]
+				  }
+				}`
+	_, _ = io.WriteString(w, status)
+}
+
 func (suite *FakeServerSuite) TestRunCancelCommand() {
 	// set up to run a command and capture output
 	buf, cmd := setUpCommand()
@@ -106,4 +124,15 @@ func (suite *FakeServerSuite) TestRunCompleteCommand() {
 	assert.NoError(suite.T(), runComplete(&tcclient.Credentials{}, args, cmd.OutOrStdout(), cmd.Flags()))
 
 	suite.Equal("completed 'completed'\n", buf.String())
+}
+
+func (suite *FakeServerSuite) TestRunScheduleCommand() {
+	// set up to run a command and capture output
+	buf, cmd := setUpCommand()
+
+	// run the command
+	args := []string{fakeTaskID}
+	assert.NoError(suite.T(), runSchedule(&tcclient.Credentials{}, args, cmd.OutOrStdout(), cmd.Flags()))
+
+	suite.Equal("pending\n", buf.String())
 }

--- a/clients/client-shell/cmds/task/fetchers_test.go
+++ b/clients/client-shell/cmds/task/fetchers_test.go
@@ -33,6 +33,7 @@ func (suite *FakeServerSuite) SetupSuite() {
 	handler.HandleFunc("/api/queue/v1/task/"+fakeTaskID+"/rerun", reRunHandler)
 	handler.HandleFunc("/api/queue/v1/task/"+fakeTaskID+"/runs/"+fakeRunID+"/claim", claimTaskHandler)
 	handler.HandleFunc("/api/queue/v1/task/"+fakeTaskID+"/runs/"+fakeRunID+"/completed", manifestHandler)
+	handler.HandleFunc("/api/queue/v1/task/"+fakeTaskID+"/schedule", scheduleHandler)
 
 	suite.testServer = httptest.NewServer(handler)
 

--- a/clients/client-shell/cmds/task/task.go
+++ b/clients/client-shell/cmds/task/task.go
@@ -45,6 +45,12 @@ var (
 		Short: "Completes a task.",
 		RunE:  executeHelperE(runComplete),
 	}
+
+	runscheduleCmd = &cobra.Command{
+		Use:   "schedule <taskId>",
+		Short: "Schedules a task.",
+		RunE:  executeHelperE(runSchedule),
+	}
 )
 
 var log = root.Logger
@@ -66,6 +72,9 @@ func init() {
 
 	runcompleteCmd.Flags().BoolP("noop", "n", false, "Using this flag, will tell the command to not actually run, but prints out what it would do.")
 	runcompleteCmd.Flags().BoolP("confirm", "c", false, "Prompts user with a confirmation (y/n) before performing any changes.")
+
+	runscheduleCmd.Flags().BoolP("noop", "n", false, "Using this flag, will tell the command to not actually run, but prints out what it would do.")
+	runscheduleCmd.Flags().BoolP("confirm", "c", false, "Prompts user with a confirmation (y/n) before performing any changes.")
 	// Commands that fetch information
 	Command.AddCommand(
 		// status
@@ -109,6 +118,8 @@ func init() {
 		rerunCmd,
 		// cancel
 		runcompleteCmd,
+		// schedule
+		runscheduleCmd,
 	)
 
 	// Add the task subtree to the root.


### PR DESCRIPTION
This adds `taskcluster task schedule <taskid>`, as a somewhat more friendly alternative to `taskcluster api queue scheduleTask <taskid>`.

<!-- Did you remember to add a changelog snippet? See
     https://github.com/taskcluster/taskcluster/blob/main/dev-docs/best-practices/changelog.md
 -->
