### PR TITLE
feat(d2g): convert d2g to generic worker task feature

### DIFF
--- a/changelog/issue-7678.md
+++ b/changelog/issue-7678.md
@@ -1,0 +1,5 @@
+audience: worker-deployers
+level: minor
+reference: issue 7678
+---
+D2G: pre and post-task-processing (image pulling/loading/saving, copying artifacts out of container, creating chain of trust additional data file, removing container/volumes, handling max runtime) now happens within the D2G Task Feature in Generic Worker, as opposed to within the resulting translated task payload. This slims the translated task payload to only the `docker run ...` command.

--- a/tools/d2g/d2gtest/testdata/testcases/artifacts_test.yml
+++ b/tools/d2g/d2gtest/testdata/testcases/artifacts_test.yml
@@ -42,16 +42,12 @@ testSuite:
         path: artifact1.txt
         type: file
       command:
-      - - bash
+      - - /usr/bin/env
+        - bash
         - -cx
-        - |-
-          docker pull ubuntu
-          timeout -s KILL 3600 docker run -t --name taskcontainer --memory-swap -1 --pids-limit -1 -e RUN_ID -e TASKCLUSTER_INSTANCE_TYPE -e TASKCLUSTER_ROOT_URL -e TASKCLUSTER_WORKER_LOCATION -e TASK_GROUP_ID -e TASK_ID ubuntu 'echo "Hello world"'
-          exit_code=$?
-          docker cp taskcontainer:'/etc/passwd'\'' artifact0; whoami; echo foo > /root/bar; cp '\''foo' artifact0
-          docker cp taskcontainer:'/home/worker/artifacts/fred.txt' 'artifact1.txt'
-          docker rm -v taskcontainer
-          exit "${exit_code}"
+        - docker run -t --name taskcontainer --memory-swap -1 --pids-limit -1 -e RUN_ID
+          -e TASKCLUSTER_INSTANCE_TYPE -e TASKCLUSTER_ROOT_URL -e TASKCLUSTER_WORKER_LOCATION
+          -e TASK_GROUP_ID -e TASK_ID ubuntu 'echo "Hello world"'
       features:
         backingLog: true
         liveLog: true
@@ -59,7 +55,7 @@ testSuite:
       logs:
         backing: public/logs/live_backing.log
         live: public/logs/live.log
-      maxRunTime: 4500
+      maxRunTime: 3600
       onExitStatus:
         retry:
         - 125
@@ -99,11 +95,12 @@ testSuite:
         path: volume0
         type: directory
       command:
-      - - bash
+      - - /usr/bin/env
+        - bash
         - -cx
-        - |-
-          docker pull ubuntu
-          timeout -s KILL 3600 docker run --rm -t --name taskcontainer --memory-swap -1 --pids-limit -1 -v "$(pwd)/volume0:/home/worker/artifacts" -e RUN_ID -e TASKCLUSTER_INSTANCE_TYPE -e TASKCLUSTER_ROOT_URL -e TASKCLUSTER_WORKER_LOCATION -e TASK_GROUP_ID -e TASK_ID ubuntu 'echo "Hello world"'
+        - docker run -t --name taskcontainer --memory-swap -1 --pids-limit -1 -v "$(pwd)/volume0:/home/worker/artifacts"
+          -e RUN_ID -e TASKCLUSTER_INSTANCE_TYPE -e TASKCLUSTER_ROOT_URL -e TASKCLUSTER_WORKER_LOCATION
+          -e TASK_GROUP_ID -e TASK_ID ubuntu 'echo "Hello world"'
       features:
         backingLog: true
         liveLog: true
@@ -111,7 +108,7 @@ testSuite:
       logs:
         backing: public/logs/live_backing.log
         live: public/logs/live.log
-      maxRunTime: 4500
+      maxRunTime: 3600
       onExitStatus:
         retry:
         - 125

--- a/tools/d2g/d2gtest/testdata/testcases/chain_of_trust_test.yml
+++ b/tools/d2g/d2gtest/testdata/testcases/chain_of_trust_test.yml
@@ -33,12 +33,13 @@ testSuite:
       maxRunTime: 3600
     genericWorkerTaskPayload:
       command:
-      - - bash
+      - - /usr/bin/env
+        - bash
         - -cx
-        - |-
-          docker pull 'my-little/pony:4.1'
-          echo '{"environment":{"imageHash":"'"$(docker inspect --format='{{index .Id}}' 'my-little/pony:4.1')"'"}}' > chain-of-trust-additional-data.json
-          timeout -s KILL 3600 docker run --rm -t --name taskcontainer --memory-swap -1 --pids-limit -1 -e ABC -e GHI -e RUN_ID -e TASKCLUSTER_INSTANCE_TYPE -e TASKCLUSTER_ROOT_URL -e TASKCLUSTER_WORKER_LOCATION -e TASK_GROUP_ID -e TASK_ID 'my-little/pony:4.1' foo bar
+        - docker run -t --name taskcontainer --memory-swap -1 --pids-limit -1 -e ABC
+          -e GHI -e RUN_ID -e TASKCLUSTER_INSTANCE_TYPE -e TASKCLUSTER_ROOT_URL -e
+          TASKCLUSTER_WORKER_LOCATION -e TASK_GROUP_ID -e TASK_ID 'my-little/pony:4.1'
+          foo bar
       env:
         ABC: def
         GHI: jkl
@@ -90,12 +91,13 @@ testSuite:
       maxRunTime: 3600
     genericWorkerTaskPayload:
       command:
-      - - bash
+      - - /usr/bin/env
+        - bash
         - -cx
-        - |-
-          IMAGE_ID=$(docker load --input dockerimage | sed -n '0,/^Loaded image: /s/^Loaded image: //p')
-          echo '{"environment":{"imageHash":"'"$(docker inspect --format='{{index .Id}}' "${IMAGE_ID}")"'","imageArtifactHash":"sha256:'"$(sha256sum dockerimage | sed 's/ .*//')"'"}}' > chain-of-trust-additional-data.json
-          timeout -s KILL 3600 docker run --rm -t --name taskcontainer --memory-swap -1 --pids-limit -1 -e ABC -e GHI -e RUN_ID -e TASKCLUSTER_INSTANCE_TYPE -e TASKCLUSTER_ROOT_URL -e TASKCLUSTER_WORKER_LOCATION -e TASK_GROUP_ID -e TASK_ID "${IMAGE_ID}" foo bar
+        - docker run -t --name taskcontainer --memory-swap -1 --pids-limit -1 -e ABC
+          -e GHI -e RUN_ID -e TASKCLUSTER_INSTANCE_TYPE -e TASKCLUSTER_ROOT_URL -e
+          TASKCLUSTER_WORKER_LOCATION -e TASK_GROUP_ID -e TASK_ID "${D2G_IMAGE_ID}"
+          foo bar
       env:
         ABC: def
         GHI: jkl
@@ -153,12 +155,13 @@ testSuite:
       maxRunTime: 3600
     genericWorkerTaskPayload:
       command:
-      - - bash
+      - - /usr/bin/env
+        - bash
         - -cx
-        - |-
-          IMAGE_ID=$(docker load --input dockerimage | sed -n '0,/^Loaded image: /s/^Loaded image: //p')
-          echo '{"environment":{"imageHash":"'"$(docker inspect --format='{{index .Id}}' "${IMAGE_ID}")"'","imageArtifactHash":"sha256:'"$(sha256sum dockerimage | sed 's/ .*//')"'"}}' > chain-of-trust-additional-data.json
-          timeout -s KILL 3600 docker run --rm -t --name taskcontainer --memory-swap -1 --pids-limit -1 -e ABC -e GHI -e RUN_ID -e TASKCLUSTER_INSTANCE_TYPE -e TASKCLUSTER_ROOT_URL -e TASKCLUSTER_WORKER_LOCATION -e TASK_GROUP_ID -e TASK_ID "${IMAGE_ID}" foo bar
+        - docker run -t --name taskcontainer --memory-swap -1 --pids-limit -1 -e ABC
+          -e GHI -e RUN_ID -e TASKCLUSTER_INSTANCE_TYPE -e TASKCLUSTER_ROOT_URL -e
+          TASKCLUSTER_WORKER_LOCATION -e TASK_GROUP_ID -e TASK_ID "${D2G_IMAGE_ID}"
+          foo bar
       env:
         ABC: def
         GHI: jkl
@@ -212,12 +215,13 @@ testSuite:
       maxRunTime: 3600
     genericWorkerTaskPayload:
       command:
-      - - bash
+      - - /usr/bin/env
+        - bash
         - -cx
