### PR TITLE
fix(w-m): transition aws/gcp workers to stopping on `removeWorker` call

### DIFF
--- a/changelog/issue-7322.md
+++ b/changelog/issue-7322.md
@@ -1,0 +1,5 @@
+audience: general
+level: patch
+reference: issue 7322
+---
+Worker Manager: AWS and GCP workers now transition into stopping state on call to `removeWorker`.

--- a/services/worker-manager/src/providers/aws.js
+++ b/services/worker-manager/src/providers/aws.js
@@ -383,10 +383,10 @@ export class AwsProvider extends Provider {
   }
 
   async removeWorker({ worker, reason }) {
-    await worker.update(this.db, worker => {
-      if ([Worker.states.REQUESTED, Worker.states.RUNNING].includes(worker.state)) {
-        worker.lastModified = new Date();
-        worker.state = Worker.states.STOPPING;
+    await worker.update(this.db, w => {
+      if ([Worker.states.REQUESTED, Worker.states.RUNNING].includes(w.state)) {
+        w.lastModified = new Date();
+        w.state = Worker.states.STOPPING;
       }
     });
     await this.onWorkerRemoved({ worker, reason });

--- a/services/worker-manager/src/providers/aws.js
+++ b/services/worker-manager/src/providers/aws.js
@@ -383,6 +383,12 @@ export class AwsProvider extends Provider {
   }
 
   async removeWorker({ worker, reason }) {
+    await worker.update(this.db, worker => {
+      if ([Worker.states.REQUESTED, Worker.states.RUNNING].includes(worker.state)) {
+        worker.lastModified = new Date();
+        worker.state = Worker.states.STOPPING;
+      }
+    });
     await this.onWorkerRemoved({ worker, reason });
     let result;
     try {

--- a/services/worker-manager/src/providers/azure/index.js
+++ b/services/worker-manager/src/providers/azure/index.js
@@ -1321,11 +1321,11 @@ export class AzureProvider extends Provider {
 
     // transition from either REQUESTED or RUNNING to STOPPING, and let the
     // worker scanner take it from there.
-    await worker.update(this.db, worker => {
+    await worker.update(this.db, w => {
       const now = new Date();
-      if ([Worker.states.REQUESTED, Worker.states.RUNNING].includes(worker.state)) {
-        worker.lastModified = now;
-        worker.state = Worker.states.STOPPING;
+      if ([Worker.states.REQUESTED, Worker.states.RUNNING].includes(w.state)) {
+        w.lastModified = now;
+        w.state = Worker.states.STOPPING;
       }
     });
   }

--- a/services/worker-manager/src/providers/google.js
+++ b/services/worker-manager/src/providers/google.js
@@ -163,10 +163,10 @@ export class GoogleProvider extends Provider {
   }
 
   async removeWorker({ worker, reason }) {
-    await worker.update(this.db, worker => {
-      if ([Worker.states.REQUESTED, Worker.states.RUNNING].includes(worker.state)) {
-        worker.lastModified = new Date();
-        worker.state = Worker.states.STOPPING;
+    await worker.update(this.db, w => {
+      if ([Worker.states.REQUESTED, Worker.states.RUNNING].includes(w.state)) {
+        w.lastModified = new Date();
+        w.state = Worker.states.STOPPING;
       }
     });
     await this.onWorkerRemoved({ worker, reason });

--- a/services/worker-manager/src/providers/google.js
+++ b/services/worker-manager/src/providers/google.js
@@ -163,6 +163,12 @@ export class GoogleProvider extends Provider {
   }
 
   async removeWorker({ worker, reason }) {
+    await worker.update(this.db, worker => {
+      if ([Worker.states.REQUESTED, Worker.states.RUNNING].includes(worker.state)) {
+        worker.lastModified = new Date();
+        worker.state = Worker.states.STOPPING;
+      }
+    });
     await this.onWorkerRemoved({ worker, reason });
     try {
       // This returns an operation that we could track but the chances

--- a/services/worker-manager/test/provider_aws_test.js
+++ b/services/worker-manager/test/provider_aws_test.js
@@ -713,15 +713,18 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
   suite('AWS provider - removeWorker', function() {
 
     test('successfully terminated instance', async function() {
-      const worker = {
-        ...defaultWorker,
+      const worker = Worker.fromApi({
+        ...workerInDB,
         workerId: 'i-123',
+        state: Worker.states.REQUESTED,
         providerData: {
-          ...defaultWorker.providerData,
-          region: 'us-west-2',
+          ...workerInDB.providerData,
         },
-      };
+      });
+      await worker.create(helper.db);
       await assert.doesNotReject(provider.removeWorker({ worker }));
+      helper.assertPulseMessage('worker-removed', m => m.payload.workerId === worker.workerId);
+      assert.equal(worker.state, Worker.states.STOPPING);
     });
 
   });


### PR DESCRIPTION
Fixes #7322.

>Worker Manager: AWS and GCP workers now transition into stopping state on call to `removeWorker`.