### PR TITLE
fix(worker-runner): protocol pipe now works on windows

### DIFF
--- a/changelog/EoscfzMoTPWBsC3kEIvYOw.md
+++ b/changelog/EoscfzMoTPWBsC3kEIvYOw.md
@@ -1,0 +1,6 @@
+audience: worker-deployers
+level: patch
+---
+Worker Runner: adds additional logging around sending `graceful-termination` request to worker.
+
+Worker Runner (windows): fixes protocol pipe connection so that Generic Worker can communicate with Worker Runner. This allows `graceful-termination` requests to be properly sent and received, among other message types. You must include `--with-worker-runner` in your Generic Worker service configuration on the `run` subcommand.

--- a/internal/mocktc/queue.go
+++ b/internal/mocktc/queue.go
@@ -407,7 +407,7 @@ func (queue *Queue) GetLatestArtifact_SignedURL(taskId, name string, duration ti
 		return queue.GetLatestArtifact_SignedURL(taskId, a.Artifact, duration)
 	}
 	queue.t.Fatalf("Unknown artifact type %T", artifact)
-	return nil, fmt.Errorf("Unknown artifact type %T", artifact)
+	return nil, fmt.Errorf("unknown artifact type %T", artifact)
 }
 
 func (queue *Queue) ListArtifacts(taskId, runId, continuationToken, limit string) (*tcqueue.ListArtifactsResponse, error) {

--- a/tools/worker-runner/provider/aws/awsprovider.go
+++ b/tools/worker-runner/provider/aws/awsprovider.go
@@ -106,6 +106,7 @@ func (p *AWSProvider) checkTerminationTime() bool {
 	if err == nil {
 		log.Println("EC2 Metadata Service says termination is imminent")
 		if p.proto != nil && p.proto.Capable("graceful-termination") {
+			log.Println("Sending graceful-termination request with finish-tasks=false")
 			p.proto.Send(workerproto.Message{
 				Type: "graceful-termination",
 				Properties: map[string]any{

--- a/tools/worker-runner/provider/azure/azure.go
+++ b/tools/worker-runner/provider/azure/azure.go
@@ -125,6 +125,7 @@ func (p *AzureProvider) checkTerminationTime() bool {
 			}
 			log.Printf("Azure Metadata Service says a %s maintenance event is imminent\n", evt.EventType)
 			if p.proto != nil && p.proto.Capable("graceful-termination") {
+				log.Println("Sending graceful-termination request with finish-tasks=false")
 				p.proto.Send(workerproto.Message{
 					Type: "graceful-termination",
 					Properties: map[string]any{

--- a/tools/worker-runner/provider/azure/azure_test.go
+++ b/tools/worker-runner/provider/azure/azure_test.go
@@ -140,12 +140,15 @@ func TestCheckTerminationTime(t *testing.T) {
 		mds.ScheduledEventsError = nil
 
 		evt := struct {
-			EventId      string
-			EventType    string
-			ResourceType string
-			Resources    []string
-			EventStatus  string
-			NotBefore    string
+			EventId           string
+			EventType         string
+			ResourceType      string
+			Resources         []string
+			EventStatus       string
+			NotBefore         string
+			Description       string
+			EventSource       string
+			DurationInSeconds int
 		}{
 			EventType: "Preempt",
 		}

--- a/tools/worker-runner/provider/azure/metadata.go
+++ b/tools/worker-runner/provider/azure/metadata.go
@@ -45,12 +45,15 @@ type Tag struct {
 // Data from the /scheduledevents endpoint
 type ScheduledEvents struct {
 	Events []struct {
-		EventId      string
-		EventType    string
-		ResourceType string
-		Resources    []string
-		EventStatus  string
-		NotBefore    string
+		EventId           string
+		EventType         string
+		ResourceType      string
+		Resources         []string
+		EventStatus       string
+		NotBefore         string
+		Description       string
+		EventSource       string
+		DurationInSeconds int
 	}
 }
 
@@ -97,7 +100,7 @@ func (mds *realMetadataService) fetch(path string, apiVersion string) (string, e
 }
 
 func (mds *realMetadataService) queryInstanceData() (*InstanceData, error) {
-	content, err := mds.fetch("/metadata/instance", "2019-08-15")
+	content, err := mds.fetch("/metadata/instance", "2025-04-07")
 	if err != nil {
 		return nil, err
 	}
@@ -107,7 +110,7 @@ func (mds *realMetadataService) queryInstanceData() (*InstanceData, error) {
 }
 
 func (mds *realMetadataService) queryAttestedDocument() (string, error) {
-	content, err := mds.fetch("/metadata/attested/document", "2019-08-15")
+	content, err := mds.fetch("/metadata/attested/document", "2025-04-07")
 	if err != nil {
 		return "", err
 	}
@@ -124,7 +127,7 @@ func (mds *realMetadataService) queryAttestedDocument() (string, error) {
 
 func (mds *realMetadataService) queryScheduledEvents() (*ScheduledEvents, error) {
 	// note that this interface is only available in this earlier API version
-	content, err := mds.fetch("/metadata/scheduledevents", "2017-11-01")
+	content, err := mds.fetch("/metadata/scheduledevents", "2020-07-01")
 	if err != nil {
 		return nil, err
 	}

--- a/tools/worker-runner/provider/azure/metadata_test.go
+++ b/tools/worker-runner/provider/azure/metadata_test.go
@@ -53,7 +53,7 @@ func testServer() *httptest.Server {
 		}
 
 		if r.URL.Path == "/metadata/instance" {
-			if apiVersion != "2019-08-15" {
+			if apiVersion != "2025-04-07" {
 				w.WriteHeader(400)
 				fmt.Fprintf(w, "Bad API version")
 				return
@@ -80,7 +80,7 @@ func testServer() *httptest.Server {
 			return
 		}
 		if r.URL.Path == "/metadata/scheduledevents" {
-			if apiVersion != "2017-11-01" { // note: different from other endpoints!
+			if apiVersion != "2020-07-01" { // note: different from other endpoints!
 				w.WriteHeader(400)
 				fmt.Fprintf(w, "Bad API version")
 				return
@@ -105,7 +105,7 @@ func testServer() *httptest.Server {
 		}
 
 		if r.URL.Path == "/metadata/attested/document" {
-			if apiVersion != "2019-08-15" {
+			if apiVersion != "2025-04-07" {
 				w.WriteHeader(400)
 				fmt.Fprintf(w, "Bad API version")
 				return

--- a/tools/worker-runner/provider/google/google.go
+++ b/tools/worker-runner/provider/google/google.go
@@ -115,6 +115,7 @@ func (p *GoogleProvider) checkTerminationTime() bool {
 	if err == nil && value == "TRUE" {
 		log.Println("GCP Metadata Service says termination is imminent")
 		if p.proto != nil && p.proto.Capable("graceful-termination") && !p.terminationMsgSent {
+			log.Println("Sending graceful-termination request with finish-tasks=false")
 			p.proto.Send(workerproto.Message{
 				Type: "graceful-termination",
 				Properties: map[string]any{

--- a/tools/worker-runner/worker/genericworker/runmethod_windows.go
+++ b/tools/worker-runner/worker/genericworker/runmethod_windows.go
@@ -43,29 +43,37 @@ func (m *serviceRunMethod) start(w *genericworker, state *run.State) (workerprot
 		return nil, fmt.Errorf("error starting service %s: %s", m.serviceName, err)
 	}
 
-	// connect the transport to the named
-	inputReader, inputWriter := io.Pipe()
-	outputReader, outputWriter := io.Pipe()
-	transp := workerproto.NewPipeTransport(inputReader, outputWriter)
+	// Use two separate unidirectional pipes to eliminate duplex deadlocks
+	inputChan := make(chan io.Reader, 1)  // server reads from this (client->server)
+	outputChan := make(chan io.Writer, 1) // server writes to this (server->client)
 
-	err = m.connectPipeToProtocol(w.wicfg.ProtocolPipe, inputWriter, outputReader)
+	err = m.connectPipeToProtocol(w.wicfg.ProtocolPipe, inputChan, outputChan)
 	if err != nil {
 		return nil, err
 	}
+
+	// Wait for both connections to be established
+	inputConn := <-inputChan
+	outputConn := <-outputChan
+	transp := workerproto.NewPipeTransport(inputConn, outputConn)
 
 	return transp, nil
 }
 
 // Connect the configured named pipe to the worker-runner workerproto.  This opens
 // the named pipe and listens for a single connection, which it considers to be
-// from the worker, and does not acccept any further connections.  Aside from
+// from the worker, and does not accept any further connections.  Aside from
 // careful configuration of the security descriptor, this provides an
 // additional layer of assurance that this pipe is not used to manipulate the
 // worker or worker-runner.
-func (m *serviceRunMethod) connectPipeToProtocol(protocolPipe string, inputWriter io.WriteCloser, outputReader io.Reader) error {
+func (m *serviceRunMethod) connectPipeToProtocol(protocolPipe string, inputChan chan io.Reader, outputChan chan io.Writer) error {
 	if protocolPipe == "" {
 		protocolPipe = `\\.\pipe\generic-worker`
 	}
+
+	// Create two separate pipe names for unidirectional communication
+	inputPipeName := protocolPipe + "-input"   // client->server
+	outputPipeName := protocolPipe + "-output" // server->client
 
 	// Construct a security-descriptor that allows all access to the current
 	// user and to "Local System" (shorthand SY)
@@ -80,32 +88,49 @@ func (m *serviceRunMethod) connectPipeToProtocol(protocolPipe string, inputWrite
 		// (A;;GA;;;<sid>) -- GENERIC_ALL access for current user
 		// (A;;GA;;;SY) -- GENERIC_ALL access for "Local System"
 		SecurityDescriptor: fmt.Sprintf("D:P(A;;GA;;;%s)(A;;GA;;;SY)", cu.Uid),
-	}
-	listener, err := winio.ListenPipe(protocolPipe, &c)
-	if err != nil {
-		return fmt.Errorf("error setting up protocolPipe: %s", err)
+		InputBufferSize:    65536, // 64KiB
+		OutputBufferSize:   65536, // 64KiB
 	}
 
+	// Create input pipe listener (client->server)
+	inputListener, err := winio.ListenPipe(inputPipeName, &c)
+	if err != nil {
+		return fmt.Errorf("error setting up input protocolPipe: %s", err)
+	}
+
+	// Create output pipe listener (server->client)
+	outputListener, err := winio.ListenPipe(outputPipeName, &c)
+	if err != nil {
+		inputListener.Close()
+		return fmt.Errorf("error setting up output protocolPipe: %s", err)
+	}
+
+	// Accept input connection (client->server)
 	go func() {
-		conn, err := listener.Accept()
+		conn, err := inputListener.Accept()
 		if err != nil {
-			// since this occurs asynchronously, there's not much we can do
-			// here other than log about it
-			log.Printf("Error accepting connection on protocolPipe: %s", err)
-			listener.Close()
+			log.Printf("Error accepting connection on input protocolPipe: %s", err)
+			inputListener.Close()
 			return
 		}
 
-		log.Printf("Worker connecteed on protocolPipe")
-		listener.Close()
+		log.Printf("Worker connected on input protocolPipe")
+		inputListener.Close()
+		inputChan <- conn
+	}()
 
-		// copy bidirectionally between this connection and the protocol transport, and do not
-		// accept any further connections.  When the pipe is closed, we close the inputWriter.
-		go io.Copy(conn, outputReader)
-		go func() {
-			io.Copy(inputWriter, conn)
-			inputWriter.Close()
-		}()
+	// Accept output connection (server->client)
+	go func() {
+		conn, err := outputListener.Accept()
+		if err != nil {
+			log.Printf("Error accepting connection on output protocolPipe: %s", err)
+			outputListener.Close()
+			return
+		}
+
+		log.Printf("Worker connected on output protocolPipe")
+		outputListener.Close()
+		outputChan <- conn
 	}()
 
 	return nil

--- a/tools/workerproto/protocol_test.go
+++ b/tools/workerproto/protocol_test.go
@@ -9,9 +9,16 @@ import (
 
 func RequireInitialized(t *testing.T, prot *Protocol, initialized bool) {
 	t.Helper()
-	prot.initializedCond.L.Lock()
-	defer prot.initializedCond.L.Unlock()
-	require.Equal(t, initialized, prot.initialized)
+	select {
+	case <-prot.initializedChan:
+		if !initialized {
+			t.Errorf("Expected protocol to be not initialized, but it is initialized")
+		}
+	default:
+		if initialized {
+			t.Errorf("Expected protocol to be initialized, but it is not initialized")
+		}
+	}
 }
 
 func TestCapabilityNegotiation(t *testing.T) {


### PR DESCRIPTION
>Worker Runner: adds additional logging around sending `graceful-termination` request to worker.
>
>Worker Runner (windows): fixes protocol pipe connection so that Generic Worker can communicate with Worker Runner. This allows `graceful-termination` requests to be properly sent and received, among other message types. You must include `--with-worker-runner` in your Generic Worker service configuration on the `run` subcommand.