-        - |-
-          docker pull 'my-little/pony:4.1'
-          echo '{"environment":{"imageHash":"'"$(docker inspect --format='{{index .Id}}' 'my-little/pony:4.1')"'"}}' > chain-of-trust-additional-data.json
-          timeout -s KILL 3600 docker run --rm -t --name taskcontainer --memory-swap -1 --pids-limit -1 -e ABC -e GHI -e RUN_ID -e TASKCLUSTER_INSTANCE_TYPE -e TASKCLUSTER_ROOT_URL -e TASKCLUSTER_WORKER_LOCATION -e TASK_GROUP_ID -e TASK_ID 'my-little/pony:4.1' foo bar
+        - docker run -t --name taskcontainer --memory-swap -1 --pids-limit -1 -e ABC
+          -e GHI -e RUN_ID -e TASKCLUSTER_INSTANCE_TYPE -e TASKCLUSTER_ROOT_URL -e
+          TASKCLUSTER_WORKER_LOCATION -e TASK_GROUP_ID -e TASK_ID 'my-little/pony:4.1'
+          foo bar
       env:
         ABC: def
         GHI: jkl

--- a/tools/d2g/d2gtest/testdata/testcases/container_engine_test.yml
+++ b/tools/d2g/d2gtest/testdata/testcases/container_engine_test.yml
@@ -25,11 +25,12 @@ testSuite:
       maxRunTime: 3600
     genericWorkerTaskPayload:
       command:
-      - - bash
+      - - /usr/bin/env
+        - bash
         - -cx
-        - |-
-          docker pull ubuntu
-          timeout -s KILL 3600 docker run --rm -t --name taskcontainer --memory-swap -1 --pids-limit -1 -e RUN_ID -e TASKCLUSTER_INSTANCE_TYPE -e TASKCLUSTER_ROOT_URL -e TASKCLUSTER_WORKER_LOCATION -e TASK_GROUP_ID -e TASK_ID ubuntu 'echo "Hello world"'
+        - docker run -t --name taskcontainer --memory-swap -1 --pids-limit -1 -e RUN_ID
+          -e TASKCLUSTER_INSTANCE_TYPE -e TASKCLUSTER_ROOT_URL -e TASKCLUSTER_WORKER_LOCATION
+          -e TASK_GROUP_ID -e TASK_ID ubuntu 'echo "Hello world"'
       features:
         backingLog: true
         liveLog: true

--- a/tools/d2g/d2gtest/testdata/testcases/decision_task_tests.yml
+++ b/tools/d2g/d2gtest/testdata/testcases/decision_task_tests.yml
@@ -81,20 +81,12 @@ testSuite:
         path: image.tar.gz
         type: file
       command:
-      - - bash
+      - - /usr/bin/env
+        - bash
         - -cx
         - |-
-          docker pull 'mozillareleases/gecko_decision:4.0.0@sha256:9f69fe08c28e3cb3cc296451f0a2735df6e25d0e3c877ea735ef1b7f0b345b06'
-          echo '{"environment":{"imageHash":"'"$(docker inspect --format='{{index .Id}}' 'mozillareleases/gecko_decision:4.0.0@sha256:9f69fe08c28e3cb3cc296451f0a2735df6e25d0e3c877ea735ef1b7f0b345b06')"'"}}' > chain-of-trust-additional-data.json
-          timeout -s KILL 3600 docker run -t --name taskcontainer --memory-swap -1 --pids-limit -1 --privileged -v "$(pwd)/cache0:/builds/worker/checkouts" --add-host=taskcluster:host-gateway -e GECKO_BASE_REPOSITORY -e GECKO_BASE_REV -e GECKO_HEAD_REF -e GECKO_HEAD_REPOSITORY -e GECKO_HEAD_REV -e HG_STORE_PATH -e MOZ_AUTOMATION -e PYTHONDONTWRITEBYTECODE -e RUN_ID -e TASKCLUSTER_CACHES -e TASKCLUSTER_INSTANCE_TYPE -e TASKCLUSTER_PROXY_URL -e TASKCLUSTER_ROOT_URL -e TASKCLUSTER_WORKER_LOCATION -e TASK_GROUP_ID -e TASK_ID 'mozillareleases/gecko_decision:4.0.0@sha256:9f69fe08c28e3cb3cc296451f0a2735df6e25d0e3c877ea735ef1b7f0b345b06' /builds/worker/bin/run-task --gecko-checkout=/builds/worker/checkouts/gecko --gecko-sparse-profile=build/sparse-profiles/taskgraph -- bash -cx 'cd /builds/worker/checkouts/gecko && ln -s /builds/worker/artifacts artifacts && ./mach --log-no-times taskgraph decision --pushlog-id='\''40334'\'' --pushdate='\''1666263365'\'' --project='\''mozilla-central'\'' --owner='\''ctuns@mozilla.com'\'' --level='\''3'\'' --tasks-for='\''hg-push'\'' --repository-type=hg --base-repository="$GECKO_BASE_REPOSITORY" --base-rev="$GECKO_BASE_REV" --head-repository="$GECKO_HEAD_REPOSITORY" --head-ref="$GECKO_HEAD_REF" --head-rev="$GECKO_HEAD_REV"
+          docker run -t --name taskcontainer --memory-swap -1 --pids-limit -1 --privileged -v "$(pwd)/cache0:/builds/worker/checkouts" --add-host=taskcluster:host-gateway -e GECKO_BASE_REPOSITORY -e GECKO_BASE_REV -e GECKO_HEAD_REF -e GECKO_HEAD_REPOSITORY -e GECKO_HEAD_REV -e HG_STORE_PATH -e MOZ_AUTOMATION -e PYTHONDONTWRITEBYTECODE -e RUN_ID -e TASKCLUSTER_CACHES -e TASKCLUSTER_INSTANCE_TYPE -e TASKCLUSTER_PROXY_URL -e TASKCLUSTER_ROOT_URL -e TASKCLUSTER_WORKER_LOCATION -e TASK_GROUP_ID -e TASK_ID 'mozillareleases/gecko_decision:4.0.0@sha256:9f69fe08c28e3cb3cc296451f0a2735df6e25d0e3c877ea735ef1b7f0b345b06' /builds/worker/bin/run-task --gecko-checkout=/builds/worker/checkouts/gecko --gecko-sparse-profile=build/sparse-profiles/taskgraph -- bash -cx 'cd /builds/worker/checkouts/gecko && ln -s /builds/worker/artifacts artifacts && ./mach --log-no-times taskgraph decision --pushlog-id='\''40334'\'' --pushdate='\''1666263365'\'' --project='\''mozilla-central'\'' --owner='\''ctuns@mozilla.com'\'' --level='\''3'\'' --tasks-for='\''hg-push'\'' --repository-type=hg --base-repository="$GECKO_BASE_REPOSITORY" --base-rev="$GECKO_BASE_REV" --head-repository="$GECKO_HEAD_REPOSITORY" --head-ref="$GECKO_HEAD_REF" --head-rev="$GECKO_HEAD_REV"
           '
-          exit_code=$?
-          docker cp taskcontainer:/builds/worker/artifacts artifact0
-          docker cp taskcontainer:/builds/worker/checkouts/gecko/docker-contexts artifact1
-          docker commit taskcontainer taskcontainer
-          docker save taskcontainer | gzip > image.tar.gz
-          docker rm -v taskcontainer
-          exit "${exit_code}"
       env:
         GECKO_BASE_REPOSITORY: https://hg.mozilla.org/mozilla-unified
         GECKO_BASE_REV: 330c69218a931b3504d44c867539ed6083521be5
@@ -115,7 +107,7 @@ testSuite:
       logs:
         backing: apple/banana_backing.log
         live: apple/banana.log
-      maxRunTime: 4500
+      maxRunTime: 3600
       mounts:
       - cacheName: gecko-level-3-checkouts-sparse-v3
         directory: cache0

--- a/tools/d2g/d2gtest/testdata/testcases/devices_tests.yml
+++ b/tools/d2g/d2gtest/testdata/testcases/devices_tests.yml
@@ -28,11 +28,12 @@ testSuite:
       maxRunTime: 3600
     genericWorkerTaskPayload:
       command:
-      - - bash
+      - - /usr/bin/env
+        - bash
         - -cx
-        - |-
-          docker pull ubuntu
-          timeout -s KILL 3600 docker run --rm -t --name taskcontainer --memory-swap -1 --pids-limit -1 -v /dev/shm:/dev/shm -e RUN_ID -e TASKCLUSTER_INSTANCE_TYPE -e TASKCLUSTER_ROOT_URL -e TASKCLUSTER_WORKER_LOCATION -e TASK_GROUP_ID -e TASK_ID ubuntu 'echo "Hello world"'
+        - docker run -t --name taskcontainer --memory-swap -1 --pids-limit -1 -v /dev/shm:/dev/shm
+          -e RUN_ID -e TASKCLUSTER_INSTANCE_TYPE -e TASKCLUSTER_ROOT_URL -e TASKCLUSTER_WORKER_LOCATION
+          -e TASK_GROUP_ID -e TASK_ID ubuntu 'echo "Hello world"'
       features:
         backingLog: true
         liveLog: true
