### PR TITLE
Queue API validation rules

### DIFF
--- a/changelog/issue-7757.md
+++ b/changelog/issue-7757.md
@@ -1,0 +1,6 @@
+audience: users
+level: patch
+reference: issue 7757
+---
+
+Fixed input validation for some queue service endpoints to return a 400 error instead of a 500 error when validation fails.

--- a/services/queue/src/api.js
+++ b/services/queue/src/api.js
@@ -57,9 +57,10 @@ const PRIORITY_LEVELS = [
  */
 
 // Common patterns URL parameters
-let SLUGID_PATTERN = /^[A-Za-z0-9_-]{8}[Q-T][A-Za-z0-9_-][CGKOSWaeimquy26-][A-Za-z0-9_-]{10}[AQgw]$/;
-let GENERIC_ID_PATTERN = /^[a-zA-Z0-9-_]{1,38}$/;
-let RUN_ID_PATTERN = /^[1-9]*[0-9]+$/;
+const SLUGID_PATTERN = /^[A-Za-z0-9_-]{8}[Q-T][A-Za-z0-9_-][CGKOSWaeimquy26-][A-Za-z0-9_-]{10}[AQgw]$/;
+const GENERIC_ID_PATTERN = /^[a-zA-Z0-9-_]{1,38}$/;
+const RUN_ID_PATTERN = /^[1-9]*[0-9]+$/;
+const TASK_QUEUE_ID_PATTERN = new RegExp('^[a-zA-Z0-9-_]{1,38}/[a-z]([-a-z0-9]{0,36}[a-z0-9])?$');
 
 /**
  * API end-point for version v1/
@@ -141,7 +142,7 @@ let builder = new APIBuilder({
   params: {
     taskId: SLUGID_PATTERN,
     taskGroupId: SLUGID_PATTERN,
-    taskQueueId: /^[A-Za-z0-9_-]{1,38}\/[A-Za-z0-9_-]{1,38}$/,
+    taskQueueId: TASK_QUEUE_ID_PATTERN,
     provisionerId: GENERIC_ID_PATTERN,
     workerType: GENERIC_ID_PATTERN,
     workerGroup: GENERIC_ID_PATTERN,

--- a/services/queue/test/querytasks_test.js
+++ b/services/queue/test/querytasks_test.js
@@ -36,6 +36,13 @@ helper.secrets.mockSuite(testing.suiteName(), ['aws'], function (mock, skipping)
     },
   };
 
+  test('pendingTasks params validation', async () => {
+    await assert.rejects(
+      () => helper.queue.pendingTasks(
+        '1/1',
+      ), err => err.code === 'InvalidRequestArguments');
+  });
+
   test('pendingTasks >= 1', async () => {
     const taskId1 = slugid.v4();
     const taskId2 = slugid.v4();


### PR DESCRIPTION
There was a slight mismatch between output schema validation and input validation, which resulted in 500 errors instead of 400

 Fixes #7757