### PR TITLE
fix(generic-worker): log artifact upload status to worker log unless failure

### DIFF
--- a/changelog/issue-8079.md
+++ b/changelog/issue-8079.md
@@ -1,0 +1,5 @@
+audience: worker-deployers
+level: patch
+reference: issue 8079
+---
+Generic Worker: logs artifact upload status to worker logs instead of the task log, unless there was an error uploading.

--- a/workers/generic-worker/artifacts/error.go
+++ b/workers/generic-worker/artifacts/error.go
@@ -2,6 +2,7 @@ package artifacts
 
 import (
 	"fmt"
+	"log"
 
 	"github.com/taskcluster/taskcluster/v93/clients/client-go/tcqueue"
 	"github.com/taskcluster/taskcluster/v93/internal/mocktc/tc"
@@ -16,11 +17,11 @@ type ErrorArtifact struct {
 }
 
 func (errArtifact *ErrorArtifact) ProcessResponse(response any, logger Logger, serviceFactory tc.ServiceFactory, config *gwconfig.Config) error {
-	log := logger.Errorf
+	printLog := logger.Errorf
 	if errArtifact.Optional {
-		log = logger.Infof
+		printLog = log.Printf
 	}
-	log("Uploading error artifact %v from file %v with message %q, reason %q and expiry %v", errArtifact.Name, errArtifact.Path, errArtifact.Message, errArtifact.Reason, errArtifact.Expires)
+	printLog("Uploading error artifact %v from file %v with message %q, reason %q and expiry %v", errArtifact.Name, errArtifact.Path, errArtifact.Message, errArtifact.Reason, errArtifact.Expires)
 	// TODO: process error response
 	return nil
 }

--- a/workers/generic-worker/artifacts/link.go
+++ b/workers/generic-worker/artifacts/link.go
@@ -2,6 +2,7 @@ package artifacts
 
 import (
 	"fmt"
+	"log"
 
 	"github.com/taskcluster/taskcluster/v93/clients/client-go/tcqueue"
 	"github.com/taskcluster/taskcluster/v93/internal/mocktc/tc"
@@ -15,7 +16,7 @@ type LinkArtifact struct {
 }
 
 func (linkArtifact *LinkArtifact) ProcessResponse(response any, logger Logger, serviceFactory tc.ServiceFactory, config *gwconfig.Config) error {
-	logger.Infof("Uploading link artifact %v to artifact %v with expiry %v", linkArtifact.Name, linkArtifact.Artifact, linkArtifact.Expires)
+	log.Printf("Uploading link artifact %v to artifact %v with expiry %v", linkArtifact.Name, linkArtifact.Artifact, linkArtifact.Expires)
 	// nothing to do
 	return nil
 }

--- a/workers/generic-worker/artifacts/object.go
+++ b/workers/generic-worker/artifacts/object.go
@@ -2,6 +2,7 @@ package artifacts
 
 import (
 	"fmt"
+	"log"
 	"time"
 
 	tcclient "github.com/taskcluster/taskcluster/v93/clients/client-go"
@@ -33,7 +34,7 @@ func (a *ObjectArtifact) ResponseObject() any {
 
 func (a *ObjectArtifact) ProcessResponse(resp any, logger Logger, serviceFactory tc.ServiceFactory, config *gwconfig.Config) (err error) {
 	response := resp.(*tcqueue.ObjectArtifactResponse)
-	logger.Infof("Uploading artifact %v from file %v with content type %q and expiry %v", a.Name, a.Path, a.ContentType, a.Expires)
+	log.Printf("Uploading artifact %v from file %v with content type %q and expiry %v", a.Name, a.Path, a.ContentType, a.Expires)
 	creds := tcclient.Credentials{
 		ClientID:    response.Credentials.ClientID,
 		AccessToken: response.Credentials.AccessToken,

--- a/workers/generic-worker/artifacts/redirect.go
+++ b/workers/generic-worker/artifacts/redirect.go
@@ -2,6 +2,7 @@ package artifacts
 
 import (
 	"fmt"
+	"log"
 
 	"github.com/taskcluster/taskcluster/v93/clients/client-go/tcqueue"
 	"github.com/taskcluster/taskcluster/v93/internal/mocktc/tc"
@@ -16,14 +17,14 @@ type RedirectArtifact struct {
 }
 
 func (redirectArtifact *RedirectArtifact) ProcessResponse(response any, logger Logger, serviceFactory tc.ServiceFactory, config *gwconfig.Config) error {
-	log := fmt.Sprintf("Uploading redirect artifact %v to ", redirectArtifact.Name)
+	output := fmt.Sprintf("Uploading redirect artifact %v to ", redirectArtifact.Name)
 	if redirectArtifact.HideURL {
-		log += "(URL hidden) "
+		output += "(URL hidden) "
 	} else {
-		log += fmt.Sprintf("URL %v ", redirectArtifact.URL)
+		output += fmt.Sprintf("URL %v ", redirectArtifact.URL)
 	}
-	log += fmt.Sprintf("with mime type %q and expiry %v", redirectArtifact.ContentType, redirectArtifact.Expires)
-	logger.Infof(log)
+	output += fmt.Sprintf("with mime type %q and expiry %v", redirectArtifact.ContentType, redirectArtifact.Expires)
+	log.Print(output)
 	// nothing to do
 	return nil
 }

--- a/workers/generic-worker/artifacts/s3.go
+++ b/workers/generic-worker/artifacts/s3.go
@@ -60,7 +60,7 @@ func (s3Artifact *S3Artifact) createTempFileForPUTBody() string {
 func (s3Artifact *S3Artifact) ProcessResponse(resp any, logger Logger, serviceFactory tc.ServiceFactory, config *gwconfig.Config) (err error) {
 	response := resp.(*tcqueue.S3ArtifactResponse)
 
-	logger.Infof("Uploading artifact %v from file %v with content encoding %q, mime type %q and expiry %v", s3Artifact.Name, s3Artifact.Path, s3Artifact.ContentEncoding, s3Artifact.ContentType, s3Artifact.Expires)
+	log.Printf("Uploading artifact %v from file %v with content encoding %q, mime type %q and expiry %v", s3Artifact.Name, s3Artifact.Path, s3Artifact.ContentEncoding, s3Artifact.ContentType, s3Artifact.Expires)
 
 	// Artifacts declared in payload are copied to a temp file
 	// as task user to ensure they are readable by task user.

--- a/workers/generic-worker/d2g_test.go
+++ b/workers/generic-worker/d2g_test.go
@@ -58,18 +58,6 @@ func TestD2GWithValidDockerWorkerPayload(t *testing.T) {
 	switch fmt.Sprintf("%s:%s", engine, runtime.GOOS) {
 	case "multiuser:linux":
 		_ = submitAndAssert(t, td, payload, "completed", "completed")
-		logtext := LogText(t)
-		t.Log(logtext)
-		// tests the default artifact expiry is not present in the
-		// translated task definition
-		if strings.Contains(logtext, "0001-01-01T00:00:00.000Z") {
-			t.Fatal("Was expecting log file to not contain '0001-01-01T00:00:00.000Z'")
-		}
-		// tests the set artifact expiry is present in the
-		// translated task definition
-		if testTimeStr := testTime.String(); !strings.Contains(logtext, testTimeStr) {
-			t.Fatalf("Was expecting log file to contain '%s'", testTimeStr)
-		}
 	case "insecure:linux":
 		_ = submitAndAssert(t, td, payload, "exception", "malformed-payload")
 		logtext := LogText(t)


### PR DESCRIPTION
Fixes #8079.

>Generic Worker: logs artifact upload status to worker logs instead of the task log, unless there was an error uploading.