### PR TITLE
fix(cli): url path encode rather than query encode url paths

### DIFF
--- a/changelog/issue-8121.md
+++ b/changelog/issue-8121.md
@@ -1,0 +1,5 @@
+audience: users
+level: patch
+reference: issue 8121
+---
+The taskcluster CLI now encodes URL path parameters as path parametes rather than as query string parameters.

--- a/clients/client-shell/apis/provider.go
+++ b/clients/client-shell/apis/provider.go
@@ -171,7 +171,7 @@ func execute(
 	// Parameterize the route
 	route := entry.Route
 	for k, v := range args {
-		val := strings.ReplaceAll(url.QueryEscape(v), "+", "%20")
+		val := url.PathEscape(v)
 		route = strings.Replace(route, "<"+k+">", val, 1)
 	}
 


### PR DESCRIPTION
Github Bug/Issue: Fixes #8121

This short go program demonstrates the change in behaviour:

```
pmoore@Petes-MacBook-Pro:~/git/taskcluster main $ cat ~/test.go 
package main

import (
	"fmt"
	"net/url"
	"unicode/utf8"
)

func main() {
	for r := rune(0); r <= utf8.MaxRune; r++ {
		s := string(r)
		pathEsc := url.PathEscape(s)
		queryEsc := url.QueryEscape(s)
		if pathEsc != queryEsc {
			fmt.Printf("U+%04X %-10q  PathEscape=%-12q  QueryEscape=%-12q\n", r, s, pathEsc, queryEsc)
		}
	}
}
pmoore@Petes-MacBook-Pro:~/git/taskcluster main $ go run ~/test.go
U+0020 " "         PathEscape="%20"         QueryEscape="+"         
U+0024 "$"         PathEscape="$"           QueryEscape="%24"       
U+0026 "&"         PathEscape="&"           QueryEscape="%26"       
U+002B "+"         PathEscape="+"           QueryEscape="%2B"       
U+003A ":"         PathEscape=":"           QueryEscape="%3A"       
U+003D "="         PathEscape="="           QueryEscape="%3D"       
U+0040 "@"         PathEscape="@"           QueryEscape="%40"       
pmoore@Petes-MacBook-Pro:~/git/taskcluster main $
```

The previous version performed QueryEscape and then converted `+` to `%20`, so the updated version only affects the encoding of the other characters, i.e. no longer encodes `$&+:=@` characters.