### PR TITLE
feat(generic-worker): add metadata task feature for data on recent task run

### DIFF
--- a/changelog/issue-7628.md
+++ b/changelog/issue-7628.md
@@ -1,0 +1,15 @@
+audience: worker-deployers
+level: minor
+reference: issue 7628
+---
+Generic Worker: adds a `Metadata` feature (controlled with worker config `enableMetadata` [default: `true`], not controllable in the task payload) that writes out a file `generic-worker-metadata.json` (in the current working directory of the generic worker process) containing information about the last task run.
+
+Currently, the file will look something like this:
+
+```json
+{
+	"lastTaskUrl": "https://firefox-ci-tc.services.mozilla.com/tasks/Klc17PU-TMmo4axlfihKJQ/runs/0"
+}
+```
+
+Additional data may be added to this file in future releases.

--- a/ui/docs/reference/workers/generic-worker/usage.mdx
+++ b/ui/docs/reference/workers/generic-worker/usage.mdx
@@ -192,6 +192,11 @@ and reports back results to the queue.
                                             task payload. [default: true]
           enableLiveLog                     Enables the LiveLog feature to be used in the task
                                             payload. [default: true]
+          enableMetadata                    Enables the Metadata feature to have generic worker
+                                            write out a file "generic-worker-metadata.json"
+                                            (in the current working directory of the generic
+                                            worker process) containing information about the
+                                            last task run. [default: true]
           enableMounts                      Enables the Mounts feature to be used in the task
                                             payload. [default: true]
           enableOSGroups                    Enables the OS Groups feature to be used in the task

--- a/workers/generic-worker/README.md
+++ b/workers/generic-worker/README.md
@@ -193,6 +193,11 @@ and reports back results to the queue.
                                             task payload. [default: true]
           enableLiveLog                     Enables the LiveLog feature to be used in the task
                                             payload. [default: true]
+          enableMetadata                    Enables the Metadata feature to have generic worker
+                                            write out a file "generic-worker-metadata.json"
+                                            (in the current working directory of the generic
+                                            worker process) containing information about the
+                                            last task run. [default: true]
           enableMounts                      Enables the Mounts feature to be used in the task
                                             payload. [default: true]
           enableOSGroups                    Enables the OS Groups feature to be used in the task

