### PR TITLE
fix(d2g): remove calls out to bash for image loading and cot additional data file

### DIFF
--- a/changelog/NDwimCSTTl6khwEkWCO-CA.md
+++ b/changelog/NDwimCSTTl6khwEkWCO-CA.md
@@ -1,0 +1,4 @@
+audience: users
+level: patch
+---
+D2G: remove calls out to bash shells to load docker image and create chain of trust additional data file.

--- a/tools/d2g/dockerimageartifact.go
+++ b/tools/d2g/dockerimageartifact.go
@@ -38,12 +38,6 @@ func (dia *DockerImageArtifact) FileMounts() ([]genericworker.FileMount, error) 
 	return []genericworker.FileMount{fm}, nil
 }
 
-func (dia *DockerImageArtifact) String() string {
+func (dia *DockerImageArtifact) String(shellEscape bool) string {
 	return `"${D2G_IMAGE_ID}"`
-}
-
-func (dia *DockerImageArtifact) ImageLoader() ImageLoader {
-	return &FileImageLoader{
-		Image: dia,
-	}
 }

--- a/tools/d2g/dockerimagename.go
+++ b/tools/d2g/dockerimagename.go
@@ -9,12 +9,9 @@ func (din *DockerImageName) FileMounts() ([]genericworker.FileMount, error) {
 	return []genericworker.FileMount{}, nil
 }
 
-func (din *DockerImageName) String() string {
-	return shell.Escape(string(*din))
-}
-
-func (din *DockerImageName) ImageLoader() ImageLoader {
-	return &RegistryImageLoader{
-		Image: din,
+func (din *DockerImageName) String(shellEscape bool) string {
+	if shellEscape {
+		return shell.Escape(string(*din))
 	}
+	return string(*din)
 }

--- a/tools/d2g/indexeddockerimage.go
+++ b/tools/d2g/indexeddockerimage.go
@@ -39,13 +39,7 @@ func (idi *IndexedDockerImage) FileMounts() ([]genericworker.FileMount, error) {
 	return []genericworker.FileMount{fm}, nil
 }
 
-func (idi *IndexedDockerImage) ImageLoader() ImageLoader {
-	return &FileImageLoader{
-		Image: idi,
-	}
-}
-
-func (idi *IndexedDockerImage) String() string {
+func (idi *IndexedDockerImage) String(shellEscape bool) string {
 	return `"${D2G_IMAGE_ID}"`
 }
 

--- a/tools/d2g/nameddockerimage.go
+++ b/tools/d2g/nameddockerimage.go
@@ -9,12 +9,9 @@ func (ndi *NamedDockerImage) FileMounts() ([]genericworker.FileMount, error) {
 	return []genericworker.FileMount{}, nil
 }
 
-func (ndi *NamedDockerImage) String() string {
-	return shell.Escape(ndi.Name)
-}
-
-func (ndi *NamedDockerImage) ImageLoader() ImageLoader {
-	return &RegistryImageLoader{
-		Image: ndi,
+func (ndi *NamedDockerImage) String(shellEscape bool) string {
+	if shellEscape {
+		return shell.Escape(ndi.Name)
 	}
+	return ndi.Name
 }


### PR DESCRIPTION
>D2G: remove calls out to bash shells to load docker image and create chain of trust additional data file.

This work combined with https://github.com/taskcluster/taskcluster/pull/7933 will have all calls out to bash shells removed from d2g.