### PR TITLE
Properly truncate logs even if it contains less lines than requested

### DIFF
--- a/changelog/issue-7664.md
+++ b/changelog/issue-7664.md
@@ -1,0 +1,5 @@
+audience: users
+level: patch
+reference: issue 7664
+---
+Fix an issue where taskcluster would try to report checks to github that exceeded the max allowed length if the log contained long lines in its tail

--- a/services/github/src/utils.js
+++ b/services/github/src/utils.js
@@ -225,12 +225,11 @@ export const extractHeadLinesFromLog = (logString, maxPayloadLength) => {
  * @returns string
  */
 export const extractLog = (log, headLines = 20, tailLines = 200, maxPayloadLength = 30000) => {
-
   const logString = ansi2txt(log);
   const lines = logString.split('\n');
   const LOG_BUFFER = 42;
 
-  if (lines.length <= headLines + tailLines) {
+  if (lines.length <= headLines + tailLines && logString.length <= maxPayloadLength) {
     return logString;
   }
 

--- a/services/github/test/utils_test.js
+++ b/services/github/test/utils_test.js
@@ -318,6 +318,18 @@ suite(testing.suiteName(), function() {
     });
   });
 
+  suite('extractLogWithLongLine', function() {
+    test('should get the complete head lines corresponding to the max payload length', function() {
+      const payload = Array.from({ length: 10 }).map(line => `line: ${line}`);
+      payload.push('A'.repeat(100000));
+
+      // Those values (20, 200, 60000) are what the github worker would use in "worst case scenarios".
+      // We append a line that far exceeds that within the `tail+head` of what it tries to get to make
+      // sure that the return value ignores it (doesn't include a cut line, doesn't exceed max payload)
+      assert.equal(extractLog(payload.join('\n'), 20, 200, 60000).length, 159);
+    });
+  });
+
   suite('extractTailLinesFromLog', function() {
     test('should get complete tail lines corresponding to may payload length or taiLines whichever is minimum', function() {
       const payload = Array.from({ length: 4 }, (_, i) => Array(i + 1).fill(`line ${i + 1}`).join(' ')).join('\n');


### PR DESCRIPTION
The `extractLog` function was not respecting `maxPayloadLength` when the number of lines was less than the amount requested, even if the content of said lines were exceeding the max length. Which leads to github rejecting some checks updates if logs had long lines in their tail.

Fixes #7664 