### PR TITLE
Include function definitions in documentation

### DIFF
--- a/changelog/SmfnwIYeTx-ovzAwJulBaQ.md
+++ b/changelog/SmfnwIYeTx-ovzAwJulBaQ.md
@@ -1,0 +1,3 @@
+audience: general
+level: silent
+---

--- a/infrastructure/tooling/src/utils/db.js
+++ b/infrastructure/tooling/src/utils/db.js
@@ -173,6 +173,14 @@ export const updateDbFns = async (schema, releases, currentTcVersion) => {
       output.push('');
       output.push(method.description);
       output.push('');
+      output.push('<details><summary>Function Body</summary>');
+      output.push('');
+      output.push('```');
+      output.push(method.body);
+      output.push('```');
+      output.push('');
+      output.push('</details>');
+      output.push('');
     }
 
     const depMethods = methods.filter(method => method.deprecated);


### PR DESCRIPTION
In working on #7286, I had a hard time finding all of the DB functions in one place. This adds them hidden behind `<details>` elements.

[Results](https://github.com/djmitche/taskcluster/blob/dumpfns/db/fns.md)