### PR TITLE
feat(d2g): add `containerEngine` to toggle between `docker`/`podman`

### DIFF
--- a/changelog/DIlRBhW6S1aQ6Rl63gLxog.md
+++ b/changelog/DIlRBhW6S1aQ6Rl63gLxog.md
@@ -1,4 +1,4 @@
 audience: users
-level: major
+level: minor
 ---
-D2G: Adds `capabilities.containerEngine` to the Docker Worker payload schema strictly to use as a `docker`/`podman` toggle for the d2g-translated payload. Defaults to `docker`.
+D2G: Adds `capabilities.containerEngine` to the Docker Worker payload schema strictly to use as a `docker`/`podman` toggle for the d2g-translated payload.

--- a/changelog/DIlRBhW6S1aQ6Rl63gLxog.md
+++ b/changelog/DIlRBhW6S1aQ6Rl63gLxog.md
@@ -1,4 +1,4 @@
 audience: users
 level: major
 ---
-D2G: Adds `capabilities.containerEngine` to the Docker Worker payload schema strictly to use as a `docker`/`podman` toggle for the d2g-translated payload. Defaults to `podman`.
+D2G: Adds `capabilities.containerEngine` to the Docker Worker payload schema strictly to use as a `docker`/`podman` toggle for the d2g-translated payload. Defaults to `docker`.

--- a/changelog/DIlRBhW6S1aQ6Rl63gLxog.md
+++ b/changelog/DIlRBhW6S1aQ6Rl63gLxog.md
@@ -1,0 +1,4 @@
+audience: users
+level: major
+---
+D2G: Adds `capabilities.containerEngine` to the Docker Worker payload schema strictly to use as a `docker`/`podman` toggle for the d2g-translated payload. Defaults to `podman`.

--- a/changelog/DZIVnP9QR7iWQYW26MFw_A.md
+++ b/changelog/DZIVnP9QR7iWQYW26MFw_A.md
@@ -1,0 +1,6 @@
+audience: worker-deployers
+level: major
+---
+Generic Worker: Adds `containerEngine` worker config option to select between `docker` and `podman` to be used during D2G payload translations.
+
+Default is `docker` and this value will be overridden by `task.payload.capabilities.containerEngine`, if specified.

--- a/changelog/T55_SlPMQeqefnWlPlhevQ.md
+++ b/changelog/T55_SlPMQeqefnWlPlhevQ.md
@@ -1,4 +1,4 @@
 audience: worker-deployers
-level: minor
+level: major
 ---
 Generic Worker: Adds `enableD2G` worker config option to internally process Docker Worker payloads using D2G. Defaults to `false` and will return a `malformed-payload` if a Docker Worker payload is detected and this config isn't set to `true`.

--- a/changelog/T55_SlPMQeqefnWlPlhevQ.md
+++ b/changelog/T55_SlPMQeqefnWlPlhevQ.md
@@ -1,0 +1,4 @@
+audience: worker-deployers
+level: minor
+---
+Generic Worker: Adds `enableD2G` worker config option to internally process Docker Worker payloads using D2G. Defaults to `false` and will return a `malformed-payload` if a Docker Worker payload is detected and this config isn't set to `true`.

--- a/clients/client-shell/README.md
+++ b/clients/client-shell/README.md
@@ -119,11 +119,12 @@ taskcluster slugid generate -n
 ### Translating Docker Worker Task Definition/Payload to Generic Worker Task Definition/Payload
 
 The `taskcluster d2g` subcommand can be used to translate a Docker Worker task definition or payload to a Generic Worker task definition or payload.
-Both the input and output are JSON. You can either pass the input as a file or pipe it in to the command.
+Both the input and output are JSON. You can either pass the input as a file or pipe it in to the command. To specify the container engine to use
+for the translation, use the `(-e, --engine)` flag to select between `docker` (default) and `podman`.
 You must use the `(-t, --task-def)` flag to specify that your input is a task definition, otherwise it will be treated as a task payload and you'll get an error message like: `Error: input validation failed: validation failed:`.
 
 ```shell
-taskcluster d2g -f /path/to/input/payload.json
+taskcluster d2g -f -e podman /path/to/input/payload.json
 ```
 
 _OR_

