### PR TITLE
fix(generic-worker)!: remove `wmic` and `net` calls on windows

### DIFF
--- a/changelog/issue-7235.md
+++ b/changelog/issue-7235.md
@@ -1,0 +1,7 @@
+audience: worker-deployers
+level: major
+reference: issue 7235
+---
+Generic Worker (windows): Removes calls to `wmic` (being [deprecated](https://techcommunity.microsoft.com/t5/windows-it-pro-blog/wmi-command-line-wmic-utility-deprecation-next-steps/ba-p/4039242)) and `net` in favor of a more modern approach using PowerShell cmdlets.
+
+The `powershell` executable is required to be in the path.

--- a/workers/generic-worker/os_groups_multiuser_test.go
+++ b/workers/generic-worker/os_groups_multiuser_test.go
@@ -46,7 +46,7 @@ func TestOSGroupsRespected(t *testing.T) {
 	for _, newGroup := range newGroups {
 		switch runtime.GOOS {
 		case "windows":
-			err = host.Run("net", "localgroup", newGroup, "/add")
+			err = host.Run("powershell", "-Command", "New-LocalGroup -Name '"+newGroup+"'")
 		case "darwin":
 			err = host.Run("/usr/sbin/dseditgroup", "-o", "create", newGroup)
 		case "freebsd":
@@ -63,7 +63,7 @@ func TestOSGroupsRespected(t *testing.T) {
 		defer func(newGroup string) {
 			switch runtime.GOOS {
 			case "windows":
-				err = host.Run("net", "localgroup", newGroup, "/delete")
+				err = host.Run("powershell", "-Command", "Remove-LocalGroup -Name '"+newGroup+"'")
 			case "darwin":
 				err = host.Run("/usr/sbin/dseditgroup", "-o", "delete", newGroup)
 			case "freebsd":

--- a/workers/generic-worker/os_groups_multiuser_windows.go
+++ b/workers/generic-worker/os_groups_multiuser_windows.go
@@ -7,11 +7,11 @@ import (
 )
 
 func addUserToGroup(user, group string) error {
-	return host.Run("net", "localgroup", group, "/add", taskContext.User.Name)
+	return host.Run("powershell", "-Command", "Add-LocalGroupMember -Group '"+group+"' -Member '"+taskContext.User.Name+"'")
 }
 
 func removeUserFromGroup(user, group string) error {
-	return host.Run("net", "localgroup", group, "/delete", taskContext.User.Name)
+	return host.Run("powershell", "-Command", "Remove-LocalGroupMember -Group '"+group+"' -Member '"+taskContext.User.Name+"'")
 }
 
 func (osGroups *OSGroups) refreshTaskCommands() (err *CommandExecutionError) {


### PR DESCRIPTION
Fixes https://github.com/taskcluster/taskcluster/issues/7235.

>Generic Worker (windows): Removes calls to `wmic` (being [deprecated](https://techcommunity.microsoft.com/t5/windows-it-pro-blog/wmi-command-line-wmic-utility-deprecation-next-steps/ba-p/4039242)) and `net` in favor of a more modern approach using PowerShell cmdlets.
>
>The `powershell` executable is required to be in the path.