### PR TITLE
Fix the `completed` flag for `taskcluster group list`

### DIFF
--- a/changelog/emD8TJ-xRkCksGQW9uhA7A.md
+++ b/changelog/emD8TJ-xRkCksGQW9uhA7A.md
@@ -1,0 +1,4 @@
+audience: users
+level: patch
+---
+Fixed the `--completed` flag for `taskcluster group list` so it actually works instead of returning an empty list all the time

--- a/clients/client-shell/cmds/group/actors.go
+++ b/clients/client-shell/cmds/group/actors.go
@@ -51,7 +51,7 @@ func init() {
 	listCmd.Flags().BoolP("running", "r", false, "Include running tasks.")
 	listCmd.Flags().BoolP("failed", "f", false, "Include failed tasks.")
 	listCmd.Flags().BoolP("exception", "e", false, "Include exception tasks.")
-	listCmd.Flags().BoolP("complete", "c", false, "Include complete tasks.")
+	listCmd.Flags().BoolP("completed", "c", false, "Include completed tasks.")
 	listCmd.Flags().BoolP("unscheduled", "u", false, "Include unscheduled tasks.")
 	listCmd.Flags().BoolP("pending", "p", false, "Include pending tasks.")
 


### PR DESCRIPTION
The way filters work for this command is that for each task in the returned list from taskcluster, it checks if the status of the task is contained in the flags. A completed task in taskcluster has its status set to `completed` [1], not `complete` so the previous flag always returned an empty list.

[1]: https://github.com/taskcluster/taskcluster/blob/107b4228071ed9b949e0281f72ae177336e9c776/services/queue/schemas/v1/task-status.yml#L37

