### PR TITLE
feat(ui): Fix signed url issue without credentials

### DIFF
--- a/changelog/issue-4943.md
+++ b/changelog/issue-4943.md
@@ -1,0 +1,6 @@
+audience: users
+level: patch
+reference: issue 4943
+---
+
+Fixes UI error "buildSignedUrl missing required credentials" shown directly after login due to missing credentials.

--- a/ui/src/utils/getArtifactUrl.js
+++ b/ui/src/utils/getArtifactUrl.js
@@ -11,7 +11,7 @@ const { Queue, Index } = require('taskcluster-client-web');
 export function getArtifactUrl({ user, taskId, runId, name }) {
   const queue = getClient({ Class: Queue, user });
 
-  if (user) {
+  if (user?.credentials) {
     return queue.buildSignedUrlSync(queue.getArtifact, taskId, runId, name, {
       expiration: 60,
     });
@@ -26,7 +26,7 @@ export function getArtifactUrl({ user, taskId, runId, name }) {
 export function getLatestArtifactUrl({ user, taskId, name }) {
   const queue = getClient({ Class: Queue, user });
 
-  if (user) {
+  if (user?.credentials) {
     return queue.buildSignedUrlSync(queue.getLatestArtifact, taskId, name, {
       expiration: 60,
     });
@@ -41,7 +41,7 @@ export function getLatestArtifactUrl({ user, taskId, name }) {
 export function findArtifactFromTaskUrl({ user, namespace, name }) {
   const index = getClient({ Class: Index, user });
 
-  if (user) {
+  if (user?.credentials) {
     return index.buildSignedUrlSync(
       index.findArtifactFromTask,
       namespace,

--- a/ui/src/utils/getArtifactUrl.test.js
+++ b/ui/src/utils/getArtifactUrl.test.js
@@ -18,9 +18,6 @@ describe('getArtifactUrl', () => {
   });
 
   it('should get artifact url', () => {
-    window.env = {
-      TASKCLUSTER_ROOT_URL: 'https://taskcluster.net',
-    };
     const url = getArtifactUrl({
       user: {
         credentials: {
@@ -35,6 +32,20 @@ describe('getArtifactUrl', () => {
 
     expect(url).toContain(
       'https://taskcluster.net/api/queue/v1/task/taskId/runs/runId/artifacts/name?bewit=Y2xpZW50SWRcMTY'
+    );
+  });
+  it('should get artifact url with no credentials', () => {
+    const url = getArtifactUrl({
+      user: {
+        profile: 'yes',
+      },
+      taskId: 'taskId',
+      runId: 'runId',
+      name: 'name',
+    });
+
+    expect(url).toEqual(
+      'https://taskcluster.net/api/queue/v1/task/taskId/runs/runId/artifacts/name'
     );
   });
   it('should get latest artifact url', () => {


### PR DESCRIPTION
This happened because user session is being initialized twice. First time it is initialized right after successful callback from external provider, and at this point credentials are not being issued. Second time it is initialized when AuthController detects that credentials are missing, so it fetches them and updates user session with valid credentials.

So between those two events error happened and tried to sign a url without valid credentials.

Fixes #4943 
