### PR TITLE
feat(w-m): worker related metrics should be exposed everywhere

### DIFF
--- a/changelog/Al15793wTJyEYhftsAx8Sg.md
+++ b/changelog/Al15793wTJyEYhftsAx8Sg.md
@@ -1,0 +1,5 @@
+audience: deployers
+level: patch
+---
+
+Worker registration metrics exposed from all relevant pods.

--- a/generated/references.json
+++ b/generated/references.json
@@ -17757,7 +17757,9 @@
           },
           "name": "worker_manager_worker_lifetime_seconds",
           "registers": [
-            "workers"
+            "default",
+            "provision",
+            "scan"
           ],
           "title": "Worker lifetime",
           "type": "histogram"
@@ -17818,7 +17820,9 @@
           },
           "name": "worker_manager_worker_registration_failures_total",
           "registers": [
-            "workers"
+            "default",
+            "provision",
+            "scan"
           ],
           "title": "Workers that never registered",
           "type": "counter"
@@ -17844,7 +17848,9 @@
           },
           "name": "worker_manager_worker_registration_seconds",
           "registers": [
-            "workers"
+            "default",
+            "provision",
+            "scan"
           ],
           "title": "Worker registration duration",
           "type": "histogram"

--- a/services/worker-manager/src/monitor.js
+++ b/services/worker-manager/src/monitor.js
@@ -381,7 +381,7 @@ MonitorManager.registerMetric('workerRegistrationDuration', {
     ...commonLabels,
     providerId: 'ID of the provider',
   },
-  registers: ['workers'],
+  registers: ['default', 'provision', 'scan'],
   buckets: [15, 30, 45, 60, 90, 120, 180, 300, 600, 1200, 1800],
 });
 
@@ -397,7 +397,7 @@ MonitorManager.registerMetric('workerLifetime', {
     ...commonLabels,
     providerId: 'ID of the provider',
   },
-  registers: ['workers'],
+  registers: ['default', 'provision', 'scan'],
   buckets: [60, 300, 900, 1800, 3600, 7200, 14400, 28800, 86400, 172800, 604800, 1209600],
 });
 
@@ -413,7 +413,7 @@ MonitorManager.registerMetric('workerRegistrationFailure', {
     ...commonLabels,
     providerId: 'ID of the provider',
   },
-  registers: ['workers'],
+  registers: ['default', 'provision', 'scan'],
 });
 
 MonitorManager.registerMetric('scanSeen', {


### PR DESCRIPTION
Since those events may happen in web, provisioner or worker scanner, we should expose it everywhere too

