### PR TITLE
chore(generic-worker)!: rename OOM config options

### DIFF
--- a/changelog/ZPZBjOAmQhCB9OdPXWL-cQ.md
+++ b/changelog/ZPZBjOAmQhCB9OdPXWL-cQ.md
@@ -1,0 +1,7 @@
+audience: worker-deployers
+level: major
+---
+Generic Worker: renamed the following worker configuration options to avoid confusion:
+
+  * `absoluteHighMemoryThreshold` --> `minAvailableMemoryBytes`
+  * `relativeHighMemoryThreshold` --> `maxMemoryUsagePercent`

--- a/generated/references.json
+++ b/generated/references.json
@@ -9005,7 +9005,7 @@
             },
             "resourceMonitor": {
               "default": true,
-              "description": "The resource monitor feature reports Peak System Memory Used,\nAverage System Memory Used, Average Available System Memory,\nand Total System Memory in the task log for each task command\nexecuted. It also will abort any task command if the used\nsystem memory exceeds worker config relativeHighMemoryThreshold\n_AND_ available system memory drops below worker config\nabsoluteHighMemoryThreshold for longer than worker config\nallowedHighMemoryDuration seconds. When this happens, the\ntask will be resolved as failed.\n\nSince: generic-worker 83.4.0",
+              "description": "The resource monitor feature reports Peak System Memory Used,\nAverage System Memory Used, Average Available System Memory,\nand Total System Memory in the task log for each task command\nexecuted. It also will abort any task command if the used\nsystem memory exceeds worker config maxMemoryUsagePercent\n_AND_ available system memory drops below worker config\nminAvailableMemoryBytes for longer than worker config\nallowedHighMemoryDuration seconds. When this happens, the\ntask will be resolved as failed.\n\nSince: generic-worker 83.4.0",
               "title": "Resource monitor",
               "type": "boolean"
             },
@@ -9540,7 +9540,7 @@
                 },
                 "resourceMonitor": {
                   "default": true,
-                  "description": "The resource monitor feature reports Peak System Memory Used,\nAverage System Memory Used, Average Available System Memory,\nand Total System Memory in the task log for each task command\nexecuted. It also will abort any task command if the used\nsystem memory exceeds worker config relativeHighMemoryThreshold\n_AND_ available system memory drops below worker config\nabsoluteHighMemoryThreshold for longer than worker config\nallowedHighMemoryDuration seconds. When this happens, the\ntask will be resolved as failed.\n\nSince: generic-worker 83.4.0",
+                  "description": "The resource monitor feature reports Peak System Memory Used,\nAverage System Memory Used, Average Available System Memory,\nand Total System Memory in the task log for each task command\nexecuted. It also will abort any task command if the used\nsystem memory exceeds worker config maxMemoryUsagePercent\n_AND_ available system memory drops below worker config\nminAvailableMemoryBytes for longer than worker config\nallowedHighMemoryDuration seconds. When this happens, the\ntask will be resolved as failed.\n\nSince: generic-worker 83.4.0",
                   "title": "Resource monitor",
                   "type": "boolean"
                 },
@@ -10349,7 +10349,7 @@
                 },
                 "resourceMonitor": {
                   "default": true,
-                  "description": "The resource monitor feature reports Peak System Memory Used,\nAverage System Memory Used, Average Available System Memory,\nand Total System Memory in the task log for each task command\nexecuted. It also will abort any task command if the used\nsystem memory exceeds worker config relativeHighMemoryThreshold\n_AND_ available system memory drops below worker config\nabsoluteHighMemoryThreshold for longer than worker config\nallowedHighMemoryDuration seconds. When this happens, the\ntask will be resolved as failed.\n\nSince: generic-worker 83.4.0",
+                  "description": "The resource monitor feature reports Peak System Memory Used,\nAverage System Memory Used, Average Available System Memory,\nand Total System Memory in the task log for each task command\nexecuted. It also will abort any task command if the used\nsystem memory exceeds worker config maxMemoryUsagePercent\n_AND_ available system memory drops below worker config\nminAvailableMemoryBytes for longer than worker config\nallowedHighMemoryDuration seconds. When this happens, the\ntask will be resolved as failed.\n\nSince: generic-worker 83.4.0",
                   "title": "Resource monitor",
                   "type": "boolean"
                 },

