### PR TITLE
fix(docs): add `containerEngine` docker worker docs

### DIFF
--- a/changelog/issue-7278.md
+++ b/changelog/issue-7278.md
@@ -1,0 +1,5 @@
+audience: general
+level: patch
+reference: issue 7278
+---
+Adds `containerEngine` docs in `Capabilities` section of Docker Worker docs.

--- a/generated/docs-search.json
+++ b/generated/docs-search.json
@@ -3227,6 +3227,13 @@
     "title": "Capabilities"
   },
   {
+    "element": "h2",
+    "id": "container-engine",
+    "path": "/reference/workers/docker-worker/capabilities",
+    "subtitle": "Container Engine",
+    "title": "Capabilities"
+  },
+  {
     "element": "h3",
     "id": "cpu",
     "path": "/reference/workers/docker-worker/capabilities",

--- a/ui/docs/reference/workers/docker-worker/capabilities.mdx
+++ b/ui/docs/reference/workers/docker-worker/capabilities.mdx
@@ -89,3 +89,19 @@ payload:
 
 It must also have scope `docker-worker:capability:privileged` or scope `docker-worker:capability:privileged:<workerPoolId>`.
 The second form is preferred, as it is specific to a single worker pool.
+
+## Container Engine
+
+This capability is strictly meant for use within D2G (Docker Worker to Generic Worker payload translator tool).
+It's a `docker`/`podman` toggle for the resulting d2g-translated payload.
+
+```yaml
+payload:
+  capabilities:
+    containerEngine: podman
+```
+
+If specified, this configuration will take priority over the `containerEngine` worker config option within Generic Worker.
+Generic Worker defaults to `docker` and this payload option does not have a default.
+
+Note: D2G needs to be enabled with the config option `enableD2G` in Generic Worker for this to work.


### PR DESCRIPTION
Fixes #7278.

>Adds `containerEngine` docs in `Capabilities` section of Docker Worker docs.