### PR TITLE
fix(generic-worker): properly log out windows user syscall token

### DIFF
--- a/changelog/TokxTqgLQLagmyyHkT1xTw.md
+++ b/changelog/TokxTqgLQLagmyyHkT1xTw.md
@@ -1,0 +1,4 @@
+audience: worker-deployers
+level: patch
+---
+Generic Worker (Windows): properly logs out `win32.LoadUserProfile()` errors with the user's `syscall.Token` in hex format instead of a quoted string.

--- a/workers/generic-worker/process/logininfo_multiuser_windows.go
+++ b/workers/generic-worker/process/logininfo_multiuser_windows.go
@@ -61,7 +61,7 @@ func loadProfile(user syscall.Token, username string) (syscall.Handle, error) {
 	}
 	err = win32.LoadUserProfile(user, &pinfo)
 	if err != nil {
-		return syscall.InvalidHandle, fmt.Errorf("LoadUserProfile(%q, %+v): %v", user, &pinfo, err)
+		return syscall.InvalidHandle, fmt.Errorf("LoadUserProfile(%#x, %+v): %v", user, &pinfo, err)
 	}
 	return pinfo.Profile, nil
 }


### PR DESCRIPTION
While looking into https://github.com/taskcluster/taskcluster/issues/8083, we noticed the user token was improperly logged out as a quoted string instead of a hexadecimal value.

>Generic Worker (Windows): properly logs out `win32.LoadUserProfile()` errors with the user's `syscall.Token` in hex format instead of a quoted string.