### PR TITLE
Test whether setting purge caches exit codes causes a nil pointer

### DIFF
--- a/changelog/fexEJX7xRlmTeobZSSpH0w.md
+++ b/changelog/fexEJX7xRlmTeobZSSpH0w.md
@@ -1,0 +1,3 @@
+audience: general
+level: silent
+---

--- a/workers/generic-worker/chain_of_trust_test.go
+++ b/workers/generic-worker/chain_of_trust_test.go
@@ -248,6 +248,9 @@ func TestChainOfTrustUploadAsCurrentUser(t *testing.T) {
 			ChainOfTrust:         true,
 			RunTaskAsCurrentUser: true,
 		},
+		OnExitStatus: ExitCodeHandling{
+			PurgeCaches: []int64{1234567},
+		},
 	}
 	defaults.SetDefaults(&payload)
 	td := testTask(t)


### PR DESCRIPTION
Testing whether this is the underlying cause of generic-worker panics in #7536 ...