### PR TITLE
feat(generic-worker): fine-tune auto-abortion of tasks

### DIFF
--- a/changelog/issue-7769.md
+++ b/changelog/issue-7769.md
@@ -1,0 +1,5 @@
+audience: users
+level: patch
+reference: issue 7769
+---
+Generic Worker: resource monitor will print out its usage summary after aborting the task.

--- a/changelog/issue-7770.md
+++ b/changelog/issue-7770.md
@@ -1,0 +1,11 @@
+audience: worker-deployers
+level: minor
+reference: issue 7770
+---
+Generic Worker: adds additional resource monitoring auto-abortion configuration to better fine-tune how your worker aborts running task processes.
+
+  * `absoluteHighMemoryThreshold`: The minimum amount of available memory (in bytes) required before considering task abortion. If available memory drops below this value, it may trigger an abort. Default: `524288000` (500MiB).
+  * `relativeHighMemoryThreshold`: The percentage of total system memory usage that, if exceeded, contributes to the decision to abort the task. Default: `90`.
+  * `allowedHighMemoryDurationSecs`: The maximum duration (in seconds) that high memory usage conditions can persist before the task is aborted. Default: `5`.
+
+Generic Worker will auto-abort a task if the total system memory used percentage is greater than `relativeHighMemoryThreshold` _AND_ the available memory is less than `absoluteHighMemoryThreshold` for longer than `allowedHighMemoryDurationSecs`, unless `disableOOMProtection` is enabled.

--- a/generated/references.json
+++ b/generated/references.json
@@ -9005,7 +9005,7 @@
             },
             "resourceMonitor": {
               "default": true,
-              "description": "The resource monitor feature reports Peak System Memory Used,\nAverage System Memory Used, Average Available System Memory,\nand Total System Memory in the task log for each task command\nexecuted. It also will abort any task command if the used\nsystem memory exceeds worker config relativeHighMemoryThreshold\n_AND_ available system memory drops below worker config\nabsoluteHighMemoryThreshold available system memory for longer\nthan worker config allowedHighMemoryDuration seconds. When\nthis happens, the task will be resolved as failed.\n\nSince: generic-worker 83.4.0",
+              "description": "The resource monitor feature reports Peak System Memory Used,\nAverage System Memory Used, Average Available System Memory,\nand Total System Memory in the task log for each task command\nexecuted. It also will abort any task command if the used\nsystem memory exceeds worker config relativeHighMemoryThreshold\n_AND_ available system memory drops below worker config\nabsoluteHighMemoryThreshold for longer than worker config\nallowedHighMemoryDuration seconds. When this happens, the\ntask will be resolved as failed.\n\nSince: generic-worker 83.4.0",
               "title": "Resource monitor",
               "type": "boolean"
             },
@@ -9540,7 +9540,7 @@
                 },
                 "resourceMonitor": {
                   "default": true,
-                  "description": "The resource monitor feature reports Peak System Memory Used,\nAverage System Memory Used, Average Available System Memory,\nand Total System Memory in the task log for each task command\nexecuted. It also will abort any task command if the used\nsystem memory exceeds worker config relativeHighMemoryThreshold\n_AND_ available system memory drops below worker config\nabsoluteHighMemoryThreshold available system memory for longer\nthan worker config allowedHighMemoryDuration seconds. When\nthis happens, the task will be resolved as failed.\n\nSince: generic-worker 83.4.0",
+                  "description": "The resource monitor feature reports Peak System Memory Used,\nAverage System Memory Used, Average Available System Memory,\nand Total System Memory in the task log for each task command\nexecuted. It also will abort any task command if the used\nsystem memory exceeds worker config relativeHighMemoryThreshold\n_AND_ available system memory drops below worker config\nabsoluteHighMemoryThreshold for longer than worker config\nallowedHighMemoryDuration seconds. When this happens, the\ntask will be resolved as failed.\n\nSince: generic-worker 83.4.0",
                   "title": "Resource monitor",
                   "type": "boolean"
                 },
@@ -10349,7 +10349,7 @@
                 },
                 "resourceMonitor": {
                   "default": true,
-                  "description": "The resource monitor feature reports Peak System Memory Used,\nAverage System Memory Used, Average Available System Memory,\nand Total System Memory in the task log for each task command\nexecuted. It also will abort any task command if the used\nsystem memory exceeds worker config relativeHighMemoryThreshold\n_AND_ available system memory drops below worker config\nabsoluteHighMemoryThreshold available system memory for longer\nthan worker config allowedHighMemoryDuration seconds. When\nthis happens, the task will be resolved as failed.\n\nSince: generic-worker 83.4.0",
+                  "description": "The resource monitor feature reports Peak System Memory Used,\nAverage System Memory Used, Average Available System Memory,\nand Total System Memory in the task log for each task command\nexecuted. It also will abort any task command if the used\nsystem memory exceeds worker config relativeHighMemoryThreshold\n_AND_ available system memory drops below worker config\nabsoluteHighMemoryThreshold for longer than worker config\nallowedHighMemoryDuration seconds. When this happens, the\ntask will be resolved as failed.\n\nSince: generic-worker 83.4.0",
                   "title": "Resource monitor",
                   "type": "boolean"
                 },

--- a/generated/references.json
+++ b/generated/references.json
@@ -9005,7 +9005,7 @@
             },
             "resourceMonitor": {
               "default": true,
-              "description": "The resource monitor features reports Peak System Memory Used,\nAverage System Memory Used and Total Available Memory in the\ntask log for each task command executed. It also will abort\nany task command that causes the available system memory to be\nreduced to less than or equal to 10% of the total system memory\nfor five consecutive measurements at 0.5s intervals. When this\nhappens, the task will be resolved as failed.\n\nSince: generic-worker 83.4.0",
+              "description": "The resource monitor feature reports Peak System Memory Used,\nAverage System Memory Used, Average Available System Memory,\nand Total System Memory in the task log for each task command\nexecuted. It also will abort any task command if the used\nsystem memory exceeds worker config relativeHighMemoryThreshold\n_AND_ available system memory drops below worker config\nabsoluteHighMemoryThreshold available system memory for longer\nthan worker config allowedHighMemoryDuration seconds. When\nthis happens, the task will be resolved as failed.\n\nSince: generic-worker 83.4.0",
               "title": "Resource monitor",
               "type": "boolean"
             },
@@ -9540,7 +9540,7 @@
                 },
                 "resourceMonitor": {
                   "default": true,
-                  "description": "The resource monitor features reports Peak System Memory Used,\nAverage System Memory Used and Total Available Memory in the\ntask log for each task command executed. It also will abort\nany task command that causes the available system memory to be\nreduced to less than or equal to 10% of the total system memory\nfor five consecutive measurements at 0.5s intervals. When this\nhappens, the task will be resolved as failed.\n\nSince: generic-worker 83.4.0",
+                  "description": "The resource monitor feature reports Peak System Memory Used,\nAverage System Memory Used, Average Available System Memory,\nand Total System Memory in the task log for each task command\nexecuted. It also will abort any task command if the used\nsystem memory exceeds worker config relativeHighMemoryThreshold\n_AND_ available system memory drops below worker config\nabsoluteHighMemoryThreshold available system memory for longer\nthan worker config allowedHighMemoryDuration seconds. When\nthis happens, the task will be resolved as failed.\n\nSince: generic-worker 83.4.0",
                   "title": "Resource monitor",
                   "type": "boolean"
                 },
@@ -10349,7 +10349,7 @@
                 },
                 "resourceMonitor": {
                   "default": true,
-                  "description": "The resource monitor features reports Peak System Memory Used,\nAverage System Memory Used and Total Available Memory in the\ntask log for each task command executed. It also will abort\nany task command that causes the available system memory to be\nreduced to less than or equal to 10% of the total system memory\nfor five consecutive measurements at 0.5s intervals. When this\nhappens, the task will be resolved as failed.\n\nSince: generic-worker 83.4.0",
+                  "description": "The resource monitor feature reports Peak System Memory Used,\nAverage System Memory Used, Average Available System Memory,\nand Total System Memory in the task log for each task command\nexecuted. It also will abort any task command if the used\nsystem memory exceeds worker config relativeHighMemoryThreshold\n_AND_ available system memory drops below worker config\nabsoluteHighMemoryThreshold available system memory for longer\nthan worker config allowedHighMemoryDuration seconds. When\nthis happens, the task will be resolved as failed.\n\nSince: generic-worker 83.4.0",
                   "title": "Resource monitor",
                   "type": "boolean"
                 },

