### PR TITLE
refactor: extract appendQueueScopes helper function

### DIFF
--- a/tools/d2g/d2g.go
+++ b/tools/d2g/d2g.go
@@ -180,6 +180,9 @@ func ConvertScopes(
 			gwScopes = append(gwScopes, "generic-worker:loopback-audio:"+s[len("docker-worker:capability:device:loopbackAudio:"):])
 		case strings.HasPrefix(s, "docker-worker:"):
 			gwScopes = append(gwScopes, "generic-worker:"+s[len("docker-worker:"):])
+		case s == "docker-worker:capability:device:kvm":
+			gwScopes = AppendQueueScopes(gwScopes, taskQueueID, "kvm")
+			gwScopes = AppendQueueScopes(gwScopes, taskQueueID, "libvirt")
 		}
 	}
 
@@ -675,4 +678,10 @@ func envMappings(dwPayload *dockerworker.DockerWorkerPayload, config Config) (st
 		envListStrBuilder.WriteString(envVar + "\n")
 	}
 	return envListStrBuilder.String(), nonEnvListArgs
+}
+
+func AppendQueueScopes(gwScopes []string, taskQueueID, capability string) []string {
+	return append(gwScopes,
+		fmt.Sprintf("generic-worker:os-group:%s/%s", taskQueueID, capability),
+	)
 }


### PR DESCRIPTION
- Add appendQueueScopes helper to reduce code duplication
- Add comprehensive unit tests for the new helper
- Improves maintainability in ConvertScopes function

Fixes: code duplication in scope conversion logic

<!-- Did you remember to add a changelog snippet? See
     https://github.com/taskcluster/taskcluster/blob/main/dev-docs/best-practices/changelog.md

     If this is related to a Bugzilla bug, please begin your title with [Bug XXXXX]
     and update this link.  Otherwise, just remove it from your PR comment.  -->

Bugzilla Bug: [XXXXX](https://bugzilla.mozilla.org/show_bug.cgi?id=XXXXX)

<!-- If this is related to a GitHub Bug/Issue, Please write Issue Number after # in the next line. Otherwise, just remove it from your PR comment. -->

Github Bug/Issue: Fixes #XXXX
