### PR TITLE
Port over the minimal code for the Task Profiler implementation

### DIFF
--- a/ui/src/components/Profiler/index.js
+++ b/ui/src/components/Profiler/index.js
@@ -1,0 +1,499 @@
+// @ts-check
+
+/**
+ * This file contains the main logic code for converting Taskcluster data structures
+ * into Firefox Profiler data structures.
+ */
+
+import {
+  asAny,
+  encodeUintArrayForUrlComponent,
+  getServer,
+  log,
+} from "./utils.js";
+import {
+  getEmptyProfile,
+  getEmptyThread,
+  UniqueStringArray,
+  getProfile,
+} from "./profiler.js";
+import { getTasks } from "./taskcluster.js";
+
+/**
+ * @typedef {import("./types").Task} Task
+ * @typedef {import('./profiler.js').Profile} Profile
+ */
+
+// TODO - Figure out how to configure preferences in the new Taskcluster UI.
+log("Override the profiler origin with window.profilerOrigin");
+asAny(window).profilerOrigin = "https://profiler.firefox.com";
+
+/**
+ * @typedef {Object} LogRow
+ *
+ * @prop {string} component
+ * @prop {Date} time
+ * @prop {string} message
+ */
+
+/**
+ * Parses log lines and returns an array of LogRow objects.
+ *
+ * @param {string[]} lines - The log lines to parse.
+ * @returns {LogRow[]} The parsed log rows.
+ */
+function readLogFile(lines) {
+  const logPattern =
+    /^\s*\[(?<component>\w+)(:(?<logLevel>\w+))?\s*(?<time>[\d\-T:.Z]+)\]\s*(?<message>.*)/;
+  // ^\s*                                                                                     Skip any beginning whitespace.
+  //     \[                                                            \]                     "[taskcluster:warn 2024-05-20T14:40:11.353Z]"
+  //       (?<component>\w+)                                                                  Capture the component name, here "taskcluster"
+  //                        (:(?<logLevel>\w+))?                                              An optional log level, like "warn"
+  //                                            \s*                                           Ignore whitespace
+  //                                               (?<time>[\d\-T:.Z]+)                       Capture the timestamp
+  //                                                                     \s*                  Ignore whitespace
+  //                                                                        (?<message>.*)    Capture the rest as the message
+
+  /** @type {LogRow[]} */
+  const logRows = [];
+
+  // Find the first time.
+  let time;
+  for (const line of lines) {
+    const match = line.match(logPattern);
+    if (match && match.groups) {
+      time = new Date(match.groups.time);
+      break;
+    }
+  }
+  if (!time) {
+    throw new Error("Could not find a time in the log rows");
+  }
+
+  for (const line of lines) {
+    if (!line.trim()) {
+      continue;
+    }
+
+    const match = line.match(logPattern);
+    if (match && match.groups) {
+      time = new Date(match.groups.time);
+      logRows.push({
+        component: match.groups.component,
+        time,
+        message: match.groups.message,
+      });
+    } else {
+      logRows.push({
+        component: "no timestamp",
+        time,
+        message: line,
+      });
+    }
+  }
+
+  return logRows;
+}
+
+/**
+ * Removes any extra datetimes from the log messages.
+ *
+ * @param {LogRow[]} logRows - The log rows to process.
+ * @returns {LogRow[]} The modified log rows.
+ */
+function fixupLogRows(logRows) {
+  //  Remove any extra datetimes.
+  //  "[2024-05-20 15:04:26] Ep. 1 : Up. 12 : Sen. 24,225 : ..."
+  //   ^^^^^^^^^^^^^^^^^^^^^
+
+  const regex = /^\s*\[[\d\-T:.Z]\]\s*/;
+
+  for (const logRow of logRows) {
+    // Remove the date-time part from the log string
+    logRow.message = logRow.message.replace(regex, "");
+  }
+
+  return logRows;
+}
+
+/**
+ * Colors are listed here:
+ * https://github.com/firefox-devtools/profiler/blob/ffe2b6af0fbf4f91a389cc31fd7df776bb198034/src/utils/colors.js#L96
+ */
+function getCategories() {
+  return [
+    {
+      name: "none",
+      color: "grey",
+      subcategories: ["Other"],
+    },
+    {
+      name: "fetches",
+      color: "purple",
+      subcategories: ["Other"],
+    },
+    {
+      name: "vcs",
+      color: "orange",
+      subcategories: ["Other"],
+    },
+    {
+      name: "setup",
+      color: "lightblue",
+      subcategories: ["Other"],
+    },
+    {
+      name: "taskcluster",
+      color: "green",
+      subcategories: ["Other"],
+    },
+    {
+      name: "Task",
+      color: "lightblue",
+      subcategories: ["Other"],
+    },
+    {
+      name: "Log",
+      color: "green",
+      subcategories: ["Other"],
+    },
+  ];
+}
+
+/**
+ * This is documented in the profiler:
+ * Markers: https://github.com/firefox-devtools/profiler/src/types/markers.js
+ * Schema: https://github.com/firefox-devtools/profiler/blob/df32b2d320cb4c9bc7b4ee988a291afa33daff71/src/types/markers.js#L100
+ */
+function getLiveLogRowSchema() {
+  return {
+    name: "LiveLogRow",
+    tooltipLabel: "{marker.data.message}",
+    tableLabel: "{marker.data.message}",
+    chartLabel: "{marker.data.message}",
+    display: ["marker-chart", "marker-table", "timeline-overview"],
+    data: [
+      {
+        key: "startTime",
+        label: "Start time",
+        format: "string",
+      },
+      {
+        key: "message",
+        label: "Log Message",
+        format: "string",
+        searchable: true,
+      },
+      {
+        key: "hour",
+        label: "Hour",
+        format: "string",
+      },
+      {
+        key: "date",
+        label: "Date",
+        format: "string",
+      },
+      {
+        key: "time",
+        label: "Time",
+        format: "time",
+      },
+    ],
+  };
+}
+
+function getTaskSchema() {
+  return {
+    name: "Task",
+    tooltipLabel: "{marker.data.taskName}",
+    tableLabel: "{marker.data.taskName}",
+    chartLabel: "{marker.data.taskName}",
+    display: ["marker-chart", "marker-table", "timeline-overview"],
+    data: [
+      {
+        key: "startTime",
+        label: "Start time",
+        format: "string",
+      },
+      {
+        key: "taskName",
+        label: "Task Name",
+        format: "string",
+        searchable: true,
+      },
+      {
+        key: "time",
+        label: "Time",
+        format: "time",
+      },
+      {
+        key: "taskURL",
+        label: "Task",
+        format: "url",
+      },
+      {
+        key: "taskGroupURL",
+        label: "Task Group",
+        format: "url",
+      },
+
+      {
+        key: "taskId",
+        label: "Task ID",
+        format: "string",
+      },
+      {
+        key: "taskGroupId",
+        label: "Task Group ID",
+        format: "string",
+      },
+      {
+        key: "taskGroupProfile",
+        label: "Task Group Profile",
+        format: "url",
+      },
+    ],
+  };
+}
+
+/**
+ * Builds a profile from the provided log rows.
+ *
+ * @param {LogRow[]} logRows - The log rows to process.
+ * @param {Task} task
+ * @param {string} taskId
+ * @returns {Profile} The generated profile.
+ */
+function buildProfileFromLogRows(logRows, task, taskId) {
+  const profile = getEmptyProfile();
+  profile.meta.markerSchema = [getLiveLogRowSchema(), getTaskSchema()];
+  profile.meta.categories = getCategories();
+
+  const date = new Date(task.created).toLocaleDateString();
+
+  profile.meta.product = `${task.metadata.name} ${taskId} - ${date}`;
+
+  // Compute and save the profile start time.
+  let profileStartTime = Infinity;
+  let lastLogRowTime = 0;
+  for (const logRow of logRows) {
+    if (logRow.time) {
+      profileStartTime = Math.min(profileStartTime, Number(logRow.time));
+      lastLogRowTime = Math.max(lastLogRowTime, Number(logRow.time));
+    }
+  }
+  profile.meta.startTime = profileStartTime;
+
+  // Create the thread that we'll attach the markers to.
+  const thread = getEmptyThread();
+  thread.name = "Live Log";
+  profile.threads.push(thread);
+  thread.isMainThread = true;
+  const markers = thread.markers;
+
+  // Map a category name to its index.
+
+  /** @type {Record<string, number>} */
+  const categoryIndexDict = {};
+  profile.meta.categories.forEach((category, index) => {
+    categoryIndexDict[category.name] = index;
+  });
+
+  const stringArray = new UniqueStringArray();
+
+  {
+    // Add the task.
+    const durationMarker = 1;
+    markers.startTime.push(0);
+    markers.endTime.push(lastLogRowTime - profileStartTime);
+    markers.phase.push(durationMarker);
+
+    markers.category.push(categoryIndexDict["Task"] ?? 0);
+    markers.name.push(stringArray.indexForString(task.metadata.name));
+
+    markers.data.push({
+      type: "Task",
+      name: "Task",
+      taskName: task.metadata.name,
+      taskGroupURL: `${getServer()}/tasks/groups/${task.taskGroupId}`,
+      taskURL: `${getServer()}/tasks/${taskId}`,
+      // TODO - This needs a new special URL.
+      taskGroupProfile: `https://gregtatum.github.io/taskcluster-tools/src/taskprofiler/?taskGroupId=${task.taskGroupId}`,
+    });
+    markers.length += 1;
+  }
+
+  for (const logRow of logRows) {
+    const runStart = Number(logRow.time);
+    const instantMarker = 0;
+    markers.startTime.push(runStart - profileStartTime);
+    markers.endTime.push(null);
+    markers.phase.push(instantMarker);
+    markers.category.push(categoryIndexDict["Log"] || 0);
+    markers.name.push(stringArray.indexForString(logRow.component));
+
+    markers.data.push({
+      type: "LiveLogRow",
+      name: "LiveLogRow",
+      message: logRow.message,
+      hour: logRow.time.toISOString().substr(11, 8),
+      date: logRow.time.toISOString().substr(0, 10),
+    });
+    markers.length += 1;
+  }
+
+  thread.stringArray = stringArray.serializeToArray();
+
+  return profile;
+}
+
+/**
+ * Fetches log rows from the specified TaskCluster URL.
+ *
+ * @param {string} taskId - The Task ID to fetch logs for.
+ * @param {Task} task
+ * @returns {Promise<Profile>} A promise that resolves to an array of LogRow objects.
+ */
+async function fetchLogsAndBuildProfile(taskId, task) {
+  const url = `https://firefoxci.taskcluster-artifacts.net/${taskId}/0/public/logs/live_backing.log`;
+  const response = await fetch(url);
+
+  if (!response.ok) {
+    throw new Error(`HTTP error! Status: ${response.status}`);
+  }
+
+  const logText = await response.text();
+  const logLines = logText.split("\n");
+  log("Log text", { logText });
+
+  const logRows = readLogFile(logLines);
+  fixupLogRows(logRows);
+
+  log("Log rows", { logRows });
+  return buildProfileFromLogRows(logRows, task, taskId);
+}
+
+/**
+ * @param {string} message
+ */
+function updateStatusMessage(message) {
+  // TODO - Needs a Taskcluster UI implementation
+}
+
+/**
+ * Uses window.postMessage to inject the profile into profiler.firefox.com.
+ *
+ * See: https://github.com/firefox-devtools/profiler/blob/e51f64485f85091e5c3f5fc692e69068b3324fbd/docs-developer/loading-in-profiles.md#from-a-windowpostmessage
+ *
+ * @param {Profile} profile
+ * @param {string} params
+ */
+async function injectProfile(profile, params = "") {
+  const { profilerOrigin } = asAny(window);
+
+  const profilerURL = profilerOrigin + "/from-post-message/" + params;
+
+  const profilerWindow = window.open(profilerURL, "_blank");
+
+  if (!profilerWindow) {
+    console.error("Failed to open the new window.");
+    return;
+  }
+
+  // Wait for the profiler page to respond that it is ready.
+  let isReady = false;
+
+  /**
+   * @param {MessageEvent} event
+   */
+  const listener = ({ data }) => {
+    if (data?.name === "ready:response") {
+      log("The profiler is ready. Injecting the profile.");
+      isReady = true;
+      const message = {
+        name: "inject-profile",
+        profile,
+      };
+      profilerWindow.postMessage(message, profilerOrigin);
+      window.removeEventListener("message", listener);
+    }
+  };
+
+  window.addEventListener("message", listener);
+  while (!isReady) {
+    await new Promise((resolve) => setTimeout(resolve, 100));
+    profilerWindow.postMessage({ name: "ready:request" }, profilerOrigin);
+  }
+
+  window.removeEventListener("message", listener);
+}
+
+/**
+ * @param {string} taskId
+ */
+async function getProfileFromTaskId(taskId) {
+  updateStatusMessage("Fetching the logs…");
+  try {
+    const taskUrl = `${getServer()}/api/queue/v1/task/${taskId}`;
+    const response = await fetch(taskUrl);
+    /** @type {Task} */
+    const task = await response.json();
+    if (!response.ok) {
+      console.error(task);
+      return;
+    }
+    log("Task", task);
+
+    const profile = await fetchLogsAndBuildProfile(taskId, task);
+
+    log("Profile", profile);
+
+    await injectProfile(profile);
+    updateStatusMessage(`Profile for task "${taskId}" was opened.`);
+  } catch (error) {
+    console.error(error);
+    updateStatusMessage("There was an error, see the console for more details");
+  }
+}
+
+/**
+ * @param {string} taskGroupId
+ */
+async function getProfileFromTaskGroup(taskGroupId) {
+  try {
+    updateStatusMessage("Loading tasks");
+
+    // TODO - This may need UI surfacing.
+    const fetchDependentTasks = false;
+
+    const result = await getTasks(
+      [taskGroupId],
+      getServer(),
+      /* fetch dep tasks */ fetchDependentTasks,
+      updateStatusMessage
+    );
+
+    log("Fetched TaskGroups", result);
+
+    if (!result) {
+      // TODO - If there is no result, report this in the UI.
+      return;
+    }
+
+    const { taskGroups } = result;
+    const profile = getProfile(taskGroups, new URL(getServer()));
+
+    const threadSelection = encodeUintArrayForUrlComponent(
+      profile.threads.map((_thread, i) => i)
+    );
+
+    // By default select all the threads.
+    const params = `?thread=${threadSelection}`;
+    await injectProfile(profile, params);
+    updateStatusMessage(`Profile for task group "${taskGroupId}" was opened.`);
+  } catch (error) {
+    console.error(error);
+    updateStatusMessage("There was an error, see the console for more details");
+  }
+}

