### PR TITLE
fix(d2g): don't write env vars to gw env

### DIFF
--- a/changelog/N3RDmzYfQVijgZBiSTqGvg.md
+++ b/changelog/N3RDmzYfQVijgZBiSTqGvg.md
@@ -1,0 +1,4 @@
+audience: users
+level: patch
+---
+D2G: don't write env vars out to Generic Worker's environment. Instead, pass them as `-e <name>=<value>`. Follow-up to https://github.com/taskcluster/taskcluster/pull/7945#discussion_r2348906304.

--- a/tools/d2g/d2g.go
+++ b/tools/d2g/d2g.go
@@ -190,11 +190,8 @@ func ConvertPayload(
 
 	setArtifacts(dwPayload, gwPayload)
 
-	if gwPayload.Env == nil {
-		gwPayload.Env = map[string]string{}
-	}
 	envVarsWithNewlines := ""
-	conversionInfo.EnvVars, envVarsWithNewlines = envMappings(dwPayload, gwPayload.Env, config)
+	conversionInfo.EnvVars, envVarsWithNewlines = envMappings(dwPayload, config)
 
 	gwWritableDirectoryCaches := writableDirectoryCaches(dwPayload.Cache)
 	dwImage, err := imageObject(&dwPayload.Image)
@@ -631,7 +628,7 @@ func imageObject(payloadImage *json.RawMessage) (Image, error) {
 	}
 }
 
-func envMappings(dwPayload *dockerworker.DockerWorkerPayload, gwEnv map[string]string, config map[string]any) (string, string) {
+func envMappings(dwPayload *dockerworker.DockerWorkerPayload, config map[string]any) (string, string) {
 	envListStrBuilder := strings.Builder{}
 	envStrBuilder := strings.Builder{}
 
@@ -656,8 +653,10 @@ func envMappings(dwPayload *dockerworker.DockerWorkerPayload, gwEnv map[string]s
 	envVarsWithNewlines := []string{}
 	for envVarName, value := range dwPayload.Env {
 		if strings.Contains(value, "\n") {
-			envVarsWithNewlines = append(envVarsWithNewlines, envVarName)
-			gwEnv[envVarName] = value
+			envVarsWithNewlines = append(
+				envVarsWithNewlines,
+				fmt.Sprintf("%s=%s", envVarName, value),
+			)
 			continue
 		}
 		envVars = append(envVars, fmt.Sprintf("%s=%s", envVarName, value))

--- a/tools/d2g/d2gtest/testdata/testcases/env_test.yml
+++ b/tools/d2g/d2gtest/testdata/testcases/env_test.yml
@@ -34,16 +34,11 @@ testSuite:
       - - /usr/bin/env
         - bash
         - -cx
-        - docker run -t --name taskcontainer --memory-swap -1 --pids-limit -1 --add-host=localhost.localdomain:127.0.0.1
-          -e ' test123 --help  ; whoami ; ' -e anotherOne --env-file env.list ubuntu
-          'echo "Hello world"'
-      env:
-        ' test123 --help  ; whoami ; ': |-
-          testing
-          123
-        anotherOne: |
-          line1
+        - |-
+          docker run -t --name taskcontainer --memory-swap -1 --pids-limit -1 --add-host=localhost.localdomain:127.0.0.1 -e ' test123 --help  ; whoami ; =testing
+          123' -e 'anotherOne=line1
           line2
+          ' --env-file env.list ubuntu 'echo "Hello world"'
       features:
         backingLog: true
         liveLog: true


### PR DESCRIPTION
>D2G: don't write env vars out to Generic Worker's environment. Instead, pass them as `-e <name>=<value>`. Follow-up to https://github.com/taskcluster/taskcluster/pull/7945#discussion_r2348906304.

cc @jcristau