### PR TITLE
fix(generic-worker): remove redundant file copy during artifact upload process

### DIFF
--- a/changelog/issue-7368.md
+++ b/changelog/issue-7368.md
@@ -1,0 +1,5 @@
+audience: worker-deployers
+level: patch
+reference: issue 7368
+---
+Generic Worker: increase performance of artifact uploads by removing a redundant file copy operation.

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,6 @@ require (
 	github.com/elastic/go-sysinfo v1.15.3
 	github.com/fatih/camelcase v1.0.0
 	github.com/getsentry/raven-go v0.2.0
-	github.com/gofrs/flock v0.12.1
 	github.com/golang-jwt/jwt/v4 v4.5.2
 	github.com/gorilla/mux v1.8.1
 	github.com/gorilla/websocket v1.5.3
@@ -66,7 +65,7 @@ require (
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/klauspost/compress v1.16.7 // indirect
 	github.com/klauspost/pgzip v1.2.6 // indirect
-	github.com/kr/text v0.2.0 // indirect
+	github.com/kr/pretty v0.3.1 // indirect
 	github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 // indirect
 	github.com/nwaples/rardecode v1.1.3 // indirect
 	github.com/pierrec/lz4/v4 v4.1.18 // indirect
@@ -85,6 +84,7 @@ require (
 	golang.org/x/mod v0.24.0 // indirect
 	golang.org/x/sync v0.13.0 // indirect
 	golang.org/x/text v0.24.0 // indirect
+	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c // indirect
 	howett.net/plist v1.0.0 // indirect
 	launchpad.net/gocheck v0.0.0-20140225173054-000000000087 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -95,8 +95,6 @@ github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72/go.mod h1:tQ2
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20200222043503-6f7a984d4dc4/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
 github.com/go-ole/go-ole v1.2.6 h1:/Fpf6oFPoeFik9ty7siob0G6Ke8QvQEuVcuChpwXzpY=
 github.com/go-ole/go-ole v1.2.6/go.mod h1:pprOEPIfldk/42T2oK7lQ4v4JSDwmV0As9GaiUsvbm0=
-github.com/gofrs/flock v0.12.1 h1:MTLVXXHf8ekldpJk3AKicLij9MdwOWkZ+a/jHHZby9E=
-github.com/gofrs/flock v0.12.1/go.mod h1:9zxTsyu5xtJ9DK+1tFZyibEV7y3uwDxPPfbxeeHCoD0=
 github.com/golang-jwt/jwt/v4 v4.5.2 h1:YtQM7lnr8iZ+j5q71MGKkNw9Mn7AjHM68uc9g5fXeUI=
 github.com/golang-jwt/jwt/v4 v4.5.2/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w39/MY0Ch0=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
@@ -192,6 +190,7 @@ github.com/klauspost/pgzip v1.2.6 h1:8RXeL5crjEUFnR2/Sn6GJNWtSQ3Dk8pq4CL3jvdDyjU
 github.com/klauspost/pgzip v1.2.6/go.mod h1:Ch1tH69qFZu15pkjo5kYi6mth2Zzwzt50oCQKQE9RUs=
 github.com/kr/fs v0.1.0/go.mod h1:FFnZGqtBN9Gxj7eW1uZ42v5BccTP0vu6NEaFoC2HwRg=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
+github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
 github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
@@ -224,6 +223,7 @@ github.com/pierrec/lz4/v4 v4.1.18 h1:xaKrnTkyoqfh1YItXl56+6KJNVYWlEEPuAQW9xsplYQ
 github.com/pierrec/lz4/v4 v4.1.18/go.mod h1:gZWDp/Ze/IJXGXf23ltt2EXimqmTUXEy0GFuRQyBid4=
 github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8 h1:KoWmjvw+nsYOo29YJK9vDA65RGE3NrOnUtO7a+RF9HU=
 github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8/go.mod h1:HKlIX3XHQyzLZPlr7++PzdhaXEj94dEiJgZDTsxEqUI=
+github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e/go.mod h1:pJLUxLENpZxwdsKMEsNbx1VGcRFpLqf3715MtcvvzbA=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/sftp v1.13.1/go.mod h1:3HaPG6Dq1ILlpPZRO0HVMrsydcdLt6HRDccSgb87qRg=
@@ -235,6 +235,7 @@ github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:
 github.com/prometheus/procfs v0.15.1 h1:YagwOFzUgYfKKHX6Dr+sHT7km/hxC76UB0learggepc=
 github.com/prometheus/procfs v0.15.1/go.mod h1:fB45yRUv8NstnjriLhBQLuOUt+WW4BsoGhij/e3PBqk=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
+github.com/rogpeppe/go-internal v1.9.0/go.mod h1:WtVeX8xhTBvf0smdhujwtBcq4Qrzq/fJaraNFVN+nFs=
 github.com/rogpeppe/go-internal v1.12.0 h1:exVL4IDcn6na9z1rAb56Vxr+CgyK3nn3O+epU5NdKM8=
 github.com/rogpeppe/go-internal v1.12.0/go.mod h1:E+RYuTGaKKdloAfM02xzb0FW3Paa99yedzYV+kq4uf4=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=

--- a/workers/generic-worker/artifacts/s3.go
+++ b/workers/generic-worker/artifacts/s3.go
@@ -9,9 +9,7 @@ import (
 	"net/http/httputil"
 	"os"
 	"path/filepath"
-	"runtime"
 
-	"github.com/gofrs/flock"
 	"github.com/taskcluster/httpbackoff/v3"
 	"github.com/taskcluster/taskcluster/v83/clients/client-go/tcqueue"
 	"github.com/taskcluster/taskcluster/v83/internal/mocktc/tc"
@@ -31,40 +29,11 @@ type S3Artifact struct {
 	ContentType     string
 }
 
-// createTempFileForPUTBody first tries to put a file lock on
-// the artifact to prevent further writes to it (posix only).
-// The file path of the locked file is returned. If this is unsuccessful,
-// it will fall back to copying to a temporary file.
-// This method will also gzip-compress the file at Path and writes
-// it to a temporary file in the same directory. The file path of the
-// generated temporary file is returned.
-// A callback function is also returned that should be used to
-// cleanup the resources (e.g. unlock the file lock or delete the
-// temp file). It is the responsibility of the caller to
-// use this cleanup function.
-func (s3Artifact *S3Artifact) createTempFileForPUTBody() (string, func()) {
-	var fileLock *flock.Flock
-	removeFileLock := func() {
-		log.Printf("Removing exclusive file lock on %v...", s3Artifact.ContentPath)
-		_ = fileLock.Unlock()
-	}
-
-	if runtime.GOOS != "windows" {
-		fileLock = flock.New(s3Artifact.ContentPath)
-		log.Printf("Attempting to get exclusive file lock on %v...", s3Artifact.ContentPath)
-		locked, _ := fileLock.TryLock()
-		if locked {
-			log.Printf("Got exclusive file lock on %v", s3Artifact.ContentPath)
-			if s3Artifact.ContentEncoding != "gzip" {
-				log.Printf("No need to copy %v to temp file", s3Artifact.ContentPath)
-				return s3Artifact.ContentPath, removeFileLock
-			}
-			log.Printf("Need to gzip-compress %v...", s3Artifact.ContentPath)
-		} else {
-			log.Printf("Failed to get exclusive file lock on %v", s3Artifact.ContentPath)
-		}
-	}
-
+// createTempFileForPUTBody gzip-compresses the file at Path and
+// writes it to a temporary file in the same directory. The file path of the
+// generated temporary file is returned.  It is the responsibility of the
+// caller to delete the temporary file.
+func (s3Artifact *S3Artifact) createTempFileForPUTBody() string {
 	baseName := filepath.Base(s3Artifact.Path)
 	tmpFile, err := os.CreateTemp("", baseName)
 	if err != nil {
@@ -84,12 +53,7 @@ func (s3Artifact *S3Artifact) createTempFileForPUTBody() (string, func()) {
 	}
 	defer source.Close()
 	_, _ = io.Copy(target, source)
-	return tmpFile.Name(), func() {
-		if runtime.GOOS != "windows" {
-			removeFileLock()
-		}
-		os.Remove(tmpFile.Name())
-	}
+	return tmpFile.Name()
 }
 
 func (s3Artifact *S3Artifact) ProcessResponse(resp any, logger Logger, serviceFactory tc.ServiceFactory, config *gwconfig.Config) (err error) {
@@ -97,15 +61,22 @@ func (s3Artifact *S3Artifact) ProcessResponse(resp any, logger Logger, serviceFa
 
 	logger.Infof("Uploading artifact %v from file %v with content encoding %q, mime type %q and expiry %v", s3Artifact.Name, s3Artifact.Path, s3Artifact.ContentEncoding, s3Artifact.ContentType, s3Artifact.Expires)
 
-	transferContentFile, cleanup := s3Artifact.createTempFileForPUTBody()
-	defer cleanup()
+	// task user copies artifact at Path to ContentPath for task artifacts
+	// and this should be cleaned up after artifact upload
+	tempFileCreated := s3Artifact.Path != s3Artifact.ContentPath
+	if tempFileCreated {
+		defer os.Remove(s3Artifact.ContentPath)
+	}
 
-	defer func() {
-		if s3Artifact.Path != s3Artifact.ContentPath {
-			// If we created a temporary file, delete it.
-			os.Remove(s3Artifact.ContentPath)
-		}
-	}()
+	var transferContentFile string
+	if tempFileCreated && s3Artifact.ContentEncoding != "gzip" {
+		log.Printf("Not copying %v to temp file", s3Artifact.ContentPath)
+		transferContentFile = s3Artifact.ContentPath
+	} else {
+		log.Printf("Copying %v to temp file...", s3Artifact.ContentPath)
+		transferContentFile = s3Artifact.createTempFileForPUTBody()
+		defer os.Remove(transferContentFile)
+	}
 
 	// perform http PUT to upload to S3...
 	httpClient := &http.Client{}


### PR DESCRIPTION
Fixes #7368.

>Generic Worker: increase performance of artifact uploads by removing a redundant file copy operation.

The additional logs should give more insight into #7623.