### PR TITLE
chore(d2g): remove D2G warnings/logs

### DIFF
--- a/changelog/WRhF7-PBTZSXxbpUkHvzhw.md
+++ b/changelog/WRhF7-PBTZSXxbpUkHvzhw.md
@@ -1,0 +1,4 @@
+audience: users
+level: patch
+---
+Generic Worker (D2G): no longer logs translated payload and our recommendation to migrate all tasks to Generic Worker payload format. Worker config `d2gConfig.logTranslation` is now unused and will be removed in a future release.

--- a/ui/docs/reference/workers/generic-worker/usage.mdx
+++ b/ui/docs/reference/workers/generic-worker/usage.mdx
@@ -186,7 +186,7 @@ and reports back results to the queue.
                                               * allowTaskclusterProxy - Allows Taskcluster Proxy. [default: true]
                                               * gpus - The NVIDIA GPUs to make available to the running container.
                                                 Only used if allowGPUs is true. [default: "all"]
-                                              * logTranslation - Logs the D2G-translated task definition to the task logs.
+                                              * logTranslation (unused) - Logs the D2G-translated task definition to the task logs.
                                                 [default: true]
           enableChainOfTrust                Enables the Chain of Trust feature to be used in the
                                             task payload. [default: true]

--- a/workers/generic-worker/README.md
+++ b/workers/generic-worker/README.md
@@ -187,7 +187,7 @@ and reports back results to the queue.
                                               * allowTaskclusterProxy - Allows Taskcluster Proxy. [default: true]
                                               * gpus - The NVIDIA GPUs to make available to the running container.
                                                 Only used if allowGPUs is true. [default: "all"]
-                                              * logTranslation - Logs the D2G-translated task definition to the task logs.
+                                              * logTranslation (unused) - Logs the D2G-translated task definition to the task logs.
                                                 [default: true]
           enableChainOfTrust                Enables the Chain of Trust feature to be used in the
                                             task payload. [default: true]

--- a/workers/generic-worker/gwconfig/config_linux.go
+++ b/workers/generic-worker/gwconfig/config_linux.go
@@ -51,7 +51,3 @@ func (c *PublicPlatformConfig) EnableD2G(t *testing.T) {
 func (c *PublicPlatformConfig) NativePayloadsDisabled() bool {
 	return c.DisableNativePayloads
 }
-
-func (c *PublicPlatformConfig) LogD2GTranslation() bool {
-	return c.D2GConfig["logTranslation"].(bool)
-}

--- a/workers/generic-worker/gwconfig/config_other.go
+++ b/workers/generic-worker/gwconfig/config_other.go
@@ -24,7 +24,3 @@ func (c *PublicPlatformConfig) EnableD2G(t *testing.T) {
 func (c *PublicPlatformConfig) NativePayloadsDisabled() bool {
 	return false
 }
-
-func (c *PublicPlatformConfig) LogD2GTranslation() bool {
-	return false
-}

--- a/workers/generic-worker/gwconfig/config_windows.go
+++ b/workers/generic-worker/gwconfig/config_windows.go
@@ -27,7 +27,3 @@ func (c *PublicPlatformConfig) EnableD2G(t *testing.T) {
 func (c *PublicPlatformConfig) NativePayloadsDisabled() bool {
 	return false
 }
-
-func (c *PublicPlatformConfig) LogD2GTranslation() bool {
-	return false
-}

--- a/workers/generic-worker/payload_linux.go
+++ b/workers/generic-worker/payload_linux.go
@@ -7,9 +7,6 @@ import (
 	"github.com/mcuadros/go-defaults"
 	"github.com/taskcluster/taskcluster/v83/tools/d2g"
 	"github.com/taskcluster/taskcluster/v83/tools/d2g/dockerworker"
-	"github.com/taskcluster/taskcluster/v83/tools/jsonschema2go/text"
-
-	"sigs.k8s.io/yaml"
 )
 
 func (task *TaskRun) convertDockerWorkerPayload() *CommandExecutionError {
@@ -63,36 +60,6 @@ func (task *TaskRun) convertDockerWorkerPayload() *CommandExecutionError {
 	}
 
 	task.Definition.Payload = json.RawMessage(d2gConvertedPayloadJSON)
-
-	// Convert full task definition to JSON
-	d2gConvertedTaskDefinitionJSON, err := json.MarshalIndent(task.Definition, "", "  ")
-	if err != nil {
-		return executionError(malformedPayload, errored, fmt.Errorf("cannot marshal d2g converted task definition %#v to JSON: %s", task.Definition, err))
-	}
-
-	d2gConvertedTaskDefinitionYAML, err := yaml.JSONToYAML(d2gConvertedTaskDefinitionJSON)
-	if err != nil {
-		return executionError(internalError, errored, fmt.Errorf("could not convert task definition from JSON to YAML: %v", err))
-	}
-
-	if !config.NativePayloadsDisabled() {
-		task.Warn("This task was designed to run under Docker Worker. Docker Worker is no longer maintained.")
-		task.Warn("In order to execute this task, it is being converted to a Generic Worker task, using the D2G")
-		task.Warn("utility (Docker Worker 2 Generic Worker):")
-		task.Warn("    https://github.com/taskcluster/taskcluster/tree/main/clients/client-shell#translating-docker-worker-task-definitionpayload-to-generic-worker-task-definitionpayload")
-		task.Warn("")
-		task.Warn("We recommend that you convert all your Docker Worker tasks to Generic Worker tasks, to ensure")
-		task.Warn("continued support. For this task, see the converted payload below. If you have many tasks that")
-		task.Warn("require conversion, consider using the d2g tool (above) directly. It simply takes a Docker")
-		task.Warn("Worker task payload as input, and outputs a Generic Worker task payload. It can also convert")
-		task.Warn("Docker Worker scopes to equivalent Generic Worker scopes.")
-		task.Warn("")
-	}
-
-	if config.LogD2GTranslation() {
-		task.Warn("Converted task definition (conversion performed by d2g):\n---\n" + text.Indent(string(d2gConvertedTaskDefinitionYAML), "  "))
-	}
-
 	task.D2GInfo = &conversionInfo
 
 	return nil

--- a/workers/generic-worker/usage_linux.go
+++ b/workers/generic-worker/usage_linux.go
@@ -28,7 +28,7 @@ func d2gConfig() string {
                                               * allowTaskclusterProxy - Allows Taskcluster Proxy. [default: true]
                                               * gpus - The NVIDIA GPUs to make available to the running container.
                                                 Only used if allowGPUs is true. [default: "all"]
-                                              * logTranslation - Logs the D2G-translated task definition to the task logs.
+                                              * logTranslation (unused) - Logs the D2G-translated task definition to the task logs.
                                                 [default: true]`
 }
 


### PR DESCRIPTION
>Generic Worker (D2G): no longer logs translated payload and our recommendation to migrate all tasks to Generic Worker payload format. Worker config `d2gConfig.logTranslation` is now unused and will be removed in a future release.