### PR TITLE
feat(w-m): Fix azure checkWorker call

### DIFF
--- a/changelog/issue-8247.md
+++ b/changelog/issue-8247.md
@@ -1,0 +1,5 @@
+audience: worker-deployers
+level: patch
+reference: issue 8247
+---
+Fix azure checkWorker() call during provisioning.

--- a/services/worker-manager/src/providers/azure/index.js
+++ b/services/worker-manager/src/providers/azure/index.js
@@ -63,7 +63,8 @@ export class AzureProvider extends Provider {
     this.providerConfig = providerConfig;
     this.downloadTimeout = 5000; // 5 seconds
 
-    this.seen = {};
+    this.scanPrepare();
+
     /** @type {Record<string, any>} */
     this.errors = {};
     this.cloudApi = null;


### PR DESCRIPTION
"seenByWorkerGroup" introduced in #8247 was not being initialized properly for the provision loop, so it sent runtime errors

Fixes #8254