### PR TITLE
Disable audio loopback tests in generic-worker while audio-loopback broken in AWS

### DIFF
--- a/changelog/ZyFDOEbmRjWmSyg85kKemA.md
+++ b/changelog/ZyFDOEbmRjWmSyg85kKemA.md
@@ -1,0 +1,3 @@
+audience: general
+level: silent
+---

--- a/workers/generic-worker/loopback_audio_darwin_test.go
+++ b/workers/generic-worker/loopback_audio_darwin_test.go
@@ -7,6 +7,9 @@ import (
 )
 
 func TestLoopbackAudioReturnsMalformedPayload(t *testing.T) {
+
+	t.Skip("Skipping since audio loopback not working in AWS...")
+
 	setup(t)
 
 	payload := GenericWorkerPayload{

--- a/workers/generic-worker/loopback_audio_freebsd_test.go
+++ b/workers/generic-worker/loopback_audio_freebsd_test.go
@@ -7,6 +7,9 @@ import (
 )
 
 func TestLoopbackAudioReturnsMalformedPayload(t *testing.T) {
+
+	t.Skip("Skipping since audio loopback not working in AWS...")
+
 	setup(t)
 
 	payload := GenericWorkerPayload{

--- a/workers/generic-worker/loopback_audio_linux_test.go
+++ b/workers/generic-worker/loopback_audio_linux_test.go
@@ -9,6 +9,9 @@ import (
 )
 
 func TestLoopbackAudio(t *testing.T) {
+
+	t.Skip("Skipping since audio loopback not working in AWS...")
+
 	setup(t)
 
 	devicePaths := []string{
@@ -44,6 +47,9 @@ func TestLoopbackAudio(t *testing.T) {
 }
 
 func TestIncorrectLoopbackAudioScopes(t *testing.T) {
+
+	t.Skip("Skipping since audio loopback not working in AWS...")
+
 	setup(t)
 
 	payload := GenericWorkerPayload{
@@ -66,6 +72,9 @@ func TestIncorrectLoopbackAudioScopes(t *testing.T) {
 }
 
 func TestLoopbackAudioNotOwnedByTaskUser(t *testing.T) {
+
+	t.Skip("Skipping since audio loopback not working in AWS...")
+
 	setup(t)
 
 	devicePaths := []string{
@@ -118,6 +127,9 @@ func TestLoopbackAudioNotOwnedByTaskUser(t *testing.T) {
 }
 
 func TestLoopbackAudioInvalidDeviceNumber(t *testing.T) {
+
+	t.Skip("Skipping since audio loopback not working in AWS...")
+
 	setup(t)
 
 	config.LoopbackAudioDeviceNumber = 32


### PR DESCRIPTION
Unfortunately we had to move Generic Worker Ubuntu workloads to AWS from GCP while our images are broken in GCP.

This (temporarily) disables the loopback audio tests, which don't run in AWS, since audio loopback is currently not working there.

When we move workloads back to Google Cloud, we should be able to safely revert this commit.