### PR TITLE
fix(d2g): ensure GPUs before adding GPU flags

### DIFF
--- a/changelog/GxTYuXpzQzOo2dw08ajm-Q.md
+++ b/changelog/GxTYuXpzQzOo2dw08ajm-Q.md
@@ -1,0 +1,4 @@
+audience: worker-deployers
+level: patch
+---
+D2G: Runs `nvidia-smi` to ensure that the `/dev/nvidia-uvm` and `/dev/nvidia-uvm-tools` devices are loaded and passed as `--device` flags.


### PR DESCRIPTION
It's _possible_ that this may help https://github.com/mozilla/translations/issues/1117.

>D2G: Runs `nvidia-smi` to ensure that the `/dev/nvidia-uvm` and `/dev/nvidia-uvm-tools` devices are loaded and passed as `--device` flags.