### PR TITLE
fix(generic-worker): don't panic when stopping tc-proxy feature

### DIFF
--- a/changelog/MMddbGelSSaXAnDk0Jre1g.md
+++ b/changelog/MMddbGelSSaXAnDk0Jre1g.md
@@ -1,0 +1,4 @@
+audience: general
+level: patch
+---
+Generic Worker: fix `panic` when the taskcluster proxy task feature tries to terminate the taskcluster proxy PID.

--- a/workers/generic-worker/taskcluster_proxy.go
+++ b/workers/generic-worker/taskcluster_proxy.go
@@ -130,6 +130,9 @@ func (l *TaskclusterProxyTask) Start() *CommandExecutionError {
 
 func (l *TaskclusterProxyTask) Stop(err *ExecutionErrors) {
 	l.task.StatusManager.DeregisterListener(l.taskStatusChangeListener)
+	if l.taskclusterProxy == nil {
+		return
+	}
 	errTerminate := l.taskclusterProxy.Terminate()
 	if errTerminate != nil {
 		// no need to raise an exception, machine will reboot anyway


### PR DESCRIPTION
Fixes a nil pointer dereference which would look like this in the task logs:

```bash
[taskcluster:error] could not start taskcluster proxy: timeout waiting for taskcluster-proxy port 80 to be active
[taskcluster:error] goroutine 1 [running]:
[taskcluster:error] runtime/debug.Stack()
[taskcluster:error] 	/home/task_174121127671722/go/go/src/runtime/debug/stack.go:26 +0x5e
[taskcluster:error] main.(*TaskRun).Run.func2()
[taskcluster:error] 	/home/task_174121127671722/taskcluster/workers/generic-worker/main.go:999 +0x9d
[taskcluster:error] panic({0xa80580?, 0x1095e40?})
[taskcluster:error] 	/home/task_174121127671722/go/go/src/runtime/panic.go:785 +0x132
[taskcluster:error] github.com/taskcluster/taskcluster/v83/workers/generic-worker/tcproxy.(*TaskclusterProxy).Terminate(0xc000254d80?)
[taskcluster:error] 	/home/task_174121127671722/taskcluster/workers/generic-worker/tcproxy/tcproxy.go:61 +0x2d
[taskcluster:error] main.(*TaskclusterProxyTask).Stop(0xc0002d65a0, 0x0?)
[taskcluster:error] 	/home/task_174121127671722/taskcluster/workers/generic-worker/taskcluster_proxy.go:137 +0x49
[taskcluster:error] main.(*TaskRun).Run.func3({{0xc80d60?, 0xc0002d65a0?}, {0xc83060?, 0x10d0260?}})
[taskcluster:error] 	/home/task_174121127671722/taskcluster/workers/generic-worker/main.go:1097 +0xe9
[taskcluster:error] main.(*TaskRun).Run(0xc0000fe808)
[taskcluster:error] 	/home/task_174121127671722/taskcluster/workers/generic-worker/main.go:1101 +0xe96
[taskcluster:error] main.RunWorker()
[taskcluster:error] 	/home/task_174121127671722/taskcluster/workers/generic-worker/main.go:471 +0xa85
[taskcluster:error] main.main()
[taskcluster:error] 	/home/task_174121127671722/taskcluster/workers/generic-worker/main.go:165 +0x5ea
[taskcluster:error] 
[taskcluster:error] "invalid memory address or nil pointer dereference"
[taskcluster:error] runtime error: invalid memory address or nil pointer dereference
```