### PR TITLE
feat(w-m): Add providerId to all metrics

### DIFF
--- a/changelog/issue-8245.md
+++ b/changelog/issue-8245.md
@@ -1,0 +1,5 @@
+audience: worker-deployers
+level: patch
+reference: issue 8245
+---
+Adds missing providerId label to all worker-manager exposed metrics.

--- a/generated/references.json
+++ b/generated/references.json
@@ -17883,6 +17883,7 @@
         {
           "description": "This number represents difference in pending tasks and idle capacity.\nAdjustment is needed to make sure workers that are still running and are currently\nnot doing any work, will soon pick up those tasks, so we don't need additional workers for those.\nAssumption is that those idling workers would pick up tasks soon.",
           "labels": {
+            "providerId": "ID of the provider",
             "workerPoolId": "The worker pool ID"
           },
           "name": "worker_manager_adjusted_pending_tasks",
@@ -17895,6 +17896,7 @@
         {
           "description": "This number represents the number of claimed tasks.",
           "labels": {
+            "providerId": "ID of the provider",
             "workerPoolId": "The worker pool ID"
           },
           "name": "worker_manager_claimed_tasks",
@@ -17907,6 +17909,7 @@
         {
           "description": "This number represents calculation of the estimator for a given worker pool,\nwith regards to min and max capacity of the worker pool, number of adjusted\npending tasks and scaling ratio. Refer to estimator.js for exact logic.",
           "labels": {
+            "providerId": "ID of the provider",
             "workerPoolId": "The worker pool ID"
           },
           "name": "worker_manager_desired_capacity",
@@ -17919,6 +17922,7 @@
         {
           "description": "This number represents the running capacity of running and not quarantined workers.",
           "labels": {
+            "providerId": "ID of the provider",
             "workerPoolId": "The worker pool ID"
           },
           "name": "worker_manager_existing_capacity",
@@ -17931,6 +17935,7 @@
         {
           "description": "This number represents the number of pending tasks.",
           "labels": {
+            "providerId": "ID of the provider",
             "workerPoolId": "The worker pool ID"
           },
           "name": "worker_manager_pending_tasks",
@@ -17943,6 +17948,7 @@
         {
           "description": "This number represents the running capacity of workers that are requested.",
           "labels": {
+            "providerId": "ID of the provider",
             "workerPoolId": "The worker pool ID"
           },
           "name": "worker_manager_requested_capacity",
@@ -17955,6 +17961,7 @@
         {
           "description": "This number represents the running capacity of workers that are stopping.",
           "labels": {
+            "providerId": "ID of the provider",
             "workerPoolId": "The worker pool ID"
           },
           "name": "worker_manager_stopping_capacity",
@@ -17967,6 +17974,7 @@
         {
           "description": "This number represents difference in existing capacity\n(running capacity of running and not quarantined workers), and the number of\nclaimed tasks.",
           "labels": {
+            "providerId": "ID of the provider",
             "workerPoolId": "The worker pool ID"
           },
           "name": "worker_manager_total_idle_capacity",

--- a/services/worker-manager/src/estimator.js
+++ b/services/worker-manager/src/estimator.js
@@ -6,6 +6,7 @@ export class Estimator {
 
   async simple({
     workerPoolId,
+    providerId,
     minCapacity,
     maxCapacity,
     scalingRatio = 1.0,
@@ -74,7 +75,7 @@ export class Estimator {
     // how many extra we want if we do want any
     const toSpawn = Math.max(0, desiredCapacity - totalNonStopped);
 
-    this.exposeMetrics({ workerPoolId, existingCapacity, stoppingCapacity,
+    this.exposeMetrics({ workerPoolId, providerId, existingCapacity, stoppingCapacity,
       requestedCapacity, desiredCapacity, totalIdleCapacity, adjustedPendingTasks,
       pendingTasks, claimedTasks });
 
@@ -86,8 +87,8 @@ export class Estimator {
   /**
    * @param {Record<string, string|number>} options
    */
-  exposeMetrics({ workerPoolId, ...metrics }) {
+  exposeMetrics({ workerPoolId, providerId, ...metrics }) {
     Object.keys(metrics).forEach(name =>
-      this.monitor.metric[name](metrics[name], { workerPoolId }));
+      this.monitor.metric[name](metrics[name], { workerPoolId, providerId }));
   }
 }

--- a/services/worker-manager/src/monitor.js
+++ b/services/worker-manager/src/monitor.js
@@ -259,6 +259,7 @@ MonitorManager.register({
 
 const commonLabels = {
   workerPoolId: 'The worker pool ID',
+  providerId: 'ID of the provider',
 };
 
 MonitorManager.registerMetric('existingCapacity', {
@@ -361,10 +362,7 @@ MonitorManager.registerMetric('provisionDuration', {
   type: 'histogram',
   title: 'Worker pool provision duration',
   description: 'Time it took to provision a single worker pool',
-  labels: {
-    ...commonLabels,
-    providerId: 'ID of the provider',
-  },
+  labels: commonLabels,
   registers: ['provision'],
   buckets: [0.01, 0.05, 0.1, 0.5, 1, 5, 10],
 });
@@ -377,10 +375,7 @@ MonitorManager.registerMetric('workerRegistrationDuration', {
     Time for a worker to go from being requested to successfully registering
     with worker-manager
   `,
-  labels: {
-    ...commonLabels,
-    providerId: 'ID of the provider',
-  },
+  labels: commonLabels,
   registers: ['default', 'provision', 'scan'],
   buckets: [15, 30, 45, 60, 90, 120, 180, 300, 600, 1200, 1800],
 });
@@ -393,10 +388,7 @@ MonitorManager.registerMetric('workerLifetime', {
     Time for a worker to go from running to either being removed or fully
     stopped
   `,
-  labels: {
-    ...commonLabels,
-    providerId: 'ID of the provider',
-  },
+  labels: commonLabels,
   registers: ['default', 'provision', 'scan'],
   buckets: [60, 300, 900, 1800, 3600, 7200, 14400, 28800, 86400, 172800, 604800, 1209600],
 });
@@ -409,10 +401,7 @@ MonitorManager.registerMetric('workerRegistrationFailure', {
     Counts workers that were requested but never registered before being
     removed or stopped.
   `,
-  labels: {
-    ...commonLabels,
-    providerId: 'ID of the provider',
-  },
+  labels: commonLabels,
   registers: ['default', 'provision', 'scan'],
 });
 
@@ -421,10 +410,7 @@ MonitorManager.registerMetric('scanSeen', {
   type: 'gauge',
   title: 'Worker pool workers checked during scan',
   description: 'Total number of workers checked for given workerPoolId during scanning.',
-  labels: {
-    ...commonLabels,
-    providerId: 'ID of the provider',
-  },
+  labels: commonLabels,
   registers: ['scan'],
 });
 
@@ -433,9 +419,6 @@ MonitorManager.registerMetric('scanErrors', {
   type: 'gauge',
   title: 'Worker pool errors during scan',
   description: 'Total number of errors for worker pool during scanning',
-  labels: {
-    ...commonLabels,
-    providerId: 'ID of the provider',
-  },
+  labels: commonLabels,
   registers: ['scan'],
 });

--- a/services/worker-manager/src/providers/aws.js
+++ b/services/worker-manager/src/providers/aws.js
@@ -88,6 +88,7 @@ export class AwsProvider extends Provider {
 
     const toSpawn = await this.estimator.simple({
       workerPoolId,
+      providerId: this.providerId,
       minCapacity: workerPool.config.minCapacity,
       maxCapacity: workerPool.config.maxCapacity,
       scalingRatio: workerPool.config.scalingRatio,

--- a/services/worker-manager/src/providers/azure/index.js
+++ b/services/worker-manager/src/providers/azure/index.js
@@ -220,6 +220,7 @@ export class AzureProvider extends Provider {
     const workerInfo = workerPoolStats?.forProvision() ?? {};
     let toSpawn = await this.estimator.simple({
       workerPoolId,
+      providerId: this.providerId,
       ...workerPool.config,
       workerInfo,
     });

--- a/services/worker-manager/src/providers/google.js
+++ b/services/worker-manager/src/providers/google.js
@@ -222,6 +222,7 @@ export class GoogleProvider extends Provider {
 
     let toSpawn = await this.estimator.simple({
       workerPoolId,
+      providerId: this.providerId,
       ...workerPool.config,
       workerInfo,
     });

--- a/services/worker-manager/test/estimator_test.js
+++ b/services/worker-manager/test/estimator_test.js
@@ -21,6 +21,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
     };
     const estimate = await estimator.simple({
       workerPoolId: 'foo/bar',
+      providerId: 'test-provider',
       maxCapacity: 0,
       minCapacity: 0,
       scalingRatio: 1,
@@ -40,6 +41,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
     };
     const estimate = await estimator.simple({
       workerPoolId: 'foo/bar',
+      providerId: 'test-provider',
       maxCapacity: 1,
       minCapacity: 1,
       workerInfo,
@@ -58,6 +60,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
     };
     const estimate = await estimator.simple({
       workerPoolId: 'foo/bar',
+      providerId: 'test-provider',
       maxCapacity: 1,
       minCapacity: 1,
       workerInfo,
@@ -77,6 +80,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
     helper.queue.setPending('foo/bar', 100);
     const estimate = await estimator.simple({
       workerPoolId: 'foo/bar',
+      providerId: 'test-provider',
       maxCapacity: 100,
       minCapacity: 0,
       scalingRatio: 1,
@@ -97,6 +101,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
     helper.queue.setPending('foo/bar', 100);
     const estimate = await estimator.simple({
       workerPoolId: 'foo/bar',
+      providerId: 'test-provider',
       maxCapacity: 50,
       minCapacity: 0,
       scalingRatio: 1,
@@ -117,6 +122,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
     helper.queue.setPending('foo/bar', 100);
     const estimate = await estimator.simple({
       workerPoolId: 'foo/bar',
+      providerId: 'test-provider',
       maxCapacity: 100,
       minCapacity: 0,
       scalingRatio: 0.5,
@@ -138,6 +144,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
     helper.queue.setClaimed('foo/bar', 25);
     const estimate = await estimator.simple({
       workerPoolId: 'foo/bar',
+      providerId: 'test-provider',
       maxCapacity: 100,
       minCapacity: 0,
       scalingRatio: 0.5,
@@ -157,6 +164,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
     };
     const estimate = await estimator.simple({
       workerPoolId: 'foo/bar',
+      providerId: 'test-provider',
       maxCapacity: 1,
       minCapacity: 1,
       workerInfo,
@@ -182,6 +190,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
     };
     const estimate = await estimator.simple({
       workerPoolId: 'foo/bar',
+      providerId: 'test-provider',
       maxCapacity: 1,
       minCapacity: 1,
       workerInfo,
@@ -201,6 +210,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
     };
     const estimate = await estimator.simple({
       workerPoolId: 'foo/bar',
+      providerId: 'test-provider',
       maxCapacity: 0,
       minCapacity: 0,
       scalingRatio: 1,
@@ -220,6 +230,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
     };
     const estimate = await estimator.simple({
       workerPoolId: 'foo/bar',
+      providerId: 'test-provider',
       maxCapacity: 50,
       minCapacity: 0,
       scalingRatio: 1,
@@ -238,6 +249,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
     };
     const estimate = await estimator.simple({
       workerPoolId: 'foo/bar',
+      providerId: 'test-provider',
       maxCapacity: 50,
       minCapacity: 0,
       scalingRatio: 1,
@@ -258,6 +270,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
     helper.queue.setClaimed('foo/bar', 0);
     const estimate = await estimator.simple({
       workerPoolId: 'foo/bar',
+      providerId: 'test-provider',
       maxCapacity: 50,
       minCapacity: 0,
       scalingRatio: 1,
@@ -293,6 +306,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       helper.queue.setClaimed('foo/bar', claimed);
       const result = await estimator.simple({
         workerPoolId: 'foo/bar',
+        providerId: 'test-provider',
         maxCapacity: 50,
         minCapacity: 0,
         scalingRatio: 1,


### PR DESCRIPTION
estimator was only exposing workerPoolId, which is not ideal for all use cases


Fixes #8245
