### PR TITLE
Remove "cloud.google.com/backend-config" from ingress

### DIFF
--- a/infrastructure/k8s/templates/ingress.yaml
+++ b/infrastructure/k8s/templates/ingress.yaml
@@ -17,7 +17,6 @@ metadata:
     kubernetes.io/tls-acme: '{{ if .Values.certManagerClusterIssuerName }}true{{ end }}'
     kubernetes.io/ingress.class: '{{ if eq .Values.ingressType "nginx" }}nginx{{ end }}'
     ingress.kubernetes.io/force-ssl-redirect: '{{ if .Values.certManagerClusterIssuerName }}true{{ end }}'
-    '{{ if .Values.cloudArmorPolicy }}cloud.google.com/backend-config{{ else }}taskcluster/empty{{ end }}': '{{ if .Values.cloudArmorPolicy }}{"default": "taskcluster-backendconfig"}{{ end }}'
 spec:
   tls:
     - secretName: '{{ .Values.ingressTlsSecretName | default "" }}'

--- a/infrastructure/tooling/templates/k8s/ingress.yaml
+++ b/infrastructure/tooling/templates/k8s/ingress.yaml
@@ -12,7 +12,6 @@ metadata:
     'kubernetes.io/tls-acme': '{{ if .Values.certManagerClusterIssuerName }}true{{ end }}'
     'kubernetes.io/ingress.class': '{{ if eq .Values.ingressType "nginx" }}nginx{{ end }}'
     'ingress.kubernetes.io/force-ssl-redirect': '{{ if .Values.certManagerClusterIssuerName }}true{{ end }}'
-    '{{ if .Values.cloudArmorPolicy }}cloud.google.com/backend-config{{ else }}taskcluster/empty{{ end }}': '{{ if .Values.cloudArmorPolicy }}{"default": "taskcluster-backendconfig"}{{ end }}'
 spec:
   tls:
   - secretName: '{{ .Values.ingressTlsSecretName | default "" }}'


### PR DESCRIPTION
This annotation should be applied to a "Service" object, not an Ingress. The proper use of it is documented in
https://cloud.google.com/kubernetes-engine/docs/how-to/ingress-configuration#configuring_ingress_features
