### PR TITLE
Generic Worker: restore snd-aloop CI tests

### DIFF
--- a/changelog/A5ondlA9T8KDsa60w5noNA.md
+++ b/changelog/A5ondlA9T8KDsa60w5noNA.md
@@ -1,0 +1,3 @@
+audience: general
+level: silent
+---

--- a/workers/generic-worker/loopback_audio_darwin_test.go
+++ b/workers/generic-worker/loopback_audio_darwin_test.go
@@ -7,9 +7,6 @@ import (
 )
 
 func TestLoopbackAudioReturnsMalformedPayload(t *testing.T) {
-
-	t.Skip("Skipping since audio loopback not working in AWS...")
-
 	setup(t)
 
 	payload := GenericWorkerPayload{

--- a/workers/generic-worker/loopback_audio_freebsd_test.go
+++ b/workers/generic-worker/loopback_audio_freebsd_test.go
@@ -7,9 +7,6 @@ import (
 )
 
 func TestLoopbackAudioReturnsMalformedPayload(t *testing.T) {
-
-	t.Skip("Skipping since audio loopback not working in AWS...")
-
 	setup(t)
 
 	payload := GenericWorkerPayload{

--- a/workers/generic-worker/loopback_audio_linux_test.go
+++ b/workers/generic-worker/loopback_audio_linux_test.go
@@ -9,9 +9,6 @@ import (
 )
 
 func TestLoopbackAudio(t *testing.T) {
-
-	t.Skip("Skipping since audio loopback not working in AWS...")
-
 	setup(t)
 
 	devicePaths := []string{
@@ -47,9 +44,6 @@ func TestLoopbackAudio(t *testing.T) {
 }
 
 func TestIncorrectLoopbackAudioScopes(t *testing.T) {
-
-	t.Skip("Skipping since audio loopback not working in AWS...")
-
 	setup(t)
 
 	payload := GenericWorkerPayload{
@@ -72,9 +66,6 @@ func TestIncorrectLoopbackAudioScopes(t *testing.T) {
 }
 
 func TestLoopbackAudioNotOwnedByTaskUser(t *testing.T) {
-
-	t.Skip("Skipping since audio loopback not working in AWS...")
-
 	setup(t)
 
 	devicePaths := []string{
@@ -127,9 +118,6 @@ func TestLoopbackAudioNotOwnedByTaskUser(t *testing.T) {
 }
 
 func TestLoopbackAudioInvalidDeviceNumber(t *testing.T) {
-
-	t.Skip("Skipping since audio loopback not working in AWS...")
-
 	setup(t)
 
 	config.LoopbackAudioDeviceNumber = 32


### PR DESCRIPTION
These tests were disabled in #7230 due to a temporary problem with workers in GCP. Since that issue has been resolved the tests can be re-enabled.

Note, CI will initially fail, because workers are still running in AWS. However, once https://github.com/taskcluster/community-tc-config/pull/808 has been applied, the workers should be running in GCP again, the failing CI tasks can be rerun, and then everything should be working again.