### PR TITLE
fix(github): only skip CI on commit message and PR title

### DIFF
--- a/changelog/issue-6304.md
+++ b/changelog/issue-6304.md
@@ -1,0 +1,5 @@
+audience: users
+level: patch
+reference: issue 6304
+---
+GitHub service no longer skips CI based on PR description. It will only skip CI based on the PR title or the commit message, [as GitHub does](https://docs.github.com/en/actions/managing-workflow-runs-and-deployments/managing-workflow-runs/skipping-workflow-runs).

--- a/services/github/src/utils.js
+++ b/services/github/src/utils.js
@@ -75,7 +75,7 @@ export const shouldSkipCommit = ({ commits, head_commit = {} }) => {
 
 /**
  * Check if pull_request event should be skipped.
- * It can happen when pull request contains keywords in title or description:
+ * It can happen when pull request contains keywords in title:
  * "[skip ci]" or "[ci skip]"
  *
  * @param {body} object event body
@@ -85,8 +85,7 @@ export const shouldSkipCommit = ({ commits, head_commit = {} }) => {
  * @returns boolean
  */
 export const shouldSkipPullRequest = ({ pull_request }) => {
-  return pull_request !== undefined &&
-    (ciSkipRegexp.test(pull_request.title) || ciSkipRegexp.test(pull_request.body));
+  return pull_request !== undefined && ciSkipRegexp.test(pull_request.title);
 };
 
 export const taskclusterCommandRegExp = new RegExp('^\\s*/taskcluster\\s+(.+)$', 'm');

--- a/services/github/test/utils_test.js
+++ b/services/github/test/utils_test.js
@@ -173,7 +173,7 @@ suite(testing.suiteName(), function() {
       skipMessages.forEach(title => assert.equal(true, shouldSkipPullRequest({
         pull_request: { title },
       })));
-      skipMessages.forEach(body => assert.equal(true, shouldSkipPullRequest({
+      skipMessages.forEach(body => assert.equal(false, shouldSkipPullRequest({
         pull_request: { title: 'regular title', body },
       })));
     });


### PR DESCRIPTION
Fixes #6304.

>GitHub service no longer skips CI based on PR description. It will only skip CI based on the PR title or the commit message, [as GitHub does](https://docs.github.com/en/actions/managing-workflow-runs-and-deployments/managing-workflow-runs/skipping-workflow-runs).