### PR TITLE
fix(generic-worker): limit concurrent artifact uploads to 10

### DIFF
--- a/changelog/issue-8023.md
+++ b/changelog/issue-8023.md
@@ -1,0 +1,5 @@
+audience: worker-deployers
+level: patch
+reference: issue 8023
+---
+Generic Worker: limits concurrent artifact uploads to 10 at a time. Followup to #8032.

--- a/workers/generic-worker/artifact_feature.go
+++ b/workers/generic-worker/artifact_feature.go
@@ -89,11 +89,11 @@ func (atf *ArtifactTaskFeature) Stop(err *ExecutionErrors) {
 	atf.FindArtifacts()
 	taskArtifacts := atf.artifacts
 
-	// Use errgroup to limit concurrent uploads to 100
+	// Use errgroup to limit concurrent uploads to 10
 	// to hopefully avoid issues like the following:
 	// https://github.com/taskcluster/taskcluster/issues/8023
 	group := &errgroup.Group{}
-	group.SetLimit(100)
+	group.SetLimit(10)
 
 	uploadErrChan := make(chan *CommandExecutionError, len(taskArtifacts))
 	failChan := make(chan *CommandExecutionError, len(taskArtifacts))


### PR DESCRIPTION
Related to #8023. Decreasing the number of concurrent uploads due to the translations team running into tasks uploading 1000+ artifacts not reclaiming task credentials in time during the artifact upload process. Example task https://firefox-ci-tc.services.mozilla.com/tasks/KAtxleBdSAKnyXzMDioHTA/runs/0 which ran on this worker https://firefox-ci-tc.services.mozilla.com/provisioners/translations-1/worker-types/b-linux-v100-gpu-d2g/workers/us-west1-b/7071171396857046289?sortBy=started&sortDirection=desc

>Generic Worker: limits concurrent artifact uploads to 10 at a time. Followup to #8032.