### PR TITLE
chore(generic-worker): remove potential future variable shadowing issues in artifact feature

### DIFF
--- a/changelog/D269EGPRTcu5qphZJ66W6A.md
+++ b/changelog/D269EGPRTcu5qphZJ66W6A.md
@@ -1,0 +1,3 @@
+audience: general
+level: silent
+---

--- a/workers/generic-worker/artifact_feature.go
+++ b/workers/generic-worker/artifact_feature.go
@@ -88,7 +88,7 @@ func (atf *ArtifactTaskFeature) Stop(err *ExecutionErrors) {
 	var wg sync.WaitGroup
 	uploadErrChan := make(chan *CommandExecutionError, len(taskArtifacts))
 	failChan := make(chan *CommandExecutionError, len(taskArtifacts))
-	for _, artifact := range taskArtifacts {
+	for _, taskArtifact := range taskArtifacts {
 		wg.Add(1)
 		go func(artifact artifacts.TaskArtifact) {
 			defer wg.Done()
@@ -124,7 +124,7 @@ func (atf *ArtifactTaskFeature) Stop(err *ExecutionErrors) {
 				failChan <- fail
 				task.Errorf("TASK FAILURE during artifact upload: %v", fail)
 			}
-		}(artifact)
+		}(taskArtifact)
 	}
 
 	wg.Wait()


### PR DESCRIPTION
While reading through the artifact feature code, I realized that we could potentially run into a variable shadowing issue due to conflicting variable names for the task artifacts we're looping over and the input to the goroutine that handles the upload.