### PR TITLE
queue: always include task tags in task-pending and task-exception pulse messages

### DIFF
--- a/changelog/issue-7842.md
+++ b/changelog/issue-7842.md
@@ -1,0 +1,5 @@
+audience: users
+level: patch
+reference: issue 7842
+---
+task-pending and task-exception pulse message now consistently include the task's tags.

--- a/services/queue/src/api.js
+++ b/services/queue/src/api.js
@@ -437,6 +437,7 @@ const cancelSingleTask = async (task, ctx) => {
     await ctx.publisher.taskException(_.defaults({
       status,
       runId,
+      task: { tags: task.tags || {} },
     }, _.pick(run, 'workerGroup', 'workerId')), task.routes);
     ctx.monitor.log.taskException({ taskId: task.taskId, runId });
   }
@@ -1157,6 +1158,7 @@ builder.declare({
       this.publisher.taskPending({
         status: status,
         runId: runId,
+        task: { tags: task.tags || {} },
       }, task.routes),
     ]);
     this.monitor.log.taskPending({ taskId, runId });

--- a/services/queue/src/claimresolver.js
+++ b/services/queue/src/claimresolver.js
@@ -149,6 +149,7 @@ class ClaimResolver {
     await this.publisher.taskException({
       status: status,
       runId: runId,
+      task: { tags: task.tags || {} },
       workerGroup: run.workerGroup,
       workerId: run.workerId,
     }, task.routes);
@@ -166,6 +167,7 @@ class ClaimResolver {
         this.publisher.taskPending({
           status: status,
           runId: runId + 1,
+          task: { tags: task.tags || {} },
         }, task.routes),
       ]);
       this.monitor.log.taskPending({ taskId, runId: runId + 1 });

--- a/services/queue/src/deadlineresolver.js
+++ b/services/queue/src/deadlineresolver.js
@@ -148,6 +148,7 @@ class DeadlineResolver {
       await this.publisher.taskException({
         status: task.status(),
         runId,
+        task: { tags: task.tags || {} },
       }, task.routes);
       this.monitor.log.taskException({ taskId, runId });
 

--- a/services/queue/src/dependencytracker.js
+++ b/services/queue/src/dependencytracker.js
@@ -280,6 +280,7 @@ class DependencyTracker {
         this.publisher.taskPending({
           status: status,
           runId: 0,
+          task: { tags: task.tags || {} },
         }, task.routes),
       ]);
       this.monitor.log.taskPending({ taskId: task.taskId, runId: 0 });

--- a/services/queue/test/deadline_test.js
+++ b/services/queue/test/deadline_test.js
@@ -1,3 +1,4 @@
+import _ from 'lodash';
 import debugFactory from 'debug';
 const debug = debugFactory('test:deadline');
 import assert from 'assert';
@@ -32,6 +33,9 @@ helper.secrets.mockSuite(testing.suiteName(), ['aws'], function(mock, skipping) 
         owner: 'jonsafj@mozilla.com',
         source: 'https://github.com/taskcluster/taskcluster-queue',
       },
+      tags: {
+        purpose: 'taskcluster-testing',
+      },
     };
     return { taskId: slugid.v4(), task };
   };
@@ -60,6 +64,7 @@ helper.secrets.mockSuite(testing.suiteName(), ['aws'], function(mock, skipping) 
     await testing.poll(async () => {
       helper.assertPulseMessage('task-exception', m => (
         m.payload.status.state === 'exception' &&
+        _.isEqual(m.payload.task.tags, task.tags) &&
         m.payload.status.runs.length === 1 &&
         m.payload.status.runs[0].reasonCreated === 'exception' &&
         m.payload.status.runs[0].reasonResolved === 'deadline-exceeded'));


### PR DESCRIPTION
Fixes #7842
