### PR TITLE
feat(ui): Fix yarn dev:start for UI

### DIFF
--- a/changelog/issue-8271.md
+++ b/changelog/issue-8271.md
@@ -1,0 +1,4 @@
+audience: developers
+level: silent
+reference: issue 8271
+---

--- a/ui/Dockerfile
+++ b/ui/Dockerfile
@@ -10,5 +10,7 @@ RUN corepack enable && \
 
 COPY . ./
 
+ENV PATH="/app/ui/node_modules/.bin:${PATH}"
+
 ENTRYPOINT [ "yarn" ]
 CMD [ "start:docker" ]


### PR DESCRIPTION
I'm not sure why ui container stopped seeing this binary without adding node modules to path

```
  docker compose -f docker-compose.yml -f docker-compose.dev.yml build --no-cache ui
```

Fixes #8271