@@ -74,11 +75,12 @@ testSuite:
       maxRunTime: 3600
     genericWorkerTaskPayload:
       command:
-      - - bash
+      - - /usr/bin/env
+        - bash
         - -cx
-        - |-
-          docker pull ubuntu
-          timeout -s KILL 3600 docker run --rm -t --name taskcontainer --memory-swap -1 --pids-limit -1 -e RUN_ID -e TASKCLUSTER_INSTANCE_TYPE -e TASKCLUSTER_ROOT_URL -e TASKCLUSTER_WORKER_LOCATION -e TASK_GROUP_ID -e TASK_ID ubuntu 'echo "Hello world"'
+        - docker run -t --name taskcontainer --memory-swap -1 --pids-limit -1 -e RUN_ID
+          -e TASKCLUSTER_INSTANCE_TYPE -e TASKCLUSTER_ROOT_URL -e TASKCLUSTER_WORKER_LOCATION
+          -e TASK_GROUP_ID -e TASK_ID ubuntu 'echo "Hello world"'
       features:
         backingLog: true
         liveLog: true
@@ -120,11 +122,12 @@ testSuite:
       maxRunTime: 3600
     genericWorkerTaskPayload:
       command:
-      - - bash
+      - - /usr/bin/env
+        - bash
         - -cx
-        - |-
-          docker pull ubuntu
-          timeout -s KILL 3600 docker run --rm -t --name taskcontainer --memory-swap -1 --pids-limit -1 --device=/dev/kvm -e RUN_ID -e TASKCLUSTER_INSTANCE_TYPE -e TASKCLUSTER_ROOT_URL -e TASKCLUSTER_WORKER_LOCATION -e TASK_GROUP_ID -e TASK_ID ubuntu 'echo "Hello world"'
+        - docker run -t --name taskcontainer --memory-swap -1 --pids-limit -1 --device=/dev/kvm
+          -e RUN_ID -e TASKCLUSTER_INSTANCE_TYPE -e TASKCLUSTER_ROOT_URL -e TASKCLUSTER_WORKER_LOCATION
+          -e TASK_GROUP_ID -e TASK_ID ubuntu 'echo "Hello world"'
       features:
         backingLog: true
         liveLog: true
@@ -166,11 +169,12 @@ testSuite:
       maxRunTime: 3600
     genericWorkerTaskPayload:
       command:
-      - - bash
+      - - /usr/bin/env
+        - bash
         - -cx
-        - |-
-          docker pull ubuntu
-          timeout -s KILL 3600 docker run --rm -t --name taskcontainer --memory-swap -1 --pids-limit -1 -e RUN_ID -e TASKCLUSTER_INSTANCE_TYPE -e TASKCLUSTER_ROOT_URL -e TASKCLUSTER_WORKER_LOCATION -e TASK_GROUP_ID -e TASK_ID ubuntu 'echo "Hello world"'
+        - docker run -t --name taskcontainer --memory-swap -1 --pids-limit -1 -e RUN_ID
+          -e TASKCLUSTER_INSTANCE_TYPE -e TASKCLUSTER_ROOT_URL -e TASKCLUSTER_WORKER_LOCATION
+          -e TASK_GROUP_ID -e TASK_ID ubuntu 'echo "Hello world"'
       features:
         backingLog: true
         liveLog: true
@@ -212,11 +216,13 @@ testSuite:
       maxRunTime: 3600
     genericWorkerTaskPayload:
       command:
-      - - bash
+      - - /usr/bin/env
+        - bash
         - -cx
-        - |-
-          docker pull ubuntu
-          timeout -s KILL 3600 docker run --rm -t --name taskcontainer --memory-swap -1 --pids-limit -1 --device="${TASKCLUSTER_VIDEO_DEVICE}" -e RUN_ID -e TASKCLUSTER_INSTANCE_TYPE -e TASKCLUSTER_ROOT_URL -e TASKCLUSTER_VIDEO_DEVICE -e TASKCLUSTER_WORKER_LOCATION -e TASK_GROUP_ID -e TASK_ID ubuntu 'echo "Hello world"'
+        - docker run -t --name taskcontainer --memory-swap -1 --pids-limit -1 --device="${TASKCLUSTER_VIDEO_DEVICE}"
+          -e RUN_ID -e TASKCLUSTER_INSTANCE_TYPE -e TASKCLUSTER_ROOT_URL -e TASKCLUSTER_VIDEO_DEVICE
+          -e TASKCLUSTER_WORKER_LOCATION -e TASK_GROUP_ID -e TASK_ID ubuntu 'echo
+          "Hello world"'
       features:
         backingLog: true
         liveLog: true
@@ -259,11 +265,12 @@ testSuite:
       maxRunTime: 3600
     genericWorkerTaskPayload:
       command:
-      - - bash
+      - - /usr/bin/env
+        - bash
         - -cx
-        - |-
-          docker pull ubuntu
-          timeout -s KILL 3600 docker run --rm -t --name taskcontainer --memory-swap -1 --pids-limit -1 -e RUN_ID -e TASKCLUSTER_INSTANCE_TYPE -e TASKCLUSTER_ROOT_URL -e TASKCLUSTER_WORKER_LOCATION -e TASK_GROUP_ID -e TASK_ID ubuntu 'echo "Hello world"'
+        - docker run -t --name taskcontainer --memory-swap -1 --pids-limit -1 -e RUN_ID
+          -e TASKCLUSTER_INSTANCE_TYPE -e TASKCLUSTER_ROOT_URL -e TASKCLUSTER_WORKER_LOCATION
+          -e TASK_GROUP_ID -e TASK_ID ubuntu 'echo "Hello world"'
       features:
         backingLog: true
         liveLog: true
@@ -305,11 +312,12 @@ testSuite:
       maxRunTime: 3600
     genericWorkerTaskPayload:
       command:
-      - - bash
+      - - /usr/bin/env
+        - bash
         - -cx
-        - |-
-          docker pull ubuntu
-          timeout -s KILL 3600 docker run --rm -t --name taskcontainer --memory-swap -1 --pids-limit -1 --device=/dev/snd -e RUN_ID -e TASKCLUSTER_INSTANCE_TYPE -e TASKCLUSTER_ROOT_URL -e TASKCLUSTER_WORKER_LOCATION -e TASK_GROUP_ID -e TASK_ID ubuntu 'echo "Hello world"'
+        - docker run -t --name taskcontainer --memory-swap -1 --pids-limit -1 --device=/dev/snd
+          -e RUN_ID -e TASKCLUSTER_INSTANCE_TYPE -e TASKCLUSTER_ROOT_URL -e TASKCLUSTER_WORKER_LOCATION
+          -e TASK_GROUP_ID -e TASK_ID ubuntu 'echo "Hello world"'
       features:
         backingLog: true
         liveLog: true
@@ -352,11 +360,12 @@ testSuite:
       maxRunTime: 3600
     genericWorkerTaskPayload:
       command:
-      - - bash
+      - - /usr/bin/env
+        - bash
         - -cx
-        - |-
-          docker pull ubuntu
-          timeout -s KILL 3600 docker run --rm -t --name taskcontainer --memory-swap -1 --pids-limit -1 -e RUN_ID -e TASKCLUSTER_INSTANCE_TYPE -e TASKCLUSTER_ROOT_URL -e TASKCLUSTER_WORKER_LOCATION -e TASK_GROUP_ID -e TASK_ID ubuntu 'echo "Hello world"'
+        - docker run -t --name taskcontainer --memory-swap -1 --pids-limit -1 -e RUN_ID
+          -e TASKCLUSTER_INSTANCE_TYPE -e TASKCLUSTER_ROOT_URL -e TASKCLUSTER_WORKER_LOCATION
+          -e TASK_GROUP_ID -e TASK_ID ubuntu 'echo "Hello world"'
       features:
         backingLog: true
         liveLog: true
@@ -395,11 +404,12 @@ testSuite:
       maxRunTime: 3600
     genericWorkerTaskPayload:
       command:
-      - - bash
+      - - /usr/bin/env
+        - bash
         - -cx
-        - |-
-          docker pull ubuntu
-          timeout -s KILL 3600 docker run --rm -t --name taskcontainer --memory-swap -1 --pids-limit -1 --gpus all -e RUN_ID -e TASKCLUSTER_INSTANCE_TYPE -e TASKCLUSTER_ROOT_URL -e TASKCLUSTER_WORKER_LOCATION -e TASK_GROUP_ID -e TASK_ID ubuntu 'echo "Hello world"'
+        - docker run -t --name taskcontainer --memory-swap -1 --pids-limit -1 --gpus
+          all -e RUN_ID -e TASKCLUSTER_INSTANCE_TYPE -e TASKCLUSTER_ROOT_URL -e TASKCLUSTER_WORKER_LOCATION
+          -e TASK_GROUP_ID -e TASK_ID ubuntu 'echo "Hello world"'
       features:
         backingLog: true
         liveLog: true