--- a/tools/d2g/genericworker/generated_types.go
+++ b/tools/d2g/genericworker/generated_types.go
@@ -447,9 +447,9 @@ type (
 		// Average System Memory Used, Average Available System Memory,
 		// and Total System Memory in the task log for each task command
 		// executed. It also will abort any task command if the used
-		// system memory exceeds worker config relativeHighMemoryThreshold
+		// system memory exceeds worker config maxMemoryUsagePercent
 		// _AND_ available system memory drops below worker config
-		// absoluteHighMemoryThreshold for longer than worker config
+		// minAvailableMemoryBytes for longer than worker config
 		// allowedHighMemoryDuration seconds. When this happens, the
 		// task will be resolved as failed.
 		//
@@ -1216,7 +1216,7 @@ func JSONSchema() string {
             },
             "resourceMonitor": {
               "default": true,
-              "description": "The resource monitor feature reports Peak System Memory Used,\nAverage System Memory Used, Average Available System Memory,\nand Total System Memory in the task log for each task command\nexecuted. It also will abort any task command if the used\nsystem memory exceeds worker config relativeHighMemoryThreshold\n_AND_ available system memory drops below worker config\nabsoluteHighMemoryThreshold for longer than worker config\nallowedHighMemoryDuration seconds. When this happens, the\ntask will be resolved as failed.\n\nSince: generic-worker 83.4.0",
+              "description": "The resource monitor feature reports Peak System Memory Used,\nAverage System Memory Used, Average Available System Memory,\nand Total System Memory in the task log for each task command\nexecuted. It also will abort any task command if the used\nsystem memory exceeds worker config maxMemoryUsagePercent\n_AND_ available system memory drops below worker config\nminAvailableMemoryBytes for longer than worker config\nallowedHighMemoryDuration seconds. When this happens, the\ntask will be resolved as failed.\n\nSince: generic-worker 83.4.0",
               "title": "Resource monitor",
               "type": "boolean"
             },

--- a/ui/docs/reference/workers/generic-worker/usage.mdx
+++ b/ui/docs/reference/workers/generic-worker/usage.mdx
@@ -113,20 +113,10 @@ and reports back results to the queue.
         ** OPTIONAL ** properties
         =========================
 
-          absoluteHighMemoryThreshold       Number of bytes the resource monitor uses to
-                                            determine when to abort a task due to high
-                                            memory usage. This is an absolute number of bytes
-                                            needed of available memory before aborting the task.
-                                            For example, if the value is 524288000, then the worker will
-                                            abort a task if the memory available is 500MiB or less
-                                            for longer than allowedHighMemoryDurationSecs seconds.
-                                            Can be used in conjunction with relativeHighMemoryThreshold.
-                                            Does nothing if disableOOMProtection is set to true.
-                                            [default: 524288000] (500MiB)
           allowedHighMemoryDurationSecs     The number of seconds the resource monitor will
                                             allow the system memory usage to be above the high
-                                            memory thresholds (see absoluteHighMemoryThreshold
-                                            and relativeHighMemoryThreshold) before aborting
+                                            memory thresholds (see minAvailableMemoryBytes
+                                            and maxMemoryUsagePercent) before aborting
                                             the task. If the memory usage is above the high
                                             memory thresholds for longer than this time, the
                                             worker will abort the task. Does nothing if
@@ -179,8 +169,8 @@ and reports back results to the queue.
                                             [default: false]
           disableOOMProtection              If true, the worker will continue to monitor system
                                             memory usage, but will not abort tasks when the
-                                            system memory usage hits the absoluteHighMemoryThreshold
-                                            AND relativeHighMemoryThreshold for longer than
+                                            system memory usage hits the minAvailableMemoryBytes
+                                            AND maxMemoryUsagePercent for longer than
                                             allowedHighMemoryDurationSecs seconds.
                                             [default: false]
           downloadsDir                      The directory to cache downloaded files for
@@ -267,8 +257,29 @@ and reports back results to the queue.
                                             /dev/video<DEVICE_NUMBER> where <DEVICE_NUMBER> is an integer
                                             between 0 and 255. This setting may be used to change it.
                                             [default: 0]
+          maxMemoryUsagePercent             A percent used by the resource monitor to determine
+                                            when to abort a task due to high memory usage.
+                                            This is a relative value, meaning that it is
+                                            relative to the total memory available on the
+                                            worker. For example, if the value is 90, then
+                                            the worker will abort a task if the memory
+                                            usage is at 90% or higher for longer than
+                                            allowedHighMemoryDurationSecs seconds. Can be used
+                                            in conjunction with minAvailableMemoryBytes.
+                                            Does nothing if disableOOMProtection is set to true.
+                                            [default: 90]
           maxTaskRunTime                    The maximum value allowed for maxRunTime on generic-worker payloads.
                                             [default: 86400]
+          minAvailableMemoryBytes           Number of bytes the resource monitor uses to
+                                            determine when to abort a task due to high
+                                            memory usage. This is an absolute number of bytes
+                                            needed of available memory before aborting the task.
+                                            For example, if the value is 524288000, then the worker will
+                                            abort a task if the memory available is 500MiB or less
+                                            for longer than allowedHighMemoryDurationSecs seconds.
+                                            Can be used in conjunction with maxMemoryUsagePercent.
+                                            Does nothing if disableOOMProtection is set to true.
+                                            [default: 524288000] (500MiB)
           numberOfTasksToRun                If zero, run tasks indefinitely. Otherwise, after
                                             this many tasks, exit. [default: 0]
           privateIP                         The private IP of the worker, used by chain of trust.
@@ -278,17 +289,6 @@ and reports back results to the queue.
           publicIP                          The IP address for VNC access.  Also used by chain of
                                             trust when present.
           region                            The EC2 region of the worker. Used by chain of trust.
-          relativeHighMemoryThreshold       A percent used by the resource monitor to determine
-                                            when to abort a task due to high memory usage.
-                                            This is a relative value, meaning that it is
-                                            relative to the total memory available on the
-                                            worker. For example, if the value is 90, then
-                                            the worker will abort a task if the memory
-                                            usage is at 90% or higher for longer than
-                                            allowedHighMemoryDurationSecs seconds. Can be used
-                                            in conjunction with absoluteHighMemoryThreshold.
-                                            Does nothing if disableOOMProtection is set to true.
-                                            [default: 90]
           requiredDiskSpaceMegabytes        The garbage collector will ensure at least this
                                             number of megabytes of disk space are available
                                             when each task starts. If it cannot free enough

--- a/workers/generic-worker/README.md
+++ b/workers/generic-worker/README.md
@@ -114,20 +114,10 @@ and reports back results to the queue.
         ** OPTIONAL ** properties
         =========================
 
-          absoluteHighMemoryThreshold       Number of bytes the resource monitor uses to
-                                            determine when to abort a task due to high
-                                            memory usage. This is an absolute number of bytes
-                                            needed of available memory before aborting the task.
-                                            For example, if the value is 524288000, then the worker will
-                                            abort a task if the memory available is 500MiB or less
-                                            for longer than allowedHighMemoryDurationSecs seconds.
-                                            Can be used in conjunction with relativeHighMemoryThreshold.
-                                            Does nothing if disableOOMProtection is set to true.
-                                            [default: 524288000] (500MiB)
           allowedHighMemoryDurationSecs     The number of seconds the resource monitor will
                                             allow the system memory usage to be above the high
-                                            memory thresholds (see absoluteHighMemoryThreshold
-                                            and relativeHighMemoryThreshold) before aborting
+                                            memory thresholds (see minAvailableMemoryBytes
+                                            and maxMemoryUsagePercent) before aborting
                                             the task. If the memory usage is above the high
                                             memory thresholds for longer than this time, the
                                             worker will abort the task. Does nothing if
@@ -180,8 +170,8 @@ and reports back results to the queue.
                                             [default: false]
           disableOOMProtection              If true, the worker will continue to monitor system
                                             memory usage, but will not abort tasks when the
-                                            system memory usage hits the absoluteHighMemoryThreshold
-                                            AND relativeHighMemoryThreshold for longer than
+                                            system memory usage hits the minAvailableMemoryBytes
+                                            AND maxMemoryUsagePercent for longer than
                                             allowedHighMemoryDurationSecs seconds.
                                             [default: false]
           downloadsDir                      The directory to cache downloaded files for
@@ -268,8 +258,29 @@ and reports back results to the queue.
                                             /dev/video<DEVICE_NUMBER> where <DEVICE_NUMBER> is an integer
                                             between 0 and 255. This setting may be used to change it.
                                             [default: 0]
+          maxMemoryUsagePercent             A percent used by the resource monitor to determine
+                                            when to abort a task due to high memory usage.
+                                            This is a relative value, meaning that it is
+                                            relative to the total memory available on the
+                                            worker. For example, if the value is 90, then
+                                            the worker will abort a task if the memory
+                                            usage is at 90% or higher for longer than
+                                            allowedHighMemoryDurationSecs seconds. Can be used
+                                            in conjunction with minAvailableMemoryBytes.
+                                            Does nothing if disableOOMProtection is set to true.
+                                            [default: 90]
           maxTaskRunTime                    The maximum value allowed for maxRunTime on generic-worker payloads.
                                             [default: 86400]
+          minAvailableMemoryBytes           Number of bytes the resource monitor uses to
+                                            determine when to abort a task due to high
+                                            memory usage. This is an absolute number of bytes
+                                            needed of available memory before aborting the task.
+                                            For example, if the value is 524288000, then the worker will
+                                            abort a task if the memory available is 500MiB or less
+                                            for longer than allowedHighMemoryDurationSecs seconds.
+                                            Can be used in conjunction with maxMemoryUsagePercent.
+                                            Does nothing if disableOOMProtection is set to true.
+                                            [default: 524288000] (500MiB)
           numberOfTasksToRun                If zero, run tasks indefinitely. Otherwise, after
                                             this many tasks, exit. [default: 0]
           privateIP                         The private IP of the worker, used by chain of trust.
@@ -279,17 +290,6 @@ and reports back results to the queue.
           publicIP                          The IP address for VNC access.  Also used by chain of
                                             trust when present.
           region                            The EC2 region of the worker. Used by chain of trust.
-          relativeHighMemoryThreshold       A percent used by the resource monitor to determine
-                                            when to abort a task due to high memory usage.
-                                            This is a relative value, meaning that it is
-                                            relative to the total memory available on the
-                                            worker. For example, if the value is 90, then
-                                            the worker will abort a task if the memory
-                                            usage is at 90% or higher for longer than
-                                            allowedHighMemoryDurationSecs seconds. Can be used
-                                            in conjunction with absoluteHighMemoryThreshold.
-                                            Does nothing if disableOOMProtection is set to true.
-                                            [default: 90]
           requiredDiskSpaceMegabytes        The garbage collector will ensure at least this
                                             number of megabytes of disk space are available
                                             when each task starts. If it cannot free enough

--- a/workers/generic-worker/generated_insecure_darwin.go
+++ b/workers/generic-worker/generated_insecure_darwin.go
@@ -435,9 +435,9 @@ type (
 		// Average System Memory Used, Average Available System Memory,
 		// and Total System Memory in the task log for each task command
 		// executed. It also will abort any task command if the used
-		// system memory exceeds worker config relativeHighMemoryThreshold
+		// system memory exceeds worker config maxMemoryUsagePercent
 		// _AND_ available system memory drops below worker config
-		// absoluteHighMemoryThreshold for longer than worker config
+		// minAvailableMemoryBytes for longer than worker config
 		// allowedHighMemoryDuration seconds. When this happens, the
 		// task will be resolved as failed.
 		//
@@ -1174,7 +1174,7 @@ func JSONSchema() string {
             },
             "resourceMonitor": {
               "default": true,
-              "description": "The resource monitor feature reports Peak System Memory Used,\nAverage System Memory Used, Average Available System Memory,\nand Total System Memory in the task log for each task command\nexecuted. It also will abort any task command if the used\nsystem memory exceeds worker config relativeHighMemoryThreshold\n_AND_ available system memory drops below worker config\nabsoluteHighMemoryThreshold for longer than worker config\nallowedHighMemoryDuration seconds. When this happens, the\ntask will be resolved as failed.\n\nSince: generic-worker 83.4.0",
+              "description": "The resource monitor feature reports Peak System Memory Used,\nAverage System Memory Used, Average Available System Memory,\nand Total System Memory in the task log for each task command\nexecuted. It also will abort any task command if the used\nsystem memory exceeds worker config maxMemoryUsagePercent\n_AND_ available system memory drops below worker config\nminAvailableMemoryBytes for longer than worker config\nallowedHighMemoryDuration seconds. When this happens, the\ntask will be resolved as failed.\n\nSince: generic-worker 83.4.0",
               "title": "Resource monitor",
               "type": "boolean"
             },

--- a/workers/generic-worker/generated_insecure_freebsd.go
+++ b/workers/generic-worker/generated_insecure_freebsd.go
@@ -435,9 +435,9 @@ type (
 		// Average System Memory Used, Average Available System Memory,
 		// and Total System Memory in the task log for each task command
 		// executed. It also will abort any task command if the used
-		// system memory exceeds worker config relativeHighMemoryThreshold
+		// system memory exceeds worker config maxMemoryUsagePercent
 		// _AND_ available system memory drops below worker config
-		// absoluteHighMemoryThreshold for longer than worker config
+		// minAvailableMemoryBytes for longer than worker config
 		// allowedHighMemoryDuration seconds. When this happens, the
 		// task will be resolved as failed.
 		//
@@ -1174,7 +1174,7 @@ func JSONSchema() string {
             },
             "resourceMonitor": {
               "default": true,
-              "description": "The resource monitor feature reports Peak System Memory Used,\nAverage System Memory Used, Average Available System Memory,\nand Total System Memory in the task log for each task command\nexecuted. It also will abort any task command if the used\nsystem memory exceeds worker config relativeHighMemoryThreshold\n_AND_ available system memory drops below worker config\nabsoluteHighMemoryThreshold for longer than worker config\nallowedHighMemoryDuration seconds. When this happens, the\ntask will be resolved as failed.\n\nSince: generic-worker 83.4.0",
+              "description": "The resource monitor feature reports Peak System Memory Used,\nAverage System Memory Used, Average Available System Memory,\nand Total System Memory in the task log for each task command\nexecuted. It also will abort any task command if the used\nsystem memory exceeds worker config maxMemoryUsagePercent\n_AND_ available system memory drops below worker config\nminAvailableMemoryBytes for longer than worker config\nallowedHighMemoryDuration seconds. When this happens, the\ntask will be resolved as failed.\n\nSince: generic-worker 83.4.0",
               "title": "Resource monitor",
               "type": "boolean"
             },

--- a/workers/generic-worker/generated_insecure_linux.go
+++ b/workers/generic-worker/generated_insecure_linux.go
@@ -435,9 +435,9 @@ type (
 		// Average System Memory Used, Average Available System Memory,
 		// and Total System Memory in the task log for each task command
 		// executed. It also will abort any task command if the used
-		// system memory exceeds worker config relativeHighMemoryThreshold
+		// system memory exceeds worker config maxMemoryUsagePercent
 		// _AND_ available system memory drops below worker config
-		// absoluteHighMemoryThreshold for longer than worker config
+		// minAvailableMemoryBytes for longer than worker config
 		// allowedHighMemoryDuration seconds. When this happens, the
 		// task will be resolved as failed.
 		//
@@ -1174,7 +1174,7 @@ func JSONSchema() string {
             },
             "resourceMonitor": {
               "default": true,
-              "description": "The resource monitor feature reports Peak System Memory Used,\nAverage System Memory Used, Average Available System Memory,\nand Total System Memory in the task log for each task command\nexecuted. It also will abort any task command if the used\nsystem memory exceeds worker config relativeHighMemoryThreshold\n_AND_ available system memory drops below worker config\nabsoluteHighMemoryThreshold for longer than worker config\nallowedHighMemoryDuration seconds. When this happens, the\ntask will be resolved as failed.\n\nSince: generic-worker 83.4.0",
+              "description": "The resource monitor feature reports Peak System Memory Used,\nAverage System Memory Used, Average Available System Memory,\nand Total System Memory in the task log for each task command\nexecuted. It also will abort any task command if the used\nsystem memory exceeds worker config maxMemoryUsagePercent\n_AND_ available system memory drops below worker config\nminAvailableMemoryBytes for longer than worker config\nallowedHighMemoryDuration seconds. When this happens, the\ntask will be resolved as failed.\n\nSince: generic-worker 83.4.0",
               "title": "Resource monitor",
               "type": "boolean"
             },

--- a/workers/generic-worker/generated_multiuser_darwin.go
+++ b/workers/generic-worker/generated_multiuser_darwin.go
@@ -449,9 +449,9 @@ type (
 		// Average System Memory Used, Average Available System Memory,
 		// and Total System Memory in the task log for each task command
 		// executed. It also will abort any task command if the used
-		// system memory exceeds worker config relativeHighMemoryThreshold
+		// system memory exceeds worker config maxMemoryUsagePercent
 		// _AND_ available system memory drops below worker config
-		// absoluteHighMemoryThreshold for longer than worker config
+		// minAvailableMemoryBytes for longer than worker config
 		// allowedHighMemoryDuration seconds. When this happens, the
 		// task will be resolved as failed.
 		//
@@ -1218,7 +1218,7 @@ func JSONSchema() string {
             },
             "resourceMonitor": {
               "default": true,
-              "description": "The resource monitor feature reports Peak System Memory Used,\nAverage System Memory Used, Average Available System Memory,\nand Total System Memory in the task log for each task command\nexecuted. It also will abort any task command if the used\nsystem memory exceeds worker config relativeHighMemoryThreshold\n_AND_ available system memory drops below worker config\nabsoluteHighMemoryThreshold for longer than worker config\nallowedHighMemoryDuration seconds. When this happens, the\ntask will be resolved as failed.\n\nSince: generic-worker 83.4.0",
+              "description": "The resource monitor feature reports Peak System Memory Used,\nAverage System Memory Used, Average Available System Memory,\nand Total System Memory in the task log for each task command\nexecuted. It also will abort any task command if the used\nsystem memory exceeds worker config maxMemoryUsagePercent\n_AND_ available system memory drops below worker config\nminAvailableMemoryBytes for longer than worker config\nallowedHighMemoryDuration seconds. When this happens, the\ntask will be resolved as failed.\n\nSince: generic-worker 83.4.0",
               "title": "Resource monitor",
               "type": "boolean"
             },

--- a/workers/generic-worker/generated_multiuser_freebsd.go
+++ b/workers/generic-worker/generated_multiuser_freebsd.go
@@ -449,9 +449,9 @@ type (
 		// Average System Memory Used, Average Available System Memory,
 		// and Total System Memory in the task log for each task command
 		// executed. It also will abort any task command if the used
-		// system memory exceeds worker config relativeHighMemoryThreshold
+		// system memory exceeds worker config maxMemoryUsagePercent
 		// _AND_ available system memory drops below worker config
-		// absoluteHighMemoryThreshold for longer than worker config
+		// minAvailableMemoryBytes for longer than worker config
 		// allowedHighMemoryDuration seconds. When this happens, the
 		// task will be resolved as failed.
 		//
@@ -1218,7 +1218,7 @@ func JSONSchema() string {
             },
             "resourceMonitor": {
               "default": true,
-              "description": "The resource monitor feature reports Peak System Memory Used,\nAverage System Memory Used, Average Available System Memory,\nand Total System Memory in the task log for each task command\nexecuted. It also will abort any task command if the used\nsystem memory exceeds worker config relativeHighMemoryThreshold\n_AND_ available system memory drops below worker config\nabsoluteHighMemoryThreshold for longer than worker config\nallowedHighMemoryDuration seconds. When this happens, the\ntask will be resolved as failed.\n\nSince: generic-worker 83.4.0",
+              "description": "The resource monitor feature reports Peak System Memory Used,\nAverage System Memory Used, Average Available System Memory,\nand Total System Memory in the task log for each task command\nexecuted. It also will abort any task command if the used\nsystem memory exceeds worker config maxMemoryUsagePercent\n_AND_ available system memory drops below worker config\nminAvailableMemoryBytes for longer than worker config\nallowedHighMemoryDuration seconds. When this happens, the\ntask will be resolved as failed.\n\nSince: generic-worker 83.4.0",
               "title": "Resource monitor",
               "type": "boolean"
             },

--- a/workers/generic-worker/generated_multiuser_linux.go
+++ b/workers/generic-worker/generated_multiuser_linux.go
@@ -449,9 +449,9 @@ type (
 		// Average System Memory Used, Average Available System Memory,
 		// and Total System Memory in the task log for each task command
 		// executed. It also will abort any task command if the used
-		// system memory exceeds worker config relativeHighMemoryThreshold
+		// system memory exceeds worker config maxMemoryUsagePercent
 		// _AND_ available system memory drops below worker config
-		// absoluteHighMemoryThreshold for longer than worker config
+		// minAvailableMemoryBytes for longer than worker config
 		// allowedHighMemoryDuration seconds. When this happens, the
 		// task will be resolved as failed.
 		//
@@ -1218,7 +1218,7 @@ func JSONSchema() string {
             },
             "resourceMonitor": {
               "default": true,
-              "description": "The resource monitor feature reports Peak System Memory Used,\nAverage System Memory Used, Average Available System Memory,\nand Total System Memory in the task log for each task command\nexecuted. It also will abort any task command if the used\nsystem memory exceeds worker config relativeHighMemoryThreshold\n_AND_ available system memory drops below worker config\nabsoluteHighMemoryThreshold for longer than worker config\nallowedHighMemoryDuration seconds. When this happens, the\ntask will be resolved as failed.\n\nSince: generic-worker 83.4.0",
+              "description": "The resource monitor feature reports Peak System Memory Used,\nAverage System Memory Used, Average Available System Memory,\nand Total System Memory in the task log for each task command\nexecuted. It also will abort any task command if the used\nsystem memory exceeds worker config maxMemoryUsagePercent\n_AND_ available system memory drops below worker config\nminAvailableMemoryBytes for longer than worker config\nallowedHighMemoryDuration seconds. When this happens, the\ntask will be resolved as failed.\n\nSince: generic-worker 83.4.0",
               "title": "Resource monitor",
               "type": "boolean"
             },

--- a/workers/generic-worker/generated_multiuser_windows.go
+++ b/workers/generic-worker/generated_multiuser_windows.go
@@ -217,9 +217,9 @@ type (
 		// Average System Memory Used, Average Available System Memory,
 		// and Total System Memory in the task log for each task command
 		// executed. It also will abort any task command if the used
-		// system memory exceeds worker config relativeHighMemoryThreshold
+		// system memory exceeds worker config maxMemoryUsagePercent
 		// _AND_ available system memory drops below worker config
-		// absoluteHighMemoryThreshold for longer than worker config
+		// minAvailableMemoryBytes for longer than worker config
 		// allowedHighMemoryDuration seconds. When this happens, the
 		// task will be resolved as failed.
 		//
@@ -947,7 +947,7 @@ func JSONSchema() string {
         },
         "resourceMonitor": {
           "default": true,
-          "description": "The resource monitor feature reports Peak System Memory Used,\nAverage System Memory Used, Average Available System Memory,\nand Total System Memory in the task log for each task command\nexecuted. It also will abort any task command if the used\nsystem memory exceeds worker config relativeHighMemoryThreshold\n_AND_ available system memory drops below worker config\nabsoluteHighMemoryThreshold for longer than worker config\nallowedHighMemoryDuration seconds. When this happens, the\ntask will be resolved as failed.\n\nSince: generic-worker 83.4.0",
+          "description": "The resource monitor feature reports Peak System Memory Used,\nAverage System Memory Used, Average Available System Memory,\nand Total System Memory in the task log for each task command\nexecuted. It also will abort any task command if the used\nsystem memory exceeds worker config maxMemoryUsagePercent\n_AND_ available system memory drops below worker config\nminAvailableMemoryBytes for longer than worker config\nallowedHighMemoryDuration seconds. When this happens, the\ntask will be resolved as failed.\n\nSince: generic-worker 83.4.0",
           "title": "Resource monitor",
           "type": "boolean"
         },

--- a/workers/generic-worker/gwconfig/config.go
+++ b/workers/generic-worker/gwconfig/config.go
@@ -27,7 +27,6 @@ type (
 	PublicConfig struct {
 		PublicEngineConfig
 		PublicPlatformConfig
-		AbsoluteHighMemoryThreshold    uint64         `json:"absoluteHighMemoryThreshold"`
 		AllowedHighMemoryDurationSecs  uint64         `json:"allowedHighMemoryDurationSecs"`
 		AvailabilityZone               string         `json:"availabilityZone"`
 		CachesDir                      string         `json:"cachesDir"`
@@ -55,12 +54,13 @@ type (
 		LiveLogExecutable              string         `json:"livelogExecutable"`
 		LiveLogPortBase                uint16         `json:"livelogPortBase"`
 		LiveLogExposePort              uint16         `json:"livelogExposePort"`
+		MaxMemoryUsagePercent          uint64         `json:"maxMemoryUsagePercent"`
 		MaxTaskRunTime                 uint32         `json:"maxTaskRunTime"`
+		MinAvailableMemoryBytes        uint64         `json:"minAvailableMemoryBytes"`
 		NumberOfTasksToRun             uint           `json:"numberOfTasksToRun"`
 		PrivateIP                      net.IP         `json:"privateIP"`
 		ProvisionerID                  string         `json:"provisionerId"`
 		PublicIP                       net.IP         `json:"publicIP"`
-		RelativeHighMemoryThreshold    uint64         `json:"relativeHighMemoryThreshold"`
 		Region                         string         `json:"region"`
 		RequiredDiskSpaceMegabytes     uint           `json:"requiredDiskSpaceMegabytes"`
 		RootURL                        string         `json:"rootURL"`

--- a/workers/generic-worker/helper_test.go
+++ b/workers/generic-worker/helper_test.go
@@ -345,7 +345,6 @@ func GWTest(t *testing.T) *Test {
 		},
 		PublicConfig: gwconfig.PublicConfig{
 			PublicPlatformConfig:          *gwconfig.DefaultPublicPlatformConfig(),
-			AbsoluteHighMemoryThreshold:   524288000, // 500 MiB
 			AllowedHighMemoryDurationSecs: 5,
 			AvailabilityZone:              "outer-space",
 			// Need common caches directory across tests, since files
@@ -375,14 +374,15 @@ func GWTest(t *testing.T) *Test {
 			// The base port on which the livelog process listens locally. (Livelog uses this and the next port.)
 			// These ports are not exposed outside of the host. However, in CI they must differ from those of the
 			// generic-worker instance running the test suite.
-			LiveLogPortBase:             30583,
-			MaxTaskRunTime:              300,
-			NumberOfTasksToRun:          1,
-			PrivateIP:                   net.ParseIP("87.65.43.21"),
-			ProvisionerID:               "test-provisioner",
-			PublicIP:                    net.ParseIP("12.34.56.78"),
-			RelativeHighMemoryThreshold: 90,
-			Region:                      "test-worker-group",
+			LiveLogPortBase:         30583,
+			MaxMemoryUsagePercent:   90,
+			MaxTaskRunTime:          300,
+			MinAvailableMemoryBytes: 524288000, // 500 MiB
+			NumberOfTasksToRun:      1,
+			PrivateIP:               net.ParseIP("87.65.43.21"),
+			ProvisionerID:           "test-provisioner",
+			PublicIP:                net.ParseIP("12.34.56.78"),
+			Region:                  "test-worker-group",
 			// should be enough for tests, and travis-ci.org CI environments don't
 			// have a lot of free disk
 			RequiredDiskSpaceMegabytes:     16,

--- a/workers/generic-worker/main.go
+++ b/workers/generic-worker/main.go
@@ -224,7 +224,6 @@ func loadConfig(configFile *gwconfig.File) error {
 		PublicConfig: gwconfig.PublicConfig{
 			PublicEngineConfig:             *gwconfig.DefaultPublicEngineConfig(),
 			PublicPlatformConfig:           *gwconfig.DefaultPublicPlatformConfig(),
-			AbsoluteHighMemoryThreshold:    524288000, // 500 MiB
 			AllowedHighMemoryDurationSecs:  5,
 			CachesDir:                      "caches",
 			CheckForNewDeploymentEverySecs: 1800,
@@ -244,10 +243,11 @@ func loadConfig(configFile *gwconfig.File) error {
 			InteractivePort:                53654,
 			LiveLogExecutable:              "livelog",
 			LiveLogPortBase:                60098,
-			MaxTaskRunTime:                 86400, // 86400s is 24 hours
+			MaxMemoryUsagePercent:          90,
+			MaxTaskRunTime:                 86400,     // 86400s is 24 hours
+			MinAvailableMemoryBytes:        524288000, // 500 MiB
 			NumberOfTasksToRun:             0,
 			ProvisionerID:                  "test-provisioner",
-			RelativeHighMemoryThreshold:    90,
 			RequiredDiskSpaceMegabytes:     10240,
 			RootURL:                        "",
 			RunAfterUserCreation:           "",

--- a/workers/generic-worker/resource_monitor_feature.go
+++ b/workers/generic-worker/resource_monitor_feature.go
@@ -48,8 +48,8 @@ func (r *ResourceMonitorTask) RequiredScopes() scopes.Required {
 func (r *ResourceMonitorTask) Start() *CommandExecutionError {
 	for _, c := range r.task.Commands {
 		c.ResourceMonitor = process.MonitorResources(
-			config.AbsoluteHighMemoryThreshold,
-			config.RelativeHighMemoryThreshold,
+			config.MinAvailableMemoryBytes,
+			config.MaxMemoryUsagePercent,
 			time.Duration(config.AllowedHighMemoryDurationSecs)*time.Second,
 			config.DisableOOMProtection,
 			r.task.Warnf,
@@ -58,8 +58,8 @@ func (r *ResourceMonitorTask) Start() *CommandExecutionError {
 					&CommandExecutionError{
 						Cause: fmt.Errorf(
 							"task aborted due to sustained memory usage above %d%% and available memory less than %v",
-							config.RelativeHighMemoryThreshold,
-							process.FormatMemoryString(config.AbsoluteHighMemoryThreshold),
+							config.MaxMemoryUsagePercent,
+							process.FormatMemoryString(config.MinAvailableMemoryBytes),
 						),
 						TaskStatus: failed,
 					},

--- a/workers/generic-worker/schemas/insecure_posix.yml
+++ b/workers/generic-worker/schemas/insecure_posix.yml
@@ -292,9 +292,9 @@ oneOf:
             Average System Memory Used, Average Available System Memory,
             and Total System Memory in the task log for each task command
             executed. It also will abort any task command if the used
-            system memory exceeds worker config relativeHighMemoryThreshold
+            system memory exceeds worker config maxMemoryUsagePercent
             _AND_ available system memory drops below worker config
-            absoluteHighMemoryThreshold for longer than worker config
+            minAvailableMemoryBytes for longer than worker config
             allowedHighMemoryDuration seconds. When this happens, the
             task will be resolved as failed.
 

--- a/workers/generic-worker/schemas/multiuser_posix.yml
+++ b/workers/generic-worker/schemas/multiuser_posix.yml
@@ -336,9 +336,9 @@ oneOf:
             Average System Memory Used, Average Available System Memory,
             and Total System Memory in the task log for each task command
             executed. It also will abort any task command if the used
-            system memory exceeds worker config relativeHighMemoryThreshold
+            system memory exceeds worker config maxMemoryUsagePercent
             _AND_ available system memory drops below worker config
-            absoluteHighMemoryThreshold for longer than worker config
+            minAvailableMemoryBytes for longer than worker config
             allowedHighMemoryDuration seconds. When this happens, the
             task will be resolved as failed.
 

--- a/workers/generic-worker/schemas/multiuser_windows.yml
+++ b/workers/generic-worker/schemas/multiuser_windows.yml
@@ -293,9 +293,9 @@ properties:
           Average System Memory Used, Average Available System Memory,
           and Total System Memory in the task log for each task command
           executed. It also will abort any task command if the used
-          system memory exceeds worker config relativeHighMemoryThreshold
+          system memory exceeds worker config maxMemoryUsagePercent
           _AND_ available system memory drops below worker config
-          absoluteHighMemoryThreshold for longer than worker config
+          minAvailableMemoryBytes for longer than worker config
           allowedHighMemoryDuration seconds. When this happens, the
           task will be resolved as failed.
 

--- a/workers/generic-worker/usage.go
+++ b/workers/generic-worker/usage.go
@@ -131,20 +131,10 @@ and reports back results to the queue.
         ** OPTIONAL ** properties
         =========================
 
-          absoluteHighMemoryThreshold       Number of bytes the resource monitor uses to
-                                            determine when to abort a task due to high
-                                            memory usage. This is an absolute number of bytes
-                                            needed of available memory before aborting the task.
-                                            For example, if the value is 524288000, then the worker will
-                                            abort a task if the memory available is 500MiB or less
-                                            for longer than allowedHighMemoryDurationSecs seconds.
-                                            Can be used in conjunction with relativeHighMemoryThreshold.
-                                            Does nothing if disableOOMProtection is set to true.
-                                            [default: 524288000] (500MiB)
           allowedHighMemoryDurationSecs     The number of seconds the resource monitor will
                                             allow the system memory usage to be above the high
-                                            memory thresholds (see absoluteHighMemoryThreshold
-                                            and relativeHighMemoryThreshold) before aborting
+                                            memory thresholds (see minAvailableMemoryBytes
+                                            and maxMemoryUsagePercent) before aborting
                                             the task. If the memory usage is above the high
                                             memory thresholds for longer than this time, the
                                             worker will abort the task. Does nothing if
@@ -193,8 +183,8 @@ and reports back results to the queue.
                                             [default: false]
           disableOOMProtection              If true, the worker will continue to monitor system
                                             memory usage, but will not abort tasks when the
-                                            system memory usage hits the absoluteHighMemoryThreshold
-                                            AND relativeHighMemoryThreshold for longer than
+                                            system memory usage hits the minAvailableMemoryBytes
+                                            AND maxMemoryUsagePercent for longer than
                                             allowedHighMemoryDurationSecs seconds.
                                             [default: false]
           downloadsDir                      The directory to cache downloaded files for
@@ -240,8 +230,29 @@ and reports back results to the queue.
           livelogExposePort                 When not using websocktunnel, livelog would be exposed using this port.
                                             If it is set to 0, logs would be exposed using a random port.
                                             [default: 0]` + loopbackDeviceNumbers() + `
+          maxMemoryUsagePercent             A percent used by the resource monitor to determine
+                                            when to abort a task due to high memory usage.
+                                            This is a relative value, meaning that it is
+                                            relative to the total memory available on the
+                                            worker. For example, if the value is 90, then
+                                            the worker will abort a task if the memory
+                                            usage is at 90% or higher for longer than
+                                            allowedHighMemoryDurationSecs seconds. Can be used
+                                            in conjunction with minAvailableMemoryBytes.
+                                            Does nothing if disableOOMProtection is set to true.
+                                            [default: 90]
           maxTaskRunTime                    The maximum value allowed for maxRunTime on generic-worker payloads.
                                             [default: 86400]
+          minAvailableMemoryBytes           Number of bytes the resource monitor uses to
+                                            determine when to abort a task due to high
+                                            memory usage. This is an absolute number of bytes
+                                            needed of available memory before aborting the task.
+                                            For example, if the value is 524288000, then the worker will
+                                            abort a task if the memory available is 500MiB or less
+                                            for longer than allowedHighMemoryDurationSecs seconds.
+                                            Can be used in conjunction with maxMemoryUsagePercent.
+                                            Does nothing if disableOOMProtection is set to true.
+                                            [default: 524288000] (500MiB)
           numberOfTasksToRun                If zero, run tasks indefinitely. Otherwise, after
                                             this many tasks, exit. [default: 0]
           privateIP                         The private IP of the worker, used by chain of trust.
@@ -251,17 +262,6 @@ and reports back results to the queue.
           publicIP                          The IP address for VNC access.  Also used by chain of
                                             trust when present.
           region                            The EC2 region of the worker. Used by chain of trust.
-          relativeHighMemoryThreshold       A percent used by the resource monitor to determine
-                                            when to abort a task due to high memory usage.
-                                            This is a relative value, meaning that it is
-                                            relative to the total memory available on the
-                                            worker. For example, if the value is 90, then
-                                            the worker will abort a task if the memory
-                                            usage is at 90% or higher for longer than
-                                            allowedHighMemoryDurationSecs seconds. Can be used
-                                            in conjunction with absoluteHighMemoryThreshold.
-                                            Does nothing if disableOOMProtection is set to true.
-                                            [default: 90]
           requiredDiskSpaceMegabytes        The garbage collector will ensure at least this
                                             number of megabytes of disk space are available
                                             when each task starts. If it cannot free enough


### PR DESCRIPTION
Follow-up on https://github.com/taskcluster/taskcluster/pull/7775.

>Generic Worker: renamed the following worker configuration options to avoid confusion:
>
>  * `absoluteHighMemoryThreshold` --> `minAvailableMemoryBytes`
>  * `relativeHighMemoryThreshold` --> `maxMemoryUsagePercent`