### PR TITLE
Bug 2010096 - taskcluster signin: shell-escape credentials

### DIFF
--- a/changelog/bug-2010096.md
+++ b/changelog/bug-2010096.md
@@ -1,0 +1,5 @@
+audience: developers
+level: patch
+reference: bug 2010096
+---
+The `taskcluster signin` command shell-escapes the credentials it receives before outputting them.

--- a/clients/client-shell/cmds/signin/signin.go
+++ b/clients/client-shell/cmds/signin/signin.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/pkg/browser"
 	"github.com/spf13/cobra"
+	"github.com/taskcluster/shell"
 	"github.com/taskcluster/slugid-go/slugid"
 	libUrls "github.com/taskcluster/taskcluster-lib-urls"
 	tcclient "github.com/taskcluster/taskcluster/v95/clients/client-go"
@@ -76,13 +77,13 @@ func cmdSignin(cmd *cobra.Command, _ []string) error {
 		csh, _ := cmd.Flags().GetBool("csh")
 		rootURL := config.RootURL()
 		if csh {
-			fmt.Fprintln(cmd.OutOrStdout(), "setenv TASKCLUSTER_CLIENT_ID '"+qs.Get("clientId")+"'")
-			fmt.Fprintln(cmd.OutOrStdout(), "setenv TASKCLUSTER_ACCESS_TOKEN '"+qs.Get("accessToken")+"'")
-			fmt.Fprintln(cmd.OutOrStdout(), "setenv TASKCLUSTER_ROOT_URL '"+rootURL+"'")
+			fmt.Fprintln(cmd.OutOrStdout(), "setenv TASKCLUSTER_CLIENT_ID "+shell.Escape(qs.Get("clientId")))
+			fmt.Fprintln(cmd.OutOrStdout(), "setenv TASKCLUSTER_ACCESS_TOKEN "+shell.Escape(qs.Get("accessToken")))
+			fmt.Fprintln(cmd.OutOrStdout(), "setenv TASKCLUSTER_ROOT_URL "+shell.Escape(rootURL))
 		} else {
-			fmt.Fprintln(cmd.OutOrStdout(), "export TASKCLUSTER_CLIENT_ID='"+qs.Get("clientId")+"'")
-			fmt.Fprintln(cmd.OutOrStdout(), "export TASKCLUSTER_ACCESS_TOKEN='"+qs.Get("accessToken")+"'")
-			fmt.Fprintln(cmd.OutOrStdout(), "export TASKCLUSTER_ROOT_URL='"+rootURL+"'")
+			fmt.Fprintln(cmd.OutOrStdout(), "export TASKCLUSTER_CLIENT_ID="+shell.Escape(qs.Get("clientId")))
+			fmt.Fprintln(cmd.OutOrStdout(), "export TASKCLUSTER_ACCESS_TOKEN="+shell.Escape(qs.Get("accessToken")))
+			fmt.Fprintln(cmd.OutOrStdout(), "export TASKCLUSTER_ROOT_URL="+shell.Escape(rootURL))
 		}
 		log.Infoln("Credentials output as environment variables")
 


### PR DESCRIPTION
The `taskcluster signin` command shell-escapes the credentials it receives before outputting them.