### PR TITLE
generic-worker/d2g: remove support for the dind and dockerSave features

### DIFF
--- a/generated/references.json
+++ b/generated/references.json
@@ -9783,18 +9783,6 @@
                   "title": "Enable generation of ed25519-signed Chain of Trust artifacts",
                   "type": "boolean"
                 },
-                "dind": {
-                  "default": false,
-                  "description": "Runs docker-in-docker and binds `/var/run/docker.sock` into the container. Doesn't allow privileged mode, capabilities or host volume mounts.",
-                  "title": "Docker in Docker",
-                  "type": "boolean"
-                },
-                "dockerSave": {
-                  "default": false,
-                  "description": "Uploads docker images as artifacts",
-                  "title": "Docker save",
-                  "type": "boolean"
-                },
                 "interactive": {
                   "default": false,
                   "description": "This allows you to interactively run commands inside the container and attaches you to the stdin/stdout/stderr over a websocket. Can be used for SSH-like access to docker containers.",
@@ -10585,18 +10573,6 @@
                   "default": false,
                   "description": "Artifacts named chain-of-trust.json and chain-of-trust.json.sig should be generated which will include information for downstream tasks to build a level of trust for the artifacts produced by the task and the environment it ran in.",
                   "title": "Enable generation of ed25519-signed Chain of Trust artifacts",
-                  "type": "boolean"
-                },
-                "dind": {
-                  "default": false,
-                  "description": "Runs docker-in-docker and binds `/var/run/docker.sock` into the container. Doesn't allow privileged mode, capabilities or host volume mounts.",
-                  "title": "Docker in Docker",
-                  "type": "boolean"
-                },
-                "dockerSave": {
-                  "default": false,
-                  "description": "Uploads docker images as artifacts",
-                  "title": "Docker save",
                   "type": "boolean"
                 },
                 "interactive": {

--- a/tools/d2g/d2g.go
+++ b/tools/d2g/d2g.go
@@ -355,18 +355,6 @@ func artifacts(dwPayload *dockerworker.DockerWorkerPayload) []genericworker.Arti
 		gwArtifacts[i] = *gwArt
 	}
 
-	if dwPayload.Features.DockerSave {
-		gwArt := new(genericworker.Artifact)
-		defaults.SetDefaults(gwArt)
-
-		gwArt.Name = "public/dockerImage.tar.gz"
-		gwArt.Path = "image.tar.gz"
-		gwArt.Type = "file"
-		gwArt.Optional = true
-
-		gwArtifacts = append(gwArtifacts, *gwArt)
-	}
-
 	return gwArtifacts
 }
 
