### PR TITLE
chore: remove delete old image step in gcp cloudbuild

### DIFF
--- a/changelog/VujHkx4yTsCmExAvFY_ZKQ.md
+++ b/changelog/VujHkx4yTsCmExAvFY_ZKQ.md
@@ -1,0 +1,3 @@
+audience: general
+level: silent
+---

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -77,12 +77,6 @@ steps:
         gcloud container clusters get-credentials ${PROJECT_ID} --region us-east1 --project ${PROJECT_ID} \
         && kubectl get pods -n dev --field-selector=status.phase!=Running -o name | xargs kubectl delete -n dev
     entrypoint: bash
-  - name: gcr.io/cloud-builders/gcloud
-    args:
-      - '-c'
-      - gcloud container images list-tags ${_IMAGE_NAME} --filter='-tags:latest' --format='get(digest)' --limit=unlimited | xargs -I {sha} gcloud container images delete "${_IMAGE_NAME}@{sha}" --force-delete-tags && gcloud container images list-tags ${_DEPLOY_IMAGE_NAME} --filter='-tags:latest' --format='get(digest)' --limit=unlimited | xargs -I {sha} gcloud container images delete "${_DEPLOY_IMAGE_NAME}@{sha}" --force-delete-tags
-    id: Delete old images
-    entrypoint: bash
   - name: node:${_NODE_VERSION}
     args:
       - '-c'


### PR DESCRIPTION
I've migrated our Container Registry usage over to Artifact Registry and found this small cleanup we can add now that I've added a cleanup policy to our Artifact Registry repository:
<img width="529" alt="Screenshot 2025-01-10 at 3 03 23 PM" src="https://github.com/user-attachments/assets/4fb4e3a6-d295-47d1-9fd4-2eb198750706" />

<img width="757" alt="Screenshot 2025-01-10 at 3 06 32 PM" src="https://github.com/user-attachments/assets/1ecb6950-6256-47b3-a258-600ac69460a4" />

Fixes https://github.com/taskcluster/taskcluster/issues/6916.