### PR TITLE
feat(queue): Task-running event includes task.tags

### DIFF
--- a/changelog/issue-7842-1.md
+++ b/changelog/issue-7842-1.md
@@ -1,0 +1,6 @@
+audience: users
+level: patch
+reference: issue 7842
+---
+
+The `task-running` event now includes `task.tags`, consistent with other lifecycle events.

--- a/clients/client-go/tcqueueevents/types.go
+++ b/clients/client-go/tcqueueevents/types.go
@@ -453,6 +453,12 @@ type (
 		// isn't reclaimed.
 		TakenUntil tcclient.Time `json:"takenUntil"`
 
+		// Subset of a task definition containing values that are useful for determining
+		// whether a message is interesting to the receiver. Where the full task
+		// definition is required, the receiver should call queue.task to download that
+		// definition.
+		Task Var `json:"task,omitzero"`
+
 		// Message version
 		//
 		// Possible values:

--- a/generated/references.json
+++ b/generated/references.json
@@ -3724,6 +3724,9 @@
           "format": "date-time",
           "type": "string"
         },
+        "task": {
+          "$ref": "task-pulse-definition.json#"
+        },
         "version": {
           "description": "Message version",
           "enum": [

--- a/services/queue/schemas/v1/task-running-message.yml
+++ b/services/queue/schemas/v1/task-running-message.yml
@@ -6,6 +6,7 @@ type:         object
 properties:
   version:    {$const: message-version}
   status:     {$ref: 'task-status.json#'}
+  task: {$ref: 'task-pulse-definition.json#'}
   runId:
     description: |
       Id of the run that just started, always starts from 0

--- a/services/queue/src/workclaimer.js
+++ b/services/queue/src/workclaimer.js
@@ -154,6 +154,7 @@ class WorkClaimer extends events.EventEmitter {
       workerGroup: workerGroup,
       workerId: workerId,
       takenUntil: run.takenUntil,
+      task: { tags: task.tags || {} },
     }, task.routes);
     this._monitor.log.taskRunning({ taskId, runId });
 

--- a/services/queue/test/workclaimer_test.js
+++ b/services/queue/test/workclaimer_test.js
@@ -20,6 +20,7 @@ helper.secrets.mockSuite(testing.suiteName(), ['aws'], function (mock, skipping)
     deadline: taskcluster.fromNowJSON('1 days'),
     expires: taskcluster.fromNowJSON('2 days'),
     payload: {},
+    tags: { tag: 'value' },
     metadata: {
       name: 'Unit testing task',
       description: 'Task created during unit tests',
@@ -89,6 +90,7 @@ helper.secrets.mockSuite(testing.suiteName(), ['aws'], function (mock, skipping)
     const claims = await workClaimer.claim('taskQueue/Id', 'workerGroup', 'workerId', 1, aborted);
     assume(claims.length).equal(1);
     assume(claims[0].status.taskId).equal(taskId);
+    helper.assertPulseMessage('task-running', m => m.payload.task?.tags?.tag === 'value');
   });
 
   test('hint poller errors are recovered', async () => {


### PR DESCRIPTION
This was the only event that didn't include this, for consistency it does now

Fixes #7842
