### PR TITLE
fix(tc-cli): `task log` command falls back to use backing log

### DIFF
--- a/changelog/RUukUKuVShKJAUalY_uD9A.md
+++ b/changelog/RUukUKuVShKJAUalY_uD9A.md
@@ -1,0 +1,4 @@
+audience: users
+level: patch
+---
+Client (shell): `taskcluster task log` command falls back to use `live_backing.log` if `live.log` is unavailable.


### PR DESCRIPTION
>Client (shell): `taskcluster task log` command falls back to use `live_backing.log` if `live.log` is unavailable.

cc @ahal