### PR TITLE
fix(d2g): remove default artifact expires timestamp on translated payload

### DIFF
--- a/changelog/issue-6858.md
+++ b/changelog/issue-6858.md
@@ -1,0 +1,5 @@
+audience: users
+level: patch
+reference: issue 6858
+---
+D2G: Translated payload or task definition will no longer contain the default `expires` string for artifacts, `"0001-01-01T00:00:00.000Z"`.

--- a/clients/client-shell/cmds/d2g/d2g.go
+++ b/clients/client-shell/cmds/d2g/d2g.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"regexp"
 	"strings"
 
 	"github.com/mcuadros/go-defaults"
@@ -106,6 +107,14 @@ func convert(cmd *cobra.Command, args []string) (err error) {
 			return fmt.Errorf("output validation failed: %v", err)
 		}
 
+		//////////////////////////////////////////////////////////////////////////////////
+		//
+		// horrible hack here, until we have jsonschema2go generating pointer types...
+		//
+		//////////////////////////////////////////////////////////////////////////////////
+		re := regexp.MustCompile(`(?m)^\s*"expires": "0001-01-01T00:00:00.000Z",?\s*\n`)
+		gwTaskDefJSON = re.ReplaceAll([]byte(gwTaskDefJSON), []byte{})
+
 		fmt.Fprintln(cmd.OutOrStdout(), string(gwTaskDefJSON))
 	} else {
 		// Convert dwPayload to gwPayload
@@ -125,6 +134,14 @@ func convert(cmd *cobra.Command, args []string) (err error) {
 		if err != nil {
 			return fmt.Errorf("output validation failed: %v", err)
 		}
+
+		//////////////////////////////////////////////////////////////////////////////////
+		//
+		// horrible hack here, until we have jsonschema2go generating pointer types...
+		//
+		//////////////////////////////////////////////////////////////////////////////////
+		re := regexp.MustCompile(`(?m)^\s*"expires": "0001-01-01T00:00:00.000Z",?\s*\n`)
+		formattedActualGWPayload = re.ReplaceAll(formattedActualGWPayload, []byte{})
 
 		fmt.Fprintln(cmd.OutOrStdout(), string(formattedActualGWPayload))
 	}

--- a/tools/d2g/d2g.go
+++ b/tools/d2g/d2g.go
@@ -18,6 +18,8 @@ import (
 	"github.com/taskcluster/shell"
 )
 
+var MaxArtifactCopyDuration int64 = 900
+
 type (
 	DockerImageName     string
 	IndexedDockerImage  dockerworker.IndexedDockerImage
@@ -427,7 +429,7 @@ func setMaxRunTime(dwPayload *dockerworker.DockerWorkerPayload, gwPayload *gener
 	gwPayload.MaxRunTime = dwPayload.MaxRunTime
 	if len(gwPayload.Artifacts) > 0 {
 		// Add 15 minutes as buffer for task to be able to upload artifacts
-		gwPayload.MaxRunTime += 900
+		gwPayload.MaxRunTime += MaxArtifactCopyDuration
 	}
 }
 

--- a/workers/generic-worker/helper_test.go
+++ b/workers/generic-worker/helper_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/taskcluster/taskcluster/v72/clients/client-go/tcqueue"
 	"github.com/taskcluster/taskcluster/v72/internal/mocktc"
 	"github.com/taskcluster/taskcluster/v72/internal/mocktc/tc"
+	"github.com/taskcluster/taskcluster/v72/tools/d2g"
 	"github.com/taskcluster/taskcluster/v72/tools/d2g/dockerworker"
 	"github.com/taskcluster/taskcluster/v72/workers/generic-worker/fileutil"
 	"github.com/taskcluster/taskcluster/v72/workers/generic-worker/gwconfig"
@@ -344,6 +345,7 @@ type (
 
 func GWTest(t *testing.T) *Test {
 	t.Helper()
+	d2g.MaxArtifactCopyDuration = 30
 	testConfig := &gwconfig.Config{
 		PrivateConfig: gwconfig.PrivateConfig{
 			AccessToken: os.Getenv("TASKCLUSTER_ACCESS_TOKEN"),

--- a/workers/generic-worker/payload_linux.go
+++ b/workers/generic-worker/payload_linux.go
@@ -3,6 +3,7 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+	"regexp"
 
 	"github.com/mcuadros/go-defaults"
 	"github.com/taskcluster/taskcluster/v72/tools/d2g"
@@ -48,6 +49,14 @@ func (task *TaskRun) convertDockerWorkerPayload() *CommandExecutionError {
 	if validateErr != nil {
 		return executionError(malformedPayload, errored, fmt.Errorf("d2g output validation failed: %v", validateErr))
 	}
+
+	//////////////////////////////////////////////////////////////////////////////////
+	//
+	// horrible hack here, until we have jsonschema2go generating pointer types...
+	//
+	//////////////////////////////////////////////////////////////////////////////////
+	re := regexp.MustCompile(`(?m)^\s*"expires": "0001-01-01T00:00:00.000Z",?\s*\n`)
+	d2gConvertedPayloadJSON = re.ReplaceAll(d2gConvertedPayloadJSON, []byte{})
 
 	err = json.Unmarshal(d2gConvertedPayloadJSON, &task.Payload)
 	if err != nil {


### PR DESCRIPTION
Fixes #6858. First commit adds new tests that will fail as we have things today, second commit is the implementation that'll fix this test and implement the fix to the issue.

>D2G: Translated payload or task definition will no longer contain the default `expires` string for artifacts, `"0001-01-01T00:00:00.000Z"`.