### PR TITLE
Fix early return in resolveTask sometimes skipping all-resolved dependents

### DIFF
--- a/changelog/issue-7829.md
+++ b/changelog/issue-7829.md
@@ -1,0 +1,7 @@
+audience: users
+level: patch
+reference: issue 7829
+---
+Fix a bug that prevented all-resolved tasks from getting scheduled if they
+depended on a task that was also part of an all-completed dependency and that
+all-completed task was processed before the all-resolved one

--- a/services/queue/src/dependencytracker.js
+++ b/services/queue/src/dependencytracker.js
@@ -184,7 +184,7 @@ class DependencyTracker {
           // dependency as satisfied if the 'require' relation is
           // 'all-resolved'.
           if (dep.requires !== 'all-resolved') {
-            return;
+            continue;
           }
         }
 


### PR DESCRIPTION


This fixes a regression from commit cd4a7ae7f82 where the code was changed to a for loop (from a .query()), which means that `return` changed semantic from skipping one dependent to skipping all remaining dependents.

This bug is very easily reproducible with the following graph:

- task A - fails
- task B - all-completed depends on A
- task C - all-resolved depends on A
- task B's ID is lexicographically ordered before C's (`get_dependent_tasks` returns task ordered by ID)

In that case, neither B or C would get scheduled even though C should be.

Fixes #7829