### PR TITLE
feat(d2g)!: added scope/payload validation

### DIFF
--- a/changelog/fady1OgaQ1ulcxtyDR4fuQ.md
+++ b/changelog/fady1OgaQ1ulcxtyDR4fuQ.md
@@ -1,0 +1,6 @@
+audience: worker-deployers
+level: major
+---
+D2G: Renamed methods `Convert()` --> `ConvertPayload()` and `Scopes()` --> `ConvertScopes()`.
+
+D2G: `ConvertScopes()` checks that the provided docker worker payload is valid with the supplied scopes. Generic Worker will now resolve a docker worker task as `exception/malformed-payload` if any required docker worker scopes are missing for its payload.

--- a/internal/scopes/scopes.go
+++ b/internal/scopes/scopes.go
@@ -158,14 +158,13 @@ func DummyExpander() ScopeExpander {
 	return &dummyExpander{}
 }
 
-// Performs no scope expansion. Directly copies
-// the set of scopes from given to expanded.
+// Performs no scope expansion. Returns a copy of given.
 func (d *dummyExpander) ExpandScopes(given *tcauth.SetOfScopes) (*tcauth.SetOfScopes, error) {
-	expanded := new(tcauth.SetOfScopes)
 	if given == nil {
-		return expanded, nil
+		return nil, nil
 	}
 
+	expanded := new(tcauth.SetOfScopes)
 	expanded.Scopes = make([]string, len(given.Scopes))
 	copy(expanded.Scopes, given.Scopes)
 

--- a/internal/scopes/scopes.go
+++ b/internal/scopes/scopes.go
@@ -158,6 +158,16 @@ func DummyExpander() ScopeExpander {
 	return &dummyExpander{}
 }
 
-func (d *dummyExpander) ExpandScopes(s *tcauth.SetOfScopes) (*tcauth.SetOfScopes, error) {
-	return s, nil
+// Performs no scope expansion. Directly copies
+// the set of scopes from given to expanded.
+func (d *dummyExpander) ExpandScopes(given *tcauth.SetOfScopes) (*tcauth.SetOfScopes, error) {
+	expanded := new(tcauth.SetOfScopes)
+	if given == nil {
+		return expanded, nil
+	}
+
+	expanded.Scopes = make([]string, len(given.Scopes))
+	copy(expanded.Scopes, given.Scopes)
+
+	return expanded, nil
 }

--- a/internal/scopes/scopes.go
+++ b/internal/scopes/scopes.go
@@ -45,6 +45,8 @@ type (
 	// are equal, required scopes ending with a `*` can be used, although are
 	// relatively uncommon. See the examples.
 	Required [][]string
+
+	dummyExpander struct{}
 )
 
 // Note, this is trivially implemented by *Auth in
@@ -101,7 +103,7 @@ func (given Given) Expand(scopeExpander ScopeExpander) (expanded Given, err erro
 			goto hasAssume
 		}
 	}
-	expanded = make(Given, 0, len(given))
+	expanded = make(Given, len(given))
 	copy(expanded, given)
 	return
 
@@ -146,4 +148,16 @@ func (required Required) String() string {
 		text += strings.Join(lines, ", or\n")
 	}
 	return text
+}
+
+// DummyExpander is a scope expander that performs
+// no scope expansion. This is useful for calling
+// Satisfies when you know the given scopes have
+// already been expanded.
+func DummyExpander() ScopeExpander {
+	return &dummyExpander{}
+}
+
+func (d *dummyExpander) ExpandScopes(s *tcauth.SetOfScopes) (*tcauth.SetOfScopes, error) {
+	return s, nil
 }

--- a/tools/d2g/d2gtest/d2g_test.go
+++ b/tools/d2g/d2gtest/d2g_test.go
@@ -46,19 +46,25 @@ func ExampleConvertScopes_mixture() {
 	}
 
 	// Output:
