### PR TITLE
feat(generic-worker): adds `optional` payload artifact field

### DIFF
--- a/changelog/issue-7545-1.md
+++ b/changelog/issue-7545-1.md
@@ -1,0 +1,5 @@
+audience: users
+level: minor
+reference: issue 7545
+---
+D2G: sets each payload artifact as `optional` so tasks won't resolve as `failed/failed` if the artifact doesn't exist, like Docker Worker does.

--- a/changelog/issue-7545.md
+++ b/changelog/issue-7545.md
@@ -1,0 +1,5 @@
+audience: users
+level: minor
+reference: issue 7545
+---
+Generic Worker: adds `optional` field to payload artifacts to ignore any artifact upload errors, for example, if the artifact isn't known to exist at the end of a task but you don't want the task to resolve as `failed/failed`. This makes the transition from Docker Worker --> Generic Worker (through d2g) more seamless, as Docker Worker does not resolve tasks as `failed/failed` if the artifact doesn't exist.

--- a/generated/references.json
+++ b/generated/references.json
@@ -8728,7 +8728,7 @@
               },
               "optional": {
                 "default": false,
-                "description": "If `true`, the artifact is optional. If the optional artifact doesn't exist and\nfails to be uploaded, the task will not resolve as `failed/failed`.\n\nSince: generic-worker 83.1.0",
+                "description": "If `true`, the artifact is optional. If the file or directory\ndoesn't exist, the artifact won't be created.\n\nSince: generic-worker 83.1.0",
                 "title": "Optional artifact",
                 "type": "boolean"
               },
@@ -9226,7 +9226,7 @@
                   },
                   "optional": {
                     "default": false,
-                    "description": "If `true`, the artifact is optional. If the optional artifact doesn't exist and\nfails to be uploaded, the task will not resolve as `failed/failed`.\n\nSince: generic-worker 83.1.0",
+                    "description": "If `true`, the artifact is optional. If the file or directory\ndoesn't exist, the artifact won't be created.\n\nSince: generic-worker 83.1.0",
                     "title": "Optional artifact",
                     "type": "boolean"
                   },
@@ -10023,7 +10023,7 @@
                   },
                   "optional": {
                     "default": false,
-                    "description": "If `true`, the artifact is optional. If the optional artifact doesn't exist and\nfails to be uploaded, the task will not resolve as `failed/failed`.\n\nSince: generic-worker 83.1.0",
+                    "description": "If `true`, the artifact is optional. If the file or directory\ndoesn't exist, the artifact won't be created.\n\nSince: generic-worker 83.1.0",
                     "title": "Optional artifact",
                     "type": "boolean"
                   },

--- a/generated/references.json
+++ b/generated/references.json
@@ -8726,6 +8726,12 @@
                 "title": "Name of the artifact",
                 "type": "string"
               },
+              "optional": {
+                "default": false,
+                "description": "If `true`, the artifact is optional. If the optional artifact doesn't exist and\nfails to be uploaded, the task will not resolve as `failed/failed`.\n\nSince: generic-worker 83.1.0",
+                "title": "Optional artifact",
+                "type": "boolean"
+              },
               "path": {
                 "description": "Relative path of the file/directory from the task directory. Note this is not an absolute\npath as is typically used in docker-worker, since the absolute task directory name is not\nknown when the task is submitted. Example: `dist\\regedit.exe`. It doesn't matter if\nforward slashes or backslashes are used.\n\nSince: generic-worker 1.0.0",
                 "title": "Artifact location",
@@ -9217,6 +9223,12 @@
                     "description": "Name of the artifact, as it will be published. If not set, `path` will be used.\nConventionally (although not enforced) path elements are forward slash separated. Example:\n`public/build/a/house`. Note, no scopes are required to read artifacts beginning `public/`.\nArtifact names not beginning `public/` are scope-protected (caller requires scopes to\ndownload the artifact). See the Queue documentation for more information.\n\nSince: generic-worker 8.1.0",
                     "title": "Name of the artifact",
                     "type": "string"
+                  },
+                  "optional": {
+                    "default": false,
+                    "description": "If `true`, the artifact is optional. If the optional artifact doesn't exist and\nfails to be uploaded, the task will not resolve as `failed/failed`.\n\nSince: generic-worker 83.1.0",
+                    "title": "Optional artifact",
+                    "type": "boolean"
                   },
                   "path": {
                     "description": "Relative path of the file/directory from the task directory. Note this is not an absolute\npath as is typically used in docker-worker, since the absolute task directory name is not\nknown when the task is submitted. Example: `dist\\regedit.exe`. It doesn't matter if\nforward slashes or backslashes are used.\n\nSince: generic-worker 1.0.0",
@@ -10008,6 +10020,12 @@
                     "description": "Name of the artifact, as it will be published. If not set, `path` will be used.\nConventionally (although not enforced) path elements are forward slash separated. Example:\n`public/build/a/house`. Note, no scopes are required to read artifacts beginning `public/`.\nArtifact names not beginning `public/` are scope-protected (caller requires scopes to\ndownload the artifact). See the Queue documentation for more information.\n\nSince: generic-worker 8.1.0",
                     "title": "Name of the artifact",
                     "type": "string"
+                  },
+                  "optional": {
+                    "default": false,
+                    "description": "If `true`, the artifact is optional. If the optional artifact doesn't exist and\nfails to be uploaded, the task will not resolve as `failed/failed`.\n\nSince: generic-worker 83.1.0",
+                    "title": "Optional artifact",
+                    "type": "boolean"
                   },
                   "path": {
                     "description": "Relative path of the file/directory from the task directory. Note this is not an absolute\npath as is typically used in docker-worker, since the absolute task directory name is not\nknown when the task is submitted. Example: `dist\\regedit.exe`. It doesn't matter if\nforward slashes or backslashes are used.\n\nSince: generic-worker 1.0.0",

--- a/tools/d2g/d2g.go
+++ b/tools/d2g/d2g.go
@@ -313,6 +313,7 @@ func artifacts(dwPayload *dockerworker.DockerWorkerPayload) []genericworker.Arti
 		ext := filepath.Ext(dwPayload.Artifacts[name].Path)
 		gwArt.Path = "artifact" + strconv.Itoa(i) + ext
 		gwArt.Type = dwPayload.Artifacts[name].Type
+		gwArt.Optional = true
 
 		gwArtifacts[i] = *gwArt
 	}
