### PR TITLE
fix(d2g): pull latest docker image tag

### DIFF
--- a/changelog/issue-7463.md
+++ b/changelog/issue-7463.md
@@ -1,0 +1,5 @@
+audience: worker-deployers
+level: patch
+reference: issue 7463
+---
+D2G: Pull docker image as initial command to ensure latest image version is used during task execution.

--- a/tools/d2g/d2gtest/testdata/testcases/artifacts_test.yml
+++ b/tools/d2g/d2gtest/testdata/testcases/artifacts_test.yml
@@ -33,6 +33,8 @@ testSuite:
           - - bash
             - '-cx'
             - >-
+              docker pull ubuntu
+
               timeout -s KILL 3600 docker run -t --name taskcontainer
               --memory-swap -1 --pids-limit -1
               -e RUN_ID

--- a/tools/d2g/d2gtest/testdata/testcases/container_engine_test.yml
+++ b/tools/d2g/d2gtest/testdata/testcases/container_engine_test.yml
@@ -16,6 +16,8 @@ testSuite:
           - - bash
             - '-cx'
             - >-
+              docker pull ubuntu
+
               docker run -t --rm --memory-swap -1 --pids-limit -1
               -e RUN_ID
               -e TASKCLUSTER_INSTANCE_TYPE
@@ -48,6 +50,8 @@ testSuite:
           - - bash
             - '-cx'
             - >-
+              podman pull ubuntu
+
               podman run -t --rm --memory-swap -1 --pids-limit -1 --ulimit host
               -e RUN_ID
               -e TASKCLUSTER_INSTANCE_TYPE

--- a/tools/d2g/d2gtest/testdata/testcases/decision_task_tests.yml
+++ b/tools/d2g/d2gtest/testdata/testcases/decision_task_tests.yml
@@ -81,6 +81,8 @@ testSuite:
           - - bash
             - '-cx'
             - >-
+              docker pull 'mozillareleases/gecko_decision:4.0.0@sha256:9f69fe08c28e3cb3cc296451f0a2735df6e25d0e3c877ea735ef1b7f0b345b06'
+
               timeout -s KILL 3600 docker run -t --name taskcontainer
               --memory-swap -1 --pids-limit -1 --privileged
               -v "$(pwd)/cache0:/builds/worker/checkouts"

--- a/tools/d2g/d2gtest/testdata/testcases/devices_tests.yml
+++ b/tools/d2g/d2gtest/testdata/testcases/devices_tests.yml
@@ -19,6 +19,8 @@ testSuite:
           - - bash
             - '-cx'
             - >-
+              docker pull ubuntu
+
               docker run -t --rm --memory-swap -1 --pids-limit -1
               -v /dev/shm:/dev/shm
               -e RUN_ID
@@ -53,6 +55,8 @@ testSuite:
           - - bash
             - '-cx'
             - >-
+              docker pull ubuntu
+
               docker run -t --rm --memory-swap -1 --pids-limit -1
               -e RUN_ID
               -e TASKCLUSTER_INSTANCE_TYPE
@@ -87,6 +91,8 @@ testSuite:
           - - bash
             - '-cx'
             - >-
+              docker pull ubuntu
+
               docker run -t --rm --memory-swap -1 --pids-limit -1
               --device=/dev/kvm
               -e RUN_ID
@@ -123,6 +129,8 @@ testSuite:
           - - bash
             - '-cx'
             - >-
+              docker pull ubuntu
+
               docker run -t --rm --memory-swap -1 --pids-limit -1
               -e RUN_ID
               -e TASKCLUSTER_INSTANCE_TYPE
@@ -157,6 +165,8 @@ testSuite:
           - - bash
             - '-cx'
             - >-
+              docker pull ubuntu
+
               docker run -t --rm --memory-swap -1 --pids-limit -1
               --device="${TASKCLUSTER_VIDEO_DEVICE}"
               -e RUN_ID
@@ -193,6 +203,8 @@ testSuite:
           - - bash
             - '-cx'
             - >-
+              docker pull ubuntu
+
               docker run -t --rm --memory-swap -1 --pids-limit -1
               -e RUN_ID
               -e TASKCLUSTER_INSTANCE_TYPE
@@ -227,6 +239,8 @@ testSuite:
           - - bash
             - '-cx'
             - >-
+              docker pull ubuntu
+
               docker run -t --rm --memory-swap -1 --pids-limit -1
               --device=/dev/snd
               -e RUN_ID
@@ -263,6 +277,8 @@ testSuite:
           - - bash
             - '-cx'
             - >-
