### PR TITLE
feat(w-m): Fix incorrectly used monitor method

### DIFF
--- a/changelog/NXh2jNrYQ9yL6d-zxwte7w.md
+++ b/changelog/NXh2jNrYQ9yL6d-zxwte7w.md
@@ -1,0 +1,3 @@
+audience: users
+level: silent
+---

--- a/services/worker-manager/src/providers/azure/index.js
+++ b/services/worker-manager/src/providers/azure/index.js
@@ -778,7 +778,7 @@ export class AzureProvider extends Provider {
       }
       monitor.debug({ message: 'found deployment operations', count: operations.length });
     } catch (error) {
-      monitor.error({ message: 'failed to query deployment operations', error });
+      monitor.reportError(error, { message: 'failed to query deployment operations' });
     }
 
     return operations;


### PR DESCRIPTION
Fixes 
```
TypeError: monitor.error is not a function
  at #fetchDeploymentOperations (file:///app/services/worker-manager/src/providers/azure/index.js:781:15)
  at process.processTicksAndRejections (node:internal/process/task_queues:103:5)
```