### PR TITLE
Revert "fix(d2g): add `audio`/`video` os-groups and scopes"

### DIFF
--- a/changelog/bihkSU9hSAe8aBJ7aJMLLg.md
+++ b/changelog/bihkSU9hSAe8aBJ7aJMLLg.md
@@ -1,0 +1,4 @@
+audience: worker-deployers
+level: patch
+---
+Generic Worker: only warn about missing `audio`/`video` os groups for non-d2g tasks.

--- a/tools/d2g/d2g.go
+++ b/tools/d2g/d2g.go
@@ -145,29 +145,13 @@ func ConvertScopes(dwScopes []string, dwPayload *dockerworker.DockerWorkerPayloa
 				"generic-worker:os-group:"+s[len("docker-worker:capability:device:kvm:"):]+"/libvirt",
 			)
 		case s == "docker-worker:capability:device:loopbackVideo":
-			gwScopes = append(
-				gwScopes,
-				"generic-worker:loopback-video:*",
-				"generic-worker:os-group:"+taskQueueID+"/video",
-			)
+			gwScopes = append(gwScopes, "generic-worker:loopback-video:*")
 		case strings.HasPrefix(s, "docker-worker:capability:device:loopbackVideo:"):
-			gwScopes = append(
-				gwScopes,
-				"generic-worker:loopback-video:"+s[len("docker-worker:capability:device:loopbackVideo:"):],
-				"generic-worker:os-group:"+s[len("docker-worker:capability:device:loopbackVideo:"):]+"/video",
-			)
+			gwScopes = append(gwScopes, "generic-worker:loopback-video:"+s[len("docker-worker:capability:device:loopbackVideo:"):])
 		case s == "docker-worker:capability:device:loopbackAudio":
-			gwScopes = append(
-				gwScopes,
-				"generic-worker:loopback-audio:*",
-				"generic-worker:os-group:"+taskQueueID+"/audio",
-			)
+			gwScopes = append(gwScopes, "generic-worker:loopback-audio:*")
 		case strings.HasPrefix(s, "docker-worker:capability:device:loopbackAudio:"):
-			gwScopes = append(
-				gwScopes,
-				"generic-worker:loopback-audio:"+s[len("docker-worker:capability:device:loopbackAudio:"):],
-				"generic-worker:os-group:"+s[len("docker-worker:capability:device:loopbackAudio:"):]+"/audio",
-			)
+			gwScopes = append(gwScopes, "generic-worker:loopback-audio:"+s[len("docker-worker:capability:device:loopbackAudio:"):])
 		case strings.HasPrefix(s, "docker-worker:"):
 			gwScopes = append(gwScopes, "generic-worker:"+s[len("docker-worker:"):])
 		}
@@ -544,12 +528,6 @@ func setOSGroups(dwPayload *dockerworker.DockerWorkerPayload, gwPayload *generic
 		// task user needs to be in kvm and libvirt groups for KVM to work:
 		// https://help.ubuntu.com/community/KVM/Installation
 		gwPayload.OSGroups = append(gwPayload.OSGroups, "kvm", "libvirt")
-	}
-	if dwPayload.Capabilities.Devices.LoopbackAudio && config["allowLoopbackAudio"].(bool) {
-		gwPayload.OSGroups = append(gwPayload.OSGroups, "audio")
-	}
-	if dwPayload.Capabilities.Devices.LoopbackVideo && config["allowLoopbackVideo"].(bool) {
-		gwPayload.OSGroups = append(gwPayload.OSGroups, "video")
 	}
 	gwPayload.OSGroups = append(gwPayload.OSGroups, "docker")
 }

--- a/tools/d2g/d2gtest/d2g_test.go
+++ b/tools/d2g/d2gtest/d2g_test.go
@@ -61,12 +61,9 @@ func ExampleConvertScopes_mixture() {
 	//	"generic-worker:loopback-video:*"
 	//	"generic-worker:loopback-video:x/y/z"
 	//	"generic-worker:monkey"
-	//	"generic-worker:os-group:/video"
 	//	"generic-worker:os-group:proj-misc/tutorial/docker"
-	//	"generic-worker:os-group:proj-misc/tutorial/video"
 	//	"generic-worker:os-group:x/y/z/kvm"
 	//	"generic-worker:os-group:x/y/z/libvirt"
-	//	"generic-worker:os-group:x/y/z/video"
 	//	"generic-worker:teapot"
 }
 

--- a/tools/d2g/d2gtest/testdata/testcases/devices_tests.yml
+++ b/tools/d2g/d2gtest/testdata/testcases/devices_tests.yml
@@ -239,7 +239,6 @@ testSuite:
         - 125
         - 128
       osGroups:
-      - video
       - docker
     name: Video Loopback
   - d2gConfig:
@@ -335,7 +334,6 @@ testSuite:
         - 125
         - 128
       osGroups:
-      - audio
       - docker
     name: Audio Loopback
   - d2gConfig:

