### PR TITLE
chore(client-py)!: drop py3.8 support

### DIFF
--- a/changelog/HMXUP9AkT_qwvHQV-h0H5w.md
+++ b/changelog/HMXUP9AkT_qwvHQV-h0H5w.md
@@ -1,0 +1,4 @@
+audience: users
+level: major
+---
+Client (python): Drops python 3.8 support, adds support and tests for 3.12 and 3.13.

--- a/clients/client-py/setup.py
+++ b/clients/client-py/setup.py
@@ -58,8 +58,8 @@ class Tox(TestCommand):
         errno = tox.cmdline(args=args)
         sys.exit(errno)
 
-if sys.version_info[0] == 3 and sys.version_info[:2] < (3, 8):
-    raise Exception('This library does not support Python 3 versions below 3.8')
+if sys.version_info[0] == 3 and sys.version_info[:2] < (3, 9):
+    raise Exception('This library does not support Python 3 versions below 3.9')
 
 with open('README.md', encoding='utf8') as f:
     long_description = f.read()
@@ -89,9 +89,10 @@ if __name__ == '__main__':
         cmdclass={'test': Tox},
         zip_safe=False,
         classifiers=[
-            'Programming Language :: Python :: 3.8',
             'Programming Language :: Python :: 3.9',
             'Programming Language :: Python :: 3.10',
             'Programming Language :: Python :: 3.11',
+            'Programming Language :: Python :: 3.12',
+            'Programming Language :: Python :: 3.13',
         ],
     )

--- a/clients/client-py/tox.ini
+++ b/clients/client-py/tox.ini
@@ -1,9 +1,10 @@
 [tox]
 envlist =
-    py38
     py39
     py310
     py311
+    py312
+    py313
 
 [testenv]
 passenv =

--- a/taskcluster/kinds/client/kind.yml
+++ b/taskcluster/kinds/client/kind.yml
@@ -72,17 +72,6 @@ tasks:
         {{ Xvfb :99 -screen 0 640x480x8 -nolisten tcp & }} &&
         sleep 2 &&
         CHROME_BIN=firefox DISPLAY=:99 corepack yarn test
-  py38:
-    description: python3.8 client tests
-    worker:
-      docker-image: python:3.8
-    run:
-      command: >-
-        eval $(python test/client-library-secrets.py) &&
-        cd clients/client-py &&
-        python3 -mvenv /sandbox &&
-        /sandbox/bin/pip install tox &&
-        TOXENV=py38 /sandbox/bin/tox
   py39:
     description: python3.9 client tests
     worker:
@@ -116,6 +105,28 @@ tasks:
         python3 -mvenv /sandbox &&
         /sandbox/bin/pip install tox &&
         TOXENV=py311 /sandbox/bin/tox
+  py312:
+    description: python3.12 client tests
+    worker:
+      docker-image: python:3.12
+    run:
+      command: >-
+        eval $(python test/client-library-secrets.py) &&
+        cd clients/client-py &&
+        python3 -mvenv /sandbox &&
+        /sandbox/bin/pip install tox &&
+        TOXENV=py312 /sandbox/bin/tox
+  py313:
+    description: python3.13 client tests
+    worker:
+      docker-image: python:3.13
+    run:
+      command: >-
+        eval $(python test/client-library-secrets.py) &&
+        cd clients/client-py &&
+        python3 -mvenv /sandbox &&
+        /sandbox/bin/pip install tox &&
+        TOXENV=py313 /sandbox/bin/tox
   rust:
     description: rust client tests
     worker:


### PR DESCRIPTION
>Client (python): Drops python 3.8 support, adds support and tests for 3.12 and 3.13.