### PR TITLE
Increase the buffer size on websocktunnel

### DIFF
--- a/changelog/RJtOo9wGRGeV-qprpSa2dw.md
+++ b/changelog/RJtOo9wGRGeV-qprpSa2dw.md
@@ -1,0 +1,4 @@
+audience: users
+level: patch
+---
+Make livelogs faster when passing through websocktunnel by increasing the buffer size on the proxy

--- a/tools/websocktunnel/wsproxy/proxy.go
+++ b/tools/websocktunnel/wsproxy/proxy.go
@@ -224,7 +224,7 @@ func (p *proxy) register(w http.ResponseWriter, r *http.Request, id, tokenString
 
 	// generate config
 	conf := wsmux.Config{
-		StreamBufferSize: 4 * 1024,
+		StreamBufferSize: 4 * 1024 * 1024,
 		CloseCallback: func() {
 			p.removeTunnel(id)
 			if p.onSessionRemove != nil {


### PR DESCRIPTION
This will hopefully help with catching up on livelogs when reading from a task that has been started for a while.

