### PR TITLE
fix(generic-worker): windows `LoadUserProfile` intermittent fix

### DIFF
--- a/changelog/issue-8083.md
+++ b/changelog/issue-8083.md
@@ -1,0 +1,5 @@
+audience: worker-deployers
+level: patch
+reference: issue 8083
+---
+Generic Worker (windows): fixes intermittent issue calling `LoadUserProfile` win32 API when the device isn't ready.

--- a/workers/generic-worker/multiuser_windows.go
+++ b/workers/generic-worker/multiuser_windows.go
@@ -528,9 +528,15 @@ func GrantSIDFullControlOfInteractiveWindowsStationAndDesktop(sid string) (err e
 }
 
 func PreRebootSetup(nextTaskUser *gwruntime.OSUser) {
+	// Create user profile before loading it to prevent temporary profile creation
+	// Preventing issues like https://github.com/taskcluster/taskcluster/issues/8083
+	err := nextTaskUser.CreateUserProfile()
+	if err != nil {
+		panic(err)
+	}
+
 	// set APPDATA
 	var loginInfo *process.LoginInfo
-	var err error
 	loginInfo, err = process.NewLoginInfo(nextTaskUser.Name, nextTaskUser.Password)
 	if err != nil {
 		panic(err)


### PR DESCRIPTION
Fixes #8083.

>Generic Worker (windows): fixes intermittent issue calling `LoadUserProfile` win32 API when the device isn't ready.