### PR TITLE
feat(w-m): Improve GCP error handling during provision

### DIFF
--- a/changelog/a-MjnJbJRZCqdSAT3yX8tQ.md
+++ b/changelog/a-MjnJbJRZCqdSAT3yX8tQ.md
@@ -1,0 +1,5 @@
+audience: worker-deployers
+level: patch
+---
+Fixes errors handling for upgraded googleapis packages. Instance creation errors were sent differently,
+which didn't allow to log some provision exceptions.

--- a/services/worker-manager/test/fakes/google.js
+++ b/services/worker-manager/test/fakes/google.js
@@ -76,13 +76,20 @@ export class FakeGoogle extends FakeCloud {
     };
   }
 
-  /**
-   * Make an API error in the shape the google apis return
-   */
   makeError(message, code) {
     const err = new Error(message);
     err.code = code;
-    err.errors = [{ message }];
+    err.status = code;
+    err.response = {
+      data: {
+        error: {
+          code,
+          message,
+          errors: [{ message, code }],
+        },
+      },
+    };
+    err.errors = err.response.data.error.errors;
     return err;
   }
 }


### PR DESCRIPTION
After @googleapis/compute upgrade, errrors were passed differently, so they failed to be reported to worker pool

