### PR TITLE
fix(d2g): always pull named docker images

### DIFF
--- a/changelog/issue-8004.md
+++ b/changelog/issue-8004.md
@@ -1,0 +1,5 @@
+audience: users
+level: patch
+reference: issue 8004
+---
+D2G: always pulls named docker images to fetch latest tag.

--- a/workers/generic-worker/d2g_feature.go
+++ b/workers/generic-worker/d2g_feature.go
@@ -84,7 +84,11 @@ func (dtf *D2GTaskFeature) Start() *CommandExecutionError {
 
 	image := dtf.imageCache[key]
 
-	if image == nil {
+	// Always want to re-pull the docker image
+	// if it's not an image artifact, as the
+	// tag could be outdated
+	// (see https://github.com/taskcluster/taskcluster/issues/8004)
+	if image == nil || !isImageArtifact {
 		dtf.task.Info("[d2g] Loading docker image")
 
 		var cmd *process.Command


### PR DESCRIPTION
Fixes #8004.

>D2G: always pulls named docker images to fetch latest tag.

cc @Eijebong