### PR TITLE
fix(ci): use updated golang download link

### DIFF
--- a/changelog/RQUmesrsQx20gD9iVQdIGQ.md
+++ b/changelog/RQUmesrsQx20gD9iVQdIGQ.md
@@ -1,0 +1,3 @@
+audience: general
+level: silent
+---

--- a/taskcluster/kinds/generic-worker/kind.yml
+++ b/taskcluster/kinds/generic-worker/kind.yml
@@ -30,7 +30,7 @@ tasks:
     worker:
       mounts:
         - content:
-            url: 'https://storage.googleapis.com/golang/{go_version}.windows-amd64.zip'
+            url: 'https://go.dev/dl/{go_version}.windows-amd64.zip'
           directory: '{go_version}'
           format: zip
         - content:
@@ -70,7 +70,7 @@ tasks:
       max-run-time: 300
       mounts:
         - content:
-            url: 'https://storage.googleapis.com/golang/{go_version}.linux-amd64.tar.gz'
+            url: 'https://go.dev/dl/{go_version}.linux-amd64.tar.gz'
           directory: '{go_version}'
           format: tar.gz
     run:
@@ -113,7 +113,7 @@ tasks:
           type: file
       mounts:
         - content:
-            url: 'https://storage.googleapis.com/golang/{go_version}.linux-amd64.tar.gz'
+            url: 'https://go.dev/dl/{go_version}.linux-amd64.tar.gz'
           directory: '{go_version}'
           format: tar.gz
         - content:
@@ -193,7 +193,7 @@ tasks:
           type: file
       mounts:
         - content:
-            url: 'https://storage.googleapis.com/golang/{go_version}.linux-amd64.tar.gz'
+            url: 'https://go.dev/dl/{go_version}.linux-amd64.tar.gz'
           directory: '{go_version}'
           format: tar.gz
         - content:
@@ -217,7 +217,7 @@ tasks:
           type: file
       mounts:
         - content:
-            url: 'https://storage.googleapis.com/golang/{go_version}.darwin-arm64.tar.gz'
+            url: 'https://go.dev/dl/{go_version}.darwin-arm64.tar.gz'
           directory: '{go_version}'
           format: tar.gz
         - content:
@@ -241,7 +241,7 @@ tasks:
           type: file
       mounts:
         - content:
-            url: 'https://storage.googleapis.com/golang/{go_version}.windows-amd64.zip'
+            url: 'https://go.dev/dl/{go_version}.windows-amd64.zip'
           directory: '{go_version}'
           format: zip
         - content:

--- a/taskcluster/kinds/go/kind.yml
+++ b/taskcluster/kinds/go/kind.yml
@@ -38,7 +38,7 @@ task-defaults:
       - cache-name: checkouts
         directory: taskcluster
       - content:
-          url: 'https://storage.googleapis.com/golang/{go_version}.linux-amd64.tar.gz'
+          url: 'https://go.dev/dl/{go_version}.linux-amd64.tar.gz'
         directory: '{go_version}'
         format: tar.gz
       - content:

--- a/taskcluster/kinds/release/kind.yml
+++ b/taskcluster/kinds/release/kind.yml
@@ -19,7 +19,7 @@ task-defaults:
         type: directory
     mounts:
       - content:
-          url: 'https://storage.googleapis.com/golang/{go_version}.linux-amd64.tar.gz'
+          url: 'https://go.dev/dl/{go_version}.linux-amd64.tar.gz'
         directory: 'go'
         format: tar.gz
       - content:

--- a/workers/generic-worker/payload_test.go
+++ b/workers/generic-worker/payload_test.go
@@ -299,7 +299,7 @@ func TestInvalidPayload(t *testing.T) {
     {
       "content": {
         "sha356": "9ded97d830bef3734ea6de70df0159656d6a63e01484175b34d72b8db326bda0",
-        "url": "https://storage.googleapis.com/golang/go1.10.8.windows-386.zip"
+        "url": "https://go.dev/dl/go1.10.8.windows-386.zip"
       },
       "directory": "go1.10.8",
       "format": "zip"


### PR DESCRIPTION
Noticed all the CI checks that download go were failing on `main`.