--- a/ui/src/components/Profiler/profiler.js
+++ b/ui/src/components/Profiler/profiler.js
@@ -1,0 +1,618 @@
+// @ts-check
+
+/**
+ * This file contains functions specific to the Firefox Profiler and the creation of
+ * profiles.
+ */
+
+/**
+ * @typedef {ReturnType<getEmptyThread>} Thread
+ * @typedef {number} IndexIntoStringTable
+ * @typedef {import("./types").TaskGroup} TaskGroup
+ * @typedef {ReturnType<getEmptyProfile>} Profile
+ */
+
+import { getTaskGroupTimeRanges } from "./taskcluster";
+import { log } from "./utils";
+
+/**
+ * Returns an empty thread for the profiler.
+ * See: https://github.com/firefox-devtools/profiler/blob/c60370e8c34c14b773d68959622f82bdcf1701ff/src/types/profile.js#L619
+ */
+export function getEmptyThread() {
+  return {
+    processType: "default",
+    processName: "Taskcluster",
+    processStartupTime: 0,
+    /** @type {number | null} */
+    processShutdownTime: null,
+    registerTime: 0,
+    /**
+     * @type {null | number}
+     */
+    unregisterTime: null,
+    pausedRanges: [],
+    name: "",
+    isMainThread: false,
+    showMarkersInTimeline: true,
+    pid: 0,
+    tid: 0,
+    samples: {
+      weightType: "samples",
+      weight: null,
+      /** @type {number[]} */
+      stack: [],
+      /** @type {number[]} */
+      time: [],
+      length: 0,
+    },
+    markers: {
+      /** @type {Object[]} */
+      data: [],
+
+      /**
+       * Index into the string table.
+       * @type {number[]}
+       */
+      name: [],
+
+      /** @type {Array<number | null>} */
+      startTime: [],
+
+      /** @type {Array<number | null>} */
+      endTime: [],
+
+      /**
+       *  enum class MarkerPhase : int {
+       *    Instant = 0,
+       *    Interval = 1,
+       *    IntervalStart = 2,
+       *    IntervalEnd = 3,
+       *  };
+       *
+       * @type {Array<0 | 1 | 2 | 3>}
+       */
+      phase: [],
+
+      /**
+       * IndexIntoCategoryList
+       * @type {number[]}
+       */
+      category: [],
+
+      length: 0,
+    },
+    stackTable: {
+      frame: [0],
+      prefix: [null],
+      category: [0],
+      subcategory: [0],
+      length: 1,
+    },
+    frameTable: {
+      address: [-1],
+      inlineDepth: [0],
+      category: [null],
+      subcategory: [0],
+      func: [0],
+      nativeSymbol: [null],
+      innerWindowID: [0],
+      implementation: [null],
+      line: [null],
+      column: [null],
+      length: 1,
+    },
+    funcTable: {
+      isJS: [false],
+      relevantForJS: [false],
+      name: [0],
+      resource: [-1],
+      fileName: [null],
+      lineNumber: [null],
+      columnNumber: [null],
+      length: 1,
+    },
+    resourceTable: {
+      lib: [],
+      name: [],
+      host: [],
+      type: [],
+      length: 0,
+    },
+    nativeSymbols: {
+      libIndex: [],
+      address: [],
+      name: [],
+      functionSize: [],
+      length: 0,
+    },
+
+    /** @type {string[]} */
+    stringArray: [],
+  };
+}
+
+/**
+ * This is documented:
+ *  Markers: https://github.com/firefox-devtools/profiler/src/types/markers.js
+ *  Schema: https://github.com/firefox-devtools/profiler/blob/df32b2d320cb4c9bc7b4ee988a291afa33daff71/src/types/markers.js#L100
+ */
+function getTaskSchema() {
+  return {
+    name: "Task",
+    tooltipLabel: "{marker.data.name}",
+    tableLabel: "{marker.data.name}",
+    chartLabel: "{marker.data.name}",
+    display: ["marker-chart", "marker-table", "timeline-overview"],
+    data: [
+      {
+        key: "startTime",
+        label: "Start time",
+        format: "string",
+      },
+      {
+        key: "name",
+        label: "Task Name",
+        format: "string",
+        searchable: true,
+      },
+      {
+        key: "taskId",
+        label: "Task ID",
+        format: "string",
+      },
+      {
+        key: "owner",
+        label: "Owner",
+        format: "string",
+      },
+      {
+        key: "retries",
+        label: "Retries",
+        format: "string",
+      },
+      {
+        key: "state",
+        label: "State",
+        format: "string",
+      },
+      {
+        key: "reasonCreated",
+        label: "Reason Created",
+        format: "string",
+      },
+      {
+        key: "reasonResolved",
+        label: "Reason Resolved",
+        format: "string",
+      },
+      {
+        key: "description",
+        label: "Description",
+        format: "string",
+      },
+
+      // URLs:
+      {
+        key: "taskURL",
+        label: "Task URL",
+        format: "url",
+      },
+      {
+        key: "source",
+        label: "Source URL",
+        format: "url",
+      },
+      {
+        key: "taskGroup",
+        label: "Task Group URL",
+        format: "url",
+      },
+      {
+        key: "liveLog",
+        label: "Live Log",
+        format: "url",
+      },
+      {
+        key: "taskProfile",
+        label: "Task Profile",
+        format: "url",
+      },
+    ],
+  };
+}
+
+function getTaskGroupSchema() {
+  return {
+    name: "TaskGroup",
+    tooltipLabel: "{marker.data.name}",
+    tableLabel: "{marker.data.name}",
+    chartLabel: "{marker.data.name}",
+    display: ["marker-chart", "marker-table", "timeline-overview"],
+    data: [
+      {
+        key: "startTime",
+        label: "Start time",
+        format: "string",
+      },
+      {
+        key: "name",
+        label: "Task Group ID",
+        format: "string",
+        searchable: true,
+      },
+      {
+        key: "expires",
+        label: "Expires",
+        format: "string",
+      },
+      {
+        key: "tasks",
+        label: "Tasks",
+        format: "integer",
+      },
+      {
+        key: "url",
+        label: "URL",
+        format: "url",
+      },
+    ],
+  };
+}
+
+export function getEmptyProfile() {
+  return {
+    meta: {
+      interval: 1,
+      startTime: 0,
+      processType: 0,
+      product: "Taskcluster",
+      stackwalk: 0,
+      version: 27,
+      preprocessedProfileVersion: 47,
+      physicalCPUs: 0,
+      logicalCPUs: 0,
+      symbolicationNotSupported: true,
+      usesOnlyOneStackType: true,
+      markerSchema: [getTaskSchema(), getTaskGroupSchema()],
+      categories: getCategories(),
+    },
+    libs: [],
+    /**
+     * @type {Thread[]}
+     */
+    threads: [],
+    counters: [],
+  };
+}
+
+function getCategories() {
+  return [
+    {
+      name: "Other",
+      color: "grey",
+      subcategories: ["Other"],
+    },
+    {
+      name: "Idle",
+      color: "transparent",
+      subcategories: ["Other"],
+    },
+    {
+      name: "Layout",
+      color: "purple",
+      subcategories: ["Other"],
+    },
+    {
+      name: "JavaScript",
+      color: "yellow",
+      subcategories: ["Other"],
+    },
+    {
+      name: "GC / CC",
+      color: "orange",
+      subcategories: ["Other"],
+    },
+    {
+      name: "Network",
+      color: "lightblue",
+      subcategories: ["Other"],
+    },
+    {
+      name: "Graphics",
+      color: "green",
+      subcategories: ["Other"],
+    },
+    {
+      name: "DOM",
+      color: "blue",
+      subcategories: ["Other"],
+    },
+  ];
+}
+
+/**
+ * This is taken from the profiler.
+ */
+export class UniqueStringArray {
+  /**
+   * @type {string[]}
+   */
+  _array;
+
+  /**
+   * @type {Map<string, IndexIntoStringTable>}
+   */
+  _stringToIndex;
+
+  /**
+   * @param {string[]} originalArray
+   */
+  constructor(originalArray = []) {
+    this._array = originalArray.slice(0);
+    this._stringToIndex = new Map();
+    for (let i = 0; i < originalArray.length; i++) {
+      this._stringToIndex.set(originalArray[i], i);
+    }
+  }
+
+  /**
+   * @param {IndexIntoStringTable} index
+   * @param {string} [els]
+   * @returns {string}
+   */
+  getString(index, els) {
+    if (!this.hasIndex(index)) {
+      if (els) {
+        console.warn(`index ${index} not in UniqueStringArray`);
+        return els;
+      }
+      throw new Error(`index ${index} not in UniqueStringArray`);
+    }
+    return this._array[index];
+  }
+
+  /**
+   * @param {IndexIntoStringTable} i
+   * @returns {boolean}
+   */
+  hasIndex(i) {
+    return i in this._array;
+  }
+
+  /**
+   * @param {string} s
+   * @returns {boolean}
+   */
+  hasString(s) {
+    return this._stringToIndex.has(s);
+  }
+
+  /**
+   * @param {string} s
+   * @returns {IndexIntoStringTable} s
+   */
+  indexForString(s) {
+    let index = this._stringToIndex.get(s);
+    if (index === undefined) {
+      index = this._array.length;
+      this._stringToIndex.set(s, index);
+      this._array.push(s);
+    }
+    return index;
+  }
+
+  /**
+   * @returns {string[]}
+   */
+  serializeToArray() {
+    return this._array.slice(0);
+  }
+}
+
+/**
+ * Creates a Firefox Profile from a list of task groups.
+ *
+ * @param {TaskGroup[]} taskGroups
+ * @param {URL} url
+ * @returns {Profile}
+ */
+export function getProfile(taskGroups, url) {
+  const profile = getEmptyProfile();
+
+  let profileStartTime = Infinity;
+
+  // Compute the start and end of each task group.
+  const taskGroupTimeRanges = getTaskGroupTimeRanges(taskGroups, () => true);
+  const taskGroupTimeRangesNoActions = getTaskGroupTimeRanges(
+    taskGroups,
+    ({ task }) => !task.metadata.name.startsWith("Action:")
+  );
+
+  for (const { start } of taskGroupTimeRanges) {
+    if (start !== null) {
+      profileStartTime = Math.min(profileStartTime, start);
+    }
+  }
+  if (profileStartTime === Infinity) {
+    // No start time was determined, as there were no runs yet with a start time.
+    profileStartTime = 0;
+  }
+
+  {
+    const ids = taskGroups.map((taskGroup) => taskGroup.taskGroupId).join(", ");
+    const date = new Date(profileStartTime).toLocaleDateString();
+    profile.meta.product = `Task Group ${ids} - ${date}`;
+  }
+
+  profile.meta.startTime = profileStartTime;
+
+  // These should be unique per thread.
+  let tid = 0;
+  let pid = 0;
+
+  // Create a "thread" for every task group.
+  profile.threads = taskGroups.map((taskGroup, i) => {
+    const stringArray = new UniqueStringArray();
+    const taskGroupTimeRange = taskGroupTimeRanges[i];
+    const taskGroupTimeRangeNoActions = taskGroupTimeRangesNoActions[i];
+
+    // Sort of the tasks by their start time.
+    const sortedTasks = taskGroup.tasks.map((task) => {
+      const { runs } = task.status;
+      if (!runs || !runs.length || !runs[0].started) {
+        return { task, start: null };
+      }
+      return {
+        task,
+        start: new Date(runs[0].started).valueOf(),
+      };
+    });
+
+    sortedTasks.sort((ta, tb) => {
+      if (!ta.start) {
+        return -1;
+      }
+      if (!tb.start) {
+        return 1;
+      }
+      return ta.start - tb.start;
+    });
+
+    const thread = getEmptyThread();
+    profile.threads.push(thread);
+    thread.isMainThread = true;
+    thread.name = taskGroup.taskGroupId;
+    thread.tid = tid++;
+    thread.pid = pid++;
+    const markers = thread.markers;
+
+    if (taskGroupTimeRange.start !== null) {
+      thread.registerTime = taskGroupTimeRange.start - profileStartTime;
+    } else {
+      // Fake an empty thread by register and unregistering it outside the time range.
+      thread.registerTime = -1;
+      thread.unregisterTime = -1;
+    }
+    if (taskGroupTimeRange.end !== null) {
+      thread.unregisterTime = taskGroupTimeRange.end - profileStartTime;
+    }
+
+    for (const { timeRange, markerName } of [
+      { timeRange: taskGroupTimeRange, markerName: "TaskGroup" },
+      {
+        timeRange: taskGroupTimeRangeNoActions,
+        markerName: "TaskGroup (no actions)",
+      },
+    ]) {
+      if (timeRange.start) {
+        const runStart = timeRange.start;
+        let runEnd = timeRange.end;
+        const durationMarker = 1;
+        const instantMarker = 2;
+        markers.startTime.push(runStart - profileStartTime);
+        if (runEnd === null) {
+          markers.endTime.push(null);
+          markers.phase.push(instantMarker);
+        } else {
+          markers.endTime.push(runEnd - profileStartTime);
+          markers.phase.push(durationMarker);
+        }
+
+        markers.category.push(5);
+        markers.name.push(stringArray.indexForString(markerName));
+
+        markers.data.push({
+          type: "TaskGroup",
+          startTime: new Date(
+            profile.meta.startTime + profileStartTime
+          ).toLocaleTimeString(),
+          name: taskGroup.taskGroupId,
+          expires: taskGroup.expires,
+          url: `https://${url.host}/tasks/groups/${taskGroup.taskGroupId}`,
+        });
+
+        markers.length++;
+      }
+    }
+
+    // Add the tasks as markers.
+    if (taskGroupTimeRange.start !== null) {
+      for (const { task } of sortedTasks) {
+        if (!task.status.runs) {
+          continue;
+        }
+        for (const run of task.status.runs) {
+          const runStart = run.started ? new Date(run.started).valueOf() : null;
+          let runEnd = run.resolved ? new Date(run.resolved).valueOf() : null;
+          if (run.state === "running" && runEnd === null) {
+            runEnd = Date.now();
+          }
+          const durationMarker = 1;
+          const instantMarker = 2;
+          if (runStart === null) {
+            // There is nothing to graph here.
+            continue;
+          } else {
+            markers.startTime.push(runStart - profileStartTime);
+          }
+          if (runEnd === null) {
+            markers.endTime.push(null);
+            markers.phase.push(instantMarker);
+          } else {
+            markers.endTime.push(runEnd - profileStartTime);
+            markers.phase.push(durationMarker);
+          }
+
+          markers.category.push(5);
+          const grouping = run.reasonResolved ?? run.state;
+          markers.name.push(
+            stringArray.indexForString(
+              run.state === "completed" ? "Task" : `Task (${grouping})`
+            )
+          );
+
+          const taskName = task.task.metadata.name;
+          const retries = task.task.retries;
+          const runId = run.runId;
+          const taskId = task.status.taskId;
+          const name =
+            run.state === "completed" && run.runId === 0 && retries > 1
+              ? taskName
+              : `${taskName} (run ${runId + 1}/${retries})`;
+
+          markers.data.push({
+            type: "Task",
+            startTime: new Date(
+              profile.meta.startTime + profileStartTime
+            ).toLocaleTimeString(),
+            name,
+            taskId,
+            owner: task.task.metadata.owner,
+            description: task.task.metadata.description,
+            source: task.task.metadata.source,
+            retries: `${runId + 1} / ${retries}`,
+            state: run.state,
+            reasonCreated: run.reasonCreated,
+            reasonResolved: run.reasonResolved,
+            taskURL: `https://${url.host}/tasks/${taskId}/runs/${runId}`,
+            taskGroup: `https://${url.host}/tasks/groups/${task.task.taskGroupId}`,
+            liveLog: `https://${url.host}/tasks/${taskId}/runs/${runId}/logs/live/public/logs/live.log`,
+            taskProfile: `https://gregtatum.github.io/taskcluster-tools/src/taskprofiler/?taskId=${taskId}`,
+          });
+
+          markers.length++;
+        }
+      }
+    }
+
+    thread.stringArray = stringArray.serializeToArray();
+
+    return thread;
+  });
+
+  profile.threads.sort((a, b) => a.registerTime - b.registerTime);
+
+  log("Generated profile:", profile);
+  return profile;
+}

