### PR TITLE
feat(generic-worker): monitor memory usage during tasks and help prevent OOMs

### DIFF
--- a/changelog/issue-6464.md
+++ b/changelog/issue-6464.md
@@ -1,0 +1,7 @@
+audience: worker-deployers
+level: minor
+reference: issue 6464
+---
+Generic Worker: adds memory usage monitoring during tasks and reports average and peak memory used, in addition to the system's total available memory.
+
+If the total percentage of memory used exceeds 90% for 5 consecutive measurements, the worker will abort the task to prevent OOM crashes and errors. If `disableOOMProtection` (default `false`) is set to `true` in the worker configuration, the worker will not abort the task.

--- a/changelog/issue-6464.md
+++ b/changelog/issue-6464.md
@@ -4,4 +4,6 @@ reference: issue 6464
 ---
 Generic Worker: adds memory usage monitoring during tasks and reports average and peak memory used, in addition to the system's total available memory.
 
-If the total percentage of memory used exceeds 90% for 5 consecutive measurements, the worker will abort the task to prevent OOM crashes and errors. If `disableOOMProtection` (default `false`) is set to `true` in the worker configuration, the worker will not abort the task.
+If the total percentage of memory used exceeds 90% for 5 consecutive measurements at 0.5s intervals, the worker will abort the task to prevent OOM crashes and errors. If `disableOOMProtection` (default `false`) is set to `true` in the worker configuration, the worker will continue to monitor and report on memory usage, but will not abort the task if memory consumption is high.
+
+Resource monitoring can be disabled with worker config `enableResourceMonitor` (default `true`) or per task via `payload.features.resourceMonitor` (default `true`).

--- a/generated/references.json
+++ b/generated/references.json
@@ -8970,6 +8970,12 @@
               "title": "Enable [livelog](https://github.com/taskcluster/taskcluster/tree/main/tools/livelog)",
               "type": "boolean"
             },
