### PR TITLE
fix(d2g): add `audio`/`video` os-groups and scopes

### DIFF
--- a/changelog/issue-7581.md
+++ b/changelog/issue-7581.md
@@ -1,0 +1,5 @@
+audience: worker-deployers
+level: patch
+reference: issue 7581
+---
+D2G: add `audio`/`video` os-groups and scopes needed when the Docker Worker task payload requests these loopback devices.

--- a/tools/d2g/d2g.go
+++ b/tools/d2g/d2g.go
@@ -145,13 +145,29 @@ func ConvertScopes(dwScopes []string, dwPayload *dockerworker.DockerWorkerPayloa
 				"generic-worker:os-group:"+s[len("docker-worker:capability:device:kvm:"):]+"/libvirt",
 			)
 		case s == "docker-worker:capability:device:loopbackVideo":
-			gwScopes = append(gwScopes, "generic-worker:loopback-video:*")
+			gwScopes = append(
+				gwScopes,
+				"generic-worker:loopback-video:*",
+				"generic-worker:os-group:"+taskQueueID+"/video",
+			)
 		case strings.HasPrefix(s, "docker-worker:capability:device:loopbackVideo:"):
-			gwScopes = append(gwScopes, "generic-worker:loopback-video:"+s[len("docker-worker:capability:device:loopbackVideo:"):])
+			gwScopes = append(
+				gwScopes,
+				"generic-worker:loopback-video:"+s[len("docker-worker:capability:device:loopbackVideo:"):],
+				"generic-worker:os-group:"+s[len("docker-worker:capability:device:loopbackVideo:"):]+"/video",
+			)
 		case s == "docker-worker:capability:device:loopbackAudio":
-			gwScopes = append(gwScopes, "generic-worker:loopback-audio:*")
+			gwScopes = append(
+				gwScopes,
+				"generic-worker:loopback-audio:*",
+				"generic-worker:os-group:"+taskQueueID+"/audio",
+			)
 		case strings.HasPrefix(s, "docker-worker:capability:device:loopbackAudio:"):
-			gwScopes = append(gwScopes, "generic-worker:loopback-audio:"+s[len("docker-worker:capability:device:loopbackAudio:"):])
+			gwScopes = append(
+				gwScopes,
+				"generic-worker:loopback-audio:"+s[len("docker-worker:capability:device:loopbackAudio:"):],
+				"generic-worker:os-group:"+s[len("docker-worker:capability:device:loopbackAudio:"):]+"/audio",
+			)
 		case strings.HasPrefix(s, "docker-worker:"):
 			gwScopes = append(gwScopes, "generic-worker:"+s[len("docker-worker:"):])
 		}
@@ -528,6 +544,12 @@ func setOSGroups(dwPayload *dockerworker.DockerWorkerPayload, gwPayload *generic
 		// task user needs to be in kvm and libvirt groups for KVM to work:
 		// https://help.ubuntu.com/community/KVM/Installation
 		gwPayload.OSGroups = append(gwPayload.OSGroups, "kvm", "libvirt")
+	}
+	if dwPayload.Capabilities.Devices.LoopbackAudio && config["allowLoopbackAudio"].(bool) {
+		gwPayload.OSGroups = append(gwPayload.OSGroups, "audio")
+	}
+	if dwPayload.Capabilities.Devices.LoopbackVideo && config["allowLoopbackVideo"].(bool) {
+		gwPayload.OSGroups = append(gwPayload.OSGroups, "video")
 	}
 	gwPayload.OSGroups = append(gwPayload.OSGroups, "docker")
 }

--- a/tools/d2g/d2gtest/d2g_test.go
+++ b/tools/d2g/d2gtest/d2g_test.go
@@ -61,9 +61,12 @@ func ExampleConvertScopes_mixture() {
 	//	"generic-worker:loopback-video:*"
 	//	"generic-worker:loopback-video:x/y/z"
 	//	"generic-worker:monkey"
+	//	"generic-worker:os-group:/video"
 	//	"generic-worker:os-group:proj-misc/tutorial/docker"
+	//	"generic-worker:os-group:proj-misc/tutorial/video"
 	//	"generic-worker:os-group:x/y/z/kvm"
 	//	"generic-worker:os-group:x/y/z/libvirt"
+	//	"generic-worker:os-group:x/y/z/video"
 	//	"generic-worker:teapot"
 }
 

--- a/tools/d2g/d2gtest/testdata/testcases/devices_tests.yml
+++ b/tools/d2g/d2gtest/testdata/testcases/devices_tests.yml
@@ -239,6 +239,7 @@ testSuite:
         - 125
         - 128
       osGroups:
