### PR TITLE
feat(w-m): Extract and report arm deployment errors

### DIFF
--- a/changelog/issue-8077.md
+++ b/changelog/issue-8077.md
@@ -1,0 +1,8 @@
+audience: worker-deployers
+level: patch
+reference: issue 8077
+---
+
+Azure provider reports ARM template deployments errors on the worker pool level.
+When deployment fails and one or more resources were not created, errors were hidden in operations list,
+which made it difficult to debug.


### PR DESCRIPTION
This is necessary to make it visible what failed inside the deployment. Those errors were only present in operation details, and were not visible on the worker pool.

Fixes #8077
