### PR TITLE
fix(release): publish python client on release

### DIFF
--- a/changelog/FCCUi4X8QVusMgZ2nxkcdw.md
+++ b/changelog/FCCUi4X8QVusMgZ2nxkcdw.md
@@ -1,0 +1,4 @@
+audience: developers
+level: patch
+---
+Client (python): fixes release of client.

--- a/clients/client-py/release.sh
+++ b/clients/client-py/release.sh
@@ -18,10 +18,8 @@ cd "$(dirname "${0}")"
 set -e
 
 # begin making the distribution
-rm -f dist/*
+rm -rf dist/
 rm -rf build/
-
-ls -al dist
 
 # Build and publish using uv
 # Install uv if not already available


### PR DESCRIPTION
Release https://docs.taskcluster.net/docs/changelog?version=v91.0.2 did not successfully publish the client to pypi.

>Client (python): fixes release of client.