### PR TITLE
fix(generic-worker): fix `fork/exec` issue on headless, multiuser engine

### DIFF
--- a/changelog/issue-7517.md
+++ b/changelog/issue-7517.md
@@ -1,0 +1,5 @@
+audience: worker-deployers
+level: patch
+reference: issue 7517
+---
+Generic Worker: fixes `fork/exec` issue on headless, multiuser engine introduced in v81.0.0.

--- a/workers/generic-worker/gwconfig/config_insecure.go
+++ b/workers/generic-worker/gwconfig/config_insecure.go
@@ -4,3 +4,7 @@ package gwconfig
 
 type PublicEngineConfig struct {
 }
+
+func DefaultPublicEngineConfig() *PublicEngineConfig {
+	return &PublicEngineConfig{}
+}

--- a/workers/generic-worker/gwconfig/config_multiuser.go
+++ b/workers/generic-worker/gwconfig/config_multiuser.go
@@ -6,3 +6,9 @@ type PublicEngineConfig struct {
 	EnableRunTaskAsCurrentUser bool `json:"enableRunTaskAsCurrentUser"`
 	HeadlessTasks              bool `json:"headlessTasks"`
 }
+
+func DefaultPublicEngineConfig() *PublicEngineConfig {
+	return &PublicEngineConfig{
+		EnableRunTaskAsCurrentUser: true,
+	}
+}

--- a/workers/generic-worker/main.go
+++ b/workers/generic-worker/main.go
@@ -218,6 +218,7 @@ func loadConfig(configFile *gwconfig.File) error {
 	// only one place if possible (defaults also declared in `usage`)
 	config = &gwconfig.Config{
 		PublicConfig: gwconfig.PublicConfig{
+			PublicEngineConfig:             *gwconfig.DefaultPublicEngineConfig(),
 			PublicPlatformConfig:           *gwconfig.DefaultPublicPlatformConfig(),
 			CachesDir:                      "caches",
 			CheckForNewDeploymentEverySecs: 1800,
@@ -426,12 +427,6 @@ func RunWorker() (exitCode ExitCode) {
 	if RotateTaskEnvironment() {
 		return REBOOT_REQUIRED
 	}
-	pdTaskUser := currentPlatformData()
-	err = validateGenericWorkerBinary(pdTaskUser)
-	if err != nil {
-		log.Printf("Invalid generic-worker binary: %v", err)
-		return INTERNAL_ERROR
-	}
 	for {
 
 		// See https://bugzil.la/1298010 - routinely check if this worker type is
@@ -452,6 +447,13 @@ func RunWorker() (exitCode ExitCode) {
 
 		if graceful.TerminationRequested() {
 			return WORKER_SHUTDOWN
+		}
+
+		pdTaskUser := currentPlatformData()
+		err = validateGenericWorkerBinary(pdTaskUser)
+		if err != nil {
+			log.Printf("Invalid generic-worker binary: %v", err)
+			return INTERNAL_ERROR
 		}
 
 		task := ClaimWork()


### PR DESCRIPTION
Fixes #7517.

>Generic Worker: fixes `fork/exec` issue on headless, multiuser engine introduced in v81.0.0.