### PR TITLE
Return an error when the rust client fails to upload an artifact

### DIFF
--- a/changelog/Og8mVokkRQm4KhmGt2gpGA.md
+++ b/changelog/Og8mVokkRQm4KhmGt2gpGA.md
@@ -1,0 +1,5 @@
+audience: developers
+level: patch
+---
+The rust client will now properly fail when the PUT url call returns an error
+while uploading an artifact.

--- a/clients/client-rust/upload/src/lib.rs
+++ b/clients/client-rust/upload/src/lib.rs
@@ -246,7 +246,7 @@ async fn simple_upload(
     let stream = FramedRead::new(reader, BytesCodec::new());
     req = req.body(Body::wrap_stream(stream));
 
-    req.send().await?;
+    req.send().await?.error_for_status()?;
 
     Ok(())
 }


### PR DESCRIPTION
Without this, the rust client would silently fail when uploading an artifact if the PUT request would return a 4/5xx.