### PR TITLE
feat(dev): Fixes local broken UI container

### DIFF
--- a/changelog/issue-7543.md
+++ b/changelog/issue-7543.md
@@ -1,0 +1,6 @@
+audience: developers
+level: minor
+reference: issue 7543
+---
+
+Fixes broken local development UI container.

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -15,8 +15,12 @@ services:
     volumes:
       - ./generated:/app/generated
       - .all-contributorsrc:/app/.all-contributorsrc
-      - ./ui:/app/ui
+      - ./ui/package.json:/app/ui/package.json
+      - ./ui/src:/app/ui/src
+      - ./ui/docs:/app/ui/docs
       - ./CHANGELOG.md:/app/CHANGELOG.md
+    ports:
+      - '3022:80'
   generic-worker-standalone:
     image: ${IMAGE_GENERIC_WORKER}
     networks:

--- a/infrastructure/tooling/src/generate/generators/docker-compose.js
+++ b/infrastructure/tooling/src/generate/generators/docker-compose.js
@@ -418,9 +418,12 @@ tasks.push({
           volumes: [
             './generated:/app/generated',
             '.all-contributorsrc:/app/.all-contributorsrc',
-            './ui:/app/ui',
+            './ui/package.json:/app/ui/package.json',
+            './ui/src:/app/ui/src',
+            './ui/docs:/app/ui/docs',
             './CHANGELOG.md:/app/CHANGELOG.md',
           ],
+          ports: servicePorts('ui'),
         },
       },
     };

--- a/ui/.dockerignore
+++ b/ui/.dockerignore
@@ -1,0 +1,6 @@
+**/node_modules
+.eslintcache
+**/.coverage
+**/coverage.report
+
+build

--- a/ui/Dockerfile
+++ b/ui/Dockerfile
@@ -4,7 +4,11 @@ WORKDIR /app/ui
 COPY yarn.lock package.json ./
 
 RUN corepack enable && \
-    yarn
+  yarn set version stable && \
+  yarn config set nodeLinker node-modules && \
+  yarn install
+
+COPY . ./
 
 ENTRYPOINT [ "yarn" ]
 CMD [ "start:docker" ]


### PR DESCRIPTION
At some point yarn switched to Plug'n'Play modules installation which results in no 'node_modules' folder present.
I'm not exactly sure how it should work inside docker container, since yarn couldn't find the packages it installed.
Switching to the node_modules behaviour.

Also fixing mapped folders and adding missing port mapping for dev ui

Fixes #7543 
