### PR TITLE
fix(generic-worker): add retries to interactive username logic

### DIFF
--- a/changelog/issue-7012.md
+++ b/changelog/issue-7012.md
@@ -1,0 +1,5 @@
+audience: worker-deployers
+level: patch
+reference: issue 7012
+---
+Generic Worker: Add retries around the logic that gets the current user who is logged in the gnome3 desktop session, in case race conditions are causing the following issue: `could not determine interactive username: number of gnome session users is not exactly one - not sure which user is interactively logged on: []string{""}`.

--- a/workers/generic-worker/gdm3/gdm3_nonfreebsd.go
+++ b/workers/generic-worker/gdm3/gdm3_nonfreebsd.go
@@ -5,6 +5,7 @@ package gdm3
 import (
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/taskcluster/taskcluster/v68/workers/generic-worker/host"
 )
@@ -13,13 +14,22 @@ import (
 // logged into a gnome3 desktop session. If it doesn't find precisely one user,
 // it returns an error, otherwise it returns the user it found.
 func InteractiveUsername() (string, error) {
-	gnomeSessionUserList, err := host.CombinedOutput("/usr/bin/env", "bash", "-c", "PROCPS_USERLEN=20 /usr/bin/w | /bin/grep gnome-[s]ession | /usr/bin/cut -f1 -d' '")
-	if err != nil {
-		return "", fmt.Errorf("cannot run command to determine the interactive user: %v", err)
+	const maxRetries = 5
+	const delay = 1 * time.Second
+	var lines []string
+
+	for i := 0; i < maxRetries; i++ {
+		gnomeSessionUserList, err := host.CombinedOutput("/usr/bin/env", "bash", "-c", "PROCPS_USERLEN=20 /usr/bin/w | /bin/grep gnome-[s]ession | /usr/bin/cut -f1 -d' '")
+		if err != nil {
+			return "", fmt.Errorf("cannot run command to determine the interactive user: %v", err)
+		}
+		lines = strings.Split(gnomeSessionUserList, "\n")
+		if len(lines) != 2 || lines[1] != "" {
+			time.Sleep(delay)
+		} else {
+			return lines[0], nil
+		}
 	}
-	lines := strings.Split(gnomeSessionUserList, "\n")
-	if len(lines) != 2 || lines[1] != "" {
-		return "", fmt.Errorf("number of gnome session users is not exactly one - not sure which user is interactively logged on: %#v", lines)
-	}
-	return lines[0], nil
+
+	return "", fmt.Errorf("number of gnome session users is not exactly one - not sure which user is interactively logged on: %#v", lines)
 }


### PR DESCRIPTION
Potentially fixes/helps https://github.com/taskcluster/taskcluster/issues/7012 and https://github.com/taskcluster/community-tc-config/issues/784.

>Generic Worker: Add retries around the logic that gets the current user who is logged in the gnome3 desktop session, in case race conditions are causing the following issue: `could not determine interactive username: number of gnome session users is not exactly one - not sure which user is interactively logged on: []string{""}`.