--- a/ui/src/components/Profiler/taskcluster.js
+++ b/ui/src/components/Profiler/taskcluster.js
@@ -1,0 +1,309 @@
+// @ts-check
+
+/**
+ * This file contains functions specific to querying and working with Taskcluster APIs
+ * TODO - This will most likely be migrated to other internal calls.
+ */
+
+/**
+ * @typedef {import("./types").TaskAndStatus} TaskAndStatus
+ * @typedef {import("./types").TaskGroup} TaskGroup
+ * @typedef {import("./types").Task} Task
+ * @typedef {import("./types").TimeRange} TimeRange
+ */
+
+import { log } from "./utils";
+
+/**
+ * @param {string} id
+ */
+export function isTaskGroupIdValid(id) {
+  return id.match(/^[a-zA-Z0-9_-]+$/);
+}
+
+/**
+ * @param {string} server
+ * @param {string} taskGroupId
+ * @param {(message: string) => void} updateStatusMessage
+ * @return {Promise<TaskGroup>}
+ */
+export async function fetchTaskGroup(server, taskGroupId, updateStatusMessage) {
+  const listUrl = `${server}/api/queue/v1/task-group/${taskGroupId}/list`;
+  updateStatusMessage(`Fetching Task Group ${taskGroupId}`);
+  log("Fetching Task Group:", listUrl);
+  const response = await fetch(listUrl);
+
+  if (!response.ok) {
+    response.json().then((json) => console.error(json));
+    return Promise.reject("Could not fetch task.");
+  }
+
+  /** @type {TaskGroup} */
+  const taskGroup = await response.json();
+  /** @type {TaskGroup} */
+  let nextTaskGroup = taskGroup;
+
+  // This API is paginated, continue through it.
+  const maxPages = 20;
+  for (let page = 0; page < maxPages; page++) {
+    if (!nextTaskGroup.continuationToken) {
+      // There are no more continuations.
+      break;
+    }
+    updateStatusMessage(
+      `Fetching Task Group ${taskGroupId} (page ${page + 2})`
+    );
+    const continuationUrl =
+      listUrl + "?continuationToken=" + nextTaskGroup.continuationToken;
+    log("Fetching next tasks for Task Group", continuationUrl);
+    const response = await fetch(continuationUrl);
+    if (!response.ok) {
+      console.error("Failed to fetch a TaskGroup task continuation");
+      break;
+    }
+    nextTaskGroup = await response.json();
+    taskGroup.tasks = [...taskGroup.tasks, ...nextTaskGroup.tasks];
+  }
+
+  return taskGroup;
+}
+
+/**
+ * TODO - Determine if fetchDependentTasks should be retained and surfaced in the new Taskcluster UI
+ *
+ * @param {string[]} taskGroupIds
+ * @param {string} server
+ * @param {boolean} fetchDependentTasks
+ * @param {(message: string) => void} updateStatusMessage
+ * @returns {Promise<{ mergedTasks: TaskAndStatus[], taskGroups: TaskGroup[]} | null>}
+ */
+export async function getTasks(
+  taskGroupIds,
+  server,
+  fetchDependentTasks,
+  updateStatusMessage
+) {
+  if (!taskGroupIds.length) {
+    return null;
+  }
+
+  // Validate the taskGroupIds
+  if (
+    taskGroupIds.length &&
+    taskGroupIds.some((id) => !isTaskGroupIdValid(id))
+  ) {
+    const p = document.createElement("p");
+    p.innerText =
+      "A task group id was not valid, " + JSON.stringify(taskGroupIds);
+    document.body.appendChild(p);
+    throw new Error(p.innerText);
+  }
+
+  log("Using the following taskGroupIds", taskGroupIds);
+
+  /** @type {Array<Promise<TaskGroup>>} */
+  const taskGroupPromises = taskGroupIds.map((id) =>
+    fetchTaskGroup(server, id, updateStatusMessage)
+  );
+
+  let taskGroups = await Promise.all(taskGroupPromises);
+
+  // Find out what task groups we are missing.
+  /** @type {Set<string>} */
+  const knownTaskIds = new Set();
+  /** @type {Set<string>} */
+  const dependencies = new Set();
+  for (const { tasks } of taskGroups) {
+    for (const { task, status } of tasks) {
+      knownTaskIds.add(status.taskId);
+      for (const id of task.dependencies) {
+        dependencies.add(id);
+      }
+    }
+  }
+
+  const taskGroupIdsFetched = new Set(taskGroupIds);
+  const taskToGroup = getTaskToGroup();
+
+  let count = 0;
+  // TODO - This should be surfaced in the UI.
+  const maxCount = 15;
+  // Load in the dependency groups.
+  for (const taskId of dependencies) {
+    if (!fetchDependentTasks) {
+      break;
+    }
+    if (knownTaskIds.has(taskId)) {
+      continue;
+    }
+    // Mark this one as searched.
+    knownTaskIds.add(taskId);
+
+    const taskUrl = `${server}/api/queue/v1/task/${taskId}`;
+    try {
+      let taskGroupId = taskToGroup[taskId];
+      if (!taskGroupId) {
+        updateStatusMessage("Fetching dependent task groups.");
+        log("Fetching Task for its Task Group ID:", taskUrl);
+        const response = await fetch(taskUrl);
+        const json = await response.json();
+        if (!response.ok) {
+          console.error(json);
+          continue;
+        }
+
+        taskGroupId = /** @type {Task} */ (json).taskGroupId;
+        setTaskToGroup(taskToGroup, taskId, taskGroupId);
+      }
+      if (taskGroupIdsFetched.has(taskGroupId)) {
+        continue;
+      }
+      updateStatusMessage("Fetching dependent task groups.");
+      taskGroupIdsFetched.add(taskGroupId);
+      const listUrl = `${server}/api/queue/v1/task-group/${taskGroupId}/list`;
+      log("Fetching TaskGroup", listUrl);
+      const response = await fetch(listUrl);
+      const json = await response.json();
+
+      if (!response.ok) {
+        console.error(json);
+        continue;
+      }
+      /** @type {TaskGroup} */
+      const taskGroup = json;
+
+      // Hold on to this new task group.
+      taskGroups.push(taskGroup);
+
+      for (const { task, status } of taskGroup.tasks) {
+        knownTaskIds.add(status.taskId);
+        for (const id of task.dependencies) {
+          // Add on the to dependencies. The iterator will continue iterating on all
+          // of the newly discovered dependencies.
+          dependencies.add(id);
+        }
+      }
+
+      count++;
+      if (count > maxCount) {
+        break;
+      }
+    } catch (error) {
+      console.error(error);
+    }
+  }
+
+  // Do a stable sort based on expires.
+  taskGroups.sort(
+    (a, b) => Number(new Date(a.expires)) - Number(new Date(b.expires))
+  );
+
+  // Get all of the tasks into a flat list.
+
+  /** @type {TaskAndStatus[]} */
+  let tasks = [];
+  for (const { tasks: tasksList } of taskGroups) {
+    for (const task of tasksList) {
+      tasks.push(task);
+    }
+  }
+
+  mutateAndRemoveMissingDependencies(tasks);
+
+  mutateAndRemoveMissingDependencies(tasks);
+
+  return { mergedTasks: tasks, taskGroups };
+}
+
+/**
+ * TODO - This should probably be removed from the official Taskcluster implementation.
+ *
+ * From local storage, retain the relationships of task to group. This saves on
+ * some API requests which will not change relationships.
+ *
+ * @returns {Record<string, string>}
+ */
+function getTaskToGroup() {
+  const taskToGroup = localStorage.getItem("taskToGroup");
+  if (!taskToGroup) {
+    return {};
+  }
+  try {
+    return JSON.parse(taskToGroup);
+  } catch (error) {
+    return {};
+  }
+}
+
+/**
+ * TODO - This should probably be removed from the official Taskcluster implementation.
+ *
+ * @param {Record<string, string>} taskToGroup
+ * @param {string} taskId
+ * @param {string} taskGroupId
+ */
+function setTaskToGroup(taskToGroup, taskId, taskGroupId) {
+  taskToGroup[taskId] = taskGroupId;
+  localStorage.setItem("taskToGroup", JSON.stringify(taskToGroup));
+}
+
+/**
+ * @param {TaskAndStatus[]} tasks
+ */
+function mutateAndRemoveMissingDependencies(tasks) {
+  // Figure out which taskIds are actually present.
+  const presentTaskIds = new Set();
+  for (const task of tasks) {
+    const { taskId } = task.status;
+    presentTaskIds.add(taskId);
+  }
+
+  // Remove any dependencies that aren't present.
+  for (const task of tasks) {
+    task.task.dependencies = task.task.dependencies.filter((id) =>
+      presentTaskIds.has(id)
+    );
+  }
+}
+
+/**
+ * @param {TaskGroup[]} taskGroups
+ * @param {(task: TaskAndStatus) => boolean} filterTask
+ * @returns {TimeRange[]}
+ */
+export function getTaskGroupTimeRanges(taskGroups, filterTask = () => true) {
+  return taskGroups.map((taskGroup) => {
+    /** @type {null | number} */
+    let start = null;
+    /** @type {null | number} */
+    let end = null;
+    for (const taskAndStatus of taskGroup.tasks) {
+      const { runs } = taskAndStatus.status;
+      if (runs && filterTask(taskAndStatus)) {
+        for (const run of runs) {
+          // Attempt to parse a Date. The results will be NaN on failure.
+          const startedMS = new Date(
+            run.started ?? run.resolved ?? ""
+          ).valueOf();
+          const resolvedMS = new Date(run.resolved ?? "").valueOf();
+
+          if (!Number.isNaN(startedMS)) {
+            if (start === null) {
+              start = startedMS;
+            } else {
+              start = Math.min(start, startedMS);
+            }
+          }
+          if (!Number.isNaN(resolvedMS)) {
+            if (end === null) {
+              end = resolvedMS;
+            } else {
+              end = Math.max(end, resolvedMS);
+            }
+          }
+        }
+      }
+    }
+    return { start, end };
+  });
+}

