### PR TITLE
Fix graphql error for claimed/pending

### DIFF
--- a/changelog/issue-7386.md
+++ b/changelog/issue-7386.md
@@ -1,0 +1,6 @@
+audience: users
+level: patch
+reference: issue 7386
+---
+
+Fixes UI issue where "No WorkerPool exists" error was shown in pending/claimed tasks list.

--- a/ui/src/views/Provisioners/ClaimedTasks/index.jsx
+++ b/ui/src/views/Provisioners/ClaimedTasks/index.jsx
@@ -18,6 +18,7 @@ import WorkersNavbar from '../../../components/WorkersNavbar';
 
 @graphql(claimedTasks, {
   options: props => ({
+    errorPolicy: 'all',
     variables: {
       taskQueueId: joinWorkerPoolId(
         props.match.params.provisionerId,
@@ -97,6 +98,9 @@ export default class WMViewClaimedTasks extends Component {
       data: { loading, error, listClaimedTasks, WorkerPool },
     } = this.props;
     const { provisionerId, workerType } = this.props.match.params;
+    // Claimed tasks could exist for the pools that are not managed by w-m
+    // so one of the request would fail with errors
+    const wpMissing = error?.message?.includes('Worker pool does not exist');
 
     return (
       <Dashboard
@@ -131,9 +135,9 @@ export default class WMViewClaimedTasks extends Component {
         </Box>
         {loading && <Spinner loading />}
 
-        {error && <ErrorPanel fixed error={error} />}
+        {error && !wpMissing && <ErrorPanel fixed error={error} />}
 
-        {!error && !loading && (
+        {!loading && listClaimedTasks && (
           <ConnectionDataTable
             noItemsMessage="No claimed tasks"
             connection={listClaimedTasks}

--- a/ui/src/views/Provisioners/PendingTasks/index.jsx
+++ b/ui/src/views/Provisioners/PendingTasks/index.jsx
@@ -19,6 +19,7 @@ import WorkersNavbar from '../../../components/WorkersNavbar';
 
 @graphql(pendingTasks, {
   options: props => ({
+    errorPolicy: 'all',
     variables: {
       taskQueueId: joinWorkerPoolId(
         props.match.params.provisionerId,
@@ -94,6 +95,9 @@ export default class WMViewPendingTasks extends Component {
       data: { loading, error, listPendingTasks, WorkerPool },
     } = this.props;
     const { provisionerId, workerType } = this.props.match.params;
+    // Pending tasks could exist for the pools that are not managed by w-m
+    // so one of the request would fail with errors
+    const wpMissing = error?.message?.includes('Worker pool does not exist');
 
     return (
       <Dashboard
@@ -129,9 +133,9 @@ export default class WMViewPendingTasks extends Component {
 
         {loading && <Spinner loading />}
 
-        {error && <ErrorPanel fixed error={error} />}
+        {error && !wpMissing && <ErrorPanel fixed error={error} />}
 
-        {!error && !loading && (
+        {!loading && listPendingTasks && (
           <ConnectionDataTable
             noItemsMessage="No pending tasks"
             connection={listPendingTasks}


### PR DESCRIPTION
Not all task queues have worker pools associated,
pending and claimed tasks list should still work

Fixes #7386 
