### PR TITLE
feat(w-m): Properly detect zombie worker using queue information

### DIFF
--- a/changelog/bug-2006698.md
+++ b/changelog/bug-2006698.md
@@ -1,0 +1,8 @@
+audience: worker-deployers
+level: patch
+reference: bug 2006698
+---
+
+Fixes worker-manager killing zombie workers when queue data is missing.
+For long running tasks that took longer than queueInactivityTimeout to finish was a high risk of getting claim-expired
+because w-m incorrectly assumed worker is not doing anything (missing queue information)

--- a/services/worker-manager/src/data.js
+++ b/services/worker-manager/src/data.js
@@ -824,11 +824,19 @@ export class Worker {
   }
 
   updateInstanceFields(worker) {
+    const queueFields = ['firstClaim', 'lastDateActive', 'quarantineUntil', 'recentTasks'];
+
     Object.keys(worker).forEach(prop => {
-      this[prop] = worker[prop];
+      // Skip undefined queue fields (preserve existing values)
+      if (worker[prop] !== undefined || !queueFields.includes(prop)) {
+        this[prop] = worker[prop];
+      }
     });
 
-    this._properties = worker;
+    this._properties = {
+      ...worker,
+      ..._.pickBy(_.pick(this, queueFields), (v, k) => worker[k] === undefined),
+    };
   }
 
   // Load the properties from the table once more, and update the instance fields.

--- a/services/worker-manager/src/providers/provider.js
+++ b/services/worker-manager/src/providers/provider.js
@@ -368,17 +368,22 @@ export class Provider {
     let reason = null;
     let isZombie = false;
 
-    if (!worker.firstClaim && isOlderThanTimeout(worker.created)) {
+    // undefined means fields are missing (not fetched from db), null means legitimately empty
+    if (worker.firstClaim === undefined || worker.lastDateActive === undefined) {
+      return { reason: 'queue fields not fetched from database', isZombie: false };
+    }
+
+    if (worker.firstClaim === null && isOlderThanTimeout(worker.created)) {
       isZombie = true;
       reason = `worker never claimed work, created=${worker.created}, queueInactivityTimeout=${queueInactivityTimeout / 1000}s`;
     }
 
-    if (!worker.lastDateActive && isOlderThanTimeout(worker.firstClaim)) {
+    if (worker.firstClaim !== null && isOlderThanTimeout(worker.firstClaim)) {
       isZombie = true;
       reason = `worker never reclaimed work, firstClaim=${worker.firstClaim}, queueInactivityTimeout=${queueInactivityTimeout / 1000}s`;
     }
 
-    if (isOlderThanTimeout(worker.lastDateActive)) {
+    if (worker.lastDateActive !== null && isOlderThanTimeout(worker.lastDateActive)) {
       isZombie = true;
       reason = `worker inactive, lastDateActive=${worker.lastDateActive}, queueInactivityTimeout=${queueInactivityTimeout / 1000}s`;
     }

--- a/services/worker-manager/test/provider_test.js
+++ b/services/worker-manager/test/provider_test.js
@@ -117,6 +117,8 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       Date.now = oldnow;
       const worker = Worker.fromApi({});
       worker.created = taskcluster.fromNow('-4 hours');
+      worker.firstClaim = null;
+      worker.lastDateActive = null;
       const res = Provider.isZombie({ worker });
       assert.equal(res.isZombie, true);
       assert.match(res.reason, /queueInactivityTimeout=7200s/);
@@ -125,6 +127,8 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       Date.now = oldnow;
       const worker = Worker.fromApi({});
       worker.created = taskcluster.fromNow('-4 hours');
+      worker.firstClaim = null;
+      worker.lastDateActive = null;
       const res = Provider.isZombie({ worker });
       assert.equal(res.isZombie, true);
       assert.match(res.reason, /worker never claimed work/);
@@ -134,6 +138,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       const worker = Worker.fromApi({});
       worker.created = taskcluster.fromNow('-4 hours');
       worker.firstClaim = taskcluster.fromNow('-4 hours');
+      worker.lastDateActive = null;
       const res = Provider.isZombie({ worker });
       assert.equal(res.isZombie, true);
       assert.match(res.reason, /worker never reclaimed work/);
@@ -161,9 +166,18 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       });
       worker.created = taskcluster.fromNow('-5 minutes');
       worker.firstClaim = taskcluster.fromNow('-4 minutes');
-      worker.lastdDateActive = taskcluster.fromNow('-3 minutes');
+      worker.lastDateActive = taskcluster.fromNow('-3 minutes');
       const res = Provider.isZombie({ worker });
       assert.equal(res.isZombie, false);
+    });
+    test('fields not fetched from database (defensive check)', function() {
+      Date.now = oldnow;
+      const worker = Worker.fromApi({});
+      worker.created = taskcluster.fromNow('-4 hours');
+      // Intentionally leave firstClaim and lastDateActive as undefined
+      const res = Provider.isZombie({ worker });
+      assert.equal(res.isZombie, false);
+      assert.match(res.reason, /queue fields not fetched/);
     });
   });
 


### PR DESCRIPTION
In some cases worker entity was reloaded from db without queue information, which led to isZombie() check incorrectly considering such worker as not doing anything and getting killed.

Bug was introduced when we deployed those arm template refactorings, it shuffled db calls a bit in code, which resulted in queue fields being wiped out, and zombie decision was made without those --> always killing after `queueInactivityTimeout`

Fixes bug 2006698