@@ -324,6 +325,7 @@ func artifacts(dwPayload *dockerworker.DockerWorkerPayload) []genericworker.Arti
 		gwArt.Name = "public/dockerImage.tar.gz"
 		gwArt.Path = "image.tar.gz"
 		gwArt.Type = "file"
+		gwArt.Optional = true
 
 		gwArtifacts = append(gwArtifacts, *gwArt)
 	}

--- a/tools/d2g/d2gtest/testdata/testcases/artifacts_test.yml
+++ b/tools/d2g/d2gtest/testdata/testcases/artifacts_test.yml
@@ -34,10 +34,12 @@ testSuite:
       artifacts:
       - expires: "2024-05-28T16:12:56.693Z"
         name: public/build.tar.gz
+        optional: true
         path: artifact0
         type: file
       - expires: "0001-01-01T00:00:00.000Z"
         name: public/fred
+        optional: true
         path: artifact1.txt
         type: file
       command:

--- a/tools/d2g/d2gtest/testdata/testcases/decision_task_tests.yml
+++ b/tools/d2g/d2gtest/testdata/testcases/decision_task_tests.yml
@@ -68,14 +68,17 @@ testSuite:
       artifacts:
       - expires: "2023-10-20T10:58:21.912Z"
         name: public
+        optional: true
         path: artifact0
         type: directory
       - expires: "2022-10-27T10:58:21.912Z"
         name: public/docker-contexts
+        optional: true
         path: artifact1
         type: directory
       - expires: "0001-01-01T00:00:00.000Z"
         name: public/dockerImage.tar.gz
+        optional: true
         path: image.tar.gz
         type: file
       command:

--- a/tools/d2g/d2gtest/testdata/testcases/fuzzing_tests.yml
+++ b/tools/d2g/d2gtest/testdata/testcases/fuzzing_tests.yml
@@ -45,6 +45,7 @@ testSuite:
       artifacts:
       - expires: "0001-01-01T00:00:00.000Z"
         name: project/fuzzing/bugmon
+        optional: true
         path: artifact0
         type: directory
       command:

