### PR TITLE
fix(d2g): account for images that have multiple tags

### DIFF
--- a/changelog/issue-7967.md
+++ b/changelog/issue-7967.md
@@ -1,0 +1,5 @@
+audience: users
+level: patch
+reference: issue 7967
+---
+D2G: accounts for image artifacts that may contain multiple tags for the same image, previously causing a worker error: `runtime error: index out of range [1] with length 1`.

--- a/workers/generic-worker/d2g_feature.go
+++ b/workers/generic-worker/d2g_feature.go
@@ -111,7 +111,10 @@ func (dtf *D2GTaskFeature) Start() *CommandExecutionError {
 			return executionError(internalError, errored, fmt.Errorf("[d2g] could not load docker image: %v\n%v", err, string(out)))
 		}
 
-		imageName := strings.TrimSpace(string(out))
+		// Only use the first line of output for image name
+		// as docker load can output multiple tags for the
+		// same image (see https://github.com/taskcluster/taskcluster/issues/7967)
+		imageName := strings.Split(strings.TrimSpace(string(out)), "\n")[0]
 		if isImageArtifact {
 			imageName = strings.TrimPrefix(imageName, "Loaded image: ")
 		}
@@ -136,7 +139,11 @@ func (dtf *D2GTaskFeature) Start() *CommandExecutionError {
 				return executionError(internalError, errored, fmt.Errorf("[d2g] could not get sha256 of docker image: %v\n%v", err, string(out)))
 			}
 
-			imageID = strings.Split(strings.TrimSpace(string(out)), ":")[1]
+			// Only use the first line of output for image ID
+			// as docker images can output multiple sha256's for the
+			// same image (see https://github.com/taskcluster/taskcluster/issues/7967)
+			idLine := strings.Split(strings.TrimSpace(string(out)), "\n")[0]
+			imageID = strings.TrimPrefix(idLine, "sha256:")
 		}
 
 		image = &Image{


### PR DESCRIPTION
Fixes #7967.

>D2G: accounts for image artifacts that may contain multiple tags for the same image, previously causing a worker error: `runtime error: index out of range [1] with length 1`.