### PR TITLE
fix(release): make npm packages public by default

### DIFF
--- a/changelog/K6jPN8gxTNChW1TEcw2YEQ.md
+++ b/changelog/K6jPN8gxTNChW1TEcw2YEQ.md
@@ -1,0 +1,4 @@
+audience: general
+level: patch
+---
+Fix releases of `@taskcluser/client` and `@taskcluster/client-web` by making their access public by default.

--- a/clients/client-web/package.json
+++ b/clients/client-web/package.json
@@ -36,5 +36,8 @@
     "hawk": "^9.0.2",
     "query-string": "^7.0.0",
     "taskcluster-lib-urls": "^13.0.0"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/clients/client/package.json
+++ b/clients/client/package.json
@@ -29,5 +29,8 @@
   "files": [
     "src"
   ],
+  "publishConfig": {
+    "access": "public"
+  },
   "main": "./src/index.js"
 }


### PR DESCRIPTION
Followup to https://github.com/taskcluster/taskcluster/pull/7865.

>Fix releases of `@taskcluser/client` and `@taskcluster/client-web` by making their access public by default.