### PR TITLE
fix(d2g): use `--device` instead of volume mounts

### DIFF
--- a/changelog/issue-7307.md
+++ b/changelog/issue-7307.md
@@ -1,0 +1,5 @@
+audience: general
+level: patch
+reference: issue 7307
+---
+Generic Worker (D2G): Pass devices through to the `docker run ...` command using `--device` instead of a volume mount.

--- a/tools/d2g/d2g.go
+++ b/tools/d2g/d2g.go
@@ -504,16 +504,16 @@ func createVolumeMountsString(dwPayload *dockerworker.DockerWorkerPayload, wdcs 
 		volumeMounts.WriteString(` -v "$(pwd)/` + wdc.Directory + ":" + dwPayload.Cache[wdc.CacheName] + `"`)
 	}
 	if dwPayload.Capabilities.Devices.KVM {
-		volumeMounts.WriteString(" -v /dev/kvm:/dev/kvm")
+		volumeMounts.WriteString(" --device=/dev/kvm")
 	}
 	if dwPayload.Capabilities.Devices.HostSharedMemory {
-		volumeMounts.WriteString(" -v /dev/shm:/dev/shm")
+		volumeMounts.WriteString(" --device=/dev/shm")
 	}
 	if dwPayload.Capabilities.Devices.LoopbackVideo {
-		volumeMounts.WriteString(` -v "${TASKCLUSTER_VIDEO_DEVICE}:${TASKCLUSTER_VIDEO_DEVICE}"`)
+		volumeMounts.WriteString(` --device="${TASKCLUSTER_VIDEO_DEVICE}"`)
 	}
 	if dwPayload.Capabilities.Devices.LoopbackAudio {
-		volumeMounts.WriteString(" -v /dev/snd:/dev/snd")
+		volumeMounts.WriteString(" --device=/dev/snd")
 	}
 	return volumeMounts.String()
 }

--- a/tools/d2g/d2gtest/testdata/testcases/devices_tests.yml
+++ b/tools/d2g/d2gtest/testdata/testcases/devices_tests.yml
@@ -20,7 +20,7 @@ testSuite:
             - '-cx'
             - >-
               docker run --init -t --rm --memory-swap -1 --pids-limit -1 --privileged
-              -v /dev/shm:/dev/shm
+              --device=/dev/shm
               -e RUN_ID
               -e TASKCLUSTER_INSTANCE_TYPE
               -e TASKCLUSTER_ROOT_URL
@@ -53,7 +53,7 @@ testSuite:
             - '-cx'
             - >-
               docker run --init -t --rm --memory-swap -1 --pids-limit -1
-              -v /dev/kvm:/dev/kvm
+              --device=/dev/kvm
               -e RUN_ID
               -e TASKCLUSTER_INSTANCE_TYPE
               -e TASKCLUSTER_ROOT_URL
@@ -88,7 +88,7 @@ testSuite:
             - '-cx'
             - >-
               docker run --init -t --rm --memory-swap -1 --pids-limit -1
-              -v "${TASKCLUSTER_VIDEO_DEVICE}:${TASKCLUSTER_VIDEO_DEVICE}"
+              --device="${TASKCLUSTER_VIDEO_DEVICE}"
               -e RUN_ID
               -e TASKCLUSTER_INSTANCE_TYPE
               -e TASKCLUSTER_ROOT_URL
@@ -123,7 +123,7 @@ testSuite:
             - '-cx'
             - >-
               docker run --init -t --rm --memory-swap -1 --pids-limit -1
-              -v /dev/snd:/dev/snd
+              --device=/dev/snd
               -e RUN_ID
               -e TASKCLUSTER_INSTANCE_TYPE
               -e TASKCLUSTER_ROOT_URL

--- a/tools/d2g/d2gtest/testdata/testcases/fuzzing_tests.yml
+++ b/tools/d2g/d2gtest/testdata/testcases/fuzzing_tests.yml
@@ -41,7 +41,7 @@ testSuite:
           - "IMAGE_ID=$(docker load --input dockerimage | sed -n '0,/^Loaded image: /s/^Loaded image:
             //p')\ntimeout 14400 docker run --init -t --name taskcontainer
             --memory-swap -1 --pids-limit -1 --privileged --security-opt=seccomp=unconfined
-            -v /dev/shm:/dev/shm -v /dev/snd:/dev/snd --add-host=taskcluster:127.0.0.1 --net=host
+            --device=/dev/shm --device=/dev/snd --add-host=taskcluster:127.0.0.1 --net=host
             -e BUG_ACTION -e MONITOR_ARTIFACT -e PROCESSOR_ARTIFACT -e RUN_ID -e TASKCLUSTER_INSTANCE_TYPE
             -e TASKCLUSTER_PROXY_URL -e TASKCLUSTER_ROOT_URL -e TASKCLUSTER_WORKER_LOCATION -e TASK_GROUP_ID
             -e TASK_ID \"${IMAGE_ID}\" \nexit_code=$?\ndocker cp taskcontainer:/bugmon-artifacts/

--- a/tools/d2g/d2gtest/testdata/testcases/task_def_test.yml
+++ b/tools/d2g/d2gtest/testdata/testcases/task_def_test.yml
@@ -56,7 +56,7 @@ testSuite:
           command:
           - - bash
             - -cx
-            - docker run --init -t --rm --memory-swap -1 --pids-limit -1 -v /dev/kvm:/dev/kvm -e RUN_ID -e TASKCLUSTER_INSTANCE_TYPE
+            - docker run --init -t --rm --memory-swap -1 --pids-limit -1 --device=/dev/kvm -e RUN_ID -e TASKCLUSTER_INSTANCE_TYPE
               -e TASKCLUSTER_ROOT_URL -e TASKCLUSTER_WORKER_LOCATION -e TASK_GROUP_ID -e TASK_ID ubuntu:latest /bin/bash -c
               'for ((i=1;i<=600;i++)); do echo $i; sleep 1; done'
           features:
@@ -142,7 +142,7 @@ testSuite:
           command:
           - - bash
             - -cx
-            - docker run --init -t --rm --memory-swap -1 --pids-limit -1 -v /dev/kvm:/dev/kvm -e RUN_ID -e TASKCLUSTER_INSTANCE_TYPE
+            - docker run --init -t --rm --memory-swap -1 --pids-limit -1 --device=/dev/kvm -e RUN_ID -e TASKCLUSTER_INSTANCE_TYPE
               -e TASKCLUSTER_ROOT_URL -e TASKCLUSTER_WORKER_LOCATION -e TASK_GROUP_ID -e TASK_ID ubuntu:latest /bin/bash -c
               'for ((i=1;i<=600;i++)); do echo $i; sleep 1; done'
           features:
@@ -232,7 +232,7 @@ testSuite:
           command:
           - - bash
             - -cx
-            - podman run --init -t --rm --memory-swap -1 --pids-limit -1 --ulimit host -v /dev/kvm:/dev/kvm -e RUN_ID -e TASKCLUSTER_INSTANCE_TYPE
+            - podman run --init -t --rm --memory-swap -1 --pids-limit -1 --ulimit host --device=/dev/kvm -e RUN_ID -e TASKCLUSTER_INSTANCE_TYPE
               -e TASKCLUSTER_ROOT_URL -e TASKCLUSTER_WORKER_LOCATION -e TASK_GROUP_ID -e TASK_ID ubuntu:latest /bin/bash -c
               'for ((i=1;i<=600;i++)); do echo $i; sleep 1; done'
           features:


### PR DESCRIPTION
Fixes #7307.

>Generic Worker (D2G): Pass devices through to the `docker run ...` command using `--device` instead of a volume mount.