### PR TITLE
feat(auth): Fix error handling in continuation token

### DIFF
--- a/changelog/a2Z3cBueQ22fD0s4BGC7bQ.md
+++ b/changelog/a2Z3cBueQ22fD0s4BGC7bQ.md
@@ -1,0 +1,4 @@
+audience: users
+level: patch
+---
+Fixes continuation token error handling

--- a/services/auth/src/api.js
+++ b/services/auth/src/api.js
@@ -56,7 +56,12 @@ const rolesResponseBuilder = async (that, req, res) => {
 
   // Assign the continuationToken
   if (req.query.continuationToken) {
-    continuationToken = hashids.decode(req.query.continuationToken);
+    try {
+      continuationToken = hashids.decode(req.query.continuationToken);
+    } catch (err) {
+      // hashids.decode will throw an error if token contains invalid characters
+      return res.reportError('InputError', 'Invalid continuationToken', {});
+    }
     // If continuationToken is invalid
     if (continuationToken.length === 0) {
       return res.reportError('InputError', 'Invalid continuationToken', {});

--- a/services/auth/test/role_test.js
+++ b/services/auth/test/role_test.js
@@ -299,6 +299,12 @@ helper.secrets.mockSuite(testing.suiteName(), ['gcp'], function(mock, skipping) 
     await helper.apiClient.listRoleIds(query)
       .then(() => assert(false, 'Expected error'),
         err => assert(err.statusCode === 400, 'Expected 400'));
+
+    // testing unexpected characters that make hashids.decode throw error
+    query.continuationToken = '@@something##';
+    await helper.apiClient.listRoleIds(query)
+      .then(() => assert(false, 'Expected error'),
+        err => assert(err.statusCode === 400, 'Expected 400'));
   });
 
   test('listRoles2', async () => {


### PR DESCRIPTION
`hashids.decode` throw an error when input contains unexpected characters. 
This wraps the handling and responds 400 to the client instead of 500