### PR TITLE
feat(k8s): Worker-scanner azure was not exposing metrics

### DIFF
--- a/changelog/eXJLGJ44SGi410uswjkKRg.md
+++ b/changelog/eXJLGJ44SGi410uswjkKRg.md
@@ -1,0 +1,5 @@
+audience: deployers
+level: patch
+---
+
+Worker-scanner azure now exposes metrics to prometheus too.

--- a/docker/prometheus.yml
+++ b/docker/prometheus.yml
@@ -18,3 +18,4 @@ scrape_configs:
           - worker-manager-web:9100
           - worker-manager-background-provisioner:9100
           - worker-manager-background-workerscanner:9100
+          - worker-manager-background-workerscanner-azure:9100

--- a/infrastructure/k8s/templates/taskcluster-worker-manager-deployment-workerscanner-azure.yaml
+++ b/infrastructure/k8s/templates/taskcluster-worker-manager-deployment-workerscanner-azure.yaml
@@ -15,7 +15,13 @@ spec:
     metadata:
       annotations:
         checksum/secret: '{{ include (print $.Template.BasePath "/taskcluster-worker-manager-secret.yaml") . | sha256sum }}'
-      labels: *ref_0
+      labels:
+        app.kubernetes.io/name: taskcluster-worker-manager
+        app.kubernetes.io/instance: '{{ .Release.Name }}'
+        app.kubernetes.io/component: taskcluster-worker-manager-workerscanner-azure
+        app.kubernetes.io/part-of: taskcluster
+        prometheus.io/scrape: 'true'
+        prometheus.io/port: '9100'
     spec:
       serviceAccountName: taskcluster-worker-manager
       imagePullSecrets: {{ if .Values.imagePullSecret }}{{ toJson (list (dict "name" .Values.imagePullSecret)) }}{{ else }}[]{{ end }}
@@ -42,7 +48,10 @@ spec:
                 name: taskcluster-worker-manager
             - configMapRef:
                 name: taskcluster-worker-manager
-          ports: []
+          ports:
+            - name: prometheus
+              containerPort: 9100
+              protocol: TCP
           livenessProbe:
             exec:
               command:

--- a/infrastructure/k8s/values.yaml
+++ b/infrastructure/k8s/values.yaml
@@ -277,6 +277,7 @@ worker_manager:
       replicas: 1
       cpu: 200m
       memory: 200Mi
+      metrics: true
     expire_workers:
       cpu: 200m
       memory: 200Mi

--- a/services/worker-manager/procs.yml
+++ b/services/worker-manager/procs.yml
@@ -16,6 +16,7 @@ workerscanner-azure:
   type: background
   subType: 'iterate'
   command: node services/worker-manager/src/main.js workerScannerAzure
+  metrics: true
 expire-workers:
   type: cron
   schedule: '30 1 * * *'

--- a/ui/docs/manual/deploying/monitoring.mdx
+++ b/ui/docs/manual/deploying/monitoring.mdx
@@ -98,20 +98,21 @@ If your Kubernetes cluster does not support the `monitoring.googleapis.com/v1/Po
 Below is the list of services and jobs that expose metrics:
 
 <!-- BEGIN METRICS TABLE -->
-| Service        | Name          | Type       | Reference                                                |
-| -------------- | ------------- | ---------- | -------------------------------------------------------- |
-| auth           | web           | web        | [reference](/docs/reference/platform/auth/metrics)       |
-| github         | web           | web        | [reference](/docs/reference/integrations/github/metrics) |
-| hooks          | web           | web        | [reference](/docs/reference/core/hooks/metrics)          |
-| index          | web           | web        | [reference](/docs/reference/core/index/metrics)          |
-| notify         | web           | web        | [reference](/docs/reference/core/notify/metrics)         |
-| object         | web           | web        | [reference](/docs/reference/platform/object/metrics)     |
-| purge-cache    | web           | web        | [reference](/docs/reference/core/purge-cache/metrics)    |
-| queue          | web           | web        | [reference](/docs/reference/platform/queue/metrics)      |
-| queue          | workerMetrics | background | [reference](/docs/reference/platform/queue/metrics)      |
-| secrets        | web           | web        | [reference](/docs/reference/core/secrets/metrics)        |
-| web-server     | web           | web        | [reference](/docs/reference/core/web-server/metrics)     |
-| worker-manager | web           | web        | [reference](/docs/reference/core/worker-manager/metrics) |
-| worker-manager | provisioner   | background | [reference](/docs/reference/core/worker-manager/metrics) |
-| worker-manager | workerscanner | background | [reference](/docs/reference/core/worker-manager/metrics) |
+| Service        | Name                | Type       | Reference                                                |
+| -------------- | ------------------- | ---------- | -------------------------------------------------------- |
+| auth           | web                 | web        | [reference](/docs/reference/platform/auth/metrics)       |
+| github         | web                 | web        | [reference](/docs/reference/integrations/github/metrics) |
+| hooks          | web                 | web        | [reference](/docs/reference/core/hooks/metrics)          |
+| index          | web                 | web        | [reference](/docs/reference/core/index/metrics)          |
+| notify         | web                 | web        | [reference](/docs/reference/core/notify/metrics)         |
+| object         | web                 | web        | [reference](/docs/reference/platform/object/metrics)     |
+| purge-cache    | web                 | web        | [reference](/docs/reference/core/purge-cache/metrics)    |
+| queue          | web                 | web        | [reference](/docs/reference/platform/queue/metrics)      |
+| queue          | workerMetrics       | background | [reference](/docs/reference/platform/queue/metrics)      |
+| secrets        | web                 | web        | [reference](/docs/reference/core/secrets/metrics)        |
+| web-server     | web                 | web        | [reference](/docs/reference/core/web-server/metrics)     |
+| worker-manager | web                 | web        | [reference](/docs/reference/core/worker-manager/metrics) |
+| worker-manager | provisioner         | background | [reference](/docs/reference/core/worker-manager/metrics) |
+| worker-manager | workerscanner       | background | [reference](/docs/reference/core/worker-manager/metrics) |
+| worker-manager | workerscanner-azure | background | [reference](/docs/reference/core/worker-manager/metrics) |
 <!-- END METRICS TABLE -->


### PR DESCRIPTION
I noticed that grafana is not showing workers scanned for azure provider and of course I forgot to enable metrics server for this service
