### PR TITLE
chore(ci): use new `*-gui` pools

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -181,7 +181,7 @@ tasks:
 
           # Note: This task is built server side without the context or tooling that
           # exist in tree so we must hard code the hash
-          image: mozillareleases/taskgraph:decision-v12.2.0@sha256:d7b0c1f1adcc7ad1d03b50dafcc6439a2af98f85c33fb8d5af518555c0d940b8
+          image: mozillareleases/taskgraph:decision-v13.1.0@sha256:8ff59a0d89e8fd7bbdc236cf1fb15e03be9ef67d7e74ed8ffe15f27765593ecd
 
           maxRunTime: 600
 

--- a/changelog/Mdm-zSfjSgSnorb9peDNMg.md
+++ b/changelog/Mdm-zSfjSgSnorb9peDNMg.md
@@ -1,0 +1,3 @@
+audience: general
+level: silent
+---

--- a/taskcluster/config.yml
+++ b/taskcluster/config.yml
@@ -26,11 +26,11 @@ workers:
       os: linux
       implementation: docker-worker
       worker-type: gw-ubuntu-24-04
-    gw-ci-ubuntu-24-04:
+    gw-ubuntu-24-04-gui:
       provisioner: proj-taskcluster
       os: linux
       implementation: generic-worker
-      worker-type: gw-ci-ubuntu-24-04
+      worker-type: gw-ubuntu-24-04-gui
     gw-ci-macos:
       provisioner: proj-taskcluster
       os: macosx
@@ -41,11 +41,11 @@ workers:
       os: windows
       implementation: generic-worker
       worker-type: gw-windows-2022
-    gw-ci-windows-2022:
+    gw-windows-2022-gui:
       provisioner: proj-taskcluster
       os: windows
       implementation: generic-worker
-      worker-type: gw-ci-windows-2022
+      worker-type: gw-windows-2022-gui
     images:
       provisioner: proj-taskcluster
       os: linux

--- a/taskcluster/kinds/generic-worker/kind.yml
+++ b/taskcluster/kinds/generic-worker/kind.yml
@@ -95,12 +95,13 @@ tasks:
         - test $(git status --porcelain | wc -l) == 0
   build/test-multiuser-ubuntu-24.04-amd64:
     description: This builds and tests the amd64 version of generic-worker (multiuser engine) on Ubuntu 24.04
-    worker-type: gw-ci-ubuntu-24-04
+    worker-type: gw-ubuntu-24-04-gui
     scopes:
       - generic-worker:cache:generic-worker-checkout
       - secrets:get:project/taskcluster/testing/generic-worker/ci-creds
     worker:
       taskcluster-proxy: true
+      run-task-as-current-user: true
       artifacts:
         - path: gopath{go_version}/bin/generic-worker
           name: public/build/generic-worker-linux-amd64
@@ -175,12 +176,13 @@ tasks:
           ../../../golangci-lint/golangci-lint-$GOLANGCI_LINT_VERSION-*/golangci-lint run --build-tags "${{ENGINE}}" --timeout=5m
   build/test-insecure-ubuntu-24.04-amd64:
     description: This builds and tests the amd64 version of generic-worker (insecure engine) on Ubuntu 24.04
-    worker-type: gw-ci-ubuntu-24-04
+    worker-type: gw-ubuntu-24-04-gui
     scopes:
       - generic-worker:cache:generic-worker-checkout
       - secrets:get:project/taskcluster/testing/generic-worker/ci-creds
     worker:
       taskcluster-proxy: true
+      run-task-as-current-user: true
       artifacts:
         - path: gopath{go_version}/bin/generic-worker
           name: public/build/generic-worker-linux-amd64
@@ -205,6 +207,7 @@ tasks:
       - secrets:get:project/taskcluster/testing/generic-worker/ci-creds
     worker:
       taskcluster-proxy: true
+      run-task-as-current-user: true
       artifacts:
         - path: gopath{go_version}/bin/generic-worker
           name: public/build/generic-worker-darwin-arm64
@@ -223,12 +226,13 @@ tasks:
     copy-command-from: build/test-multiuser-ubuntu-24.04-amd64
   build/test-multiuser-windows-server-2022-amd64:
     description: This builds and tests the amd64 version of generic-worker (multiuser engine) on Windows Server 2022
-    worker-type: gw-ci-windows-2022
+    worker-type: gw-windows-2022-gui
     scopes:
       - generic-worker:cache:generic-worker-checkout
       - secrets:get:project/taskcluster/testing/generic-worker/ci-creds
     worker:
       taskcluster-proxy: true
+      run-task-as-current-user: true
       artifacts:
         - path: gopath{go_version}/bin/generic-worker.exe
           name: public/build/generic-worker-windows-amd64.exe

--- a/taskcluster/requirements.in
+++ b/taskcluster/requirements.in
@@ -4,4 +4,4 @@
 arrow
 pyyaml
 taskcluster
-taskcluster-taskgraph>=9.1
+taskcluster-taskgraph>=13.1.0

--- a/taskcluster/requirements.txt
+++ b/taskcluster/requirements.txt
@@ -103,7 +103,9 @@ arrow==1.3.0 \
 async-timeout==4.0.3 \
     --hash=sha256:4640d96be84d82d02ed59ea2b7105a0f7b33abe8703703cd0ab0bf87c427522f \
     --hash=sha256:7405140ff1230c310e51dc27b3145b9092d659ce68ff733fb0cefe3ee42be028
-    # via taskcluster
+    # via
+    #   aiohttp
+    #   taskcluster
 attrs==23.2.0 \
     --hash=sha256:935dc3b529c262f6cf76e50877d35a4bd3c1de194fd41f47a2b7ae8f19971f30 \
     --hash=sha256:99b87a485a5820b23b879f04c2305b44b951b502fd64be915879d77a7e8fc6f1
@@ -594,9 +596,9 @@ taskcluster==79.0.0 \
     --hash=sha256:005dcb267d085433c1f4fc482316e63c6a0d5873ce89e258280ae20176f51859 \
     --hash=sha256:e75edbf883dd274c3fa4be5c00156b4a5bbd33830d4d632611e95a8b1c3b7c4c
     # via -r requirements.in
-taskcluster-taskgraph==13.0.0 \
-    --hash=sha256:059d7c84f074f0bc182e7fc0b227e380e7847e519a8679349cadd83e92973a18 \
-    --hash=sha256:18399b923b1188fd6deab972939f2e094d2ac269931d5db6e13f0e9d1c41cdd6
+taskcluster-taskgraph==13.1.0 \
+    --hash=sha256:68bbcb094d4b97c4fd59a5f61385bca5aee70f8da7b432a139efe221153abe36 \
+    --hash=sha256:be7d8dea6587eca3a751a501afe2708e37f8dbea631614775cca21432fa4f2d0
     # via -r requirements.in
 taskcluster-urls==13.0.1 \
     --hash=sha256:5e25e7e6818e8877178b175ff43d2e6548afad72694aa125f404a7329ece0973 \


### PR DESCRIPTION
Due to https://github.com/taskcluster/community-tc-config/pull/917 (which I've already applied so that this PR's CI will work)

~~Need https://github.com/taskcluster/taskgraph/pull/644 to land and a new version of Taskgraph to be released first.~~