### PR TITLE
feat(docs): add client-side multi-language API examples

### DIFF
--- a/changelog/issue-8049.md
+++ b/changelog/issue-8049.md
@@ -1,0 +1,23 @@
+audience: general
+level: minor
+reference: issue 8049
+---
+
+#### API Documentation Now Includes Code Examples
+
+The API reference documentation now includes code examples for every endpoint in multiple languages:
+- **curl** - Raw HTTP requests
+- **Go** - Go client library
+- **Python** - Synchronous and asynchronous client libraries
+- **Node.js** - Node.js client library
+- **Web** - Browser/web client library
+- **Rust** - Rust client library
+- **Shell** - Taskcluster CLI (taskcluster-cli)
+
+Each example demonstrates how to:
+- Set up the client with authentication (both explicit credentials and environment variables)
+- Call the API endpoint with proper parameters
+- Handle errors appropriately
+- Process the response
+
+Examples are generated dynamically in the browser from API metadata, keeping the documentation lean while providing comprehensive, up-to-date code samples. Examples include syntax highlighting and can be copied to clipboard directly from the documentation.

--- a/ui/src/components/CodeExample/index.jsx
+++ b/ui/src/components/CodeExample/index.jsx
@@ -1,0 +1,87 @@
+import React, { Component } from 'react';
+import { string } from 'prop-types';
+import { withStyles } from '@material-ui/core/styles';
+import { CopyToClipboard } from 'react-copy-to-clipboard';
+import IconButton from '@material-ui/core/IconButton';
+import Tooltip from '@material-ui/core/Tooltip';
+import ContentCopyIcon from '@material-ui/icons/FileCopy';
+import CheckIcon from '@material-ui/icons/Check';
+import Code from '../Code';
+
+@withStyles(theme => ({
+  container: {
+    position: 'relative',
+    marginBottom: theme.spacing(2),
+  },
+  copyButton: {
+    position: 'absolute',
+    top: theme.spacing(1),
+    right: theme.spacing(1),
+    color: theme.palette.common.white,
+    backgroundColor: 'rgba(0, 0, 0, 0.3)',
+    '&:hover': {
+      backgroundColor: 'rgba(0, 0, 0, 0.5)',
+    },
+  },
+  code: {
+    borderRadius: 4,
+    fontSize: '0.875rem',
+    '& pre': {
+      margin: 0,
+      padding: `${theme.spacing(2)}px !important`,
+      paddingRight: `${theme.spacing(6)}px !important`, // Make room for copy button
+    },
+  },
+}))
+export default class CodeExample extends Component {
+  static propTypes = {
+    /** The code example to display */
+    code: string.isRequired,
+    /** Programming language for syntax highlighting */
+    language: string.isRequired,
+  };
+
+  state = {
+    copied: false,
+  };
+
+  handleCopy = () => {
+    this.setState({ copied: true });
+    setTimeout(() => this.setState({ copied: false }), 2000);
+  };
+
+  render() {
+    const { code, language, classes } = this.props;
+    const { copied } = this.state;
+    // Map our language names to highlight.js language names
+    const languageMap = {
+      curl: 'bash',
+      go: 'go',
+      python: 'python',
+      pythonAsync: 'python',
+      node: 'javascript',
+      web: 'javascript',
+      rust: 'rust',
+      shell: 'bash',
+    };
+    const hlLanguage = languageMap[language] || language;
+
+    return (
+      <div className={classes.container}>
+        <CopyToClipboard text={code} onCopy={this.handleCopy}>
+          <Tooltip title={copied ? 'Copied!' : 'Copy to clipboard'}>
+            <IconButton
+              className={classes.copyButton}
+              size="small"
+              aria-label="copy code to clipboard">
+              {copied ? <CheckIcon /> : <ContentCopyIcon />}
+            </IconButton>
+          </Tooltip>
+        </CopyToClipboard>
+        <Code language={hlLanguage} className={classes.code}>
+          {code}
+        </Code>
+      </div>
+    );
+  }
+}

--- a/ui/src/utils/api-examples/curl.js
+++ b/ui/src/utils/api-examples/curl.js
@@ -1,0 +1,96 @@
+/**
+ * Generate curl command examples for API endpoints
+ */
+
+import {
+  PLACEHOLDERS,
+  getPlaceholderValue,
+  requiresAuth,
+  formatPayloadJson,
+} from './helpers';
+
+/**
+ * Generate a curl example for an API endpoint
+ *
+ * @param {string} serviceName - Service name (e.g., 'queue')
+ * @param {string} apiVersion - API version (e.g., 'v1')
+ * @param {object} entry - API entry metadata
+ * @param {object} payloadExample - Example payload object (optional)
+ * @returns {string} curl command example
+ */
+export default function generateCurlExample(
+  serviceName,
+  apiVersion,
+  entry,
+  payloadExample = null
+) {
+  const { method, route, args, query, input } = entry;
+  // Build the URL
+  let url = `${PLACEHOLDERS.rootUrl}/api/${serviceName}/${apiVersion}${route}`;
+
+  // Replace path parameters
+  args.forEach(arg => {
+    const placeholder = getPlaceholderValue(arg);
+
+    url = url.replace(`<${arg}>`, placeholder);
+  });
+
+  // Add query parameters if present
+  if (query && query.length > 0) {
+    const queryParams = query.map(q => `${q}=<${q}>`).join('&');
+
+    url += `?${queryParams}`;
+  }
+
+  // Build the command
+  let example = `# ${entry.title}\n`;
+
+  if (requiresAuth(entry)) {
+    example += `# This endpoint requires authentication\n`;
+    example += `# Set your credentials in environment variables:\n`;
+    example += `#   TASKCLUSTER_CLIENT_ID=your-client-id\n`;
+    example += `#   TASKCLUSTER_ACCESS_TOKEN=your-access-token\n\n`;
+  }
+
+  let command = `curl`;
+
+  // Add method if not GET
+  if (method.toUpperCase() !== 'GET') {
+    command += ` -X ${method.toUpperCase()}`;
+  }
+
+  // Add headers
+  if (requiresAuth(entry)) {
+    command += ` \\\n  -H "Authorization: Bearer \${TASKCLUSTER_ACCESS_TOKEN}"`;
+  }
+
+  // Add request body for methods that typically have one
+  if (input) {
+    command += ` \\\n  -H "Content-Type: application/json"`;
+
+    let payloadData;
+
+    if (payloadExample) {
+      const jsonPayload = formatPayloadJson(payloadExample, 2);
+
+      payloadData = ` \\\n  -d '${jsonPayload}'`;
+    } else {
+      payloadData = ` \\\n  -d '{\n    "key": "value"\n    # See ${serviceName}/${input} schema for required fields\n  }'`;
+    }
+
+    command += payloadData;
+  }
+
+  // Add the URL
+  command += ` \\\n  "${url}"`;
+
+  example += command;
+
+  // Add note about response
+  if (entry.output && entry.output !== 'blob') {
+    example += `\n\n# Response will be JSON. To pretty-print, pipe through jq:\n`;
+    example += `# ${command.split('\n')[0]} ... | jq .`;
+  }
+
+  return example;
+}

