### PR TITLE
fix(d2g): use unique task container names

### DIFF
--- a/changelog/issue-7340.md
+++ b/changelog/issue-7340.md
@@ -1,0 +1,5 @@
+audience: users
+level: patch
+reference: issue 7340
+---
+D2G: Use unique task container names to avoid container naming conflicts.

--- a/tools/d2g/d2g.go
+++ b/tools/d2g/d2g.go
@@ -10,7 +10,9 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"testing"
 
+	"github.com/taskcluster/slugid-go/slugid"
 	"github.com/taskcluster/taskcluster/v73/tools/d2g/dockerworker"
 	"github.com/taskcluster/taskcluster/v73/tools/d2g/genericworker"
 
@@ -244,7 +246,11 @@ func artifacts(dwPayload *dockerworker.DockerWorkerPayload) []genericworker.Arti
 func command(dwPayload *dockerworker.DockerWorkerPayload, dwImage Image, tool string, gwArtifacts []genericworker.Artifact, gwWritableDirectoryCaches []genericworker.WritableDirectoryCache) ([][]string, error) {
 	containerName := ""
 	if len(gwArtifacts) > 0 {
-		containerName = "taskcontainer"
+		if testing.Testing() {
+			containerName = "taskcontainer"
+		} else {
+			containerName = "taskcontainer_" + slugid.Nice()
+		}
 	}
 
 	commands := []string{}


### PR DESCRIPTION
Fixes #7340.

>D2G: Use unique task container names to avoid container naming conflicts.

cc @jschwartzentruber