### PR TITLE
fix(generic-worker): unset unexpected cached username

### DIFF
--- a/changelog/issue-7218.md
+++ b/changelog/issue-7218.md
@@ -1,0 +1,7 @@
+audience: worker-deployers
+level: patch
+reference: issue 7218
+---
+Generic Worker: Unset cached interactive username when we unexpectedly receive a non-task username.
+
+This will fix errors like: `interactive username gdm does not match task user task_173764785573833`.

--- a/workers/generic-worker/gdm3/gdm3.go
+++ b/workers/generic-worker/gdm3/gdm3.go
@@ -7,26 +7,9 @@ import (
 )
 
 var (
-	automaticLogin        = regexp.MustCompile(`^\s*AutomaticLogin\s*=`)
-	automaticLoginEnable  = regexp.MustCompile(`^\s*AutomaticLoginEnable\s*=`)
-	automaticLoginReplace = regexp.MustCompile(`^\s*AutomaticLogin\s*=\s*(\S*)\s*$`)
+	automaticLogin       = regexp.MustCompile(`^\s*AutomaticLogin\s*=`)
+	automaticLoginEnable = regexp.MustCompile(`^\s*AutomaticLoginEnable\s*=`)
 )
-
-// AutoLogonUser interprets source as the contents of the gdm3 custom.conf
-// file, and parses it to look for an auto login user, and returns it if found,
-// otherwise it returns the empty string.
-func AutoLogonUser(source []byte) (username string) {
-	iniFileLineHandler(source, func(section, line string) {
-		if section == "daemon" {
-			u := automaticLoginReplace.ReplaceAllString(line, "${1}")
-			if u != line {
-				username = u
-				return
-			}
-		}
-	})
-	return
-}
 
 // SetAutoLogin interprets source as the contents of the gdm3 custom.conf file,
 // and returns an updated version of it with the automatic desktop login

--- a/workers/generic-worker/gdm3/gdm3_test.go
+++ b/workers/generic-worker/gdm3/gdm3_test.go
@@ -28,18 +28,3 @@ AutomaticLogin = user5`)
 		t.Fatalf("Got:\n%s", result)
 	}
 }
-
-func TestGetAutoLogon(t *testing.T) {
-	source := []byte(`
-[fred]
-[mary]
-[daemon]
-AutomaticLogin = user4
-[john]
-AutomaticLoginEnable = true
-AutomaticLogin = user5`)
-	autoLogonUser := AutoLogonUser(source)
-	if autoLogonUser != "user4" {
-		t.Fatalf("Was expecting user4 but got %v", autoLogonUser)
-	}
-}

--- a/workers/generic-worker/runtime/runtime_darwin.go
+++ b/workers/generic-worker/runtime/runtime_darwin.go
@@ -85,6 +85,7 @@ func WaitForLoginCompletion(timeout time.Duration, username string) (err error) 
 		}
 		if interactiveUsername != username {
 			log.Printf("WARNING: user %v appears to be logged in but was expecting %v.", interactiveUsername, username)
+			cachedInteractiveUsername = ""
 			time.Sleep(time.Second)
 			continue
 		}
@@ -135,15 +136,6 @@ func InteractiveUsername() (string, error) {
 	}
 	cachedInteractiveUsername = output[:strings.Index(output, " ")]
 	return cachedInteractiveUsername, nil
-}
-
-func AutoLogonUser() (username string) {
-	var err error
-	username, err = kc.AutoLoginUsername()
-	if err != nil {
-		log.Print("error fetching auto-logon username: " + err.Error())
-	}
-	return
 }
 
 func SetAutoLogin(user *OSUser) error {

--- a/workers/generic-worker/runtime/runtime_other.go
+++ b/workers/generic-worker/runtime/runtime_other.go
@@ -54,6 +54,7 @@ func WaitForLoginCompletion(timeout time.Duration, username string) (err error) 
 		}
 		if interactiveUsername != username {
 			log.Printf("WARNING: user %v appears to be logged in but was expecting %v.", interactiveUsername, username)
+			cachedInteractiveUsername = ""
 			time.Sleep(time.Second)
 			continue
 		}
@@ -94,12 +95,4 @@ func SetAutoLogin(user *OSUser) error {
 		return fmt.Errorf("error overwriting file %v: %v", gdm3CustomConfFile, err)
 	}
 	return nil
-}
-
-func AutoLogonUser() (username string) {
-	source, err := os.ReadFile(gdm3CustomConfFile)
-	if err != nil {
-		return ""
-	}
-	return gdm3.AutoLogonUser(source)
 }

--- a/workers/generic-worker/runtime/runtime_windows.go
+++ b/workers/generic-worker/runtime/runtime_windows.go
@@ -119,23 +119,6 @@ func WaitForLoginCompletion(timeout time.Duration, username string) error {
 	return nil
 }
 
-func AutoLogonUser() (username string) {
-	// Set flag registry.WOW64_64KEY since Windows 10 ARM machines will otherwise read from:
-	// HKEY_LOCAL_MACHINE\SOFTWARE\WOW6432Node\Microsoft\Windows NT\CurrentVersion\Winlogon
-	k, err := registry.OpenKey(registry.LOCAL_MACHINE, `SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon`, registry.QUERY_VALUE|registry.WOW64_64KEY)
-	if err != nil {
-		log.Printf("Hit error reading Winlogon registry key - assume no autologon set: %v", err)
-		return
-	}
-	defer k.Close()
-	username, _, err = k.GetStringValue("DefaultUserName")
-	if err != nil {
-		log.Printf("Hit error reading winlogon DefaultUserName registry value - assume no autologon set: %v", err)
-		return
-	}
-	return
-}
-
 func SetAutoLogin(user *OSUser) error {
 	// Set flag registry.WOW64_64KEY since Windows 10 ARM machines will otherwise write to:
 	// HKEY_LOCAL_MACHINE\SOFTWARE\WOW6432Node\Microsoft\Windows NT\CurrentVersion\Winlogon


### PR DESCRIPTION
Fixes https://github.com/taskcluster/taskcluster/issues/7218.

>Generic Worker: Unset cached interactive username when we unexpectedly receive a non-task username.
>
>This will fix errors like: `interactive username gdm does not match task user task_173764785573833`.