### PR TITLE
Let worker-runner unregister workers when they shutdown with idle timeout

### DIFF
--- a/changelog/T0YIfpClSNeg6YrNUv2-Rw.md
+++ b/changelog/T0YIfpClSNeg6YrNUv2-Rw.md
@@ -1,0 +1,4 @@
+audience: worker-deployers
+level: patch
+---
+Worker-runner will now properly unregister a worker when it exits because of an idle timeout

--- a/workers/generic-worker/workerrunner.go
+++ b/workers/generic-worker/workerrunner.go
@@ -98,6 +98,7 @@ func startProtocol() {
 
 	WorkerRunnerProtocol.AddCapability("error-report")
 	WorkerRunnerProtocol.AddCapability("log")
+	WorkerRunnerProtocol.AddCapability("shutdown")
 
 	WorkerRunnerProtocol.Start(true)
 }


### PR DESCRIPTION
Currently on idle timeout, the worker decides to shut the machine down itself by using `shutdown now` and then `exit 68`. This leads to the machine shutting down while the worker is still registered, which lets worker-manager think that the worker is still alive until the cleanup loop passes by and realizes that the VM is gone which can take up to 15+mn. On pools that are not very active this can mean that we're waiting 15+mn for a new worker to spawn because there's only one task in the queue but worker manager thinks that there is a worker for it.

The root cause is that the exit code isn't read by worker-manager at all, when a worker exits with a non 0 code, it just exits itself without calling any exit handler, leaving the worker registered. Since the worker itself decides that its time has come but cannot handle its registration, worker-manager never even tries to unregister it.

Now one might think "oh that's easy, we'll just handle exit code 68 and unregister in that case" and it might work but here comes the second issue. The worker tells the machine to shut down before exiting. Which SIGTERM's worker-runner. So it most likely won't even have time to read the exit code from generic-worker, let alone make an HTTP request to unregister it.

To avoid racy behavior like this we could let the worker use `shutdown -h +1` to give a full minute to worker-manager but while looking at this, I saw that worker-manager actually exposes a `shutdown` command which allows the worker to tell it to unregister the worker which will make worker-manager terminate it.