+            "resourceMonitor": {
+              "default": true,
+              "description": "The resource monitor features reports Peak System Memory Used,\nAverage System Memory Used and Total Available Memory in the\ntask log for each task command executed. It also will abort\nany task command that causes the available system memory to be\nreduced to less than or equal to 10% of the total system memory\nfor five consecutive measurements at 0.5s intervals. When this\nhappens, the task will be resolved as failed.\n\nSince: generic-worker 83.4.0",
+              "title": "Resource monitor",
+              "type": "boolean"
+            },
             "runAsAdministrator": {
               "description": "Runs commands with UAC elevation. Only set to true when UAC is\nenabled on the worker and Administrative privileges are required by\ntask commands. When UAC is disabled on the worker, task commands will\nalready run with full user privileges, and therefore a value of true\nwill result in a malformed-payload task exception.\n\nA value of true does not add the task user to the `Administrators`\ngroup - see the `osGroups` property for that. Typically\n`task.payload.osGroups` should include an Administrative group, such\nas `Administrators`, when setting to true.\n\nFor security, `runAsAdministrator` feature cannot be used in\nconjunction with `chainOfTrust` feature.\n\nRequires scope\n`generic-worker:run-as-administrator:<provisionerId>/<workerType>`.\n\nSince: generic-worker 10.11.0",
               "title": "Run commands with UAC process elevation",
@@ -9486,6 +9492,12 @@
                 "loopbackVideo": {
                   "description": "Video loopback device created using v4l2loopback.\nA video device will be available for the task. Its\nlocation will be passed to the task via environment\nvariable `TASKCLUSTER_VIDEO_DEVICE`. The\nlocation will be `/dev/video<N>` where `<N>` is\nan integer between 0 and 255. The value of `<N>`\nis not static, and therefore either the environment\nvariable should be used, or `/dev` should be\nscanned in order to determine the correct location.\nTasks should not assume a constant value.\n\nThis feature is only available on Linux. If a task\nis submitted with this feature enabled on a non-Linux,\nposix platform (FreeBSD, macOS), the task will resolve as\n`exception/malformed-payload`.\n\nSince: generic-worker 53.1.0",
                   "title": "Loopback Video device",
+                  "type": "boolean"
+                },
+                "resourceMonitor": {
+                  "default": true,
+                  "description": "The resource monitor features reports Peak System Memory Used,\nAverage System Memory Used and Total Available Memory in the\ntask log for each task command executed. It also will abort\nany task command that causes the available system memory to be\nreduced to less than or equal to 10% of the total system memory\nfor five consecutive measurements at 0.5s intervals. When this\nhappens, the task will be resolved as failed.\n\nSince: generic-worker 83.4.0",
+                  "title": "Resource monitor",
                   "type": "boolean"
                 },
                 "runTaskAsCurrentUser": {
@@ -10278,6 +10290,12 @@
                 "loopbackVideo": {
                   "description": "Video loopback device created using v4l2loopback.\nA video device will be available for the task. Its\nlocation will be passed to the task via environment\nvariable `TASKCLUSTER_VIDEO_DEVICE`. The\nlocation will be `/dev/video<N>` where `<N>` is\nan integer between 0 and 255. The value of `<N>`\nis not static, and therefore either the environment\nvariable should be used, or `/dev` should be\nscanned in order to determine the correct location.\nTasks should not assume a constant value.\n\nThis feature is only available on Linux. If a task\nis submitted with this feature enabled on a non-Linux,\nposix platform (FreeBSD, macOS), the task will resolve as\n`exception/malformed-payload`.\n\nSince: generic-worker 53.1.0",
                   "title": "Loopback Video device",
+                  "type": "boolean"
+                },
+                "resourceMonitor": {
+                  "default": true,
+                  "description": "The resource monitor features reports Peak System Memory Used,\nAverage System Memory Used and Total Available Memory in the\ntask log for each task command executed. It also will abort\nany task command that causes the available system memory to be\nreduced to less than or equal to 10% of the total system memory\nfor five consecutive measurements at 0.5s intervals. When this\nhappens, the task will be resolved as failed.\n\nSince: generic-worker 83.4.0",
+                  "title": "Resource monitor",
                   "type": "boolean"
                 },
                 "taskclusterProxy": {

--- a/go.mod
+++ b/go.mod
@@ -30,6 +30,7 @@ require (
 	github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8
 	github.com/pkg/errors v0.9.1
 	github.com/sergi/go-diff v1.3.1
+	github.com/shirou/gopsutil/v4 v4.25.2
 	github.com/sirupsen/logrus v1.9.3
 	github.com/spf13/cobra v1.9.1
 	github.com/spf13/pflag v1.0.6
@@ -57,23 +58,30 @@ require (
 	github.com/certifi/gocertifi v0.0.0-20210507211836-431795d63e8d // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/dsnet/compress v0.0.2-0.20210315054119-f66993602bf5 // indirect
+	github.com/ebitengine/purego v0.8.2 // indirect
 	github.com/elastic/go-windows v1.0.1 // indirect
+	github.com/go-ole/go-ole v1.2.6 // indirect
 	github.com/golang/snappy v0.0.4 // indirect
 	github.com/google/uuid v1.3.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/klauspost/compress v1.16.7 // indirect
 	github.com/klauspost/pgzip v1.2.6 // indirect
 	github.com/kr/text v0.2.0 // indirect
+	github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 // indirect
 	github.com/nwaples/rardecode v1.1.3 // indirect
 	github.com/pierrec/lz4/v4 v4.1.18 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c // indirect
 	github.com/prometheus/procfs v0.15.1 // indirect
 	github.com/rogpeppe/go-internal v1.12.0 // indirect
 	github.com/spf13/afero v1.9.5 // indirect
+	github.com/tklauser/go-sysconf v0.3.12 // indirect
+	github.com/tklauser/numcpus v0.6.1 // indirect
 	github.com/ulikunitz/xz v0.5.11 // indirect
 	github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb // indirect
 	github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 // indirect
 	github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8 // indirect
+	github.com/yusufpapurcu/wmi v1.2.4 // indirect
 	golang.org/x/mod v0.23.0 // indirect
 	golang.org/x/sync v0.11.0 // indirect
 	golang.org/x/text v0.22.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -74,6 +74,8 @@ github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815/go.mod h1:WwZ+bS3
 github.com/dsnet/compress v0.0.2-0.20210315054119-f66993602bf5 h1:iFaUwBSo5Svw6L7HYpRu/0lE3e0BaElwnNO1qkNQxBY=
 github.com/dsnet/compress v0.0.2-0.20210315054119-f66993602bf5/go.mod h1:qssHWj60/X5sZFNxpG4HBPDHVqxNm4DfnCKgrbZOT+s=
 github.com/dsnet/golib v0.0.0-20171103203638-1ea166775780/go.mod h1:Lj+Z9rebOhdfkVLjJ8T6VcRQv3SXugXy999NBtR9aFY=
+github.com/ebitengine/purego v0.8.2 h1:jPPGWs2sZ1UgOSgD2bClL0MJIqu58nOmIcBuXr62z1I=
+github.com/ebitengine/purego v0.8.2/go.mod h1:iIjxzd6CiRiOG0UyXP+V1+jWqUXVjPKLAI0mRfJZTmQ=
 github.com/elastic/go-sysinfo v1.15.1 h1:zBmTnFEXxIQ3iwcQuk7MzaUotmKRp3OabbbWM8TdzIQ=
 github.com/elastic/go-sysinfo v1.15.1/go.mod h1:jPSuTgXG+dhhh0GKIyI2Cso+w5lPJ5PvVqKlL8LV/Hk=
 github.com/elastic/go-windows v1.0.1 h1:AlYZOldA+UJ0/2nBuqWdo90GFCgG9xuyw9SYzGUtJm0=
@@ -91,6 +93,8 @@ github.com/getsentry/raven-go v0.2.0/go.mod h1:KungGk8q33+aIAZUIVWZDr2OfAEBsO49P
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20200222043503-6f7a984d4dc4/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
+github.com/go-ole/go-ole v1.2.6 h1:/Fpf6oFPoeFik9ty7siob0G6Ke8QvQEuVcuChpwXzpY=
+github.com/go-ole/go-ole v1.2.6/go.mod h1:pprOEPIfldk/42T2oK7lQ4v4JSDwmV0As9GaiUsvbm0=
 github.com/gofrs/flock v0.12.1 h1:MTLVXXHf8ekldpJk3AKicLij9MdwOWkZ+a/jHHZby9E=
 github.com/gofrs/flock v0.12.1/go.mod h1:9zxTsyu5xtJ9DK+1tFZyibEV7y3uwDxPPfbxeeHCoD0=
 github.com/golang-jwt/jwt/v4 v4.5.2 h1:YtQM7lnr8iZ+j5q71MGKkNw9Mn7AjHM68uc9g5fXeUI=
@@ -135,9 +139,10 @@ github.com/google/go-cmp v0.5.1/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
-github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
-github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
+github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
 github.com/google/martian v2.1.0+incompatible/go.mod h1:9I4somxYTbIHy5NJKHRl3wXiIaQGbYVAs8BPL6v8lEs=
 github.com/google/martian/v3 v3.0.0/go.mod h1:y5Zk1BBys9G+gd6Jrk0W3cC1+ELVxBWuIGO+w/tUAp0=
 github.com/google/martian/v3 v3.1.0/go.mod h1:y5Zk1BBys9G+gd6Jrk0W3cC1+ELVxBWuIGO+w/tUAp0=
@@ -193,6 +198,8 @@ github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
 github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
+github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 h1:6E+4a0GO5zZEnZ81pIr0yLvtUWk2if982qA3F3QD6H4=
+github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0/go.mod h1:zJYVVT2jmtg6P3p1VtQj7WsuWi/y4VnjVBn7F8KPB3I=
 github.com/mcuadros/go-defaults v1.2.0 h1:FODb8WSf0uGaY8elWJAkoLL0Ri6AlZ1bFlenk56oZtc=
 github.com/mcuadros/go-defaults v1.2.0/go.mod h1:WEZtHEVIGYVDqkKSWBdWKUVdRyKlMfulPaGDWIVeCWY=
 github.com/mholt/archiver/v3 v3.5.1 h1:rDjOBX9JSF5BvoJGvjqK479aL70qh9DIpZCl+k7Clwo=
@@ -223,6 +230,8 @@ github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINE
 github.com/pkg/sftp v1.13.1/go.mod h1:3HaPG6Dq1ILlpPZRO0HVMrsydcdLt6HRDccSgb87qRg=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c h1:ncq/mPwQF4JjgDlrVEn3C11VoGHZN7m8qihwgMEtzYw=
+github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c/go.mod h1:OmDBASR4679mdNQnz2pUhc2G8CO2JrUAVFDRBDP/hJE=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
 github.com/prometheus/procfs v0.15.1 h1:YagwOFzUgYfKKHX6Dr+sHT7km/hxC76UB0learggepc=
 github.com/prometheus/procfs v0.15.1/go.mod h1:fB45yRUv8NstnjriLhBQLuOUt+WW4BsoGhij/e3PBqk=
@@ -232,6 +241,8 @@ github.com/rogpeppe/go-internal v1.12.0/go.mod h1:E+RYuTGaKKdloAfM02xzb0FW3Paa99
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/sergi/go-diff v1.3.1 h1:xkr+Oxo4BOQKmkn/B9eMK0g5Kg/983T9DqqPHwYqD+8=
 github.com/sergi/go-diff v1.3.1/go.mod h1:aMJSSKb2lpPvRNec0+w3fl7LP9IOFzdc9Pa4NFbPK1I=
+github.com/shirou/gopsutil/v4 v4.25.2 h1:NMscG3l2CqtWFS86kj3vP7soOczqrQYIEhO/pMvvQkk=
+github.com/shirou/gopsutil/v4 v4.25.2/go.mod h1:34gBYJzyqCDT11b6bMHP0XCvWeU3J61XRT7a2EmCRTA=
 github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ=
 github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
 github.com/spf13/afero v1.9.5 h1:stMpOSZFs//0Lv29HduCmli3GUfpFoF3Y1Q/aXj/wVM=
@@ -263,6 +274,10 @@ github.com/taskcluster/taskcluster-lib-urls v13.0.1+incompatible h1:Q3kagxQiHw7Q
 github.com/taskcluster/taskcluster-lib-urls v13.0.1+incompatible/go.mod h1:ALqTgi15AmJGEGubRKM0ydlLAFatlQPrQrmal9YZpQs=
 github.com/tent/hawk-go v0.0.0-20161026210932-d341ea318957 h1:6Fre/uvwovW5YY4nfHZk66cAg9HjT9YdFSAJHUUgOyQ=
 github.com/tent/hawk-go v0.0.0-20161026210932-d341ea318957/go.mod h1:dch7ywQEefE1ibFqBG1erFibrdUIwovcwQjksYuHuP4=
+github.com/tklauser/go-sysconf v0.3.12 h1:0QaGUFOdQaIVdPgfITYzaTegZvdCjmYO52cSFAEVmqU=
+github.com/tklauser/go-sysconf v0.3.12/go.mod h1:Ho14jnntGE1fpdOqQEEaiKRpvIavV0hSfmBq8nJbHYI=
+github.com/tklauser/numcpus v0.6.1 h1:ng9scYS7az0Bk4OZLvrNXNSAO2Pxr1XXRAPyjhIx+Fk=
+github.com/tklauser/numcpus v0.6.1/go.mod h1:1XfjsgE2zo8GVw7POkMbHENHzVg3GzmoZ9fESEdAacY=
 github.com/ulikunitz/xz v0.5.8/go.mod h1:nbz6k7qbPmH4IRqmfOplQw/tblSgqTqBwxkY0oWt/14=
 github.com/ulikunitz/xz v0.5.9/go.mod h1:nbz6k7qbPmH4IRqmfOplQw/tblSgqTqBwxkY0oWt/14=
 github.com/ulikunitz/xz v0.5.11 h1:kpFauv27b6ynzBNT/Xy+1k+fK4WswhN/6PN5WhFAGw8=
@@ -280,6 +295,8 @@ github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9de
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
+github.com/yusufpapurcu/wmi v1.2.4 h1:zFUKzehAFReQwLys1b/iSMl+JQGSCSjtVqQn9bBrPo0=
+github.com/yusufpapurcu/wmi v1.2.4/go.mod h1:SBZ9tNy3G9/m5Oi98Zks0QjeHVDvuK0qfxQmPyzfmi0=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=
 go.opencensus.io v0.22.0/go.mod h1:+kGneAE2xo2IficOXnaByMWTGM9T73dGwxeWcUqIpI8=
 go.opencensus.io v0.22.2/go.mod h1:yxeiOL68Rb0Xd1ddK5vPZ/oVn4vY4Ynel7k9FzqtOIw=
@@ -395,6 +412,7 @@ golang.org/x/sys v0.0.0-20190606165138-5da285871e9c/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20190624142023-c5567b49c5d0/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190726091711-fc99dfbffb4e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190813064441-fde4db37ae7a/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20190916202348-b4ddaad3f8a3/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191001151750-bb3f8db39f24/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191204072324-ce4227a45e2e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191228213918-04cbcbbfeed8/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
@@ -415,6 +433,7 @@ golang.org/x/sys v0.0.0-20200905004654-be1d3432aa8f/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201201145000-ef89a241ccb3/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20201204225414-ed752295db88/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210104204734-6f8348627aad/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210119212857-b64e53b001e4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210225134936-a50acf3fe073/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
@@ -423,6 +442,8 @@ golang.org/x/sys v0.0.0-20210423185535-09eb48e85fd7/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210616045830-e2b7044e8c71/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.8.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.11.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.30.0 h1:QjkSwP/36a20jFYWkSue1YwXzLmsV5Gfq7Eiy72C1uc=
 golang.org/x/sys v0.30.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=

--- a/tools/d2g/d2gtest/testdata/testcases/task_def_test.yml
+++ b/tools/d2g/d2gtest/testdata/testcases/task_def_test.yml
@@ -77,6 +77,7 @@ testSuite:
         features:
           backingLog: true
           liveLog: true
+          resourceMonitor: true
         logs:
           backing: public/logs/live_backing.log
           live: public/logs/live.log
@@ -181,6 +182,7 @@ testSuite:
         features:
           backingLog: true
           liveLog: true
+          resourceMonitor: true
         logs:
           backing: public/logs/live_backing.log
           live: public/logs/live.log
@@ -288,6 +290,7 @@ testSuite:
         features:
           backingLog: true
           liveLog: true
+          resourceMonitor: true
         logs:
           backing: public/logs/live_backing.log
           live: public/logs/live.log

--- a/tools/d2g/genericworker/generated_types.go
+++ b/tools/d2g/genericworker/generated_types.go
@@ -431,6 +431,19 @@ type (
 		// Since: generic-worker 53.1.0
 		LoopbackVideo bool `json:"loopbackVideo,omitempty"`
 
+		// The resource monitor features reports Peak System Memory Used,
+		// Average System Memory Used and Total Available Memory in the
+		// task log for each task command executed. It also will abort
+		// any task command that causes the available system memory to be
+		// reduced to less than or equal to 10% of the total system memory
+		// for five consecutive measurements at 0.5s intervals. When this
+		// happens, the task will be resolved as failed.
+		//
+		// Since: generic-worker 83.4.0
+		//
+		// Default:    true
+		ResourceMonitor bool `json:"resourceMonitor" default:"true"`
+
 		// If `true`, task commands will be executed as the
 		// user currently running Generic Worker (typically
 		// `root` or `LocalSystem`), rather than as the
@@ -1171,6 +1184,12 @@ func JSONSchema() string {
             "loopbackVideo": {
               "description": "Video loopback device created using v4l2loopback.\nA video device will be available for the task. Its\nlocation will be passed to the task via environment\nvariable ` + "`" + `TASKCLUSTER_VIDEO_DEVICE` + "`" + `. The\nlocation will be ` + "`" + `/dev/video\u003cN\u003e` + "`" + ` where ` + "`" + `\u003cN\u003e` + "`" + ` is\nan integer between 0 and 255. The value of ` + "`" + `\u003cN\u003e` + "`" + `\nis not static, and therefore either the environment\nvariable should be used, or ` + "`" + `/dev` + "`" + ` should be\nscanned in order to determine the correct location.\nTasks should not assume a constant value.\n\nThis feature is only available on Linux. If a task\nis submitted with this feature enabled on a non-Linux,\nposix platform (FreeBSD, macOS), the task will resolve as\n` + "`" + `exception/malformed-payload` + "`" + `.\n\nSince: generic-worker 53.1.0",
               "title": "Loopback Video device",
+              "type": "boolean"
+            },
+            "resourceMonitor": {
+              "default": true,
+              "description": "The resource monitor features reports Peak System Memory Used,\nAverage System Memory Used and Total Available Memory in the\ntask log for each task command executed. It also will abort\nany task command that causes the available system memory to be\nreduced to less than or equal to 10% of the total system memory\nfor five consecutive measurements at 0.5s intervals. When this\nhappens, the task will be resolved as failed.\n\nSince: generic-worker 83.4.0",
+              "title": "Resource monitor",
               "type": "boolean"
             },
             "runTaskAsCurrentUser": {

--- a/workers/generic-worker/README.md
+++ b/workers/generic-worker/README.md
@@ -159,6 +159,8 @@ and reports back results to the queue.
                                             (such as formatting a hard drive) and then
                                             rebooting in the run-generic-worker.bat script.
                                             [default: false]
+          disableOOMProtection              If true, the worker will not abort tasks that use
+                                            >= 90% of the available memory. [default: false]
           downloadsDir                      The directory to cache downloaded files for
                                             populating preloaded caches and readonly mounts. The
                                             directory will be created if it does not exist. This

--- a/workers/generic-worker/README.md
+++ b/workers/generic-worker/README.md
@@ -159,8 +159,11 @@ and reports back results to the queue.
                                             (such as formatting a hard drive) and then
                                             rebooting in the run-generic-worker.bat script.
                                             [default: false]
-          disableOOMProtection              If true, the worker will not abort tasks that use
-                                            >= 90% of the available memory. [default: false]
+          disableOOMProtection              If true, the worker will continue to monitor system
+                                            memory usage, but will not abort tasks when the
+                                            system memory usage is at 90% or higher for five
+                                            consecutive measurements at 0.5s intervals.
+                                            [default: false]
           downloadsDir                      The directory to cache downloaded files for
                                             populating preloaded caches and readonly mounts. The
                                             directory will be created if it does not exist. This
@@ -194,6 +197,8 @@ and reports back results to the queue.
                                             payload. [default: true]
           enableOSGroups                    Enables the OS Groups feature to be used in the task
                                             payload. [default: true]
+          enableResourceMonitor             Enables the Resource Monitor feature to be used in
+                                            the task payload. [default: true]
           enableTaskclusterProxy            Enables the Taskcluster Proxy feature to be used in
                                             the task payload. [default: true]
           enableInteractive                 Enables the Interactive feature to be used in the

--- a/workers/generic-worker/generated_insecure_darwin.go
+++ b/workers/generic-worker/generated_insecure_darwin.go
@@ -419,6 +419,19 @@ type (
 		// Since: generic-worker 53.1.0
 		LoopbackVideo bool `json:"loopbackVideo,omitempty"`
 
+		// The resource monitor features reports Peak System Memory Used,
+		// Average System Memory Used and Total Available Memory in the
+		// task log for each task command executed. It also will abort
+		// any task command that causes the available system memory to be
+		// reduced to less than or equal to 10% of the total system memory
+		// for five consecutive measurements at 0.5s intervals. When this
+		// happens, the task will be resolved as failed.
+		//
+		// Since: generic-worker 83.4.0
+		//
+		// Default:    true
+		ResourceMonitor bool `json:"resourceMonitor" default:"true"`
+
 		// The taskcluster proxy provides an easy and safe way to make authenticated
 		// taskcluster requests within the scope(s) of a particular task. See
 		// [the github project](https://github.com/taskcluster/taskcluster/tree/main/tools/taskcluster-proxy) for more information.
@@ -1129,6 +1142,12 @@ func JSONSchema() string {
             "loopbackVideo": {
               "description": "Video loopback device created using v4l2loopback.\nA video device will be available for the task. Its\nlocation will be passed to the task via environment\nvariable ` + "`" + `TASKCLUSTER_VIDEO_DEVICE` + "`" + `. The\nlocation will be ` + "`" + `/dev/video\u003cN\u003e` + "`" + ` where ` + "`" + `\u003cN\u003e` + "`" + ` is\nan integer between 0 and 255. The value of ` + "`" + `\u003cN\u003e` + "`" + `\nis not static, and therefore either the environment\nvariable should be used, or ` + "`" + `/dev` + "`" + ` should be\nscanned in order to determine the correct location.\nTasks should not assume a constant value.\n\nThis feature is only available on Linux. If a task\nis submitted with this feature enabled on a non-Linux,\nposix platform (FreeBSD, macOS), the task will resolve as\n` + "`" + `exception/malformed-payload` + "`" + `.\n\nSince: generic-worker 53.1.0",
               "title": "Loopback Video device",
+              "type": "boolean"
+            },
+            "resourceMonitor": {
+              "default": true,
+              "description": "The resource monitor features reports Peak System Memory Used,\nAverage System Memory Used and Total Available Memory in the\ntask log for each task command executed. It also will abort\nany task command that causes the available system memory to be\nreduced to less than or equal to 10% of the total system memory\nfor five consecutive measurements at 0.5s intervals. When this\nhappens, the task will be resolved as failed.\n\nSince: generic-worker 83.4.0",
+              "title": "Resource monitor",
               "type": "boolean"
             },
             "taskclusterProxy": {

--- a/workers/generic-worker/generated_insecure_freebsd.go
+++ b/workers/generic-worker/generated_insecure_freebsd.go
@@ -419,6 +419,19 @@ type (
 		// Since: generic-worker 53.1.0
 		LoopbackVideo bool `json:"loopbackVideo,omitempty"`
 
+		// The resource monitor features reports Peak System Memory Used,
+		// Average System Memory Used and Total Available Memory in the
+		// task log for each task command executed. It also will abort
+		// any task command that causes the available system memory to be
+		// reduced to less than or equal to 10% of the total system memory
+		// for five consecutive measurements at 0.5s intervals. When this
+		// happens, the task will be resolved as failed.
+		//
+		// Since: generic-worker 83.4.0
+		//
+		// Default:    true
+		ResourceMonitor bool `json:"resourceMonitor" default:"true"`
+
 		// The taskcluster proxy provides an easy and safe way to make authenticated
 		// taskcluster requests within the scope(s) of a particular task. See
 		// [the github project](https://github.com/taskcluster/taskcluster/tree/main/tools/taskcluster-proxy) for more information.
@@ -1129,6 +1142,12 @@ func JSONSchema() string {
             "loopbackVideo": {
               "description": "Video loopback device created using v4l2loopback.\nA video device will be available for the task. Its\nlocation will be passed to the task via environment\nvariable ` + "`" + `TASKCLUSTER_VIDEO_DEVICE` + "`" + `. The\nlocation will be ` + "`" + `/dev/video\u003cN\u003e` + "`" + ` where ` + "`" + `\u003cN\u003e` + "`" + ` is\nan integer between 0 and 255. The value of ` + "`" + `\u003cN\u003e` + "`" + `\nis not static, and therefore either the environment\nvariable should be used, or ` + "`" + `/dev` + "`" + ` should be\nscanned in order to determine the correct location.\nTasks should not assume a constant value.\n\nThis feature is only available on Linux. If a task\nis submitted with this feature enabled on a non-Linux,\nposix platform (FreeBSD, macOS), the task will resolve as\n` + "`" + `exception/malformed-payload` + "`" + `.\n\nSince: generic-worker 53.1.0",
               "title": "Loopback Video device",
+              "type": "boolean"
+            },
+            "resourceMonitor": {
+              "default": true,
+              "description": "The resource monitor features reports Peak System Memory Used,\nAverage System Memory Used and Total Available Memory in the\ntask log for each task command executed. It also will abort\nany task command that causes the available system memory to be\nreduced to less than or equal to 10% of the total system memory\nfor five consecutive measurements at 0.5s intervals. When this\nhappens, the task will be resolved as failed.\n\nSince: generic-worker 83.4.0",
+              "title": "Resource monitor",
               "type": "boolean"
             },
             "taskclusterProxy": {

--- a/workers/generic-worker/generated_insecure_linux.go
+++ b/workers/generic-worker/generated_insecure_linux.go
@@ -419,6 +419,19 @@ type (
 		// Since: generic-worker 53.1.0
 		LoopbackVideo bool `json:"loopbackVideo,omitempty"`
 
+		// The resource monitor features reports Peak System Memory Used,
+		// Average System Memory Used and Total Available Memory in the
+		// task log for each task command executed. It also will abort
+		// any task command that causes the available system memory to be
+		// reduced to less than or equal to 10% of the total system memory
+		// for five consecutive measurements at 0.5s intervals. When this
+		// happens, the task will be resolved as failed.
+		//
+		// Since: generic-worker 83.4.0
+		//
+		// Default:    true
+		ResourceMonitor bool `json:"resourceMonitor" default:"true"`
+
 		// The taskcluster proxy provides an easy and safe way to make authenticated
 		// taskcluster requests within the scope(s) of a particular task. See
 		// [the github project](https://github.com/taskcluster/taskcluster/tree/main/tools/taskcluster-proxy) for more information.
@@ -1129,6 +1142,12 @@ func JSONSchema() string {
             "loopbackVideo": {
               "description": "Video loopback device created using v4l2loopback.\nA video device will be available for the task. Its\nlocation will be passed to the task via environment\nvariable ` + "`" + `TASKCLUSTER_VIDEO_DEVICE` + "`" + `. The\nlocation will be ` + "`" + `/dev/video\u003cN\u003e` + "`" + ` where ` + "`" + `\u003cN\u003e` + "`" + ` is\nan integer between 0 and 255. The value of ` + "`" + `\u003cN\u003e` + "`" + `\nis not static, and therefore either the environment\nvariable should be used, or ` + "`" + `/dev` + "`" + ` should be\nscanned in order to determine the correct location.\nTasks should not assume a constant value.\n\nThis feature is only available on Linux. If a task\nis submitted with this feature enabled on a non-Linux,\nposix platform (FreeBSD, macOS), the task will resolve as\n` + "`" + `exception/malformed-payload` + "`" + `.\n\nSince: generic-worker 53.1.0",
               "title": "Loopback Video device",
+              "type": "boolean"
+            },
+            "resourceMonitor": {
+              "default": true,
+              "description": "The resource monitor features reports Peak System Memory Used,\nAverage System Memory Used and Total Available Memory in the\ntask log for each task command executed. It also will abort\nany task command that causes the available system memory to be\nreduced to less than or equal to 10% of the total system memory\nfor five consecutive measurements at 0.5s intervals. When this\nhappens, the task will be resolved as failed.\n\nSince: generic-worker 83.4.0",
+              "title": "Resource monitor",
               "type": "boolean"
             },
             "taskclusterProxy": {

--- a/workers/generic-worker/generated_multiuser_darwin.go
+++ b/workers/generic-worker/generated_multiuser_darwin.go
@@ -433,6 +433,19 @@ type (
 		// Since: generic-worker 53.1.0
 		LoopbackVideo bool `json:"loopbackVideo,omitempty"`
 
+		// The resource monitor features reports Peak System Memory Used,
+		// Average System Memory Used and Total Available Memory in the
+		// task log for each task command executed. It also will abort
+		// any task command that causes the available system memory to be
+		// reduced to less than or equal to 10% of the total system memory
+		// for five consecutive measurements at 0.5s intervals. When this
+		// happens, the task will be resolved as failed.
+		//
+		// Since: generic-worker 83.4.0
+		//
+		// Default:    true
+		ResourceMonitor bool `json:"resourceMonitor" default:"true"`
+
 		// If `true`, task commands will be executed as the
 		// user currently running Generic Worker (typically
 		// `root` or `LocalSystem`), rather than as the
@@ -1173,6 +1186,12 @@ func JSONSchema() string {
             "loopbackVideo": {
               "description": "Video loopback device created using v4l2loopback.\nA video device will be available for the task. Its\nlocation will be passed to the task via environment\nvariable ` + "`" + `TASKCLUSTER_VIDEO_DEVICE` + "`" + `. The\nlocation will be ` + "`" + `/dev/video\u003cN\u003e` + "`" + ` where ` + "`" + `\u003cN\u003e` + "`" + ` is\nan integer between 0 and 255. The value of ` + "`" + `\u003cN\u003e` + "`" + `\nis not static, and therefore either the environment\nvariable should be used, or ` + "`" + `/dev` + "`" + ` should be\nscanned in order to determine the correct location.\nTasks should not assume a constant value.\n\nThis feature is only available on Linux. If a task\nis submitted with this feature enabled on a non-Linux,\nposix platform (FreeBSD, macOS), the task will resolve as\n` + "`" + `exception/malformed-payload` + "`" + `.\n\nSince: generic-worker 53.1.0",
               "title": "Loopback Video device",
+              "type": "boolean"
+            },
+            "resourceMonitor": {
+              "default": true,
+              "description": "The resource monitor features reports Peak System Memory Used,\nAverage System Memory Used and Total Available Memory in the\ntask log for each task command executed. It also will abort\nany task command that causes the available system memory to be\nreduced to less than or equal to 10% of the total system memory\nfor five consecutive measurements at 0.5s intervals. When this\nhappens, the task will be resolved as failed.\n\nSince: generic-worker 83.4.0",
+              "title": "Resource monitor",
               "type": "boolean"
             },
             "runTaskAsCurrentUser": {

--- a/workers/generic-worker/generated_multiuser_freebsd.go
+++ b/workers/generic-worker/generated_multiuser_freebsd.go
@@ -433,6 +433,19 @@ type (
 		// Since: generic-worker 53.1.0
 		LoopbackVideo bool `json:"loopbackVideo,omitempty"`
 
+		// The resource monitor features reports Peak System Memory Used,
+		// Average System Memory Used and Total Available Memory in the
+		// task log for each task command executed. It also will abort
+		// any task command that causes the available system memory to be
+		// reduced to less than or equal to 10% of the total system memory
+		// for five consecutive measurements at 0.5s intervals. When this
+		// happens, the task will be resolved as failed.
+		//
+		// Since: generic-worker 83.4.0
+		//
+		// Default:    true
+		ResourceMonitor bool `json:"resourceMonitor" default:"true"`
+
 		// If `true`, task commands will be executed as the
 		// user currently running Generic Worker (typically
 		// `root` or `LocalSystem`), rather than as the
@@ -1173,6 +1186,12 @@ func JSONSchema() string {
             "loopbackVideo": {
               "description": "Video loopback device created using v4l2loopback.\nA video device will be available for the task. Its\nlocation will be passed to the task via environment\nvariable ` + "`" + `TASKCLUSTER_VIDEO_DEVICE` + "`" + `. The\nlocation will be ` + "`" + `/dev/video\u003cN\u003e` + "`" + ` where ` + "`" + `\u003cN\u003e` + "`" + ` is\nan integer between 0 and 255. The value of ` + "`" + `\u003cN\u003e` + "`" + `\nis not static, and therefore either the environment\nvariable should be used, or ` + "`" + `/dev` + "`" + ` should be\nscanned in order to determine the correct location.\nTasks should not assume a constant value.\n\nThis feature is only available on Linux. If a task\nis submitted with this feature enabled on a non-Linux,\nposix platform (FreeBSD, macOS), the task will resolve as\n` + "`" + `exception/malformed-payload` + "`" + `.\n\nSince: generic-worker 53.1.0",
               "title": "Loopback Video device",
+              "type": "boolean"
+            },
+            "resourceMonitor": {
+              "default": true,
+              "description": "The resource monitor features reports Peak System Memory Used,\nAverage System Memory Used and Total Available Memory in the\ntask log for each task command executed. It also will abort\nany task command that causes the available system memory to be\nreduced to less than or equal to 10% of the total system memory\nfor five consecutive measurements at 0.5s intervals. When this\nhappens, the task will be resolved as failed.\n\nSince: generic-worker 83.4.0",
+              "title": "Resource monitor",
               "type": "boolean"
             },
             "runTaskAsCurrentUser": {

--- a/workers/generic-worker/generated_multiuser_linux.go
+++ b/workers/generic-worker/generated_multiuser_linux.go
@@ -433,6 +433,19 @@ type (
 		// Since: generic-worker 53.1.0
 		LoopbackVideo bool `json:"loopbackVideo,omitempty"`
 
+		// The resource monitor features reports Peak System Memory Used,
+		// Average System Memory Used and Total Available Memory in the
+		// task log for each task command executed. It also will abort
+		// any task command that causes the available system memory to be
+		// reduced to less than or equal to 10% of the total system memory
+		// for five consecutive measurements at 0.5s intervals. When this
+		// happens, the task will be resolved as failed.
+		//
+		// Since: generic-worker 83.4.0
+		//
+		// Default:    true
+		ResourceMonitor bool `json:"resourceMonitor" default:"true"`
+
 		// If `true`, task commands will be executed as the
 		// user currently running Generic Worker (typically
 		// `root` or `LocalSystem`), rather than as the
@@ -1173,6 +1186,12 @@ func JSONSchema() string {
             "loopbackVideo": {
               "description": "Video loopback device created using v4l2loopback.\nA video device will be available for the task. Its\nlocation will be passed to the task via environment\nvariable ` + "`" + `TASKCLUSTER_VIDEO_DEVICE` + "`" + `. The\nlocation will be ` + "`" + `/dev/video\u003cN\u003e` + "`" + ` where ` + "`" + `\u003cN\u003e` + "`" + ` is\nan integer between 0 and 255. The value of ` + "`" + `\u003cN\u003e` + "`" + `\nis not static, and therefore either the environment\nvariable should be used, or ` + "`" + `/dev` + "`" + ` should be\nscanned in order to determine the correct location.\nTasks should not assume a constant value.\n\nThis feature is only available on Linux. If a task\nis submitted with this feature enabled on a non-Linux,\nposix platform (FreeBSD, macOS), the task will resolve as\n` + "`" + `exception/malformed-payload` + "`" + `.\n\nSince: generic-worker 53.1.0",
               "title": "Loopback Video device",
+              "type": "boolean"
+            },
+            "resourceMonitor": {
+              "default": true,
+              "description": "The resource monitor features reports Peak System Memory Used,\nAverage System Memory Used and Total Available Memory in the\ntask log for each task command executed. It also will abort\nany task command that causes the available system memory to be\nreduced to less than or equal to 10% of the total system memory\nfor five consecutive measurements at 0.5s intervals. When this\nhappens, the task will be resolved as failed.\n\nSince: generic-worker 83.4.0",
+              "title": "Resource monitor",
               "type": "boolean"
             },
             "runTaskAsCurrentUser": {

--- a/workers/generic-worker/generated_multiuser_windows.go
+++ b/workers/generic-worker/generated_multiuser_windows.go
@@ -200,6 +200,19 @@ type (
 		// Default:    true
 		LiveLog bool `json:"liveLog" default:"true"`
 
+		// The resource monitor features reports Peak System Memory Used,
+		// Average System Memory Used and Total Available Memory in the
+		// task log for each task command executed. It also will abort
+		// any task command that causes the available system memory to be
+		// reduced to less than or equal to 10% of the total system memory
+		// for five consecutive measurements at 0.5s intervals. When this
+		// happens, the task will be resolved as failed.
+		//
+		// Since: generic-worker 83.4.0
+		//
+		// Default:    true
+		ResourceMonitor bool `json:"resourceMonitor" default:"true"`
+
 		// Runs commands with UAC elevation. Only set to true when UAC is
 		// enabled on the worker and Administrative privileges are required by
 		// task commands. When UAC is disabled on the worker, task commands will
@@ -897,6 +910,12 @@ func JSONSchema() string {
           "default": true,
           "description": "The live log feature streams the combined stderr and stdout to a task artifact\nso that the output is available while the task is running.\n\nSince: generic-worker 48.2.0",
           "title": "Enable [livelog](https://github.com/taskcluster/taskcluster/tree/main/tools/livelog)",
+          "type": "boolean"
+        },
+        "resourceMonitor": {
+          "default": true,
+          "description": "The resource monitor features reports Peak System Memory Used,\nAverage System Memory Used and Total Available Memory in the\ntask log for each task command executed. It also will abort\nany task command that causes the available system memory to be\nreduced to less than or equal to 10% of the total system memory\nfor five consecutive measurements at 0.5s intervals. When this\nhappens, the task will be resolved as failed.\n\nSince: generic-worker 83.4.0",
+          "title": "Resource monitor",
           "type": "boolean"
         },
         "runAsAdministrator": {

--- a/workers/generic-worker/gwconfig/config.go
+++ b/workers/generic-worker/gwconfig/config.go
@@ -42,6 +42,7 @@ type (
 		EnableLiveLog                  bool           `json:"enableLiveLog"`
 		EnableMounts                   bool           `json:"enableMounts"`
 		EnableOSGroups                 bool           `json:"enableOSGroups"`
+		EnableResourceMonitor          bool           `json:"enableResourceMonitor"`
 		EnableTaskclusterProxy         bool           `json:"enableTaskclusterProxy"`
 		IdleTimeoutSecs                uint           `json:"idleTimeoutSecs"`
 		InstanceID                     string         `json:"instanceId"`

--- a/workers/generic-worker/gwconfig/config.go
+++ b/workers/generic-worker/gwconfig/config.go
@@ -34,6 +34,7 @@ type (
 		ClientID                       string         `json:"clientId"`
 		CreateObjectArtifacts          bool           `json:"createObjectArtifacts"`
 		DeploymentID                   string         `json:"deploymentId"`
+		DisableOOMProtection           bool           `json:"disableOOMProtection"`
 		DisableReboots                 bool           `json:"disableReboots"`
 		DownloadsDir                   string         `json:"downloadsDir"`
 		Ed25519SigningKeyLocation      string         `json:"ed25519SigningKeyLocation"`

--- a/workers/generic-worker/helper_test.go
+++ b/workers/generic-worker/helper_test.go
@@ -371,6 +371,7 @@ func GWTest(t *testing.T) *Test {
 			EnableLiveLog:             true,
 			EnableMounts:              true,
 			EnableOSGroups:            true,
+			EnableResourceMonitor:     true,
 			EnableTaskclusterProxy:    true,
 			Ed25519SigningKeyLocation: filepath.Join(testdataDir, "ed25519_private_key"),
 			IdleTimeoutSecs:           60,

--- a/workers/generic-worker/process/insecure.go
+++ b/workers/generic-worker/process/insecure.go
@@ -3,8 +3,6 @@
 package process
 
 import (
-	"fmt"
-	"log"
 	"os/exec"
 	"syscall"
 
@@ -27,50 +25,6 @@ func (pd *PlatformData) ReleaseResources() error {
 	return nil
 }
 
-// Unlike on Windows, a system error is grounds for a task failure, rather than
-// a task exception, since it can be caused by e.g. a task trying to execute a
-// command that doesn't exist, or trying to execute a file that isn't
-// executable. Therefore a system error, or an exit error (process ran but
-// returned non-zero exit code) or a task abortion are all task failures.
-//
-// See https://bugzil.la/1479415
-func (r *Result) Failed() bool {
-	return r.SystemError != nil || r.ExitError != nil || r.Aborted
-}
-
-// Unlike on Windows, if there is a system error, we don't crash the worker,
-// since this can be caused by task that tries to execute a non-existing
-// command or a file that isn't executable. On Windows all commands are
-// wrapped in a command shell execution, where not being able to execute a
-// shell should cause the worker to panic.
-func (r *Result) CrashCause() error {
-	return nil
-}
-
-func (r *Result) FailureCause() error {
-	if r.Aborted {
-		return fmt.Errorf("task was aborted")
-	}
-	if r.ExitError != nil {
-		return r.ExitError
-	}
-	if r.SystemError != nil {
-		return r.SystemError
-	}
-	return nil
-}
-
-// Unlike on Windows, if there is a system error, we don't crash the worker,
-// since this can be caused by task that tries to execute a non-existing
-// command or a file that isn't executable. On Windows all commands are
-// wrapped in a command shell execution, where not being able to execute a
-// shell should cause the worker to panic.
-//
-// See https://bugzil.la/1479415
-func (r *Result) Crashed() bool {
-	return false
-}
-
 func newCommand(f func() *exec.Cmd, workingDirectory string, env []string) (*Command, error) {
 	cmd := f()
 	cmd.Env = env
@@ -78,8 +32,10 @@ func newCommand(f func() *exec.Cmd, workingDirectory string, env []string) (*Com
 	// See https://medium.com/@felixge/killing-a-child-process-and-all-of-its-children-in-go-54079af94773
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 	return &Command{
-		Cmd:   cmd,
-		abort: make(chan struct{}),
+		Cmd:                   cmd,
+		abort:                 make(chan struct{}),
+		usageChan:             make(chan *ResourceUsage, 1),
+		usageMeasurementsDone: make(chan struct{}),
 	}, nil
 }
 
@@ -95,22 +51,4 @@ func NewCommandContext(ctx context.Context, commandLine []string, workingDirecto
 		return exec.CommandContext(ctx, commandLine[0], commandLine[1:]...)
 	}
 	return newCommand(f, workingDirectory, env)
-}
-
-func (c *Command) SetEnv(envVar, value string) {
-	c.Env = append(c.Env, envVar+"="+value)
-}
-
-func (c *Command) Kill() (killOutput string, err error) {
-	c.mutex.Lock()
-	defer c.mutex.Unlock()
-	if c.Process == nil {
-		// If process hasn't been started yet, nothing to kill
-		return "", nil
-	}
-	close(c.abort)
-	log.Printf("Killing process tree with parent PID %v... (%p)", c.Process.Pid, c)
-	defer log.Printf("Process tree with parent PID %v killed.", c.Process.Pid)
-	// See https://medium.com/@felixge/killing-a-child-process-and-all-of-its-children-in-go-54079af94773
-	return "", syscall.Kill(-c.Process.Pid, syscall.SIGKILL)
 }

--- a/workers/generic-worker/process/insecure.go
+++ b/workers/generic-worker/process/insecure.go
@@ -32,10 +32,8 @@ func newCommand(f func() *exec.Cmd, workingDirectory string, env []string) (*Com
 	// See https://medium.com/@felixge/killing-a-child-process-and-all-of-its-children-in-go-54079af94773
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 	return &Command{
-		Cmd:                   cmd,
-		abort:                 make(chan struct{}),
-		usageChan:             make(chan *ResourceUsage, 1),
-		usageMeasurementsDone: make(chan struct{}),
+		Cmd:   cmd,
+		abort: make(chan struct{}),
 	}, nil
 }
 

--- a/workers/generic-worker/process/multiuser_posix.go
+++ b/workers/generic-worker/process/multiuser_posix.go
@@ -80,10 +80,8 @@ func newCommand(f func() *exec.Cmd, workingDirectory string, env []string, platf
 	// See https://medium.com/@felixge/killing-a-child-process-and-all-of-its-children-in-go-54079af94773
 	cmd.SysProcAttr.Setpgid = true
 	return &Command{
-		Cmd:                   cmd,
-		abort:                 make(chan struct{}),
-		usageChan:             make(chan *ResourceUsage, 1),
-		usageMeasurementsDone: make(chan struct{}),
+		Cmd:   cmd,
+		abort: make(chan struct{}),
 	}, nil
 }
 

--- a/workers/generic-worker/process/multiuser_posix.go
+++ b/workers/generic-worker/process/multiuser_posix.go
@@ -4,7 +4,6 @@ package process
 
 import (
 	"fmt"
-	"log"
 	"os"
 	"os/exec"
 	"os/user"
@@ -68,50 +67,6 @@ func (pd *PlatformData) ReleaseResources() error {
 	return nil
 }
 
-// Unlike on Windows, a system error is grounds for a task failure, rather than
-// a task exception, since it can be caused by e.g. a task trying to execute a
-// command that doesn't exist, or trying to execute a file that isn't
-// executable. Therefore a system error, or an exit error (process ran but
-// returned non-zero exit code) or a task abortion are all task failures.
-//
-// See https://bugzil.la/1479415
-func (r *Result) Failed() bool {
-	return r.SystemError != nil || r.ExitError != nil || r.Aborted
-}
-
-// Unlike on Windows, if there is a system error, we don't crash the worker,
-// since this can be caused by task that tries to execute a non-existing
-// command or a file that isn't executable. On Windows all commands are
-// wrapped in a command shell execution, where not being able to execute a
-// shell should cause the worker to panic.
-func (r *Result) CrashCause() error {
-	return nil
-}
-
-func (r *Result) FailureCause() error {
-	if r.Aborted {
-		return fmt.Errorf("task was aborted")
-	}
-	if r.ExitError != nil {
-		return r.ExitError
-	}
-	if r.SystemError != nil {
-		return r.SystemError
-	}
-	return nil
-}
-
-// Unlike on Windows, if there is a system error, we don't crash the worker,
-// since this can be caused by task that tries to execute a non-existing
-// command or a file that isn't executable. On Windows all commands are
-// wrapped in a command shell execution, where not being able to execute a
-// shell should cause the worker to panic.
-//
-// See https://bugzil.la/1479415
-func (r *Result) Crashed() bool {
-	return false
-}
-
 func newCommand(f func() *exec.Cmd, workingDirectory string, env []string, platformData *PlatformData) (*Command, error) {
 	cmd := f()
 	cmd.Env = env
@@ -125,8 +80,10 @@ func newCommand(f func() *exec.Cmd, workingDirectory string, env []string, platf
 	// See https://medium.com/@felixge/killing-a-child-process-and-all-of-its-children-in-go-54079af94773
 	cmd.SysProcAttr.Setpgid = true
 	return &Command{
-		Cmd:   cmd,
-		abort: make(chan struct{}),
+		Cmd:                   cmd,
+		abort:                 make(chan struct{}),
+		usageChan:             make(chan *ResourceUsage, 1),
+		usageMeasurementsDone: make(chan struct{}),
 	}, nil
 }
 
@@ -152,23 +109,4 @@ func NewCommandContext(ctx context.Context, commandLine []string, workingDirecto
 		return exec.CommandContext(ctx, commandLine[0], commandLine[1:]...)
 	}
 	return newCommand(f, workingDirectory, env, platformData)
-}
-
-func (c *Command) SetEnv(envVar, value string) {
-	c.Env = append(c.Env, envVar+"="+value)
-}
-
-func (c *Command) Kill() (killOutput string, err error) {
-	c.mutex.Lock()
-	defer c.mutex.Unlock()
-	// abort even if process hasn't started
-	close(c.abort)
-	if c.Process == nil {
-		// If process hasn't been started yet, nothing to kill
-		return "", nil
-	}
-	log.Printf("Killing process tree with parent PID %v... (%p)", c.Process.Pid, c)
-	defer log.Printf("Process tree with parent PID %v killed.", c.Process.Pid)
-	// See https://medium.com/@felixge/killing-a-child-process-and-all-of-its-children-in-go-54079af94773
-	return "", syscall.Kill(-c.Process.Pid, syscall.SIGKILL)
 }

--- a/workers/generic-worker/process/multiuser_windows.go
+++ b/workers/generic-worker/process/multiuser_windows.go
@@ -98,10 +98,8 @@ func newCommand(f func() *exec.Cmd, workingDirectory string, env []string, pd *P
 		}
 	}
 	return &Command{
-		Cmd:                   cmd,
-		abort:                 make(chan struct{}),
-		usageChan:             make(chan *ResourceUsage, 1),
-		usageMeasurementsDone: make(chan struct{}),
+		Cmd:   cmd,
+		abort: make(chan struct{}),
 	}, nil
 }
 

--- a/workers/generic-worker/process/posix.go
+++ b/workers/generic-worker/process/posix.go
@@ -1,0 +1,72 @@
+//go:build darwin || linux || freebsd
+
+package process
+
+import (
+	"fmt"
+	"log"
+	"syscall"
+)
+
+// Unlike on Windows, a system error is grounds for a task failure, rather than
+// a task exception, since it can be caused by e.g. a task trying to execute a
+// command that doesn't exist, or trying to execute a file that isn't
+// executable. Therefore a system error, or an exit error (process ran but
+// returned non-zero exit code) or a task abortion are all task failures.
+//
+// See https://bugzil.la/1479415
+func (r *Result) Failed() bool {
+	return r.SystemError != nil || r.ExitError != nil || r.Aborted
+}
+
+// Unlike on Windows, if there is a system error, we don't crash the worker,
+// since this can be caused by task that tries to execute a non-existing
+// command or a file that isn't executable. On Windows all commands are
+// wrapped in a command shell execution, where not being able to execute a
+// shell should cause the worker to panic.
+func (r *Result) CrashCause() error {
+	return nil
+}
+
+func (r *Result) FailureCause() error {
+	if r.Aborted {
+		return fmt.Errorf("task was aborted")
+	}
+	if r.ExitError != nil {
+		return r.ExitError
+	}
+	if r.SystemError != nil {
+		return r.SystemError
+	}
+	return nil
+}
+
+// Unlike on Windows, if there is a system error, we don't crash the worker,
+// since this can be caused by task that tries to execute a non-existing
+// command or a file that isn't executable. On Windows all commands are
+// wrapped in a command shell execution, where not being able to execute a
+// shell should cause the worker to panic.
+//
+// See https://bugzil.la/1479415
+func (r *Result) Crashed() bool {
+	return false
+}
+
+func (c *Command) SetEnv(envVar, value string) {
+	c.Env = append(c.Env, envVar+"="+value)
+}
+
+func (c *Command) Kill() (killOutput string, err error) {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+	// abort even if process hasn't started
+	close(c.abort)
+	if c.Process == nil {
+		// If process hasn't been started yet, nothing to kill
+		return "", nil
+	}
+	log.Printf("Killing process tree with parent PID %v... (%p)", c.Process.Pid, c)
+	defer log.Printf("Process tree with parent PID %v killed.", c.Process.Pid)
+	// See https://medium.com/@felixge/killing-a-child-process-and-all-of-its-children-in-go-54079af94773
+	return "", syscall.Kill(-c.Process.Pid, syscall.SIGKILL)
+}

--- a/workers/generic-worker/process/process.go
+++ b/workers/generic-worker/process/process.go
@@ -7,29 +7,42 @@ import (
 	"sync"
 	"syscall"
 	"time"
+
+	"github.com/shirou/gopsutil/v4/mem"
 )
 
 func (r *Result) Succeeded() bool {
 	return r.SystemError == nil && r.ExitError == nil && !r.Aborted
 }
 
-type Command struct {
-	mutex sync.RWMutex
-	*exec.Cmd
-	// abort channel is closed when Kill() is called so that Execute() can
-	// return even if cmd.Wait() is blocked. This is useful since cmd.Wait()
-	// sometimes does not return promptly.
-	abort chan struct{}
-}
+type (
+	Command struct {
+		mutex sync.RWMutex
+		*exec.Cmd
+		// abort channel is closed when Kill() is called so that Execute() can
+		// return even if cmd.Wait() is blocked. This is useful since cmd.Wait()
+		// sometimes does not return promptly.
+		abort                 chan struct{}
+		usageChan             chan *ResourceUsage
+		usageMeasurementsDone chan struct{}
+	}
 
-type Result struct {
-	SystemError error
-	ExitError   *exec.ExitError
-	Duration    time.Duration
-	Aborted     bool
-	KernelTime  time.Duration
-	UserTime    time.Duration
-}
+	Result struct {
+		SystemError error
+		ExitError   *exec.ExitError
+		Duration    time.Duration
+		Aborted     bool
+		KernelTime  time.Duration
+		UserTime    time.Duration
+		Usage       *ResourceUsage
+	}
+
+	ResourceUsage struct {
+		AverageMemoryUsed    float64
+		PeakMemoryUsed       uint64
+		TotalMemoryAvailable uint64
+	}
+)
 
 // ExitCode returns the exit code, or
 //
@@ -56,6 +69,9 @@ func (r *Result) ExitCode() int {
 func (c *Command) Execute() (r *Result) {
 	r = &Result{}
 	started := time.Now()
+
+	defer close(c.usageMeasurementsDone)
+
 	c.mutex.Lock()
 	err := c.Start()
 	c.mutex.Unlock()
@@ -63,12 +79,14 @@ func (c *Command) Execute() (r *Result) {
 		r.SystemError = err
 		return
 	}
+
 	exitErr := make(chan error)
 	// wait for command to complete in separate go routine, so we handle abortion in parallel to command termination
 	go func() {
 		err := c.Wait()
 		exitErr <- err
 	}()
+
 	select {
 	case err = <-exitErr:
 		r.UserTime = c.ProcessState.UserTime()
@@ -84,6 +102,7 @@ func (c *Command) Execute() (r *Result) {
 		r.SystemError = fmt.Errorf("process aborted")
 		r.Aborted = true
 	}
+
 	finished := time.Now()
 	// Round(0) forces wall time calculation instead of monotonic time in case machine slept etc
 	r.Duration = finished.Round(0).Sub(started)
@@ -96,21 +115,32 @@ func (c *Command) String() string {
 
 func (r *Result) String() string {
 	if r.Aborted {
-		return fmt.Sprintf("Command ABORTED after %v", r.Duration)
+		return fmt.Sprintf("Command ABORTED after %v: %v", r.Duration, r.SystemError)
 	}
 	if r.SystemError != nil {
 		return fmt.Sprintf("System error executing command: %v", r.SystemError)
 	}
+	var usageStr string
+	if r.Usage != nil && r.Usage.TotalMemoryAvailable > 0 {
+		usageStr = fmt.Sprintf(" Average Memory Used: %v\n"+
+			"    Peak Memory Used: %v\n"+
+			" Total System Memory: %v\n",
+			formatMemoryString(r.Usage.AverageMemoryUsed),
+			formatMemoryString(r.Usage.PeakMemoryUsed),
+			formatMemoryString(r.Usage.TotalMemoryAvailable),
+		)
+	}
 	return fmt.Sprintf(""+
-		"   Exit Code: %v\n"+
-		"   User Time: %v\n"+
-		" Kernel Time: %v\n"+
-		"   Wall Time: %v\n"+
-		"      Result: %v",
+		"           Exit Code: %v\n"+
+		"           User Time: %v\n"+
+		"         Kernel Time: %v\n"+
+		"           Wall Time: %v\n%v"+
+		"              Result: %v",
 		r.ExitCode(),
 		r.UserTime,
 		r.KernelTime,
 		r.Duration,
+		usageStr,
 		r.Verdict(),
 	)
 }
@@ -126,7 +156,86 @@ func (r *Result) Verdict() string {
 	}
 }
 
+// GatherUsage collects the resource usage data for the command execution.
+func (r *Result) GatherUsage(c *Command) {
+	r.Usage = <-c.usageChan
+}
+
 func (c *Command) DirectOutput(writer io.Writer) {
 	c.Stdout = writer
 	c.Stderr = writer
+}
+
+// formatMemoryString formats a memory size in bytes into a human-readable string.
+// It accepts a value of type float64 or uint64 representing the number of bytes.
+// The function returns a string with the value formatted to two decimal places
+// and appended with the appropriate unit: "B" for bytes, "MB" for megabytes, or "GB" for gigabytes.
+func formatMemoryString[T float64 | uint64](bytes T) string {
+	val := float64(bytes)
+	if val < 1024*1024 {
+		return fmt.Sprintf("%f B", val)
+	} else if val < 1024*1024*1024 {
+		mb := val / (1024 * 1024)
+		return fmt.Sprintf("%.2f MB", mb)
+	} else {
+		gb := val / (1024 * 1024 * 1024)
+		return fmt.Sprintf("%.2f GB", gb)
+	}
+}
+
+// MonitorResources monitors the system's memory usage at 500ms intervals while a command is executing.
+// It tracks peak memory used, total memory available, and calculates the average memory used.
+// If memory usage exceeds 90% for five consecutive measurements, it calls the provided abort function.
+// The abort function is called with a boolean indicating if a warning was previously issued.
+// If the abort function returns true (indicating the task will be aborted), the monitoring stops.
+// The function sends the collected ResourceUsage data through c.usageChan when monitoring stops.
+// The monitoring can also be stopped by sending a signal through c.usageMeasurementsDone.
+func (c *Command) MonitorResources(abort func(previouslyWarned bool) bool) {
+	var consecutiveHighMemoryUsage, numOfMeasurements, totalMemoryUsed uint64
+	previouslyWarned := false
+	usage := new(ResourceUsage)
+	ticker := time.NewTicker(500 * time.Millisecond)
+
+	defer func() {
+		ticker.Stop()
+		if numOfMeasurements > 0 {
+			usage.AverageMemoryUsed = float64(totalMemoryUsed) / float64(numOfMeasurements)
+		}
+		c.usageChan <- usage
+	}()
+
+	for {
+		select {
+		case <-ticker.C:
+			if vm, err := mem.VirtualMemory(); err == nil {
+				numOfMeasurements++
+
+				if vm.Used > usage.PeakMemoryUsed {
+					usage.PeakMemoryUsed = vm.Used
+				}
+				if usage.TotalMemoryAvailable == 0 {
+					usage.TotalMemoryAvailable = vm.Total
+				}
+				totalMemoryUsed += vm.Used
+
+				// if memory used is greater than 90%
+				// for 5 measurements consecutively, then
+				// kill the process
+				if vm.UsedPercent >= 90.0 {
+					consecutiveHighMemoryUsage++
+					if consecutiveHighMemoryUsage >= 5 {
+						if abort(previouslyWarned) {
+							return
+						} else {
+							previouslyWarned = true
+						}
+					}
+				} else {
+					consecutiveHighMemoryUsage = 0
+				}
+			}
+		case <-c.usageMeasurementsDone:
+			return
+		}
+	}
 }

--- a/workers/generic-worker/resource_monitor.go
+++ b/workers/generic-worker/resource_monitor.go
@@ -1,0 +1,76 @@
+package main
+
+import (
+	"errors"
+
+	"github.com/taskcluster/taskcluster/v83/internal/scopes"
+	"github.com/taskcluster/taskcluster/v83/workers/generic-worker/process"
+)
+
+type ResourceMonitorFeature struct {
+}
+
+func (feature *ResourceMonitorFeature) Name() string {
+	return "Resource Monitor"
+}
+
+func (feature *ResourceMonitorFeature) Initialise() error {
+	return nil
+}
+
+func (feature *ResourceMonitorFeature) IsEnabled() bool {
+	return config.EnableResourceMonitor
+}
+
+func (feature *ResourceMonitorFeature) IsRequested(task *TaskRun) bool {
+	return task.Payload.Features.ResourceMonitor
+}
+
+type ResourceMonitorTask struct {
+	task *TaskRun
+}
+
+func (feature *ResourceMonitorFeature) NewTaskFeature(task *TaskRun) TaskFeature {
+	return &ResourceMonitorTask{
+		task: task,
+	}
+}
+
+func (r *ResourceMonitorTask) ReservedArtifacts() []string {
+	return []string{}
+}
+
+func (r *ResourceMonitorTask) RequiredScopes() scopes.Required {
+	return scopes.Required{}
+}
+
+func (r *ResourceMonitorTask) Start() *CommandExecutionError {
+	for _, c := range r.task.Commands {
+		c.ResourceMonitor = process.MonitorResources(func(previouslyWarned bool) bool {
+			if config.DisableOOMProtection {
+				if !previouslyWarned {
+					r.task.Warn("Sustained memory usage above 90%!")
+					r.task.Warn("OOM protections are disabled, continuing task...")
+				}
+				return false
+			} else {
+				r.task.Warn("Sustained memory usage above 90%!")
+				r.task.Warn("Aborting task to prevent OOM issues...")
+			}
+			err := r.task.StatusManager.Abort(
+				&CommandExecutionError{
+					Cause:      errors.New("task aborted due to sustained memory usage above 90%"),
+					TaskStatus: failed,
+				},
+			)
+			if err != nil {
+				r.task.Warnf("Error when aborting task: %v", err)
+			}
+			return true
+		})
+	}
+	return nil
+}
+
+func (r *ResourceMonitorTask) Stop(err *ExecutionErrors) {
+}

--- a/workers/generic-worker/schemas/insecure_posix.yml
+++ b/workers/generic-worker/schemas/insecure_posix.yml
@@ -263,27 +263,41 @@ oneOf:
 
             Since: generic-worker 53.1.0
         loopbackAudio:
-            type: boolean
-            title: Loopback Audio device
-            description: |-
-              Audio loopback device created using snd-aloop.
-              An audio device will be available for the task. Its
-              location will be `/dev/snd`. Devices inside that directory
-              will take the form `/dev/snd/controlC<N>`,
-              `/dev/snd/pcmC<N>D0c`, `/dev/snd/pcmC<N>D0p`,
-              `/dev/snd/pcmC<N>D1c`, and `/dev/snd/pcmC<N>D1p`,
-              where <N> is an integer between 0 and 31, inclusive.
-              The Generic Worker config setting `loopbackAudioDeviceNumber`
-              may be used to change the device number in case the
-              default value (`16`) conflicts with another
-              audio device on the worker.
+          type: boolean
+          title: Loopback Audio device
+          description: |-
+            Audio loopback device created using snd-aloop.
+            An audio device will be available for the task. Its
+            location will be `/dev/snd`. Devices inside that directory
+            will take the form `/dev/snd/controlC<N>`,
+            `/dev/snd/pcmC<N>D0c`, `/dev/snd/pcmC<N>D0p`,
+            `/dev/snd/pcmC<N>D1c`, and `/dev/snd/pcmC<N>D1p`,
+            where <N> is an integer between 0 and 31, inclusive.
+            The Generic Worker config setting `loopbackAudioDeviceNumber`
+            may be used to change the device number in case the
+            default value (`16`) conflicts with another
+            audio device on the worker.
 
-              This feature is only available on Linux. If a task
-              is submitted with this feature enabled on a non-Linux,
-              posix platform (FreeBSD, macOS), the task will resolve as
-              `exception/malformed-payload`.
+            This feature is only available on Linux. If a task
+            is submitted with this feature enabled on a non-Linux,
+            posix platform (FreeBSD, macOS), the task will resolve as
+            `exception/malformed-payload`.
 
-              Since: generic-worker 54.5.0
+            Since: generic-worker 54.5.0
+        resourceMonitor:
+          type: boolean
+          title: Resource monitor
+          description: |-
+            The resource monitor features reports Peak System Memory Used,
+            Average System Memory Used and Total Available Memory in the
+            task log for each task command executed. It also will abort
+            any task command that causes the available system memory to be
+            reduced to less than or equal to 10% of the total system memory
+            for five consecutive measurements at 0.5s intervals. When this
+            happens, the task will be resolved as failed.
+
+            Since: generic-worker 83.4.0
+          default: true
     mounts:
       type: array
       description: |-

--- a/workers/generic-worker/schemas/multiuser_posix.yml
+++ b/workers/generic-worker/schemas/multiuser_posix.yml
@@ -328,6 +328,20 @@ oneOf:
             as `exception/malformed-payload`.
 
             Since: generic-worker 81.0.0
+        resourceMonitor:
+          type: boolean
+          title: Resource monitor
+          description: |-
+            The resource monitor features reports Peak System Memory Used,
+            Average System Memory Used and Total Available Memory in the
+            task log for each task command executed. It also will abort
+            any task command that causes the available system memory to be
+            reduced to less than or equal to 10% of the total system memory
+            for five consecutive measurements at 0.5s intervals. When this
+            happens, the task will be resolved as failed.
+
+            Since: generic-worker 83.4.0
+          default: true
     mounts:
       type: array
       description: |-

--- a/workers/generic-worker/schemas/multiuser_windows.yml
+++ b/workers/generic-worker/schemas/multiuser_windows.yml
@@ -270,21 +270,35 @@ properties:
           Since: generic-worker 48.2.0
         default: true
       runTaskAsCurrentUser:
-          type: boolean
-          title: Run task as current user
-          description: |-
-            If `true`, task commands will be executed as the
-            user currently running Generic Worker (typically
-            `root` or `LocalSystem`), rather than as the
-            dedicated task user created for the task. The task
-            user account will still be created, and is
-            available for the task to use.
+        type: boolean
+        title: Run task as current user
+        description: |-
+          If `true`, task commands will be executed as the
+          user currently running Generic Worker (typically
+          `root` or `LocalSystem`), rather than as the
+          dedicated task user created for the task. The task
+          user account will still be created, and is
+          available for the task to use.
 
-            Requires scope `generic-worker:run-task-as-current-user:<provisionerID>/<workerType>`.
-            Tasks submitted without this scope will be resolved
-            as `exception/malformed-payload`.
+          Requires scope `generic-worker:run-task-as-current-user:<provisionerID>/<workerType>`.
+          Tasks submitted without this scope will be resolved
+          as `exception/malformed-payload`.
 
-            Since: generic-worker 81.0.0
+          Since: generic-worker 81.0.0
+      resourceMonitor:
+        type: boolean
+        title: Resource monitor
+        description: |-
+          The resource monitor features reports Peak System Memory Used,
+          Average System Memory Used and Total Available Memory in the
+          task log for each task command executed. It also will abort
+          any task command that causes the available system memory to be
+          reduced to less than or equal to 10% of the total system memory
+          for five consecutive measurements at 0.5s intervals. When this
+          happens, the task will be resolved as failed.
+
+          Since: generic-worker 83.4.0
+        default: true
   mounts:
     type: array
     description: |-

--- a/workers/generic-worker/usage.go
+++ b/workers/generic-worker/usage.go
@@ -172,6 +172,8 @@ and reports back results to the queue.
                                             (such as formatting a hard drive) and then
                                             rebooting in the run-generic-worker.bat script.
                                             [default: false]
+          disableOOMProtection              If true, the worker will not abort tasks that use
+                                            >= 90% of the available memory. [default: false]
           downloadsDir                      The directory to cache downloaded files for
                                             populating preloaded caches and readonly mounts. The
                                             directory will be created if it does not exist. This

--- a/workers/generic-worker/usage.go
+++ b/workers/generic-worker/usage.go
@@ -172,8 +172,11 @@ and reports back results to the queue.
                                             (such as formatting a hard drive) and then
                                             rebooting in the run-generic-worker.bat script.
                                             [default: false]
-          disableOOMProtection              If true, the worker will not abort tasks that use
-                                            >= 90% of the available memory. [default: false]
+          disableOOMProtection              If true, the worker will continue to monitor system
+                                            memory usage, but will not abort tasks when the
+                                            system memory usage is at 90% or higher for five
+                                            consecutive measurements at 0.5s intervals.
+                                            [default: false]
           downloadsDir                      The directory to cache downloaded files for
                                             populating preloaded caches and readonly mounts. The
                                             directory will be created if it does not exist. This
@@ -187,6 +190,8 @@ and reports back results to the queue.
                                             payload. [default: true]
           enableOSGroups                    Enables the OS Groups feature to be used in the task
                                             payload. [default: true]
+          enableResourceMonitor             Enables the Resource Monitor feature to be used in
+                                            the task payload. [default: true]
           enableTaskclusterProxy            Enables the Taskcluster Proxy feature to be used in
                                             the task payload. [default: true]` + enableTaskFeatures() + headlessTasksUsage() + `
           idleTimeoutSecs                   How many seconds to wait without getting a new


### PR DESCRIPTION
Fixes https://github.com/taskcluster/taskcluster/issues/6464.
Fixes https://github.com/taskcluster/taskcluster/issues/6894.

>Generic Worker: adds memory usage monitoring during tasks and reports average and peak memory used, in addition to the system's total available memory.
>
>If the total percentage of memory used exceeds 90% for 5 consecutive measurements at 0.5s intervals, the worker will abort the task to prevent OOM crashes and errors. If `disableOOMProtection` (default `false`) is set to `true` in the worker configuration, the worker will continue to monitor and report on memory usage, but will not abort the task if memory consumption is high.
>
>Resource monitoring can be disabled with worker config `enableResourceMonitor` (default `true`) or per task via `payload.features.resourceMonitor` (default `true`).