### PR TITLE
feat(w-m): Provider workerGroup label for some metric

### DIFF
--- a/changelog/issue-8247.md
+++ b/changelog/issue-8247.md
@@ -1,0 +1,5 @@
+audience: worker-deployers
+level: minor
+reference: issue 8247
+---
+Worker-manager includes workerGroup label for some metrics (location/zone/region): `existing_capacity`, `stopping_capacity`, `requested_capacity`

--- a/generated/references.json
+++ b/generated/references.json
@@ -17923,6 +17923,7 @@
           "description": "This number represents the running capacity of running and not quarantined workers.",
           "labels": {
             "providerId": "ID of the provider",
+            "workerGroup": "Worker group (region/zone/location)",
             "workerPoolId": "The worker pool ID"
           },
           "name": "worker_manager_existing_capacity",
@@ -17949,6 +17950,7 @@
           "description": "This number represents the running capacity of workers that are requested.",
           "labels": {
             "providerId": "ID of the provider",
+            "workerGroup": "Worker group (region/zone/location)",
             "workerPoolId": "The worker pool ID"
           },
           "name": "worker_manager_requested_capacity",
@@ -17962,6 +17964,7 @@
           "description": "This number represents the running capacity of workers that are stopping.",
           "labels": {
             "providerId": "ID of the provider",
+            "workerGroup": "Worker group (region/zone/location)",
             "workerPoolId": "The worker pool ID"
           },
           "name": "worker_manager_stopping_capacity",

--- a/services/worker-manager/src/monitor.js
+++ b/services/worker-manager/src/monitor.js
@@ -261,6 +261,10 @@ const commonLabels = {
   workerPoolId: 'The worker pool ID',
   providerId: 'ID of the provider',
 };
+const labelsWithWorkerGroup = {
+  ...commonLabels,
+  workerGroup: 'Worker group (region/zone/location)',
+};
 
 MonitorManager.registerMetric('existingCapacity', {
   name: 'worker_manager_existing_capacity',
@@ -269,7 +273,7 @@ MonitorManager.registerMetric('existingCapacity', {
   description: `
     This number represents the running capacity of running and not quarantined workers.
   `,
-  labels: commonLabels,
+  labels: labelsWithWorkerGroup,
   registers: ['provision'],
 });
 
@@ -280,7 +284,7 @@ MonitorManager.registerMetric('stoppingCapacity', {
   description: `
     This number represents the running capacity of workers that are stopping.
   `,
-  labels: commonLabels,
+  labels: labelsWithWorkerGroup,
   registers: ['provision'],
 });
 
@@ -291,7 +295,7 @@ MonitorManager.registerMetric('requestedCapacity', {
   description: `
     This number represents the running capacity of workers that are requested.
   `,
-  labels: commonLabels,
+  labels: labelsWithWorkerGroup,
   registers: ['provision'],
 });
 

--- a/services/worker-manager/src/providers/provider.js
+++ b/services/worker-manager/src/providers/provider.js
@@ -289,6 +289,7 @@ export class Provider {
       this.monitor.metric.workerRegistrationDuration(durationSeconds, {
         workerPoolId: worker.workerPoolId,
         providerId: this.providerId,
+        workerGroup: worker.workerGroup,
       });
     }
 
@@ -329,6 +330,7 @@ export class Provider {
         this.monitor.metric.workerLifetime(durationSeconds, {
           workerPoolId: worker.workerPoolId,
           providerId: this.providerId,
+          workerGroup: worker.workerGroup,
         });
       }
     } else if (currentState === Worker.states.REQUESTED) {
@@ -336,6 +338,7 @@ export class Provider {
       this.monitor.metric.workerRegistrationFailure(1, {
         workerPoolId: worker.workerPoolId,
         providerId: this.providerId,
+        workerGroup: worker.workerGroup,
       });
     }
   }

--- a/services/worker-manager/test/provider_aws_test.js
+++ b/services/worker-manager/test/provider_aws_test.js
@@ -87,6 +87,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
     await helper.db.fns.delete_worker_pool(workerPoolId);
 
     await provider.setup();
+    provider.scanPrepare();
   });
 
   const makeWorkerPool = async (overrides = {}) => {
@@ -487,7 +488,6 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       });
       await worker.create(helper.db);
 
