### PR TITLE
feat(w-m): createWorker correctly handles unique key errors

### DIFF
--- a/changelog/issue-7465.md
+++ b/changelog/issue-7465.md
@@ -1,0 +1,7 @@
+audience: worker-deployers
+level: minor
+reference: issue 7465
+---
+
+`WorkerManager.createWorker()` API call handles non-unique errors and responds with `409`
+if worker with same `workerId` already exists in the pool

--- a/services/worker-manager/src/api.js
+++ b/services/worker-manager/src/api.js
@@ -603,6 +603,9 @@ declareWithTrailingColon({
       },
     });
   } catch (err) {
+    if (err.code === UNIQUE_VIOLATION) {
+      return res.reportError('RequestConflict', 'Worker already exists', {});
+    }
     if (!(err instanceof ApiError)) {
       throw err;
     }


### PR DESCRIPTION
Before it would return `500` if worker with the same `workerId` already existed

Related to #7465 issue
