### PR TITLE
fix(release): run as current user

### DIFF
--- a/changelog/WYasEGVwS6mc4brujKnaYw.md
+++ b/changelog/WYasEGVwS6mc4brujKnaYw.md
@@ -1,0 +1,3 @@
+audience: general
+level: silent
+---

--- a/taskcluster/kinds/release/kind.yml
+++ b/taskcluster/kinds/release/kind.yml
@@ -12,6 +12,7 @@ task-defaults:
   worker:
     max-run-time: 3600
     taskcluster-proxy: true
+    run-task-as-current-user: true
     artifacts:
       - path: taskcluster/release-debug-logs
         name: debug-logs # Note: this should never be public because who knows what is in here


### PR DESCRIPTION
Was removed from the worker config here https://github.com/taskcluster/community-tc-config/commit/b84b8e2ac98b3fab1ab72d31a06d76a75b8ff301#diff-23fc71490cc090eec860515efc9788fad76e67b9559b9420316af4a48ef23713L39 and we now need to use the task feature.