### PR TITLE
Don't panic if we can't remove d2g-image-cache.json and it's not there

### DIFF
--- a/changelog/HoTbhLb3QDi8i72l0_dfUg.md
+++ b/changelog/HoTbhLb3QDi8i72l0_dfUg.md
@@ -1,0 +1,4 @@
+audience: worker-deployers
+level: patch
+---
+Fix a worker panic when the garbage collector runs twice with no task in between if d2g is enabled

--- a/workers/generic-worker/garbagecollector.go
+++ b/workers/generic-worker/garbagecollector.go
@@ -75,7 +75,7 @@ func runGarbageCollection(r Resources) error {
 		}
 
 		err = os.Remove("d2g-image-cache.json")
-		if err != nil {
+		if err != nil && !os.IsNotExist(err) {
 			return fmt.Errorf("could not remove d2g-image-cache.json due to error %#v", err)
 		}
 


### PR DESCRIPTION
This can happen if you start the worker with low disk space and that file is already missing or in my case if the previous garbage collection put you just below the threshold for the worker to decide to system prune, and then an unrelated event puts you back above with no task running in between.
