### PR TITLE
Generic Worker: run CI tests via launch agent on macOS by default

### DIFF
--- a/changelog/dVLM3e4gRgeY-uPKledW2Q.md
+++ b/changelog/dVLM3e4gRgeY-uPKledW2Q.md
@@ -1,0 +1,3 @@
+audience: general
+level: silent
+---

--- a/workers/generic-worker/helper_multiuser_test.go
+++ b/workers/generic-worker/helper_multiuser_test.go
@@ -4,6 +4,7 @@ package main
 
 import (
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/taskcluster/taskcluster/v86/clients/client-go/tcqueue"
@@ -37,7 +38,8 @@ func expectChainOfTrustKeyNotSecureMessage(t *testing.T, td *tcqueue.TaskDefinit
 func engineTestSetup(t *testing.T, testConfig *gwconfig.Config) {
 	t.Helper()
 	runningTests = true
-	testConfig.HeadlessTasks = true
+	// macOS CI tests to not run in headless in order to exercise the launch agent as much as possible
+	testConfig.HeadlessTasks = (runtime.GOOS != "darwin")
 	testConfig.EnableRunTaskAsCurrentUser = true
 	testConfig.EnableD2G(t)
 	// Needed for tests that don't call RunWorker()

--- a/workers/generic-worker/process/multiuser_darwin.go
+++ b/workers/generic-worker/process/multiuser_darwin.go
@@ -135,9 +135,13 @@ func (c *Command) Start() error {
 	fds := []int{}
 	gofuncs := []func(){}
 
+	// declare outside of if statements so that file descriptors don't get garbage collected
+	var stdinReader, stdinWriter, stdoutReader, stdoutWriter, stderrReader, stderrWriter *os.File
+	var errPipe error
+
 	if c.Stdin != nil {
 		request.Stdin = true
-		stdinReader, stdinWriter, errPipe := os.Pipe()
+		stdinReader, stdinWriter, errPipe = os.Pipe()
 		if errPipe != nil {
 			return fmt.Errorf("failed to create stdin pipe: %w", errPipe)
 		}
@@ -150,7 +154,7 @@ func (c *Command) Start() error {
 
 	if c.Stdout != nil {
 		request.Stdout = true
-		stdoutReader, stdoutWriter, errPipe := os.Pipe()
+		stdoutReader, stdoutWriter, errPipe = os.Pipe()
 		if errPipe != nil {
 			return fmt.Errorf("failed to create stdout pipe: %w", errPipe)
 		}
@@ -163,7 +167,7 @@ func (c *Command) Start() error {
 
 	if c.Stderr != nil {
 		request.Stderr = true
-		stderrReader, stderrWriter, errPipe := os.Pipe()
+		stderrReader, stderrWriter, errPipe = os.Pipe()
 		if errPipe != nil {
 			return fmt.Errorf("failed to create stderr pipe: %w", errPipe)
 		}


### PR DESCRIPTION
This should improve coverage of the new launch agent setup on macOS, by enabling its use by default in CI tests.