@@ -438,11 +448,13 @@ testSuite:
       maxRunTime: 3600
     genericWorkerTaskPayload:
       command:
-      - - bash
+      - - /usr/bin/env
+        - bash
         - -cx
-        - |-
-          docker pull ubuntu
-          timeout -s KILL 3600 docker run --rm -t --name taskcontainer --memory-swap -1 --pids-limit -1 --gpus device=GPU-3a23c669-1f69-c64e-cf85-44e9b07e7a2a -e RUN_ID -e TASKCLUSTER_INSTANCE_TYPE -e TASKCLUSTER_ROOT_URL -e TASKCLUSTER_WORKER_LOCATION -e TASK_GROUP_ID -e TASK_ID ubuntu 'echo "Hello world"'
+        - docker run -t --name taskcontainer --memory-swap -1 --pids-limit -1 --gpus
+          device=GPU-3a23c669-1f69-c64e-cf85-44e9b07e7a2a -e RUN_ID -e TASKCLUSTER_INSTANCE_TYPE
+          -e TASKCLUSTER_ROOT_URL -e TASKCLUSTER_WORKER_LOCATION -e TASK_GROUP_ID
+          -e TASK_ID ubuntu 'echo "Hello world"'
       features:
         backingLog: true
         liveLog: true

--- a/tools/d2g/d2gtest/testdata/testcases/docker_image_tests.yml
+++ b/tools/d2g/d2gtest/testdata/testcases/docker_image_tests.yml
@@ -23,11 +23,12 @@ testSuite:
       maxRunTime: 3600
     genericWorkerTaskPayload:
       command:
-      - - bash
+      - - /usr/bin/env
+        - bash
         - -cx
-        - |-
-          docker pull ubuntu
-          timeout -s KILL 3600 docker run --rm -t --name taskcontainer --memory-swap -1 --pids-limit -1 -e RUN_ID -e TASKCLUSTER_INSTANCE_TYPE -e TASKCLUSTER_ROOT_URL -e TASKCLUSTER_WORKER_LOCATION -e TASK_GROUP_ID -e TASK_ID ubuntu 'echo "Hello world"'
+        - docker run -t --name taskcontainer --memory-swap -1 --pids-limit -1 -e RUN_ID
+          -e TASKCLUSTER_INSTANCE_TYPE -e TASKCLUSTER_ROOT_URL -e TASKCLUSTER_WORKER_LOCATION
+          -e TASK_GROUP_ID -e TASK_ID ubuntu 'echo "Hello world"'
       features:
         backingLog: true
         liveLog: true
@@ -67,11 +68,12 @@ testSuite:
       maxRunTime: 3600
     genericWorkerTaskPayload:
       command:
-      - - bash
+      - - /usr/bin/env
+        - bash
         - -cx
-        - |-
-          docker pull ubuntu
-          timeout -s KILL 3600 docker run --rm -t --name taskcontainer --memory-swap -1 --pids-limit -1 -e RUN_ID -e TASKCLUSTER_INSTANCE_TYPE -e TASKCLUSTER_ROOT_URL -e TASKCLUSTER_WORKER_LOCATION -e TASK_GROUP_ID -e TASK_ID ubuntu 'echo "Hello world"'
+        - docker run -t --name taskcontainer --memory-swap -1 --pids-limit -1 -e RUN_ID
+          -e TASKCLUSTER_INSTANCE_TYPE -e TASKCLUSTER_ROOT_URL -e TASKCLUSTER_WORKER_LOCATION
+          -e TASK_GROUP_ID -e TASK_ID ubuntu 'echo "Hello world"'
       features:
         backingLog: true
         liveLog: true
@@ -112,11 +114,12 @@ testSuite:
       maxRunTime: 3600
     genericWorkerTaskPayload:
       command:
-      - - bash
+      - - /usr/bin/env
+        - bash
         - -cx
-        - |-
-          IMAGE_ID=$(docker load --input dockerimage | sed -n '0,/^Loaded image: /s/^Loaded image: //p')
-          timeout -s KILL 3600 docker run --rm -t --name taskcontainer --memory-swap -1 --pids-limit -1 -e RUN_ID -e TASKCLUSTER_INSTANCE_TYPE -e TASKCLUSTER_ROOT_URL -e TASKCLUSTER_WORKER_LOCATION -e TASK_GROUP_ID -e TASK_ID "${IMAGE_ID}" 'echo "Hello world"'
+        - docker run -t --name taskcontainer --memory-swap -1 --pids-limit -1 -e RUN_ID
+          -e TASKCLUSTER_INSTANCE_TYPE -e TASKCLUSTER_ROOT_URL -e TASKCLUSTER_WORKER_LOCATION
+          -e TASK_GROUP_ID -e TASK_ID "${D2G_IMAGE_ID}" 'echo "Hello world"'
       features:
         backingLog: true
         liveLog: true
@@ -163,11 +166,12 @@ testSuite:
       maxRunTime: 3600
     genericWorkerTaskPayload:
       command:
-      - - bash
+      - - /usr/bin/env
+        - bash
         - -cx
-        - |-
-          IMAGE_ID=$(docker load --input dockerimage | sed -n '0,/^Loaded image: /s/^Loaded image: //p')
-          timeout -s KILL 3600 docker run --rm -t --name taskcontainer --memory-swap -1 --pids-limit -1 -e RUN_ID -e TASKCLUSTER_INSTANCE_TYPE -e TASKCLUSTER_ROOT_URL -e TASKCLUSTER_WORKER_LOCATION -e TASK_GROUP_ID -e TASK_ID "${IMAGE_ID}" 'echo "Hello world"'
+        - docker run -t --name taskcontainer --memory-swap -1 --pids-limit -1 -e RUN_ID
+          -e TASKCLUSTER_INSTANCE_TYPE -e TASKCLUSTER_ROOT_URL -e TASKCLUSTER_WORKER_LOCATION
+          -e TASK_GROUP_ID -e TASK_ID "${D2G_IMAGE_ID}" 'echo "Hello world"'
       features:
         backingLog: true
         liveLog: true
@@ -215,11 +219,12 @@ testSuite:
       maxRunTime: 3600
     genericWorkerTaskPayload:
       command:
-      - - bash
+      - - /usr/bin/env
+        - bash
         - -cx
-        - |-
-          IMAGE_ID=$(docker load --input dockerimage | sed -n '0,/^Loaded image: /s/^Loaded image: //p')
-          timeout -s KILL 3600 docker run --rm -t --name taskcontainer --memory-swap -1 --pids-limit -1 -e RUN_ID -e TASKCLUSTER_INSTANCE_TYPE -e TASKCLUSTER_ROOT_URL -e TASKCLUSTER_WORKER_LOCATION -e TASK_GROUP_ID -e TASK_ID "${IMAGE_ID}" 'echo "Hello world"'
+        - docker run -t --name taskcontainer --memory-swap -1 --pids-limit -1 -e RUN_ID
+          -e TASKCLUSTER_INSTANCE_TYPE -e TASKCLUSTER_ROOT_URL -e TASKCLUSTER_WORKER_LOCATION
+          -e TASK_GROUP_ID -e TASK_ID "${D2G_IMAGE_ID}" 'echo "Hello world"'
       features:
         backingLog: true
         liveLog: true
@@ -266,11 +271,12 @@ testSuite:
       maxRunTime: 3600
     genericWorkerTaskPayload:
       command:
-      - - bash
+      - - /usr/bin/env
+        - bash
         - -cx
-        - |-
-          IMAGE_ID=$(docker load --input dockerimage | sed -n '0,/^Loaded image: /s/^Loaded image: //p')
-          timeout -s KILL 3600 docker run --rm -t --name taskcontainer --memory-swap -1 --pids-limit -1 -e RUN_ID -e TASKCLUSTER_INSTANCE_TYPE -e TASKCLUSTER_ROOT_URL -e TASKCLUSTER_WORKER_LOCATION -e TASK_GROUP_ID -e TASK_ID "${IMAGE_ID}" 'echo "Hello world"'
+        - docker run -t --name taskcontainer --memory-swap -1 --pids-limit -1 -e RUN_ID
+          -e TASKCLUSTER_INSTANCE_TYPE -e TASKCLUSTER_ROOT_URL -e TASKCLUSTER_WORKER_LOCATION
+          -e TASK_GROUP_ID -e TASK_ID "${D2G_IMAGE_ID}" 'echo "Hello world"'
       features:
         backingLog: true
         liveLog: true
