### PR TITLE
fix(generic-worker): don't `chown` loopback devices

### DIFF
--- a/changelog/issue-7411.md
+++ b/changelog/issue-7411.md
@@ -1,0 +1,5 @@
+audience: users
+level: patch
+reference: issue 7411
+---
+Generic Worker: no longer `chown` loopback video/audio devices to the task user. Explicitly change group of the devices to `video`/`audio`, respectively, so that users in those groups may still access them.

--- a/tools/d2g/d2g.go
+++ b/tools/d2g/d2g.go
@@ -637,6 +637,10 @@ func envMappings(dwPayload *dockerworker.DockerWorkerPayload, config map[string]
 		additionalEnvVars = append(additionalEnvVars, "TASKCLUSTER_PROXY_URL")
 	}
 
+	if dwPayload.Capabilities.Devices.LoopbackVideo && config["allowLoopbackVideo"].(bool) {
+		additionalEnvVars = append(additionalEnvVars, "TASKCLUSTER_VIDEO_DEVICE")
+	}
+
 	envVarNames := []string{}
 	for envVarName := range dwPayload.Env {
 		envVarNames = append(envVarNames, envVarName)

--- a/tools/d2g/d2gtest/testdata/testcases/devices_tests.yml
+++ b/tools/d2g/d2gtest/testdata/testcases/devices_tests.yml
@@ -222,7 +222,7 @@ testSuite:
         - -cx
         - |-
           docker pull ubuntu
-          timeout -s KILL 3600 docker run -t --name taskcontainer --memory-swap -1 --pids-limit -1 --device="${TASKCLUSTER_VIDEO_DEVICE}" -e RUN_ID -e TASKCLUSTER_INSTANCE_TYPE -e TASKCLUSTER_ROOT_URL -e TASKCLUSTER_WORKER_LOCATION -e TASK_GROUP_ID -e TASK_ID ubuntu 'echo "Hello world"'
+          timeout -s KILL 3600 docker run -t --name taskcontainer --memory-swap -1 --pids-limit -1 --device="${TASKCLUSTER_VIDEO_DEVICE}" -e RUN_ID -e TASKCLUSTER_INSTANCE_TYPE -e TASKCLUSTER_ROOT_URL -e TASKCLUSTER_VIDEO_DEVICE -e TASKCLUSTER_WORKER_LOCATION -e TASK_GROUP_ID -e TASK_ID ubuntu 'echo "Hello world"'
           exit_code=$?
           docker rm -v taskcontainer
           exit "${exit_code}"

--- a/workers/generic-worker/insecure_linux.go
+++ b/workers/generic-worker/insecure_linux.go
@@ -2,16 +2,6 @@
 
 package main
 
-import gwruntime "github.com/taskcluster/taskcluster/v83/workers/generic-worker/runtime"
-
-func makeFileOrDirReadWritableForUser(recurse bool, fileOrDir string, user *gwruntime.OSUser) error {
-	return nil
-}
-
-func makeDirUnreadableForUser(dir string, user *gwruntime.OSUser) error {
-	return nil
-}
-
 func platformFeatures() []Feature {
 	return []Feature{
 		&InteractiveFeature{},

--- a/workers/generic-worker/loopback_audio_linux_test.go
+++ b/workers/generic-worker/loopback_audio_linux_test.go
@@ -38,8 +38,8 @@ func TestLoopbackAudio(t *testing.T) {
 	_ = submitAndAssert(t, td, payload, "completed", "completed")
 
 	logText := LogText(t)
-	if !strings.Contains(logText, "crw-rw----") {
-		t.Fatalf("Expected log to contain 'crw-rw----', but it didn't\n%s", logText)
+	if !strings.Contains(logText, "crw-rw----+ 1 root audio") {
+		t.Fatalf("Expected log to contain 'crw-rw----+ 1 root audio', but it didn't\n%s", logText)
 	}
 }
 

--- a/workers/generic-worker/multiuser_linux.go
+++ b/workers/generic-worker/multiuser_linux.go
@@ -2,14 +2,6 @@
 
 package main
 
-import (
-	"fmt"
-	"os"
-
-	"github.com/taskcluster/taskcluster/v83/workers/generic-worker/host"
-	gwruntime "github.com/taskcluster/taskcluster/v83/workers/generic-worker/runtime"
-)
-
 func defaultTasksDir() string {
 	return "/home"
 }
@@ -25,14 +17,4 @@ func platformFeatures() []Feature {
 		// checks as late as possible
 		&ChainOfTrustFeature{},
 	}
-}
-
-func makeDirUnreadableForUser(dir string, user *gwruntime.OSUser) error {
-	// Note, only need to set top directory, not recursively, since without
-	// access to top directory, nothing inside can be read anyway
-	err := host.Run("/bin/chown", "0:0", dir)
-	if err != nil {
-		return fmt.Errorf("[mounts] Not able to make directory %v owned by root/root in order to prevent %v from having access: %v", dir, user.Name, err)
-	}
-	return os.Chmod(dir, 0700)
 }


### PR DESCRIPTION
Fixes #7411.

>Generic Worker: no longer `chown` loopback video/audio devices to the task user. Explicitly change group of the devices to `video`/`audio`, respectively, so that users in those groups may still access them.