### PR TITLE
feat(api): Allow endpoints to define query wildcard

### DIFF
--- a/changelog/GBPeHsVYT5KkmHwRdJ10zg.md
+++ b/changelog/GBPeHsVYT5KkmHwRdJ10zg.md
@@ -1,0 +1,28 @@
+audience: developers
+level: minor
+---
+
+Added `QUERY_WILDCARD` symbol to APIBuilder for dynamic query string validation. This enables:
+
+- Validation of arbitrary query parameters using a single pattern
+- Mixed validation of both specific and wildcard query parameters
+- Support for endpoints that accept dynamic or user-defined query parameters
+
+Example usage:
+```javascript
+builder.declare({
+  query: {
+    [QUERY_WILDCARD]: /^[\w-]+$/,     // Pattern for any unspecified query parameter
+    specificParam: /^specific-value$/ // Pattern for a specific parameter
+  }
+});
+```
+
+When function is passed, it allows to validate query argument name as well:
+```javascript
+builder.declare({
+  query: {
+    [QUERY_WILDCARD]: (value, key) => key.startsWith('x-'), // Allow only query parameters starting with 'x-'
+  }
+});
+```

--- a/libraries/api/@types/index.d.ts
+++ b/libraries/api/@types/index.d.ts
@@ -5,7 +5,7 @@ import { APIBuilder, ErrorReply } from '../src/index.js';
 export type StabilityLevel = 'deprecated' | 'experimental' | 'stable';
 
 export type ValidationMap = {
-  [key: string]: RegExp | ((val: string) => string | null);
+  [key: string | Symbol]: RegExp | ((val: string) => string | null);
 };
 
 export type ErrorCodes = Record<string, number>;

--- a/libraries/api/README.md
+++ b/libraries/api/README.md
@@ -147,6 +147,28 @@ Examples:
   }
 ```
 
+If an endpoint doesn't know exactly which query parameters can be passed to it,
+wildcard query can be used. This will allow any query parameter to be passed to
+the endpoint with validation of the value (if RegExp is used, or also key if function):
+
+```js
+// import { QUERY_WILDCARD } from 'taskcluster-lib-api';
+  query: {
+    [QUERY_WILDCARD]: /.*/,  // would allow any query paramters
+  }
+// or
+  query: {
+    [QUERY_WILDCARD]: (value, key) => {
+      if (!key.startsWith('pref_')) {
+        return 'foo is not allowed';
+      }
+      if (!validFilterExpression(value)) {
+        return "invalid filter expression";
+      }
+    }
+  }
+```
+
 ### Scopes
 
 Scopes should be specified in

--- a/libraries/api/src/index.js
+++ b/libraries/api/src/index.js
@@ -7,6 +7,7 @@ import path from 'path';
 import fs from 'fs/promises';
 import * as middleware from './middleware/index.js';
 
+export { QUERY_WILDCARD } from './middleware/queries.js';
 export * from './pagination.js';
 export * from './error-reply.js';
 
@@ -157,7 +158,7 @@ export class APIBuilder {
 
   /**
    * Declare an API end-point entry, where options is on the following form:
-   *
+   * @example
    * {
    *   method:   'post|head|put|get|delete',
    *   route:    '/object/:id/action/:param',      // URL pattern with parameters
@@ -171,6 +172,7 @@ export class APIBuilder {
    *     offset: /.../,                            // Reg-exp pattern
    *     limit(n) { return "..." }                 // Function, returns message
    *                                               // if value is invalid
+   *     [QUERY_WILDCARD]: /.../,                  // Allow any query-string parameter
    *     // Query-string options are always optional (at-least in this iteration)
    *   },
    *   name:     'identifierForLibraries',         // identifier for client libraries


### PR DESCRIPTION
Dynamic query validation allows endpoints receive any query parameters that are not known in advance, but still can be validated.

Added `QUERY_WILDCARD` symbol to APIBuilder for dynamic query string validation. This enables:

- Validation of arbitrary query parameters using a single pattern
- Mixed validation of both specific and wildcard query parameters
- Support for endpoints that accept dynamic or user-defined query parameters

Example usage:
```javascript
builder.declare({
  query: {
    [QUERY_WILDCARD]: /^[\w-]+$/,     // Pattern for any unspecified query parameter
    specificParam: /^specific-value$/ // Pattern for a specific parameter
  }
});
```

When function is passed, it allows to validate query argument name as well:
```javascript
builder.declare({
  query: {
    [QUERY_WILDCARD]: (value, key) => key.startsWith('x-'), // Allow only query parameters starting with 'x-'
  }
});