@@ -316,11 +322,12 @@ testSuite:
       maxRunTime: 3600
     genericWorkerTaskPayload:
       command:
-      - - bash
+      - - /usr/bin/env
+        - bash
         - -cx
-        - |-
-          IMAGE_ID=$(docker load --input dockerimage | sed -n '0,/^Loaded image: /s/^Loaded image: //p')
-          timeout -s KILL 3600 docker run --rm -t --name taskcontainer --memory-swap -1 --pids-limit -1 -e RUN_ID -e TASKCLUSTER_INSTANCE_TYPE -e TASKCLUSTER_ROOT_URL -e TASKCLUSTER_WORKER_LOCATION -e TASK_GROUP_ID -e TASK_ID "${IMAGE_ID}" 'echo "Hello world"'
+        - docker run -t --name taskcontainer --memory-swap -1 --pids-limit -1 -e RUN_ID
+          -e TASKCLUSTER_INSTANCE_TYPE -e TASKCLUSTER_ROOT_URL -e TASKCLUSTER_WORKER_LOCATION
+          -e TASK_GROUP_ID -e TASK_ID "${D2G_IMAGE_ID}" 'echo "Hello world"'
       features:
         backingLog: true
         liveLog: true
@@ -367,11 +374,12 @@ testSuite:
       maxRunTime: 3600
     genericWorkerTaskPayload:
       command:
-      - - bash
+      - - /usr/bin/env
+        - bash
         - -cx
-        - |-
-          IMAGE_ID=$(docker load --input dockerimage | sed -n '0,/^Loaded image: /s/^Loaded image: //p')
-          timeout -s KILL 3600 docker run --rm -t --name taskcontainer --memory-swap -1 --pids-limit -1 -e RUN_ID -e TASKCLUSTER_INSTANCE_TYPE -e TASKCLUSTER_ROOT_URL -e TASKCLUSTER_WORKER_LOCATION -e TASK_GROUP_ID -e TASK_ID "${IMAGE_ID}" 'echo "Hello world"'
+        - docker run -t --name taskcontainer --memory-swap -1 --pids-limit -1 -e RUN_ID
+          -e TASKCLUSTER_INSTANCE_TYPE -e TASKCLUSTER_ROOT_URL -e TASKCLUSTER_WORKER_LOCATION
+          -e TASK_GROUP_ID -e TASK_ID "${D2G_IMAGE_ID}" 'echo "Hello world"'
       features:
         backingLog: true
         liveLog: true
@@ -419,11 +427,12 @@ testSuite:
       maxRunTime: 3600
     genericWorkerTaskPayload:
       command:
-      - - bash
+      - - /usr/bin/env
+        - bash
         - -cx
-        - |-
-          IMAGE_ID=$(docker load --input dockerimage | sed -n '0,/^Loaded image: /s/^Loaded image: //p')
-          timeout -s KILL 3600 docker run --rm -t --name taskcontainer --memory-swap -1 --pids-limit -1 -v "$(pwd)/cache0:/builds/worker/checkouts" -e RUN_ID -e TASKCLUSTER_INSTANCE_TYPE -e TASKCLUSTER_ROOT_URL -e TASKCLUSTER_WORKER_LOCATION -e TASK_GROUP_ID -e TASK_ID "${IMAGE_ID}" 'echo "Hello world"'
+        - docker run -t --name taskcontainer --memory-swap -1 --pids-limit -1 -v "$(pwd)/cache0:/builds/worker/checkouts"
+          -e RUN_ID -e TASKCLUSTER_INSTANCE_TYPE -e TASKCLUSTER_ROOT_URL -e TASKCLUSTER_WORKER_LOCATION
+          -e TASK_GROUP_ID -e TASK_ID "${D2G_IMAGE_ID}" 'echo "Hello world"'
       features:
         backingLog: true
         liveLog: true

--- a/tools/d2g/d2gtest/testdata/testcases/dw_features_tests.yml
+++ b/tools/d2g/d2gtest/testdata/testcases/dw_features_tests.yml
@@ -28,11 +28,14 @@ testSuite:
       maxRunTime: 3600
     genericWorkerTaskPayload:
       command:
-      - - bash
+      - - /usr/bin/env
+        - bash
         - -cx
-        - |-
-          docker pull ubuntu
-          timeout -s KILL 3600 docker run --rm -t --name taskcontainer --memory-swap -1 --pids-limit -1 --cap-add=SYS_PTRACE --security-opt=seccomp=unconfined --add-host=taskcluster:host-gateway -e RUN_ID -e TASKCLUSTER_INSTANCE_TYPE -e TASKCLUSTER_PROXY_URL -e TASKCLUSTER_ROOT_URL -e TASKCLUSTER_WORKER_LOCATION -e TASK_GROUP_ID -e TASK_ID ubuntu 'echo "Hello world"'
+        - docker run -t --name taskcontainer --memory-swap -1 --pids-limit -1 --cap-add=SYS_PTRACE
+          --security-opt=seccomp=unconfined --add-host=taskcluster:host-gateway -e
+          RUN_ID -e TASKCLUSTER_INSTANCE_TYPE -e TASKCLUSTER_PROXY_URL -e TASKCLUSTER_ROOT_URL
+          -e TASKCLUSTER_WORKER_LOCATION -e TASK_GROUP_ID -e TASK_ID ubuntu 'echo
+          "Hello world"'
       features:
         backingLog: true
         liveLog: true
@@ -77,11 +80,12 @@ testSuite:
       maxRunTime: 3600
     genericWorkerTaskPayload:
       command:
-      - - bash
+      - - /usr/bin/env
+        - bash
         - -cx
-        - |-
-          docker pull ubuntu
-          timeout -s KILL 3600 docker run --rm -t --name taskcontainer --memory-swap -1 --pids-limit -1 -e RUN_ID -e TASKCLUSTER_INSTANCE_TYPE -e TASKCLUSTER_ROOT_URL -e TASKCLUSTER_WORKER_LOCATION -e TASK_GROUP_ID -e TASK_ID ubuntu 'echo "Hello world"'
+        - docker run -t --name taskcontainer --memory-swap -1 --pids-limit -1 -e RUN_ID
+          -e TASKCLUSTER_INSTANCE_TYPE -e TASKCLUSTER_ROOT_URL -e TASKCLUSTER_WORKER_LOCATION
+          -e TASK_GROUP_ID -e TASK_ID ubuntu 'echo "Hello world"'
       features:
         backingLog: true
         liveLog: true
@@ -121,11 +125,12 @@ testSuite:
       maxRunTime: 3600
     genericWorkerTaskPayload:
       command:
-      - - bash
+      - - /usr/bin/env
+        - bash
         - -cx
-        - |-
-          docker pull ubuntu
-          timeout -s KILL 3600 docker run --rm -t --name taskcontainer --memory-swap -1 --pids-limit -1 --privileged -e RUN_ID -e TASKCLUSTER_INSTANCE_TYPE -e TASKCLUSTER_ROOT_URL -e TASKCLUSTER_WORKER_LOCATION -e TASK_GROUP_ID -e TASK_ID ubuntu 'echo "Hello world"'
+        - docker run -t --name taskcontainer --memory-swap -1 --pids-limit -1 --privileged
+          -e RUN_ID -e TASKCLUSTER_INSTANCE_TYPE -e TASKCLUSTER_ROOT_URL -e TASKCLUSTER_WORKER_LOCATION
+          -e TASK_GROUP_ID -e TASK_ID ubuntu 'echo "Hello world"'
       features:
         backingLog: true
         liveLog: true
@@ -166,11 +171,12 @@ testSuite:
       maxRunTime: 3600
     genericWorkerTaskPayload:
       command:
-      - - bash
+      - - /usr/bin/env
+        - bash
         - -cx
-        - |-
-          docker pull ubuntu
-          timeout -s KILL 3600 docker run --rm -t --name taskcontainer --memory-swap -1 --pids-limit -1 -e RUN_ID -e TASKCLUSTER_INSTANCE_TYPE -e TASKCLUSTER_ROOT_URL -e TASKCLUSTER_WORKER_LOCATION -e TASK_GROUP_ID -e TASK_ID ubuntu 'echo "Hello world"'
+        - docker run -t --name taskcontainer --memory-swap -1 --pids-limit -1 -e RUN_ID
+          -e TASKCLUSTER_INSTANCE_TYPE -e TASKCLUSTER_ROOT_URL -e TASKCLUSTER_WORKER_LOCATION
+          -e TASK_GROUP_ID -e TASK_ID ubuntu 'echo "Hello world"'
       features:
         backingLog: true
         liveLog: true

--- a/tools/d2g/d2gtest/testdata/testcases/env_escaping_test.yml
+++ b/tools/d2g/d2gtest/testdata/testcases/env_escaping_test.yml
@@ -26,11 +26,13 @@ testSuite:
       maxRunTime: 3600
     genericWorkerTaskPayload:
       command:
