### PR TITLE
fix(generic-worker): shutdown with worker runner in all shutdown cases

### DIFF
--- a/changelog/X8YbdW82Rc2dgqZb8_A5IA.md
+++ b/changelog/X8YbdW82Rc2dgqZb8_A5IA.md
@@ -1,0 +1,4 @@
+audience: worker-deployers
+level: patch
+---
+Generic Worker (with worker-runner): properly unregisters a worker when it exits due to internal error or non-current deployment ID. Followup to #8165.


### PR DESCRIPTION
>Generic Worker (with worker-runner): properly unregisters a worker when it exits due to internal error or non-current deployment ID. Followup to #8165.