### PR TITLE
feat(d2g): add volume mount artifact type

### DIFF
--- a/changelog/issue-7594.md
+++ b/changelog/issue-7594.md
@@ -1,0 +1,5 @@
+audience: users
+level: minor
+reference: issue 7594
+---
+Docker Worker (D2G): adds `volume` type for artifacts. This is strictly used for D2G purposes only. Use this type to have D2G volume mount your artifact path instead of `docker cp`'ing the artifact at the end of the task run. This can be useful under spot termination instances where the `docker cp` command doesn't get a chance to run, instead a volume mount will have the files on the host ready for upload as soon as the spot termination requests comes in.

--- a/generated/references.json
+++ b/generated/references.json
@@ -9617,7 +9617,7 @@
               "additionalProperties": {
                 "$ref": "#/definitions/artifact"
               },
-              "description": "Artifact upload map example: ```{\"public/build.tar.gz\": {\"path\": \"/home/worker/build.tar.gz\", \"expires\": \"2016-05-28T16:12:56.693817Z\", \"type\": \"file\"}}```",
+              "description": "Artifact upload map example: ```{\"public/build.tar.gz\": {\"path\": \"/home/worker/build.tar.gz\", \"expires\": \"2016-05-28T16:12:56.693817Z\", \"type\": \"file\"}}```\nArtifacts can be an individual `file`, a `directory` containing\npotentially multiple files with recursively included subdirectories,\nor a `volume` which will create a volume mount from the\nhost to the running container. Unlike `directory` artifacts, the\n`volume` directory will already exist as the task starts. Since the\nartifacts will be created directly on the host, they do not need to\nbe copied from the container to the host prior to being published,\nso perform more efficiently, and simplify the d2g-generated task payload.\nMoreover, in the case of time-critical spot terminations, tasks have\nmore chance of successfully publishing volume artifacts than directory\nartifacts, due to the efficiency gain.",
               "title": "Artifacts",
               "type": "object"
             },
@@ -10411,7 +10411,7 @@
               "additionalProperties": {
                 "$ref": "#/definitions/artifact"
               },
-              "description": "Artifact upload map example: ```{\"public/build.tar.gz\": {\"path\": \"/home/worker/build.tar.gz\", \"expires\": \"2016-05-28T16:12:56.693817Z\", \"type\": \"file\"}}```",
+              "description": "Artifact upload map example: ```{\"public/build.tar.gz\": {\"path\": \"/home/worker/build.tar.gz\", \"expires\": \"2016-05-28T16:12:56.693817Z\", \"type\": \"file\"}}```\nArtifacts can be an individual `file`, a `directory` containing\npotentially multiple files with recursively included subdirectories,\nor a `volume` which will create a volume mount from the\nhost to the running container. Unlike `directory` artifacts, the\n`volume` directory will already exist as the task starts. Since the\nartifacts will be created directly on the host, they do not need to\nbe copied from the container to the host prior to being published,\nso perform more efficiently, and simplify the d2g-generated task payload.\nMoreover, in the case of time-critical spot terminations, tasks have\nmore chance of successfully publishing volume artifacts than directory\nartifacts, due to the efficiency gain.",
               "title": "Artifacts",
               "type": "object"
             },
@@ -10735,7 +10735,7 @@
           "additionalProperties": {
             "$ref": "#/definitions/artifact"
           },
-          "description": "Artifact upload map example: ```{\"public/build.tar.gz\": {\"path\": \"/home/worker/build.tar.gz\", \"expires\": \"2016-05-28T16:12:56.693817Z\", \"type\": \"file\"}}```",
+          "description": "Artifact upload map example: ```{\"public/build.tar.gz\": {\"path\": \"/home/worker/build.tar.gz\", \"expires\": \"2016-05-28T16:12:56.693817Z\", \"type\": \"file\"}}```\nArtifacts can be an individual `file`, a `directory` containing\npotentially multiple files with recursively included subdirectories,\nor a `volume` (d2g only) which will create a volume mount from the\nhost to the running container. Unlike `directory` artifacts, the\n`volume` directory will already exist as the task starts. Since the\nartifacts will be created directly on the host, they do not need to\nbe copied from the container to the host prior to being published,\nso perform more efficiently, and simplify the d2g-generated task payload.\nMoreover, in the case of time-critical spot terminations, tasks have\nmore chance of successfully publishing volume artifacts than directory\nartifacts, due to the efficiency gain.",
           "title": "Artifacts",
           "type": "object"
         },