-      - - bash
+      - - /usr/bin/env
+        - bash
         - -cx
-        - |-
-          docker pull ubuntu
-          timeout -s KILL 3600 docker run --rm -t --name taskcontainer --memory-swap -1 --pids-limit -1 -e ' test123 --help  ; whoami ; ' -e RUN_ID -e TASKCLUSTER_INSTANCE_TYPE -e TASKCLUSTER_ROOT_URL -e TASKCLUSTER_WORKER_LOCATION -e TASK_GROUP_ID -e TASK_ID ubuntu 'echo "Hello world"'
+        - docker run -t --name taskcontainer --memory-swap -1 --pids-limit -1 -e '
+          test123 --help  ; whoami ; ' -e RUN_ID -e TASKCLUSTER_INSTANCE_TYPE -e TASKCLUSTER_ROOT_URL
+          -e TASKCLUSTER_WORKER_LOCATION -e TASK_GROUP_ID -e TASK_ID ubuntu 'echo
+          "Hello world"'
       env:
         ' test123 --help  ; whoami ; ': testing
       features:

--- a/tools/d2g/d2gtest/testdata/testcases/fuzzing_tests.yml
+++ b/tools/d2g/d2gtest/testdata/testcases/fuzzing_tests.yml
@@ -48,16 +48,15 @@ testSuite:
         path: artifact0
         type: directory
       command:
-      - - bash
+      - - /usr/bin/env
+        - bash
         - -cx
-        - "IMAGE_ID=$(docker load --input dockerimage | sed -n '0,/^Loaded image:
-          /s/^Loaded image: //p')\ntimeout -s KILL 14400 docker run -t --name taskcontainer
-          --memory-swap -1 --pids-limit -1 --privileged --security-opt=seccomp=unconfined
-          -v /dev/shm:/dev/shm --device=/dev/snd --add-host=taskcluster:host-gateway
-          -e BUG_ACTION -e MONITOR_ARTIFACT -e PROCESSOR_ARTIFACT -e RUN_ID -e TASKCLUSTER_INSTANCE_TYPE
-          -e TASKCLUSTER_PROXY_URL -e TASKCLUSTER_ROOT_URL -e TASKCLUSTER_WORKER_LOCATION
-          -e TASK_GROUP_ID -e TASK_ID \"${IMAGE_ID}\" \nexit_code=$?\ndocker cp taskcontainer:/bugmon-artifacts/
-          artifact0\ndocker rm -v taskcontainer\nexit \"${exit_code}\""
+        - 'docker run -t --name taskcontainer --memory-swap -1 --pids-limit -1 --privileged
+          --security-opt=seccomp=unconfined -v /dev/shm:/dev/shm --device=/dev/snd
+          --add-host=taskcluster:host-gateway -e BUG_ACTION -e MONITOR_ARTIFACT -e
+          PROCESSOR_ARTIFACT -e RUN_ID -e TASKCLUSTER_INSTANCE_TYPE -e TASKCLUSTER_PROXY_URL
+          -e TASKCLUSTER_ROOT_URL -e TASKCLUSTER_WORKER_LOCATION -e TASK_GROUP_ID
+          -e TASK_ID "${D2G_IMAGE_ID}" '
       env:
         BUG_ACTION: process
         MONITOR_ARTIFACT: monitor-1881157-dnCUWpVmTzC-dQguT0njPQ.json
@@ -71,7 +70,7 @@ testSuite:
       logs:
         backing: public/logs/live_backing.log
         live: public/logs/live.log
-      maxRunTime: 15300
+      maxRunTime: 14400
       mounts:
       - content:
           artifact: public/bugmon.tar.zst

--- a/tools/d2g/d2gtest/testdata/testcases/no_artifacts_test.yml
+++ b/tools/d2g/d2gtest/testdata/testcases/no_artifacts_test.yml
@@ -31,11 +31,12 @@ testSuite:
       maxRunTime: 3600
     genericWorkerTaskPayload:
       command:
-      - - bash
+      - - /usr/bin/env
+        - bash
         - -cx
-        - |-
-          docker pull ubuntu
-          timeout -s KILL 3600 docker run --rm -t --name taskcontainer --memory-swap -1 --pids-limit -1 -e RUN_ID -e TASKCLUSTER_INSTANCE_TYPE -e TASKCLUSTER_ROOT_URL -e TASKCLUSTER_WORKER_LOCATION -e TASK_GROUP_ID -e TASK_ID ubuntu 'echo "Hello world"'
+        - docker run -t --name taskcontainer --memory-swap -1 --pids-limit -1 -e RUN_ID
+          -e TASKCLUSTER_INSTANCE_TYPE -e TASKCLUSTER_ROOT_URL -e TASKCLUSTER_WORKER_LOCATION
+          -e TASK_GROUP_ID -e TASK_ID ubuntu 'echo "Hello world"'
       features:
         backingLog: false
         liveLog: false

--- a/tools/d2g/d2gtest/testdata/testcases/task_def_test.yml
+++ b/tools/d2g/d2gtest/testdata/testcases/task_def_test.yml
@@ -66,11 +66,13 @@ testSuite:
         source: https://community-tc.services.mozilla.com/tasks/create
       payload:
         command:
-        - - bash
+        - - /usr/bin/env
+          - bash
           - -cx
-          - |-
-            docker pull ubuntu:latest
-            timeout -s KILL 630 docker run --rm -t --name taskcontainer --memory-swap -1 --pids-limit -1 --device=/dev/kvm -e RUN_ID -e TASKCLUSTER_INSTANCE_TYPE -e TASKCLUSTER_ROOT_URL -e TASKCLUSTER_WORKER_LOCATION -e TASK_GROUP_ID -e TASK_ID ubuntu:latest /bin/bash -c 'for ((i=1;i<=600;i++)); do echo $i; sleep 1; done'
+          - docker run -t --name taskcontainer --memory-swap -1 --pids-limit -1 --device=/dev/kvm
+            -e RUN_ID -e TASKCLUSTER_INSTANCE_TYPE -e TASKCLUSTER_ROOT_URL -e TASKCLUSTER_WORKER_LOCATION
+            -e TASK_GROUP_ID -e TASK_ID ubuntu:latest /bin/bash -c 'for ((i=1;i<=600;i++));
+            do echo $i; sleep 1; done'
         features:
           backingLog: true
           liveLog: true
@@ -167,11 +169,13 @@ testSuite:
         source: https://community-tc.services.mozilla.com/tasks/create
       payload:
         command:
-        - - bash
+        - - /usr/bin/env
+          - bash
           - -cx
-          - |-
-            docker pull ubuntu:latest
-            timeout -s KILL 630 docker run --rm -t --name taskcontainer --memory-swap -1 --pids-limit -1 --device=/dev/kvm -e RUN_ID -e TASKCLUSTER_INSTANCE_TYPE -e TASKCLUSTER_ROOT_URL -e TASKCLUSTER_WORKER_LOCATION -e TASK_GROUP_ID -e TASK_ID ubuntu:latest /bin/bash -c 'for ((i=1;i<=600;i++)); do echo $i; sleep 1; done'
+          - docker run -t --name taskcontainer --memory-swap -1 --pids-limit -1 --device=/dev/kvm
+            -e RUN_ID -e TASKCLUSTER_INSTANCE_TYPE -e TASKCLUSTER_ROOT_URL -e TASKCLUSTER_WORKER_LOCATION
+            -e TASK_GROUP_ID -e TASK_ID ubuntu:latest /bin/bash -c 'for ((i=1;i<=600;i++));
+            do echo $i; sleep 1; done'
         features:
           backingLog: true
           liveLog: true
@@ -271,11 +275,13 @@ testSuite:
         source: https://community-tc.services.mozilla.com/tasks/create
       payload:
         command:
-        - - bash
+        - - /usr/bin/env
+          - bash
           - -cx
-          - |-
-            docker pull ubuntu:latest
-            timeout -s KILL 630 docker run --rm -t --name taskcontainer --memory-swap -1 --pids-limit -1 --device=/dev/kvm -e RUN_ID -e TASKCLUSTER_INSTANCE_TYPE -e TASKCLUSTER_ROOT_URL -e TASKCLUSTER_WORKER_LOCATION -e TASK_GROUP_ID -e TASK_ID ubuntu:latest /bin/bash -c 'for ((i=1;i<=600;i++)); do echo $i; sleep 1; done'
+          - docker run -t --name taskcontainer --memory-swap -1 --pids-limit -1 --device=/dev/kvm
+            -e RUN_ID -e TASKCLUSTER_INSTANCE_TYPE -e TASKCLUSTER_ROOT_URL -e TASKCLUSTER_WORKER_LOCATION
+            -e TASK_GROUP_ID -e TASK_ID ubuntu:latest /bin/bash -c 'for ((i=1;i<=600;i++));
+            do echo $i; sleep 1; done'
         features:
           backingLog: true
           liveLog: true

