### PR TITLE
fix(cloudbuild): add small `sleep` before smoketests to reduce intermittents

### DIFF
--- a/changelog/issue-6854.md
+++ b/changelog/issue-6854.md
@@ -1,0 +1,4 @@
+audience: general
+level: silent
+reference: issue 6854
+---

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -80,7 +80,7 @@ steps:
   - name: node:${_NODE_VERSION}
     args:
       - '-c'
-      - corepack enable && yarn && yarn smoketest
+      - sleep 10 && corepack enable && yarn && yarn smoketest
     id: Smoketest
     entrypoint: bash
     env:


### PR DESCRIPTION
Fixes #6854.