### PR TITLE
fix(generic-worker): don't limit size of message between agent and daemon

### DIFF
--- a/changelog/issue-8025.md
+++ b/changelog/issue-8025.md
@@ -1,0 +1,5 @@
+audience: worker-deployers
+level: patch
+reference: issue 8025
+---
+Generic Worker (macOS): updates the socket-based communication between the LaunchAgent and LaunchDaemon to handle any size of payload.

--- a/workers/generic-worker/process/multiuser_darwin.go
+++ b/workers/generic-worker/process/multiuser_darwin.go
@@ -19,6 +19,12 @@ import (
 	"golang.org/x/sys/unix"
 )
 
+const (
+	// HandshakeAckByte is the ACK byte ('K') sent by the agent to the daemon
+	// in Phase 2 of the three-phase protocol to signal handshake consumption.
+	HandshakeAckByte = 'K'
+)
+
 type (
 	Command struct {
 		// ResourceMonitor is a function that monitors the system's resource usage.
@@ -50,6 +56,13 @@ type (
 		Setctty bool     `json:"setctty"`
 		Setpgid bool     `json:"setpgid"`
 		Setsid  bool     `json:"setsid"`
+	}
+
+	// FDHandshake is sent via WriteMsgUnix with file descriptors (SCM_RIGHTS).
+	// The agent responds with an ACK byte, then the daemon sends the full CommandRequest.
+	FDHandshake struct {
+		NumFDs      int `json:"num_fds"`
+		PayloadSize int `json:"payload_size"`
 	}
 )
 
@@ -191,19 +204,54 @@ func (c *Command) Start() error {
 
 	log.Printf("FDs: %#v", fds)
 
-	// Send FDs to the agent using SCM_RIGHTS
-	rights := unix.UnixRights(fds...)
-
+	// Marshal the full command request
 	payload, err := json.Marshal(request)
 	if err != nil {
 		return fmt.Errorf("failed to marshal JSON: %w", err)
 	}
 
-	log.Printf("Request to be sent from daemon: %v", string(payload))
+	log.Printf("Request to be sent from daemon (%d bytes): %v", len(payload), string(payload))
 
-	_, _, err = conn.(*net.UnixConn).WriteMsgUnix(payload, rights, nil)
+	// Three-phase protocol with ACK synchronization:
+	// Phase 1: Send file descriptors + handshake via WriteMsgUnix (SCM_RIGHTS)
+	// Phase 2: Wait for agent ACK (ensures agent has consumed the handshake)
+	// Phase 3: Send full command request via WriteFrame (no size limit)
+
+	handshake := FDHandshake{
+		NumFDs:      len(fds),
+		PayloadSize: len(payload),
+	}
+
+	handshakeJSON, err := json.Marshal(handshake)
 	if err != nil {
-		return fmt.Errorf("failed to write to unix socket: %w", err)
+		return fmt.Errorf("failed to marshal handshake: %w", err)
+	}
+
+	// Phase 1: Send FDs and handshake
+	rights := unix.UnixRights(fds...)
+	_, _, err = conn.(*net.UnixConn).WriteMsgUnix(handshakeJSON, rights, nil)
+	if err != nil {
+		return fmt.Errorf("failed to write handshake to unix socket: %w", err)
+	}
+
+	log.Printf("Sent handshake: %d FDs, %d byte payload", len(fds), len(payload))
+
+	// Phase 2: Wait for ACK from agent (single byte confirming handshake received)
+	ackBuf := make([]byte, 1)
+	_, err = io.ReadFull(conn, ackBuf)
+	if err != nil {
+		return fmt.Errorf("failed to read handshake ACK: %w", err)
+	}
+	if ackBuf[0] != HandshakeAckByte {
+		return fmt.Errorf("invalid ACK byte: expected %#x, got %#x", HandshakeAckByte, ackBuf[0])
+	}
+
+	log.Print("Received ACK, sending payload")
+
+	// Phase 3: Send full command request using framed protocol
+	err = WriteFrame(conn, payload)
+	if err != nil {
+		return fmt.Errorf("failed to write command request frame: %w", err)
 	}
 
 	// Only start io/copy go routines after writing FDs to the socket, to avoid


### PR DESCRIPTION
Fixes #8025.

>Generic Worker (macOS): updates the socket-based communication between the LaunchAgent and LaunchDaemon to handle any size of payload.