--- a/ui/src/utils/api-examples/go.js
+++ b/ui/src/utils/api-examples/go.js
@@ -1,0 +1,162 @@
+/**
+ * Generate Go client library examples for API endpoints
+ */
+
+import {
+  PLACEHOLDERS,
+  getPlaceholderValue,
+  requiresAuth,
+  capitalize,
+  formatPayloadJson,
+} from './helpers';
+
+/**
+ * Convert hyphenated service name to valid Go identifier
+ * @param {string} name - Service name (e.g., 'worker-manager')
+ * @returns {string} Valid Go identifier (e.g., 'workerManager')
+ */
+function formatGoIdentifier(name) {
+  if (!name.includes('-')) {
+    return name;
+  }
+
+  const parts = name.split('-');
+
+  return (
+    parts[0] +
+    parts
+      .slice(1)
+      .map(capitalize)
+      .join('')
+  );
+}
+
+/**
+ * Generate a Go example for an API endpoint
+ *
+ * @param {string} serviceName - Service name (e.g., 'queue')
+ * @param {string} apiVersion - API version (e.g., 'v1')
+ * @param {object} entry - API entry metadata
+ * @param {string} version - Taskcluster version (default: '93')
+ * @param {object} payloadExample - Example payload object (optional)
+ * @returns {string} Go code example
+ */
+export default function generateGoExample(
+  serviceName,
+  apiVersion,
+  entry,
+  version = '93',
+  payloadExample = null
+) {
+  const methodName = capitalize(entry.name);
+  const varName = formatGoIdentifier(serviceName);
+  const packageName = `tc${serviceName.toLowerCase().replace(/-/g, '')}`;
+  const params = entry.args.map(arg => `"${getPlaceholderValue(arg)}"`);
+  // Build imports
+  const imports = ['fmt', 'log'];
+
+  if (requiresAuth(entry)) {
+    imports.push('os');
+  }
+
+  if (entry.input) {
+    imports.push('encoding/json');
+  }
+
+  const importStatements = imports.map(imp => `	"${imp}"`).join('\n');
+  // Build client initialization
+  let clientInit;
+
+  if (requiresAuth(entry)) {
+    clientInit = `// Option 1: Explicit credentials
+	creds := &tcclient.Credentials{
+		ClientID:    "${PLACEHOLDERS.clientId}",
+		AccessToken: "${PLACEHOLDERS.accessToken}",
+	}
+	${varName} := ${packageName}.New(creds, "${PLACEHOLDERS.rootUrl}")
+
+	// Option 2: Credentials from environment variables
+	// Requires: TASKCLUSTER_ROOT_URL, TASKCLUSTER_CLIENT_ID, TASKCLUSTER_ACCESS_TOKEN
+	// creds := &tcclient.Credentials{
+	//     ClientID:    os.Getenv("TASKCLUSTER_CLIENT_ID"),
+	//     AccessToken: os.Getenv("TASKCLUSTER_ACCESS_TOKEN"),
+	// }
+	// ${varName} := ${packageName}.New(creds, os.Getenv("TASKCLUSTER_ROOT_URL"))`;
+  } else {
+    clientInit = `// No authentication required for this endpoint
+	${varName} := ${packageName}.New(nil, "${PLACEHOLDERS.rootUrl}")`;
+  }
+
+  // Build API call
+  let apiCall;
+
+  if (entry.input) {
+    let payloadCode;
+
+    if (payloadExample) {
+      // Use actual payload example with JSON unmarshaling
+      const jsonPayload = formatPayloadJson(payloadExample, 2);
+
+      payloadCode = `// Create request payload - see schema at:
+	// ${PLACEHOLDERS.rootUrl}/schemas/${serviceName}/${entry.input}
+	payloadJSON := []byte(\`${jsonPayload}\`)
+
+	payload := &${packageName}.${methodName}Request{}
+	if err := json.Unmarshal(payloadJSON, payload); err != nil {
+		log.Fatalf("Failed to parse payload: %v", err)
+	}`;
+    } else {
+      payloadCode = `// Create request payload
+	// See schema at: ${PLACEHOLDERS.rootUrl}/schemas/${serviceName}/${entry.input}
+	payload := &${packageName}.${methodName}Request{
+		// Fill in required fields according to the schema
+	}`;
+    }
+
+    apiCall = `${payloadCode}
+
+	// Call the API method
+	result, err := ${varName}.${methodName}(${params.join(', ')}, payload)`;
+  } else {
+    apiCall = `// Call the API method
+	result, err := ${varName}.${methodName}(${params.join(', ')})`;
+  }
+
+  // Build response handling
+  let responseHandling;
+
+  if (entry.output && entry.output !== 'blob') {
+    responseHandling = `// Handle successful response
+	fmt.Printf("Success: %+v\n", result)`;
+  } else if (entry.output === 'blob') {
+    responseHandling = `// Handle blob response
+	fmt.Printf("Downloaded %d bytes\n", len(result))`;
+  } else {
+    responseHandling = `// Method completed successfully
+	fmt.Println("Success")`;
+  }
+
+  // Assemble the complete example
+  const example = `package main
+
+import (
+${importStatements}
+
+	tcclient "github.com/taskcluster/taskcluster/v${version}/clients/client-go"
+	"github.com/taskcluster/taskcluster/v${version}/clients/client-go/${packageName}"
+)
+
+func main() {
+	${clientInit}
+
+	${apiCall}
+	if err != nil {
+		// Handle error
+		log.Fatalf("API call failed: %v", err)
+	}
+
+	${responseHandling}
+}`;
+
+  return example;
+}

--- a/ui/src/utils/api-examples/helpers.js
+++ b/ui/src/utils/api-examples/helpers.js
@@ -1,0 +1,164 @@
+/**
+ * Shared helper functions and constants for API example generators
+ */
+
+/**
+ * Standard placeholder values for consistent examples
+ */
+export const PLACEHOLDERS = {
+  rootUrl: 'https://tc.example.com',
+  clientId: 'your-client-id',
+  accessToken: 'your-access-token',
+  taskId: 'dSlITZ4yQgmvxxAi4A8fHQ',
+  taskGroupId: 'dSlITZ4yQgmvxxAi4A8fHQ',
+  runId: '0',
+  workerGroup: 'my-worker-group',
+  workerId: 'my-worker',
+  workerPoolId: 'my-worker-pool',
+  workerType: 'my-worker-type',
+  provisionerId: 'my-provisioner',
+  artifactName: 'public/build/target.tar.gz',
+  hookGroupId: 'project-taskcluster',
+  hookId: 'smoketest',
+  namespace: 'garbage.test-artifacts',
+  cacheName: 'my-cache',
+  roleId: 'repo:github.com/taskcluster/*',
+  clientScopes: ['queue:create-task:*'],
+  secretName: 'project/taskcluster/test',
+  continuationToken: 'continuationToken',
+  limit: '1000',
+};
+
+/**
+ * Map parameter names to appropriate placeholder values
+ *
+ * @param {string} paramName - Parameter name from API definition
+ * @returns {string} Appropriate placeholder value
+ */
+export function getPlaceholderValue(paramName) {
+  // Direct mappings
+  if (PLACEHOLDERS[paramName]) {
+    return PLACEHOLDERS[paramName];
+  }
+
+  // Pattern-based mappings
+  if (paramName.endsWith('Id')) {
+    // For IDs that aren't in our mapping, use the standard taskId placeholder
+    return PLACEHOLDERS.taskId;
+  }
+
+  if (paramName.includes('Name')) {
+    return `my-${paramName.replace('Name', '').toLowerCase()}`;
+  }
+
+  if (paramName === 'limit') {
+    return '1000';
+  }
+
+  if (paramName === 'continuationToken') {
+    return 'continuationTokenHere';
+  }
+
+  // Default: use parameter name wrapped in angle brackets
+  return `<${paramName}>`;
+}
+
+/**
+ * Determine if an API call requires authentication based on scopes
+ *
+ * @param {object} entry - API entry metadata
+ * @returns {boolean} True if authentication is required
+ */
+export function requiresAuth(entry) {
+  // Check if scopes are required (scopes can be null, undefined, or absent)
+  return entry.scopes !== null && entry.scopes !== undefined;
+}
+
+/**
+ * Capitalize the first letter of a string
+ *
+ * @param {string} str - String to capitalize
+ * @returns {string} Capitalized string
+ */
+export function capitalize(str) {
+  if (!str) {
+    return '';
+  }
+
+  return str.charAt(0).toUpperCase() + str.slice(1);
+}
+
+/**
+ * Convert string to camelCase
+ *
+ * @param {string} str - String to convert
+ * @returns {string} camelCase string
+ */
+export function camelCase(str) {
+  if (!str) {
+    return '';
+  }
+
+  // Handle snake_case
+  if (str.includes('_')) {
+    return str
+      .split('_')
+      .map((part, i) => (i === 0 ? part : capitalize(part)))
+      .join('');
+  }
+
+  // Handle kebab-case
+  if (str.includes('-')) {
+    return str
+      .split('-')
+      .map((part, i) => (i === 0 ? part : capitalize(part)))
+      .join('');
+  }
+
+  // Already camelCase or single word
+  return str;
+}
+
+/**
+ * Generate a placeholder payload object with helpful comments
+ *
+ * @param {string} serviceName - Service name
+ * @param {string} schemaRef - Schema reference
+ * @param {string} rootUrl - Taskcluster root URL
+ * @returns {string} JSON string with placeholder payload
+ */
+export function generatePlaceholderPayload(
+  serviceName,
+  schemaRef,
+  rootUrl = PLACEHOLDERS.rootUrl
+) {
+  const schemaUrl = `${rootUrl}/schemas/${serviceName}/${schemaRef}`;
+
+  return `{
+  // TODO: Fill in request fields
+  // See schema: ${schemaUrl}
+  // Required fields depend on the schema - consult the documentation
+}`;
+}
+
+/**
+ * Format a payload object as JSON string with proper indentation
+ *
+ * @param {object} payload - Payload object to format
+ * @param {number} baseIndent - Base indentation level (number of spaces)
+ * @returns {string} Formatted JSON string
+ */
+export function formatPayloadJson(payload, baseIndent = 0) {
+  if (!payload || typeof payload !== 'object') {
+    return '{}';
+  }
+
+  const indentStr = ' '.repeat(baseIndent);
+  const json = JSON.stringify(payload, null, 2);
+  // Add base indentation to all lines except the first
+  const lines = json.split('\n');
+
+  return lines
+    .map((line, index) => (index === 0 ? line : indentStr + line))
+    .join('\n');
+}

