### PR TITLE
fix(generic-worker): prune docker images during garbage collection

### DIFF
--- a/changelog/issue-7462.md
+++ b/changelog/issue-7462.md
@@ -1,0 +1,5 @@
+audience: worker-deployers
+level: patch
+reference: issue 7462
+---
+Generic Worker (D2G): prune docker images during garbage collection, if needed.


### PR DESCRIPTION
Fixes #7462.

>Generic Worker (D2G): prune docker images during garbage collection, if needed.