### PR TITLE
fix(worker): arbitrary file access during archive extraction zipslip

### DIFF
--- a/tools/worker-runner/files/files.go
+++ b/tools/worker-runner/files/files.go
@@ -10,6 +10,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"strings"
 )
 
 func ExtractAll(files []File) error {
@@ -112,6 +113,19 @@ func unzip(b []byte, dest string) error {
 		// note that the ZIP file here is trusted so `..` in this path does not
 		// constitute a vulnerability (just an odd way to get things done)
 		path := filepath.Join(dest, f.Name)
+
+		// Prevent Zip Slip: ensure the resulting path is within dest
+		absDest, err := filepath.Abs(dest)
+		if err != nil {
+			return err
+		}
+		absPath, err := filepath.Abs(path)
+		if err != nil {
+			return err
+		}
+		if !strings.HasPrefix(absPath, absDest+string(os.PathSeparator)) && absPath != absDest {
+			return fmt.Errorf("illegal file path in zip: %s", f.Name)
+		}
 
 		dir := filepath.Dir(path)
 		err = os.MkdirAll(dir, 0755)


### PR DESCRIPTION


fix the "Zip Slip" vulnerability, we need to ensure that files extracted from the zip archive cannot escape the intended destination directory. The best way to do this is to:

1. For each file entry, construct the full output path using `filepath.Join(dest, f.Name)`.
2. Clean the resulting path using `filepath.Clean`.
3. Obtain the absolute path of both the destination directory and the output file.
4. Ensure that the output file's absolute path has the destination directory's absolute path as its prefix (with a path separator to avoid partial matches).
5. If the check fails, skip extraction or return an error.

This check should be added in the `extractAndWriteFile` closure, right after constructing the `path` variable and before any filesystem operations are performed.

We will need to import `"strings"` if not already present.