-	// 	"bar:dog"
-	// 	"cat:docker-worker:feet"
-	// 	"docker-worker"
-	// 	"foo"
-	// 	"generic-worker:docker-worker:potato"
-	// 	"generic-worker:loopback-video:"
-	// 	"generic-worker:loopback-video:*"
-	// 	"generic-worker:loopback-video:x/y/z"
-	// 	"generic-worker:monkey"
+	//	"bar:dog"
+	//	"cat:docker-worker:feet"
+	//	"docker-worker"
+	//	"docker-worker:capability:device:kvm:x/y/z"
+	//	"docker-worker:capability:device:loopbackVideo"
+	//	"docker-worker:capability:device:loopbackVideo:"
+	//	"docker-worker:capability:device:loopbackVideo:x/y/z"
+	//	"docker-worker:docker-worker:potato"
+	//	"docker-worker:monkey"
+	//	"foo"
+	//	"generic-worker:docker-worker:potato"
+	//	"generic-worker:loopback-video:"
+	//	"generic-worker:loopback-video:*"
+	//	"generic-worker:loopback-video:x/y/z"
+	//	"generic-worker:monkey"
 	//	"generic-worker:os-group:proj-misc/tutorial/docker"
-	//	"generic-worker:os-group:proj-misc/tutorial/kvm"
-	//	"generic-worker:os-group:proj-misc/tutorial/libvirt"
-	// 	"generic-worker:teapot"
+	//	"generic-worker:os-group:x/y/z/kvm"
+	//	"generic-worker:os-group:x/y/z/libvirt"
+	//	"generic-worker:teapot"
 }
 
 // TestDataTestCases runs all the test cases found in directory testdata/testcases.

--- a/tools/d2g/d2gtest/testdata/testcases/task_def_test.yml
+++ b/tools/d2g/d2gtest/testdata/testcases/task_def_test.yml
@@ -83,6 +83,8 @@ testSuite:
         routes: []
         schedulerId: taskcluster-ui
         scopes:
+          - docker-worker:apples
+          - docker-worker:capability:device:kvm:proj-taskcluster/gw-ubuntu-24-04
           - generic-worker:apples
           - generic-worker:os-group:proj-taskcluster/gw-ubuntu-24-04/docker
           - generic-worker:os-group:proj-taskcluster/gw-ubuntu-24-04/kvm
@@ -171,6 +173,8 @@ testSuite:
         routes: []
         schedulerId: taskcluster-ui
         scopes:
+          - docker-worker:apples
+          - docker-worker:capability:device:kvm
           - generic-worker:apples
           - generic-worker:os-group:proj-taskcluster/gw-ubuntu-24-04/docker
           - generic-worker:os-group:proj-taskcluster/gw-ubuntu-24-04/kvm
@@ -261,6 +265,8 @@ testSuite:
         routes: []
         schedulerId: taskcluster-ui
         scopes:
+          - docker-worker:apples
+          - docker-worker:capability:device:kvm:proj-taskcluster/gw-ubuntu-24-04
           - generic-worker:apples
           - generic-worker:os-group:proj-taskcluster/gw-ubuntu-24-04/kvm
           - generic-worker:os-group:proj-taskcluster/gw-ubuntu-24-04/libvirt

--- a/tools/d2g/d2gtest/testdata/testcases/task_def_test.yml
+++ b/tools/d2g/d2gtest/testdata/testcases/task_def_test.yml
@@ -24,6 +24,7 @@ testSuite:
         expires: '2024-10-26T17:06:09.867Z'
         scopes:
           - docker-worker:apples
+          - docker-worker:capability:device:kvm:proj-taskcluster/gw-ubuntu-24-04
         payload:
           image: ubuntu:latest
           command:
@@ -84,6 +85,8 @@ testSuite:
         scopes:
           - generic-worker:apples
           - generic-worker:os-group:proj-taskcluster/gw-ubuntu-24-04/docker
+          - generic-worker:os-group:proj-taskcluster/gw-ubuntu-24-04/kvm
+          - generic-worker:os-group:proj-taskcluster/gw-ubuntu-24-04/libvirt
         tags: {}
         taskGroupId: PIxhISDQSDa98W9ppGUNsw
         taskQueueId: proj-taskcluster/gw-ubuntu-24-04
@@ -198,6 +201,7 @@ testSuite:
         expires: '2024-10-26T17:06:09.867Z'
         scopes:
           - docker-worker:apples
+          - docker-worker:capability:device:kvm:proj-taskcluster/gw-ubuntu-24-04
         payload:
           image: ubuntu:latest
           command:
