### PR TITLE
fix(generic-worker): clean up cache ACLs and fix permission issues on windows

### DIFF
--- a/changelog/issue-7532.md
+++ b/changelog/issue-7532.md
@@ -1,0 +1,5 @@
+audience: general
+level: patch
+reference: issue 7532
+---
+Generic Worker (windows): fix cache ownership issues. Clean up ACLs so prior task users aren't referenced anymore.

--- a/workers/generic-worker/mounts_multiuser.go
+++ b/workers/generic-worker/mounts_multiuser.go
@@ -22,11 +22,11 @@ func exchangeDirectoryOwnership(taskMount *TaskMount, dir string, cache *Cache) 
 	// because files inside task directory should be owned/managed by task user
 	newOwnerUsername := taskContext.User.Name
 	newOwnerUID, err := taskContext.User.ID()
-	taskMount.Infof("Updating ownership of files inside directory '%v' from %v to %v", dir, cache.OwnerUsername, newOwnerUsername)
 	if err != nil {
 		panic(fmt.Errorf("[mounts] Not able to look up UID for user %v: %w", taskContext.User.Name, err))
 	}
-	err = changeOwnershipInDir(dir, cache.OwnerUID, newOwnerUsername)
+	taskMount.Infof("Updating ownership of files inside directory '%v' from %v to %v", dir, cache.OwnerUsername, newOwnerUsername)
+	err = changeOwnershipInDir(dir, newOwnerUsername, cache)
 	if err != nil {
 		return fmt.Errorf("[mounts] Not able to update ownership of directory %v from %v (UID %v) to %v (UID %v): %w", dir, cache.OwnerUsername, cache.OwnerUID, newOwnerUsername, newOwnerUID, err)
 	}


### PR DESCRIPTION
Fixes #7532.

>Generic Worker (windows): fix cache ownership issues. Clean up ACLs so prior task users aren't referenced anymore.