### PR TITLE
feat(w-m): Ensure workers are being launched for some edge cases

### DIFF
--- a/changelog/issue-8176.md
+++ b/changelog/issue-8176.md
@@ -1,0 +1,6 @@
+audience: worker-deployers
+level: patch
+reference: issue 8176
+---
+
+Worker-manager ensures workers are spawned for single launch config worker pools when adjusted weight might drop below zero with remaining capacity.


### PR DESCRIPTION
When worker pool has only one launch config and it contain some errors plus capacity is non zero, dynamic weight might go below zero, which would leave zero available launch configs even though capacity is not yet reached. We check if that's the only available config with remaining capacity and adjust the weight to let it be selected


Github Bug/Issue: Fixes #8176 
