### PR TITLE
fix(worker-manager): terminate aws workers that are in stopped state

### DIFF
--- a/changelog/issue-7680.md
+++ b/changelog/issue-7680.md
@@ -1,0 +1,5 @@
+audience: general
+level: patch
+reference: issue 7680
+---
+Worker Manager (AWS): terminates workers that are in the stopped state.

--- a/services/worker-manager/src/providers/aws.js
+++ b/services/worker-manager/src/providers/aws.js
@@ -337,6 +337,9 @@ export class AwsProvider extends Provider {
 
           case 'terminated':
           case 'stopped':
+            await this._enqueue(`${region}.modify`, () => this.ec2s[region].send(new TerminateInstancesCommand({
+              InstanceIds: [worker.workerId.toString()],
+            })));
             await this.onWorkerStopped({ worker });
             state = Worker.states.STOPPED;
             break;
@@ -388,7 +391,7 @@ export class AwsProvider extends Provider {
     try {
       const region = worker.providerData.region;
       result = await this._enqueue(`${region}.modify`, () => this.ec2s[region].send(new TerminateInstancesCommand({
-        InstanceIds: [worker.workerId],
+        InstanceIds: [worker.workerId.toString()],
       })));
     } catch (e) {
       const workerPool = await WorkerPool.get(this.db, worker.workerPoolId);


### PR DESCRIPTION
Fixes #7680.

>Worker Manager (AWS): terminates workers that are in the stopped state.