### PR TITLE
Use proper URL encoding in the go client for path parameters

### DIFF
--- a/changelog/issue-7765.md
+++ b/changelog/issue-7765.md
@@ -1,0 +1,5 @@
+audience: users
+level: major
+reference: issue 7765
+---
+Spaces in artifact names are now correctly preserved instead of being replaced with `+`

--- a/clients/client-go/codegenerator/model/api.go
+++ b/clients/client-go/codegenerator/model/api.go
@@ -347,10 +347,10 @@ func (entry *APIEntry) generateDirectMethod(apiName string) string {
 	content += queryCode
 	content += "\tcd := tcclient.Client(*" + entry.Parent.apiDef.ExampleVarName + ")\n"
 	if entry.OutputURL != "" {
-		content += "\tresponseObject, _, err := (&cd).APICall(" + apiArgsPayload + ", \"" + strings.ToUpper(entry.Method) + "\", \"" + strings.ReplaceAll(strings.ReplaceAll(entry.Route, "<", "\" + url.QueryEscape("), ">", ") + \"") + "\", new(" + entry.Parent.apiDef.schemas.SubSchema(entry.OutputURL).TypeName + "), " + queryExpr + ")\n"
+		content += "\tresponseObject, _, err := (&cd).APICall(" + apiArgsPayload + ", \"" + strings.ToUpper(entry.Method) + "\", \"" + strings.ReplaceAll(strings.ReplaceAll(entry.Route, "<", "\" + url.PathEscape("), ">", ") + \"") + "\", new(" + entry.Parent.apiDef.schemas.SubSchema(entry.OutputURL).TypeName + "), " + queryExpr + ")\n"
 		content += "\treturn responseObject.(*" + entry.Parent.apiDef.schemas.SubSchema(entry.OutputURL).TypeName + "), err\n"
 	} else {
-		content += "\t_, _, err := (&cd).APICall(" + apiArgsPayload + ", \"" + strings.ToUpper(entry.Method) + "\", \"" + strings.ReplaceAll(strings.ReplaceAll(entry.Route, "<", "\" + url.QueryEscape("), ">", ") + \"") + "\", nil, " + queryExpr + ")\n"
+		content += "\t_, _, err := (&cd).APICall(" + apiArgsPayload + ", \"" + strings.ToUpper(entry.Method) + "\", \"" + strings.ReplaceAll(strings.ReplaceAll(entry.Route, "<", "\" + url.PathEscape("), ">", ") + \"") + "\", nil, " + queryExpr + ")\n"
 		content += "\treturn err\n"
 	}
 	content += "}\n"
@@ -385,7 +385,7 @@ func (entry *APIEntry) generateSignedURLMethod(apiName string) string {
 	content += "func (" + entry.Parent.apiDef.ExampleVarName + " *" + entry.Parent.Name() + ") " + entry.MethodName + "_SignedURL(" + inputParams + ") (*url.URL, error) {\n"
 	content += queryCode
 	content += "\tcd := tcclient.Client(*" + entry.Parent.apiDef.ExampleVarName + ")\n"
-	content += "\treturn (&cd).SignedURL(\"" + strings.ReplaceAll(strings.ReplaceAll(entry.Route, "<", "\" + url.QueryEscape("), ">", ") + \"") + "\", " + queryExpr + ", duration)\n"
+	content += "\treturn (&cd).SignedURL(\"" + strings.ReplaceAll(strings.ReplaceAll(entry.Route, "<", "\" + url.PathEscape("), ">", ") + \"") + "\", " + queryExpr + ", duration)\n"
 	content += "}\n"
 	content += "\n"
 	// can remove any code that added an empty string to another string

--- a/clients/client-go/tcauth/tcauth.go
+++ b/clients/client-go/tcauth/tcauth.go
@@ -191,7 +191,7 @@ func (auth *Auth) ListClients_SignedURL(continuationToken, limit, prefix string,
 // See #client
 func (auth *Auth) Client(clientId string) (*GetClientResponse, error) {
 	cd := tcclient.Client(*auth)
-	responseObject, _, err := (&cd).APICall(nil, "GET", "/clients/"+url.QueryEscape(clientId), new(GetClientResponse), nil)
+	responseObject, _, err := (&cd).APICall(nil, "GET", "/clients/"+url.PathEscape(clientId), new(GetClientResponse), nil)
 	return responseObject.(*GetClientResponse), err
 }
 
@@ -204,7 +204,7 @@ func (auth *Auth) Client(clientId string) (*GetClientResponse, error) {
 // See Client for more details.
 func (auth *Auth) Client_SignedURL(clientId string, duration time.Duration) (*url.URL, error) {
 	cd := tcclient.Client(*auth)
-	return (&cd).SignedURL("/clients/"+url.QueryEscape(clientId), nil, duration)
+	return (&cd).SignedURL("/clients/"+url.PathEscape(clientId), nil, duration)
 }
 
 // Create a new client and get the `accessToken` for this client.
@@ -229,7 +229,7 @@ func (auth *Auth) Client_SignedURL(clientId string, duration time.Duration) (*ur
 // See #createClient
 func (auth *Auth) CreateClient(clientId string, payload *CreateClientRequest) (*CreateClientResponse, error) {
 	cd := tcclient.Client(*auth)
-	responseObject, _, err := (&cd).APICall(payload, "PUT", "/clients/"+url.QueryEscape(clientId), new(CreateClientResponse), nil)
+	responseObject, _, err := (&cd).APICall(payload, "PUT", "/clients/"+url.PathEscape(clientId), new(CreateClientResponse), nil)
 	return responseObject.(*CreateClientResponse), err
 }
 
@@ -249,7 +249,7 @@ func (auth *Auth) GetEntityHistory(entityType, entityId, continuationToken, limi
 		v.Add("limit", limit)
 	}
 	cd := tcclient.Client(*auth)
-	responseObject, _, err := (&cd).APICall(nil, "GET", "/audit/"+url.QueryEscape(entityType)+"/"+url.QueryEscape(entityId), new(GetEntityHistoryResponse), v)
+	responseObject, _, err := (&cd).APICall(nil, "GET", "/audit/"+url.PathEscape(entityType)+"/"+url.PathEscape(entityId), new(GetEntityHistoryResponse), v)
 	return responseObject.(*GetEntityHistoryResponse), err
 }
 
@@ -269,7 +269,7 @@ func (auth *Auth) GetEntityHistory_SignedURL(entityType, entityId, continuationT
 		v.Add("limit", limit)
 	}
 	cd := tcclient.Client(*auth)
-	return (&cd).SignedURL("/audit/"+url.QueryEscape(entityType)+"/"+url.QueryEscape(entityId), v, duration)
+	return (&cd).SignedURL("/audit/"+url.PathEscape(entityType)+"/"+url.PathEscape(entityId), v, duration)
 }
 
 // Get audit history of a client based on clientId.
@@ -288,7 +288,7 @@ func (auth *Auth) ListAuditHistory(clientId, continuationToken, limit string) (*
 		v.Add("limit", limit)
 	}
 	cd := tcclient.Client(*auth)
-	responseObject, _, err := (&cd).APICall(nil, "GET", "/clients/"+url.QueryEscape(clientId)+"/audit", new(GetEntityHistoryResponse), v)
+	responseObject, _, err := (&cd).APICall(nil, "GET", "/clients/"+url.PathEscape(clientId)+"/audit", new(GetEntityHistoryResponse), v)
 	return responseObject.(*GetEntityHistoryResponse), err
 }
 
@@ -308,7 +308,7 @@ func (auth *Auth) ListAuditHistory_SignedURL(clientId, continuationToken, limit 
 		v.Add("limit", limit)
 	}
 	cd := tcclient.Client(*auth)
-	return (&cd).SignedURL("/clients/"+url.QueryEscape(clientId)+"/audit", v, duration)
+	return (&cd).SignedURL("/clients/"+url.PathEscape(clientId)+"/audit", v, duration)
 }
 
 // Reset a clients `accessToken`, this will revoke the existing
@@ -325,7 +325,7 @@ func (auth *Auth) ListAuditHistory_SignedURL(clientId, continuationToken, limit 
 // See #resetAccessToken
 func (auth *Auth) ResetAccessToken(clientId string) (*CreateClientResponse, error) {
 	cd := tcclient.Client(*auth)
-	responseObject, _, err := (&cd).APICall(nil, "POST", "/clients/"+url.QueryEscape(clientId)+"/reset", new(CreateClientResponse), nil)
+	responseObject, _, err := (&cd).APICall(nil, "POST", "/clients/"+url.PathEscape(clientId)+"/reset", new(CreateClientResponse), nil)
 	return responseObject.(*CreateClientResponse), err
 }
 
@@ -344,7 +344,7 @@ func (auth *Auth) ResetAccessToken(clientId string) (*CreateClientResponse, erro
 // See #updateClient
 func (auth *Auth) UpdateClient(clientId string, payload *CreateClientRequest) (*GetClientResponse, error) {
 	cd := tcclient.Client(*auth)
-	responseObject, _, err := (&cd).APICall(payload, "POST", "/clients/"+url.QueryEscape(clientId), new(GetClientResponse), nil)
+	responseObject, _, err := (&cd).APICall(payload, "POST", "/clients/"+url.PathEscape(clientId), new(GetClientResponse), nil)
 	return responseObject.(*GetClientResponse), err
 }
 
@@ -361,7 +361,7 @@ func (auth *Auth) UpdateClient(clientId string, payload *CreateClientRequest) (*
 // See #enableClient
 func (auth *Auth) EnableClient(clientId string) (*GetClientResponse, error) {
 	cd := tcclient.Client(*auth)
-	responseObject, _, err := (&cd).APICall(nil, "POST", "/clients/"+url.QueryEscape(clientId)+"/enable", new(GetClientResponse), nil)
+	responseObject, _, err := (&cd).APICall(nil, "POST", "/clients/"+url.PathEscape(clientId)+"/enable", new(GetClientResponse), nil)
 	return responseObject.(*GetClientResponse), err
 }
 
@@ -377,7 +377,7 @@ func (auth *Auth) EnableClient(clientId string) (*GetClientResponse, error) {
 // See #disableClient
 func (auth *Auth) DisableClient(clientId string) (*GetClientResponse, error) {
 	cd := tcclient.Client(*auth)
-	responseObject, _, err := (&cd).APICall(nil, "POST", "/clients/"+url.QueryEscape(clientId)+"/disable", new(GetClientResponse), nil)
+	responseObject, _, err := (&cd).APICall(nil, "POST", "/clients/"+url.PathEscape(clientId)+"/disable", new(GetClientResponse), nil)
 	return responseObject.(*GetClientResponse), err
 }
 
@@ -391,7 +391,7 @@ func (auth *Auth) DisableClient(clientId string) (*GetClientResponse, error) {
 // See #deleteClient
 func (auth *Auth) DeleteClient(clientId string) error {
 	cd := tcclient.Client(*auth)
-	_, _, err := (&cd).APICall(nil, "DELETE", "/clients/"+url.QueryEscape(clientId), nil, nil)
+	_, _, err := (&cd).APICall(nil, "DELETE", "/clients/"+url.PathEscape(clientId), nil, nil)
 	return err
 }
 
@@ -522,7 +522,7 @@ func (auth *Auth) ListRoleIds_SignedURL(continuationToken, limit string, duratio
 // See #role
 func (auth *Auth) Role(roleId string) (*GetRoleResponse, error) {
 	cd := tcclient.Client(*auth)
-	responseObject, _, err := (&cd).APICall(nil, "GET", "/roles/"+url.QueryEscape(roleId), new(GetRoleResponse), nil)
+	responseObject, _, err := (&cd).APICall(nil, "GET", "/roles/"+url.PathEscape(roleId), new(GetRoleResponse), nil)
 	return responseObject.(*GetRoleResponse), err
 }
 
@@ -535,7 +535,7 @@ func (auth *Auth) Role(roleId string) (*GetRoleResponse, error) {
 // See Role for more details.
 func (auth *Auth) Role_SignedURL(roleId string, duration time.Duration) (*url.URL, error) {
 	cd := tcclient.Client(*auth)
-	return (&cd).SignedURL("/roles/"+url.QueryEscape(roleId), nil, duration)
+	return (&cd).SignedURL("/roles/"+url.PathEscape(roleId), nil, duration)
 }
 
 // Create a new role.
@@ -557,7 +557,7 @@ func (auth *Auth) Role_SignedURL(roleId string, duration time.Duration) (*url.UR
 // See #createRole
 func (auth *Auth) CreateRole(roleId string, payload *CreateRoleRequest) (*GetRoleResponse, error) {
 	cd := tcclient.Client(*auth)
-	responseObject, _, err := (&cd).APICall(payload, "PUT", "/roles/"+url.QueryEscape(roleId), new(GetRoleResponse), nil)
+	responseObject, _, err := (&cd).APICall(payload, "PUT", "/roles/"+url.PathEscape(roleId), new(GetRoleResponse), nil)
 	return responseObject.(*GetRoleResponse), err
 }
 
@@ -578,7 +578,7 @@ func (auth *Auth) CreateRole(roleId string, payload *CreateRoleRequest) (*GetRol
 // See #updateRole
 func (auth *Auth) UpdateRole(roleId string, payload *CreateRoleRequest) (*GetRoleResponse, error) {
 	cd := tcclient.Client(*auth)
-	responseObject, _, err := (&cd).APICall(payload, "POST", "/roles/"+url.QueryEscape(roleId), new(GetRoleResponse), nil)
+	responseObject, _, err := (&cd).APICall(payload, "POST", "/roles/"+url.PathEscape(roleId), new(GetRoleResponse), nil)
 	return responseObject.(*GetRoleResponse), err
 }
 
@@ -592,7 +592,7 @@ func (auth *Auth) UpdateRole(roleId string, payload *CreateRoleRequest) (*GetRol
 // See #deleteRole
 func (auth *Auth) DeleteRole(roleId string) error {
 	cd := tcclient.Client(*auth)
-	_, _, err := (&cd).APICall(nil, "DELETE", "/roles/"+url.QueryEscape(roleId), nil, nil)
+	_, _, err := (&cd).APICall(nil, "DELETE", "/roles/"+url.PathEscape(roleId), nil, nil)
 	return err
 }
 
@@ -688,7 +688,7 @@ func (auth *Auth) AwsS3Credentials(level, bucket, prefix, format string) (*AWSS3
 		v.Add("format", format)
 	}
 	cd := tcclient.Client(*auth)
-	responseObject, _, err := (&cd).APICall(nil, "GET", "/aws/s3/"+url.QueryEscape(level)+"/"+url.QueryEscape(bucket)+"/"+url.QueryEscape(prefix), new(AWSS3CredentialsResponse), v)
+	responseObject, _, err := (&cd).APICall(nil, "GET", "/aws/s3/"+url.PathEscape(level)+"/"+url.PathEscape(bucket)+"/"+url.PathEscape(prefix), new(AWSS3CredentialsResponse), v)
 	return responseObject.(*AWSS3CredentialsResponse), err
 }
 
@@ -708,7 +708,7 @@ func (auth *Auth) AwsS3Credentials_SignedURL(level, bucket, prefix, format strin
 		v.Add("format", format)
 	}
 	cd := tcclient.Client(*auth)
-	return (&cd).SignedURL("/aws/s3/"+url.QueryEscape(level)+"/"+url.QueryEscape(bucket)+"/"+url.QueryEscape(prefix), v, duration)
+	return (&cd).SignedURL("/aws/s3/"+url.PathEscape(level)+"/"+url.PathEscape(bucket)+"/"+url.PathEscape(prefix), v, duration)
 }
 
 // Stability: *** DEPRECATED ***
@@ -753,7 +753,7 @@ func (auth *Auth) AzureTables(account, continuationToken string) (*AzureListTabl
 		v.Add("continuationToken", continuationToken)
 	}
 	cd := tcclient.Client(*auth)
-	responseObject, _, err := (&cd).APICall(nil, "GET", "/azure/"+url.QueryEscape(account)+"/tables", new(AzureListTableResponse), v)
+	responseObject, _, err := (&cd).APICall(nil, "GET", "/azure/"+url.PathEscape(account)+"/tables", new(AzureListTableResponse), v)
 	return responseObject.(*AzureListTableResponse), err
 }
 
@@ -770,7 +770,7 @@ func (auth *Auth) AzureTables_SignedURL(account, continuationToken string, durat
 		v.Add("continuationToken", continuationToken)
 	}
 	cd := tcclient.Client(*auth)
-	return (&cd).SignedURL("/azure/"+url.QueryEscape(account)+"/tables", v, duration)
+	return (&cd).SignedURL("/azure/"+url.PathEscape(account)+"/tables", v, duration)
 }
 
 // Stability: *** DEPRECATED ***
@@ -792,7 +792,7 @@ func (auth *Auth) AzureTables_SignedURL(account, continuationToken string, durat
 // See #azureTableSAS
 func (auth *Auth) AzureTableSAS(account, table, level string) (*AzureTableSharedAccessSignature, error) {
 	cd := tcclient.Client(*auth)
-	responseObject, _, err := (&cd).APICall(nil, "GET", "/azure/"+url.QueryEscape(account)+"/table/"+url.QueryEscape(table)+"/"+url.QueryEscape(level), new(AzureTableSharedAccessSignature), nil)
+	responseObject, _, err := (&cd).APICall(nil, "GET", "/azure/"+url.PathEscape(account)+"/table/"+url.PathEscape(table)+"/"+url.PathEscape(level), new(AzureTableSharedAccessSignature), nil)
 	return responseObject.(*AzureTableSharedAccessSignature), err
 }
 
@@ -808,7 +808,7 @@ func (auth *Auth) AzureTableSAS(account, table, level string) (*AzureTableShared
 // See AzureTableSAS for more details.
 func (auth *Auth) AzureTableSAS_SignedURL(account, table, level string, duration time.Duration) (*url.URL, error) {
 	cd := tcclient.Client(*auth)
-	return (&cd).SignedURL("/azure/"+url.QueryEscape(account)+"/table/"+url.QueryEscape(table)+"/"+url.QueryEscape(level), nil, duration)
+	return (&cd).SignedURL("/azure/"+url.PathEscape(account)+"/table/"+url.PathEscape(table)+"/"+url.PathEscape(level), nil, duration)
 }
 
 // Stability: *** DEPRECATED ***
@@ -826,7 +826,7 @@ func (auth *Auth) AzureContainers(account, continuationToken string) (*AzureList
 		v.Add("continuationToken", continuationToken)
 	}
 	cd := tcclient.Client(*auth)
-	responseObject, _, err := (&cd).APICall(nil, "GET", "/azure/"+url.QueryEscape(account)+"/containers", new(AzureListContainersResponse), v)
+	responseObject, _, err := (&cd).APICall(nil, "GET", "/azure/"+url.PathEscape(account)+"/containers", new(AzureListContainersResponse), v)
 	return responseObject.(*AzureListContainersResponse), err
 }
 
@@ -843,7 +843,7 @@ func (auth *Auth) AzureContainers_SignedURL(account, continuationToken string, d
 		v.Add("continuationToken", continuationToken)
 	}
 	cd := tcclient.Client(*auth)
-	return (&cd).SignedURL("/azure/"+url.QueryEscape(account)+"/containers", v, duration)
+	return (&cd).SignedURL("/azure/"+url.PathEscape(account)+"/containers", v, duration)
 }
 
 // Stability: *** DEPRECATED ***
@@ -865,7 +865,7 @@ func (auth *Auth) AzureContainers_SignedURL(account, continuationToken string, d
 // See #azureContainerSAS
 func (auth *Auth) AzureContainerSAS(account, container, level string) (*AzureBlobSharedAccessSignature, error) {
 	cd := tcclient.Client(*auth)
-	responseObject, _, err := (&cd).APICall(nil, "GET", "/azure/"+url.QueryEscape(account)+"/containers/"+url.QueryEscape(container)+"/"+url.QueryEscape(level), new(AzureBlobSharedAccessSignature), nil)
+	responseObject, _, err := (&cd).APICall(nil, "GET", "/azure/"+url.PathEscape(account)+"/containers/"+url.PathEscape(container)+"/"+url.PathEscape(level), new(AzureBlobSharedAccessSignature), nil)
 	return responseObject.(*AzureBlobSharedAccessSignature), err
 }
 
@@ -881,7 +881,7 @@ func (auth *Auth) AzureContainerSAS(account, container, level string) (*AzureBlo
 // See AzureContainerSAS for more details.
 func (auth *Auth) AzureContainerSAS_SignedURL(account, container, level string, duration time.Duration) (*url.URL, error) {
 	cd := tcclient.Client(*auth)
-	return (&cd).SignedURL("/azure/"+url.QueryEscape(account)+"/containers/"+url.QueryEscape(container)+"/"+url.QueryEscape(level), nil, duration)
+	return (&cd).SignedURL("/azure/"+url.PathEscape(account)+"/containers/"+url.PathEscape(container)+"/"+url.PathEscape(level), nil, duration)
 }
 
 // Get temporary DSN (access credentials) for a sentry project.
@@ -899,7 +899,7 @@ func (auth *Auth) AzureContainerSAS_SignedURL(account, container, level string, 
 // See #sentryDSN
 func (auth *Auth) SentryDSN(project string) (*SentryDSNResponse, error) {
 	cd := tcclient.Client(*auth)
-	responseObject, _, err := (&cd).APICall(nil, "GET", "/sentry/"+url.QueryEscape(project)+"/dsn", new(SentryDSNResponse), nil)
+	responseObject, _, err := (&cd).APICall(nil, "GET", "/sentry/"+url.PathEscape(project)+"/dsn", new(SentryDSNResponse), nil)
 	return responseObject.(*SentryDSNResponse), err
 }
 
@@ -912,7 +912,7 @@ func (auth *Auth) SentryDSN(project string) (*SentryDSNResponse, error) {
 // See SentryDSN for more details.
 func (auth *Auth) SentryDSN_SignedURL(project string, duration time.Duration) (*url.URL, error) {
 	cd := tcclient.Client(*auth)
-	return (&cd).SignedURL("/sentry/"+url.QueryEscape(project)+"/dsn", nil, duration)
+	return (&cd).SignedURL("/sentry/"+url.PathEscape(project)+"/dsn", nil, duration)
 }
 
 // Get a temporary token suitable for use connecting to a
@@ -933,7 +933,7 @@ func (auth *Auth) SentryDSN_SignedURL(project string, duration time.Duration) (*
 // See #websocktunnelToken
 func (auth *Auth) WebsocktunnelToken(wstAudience, wstClient string) (*WebsocktunnelTokenResponse, error) {
 	cd := tcclient.Client(*auth)
-	responseObject, _, err := (&cd).APICall(nil, "GET", "/websocktunnel/"+url.QueryEscape(wstAudience)+"/"+url.QueryEscape(wstClient), new(WebsocktunnelTokenResponse), nil)
+	responseObject, _, err := (&cd).APICall(nil, "GET", "/websocktunnel/"+url.PathEscape(wstAudience)+"/"+url.PathEscape(wstClient), new(WebsocktunnelTokenResponse), nil)
 	return responseObject.(*WebsocktunnelTokenResponse), err
 }
 
@@ -946,7 +946,7 @@ func (auth *Auth) WebsocktunnelToken(wstAudience, wstClient string) (*Websocktun
 // See WebsocktunnelToken for more details.
 func (auth *Auth) WebsocktunnelToken_SignedURL(wstAudience, wstClient string, duration time.Duration) (*url.URL, error) {
 	cd := tcclient.Client(*auth)
-	return (&cd).SignedURL("/websocktunnel/"+url.QueryEscape(wstAudience)+"/"+url.QueryEscape(wstClient), nil, duration)
+	return (&cd).SignedURL("/websocktunnel/"+url.PathEscape(wstAudience)+"/"+url.PathEscape(wstClient), nil, duration)
 }
 
 // Get temporary GCP credentials for the given serviceAccount in the given project.
@@ -966,7 +966,7 @@ func (auth *Auth) WebsocktunnelToken_SignedURL(wstAudience, wstClient string, du
 // See #gcpCredentials
 func (auth *Auth) GcpCredentials(projectId, serviceAccount string) (*GCPCredentialsResponse, error) {
 	cd := tcclient.Client(*auth)
-	responseObject, _, err := (&cd).APICall(nil, "GET", "/gcp/credentials/"+url.QueryEscape(projectId)+"/"+url.QueryEscape(serviceAccount), new(GCPCredentialsResponse), nil)
+	responseObject, _, err := (&cd).APICall(nil, "GET", "/gcp/credentials/"+url.PathEscape(projectId)+"/"+url.PathEscape(serviceAccount), new(GCPCredentialsResponse), nil)
 	return responseObject.(*GCPCredentialsResponse), err
 }
 
@@ -979,7 +979,7 @@ func (auth *Auth) GcpCredentials(projectId, serviceAccount string) (*GCPCredenti
 // See GcpCredentials for more details.
 func (auth *Auth) GcpCredentials_SignedURL(projectId, serviceAccount string, duration time.Duration) (*url.URL, error) {
 	cd := tcclient.Client(*auth)
-	return (&cd).SignedURL("/gcp/credentials/"+url.QueryEscape(projectId)+"/"+url.QueryEscape(serviceAccount), nil, duration)
+	return (&cd).SignedURL("/gcp/credentials/"+url.PathEscape(projectId)+"/"+url.PathEscape(serviceAccount), nil, duration)
 }
 
 // Validate the request signature given on input and return list of scopes

--- a/clients/client-go/tcgithub/tcgithub.go
+++ b/clients/client-go/tcgithub/tcgithub.go
@@ -212,7 +212,7 @@ func (github *Github) CancelBuilds(owner, repo, pullRequest, sha string) (*Build
 		v.Add("sha", sha)
 	}
 	cd := tcclient.Client(*github)
-	responseObject, _, err := (&cd).APICall(nil, "POST", "/builds/"+url.QueryEscape(owner)+"/"+url.QueryEscape(repo)+"/cancel", new(BuildsResponse), v)
+	responseObject, _, err := (&cd).APICall(nil, "POST", "/builds/"+url.PathEscape(owner)+"/"+url.PathEscape(repo)+"/cancel", new(BuildsResponse), v)
 	return responseObject.(*BuildsResponse), err
 }
 
@@ -228,7 +228,7 @@ func (github *Github) CancelBuilds(owner, repo, pullRequest, sha string) (*Build
 // See #badge
 func (github *Github) Badge(owner, repo, branch string) error {
 	cd := tcclient.Client(*github)
-	_, _, err := (&cd).APICall(nil, "GET", "/repository/"+url.QueryEscape(owner)+"/"+url.QueryEscape(repo)+"/"+url.QueryEscape(branch)+"/badge.svg", nil, nil)
+	_, _, err := (&cd).APICall(nil, "GET", "/repository/"+url.PathEscape(owner)+"/"+url.PathEscape(repo)+"/"+url.PathEscape(branch)+"/badge.svg", nil, nil)
 	return err
 }
 
@@ -241,7 +241,7 @@ func (github *Github) Badge(owner, repo, branch string) error {
 // See Badge for more details.
 func (github *Github) Badge_SignedURL(owner, repo, branch string, duration time.Duration) (*url.URL, error) {
 	cd := tcclient.Client(*github)
-	return (&cd).SignedURL("/repository/"+url.QueryEscape(owner)+"/"+url.QueryEscape(repo)+"/"+url.QueryEscape(branch)+"/badge.svg", nil, duration)
+	return (&cd).SignedURL("/repository/"+url.PathEscape(owner)+"/"+url.PathEscape(repo)+"/"+url.PathEscape(branch)+"/badge.svg", nil, duration)
 }
 
 // Stability: *** EXPERIMENTAL ***
@@ -256,7 +256,7 @@ func (github *Github) Badge_SignedURL(owner, repo, branch string, duration time.
 // See #repository
 func (github *Github) Repository(owner, repo string) (*RepositoryResponse, error) {
 	cd := tcclient.Client(*github)
-	responseObject, _, err := (&cd).APICall(nil, "GET", "/repository/"+url.QueryEscape(owner)+"/"+url.QueryEscape(repo), new(RepositoryResponse), nil)
+	responseObject, _, err := (&cd).APICall(nil, "GET", "/repository/"+url.PathEscape(owner)+"/"+url.PathEscape(repo), new(RepositoryResponse), nil)
 	return responseObject.(*RepositoryResponse), err
 }
 
@@ -269,7 +269,7 @@ func (github *Github) Repository(owner, repo string) (*RepositoryResponse, error
 // See Repository for more details.
 func (github *Github) Repository_SignedURL(owner, repo string, duration time.Duration) (*url.URL, error) {
 	cd := tcclient.Client(*github)
-	return (&cd).SignedURL("/repository/"+url.QueryEscape(owner)+"/"+url.QueryEscape(repo), nil, duration)
+	return (&cd).SignedURL("/repository/"+url.PathEscape(owner)+"/"+url.PathEscape(repo), nil, duration)
 }
 
 // For a given branch of a repository, this will always point
@@ -285,7 +285,7 @@ func (github *Github) Repository_SignedURL(owner, repo string, duration time.Dur
 // See #latest
 func (github *Github) Latest(owner, repo, branch string) error {
 	cd := tcclient.Client(*github)
-	_, _, err := (&cd).APICall(nil, "GET", "/repository/"+url.QueryEscape(owner)+"/"+url.QueryEscape(repo)+"/"+url.QueryEscape(branch)+"/latest", nil, nil)
+	_, _, err := (&cd).APICall(nil, "GET", "/repository/"+url.PathEscape(owner)+"/"+url.PathEscape(repo)+"/"+url.PathEscape(branch)+"/latest", nil, nil)
 	return err
 }
 
@@ -298,7 +298,7 @@ func (github *Github) Latest(owner, repo, branch string) error {
 // See Latest for more details.
 func (github *Github) Latest_SignedURL(owner, repo, branch string, duration time.Duration) (*url.URL, error) {
 	cd := tcclient.Client(*github)
-	return (&cd).SignedURL("/repository/"+url.QueryEscape(owner)+"/"+url.QueryEscape(repo)+"/"+url.QueryEscape(branch)+"/latest", nil, duration)
+	return (&cd).SignedURL("/repository/"+url.PathEscape(owner)+"/"+url.PathEscape(repo)+"/"+url.PathEscape(branch)+"/latest", nil, duration)
 }
 
 // Stability: *** EXPERIMENTAL ***
@@ -315,7 +315,7 @@ func (github *Github) Latest_SignedURL(owner, repo, branch string, duration time
 // See #createStatus
 func (github *Github) CreateStatus(owner, repo, sha string, payload *CreateStatusRequest) error {
 	cd := tcclient.Client(*github)
-	_, _, err := (&cd).APICall(payload, "POST", "/repository/"+url.QueryEscape(owner)+"/"+url.QueryEscape(repo)+"/statuses/"+url.QueryEscape(sha), nil, nil)
+	_, _, err := (&cd).APICall(payload, "POST", "/repository/"+url.PathEscape(owner)+"/"+url.PathEscape(repo)+"/statuses/"+url.PathEscape(sha), nil, nil)
 	return err
 }
 
@@ -328,7 +328,7 @@ func (github *Github) CreateStatus(owner, repo, sha string, payload *CreateStatu
 // See #createComment
 func (github *Github) CreateComment(owner, repo, number string, payload *CreateCommentRequest) error {
 	cd := tcclient.Client(*github)
-	_, _, err := (&cd).APICall(payload, "POST", "/repository/"+url.QueryEscape(owner)+"/"+url.QueryEscape(repo)+"/issues/"+url.QueryEscape(number)+"/comments", nil, nil)
+	_, _, err := (&cd).APICall(payload, "POST", "/repository/"+url.PathEscape(owner)+"/"+url.PathEscape(repo)+"/issues/"+url.PathEscape(number)+"/comments", nil, nil)
 	return err
 }
 

--- a/clients/client-go/tchooks/tchooks.go
+++ b/clients/client-go/tchooks/tchooks.go
@@ -159,7 +159,7 @@ func (hooks *Hooks) ListHookGroups_SignedURL(duration time.Duration) (*url.URL, 
 // See #listHooks
 func (hooks *Hooks) ListHooks(hookGroupId string) (*HookList, error) {
 	cd := tcclient.Client(*hooks)
-	responseObject, _, err := (&cd).APICall(nil, "GET", "/hooks/"+url.QueryEscape(hookGroupId), new(HookList), nil)
+	responseObject, _, err := (&cd).APICall(nil, "GET", "/hooks/"+url.PathEscape(hookGroupId), new(HookList), nil)
 	return responseObject.(*HookList), err
 }
 
@@ -172,7 +172,7 @@ func (hooks *Hooks) ListHooks(hookGroupId string) (*HookList, error) {
 // See ListHooks for more details.
 func (hooks *Hooks) ListHooks_SignedURL(hookGroupId string, duration time.Duration) (*url.URL, error) {
 	cd := tcclient.Client(*hooks)
-	return (&cd).SignedURL("/hooks/"+url.QueryEscape(hookGroupId), nil, duration)
+	return (&cd).SignedURL("/hooks/"+url.PathEscape(hookGroupId), nil, duration)
 }
 
 // This endpoint will return the hook definition for the given `hookGroupId`
@@ -185,7 +185,7 @@ func (hooks *Hooks) ListHooks_SignedURL(hookGroupId string, duration time.Durati
 // See #hook
 func (hooks *Hooks) Hook(hookGroupId, hookId string) (*HookDefinition, error) {
 	cd := tcclient.Client(*hooks)
-	responseObject, _, err := (&cd).APICall(nil, "GET", "/hooks/"+url.QueryEscape(hookGroupId)+"/"+url.QueryEscape(hookId), new(HookDefinition), nil)
+	responseObject, _, err := (&cd).APICall(nil, "GET", "/hooks/"+url.PathEscape(hookGroupId)+"/"+url.PathEscape(hookId), new(HookDefinition), nil)
 	return responseObject.(*HookDefinition), err
 }
 
@@ -198,7 +198,7 @@ func (hooks *Hooks) Hook(hookGroupId, hookId string) (*HookDefinition, error) {
 // See Hook for more details.
 func (hooks *Hooks) Hook_SignedURL(hookGroupId, hookId string, duration time.Duration) (*url.URL, error) {
 	cd := tcclient.Client(*hooks)
-	return (&cd).SignedURL("/hooks/"+url.QueryEscape(hookGroupId)+"/"+url.QueryEscape(hookId), nil, duration)
+	return (&cd).SignedURL("/hooks/"+url.PathEscape(hookGroupId)+"/"+url.PathEscape(hookId), nil, duration)
 }
 
 // Stability: *** DEPRECATED ***
@@ -215,7 +215,7 @@ func (hooks *Hooks) Hook_SignedURL(hookGroupId, hookId string, duration time.Dur
 // See #getHookStatus
 func (hooks *Hooks) GetHookStatus(hookGroupId, hookId string) (*HookStatusResponse, error) {
 	cd := tcclient.Client(*hooks)
-	responseObject, _, err := (&cd).APICall(nil, "GET", "/hooks/"+url.QueryEscape(hookGroupId)+"/"+url.QueryEscape(hookId)+"/status", new(HookStatusResponse), nil)
+	responseObject, _, err := (&cd).APICall(nil, "GET", "/hooks/"+url.PathEscape(hookGroupId)+"/"+url.PathEscape(hookId)+"/status", new(HookStatusResponse), nil)
 	return responseObject.(*HookStatusResponse), err
 }
 
@@ -228,7 +228,7 @@ func (hooks *Hooks) GetHookStatus(hookGroupId, hookId string) (*HookStatusRespon
 // See GetHookStatus for more details.
 func (hooks *Hooks) GetHookStatus_SignedURL(hookGroupId, hookId string, duration time.Duration) (*url.URL, error) {
 	cd := tcclient.Client(*hooks)
-	return (&cd).SignedURL("/hooks/"+url.QueryEscape(hookGroupId)+"/"+url.QueryEscape(hookId)+"/status", nil, duration)
+	return (&cd).SignedURL("/hooks/"+url.PathEscape(hookGroupId)+"/"+url.PathEscape(hookId)+"/status", nil, duration)
 }
 
 // This endpoint will create a new hook.
@@ -246,7 +246,7 @@ func (hooks *Hooks) GetHookStatus_SignedURL(hookGroupId, hookId string, duration
 // See #createHook
 func (hooks *Hooks) CreateHook(hookGroupId, hookId string, payload *HookCreationRequest) (*HookDefinition, error) {
 	cd := tcclient.Client(*hooks)
-	responseObject, _, err := (&cd).APICall(payload, "PUT", "/hooks/"+url.QueryEscape(hookGroupId)+"/"+url.QueryEscape(hookId), new(HookDefinition), nil)
+	responseObject, _, err := (&cd).APICall(payload, "PUT", "/hooks/"+url.PathEscape(hookGroupId)+"/"+url.PathEscape(hookId), new(HookDefinition), nil)
 	return responseObject.(*HookDefinition), err
 }
 
@@ -262,7 +262,7 @@ func (hooks *Hooks) CreateHook(hookGroupId, hookId string, payload *HookCreation
 // See #updateHook
 func (hooks *Hooks) UpdateHook(hookGroupId, hookId string, payload *HookCreationRequest) (*HookDefinition, error) {
 	cd := tcclient.Client(*hooks)
-	responseObject, _, err := (&cd).APICall(payload, "POST", "/hooks/"+url.QueryEscape(hookGroupId)+"/"+url.QueryEscape(hookId), new(HookDefinition), nil)
+	responseObject, _, err := (&cd).APICall(payload, "POST", "/hooks/"+url.PathEscape(hookGroupId)+"/"+url.PathEscape(hookId), new(HookDefinition), nil)
 	return responseObject.(*HookDefinition), err
 }
 
@@ -275,7 +275,7 @@ func (hooks *Hooks) UpdateHook(hookGroupId, hookId string, payload *HookCreation
 // See #removeHook
 func (hooks *Hooks) RemoveHook(hookGroupId, hookId string) error {
 	cd := tcclient.Client(*hooks)
-	_, _, err := (&cd).APICall(nil, "DELETE", "/hooks/"+url.QueryEscape(hookGroupId)+"/"+url.QueryEscape(hookId), nil, nil)
+	_, _, err := (&cd).APICall(nil, "DELETE", "/hooks/"+url.PathEscape(hookGroupId)+"/"+url.PathEscape(hookId), nil, nil)
 	return err
 }
 
@@ -292,7 +292,7 @@ func (hooks *Hooks) RemoveHook(hookGroupId, hookId string) error {
 // See #triggerHook
 func (hooks *Hooks) TriggerHook(hookGroupId, hookId string, payload *TriggerHookRequest) (*TriggerHookResponse, error) {
 	cd := tcclient.Client(*hooks)
-	responseObject, _, err := (&cd).APICall(payload, "POST", "/hooks/"+url.QueryEscape(hookGroupId)+"/"+url.QueryEscape(hookId)+"/trigger", new(TriggerHookResponse), nil)
+	responseObject, _, err := (&cd).APICall(payload, "POST", "/hooks/"+url.PathEscape(hookGroupId)+"/"+url.PathEscape(hookId)+"/trigger", new(TriggerHookResponse), nil)
 	return responseObject.(*TriggerHookResponse), err
 }
 
@@ -306,7 +306,7 @@ func (hooks *Hooks) TriggerHook(hookGroupId, hookId string, payload *TriggerHook
 // See #getTriggerToken
 func (hooks *Hooks) GetTriggerToken(hookGroupId, hookId string) (*TriggerTokenResponse, error) {
 	cd := tcclient.Client(*hooks)
-	responseObject, _, err := (&cd).APICall(nil, "GET", "/hooks/"+url.QueryEscape(hookGroupId)+"/"+url.QueryEscape(hookId)+"/token", new(TriggerTokenResponse), nil)
+	responseObject, _, err := (&cd).APICall(nil, "GET", "/hooks/"+url.PathEscape(hookGroupId)+"/"+url.PathEscape(hookId)+"/token", new(TriggerTokenResponse), nil)
 	return responseObject.(*TriggerTokenResponse), err
 }
 
@@ -319,7 +319,7 @@ func (hooks *Hooks) GetTriggerToken(hookGroupId, hookId string) (*TriggerTokenRe
 // See GetTriggerToken for more details.
 func (hooks *Hooks) GetTriggerToken_SignedURL(hookGroupId, hookId string, duration time.Duration) (*url.URL, error) {
 	cd := tcclient.Client(*hooks)
-	return (&cd).SignedURL("/hooks/"+url.QueryEscape(hookGroupId)+"/"+url.QueryEscape(hookId)+"/token", nil, duration)
+	return (&cd).SignedURL("/hooks/"+url.PathEscape(hookGroupId)+"/"+url.PathEscape(hookId)+"/token", nil, duration)
 }
 
 // Reset the token for triggering a given hook. This invalidates token that
@@ -332,7 +332,7 @@ func (hooks *Hooks) GetTriggerToken_SignedURL(hookGroupId, hookId string, durati
 // See #resetTriggerToken
 func (hooks *Hooks) ResetTriggerToken(hookGroupId, hookId string) (*TriggerTokenResponse, error) {
 	cd := tcclient.Client(*hooks)
-	responseObject, _, err := (&cd).APICall(nil, "POST", "/hooks/"+url.QueryEscape(hookGroupId)+"/"+url.QueryEscape(hookId)+"/token", new(TriggerTokenResponse), nil)
+	responseObject, _, err := (&cd).APICall(nil, "POST", "/hooks/"+url.PathEscape(hookGroupId)+"/"+url.PathEscape(hookId)+"/token", new(TriggerTokenResponse), nil)
 	return responseObject.(*TriggerTokenResponse), err
 }
 
@@ -345,7 +345,7 @@ func (hooks *Hooks) ResetTriggerToken(hookGroupId, hookId string) (*TriggerToken
 // See #triggerHookWithToken
 func (hooks *Hooks) TriggerHookWithToken(hookGroupId, hookId, token string, payload *TriggerHookRequest) (*TriggerHookResponse, error) {
 	cd := tcclient.Client(*hooks)
-	responseObject, _, err := (&cd).APICall(payload, "POST", "/hooks/"+url.QueryEscape(hookGroupId)+"/"+url.QueryEscape(hookId)+"/trigger/"+url.QueryEscape(token), new(TriggerHookResponse), nil)
+	responseObject, _, err := (&cd).APICall(payload, "POST", "/hooks/"+url.PathEscape(hookGroupId)+"/"+url.PathEscape(hookId)+"/trigger/"+url.PathEscape(token), new(TriggerHookResponse), nil)
 	return responseObject.(*TriggerHookResponse), err
 }
 
@@ -368,7 +368,7 @@ func (hooks *Hooks) ListLastFires(hookGroupId, hookId, continuationToken, limit 
 		v.Add("limit", limit)
 	}
 	cd := tcclient.Client(*hooks)
-	responseObject, _, err := (&cd).APICall(nil, "GET", "/hooks/"+url.QueryEscape(hookGroupId)+"/"+url.QueryEscape(hookId)+"/last-fires", new(LastFiresList), v)
+	responseObject, _, err := (&cd).APICall(nil, "GET", "/hooks/"+url.PathEscape(hookGroupId)+"/"+url.PathEscape(hookId)+"/last-fires", new(LastFiresList), v)
 	return responseObject.(*LastFiresList), err
 }
 
@@ -388,7 +388,7 @@ func (hooks *Hooks) ListLastFires_SignedURL(hookGroupId, hookId, continuationTok
 		v.Add("limit", limit)
 	}
 	cd := tcclient.Client(*hooks)
-	return (&cd).SignedURL("/hooks/"+url.QueryEscape(hookGroupId)+"/"+url.QueryEscape(hookId)+"/last-fires", v, duration)
+	return (&cd).SignedURL("/hooks/"+url.PathEscape(hookGroupId)+"/"+url.PathEscape(hookId)+"/last-fires", v, duration)
 }
 
 // Respond with a service heartbeat.

--- a/clients/client-go/tcindex/tcindex.go
+++ b/clients/client-go/tcindex/tcindex.go
@@ -140,7 +140,7 @@ func (index *Index) Version() error {
 // See #findTask
 func (index *Index) FindTask(indexPath string) (*IndexedTaskResponse, error) {
 	cd := tcclient.Client(*index)
-	responseObject, _, err := (&cd).APICall(nil, "GET", "/task/"+url.QueryEscape(indexPath), new(IndexedTaskResponse), nil)
+	responseObject, _, err := (&cd).APICall(nil, "GET", "/task/"+url.PathEscape(indexPath), new(IndexedTaskResponse), nil)
 	return responseObject.(*IndexedTaskResponse), err
 }
 
@@ -153,7 +153,7 @@ func (index *Index) FindTask(indexPath string) (*IndexedTaskResponse, error) {
 // See FindTask for more details.
 func (index *Index) FindTask_SignedURL(indexPath string, duration time.Duration) (*url.URL, error) {
 	cd := tcclient.Client(*index)
-	return (&cd).SignedURL("/task/"+url.QueryEscape(indexPath), nil, duration)
+	return (&cd).SignedURL("/task/"+url.PathEscape(indexPath), nil, duration)
 }
 
 // Stability: *** EXPERIMENTAL ***
@@ -206,7 +206,7 @@ func (index *Index) ListNamespaces(namespace, continuationToken, limit string) (
 		v.Add("limit", limit)
 	}
 	cd := tcclient.Client(*index)
-	responseObject, _, err := (&cd).APICall(nil, "GET", "/namespaces/"+url.QueryEscape(namespace), new(ListNamespacesResponse), v)
+	responseObject, _, err := (&cd).APICall(nil, "GET", "/namespaces/"+url.PathEscape(namespace), new(ListNamespacesResponse), v)
 	return responseObject.(*ListNamespacesResponse), err
 }
 
@@ -226,7 +226,7 @@ func (index *Index) ListNamespaces_SignedURL(namespace, continuationToken, limit
 		v.Add("limit", limit)
 	}
 	cd := tcclient.Client(*index)
-	return (&cd).SignedURL("/namespaces/"+url.QueryEscape(namespace), v, duration)
+	return (&cd).SignedURL("/namespaces/"+url.PathEscape(namespace), v, duration)
 }
 
 // List the tasks immediately under a given namespace.
@@ -254,7 +254,7 @@ func (index *Index) ListTasks(namespace, continuationToken, limit string) (*List
 		v.Add("limit", limit)
 	}
 	cd := tcclient.Client(*index)
-	responseObject, _, err := (&cd).APICall(nil, "GET", "/tasks/"+url.QueryEscape(namespace), new(ListTasksResponse), v)
+	responseObject, _, err := (&cd).APICall(nil, "GET", "/tasks/"+url.PathEscape(namespace), new(ListTasksResponse), v)
 	return responseObject.(*ListTasksResponse), err
 }
 
@@ -274,7 +274,7 @@ func (index *Index) ListTasks_SignedURL(namespace, continuationToken, limit stri
 		v.Add("limit", limit)
 	}
 	cd := tcclient.Client(*index)
-	return (&cd).SignedURL("/tasks/"+url.QueryEscape(namespace), v, duration)
+	return (&cd).SignedURL("/tasks/"+url.PathEscape(namespace), v, duration)
 }
 
 // Insert a task into the index.  If the new rank is less than the existing rank
@@ -290,7 +290,7 @@ func (index *Index) ListTasks_SignedURL(namespace, continuationToken, limit stri
 // See #insertTask
 func (index *Index) InsertTask(namespace string, payload *InsertTaskRequest) (*IndexedTaskResponse, error) {
 	cd := tcclient.Client(*index)
-	responseObject, _, err := (&cd).APICall(payload, "PUT", "/task/"+url.QueryEscape(namespace), new(IndexedTaskResponse), nil)
+	responseObject, _, err := (&cd).APICall(payload, "PUT", "/task/"+url.PathEscape(namespace), new(IndexedTaskResponse), nil)
 	return responseObject.(*IndexedTaskResponse), err
 }
 
@@ -306,7 +306,7 @@ func (index *Index) InsertTask(namespace string, payload *InsertTaskRequest) (*I
 // See #deleteTask
 func (index *Index) DeleteTask(namespace string) error {
 	cd := tcclient.Client(*index)
-	_, _, err := (&cd).APICall(nil, "DELETE", "/task/"+url.QueryEscape(namespace), nil, nil)
+	_, _, err := (&cd).APICall(nil, "DELETE", "/task/"+url.PathEscape(namespace), nil, nil)
 	return err
 }
 
@@ -332,7 +332,7 @@ func (index *Index) DeleteTask(namespace string) error {
 // See #findArtifactFromTask
 func (index *Index) FindArtifactFromTask(indexPath, name string) error {
 	cd := tcclient.Client(*index)
-	_, _, err := (&cd).APICall(nil, "GET", "/task/"+url.QueryEscape(indexPath)+"/artifacts/"+url.QueryEscape(name), nil, nil)
+	_, _, err := (&cd).APICall(nil, "GET", "/task/"+url.PathEscape(indexPath)+"/artifacts/"+url.PathEscape(name), nil, nil)
 	return err
 }
 
@@ -345,7 +345,7 @@ func (index *Index) FindArtifactFromTask(indexPath, name string) error {
 // See FindArtifactFromTask for more details.
 func (index *Index) FindArtifactFromTask_SignedURL(indexPath, name string, duration time.Duration) (*url.URL, error) {
 	cd := tcclient.Client(*index)
-	return (&cd).SignedURL("/task/"+url.QueryEscape(indexPath)+"/artifacts/"+url.QueryEscape(name), nil, duration)
+	return (&cd).SignedURL("/task/"+url.PathEscape(indexPath)+"/artifacts/"+url.PathEscape(name), nil, duration)
 }
 
 // Respond with a service heartbeat.

--- a/clients/client-go/tcobject/tcobject.go
+++ b/clients/client-go/tcobject/tcobject.go
@@ -154,7 +154,7 @@ func (object *Object) Version() error {
 // See #createUpload
 func (object *Object) CreateUpload(name string, payload *CreateUploadRequest) (*CreateUploadResponse, error) {
 	cd := tcclient.Client(*object)
-	responseObject, _, err := (&cd).APICall(payload, "PUT", "/upload/"+url.QueryEscape(name), new(CreateUploadResponse), nil)
+	responseObject, _, err := (&cd).APICall(payload, "PUT", "/upload/"+url.PathEscape(name), new(CreateUploadResponse), nil)
 	return responseObject.(*CreateUploadResponse), err
 }
 
@@ -177,7 +177,7 @@ func (object *Object) CreateUpload(name string, payload *CreateUploadRequest) (*
 // See #finishUpload
 func (object *Object) FinishUpload(name string, payload *FinishUploadRequest) error {
 	cd := tcclient.Client(*object)
-	_, _, err := (&cd).APICall(payload, "POST", "/finish-upload/"+url.QueryEscape(name), nil, nil)
+	_, _, err := (&cd).APICall(payload, "POST", "/finish-upload/"+url.PathEscape(name), nil, nil)
 	return err
 }
 
@@ -195,7 +195,7 @@ func (object *Object) FinishUpload(name string, payload *FinishUploadRequest) er
 // See #startDownload
 func (object *Object) StartDownload(name string, payload *DownloadObjectRequest) (*DownloadObjectResponse, error) {
 	cd := tcclient.Client(*object)
-	responseObject, _, err := (&cd).APICall(payload, "PUT", "/start-download/"+url.QueryEscape(name), new(DownloadObjectResponse), nil)
+	responseObject, _, err := (&cd).APICall(payload, "PUT", "/start-download/"+url.PathEscape(name), new(DownloadObjectResponse), nil)
 	return responseObject.(*DownloadObjectResponse), err
 }
 
@@ -209,7 +209,7 @@ func (object *Object) StartDownload(name string, payload *DownloadObjectRequest)
 // See #object
 func (object *Object) Object(name string) (*ObjectMetadata, error) {
 	cd := tcclient.Client(*object)
-	responseObject, _, err := (&cd).APICall(nil, "GET", "/metadata/"+url.QueryEscape(name), new(ObjectMetadata), nil)
+	responseObject, _, err := (&cd).APICall(nil, "GET", "/metadata/"+url.PathEscape(name), new(ObjectMetadata), nil)
 	return responseObject.(*ObjectMetadata), err
 }
 
@@ -222,7 +222,7 @@ func (object *Object) Object(name string) (*ObjectMetadata, error) {
 // See Object for more details.
 func (object *Object) Object_SignedURL(name string, duration time.Duration) (*url.URL, error) {
 	cd := tcclient.Client(*object)
-	return (&cd).SignedURL("/metadata/"+url.QueryEscape(name), nil, duration)
+	return (&cd).SignedURL("/metadata/"+url.PathEscape(name), nil, duration)
 }
 
 // Get the data in an object directly.  This method does not return a JSON body, but
@@ -246,7 +246,7 @@ func (object *Object) Object_SignedURL(name string, duration time.Duration) (*ur
 // See #download
 func (object *Object) Download(name string) error {
 	cd := tcclient.Client(*object)
-	_, _, err := (&cd).APICall(nil, "GET", "/download/"+url.QueryEscape(name), nil, nil)
+	_, _, err := (&cd).APICall(nil, "GET", "/download/"+url.PathEscape(name), nil, nil)
 	return err
 }
 
@@ -259,7 +259,7 @@ func (object *Object) Download(name string) error {
 // See Download for more details.
 func (object *Object) Download_SignedURL(name string, duration time.Duration) (*url.URL, error) {
 	cd := tcclient.Client(*object)
-	return (&cd).SignedURL("/download/"+url.QueryEscape(name), nil, duration)
+	return (&cd).SignedURL("/download/"+url.PathEscape(name), nil, duration)
 }
 
 // Respond with a service heartbeat.

--- a/clients/client-go/tcpurgecache/tcpurgecache.go
+++ b/clients/client-go/tcpurgecache/tcpurgecache.go
@@ -141,7 +141,7 @@ func (purgeCache *PurgeCache) Version() error {
 // See #purgeCache
 func (purgeCache *PurgeCache) PurgeCache(workerPoolId string, payload *PurgeCacheRequest) error {
 	cd := tcclient.Client(*purgeCache)
-	_, _, err := (&cd).APICall(payload, "POST", "/purge-cache/"+url.QueryEscape(workerPoolId), nil, nil)
+	_, _, err := (&cd).APICall(payload, "POST", "/purge-cache/"+url.PathEscape(workerPoolId), nil, nil)
 	return err
 }
 
@@ -206,7 +206,7 @@ func (purgeCache *PurgeCache) PurgeRequests(workerPoolId, since string) (*OpenPu
 		v.Add("since", since)
 	}
 	cd := tcclient.Client(*purgeCache)
-	responseObject, _, err := (&cd).APICall(nil, "GET", "/purge-cache/"+url.QueryEscape(workerPoolId), new(OpenPurgeRequestList), v)
+	responseObject, _, err := (&cd).APICall(nil, "GET", "/purge-cache/"+url.PathEscape(workerPoolId), new(OpenPurgeRequestList), v)
 	return responseObject.(*OpenPurgeRequestList), err
 }
 
@@ -223,7 +223,7 @@ func (purgeCache *PurgeCache) PurgeRequests_SignedURL(workerPoolId, since string
 		v.Add("since", since)
 	}
 	cd := tcclient.Client(*purgeCache)
-	return (&cd).SignedURL("/purge-cache/"+url.QueryEscape(workerPoolId), v, duration)
+	return (&cd).SignedURL("/purge-cache/"+url.PathEscape(workerPoolId), v, duration)
 }
 
 // Respond with a service heartbeat.

--- a/clients/client-go/tcqueue/tcqueue.go
+++ b/clients/client-go/tcqueue/tcqueue.go
@@ -179,7 +179,7 @@ func (queue *Queue) Version() error {
 // See #task
 func (queue *Queue) Task(taskId string) (*TaskDefinitionResponse, error) {
 	cd := tcclient.Client(*queue)
-	responseObject, _, err := (&cd).APICall(nil, "GET", "/task/"+url.QueryEscape(taskId), new(TaskDefinitionResponse), nil)
+	responseObject, _, err := (&cd).APICall(nil, "GET", "/task/"+url.PathEscape(taskId), new(TaskDefinitionResponse), nil)
 	return responseObject.(*TaskDefinitionResponse), err
 }
 
@@ -192,7 +192,7 @@ func (queue *Queue) Task(taskId string) (*TaskDefinitionResponse, error) {
 // See Task for more details.
 func (queue *Queue) Task_SignedURL(taskId string, duration time.Duration) (*url.URL, error) {
 	cd := tcclient.Client(*queue)
-	return (&cd).SignedURL("/task/"+url.QueryEscape(taskId), nil, duration)
+	return (&cd).SignedURL("/task/"+url.PathEscape(taskId), nil, duration)
 }
 
 // Stability: *** EXPERIMENTAL ***
@@ -251,7 +251,7 @@ func (queue *Queue) Statuses(continuationToken, limit string, payload *TaskDefin
 // See #status
 func (queue *Queue) Status(taskId string) (*TaskStatusResponse, error) {
 	cd := tcclient.Client(*queue)
-	responseObject, _, err := (&cd).APICall(nil, "GET", "/task/"+url.QueryEscape(taskId)+"/status", new(TaskStatusResponse), nil)
+	responseObject, _, err := (&cd).APICall(nil, "GET", "/task/"+url.PathEscape(taskId)+"/status", new(TaskStatusResponse), nil)
 	return responseObject.(*TaskStatusResponse), err
 }
 
@@ -264,7 +264,7 @@ func (queue *Queue) Status(taskId string) (*TaskStatusResponse, error) {
 // See Status for more details.
 func (queue *Queue) Status_SignedURL(taskId string, duration time.Duration) (*url.URL, error) {
 	cd := tcclient.Client(*queue)
-	return (&cd).SignedURL("/task/"+url.QueryEscape(taskId)+"/status", nil, duration)
+	return (&cd).SignedURL("/task/"+url.PathEscape(taskId)+"/status", nil, duration)
 }
 
 // List tasks sharing the same `taskGroupId`.
@@ -301,7 +301,7 @@ func (queue *Queue) ListTaskGroup(taskGroupId, continuationToken, limit string) 
 		v.Add("limit", limit)
 	}
 	cd := tcclient.Client(*queue)
-	responseObject, _, err := (&cd).APICall(nil, "GET", "/task-group/"+url.QueryEscape(taskGroupId)+"/list", new(ListTaskGroupResponse), v)
+	responseObject, _, err := (&cd).APICall(nil, "GET", "/task-group/"+url.PathEscape(taskGroupId)+"/list", new(ListTaskGroupResponse), v)
 	return responseObject.(*ListTaskGroupResponse), err
 }
 
@@ -321,7 +321,7 @@ func (queue *Queue) ListTaskGroup_SignedURL(taskGroupId, continuationToken, limi
 		v.Add("limit", limit)
 	}
 	cd := tcclient.Client(*queue)
-	return (&cd).SignedURL("/task-group/"+url.QueryEscape(taskGroupId)+"/list", v, duration)
+	return (&cd).SignedURL("/task-group/"+url.PathEscape(taskGroupId)+"/list", v, duration)
 }
 
 // Stability: *** EXPERIMENTAL ***
@@ -343,7 +343,7 @@ func (queue *Queue) ListTaskGroup_SignedURL(taskGroupId, continuationToken, limi
 // See #cancelTaskGroup
 func (queue *Queue) CancelTaskGroup(taskGroupId string) (*CancelTaskGroupResponse, error) {
 	cd := tcclient.Client(*queue)
-	responseObject, _, err := (&cd).APICall(nil, "POST", "/task-group/"+url.QueryEscape(taskGroupId)+"/cancel", new(CancelTaskGroupResponse), nil)
+	responseObject, _, err := (&cd).APICall(nil, "POST", "/task-group/"+url.PathEscape(taskGroupId)+"/cancel", new(CancelTaskGroupResponse), nil)
 	return responseObject.(*CancelTaskGroupResponse), err
 }
 
@@ -362,7 +362,7 @@ func (queue *Queue) CancelTaskGroup(taskGroupId string) (*CancelTaskGroupRespons
 // See #getTaskGroup
 func (queue *Queue) GetTaskGroup(taskGroupId string) (*TaskGroupDefinitionResponse, error) {
 	cd := tcclient.Client(*queue)
-	responseObject, _, err := (&cd).APICall(nil, "GET", "/task-group/"+url.QueryEscape(taskGroupId), new(TaskGroupDefinitionResponse), nil)
+	responseObject, _, err := (&cd).APICall(nil, "GET", "/task-group/"+url.PathEscape(taskGroupId), new(TaskGroupDefinitionResponse), nil)
 	return responseObject.(*TaskGroupDefinitionResponse), err
 }
 
@@ -375,7 +375,7 @@ func (queue *Queue) GetTaskGroup(taskGroupId string) (*TaskGroupDefinitionRespon
 // See GetTaskGroup for more details.
 func (queue *Queue) GetTaskGroup_SignedURL(taskGroupId string, duration time.Duration) (*url.URL, error) {
 	cd := tcclient.Client(*queue)
-	return (&cd).SignedURL("/task-group/"+url.QueryEscape(taskGroupId), nil, duration)
+	return (&cd).SignedURL("/task-group/"+url.PathEscape(taskGroupId), nil, duration)
 }
 
 // Stability: *** EXPERIMENTAL ***
@@ -392,7 +392,7 @@ func (queue *Queue) GetTaskGroup_SignedURL(taskGroupId string, duration time.Dur
 // See #sealTaskGroup
 func (queue *Queue) SealTaskGroup(taskGroupId string) (*TaskGroupDefinitionResponse, error) {
 	cd := tcclient.Client(*queue)
-	responseObject, _, err := (&cd).APICall(nil, "POST", "/task-group/"+url.QueryEscape(taskGroupId)+"/seal", new(TaskGroupDefinitionResponse), nil)
+	responseObject, _, err := (&cd).APICall(nil, "POST", "/task-group/"+url.PathEscape(taskGroupId)+"/seal", new(TaskGroupDefinitionResponse), nil)
 	return responseObject.(*TaskGroupDefinitionResponse), err
 }
 
@@ -427,7 +427,7 @@ func (queue *Queue) ListDependentTasks(taskId, continuationToken, limit string) 
 		v.Add("limit", limit)
 	}
 	cd := tcclient.Client(*queue)
-	responseObject, _, err := (&cd).APICall(nil, "GET", "/task/"+url.QueryEscape(taskId)+"/dependents", new(ListDependentTasksResponse), v)
+	responseObject, _, err := (&cd).APICall(nil, "GET", "/task/"+url.PathEscape(taskId)+"/dependents", new(ListDependentTasksResponse), v)
 	return responseObject.(*ListDependentTasksResponse), err
 }
 
@@ -447,7 +447,7 @@ func (queue *Queue) ListDependentTasks_SignedURL(taskId, continuationToken, limi
 		v.Add("limit", limit)
 	}
 	cd := tcclient.Client(*queue)
-	return (&cd).SignedURL("/task/"+url.QueryEscape(taskId)+"/dependents", v, duration)
+	return (&cd).SignedURL("/task/"+url.PathEscape(taskId)+"/dependents", v, duration)
 }
 
 // Create a new task, this is an **idempotent** operation, so repeat it if
@@ -493,7 +493,7 @@ func (queue *Queue) ListDependentTasks_SignedURL(taskId, continuationToken, limi
 // See #createTask
 func (queue *Queue) CreateTask(taskId string, payload *TaskDefinitionRequest) (*TaskStatusResponse, error) {
 	cd := tcclient.Client(*queue)
-	responseObject, _, err := (&cd).APICall(payload, "PUT", "/task/"+url.QueryEscape(taskId), new(TaskStatusResponse), nil)
+	responseObject, _, err := (&cd).APICall(payload, "PUT", "/task/"+url.PathEscape(taskId), new(TaskStatusResponse), nil)
 	return responseObject.(*TaskStatusResponse), err
 }
 
@@ -524,7 +524,7 @@ func (queue *Queue) CreateTask(taskId string, payload *TaskDefinitionRequest) (*
 // See #scheduleTask
 func (queue *Queue) ScheduleTask(taskId string) (*TaskStatusResponse, error) {
 	cd := tcclient.Client(*queue)
-	responseObject, _, err := (&cd).APICall(nil, "POST", "/task/"+url.QueryEscape(taskId)+"/schedule", new(TaskStatusResponse), nil)
+	responseObject, _, err := (&cd).APICall(nil, "POST", "/task/"+url.PathEscape(taskId)+"/schedule", new(TaskStatusResponse), nil)
 	return responseObject.(*TaskStatusResponse), err
 }
 
@@ -553,7 +553,7 @@ func (queue *Queue) ScheduleTask(taskId string) (*TaskStatusResponse, error) {
 // See #rerunTask
 func (queue *Queue) RerunTask(taskId string) (*TaskStatusResponse, error) {
 	cd := tcclient.Client(*queue)
-	responseObject, _, err := (&cd).APICall(nil, "POST", "/task/"+url.QueryEscape(taskId)+"/rerun", new(TaskStatusResponse), nil)
+	responseObject, _, err := (&cd).APICall(nil, "POST", "/task/"+url.PathEscape(taskId)+"/rerun", new(TaskStatusResponse), nil)
 	return responseObject.(*TaskStatusResponse), err
 }
 
@@ -582,7 +582,7 @@ func (queue *Queue) RerunTask(taskId string) (*TaskStatusResponse, error) {
 // See #cancelTask
 func (queue *Queue) CancelTask(taskId string) (*TaskStatusResponse, error) {
 	cd := tcclient.Client(*queue)
-	responseObject, _, err := (&cd).APICall(nil, "POST", "/task/"+url.QueryEscape(taskId)+"/cancel", new(TaskStatusResponse), nil)
+	responseObject, _, err := (&cd).APICall(nil, "POST", "/task/"+url.PathEscape(taskId)+"/cancel", new(TaskStatusResponse), nil)
 	return responseObject.(*TaskStatusResponse), err
 }
 
@@ -604,7 +604,7 @@ func (queue *Queue) CancelTask(taskId string) (*TaskStatusResponse, error) {
 // See #claimWork
 func (queue *Queue) ClaimWork(taskQueueId string, payload *ClaimWorkRequest) (*ClaimWorkResponse, error) {
 	cd := tcclient.Client(*queue)
-	responseObject, _, err := (&cd).APICall(payload, "POST", "/claim-work/"+url.QueryEscape(taskQueueId), new(ClaimWorkResponse), nil)
+	responseObject, _, err := (&cd).APICall(payload, "POST", "/claim-work/"+url.PathEscape(taskQueueId), new(ClaimWorkResponse), nil)
 	return responseObject.(*ClaimWorkResponse), err
 }
 
@@ -621,7 +621,7 @@ func (queue *Queue) ClaimWork(taskQueueId string, payload *ClaimWorkRequest) (*C
 // See #claimTask
 func (queue *Queue) ClaimTask(taskId, runId string, payload *TaskClaimRequest) (*TaskClaimResponse, error) {
 	cd := tcclient.Client(*queue)
-	responseObject, _, err := (&cd).APICall(payload, "POST", "/task/"+url.QueryEscape(taskId)+"/runs/"+url.QueryEscape(runId)+"/claim", new(TaskClaimResponse), nil)
+	responseObject, _, err := (&cd).APICall(payload, "POST", "/task/"+url.PathEscape(taskId)+"/runs/"+url.PathEscape(runId)+"/claim", new(TaskClaimResponse), nil)
 	return responseObject.(*TaskClaimResponse), err
 }
 
@@ -654,7 +654,7 @@ func (queue *Queue) ClaimTask(taskId, runId string, payload *TaskClaimRequest) (
 // See #reclaimTask
 func (queue *Queue) ReclaimTask(taskId, runId string) (*TaskReclaimResponse, error) {
 	cd := tcclient.Client(*queue)
-	responseObject, _, err := (&cd).APICall(nil, "POST", "/task/"+url.QueryEscape(taskId)+"/runs/"+url.QueryEscape(runId)+"/reclaim", new(TaskReclaimResponse), nil)
+	responseObject, _, err := (&cd).APICall(nil, "POST", "/task/"+url.PathEscape(taskId)+"/runs/"+url.PathEscape(runId)+"/reclaim", new(TaskReclaimResponse), nil)
 	return responseObject.(*TaskReclaimResponse), err
 }
 
@@ -667,7 +667,7 @@ func (queue *Queue) ReclaimTask(taskId, runId string) (*TaskReclaimResponse, err
 // See #reportCompleted
 func (queue *Queue) ReportCompleted(taskId, runId string) (*TaskStatusResponse, error) {
 	cd := tcclient.Client(*queue)
-	responseObject, _, err := (&cd).APICall(nil, "POST", "/task/"+url.QueryEscape(taskId)+"/runs/"+url.QueryEscape(runId)+"/completed", new(TaskStatusResponse), nil)
+	responseObject, _, err := (&cd).APICall(nil, "POST", "/task/"+url.PathEscape(taskId)+"/runs/"+url.PathEscape(runId)+"/completed", new(TaskStatusResponse), nil)
 	return responseObject.(*TaskStatusResponse), err
 }
 
@@ -686,7 +686,7 @@ func (queue *Queue) ReportCompleted(taskId, runId string) (*TaskStatusResponse, 
 // See #reportFailed
 func (queue *Queue) ReportFailed(taskId, runId string) (*TaskStatusResponse, error) {
 	cd := tcclient.Client(*queue)
-	responseObject, _, err := (&cd).APICall(nil, "POST", "/task/"+url.QueryEscape(taskId)+"/runs/"+url.QueryEscape(runId)+"/failed", new(TaskStatusResponse), nil)
+	responseObject, _, err := (&cd).APICall(nil, "POST", "/task/"+url.PathEscape(taskId)+"/runs/"+url.PathEscape(runId)+"/failed", new(TaskStatusResponse), nil)
 	return responseObject.(*TaskStatusResponse), err
 }
 
@@ -711,7 +711,7 @@ func (queue *Queue) ReportFailed(taskId, runId string) (*TaskStatusResponse, err
 // See #reportException
 func (queue *Queue) ReportException(taskId, runId string, payload *TaskExceptionRequest) (*TaskStatusResponse, error) {
 	cd := tcclient.Client(*queue)
-	responseObject, _, err := (&cd).APICall(payload, "POST", "/task/"+url.QueryEscape(taskId)+"/runs/"+url.QueryEscape(runId)+"/exception", new(TaskStatusResponse), nil)
+	responseObject, _, err := (&cd).APICall(payload, "POST", "/task/"+url.PathEscape(taskId)+"/runs/"+url.PathEscape(runId)+"/exception", new(TaskStatusResponse), nil)
 	return responseObject.(*TaskStatusResponse), err
 }
 
@@ -732,7 +732,7 @@ func (queue *Queue) ReportException(taskId, runId string, payload *TaskException
 // See #createArtifact
 func (queue *Queue) CreateArtifact(taskId, runId, name string, payload *PostArtifactRequest) (*PostArtifactResponse, error) {
 	cd := tcclient.Client(*queue)
-	responseObject, _, err := (&cd).APICall(payload, "POST", "/task/"+url.QueryEscape(taskId)+"/runs/"+url.QueryEscape(runId)+"/artifacts/"+url.QueryEscape(name), new(PostArtifactResponse), nil)
+	responseObject, _, err := (&cd).APICall(payload, "POST", "/task/"+url.PathEscape(taskId)+"/runs/"+url.PathEscape(runId)+"/artifacts/"+url.PathEscape(name), new(PostArtifactResponse), nil)
 	return responseObject.(*PostArtifactResponse), err
 }
 
@@ -752,7 +752,7 @@ func (queue *Queue) CreateArtifact(taskId, runId, name string, payload *PostArti
 // See #finishArtifact
 func (queue *Queue) FinishArtifact(taskId, runId, name string, payload *FinishArtifactRequest) error {
 	cd := tcclient.Client(*queue)
-	_, _, err := (&cd).APICall(payload, "PUT", "/task/"+url.QueryEscape(taskId)+"/runs/"+url.QueryEscape(runId)+"/artifacts/"+url.QueryEscape(name), nil, nil)
+	_, _, err := (&cd).APICall(payload, "PUT", "/task/"+url.PathEscape(taskId)+"/runs/"+url.PathEscape(runId)+"/artifacts/"+url.PathEscape(name), nil, nil)
 	return err
 }
 
@@ -812,7 +812,7 @@ func (queue *Queue) FinishArtifact(taskId, runId, name string, payload *FinishAr
 // See #getArtifact
 func (queue *Queue) GetArtifact(taskId, runId, name string) (*GetArtifactResponse, error) {
 	cd := tcclient.Client(*queue)
-	responseObject, _, err := (&cd).APICall(nil, "GET", "/task/"+url.QueryEscape(taskId)+"/runs/"+url.QueryEscape(runId)+"/artifacts/"+url.QueryEscape(name), new(GetArtifactResponse), nil)
+	responseObject, _, err := (&cd).APICall(nil, "GET", "/task/"+url.PathEscape(taskId)+"/runs/"+url.PathEscape(runId)+"/artifacts/"+url.PathEscape(name), new(GetArtifactResponse), nil)
 	return responseObject.(*GetArtifactResponse), err
 }
 
@@ -825,7 +825,7 @@ func (queue *Queue) GetArtifact(taskId, runId, name string) (*GetArtifactRespons
 // See GetArtifact for more details.
 func (queue *Queue) GetArtifact_SignedURL(taskId, runId, name string, duration time.Duration) (*url.URL, error) {
 	cd := tcclient.Client(*queue)
-	return (&cd).SignedURL("/task/"+url.QueryEscape(taskId)+"/runs/"+url.QueryEscape(runId)+"/artifacts/"+url.QueryEscape(name), nil, duration)
+	return (&cd).SignedURL("/task/"+url.PathEscape(taskId)+"/runs/"+url.PathEscape(runId)+"/artifacts/"+url.PathEscape(name), nil, duration)
 }
 
 // Get artifact by `<name>` from the last run of a task.
@@ -888,7 +888,7 @@ func (queue *Queue) GetArtifact_SignedURL(taskId, runId, name string, duration t
 // See #getLatestArtifact
 func (queue *Queue) GetLatestArtifact(taskId, name string) (*GetArtifactResponse, error) {
 	cd := tcclient.Client(*queue)
-	responseObject, _, err := (&cd).APICall(nil, "GET", "/task/"+url.QueryEscape(taskId)+"/artifacts/"+url.QueryEscape(name), new(GetArtifactResponse), nil)
+	responseObject, _, err := (&cd).APICall(nil, "GET", "/task/"+url.PathEscape(taskId)+"/artifacts/"+url.PathEscape(name), new(GetArtifactResponse), nil)
 	return responseObject.(*GetArtifactResponse), err
 }
 
@@ -901,7 +901,7 @@ func (queue *Queue) GetLatestArtifact(taskId, name string) (*GetArtifactResponse
 // See GetLatestArtifact for more details.
 func (queue *Queue) GetLatestArtifact_SignedURL(taskId, name string, duration time.Duration) (*url.URL, error) {
 	cd := tcclient.Client(*queue)
-	return (&cd).SignedURL("/task/"+url.QueryEscape(taskId)+"/artifacts/"+url.QueryEscape(name), nil, duration)
+	return (&cd).SignedURL("/task/"+url.PathEscape(taskId)+"/artifacts/"+url.PathEscape(name), nil, duration)
 }
 
 // Returns a list of artifacts and associated meta-data for a given run.
@@ -928,7 +928,7 @@ func (queue *Queue) ListArtifacts(taskId, runId, continuationToken, limit string
 		v.Add("limit", limit)
 	}
 	cd := tcclient.Client(*queue)
-	responseObject, _, err := (&cd).APICall(nil, "GET", "/task/"+url.QueryEscape(taskId)+"/runs/"+url.QueryEscape(runId)+"/artifacts", new(ListArtifactsResponse), v)
+	responseObject, _, err := (&cd).APICall(nil, "GET", "/task/"+url.PathEscape(taskId)+"/runs/"+url.PathEscape(runId)+"/artifacts", new(ListArtifactsResponse), v)
 	return responseObject.(*ListArtifactsResponse), err
 }
 
@@ -948,7 +948,7 @@ func (queue *Queue) ListArtifacts_SignedURL(taskId, runId, continuationToken, li
 		v.Add("limit", limit)
 	}
 	cd := tcclient.Client(*queue)
-	return (&cd).SignedURL("/task/"+url.QueryEscape(taskId)+"/runs/"+url.QueryEscape(runId)+"/artifacts", v, duration)
+	return (&cd).SignedURL("/task/"+url.PathEscape(taskId)+"/runs/"+url.PathEscape(runId)+"/artifacts", v, duration)
 }
 
 // Returns a list of artifacts and associated meta-data for the latest run
@@ -976,7 +976,7 @@ func (queue *Queue) ListLatestArtifacts(taskId, continuationToken, limit string)
 		v.Add("limit", limit)
 	}
 	cd := tcclient.Client(*queue)
-	responseObject, _, err := (&cd).APICall(nil, "GET", "/task/"+url.QueryEscape(taskId)+"/artifacts", new(ListArtifactsResponse), v)
+	responseObject, _, err := (&cd).APICall(nil, "GET", "/task/"+url.PathEscape(taskId)+"/artifacts", new(ListArtifactsResponse), v)
 	return responseObject.(*ListArtifactsResponse), err
 }
 
@@ -996,7 +996,7 @@ func (queue *Queue) ListLatestArtifacts_SignedURL(taskId, continuationToken, lim
 		v.Add("limit", limit)
 	}
 	cd := tcclient.Client(*queue)
-	return (&cd).SignedURL("/task/"+url.QueryEscape(taskId)+"/artifacts", v, duration)
+	return (&cd).SignedURL("/task/"+url.PathEscape(taskId)+"/artifacts", v, duration)
 }
 
 // Returns associated metadata for a given artifact, in the given task run.
@@ -1012,7 +1012,7 @@ func (queue *Queue) ListLatestArtifacts_SignedURL(taskId, continuationToken, lim
 // See #artifactInfo
 func (queue *Queue) ArtifactInfo(taskId, runId, name string) (*Artifact, error) {
 	cd := tcclient.Client(*queue)
-	responseObject, _, err := (&cd).APICall(nil, "GET", "/task/"+url.QueryEscape(taskId)+"/runs/"+url.QueryEscape(runId)+"/artifact-info/"+url.QueryEscape(name), new(Artifact), nil)
+	responseObject, _, err := (&cd).APICall(nil, "GET", "/task/"+url.PathEscape(taskId)+"/runs/"+url.PathEscape(runId)+"/artifact-info/"+url.PathEscape(name), new(Artifact), nil)
 	return responseObject.(*Artifact), err
 }
 
@@ -1025,7 +1025,7 @@ func (queue *Queue) ArtifactInfo(taskId, runId, name string) (*Artifact, error) 
 // See ArtifactInfo for more details.
 func (queue *Queue) ArtifactInfo_SignedURL(taskId, runId, name string, duration time.Duration) (*url.URL, error) {
 	cd := tcclient.Client(*queue)
-	return (&cd).SignedURL("/task/"+url.QueryEscape(taskId)+"/runs/"+url.QueryEscape(runId)+"/artifact-info/"+url.QueryEscape(name), nil, duration)
+	return (&cd).SignedURL("/task/"+url.PathEscape(taskId)+"/runs/"+url.PathEscape(runId)+"/artifact-info/"+url.PathEscape(name), nil, duration)
 }
 
 // Returns associated metadata for a given artifact, in the latest run of the
@@ -1041,7 +1041,7 @@ func (queue *Queue) ArtifactInfo_SignedURL(taskId, runId, name string, duration 
 // See #latestArtifactInfo
 func (queue *Queue) LatestArtifactInfo(taskId, name string) (*Artifact, error) {
 	cd := tcclient.Client(*queue)
-	responseObject, _, err := (&cd).APICall(nil, "GET", "/task/"+url.QueryEscape(taskId)+"/artifact-info/"+url.QueryEscape(name), new(Artifact), nil)
+	responseObject, _, err := (&cd).APICall(nil, "GET", "/task/"+url.PathEscape(taskId)+"/artifact-info/"+url.PathEscape(name), new(Artifact), nil)
 	return responseObject.(*Artifact), err
 }
 
@@ -1054,7 +1054,7 @@ func (queue *Queue) LatestArtifactInfo(taskId, name string) (*Artifact, error) {
 // See LatestArtifactInfo for more details.
 func (queue *Queue) LatestArtifactInfo_SignedURL(taskId, name string, duration time.Duration) (*url.URL, error) {
 	cd := tcclient.Client(*queue)
-	return (&cd).SignedURL("/task/"+url.QueryEscape(taskId)+"/artifact-info/"+url.QueryEscape(name), nil, duration)
+	return (&cd).SignedURL("/task/"+url.PathEscape(taskId)+"/artifact-info/"+url.PathEscape(name), nil, duration)
 }
 
 // Returns information about the content of the artifact, in the given task run.
@@ -1072,7 +1072,7 @@ func (queue *Queue) LatestArtifactInfo_SignedURL(taskId, name string, duration t
 // See #artifact
 func (queue *Queue) Artifact(taskId, runId, name string) (*GetArtifactContentResponse, error) {
 	cd := tcclient.Client(*queue)
-	responseObject, _, err := (&cd).APICall(nil, "GET", "/task/"+url.QueryEscape(taskId)+"/runs/"+url.QueryEscape(runId)+"/artifact-content/"+url.QueryEscape(name), new(GetArtifactContentResponse), nil)
+	responseObject, _, err := (&cd).APICall(nil, "GET", "/task/"+url.PathEscape(taskId)+"/runs/"+url.PathEscape(runId)+"/artifact-content/"+url.PathEscape(name), new(GetArtifactContentResponse), nil)
 	return responseObject.(*GetArtifactContentResponse), err
 }
 
@@ -1085,7 +1085,7 @@ func (queue *Queue) Artifact(taskId, runId, name string) (*GetArtifactContentRes
 // See Artifact for more details.
 func (queue *Queue) Artifact_SignedURL(taskId, runId, name string, duration time.Duration) (*url.URL, error) {
 	cd := tcclient.Client(*queue)
-	return (&cd).SignedURL("/task/"+url.QueryEscape(taskId)+"/runs/"+url.QueryEscape(runId)+"/artifact-content/"+url.QueryEscape(name), nil, duration)
+	return (&cd).SignedURL("/task/"+url.PathEscape(taskId)+"/runs/"+url.PathEscape(runId)+"/artifact-content/"+url.PathEscape(name), nil, duration)
 }
 
 // Returns information about the content of the artifact, in the latest task run.
@@ -1103,7 +1103,7 @@ func (queue *Queue) Artifact_SignedURL(taskId, runId, name string, duration time
 // See #latestArtifact
 func (queue *Queue) LatestArtifact(taskId, name string) (*GetArtifactContentResponse, error) {
 	cd := tcclient.Client(*queue)
-	responseObject, _, err := (&cd).APICall(nil, "GET", "/task/"+url.QueryEscape(taskId)+"/artifact-content/"+url.QueryEscape(name), new(GetArtifactContentResponse), nil)
+	responseObject, _, err := (&cd).APICall(nil, "GET", "/task/"+url.PathEscape(taskId)+"/artifact-content/"+url.PathEscape(name), new(GetArtifactContentResponse), nil)
 	return responseObject.(*GetArtifactContentResponse), err
 }
 
@@ -1116,7 +1116,7 @@ func (queue *Queue) LatestArtifact(taskId, name string) (*GetArtifactContentResp
 // See LatestArtifact for more details.
 func (queue *Queue) LatestArtifact_SignedURL(taskId, name string, duration time.Duration) (*url.URL, error) {
 	cd := tcclient.Client(*queue)
-	return (&cd).SignedURL("/task/"+url.QueryEscape(taskId)+"/artifact-content/"+url.QueryEscape(name), nil, duration)
+	return (&cd).SignedURL("/task/"+url.PathEscape(taskId)+"/artifact-content/"+url.PathEscape(name), nil, duration)
 }
 
 // Stability: *** DEPRECATED ***
@@ -1184,7 +1184,7 @@ func (queue *Queue) ListProvisioners_SignedURL(continuationToken, limit string, 
 // See #getProvisioner
 func (queue *Queue) GetProvisioner(provisionerId string) (*ProvisionerResponse, error) {
 	cd := tcclient.Client(*queue)
-	responseObject, _, err := (&cd).APICall(nil, "GET", "/provisioners/"+url.QueryEscape(provisionerId), new(ProvisionerResponse), nil)
+	responseObject, _, err := (&cd).APICall(nil, "GET", "/provisioners/"+url.PathEscape(provisionerId), new(ProvisionerResponse), nil)
 	return responseObject.(*ProvisionerResponse), err
 }
 
@@ -1197,7 +1197,7 @@ func (queue *Queue) GetProvisioner(provisionerId string) (*ProvisionerResponse, 
 // See GetProvisioner for more details.
 func (queue *Queue) GetProvisioner_SignedURL(provisionerId string, duration time.Duration) (*url.URL, error) {
 	cd := tcclient.Client(*queue)
-	return (&cd).SignedURL("/provisioners/"+url.QueryEscape(provisionerId), nil, duration)
+	return (&cd).SignedURL("/provisioners/"+url.PathEscape(provisionerId), nil, duration)
 }
 
 // Stability: *** DEPRECATED ***
@@ -1220,7 +1220,7 @@ func (queue *Queue) GetProvisioner_SignedURL(provisionerId string, duration time
 // See #declareProvisioner
 func (queue *Queue) DeclareProvisioner(provisionerId string, payload *ProvisionerRequest) (*ProvisionerResponse, error) {
 	cd := tcclient.Client(*queue)
-	responseObject, _, err := (&cd).APICall(payload, "PUT", "/provisioners/"+url.QueryEscape(provisionerId), new(ProvisionerResponse), nil)
+	responseObject, _, err := (&cd).APICall(payload, "PUT", "/provisioners/"+url.PathEscape(provisionerId), new(ProvisionerResponse), nil)
 	return responseObject.(*ProvisionerResponse), err
 }
 
@@ -1240,7 +1240,7 @@ func (queue *Queue) DeclareProvisioner(provisionerId string, payload *Provisione
 // See #pendingTasks
 func (queue *Queue) PendingTasks(taskQueueId string) (*CountPendingTasksResponse, error) {
 	cd := tcclient.Client(*queue)
-	responseObject, _, err := (&cd).APICall(nil, "GET", "/pending/"+url.QueryEscape(taskQueueId), new(CountPendingTasksResponse), nil)
+	responseObject, _, err := (&cd).APICall(nil, "GET", "/pending/"+url.PathEscape(taskQueueId), new(CountPendingTasksResponse), nil)
 	return responseObject.(*CountPendingTasksResponse), err
 }
 
@@ -1253,7 +1253,7 @@ func (queue *Queue) PendingTasks(taskQueueId string) (*CountPendingTasksResponse
 // See PendingTasks for more details.
 func (queue *Queue) PendingTasks_SignedURL(taskQueueId string, duration time.Duration) (*url.URL, error) {
 	cd := tcclient.Client(*queue)
-	return (&cd).SignedURL("/pending/"+url.QueryEscape(taskQueueId), nil, duration)
+	return (&cd).SignedURL("/pending/"+url.PathEscape(taskQueueId), nil, duration)
 }
 
 // Get an approximate number of pending and claimed tasks for the given `taskQueueId`.
@@ -1270,7 +1270,7 @@ func (queue *Queue) PendingTasks_SignedURL(taskQueueId string, duration time.Dur
 // See #taskQueueCounts
 func (queue *Queue) TaskQueueCounts(taskQueueId string) (*Var, error) {
 	cd := tcclient.Client(*queue)
-	responseObject, _, err := (&cd).APICall(nil, "GET", "/task-queues/"+url.QueryEscape(taskQueueId)+"/counts", new(Var), nil)
+	responseObject, _, err := (&cd).APICall(nil, "GET", "/task-queues/"+url.PathEscape(taskQueueId)+"/counts", new(Var), nil)
 	return responseObject.(*Var), err
 }
 
@@ -1285,7 +1285,7 @@ func (queue *Queue) TaskQueueCounts(taskQueueId string) (*Var, error) {
 // See TaskQueueCounts for more details.
 func (queue *Queue) TaskQueueCounts_SignedURL(taskQueueId string, duration time.Duration) (*url.URL, error) {
 	cd := tcclient.Client(*queue)
-	return (&cd).SignedURL("/task-queues/"+url.QueryEscape(taskQueueId)+"/counts", nil, duration)
+	return (&cd).SignedURL("/task-queues/"+url.PathEscape(taskQueueId)+"/counts", nil, duration)
 }
 
 // Stability: *** EXPERIMENTAL ***
@@ -1309,7 +1309,7 @@ func (queue *Queue) ListPendingTasks(taskQueueId, continuationToken, limit strin
 		v.Add("limit", limit)
 	}
 	cd := tcclient.Client(*queue)
-	responseObject, _, err := (&cd).APICall(nil, "GET", "/task-queues/"+url.QueryEscape(taskQueueId)+"/pending", new(ListPendingTasksResponse), v)
+	responseObject, _, err := (&cd).APICall(nil, "GET", "/task-queues/"+url.PathEscape(taskQueueId)+"/pending", new(ListPendingTasksResponse), v)
 	return responseObject.(*ListPendingTasksResponse), err
 }
 
@@ -1329,7 +1329,7 @@ func (queue *Queue) ListPendingTasks_SignedURL(taskQueueId, continuationToken, l
 		v.Add("limit", limit)
 	}
 	cd := tcclient.Client(*queue)
-	return (&cd).SignedURL("/task-queues/"+url.QueryEscape(taskQueueId)+"/pending", v, duration)
+	return (&cd).SignedURL("/task-queues/"+url.PathEscape(taskQueueId)+"/pending", v, duration)
 }
 
 // Stability: *** EXPERIMENTAL ***
@@ -1353,7 +1353,7 @@ func (queue *Queue) ListClaimedTasks(taskQueueId, continuationToken, limit strin
 		v.Add("limit", limit)
 	}
 	cd := tcclient.Client(*queue)
-	responseObject, _, err := (&cd).APICall(nil, "GET", "/task-queues/"+url.QueryEscape(taskQueueId)+"/claimed", new(ListClaimedTasksResponse), v)
+	responseObject, _, err := (&cd).APICall(nil, "GET", "/task-queues/"+url.PathEscape(taskQueueId)+"/claimed", new(ListClaimedTasksResponse), v)
 	return responseObject.(*ListClaimedTasksResponse), err
 }
 
@@ -1373,7 +1373,7 @@ func (queue *Queue) ListClaimedTasks_SignedURL(taskQueueId, continuationToken, l
 		v.Add("limit", limit)
 	}
 	cd := tcclient.Client(*queue)
-	return (&cd).SignedURL("/task-queues/"+url.QueryEscape(taskQueueId)+"/claimed", v, duration)
+	return (&cd).SignedURL("/task-queues/"+url.PathEscape(taskQueueId)+"/claimed", v, duration)
 }
 
 // Stability: *** DEPRECATED ***
@@ -1399,7 +1399,7 @@ func (queue *Queue) ListWorkerTypes(provisionerId, continuationToken, limit stri
 		v.Add("limit", limit)
 	}
 	cd := tcclient.Client(*queue)
-	responseObject, _, err := (&cd).APICall(nil, "GET", "/provisioners/"+url.QueryEscape(provisionerId)+"/worker-types", new(ListWorkerTypesResponse), v)
+	responseObject, _, err := (&cd).APICall(nil, "GET", "/provisioners/"+url.PathEscape(provisionerId)+"/worker-types", new(ListWorkerTypesResponse), v)
 	return responseObject.(*ListWorkerTypesResponse), err
 }
 
@@ -1419,7 +1419,7 @@ func (queue *Queue) ListWorkerTypes_SignedURL(provisionerId, continuationToken, 
 		v.Add("limit", limit)
 	}
 	cd := tcclient.Client(*queue)
-	return (&cd).SignedURL("/provisioners/"+url.QueryEscape(provisionerId)+"/worker-types", v, duration)
+	return (&cd).SignedURL("/provisioners/"+url.PathEscape(provisionerId)+"/worker-types", v, duration)
 }
 
 // Stability: *** DEPRECATED ***
@@ -1433,7 +1433,7 @@ func (queue *Queue) ListWorkerTypes_SignedURL(provisionerId, continuationToken, 
 // See #getWorkerType
 func (queue *Queue) GetWorkerType(provisionerId, workerType string) (*WorkerTypeResponse, error) {
 	cd := tcclient.Client(*queue)
-	responseObject, _, err := (&cd).APICall(nil, "GET", "/provisioners/"+url.QueryEscape(provisionerId)+"/worker-types/"+url.QueryEscape(workerType), new(WorkerTypeResponse), nil)
+	responseObject, _, err := (&cd).APICall(nil, "GET", "/provisioners/"+url.PathEscape(provisionerId)+"/worker-types/"+url.PathEscape(workerType), new(WorkerTypeResponse), nil)
 	return responseObject.(*WorkerTypeResponse), err
 }
 
@@ -1446,7 +1446,7 @@ func (queue *Queue) GetWorkerType(provisionerId, workerType string) (*WorkerType
 // See GetWorkerType for more details.
 func (queue *Queue) GetWorkerType_SignedURL(provisionerId, workerType string, duration time.Duration) (*url.URL, error) {
 	cd := tcclient.Client(*queue)
-	return (&cd).SignedURL("/provisioners/"+url.QueryEscape(provisionerId)+"/worker-types/"+url.QueryEscape(workerType), nil, duration)
+	return (&cd).SignedURL("/provisioners/"+url.PathEscape(provisionerId)+"/worker-types/"+url.PathEscape(workerType), nil, duration)
 }
 
 // Stability: *** DEPRECATED ***
@@ -1465,7 +1465,7 @@ func (queue *Queue) GetWorkerType_SignedURL(provisionerId, workerType string, du
 // See #declareWorkerType
 func (queue *Queue) DeclareWorkerType(provisionerId, workerType string, payload *WorkerTypeRequest) (*WorkerTypeResponse, error) {
 	cd := tcclient.Client(*queue)
-	responseObject, _, err := (&cd).APICall(payload, "PUT", "/provisioners/"+url.QueryEscape(provisionerId)+"/worker-types/"+url.QueryEscape(workerType), new(WorkerTypeResponse), nil)
+	responseObject, _, err := (&cd).APICall(payload, "PUT", "/provisioners/"+url.PathEscape(provisionerId)+"/worker-types/"+url.PathEscape(workerType), new(WorkerTypeResponse), nil)
 	return responseObject.(*WorkerTypeResponse), err
 }
 
@@ -1522,7 +1522,7 @@ func (queue *Queue) ListTaskQueues_SignedURL(continuationToken, limit string, du
 // See #getTaskQueue
 func (queue *Queue) GetTaskQueue(taskQueueId string) (*TaskQueueResponse, error) {
 	cd := tcclient.Client(*queue)
-	responseObject, _, err := (&cd).APICall(nil, "GET", "/task-queues/"+url.QueryEscape(taskQueueId), new(TaskQueueResponse), nil)
+	responseObject, _, err := (&cd).APICall(nil, "GET", "/task-queues/"+url.PathEscape(taskQueueId), new(TaskQueueResponse), nil)
 	return responseObject.(*TaskQueueResponse), err
 }
 
@@ -1535,7 +1535,7 @@ func (queue *Queue) GetTaskQueue(taskQueueId string) (*TaskQueueResponse, error)
 // See GetTaskQueue for more details.
 func (queue *Queue) GetTaskQueue_SignedURL(taskQueueId string, duration time.Duration) (*url.URL, error) {
 	cd := tcclient.Client(*queue)
-	return (&cd).SignedURL("/task-queues/"+url.QueryEscape(taskQueueId), nil, duration)
+	return (&cd).SignedURL("/task-queues/"+url.PathEscape(taskQueueId), nil, duration)
 }
 
 // Stability: *** DEPRECATED ***
@@ -1568,7 +1568,7 @@ func (queue *Queue) ListWorkers(provisionerId, workerType, continuationToken, li
 		v.Add("quarantined", quarantined)
 	}
 	cd := tcclient.Client(*queue)
-	responseObject, _, err := (&cd).APICall(nil, "GET", "/provisioners/"+url.QueryEscape(provisionerId)+"/worker-types/"+url.QueryEscape(workerType)+"/workers", new(ListWorkersResponse), v)
+	responseObject, _, err := (&cd).APICall(nil, "GET", "/provisioners/"+url.PathEscape(provisionerId)+"/worker-types/"+url.PathEscape(workerType)+"/workers", new(ListWorkersResponse), v)
 	return responseObject.(*ListWorkersResponse), err
 }
 
@@ -1591,7 +1591,7 @@ func (queue *Queue) ListWorkers_SignedURL(provisionerId, workerType, continuatio
 		v.Add("quarantined", quarantined)
 	}
 	cd := tcclient.Client(*queue)
-	return (&cd).SignedURL("/provisioners/"+url.QueryEscape(provisionerId)+"/worker-types/"+url.QueryEscape(workerType)+"/workers", v, duration)
+	return (&cd).SignedURL("/provisioners/"+url.PathEscape(provisionerId)+"/worker-types/"+url.PathEscape(workerType)+"/workers", v, duration)
 }
 
 // Stability: *** DEPRECATED ***
@@ -1605,7 +1605,7 @@ func (queue *Queue) ListWorkers_SignedURL(provisionerId, workerType, continuatio
 // See #getWorker
 func (queue *Queue) GetWorker(provisionerId, workerType, workerGroup, workerId string) (*WorkerResponse, error) {
 	cd := tcclient.Client(*queue)
-	responseObject, _, err := (&cd).APICall(nil, "GET", "/provisioners/"+url.QueryEscape(provisionerId)+"/worker-types/"+url.QueryEscape(workerType)+"/workers/"+url.QueryEscape(workerGroup)+"/"+url.QueryEscape(workerId), new(WorkerResponse), nil)
+	responseObject, _, err := (&cd).APICall(nil, "GET", "/provisioners/"+url.PathEscape(provisionerId)+"/worker-types/"+url.PathEscape(workerType)+"/workers/"+url.PathEscape(workerGroup)+"/"+url.PathEscape(workerId), new(WorkerResponse), nil)
 	return responseObject.(*WorkerResponse), err
 }
 
@@ -1618,7 +1618,7 @@ func (queue *Queue) GetWorker(provisionerId, workerType, workerGroup, workerId s
 // See GetWorker for more details.
 func (queue *Queue) GetWorker_SignedURL(provisionerId, workerType, workerGroup, workerId string, duration time.Duration) (*url.URL, error) {
 	cd := tcclient.Client(*queue)
-	return (&cd).SignedURL("/provisioners/"+url.QueryEscape(provisionerId)+"/worker-types/"+url.QueryEscape(workerType)+"/workers/"+url.QueryEscape(workerGroup)+"/"+url.QueryEscape(workerId), nil, duration)
+	return (&cd).SignedURL("/provisioners/"+url.PathEscape(provisionerId)+"/worker-types/"+url.PathEscape(workerType)+"/workers/"+url.PathEscape(workerGroup)+"/"+url.PathEscape(workerId), nil, duration)
 }
 
 // Stability: *** EXPERIMENTAL ***
@@ -1632,7 +1632,7 @@ func (queue *Queue) GetWorker_SignedURL(provisionerId, workerType, workerGroup, 
 // See #quarantineWorker
 func (queue *Queue) QuarantineWorker(provisionerId, workerType, workerGroup, workerId string, payload *QuarantineWorkerRequest) (*WorkerResponse, error) {
 	cd := tcclient.Client(*queue)
-	responseObject, _, err := (&cd).APICall(payload, "PUT", "/provisioners/"+url.QueryEscape(provisionerId)+"/worker-types/"+url.QueryEscape(workerType)+"/workers/"+url.QueryEscape(workerGroup)+"/"+url.QueryEscape(workerId), new(WorkerResponse), nil)
+	responseObject, _, err := (&cd).APICall(payload, "PUT", "/provisioners/"+url.PathEscape(provisionerId)+"/worker-types/"+url.PathEscape(workerType)+"/workers/"+url.PathEscape(workerGroup)+"/"+url.PathEscape(workerId), new(WorkerResponse), nil)
 	return responseObject.(*WorkerResponse), err
 }
 
@@ -1650,7 +1650,7 @@ func (queue *Queue) QuarantineWorker(provisionerId, workerType, workerGroup, wor
 // See #declareWorker
 func (queue *Queue) DeclareWorker(provisionerId, workerType, workerGroup, workerId string, payload *WorkerRequest) (*WorkerResponse, error) {
 	cd := tcclient.Client(*queue)
-	responseObject, _, err := (&cd).APICall(payload, "PUT", "/provisioners/"+url.QueryEscape(provisionerId)+"/worker-types/"+url.QueryEscape(workerType)+"/"+url.QueryEscape(workerGroup)+"/"+url.QueryEscape(workerId), new(WorkerResponse), nil)
+	responseObject, _, err := (&cd).APICall(payload, "PUT", "/provisioners/"+url.PathEscape(provisionerId)+"/worker-types/"+url.PathEscape(workerType)+"/"+url.PathEscape(workerGroup)+"/"+url.PathEscape(workerId), new(WorkerResponse), nil)
 	return responseObject.(*WorkerResponse), err
 }
 

--- a/clients/client-go/tcsecrets/tcsecrets.go
+++ b/clients/client-go/tcsecrets/tcsecrets.go
@@ -140,7 +140,7 @@ func (secrets *Secrets) Version() error {
 // See #set
 func (secrets *Secrets) Set(name string, payload *Secret) error {
 	cd := tcclient.Client(*secrets)
-	_, _, err := (&cd).APICall(payload, "PUT", "/secret/"+url.QueryEscape(name), nil, nil)
+	_, _, err := (&cd).APICall(payload, "PUT", "/secret/"+url.PathEscape(name), nil, nil)
 	return err
 }
 
@@ -153,7 +153,7 @@ func (secrets *Secrets) Set(name string, payload *Secret) error {
 // See #remove
 func (secrets *Secrets) Remove(name string) error {
 	cd := tcclient.Client(*secrets)
-	_, _, err := (&cd).APICall(nil, "DELETE", "/secret/"+url.QueryEscape(name), nil, nil)
+	_, _, err := (&cd).APICall(nil, "DELETE", "/secret/"+url.PathEscape(name), nil, nil)
 	return err
 }
 
@@ -169,7 +169,7 @@ func (secrets *Secrets) Remove(name string) error {
 // See #get
 func (secrets *Secrets) Get(name string) (*Secret, error) {
 	cd := tcclient.Client(*secrets)
-	responseObject, _, err := (&cd).APICall(nil, "GET", "/secret/"+url.QueryEscape(name), new(Secret), nil)
+	responseObject, _, err := (&cd).APICall(nil, "GET", "/secret/"+url.PathEscape(name), new(Secret), nil)
 	return responseObject.(*Secret), err
 }
 
@@ -182,7 +182,7 @@ func (secrets *Secrets) Get(name string) (*Secret, error) {
 // See Get for more details.
 func (secrets *Secrets) Get_SignedURL(name string, duration time.Duration) (*url.URL, error) {
 	cd := tcclient.Client(*secrets)
-	return (&cd).SignedURL("/secret/"+url.QueryEscape(name), nil, duration)
+	return (&cd).SignedURL("/secret/"+url.PathEscape(name), nil, duration)
 }
 
 // List the names of all secrets.

--- a/clients/client-go/tcsecrets/tcsecrets_test.go
+++ b/clients/client-go/tcsecrets/tcsecrets_test.go
@@ -1,0 +1,25 @@
+package tcsecrets
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSpacesInRouteParameters(t *testing.T) {
+	var capturedURI string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedURI = r.RequestURI
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"secret": {}, "expires": "2099-01-01T00:00:00.000Z"}`))
+	}))
+	defer server.Close()
+
+	secrets := New(nil, server.URL)
+	_, _ = secrets.Get("my secret")
+
+	require.Equal(t, capturedURI, "/api/secrets/v1/secret/my%20secret")
+}

--- a/clients/client-go/tcworkermanager/tcworkermanager.go
+++ b/clients/client-go/tcworkermanager/tcworkermanager.go
@@ -178,7 +178,7 @@ func (workerManager *WorkerManager) ListProviders_SignedURL(continuationToken, l
 // See #createWorkerPool
 func (workerManager *WorkerManager) CreateWorkerPool(workerPoolId string, payload *WorkerPoolDefinition) (*WorkerPoolFullDefinition, error) {
 	cd := tcclient.Client(*workerManager)
-	responseObject, _, err := (&cd).APICall(payload, "PUT", "/worker-pool/"+url.QueryEscape(workerPoolId), new(WorkerPoolFullDefinition), nil)
+	responseObject, _, err := (&cd).APICall(payload, "PUT", "/worker-pool/"+url.PathEscape(workerPoolId), new(WorkerPoolFullDefinition), nil)
 	return responseObject.(*WorkerPoolFullDefinition), err
 }
 
@@ -201,7 +201,7 @@ func (workerManager *WorkerManager) CreateWorkerPool(workerPoolId string, payloa
 // See #updateWorkerPool
 func (workerManager *WorkerManager) UpdateWorkerPool(workerPoolId string, payload *WorkerPoolDefinition1) (*WorkerPoolFullDefinition, error) {
 	cd := tcclient.Client(*workerManager)
-	responseObject, _, err := (&cd).APICall(payload, "POST", "/worker-pool/"+url.QueryEscape(workerPoolId), new(WorkerPoolFullDefinition), nil)
+	responseObject, _, err := (&cd).APICall(payload, "POST", "/worker-pool/"+url.PathEscape(workerPoolId), new(WorkerPoolFullDefinition), nil)
 	return responseObject.(*WorkerPoolFullDefinition), err
 }
 
@@ -217,7 +217,7 @@ func (workerManager *WorkerManager) UpdateWorkerPool(workerPoolId string, payloa
 // See #deleteWorkerPool
 func (workerManager *WorkerManager) DeleteWorkerPool(workerPoolId string) (*WorkerPoolFullDefinition, error) {
 	cd := tcclient.Client(*workerManager)
-	responseObject, _, err := (&cd).APICall(nil, "DELETE", "/worker-pool/"+url.QueryEscape(workerPoolId), new(WorkerPoolFullDefinition), nil)
+	responseObject, _, err := (&cd).APICall(nil, "DELETE", "/worker-pool/"+url.PathEscape(workerPoolId), new(WorkerPoolFullDefinition), nil)
 	return responseObject.(*WorkerPoolFullDefinition), err
 }
 
@@ -244,7 +244,7 @@ func (workerManager *WorkerManager) ListWorkerPoolLaunchConfigs(workerPoolId, co
 		v.Add("limit", limit)
 	}
 	cd := tcclient.Client(*workerManager)
-	responseObject, _, err := (&cd).APICall(nil, "GET", "/worker-pool/"+url.QueryEscape(workerPoolId)+"/launch-configs", new(WorkerPoolLaunchConfigList), v)
+	responseObject, _, err := (&cd).APICall(nil, "GET", "/worker-pool/"+url.PathEscape(workerPoolId)+"/launch-configs", new(WorkerPoolLaunchConfigList), v)
 	return responseObject.(*WorkerPoolLaunchConfigList), err
 }
 
@@ -267,7 +267,7 @@ func (workerManager *WorkerManager) ListWorkerPoolLaunchConfigs_SignedURL(worker
 		v.Add("limit", limit)
 	}
 	cd := tcclient.Client(*workerManager)
-	return (&cd).SignedURL("/worker-pool/"+url.QueryEscape(workerPoolId)+"/launch-configs", v, duration)
+	return (&cd).SignedURL("/worker-pool/"+url.PathEscape(workerPoolId)+"/launch-configs", v, duration)
 }
 
 // Stability: *** EXPERIMENTAL ***
@@ -282,7 +282,7 @@ func (workerManager *WorkerManager) ListWorkerPoolLaunchConfigs_SignedURL(worker
 // See #workerPoolStats
 func (workerManager *WorkerManager) WorkerPoolStats(workerPoolId string) (*WorkerPoolStatistics, error) {
 	cd := tcclient.Client(*workerManager)
-	responseObject, _, err := (&cd).APICall(nil, "GET", "/worker-pool/"+url.QueryEscape(workerPoolId)+"/stats", new(WorkerPoolStatistics), nil)
+	responseObject, _, err := (&cd).APICall(nil, "GET", "/worker-pool/"+url.PathEscape(workerPoolId)+"/stats", new(WorkerPoolStatistics), nil)
 	return responseObject.(*WorkerPoolStatistics), err
 }
 
@@ -295,7 +295,7 @@ func (workerManager *WorkerManager) WorkerPoolStats(workerPoolId string) (*Worke
 // See WorkerPoolStats for more details.
 func (workerManager *WorkerManager) WorkerPoolStats_SignedURL(workerPoolId string, duration time.Duration) (*url.URL, error) {
 	cd := tcclient.Client(*workerManager)
-	return (&cd).SignedURL("/worker-pool/"+url.QueryEscape(workerPoolId)+"/stats", nil, duration)
+	return (&cd).SignedURL("/worker-pool/"+url.PathEscape(workerPoolId)+"/stats", nil, duration)
 }
 
 // Fetch an existing worker pool defition.
@@ -307,7 +307,7 @@ func (workerManager *WorkerManager) WorkerPoolStats_SignedURL(workerPoolId strin
 // See #workerPool
 func (workerManager *WorkerManager) WorkerPool(workerPoolId string) (*WorkerPoolFullDefinition, error) {
 	cd := tcclient.Client(*workerManager)
-	responseObject, _, err := (&cd).APICall(nil, "GET", "/worker-pool/"+url.QueryEscape(workerPoolId), new(WorkerPoolFullDefinition), nil)
+	responseObject, _, err := (&cd).APICall(nil, "GET", "/worker-pool/"+url.PathEscape(workerPoolId), new(WorkerPoolFullDefinition), nil)
 	return responseObject.(*WorkerPoolFullDefinition), err
 }
 
@@ -320,7 +320,7 @@ func (workerManager *WorkerManager) WorkerPool(workerPoolId string) (*WorkerPool
 // See WorkerPool for more details.
 func (workerManager *WorkerManager) WorkerPool_SignedURL(workerPoolId string, duration time.Duration) (*url.URL, error) {
 	cd := tcclient.Client(*workerManager)
-	return (&cd).SignedURL("/worker-pool/"+url.QueryEscape(workerPoolId), nil, duration)
+	return (&cd).SignedURL("/worker-pool/"+url.PathEscape(workerPoolId), nil, duration)
 }
 
 // Get the list of all the existing worker pools.
@@ -422,7 +422,7 @@ func (workerManager *WorkerManager) ListWorkerPoolsStats_SignedURL(continuationT
 // See #reportWorkerError
 func (workerManager *WorkerManager) ReportWorkerError(workerPoolId string, payload *WorkerErrorReport) (*WorkerPoolError, error) {
 	cd := tcclient.Client(*workerManager)
-	responseObject, _, err := (&cd).APICall(payload, "POST", "/worker-pool-errors/"+url.QueryEscape(workerPoolId), new(WorkerPoolError), nil)
+	responseObject, _, err := (&cd).APICall(payload, "POST", "/worker-pool-errors/"+url.PathEscape(workerPoolId), new(WorkerPoolError), nil)
 	return responseObject.(*WorkerPoolError), err
 }
 
@@ -487,7 +487,7 @@ func (workerManager *WorkerManager) ListWorkerPoolErrors(workerPoolId, continuat
 		v.Add("limit", limit)
 	}
 	cd := tcclient.Client(*workerManager)
-	responseObject, _, err := (&cd).APICall(nil, "GET", "/worker-pool-errors/"+url.QueryEscape(workerPoolId), new(WorkerPoolErrorList), v)
+	responseObject, _, err := (&cd).APICall(nil, "GET", "/worker-pool-errors/"+url.PathEscape(workerPoolId), new(WorkerPoolErrorList), v)
 	return responseObject.(*WorkerPoolErrorList), err
 }
 
@@ -513,7 +513,7 @@ func (workerManager *WorkerManager) ListWorkerPoolErrors_SignedURL(workerPoolId,
 		v.Add("limit", limit)
 	}
 	cd := tcclient.Client(*workerManager)
-	return (&cd).SignedURL("/worker-pool-errors/"+url.QueryEscape(workerPoolId), v, duration)
+	return (&cd).SignedURL("/worker-pool-errors/"+url.PathEscape(workerPoolId), v, duration)
 }
 
 // Get the list of all the existing workers in a given group in a given worker pool.
@@ -532,7 +532,7 @@ func (workerManager *WorkerManager) ListWorkersForWorkerGroup(workerPoolId, work
 		v.Add("limit", limit)
 	}
 	cd := tcclient.Client(*workerManager)
-	responseObject, _, err := (&cd).APICall(nil, "GET", "/workers/"+url.QueryEscape(workerPoolId)+"/"+url.QueryEscape(workerGroup), new(WorkerListInAGivenWorkerPool), v)
+	responseObject, _, err := (&cd).APICall(nil, "GET", "/workers/"+url.PathEscape(workerPoolId)+"/"+url.PathEscape(workerGroup), new(WorkerListInAGivenWorkerPool), v)
 	return responseObject.(*WorkerListInAGivenWorkerPool), err
 }
 
@@ -552,7 +552,7 @@ func (workerManager *WorkerManager) ListWorkersForWorkerGroup_SignedURL(workerPo
 		v.Add("limit", limit)
 	}
 	cd := tcclient.Client(*workerManager)
-	return (&cd).SignedURL("/workers/"+url.QueryEscape(workerPoolId)+"/"+url.QueryEscape(workerGroup), v, duration)
+	return (&cd).SignedURL("/workers/"+url.PathEscape(workerPoolId)+"/"+url.PathEscape(workerGroup), v, duration)
 }
 
 // Get a single worker.
@@ -564,7 +564,7 @@ func (workerManager *WorkerManager) ListWorkersForWorkerGroup_SignedURL(workerPo
 // See #worker
 func (workerManager *WorkerManager) Worker(workerPoolId, workerGroup, workerId string) (*WorkerFullDefinition, error) {
 	cd := tcclient.Client(*workerManager)
-	responseObject, _, err := (&cd).APICall(nil, "GET", "/workers/"+url.QueryEscape(workerPoolId)+"/"+url.QueryEscape(workerGroup)+"/"+url.QueryEscape(workerId), new(WorkerFullDefinition), nil)
+	responseObject, _, err := (&cd).APICall(nil, "GET", "/workers/"+url.PathEscape(workerPoolId)+"/"+url.PathEscape(workerGroup)+"/"+url.PathEscape(workerId), new(WorkerFullDefinition), nil)
 	return responseObject.(*WorkerFullDefinition), err
 }
 
@@ -577,7 +577,7 @@ func (workerManager *WorkerManager) Worker(workerPoolId, workerGroup, workerId s
 // See Worker for more details.
 func (workerManager *WorkerManager) Worker_SignedURL(workerPoolId, workerGroup, workerId string, duration time.Duration) (*url.URL, error) {
 	cd := tcclient.Client(*workerManager)
-	return (&cd).SignedURL("/workers/"+url.QueryEscape(workerPoolId)+"/"+url.QueryEscape(workerGroup)+"/"+url.QueryEscape(workerId), nil, duration)
+	return (&cd).SignedURL("/workers/"+url.PathEscape(workerPoolId)+"/"+url.PathEscape(workerGroup)+"/"+url.PathEscape(workerId), nil, duration)
 }
 
 // Create a new worker.  This is only useful for worker pools where the provider
@@ -594,7 +594,7 @@ func (workerManager *WorkerManager) Worker_SignedURL(workerPoolId, workerGroup, 
 // See #createWorker
 func (workerManager *WorkerManager) CreateWorker(workerPoolId, workerGroup, workerId string, payload *WorkerCreationUpdateRequest) (*WorkerFullDefinition, error) {
 	cd := tcclient.Client(*workerManager)
-	responseObject, _, err := (&cd).APICall(payload, "PUT", "/workers/"+url.QueryEscape(workerPoolId)+"/"+url.QueryEscape(workerGroup)+"/"+url.QueryEscape(workerId), new(WorkerFullDefinition), nil)
+	responseObject, _, err := (&cd).APICall(payload, "PUT", "/workers/"+url.PathEscape(workerPoolId)+"/"+url.PathEscape(workerGroup)+"/"+url.PathEscape(workerId), new(WorkerFullDefinition), nil)
 	return responseObject.(*WorkerFullDefinition), err
 }
 
@@ -613,7 +613,7 @@ func (workerManager *WorkerManager) CreateWorker(workerPoolId, workerGroup, work
 // See #updateWorker
 func (workerManager *WorkerManager) UpdateWorker(workerPoolId, workerGroup, workerId string, payload *WorkerCreationUpdateRequest) (*WorkerFullDefinition, error) {
 	cd := tcclient.Client(*workerManager)
-	responseObject, _, err := (&cd).APICall(payload, "POST", "/workers/"+url.QueryEscape(workerPoolId)+"/"+url.QueryEscape(workerGroup)+"/"+url.QueryEscape(workerId), new(WorkerFullDefinition), nil)
+	responseObject, _, err := (&cd).APICall(payload, "POST", "/workers/"+url.PathEscape(workerPoolId)+"/"+url.PathEscape(workerGroup)+"/"+url.PathEscape(workerId), new(WorkerFullDefinition), nil)
 	return responseObject.(*WorkerFullDefinition), err
 }
 
@@ -630,7 +630,7 @@ func (workerManager *WorkerManager) UpdateWorker(workerPoolId, workerGroup, work
 // See #removeWorker
 func (workerManager *WorkerManager) RemoveWorker(workerPoolId, workerGroup, workerId string) error {
 	cd := tcclient.Client(*workerManager)
-	_, _, err := (&cd).APICall(nil, "DELETE", "/workers/"+url.QueryEscape(workerPoolId)+"/"+url.QueryEscape(workerGroup)+"/"+url.QueryEscape(workerId), nil, nil)
+	_, _, err := (&cd).APICall(nil, "DELETE", "/workers/"+url.PathEscape(workerPoolId)+"/"+url.PathEscape(workerGroup)+"/"+url.PathEscape(workerId), nil, nil)
 	return err
 }
 
@@ -656,7 +656,7 @@ func (workerManager *WorkerManager) ListWorkersForWorkerPool(workerPoolId, conti
 		v.Add("state", state)
 	}
 	cd := tcclient.Client(*workerManager)
-	responseObject, _, err := (&cd).APICall(nil, "GET", "/workers/"+url.QueryEscape(workerPoolId), new(WorkerListInAGivenWorkerPool), v)
+	responseObject, _, err := (&cd).APICall(nil, "GET", "/workers/"+url.PathEscape(workerPoolId), new(WorkerListInAGivenWorkerPool), v)
 	return responseObject.(*WorkerListInAGivenWorkerPool), err
 }
 
@@ -682,7 +682,7 @@ func (workerManager *WorkerManager) ListWorkersForWorkerPool_SignedURL(workerPoo
 		v.Add("state", state)
 	}
 	cd := tcclient.Client(*workerManager)
-	return (&cd).SignedURL("/workers/"+url.QueryEscape(workerPoolId), v, duration)
+	return (&cd).SignedURL("/workers/"+url.PathEscape(workerPoolId), v, duration)
 }
 
 // Register a running worker.  Workers call this method on worker start-up.
@@ -755,7 +755,7 @@ func (workerManager *WorkerManager) ListWorkers(provisionerId, workerType, conti
 		v.Add("workerState", workerState)
 	}
 	cd := tcclient.Client(*workerManager)
-	responseObject, _, err := (&cd).APICall(nil, "GET", "/provisioners/"+url.QueryEscape(provisionerId)+"/worker-types/"+url.QueryEscape(workerType)+"/workers", new(ListWorkersResponse), v)
+	responseObject, _, err := (&cd).APICall(nil, "GET", "/provisioners/"+url.PathEscape(provisionerId)+"/worker-types/"+url.PathEscape(workerType)+"/workers", new(ListWorkersResponse), v)
 	return responseObject.(*ListWorkersResponse), err
 }
 
@@ -784,7 +784,7 @@ func (workerManager *WorkerManager) ListWorkers_SignedURL(provisionerId, workerT
 		v.Add("workerState", workerState)
 	}
 	cd := tcclient.Client(*workerManager)
-	return (&cd).SignedURL("/provisioners/"+url.QueryEscape(provisionerId)+"/worker-types/"+url.QueryEscape(workerType)+"/workers", v, duration)
+	return (&cd).SignedURL("/provisioners/"+url.PathEscape(provisionerId)+"/worker-types/"+url.PathEscape(workerType)+"/workers", v, duration)
 }
 
 // Stability: *** EXPERIMENTAL ***
@@ -798,7 +798,7 @@ func (workerManager *WorkerManager) ListWorkers_SignedURL(provisionerId, workerT
 // See #getWorker
 func (workerManager *WorkerManager) GetWorker(provisionerId, workerType, workerGroup, workerId string) (*WorkerResponse, error) {
 	cd := tcclient.Client(*workerManager)
-	responseObject, _, err := (&cd).APICall(nil, "GET", "/provisioners/"+url.QueryEscape(provisionerId)+"/worker-types/"+url.QueryEscape(workerType)+"/workers/"+url.QueryEscape(workerGroup)+"/"+url.QueryEscape(workerId), new(WorkerResponse), nil)
+	responseObject, _, err := (&cd).APICall(nil, "GET", "/provisioners/"+url.PathEscape(provisionerId)+"/worker-types/"+url.PathEscape(workerType)+"/workers/"+url.PathEscape(workerGroup)+"/"+url.PathEscape(workerId), new(WorkerResponse), nil)
 	return responseObject.(*WorkerResponse), err
 }
 
@@ -811,7 +811,7 @@ func (workerManager *WorkerManager) GetWorker(provisionerId, workerType, workerG
 // See GetWorker for more details.
 func (workerManager *WorkerManager) GetWorker_SignedURL(provisionerId, workerType, workerGroup, workerId string, duration time.Duration) (*url.URL, error) {
 	cd := tcclient.Client(*workerManager)
-	return (&cd).SignedURL("/provisioners/"+url.QueryEscape(provisionerId)+"/worker-types/"+url.QueryEscape(workerType)+"/workers/"+url.QueryEscape(workerGroup)+"/"+url.QueryEscape(workerId), nil, duration)
+	return (&cd).SignedURL("/provisioners/"+url.PathEscape(provisionerId)+"/worker-types/"+url.PathEscape(workerType)+"/workers/"+url.PathEscape(workerGroup)+"/"+url.PathEscape(workerId), nil, duration)
 }
 
 // Respond with a service heartbeat.


### PR DESCRIPTION
The go client was using `QueryEscape` to escape path parameters, however, that is not the correct function to escape paths (`PathEscape` as the name implies is better suited for that).

`QueryEscape` follows the `application/x-www-form-urlencoded` spec, which encodes more than what paths require but also replaces spaces by `+`. The over-encoding isn't an issue since the server would decode that, but the space replacement means that for example, a secret with a space in it could never get retrieved by the go client (as it would request `a+b` instead of `a b`.)

This behavior was very visible when uploading artifacts with a space in their name as they'd end up stored with a `+` instead. It gets worse when you had an artifact named `a b` and `a+b` as it would upload the second one on top of the first. All services in the client were affected but since the taskcluster CLI uses its own URL builder for API calls (where it calls `strings.ReplaceAll(url.QueryEscape(v), "+", "%20")` to work around this issue), the only product really affected by this change is generic-worker.

I added a simple test using the secrets service because this is the easiest way I figured out how to test the behavior without a complicated setup.

This is a breaking change because anyone relying on space in artifacts being replaced by a `+` will have to remove their workarounds for it.

It's also worth noting that this brings the go client in line with the other clients (js, py, rs) which were already all doing the right thing.

Fixes #7765