--- a/tools/d2g/genericworker/generated_types.go
+++ b/tools/d2g/genericworker/generated_types.go
@@ -76,8 +76,8 @@ type (
 		// Since: generic-worker 8.1.0
 		Name string `json:"name,omitempty"`
 
-		// If `true`, the artifact is optional. If the optional artifact doesn't exist and
-		// fails to be uploaded, the task will not resolve as `failed/failed`.
+		// If `true`, the artifact is optional. If the file or directory
+		// doesn't exist, the artifact won't be created.
 		//
 		// Since: generic-worker 83.1.0
 		//
@@ -1084,7 +1084,7 @@ func JSONSchema() string {
               },
               "optional": {
                 "default": false,
-                "description": "If ` + "`" + `true` + "`" + `, the artifact is optional. If the optional artifact doesn't exist and\nfails to be uploaded, the task will not resolve as ` + "`" + `failed/failed` + "`" + `.\n\nSince: generic-worker 83.1.0",
+                "description": "If ` + "`" + `true` + "`" + `, the artifact is optional. If the file or directory\ndoesn't exist, the artifact won't be created.\n\nSince: generic-worker 83.1.0",
                 "title": "Optional artifact",
                 "type": "boolean"
               },

--- a/tools/d2g/genericworker/generated_types.go
+++ b/tools/d2g/genericworker/generated_types.go
@@ -76,6 +76,14 @@ type (
 		// Since: generic-worker 8.1.0
 		Name string `json:"name,omitempty"`
 
+		// If `true`, the artifact is optional. If the optional artifact doesn't exist and
+		// fails to be uploaded, the task will not resolve as `failed/failed`.
+		//
+		// Since: generic-worker 83.1.0
+		//
+		// Default:    false
+		Optional bool `json:"optional" default:"false"`
+
 		// Relative path of the file/directory from the task directory. Note this is not an absolute
 		// path as is typically used in docker-worker, since the absolute task directory name is not
 		// known when the task is submitted. Example: `dist\regedit.exe`. It doesn't matter if
@@ -1073,6 +1081,12 @@ func JSONSchema() string {
                 "description": "Name of the artifact, as it will be published. If not set, ` + "`" + `path` + "`" + ` will be used.\nConventionally (although not enforced) path elements are forward slash separated. Example:\n` + "`" + `public/build/a/house` + "`" + `. Note, no scopes are required to read artifacts beginning ` + "`" + `public/` + "`" + `.\nArtifact names not beginning ` + "`" + `public/` + "`" + ` are scope-protected (caller requires scopes to\ndownload the artifact). See the Queue documentation for more information.\n\nSince: generic-worker 8.1.0",
                 "title": "Name of the artifact",
                 "type": "string"
+              },
+              "optional": {
+                "default": false,
+                "description": "If ` + "`" + `true` + "`" + `, the artifact is optional. If the optional artifact doesn't exist and\nfails to be uploaded, the task will not resolve as ` + "`" + `failed/failed` + "`" + `.\n\nSince: generic-worker 83.1.0",
+                "title": "Optional artifact",
+                "type": "boolean"
               },
               "path": {
                 "description": "Relative path of the file/directory from the task directory. Note this is not an absolute\npath as is typically used in docker-worker, since the absolute task directory name is not\nknown when the task is submitted. Example: ` + "`" + `dist\\regedit.exe` + "`" + `. It doesn't matter if\nforward slashes or backslashes are used.\n\nSince: generic-worker 1.0.0",

--- a/workers/generic-worker/artifacts.go
+++ b/workers/generic-worker/artifacts.go
@@ -39,8 +39,9 @@ func (task *TaskRun) PayloadArtifacts() []artifacts.TaskArtifact {
 	for _, artifact := range task.Payload.Artifacts {
 		basePath := artifact.Path
 		base := &artifacts.BaseArtifact{
-			Name:    artifact.Name,
-			Expires: artifact.Expires,
+			Name:     artifact.Name,
+			Expires:  artifact.Expires,
+			Optional: artifact.Optional,
 		}
 		// if no name given, use canonical path
 		if base.Name == "" {
@@ -71,8 +72,9 @@ func (task *TaskRun) PayloadArtifacts() []artifacts.TaskArtifact {
 				}
 				subName := filepath.Join(base.Name, relativePath)
 				b := &artifacts.BaseArtifact{
-					Name:    canonicalPath(subName),
-					Expires: base.Expires,
+					Name:     canonicalPath(subName),
+					Expires:  base.Expires,
+					Optional: base.Optional,
 				}
 				switch {
 				// Issue 6488

--- a/workers/generic-worker/artifacts/artifacts.go
+++ b/workers/generic-worker/artifacts/artifacts.go
@@ -50,8 +50,9 @@ type (
 
 	// Common properties across all implementations.
 	BaseArtifact struct {
-		Name    string
-		Expires tcclient.Time
+		Name     string
+		Expires  tcclient.Time
+		Optional bool
 	}
 )
 

--- a/workers/generic-worker/artifacts_test.go
+++ b/workers/generic-worker/artifacts_test.go
@@ -647,6 +647,31 @@ func TestMissingArtifactFailsTest(t *testing.T) {
 	_ = submitAndAssert(t, td, payload, "failed", "failed")
 }
 
+func TestMissingOptionalArtifactDoesNotFailTest(t *testing.T) {
+
+	setup(t)
+
+	expires := tcclient.Time(time.Now().Add(time.Minute * 30))
+
+	payload := GenericWorkerPayload{
+		Command:    helloGoodbye(),
+		MaxRunTime: 30,
+		Artifacts: []Artifact{
+			{
+				Path:     "Nonexistent/art i fact.txt",
+				Expires:  expires,
+				Type:     "file",
+				Optional: true,
+			},
+		},
+	}
+	defaults.SetDefaults(&payload)
+
+	td := testTask(t)
+
+	_ = submitAndAssert(t, td, payload, "completed", "completed")
+}
+
 func TestInvalidContentEncoding(t *testing.T) {
 
 	setup(t)

--- a/workers/generic-worker/artifacts_test.go
+++ b/workers/generic-worker/artifacts_test.go
@@ -647,7 +647,7 @@ func TestMissingArtifactFailsTest(t *testing.T) {
 	_ = submitAndAssert(t, td, payload, "failed", "failed")
 }
 
-func TestMissingOptionalArtifactDoesNotFailTest(t *testing.T) {
+func TestMissingOptionalFileArtifactDoesNotFailTest(t *testing.T) {
 
 	setup(t)
 
@@ -658,7 +658,7 @@ func TestMissingOptionalArtifactDoesNotFailTest(t *testing.T) {
 		MaxRunTime: 30,
 		Artifacts: []Artifact{
 			{
-				Path:     "Nonexistent/art i fact.txt",
+				Path:     "Nonexistent/artifact.txt",
 				Expires:  expires,
 				Type:     "file",
 				Optional: true,
@@ -669,7 +669,87 @@ func TestMissingOptionalArtifactDoesNotFailTest(t *testing.T) {
 
 	td := testTask(t)
 
-	_ = submitAndAssert(t, td, payload, "completed", "completed")
+	taskID := submitAndAssert(t, td, payload, "completed", "completed")
+	expectedArtifacts := ExpectedArtifacts{
+		"Nonexistent/artifact.txt": {
+			StorageType:      "error",
+			SkipContentCheck: true,
+		},
+		"public/logs/live_backing.log": {
+			Extracts: []string{
+				"hello world!",
+				"goodbye world!",
+			},
+			ContentType:     "text/plain; charset=utf-8",
+			ContentEncoding: "gzip",
+			Expires:         td.Expires,
+		},
+		"public/logs/live.log": {
+			Extracts: []string{
+				"hello world!",
+				"goodbye world!",
+				"=== Task Finished ===",
+				"Exit Code: 0",
+			},
+			ContentType:     "text/plain; charset=utf-8",
+			ContentEncoding: "gzip",
+			Expires:         td.Expires,
+		},
+	}
+	expectedArtifacts.Validate(t, taskID, 0)
+}
+
+func TestMissingOptionalDirectoryArtifactDoesNotFailTest(t *testing.T) {
+
+	setup(t)
+
+	expires := tcclient.Time(time.Now().Add(time.Minute * 30))
+
+	payload := GenericWorkerPayload{
+		Command:    helloGoodbye(),
+		MaxRunTime: 30,
+		Artifacts: []Artifact{
+			{
+				Path:     "Nonexistent/dir",
+				Expires:  expires,
+				Type:     "directory",
+				Optional: true,
+			},
+		},
+	}
+	defaults.SetDefaults(&payload)
+
+	td := testTask(t)
+
+	taskID := submitAndAssert(t, td, payload, "completed", "completed")
+
+	expectedArtifacts := ExpectedArtifacts{
+		"Nonexistent/dir": {
+			StorageType:      "error",
+			SkipContentCheck: true,
+		},
+		"public/logs/live_backing.log": {
+			Extracts: []string{
+				"hello world!",
+				"goodbye world!",
+			},
+			ContentType:     "text/plain; charset=utf-8",
+			ContentEncoding: "gzip",
+			Expires:         td.Expires,
+		},
+		"public/logs/live.log": {
+			Extracts: []string{
+				"hello world!",
+				"goodbye world!",
+				"=== Task Finished ===",
+				"Exit Code: 0",
+			},
+			ContentType:     "text/plain; charset=utf-8",
+			ContentEncoding: "gzip",
+			Expires:         td.Expires,
+		},
+	}
+	expectedArtifacts.Validate(t, taskID, 0)
 }
 
 func TestInvalidContentEncoding(t *testing.T) {

--- a/workers/generic-worker/generated_insecure_darwin.go
+++ b/workers/generic-worker/generated_insecure_darwin.go
@@ -78,6 +78,14 @@ type (
 		// Since: generic-worker 8.1.0
 		Name string `json:"name,omitempty"`
 
+		// If `true`, the artifact is optional. If the optional artifact doesn't exist and
+		// fails to be uploaded, the task will not resolve as `failed/failed`.
+		//
+		// Since: generic-worker 83.1.0
+		//
+		// Default:    false
+		Optional bool `json:"optional" default:"false"`
+
 		// Relative path of the file/directory from the task directory. Note this is not an absolute
 		// path as is typically used in docker-worker, since the absolute task directory name is not
 		// known when the task is submitted. Example: `dist\regedit.exe`. It doesn't matter if
@@ -1036,6 +1044,12 @@ func JSONSchema() string {
                 "description": "Name of the artifact, as it will be published. If not set, ` + "`" + `path` + "`" + ` will be used.\nConventionally (although not enforced) path elements are forward slash separated. Example:\n` + "`" + `public/build/a/house` + "`" + `. Note, no scopes are required to read artifacts beginning ` + "`" + `public/` + "`" + `.\nArtifact names not beginning ` + "`" + `public/` + "`" + ` are scope-protected (caller requires scopes to\ndownload the artifact). See the Queue documentation for more information.\n\nSince: generic-worker 8.1.0",
                 "title": "Name of the artifact",
                 "type": "string"
+              },
+              "optional": {
+                "default": false,
+                "description": "If ` + "`" + `true` + "`" + `, the artifact is optional. If the optional artifact doesn't exist and\nfails to be uploaded, the task will not resolve as ` + "`" + `failed/failed` + "`" + `.\n\nSince: generic-worker 83.1.0",
+                "title": "Optional artifact",
+                "type": "boolean"
               },
               "path": {
                 "description": "Relative path of the file/directory from the task directory. Note this is not an absolute\npath as is typically used in docker-worker, since the absolute task directory name is not\nknown when the task is submitted. Example: ` + "`" + `dist\\regedit.exe` + "`" + `. It doesn't matter if\nforward slashes or backslashes are used.\n\nSince: generic-worker 1.0.0",

--- a/workers/generic-worker/generated_insecure_darwin.go
+++ b/workers/generic-worker/generated_insecure_darwin.go
@@ -78,8 +78,8 @@ type (
 		// Since: generic-worker 8.1.0
 		Name string `json:"name,omitempty"`
 
-		// If `true`, the artifact is optional. If the optional artifact doesn't exist and
-		// fails to be uploaded, the task will not resolve as `failed/failed`.
+		// If `true`, the artifact is optional. If the file or directory
+		// doesn't exist, the artifact won't be created.
 		//
 		// Since: generic-worker 83.1.0
 		//
@@ -1047,7 +1047,7 @@ func JSONSchema() string {
               },
               "optional": {
                 "default": false,
-                "description": "If ` + "`" + `true` + "`" + `, the artifact is optional. If the optional artifact doesn't exist and\nfails to be uploaded, the task will not resolve as ` + "`" + `failed/failed` + "`" + `.\n\nSince: generic-worker 83.1.0",
+                "description": "If ` + "`" + `true` + "`" + `, the artifact is optional. If the file or directory\ndoesn't exist, the artifact won't be created.\n\nSince: generic-worker 83.1.0",
                 "title": "Optional artifact",
                 "type": "boolean"
               },

--- a/workers/generic-worker/generated_insecure_freebsd.go
+++ b/workers/generic-worker/generated_insecure_freebsd.go
@@ -78,6 +78,14 @@ type (
 		// Since: generic-worker 8.1.0
 		Name string `json:"name,omitempty"`
 
+		// If `true`, the artifact is optional. If the optional artifact doesn't exist and
+		// fails to be uploaded, the task will not resolve as `failed/failed`.
+		//
+		// Since: generic-worker 83.1.0
+		//
+		// Default:    false
+		Optional bool `json:"optional" default:"false"`
+
 		// Relative path of the file/directory from the task directory. Note this is not an absolute
 		// path as is typically used in docker-worker, since the absolute task directory name is not
 		// known when the task is submitted. Example: `dist\regedit.exe`. It doesn't matter if
@@ -1036,6 +1044,12 @@ func JSONSchema() string {
                 "description": "Name of the artifact, as it will be published. If not set, ` + "`" + `path` + "`" + ` will be used.\nConventionally (although not enforced) path elements are forward slash separated. Example:\n` + "`" + `public/build/a/house` + "`" + `. Note, no scopes are required to read artifacts beginning ` + "`" + `public/` + "`" + `.\nArtifact names not beginning ` + "`" + `public/` + "`" + ` are scope-protected (caller requires scopes to\ndownload the artifact). See the Queue documentation for more information.\n\nSince: generic-worker 8.1.0",
                 "title": "Name of the artifact",
                 "type": "string"
+              },
+              "optional": {
+                "default": false,
+                "description": "If ` + "`" + `true` + "`" + `, the artifact is optional. If the optional artifact doesn't exist and\nfails to be uploaded, the task will not resolve as ` + "`" + `failed/failed` + "`" + `.\n\nSince: generic-worker 83.1.0",
+                "title": "Optional artifact",
+                "type": "boolean"
               },
               "path": {
                 "description": "Relative path of the file/directory from the task directory. Note this is not an absolute\npath as is typically used in docker-worker, since the absolute task directory name is not\nknown when the task is submitted. Example: ` + "`" + `dist\\regedit.exe` + "`" + `. It doesn't matter if\nforward slashes or backslashes are used.\n\nSince: generic-worker 1.0.0",

--- a/workers/generic-worker/generated_insecure_freebsd.go
+++ b/workers/generic-worker/generated_insecure_freebsd.go
@@ -78,8 +78,8 @@ type (
 		// Since: generic-worker 8.1.0
 		Name string `json:"name,omitempty"`
 
-		// If `true`, the artifact is optional. If the optional artifact doesn't exist and
-		// fails to be uploaded, the task will not resolve as `failed/failed`.
+		// If `true`, the artifact is optional. If the file or directory
+		// doesn't exist, the artifact won't be created.
 		//
 		// Since: generic-worker 83.1.0
 		//
@@ -1047,7 +1047,7 @@ func JSONSchema() string {
               },
               "optional": {
                 "default": false,
-                "description": "If ` + "`" + `true` + "`" + `, the artifact is optional. If the optional artifact doesn't exist and\nfails to be uploaded, the task will not resolve as ` + "`" + `failed/failed` + "`" + `.\n\nSince: generic-worker 83.1.0",
+                "description": "If ` + "`" + `true` + "`" + `, the artifact is optional. If the file or directory\ndoesn't exist, the artifact won't be created.\n\nSince: generic-worker 83.1.0",
                 "title": "Optional artifact",
                 "type": "boolean"
               },

--- a/workers/generic-worker/generated_insecure_linux.go
+++ b/workers/generic-worker/generated_insecure_linux.go
@@ -78,6 +78,14 @@ type (
 		// Since: generic-worker 8.1.0
 		Name string `json:"name,omitempty"`
 
+		// If `true`, the artifact is optional. If the optional artifact doesn't exist and
+		// fails to be uploaded, the task will not resolve as `failed/failed`.
+		//
+		// Since: generic-worker 83.1.0
+		//
+		// Default:    false
+		Optional bool `json:"optional" default:"false"`
+
 		// Relative path of the file/directory from the task directory. Note this is not an absolute
 		// path as is typically used in docker-worker, since the absolute task directory name is not
 		// known when the task is submitted. Example: `dist\regedit.exe`. It doesn't matter if
@@ -1036,6 +1044,12 @@ func JSONSchema() string {
                 "description": "Name of the artifact, as it will be published. If not set, ` + "`" + `path` + "`" + ` will be used.\nConventionally (although not enforced) path elements are forward slash separated. Example:\n` + "`" + `public/build/a/house` + "`" + `. Note, no scopes are required to read artifacts beginning ` + "`" + `public/` + "`" + `.\nArtifact names not beginning ` + "`" + `public/` + "`" + ` are scope-protected (caller requires scopes to\ndownload the artifact). See the Queue documentation for more information.\n\nSince: generic-worker 8.1.0",
                 "title": "Name of the artifact",
                 "type": "string"
+              },
+              "optional": {
+                "default": false,
+                "description": "If ` + "`" + `true` + "`" + `, the artifact is optional. If the optional artifact doesn't exist and\nfails to be uploaded, the task will not resolve as ` + "`" + `failed/failed` + "`" + `.\n\nSince: generic-worker 83.1.0",
+                "title": "Optional artifact",
+                "type": "boolean"
               },
               "path": {
                 "description": "Relative path of the file/directory from the task directory. Note this is not an absolute\npath as is typically used in docker-worker, since the absolute task directory name is not\nknown when the task is submitted. Example: ` + "`" + `dist\\regedit.exe` + "`" + `. It doesn't matter if\nforward slashes or backslashes are used.\n\nSince: generic-worker 1.0.0",

--- a/workers/generic-worker/generated_insecure_linux.go
+++ b/workers/generic-worker/generated_insecure_linux.go
@@ -78,8 +78,8 @@ type (
 		// Since: generic-worker 8.1.0
 		Name string `json:"name,omitempty"`
 
-		// If `true`, the artifact is optional. If the optional artifact doesn't exist and
-		// fails to be uploaded, the task will not resolve as `failed/failed`.
+		// If `true`, the artifact is optional. If the file or directory
+		// doesn't exist, the artifact won't be created.
 		//
 		// Since: generic-worker 83.1.0
 		//
@@ -1047,7 +1047,7 @@ func JSONSchema() string {
               },
               "optional": {
                 "default": false,
-                "description": "If ` + "`" + `true` + "`" + `, the artifact is optional. If the optional artifact doesn't exist and\nfails to be uploaded, the task will not resolve as ` + "`" + `failed/failed` + "`" + `.\n\nSince: generic-worker 83.1.0",
+                "description": "If ` + "`" + `true` + "`" + `, the artifact is optional. If the file or directory\ndoesn't exist, the artifact won't be created.\n\nSince: generic-worker 83.1.0",
                 "title": "Optional artifact",
                 "type": "boolean"
               },

--- a/workers/generic-worker/generated_multiuser_darwin.go
+++ b/workers/generic-worker/generated_multiuser_darwin.go
@@ -78,8 +78,8 @@ type (
 		// Since: generic-worker 8.1.0
 		Name string `json:"name,omitempty"`
 
-		// If `true`, the artifact is optional. If the optional artifact doesn't exist and
-		// fails to be uploaded, the task will not resolve as `failed/failed`.
+		// If `true`, the artifact is optional. If the file or directory
+		// doesn't exist, the artifact won't be created.
 		//
 		// Since: generic-worker 83.1.0
 		//
@@ -1086,7 +1086,7 @@ func JSONSchema() string {
               },
               "optional": {
                 "default": false,
-                "description": "If ` + "`" + `true` + "`" + `, the artifact is optional. If the optional artifact doesn't exist and\nfails to be uploaded, the task will not resolve as ` + "`" + `failed/failed` + "`" + `.\n\nSince: generic-worker 83.1.0",
+                "description": "If ` + "`" + `true` + "`" + `, the artifact is optional. If the file or directory\ndoesn't exist, the artifact won't be created.\n\nSince: generic-worker 83.1.0",
                 "title": "Optional artifact",
                 "type": "boolean"
               },

--- a/workers/generic-worker/generated_multiuser_darwin.go
+++ b/workers/generic-worker/generated_multiuser_darwin.go
@@ -78,6 +78,14 @@ type (
 		// Since: generic-worker 8.1.0
 		Name string `json:"name,omitempty"`
 
+		// If `true`, the artifact is optional. If the optional artifact doesn't exist and
+		// fails to be uploaded, the task will not resolve as `failed/failed`.
+		//
+		// Since: generic-worker 83.1.0
+		//
+		// Default:    false
+		Optional bool `json:"optional" default:"false"`
+
 		// Relative path of the file/directory from the task directory. Note this is not an absolute
 		// path as is typically used in docker-worker, since the absolute task directory name is not
 		// known when the task is submitted. Example: `dist\regedit.exe`. It doesn't matter if
@@ -1075,6 +1083,12 @@ func JSONSchema() string {
                 "description": "Name of the artifact, as it will be published. If not set, ` + "`" + `path` + "`" + ` will be used.\nConventionally (although not enforced) path elements are forward slash separated. Example:\n` + "`" + `public/build/a/house` + "`" + `. Note, no scopes are required to read artifacts beginning ` + "`" + `public/` + "`" + `.\nArtifact names not beginning ` + "`" + `public/` + "`" + ` are scope-protected (caller requires scopes to\ndownload the artifact). See the Queue documentation for more information.\n\nSince: generic-worker 8.1.0",
                 "title": "Name of the artifact",
                 "type": "string"
+              },
+              "optional": {
+                "default": false,
+                "description": "If ` + "`" + `true` + "`" + `, the artifact is optional. If the optional artifact doesn't exist and\nfails to be uploaded, the task will not resolve as ` + "`" + `failed/failed` + "`" + `.\n\nSince: generic-worker 83.1.0",
+                "title": "Optional artifact",
+                "type": "boolean"
               },
               "path": {
                 "description": "Relative path of the file/directory from the task directory. Note this is not an absolute\npath as is typically used in docker-worker, since the absolute task directory name is not\nknown when the task is submitted. Example: ` + "`" + `dist\\regedit.exe` + "`" + `. It doesn't matter if\nforward slashes or backslashes are used.\n\nSince: generic-worker 1.0.0",

--- a/workers/generic-worker/generated_multiuser_freebsd.go
+++ b/workers/generic-worker/generated_multiuser_freebsd.go
@@ -78,8 +78,8 @@ type (
 		// Since: generic-worker 8.1.0
 		Name string `json:"name,omitempty"`
 
-		// If `true`, the artifact is optional. If the optional artifact doesn't exist and
-		// fails to be uploaded, the task will not resolve as `failed/failed`.
+		// If `true`, the artifact is optional. If the file or directory
+		// doesn't exist, the artifact won't be created.
 		//
 		// Since: generic-worker 83.1.0
 		//
@@ -1086,7 +1086,7 @@ func JSONSchema() string {
               },
               "optional": {
                 "default": false,
-                "description": "If ` + "`" + `true` + "`" + `, the artifact is optional. If the optional artifact doesn't exist and\nfails to be uploaded, the task will not resolve as ` + "`" + `failed/failed` + "`" + `.\n\nSince: generic-worker 83.1.0",
+                "description": "If ` + "`" + `true` + "`" + `, the artifact is optional. If the file or directory\ndoesn't exist, the artifact won't be created.\n\nSince: generic-worker 83.1.0",
                 "title": "Optional artifact",
                 "type": "boolean"
               },

--- a/workers/generic-worker/generated_multiuser_freebsd.go
+++ b/workers/generic-worker/generated_multiuser_freebsd.go
@@ -78,6 +78,14 @@ type (
 		// Since: generic-worker 8.1.0
 		Name string `json:"name,omitempty"`
 
+		// If `true`, the artifact is optional. If the optional artifact doesn't exist and
+		// fails to be uploaded, the task will not resolve as `failed/failed`.
+		//
+		// Since: generic-worker 83.1.0
+		//
+		// Default:    false
+		Optional bool `json:"optional" default:"false"`
+
 		// Relative path of the file/directory from the task directory. Note this is not an absolute
 		// path as is typically used in docker-worker, since the absolute task directory name is not
 		// known when the task is submitted. Example: `dist\regedit.exe`. It doesn't matter if
@@ -1075,6 +1083,12 @@ func JSONSchema() string {
                 "description": "Name of the artifact, as it will be published. If not set, ` + "`" + `path` + "`" + ` will be used.\nConventionally (although not enforced) path elements are forward slash separated. Example:\n` + "`" + `public/build/a/house` + "`" + `. Note, no scopes are required to read artifacts beginning ` + "`" + `public/` + "`" + `.\nArtifact names not beginning ` + "`" + `public/` + "`" + ` are scope-protected (caller requires scopes to\ndownload the artifact). See the Queue documentation for more information.\n\nSince: generic-worker 8.1.0",
                 "title": "Name of the artifact",
                 "type": "string"
+              },
+              "optional": {
+                "default": false,
+                "description": "If ` + "`" + `true` + "`" + `, the artifact is optional. If the optional artifact doesn't exist and\nfails to be uploaded, the task will not resolve as ` + "`" + `failed/failed` + "`" + `.\n\nSince: generic-worker 83.1.0",
+                "title": "Optional artifact",
+                "type": "boolean"
               },
               "path": {
                 "description": "Relative path of the file/directory from the task directory. Note this is not an absolute\npath as is typically used in docker-worker, since the absolute task directory name is not\nknown when the task is submitted. Example: ` + "`" + `dist\\regedit.exe` + "`" + `. It doesn't matter if\nforward slashes or backslashes are used.\n\nSince: generic-worker 1.0.0",

--- a/workers/generic-worker/generated_multiuser_linux.go
+++ b/workers/generic-worker/generated_multiuser_linux.go
@@ -78,8 +78,8 @@ type (
 		// Since: generic-worker 8.1.0
 		Name string `json:"name,omitempty"`
 
-		// If `true`, the artifact is optional. If the optional artifact doesn't exist and
-		// fails to be uploaded, the task will not resolve as `failed/failed`.
+		// If `true`, the artifact is optional. If the file or directory
+		// doesn't exist, the artifact won't be created.
 		//
 		// Since: generic-worker 83.1.0
 		//
@@ -1086,7 +1086,7 @@ func JSONSchema() string {
               },
               "optional": {
                 "default": false,
-                "description": "If ` + "`" + `true` + "`" + `, the artifact is optional. If the optional artifact doesn't exist and\nfails to be uploaded, the task will not resolve as ` + "`" + `failed/failed` + "`" + `.\n\nSince: generic-worker 83.1.0",
+                "description": "If ` + "`" + `true` + "`" + `, the artifact is optional. If the file or directory\ndoesn't exist, the artifact won't be created.\n\nSince: generic-worker 83.1.0",
                 "title": "Optional artifact",
                 "type": "boolean"
               },

--- a/workers/generic-worker/generated_multiuser_linux.go
+++ b/workers/generic-worker/generated_multiuser_linux.go
@@ -78,6 +78,14 @@ type (
 		// Since: generic-worker 8.1.0
 		Name string `json:"name,omitempty"`
 
+		// If `true`, the artifact is optional. If the optional artifact doesn't exist and
+		// fails to be uploaded, the task will not resolve as `failed/failed`.
+		//
+		// Since: generic-worker 83.1.0
+		//
+		// Default:    false
+		Optional bool `json:"optional" default:"false"`
+
 		// Relative path of the file/directory from the task directory. Note this is not an absolute
 		// path as is typically used in docker-worker, since the absolute task directory name is not
 		// known when the task is submitted. Example: `dist\regedit.exe`. It doesn't matter if
@@ -1075,6 +1083,12 @@ func JSONSchema() string {
                 "description": "Name of the artifact, as it will be published. If not set, ` + "`" + `path` + "`" + ` will be used.\nConventionally (although not enforced) path elements are forward slash separated. Example:\n` + "`" + `public/build/a/house` + "`" + `. Note, no scopes are required to read artifacts beginning ` + "`" + `public/` + "`" + `.\nArtifact names not beginning ` + "`" + `public/` + "`" + ` are scope-protected (caller requires scopes to\ndownload the artifact). See the Queue documentation for more information.\n\nSince: generic-worker 8.1.0",
                 "title": "Name of the artifact",
                 "type": "string"
+              },
+              "optional": {
+                "default": false,
+                "description": "If ` + "`" + `true` + "`" + `, the artifact is optional. If the optional artifact doesn't exist and\nfails to be uploaded, the task will not resolve as ` + "`" + `failed/failed` + "`" + `.\n\nSince: generic-worker 83.1.0",
+                "title": "Optional artifact",
+                "type": "boolean"
               },
               "path": {
                 "description": "Relative path of the file/directory from the task directory. Note this is not an absolute\npath as is typically used in docker-worker, since the absolute task directory name is not\nknown when the task is submitted. Example: ` + "`" + `dist\\regedit.exe` + "`" + `. It doesn't matter if\nforward slashes or backslashes are used.\n\nSince: generic-worker 1.0.0",

--- a/workers/generic-worker/generated_multiuser_windows.go
+++ b/workers/generic-worker/generated_multiuser_windows.go
@@ -76,8 +76,8 @@ type (
 		// Since: generic-worker 8.1.0
 		Name string `json:"name,omitempty"`
 
-		// If `true`, the artifact is optional. If the optional artifact doesn't exist and
-		// fails to be uploaded, the task will not resolve as `failed/failed`.
+		// If `true`, the artifact is optional. If the file or directory
+		// doesn't exist, the artifact won't be created.
 		//
 		// Since: generic-worker 83.1.0
 		//
@@ -830,7 +830,7 @@ func JSONSchema() string {
           },
           "optional": {
             "default": false,
-            "description": "If ` + "`" + `true` + "`" + `, the artifact is optional. If the optional artifact doesn't exist and\nfails to be uploaded, the task will not resolve as ` + "`" + `failed/failed` + "`" + `.\n\nSince: generic-worker 83.1.0",
+            "description": "If ` + "`" + `true` + "`" + `, the artifact is optional. If the file or directory\ndoesn't exist, the artifact won't be created.\n\nSince: generic-worker 83.1.0",
             "title": "Optional artifact",
             "type": "boolean"
           },

--- a/workers/generic-worker/generated_multiuser_windows.go
+++ b/workers/generic-worker/generated_multiuser_windows.go
@@ -76,6 +76,14 @@ type (
 		// Since: generic-worker 8.1.0
 		Name string `json:"name,omitempty"`
 
+		// If `true`, the artifact is optional. If the optional artifact doesn't exist and
+		// fails to be uploaded, the task will not resolve as `failed/failed`.
+		//
+		// Since: generic-worker 83.1.0
+		//
+		// Default:    false
+		Optional bool `json:"optional" default:"false"`
+
 		// Relative path of the file/directory from the task directory. Note this is not an absolute
 		// path as is typically used in docker-worker, since the absolute task directory name is not
 		// known when the task is submitted. Example: `dist\regedit.exe`. It doesn't matter if
@@ -819,6 +827,12 @@ func JSONSchema() string {
             "description": "Name of the artifact, as it will be published. If not set, ` + "`" + `path` + "`" + ` will be used.\nConventionally (although not enforced) path elements are forward slash separated. Example:\n` + "`" + `public/build/a/house` + "`" + `. Note, no scopes are required to read artifacts beginning ` + "`" + `public/` + "`" + `.\nArtifact names not beginning ` + "`" + `public/` + "`" + ` are scope-protected (caller requires scopes to\ndownload the artifact). See the Queue documentation for more information.\n\nSince: generic-worker 8.1.0",
             "title": "Name of the artifact",
             "type": "string"
+          },
+          "optional": {
+            "default": false,
+            "description": "If ` + "`" + `true` + "`" + `, the artifact is optional. If the optional artifact doesn't exist and\nfails to be uploaded, the task will not resolve as ` + "`" + `failed/failed` + "`" + `.\n\nSince: generic-worker 83.1.0",
+            "title": "Optional artifact",
+            "type": "boolean"
           },
           "path": {
             "description": "Relative path of the file/directory from the task directory. Note this is not an absolute\npath as is typically used in docker-worker, since the absolute task directory name is not\nknown when the task is submitted. Example: ` + "`" + `dist\\regedit.exe` + "`" + `. It doesn't matter if\nforward slashes or backslashes are used.\n\nSince: generic-worker 1.0.0",

--- a/workers/generic-worker/helper_test.go
+++ b/workers/generic-worker/helper_test.go
@@ -14,6 +14,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"slices"
 	"strconv"
 	"strings"
 	"testing"
@@ -339,6 +340,7 @@ type (
 		ContentEncoding  string
 		Expires          tcclient.Time
 		SkipContentCheck bool
+		StorageType      string
 	}
 	ExpectedArtifacts map[string]ArtifactTraits
 )
@@ -547,10 +549,15 @@ func (expectedArtifacts ExpectedArtifacts) Validate(t *testing.T, taskID string,
 			continue
 		}
 		actual := unexpectedArtifacts[artifactName]
-		// link artifacts do not have content types
-		if actual.StorageType != "link" {
+		// link and error artifacts do not have content types
+		if !slices.Contains([]string{"link", "error"}, actual.StorageType) {
 			if actual.ContentType != expected.ContentType {
 				t.Errorf("Artifact %s should have mime type '%v' but has '%s'", artifactName, expected.ContentType, actual.ContentType)
+			}
+		}
+		if expected.StorageType != "" {
+			if actual.StorageType != expected.StorageType {
+				t.Errorf("Artifact %s should have storage type '%v' but has '%s'", artifactName, expected.StorageType, actual.StorageType)
 			}
 		}
 		if !time.Time(expected.Expires).IsZero() {

--- a/workers/generic-worker/main.go
+++ b/workers/generic-worker/main.go
@@ -1123,6 +1123,10 @@ If you do require this feature, please do one of two things:
 				}
 				err := task.uploadArtifact(artifact)
 				if err != nil {
+					// we don't care about optional artifacts failing to upload
+					if artifact.Base().Optional {
+						return
+					}
 					uploadErrChan <- err
 				}
 				// Note - the above error only covers not being able to upload an
@@ -1131,6 +1135,10 @@ If you do require this feature, please do one of two things:
 				// here:
 				switch a := artifact.(type) {
 				case *artifacts.ErrorArtifact:
+					// we don't care about optional artifacts failing to upload
+					if a.Optional {
+						return
+					}
 					fail := Failure(fmt.Errorf("%v: %v", a.Reason, a.Message))
 					failChan <- fail
 					task.Errorf("TASK FAILURE during artifact upload: %v", fail)

--- a/workers/generic-worker/schemas/insecure_posix.yml
+++ b/workers/generic-worker/schemas/insecure_posix.yml
@@ -177,6 +177,15 @@ oneOf:
               encoding to all the files contained in the directory.
 
               Since: generic-worker 16.2.0
+          optional:
+            title: Optional artifact
+            type: boolean
+            default: false
+            description: |-
+              If `true`, the artifact is optional. If the optional artifact doesn't exist and
+              fails to be uploaded, the task will not resolve as `failed/failed`.
+
+              Since: generic-worker 83.1.0
         required:
         - type
         - path

--- a/workers/generic-worker/schemas/insecure_posix.yml
+++ b/workers/generic-worker/schemas/insecure_posix.yml
@@ -182,8 +182,8 @@ oneOf:
             type: boolean
             default: false
             description: |-
-              If `true`, the artifact is optional. If the optional artifact doesn't exist and
-              fails to be uploaded, the task will not resolve as `failed/failed`.
+              If `true`, the artifact is optional. If the file or directory
+              doesn't exist, the artifact won't be created.
 
               Since: generic-worker 83.1.0
         required:

--- a/workers/generic-worker/schemas/multiuser_posix.yml
+++ b/workers/generic-worker/schemas/multiuser_posix.yml
@@ -189,6 +189,15 @@ oneOf:
               encoding to all the files contained in the directory.
 
               Since: generic-worker 16.2.0
+          optional:
+            title: Optional artifact
+            type: boolean
+            default: false
+            description: |-
+              If `true`, the artifact is optional. If the optional artifact doesn't exist and
+              fails to be uploaded, the task will not resolve as `failed/failed`.
+
+              Since: generic-worker 83.1.0
         required:
         - type
         - path

--- a/workers/generic-worker/schemas/multiuser_posix.yml
+++ b/workers/generic-worker/schemas/multiuser_posix.yml
@@ -194,8 +194,8 @@ oneOf:
             type: boolean
             default: false
             description: |-
-              If `true`, the artifact is optional. If the optional artifact doesn't exist and
-              fails to be uploaded, the task will not resolve as `failed/failed`.
+              If `true`, the artifact is optional. If the file or directory
+              doesn't exist, the artifact won't be created.
 
               Since: generic-worker 83.1.0
         required:

--- a/workers/generic-worker/schemas/multiuser_windows.yml
+++ b/workers/generic-worker/schemas/multiuser_windows.yml
@@ -187,8 +187,8 @@ properties:
           type: boolean
           default: false
           description: |-
-            If `true`, the artifact is optional. If the optional artifact doesn't exist and
-            fails to be uploaded, the task will not resolve as `failed/failed`.
+            If `true`, the artifact is optional. If the file or directory
+            doesn't exist, the artifact won't be created.
 
             Since: generic-worker 83.1.0
       required:

--- a/workers/generic-worker/schemas/multiuser_windows.yml
+++ b/workers/generic-worker/schemas/multiuser_windows.yml
@@ -182,6 +182,15 @@ properties:
             encoding to all the files contained in the directory.
 
             Since: generic-worker 16.2.0
+        optional:
+          title: Optional artifact
+          type: boolean
+          default: false
+          description: |-
+            If `true`, the artifact is optional. If the optional artifact doesn't exist and
+            fails to be uploaded, the task will not resolve as `failed/failed`.
+
+            Since: generic-worker 83.1.0
       required:
       - type
       - path


### PR DESCRIPTION
Fixes #7545.

>Generic Worker: adds `optional` field to payload artifacts to ignore any artifact upload errors, for example, if the artifact isn't known to exist at the end of a task but you don't want the task to resolve as `failed/failed`. This makes the transition from Docker Worker --> Generic Worker (through d2g) more seamless, as Docker Worker does not resolve tasks as `failed/failed` if the artifact doesn't exist.

>D2G: sets each payload artifact as `optional` so tasks won't resolve as `failed/failed` if the artifact doesn't exist, like Docker Worker does.