### PR TITLE
queue: uri-encode artifact names in CDN urls

### DIFF
--- a/changelog/issue-7233.md
+++ b/changelog/issue-7233.md
@@ -1,0 +1,6 @@
+audience: users
+level: patch
+reference: issue 7233
+---
+getArtifact now encodes artifact names to return valid URLs even when
+the name contains unsafe characters.

--- a/services/queue/src/bucket.js
+++ b/services/queue/src/bucket.js
@@ -102,7 +102,7 @@ Bucket.prototype.createPutUrl = function(prefix, options) {
 Bucket.prototype.createGetUrl = async function(prefix, forceS3 = false) {
   assert(prefix, 'prefix must be given');
   if (this.bucketCDN && !forceS3) {
-    return `${this.bucketCDN}/${prefix}`;
+    return `${this.bucketCDN}/${encodeURI(prefix)}`;
   }
   const command = new GetObjectCommand({
     Bucket: this.bucket,

--- a/services/queue/test/bucket_test.js
+++ b/services/queue/test/bucket_test.js
@@ -100,6 +100,8 @@ helper.secrets.mockSuite(testing.suiteName(), ['aws'], function(mock, skipping) 
     });
     const url = await bucket.createGetUrl('test');
     assert(url === 'https://example.com/test');
+    const urlWithSpaces = await bucket.createGetUrl('test with spaces');
+    assert(urlWithSpaces === 'https://example.com/test%20with%20spaces');
   });
 
   test('default endpoint', async function() {


### PR DESCRIPTION
Github Bug/Issue: Fixes #7233 
