### PR TITLE
fix(g-w): better detection of the docker bridge ip address

### DIFF
--- a/changelog/OU8YgOZpT_O2KZBLB3QecQ.md
+++ b/changelog/OU8YgOZpT_O2KZBLB3QecQ.md
@@ -1,0 +1,4 @@
+audience: worker-deployers
+level: patch
+---
+Generic Worker: fix detection of docker bridge gateway address in the presence of ipv6

--- a/workers/generic-worker/tcproxy/tcproxy.go
+++ b/workers/generic-worker/tcproxy/tcproxy.go
@@ -85,5 +85,5 @@ func waitForPortToBeActive(ipAddress string, port uint16) error {
 		}
 		time.Sleep(100 * time.Millisecond)
 	}
-	return fmt.Errorf("timeout waiting for taskcluster-proxy port %v to be active", port)
+	return fmt.Errorf("timeout waiting for taskcluster-proxy %v:%v to be active", ipAddress, port)
 }


### PR DESCRIPTION
In the presence of more than one address on the docker bridge network, we were assuming the gateway could be found on the first network, which is not necessarily the case.  Instead, we now get all gateways from `docker network inspect`, and select the first ipv4 one (ipv6 addresses would need more massaging to work in URLs, so we skip them).
