### PR TITLE
feat(ui): TaskGroup page memory and rendering optimizations

### DIFF
--- a/changelog/issue-7498.md
+++ b/changelog/issue-7498.md
@@ -1,0 +1,6 @@
+audience: users
+level: patch
+reference: issue 7498
+---
+
+Further UI memory optimizations for the TaskGroup page to avoid using too much memory during intensive updates.

--- a/ui/src/components/TaskGroupProgress/index.test.jsx
+++ b/ui/src/components/TaskGroupProgress/index.test.jsx
@@ -10,10 +10,16 @@ it('should render TaskGroupProgress', () => {
       <TaskGroupProgress
         taskGroupId="abc"
         taskGroupLoaded={false}
-        taskGroup={{ edges: [] }}
+        statusCount={{
+          completed: 0,
+          failed: 0,
+          exception: 0,
+          running: 0,
+          pending: 0,
+          unscheduled: 0,
+        }}
         filter="RUNNING"
         onStatusClick={nop}
-        onUpdate={nop}
       />
     </MemoryRouter>
   );

--- a/ui/src/utils/memoize.js
+++ b/ui/src/utils/memoize.js
@@ -1,7 +1,7 @@
 import fastMemoize from 'fast-memoize';
 import crypto from 'crypto';
 
-const MAX_SIZE = 50;
+const MAX_SIZE = 10;
 const MAX_KEY_LENGTH = 200;
 
 /**


### PR DESCRIPTION
This is not a complete fix, but a big step forward. Page stays responsive under frequent updates, and memory grows considerably slower compared to the existing state. 

* Limit default maxsize for memoized functions
* Uses React.memo for row rendering to avoid creating new objects when data is not be changed. This seems to improve memory consumption
* Calculate TaskGroup counts in the main component (This will avoid passing huge lists of tasks between components)
* TaskGroupTable uses batched updates for the subscriptions to avoid frequent updates

Fixes #7498 (again)
