### PR TITLE
Log cloud api call metrics for scanner and provisioner

### DIFF
--- a/changelog/dxMKwlKpRNyo1GnU2pstkg.md
+++ b/changelog/dxMKwlKpRNyo1GnU2pstkg.md
@@ -1,0 +1,6 @@
+audience: worker-deployers
+level: minor
+---
+
+Worker-manager scanner and provisioner logs cloud api call times and statistics.
+New metric will be logged with 'cloud-api-metrics' type at the end of each scan and provision loop.

--- a/generated/references.json
+++ b/generated/references.json
@@ -14616,6 +14616,28 @@
           "version": 1
         },
         {
+          "description": "Metrics for cloud api calls",
+          "fields": {
+            "avg": "Average API call duration in milliseconds",
+            "byStatus": "Map of HTTP status codes to counts",
+            "failed": "Number of failed API calls",
+            "max": "Maximum API call duration in milliseconds",
+            "median": "Median API call duration in milliseconds",
+            "min": "Minimum API call duration in milliseconds",
+            "p95": "95th percentile API call duration in milliseconds",
+            "p99": "99th percentile API call duration in milliseconds",
+            "providerId": "Metrics for the given provider",
+            "retries": "Number of retried API calls",
+            "success": "Number of successful API calls",
+            "total": "Total number of API calls made"
+          },
+          "level": "notice",
+          "name": "cloudApiMetrics",
+          "title": "Cloud API call metrics",
+          "type": "cloud-api-metrics",
+          "version": 1
+        },
+        {
           "description": "Rate limiting engaged for a cloud api",
           "fields": {
             "duration": "Length of time the queue is paused for in ms.",

--- a/services/worker-manager/src/monitor.js
+++ b/services/worker-manager/src/monitor.js
@@ -161,6 +161,29 @@ MonitorManager.register({
 });
 
 MonitorManager.register({
+  name: 'cloudApiMetrics',
+  title: 'Cloud API call metrics',
+  type: 'cloud-api-metrics',
+  version: 1,
+  level: 'notice',
+  description: 'Metrics for cloud api calls',
+  fields: {
+    providerId: 'Metrics for the given provider',
+    total: 'Total number of API calls made',
+    success: 'Number of successful API calls',
+    failed: 'Number of failed API calls',
+    retries: 'Number of retried API calls',
+    byStatus: 'Map of HTTP status codes to counts',
+    min: 'Minimum API call duration in milliseconds',
+    max: 'Maximum API call duration in milliseconds',
+    avg: 'Average API call duration in milliseconds',
+    median: 'Median API call duration in milliseconds',
+    p95: '95th percentile API call duration in milliseconds',
+    p99: '99th percentile API call duration in milliseconds',
+  },
+});
+
+MonitorManager.register({
   name: 'registrationErrorWarning',
   title: 'Registration Error Warning',
   type: 'registration-error-warning',

--- a/services/worker-manager/src/providers/aws.js
+++ b/services/worker-manager/src/providers/aws.js
@@ -76,7 +76,7 @@ export class AwsProvider extends Provider {
       }
     });
 
-    const cloud = new CloudAPI({
+    this.cloudApi = new CloudAPI({
       types: Object.keys(requestTypes),
       apiRateLimits: requestTypes,
       intervalDefault: this.providerConfig.intervalDefault,
@@ -91,8 +91,9 @@ export class AwsProvider extends Provider {
         }
         throw err;
       },
+      collectMetrics: true,
     });
-    this._enqueue = cloud.enqueue.bind(cloud);
+    this._enqueue = this.cloudApi.enqueue.bind(this.cloudApi);
   }
 
   async provision({ workerPool, workerInfo }) {
@@ -430,6 +431,15 @@ export class AwsProvider extends Provider {
       seen: this.seen,
       total: Provider.calcSeenTotal(this.seen),
     });
+
+    this.cloudApi?.logAndResetMetrics();
+  }
+
+  /**
+   * This is called at the end of the provision loop
+   */
+  async cleanup() {
+    this.cloudApi?.logAndResetMetrics();
   }
 
   /**


### PR DESCRIPTION
Logging cloud api call metrics for provisioner and scanner. 
This includes min/max/median values and breakdown by status.

Attempt to understand how (in)effective cloud provider calls are