### PR TITLE
feat(w-m): Azure provider skips checking already deleted resources

### DIFF
--- a/changelog/PA4Raz-aRnGPqX5kmBE2PA.md
+++ b/changelog/PA4Raz-aRnGPqX5kmBE2PA.md
@@ -1,0 +1,7 @@
+audience: worker-deployers
+level: patch
+---
+
+Improves Azure resource deprovisioning by skipping checks on already deleted resources.
+Previously implemented logic was flawed in a way that same resources would be queried over and over.
+Which led to an increased number of cloud api calls and was likely causing some minor delays per each worker being deprovisioned


### PR DESCRIPTION
When VM was being deprovisioned it would check resource by resource and delete if necessary: vm -> nic -> ip -> disks. Each of them would first query api to see if resource is 404 to know for sure it was gone. But checks were insufficient in place to prevent those resources from being queried over and over. So vm would be checked always, nic x-1 times, ip x-2 times, etc.
By adding clear indication "deleted: true" we can skip consequent checks and avoid calling azure api
