### PR TITLE
feat(generic-worker): add `status` subcommand

### DIFF
--- a/changelog/issue-7840.md
+++ b/changelog/issue-7840.md
@@ -1,0 +1,25 @@
+audience: worker-deployers
+level: minor
+reference: issue 7840
+---
+Generic Worker: adds `status` subcommand to output task ID if a task is currently being executed.
+
+Example output while a task is running:
+
+```bash
+$ generic-worker status
+{
+  "currentTaskIds": [
+    "fz7IO4uCTtevuLBoq8Qz3w"
+  ]
+}
+```
+
+Example output while worker is idle:
+
+```bash
+$ generic-worker status
+{
+  "currentTaskIds": []
+}
+```

--- a/ui/docs/reference/workers/generic-worker/usage.mdx
+++ b/ui/docs/reference/workers/generic-worker/usage.mdx
@@ -24,6 +24,7 @@ and reports back results to the queue.
     generic-worker create-file              --create-file CREATE-FILE
     generic-worker create-dir               --create-dir CREATE-DIR
     generic-worker unarchive                --archive-src ARCHIVE-SRC --archive-dst ARCHIVE-DST --archive-fmt ARCHIVE-FMT
+    generic-worker status
     generic-worker --help
     generic-worker --version
     generic-worker --short-version
@@ -53,6 +54,8 @@ and reports back results to the queue.
     unarchive                               This will unarchive the specified archive file
                                             to the specified destination directory.
                                             Intended for internal use.
+    status                                  This will print whether the worker is currently
+                                            running a task, and if so, what the task ID is.
 
   Options:
     --config CONFIG-FILE                    Json configuration file to use. See

--- a/workers/generic-worker/README.md
+++ b/workers/generic-worker/README.md
@@ -25,6 +25,7 @@ and reports back results to the queue.
     generic-worker create-file              --create-file CREATE-FILE
     generic-worker create-dir               --create-dir CREATE-DIR
     generic-worker unarchive                --archive-src ARCHIVE-SRC --archive-dst ARCHIVE-DST --archive-fmt ARCHIVE-FMT
+    generic-worker status
     generic-worker --help
     generic-worker --version
     generic-worker --short-version
@@ -54,6 +55,8 @@ and reports back results to the queue.
     unarchive                               This will unarchive the specified archive file
                                             to the specified destination directory.
                                             Intended for internal use.
+    status                                  This will print whether the worker is currently
+                                            running a task, and if so, what the task ID is.
 
   Options:
     --config CONFIG-FILE                    Json configuration file to use. See

--- a/workers/generic-worker/main.go
+++ b/workers/generic-worker/main.go
@@ -66,8 +66,9 @@ var (
 	logPath   = filepath.Join("generic-worker", "live_backing.log")
 	debugInfo map[string]string
 
-	version  = internal.Version
-	revision = "" // this is set during build with `-ldflags "-X main.revision=$(git rev-parse HEAD)"`
+	version          = internal.Version
+	revision         = "" // this is set during build with `-ldflags "-X main.revision=$(git rev-parse HEAD)"`
+	workerStatusPath = filepath.Join(os.TempDir(), "worker-status.json")
 )
 
 func initialiseFeatures() (err error) {
@@ -124,6 +125,16 @@ func main() {
 		fmt.Println(JSONSchema())
 	case arguments["--short-version"]:
 		fmt.Println(version)
+	case arguments["status"]:
+		statusBytes, err := os.ReadFile(workerStatusPath)
+		if err != nil && !os.IsNotExist(err) {
+			exitOnError(CANT_GET_WORKER_STATUS, err, "Error reading worker status file")
+		}
+		if statusBytes == nil {
+			statusBytes, err = json.MarshalIndent(&WorkerStatus{CurrentTaskIDs: []string{}}, "", "  ")
+			exitOnError(INTERNAL_ERROR, err, "Error marshalling worker status")
+		}
+		fmt.Println(string(statusBytes))
 
 	case arguments["run"]:
 		withWorkerRunner := arguments["--with-worker-runner"].(bool)
@@ -892,6 +903,12 @@ func (task *TaskRun) Run() (err *ExecutionErrors) {
 
 	err = &ExecutionErrors{}
 
+	workerStatus := &WorkerStatus{
+		CurrentTaskIDs: []string{task.TaskID},
+	}
+	err.add(executionError(internalError, errored, fileutil.WriteToFileAsJSON(workerStatus, workerStatusPath)))
+	defer os.Remove(workerStatusPath)
+
 	defer func() {
 		if r := recover(); r != nil {
 			err.add(executionError(internalError, errored, fmt.Errorf("%#v", r)))
@@ -1026,6 +1043,10 @@ func (task *TaskRun) ReleaseResources() error {
 type TaskContext struct {
 	TaskDir string
 	User    *gwruntime.OSUser
+}
+
+type WorkerStatus struct {
+	CurrentTaskIDs []string `json:"currentTaskIds"`
 }
 
 // deleteTaskDirs deletes all task directories (directories whose name starts

--- a/workers/generic-worker/main.go
+++ b/workers/generic-worker/main.go
@@ -1094,6 +1094,8 @@ func exitOnError(exitCode ExitCode, err error, logMessage string, args ...any) {
 	log.Printf("Root cause: %v", err)
 	log.Printf("%#v (%T)", err, err)
 	combinedErr := fmt.Errorf("%s, args: %v, root cause: %v, exit code: %d", logMessage, args, err, exitCode)
-	errorreport.Send(WorkerRunnerProtocol, combinedErr, debugInfo)
+	if WorkerRunnerProtocol != nil {
+		errorreport.Send(WorkerRunnerProtocol, combinedErr, debugInfo)
+	}
 	os.Exit(int(exitCode))
 }

--- a/workers/generic-worker/usage.go
+++ b/workers/generic-worker/usage.go
@@ -22,6 +22,7 @@ const (
 	CANT_CREATE_FILE            ExitCode = 79
 	CANT_CREATE_DIRECTORY       ExitCode = 80
 	CANT_UNARCHIVE              ExitCode = 81
+	CANT_GET_WORKER_STATUS      ExitCode = 84
 )
 
 func usage(versionName string) string {
@@ -42,6 +43,7 @@ and reports back results to the queue.
     generic-worker create-file              --create-file CREATE-FILE
     generic-worker create-dir               --create-dir CREATE-DIR
     generic-worker unarchive                --archive-src ARCHIVE-SRC --archive-dst ARCHIVE-DST --archive-fmt ARCHIVE-FMT
+    generic-worker status
     generic-worker --help
     generic-worker --version
     generic-worker --short-version
@@ -71,6 +73,8 @@ and reports back results to the queue.
     unarchive                               This will unarchive the specified archive file
                                             to the specified destination directory.
                                             Intended for internal use.
+    status                                  This will print whether the worker is currently
+                                            running a task, and if so, what the task ID is.
 
   Options:
     --config CONFIG-FILE                    Json configuration file to use. See


### PR DESCRIPTION
Fixes #7840.

>Generic Worker: adds `status` subcommand to output task ID if a task is currently being executed.
>
>Example output while a task is running:
>
>```bash
>$ generic-worker status
>{
>  "currentTaskIds": [
>    "fz7IO4uCTtevuLBoq8Qz3w"
>  ]
>}
>```
>
>Example output while worker is idle:
>
>```bash
>$ generic-worker status
>{
>  "currentTaskIds": []
>}
>```