### PR TITLE
feat(github): Improve checks output, add artifact redirect handling

### DIFF
--- a/changelog/issue-7263.md
+++ b/changelog/issue-7263.md
@@ -1,0 +1,7 @@
+audience: users
+level: patch
+reference: issue 7263
+---
+
+Improve github checks output - handle 404 cases for empty artifact list.
+Adds artifact redirect page in UI to redirect user to the actual artifact.

--- a/services/github/src/handlers/status.js
+++ b/services/github/src/handlers/status.js
@@ -203,9 +203,9 @@ export async function statusHandler(message) {
       output.addText(`Started: ${runs[runId]?.started ?? "n/a"}`);
       output.addText(`Resolved: ${runs[runId]?.resolved ?? "n/a"}`);
       output.addText(`Task Execution Time: ${taskExecutionTime ?? "n/a"}`);
-      output.addText(`Task Status: ${runs[runId]?.state ?? "n/a"}`);
-      output.addText(`Reason Resolved: ${runs[runId]?.reasonResolved ?? "n/a"}`);
-      output.addText(`RunId: ${runId}`);
+      output.addText(`Task Status: **${runs[runId]?.state ?? "n/a"}**`);
+      output.addText(`Reason Resolved: **${runs[runId]?.reasonResolved ?? "n/a"}**`);
+      output.addText(`RunId: **${runId}**`);
     }
 
     try {
@@ -232,7 +232,9 @@ export async function statusHandler(message) {
         output.addText(`\\- ${ARTIFACT_LINK}`);
       });
     } catch (e) {
-      await createExceptionComment(e);
+      if (e.statusCode !== 404) {
+        await createExceptionComment(e);
+      }
     }
 
     if (customCheckRunText) {

--- a/ui/src/views/Tasks/TaskArtifactRedirect/index.jsx
+++ b/ui/src/views/Tasks/TaskArtifactRedirect/index.jsx
@@ -1,0 +1,53 @@
+import React, { Component } from 'react';
+import { Redirect } from 'react-router-dom';
+import Spinner from '../../../components/Spinner';
+import Dashboard from '../../../components/Dashboard';
+import { withAuth } from '../../../utils/Auth';
+import { getArtifactUrl } from '../../../utils/getArtifactUrl';
+
+@withAuth
+export default class TaskArtifactRedire extends Component {
+  state = {
+    redirect: false,
+  };
+
+  componentDidMount() {
+    const {
+      match: {
+        params: { artifactName, taskId, runId },
+      },
+      user,
+    } = this.props;
+    const url = getArtifactUrl({ user, taskId, runId, name: artifactName });
+
+    window.location = url;
+
+    setTimeout(() => {
+      // in case of binaries and files that are forced to download
+      // we need to redirect back to the run page to avoid showing empty spinner
+      this.setState({ redirect: true });
+    }, 2000);
+  }
+
+  render() {
+    const {
+      match: {
+        params: { taskId, runId },
+      },
+    } = this.props;
+    const { redirect } = this.state;
+
+    return (
+      <Dashboard>
+        {!redirect && <Spinner />}
+        {redirect && (
+          <Redirect
+            to={{
+              pathname: `/tasks/${taskId}/runs/${runId}`,
+            }}
+          />
+        )}
+      </Dashboard>
+    );
+  }
+}

--- a/ui/src/views/Tasks/routes.js
+++ b/ui/src/views/Tasks/routes.js
@@ -10,6 +10,11 @@ const NoTaskGroup = lazy(() =>
 const ViewTask = lazy(() =>
   import(/* webpackChunkName: 'Tasks.ViewTask' */ './ViewTask')
 );
+const TaskArtifactRedirect = lazy(() =>
+  import(
+    /* webpackChunkName: 'Tasks.TaskArtifactRedirect' */ './TaskArtifactRedirect'
+  )
+);
 const TaskLog = lazy(() =>
   import(/* webpackChunkName: 'Tasks.TaskLog' */ './TaskLog')
 );
@@ -68,6 +73,11 @@ export default path => [
   {
     component: TaskLog,
     path: `${path}/:taskId/runs/:runId/logs/:name+`,
+  },
+  {
+    component: TaskArtifactRedirect,
+    path: `${path}/:taskId/runs/:runId/:artifactName+`,
+    description: taskDescription,
   },
   {
     component: ViewTask,


### PR DESCRIPTION
UI adds new artifact redirect route:

`/tasks/QPXuvAhvThmoieABhZ1c_g/runs/0/public/parameters.yml`

would fetch signed url for artifact and do redirect