### PR TITLE
feat(github): Github service reacts to empty tasks

### DIFF
--- a/changelog/issue-7786.md
+++ b/changelog/issue-7786.md
@@ -1,0 +1,6 @@
+audience: users
+level: patch
+reference: issue 7786
+---
+
+Github service comments back when taskcluster command in issue comment didn't produce any tasks

--- a/services/github/src/handlers/job.js
+++ b/services/github/src/handlers/job.js
@@ -239,6 +239,17 @@ export async function jobHandler(message) {
     }
     if (!graphConfig.tasks || graphConfig.tasks.length === 0) {
       debug(`intree config for ${organization}/${repository}@${sha} compiled with zero tasks. Skipping.`);
+
+      // If triggered by a comment, let everyone know we couldn't create tasks
+      if (message.payload.details['event.type'].startsWith('issue_comment')) {
+        await this.createComment({
+          instGithub, organization, repository, pullNumber, sha, debug,
+          body: {
+            summary: 'No Taskcluster jobs started for this command',
+            details: 'Task graph produced empty list of tasks',
+          },
+        });
+      }
       return;
     }
   } catch (e) {

--- a/services/github/test/handler_test.js
+++ b/services/github/test/handler_test.js
@@ -981,6 +981,23 @@ helper.secrets.mockSuite(testing.suiteName(), [], function (mock, skipping) {
         assert.equal(build.state, 'pending');
       });
 
+      test('valid issue_comment (user is collaborator) no tasks created', async function () {
+        instGithub.setTaskclusterYml({
+          owner: 'taskcluster',
+          repo: 'tc-dev-integration-test',
+          ref: COMMIT_SHA,
+          content: {
+            ...validYamlCommentsJson,
+            tasks: [],
+          },
+        });
+
+        await simulateIssueCommentMessage({ user: 'lotas' });
+
+        assert(handlers.createTasks.notCalled);
+        assert(instGithub.issues.createComment.calledOnce);
+      });
+
       test('valid issue_comment (user is not a collaborator) skips task creation', async function () {
         await simulateIssueCommentMessage({ user: 'notCollaborator' });
 


### PR DESCRIPTION
If `/taskcluster xx` command didn't produce any tasks - comment would receive a reaction

Fixes #7786 
