### PR TITLE
Generic Worker: keep file handles alive through Wait() on macOS (when using launch agent)

### DIFF
--- a/changelog/issue-7905.md
+++ b/changelog/issue-7905.md
@@ -1,0 +1,5 @@
+audience: worker-deployers
+level: patch
+reference: issue 7905
+---
+Generic Worker launch agent on macOS for multiuser engine was crashing due to a bug in the launch daemon that was garbage collecting file handles while the agent was using them. This resulted in the launch agent crashing. This has been fixed by keeping file handles alive in the daemon.


### PR DESCRIPTION
Original fix for this (#7806) was insufficient as it only held references until the end of the `Start()` call, not the `Wait()` call. This meant a command could be started, the file references (stdin/stdout/stderr) were dereferenced, and the `os.Reader`s and `os.Writer`s that were attached to these file handles would no longer work. The fix is to hold onto these references until the end of the `Wait()` call, so that they are held until the command execution has completed.