### PR TITLE
feat(w-m): Expose metrics

### DIFF
--- a/changelog/Uxn5On2fTeewm5CLiRXlUA.md
+++ b/changelog/Uxn5On2fTeewm5CLiRXlUA.md
@@ -1,0 +1,5 @@
+audience: deployers
+level: patch
+---
+
+Worker-manager web services exposes metrics now.

--- a/services/worker-manager/src/main.js
+++ b/services/worker-manager/src/main.js
@@ -150,19 +150,24 @@ let load = loader({
       providers,
       publisher,
       notify,
-    }) => builder.build({
-      rootUrl: cfg.taskcluster.rootUrl,
-      context: {
-        cfg,
-        db,
-        monitor: monitor.childMonitor('api-context'),
-        providers,
-        publisher,
-        notify,
-      },
-      monitor: monitor.childMonitor('api'),
-      schemaset,
-    }),
+    }) => {
+      const api = builder.build({
+        rootUrl: cfg.taskcluster.rootUrl,
+        context: {
+          cfg,
+          db,
+          monitor: monitor.childMonitor('api-context'),
+          providers,
+          publisher,
+          notify,
+        },
+        monitor: monitor.childMonitor('api'),
+        schemaset,
+      });
+
+      monitor.exposeMetrics('default');
+      return api;
+    },
   },
 
   server: {


### PR DESCRIPTION
Worker manager already aggregates some metrics around http calls, but now we also expose worker lifetime related metrics as well.

In addition to #8072 
