### PR TITLE
feat(w-m): Static workers use pool's workerConfig

### DIFF
--- a/changelog/issue-7464.md
+++ b/changelog/issue-7464.md
@@ -1,0 +1,8 @@
+audience: worker-deployers
+level: major
+reference: issue 7464
+---
+
+Static workers always receive workerPool's workerConfig.
+Previously workerConfig was stored in the worker.providerData,
+which made it impossible to update config without creating new worker

--- a/services/worker-manager/src/providers/static.js
+++ b/services/worker-manager/src/providers/static.js
@@ -23,7 +23,7 @@ export class StaticProvider extends Provider {
       expires: new Date(input.expires),
       capacity: input.capacity,
       state: Worker.states.RUNNING,
-      providerData: { staticSecret, workerConfig: workerPool.config.workerConfig },
+      providerData: { staticSecret },
     };
 
     let worker;
@@ -93,7 +93,7 @@ export class StaticProvider extends Provider {
     } else {
       expires = taskcluster.fromNow('96 hours');
     }
-    const workerConfig = worker.providerData.workerConfig || {};
+    const workerConfig = workerPool.config.workerConfig || {};
     return {
       expires,
       workerConfig,


### PR DESCRIPTION
Instead of caching workerConfig inside worker.providerData at create time, static workers would always receive "fresh" workerPool's workerConfig at register time.


Fixes #7464
