### PR TITLE
feat(w-m): Stopping capacity is no longer used in estimations

### DIFF
--- a/changelog/issue-8161.md
+++ b/changelog/issue-8161.md
@@ -1,0 +1,8 @@
+audience: worker-deployers
+level: minor
+reference: issue 8161
+---
+
+Estimator no longer includes `stoppingCapacity` to calculate how many workers needs to be created.
+This is no longer necessary since Azure started using ARM templates for deployment, which are no longer blocked
+by the worker scanner that had to provision and deprovision resources at the same time.

--- a/generated/references.json
+++ b/generated/references.json
@@ -18199,7 +18199,7 @@
           "version": 3
         },
         {
-          "description": "The simple estimator has decided that we need some number of instances.",
+          "description": "The simple estimator has decided that we need some number of instances. Note: stoppingCapacity field is deprecated and no longer used in calculations.",
           "fields": {
             "desiredCapacity": "Amount of capacity that this estimator thinks we should have",
             "existingCapacity": "Amount of currently requested and available capacity",
@@ -18208,14 +18208,14 @@
             "pendingTasks": "The number of tasks the queue reports are pending for this worker pool",
             "requestedCapacity": "Amount of capacity that this estimator thinks we should add",
             "scalingRatio": "The ratio of workers to spawn per pending task for this worker pool.",
-            "stoppingCapacity": "Amount of capacity being stopped",
+            "stoppingCapacity": "Amount of capacity being stopped (deprecated, not used in calculations)",
             "workerPoolId": "The worker pool name"
           },
           "level": "any",
           "name": "simpleEstimate",
           "title": "Simple Estimate Provided",
           "type": "simple-estimate",
-          "version": 4
+          "version": 5
         },
         {
           "description": "A simple timekeeper for measuring arbitrary time spans.",

--- a/services/worker-manager/src/data.js
+++ b/services/worker-manager/src/data.js
@@ -246,7 +246,7 @@ export class WorkerPoolStats {
     return {
       existingCapacity: this.existingCapacity,
       requestedCapacity: this.requestedCapacity,
-      stoppingCapacity: this.stoppingCapacity,
+      stoppingCapacity: this.stoppingCapacity, // Deprecated: no longer used in capacity estimation
     };
   }
 

--- a/services/worker-manager/src/estimator.js
+++ b/services/worker-manager/src/estimator.js
@@ -19,23 +19,15 @@ export class Estimator {
     // we assume that idle workers are going to pick up tasks soon
     const adjustedPendingTasks = Math.max(0, pendingTasks - totalIdleCapacity);
 
-    // Due to the fact that workers could fail to start on azure, deprovisioning will take significant amount of time
-    // and on the next provision loop, those workers wouldn't be considered as requested or existing capacity
-    // so worker manager would try to provision for this pool again
-    // workers in stopping state would keep growing, and deprovisioning takes many calls, even though it wasn't created
-    // to avoid this situation we would take into account stopping capacity and don't allow worker pool
-    // to have existing + stopping capacity > max capacity to prevent affected pool start extra instances
-    const totalNonStopped = existingCapacity + stoppingCapacity;
-
     // First we find the amount of capacity we want. This is a very simple approximation
-    // We add totalNonStopped here to represent existing workers and subtract it later.
+    // We add existingCapacity here to represent existing workers and subtract it later.
     // We scale up based on the scaling ratio and number of pending tasks.
     // We ask to spawn as much capacity as the scaling ratio dictates to cover all
     // pending tasks at any time unless it would create more than maxCapacity instances
     const desiredCapacity = Math.max(
       minCapacity,
       // only scale as high as maxCapacity
-      Math.min(adjustedPendingTasks * scalingRatio + totalNonStopped, maxCapacity),
+      Math.min(adjustedPendingTasks * scalingRatio + existingCapacity, maxCapacity),
     );
     const estimatorInfo = {
       workerPoolId,
@@ -72,7 +64,7 @@ export class Estimator {
 
     // Workers turn themselves off so we just return a positive number for
     // how many extra we want if we do want any
-    const toSpawn = Math.max(0, desiredCapacity - totalNonStopped);
+    const toSpawn = Math.max(0, desiredCapacity - existingCapacity);
 
     this.exposeMetrics({ workerPoolId, existingCapacity, stoppingCapacity,
       requestedCapacity, desiredCapacity, totalIdleCapacity, adjustedPendingTasks,

--- a/services/worker-manager/src/monitor.js
+++ b/services/worker-manager/src/monitor.js
@@ -80,9 +80,9 @@ MonitorManager.register({
   name: 'simpleEstimate',
   title: 'Simple Estimate Provided',
   type: 'simple-estimate',
-  version: 4,
+  version: 5,
   level: 'any',
-  description: 'The simple estimator has decided that we need some number of instances.',
+  description: 'The simple estimator has decided that we need some number of instances. Note: stoppingCapacity field is deprecated and no longer used in calculations.',
   fields: {
     workerPoolId: 'The worker pool name',
     pendingTasks: 'The number of tasks the queue reports are pending for this worker pool',
@@ -92,7 +92,7 @@ MonitorManager.register({
     existingCapacity: 'Amount of currently requested and available capacity',
     desiredCapacity: 'Amount of capacity that this estimator thinks we should have',
     requestedCapacity: 'Amount of capacity that this estimator thinks we should add',
-    stoppingCapacity: 'Amount of capacity being stopped',
+    stoppingCapacity: 'Amount of capacity being stopped (deprecated, not used in calculations)',
   },
 });
 

--- a/services/worker-manager/test/estimator_test.js
+++ b/services/worker-manager/test/estimator_test.js
@@ -212,7 +212,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
     assert(monitor.manager.messages.some(({ Type, Severity }) => Type === 'simple-estimate' && Severity === 5));
   });
 
-  test('stopping capacity non zero', async function () {
+  test('stopping capacity non zero (deprecated - no longer affects estimation)', async function () {
     const workerInfo = {
       existingCapacity: 10,
       requestedCapacity: 10,
@@ -226,11 +226,11 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       workerInfo,
     });
 
-    assert.strictEqual(estimate, 20);
+    assert.strictEqual(estimate, 30);
     assert.strictEqual(monitor.manager.messages.length, 1);
     assert(monitor.manager.messages.some(({ Type, Severity }) => Type === 'simple-estimate' && Severity === 5));
   });
-  test('stopping capacity exceeds max capacity', async function () {
+  test('stopping capacity exceeds max capacity (deprecated - no longer affects estimation)', async function () {
     const workerInfo = {
       existingCapacity: 10,
       requestedCapacity: 10,
@@ -244,11 +244,11 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       workerInfo,
     });
 
-    assert.strictEqual(estimate, 0);
+    assert.strictEqual(estimate, 30);
     assert.strictEqual(monitor.manager.messages.length, 1);
     assert(monitor.manager.messages.some(({ Type, Severity }) => Type === 'simple-estimate' && Severity === 5));
   });
-  test('stopping + requested capacity exceeds pending', async function () {
+  test('stopping + requested capacity exceeds pending (deprecated - no longer affects estimation)', async function () {
     const workerInfo = {
       existingCapacity: 0,
       requestedCapacity: 10,


### PR DESCRIPTION
Since ARM is deploying every resource on the Azure side we are no longer blocked by having to both provision and deprovision resources in the same loop.
Another fail-safe mechanism was added in launch configs that would lower LC weight if it would have increased rate of errors.

Fixes #8161 