+              docker pull ubuntu
+
               docker run -t --rm --memory-swap -1 --pids-limit -1
               -e RUN_ID
               -e TASKCLUSTER_INSTANCE_TYPE
@@ -293,6 +309,8 @@ testSuite:
           - - bash
             - '-cx'
             - >-
+              docker pull ubuntu
+
               docker run -t --rm --memory-swap -1 --pids-limit -1
               --gpus all
               -e RUN_ID
@@ -324,6 +342,8 @@ testSuite:
           - - bash
             - '-cx'
             - >-
+              docker pull ubuntu
+
               docker run -t --rm --memory-swap -1 --pids-limit -1
               --gpus device=GPU-3a23c669-1f69-c64e-cf85-44e9b07e7a2a
               -e RUN_ID

--- a/tools/d2g/d2gtest/testdata/testcases/docker_image_tests.yml
+++ b/tools/d2g/d2gtest/testdata/testcases/docker_image_tests.yml
@@ -15,6 +15,8 @@ testSuite:
           - - bash
             - '-cx'
             - >-
+              docker pull ubuntu
+
               docker run -t --rm --memory-swap -1 --pids-limit -1
               -e RUN_ID
               -e TASKCLUSTER_INSTANCE_TYPE
@@ -46,6 +48,8 @@ testSuite:
           - - bash
             - '-cx'
             - >-
+              docker pull ubuntu
+
               docker run -t --rm --memory-swap -1 --pids-limit -1
               -e RUN_ID
               -e TASKCLUSTER_INSTANCE_TYPE

--- a/tools/d2g/d2gtest/testdata/testcases/dw_features_tests.yml
+++ b/tools/d2g/d2gtest/testdata/testcases/dw_features_tests.yml
@@ -21,6 +21,8 @@ testSuite:
           - - bash
             - "-cx"
             - >-
+              docker pull ubuntu
+
               docker run -t --rm --memory-swap -1 --pids-limit -1
               --cap-add=SYS_PTRACE --security-opt=seccomp=unconfined
               --add-host=taskcluster:127.0.0.1 --net=host
@@ -63,6 +65,8 @@ testSuite:
           - - bash
             - "-cx"
             - >-
+              docker pull ubuntu
+
               docker run -t --rm --memory-swap -1 --pids-limit -1
               -e RUN_ID
               -e TASKCLUSTER_INSTANCE_TYPE
@@ -99,6 +103,8 @@ testSuite:
           - - bash
             - "-cx"
             - >-
+              docker pull ubuntu
+
               docker run -t --rm --memory-swap -1 --pids-limit -1 --privileged
               -e RUN_ID
               -e TASKCLUSTER_INSTANCE_TYPE
@@ -131,6 +137,8 @@ testSuite:
           - - bash
             - "-cx"
             - >-
+              docker pull ubuntu
+
               docker run -t --rm --memory-swap -1 --pids-limit -1
               -e RUN_ID
               -e TASKCLUSTER_INSTANCE_TYPE

--- a/tools/d2g/d2gtest/testdata/testcases/env_escaping_test.yml
+++ b/tools/d2g/d2gtest/testdata/testcases/env_escaping_test.yml
@@ -19,6 +19,8 @@ testSuite:
           - - bash
             - '-cx'
             - >-
+              docker pull ubuntu
+
               docker run -t --rm --memory-swap -1 --pids-limit -1
               -e ' test123 --help  ; whoami ; '
               -e RUN_ID

--- a/tools/d2g/d2gtest/testdata/testcases/no_artifacts_test.yml
+++ b/tools/d2g/d2gtest/testdata/testcases/no_artifacts_test.yml
@@ -23,6 +23,8 @@ testSuite:
           - - bash
             - '-cx'
             - >-
+              docker pull ubuntu
+
               docker run -t --rm --memory-swap -1 --pids-limit -1
               -e RUN_ID
               -e TASKCLUSTER_INSTANCE_TYPE

--- a/tools/d2g/d2gtest/testdata/testcases/task_def_test.yml
+++ b/tools/d2g/d2gtest/testdata/testcases/task_def_test.yml
@@ -57,9 +57,14 @@ testSuite:
           command:
           - - bash
             - -cx
