### PR TITLE
fix(release): update `uv.lock` file on release

### DIFF
--- a/changelog/issue-8061.md
+++ b/changelog/issue-8061.md
@@ -1,0 +1,5 @@
+audience: general
+level: patch
+reference: issue 8061
+---
+Updates the python client's `uv.lock` file to properly bump the `taskcluster` version on `yarn release`.

--- a/clients/client-py/uv.lock
+++ b/clients/client-py/uv.lock
@@ -1267,7 +1267,7 @@ wheels = [
 
 [[package]]
 name = "taskcluster"
-version = "91.1.2"
+version = "92.0.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
Fixes #8061.

>Updates the python client's `uv.lock` file to properly bump the `taskcluster` version on `yarn release`.