### PR TITLE
feat(ui): Fix missing status colors in task view

### DIFF
--- a/changelog/issue-7151.md
+++ b/changelog/issue-7151.md
@@ -1,0 +1,6 @@
+audience: users
+level: patch
+reference: issue 7151
+---
+
+Fixes a bug in UI where task dependencies were not having colours.

--- a/ui/src/components/StatusLabel/index.jsx
+++ b/ui/src/components/StatusLabel/index.jsx
@@ -46,7 +46,7 @@ export default class StatusLabel extends Component {
     return (
       <Label
         mini={mini}
-        status={variant || labels[state] || 'default'}
+        status={variant || labels[state.toUpperCase()] || 'default'}
         className={classNames(
           {
             [classes.pending]: state === 'PENDING',


### PR DESCRIPTION
Regression from #7158 
Since we fetch dependencies differently, their status was not upper-cased which didn't let the component to pick right color 
