### PR TITLE
fix(worker-runner): replace deprecated oom adjuster

### DIFF
--- a/changelog/issue-7222.md
+++ b/changelog/issue-7222.md
@@ -1,0 +1,5 @@
+audience: worker-deployers
+level: patch
+reference: issue 7222
+---
+Worker Runner: Replaces deprecated `/proc/<pid>/oom_adj` with `/proc/<pid>/oom_score_adj`.

--- a/tools/worker-runner/util/oom_linux.go
+++ b/tools/worker-runner/util/oom_linux.go
@@ -8,8 +8,10 @@ import (
 // DisableOOM disables oom killer for the given process
 func DisableOOM(pid int) error {
 	return os.WriteFile(
-		fmt.Sprintf("/proc/%d/oom_adj", pid),
-		[]byte("-17"),
+		fmt.Sprintf("/proc/%d/oom_score_adj", pid),
+		// Use -1000 to completely disable OOM-killing
+		// https://man7.org/linux/man-pages/man5/proc_pid_oom_adj.5.html
+		[]byte("-1000"),
 		0600,
 	)
 }


### PR DESCRIPTION
Fixes https://github.com/taskcluster/taskcluster/issues/7222.

>Worker Runner: Replaces deprecated `/proc/<pid>/oom_adj` with `/proc/<pid>/oom_score_adj`.