-            - docker run -t --rm --memory-swap -1 --pids-limit -1 --device=/dev/kvm -e RUN_ID -e TASKCLUSTER_INSTANCE_TYPE
-              -e TASKCLUSTER_ROOT_URL -e TASKCLUSTER_WORKER_LOCATION -e TASK_GROUP_ID -e TASK_ID ubuntu:latest /bin/bash -c
-              'for ((i=1;i<=600;i++)); do echo $i; sleep 1; done'
+            - >-
+              docker pull ubuntu:latest
+
+              docker run -t --rm --memory-swap -1 --pids-limit -1
+              --device=/dev/kvm -e RUN_ID -e TASKCLUSTER_INSTANCE_TYPE
+              -e TASKCLUSTER_ROOT_URL -e TASKCLUSTER_WORKER_LOCATION
+              -e TASK_GROUP_ID -e TASK_ID ubuntu:latest
+              /bin/bash -c 'for ((i=1;i<=600;i++)); do echo $i; sleep 1; done'
           features:
             backingLog: true
             liveLog: true
@@ -148,9 +153,14 @@ testSuite:
           command:
           - - bash
             - -cx
-            - docker run -t --rm --memory-swap -1 --pids-limit -1 --device=/dev/kvm -e RUN_ID -e TASKCLUSTER_INSTANCE_TYPE
-              -e TASKCLUSTER_ROOT_URL -e TASKCLUSTER_WORKER_LOCATION -e TASK_GROUP_ID -e TASK_ID ubuntu:latest /bin/bash -c
-              'for ((i=1;i<=600;i++)); do echo $i; sleep 1; done'
+            - >-
+              docker pull ubuntu:latest
+
+              docker run -t --rm --memory-swap -1 --pids-limit -1
+              --device=/dev/kvm -e RUN_ID -e TASKCLUSTER_INSTANCE_TYPE
+              -e TASKCLUSTER_ROOT_URL -e TASKCLUSTER_WORKER_LOCATION
+              -e TASK_GROUP_ID -e TASK_ID ubuntu:latest
+              /bin/bash -c 'for ((i=1;i<=600;i++)); do echo $i; sleep 1; done'
           features:
             backingLog: true
             liveLog: true
@@ -242,9 +252,15 @@ testSuite:
           command:
           - - bash
             - -cx
-            - podman run -t --rm --memory-swap -1 --pids-limit -1 --ulimit host --device=/dev/kvm -e RUN_ID -e TASKCLUSTER_INSTANCE_TYPE
-              -e TASKCLUSTER_ROOT_URL -e TASKCLUSTER_WORKER_LOCATION -e TASK_GROUP_ID -e TASK_ID ubuntu:latest /bin/bash -c
-              'for ((i=1;i<=600;i++)); do echo $i; sleep 1; done'
+            - >-
+              podman pull ubuntu:latest
+
+              podman run -t --rm --memory-swap -1 --pids-limit -1
+              --ulimit host --device=/dev/kvm
+              -e RUN_ID -e TASKCLUSTER_INSTANCE_TYPE
+              -e TASKCLUSTER_ROOT_URL -e TASKCLUSTER_WORKER_LOCATION
+              -e TASK_GROUP_ID -e TASK_ID ubuntu:latest
+              /bin/bash -c 'for ((i=1;i<=600;i++)); do echo $i; sleep 1; done'
           features:
             backingLog: true
             liveLog: true

--- a/tools/d2g/dockerimagename.go
+++ b/tools/d2g/dockerimagename.go
@@ -1,6 +1,8 @@
 package d2g
 
 import (
+	"fmt"
+
 	"github.com/taskcluster/shell"
 
 	"github.com/taskcluster/taskcluster/v78/tools/d2g/genericworker"
@@ -15,5 +17,8 @@ func (din *DockerImageName) String(tool string) (string, error) {
 }
 
 func (din *DockerImageName) LoadCommands(tool string) []string {
-	return []string{}
+	image, _ := din.String(tool)
+	return []string{
+		fmt.Sprintf("%s pull %s", tool, image),
+	}
 }

--- a/tools/d2g/nameddockerimage.go
+++ b/tools/d2g/nameddockerimage.go
@@ -1,6 +1,8 @@
 package d2g
 
 import (
+	"fmt"
+
 	"github.com/taskcluster/shell"
 	"github.com/taskcluster/taskcluster/v78/tools/d2g/genericworker"
 )
@@ -14,5 +16,8 @@ func (ndi *NamedDockerImage) String(tool string) (string, error) {
 }
 
 func (ndi *NamedDockerImage) LoadCommands(tool string) []string {
-	return []string{}
+	image, _ := ndi.String(tool)
+	return []string{
+		fmt.Sprintf("%s pull %s", tool, image),
+	}
 }


### PR DESCRIPTION
Fixes #7463.

>D2G: Pull docker image as initial command to ensure latest image version is used during task execution.