### PR TITLE
Generic Worker task log headers and sentry reports include key worker config settings

### DIFF
--- a/changelog/issue-7305.md
+++ b/changelog/issue-7305.md
@@ -1,0 +1,11 @@
+audience: users
+level: patch
+reference: issue 7305
+---
+Generic Worker multiuser engine task log headers now include generic-worker
+config properties `runTasksAsCurrentUser` and `headlessTasks` in order to help
+troubleshoot unexpected behaviour. These properties fundamentally affect how
+the task runs, so it is useful to log them together with the other worker
+environment information.
+
+Sentry reports also now include this information.

--- a/workers/generic-worker/insecure.go
+++ b/workers/generic-worker/insecure.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 
 	"github.com/taskcluster/shell"
+	"github.com/taskcluster/taskcluster/v72/workers/generic-worker/gwconfig"
 	"github.com/taskcluster/taskcluster/v72/workers/generic-worker/host"
 	"github.com/taskcluster/taskcluster/v72/workers/generic-worker/process"
 )
@@ -191,4 +192,10 @@ func (task *TaskRun) EnvVars() []string {
 
 func featureInitFailure(err error) ExitCode {
 	panic(err)
+}
+
+func addEngineDebugInfo(m map[string]string, c *gwconfig.Config) {
+}
+
+func addEngineMetadata(m map[string]interface{}, c *gwconfig.Config) {
 }

--- a/workers/generic-worker/main.go
+++ b/workers/generic-worker/main.go
@@ -288,6 +288,8 @@ func loadConfig(configFile *gwconfig.File) error {
 		"workerId":        config.WorkerID,
 		"workerType":      config.WorkerType,
 	}
+	addEngineDebugInfo(debugInfo, config)
+	addEngineMetadata(gwMetadata, config)
 	return nil
 }
 

--- a/workers/generic-worker/multiuser.go
+++ b/workers/generic-worker/multiuser.go
@@ -9,11 +9,13 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 
 	"github.com/taskcluster/slugid-go/slugid"
 	"github.com/taskcluster/taskcluster/v72/workers/generic-worker/fileutil"
+	"github.com/taskcluster/taskcluster/v72/workers/generic-worker/gwconfig"
 	"github.com/taskcluster/taskcluster/v72/workers/generic-worker/process"
 	gwruntime "github.com/taskcluster/taskcluster/v72/workers/generic-worker/runtime"
 )
@@ -290,4 +292,20 @@ func featureInitFailure(err error) (exitCode ExitCode) {
 	}
 	log.Print(err)
 	return
+}
+
+func addEngineDebugInfo(m map[string]string, c *gwconfig.Config) {
+	// sentry requires string values...
+	m["headlessTasks"] = strconv.FormatBool(c.HeadlessTasks)
+	m["runTasksAsCurrentUser"] = strconv.FormatBool(c.RunTasksAsCurrentUser)
+}
+
+func addEngineMetadata(m map[string]interface{}, c *gwconfig.Config) {
+	// Create empty config entry if it doesn't exist already, so that if it does
+	// exist, entries are merged rather than entire map being replaced.
+	if _, exists := m["config"]; !exists {
+		m["config"] = map[string]interface{}{}
+	}
+	m["config"].(map[string]interface{})["headlessTasks"] = c.HeadlessTasks
+	m["config"].(map[string]interface{})["runTasksAsCurrentUser"] = c.RunTasksAsCurrentUser
 }


### PR DESCRIPTION
Fixes #7305