### PR TITLE
feat(pulse): use quorum queues and bump rmq to v4

### DIFF
--- a/changelog/issue-8156.md
+++ b/changelog/issue-8156.md
@@ -1,0 +1,5 @@
+audience: deployers
+level: minor
+reference: issue 8156
+---
+Pulse library declares non-ephemeral core Taskcluster queues as quorum queues to prepare for upgrading to RabbitMQ v4+.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ networks:
     driver: bridge
 services:
   rabbitmq:
-    image: rabbitmq:3.12.1-management
+    image: rabbitmq:4.2.1-management
     networks:
       - local
     healthcheck:

--- a/infrastructure/tooling/src/generate/generators/docker-compose.js
+++ b/infrastructure/tooling/src/generate/generators/docker-compose.js
@@ -277,7 +277,7 @@ tasks.push({
       },
       services: {
         rabbitmq: serviceDefinition('rabbitmq', {
-          image: 'rabbitmq:3.12.1-management',
+          image: 'rabbitmq:4.2.1-management',
           healthcheck: healthcheck('rabbitmq-diagnostics ping'),
           ports: [
             '5672:5672',

--- a/libraries/pulse/src/consumer.js
+++ b/libraries/pulse/src/consumer.js
@@ -154,6 +154,10 @@ export class PulseConsumer {
       durable: true,
       autoDelete: this.ephemeral,
       ...this.queueOptions,
+      arguments: {
+        ...(!this.ephemeral && { 'x-queue-type': 'quorum' }),
+        ...this.queueOptions.arguments,
+      },
     });
 
     for (let { exchange, routingKeyPattern } of this.bindings) {

--- a/services/web-server/src/PulseEngine/Subscription.js
+++ b/services/web-server/src/PulseEngine/Subscription.js
@@ -70,6 +70,7 @@ export default class Subscription {
           durable: true,
           autoDelete: false,
           expires: 30000, // 30 seconds, long enough for a reconnect
+          arguments: { 'x-queue-type': 'quorum' },
         });
 
         // perform the queue binding in a new channel, so that the existing channel


### PR DESCRIPTION
Fixes https://github.com/taskcluster/taskcluster/issues/8074.

>Pulse library declares non-ephemeral core Taskcluster queues as quorum queues to prepare for upgrading to RabbitMQ v4+.