### PR TITLE
fix(generic-worker): add retries to `LoadUserProfile`

### DIFF
--- a/changelog/issue-8083.md
+++ b/changelog/issue-8083.md
@@ -1,0 +1,5 @@
+audience: worker-deployers
+level: patch
+reference: issue 8083
+---
+Generic Worker (windows): adds retries to the win32 `LoadUserProfile` call to help prevent `The device is not ready` worker errors.


### PR DESCRIPTION
(Hopefully) Fixes #8083.

>Generic Worker (windows): adds retries to the win32 `LoadUserProfile` call to help prevent `The device is not ready` worker errors.