### PR TITLE
Generic Worker: keep both ends of Launch Agent pipes alive while in use

### DIFF
--- a/changelog/U-1xwYs4Q7WO2PNapNeVHg.md
+++ b/changelog/U-1xwYs4Q7WO2PNapNeVHg.md
@@ -1,0 +1,5 @@
+audience: users
+level: patch
+---
+Generic Worker multiuser on macOS now ensures finalisers are not called on
+launch agent pipes while they are still in use.

--- a/workers/generic-worker/process/multiuser_darwin.go
+++ b/workers/generic-worker/process/multiuser_darwin.go
@@ -13,6 +13,7 @@ import (
 	"net"
 	"os"
 	"os/exec"
+	"runtime"
 	"sync"
 	"time"
 
@@ -148,6 +149,9 @@ func (c *Command) Start() error {
 		gofuncs = append(gofuncs, func() {
 			_, _ = io.Copy(stdinWriter, c.Stdin)
 			stdinWriter.Close()
+			// not sure if this is needed, but let's make sure both ends of the
+			// pipe are not garbage collected until we've finished using them!
+			runtime.KeepAlive(stdinReader)
 		})
 		fds = append(fds, int(stdinReader.Fd()))
 	}
@@ -161,6 +165,9 @@ func (c *Command) Start() error {
 		gofuncs = append(gofuncs, func() {
 			_, _ = io.Copy(c.Stdout, stdoutReader)
 			stdoutReader.Close()
+			// not sure if this is needed, but let's make sure both ends of the
+			// pipe are not garbage collected until we've finished using them!
+			runtime.KeepAlive(stdoutWriter)
 		})
 		fds = append(fds, int(stdoutWriter.Fd()))
 	}
@@ -174,6 +181,9 @@ func (c *Command) Start() error {
 		gofuncs = append(gofuncs, func() {
 			_, _ = io.Copy(c.Stderr, stderrReader)
 			stderrReader.Close()
+			// not sure if this is needed, but let's make sure both ends of the
+			// pipe are not garbage collected until we've finished using them!
+			runtime.KeepAlive(stderrWriter)
 		})
 		fds = append(fds, int(stderrWriter.Fd()))
 	}


### PR DESCRIPTION
It occurred to me that there may be a risk that the side of the pipes that are forwarded to the launch agent might get freed prematurely by the go runtime garbage collector. It may be this isn't needed, e.g. if go internally holds onto one side of a pipe if the other side is still referenced, but better to be safe than sorry. It certainly won't do any harm holding on to these references, and may prevent intermittent issues, or future proof against them if the garbage collector mechanics change in a future go release.