### PR TITLE
fix(d2g): use `KILL` signal on `timeout` command instead of `--init`

### DIFF
--- a/changelog/issue-7309.md
+++ b/changelog/issue-7309.md
@@ -1,0 +1,5 @@
+audience: users
+level: patch
+reference: issue 7309
+---
+D2G: No longer pass `--init` to the `docker run ...` command. This was breaking docker image build tasks that Taskgraph creates. To kill the running docker container, we now pass `-s KILL` to the `timeout` command.

--- a/tools/d2g/d2g.go
+++ b/tools/d2g/d2g.go
@@ -299,9 +299,9 @@ func runCommand(containerName string, dwPayload *dockerworker.DockerWorkerPayloa
 	// https://github.com/taskcluster/taskcluster/blob/6b99f0ef71d9d8628c50adc17424167647a1c533/workers/docker-worker/src/task.js#L384
 	switch containerName {
 	case "":
-		command.WriteString(tool + " run --init -t --rm")
+		command.WriteString(tool + " run -t --rm")
 	default:
-		command.WriteString(fmt.Sprintf("timeout %v %v run --init -t --name %v", dwPayload.MaxRunTime, tool, containerName))
+		command.WriteString(fmt.Sprintf("timeout -s KILL %v %v run -t --name %v", dwPayload.MaxRunTime, tool, containerName))
 	}
 	// Do not limit resource usage by the containerName. See
 	// https://docs.podman.io/en/latest/markdown/podman-run.1.html

--- a/tools/d2g/d2gtest/testdata/testcases/artifacts_test.yml
+++ b/tools/d2g/d2gtest/testdata/testcases/artifacts_test.yml
@@ -33,7 +33,7 @@ testSuite:
           - - bash
             - '-cx'
             - >-
-              timeout 3600 docker run --init -t --name taskcontainer
+              timeout -s KILL 3600 docker run -t --name taskcontainer
               --memory-swap -1 --pids-limit -1
               -e RUN_ID
               -e TASKCLUSTER_INSTANCE_TYPE

--- a/tools/d2g/d2gtest/testdata/testcases/container_engine_test.yml
+++ b/tools/d2g/d2gtest/testdata/testcases/container_engine_test.yml
@@ -16,7 +16,7 @@ testSuite:
           - - bash
             - '-cx'
             - >-
-              docker run --init -t --rm --memory-swap -1 --pids-limit -1
+              docker run -t --rm --memory-swap -1 --pids-limit -1
               -e RUN_ID
               -e TASKCLUSTER_INSTANCE_TYPE
               -e TASKCLUSTER_ROOT_URL
@@ -47,7 +47,7 @@ testSuite:
           - - bash
             - '-cx'
             - >-
-              podman run --init -t --rm --memory-swap -1 --pids-limit -1 --ulimit host
+              podman run -t --rm --memory-swap -1 --pids-limit -1 --ulimit host
               -e RUN_ID
               -e TASKCLUSTER_INSTANCE_TYPE
               -e TASKCLUSTER_ROOT_URL

--- a/tools/d2g/d2gtest/testdata/testcases/decision_task_tests.yml
+++ b/tools/d2g/d2gtest/testdata/testcases/decision_task_tests.yml
@@ -81,7 +81,7 @@ testSuite:
           - - bash
             - '-cx'
             - >-
-              timeout 3600 docker run --init -t --name taskcontainer
+              timeout -s KILL 3600 docker run -t --name taskcontainer
               --memory-swap -1 --pids-limit -1 --privileged
               -v "$(pwd)/cache0:/builds/worker/checkouts"
               --add-host=taskcluster:127.0.0.1 --net=host

--- a/tools/d2g/d2gtest/testdata/testcases/devices_tests.yml
+++ b/tools/d2g/d2gtest/testdata/testcases/devices_tests.yml
@@ -19,7 +19,7 @@ testSuite:
           - - bash
             - '-cx'
             - >-
-              docker run --init -t --rm --memory-swap -1 --pids-limit -1 --privileged
+              docker run -t --rm --memory-swap -1 --pids-limit -1 --privileged
               --device=/dev/shm
               -e RUN_ID
               -e TASKCLUSTER_INSTANCE_TYPE
@@ -52,7 +52,7 @@ testSuite:
           - - bash
             - '-cx'
             - >-
-              docker run --init -t --rm --memory-swap -1 --pids-limit -1
+              docker run -t --rm --memory-swap -1 --pids-limit -1
               --device=/dev/kvm
               -e RUN_ID
               -e TASKCLUSTER_INSTANCE_TYPE
@@ -87,7 +87,7 @@ testSuite:
           - - bash
             - '-cx'
             - >-
-              docker run --init -t --rm --memory-swap -1 --pids-limit -1
+              docker run -t --rm --memory-swap -1 --pids-limit -1
               --device="${TASKCLUSTER_VIDEO_DEVICE}"
               -e RUN_ID
               -e TASKCLUSTER_INSTANCE_TYPE
@@ -122,7 +122,7 @@ testSuite:
           - - bash
             - '-cx'
             - >-
-              docker run --init -t --rm --memory-swap -1 --pids-limit -1
+              docker run -t --rm --memory-swap -1 --pids-limit -1
               --device=/dev/snd
               -e RUN_ID
               -e TASKCLUSTER_INSTANCE_TYPE

--- a/tools/d2g/d2gtest/testdata/testcases/docker_image_tests.yml
+++ b/tools/d2g/d2gtest/testdata/testcases/docker_image_tests.yml
@@ -15,7 +15,7 @@ testSuite:
           - - bash
             - '-cx'
             - >-
-              docker run --init -t --rm --memory-swap -1 --pids-limit -1
+              docker run -t --rm --memory-swap -1 --pids-limit -1
               -e RUN_ID
               -e TASKCLUSTER_INSTANCE_TYPE
               -e TASKCLUSTER_ROOT_URL
@@ -45,7 +45,7 @@ testSuite:
           - - bash
             - '-cx'
             - >-
-              docker run --init -t --rm --memory-swap -1 --pids-limit -1
+              docker run -t --rm --memory-swap -1 --pids-limit -1
               -e RUN_ID
               -e TASKCLUSTER_INSTANCE_TYPE
               -e TASKCLUSTER_ROOT_URL
@@ -78,7 +78,7 @@ testSuite:
             - >-
               IMAGE_ID=$(docker load --input dockerimage | sed -n '0,/^Loaded image: /s/^Loaded image: //p')
 
-              docker run --init -t --rm --memory-swap -1 --pids-limit -1
+              docker run -t --rm --memory-swap -1 --pids-limit -1
               -e RUN_ID
               -e TASKCLUSTER_INSTANCE_TYPE
               -e TASKCLUSTER_ROOT_URL
@@ -118,7 +118,7 @@ testSuite:
             - >-
               IMAGE_ID=$(docker load --input dockerimage | sed -n '0,/^Loaded image: /s/^Loaded image: //p')
 
-              docker run --init -t --rm --memory-swap -1 --pids-limit -1
+              docker run -t --rm --memory-swap -1 --pids-limit -1
               -e RUN_ID
               -e TASKCLUSTER_INSTANCE_TYPE
               -e TASKCLUSTER_ROOT_URL
@@ -159,7 +159,7 @@ testSuite:
             - >-
               IMAGE_ID=$(docker load --input dockerimage | sed -n '0,/^Loaded image: /s/^Loaded image: //p')
 
-              docker run --init -t --rm --memory-swap -1 --pids-limit -1
+              docker run -t --rm --memory-swap -1 --pids-limit -1
               -e RUN_ID
               -e TASKCLUSTER_INSTANCE_TYPE
               -e TASKCLUSTER_ROOT_URL
@@ -199,7 +199,7 @@ testSuite:
             - >-
               IMAGE_ID=$(docker load --input dockerimage | sed -n '0,/^Loaded image: /s/^Loaded image: //p')
 
-              docker run --init -t --rm --memory-swap -1 --pids-limit -1
+              docker run -t --rm --memory-swap -1 --pids-limit -1
               -e RUN_ID
               -e TASKCLUSTER_INSTANCE_TYPE
               -e TASKCLUSTER_ROOT_URL
@@ -237,7 +237,7 @@ testSuite:
             - >-
               IMAGE_ID=$(docker load --input dockerimage | sed -n '0,/^Loaded image: /s/^Loaded image: //p')
 
-              docker run --init -t --rm --memory-swap -1 --pids-limit -1
+              docker run -t --rm --memory-swap -1 --pids-limit -1
               -e RUN_ID
               -e TASKCLUSTER_INSTANCE_TYPE
               -e TASKCLUSTER_ROOT_URL
@@ -276,7 +276,7 @@ testSuite:
             - >-
               IMAGE_ID=$(docker load --input dockerimage | sed -n '0,/^Loaded image: /s/^Loaded image: //p')
 
-              docker run --init -t --rm --memory-swap -1 --pids-limit -1
+              docker run -t --rm --memory-swap -1 --pids-limit -1
               -e RUN_ID
               -e TASKCLUSTER_INSTANCE_TYPE
               -e TASKCLUSTER_ROOT_URL
@@ -316,7 +316,7 @@ testSuite:
           - - bash
             - '-cx'
             - >-
-              podman run --init -t --rm --memory-swap -1 --pids-limit -1 --ulimit host
+              podman run -t --rm --memory-swap -1 --pids-limit -1 --ulimit host
               --uidmap 1000:0:1 --uidmap 0:1:1000 --uidmap 1001:1001:64536
               --gidmap 1000:0:1 --gidmap 0:1:1000 --gidmap 1001:1001:64536
               -v "$(pwd)/cache0:/builds/worker/checkouts"
@@ -360,7 +360,7 @@ testSuite:
             - >-
               IMAGE_ID=$(docker load --input dockerimage | sed -n '0,/^Loaded image: /s/^Loaded image: //p')
 
-              docker run --init -t --rm --memory-swap -1 --pids-limit -1
+              docker run -t --rm --memory-swap -1 --pids-limit -1
               -v "$(pwd)/cache0:/builds/worker/checkouts"
               -e RUN_ID
               -e TASKCLUSTER_INSTANCE_TYPE

--- a/tools/d2g/d2gtest/testdata/testcases/dw_features_tests.yml
+++ b/tools/d2g/d2gtest/testdata/testcases/dw_features_tests.yml
@@ -18,7 +18,7 @@ testSuite:
           - - bash
             - "-cx"
             - >-
-              docker run --init -t --rm --memory-swap -1 --pids-limit -1 --cap-add=SYS_PTRACE
+              docker run -t --rm --memory-swap -1 --pids-limit -1 --cap-add=SYS_PTRACE
               -e RUN_ID
               -e TASKCLUSTER_INSTANCE_TYPE
               -e TASKCLUSTER_ROOT_URL

--- a/tools/d2g/d2gtest/testdata/testcases/env_escaping_test.yml
+++ b/tools/d2g/d2gtest/testdata/testcases/env_escaping_test.yml
@@ -6,7 +6,7 @@ testSuite:
     - name: Env escaping test
       description: >-
         If an environment variable contains spaces or special characters,
-        it should be escaped before passing to the docker run --init command.
+        it should be escaped before passing to the docker run command.
       dockerWorkerTaskPayload:
         command:
           - echo "Hello world"
@@ -19,7 +19,7 @@ testSuite:
           - - bash
             - '-cx'
             - >-
-              docker run --init -t --rm --memory-swap -1 --pids-limit -1
+              docker run -t --rm --memory-swap -1 --pids-limit -1
               -e ' test123 --help  ; whoami ; '
               -e RUN_ID
               -e TASKCLUSTER_INSTANCE_TYPE

--- a/tools/d2g/d2gtest/testdata/testcases/fuzzing_tests.yml
+++ b/tools/d2g/d2gtest/testdata/testcases/fuzzing_tests.yml
@@ -39,7 +39,7 @@ testSuite:
         - - bash
           - "-cx"
           - "IMAGE_ID=$(docker load --input dockerimage | sed -n '0,/^Loaded image: /s/^Loaded image:
-            //p')\ntimeout 14400 docker run --init -t --name taskcontainer
+            //p')\ntimeout -s KILL 14400 docker run -t --name taskcontainer
             --memory-swap -1 --pids-limit -1 --privileged --security-opt=seccomp=unconfined
             --device=/dev/shm --device=/dev/snd --add-host=taskcluster:127.0.0.1 --net=host
             -e BUG_ACTION -e MONITOR_ARTIFACT -e PROCESSOR_ARTIFACT -e RUN_ID -e TASKCLUSTER_INSTANCE_TYPE

--- a/tools/d2g/d2gtest/testdata/testcases/no_artifacts_test.yml
+++ b/tools/d2g/d2gtest/testdata/testcases/no_artifacts_test.yml
@@ -23,7 +23,7 @@ testSuite:
           - - bash
             - '-cx'
             - >-
-              docker run --init -t --rm --memory-swap -1 --pids-limit -1
+              docker run -t --rm --memory-swap -1 --pids-limit -1
               -e RUN_ID
               -e TASKCLUSTER_INSTANCE_TYPE
               -e TASKCLUSTER_ROOT_URL

--- a/tools/d2g/d2gtest/testdata/testcases/task_def_test.yml
+++ b/tools/d2g/d2gtest/testdata/testcases/task_def_test.yml
@@ -56,7 +56,7 @@ testSuite:
           command:
           - - bash
             - -cx
-            - docker run --init -t --rm --memory-swap -1 --pids-limit -1 --device=/dev/kvm -e RUN_ID -e TASKCLUSTER_INSTANCE_TYPE
+            - docker run -t --rm --memory-swap -1 --pids-limit -1 --device=/dev/kvm -e RUN_ID -e TASKCLUSTER_INSTANCE_TYPE
               -e TASKCLUSTER_ROOT_URL -e TASKCLUSTER_WORKER_LOCATION -e TASK_GROUP_ID -e TASK_ID ubuntu:latest /bin/bash -c
               'for ((i=1;i<=600;i++)); do echo $i; sleep 1; done'
           features:
@@ -142,7 +142,7 @@ testSuite:
           command:
           - - bash
             - -cx
-            - docker run --init -t --rm --memory-swap -1 --pids-limit -1 --device=/dev/kvm -e RUN_ID -e TASKCLUSTER_INSTANCE_TYPE
+            - docker run -t --rm --memory-swap -1 --pids-limit -1 --device=/dev/kvm -e RUN_ID -e TASKCLUSTER_INSTANCE_TYPE
               -e TASKCLUSTER_ROOT_URL -e TASKCLUSTER_WORKER_LOCATION -e TASK_GROUP_ID -e TASK_ID ubuntu:latest /bin/bash -c
               'for ((i=1;i<=600;i++)); do echo $i; sleep 1; done'
           features:
@@ -232,7 +232,7 @@ testSuite:
           command:
           - - bash
             - -cx
-            - podman run --init -t --rm --memory-swap -1 --pids-limit -1 --ulimit host --device=/dev/kvm -e RUN_ID -e TASKCLUSTER_INSTANCE_TYPE
+            - podman run -t --rm --memory-swap -1 --pids-limit -1 --ulimit host --device=/dev/kvm -e RUN_ID -e TASKCLUSTER_INSTANCE_TYPE
               -e TASKCLUSTER_ROOT_URL -e TASKCLUSTER_WORKER_LOCATION -e TASK_GROUP_ID -e TASK_ID ubuntu:latest /bin/bash -c
               'for ((i=1;i<=600;i++)); do echo $i; sleep 1; done'
           features:


### PR DESCRIPTION
Fixes #7309.

>D2G: No longer pass `--init` to the `docker run ...` command. This was breaking docker image build tasks that Taskgraph creates. To kill the running docker container, we now pass `-s KILL` to the `timeout` command.