### PR TITLE
Don't duplicate content-length in PUT request to upstream object storage

### DIFF
--- a/changelog/IvW12q6QRjSbGotMqDkFXQ.md
+++ b/changelog/IvW12q6QRjSbGotMqDkFXQ.md
@@ -1,0 +1,6 @@
+audience: developers
+level: patch
+---
+Fixed the rust library for uploading artifact when the object service returned
+a `content-length` header. It will now avoid duping the header which was
+resulting in 400s from upstream object storages.


### PR DESCRIPTION
When the object service gives us a PUT URL, it also gives a list of headers to add to the call. That list might contain a content-length. Before this change, the library would always add its own content-length header which would result in a header list like this:

```
 {
    "content-length": "421",
    "content-length": "421",
    "content-encoding": "identity",
    "content-type": "application/octet-stream",
}
```

which in turn would result in the upstream object storage returning a 400.

Unfortunately, reqwest doesn't allow insights into the current header map of the request builder so we have to build the entire thing ourselves, hence the size of this change.

It's also worth noting that the header map is case insensitive so we don't have to worry about casing ourselves.
