### PR TITLE
fix(worker-manager): use static public ip allocation for azure

### DIFF
--- a/changelog/issue-7914.md
+++ b/changelog/issue-7914.md
@@ -1,0 +1,5 @@
+audience: general
+level: patch
+reference: issue 7914
+---
+Worker Manager (Azure): uses `Static` public IP allocation with the `Standard` SKU.

--- a/services/worker-manager/src/providers/azure/index.js
+++ b/services/worker-manager/src/providers/azure/index.js
@@ -808,7 +808,7 @@ export class AzureProvider extends Provider {
       // IP
       let ipConfig = {
         location: worker.providerData.location,
-        publicIPAllocationMethod: 'Dynamic',
+        publicIPAllocationMethod: 'Static',
         sku: { name: 'Standard' },
       };
 

--- a/services/worker-manager/test/provider_azure_test.js
+++ b/services/worker-manager/test/provider_azure_test.js
@@ -549,7 +549,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       await assertProvisioningState({ ip: 'inprogress' });
       const ipParams = fake.networkClient.publicIPAddresses.getFakeRequestParameters('rgrp', ipName);
       assert.equal(ipParams.location, 'westus');
-      assert.equal(ipParams.publicIPAllocationMethod, 'Dynamic');
+      assert.equal(ipParams.publicIPAllocationMethod, 'Static');
 
       debug('second call');
       await provider.provisionResources({ worker, monitor });


### PR DESCRIPTION
Fixes #7914.

>Worker Manager (Azure): uses `Static` public IP allocation with the `Standard` SKU.