### PR TITLE
Revert "[Bug 1935142] Include URL query parameters in trigger hook API endpoints"

### DIFF
--- a/changelog/issue-7475.md
+++ b/changelog/issue-7475.md
@@ -1,5 +1,0 @@
-audience: users
-level: minor
-reference: issue 7475
----
-Include URL query parameters in trigger hook API endpoints' payload

--- a/services/hooks/src/api.js
+++ b/services/hooks/src/api.js
@@ -446,7 +446,7 @@ builder.declare({
 
   await req.authorize({ hookGroupId, hookId });
 
-  const payload = { ...req.body, queryParameters: req.query };
+  const payload = req.body;
   const clientId = await req.clientId();
   const hook = hookUtils.fromDbRows(await this.db.fns.get_hook(hookGroupId, hookId));
 
@@ -554,7 +554,7 @@ builder.declare({
     'task template.',
   ].join('\n'),
 }, async function(req, res) {
-  const payload = { ...req.body, queryParameters: req.query };
+  const payload = req.body;
   const { hookGroupId, hookId } = req.params;
 
   const hook = hookUtils.fromDbRows(await this.db.fns.get_hook(hookGroupId, hookId));

--- a/services/hooks/test/api_test.js
+++ b/services/hooks/test/api_test.js
@@ -563,7 +563,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       assume(helper.creator.fireCalls).deep.equals([{
         hookGroupId: 'foo',
         hookId: 'bar',
-        context: { firedBy: 'triggerHook', clientId: 'test-client', payload: { location: 'Belo Horizonte, MG', foo: 'triggerHook', queryParameters: {} } },
+        context: { firedBy: 'triggerHook', clientId: 'test-client', payload: { location: 'Belo Horizonte, MG', foo: 'triggerHook' } },
         options: {},
       }]);
     });
@@ -756,7 +756,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       assume(helper.creator.fireCalls).deep.equals([{
         hookGroupId: 'foo',
         hookId: 'bar',
-        context: { firedBy: 'triggerHookWithToken', payload: { location: 'New Zealand', queryParameters: {} } },
+        context: { firedBy: 'triggerHookWithToken', payload: { location: 'New Zealand' } },
         options: {},
       }]);
     });
@@ -800,7 +800,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       assume(helper.creator.fireCalls).deep.equals([{
         hookGroupId: 'foo',
         hookId: 'bar',
-        context: { firedBy: 'triggerHookWithToken', payload: { a: 'payload', queryParameters: {} } },
+        context: { firedBy: 'triggerHookWithToken', payload },
         options: {},
       }]);
     });

--- a/ui/docs/reference/core/hooks/firing-hooks.mdx
+++ b/ui/docs/reference/core/hooks/firing-hooks.mdx
@@ -69,8 +69,6 @@ object is also supplied in the JSON-e context as `context`:
 }
 ```
 
-The payload includes a `queryParameters` mapping with optional URL query parameters.
-
 The schema validation also applies any default values specified in the schema.
 
 ### Webhooks
@@ -89,8 +87,6 @@ The context is similar to that for `triggerHook`:
     payload: {..}               // API call payload
 }
 ```
-
-The payload includes a `queryParameters` mapping with optional URL query parameters.
 
 ### Pulse Messages
 


### PR DESCRIPTION
Reverts taskcluster/taskcluster#7476

Unfortunately I forgot about the query validation step, so no arbitrary parameters would be passed, if there is no validation defined. 

I'm reverting this until a better plan comes up with Phabricator team how those values are delivered

cc @La0 