### PR TITLE
fix(d2g): one-to-one mapping for `--privileged` flag

### DIFF
--- a/changelog/issue-7327.md
+++ b/changelog/issue-7327.md
@@ -1,0 +1,5 @@
+audience: users
+level: patch
+reference: issue 7327
+---
+D2G: Don't provide `--privileged` flag for dind and host shared memory use. Only using now as a one-to-one mapping to Docker Worker's privileged payload flag.

--- a/tools/d2g/d2g.go
+++ b/tools/d2g/d2g.go
@@ -348,7 +348,7 @@ func runCommand(containerName string, dwPayload *dockerworker.DockerWorkerPayloa
 			command.WriteString(fmt.Sprintf(" --gidmap %v:%v:%v", gidStart+1, gidStart+1, mappingRange))
 		}
 	}
-	if dwPayload.Capabilities.Privileged || dwPayload.Features.Dind || dwPayload.Capabilities.Devices.HostSharedMemory {
+	if dwPayload.Capabilities.Privileged {
 		command.WriteString(" --privileged")
 	} else if dwPayload.Features.AllowPtrace {
 		command.WriteString(" --cap-add=SYS_PTRACE")

--- a/tools/d2g/d2g.go
+++ b/tools/d2g/d2g.go
@@ -509,7 +509,11 @@ func createVolumeMountsString(dwPayload *dockerworker.DockerWorkerPayload, wdcs 
 		volumeMounts.WriteString(" --device=/dev/kvm")
 	}
 	if dwPayload.Capabilities.Devices.HostSharedMemory {
-		volumeMounts.WriteString(" --device=/dev/shm")
+		// need to use volume mount here otherwise we get
+		// docker: Error response from daemon: error
+		// gathering device information while adding
+		// custom device "/dev/shm": not a device node
+		volumeMounts.WriteString(" -v /dev/shm:/dev/shm")
 	}
 	if dwPayload.Capabilities.Devices.LoopbackVideo {
 		volumeMounts.WriteString(` --device="${TASKCLUSTER_VIDEO_DEVICE}"`)

--- a/tools/d2g/d2gtest/testdata/testcases/devices_tests.yml
+++ b/tools/d2g/d2gtest/testdata/testcases/devices_tests.yml
@@ -20,7 +20,7 @@ testSuite:
             - '-cx'
             - >-
               docker run -t --rm --memory-swap -1 --pids-limit -1
-              --device=/dev/shm
+              -v /dev/shm:/dev/shm
               -e RUN_ID
               -e TASKCLUSTER_INSTANCE_TYPE
               -e TASKCLUSTER_ROOT_URL

--- a/tools/d2g/d2gtest/testdata/testcases/devices_tests.yml
+++ b/tools/d2g/d2gtest/testdata/testcases/devices_tests.yml
@@ -19,7 +19,7 @@ testSuite:
           - - bash
             - '-cx'
             - >-
-              docker run -t --rm --memory-swap -1 --pids-limit -1 --privileged
+              docker run -t --rm --memory-swap -1 --pids-limit -1
               --device=/dev/shm
               -e RUN_ID
               -e TASKCLUSTER_INSTANCE_TYPE

--- a/tools/d2g/d2gtest/testdata/testcases/fuzzing_tests.yml
+++ b/tools/d2g/d2gtest/testdata/testcases/fuzzing_tests.yml
@@ -41,7 +41,7 @@ testSuite:
           - "IMAGE_ID=$(docker load --input dockerimage | sed -n '0,/^Loaded image: /s/^Loaded image: //p')\n\
             timeout -s KILL 14400 docker run -t --name taskcontainer
             --memory-swap -1 --pids-limit -1 --privileged --security-opt=seccomp=unconfined
-            --device=/dev/shm --device=/dev/snd
+            -v /dev/shm:/dev/shm --device=/dev/snd
             --add-host=taskcluster:host-gateway
             -e TASKCLUSTER_PROXY_URL=${TASKCLUSTER_PROXY_URL/localhost/taskcluster}
             -e BUG_ACTION


### PR DESCRIPTION
Fixes #7327.

>D2G: Don't provide `--privileged` flag for dind and host shared memory use. Only using now as a one-to-one mapping to Docker Worker's privileged payload flag.