### PR TITLE
Skip ownership changes for caches when using d2g

### DIFF
--- a/changelog/issue-8102.md
+++ b/changelog/issue-8102.md
@@ -1,0 +1,5 @@
+audience: general
+level: patch
+reference: issue 8102
+---
+Don't try to chown caches when using d2g as this is a long no-op anyway

--- a/workers/generic-worker/mounts_multiuser.go
+++ b/workers/generic-worker/mounts_multiuser.go
@@ -18,6 +18,12 @@ func makeDirReadWritableForTaskUser(taskMount *TaskMount, dir string) error {
 }
 
 func exchangeDirectoryOwnership(taskMount *TaskMount, dir string, cache *Cache) error {
+	// Skip ownership changes for d2g tasks since the ownership of files is decided
+	// by the container itself (there's no mapping)
+	if taskMount.task.D2GInfo != nil {
+		return nil
+	}
+
 	// It doesn't concern us if payload.features.runTaskAsCurrentUser is set or not
 	// because files inside task directory should be owned/managed by task user
 	newOwnerUsername := taskContext.User.Name


### PR DESCRIPTION
When using d2g, it makes no sense to change the ownership of anything getting mounted in the container as there's no UID mapping whatsoever. Task users will have random UIDs that basically will never match what containers are running as, so the --from of chown will never match anyway, making this a very slow no-op.

An example of this is when using run-task with a checkout cache, assuming the task user on the worker has UID 5000, run-task creates the checkout inside of the container with UID 1000. On the second run, we'd try to run `chown --from=5000 5001 ...`, which does nothing since all files are and should be owned by 1000.

While the chown doesn't do anything, it still needs to iterate over the cache and stat every single file/directory which can be fairly slow on large caches (firefox checkouts for example).

```
[taskcluster 2025-11-18T20:47:01.968Z] [mounts] Moving existing writable directory cache gecko-level-1-checkouts-hg58-v3-38439bed431008791a5f from /home/generic-worker/caches/S4PIHUZCSTaejCispwQ35Q to /home/task_176349854923211/cache2
[taskcluster 2025-11-18T20:47:01.968Z] [mounts] Creating directory /home/task_176349854923211
[taskcluster 2025-11-18T20:47:01.976Z] [mounts] Updating ownership of files inside directory '/home/task_176349854923211/cache2' from task_176349846230078 to task_176349854923211
[taskcluster 2025-11-18T20:47:06.497Z] [mounts] Successfully mounted writable directory cache '/home/task_176349854923211/cache2'
```

Fixes #8102