### PR TITLE
fix(generate): generic worker readme generation fixed to linux amd64

### DIFF
--- a/changelog/dyIkQZPYS16nYjzjJEZyxw.md
+++ b/changelog/dyIkQZPYS16nYjzjJEZyxw.md
@@ -1,0 +1,3 @@
+audience: general
+level: silent
+---

--- a/infrastructure/tooling/src/generate/generators/generic-worker.js
+++ b/infrastructure/tooling/src/generate/generators/generic-worker.js
@@ -57,11 +57,19 @@ tasks.push({
     await execCommand({
       command: ['go', 'build', '-tags', 'multiuser', '-o', binary, './workers/generic-worker'],
       utils,
+      env: { GOOS: 'linux', GOARCH: 'amd64', ...process.env },
     });
+
+    let gwHelpCommand;
+    if (process.platform === 'linux') {
+      gwHelpCommand = [binary, '--help'];
+    } else {
+      gwHelpCommand = ['docker', 'run', '--rm', '-q', '-v', `${tempDir}:/app`, '-w', '/app', 'alpine', './generic-worker', '--help'];
+    }
 
     let gwHelp = await execCommand({
       dir: REPO_ROOT,
-      command: [binary, '--help'],
+      command: gwHelpCommand,
       utils,
       keepAllOutput: true,
     });


### PR DESCRIPTION
Fixes an issue with `yarn generate` causing a diff from what's on `main`. This was due to generic worker config splitting out into linux-specific config, apart from posix.