### PR TITLE
fix: modernize logger interface

### DIFF
--- a/clients/client-py/taskcluster/aio/asyncutils.py
+++ b/clients/client-py/taskcluster/aio/asyncutils.py
@@ -56,16 +56,16 @@ async def makeHttpRequest(method, url, payload, headers, retries=utils.MAX_RETRI
                 # raise a connection exception
                 raise rerr
             except ValueError as rerr:
-                log.warn('ValueError from aiohttp: redirect to non-http or https')
+                log.warning('ValueError from aiohttp: redirect to non-http or https')
                 raise rerr
             except RuntimeError as rerr:
-                log.warn('RuntimeError from aiohttp: session closed')
+                log.warning('RuntimeError from aiohttp: session closed')
                 raise rerr
             # Handle non 2xx status code and retry if possible
             status = response.status
             if 500 <= status and status < 600 and retry < retries:
                 if retry < retries:
-                    log.warn('Retrying because of: %d status' % status)
+                    log.warning('Retrying because of: %d status' % status)
                     continue
                 else:
                     raise exceptions.TaskclusterRestFailure("Unknown Server Error", superExc=None)

--- a/clients/client-py/taskcluster/utils.py
+++ b/clients/client-py/taskcluster/utils.py
@@ -123,7 +123,7 @@ def fromNowJSON(offset):
 
 
 def dumpJson(obj, **kwargs):
-    """ Match JS's JSON.stringify.  When using the default seperators,
+    """ Match JS's JSON.stringify.  When using the default separators,
     base64 encoding JSON results in \n sequences in the output.  Hawk
     barfs in your face if you have that in the text"""
     def handleDateAndBinaryForJs(x):
@@ -217,10 +217,10 @@ def scopeMatch(assumedScopes, requiredScopeSets):
         for requiredScope in scopeSet:
             for scope in assumedScopes:
                 if scope == requiredScope:
-                    # requiredScope satisifed, no need to check more scopes
+                    # requiredScope satisfied, no need to check more scopes
                     break
                 if scope.endswith("*") and requiredScope.startswith(scope[:-1]):
-                    # requiredScope satisifed, no need to check more scopes
+                    # requiredScope satisfied, no need to check more scopes
                     break
             else:
                 # requiredScope not satisfied, stop checking scopeSet
@@ -274,7 +274,7 @@ def makeHttpRequest(method, url, payload, headers, retries=MAX_RETRIES, session=
         status = response.status_code
         if 500 <= status and status < 600 and retry < retries:
             if retry < retries:
-                log.warn('Retrying because of: %d status' % status)
+                log.warning('Retrying because of: %d status' % status)
                 continue
             else:
                 raise exceptions.TaskclusterRestFailure("Unknown Server Error", superExc=None)


### PR DESCRIPTION
## PR Summary
The `logger.warn()` method is deprecated since Python2.7 and replaced with `logger.warning()`. It leads to those warnings:
```python
DeprecationWarning: The 'warn' method is deprecated, use 'warning' instead
```