### PR TITLE
feat(livelog): Increase throughput for large logs

### DIFF
--- a/changelog/MWs5OgXtR2uC8EM9lHbdIg.md
+++ b/changelog/MWs5OgXtR2uC8EM9lHbdIg.md
@@ -1,0 +1,5 @@
+audience: users
+level: patch
+---
+
+Improved livelog streaming throughput by increasing read buffer to 64KB and event buffer to 1000 events

--- a/tools/livelog/writer/stream.go
+++ b/tools/livelog/writer/stream.go
@@ -8,7 +8,7 @@ import (
 	"sync"
 )
 
-const READ_BUFFER_SIZE = 4 * 1024 // XXX: 4kb chosen at random
+const READ_BUFFER_SIZE = 64 * 1024 // 64KB for better throughput
 
 type Event struct {
 	Number int

--- a/tools/livelog/writer/stream_handle.go
+++ b/tools/livelog/writer/stream_handle.go
@@ -7,7 +7,7 @@ import (
 	"os"
 )
 
-const EVENT_BUFFER_SIZE = 200
+const EVENT_BUFFER_SIZE = 1000
 
 type StreamHandle struct {
 	Start int64


### PR DESCRIPTION
This should theoretically improve streaming really big live logs. Websocktunnel was already upgraded to have 4Mb buffer size (#8114)


cc @Eijebong 