### PR TITLE
Properly reap the proxy process when stopping the feature

### DIFF
--- a/changelog/issue-5786.md
+++ b/changelog/issue-5786.md
@@ -1,0 +1,5 @@
+audience: worker-deployers
+level: patch
+reference: issue 5786
+---
+Properly reap proxy processes when stopping the taskcluster proxy feature

--- a/workers/generic-worker/tcproxy/tcproxy.go
+++ b/workers/generic-worker/tcproxy/tcproxy.go
@@ -67,6 +67,10 @@ func (l *TaskclusterProxy) Terminate() error {
 		return nil
 	}
 	defer func() {
+		_, err := l.command.Process.Wait()
+		if err != nil {
+			log.Printf("Error while waiting for taskcluster proxy to stop: %v", err)
+		}
 		log.Printf("Stopped taskcluster proxy process (PID %v)", l.Pid)
 		l.HTTPPort = 0
 		l.Pid = 0


### PR DESCRIPTION
On posix systems, when killing a child process, the parent process has to call `wait(2)` on it or the child process will be left in a "zombie" state until the parent exits, at which point PID 1 will do that.

For generic worker, it means that every time it starts a proxy, it leaks one zombie as it's never waiting for it until it gets restarted which in some cases could be never (headless multiuser, insecure engine).

By simply calling `Wait` on the proxy process after killing it, it now ends up calling `wait(2)` on it, reaping it. We simply ignore the actual return status and print an error in case something went horribly wrong.

I got bitten by this this weekend where after processing a few hundred tasks, linux was just refusing to start new processes leading to the worker being unable to complete any task.

Fixes #5786