--- a/tools/d2g/d2gtest/testdata/testcases/fuzzing_tests.yml
+++ b/tools/d2g/d2gtest/testdata/testcases/fuzzing_tests.yml
@@ -82,6 +82,5 @@ testSuite:
         - 125
         - 128
       osGroups:
-      - audio
       - docker
     name: Bugmon Processor disableSeccomp test task

--- a/workers/generic-worker/d2g_test.go
+++ b/workers/generic-worker/d2g_test.go
@@ -331,9 +331,7 @@ func TestD2GLoopbackVideoDevice(t *testing.T) {
 		Command: []string{
 			"/bin/bash",
 			"-c",
-			`ls /dev && test -c ${TASKCLUSTER_VIDEO_DEVICE} \
-			-a -r ${TASKCLUSTER_VIDEO_DEVICE} \
-			|| { echo 'Device not found or not readable' ; exit 1; }`,
+			"ls /dev && test -c ${TASKCLUSTER_VIDEO_DEVICE} || { echo 'Device not found' ; exit 1; }",
 		},
 		Image:      json.RawMessage(imageBytes),
 		MaxRunTime: 30,
@@ -356,8 +354,8 @@ func TestD2GLoopbackVideoDevice(t *testing.T) {
 		_ = submitAndAssert(t, td, payload, "exception", "malformed-payload")
 		logtext := LogText(t)
 		t.Log(logtext)
-		if !strings.Contains(logtext, "task payload contains unsupported osGroups: [video docker]") {
-			t.Fatal("Was expecting log file to contain 'task payload contains unsupported osGroups: [video docker]'")
+		if !strings.Contains(logtext, "task payload contains unsupported osGroups: [docker]") {
+			t.Fatal("Was expecting log file to contain 'task payload contains unsupported osGroups: [docker]'")
 		}
 	default:
 		_ = submitAndAssert(t, td, payload, "exception", "malformed-payload")
@@ -401,8 +399,8 @@ func TestD2GLoopbackVideoDeviceWithWorkerPoolScopes(t *testing.T) {
 		_ = submitAndAssert(t, td, payload, "exception", "malformed-payload")
 		logtext := LogText(t)
 		t.Log(logtext)
-		if !strings.Contains(logtext, "task payload contains unsupported osGroups: [video docker]") {
-			t.Fatal("Was expecting log file to contain 'task payload contains unsupported osGroups: [video docker]'")
+		if !strings.Contains(logtext, "task payload contains unsupported osGroups: [docker]") {
+			t.Fatal("Was expecting log file to contain 'task payload contains unsupported osGroups: [docker]'")
 		}
 	default:
 		_ = submitAndAssert(t, td, payload, "exception", "malformed-payload")
@@ -452,8 +450,8 @@ func TestD2GLoopbackVideoDeviceNonRootUserInVideoGroup(t *testing.T) {
 		_ = submitAndAssert(t, td, payload, "exception", "malformed-payload")
 		logtext := LogText(t)
 		t.Log(logtext)
-		if !strings.Contains(logtext, "task payload contains unsupported osGroups: [video docker]") {
-			t.Fatal("Was expecting log file to contain 'task payload contains unsupported osGroups: [video docker]'")
+		if !strings.Contains(logtext, "task payload contains unsupported osGroups: [docker]") {
+			t.Fatal("Was expecting log file to contain 'task payload contains unsupported osGroups: [docker]'")
 		}
 	default:
 		_ = submitAndAssert(t, td, payload, "exception", "malformed-payload")
@@ -503,8 +501,8 @@ func TestD2GLoopbackVideoDeviceNonRootUserNotInVideoGroup(t *testing.T) {
 		_ = submitAndAssert(t, td, payload, "exception", "malformed-payload")
 		logtext := LogText(t)
 		t.Log(logtext)
-		if !strings.Contains(logtext, "task payload contains unsupported osGroups: [video docker]") {
-			t.Fatal("Was expecting log file to contain 'task payload contains unsupported osGroups: [video docker]'")
+		if !strings.Contains(logtext, "task payload contains unsupported osGroups: [docker]") {
+			t.Fatal("Was expecting log file to contain 'task payload contains unsupported osGroups: [docker]'")
 		}
 	default:
 		_ = submitAndAssert(t, td, payload, "exception", "malformed-payload")
@@ -528,10 +526,7 @@ func TestD2GLoopbackAudioDevice(t *testing.T) {
 			`ls /dev/snd && test -c /dev/snd/controlC16 \
 			-a -c /dev/snd/pcmC16D0c -a -c /dev/snd/pcmC16D0p \
 			-a -c /dev/snd/pcmC16D1c -a -c /dev/snd/pcmC16D1p \
-			-a -r /dev/snd/controlC16 \
-			-a -r /dev/snd/pcmC16D0c -a -r /dev/snd/pcmC16D0p \
-			-a -r /dev/snd/pcmC16D1c -a -r /dev/snd/pcmC16D1p \
-			|| { echo 'Device not found or not readable' ; exit 1; }`,
+			|| { echo 'Device not found' ; exit 1; }`,
 		},
 		Image:      json.RawMessage(imageBytes),
 		MaxRunTime: 30,
@@ -554,8 +549,8 @@ func TestD2GLoopbackAudioDevice(t *testing.T) {
 		_ = submitAndAssert(t, td, payload, "exception", "malformed-payload")
 		logtext := LogText(t)
 		t.Log(logtext)
-		if !strings.Contains(logtext, "task payload contains unsupported osGroups: [audio docker]") {
-			t.Fatal("Was expecting log file to contain 'task payload contains unsupported osGroups: [audio docker]'")
+		if !strings.Contains(logtext, "task payload contains unsupported osGroups: [docker]") {
+			t.Fatal("Was expecting log file to contain 'task payload contains unsupported osGroups: [docker]'")
 		}
 	default:
 		_ = submitAndAssert(t, td, payload, "exception", "malformed-payload")
@@ -602,8 +597,8 @@ func TestD2GLoopbackAudioDeviceWithWorkerPoolScopes(t *testing.T) {
 		_ = submitAndAssert(t, td, payload, "exception", "malformed-payload")
 		logtext := LogText(t)
 		t.Log(logtext)
-		if !strings.Contains(logtext, "task payload contains unsupported osGroups: [audio docker]") {
-			t.Fatal("Was expecting log file to contain 'task payload contains unsupported osGroups: [audio docker]'")
+		if !strings.Contains(logtext, "task payload contains unsupported osGroups: [docker]") {
+			t.Fatal("Was expecting log file to contain 'task payload contains unsupported osGroups: [docker]'")
 		}
 	default:
 		_ = submitAndAssert(t, td, payload, "exception", "malformed-payload")
@@ -655,8 +650,8 @@ func TestD2GLoopbackAudioDeviceNonRootUserInAudioGroup(t *testing.T) {
 		_ = submitAndAssert(t, td, payload, "exception", "malformed-payload")
 		logtext := LogText(t)
 		t.Log(logtext)
-		if !strings.Contains(logtext, "task payload contains unsupported osGroups: [audio docker]") {
-			t.Fatal("Was expecting log file to contain 'task payload contains unsupported osGroups: [audio docker]'")
+		if !strings.Contains(logtext, "task payload contains unsupported osGroups: [docker]") {
+			t.Fatal("Was expecting log file to contain 'task payload contains unsupported osGroups: [docker]'")
 		}
 	default:
 		_ = submitAndAssert(t, td, payload, "exception", "malformed-payload")
@@ -708,8 +703,8 @@ func TestD2GLoopbackAudioDeviceNonRootUserNotInAudioGroup(t *testing.T) {
 		_ = submitAndAssert(t, td, payload, "exception", "malformed-payload")
 		logtext := LogText(t)
 		t.Log(logtext)
-		if !strings.Contains(logtext, "task payload contains unsupported osGroups: [audio docker]") {
-			t.Fatal("Was expecting log file to contain 'task payload contains unsupported osGroups: [audio docker]'")
+		if !strings.Contains(logtext, "task payload contains unsupported osGroups: [docker]") {
+			t.Fatal("Was expecting log file to contain 'task payload contains unsupported osGroups: [docker]'")
 		}
 	default:
 		_ = submitAndAssert(t, td, payload, "exception", "malformed-payload")

--- a/workers/generic-worker/loopback_audio_linux.go
+++ b/workers/generic-worker/loopback_audio_linux.go
@@ -61,7 +61,7 @@ func (lat *LoopbackAudioTask) Start() *CommandExecutionError {
 		return executionError(internalError, errored, fmt.Errorf("loopback audio device number must be between 0 and 31, inclusive"))
 	}
 
-	if !slices.Contains(lat.task.Payload.OSGroups, "audio") {
+	if lat.task.D2GInfo == nil && !slices.Contains(lat.task.Payload.OSGroups, "audio") {
 		lat.task.Warn("The 'audio' group is not in the list of OS groups. Consider adding so that the loopback audio devices will work as expected.")
 	}
 

--- a/workers/generic-worker/loopback_video_linux.go
+++ b/workers/generic-worker/loopback_video_linux.go
@@ -51,7 +51,7 @@ func (lvt *LoopbackVideoTask) ReservedArtifacts() []string {
 }
 
 func (lvt *LoopbackVideoTask) Start() *CommandExecutionError {
-	if !slices.Contains(lvt.task.Payload.OSGroups, "video") {
+	if lvt.task.D2GInfo == nil && !slices.Contains(lvt.task.Payload.OSGroups, "video") {
 		lvt.task.Warn("The 'video' group is not in the list of OS groups. Consider adding so that the loopback video device will work as expected.")
 	}
 


### PR DESCRIPTION
Reverts taskcluster/taskcluster#7583

>Generic Worker: only warn about missing `audio`/`video` os groups for non-d2g tasks.

A great callout by @jcristau here https://github.com/taskcluster/taskcluster/pull/7583#issuecomment-2733983296