### PR TITLE
feat(k8s): Disable metrics-only deployments without prometheus

### DIFF
--- a/changelog/issue-7763.md
+++ b/changelog/issue-7763.md
@@ -1,0 +1,6 @@
+audience: deployers
+level: patch
+reference: issue 7763
+---
+
+Helm chart forces metrics-only deployments to have `replicas: 0` if `prometheus.enabled` is `false`

--- a/infrastructure/k8s/templates/taskcluster-queue-deployment-workerMetrics.yaml
+++ b/infrastructure/k8s/templates/taskcluster-queue-deployment-workerMetrics.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/component: taskcluster-queue-workermetrics
     app.kubernetes.io/part-of: taskcluster
 spec:
-  replicas: {{ int (.Values.queue.procs.workerMetrics.replicas) }}
+  replicas: {{ if .Values.prometheus.enabled  }}{{ int (.Values.queue.procs.workerMetrics.replicas) }}{{ else }}0{{end}}
   selector:
     matchLabels: *ref_0
   template:


### PR DESCRIPTION
We force replcas:0 for such deployments

Fixes #7763