--- a/tools/d2g/dockerimageartifact.go
+++ b/tools/d2g/dockerimageartifact.go
@@ -39,7 +39,7 @@ func (dia *DockerImageArtifact) FileMounts() ([]genericworker.FileMount, error) 
 }
 
 func (dia *DockerImageArtifact) String() string {
-	return `"${IMAGE_ID}"`
+	return `"${D2G_IMAGE_ID}"`
 }
 
 func (dia *DockerImageArtifact) ImageLoader() ImageLoader {

--- a/tools/d2g/indexeddockerimage.go
+++ b/tools/d2g/indexeddockerimage.go
@@ -46,7 +46,7 @@ func (idi *IndexedDockerImage) ImageLoader() ImageLoader {
 }
 
 func (idi *IndexedDockerImage) String() string {
-	return `"${IMAGE_ID}"`
+	return `"${D2G_IMAGE_ID}"`
 }
 
 func fileExtension(path string) string {

--- a/workers/generic-worker/artifact_feature.go
+++ b/workers/generic-worker/artifact_feature.go
@@ -71,13 +71,13 @@ func (atf *ArtifactTaskFeature) Stop(err *ExecutionErrors) {
 				task.Warnf("Not uploading artifact %v found in task.payload.artifacts section, since this will be uploaded later by %v", artifact.Base().Name, feature)
 				return
 			}
-			err := task.uploadArtifact(artifact)
-			if err != nil {
+			e := task.uploadArtifact(artifact)
+			if e != nil {
 				// we don't care about optional artifacts failing to upload
 				if artifact.Base().Optional {
 					return
 				}
-				uploadErrChan <- err
+				uploadErrChan <- e
 			}
 			// Note - the above error only covers not being able to upload an
 			// artifact, but doesn't cover case that an artifact could not be

--- a/workers/generic-worker/d2g_feature.go
+++ b/workers/generic-worker/d2g_feature.go
@@ -1,0 +1,159 @@
+//go:build linux
+
+package main
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/taskcluster/taskcluster/v83/internal/scopes"
+	"github.com/taskcluster/taskcluster/v83/workers/generic-worker/process"
+)
+
+type (
+	D2GFeature struct {
+	}
+
+	D2GTaskFeature struct {
+		task *TaskRun
+	}
+)
+
+func (df *D2GFeature) Name() string {
+	return "D2G"
+}
+
+func (df *D2GFeature) Initialise() error {
+	return nil
+}
+
+func (df *D2GFeature) IsEnabled() bool {
+	return config.D2GEnabled()
+}
+
+func (df *D2GFeature) IsRequested(task *TaskRun) bool {
+	return task.D2GInfo != nil
+}
+
+func (df *D2GFeature) NewTaskFeature(task *TaskRun) TaskFeature {
+	return &D2GTaskFeature{
+		task: task,
+	}
+}
+
+func (dtf *D2GTaskFeature) ReservedArtifacts() []string {
+	return []string{}
+}
+
+func (dtf *D2GTaskFeature) RequiredScopes() scopes.Required {
+	return scopes.Required{}
+}
+
+func (dtf *D2GTaskFeature) Start() *CommandExecutionError {
+	imageLoader := dtf.task.D2GInfo.Image.ImageLoader()
+	cmd, err := process.NewCommandNoOutputStreams([]string{
+		"/usr/bin/env",
+		"bash",
+		"-c",
+		imageLoader.LoadCommand(),
+	}, taskContext.TaskDir, []string{}, dtf.task.pd)
+	if err != nil {
+		return executionError(internalError, errored, fmt.Errorf("could not create process to load docker image: %v", err))
+	}
+	out, err := cmd.Output()
+	if err != nil {
+		return executionError(internalError, errored, fmt.Errorf("could not load docker image: %v\n%v", err, string(out)))
+	}
+
+	imageID := strings.TrimSpace(string(out))
+
+	if dtf.task.Payload.Env == nil {
+		dtf.task.Payload.Env = make(map[string]string)
+	}
+
+	dtf.task.Payload.Env["D2G_IMAGE_ID"] = imageID
+	err = dtf.task.setVariable("D2G_IMAGE_ID", imageID)
+	if err != nil {
+		return executionError(internalError, errored, fmt.Errorf("could not set D2G_IMAGE_ID environment variable: %v", err))
+	}
+
+	if dtf.task.DockerWorkerPayload.Features.ChainOfTrust {
+		cmd, err := process.NewCommandNoOutputStreams([]string{
+			"/usr/bin/env",
+			"bash",
+			"-c",
+			imageLoader.ChainOfTrustCommand(),
+		}, taskContext.TaskDir, []string{fmt.Sprintf("D2G_IMAGE_ID=%s", imageID)}, dtf.task.pd)
+		if err != nil {
+			return executionError(internalError, errored, fmt.Errorf("could not create process to create chain of trust additional data file: %v", err))
+		}
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			return executionError(internalError, errored, fmt.Errorf("could not create chain of trust additional data file: %v\n%v", err, string(out)))
+		}
+	}
+	return nil
+}
+
+func (dtf *D2GTaskFeature) Stop(err *ExecutionErrors) {
+	if dtf.task.DockerWorkerPayload.Features.DockerSave {
+		cmd, e := process.NewCommandNoOutputStreams([]string{
+			"docker",
+			"commit",
+			dtf.task.D2GInfo.ContainerName,
+			dtf.task.D2GInfo.ContainerName,
+		}, taskContext.TaskDir, []string{}, dtf.task.pd)
+		if e != nil {
+			err.add(executionError(internalError, errored, fmt.Errorf("could not create process to commit docker container: %v", e)))
+		}
+		out, e := cmd.CombinedOutput()
+		if e != nil {
+			err.add(executionError(internalError, errored, fmt.Errorf("could not commit docker container: %v\n%v", e, string(out))))
+		}
+
+		cmd, e = process.NewCommandNoOutputStreams([]string{
+			"/usr/bin/env",
+			"bash",
+			"-c",
+			fmt.Sprintf("docker save %s | gzip > image.tar.gz", dtf.task.D2GInfo.ContainerName),
+		}, taskContext.TaskDir, []string{}, dtf.task.pd)
+		if e != nil {
+			err.add(executionError(internalError, errored, fmt.Errorf("could not create process to save docker image: %v", e)))
+		}
+		out, e = cmd.CombinedOutput()
+		if e != nil {
+			err.add(executionError(internalError, errored, fmt.Errorf("could not save docker image: %v\n%v", e, string(out))))
+		}
+	}
+
+	for _, artifact := range dtf.task.D2GInfo.CopyArtifacts {
+		cmd, e := process.NewCommandNoOutputStreams([]string{
+			"docker",
+			"cp",
+			fmt.Sprintf("%s:%s", dtf.task.D2GInfo.ContainerName, artifact.SrcPath),
+			artifact.DestPath,
+		}, taskContext.TaskDir, []string{}, dtf.task.pd)
+		if e != nil {
+			err.add(executionError(internalError, errored, fmt.Errorf("could not create process to copy artifact: %v", e)))
+		}
+		out, e := cmd.CombinedOutput()
+		if e != nil {
+			dtf.task.Warnf("Artifact %q not found at %q: %v\n%v", artifact.Name, artifact.SrcPath, e, string(out))
+		}
+	}
+
+	cmd, e := process.NewCommandNoOutputStreams([]string{
+		"docker",
+		"rm",
+		"--force",
+		"--volumes",
+		dtf.task.D2GInfo.ContainerName,
+	}, taskContext.TaskDir, []string{}, dtf.task.pd)
+	if e != nil {
+		err.add(executionError(internalError, errored, fmt.Errorf("could not create process to remove docker container: %v", e)))
+	}
+	out, e := cmd.CombinedOutput()
+	if e != nil {
+		err.add(executionError(internalError, errored, fmt.Errorf("could not remove docker container: %v\n%v", e, string(out))))
+	}
+}

--- a/workers/generic-worker/helper_test.go
+++ b/workers/generic-worker/helper_test.go
@@ -28,7 +28,6 @@ import (
 	"github.com/taskcluster/taskcluster/v83/clients/client-go/tcqueue"
 	"github.com/taskcluster/taskcluster/v83/internal/mocktc"
 	"github.com/taskcluster/taskcluster/v83/internal/mocktc/tc"
-	"github.com/taskcluster/taskcluster/v83/tools/d2g"
 	"github.com/taskcluster/taskcluster/v83/tools/d2g/dockerworker"
 	"github.com/taskcluster/taskcluster/v83/workers/generic-worker/fileutil"
 	"github.com/taskcluster/taskcluster/v83/workers/generic-worker/gwconfig"
@@ -339,7 +338,6 @@ type (
 
 func GWTest(t *testing.T) *Test {
 	t.Helper()
-	d2g.MaxArtifactCopyDuration = 30
 	testConfig := &gwconfig.Config{
 		PrivateConfig: gwconfig.PrivateConfig{
 			AccessToken: os.Getenv("TASKCLUSTER_ACCESS_TOKEN"),

--- a/workers/generic-worker/insecure_linux.go
+++ b/workers/generic-worker/insecure_linux.go
@@ -6,5 +6,13 @@ func platformFeatures() []Feature {
 	return []Feature{
 		&LoopbackAudioFeature{},
 		&LoopbackVideoFeature{},
+		// ArtifactFeature second-to-last in the list, to match previous behaviour.
+		// It may be possible to move further up at some point, but then task
+		// log comments might need to be adjusted (since they refer to other
+		// features running later in the Stop() method).
+		&ArtifactFeature{},
+		// D2GFeature last in the list so that ArtifactFeature can upload
+		// any artifacts copied out of the container.
+		&D2GFeature{},
 	}
 }

--- a/workers/generic-worker/insecure_other.go
+++ b/workers/generic-worker/insecure_other.go
@@ -3,5 +3,11 @@
 package main
 
 func platformFeatures() []Feature {
-	return []Feature{}
+	return []Feature{
+		// ArtifactFeature last in the list, to match previous behaviour. It
+		// may be possible to move further up at some point, but then task
+		// log comments might need to be adjusted (since they refer to other
+		// features running later in the Stop() method).
+		&ArtifactFeature{},
+	}
 }

--- a/workers/generic-worker/main.go
+++ b/workers/generic-worker/main.go
@@ -80,14 +80,6 @@ func initialiseFeatures() (err error) {
 		&InteractiveFeature{},
 	}
 	features = append(features, platformFeatures()...)
-	features = append(
-		features,
-		// ArtifactFeature last in the list, to match previous behaviour. It
-		// may be possible to move further up at some point, but then task
-		// log comments might need to be adjusted (since they refer to other
-		// features running later in the Stop() method).
-		&ArtifactFeature{},
-	)
 	for _, feature := range features {
 		log.Printf("Initialising task feature %v...", feature.Name())
 		err := feature.Initialise()

--- a/workers/generic-worker/model.go
+++ b/workers/generic-worker/model.go
@@ -9,6 +9,7 @@ import (
 	"github.com/taskcluster/taskcluster/v83/clients/client-go/tcqueue"
 	"github.com/taskcluster/taskcluster/v83/internal/mocktc/tc"
 	"github.com/taskcluster/taskcluster/v83/tools/d2g"
+	"github.com/taskcluster/taskcluster/v83/tools/d2g/dockerworker"
 	"github.com/taskcluster/taskcluster/v83/workers/generic-worker/artifacts"
 	"github.com/taskcluster/taskcluster/v83/workers/generic-worker/process"
 )
@@ -46,8 +47,9 @@ type (
 		// the feature name that caused the upload to be skipped, which may
 		// be useful for the user. Normally this map would get appended to by
 		// features when they are started.
-		featureArtifacts map[string]string
-		D2GInfo          *d2g.ConversionInfo `json:"-"`
+		featureArtifacts    map[string]string
+		D2GInfo             *d2g.ConversionInfo               `json:"-"`
+		DockerWorkerPayload *dockerworker.DockerWorkerPayload `json:"-"`
 	}
 
 	TaskStatus       string

--- a/workers/generic-worker/multiuser_linux.go
+++ b/workers/generic-worker/multiuser_linux.go
@@ -15,5 +15,13 @@ func platformFeatures() []Feature {
 		// of signing key file, and a feature could change them, so we want these
 		// checks as late as possible
 		&ChainOfTrustFeature{},
+		// ArtifactFeature second-to-last in the list, to match previous behaviour.
+		// It may be possible to move further up at some point, but then task
+		// log comments might need to be adjusted (since they refer to other
+		// features running later in the Stop() method).
+		&ArtifactFeature{},
+		// D2GFeature last in the list so that ArtifactFeature can upload
+		// any artifacts copied out of the container.
+		&D2GFeature{},
 	}
 }

--- a/workers/generic-worker/multiuser_other.go
+++ b/workers/generic-worker/multiuser_other.go
@@ -9,5 +9,10 @@ func platformFeatures() []Feature {
 		// of signing key file, and a feature could change them, so we want these
 		// checks as late as possible
 		&ChainOfTrustFeature{},
+		// ArtifactFeature last in the list, to match previous behaviour. It
+		// may be possible to move further up at some point, but then task
+		// log comments might need to be adjusted (since they refer to other
+		// features running later in the Stop() method).
+		&ArtifactFeature{},
 	}
 }

--- a/workers/generic-worker/multiuser_windows.go
+++ b/workers/generic-worker/multiuser_windows.go
@@ -37,6 +37,11 @@ func platformFeatures() []Feature {
 		// of signing key file, and a feature could change them, so we want these
 		// checks as late as possible
 		&ChainOfTrustFeature{},
+		// ArtifactFeature last in the list, to match previous behaviour. It
+		// may be possible to move further up at some point, but then task
+		// log comments might need to be adjusted (since they refer to other
+		// features running later in the Stop() method).
+		&ArtifactFeature{},
 	}
 }
 

--- a/workers/generic-worker/payload_linux.go
+++ b/workers/generic-worker/payload_linux.go
@@ -16,9 +16,9 @@ func (task *TaskRun) convertDockerWorkerPayload() *CommandExecutionError {
 	jsonPayload := task.Definition.Payload
 
 	// Convert the validated JSON input
-	dwPayload := new(dockerworker.DockerWorkerPayload)
-	defaults.SetDefaults(dwPayload)
-	err := json.Unmarshal(jsonPayload, &dwPayload)
+	task.DockerWorkerPayload = new(dockerworker.DockerWorkerPayload)
+	defaults.SetDefaults(task.DockerWorkerPayload)
+	err := json.Unmarshal(jsonPayload, &task.DockerWorkerPayload)
 	if err != nil {
 		return MalformedPayloadError(err)
 	}
@@ -34,13 +34,13 @@ func (task *TaskRun) convertDockerWorkerPayload() *CommandExecutionError {
 	// Validate that the required docker worker scopes
 	// are present for the given docker worker payload
 	// and then convert dwScopes to gwScopes
-	task.Definition.Scopes, err = d2g.ConvertScopes(task.Definition.Scopes, dwPayload, taskQueueID, serviceFactory.Auth(config.Credentials(), config.RootURL))
+	task.Definition.Scopes, err = d2g.ConvertScopes(task.Definition.Scopes, task.DockerWorkerPayload, taskQueueID, serviceFactory.Auth(config.Credentials(), config.RootURL))
 	if err != nil {
 		return MalformedPayloadError(err)
 	}
 
-	// Convert dwPayload to gwPayload
-	gwPayload, conversionInfo, err := d2g.ConvertPayload(dwPayload, config.D2GConfig)
+	// Convert task.DockerWorkerPayload to gwPayload
+	gwPayload, conversionInfo, err := d2g.ConvertPayload(task.DockerWorkerPayload, config.D2GConfig)
 	if err != nil {
 		return executionError(internalError, errored, fmt.Errorf("failed to convert docker worker payload to a generic worker payload: %v", err))
 	}

--- a/workers/generic-worker/process/insecure.go
+++ b/workers/generic-worker/process/insecure.go
@@ -3,6 +3,7 @@
 package process
 
 import (
+	"os"
 	"os/exec"
 	"syscall"
 
@@ -38,6 +39,16 @@ func newCommand(f func() *exec.Cmd, workingDirectory string, env []string) (*Com
 }
 
 func NewCommand(commandLine []string, workingDirectory string, env []string) (*Command, error) {
+	f := func() *exec.Cmd {
+		cmd := exec.Command(commandLine[0], commandLine[1:]...)
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+		return cmd
+	}
+	return newCommand(f, workingDirectory, env)
+}
+
+func NewCommandNoOutputStreams(commandLine []string, workingDirectory string, env []string, platformData *PlatformData) (*Command, error) {
 	f := func() *exec.Cmd {
 		return exec.Command(commandLine[0], commandLine[1:]...)
 	}


### PR DESCRIPTION
Fixes #7678.
Fixes #7599.

>D2G: pre and post-task-processing (image pulling/loading/saving, copying artifacts out of container, creating chain of trust additional data file, removing container/volumes, handling max runtime) now happens within the D2G Task Feature in Generic Worker, as opposed to within the resulting translated task payload. This slims the translated task payload to only the `docker run ...` command.