### PR TITLE
chore: clean up deprecated `util.log()` usage

### DIFF
--- a/changelog/U77J9G-tSsKxYnI_MrbvVg.md
+++ b/changelog/U77J9G-tSsKxYnI_MrbvVg.md
@@ -1,0 +1,3 @@
+audience: general
+level: silent
+---

--- a/db/src/main.js
+++ b/db/src/main.js
@@ -1,4 +1,3 @@
-import util from 'util';
 import chalk from 'chalk';
 import { upgrade, downgrade } from './upgrade.js';
 import { renumberVersions, newVersion } from './versions.js';
@@ -16,7 +15,7 @@ const main = async () => {
 
   /** @param {string} message */
   const showProgress = message => {
-    util.log(chalk.green(message));
+    console.log(chalk.green(message));
   };
 
   const toVersion = process.argv[3] ? parseInt(process.argv[3], 10) : undefined;

--- a/infrastructure/tooling/src/dev/index.js
+++ b/infrastructure/tooling/src/dev/index.js
@@ -1,4 +1,3 @@
-import util from 'util';
 import chalk from 'chalk';
 import path from 'path';
 import _ from 'lodash';
@@ -79,7 +78,7 @@ export const dbUpgrade = async (options) => {
 
   const { adminDbUrl, usernamePrefix } = dbParams(meta);
   const showProgress = message => {
-    util.log(chalk.green(message));
+    console.log(chalk.green(message));
   };
 
   await upgrade({ showProgress, adminDbUrl, usernamePrefix, toVersion });
@@ -97,7 +96,7 @@ export const dbDowngrade = async (options) => {
 
   const { adminDbUrl, usernamePrefix } = dbParams(meta);
   const showProgress = message => {
-    util.log(chalk.green(message));
+    console.log(chalk.green(message));
   };
 
   await downgrade({ showProgress, adminDbUrl, usernamePrefix, toVersion });


### PR DESCRIPTION
Seen in the `Deploy` stage of a recent cloudbuild log:
```bash
(node:570) [DEP0059] DeprecationWarning: The `util.log API is deprecated. Please use console.log() with a custom formatter or a third-party logger instead.
(Use `node --trace-deprecation ...` to show where the warning was created)
```