--- a/ui/src/utils/api-examples/index.js
+++ b/ui/src/utils/api-examples/index.js
@@ -1,0 +1,203 @@
+/**
+ * Generate code examples for API endpoints (client-side)
+ *
+ * This module generates code examples dynamically in the browser from
+ * API metadata.
+ */
+
+import generateCurlExample from './curl';
+import generateGoExample from './go';
+import generateNodeExample from './node';
+import generatePythonExample from './python';
+import generateWebExample from './web';
+import generateRustExample from './rust';
+import generateShellExample from './shell';
+import generatePayloadExample from './payload-generator';
+
+// Default version - should match the current Taskcluster version
+const DEFAULT_VERSION = '93';
+// Import references for schema lookup
+let references = [];
+
+try {
+  // Try to import references - will be available after yarn generate
+  // eslint-disable-next-line global-require
+  references = require('../../../../generated/references.json');
+} catch (e) {
+  // References not available - examples will use placeholder payloads
+}
+
+/**
+ * Get schema content by ID
+ *
+ * @param {string} schemaId - Schema ID
+ * @returns {object|null} Schema content or null if not found
+ */
+function getSchemaContent(schemaId) {
+  if (!references || references.length === 0) {
+    return null;
+  }
+
+  const schema = references.find(({ content }) => content.$id === schemaId);
+
+  return schema ? schema.content : null;
+}
+
+/**
+ * Generate a single code example for a specific language
+ *
+ * @param {string} language - Language key (e.g., 'go', 'python', 'curl')
+ * @param {string} serviceName - Service name (e.g., 'queue', 'auth')
+ * @param {string} apiVersion - API version (e.g., 'v1')
+ * @param {object} entry - API entry metadata from references.json
+ * @param {string} version - Taskcluster version (e.g., '93')
+ * @returns {string|null} Code example or null if not found
+ */
+function generateSingleExample(
+  language,
+  serviceName,
+  apiVersion,
+  entry,
+  version = DEFAULT_VERSION
+) {
+  // Generate payload example if entry has input schema
+  let payloadExample = null;
+
+  if (entry.input) {
+    const schemaId = `/schemas/${serviceName}/${entry.input}`;
+    const schema = getSchemaContent(schemaId);
+
+    if (schema) {
+      // Pass all references for $ref resolution
+      payloadExample = generatePayloadExample(schema, references);
+    }
+  }
+
+  const generators = {
+    curl: () =>
+      generateCurlExample(serviceName, apiVersion, entry, payloadExample),
+    go: () =>
+      generateGoExample(
+        serviceName,
+        apiVersion,
+        entry,
+        version,
+        payloadExample
+      ),
+    python: () =>
+      generatePythonExample(
+        serviceName,
+        apiVersion,
+        entry,
+        false,
+        payloadExample
+      ),
+    pythonAsync: () =>
+      generatePythonExample(
+        serviceName,
+        apiVersion,
+        entry,
+        true,
+        payloadExample
+      ),
+    node: () =>
+      generateNodeExample(serviceName, apiVersion, entry, payloadExample),
+    web: () =>
+      generateWebExample(serviceName, apiVersion, entry, payloadExample),
+    rust: () =>
+      generateRustExample(serviceName, apiVersion, entry, payloadExample),
+    shell: () =>
+      generateShellExample(serviceName, apiVersion, entry, payloadExample),
+  };
+  const generator = generators[language];
+
+  if (!generator) {
+    throw new Error(`Unknown language requested: ${language}`);
+  }
+
+  return generator();
+}
+
+/**
+ * Generate code examples for an API entry
+ *
+ * @param {string} serviceName - Service name
+ * @param {string} apiVersion - API version (e.g., 'v1')
+ * @param {object} entry - API entry metadata
+ * @param {string} [language] - Optional language to generate
+ * @param {string} [version] - Optional Taskcluster version
+ * @returns {object|string|null} Examples object or string or null
+ */
+export default function generateExamples(
+  serviceName,
+  apiVersion,
+  entry,
+  language = null,
+  version = DEFAULT_VERSION
+) {
+  // Only generate examples for function entries (not exchanges, logs, etc.)
+  if (entry.type !== 'function') {
+    return null;
+  }
+
+  // If a specific language is requested, generate only that one (lazy loading)
+  if (language) {
+    return generateSingleExample(
+      language,
+      serviceName,
+      apiVersion,
+      entry,
+      version
+    );
+  }
+
+  // Generate all examples
+  const examples = {
+    curl: generateSingleExample(
+      'curl',
+      serviceName,
+      apiVersion,
+      entry,
+      version
+    ),
+    go: generateSingleExample('go', serviceName, apiVersion, entry, version),
+    python: generateSingleExample(
+      'python',
+      serviceName,
+      apiVersion,
+      entry,
+      version
+    ),
+    pythonAsync: generateSingleExample(
+      'pythonAsync',
+      serviceName,
+      apiVersion,
+      entry,
+      version
+    ),
+    node: generateSingleExample(
+      'node',
+      serviceName,
+      apiVersion,
+      entry,
+      version
+    ),
+    web: generateSingleExample('web', serviceName, apiVersion, entry, version),
+    rust: generateSingleExample(
+      'rust',
+      serviceName,
+      apiVersion,
+      entry,
+      version
+    ),
+    shell: generateSingleExample(
+      'shell',
+      serviceName,
+      apiVersion,
+      entry,
+      version
+    ),
+  };
+
+  return examples;
+}

--- a/ui/src/utils/api-examples/node.js
+++ b/ui/src/utils/api-examples/node.js
@@ -1,0 +1,127 @@
+/**
+ * Generate Node.js client library examples for API endpoints
+ */
+
+import {
+  PLACEHOLDERS,
+  getPlaceholderValue,
+  requiresAuth,
+  capitalize,
+  formatPayloadJson,
+} from './helpers';
+
+/**
+ * Generate a Node.js example for an API endpoint
+ *
+ * @param {string} serviceName - Service name (e.g., 'queue')
+ * @param {string} apiVersion - API version (e.g., 'v1')
+ * @param {object} entry - API entry metadata
+ * @param {object} payloadExample - Example payload object (optional)
+ * @returns {string} Node.js code example
+ */
+export default function generateNodeExample(
+  serviceName,
+  apiVersion,
+  entry,
+  payloadExample = null
+) {
+  const className = capitalize(serviceName);
+  const params = entry.args.map(arg => `'${getPlaceholderValue(arg)}'`);
+  // Build client initialization
+  let clientInit;
+
+  if (requiresAuth(entry)) {
+    clientInit = `// Option 1: Explicit credentials
+  const ${serviceName} = new taskcluster.${className}({
+    rootUrl: '${PLACEHOLDERS.rootUrl}',
+    credentials: {
+      clientId: '${PLACEHOLDERS.clientId}',
+      accessToken: '${PLACEHOLDERS.accessToken}'
+    }
+  });
+
+  // Option 2: Credentials from environment variables
+  // Requires: TASKCLUSTER_ROOT_URL, TASKCLUSTER_CLIENT_ID, TASKCLUSTER_ACCESS_TOKEN
+  // const ${serviceName} = new taskcluster.${className}({
+  //   ...taskcluster.fromEnvVars(),
+  // });`;
+  } else {
+    clientInit = `// No authentication required for this endpoint
+  const ${serviceName} = new taskcluster.${className}({
+    rootUrl: '${PLACEHOLDERS.rootUrl}'
+  });`;
+  }
+
+  // Build API call
+  let apiCall;
+
+  if (entry.input) {
+    let payloadCode;
+
+    if (payloadExample) {
+      // Use actual payload example
+      const jsonPayload = formatPayloadJson(payloadExample, 4);
+
+      payloadCode = `// Request payload - see schema at:
+    // ${PLACEHOLDERS.rootUrl}/schemas/${serviceName}/${entry.input}
+    const payload = ${jsonPayload};`;
+    } else {
+      payloadCode = `// Request payload
+    // See schema at: ${PLACEHOLDERS.rootUrl}/schemas/${serviceName}/${entry.input}
+    const payload = {
+      // Fill in required fields according to the schema
+    };`;
+    }
+
+    apiCall = `${payloadCode}
+
+    // Call the API method
+    const result = await ${serviceName}.${entry.name}(${params.join(
+      ', '
+    )}, payload);`;
+  } else {
+    apiCall = `// Call the API method
+    const result = await ${serviceName}.${entry.name}(${params.join(', ')});`;
+  }
+
+  // Build response handling
+  let responseHandling;
+
+  if (entry.output && entry.output !== 'blob') {
+    responseHandling = `console.log('Success:', result);
+    return result;`;
+  } else if (entry.output === 'blob') {
+    responseHandling = `console.log(\`Downloaded \${result.length} bytes\`);
+    return result;`;
+  } else {
+    responseHandling = `console.log('Success');`;
+  }
+
+  // Assemble the complete example
+  const example = `const taskcluster = require('@taskcluster/client');
+
+async function callApi() {
+  ${clientInit}
+
+  try {
+    ${apiCall}
+    ${responseHandling}
+  } catch (err) {
+    // Handle Taskcluster API errors
+    if (err.statusCode) {
+      console.error(\`API Error \${err.statusCode}: \${err.message}\`);
+    } else {
+      console.error('Unexpected error:', err);
+    }
+    throw err;
+  }
+}
+
+// Run the function
+callApi().catch(err => {
+  console.error('Failed:', err);
+  process.exit(1);
+});`;
+
+  return example;
+}

