### PR TITLE
fix(generic-worker): allow tasks to create new consoles (windows)

### DIFF
--- a/changelog/issue-8115.md
+++ b/changelog/issue-8115.md
@@ -1,0 +1,5 @@
+audience: worker-deployers
+level: patch
+reference: issue 8115
+---
+Generic Worker (windows): reverts #8030 to use `CREATE_NEW_CONSOLE` over `CREATE_NO_WINDOW` so that child processes can call `AllocConsole()` to create new consoles.

--- a/workers/generic-worker/process/multiuser_windows.go
+++ b/workers/generic-worker/process/multiuser_windows.go
@@ -87,7 +87,7 @@ func newCommand(f func() *exec.Cmd, workingDirectory string, env []string, pd *P
 	cmd.Env = *combined
 	cmd.Dir = workingDirectory
 	isWindows8OrGreater := win32.IsWindows8OrGreater()
-	creationFlags := uint32(win32.CREATE_NEW_PROCESS_GROUP | win32.CREATE_NO_WINDOW)
+	creationFlags := uint32(win32.CREATE_NEW_PROCESS_GROUP | win32.CREATE_NEW_CONSOLE)
 	if !isWindows8OrGreater {
 		creationFlags |= win32.CREATE_BREAKAWAY_FROM_JOB
 	}

--- a/workers/generic-worker/runtime/runtime_windows.go
+++ b/workers/generic-worker/runtime/runtime_windows.go
@@ -92,9 +92,9 @@ func (osUser *OSUser) CreateUserProfile() error {
 	// Verify the profile directory is accessible before returning
 	// CreateProfile may return before the file system has fully initialized the directory
 	// This prevents ERROR_NOT_READY errors when LoadUserProfile is called immediately after
-	const maxRetries = 10
+	const maxRetries = 25
 	const initialDelay = 50 * time.Millisecond
-	const maxDelay = 2 * time.Second
+	const maxDelay = 5 * time.Second
 	const backoffMultiplier = 1.5
 
 	delay := initialDelay

--- a/workers/generic-worker/win32/win32_windows.go
+++ b/workers/generic-worker/win32/win32_windows.go
@@ -67,8 +67,9 @@ const (
 
 	KF_FLAG_CREATE uint32 = 0x00008000
 
+	// https://learn.microsoft.com/en-us/windows/win32/procthread/process-creation-flags
 	CREATE_BREAKAWAY_FROM_JOB = 0x01000000
-	CREATE_NO_WINDOW          = 0x08000000
+	CREATE_NEW_CONSOLE        = 0x00000010
 	CREATE_NEW_PROCESS_GROUP  = 0x00000200
 
 	VER_MAJORVERSION     = 0x0000002


### PR DESCRIPTION
Fixes #8115.

>Generic Worker (windows): reverts #8030 to use `CREATE_NEW_CONSOLE` over `CREATE_NO_WINDOW` so that child processes can call `AllocConsole()` to create new consoles.