### PR TITLE
fix(d2g): garbage collector prunes entire system

### DIFF
--- a/changelog/issue-8153.md
+++ b/changelog/issue-8153.md
@@ -1,0 +1,5 @@
+audience: worker-deployers
+level: patch
+reference: issue 8153
+---
+Generic Worker (d2g): anonymous volumes from the task container are no longer removed at the end of a task run in order to resolve the task sooner. The garbage collector was updated to take care of these instead.

--- a/workers/generic-worker/d2g_feature.go
+++ b/workers/generic-worker/d2g_feature.go
@@ -247,7 +247,6 @@ func (dtf *D2GTaskFeature) Stop(err *ExecutionErrors) {
 		"docker",
 		"rm",
 		"--force",
-		"--volumes",
 		dtf.task.D2GInfo.ContainerName,
 	}, taskContext.TaskDir, []string{}, dtf.task.pd)
 	if e != nil {


### PR DESCRIPTION
Fixes #8153.

>Generic Worker (d2g): anonymous volumes from the task container are no longer removed at the end of a task run in order to resolve the task sooner. The garbage collector was updated to take care of these instead.

cc @Eijebong