--- a/ui/src/utils/api-examples/payload-generator.js
+++ b/ui/src/utils/api-examples/payload-generator.js
@@ -1,0 +1,680 @@
+/**
+ * Generate example payloads from JSON schemas
+ *
+ * This module creates example JSON payloads based on JSON Schema definitions,
+ * providing developers with concrete starting points for API calls.
+ */
+
+import { PLACEHOLDERS, getPlaceholderValue } from './helpers';
+
+/**
+ * Get contextual placeholder value for known property names
+ *
+ * @param {string} propertyName - Property name
+ * @param {string} type - JSON Schema type
+ * @returns {*|null} Placeholder value or null if not found
+ */
+function getContextualPlaceholder(propertyName, type) {
+  // Use existing placeholder system for known names
+  const placeholder = getPlaceholderValue(propertyName);
+
+  // If meaningful value (not wrapped in <>), use it
+  if (placeholder && !placeholder.startsWith('<')) {
+    return placeholder;
+  }
+
+  // Additional context-aware mappings
+  const lowerName = propertyName.toLowerCase();
+
+  // Taskcluster-specific ID patterns (only for string types)
+  if (type === 'string' && lowerName.includes('taskid')) {
+    return PLACEHOLDERS.taskId;
+  }
+
+  if (
+    type === 'string' &&
+    (lowerName.includes('taskgroupid') || lowerName === 'taskgroupid')
+  ) {
+    return PLACEHOLDERS.taskGroupId;
+  }
+
+  if (type === 'string' && lowerName.includes('workerid')) {
+    return PLACEHOLDERS.workerId;
+  }
+
+  if (type === 'string' && lowerName.includes('workerpoolid')) {
+    return PLACEHOLDERS.workerPoolId;
+  }
+
+  if (type === 'string' && lowerName.includes('provisionid')) {
+    return PLACEHOLDERS.provisionerId;
+  }
+
+  if (type === 'string' && lowerName.includes('workertype')) {
+    return PLACEHOLDERS.workerType;
+  }
+
+  if (type === 'string' && lowerName.includes('clientid')) {
+    return PLACEHOLDERS.clientId;
+  }
+
+  if (type === 'string' && lowerName.includes('accesstoken')) {
+    return PLACEHOLDERS.accessToken;
+  }
+
+  if (type === 'string' && lowerName.includes('hookgroupid')) {
+    return PLACEHOLDERS.hookGroupId;
+  }
+
+  if (type === 'string' && lowerName.includes('hookid')) {
+    return PLACEHOLDERS.hookId;
+  }
+
+  // Timestamp patterns
+  if (lowerName.includes('deadline') || lowerName.includes('expires')) {
+    return new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString();
+  }
+
+  if (lowerName.includes('created')) {
+    return new Date().toISOString();
+  }
+
+  // Scope patterns (return array for type array)
+  if (lowerName.includes('scope') && type === 'array') {
+    return ['queue:create-task:highest:my-provider/*'];
+  }
+
+  // Route patterns (return array for type array)
+  if (lowerName.includes('route') && type === 'array') {
+    return ['index.project.taskcluster.example'];
+  }
+
+  // Common patterns for names
+  if (lowerName.includes('name') && type === 'string') {
+    return 'example-name';
+  }
+
+  // Common patterns for counts/limits
+  if (
+    (lowerName.includes('count') || lowerName === 'limit') &&
+    (type === 'number' || type === 'integer')
+  ) {
+    return 10;
+  }
+
+  // Owner pattern (email)
+  if (lowerName === 'owner' || lowerName.includes('owner')) {
+    return 'user@example.com';
+  }
+
+  return null;
+}
+
+/**
+ * Navigate JSON pointer path in schema
+ * @param {object} schema - Schema object
+ * @param {string} path - JSON pointer path like "#/properties/config"
+ * @returns {object|null} Resolved schema or null
+ */
+function navigateJsonPointer(schema, path) {
+  if (!path || path === '#') {
+    return schema;
+  }
+
+  const parts = path.replace(/^#\//, '').split('/');
+
+  return parts.reduce((current, part) => {
+    if (!current || typeof current !== 'object') {
+      return null;
+    }
+
+    return current[part];
+  }, schema);
+}
+
+/**
+ * Resolve a $ref to its actual schema definition
+ * @param {string} ref - Reference like "worker-pool-full.json#/path"
+ * @param {string} currentSchemaId - Current schema $id for internal refs
+ * @param {Array} allSchemas - All available schemas
+ * @param {Set} visitedRefs - Track visited refs to prevent cycles
+ * @returns {object|null} Resolved schema or null
+ */
+function resolveRef(ref, currentSchemaId, allSchemas, visitedRefs = new Set()) {
+  if (visitedRefs.has(ref)) {
+    return null; // Circular reference
+  }
+
+  visitedRefs.add(ref);
+
+  // Parse ref into filename and path
+  const [fileRef, pathRef] = ref.split('#');
+  let targetSchema;
+
+  // Internal reference (same file)
+  if (!fileRef || fileRef === '') {
+    // Find the root schema document using the current schema ID
+    targetSchema = allSchemas.find(
+      s => s.content && s.content.$id === currentSchemaId
+    );
+
+    if (!targetSchema) {
+      return null;
+    }
+
+    const resolved = navigateJsonPointer(
+      targetSchema.content,
+      `#${pathRef || ''}`
+    );
+
+    // If resolved schema has a $ref, resolve it recursively
+    if (resolved && resolved.$ref) {
+      return resolveRef(
+        resolved.$ref,
+        currentSchemaId,
+        allSchemas,
+        visitedRefs
+      );
+    }
+
+    return resolved;
+  }
+
+  // External reference - find schema by filename in $id
+  targetSchema = allSchemas.find(
+    s => s.content && s.content.$id && s.content.$id.endsWith(fileRef)
+  );
+
+  if (!targetSchema) {
+    return null;
+  }
+
+  // Navigate path in target schema
+  const resolved = navigateJsonPointer(
+    targetSchema.content,
+    `#${pathRef || ''}`
+  );
+
+  // If resolved schema has a $ref, resolve it recursively with the new
+  // schema context
+  if (resolved && resolved.$ref) {
+    return resolveRef(
+      resolved.$ref,
+      targetSchema.content.$id,
+      allSchemas,
+      visitedRefs
+    );
+  }
+
+  return resolved;
+}
+
+/**
+ * Generate example for string type
+ *
+ * @param {object} schema - JSON Schema definition
+ * @param {string} propertyName - Property name
+ * @returns {string} Example string value
+ */
+function generateStringExample(schema, propertyName) {
+  // Use default if available
+  if (schema.default !== undefined) {
+    return schema.default;
+  }
+
+  // Use enum if available (pick first value)
+  if (schema.enum && schema.enum.length > 0) {
+    return schema.enum[0];
+  }
+
+  // Use examples if available
+  if (schema.examples && schema.examples.length > 0) {
+    return schema.examples[0];
+  }
+
+  // Handle format with realistic values
+  if (schema.format) {
+    switch (schema.format) {
+      case 'date-time':
+        return new Date().toISOString();
+      case 'date':
+        return new Date().toISOString().split('T')[0];
+      case 'time':
+        return new Date().toISOString().split('T')[1];
+      case 'email':
+        return 'user@example.com';
+      case 'hostname':
+        return 'example.com';
+      case 'uri':
+      case 'url':
+        return 'https://example.com';
+      case 'uuid':
+        return '00000000-0000-0000-0000-000000000000';
+      default:
+        break;
+    }
+  }
+
+  // Use contextual placeholder for known property names
+  const contextual = getContextualPlaceholder(propertyName, 'string');
+
+  if (contextual) {
+    return contextual;
+  }
+
+  // Use minLength as hint for string length
+  if (schema.minLength && schema.minLength > 0) {
+    return 'x'.repeat(Math.min(schema.minLength, 20));
+  }
+
+  // Contextual string values based on property name
+  const lowerName = propertyName ? propertyName.toLowerCase() : '';
+
+  if (lowerName.includes('name')) {
+    return 'example-name';
+  }
+
+  if (lowerName.includes('description')) {
+    return 'Example description';
+  }
+
+  if (lowerName.includes('url') || lowerName.includes('uri')) {
+    return 'https://example.com';
+  }
+
+  if (lowerName.includes('email')) {
+    return 'user@example.com';
+  }
+
+  // Use pattern as hint if available
+  if (schema.pattern) {
+    // Try to generate a realistic value for common patterns
+    if (
+      schema.pattern.includes('[a-z]') ||
+      schema.pattern.includes('[a-zA-Z]')
+    ) {
+      return 'example-value';
+    }
+
+    if (schema.pattern.includes('\\d') || schema.pattern.includes('[0-9]')) {
+      return '0';
+    }
+
+    return 'example-value';
+  }
+
+  // Default to empty string (zero value) instead of placeholder
+  return '';
+}
+
+/**
+ * Generate example for number/integer type
+ *
+ * @param {object} schema - JSON Schema definition
+ * @param {string} propertyName - Property name for context
+ * @returns {number} Example number value
+ */
+function generateNumberExample(schema, propertyName = '') {
+  // Use default if available
+  if (schema.default !== undefined) {
+    return schema.default;
+  }
+
+  // Use examples if available
+  if (schema.examples && schema.examples.length > 0) {
+    return schema.examples[0];
+  }
+
+  // Use minimum if specified
+  if (schema.minimum !== undefined) {
+    return schema.minimum;
+  }
+
+  // Use middle of range if both min and max specified
+  if (schema.minimum !== undefined && schema.maximum !== undefined) {
+    return Math.floor((schema.minimum + schema.maximum) / 2);
+  }
+
+  // Contextual number values based on property name
+  const lowerName = propertyName ? propertyName.toLowerCase() : '';
+
+  if (lowerName.includes('count') || lowerName.includes('limit')) {
+    return 10;
+  }
+
+  if (lowerName.includes('priority')) {
+    return 0;
+  }
+
+  if (lowerName.includes('retries') || lowerName.includes('retry')) {
+    return 5;
+  }
+
+  if (lowerName.includes('timeout') || lowerName.includes('maxruntime')) {
+    return 600; // 10 minutes in seconds
+  }
+
+  // Default to 0 for integer, 0.0 for number
+  return schema.type === 'integer' ? 0 : 0.0;
+}
+
+/**
+ * Generate example for array type
+ *
+ * @param {object} schema - JSON Schema definition
+ * @param {string} propertyName - Property name
+ * @param {Set} visited - Set of visited schema $ids
+ * @param {Array} allSchemas - All available schemas
+ * @param {string} currentSchemaId - Current schema $id
+ * @param {Set} visitedRefs - Set of visited $refs
+ * @returns {Array} Example array value
+ */
+function generateArrayExample(
+  schema,
+  propertyName,
+  visited,
+  allSchemas,
+  currentSchemaId,
+  visitedRefs
+) {
+  // Use default if available
+  if (schema.default !== undefined) {
+    return schema.default;
+  }
+
+  // Use examples if available
+  if (schema.examples && schema.examples.length > 0) {
+    return schema.examples[0];
+  }
+
+  // Check for contextual array values (e.g., scopes, routes)
+  const contextual = getContextualPlaceholder(propertyName, 'array');
+
+  if (contextual && Array.isArray(contextual)) {
+    return contextual;
+  }
+
+  // Generate array with one example item if items schema is defined
+  if (schema.items) {
+    // eslint-disable-next-line no-use-before-define
+    const itemExample = generateExampleValue(
+      schema.items,
+      propertyName,
+      visited,
+      allSchemas,
+      currentSchemaId,
+      visitedRefs
+    );
+
+    return [itemExample];
+  }
+
+  // Empty array
+  return [];
+}
+
+/**
+ * Generate example for object type
+ *
+ * @param {object} schema - JSON Schema definition
+ * @param {Set} visited - Set of visited schema $ids
+ * @param {Array} allSchemas - All available schemas
+ * @param {string} currentSchemaId - Current schema $id
+ * @param {Set} visitedRefs - Set of visited $refs
+ * @returns {object} Example object value
+ */
+function generateObjectExample(
+  schema,
+  visited,
+  allSchemas,
+  currentSchemaId,
+  visitedRefs
+) {
+  // Use default if available (but avoid empty arrays as default)
+  if (schema.default !== undefined && !Array.isArray(schema.default)) {
+    return schema.default;
+  }
+
+  // Use examples if available
+  if (schema.examples && schema.examples.length > 0) {
+    return schema.examples[0];
+  }
+
+  const example = {};
+
+  // Generate examples for all properties (prioritize required)
+  if (schema.properties) {
+    const required = schema.required || [];
+
+    // Add required properties first
+    required.forEach(propName => {
+      if (schema.properties[propName]) {
+        // eslint-disable-next-line no-use-before-define
+        example[propName] = generateExampleValue(
+          schema.properties[propName],
+          propName,
+          visited,
+          allSchemas,
+          currentSchemaId,
+          visitedRefs
+        );
+      }
+    });
+
+    // Optionally add one non-required property as an example
+    const optionalProps = Object.keys(schema.properties).filter(
+      propName => !required.includes(propName)
+    );
+
+    if (optionalProps.length > 0 && required.length < 3) {
+      // Only add optional if we don't have too many required
+      const propName = optionalProps[0];
+
+      // eslint-disable-next-line no-use-before-define
+      example[propName] = generateExampleValue(
+        schema.properties[propName],
+        propName,
+        visited,
+        allSchemas,
+        currentSchemaId,
+        visitedRefs
+      );
+    }
+  }
+
+  // If no properties defined but additionalProperties allowed, add example
+  if (
+    Object.keys(example).length === 0 &&
+    schema.additionalProperties !== false
+  ) {
+    example.exampleKey = 'example-value';
+  }
+
+  return example;
+}
+
+/**
+ * Generate an example value based on JSON Schema type
+ *
+ * @param {object} schema - JSON Schema definition
+ * @param {string} propertyName - Property name
+ * @param {Set} visited - Set of visited schema $ids to prevent cycles
+ * @param {Array} allSchemas - All available schemas from references.json
+ * @param {string} currentSchemaId - Current schema $id for resolving refs
+ * @param {Set} visitedRefs - Set of visited $refs to prevent cycles
+ * @returns {*} Example value matching the schema
+ */
+function generateExampleValue(
+  schema,
+  propertyName = '',
+  visited = new Set(),
+  allSchemas = [],
+  currentSchemaId = null,
+  visitedRefs = new Set()
+) {
+  if (!schema) {
+    return {};
+  }
+
+  // Handle $ref - resolve to actual schema definition
+  if (schema.$ref) {
+    // Determine the schema ID to use for resolution
+    const schemaIdForResolution = currentSchemaId || schema.$id;
+    const resolved = resolveRef(
+      schema.$ref,
+      schemaIdForResolution,
+      allSchemas,
+      visitedRefs
+    );
+
+    if (resolved) {
+      // Determine the new schema ID context
+      const newSchemaId = resolved.$id || schemaIdForResolution;
+
+      return generateExampleValue(
+        resolved,
+        propertyName,
+        visited,
+        allSchemas,
+        newSchemaId,
+        visitedRefs
+      );
+    }
+    // If resolution fails, fall through to default handling
+  }
+
+  // Handle schema references (prevent infinite recursion)
+  if (schema.$id) {
+    if (visited.has(schema.$id)) {
+      return `<${schema.$id}>`;
+    }
+
+    visited.add(schema.$id);
+  }
+
+  // Update current schema ID if present
+  const effectiveSchemaId = schema.$id || currentSchemaId;
+
+  // Handle oneOf - pick the first option
+  if (schema.oneOf && Array.isArray(schema.oneOf)) {
+    return generateExampleValue(
+      schema.oneOf[0],
+      propertyName,
+      visited,
+      allSchemas,
+      effectiveSchemaId,
+      visitedRefs
+    );
+  }
+
+  // Handle anyOf - pick the first option
+  if (schema.anyOf && Array.isArray(schema.anyOf)) {
+    return generateExampleValue(
+      schema.anyOf[0],
+      propertyName,
+      visited,
+      allSchemas,
+      effectiveSchemaId,
+      visitedRefs
+    );
+  }
+
+  // Handle allOf - merge all schemas (simplified)
+  if (schema.allOf && Array.isArray(schema.allOf)) {
+    const merged = {};
+
+    schema.allOf.forEach(subSchema => {
+      // eslint-disable-next-line no-use-before-define
+      const example = generateExampleValue(
+        subSchema,
+        propertyName,
+        visited,
+        allSchemas,
+        effectiveSchemaId,
+        visitedRefs
+      );
+
+      if (typeof example === 'object' && example !== null) {
+        Object.assign(merged, example);
+      }
+    });
+
+    return merged;
+  }
+
+  // Handle enum - pick the first value
+  if (schema.enum && Array.isArray(schema.enum) && schema.enum.length > 0) {
+    return schema.enum[0];
+  }
+
+  // Handle const
+  if ('const' in schema) {
+    return schema.const;
+  }
+
+  // Get type (can be string or array)
+  const types = Array.isArray(schema.type) ? schema.type : [schema.type];
+  // Prefer non-null types if available
+  const type = types.find(t => t !== 'null') || types[0];
+
+  // Generate value based on type
+  switch (type) {
+    case 'string':
+      return generateStringExample(schema, propertyName);
+    case 'number':
+    case 'integer':
+      return generateNumberExample(schema, propertyName);
+    case 'boolean':
+      return schema.default !== undefined ? schema.default : false;
+    case 'array':
+      return generateArrayExample(
+        schema,
+        propertyName,
+        visited,
+        allSchemas,
+        effectiveSchemaId,
+        visitedRefs
+      );
+    case 'object':
+      return generateObjectExample(
+        schema,
+        visited,
+        allSchemas,
+        effectiveSchemaId,
+        visitedRefs
+      );
+    case 'null':
+      // Avoid returning null for non-nullable fields
+      return types.length === 1 ? {} : null;
+    default:
+      // Default to object for unknown types
+      return schema.default !== undefined ? schema.default : {};
+  }
+}
+
+/**
+ * Generate an example payload from a JSON schema
+ *
+ * @param {object} schema - JSON Schema definition
+ * @param {Array} allSchemas - All available schemas from references.json
+ * @returns {object|null} Example payload object
+ */
+export default function generatePayloadExample(schema, allSchemas = []) {
+  if (!schema) {
+    return null;
+  }
+
+  try {
+    return generateExampleValue(
+      schema,
+      '',
+      new Set(),
+      allSchemas,
+      schema.$id,
+      new Set()
+    );
+  } catch (error) {
+    // Error generating payload example
+    return null;
+  }
+}

--- a/ui/src/utils/api-examples/payload-generator.test.js
+++ b/ui/src/utils/api-examples/payload-generator.test.js
@@ -1,0 +1,490 @@
+import generatePayloadExample from './payload-generator';
+
+describe('generatePayloadExample', () => {
+  describe('basic types', () => {
+    test('generates string examples', () => {
+      const schema = {
+        $id: '/test-schema.json',
+        type: 'object',
+        properties: {
+          name: { type: 'string' },
+        },
+        required: ['name'],
+      };
+      const result = generatePayloadExample(schema, [{ content: schema }]);
+
+      expect(result).toHaveProperty('name');
+      expect(typeof result.name).toBe('string');
+    });
+
+    test('generates number examples', () => {
+      const schema = {
+        $id: '/test-schema.json',
+        type: 'object',
+        properties: {
+          count: { type: 'integer' },
+          score: { type: 'number' },
+        },
+        required: ['count', 'score'],
+      };
+      const result = generatePayloadExample(schema, [{ content: schema }]);
+
+      expect(result).toHaveProperty('count');
+      expect(result).toHaveProperty('score');
+      expect(Number.isInteger(result.count)).toBe(true);
+      expect(typeof result.score).toBe('number');
+    });
+
+    test('generates boolean examples', () => {
+      const schema = {
+        $id: '/test-schema.json',
+        type: 'object',
+        properties: {
+          enabled: { type: 'boolean' },
+        },
+        required: ['enabled'],
+      };
+      const result = generatePayloadExample(schema, [{ content: schema }]);
+
+      expect(result).toHaveProperty('enabled');
+      expect(typeof result.enabled).toBe('boolean');
+    });
+
+    test('generates array examples', () => {
+      const schema = {
+        $id: '/test-schema.json',
+        type: 'object',
+        properties: {
+          tags: {
+            type: 'array',
+            items: { type: 'string' },
+          },
+        },
+        required: ['tags'],
+      };
+      const result = generatePayloadExample(schema, [{ content: schema }]);
+
+      expect(result).toHaveProperty('tags');
+      expect(Array.isArray(result.tags)).toBe(true);
+    });
+
+    test('generates nested object examples', () => {
+      const schema = {
+        $id: '/test-schema.json',
+        type: 'object',
+        properties: {
+          config: {
+            type: 'object',
+            properties: {
+              setting: { type: 'string' },
+            },
+            required: ['setting'],
+          },
+        },
+        required: ['config'],
+      };
+      const result = generatePayloadExample(schema, [{ content: schema }]);
+
+      expect(result).toHaveProperty('config');
+      expect(result.config).toHaveProperty('setting');
+      expect(typeof result.config.setting).toBe('string');
+    });
+  });
+
+  describe('Taskcluster-specific placeholders', () => {
+    test('generates taskId placeholder for string type', () => {
+      const schema = {
+        $id: '/test-schema.json',
+        type: 'object',
+        properties: {
+          taskId: { type: 'string' },
+        },
+        required: ['taskId'],
+      };
+      const result = generatePayloadExample(schema, [{ content: schema }]);
+
+      expect(result.taskId).toBe('dSlITZ4yQgmvxxAi4A8fHQ');
+    });
+
+    test('does not apply taskId placeholder to object type', () => {
+      const schema = {
+        $id: '/test-schema.json',
+        type: 'object',
+        properties: {
+          task: {
+            type: 'object',
+            properties: {
+              id: { type: 'string' },
+            },
+            required: ['id'],
+          },
+        },
+        required: ['task'],
+      };
+      const result = generatePayloadExample(schema, [{ content: schema }]);
+
+      expect(result.task).toBeInstanceOf(Object);
+      expect(result.task).toHaveProperty('id');
+    });
+
+    test('generates workerPoolId placeholder for string type', () => {
+      const schema = {
+        $id: '/test-schema.json',
+        type: 'object',
+        properties: {
+          workerPoolId: { type: 'string' },
+        },
+        required: ['workerPoolId'],
+      };
+      const result = generatePayloadExample(schema, [{ content: schema }]);
+
+      expect(result.workerPoolId).toBe('my-worker-pool');
+    });
+
+    test('does not apply workerPoolId placeholder to object type', () => {
+      const schema = {
+        $id: '/test-schema.json',
+        type: 'object',
+        properties: {
+          workerPool: {
+            type: 'object',
+            properties: {
+              id: { type: 'string' },
+            },
+            required: ['id'],
+          },
+        },
+        required: ['workerPool'],
+      };
+      const result = generatePayloadExample(schema, [{ content: schema }]);
+
+      expect(result.workerPool).toBeInstanceOf(Object);
+      expect(result.workerPool).toHaveProperty('id');
+    });
+  });
+
+  describe('$ref resolution', () => {
+    test('resolves internal $ref', () => {
+      const schema = {
+        $id: '/test-schema.json',
+        type: 'object',
+        definitions: {
+          person: {
+            type: 'object',
+            properties: {
+              name: { type: 'string' },
+            },
+            required: ['name'],
+          },
+        },
+        properties: {
+          owner: { $ref: '#/definitions/person' },
+        },
+        required: ['owner'],
+      };
+      const result = generatePayloadExample(schema, [{ content: schema }]);
+
+      expect(result).toHaveProperty('owner');
+      expect(result.owner).toHaveProperty('name');
+      expect(typeof result.owner.name).toBe('string');
+    });
+
+    test('resolves external $ref', () => {
+      const personSchema = {
+        $id: '/schemas/person.json',
+        type: 'object',
+        properties: {
+          name: { type: 'string' },
+          age: { type: 'integer' },
+        },
+        required: ['name'],
+      };
+      const taskSchema = {
+        $id: '/schemas/task.json',
+        type: 'object',
+        properties: {
+          owner: { $ref: 'person.json' },
+        },
+        required: ['owner'],
+      };
+      const result = generatePayloadExample(taskSchema, [
+        { content: personSchema },
+        { content: taskSchema },
+      ]);
+
+      expect(result).toHaveProperty('owner');
+      expect(result.owner).toHaveProperty('name');
+      expect(typeof result.owner.name).toBe('string');
+    });
+
+    test('resolves external $ref with path', () => {
+      const definitionsSchema = {
+        $id: '/schemas/definitions.json',
+        definitions: {
+          metadata: {
+            type: 'object',
+            properties: {
+              title: { type: 'string' },
+              version: { type: 'integer' },
+            },
+            required: ['title'],
+          },
+        },
+      };
+      const taskSchema = {
+        $id: '/schemas/task.json',
+        type: 'object',
+        properties: {
+          metadata: { $ref: 'definitions.json#/definitions/metadata' },
+        },
+        required: ['metadata'],
+      };
+      const result = generatePayloadExample(taskSchema, [
+        { content: definitionsSchema },
+        { content: taskSchema },
+      ]);
+
+      expect(result).toHaveProperty('metadata');
+      expect(result.metadata).toHaveProperty('title');
+      expect(typeof result.metadata.title).toBe('string');
+    });
+
+    test('handles nested $refs', () => {
+      const addressSchema = {
+        $id: '/schemas/address.json',
+        type: 'object',
+        properties: {
+          street: { type: 'string' },
+          city: { type: 'string' },
+        },
+        required: ['city'],
+      };
+      const personSchema = {
+        $id: '/schemas/person.json',
+        type: 'object',
+        properties: {
+          name: { type: 'string' },
+          address: { $ref: 'address.json' },
+        },
+        required: ['name', 'address'],
+      };
+      const taskSchema = {
+        $id: '/schemas/task.json',
+        type: 'object',
+        properties: {
+          owner: { $ref: 'person.json' },
+        },
+        required: ['owner'],
+      };
+      const result = generatePayloadExample(taskSchema, [
+        { content: addressSchema },
+        { content: personSchema },
+        { content: taskSchema },
+      ]);
+
+      expect(result).toHaveProperty('owner');
+      expect(result.owner).toHaveProperty('name');
+      expect(result.owner).toHaveProperty('address');
+      expect(result.owner.address).toHaveProperty('city');
+    });
+
+    test('handles circular $refs without infinite loop', () => {
+      const schema = {
+        $id: '/test-schema.json',
+        type: 'object',
+        properties: {
+          name: { type: 'string' },
+          parent: { $ref: '#' },
+        },
+        required: ['name'],
+      };
+      const result = generatePayloadExample(schema, [{ content: schema }]);
+
+      expect(result).toHaveProperty('name');
+      // Should not crash, circular reference should be handled
+    });
+
+    test('resolves $ref that itself contains a $ref', () => {
+      const baseSchema = {
+        $id: '/schemas/base.json',
+        type: 'object',
+        properties: {
+          id: { type: 'string' },
+        },
+        required: ['id'],
+      };
+      const midSchema = {
+        $id: '/schemas/mid.json',
+        $ref: 'base.json',
+      };
+      const topSchema = {
+        $id: '/schemas/top.json',
+        type: 'object',
+        properties: {
+          item: { $ref: 'mid.json' },
+        },
+        required: ['item'],
+      };
+      const result = generatePayloadExample(topSchema, [
+        { content: baseSchema },
+        { content: midSchema },
+        { content: topSchema },
+      ]);
+
+      expect(result).toHaveProperty('item');
+      expect(result.item).toHaveProperty('id');
+    });
+  });
+
+  describe('schema keywords', () => {
+    test('uses default values', () => {
+      const schema = {
+        $id: '/test-schema.json',
+        type: 'object',
+        properties: {
+          status: { type: 'string', default: 'pending' },
+          priority: { type: 'integer', default: 5 },
+        },
+        required: ['status', 'priority'],
+      };
+      const result = generatePayloadExample(schema, [{ content: schema }]);
+
+      expect(result.status).toBe('pending');
+      expect(result.priority).toBe(5);
+    });
+
+    test('uses enum values', () => {
+      const schema = {
+        $id: '/test-schema.json',
+        type: 'object',
+        properties: {
+          level: { type: 'string', enum: ['debug', 'info', 'error'] },
+        },
+        required: ['level'],
+      };
+      const result = generatePayloadExample(schema, [{ content: schema }]);
+
+      expect(['debug', 'info', 'error']).toContain(result.level);
+    });
+
+    test('handles oneOf by picking first option', () => {
+      const schema = {
+        $id: '/test-schema.json',
+        type: 'object',
+        properties: {
+          value: {
+            oneOf: [{ type: 'string' }, { type: 'integer' }],
+          },
+        },
+        required: ['value'],
+      };
+      const result = generatePayloadExample(schema, [{ content: schema }]);
+
+      expect(result).toHaveProperty('value');
+      // Should pick first option (string)
+      expect(typeof result.value).toBe('string');
+    });
+
+    test('handles anyOf by picking first option', () => {
+      const schema = {
+        $id: '/test-schema.json',
+        type: 'object',
+        properties: {
+          value: {
+            anyOf: [{ type: 'number' }, { type: 'string' }],
+          },
+        },
+        required: ['value'],
+      };
+      const result = generatePayloadExample(schema, [{ content: schema }]);
+
+      expect(result).toHaveProperty('value');
+      // Should pick first option (number)
+      expect(typeof result.value).toBe('number');
+    });
+
+    test('handles allOf by merging schemas', () => {
+      const schema = {
+        $id: '/test-schema.json',
+        type: 'object',
+        properties: {
+          item: {
+            allOf: [
+              {
+                type: 'object',
+                properties: {
+                  name: { type: 'string' },
+                },
+                required: ['name'],
+              },
+              {
+                type: 'object',
+                properties: {
+                  id: { type: 'integer' },
+                },
+                required: ['id'],
+              },
+            ],
+          },
+        },
+        required: ['item'],
+      };
+      const result = generatePayloadExample(schema, [{ content: schema }]);
+
+      expect(result).toHaveProperty('item');
+      expect(result.item).toHaveProperty('name');
+      expect(result.item).toHaveProperty('id');
+    });
+  });
+
+  describe('edge cases', () => {
+    test('handles null schema', () => {
+      const result = generatePayloadExample(null, []);
+
+      expect(result).toBeNull();
+    });
+
+    test('handles empty allSchemas array', () => {
+      const schema = {
+        $id: '/test-schema.json',
+        type: 'object',
+        properties: {
+          name: { type: 'string' },
+        },
+        required: ['name'],
+      };
+      const result = generatePayloadExample(schema, []);
+
+      expect(result).toHaveProperty('name');
+    });
+
+    test('handles schema without required properties', () => {
+      const schema = {
+        $id: '/test-schema.json',
+        type: 'object',
+        properties: {
+          name: { type: 'string' },
+          age: { type: 'integer' },
+        },
+      };
+      const result = generatePayloadExample(schema, [{ content: schema }]);
+
+      expect(result).toBeInstanceOf(Object);
+    });
+
+    test('returns null for unresolvable $ref', () => {
+      const schema = {
+        $id: '/test-schema.json',
+        type: 'object',
+        properties: {
+          item: { $ref: 'non-existent.json' },
+        },
+        required: ['item'],
+      };
+      const result = generatePayloadExample(schema, [{ content: schema }]);
+
+      // Should handle gracefully without crashing
+      expect(result).toBeDefined();
+    });
+  });
+});

--- a/ui/src/utils/api-examples/python.js
+++ b/ui/src/utils/api-examples/python.js
@@ -1,0 +1,174 @@
+/**
+ * Generate Python client library examples for API endpoints
+ */
+
+import {
+  PLACEHOLDERS,
+  getPlaceholderValue,
+  requiresAuth,
+  capitalize,
+  formatPayloadJson,
+} from './helpers';
+
+/**
+ * Generate a Python example for an API endpoint
+ *
+ * @param {string} serviceName - Service name (e.g., 'queue')
+ * @param {string} apiVersion - API version (e.g., 'v1')
+ * @param {object} entry - API entry metadata
+ * @param {boolean} isAsync - Generate async or sync version
+ * @param {object} payloadExample - Example payload object (optional)
+ * @returns {string} Python code example
+ */
+export default function generatePythonExample(
+  serviceName,
+  apiVersion,
+  entry,
+  isAsync,
+  payloadExample = null
+) {
+  const className = capitalize(serviceName);
+  const params = entry.args.map(arg => `'${getPlaceholderValue(arg)}'`);
+  const tcModule = isAsync ? 'taskcluster.aio' : 'taskcluster';
+  // Build imports
+  const imports = isAsync
+    ? `import taskcluster.aio
+import asyncio`
+    : `import taskcluster`;
+  // Build client initialization
+  let clientInit;
+
+  if (requiresAuth(entry)) {
+    clientInit = `# Option 1: Explicit credentials
+${serviceName} = ${tcModule}.${className}({
+    'rootUrl': '${PLACEHOLDERS.rootUrl}',
+    'credentials': {
+        'clientId': '${PLACEHOLDERS.clientId}',
+        'accessToken': '${PLACEHOLDERS.accessToken}'
+    }
+})
+
+# Option 2: Credentials from environment variables
+# Requires: TASKCLUSTER_ROOT_URL, TASKCLUSTER_CLIENT_ID, TASKCLUSTER_ACCESS_TOKEN
+# ${serviceName} = ${tcModule}.${className}(taskcluster.optionsFromEnvironment())`;
+  } else {
+    clientInit = `# No authentication required for this endpoint
+${serviceName} = ${tcModule}.${className}({'rootUrl': '${PLACEHOLDERS.rootUrl}'})`;
+  }
+
+  // Build API call and error handling
+  let mainCode;
+
+  if (isAsync) {
+    let apiCall;
+
+    if (entry.input) {
+      let payloadCode;
+
+      if (payloadExample) {
+        // Use actual payload example
+        const jsonPayload = formatPayloadJson(payloadExample, 8);
+
+        payloadCode = `# Request payload - see schema at:
+        # ${PLACEHOLDERS.rootUrl}/schemas/${serviceName}/${entry.input}
+        payload = ${jsonPayload}`;
+      } else {
+        payloadCode = `# Request payload
+        # Schema: ${PLACEHOLDERS.rootUrl}/schemas/${serviceName}/${entry.input}
+        payload = {
+            # Fill in required fields according to the schema
+        }`;
+      }
+
+      apiCall = `${payloadCode}
+        result = await ${serviceName}.${entry.name}(${params.join(
+        ', '
+      )}, payload)`;
+    } else {
+      apiCall = `# Call the API method
+        result = await ${serviceName}.${entry.name}(${params.join(', ')})`;
+    }
+
+    let responseHandling;
+
+    if (entry.output && entry.output !== 'blob') {
+      responseHandling = `print(f"Success: {result}")
+        return result`;
+    } else if (entry.output === 'blob') {
+      responseHandling = `print(f"Downloaded {len(result)} bytes")
+        return result`;
+    } else {
+      responseHandling = `print("Success")`;
+    }
+
+    mainCode = `async def call_api():
+    try:
+        ${apiCall}
+        ${responseHandling}
+    except taskcluster.exceptions.TaskclusterAuthFailure as e:
+        print(f"Authentication failed: {e}")
+    except taskcluster.exceptions.TaskclusterRestFailure as e:
+        print(f"API error {e.status_code}: {e}")
+    except Exception as e:
+        print(f"Unexpected error: {e}")
+
+# Run the async function
+asyncio.run(call_api())`;
+  } else {
+    let apiCall;
+
+    if (entry.input) {
+      let payloadCode;
+
+      if (payloadExample) {
+        // Use actual payload example
+        const jsonPayload = formatPayloadJson(payloadExample, 4);
+
+        payloadCode = `# Request payload - see schema at:
+    # ${PLACEHOLDERS.rootUrl}/schemas/${serviceName}/${entry.input}
+    payload = ${jsonPayload}`;
+      } else {
+        payloadCode = `# Request payload
+    # Schema: ${PLACEHOLDERS.rootUrl}/schemas/${serviceName}/${entry.input}
+    payload = {
+        # Fill in required fields according to the schema
+    }`;
+      }
+
+      apiCall = `${payloadCode}
+    result = ${serviceName}.${entry.name}(${params.join(', ')}, payload)`;
+    } else {
+      apiCall = `# Call the API method
+    result = ${serviceName}.${entry.name}(${params.join(', ')})`;
+    }
+
+    let responseHandling;
+
+    if (entry.output && entry.output !== 'blob') {
+      responseHandling = `print(f"Success: {result}")`;
+    } else if (entry.output === 'blob') {
+      responseHandling = `print(f"Downloaded {len(result)} bytes")`;
+    } else {
+      responseHandling = `print("Success")`;
+    }
+
+    mainCode = `try:
+    ${apiCall}
+    ${responseHandling}
+except taskcluster.exceptions.TaskclusterAuthFailure as e:
+    print(f"Authentication failed: {e}")
+except taskcluster.exceptions.TaskclusterRestFailure as e:
+    print(f"API error {e.status_code}: {e}")
+except Exception as e:
+    print(f"Unexpected error: {e}")`;
+  }
+
+  // Assemble the complete example
+  const example = `${imports}
+
+${clientInit}
+
+${mainCode}`;
+
+  return example;
+}

--- a/ui/src/utils/api-examples/rust.js
+++ b/ui/src/utils/api-examples/rust.js
@@ -1,0 +1,116 @@
+/**
+ * Generate Rust client library examples for API endpoints
+ */
+
+import {
+  PLACEHOLDERS,
+  getPlaceholderValue,
+  requiresAuth,
+  capitalize,
+  formatPayloadJson,
+} from './helpers';
+
+/**
+ * Generate a Rust example for an API endpoint
+ *
+ * @param {string} serviceName - Service name (e.g., 'queue')
+ * @param {string} apiVersion - API version (e.g., 'v1')
+ * @param {object} entry - API entry metadata
+ * @param {object} payloadExample - Example payload object (optional)
+ * @returns {string} Rust code example
+ */
+export default function generateRustExample(
+  serviceName,
+  apiVersion,
+  entry,
+  payloadExample = null
+) {
+  const className = capitalize(serviceName);
+  const params = entry.args.map(arg => `"${getPlaceholderValue(arg)}"`);
+  // Build imports
+  const imports = entry.input
+    ? `use taskcluster::{${className}, ClientBuilder, Credentials};
+use anyhow::Result;
+use serde_json::json;`
+    : `use taskcluster::{${className}, ClientBuilder, Credentials};
+use anyhow::Result;`;
+  // Build client initialization
+  let clientInit;
+
+  if (requiresAuth(entry)) {
+    clientInit = `// Option 1: Explicit credentials
+    let creds = Credentials {
+        client_id: "${PLACEHOLDERS.clientId}".to_string(),
+        access_token: "${PLACEHOLDERS.accessToken}".to_string(),
+        certificate: None,
+    };
+    let client = ${className}::new(
+        ClientBuilder::new("${PLACEHOLDERS.rootUrl}")
+            .credentials(creds)
+    )?;
+
+    // Option 2: Credentials from environment variables
+    // Requires: TASKCLUSTER_ROOT_URL, TASKCLUSTER_CLIENT_ID, TASKCLUSTER_ACCESS_TOKEN
+    // let creds = Credentials::from_env()?;
+    // let root_url = std::env::var("TASKCLUSTER_ROOT_URL")?;
+    // let client = ${className}::new(ClientBuilder::new(&root_url).credentials(creds))?;`;
+  } else {
+    clientInit = `// No authentication required for this endpoint
+    let client = ${className}::new(ClientBuilder::new("${PLACEHOLDERS.rootUrl}"))?;`;
+  }
+
+  // Build API call
+  let apiCall;
+
+  if (entry.input) {
+    let payloadCode;
+
+    if (payloadExample) {
+      // Use actual payload example in json! macro
+      const jsonPayload = formatPayloadJson(payloadExample, 8);
+
+      payloadCode = `// Create request payload - see schema at:
+    // ${PLACEHOLDERS.rootUrl}/schemas/${serviceName}/${entry.input}
+    let payload = json!(${jsonPayload});`;
+    } else {
+      payloadCode = `// Create request payload
+    // See schema at: ${PLACEHOLDERS.rootUrl}/schemas/${serviceName}/${entry.input}
+    let payload = json!({
+        // Fill in required fields according to the schema
+    });`;
+    }
+
+    apiCall = `${payloadCode}
+
+    // Call the API method
+    let result = client.${entry.name}(${params.join(', ')}, &payload).await?;`;
+  } else {
+    apiCall = `// Call the API method
+    let result = client.${entry.name}(${params.join(', ')}).await?;`;
+  }
+
+  // Build response handling
+  let responseHandling;
+
+  if (entry.output && entry.output !== 'blob') {
+    responseHandling = `println!("Success: {:?}", result);`;
+  } else if (entry.output === 'blob') {
+    responseHandling = `println!("Downloaded {} bytes", result.len());`;
+  } else {
+    responseHandling = `println!("Success");`;
+  }
+
+  // Assemble the complete example
+  const example = `${imports}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    ${clientInit}
+
+    ${apiCall}
+    ${responseHandling}
+    Ok(())
+}`;
+
+  return example;
+}

--- a/ui/src/utils/api-examples/shell.js
+++ b/ui/src/utils/api-examples/shell.js
@@ -1,0 +1,80 @@
+/**
+ * Generate taskcluster-cli (shell client) examples for API endpoints
+ */
+
+import {
+  PLACEHOLDERS,
+  getPlaceholderValue,
+  requiresAuth,
+  camelCase,
+  formatPayloadJson,
+} from './helpers';
+
+/**
+ * Generate a taskcluster-cli example for an API endpoint
+ *
+ * @param {string} serviceName - Service name (e.g., 'queue')
+ * @param {string} apiVersion - API version (e.g., 'v1')
+ * @param {object} entry - API entry metadata
+ * @param {object} payloadExample - Example payload object (optional)
+ * @returns {string} taskcluster-cli command example
+ */
+export default function generateShellExample(
+  serviceName,
+  apiVersion,
+  entry,
+  payloadExample = null
+) {
+  const methodName = camelCase(entry.name);
+  // Build header comment
+  const header = requiresAuth(entry)
+    ? `# ${entry.title}
+# This endpoint requires authentication
+# Set your credentials in environment variables:
+#   TASKCLUSTER_ROOT_URL=https://tc.example.com
+#   TASKCLUSTER_CLIENT_ID=your-client-id
+#   TASKCLUSTER_ACCESS_TOKEN=your-access-token`
+    : `# ${entry.title}
+# No authentication required
+# Set TASKCLUSTER_ROOT_URL=${PLACEHOLDERS.rootUrl}`;
+  // Build base command
+  let command = `taskcluster api ${serviceName} ${methodName}`;
+
+  // Add path parameters
+  entry.args.forEach(arg => {
+    const placeholder = getPlaceholderValue(arg);
+
+    command += ` --${arg} "${placeholder}"`;
+  });
+
+  // Add query parameters if present
+  if (entry.query && entry.query.length > 0) {
+    entry.query.forEach(q => {
+      command += ` \\\n  --${q} "<${q}>"`;
+    });
+  }
+
+  // Add request body for methods that have one
+  if (entry.input) {
+    let inputPayload = '{\n  "key": "value"\n}';
+
+    if (payloadExample) {
+      inputPayload = formatPayloadJson(payloadExample, 0);
+    }
+
+    command += ` \\\n  --input - <<'EOF'\n${inputPayload}\nEOF`;
+  }
+
+  // Build output formatting hint
+  const outputHint =
+    entry.output && entry.output !== 'blob'
+      ? `\n\n# To format output as JSON:
+# ${command.split('\n')[0]} | jq .`
+      : '';
+  // Assemble the complete example
+  const example = `${header}
+
+${command}${outputHint}`;
+
+  return example;
+}

--- a/ui/src/utils/api-examples/web.js
+++ b/ui/src/utils/api-examples/web.js
@@ -1,0 +1,128 @@
+/**
+ * Generate Web/browser client library examples for API endpoints
+ */
+
+import {
+  PLACEHOLDERS,
+  getPlaceholderValue,
+  requiresAuth,
+  capitalize,
+  formatPayloadJson,
+} from './helpers';
+
+/**
+ * Generate a Web example for an API endpoint
+ *
+ * @param {string} serviceName - Service name (e.g., 'queue')
+ * @param {string} apiVersion - API version (e.g., 'v1')
+ * @param {object} entry - API entry metadata
+ * @param {object} payloadExample - Example payload object (optional)
+ * @returns {string} Web/browser code example
+ */
+export default function generateWebExample(
+  serviceName,
+  apiVersion,
+  entry,
+  payloadExample = null
+) {
+  const className = capitalize(serviceName);
+  const params = entry.args.map(arg => `'${getPlaceholderValue(arg)}'`);
+  // Build client initialization
+  let clientInit;
+
+  if (requiresAuth(entry)) {
+    clientInit = `// Option 1: Explicit credentials
+  const ${serviceName} = new ${className}({
+    rootUrl: '${PLACEHOLDERS.rootUrl}',
+    credentials: {
+      clientId: '${PLACEHOLDERS.clientId}',
+      accessToken: '${PLACEHOLDERS.accessToken}'
+    }
+  });
+
+  // Option 2: Credentials from environment/config
+  // In browser environments, credentials are typically obtained from
+  // your application's authentication flow
+  // const ${serviceName} = new ${className}({
+  //   rootUrl: window.env.TASKCLUSTER_ROOT_URL,
+  //   credentials: getCredentialsFromAuth()
+  // });`;
+  } else {
+    clientInit = `// No authentication required for this endpoint
+  const ${serviceName} = new ${className}({
+    rootUrl: '${PLACEHOLDERS.rootUrl}'
+  });`;
+  }
+
+  // Build API call
+  let apiCall;
+
+  if (entry.input) {
+    let payloadCode;
+
+    if (payloadExample) {
+      // Use actual payload example
+      const jsonPayload = formatPayloadJson(payloadExample, 4);
+
+      payloadCode = `// Request payload - see schema at:
+    // ${PLACEHOLDERS.rootUrl}/schemas/${serviceName}/${entry.input}
+    const payload = ${jsonPayload};`;
+    } else {
+      payloadCode = `// Request payload
+    // See schema at: ${PLACEHOLDERS.rootUrl}/schemas/${serviceName}/${entry.input}
+    const payload = {
+      // Fill in required fields according to the schema
+    };`;
+    }
+
+    apiCall = `${payloadCode}
+
+    // Call the API method
+    const result = await ${serviceName}.${entry.name}(${params.join(
+      ', '
+    )}, payload);`;
+  } else {
+    apiCall = `// Call the API method
+    const result = await ${serviceName}.${entry.name}(${params.join(', ')});`;
+  }
+
+  // Build response handling
+  let responseHandling;
+
+  if (entry.output && entry.output !== 'blob') {
+    responseHandling = `console.log('Success:', result);
+    return result;`;
+  } else if (entry.output === 'blob') {
+    responseHandling = `console.log(\`Downloaded \${result.length} bytes\`);
+    return result;`;
+  } else {
+    responseHandling = `console.log('Success');`;
+  }
+
+  // Assemble the complete example
+  const example = `import { ${className} } from '@taskcluster/client-web';
+
+async function callApi() {
+  ${clientInit}
+
+  try {
+    ${apiCall}
+    ${responseHandling}
+  } catch (err) {
+    // Handle Taskcluster API errors
+    if (err.statusCode) {
+      console.error(\`API Error \${err.statusCode}: \${err.message}\`);
+    } else {
+      console.error('Unexpected error:', err);
+    }
+    throw err;
+  }
+}
+
+// Call the function
+callApi().catch(err => {
+  console.error('Failed:', err);
+});`;
+
+  return example;
+}

--- a/ui/src/views/Documentation/Reference/ApiReference.jsx
+++ b/ui/src/views/Documentation/Reference/ApiReference.jsx
@@ -77,6 +77,7 @@ export default class ApiReference extends Component {
                     type="function"
                     entry={entry}
                     serviceName={ref.serviceName}
+                    apiVersion={ref.apiVersion}
                   />
                 ))}
               </Fragment>


### PR DESCRIPTION
The API reference documentation now includes code examples for every endpoint in multiple languages:
- **curl** - Raw HTTP requests
- **Go** - Go client library
- **Python** - Synchronous and asynchronous client libraries
- **Node.js** - Node.js client library
- **Web** - Browser/web client library
- **Rust** - Rust client library
- **Shell** - Taskcluster CLI (taskcluster-cli)

<img width="1715" height="996" alt="Tascluster Screenshot" src="https://github.com/user-attachments/assets/88cb66c9-6d16-4fbc-a5f7-a6fad7264572" />

Each example demonstrates how to:
- Set up the client with authentication (both explicit credentials and environment variables)
- Call the API endpoint with proper parameters
- Handle errors appropriately
- Process the response

Examples are generated dynamically in the browser from API metadata, keeping the documentation lean while providing comprehensive, up-to-date code samples. Examples include syntax highlighting and can be copied to clipboard directly from the documentation.

Github Bug/Issue: Fixes #8049 
