### PR TITLE
feat(w-m): Increase queueInactivityTimeout min to 1200

### DIFF
--- a/changelog/issue-7443.md
+++ b/changelog/issue-7443.md
@@ -1,0 +1,8 @@
+audience: worker-deployers
+level: minor
+reference: issue 7443
+---
+
+Worker-pool's lifecycle `queueInactivityTimeout` minimum allowed value is increased
+to `1200` (20min) to avoid having workers being incorrectly considered idling
+while they were working on a task.

--- a/changelog/issue-7443.md
+++ b/changelog/issue-7443.md
@@ -1,5 +1,5 @@
 audience: worker-deployers
-level: minor
+level: major
 reference: issue 7443
 ---
 

--- a/generated/references.json
+++ b/generated/references.json
@@ -575,8 +575,8 @@
       "properties": {
         "queueInactivityTimeout": {
           "default": 7200,
-          "description": "In order to prevent workers from being stuck without doing any work,\n`queueInactivityTimeout` controls how long a worker can do something other than\nworking on a task. If worker process dies, or it stops calling `claimWork`\nor `reclaimTask` it should be considered dead and terminated.\n\nMinimum allowed value is 1 minute, to prevent workers from being terminated\nwhile they are starting up or rebooting between the tasks.\n\nThis timeout has no affect quarantined workers,\nas they are still calling `claimWork`.\nStatic workers are also unaffected.\n",
-          "minimum": 60,
+          "description": "In order to prevent workers from being stuck without doing any work,\n`queueInactivityTimeout` controls how long a worker can do something other than\nworking on a task. If worker process dies, or it stops calling `claimWork`\nor `reclaimTask` it should be considered dead and terminated.\n\nMinimum allowed value is 20 minutes (default claim timeout),\nto prevent workers from being terminated\nwhile they are executing task, starting up or rebooting between the tasks.\n\nThis timeout has no affect quarantined workers,\nas they are still calling `claimWork`.\nStatic workers are also unaffected.\n",
+          "minimum": 1200,
           "title": "Queue Inactivity Timeout",
           "type": "integer"
         },

--- a/services/worker-manager/schemas/v1/worker-lifecycle.yml
+++ b/services/worker-manager/schemas/v1/worker-lifecycle.yml
@@ -33,7 +33,7 @@ properties:
   queueInactivityTimeout:
     title: Queue Inactivity Timeout
     type: integer
-    minimum: 60 # 1 minute
+    minimum: 1200 # 20 minutes DEFAULT_CLAIM_TIMEOUT
     default: 7200 # 2 hours
     description: |
       In order to prevent workers from being stuck without doing any work,
@@ -41,8 +41,9 @@ properties:
       working on a task. If worker process dies, or it stops calling `claimWork`
       or `reclaimTask` it should be considered dead and terminated.
 
-      Minimum allowed value is 1 minute, to prevent workers from being terminated
-      while they are starting up or rebooting between the tasks.
+      Minimum allowed value is 20 minutes (default claim timeout),
+      to prevent workers from being terminated
+      while they are executing task, starting up or rebooting between the tasks.
 
       This timeout has no affect quarantined workers,
       as they are still calling `claimWork`.

--- a/services/worker-manager/test/api_test.js
+++ b/services/worker-manager/test/api_test.js
@@ -148,6 +148,32 @@ helper.secrets.mockSuite(testing.suiteName(), [], function (mock, skipping) {
       await helper.workerManager.createWorkerPool(workerPoolId2, input2));
   });
 
+  test('schema validation - queueInactivityTimeout', async function () {
+    const input = {
+      providerId: 'aws',
+      description: 'bar',
+      owner: 'example@example.com',
+      emailOnError: false,
+      config: {
+        launchConfigs: [],
+        minCapacity: 1,
+        maxCapacity: 1,
+        scalingRatio: 1,
+        lifecycle: {
+          registrationTimeout: 6000,
+          queueInactivityTimeout: 2,
+        },
+      },
+    };
+    const apiClient = helper.workerManager.use({ retries: 0 });
+    await assert.rejects(
+      () => apiClient.createWorkerPool(workerPoolId, input),
+      err => (
+        err.statusCode === 400 &&
+        err.message.includes('queueInactivityTimeout must be >= 1200')
+      ));
+  });
+
   test('create worker pool fails when pulse publish fails', async function () {
     const input = {
       providerId: 'testing1',


### PR DESCRIPTION
Default claim timeout constant is set to 20 min.
Former value of minimum for queueInactivityTimeout was incorrectly set to 1min which conflicted with workers being killed while working on tasks.

Fixes #7443 
