### PR TITLE
Allow provision of public IP for g-w in Azure

### DIFF
--- a/changelog/issue-7257.md
+++ b/changelog/issue-7257.md
@@ -1,0 +1,15 @@
+audience: worker-deployers
+level: minor
+reference: issue 7257
+---
+
+Worker-manager provides an option to request public IP for generic-worker in Azure that is skipped by default.
+Passing `publicIp = true` in the launch configuration will enable the public IP request.
+
+```json
+{
+  "workerManager": {
+    "publicIp": true
+  }
+}
+```

--- a/generated/references.json
+++ b/generated/references.json
@@ -2035,6 +2035,19 @@
                 "description": "This value is supplied unchanged as the `workerConfig` property of the `taskcluster` instance metadata attribute.\nThe expectation is that the worker will merge this information with configuration from other sources,\nand this is precisely what [worker-runner](https://docs.taskcluster.net/docs/reference/workers/worker-runner) does.\nThis property must not be used for secret configuration, as it is visible both in the worker pool configuration and in the worker instance's metadata.\nInstead, put secret configuration in the [secrets service](https://docs.taskcluster.net/docs/reference/workers/worker-runner).\n",
                 "title": "Worker Config",
                 "type": "object"
+              },
+              "workerManager": {
+                "additionalProperties": false,
+                "description": "Worker Manager's own configuration settings per launch configuration.\nThe other properties of the launch configuration section are passed directly through to\nAzure APIs, whereas this section is interpreted directly by Worker Manager.",
+                "properties": {
+                  "publicIp": {
+                    "description": "If `true`, Worker Manager will request a public IPv4 address for the worker.\nThis is set to `false` by default. It is typically only needed for Windows\nworkers that should allow incoming RDP connections from the public internet.\n",
+                    "title": "Public IP",
+                    "type": "boolean"
+                  }
+                },
+                "title": "Worker Manager Config",
+                "type": "object"
               }
             },
             "required": [

--- a/services/worker-manager/schemas/v1/config-azure.yml
+++ b/services/worker-manager/schemas/v1/config-azure.yml
@@ -46,6 +46,22 @@ properties:
           type: integer
           minimum: 1
           description: The number of tasks a single worker of this type can run at any given time.
+        workerManager:
+          title: Worker Manager Config
+          type: object
+          description: |-
+            Worker Manager's own configuration settings per launch configuration.
+            The other properties of the launch configuration section are passed directly through to
+            Azure APIs, whereas this section is interpreted directly by Worker Manager.
+          properties:
+            publicIp:
+              title: Public IP
+              type: boolean
+              description: |
+                If `true`, Worker Manager will request a public IPv4 address for the worker.
+                This is set to `false` by default. It is typically only needed for Windows
+                workers that should allow incoming RDP connections from the public internet.
+          additionalProperties: false
         workerConfig:
           title: Worker Config
           type: object


### PR DESCRIPTION
in #4987 it was decided to skip public IP provisioning for generic-worker since it wasn't used
However, having public IP might still be useful for debug purposes. Worker pool configuration allows `workerManager.publicIP=true` to override that logic

Fixes #7257 
