### PR TITLE
fix(d2g): remove unneeded os groups when using kvm

### DIFF
--- a/changelog/issue-7671.md
+++ b/changelog/issue-7671.md
@@ -1,0 +1,5 @@
+audience: worker-deployers
+level: patch
+reference: issue 7671
+---
+D2G: removes unneeded `kvm` and `libvirt` OS groups for generic worker task user if KVM device is requested.

--- a/tools/d2g/d2g.go
+++ b/tools/d2g/d2g.go
@@ -208,7 +208,7 @@ func ConvertPayload(dwPayload *dockerworker.DockerWorkerPayload, config map[stri
 	setMaxRunTime(dwPayload, gwPayload)
 	setOnExitStatus(dwPayload, gwPayload)
 	setSupersederURL(dwPayload, gwPayload)
-	setOSGroups(dwPayload, gwPayload, config)
+	setOSGroups(gwPayload)
 	gwPayload.TaskclusterProxyInterface = "docker-bridge"
 
 	return
@@ -549,12 +549,7 @@ func setSupersederURL(dwPayload *dockerworker.DockerWorkerPayload, gwPayload *ge
 	gwPayload.SupersederURL = dwPayload.SupersederURL
 }
 
-func setOSGroups(dwPayload *dockerworker.DockerWorkerPayload, gwPayload *genericworker.GenericWorkerPayload, config map[string]any) {
-	if dwPayload.Capabilities.Devices.KVM && config["allowKVM"].(bool) {
-		// task user needs to be in kvm and libvirt groups for KVM to work:
-		// https://help.ubuntu.com/community/KVM/Installation
-		gwPayload.OSGroups = append(gwPayload.OSGroups, "kvm", "libvirt")
-	}
+func setOSGroups(gwPayload *genericworker.GenericWorkerPayload) {
 	gwPayload.OSGroups = append(gwPayload.OSGroups, "docker")
 }
 

--- a/tools/d2g/d2gtest/testdata/testcases/devices_tests.yml
+++ b/tools/d2g/d2gtest/testdata/testcases/devices_tests.yml
@@ -138,8 +138,6 @@ testSuite:
         - 125
         - 128
       osGroups:
-      - kvm
-      - libvirt
       - docker
       taskclusterProxyInterface: docker-bridge
     name: KVM

--- a/tools/d2g/d2gtest/testdata/testcases/task_def_test.yml
+++ b/tools/d2g/d2gtest/testdata/testcases/task_def_test.yml
@@ -84,8 +84,6 @@ testSuite:
           - 125
           - 128
         osGroups:
-        - kvm
-        - libvirt
         - docker
         taskclusterProxyInterface: docker-bridge
       priority: lowest
@@ -187,8 +185,6 @@ testSuite:
           - 125
           - 128
         osGroups:
-        - kvm
-        - libvirt
         - docker
         taskclusterProxyInterface: docker-bridge
       priority: lowest
@@ -293,8 +289,6 @@ testSuite:
           - 125
           - 128
         osGroups:
-        - kvm
-        - libvirt
         - docker
         taskclusterProxyInterface: docker-bridge
       priority: lowest

--- a/workers/generic-worker/d2g_test.go
+++ b/workers/generic-worker/d2g_test.go
@@ -340,8 +340,8 @@ func TestD2GWithValidScopes(t *testing.T) {
 		_ = submitAndAssert(t, td, payload, "exception", "malformed-payload")
 		logtext := LogText(t)
 		t.Log(logtext)
-		if !strings.Contains(logtext, "task payload contains unsupported osGroups: [kvm libvirt docker]") {
-			t.Fatalf("Was expecting log file to contain 'task payload contains unsupported osGroups: [kvm libvirt docker]'")
+		if !strings.Contains(logtext, "task payload contains unsupported osGroups: [docker]") {
+			t.Fatalf("Was expecting log file to contain 'task payload contains unsupported osGroups: [docker]'")
 		}
 	default:
 		_ = submitAndAssert(t, td, payload, "exception", "malformed-payload")


### PR DESCRIPTION
Fixes #7671.

>D2G: removes unneeded `kvm` and `libvirt` OS groups for generic worker task user if KVM device is requested.