### PR TITLE
fix(generic-worker): fix PUT url for refreshing tc proxy creds

### DIFF
--- a/changelog/issue-7568.md
+++ b/changelog/issue-7568.md
@@ -1,0 +1,5 @@
+audience: worker-deployers
+level: patch
+reference: issue 7568
+---
+Generic Worker: fixes panic while trying to refresh `taskcluster-proxy` credentials.

--- a/workers/generic-worker/taskcluster_proxy.go
+++ b/workers/generic-worker/taskcluster_proxy.go
@@ -110,7 +110,7 @@ func (l *TaskclusterProxyTask) Start() *CommandExecutionError {
 				panic(err)
 			}
 			buffer := bytes.NewBuffer(b)
-			putURL := fmt.Sprintf("http://localhost:%v/credentials", config.TaskclusterProxyPort)
+			putURL := fmt.Sprintf("http://%s:%v/credentials", l.taskclusterProxyAddress, config.TaskclusterProxyPort)
 			req, err := http.NewRequest("PUT", putURL, buffer)
 			if err != nil {
 				panic(fmt.Sprintf("Could not create PUT request to taskcluster-proxy /credentials endpoint: %v", err))


### PR DESCRIPTION
Fixes #7568.

>Generic Worker: fixes panic while trying to refresh `taskcluster-proxy` credentials.

Note: this issue only occurs with d2g tasks.