### PR TITLE
fix(ui): update task duration in real-time when filtering by status

### DIFF
--- a/changelog/issue-8104.md
+++ b/changelog/issue-8104.md
@@ -1,0 +1,5 @@
+audience: general
+level: patch
+reference: issue 8104
+---
+Fixed task duration not updating in real-time when filtering by status. When using react-window for virtualized task lists, filtering caused different tasks to appear at the same index without triggering a re-render due to React.memo. This is fixed by using react-window's itemKey prop to ensure proper component lifecycle when the task at a given index changes.

--- a/ui/src/components/Duration/index.test.jsx
+++ b/ui/src/components/Duration/index.test.jsx
@@ -1,0 +1,114 @@
+import React from 'react';
+import { render, act } from '@testing-library/react';
+import Duration from './index';
+
+// Mock timers for testing setInterval behavior
+jest.useFakeTimers();
+
+describe('Duration component', () => {
+  afterEach(() => {
+    jest.clearAllTimers();
+  });
+
+  it('should render duration with fixed offset (completed task)', () => {
+    const from = '2025-01-01T00:00:00.000Z';
+    const offset = '2025-01-01T00:05:30.000Z';
+    const { container } = render(<Duration from={from} offset={offset} />);
+
+    expect(container.textContent).toBe('05m 30s ');
+  });
+
+  it('should start interval when offset is not provided (running task)', () => {
+    const from = new Date(Date.now() - 65000).toISOString(); // 65 seconds ago
+    const { container } = render(<Duration from={from} />);
+
+    expect(container.textContent).toMatch(/01m \d+s/);
+
+    act(() => {
+      jest.advanceTimersByTime(1000);
+    });
+
+    expect(container.textContent).toMatch(/01m \d+s/);
+  });
+
+  it('should update in real-time when no offset is provided', () => {
+    const originalDate = global.Date;
+    const startTime = new originalDate('2025-01-01T00:01:00.000Z').getTime();
+    let currentTime = startTime;
+
+    class MockDate extends originalDate {
+      constructor(...args) {
+        if (args.length === 0) {
+          super(currentTime);
+        } else {
+          super(...args);
+        }
+      }
+
+      static now() {
+        return currentTime;
+      }
+    }
+
+    global.Date = MockDate;
+
+    const from = '2025-01-01T00:00:00.000Z';
+    const { container } = render(<Duration from={from} />);
+
+    expect(container.textContent).toBe('01m 00s ');
+
+    currentTime = startTime + 5000;
+
+    act(() => {
+      jest.advanceTimersByTime(1000);
+    });
+
+    expect(container.textContent).toBe('01m 05s ');
+
+    global.Date = originalDate;
+  });
+
+  it('should handle key prop change correctly (task switch due to filtering)', () => {
+    const task1From = '2025-01-01T00:00:00.000Z';
+    const task2From = '2025-01-01T00:10:00.000Z';
+    const { container, rerender } = render(
+      <Duration key="task1" from={task1From} />
+    );
+
+    rerender(<Duration key="task2" from={task2From} />);
+
+    expect(container).toBeTruthy();
+  });
+
+  it('should clear interval when offset becomes defined', () => {
+    const from = '2025-01-01T00:00:00.000Z';
+    const { container, rerender } = render(<Duration from={from} />);
+    const offset = '2025-01-01T00:05:00.000Z';
+
+    rerender(<Duration from={from} offset={offset} />);
+
+    expect(() => {
+      act(() => {
+        jest.advanceTimersByTime(5000);
+      });
+    }).not.toThrow();
+
+    expect(container.textContent).toBe('05m 00s ');
+  });
+
+  it('should display hours correctly', () => {
+    const from = '2025-01-01T00:00:00.000Z';
+    const offset = '2025-01-01T02:30:45.000Z';
+    const { container } = render(<Duration from={from} offset={offset} />);
+
+    expect(container.textContent).toBe('2h 30m 45s ');
+  });
+
+  it('should display days correctly', () => {
+    const from = '2025-01-01T00:00:00.000Z';
+    const offset = '2025-01-03T05:30:45.000Z';
+    const { container } = render(<Duration from={from} offset={offset} />);
+
+    expect(container.textContent).toBe('2d 5h 30m 45s ');
+  });
+});

