### PR TITLE
fix(worker-runner): retry worker registration

### DIFF
--- a/changelog/CmIHaI1ASc-83oryuNbZPg.md
+++ b/changelog/CmIHaI1ASc-83oryuNbZPg.md
@@ -1,0 +1,4 @@
+audience: worker-deployers
+level: patch
+---
+Worker Runner: retries to register a worker 3 times and will shutdown if unsuccessful.


### PR DESCRIPTION
>Worker Runner: retries to register a worker 3 times and will shutdown if unsuccessful.