### PR TITLE
fix(decision): don't remove `artifacts/actions.json` so CoT can still verify

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -212,7 +212,7 @@ tasks:
               --head-ref='${head_ref}'
               --head-rev='${head_sha}'
               --head-tag='${head_tag}' &&
-              rm artifacts/actions.json # taskcluster is not using actions.json
+              echo "{}" > artifacts/actions.json # taskcluster is not using actions.json, setting to {} so CoT can still verify
 
           artifacts:
             "public":

--- a/changelog/Ex6It1SVQgWNlehACJqdlA.md
+++ b/changelog/Ex6It1SVQgWNlehACJqdlA.md
@@ -1,0 +1,3 @@
+audience: general
+level: silent
+---


### PR DESCRIPTION
Prevents issues like:
```bash
export TASKCLUSTER_ROOT_URL='https://community-tc.services.mozilla.com/' && verify_cot --task-type decision a2d7wQF5QxeHl4l_wZFX5Q
scriptworker.exceptions.CoTError: 'path public/actions.json not in decision a2d7wQF5QxeHl4l_wZFX5Q chain of trust artifacts! This is likely a bug in a2d7wQF5QxeHl4l_wZFX5Q: docker-worker does not fail if a declared artifact was never generated by the task. Please download and make sure the artifact public/actions.json is the one you expect. If it is, then please reach out to the Release Engineering team. For more information: https://github.com/taskcluster/taskgraph/issues/47'
```