### PR TITLE
generic-worker, d2g: let containers talk to the tc proxy without sharing the host network namespace

### DIFF
--- a/changelog/issue-7320.md
+++ b/changelog/issue-7320.md
@@ -1,0 +1,5 @@
+audience: worker-deployers
+level: major
+reference: issue 7320
+---
+D2G: containers no longer use the host's network namespace

--- a/tools/d2g/d2g.go
+++ b/tools/d2g/d2g.go
@@ -358,7 +358,7 @@ func runCommand(containerName string, dwPayload *dockerworker.DockerWorkerPayloa
 	}
 	command.WriteString(createVolumeMountsString(dwPayload, wdcs))
 	if dwPayload.Features.TaskclusterProxy {
-		command.WriteString(" --add-host=taskcluster:127.0.0.1 --net=host")
+		command.WriteString(" --add-host=taskcluster:host-gateway -e TASKCLUSTER_PROXY_URL=${TASKCLUSTER_PROXY_URL/localhost/taskcluster}")
 	}
 	command.WriteString(envMappings(dwPayload))
 	dockerImageString, err := dwImage.String(tool)
@@ -566,10 +566,6 @@ func envMappings(dwPayload *dockerworker.DockerWorkerPayload) string {
 		"TASKCLUSTER_WORKER_LOCATION",
 		"TASK_GROUP_ID", // note, docker-worker didn't set this, but decision tasks may in future choose to use it if it is set
 		"TASK_ID",
-	}
-
-	if dwPayload.Features.TaskclusterProxy {
-		additionalEnvVars = append(additionalEnvVars, "TASKCLUSTER_PROXY_URL")
 	}
 
 	envVarNames := []string{}

--- a/tools/d2g/d2gtest/testdata/testcases/decision_task_tests.yml
+++ b/tools/d2g/d2gtest/testdata/testcases/decision_task_tests.yml
@@ -84,7 +84,8 @@ testSuite:
               timeout -s KILL 3600 docker run -t --name taskcontainer
               --memory-swap -1 --pids-limit -1 --privileged
               -v "$(pwd)/cache0:/builds/worker/checkouts"
-              --add-host=taskcluster:127.0.0.1 --net=host
+              --add-host=taskcluster:host-gateway
+              -e TASKCLUSTER_PROXY_URL=${TASKCLUSTER_PROXY_URL/localhost/taskcluster}
               -e GECKO_BASE_REPOSITORY
               -e GECKO_BASE_REV
               -e GECKO_HEAD_REF
@@ -96,7 +97,6 @@ testSuite:
               -e RUN_ID
               -e TASKCLUSTER_CACHES
               -e TASKCLUSTER_INSTANCE_TYPE
-              -e TASKCLUSTER_PROXY_URL
               -e TASKCLUSTER_ROOT_URL
               -e TASKCLUSTER_WORKER_LOCATION
               -e TASK_GROUP_ID

--- a/tools/d2g/d2gtest/testdata/testcases/fuzzing_tests.yml
+++ b/tools/d2g/d2gtest/testdata/testcases/fuzzing_tests.yml
@@ -38,14 +38,26 @@ testSuite:
         command:
         - - bash
           - "-cx"
-          - "IMAGE_ID=$(docker load --input dockerimage | sed -n '0,/^Loaded image: /s/^Loaded image:
-            //p')\ntimeout -s KILL 14400 docker run -t --name taskcontainer
+          - "IMAGE_ID=$(docker load --input dockerimage | sed -n '0,/^Loaded image: /s/^Loaded image: //p')\n\
+            timeout -s KILL 14400 docker run -t --name taskcontainer
             --memory-swap -1 --pids-limit -1 --privileged --security-opt=seccomp=unconfined
-            --device=/dev/shm --device=/dev/snd --add-host=taskcluster:127.0.0.1 --net=host
-            -e BUG_ACTION -e MONITOR_ARTIFACT -e PROCESSOR_ARTIFACT -e RUN_ID -e TASKCLUSTER_INSTANCE_TYPE
-            -e TASKCLUSTER_PROXY_URL -e TASKCLUSTER_ROOT_URL -e TASKCLUSTER_WORKER_LOCATION -e TASK_GROUP_ID
-            -e TASK_ID \"${IMAGE_ID}\" \nexit_code=$?\ndocker cp taskcontainer:/bugmon-artifacts/
-            artifact0\ndocker rm taskcontainer\nexit \"${exit_code}\""
+            --device=/dev/shm --device=/dev/snd
+            --add-host=taskcluster:host-gateway
+            -e TASKCLUSTER_PROXY_URL=${TASKCLUSTER_PROXY_URL/localhost/taskcluster}
+            -e BUG_ACTION
+            -e MONITOR_ARTIFACT
+            -e PROCESSOR_ARTIFACT
+            -e RUN_ID
+            -e TASKCLUSTER_INSTANCE_TYPE
+            -e TASKCLUSTER_ROOT_URL
+            -e TASKCLUSTER_WORKER_LOCATION
+            -e TASK_GROUP_ID
+            -e TASK_ID
+            \"${IMAGE_ID}\" \n\
+            exit_code=$?\n\
+            docker cp taskcontainer:/bugmon-artifacts/ artifact0\n\
+            docker rm taskcontainer\n\
+            exit \"${exit_code}\""
         env:
           BUG_ACTION: process
           MONITOR_ARTIFACT: monitor-1881157-dnCUWpVmTzC-dQguT0njPQ.json

--- a/workers/generic-worker/tcproxy/tcproxy.go
+++ b/workers/generic-worker/tcproxy/tcproxy.go
@@ -32,7 +32,6 @@ func New(taskclusterProxyExecutable string, httpPort uint16, rootURL string, cre
 		"--root-url", rootURL,
 		"--client-id", creds.ClientID,
 		"--access-token", creds.AccessToken,
-		"--ip-address", "127.0.0.1",
 	}
 	if creds.Certificate != "" {
 		args = append(args, "--certificate", creds.Certificate)


### PR DESCRIPTION
Github Bug/Issue: Fixes #7320, fixes #6797
