### PR TITLE
fix(ui): bypass GraphQL for createTask, call Queue API directly (fixes #8171)

### DIFF
--- a/changelog/issue-8171.md
+++ b/changelog/issue-8171.md
@@ -1,0 +1,7 @@
+audience: users
+level: patch
+reference: issue 8171
+---
+Task creation in the UI now calls the Queue API directly instead of routing
+through GraphQL, fixing 413 errors when creating tasks with large payloads
+(up to the Queue API's 10MB limit).

--- a/ui/src/views/Tasks/CreateTask/index.jsx
+++ b/ui/src/views/Tasks/CreateTask/index.jsx
@@ -1,7 +1,6 @@
 import React, { Component, Fragment } from 'react';
 import { Redirect } from 'react-router-dom';
 import { parse, stringify } from 'qs';
-import { withApollo } from '@apollo/client/react/hoc';
 import storage from 'localforage';
 import merge from 'deepmerge';
 import { load, dump } from 'js-yaml';
@@ -28,6 +27,7 @@ import ContentSaveIcon from 'mdi-react/ContentSaveIcon';
 import RotateLeftIcon from 'mdi-react/RotateLeftIcon';
 import ClockOutlineIcon from 'mdi-react/ClockOutlineIcon';
 import { Box } from '@material-ui/core';
+import { Queue } from '@taskcluster/client-web';
 import CodeEditor from '../../../components/CodeEditor';
 import SpeedDial from '../../../components/SpeedDial';
 import SiteSpecific from '../../../components/SiteSpecific';
@@ -44,7 +44,8 @@ import {
   TASK_PAYLOAD_SCHEMAS,
 } from '../../../utils/constants';
 import urls from '../../../utils/urls';
-import createTaskQuery from '../createTask.graphql';
+import { AuthContext } from '../../../utils/Auth';
+import { getClient } from '../../../utils/client';
 import Button from '../../../components/Button';
 import db from '../../../utils/db';
 import validateTaskPayloadSchemas from '../../../utils/validateTaskPayloadSchemas';
@@ -73,7 +74,6 @@ const defaultTask = schema => {
   };
 };
 
-@withApollo
 @withStyles(theme => ({
   createIcon: {
     ...theme.mixins.successIcon,
@@ -91,6 +91,8 @@ const defaultTask = schema => {
   },
 }))
 export default class CreateTask extends Component {
+  static contextType = AuthContext;
+
   static defaultProps = {
     interactive: false,
   };
@@ -203,13 +205,9 @@ export default class CreateTask extends Component {
       this.setState({ loading: true });
 
       try {
-        await this.props.client.mutate({
-          mutation: createTaskQuery,
-          variables: {
-            taskId,
-            task: payload,
-          },
-        });
+        const queue = getClient({ Class: Queue, user: this.context.user });
+
+        await queue.createTask(taskId, payload);
 
         this.setState({ loading: false, createdTaskId: taskId });
         storage.setItem(TASKS_CREATE_STORAGE_KEY, payload);

--- a/ui/src/views/Tasks/TaskGroup/index.jsx
+++ b/ui/src/views/Tasks/TaskGroup/index.jsx
@@ -50,6 +50,7 @@ import CopyToClipboardListItem from '../../../components/CopyToClipboardListItem
 import DateDistance from '../../../components/DateDistance';
 import sealTaskGroupQuery from './sealTaskGroup.graphql';
 import cancelTaskGroupQuery from './cancelTaskGroup.graphql';
+import { AuthContext } from '../../../utils/Auth';
 
 const initialTaskGroupActions = [
   {
@@ -155,6 +156,8 @@ const updateTaskGroupIdHistory = id => {
   },
 }))
 export default class TaskGroup extends Component {
+  static contextType = AuthContext;
+
   static calculateStatusCountStatic(taskGroup) {
     const statusCount = {
       completed: 0,
@@ -620,6 +623,7 @@ export default class TaskGroup extends Component {
         form,
         action,
         apolloClient,
+        user: this.context.user,
       });
 
       return taskId;

--- a/ui/src/views/Tasks/ViewTask/index.jsx
+++ b/ui/src/views/Tasks/ViewTask/index.jsx
@@ -12,6 +12,7 @@ import Checkbox from '@material-ui/core/Checkbox';
 import dotProp from 'dot-prop-immutable';
 import jsonSchemaDefaults from 'json-schema-defaults';
 import { dump } from 'js-yaml';
+import { Queue } from '@taskcluster/client-web';
 import HammerIcon from 'mdi-react/HammerIcon';
 import CreationIcon from 'mdi-react/CreationIcon';
 import PencilIcon from 'mdi-react/PencilIcon';
@@ -52,6 +53,8 @@ import removeKeys from '../../../utils/removeKeys';
 import parameterizeTask from '../../../utils/parameterizeTask';
 import { nice } from '../../../utils/slugid';
 import Link from '../../../utils/Link';
+import { getClient } from '../../../utils/client';
+import { AuthContext } from '../../../utils/Auth';
 import submitTaskAction from '../submitTaskAction';
 import taskQuery from './task.graphql';
 import taskSubscription from './taskSubscription.graphql';
@@ -60,8 +63,6 @@ import rerunTaskQuery from './rerunTask.graphql';
 import cancelTaskQuery from './cancelTask.graphql';
 import purgeWorkerCacheQuery from './purgeWorkerCache.graphql';
 import pageArtifactsQuery from './pageArtifacts.graphql';
-import createTaskQuery from '../createTask.graphql';
-import { AuthContext } from '../../../utils/Auth';
 
 const updateTaskIdHistory = id => {
   if (!VALID_TASK.test(id)) {
@@ -116,6 +117,8 @@ const getCachesFromTask = task =>
   }),
 })
 export default class ViewTask extends Component {
+  static contextType = AuthContext;
+
   static getDerivedStateFromProps(props, state) {
     const taskId = props.match.params.taskId || '';
     const {
@@ -295,6 +298,7 @@ export default class ViewTask extends Component {
         form: formInputs,
         action,
         apolloClient: client,
+        user: this.context.user,
       });
 
       return taskId;
@@ -473,13 +477,9 @@ export default class ViewTask extends Component {
     this.preRunningAction();
 
     try {
-      await this.props.client.mutate({
-        mutation: createTaskQuery,
-        variables: {
-          taskId,
-          task,
-        },
-      });
+      const queue = getClient({ Class: Queue, user: this.context.user });
+
+      await queue.createTask(taskId, task);
 
       return taskId;
     } catch (error) {
@@ -789,13 +789,9 @@ export default class ViewTask extends Component {
     this.preRunningAction();
 
     try {
-      await this.props.client.mutate({
-        mutation: createTaskQuery,
-        variables: {
-          taskId,
-          task,
-        },
-      });
+      const queue = getClient({ Class: Queue, user: this.context.user });
+
+      await queue.createTask(taskId, task);
 
       return taskId;
     } catch (error) {
@@ -947,16 +943,12 @@ export default class ViewTask extends Component {
             <br />
             <Grid container spacing={3}>
               <Grid item xs={12} md={6}>
-                <AuthContext.Consumer>
-                  {auth => (
-                    <TaskDetailsCard
-                      task={task}
-                      user={auth.user}
-                      dependents={dependents}
-                      onDependentsPageChange={this.handleDependentsPageChange}
-                    />
-                  )}
-                </AuthContext.Consumer>
+                <TaskDetailsCard
+                  task={task}
+                  user={this.context.user}
+                  dependents={dependents}
+                  onDependentsPageChange={this.handleDependentsPageChange}
+                />
               </Grid>
 
               <Grid item xs={12} md={6}>

--- a/ui/src/views/Tasks/createTask.graphql
+++ b/ui/src/views/Tasks/createTask.graphql
@@ -1,5 +1,0 @@
-mutation CreateTask($taskId: ID!, $task: JSON!) {
-  createTask(taskId: $taskId, task: $task) {
-    taskId
-  }
-}

--- a/ui/src/views/Tasks/submitTaskAction.js
+++ b/ui/src/views/Tasks/submitTaskAction.js
@@ -3,15 +3,23 @@ import { satisfiesExpression } from 'taskcluster-lib-scopes';
 import cloneDeep from 'lodash.clonedeep';
 import jsone from 'json-e';
 import { load } from 'js-yaml';
+import { Queue } from '@taskcluster/client-web';
 import removeKeys from '../../utils/removeKeys';
 import { nice } from '../../utils/slugid';
 import expandScopesQuery from './expandScopes.graphql';
 import triggerHookQuery from './triggerHook.graphql';
-import createTaskQuery from './createTask.graphql';
 import validateActionsJson from '../../utils/validateActionsJson';
 import ajv from '../../utils/ajv';
+import { getClient } from '../../utils/client';
 
-export default async ({ task, form, action, apolloClient, taskActions }) => {
+export default async ({
+  task,
+  form,
+  action,
+  apolloClient,
+  user,
+  taskActions,
+}) => {
   const actions = removeKeys(cloneDeep(taskActions), ['__typename']);
   // We need to source scopes from somewhere. Typically these come from the
   // task we're given, which is either a regular decision task or an action
@@ -56,21 +64,15 @@ export default async ({ task, form, action, apolloClient, taskActions }) => {
     context.ownTaskId = ownTaskId;
 
     const newTask = jsone(action.task, context);
-
-    await apolloClient.mutate({
-      mutation: createTaskQuery,
-      variables: {
-        taskId: ownTaskId,
-        task: {
-          ...newTask,
-          // Call the queue with the decision task's scopes,
-          // as directed by the action spec
-          options: {
-            authorizedScopes: taskGroup.scopes || [],
-          },
-        },
-      },
+    const queue = getClient({
+      Class: Queue,
+      user,
+      // Call the queue with the decision task's scopes,
+      // as directed by the action spec
+      authorizedScopes: taskGroup.scopes || [],
     });
+
+    await queue.createTask(ownTaskId, newTask);
 
     return ownTaskId;
   }

--- a/ui/src/views/Tasks/submitTaskAction.test.js
+++ b/ui/src/views/Tasks/submitTaskAction.test.js
@@ -1,0 +1,123 @@
+import submitTaskAction from './submitTaskAction';
+import { getClient } from '../../utils/client';
+
+// Mock getClient to return a mock Queue instance
+jest.mock('../../utils/client', () => ({
+  getClient: jest.fn(),
+}));
+jest.mock('@taskcluster/client-web', () => ({
+  Queue: jest.fn(),
+}));
+// Mock validateActionsJson to avoid fetch in test environment
+jest.mock('../../utils/validateActionsJson', () =>
+  jest.fn().mockResolvedValue(() => true)
+);
+
+const taskDef = JSON.stringify({
+  taskQueueId: 'test/test',
+  created: '2024-01-01T00:00:00.000Z',
+  deadline: '2024-01-02T00:00:00.000Z',
+  expires: '2024-12-31T00:00:00.000Z',
+  payload: {},
+  metadata: {
+    name: 'test',
+    description: 'test',
+    owner: 'test@test.com',
+    source: 'http://test',
+  },
+});
+
+describe('submitTaskAction', () => {
+  const user = {
+    credentials: { clientId: 'test', accessToken: 'secret' },
+  };
+  const mockCreateTask = jest.fn().mockResolvedValue({});
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    getClient.mockReturnValue({ createTask: mockCreateTask });
+  });
+
+  it('action.kind=task: calls Queue.createTask directly (not Apollo)', async () => {
+    const apolloClient = { mutate: jest.fn(), query: jest.fn() };
+    const task = {
+      taskId: 'abc123',
+      taskGroupId: 'abc123',
+      scopes: ['queue:create-task:*'],
+      taskActions: {
+        variables: {},
+        actions: [
+          {
+            kind: 'task',
+            name: 'test-action',
+            title: 'Test Action',
+            context: [],
+            schema: {},
+            task: taskDef,
+            description: 'Test action',
+          },
+        ],
+        version: 1,
+      },
+    };
+    const action = task.taskActions.actions[0];
+
+    await submitTaskAction({
+      task,
+      taskActions: task.taskActions,
+      form: '{}',
+      action,
+      apolloClient,
+      user,
+    });
+
+    // Queue.createTask should be called directly
+    expect(mockCreateTask).toHaveBeenCalledTimes(1);
+    // apolloClient.mutate should NOT be called for task kind
+    expect(apolloClient.mutate).not.toHaveBeenCalled();
+  });
+
+  it('action.kind=task: passes authorizedScopes from taskGroup.scopes', async () => {
+    const apolloClient = { mutate: jest.fn(), query: jest.fn() };
+    const scopes = ['queue:create-task:proj-test/test-worker'];
+    const task = {
+      taskId: 'abc123',
+      taskGroupId: 'abc123',
+      scopes,
+      taskActions: {
+        variables: {},
+        actions: [],
+        version: 1,
+      },
+    };
+    const action = {
+      kind: 'task',
+      name: 'retrigger',
+      title: 'Retrigger',
+      context: [],
+      schema: {},
+      task: taskDef,
+      description: 'Retrigger task',
+    };
+
+    await submitTaskAction({
+      task,
+      taskActions: {
+        variables: {},
+        actions: [action],
+        version: 1,
+      },
+      form: '{}',
+      action,
+      apolloClient,
+      user,
+    });
+
+    expect(getClient).toHaveBeenCalledWith(
+      expect.objectContaining({
+        user,
+        authorizedScopes: scopes,
+      })
+    );
+  });
+});

--- a/ui/src/views/Tasks/submitTaskAction.test.js
+++ b/ui/src/views/Tasks/submitTaskAction.test.js
@@ -1,17 +1,18 @@
+import { vi, describe, it, expect, beforeEach } from 'vitest';
 import submitTaskAction from './submitTaskAction';
 import { getClient } from '../../utils/client';
 
 // Mock getClient to return a mock Queue instance
-jest.mock('../../utils/client', () => ({
-  getClient: jest.fn(),
+vi.mock('../../utils/client', () => ({
+  getClient: vi.fn(),
 }));
-jest.mock('@taskcluster/client-web', () => ({
-  Queue: jest.fn(),
+vi.mock('@taskcluster/client-web', () => ({
+  Queue: vi.fn(),
 }));
 // Mock validateActionsJson to avoid fetch in test environment
-jest.mock('../../utils/validateActionsJson', () =>
-  jest.fn().mockResolvedValue(() => true)
-);
+vi.mock('../../utils/validateActionsJson', () => ({
+  default: vi.fn().mockResolvedValue(() => true),
+}));
 
 const taskDef = JSON.stringify({
   taskQueueId: 'test/test',
@@ -31,15 +32,15 @@ describe('submitTaskAction', () => {
   const user = {
     credentials: { clientId: 'test', accessToken: 'secret' },
   };
-  const mockCreateTask = jest.fn().mockResolvedValue({});
+  const mockCreateTask = vi.fn().mockResolvedValue({});
 
   beforeEach(() => {
-    jest.clearAllMocks();
+    vi.clearAllMocks();
     getClient.mockReturnValue({ createTask: mockCreateTask });
   });
 
   it('action.kind=task: calls Queue.createTask directly (not Apollo)', async () => {
-    const apolloClient = { mutate: jest.fn(), query: jest.fn() };
+    const apolloClient = { mutate: vi.fn(), query: vi.fn() };
     const task = {
       taskId: 'abc123',
       taskGroupId: 'abc123',
@@ -78,7 +79,7 @@ describe('submitTaskAction', () => {
   });
 
   it('action.kind=task: passes authorizedScopes from taskGroup.scopes', async () => {
-    const apolloClient = { mutate: jest.fn(), query: jest.fn() };
+    const apolloClient = { mutate: vi.fn(), query: vi.fn() };
     const scopes = ['queue:create-task:proj-test/test-worker'];
     const task = {
       taskId: 'abc123',


### PR DESCRIPTION
## Summary

- The UI's `createTask` calls (loaner, retrigger, submitTaskAction, CreateTask page) now call the Queue REST API directly via `@taskcluster/client-web` instead of routing through GraphQL
- This fixes 413 errors when creating tasks with payloads larger than 100KB (the default `bodyParser.json` limit) — up to the Queue API's 10MB limit
- Also fixes a latent bug where `authorizedScopes` passed via GraphQL `options` were silently dropped by the resolver; the Queue client now receives them correctly via `getClient({ authorizedScopes: ... })`
- Reverts the server-side body-size limit increases from the previous approach (no changes to `createApp.js` vs `main`)
- Deletes the now-unused `createTask.graphql` mutation file

## Approach

Per architect review by @lotas in #8171: skipping the GraphQL layer for task creation avoids widening the Apollo attack surface (increased body limits have historically been a source of security issues in Apollo).

The UI already uses `@taskcluster/client-web` for other endpoints (e.g. `WorkerManager.removeWorker`). Task creation follows the same `getClient()` pattern.

## Test plan

- [ ] `cd ui && yarn test` — all 52 suites / 137 tests pass (including new `submitTaskAction.test.js`)
- [ ] `cd ui && yarn lint` — no errors
- [ ] `cd services/web-server && yarn test` — `validation_test.js` passes with original 413 + `PayloadTooLargeError` assertions
- [ ] Manually verify task creation with a large payload (>100KB) succeeds in the UI

GitHub Bug/Issue: Fixes #8171