### PR TITLE
notify: add rootUrl to the email link context

### DIFF
--- a/services/notify/src/handler.js
+++ b/services/notify/src/handler.js
@@ -215,7 +215,7 @@ Task [\`${taskId}\`](${href}) in task-group [\`${task.taskGroupId}\`](${groupHre
               : content;
             subject = extra.subject ? this.renderMessage(extra.subject, { task, status, taskId, rootUrl: this.rootUrl })
               : subject;
-            link = extra.link ? jsone(extra.link, { task, status }) : link;
+            link = extra.link ? jsone(extra.link, { task, status, rootUrl: this.rootUrl }) : link;
             template = extra.template ? jsone(extra.template, { task, status }) : template;
           }
           return await this.notifier.email({


### PR DESCRIPTION
In #7311 I added rootUrl to most notification jsone contexts, but missed `link` in emails.  That could be beneficial e.g. for
https://searchfox.org/mozilla-central/rev/234f91a9d3ebef0d514868701cfb022d5f199cb5/taskcluster/kinds/signing-apk/kind.yml#66

<!-- Did you remember to add a changelog snippet? See
     https://github.com/taskcluster/taskcluster/blob/main/dev-docs/best-practices/changelog.md

     If this is related to a Bugzilla bug, please begin your title with [Bug XXXXX]
     and update this link.  Otherwise, just remove it from your PR comment.  -->

Bugzilla Bug: [XXXXX](https://bugzilla.mozilla.org/show_bug.cgi?id=XXXXX)

<!-- If this is related to a GitHub Bug/Issue, Please write Issue Number after # in the next line. Otherwise, just remove it from your PR comment. -->

Github Bug/Issue: Fixes #XXXX
