### PR TITLE
fix(generic-worker): clean up temp files

### DIFF
--- a/changelog/issue-7652.md
+++ b/changelog/issue-7652.md
@@ -1,0 +1,5 @@
+audience: worker-deployers
+level: patch
+reference: issue 7652
+---
+Generic Worker: remove temp file created while adding additional data to chain of trust file.

--- a/workers/generic-worker/chain_of_trust.go
+++ b/workers/generic-worker/chain_of_trust.go
@@ -257,6 +257,7 @@ func (cot *ChainOfTrustTaskFeature) MergeAdditionalData(certBytes []byte) (merge
 	if err != nil {
 		return
 	}
+	defer os.Remove(tempPath)
 
 	var additionalDataBytes []byte
 	additionalDataBytes, err = os.ReadFile(tempPath)


### PR DESCRIPTION
>Generic Worker: remove temp file created while adding additional data to chain of trust file.