### PR TITLE
feat(d2g): disable native payloads

### DIFF
--- a/changelog/TLW2aOmER_-7eM2Um6TfEQ.md
+++ b/changelog/TLW2aOmER_-7eM2Um6TfEQ.md
@@ -1,0 +1,6 @@
+audience: worker-deployers
+level: minor
+---
+Generic Worker: adds `disableNativePayloads` (default: `false`) worker config option (`linux` only) to require all task payloads to be Docker Worker payloads. If this option is set to `true`, the task log will no longer contain the translated task definition and the warning about using Docker Worker payloads.
+
+Tasks submitted with native payloads will be resolved as `exception/malformed-payload`.

--- a/changelog/TLW2aOmER_-7eM2Um6TfEQ.md
+++ b/changelog/TLW2aOmER_-7eM2Um6TfEQ.md
@@ -4,3 +4,5 @@ level: minor
 Generic Worker: adds `disableNativePayloads` (default: `false`) worker config option (`linux` only) to require all task payloads to be Docker Worker payloads. If this option is set to `true`, the task log will no longer contain the translated task definition and the warning about using Docker Worker payloads.
 
 Tasks submitted with native payloads will be resolved as `exception/malformed-payload`.
+
+Generic Worker: adds `d2gConfig.logTranslation` (default: `true`) worker config to control whether the D2G-translated task definition is logged to the task logs.

--- a/workers/generic-worker/README.md
+++ b/workers/generic-worker/README.md
@@ -186,6 +186,8 @@ and reports back results to the queue.
                                                 [default: "docker"]
                                               * gpus - The NVIDIA GPUs to make available to the running container.
                                                 Only used if allowGPUs is true. [default: "all"]
+                                              * logTranslation - Logs the D2G-translated task definition to the task logs.
+                                                [default: true]
           enableChainOfTrust                Enables the Chain of Trust feature to be used in the
                                             task payload. [default: true]
           enableLiveLog                     Enables the LiveLog feature to be used in the task

--- a/workers/generic-worker/README.md
+++ b/workers/generic-worker/README.md
@@ -146,6 +146,10 @@ and reports back results to the queue.
                                             different to the worker's current deploymentId, the
                                             worker will shut itself down. See
                                             https://bugzil.la/1298010
+          disableNativePayloads             Disables native Generic Worker payloads. D2G should be
+                                            enabled (d2gConfig.enableD2G) when this is set to true.
+                                            Tasks submitted with native payloads will be resolved
+                                            as exception/malformed-payload. [default: false]
           disableReboots                    If true, no system reboot will be initiated by
                                             generic-worker program, but it will still return
                                             with exit code 67 if the system needs rebooting.

