### PR TITLE
feat(w-m): Handling deployment deletion gracefully

### DIFF
--- a/changelog/issue-8059.md
+++ b/changelog/issue-8059.md
@@ -1,0 +1,6 @@
+audience: deployers
+level: patch
+reference: issue 8059
+---
+
+Azure provider improves handling of ARM template deployments removal to avoid some conflicts that may happen when resources are being removed too fast.


### PR DESCRIPTION
When worker shuts down during deployment, we would hit 409 conflict while removing the deployment (unable to edit or replace deployment conflict)
We check if deployment is still active at this point and don't report errors on 409 conflict

Fixes #8059
