### PR TITLE
feat(release): Temporarily switch to root to install global nodemon in dev image

### DIFF
--- a/changelog/L4foDVUlRYCkT9LHbp6ghw.md
+++ b/changelog/L4foDVUlRYCkT9LHbp6ghw.md
@@ -1,0 +1,3 @@
+audience: users
+level: silent
+---

--- a/infrastructure/tooling/src/build/tasks/monoimage.js
+++ b/infrastructure/tooling/src/build/tasks/monoimage.js
@@ -163,7 +163,9 @@ const generateMonoimageTasks = ({ tasks, baseDir, cmdOptions, credentials, logsD
 
       await writeRepoFile('temp/devel-image/Dockerfile', [
         `FROM ${requirements['monoimage-docker-image']}`,
+        'USER root',
         'RUN npm install --global nodemon',
+        'USER 1000',
         'RUN yarn install && yarn cache clean --all',
       ].join('\n'));
 


### PR DESCRIPTION
This broke 96.2.0 release https://community-tc.services.mozilla.com/tasks/Q1rZSMVvRJ6mXrrfJCunmQ/runs/0/logs/live/public/logs/live.log 