### PR TITLE
fix(worker-runner): capture windows service exit code for reboots

### DIFF
--- a/changelog/TaDW6njEQ-OrgiJdMf6G5Q.md
+++ b/changelog/TaDW6njEQ-OrgiJdMf6G5Q.md
@@ -1,0 +1,4 @@
+audience: worker-deployers
+level: patch
+---
+Worker Runner (Windows): capture Generic Worker service exit code and exit early if the worker is rebooting, preventing a Worker Manager `removeWorker` API call.

--- a/tools/worker-runner/worker/genericworker/runmethod_windows.go
+++ b/tools/worker-runner/worker/genericworker/runmethod_windows.go
@@ -151,6 +151,9 @@ func (m *serviceRunMethod) wait() error {
 		if err != nil {
 			return fmt.Errorf("error querying service %s status: %s", m.serviceName, err)
 		}
+		if status.ServiceSpecificExitCode == 67 {
+			return fmt.Errorf("%s requested immediate reboot", m.serviceName)
+		}
 		if status.State != svc.StartPending && status.State != svc.Running {
 			break
 		}


### PR DESCRIPTION
>Worker Runner (Windows): capture Generic Worker service exit code and exit early if the worker is rebooting, preventing a Worker Manager `removeWorker` API call.