### PR TITLE
fix(d2g): don't decompress certain image extensions before docker load

### DIFF
--- a/changelog/R2HFCq_uQE64uf2VIN3uYQ.md
+++ b/changelog/R2HFCq_uQE64uf2VIN3uYQ.md
@@ -1,0 +1,4 @@
+audience: users
+level: patch
+---
+D2G: No longer specify file mount format on image if compressed with gzip, bzip2, xz, or zstd when using docker. Generic Worker will now no longer decompress these files before running `docker load`. Docs [here](https://docs.docker.com/reference/cli/docker/image/load/).

--- a/tools/d2g/d2g.go
+++ b/tools/d2g/d2g.go
@@ -24,7 +24,7 @@ type (
 	NamedDockerImage    dockerworker.NamedDockerImage
 	DockerImageArtifact dockerworker.DockerImageArtifact
 	Image               interface {
-		FileMounts() ([]genericworker.FileMount, error)
+		FileMounts(tool string) ([]genericworker.FileMount, error)
 		String(tool string) (string, error)
 		LoadCommands(tool string) []string
 	}
@@ -163,7 +163,7 @@ func Convert(dwPayload *dockerworker.DockerWorkerPayload, containerEngine string
 	if err != nil {
 		return
 	}
-	gwFileMounts, err := dwImage.FileMounts()
+	gwFileMounts, err := dwImage.FileMounts(tool)
 	if err != nil {
 		return
 	}

--- a/tools/d2g/d2gtest/testdata/testcases/docker_image_tests.yml
+++ b/tools/d2g/d2gtest/testdata/testcases/docker_image_tests.yml
@@ -173,7 +173,6 @@ testSuite:
               artifact: test/path.zst
               namespace: test.namespace
             file: dockerimage
-            format: zst
         features:
           taskclusterProxy: true
         onExitStatus:
@@ -290,7 +289,6 @@ testSuite:
               artifact: public/test/path.zst
               taskId: 2JGiKFtpRnGbVczc6-OJ1Q
             file: dockerimage
-            format: zst
         maxRunTime: 3600
         onExitStatus:
           retry:
@@ -378,7 +376,6 @@ testSuite:
               artifact: public/test/path.zst
               taskId: 2JGiKFtpRnGbVczc6-OJ1Q
             file: dockerimage
-            format: zst
         maxRunTime: 3600
         onExitStatus:
           retry:

--- a/tools/d2g/d2gtest/testdata/testcases/fuzzing_tests.yml
+++ b/tools/d2g/d2gtest/testdata/testcases/fuzzing_tests.yml
@@ -59,7 +59,6 @@ testSuite:
             artifact: public/bugmon.tar.zst
             namespace: project.fuzzing.orion.bugmon.master
           file: dockerimage
-          format: zst
         onExitStatus:
           retry:
           - 125

--- a/tools/d2g/dockerimageartifact.go
+++ b/tools/d2g/dockerimageartifact.go
@@ -7,7 +7,7 @@ import (
 	"github.com/taskcluster/taskcluster/v72/tools/d2g/genericworker"
 )
 
-func (dia *DockerImageArtifact) FileMounts() ([]genericworker.FileMount, error) {
+func (dia *DockerImageArtifact) FileMounts(tool string) ([]genericworker.FileMount, error) {
 	artifactContent := genericworker.ArtifactContent{
 		Artifact: dia.Path,
 		SHA256:   "", // We could add this as an optional property to docker worker schema
@@ -17,17 +17,28 @@ func (dia *DockerImageArtifact) FileMounts() ([]genericworker.FileMount, error) 
 	if err != nil {
 		return nil, fmt.Errorf("cannot marshal artifact content %#v into json: %w", artifactContent, err)
 	}
-	return []genericworker.FileMount{
-		{
-			Content: json.RawMessage(raw),
-			// Instead of trying to preserve the artifact filename, we use a
-			// hardcoded name to prevent filename collisions.
-			// This _may_ cause issues once concurrent tasks are supported
-			// on generic worker (see https://bugzil.la/1609102).
-			File:   "dockerimage",
-			Format: fileExtension(dia.Path),
-		},
-	}, nil
+	fm := genericworker.FileMount{
+		Content: json.RawMessage(raw),
+		// Instead of trying to preserve the artifact filename, we use a
+		// hardcoded name to prevent filename collisions.
+		// This _may_ cause issues once concurrent tasks are supported
+		// on generic worker (see https://bugzil.la/1609102).
+		File:   "dockerimage",
+		Format: fileExtension(dia.Path),
+	}
+	// docker can load images compressed with gzip, bzip2, xz, or zstd
+	// https://docs.docker.com/reference/cli/docker/image/load/
+	if tool == "docker" {
+		for _, ext := range []string{"gz", "bz2", "xz", "zst"} {
+			// explicity set to the empty string so generic worker
+			// does not decompress the image before running `docker load`
+			if ext == fm.Format {
+				fm.Format = ""
+				break
+			}
+		}
+	}
+	return []genericworker.FileMount{fm}, nil
 }
 
 func (dia *DockerImageArtifact) String(tool string) (string, error) {

--- a/tools/d2g/dockerimagename.go
+++ b/tools/d2g/dockerimagename.go
@@ -6,7 +6,7 @@ import (
 	"github.com/taskcluster/taskcluster/v72/tools/d2g/genericworker"
 )
 
-func (din *DockerImageName) FileMounts() ([]genericworker.FileMount, error) {
+func (din *DockerImageName) FileMounts(tool string) ([]genericworker.FileMount, error) {
 	return []genericworker.FileMount{}, nil
 }
 

--- a/tools/d2g/indexeddockerimage.go
+++ b/tools/d2g/indexeddockerimage.go
@@ -9,7 +9,7 @@ import (
 	"github.com/taskcluster/taskcluster/v72/tools/d2g/genericworker"
 )
 
-func (idi *IndexedDockerImage) FileMounts() ([]genericworker.FileMount, error) {
+func (idi *IndexedDockerImage) FileMounts(tool string) ([]genericworker.FileMount, error) {
 	indexedContent := genericworker.IndexedContent{
 		Artifact:  idi.Path,
 		Namespace: idi.Namespace,
@@ -18,17 +18,28 @@ func (idi *IndexedDockerImage) FileMounts() ([]genericworker.FileMount, error) {
 	if err != nil {
 		return nil, fmt.Errorf("cannot marshal indexed content %#v into json: %w", indexedContent, err)
 	}
-	return []genericworker.FileMount{
-		{
-			Content: json.RawMessage(raw),
-			// Instead of trying to preserve the artifact filename, we use a
-			// hardcoded name to prevent filename collisions.
-			// This _may_ cause issues once concurrent tasks are supported
-			// on generic worker (see https://bugzil.la/1609102).
-			File:   "dockerimage",
-			Format: fileExtension(idi.Path),
-		},
-	}, nil
+	fm := genericworker.FileMount{
+		Content: json.RawMessage(raw),
+		// Instead of trying to preserve the artifact filename, we use a
+		// hardcoded name to prevent filename collisions.
+		// This _may_ cause issues once concurrent tasks are supported
+		// on generic worker (see https://bugzil.la/1609102).
+		File:   "dockerimage",
+		Format: fileExtension(idi.Path),
+	}
+	// docker can load images compressed with gzip, bzip2, xz, or zstd
+	// https://docs.docker.com/reference/cli/docker/image/load/
+	if tool == "docker" {
+		for _, ext := range []string{"gz", "bz2", "xz", "zst"} {
+			// explicity set to the empty string so generic worker
+			// does not decompress the image before running `docker load`
+			if ext == fm.Format {
+				fm.Format = ""
+				break
+			}
+		}
+	}
+	return []genericworker.FileMount{fm}, nil
 }
 
 func (idi *IndexedDockerImage) LoadCommands(tool string) []string {

--- a/tools/d2g/nameddockerimage.go
+++ b/tools/d2g/nameddockerimage.go
@@ -5,7 +5,7 @@ import (
 	"github.com/taskcluster/taskcluster/v72/tools/d2g/genericworker"
 )
 
-func (ndi *NamedDockerImage) FileMounts() ([]genericworker.FileMount, error) {
+func (ndi *NamedDockerImage) FileMounts(tool string) ([]genericworker.FileMount, error) {
 	return []genericworker.FileMount{}, nil
 }
 


### PR DESCRIPTION
>D2G: No longer specify file mount format on image if compressed with gzip, bzip2, xz, or zstd when using docker. Generic Worker will now no longer decompress these files before running `docker load`. Docs [here](https://docs.docker.com/reference/cli/docker/image/load/).

A small optimization I found while looking into https://github.com/taskcluster/taskcluster/issues/7254.