### PR TITLE
Increase the send buffer size on websocktunnel clients

### DIFF
--- a/changelog/HeIu4QqPR1K07E8TNfhv8w.md
+++ b/changelog/HeIu4QqPR1K07E8TNfhv8w.md
@@ -1,0 +1,4 @@
+audience: users
+level: patch
+---
+Increase the buffer size of websocktunnel on the worker side to make livelogs a lot faster

--- a/tools/websocktunnel/client/client.go
+++ b/tools/websocktunnel/client/client.go
@@ -85,7 +85,9 @@ func New(configurer Configurer) (*Client, error) {
 		return nil, err
 	}
 	cl.url.Store(url)
-	cl.session = wsmux.Client(conn, wsmux.Config{})
+	cl.session = wsmux.Client(conn, wsmux.Config{
+		StreamBufferSize: 4 * 1024 * 1024,
+	})
 	if cl.connectHook != nil {
 		cl.connectHook(cl)
 	}
@@ -256,7 +258,7 @@ func (c *Client) reconnect() {
 
 	sessionConfig := wsmux.Config{
 		// Log:              c.logger,
-		StreamBufferSize: 4 * 1024,
+		StreamBufferSize: 4 * 1024 * 1024,
 	}
 	c.session = wsmux.Client(conn, sessionConfig)
 	c.url.Store(url)


### PR DESCRIPTION
Without this, the client has a 4kB default buffer size which it sends and then awaits an ACK before sending another buffer... (that's still the case with this but at least it's sending a maximum of 4MB of data every time)

I tested this with 100ms delay both sides on websocktunnel and it went from ~500 lines/s to 60k lines/s with `- head -c 100000000 /dev/urandom | base64 && sleep 30` while catching up which should be more than enough.