### PR TITLE
Generic Worker: don't update /etc/subgid since podman support dropped

### DIFF
--- a/changelog/Qgfg20wZSni3PRa0gxb84A.md
+++ b/changelog/Qgfg20wZSni3PRa0gxb84A.md
@@ -1,0 +1,3 @@
+audience: general
+level: silent
+---

--- a/workers/generic-worker/d2g_test.go
+++ b/workers/generic-worker/d2g_test.go
@@ -808,7 +808,7 @@ func TestD2GTaskclusterProxy(t *testing.T) {
 			// sleep long enough to reclaim and get new credentials
 			fmt.Sprintf("sleep 12 && curl -v %s", artifactURL),
 		},
-		Image:      json.RawMessage(`"centos:latest"`),
+		Image:      json.RawMessage(`"denolehov/curl"`),
 		MaxRunTime: 60,
 		Features: dockerworker.FeatureFlags{
 			TaskclusterProxy: true,

--- a/workers/generic-worker/mounts.go
+++ b/workers/generic-worker/mounts.go
@@ -73,10 +73,6 @@ type Cache struct {
 	// Keeps a record of which task user mounts this cache. This is so that
 	// when the cache is mounted as a new task user, file ownership can be
 	// recursively changed from the previous task user to the new task user.
-	// Note, when tasks create containers which contain additional users
-	// (subuids), it is recommended that those subuids and subgids are mapped
-	// with explicit fixed ranges, so that when a future task mounts the cache,
-	// inside the container the same uids will be seen.
 	//
 	// Note, although uid is typically a uint32, we store as a string since
 	// that is how the standard library passes it to us, and we pass it to

--- a/workers/generic-worker/runtime/runtime_linux.go
+++ b/workers/generic-worker/runtime/runtime_linux.go
@@ -18,7 +18,6 @@ func (user *OSUser) CreateNew(okIfExists bool) (err error) {
 		/usr/sbin/useradd -m -d "${homedir}" "${username}"
 		/usr/bin/chfn -f "${username}"
 		echo "${username}:${password}" | /usr/sbin/chpasswd
-		/usr/bin/sed -i "s/^${username}:.*$/${username}:100000:65536/" /etc/subuid /etc/subgid
 	`
 
 	return host.Run("/usr/bin/env", "bash", "-c", createUserScript, user.Name, user.Password)


### PR DESCRIPTION
I think this is left over from podman days, and no longer needed.

@Eijebong can you confirm?

Thanks!