-      provider.seen = {};
       await provider.checkWorker({ worker: worker });
 
       const workers = await helper.getWorkers();
@@ -507,7 +507,6 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       });
       await worker.create(helper.db);
 
-      provider.seen = {};
       await provider.checkWorker({ worker: worker });
 
       const workers = await helper.getWorkers();
@@ -527,7 +526,6 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       });
       await worker.create(helper.db);
 
-      provider.seen = {};
       await assert.rejects(provider.checkWorker({ worker: worker }));
       assert.strictEqual(provider.seen[worker.workerPoolId], 0);
     });
@@ -541,7 +539,6 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       });
       await worker.create(helper.db);
 
-      provider.seen = {};
       await provider.checkWorker({ worker: worker });
       assert.strictEqual(provider.seen[worker.workerPoolId], 0);
       // should be marked as stopped because it was missing
@@ -562,7 +559,6 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       });
       await worker.create(helper.db);
 
-      provider.seen = {};
       await provider.checkWorker({ worker: worker });
 
       const workers = await helper.getWorkers();
@@ -585,7 +581,6 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
         },
       });
       await worker.create(helper.db);
-      provider.seen = {};
       await provider.checkWorker({ worker: worker });
       assert.deepEqual(fake.rgn('us-west-2').terminatedInstances, ['i-123']);
       helper.assertNoPulseMessage('worker-stopped');
@@ -604,7 +599,6 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
         },
       });
       await worker.create(helper.db);
-      provider.seen = {};
       await provider.checkWorker({ worker: worker });
       assert.deepEqual(fake.rgn('us-west-2').terminatedInstances, []);
       helper.assertNoPulseMessage('worker-stopped');
@@ -623,7 +617,6 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
         },
       });
       await worker.create(helper.db);
-      provider.seen = {};
       worker.reload = function () {
         this.providerData.terminateAfter = Date.now() + 1000;
       };
@@ -646,7 +639,6 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
         },
       });
       await worker.create(helper.db);
-      provider.seen = {};
       await provider.checkWorker({ worker: worker });
       assert.deepEqual(fake.rgn('us-west-2').terminatedInstances, ['i-123']);
       helper.assertPulseMessage('worker-removed', m => m.payload.workerId === worker.workerId &&
@@ -665,7 +657,6 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
         },
       });
       await worker.create(helper.db);
-      provider.seen = {};
       await provider.checkWorker({ worker: worker });
       assert.deepEqual(fake.rgn('us-west-2').terminatedInstances, []);
       helper.assertNoPulseMessage('worker-removed');
@@ -684,7 +675,6 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
         },
       });
       await worker.create(helper.db);
-      provider.seen = {};
 
       worker.firstClaim = null;
       worker.lastDateActive = null;
@@ -706,7 +696,6 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
         },
       });
       await worker.create(helper.db);
-      provider.seen = {};
 
       worker.created = taskcluster.fromNow('-120 minutes');
       worker.firstClaim = taskcluster.fromNow('-110 minutes');
@@ -729,7 +718,6 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
         },
       });
       await worker.create(helper.db);
-      provider.seen = {};
 
       worker.created = taskcluster.fromNow('-120 minutes');
       worker.firstClaim = taskcluster.fromNow('-110 minutes');

--- a/services/worker-manager/test/provider_azure_test.js
+++ b/services/worker-manager/test/provider_azure_test.js
@@ -197,6 +197,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
     await helper.db.fns.delete_worker_pool(workerPoolId);
 
     await provider.setup();
+    provider.scanPrepare();
   });
 
   const makeWorkerPool = async (overrides = {}, launchConfigOverrides = {}) => {

--- a/services/worker-manager/test/provider_google_test.js
+++ b/services/worker-manager/test/provider_google_test.js
@@ -45,6 +45,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
     await helper.db.fns.delete_worker_pool(workerPoolId);
 
     await provider.setup();
+    provider.scanPrepare();
   });
 
   const defaultLaunchConfig = {


### PR DESCRIPTION
For worker deployers it might be useful to see breakdown by region/location of the workers to track costs more effectively.


Fixes #8247
