### PR TITLE
feat(github): allow fetching artifacts from queue

### DIFF
--- a/changelog/issue-5669-1.md
+++ b/changelog/issue-5669-1.md
@@ -1,0 +1,4 @@
+audience: developers
+level: silent
+reference: issue 5669
+---

--- a/services/auth/src/static-scopes.json
+++ b/services/auth/src/static-scopes.json
@@ -12,6 +12,7 @@
       "assume:repo:github.com/*",
       "assume:scheduler-id:taskcluster-github/*",
       "queue:cancel-task-group:taskcluster-github/*",
+      "queue:list-artifacts:*",
       "queue:list-task-group:*",
       "queue:route:checks",
       "queue:route:statuses",

--- a/services/github/scopes.yml
+++ b/services/github/scopes.yml
@@ -6,3 +6,4 @@
 - queue:list-task-group:*
 - queue:seal-task-group:taskcluster-github/*
 - queue:cancel-task-group:taskcluster-github/*
+- queue:list-artifacts:*


### PR DESCRIPTION
For the #5669 we forgot to include necessary scopes


After this feature was merged https://github.com/taskcluster/taskcluster/pull/7208 we noticed we forgot to include one more scope 
https://github.com/taskcluster/tc-dev-integration-test/commit/643820fe0576909515c72f6c40d4990d36837812#comments
