### PR TITLE
fix(generic-worker): properly configure env vars when running as current user

### DIFF
--- a/changelog/issue-7521.md
+++ b/changelog/issue-7521.md
@@ -1,0 +1,5 @@
+audience: worker-deployers
+level: patch
+reference: issue 7521
+---
+Generic Worker: fixes an issue introduced in v81.0.0 where `TASK_USER_CREDENTIALS` env var wasn't written to the task's environment if `task.payload.features.runTaskAsCurrentUser` was enabled.

--- a/workers/generic-worker/multiuser_linux_test.go
+++ b/workers/generic-worker/multiuser_linux_test.go
@@ -1,0 +1,67 @@
+//go:build multiuser
+
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/mcuadros/go-defaults"
+)
+
+func TestTaskUserCredentialsEnvVarIsWrittenAsCurrentUser(t *testing.T) {
+	setup(t)
+	config.EnableRunTaskAsCurrentUser = true
+
+	payload := GenericWorkerPayload{
+		Command: [][]string{{
+			"echo", "${TASK_USER_CREDENTIALS:?Error: TASK_USER_CREDENTIALS not set}",
+		}},
+		MaxRunTime: 180,
+		Features: FeatureFlags{
+			RunTaskAsCurrentUser: true,
+		},
+	}
+	defaults.SetDefaults(&payload)
+
+	td := testTask(t)
+	td.Scopes = append(td.Scopes,
+		"generic-worker:run-task-as-current-user:"+td.ProvisionerID+"/"+td.WorkerType,
+	)
+
+	_ = submitAndAssert(t, td, payload, "completed", "completed")
+	logtext := LogText(t)
+	if strings.Contains(logtext, "Error: TASK_USER_CREDENTIALS not set") {
+		t.Fatalf("Was expecting log file to not contain \"Error: TASK_USER_CREDENTIALS not set\", but it does: \n%v", logtext)
+	}
+}
+
+func TestXDGRuntimeDirEnvVarIsRemovedAsCurrentUser(t *testing.T) {
+	setup(t)
+	config.EnableRunTaskAsCurrentUser = true
+
+	payload := GenericWorkerPayload{
+		Command: [][]string{{
+			"echo", "${XDG_RUNTIME_DIR:?Success: XDG_RUNTIME_DIR not set}",
+		}},
+		Env: map[string]string{
+			"XDG_RUNTIME_DIR": "/run/user/1000",
+		},
+		MaxRunTime: 180,
+		Features: FeatureFlags{
+			RunTaskAsCurrentUser: true,
+		},
+	}
+	defaults.SetDefaults(&payload)
+
+	td := testTask(t)
+	td.Scopes = append(td.Scopes,
+		"generic-worker:run-task-as-current-user:"+td.ProvisionerID+"/"+td.WorkerType,
+	)
+
+	_ = submitAndAssert(t, td, payload, "failed", "failed")
+	logtext := LogText(t)
+	if !strings.Contains(logtext, "Success: XDG_RUNTIME_DIR not set") {
+		t.Fatalf("Was expecting log file to contain \"Success: XDG_RUNTIME_DIR not set\", but it doesn't: \n%v", logtext)
+	}
+}

--- a/workers/generic-worker/multiuser_windows.go
+++ b/workers/generic-worker/multiuser_windows.go
@@ -111,6 +111,9 @@ func (task *TaskRun) prepareCommand(index int) *CommandExecutionError {
 		contents += setEnvVarCommand("TASK_WORKDIR", taskContext.TaskDir)
 		contents += setEnvVarCommand("TASK_GROUP_ID", task.TaskGroupID)
 		contents += setEnvVarCommand("TASKCLUSTER_ROOT_URL", config.RootURL)
+		if task.Payload.Features.RunTaskAsCurrentUser {
+			contents += setEnvVarCommand("TASK_USER_CREDENTIALS", ctuPath)
+		}
 		if config.WorkerLocation != "" {
 			// Note, in contrast to other shells, the cmd shell set command
 			// expects literal bytes between the `=` character and the line

--- a/workers/generic-worker/run_task_as_current_user.go
+++ b/workers/generic-worker/run_task_as_current_user.go
@@ -51,18 +51,9 @@ func (r *RunTaskAsCurrentUserTask) RequiredScopes() scopes.Required {
 
 func (r *RunTaskAsCurrentUserTask) Start() *CommandExecutionError {
 	r.resetPlatformData()
-	r.setTaskUserCredentialsEnvVar()
 	r.platformSpecificActions()
 	return nil
 }
 
 func (r *RunTaskAsCurrentUserTask) Stop(err *ExecutionErrors) {
-}
-
-func (r *RunTaskAsCurrentUserTask) setTaskUserCredentialsEnvVar() {
-	if r.task.Payload.Env == nil {
-		r.task.Payload.Env = make(map[string]string)
-	}
-
-	r.task.Payload.Env["TASK_USER_CREDENTIALS"] = ctuPath
 }


### PR DESCRIPTION
Fixes #7521.

>Generic Worker: fixes an issue introduced in v81.0.0 where `TASK_USER_CREDENTIALS` env var wasn't written to the task's environment if `task.payload.features.runTaskAsCurrentUser` was enabled.