### PR TITLE
feat(generic-worker): add `allowPtrace` feature toggle for d2g

### DIFF
--- a/changelog/LSgWXwQtQS-ng6KUxQshdA.md
+++ b/changelog/LSgWXwQtQS-ng6KUxQshdA.md
@@ -1,0 +1,4 @@
+audience: users
+level: minor
+---
+Generic Worker (D2G): Adds `payload.features.allowPtrace` boolean toggle to guard D2G ptrace usage with Generic Worker scopes.

--- a/generated/references.json
+++ b/generated/references.json
@@ -8978,6 +8978,11 @@
               "additionalProperties": false,
               "description": "Feature flags enable additional functionality.\n\nSince: generic-worker 5.3.0",
               "properties": {
+                "allowPtrace": {
+                  "description": "ptrace support for D2G tasks in order to properly\nprotect the feature using native, Generic Worker\nscopes.\n\nThis feature is only available on Linux. If a task\nis submitted with this feature enabled on a non-Linux,\nposix platform (FreeBSD, macOS), the task will resolve as\n`exception/malformed-payload`.\n\nSince: generic-worker 73.1.0",
+                  "title": "ptrace support for D2G tasks",
+                  "type": "boolean"
+                },
                 "backingLog": {
                   "default": true,
                   "description": "The backing log feature publishes a task artifact containing the complete\nstderr and stdout of the task.\n\nSince: generic-worker 48.2.0",
@@ -9773,6 +9778,11 @@
               "additionalProperties": false,
               "description": "Feature flags enable additional functionality.\n\nSince: generic-worker 5.3.0",
               "properties": {
+                "allowPtrace": {
+                  "description": "ptrace support for D2G tasks in order to properly\nprotect the feature using native, Generic Worker\nscopes.\n\nThis feature is only available on Linux. If a task\nis submitted with this feature enabled on a non-Linux,\nposix platform (FreeBSD, macOS), the task will resolve as\n`exception/malformed-payload`.\n\nSince: generic-worker 73.1.0",
+                  "title": "ptrace support for D2G tasks",
+                  "type": "boolean"
+                },
                 "backingLog": {
                   "default": true,
                   "description": "The backing log feature publishes a task artifact containing the complete\nstderr and stdout of the task.\n\nSince: generic-worker 48.2.0",

--- a/tools/d2g/d2g.go
+++ b/tools/d2g/d2g.go
@@ -398,6 +398,7 @@ func setFeatures(dwPayload *dockerworker.DockerWorkerPayload, gwPayload *generic
 	gwPayload.Features.Interactive = dwPayload.Features.Interactive
 	gwPayload.Features.LoopbackVideo = dwPayload.Capabilities.Devices.LoopbackVideo
 	gwPayload.Features.LoopbackAudio = dwPayload.Capabilities.Devices.LoopbackAudio
+	gwPayload.Features.AllowPtrace = dwPayload.Features.AllowPtrace
 
 	switch dwPayload.Features.Artifacts {
 	case true:

--- a/tools/d2g/d2gtest/d2g_test.go
+++ b/tools/d2g/d2gtest/d2g_test.go
@@ -29,6 +29,7 @@ func ExampleScopes_mixture() {
 		"docker-worker:monkey",
 		"generic-worker:teapot",
 		"docker-worker:docker-worker:potato",
+		"docker-worker:feature:allowPtrace",
 		"docker-worker:capability:device:loopbackVideo",
 		"docker-worker:capability:device:loopbackVideo:",
 		"docker-worker:capability:device:loopbackVideo:x/y/z",
@@ -48,6 +49,7 @@ func ExampleScopes_mixture() {
 	// 	"foo"
 	// 	"generic-worker:capability:device:kvm:x/y/z"
 	// 	"generic-worker:docker-worker:potato"
+	//	"generic-worker:feature:allowPtrace"
 	// 	"generic-worker:loopback-video:"
 	// 	"generic-worker:loopback-video:*"
 	// 	"generic-worker:loopback-video:x/y/z"

--- a/tools/d2g/d2gtest/testdata/testcases/dw_features_tests.yml
+++ b/tools/d2g/d2gtest/testdata/testcases/dw_features_tests.yml
@@ -27,6 +27,10 @@ testSuite:
               -e TASK_ID
               ubuntu 'echo "Hello world"'
         maxRunTime: 3600
+        features:
+          allowPtrace: true
+          backingLog: true
+          liveLog: true
         onExitStatus:
           retry:
             - 125

--- a/tools/d2g/d2gtest/testdata/testcases/task_def_test.yml
+++ b/tools/d2g/d2gtest/testdata/testcases/task_def_test.yml
@@ -110,6 +110,7 @@ testSuite:
         scopes:
           - docker-worker:apples
           - docker-worker:capability:device:kvm
+          - docker-worker:feature:allowPtrace
         payload:
           image: ubuntu:latest
           command:
@@ -120,6 +121,8 @@ testSuite:
           capabilities:
             devices:
               kvm: true
+          features:
+            allowPtrace: true
         metadata:
           name: example-task
           owner: name@example.com
@@ -142,10 +145,11 @@ testSuite:
           command:
           - - bash
             - -cx
-            - docker run -t --rm --memory-swap -1 --pids-limit -1 --device=/dev/kvm -e RUN_ID -e TASKCLUSTER_INSTANCE_TYPE
+            - docker run -t --rm --memory-swap -1 --pids-limit -1 --cap-add=SYS_PTRACE --device=/dev/kvm -e RUN_ID -e TASKCLUSTER_INSTANCE_TYPE
               -e TASKCLUSTER_ROOT_URL -e TASKCLUSTER_WORKER_LOCATION -e TASK_GROUP_ID -e TASK_ID ubuntu:latest /bin/bash -c
               'for ((i=1;i<=600;i++)); do echo $i; sleep 1; done'
           features:
+            allowPtrace: true
             backingLog: true
             liveLog: true
           logs:
@@ -169,6 +173,7 @@ testSuite:
         schedulerId: taskcluster-ui
         scopes:
           - generic-worker:apples
+          - generic-worker:feature:allowPtrace
           - generic-worker:os-group:proj-taskcluster/gw-ubuntu-24-04/docker
           - generic-worker:os-group:proj-taskcluster/gw-ubuntu-24-04/kvm
           - generic-worker:os-group:proj-taskcluster/gw-ubuntu-24-04/libvirt

--- a/tools/d2g/genericworker/generated_types.go
+++ b/tools/d2g/genericworker/generated_types.go
@@ -348,6 +348,18 @@ type (
 	// Since: generic-worker 5.3.0
 	FeatureFlags struct {
 
+		// ptrace support for D2G tasks in order to properly
+		// protect the feature using native, Generic Worker
+		// scopes.
+		//
+		// This feature is only available on Linux. If a task
+		// is submitted with this feature enabled on a non-Linux,
+		// posix platform (FreeBSD, macOS), the task will resolve as
+		// `exception/malformed-payload`.
+		//
+		// Since: generic-worker 73.1.0
+		AllowPtrace bool `json:"allowPtrace,omitempty"`
+
 		// The backing log feature publishes a task artifact containing the complete
 		// stderr and stdout of the task.
 		//
@@ -1113,6 +1125,11 @@ func JSONSchema() string {
           "additionalProperties": false,
           "description": "Feature flags enable additional functionality.\n\nSince: generic-worker 5.3.0",
           "properties": {
+            "allowPtrace": {
+              "description": "ptrace support for D2G tasks in order to properly\nprotect the feature using native, Generic Worker\nscopes.\n\nThis feature is only available on Linux. If a task\nis submitted with this feature enabled on a non-Linux,\nposix platform (FreeBSD, macOS), the task will resolve as\n` + "`" + `exception/malformed-payload` + "`" + `.\n\nSince: generic-worker 73.1.0",
+              "title": "ptrace support for D2G tasks",
+              "type": "boolean"
+            },
             "backingLog": {
               "default": true,
               "description": "The backing log feature publishes a task artifact containing the complete\nstderr and stdout of the task.\n\nSince: generic-worker 48.2.0",

--- a/workers/generic-worker/allow_ptrace_darwin.go
+++ b/workers/generic-worker/allow_ptrace_darwin.go
@@ -1,0 +1,7 @@
+package main
+
+import "fmt"
+
+func (aptt *AllowPtraceTask) ensurePlatform() *CommandExecutionError {
+	return executionError(malformedPayload, errored, fmt.Errorf("allowPtrace feature toggle is not supported on macOS"))
+}

--- a/workers/generic-worker/allow_ptrace_darwin_test.go
+++ b/workers/generic-worker/allow_ptrace_darwin_test.go
@@ -1,0 +1,26 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/mcuadros/go-defaults"
+)
+
+func TestAllowPtraceReturnsMalformedPayload(t *testing.T) {
+	setup(t)
+
+	payload := GenericWorkerPayload{
+		Command:    helloGoodbye(),
+		MaxRunTime: 30,
+		Features: FeatureFlags{
+			AllowPtrace: true,
+		},
+	}
+	defaults.SetDefaults(&payload)
+	td := testTask(t)
+	td.Scopes = append(td.Scopes, "generic-worker:feature:allowPtrace")
+
+	// This test is expected to fail with malformed payload
+	// because allowPtrace feature toggle is not supported on macOS
+	_ = submitAndAssert(t, td, payload, "exception", "malformed-payload")
+}

--- a/workers/generic-worker/allow_ptrace_freebsd.go
+++ b/workers/generic-worker/allow_ptrace_freebsd.go
@@ -1,0 +1,7 @@
+package main
+
+import "fmt"
+
+func (aptt *AllowPtraceTask) ensurePlatform() *CommandExecutionError {
+	return executionError(malformedPayload, errored, fmt.Errorf("allowPtrace feature toggle is not supported on FreeBSD"))
+}

--- a/workers/generic-worker/allow_ptrace_freebsd_test.go
+++ b/workers/generic-worker/allow_ptrace_freebsd_test.go
@@ -1,0 +1,26 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/mcuadros/go-defaults"
+)
+
+func TestAllowPtraceReturnsMalformedPayload(t *testing.T) {
+	setup(t)
+
+	payload := GenericWorkerPayload{
+		Command:    helloGoodbye(),
+		MaxRunTime: 30,
+		Features: FeatureFlags{
+			AllowPtrace: true,
+		},
+	}
+	defaults.SetDefaults(&payload)
+	td := testTask(t)
+	td.Scopes = append(td.Scopes, "generic-worker:feature:allowPtrace")
+
+	// This test is expected to fail with malformed payload
+	// because allowPtrace feature toggle is not supported on FreeBSD
+	_ = submitAndAssert(t, td, payload, "exception", "malformed-payload")
+}

--- a/workers/generic-worker/allow_ptrace_linux.go
+++ b/workers/generic-worker/allow_ptrace_linux.go
@@ -1,0 +1,5 @@
+package main
+
+func (aptt *AllowPtraceTask) ensurePlatform() *CommandExecutionError {
+	return nil
+}

--- a/workers/generic-worker/allow_ptrace_linux_test.go
+++ b/workers/generic-worker/allow_ptrace_linux_test.go
@@ -1,0 +1,51 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/mcuadros/go-defaults"
+)
+
+func TestAllowPtrace(t *testing.T) {
+	setup(t)
+
+	payload := GenericWorkerPayload{
+		Command:    returnExitCode(0),
+		MaxRunTime: 10,
+		Features: FeatureFlags{
+			AllowPtrace: true,
+		},
+	}
+	defaults.SetDefaults(&payload)
+	td := testTask(t)
+	td.Scopes = append(td.Scopes, "generic-worker:feature:allowPtrace")
+
+	_ = submitAndAssert(t, td, payload, "completed", "completed")
+
+	t.Log(LogText(t))
+}
+
+func TestIncorrectAllowPtraceScopes(t *testing.T) {
+	setup(t)
+
+	payload := GenericWorkerPayload{
+		Command:    returnExitCode(0),
+		MaxRunTime: 10,
+		Features: FeatureFlags{
+			AllowPtrace: true,
+		},
+	}
+	defaults.SetDefaults(&payload)
+	td := testTask(t)
+
+	// don't set any scopes
+	_ = submitAndAssert(t, td, payload, "exception", "malformed-payload")
+
+	logtext := LogText(t)
+	if !strings.Contains(logtext, "generic-worker:feature:allowPtrace") {
+		t.Fatal("Expected log file to contain missing scopes, but it didn't")
+	}
+
+	t.Log(logtext)
+}

--- a/workers/generic-worker/allow_ptrace_posix.go
+++ b/workers/generic-worker/allow_ptrace_posix.go
@@ -1,0 +1,57 @@
+//go:build darwin || linux || freebsd
+
+package main
+
+import (
+	"github.com/taskcluster/taskcluster/v73/internal/scopes"
+)
+
+type AllowPtraceFeature struct {
+}
+
+func (feature *AllowPtraceFeature) Name() string {
+	return "Allow Ptrace"
+}
+
+func (feature *AllowPtraceFeature) Initialise() error {
+	return nil
+}
+
+func (feature *AllowPtraceFeature) PersistState() error {
+	return nil
+}
+
+func (feature *AllowPtraceFeature) IsEnabled(task *TaskRun) bool {
+	return config.EnableD2G && task.Payload.Features.AllowPtrace
+}
+
+func (feature *AllowPtraceFeature) NewTaskFeature(task *TaskRun) TaskFeature {
+	return &AllowPtraceTask{
+		task: task,
+	}
+}
+
+type AllowPtraceTask struct {
+	task *TaskRun
+}
+
+func (aptt *AllowPtraceTask) RequiredScopes() scopes.Required {
+	// these scopes come from the d2g.Scopes() translation
+	// of the Docker Worker scope needed for ptrace usage below:
+	//
+	// docker-worker:feature:allowPtrace
+	return scopes.Required{
+		{"generic-worker:feature:allowPtrace"},
+	}
+}
+
+func (aptt *AllowPtraceTask) ReservedArtifacts() []string {
+	return []string{}
+}
+
+func (aptt *AllowPtraceTask) Start() *CommandExecutionError {
+	return aptt.ensurePlatform()
+}
+
+func (aptt *AllowPtraceTask) Stop(err *ExecutionErrors) {
+}

--- a/workers/generic-worker/d2g_multiuser_test.go
+++ b/workers/generic-worker/d2g_multiuser_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"reflect"
 	"runtime"
+	"strings"
 	"testing"
 
 	"github.com/mcuadros/go-defaults"
@@ -50,5 +51,34 @@ func TestD2GWithChainOfTrust(t *testing.T) {
 	default:
 		_ = submitAndAssert(t, td, payload, "exception", "malformed-payload")
 	}
+	t.Log(LogText(t))
+}
+
+func TestD2GWithIncorrectAllowPtraceScopes(t *testing.T) {
+	setup(t)
+	payload := dockerworker.DockerWorkerPayload{
+		Command: []string{"/bin/bash", "-c", "echo hello"},
+		Image:   json.RawMessage(`"denolehov/curl"`),
+		Features: dockerworker.FeatureFlags{
+			AllowPtrace: true,
+		},
+		MaxRunTime: 10,
+	}
+	defaults.SetDefaults(&payload)
+	td := testTask(t)
+	// don't set ptrace toggle scope, generic-worker:feature:allowPtrace
+
+	switch runtime.GOOS {
+	case "linux":
+		_ = submitAndAssert(t, td, payload, "exception", "malformed-payload")
+
+		logtext := LogText(t)
+		if !strings.Contains(logtext, "generic-worker:feature:allowPtrace") {
+			t.Fatal("Expected log file to contain missing scopes, but it didn't")
+		}
+	default:
+		_ = submitAndAssert(t, td, payload, "exception", "malformed-payload")
+	}
+
 	t.Log(LogText(t))
 }

--- a/workers/generic-worker/generated_insecure_darwin.go
+++ b/workers/generic-worker/generated_insecure_darwin.go
@@ -350,6 +350,18 @@ type (
 	// Since: generic-worker 5.3.0
 	FeatureFlags struct {
 
+		// ptrace support for D2G tasks in order to properly
+		// protect the feature using native, Generic Worker
+		// scopes.
+		//
+		// This feature is only available on Linux. If a task
+		// is submitted with this feature enabled on a non-Linux,
+		// posix platform (FreeBSD, macOS), the task will resolve as
+		// `exception/malformed-payload`.
+		//
+		// Since: generic-worker 73.1.0
+		AllowPtrace bool `json:"allowPtrace,omitempty"`
+
 		// The backing log feature publishes a task artifact containing the complete
 		// stderr and stdout of the task.
 		//
@@ -1096,6 +1108,11 @@ func JSONSchema() string {
           "additionalProperties": false,
           "description": "Feature flags enable additional functionality.\n\nSince: generic-worker 5.3.0",
           "properties": {
+            "allowPtrace": {
+              "description": "ptrace support for D2G tasks in order to properly\nprotect the feature using native, Generic Worker\nscopes.\n\nThis feature is only available on Linux. If a task\nis submitted with this feature enabled on a non-Linux,\nposix platform (FreeBSD, macOS), the task will resolve as\n` + "`" + `exception/malformed-payload` + "`" + `.\n\nSince: generic-worker 73.1.0",
+              "title": "ptrace support for D2G tasks",
+              "type": "boolean"
+            },
             "backingLog": {
               "default": true,
               "description": "The backing log feature publishes a task artifact containing the complete\nstderr and stdout of the task.\n\nSince: generic-worker 48.2.0",

--- a/workers/generic-worker/generated_insecure_freebsd.go
+++ b/workers/generic-worker/generated_insecure_freebsd.go
@@ -350,6 +350,18 @@ type (
 	// Since: generic-worker 5.3.0
 	FeatureFlags struct {
 
+		// ptrace support for D2G tasks in order to properly
+		// protect the feature using native, Generic Worker
+		// scopes.
+		//
+		// This feature is only available on Linux. If a task
+		// is submitted with this feature enabled on a non-Linux,
+		// posix platform (FreeBSD, macOS), the task will resolve as
+		// `exception/malformed-payload`.
+		//
+		// Since: generic-worker 73.1.0
+		AllowPtrace bool `json:"allowPtrace,omitempty"`
+
 		// The backing log feature publishes a task artifact containing the complete
 		// stderr and stdout of the task.
 		//
@@ -1096,6 +1108,11 @@ func JSONSchema() string {
           "additionalProperties": false,
           "description": "Feature flags enable additional functionality.\n\nSince: generic-worker 5.3.0",
           "properties": {
+            "allowPtrace": {
+              "description": "ptrace support for D2G tasks in order to properly\nprotect the feature using native, Generic Worker\nscopes.\n\nThis feature is only available on Linux. If a task\nis submitted with this feature enabled on a non-Linux,\nposix platform (FreeBSD, macOS), the task will resolve as\n` + "`" + `exception/malformed-payload` + "`" + `.\n\nSince: generic-worker 73.1.0",
+              "title": "ptrace support for D2G tasks",
+              "type": "boolean"
+            },
             "backingLog": {
               "default": true,
               "description": "The backing log feature publishes a task artifact containing the complete\nstderr and stdout of the task.\n\nSince: generic-worker 48.2.0",

--- a/workers/generic-worker/generated_insecure_linux.go
+++ b/workers/generic-worker/generated_insecure_linux.go
@@ -350,6 +350,18 @@ type (
 	// Since: generic-worker 5.3.0
 	FeatureFlags struct {
 
+		// ptrace support for D2G tasks in order to properly
+		// protect the feature using native, Generic Worker
+		// scopes.
+		//
+		// This feature is only available on Linux. If a task
+		// is submitted with this feature enabled on a non-Linux,
+		// posix platform (FreeBSD, macOS), the task will resolve as
+		// `exception/malformed-payload`.
+		//
+		// Since: generic-worker 73.1.0
+		AllowPtrace bool `json:"allowPtrace,omitempty"`
+
 		// The backing log feature publishes a task artifact containing the complete
 		// stderr and stdout of the task.
 		//
@@ -1096,6 +1108,11 @@ func JSONSchema() string {
           "additionalProperties": false,
           "description": "Feature flags enable additional functionality.\n\nSince: generic-worker 5.3.0",
           "properties": {
+            "allowPtrace": {
+              "description": "ptrace support for D2G tasks in order to properly\nprotect the feature using native, Generic Worker\nscopes.\n\nThis feature is only available on Linux. If a task\nis submitted with this feature enabled on a non-Linux,\nposix platform (FreeBSD, macOS), the task will resolve as\n` + "`" + `exception/malformed-payload` + "`" + `.\n\nSince: generic-worker 73.1.0",
+              "title": "ptrace support for D2G tasks",
+              "type": "boolean"
+            },
             "backingLog": {
               "default": true,
               "description": "The backing log feature publishes a task artifact containing the complete\nstderr and stdout of the task.\n\nSince: generic-worker 48.2.0",

--- a/workers/generic-worker/generated_multiuser_darwin.go
+++ b/workers/generic-worker/generated_multiuser_darwin.go
@@ -350,6 +350,18 @@ type (
 	// Since: generic-worker 5.3.0
 	FeatureFlags struct {
 
+		// ptrace support for D2G tasks in order to properly
+		// protect the feature using native, Generic Worker
+		// scopes.
+		//
+		// This feature is only available on Linux. If a task
+		// is submitted with this feature enabled on a non-Linux,
+		// posix platform (FreeBSD, macOS), the task will resolve as
+		// `exception/malformed-payload`.
+		//
+		// Since: generic-worker 73.1.0
+		AllowPtrace bool `json:"allowPtrace,omitempty"`
+
 		// The backing log feature publishes a task artifact containing the complete
 		// stderr and stdout of the task.
 		//
@@ -1115,6 +1127,11 @@ func JSONSchema() string {
           "additionalProperties": false,
           "description": "Feature flags enable additional functionality.\n\nSince: generic-worker 5.3.0",
           "properties": {
+            "allowPtrace": {
+              "description": "ptrace support for D2G tasks in order to properly\nprotect the feature using native, Generic Worker\nscopes.\n\nThis feature is only available on Linux. If a task\nis submitted with this feature enabled on a non-Linux,\nposix platform (FreeBSD, macOS), the task will resolve as\n` + "`" + `exception/malformed-payload` + "`" + `.\n\nSince: generic-worker 73.1.0",
+              "title": "ptrace support for D2G tasks",
+              "type": "boolean"
+            },
             "backingLog": {
               "default": true,
               "description": "The backing log feature publishes a task artifact containing the complete\nstderr and stdout of the task.\n\nSince: generic-worker 48.2.0",

--- a/workers/generic-worker/generated_multiuser_freebsd.go
+++ b/workers/generic-worker/generated_multiuser_freebsd.go
@@ -350,6 +350,18 @@ type (
 	// Since: generic-worker 5.3.0
 	FeatureFlags struct {
 
+		// ptrace support for D2G tasks in order to properly
+		// protect the feature using native, Generic Worker
+		// scopes.
+		//
+		// This feature is only available on Linux. If a task
+		// is submitted with this feature enabled on a non-Linux,
+		// posix platform (FreeBSD, macOS), the task will resolve as
+		// `exception/malformed-payload`.
+		//
+		// Since: generic-worker 73.1.0
+		AllowPtrace bool `json:"allowPtrace,omitempty"`
+
 		// The backing log feature publishes a task artifact containing the complete
 		// stderr and stdout of the task.
 		//
@@ -1115,6 +1127,11 @@ func JSONSchema() string {
           "additionalProperties": false,
           "description": "Feature flags enable additional functionality.\n\nSince: generic-worker 5.3.0",
           "properties": {
+            "allowPtrace": {
+              "description": "ptrace support for D2G tasks in order to properly\nprotect the feature using native, Generic Worker\nscopes.\n\nThis feature is only available on Linux. If a task\nis submitted with this feature enabled on a non-Linux,\nposix platform (FreeBSD, macOS), the task will resolve as\n` + "`" + `exception/malformed-payload` + "`" + `.\n\nSince: generic-worker 73.1.0",
+              "title": "ptrace support for D2G tasks",
+              "type": "boolean"
+            },
             "backingLog": {
               "default": true,
               "description": "The backing log feature publishes a task artifact containing the complete\nstderr and stdout of the task.\n\nSince: generic-worker 48.2.0",

--- a/workers/generic-worker/generated_multiuser_linux.go
+++ b/workers/generic-worker/generated_multiuser_linux.go
@@ -350,6 +350,18 @@ type (
 	// Since: generic-worker 5.3.0
 	FeatureFlags struct {
 
+		// ptrace support for D2G tasks in order to properly
+		// protect the feature using native, Generic Worker
+		// scopes.
+		//
+		// This feature is only available on Linux. If a task
+		// is submitted with this feature enabled on a non-Linux,
+		// posix platform (FreeBSD, macOS), the task will resolve as
+		// `exception/malformed-payload`.
+		//
+		// Since: generic-worker 73.1.0
+		AllowPtrace bool `json:"allowPtrace,omitempty"`
+
 		// The backing log feature publishes a task artifact containing the complete
 		// stderr and stdout of the task.
 		//
@@ -1115,6 +1127,11 @@ func JSONSchema() string {
           "additionalProperties": false,
           "description": "Feature flags enable additional functionality.\n\nSince: generic-worker 5.3.0",
           "properties": {
+            "allowPtrace": {
+              "description": "ptrace support for D2G tasks in order to properly\nprotect the feature using native, Generic Worker\nscopes.\n\nThis feature is only available on Linux. If a task\nis submitted with this feature enabled on a non-Linux,\nposix platform (FreeBSD, macOS), the task will resolve as\n` + "`" + `exception/malformed-payload` + "`" + `.\n\nSince: generic-worker 73.1.0",
+              "title": "ptrace support for D2G tasks",
+              "type": "boolean"
+            },
             "backingLog": {
               "default": true,
               "description": "The backing log feature publishes a task artifact containing the complete\nstderr and stdout of the task.\n\nSince: generic-worker 48.2.0",

--- a/workers/generic-worker/insecure.go
+++ b/workers/generic-worker/insecure.go
@@ -24,6 +24,7 @@ const (
 
 func platformFeatures() []Feature {
 	return []Feature{
+		&AllowPtraceFeature{},
 		&InteractiveFeature{},
 		&LoopbackAudioFeature{},
 		&LoopbackVideoFeature{},

--- a/workers/generic-worker/multiuser_posix.go
+++ b/workers/generic-worker/multiuser_posix.go
@@ -24,6 +24,7 @@ func (task *TaskRun) formatCommand(index int) string {
 
 func platformFeatures() []Feature {
 	return []Feature{
+		&AllowPtraceFeature{},
 		&InteractiveFeature{},
 		&LoopbackAudioFeature{},
 		&LoopbackVideoFeature{},

--- a/workers/generic-worker/schemas/insecure_posix.yml
+++ b/workers/generic-worker/schemas/insecure_posix.yml
@@ -274,6 +274,20 @@ oneOf:
               `exception/malformed-payload`.
 
               Since: generic-worker 54.5.0
+        allowPtrace:
+          type: boolean
+          title: ptrace support for D2G tasks
+          description: |-
+            ptrace support for D2G tasks in order to properly
+            protect the feature using native, Generic Worker
+            scopes.
+
+            This feature is only available on Linux. If a task
+            is submitted with this feature enabled on a non-Linux,
+            posix platform (FreeBSD, macOS), the task will resolve as
+            `exception/malformed-payload`.
+
+            Since: generic-worker 73.1.0
     mounts:
       type: array
       description: |-

--- a/workers/generic-worker/schemas/multiuser_posix.yml
+++ b/workers/generic-worker/schemas/multiuser_posix.yml
@@ -296,6 +296,20 @@ oneOf:
             `exception/malformed-payload`.
 
             Since: generic-worker 54.5.0
+        allowPtrace:
+          type: boolean
+          title: ptrace support for D2G tasks
+          description: |-
+            ptrace support for D2G tasks in order to properly
+            protect the feature using native, Generic Worker
+            scopes.
+
+            This feature is only available on Linux. If a task
+            is submitted with this feature enabled on a non-Linux,
+            posix platform (FreeBSD, macOS), the task will resolve as
+            `exception/malformed-payload`.
+
+            Since: generic-worker 73.1.0
     mounts:
       type: array
       description: |-


### PR DESCRIPTION
>Generic Worker (D2G): Adds `payload.features.allowPtrace` boolean toggle to guard D2G ptrace usage with Generic Worker scopes.

https://github.com/taskcluster/community-tc-config/pull/877 also needs to be reviewed (though, changes are already applied)