### PR TITLE
fix(worker-runner): poll azure metadata service every second

### DIFF
--- a/changelog/d2bDYorTQ8CdzChNWDPgPg.md
+++ b/changelog/d2bDYorTQ8CdzChNWDPgPg.md
@@ -1,0 +1,4 @@
+audience: worker-deployers
+level: patch
+---
+Worker Runner/Generic Worker (Azure): polls the metadata service for events the worker should gracefully terminate on every second (down from 15s). This frequency is recommended by Microsoft [here](https://learn.microsoft.com/en-us/azure/virtual-machines/windows/scheduled-events#polling-frequency) and will hopefully reduce tasks resolving as `claim-expired`.

--- a/tools/worker-runner/provider/azure/azure.go
+++ b/tools/worker-runner/provider/azure/azure.go
@@ -154,7 +154,9 @@ func (p *AzureProvider) WorkerStarted(state *run.State) error {
 	p.proto.AddCapability("graceful-termination")
 
 	// start polling for graceful shutdown
-	p.terminationTicker = time.NewTicker(15 * time.Second)
+	// Microsoft recommends once per second
+	// https://learn.microsoft.com/en-us/azure/virtual-machines/windows/scheduled-events#polling-frequency
+	p.terminationTicker = time.NewTicker(1 * time.Second)
 	go func() {
 		for {
 			<-p.terminationTicker.C


### PR DESCRIPTION
>Worker Runner/Generic Worker (Azure): polls the metadata service for events the worker should gracefully terminate on every second (down from 15s). This frequency is recommended by Microsoft [here](https://learn.microsoft.com/en-us/azure/virtual-machines/windows/scheduled-events#polling-frequency) and will hopefully reduce tasks resolving as `claim-expired`.