### PR TITLE
feat(web): Web-server subscriptions using classic queues

### DIFF
--- a/changelog/Y22ePb6VQLuQvp03yHacpw.md
+++ b/changelog/Y22ePb6VQLuQvp03yHacpw.md
@@ -1,0 +1,6 @@
+audience: users
+level: patch
+---
+
+Switch back web-server queues to classic, as those are only used for short-lived task group updates in the UI
+and don't require same durability and Raft consensus algorithm.

--- a/services/web-server/src/PulseEngine/Subscription.js
+++ b/services/web-server/src/PulseEngine/Subscription.js
@@ -70,7 +70,6 @@ export default class Subscription {
           durable: true,
           autoDelete: false,
           expires: 30000, // 30 seconds, long enough for a reconnect
-          arguments: { 'x-queue-type': 'quorum' },
         });
 
         // perform the queue binding in a new channel, so that the existing channel


### PR DESCRIPTION
Quorum queues are durable and provide high availability at a higher memory usage cost, and for this particular UI updates use-case we don't need to use it. Classic should be enough
