### PR TITLE
feat(generic-worker): parallelize file scanning for artifacts

### DIFF
--- a/changelog/issue-7630.md
+++ b/changelog/issue-7630.md
@@ -1,0 +1,5 @@
+audience: worker-deployers
+level: patch
+reference: issue 7630
+---
+Generic Worker: improves artifact upload process by parallelizing the scanning of the system for file/directory artifacts from the payload.

--- a/workers/generic-worker/artifacts/artifacts.go
+++ b/workers/generic-worker/artifacts/artifacts.go
@@ -43,6 +43,14 @@ type (
 		// FinishArtifact calls queue.FinishArtifact if necessary for the artifact type
 		FinishArtifact(response any, queue tc.Queue, taskID, runID, name string) error
 
+		// String returns a string representation of the artifact type
+		// with all properties.
+		//
+		// For example, String for S3Artifact would look something like:
+		// "S3 Artifact - Name: artifact, Path: /test/path, Expires: 2006-01-02T15:04:05.000Z,
+		// Content Encoding: 'gzip', MIME Type: 'text/plain; charset=utf-8'"
+		String() string
+
 		// Base returns a *BaseArtifact which stores the properties common to
 		// all implementations
 		Base() *BaseArtifact

--- a/workers/generic-worker/artifacts/link.go
+++ b/workers/generic-worker/artifacts/link.go
@@ -1,6 +1,8 @@
 package artifacts
 
 import (
+	"fmt"
+
 	"github.com/taskcluster/taskcluster/v84/clients/client-go/tcqueue"
 	"github.com/taskcluster/taskcluster/v84/internal/mocktc/tc"
 	"github.com/taskcluster/taskcluster/v84/workers/generic-worker/gwconfig"
@@ -29,4 +31,13 @@ func (linkArtifact *LinkArtifact) RequestObject() any {
 
 func (linkArtifact *LinkArtifact) ResponseObject() any {
 	return new(tcqueue.LinkArtifactResponse)
+}
+
+func (linkArtifact *LinkArtifact) String() string {
+	return fmt.Sprintf("Link Artifact - Name: '%v', Artifact: '%v', Expires: %v, MIME Type: '%v'",
+		linkArtifact.Name,
+		linkArtifact.Artifact,
+		linkArtifact.Expires,
+		linkArtifact.ContentType,
+	)
 }

--- a/workers/generic-worker/artifacts/redirect.go
+++ b/workers/generic-worker/artifacts/redirect.go
@@ -40,3 +40,13 @@ func (redirectArtifact *RedirectArtifact) RequestObject() any {
 func (redirectArtifact *RedirectArtifact) ResponseObject() any {
 	return new(tcqueue.RedirectArtifactResponse)
 }
+
+func (redirectArtifact *RedirectArtifact) String() string {
+	return fmt.Sprintf("Redirect Artifact - Name: '%v', URL: '%v', Hide URL: '%v', Expires: %v, MIME Type: '%v'",
+		redirectArtifact.Name,
+		redirectArtifact.URL,
+		redirectArtifact.HideURL,
+		redirectArtifact.Expires,
+		redirectArtifact.ContentType,
+	)
+}

--- a/workers/generic-worker/artifacts_test.go
+++ b/workers/generic-worker/artifacts_test.go
@@ -218,12 +218,12 @@ func TestFileArtifactWithContentEncoding(t *testing.T) {
 			},
 			&artifacts.S3Artifact{
 				BaseArtifact: &artifacts.BaseArtifact{
-					Name:    "public/b/c/d.jpg",
+					Name:    "public/_/X.txt",
 					Expires: inAnHour,
 				},
-				ContentType:     "image/jpeg",
-				ContentEncoding: "identity",
-				Path:            filepath.Join(taskContext.TaskDir, "SampleArtifacts", "b", "c", "d.jpg"),
+				ContentType:     "text/plain; charset=utf-8",
+				ContentEncoding: "gzip",
+				Path:            filepath.Join(taskContext.TaskDir, "SampleArtifacts", "_", "X.txt"),
 			},
 			&artifacts.S3Artifact{
 				BaseArtifact: &artifacts.BaseArtifact{
@@ -240,17 +240,8 @@ func TestFileArtifactWithContentEncoding(t *testing.T) {
 					Expires: inAnHour,
 				},
 				ContentType:     "image/jpeg",
-				ContentEncoding: "identity",
-				Path:            filepath.Join(taskContext.TaskDir, "SampleArtifacts", "b", "c", "d.jpg"),
-			},
-			&artifacts.S3Artifact{
-				BaseArtifact: &artifacts.BaseArtifact{
-					Name:    "public/_/X.txt",
-					Expires: inAnHour,
-				},
-				ContentType:     "text/plain; charset=utf-8",
 				ContentEncoding: "gzip",
-				Path:            filepath.Join(taskContext.TaskDir, "SampleArtifacts", "_", "X.txt"),
+				Path:            filepath.Join(taskContext.TaskDir, "SampleArtifacts", "b", "c", "d.jpg"),
 			},
 			&artifacts.S3Artifact{
 				BaseArtifact: &artifacts.BaseArtifact{
@@ -258,7 +249,16 @@ func TestFileArtifactWithContentEncoding(t *testing.T) {
 					Expires: inAnHour,
 				},
 				ContentType:     "image/jpeg",
-				ContentEncoding: "gzip",
+				ContentEncoding: "identity",
+				Path:            filepath.Join(taskContext.TaskDir, "SampleArtifacts", "b", "c", "d.jpg"),
+			},
+			&artifacts.S3Artifact{
+				BaseArtifact: &artifacts.BaseArtifact{
+					Name:    "public/b/c/d.jpg",
+					Expires: inAnHour,
+				},
+				ContentType:     "image/jpeg",
+				ContentEncoding: "identity",
 				Path:            filepath.Join(taskContext.TaskDir, "SampleArtifacts", "b", "c", "d.jpg"),
 			},
 		})
@@ -392,26 +392,8 @@ func TestDirectoryArtifactWithContentEncoding(t *testing.T) {
 					Expires: inAnHour,
 				},
 				ContentType:     "text/plain; charset=utf-8",
-				ContentEncoding: "identity",
+				ContentEncoding: "gzip",
 				Path:            filepath.Join(taskContext.TaskDir, "SampleArtifacts", "%%%", "v", "X"),
-			},
-			&artifacts.S3Artifact{
-				BaseArtifact: &artifacts.BaseArtifact{
-					Name:    "public/b/c/_/X.txt",
-					Expires: inAnHour,
-				},
-				ContentType:     "text/plain; charset=utf-8",
-				ContentEncoding: "identity",
-				Path:            filepath.Join(taskContext.TaskDir, "SampleArtifacts", "_", "X.txt"),
-			},
-			&artifacts.S3Artifact{
-				BaseArtifact: &artifacts.BaseArtifact{
-					Name:    "public/b/c/b/c/d.jpg",
-					Expires: inAnHour,
-				},
-				ContentType:     "text/plain; charset=utf-8",
-				ContentEncoding: "identity",
-				Path:            filepath.Join(taskContext.TaskDir, "SampleArtifacts", "b", "c", "d.jpg"),
 			},
 			&artifacts.S3Artifact{
 				BaseArtifact: &artifacts.BaseArtifact{
@@ -419,7 +401,7 @@ func TestDirectoryArtifactWithContentEncoding(t *testing.T) {
 					Expires: inAnHour,
 				},
 				ContentType:     "text/plain; charset=utf-8",
-				ContentEncoding: "gzip",
+				ContentEncoding: "identity",
 				Path:            filepath.Join(taskContext.TaskDir, "SampleArtifacts", "%%%", "v", "X"),
 			},
 			&artifacts.S3Artifact{
@@ -433,11 +415,29 @@ func TestDirectoryArtifactWithContentEncoding(t *testing.T) {
 			},
 			&artifacts.S3Artifact{
 				BaseArtifact: &artifacts.BaseArtifact{
+					Name:    "public/b/c/_/X.txt",
+					Expires: inAnHour,
+				},
+				ContentType:     "text/plain; charset=utf-8",
+				ContentEncoding: "identity",
+				Path:            filepath.Join(taskContext.TaskDir, "SampleArtifacts", "_", "X.txt"),
+			},
+			&artifacts.S3Artifact{
+				BaseArtifact: &artifacts.BaseArtifact{
 					Name:    "public/b/c/b/c/d.jpg",
 					Expires: inAnHour,
 				},
 				ContentType:     "text/plain; charset=utf-8",
 				ContentEncoding: "gzip",
+				Path:            filepath.Join(taskContext.TaskDir, "SampleArtifacts", "b", "c", "d.jpg"),
+			},
+			&artifacts.S3Artifact{
+				BaseArtifact: &artifacts.BaseArtifact{
+					Name:    "public/b/c/b/c/d.jpg",
+					Expires: inAnHour,
+				},
+				ContentType:     "text/plain; charset=utf-8",
+				ContentEncoding: "identity",
 				Path:            filepath.Join(taskContext.TaskDir, "SampleArtifacts", "b", "c", "d.jpg"),
 			},
 		})


### PR DESCRIPTION
Will improve artifact upload performance for tasks with more than one artifact included in their payload. Could help in cases like https://github.com/taskcluster/taskcluster/issues/7630.

>Generic Worker: improves artifact upload process by parallelizing the scanning of the system for file/directory artifacts from the payload.