### PR TITLE
fix(release): don't share logfiles during release pipeline

### DIFF
--- a/changelog/B9fb36vqR2CQHDmydFAArA.md
+++ b/changelog/B9fb36vqR2CQHDmydFAArA.md
@@ -1,0 +1,3 @@
+audience: general
+level: silent
+---

--- a/infrastructure/tooling/src/build/tasks/generic-worker-image.js
+++ b/infrastructure/tooling/src/build/tasks/generic-worker-image.js
@@ -89,7 +89,7 @@ export default ({ tasks, baseDir, cmdOptions, credentials, logsDir }) => {
       await execCommand({
         command,
         dir: sourceDir,
-        logfile: path.join(logsDir, 'docker-build.log'),
+        logfile: path.join(logsDir, 'generic-worker-docker-build.log'),
         utils,
         env: { DOCKER_BUILDKIT: 1, ...process.env },
       });
@@ -128,7 +128,7 @@ export default ({ tasks, baseDir, cmdOptions, credentials, logsDir }) => {
       }
 
       await dockerPush({
-        logfile: path.join(logsDir, 'docker-push.log'),
+        logfile: path.join(logsDir, 'generic-worker-docker-push.log'),
         tag,
         utils,
         baseDir,

--- a/infrastructure/tooling/src/build/tasks/monoimage.js
+++ b/infrastructure/tooling/src/build/tasks/monoimage.js
@@ -100,7 +100,7 @@ const generateMonoimageTasks = ({ tasks, baseDir, cmdOptions, credentials, logsD
       await execCommand({
         command,
         dir: sourceDir,
-        logfile: path.join(logsDir, 'docker-build.log'),
+        logfile: path.join(logsDir, 'monoimage-docker-build.log'),
         utils,
         env: { DOCKER_BUILDKIT: 1, ...process.env },
       });
@@ -171,7 +171,7 @@ const generateMonoimageTasks = ({ tasks, baseDir, cmdOptions, credentials, logsD
         await execCommand({
           command: ['docker', 'build', '--progress', 'plain', '--tag', tag, '.'],
           dir: dockerDir,
-          logfile: path.join(logsDir, 'docker-build-devel.log'),
+          logfile: path.join(logsDir, 'monoimage-devel-docker-build.log'),
           utils,
           env: { DOCKER_BUILDKIT: 1, ...process.env },
         });
@@ -213,7 +213,7 @@ const generateMonoimageTasks = ({ tasks, baseDir, cmdOptions, credentials, logsD
       }
 
       await dockerPush({
-        logfile: path.join(logsDir, 'docker-push.log'),
+        logfile: path.join(logsDir, 'monoimage-docker-push.log'),
         tag,
         utils,
         baseDir,
@@ -254,7 +254,7 @@ const generateMonoimageTasks = ({ tasks, baseDir, cmdOptions, credentials, logsD
       }
 
       await dockerPush({
-        logfile: path.join(logsDir, 'docker-push.log'),
+        logfile: path.join(logsDir, 'monoimage-devel-docker-push.log'),
         tag,
         utils,
         baseDir,

--- a/infrastructure/tooling/src/build/tasks/release.js
+++ b/infrastructure/tooling/src/build/tasks/release.js
@@ -73,7 +73,7 @@ export default ({ tasks, cmdOptions, credentials, baseDir, logsDir }) => {
           './tools/websocktunnel/cmd/websocktunnel',
         ],
         dir: REPO_ROOT,
-        logfile: path.join(logsDir, '/websocktunnel-build.log'),
+        logfile: path.join(logsDir, 'websocktunnel-build.log'),
         utils,
         env: { CGO_ENABLED: '0', ...process.env },
       });
@@ -122,7 +122,7 @@ export default ({ tasks, cmdOptions, credentials, baseDir, logsDir }) => {
       }
 
       await dockerPush({
-        logfile: path.join(logsDir, 'docker-push.log'),
+        logfile: path.join(logsDir, 'websocktunnel-docker-push.log'),
         tag,
         utils,
         baseDir,

--- a/infrastructure/tooling/src/build/tasks/taskcluster-proxy.js
+++ b/infrastructure/tooling/src/build/tasks/taskcluster-proxy.js
@@ -101,7 +101,7 @@ export default ({ tasks, cmdOptions, credentials, baseDir, logsDir }) => {
       }
 
       await dockerPush({
-        logfile: path.join(logsDir, 'docker-push.log'),
+        logfile: path.join(logsDir, 'taskcluster-proxy-docker-push.log'),
         tag,
         utils,
         baseDir,

--- a/infrastructure/tooling/src/build/tasks/websocktunnel.js
+++ b/infrastructure/tooling/src/build/tasks/websocktunnel.js
@@ -31,7 +31,7 @@ export default ({ tasks, cmdOptions, credentials, baseDir, logsDir }) => {
           './tools/websocktunnel/cmd/websocktunnel',
         ],
         dir: REPO_ROOT,
-        logfile: path.join(logsDir, '/websocktunnel-build.log'),
+        logfile: path.join(logsDir, 'websocktunnel-build.log'),
         utils,
         env: { CGO_ENABLED: '0', ...process.env },
       });
@@ -80,7 +80,7 @@ export default ({ tasks, cmdOptions, credentials, baseDir, logsDir }) => {
       }
 
       await dockerPush({
-        logfile: path.join(logsDir, 'docker-push.log'),
+        logfile: path.join(logsDir, 'websocktunnel-docker-push.log'),
         tag,
         utils,
         baseDir,

--- a/infrastructure/tooling/src/utils/command.js
+++ b/infrastructure/tooling/src/utils/command.js
@@ -35,8 +35,9 @@ export const execCommand = async ({
 
   if (logfile) {
     const logStream = fs.createWriteStream(logfile);
-    cp.stdout.pipe(logStream);
-    cp.stderr.pipe(logStream);
+    cp.stdout.pipe(logStream, { end: false });
+    cp.stderr.pipe(logStream, { end: false });
+    cp.on('close', () => logStream.end());
   }
 
   const stream = new Transform({
@@ -49,8 +50,9 @@ export const execCommand = async ({
       callback(null, chunk);
     },
   });
-  cp.stdout.pipe(stream);
-  cp.stderr.pipe(stream);
+  cp.stdout.pipe(stream, { end: false });
+  cp.stderr.pipe(stream, { end: false });
+  cp.on('close', () => stream.end());
   if (stdin) {
     cp.stdin.write(stdin);
     cp.stdin.end();

--- a/infrastructure/tooling/src/utils/crates.js
+++ b/infrastructure/tooling/src/utils/crates.js
@@ -45,8 +45,9 @@ export const cargoPublish = async ({ dir, token, push, logfile, utils }) => {
 
       if (logfile) {
         const logStream = fs.createWriteStream(logfile);
-        proc.stdout.pipe(logStream);
-        proc.stderr.pipe(logStream);
+        proc.stdout.pipe(logStream, { end: false });
+        proc.stderr.pipe(logStream, { end: false });
+        proc.on('close', () => logStream.end());
       }
 
       const loglines = data =>

--- a/infrastructure/tooling/src/utils/pypi.js
+++ b/infrastructure/tooling/src/utils/pypi.js
@@ -36,8 +36,9 @@ export const pyClientRelease = async ({ dir, username, password, logfile, utils 
 
       if (logfile) {
         const logStream = fs.createWriteStream(logfile);
-        proc.stdout.pipe(logStream);
-        proc.stderr.pipe(logStream);
+        proc.stdout.pipe(logStream, { end: false });
+        proc.stderr.pipe(logStream, { end: false });
+        proc.on('close', () => logStream.end());
       }
 
       const loglines = data =>


### PR DESCRIPTION
I _believe_ this should fix https://github.com/taskcluster/taskcluster/issues/3018 (already closed as completed for some reason).

Release error logs like:
```bash
node:events:502
      throw er; // Unhandled 'error' event
      ^

Error [ERR_STREAM_WRITE_AFTER_END]: write after end
    at _write (node:internal/streams/writable:489:11)
    at Writable.write (node:internal/streams/writable:510:10)
    at Socket.ondata (node:internal/streams/readable:1009:22)
    at Socket.emit (node:events:524:28)
    at addChunk (node:internal/streams/readable:561:12)
    at readableAddChunkPushByteMode (node:internal/streams/readable:512:3)
    at Readable.push (node:internal/streams/readable:392:5)
    at Pipe.onStreamRead (node:internal/stream_base_commons:189:23)
Emitted 'error' event on WriteStream instance at:
    at WriteStream.onerror (node:internal/streams/readable:1028:14)
    at WriteStream.emit (node:events:536:35)
    at emitErrorNT (node:internal/streams/destroy:170:8)
    at emitErrorCloseNT (node:internal/streams/destroy:129:3)
    at process.processTicksAndRejections (node:internal/process/task_queues:90:21) {
  code: 'ERR_STREAM_WRITE_AFTER_END'
}

Node.js v22.13.1
```