+      - video
       - docker
     name: Video Loopback
   - d2gConfig:
@@ -334,6 +335,7 @@ testSuite:
         - 125
         - 128
       osGroups:
+      - audio
       - docker
     name: Audio Loopback
   - d2gConfig:

--- a/tools/d2g/d2gtest/testdata/testcases/fuzzing_tests.yml
+++ b/tools/d2g/d2gtest/testdata/testcases/fuzzing_tests.yml
@@ -82,5 +82,6 @@ testSuite:
         - 125
         - 128
       osGroups:
+      - audio
       - docker
     name: Bugmon Processor disableSeccomp test task

--- a/workers/generic-worker/d2g_test.go
+++ b/workers/generic-worker/d2g_test.go
@@ -331,7 +331,9 @@ func TestD2GLoopbackVideoDevice(t *testing.T) {
 		Command: []string{
 			"/bin/bash",
 			"-c",
-			"ls /dev && test -c ${TASKCLUSTER_VIDEO_DEVICE} || { echo 'Device not found' ; exit 1; }",
+			`ls /dev && test -c ${TASKCLUSTER_VIDEO_DEVICE} \
+			-a -r ${TASKCLUSTER_VIDEO_DEVICE} \
+			|| { echo 'Device not found or not readable' ; exit 1; }`,
 		},
 		Image:      json.RawMessage(imageBytes),
 		MaxRunTime: 30,
@@ -354,8 +356,8 @@ func TestD2GLoopbackVideoDevice(t *testing.T) {
 		_ = submitAndAssert(t, td, payload, "exception", "malformed-payload")
 		logtext := LogText(t)
 		t.Log(logtext)
-		if !strings.Contains(logtext, "task payload contains unsupported osGroups: [docker]") {
-			t.Fatal("Was expecting log file to contain 'task payload contains unsupported osGroups: [docker]'")
+		if !strings.Contains(logtext, "task payload contains unsupported osGroups: [video docker]") {
+			t.Fatal("Was expecting log file to contain 'task payload contains unsupported osGroups: [video docker]'")
 		}
 	default:
 		_ = submitAndAssert(t, td, payload, "exception", "malformed-payload")
@@ -399,8 +401,8 @@ func TestD2GLoopbackVideoDeviceWithWorkerPoolScopes(t *testing.T) {
 		_ = submitAndAssert(t, td, payload, "exception", "malformed-payload")
 		logtext := LogText(t)
 		t.Log(logtext)
-		if !strings.Contains(logtext, "task payload contains unsupported osGroups: [docker]") {
-			t.Fatal("Was expecting log file to contain 'task payload contains unsupported osGroups: [docker]'")
+		if !strings.Contains(logtext, "task payload contains unsupported osGroups: [video docker]") {
+			t.Fatal("Was expecting log file to contain 'task payload contains unsupported osGroups: [video docker]'")
 		}
 	default:
 		_ = submitAndAssert(t, td, payload, "exception", "malformed-payload")
@@ -450,8 +452,8 @@ func TestD2GLoopbackVideoDeviceNonRootUserInVideoGroup(t *testing.T) {
 		_ = submitAndAssert(t, td, payload, "exception", "malformed-payload")
 		logtext := LogText(t)
 		t.Log(logtext)
-		if !strings.Contains(logtext, "task payload contains unsupported osGroups: [docker]") {
-			t.Fatal("Was expecting log file to contain 'task payload contains unsupported osGroups: [docker]'")
+		if !strings.Contains(logtext, "task payload contains unsupported osGroups: [video docker]") {
+			t.Fatal("Was expecting log file to contain 'task payload contains unsupported osGroups: [video docker]'")
 		}
 	default:
 		_ = submitAndAssert(t, td, payload, "exception", "malformed-payload")
@@ -501,8 +503,8 @@ func TestD2GLoopbackVideoDeviceNonRootUserNotInVideoGroup(t *testing.T) {
 		_ = submitAndAssert(t, td, payload, "exception", "malformed-payload")
 		logtext := LogText(t)
 		t.Log(logtext)
-		if !strings.Contains(logtext, "task payload contains unsupported osGroups: [docker]") {
-			t.Fatal("Was expecting log file to contain 'task payload contains unsupported osGroups: [docker]'")
+		if !strings.Contains(logtext, "task payload contains unsupported osGroups: [video docker]") {
+			t.Fatal("Was expecting log file to contain 'task payload contains unsupported osGroups: [video docker]'")
 		}
 	default:
 		_ = submitAndAssert(t, td, payload, "exception", "malformed-payload")
@@ -526,7 +528,10 @@ func TestD2GLoopbackAudioDevice(t *testing.T) {
 			`ls /dev/snd && test -c /dev/snd/controlC16 \
 			-a -c /dev/snd/pcmC16D0c -a -c /dev/snd/pcmC16D0p \
 			-a -c /dev/snd/pcmC16D1c -a -c /dev/snd/pcmC16D1p \
-			|| { echo 'Device not found' ; exit 1; }`,
+			-a -r /dev/snd/controlC16 \
+			-a -r /dev/snd/pcmC16D0c -a -r /dev/snd/pcmC16D0p \
+			-a -r /dev/snd/pcmC16D1c -a -r /dev/snd/pcmC16D1p \
+			|| { echo 'Device not found or not readable' ; exit 1; }`,
 		},
 		Image:      json.RawMessage(imageBytes),
 		MaxRunTime: 30,
@@ -549,8 +554,8 @@ func TestD2GLoopbackAudioDevice(t *testing.T) {
 		_ = submitAndAssert(t, td, payload, "exception", "malformed-payload")
 		logtext := LogText(t)
 		t.Log(logtext)
-		if !strings.Contains(logtext, "task payload contains unsupported osGroups: [docker]") {
-			t.Fatal("Was expecting log file to contain 'task payload contains unsupported osGroups: [docker]'")
+		if !strings.Contains(logtext, "task payload contains unsupported osGroups: [audio docker]") {
+			t.Fatal("Was expecting log file to contain 'task payload contains unsupported osGroups: [audio docker]'")
 		}
 	default:
 		_ = submitAndAssert(t, td, payload, "exception", "malformed-payload")
@@ -597,8 +602,8 @@ func TestD2GLoopbackAudioDeviceWithWorkerPoolScopes(t *testing.T) {
 		_ = submitAndAssert(t, td, payload, "exception", "malformed-payload")
 		logtext := LogText(t)
 		t.Log(logtext)
-		if !strings.Contains(logtext, "task payload contains unsupported osGroups: [docker]") {
-			t.Fatal("Was expecting log file to contain 'task payload contains unsupported osGroups: [docker]'")
+		if !strings.Contains(logtext, "task payload contains unsupported osGroups: [audio docker]") {
+			t.Fatal("Was expecting log file to contain 'task payload contains unsupported osGroups: [audio docker]'")
 		}
 	default:
 		_ = submitAndAssert(t, td, payload, "exception", "malformed-payload")
@@ -650,8 +655,8 @@ func TestD2GLoopbackAudioDeviceNonRootUserInAudioGroup(t *testing.T) {
 		_ = submitAndAssert(t, td, payload, "exception", "malformed-payload")
 		logtext := LogText(t)
 		t.Log(logtext)
-		if !strings.Contains(logtext, "task payload contains unsupported osGroups: [docker]") {
-			t.Fatal("Was expecting log file to contain 'task payload contains unsupported osGroups: [docker]'")
+		if !strings.Contains(logtext, "task payload contains unsupported osGroups: [audio docker]") {
+			t.Fatal("Was expecting log file to contain 'task payload contains unsupported osGroups: [audio docker]'")
 		}
 	default:
 		_ = submitAndAssert(t, td, payload, "exception", "malformed-payload")
@@ -703,8 +708,8 @@ func TestD2GLoopbackAudioDeviceNonRootUserNotInAudioGroup(t *testing.T) {
 		_ = submitAndAssert(t, td, payload, "exception", "malformed-payload")
 		logtext := LogText(t)
 		t.Log(logtext)
-		if !strings.Contains(logtext, "task payload contains unsupported osGroups: [docker]") {
-			t.Fatal("Was expecting log file to contain 'task payload contains unsupported osGroups: [docker]'")
+		if !strings.Contains(logtext, "task payload contains unsupported osGroups: [audio docker]") {
+			t.Fatal("Was expecting log file to contain 'task payload contains unsupported osGroups: [audio docker]'")
 		}
 	default:
 		_ = submitAndAssert(t, td, payload, "exception", "malformed-payload")


### PR DESCRIPTION
Fixes #7581.

Should have been handled in https://github.com/taskcluster/taskcluster/pull/7551.

>D2G: add `audio`/`video` os-groups and scopes needed when the Docker Worker task payload requests these loopback devices.