### PR TITLE
chore: enable CoT on CI tasks

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -177,6 +177,7 @@ tasks:
             "${trustDomain}-level-${level}-checkouts-sparse-v2": /builds/worker/checkouts
 
           features:
+            chainOfTrust: true
             taskclusterProxy: true
 
           # Note: This task is built server side without the context or tooling that

--- a/changelog/dJVjhHlYSl2A3CKKG9n83g.md
+++ b/changelog/dJVjhHlYSl2A3CKKG9n83g.md
@@ -1,0 +1,3 @@
+audience: general
+level: silent
+---

--- a/taskcluster/kinds/client/kind.yml
+++ b/taskcluster/kinds/client/kind.yml
@@ -14,6 +14,7 @@ task-defaults:
   worker:
     max-run-time: 600
     taskcluster-proxy: true
+    chain-of-trust: true
   scopes:
     - secrets:get:project/taskcluster/testing/client-libraries
 

--- a/taskcluster/kinds/db/kind.yml
+++ b/taskcluster/kinds/db/kind.yml
@@ -11,6 +11,7 @@ task-defaults:
     using: bare
   worker:
     docker-image: {in-tree: ci}
+    chain-of-trust: true
     max-run-time: 600
 
 tasks:

--- a/taskcluster/kinds/library/kind.yml
+++ b/taskcluster/kinds/library/kind.yml
@@ -19,6 +19,7 @@ task-defaults:
   worker:
     docker-image: {in-tree: ci}
     taskcluster-proxy: true
+    chain-of-trust: true
     artifacts:
       - name: public
         path: /builds/worker/checkouts/taskcluster/artifacts

--- a/taskcluster/kinds/lint/kind.yml
+++ b/taskcluster/kinds/lint/kind.yml
@@ -11,6 +11,7 @@ task-defaults:
     using: bare
   worker:
     max-run-time: 600
+    chain-of-trust: true
 
 tasks:
   nodejs:

--- a/taskcluster/kinds/meta/kind.yml
+++ b/taskcluster/kinds/meta/kind.yml
@@ -15,6 +15,7 @@ task-defaults:
     using: bare
   worker:
     docker-image: {in-tree: ci}
+    chain-of-trust: true
     caches:
       - name: taskcluster
         mount-point: /builds/worker/checkouts

--- a/taskcluster/kinds/service/kind.yml
+++ b/taskcluster/kinds/service/kind.yml
@@ -18,6 +18,7 @@ task-defaults:
   worker:
     docker-image: {in-tree: ci}
     taskcluster-proxy: true
+    chain-of-trust: true
     artifacts:
       - name: public
         path: /builds/worker/checkouts/taskcluster/artifacts

--- a/taskcluster/kinds/ui/kind.yml
+++ b/taskcluster/kinds/ui/kind.yml
@@ -12,6 +12,7 @@ task-defaults:
     using: bare
   worker:
     docker-image: {in-tree: browser-test}
+    chain-of-trust: true
     caches:
       - name: taskcluster
         mount-point: /builds/worker/checkouts


### PR DESCRIPTION
Mainly to test/use the `chain-of-trust-additional-data.json` d2g/gw feature.