@@ -435,14 +423,6 @@ func runCommand(
 func copyArtifacts(dwPayload *dockerworker.DockerWorkerPayload, gwArtifacts []genericworker.Artifact) []CopyArtifact {
 	artifacts := []CopyArtifact{}
 	for i := range gwArtifacts {
-		// An image artifact will be in the generic worker payload when
-		// dockerSave is enabled. That artifact will not be found in either the
-		// docker worker payload or the container after the run command is
-		// complete, so no cp command is needed for it. The image artifact is
-		// created after the run command is complete.
-		if _, ok := dwPayload.Artifacts[gwArtifacts[i].Name]; !ok {
-			continue
-		}
 		// Volume artifact mounts do not need to be copied
 		if dwPayload.Artifacts[gwArtifacts[i].Name].Type == "volume" {
 			continue

--- a/tools/d2g/genericworker/generated_types.go
+++ b/tools/d2g/genericworker/generated_types.go
@@ -216,16 +216,6 @@ type (
 		// Default:    false
 		ChainOfTrust bool `json:"chainOfTrust" default:"false"`
 
-		// Runs docker-in-docker and binds `/var/run/docker.sock` into the container. Doesn't allow privileged mode, capabilities or host volume mounts.
-		//
-		// Default:    false
-		Dind bool `json:"dind" default:"false"`
-
-		// Uploads docker images as artifacts
-		//
-		// Default:    false
-		DockerSave bool `json:"dockerSave" default:"false"`
-
 		// This allows you to interactively run commands inside the container and attaches you to the stdin/stdout/stderr over a websocket. Can be used for SSH-like access to docker containers.
 		//
 		// Default:    false
@@ -1448,18 +1438,6 @@ func JSONSchema() string {
               "default": false,
               "description": "Artifacts named chain-of-trust.json and chain-of-trust.json.sig should be generated which will include information for downstream tasks to build a level of trust for the artifacts produced by the task and the environment it ran in.",
               "title": "Enable generation of ed25519-signed Chain of Trust artifacts",
-              "type": "boolean"
-            },
-            "dind": {
-              "default": false,
-              "description": "Runs docker-in-docker and binds ` + "`" + `/var/run/docker.sock` + "`" + ` into the container. Doesn't allow privileged mode, capabilities or host volume mounts.",
-              "title": "Docker in Docker",
-              "type": "boolean"
-            },
-            "dockerSave": {
-              "default": false,
-              "description": "Uploads docker images as artifacts",
-              "title": "Docker save",
               "type": "boolean"
             },
             "interactive": {

--- a/ui/docs/reference/workers/docker-worker/features.mdx
+++ b/ui/docs/reference/workers/docker-worker/features.mdx
@@ -67,7 +67,7 @@ References:
 
 ## Feature: `dockerSave`
 
-Status: Unstable, api may be changed
+Status: deprecated, not supported in generic-worker
 
 When this feature is activated, after the task finishes, a copy of the container is saved using `docker commit`, converted into a tarball with `docker save`, and uploaded to s3 under the filename `public/dockerImage.tar`. The image itself will have repository `task-${taskId}-${runId}:latest` and tag `:latest`.
 

--- a/workers/generic-worker/d2g_feature.go
+++ b/workers/generic-worker/d2g_feature.go
@@ -164,36 +164,6 @@ func (dtf *D2GTaskFeature) Start() *CommandExecutionError {
 }
 
 func (dtf *D2GTaskFeature) Stop(err *ExecutionErrors) {
-	if dtf.task.DockerWorkerPayload.Features.DockerSave {
-		cmd, e := process.NewCommandNoOutputStreams([]string{
-			"docker",
-			"commit",
-			dtf.task.D2GInfo.ContainerName,
-			dtf.task.D2GInfo.ContainerName,
-		}, taskContext.TaskDir, []string{}, dtf.task.pd)
-		if e != nil {
-			err.add(executionError(internalError, errored, fmt.Errorf("[d2g] could not create process to commit docker container: %v", e)))
-		}
-		out, e := cmd.CombinedOutput()
-		if e != nil {
-			err.add(executionError(internalError, errored, fmt.Errorf("[d2g] could not commit docker container: %v\n%v", e, string(out))))
-		}
-
-		cmd, e = process.NewCommandNoOutputStreams([]string{
-			"/usr/bin/env",
-			"bash",
-			"-c",
-			fmt.Sprintf("docker save %s | gzip > image.tar.gz", dtf.task.D2GInfo.ContainerName),
-		}, taskContext.TaskDir, []string{}, dtf.task.pd)
-		if e != nil {
-			err.add(executionError(internalError, errored, fmt.Errorf("[d2g] could not create process to save docker image: %v", e)))
-		}
-		out, e = cmd.CombinedOutput()
-		if e != nil {
-			err.add(executionError(internalError, errored, fmt.Errorf("[d2g] could not save docker image: %v\n%v", e, string(out))))
-		}
-	}
-
 	for _, artifact := range dtf.task.D2GInfo.CopyArtifacts {
 		cmd, e := process.NewCommandNoOutputStreams([]string{
 			"docker",

--- a/workers/generic-worker/generated_insecure_darwin.go
+++ b/workers/generic-worker/generated_insecure_darwin.go
@@ -218,16 +218,6 @@ type (
 		// Default:    false
 		ChainOfTrust bool `json:"chainOfTrust" default:"false"`
 
-		// Runs docker-in-docker and binds `/var/run/docker.sock` into the container. Doesn't allow privileged mode, capabilities or host volume mounts.
-		//
-		// Default:    false
-		Dind bool `json:"dind" default:"false"`
-
-		// Uploads docker images as artifacts
-		//
-		// Default:    false
-		DockerSave bool `json:"dockerSave" default:"false"`
-
 		// This allows you to interactively run commands inside the container and attaches you to the stdin/stdout/stderr over a websocket. Can be used for SSH-like access to docker containers.
 		//
 		// Default:    false
@@ -1401,18 +1391,6 @@ func JSONSchema() string {
               "default": false,
               "description": "Artifacts named chain-of-trust.json and chain-of-trust.json.sig should be generated which will include information for downstream tasks to build a level of trust for the artifacts produced by the task and the environment it ran in.",
               "title": "Enable generation of ed25519-signed Chain of Trust artifacts",
-              "type": "boolean"
-            },
-            "dind": {
-              "default": false,
-              "description": "Runs docker-in-docker and binds ` + "`" + `/var/run/docker.sock` + "`" + ` into the container. Doesn't allow privileged mode, capabilities or host volume mounts.",
-              "title": "Docker in Docker",
-              "type": "boolean"
-            },
-            "dockerSave": {
-              "default": false,
-              "description": "Uploads docker images as artifacts",
-              "title": "Docker save",
               "type": "boolean"
             },
             "interactive": {

--- a/workers/generic-worker/generated_insecure_freebsd.go
+++ b/workers/generic-worker/generated_insecure_freebsd.go
@@ -218,16 +218,6 @@ type (
 		// Default:    false
 		ChainOfTrust bool `json:"chainOfTrust" default:"false"`
 
-		// Runs docker-in-docker and binds `/var/run/docker.sock` into the container. Doesn't allow privileged mode, capabilities or host volume mounts.
-		//
-		// Default:    false
-		Dind bool `json:"dind" default:"false"`
-
-		// Uploads docker images as artifacts
-		//
-		// Default:    false
-		DockerSave bool `json:"dockerSave" default:"false"`
-
 		// This allows you to interactively run commands inside the container and attaches you to the stdin/stdout/stderr over a websocket. Can be used for SSH-like access to docker containers.
 		//
 		// Default:    false
@@ -1401,18 +1391,6 @@ func JSONSchema() string {
               "default": false,
               "description": "Artifacts named chain-of-trust.json and chain-of-trust.json.sig should be generated which will include information for downstream tasks to build a level of trust for the artifacts produced by the task and the environment it ran in.",
               "title": "Enable generation of ed25519-signed Chain of Trust artifacts",
-              "type": "boolean"
-            },
-            "dind": {
-              "default": false,
-              "description": "Runs docker-in-docker and binds ` + "`" + `/var/run/docker.sock` + "`" + ` into the container. Doesn't allow privileged mode, capabilities or host volume mounts.",
-              "title": "Docker in Docker",
-              "type": "boolean"
-            },
-            "dockerSave": {
-              "default": false,
-              "description": "Uploads docker images as artifacts",
-              "title": "Docker save",
               "type": "boolean"
             },
             "interactive": {

--- a/workers/generic-worker/generated_insecure_linux.go
+++ b/workers/generic-worker/generated_insecure_linux.go
@@ -218,16 +218,6 @@ type (
 		// Default:    false
 		ChainOfTrust bool `json:"chainOfTrust" default:"false"`
 
-		// Runs docker-in-docker and binds `/var/run/docker.sock` into the container. Doesn't allow privileged mode, capabilities or host volume mounts.
-		//
-		// Default:    false
-		Dind bool `json:"dind" default:"false"`
-
-		// Uploads docker images as artifacts
-		//
-		// Default:    false
-		DockerSave bool `json:"dockerSave" default:"false"`
-
 		// This allows you to interactively run commands inside the container and attaches you to the stdin/stdout/stderr over a websocket. Can be used for SSH-like access to docker containers.
 		//
 		// Default:    false
@@ -1401,18 +1391,6 @@ func JSONSchema() string {
               "default": false,
               "description": "Artifacts named chain-of-trust.json and chain-of-trust.json.sig should be generated which will include information for downstream tasks to build a level of trust for the artifacts produced by the task and the environment it ran in.",
               "title": "Enable generation of ed25519-signed Chain of Trust artifacts",
-              "type": "boolean"
-            },
-            "dind": {
-              "default": false,
-              "description": "Runs docker-in-docker and binds ` + "`" + `/var/run/docker.sock` + "`" + ` into the container. Doesn't allow privileged mode, capabilities or host volume mounts.",
-              "title": "Docker in Docker",
-              "type": "boolean"
-            },
-            "dockerSave": {
-              "default": false,
-              "description": "Uploads docker images as artifacts",
-              "title": "Docker save",
               "type": "boolean"
             },
             "interactive": {

--- a/workers/generic-worker/generated_multiuser_darwin.go
+++ b/workers/generic-worker/generated_multiuser_darwin.go
@@ -218,16 +218,6 @@ type (
 		// Default:    false
 		ChainOfTrust bool `json:"chainOfTrust" default:"false"`
 
-		// Runs docker-in-docker and binds `/var/run/docker.sock` into the container. Doesn't allow privileged mode, capabilities or host volume mounts.
-		//
-		// Default:    false
-		Dind bool `json:"dind" default:"false"`
-
-		// Uploads docker images as artifacts
-		//
-		// Default:    false
-		DockerSave bool `json:"dockerSave" default:"false"`
-
 		// This allows you to interactively run commands inside the container and attaches you to the stdin/stdout/stderr over a websocket. Can be used for SSH-like access to docker containers.
 		//
 		// Default:    false
@@ -1450,18 +1440,6 @@ func JSONSchema() string {
               "default": false,
               "description": "Artifacts named chain-of-trust.json and chain-of-trust.json.sig should be generated which will include information for downstream tasks to build a level of trust for the artifacts produced by the task and the environment it ran in.",
               "title": "Enable generation of ed25519-signed Chain of Trust artifacts",
-              "type": "boolean"
-            },
-            "dind": {
-              "default": false,
-              "description": "Runs docker-in-docker and binds ` + "`" + `/var/run/docker.sock` + "`" + ` into the container. Doesn't allow privileged mode, capabilities or host volume mounts.",
-              "title": "Docker in Docker",
-              "type": "boolean"
-            },
-            "dockerSave": {
-              "default": false,
-              "description": "Uploads docker images as artifacts",
-              "title": "Docker save",
               "type": "boolean"
             },
             "interactive": {

--- a/workers/generic-worker/generated_multiuser_freebsd.go
+++ b/workers/generic-worker/generated_multiuser_freebsd.go
@@ -218,16 +218,6 @@ type (
 		// Default:    false
 		ChainOfTrust bool `json:"chainOfTrust" default:"false"`
 
-		// Runs docker-in-docker and binds `/var/run/docker.sock` into the container. Doesn't allow privileged mode, capabilities or host volume mounts.
-		//
-		// Default:    false
-		Dind bool `json:"dind" default:"false"`
-
-		// Uploads docker images as artifacts
-		//
-		// Default:    false
-		DockerSave bool `json:"dockerSave" default:"false"`
-
 		// This allows you to interactively run commands inside the container and attaches you to the stdin/stdout/stderr over a websocket. Can be used for SSH-like access to docker containers.
 		//
 		// Default:    false
@@ -1450,18 +1440,6 @@ func JSONSchema() string {
               "default": false,
               "description": "Artifacts named chain-of-trust.json and chain-of-trust.json.sig should be generated which will include information for downstream tasks to build a level of trust for the artifacts produced by the task and the environment it ran in.",
               "title": "Enable generation of ed25519-signed Chain of Trust artifacts",
-              "type": "boolean"
-            },
-            "dind": {
-              "default": false,
-              "description": "Runs docker-in-docker and binds ` + "`" + `/var/run/docker.sock` + "`" + ` into the container. Doesn't allow privileged mode, capabilities or host volume mounts.",
-              "title": "Docker in Docker",
-              "type": "boolean"
-            },
-            "dockerSave": {
-              "default": false,
-              "description": "Uploads docker images as artifacts",
-              "title": "Docker save",
               "type": "boolean"
             },
             "interactive": {

--- a/workers/generic-worker/generated_multiuser_linux.go
+++ b/workers/generic-worker/generated_multiuser_linux.go
@@ -218,16 +218,6 @@ type (
 		// Default:    false
 		ChainOfTrust bool `json:"chainOfTrust" default:"false"`
 
-		// Runs docker-in-docker and binds `/var/run/docker.sock` into the container. Doesn't allow privileged mode, capabilities or host volume mounts.
-		//
-		// Default:    false
-		Dind bool `json:"dind" default:"false"`
-
-		// Uploads docker images as artifacts
-		//
-		// Default:    false
-		DockerSave bool `json:"dockerSave" default:"false"`
-
 		// This allows you to interactively run commands inside the container and attaches you to the stdin/stdout/stderr over a websocket. Can be used for SSH-like access to docker containers.
 		//
 		// Default:    false
@@ -1450,18 +1440,6 @@ func JSONSchema() string {
               "default": false,
               "description": "Artifacts named chain-of-trust.json and chain-of-trust.json.sig should be generated which will include information for downstream tasks to build a level of trust for the artifacts produced by the task and the environment it ran in.",
               "title": "Enable generation of ed25519-signed Chain of Trust artifacts",
-              "type": "boolean"
-            },
-            "dind": {
-              "default": false,
-              "description": "Runs docker-in-docker and binds ` + "`" + `/var/run/docker.sock` + "`" + ` into the container. Doesn't allow privileged mode, capabilities or host volume mounts.",
-              "title": "Docker in Docker",
-              "type": "boolean"
-            },
-            "dockerSave": {
-              "default": false,
-              "description": "Uploads docker images as artifacts",
-              "title": "Docker save",
               "type": "boolean"
             },
             "interactive": {

--- a/workers/generic-worker/schemas/insecure_posix.yml
+++ b/workers/generic-worker/schemas/insecure_posix.yml
@@ -624,17 +624,6 @@ oneOf:
           title: Artifact uploads
           description: ""
           default: true
-        dind:
-          type: boolean
-          title: Docker in Docker
-          description: >-
-            Runs docker-in-docker and binds `/var/run/docker.sock` into the container. Doesn't allow privileged mode, capabilities or host volume mounts.
-          default: false
-        dockerSave:
-          type: boolean
-          title: Docker save
-          description: Uploads docker images as artifacts
-          default: false
         interactive:
           type: boolean
           title: Docker Exec Interactive

--- a/workers/generic-worker/schemas/multiuser_posix.yml
+++ b/workers/generic-worker/schemas/multiuser_posix.yml
@@ -667,17 +667,6 @@ oneOf:
           title: Artifact uploads
           description: ""
           default: true
-        dind:
-          type: boolean
-          title: Docker in Docker
-          description: >-
-            Runs docker-in-docker and binds `/var/run/docker.sock` into the container. Doesn't allow privileged mode, capabilities or host volume mounts.
-          default: false
-        dockerSave:
-          type: boolean
-          title: Docker save
-          description: Uploads docker images as artifacts
-          default: false
         interactive:
           type: boolean
           title: Docker Exec Interactive


### PR DESCRIPTION
dind was not actually implemented as far as I can tell.  dockerSave seems to be unused and broken, so rather than try to fix a feature we don't need, stop pretending it exists.

<!-- Did you remember to add a changelog snippet? See
     https://github.com/taskcluster/taskcluster/blob/main/dev-docs/best-practices/changelog.md

     If this is related to a Bugzilla bug, please begin your title with [Bug XXXXX]
     and update this link.  Otherwise, just remove it from your PR comment.  -->

Bugzilla Bug: [XXXXX](https://bugzilla.mozilla.org/show_bug.cgi?id=XXXXX)

<!-- If this is related to a GitHub Bug/Issue, Please write Issue Number after # in the next line. Otherwise, just remove it from your PR comment. -->

Github Bug/Issue: Fixes #XXXX
