### PR TITLE
Fix tests warning

### DIFF
--- a/changelog/issue-7269.md
+++ b/changelog/issue-7269.md
@@ -1,0 +1,4 @@
+audience: developers
+level: silent
+reference: issue 7269
+---

--- a/libraries/app/src/index.js
+++ b/libraries/app/src/index.js
@@ -29,6 +29,8 @@ export const traceMiddleware = (req, res, next) => {
   next();
 };
 
+let listenersAdded = false;
+
 /**
  * Create server; this becomes a method of the `app` object, so `this`
  * refers to an Express app.
@@ -65,8 +67,12 @@ const createServer = function() {
         process.exit(0);
       });
   }
-  process.on('SIGTERM', shutdown);
-  process.on('SIGINT', shutdown);
+
+  if (!listenersAdded) {
+    listenersAdded = true;
+    process.on('SIGTERM', shutdown);
+    process.on('SIGINT', shutdown);
+  }
 
   return new Promise((accept, reject) => {
     // Launch HTTP server


### PR DESCRIPTION
"Possible EventEmitter memory leak detected" was happening because many tests run at once and server tries to add termination handler every time

Fixes #7269 