--- a/ui/src/components/Profiler/types.ts
+++ b/ui/src/components/Profiler/types.ts
@@ -1,0 +1,99 @@
+interface Run {
+  runId: 0;
+  state: TaskState; // "completed";
+  reasonCreated: string; // "scheduled";
+  reasonResolved: string; // "completed";
+  workerGroup: string; // "built-in";
+  workerId: string; // "succeed";
+  takenUntil: string; // "2023-09-19T20:33:46.188Z";
+  scheduled: string; // "2023-09-19T20:13:45.402Z";
+  started?: string; // "2023-09-19T20:13:46.193Z";
+  resolved?: string; // "2023-09-19T20:13:46.266Z";
+}
+
+export interface Task {
+  provisionerId: string; // "built-in";
+  workerType: string; // "succeed";
+  taskQueueId: string; // "built-in/succeed";
+  schedulerId: string; // "translations-level-1";
+  projectId: string; // "none";
+  taskGroupId: string; // "Fo1npr9eTFqsAj4DFlqBbA";
+  dependencies: string[], // ["CTPPid-iT8WUEzf-j6YKUw", "Fn-77WB6SFKBuQGE62-SMg", ... ]
+  requires: string; // "all-completed";
+  routes: ["checks"];
+  priority: string; // "low";
+  retries: 5;
+  created: string; // "2023-09-19T18:58:07.341Z";
+  deadline: string; // "2023-09-24T18:58:07.341Z";
+  expires: string; // "2023-10-17T18:58:07.341Z";
+  scopes: string[]; // ["generic-worker:cache:translations-level-3-checkouts"]
+  payload: {
+    // This was all the same for translations.
+    artifacts: [
+      {
+        name: "public/build",
+        path: "artifacts",
+        type: "directory"
+      }
+    ],
+    // The command comes in the form of an array, e.g. ["echo", "hello"]
+    command: Array<string[]>
+  };
+  metadata: {
+    name: string; // "all-ru-en";
+    owner: string; // "eu9ene@users.noreply.github.com";
+    source: string; // "https://github.com/mozilla/firefox-translations-training/blob/773420ae1011f78ef58d375a75c61b65d324aa70/taskcluster/ci/all";
+    description: string; // "Dummy task that ensures all parts of training pipeline will run";
+  };
+  tags: {
+    kind: string; // "all";
+    label?: string; // "all-ru-en";
+    createdForUser: string; // "eu9ene@users.noreply.github.com";
+    "worker-implementation": string; // "succeed";
+  };
+  extra: {
+    index: { rank: 0 };
+    parent: string; // The task's group id "Fo1npr9eTFqsAj4DFlqBbA";
+  };
+}
+
+interface TaskStatus {
+  taskId: string; // "ewZ4vpZbQISjhIPnU3R36g";
+  provisionerId: string; // "built-in";
+  workerType: string; // "succeed";
+  taskQueueId: string; // "built-in/succeed";
+  schedulerId: string; // "translations-level-1";
+  projectId: string; // "none";
+  taskGroupId: string; // "Fo1npr9eTFqsAj4DFlqBbA";
+  deadline: string; // "2023-09-24T18:58:07.341Z";
+  expires: string; // "2023-10-17T18:58:07.341Z";
+  retriesLeft: number;
+  state: TaskState; // "completed";
+  runs?: Run[];
+}
+
+export interface TaskAndStatus {
+  status: TaskStatus;
+  task: Task;
+}
+
+export interface TaskGroup {
+  taskGroupId: string, // "Fo1npr9eTFqsAj4DFlqBbA",
+  schedulerId: string, // "translations-level-1",
+  expires: string,// "2024-09-18T19:57:56.114Z",
+  tasks: TaskAndStatus[],
+  continuationToken?: string
+}
+
+export interface TimeRange {
+  start: number | null;
+  end: number | null;
+}
+
+type TaskState =
+  | "completed"
+  | "running"
+  | "failed"
+  | "exception"
+  | "pending"
+  | "unscheduled"

