### PR TITLE
chore(generic-worker): prefer `ParseUint` over `Atoi` where possible

### DIFF
--- a/changelog/bO6Y60KsTB2K7aoeIW5VuA.md
+++ b/changelog/bO6Y60KsTB2K7aoeIW5VuA.md
@@ -1,0 +1,4 @@
+audience: worker-deployers
+level: patch
+---
+Generic Worker: prefer `strconv.ParseUint()` over `strconv.Atoi()` when resulting int is converted to an int type of smaller size to prevent unexpected values.

--- a/tools/livelog/helper_test.go
+++ b/tools/livelog/helper_test.go
@@ -26,7 +26,7 @@ func listenOnRandomPort() (net.Listener, uint16, error) {
 		return nil, 0, err
 	}
 
-	port, err := strconv.Atoi(portStr)
+	port, err := strconv.ParseUint(portStr, 10, 16)
 	if err != nil {
 		return nil, 0, err
 	}

--- a/workers/generic-worker/expose/helpers_for_test.go
+++ b/workers/generic-worker/expose/helpers_for_test.go
@@ -25,7 +25,7 @@ func listenOnRandomPort() (net.Listener, uint16, error) {
 		return nil, 0, err
 	}
 
-	port, err := strconv.Atoi(portStr)
+	port, err := strconv.ParseUint(portStr, 10, 16)
 	if err != nil {
 		return nil, 0, err
 	}

--- a/workers/generic-worker/expose/local_test.go
+++ b/workers/generic-worker/expose/local_test.go
@@ -41,7 +41,7 @@ func TestLocalExposeHTTP(t *testing.T) {
 
 	testURL, _ := url.Parse(ts.URL)
 	_, testPortStr, _ := net.SplitHostPort(testURL.Host)
-	testPort, _ := strconv.Atoi(testPortStr)
+	testPort, _ := strconv.ParseUint(testPortStr, 10, 16)
 
 	exposer := makeLocalExposer(t)
 	exposure, err := exposer.ExposeHTTP(uint16(testPort))

--- a/workers/generic-worker/expose/proxy_test.go
+++ b/workers/generic-worker/expose/proxy_test.go
@@ -23,7 +23,7 @@ func TestBasicProxying(t *testing.T) {
 
 	u, _ := url.Parse(server.URL)
 	_, portStr, _ := net.SplitHostPort(u.Host)
-	port, _ := strconv.Atoi(portStr)
+	port, _ := strconv.ParseUint(portStr, 10, 16)
 
 	listener, listenPort, err := listenOnRandomPort()
 	if err != nil {
@@ -64,7 +64,7 @@ func TestBasicProxyingNon200(t *testing.T) {
 
 	u, _ := url.Parse(server.URL)
 	_, portStr, _ := net.SplitHostPort(u.Host)
-	port, _ := strconv.Atoi(portStr)
+	port, _ := strconv.ParseUint(portStr, 10, 16)
 
 	listener, listenPort, err := listenOnRandomPort()
 	if err != nil {
@@ -117,7 +117,7 @@ func TestStreamingProxy(t *testing.T) {
 
 	u, _ := url.Parse(server.URL)
 	_, portStr, _ := net.SplitHostPort(u.Host)
-	port, _ := strconv.Atoi(portStr)
+	port, _ := strconv.ParseUint(portStr, 10, 16)
 
 	listener, listenPort, err := listenOnRandomPort()
 	if err != nil {
@@ -171,7 +171,7 @@ func TestProxyHTTPWebsocket(t *testing.T) {
 
 	u, _ := url.Parse(server.URL)
 	_, portStr, _ := net.SplitHostPort(u.Host)
-	port, _ := strconv.Atoi(portStr)
+	port, _ := strconv.ParseUint(portStr, 10, 16)
 
 	listener, listenPort, err := listenOnRandomPort()
 	if err != nil {

--- a/workers/generic-worker/expose/wst_test.go
+++ b/workers/generic-worker/expose/wst_test.go
@@ -109,7 +109,7 @@ func TestBasicWSTExposeHTTP(t *testing.T) {
 
 	testURL, _ := url.Parse(ts.URL)
 	_, testPortStr, _ := net.SplitHostPort(testURL.Host)
-	testPort, _ := strconv.Atoi(testPortStr)
+	testPort, _ := strconv.ParseUint(testPortStr, 10, 16)
 	t.Logf("testPort: %d", testPort)
 
 	exposer := makeWSTExposer(t, wstServer.url())
@@ -149,7 +149,7 @@ func TestWSTExposeHTTPWebsocket(t *testing.T) {
 
 	testURL, _ := url.Parse(ts.URL)
 	_, testPortStr, _ := net.SplitHostPort(testURL.Host)
-	testPort, _ := strconv.Atoi(testPortStr)
+	testPort, _ := strconv.ParseUint(testPortStr, 10, 16)
 	t.Logf("testPort: %d", testPort)
 
 	exposer := makeWSTExposer(t, wstServer.url())

--- a/workers/generic-worker/os_groups_multiuser_posix.go
+++ b/workers/generic-worker/os_groups_multiuser_posix.go
@@ -10,7 +10,7 @@ import (
 func (osGroups *OSGroups) refreshTaskCommands() (err *CommandExecutionError) {
 	gids := make([]uint32, len(osGroups.AddedGroups))
 	for i, group := range osGroups.AddedGroups {
-		gid, err := strconv.Atoi(group.Gid)
+		gid, err := strconv.ParseUint(group.Gid, 10, 32)
 		if err != nil {
 			panic(fmt.Sprintf("Group ID for %q is %q which isn't an int: %v", group.Name, group.Gid, err))
 		}

--- a/workers/generic-worker/process/multiuser_posix.go
+++ b/workers/generic-worker/process/multiuser_posix.go
@@ -28,12 +28,12 @@ func TaskUserPlatformData(u *gwruntime.OSUser, headlessTasks bool) (pd *Platform
 		return nil, fmt.Errorf("failed to lookup user: %w", err)
 	}
 
-	uid, err := strconv.Atoi(usr.Uid)
+	uid, err := strconv.ParseUint(usr.Uid, 10, 32)
 	if err != nil {
 		return nil, fmt.Errorf("failed to convert UID to int: %w", err)
 	}
 
-	gid, err := strconv.Atoi(usr.Gid)
+	gid, err := strconv.ParseUint(usr.Gid, 10, 32)
 	if err != nil {
 		return nil, fmt.Errorf("failed to convert GID to int: %w", err)
 	}
@@ -45,7 +45,7 @@ func TaskUserPlatformData(u *gwruntime.OSUser, headlessTasks bool) (pd *Platform
 
 	var gids []uint32
 	for _, gidStr := range groupIDs {
-		gid, err := strconv.Atoi(gidStr)
+		gid, err := strconv.ParseUint(gidStr, 10, 32)
 		if err != nil {
 			return nil, fmt.Errorf("failed to convert GID to int: %w", err)
 		}


### PR DESCRIPTION
Should fix 12 code scanning alerts from CodeQL https://github.com/taskcluster/taskcluster/security/code-scanning

>Generic Worker: prefer `strconv.ParseUint()` over `strconv.Atoi()` when resulting int is converted to an int type of smaller size to prevent unexpected values.