--- a/tools/d2g/genericworker/generated_types.go
+++ b/tools/d2g/genericworker/generated_types.go
@@ -449,9 +449,9 @@ type (
 		// executed. It also will abort any task command if the used
 		// system memory exceeds worker config relativeHighMemoryThreshold
 		// _AND_ available system memory drops below worker config
-		// absoluteHighMemoryThreshold available system memory for longer
-		// than worker config allowedHighMemoryDuration seconds. When
-		// this happens, the task will be resolved as failed.
+		// absoluteHighMemoryThreshold for longer than worker config
+		// allowedHighMemoryDuration seconds. When this happens, the
+		// task will be resolved as failed.
 		//
 		// Since: generic-worker 83.4.0
 		//
@@ -1216,7 +1216,7 @@ func JSONSchema() string {
             },
             "resourceMonitor": {
               "default": true,
-              "description": "The resource monitor feature reports Peak System Memory Used,\nAverage System Memory Used, Average Available System Memory,\nand Total System Memory in the task log for each task command\nexecuted. It also will abort any task command if the used\nsystem memory exceeds worker config relativeHighMemoryThreshold\n_AND_ available system memory drops below worker config\nabsoluteHighMemoryThreshold available system memory for longer\nthan worker config allowedHighMemoryDuration seconds. When\nthis happens, the task will be resolved as failed.\n\nSince: generic-worker 83.4.0",
+              "description": "The resource monitor feature reports Peak System Memory Used,\nAverage System Memory Used, Average Available System Memory,\nand Total System Memory in the task log for each task command\nexecuted. It also will abort any task command if the used\nsystem memory exceeds worker config relativeHighMemoryThreshold\n_AND_ available system memory drops below worker config\nabsoluteHighMemoryThreshold for longer than worker config\nallowedHighMemoryDuration seconds. When this happens, the\ntask will be resolved as failed.\n\nSince: generic-worker 83.4.0",
               "title": "Resource monitor",
               "type": "boolean"
             },

--- a/tools/d2g/genericworker/generated_types.go
+++ b/tools/d2g/genericworker/generated_types.go
@@ -443,13 +443,15 @@ type (
 		// Since: generic-worker 53.1.0
 		LoopbackVideo bool `json:"loopbackVideo,omitempty"`
 
-		// The resource monitor features reports Peak System Memory Used,
-		// Average System Memory Used and Total Available Memory in the
-		// task log for each task command executed. It also will abort
-		// any task command that causes the available system memory to be
-		// reduced to less than or equal to 10% of the total system memory
-		// for five consecutive measurements at 0.5s intervals. When this
-		// happens, the task will be resolved as failed.
+		// The resource monitor feature reports Peak System Memory Used,
+		// Average System Memory Used, Average Available System Memory,
+		// and Total System Memory in the task log for each task command
+		// executed. It also will abort any task command if the used
+		// system memory exceeds worker config relativeHighMemoryThreshold
+		// _AND_ available system memory drops below worker config
+		// absoluteHighMemoryThreshold available system memory for longer
+		// than worker config allowedHighMemoryDuration seconds. When
+		// this happens, the task will be resolved as failed.
 		//
 		// Since: generic-worker 83.4.0
 		//
@@ -1214,7 +1216,7 @@ func JSONSchema() string {
             },
             "resourceMonitor": {
               "default": true,
-              "description": "The resource monitor features reports Peak System Memory Used,\nAverage System Memory Used and Total Available Memory in the\ntask log for each task command executed. It also will abort\nany task command that causes the available system memory to be\nreduced to less than or equal to 10% of the total system memory\nfor five consecutive measurements at 0.5s intervals. When this\nhappens, the task will be resolved as failed.\n\nSince: generic-worker 83.4.0",
+              "description": "The resource monitor feature reports Peak System Memory Used,\nAverage System Memory Used, Average Available System Memory,\nand Total System Memory in the task log for each task command\nexecuted. It also will abort any task command if the used\nsystem memory exceeds worker config relativeHighMemoryThreshold\n_AND_ available system memory drops below worker config\nabsoluteHighMemoryThreshold available system memory for longer\nthan worker config allowedHighMemoryDuration seconds. When\nthis happens, the task will be resolved as failed.\n\nSince: generic-worker 83.4.0",
               "title": "Resource monitor",
               "type": "boolean"
             },

--- a/ui/docs/reference/workers/generic-worker/usage.mdx
+++ b/ui/docs/reference/workers/generic-worker/usage.mdx
@@ -113,6 +113,25 @@ and reports back results to the queue.
         ** OPTIONAL ** properties
         =========================
 
+          absoluteHighMemoryThreshold       Number of bytes the resource monitor uses to
+                                            determine when to abort a task due to high
+                                            memory usage. The is an absolute number of bytes
+                                            needed of available memory before aborting the task.
+                                            For example, if the value is 524288000, then the worker will
+                                            abort a task if the memory available is 200MiB or less
+                                            for longer than allowedHighMemoryDurationSecs seconds.
+                                            Can be used in conjunction with relativeHighMemoryThreshold.
+                                            Does nothing if disableOOMProtection is set to true.
+                                            [default: 524288000] (500MiB)
+          allowedHighMemoryDurationSecs     The number of seconds the resource monitor will
+                                            allow the system memory usage to be above the high
+                                            memory thresholds (see absoluteHighMemoryThreshold
+                                            and relativeHighMemoryThreshold) before aborting
+                                            the task. If the memory usage is above the high
+                                            memory thresholds for longer than this time, the
+                                            worker will abort the task. Does nothing if
+                                            disableOOMProtection is set to true.
+                                            [default: 5]
           availabilityZone                  The EC2 availability zone of the worker.
           cachesDir                         The directory where task caches should be stored on
                                             the worker. The directory will be created if it does
@@ -160,8 +179,9 @@ and reports back results to the queue.
                                             [default: false]
           disableOOMProtection              If true, the worker will continue to monitor system
                                             memory usage, but will not abort tasks when the
-                                            system memory usage is at 90% or higher for five
-                                            consecutive measurements at 0.5s intervals.
+                                            system memory usage hits the absoluteHighMemoryThreshold
+                                            AND relativeHighMemoryThreshold for longer than
+                                            allowedHighMemoryDurationSecs seconds.
                                             [default: false]
           downloadsDir                      The directory to cache downloaded files for
                                             populating preloaded caches and readonly mounts. The
@@ -258,6 +278,17 @@ and reports back results to the queue.
           publicIP                          The IP address for VNC access.  Also used by chain of
                                             trust when present.
           region                            The EC2 region of the worker. Used by chain of trust.
+          relativeHighMemoryThreshold       A percent used by the resource monitor to determine
+                                            when to abort a task due to high memory usage.
+                                            This is a relative value, meaning that it is
+                                            relative to the total memory available on the
+                                            worker. For example, if the value is 90, then
+                                            the worker will abort a task if the memory
+                                            usage is at 90% or higher for longer than
+                                            allowedHighMemoryDurationSecs seconds. Can be used
+                                            in conjunction with absoluteHighMemoryThreshold.
+                                            Does nothing if disableOOMProtection is set to true.
+                                            [default: 90]
           requiredDiskSpaceMegabytes        The garbage collector will ensure at least this
                                             number of megabytes of disk space are available
                                             when each task starts. If it cannot free enough

--- a/ui/docs/reference/workers/generic-worker/usage.mdx
+++ b/ui/docs/reference/workers/generic-worker/usage.mdx
@@ -115,10 +115,10 @@ and reports back results to the queue.
 
           absoluteHighMemoryThreshold       Number of bytes the resource monitor uses to
                                             determine when to abort a task due to high
-                                            memory usage. The is an absolute number of bytes
+                                            memory usage. This is an absolute number of bytes
                                             needed of available memory before aborting the task.
                                             For example, if the value is 524288000, then the worker will
-                                            abort a task if the memory available is 200MiB or less
+                                            abort a task if the memory available is 500MiB or less
                                             for longer than allowedHighMemoryDurationSecs seconds.
                                             Can be used in conjunction with relativeHighMemoryThreshold.
                                             Does nothing if disableOOMProtection is set to true.

--- a/workers/generic-worker/README.md
+++ b/workers/generic-worker/README.md
@@ -114,6 +114,25 @@ and reports back results to the queue.
         ** OPTIONAL ** properties
         =========================
 
+          absoluteHighMemoryThreshold       Number of bytes the resource monitor uses to
+                                            determine when to abort a task due to high
+                                            memory usage. The is an absolute number of bytes
+                                            needed of available memory before aborting the task.
+                                            For example, if the value is 524288000, then the worker will
+                                            abort a task if the memory available is 200MiB or less
+                                            for longer than allowedHighMemoryDurationSecs seconds.
+                                            Can be used in conjunction with relativeHighMemoryThreshold.
+                                            Does nothing if disableOOMProtection is set to true.
+                                            [default: 524288000] (500MiB)
+          allowedHighMemoryDurationSecs     The number of seconds the resource monitor will
+                                            allow the system memory usage to be above the high
+                                            memory thresholds (see absoluteHighMemoryThreshold
+                                            and relativeHighMemoryThreshold) before aborting
+                                            the task. If the memory usage is above the high
+                                            memory thresholds for longer than this time, the
+                                            worker will abort the task. Does nothing if
+                                            disableOOMProtection is set to true.
+                                            [default: 5]
           availabilityZone                  The EC2 availability zone of the worker.
           cachesDir                         The directory where task caches should be stored on
                                             the worker. The directory will be created if it does
@@ -161,8 +180,9 @@ and reports back results to the queue.
                                             [default: false]
           disableOOMProtection              If true, the worker will continue to monitor system
                                             memory usage, but will not abort tasks when the
-                                            system memory usage is at 90% or higher for five
-                                            consecutive measurements at 0.5s intervals.
+                                            system memory usage hits the absoluteHighMemoryThreshold
+                                            AND relativeHighMemoryThreshold for longer than
+                                            allowedHighMemoryDurationSecs seconds.
                                             [default: false]
           downloadsDir                      The directory to cache downloaded files for
                                             populating preloaded caches and readonly mounts. The
@@ -259,6 +279,17 @@ and reports back results to the queue.
           publicIP                          The IP address for VNC access.  Also used by chain of
                                             trust when present.
           region                            The EC2 region of the worker. Used by chain of trust.
+          relativeHighMemoryThreshold       A percent used by the resource monitor to determine
+                                            when to abort a task due to high memory usage.
+                                            This is a relative value, meaning that it is
+                                            relative to the total memory available on the
+                                            worker. For example, if the value is 90, then
+                                            the worker will abort a task if the memory
+                                            usage is at 90% or higher for longer than
+                                            allowedHighMemoryDurationSecs seconds. Can be used
+                                            in conjunction with absoluteHighMemoryThreshold.
+                                            Does nothing if disableOOMProtection is set to true.
+                                            [default: 90]
           requiredDiskSpaceMegabytes        The garbage collector will ensure at least this
                                             number of megabytes of disk space are available
                                             when each task starts. If it cannot free enough

--- a/workers/generic-worker/README.md
+++ b/workers/generic-worker/README.md
@@ -116,10 +116,10 @@ and reports back results to the queue.
 
           absoluteHighMemoryThreshold       Number of bytes the resource monitor uses to
                                             determine when to abort a task due to high
-                                            memory usage. The is an absolute number of bytes
+                                            memory usage. This is an absolute number of bytes
                                             needed of available memory before aborting the task.
                                             For example, if the value is 524288000, then the worker will
-                                            abort a task if the memory available is 200MiB or less
+                                            abort a task if the memory available is 500MiB or less
                                             for longer than allowedHighMemoryDurationSecs seconds.
                                             Can be used in conjunction with relativeHighMemoryThreshold.
                                             Does nothing if disableOOMProtection is set to true.

--- a/workers/generic-worker/generated_insecure_darwin.go
+++ b/workers/generic-worker/generated_insecure_darwin.go
@@ -431,13 +431,15 @@ type (
 		// Since: generic-worker 53.1.0
 		LoopbackVideo bool `json:"loopbackVideo,omitempty"`
 
-		// The resource monitor features reports Peak System Memory Used,
-		// Average System Memory Used and Total Available Memory in the
-		// task log for each task command executed. It also will abort
-		// any task command that causes the available system memory to be
-		// reduced to less than or equal to 10% of the total system memory
-		// for five consecutive measurements at 0.5s intervals. When this
-		// happens, the task will be resolved as failed.
+		// The resource monitor feature reports Peak System Memory Used,
+		// Average System Memory Used, Average Available System Memory,
+		// and Total System Memory in the task log for each task command
+		// executed. It also will abort any task command if the used
+		// system memory exceeds worker config relativeHighMemoryThreshold
+		// _AND_ available system memory drops below worker config
+		// absoluteHighMemoryThreshold available system memory for longer
+		// than worker config allowedHighMemoryDuration seconds. When
+		// this happens, the task will be resolved as failed.
 		//
 		// Since: generic-worker 83.4.0
 		//
@@ -1172,7 +1174,7 @@ func JSONSchema() string {
             },
             "resourceMonitor": {
               "default": true,
-              "description": "The resource monitor features reports Peak System Memory Used,\nAverage System Memory Used and Total Available Memory in the\ntask log for each task command executed. It also will abort\nany task command that causes the available system memory to be\nreduced to less than or equal to 10% of the total system memory\nfor five consecutive measurements at 0.5s intervals. When this\nhappens, the task will be resolved as failed.\n\nSince: generic-worker 83.4.0",
+              "description": "The resource monitor feature reports Peak System Memory Used,\nAverage System Memory Used, Average Available System Memory,\nand Total System Memory in the task log for each task command\nexecuted. It also will abort any task command if the used\nsystem memory exceeds worker config relativeHighMemoryThreshold\n_AND_ available system memory drops below worker config\nabsoluteHighMemoryThreshold available system memory for longer\nthan worker config allowedHighMemoryDuration seconds. When\nthis happens, the task will be resolved as failed.\n\nSince: generic-worker 83.4.0",
               "title": "Resource monitor",
               "type": "boolean"
             },

--- a/workers/generic-worker/generated_insecure_darwin.go
+++ b/workers/generic-worker/generated_insecure_darwin.go
@@ -437,9 +437,9 @@ type (
 		// executed. It also will abort any task command if the used
 		// system memory exceeds worker config relativeHighMemoryThreshold
 		// _AND_ available system memory drops below worker config
-		// absoluteHighMemoryThreshold available system memory for longer
-		// than worker config allowedHighMemoryDuration seconds. When
-		// this happens, the task will be resolved as failed.
+		// absoluteHighMemoryThreshold for longer than worker config
+		// allowedHighMemoryDuration seconds. When this happens, the
+		// task will be resolved as failed.
 		//
 		// Since: generic-worker 83.4.0
 		//
@@ -1174,7 +1174,7 @@ func JSONSchema() string {
             },
             "resourceMonitor": {
               "default": true,
-              "description": "The resource monitor feature reports Peak System Memory Used,\nAverage System Memory Used, Average Available System Memory,\nand Total System Memory in the task log for each task command\nexecuted. It also will abort any task command if the used\nsystem memory exceeds worker config relativeHighMemoryThreshold\n_AND_ available system memory drops below worker config\nabsoluteHighMemoryThreshold available system memory for longer\nthan worker config allowedHighMemoryDuration seconds. When\nthis happens, the task will be resolved as failed.\n\nSince: generic-worker 83.4.0",
+              "description": "The resource monitor feature reports Peak System Memory Used,\nAverage System Memory Used, Average Available System Memory,\nand Total System Memory in the task log for each task command\nexecuted. It also will abort any task command if the used\nsystem memory exceeds worker config relativeHighMemoryThreshold\n_AND_ available system memory drops below worker config\nabsoluteHighMemoryThreshold for longer than worker config\nallowedHighMemoryDuration seconds. When this happens, the\ntask will be resolved as failed.\n\nSince: generic-worker 83.4.0",
               "title": "Resource monitor",
               "type": "boolean"
             },

--- a/workers/generic-worker/generated_insecure_freebsd.go
+++ b/workers/generic-worker/generated_insecure_freebsd.go
@@ -431,13 +431,15 @@ type (
 		// Since: generic-worker 53.1.0
 		LoopbackVideo bool `json:"loopbackVideo,omitempty"`
 
-		// The resource monitor features reports Peak System Memory Used,
-		// Average System Memory Used and Total Available Memory in the
-		// task log for each task command executed. It also will abort
-		// any task command that causes the available system memory to be
-		// reduced to less than or equal to 10% of the total system memory
-		// for five consecutive measurements at 0.5s intervals. When this
-		// happens, the task will be resolved as failed.
+		// The resource monitor feature reports Peak System Memory Used,
+		// Average System Memory Used, Average Available System Memory,
+		// and Total System Memory in the task log for each task command
+		// executed. It also will abort any task command if the used
+		// system memory exceeds worker config relativeHighMemoryThreshold
+		// _AND_ available system memory drops below worker config
+		// absoluteHighMemoryThreshold available system memory for longer
+		// than worker config allowedHighMemoryDuration seconds. When
+		// this happens, the task will be resolved as failed.
 		//
 		// Since: generic-worker 83.4.0
 		//
@@ -1172,7 +1174,7 @@ func JSONSchema() string {
             },
             "resourceMonitor": {
               "default": true,
-              "description": "The resource monitor features reports Peak System Memory Used,\nAverage System Memory Used and Total Available Memory in the\ntask log for each task command executed. It also will abort\nany task command that causes the available system memory to be\nreduced to less than or equal to 10% of the total system memory\nfor five consecutive measurements at 0.5s intervals. When this\nhappens, the task will be resolved as failed.\n\nSince: generic-worker 83.4.0",
+              "description": "The resource monitor feature reports Peak System Memory Used,\nAverage System Memory Used, Average Available System Memory,\nand Total System Memory in the task log for each task command\nexecuted. It also will abort any task command if the used\nsystem memory exceeds worker config relativeHighMemoryThreshold\n_AND_ available system memory drops below worker config\nabsoluteHighMemoryThreshold available system memory for longer\nthan worker config allowedHighMemoryDuration seconds. When\nthis happens, the task will be resolved as failed.\n\nSince: generic-worker 83.4.0",
               "title": "Resource monitor",
               "type": "boolean"
             },

--- a/workers/generic-worker/generated_insecure_freebsd.go
+++ b/workers/generic-worker/generated_insecure_freebsd.go
@@ -437,9 +437,9 @@ type (
 		// executed. It also will abort any task command if the used
 		// system memory exceeds worker config relativeHighMemoryThreshold
 		// _AND_ available system memory drops below worker config
-		// absoluteHighMemoryThreshold available system memory for longer
-		// than worker config allowedHighMemoryDuration seconds. When
-		// this happens, the task will be resolved as failed.
+		// absoluteHighMemoryThreshold for longer than worker config
+		// allowedHighMemoryDuration seconds. When this happens, the
+		// task will be resolved as failed.
 		//
 		// Since: generic-worker 83.4.0
 		//
@@ -1174,7 +1174,7 @@ func JSONSchema() string {
             },
             "resourceMonitor": {
               "default": true,
-              "description": "The resource monitor feature reports Peak System Memory Used,\nAverage System Memory Used, Average Available System Memory,\nand Total System Memory in the task log for each task command\nexecuted. It also will abort any task command if the used\nsystem memory exceeds worker config relativeHighMemoryThreshold\n_AND_ available system memory drops below worker config\nabsoluteHighMemoryThreshold available system memory for longer\nthan worker config allowedHighMemoryDuration seconds. When\nthis happens, the task will be resolved as failed.\n\nSince: generic-worker 83.4.0",
+              "description": "The resource monitor feature reports Peak System Memory Used,\nAverage System Memory Used, Average Available System Memory,\nand Total System Memory in the task log for each task command\nexecuted. It also will abort any task command if the used\nsystem memory exceeds worker config relativeHighMemoryThreshold\n_AND_ available system memory drops below worker config\nabsoluteHighMemoryThreshold for longer than worker config\nallowedHighMemoryDuration seconds. When this happens, the\ntask will be resolved as failed.\n\nSince: generic-worker 83.4.0",
               "title": "Resource monitor",
               "type": "boolean"
             },

--- a/workers/generic-worker/generated_insecure_linux.go
+++ b/workers/generic-worker/generated_insecure_linux.go
@@ -431,13 +431,15 @@ type (
 		// Since: generic-worker 53.1.0
 		LoopbackVideo bool `json:"loopbackVideo,omitempty"`
 
-		// The resource monitor features reports Peak System Memory Used,
-		// Average System Memory Used and Total Available Memory in the
-		// task log for each task command executed. It also will abort
-		// any task command that causes the available system memory to be
-		// reduced to less than or equal to 10% of the total system memory
-		// for five consecutive measurements at 0.5s intervals. When this
-		// happens, the task will be resolved as failed.
+		// The resource monitor feature reports Peak System Memory Used,
+		// Average System Memory Used, Average Available System Memory,
+		// and Total System Memory in the task log for each task command
+		// executed. It also will abort any task command if the used
+		// system memory exceeds worker config relativeHighMemoryThreshold
+		// _AND_ available system memory drops below worker config
+		// absoluteHighMemoryThreshold available system memory for longer
+		// than worker config allowedHighMemoryDuration seconds. When
+		// this happens, the task will be resolved as failed.
 		//
 		// Since: generic-worker 83.4.0
 		//
@@ -1172,7 +1174,7 @@ func JSONSchema() string {
             },
             "resourceMonitor": {
               "default": true,
-              "description": "The resource monitor features reports Peak System Memory Used,\nAverage System Memory Used and Total Available Memory in the\ntask log for each task command executed. It also will abort\nany task command that causes the available system memory to be\nreduced to less than or equal to 10% of the total system memory\nfor five consecutive measurements at 0.5s intervals. When this\nhappens, the task will be resolved as failed.\n\nSince: generic-worker 83.4.0",
+              "description": "The resource monitor feature reports Peak System Memory Used,\nAverage System Memory Used, Average Available System Memory,\nand Total System Memory in the task log for each task command\nexecuted. It also will abort any task command if the used\nsystem memory exceeds worker config relativeHighMemoryThreshold\n_AND_ available system memory drops below worker config\nabsoluteHighMemoryThreshold available system memory for longer\nthan worker config allowedHighMemoryDuration seconds. When\nthis happens, the task will be resolved as failed.\n\nSince: generic-worker 83.4.0",
               "title": "Resource monitor",
               "type": "boolean"
             },

--- a/workers/generic-worker/generated_insecure_linux.go
+++ b/workers/generic-worker/generated_insecure_linux.go
@@ -437,9 +437,9 @@ type (
 		// executed. It also will abort any task command if the used
 		// system memory exceeds worker config relativeHighMemoryThreshold
 		// _AND_ available system memory drops below worker config
-		// absoluteHighMemoryThreshold available system memory for longer
-		// than worker config allowedHighMemoryDuration seconds. When
-		// this happens, the task will be resolved as failed.
+		// absoluteHighMemoryThreshold for longer than worker config
+		// allowedHighMemoryDuration seconds. When this happens, the
+		// task will be resolved as failed.
 		//
 		// Since: generic-worker 83.4.0
 		//
@@ -1174,7 +1174,7 @@ func JSONSchema() string {
             },
             "resourceMonitor": {
               "default": true,
-              "description": "The resource monitor feature reports Peak System Memory Used,\nAverage System Memory Used, Average Available System Memory,\nand Total System Memory in the task log for each task command\nexecuted. It also will abort any task command if the used\nsystem memory exceeds worker config relativeHighMemoryThreshold\n_AND_ available system memory drops below worker config\nabsoluteHighMemoryThreshold available system memory for longer\nthan worker config allowedHighMemoryDuration seconds. When\nthis happens, the task will be resolved as failed.\n\nSince: generic-worker 83.4.0",
+              "description": "The resource monitor feature reports Peak System Memory Used,\nAverage System Memory Used, Average Available System Memory,\nand Total System Memory in the task log for each task command\nexecuted. It also will abort any task command if the used\nsystem memory exceeds worker config relativeHighMemoryThreshold\n_AND_ available system memory drops below worker config\nabsoluteHighMemoryThreshold for longer than worker config\nallowedHighMemoryDuration seconds. When this happens, the\ntask will be resolved as failed.\n\nSince: generic-worker 83.4.0",
               "title": "Resource monitor",
               "type": "boolean"
             },

--- a/workers/generic-worker/generated_multiuser_darwin.go
+++ b/workers/generic-worker/generated_multiuser_darwin.go
@@ -445,13 +445,15 @@ type (
 		// Since: generic-worker 53.1.0
 		LoopbackVideo bool `json:"loopbackVideo,omitempty"`
 
-		// The resource monitor features reports Peak System Memory Used,
-		// Average System Memory Used and Total Available Memory in the
-		// task log for each task command executed. It also will abort
-		// any task command that causes the available system memory to be
-		// reduced to less than or equal to 10% of the total system memory
-		// for five consecutive measurements at 0.5s intervals. When this
-		// happens, the task will be resolved as failed.
+		// The resource monitor feature reports Peak System Memory Used,
+		// Average System Memory Used, Average Available System Memory,
+		// and Total System Memory in the task log for each task command
+		// executed. It also will abort any task command if the used
+		// system memory exceeds worker config relativeHighMemoryThreshold
+		// _AND_ available system memory drops below worker config
+		// absoluteHighMemoryThreshold available system memory for longer
+		// than worker config allowedHighMemoryDuration seconds. When
+		// this happens, the task will be resolved as failed.
 		//
 		// Since: generic-worker 83.4.0
 		//
@@ -1216,7 +1218,7 @@ func JSONSchema() string {
             },
             "resourceMonitor": {
               "default": true,
-              "description": "The resource monitor features reports Peak System Memory Used,\nAverage System Memory Used and Total Available Memory in the\ntask log for each task command executed. It also will abort\nany task command that causes the available system memory to be\nreduced to less than or equal to 10% of the total system memory\nfor five consecutive measurements at 0.5s intervals. When this\nhappens, the task will be resolved as failed.\n\nSince: generic-worker 83.4.0",
+              "description": "The resource monitor feature reports Peak System Memory Used,\nAverage System Memory Used, Average Available System Memory,\nand Total System Memory in the task log for each task command\nexecuted. It also will abort any task command if the used\nsystem memory exceeds worker config relativeHighMemoryThreshold\n_AND_ available system memory drops below worker config\nabsoluteHighMemoryThreshold available system memory for longer\nthan worker config allowedHighMemoryDuration seconds. When\nthis happens, the task will be resolved as failed.\n\nSince: generic-worker 83.4.0",
               "title": "Resource monitor",
               "type": "boolean"
             },

--- a/workers/generic-worker/generated_multiuser_darwin.go
+++ b/workers/generic-worker/generated_multiuser_darwin.go
@@ -451,9 +451,9 @@ type (
 		// executed. It also will abort any task command if the used
 		// system memory exceeds worker config relativeHighMemoryThreshold
 		// _AND_ available system memory drops below worker config
-		// absoluteHighMemoryThreshold available system memory for longer
-		// than worker config allowedHighMemoryDuration seconds. When
-		// this happens, the task will be resolved as failed.
+		// absoluteHighMemoryThreshold for longer than worker config
+		// allowedHighMemoryDuration seconds. When this happens, the
+		// task will be resolved as failed.
 		//
 		// Since: generic-worker 83.4.0
 		//
@@ -1218,7 +1218,7 @@ func JSONSchema() string {
             },
             "resourceMonitor": {
               "default": true,
-              "description": "The resource monitor feature reports Peak System Memory Used,\nAverage System Memory Used, Average Available System Memory,\nand Total System Memory in the task log for each task command\nexecuted. It also will abort any task command if the used\nsystem memory exceeds worker config relativeHighMemoryThreshold\n_AND_ available system memory drops below worker config\nabsoluteHighMemoryThreshold available system memory for longer\nthan worker config allowedHighMemoryDuration seconds. When\nthis happens, the task will be resolved as failed.\n\nSince: generic-worker 83.4.0",
+              "description": "The resource monitor feature reports Peak System Memory Used,\nAverage System Memory Used, Average Available System Memory,\nand Total System Memory in the task log for each task command\nexecuted. It also will abort any task command if the used\nsystem memory exceeds worker config relativeHighMemoryThreshold\n_AND_ available system memory drops below worker config\nabsoluteHighMemoryThreshold for longer than worker config\nallowedHighMemoryDuration seconds. When this happens, the\ntask will be resolved as failed.\n\nSince: generic-worker 83.4.0",
               "title": "Resource monitor",
               "type": "boolean"
             },

--- a/workers/generic-worker/generated_multiuser_freebsd.go
+++ b/workers/generic-worker/generated_multiuser_freebsd.go
@@ -445,13 +445,15 @@ type (
 		// Since: generic-worker 53.1.0
 		LoopbackVideo bool `json:"loopbackVideo,omitempty"`
 
-		// The resource monitor features reports Peak System Memory Used,
-		// Average System Memory Used and Total Available Memory in the
-		// task log for each task command executed. It also will abort
-		// any task command that causes the available system memory to be
-		// reduced to less than or equal to 10% of the total system memory
-		// for five consecutive measurements at 0.5s intervals. When this
-		// happens, the task will be resolved as failed.
+		// The resource monitor feature reports Peak System Memory Used,
+		// Average System Memory Used, Average Available System Memory,
+		// and Total System Memory in the task log for each task command
+		// executed. It also will abort any task command if the used
+		// system memory exceeds worker config relativeHighMemoryThreshold
+		// _AND_ available system memory drops below worker config
+		// absoluteHighMemoryThreshold available system memory for longer
+		// than worker config allowedHighMemoryDuration seconds. When
+		// this happens, the task will be resolved as failed.
 		//
 		// Since: generic-worker 83.4.0
 		//
@@ -1216,7 +1218,7 @@ func JSONSchema() string {
             },
             "resourceMonitor": {
               "default": true,
-              "description": "The resource monitor features reports Peak System Memory Used,\nAverage System Memory Used and Total Available Memory in the\ntask log for each task command executed. It also will abort\nany task command that causes the available system memory to be\nreduced to less than or equal to 10% of the total system memory\nfor five consecutive measurements at 0.5s intervals. When this\nhappens, the task will be resolved as failed.\n\nSince: generic-worker 83.4.0",
+              "description": "The resource monitor feature reports Peak System Memory Used,\nAverage System Memory Used, Average Available System Memory,\nand Total System Memory in the task log for each task command\nexecuted. It also will abort any task command if the used\nsystem memory exceeds worker config relativeHighMemoryThreshold\n_AND_ available system memory drops below worker config\nabsoluteHighMemoryThreshold available system memory for longer\nthan worker config allowedHighMemoryDuration seconds. When\nthis happens, the task will be resolved as failed.\n\nSince: generic-worker 83.4.0",
               "title": "Resource monitor",
               "type": "boolean"
             },

--- a/workers/generic-worker/generated_multiuser_freebsd.go
+++ b/workers/generic-worker/generated_multiuser_freebsd.go
@@ -451,9 +451,9 @@ type (
 		// executed. It also will abort any task command if the used
 		// system memory exceeds worker config relativeHighMemoryThreshold
 		// _AND_ available system memory drops below worker config
-		// absoluteHighMemoryThreshold available system memory for longer
-		// than worker config allowedHighMemoryDuration seconds. When
-		// this happens, the task will be resolved as failed.
+		// absoluteHighMemoryThreshold for longer than worker config
+		// allowedHighMemoryDuration seconds. When this happens, the
+		// task will be resolved as failed.
 		//
 		// Since: generic-worker 83.4.0
 		//
@@ -1218,7 +1218,7 @@ func JSONSchema() string {
             },
             "resourceMonitor": {
               "default": true,
-              "description": "The resource monitor feature reports Peak System Memory Used,\nAverage System Memory Used, Average Available System Memory,\nand Total System Memory in the task log for each task command\nexecuted. It also will abort any task command if the used\nsystem memory exceeds worker config relativeHighMemoryThreshold\n_AND_ available system memory drops below worker config\nabsoluteHighMemoryThreshold available system memory for longer\nthan worker config allowedHighMemoryDuration seconds. When\nthis happens, the task will be resolved as failed.\n\nSince: generic-worker 83.4.0",
+              "description": "The resource monitor feature reports Peak System Memory Used,\nAverage System Memory Used, Average Available System Memory,\nand Total System Memory in the task log for each task command\nexecuted. It also will abort any task command if the used\nsystem memory exceeds worker config relativeHighMemoryThreshold\n_AND_ available system memory drops below worker config\nabsoluteHighMemoryThreshold for longer than worker config\nallowedHighMemoryDuration seconds. When this happens, the\ntask will be resolved as failed.\n\nSince: generic-worker 83.4.0",
               "title": "Resource monitor",
               "type": "boolean"
             },

--- a/workers/generic-worker/generated_multiuser_linux.go
+++ b/workers/generic-worker/generated_multiuser_linux.go
@@ -445,13 +445,15 @@ type (
 		// Since: generic-worker 53.1.0
 		LoopbackVideo bool `json:"loopbackVideo,omitempty"`
 
-		// The resource monitor features reports Peak System Memory Used,
-		// Average System Memory Used and Total Available Memory in the
-		// task log for each task command executed. It also will abort
-		// any task command that causes the available system memory to be
-		// reduced to less than or equal to 10% of the total system memory
-		// for five consecutive measurements at 0.5s intervals. When this
-		// happens, the task will be resolved as failed.
+		// The resource monitor feature reports Peak System Memory Used,
+		// Average System Memory Used, Average Available System Memory,
+		// and Total System Memory in the task log for each task command
+		// executed. It also will abort any task command if the used
+		// system memory exceeds worker config relativeHighMemoryThreshold
+		// _AND_ available system memory drops below worker config
+		// absoluteHighMemoryThreshold available system memory for longer
+		// than worker config allowedHighMemoryDuration seconds. When
+		// this happens, the task will be resolved as failed.
 		//
 		// Since: generic-worker 83.4.0
 		//
@@ -1216,7 +1218,7 @@ func JSONSchema() string {
             },
             "resourceMonitor": {
               "default": true,
-              "description": "The resource monitor features reports Peak System Memory Used,\nAverage System Memory Used and Total Available Memory in the\ntask log for each task command executed. It also will abort\nany task command that causes the available system memory to be\nreduced to less than or equal to 10% of the total system memory\nfor five consecutive measurements at 0.5s intervals. When this\nhappens, the task will be resolved as failed.\n\nSince: generic-worker 83.4.0",
+              "description": "The resource monitor feature reports Peak System Memory Used,\nAverage System Memory Used, Average Available System Memory,\nand Total System Memory in the task log for each task command\nexecuted. It also will abort any task command if the used\nsystem memory exceeds worker config relativeHighMemoryThreshold\n_AND_ available system memory drops below worker config\nabsoluteHighMemoryThreshold available system memory for longer\nthan worker config allowedHighMemoryDuration seconds. When\nthis happens, the task will be resolved as failed.\n\nSince: generic-worker 83.4.0",
               "title": "Resource monitor",
               "type": "boolean"
             },

--- a/workers/generic-worker/generated_multiuser_linux.go
+++ b/workers/generic-worker/generated_multiuser_linux.go
@@ -451,9 +451,9 @@ type (
 		// executed. It also will abort any task command if the used
 		// system memory exceeds worker config relativeHighMemoryThreshold
 		// _AND_ available system memory drops below worker config
-		// absoluteHighMemoryThreshold available system memory for longer
-		// than worker config allowedHighMemoryDuration seconds. When
-		// this happens, the task will be resolved as failed.
+		// absoluteHighMemoryThreshold for longer than worker config
+		// allowedHighMemoryDuration seconds. When this happens, the
+		// task will be resolved as failed.
 		//
 		// Since: generic-worker 83.4.0
 		//
@@ -1218,7 +1218,7 @@ func JSONSchema() string {
             },
             "resourceMonitor": {
               "default": true,
-              "description": "The resource monitor feature reports Peak System Memory Used,\nAverage System Memory Used, Average Available System Memory,\nand Total System Memory in the task log for each task command\nexecuted. It also will abort any task command if the used\nsystem memory exceeds worker config relativeHighMemoryThreshold\n_AND_ available system memory drops below worker config\nabsoluteHighMemoryThreshold available system memory for longer\nthan worker config allowedHighMemoryDuration seconds. When\nthis happens, the task will be resolved as failed.\n\nSince: generic-worker 83.4.0",
+              "description": "The resource monitor feature reports Peak System Memory Used,\nAverage System Memory Used, Average Available System Memory,\nand Total System Memory in the task log for each task command\nexecuted. It also will abort any task command if the used\nsystem memory exceeds worker config relativeHighMemoryThreshold\n_AND_ available system memory drops below worker config\nabsoluteHighMemoryThreshold for longer than worker config\nallowedHighMemoryDuration seconds. When this happens, the\ntask will be resolved as failed.\n\nSince: generic-worker 83.4.0",
               "title": "Resource monitor",
               "type": "boolean"
             },

--- a/workers/generic-worker/generated_multiuser_windows.go
+++ b/workers/generic-worker/generated_multiuser_windows.go
@@ -213,13 +213,15 @@ type (
 		// Default:    true
 		LiveLog bool `json:"liveLog" default:"true"`
 
-		// The resource monitor features reports Peak System Memory Used,
-		// Average System Memory Used and Total Available Memory in the
-		// task log for each task command executed. It also will abort
-		// any task command that causes the available system memory to be
-		// reduced to less than or equal to 10% of the total system memory
-		// for five consecutive measurements at 0.5s intervals. When this
-		// happens, the task will be resolved as failed.
+		// The resource monitor feature reports Peak System Memory Used,
+		// Average System Memory Used, Average Available System Memory,
+		// and Total System Memory in the task log for each task command
+		// executed. It also will abort any task command if the used
+		// system memory exceeds worker config relativeHighMemoryThreshold
+		// _AND_ available system memory drops below worker config
+		// absoluteHighMemoryThreshold available system memory for longer
+		// than worker config allowedHighMemoryDuration seconds. When
+		// this happens, the task will be resolved as failed.
 		//
 		// Since: generic-worker 83.4.0
 		//
@@ -945,7 +947,7 @@ func JSONSchema() string {
         },
         "resourceMonitor": {
           "default": true,
-          "description": "The resource monitor features reports Peak System Memory Used,\nAverage System Memory Used and Total Available Memory in the\ntask log for each task command executed. It also will abort\nany task command that causes the available system memory to be\nreduced to less than or equal to 10% of the total system memory\nfor five consecutive measurements at 0.5s intervals. When this\nhappens, the task will be resolved as failed.\n\nSince: generic-worker 83.4.0",
+          "description": "The resource monitor feature reports Peak System Memory Used,\nAverage System Memory Used, Average Available System Memory,\nand Total System Memory in the task log for each task command\nexecuted. It also will abort any task command if the used\nsystem memory exceeds worker config relativeHighMemoryThreshold\n_AND_ available system memory drops below worker config\nabsoluteHighMemoryThreshold available system memory for longer\nthan worker config allowedHighMemoryDuration seconds. When\nthis happens, the task will be resolved as failed.\n\nSince: generic-worker 83.4.0",
           "title": "Resource monitor",
           "type": "boolean"
         },

--- a/workers/generic-worker/generated_multiuser_windows.go
+++ b/workers/generic-worker/generated_multiuser_windows.go
@@ -219,9 +219,9 @@ type (
 		// executed. It also will abort any task command if the used
 		// system memory exceeds worker config relativeHighMemoryThreshold
 		// _AND_ available system memory drops below worker config
-		// absoluteHighMemoryThreshold available system memory for longer
-		// than worker config allowedHighMemoryDuration seconds. When
-		// this happens, the task will be resolved as failed.
+		// absoluteHighMemoryThreshold for longer than worker config
+		// allowedHighMemoryDuration seconds. When this happens, the
+		// task will be resolved as failed.
 		//
 		// Since: generic-worker 83.4.0
 		//
@@ -947,7 +947,7 @@ func JSONSchema() string {
         },
         "resourceMonitor": {
           "default": true,
-          "description": "The resource monitor feature reports Peak System Memory Used,\nAverage System Memory Used, Average Available System Memory,\nand Total System Memory in the task log for each task command\nexecuted. It also will abort any task command if the used\nsystem memory exceeds worker config relativeHighMemoryThreshold\n_AND_ available system memory drops below worker config\nabsoluteHighMemoryThreshold available system memory for longer\nthan worker config allowedHighMemoryDuration seconds. When\nthis happens, the task will be resolved as failed.\n\nSince: generic-worker 83.4.0",
+          "description": "The resource monitor feature reports Peak System Memory Used,\nAverage System Memory Used, Average Available System Memory,\nand Total System Memory in the task log for each task command\nexecuted. It also will abort any task command if the used\nsystem memory exceeds worker config relativeHighMemoryThreshold\n_AND_ available system memory drops below worker config\nabsoluteHighMemoryThreshold for longer than worker config\nallowedHighMemoryDuration seconds. When this happens, the\ntask will be resolved as failed.\n\nSince: generic-worker 83.4.0",
           "title": "Resource monitor",
           "type": "boolean"
         },

--- a/workers/generic-worker/gwconfig/config.go
+++ b/workers/generic-worker/gwconfig/config.go
@@ -27,6 +27,8 @@ type (
 	PublicConfig struct {
 		PublicEngineConfig
 		PublicPlatformConfig
+		AbsoluteHighMemoryThreshold    uint64         `json:"absoluteHighMemoryThreshold"`
+		AllowedHighMemoryDurationSecs  uint64         `json:"allowedHighMemoryDurationSecs"`
 		AvailabilityZone               string         `json:"availabilityZone"`
 		CachesDir                      string         `json:"cachesDir"`
 		CheckForNewDeploymentEverySecs uint           `json:"checkForNewDeploymentEverySecs"`
@@ -58,6 +60,7 @@ type (
 		PrivateIP                      net.IP         `json:"privateIP"`
 		ProvisionerID                  string         `json:"provisionerId"`
 		PublicIP                       net.IP         `json:"publicIP"`
+		RelativeHighMemoryThreshold    uint64         `json:"relativeHighMemoryThreshold"`
 		Region                         string         `json:"region"`
 		RequiredDiskSpaceMegabytes     uint           `json:"requiredDiskSpaceMegabytes"`
 		RootURL                        string         `json:"rootURL"`

--- a/workers/generic-worker/helper_test.go
+++ b/workers/generic-worker/helper_test.go
@@ -344,8 +344,10 @@ func GWTest(t *testing.T) *Test {
 			Certificate: os.Getenv("TASKCLUSTER_CERTIFICATE"),
 		},
 		PublicConfig: gwconfig.PublicConfig{
-			PublicPlatformConfig: *gwconfig.DefaultPublicPlatformConfig(),
-			AvailabilityZone:     "outer-space",
+			PublicPlatformConfig:          *gwconfig.DefaultPublicPlatformConfig(),
+			AbsoluteHighMemoryThreshold:   524288000, // 500 MiB
+			AllowedHighMemoryDurationSecs: 5,
+			AvailabilityZone:              "outer-space",
 			// Need common caches directory across tests, since files
 			// directory-caches.json and file-caches.json are not per-test.
 			CachesDir:                      cachesDir,
@@ -373,13 +375,14 @@ func GWTest(t *testing.T) *Test {
 			// The base port on which the livelog process listens locally. (Livelog uses this and the next port.)
 			// These ports are not exposed outside of the host. However, in CI they must differ from those of the
 			// generic-worker instance running the test suite.
-			LiveLogPortBase:    30583,
-			MaxTaskRunTime:     300,
-			NumberOfTasksToRun: 1,
-			PrivateIP:          net.ParseIP("87.65.43.21"),
-			ProvisionerID:      "test-provisioner",
-			PublicIP:           net.ParseIP("12.34.56.78"),
-			Region:             "test-worker-group",
+			LiveLogPortBase:             30583,
+			MaxTaskRunTime:              300,
+			NumberOfTasksToRun:          1,
+			PrivateIP:                   net.ParseIP("87.65.43.21"),
+			ProvisionerID:               "test-provisioner",
+			PublicIP:                    net.ParseIP("12.34.56.78"),
+			RelativeHighMemoryThreshold: 90,
+			Region:                      "test-worker-group",
 			// should be enough for tests, and travis-ci.org CI environments don't
 			// have a lot of free disk
 			RequiredDiskSpaceMegabytes:     16,

--- a/workers/generic-worker/main.go
+++ b/workers/generic-worker/main.go
@@ -224,6 +224,8 @@ func loadConfig(configFile *gwconfig.File) error {
 		PublicConfig: gwconfig.PublicConfig{
 			PublicEngineConfig:             *gwconfig.DefaultPublicEngineConfig(),
 			PublicPlatformConfig:           *gwconfig.DefaultPublicPlatformConfig(),
+			AbsoluteHighMemoryThreshold:    524288000, // 500 MiB
+			AllowedHighMemoryDurationSecs:  5,
 			CachesDir:                      "caches",
 			CheckForNewDeploymentEverySecs: 1800,
 			CleanUpTaskDirs:                true,
@@ -245,6 +247,7 @@ func loadConfig(configFile *gwconfig.File) error {
 			MaxTaskRunTime:                 86400, // 86400s is 24 hours
 			NumberOfTasksToRun:             0,
 			ProvisionerID:                  "test-provisioner",
+			RelativeHighMemoryThreshold:    90,
 			RequiredDiskSpaceMegabytes:     10240,
 			RootURL:                        "",
 			RunAfterUserCreation:           "",
@@ -787,10 +790,11 @@ func (task *TaskRun) ExecuteCommand(index int) *CommandExecutionError {
 		panic(cee)
 	}
 	task.result = task.Commands[index].Execute()
+	task.Infof("%v", task.result)
+
 	if ae := task.StatusManager.AbortException(); ae != nil {
 		return ae
 	}
-	task.Infof("%v", task.result)
 
 	switch {
 	case task.result.Failed():

--- a/workers/generic-worker/schemas/insecure_posix.yml
+++ b/workers/generic-worker/schemas/insecure_posix.yml
@@ -294,9 +294,9 @@ oneOf:
             executed. It also will abort any task command if the used
             system memory exceeds worker config relativeHighMemoryThreshold
             _AND_ available system memory drops below worker config
-            absoluteHighMemoryThreshold available system memory for longer
-            than worker config allowedHighMemoryDuration seconds. When
-            this happens, the task will be resolved as failed.
+            absoluteHighMemoryThreshold for longer than worker config
+            allowedHighMemoryDuration seconds. When this happens, the
+            task will be resolved as failed.
 
             Since: generic-worker 83.4.0
           default: true

--- a/workers/generic-worker/schemas/insecure_posix.yml
+++ b/workers/generic-worker/schemas/insecure_posix.yml
@@ -288,13 +288,15 @@ oneOf:
           type: boolean
           title: Resource monitor
           description: |-
-            The resource monitor features reports Peak System Memory Used,
-            Average System Memory Used and Total Available Memory in the
-            task log for each task command executed. It also will abort
-            any task command that causes the available system memory to be
-            reduced to less than or equal to 10% of the total system memory
-            for five consecutive measurements at 0.5s intervals. When this
-            happens, the task will be resolved as failed.
+            The resource monitor feature reports Peak System Memory Used,
+            Average System Memory Used, Average Available System Memory,
+            and Total System Memory in the task log for each task command
+            executed. It also will abort any task command if the used
+            system memory exceeds worker config relativeHighMemoryThreshold
+            _AND_ available system memory drops below worker config
+            absoluteHighMemoryThreshold available system memory for longer
+            than worker config allowedHighMemoryDuration seconds. When
+            this happens, the task will be resolved as failed.
 
             Since: generic-worker 83.4.0
           default: true

--- a/workers/generic-worker/schemas/multiuser_posix.yml
+++ b/workers/generic-worker/schemas/multiuser_posix.yml
@@ -332,13 +332,15 @@ oneOf:
           type: boolean
           title: Resource monitor
           description: |-
-            The resource monitor features reports Peak System Memory Used,
-            Average System Memory Used and Total Available Memory in the
-            task log for each task command executed. It also will abort
-            any task command that causes the available system memory to be
-            reduced to less than or equal to 10% of the total system memory
-            for five consecutive measurements at 0.5s intervals. When this
-            happens, the task will be resolved as failed.
+            The resource monitor feature reports Peak System Memory Used,
+            Average System Memory Used, Average Available System Memory,
+            and Total System Memory in the task log for each task command
+            executed. It also will abort any task command if the used
+            system memory exceeds worker config relativeHighMemoryThreshold
+            _AND_ available system memory drops below worker config
+            absoluteHighMemoryThreshold available system memory for longer
+            than worker config allowedHighMemoryDuration seconds. When
+            this happens, the task will be resolved as failed.
 
             Since: generic-worker 83.4.0
           default: true

--- a/workers/generic-worker/schemas/multiuser_posix.yml
+++ b/workers/generic-worker/schemas/multiuser_posix.yml
@@ -338,9 +338,9 @@ oneOf:
             executed. It also will abort any task command if the used
             system memory exceeds worker config relativeHighMemoryThreshold
             _AND_ available system memory drops below worker config
-            absoluteHighMemoryThreshold available system memory for longer
-            than worker config allowedHighMemoryDuration seconds. When
-            this happens, the task will be resolved as failed.
+            absoluteHighMemoryThreshold for longer than worker config
+            allowedHighMemoryDuration seconds. When this happens, the
+            task will be resolved as failed.
 
             Since: generic-worker 83.4.0
           default: true

--- a/workers/generic-worker/schemas/multiuser_windows.yml
+++ b/workers/generic-worker/schemas/multiuser_windows.yml
@@ -295,9 +295,9 @@ properties:
           executed. It also will abort any task command if the used
           system memory exceeds worker config relativeHighMemoryThreshold
           _AND_ available system memory drops below worker config
-          absoluteHighMemoryThreshold available system memory for longer
-          than worker config allowedHighMemoryDuration seconds. When
-          this happens, the task will be resolved as failed.
+          absoluteHighMemoryThreshold for longer than worker config
+          allowedHighMemoryDuration seconds. When this happens, the
+          task will be resolved as failed.
 
           Since: generic-worker 83.4.0
         default: true

--- a/workers/generic-worker/schemas/multiuser_windows.yml
+++ b/workers/generic-worker/schemas/multiuser_windows.yml
@@ -289,13 +289,15 @@ properties:
         type: boolean
         title: Resource monitor
         description: |-
-          The resource monitor features reports Peak System Memory Used,
-          Average System Memory Used and Total Available Memory in the
-          task log for each task command executed. It also will abort
-          any task command that causes the available system memory to be
-          reduced to less than or equal to 10% of the total system memory
-          for five consecutive measurements at 0.5s intervals. When this
-          happens, the task will be resolved as failed.
+          The resource monitor feature reports Peak System Memory Used,
+          Average System Memory Used, Average Available System Memory,
+          and Total System Memory in the task log for each task command
+          executed. It also will abort any task command if the used
+          system memory exceeds worker config relativeHighMemoryThreshold
+          _AND_ available system memory drops below worker config
+          absoluteHighMemoryThreshold available system memory for longer
+          than worker config allowedHighMemoryDuration seconds. When
+          this happens, the task will be resolved as failed.
 
           Since: generic-worker 83.4.0
         default: true

--- a/workers/generic-worker/taskstatus.go
+++ b/workers/generic-worker/taskstatus.go
@@ -183,9 +183,6 @@ func (tsm *TaskStatusManager) reclaim() error {
 			task.queueMux.Unlock()
 			tsm.status = tcrsp.Status
 			tsm.takenUntil = tcrsp.TakenUntil
-			if err != nil {
-				log.Printf("SERIOUS BUG: invalid credentials in queue claim response body: %v", err)
-			}
 			log.Printf("Reclaimed task %v successfully.", task.TaskID)
 			return nil
 		},

--- a/workers/generic-worker/usage.go
+++ b/workers/generic-worker/usage.go
@@ -131,6 +131,25 @@ and reports back results to the queue.
         ** OPTIONAL ** properties
         =========================
 
+          absoluteHighMemoryThreshold       Number of bytes the resource monitor uses to
+                                            determine when to abort a task due to high
+                                            memory usage. The is an absolute number of bytes
+                                            needed of available memory before aborting the task.
+                                            For example, if the value is 524288000, then the worker will
+                                            abort a task if the memory available is 200MiB or less
+                                            for longer than allowedHighMemoryDurationSecs seconds.
+                                            Can be used in conjunction with relativeHighMemoryThreshold.
+                                            Does nothing if disableOOMProtection is set to true.
+                                            [default: 524288000] (500MiB)
+          allowedHighMemoryDurationSecs     The number of seconds the resource monitor will
+                                            allow the system memory usage to be above the high
+                                            memory thresholds (see absoluteHighMemoryThreshold
+                                            and relativeHighMemoryThreshold) before aborting
+                                            the task. If the memory usage is above the high
+                                            memory thresholds for longer than this time, the
+                                            worker will abort the task. Does nothing if
+                                            disableOOMProtection is set to true.
+                                            [default: 5]
           availabilityZone                  The EC2 availability zone of the worker.
           cachesDir                         The directory where task caches should be stored on
                                             the worker. The directory will be created if it does
@@ -174,8 +193,9 @@ and reports back results to the queue.
                                             [default: false]
           disableOOMProtection              If true, the worker will continue to monitor system
                                             memory usage, but will not abort tasks when the
-                                            system memory usage is at 90% or higher for five
-                                            consecutive measurements at 0.5s intervals.
+                                            system memory usage hits the absoluteHighMemoryThreshold
+                                            AND relativeHighMemoryThreshold for longer than
+                                            allowedHighMemoryDurationSecs seconds.
                                             [default: false]
           downloadsDir                      The directory to cache downloaded files for
                                             populating preloaded caches and readonly mounts. The
@@ -231,6 +251,17 @@ and reports back results to the queue.
           publicIP                          The IP address for VNC access.  Also used by chain of
                                             trust when present.
           region                            The EC2 region of the worker. Used by chain of trust.
+          relativeHighMemoryThreshold       A percent used by the resource monitor to determine
+                                            when to abort a task due to high memory usage.
+                                            This is a relative value, meaning that it is
+                                            relative to the total memory available on the
+                                            worker. For example, if the value is 90, then
+                                            the worker will abort a task if the memory
+                                            usage is at 90% or higher for longer than
+                                            allowedHighMemoryDurationSecs seconds. Can be used
+                                            in conjunction with absoluteHighMemoryThreshold.
+                                            Does nothing if disableOOMProtection is set to true.
+                                            [default: 90]
           requiredDiskSpaceMegabytes        The garbage collector will ensure at least this
                                             number of megabytes of disk space are available
                                             when each task starts. If it cannot free enough

--- a/workers/generic-worker/usage.go
+++ b/workers/generic-worker/usage.go
@@ -133,10 +133,10 @@ and reports back results to the queue.
 
           absoluteHighMemoryThreshold       Number of bytes the resource monitor uses to
                                             determine when to abort a task due to high
-                                            memory usage. The is an absolute number of bytes
+                                            memory usage. This is an absolute number of bytes
                                             needed of available memory before aborting the task.
                                             For example, if the value is 524288000, then the worker will
-                                            abort a task if the memory available is 200MiB or less
+                                            abort a task if the memory available is 500MiB or less
                                             for longer than allowedHighMemoryDurationSecs seconds.
                                             Can be used in conjunction with relativeHighMemoryThreshold.
                                             Does nothing if disableOOMProtection is set to true.


### PR DESCRIPTION
Fixes #7769.

>Generic Worker: resource monitor will print out its usage summary after aborting the task.


Fixes #7770.

>Generic Worker: adds additional resource monitoring auto-abortion configuration to better fine-tune how your worker aborts running task processes.
>
>  * `absoluteHighMemoryThreshold`: The minimum amount of available memory (in bytes) required before considering task abortion. If available memory drops below this value, it may trigger an abort. Default: `524288000` (500MiB).
>  * `relativeHighMemoryThreshold`: The percentage of total system memory usage that, if exceeded, contributes to the decision to abort the task. Default: `90`.
>  * `allowedHighMemoryDurationSecs`: The maximum duration (in seconds) that high memory usage conditions can persist before the task is aborted. Default: `5`.
>
>Generic Worker will auto-abort a task if the total system memory used percentage is greater than `relativeHighMemoryThreshold` _AND_ the available memory is less than `absoluteHighMemoryThreshold` for `numberOfConsecutiveMeasurements` measurements at 0.5s intervals, unless `disableOOMProtection` is enabled.