### PR TITLE
fix(generic-worker): use info level when uploading optional error artifact

### DIFF
--- a/changelog/bug-1967254.md
+++ b/changelog/bug-1967254.md
@@ -1,0 +1,5 @@
+audience: worker-deployers
+level: patch
+reference: bug 1967254
+---
+Generic Worker (d2g): uses info log level when uploading error artifacts if the artifact was marked optional. Previously, the log would contain `[taskcluster:error]` which Treeherder would identify as a failure, even if the task is successful.

--- a/workers/generic-worker/artifacts/error.go
+++ b/workers/generic-worker/artifacts/error.go
@@ -16,7 +16,11 @@ type ErrorArtifact struct {
 }
 
 func (errArtifact *ErrorArtifact) ProcessResponse(response any, logger Logger, serviceFactory tc.ServiceFactory, config *gwconfig.Config) error {
-	logger.Errorf("Uploading error artifact %v from file %v with message %q, reason %q and expiry %v", errArtifact.Name, errArtifact.Path, errArtifact.Message, errArtifact.Reason, errArtifact.Expires)
+	log := logger.Errorf
+	if errArtifact.Optional {
+		log = logger.Infof
+	}
+	log("Uploading error artifact %v from file %v with message %q, reason %q and expiry %v", errArtifact.Name, errArtifact.Path, errArtifact.Message, errArtifact.Reason, errArtifact.Expires)
 	// TODO: process error response
 	return nil
 }


### PR DESCRIPTION
Fixes https://bugzilla.mozilla.org/show_bug.cgi?id=1967254.

>Generic Worker (d2g): uses info log level when uploading error artifacts if the artifact was marked optional. Previously, the log would contain `[taskcluster:error]` which Treeherder would identify as a failure, even if the task is successful.