### PR TITLE
feat(clients): Python sync client follows artifact redirects

### DIFF
--- a/changelog/issue-8010.md
+++ b/changelog/issue-8010.md
@@ -1,0 +1,7 @@
+audience: developers
+level: major
+reference: issue 8010
+---
+
+Python client follows redirects in artifact download for both async and sync code.
+This was partially fixed in the past in #4057

--- a/clients/client-py/taskcluster/utils.py
+++ b/clients/client-py/taskcluster/utils.py
@@ -290,7 +290,7 @@ def makeSingleHttpRequest(method, url, payload, headers, session=None):
     log.debug('HTTP Headers: %s' % str(headers))
     log.debug('HTTP Payload: %s (limit 100 char)' % str(payload)[:100])
     obj = session if session else requests
-    response = obj.request(method.upper(), url, data=payload, headers=headers, allow_redirects=False)
+    response = obj.request(method.upper(), url, data=payload, headers=headers, allow_redirects=True)
     log.debug('Received HTTP Status:    %s' % response.status_code)
     log.debug('Received HTTP Headers: %s' % str(response.headers))
 


### PR DESCRIPTION
Related to  #8010

This will make both sync and async python clients behave same way - follow redirects (while leaving rust/go/js clients with the existing, non-following behavior)


