### PR TITLE
feat(release): add Chocolatey package publishing support

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -131,7 +131,7 @@ release:
   # URL, for instance, homebrew taps.
   #
   # Defaults to false.
-  disable: false
+  disable: true
 
 changelog:
   # Set this to true if you don't want any changelog at all.

--- a/infrastructure/tooling/src/build/index.js
+++ b/infrastructure/tooling/src/build/index.js
@@ -239,6 +239,6 @@ export const build = async (options) => {
 };
 
 export const publish = async (options) => {
-  const publish = new Publish(options);
+  const publish = new Publish({ ...options, releasePublish: true });
   await publish.run();
 };

--- a/infrastructure/tooling/src/build/tasks/client-shell.js
+++ b/infrastructure/tooling/src/build/tasks/client-shell.js
@@ -2,6 +2,10 @@ import path from 'path';
 import { ensureTask, execCommand, REPO_ROOT } from '../../utils/index.js';
 
 export default ({ tasks, cmdOptions, credentials, baseDir, logsDir }) => {
+  if (cmdOptions.releasePublish) {
+    return;
+  }
+
   ensureTask(tasks, {
     title: 'Build client-shell artifacts',
     requires: ['clean-artifacts-dir'],
@@ -13,20 +17,13 @@ export default ({ tasks, cmdOptions, credentials, baseDir, logsDir }) => {
         'tool',
         'goreleaser',
         'release',
-        '--id', 'taskcluster',
         '--clean',
-        '--skip=publish',
-        '--skip=announce',
-        '--skip=homebrew',
-        '--skip=chocolatey',
       ];
 
       if (cmdOptions.staging || !cmdOptions.push) {
         // --snapshot will generate an unversioned snapshot release,
         // skipping all validations and without publishing any artifacts
         goreleaserCmd.push('--snapshot');
-      } else {
-        goreleaserCmd.push('--skip=validate');
       }
 
       await execCommand({

--- a/infrastructure/tooling/src/build/tasks/release.js
+++ b/infrastructure/tooling/src/build/tasks/release.js
@@ -136,11 +136,88 @@ export default ({ tasks, cmdOptions, credentials, baseDir, logsDir }) => {
   /* -- monoimage docker image build occurs here -- */
 
   ensureTask(tasks, {
+    title: 'Build GoReleaser artifacts',
+    requires: [
+      'clean-artifacts-dir',
+      'release-version',
+    ],
+    provides: [
+      'client-shell-artifacts',
+      'windows-worker-archives',
+    ],
+    run: async (requirements, utils) => {
+      const artifactsDir = requirements['clean-artifacts-dir'];
+      const version = requirements['release-version'];
+
+      await execCommand({
+        dir: REPO_ROOT,
+        command: [
+          'go', 'tool', 'goreleaser', 'release',
+          '--clean',
+          '--skip=announce',
+          '--skip=publish',
+          '--skip=validate',
+        ],
+        utils,
+        env: {
+          ...process.env,
+          GORELEASER_CURRENT_TAG: `v${version}`,
+        },
+      });
+
+      const windowsWorkerArchives = [
+        'generic-worker-multiuser-windows-amd64.zip',
+        'generic-worker-multiuser-windows-arm64.zip',
+        'start-worker-windows-amd64.zip',
+        'start-worker-windows-arm64.zip',
+        'livelog-windows-amd64.zip',
+        'livelog-windows-arm64.zip',
+        'taskcluster-proxy-windows-amd64.zip',
+        'taskcluster-proxy-windows-arm64.zip',
+      ];
+
+      await execCommand({
+        dir: path.join(REPO_ROOT, 'dist'),
+        command: [
+          'mv',
+          'taskcluster-darwin-amd64.tar.gz',
+          'taskcluster-darwin-arm64.tar.gz',
+          'taskcluster-linux-amd64.tar.gz',
+          'taskcluster-linux-arm64.tar.gz',
+          'taskcluster-freebsd-amd64.tar.gz',
+          'taskcluster-freebsd-arm64.tar.gz',
+          'taskcluster-windows-arm64.zip',
+          'taskcluster-windows-amd64.zip',
+          ...windowsWorkerArchives,
+          artifactsDir,
+        ],
+        utils,
+      });
+
+      const osarch = 'linux/amd64 linux/arm64 darwin/amd64 darwin/arm64 windows/amd64 windows/arm64 freebsd/amd64 freebsd/arm64';
+      const clientShellArtifacts = osarch.split(' ')
+        .map(osarch => {
+          const [os, arch] = osarch.split('/');
+          if (os === 'windows') {
+            return `taskcluster-${os}-${arch}.zip`;
+          }
+          return `taskcluster-${os}-${arch}.tar.gz`;
+        });
+
+      return {
+        'client-shell-artifacts': clientShellArtifacts,
+        'windows-worker-archives': windowsWorkerArchives,
+      };
+    },
+  });
+
+  ensureTask(tasks, {
     title: 'Create GitHub Release',
     requires: [
       'clean-artifacts-dir',
       'release-version',
       'client-shell-artifacts',
+      'windows-worker-archives',
       'generic-worker-artifacts',
       'worker-runner-artifacts',
       'taskcluster-proxy-artifacts',
@@ -173,6 +250,7 @@ export default ({ tasks, cmdOptions, credentials, baseDir, logsDir }) => {
       const { upload_url } = release.data;
 
       const files = requirements['client-shell-artifacts']
+        .concat(requirements['windows-worker-archives'])
         .concat(requirements['generic-worker-artifacts'])
         .concat(requirements['worker-runner-artifacts'])
         .concat(requirements['livelog-artifacts'])
@@ -329,10 +407,6 @@ export default ({ tasks, cmdOptions, credentials, baseDir, logsDir }) => {
         dir: REPO_ROOT,
         command: [
           'go', 'tool', 'goreleaser', 'release',
-          '--id', 'generic-worker-multiuser',
-          '--id', 'start-worker',
-          '--id', 'livelog',
-          '--id', 'taskcluster-proxy',
           '--clean',
           '--skip=announce',
           '--skip=validate',


### PR DESCRIPTION
Fixes #8221.
Fixes #5598.

Adds GoReleaser Windows builds/archives for worker binaries (generic-worker multiuser, start-worker, livelog, taskcluster-proxy) and Chocolatey metadata. GoReleaser runs during release:publish to build and upload worker zips + CLI archives before publishing to Homebrew/Chocolatey; requires CHOCOLATEY_API_KEY in the release secret.