### PR TITLE
feat(w-m): Fix workers stuck in removal loop for ARM templates

### DIFF
--- a/changelog/issue-8086.md
+++ b/changelog/issue-8086.md
@@ -1,0 +1,6 @@
+audience: deployers
+level: patch
+reference: issue 8086
+---
+
+Worker-manager Azure ARM deployment fix for stuck worker in removal/stopping loop, better descriptions in reported errors.


### PR DESCRIPTION
Due to lack of extra checks for arm template deployment failures, workers got stuck in eternal loop where deployment contained errors, check arm deployment noticed those errors and tried to remove worker, even though worker was already stopping

Improved error descriptions

Fixes #8086 
