### PR TITLE
feat(generic-worker): add `kvm` feature toggle for d2g

### DIFF
--- a/changelog/LlV7kkfZQ2-42gqVrn8EWA.md
+++ b/changelog/LlV7kkfZQ2-42gqVrn8EWA.md
@@ -1,0 +1,4 @@
+audience: users
+level: minor
+---
+Generic Worker (D2G): Adds `payload.features.kvm` boolean toggle to guard D2G kvm usage with Generic Worker scopes.

--- a/generated/references.json
+++ b/generated/references.json
@@ -8994,6 +8994,11 @@
                   "title": "Interactive shell",
                   "type": "boolean"
                 },
+                "kvm": {
+                  "description": "KVM device support for D2G tasks in order to properly\nprotect the feature using native, Generic Worker\nscopes.\n\nThis feature is only available on Linux. If a task\nis submitted with this feature enabled on a non-Linux,\nposix platform (FreeBSD, macOS), the task will resolve as\n`exception/malformed-payload`.\n\nSince: generic-worker 73.1.0",
+                  "title": "KVM device support for D2G tasks",
+                  "type": "boolean"
+                },
                 "liveLog": {
                   "default": true,
                   "description": "The live log feature streams the combined stderr and stdout to a task artifact\nso that the output is available while the task is running.\n\nSince: generic-worker 48.2.0",
@@ -9782,6 +9787,11 @@
                 "interactive": {
                   "description": "This allows you to interactively run commands from within the worker\nas the task user. This may be useful for debugging purposes.\nCan be used for SSH-like access to the running worker.\nNote that this feature works differently from the `interactive` feature\nin docker worker, which `docker exec`s into the running container.\nSince tasks on generic worker are not guaranteed to be running in a\ncontainer, a bash shell is started on the task user's account.\nA user can then `docker exec` into the a running container, if there\nis one.\n\nSince: generic-worker 49.2.0",
                   "title": "Interactive shell",
+                  "type": "boolean"
+                },
+                "kvm": {
+                  "description": "KVM device support for D2G tasks in order to properly\nprotect the feature using native, Generic Worker\nscopes.\n\nThis feature is only available on Linux. If a task\nis submitted with this feature enabled on a non-Linux,\nposix platform (FreeBSD, macOS), the task will resolve as\n`exception/malformed-payload`.\n\nSince: generic-worker 73.1.0",
+                  "title": "KVM device support for D2G tasks",
                   "type": "boolean"
                 },
                 "liveLog": {

--- a/tools/d2g/d2g.go
+++ b/tools/d2g/d2g.go
@@ -111,6 +111,14 @@ func Scopes(dwScopes []string, dwPayload *dockerworker.DockerWorkerPayload, task
 		case s == "docker-worker:capability:device:kvm":
 			gwScopes = append(
 				gwScopes,
+				"generic-worker:capability:device:kvm",
+				"generic-worker:os-group:"+taskQueueID+"/kvm",
+				"generic-worker:os-group:"+taskQueueID+"/libvirt",
+			)
+		case strings.HasPrefix(s, "docker-worker:capability:device:kvm:"):
+			gwScopes = append(
+				gwScopes,
+				"generic-worker:capability:device:kvm:"+s[len("docker-worker:capability:device:kvm:"):],
 				"generic-worker:os-group:"+taskQueueID+"/kvm",
 				"generic-worker:os-group:"+taskQueueID+"/libvirt",
 			)
@@ -398,6 +406,7 @@ func setFeatures(dwPayload *dockerworker.DockerWorkerPayload, gwPayload *generic
 	gwPayload.Features.Interactive = dwPayload.Features.Interactive
 	gwPayload.Features.LoopbackVideo = dwPayload.Capabilities.Devices.LoopbackVideo
 	gwPayload.Features.LoopbackAudio = dwPayload.Capabilities.Devices.LoopbackAudio
+	gwPayload.Features.KVM = dwPayload.Capabilities.Devices.KVM
 
 	switch dwPayload.Features.Artifacts {
 	case true:

--- a/tools/d2g/d2gtest/d2g_test.go
+++ b/tools/d2g/d2gtest/d2g_test.go
@@ -53,7 +53,9 @@ func ExampleScopes_mixture() {
 	// 	"generic-worker:loopback-video:x/y/z"
 	// 	"generic-worker:monkey"
 	//	"generic-worker:os-group:proj-misc/tutorial/docker"
-	// 	"generic-worker:teapot"
+	//	"generic-worker:os-group:proj-misc/tutorial/kvm"
+	//	"generic-worker:os-group:proj-misc/tutorial/libvirt"
+	//	"generic-worker:teapot"
 }
 
 // TestDataTestCases runs all the test cases found in directory testdata/testcases.

--- a/tools/d2g/d2gtest/testdata/testcases/devices_tests.yml
+++ b/tools/d2g/d2gtest/testdata/testcases/devices_tests.yml
@@ -70,6 +70,10 @@ testSuite:
           - kvm
           - libvirt
           - docker
+        features:
+          backingLog: true
+          kvm: true
+          liveLog: true
 
     - name: Video Loopback
       description: >-

--- a/tools/d2g/d2gtest/testdata/testcases/task_def_test.yml
+++ b/tools/d2g/d2gtest/testdata/testcases/task_def_test.yml
@@ -61,6 +61,7 @@ testSuite:
               'for ((i=1;i<=600;i++)); do echo $i; sleep 1; done'
           features:
             backingLog: true
+            kvm: true
             liveLog: true
           logs:
             backing: public/logs/live_backing.log
@@ -147,6 +148,7 @@ testSuite:
               'for ((i=1;i<=600;i++)); do echo $i; sleep 1; done'
           features:
             backingLog: true
+            kvm: true
             liveLog: true
           logs:
             backing: public/logs/live_backing.log
@@ -169,6 +171,7 @@ testSuite:
         schedulerId: taskcluster-ui
         scopes:
           - generic-worker:apples
+          - generic-worker:capability:device:kvm
           - generic-worker:os-group:proj-taskcluster/gw-ubuntu-24-04/docker
           - generic-worker:os-group:proj-taskcluster/gw-ubuntu-24-04/kvm
           - generic-worker:os-group:proj-taskcluster/gw-ubuntu-24-04/libvirt
@@ -237,6 +240,7 @@ testSuite:
               'for ((i=1;i<=600;i++)); do echo $i; sleep 1; done'
           features:
             backingLog: true
+            kvm: true
             liveLog: true
           logs:
             backing: public/logs/live_backing.log

--- a/tools/d2g/genericworker/generated_types.go
+++ b/tools/d2g/genericworker/generated_types.go
@@ -377,6 +377,18 @@ type (
 		// Since: generic-worker 49.2.0
 		Interactive bool `json:"interactive,omitempty"`
 
+		// KVM device support for D2G tasks in order to properly
+		// protect the feature using native, Generic Worker
+		// scopes.
+		//
+		// This feature is only available on Linux. If a task
+		// is submitted with this feature enabled on a non-Linux,
+		// posix platform (FreeBSD, macOS), the task will resolve as
+		// `exception/malformed-payload`.
+		//
+		// Since: generic-worker 73.1.0
+		KVM bool `json:"kvm,omitempty"`
+
 		// The live log feature streams the combined stderr and stdout to a task artifact
 		// so that the output is available while the task is running.
 		//
@@ -1127,6 +1139,11 @@ func JSONSchema() string {
             "interactive": {
               "description": "This allows you to interactively run commands from within the worker\nas the task user. This may be useful for debugging purposes.\nCan be used for SSH-like access to the running worker.\nNote that this feature works differently from the ` + "`" + `interactive` + "`" + ` feature\nin docker worker, which ` + "`" + `docker exec` + "`" + `s into the running container.\nSince tasks on generic worker are not guaranteed to be running in a\ncontainer, a bash shell is started on the task user's account.\nA user can then ` + "`" + `docker exec` + "`" + ` into the a running container, if there\nis one.\n\nSince: generic-worker 49.2.0",
               "title": "Interactive shell",
+              "type": "boolean"
+            },
+            "kvm": {
+              "description": "KVM device support for D2G tasks in order to properly\nprotect the feature using native, Generic Worker\nscopes.\n\nThis feature is only available on Linux. If a task\nis submitted with this feature enabled on a non-Linux,\nposix platform (FreeBSD, macOS), the task will resolve as\n` + "`" + `exception/malformed-payload` + "`" + `.\n\nSince: generic-worker 73.1.0",
+              "title": "KVM device support for D2G tasks",
               "type": "boolean"
             },
             "liveLog": {

--- a/workers/generic-worker/generated_insecure_darwin.go
+++ b/workers/generic-worker/generated_insecure_darwin.go
@@ -371,6 +371,18 @@ type (
 		// Since: generic-worker 49.2.0
 		Interactive bool `json:"interactive,omitempty"`
 
+		// KVM device support for D2G tasks in order to properly
+		// protect the feature using native, Generic Worker
+		// scopes.
+		//
+		// This feature is only available on Linux. If a task
+		// is submitted with this feature enabled on a non-Linux,
+		// posix platform (FreeBSD, macOS), the task will resolve as
+		// `exception/malformed-payload`.
+		//
+		// Since: generic-worker 73.1.0
+		KVM bool `json:"kvm,omitempty"`
+
 		// The live log feature streams the combined stderr and stdout to a task artifact
 		// so that the output is available while the task is running.
 		//
@@ -1105,6 +1117,11 @@ func JSONSchema() string {
             "interactive": {
               "description": "This allows you to interactively run commands from within the worker\nas the task user. This may be useful for debugging purposes.\nCan be used for SSH-like access to the running worker.\nNote that this feature works differently from the ` + "`" + `interactive` + "`" + ` feature\nin docker worker, which ` + "`" + `docker exec` + "`" + `s into the running container.\nSince tasks on generic worker are not guaranteed to be running in a\ncontainer, a bash shell is started on the task user's account.\nA user can then ` + "`" + `docker exec` + "`" + ` into the a running container, if there\nis one.\n\nSince: generic-worker 49.2.0",
               "title": "Interactive shell",
+              "type": "boolean"
+            },
+            "kvm": {
+              "description": "KVM device support for D2G tasks in order to properly\nprotect the feature using native, Generic Worker\nscopes.\n\nThis feature is only available on Linux. If a task\nis submitted with this feature enabled on a non-Linux,\nposix platform (FreeBSD, macOS), the task will resolve as\n` + "`" + `exception/malformed-payload` + "`" + `.\n\nSince: generic-worker 73.1.0",
+              "title": "KVM device support for D2G tasks",
               "type": "boolean"
             },
             "liveLog": {

--- a/workers/generic-worker/generated_insecure_freebsd.go
+++ b/workers/generic-worker/generated_insecure_freebsd.go
@@ -371,6 +371,18 @@ type (
 		// Since: generic-worker 49.2.0
 		Interactive bool `json:"interactive,omitempty"`
 
+		// KVM device support for D2G tasks in order to properly
+		// protect the feature using native, Generic Worker
+		// scopes.
+		//
+		// This feature is only available on Linux. If a task
+		// is submitted with this feature enabled on a non-Linux,
+		// posix platform (FreeBSD, macOS), the task will resolve as
+		// `exception/malformed-payload`.
+		//
+		// Since: generic-worker 73.1.0
+		KVM bool `json:"kvm,omitempty"`
+
 		// The live log feature streams the combined stderr and stdout to a task artifact
 		// so that the output is available while the task is running.
 		//
@@ -1105,6 +1117,11 @@ func JSONSchema() string {
             "interactive": {
               "description": "This allows you to interactively run commands from within the worker\nas the task user. This may be useful for debugging purposes.\nCan be used for SSH-like access to the running worker.\nNote that this feature works differently from the ` + "`" + `interactive` + "`" + ` feature\nin docker worker, which ` + "`" + `docker exec` + "`" + `s into the running container.\nSince tasks on generic worker are not guaranteed to be running in a\ncontainer, a bash shell is started on the task user's account.\nA user can then ` + "`" + `docker exec` + "`" + ` into the a running container, if there\nis one.\n\nSince: generic-worker 49.2.0",
               "title": "Interactive shell",
+              "type": "boolean"
+            },
+            "kvm": {
+              "description": "KVM device support for D2G tasks in order to properly\nprotect the feature using native, Generic Worker\nscopes.\n\nThis feature is only available on Linux. If a task\nis submitted with this feature enabled on a non-Linux,\nposix platform (FreeBSD, macOS), the task will resolve as\n` + "`" + `exception/malformed-payload` + "`" + `.\n\nSince: generic-worker 73.1.0",
+              "title": "KVM device support for D2G tasks",
               "type": "boolean"
             },
             "liveLog": {

--- a/workers/generic-worker/generated_insecure_linux.go
+++ b/workers/generic-worker/generated_insecure_linux.go
@@ -371,6 +371,18 @@ type (
 		// Since: generic-worker 49.2.0
 		Interactive bool `json:"interactive,omitempty"`
 
+		// KVM device support for D2G tasks in order to properly
+		// protect the feature using native, Generic Worker
+		// scopes.
+		//
+		// This feature is only available on Linux. If a task
+		// is submitted with this feature enabled on a non-Linux,
+		// posix platform (FreeBSD, macOS), the task will resolve as
+		// `exception/malformed-payload`.
+		//
+		// Since: generic-worker 73.1.0
+		KVM bool `json:"kvm,omitempty"`
+
 		// The live log feature streams the combined stderr and stdout to a task artifact
 		// so that the output is available while the task is running.
 		//
@@ -1105,6 +1117,11 @@ func JSONSchema() string {
             "interactive": {
               "description": "This allows you to interactively run commands from within the worker\nas the task user. This may be useful for debugging purposes.\nCan be used for SSH-like access to the running worker.\nNote that this feature works differently from the ` + "`" + `interactive` + "`" + ` feature\nin docker worker, which ` + "`" + `docker exec` + "`" + `s into the running container.\nSince tasks on generic worker are not guaranteed to be running in a\ncontainer, a bash shell is started on the task user's account.\nA user can then ` + "`" + `docker exec` + "`" + ` into the a running container, if there\nis one.\n\nSince: generic-worker 49.2.0",
               "title": "Interactive shell",
+              "type": "boolean"
+            },
+            "kvm": {
+              "description": "KVM device support for D2G tasks in order to properly\nprotect the feature using native, Generic Worker\nscopes.\n\nThis feature is only available on Linux. If a task\nis submitted with this feature enabled on a non-Linux,\nposix platform (FreeBSD, macOS), the task will resolve as\n` + "`" + `exception/malformed-payload` + "`" + `.\n\nSince: generic-worker 73.1.0",
+              "title": "KVM device support for D2G tasks",
               "type": "boolean"
             },
             "liveLog": {

--- a/workers/generic-worker/generated_multiuser_darwin.go
+++ b/workers/generic-worker/generated_multiuser_darwin.go
@@ -379,6 +379,18 @@ type (
 		// Since: generic-worker 49.2.0
 		Interactive bool `json:"interactive,omitempty"`
 
+		// KVM device support for D2G tasks in order to properly
+		// protect the feature using native, Generic Worker
+		// scopes.
+		//
+		// This feature is only available on Linux. If a task
+		// is submitted with this feature enabled on a non-Linux,
+		// posix platform (FreeBSD, macOS), the task will resolve as
+		// `exception/malformed-payload`.
+		//
+		// Since: generic-worker 73.1.0
+		KVM bool `json:"kvm,omitempty"`
+
 		// The live log feature streams the combined stderr and stdout to a task artifact
 		// so that the output is available while the task is running.
 		//
@@ -1129,6 +1141,11 @@ func JSONSchema() string {
             "interactive": {
               "description": "This allows you to interactively run commands from within the worker\nas the task user. This may be useful for debugging purposes.\nCan be used for SSH-like access to the running worker.\nNote that this feature works differently from the ` + "`" + `interactive` + "`" + ` feature\nin docker worker, which ` + "`" + `docker exec` + "`" + `s into the running container.\nSince tasks on generic worker are not guaranteed to be running in a\ncontainer, a bash shell is started on the task user's account.\nA user can then ` + "`" + `docker exec` + "`" + ` into the a running container, if there\nis one.\n\nSince: generic-worker 49.2.0",
               "title": "Interactive shell",
+              "type": "boolean"
+            },
+            "kvm": {
+              "description": "KVM device support for D2G tasks in order to properly\nprotect the feature using native, Generic Worker\nscopes.\n\nThis feature is only available on Linux. If a task\nis submitted with this feature enabled on a non-Linux,\nposix platform (FreeBSD, macOS), the task will resolve as\n` + "`" + `exception/malformed-payload` + "`" + `.\n\nSince: generic-worker 73.1.0",
+              "title": "KVM device support for D2G tasks",
               "type": "boolean"
             },
             "liveLog": {

--- a/workers/generic-worker/generated_multiuser_freebsd.go
+++ b/workers/generic-worker/generated_multiuser_freebsd.go
@@ -379,6 +379,18 @@ type (
 		// Since: generic-worker 49.2.0
 		Interactive bool `json:"interactive,omitempty"`
 
+		// KVM device support for D2G tasks in order to properly
+		// protect the feature using native, Generic Worker
+		// scopes.
+		//
+		// This feature is only available on Linux. If a task
+		// is submitted with this feature enabled on a non-Linux,
+		// posix platform (FreeBSD, macOS), the task will resolve as
+		// `exception/malformed-payload`.
+		//
+		// Since: generic-worker 73.1.0
+		KVM bool `json:"kvm,omitempty"`
+
 		// The live log feature streams the combined stderr and stdout to a task artifact
 		// so that the output is available while the task is running.
 		//
@@ -1129,6 +1141,11 @@ func JSONSchema() string {
             "interactive": {
               "description": "This allows you to interactively run commands from within the worker\nas the task user. This may be useful for debugging purposes.\nCan be used for SSH-like access to the running worker.\nNote that this feature works differently from the ` + "`" + `interactive` + "`" + ` feature\nin docker worker, which ` + "`" + `docker exec` + "`" + `s into the running container.\nSince tasks on generic worker are not guaranteed to be running in a\ncontainer, a bash shell is started on the task user's account.\nA user can then ` + "`" + `docker exec` + "`" + ` into the a running container, if there\nis one.\n\nSince: generic-worker 49.2.0",
               "title": "Interactive shell",
+              "type": "boolean"
+            },
+            "kvm": {
+              "description": "KVM device support for D2G tasks in order to properly\nprotect the feature using native, Generic Worker\nscopes.\n\nThis feature is only available on Linux. If a task\nis submitted with this feature enabled on a non-Linux,\nposix platform (FreeBSD, macOS), the task will resolve as\n` + "`" + `exception/malformed-payload` + "`" + `.\n\nSince: generic-worker 73.1.0",
+              "title": "KVM device support for D2G tasks",
               "type": "boolean"
             },
             "liveLog": {

--- a/workers/generic-worker/generated_multiuser_linux.go
+++ b/workers/generic-worker/generated_multiuser_linux.go
@@ -379,6 +379,18 @@ type (
 		// Since: generic-worker 49.2.0
 		Interactive bool `json:"interactive,omitempty"`
 
+		// KVM device support for D2G tasks in order to properly
+		// protect the feature using native, Generic Worker
+		// scopes.
+		//
+		// This feature is only available on Linux. If a task
+		// is submitted with this feature enabled on a non-Linux,
+		// posix platform (FreeBSD, macOS), the task will resolve as
+		// `exception/malformed-payload`.
+		//
+		// Since: generic-worker 73.1.0
+		KVM bool `json:"kvm,omitempty"`
+
 		// The live log feature streams the combined stderr and stdout to a task artifact
 		// so that the output is available while the task is running.
 		//
@@ -1129,6 +1141,11 @@ func JSONSchema() string {
             "interactive": {
               "description": "This allows you to interactively run commands from within the worker\nas the task user. This may be useful for debugging purposes.\nCan be used for SSH-like access to the running worker.\nNote that this feature works differently from the ` + "`" + `interactive` + "`" + ` feature\nin docker worker, which ` + "`" + `docker exec` + "`" + `s into the running container.\nSince tasks on generic worker are not guaranteed to be running in a\ncontainer, a bash shell is started on the task user's account.\nA user can then ` + "`" + `docker exec` + "`" + ` into the a running container, if there\nis one.\n\nSince: generic-worker 49.2.0",
               "title": "Interactive shell",
+              "type": "boolean"
+            },
+            "kvm": {
+              "description": "KVM device support for D2G tasks in order to properly\nprotect the feature using native, Generic Worker\nscopes.\n\nThis feature is only available on Linux. If a task\nis submitted with this feature enabled on a non-Linux,\nposix platform (FreeBSD, macOS), the task will resolve as\n` + "`" + `exception/malformed-payload` + "`" + `.\n\nSince: generic-worker 73.1.0",
+              "title": "KVM device support for D2G tasks",
               "type": "boolean"
             },
             "liveLog": {

--- a/workers/generic-worker/insecure.go
+++ b/workers/generic-worker/insecure.go
@@ -24,6 +24,7 @@ const (
 
 func platformFeatures() []Feature {
 	return []Feature{
+		&KVMFeature{},
 		&InteractiveFeature{},
 		&LoopbackAudioFeature{},
 		&LoopbackVideoFeature{},

--- a/workers/generic-worker/insecure_linux.go
+++ b/workers/generic-worker/insecure_linux.go
@@ -1,4 +1,4 @@
-//go:build insecure && linux
+//go:build insecure
 
 package main
 

--- a/workers/generic-worker/kvm_darwin.go
+++ b/workers/generic-worker/kvm_darwin.go
@@ -1,0 +1,7 @@
+package main
+
+import "fmt"
+
+func (kvmt *KVMTask) ensurePlatform() *CommandExecutionError {
+	return executionError(malformedPayload, errored, fmt.Errorf("kvm feature toggle is not supported on macOS"))
+}

--- a/workers/generic-worker/kvm_darwin_test.go
+++ b/workers/generic-worker/kvm_darwin_test.go
@@ -1,0 +1,26 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/mcuadros/go-defaults"
+)
+
+func TestKVMReturnsMalformedPayload(t *testing.T) {
+	setup(t)
+
+	payload := GenericWorkerPayload{
+		Command:    helloGoodbye(),
+		MaxRunTime: 30,
+		Features: FeatureFlags{
+			KVM: true,
+		},
+	}
+	defaults.SetDefaults(&payload)
+	td := testTask(t)
+	td.Scopes = append(td.Scopes, "generic-worker:capability:device:kvm")
+
+	// This test is expected to fail with malformed payload
+	// because kvm feature toggle is not supported on macOS
+	_ = submitAndAssert(t, td, payload, "exception", "malformed-payload")
+}

--- a/workers/generic-worker/kvm_freebsd.go
+++ b/workers/generic-worker/kvm_freebsd.go
@@ -1,0 +1,7 @@
+package main
+
+import "fmt"
+
+func (kvmt *KVMTask) ensurePlatform() *CommandExecutionError {
+	return executionError(malformedPayload, errored, fmt.Errorf("kvm feature toggle is not supported on FreeBSD"))
+}

--- a/workers/generic-worker/kvm_freebsd_test.go
+++ b/workers/generic-worker/kvm_freebsd_test.go
@@ -1,0 +1,26 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/mcuadros/go-defaults"
+)
+
+func TestKVMReturnsMalformedPayload(t *testing.T) {
+	setup(t)
+
+	payload := GenericWorkerPayload{
+		Command:    helloGoodbye(),
+		MaxRunTime: 30,
+		Features: FeatureFlags{
+			KVM: true,
+		},
+	}
+	defaults.SetDefaults(&payload)
+	td := testTask(t)
+	td.Scopes = append(td.Scopes, "generic-worker:capability:device:kvm:freebsd/kvm")
+
+	// This test is expected to fail with malformed payload
+	// because kvm feature toggle is not supported on FreeBSD
+	_ = submitAndAssert(t, td, payload, "exception", "malformed-payload")
+}

--- a/workers/generic-worker/kvm_linux.go
+++ b/workers/generic-worker/kvm_linux.go
@@ -1,0 +1,5 @@
+package main
+
+func (kvmt *KVMTask) ensurePlatform() *CommandExecutionError {
+	return nil
+}

--- a/workers/generic-worker/kvm_linux_test.go
+++ b/workers/generic-worker/kvm_linux_test.go
@@ -1,0 +1,51 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/mcuadros/go-defaults"
+)
+
+func TestKVM(t *testing.T) {
+	setup(t)
+
+	payload := GenericWorkerPayload{
+		Command:    returnExitCode(0),
+		MaxRunTime: 10,
+		Features: FeatureFlags{
+			KVM: true,
+		},
+	}
+	defaults.SetDefaults(&payload)
+	td := testTask(t)
+	td.Scopes = append(td.Scopes, "generic-worker:capability:device:kvm")
+
+	_ = submitAndAssert(t, td, payload, "completed", "completed")
+
+	t.Log(LogText(t))
+}
+
+func TestIncorrectKVMScopes(t *testing.T) {
+	setup(t)
+
+	payload := GenericWorkerPayload{
+		Command:    returnExitCode(0),
+		MaxRunTime: 10,
+		Features: FeatureFlags{
+			KVM: true,
+		},
+	}
+	defaults.SetDefaults(&payload)
+	td := testTask(t)
+
+	// don't set any scopes
+	_ = submitAndAssert(t, td, payload, "exception", "malformed-payload")
+
+	logtext := LogText(t)
+	if !strings.Contains(logtext, "generic-worker:capability:device:kvm:"+td.ProvisionerID+"/"+td.WorkerType) || !strings.Contains(logtext, "generic-worker:capability:device:kvm") {
+		t.Fatal("Expected log file to contain missing scopes, but it didn't")
+	}
+
+	t.Log(logtext)
+}

--- a/workers/generic-worker/kvm_posix.go
+++ b/workers/generic-worker/kvm_posix.go
@@ -1,0 +1,60 @@
+//go:build darwin || linux || freebsd
+
+package main
+
+import (
+	"github.com/taskcluster/taskcluster/v73/internal/scopes"
+)
+
+type KVMFeature struct {
+}
+
+func (feature *KVMFeature) Name() string {
+	return "KVM"
+}
+
+func (feature *KVMFeature) Initialise() error {
+	return nil
+}
+
+func (feature *KVMFeature) PersistState() error {
+	return nil
+}
+
+func (feature *KVMFeature) IsEnabled(task *TaskRun) bool {
+	return config.EnableD2G && task.Payload.Features.KVM
+}
+
+func (feature *KVMFeature) NewTaskFeature(task *TaskRun) TaskFeature {
+	return &KVMTask{
+		task: task,
+	}
+}
+
+type KVMTask struct {
+	task *TaskRun
+}
+
+func (kvmt *KVMTask) RequiredScopes() scopes.Required {
+	// these scopes come from the d2g.Scopes() translation
+	// of the Docker Worker scope needed for KVM usage below:
+	//
+	// docker-worker:capability:device:kvm:<workerPoolName>
+	// OR
+	// docker-worker:capability:device:kvm
+	return scopes.Required{
+		{"generic-worker:capability:device:kvm:" + config.ProvisionerID + "/" + config.WorkerType},
+		{"generic-worker:capability:device:kvm"},
+	}
+}
+
+func (kvmt *KVMTask) ReservedArtifacts() []string {
+	return []string{}
+}
+
+func (kvmt *KVMTask) Start() *CommandExecutionError {
+	return kvmt.ensurePlatform()
+}
+
+func (kvmt *KVMTask) Stop(err *ExecutionErrors) {
+}

--- a/workers/generic-worker/multiuser_posix.go
+++ b/workers/generic-worker/multiuser_posix.go
@@ -24,6 +24,7 @@ func (task *TaskRun) formatCommand(index int) string {
 
 func platformFeatures() []Feature {
 	return []Feature{
+		&KVMFeature{},
 		&InteractiveFeature{},
 		&LoopbackAudioFeature{},
 		&LoopbackVideoFeature{},

--- a/workers/generic-worker/schemas/insecure_posix.yml
+++ b/workers/generic-worker/schemas/insecure_posix.yml
@@ -274,6 +274,20 @@ oneOf:
               `exception/malformed-payload`.
 
               Since: generic-worker 54.5.0
+        kvm:
+          type: boolean
+          title: KVM device support for D2G tasks
+          description: |-
+            KVM device support for D2G tasks in order to properly
+            protect the feature using native, Generic Worker
+            scopes.
+
+            This feature is only available on Linux. If a task
+            is submitted with this feature enabled on a non-Linux,
+            posix platform (FreeBSD, macOS), the task will resolve as
+            `exception/malformed-payload`.
+
+            Since: generic-worker 73.1.0
     mounts:
       type: array
       description: |-

--- a/workers/generic-worker/schemas/multiuser_posix.yml
+++ b/workers/generic-worker/schemas/multiuser_posix.yml
@@ -296,6 +296,20 @@ oneOf:
             `exception/malformed-payload`.
 
             Since: generic-worker 54.5.0
+        kvm:
+          type: boolean
+          title: KVM device support for D2G tasks
+          description: |-
+            KVM device support for D2G tasks in order to properly
+            protect the feature using native, Generic Worker
+            scopes.
+
+            This feature is only available on Linux. If a task
+            is submitted with this feature enabled on a non-Linux,
+            posix platform (FreeBSD, macOS), the task will resolve as
+            `exception/malformed-payload`.
+
+            Since: generic-worker 73.1.0
     mounts:
       type: array
       description: |-


### PR DESCRIPTION
>Generic Worker (D2G): Adds `payload.features.kvm` boolean toggle to guard D2G kvm usage with Generic Worker scopes.

https://github.com/taskcluster/community-tc-config/pull/877 also needs to be reviewed (though, changes are already applied)