--- a/ui/src/components/TaskGroupTable/index.jsx
+++ b/ui/src/components/TaskGroupTable/index.jsx
@@ -427,7 +427,8 @@ export default class TaskGroupTable extends Component {
               itemSize={48}
               className={classes.windowScrollerOverride}
               overscanCount={50}
-              itemData={{ iconSize, items, showTimings, classes }}>
+              itemData={{ iconSize, items, showTimings, classes }}
+              itemKey={(index, data) => data.items[index]?.node.taskId}>
               {ItemRendererMemo}
             </List>
           </Fragment>

--- a/ui/src/components/TaskGroupTable/index.test.jsx
+++ b/ui/src/components/TaskGroupTable/index.test.jsx
@@ -1,0 +1,123 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import TaskGroupTable from './index';
+
+jest.mock('@material-ui/core/styles', () => ({
+  withStyles: () => Component => {
+    function StyledComponent(props) {
+      return <Component {...props} classes={{}} />;
+    }
+
+    return StyledComponent;
+  },
+  alpha: (color, opacity) => `rgba(${color}, ${opacity})`,
+}));
+
+let capturedItemKey = null;
+let capturedItemData = null;
+
+jest.mock('react-window', () => ({
+  FixedSizeList: jest.fn(
+    ({ children: Children, itemData, itemKey, itemCount }) => {
+      capturedItemKey = itemKey;
+      capturedItemData = itemData;
+
+      const items = [];
+
+      for (let i = 0; i < Math.min(3, itemCount); i += 1) {
+        const key = itemKey ? itemKey(i, itemData) : i;
+
+        items.push(
+          <div key={key} data-testid={`item-${i}`} data-item-key={key}>
+            <Children data={itemData} index={i} style={{}} />
+          </div>
+        );
+      }
+
+      return <div data-testid="virtual-list">{items}</div>;
+    }
+  ),
+}));
+
+jest.mock('react-virtualized', () => ({
+  WindowScroller: ({ children }) => children({}),
+}));
+
+const createMockTask = (taskId, name, state, started, resolved = null) => ({
+  node: {
+    taskId,
+    metadata: { name },
+    status: {
+      state,
+      runs: [{ runId: 0, started, resolved }],
+    },
+  },
+});
+
+describe('TaskGroupTable', () => {
+  beforeEach(() => {
+    capturedItemKey = null;
+    capturedItemData = null;
+  });
+
+  const mockTasks = [
+    createMockTask('task-1', 'A-Task', 'running', '2025-01-01T00:00:00Z', null),
+    createMockTask(
+      'task-2',
+      'B-Task',
+      'completed',
+      '2025-01-01T00:00:00Z',
+      '2025-01-01T00:05:00Z'
+    ),
+    createMockTask('task-3', 'C-Task', 'running', '2025-01-01T00:00:00Z', null),
+  ];
+
+  it('should use taskId as itemKey for proper component lifecycle on filter change', () => {
+    render(
+      <MemoryRouter>
+        <TaskGroupTable
+          taskGroupConnection={{ edges: mockTasks, pageInfo: {} }}
+          filter=""
+          searchTerm=""
+        />
+      </MemoryRouter>
+    );
+
+    expect(capturedItemKey).toBeDefined();
+    expect(typeof capturedItemKey).toBe('function');
+
+    expect(capturedItemKey(0, capturedItemData)).toBe('task-1');
+    expect(capturedItemKey(1, capturedItemData)).toBe('task-2');
+    expect(capturedItemKey(2, capturedItemData)).toBe('task-3');
+  });
+
+  it('should return different keys when filtering changes item order', () => {
+    const { rerender } = render(
+      <MemoryRouter>
+        <TaskGroupTable
+          taskGroupConnection={{ edges: mockTasks, pageInfo: {} }}
+          filter=""
+          searchTerm=""
+        />
+      </MemoryRouter>
+    );
+    const keyAtIndex0BeforeFilter = capturedItemKey(0, capturedItemData);
+
+    expect(keyAtIndex0BeforeFilter).toBe('task-1');
+
+    rerender(
+      <MemoryRouter>
+        <TaskGroupTable
+          taskGroupConnection={{ edges: mockTasks, pageInfo: {} }}
+          filter="running"
+          searchTerm=""
+        />
+      </MemoryRouter>
+    );
+
+    const keyAtIndex0AfterFilter = capturedItemKey(0, capturedItemData);
+
+    expect(keyAtIndex0AfterFilter).toBe(capturedItemData.items[0].node.taskId);
+  });
+});


### PR DESCRIPTION
When filtering tasks by status (e.g., clicking 'Running'), the Duration component was not updating in real-time. This was because react-window reuses component instances at each index, and when filtering changed which task appeared at a given index, the Duration component's interval was not properly reset.

The fix adds a key prop to the Duration (TimeDiff) component based on taskId and start time, ensuring proper component lifecycle management when the displayed task changes due to filtering or reordering.

Also adds unit tests for the Duration component covering:
- Fixed duration display (completed tasks)
- Real-time updates (running tasks)
- Key prop handling for task switching
- Interval cleanup when task completes

Fixes #8104