### PR TITLE
Preserve caches over docker volumes/images when garbage collecting

### DIFF
--- a/changelog/GcRK4PSbSz22FQgIngKR9A.md
+++ b/changelog/GcRK4PSbSz22FQgIngKR9A.md
@@ -1,0 +1,4 @@
+audience: worker-deployers
+level: patch
+---
+Changed the garbage collector to clean caches after docker resources when d2g is enabled


### PR DESCRIPTION
I was experimenting with making my caching better and was very confused as to why any change I made didn't change *anything*. Turns out that my cache was getting evicted on every single task because I had 60GB of anonymous volumes left behind by image building. The garbage collector should, in order, clean volumes (they're always going to be garbage as we don't support named volumes), images (that's a loss, and honestly I wish there was a way to merge that with caches with a proper heuristic) and finally caches as those are the most likely to be valuable.