--- a/clients/client-shell/cmds/d2g/d2g.go
+++ b/clients/client-shell/cmds/d2g/d2g.go
@@ -29,6 +29,7 @@ To convert a task definition (JSON), you must use the task definition flag (-t, 
   cat /path/to/input/task-definition.json | taskcluster d2g -t
   echo '{"image": "ubuntu", "command": ["bash", "-c", "echo hello world"], "maxRunTime": 300}' | taskcluster d2g`,
 	}
+	cmd.Flags().StringP("engine", "e", "docker", "The container engine to use between docker and podman.")
 	cmd.Flags().StringP("file", "f", "", "Path to a .json file containing a docker-worker payload or task definition.")
 	cmd.Flags().BoolP("task-def", "t", false, "Must use if the input is a docker-worker task definition.")
 	root.Command.AddCommand(cmd)

--- a/clients/client-shell/cmds/d2g/d2g.go
+++ b/clients/client-shell/cmds/d2g/d2g.go
@@ -23,7 +23,7 @@ func init() {
 		Short: `Converts a docker-worker payload (JSON) to a generic-worker payload (JSON).
 To convert a task definition (JSON), you must use the task definition flag (-t, --task-def).`,
 		RunE: convert,
-		Example: `  taskcluster d2g -f /path/to/input/payload.json
+		Example: `  taskcluster d2g -f -e podman /path/to/input/payload.json
   taskcluster d2g -t -f /path/to/input/task-definition.json
   cat /path/to/input/payload.json | taskcluster d2g
   cat /path/to/input/task-definition.json | taskcluster d2g -t
@@ -38,6 +38,7 @@ To convert a task definition (JSON), you must use the task definition flag (-t, 
 func convert(cmd *cobra.Command, args []string) (err error) {
 	isTaskDef, _ := cmd.Flags().GetBool("task-def")
 	filePath, _ := cmd.Flags().GetString("file")
+	engine, _ := cmd.Flags().GetString("engine")
 
 	input, err := userInput(filePath)
 	if err != nil {
@@ -84,7 +85,7 @@ func convert(cmd *cobra.Command, args []string) (err error) {
 		}
 
 		// Convert dwTaskDef to gwTaskDef
-		gwTaskDefJSON, err := d2g.ConvertTaskDefinition(dwTaskDefJSON)
+		gwTaskDefJSON, err := d2g.ConvertTaskDefinition(dwTaskDefJSON, engine)
 		if err != nil {
 			return fmt.Errorf("failed to convert docker worker task definition to a generic worker task definition: %v", err)
 		}
@@ -108,7 +109,7 @@ func convert(cmd *cobra.Command, args []string) (err error) {
 		fmt.Fprintln(cmd.OutOrStdout(), string(gwTaskDefJSON))
 	} else {
 		// Convert dwPayload to gwPayload
-		gwPayload, err := d2g.Convert(dwPayload)
+		gwPayload, err := d2g.Convert(dwPayload, engine)
 		if err != nil {
 			return fmt.Errorf("conversion error: %v", err)
 		}

--- a/generated/references.json
+++ b/generated/references.json
@@ -9097,8 +9097,7 @@
               "description": "Set of capabilities that must be enabled or made available to the task container Example: ```{ \"capabilities\": { \"privileged\": true }```",
               "properties": {
                 "containerEngine": {
-                  "default": "docker",
-                  "description": "The container engine to use, between `docker` and `podman`. This property is only used during Generic Worker's internal payload translation (d2g). [default: docker]",
+                  "description": "The container engine to use when executing tasks with Docker Worker formatted task payloads.",
                   "enum": [
                     "docker",
                     "podman"
@@ -9888,8 +9887,7 @@
               "description": "Set of capabilities that must be enabled or made available to the task container Example: ```{ \"capabilities\": { \"privileged\": true }```",
               "properties": {
                 "containerEngine": {
-                  "default": "docker",
-                  "description": "The container engine to use, between `docker` and `podman`. This property is only used during Generic Worker's internal payload translation (d2g). [default: docker]",
+                  "description": "The container engine to use when executing tasks with Docker Worker formatted task payloads.",
                   "enum": [
                     "docker",
                     "podman"
@@ -10221,8 +10219,7 @@
           "description": "Set of capabilities that must be enabled or made available to the task container Example: ```{ \"capabilities\": { \"privileged\": true }```",
           "properties": {
             "containerEngine": {
-              "default": "docker",
-              "description": "The container engine to use, between `docker` and `podman`. This property is only used during Generic Worker's internal payload translation (d2g). [default: docker]",
+              "description": "The container engine to use when executing tasks with Docker Worker formatted task payloads.",
               "enum": [
                 "docker",
                 "podman"

--- a/generated/references.json
+++ b/generated/references.json
@@ -9096,6 +9096,16 @@
               "additionalProperties": false,
               "description": "Set of capabilities that must be enabled or made available to the task container Example: ```{ \"capabilities\": { \"privileged\": true }```",
               "properties": {
+                "containerEngine": {
+                  "default": "docker",
+                  "description": "The container engine to use, between `docker` and `podman`. This property is only used during Generic Worker's internal payload translation (d2g). [default: docker]",
+                  "enum": [
+                    "docker",
+                    "podman"
+                  ],
+                  "title": "Container engine",
+                  "type": "string"
+                },
                 "devices": {
                   "additionalProperties": false,
                   "description": "Allows devices from the host system to be attached to a task container similar to using `--device` in docker.",
@@ -9836,7 +9846,6 @@
               "items": {
                 "type": "string"
               },
-              "maxItems": 0,
               "title": "OS Groups",
               "type": "array",
               "uniqueItems": true
@@ -9878,6 +9887,16 @@
               "additionalProperties": false,
               "description": "Set of capabilities that must be enabled or made available to the task container Example: ```{ \"capabilities\": { \"privileged\": true }```",
               "properties": {
+                "containerEngine": {
+                  "default": "docker",
+                  "description": "The container engine to use, between `docker` and `podman`. This property is only used during Generic Worker's internal payload translation (d2g). [default: docker]",
+                  "enum": [
+                    "docker",
+                    "podman"
+                  ],
+                  "title": "Container engine",
+                  "type": "string"
+                },
                 "devices": {
                   "additionalProperties": false,
                   "description": "Allows devices from the host system to be attached to a task container similar to using `--device` in docker.",
@@ -10201,6 +10220,16 @@
           "additionalProperties": false,
           "description": "Set of capabilities that must be enabled or made available to the task container Example: ```{ \"capabilities\": { \"privileged\": true }```",
           "properties": {
+            "containerEngine": {
+              "default": "docker",
+              "description": "The container engine to use, between `docker` and `podman`. This property is only used during Generic Worker's internal payload translation (d2g). [default: docker]",
+              "enum": [
+                "docker",
+                "podman"
+              ],
+              "title": "Container engine",
+              "type": "string"
+            },
             "devices": {
               "additionalProperties": false,
               "description": "Allows devices from the host system to be attached to a task container similar to using `--device` in docker.",

--- a/tools/d2g/d2g.go
+++ b/tools/d2g/d2g.go
@@ -98,8 +98,11 @@ func ConvertTaskDefinition(dwTaskDef json.RawMessage) (json.RawMessage, error) {
 // a converted Docker Worker task payload (see d2g.Convert function) to run
 // Docker Worker tasks under Generic Worker.
 func Scopes(dwScopes []string, dwPayload *dockerworker.DockerWorkerPayload, taskQueueID string) (gwScopes []string) {
-	// scopes to use docker, by default, should just come "for free"
-	gwScopes = []string{"generic-worker:os-group:" + taskQueueID + "/docker"}
+	gwScopes = []string{}
+	if dwPayload.Capabilities.ContainerEngine == "docker" {
+		// scopes to use docker, by default, should just come "for free"
+		gwScopes = append(gwScopes, "generic-worker:os-group:"+taskQueueID+"/docker")
+	}
 	for _, s := range dwScopes {
 		switch true {
 		case s == "docker-worker:capability:device:kvm":
@@ -132,7 +135,7 @@ func Scopes(dwScopes []string, dwPayload *dockerworker.DockerWorkerPayload, task
 
 // Convert transforms a Docker Worker task payload into an equivalent Generic
 // Worker Multiuser POSIX task payload. The resulting Generic Worker payload is
-// a BASH script which uses Podman (by default) to contain the Docker Worker payload. Since
+// a BASH script which uses Docker (by default) to contain the Docker Worker payload. Since
 // scopes fall outside of the payload in a task definition, scopes need to be
 // converted separately (see d2g.Scopes function).
 func Convert(dwPayload *dockerworker.DockerWorkerPayload) (gwPayload *genericworker.GenericWorkerPayload, err error) {

--- a/tools/d2g/d2gtest/d2g_test.go
+++ b/tools/d2g/d2gtest/d2g_test.go
@@ -36,7 +36,7 @@ func ExampleScopes_mixture() {
 	}
 	dwPayload := dockerworker.DockerWorkerPayload{}
 	defaults.SetDefaults(&dwPayload)
-	gwScopes := d2g.Scopes(dwScopes, &dwPayload, "proj-misc/tutorial")
+	gwScopes := d2g.Scopes(dwScopes, &dwPayload, "proj-misc/tutorial", "docker")
 	for _, s := range gwScopes {
 		fmt.Printf("\t%#v\n", s)
 	}
@@ -124,7 +124,7 @@ func (tc *TaskPayloadTestCase) TestTaskPayloadCase() func(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Cannot unmarshal test suite Docker Worker payload %v: %v", string(tc.DockerWorkerTaskPayload), err)
 		}
-		actualGWPayload, err := d2g.Convert(&dwPayload)
+		actualGWPayload, err := d2g.Convert(&dwPayload, tc.ContainerEngine)
 		if err != nil {
 			t.Fatalf("Cannot convert Docker Worker payload %#v to Generic Worker payload: %s", dwPayload, err)
 		}
@@ -154,7 +154,7 @@ func (tc *TaskDefinitionTestCase) TestTaskDefinitionCase() func(t *testing.T) {
 	return func(t *testing.T) {
 		t.Helper()
 		tc.Validate(t)
-		gwTaskDef, err := d2g.ConvertTaskDefinition(tc.DockerWorkerTaskDefinition)
+		gwTaskDef, err := d2g.ConvertTaskDefinition(tc.DockerWorkerTaskDefinition, tc.ContainerEngine)
 		if err != nil {
 			t.Fatalf("cannot convert task definition: %v", err)
 		}

--- a/tools/d2g/d2gtest/d2g_test.go
+++ b/tools/d2g/d2gtest/d2g_test.go
@@ -34,7 +34,9 @@ func ExampleScopes_mixture() {
 		"docker-worker:capability:device:loopbackVideo:x/y/z",
 		"docker-worker:capability:device:kvm:x/y/z",
 	}
-	gwScopes := d2g.Scopes(dwScopes, nil, "proj-misc/tutorial")
+	dwPayload := dockerworker.DockerWorkerPayload{}
+	defaults.SetDefaults(&dwPayload)
+	gwScopes := d2g.Scopes(dwScopes, &dwPayload, "proj-misc/tutorial")
 	for _, s := range gwScopes {
 		fmt.Printf("\t%#v\n", s)
 	}
@@ -50,6 +52,7 @@ func ExampleScopes_mixture() {
 	// 	"generic-worker:loopback-video:*"
 	// 	"generic-worker:loopback-video:x/y/z"
 	// 	"generic-worker:monkey"
+	//	"generic-worker:os-group:proj-misc/tutorial/docker"
 	// 	"generic-worker:teapot"
 }
 

--- a/tools/d2g/d2gtest/generated_types.go
+++ b/tools/d2g/d2gtest/generated_types.go
@@ -22,6 +22,13 @@ type (
 	// Worker task definition in the test case.
 	TaskDefinitionTestCase struct {
 
+		// Possible values:
+		//   * "docker"
+		//   * "podman"
+		//
+		// Default:    "docker"
+		ContainerEngine string `json:"containerEngine" default:"docker"`
+
 		// Detailed information about what the test case tests
 		Description string `json:"description"`
 
@@ -41,6 +48,13 @@ type (
 	// if the generated Generic Worker task payload exactly matches the Generic
 	// Worker task payload in the test case.
 	TaskPayloadTestCase struct {
+
+		// Possible values:
+		//   * "docker"
+		//   * "podman"
+		//
+		// Default:    "docker"
+		ContainerEngine string `json:"containerEngine" default:"docker"`
 
 		// Detailed information about what the test case tests
 		Description string `json:"description"`
@@ -129,6 +143,14 @@ func JSONSchema() string {
             "additionalProperties": false,
             "description": "A test case contains a static input Docker Worker task payload, and an\nexpected Generic Worker task payload output. The Docker Worker task payload\nis converted by d2g to a Generic Worker task payload. The test is successful\nif the generated Generic Worker task payload exactly matches the Generic\nWorker task payload in the test case.",
             "properties": {
+              "containerEngine": {
+                "default": "docker",
+                "enum": [
+                  "docker",
+                  "podman"
+                ],
+                "type": "string"
+              },
               "description": {
                 "$ref": "#/definitions/caseDescription"
               },
@@ -160,6 +182,14 @@ func JSONSchema() string {
             "additionalProperties": false,
             "description": "A test case contains a static input Docker Worker task definition, and an\nexpected Generic Worker task definition output. The Docker Worker task definition\nis converted by d2g to a Generic Worker task definition. The test is successful\nif the generated Generic Worker task definition exactly matches the Generic\nWorker task definition in the test case.",
             "properties": {
+              "containerEngine": {
+                "default": "docker",
+                "enum": [
+                  "docker",
+                  "podman"
+                ],
+                "type": "string"
+              },
               "description": {
                 "$ref": "#/definitions/caseDescription"
               },

--- a/tools/d2g/d2gtest/schemas/test_suites.yml
+++ b/tools/d2g/d2gtest/schemas/test_suites.yml
@@ -56,6 +56,12 @@ properties:
               # schemas and we prefer not to keep both json and yml versions in
               # the repo
               type: object
+            containerEngine:
+              type: string
+              enum:
+                - docker
+                - podman
+              default: docker
       taskDefTests:
         title: Task definition test cases
         description: |-
@@ -91,6 +97,12 @@ properties:
               # schemas and we prefer not to keep both json and yml versions in
               # the repo
               type: object
+            containerEngine:
+              type: string
+              enum:
+                - docker
+                - podman
+              default: docker
 definitions:
   suiteName:
     title: Test Suite Name

--- a/tools/d2g/d2gtest/testdata/testcases/artifacts_test.yml
+++ b/tools/d2g/d2gtest/testdata/testcases/artifacts_test.yml
@@ -33,8 +33,8 @@ testSuite:
           - - bash
             - '-cx'
             - >-
-              timeout 3600 podman run --init -t --name taskcontainer
-              --memory-swap -1 --pids-limit -1 --ulimit host
+              timeout 3600 docker run --init -t --name taskcontainer
+              --memory-swap -1 --pids-limit -1
               -e RUN_ID
               -e TASKCLUSTER_INSTANCE_TYPE
               -e TASKCLUSTER_ROOT_URL
@@ -45,11 +45,11 @@ testSuite:
 
               exit_code=$?
 
-              podman cp taskcontainer:'/etc/passwd'\'' artifact0; whoami; echo foo > /root/bar; cp '\''foo' artifact0
+              docker cp taskcontainer:'/etc/passwd'\'' artifact0; whoami; echo foo > /root/bar; cp '\''foo' artifact0
 
-              podman cp taskcontainer:'/home/worker/artifacts/fred.txt' 'artifact1.txt'
+              docker cp taskcontainer:'/home/worker/artifacts/fred.txt' 'artifact1.txt'
 
-              podman rm taskcontainer
+              docker rm taskcontainer
 
               exit "${exit_code}"
         maxRunTime: 4500
@@ -57,4 +57,6 @@ testSuite:
           retry:
             - 125
             - 128
+        osGroups:
+          - docker
   taskDefTests: []

--- a/tools/d2g/d2gtest/testdata/testcases/container_engine_test.yml
+++ b/tools/d2g/d2gtest/testdata/testcases/container_engine_test.yml
@@ -5,7 +5,7 @@ testSuite:
   payloadTests:
     - name: Default container engine test
       description: >-
-        Tests that podman should be set as the default container engine in the resulting generic worker task payload.
+        Tests that docker should be set as the default container engine in the resulting generic worker task payload.
       dockerWorkerTaskPayload:
         command:
           - echo "Hello world"
@@ -16,37 +16,7 @@ testSuite:
           - - bash
             - '-cx'
             - >-
-              podman run -t --rm --memory-swap -1 --pids-limit -1 --ulimit host
-              -e RUN_ID
-              -e TASKCLUSTER_INSTANCE_TYPE
-              -e TASKCLUSTER_ROOT_URL
-              -e TASKCLUSTER_WORKER_LOCATION
-              -e TASK_GROUP_ID
-              -e TASK_ID
-              ubuntu 'echo "Hello world"'
-        maxRunTime: 3600
-        onExitStatus:
-          retry:
-            - 125
-            - 128
-
-    - name: Container engine test with privileged set
-      description: >-
-        Tests that container engine user passes is not changed when privileged is set to true in the resulting generic worker task payload.
-      dockerWorkerTaskPayload:
-        command:
-          - echo "Hello world"
-        capabilities:
-          privileged: true
-          containerEngine: docker
-        image: ubuntu
-        maxRunTime: 3600
-      genericWorkerTaskPayload:
-        command:
-          - - bash
-            - '-cx'
-            - >-
-              docker run -t --rm --memory-swap -1 --pids-limit -1 --privileged
+              docker run --init -t --rm --memory-swap -1 --pids-limit -1
               -e RUN_ID
               -e TASKCLUSTER_INSTANCE_TYPE
               -e TASKCLUSTER_ROOT_URL
@@ -62,41 +32,14 @@ testSuite:
         osGroups:
           - docker
 
-    - name: Default container engine test
+    - name: Set to podman container engine test
       description: >-
-        Tests that container engine is set to worker config when not specified in the resulting generic worker task payload.
-      dockerWorkerTaskPayload:
-        command:
-          - echo "Hello world"
-        image: ubuntu
-        maxRunTime: 3600
-      genericWorkerTaskPayload:
-        command:
-          - - bash
-            - '-cx'
-            - >-
-              podman run -t --rm --memory-swap -1 --pids-limit -1 --ulimit host
-              -e RUN_ID
-              -e TASKCLUSTER_INSTANCE_TYPE
-              -e TASKCLUSTER_ROOT_URL
-              -e TASKCLUSTER_WORKER_LOCATION
-              -e TASK_GROUP_ID
-              -e TASK_ID
-              ubuntu 'echo "Hello world"'
-        maxRunTime: 3600
-        onExitStatus:
-          retry:
-            - 125
-            - 128
-
-    - name: Set to docker container engine test
-      description: >-
-        Tests that docker should be set as the container engine in the resulting generic worker task payload.
+        Tests that podman should be set as the container engine in the resulting generic worker task payload.
       dockerWorkerTaskPayload:
         command:
           - echo "Hello world"
         capabilities:
-          containerEngine: docker
+          containerEngine: podman
         image: ubuntu
         maxRunTime: 3600
       genericWorkerTaskPayload:
@@ -104,7 +47,7 @@ testSuite:
           - - bash
             - '-cx'
             - >-
-              docker run -t --rm --memory-swap -1 --pids-limit -1
+              podman run --init -t --rm --memory-swap -1 --pids-limit -1 --ulimit host
               -e RUN_ID
               -e TASKCLUSTER_INSTANCE_TYPE
               -e TASKCLUSTER_ROOT_URL
@@ -117,6 +60,4 @@ testSuite:
           retry:
             - 125
             - 128
-        osGroups:
-          - docker
   taskDefTests: []

--- a/tools/d2g/d2gtest/testdata/testcases/container_engine_test.yml
+++ b/tools/d2g/d2gtest/testdata/testcases/container_engine_test.yml
@@ -1,0 +1,122 @@
+---
+testSuite:
+  name: Container engine tests
+  description: Test that the container engine should be set properly in the resulting generic worker task payload.
+  payloadTests:
+    - name: Default container engine test
+      description: >-
+        Tests that podman should be set as the default container engine in the resulting generic worker task payload.
+      dockerWorkerTaskPayload:
+        command:
+          - echo "Hello world"
+        image: ubuntu
+        maxRunTime: 3600
+      genericWorkerTaskPayload:
+        command:
+          - - bash
+            - '-cx'
+            - >-
+              podman run -t --rm --memory-swap -1 --pids-limit -1 --ulimit host
+              -e RUN_ID
+              -e TASKCLUSTER_INSTANCE_TYPE
+              -e TASKCLUSTER_ROOT_URL
+              -e TASKCLUSTER_WORKER_LOCATION
+              -e TASK_GROUP_ID
+              -e TASK_ID
+              ubuntu 'echo "Hello world"'
+        maxRunTime: 3600
+        onExitStatus:
+          retry:
+            - 125
+            - 128
+
+    - name: Container engine test with privileged set
+      description: >-
+        Tests that container engine user passes is not changed when privileged is set to true in the resulting generic worker task payload.
+      dockerWorkerTaskPayload:
+        command:
+          - echo "Hello world"
+        capabilities:
+          privileged: true
+          containerEngine: docker
+        image: ubuntu
+        maxRunTime: 3600
+      genericWorkerTaskPayload:
+        command:
+          - - bash
+            - '-cx'
+            - >-
+              docker run -t --rm --memory-swap -1 --pids-limit -1 --privileged
+              -e RUN_ID
+              -e TASKCLUSTER_INSTANCE_TYPE
+              -e TASKCLUSTER_ROOT_URL
+              -e TASKCLUSTER_WORKER_LOCATION
+              -e TASK_GROUP_ID
+              -e TASK_ID
+              ubuntu 'echo "Hello world"'
+        maxRunTime: 3600
+        onExitStatus:
+          retry:
+            - 125
+            - 128
+        osGroups:
+          - docker
+
+    - name: Default container engine test
+      description: >-
+        Tests that container engine is set to worker config when not specified in the resulting generic worker task payload.
+      dockerWorkerTaskPayload:
+        command:
+          - echo "Hello world"
+        image: ubuntu
+        maxRunTime: 3600
+      genericWorkerTaskPayload:
+        command:
+          - - bash
+            - '-cx'
+            - >-
+              podman run -t --rm --memory-swap -1 --pids-limit -1 --ulimit host
+              -e RUN_ID
+              -e TASKCLUSTER_INSTANCE_TYPE
+              -e TASKCLUSTER_ROOT_URL
+              -e TASKCLUSTER_WORKER_LOCATION
+              -e TASK_GROUP_ID
+              -e TASK_ID
+              ubuntu 'echo "Hello world"'
+        maxRunTime: 3600
+        onExitStatus:
+          retry:
+            - 125
+            - 128
+
+    - name: Set to docker container engine test
+      description: >-
+        Tests that docker should be set as the container engine in the resulting generic worker task payload.
+      dockerWorkerTaskPayload:
+        command:
+          - echo "Hello world"
+        capabilities:
+          containerEngine: docker
+        image: ubuntu
+        maxRunTime: 3600
+      genericWorkerTaskPayload:
+        command:
+          - - bash
+            - '-cx'
+            - >-
+              docker run -t --rm --memory-swap -1 --pids-limit -1
+              -e RUN_ID
+              -e TASKCLUSTER_INSTANCE_TYPE
+              -e TASKCLUSTER_ROOT_URL
+              -e TASKCLUSTER_WORKER_LOCATION
+              -e TASK_GROUP_ID
+              -e TASK_ID
+              ubuntu 'echo "Hello world"'
+        maxRunTime: 3600
+        onExitStatus:
+          retry:
+            - 125
+            - 128
+        osGroups:
+          - docker
+  taskDefTests: []

--- a/tools/d2g/d2gtest/testdata/testcases/devices_tests.yml
+++ b/tools/d2g/d2gtest/testdata/testcases/devices_tests.yml
@@ -19,7 +19,7 @@ testSuite:
           - - bash
             - '-cx'
             - >-
-              podman run --init -t --rm --memory-swap -1 --pids-limit -1 --ulimit host --privileged
+              docker run --init -t --rm --memory-swap -1 --pids-limit -1 --privileged
               -v /dev/shm:/dev/shm
               -e RUN_ID
               -e TASKCLUSTER_INSTANCE_TYPE
@@ -33,6 +33,8 @@ testSuite:
           retry:
             - 125
             - 128
+        osGroups:
+          - docker
 
     - name: KVM
       description: >-
@@ -50,7 +52,7 @@ testSuite:
           - - bash
             - '-cx'
             - >-
-              podman run --init -t --rm --memory-swap -1 --pids-limit -1 --ulimit host
+              docker run --init -t --rm --memory-swap -1 --pids-limit -1
               -v /dev/kvm:/dev/kvm
               -e RUN_ID
               -e TASKCLUSTER_INSTANCE_TYPE
@@ -67,6 +69,7 @@ testSuite:
         osGroups:
           - kvm
           - libvirt
+          - docker
 
     - name: Video Loopback
       description: >-
@@ -84,7 +87,7 @@ testSuite:
           - - bash
             - '-cx'
             - >-
-              podman run --init -t --rm --memory-swap -1 --pids-limit -1 --ulimit host
+              docker run --init -t --rm --memory-swap -1 --pids-limit -1
               -v "${TASKCLUSTER_VIDEO_DEVICE}:${TASKCLUSTER_VIDEO_DEVICE}"
               -e RUN_ID
               -e TASKCLUSTER_INSTANCE_TYPE
@@ -100,6 +103,8 @@ testSuite:
           retry:
             - 125
             - 128
+        osGroups:
+          - docker
 
     - name: Audio Loopback
       description: >-
@@ -117,7 +122,7 @@ testSuite:
           - - bash
             - '-cx'
             - >-
-              podman run --init -t --rm --memory-swap -1 --pids-limit -1 --ulimit host
+              docker run --init -t --rm --memory-swap -1 --pids-limit -1
               -v /dev/snd:/dev/snd
               -e RUN_ID
               -e TASKCLUSTER_INSTANCE_TYPE
@@ -133,4 +138,6 @@ testSuite:
           retry:
             - 125
             - 128
+        osGroups:
+          - docker
   taskDefTests: []

--- a/tools/d2g/d2gtest/testdata/testcases/docker_image_tests.yml
+++ b/tools/d2g/d2gtest/testdata/testcases/docker_image_tests.yml
@@ -15,7 +15,7 @@ testSuite:
           - - bash
             - '-cx'
             - >-
-              podman run --init -t --rm --memory-swap -1 --pids-limit -1 --ulimit host
+              docker run --init -t --rm --memory-swap -1 --pids-limit -1
               -e RUN_ID
               -e TASKCLUSTER_INSTANCE_TYPE
               -e TASKCLUSTER_ROOT_URL
@@ -28,6 +28,8 @@ testSuite:
           retry:
             - 125
             - 128
+        osGroups:
+          - docker
 
     - name: NamedDockerImage
       description: Test NamedDockerImage
@@ -43,7 +45,7 @@ testSuite:
           - - bash
             - '-cx'
             - >-
-              podman run --init -t --rm --memory-swap -1 --pids-limit -1 --ulimit host
+              docker run --init -t --rm --memory-swap -1 --pids-limit -1
               -e RUN_ID
               -e TASKCLUSTER_INSTANCE_TYPE
               -e TASKCLUSTER_ROOT_URL
@@ -56,6 +58,8 @@ testSuite:
           retry:
             - 125
             - 128
+        osGroups:
+          - docker
 
     - name: IndexedDockerImage
       description: Test IndexedDockerImage
@@ -72,14 +76,16 @@ testSuite:
           - - bash
             - '-cx'
             - >-
-              podman run --init -t --rm --memory-swap -1 --pids-limit -1 --ulimit host
+              IMAGE_ID=$(docker load --input dockerimage | sed -n '0,/^Loaded image: /s/^Loaded image: //p')
+
+              docker run --init -t --rm --memory-swap -1 --pids-limit -1
               -e RUN_ID
               -e TASKCLUSTER_INSTANCE_TYPE
               -e TASKCLUSTER_ROOT_URL
               -e TASKCLUSTER_WORKER_LOCATION
               -e TASK_GROUP_ID
               -e TASK_ID
-              docker-archive:dockerimage 'echo "Hello world"'
+              "${IMAGE_ID}" 'echo "Hello world"'
         maxRunTime: 3600
         mounts:
           - content:
@@ -92,6 +98,8 @@ testSuite:
           retry:
             - 125
             - 128
+        osGroups:
+          - docker
 
     - name: IndexedDockerImage with .lz4 extension
       description: Test IndexedDockerImage with .lz4 extension
@@ -108,14 +116,16 @@ testSuite:
           - - bash
             - '-cx'
             - >-
-              podman run --init -t --rm --memory-swap -1 --pids-limit -1 --ulimit host
+              IMAGE_ID=$(docker load --input dockerimage | sed -n '0,/^Loaded image: /s/^Loaded image: //p')
+
+              docker run --init -t --rm --memory-swap -1 --pids-limit -1
               -e RUN_ID
               -e TASKCLUSTER_INSTANCE_TYPE
               -e TASKCLUSTER_ROOT_URL
               -e TASKCLUSTER_WORKER_LOCATION
               -e TASK_GROUP_ID
               -e TASK_ID
-              docker-archive:dockerimage 'echo "Hello world"'
+              "${IMAGE_ID}" 'echo "Hello world"'
         maxRunTime: 3600
         mounts:
           - content:
@@ -129,6 +139,8 @@ testSuite:
           retry:
             - 125
             - 128
+        osGroups:
+          - docker
 
     - name: IndexedDockerImage with .zst extension
       description: Test IndexedDockerImage with .zst extension
@@ -145,14 +157,16 @@ testSuite:
           - - bash
             - '-cx'
             - >-
-              podman run --init -t --rm --memory-swap -1 --pids-limit -1 --ulimit host
+              IMAGE_ID=$(docker load --input dockerimage | sed -n '0,/^Loaded image: /s/^Loaded image: //p')
+
+              docker run --init -t --rm --memory-swap -1 --pids-limit -1
               -e RUN_ID
               -e TASKCLUSTER_INSTANCE_TYPE
               -e TASKCLUSTER_ROOT_URL
               -e TASKCLUSTER_WORKER_LOCATION
               -e TASK_GROUP_ID
               -e TASK_ID
-              docker-archive:dockerimage 'echo "Hello world"'
+              "${IMAGE_ID}" 'echo "Hello world"'
         maxRunTime: 3600
         mounts:
           - content:
@@ -166,6 +180,8 @@ testSuite:
           retry:
             - 125
             - 128
+        osGroups:
+          - docker
 
     - name: DockerImageArtifact
       description: Test DockerImageArtifact
@@ -182,14 +198,16 @@ testSuite:
           - - bash
             - '-cx'
             - >-
-              podman run --init -t --rm --memory-swap -1 --pids-limit -1 --ulimit host
+              IMAGE_ID=$(docker load --input dockerimage | sed -n '0,/^Loaded image: /s/^Loaded image: //p')
+
+              docker run --init -t --rm --memory-swap -1 --pids-limit -1
               -e RUN_ID
               -e TASKCLUSTER_INSTANCE_TYPE
               -e TASKCLUSTER_ROOT_URL
               -e TASKCLUSTER_WORKER_LOCATION
               -e TASK_GROUP_ID
               -e TASK_ID
-              docker-archive:dockerimage 'echo "Hello world"'
+              "${IMAGE_ID}" 'echo "Hello world"'
         mounts:
           - content:
               artifact: public/test/path
@@ -200,6 +218,8 @@ testSuite:
           retry:
             - 125
             - 128
+        osGroups:
+          - docker
 
     - name: DockerImageArtifact with .lz4 extension
       description: Test DockerImageArtifact with .lz4 extension
@@ -216,14 +236,16 @@ testSuite:
           - - bash
             - '-cx'
             - >-
-              podman run --init -t --rm --memory-swap -1 --pids-limit -1 --ulimit host
+              IMAGE_ID=$(docker load --input dockerimage | sed -n '0,/^Loaded image: /s/^Loaded image: //p')
+
+              docker run --init -t --rm --memory-swap -1 --pids-limit -1
               -e RUN_ID
               -e TASKCLUSTER_INSTANCE_TYPE
               -e TASKCLUSTER_ROOT_URL
               -e TASKCLUSTER_WORKER_LOCATION
               -e TASK_GROUP_ID
               -e TASK_ID
-              docker-archive:dockerimage 'echo "Hello world"'
+              "${IMAGE_ID}" 'echo "Hello world"'
         mounts:
           - content:
               artifact: public/test/path.lz4
@@ -235,6 +257,8 @@ testSuite:
           retry:
             - 125
             - 128
+        osGroups:
+          - docker
 
     - name: DockerImageArtifact with .zst extension
       description: Test DockerImageArtifact with .zst extension
@@ -251,14 +275,16 @@ testSuite:
           - - bash
             - '-cx'
             - >-
-              podman run --init -t --rm --memory-swap -1 --pids-limit -1 --ulimit host
+              IMAGE_ID=$(docker load --input dockerimage | sed -n '0,/^Loaded image: /s/^Loaded image: //p')
+
+              docker run --init -t --rm --memory-swap -1 --pids-limit -1
               -e RUN_ID
               -e TASKCLUSTER_INSTANCE_TYPE
               -e TASKCLUSTER_ROOT_URL
               -e TASKCLUSTER_WORKER_LOCATION
               -e TASK_GROUP_ID
               -e TASK_ID
-              docker-archive:dockerimage 'echo "Hello world"'
+              "${IMAGE_ID}" 'echo "Hello world"'
         mounts:
           - content:
               artifact: public/test/path.zst
@@ -270,12 +296,16 @@ testSuite:
           retry:
             - 125
             - 128
+        osGroups:
+          - docker
 
-    - name: DockerImage with cache
-      description: Test DockerImage with cache
+    - name: DockerImage with cache using podman
+      description: Test DockerImage with cache using podman
       dockerWorkerTaskPayload:
         cache:
           gecko-level-3-checkouts-sparse-v3: /builds/worker/checkouts
+        capabilities:
+          containerEngine: podman
         command:
           - echo "Hello world"
         image:
@@ -312,4 +342,48 @@ testSuite:
           retry:
             - 125
             - 128
+
+    - name: DockerImage with cache
+      description: Test DockerImage with cache
+      dockerWorkerTaskPayload:
+        cache:
+          gecko-level-3-checkouts-sparse-v3: /builds/worker/checkouts
+        command:
+          - echo "Hello world"
+        image:
+          path: public/test/path.zst
+          taskId: 2JGiKFtpRnGbVczc6-OJ1Q
+          type: task-image
+        maxRunTime: 3600
+      genericWorkerTaskPayload:
+        command:
+          - - bash
+            - '-cx'
+            - >-
+              IMAGE_ID=$(docker load --input dockerimage | sed -n '0,/^Loaded image: /s/^Loaded image: //p')
+
+              docker run --init -t --rm --memory-swap -1 --pids-limit -1
+              -v "$(pwd)/cache0:/builds/worker/checkouts"
+              -e RUN_ID
+              -e TASKCLUSTER_INSTANCE_TYPE
+              -e TASKCLUSTER_ROOT_URL
+              -e TASKCLUSTER_WORKER_LOCATION
+              -e TASK_GROUP_ID
+              -e TASK_ID
+              "${IMAGE_ID}" 'echo "Hello world"'
+        mounts:
+          - cacheName: gecko-level-3-checkouts-sparse-v3
+            directory: cache0
+          - content:
+              artifact: public/test/path.zst
+              taskId: 2JGiKFtpRnGbVczc6-OJ1Q
+            file: dockerimage
+            format: zst
+        maxRunTime: 3600
+        onExitStatus:
+          retry:
+            - 125
+            - 128
+        osGroups:
+          - docker
   taskDefTests: []

--- a/tools/d2g/d2gtest/testdata/testcases/dw_features_tests.yml
+++ b/tools/d2g/d2gtest/testdata/testcases/dw_features_tests.yml
@@ -18,7 +18,7 @@ testSuite:
           - - bash
             - "-cx"
             - >-
-              podman run --init -t --rm --memory-swap -1 --pids-limit -1 --ulimit host --cap-add=SYS_PTRACE
+              docker run --init -t --rm --memory-swap -1 --pids-limit -1 --cap-add=SYS_PTRACE
               -e RUN_ID
               -e TASKCLUSTER_INSTANCE_TYPE
               -e TASKCLUSTER_ROOT_URL
@@ -31,4 +31,6 @@ testSuite:
           retry:
             - 125
             - 128
+        osGroups:
+          - docker
   taskDefTests: []

--- a/tools/d2g/d2gtest/testdata/testcases/env_escaping_test.yml
+++ b/tools/d2g/d2gtest/testdata/testcases/env_escaping_test.yml
@@ -6,7 +6,7 @@ testSuite:
     - name: Env escaping test
       description: >-
         If an environment variable contains spaces or special characters,
-        it should be escaped before passing to the podman run --init command.
+        it should be escaped before passing to the docker run --init command.
       dockerWorkerTaskPayload:
         command:
           - echo "Hello world"
@@ -19,7 +19,7 @@ testSuite:
           - - bash
             - '-cx'
             - >-
-              podman run --init -t --rm --memory-swap -1 --pids-limit -1 --ulimit host
+              docker run --init -t --rm --memory-swap -1 --pids-limit -1
               -e ' test123 --help  ; whoami ; '
               -e RUN_ID
               -e TASKCLUSTER_INSTANCE_TYPE
@@ -35,4 +35,6 @@ testSuite:
           retry:
             - 125
             - 128
+        osGroups:
+          - docker
   taskDefTests: []

--- a/tools/d2g/d2gtest/testdata/testcases/no_artifacts_test.yml
+++ b/tools/d2g/d2gtest/testdata/testcases/no_artifacts_test.yml
@@ -23,7 +23,7 @@ testSuite:
           - - bash
             - '-cx'
             - >-
-              podman run --init -t --rm --memory-swap -1 --pids-limit -1 --ulimit host
+              docker run --init -t --rm --memory-swap -1 --pids-limit -1
               -e RUN_ID
               -e TASKCLUSTER_INSTANCE_TYPE
               -e TASKCLUSTER_ROOT_URL
@@ -39,4 +39,6 @@ testSuite:
           retry:
             - 125
             - 128
+        osGroups:
+          - docker
   taskDefTests: []

--- a/tools/d2g/d2gtest/testdata/testcases/task_def_test.yml
+++ b/tools/d2g/d2gtest/testdata/testcases/task_def_test.yml
@@ -56,7 +56,7 @@ testSuite:
           command:
           - - bash
             - -cx
-            - podman run --init -t --rm --memory-swap -1 --pids-limit -1 --ulimit host -v /dev/kvm:/dev/kvm -e RUN_ID -e TASKCLUSTER_INSTANCE_TYPE
+            - docker run --init -t --rm --memory-swap -1 --pids-limit -1 -v /dev/kvm:/dev/kvm -e RUN_ID -e TASKCLUSTER_INSTANCE_TYPE
               -e TASKCLUSTER_ROOT_URL -e TASKCLUSTER_WORKER_LOCATION -e TASK_GROUP_ID -e TASK_ID ubuntu:latest /bin/bash -c
               'for ((i=1;i<=600;i++)); do echo $i; sleep 1; done'
           features:
@@ -73,6 +73,7 @@ testSuite:
           osGroups:
             - kvm
             - libvirt
+            - docker
         priority: lowest
         projectId: none
         provisionerId: proj-taskcluster
@@ -82,6 +83,7 @@ testSuite:
         schedulerId: taskcluster-ui
         scopes:
           - generic-worker:apples
+          - generic-worker:os-group:proj-taskcluster/gw-ubuntu-24-04/docker
         tags: {}
         taskGroupId: PIxhISDQSDa98W9ppGUNsw
         taskQueueId: proj-taskcluster/gw-ubuntu-24-04
@@ -140,7 +142,7 @@ testSuite:
           command:
           - - bash
             - -cx
-            - podman run --init -t --rm --memory-swap -1 --pids-limit -1 --ulimit host -v /dev/kvm:/dev/kvm -e RUN_ID -e TASKCLUSTER_INSTANCE_TYPE
+            - docker run --init -t --rm --memory-swap -1 --pids-limit -1 -v /dev/kvm:/dev/kvm -e RUN_ID -e TASKCLUSTER_INSTANCE_TYPE
               -e TASKCLUSTER_ROOT_URL -e TASKCLUSTER_WORKER_LOCATION -e TASK_GROUP_ID -e TASK_ID ubuntu:latest /bin/bash -c
               'for ((i=1;i<=600;i++)); do echo $i; sleep 1; done'
           features:
@@ -157,6 +159,7 @@ testSuite:
           osGroups:
             - kvm
             - libvirt
+            - docker
         priority: lowest
         projectId: none
         provisionerId: proj-taskcluster
@@ -166,6 +169,7 @@ testSuite:
         schedulerId: taskcluster-ui
         scopes:
           - generic-worker:apples
+          - generic-worker:os-group:proj-taskcluster/gw-ubuntu-24-04/docker
           - generic-worker:os-group:proj-taskcluster/gw-ubuntu-24-04/kvm
           - generic-worker:os-group:proj-taskcluster/gw-ubuntu-24-04/libvirt
         tags: {}
@@ -202,6 +206,7 @@ testSuite:
             - for ((i=1;i<=600;i++)); do echo $i; sleep 1; done
           maxRunTime: 630
           capabilities:
+            containerEngine: podman
             devices:
               kvm: true
         metadata:

--- a/tools/d2g/dockerworker/generated_types.go
+++ b/tools/d2g/dockerworker/generated_types.go
@@ -23,6 +23,15 @@ type (
 	// Set of capabilities that must be enabled or made available to the task container Example: ```{ "capabilities": { "privileged": true }```
 	Capabilities struct {
 
+		// The container engine to use, between `docker` and `podman`. This property is only used during Generic Worker's internal payload translation (d2g). [default: docker]
+		//
+		// Possible values:
+		//   * "docker"
+		//   * "podman"
+		//
+		// Default:    "docker"
+		ContainerEngine string `json:"containerEngine" default:"docker"`
+
 		// Allows devices from the host system to be attached to a task container similar to using `--device` in docker.
 		Devices Devices `json:"devices,omitempty"`
 
@@ -277,6 +286,16 @@ func JSONSchema() string {
       "additionalProperties": false,
       "description": "Set of capabilities that must be enabled or made available to the task container Example: ` + "`" + `` + "`" + `` + "`" + `{ \"capabilities\": { \"privileged\": true }` + "`" + `` + "`" + `` + "`" + `",
       "properties": {
+        "containerEngine": {
+          "default": "docker",
+          "description": "The container engine to use, between ` + "`" + `docker` + "`" + ` and ` + "`" + `podman` + "`" + `. This property is only used during Generic Worker's internal payload translation (d2g). [default: docker]",
+          "enum": [
+            "docker",
+            "podman"
+          ],
+          "title": "Container engine",
+          "type": "string"
+        },
         "devices": {
           "additionalProperties": false,
           "description": "Allows devices from the host system to be attached to a task container similar to using ` + "`" + `--device` + "`" + ` in docker.",

--- a/tools/d2g/dockerworker/generated_types.go
+++ b/tools/d2g/dockerworker/generated_types.go
@@ -23,14 +23,12 @@ type (
 	// Set of capabilities that must be enabled or made available to the task container Example: ```{ "capabilities": { "privileged": true }```
 	Capabilities struct {
 
-		// The container engine to use, between `docker` and `podman`. This property is only used during Generic Worker's internal payload translation (d2g). [default: docker]
+		// The container engine to use when executing tasks with Docker Worker formatted task payloads.
 		//
 		// Possible values:
 		//   * "docker"
 		//   * "podman"
-		//
-		// Default:    "docker"
-		ContainerEngine string `json:"containerEngine" default:"docker"`
+		ContainerEngine string `json:"containerEngine,omitempty"`
 
 		// Allows devices from the host system to be attached to a task container similar to using `--device` in docker.
 		Devices Devices `json:"devices,omitempty"`
@@ -287,8 +285,7 @@ func JSONSchema() string {
       "description": "Set of capabilities that must be enabled or made available to the task container Example: ` + "`" + `` + "`" + `` + "`" + `{ \"capabilities\": { \"privileged\": true }` + "`" + `` + "`" + `` + "`" + `",
       "properties": {
         "containerEngine": {
-          "default": "docker",
-          "description": "The container engine to use, between ` + "`" + `docker` + "`" + ` and ` + "`" + `podman` + "`" + `. This property is only used during Generic Worker's internal payload translation (d2g). [default: docker]",
+          "description": "The container engine to use when executing tasks with Docker Worker formatted task payloads.",
           "enum": [
             "docker",
             "podman"

--- a/tools/d2g/genericworker/generated_types.go
+++ b/tools/d2g/genericworker/generated_types.go
@@ -131,6 +131,15 @@ type (
 	// Set of capabilities that must be enabled or made available to the task container Example: ```{ "capabilities": { "privileged": true }```
 	Capabilities struct {
 
+		// The container engine to use, between `docker` and `podman`. This property is only used during Generic Worker's internal payload translation (d2g). [default: docker]
+		//
+		// Possible values:
+		//   * "docker"
+		//   * "podman"
+		//
+		// Default:    "docker"
+		ContainerEngine string `json:"containerEngine" default:"docker"`
+
 		// Allows devices from the host system to be attached to a task container similar to using `--device` in docker.
 		Devices Devices `json:"devices,omitempty"`
 
@@ -1262,6 +1271,16 @@ func JSONSchema() string {
           "additionalProperties": false,
           "description": "Set of capabilities that must be enabled or made available to the task container Example: ` + "`" + `` + "`" + `` + "`" + `{ \"capabilities\": { \"privileged\": true }` + "`" + `` + "`" + `` + "`" + `",
           "properties": {
+            "containerEngine": {
+              "default": "docker",
+              "description": "The container engine to use, between ` + "`" + `docker` + "`" + ` and ` + "`" + `podman` + "`" + `. This property is only used during Generic Worker's internal payload translation (d2g). [default: docker]",
+              "enum": [
+                "docker",
+                "podman"
+              ],
+              "title": "Container engine",
+              "type": "string"
+            },
             "devices": {
               "additionalProperties": false,
               "description": "Allows devices from the host system to be attached to a task container similar to using ` + "`" + `--device` + "`" + ` in docker.",

--- a/tools/d2g/genericworker/generated_types.go
+++ b/tools/d2g/genericworker/generated_types.go
@@ -131,14 +131,12 @@ type (
 	// Set of capabilities that must be enabled or made available to the task container Example: ```{ "capabilities": { "privileged": true }```
 	Capabilities struct {
 
-		// The container engine to use, between `docker` and `podman`. This property is only used during Generic Worker's internal payload translation (d2g). [default: docker]
+		// The container engine to use when executing tasks with Docker Worker formatted task payloads.
 		//
 		// Possible values:
 		//   * "docker"
 		//   * "podman"
-		//
-		// Default:    "docker"
-		ContainerEngine string `json:"containerEngine" default:"docker"`
+		ContainerEngine string `json:"containerEngine,omitempty"`
 
 		// Allows devices from the host system to be attached to a task container similar to using `--device` in docker.
 		Devices Devices `json:"devices,omitempty"`
@@ -1272,8 +1270,7 @@ func JSONSchema() string {
           "description": "Set of capabilities that must be enabled or made available to the task container Example: ` + "`" + `` + "`" + `` + "`" + `{ \"capabilities\": { \"privileged\": true }` + "`" + `` + "`" + `` + "`" + `",
           "properties": {
             "containerEngine": {
-              "default": "docker",
-              "description": "The container engine to use, between ` + "`" + `docker` + "`" + ` and ` + "`" + `podman` + "`" + `. This property is only used during Generic Worker's internal payload translation (d2g). [default: docker]",
+              "description": "The container engine to use when executing tasks with Docker Worker formatted task payloads.",
               "enum": [
                 "docker",
                 "podman"

--- a/workers/docker-worker/schemas/v1/payload.yml
+++ b/workers/docker-worker/schemas/v1/payload.yml
@@ -123,6 +123,17 @@ properties:
           still includes feature in order for d2g to work with it.
         type: boolean
         default: false
+      containerEngine:
+        title: Container engine
+        description: >-
+          The container engine to use, between `docker` and `podman`.
+          This property is only used during Generic Worker's internal
+          payload translation (d2g). [default: docker]
+        type: string
+        enum:
+          - docker
+          - podman
+        default: docker
       devices:
         title: Devices to be attached to task containers
         description: >-

--- a/workers/docker-worker/schemas/v1/payload.yml
+++ b/workers/docker-worker/schemas/v1/payload.yml
@@ -126,14 +126,12 @@ properties:
       containerEngine:
         title: Container engine
         description: >-
-          The container engine to use, between `docker` and `podman`.
-          This property is only used during Generic Worker's internal
-          payload translation (d2g). [default: docker]
+          The container engine to use when executing tasks
+          with Docker Worker formatted task payloads.
         type: string
         enum:
           - docker
           - podman
-        default: docker
       devices:
         title: Devices to be attached to task containers
         description: >-

--- a/workers/generic-worker/README.md
+++ b/workers/generic-worker/README.md
@@ -125,6 +125,12 @@ and reports back results to the queue.
                                             but for one-off troubleshooting, it can be useful
                                             to (temporarily) leave home directories in place.
                                             Accepted values: true or false. [default: true]
+          containerEngine                   The default container engine to use for translated
+                                            Docker Worker tasks when not specified in the
+                                            Docker Worker task payload (property
+                                            capabilities.containerEngine).
+                                            Accepted values: "docker" or "podman".
+                                            [default: "docker"]
           createObjectArtifacts             If true, use artifact type 'object' for artifacts
                                             containing data.  If false, use artifact type 's3'.
                                             The 'object' type will become the default when the

--- a/workers/generic-worker/README.md
+++ b/workers/generic-worker/README.md
@@ -152,6 +152,9 @@ and reports back results to the queue.
                                             directory will be created if it does not exist. This
                                             may be a relative path to the current directory, or
                                             an absolute path. [default: "downloads"]
+          enableD2G                         Enables D2G (Docker Worker to Generic Worker payload
+                                            transformation). This allows for Docker Worker payloads
+                                            to be submitted to Generic Worker. [default: false]
           enableInteractive                 Enables interactive mode. This allows an
                                             interactive shell session to run on the worker.
                                             [default: false]

--- a/workers/generic-worker/d2g_test.go
+++ b/workers/generic-worker/d2g_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"fmt"
 	"runtime"
 	"testing"
 
@@ -27,8 +28,8 @@ func TestWithValidDockerWorkerPayload(t *testing.T) {
 	defaults.SetDefaults(&payload)
 	td := testTask(t)
 
-	switch runtime.GOOS {
-	case "linux":
+	switch fmt.Sprintf("%s:%s", engine, runtime.GOOS) {
+	case "multiuser:linux":
 		_ = submitAndAssert(t, td, payload, "completed", "completed")
 	default:
 		_ = submitAndAssert(t, td, payload, "exception", "malformed-payload")
@@ -73,8 +74,8 @@ func TestIssue6789(t *testing.T) {
 	td := testTask(t)
 	td.Scopes = append(td.Scopes, "docker-worker:cache:d2g-test")
 
-	switch runtime.GOOS {
-	case "linux":
+	switch fmt.Sprintf("%s:%s", engine, runtime.GOOS) {
+	case "multiuser:linux":
 		_ = submitAndAssert(t, td, payload, "completed", "completed")
 	default:
 		_ = submitAndAssert(t, td, payload, "exception", "malformed-payload")

--- a/workers/generic-worker/d2g_test.go
+++ b/workers/generic-worker/d2g_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"runtime"
+	"strings"
 	"testing"
 
 	"github.com/mcuadros/go-defaults"
@@ -31,6 +32,12 @@ func TestWithValidDockerWorkerPayload(t *testing.T) {
 	switch fmt.Sprintf("%s:%s", engine, runtime.GOOS) {
 	case "multiuser:linux":
 		_ = submitAndAssert(t, td, payload, "completed", "completed")
+	case "insecure:linux":
+		_ = submitAndAssert(t, td, payload, "exception", "malformed-payload")
+		logtext := LogText(t)
+		if !strings.Contains(logtext, "task payload contains unsupported osGroups: [docker]") {
+			t.Fatalf("Was expecting log file to contain 'task payload contains unsupported osGroups: [docker]")
+		}
 	default:
 		_ = submitAndAssert(t, td, payload, "exception", "malformed-payload")
 	}
@@ -77,6 +84,12 @@ func TestIssue6789(t *testing.T) {
 	switch fmt.Sprintf("%s:%s", engine, runtime.GOOS) {
 	case "multiuser:linux":
 		_ = submitAndAssert(t, td, payload, "completed", "completed")
+	case "insecure:linux":
+		_ = submitAndAssert(t, td, payload, "exception", "malformed-payload")
+		logtext := LogText(t)
+		if !strings.Contains(logtext, "task payload contains unsupported osGroups: [docker]") {
+			t.Fatalf("Was expecting log file to contain 'task payload contains unsupported osGroups: [docker]")
+		}
 	default:
 		_ = submitAndAssert(t, td, payload, "exception", "malformed-payload")
 	}

--- a/workers/generic-worker/generated_insecure_darwin.go
+++ b/workers/generic-worker/generated_insecure_darwin.go
@@ -133,6 +133,15 @@ type (
 	// Set of capabilities that must be enabled or made available to the task container Example: ```{ "capabilities": { "privileged": true }```
 	Capabilities struct {
 
+		// The container engine to use, between `docker` and `podman`. This property is only used during Generic Worker's internal payload translation (d2g). [default: docker]
+		//
+		// Possible values:
+		//   * "docker"
+		//   * "podman"
+		//
+		// Default:    "docker"
+		ContainerEngine string `json:"containerEngine" default:"docker"`
+
 		// Allows devices from the host system to be attached to a task container similar to using `--device` in docker.
 		Devices Devices `json:"devices,omitempty"`
 
@@ -1199,7 +1208,6 @@ func JSONSchema() string {
           "items": {
             "type": "string"
           },
-          "maxItems": 0,
           "title": "OS Groups",
           "type": "array",
           "uniqueItems": true
@@ -1241,6 +1249,16 @@ func JSONSchema() string {
           "additionalProperties": false,
           "description": "Set of capabilities that must be enabled or made available to the task container Example: ` + "`" + `` + "`" + `` + "`" + `{ \"capabilities\": { \"privileged\": true }` + "`" + `` + "`" + `` + "`" + `",
           "properties": {
+            "containerEngine": {
+              "default": "docker",
+              "description": "The container engine to use, between ` + "`" + `docker` + "`" + ` and ` + "`" + `podman` + "`" + `. This property is only used during Generic Worker's internal payload translation (d2g). [default: docker]",
+              "enum": [
+                "docker",
+                "podman"
+              ],
+              "title": "Container engine",
+              "type": "string"
+            },
             "devices": {
               "additionalProperties": false,
               "description": "Allows devices from the host system to be attached to a task container similar to using ` + "`" + `--device` + "`" + ` in docker.",

--- a/workers/generic-worker/generated_insecure_darwin.go
+++ b/workers/generic-worker/generated_insecure_darwin.go
@@ -133,14 +133,12 @@ type (
 	// Set of capabilities that must be enabled or made available to the task container Example: ```{ "capabilities": { "privileged": true }```
 	Capabilities struct {
 
-		// The container engine to use, between `docker` and `podman`. This property is only used during Generic Worker's internal payload translation (d2g). [default: docker]
+		// The container engine to use when executing tasks with Docker Worker formatted task payloads.
 		//
 		// Possible values:
 		//   * "docker"
 		//   * "podman"
-		//
-		// Default:    "docker"
-		ContainerEngine string `json:"containerEngine" default:"docker"`
+		ContainerEngine string `json:"containerEngine,omitempty"`
 
 		// Allows devices from the host system to be attached to a task container similar to using `--device` in docker.
 		Devices Devices `json:"devices,omitempty"`
@@ -1250,8 +1248,7 @@ func JSONSchema() string {
           "description": "Set of capabilities that must be enabled or made available to the task container Example: ` + "`" + `` + "`" + `` + "`" + `{ \"capabilities\": { \"privileged\": true }` + "`" + `` + "`" + `` + "`" + `",
           "properties": {
             "containerEngine": {
-              "default": "docker",
-              "description": "The container engine to use, between ` + "`" + `docker` + "`" + ` and ` + "`" + `podman` + "`" + `. This property is only used during Generic Worker's internal payload translation (d2g). [default: docker]",
+              "description": "The container engine to use when executing tasks with Docker Worker formatted task payloads.",
               "enum": [
                 "docker",
                 "podman"

--- a/workers/generic-worker/generated_insecure_freebsd.go
+++ b/workers/generic-worker/generated_insecure_freebsd.go
@@ -133,6 +133,15 @@ type (
 	// Set of capabilities that must be enabled or made available to the task container Example: ```{ "capabilities": { "privileged": true }```
 	Capabilities struct {
 
+		// The container engine to use, between `docker` and `podman`. This property is only used during Generic Worker's internal payload translation (d2g). [default: docker]
+		//
+		// Possible values:
+		//   * "docker"
+		//   * "podman"
+		//
+		// Default:    "docker"
+		ContainerEngine string `json:"containerEngine" default:"docker"`
+
 		// Allows devices from the host system to be attached to a task container similar to using `--device` in docker.
 		Devices Devices `json:"devices,omitempty"`
 
@@ -1199,7 +1208,6 @@ func JSONSchema() string {
           "items": {
             "type": "string"
           },
-          "maxItems": 0,
           "title": "OS Groups",
           "type": "array",
           "uniqueItems": true
@@ -1241,6 +1249,16 @@ func JSONSchema() string {
           "additionalProperties": false,
           "description": "Set of capabilities that must be enabled or made available to the task container Example: ` + "`" + `` + "`" + `` + "`" + `{ \"capabilities\": { \"privileged\": true }` + "`" + `` + "`" + `` + "`" + `",
           "properties": {
+            "containerEngine": {
+              "default": "docker",
+              "description": "The container engine to use, between ` + "`" + `docker` + "`" + ` and ` + "`" + `podman` + "`" + `. This property is only used during Generic Worker's internal payload translation (d2g). [default: docker]",
+              "enum": [
+                "docker",
+                "podman"
+              ],
+              "title": "Container engine",
+              "type": "string"
+            },
             "devices": {
               "additionalProperties": false,
               "description": "Allows devices from the host system to be attached to a task container similar to using ` + "`" + `--device` + "`" + ` in docker.",

--- a/workers/generic-worker/generated_insecure_freebsd.go
+++ b/workers/generic-worker/generated_insecure_freebsd.go
@@ -133,14 +133,12 @@ type (
 	// Set of capabilities that must be enabled or made available to the task container Example: ```{ "capabilities": { "privileged": true }```
 	Capabilities struct {
 
-		// The container engine to use, between `docker` and `podman`. This property is only used during Generic Worker's internal payload translation (d2g). [default: docker]
+		// The container engine to use when executing tasks with Docker Worker formatted task payloads.
 		//
 		// Possible values:
 		//   * "docker"
 		//   * "podman"
-		//
-		// Default:    "docker"
-		ContainerEngine string `json:"containerEngine" default:"docker"`
+		ContainerEngine string `json:"containerEngine,omitempty"`
 
 		// Allows devices from the host system to be attached to a task container similar to using `--device` in docker.
 		Devices Devices `json:"devices,omitempty"`
@@ -1250,8 +1248,7 @@ func JSONSchema() string {
           "description": "Set of capabilities that must be enabled or made available to the task container Example: ` + "`" + `` + "`" + `` + "`" + `{ \"capabilities\": { \"privileged\": true }` + "`" + `` + "`" + `` + "`" + `",
           "properties": {
             "containerEngine": {
-              "default": "docker",
-              "description": "The container engine to use, between ` + "`" + `docker` + "`" + ` and ` + "`" + `podman` + "`" + `. This property is only used during Generic Worker's internal payload translation (d2g). [default: docker]",
+              "description": "The container engine to use when executing tasks with Docker Worker formatted task payloads.",
               "enum": [
                 "docker",
                 "podman"

--- a/workers/generic-worker/generated_insecure_linux.go
+++ b/workers/generic-worker/generated_insecure_linux.go
@@ -133,6 +133,15 @@ type (
 	// Set of capabilities that must be enabled or made available to the task container Example: ```{ "capabilities": { "privileged": true }```
 	Capabilities struct {
 
+		// The container engine to use, between `docker` and `podman`. This property is only used during Generic Worker's internal payload translation (d2g). [default: docker]
+		//
+		// Possible values:
+		//   * "docker"
+		//   * "podman"
+		//
+		// Default:    "docker"
+		ContainerEngine string `json:"containerEngine" default:"docker"`
+
 		// Allows devices from the host system to be attached to a task container similar to using `--device` in docker.
 		Devices Devices `json:"devices,omitempty"`
 
@@ -1199,7 +1208,6 @@ func JSONSchema() string {
           "items": {
             "type": "string"
           },
-          "maxItems": 0,
           "title": "OS Groups",
           "type": "array",
           "uniqueItems": true
@@ -1241,6 +1249,16 @@ func JSONSchema() string {
           "additionalProperties": false,
           "description": "Set of capabilities that must be enabled or made available to the task container Example: ` + "`" + `` + "`" + `` + "`" + `{ \"capabilities\": { \"privileged\": true }` + "`" + `` + "`" + `` + "`" + `",
           "properties": {
+            "containerEngine": {
+              "default": "docker",
+              "description": "The container engine to use, between ` + "`" + `docker` + "`" + ` and ` + "`" + `podman` + "`" + `. This property is only used during Generic Worker's internal payload translation (d2g). [default: docker]",
+              "enum": [
+                "docker",
+                "podman"
+              ],
+              "title": "Container engine",
+              "type": "string"
+            },
             "devices": {
               "additionalProperties": false,
               "description": "Allows devices from the host system to be attached to a task container similar to using ` + "`" + `--device` + "`" + ` in docker.",

--- a/workers/generic-worker/generated_insecure_linux.go
+++ b/workers/generic-worker/generated_insecure_linux.go
@@ -133,14 +133,12 @@ type (
 	// Set of capabilities that must be enabled or made available to the task container Example: ```{ "capabilities": { "privileged": true }```
 	Capabilities struct {
 
-		// The container engine to use, between `docker` and `podman`. This property is only used during Generic Worker's internal payload translation (d2g). [default: docker]
+		// The container engine to use when executing tasks with Docker Worker formatted task payloads.
 		//
 		// Possible values:
 		//   * "docker"
 		//   * "podman"
-		//
-		// Default:    "docker"
-		ContainerEngine string `json:"containerEngine" default:"docker"`
+		ContainerEngine string `json:"containerEngine,omitempty"`
 
 		// Allows devices from the host system to be attached to a task container similar to using `--device` in docker.
 		Devices Devices `json:"devices,omitempty"`
@@ -1250,8 +1248,7 @@ func JSONSchema() string {
           "description": "Set of capabilities that must be enabled or made available to the task container Example: ` + "`" + `` + "`" + `` + "`" + `{ \"capabilities\": { \"privileged\": true }` + "`" + `` + "`" + `` + "`" + `",
           "properties": {
             "containerEngine": {
-              "default": "docker",
-              "description": "The container engine to use, between ` + "`" + `docker` + "`" + ` and ` + "`" + `podman` + "`" + `. This property is only used during Generic Worker's internal payload translation (d2g). [default: docker]",
+              "description": "The container engine to use when executing tasks with Docker Worker formatted task payloads.",
               "enum": [
                 "docker",
                 "podman"

--- a/workers/generic-worker/generated_multiuser_darwin.go
+++ b/workers/generic-worker/generated_multiuser_darwin.go
@@ -133,6 +133,15 @@ type (
 	// Set of capabilities that must be enabled or made available to the task container Example: ```{ "capabilities": { "privileged": true }```
 	Capabilities struct {
 
+		// The container engine to use, between `docker` and `podman`. This property is only used during Generic Worker's internal payload translation (d2g). [default: docker]
+		//
+		// Possible values:
+		//   * "docker"
+		//   * "podman"
+		//
+		// Default:    "docker"
+		ContainerEngine string `json:"containerEngine" default:"docker"`
+
 		// Allows devices from the host system to be attached to a task container similar to using `--device` in docker.
 		Devices Devices `json:"devices,omitempty"`
 
@@ -1264,6 +1273,16 @@ func JSONSchema() string {
           "additionalProperties": false,
           "description": "Set of capabilities that must be enabled or made available to the task container Example: ` + "`" + `` + "`" + `` + "`" + `{ \"capabilities\": { \"privileged\": true }` + "`" + `` + "`" + `` + "`" + `",
           "properties": {
+            "containerEngine": {
+              "default": "docker",
+              "description": "The container engine to use, between ` + "`" + `docker` + "`" + ` and ` + "`" + `podman` + "`" + `. This property is only used during Generic Worker's internal payload translation (d2g). [default: docker]",
+              "enum": [
+                "docker",
+                "podman"
+              ],
+              "title": "Container engine",
+              "type": "string"
+            },
             "devices": {
               "additionalProperties": false,
               "description": "Allows devices from the host system to be attached to a task container similar to using ` + "`" + `--device` + "`" + ` in docker.",

--- a/workers/generic-worker/generated_multiuser_darwin.go
+++ b/workers/generic-worker/generated_multiuser_darwin.go
@@ -133,14 +133,12 @@ type (
 	// Set of capabilities that must be enabled or made available to the task container Example: ```{ "capabilities": { "privileged": true }```
 	Capabilities struct {
 
-		// The container engine to use, between `docker` and `podman`. This property is only used during Generic Worker's internal payload translation (d2g). [default: docker]
+		// The container engine to use when executing tasks with Docker Worker formatted task payloads.
 		//
 		// Possible values:
 		//   * "docker"
 		//   * "podman"
-		//
-		// Default:    "docker"
-		ContainerEngine string `json:"containerEngine" default:"docker"`
+		ContainerEngine string `json:"containerEngine,omitempty"`
 
 		// Allows devices from the host system to be attached to a task container similar to using `--device` in docker.
 		Devices Devices `json:"devices,omitempty"`
@@ -1274,8 +1272,7 @@ func JSONSchema() string {
           "description": "Set of capabilities that must be enabled or made available to the task container Example: ` + "`" + `` + "`" + `` + "`" + `{ \"capabilities\": { \"privileged\": true }` + "`" + `` + "`" + `` + "`" + `",
           "properties": {
             "containerEngine": {
-              "default": "docker",
-              "description": "The container engine to use, between ` + "`" + `docker` + "`" + ` and ` + "`" + `podman` + "`" + `. This property is only used during Generic Worker's internal payload translation (d2g). [default: docker]",
+              "description": "The container engine to use when executing tasks with Docker Worker formatted task payloads.",
               "enum": [
                 "docker",
                 "podman"

--- a/workers/generic-worker/generated_multiuser_freebsd.go
+++ b/workers/generic-worker/generated_multiuser_freebsd.go
@@ -133,6 +133,15 @@ type (
 	// Set of capabilities that must be enabled or made available to the task container Example: ```{ "capabilities": { "privileged": true }```
 	Capabilities struct {
 
+		// The container engine to use, between `docker` and `podman`. This property is only used during Generic Worker's internal payload translation (d2g). [default: docker]
+		//
+		// Possible values:
+		//   * "docker"
+		//   * "podman"
+		//
+		// Default:    "docker"
+		ContainerEngine string `json:"containerEngine" default:"docker"`
+
 		// Allows devices from the host system to be attached to a task container similar to using `--device` in docker.
 		Devices Devices `json:"devices,omitempty"`
 
@@ -1264,6 +1273,16 @@ func JSONSchema() string {
           "additionalProperties": false,
           "description": "Set of capabilities that must be enabled or made available to the task container Example: ` + "`" + `` + "`" + `` + "`" + `{ \"capabilities\": { \"privileged\": true }` + "`" + `` + "`" + `` + "`" + `",
           "properties": {
+            "containerEngine": {
+              "default": "docker",
+              "description": "The container engine to use, between ` + "`" + `docker` + "`" + ` and ` + "`" + `podman` + "`" + `. This property is only used during Generic Worker's internal payload translation (d2g). [default: docker]",
+              "enum": [
+                "docker",
+                "podman"
+              ],
+              "title": "Container engine",
+              "type": "string"
+            },
             "devices": {
               "additionalProperties": false,
               "description": "Allows devices from the host system to be attached to a task container similar to using ` + "`" + `--device` + "`" + ` in docker.",

--- a/workers/generic-worker/generated_multiuser_freebsd.go
+++ b/workers/generic-worker/generated_multiuser_freebsd.go
@@ -133,14 +133,12 @@ type (
 	// Set of capabilities that must be enabled or made available to the task container Example: ```{ "capabilities": { "privileged": true }```
 	Capabilities struct {
 
-		// The container engine to use, between `docker` and `podman`. This property is only used during Generic Worker's internal payload translation (d2g). [default: docker]
+		// The container engine to use when executing tasks with Docker Worker formatted task payloads.
 		//
 		// Possible values:
 		//   * "docker"
 		//   * "podman"
-		//
-		// Default:    "docker"
-		ContainerEngine string `json:"containerEngine" default:"docker"`
+		ContainerEngine string `json:"containerEngine,omitempty"`
 
 		// Allows devices from the host system to be attached to a task container similar to using `--device` in docker.
 		Devices Devices `json:"devices,omitempty"`
@@ -1274,8 +1272,7 @@ func JSONSchema() string {
           "description": "Set of capabilities that must be enabled or made available to the task container Example: ` + "`" + `` + "`" + `` + "`" + `{ \"capabilities\": { \"privileged\": true }` + "`" + `` + "`" + `` + "`" + `",
           "properties": {
             "containerEngine": {
-              "default": "docker",
-              "description": "The container engine to use, between ` + "`" + `docker` + "`" + ` and ` + "`" + `podman` + "`" + `. This property is only used during Generic Worker's internal payload translation (d2g). [default: docker]",
+              "description": "The container engine to use when executing tasks with Docker Worker formatted task payloads.",
               "enum": [
                 "docker",
                 "podman"

--- a/workers/generic-worker/generated_multiuser_linux.go
+++ b/workers/generic-worker/generated_multiuser_linux.go
@@ -133,6 +133,15 @@ type (
 	// Set of capabilities that must be enabled or made available to the task container Example: ```{ "capabilities": { "privileged": true }```
 	Capabilities struct {
 
+		// The container engine to use, between `docker` and `podman`. This property is only used during Generic Worker's internal payload translation (d2g). [default: docker]
+		//
+		// Possible values:
+		//   * "docker"
+		//   * "podman"
+		//
+		// Default:    "docker"
+		ContainerEngine string `json:"containerEngine" default:"docker"`
+
 		// Allows devices from the host system to be attached to a task container similar to using `--device` in docker.
 		Devices Devices `json:"devices,omitempty"`
 
@@ -1264,6 +1273,16 @@ func JSONSchema() string {
           "additionalProperties": false,
           "description": "Set of capabilities that must be enabled or made available to the task container Example: ` + "`" + `` + "`" + `` + "`" + `{ \"capabilities\": { \"privileged\": true }` + "`" + `` + "`" + `` + "`" + `",
           "properties": {
+            "containerEngine": {
+              "default": "docker",
+              "description": "The container engine to use, between ` + "`" + `docker` + "`" + ` and ` + "`" + `podman` + "`" + `. This property is only used during Generic Worker's internal payload translation (d2g). [default: docker]",
+              "enum": [
+                "docker",
+                "podman"
+              ],
+              "title": "Container engine",
+              "type": "string"
+            },
             "devices": {
               "additionalProperties": false,
               "description": "Allows devices from the host system to be attached to a task container similar to using ` + "`" + `--device` + "`" + ` in docker.",

--- a/workers/generic-worker/generated_multiuser_linux.go
+++ b/workers/generic-worker/generated_multiuser_linux.go
@@ -133,14 +133,12 @@ type (
 	// Set of capabilities that must be enabled or made available to the task container Example: ```{ "capabilities": { "privileged": true }```
 	Capabilities struct {
 
-		// The container engine to use, between `docker` and `podman`. This property is only used during Generic Worker's internal payload translation (d2g). [default: docker]
+		// The container engine to use when executing tasks with Docker Worker formatted task payloads.
 		//
 		// Possible values:
 		//   * "docker"
 		//   * "podman"
-		//
-		// Default:    "docker"
-		ContainerEngine string `json:"containerEngine" default:"docker"`
+		ContainerEngine string `json:"containerEngine,omitempty"`
 
 		// Allows devices from the host system to be attached to a task container similar to using `--device` in docker.
 		Devices Devices `json:"devices,omitempty"`
@@ -1274,8 +1272,7 @@ func JSONSchema() string {
           "description": "Set of capabilities that must be enabled or made available to the task container Example: ` + "`" + `` + "`" + `` + "`" + `{ \"capabilities\": { \"privileged\": true }` + "`" + `` + "`" + `` + "`" + `",
           "properties": {
             "containerEngine": {
-              "default": "docker",
-              "description": "The container engine to use, between ` + "`" + `docker` + "`" + ` and ` + "`" + `podman` + "`" + `. This property is only used during Generic Worker's internal payload translation (d2g). [default: docker]",
+              "description": "The container engine to use when executing tasks with Docker Worker formatted task payloads.",
               "enum": [
                 "docker",
                 "podman"

--- a/workers/generic-worker/gwconfig/config.go
+++ b/workers/generic-worker/gwconfig/config.go
@@ -36,6 +36,7 @@ type (
 		DisableReboots                 bool                   `json:"disableReboots"`
 		DownloadsDir                   string                 `json:"downloadsDir"`
 		Ed25519SigningKeyLocation      string                 `json:"ed25519SigningKeyLocation"`
+		EnableD2G                      bool                   `json:"enableD2G"`
 		EnableInteractive              bool                   `json:"enableInteractive"`
 		IdleTimeoutSecs                uint                   `json:"idleTimeoutSecs"`
 		InstanceID                     string                 `json:"instanceId"`

--- a/workers/generic-worker/gwconfig/config.go
+++ b/workers/generic-worker/gwconfig/config.go
@@ -31,6 +31,7 @@ type (
 		CheckForNewDeploymentEverySecs uint                   `json:"checkForNewDeploymentEverySecs"`
 		CleanUpTaskDirs                bool                   `json:"cleanUpTaskDirs"`
 		ClientID                       string                 `json:"clientId"`
+		ContainerEngine                string                 `json:"containerEngine"`
 		CreateObjectArtifacts          bool                   `json:"createObjectArtifacts"`
 		DeploymentID                   string                 `json:"deploymentId"`
 		DisableReboots                 bool                   `json:"disableReboots"`

--- a/workers/generic-worker/helper_test.go
+++ b/workers/generic-worker/helper_test.go
@@ -362,6 +362,7 @@ func GWTest(t *testing.T) *Test {
 			// Need common downloads directory across tests, since files
 			// directory-caches.json and file-caches.json are not per-test.
 			DownloadsDir:              filepath.Join(cwd, "downloads"),
+			EnableD2G:                 true,
 			Ed25519SigningKeyLocation: filepath.Join(testdataDir, "ed25519_private_key"),
 			IdleTimeoutSecs:           60,
 			InstanceID:                "test-instance-id",

--- a/workers/generic-worker/helper_test.go
+++ b/workers/generic-worker/helper_test.go
@@ -357,6 +357,7 @@ func GWTest(t *testing.T) *Test {
 			CheckForNewDeploymentEverySecs: 0,
 			CleanUpTaskDirs:                false,
 			ClientID:                       os.Getenv("TASKCLUSTER_CLIENT_ID"),
+			ContainerEngine:                "docker",
 			DeploymentID:                   "",
 			DisableReboots:                 true,
 			// Need common downloads directory across tests, since files

--- a/workers/generic-worker/main.go
+++ b/workers/generic-worker/main.go
@@ -11,6 +11,7 @@ package main
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log"
@@ -222,6 +223,7 @@ func loadConfig(configFile *gwconfig.File) error {
 			CleanUpTaskDirs:                true,
 			DisableReboots:                 false,
 			DownloadsDir:                   "downloads",
+			EnableD2G:                      false,
 			EnableInteractive:              false,
 			IdleTimeoutSecs:                0,
 			InteractivePort:                53654,
@@ -623,6 +625,12 @@ func (task *TaskRun) validatePayload() *CommandExecutionError {
 		panic(err)
 	}
 	if _, exists := payload["image"]; exists {
+		if !config.EnableD2G {
+			return MalformedPayloadError(errors.New(`docker worker payload detected, but D2G is not enabled on this worker pool.
+If you need D2G to translate your Docker Worker payload so Generic Worker can process it, please do one of two things:
+	1. Contact the owner of the worker pool and ask for D2G to be enabled.
+	2. Use a worker pool that already allows docker worker payloads (search for "enableD2G": "true" in the worker pool definition)`))
+		}
 		err := task.convertDockerWorkerPayload()
 		if err != nil {
 			return err

--- a/workers/generic-worker/main.go
+++ b/workers/generic-worker/main.go
@@ -11,10 +11,10 @@ package main
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
 	"log"
+	"net/url"
 	"os"
 	"os/signal"
 	"path/filepath"
@@ -221,6 +221,7 @@ func loadConfig(configFile *gwconfig.File) error {
 			CachesDir:                      "caches",
 			CheckForNewDeploymentEverySecs: 1800,
 			CleanUpTaskDirs:                true,
+			ContainerEngine:                "docker",
 			DisableReboots:                 false,
 			DownloadsDir:                   "downloads",
 			EnableD2G:                      false,
@@ -626,10 +627,12 @@ func (task *TaskRun) validatePayload() *CommandExecutionError {
 	}
 	if _, exists := payload["image"]; exists {
 		if !config.EnableD2G {
-			return MalformedPayloadError(errors.New(`docker worker payload detected, but D2G is not enabled on this worker pool.
+			workerPoolID := config.ProvisionerID + "/" + config.WorkerType
+			workerManagerURL := config.RootURL + "/worker-manager/" + url.PathEscape(workerPoolID)
+			return MalformedPayloadError(fmt.Errorf(`docker worker payload detected, but D2G is not enabled on this worker pool (%s).
 If you need D2G to translate your Docker Worker payload so Generic Worker can process it, please do one of two things:
-	1. Contact the owner of the worker pool and ask for D2G to be enabled.
-	2. Use a worker pool that already allows docker worker payloads (search for "enableD2G": "true" in the worker pool definition)`))
+	1. Contact the owner of the worker pool %s (see %s) and ask for D2G to be enabled.
+	2. Use a worker pool that already allows docker worker payloads (search for "enableD2G": "true" in the worker pool definition)`, workerPoolID, workerPoolID, workerManagerURL))
 		}
 		err := task.convertDockerWorkerPayload()
 		if err != nil {

--- a/workers/generic-worker/os_groups_insecure_test.go
+++ b/workers/generic-worker/os_groups_insecure_test.go
@@ -3,7 +3,6 @@
 package main
 
 import (
-	"strings"
 	"testing"
 
 	"github.com/mcuadros/go-defaults"
@@ -22,20 +21,15 @@ func TestEmptyOSGroups(t *testing.T) {
 	_ = submitAndAssert(t, td, payload, "completed", "completed")
 }
 
-func TestNonEmptyOSGroups(t *testing.T) {
+func TestNonEmptyOSGroupsUserIsNotIn(t *testing.T) {
 	setup(t)
 	payload := GenericWorkerPayload{
 		Command:    listGroups(),
 		MaxRunTime: 30,
-		OSGroups:   []string{"abc"},
+		OSGroups:   []string{"docker"},
 	}
 	defaults.SetDefaults(&payload)
 	td := testTask(t)
 
 	_ = submitAndAssert(t, td, payload, "exception", "malformed-payload")
-
-	logtext := LogText(t)
-	if !strings.Contains(logtext, "- osGroups: Array must have at most 0 items") {
-		t.Fatalf("Was expecting log file to contain '- osGroups: Array must have at most 0 items' but it doesn't")
-	}
 }

--- a/workers/generic-worker/os_groups_insecure_test.go
+++ b/workers/generic-worker/os_groups_insecure_test.go
@@ -3,6 +3,7 @@
 package main
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/mcuadros/go-defaults"
@@ -26,10 +27,21 @@ func TestNonEmptyOSGroupsUserIsNotIn(t *testing.T) {
 	payload := GenericWorkerPayload{
 		Command:    listGroups(),
 		MaxRunTime: 30,
-		OSGroups:   []string{"docker"},
+		OSGroups:   []string{"abc"},
 	}
 	defaults.SetDefaults(&payload)
 	td := testTask(t)
 
+	td.Scopes = []string{}
+	// grant all required scopes
+	for _, group := range payload.OSGroups {
+		td.Scopes = append(td.Scopes, "generic-worker:os-group:"+td.ProvisionerID+"/"+td.WorkerType+"/"+group)
+	}
+
 	_ = submitAndAssert(t, td, payload, "exception", "malformed-payload")
+
+	logtext := LogText(t)
+	if !strings.Contains(logtext, "task payload contains unsupported osGroups:") {
+		t.Fatalf("Was expecting log file to contain 'task payload contains unsupported osGroups:'")
+	}
 }

--- a/workers/generic-worker/payload_linux.go
+++ b/workers/generic-worker/payload_linux.go
@@ -24,7 +24,7 @@ func (task *TaskRun) convertDockerWorkerPayload() *CommandExecutionError {
 	}
 
 	// Convert dwPayload to gwPayload
-	gwPayload, err := d2g.Convert(dwPayload)
+	gwPayload, err := d2g.Convert(dwPayload, config.ContainerEngine)
 	if err != nil {
 		return executionError(internalError, errored, fmt.Errorf("failed to convert docker worker payload to a generic worker payload: %v", err))
 	}
@@ -35,7 +35,7 @@ func (task *TaskRun) convertDockerWorkerPayload() *CommandExecutionError {
 	if taskQueueID == "" {
 		return executionError(malformedPayload, errored, fmt.Errorf("taskQueueId ('provisionerId/workerType') is required"))
 	}
-	task.Definition.Scopes = d2g.Scopes(task.Definition.Scopes, dwPayload, taskQueueID)
+	task.Definition.Scopes = d2g.Scopes(task.Definition.Scopes, dwPayload, taskQueueID, config.ContainerEngine)
 
 	// Convert gwPayload to JSON
 	d2gConvertedPayloadJSON, err := json.MarshalIndent(*gwPayload, "", "  ")

--- a/workers/generic-worker/schemas/insecure_posix.yml
+++ b/workers/generic-worker/schemas/insecure_posix.yml
@@ -296,7 +296,6 @@ oneOf:
       uniqueItems: true
       items:
         type: string
-      maxItems: 0
     supersederUrl:
       type: string
       title: unused
@@ -460,6 +459,17 @@ oneOf:
             still includes feature in order for d2g to work with it.
           type: boolean
           default: false
+        containerEngine:
+          title: Container engine
+          description: >-
+            The container engine to use, between `docker` and `podman`.
+            This property is only used during Generic Worker's internal
+            payload translation (d2g). [default: docker]
+          type: string
+          enum:
+            - docker
+            - podman
+          default: docker
         devices:
           title: Devices to be attached to task containers
           description: >-

--- a/workers/generic-worker/schemas/insecure_posix.yml
+++ b/workers/generic-worker/schemas/insecure_posix.yml
@@ -462,14 +462,12 @@ oneOf:
         containerEngine:
           title: Container engine
           description: >-
-            The container engine to use, between `docker` and `podman`.
-            This property is only used during Generic Worker's internal
-            payload translation (d2g). [default: docker]
+            The container engine to use when executing tasks
+            with Docker Worker formatted task payloads.
           type: string
           enum:
             - docker
             - podman
-          default: docker
         devices:
           title: Devices to be attached to task containers
           description: >-

--- a/workers/generic-worker/schemas/multiuser_posix.yml
+++ b/workers/generic-worker/schemas/multiuser_posix.yml
@@ -480,6 +480,17 @@ oneOf:
             still includes feature in order for d2g to work with it.
           type: boolean
           default: false
+        containerEngine:
+          title: Container engine
+          description: >-
+            The container engine to use, between `docker` and `podman`.
+            This property is only used during Generic Worker's internal
+            payload translation (d2g). [default: docker]
+          type: string
+          enum:
+            - docker
+            - podman
+          default: docker
         devices:
           title: Devices to be attached to task containers
           description: >-

--- a/workers/generic-worker/schemas/multiuser_posix.yml
+++ b/workers/generic-worker/schemas/multiuser_posix.yml
@@ -483,14 +483,12 @@ oneOf:
         containerEngine:
           title: Container engine
           description: >-
-            The container engine to use, between `docker` and `podman`.
-            This property is only used during Generic Worker's internal
-            payload translation (d2g). [default: docker]
+            The container engine to use when executing tasks
+            with Docker Worker formatted task payloads.
           type: string
           enum:
             - docker
             - podman
-          default: docker
         devices:
           title: Devices to be attached to task containers
           description: >-

--- a/workers/generic-worker/usage.go
+++ b/workers/generic-worker/usage.go
@@ -169,6 +169,9 @@ and reports back results to the queue.
                                             directory will be created if it does not exist. This
                                             may be a relative path to the current directory, or
                                             an absolute path. [default: "downloads"]
+          enableD2G                         Enables D2G (Docker Worker to Generic Worker payload
+                                            transformation). This allows for Docker Worker payloads
+                                            to be submitted to Generic Worker. [default: false]
           enableInteractive                 Enables interactive mode. This allows an
                                             interactive shell session to run on the worker.
                                             [default: false]` + headlessTasksUsage() + `

--- a/workers/generic-worker/usage.go
+++ b/workers/generic-worker/usage.go
@@ -142,6 +142,12 @@ and reports back results to the queue.
                                             but for one-off troubleshooting, it can be useful
                                             to (temporarily) leave home directories in place.
                                             Accepted values: true or false. [default: true]
+          containerEngine                   The default container engine to use for translated
+                                            Docker Worker tasks when not specified in the
+                                            Docker Worker task payload (property
+                                            capabilities.containerEngine).
+                                            Accepted values: "docker" or "podman".
+                                            [default: "docker"]
           createObjectArtifacts             If true, use artifact type 'object' for artifacts
                                             containing data.  If false, use artifact type 's3'.
                                             The 'object' type will become the default when the


### PR DESCRIPTION
>D2G: Adds `capabilities.containerEngine` to the Docker Worker payload schema strictly to use as a `docker`/`podman` toggle for the d2g-translated payload.

>Generic Worker: Adds `containerEngine` worker config option to select between `docker` and `podman` to be used during D2G payload translations.
>
>Default is `docker` and this value will be overridden by `task.payload.capabilities.containerEngine`, if specified.

>Generic Worker: Adds `enableD2G` worker config option to internally process Docker Worker payloads using D2G. Defaults to `false` and will return a `malformed-payload` if a Docker Worker payload is detected and this config isn't set to `true`.