### PR TITLE
fix(ui): correct save button for worker pool config changes

### DIFF
--- a/changelog/issue-7846.md
+++ b/changelog/issue-7846.md
@@ -1,0 +1,5 @@
+audience: users
+level: patch
+reference: issue 7846
+---
+UI: properly handle Worker Pool config changes and enable/disable `Save Worker Pool` button dynamically.


### PR DESCRIPTION
Fixes #7846.

>UI: properly handle Worker Pool config changes and enable/disable `Save Worker Pool` button dynamically.