--- a/ui/src/components/Profiler/utils.js
+++ b/ui/src/components/Profiler/utils.js
@@ -1,0 +1,120 @@
+// @ts-check
+/**
+ * @param {any} any
+ * @returns {any}
+ */
+export function asAny(any) {
+  return any;
+}
+
+// The uint array encoding code is taken from:
+// https://github.com/firefox-devtools/profiler/blob/e51f64485f85091e5c3f5fc692e69068b3324fbd/src/utils/uintarray-encoding.js
+
+const ENCODING_DIGITS =
+  "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ._";
+const LEADING_ZERO_DIGIT = ENCODING_DIGITS[0b100000];
+
+/**
+ * @param {Set<number>} numbers
+ * @returns {string}
+ */
+export function encodeUintSetForUrlComponent(numbers) {
+  // A set has no order. Convert it to an array and then sort the array,
+  // so that consecutive numbers can be detected by encodeUintArrayForUrlComponent.
+  const array = Array.from(numbers);
+  array.sort((a, b) => a - b);
+  return encodeUintArrayForUrlComponent(array);
+}
+
+/**
+ * @param {number[]} numbers
+ * @returns {string}
+ */
+export function encodeUintArrayForUrlComponent(numbers) {
+  let result = "";
+  for (let i = 0; i < numbers.length; i++) {
+    const skipCount = countSkippableConsecutiveNumbersAt(numbers, i);
+    if (skipCount === 0) {
+      result += encodeUint(numbers[i]);
+      continue;
+    }
+
+    i += skipCount;
+
+    // We use the "leading zero digit" as the range marker.
+    result += LEADING_ZERO_DIGIT;
+    result += encodeUint(numbers[i]);
+  }
+  return result;
+}
+
+/**
+ * @param {number[]} numbers
+ * @param {number} start
+ * @returns {number}
+ */
+function countSkippableConsecutiveNumbersAt(numbers, start) {
+  if (start < 1 || start + 1 >= numbers.length) {
+    return 0;
+  }
+  const previous = numbers[start - 1];
+  const current = numbers[start];
+  const next = numbers[start + 1];
+
+  let skipCount = 0;
+  if (current === previous + 1 && next === current + 1) {
+    // Found increasing consecutive range.
+    skipCount = 1;
+    while (
+      start + skipCount + 1 < numbers.length &&
+      numbers[start + skipCount + 1] === current + skipCount + 1
+    ) {
+      skipCount++;
+    }
+  } else if (current === previous - 1 && next === current - 1) {
+    // Found decreasing consecutive range.
+    skipCount = 1;
+    while (
+      start + skipCount + 1 < numbers.length &&
+      numbers[start + skipCount + 1] === current - skipCount - 1
+    ) {
+      skipCount++;
+    }
+  }
+  return skipCount;
+}
+
+/**
+ * @param {number} value
+ * @returns {string}
+ */
+function encodeUint(value) {
+  // Build the string digit by digit, back to front. The last digit has the
+  // continuation bit set to 0, the other digits have it set to 1.
+  // No "leading zero" digits are emitted, so that smaller numbers use fewer
+  // digits, and so that "leading zero" digits can have special meaning.
+  let x = value;
+  let r = ENCODING_DIGITS[x & 0b11111];
+  x >>= 5;
+  while (x !== 0) {
+    r = ENCODING_DIGITS[0b100000 + (x & 0b11111)] + r;
+    x >>= 5;
+  }
+  return r;
+}
+
+/**
+ * TODO - This needs the real server selection.
+ */
+export function getServer() {
+  return "https://firefox-ci-tc.services.mozilla.com";
+}
+
+/**
+ * TODO - Handle logging in the new Taskcluster UI.
+ *
+ * @param {any[]} args
+ */
+export function log(...args) {
+  console.log(...args);
+}

--- a/ui/tsconfig.json
+++ b/ui/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "module": "ESNext",
+    // Make the type checking as strict as possible.
+    "strict": true,
+    // TypeScript will check JS files only if they have a @ts-check comment in them.
+    "allowJs": true,
+    "checkJs": true,
+    // Only type check, don't emit files.
+    "noEmit": true,
+    // Allow esnext syntax. Otherwise the default is ES5 only.
+    "target": "esnext",
+    "lib": ["esnext", "dom"],
+    "esModuleInterop": true
+  },
+  "include": ["./ui/src/components/Profiler/**/*.js"],
+  // "files": [],
+  "exclude": []
+}


### PR DESCRIPTION
This is the initial code needed for converting Taskcluster tasks and live logs into the Firefox Profiler format. It is taken from:

https://github.com/gregtatum/taskcluster-tools

The goal with this PR is not to have a full working piece of code, but to port over the minimal amount of code, and get TypeScript to have no issues with the code. I added TODOs across the code while porting for things that will need to be handled for the real implementation.

Part 2 of #7374.