--- a/workers/generic-worker/gwconfig/config.go
+++ b/workers/generic-worker/gwconfig/config.go
@@ -41,6 +41,7 @@ type (
 		EnableChainOfTrust             bool           `json:"enableChainOfTrust"`
 		EnableInteractive              bool           `json:"enableInteractive"`
 		EnableLiveLog                  bool           `json:"enableLiveLog"`
+		EnableMetadata                 bool           `json:"enableMetadata"`
 		EnableMounts                   bool           `json:"enableMounts"`
 		EnableOSGroups                 bool           `json:"enableOSGroups"`
 		EnableResourceMonitor          bool           `json:"enableResourceMonitor"`

--- a/workers/generic-worker/helper_test.go
+++ b/workers/generic-worker/helper_test.go
@@ -359,6 +359,7 @@ func GWTest(t *testing.T) *Test {
 			DownloadsDir:              filepath.Join(cwd, "downloads"),
 			EnableChainOfTrust:        true,
 			EnableLiveLog:             true,
+			EnableMetadata:            true,
 			EnableMounts:              true,
 			EnableOSGroups:            true,
 			EnableResourceMonitor:     true,

--- a/workers/generic-worker/main.go
+++ b/workers/generic-worker/main.go
@@ -78,6 +78,7 @@ func initialiseFeatures() (err error) {
 		&MountsFeature{},
 		&ResourceMonitorFeature{},
 		&InteractiveFeature{},
+		&MetadataFeature{},
 	}
 	features = append(features, platformFeatures()...)
 	for _, feature := range features {
@@ -222,6 +223,7 @@ func loadConfig(configFile *gwconfig.File) error {
 			EnableChainOfTrust:             true,
 			EnableInteractive:              true,
 			EnableLiveLog:                  true,
+			EnableMetadata:                 true,
 			EnableMounts:                   true,
 			EnableOSGroups:                 true,
 			EnableResourceMonitor:          true,

--- a/workers/generic-worker/metadata_feature.go
+++ b/workers/generic-worker/metadata_feature.go
@@ -1,0 +1,72 @@
+package main
+
+import (
+	"fmt"
+	"path/filepath"
+
+	"github.com/taskcluster/taskcluster/v83/internal/scopes"
+	"github.com/taskcluster/taskcluster/v83/workers/generic-worker/fileutil"
+)
+
+var metadataFilename = filepath.Join(cwd, "generic-worker-metadata.json")
+
+type (
+	MetadataFeature struct {
+	}
+
+	MetadataTaskFeature struct {
+		task *TaskRun
+		info *MetadataInfo
+	}
+
+	MetadataInfo struct {
+		LastTaskURL string `json:"lastTaskUrl"`
+	}
+)
+
+func (mf *MetadataFeature) Name() string {
+	return "Metadata"
+}
+
+func (mf *MetadataFeature) Initialise() error {
+	return nil
+}
+
+func (mf *MetadataFeature) IsEnabled() bool {
+	return config.EnableMetadata
+}
+
+func (mf *MetadataFeature) IsRequested(task *TaskRun) bool {
+	return true
+}
+
+func (mf *MetadataFeature) NewTaskFeature(task *TaskRun) TaskFeature {
+	return &MetadataTaskFeature{
+		task: task,
+	}
+}
+
+func (mtf *MetadataTaskFeature) ReservedArtifacts() []string {
+	return []string{}
+}
+
+func (mtf *MetadataTaskFeature) RequiredScopes() scopes.Required {
+	return scopes.Required{}
+}
+
+func (mtf *MetadataTaskFeature) Start() *CommandExecutionError {
+	return nil
+}
+
+func (mtf *MetadataTaskFeature) Stop(err *ExecutionErrors) {
+	mtf.info = &MetadataInfo{
+		LastTaskURL: fmt.Sprintf("%v/tasks/%v/runs/%v", config.RootURL, mtf.task.TaskID, mtf.task.RunID),
+	}
+
+	e := fileutil.WriteToFileAsJSON(mtf.info, metadataFilename)
+	// if we can't write this, something seriously wrong, so cause worker to
+	// report an internal-error to sentry and crash!
+	if e != nil {
+		panic(err)
+	}
+}

--- a/workers/generic-worker/usage.go
+++ b/workers/generic-worker/usage.go
@@ -186,6 +186,11 @@ and reports back results to the queue.
                                             task payload. [default: true]
           enableLiveLog                     Enables the LiveLog feature to be used in the task
                                             payload. [default: true]
+          enableMetadata                    Enables the Metadata feature to have generic worker
+                                            write out a file "generic-worker-metadata.json"
+                                            (in the current working directory of the generic
+                                            worker process) containing information about the
+                                            last task run. [default: true]
           enableMounts                      Enables the Mounts feature to be used in the task
                                             payload. [default: true]
           enableOSGroups                    Enables the OS Groups feature to be used in the task


### PR DESCRIPTION
Fixes https://github.com/taskcluster/taskcluster/issues/7628.

>Generic Worker: adds a `Metadata` feature (controlled with worker config `enableMetadata` [default: `true`], not controllable in the task payload) that writes out a file `generic-worker-metadata.json` (in the current working directory of the generic worker process) containing information about the last task run.
>
>Currently, the file will look something like this:
>
>```json
>{
>	"lastTaskUrl": "https://firefox-ci-tc.services.mozilla.com/tasks/Klc17PU-TMmo4axlfihKJQ/runs/0"
>}
>```
>
>Additional data may be added to this file in future releases.