### PR TITLE
feat(w-m): Handling edge-case in estimation

### DIFF
--- a/changelog/issue-7052.md
+++ b/changelog/issue-7052.md
@@ -1,0 +1,6 @@
+audience: worker-deployers
+level: patch
+reference: issue 7052
+---
+
+Fixes edge-case in estimation that was introduced in #7283 where claimed count might be greater than the existing capacity.

--- a/services/worker-manager/src/estimator.js
+++ b/services/worker-manager/src/estimator.js
@@ -13,7 +13,8 @@ export class Estimator {
   }) {
     const { pendingTasks, claimedTasks } = await this.queue.taskQueueCounts(workerPoolId);
 
-    const totalIdleCapacity = existingCapacity - claimedTasks;
+    // if data is stale we might have more claimed tasks than existing capacity
+    const totalIdleCapacity = Math.max(0, existingCapacity - claimedTasks);
 
     // we assume that idle workers are going to pick up tasks soon
     const adjustedPendingTasks = Math.max(0, pendingTasks - totalIdleCapacity);


### PR DESCRIPTION
provisioner and estimator are operating with partially stale information

Fixes #7052