--- a/workers/generic-worker/gwconfig/config_linux.go
+++ b/workers/generic-worker/gwconfig/config_linux.go
@@ -4,6 +4,7 @@ import "testing"
 
 type PublicPlatformConfig struct {
 	D2GConfig                 map[string]interface{} `json:"d2gConfig"`
+	DisableNativePayloads     bool                   `json:"disableNativePayloads"`
 	EnableInteractive         bool                   `json:"enableInteractive"`
 	EnableLoopbackAudio       bool                   `json:"enableLoopbackAudio"`
 	EnableLoopbackVideo       bool                   `json:"enableLoopbackVideo"`
@@ -29,6 +30,7 @@ func DefaultPublicPlatformConfig() *PublicPlatformConfig {
 			"containerEngine":       "docker",
 			"gpus":                  "all",
 		},
+		DisableNativePayloads:     false,
 		EnableInteractive:         true,
 		EnableLoopbackAudio:       true,
 		EnableLoopbackVideo:       true,
@@ -46,4 +48,8 @@ func (c *PublicPlatformConfig) D2GEnabled() bool {
 func (c *PublicPlatformConfig) EnableD2G(t *testing.T) {
 	t.Helper()
 	c.D2GConfig["enableD2G"] = true
+}
+
+func (c *PublicPlatformConfig) NativePayloadsDisabled() bool {
+	return c.DisableNativePayloads
 }

--- a/workers/generic-worker/gwconfig/config_linux.go
+++ b/workers/generic-worker/gwconfig/config_linux.go
@@ -29,6 +29,7 @@ func DefaultPublicPlatformConfig() *PublicPlatformConfig {
 			"allowTaskclusterProxy": true,
 			"containerEngine":       "docker",
 			"gpus":                  "all",
+			"logTranslation":        true,
 		},
 		DisableNativePayloads:     false,
 		EnableInteractive:         true,
@@ -52,4 +53,8 @@ func (c *PublicPlatformConfig) EnableD2G(t *testing.T) {
 
 func (c *PublicPlatformConfig) NativePayloadsDisabled() bool {
 	return c.DisableNativePayloads
+}
+
+func (c *PublicPlatformConfig) LogD2GTranslation() bool {
+	return c.D2GConfig["logTranslation"].(bool)
 }

--- a/workers/generic-worker/gwconfig/config_other.go
+++ b/workers/generic-worker/gwconfig/config_other.go
@@ -27,3 +27,7 @@ func (c *PublicPlatformConfig) EnableD2G(t *testing.T) {
 func (c *PublicPlatformConfig) NativePayloadsDisabled() bool {
 	return false
 }
+
+func (c *PublicPlatformConfig) LogD2GTranslation() bool {
+	return false
+}

--- a/workers/generic-worker/gwconfig/config_other.go
+++ b/workers/generic-worker/gwconfig/config_other.go
@@ -23,3 +23,7 @@ func (c *PublicPlatformConfig) D2GEnabled() bool {
 func (c *PublicPlatformConfig) EnableD2G(t *testing.T) {
 	t.Helper()
 }
+
+func (c *PublicPlatformConfig) NativePayloadsDisabled() bool {
+	return false
+}

--- a/workers/generic-worker/gwconfig/config_windows.go
+++ b/workers/generic-worker/gwconfig/config_windows.go
@@ -27,3 +27,7 @@ func (c *PublicPlatformConfig) EnableD2G(t *testing.T) {
 func (c *PublicPlatformConfig) NativePayloadsDisabled() bool {
 	return false
 }
+
+func (c *PublicPlatformConfig) LogD2GTranslation() bool {
+	return false
+}

--- a/workers/generic-worker/gwconfig/config_windows.go
+++ b/workers/generic-worker/gwconfig/config_windows.go
@@ -23,3 +23,7 @@ func (c *PublicPlatformConfig) D2GEnabled() bool {
 func (c *PublicPlatformConfig) EnableD2G(t *testing.T) {
 	t.Helper()
 }
+
+func (c *PublicPlatformConfig) NativePayloadsDisabled() bool {
+	return false
+}

--- a/workers/generic-worker/main.go
+++ b/workers/generic-worker/main.go
@@ -628,10 +628,10 @@ func (task *TaskRun) validatePayload() *CommandExecutionError {
 	if err != nil {
 		panic(err)
 	}
+	workerPoolID := config.ProvisionerID + "/" + config.WorkerType
+	workerManagerURL := config.RootURL + "/worker-manager/" + url.PathEscape(workerPoolID)
 	if _, exists := payload["image"]; exists {
 		if !config.PublicPlatformConfig.D2GEnabled() {
-			workerPoolID := config.ProvisionerID + "/" + config.WorkerType
-			workerManagerURL := config.RootURL + "/worker-manager/" + url.PathEscape(workerPoolID)
 			return MalformedPayloadError(fmt.Errorf(`docker worker payload detected, but D2G is not enabled on this worker pool (%s).
 If you need D2G to translate your Docker Worker payload so Generic Worker can process it, please do one of two things:
 	1. Contact the owner of the worker pool %s (see %s) and ask for D2G to be enabled.
@@ -641,6 +641,8 @@ If you need D2G to translate your Docker Worker payload so Generic Worker can pr
 		if err != nil {
 			return err
 		}
+	} else if config.PublicPlatformConfig.NativePayloadsDisabled() {
+		return MalformedPayloadError(fmt.Errorf("native Generic Worker payloads are disabled on this worker pool (%s)", workerPoolID))
 	} else {
 		err := json.Unmarshal(jsonPayload, &task.Payload)
 		if err != nil {

--- a/workers/generic-worker/payload_linux.go
+++ b/workers/generic-worker/payload_linux.go
@@ -84,18 +84,20 @@ func (task *TaskRun) convertDockerWorkerPayload() *CommandExecutionError {
 		return executionError(internalError, errored, fmt.Errorf("could not convert task definition from JSON to YAML: %v", err))
 	}
 
-	task.Warn("This task was designed to run under Docker Worker. Docker Worker is no longer maintained.")
-	task.Warn("In order to execute this task, it is being converted to a Generic Worker task, using the D2G")
-	task.Warn("utility (Docker Worker 2 Generic Worker):")
-	task.Warn("    https://github.com/taskcluster/taskcluster/tree/main/clients/client-shell#translating-docker-worker-task-definitionpayload-to-generic-worker-task-definitionpayload")
-	task.Warn("")
-	task.Warn("We recommend that you convert all your Docker Worker tasks to Generic Worker tasks, to ensure")
-	task.Warn("continued support. For this task, see the converted payload below. If you have many tasks that")
-	task.Warn("require conversion, consider using the d2g tool (above) directly. It simply takes a Docker")
-	task.Warn("Worker task payload as input, and outputs a Generic Worker task payload. It can also convert")
-	task.Warn("Docker Worker scopes to equivalent Generic Worker scopes.")
-	task.Warn("")
-	task.Warn("Converted task definition (conversion performed by d2g):\n---\n" + text.Indent(string(d2gConvertedTaskDefinitionYAML), "  "))
+	if !config.PublicPlatformConfig.NativePayloadsDisabled() {
+		task.Warn("This task was designed to run under Docker Worker. Docker Worker is no longer maintained.")
+		task.Warn("In order to execute this task, it is being converted to a Generic Worker task, using the D2G")
+		task.Warn("utility (Docker Worker 2 Generic Worker):")
+		task.Warn("    https://github.com/taskcluster/taskcluster/tree/main/clients/client-shell#translating-docker-worker-task-definitionpayload-to-generic-worker-task-definitionpayload")
+		task.Warn("")
+		task.Warn("We recommend that you convert all your Docker Worker tasks to Generic Worker tasks, to ensure")
+		task.Warn("continued support. For this task, see the converted payload below. If you have many tasks that")
+		task.Warn("require conversion, consider using the d2g tool (above) directly. It simply takes a Docker")
+		task.Warn("Worker task payload as input, and outputs a Generic Worker task payload. It can also convert")
+		task.Warn("Docker Worker scopes to equivalent Generic Worker scopes.")
+		task.Warn("")
+		task.Warn("Converted task definition (conversion performed by d2g):\n---\n" + text.Indent(string(d2gConvertedTaskDefinitionYAML), "  "))
+	}
 
 	return nil
 }

--- a/workers/generic-worker/payload_linux.go
+++ b/workers/generic-worker/payload_linux.go
@@ -96,6 +96,9 @@ func (task *TaskRun) convertDockerWorkerPayload() *CommandExecutionError {
 		task.Warn("Worker task payload as input, and outputs a Generic Worker task payload. It can also convert")
 		task.Warn("Docker Worker scopes to equivalent Generic Worker scopes.")
 		task.Warn("")
+	}
+
+	if config.PublicPlatformConfig.LogD2GTranslation() {
 		task.Warn("Converted task definition (conversion performed by d2g):\n---\n" + text.Indent(string(d2gConvertedTaskDefinitionYAML), "  "))
 	}
 

--- a/workers/generic-worker/payload_test.go
+++ b/workers/generic-worker/payload_test.go
@@ -148,6 +148,7 @@ func NowMillis(t *testing.T) (now time.Time) {
 
 // If an artifact expires before task deadline we should get a Malformed Payload
 func TestArtifactExpiresBeforeDeadline(t *testing.T) {
+	setup(t)
 	now := NowMillis(t)
 	task := taskWithPayload(`{
   "env": {
@@ -285,6 +286,7 @@ func TestArtifactExpiresWithTask(t *testing.T) {
 
 // If an artifact expires after task expiry we should get a Malformed Payload
 func TestArtifactExpiresAfterTaskExpiry(t *testing.T) {
+	setup(t)
 	now := NowMillis(t)
 	task := taskWithPayload(`{
   "env": {

--- a/workers/generic-worker/usage.go
+++ b/workers/generic-worker/usage.go
@@ -162,7 +162,7 @@ and reports back results to the queue.
                                             in the config of the worker type definition is
                                             different to the worker's current deploymentId, the
                                             worker will shut itself down. See
-                                            https://bugzil.la/1298010
+                                            https://bugzil.la/1298010` + disableNativePayloads() + `
           disableReboots                    If true, no system reboot will be initiated by
                                             generic-worker program, but it will still return
                                             with exit code 67 if the system needs rebooting.

--- a/workers/generic-worker/usage_linux.go
+++ b/workers/generic-worker/usage_linux.go
@@ -31,7 +31,9 @@ func d2gConfig() string {
                                                 (property capabilities.containerEngine). Accepted values: "docker" or "podman".
                                                 [default: "docker"]
                                               * gpus - The NVIDIA GPUs to make available to the running container.
-                                                Only used if allowGPUs is true. [default: "all"]`
+                                                Only used if allowGPUs is true. [default: "all"]
+                                              * logTranslation - Logs the D2G-translated task definition to the task logs.
+                                                [default: true]`
 }
 
 func enableTaskFeatures() string {

--- a/workers/generic-worker/usage_linux.go
+++ b/workers/generic-worker/usage_linux.go
@@ -1,5 +1,13 @@
 package main
 
+func disableNativePayloads() string {
+	return `
+          disableNativePayloads             Disables native Generic Worker payloads. D2G should be
+                                            enabled (d2gConfig.enableD2G) when this is set to true.
+                                            Tasks submitted with native payloads will be resolved
+                                            as exception/malformed-payload. [default: false]`
+}
+
 func d2gConfig() string {
 	return `
           d2gConfig                         D2G-specific (Docker Worker to Generic Worker payload

--- a/workers/generic-worker/usage_other.go
+++ b/workers/generic-worker/usage_other.go
@@ -2,6 +2,10 @@
 
 package main
 
+func disableNativePayloads() string {
+	return ""
+}
+
 func d2gConfig() string {
 	return ""
 }

--- a/workers/generic-worker/usage_windows.go
+++ b/workers/generic-worker/usage_windows.go
@@ -65,6 +65,10 @@ func sidSID() string {
                                             example: 'S-1-5-5-0-41431533'.`
 }
 
+func disableNativePayloads() string {
+	return ""
+}
+
 func d2gConfig() string {
 	return ""
 }


### PR DESCRIPTION
>Generic Worker: adds `disableNativePayloads` (default: `false`) worker config option (`linux` only) to require all task payloads to be Docker Worker payloads. If this option is set to `true`, the task log will no longer contain the translated task definition and the warning about using Docker Worker payloads.
>
>Tasks submitted with native payloads will be resolved as `exception/malformed-payload`.
>
>Generic Worker: adds `d2gConfig.logTranslation` (default: `true`) worker config to control whether the D2G-translated task definition is logged to the task logs.