### PR TITLE
feat(w-m): Azure deployment extra error logging

### DIFF
--- a/changelog/NJ1BF8xDSZibjoIfGBHd5Q.md
+++ b/changelog/NJ1BF8xDSZibjoIfGBHd5Q.md
@@ -1,0 +1,5 @@
+audience: worker-deployers
+level: patch
+---
+
+Azure provider logs additional error details for failed ARM deployments.

--- a/services/worker-manager/src/providers/azure/index.js
+++ b/services/worker-manager/src/providers/azure/index.js
@@ -525,12 +525,19 @@ export class AzureProvider extends Provider {
     } catch (err) {
       const workerPool = await WorkerPool.get(this.db, worker.workerPoolId);
 
+      this.monitor.debug({
+        message: 'Error creating ARM deployment',
+        deploymentName,
+        error: err,
+      });
+
       await this.reportError({
         workerPool,
         kind: 'creation-error',
         title: 'Failed to create ARM deployment',
         description: err.message,
         extra: {
+          innerError: err?.innererror ?? '',
           workerId: worker.workerId,
           workerGroup: workerGroup,
           armDeployment,


### PR DESCRIPTION
Some arm deployment errors contain extra information in the 'innererror' field which is not being reported, so the original failure reason might be unclear


