### PR TITLE
fix(generic-worker): give task user access to readonly mounts

### DIFF
--- a/changelog/RretABTnSM6y7D-IgcBNbA.md
+++ b/changelog/RretABTnSM6y7D-IgcBNbA.md
@@ -1,0 +1,4 @@
+audience: worker-deployers
+level: patch
+---
+Generic Worker: fixes permissions issues with ReadOnlyDirectory mounts.

--- a/workers/generic-worker/mounts.go
+++ b/workers/generic-worker/mounts.go
@@ -633,7 +633,11 @@ func (r *ReadOnlyDirectory) Mount(taskMount *TaskMount) error {
 		return fmt.Errorf("not able to retrieve FSContent: %v", err)
 	}
 	dir := filepath.Join(taskContext.TaskDir, r.Directory)
-	return extract(c, r.Format, dir, taskMount)
+	err = extract(c, r.Format, dir, taskMount)
+	if err != nil {
+		return err
+	}
+	return makeDirReadWritableForTaskUser(taskMount, dir)
 }
 
 // Nothing to do - original archive file wasn't moved

--- a/workers/generic-worker/mounts_insecure.go
+++ b/workers/generic-worker/mounts_insecure.go
@@ -14,6 +14,11 @@ func makeFileReadWritableForTaskUser(taskMount *TaskMount, dir string) error {
 	return nil
 }
 
+func makeDirReadWritableForTaskUser(taskMount *TaskMount, dir string) error {
+	// No user separation
+	return nil
+}
+
 func exchangeDirectoryOwnership(taskMount *TaskMount, dir string, cache *Cache) error {
 	// No user separation
 	return nil

--- a/workers/generic-worker/mounts_multiuser.go
+++ b/workers/generic-worker/mounts_multiuser.go
@@ -13,6 +13,10 @@ func makeFileReadWritableForTaskUser(taskMount *TaskMount, file string) error {
 	return makeReadWritableForTaskUser(taskMount, file, "file", false)
 }
 
+func makeDirReadWritableForTaskUser(taskMount *TaskMount, dir string) error {
+	return makeReadWritableForTaskUser(taskMount, dir, "directory", true)
+}
+
 func exchangeDirectoryOwnership(taskMount *TaskMount, dir string, cache *Cache) error {
 	// It doesn't concern us if config.RunTasksAsCurrentUser is set or not
 	// because files inside task directory should be owned/managed by task user

--- a/workers/generic-worker/mounts_test.go
+++ b/workers/generic-worker/mounts_test.go
@@ -324,6 +324,7 @@ func TestValidSHA256(t *testing.T) {
 
 	// whether permission is granted to task user depends if running under windows or not
 	// and is independent of whether running as current user or not
+	grantingDir, _ := grantingDenying(t, "directory", false, "unknown_issuer_app_1")
 	grantingCacheFile, _ := grantingDenying(t, "file", true)
 
 	// Required text from first task with no cached value
@@ -340,6 +341,9 @@ func TestValidSHA256(t *testing.T) {
 		`Extracting zip file .* to '.*unknown_issuer_app_1'`,
 		`Removing file '.*'`,
 	)
+	pass1 = append(pass1,
+		grantingDir...,
+	)
 
 	// Required text from second task when download is already cached
 	pass2 := append([]string{
@@ -352,6 +356,9 @@ func TestValidSHA256(t *testing.T) {
 	pass2 = append(pass2,
 		`Extracting zip file .* to '.*unknown_issuer_app_1'`,
 		`Removing file '.*'`,
+	)
+	pass2 = append(pass2,
+		grantingDir...,
 	)
 
 	LogTest(


### PR DESCRIPTION
Fixes an issue that was brought up with the initial commit in https://github.com/taskcluster/taskcluster/pull/7428. I'm not sure why this code was pulled out.

>Generic Worker: fixes permissions issues with ReadOnlyDirectory mounts.