### PR TITLE
chore(ui): small navigation and filtering tweaks

### DIFF
--- a/changelog/PwkwA18BRaeBP7UfNB95YQ.md
+++ b/changelog/PwkwA18BRaeBP7UfNB95YQ.md
@@ -1,0 +1,4 @@
+audience: users
+level: patch
+---
+UI: don't show `Requested` filter option on `Queue Workers` view, link to `W-M Workers` filtered view when clicking on `Requested Capacity` or `Stopping Capacity` buttons, don't redirect to Worker Manager Worker Pools page after saving Worker Pool config changes.

--- a/ui/src/components/WMWorkerPoolEditor/index.jsx
+++ b/ui/src/components/WMWorkerPoolEditor/index.jsx
@@ -354,8 +354,6 @@ export default class WMWorkerPoolEditor extends Component {
         workerPoolId: joinWorkerPoolId(workerPoolId1, workerPoolId2),
         payload,
       });
-
-      this.props.history.push('/worker-manager');
     } catch (error) {
       this.setState({ error: formatError(error), actionLoading: false });
     }
@@ -420,7 +418,7 @@ export default class WMWorkerPoolEditor extends Component {
         value: requestedCapacity,
         className: 'requestedCapacity',
         Icon: TimerSandIcon,
-        href: `${workerTypeUrl}?filterBy=requested`,
+        href: `${workerPoolUrl}/workers?state=requested`,
       },
       {
         label: 'Running Capacity',
@@ -434,7 +432,7 @@ export default class WMWorkerPoolEditor extends Component {
         value: stoppingCapacity,
         className: 'stoppingCapacity',
         Icon: CloseIcon,
-        href: `${workerTypeUrl}?filterBy=stopping`,
+        href: `${workerPoolUrl}/workers?state=stopping`,
       },
       {
         label: 'Errors',

--- a/ui/src/views/Provisioners/ViewWorkers/index.jsx
+++ b/ui/src/views/Provisioners/ViewWorkers/index.jsx
@@ -25,7 +25,6 @@ import workersQuery from './workers.graphql';
 import WorkersNavbar from '../../../components/WorkersNavbar';
 
 const STATES = {
-  requested: 'requested',
   running: 'running',
   stopping: 'stopping',
   stopped: 'stopped',
@@ -272,7 +271,6 @@ export default class ViewWorkers extends Component {
                   <em>None</em>
                 </MenuItem>
                 <MenuItem value="quarantined">Quarantined</MenuItem>
-                <MenuItem value="requested">Requested</MenuItem>
                 <MenuItem value="running">Running</MenuItem>
                 <MenuItem value="stopping">Stopping</MenuItem>
                 <MenuItem value="stopped">Stopped</MenuItem>


### PR DESCRIPTION
>UI: don't show `Requested` filter option on `Queue Workers` view, link to `W-M Workers` filtered view when clicking on `Requested Capacity` or `Stopping Capacity` buttons, don't redirect to Worker Manager Worker Pools page after saving Worker Pool config changes.