@@ -258,6 +262,8 @@ testSuite:
         schedulerId: taskcluster-ui
         scopes:
           - generic-worker:apples
+          - generic-worker:os-group:proj-taskcluster/gw-ubuntu-24-04/kvm
+          - generic-worker:os-group:proj-taskcluster/gw-ubuntu-24-04/libvirt
         tags: {}
         taskGroupId: PIxhISDQSDa98W9ppGUNsw
         taskQueueId: proj-taskcluster/gw-ubuntu-24-04

--- a/workers/generic-worker/d2g_multiuser_test.go
+++ b/workers/generic-worker/d2g_multiuser_test.go
@@ -29,6 +29,7 @@ func TestD2GWithChainOfTrust(t *testing.T) {
 	switch fmt.Sprintf("%s:%v", runtime.GOOS, config.RunTasksAsCurrentUser) {
 	case "linux:false":
 		taskID := submitAndAssert(t, td, payload, "completed", "completed")
+		t.Log(LogText(t))
 		cotUnsignedBytes := getArtifactContent(t, taskID, "public/chain-of-trust.json")
 		var cotCert ChainOfTrustData
 		err := json.Unmarshal(cotUnsignedBytes, &cotCert)
@@ -50,5 +51,4 @@ func TestD2GWithChainOfTrust(t *testing.T) {
 	default:
 		_ = submitAndAssert(t, td, payload, "exception", "malformed-payload")
 	}
-	t.Log(LogText(t))
 }

--- a/workers/generic-worker/d2g_test.go
+++ b/workers/generic-worker/d2g_test.go
@@ -53,6 +53,7 @@ func TestWithValidDockerWorkerPayload(t *testing.T) {
 	case "multiuser:linux":
 		_ = submitAndAssert(t, td, payload, "completed", "completed")
 		logtext := LogText(t)
+		t.Log(logtext)
 		// tests the default artifact expiry is not present in the
 		// translated task definition
 		if strings.Contains(logtext, "0001-01-01T00:00:00.000Z") {
@@ -66,13 +67,13 @@ func TestWithValidDockerWorkerPayload(t *testing.T) {
 	case "insecure:linux":
 		_ = submitAndAssert(t, td, payload, "exception", "malformed-payload")
 		logtext := LogText(t)
+		t.Log(logtext)
 		if !strings.Contains(logtext, "task payload contains unsupported osGroups: [docker]") {
 			t.Fatal("Was expecting log file to contain 'task payload contains unsupported osGroups: [docker]'")
 		}
 	default:
 		_ = submitAndAssert(t, td, payload, "exception", "malformed-payload")
 	}
-	t.Log(LogText(t))
 }
 
 func TestWithInvalidDockerWorkerPayload(t *testing.T) {
@@ -118,11 +119,96 @@ func TestIssue6789(t *testing.T) {
 	case "insecure:linux":
 		_ = submitAndAssert(t, td, payload, "exception", "malformed-payload")
 		logtext := LogText(t)
+		t.Log(logtext)
 		if !strings.Contains(logtext, "task payload contains unsupported osGroups: [docker]") {
 			t.Fatalf("Was expecting log file to contain 'task payload contains unsupported osGroups: [docker]'")
 		}
 	default:
 		_ = submitAndAssert(t, td, payload, "exception", "malformed-payload")
 	}
-	t.Log(LogText(t))
+}
+
+func TestDockerWorkerPayloadWithValidScopes(t *testing.T) {
+	setup(t)
+	image := map[string]interface{}{
+		"name": "ubuntu:latest",
+		"type": "docker-image",
+	}
+	imageBytes, err := json.Marshal(image)
+	if err != nil {
+		t.Fatalf("Error marshaling JSON: %v", err)
+	}
+	payload := dockerworker.DockerWorkerPayload{
+		Command:    []string{"/bin/bash", "-c", "echo hello world"},
+		Image:      json.RawMessage(imageBytes),
+		MaxRunTime: 10,
+		Capabilities: dockerworker.Capabilities{
+			Privileged: true,
+			Devices: dockerworker.Devices{
+				HostSharedMemory: true,
+				KVM:              true,
+			},
+		},
+		Features: dockerworker.FeatureFlags{
+			AllowPtrace: true,
+		},
+	}
+	defaults.SetDefaults(&payload)
+	td := testTask(t)
+	td.Scopes = append(td.Scopes, []string{
+		"docker-worker:capability:privileged:" + td.ProvisionerID + "/" + td.WorkerType,
+		"docker-worker:capability:device:hostSharedMemory:" + td.ProvisionerID + "/" + td.WorkerType,
+		"docker-worker:capability:device:kvm:" + td.ProvisionerID + "/" + td.WorkerType,
+		"docker-worker:feature:allowPtrace",
+	}...)
+
+	switch fmt.Sprintf("%s:%s", engine, runtime.GOOS) {
+	case "multiuser:linux":
+		_ = submitAndAssert(t, td, payload, "completed", "completed")
+	case "insecure:linux":
+		_ = submitAndAssert(t, td, payload, "exception", "malformed-payload")
+		logtext := LogText(t)
+		t.Log(logtext)
+		if !strings.Contains(logtext, "task payload contains unsupported osGroups: [kvm libvirt docker]") {
+			t.Fatalf("Was expecting log file to contain 'task payload contains unsupported osGroups: [kvm libvirt docker]'")
+		}
+	default:
+		_ = submitAndAssert(t, td, payload, "exception", "malformed-payload")
+	}
+}
+
+func TestDockerWorkerPayloadWithInvalidScopes(t *testing.T) {
+	setup(t)
+	image := map[string]interface{}{
+		"name": "ubuntu:latest",
+		"type": "docker-image",
+	}
+	imageBytes, err := json.Marshal(image)
+	if err != nil {
+		t.Fatalf("Error marshaling JSON: %v", err)
+	}
+	payload := dockerworker.DockerWorkerPayload{
+		Command:    []string{"/bin/bash", "-c", "echo hello world"},
+		Image:      json.RawMessage(imageBytes),
+		MaxRunTime: 10,
+		Capabilities: dockerworker.Capabilities{
+			Privileged: true,
+		},
+	}
+	defaults.SetDefaults(&payload)
+	td := testTask(t)
+
+	// don't set any scopes
+
+	switch runtime.GOOS {
+	case "linux":
+		_ = submitAndAssert(t, td, payload, "exception", "malformed-payload")
+		logtext := LogText(t)
+		t.Log(logtext)
+		if !strings.Contains(logtext, "docker-worker:capability:privileged:"+td.ProvisionerID+"/"+td.WorkerType) || !strings.Contains(logtext, "docker-worker:capability:privileged") {
+			t.Fatalf("Expected log file to contain missing scopes, but it didn't")
+		}
+	default:
+		_ = submitAndAssert(t, td, payload, "exception", "malformed-payload")
+	}
 }

--- a/workers/generic-worker/loopback_audio_darwin_test.go
+++ b/workers/generic-worker/loopback_audio_darwin_test.go
@@ -18,7 +18,7 @@ func TestLoopbackAudioReturnsMalformedPayload(t *testing.T) {
 	}
 	defaults.SetDefaults(&payload)
 	td := testTask(t)
-	td.Scopes = append(td.Scopes, "generic-worker:loopback-audio")
+	td.Scopes = append(td.Scopes, "generic-worker:loopback-audio:"+td.ProvisionerID+"/"+td.WorkerType)
 
 	// This test is expected to fail with malformed payload
 	// because loopback audio is not supported on macOS

--- a/workers/generic-worker/loopback_audio_freebsd_test.go
+++ b/workers/generic-worker/loopback_audio_freebsd_test.go
@@ -18,7 +18,7 @@ func TestLoopbackAudioReturnsMalformedPayload(t *testing.T) {
 	}
 	defaults.SetDefaults(&payload)
 	td := testTask(t)
-	td.Scopes = append(td.Scopes, "generic-worker:loopback-audio:freebsd/loopback-audio")
+	td.Scopes = append(td.Scopes, "generic-worker:loopback-audio:"+td.ProvisionerID+"/"+td.WorkerType)
 
 	// This test is expected to fail with malformed payload
 	// because loopback audio is not supported on FreeBSD

--- a/workers/generic-worker/loopback_audio_linux_test.go
+++ b/workers/generic-worker/loopback_audio_linux_test.go
@@ -33,7 +33,7 @@ func TestLoopbackAudio(t *testing.T) {
 	}
 	defaults.SetDefaults(&payload)
 	td := testTask(t)
-	td.Scopes = append(td.Scopes, "generic-worker:loopback-audio")
+	td.Scopes = append(td.Scopes, "generic-worker:loopback-audio:"+td.ProvisionerID+"/"+td.WorkerType)
 
 	_ = submitAndAssert(t, td, payload, "completed", "completed")
 
@@ -89,7 +89,7 @@ func TestLoopbackAudioNotOwnedByTaskUser(t *testing.T) {
 	}
 	defaults.SetDefaults(&payload)
 	td := testTask(t)
-	td.Scopes = append(td.Scopes, "generic-worker:loopback-audio")
+	td.Scopes = append(td.Scopes, "generic-worker:loopback-audio:"+td.ProvisionerID+"/"+td.WorkerType)
 
 	_ = submitAndAssert(t, td, payload, "completed", "completed")
 
@@ -107,7 +107,7 @@ func TestLoopbackAudioNotOwnedByTaskUser(t *testing.T) {
 	}
 	defaults.SetDefaults(&payload)
 	td = testTask(t)
-	td.Scopes = append(td.Scopes, "generic-worker:loopback-audio")
+	td.Scopes = append(td.Scopes, "generic-worker:loopback-audio:"+td.ProvisionerID+"/"+td.WorkerType)
 
 	_ = submitAndAssert(t, td, payload, "completed", "completed")
 
@@ -144,7 +144,7 @@ func TestLoopbackAudioInvalidDeviceNumber(t *testing.T) {
 	}
 	defaults.SetDefaults(&payload)
 	td := testTask(t)
-	td.Scopes = append(td.Scopes, "generic-worker:loopback-audio")
+	td.Scopes = append(td.Scopes, "generic-worker:loopback-audio:"+td.ProvisionerID+"/"+td.WorkerType)
 
 	_ = submitAndAssert(t, td, payload, "exception", "internal-error")
 }

--- a/workers/generic-worker/loopback_video_darwin_test.go
+++ b/workers/generic-worker/loopback_video_darwin_test.go
@@ -18,7 +18,7 @@ func TestLoopbackVideoReturnsMalformedPayload(t *testing.T) {
 	}
 	defaults.SetDefaults(&payload)
 	td := testTask(t)
-	td.Scopes = append(td.Scopes, "generic-worker:loopback-video")
+	td.Scopes = append(td.Scopes, "generic-worker:loopback-video:"+td.ProvisionerID+"/"+td.WorkerType)
 
 	// This test is expected to fail with malformed payload
 	// because loopback video is not supported on macOS

--- a/workers/generic-worker/loopback_video_freebsd_test.go
+++ b/workers/generic-worker/loopback_video_freebsd_test.go
@@ -18,7 +18,7 @@ func TestLoopbackVideoReturnsMalformedPayload(t *testing.T) {
 	}
 	defaults.SetDefaults(&payload)
 	td := testTask(t)
-	td.Scopes = append(td.Scopes, "generic-worker:loopback-video:freebsd/loopback-video")
+	td.Scopes = append(td.Scopes, "generic-worker:loopback-video:"+td.ProvisionerID+"/"+td.WorkerType)
 
 	// This test is expected to fail with malformed payload
 	// because loopback video is not supported on FreeBSD

--- a/workers/generic-worker/loopback_video_linux_test.go
+++ b/workers/generic-worker/loopback_video_linux_test.go
@@ -24,7 +24,7 @@ func TestLoopbackVideo(t *testing.T) {
 	}
 	defaults.SetDefaults(&payload)
 	td := testTask(t)
-	td.Scopes = append(td.Scopes, "generic-worker:loopback-video")
+	td.Scopes = append(td.Scopes, "generic-worker:loopback-video:"+td.ProvisionerID+"/"+td.WorkerType)
 
 	_ = submitAndAssert(t, td, payload, "completed", "completed")
 
@@ -77,7 +77,7 @@ func TestLoopbackVideoNotOwnedByTaskUser(t *testing.T) {
 	}
 	defaults.SetDefaults(&payload)
 	td := testTask(t)
-	td.Scopes = append(td.Scopes, "generic-worker:loopback-video")
+	td.Scopes = append(td.Scopes, "generic-worker:loopback-video:"+td.ProvisionerID+"/"+td.WorkerType)
 
 	_ = submitAndAssert(t, td, payload, "completed", "completed")
 
@@ -95,7 +95,7 @@ func TestLoopbackVideoNotOwnedByTaskUser(t *testing.T) {
 	}
 	defaults.SetDefaults(&payload)
 	td = testTask(t)
-	td.Scopes = append(td.Scopes, "generic-worker:loopback-video")
+	td.Scopes = append(td.Scopes, "generic-worker:loopback-video:"+td.ProvisionerID+"/"+td.WorkerType)
 
 	_ = submitAndAssert(t, td, payload, "completed", "completed")
 

--- a/workers/generic-worker/payload_linux.go
+++ b/workers/generic-worker/payload_linux.go
@@ -24,11 +24,6 @@ func (task *TaskRun) convertDockerWorkerPayload() *CommandExecutionError {
 		return MalformedPayloadError(err)
 	}
 
-	// Convert dwPayload to gwPayload
-	gwPayload, err := d2g.Convert(dwPayload, config.ContainerEngine)
-	if err != nil {
-		return executionError(internalError, errored, fmt.Errorf("failed to convert docker worker payload to a generic worker payload: %v", err))
-	}
 	taskQueueID := task.Definition.TaskQueueID
 	if taskQueueID == "" {
 		taskQueueID = fmt.Sprintf("%s/%s", task.Definition.ProvisionerID, task.Definition.WorkerType)
@@ -36,7 +31,20 @@ func (task *TaskRun) convertDockerWorkerPayload() *CommandExecutionError {
 	if taskQueueID == "" {
 		return executionError(malformedPayload, errored, fmt.Errorf("taskQueueId ('provisionerId/workerType') is required"))
 	}
-	task.Definition.Scopes = d2g.Scopes(task.Definition.Scopes, dwPayload, taskQueueID, config.ContainerEngine)
+
+	// Validate that the required docker worker scopes
+	// are present for the given docker worker payload
+	// and then convert dwScopes to gwScopes
+	task.Definition.Scopes, err = d2g.ConvertScopes(task.Definition.Scopes, dwPayload, taskQueueID, config.ContainerEngine, serviceFactory.Auth(config.Credentials(), config.RootURL))
+	if err != nil {
+		return MalformedPayloadError(err)
+	}
+
+	// Convert dwPayload to gwPayload
+	gwPayload, err := d2g.ConvertPayload(dwPayload, config.ContainerEngine)
+	if err != nil {
+		return executionError(internalError, errored, fmt.Errorf("failed to convert docker worker payload to a generic worker payload: %v", err))
+	}
 
 	// Convert gwPayload to JSON
 	d2gConvertedPayloadJSON, err := json.MarshalIndent(*gwPayload, "", "  ")

--- a/workers/generic-worker/sentry.go
+++ b/workers/generic-worker/sentry.go
@@ -11,8 +11,8 @@ func ReportCrashToSentry(r interface{}) {
 		log.Println("No sentry project defined, not reporting to sentry")
 		return
 	}
-	Auth := serviceFactory.Auth(config.Credentials(), config.RootURL)
-	res, err := Auth.SentryDSN(config.SentryProject)
+	auth := serviceFactory.Auth(config.Credentials(), config.RootURL)
+	res, err := auth.SentryDSN(config.SentryProject)
 	if err != nil {
 		log.Printf("WARNING: Could not get sentry DSN: %v", err)
 		return


### PR DESCRIPTION
>D2G: Renamed methods `Convert()` --> `ConvertPayload()` and `Scopes()` --> `ConvertScopes()`.
>
>D2G: `ConvertScopes()` checks that the provided docker worker payload is valid with the supplied scopes. Generic Worker will now resolve a docker worker task as `exception/malformed-payload` if any required docker worker scopes are missing for its payload.