### PR TITLE
chore: modernize go code

### DIFF
--- a/changelog/aJtKNFFnR9CiJWO6-263Wg.md
+++ b/changelog/aJtKNFFnR9CiJWO6-263Wg.md
@@ -1,0 +1,3 @@
+audience: general
+level: silent
+---

--- a/clients/client-go/README.md
+++ b/clients/client-go/README.md
@@ -720,7 +720,7 @@ func fatalOnError(err error) {
 	}
 }
 
-func mustCompileToRawMessage(data interface{}) *json.RawMessage {
+func mustCompileToRawMessage(data any) *json.RawMessage {
 	bytes, err := json.Marshal(data)
 	fatalOnError(err)
 	var JSON json.RawMessage

--- a/clients/client-go/codegenerator/model/api.go
+++ b/clients/client-go/codegenerator/model/api.go
@@ -7,6 +7,8 @@ import (
 	"sort"
 	"strings"
 
+	"slices"
+
 	"github.com/taskcluster/taskcluster/v81/tools/jsonschema2go/text"
 )
 
@@ -285,7 +287,7 @@ func (entry *APIEntry) generateAPICode(apiName string) string {
 }
 
 func (entry *APIEntry) getInputParamsAndQueryStringCode() (inputParams, queryCode, queryExpr string) {
-	inputArgs := append([]string{}, entry.Args...)
+	inputArgs := slices.Clone(entry.Args)
 
 	// add optional query parameters
 	queryCode = ""
@@ -478,7 +480,7 @@ func (m *ScopeExpressionTemplate) UnmarshalJSON(data []byte) error {
 		return errors.New("ScopeExpressionTemplate: UnmarshalJSON on nil pointer")
 	}
 	m.RawMessage = append((m.RawMessage)[0:0], data...)
-	var tempObj interface{}
+	var tempObj any
 	err := json.Unmarshal(m.RawMessage, &tempObj)
 	if err != nil {
 		panic("Internal error: " + err.Error())
@@ -488,7 +490,7 @@ func (m *ScopeExpressionTemplate) UnmarshalJSON(data []byte) error {
 		m.Type = "RequiredScope"
 		m.RequiredScope = new(RequiredScope)
 		*(m.RequiredScope) = RequiredScope(t)
-	case map[string]interface{}:
+	case map[string]any:
 		j, err := json.Marshal(t)
 		if err != nil {
 			panic("Internal error: " + err.Error())
@@ -517,13 +519,13 @@ func (m *ScopeExpressionTemplate) UnmarshalJSON(data []byte) error {
 			panic("Internal error: " + err.Error())
 		}
 	// for old style scopesets [][]string (normal disjunctive form)
-	case []interface{}:
+	case []any:
 		m.Type = "AnyOf"
 		m.AnyOf = &Disjunction{
 			AnyOf: make([]ScopeExpressionTemplate, len(t)),
 		}
 		for i, j := range t {
-			allOf := j.([]interface{})
+			allOf := j.([]any)
 			m.AnyOf.AnyOf[i] = ScopeExpressionTemplate{
 				Type: "AllOf",
 				AllOf: &Conjunction{

--- a/clients/client-go/codegenerator/model/exchange.go
+++ b/clients/client-go/codegenerator/model/exchange.go
@@ -15,7 +15,7 @@ import (
 // Exchange represents the set of AMQP interfaces for a Taskcluster service
 type Exchange struct {
 	Schema         string          `json:"$schema"`
-	APIVersion     interface{}     `json:"apiVersion"`
+	APIVersion     any             `json:"apiVersion"`
 	Description    string          `json:"description"`
 	Entries        []ExchangeEntry `json:"entries"`
 	ExchangePrefix string          `json:"exchangePrefix"`
@@ -150,7 +150,7 @@ func (exchange *Exchange) generateAPICode(exchangeName string) string {
 	comment += "//  queueevents.TaskDefined{WorkerType: \"gaia\"}\n"
 	comment += "// \n"
 	comment += "// In addition, this means that you will also get objects in your callback method like *queueevents.TaskDefinedMessage\n"
-	comment += "// rather than just interface{}.\n"
+	comment += "// rather than just any.\n"
 	content := comment
 	content += "package " + exchange.apiDef.PackageName + "\n"
 	content += `
@@ -167,7 +167,7 @@ import (
 	}
 
 	content += `
-func generateRoutingKey(x interface{}) string {
+func generateRoutingKey(x any) string {
 	val := reflect.ValueOf(x).Elem()
 	p := make([]string, 0, val.NumField())
 	for i := range val.NumField() {
@@ -217,7 +217,7 @@ func (entry *ExchangeEntry) generateAPICode() string {
 	content += "\treturn \"" + entry.Parent.ExchangePrefix + entry.Exchange + "\"\n"
 	content += "}\n"
 	content += "\n"
-	content += "func (binding " + entry.typeName + ") NewPayloadObject() interface{} {\n"
+	content += "func (binding " + entry.typeName + ") NewPayloadObject() any {\n"
 	content += "\treturn new(" + entry.Parent.apiDef.schemas.SubSchema(entry.schemaURL).TypeName + ")\n"
 	content += "}\n"
 	content += "\n"

--- a/clients/client-go/codegenerator/model/model.go
+++ b/clients/client-go/codegenerator/model/model.go
@@ -89,29 +89,29 @@ func (apiDef *APIDefinition) generateAPICode() string {
 }
 
 func (apiDef *APIDefinition) loadJSON(refRaw json.RawMessage) bool {
-	f := new(interface{})
+	f := new(any)
 	err = json.Unmarshal(refRaw, f)
 	exitOnFail(err)
-	schemaURL := (*f).(map[string]interface{})["$schema"].(string)
+	schemaURL := (*f).(map[string]any)["$schema"].(string)
 	apiDef.SchemaURL = schemaURL
 
 	schemaRaw := ReferencesServerGet(schemaURL[:len(schemaURL)-1])
 	if schemaRaw == nil {
 		panic("No schema")
 	}
-	var schema interface{}
+	var schema any
 	err = json.Unmarshal(*schemaRaw, &schema)
 	exitOnFail(err)
-	var x interface{}
+	var x any
 
 	x = schema
-	x = x.(map[string]interface{})["metadata"]
-	x = x.(map[string]interface{})["name"]
+	x = x.(map[string]any)["metadata"]
+	x = x.(map[string]any)["name"]
 	schemaName := x.(string)
 
 	x = schema
-	x = x.(map[string]interface{})["metadata"]
-	x = x.(map[string]interface{})["version"]
+	x = x.(map[string]any)["metadata"]
+	x = x.(map[string]any)["version"]
 	schemaVersion := int(x.(float64))
 
 	var m APIModel

--- a/clients/client-go/codegenerator/model/refserver.go
+++ b/clients/client-go/codegenerator/model/refserver.go
@@ -53,12 +53,12 @@ func StartReferencesServer() error {
 			continue
 		}
 
-		var x map[string]interface{}
+		var x map[string]any
 		err := json.Unmarshal(ref.Content, &x)
 		if err != nil {
 			panic(err)
 		}
-		x["$id"] = interface{}(referencesServer.URL + x["$id"].(string))
+		x["$id"] = any(referencesServer.URL + x["$id"].(string))
 		ref.Content, err = json.Marshal(&x)
 		if err != nil {
 			panic(err)

--- a/clients/client-go/http.go
+++ b/clients/client-go/http.go
@@ -45,7 +45,7 @@ type CallSummary struct {
 	HTTPRequestBody string
 	// The Go Type which is marshaled into json and used as the http request
 	// body.
-	HTTPRequestObject interface{}
+	HTTPRequestObject any
 	HTTPResponse      *http.Response
 	// Keep a copy of response body in addition to the *http.Response, since
 	// accessing the Body via the *http.Response object, you get a
@@ -224,7 +224,7 @@ func (err *APICallException) Error() string {
 // APICall is the generic REST API calling method which performs all REST API
 // calls for this library.  Each auto-generated REST API method simply is a
 // wrapper around this method, calling it with specific specific arguments.
-func (client *Client) APICall(payload interface{}, method, route string, result interface{}, query url.Values) (interface{}, *CallSummary, error) {
+func (client *Client) APICall(payload any, method, route string, result any, query url.Values) (any, *CallSummary, error) {
 	rawPayload := []byte{}
 	var err error
 	if reflect.ValueOf(payload).IsValid() && !reflect.ValueOf(payload).IsNil() {

--- a/clients/client-go/http_test.go
+++ b/clients/client-go/http_test.go
@@ -290,12 +290,12 @@ func TestNoFollowRedirects(t *testing.T) {
 		Authenticate: false,
 	}
 
-	var result map[string]interface{}
+	var result map[string]any
 	res, cs, err := client.APICall(nil, "GET", "/whatever", &result, nil)
 	assert.NoError(t, err)
 	assert.Equal(t, 303, cs.HTTPResponse.StatusCode)
 	assert.Equal(t,
-		&map[string]interface{}{"url": "http://nosuch.example.com"},
+		&map[string]any{"url": "http://nosuch.example.com"},
 		res)
 }
 

--- a/clients/client-go/tcauthevents/tcauthevents.go
+++ b/clients/client-go/tcauthevents/tcauthevents.go
@@ -43,7 +43,7 @@
 //	queueevents.TaskDefined{WorkerType: "gaia"}
 //
 // In addition, this means that you will also get objects in your callback method like *queueevents.TaskDefinedMessage
-// rather than just interface{}.
+// rather than just any.
 package tcauthevents
 
 import (
@@ -66,7 +66,7 @@ func (binding ClientCreated) ExchangeName() string {
 	return "exchange/taskcluster-auth/v1/client-created"
 }
 
-func (binding ClientCreated) NewPayloadObject() interface{} {
+func (binding ClientCreated) NewPayloadObject() any {
 	return new(ClientMessage)
 }
 
@@ -85,7 +85,7 @@ func (binding ClientUpdated) ExchangeName() string {
 	return "exchange/taskcluster-auth/v1/client-updated"
 }
 
-func (binding ClientUpdated) NewPayloadObject() interface{} {
+func (binding ClientUpdated) NewPayloadObject() any {
 	return new(ClientMessage)
 }
 
@@ -104,7 +104,7 @@ func (binding ClientDeleted) ExchangeName() string {
 	return "exchange/taskcluster-auth/v1/client-deleted"
 }
 
-func (binding ClientDeleted) NewPayloadObject() interface{} {
+func (binding ClientDeleted) NewPayloadObject() any {
 	return new(ClientMessage)
 }
 
@@ -123,7 +123,7 @@ func (binding RoleCreated) ExchangeName() string {
 	return "exchange/taskcluster-auth/v1/role-created"
 }
 
-func (binding RoleCreated) NewPayloadObject() interface{} {
+func (binding RoleCreated) NewPayloadObject() any {
 	return new(RoleMessage)
 }
 
@@ -142,7 +142,7 @@ func (binding RoleUpdated) ExchangeName() string {
 	return "exchange/taskcluster-auth/v1/role-updated"
 }
 
-func (binding RoleUpdated) NewPayloadObject() interface{} {
+func (binding RoleUpdated) NewPayloadObject() any {
 	return new(RoleMessage)
 }
 
@@ -161,11 +161,11 @@ func (binding RoleDeleted) ExchangeName() string {
 	return "exchange/taskcluster-auth/v1/role-deleted"
 }
 
-func (binding RoleDeleted) NewPayloadObject() interface{} {
+func (binding RoleDeleted) NewPayloadObject() any {
 	return new(RoleMessage)
 }
 
-func generateRoutingKey(x interface{}) string {
+func generateRoutingKey(x any) string {
 	val := reflect.ValueOf(x).Elem()
 	p := make([]string, 0, val.NumField())
 	for i := range val.NumField() {

--- a/clients/client-go/tcgithubevents/tcgithubevents.go
+++ b/clients/client-go/tcgithubevents/tcgithubevents.go
@@ -41,7 +41,7 @@
 //	queueevents.TaskDefined{WorkerType: "gaia"}
 //
 // In addition, this means that you will also get objects in your callback method like *queueevents.TaskDefinedMessage
-// rather than just interface{}.
+// rather than just any.
 package tcgithubevents
 
 import (
@@ -69,7 +69,7 @@ func (binding PullRequest) ExchangeName() string {
 	return "exchange/taskcluster-github/v1/pull-request"
 }
 
-func (binding PullRequest) NewPayloadObject() interface{} {
+func (binding PullRequest) NewPayloadObject() any {
 	return new(GitHubPullRequestMessage)
 }
 
@@ -92,7 +92,7 @@ func (binding Push) ExchangeName() string {
 	return "exchange/taskcluster-github/v1/push"
 }
 
-func (binding Push) NewPayloadObject() interface{} {
+func (binding Push) NewPayloadObject() any {
 	return new(GitHubPushMessage)
 }
 
@@ -115,7 +115,7 @@ func (binding Release) ExchangeName() string {
 	return "exchange/taskcluster-github/v1/release"
 }
 
-func (binding Release) NewPayloadObject() interface{} {
+func (binding Release) NewPayloadObject() any {
 	return new(GitHubReleaseMessage)
 }
 
@@ -139,7 +139,7 @@ func (binding Rerun) ExchangeName() string {
 	return "exchange/taskcluster-github/v1/rerun"
 }
 
-func (binding Rerun) NewPayloadObject() interface{} {
+func (binding Rerun) NewPayloadObject() any {
 	return new(GitHubReRunRequestMessage)
 }
 
@@ -165,11 +165,11 @@ func (binding TaskGroupCreationRequested) ExchangeName() string {
 	return "exchange/taskcluster-github/v1/task-group-creation-requested"
 }
 
-func (binding TaskGroupCreationRequested) NewPayloadObject() interface{} {
+func (binding TaskGroupCreationRequested) NewPayloadObject() any {
 	return new(TaskGroupDefinedCreateStatus)
 }
 
-func generateRoutingKey(x interface{}) string {
+func generateRoutingKey(x any) string {
 	val := reflect.ValueOf(x).Elem()
 	p := make([]string, 0, val.NumField())
 	for i := range val.NumField() {

--- a/clients/client-go/tchooksevents/tchooksevents.go
+++ b/clients/client-go/tchooksevents/tchooksevents.go
@@ -36,7 +36,7 @@
 //	queueevents.TaskDefined{WorkerType: "gaia"}
 //
 // In addition, this means that you will also get objects in your callback method like *queueevents.TaskDefinedMessage
-// rather than just interface{}.
+// rather than just any.
 package tchooksevents
 
 import (
@@ -59,7 +59,7 @@ func (binding HookCreated) ExchangeName() string {
 	return "exchange/taskcluster-hooks/v1/hook-created"
 }
 
-func (binding HookCreated) NewPayloadObject() interface{} {
+func (binding HookCreated) NewPayloadObject() any {
 	return new(HookChangedMessage)
 }
 
@@ -78,7 +78,7 @@ func (binding HookUpdated) ExchangeName() string {
 	return "exchange/taskcluster-hooks/v1/hook-updated"
 }
 
-func (binding HookUpdated) NewPayloadObject() interface{} {
+func (binding HookUpdated) NewPayloadObject() any {
 	return new(HookChangedMessage)
 }
 
@@ -97,11 +97,11 @@ func (binding HookDeleted) ExchangeName() string {
 	return "exchange/taskcluster-hooks/v1/hook-deleted"
 }
 
-func (binding HookDeleted) NewPayloadObject() interface{} {
+func (binding HookDeleted) NewPayloadObject() any {
 	return new(HookChangedMessage)
 }
 
-func generateRoutingKey(x interface{}) string {
+func generateRoutingKey(x any) string {
 	val := reflect.ValueOf(x).Elem()
 	p := make([]string, 0, val.NumField())
 	for i := range val.NumField() {

--- a/clients/client-go/tcnotify/types.go
+++ b/clients/client-go/tcnotify/types.go
@@ -134,10 +134,10 @@ type (
 	SendSlackMessage struct {
 
 		// An array of Slack attachments. See https://api.slack.com/messaging/composing/layouts#attachments.
-		Attachments []interface{} `json:"attachments,omitempty"`
+		Attachments []any `json:"attachments,omitempty"`
 
 		// An array of Slack layout blocks. See https://api.slack.com/reference/block-kit/blocks.
-		Blocks []interface{} `json:"blocks,omitempty"`
+		Blocks []any `json:"blocks,omitempty"`
 
 		// The unique Slack channel ID, such as `C123456GZ`.
 		// In the app, this is the last section of the 'copy link' URL for a channel.

--- a/clients/client-go/tcnotifyevents/tcnotifyevents.go
+++ b/clients/client-go/tcnotifyevents/tcnotifyevents.go
@@ -38,7 +38,7 @@
 //	queueevents.TaskDefined{WorkerType: "gaia"}
 //
 // In addition, this means that you will also get objects in your callback method like *queueevents.TaskDefinedMessage
-// rather than just interface{}.
+// rather than just any.
 package tcnotifyevents
 
 import (
@@ -68,11 +68,11 @@ func (binding Notify) ExchangeName() string {
 	return "exchange/taskcluster-notify/v1/notification"
 }
 
-func (binding Notify) NewPayloadObject() interface{} {
+func (binding Notify) NewPayloadObject() any {
 	return new(NotificationMessage)
 }
 
-func generateRoutingKey(x interface{}) string {
+func generateRoutingKey(x any) string {
 	val := reflect.ValueOf(x).Elem()
 	p := make([]string, 0, val.NumField())
 	for i := range val.NumField() {

--- a/clients/client-go/tcobject/upload_download_test.go
+++ b/clients/client-go/tcobject/upload_download_test.go
@@ -24,7 +24,7 @@ func mockObjectServer(t *testing.T) (*httptest.Server, *mux.Router, *tcobject.Ob
 	r := mux.NewRouter().UseEncodedPath()
 	r.NotFoundHandler = http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		w.WriteHeader(404)
-		_, _ = w.Write([]byte(fmt.Sprintf("URL %v with method %v NOT FOUND\n", req.URL, req.Method)))
+		_, _ = w.Write(fmt.Appendf(nil, "URL %v with method %v NOT FOUND\n", req.URL, req.Method))
 	})
 	srv := httptest.NewServer(r)
 	mockobj := mocktc.NewObject(t, srv.URL)

--- a/clients/client-go/tcpurgecacheevents/tcpurgecacheevents.go
+++ b/clients/client-go/tcpurgecacheevents/tcpurgecacheevents.go
@@ -38,7 +38,7 @@
 //	queueevents.TaskDefined{WorkerType: "gaia"}
 //
 // In addition, this means that you will also get objects in your callback method like *queueevents.TaskDefinedMessage
-// rather than just interface{}.
+// rather than just any.
 package tcpurgecacheevents
 
 import (
@@ -65,11 +65,11 @@ func (binding PurgeCache) ExchangeName() string {
 	return "exchange/taskcluster-purge-cache/v1/purge-cache"
 }
 
-func (binding PurgeCache) NewPayloadObject() interface{} {
+func (binding PurgeCache) NewPayloadObject() any {
 	return new(PurgeCacheMessage)
 }
 
-func generateRoutingKey(x interface{}) string {
+func generateRoutingKey(x any) string {
 	val := reflect.ValueOf(x).Elem()
 	p := make([]string, 0, val.NumField())
 	for i := range val.NumField() {

--- a/clients/client-go/tcqueue/download_test.go
+++ b/clients/client-go/tcqueue/download_test.go
@@ -42,7 +42,7 @@ func mockTcServices(t *testing.T) mock {
 	m.router = mux.NewRouter().UseEncodedPath()
 	m.router.NotFoundHandler = http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		w.WriteHeader(404)
-		_, _ = w.Write([]byte(fmt.Sprintf("URL %v with method %v NOT FOUND\n", req.URL, req.Method)))
+		_, _ = w.Write(fmt.Appendf(nil, "URL %v with method %v NOT FOUND\n", req.URL, req.Method))
 	})
 	m.srv = httptest.NewServer(m.router)
 

--- a/clients/client-go/tcqueueevents/queueevents_examples_test.go
+++ b/clients/client-go/tcqueueevents/queueevents_examples_test.go
@@ -16,7 +16,7 @@ func Example_taskclusterSniffer() {
 	conn := pulse.NewConnection("", "", "")
 	_, _ = conn.Consume(
 		"taskprocessing", // queue name
-		func(message interface{}, delivery amqp.Delivery) { // callback function to pass messages to
+		func(message any, delivery amqp.Delivery) { // callback function to pass messages to
 			switch t := message.(type) {
 			case *tcqueueevents.TaskDefinedMessage:
 				fmt.Println("Task " + t.Status.TaskID + " defined")
@@ -35,7 +35,7 @@ func Example_taskclusterSniffer() {
 		tcqueueevents.TaskRunning{WorkerType: "gaia", ProvisionerID: "aws-provisioner"})
 	_, _ = conn.Consume( // a second workflow to manage concurrently
 		"", // empty name implies anonymous queue
-		func(message interface{}, delivery amqp.Delivery) { // simpler callback than before
+		func(message any, delivery amqp.Delivery) { // simpler callback than before
 			fmt.Println("A buildbot message was received")
 			fmt.Println("===========")
 		},

--- a/clients/client-go/tcqueueevents/tcqueueevents.go
+++ b/clients/client-go/tcqueueevents/tcqueueevents.go
@@ -82,7 +82,7 @@
 //	queueevents.TaskDefined{WorkerType: "gaia"}
 //
 // In addition, this means that you will also get objects in your callback method like *queueevents.TaskDefinedMessage
-// rather than just interface{}.
+// rather than just any.
 package tcqueueevents
 
 import (
@@ -119,7 +119,7 @@ func (binding TaskDefined) ExchangeName() string {
 	return "exchange/taskcluster-queue/v1/task-defined"
 }
 
-func (binding TaskDefined) NewPayloadObject() interface{} {
+func (binding TaskDefined) NewPayloadObject() any {
 	return new(TaskDefinedMessage)
 }
 
@@ -153,7 +153,7 @@ func (binding TaskPending) ExchangeName() string {
 	return "exchange/taskcluster-queue/v1/task-pending"
 }
 
-func (binding TaskPending) NewPayloadObject() interface{} {
+func (binding TaskPending) NewPayloadObject() any {
 	return new(TaskPendingMessage)
 }
 
@@ -182,7 +182,7 @@ func (binding TaskRunning) ExchangeName() string {
 	return "exchange/taskcluster-queue/v1/task-running"
 }
 
-func (binding TaskRunning) NewPayloadObject() interface{} {
+func (binding TaskRunning) NewPayloadObject() any {
 	return new(TaskRunningMessage)
 }
 
@@ -230,7 +230,7 @@ func (binding ArtifactCreated) ExchangeName() string {
 	return "exchange/taskcluster-queue/v1/artifact-created"
 }
 
-func (binding ArtifactCreated) NewPayloadObject() interface{} {
+func (binding ArtifactCreated) NewPayloadObject() any {
 	return new(ArtifactCreatedMessage)
 }
 
@@ -262,7 +262,7 @@ func (binding TaskCompleted) ExchangeName() string {
 	return "exchange/taskcluster-queue/v1/task-completed"
 }
 
-func (binding TaskCompleted) NewPayloadObject() interface{} {
+func (binding TaskCompleted) NewPayloadObject() any {
 	return new(TaskCompletedMessage)
 }
 
@@ -292,7 +292,7 @@ func (binding TaskFailed) ExchangeName() string {
 	return "exchange/taskcluster-queue/v1/task-failed"
 }
 
-func (binding TaskFailed) NewPayloadObject() interface{} {
+func (binding TaskFailed) NewPayloadObject() any {
 	return new(TaskFailedMessage)
 }
 
@@ -326,7 +326,7 @@ func (binding TaskException) ExchangeName() string {
 	return "exchange/taskcluster-queue/v1/task-exception"
 }
 
-func (binding TaskException) NewPayloadObject() interface{} {
+func (binding TaskException) NewPayloadObject() any {
 	return new(TaskExceptionMessage)
 }
 
@@ -352,7 +352,7 @@ func (binding TaskGroupResolved) ExchangeName() string {
 	return "exchange/taskcluster-queue/v1/task-group-resolved"
 }
 
-func (binding TaskGroupResolved) NewPayloadObject() interface{} {
+func (binding TaskGroupResolved) NewPayloadObject() any {
 	return new(TaskGroupChangedMessage)
 }
 
@@ -375,11 +375,11 @@ func (binding TaskGroupSealed) ExchangeName() string {
 	return "exchange/taskcluster-queue/v1/task-group-sealed"
 }
 
-func (binding TaskGroupSealed) NewPayloadObject() interface{} {
+func (binding TaskGroupSealed) NewPayloadObject() any {
 	return new(TaskGroupChangedMessage)
 }
 
-func generateRoutingKey(x interface{}) string {
+func generateRoutingKey(x any) string {
 	val := reflect.ValueOf(x).Elem()
 	p := make([]string, 0, val.NumField())
 	for i := range val.NumField() {

--- a/clients/client-go/tcworkermanagerevents/tcworkermanagerevents.go
+++ b/clients/client-go/tcworkermanagerevents/tcworkermanagerevents.go
@@ -36,7 +36,7 @@
 //	queueevents.TaskDefined{WorkerType: "gaia"}
 //
 // In addition, this means that you will also get objects in your callback method like *queueevents.TaskDefinedMessage
-// rather than just interface{}.
+// rather than just any.
 package tcworkermanagerevents
 
 import (
@@ -67,7 +67,7 @@ func (binding WorkerPoolCreated) ExchangeName() string {
 	return "exchange/taskcluster-worker-manager/v1/worker-pool-created"
 }
 
-func (binding WorkerPoolCreated) NewPayloadObject() interface{} {
+func (binding WorkerPoolCreated) NewPayloadObject() any {
 	return new(WorkerTypePulseMessage)
 }
 
@@ -94,7 +94,7 @@ func (binding WorkerPoolUpdated) ExchangeName() string {
 	return "exchange/taskcluster-worker-manager/v1/worker-pool-updated"
 }
 
-func (binding WorkerPoolUpdated) NewPayloadObject() interface{} {
+func (binding WorkerPoolUpdated) NewPayloadObject() any {
 	return new(WorkerTypePulseMessage)
 }
 
@@ -122,7 +122,7 @@ func (binding WorkerPoolError) ExchangeName() string {
 	return "exchange/taskcluster-worker-manager/v1/worker-pool-error"
 }
 
-func (binding WorkerPoolError) NewPayloadObject() interface{} {
+func (binding WorkerPoolError) NewPayloadObject() any {
 	return new(WorkerTypePulseMessage1)
 }
 
@@ -148,7 +148,7 @@ func (binding WorkerRequested) ExchangeName() string {
 	return "exchange/taskcluster-worker-manager/v1/worker-requested"
 }
 
-func (binding WorkerRequested) NewPayloadObject() interface{} {
+func (binding WorkerRequested) NewPayloadObject() any {
 	return new(WorkerPulseMessage)
 }
 
@@ -175,7 +175,7 @@ func (binding WorkerRunning) ExchangeName() string {
 	return "exchange/taskcluster-worker-manager/v1/worker-running"
 }
 
-func (binding WorkerRunning) NewPayloadObject() interface{} {
+func (binding WorkerRunning) NewPayloadObject() any {
 	return new(WorkerPulseMessage)
 }
 
@@ -202,7 +202,7 @@ func (binding WorkerStopped) ExchangeName() string {
 	return "exchange/taskcluster-worker-manager/v1/worker-stopped"
 }
 
-func (binding WorkerStopped) NewPayloadObject() interface{} {
+func (binding WorkerStopped) NewPayloadObject() any {
 	return new(WorkerPulseMessage)
 }
 
@@ -230,11 +230,11 @@ func (binding WorkerRemoved) ExchangeName() string {
 	return "exchange/taskcluster-worker-manager/v1/worker-removed"
 }
 
-func (binding WorkerRemoved) NewPayloadObject() interface{} {
+func (binding WorkerRemoved) NewPayloadObject() any {
 	return new(WorkerRemovedPulseMessage)
 }
 
-func generateRoutingKey(x interface{}) string {
+func generateRoutingKey(x any) string {
 	val := reflect.ValueOf(x).Elem()
 	p := make([]string, 0, val.NumField())
 	for i := range val.NumField() {

--- a/clients/client-shell/apis/provider.go
+++ b/clients/client-shell/apis/provider.go
@@ -256,7 +256,7 @@ func execute(
 func formatGotError(err error) error {
 	if res, ok := err.(got.BadResponseCodeError); ok {
 		if strings.HasPrefix(res.Header.Get("Content-Type"), "application/json") {
-			var body map[string]interface{}
+			var body map[string]any
 			if json.Unmarshal(res.Body, &body) == nil {
 				if message, ok := body["message"]; ok {
 					if code, ok := body["code"]; ok {

--- a/clients/client-shell/apis/provider_test.go
+++ b/clients/client-shell/apis/provider_test.go
@@ -175,7 +175,7 @@ func redirHandler(w http.ResponseWriter, r *http.Request) {
 func errorHandler(w http.ResponseWriter, r *http.Request) {
 	w.Header()["Content-Type"] = []string{"application/json"}
 	w.WriteHeader(409)
-	body := map[string]interface{}{
+	body := map[string]any{
 		"code":    "ResourceConflict",
 		"message": "I'm sorry dave..\nI can't let you do that.",
 	}

--- a/clients/client-shell/cmds/config/config.go
+++ b/clients/client-shell/cmds/config/config.go
@@ -55,7 +55,7 @@ func init() {
 			Description: "Certificate as required if using temporary credentials (must be given as string).",
 			Default:     nil,
 			Env:         "TASKCLUSTER_CERTIFICATE",
-			Validate: func(value interface{}) error {
+			Validate: func(value any) error {
 				s, ok := value.(string)
 				if !ok {
 					return errors.New("must be a string containing certificate in JSON")
@@ -70,8 +70,8 @@ func init() {
 		"authorizedScopes": config.OptionDefinition{
 			Description: `Set of scopes to be used for authorizing requests, defaults to all the scopes you have.`,
 			Parse:       true,
-			Validate: func(value interface{}) error {
-				strs, ok := value.([]interface{})
+			Validate: func(value any) error {
+				strs, ok := value.([]any)
 				if ok {
 					for _, str := range strs {
 						if _, ok2 := str.(string); !ok2 {
@@ -97,7 +97,7 @@ func cmdConfig(cmd *cobra.Command, args []string) error {
 	}
 
 	// select formatter
-	var formatter func(interface{}) []byte
+	var formatter func(any) []byte
 	format, _ := cmd.Flags().GetString("format")
 
 	if format == "yaml" {

--- a/clients/client-shell/cmds/config/get.go
+++ b/clients/client-shell/cmds/config/get.go
@@ -25,7 +25,7 @@ func cmdGet(cmd *cobra.Command, args []string) error {
 	}
 
 	// select formatter
-	var formatter func(interface{}) []byte
+	var formatter func(any) []byte
 	format, _ := cmd.Flags().GetString("format")
 
 	switch format {

--- a/clients/client-shell/cmds/config/utils.go
+++ b/clients/client-shell/cmds/config/utils.go
@@ -12,7 +12,7 @@ import (
 
 // getOptionFromKey returns the command, option, definition, value of a config option
 // this is the whole package, does everything
-func getOptionFromKey(key string) (string, string, config.OptionDefinition, interface{}, error) {
+func getOptionFromKey(key string) (string, string, config.OptionDefinition, any, error) {
 	command, option, err := parseKey(key)
 	if err != nil {
 		return "", "", config.OptionDefinition{}, "", err
@@ -36,7 +36,7 @@ func parseKey(key string) (string, string, error) {
 
 // getOption retrieves the definition, value of a config option
 // use if you don't need to parse the command and option
-func getOption(command string, option string) (config.OptionDefinition, interface{}, error) {
+func getOption(command string, option string) (config.OptionDefinition, any, error) {
 	// find map of options for specified command
 	options, ok := config.OptionsDefinitions[command]
 	if !ok {
@@ -53,14 +53,11 @@ func getOption(command string, option string) (config.OptionDefinition, interfac
 }
 
 func pad(s string, length int) string {
-	p := length - len(s)
-	if p < 0 {
-		p = 0
-	}
+	p := max(length-len(s), 0)
 	return s + strings.Repeat(" ", p)
 }
 
-func formatYAML(value interface{}) []byte {
+func formatYAML(value any) []byte {
 	data, err := yaml.Marshal(value)
 	if err != nil {
 		panic(fmt.Sprintf("Internal error rendering yaml, error: %s", err))
@@ -68,7 +65,7 @@ func formatYAML(value interface{}) []byte {
 	return data
 }
 
-func formatJSON(value interface{}) []byte {
+func formatJSON(value any) []byte {
 	data, err := json.MarshalIndent(value, "", "  ")
 	if err != nil {
 		panic(fmt.Sprintf("Internal error rendering json, error: %s", err))
@@ -76,7 +73,7 @@ func formatJSON(value interface{}) []byte {
 	return data
 }
 
-func isString(value interface{}) error {
+func isString(value any) error {
 	if _, ok := value.(string); !ok {
 		return errors.New("must be a string")
 	}

--- a/clients/client-shell/cmds/d2g/d2g.go
+++ b/clients/client-shell/cmds/d2g/d2g.go
@@ -46,7 +46,7 @@ func convert(cmd *cobra.Command, args []string) (err error) {
 		return err
 	}
 
-	var dwTaskDef map[string]interface{}
+	var dwTaskDef map[string]any
 	var inputPayload json.RawMessage
 	if isTaskDef {
 		err = json.Unmarshal(input, &dwTaskDef)
@@ -79,7 +79,7 @@ func convert(cmd *cobra.Command, args []string) (err error) {
 		return fmt.Errorf("failed to convert input to a docker worker payload definition: %v", err)
 	}
 
-	d2gConfig := map[string]interface{}{
+	d2gConfig := map[string]any{
 		"allowChainOfTrust":     true,
 		"allowDisableSeccomp":   true,
 		"allowHostSharedMemory": true,
@@ -111,7 +111,7 @@ func convert(cmd *cobra.Command, args []string) (err error) {
 		}
 
 		// Validate the JSON output against the schema
-		var gwTaskDef map[string]interface{}
+		var gwTaskDef map[string]any
 		err = json.Unmarshal(gwTaskDefJSON, &gwTaskDef)
 		if err != nil {
 			return fmt.Errorf("failed to unmarshal generic worker task definition: %v", err)

--- a/clients/client-shell/cmds/task/fetchers_test.go
+++ b/clients/client-shell/cmds/task/fetchers_test.go
@@ -120,10 +120,10 @@ func (suite *FakeServerSuite) TestDefCommand() {
 	args := []string{fakeTaskID}
 	assert.NoError(suite.T(), runDef(&tcclient.Credentials{}, args, cmd.OutOrStdout(), cmd.Flags()))
 
-	var f interface{}
+	var f any
 	assert.NoError(suite.T(), json.Unmarshal(buf.Bytes(), &f))
-	m := f.(map[string]interface{})
-	m = m["metadata"].(map[string]interface{})
+	m := f.(map[string]any)
+	m = m["metadata"].(map[string]any)
 	suite.Equal("my-test", m["name"])
 }
 

--- a/clients/client-shell/codegen/generator.go
+++ b/clients/client-shell/codegen/generator.go
@@ -20,12 +20,12 @@ func (g *Generator) Write(p []byte) (n int, err error) {
 }
 
 // Printf prints the given format+args to the buffer.
-func (g *Generator) Printf(format string, args ...interface{}) {
+func (g *Generator) Printf(format string, args ...any) {
 	fmt.Fprintf(&g.buf, format, args...)
 }
 
 // Print prints the given a to the buffer.
-func (g *Generator) Print(a ...interface{}) {
+func (g *Generator) Print(a ...any) {
 	fmt.Fprint(&g.buf, a...)
 }
 
@@ -34,7 +34,7 @@ func (g *Generator) Print(a ...interface{}) {
 // There are special rules for some composite types to ensure we have verbose
 // output, but simple types such as strings and numbers are printed using the
 // built-in `%#v` format filter.
-func (g *Generator) PrettyPrint(data interface{}) {
+func (g *Generator) PrettyPrint(data any) {
 	v := reflect.ValueOf(data)
 	t := v.Type()
 

--- a/clients/client-shell/codegen/references.go
+++ b/clients/client-shell/codegen/references.go
@@ -32,7 +32,7 @@ func LoadReferences() (*References, error) {
 	return r, nil
 }
 
-func (r *References) get(filename string, v interface{}) error {
+func (r *References) get(filename string, v any) error {
 	if filename[0] == '/' {
 		filename = filename[1:]
 	}

--- a/clients/client-shell/config/init.go
+++ b/clients/client-shell/config/init.go
@@ -9,7 +9,7 @@ import (
 
 var (
 	// Configuration contains the current configuration values.
-	Configuration map[string]map[string]interface{}
+	Configuration map[string]map[string]any
 
 	// OptionsDefinitions is a map of all the OptionDefinitions, by command.
 	OptionsDefinitions = make(map[string]map[string]OptionDefinition)

--- a/clients/client-shell/config/option.go
+++ b/clients/client-shell/config/option.go
@@ -1,13 +1,15 @@
 package config
 
+import "maps"
+
 // A OptionDefinition is something with a default value and a validator.
 // Only requirement is that values are JSON structures.
 type OptionDefinition struct {
-	Description string      // Description of the config option
-	Default     interface{} // Default value
-	Env         string      // Environment variable to attempt to load from (optional)
-	Parse       bool        // True, if string input should be parsed as JSON
-	Validate    func(value interface{}) error
+	Description string // Description of the config option
+	Default     any    // Default value
+	Env         string // Environment variable to attempt to load from (optional)
+	Parse       bool   // True, if string input should be parsed as JSON
+	Validate    func(value any) error
 }
 
 // RegisterOptions takes in the name of the command and an map of OptionDefinition objects
@@ -16,8 +18,5 @@ func RegisterOptions(command string, options map[string]OptionDefinition) {
 		OptionsDefinitions[command] = make(map[string]OptionDefinition)
 	}
 
-	// we could just copy 'options' but sometimes there might already be other options
-	for key, option := range options {
-		OptionsDefinitions[command][key] = option
-	}
+	maps.Copy(OptionsDefinitions[command], options)
 }

--- a/clients/client-shell/config/serialization.go
+++ b/clients/client-shell/config/serialization.go
@@ -29,8 +29,8 @@ func configFile() string {
 // Load will load configuration file, and initialize a default configuration
 // if no configuration is present. This only returns an error if a configuration
 // file is present, but we are unable to parse it.
-func Load() (map[string]map[string]interface{}, error) {
-	config := make(map[string]map[string]interface{})
+func Load() (map[string]map[string]any, error) {
+	config := make(map[string]map[string]any)
 
 	// Read config file and unmarshal into config overwriting default values
 	// if os.ReadFile returns an error, it means the config file couldn't
@@ -48,7 +48,7 @@ func Load() (map[string]map[string]interface{}, error) {
 	// Populate missing config fields with default values
 	for command, options := range OptionsDefinitions {
 		if _, ok := config[command]; !ok {
-			config[command] = make(map[string]interface{})
+			config[command] = make(map[string]any)
 		}
 
 		for option, definition := range options {
@@ -73,7 +73,7 @@ func Load() (map[string]map[string]interface{}, error) {
 			}
 
 			// parse value, if required
-			var value interface{}
+			var value any
 			if definition.Parse {
 				if err := json.Unmarshal([]byte(val), &value); err != nil {
 					return nil, fmt.Errorf(
@@ -126,8 +126,8 @@ func Load() (map[string]map[string]interface{}, error) {
 }
 
 // Save will save configuration.
-func Save(config map[string]map[string]interface{}) error {
-	result := make(map[string]map[string]interface{})
+func Save(config map[string]map[string]any) error {
+	result := make(map[string]map[string]any)
 
 	// go over new object
 	for name, options := range OptionsDefinitions {
@@ -151,7 +151,7 @@ func Save(config map[string]map[string]interface{}) error {
 
 			// Ensure we have an object to save the key
 			if result[name] == nil {
-				result[name] = make(map[string]interface{})
+				result[name] = make(map[string]any)
 			}
 
 			// Save the config key

--- a/internal/jsontest/jsontest.go
+++ b/internal/jsontest/jsontest.go
@@ -21,7 +21,7 @@ func JsonEqual(a []byte, b []byte) (bool, []byte, []byte, error) {
 // canonical representation of json (i.e. formatted with objects ordered).
 // Ugly and perhaps inefficient, but effective! :p
 func FormatJson(a []byte) ([]byte, error) {
-	tmpObj := new(interface{})
+	tmpObj := new(any)
 	err := json.Unmarshal(a, &tmpObj)
 	if err != nil {
 		return a, err

--- a/internal/mocktc/mocktc.go
+++ b/internal/mocktc/mocktc.go
@@ -26,7 +26,7 @@ func Vars(r *http.Request) map[string]string {
 	return decodedVars
 }
 
-func WriteAsJSON(t *testing.T, w http.ResponseWriter, resp interface{}) {
+func WriteAsJSON(t *testing.T, w http.ResponseWriter, resp any) {
 	t.Helper()
 	bytes, err := json.MarshalIndent(resp, "", "  ")
 	if err != nil {
@@ -38,7 +38,7 @@ func WriteAsJSON(t *testing.T, w http.ResponseWriter, resp interface{}) {
 	}
 }
 
-func JSON(w http.ResponseWriter, resp interface{}, err error) {
+func JSON(w http.ResponseWriter, resp any, err error) {
 	if err != nil {
 		ReportError(w, err)
 		return
@@ -79,7 +79,7 @@ func NoBody(w http.ResponseWriter, err error) {
 	w.WriteHeader(200)
 }
 
-func Marshal(req *http.Request, payload interface{}) {
+func Marshal(req *http.Request, payload any) {
 	dec := json.NewDecoder(req.Body)
 	dec.DisallowUnknownFields()
 	err := dec.Decode(payload)

--- a/internal/mocktc/object.go
+++ b/internal/mocktc/object.go
@@ -6,6 +6,8 @@ import (
 	"testing"
 	"time"
 
+	"maps"
+
 	tcclient "github.com/taskcluster/taskcluster/v81/clients/client-go"
 	"github.com/taskcluster/taskcluster/v81/clients/client-go/tcobject"
 )
@@ -81,9 +83,7 @@ func (object *Object) FinishUpload(name string, payload *tcobject.FinishUploadRe
 			return err
 		}
 
-		for k, v := range newHashes {
-			o.hashes[k] = v
-		}
+		maps.Copy(o.hashes, newHashes)
 	}
 
 	return nil
@@ -100,7 +100,7 @@ func (object *Object) StartDownload(name string, payload *tcobject.DownloadObjec
 
 	var err error
 	var dor tcobject.DownloadObjectResponse
-	var resp interface{}
+	var resp any
 	switch {
 	case payload.AcceptDownloadMethods.Simple:
 		if o.onMockS3 {

--- a/internal/mocktc/queue.go
+++ b/internal/mocktc/queue.go
@@ -32,7 +32,7 @@ type Queue struct {
 	tasks map[string]*tcqueue.TaskDefinitionAndStatus
 
 	// artifacts["<taskId>:<runId>"]["<name>"]
-	artifacts map[string]map[string]interface{}
+	artifacts map[string]map[string]any
 
 	baseURL string
 }
@@ -42,7 +42,7 @@ func NewQueue(t *testing.T, baseURL string) *Queue {
 	return &Queue{
 		t:         t,
 		tasks:     map[string]*tcqueue.TaskDefinitionAndStatus{},
-		artifacts: map[string]map[string]interface{}{},
+		artifacts: map[string]map[string]any{},
 		baseURL:   baseURL,
 	}
 }
@@ -101,7 +101,7 @@ func (queue *Queue) ClaimWork(taskQueueId string, payload *tcqueue.ClaimWorkRequ
 
 func (queue *Queue) ensureArtifactMap(taskId, runId string) {
 	if _, mapAlreadyCreated := queue.artifacts[taskId+":"+runId]; !mapAlreadyCreated {
-		queue.artifacts[taskId+":"+runId] = map[string]interface{}{}
+		queue.artifacts[taskId+":"+runId] = map[string]any{}
 	}
 }
 
@@ -117,7 +117,7 @@ func (queue *Queue) CreateArtifact(taskId, runId, name string, payload *tcqueue.
 		queue.t.Fatalf("Error unmarshalling from json: %v", err)
 	}
 
-	var req, resp interface{}
+	var req, resp any
 	switch request.StorageType {
 	case "s3":
 		var s3Request tcqueue.S3ArtifactRequest
@@ -185,7 +185,7 @@ func (queue *Queue) FinishArtifact(taskId, runId, name string, payload *tcqueue.
 	return nil
 }
 
-func (queue *Queue) ensureUnchangedIfAlreadyExists(taskId, runId, name string, request interface{}) error {
+func (queue *Queue) ensureUnchangedIfAlreadyExists(taskId, runId, name string, request any) error {
 	previousVersion, existed := queue.artifacts[taskId+":"+runId][name]
 	if !existed || reflect.DeepEqual(previousVersion, request) {
 		return nil

--- a/taskcluster/kinds/go/kind.yml
+++ b/taskcluster/kinds/go/kind.yml
@@ -68,3 +68,10 @@ tasks:
           git status
           test $(git status --porcelain | wc -l) == 0
           go install ./...
+  modernize:
+    description: ensure go code is modern
+    run:
+      command:
+        - |
+          GOFLAGS="-tags=insecure" go run golang.org/x/tools/gopls/internal/analysis/modernize/cmd/modernize@latest -test ./...
+          GOFLAGS="-tags=multiuser" go run -tags=multiuser golang.org/x/tools/gopls/internal/analysis/modernize/cmd/modernize@latest -test ./...

--- a/tools/d2g/d2gtest/d2g_test.go
+++ b/tools/d2g/d2gtest/d2g_test.go
@@ -145,7 +145,7 @@ func (tc *TaskPayloadTestCase) TestTaskPayloadCase() func(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Cannot marshal test suite D2GConfig: %v", err)
 		}
-		var d2gConfigMap map[string]interface{}
+		var d2gConfigMap map[string]any
 		err = json.Unmarshal(d2gConfigBytes, &d2gConfigMap)
 		if err != nil {
 			t.Fatalf("Cannot unmarshal test suite D2GConfig %v: %v", string(d2gConfigBytes), err)
@@ -187,7 +187,7 @@ func (tc *TaskDefinitionTestCase) TestTaskDefinitionCase() func(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Cannot marshal test suite D2GConfig: %v", err)
 		}
-		var d2gConfigMap map[string]interface{}
+		var d2gConfigMap map[string]any
 		err = json.Unmarshal(d2gConfigBytes, &d2gConfigMap)
 		if err != nil {
 			t.Fatalf("Cannot unmarshal test suite D2GConfig %v: %v", string(d2gConfigBytes), err)
@@ -231,7 +231,7 @@ func yamlToJSON(t *testing.T, path string) []byte {
 	// Takes json []byte input, unmarshals and then marshals, in order to get a
 	// canonical representation of json (i.e. formatted with objects ordered).
 	// Ugly and perhaps inefficient, but effective! :p
-	tmpObj := new(interface{})
+	tmpObj := new(any)
 	err = json.Unmarshal(j, &tmpObj)
 	if err != nil {
 		t.Fatal(err)
@@ -243,7 +243,7 @@ func yamlToJSON(t *testing.T, path string) []byte {
 	return formatted
 }
 
-func unmarshalYAML(t *testing.T, dest interface{}, path string) {
+func unmarshalYAML(t *testing.T, dest any, path string) {
 	t.Helper()
 	j := yamlToJSON(t, path)
 	err := json.Unmarshal(j, dest)
@@ -252,7 +252,7 @@ func unmarshalYAML(t *testing.T, dest interface{}, path string) {
 	}
 }
 
-func marshalYAML(t *testing.T, src interface{}, path string) {
+func marshalYAML(t *testing.T, src any, path string) {
 	t.Helper()
 	j, err := json.Marshal(src)
 	if err != nil {
@@ -304,7 +304,7 @@ func (tc *TaskDefinitionTestCase) Validate(t *testing.T) {
 	var dwRaw json.RawMessage
 	var gwRaw json.RawMessage
 
-	var parsedDwTaskDef map[string]interface{}
+	var parsedDwTaskDef map[string]any
 	err := json.Unmarshal(tc.DockerWorkerTaskDefinition, &parsedDwTaskDef)
 	if err != nil {
 		t.Fatalf("cannot parse Docker Worker task definition: %v", err)
@@ -315,7 +315,7 @@ func (tc *TaskDefinitionTestCase) Validate(t *testing.T) {
 		t.Fatalf("Cannot marshal test suite Docker Worker payload %#v: %v", parsedDwTaskDef["payload"], err)
 	}
 
-	var parsedGwTaskDef map[string]interface{}
+	var parsedGwTaskDef map[string]any
 	err = json.Unmarshal(tc.GenericWorkerTaskDefinition, &parsedGwTaskDef)
 	if err != nil {
 		t.Fatalf("cannot parse Generic Worker task definition: %v", err)

--- a/tools/d2g/dockerimageartifact.go
+++ b/tools/d2g/dockerimageartifact.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"slices"
+
 	"github.com/taskcluster/taskcluster/v81/tools/d2g/genericworker"
 )
 
@@ -28,13 +30,10 @@ func (dia *DockerImageArtifact) FileMounts() ([]genericworker.FileMount, error) 
 	}
 	// docker can load images compressed with gzip, bzip2, xz, or zstd
 	// https://docs.docker.com/reference/cli/docker/image/load/
-	for _, ext := range []string{"gz", "bz2", "xz", "zst"} {
+	if slices.Contains([]string{"gz", "bz2", "xz", "zst"}, fm.Format) {
 		// explicity set to the empty string so generic worker
 		// does not decompress the image before running `docker load`
-		if ext == fm.Format {
-			fm.Format = ""
-			break
-		}
+		fm.Format = ""
 	}
 	return []genericworker.FileMount{fm}, nil
 }

--- a/tools/d2g/indexeddockerimage.go
+++ b/tools/d2g/indexeddockerimage.go
@@ -6,6 +6,8 @@ import (
 	"path/filepath"
 	"strings"
 
+	"slices"
+
 	"github.com/taskcluster/taskcluster/v81/tools/d2g/genericworker"
 )
 
@@ -29,13 +31,10 @@ func (idi *IndexedDockerImage) FileMounts() ([]genericworker.FileMount, error) {
 	}
 	// docker can load images compressed with gzip, bzip2, xz, or zstd
 	// https://docs.docker.com/reference/cli/docker/image/load/
-	for _, ext := range []string{"gz", "bz2", "xz", "zst"} {
+	if slices.Contains([]string{"gz", "bz2", "xz", "zst"}, fm.Format) {
 		// explicity set to the empty string so generic worker
 		// does not decompress the image before running `docker load`
-		if ext == fm.Format {
-			fm.Format = ""
-			break
-		}
+		fm.Format = ""
 	}
 	return []genericworker.FileMount{fm}, nil
 }

--- a/tools/jsonschema2go/README.md
+++ b/tools/jsonschema2go/README.md
@@ -6,7 +6,7 @@ Are you writing a service in go that needs to interpret json data, and you alrea
 
 Typically, you would need to unmarshal the json into a go type in order to use the data. The go type could be:
 
-1. A generic `interface{}` ... ouch
+1. A generic `any` ... ouch
 2. A hand-crafted type ... not bad
 3. An auto-generated type ... even better!
 

--- a/tools/jsonschema2go/jsonschema.go
+++ b/tools/jsonschema2go/jsonschema.go
@@ -118,12 +118,12 @@ type (
 		AdditionalProperties *AdditionalProperties  `json:"additionalProperties,omitempty"`
 		AllOf                *Items                 `json:"allOf,omitempty"`
 		AnyOf                *Items                 `json:"anyOf,omitempty"`
-		Const                *interface{}           `json:"const,omitempty"`
-		Default              *interface{}           `json:"default,omitempty"`
+		Const                *any                   `json:"const,omitempty"`
+		Default              *any                   `json:"default,omitempty"`
 		Definitions          *Properties            `json:"definitions,omitempty"`
 		Dependencies         map[string]*Dependency `json:"dependencies,omitempty"`
 		Description          *string                `json:"description,omitempty"`
-		Enum                 []interface{}          `json:"enum,omitempty"`
+		Enum                 []any                  `json:"enum,omitempty"`
 		ExclusiveMaximum     *bool                  `json:"exclusiveMaximum,omitempty"`
 		ExclusiveMinimum     *bool                  `json:"exclusiveMinimum,omitempty"`
 		Format               *string                `json:"format,omitempty"`
@@ -370,7 +370,7 @@ func (jsonSubSchema *JsonSubSchema) typeDefinition(disableNested bool, enableDef
 	}
 	switch typ {
 	case "array":
-		typ = "[]interface{}"
+		typ = "[]any"
 		if jsonSubSchema.Items != nil {
 			arrayComment, arrayType := jsonSubSchema.Items.typeDefinition(disableNested, enableDefaults, false, extraPackages, rawMessageTypes)
 			typ = "[]" + arrayType
@@ -1180,7 +1180,7 @@ func (subSchema *JsonSubSchema) inferType() *string {
 	return nil
 }
 
-func jsonSchemaTypeFromValue(v interface{}) *string {
+func jsonSchemaTypeFromValue(v any) *string {
 	var inferredType string
 	switch t := v.(type) {
 	case bool:
@@ -1189,9 +1189,9 @@ func jsonSchemaTypeFromValue(v interface{}) *string {
 		inferredType = "number"
 	case string:
 		inferredType = "string"
-	case []interface{}:
+	case []any:
 		inferredType = "array"
-	case map[string]interface{}:
+	case map[string]any:
 		inferredType = "object"
 	case nil:
 		inferredType = "null"

--- a/tools/livelog/sequence_test.go
+++ b/tools/livelog/sequence_test.go
@@ -65,7 +65,7 @@ func TestSequence(t *testing.T) {
 	// generate some longish chunks
 	var chunks [][]byte
 	for i := range 5000 {
-		chunks = append(chunks, []byte(fmt.Sprintf("%d|%s\n", i, TEXT)))
+		chunks = append(chunks, fmt.Appendf(nil, "%d|%s\n", i, TEXT))
 	}
 
 	client := http.Client{}

--- a/tools/livelog/writer/stream_handle.go
+++ b/tools/livelog/writer/stream_handle.go
@@ -79,12 +79,7 @@ func (streamHandle *StreamHandle) WriteTo(target io.Writer) (n int64, err error)
 
 		// Determine how much to copy over based on the `Stop` value for this
 		// handle.
-		var offset int64
-		if streamHandle.Stop > streamOffset {
-			offset = streamOffset
-		} else {
-			offset = streamHandle.Stop
-		}
+		offset := min(streamHandle.Stop, streamOffset)
 
 		// Begin by copying the initial data from the sink...
 		written, copyErr := io.CopyN(target, file, offset)

--- a/tools/taskcluster-proxy/authorization_test.go
+++ b/tools/taskcluster-proxy/authorization_test.go
@@ -571,7 +571,7 @@ func TestGetResponseBody(t *testing.T) {
 			// Function to test
 			routes.RootHandler(res, req)
 
-			var body map[string]interface{}
+			var body map[string]any
 			err = json.Unmarshal(res.Body.Bytes(), &body)
 			if err != nil {
 				log.Fatal(err)

--- a/tools/taskcluster-proxy/main.go
+++ b/tools/taskcluster-proxy/main.go
@@ -80,7 +80,7 @@ func ParseCommandArgs(argv []string, exit bool) (routes Routes, address string, 
 	if revision != "" {
 		fullversion += " (git revision " + revision + ")"
 	}
-	var arguments map[string]interface{}
+	var arguments map[string]any
 	arguments, err = docopt.ParseArgs(usage, argv, fullversion)
 	if err != nil {
 		return

--- a/tools/taskcluster-proxy/routes.go
+++ b/tools/taskcluster-proxy/routes.go
@@ -13,6 +13,8 @@ import (
 	"sync"
 	"time"
 
+	"maps"
+
 	"github.com/taskcluster/httpbackoff/v3"
 	tcUrls "github.com/taskcluster/taskcluster-lib-urls"
 	tcclient "github.com/taskcluster/taskcluster/v81/clients/client-go"
@@ -251,9 +253,7 @@ func (routes *Routes) commonHandler(res http.ResponseWriter, req *http.Request, 
 		if err != nil {
 			return nil, nil, fmt.Errorf("error constructing request: %s", err)
 		}
-		for k, v := range req.Header {
-			proxyreq.Header[k] = v
-		}
+		maps.Copy(proxyreq.Header, req.Header)
 
 		// for compatibility, if there is no request Content-Type and the body
 		// has nonzero length, we add a Content-Type header.  See #3521.

--- a/tools/websocktunnel/client/client_test.go
+++ b/tools/websocktunnel/client/client_test.go
@@ -164,7 +164,7 @@ func TestAuthorizer(t *testing.T) {
 			return
 		}
 
-		token, err := jwt.Parse(tokenString, func(token *jwt.Token) (interface{}, error) {
+		token, err := jwt.Parse(tokenString, func(token *jwt.Token) (any, error) {
 			if _, ok := token.Method.(*jwt.SigningMethodHMAC); !ok {
 				return nil, errors.New("unexpected signing method")
 			}

--- a/tools/websocktunnel/client/retry_config.go
+++ b/tools/websocktunnel/client/retry_config.go
@@ -51,11 +51,7 @@ func (r RetryConfig) nextDelay(currentDelay time.Duration) time.Duration {
 	minDelay := r.Multiplier*float64(currentDelay) - delta
 	maxDelay := r.Multiplier*float64(currentDelay) + delta
 	nextDelay := minDelay + (rand.Float64() * (maxDelay - minDelay + 1))
-	Delay := time.Duration(nextDelay)
-	if Delay > r.MaxDelay {
-		Delay = r.MaxDelay
-	}
-	return Delay
+	return min(time.Duration(nextDelay), r.MaxDelay)
 }
 
 // initializeRetryValues returns a copy of this RetryConfig with nonzero

--- a/tools/websocktunnel/util/logging.go
+++ b/tools/websocktunnel/util/logging.go
@@ -2,15 +2,15 @@ package util
 
 // Logger is used by Session and Client to write logs
 type Logger interface {
-	Printf(format string, a ...interface{})
-	Print(a ...interface{})
+	Printf(format string, a ...any)
+	Print(a ...any)
 }
 
 // NilLogger implements Logger and discards all writes
 type NilLogger struct{}
 
 // Printf discards writes
-func (n *NilLogger) Printf(format string, a ...interface{}) {}
+func (n *NilLogger) Printf(format string, a ...any) {}
 
 // Print discards writes
-func (n *NilLogger) Print(a ...interface{}) {}
+func (n *NilLogger) Print(a ...any) {}

--- a/tools/worker-runner/cfg/loggingconfig.go
+++ b/tools/worker-runner/cfg/loggingconfig.go
@@ -10,7 +10,7 @@ import (
 // plus any additional provider-specific properties.
 type LoggingConfig struct {
 	Implementation string
-	Data           map[string]interface{}
+	Data           map[string]any
 }
 
 func (lc *LoggingConfig) UnmarshalYAML(node *yaml.Node) error {

--- a/tools/worker-runner/cfg/loggingconfig_test.go
+++ b/tools/worker-runner/cfg/loggingconfig_test.go
@@ -15,5 +15,5 @@ func TestUnmarshalLoggingYAML(t *testing.T) {
 		t.Fatalf("failed to load: %s", err)
 	}
 	require.Equal(t, "stdio", lc.Implementation)
-	require.Equal(t, map[string]interface{}{"foo": "bar"}, lc.Data)
+	require.Equal(t, map[string]any{"foo": "bar"}, lc.Data)
 }

--- a/tools/worker-runner/cfg/providerconfig.go
+++ b/tools/worker-runner/cfg/providerconfig.go
@@ -12,7 +12,7 @@ import (
 // plus any additional provider-specific properties.
 type ProviderConfig struct {
 	ProviderType string
-	Data         map[string]interface{}
+	Data         map[string]any
 }
 
 func (pc *ProviderConfig) UnmarshalYAML(node *yaml.Node) error {
@@ -40,7 +40,7 @@ func (pc *ProviderConfig) UnmarshalYAML(node *yaml.Node) error {
 //
 // Structs should be tagged with `provider:"name"`, with the name defaulting to the
 // lowercased version of the field name.
-func (pc *ProviderConfig) Unpack(out interface{}) error {
+func (pc *ProviderConfig) Unpack(out any) error {
 	outval := reflect.ValueOf(out)
 	if outval.Kind() != reflect.Ptr || outval.IsNil() {
 		return fmt.Errorf("expected a pointer, got %s", outval.Kind())

--- a/tools/worker-runner/cfg/providerconfig_test.go
+++ b/tools/worker-runner/cfg/providerconfig_test.go
@@ -37,7 +37,7 @@ func TestProviderOK(t *testing.T) {
 		t.Fatalf("failed to unmarshal: %s", err)
 	}
 
-	assert.Equal(t, map[string]interface{}{"value": "sure"}, pc.Data, "did not get expected config")
+	assert.Equal(t, map[string]any{"value": "sure"}, pc.Data, "did not get expected config")
 }
 
 func TestProviderUnpack(t *testing.T) {

--- a/tools/worker-runner/cfg/workerconfig_test.go
+++ b/tools/worker-runner/cfg/workerconfig_test.go
@@ -16,7 +16,7 @@ func TestUnmarshalYAML(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to load: %s", err)
 	}
-	assert.Equal(t, map[string]interface{}{"x": 10.0}, wc.data, "should read yaml correctly")
+	assert.Equal(t, map[string]any{"x": 10.0}, wc.data, "should read yaml correctly")
 }
 
 func TestUnmarshalJSON(t *testing.T) {
@@ -26,7 +26,7 @@ func TestUnmarshalJSON(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to load: %s", err)
 	}
-	assert.Equal(t, map[string]interface{}{"x": "y"}, wc.data, "should read json correctly")
+	assert.Equal(t, map[string]any{"x": "y"}, wc.data, "should read json correctly")
 }
 
 func TestMergeDistinctProperties(t *testing.T) {
@@ -39,7 +39,7 @@ func TestMergeDistinctProperties(t *testing.T) {
 
 	merged := wc1.Merge(&wc2)
 
-	assert.Equal(t, map[string]interface{}{"x": 10.0, "y": 20.0}, merged.data, "should merge configs")
+	assert.Equal(t, map[string]any{"x": 10.0, "y": 20.0}, merged.data, "should merge configs")
 }
 
 func TestMergeOverwriteProperty(t *testing.T) {
@@ -52,7 +52,7 @@ func TestMergeOverwriteProperty(t *testing.T) {
 
 	merged := wc1.Merge(&wc2)
 
-	assert.Equal(t, map[string]interface{}{"x": 20.0}, merged.data, "should merge configs")
+	assert.Equal(t, map[string]any{"x": 20.0}, merged.data, "should merge configs")
 }
 
 func TestMergeOverwritePropertyDifferentTypes(t *testing.T) {
@@ -65,7 +65,7 @@ func TestMergeOverwritePropertyDifferentTypes(t *testing.T) {
 
 	merged := wc1.Merge(&wc2)
 
-	assert.Equal(t, map[string]interface{}{"x": 13.0}, merged.data, "should merge configs")
+	assert.Equal(t, map[string]any{"x": 13.0}, merged.data, "should merge configs")
 }
 
 func TestMergeAppendArray(t *testing.T) {
@@ -79,9 +79,9 @@ func TestMergeAppendArray(t *testing.T) {
 	merged := wc1.Merge(&wc2)
 
 	assert.Equal(t,
-		map[string]interface{}{"x": []interface{}{
-			interface{}("a"),
-			interface{}("b"),
+		map[string]any{"x": []any{
+			any("a"),
+			any("b"),
 		}},
 		merged.data,
 		"should append arrays")
@@ -98,8 +98,8 @@ func TestMergeRecurseObjects(t *testing.T) {
 	merged := wc1.Merge(&wc2)
 
 	assert.Equal(t,
-		map[string]interface{}{
-			"x": map[string]interface{}{
+		map[string]any{
+			"x": map[string]any{
 				"a": 10.0,
 				"b": 10.0,
 			},
@@ -117,7 +117,7 @@ func TestMergeFirstNil(t *testing.T) {
 
 	merged := wc1.Merge(&wc2)
 
-	assert.Equal(t, map[string]interface{}{"x": 10.0}, merged.data, "should return existing config")
+	assert.Equal(t, map[string]any{"x": 10.0}, merged.data, "should return existing config")
 }
 
 func TestMergeSecondNil(t *testing.T) {
@@ -129,7 +129,7 @@ func TestMergeSecondNil(t *testing.T) {
 
 	merged := wc1.Merge(wc2)
 
-	assert.Equal(t, map[string]interface{}{"x": 10.0}, merged.data, "should return existing config")
+	assert.Equal(t, map[string]any{"x": 10.0}, merged.data, "should return existing config")
 }
 
 func TestMergeBothNil(t *testing.T) {
@@ -138,7 +138,7 @@ func TestMergeBothNil(t *testing.T) {
 
 	merged := wc1.Merge(wc2)
 
-	assert.Equal(t, map[string]interface{}{}, merged.data, "should return empty config")
+	assert.Equal(t, map[string]any{}, merged.data, "should return empty config")
 }
 
 func TestSetNilNoDot(t *testing.T) {
@@ -147,7 +147,7 @@ func TestSetNilNoDot(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to set: %s", err)
 	}
-	assert.Equal(t, map[string]interface{}{"x": "a"}, wc2.data, "should set x")
+	assert.Equal(t, map[string]any{"x": "a"}, wc2.data, "should set x")
 }
 
 func TestSetEmptyNoDot(t *testing.T) {
@@ -159,7 +159,7 @@ func TestSetEmptyNoDot(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to set: %s", err)
 	}
-	assert.Equal(t, map[string]interface{}{"x": "a"}, wc2.data, "should set x")
+	assert.Equal(t, map[string]any{"x": "a"}, wc2.data, "should set x")
 }
 
 func TestSetEmptyWithDot(t *testing.T) {
@@ -171,7 +171,7 @@ func TestSetEmptyWithDot(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to set: %s", err)
 	}
-	assert.Equal(t, map[string]interface{}{"x": map[string]interface{}{"y": "a"}}, wc2.data, "should set x.y")
+	assert.Equal(t, map[string]any{"x": map[string]any{"y": "a"}}, wc2.data, "should set x.y")
 }
 
 func TestSetExistingData(t *testing.T) {
@@ -183,7 +183,7 @@ func TestSetExistingData(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to set: %s", err)
 	}
-	assert.Equal(t, map[string]interface{}{"x": map[string]interface{}{"y": "a"}}, wc2.data, "should set x.y")
+	assert.Equal(t, map[string]any{"x": map[string]any{"y": "a"}}, wc2.data, "should set x.y")
 }
 
 func TestSetExistingDataSiblings(t *testing.T) {
@@ -196,9 +196,9 @@ func TestSetExistingDataSiblings(t *testing.T) {
 		t.Fatalf("failed to set: %s", err)
 	}
 	assert.Equal(t,
-		map[string]interface{}{
+		map[string]any{
 			"p": true,
-			"x": map[string]interface{}{
+			"x": map[string]any{
 				"q": true,
 				"y": "a",
 			},
@@ -206,9 +206,9 @@ func TestSetExistingDataSiblings(t *testing.T) {
 
 	// and just check wc wasn't modified
 	assert.Equal(t,
-		map[string]interface{}{
+		map[string]any{
 			"p": true,
-			"x": map[string]interface{}{
+			"x": map[string]any{
 				"q": true,
 				"y": "xxx",
 			},

--- a/tools/worker-runner/cfg/workerimplconfig.go
+++ b/tools/worker-runner/cfg/workerimplconfig.go
@@ -12,7 +12,7 @@ import (
 // plus any additional worker implementation-specific properties.
 type WorkerImplementationConfig struct {
 	Implementation string
-	Data           map[string]interface{}
+	Data           map[string]any
 }
 
 func (pc *WorkerImplementationConfig) UnmarshalYAML(node *yaml.Node) error {
@@ -40,7 +40,7 @@ func (pc *WorkerImplementationConfig) UnmarshalYAML(node *yaml.Node) error {
 //
 // Structs should be tagged with `workerimpl:"name"`, with the name defaulting to the
 // lowercased version of the field name.
-func (pc *WorkerImplementationConfig) Unpack(out interface{}) error {
+func (pc *WorkerImplementationConfig) Unpack(out any) error {
 	outval := reflect.ValueOf(out)
 	if outval.Kind() != reflect.Ptr || outval.IsNil() {
 		return fmt.Errorf("expected a pointer, got %s", outval.Kind())

--- a/tools/worker-runner/cfg/workerimplconfig_test.go
+++ b/tools/worker-runner/cfg/workerimplconfig_test.go
@@ -38,7 +38,7 @@ func TestWorkerImplOK(t *testing.T) {
 		t.Fatalf("failed to unmarshal: %s", err)
 	}
 
-	assert.Equal(t, map[string]interface{}{"value": "sure"}, pc.Data, "did not get expected config")
+	assert.Equal(t, map[string]any{"value": "sure"}, pc.Data, "did not get expected config")
 }
 
 func TestWorkerImplUnpack(t *testing.T) {

--- a/tools/worker-runner/errorreport/errorreport.go
+++ b/tools/worker-runner/errorreport/errorreport.go
@@ -31,7 +31,7 @@ func (er *ErrorReporter) HandleMessage(msg workerproto.Message) {
 	er.state.Lock()
 	defer er.state.Unlock()
 
-	validate := func(things map[string]interface{}, key, expectedType string) bool {
+	validate := func(things map[string]any, key, expectedType string) bool {
 		if _, ok := things[key]; !ok {
 			return false
 		}
@@ -59,7 +59,7 @@ func (er *ErrorReporter) HandleMessage(msg workerproto.Message) {
 		return
 	}
 
-	extra := msg.Properties["extra"].(map[string]interface{})
+	extra := msg.Properties["extra"].(map[string]any)
 	extraMsg, err := json.Marshal(extra)
 	if err != nil {
 		log.Printf("Error processing error-report message, could not marshal extra")

--- a/tools/worker-runner/errorreport/errorreport_test.go
+++ b/tools/worker-runner/errorreport/errorreport_test.go
@@ -15,7 +15,7 @@ import (
 
 func TestHandleMessage(t *testing.T) {
 	description := "this is a serious error"
-	extra := map[string]interface{}{
+	extra := map[string]any{
 		"foo": "bar",
 	}
 	kind := "severe"
@@ -38,7 +38,7 @@ func TestHandleMessage(t *testing.T) {
 	wkr.WorkerProtocol.Start(true)
 	wkr.WorkerProtocol.Send(workerproto.Message{
 		Type: "error-report",
-		Properties: map[string]interface{}{
+		Properties: map[string]any{
 			"description": description,
 			"extra":       extra,
 			"kind":        kind,

--- a/tools/worker-runner/exit/exit_test.go
+++ b/tools/worker-runner/exit/exit_test.go
@@ -31,7 +31,7 @@ func TestShutdownMessage(t *testing.T) {
 
 	wkr.WorkerProtocol.Send(workerproto.Message{
 		Type:       "shutdown",
-		Properties: map[string]interface{}{},
+		Properties: map[string]any{},
 	})
 	wkr.FlushMessagesToRunner()
 

--- a/tools/worker-runner/logging/logging/convert.go
+++ b/tools/worker-runner/logging/logging/convert.go
@@ -10,7 +10,7 @@ import (
 //
 // This treats `textPayload` specially as the message in the message, and includes all
 // other fields after that
-func ToUnstructured(message map[string]interface{}) string {
+func ToUnstructured(message map[string]any) string {
 	textPayload := ""
 	messageKeys := make([]string, 0, len(message))
 	for k := range message {
@@ -58,6 +58,6 @@ func ToUnstructured(message map[string]interface{}) string {
 // Convert an unstructured message to a structured message in a consistent fashion.
 //
 // This returns a value of the shape {"textPayload": <message>}
-func ToStructured(message string) map[string]interface{} {
-	return map[string]interface{}{"textPayload": message}
+func ToStructured(message string) map[string]any {
+	return map[string]any{"textPayload": message}
 }

--- a/tools/worker-runner/logging/logging/convert_test.go
+++ b/tools/worker-runner/logging/logging/convert_test.go
@@ -16,37 +16,37 @@ func TestToUnstructured(t *testing.T) {
 	t.Run("empty", func(t *testing.T) {
 		require.Equal(t,
 			`{}`,
-			ToUnstructured(map[string]interface{}{}))
+			ToUnstructured(map[string]any{}))
 	})
 	t.Run("without textPayload", func(t *testing.T) {
 		require.Equal(t,
 			`a: uh; b: oh`,
-			ToUnstructured(map[string]interface{}{"a": "uh", "b": "oh"}))
+			ToUnstructured(map[string]any{"a": "uh", "b": "oh"}))
 	})
 	t.Run("with textPayload", func(t *testing.T) {
 		require.Equal(t,
 			`uhoh; level: bad`,
-			ToUnstructured(map[string]interface{}{"textPayload": "uhoh", "level": "bad"}))
+			ToUnstructured(map[string]any{"textPayload": "uhoh", "level": "bad"}))
 	})
 	t.Run("with textPayload, but not a string", func(t *testing.T) {
 		require.Equal(t,
 			`level: bad; textPayload: ["uh","oh"]`,
-			ToUnstructured(map[string]interface{}{"textPayload": []string{"uh", "oh"}, "level": "bad"}))
+			ToUnstructured(map[string]any{"textPayload": []string{"uh", "oh"}, "level": "bad"}))
 	})
 	t.Run("with non-string values", func(t *testing.T) {
 		require.Equal(t,
 			`array: [1,2]; bool: false; number: 4`,
-			ToUnstructured(map[string]interface{}{"array": []int{1, 2}, "bool": false, "number": 4}))
+			ToUnstructured(map[string]any{"array": []int{1, 2}, "bool": false, "number": 4}))
 	})
 	t.Run("with non-json-able values", func(t *testing.T) {
 		require.Equal(t,
 			`wat: (func())(0xffff)`,
-			stripHex(ToUnstructured(map[string]interface{}{"wat": func() {}})))
+			stripHex(ToUnstructured(map[string]any{"wat": func() {}})))
 	})
 }
 
 func TestToStructured(t *testing.T) {
 	t.Run("simple payload", func(t *testing.T) {
-		require.Equal(t, map[string]interface{}{"textPayload": "uhoh"}, ToStructured("uhoh"))
+		require.Equal(t, map[string]any{"textPayload": "uhoh"}, ToStructured("uhoh"))
 	})
 }

--- a/tools/worker-runner/logging/logging/interface.go
+++ b/tools/worker-runner/logging/logging/interface.go
@@ -9,5 +9,5 @@ type Logger interface {
 	LogUnstructured(message string)
 
 	// Log a structured message.
-	LogStructured(message map[string]interface{})
+	LogStructured(message map[string]any)
 }

--- a/tools/worker-runner/logging/patch_test.go
+++ b/tools/worker-runner/logging/patch_test.go
@@ -20,13 +20,13 @@ func TestPatchLogger(t *testing.T) {
 	t.Run("single-line println", func(t *testing.T) {
 		defer logDest.Clear()
 		stdLog.Println("hello, world!")
-		require.Equal(t, logDest.Messages(), []map[string]interface{}{map[string]interface{}{"textPayload": "hello, world!"}})
+		require.Equal(t, logDest.Messages(), []map[string]any{{"textPayload": "hello, world!"}})
 	})
 
 	t.Run("multi-line println", func(t *testing.T) {
 		defer logDest.Clear()
 		stdLog.Println("hello\ncruel\nworld!")
-		require.Equal(t, logDest.Messages(), []map[string]interface{}{map[string]interface{}{"textPayload": "hello\ncruel\nworld!"}})
+		require.Equal(t, logDest.Messages(), []map[string]any{{"textPayload": "hello\ncruel\nworld!"}})
 	})
 
 	t.Run("very long multi-line printf", func(t *testing.T) {
@@ -38,6 +38,6 @@ func TestPatchLogger(t *testing.T) {
 		}
 		msg = msg[:len(msg)-1] // remove trailing newline
 		stdLog.Print(msg)
-		require.Equal(t, logDest.Messages(), []map[string]interface{}{map[string]interface{}{"textPayload": msg}})
+		require.Equal(t, logDest.Messages(), []map[string]any{{"textPayload": msg}})
 	})
 }

--- a/tools/worker-runner/logging/protocol/proto.go
+++ b/tools/worker-runner/logging/protocol/proto.go
@@ -11,7 +11,7 @@ func SetProtocol(proto *workerproto.Protocol) {
 	proto.Register("log", func(msg workerproto.Message) {
 		body, ok := msg.Properties["body"]
 		if ok {
-			logging.Destination.LogStructured(body.(map[string]interface{}))
+			logging.Destination.LogStructured(body.(map[string]any))
 		} else {
 			logging.Destination.LogUnstructured("received log message from worker lacking 'body' property")
 		}

--- a/tools/worker-runner/logging/protocol/proto_test.go
+++ b/tools/worker-runner/logging/protocol/proto_test.go
@@ -39,8 +39,8 @@ func TestLoggingProtocol(t *testing.T) {
 		defer logDest.Clear()
 		wkr.WorkerProtocol.Send(workerproto.Message{
 			Type: "log",
-			Properties: map[string]interface{}{
-				"body": map[string]interface{}{
+			Properties: map[string]any{
+				"body": map[string]any{
 					"metric": "foos",
 					"value":  10,
 				},
@@ -50,8 +50,8 @@ func TestLoggingProtocol(t *testing.T) {
 		waitForLogMessage()
 
 		require.Equal(t,
-			[]map[string]interface{}{
-				map[string]interface{}{
+			[]map[string]any{
+				map[string]any{
 					"metric": "foos",
 					"value":  10.0,
 				},
@@ -64,7 +64,7 @@ func TestLoggingProtocol(t *testing.T) {
 		defer logDest.Clear()
 		wkr.WorkerProtocol.Send(workerproto.Message{
 			Type: "log",
-			Properties: map[string]interface{}{
+			Properties: map[string]any{
 				"textPayload": "I forgot about the body property, oops",
 			},
 		})
@@ -72,8 +72,8 @@ func TestLoggingProtocol(t *testing.T) {
 		waitForLogMessage()
 
 		require.Equal(t,
-			[]map[string]interface{}{
-				map[string]interface{}{
+			[]map[string]any{
+				map[string]any{
 					"textPayload": "received log message from worker lacking 'body' property",
 				},
 			},

--- a/tools/worker-runner/logging/stdio/stdio.go
+++ b/tools/worker-runner/logging/stdio/stdio.go
@@ -16,7 +16,7 @@ func (dst *stdioLogDestination) LogUnstructured(message string) {
 	dst.log.Println(message)
 }
 
-func (dst *stdioLogDestination) LogStructured(message map[string]interface{}) {
+func (dst *stdioLogDestination) LogStructured(message map[string]any) {
 	dst.log.Println(logging.ToUnstructured(message))
 }
 

--- a/tools/worker-runner/logging/stdio/stdio_test.go
+++ b/tools/worker-runner/logging/stdio/stdio_test.go
@@ -29,6 +29,6 @@ func TestLogUnstructured(t *testing.T) {
 func TestLogStructured(t *testing.T) {
 	dst, buf := makeLogger()
 
-	dst.LogStructured(map[string]interface{}{"level": "bad"})
+	dst.LogStructured(map[string]any{"level": "bad"})
 	require.Equal(t, []byte("level: bad\n"), buf.Bytes())
 }

--- a/tools/worker-runner/logging/test.go
+++ b/tools/worker-runner/logging/test.go
@@ -8,10 +8,10 @@ import (
 
 type TestLogDestination struct {
 	mutex    sync.Mutex
-	messages []map[string]interface{}
+	messages []map[string]any
 }
 
-func (dst *TestLogDestination) Messages() []map[string]interface{} {
+func (dst *TestLogDestination) Messages() []map[string]any {
 	dst.mutex.Lock()
 	messages := dst.messages
 	dst.mutex.Unlock()
@@ -20,7 +20,7 @@ func (dst *TestLogDestination) Messages() []map[string]interface{} {
 
 func (dst *TestLogDestination) Clear() {
 	dst.mutex.Lock()
-	dst.messages = []map[string]interface{}{}
+	dst.messages = []map[string]any{}
 	dst.mutex.Unlock()
 }
 
@@ -30,7 +30,7 @@ func (dst *TestLogDestination) LogUnstructured(message string) {
 	dst.mutex.Unlock()
 }
 
-func (dst *TestLogDestination) LogStructured(message map[string]interface{}) {
+func (dst *TestLogDestination) LogStructured(message map[string]any) {
 	dst.mutex.Lock()
 	dst.messages = append(dst.messages, message)
 	dst.mutex.Unlock()

--- a/tools/worker-runner/provider/aws/awsprovider.go
+++ b/tools/worker-runner/provider/aws/awsprovider.go
@@ -22,7 +22,7 @@ type AWSProvider struct {
 	workerManagerClientFactory tc.WorkerManagerClientFactory
 	metadataService            MetadataService
 	proto                      *workerproto.Protocol
-	workerIdentityProof        map[string]interface{}
+	workerIdentityProof        map[string]any
 	terminationTicker          *time.Ticker
 }
 
@@ -67,7 +67,7 @@ func (p *AWSProvider) ConfigureRun(state *run.State) error {
 		return err
 	}
 
-	providerMetadata := map[string]interface{}{
+	providerMetadata := map[string]any{
 		"instance-id":       iid_json.InstanceId,
 		"image":             iid_json.ImageId,
 		"instance-type":     iid_json.InstanceType,
@@ -80,15 +80,15 @@ func (p *AWSProvider) ConfigureRun(state *run.State) error {
 
 	state.ProviderMetadata = providerMetadata
 
-	p.workerIdentityProof = map[string]interface{}{
-		"document":  interface{}(iid_string),
-		"signature": interface{}(instanceIdentityDocumentSignature),
+	p.workerIdentityProof = map[string]any{
+		"document":  any(iid_string),
+		"signature": any(instanceIdentityDocumentSignature),
 	}
 
 	return nil
 }
 
-func (p *AWSProvider) GetWorkerIdentityProof() (map[string]interface{}, error) {
+func (p *AWSProvider) GetWorkerIdentityProof() (map[string]any, error) {
 	return p.workerIdentityProof, nil
 }
 
@@ -108,7 +108,7 @@ func (p *AWSProvider) checkTerminationTime() bool {
 		if p.proto != nil && p.proto.Capable("graceful-termination") {
 			p.proto.Send(workerproto.Message{
 				Type: "graceful-termination",
-				Properties: map[string]interface{}{
+				Properties: map[string]any{
 					// spot termination generally doesn't leave time to finish tasks
 					"finish-tasks": false,
 				},

--- a/tools/worker-runner/provider/aws/awsprovider_test.go
+++ b/tools/worker-runner/provider/aws/awsprovider_test.go
@@ -51,7 +51,7 @@ func TestAWSConfigureRun(t *testing.T) {
 	require.Equal(t, "wg", state.WorkerGroup, "workerGroup is correct")
 	require.Equal(t, "i-55555nonesense5", state.WorkerID, "workerID is correct")
 
-	require.Equal(t, map[string]interface{}{
+	require.Equal(t, map[string]any{
 		"instance-id":       "i-55555nonesense5",
 		"image":             "banana",
 		"instance-type":     "t2.micro",
@@ -76,7 +76,7 @@ func TestAWSConfigureRun(t *testing.T) {
 
 	proof, err := p.GetWorkerIdentityProof()
 	require.NoError(t, err)
-	require.Equal(t, map[string]interface{}{
+	require.Equal(t, map[string]any{
 		"document":  "{\n  \"instanceId\" : \"i-55555nonesense5\",\n  \"region\" : \"us-west-2\",\n  \"availabilityZone\" : \"us-west-2a\",\n  \"instanceType\" : \"t2.micro\",\n  \"imageId\" : \"banana\"\n,  \"privateIp\" : \"1.1.1.1\"\n}",
 		"signature": "thisisasignature",
 	}, proof)

--- a/tools/worker-runner/provider/azure/azure.go
+++ b/tools/worker-runner/provider/azure/azure.go
@@ -20,7 +20,7 @@ type AzureProvider struct {
 	workerManagerClientFactory tc.WorkerManagerClientFactory
 	metadataService            MetadataService
 	proto                      *workerproto.Protocol
-	workerIdentityProof        map[string]interface{}
+	workerIdentityProof        map[string]any
 	terminationTicker          *time.Ticker
 }
 
@@ -72,7 +72,7 @@ func (p *AzureProvider) ConfigureRun(state *run.State) error {
 		"region": instanceData.Compute.Location,
 	}
 
-	providerMetadata := map[string]interface{}{
+	providerMetadata := map[string]any{
 		"vm-id":         instanceData.Compute.VMID,
 		"instance-type": instanceData.Compute.VMSize,
 		"region":        instanceData.Compute.Location,
@@ -89,14 +89,14 @@ func (p *AzureProvider) ConfigureRun(state *run.State) error {
 
 	state.ProviderMetadata = providerMetadata
 
-	p.workerIdentityProof = map[string]interface{}{
-		"document": interface{}(document),
+	p.workerIdentityProof = map[string]any{
+		"document": any(document),
 	}
 
 	return nil
 }
 
-func (p *AzureProvider) GetWorkerIdentityProof() (map[string]interface{}, error) {
+func (p *AzureProvider) GetWorkerIdentityProof() (map[string]any, error) {
 	return p.workerIdentityProof, nil
 }
 
@@ -127,7 +127,7 @@ func (p *AzureProvider) checkTerminationTime() bool {
 			if p.proto != nil && p.proto.Capable("graceful-termination") {
 				p.proto.Send(workerproto.Message{
 					Type: "graceful-termination",
-					Properties: map[string]interface{}{
+					Properties: map[string]any{
 						// termination generally doesn't leave time to finish
 						// tasks. We prefer to have the worker exit cleanly
 						// immediately, resolving tasks as

--- a/tools/worker-runner/provider/azure/azure_test.go
+++ b/tools/worker-runner/provider/azure/azure_test.go
@@ -29,7 +29,7 @@ func TestConfigureRun(t *testing.T) {
 	workerGroup := "wg"
 
 	userData := &InstanceData{}
-	_ = json.Unmarshal([]byte(fmt.Sprintf(`{
+	_ = json.Unmarshal(fmt.Appendf(nil, `{
 		"compute": {
 			"customData": "",
 			"vmId": "df09142e-c0dd-43d9-a515-489f19829dfd",
@@ -65,7 +65,7 @@ func TestConfigureRun(t *testing.T) {
 		   	 }
 		   }]
         }
-      }`, workerPoolId, providerId, workerGroup)), userData)
+      }`, workerPoolId, providerId, workerGroup), userData)
 
 	attestedDocument := base64.StdEncoding.EncodeToString([]byte("trust me, it's cool --Bill"))
 
@@ -87,7 +87,7 @@ func TestConfigureRun(t *testing.T) {
 	require.Equal(t, "wg", state.WorkerGroup, "workerGroup is correct")
 	require.Equal(t, "vm-w-p-test", state.WorkerID, "workerID is correct")
 
-	require.Equal(t, map[string]interface{}{
+	require.Equal(t, map[string]any{
 		"vm-id":         "df09142e-c0dd-43d9-a515-489f19829dfd",
 		"instance-type": "medium",
 		"region":        "uswest",
@@ -108,7 +108,7 @@ func TestConfigureRun(t *testing.T) {
 
 	proof, err := p.GetWorkerIdentityProof()
 	require.NoError(t, err)
-	require.Equal(t, map[string]interface{}{
+	require.Equal(t, map[string]any{
 		"document": attestedDocument,
 	}, proof)
 }

--- a/tools/worker-runner/provider/google/google.go
+++ b/tools/worker-runner/provider/google/google.go
@@ -22,7 +22,7 @@ type GoogleProvider struct {
 	workerManagerClientFactory tc.WorkerManagerClientFactory
 	metadataService            MetadataService
 	proto                      *workerproto.Protocol
-	workerIdentityProof        map[string]interface{}
+	workerIdentityProof        map[string]any
 	terminationMsgSent         bool
 }
 
@@ -46,7 +46,7 @@ func (p *GoogleProvider) ConfigureRun(state *run.State) error {
 	state.WorkerGroup = userData.WorkerGroup
 	state.WorkerID = workerID
 
-	providerMetadata := map[string]interface{}{
+	providerMetadata := map[string]any{
 		"instance-id": workerID,
 	}
 	for _, f := range []struct {
@@ -90,14 +90,14 @@ func (p *GoogleProvider) ConfigureRun(state *run.State) error {
 		return err
 	}
 
-	p.workerIdentityProof = map[string]interface{}{
-		"token": interface{}(proofToken),
+	p.workerIdentityProof = map[string]any{
+		"token": any(proofToken),
 	}
 
 	return nil
 }
 
-func (p *GoogleProvider) GetWorkerIdentityProof() (map[string]interface{}, error) {
+func (p *GoogleProvider) GetWorkerIdentityProof() (map[string]any, error) {
 	return p.workerIdentityProof, nil
 }
 
@@ -117,7 +117,7 @@ func (p *GoogleProvider) checkTerminationTime() bool {
 		if p.proto != nil && p.proto.Capable("graceful-termination") && !p.terminationMsgSent {
 			p.proto.Send(workerproto.Message{
 				Type: "graceful-termination",
-				Properties: map[string]interface{}{
+				Properties: map[string]any{
 					// preemption generally doesn't leave time to finish tasks
 					"finish-tasks": false,
 				},

--- a/tools/worker-runner/provider/google/google_test.go
+++ b/tools/worker-runner/provider/google/google_test.go
@@ -55,7 +55,7 @@ func TestGoogleConfigureRun(t *testing.T) {
 	require.Equal(t, "wg", state.WorkerGroup, "workerGroup is correct")
 	require.Equal(t, "i-123", state.WorkerID, "workerID is correct")
 
-	require.Equal(t, map[string]interface{}{
+	require.Equal(t, map[string]any{
 		"project-id":      "proj-1234",
 		"image":           "img-123",
 		"instance-type":   "most-of-the-cloud",
@@ -81,7 +81,7 @@ func TestGoogleConfigureRun(t *testing.T) {
 
 	proof, err := p.GetWorkerIdentityProof()
 	require.NoError(t, err)
-	require.Equal(t, map[string]interface{}{
+	require.Equal(t, map[string]any{
 		"token": "i-promise",
 	}, proof)
 }

--- a/tools/worker-runner/provider/provider/iface.go
+++ b/tools/worker-runner/provider/provider/iface.go
@@ -15,7 +15,7 @@ type Provider interface {
 	// Get the worker identity proof to pass to worker-manager, or return nil
 	// to skip calling workerManager.registerWorker at all, in which case
 	// ConfigureRun should set state.Credentials correctly.
-	GetWorkerIdentityProof() (map[string]interface{}, error)
+	GetWorkerIdentityProof() (map[string]any, error)
 
 	// In a subsequent run with cacheOverRestarts set, this method is called
 	// instead of ConfigureRun.  It should recover any provider state required

--- a/tools/worker-runner/provider/standalone/standalone.go
+++ b/tools/worker-runner/provider/standalone/standalone.go
@@ -3,6 +3,8 @@ package standalone
 import (
 	"fmt"
 
+	"maps"
+
 	tcurls "github.com/taskcluster/taskcluster-lib-urls"
 	"github.com/taskcluster/taskcluster/v81/tools/worker-runner/cfg"
 	"github.com/taskcluster/taskcluster/v81/tools/worker-runner/provider/provider"
@@ -45,7 +47,7 @@ func (p *StandaloneProvider) ConfigureRun(state *run.State) error {
 	}
 
 	if workerLocation, ok := p.runnercfg.Provider.Data["workerLocation"]; ok {
-		for k, v := range workerLocation.(map[string]interface{}) {
+		for k, v := range workerLocation.(map[string]any) {
 			state.WorkerLocation[k], ok = v.(string)
 			if !ok {
 				return fmt.Errorf("workerLocation value %s is not a string", k)
@@ -53,18 +55,16 @@ func (p *StandaloneProvider) ConfigureRun(state *run.State) error {
 		}
 	}
 
-	state.ProviderMetadata = map[string]interface{}{}
+	state.ProviderMetadata = map[string]any{}
 
 	if providerMetadata, ok := p.runnercfg.Provider.Data["providerMetadata"]; ok {
-		for k, v := range providerMetadata.(map[string]interface{}) {
-			state.ProviderMetadata[k] = v
-		}
+		maps.Copy(state.ProviderMetadata, providerMetadata.(map[string]any))
 	}
 
 	return nil
 }
 
-func (p *StandaloneProvider) GetWorkerIdentityProof() (map[string]interface{}, error) {
+func (p *StandaloneProvider) GetWorkerIdentityProof() (map[string]any, error) {
 	return nil, nil
 }
 

--- a/tools/worker-runner/provider/standalone/standalone_test.go
+++ b/tools/worker-runner/provider/standalone/standalone_test.go
@@ -17,7 +17,7 @@ func TestConfigureRunNoOptional(t *testing.T) {
 	runnercfg := &cfg.RunnerConfig{
 		Provider: cfg.ProviderConfig{
 			ProviderType: "standalone",
-			Data: map[string]interface{}{
+			Data: map[string]any{
 				"rootURL":      "https://tc.example.com",
 				"clientID":     "testing",
 				"accessToken":  "at",
@@ -48,7 +48,7 @@ func TestConfigureRunNoOptional(t *testing.T) {
 	require.Equal(t, "w/p", state.WorkerPoolID, "workerPoolID is correct")
 	require.Equal(t, "wg", state.WorkerGroup, "workerGroup is correct")
 	require.Equal(t, "wi", state.WorkerID, "workerID is correct")
-	require.Equal(t, map[string]interface{}{}, state.ProviderMetadata, "providerMetadata is correct")
+	require.Equal(t, map[string]any{}, state.ProviderMetadata, "providerMetadata is correct")
 
 	require.Equal(t, true, state.WorkerConfig.MustGet("from-runner-cfg"), "value for from-runner-cfg")
 	require.Equal(t, "standalone", state.WorkerLocation["cloud"])
@@ -62,18 +62,18 @@ func TestConfigureRunAllOptional(t *testing.T) {
 	runnercfg := &cfg.RunnerConfig{
 		Provider: cfg.ProviderConfig{
 			ProviderType: "standalone",
-			Data: map[string]interface{}{
+			Data: map[string]any{
 				"rootURL":      "https://tc.example.com",
 				"clientID":     "testing",
 				"accessToken":  "at",
 				"workerPoolID": "w/p",
 				"workerGroup":  "wg",
 				"workerID":     "wi",
-				"workerLocation": map[string]interface{}{
+				"workerLocation": map[string]any{
 					"region": "underworld",
 					"zone":   "666",
 				},
-				"providerMetadata": map[string]interface{}{
+				"providerMetadata": map[string]any{
 					"public-ip": "1.2.3.4",
 					"secret-ip": "0.0.0.0",
 				},
@@ -122,14 +122,14 @@ func TestConfigureRunNonStringLocation(t *testing.T) {
 	runnercfg := &cfg.RunnerConfig{
 		Provider: cfg.ProviderConfig{
 			ProviderType: "standalone",
-			Data: map[string]interface{}{
+			Data: map[string]any{
 				"rootURL":      "https://tc.example.com",
 				"clientID":     "testing",
 				"accessToken":  "at",
 				"workerPoolID": "w/p",
 				"workerGroup":  "wg",
 				"workerID":     "wi",
-				"workerLocation": map[string]interface{}{
+				"workerLocation": map[string]any{
 					"region": 13,
 				},
 			},

--- a/tools/worker-runner/provider/static/static_test.go
+++ b/tools/worker-runner/provider/static/static_test.go
@@ -13,18 +13,18 @@ func TestConfigureRun(t *testing.T) {
 	runnercfg := &cfg.RunnerConfig{
 		Provider: cfg.ProviderConfig{
 			ProviderType: "static",
-			Data: map[string]interface{}{
+			Data: map[string]any{
 				"rootURL":      "https://tc.example.com",
 				"providerID":   "static-1",
 				"workerPoolID": "w/p",
 				"workerGroup":  "wg",
 				"workerID":     "wi",
 				"staticSecret": "quiet",
-				"workerLocation": map[string]interface{}{
+				"workerLocation": map[string]any{
 					"region": "underworld",
 					"zone":   "666",
 				},
-				"providerMetadata": map[string]interface{}{
+				"providerMetadata": map[string]any{
 					"temperature": "24",
 				},
 			},
@@ -46,7 +46,7 @@ func TestConfigureRun(t *testing.T) {
 	require.Equal(t, "w/p", state.WorkerPoolID, "workerPoolID is correct")
 	require.Equal(t, "wg", state.WorkerGroup, "workerGroup is correct")
 	require.Equal(t, "wi", state.WorkerID, "workerID is correct")
-	require.Equal(t, map[string]interface{}{"temperature": "24"}, state.ProviderMetadata, "providerMetadata is correct")
+	require.Equal(t, map[string]any{"temperature": "24"}, state.ProviderMetadata, "providerMetadata is correct")
 
 	require.Equal(t, "static", state.WorkerLocation["cloud"])
 	require.Equal(t, "underworld", state.WorkerLocation["region"])
@@ -54,7 +54,7 @@ func TestConfigureRun(t *testing.T) {
 
 	proof, err := p.GetWorkerIdentityProof()
 	require.NoError(t, err)
-	require.Equal(t, map[string]interface{}{
+	require.Equal(t, map[string]any{
 		"staticSecret": "quiet",
 	}, proof)
 }

--- a/tools/worker-runner/registration/registration.go
+++ b/tools/worker-runner/registration/registration.go
@@ -39,7 +39,7 @@ type RegistrationManager struct {
 
 // Register this worker with the worker-manager, and update the state with the
 // results
-func (reg *RegistrationManager) RegisterWorker(workerIdentityProofMap map[string]interface{}) error {
+func (reg *RegistrationManager) RegisterWorker(workerIdentityProofMap map[string]any) error {
 	reg.state.Lock()
 	defer reg.state.Unlock()
 
@@ -194,7 +194,7 @@ func (reg *RegistrationManager) reregisterWorker() {
 
 	reg.proto.Send(workerproto.Message{
 		Type: "new-credentials",
-		Properties: map[string]interface{}{
+		Properties: map[string]any{
 			"client-id":    res.Credentials.ClientID,
 			"access-token": res.Credentials.AccessToken,
 			"certificate":  res.Credentials.Certificate,
@@ -216,7 +216,7 @@ func (reg *RegistrationManager) terminateWorker() {
 	log.Printf("Taskcluster Credentials are expiring in %s; stopping worker", reg.untilExpires())
 	reg.proto.Send(workerproto.Message{
 		Type: "graceful-termination",
-		Properties: map[string]interface{}{
+		Properties: map[string]any{
 			// credentials are expiring, so no time to shut down..
 			"finish-tasks": false,
 		},
@@ -256,10 +256,7 @@ func renewBeforeExpire(expires time.Duration) time.Duration {
 	if renew < waitAtLeast {
 		renew = waitAtLeast
 		if renew > expires-minSetback {
-			renew = expires - minSetback
-			if renew < 0 {
-				renew = 0
-			}
+			renew = max(expires-minSetback, 0)
 		}
 	}
 

--- a/tools/worker-runner/registration/registration_test.go
+++ b/tools/worker-runner/registration/registration_test.go
@@ -30,7 +30,7 @@ func TestRegisterWorker(t *testing.T) {
 	runnercfg.WorkerImplementation.Implementation = "whatever-worker"
 	reg := new(&runnercfg, &state, tc.FakeWorkerManagerClientFactory)
 
-	proof := map[string]interface{}{
+	proof := map[string]any{
 		"because": "I said so",
 	}
 

--- a/tools/worker-runner/run/state.go
+++ b/tools/worker-runner/run/state.go
@@ -52,7 +52,7 @@ type State struct {
 	// but may fall onto undesirable defaults if these are not provided
 	// A bit more info on that here
 	// https://github.com/taskcluster/taskcluster-worker-runner/pull/30#pullrequestreview-277378260
-	ProviderMetadata map[string]interface{}
+	ProviderMetadata map[string]any
 
 	// the accumulated WorkerConfig for this run, including files to create
 	WorkerConfig *cfg.WorkerConfig

--- a/tools/worker-runner/runner/run_test.go
+++ b/tools/worker-runner/runner/run_test.go
@@ -70,8 +70,8 @@ worker:
 	_, err = Run(configPath)
 	require.NoError(t, err)
 
-	require.Equal(t, []map[string]interface{}{
-		map[string]interface{}{"conversationLevel": "low", "textPayload": "workin hard or hardly workin, amirite?"},
+	require.Equal(t, []map[string]any{
+		{"conversationLevel": "low", "textPayload": "workin hard or hardly workin, amirite?"},
 	}, loggingDestination.Messages())
 
 	// sleep a short bit to let NTFS figure out that fake.exe isn't in use anymore
@@ -117,7 +117,7 @@ func TestDummyCached(t *testing.T) {
 	configPath := filepath.Join(dir, "runner.yaml")
 	cachePath := filepath.Join(dir, "cache.json")
 
-	err := os.WriteFile(configPath, []byte(fmt.Sprintf(`
+	err := os.WriteFile(configPath, fmt.Appendf(nil, `
 provider:
   providerType: standalone
   rootURL: https://tc.example.com
@@ -132,7 +132,7 @@ workerConfig:
   fromFirstRun: true
 worker:
   implementation: dummy
-`, cachePath)), 0755)
+`, cachePath), 0755)
 	require.NoError(t, err)
 
 	run, err := Run(configPath)
@@ -144,7 +144,7 @@ worker:
 	fmt.Printf("cache: %s", cache)
 
 	// slightly different config this time, omitting `fromFirstRun`:
-	err = os.WriteFile(configPath, []byte(fmt.Sprintf(`
+	err = os.WriteFile(configPath, fmt.Appendf(nil, `
 provider:
   providerType: standalone
   rootURL: https://tc.example.com
@@ -157,7 +157,7 @@ getSecrets: false
 cacheOverRestarts: %s
 worker:
   implementation: dummy
-`, cachePath)), 0755)
+`, cachePath), 0755)
 	require.NoError(t, err)
 
 	run, err = Run(configPath)

--- a/tools/worker-runner/worker/genericworker/fake/fake.go
+++ b/tools/worker-runner/worker/genericworker/fake/fake.go
@@ -16,8 +16,8 @@ func main() {
 	if proto.Capable("log") {
 		proto.Send(workerproto.Message{
 			Type: "log",
-			Properties: map[string]interface{}{
-				"body": map[string]interface{}{
+			Properties: map[string]any{
+				"body": map[string]any{
 					"textPayload":       "workin hard or hardly workin, amirite?",
 					"conversationLevel": "low",
 				},

--- a/tools/worker-runner/worker/genericworker/genericworker_test.go
+++ b/tools/worker-runner/worker/genericworker/genericworker_test.go
@@ -14,7 +14,7 @@ func CallConfigureRun(t *testing.T, state *run.State) {
 	runnercfg := &cfg.RunnerConfig{
 		WorkerImplementation: cfg.WorkerImplementationConfig{
 			Implementation: "generic-worker",
-			Data: map[string]interface{}{
+			Data: map[string]any{
 				"configPath": "/no/such/path",
 			},
 		},
@@ -30,7 +30,7 @@ func CallConfigureRun(t *testing.T, state *run.State) {
 func TestConfigureRunWithProviderMetadataConfig(t *testing.T) {
 	wc, err := cfg.NewWorkerConfig().Set(
 		"workerTypeMetadata",
-		map[string]interface{}{
+		map[string]any{
 			"from-worker-pool": "yup",
 		},
 	)
@@ -47,7 +47,7 @@ func TestConfigureRunWithProviderMetadataConfig(t *testing.T) {
 		WorkerPoolID: "prov/wt",
 		WorkerGroup:  "wg",
 		WorkerID:     "wi",
-		ProviderMetadata: map[string]interface{}{
+		ProviderMetadata: map[string]any{
 			"public-ipv4":       "1.2.3.4",
 			"local-ipv4":        "10.1.1.1",
 			"availability-zone": "mars",
@@ -73,7 +73,7 @@ func TestConfigureRunWithProviderMetadataConfig(t *testing.T) {
 	require.Equal(t, "wg", state.WorkerConfig.MustGet("workerGroup"))
 	require.Equal(t, "wi", state.WorkerConfig.MustGet("workerId"))
 	require.Equal(t, "cert", state.WorkerConfig.MustGet("certificate"))
-	require.Equal(t, map[string]interface{}{
+	require.Equal(t, map[string]any{
 		"public-ipv4":       "1.2.3.4",
 		"local-ipv4":        "10.1.1.1",
 		"availability-zone": "mars",
@@ -96,7 +96,7 @@ func TestConfigureRunWithoutProviderMetadataConfig(t *testing.T) {
 		WorkerPoolID:     "prov/wt",
 		WorkerGroup:      "wg",
 		WorkerID:         "wi",
-		ProviderMetadata: map[string]interface{}{},
+		ProviderMetadata: map[string]any{},
 	}
 
 	CallConfigureRun(t, state)
@@ -115,5 +115,5 @@ func TestConfigureRunWithoutProviderMetadataConfig(t *testing.T) {
 	require.Equal(t, "wg", state.WorkerConfig.MustGet("workerGroup"))
 	require.Equal(t, "wi", state.WorkerConfig.MustGet("workerId"))
 	require.Equal(t, "cert", state.WorkerConfig.MustGet("certificate"))
-	require.Equal(t, map[string]interface{}{}, state.WorkerConfig.MustGet("workerTypeMetadata"))
+	require.Equal(t, map[string]any{}, state.WorkerConfig.MustGet("workerTypeMetadata"))
 }

--- a/tools/workerproto/message.go
+++ b/tools/workerproto/message.go
@@ -3,11 +3,12 @@ package workerproto
 import (
 	"encoding/json"
 	"fmt"
+	"maps"
 )
 
 type Message struct {
 	Type       string
-	Properties map[string]interface{}
+	Properties map[string]any
 }
 
 func (msg *Message) UnmarshalJSON(b []byte) error {
@@ -31,10 +32,8 @@ func (msg *Message) UnmarshalJSON(b []byte) error {
 }
 
 func (msg *Message) MarshalJSON() ([]byte, error) {
-	obj := make(map[string]interface{})
-	for k, v := range msg.Properties {
-		obj[k] = v
-	}
+	obj := make(map[string]any)
+	maps.Copy(obj, msg.Properties)
 	obj["type"] = msg.Type
 	return json.Marshal(obj)
 }

--- a/tools/workerproto/message_test.go
+++ b/tools/workerproto/message_test.go
@@ -10,7 +10,7 @@ import (
 func TestMessageMarshal(t *testing.T) {
 	msg := Message{
 		Type: "hey-you",
-		Properties: map[string]interface{}{
+		Properties: map[string]any{
 			"x": true,
 			"y": "twenty",
 		},
@@ -18,7 +18,7 @@ func TestMessageMarshal(t *testing.T) {
 	bytes, err := json.Marshal(&msg)
 	assert.NoError(t, err, "should not fail")
 
-	var obj map[string]interface{}
+	var obj map[string]any
 	err = json.Unmarshal(bytes, &obj)
 	assert.NoError(t, err, "should not fail")
 
@@ -33,7 +33,7 @@ func TestMessageUnmarshal(t *testing.T) {
 	assert.NoError(t, err, "should not fail")
 
 	assert.Equal(t, "hey-you", msg.Type, "did not get expected properties")
-	assert.Equal(t, map[string]interface{}{"value": "sure"}, msg.Properties, "did not get expected properties")
+	assert.Equal(t, map[string]any{"value": "sure"}, msg.Properties, "did not get expected properties")
 }
 
 func TestMessageUnmarshalNoType(t *testing.T) {

--- a/tools/workerproto/pipe_test.go
+++ b/tools/workerproto/pipe_test.go
@@ -97,8 +97,8 @@ func TestPipeWriter(t *testing.T) {
 		}
 
 		require.Equal(t, []Message{
-			Message{Type: "abc", Properties: map[string]interface{}{}},
-			Message{Type: "bcdf", Properties: map[string]interface{}{"lengthy": "abc abc abc abc abc abc abc abc abc abc abc abc abc abc"}},
+			Message{Type: "abc", Properties: map[string]any{}},
+			Message{Type: "bcdf", Properties: map[string]any{"lengthy": "abc abc abc abc abc abc abc abc abc abc abc abc abc abc"}},
 		}, got, "should have gotten two messages")
 
 		require.Equal(t, []string{
@@ -136,9 +136,9 @@ func TestPipeReader(t *testing.T) {
 	output := bytes.NewBuffer([]byte{})
 	transp := NewPipeTransport(bytes.NewReader([]byte{}), output)
 
-	transp.Send(Message{Type: "abc", Properties: map[string]interface{}{}})
-	transp.Send(Message{Type: "def", Properties: map[string]interface{}{"x": true}})
-	transp.Send(Message{Type: "def", Properties: map[string]interface{}{"x": false}})
+	transp.Send(Message{Type: "abc", Properties: map[string]any{}})
+	transp.Send(Message{Type: "def", Properties: map[string]any{"x": true}})
+	transp.Send(Message{Type: "def", Properties: map[string]any{"x": false}})
 
 	require.Equal(t, `
 ~{"type":"abc"}

--- a/tools/workerproto/protocol.go
+++ b/tools/workerproto/protocol.go
@@ -57,8 +57,8 @@ func (prot *Protocol) Register(messageType string, callback MessageCallback) {
 
 // convert an anymous interface into a list of strings; useful for parsing lists
 // out of messages
-func listOfStrings(val interface{}) []string {
-	aslist := val.([]interface{})
+func listOfStrings(val any) []string {
+	aslist := val.([]any)
 	rv := make([]string, 0, len(aslist))
 	for _, elt := range aslist {
 		rv = append(rv, elt.(string))
@@ -73,7 +73,7 @@ func (prot *Protocol) Start(asWorker bool) {
 			prot.remoteCapabilities = FromCapabilitiesList(listOfStrings(msg.Properties["capabilities"]))
 			prot.Send(Message{
 				Type: "hello",
-				Properties: map[string]interface{}{
+				Properties: map[string]any{
 					"capabilities": prot.localCapabilities.List(),
 				},
 			})
@@ -89,7 +89,7 @@ func (prot *Protocol) Start(asWorker bool) {
 		go func() {
 			prot.Send(Message{
 				Type: "welcome",
-				Properties: map[string]interface{}{
+				Properties: map[string]any{
 					"capabilities": prot.localCapabilities.List(),
 				},
 			})

--- a/tools/workerproto/testing/localtransport_test.go
+++ b/tools/workerproto/testing/localtransport_test.go
@@ -14,7 +14,7 @@ func TestLocalTransport(t *testing.T) {
 		t.Helper()
 		a.Send(workerproto.Message{
 			Type: "test",
-			Properties: map[string]interface{}{
+			Properties: map[string]any{
 				"test": true,
 			},
 		})

--- a/workers/generic-worker/artifacts/artifacts.go
+++ b/workers/generic-worker/artifacts/artifacts.go
@@ -18,14 +18,14 @@ type (
 		//
 		// For example, this is a *tcqueue.S3ArtifactRequest for type
 		// S3Artifact.
-		RequestObject() interface{}
+		RequestObject() any
 
 		// ResponseObject returns a pointer to an empty go type for
 		// unmarshaling the result of a tcqueue.CreateArtifact API call into.
 		//
 		// For example, this would be new(tcqueue.RedirectArtifactRequest) for
 		// RedirectArtifact.
-		ResponseObject() interface{}
+		ResponseObject() any
 
 		// ProcessResponse is a callback for performing actions after
 		// tcqueue.CreateArtifact API is called. response is the object
@@ -38,10 +38,10 @@ type (
 		//
 		// ProcessResponse can be an empty method if no post
 		// tcqueue.CreateArtifact steps are required.
-		ProcessResponse(response interface{}, logger Logger, serviceFactory tc.ServiceFactory, config *gwconfig.Config) error
+		ProcessResponse(response any, logger Logger, serviceFactory tc.ServiceFactory, config *gwconfig.Config) error
 
 		// FinishArtifact calls queue.FinishArtifact if necessary for the artifact type
-		FinishArtifact(response interface{}, queue tc.Queue, taskID, runID, name string) error
+		FinishArtifact(response any, queue tc.Queue, taskID, runID, name string) error
 
 		// Base returns a *BaseArtifact which stores the properties common to
 		// all implementations
@@ -64,6 +64,6 @@ func (base *BaseArtifact) Base() *BaseArtifact {
 // This provides a default implementation that does not call
 // queue.FinishArtifact, as appropriate for link, redirect, error, and s3
 // artifact types.
-func (*BaseArtifact) FinishArtifact(response interface{}, queue tc.Queue, taskID, runID, name string) error {
+func (*BaseArtifact) FinishArtifact(response any, queue tc.Queue, taskID, runID, name string) error {
 	return nil
 }

--- a/workers/generic-worker/artifacts/error.go
+++ b/workers/generic-worker/artifacts/error.go
@@ -15,13 +15,13 @@ type ErrorArtifact struct {
 	Reason  string
 }
 
-func (errArtifact *ErrorArtifact) ProcessResponse(response interface{}, logger Logger, serviceFactory tc.ServiceFactory, config *gwconfig.Config) error {
+func (errArtifact *ErrorArtifact) ProcessResponse(response any, logger Logger, serviceFactory tc.ServiceFactory, config *gwconfig.Config) error {
 	logger.Errorf("Uploading error artifact %v from file %v with message %q, reason %q and expiry %v", errArtifact.Name, errArtifact.Path, errArtifact.Message, errArtifact.Reason, errArtifact.Expires)
 	// TODO: process error response
 	return nil
 }
 
-func (errArtifact *ErrorArtifact) RequestObject() interface{} {
+func (errArtifact *ErrorArtifact) RequestObject() any {
 	return &tcqueue.ErrorArtifactRequest{
 		Expires:     errArtifact.Expires,
 		Message:     errArtifact.Message,
@@ -30,7 +30,7 @@ func (errArtifact *ErrorArtifact) RequestObject() interface{} {
 	}
 }
 
-func (errArtifact *ErrorArtifact) ResponseObject() interface{} {
+func (errArtifact *ErrorArtifact) ResponseObject() any {
 	return new(tcqueue.ErrorArtifactResponse)
 }
 

--- a/workers/generic-worker/artifacts/link.go
+++ b/workers/generic-worker/artifacts/link.go
@@ -12,13 +12,13 @@ type LinkArtifact struct {
 	ContentType string
 }
 
-func (linkArtifact *LinkArtifact) ProcessResponse(response interface{}, logger Logger, serviceFactory tc.ServiceFactory, config *gwconfig.Config) error {
+func (linkArtifact *LinkArtifact) ProcessResponse(response any, logger Logger, serviceFactory tc.ServiceFactory, config *gwconfig.Config) error {
 	logger.Infof("Uploading link artifact %v to artifact %v with expiry %v", linkArtifact.Name, linkArtifact.Artifact, linkArtifact.Expires)
 	// nothing to do
 	return nil
 }
 
-func (linkArtifact *LinkArtifact) RequestObject() interface{} {
+func (linkArtifact *LinkArtifact) RequestObject() any {
 	return &tcqueue.LinkArtifactRequest{
 		Expires:     linkArtifact.Expires,
 		StorageType: "link",
@@ -27,6 +27,6 @@ func (linkArtifact *LinkArtifact) RequestObject() interface{} {
 	}
 }
 
-func (linkArtifact *LinkArtifact) ResponseObject() interface{} {
+func (linkArtifact *LinkArtifact) ResponseObject() any {
 	return new(tcqueue.LinkArtifactResponse)
 }

--- a/workers/generic-worker/artifacts/log.go
+++ b/workers/generic-worker/artifacts/log.go
@@ -3,8 +3,8 @@ package artifacts
 // Logger represents a target for log messages from the artifact implementation.
 type Logger interface {
 	// Infof formats and lots a message at the info level
-	Infof(format string, a ...interface{})
+	Infof(format string, a ...any)
 
 	// Errorf formats and lots a message at the error level
-	Errorf(format string, a ...interface{})
+	Errorf(format string, a ...any)
 }

--- a/workers/generic-worker/artifacts/object.go
+++ b/workers/generic-worker/artifacts/object.go
@@ -19,7 +19,7 @@ type ObjectArtifact struct {
 	ContentType string
 }
 
-func (a *ObjectArtifact) RequestObject() interface{} {
+func (a *ObjectArtifact) RequestObject() any {
 	return &tcqueue.ObjectArtifactRequest{
 		ContentType: a.ContentType,
 		Expires:     a.Expires,
@@ -27,11 +27,11 @@ func (a *ObjectArtifact) RequestObject() interface{} {
 	}
 }
 
-func (a *ObjectArtifact) ResponseObject() interface{} {
+func (a *ObjectArtifact) ResponseObject() any {
 	return new(tcqueue.ObjectArtifactResponse)
 }
 
-func (a *ObjectArtifact) ProcessResponse(resp interface{}, logger Logger, serviceFactory tc.ServiceFactory, config *gwconfig.Config) (err error) {
+func (a *ObjectArtifact) ProcessResponse(resp any, logger Logger, serviceFactory tc.ServiceFactory, config *gwconfig.Config) (err error) {
 	response := resp.(*tcqueue.ObjectArtifactResponse)
 	logger.Infof("Uploading artifact %v from file %v with content type %q and expiry %v", a.Name, a.Path, a.ContentType, a.Expires)
 	creds := tcclient.Credentials{
@@ -50,7 +50,7 @@ func (a *ObjectArtifact) ProcessResponse(resp interface{}, logger Logger, servic
 	)
 }
 
-func (a *ObjectArtifact) FinishArtifact(resp interface{}, queue tc.Queue, taskID, runID, name string) error {
+func (a *ObjectArtifact) FinishArtifact(resp any, queue tc.Queue, taskID, runID, name string) error {
 	response := resp.(*tcqueue.ObjectArtifactResponse)
 	far := tcqueue.FinishArtifactRequest{
 		UploadID: response.UploadID,

--- a/workers/generic-worker/artifacts/redirect.go
+++ b/workers/generic-worker/artifacts/redirect.go
@@ -15,7 +15,7 @@ type RedirectArtifact struct {
 	ContentType string
 }
 
-func (redirectArtifact *RedirectArtifact) ProcessResponse(response interface{}, logger Logger, serviceFactory tc.ServiceFactory, config *gwconfig.Config) error {
+func (redirectArtifact *RedirectArtifact) ProcessResponse(response any, logger Logger, serviceFactory tc.ServiceFactory, config *gwconfig.Config) error {
 	log := fmt.Sprintf("Uploading redirect artifact %v to ", redirectArtifact.Name)
 	if redirectArtifact.HideURL {
 		log += "(URL hidden) "
@@ -28,7 +28,7 @@ func (redirectArtifact *RedirectArtifact) ProcessResponse(response interface{}, 
 	return nil
 }
 
-func (redirectArtifact *RedirectArtifact) RequestObject() interface{} {
+func (redirectArtifact *RedirectArtifact) RequestObject() any {
 	return &tcqueue.RedirectArtifactRequest{
 		ContentType: redirectArtifact.ContentType,
 		Expires:     redirectArtifact.Expires,
@@ -37,6 +37,6 @@ func (redirectArtifact *RedirectArtifact) RequestObject() interface{} {
 	}
 }
 
-func (redirectArtifact *RedirectArtifact) ResponseObject() interface{} {
+func (redirectArtifact *RedirectArtifact) ResponseObject() any {
 	return new(tcqueue.RedirectArtifactResponse)
 }

--- a/workers/generic-worker/artifacts/s3.go
+++ b/workers/generic-worker/artifacts/s3.go
@@ -81,7 +81,7 @@ func (s3Artifact *S3Artifact) createTempFileForPUTBody() (string, func()) {
 	}
 }
 
-func (s3Artifact *S3Artifact) ProcessResponse(resp interface{}, logger Logger, serviceFactory tc.ServiceFactory, config *gwconfig.Config) (err error) {
+func (s3Artifact *S3Artifact) ProcessResponse(resp any, logger Logger, serviceFactory tc.ServiceFactory, config *gwconfig.Config) (err error) {
 	response := resp.(*tcqueue.S3ArtifactResponse)
 
 	logger.Infof("Uploading artifact %v from file %v with content encoding %q, mime type %q and expiry %v", s3Artifact.Name, s3Artifact.Path, s3Artifact.ContentEncoding, s3Artifact.ContentType, s3Artifact.Expires)
@@ -155,7 +155,7 @@ func (s3Artifact *S3Artifact) ProcessResponse(resp interface{}, logger Logger, s
 	return err
 }
 
-func (s3Artifact *S3Artifact) RequestObject() interface{} {
+func (s3Artifact *S3Artifact) RequestObject() any {
 	return &tcqueue.S3ArtifactRequest{
 		ContentType: s3Artifact.ContentType,
 		Expires:     s3Artifact.Expires,
@@ -163,7 +163,7 @@ func (s3Artifact *S3Artifact) RequestObject() interface{} {
 	}
 }
 
-func (s3Artifact *S3Artifact) ResponseObject() interface{} {
+func (s3Artifact *S3Artifact) ResponseObject() any {
 	return new(tcqueue.S3ArtifactResponse)
 }
 

--- a/workers/generic-worker/chain_of_trust.go
+++ b/workers/generic-worker/chain_of_trust.go
@@ -268,8 +268,8 @@ func (cot *ChainOfTrustTaskFeature) MergeAdditionalData(certBytes []byte) (merge
 		return
 	}
 
-	initialCert := map[string]interface{}{}
-	additionalData := map[string]interface{}{}
+	initialCert := map[string]any{}
+	additionalData := map[string]any{}
 
 	err = json.Unmarshal(additionalDataBytes, &additionalData)
 	if err != nil {

--- a/workers/generic-worker/chain_of_trust_test.go
+++ b/workers/generic-worker/chain_of_trust_test.go
@@ -248,6 +248,12 @@ func TestChainOfTrustUploadAsCurrentUser(t *testing.T) {
 			ChainOfTrust:         true,
 			RunTaskAsCurrentUser: true,
 		},
+		OnExitStatus: ExitCodeHandling{
+			// This tests that OnExitStatus does not
+			// break when no task commands run, since
+			// task is resolved exception/malformed-payload
+			PurgeCaches: []int64{1234567},
+		},
 	}
 	defaults.SetDefaults(&payload)
 	td := testTask(t)

--- a/workers/generic-worker/chain_of_trust_test.go
+++ b/workers/generic-worker/chain_of_trust_test.go
@@ -457,7 +457,7 @@ func TestChainOfTrustAdditionalData(t *testing.T) {
 	taskID := submitAndAssert(t, td, payload, "completed", "completed")
 
 	cotUnsignedBytes := getArtifactContent(t, taskID, "public/chain-of-trust.json")
-	cotCert := map[string]interface{}{}
+	cotCert := map[string]any{}
 	err := json.Unmarshal(cotUnsignedBytes, &cotCert)
 	if err != nil {
 		t.Fatalf("Could not interpret public/chain-of-trust.json as json")
@@ -475,9 +475,9 @@ func TestChainOfTrustAdditionalData(t *testing.T) {
 		t.Fatalf("Chain of trust cert invalid - doesn't contain property task. Contents: %v", string(cotUnsignedBytes))
 	}
 	// check it is an object rather than a string or int etc
-	task, taskIsMapStringInterface := taskMap.(map[string]interface{})
+	task, taskIsMapStringInterface := taskMap.(map[string]any)
 	if !taskIsMapStringInterface {
-		t.Fatalf("Expected taskMap to be of type map[string]interface{}, but got %T", taskMap)
+		t.Fatalf("Expected taskMap to be of type map[string]any, but got %T", taskMap)
 	}
 	// now check it contains a property from the standard chain of trust cert
 	provisionerID, provisionerIDExists := task["provisionerId"]

--- a/workers/generic-worker/config_test.go
+++ b/workers/generic-worker/config_test.go
@@ -101,15 +101,15 @@ func TestWorkerTypeMetadata(t *testing.T) {
 		t.Fatalf("Config should pass validation, but get:\n%s", err)
 	}
 	// loadConfig function specifies a value, let's check we can't override it in the config file ("fakeos")
-	if config.WorkerTypeMetadata["generic-worker"].(map[string]interface{})["go-os"] != runtime.GOOS {
+	if config.WorkerTypeMetadata["generic-worker"].(map[string]any)["go-os"] != runtime.GOOS {
 		t.Fatalf("Was not expecting key 'go-os' from file worker-type-metadata.json to override default value\n%#v", config)
 	}
 	// go-version not specified in config file, but should be set in loadConfig, let's check it is
-	if config.WorkerTypeMetadata["generic-worker"].(map[string]interface{})["go-version"] != runtime.Version() {
+	if config.WorkerTypeMetadata["generic-worker"].(map[string]any)["go-version"] != runtime.Version() {
 		t.Fatalf("Was expecting key 'go-version' to be set to go version in worker type metadata\n%#v", config)
 	}
 	// machine-setup is not set in loadConfig, but is set in config file, let's check we have it
-	if config.WorkerTypeMetadata["machine-setup"].(map[string]interface{})["script"] != "https://raw.githubusercontent.com/taskcluster/generic-worker/2d2ad3000787f2c893299e693ea3f59287127f5c/worker_types/win2012r2/userdata" {
+	if config.WorkerTypeMetadata["machine-setup"].(map[string]any)["script"] != "https://raw.githubusercontent.com/taskcluster/generic-worker/2d2ad3000787f2c893299e693ea3f59287127f5c/worker_types/win2012r2/userdata" {
 		t.Fatalf("Was expecting machine-setup to be set properly\n%#v", config)
 	}
 }

--- a/workers/generic-worker/d2g_test.go
+++ b/workers/generic-worker/d2g_test.go
@@ -18,7 +18,7 @@ import (
 func TestD2GWithValidDockerWorkerPayload(t *testing.T) {
 	setup(t)
 	testTime := tcclient.Time(time.Now().AddDate(0, 0, 1))
-	image := map[string]interface{}{
+	image := map[string]any{
 		"name": "ubuntu:latest",
 		"type": "docker-image",
 	}
@@ -85,7 +85,7 @@ func TestD2GWithValidDockerWorkerPayload(t *testing.T) {
 
 func TestD2GWithInvalidDockerWorkerPayload(t *testing.T) {
 	setup(t)
-	image := map[string]interface{}{
+	image := map[string]any{
 		"name": "ubuntu:latest",
 		"type": "docker-image",
 	}
@@ -147,7 +147,7 @@ func TestD2GIssue6789(t *testing.T) {
 
 func TestD2GWithValidScopes(t *testing.T) {
 	setup(t)
-	image := map[string]interface{}{
+	image := map[string]any{
 		"name": "ubuntu:latest",
 		"type": "docker-image",
 	}
@@ -201,7 +201,7 @@ func TestD2GWithValidScopes(t *testing.T) {
 
 func TestD2GWithInvalidScopes(t *testing.T) {
 	setup(t)
-	image := map[string]interface{}{
+	image := map[string]any{
 		"name": "ubuntu:latest",
 		"type": "docker-image",
 	}
@@ -242,7 +242,7 @@ func TestD2GWithInvalidScopes(t *testing.T) {
 
 func TestD2GLoopbackVideoDevice(t *testing.T) {
 	setup(t)
-	image := map[string]interface{}{
+	image := map[string]any{
 		"name": "ubuntu:latest",
 		"type": "docker-image",
 	}
@@ -288,7 +288,7 @@ func TestD2GLoopbackVideoDevice(t *testing.T) {
 
 func TestD2GLoopbackVideoDeviceWithWorkerPoolScopes(t *testing.T) {
 	setup(t)
-	image := map[string]interface{}{
+	image := map[string]any{
 		"name": "ubuntu:latest",
 		"type": "docker-image",
 	}
@@ -334,7 +334,7 @@ func TestD2GLoopbackVideoDeviceWithWorkerPoolScopes(t *testing.T) {
 
 func TestD2GLoopbackAudioDevice(t *testing.T) {
 	setup(t)
-	image := map[string]interface{}{
+	image := map[string]any{
 		"name": "ubuntu:latest",
 		"type": "docker-image",
 	}
@@ -383,7 +383,7 @@ func TestD2GLoopbackAudioDevice(t *testing.T) {
 
 func TestD2GLoopbackAudioDeviceWithWorkerPoolScopes(t *testing.T) {
 	setup(t)
-	image := map[string]interface{}{
+	image := map[string]any{
 		"name": "ubuntu:latest",
 		"type": "docker-image",
 	}
@@ -432,7 +432,7 @@ func TestD2GLoopbackAudioDeviceWithWorkerPoolScopes(t *testing.T) {
 
 func TestD2GDevicesWithoutAllScopes(t *testing.T) {
 	setup(t)
-	image := map[string]interface{}{
+	image := map[string]any{
 		"name": "ubuntu:latest",
 		"type": "docker-image",
 	}
@@ -467,7 +467,7 @@ func TestD2GDevicesWithoutAllScopes(t *testing.T) {
 
 func TestD2GHostSharedMemory(t *testing.T) {
 	setup(t)
-	image := map[string]interface{}{
+	image := map[string]any{
 		"name": "ubuntu:latest",
 		"type": "docker-image",
 	}

--- a/workers/generic-worker/errorreport/errorreport.go
+++ b/workers/generic-worker/errorreport/errorreport.go
@@ -6,7 +6,7 @@ import (
 	"github.com/taskcluster/taskcluster/v81/tools/workerproto"
 )
 
-func Send(proto *workerproto.Protocol, message interface{}, debugInfo map[string]string) {
+func Send(proto *workerproto.Protocol, message any, debugInfo map[string]string) {
 	if !proto.Capable("error-report") {
 		return
 	}
@@ -15,14 +15,14 @@ func Send(proto *workerproto.Protocol, message interface{}, debugInfo map[string
 	description := fmt.Sprintf("%s", message)
 	// could support differentiating for panics
 	kind := "worker-error"
-	// convert debugInfo from map[string]string to map[string]interface{}
-	extra := map[string]interface{}{}
+	// convert debugInfo from map[string]string to map[string]any
+	extra := map[string]any{}
 	for k, v := range debugInfo {
 		extra[k] = v
 	}
 	proto.Send(workerproto.Message{
 		Type: "error-report",
-		Properties: map[string]interface{}{
+		Properties: map[string]any{
 			"description": description,
 			"kind":        kind,
 			"title":       title,

--- a/workers/generic-worker/errorreport/errorreport_test.go
+++ b/workers/generic-worker/errorreport/errorreport_test.go
@@ -35,7 +35,7 @@ func TestSendEmptyExtra(t *testing.T) {
 		assert.Contains(t, msg.Properties, "description")
 		assert.Equal(t, "test error", msg.Properties["description"].(string))
 		assert.Contains(t, msg.Properties, "extra")
-		assert.Equal(t, msg.Properties["extra"], map[string]interface{}{})
+		assert.Equal(t, msg.Properties["extra"], map[string]any{})
 		errorReported = true
 		lock.Unlock()
 	})
@@ -64,8 +64,8 @@ func TestSendExtra(t *testing.T) {
 		assert.Contains(t, msg.Properties, "extra")
 		assert.Contains(t, msg.Properties["extra"], "kangaroo")
 		assert.Contains(t, msg.Properties["extra"], "monster")
-		assert.Equal(t, "pouches", msg.Properties["extra"].(map[string]interface{})["kangaroo"].(string))
-		assert.Equal(t, "trucks", msg.Properties["extra"].(map[string]interface{})["monster"].(string))
+		assert.Equal(t, "pouches", msg.Properties["extra"].(map[string]any)["kangaroo"].(string))
+		assert.Equal(t, "trucks", msg.Properties["extra"].(map[string]any)["monster"].(string))
 		errorReported = true
 		lock.Unlock()
 	})

--- a/workers/generic-worker/expose/wsproxy.go
+++ b/workers/generic-worker/expose/wsproxy.go
@@ -22,7 +22,7 @@ type proxy struct {
 
 var debug = false
 
-func (p *proxy) logf(format string, v ...interface{}) {
+func (p *proxy) logf(format string, v ...any) {
 	if debug {
 		fmt.Printf(format+"\n", v...)
 	}

--- a/workers/generic-worker/fileutil/fileutil.go
+++ b/workers/generic-worker/fileutil/fileutil.go
@@ -13,7 +13,7 @@ import (
 	"github.com/mholt/archiver/v3"
 )
 
-func WriteToFileAsJSON(obj interface{}, filename string) error {
+func WriteToFileAsJSON(obj any, filename string) error {
 	jsonBytes, err := json.MarshalIndent(obj, "", "  ")
 	if err != nil {
 		return err

--- a/workers/generic-worker/gwconfig/config.go
+++ b/workers/generic-worker/gwconfig/config.go
@@ -27,50 +27,50 @@ type (
 	PublicConfig struct {
 		PublicEngineConfig
 		PublicPlatformConfig
-		AvailabilityZone               string                 `json:"availabilityZone"`
-		CachesDir                      string                 `json:"cachesDir"`
-		CheckForNewDeploymentEverySecs uint                   `json:"checkForNewDeploymentEverySecs"`
-		CleanUpTaskDirs                bool                   `json:"cleanUpTaskDirs"`
-		ClientID                       string                 `json:"clientId"`
-		CreateObjectArtifacts          bool                   `json:"createObjectArtifacts"`
-		DeploymentID                   string                 `json:"deploymentId"`
-		DisableReboots                 bool                   `json:"disableReboots"`
-		DownloadsDir                   string                 `json:"downloadsDir"`
-		Ed25519SigningKeyLocation      string                 `json:"ed25519SigningKeyLocation"`
-		EnableChainOfTrust             bool                   `json:"enableChainOfTrust"`
-		EnableLiveLog                  bool                   `json:"enableLiveLog"`
-		EnableMounts                   bool                   `json:"enableMounts"`
-		EnableOSGroups                 bool                   `json:"enableOSGroups"`
-		EnableTaskclusterProxy         bool                   `json:"enableTaskclusterProxy"`
-		IdleTimeoutSecs                uint                   `json:"idleTimeoutSecs"`
-		InstanceID                     string                 `json:"instanceId"`
-		InstanceType                   string                 `json:"instanceType"`
-		InteractivePort                uint16                 `json:"interactivePort"`
-		LiveLogExecutable              string                 `json:"livelogExecutable"`
-		LiveLogPortBase                uint16                 `json:"livelogPortBase"`
-		LiveLogExposePort              uint16                 `json:"livelogExposePort"`
-		MaxTaskRunTime                 uint32                 `json:"maxTaskRunTime"`
-		NumberOfTasksToRun             uint                   `json:"numberOfTasksToRun"`
-		PrivateIP                      net.IP                 `json:"privateIP"`
-		ProvisionerID                  string                 `json:"provisionerId"`
-		PublicIP                       net.IP                 `json:"publicIP"`
-		Region                         string                 `json:"region"`
-		RequiredDiskSpaceMegabytes     uint                   `json:"requiredDiskSpaceMegabytes"`
-		RootURL                        string                 `json:"rootURL"`
-		RunAfterUserCreation           string                 `json:"runAfterUserCreation"`
-		SentryProject                  string                 `json:"sentryProject"`
-		ShutdownMachineOnIdle          bool                   `json:"shutdownMachineOnIdle"`
-		ShutdownMachineOnInternalError bool                   `json:"shutdownMachineOnInternalError"`
-		TaskclusterProxyExecutable     string                 `json:"taskclusterProxyExecutable"`
-		TaskclusterProxyPort           uint16                 `json:"taskclusterProxyPort"`
-		TasksDir                       string                 `json:"tasksDir"`
-		WorkerGroup                    string                 `json:"workerGroup"`
-		WorkerID                       string                 `json:"workerId"`
-		WorkerLocation                 string                 `json:"workerLocation,omitempty"`
-		WorkerType                     string                 `json:"workerType"`
-		WorkerTypeMetadata             map[string]interface{} `json:"workerTypeMetadata"`
-		WSTAudience                    string                 `json:"wstAudience"`
-		WSTServerURL                   string                 `json:"wstServerURL"`
+		AvailabilityZone               string         `json:"availabilityZone"`
+		CachesDir                      string         `json:"cachesDir"`
+		CheckForNewDeploymentEverySecs uint           `json:"checkForNewDeploymentEverySecs"`
+		CleanUpTaskDirs                bool           `json:"cleanUpTaskDirs"`
+		ClientID                       string         `json:"clientId"`
+		CreateObjectArtifacts          bool           `json:"createObjectArtifacts"`
+		DeploymentID                   string         `json:"deploymentId"`
+		DisableReboots                 bool           `json:"disableReboots"`
+		DownloadsDir                   string         `json:"downloadsDir"`
+		Ed25519SigningKeyLocation      string         `json:"ed25519SigningKeyLocation"`
+		EnableChainOfTrust             bool           `json:"enableChainOfTrust"`
+		EnableLiveLog                  bool           `json:"enableLiveLog"`
+		EnableMounts                   bool           `json:"enableMounts"`
+		EnableOSGroups                 bool           `json:"enableOSGroups"`
+		EnableTaskclusterProxy         bool           `json:"enableTaskclusterProxy"`
+		IdleTimeoutSecs                uint           `json:"idleTimeoutSecs"`
+		InstanceID                     string         `json:"instanceId"`
+		InstanceType                   string         `json:"instanceType"`
+		InteractivePort                uint16         `json:"interactivePort"`
+		LiveLogExecutable              string         `json:"livelogExecutable"`
+		LiveLogPortBase                uint16         `json:"livelogPortBase"`
+		LiveLogExposePort              uint16         `json:"livelogExposePort"`
+		MaxTaskRunTime                 uint32         `json:"maxTaskRunTime"`
+		NumberOfTasksToRun             uint           `json:"numberOfTasksToRun"`
+		PrivateIP                      net.IP         `json:"privateIP"`
+		ProvisionerID                  string         `json:"provisionerId"`
+		PublicIP                       net.IP         `json:"publicIP"`
+		Region                         string         `json:"region"`
+		RequiredDiskSpaceMegabytes     uint           `json:"requiredDiskSpaceMegabytes"`
+		RootURL                        string         `json:"rootURL"`
+		RunAfterUserCreation           string         `json:"runAfterUserCreation"`
+		SentryProject                  string         `json:"sentryProject"`
+		ShutdownMachineOnIdle          bool           `json:"shutdownMachineOnIdle"`
+		ShutdownMachineOnInternalError bool           `json:"shutdownMachineOnInternalError"`
+		TaskclusterProxyExecutable     string         `json:"taskclusterProxyExecutable"`
+		TaskclusterProxyPort           uint16         `json:"taskclusterProxyPort"`
+		TasksDir                       string         `json:"tasksDir"`
+		WorkerGroup                    string         `json:"workerGroup"`
+		WorkerID                       string         `json:"workerId"`
+		WorkerLocation                 string         `json:"workerLocation,omitempty"`
+		WorkerType                     string         `json:"workerType"`
+		WorkerTypeMetadata             map[string]any `json:"workerTypeMetadata"`
+		WSTAudience                    string         `json:"wstAudience"`
+		WSTServerURL                   string         `json:"wstServerURL"`
 	}
 
 	PrivateConfig struct {
@@ -89,14 +89,14 @@ func (c *Config) String() string {
 	// concatenates the results from each of the nested structs together.
 	// Therefore we need to flatten the data structure first before marshaling
 	// into json in order to have all properties sorted alphabetically. We do
-	// this by first marshaling to json, then unmarshaling to an interface{}
+	// this by first marshaling to json, then unmarshaling to an any
 	// (so that the structure is flattened), and then finally marshaling back
 	// to json. Whew.
 	j, err := json.Marshal(&c.PublicConfig)
 	if err != nil {
 		panic(err)
 	}
-	var data interface{}
+	var data any
 	err = json.Unmarshal(j, &data)
 	if err != nil {
 		panic(err)
@@ -113,9 +113,9 @@ func (c *Config) Validate() error {
 	// TODO: we should be using json schema here
 
 	fields := []struct {
-		value      interface{}
+		value      any
 		name       string
-		disallowed interface{}
+		disallowed any
 	}{
 		{value: c.AccessToken, name: "accessToken", disallowed: ""},
 		{value: c.CachesDir, name: "cachesDir", disallowed: ""},
@@ -197,7 +197,7 @@ func (cf *File) UpdateConfig(c *Config) error {
 		// An error here is serious - it means the file existed but was invalid
 		return fmt.Errorf("Error unmarshaling generic worker config file %v as JSON: %v", cf.Path, err)
 	}
-	err = c.MergeInJSON(configData, func(a map[string]interface{}) map[string]interface{} {
+	err = c.MergeInJSON(configData, func(a map[string]any) map[string]any {
 		return a
 	})
 	if err != nil {

--- a/workers/generic-worker/gwconfig/config_linux.go
+++ b/workers/generic-worker/gwconfig/config_linux.go
@@ -3,18 +3,18 @@ package gwconfig
 import "testing"
 
 type PublicPlatformConfig struct {
-	D2GConfig                 map[string]interface{} `json:"d2gConfig"`
-	DisableNativePayloads     bool                   `json:"disableNativePayloads"`
-	EnableInteractive         bool                   `json:"enableInteractive"`
-	EnableLoopbackAudio       bool                   `json:"enableLoopbackAudio"`
-	EnableLoopbackVideo       bool                   `json:"enableLoopbackVideo"`
-	LoopbackAudioDeviceNumber uint8                  `json:"loopbackAudioDeviceNumber"`
-	LoopbackVideoDeviceNumber uint8                  `json:"loopbackVideoDeviceNumber"`
+	D2GConfig                 map[string]any `json:"d2gConfig"`
+	DisableNativePayloads     bool           `json:"disableNativePayloads"`
+	EnableInteractive         bool           `json:"enableInteractive"`
+	EnableLoopbackAudio       bool           `json:"enableLoopbackAudio"`
+	EnableLoopbackVideo       bool           `json:"enableLoopbackVideo"`
+	LoopbackAudioDeviceNumber uint8          `json:"loopbackAudioDeviceNumber"`
+	LoopbackVideoDeviceNumber uint8          `json:"loopbackVideoDeviceNumber"`
 }
 
 func DefaultPublicPlatformConfig() *PublicPlatformConfig {
 	return &PublicPlatformConfig{
-		D2GConfig: map[string]interface{}{
+		D2GConfig: map[string]any{
 			"enableD2G":             false,
 			"allowChainOfTrust":     true,
 			"allowDisableSeccomp":   true,

--- a/workers/generic-worker/gwconfig/mergeconfig.go
+++ b/workers/generic-worker/gwconfig/mergeconfig.go
@@ -12,18 +12,18 @@ import (
 // map[string]interface and calling extract against the result to return a
 // map[string]interface for its config portion, then merging the two
 // map[string]interfaces together and unmarshaling back into c.
-func (c *Config) MergeInJSON(data json.RawMessage, extract func(map[string]interface{}) map[string]interface{}) error {
+func (c *Config) MergeInJSON(data json.RawMessage, extract func(map[string]any) map[string]any) error {
 	// This is all HORRIBLE
 	// but it seems about the only reasonable way to properly merge
 	// the json schemas such that json objects are recursively merged.
 	// Steps: convert c to json and then back to a go type, so that
-	// it is a map[string]interface{} and not a Config type. Get
-	// the json bytes also into a map[string]interface{} so that
-	// the two map[string]interface{} objects can be merged. Finally
+	// it is a map[string]any and not a Config type. Get
+	// the json bytes also into a map[string]any so that
+	// the two map[string]any objects can be merged. Finally
 	// convert the merge result to json again so that it can be
 	// marshaled back into the original Config type... Yuck!
-	m1 := make(map[string]interface{})
-	m2 := make(map[string]interface{})
+	m1 := make(map[string]any)
+	m2 := make(map[string]any)
 	m1bytes, err := json.Marshal(c)
 	if err != nil {
 		return err

--- a/workers/generic-worker/helper_test.go
+++ b/workers/generic-worker/helper_test.go
@@ -208,7 +208,7 @@ func submitAndAssert[P GenericWorkerPayload | dockerworker.DockerWorkerPayload](
 	return taskID
 }
 
-func toMountArray(t *testing.T, x interface{}) []json.RawMessage {
+func toMountArray(t *testing.T, x any) []json.RawMessage {
 	t.Helper()
 	b, err := json.Marshal(x)
 	if err != nil {
@@ -400,7 +400,7 @@ func GWTest(t *testing.T) *Test {
 			WorkerGroup:                    "test-worker-group",
 			WorkerID:                       "test-worker-id",
 			WorkerType:                     testWorkerType(),
-			WorkerTypeMetadata: map[string]interface{}{
+			WorkerTypeMetadata: map[string]any{
 				"generic-worker": map[string]string{
 					"go-arch":    runtime.GOARCH,
 					"go-os":      runtime.GOOS,
@@ -457,7 +457,7 @@ func GWTest(t *testing.T) *Test {
 
 	r.NotFoundHandler = http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		w.WriteHeader(404)
-		_, _ = w.Write([]byte(fmt.Sprintf("URL %v with method %v NOT FOUND\n", req.URL, req.Method)))
+		_, _ = w.Write(fmt.Appendf(nil, "URL %v with method %v NOT FOUND\n", req.URL, req.Method))
 	})
 
 	srv := &http.Server{

--- a/workers/generic-worker/insecure.go
+++ b/workers/generic-worker/insecure.go
@@ -12,6 +12,8 @@ import (
 	"strconv"
 	"strings"
 
+	"maps"
+
 	"github.com/taskcluster/shell"
 	"github.com/taskcluster/taskcluster/v81/tools/d2g"
 	"github.com/taskcluster/taskcluster/v81/workers/generic-worker/gwconfig"
@@ -145,7 +147,7 @@ func purgeOldTasks() error {
 	return nil
 }
 
-func install(arguments map[string]interface{}) (err error) {
+func install(arguments map[string]any) (err error) {
 	return nil
 }
 
@@ -164,7 +166,7 @@ func rebootBetweenTasks() bool {
 	return false
 }
 
-func platformTargets(arguments map[string]interface{}) ExitCode {
+func platformTargets(arguments map[string]any) ExitCode {
 	log.Print("Internal error - no target found to run, yet command line parsing successful")
 	return INTERNAL_ERROR
 }
@@ -195,9 +197,7 @@ func (task *TaskRun) EnvVars() []string {
 			taskEnv[spl[0]] = spl[1]
 		}
 	}
-	for k, v := range task.Payload.Env {
-		taskEnv[k] = v
-	}
+	maps.Copy(taskEnv, task.Payload.Env)
 	taskEnv["TASK_ID"] = task.TaskID
 	taskEnv["RUN_ID"] = strconv.Itoa(int(task.RunID))
 	taskEnv["TASK_WORKDIR"] = taskContext.TaskDir
@@ -226,5 +226,5 @@ func featureInitFailure(err error) ExitCode {
 func addEngineDebugInfo(m map[string]string, c *gwconfig.Config) {
 }
 
-func addEngineMetadata(m map[string]interface{}, c *gwconfig.Config) {
+func addEngineMetadata(m map[string]any, c *gwconfig.Config) {
 }

--- a/workers/generic-worker/interactive/interactive.go
+++ b/workers/generic-worker/interactive/interactive.go
@@ -104,7 +104,7 @@ func (it *Interactive) waitUntilReady(conn *websocket.Conn) (err error) {
 	}
 
 	last_output := []byte("")
-	for i := 0; i < 20; i++ {
+	for range 20 {
 		var isReadyCmd *exec.Cmd
 		isReadyCmd, err = it.interactiveCommands.IsReadyCmd()
 		if err != nil {

--- a/workers/generic-worker/interactive_test.go
+++ b/workers/generic-worker/interactive_test.go
@@ -100,7 +100,7 @@ func TestInteractiveCommand(t *testing.T) {
 			url := fmt.Sprintf("ws://localhost:%v/shell/%v", config.InteractivePort, os.Getenv("INTERACTIVE_ACCESS_TOKEN"))
 			conn, _, err = websocket.DefaultDialer.Dial(url, nil)
 			if err == nil {
-				err = conn.WriteMessage(websocket.TextMessage, []byte(fmt.Sprintf("\x01echo %s\n", SENTINEL)))
+				err = conn.WriteMessage(websocket.TextMessage, fmt.Appendf(nil, "\x01echo %s\n", SENTINEL))
 				if err != nil {
 					t.Fatalf("write error: %v", err)
 				}

--- a/workers/generic-worker/kc/kc.go
+++ b/workers/generic-worker/kc/kc.go
@@ -79,7 +79,7 @@ func AutoLoginPassword() (password []byte, err error) {
 	return
 }
 
-func LoginWindowPList() (data map[string]interface{}, err error) {
+func LoginWindowPList() (data map[string]any, err error) {
 	loginWindowPListString, err := host.CombinedOutput("/usr/bin/plutil", "-convert", "json", "/Library/Preferences/com.apple.loginwindow.plist", "-o", "-")
 	if err != nil {
 		return data, err

--- a/workers/generic-worker/loopback_audio_linux_test.go
+++ b/workers/generic-worker/loopback_audio_linux_test.go
@@ -141,6 +141,12 @@ func TestLoopbackAudioInvalidDeviceNumber(t *testing.T) {
 		Features: FeatureFlags{
 			LoopbackAudio: true,
 		},
+		OnExitStatus: ExitCodeHandling{
+			// This tests that OnExitStatus does not
+			// break when no task commands run, since
+			// task is resolved exception/malformed-payload
+			PurgeCaches: []int64{1234567},
+		},
 	}
 	defaults.SetDefaults(&payload)
 	td := testTask(t)

--- a/workers/generic-worker/metrics.go
+++ b/workers/generic-worker/metrics.go
@@ -8,7 +8,7 @@ import (
 )
 
 func logEvent(eventType string, task *TaskRun, timestamp time.Time) {
-	fields := map[string]interface{}{
+	fields := map[string]any{
 		"eventType":    eventType,
 		"worker":       "generic-worker",
 		"workerPoolId": fmt.Sprintf("%s/%s", config.ProvisionerID, config.WorkerType),

--- a/workers/generic-worker/multiuser.go
+++ b/workers/generic-worker/multiuser.go
@@ -303,11 +303,11 @@ func addEngineDebugInfo(m map[string]string, c *gwconfig.Config) {
 	m["headlessTasks"] = strconv.FormatBool(c.HeadlessTasks)
 }
 
-func addEngineMetadata(m map[string]interface{}, c *gwconfig.Config) {
+func addEngineMetadata(m map[string]any, c *gwconfig.Config) {
 	// Create empty config entry if it doesn't exist already, so that if it does
 	// exist, entries are merged rather than entire map being replaced.
 	if _, exists := m["config"]; !exists {
-		m["config"] = map[string]interface{}{}
+		m["config"] = map[string]any{}
 	}
-	m["config"].(map[string]interface{})["headlessTasks"] = c.HeadlessTasks
+	m["config"].(map[string]any)["headlessTasks"] = c.HeadlessTasks
 }

--- a/workers/generic-worker/multiuser_posix.go
+++ b/workers/generic-worker/multiuser_posix.go
@@ -12,6 +12,8 @@ import (
 	"runtime"
 	"strconv"
 
+	"maps"
+
 	"github.com/taskcluster/shell"
 	"github.com/taskcluster/taskcluster/v81/tools/d2g"
 	"github.com/taskcluster/taskcluster/v81/workers/generic-worker/host"
@@ -104,7 +106,7 @@ func (task *TaskRun) setVariable(variable string, value string) error {
 	return nil
 }
 
-func install(arguments map[string]interface{}) (err error) {
+func install(arguments map[string]any) (err error) {
 	return nil
 }
 
@@ -114,7 +116,7 @@ func RenameCrossDevice(oldpath, newpath string) error {
 	return os.Rename(oldpath, newpath)
 }
 
-func platformTargets(arguments map[string]interface{}) ExitCode {
+func platformTargets(arguments map[string]any) ExitCode {
 	log.Print("Internal error - no target found to run, yet command line parsing successful")
 	return INTERNAL_ERROR
 }
@@ -141,9 +143,7 @@ func (task *TaskRun) EnvVars() []string {
 	taskEnv["PATH"] = "/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
 	taskEnv["USER"] = taskContext.User.Name
 
-	for k, v := range task.Payload.Env {
-		taskEnv[k] = v
-	}
+	maps.Copy(taskEnv, task.Payload.Env)
 
 	// Values that should be overwritten if also set in task definition
 	taskEnv["TASK_ID"] = task.TaskID

--- a/workers/generic-worker/multiuser_windows.go
+++ b/workers/generic-worker/multiuser_windows.go
@@ -231,7 +231,7 @@ func (task *TaskRun) setVariable(variable string, value string) error {
 	return nil
 }
 
-func install(arguments map[string]interface{}) (err error) {
+func install(arguments map[string]any) (err error) {
 	exePath, err := ExePath()
 	if err != nil {
 		return err
@@ -362,7 +362,7 @@ func UACEnabled() bool {
 	return enableLUA == 1
 }
 
-func platformTargets(arguments map[string]interface{}) ExitCode {
+func platformTargets(arguments map[string]any) ExitCode {
 	switch {
 	case arguments["grant-winsta-access"]:
 		sid := arguments["--sid"].(string)
@@ -565,7 +565,7 @@ func changeOwnershipInDir(dir, newOwnerUsername string, cache *Cache) error {
 	return nil
 }
 
-func convertNilToEmptyString(val interface{}) string {
+func convertNilToEmptyString(val any) string {
 	if val == nil {
 		return ""
 	}

--- a/workers/generic-worker/sentry.go
+++ b/workers/generic-worker/sentry.go
@@ -6,7 +6,7 @@ import (
 	raven "github.com/getsentry/raven-go"
 )
 
-func ReportCrashToSentry(r interface{}) {
+func ReportCrashToSentry(r any) {
 	if config.SentryProject == "" {
 		log.Println("No sentry project defined, not reporting to sentry")
 		return

--- a/workers/generic-worker/update-worker-pool/update-worker-pool.go
+++ b/workers/generic-worker/update-worker-pool/update-worker-pool.go
@@ -52,20 +52,20 @@ func main() {
 	cdv := tcclient.Client(*workerManager)
 	cd := &cdv
 
-	var wt map[string]interface{}
+	var wt map[string]any
 	_, _, err = cd.APICall(nil, "GET", "/worker-pool/"+url.QueryEscape(workerPoolId), &wt, nil)
 	if err != nil {
 		log.Fatal(err)
 	}
-	workerPoolConfig := wt["config"].(map[string]interface{})
-	disks := workerPoolConfig["disks"].([]interface{})
+	workerPoolConfig := wt["config"].(map[string]any)
+	disks := workerPoolConfig["disks"].([]any)
 
 	delete(wt, "workerPoolId")
 	delete(wt, "created")
 	delete(wt, "lastModified")
 
-	diskObj := disks[0].(map[string]interface{})
-	initializeParams := diskObj["initializeParams"].(map[string]interface{})
+	diskObj := disks[0].(map[string]any)
+	initializeParams := diskObj["initializeParams"].(map[string]any)
 	oldImage := initializeParams["sourceImage"].(string)
 	newImage := "projects/pmoore-dev/global/images/" + os.Getenv("UNIQUE_NAME")
 	log.Print("Old image: " + oldImage)
@@ -77,16 +77,16 @@ func main() {
 		log.Print("Worker pool " + workerPoolId + " updated to use image " + newImage)
 	}
 
-	userDataMap := workerPoolConfig["workerConfig"].(map[string]interface{})
-	genericWorker := userDataMap["genericWorker"].(map[string]interface{})
-	config := genericWorker["config"].(map[string]interface{})
+	userDataMap := workerPoolConfig["workerConfig"].(map[string]any)
+	genericWorker := userDataMap["genericWorker"].(map[string]any)
+	config := genericWorker["config"].(map[string]any)
 	oldDeploymentID := config["deploymentId"].(string)
 	newDeploymentID := slugid.Nice()
 	config["deploymentId"] = newDeploymentID
 	log.Print("Old deployment ID: " + oldDeploymentID)
 	log.Print("New deployment ID: " + newDeploymentID)
-	oldMetadata := config["workerTypeMetadata"].(map[string]interface{})
-	oldMachineSetup := oldMetadata["machine-setup"].(map[string]interface{})
+	oldMetadata := config["workerTypeMetadata"].(map[string]any)
+	oldMachineSetup := oldMetadata["machine-setup"].(map[string]any)
 	oldScript := oldMachineSetup["script"].(string)
 	newScript := "https://raw.githubusercontent.com/taskcluster/generic-worker/" + gitRevision(workerTypeDir) + "/worker_types/" + workerType + "/" + scriptName
 	oldMachineSetup["script"] = newScript
@@ -94,7 +94,7 @@ func main() {
 	log.Print("Old machine setup script: " + oldScript)
 	log.Print("New machine setup script: " + newScript)
 
-	_, _, err = cd.APICall(wt, "POST", "/worker-pool/"+url.QueryEscape(workerPoolId), new(interface{}), nil)
+	_, _, err = cd.APICall(wt, "POST", "/worker-pool/"+url.QueryEscape(workerPoolId), new(any), nil)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/workers/generic-worker/workerrunner.go
+++ b/workers/generic-worker/workerrunner.go
@@ -36,8 +36,8 @@ func (w *loggingWriter) Write(p []byte) (n int, err error) {
 	if WorkerRunnerProtocol.Capable("log") {
 		WorkerRunnerProtocol.Send(workerproto.Message{
 			Type: "log",
-			Properties: map[string]interface{}{
-				"body": map[string]interface{}{
+			Properties: map[string]any{
+				"body": map[string]any{
 					"textPayload": message,
 				},
 			},

--- a/workers/generic-worker/workerrunner_test.go
+++ b/workers/generic-worker/workerrunner_test.go
@@ -51,7 +51,7 @@ func TestGracefulTermination(t *testing.T) {
 
 	runnerProto.Send(workerproto.Message{
 		Type: "graceful-termination",
-		Properties: map[string]interface{}{
+		Properties: map[string]any{
 			"finish-tasks": true,
 		},
 	})
@@ -71,7 +71,7 @@ func TestNewCredentials(t *testing.T) {
 			config.ClientID = "old"
 			clientID := fmt.Sprintf("client-cert-%v", withCert)
 
-			properties := map[string]interface{}{
+			properties := map[string]any{
 				"client-id":    clientID,
 				"access-token": "big-secret",
 			}

--- a/workers/generic-worker/yamltojson/main.go
+++ b/workers/generic-worker/yamltojson/main.go
@@ -30,7 +30,7 @@ func main() {
 // canonical representation of json (i.e. formatted with objects ordered).
 // Ugly and perhaps inefficient, but effective! :p
 func FormatJSON(a []byte) ([]byte, error) {
-	tmpObj := new(interface{})
+	tmpObj := new(any)
 	err := json.Unmarshal(a, &tmpObj)
 	if err != nil {
 		return a, err


### PR DESCRIPTION
Achieved by running `go run golang.org/x/tools/gopls/internal/analysis/modernize/cmd/modernize@latest -test ./...` as instructed in https://pkg.go.dev/golang.org/x/tools/gopls@v0.18.0/internal/analysis/modernize.

Modernizations made in this PR:

- `replacing an if/else conditional assignment by a call to the built-in min or max functions added in go1.21;`
- `replacing interface{} by the 'any' type added in go1.18;`
- `replacing append([]T(nil), s...) by slices.Clone(s) or slices.Concat(s), added in go1.21;`
- `replacing a loop around an m[k]=v map update by a call to one of the Collect, Copy, Clone, or Insert functions from the maps package, added in go1.21;`
- `replacing []byte(fmt.Sprintf...) by fmt.Appendf(nil, ...), added in go1.19;`
- `replacing a 3-clause for i := 0; i < n; i++ {} loop by for i := range n {}, added in go1.22;`