### PR TITLE
Fix d2g container deletion to not leak anonymous volumes

### DIFF
--- a/changelog/QV0lt44lRRGrvqdCFIBv-A.md
+++ b/changelog/QV0lt44lRRGrvqdCFIBv-A.md
@@ -1,0 +1,4 @@
+audience: users
+level: minor
+---
+Generic Worker: Stop leaking anonymous volumes created by docker containers when using d2g with tasks that have artifacts declared in the task

--- a/tools/d2g/d2g.go
+++ b/tools/d2g/d2g.go
@@ -362,7 +362,7 @@ func command(dwPayload *dockerworker.DockerWorkerPayload, dwImage Image, tool st
 	if containerName != "" {
 		commands = append(
 			commands,
-			tool+" rm "+containerName,
+			tool+" rm -v "+containerName,
 			`exit "${exit_code}"`,
 		)
 	}

--- a/tools/d2g/d2gtest/testdata/testcases/artifacts_test.yml
+++ b/tools/d2g/d2gtest/testdata/testcases/artifacts_test.yml
@@ -49,7 +49,7 @@ testSuite:
 
               docker cp taskcontainer:'/home/worker/artifacts/fred.txt' 'artifact1.txt'
 
-              docker rm taskcontainer
+              docker rm -v taskcontainer
 
               exit "${exit_code}"
         maxRunTime: 4500

--- a/tools/d2g/d2gtest/testdata/testcases/decision_task_tests.yml
+++ b/tools/d2g/d2gtest/testdata/testcases/decision_task_tests.yml
@@ -130,7 +130,7 @@ testSuite:
 
               docker save taskcontainer | gzip > image.tar.gz
 
-              docker rm taskcontainer
+              docker rm -v taskcontainer
 
               exit "${exit_code}"
         env:

--- a/tools/d2g/d2gtest/testdata/testcases/fuzzing_tests.yml
+++ b/tools/d2g/d2gtest/testdata/testcases/fuzzing_tests.yml
@@ -45,7 +45,7 @@ testSuite:
             -e BUG_ACTION -e MONITOR_ARTIFACT -e PROCESSOR_ARTIFACT -e RUN_ID -e TASKCLUSTER_INSTANCE_TYPE
             -e TASKCLUSTER_PROXY_URL -e TASKCLUSTER_ROOT_URL -e TASKCLUSTER_WORKER_LOCATION -e TASK_GROUP_ID
             -e TASK_ID \"${IMAGE_ID}\" \nexit_code=$?\ndocker cp taskcontainer:/bugmon-artifacts/
-            artifact0\ndocker rm taskcontainer\nexit \"${exit_code}\""
+            artifact0\ndocker rm -v taskcontainer\nexit \"${exit_code}\""
         env:
           BUG_ACTION: process
           MONITOR_ARTIFACT: monitor-1881157-dnCUWpVmTzC-dQguT0njPQ.json


### PR DESCRIPTION
Before this commit, when a docker container had a volume declared that wasn't explicitly mounted by the task, it would leak it as it would create an anonymous docker volume for every single one. This changes the `rm` command to remove those anonymous volumes.

Note that the unnamed task container path used `docker run --rm` which takes care of those anonymous volumes on its own.
