### PR TITLE
chore: use generic macos pool

### DIFF
--- a/changelog/b7yn_DkbSAeqXnmIGB3wNA.md
+++ b/changelog/b7yn_DkbSAeqXnmIGB3wNA.md
@@ -1,0 +1,3 @@
+audience: general
+level: silent
+---

--- a/taskcluster/config.yml
+++ b/taskcluster/config.yml
@@ -31,11 +31,11 @@ workers:
       os: linux
       implementation: generic-worker
       worker-type: gw-ci-ubuntu-24-04
-    gw-ci-macos-13:
+    gw-ci-macos:
       provisioner: proj-taskcluster
       os: macosx
       implementation: generic-worker
-      worker-type: gw-ci-macos-13
+      worker-type: gw-ci-macos
     gw-windows-2022:
       provisioner: proj-taskcluster
       os: windows

--- a/taskcluster/kinds/generic-worker/kind.yml
+++ b/taskcluster/kinds/generic-worker/kind.yml
@@ -226,9 +226,9 @@ tasks:
       env:
         ENGINE: insecure
     copy-command-from: build/test-multiuser-ubuntu-24.04-amd64
-  build/test-multiuser-macos-13-arm64:
-    description: This builds and tests the arm64 version of generic-worker (multiuser engine) on macOS Ventura 13
-    worker-type: gw-ci-macos-13
+  build/test-multiuser-macos-arm64:
+    description: This builds and tests the arm64 version of generic-worker (multiuser engine) on macOS
+    worker-type: gw-ci-macos
     scopes:
       - generic-worker:cache:generic-worker-checkout
       - secrets:get:project/taskcluster/testing/generic-worker/ci-creds
@@ -251,9 +251,9 @@ tasks:
         ENGINE: multiuser
         GW_TESTS_RUN_AS_CURRENT_USER: ''
     copy-command-from: build/test-multiuser-ubuntu-24.04-amd64
-  build/test-multiuser-current-user-macos-13-arm64:
-    description: This builds and tests the arm64 version of generic-worker (multiuser engine) on macOS Ventura 13 as the current user
-    worker-type: gw-ci-macos-13
+  build/test-multiuser-current-user-macos-arm64:
+    description: This builds and tests the arm64 version of generic-worker (multiuser engine) on macOS as the current user
+    worker-type: gw-ci-macos
     scopes:
       - generic-worker:cache:generic-worker-checkout
       - secrets:get:project/taskcluster/testing/generic-worker/ci-creds


### PR DESCRIPTION
Uses new pool https://github.com/taskcluster/community-tc-config/pull/909. No longer version-specific naming.