### PR TITLE
Bug 1971309 - Don't print out the URL twice when uploading an artifact

### DIFF
--- a/changelog/bug-1971309.md
+++ b/changelog/bug-1971309.md
@@ -1,0 +1,4 @@
+audience: general
+level: silent
+reference: bug 1971309
+---


### PR DESCRIPTION
It's redundant and just adds noise to the log
