### PR TITLE
feat(w-m): Fix edge case with empty launch configs

### DIFF
--- a/changelog/bCcRR_sGRVKYZdADicMirg.md
+++ b/changelog/bCcRR_sGRVKYZdADicMirg.md
@@ -1,0 +1,5 @@
+audience: worker-deployers
+level: patch
+---
+
+Fixes an error in worker manager's provisioner when no launch configs are defined.

--- a/services/worker-manager/src/providers/aws.js
+++ b/services/worker-manager/src/providers/aws.js
@@ -94,7 +94,7 @@ export class AwsProvider extends Provider {
       workerInfo,
     });
 
-    if (toSpawn === 0 || workerPool.config.launchConfigs.length === 0) {
+    if (toSpawn === 0 || workerPool.config?.launchConfigs?.length === 0) {
       return; // Nothing to do
     }
 

--- a/services/worker-manager/src/providers/azure/index.js
+++ b/services/worker-manager/src/providers/azure/index.js
@@ -309,7 +309,7 @@ export class AzureProvider extends Provider {
       workerInfo,
     });
 
-    if (toSpawn === 0 || workerPool.config.launchConfigs.length === 0) {
+    if (toSpawn === 0 || workerPool.config?.launchConfigs?.length === 0) {
       return; // Nothing to do
     }
 

--- a/services/worker-manager/src/providers/google.js
+++ b/services/worker-manager/src/providers/google.js
@@ -209,7 +209,7 @@ export class GoogleProvider extends Provider {
       workerInfo,
     });
 
-    if (toSpawn === 0 || workerPool.config.launchConfigs.length === 0) {
+    if (toSpawn === 0 || workerPool.config?.launchConfigs?.length === 0) {
       return; // Nothing to do
     }
 

--- a/services/worker-manager/test/provider_aws_test.js
+++ b/services/worker-manager/test/provider_aws_test.js
@@ -133,10 +133,26 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
         const workers = await helper.getWorkers();
         assert.equal(workers.length, expectedWorkers);
         await check(workers);
-        helper.assertPulseMessage('worker-requested', m => m.payload.workerPoolId === workerPoolId);
-        helper.assertPulseMessage('worker-requested', m => m.payload.workerId === workers[0].workerId);
+        if (expectedWorkers > 0) {
+          helper.assertPulseMessage('worker-requested', m => m.payload.workerPoolId === workerPoolId);
+          helper.assertPulseMessage('worker-requested', m => m.payload.workerId === workers[0].workerId);
+        }
       });
     };
+
+    provisionTest('no launch configs', {
+      config: {
+        minCapacity: 1,
+        maxCapacity: 1,
+        scalingRatio: 1,
+        lifecycle: {
+          registrationTimeout: 6000,
+        },
+      },
+      expectedWorkers: 0,
+    }, async function(workers) {
+      assert.equal(workers.length, 0);
+    });
 
     provisionTest('simple launchConfig, single worker', {
       config: {

--- a/services/worker-manager/test/provider_azure_test.js
+++ b/services/worker-manager/test/provider_azure_test.js
@@ -289,6 +289,23 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       return worker;
     };
 
+    test('provision with no launch configs', async function() {
+      const workerPool = await makeWorkerPool({
+        config: {
+          minCapacity: 1,
+          maxCapacity: 1,
+          scalingRatio: 1,
+        },
+        owner: 'whatever@example.com',
+        providerData: {},
+        emailOnError: false,
+      });
+      const workerPoolStats = new WorkerPoolStats('wpid');
+      await provider.provision({ workerPool, workerPoolStats });
+      const workers = await helper.getWorkers();
+      assert.equal(workers.length, 0);
+    });
+
     test('provision a simple worker', async function() {
       const worker = await provisionWorkerPool({});
 

--- a/services/worker-manager/test/provider_google_test.js
+++ b/services/worker-manager/test/provider_google_test.js
@@ -131,8 +131,10 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
         const workers = await helper.getWorkers();
         assert.equal(workers.length, expectedWorkers);
         await check(workers);
-        helper.assertPulseMessage('worker-requested', m => m.payload.workerPoolId === workerPoolId);
-        helper.assertPulseMessage('worker-requested', m => m.payload.workerId === workers[0].workerId);
+        if (expectedWorkers > 0) {
+          helper.assertPulseMessage('worker-requested', m => m.payload.workerPoolId === workerPoolId);
+          helper.assertPulseMessage('worker-requested', m => m.payload.workerId === workers[0].workerId);
+        }
       });
     };
 
@@ -142,6 +144,13 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       scalingRatio: 1,
       launchConfigs: [defaultLaunchConfig],
     };
+
+    provisionTest('no launch configs', {
+      config: { minCapacity: 0, maxCapacity: 1, scalingRatio: 1 },
+      expectedWorkers: 0,
+    }, async workers => {
+      assert.equal(workers.length, 0);
+    });
 
     provisionTest('simple success', {
       config,


### PR DESCRIPTION
Spotted in logs on dev for worker pool without launch configs

```
TypeError: Cannot read properties of undefined (reading 'length')
    at AzureProvider.provision (file:///app/services/worker-manager/src/providers/azure/index.js:312:58)
```