### PR TITLE
chore(deps): ignore docker worker dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -139,3 +139,12 @@ updates:
         update-types:
           - "minor"
           - "patch"
+
+  # Ignore docker worker dependencies
+  - package-ecosystem: "npm"
+    directory: "/workers/docker-worker"
+    schedule:
+      interval: "monthly"
+    rebase-strategy: "disabled"
+    ignore:
+      - dependency-name: "*"

--- a/changelog/O4PcaC2FTK2ZJBDj15Xwtw.md
+++ b/changelog/O4PcaC2FTK2ZJBDj15Xwtw.md
@@ -1,0 +1,3 @@
+audience: general
+level: silent
+---


### PR DESCRIPTION
Will prevent future PRs like the following https://github.com/taskcluster/taskcluster/pulls?q=is%3Apr+is%3Aclosed+in+%2Fworkers%2Fdocker-worker+author%3Aapp%2Fdependabot+

https://github.com/taskcluster/taskcluster/pull/7631 was the most recent that I closed. We don't need to spend CI resources on keeping docker worker deps up-to-date.