--- a/generated/references.json
+++ b/generated/references.json
@@ -9116,7 +9116,8 @@
             "type": {
               "enum": [
                 "file",
-                "directory"
+                "directory",
+                "volume"
               ],
               "title": "Artifact upload type.",
               "type": "string"
@@ -9919,7 +9920,8 @@
             "type": {
               "enum": [
                 "file",
-                "directory"
+                "directory",
+                "volume"
               ],
               "title": "Artifact upload type.",
               "type": "string"
@@ -10713,7 +10715,8 @@
             "type": {
               "enum": [
                 "file",
-                "directory"
+                "directory",
+                "volume"
               ],
               "title": "Artifact upload type.",
               "type": "string"

--- a/tools/d2g/d2gtest/testdata/testcases/artifacts_test.yml
+++ b/tools/d2g/d2gtest/testdata/testcases/artifacts_test.yml
@@ -67,3 +67,57 @@ testSuite:
       osGroups:
       - docker
     name: Artifacts test
+  - d2gConfig:
+      allowChainOfTrust: true
+      allowDisableSeccomp: true
+      allowGPUs: false
+      allowHostSharedMemory: true
+      allowInteractive: true
+      allowKVM: true
+      allowLoopbackAudio: true
+      allowLoopbackVideo: true
+      allowPrivileged: true
+      allowPtrace: true
+      allowTaskclusterProxy: true
+      gpus: all
+    description: Tests that volume artifacts will be created in the resulting generic
+      worker task payload.
+    dockerWorkerTaskPayload:
+      artifacts:
+        public/fred:
+          path: /home/worker/artifacts
+          type: volume
+      command:
+      - echo "Hello world"
+      image: ubuntu
+      maxRunTime: 3600
+    genericWorkerTaskPayload:
+      artifacts:
+      - expires: "0001-01-01T00:00:00.000Z"
+        name: public/fred
+        optional: true
+        path: volume0
+        type: directory
+      command:
+      - - bash
+        - -cx
+        - |-
+          docker pull ubuntu
+          timeout -s KILL 3600 docker run -t --name taskcontainer --memory-swap -1 --pids-limit -1 -v "$(pwd)/volume0:/home/worker/artifacts" -e RUN_ID -e TASKCLUSTER_INSTANCE_TYPE -e TASKCLUSTER_ROOT_URL -e TASKCLUSTER_WORKER_LOCATION -e TASK_GROUP_ID -e TASK_ID ubuntu 'echo "Hello world"'
+          exit_code=$?
+          docker rm -v taskcontainer
+          exit "${exit_code}"
+      features:
+        backingLog: true
+        liveLog: true
+      logs:
+        backing: public/logs/live_backing.log
+        live: public/logs/live.log
+      maxRunTime: 4500
+      onExitStatus:
+        retry:
+        - 125
+        - 128
+      osGroups:
+      - docker
+    name: Artifacts test

--- a/tools/d2g/d2gtest/testdata/testcases/artifacts_test.yml
+++ b/tools/d2g/d2gtest/testdata/testcases/artifacts_test.yml
@@ -103,10 +103,7 @@ testSuite:
         - -cx
         - |-
           docker pull ubuntu
-          timeout -s KILL 3600 docker run -t --name taskcontainer --memory-swap -1 --pids-limit -1 -v "$(pwd)/volume0:/home/worker/artifacts" -e RUN_ID -e TASKCLUSTER_INSTANCE_TYPE -e TASKCLUSTER_ROOT_URL -e TASKCLUSTER_WORKER_LOCATION -e TASK_GROUP_ID -e TASK_ID ubuntu 'echo "Hello world"'
-          exit_code=$?
-          docker rm -v taskcontainer
-          exit "${exit_code}"
+          timeout -s KILL 3600 docker run --rm -t --name taskcontainer --memory-swap -1 --pids-limit -1 -v "$(pwd)/volume0:/home/worker/artifacts" -e RUN_ID -e TASKCLUSTER_INSTANCE_TYPE -e TASKCLUSTER_ROOT_URL -e TASKCLUSTER_WORKER_LOCATION -e TASK_GROUP_ID -e TASK_ID ubuntu 'echo "Hello world"'
       features:
         backingLog: true
         liveLog: true

--- a/tools/d2g/d2gtest/testdata/testcases/chain_of_trust_test.yml
+++ b/tools/d2g/d2gtest/testdata/testcases/chain_of_trust_test.yml
@@ -38,10 +38,7 @@ testSuite:
         - |-
           docker pull 'my-little/pony:4.1'
           echo '{"environment":{"imageHash":"'"$(docker inspect --format='{{index .Id}}' 'my-little/pony:4.1')"'"}}' > chain-of-trust-additional-data.json
-          timeout -s KILL 3600 docker run -t --name taskcontainer --memory-swap -1 --pids-limit -1 -e ABC -e GHI -e RUN_ID -e TASKCLUSTER_INSTANCE_TYPE -e TASKCLUSTER_ROOT_URL -e TASKCLUSTER_WORKER_LOCATION -e TASK_GROUP_ID -e TASK_ID 'my-little/pony:4.1' foo bar
-          exit_code=$?
-          docker rm -v taskcontainer
-          exit "${exit_code}"
+          timeout -s KILL 3600 docker run --rm -t --name taskcontainer --memory-swap -1 --pids-limit -1 -e ABC -e GHI -e RUN_ID -e TASKCLUSTER_INSTANCE_TYPE -e TASKCLUSTER_ROOT_URL -e TASKCLUSTER_WORKER_LOCATION -e TASK_GROUP_ID -e TASK_ID 'my-little/pony:4.1' foo bar
       env:
         ABC: def
         GHI: jkl
@@ -96,10 +93,7 @@ testSuite:
         - |-
           IMAGE_ID=$(docker load --input dockerimage | sed -n '0,/^Loaded image: /s/^Loaded image: //p')
           echo '{"environment":{"imageHash":"'"$(docker inspect --format='{{index .Id}}' "${IMAGE_ID}")"'","imageArtifactHash":"sha256:'"$(sha256sum dockerimage | sed 's/ .*//')"'"}}' > chain-of-trust-additional-data.json
-          timeout -s KILL 3600 docker run -t --name taskcontainer --memory-swap -1 --pids-limit -1 -e ABC -e GHI -e RUN_ID -e TASKCLUSTER_INSTANCE_TYPE -e TASKCLUSTER_ROOT_URL -e TASKCLUSTER_WORKER_LOCATION -e TASK_GROUP_ID -e TASK_ID "${IMAGE_ID}" foo bar
-          exit_code=$?
-          docker rm -v taskcontainer
-          exit "${exit_code}"
+          timeout -s KILL 3600 docker run --rm -t --name taskcontainer --memory-swap -1 --pids-limit -1 -e ABC -e GHI -e RUN_ID -e TASKCLUSTER_INSTANCE_TYPE -e TASKCLUSTER_ROOT_URL -e TASKCLUSTER_WORKER_LOCATION -e TASK_GROUP_ID -e TASK_ID "${IMAGE_ID}" foo bar
       env:
         ABC: def
         GHI: jkl
@@ -160,10 +154,7 @@ testSuite:
         - |-
           IMAGE_ID=$(docker load --input dockerimage | sed -n '0,/^Loaded image: /s/^Loaded image: //p')
           echo '{"environment":{"imageHash":"'"$(docker inspect --format='{{index .Id}}' "${IMAGE_ID}")"'","imageArtifactHash":"sha256:'"$(sha256sum dockerimage | sed 's/ .*//')"'"}}' > chain-of-trust-additional-data.json
-          timeout -s KILL 3600 docker run -t --name taskcontainer --memory-swap -1 --pids-limit -1 -e ABC -e GHI -e RUN_ID -e TASKCLUSTER_INSTANCE_TYPE -e TASKCLUSTER_ROOT_URL -e TASKCLUSTER_WORKER_LOCATION -e TASK_GROUP_ID -e TASK_ID "${IMAGE_ID}" foo bar
-          exit_code=$?
-          docker rm -v taskcontainer
-          exit "${exit_code}"
+          timeout -s KILL 3600 docker run --rm -t --name taskcontainer --memory-swap -1 --pids-limit -1 -e ABC -e GHI -e RUN_ID -e TASKCLUSTER_INSTANCE_TYPE -e TASKCLUSTER_ROOT_URL -e TASKCLUSTER_WORKER_LOCATION -e TASK_GROUP_ID -e TASK_ID "${IMAGE_ID}" foo bar
       env:
         ABC: def
         GHI: jkl
@@ -220,10 +211,7 @@ testSuite:
         - |-
           docker pull 'my-little/pony:4.1'
           echo '{"environment":{"imageHash":"'"$(docker inspect --format='{{index .Id}}' 'my-little/pony:4.1')"'"}}' > chain-of-trust-additional-data.json
-          timeout -s KILL 3600 docker run -t --name taskcontainer --memory-swap -1 --pids-limit -1 -e ABC -e GHI -e RUN_ID -e TASKCLUSTER_INSTANCE_TYPE -e TASKCLUSTER_ROOT_URL -e TASKCLUSTER_WORKER_LOCATION -e TASK_GROUP_ID -e TASK_ID 'my-little/pony:4.1' foo bar
-          exit_code=$?
-          docker rm -v taskcontainer
-          exit "${exit_code}"
+          timeout -s KILL 3600 docker run --rm -t --name taskcontainer --memory-swap -1 --pids-limit -1 -e ABC -e GHI -e RUN_ID -e TASKCLUSTER_INSTANCE_TYPE -e TASKCLUSTER_ROOT_URL -e TASKCLUSTER_WORKER_LOCATION -e TASK_GROUP_ID -e TASK_ID 'my-little/pony:4.1' foo bar
       env:
         ABC: def
         GHI: jkl

--- a/tools/d2g/d2gtest/testdata/testcases/container_engine_test.yml
+++ b/tools/d2g/d2gtest/testdata/testcases/container_engine_test.yml
@@ -29,10 +29,7 @@ testSuite:
         - -cx
         - |-
           docker pull ubuntu
-          timeout -s KILL 3600 docker run -t --name taskcontainer --memory-swap -1 --pids-limit -1 -e RUN_ID -e TASKCLUSTER_INSTANCE_TYPE -e TASKCLUSTER_ROOT_URL -e TASKCLUSTER_WORKER_LOCATION -e TASK_GROUP_ID -e TASK_ID ubuntu 'echo "Hello world"'
-          exit_code=$?
-          docker rm -v taskcontainer
-          exit "${exit_code}"
+          timeout -s KILL 3600 docker run --rm -t --name taskcontainer --memory-swap -1 --pids-limit -1 -e RUN_ID -e TASKCLUSTER_INSTANCE_TYPE -e TASKCLUSTER_ROOT_URL -e TASKCLUSTER_WORKER_LOCATION -e TASK_GROUP_ID -e TASK_ID ubuntu 'echo "Hello world"'
       features:
         backingLog: true
         liveLog: true

--- a/tools/d2g/d2gtest/testdata/testcases/devices_tests.yml
+++ b/tools/d2g/d2gtest/testdata/testcases/devices_tests.yml
@@ -32,10 +32,7 @@ testSuite:
         - -cx
         - |-
           docker pull ubuntu
-          timeout -s KILL 3600 docker run -t --name taskcontainer --memory-swap -1 --pids-limit -1 -v /dev/shm:/dev/shm -e RUN_ID -e TASKCLUSTER_INSTANCE_TYPE -e TASKCLUSTER_ROOT_URL -e TASKCLUSTER_WORKER_LOCATION -e TASK_GROUP_ID -e TASK_ID ubuntu 'echo "Hello world"'
-          exit_code=$?
-          docker rm -v taskcontainer
-          exit "${exit_code}"
+          timeout -s KILL 3600 docker run --rm -t --name taskcontainer --memory-swap -1 --pids-limit -1 -v /dev/shm:/dev/shm -e RUN_ID -e TASKCLUSTER_INSTANCE_TYPE -e TASKCLUSTER_ROOT_URL -e TASKCLUSTER_WORKER_LOCATION -e TASK_GROUP_ID -e TASK_ID ubuntu 'echo "Hello world"'
       features:
         backingLog: true
         liveLog: true
@@ -79,10 +76,7 @@ testSuite:
         - -cx
         - |-
           docker pull ubuntu
-          timeout -s KILL 3600 docker run -t --name taskcontainer --memory-swap -1 --pids-limit -1 -e RUN_ID -e TASKCLUSTER_INSTANCE_TYPE -e TASKCLUSTER_ROOT_URL -e TASKCLUSTER_WORKER_LOCATION -e TASK_GROUP_ID -e TASK_ID ubuntu 'echo "Hello world"'
-          exit_code=$?
-          docker rm -v taskcontainer
-          exit "${exit_code}"
+          timeout -s KILL 3600 docker run --rm -t --name taskcontainer --memory-swap -1 --pids-limit -1 -e RUN_ID -e TASKCLUSTER_INSTANCE_TYPE -e TASKCLUSTER_ROOT_URL -e TASKCLUSTER_WORKER_LOCATION -e TASK_GROUP_ID -e TASK_ID ubuntu 'echo "Hello world"'
       features:
         backingLog: true
         liveLog: true
@@ -126,10 +120,7 @@ testSuite:
         - -cx
         - |-
           docker pull ubuntu
-          timeout -s KILL 3600 docker run -t --name taskcontainer --memory-swap -1 --pids-limit -1 --device=/dev/kvm -e RUN_ID -e TASKCLUSTER_INSTANCE_TYPE -e TASKCLUSTER_ROOT_URL -e TASKCLUSTER_WORKER_LOCATION -e TASK_GROUP_ID -e TASK_ID ubuntu 'echo "Hello world"'
-          exit_code=$?
-          docker rm -v taskcontainer
-          exit "${exit_code}"
+          timeout -s KILL 3600 docker run --rm -t --name taskcontainer --memory-swap -1 --pids-limit -1 --device=/dev/kvm -e RUN_ID -e TASKCLUSTER_INSTANCE_TYPE -e TASKCLUSTER_ROOT_URL -e TASKCLUSTER_WORKER_LOCATION -e TASK_GROUP_ID -e TASK_ID ubuntu 'echo "Hello world"'
       features:
         backingLog: true
         liveLog: true
@@ -175,10 +166,7 @@ testSuite:
         - -cx
         - |-
           docker pull ubuntu
-          timeout -s KILL 3600 docker run -t --name taskcontainer --memory-swap -1 --pids-limit -1 -e RUN_ID -e TASKCLUSTER_INSTANCE_TYPE -e TASKCLUSTER_ROOT_URL -e TASKCLUSTER_WORKER_LOCATION -e TASK_GROUP_ID -e TASK_ID ubuntu 'echo "Hello world"'
-          exit_code=$?
-          docker rm -v taskcontainer
-          exit "${exit_code}"
+          timeout -s KILL 3600 docker run --rm -t --name taskcontainer --memory-swap -1 --pids-limit -1 -e RUN_ID -e TASKCLUSTER_INSTANCE_TYPE -e TASKCLUSTER_ROOT_URL -e TASKCLUSTER_WORKER_LOCATION -e TASK_GROUP_ID -e TASK_ID ubuntu 'echo "Hello world"'
       features:
         backingLog: true
         liveLog: true
@@ -222,10 +210,7 @@ testSuite:
         - -cx
         - |-
           docker pull ubuntu
-          timeout -s KILL 3600 docker run -t --name taskcontainer --memory-swap -1 --pids-limit -1 --device="${TASKCLUSTER_VIDEO_DEVICE}" -e RUN_ID -e TASKCLUSTER_INSTANCE_TYPE -e TASKCLUSTER_ROOT_URL -e TASKCLUSTER_VIDEO_DEVICE -e TASKCLUSTER_WORKER_LOCATION -e TASK_GROUP_ID -e TASK_ID ubuntu 'echo "Hello world"'
-          exit_code=$?
-          docker rm -v taskcontainer
-          exit "${exit_code}"
+          timeout -s KILL 3600 docker run --rm -t --name taskcontainer --memory-swap -1 --pids-limit -1 --device="${TASKCLUSTER_VIDEO_DEVICE}" -e RUN_ID -e TASKCLUSTER_INSTANCE_TYPE -e TASKCLUSTER_ROOT_URL -e TASKCLUSTER_VIDEO_DEVICE -e TASKCLUSTER_WORKER_LOCATION -e TASK_GROUP_ID -e TASK_ID ubuntu 'echo "Hello world"'
       features:
         backingLog: true
         liveLog: true
@@ -270,10 +255,7 @@ testSuite:
         - -cx
         - |-
           docker pull ubuntu
-          timeout -s KILL 3600 docker run -t --name taskcontainer --memory-swap -1 --pids-limit -1 -e RUN_ID -e TASKCLUSTER_INSTANCE_TYPE -e TASKCLUSTER_ROOT_URL -e TASKCLUSTER_WORKER_LOCATION -e TASK_GROUP_ID -e TASK_ID ubuntu 'echo "Hello world"'
-          exit_code=$?
-          docker rm -v taskcontainer
-          exit "${exit_code}"
+          timeout -s KILL 3600 docker run --rm -t --name taskcontainer --memory-swap -1 --pids-limit -1 -e RUN_ID -e TASKCLUSTER_INSTANCE_TYPE -e TASKCLUSTER_ROOT_URL -e TASKCLUSTER_WORKER_LOCATION -e TASK_GROUP_ID -e TASK_ID ubuntu 'echo "Hello world"'
       features:
         backingLog: true
         liveLog: true
@@ -317,10 +299,7 @@ testSuite:
         - -cx
         - |-
           docker pull ubuntu
-          timeout -s KILL 3600 docker run -t --name taskcontainer --memory-swap -1 --pids-limit -1 --device=/dev/snd -e RUN_ID -e TASKCLUSTER_INSTANCE_TYPE -e TASKCLUSTER_ROOT_URL -e TASKCLUSTER_WORKER_LOCATION -e TASK_GROUP_ID -e TASK_ID ubuntu 'echo "Hello world"'
-          exit_code=$?
-          docker rm -v taskcontainer
-          exit "${exit_code}"
+          timeout -s KILL 3600 docker run --rm -t --name taskcontainer --memory-swap -1 --pids-limit -1 --device=/dev/snd -e RUN_ID -e TASKCLUSTER_INSTANCE_TYPE -e TASKCLUSTER_ROOT_URL -e TASKCLUSTER_WORKER_LOCATION -e TASK_GROUP_ID -e TASK_ID ubuntu 'echo "Hello world"'
       features:
         backingLog: true
         liveLog: true
@@ -365,10 +344,7 @@ testSuite:
         - -cx
         - |-
           docker pull ubuntu
-          timeout -s KILL 3600 docker run -t --name taskcontainer --memory-swap -1 --pids-limit -1 -e RUN_ID -e TASKCLUSTER_INSTANCE_TYPE -e TASKCLUSTER_ROOT_URL -e TASKCLUSTER_WORKER_LOCATION -e TASK_GROUP_ID -e TASK_ID ubuntu 'echo "Hello world"'
-          exit_code=$?
-          docker rm -v taskcontainer
-          exit "${exit_code}"
+          timeout -s KILL 3600 docker run --rm -t --name taskcontainer --memory-swap -1 --pids-limit -1 -e RUN_ID -e TASKCLUSTER_INSTANCE_TYPE -e TASKCLUSTER_ROOT_URL -e TASKCLUSTER_WORKER_LOCATION -e TASK_GROUP_ID -e TASK_ID ubuntu 'echo "Hello world"'
       features:
         backingLog: true
         liveLog: true
@@ -409,10 +385,7 @@ testSuite:
         - -cx
         - |-
           docker pull ubuntu
-          timeout -s KILL 3600 docker run -t --name taskcontainer --memory-swap -1 --pids-limit -1 --gpus all -e RUN_ID -e TASKCLUSTER_INSTANCE_TYPE -e TASKCLUSTER_ROOT_URL -e TASKCLUSTER_WORKER_LOCATION -e TASK_GROUP_ID -e TASK_ID ubuntu 'echo "Hello world"'
-          exit_code=$?
-          docker rm -v taskcontainer
-          exit "${exit_code}"
+          timeout -s KILL 3600 docker run --rm -t --name taskcontainer --memory-swap -1 --pids-limit -1 --gpus all -e RUN_ID -e TASKCLUSTER_INSTANCE_TYPE -e TASKCLUSTER_ROOT_URL -e TASKCLUSTER_WORKER_LOCATION -e TASK_GROUP_ID -e TASK_ID ubuntu 'echo "Hello world"'
       features:
         backingLog: true
         liveLog: true
@@ -453,10 +426,7 @@ testSuite:
         - -cx
         - |-
           docker pull ubuntu
-          timeout -s KILL 3600 docker run -t --name taskcontainer --memory-swap -1 --pids-limit -1 --gpus device=GPU-3a23c669-1f69-c64e-cf85-44e9b07e7a2a -e RUN_ID -e TASKCLUSTER_INSTANCE_TYPE -e TASKCLUSTER_ROOT_URL -e TASKCLUSTER_WORKER_LOCATION -e TASK_GROUP_ID -e TASK_ID ubuntu 'echo "Hello world"'
-          exit_code=$?
-          docker rm -v taskcontainer
-          exit "${exit_code}"
+          timeout -s KILL 3600 docker run --rm -t --name taskcontainer --memory-swap -1 --pids-limit -1 --gpus device=GPU-3a23c669-1f69-c64e-cf85-44e9b07e7a2a -e RUN_ID -e TASKCLUSTER_INSTANCE_TYPE -e TASKCLUSTER_ROOT_URL -e TASKCLUSTER_WORKER_LOCATION -e TASK_GROUP_ID -e TASK_ID ubuntu 'echo "Hello world"'
       features:
         backingLog: true
         liveLog: true

--- a/tools/d2g/d2gtest/testdata/testcases/docker_image_tests.yml
+++ b/tools/d2g/d2gtest/testdata/testcases/docker_image_tests.yml
@@ -27,10 +27,7 @@ testSuite:
         - -cx
         - |-
           docker pull ubuntu
-          timeout -s KILL 3600 docker run -t --name taskcontainer --memory-swap -1 --pids-limit -1 -e RUN_ID -e TASKCLUSTER_INSTANCE_TYPE -e TASKCLUSTER_ROOT_URL -e TASKCLUSTER_WORKER_LOCATION -e TASK_GROUP_ID -e TASK_ID ubuntu 'echo "Hello world"'
-          exit_code=$?
-          docker rm -v taskcontainer
-          exit "${exit_code}"
+          timeout -s KILL 3600 docker run --rm -t --name taskcontainer --memory-swap -1 --pids-limit -1 -e RUN_ID -e TASKCLUSTER_INSTANCE_TYPE -e TASKCLUSTER_ROOT_URL -e TASKCLUSTER_WORKER_LOCATION -e TASK_GROUP_ID -e TASK_ID ubuntu 'echo "Hello world"'
       features:
         backingLog: true
         liveLog: true
@@ -72,10 +69,7 @@ testSuite:
         - -cx
         - |-
           docker pull ubuntu
-          timeout -s KILL 3600 docker run -t --name taskcontainer --memory-swap -1 --pids-limit -1 -e RUN_ID -e TASKCLUSTER_INSTANCE_TYPE -e TASKCLUSTER_ROOT_URL -e TASKCLUSTER_WORKER_LOCATION -e TASK_GROUP_ID -e TASK_ID ubuntu 'echo "Hello world"'
-          exit_code=$?
-          docker rm -v taskcontainer
-          exit "${exit_code}"
+          timeout -s KILL 3600 docker run --rm -t --name taskcontainer --memory-swap -1 --pids-limit -1 -e RUN_ID -e TASKCLUSTER_INSTANCE_TYPE -e TASKCLUSTER_ROOT_URL -e TASKCLUSTER_WORKER_LOCATION -e TASK_GROUP_ID -e TASK_ID ubuntu 'echo "Hello world"'
       features:
         backingLog: true
         liveLog: true
@@ -118,10 +112,7 @@ testSuite:
         - -cx
         - |-
           IMAGE_ID=$(docker load --input dockerimage | sed -n '0,/^Loaded image: /s/^Loaded image: //p')
-          timeout -s KILL 3600 docker run -t --name taskcontainer --memory-swap -1 --pids-limit -1 -e RUN_ID -e TASKCLUSTER_INSTANCE_TYPE -e TASKCLUSTER_ROOT_URL -e TASKCLUSTER_WORKER_LOCATION -e TASK_GROUP_ID -e TASK_ID "${IMAGE_ID}" 'echo "Hello world"'
-          exit_code=$?
-          docker rm -v taskcontainer
-          exit "${exit_code}"
+          timeout -s KILL 3600 docker run --rm -t --name taskcontainer --memory-swap -1 --pids-limit -1 -e RUN_ID -e TASKCLUSTER_INSTANCE_TYPE -e TASKCLUSTER_ROOT_URL -e TASKCLUSTER_WORKER_LOCATION -e TASK_GROUP_ID -e TASK_ID "${IMAGE_ID}" 'echo "Hello world"'
       features:
         backingLog: true
         liveLog: true
@@ -170,10 +161,7 @@ testSuite:
         - -cx
         - |-
           IMAGE_ID=$(docker load --input dockerimage | sed -n '0,/^Loaded image: /s/^Loaded image: //p')
-          timeout -s KILL 3600 docker run -t --name taskcontainer --memory-swap -1 --pids-limit -1 -e RUN_ID -e TASKCLUSTER_INSTANCE_TYPE -e TASKCLUSTER_ROOT_URL -e TASKCLUSTER_WORKER_LOCATION -e TASK_GROUP_ID -e TASK_ID "${IMAGE_ID}" 'echo "Hello world"'
-          exit_code=$?
-          docker rm -v taskcontainer
-          exit "${exit_code}"
+          timeout -s KILL 3600 docker run --rm -t --name taskcontainer --memory-swap -1 --pids-limit -1 -e RUN_ID -e TASKCLUSTER_INSTANCE_TYPE -e TASKCLUSTER_ROOT_URL -e TASKCLUSTER_WORKER_LOCATION -e TASK_GROUP_ID -e TASK_ID "${IMAGE_ID}" 'echo "Hello world"'
       features:
         backingLog: true
         liveLog: true
@@ -223,10 +211,7 @@ testSuite:
         - -cx
         - |-
           IMAGE_ID=$(docker load --input dockerimage | sed -n '0,/^Loaded image: /s/^Loaded image: //p')
-          timeout -s KILL 3600 docker run -t --name taskcontainer --memory-swap -1 --pids-limit -1 -e RUN_ID -e TASKCLUSTER_INSTANCE_TYPE -e TASKCLUSTER_ROOT_URL -e TASKCLUSTER_WORKER_LOCATION -e TASK_GROUP_ID -e TASK_ID "${IMAGE_ID}" 'echo "Hello world"'
-          exit_code=$?
-          docker rm -v taskcontainer
-          exit "${exit_code}"
+          timeout -s KILL 3600 docker run --rm -t --name taskcontainer --memory-swap -1 --pids-limit -1 -e RUN_ID -e TASKCLUSTER_INSTANCE_TYPE -e TASKCLUSTER_ROOT_URL -e TASKCLUSTER_WORKER_LOCATION -e TASK_GROUP_ID -e TASK_ID "${IMAGE_ID}" 'echo "Hello world"'
       features:
         backingLog: true
         liveLog: true
@@ -275,10 +260,7 @@ testSuite:
         - -cx
         - |-
           IMAGE_ID=$(docker load --input dockerimage | sed -n '0,/^Loaded image: /s/^Loaded image: //p')
-          timeout -s KILL 3600 docker run -t --name taskcontainer --memory-swap -1 --pids-limit -1 -e RUN_ID -e TASKCLUSTER_INSTANCE_TYPE -e TASKCLUSTER_ROOT_URL -e TASKCLUSTER_WORKER_LOCATION -e TASK_GROUP_ID -e TASK_ID "${IMAGE_ID}" 'echo "Hello world"'
-          exit_code=$?
-          docker rm -v taskcontainer
-          exit "${exit_code}"
+          timeout -s KILL 3600 docker run --rm -t --name taskcontainer --memory-swap -1 --pids-limit -1 -e RUN_ID -e TASKCLUSTER_INSTANCE_TYPE -e TASKCLUSTER_ROOT_URL -e TASKCLUSTER_WORKER_LOCATION -e TASK_GROUP_ID -e TASK_ID "${IMAGE_ID}" 'echo "Hello world"'
       features:
         backingLog: true
         liveLog: true
@@ -326,10 +308,7 @@ testSuite:
         - -cx
         - |-
           IMAGE_ID=$(docker load --input dockerimage | sed -n '0,/^Loaded image: /s/^Loaded image: //p')
-          timeout -s KILL 3600 docker run -t --name taskcontainer --memory-swap -1 --pids-limit -1 -e RUN_ID -e TASKCLUSTER_INSTANCE_TYPE -e TASKCLUSTER_ROOT_URL -e TASKCLUSTER_WORKER_LOCATION -e TASK_GROUP_ID -e TASK_ID "${IMAGE_ID}" 'echo "Hello world"'
-          exit_code=$?
-          docker rm -v taskcontainer
-          exit "${exit_code}"
+          timeout -s KILL 3600 docker run --rm -t --name taskcontainer --memory-swap -1 --pids-limit -1 -e RUN_ID -e TASKCLUSTER_INSTANCE_TYPE -e TASKCLUSTER_ROOT_URL -e TASKCLUSTER_WORKER_LOCATION -e TASK_GROUP_ID -e TASK_ID "${IMAGE_ID}" 'echo "Hello world"'
       features:
         backingLog: true
         liveLog: true
@@ -378,10 +357,7 @@ testSuite:
         - -cx
         - |-
           IMAGE_ID=$(docker load --input dockerimage | sed -n '0,/^Loaded image: /s/^Loaded image: //p')
-          timeout -s KILL 3600 docker run -t --name taskcontainer --memory-swap -1 --pids-limit -1 -e RUN_ID -e TASKCLUSTER_INSTANCE_TYPE -e TASKCLUSTER_ROOT_URL -e TASKCLUSTER_WORKER_LOCATION -e TASK_GROUP_ID -e TASK_ID "${IMAGE_ID}" 'echo "Hello world"'
-          exit_code=$?
-          docker rm -v taskcontainer
-          exit "${exit_code}"
+          timeout -s KILL 3600 docker run --rm -t --name taskcontainer --memory-swap -1 --pids-limit -1 -e RUN_ID -e TASKCLUSTER_INSTANCE_TYPE -e TASKCLUSTER_ROOT_URL -e TASKCLUSTER_WORKER_LOCATION -e TASK_GROUP_ID -e TASK_ID "${IMAGE_ID}" 'echo "Hello world"'
       features:
         backingLog: true
         liveLog: true
@@ -431,10 +407,7 @@ testSuite:
         - -cx
         - |-
           IMAGE_ID=$(docker load --input dockerimage | sed -n '0,/^Loaded image: /s/^Loaded image: //p')
-          timeout -s KILL 3600 docker run -t --name taskcontainer --memory-swap -1 --pids-limit -1 -v "$(pwd)/cache0:/builds/worker/checkouts" -e RUN_ID -e TASKCLUSTER_INSTANCE_TYPE -e TASKCLUSTER_ROOT_URL -e TASKCLUSTER_WORKER_LOCATION -e TASK_GROUP_ID -e TASK_ID "${IMAGE_ID}" 'echo "Hello world"'
-          exit_code=$?
-          docker rm -v taskcontainer
-          exit "${exit_code}"
+          timeout -s KILL 3600 docker run --rm -t --name taskcontainer --memory-swap -1 --pids-limit -1 -v "$(pwd)/cache0:/builds/worker/checkouts" -e RUN_ID -e TASKCLUSTER_INSTANCE_TYPE -e TASKCLUSTER_ROOT_URL -e TASKCLUSTER_WORKER_LOCATION -e TASK_GROUP_ID -e TASK_ID "${IMAGE_ID}" 'echo "Hello world"'
       features:
         backingLog: true
         liveLog: true

--- a/tools/d2g/d2gtest/testdata/testcases/dw_features_tests.yml
+++ b/tools/d2g/d2gtest/testdata/testcases/dw_features_tests.yml
@@ -32,10 +32,7 @@ testSuite:
         - -cx
         - |-
           docker pull ubuntu
-          timeout -s KILL 3600 docker run -t --name taskcontainer --memory-swap -1 --pids-limit -1 --cap-add=SYS_PTRACE --security-opt=seccomp=unconfined --add-host=taskcluster:host-gateway -e RUN_ID -e TASKCLUSTER_INSTANCE_TYPE -e TASKCLUSTER_PROXY_URL -e TASKCLUSTER_ROOT_URL -e TASKCLUSTER_WORKER_LOCATION -e TASK_GROUP_ID -e TASK_ID ubuntu 'echo "Hello world"'
-          exit_code=$?
-          docker rm -v taskcontainer
-          exit "${exit_code}"
+          timeout -s KILL 3600 docker run --rm -t --name taskcontainer --memory-swap -1 --pids-limit -1 --cap-add=SYS_PTRACE --security-opt=seccomp=unconfined --add-host=taskcluster:host-gateway -e RUN_ID -e TASKCLUSTER_INSTANCE_TYPE -e TASKCLUSTER_PROXY_URL -e TASKCLUSTER_ROOT_URL -e TASKCLUSTER_WORKER_LOCATION -e TASK_GROUP_ID -e TASK_ID ubuntu 'echo "Hello world"'
       features:
         backingLog: true
         liveLog: true
@@ -82,10 +79,7 @@ testSuite:
         - -cx
         - |-
           docker pull ubuntu
-          timeout -s KILL 3600 docker run -t --name taskcontainer --memory-swap -1 --pids-limit -1 -e RUN_ID -e TASKCLUSTER_INSTANCE_TYPE -e TASKCLUSTER_ROOT_URL -e TASKCLUSTER_WORKER_LOCATION -e TASK_GROUP_ID -e TASK_ID ubuntu 'echo "Hello world"'
-          exit_code=$?
-          docker rm -v taskcontainer
-          exit "${exit_code}"
+          timeout -s KILL 3600 docker run --rm -t --name taskcontainer --memory-swap -1 --pids-limit -1 -e RUN_ID -e TASKCLUSTER_INSTANCE_TYPE -e TASKCLUSTER_ROOT_URL -e TASKCLUSTER_WORKER_LOCATION -e TASK_GROUP_ID -e TASK_ID ubuntu 'echo "Hello world"'
       features:
         backingLog: true
         liveLog: true
@@ -127,10 +121,7 @@ testSuite:
         - -cx
         - |-
           docker pull ubuntu
-          timeout -s KILL 3600 docker run -t --name taskcontainer --memory-swap -1 --pids-limit -1 --privileged -e RUN_ID -e TASKCLUSTER_INSTANCE_TYPE -e TASKCLUSTER_ROOT_URL -e TASKCLUSTER_WORKER_LOCATION -e TASK_GROUP_ID -e TASK_ID ubuntu 'echo "Hello world"'
-          exit_code=$?
-          docker rm -v taskcontainer
-          exit "${exit_code}"
+          timeout -s KILL 3600 docker run --rm -t --name taskcontainer --memory-swap -1 --pids-limit -1 --privileged -e RUN_ID -e TASKCLUSTER_INSTANCE_TYPE -e TASKCLUSTER_ROOT_URL -e TASKCLUSTER_WORKER_LOCATION -e TASK_GROUP_ID -e TASK_ID ubuntu 'echo "Hello world"'
       features:
         backingLog: true
         liveLog: true
@@ -173,10 +164,7 @@ testSuite:
         - -cx
         - |-
           docker pull ubuntu
-          timeout -s KILL 3600 docker run -t --name taskcontainer --memory-swap -1 --pids-limit -1 -e RUN_ID -e TASKCLUSTER_INSTANCE_TYPE -e TASKCLUSTER_ROOT_URL -e TASKCLUSTER_WORKER_LOCATION -e TASK_GROUP_ID -e TASK_ID ubuntu 'echo "Hello world"'
-          exit_code=$?
-          docker rm -v taskcontainer
-          exit "${exit_code}"
+          timeout -s KILL 3600 docker run --rm -t --name taskcontainer --memory-swap -1 --pids-limit -1 -e RUN_ID -e TASKCLUSTER_INSTANCE_TYPE -e TASKCLUSTER_ROOT_URL -e TASKCLUSTER_WORKER_LOCATION -e TASK_GROUP_ID -e TASK_ID ubuntu 'echo "Hello world"'
       features:
         backingLog: true
         liveLog: true

--- a/tools/d2g/d2gtest/testdata/testcases/env_escaping_test.yml
+++ b/tools/d2g/d2gtest/testdata/testcases/env_escaping_test.yml
@@ -30,10 +30,7 @@ testSuite:
         - -cx
         - |-
           docker pull ubuntu
-          timeout -s KILL 3600 docker run -t --name taskcontainer --memory-swap -1 --pids-limit -1 -e ' test123 --help  ; whoami ; ' -e RUN_ID -e TASKCLUSTER_INSTANCE_TYPE -e TASKCLUSTER_ROOT_URL -e TASKCLUSTER_WORKER_LOCATION -e TASK_GROUP_ID -e TASK_ID ubuntu 'echo "Hello world"'
-          exit_code=$?
-          docker rm -v taskcontainer
-          exit "${exit_code}"
+          timeout -s KILL 3600 docker run --rm -t --name taskcontainer --memory-swap -1 --pids-limit -1 -e ' test123 --help  ; whoami ; ' -e RUN_ID -e TASKCLUSTER_INSTANCE_TYPE -e TASKCLUSTER_ROOT_URL -e TASKCLUSTER_WORKER_LOCATION -e TASK_GROUP_ID -e TASK_ID ubuntu 'echo "Hello world"'
       env:
         ' test123 --help  ; whoami ; ': testing
       features:

--- a/tools/d2g/d2gtest/testdata/testcases/no_artifacts_test.yml
+++ b/tools/d2g/d2gtest/testdata/testcases/no_artifacts_test.yml
@@ -35,10 +35,7 @@ testSuite:
         - -cx
         - |-
           docker pull ubuntu
-          timeout -s KILL 3600 docker run -t --name taskcontainer --memory-swap -1 --pids-limit -1 -e RUN_ID -e TASKCLUSTER_INSTANCE_TYPE -e TASKCLUSTER_ROOT_URL -e TASKCLUSTER_WORKER_LOCATION -e TASK_GROUP_ID -e TASK_ID ubuntu 'echo "Hello world"'
-          exit_code=$?
-          docker rm -v taskcontainer
-          exit "${exit_code}"
+          timeout -s KILL 3600 docker run --rm -t --name taskcontainer --memory-swap -1 --pids-limit -1 -e RUN_ID -e TASKCLUSTER_INSTANCE_TYPE -e TASKCLUSTER_ROOT_URL -e TASKCLUSTER_WORKER_LOCATION -e TASK_GROUP_ID -e TASK_ID ubuntu 'echo "Hello world"'
       features:
         backingLog: false
         liveLog: false

--- a/tools/d2g/d2gtest/testdata/testcases/task_def_test.yml
+++ b/tools/d2g/d2gtest/testdata/testcases/task_def_test.yml
@@ -70,10 +70,7 @@ testSuite:
           - -cx
           - |-
             docker pull ubuntu:latest
-            timeout -s KILL 630 docker run -t --name taskcontainer --memory-swap -1 --pids-limit -1 --device=/dev/kvm -e RUN_ID -e TASKCLUSTER_INSTANCE_TYPE -e TASKCLUSTER_ROOT_URL -e TASKCLUSTER_WORKER_LOCATION -e TASK_GROUP_ID -e TASK_ID ubuntu:latest /bin/bash -c 'for ((i=1;i<=600;i++)); do echo $i; sleep 1; done'
-            exit_code=$?
-            docker rm -v taskcontainer
-            exit "${exit_code}"
+            timeout -s KILL 630 docker run --rm -t --name taskcontainer --memory-swap -1 --pids-limit -1 --device=/dev/kvm -e RUN_ID -e TASKCLUSTER_INSTANCE_TYPE -e TASKCLUSTER_ROOT_URL -e TASKCLUSTER_WORKER_LOCATION -e TASK_GROUP_ID -e TASK_ID ubuntu:latest /bin/bash -c 'for ((i=1;i<=600;i++)); do echo $i; sleep 1; done'
         features:
           backingLog: true
           liveLog: true
@@ -175,10 +172,7 @@ testSuite:
           - -cx
           - |-
             docker pull ubuntu:latest
-            timeout -s KILL 630 docker run -t --name taskcontainer --memory-swap -1 --pids-limit -1 --device=/dev/kvm -e RUN_ID -e TASKCLUSTER_INSTANCE_TYPE -e TASKCLUSTER_ROOT_URL -e TASKCLUSTER_WORKER_LOCATION -e TASK_GROUP_ID -e TASK_ID ubuntu:latest /bin/bash -c 'for ((i=1;i<=600;i++)); do echo $i; sleep 1; done'
-            exit_code=$?
-            docker rm -v taskcontainer
-            exit "${exit_code}"
+            timeout -s KILL 630 docker run --rm -t --name taskcontainer --memory-swap -1 --pids-limit -1 --device=/dev/kvm -e RUN_ID -e TASKCLUSTER_INSTANCE_TYPE -e TASKCLUSTER_ROOT_URL -e TASKCLUSTER_WORKER_LOCATION -e TASK_GROUP_ID -e TASK_ID ubuntu:latest /bin/bash -c 'for ((i=1;i<=600;i++)); do echo $i; sleep 1; done'
         features:
           backingLog: true
           liveLog: true
@@ -283,10 +277,7 @@ testSuite:
           - -cx
           - |-
             docker pull ubuntu:latest
-            timeout -s KILL 630 docker run -t --name taskcontainer --memory-swap -1 --pids-limit -1 --device=/dev/kvm -e RUN_ID -e TASKCLUSTER_INSTANCE_TYPE -e TASKCLUSTER_ROOT_URL -e TASKCLUSTER_WORKER_LOCATION -e TASK_GROUP_ID -e TASK_ID ubuntu:latest /bin/bash -c 'for ((i=1;i<=600;i++)); do echo $i; sleep 1; done'
-            exit_code=$?
-            docker rm -v taskcontainer
-            exit "${exit_code}"
+            timeout -s KILL 630 docker run --rm -t --name taskcontainer --memory-swap -1 --pids-limit -1 --device=/dev/kvm -e RUN_ID -e TASKCLUSTER_INSTANCE_TYPE -e TASKCLUSTER_ROOT_URL -e TASKCLUSTER_WORKER_LOCATION -e TASK_GROUP_ID -e TASK_ID ubuntu:latest /bin/bash -c 'for ((i=1;i<=600;i++)); do echo $i; sleep 1; done'
         features:
           backingLog: true
           liveLog: true

--- a/tools/d2g/dockerworker/generated_types.go
+++ b/tools/d2g/dockerworker/generated_types.go
@@ -17,6 +17,7 @@ type (
 		// Possible values:
 		//   * "file"
 		//   * "directory"
+		//   * "volume"
 		Type string `json:"type"`
 	}
 
@@ -242,7 +243,8 @@ func JSONSchema() string {
         "type": {
           "enum": [
             "file",
-            "directory"
+            "directory",
+            "volume"
           ],
           "title": "Artifact upload type.",
           "type": "string"

--- a/tools/d2g/dockerworker/generated_types.go
+++ b/tools/d2g/dockerworker/generated_types.go
@@ -72,6 +72,17 @@ type (
 	DockerWorkerPayload struct {
 
 		// Artifact upload map example: ```{"public/build.tar.gz": {"path": "/home/worker/build.tar.gz", "expires": "2016-05-28T16:12:56.693817Z", "type": "file"}}```
+		// Artifacts can be an individual `file`, a `directory` containing
+		// potentially multiple files with recursively included subdirectories,
+		// or a `volume` (d2g only) which will create a volume mount from the
+		// host to the running container. Unlike `directory` artifacts, the
+		// `volume` directory will already exist as the task starts. Since the
+		// artifacts will be created directly on the host, they do not need to
+		// be copied from the container to the host prior to being published,
+		// so perform more efficiently, and simplify the d2g-generated task payload.
+		// Moreover, in the case of time-critical spot terminations, tasks have
+		// more chance of successfully publishing volume artifacts than directory
+		// artifacts, due to the efficiency gain.
 		Artifacts map[string]Artifact `json:"artifacts,omitempty"`
 
 		// Caches are mounted within the docker container at the mount point specified. Example: ```{ "CACHE NAME": "/mount/path/in/container" }```
@@ -263,7 +274,7 @@ func JSONSchema() string {
       "additionalProperties": {
         "$ref": "#/definitions/artifact"
       },
-      "description": "Artifact upload map example: ` + "`" + `` + "`" + `` + "`" + `{\"public/build.tar.gz\": {\"path\": \"/home/worker/build.tar.gz\", \"expires\": \"2016-05-28T16:12:56.693817Z\", \"type\": \"file\"}}` + "`" + `` + "`" + `` + "`" + `",
+      "description": "Artifact upload map example: ` + "`" + `` + "`" + `` + "`" + `{\"public/build.tar.gz\": {\"path\": \"/home/worker/build.tar.gz\", \"expires\": \"2016-05-28T16:12:56.693817Z\", \"type\": \"file\"}}` + "`" + `` + "`" + `` + "`" + `\nArtifacts can be an individual ` + "`" + `file` + "`" + `, a ` + "`" + `directory` + "`" + ` containing\npotentially multiple files with recursively included subdirectories,\nor a ` + "`" + `volume` + "`" + ` (d2g only) which will create a volume mount from the\nhost to the running container. Unlike ` + "`" + `directory` + "`" + ` artifacts, the\n` + "`" + `volume` + "`" + ` directory will already exist as the task starts. Since the\nartifacts will be created directly on the host, they do not need to\nbe copied from the container to the host prior to being published,\nso perform more efficiently, and simplify the d2g-generated task payload.\nMoreover, in the case of time-critical spot terminations, tasks have\nmore chance of successfully publishing volume artifacts than directory\nartifacts, due to the efficiency gain.",
       "title": "Artifacts",
       "type": "object"
     },

--- a/tools/d2g/genericworker/generated_types.go
+++ b/tools/d2g/genericworker/generated_types.go
@@ -246,6 +246,17 @@ type (
 	DockerWorkerPayload struct {
 
 		// Artifact upload map example: ```{"public/build.tar.gz": {"path": "/home/worker/build.tar.gz", "expires": "2016-05-28T16:12:56.693817Z", "type": "file"}}```
+		// Artifacts can be an individual `file`, a `directory` containing
+		// potentially multiple files with recursively included subdirectories,
+		// or a `volume` which will create a volume mount from the
+		// host to the running container. Unlike `directory` artifacts, the
+		// `volume` directory will already exist as the task starts. Since the
+		// artifacts will be created directly on the host, they do not need to
+		// be copied from the container to the host prior to being published,
+		// so perform more efficiently, and simplify the d2g-generated task payload.
+		// Moreover, in the case of time-critical spot terminations, tasks have
+		// more chance of successfully publishing volume artifacts than directory
+		// artifacts, due to the efficiency gain.
 		Artifacts map[string]DockerWorkerArtifact `json:"artifacts,omitempty"`
 
 		// Caches are mounted within the docker container at the mount point specified. Example: ```{ "CACHE NAME": "/mount/path/in/container" }```
@@ -1307,7 +1318,7 @@ func JSONSchema() string {
           "additionalProperties": {
             "$ref": "#/definitions/artifact"
           },
-          "description": "Artifact upload map example: ` + "`" + `` + "`" + `` + "`" + `{\"public/build.tar.gz\": {\"path\": \"/home/worker/build.tar.gz\", \"expires\": \"2016-05-28T16:12:56.693817Z\", \"type\": \"file\"}}` + "`" + `` + "`" + `` + "`" + `",
+          "description": "Artifact upload map example: ` + "`" + `` + "`" + `` + "`" + `{\"public/build.tar.gz\": {\"path\": \"/home/worker/build.tar.gz\", \"expires\": \"2016-05-28T16:12:56.693817Z\", \"type\": \"file\"}}` + "`" + `` + "`" + `` + "`" + `\nArtifacts can be an individual ` + "`" + `file` + "`" + `, a ` + "`" + `directory` + "`" + ` containing\npotentially multiple files with recursively included subdirectories,\nor a ` + "`" + `volume` + "`" + ` which will create a volume mount from the\nhost to the running container. Unlike ` + "`" + `directory` + "`" + ` artifacts, the\n` + "`" + `volume` + "`" + ` directory will already exist as the task starts. Since the\nartifacts will be created directly on the host, they do not need to\nbe copied from the container to the host prior to being published,\nso perform more efficiently, and simplify the d2g-generated task payload.\nMoreover, in the case of time-critical spot terminations, tasks have\nmore chance of successfully publishing volume artifacts than directory\nartifacts, due to the efficiency gain.",
           "title": "Artifacts",
           "type": "object"
         },

--- a/tools/d2g/genericworker/generated_types.go
+++ b/tools/d2g/genericworker/generated_types.go
@@ -191,6 +191,7 @@ type (
 		// Possible values:
 		//   * "file"
 		//   * "directory"
+		//   * "volume"
 		Type string `json:"type"`
 	}
 
@@ -808,7 +809,8 @@ func JSONSchema() string {
         "type": {
           "enum": [
             "file",
-            "directory"
+            "directory",
+            "volume"
           ],
           "title": "Artifact upload type.",
           "type": "string"

--- a/workers/docker-worker/schemas/v1/payload.yml
+++ b/workers/docker-worker/schemas/v1/payload.yml
@@ -13,7 +13,7 @@ definitions:
         enum:
           - file
           - directory
-          - volume # used only in d2g translation
+          - volume
       path:
         title: Location of artifact in container, as an absolute path.
         type: string
@@ -208,10 +208,19 @@ properties:
   artifacts:
     type: object
     title: Artifacts
-    description: >-
-      Artifact upload map example: ```{"public/build.tar.gz": {"path":
-      "/home/worker/build.tar.gz", "expires": "2016-05-28T16:12:56.693817Z",
-      "type": "file"}}```
+    description: |-
+      Artifact upload map example: ```{"public/build.tar.gz": {"path": "/home/worker/build.tar.gz", "expires": "2016-05-28T16:12:56.693817Z", "type": "file"}}```
+      Artifacts can be an individual `file`, a `directory` containing
+      potentially multiple files with recursively included subdirectories,
+      or a `volume` (d2g only) which will create a volume mount from the
+      host to the running container. Unlike `directory` artifacts, the
+      `volume` directory will already exist as the task starts. Since the
+      artifacts will be created directly on the host, they do not need to
+      be copied from the container to the host prior to being published,
+      so perform more efficiently, and simplify the d2g-generated task payload.
+      Moreover, in the case of time-critical spot terminations, tasks have
+      more chance of successfully publishing volume artifacts than directory
+      artifacts, due to the efficiency gain.
     additionalProperties:
       $ref: '#/definitions/artifact'
   supersederUrl:

--- a/workers/docker-worker/schemas/v1/payload.yml
+++ b/workers/docker-worker/schemas/v1/payload.yml
@@ -13,6 +13,7 @@ definitions:
         enum:
           - file
           - directory
+          - volume # used only in d2g translation
       path:
         title: Location of artifact in container, as an absolute path.
         type: string

--- a/workers/generic-worker/generated_insecure_darwin.go
+++ b/workers/generic-worker/generated_insecure_darwin.go
@@ -193,6 +193,7 @@ type (
 		// Possible values:
 		//   * "file"
 		//   * "directory"
+		//   * "volume"
 		Type string `json:"type"`
 	}
 
@@ -771,7 +772,8 @@ func JSONSchema() string {
         "type": {
           "enum": [
             "file",
-            "directory"
+            "directory",
+            "volume"
           ],
           "title": "Artifact upload type.",
           "type": "string"

--- a/workers/generic-worker/generated_insecure_darwin.go
+++ b/workers/generic-worker/generated_insecure_darwin.go
@@ -248,6 +248,17 @@ type (
 	DockerWorkerPayload struct {
 
 		// Artifact upload map example: ```{"public/build.tar.gz": {"path": "/home/worker/build.tar.gz", "expires": "2016-05-28T16:12:56.693817Z", "type": "file"}}```
+		// Artifacts can be an individual `file`, a `directory` containing
+		// potentially multiple files with recursively included subdirectories,
+		// or a `volume` which will create a volume mount from the
+		// host to the running container. Unlike `directory` artifacts, the
+		// `volume` directory will already exist as the task starts. Since the
+		// artifacts will be created directly on the host, they do not need to
+		// be copied from the container to the host prior to being published,
+		// so perform more efficiently, and simplify the d2g-generated task payload.
+		// Moreover, in the case of time-critical spot terminations, tasks have
+		// more chance of successfully publishing volume artifacts than directory
+		// artifacts, due to the efficiency gain.
 		Artifacts map[string]DockerWorkerArtifact `json:"artifacts,omitempty"`
 
 		// Caches are mounted within the docker container at the mount point specified. Example: ```{ "CACHE NAME": "/mount/path/in/container" }```
@@ -1260,7 +1271,7 @@ func JSONSchema() string {
           "additionalProperties": {
             "$ref": "#/definitions/artifact"
           },
-          "description": "Artifact upload map example: ` + "`" + `` + "`" + `` + "`" + `{\"public/build.tar.gz\": {\"path\": \"/home/worker/build.tar.gz\", \"expires\": \"2016-05-28T16:12:56.693817Z\", \"type\": \"file\"}}` + "`" + `` + "`" + `` + "`" + `",
+          "description": "Artifact upload map example: ` + "`" + `` + "`" + `` + "`" + `{\"public/build.tar.gz\": {\"path\": \"/home/worker/build.tar.gz\", \"expires\": \"2016-05-28T16:12:56.693817Z\", \"type\": \"file\"}}` + "`" + `` + "`" + `` + "`" + `\nArtifacts can be an individual ` + "`" + `file` + "`" + `, a ` + "`" + `directory` + "`" + ` containing\npotentially multiple files with recursively included subdirectories,\nor a ` + "`" + `volume` + "`" + ` which will create a volume mount from the\nhost to the running container. Unlike ` + "`" + `directory` + "`" + ` artifacts, the\n` + "`" + `volume` + "`" + ` directory will already exist as the task starts. Since the\nartifacts will be created directly on the host, they do not need to\nbe copied from the container to the host prior to being published,\nso perform more efficiently, and simplify the d2g-generated task payload.\nMoreover, in the case of time-critical spot terminations, tasks have\nmore chance of successfully publishing volume artifacts than directory\nartifacts, due to the efficiency gain.",
           "title": "Artifacts",
           "type": "object"
         },

--- a/workers/generic-worker/generated_insecure_freebsd.go
+++ b/workers/generic-worker/generated_insecure_freebsd.go
@@ -193,6 +193,7 @@ type (
 		// Possible values:
 		//   * "file"
 		//   * "directory"
+		//   * "volume"
 		Type string `json:"type"`
 	}
 
@@ -771,7 +772,8 @@ func JSONSchema() string {
         "type": {
           "enum": [
             "file",
-            "directory"
+            "directory",
+            "volume"
           ],
           "title": "Artifact upload type.",
           "type": "string"

--- a/workers/generic-worker/generated_insecure_freebsd.go
+++ b/workers/generic-worker/generated_insecure_freebsd.go
@@ -248,6 +248,17 @@ type (
 	DockerWorkerPayload struct {
 
 		// Artifact upload map example: ```{"public/build.tar.gz": {"path": "/home/worker/build.tar.gz", "expires": "2016-05-28T16:12:56.693817Z", "type": "file"}}```
+		// Artifacts can be an individual `file`, a `directory` containing
+		// potentially multiple files with recursively included subdirectories,
+		// or a `volume` which will create a volume mount from the
+		// host to the running container. Unlike `directory` artifacts, the
+		// `volume` directory will already exist as the task starts. Since the
+		// artifacts will be created directly on the host, they do not need to
+		// be copied from the container to the host prior to being published,
+		// so perform more efficiently, and simplify the d2g-generated task payload.
+		// Moreover, in the case of time-critical spot terminations, tasks have
+		// more chance of successfully publishing volume artifacts than directory
+		// artifacts, due to the efficiency gain.
 		Artifacts map[string]DockerWorkerArtifact `json:"artifacts,omitempty"`
 
 		// Caches are mounted within the docker container at the mount point specified. Example: ```{ "CACHE NAME": "/mount/path/in/container" }```
@@ -1260,7 +1271,7 @@ func JSONSchema() string {
           "additionalProperties": {
             "$ref": "#/definitions/artifact"
           },
-          "description": "Artifact upload map example: ` + "`" + `` + "`" + `` + "`" + `{\"public/build.tar.gz\": {\"path\": \"/home/worker/build.tar.gz\", \"expires\": \"2016-05-28T16:12:56.693817Z\", \"type\": \"file\"}}` + "`" + `` + "`" + `` + "`" + `",
+          "description": "Artifact upload map example: ` + "`" + `` + "`" + `` + "`" + `{\"public/build.tar.gz\": {\"path\": \"/home/worker/build.tar.gz\", \"expires\": \"2016-05-28T16:12:56.693817Z\", \"type\": \"file\"}}` + "`" + `` + "`" + `` + "`" + `\nArtifacts can be an individual ` + "`" + `file` + "`" + `, a ` + "`" + `directory` + "`" + ` containing\npotentially multiple files with recursively included subdirectories,\nor a ` + "`" + `volume` + "`" + ` which will create a volume mount from the\nhost to the running container. Unlike ` + "`" + `directory` + "`" + ` artifacts, the\n` + "`" + `volume` + "`" + ` directory will already exist as the task starts. Since the\nartifacts will be created directly on the host, they do not need to\nbe copied from the container to the host prior to being published,\nso perform more efficiently, and simplify the d2g-generated task payload.\nMoreover, in the case of time-critical spot terminations, tasks have\nmore chance of successfully publishing volume artifacts than directory\nartifacts, due to the efficiency gain.",
           "title": "Artifacts",
           "type": "object"
         },

--- a/workers/generic-worker/generated_insecure_linux.go
+++ b/workers/generic-worker/generated_insecure_linux.go
@@ -193,6 +193,7 @@ type (
 		// Possible values:
 		//   * "file"
 		//   * "directory"
+		//   * "volume"
 		Type string `json:"type"`
 	}
 
@@ -771,7 +772,8 @@ func JSONSchema() string {
         "type": {
           "enum": [
             "file",
-            "directory"
+            "directory",
+            "volume"
           ],
           "title": "Artifact upload type.",
           "type": "string"

--- a/workers/generic-worker/generated_insecure_linux.go
+++ b/workers/generic-worker/generated_insecure_linux.go
@@ -248,6 +248,17 @@ type (
 	DockerWorkerPayload struct {
 
 		// Artifact upload map example: ```{"public/build.tar.gz": {"path": "/home/worker/build.tar.gz", "expires": "2016-05-28T16:12:56.693817Z", "type": "file"}}```
+		// Artifacts can be an individual `file`, a `directory` containing
+		// potentially multiple files with recursively included subdirectories,
+		// or a `volume` which will create a volume mount from the
+		// host to the running container. Unlike `directory` artifacts, the
+		// `volume` directory will already exist as the task starts. Since the
+		// artifacts will be created directly on the host, they do not need to
+		// be copied from the container to the host prior to being published,
+		// so perform more efficiently, and simplify the d2g-generated task payload.
+		// Moreover, in the case of time-critical spot terminations, tasks have
+		// more chance of successfully publishing volume artifacts than directory
+		// artifacts, due to the efficiency gain.
 		Artifacts map[string]DockerWorkerArtifact `json:"artifacts,omitempty"`
 
 		// Caches are mounted within the docker container at the mount point specified. Example: ```{ "CACHE NAME": "/mount/path/in/container" }```
@@ -1260,7 +1271,7 @@ func JSONSchema() string {
           "additionalProperties": {
             "$ref": "#/definitions/artifact"
           },
-          "description": "Artifact upload map example: ` + "`" + `` + "`" + `` + "`" + `{\"public/build.tar.gz\": {\"path\": \"/home/worker/build.tar.gz\", \"expires\": \"2016-05-28T16:12:56.693817Z\", \"type\": \"file\"}}` + "`" + `` + "`" + `` + "`" + `",
+          "description": "Artifact upload map example: ` + "`" + `` + "`" + `` + "`" + `{\"public/build.tar.gz\": {\"path\": \"/home/worker/build.tar.gz\", \"expires\": \"2016-05-28T16:12:56.693817Z\", \"type\": \"file\"}}` + "`" + `` + "`" + `` + "`" + `\nArtifacts can be an individual ` + "`" + `file` + "`" + `, a ` + "`" + `directory` + "`" + ` containing\npotentially multiple files with recursively included subdirectories,\nor a ` + "`" + `volume` + "`" + ` which will create a volume mount from the\nhost to the running container. Unlike ` + "`" + `directory` + "`" + ` artifacts, the\n` + "`" + `volume` + "`" + ` directory will already exist as the task starts. Since the\nartifacts will be created directly on the host, they do not need to\nbe copied from the container to the host prior to being published,\nso perform more efficiently, and simplify the d2g-generated task payload.\nMoreover, in the case of time-critical spot terminations, tasks have\nmore chance of successfully publishing volume artifacts than directory\nartifacts, due to the efficiency gain.",
           "title": "Artifacts",
           "type": "object"
         },

--- a/workers/generic-worker/generated_multiuser_darwin.go
+++ b/workers/generic-worker/generated_multiuser_darwin.go
@@ -193,6 +193,7 @@ type (
 		// Possible values:
 		//   * "file"
 		//   * "directory"
+		//   * "volume"
 		Type string `json:"type"`
 	}
 
@@ -810,7 +811,8 @@ func JSONSchema() string {
         "type": {
           "enum": [
             "file",
-            "directory"
+            "directory",
+            "volume"
           ],
           "title": "Artifact upload type.",
           "type": "string"

--- a/workers/generic-worker/generated_multiuser_darwin.go
+++ b/workers/generic-worker/generated_multiuser_darwin.go
@@ -248,6 +248,17 @@ type (
 	DockerWorkerPayload struct {
 
 		// Artifact upload map example: ```{"public/build.tar.gz": {"path": "/home/worker/build.tar.gz", "expires": "2016-05-28T16:12:56.693817Z", "type": "file"}}```
+		// Artifacts can be an individual `file`, a `directory` containing
+		// potentially multiple files with recursively included subdirectories,
+		// or a `volume` which will create a volume mount from the
+		// host to the running container. Unlike `directory` artifacts, the
+		// `volume` directory will already exist as the task starts. Since the
+		// artifacts will be created directly on the host, they do not need to
+		// be copied from the container to the host prior to being published,
+		// so perform more efficiently, and simplify the d2g-generated task payload.
+		// Moreover, in the case of time-critical spot terminations, tasks have
+		// more chance of successfully publishing volume artifacts than directory
+		// artifacts, due to the efficiency gain.
 		Artifacts map[string]DockerWorkerArtifact `json:"artifacts,omitempty"`
 
 		// Caches are mounted within the docker container at the mount point specified. Example: ```{ "CACHE NAME": "/mount/path/in/container" }```
@@ -1309,7 +1320,7 @@ func JSONSchema() string {
           "additionalProperties": {
             "$ref": "#/definitions/artifact"
           },
-          "description": "Artifact upload map example: ` + "`" + `` + "`" + `` + "`" + `{\"public/build.tar.gz\": {\"path\": \"/home/worker/build.tar.gz\", \"expires\": \"2016-05-28T16:12:56.693817Z\", \"type\": \"file\"}}` + "`" + `` + "`" + `` + "`" + `",
+          "description": "Artifact upload map example: ` + "`" + `` + "`" + `` + "`" + `{\"public/build.tar.gz\": {\"path\": \"/home/worker/build.tar.gz\", \"expires\": \"2016-05-28T16:12:56.693817Z\", \"type\": \"file\"}}` + "`" + `` + "`" + `` + "`" + `\nArtifacts can be an individual ` + "`" + `file` + "`" + `, a ` + "`" + `directory` + "`" + ` containing\npotentially multiple files with recursively included subdirectories,\nor a ` + "`" + `volume` + "`" + ` which will create a volume mount from the\nhost to the running container. Unlike ` + "`" + `directory` + "`" + ` artifacts, the\n` + "`" + `volume` + "`" + ` directory will already exist as the task starts. Since the\nartifacts will be created directly on the host, they do not need to\nbe copied from the container to the host prior to being published,\nso perform more efficiently, and simplify the d2g-generated task payload.\nMoreover, in the case of time-critical spot terminations, tasks have\nmore chance of successfully publishing volume artifacts than directory\nartifacts, due to the efficiency gain.",
           "title": "Artifacts",
           "type": "object"
         },

--- a/workers/generic-worker/generated_multiuser_freebsd.go
+++ b/workers/generic-worker/generated_multiuser_freebsd.go
@@ -193,6 +193,7 @@ type (
 		// Possible values:
 		//   * "file"
 		//   * "directory"
+		//   * "volume"
 		Type string `json:"type"`
 	}
 
@@ -810,7 +811,8 @@ func JSONSchema() string {
         "type": {
           "enum": [
             "file",
-            "directory"
+            "directory",
+            "volume"
           ],
           "title": "Artifact upload type.",
           "type": "string"

--- a/workers/generic-worker/generated_multiuser_freebsd.go
+++ b/workers/generic-worker/generated_multiuser_freebsd.go
@@ -248,6 +248,17 @@ type (
 	DockerWorkerPayload struct {
 
 		// Artifact upload map example: ```{"public/build.tar.gz": {"path": "/home/worker/build.tar.gz", "expires": "2016-05-28T16:12:56.693817Z", "type": "file"}}```
+		// Artifacts can be an individual `file`, a `directory` containing
+		// potentially multiple files with recursively included subdirectories,
+		// or a `volume` which will create a volume mount from the
+		// host to the running container. Unlike `directory` artifacts, the
+		// `volume` directory will already exist as the task starts. Since the
+		// artifacts will be created directly on the host, they do not need to
+		// be copied from the container to the host prior to being published,
+		// so perform more efficiently, and simplify the d2g-generated task payload.
+		// Moreover, in the case of time-critical spot terminations, tasks have
+		// more chance of successfully publishing volume artifacts than directory
+		// artifacts, due to the efficiency gain.
 		Artifacts map[string]DockerWorkerArtifact `json:"artifacts,omitempty"`
 
 		// Caches are mounted within the docker container at the mount point specified. Example: ```{ "CACHE NAME": "/mount/path/in/container" }```
@@ -1309,7 +1320,7 @@ func JSONSchema() string {
           "additionalProperties": {
             "$ref": "#/definitions/artifact"
           },
-          "description": "Artifact upload map example: ` + "`" + `` + "`" + `` + "`" + `{\"public/build.tar.gz\": {\"path\": \"/home/worker/build.tar.gz\", \"expires\": \"2016-05-28T16:12:56.693817Z\", \"type\": \"file\"}}` + "`" + `` + "`" + `` + "`" + `",
+          "description": "Artifact upload map example: ` + "`" + `` + "`" + `` + "`" + `{\"public/build.tar.gz\": {\"path\": \"/home/worker/build.tar.gz\", \"expires\": \"2016-05-28T16:12:56.693817Z\", \"type\": \"file\"}}` + "`" + `` + "`" + `` + "`" + `\nArtifacts can be an individual ` + "`" + `file` + "`" + `, a ` + "`" + `directory` + "`" + ` containing\npotentially multiple files with recursively included subdirectories,\nor a ` + "`" + `volume` + "`" + ` which will create a volume mount from the\nhost to the running container. Unlike ` + "`" + `directory` + "`" + ` artifacts, the\n` + "`" + `volume` + "`" + ` directory will already exist as the task starts. Since the\nartifacts will be created directly on the host, they do not need to\nbe copied from the container to the host prior to being published,\nso perform more efficiently, and simplify the d2g-generated task payload.\nMoreover, in the case of time-critical spot terminations, tasks have\nmore chance of successfully publishing volume artifacts than directory\nartifacts, due to the efficiency gain.",
           "title": "Artifacts",
           "type": "object"
         },

--- a/workers/generic-worker/generated_multiuser_linux.go
+++ b/workers/generic-worker/generated_multiuser_linux.go
@@ -193,6 +193,7 @@ type (
 		// Possible values:
 		//   * "file"
 		//   * "directory"
+		//   * "volume"
 		Type string `json:"type"`
 	}
 
@@ -810,7 +811,8 @@ func JSONSchema() string {
         "type": {
           "enum": [
             "file",
-            "directory"
+            "directory",
+            "volume"
           ],
           "title": "Artifact upload type.",
           "type": "string"

--- a/workers/generic-worker/generated_multiuser_linux.go
+++ b/workers/generic-worker/generated_multiuser_linux.go
@@ -248,6 +248,17 @@ type (
 	DockerWorkerPayload struct {
 
 		// Artifact upload map example: ```{"public/build.tar.gz": {"path": "/home/worker/build.tar.gz", "expires": "2016-05-28T16:12:56.693817Z", "type": "file"}}```
+		// Artifacts can be an individual `file`, a `directory` containing
+		// potentially multiple files with recursively included subdirectories,
+		// or a `volume` which will create a volume mount from the
+		// host to the running container. Unlike `directory` artifacts, the
+		// `volume` directory will already exist as the task starts. Since the
+		// artifacts will be created directly on the host, they do not need to
+		// be copied from the container to the host prior to being published,
+		// so perform more efficiently, and simplify the d2g-generated task payload.
+		// Moreover, in the case of time-critical spot terminations, tasks have
+		// more chance of successfully publishing volume artifacts than directory
+		// artifacts, due to the efficiency gain.
 		Artifacts map[string]DockerWorkerArtifact `json:"artifacts,omitempty"`
 
 		// Caches are mounted within the docker container at the mount point specified. Example: ```{ "CACHE NAME": "/mount/path/in/container" }```
@@ -1309,7 +1320,7 @@ func JSONSchema() string {
           "additionalProperties": {
             "$ref": "#/definitions/artifact"
           },
-          "description": "Artifact upload map example: ` + "`" + `` + "`" + `` + "`" + `{\"public/build.tar.gz\": {\"path\": \"/home/worker/build.tar.gz\", \"expires\": \"2016-05-28T16:12:56.693817Z\", \"type\": \"file\"}}` + "`" + `` + "`" + `` + "`" + `",
+          "description": "Artifact upload map example: ` + "`" + `` + "`" + `` + "`" + `{\"public/build.tar.gz\": {\"path\": \"/home/worker/build.tar.gz\", \"expires\": \"2016-05-28T16:12:56.693817Z\", \"type\": \"file\"}}` + "`" + `` + "`" + `` + "`" + `\nArtifacts can be an individual ` + "`" + `file` + "`" + `, a ` + "`" + `directory` + "`" + ` containing\npotentially multiple files with recursively included subdirectories,\nor a ` + "`" + `volume` + "`" + ` which will create a volume mount from the\nhost to the running container. Unlike ` + "`" + `directory` + "`" + ` artifacts, the\n` + "`" + `volume` + "`" + ` directory will already exist as the task starts. Since the\nartifacts will be created directly on the host, they do not need to\nbe copied from the container to the host prior to being published,\nso perform more efficiently, and simplify the d2g-generated task payload.\nMoreover, in the case of time-critical spot terminations, tasks have\nmore chance of successfully publishing volume artifacts than directory\nartifacts, due to the efficiency gain.",
           "title": "Artifacts",
           "type": "object"
         },

--- a/workers/generic-worker/schemas/insecure_posix.yml
+++ b/workers/generic-worker/schemas/insecure_posix.yml
@@ -562,8 +562,19 @@ oneOf:
     artifacts:
       type: object
       title: Artifacts
-      description: >-
+      description: |-
         Artifact upload map example: ```{"public/build.tar.gz": {"path": "/home/worker/build.tar.gz", "expires": "2016-05-28T16:12:56.693817Z", "type": "file"}}```
+        Artifacts can be an individual `file`, a `directory` containing
+        potentially multiple files with recursively included subdirectories,
+        or a `volume` which will create a volume mount from the
+        host to the running container. Unlike `directory` artifacts, the
+        `volume` directory will already exist as the task starts. Since the
+        artifacts will be created directly on the host, they do not need to
+        be copied from the container to the host prior to being published,
+        so perform more efficiently, and simplify the d2g-generated task payload.
+        Moreover, in the case of time-critical spot terminations, tasks have
+        more chance of successfully publishing volume artifacts than directory
+        artifacts, due to the efficiency gain.
       additionalProperties:
         $ref: "#/definitions/artifact"
     supersederUrl:
@@ -882,7 +893,7 @@ definitions:
         enum:
         - file
         - directory
-        - volume # used only in d2g translation
+        - volume
       path:
         title: Location of artifact in container, as an absolute path.
         type: string

--- a/workers/generic-worker/schemas/insecure_posix.yml
+++ b/workers/generic-worker/schemas/insecure_posix.yml
@@ -882,6 +882,7 @@ definitions:
         enum:
         - file
         - directory
+        - volume # used only in d2g translation
       path:
         title: Location of artifact in container, as an absolute path.
         type: string

--- a/workers/generic-worker/schemas/multiuser_posix.yml
+++ b/workers/generic-worker/schemas/multiuser_posix.yml
@@ -605,8 +605,19 @@ oneOf:
     artifacts:
       type: object
       title: Artifacts
-      description: >-
+      description: |-
         Artifact upload map example: ```{"public/build.tar.gz": {"path": "/home/worker/build.tar.gz", "expires": "2016-05-28T16:12:56.693817Z", "type": "file"}}```
+        Artifacts can be an individual `file`, a `directory` containing
+        potentially multiple files with recursively included subdirectories,
+        or a `volume` which will create a volume mount from the
+        host to the running container. Unlike `directory` artifacts, the
+        `volume` directory will already exist as the task starts. Since the
+        artifacts will be created directly on the host, they do not need to
+        be copied from the container to the host prior to being published,
+        so perform more efficiently, and simplify the d2g-generated task payload.
+        Moreover, in the case of time-critical spot terminations, tasks have
+        more chance of successfully publishing volume artifacts than directory
+        artifacts, due to the efficiency gain.
       additionalProperties:
         $ref: "#/definitions/artifact"
     supersederUrl:
@@ -925,7 +936,7 @@ definitions:
         enum:
         - file
         - directory
-        - volume # used only in d2g translation
+        - volume
       path:
         title: Location of artifact in container, as an absolute path.
         type: string

--- a/workers/generic-worker/schemas/multiuser_posix.yml
+++ b/workers/generic-worker/schemas/multiuser_posix.yml
@@ -925,6 +925,7 @@ definitions:
         enum:
         - file
         - directory
+        - volume # used only in d2g translation
       path:
         title: Location of artifact in container, as an absolute path.
         type: string


### PR DESCRIPTION
Fixes #7594.

>Docker Worker (D2G): adds `volume` type for artifacts. This is strictly used for D2G purposes only. Use this type to have D2G volume mount your artifact path instead of `docker cp`'ing the artifact at the end of the task run. This can be useful under spot termination instances where the `docker cp` command doesn't get a chance to run, instead a volume mount will have the files on the host ready for upload as soon as the spot termination requests comes in.