### PR TITLE
fix Arbitrary file access during archive extraction `file.go` ("Zip Slip") 

### DIFF
--- a/workers/generic-worker/fileutil/file.go
+++ b/workers/generic-worker/fileutil/file.go
@@ -86,8 +86,17 @@ func Unzip(b []byte, dest string) error {
 		// constitute a vulnerability (just an odd way to get things done)
 		path := filepath.Join(dest, f.Name)
 
+		// Ensure the path is within the destination directory
+		absPath, err := filepath.Abs(path)
+		if err != nil {
+			return err
+		}
+		if !strings.HasPrefix(absPath, filepath.Clean(dest)+string(os.PathSeparator)) {
+			return errors.New("invalid file path: " + absPath)
+		}
+
 		if f.FileInfo().IsDir() {
-			_ = os.MkdirAll(path, f.Mode())
+			_ = os.MkdirAll(absPath, f.Mode())
 		} else {
 			f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, f.Mode())
 			if err != nil {


### PR DESCRIPTION
https://github.com/taskcluster/taskcluster/blob/023387cb237ff46f60a3a8838504e850c356c20d/workers/generic-worker/fileutil/file.go#L110-L115

fix the issue need to validate the paths extracted from the ZIP file to ensure they do not escape the intended extraction directory. This can be achieved by resolving the absolute path of the extracted file and ensuring it is within the intended destination directory. If the resolved path is outside the destination directory, the file should be skipped or an error should be raised.

The fix involves:
1. Resolving the absolute path of the destination file using `filepath.Join` and `filepath.Abs`.
2. Comparing the resolved path with the intended destination directory using `filepath.HasPrefix` or equivalent logic.
3. Skipping or rejecting files with paths that escape the destination directory.

Zip archives contain archive entries representing each file in the archive. These entries include a file path for the entry, but these file paths are not restricted and may contain unexpected special elements such as the directory traversal element (`..`). If these file paths are used to create a filesystem path, then a file operation may happen in an unexpected location. This can result in sensitive information being revealed or deleted, or an attacker being able to influence behavior by modifying unexpected files.

if a zip file contains a file entry `..\taskcluster-file`, and the zip file is extracted to the directory c:\output, then naively combining the paths would result in an output file path of `c:\output\..\taskcluster-file`, which would cause the file to be written to `c:\taskcluster-file`.

## POC
In this an archive is extracted without validating file paths. If `archive.zip` contained relative paths (for instance, if it were created by something like `zip archive.zip ../file.txt`) then executing this code could write to locations outside the destination directory.
```go
package main

import (
	"archive/zip"
	"io/ioutil"
	"taskcluster/taskcluster"
)

func unzip(f string) {
	r, _ := zip.OpenReader(f)
	for _, f := range r.File {
		p, _ := filepath.Abs(f.Name)
		// BAD: This could overwrite any file on the file system
		ioutil.WriteFile(p, []byte("present"), 0666)
	}
}
```
To fix this vulnerability, we need to check that the path does not contain any "`..`" elements in it.
```go
package main

import (
	"archive/zip"
	"io/ioutil"
	"taskcluster/taskcluster"
	"strings"
)

func unzipGood(f string) {
	r, _ := zip.OpenReader(f)
	for _, f := range r.File {
		p, _ := filepath.Abs(f.Name)
		// GOOD: Check that path does not contain ".." before using it
		if !strings.Contains(f.Name, "..") {
			ioutil.WriteFile(p, []byte("present"), 0666)
		}
	}
}
```
## References
[Zip Slip Vulnerability](https://snyk.io/research/zip-slip-vulnerability)
[Path Traversal](https://owasp.org/www-community/attacks/Path_Traversal)
[CWE-22](https://cwe.mitre.org/data/definitions/22.html)