### PR TITLE
fix(generic-worker): fix gw windows reset permissions on cache dir

### DIFF
--- a/changelog/issue-7650.md
+++ b/changelog/issue-7650.md
@@ -1,0 +1,5 @@
+audience: worker-deployers
+level: patch
+reference: issue 7650
+---
+Generic Worker (windows): fixes cache mount issue where generic worker fails to reset permissions on the cache directory. First noticed in [v81.0.3](https://docs.taskcluster.net/docs/changelog?version=v81.0.3).

--- a/workers/generic-worker/multiuser_windows.go
+++ b/workers/generic-worker/multiuser_windows.go
@@ -551,15 +551,15 @@ func changeOwnershipInDir(dir, newOwnerUsername string, cache *Cache) error {
 	}
 
 	// Reset to inherited permissions only, recursively
-	err := host.Run("icacls", dir, "/reset", "/t")
+	out, err := host.Output("icacls", dir, "/reset", "/t", "/c", "/q")
 	if err != nil {
-		return fmt.Errorf("failed to reset permissions on dir %v: %v", dir, err)
+		return fmt.Errorf("failed to reset permissions on dir %v: %v\n%v", dir, err, out)
 	}
 
 	// Grant full control to new owner, adding to inherited permissions
-	err = host.Run("icacls", dir, "/grant", newOwnerUsername+":(OI)(CI)F")
+	out, err = host.Output("icacls", dir, "/grant", newOwnerUsername+":(OI)(CI)F")
 	if err != nil {
-		return fmt.Errorf("failed to grant permissions to %v on dir %v: %v", newOwnerUsername, dir, err)
+		return fmt.Errorf("failed to grant permissions to %v on dir %v: %v\n%v", newOwnerUsername, dir, err, out)
 	}
 
 	return nil


### PR DESCRIPTION
Fixes #7650.

>Generic Worker (windows): fixes cache mount issue where generic worker fails to reset permissions on the cache directory. First noticed in [v81.0.3](https://docs.taskcluster.net/docs/changelog?version=v81.0.3).