### PR TITLE
feat(generic-worker): support capacity > 1 for concurrent task execution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@ _testmain.go
 
 *.exe
 *.test
+!Dockerfile.test
 *.prof
 
 # Coverage report

--- a/.gitignore
+++ b/.gitignore
@@ -62,6 +62,7 @@ next-task-user.json
 /workers/generic-worker/generic-worker
 /workers/generic-worker/testdata/Test*
 /workers/generic-worker/downloads
+/workers/generic-worker/.tmp-test
 /tools/worker-runner/start-worker
 /tools/worker-runner/start-worker-*-*
 /tools/worker-runner/fake.exe

--- a/changelog/issue-7388.md
+++ b/changelog/issue-7388.md
@@ -1,0 +1,29 @@
+audience: worker-deployers
+level: minor
+reference: issue 7388
+---
+Generic Worker now supports running multiple tasks concurrently via the new `capacity` configuration option.
+
+**Configuration:**
+
+- `capacity` (uint8, default: `1`, max: `255`) - the number of tasks the worker will claim and execute in parallel.
+- When `capacity` is `1`, behavior is unchanged from previous releases.
+- When `capacity` > 1, each task slot is allocated a block of 4 ports offset from the configured base ports (`livelogPortBase`, `interactivePort`, `taskclusterProxyPort`). Deployers must ensure these base ports are spaced far enough apart to avoid overlapping ranges. The worker validates this at startup and exits with an error if ranges collide.
+
+**Engine support:**
+
+- Insecure engine: supported.
+- Multiuser engine: supported only when `headlessTasks` is enabled. Non-headless multiuser mode (which reboots between tasks) is restricted to `capacity` = 1.
+
+**Task isolation:**
+
+- Each concurrent task receives its own task directory under `tasksDir`, its own set of dynamically allocated ports for LiveLog, Interactive, and TaskclusterProxy, and (in multiuser mode) its own OS user.
+- Caches and mounts are protected by per-cache read/write locks so that multiple tasks can read from the same cache concurrently while writes are serialized.
+- Docker image loading (D2G) uses file-level locking so parallel tasks sharing the same image coordinate without redundant loads.
+- TaskclusterProxy now verifies that incoming connections originate from the OS user running the task, preventing one task from accessing another task's credentials. This is implemented via `/proc/net/tcp` on Linux, `lsof` on macOS, and `GetExtendedTcpTable` on Windows.
+
+**Constraints:**
+
+- The `runTaskAsCurrentUser` and `runAsAdministrator` task features are not supported when `capacity` > 1 and will return a `MalformedPayloadError` if requested.
+- Graceful shutdown waits for all running tasks to complete before the worker exits.
+- `numberOfTasksToRun` is respected across all concurrent slots - the worker will not start more tasks than the configured total.

--- a/changelog/issue-7388.md
+++ b/changelog/issue-7388.md
@@ -20,7 +20,7 @@ Generic Worker now supports running multiple tasks concurrently via the new `cap
 - Each concurrent task receives its own task directory under `tasksDir`, its own set of dynamically allocated ports for LiveLog, Interactive, and TaskclusterProxy, and (in multiuser mode) its own OS user.
 - Caches and mounts are protected by per-cache read/write locks so that multiple tasks can read from the same cache concurrently while writes are serialized.
 - Docker image loading (D2G) uses file-level locking so parallel tasks sharing the same image coordinate without redundant loads.
-- TaskclusterProxy now verifies that incoming connections originate from the OS user running the task, preventing one task from accessing another task's credentials. This is implemented via `/proc/net/tcp` on Linux, `lsof` on macOS, and `GetExtendedTcpTable` on Windows.
+- In multiuser mode, TaskclusterProxy now verifies that incoming connections originate from the OS user running the task, preventing one task from accessing another task's credentials. This is implemented via `/proc/net/tcp` on Linux, `lsof` on macOS, and `GetExtendedTcpTable` on Windows. Note: in insecure mode, all tasks run as the same OS user, so UID-based connection verification is not possible; insecure mode with `capacity` > 1 does not provide credential isolation between concurrent tasks.
 
 **Constraints:**
 

--- a/infrastructure/tooling/src/generate/generators/go-version.js
+++ b/infrastructure/tooling/src/generate/generators/go-version.js
@@ -70,6 +70,7 @@ export const tasks = [{
     for (const file of [
       'generic-worker.Dockerfile',
       'taskcluster/docker/ci/Dockerfile',
+      'workers/generic-worker/Dockerfile.test',
     ]) {
       utils.status({ message: file });
       await modifyRepoFile(file,

--- a/tools/d2g/d2g.go
+++ b/tools/d2g/d2g.go
@@ -424,7 +424,10 @@ func runCommand(
 	args = append(args, createVolumeMountArgs(dwPayload, wdcs, gwArtifacts, config)...)
 
 	if dwPayload.Features.TaskclusterProxy && config.AllowTaskclusterProxy {
-		args = append(args, "--add-host=taskcluster:host-gateway")
+		// Use per-task Docker network for tc-proxy isolation.
+		// The network name and gateway IP are set by generic-worker at runtime.
+		args = append(args, "--network", "__TASKCLUSTER_DOCKER_NETWORK__")
+		args = append(args, "--add-host=taskcluster:__TASKCLUSTER_PROXY_GATEWAY__")
 	}
 
 	if config.AllowGPUs {

--- a/tools/d2g/d2gtest/testdata/testcases/decision_task_tests.yml
+++ b/tools/d2g/d2gtest/testdata/testcases/decision_task_tests.yml
@@ -91,7 +91,9 @@ testSuite:
         - --add-host=localhost.localdomain:127.0.0.1
         - -v
         - __TASK_DIR__/cache0:/builds/worker/checkouts
-        - --add-host=taskcluster:host-gateway
+        - --network
+        - __TASKCLUSTER_DOCKER_NETWORK__
+        - --add-host=taskcluster:__TASKCLUSTER_PROXY_GATEWAY__
         - --env-file
         - env.list
         - mozillareleases/gecko_decision:4.0.0@sha256:9f69fe08c28e3cb3cc296451f0a2735df6e25d0e3c877ea735ef1b7f0b345b06

--- a/tools/d2g/d2gtest/testdata/testcases/dw_features_tests.yml
+++ b/tools/d2g/d2gtest/testdata/testcases/dw_features_tests.yml
@@ -42,7 +42,9 @@ testSuite:
         - --cap-add=SYS_PTRACE
         - --security-opt=seccomp=unconfined
         - --add-host=localhost.localdomain:127.0.0.1
-        - --add-host=taskcluster:host-gateway
+        - --network
+        - __TASKCLUSTER_DOCKER_NETWORK__
+        - --add-host=taskcluster:__TASKCLUSTER_PROXY_GATEWAY__
         - --env-file
         - env.list
         - ubuntu

--- a/tools/d2g/d2gtest/testdata/testcases/fuzzing_tests.yml
+++ b/tools/d2g/d2gtest/testdata/testcases/fuzzing_tests.yml
@@ -65,7 +65,9 @@ testSuite:
         - -v
         - /dev/shm:/dev/shm
         - --device=/dev/snd
-        - --add-host=taskcluster:host-gateway
+        - --network
+        - __TASKCLUSTER_DOCKER_NETWORK__
+        - --add-host=taskcluster:__TASKCLUSTER_PROXY_GATEWAY__
         - --env-file
         - env.list
         - __D2G_IMAGE_ID__

--- a/tools/taskcluster-proxy/connectionverifier.go
+++ b/tools/taskcluster-proxy/connectionverifier.go
@@ -1,0 +1,74 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"net"
+)
+
+// ConnectionVerifier verifies whether an incoming connection should be
+// accepted. Implementations inspect the connection (e.g. peer credentials)
+// and return nil to allow it or an error to reject it.
+type ConnectionVerifier interface {
+	Verify(conn net.Conn) error
+}
+
+// ErrUnauthorizedConnection is returned when a connection is rejected because
+// the connecting process does not belong to the expected user.
+type ErrUnauthorizedConnection struct {
+	ExpectedUser string
+	ActualUID    string
+	RemoteAddr   string
+}
+
+func (e *ErrUnauthorizedConnection) Error() string {
+	return fmt.Sprintf(
+		"unauthorized connection from UID %s at %s (expected user %q)",
+		e.ActualUID, e.RemoteAddr, e.ExpectedUser,
+	)
+}
+
+// noopVerifier allows all connections without any verification.
+type noopVerifier struct{}
+
+func (n *noopVerifier) Verify(_ net.Conn) error {
+	return nil
+}
+
+// newConnectionVerifier returns a ConnectionVerifier appropriate for the given
+// username. If username is empty, a noopVerifier is returned that allows all
+// connections. Otherwise, a platform-specific verifier is created via
+// newPlatformVerifier.
+func newConnectionVerifier(username string) (ConnectionVerifier, error) {
+	if username == "" {
+		return &noopVerifier{}, nil
+	}
+	return newPlatformVerifier(username)
+}
+
+// verifiedListener wraps a net.Listener and verifies each accepted connection
+// using a ConnectionVerifier. Connections that fail verification are logged
+// and closed; the listener then continues accepting new connections.
+type verifiedListener struct {
+	net.Listener
+	verifier ConnectionVerifier
+}
+
+// Accept waits for and returns the next verified connection. Connections that
+// fail verification are closed and a log message is emitted. The method keeps
+// accepting until a verified connection arrives or the underlying listener
+// returns a permanent error.
+func (vl *verifiedListener) Accept() (net.Conn, error) {
+	for {
+		conn, err := vl.Listener.Accept()
+		if err != nil {
+			return nil, err
+		}
+		if verifyErr := vl.verifier.Verify(conn); verifyErr != nil {
+			log.Printf("Rejected connection: %v", verifyErr)
+			conn.Close()
+			continue
+		}
+		return conn, nil
+	}
+}

--- a/tools/taskcluster-proxy/connectionverifier.go
+++ b/tools/taskcluster-proxy/connectionverifier.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"log"
 	"net"
@@ -28,6 +29,14 @@ func (e *ErrUnauthorizedConnection) Error() string {
 	)
 }
 
+// errPeerNotFound is returned by platform-specific UID lookups when the
+// peer's client-side socket is not visible to this process — most commonly
+// because the peer is in a different network namespace (e.g. a container
+// connecting via a Docker bridge gateway). When this error is wrapped, the
+// network-fallback admission path may admit the connection if its remote
+// IP falls within an --allowed-network CIDR.
+var errPeerNotFound = errors.New("peer connection not found")
+
 // noopVerifier allows all connections without any verification.
 type noopVerifier struct{}
 
@@ -35,15 +44,57 @@ func (n *noopVerifier) Verify(_ net.Conn) error {
 	return nil
 }
 
-// newConnectionVerifier returns a ConnectionVerifier appropriate for the given
-// username. If username is empty, a noopVerifier is returned that allows all
-// connections. Otherwise, a platform-specific verifier is created via
-// newPlatformVerifier.
-func newConnectionVerifier(username string) (ConnectionVerifier, error) {
-	if username == "" {
+// networkAdmittingVerifier wraps a platform UID verifier with a fallback
+// admission rule: connections whose UID lookup fails specifically because
+// the peer is invisible (errPeerNotFound) are admitted if their remote IP
+// is contained in allowedNetwork. Connections that fail the UID check for
+// any other reason — including UID mismatch — are still rejected.
+//
+// This exists so the d2g + docker-bridge case works: the container's
+// client-side socket lives in the container's netns and is therefore not
+// in the proxy's /proc/net/tcp. Without this, a UID check would fail
+// closed for legitimate in-container traffic.
+type networkAdmittingVerifier struct {
+	inner          ConnectionVerifier
+	allowedNetwork *net.IPNet
+}
+
+func (v *networkAdmittingVerifier) Verify(conn net.Conn) error {
+	err := v.inner.Verify(conn)
+	if err == nil {
+		return nil
+	}
+	if !errors.Is(err, errPeerNotFound) {
+		return err
+	}
+	tcpAddr, ok := conn.RemoteAddr().(*net.TCPAddr)
+	if !ok {
+		return err
+	}
+	if v.allowedNetwork.Contains(tcpAddr.IP) {
+		return nil
+	}
+	return err
+}
+
+// newConnectionVerifier returns a ConnectionVerifier appropriate for the
+// given configuration. If neither username nor allowedNetwork is set, a
+// noopVerifier is returned. Otherwise a platform-specific UID verifier
+// is created and (when allowedNetwork is non-nil) wrapped with
+// networkAdmittingVerifier to admit container traffic whose peer is
+// invisible to /proc/net/tcp / lsof / GetExtendedTcpTable.
+func newConnectionVerifier(username string, allowedNetwork *net.IPNet) (ConnectionVerifier, error) {
+	if username == "" && allowedNetwork == nil {
 		return &noopVerifier{}, nil
 	}
-	return newPlatformVerifier(username)
+	platform, err := newPlatformVerifier(username)
+	if err != nil {
+		return nil, err
+	}
+	if allowedNetwork == nil {
+		return platform, nil
+	}
+	return &networkAdmittingVerifier{inner: platform, allowedNetwork: allowedNetwork}, nil
 }
 
 // verifiedListener wraps a net.Listener and verifies each accepted connection

--- a/tools/taskcluster-proxy/connectionverifier_darwin.go
+++ b/tools/taskcluster-proxy/connectionverifier_darwin.go
@@ -42,7 +42,7 @@ func (v *darwinVerifier) Verify(conn net.Conn) error {
 		return fmt.Errorf("failed to look up UID for %s: %w", tcpAddr, err)
 	}
 
-	// Always allow root (UID 0) — the worker process runs as root and
+	// Always allow root (UID 0) - the worker process runs as root and
 	// needs to reach tc-proxy for credential refresh and health checks.
 	if uid == 0 {
 		return nil

--- a/tools/taskcluster-proxy/connectionverifier_darwin.go
+++ b/tools/taskcluster-proxy/connectionverifier_darwin.go
@@ -1,0 +1,89 @@
+//go:build darwin
+
+package main
+
+import (
+	"fmt"
+	"net"
+	"os/exec"
+	"os/user"
+	"strconv"
+	"strings"
+)
+
+type darwinVerifier struct {
+	allowedUID uint32
+	username   string
+}
+
+func newPlatformVerifier(username string) (ConnectionVerifier, error) {
+	u, err := user.Lookup(username)
+	if err != nil {
+		return nil, fmt.Errorf("failed to look up user %q: %w", username, err)
+	}
+	uid, err := strconv.ParseUint(u.Uid, 10, 32)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse UID %q: %w", u.Uid, err)
+	}
+	return &darwinVerifier{
+		allowedUID: uint32(uid),
+		username:   username,
+	}, nil
+}
+
+func (v *darwinVerifier) Verify(conn net.Conn) error {
+	tcpAddr, ok := conn.RemoteAddr().(*net.TCPAddr)
+	if !ok {
+		return fmt.Errorf("connection is not TCP")
+	}
+
+	uid, err := lookupUIDWithLsof(tcpAddr)
+	if err != nil {
+		return fmt.Errorf("failed to look up UID for %s: %w", tcpAddr, err)
+	}
+
+	// Always allow root (UID 0) — the worker process runs as root and
+	// needs to reach tc-proxy for credential refresh and health checks.
+	if uid == 0 {
+		return nil
+	}
+
+	if uid != v.allowedUID {
+		return &ErrUnauthorizedConnection{
+			ExpectedUser: v.username,
+			ActualUID:    strconv.FormatUint(uint64(uid), 10),
+			RemoteAddr:   conn.RemoteAddr().String(),
+		}
+	}
+	return nil
+}
+
+// lookupUIDWithLsof uses lsof to find the UID of the process that owns
+// the TCP connection from the given address.
+func lookupUIDWithLsof(addr *net.TCPAddr) (uint32, error) {
+	// lsof -i tcp@<ip>:<port> -sTCP:ESTABLISHED -F u -n -P
+	// -F u: output UID field (prefixed with 'u')
+	// -n: no DNS resolution
+	// -P: no port name resolution
+	out, err := exec.Command("lsof",
+		"-i", fmt.Sprintf("tcp@%s:%d", addr.IP, addr.Port),
+		"-sTCP:ESTABLISHED",
+		"-F", "u",
+		"-n", "-P",
+	).Output()
+	if err != nil {
+		return 0, fmt.Errorf("lsof failed: %w", err)
+	}
+
+	// Parse lsof -F output: lines starting with 'u' contain the UID
+	for line := range strings.SplitSeq(string(out), "\n") {
+		if strings.HasPrefix(line, "u") {
+			uid, err := strconv.ParseUint(line[1:], 10, 32)
+			if err != nil {
+				return 0, fmt.Errorf("failed to parse UID from lsof output %q: %w", line, err)
+			}
+			return uint32(uid), nil
+		}
+	}
+	return 0, fmt.Errorf("no UID found in lsof output for %s", addr)
+}

--- a/tools/taskcluster-proxy/connectionverifier_darwin.go
+++ b/tools/taskcluster-proxy/connectionverifier_darwin.go
@@ -3,6 +3,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"net"
 	"os"
@@ -10,18 +11,13 @@ import (
 	"os/user"
 	"strconv"
 	"strings"
-	"sync"
+	"time"
 )
 
 type darwinVerifier struct {
 	allowedUID uint32
 	username   string
 	proxyPID   int
-	// verified caches remote addresses (ip:port strings) that have passed
-	// verification, so that repeated connections from the same endpoint
-	// skip the expensive lsof lookup. A TCP source port is bound to one
-	// process for its lifetime, and TIME_WAIT prevents immediate reuse.
-	verified sync.Map
 }
 
 func newPlatformVerifier(username string) (ConnectionVerifier, error) {
@@ -46,11 +42,12 @@ func (v *darwinVerifier) Verify(conn net.Conn) error {
 		return fmt.Errorf("connection is not TCP")
 	}
 
-	key := tcpAddr.String()
-	if _, ok := v.verified.Load(key); ok {
-		return nil
-	}
-
+	// Verify is invoked once per accepted TCP connection
+	// (verifiedListener.Accept). The kernel guarantees a source port
+	// stays bound to the same process for the lifetime of that
+	// connection, so no cross-call cache is needed; once a connection
+	// is admitted by Accept, all subsequent traffic on that conn rides
+	// on the verified peer.
 	uid, err := lookupUIDWithLsof(tcpAddr, v.proxyPID)
 	if err != nil {
 		return fmt.Errorf("failed to look up UID for %s: %w", tcpAddr, err)
@@ -59,7 +56,6 @@ func (v *darwinVerifier) Verify(conn net.Conn) error {
 	// Always allow root (UID 0) - the worker process runs as root and
 	// needs to reach tc-proxy for credential refresh and health checks.
 	if uid == 0 {
-		v.verified.Store(key, struct{}{})
 		return nil
 	}
 
@@ -70,7 +66,6 @@ func (v *darwinVerifier) Verify(conn net.Conn) error {
 			RemoteAddr:   conn.RemoteAddr().String(),
 		}
 	}
-	v.verified.Store(key, struct{}{})
 	return nil
 }
 
@@ -81,11 +76,24 @@ func (v *darwinVerifier) Verify(conn net.Conn) error {
 // accepted-connection entry (foreign = client addr) would otherwise
 // shadow the client's entry.
 func lookupUIDWithLsof(addr *net.TCPAddr, proxyPID int) (uint32, error) {
+	// lsof requires IPv6 literals to be bracketed: tcp@[::1]:8080.
+	// Without brackets the tool rejects the spec ("unacceptable Internet
+	// address") and the verifier fails closed.
+	hostPart := addr.IP.String()
+	if addr.IP.To4() == nil {
+		hostPart = "[" + hostPart + "]"
+	}
+
+	// 5s deadline guards against a wedged lsof (rare but possible with
+	// massive open-FD counts) freezing the listener.
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
 	// -F pu: output PID ('p' prefix) and UID ('u' prefix) fields
 	// -sTCP:ESTABLISHED: only established connections
 	// -n -P: no DNS/port name resolution
-	out, err := exec.Command("lsof",
-		"-i", fmt.Sprintf("tcp@%s:%d", addr.IP, addr.Port),
+	out, err := exec.CommandContext(ctx, "lsof",
+		"-i", fmt.Sprintf("tcp@%s:%d", hostPart, addr.Port),
 		"-sTCP:ESTABLISHED",
 		"-F", "pu",
 		"-n", "-P",
@@ -112,5 +120,5 @@ func lookupUIDWithLsof(addr *net.TCPAddr, proxyPID int) (uint32, error) {
 			return uint32(uid), nil
 		}
 	}
-	return 0, fmt.Errorf("no UID found in lsof output for %s", addr)
+	return 0, fmt.Errorf("no UID found in lsof output for %s: %w", addr, errPeerNotFound)
 }

--- a/tools/taskcluster-proxy/connectionverifier_darwin.go
+++ b/tools/taskcluster-proxy/connectionverifier_darwin.go
@@ -5,15 +5,23 @@ package main
 import (
 	"fmt"
 	"net"
+	"os"
 	"os/exec"
 	"os/user"
 	"strconv"
 	"strings"
+	"sync"
 )
 
 type darwinVerifier struct {
 	allowedUID uint32
 	username   string
+	proxyPID   int
+	// verified caches remote addresses (ip:port strings) that have passed
+	// verification, so that repeated connections from the same endpoint
+	// skip the expensive lsof lookup. A TCP source port is bound to one
+	// process for its lifetime, and TIME_WAIT prevents immediate reuse.
+	verified sync.Map
 }
 
 func newPlatformVerifier(username string) (ConnectionVerifier, error) {
@@ -28,6 +36,7 @@ func newPlatformVerifier(username string) (ConnectionVerifier, error) {
 	return &darwinVerifier{
 		allowedUID: uint32(uid),
 		username:   username,
+		proxyPID:   os.Getpid(),
 	}, nil
 }
 
@@ -37,7 +46,12 @@ func (v *darwinVerifier) Verify(conn net.Conn) error {
 		return fmt.Errorf("connection is not TCP")
 	}
 
-	uid, err := lookupUIDWithLsof(tcpAddr)
+	key := tcpAddr.String()
+	if _, ok := v.verified.Load(key); ok {
+		return nil
+	}
+
+	uid, err := lookupUIDWithLsof(tcpAddr, v.proxyPID)
 	if err != nil {
 		return fmt.Errorf("failed to look up UID for %s: %w", tcpAddr, err)
 	}
@@ -45,6 +59,7 @@ func (v *darwinVerifier) Verify(conn net.Conn) error {
 	// Always allow root (UID 0) - the worker process runs as root and
 	// needs to reach tc-proxy for credential refresh and health checks.
 	if uid == 0 {
+		v.verified.Store(key, struct{}{})
 		return nil
 	}
 
@@ -55,32 +70,44 @@ func (v *darwinVerifier) Verify(conn net.Conn) error {
 			RemoteAddr:   conn.RemoteAddr().String(),
 		}
 	}
+	v.verified.Store(key, struct{}{})
 	return nil
 }
 
 // lookupUIDWithLsof uses lsof to find the UID of the process that owns
-// the TCP connection from the given address.
-func lookupUIDWithLsof(addr *net.TCPAddr) (uint32, error) {
-	// lsof -i tcp@<ip>:<port> -sTCP:ESTABLISHED -F u -n -P
-	// -F u: output UID field (prefixed with 'u')
-	// -n: no DNS resolution
-	// -P: no port name resolution
+// the TCP connection from the given address. proxyPID is the PID of the
+// proxy process itself, which must be excluded from the results because
+// lsof -i matches both local and foreign addresses — the proxy's
+// accepted-connection entry (foreign = client addr) would otherwise
+// shadow the client's entry.
+func lookupUIDWithLsof(addr *net.TCPAddr, proxyPID int) (uint32, error) {
+	// -F pu: output PID ('p' prefix) and UID ('u' prefix) fields
+	// -sTCP:ESTABLISHED: only established connections
+	// -n -P: no DNS/port name resolution
 	out, err := exec.Command("lsof",
 		"-i", fmt.Sprintf("tcp@%s:%d", addr.IP, addr.Port),
 		"-sTCP:ESTABLISHED",
-		"-F", "u",
+		"-F", "pu",
 		"-n", "-P",
 	).Output()
 	if err != nil {
 		return 0, fmt.Errorf("lsof failed: %w", err)
 	}
 
-	// Parse lsof -F output: lines starting with 'u' contain the UID
+	// Parse lsof -F output: 'p' lines carry the PID, 'u' lines the UID.
+	// Skip entries whose PID matches the proxy itself.
+	var currentPID int
 	for line := range strings.SplitSeq(string(out), "\n") {
-		if strings.HasPrefix(line, "u") {
-			uid, err := strconv.ParseUint(line[1:], 10, 32)
-			if err != nil {
-				return 0, fmt.Errorf("failed to parse UID from lsof output %q: %w", line, err)
+		if strings.HasPrefix(line, "p") {
+			pid, parseErr := strconv.Atoi(line[1:])
+			if parseErr != nil {
+				continue
+			}
+			currentPID = pid
+		} else if strings.HasPrefix(line, "u") && currentPID != proxyPID {
+			uid, parseErr := strconv.ParseUint(line[1:], 10, 32)
+			if parseErr != nil {
+				return 0, fmt.Errorf("failed to parse UID from lsof output %q: %w", line, parseErr)
 			}
 			return uint32(uid), nil
 		}

--- a/tools/taskcluster-proxy/connectionverifier_darwin_test.go
+++ b/tools/taskcluster-proxy/connectionverifier_darwin_test.go
@@ -1,0 +1,73 @@
+//go:build darwin
+
+package main
+
+import (
+	"net"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLookupUIDWithLsofSelf(t *testing.T) {
+	// Create a TCP connection pair and verify that lookupUIDWithLsof
+	// returns the current process's UID for the client side.
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	defer ln.Close()
+
+	done := make(chan net.Conn, 1)
+	go func() {
+		conn, _ := ln.Accept()
+		done <- conn
+	}()
+
+	client, err := net.Dial("tcp", ln.Addr().String())
+	require.NoError(t, err)
+	defer client.Close()
+
+	server := <-done
+	defer server.Close()
+
+	// The client's local address is the server's RemoteAddr
+	clientAddr := server.RemoteAddr().(*net.TCPAddr)
+
+	// Use a bogus proxy PID (0) so we don't filter anything out —
+	// we just want to confirm the lookup returns our own UID.
+	uid, err := lookupUIDWithLsof(clientAddr, 0)
+	require.NoError(t, err)
+	assert.Equal(t, uint32(os.Getuid()), uid)
+}
+
+func TestLookupUIDWithLsofFiltersProxyPID(t *testing.T) {
+	// Verify that when we pass our own PID as the proxyPID, the lookup
+	// skips our entry. Since both sides of this connection belong to us,
+	// all entries have our PID and should be filtered — resulting in
+	// "no UID found".
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	defer ln.Close()
+
+	done := make(chan net.Conn, 1)
+	go func() {
+		conn, _ := ln.Accept()
+		done <- conn
+	}()
+
+	client, err := net.Dial("tcp", ln.Addr().String())
+	require.NoError(t, err)
+	defer client.Close()
+
+	server := <-done
+	defer server.Close()
+
+	clientAddr := server.RemoteAddr().(*net.TCPAddr)
+
+	// Pass our own PID as proxyPID — all lsof entries belong to us,
+	// so they should all be filtered out.
+	_, err = lookupUIDWithLsof(clientAddr, os.Getpid())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no UID found")
+}

--- a/tools/taskcluster-proxy/connectionverifier_linux.go
+++ b/tools/taskcluster-proxy/connectionverifier_linux.go
@@ -43,7 +43,7 @@ func (v *linuxVerifier) Verify(conn net.Conn) error {
 		return fmt.Errorf("failed to look up UID for %s: %w", tcpAddr, err)
 	}
 
-	// Always allow root (UID 0) — the worker process runs as root and
+	// Always allow root (UID 0) - the worker process runs as root and
 	// needs to reach tc-proxy for credential refresh and health checks.
 	if uid == 0 {
 		return nil

--- a/tools/taskcluster-proxy/connectionverifier_linux.go
+++ b/tools/taskcluster-proxy/connectionverifier_linux.go
@@ -1,0 +1,113 @@
+//go:build linux
+
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"net"
+	"os"
+	"os/user"
+	"strconv"
+	"strings"
+)
+
+type linuxVerifier struct {
+	allowedUID uint32
+	username   string
+}
+
+func newPlatformVerifier(username string) (ConnectionVerifier, error) {
+	u, err := user.Lookup(username)
+	if err != nil {
+		return nil, fmt.Errorf("failed to look up user %q: %w", username, err)
+	}
+	uid, err := strconv.ParseUint(u.Uid, 10, 32)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse UID %q: %w", u.Uid, err)
+	}
+	return &linuxVerifier{
+		allowedUID: uint32(uid),
+		username:   username,
+	}, nil
+}
+
+func (v *linuxVerifier) Verify(conn net.Conn) error {
+	tcpAddr, ok := conn.RemoteAddr().(*net.TCPAddr)
+	if !ok {
+		return fmt.Errorf("connection is not TCP")
+	}
+
+	uid, err := lookupUIDFromProcNet(tcpAddr)
+	if err != nil {
+		return fmt.Errorf("failed to look up UID for %s: %w", tcpAddr, err)
+	}
+
+	// Always allow root (UID 0) — the worker process runs as root and
+	// needs to reach tc-proxy for credential refresh and health checks.
+	if uid == 0 {
+		return nil
+	}
+
+	if uid != v.allowedUID {
+		return &ErrUnauthorizedConnection{
+			ExpectedUser: v.username,
+			ActualUID:    strconv.FormatUint(uint64(uid), 10),
+			RemoteAddr:   conn.RemoteAddr().String(),
+		}
+	}
+	return nil
+}
+
+// lookupUIDFromProcNet reads /proc/net/tcp (or tcp6) to find the UID
+// owning the given source address/port.
+func lookupUIDFromProcNet(addr *net.TCPAddr) (uint32, error) {
+	procFile := "/proc/net/tcp"
+	if addr.IP.To4() == nil {
+		procFile = "/proc/net/tcp6"
+	}
+
+	localAddrHex := ipPortToHex(addr.IP, addr.Port)
+
+	f, err := os.Open(procFile)
+	if err != nil {
+		return 0, fmt.Errorf("failed to open %s: %w", procFile, err)
+	}
+	defer f.Close()
+
+	scanner := bufio.NewScanner(f)
+	scanner.Scan() // skip header line
+	for scanner.Scan() {
+		fields := strings.Fields(scanner.Text())
+		if len(fields) < 8 {
+			continue
+		}
+		// fields[1] is local_address in hex, fields[7] is UID.
+		// We match on the client's local address (which appears as
+		// local_address in the client process's entry in /proc/net/tcp).
+		if strings.EqualFold(fields[1], localAddrHex) {
+			uid, err := strconv.ParseUint(fields[7], 10, 32)
+			if err != nil {
+				return 0, fmt.Errorf("failed to parse UID from %s: %w", fields[7], err)
+			}
+			return uint32(uid), nil
+		}
+	}
+	return 0, fmt.Errorf("connection from %s not found in %s", addr, procFile)
+}
+
+// ipPortToHex converts an IP and port to the hex format used in /proc/net/tcp.
+// IPv4: bytes in little-endian 32-bit word order. IPv6: four 32-bit words, each little-endian.
+func ipPortToHex(ip net.IP, port int) string {
+	ip4 := ip.To4()
+	if ip4 != nil {
+		return fmt.Sprintf("%02X%02X%02X%02X:%04X",
+			ip4[3], ip4[2], ip4[1], ip4[0], port)
+	}
+	ip16 := ip.To16()
+	var b strings.Builder
+	for i := 0; i < 16; i += 4 {
+		fmt.Fprintf(&b, "%02X%02X%02X%02X", ip16[i+3], ip16[i+2], ip16[i+1], ip16[i])
+	}
+	return fmt.Sprintf("%s:%04X", b.String(), port)
+}

--- a/tools/taskcluster-proxy/connectionverifier_linux.go
+++ b/tools/taskcluster-proxy/connectionverifier_linux.go
@@ -4,6 +4,7 @@ package main
 
 import (
 	"bufio"
+	"errors"
 	"fmt"
 	"net"
 	"os"
@@ -66,13 +67,41 @@ func (v *linuxVerifier) Verify(conn net.Conn) error {
 // namespace. Connections from a separate namespace (e.g. a container
 // with its own netns) will not appear in /proc/net/tcp and
 // verification will fail (fail-closed).
+//
+// IPv4 clients on a dual-stack listener (proxy bound to ::) appear in
+// /proc/net/tcp6 as ::ffff:<ipv4>, not in /proc/net/tcp. Go normalizes
+// IPv4-mapped-IPv6 addresses to plain IPv4 (To4() returns non-nil), so
+// we search both files when the IP is IPv4 to cover both cases. A
+// follow-up may switch to SO_PEERCRED to eliminate /proc parsing
+// entirely.
 func lookupUIDFromProcNet(addr *net.TCPAddr) (uint32, error) {
-	procFile := "/proc/net/tcp"
+	procFiles := []string{"/proc/net/tcp", "/proc/net/tcp6"}
 	if addr.IP.To4() == nil {
-		procFile = "/proc/net/tcp6"
+		procFiles = []string{"/proc/net/tcp6"}
 	}
 
-	localAddrHex := ipPortToHex(addr.IP, addr.Port)
+	for _, procFile := range procFiles {
+		uid, err := scanProcNet(procFile, addr)
+		if err == nil {
+			return uid, nil
+		}
+		if !errors.Is(err, errPeerNotFound) {
+			return 0, err
+		}
+	}
+	return 0, fmt.Errorf("connection from %s not found in /proc/net/tcp{,6}: %w", addr, errPeerNotFound)
+}
+
+func scanProcNet(procFile string, addr *net.TCPAddr) (uint32, error) {
+	// In /proc/net/tcp the address is a 4-byte word; in tcp6 it's
+	// 16 bytes. IPv4-mapped-IPv6 form (::ffff:a.b.c.d) is what shows
+	// up in tcp6 for an IPv4 client connecting to a dual-stack listener.
+	var localAddrHex string
+	if strings.HasSuffix(procFile, "tcp6") {
+		localAddrHex = ipPortToHex6(addr.IP, addr.Port)
+	} else {
+		localAddrHex = ipPortToHex(addr.IP, addr.Port)
+	}
 
 	f, err := os.Open(procFile)
 	if err != nil {
@@ -98,7 +127,7 @@ func lookupUIDFromProcNet(addr *net.TCPAddr) (uint32, error) {
 			return uint32(uid), nil
 		}
 	}
-	return 0, fmt.Errorf("connection from %s not found in %s", addr, procFile)
+	return 0, errPeerNotFound
 }
 
 // ipPortToHex converts an IP and port to the hex format used in /proc/net/tcp.
@@ -109,6 +138,13 @@ func ipPortToHex(ip net.IP, port int) string {
 		return fmt.Sprintf("%02X%02X%02X%02X:%04X",
 			ip4[3], ip4[2], ip4[1], ip4[0], port)
 	}
+	return ipPortToHex6(ip, port)
+}
+
+// ipPortToHex6 emits the /proc/net/tcp6 form for any IP, including
+// IPv4 addresses (which appear as ::ffff:a.b.c.d on a dual-stack
+// listener). Always 16 bytes, four little-endian 32-bit words.
+func ipPortToHex6(ip net.IP, port int) string {
 	ip16 := ip.To16()
 	var b strings.Builder
 	for i := 0; i < 16; i += 4 {

--- a/tools/taskcluster-proxy/connectionverifier_linux.go
+++ b/tools/taskcluster-proxy/connectionverifier_linux.go
@@ -61,6 +61,11 @@ func (v *linuxVerifier) Verify(conn net.Conn) error {
 
 // lookupUIDFromProcNet reads /proc/net/tcp (or tcp6) to find the UID
 // owning the given source address/port.
+//
+// Limitation: only works when proxy and task share the same network
+// namespace. Connections from a separate namespace (e.g. a container
+// with its own netns) will not appear in /proc/net/tcp and
+// verification will fail (fail-closed).
 func lookupUIDFromProcNet(addr *net.TCPAddr) (uint32, error) {
 	procFile := "/proc/net/tcp"
 	if addr.IP.To4() == nil {

--- a/tools/taskcluster-proxy/connectionverifier_linux_test.go
+++ b/tools/taskcluster-proxy/connectionverifier_linux_test.go
@@ -4,9 +4,14 @@ package main
 
 import (
 	"net"
+	"net/http"
 	"os"
+	"os/exec"
 	"os/user"
+	"strconv"
+	"syscall"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -93,7 +98,7 @@ func TestVerifiedListenerSelfConnection(t *testing.T) {
 	u, err := user.Current()
 	require.NoError(t, err)
 
-	v, err := newConnectionVerifier(u.Username)
+	v, err := newConnectionVerifier(u.Username, nil)
 	require.NoError(t, err)
 
 	ln, err := net.Listen("tcp", "127.0.0.1:0")
@@ -118,4 +123,270 @@ func TestVerifiedListenerSelfConnection(t *testing.T) {
 	conn, err := vl.Accept()
 	require.NoError(t, err)
 	conn.Close()
+}
+
+// TestProxyRejectsForeignUser proves the parallel-task isolation
+// property at the proxy level: a verifiedListener restricted to user A
+// (--allowed-user) must reject a TCP/HTTP request from a process
+// running as user B.
+//
+// The test stands up a real verifiedListener fronting a trivial HTTP
+// handler, then has a child subprocess (running as a different OS user
+// via SysProcAttr.Credential) attempt an HTTP GET. The child's exit
+// status tells us whether it was admitted (200 OK) or rejected
+// (connection-reset / EOF on read).
+//
+// Skipped without root (cannot setuid the child), skipped if no
+// non-root system user is reachable.
+func TestProxyRejectsForeignUser(t *testing.T) {
+	if os.Getuid() != 0 {
+		t.Skip("requires root to setuid the connecting child")
+	}
+	foreignUID, ok := pickNonRootUID(t)
+	if !ok {
+		t.Skip("no usable non-root UID on this host")
+	}
+
+	server, addr := startVerifiedListener(t, "root")
+	t.Cleanup(func() { _ = server.Close() })
+
+	// Sanity check: connecting from this process (root) is admitted by
+	// the root-bypass branch of the verifier — proves the listener
+	// itself is healthy before we judge the rejection case.
+	require.Equal(t, probeAdmitted, probeAsUID(t, addr, 0),
+		"root should be admitted by --allowed-user=root")
+
+	// The actual claim under test: a different OS user cannot reach
+	// this proxy.
+	assert.Equal(t, probeRejected, probeAsUID(t, addr, foreignUID),
+		"UID %d should not be able to access a proxy restricted to root",
+		foreignUID)
+}
+
+// TestProxyIsolationBetweenTwoUsers is the strictly-symmetric version of
+// the above — two real verifiedListeners restricted to two different
+// non-root OS users (proxyA → userA, proxyB → userB). Each user can
+// reach their own proxy, neither can reach the other's. This is the
+// closest tc-proxy-level analogue to "two parallel tasks running as
+// different OS users on the same worker, neither's task can hit the
+// other's proxy."
+//
+// Skipped without root, or if two distinct non-root system users
+// aren't both available on the host. Root bypass is intentionally not
+// tested here — every proxy admits root because the worker process
+// itself runs as root.
+func TestProxyIsolationBetweenTwoUsers(t *testing.T) {
+	if os.Getuid() != 0 {
+		t.Skip("requires root to setuid the connecting children")
+	}
+	uidA, uidB, ok := pickTwoNonRootUIDs(t)
+	if !ok {
+		t.Skip("need two distinct non-root system users; could not find them")
+	}
+	userA, err := user.LookupId(strconv.FormatUint(uint64(uidA), 10))
+	require.NoError(t, err)
+	userB, err := user.LookupId(strconv.FormatUint(uint64(uidB), 10))
+	require.NoError(t, err)
+
+	srvA, addrA := startVerifiedListener(t, userA.Username)
+	t.Cleanup(func() { _ = srvA.Close() })
+	srvB, addrB := startVerifiedListener(t, userB.Username)
+	t.Cleanup(func() { _ = srvB.Close() })
+
+	cases := []struct {
+		name string
+		uid  uint32
+		addr string
+		want probeResult
+	}{
+		{userA.Username + " -> proxyA", uidA, addrA, probeAdmitted},
+		{userA.Username + " -> proxyB", uidA, addrB, probeRejected},
+		{userB.Username + " -> proxyA", uidB, addrA, probeRejected},
+		{userB.Username + " -> proxyB", uidB, addrB, probeAdmitted},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, probeAsUID(t, tc.addr, tc.uid))
+		})
+	}
+}
+
+// startVerifiedListener spins up a verifiedListener on a free 127.0.0.1
+// port that admits only the given OS user and serves a trivial HTTP
+// handler returning 200 "OK". Returns the http.Server (for shutdown)
+// and the listener's "host:port" address.
+func startVerifiedListener(t *testing.T, allowedUser string) (*http.Server, string) {
+	t.Helper()
+	v, err := newConnectionVerifier(allowedUser, nil)
+	require.NoError(t, err, "build verifier for %q", allowedUser)
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	server := &http.Server{
+		Handler: http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			_, _ = w.Write([]byte("OK"))
+		}),
+	}
+	go func() {
+		_ = server.Serve(&verifiedListener{Listener: ln, verifier: v})
+	}()
+	return server, ln.Addr().String()
+}
+
+type probeResult string
+
+const (
+	probeAdmitted probeResult = "ADMITTED"
+	probeRejected probeResult = "REJECTED"
+	probeUnknown  probeResult = "UNKNOWN"
+)
+
+// probeAsUID re-invokes the test binary as a child running under the
+// given UID, asks it to GET http://addr/, and translates the child's
+// exit code back into a probeResult.
+func probeAsUID(t *testing.T, addr string, uid uint32) probeResult {
+	t.Helper()
+	helperBin, err := os.Executable()
+	require.NoError(t, err)
+
+	cmd := exec.Command(helperBin, "-test.run=^TestHelperHTTPProbeChild$", "-test.timeout=15s")
+	cmd.Env = append(os.Environ(), "HELPER_HTTP_PROBE_TARGET=http://"+addr+"/")
+	if uid != 0 {
+		cmd.SysProcAttr = &syscall.SysProcAttr{
+			Credential: &syscall.Credential{Uid: uid, Gid: uid},
+		}
+	}
+	// Surface child output to make failures debuggable without being
+	// noisy on success — the test framework only prints stderr/stdout
+	// when -v is set.
+	cmd.Stdout = os.Stderr
+	cmd.Stderr = os.Stderr
+
+	err = cmd.Run()
+	if err == nil {
+		return probeAdmitted
+	}
+	var exitErr *exec.ExitError
+	if errorsAs(err, &exitErr) {
+		switch exitErr.ExitCode() {
+		case helperExitAdmitted:
+			return probeAdmitted
+		case helperExitRejected:
+			return probeRejected
+		}
+	}
+	return probeUnknown
+}
+
+// errorsAs is a tiny shim so we don't need to pull in the full errors
+// package just for one ErrorAs call. It mimics errors.As for the one
+// concrete target type used here.
+func errorsAs(err error, target **exec.ExitError) bool {
+	for err != nil {
+		if e, ok := err.(*exec.ExitError); ok {
+			*target = e
+			return true
+		}
+		type unwrapper interface{ Unwrap() error }
+		u, ok := err.(unwrapper)
+		if !ok {
+			return false
+		}
+		err = u.Unwrap()
+	}
+	return false
+}
+
+const (
+	helperExitAdmitted = 0
+	helperExitRejected = 10
+	helperExitOther    = 11
+)
+
+// TestHelperHTTPProbeChild is invoked by probeAsUID as a child process
+// running under a specific UID. When HELPER_HTTP_PROBE_TARGET is unset
+// it is a normal no-op test. When set, it issues an HTTP GET and exits
+// with helperExitAdmitted if a 200 came back, helperExitRejected if
+// the connection was reset/closed, or helperExitOther for anything
+// else (e.g. unexpected status, network plumbing failure).
+func TestHelperHTTPProbeChild(t *testing.T) {
+	target := os.Getenv("HELPER_HTTP_PROBE_TARGET")
+	if target == "" {
+		return
+	}
+	client := &http.Client{Timeout: 5 * time.Second}
+	resp, err := client.Get(target)
+	if err != nil {
+		// Connection reset / EOF on a verifier-rejected conn surfaces
+		// here as a network error from net/http.
+		os.Stderr.WriteString("HelperHTTPProbeChild: GET error: " + err.Error() + "\n")
+		os.Exit(helperExitRejected)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		os.Stderr.WriteString("HelperHTTPProbeChild: unexpected status: " + resp.Status + "\n")
+		os.Exit(helperExitOther)
+	}
+	os.Exit(helperExitAdmitted)
+}
+
+// pickNonRootUID returns one non-root UID for an account that exists
+// on the host. Tries "nobody" first; falls back to scanning a small
+// list of system accounts that are present on most Linux distributions.
+func pickNonRootUID(t *testing.T) (uint32, bool) {
+	t.Helper()
+	for _, name := range nonRootCandidates() {
+		uid, ok := lookupNonRootUID(name)
+		if ok {
+			return uid, true
+		}
+	}
+	return 0, false
+}
+
+// pickTwoNonRootUIDs returns two distinct non-root UIDs for accounts
+// that exist on the host. Used by the cross-user isolation test.
+func pickTwoNonRootUIDs(t *testing.T) (uint32, uint32, bool) {
+	t.Helper()
+	seen := map[uint32]bool{}
+	var uids []uint32
+	for _, name := range nonRootCandidates() {
+		uid, ok := lookupNonRootUID(name)
+		if !ok || seen[uid] {
+			continue
+		}
+		seen[uid] = true
+		uids = append(uids, uid)
+		if len(uids) == 2 {
+			return uids[0], uids[1], true
+		}
+	}
+	return 0, 0, false
+}
+
+func nonRootCandidates() []string {
+	// Common system accounts present on most Linux distros. Order
+	// matters only for which two are picked first; any pair works.
+	return []string{
+		"nobody",
+		"daemon",
+		"bin",
+		"sys",
+		"mail",
+		"www-data",
+		"sshd",
+	}
+}
+
+func lookupNonRootUID(name string) (uint32, bool) {
+	u, err := user.Lookup(name)
+	if err != nil {
+		return 0, false
+	}
+	uid, err := strconv.ParseUint(u.Uid, 10, 32)
+	if err != nil || uid == 0 {
+		return 0, false
+	}
+	return uint32(uid), true
 }

--- a/tools/taskcluster-proxy/connectionverifier_linux_test.go
+++ b/tools/taskcluster-proxy/connectionverifier_linux_test.go
@@ -1,0 +1,121 @@
+//go:build linux
+
+package main
+
+import (
+	"net"
+	"os"
+	"os/user"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIpPortToHexIPv4(t *testing.T) {
+	tests := []struct {
+		ip   string
+		port int
+		want string
+	}{
+		{"127.0.0.1", 8080, "0100007F:1F90"},
+		{"0.0.0.0", 0, "00000000:0000"},
+		{"192.168.1.1", 443, "0101A8C0:01BB"},
+		{"10.0.0.1", 65535, "0100000A:FFFF"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.ip, func(t *testing.T) {
+			got := ipPortToHex(net.ParseIP(tt.ip), tt.port)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestIpPortToHexIPv6(t *testing.T) {
+	tests := []struct {
+		name string
+		ip   string
+		port int
+		want string
+	}{
+		{
+			name: "loopback",
+			ip:   "::1",
+			port: 8080,
+			want: "00000000000000000000000001000000:1F90",
+		},
+		{
+			name: "all-zeros",
+			ip:   "::",
+			port: 0,
+			want: "00000000000000000000000000000000:0000",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ipPortToHex(net.ParseIP(tt.ip), tt.port)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestLookupUIDFromProcNetSelf(t *testing.T) {
+	// Create a TCP connection and verify lookupUIDFromProcNet returns
+	// the current process's UID.
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	defer ln.Close()
+
+	done := make(chan net.Conn, 1)
+	go func() {
+		conn, _ := ln.Accept()
+		done <- conn
+	}()
+
+	client, err := net.Dial("tcp", ln.Addr().String())
+	require.NoError(t, err)
+	defer client.Close()
+
+	server := <-done
+	defer server.Close()
+
+	clientAddr := server.RemoteAddr().(*net.TCPAddr)
+
+	uid, err := lookupUIDFromProcNet(clientAddr)
+	require.NoError(t, err)
+	assert.Equal(t, uint32(os.Getuid()), uid)
+}
+
+func TestVerifiedListenerSelfConnection(t *testing.T) {
+	// End-to-end: create a verifier for the current user, connect, verify.
+	// This test only runs on Linux because the Darwin verifier filters by
+	// PID, and in a single-process test both sides share the same PID.
+	u, err := user.Current()
+	require.NoError(t, err)
+
+	v, err := newConnectionVerifier(u.Username)
+	require.NoError(t, err)
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	defer ln.Close()
+
+	vl := &verifiedListener{
+		Listener: ln,
+		verifier: v,
+	}
+
+	go func() {
+		conn, dialErr := net.Dial("tcp", ln.Addr().String())
+		if dialErr == nil {
+			// Keep open; deferred ln.Close() will unblock Accept
+			// and the test will clean up.
+			defer conn.Close()
+			select {}
+		}
+	}()
+
+	conn, err := vl.Accept()
+	require.NoError(t, err)
+	conn.Close()
+}

--- a/tools/taskcluster-proxy/connectionverifier_test.go
+++ b/tools/taskcluster-proxy/connectionverifier_test.go
@@ -114,23 +114,89 @@ func TestErrUnauthorizedConnectionMessage(t *testing.T) {
 }
 
 func TestNewConnectionVerifierEmptyUsername(t *testing.T) {
-	v, err := newConnectionVerifier("")
+	v, err := newConnectionVerifier("", nil)
 	require.NoError(t, err)
 	_, ok := v.(*noopVerifier)
-	assert.True(t, ok, "empty username should return noopVerifier")
+	assert.True(t, ok, "empty username and no allowed-network should return noopVerifier")
 }
 
 func TestNewConnectionVerifierCurrentUser(t *testing.T) {
 	// Use current user so the lookup succeeds on any platform
-	v, err := newConnectionVerifier(currentUsername(t))
+	v, err := newConnectionVerifier(currentUsername(t), nil)
 	require.NoError(t, err)
 	assert.NotNil(t, v)
 }
 
 func TestNewConnectionVerifierBadUsername(t *testing.T) {
-	_, err := newConnectionVerifier("nonexistent-user-abc123xyz")
+	_, err := newConnectionVerifier("nonexistent-user-abc123xyz", nil)
 	require.Error(t, err)
 }
+
+func TestNewConnectionVerifierWithAllowedNetwork(t *testing.T) {
+	_, cidr, err := net.ParseCIDR("172.18.0.0/16")
+	require.NoError(t, err)
+	v, err := newConnectionVerifier(currentUsername(t), cidr)
+	require.NoError(t, err)
+	_, ok := v.(*networkAdmittingVerifier)
+	assert.True(t, ok, "non-nil allowed-network should wrap with networkAdmittingVerifier")
+}
+
+// fakeUIDVerifier returns the given error from Verify, so tests can drive
+// networkAdmittingVerifier through both branches without doing real OS
+// peer-credential lookups.
+type fakeUIDVerifier struct{ err error }
+
+func (f *fakeUIDVerifier) Verify(_ net.Conn) error { return f.err }
+
+func TestNetworkAdmittingVerifier_AdmitsOnPeerNotFoundInsideCIDR(t *testing.T) {
+	_, cidr, err := net.ParseCIDR("172.18.0.0/16")
+	require.NoError(t, err)
+	v := &networkAdmittingVerifier{
+		inner:          &fakeUIDVerifier{err: errPeerNotFound},
+		allowedNetwork: cidr,
+	}
+	conn := &fakeRemoteAddrConn{remote: &net.TCPAddr{IP: net.IPv4(172, 18, 0, 5), Port: 1234}}
+	require.NoError(t, v.Verify(conn))
+}
+
+func TestNetworkAdmittingVerifier_RejectsOnPeerNotFoundOutsideCIDR(t *testing.T) {
+	_, cidr, err := net.ParseCIDR("172.18.0.0/16")
+	require.NoError(t, err)
+	v := &networkAdmittingVerifier{
+		inner:          &fakeUIDVerifier{err: errPeerNotFound},
+		allowedNetwork: cidr,
+	}
+	conn := &fakeRemoteAddrConn{remote: &net.TCPAddr{IP: net.IPv4(10, 0, 0, 5), Port: 1234}}
+	require.Error(t, v.Verify(conn))
+}
+
+func TestNetworkAdmittingVerifier_DoesNotMaskUIDMismatch(t *testing.T) {
+	// A genuine UID-mismatch error must NOT be admitted by the network
+	// fallback even if the remote IP is in the allowed CIDR — otherwise
+	// a host process from a sibling task would be admitted just because
+	// its source IP happened to be inside the docker subnet.
+	_, cidr, err := net.ParseCIDR("172.18.0.0/16")
+	require.NoError(t, err)
+	v := &networkAdmittingVerifier{
+		inner: &fakeUIDVerifier{err: &ErrUnauthorizedConnection{
+			ExpectedUser: "task-user",
+			ActualUID:    "1234",
+			RemoteAddr:   "172.18.0.5:1234",
+		}},
+		allowedNetwork: cidr,
+	}
+	conn := &fakeRemoteAddrConn{remote: &net.TCPAddr{IP: net.IPv4(172, 18, 0, 5), Port: 1234}}
+	require.Error(t, v.Verify(conn))
+}
+
+// fakeRemoteAddrConn is a minimal net.Conn whose only meaningful method is
+// RemoteAddr; the verifiers under test only ever read that.
+type fakeRemoteAddrConn struct {
+	net.Conn
+	remote net.Addr
+}
+
+func (f *fakeRemoteAddrConn) RemoteAddr() net.Addr { return f.remote }
 
 func currentUsername(t *testing.T) string {
 	t.Helper()

--- a/tools/taskcluster-proxy/connectionverifier_test.go
+++ b/tools/taskcluster-proxy/connectionverifier_test.go
@@ -1,0 +1,140 @@
+package main
+
+import (
+	"net"
+	"os/user"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNoopVerifierAllowsAll(t *testing.T) {
+	v := &noopVerifier{}
+
+	// Create a real TCP connection pair
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	defer ln.Close()
+
+	done := make(chan net.Conn, 1)
+	go func() {
+		conn, _ := ln.Accept()
+		done <- conn
+	}()
+
+	client, err := net.Dial("tcp", ln.Addr().String())
+	require.NoError(t, err)
+	defer client.Close()
+
+	server := <-done
+	defer server.Close()
+
+	// noopVerifier should allow the connection
+	assert.NoError(t, v.Verify(client))
+	assert.NoError(t, v.Verify(server))
+}
+
+// rejectVerifier is a mock that always rejects connections.
+type rejectVerifier struct{}
+
+func (r *rejectVerifier) Verify(_ net.Conn) error {
+	return &ErrUnauthorizedConnection{
+		ExpectedUser: "allowed-user",
+		ActualUID:    "9999",
+		RemoteAddr:   "127.0.0.1:0",
+	}
+}
+
+func TestVerifiedListenerRejectsUnauthorized(t *testing.T) {
+	// Set up a raw listener wrapped by a verifiedListener with a reject verifier
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	defer ln.Close()
+
+	vl := &verifiedListener{
+		Listener: ln,
+		verifier: &rejectVerifier{},
+	}
+
+	// Connect a client — the verifiedListener should reject it and keep
+	// waiting, so Accept will block until we close the underlying listener.
+	client, err := net.Dial("tcp", ln.Addr().String())
+	require.NoError(t, err)
+	defer client.Close()
+
+	// Close the underlying listener to unblock Accept
+	go func() {
+		// Give Accept time to reject the first connection
+		client2, err := net.Dial("tcp", ln.Addr().String())
+		if err == nil {
+			client2.Close()
+		}
+		ln.Close()
+	}()
+
+	_, err = vl.Accept()
+	// Should get a "use of closed network connection" error since we
+	// closed the listener — all real connections were rejected
+	require.Error(t, err)
+}
+
+func TestVerifiedListenerAcceptsAuthorized(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	defer ln.Close()
+
+	vl := &verifiedListener{
+		Listener: ln,
+		verifier: &noopVerifier{},
+	}
+
+	go func() {
+		conn, err := net.Dial("tcp", ln.Addr().String())
+		if err == nil {
+			defer conn.Close()
+		}
+	}()
+
+	conn, err := vl.Accept()
+	require.NoError(t, err)
+	defer conn.Close()
+}
+
+func TestErrUnauthorizedConnectionMessage(t *testing.T) {
+	err := &ErrUnauthorizedConnection{
+		ExpectedUser: "task-user",
+		ActualUID:    "1234",
+		RemoteAddr:   "127.0.0.1:54321",
+	}
+	msg := err.Error()
+	assert.Contains(t, msg, "1234")
+	assert.Contains(t, msg, "task-user")
+	assert.Contains(t, msg, "127.0.0.1:54321")
+}
+
+func TestNewConnectionVerifierEmptyUsername(t *testing.T) {
+	v, err := newConnectionVerifier("")
+	require.NoError(t, err)
+	_, ok := v.(*noopVerifier)
+	assert.True(t, ok, "empty username should return noopVerifier")
+}
+
+func TestNewConnectionVerifierCurrentUser(t *testing.T) {
+	// Use current user so the lookup succeeds on any platform
+	v, err := newConnectionVerifier(currentUsername(t))
+	require.NoError(t, err)
+	assert.NotNil(t, v)
+}
+
+func TestNewConnectionVerifierBadUsername(t *testing.T) {
+	_, err := newConnectionVerifier("nonexistent-user-abc123xyz")
+	require.Error(t, err)
+}
+
+func currentUsername(t *testing.T) string {
+	t.Helper()
+	u, err := user.Current()
+	require.NoError(t, err)
+	return u.Username
+}

--- a/tools/taskcluster-proxy/connectionverifier_windows.go
+++ b/tools/taskcluster-proxy/connectionverifier_windows.go
@@ -49,7 +49,7 @@ func (v *windowsVerifier) Verify(conn net.Conn) error {
 		return fmt.Errorf("failed to get SID for PID %d: %w", pid, err)
 	}
 
-	// Always allow SYSTEM (S-1-5-18) and Administrators (S-1-5-32-544) —
+	// Always allow SYSTEM (S-1-5-18) and Administrators (S-1-5-32-544) -
 	// the worker process runs as SYSTEM/admin and needs to reach tc-proxy
 	// for credential refresh and health checks.
 	systemSID, _ := windows.StringToSid("S-1-5-18")

--- a/tools/taskcluster-proxy/connectionverifier_windows.go
+++ b/tools/taskcluster-proxy/connectionverifier_windows.go
@@ -1,0 +1,146 @@
+//go:build windows
+
+package main
+
+import (
+	"fmt"
+	"net"
+	"os/user"
+	"syscall"
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+)
+
+type windowsVerifier struct {
+	allowedSID *windows.SID
+	username   string
+}
+
+func newPlatformVerifier(username string) (ConnectionVerifier, error) {
+	u, err := user.Lookup(username)
+	if err != nil {
+		return nil, fmt.Errorf("failed to look up user %q: %w", username, err)
+	}
+	// On Windows, user.User.Uid is the SID string
+	sid, err := windows.StringToSid(u.Uid)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse SID %q: %w", u.Uid, err)
+	}
+	return &windowsVerifier{
+		allowedSID: sid,
+		username:   username,
+	}, nil
+}
+
+func (v *windowsVerifier) Verify(conn net.Conn) error {
+	tcpAddr, ok := conn.RemoteAddr().(*net.TCPAddr)
+	if !ok {
+		return fmt.Errorf("connection is not TCP")
+	}
+
+	pid, err := lookupPIDFromTcpTable(tcpAddr)
+	if err != nil {
+		return fmt.Errorf("failed to look up PID for %s: %w", tcpAddr, err)
+	}
+
+	sid, err := getProcessUserSID(pid)
+	if err != nil {
+		return fmt.Errorf("failed to get SID for PID %d: %w", pid, err)
+	}
+
+	// Always allow SYSTEM (S-1-5-18) and Administrators (S-1-5-32-544) —
+	// the worker process runs as SYSTEM/admin and needs to reach tc-proxy
+	// for credential refresh and health checks.
+	systemSID, _ := windows.StringToSid("S-1-5-18")
+	adminSID, _ := windows.StringToSid("S-1-5-32-544")
+	if (systemSID != nil && sid.Equals(systemSID)) || (adminSID != nil && sid.Equals(adminSID)) {
+		return nil
+	}
+
+	if !v.allowedSID.Equals(sid) {
+		return &ErrUnauthorizedConnection{
+			ExpectedUser: v.username,
+			ActualUID:    sid.String(),
+			RemoteAddr:   conn.RemoteAddr().String(),
+		}
+	}
+	return nil
+}
+
+type mibTcpRowOwnerPid struct {
+	State      uint32
+	LocalAddr  uint32
+	LocalPort  uint32
+	RemoteAddr uint32
+	RemotePort uint32
+	OwningPid  uint32
+}
+
+var (
+	modIphlpapi             = windows.NewLazySystemDLL("iphlpapi.dll")
+	procGetExtendedTcpTable = modIphlpapi.NewProc("GetExtendedTcpTable")
+)
+
+const (
+	tcpTableOwnerPidConnections = 4
+	afInet                      = 2
+)
+
+func lookupPIDFromTcpTable(addr *net.TCPAddr) (uint32, error) {
+	ip4 := addr.IP.To4()
+	if ip4 == nil {
+		return 0, fmt.Errorf("IPv6 not yet supported on Windows connection verification")
+	}
+
+	// First call to get buffer size
+	var size uint32
+	procGetExtendedTcpTable.Call(0, uintptr(unsafe.Pointer(&size)), 0,
+		afInet, tcpTableOwnerPidConnections, 0)
+
+	buf := make([]byte, size)
+	ret, _, _ := procGetExtendedTcpTable.Call(
+		uintptr(unsafe.Pointer(&buf[0])),
+		uintptr(unsafe.Pointer(&size)),
+		0, afInet, tcpTableOwnerPidConnections, 0,
+	)
+	if ret != 0 {
+		return 0, fmt.Errorf("GetExtendedTcpTable failed with code %d", ret)
+	}
+
+	numEntries := *(*uint32)(unsafe.Pointer(&buf[0]))
+	rows := unsafe.Slice((*mibTcpRowOwnerPid)(unsafe.Pointer(&buf[4])), numEntries)
+
+	targetIP := uint32(ip4[0]) | uint32(ip4[1])<<8 | uint32(ip4[2])<<16 | uint32(ip4[3])<<24
+	// Port in the TCP table is in network byte order (big-endian)
+	targetPort := uint32(addr.Port)<<8&0xff00 | uint32(addr.Port)>>8&0x00ff
+
+	for _, row := range rows {
+		if row.LocalAddr == targetIP && row.LocalPort == targetPort {
+			return row.OwningPid, nil
+		}
+	}
+	return 0, fmt.Errorf("connection from %s not found in TCP table", addr)
+}
+
+func getProcessUserSID(pid uint32) (*windows.SID, error) {
+	handle, err := windows.OpenProcess(windows.PROCESS_QUERY_INFORMATION, false, pid)
+	if err != nil {
+		return nil, fmt.Errorf("OpenProcess: %w", err)
+	}
+	defer windows.CloseHandle(handle)
+
+	var token syscall.Token
+	err = syscall.OpenProcessToken(syscall.Handle(handle), syscall.TOKEN_QUERY, &token)
+	if err != nil {
+		return nil, fmt.Errorf("OpenProcessToken: %w", err)
+	}
+	defer token.Close()
+
+	tokenUser, err := token.GetTokenUser()
+	if err != nil {
+		return nil, fmt.Errorf("GetTokenUser: %w", err)
+	}
+
+	return (*windows.SID)(unsafe.Pointer(tokenUser.User.Sid)), nil
+}

--- a/tools/taskcluster-proxy/connectionverifier_windows.go
+++ b/tools/taskcluster-proxy/connectionverifier_windows.go
@@ -87,6 +87,11 @@ const (
 	afInet                      = 2
 )
 
+// lookupPIDFromTcpTable finds the PID owning the local TCP endpoint at addr.
+// Only IPv4 is supported via MIB_TCPTABLE_OWNER_PID (AF_INET). Pure IPv6
+// and IPv4-mapped-IPv6 addresses (e.g. ::ffff:127.0.0.1) are rejected
+// fail-closed. A follow-up may add MIB_TCP6TABLE_OWNER_PID support if
+// Windows workers need IPv6 loopback.
 func lookupPIDFromTcpTable(addr *net.TCPAddr) (uint32, error) {
 	ip4 := addr.IP.To4()
 	if ip4 == nil {
@@ -142,5 +147,8 @@ func getProcessUserSID(pid uint32) (*windows.SID, error) {
 		return nil, fmt.Errorf("GetTokenUser: %w", err)
 	}
 
-	return (*windows.SID)(unsafe.Pointer(tokenUser.User.Sid)), nil
+	// Copy the SID so the returned pointer doesn't alias the tokenUser
+	// buffer, which may be garbage-collected after this function returns.
+	sid := (*windows.SID)(unsafe.Pointer(tokenUser.User.Sid))
+	return sid.Copy()
 }

--- a/tools/taskcluster-proxy/connectionverifier_windows.go
+++ b/tools/taskcluster-proxy/connectionverifier_windows.go
@@ -49,12 +49,16 @@ func (v *windowsVerifier) Verify(conn net.Conn) error {
 		return fmt.Errorf("failed to get SID for PID %d: %w", pid, err)
 	}
 
-	// Always allow SYSTEM (S-1-5-18) and Administrators (S-1-5-32-544) -
-	// the worker process runs as SYSTEM/admin and needs to reach tc-proxy
-	// for credential refresh and health checks.
+	// Always allow SYSTEM (S-1-5-18) - the worker process runs as
+	// SYSTEM and needs to reach tc-proxy for credential refresh and
+	// health checks. The previous implementation also compared against
+	// the Administrators *group* SID (S-1-5-32-544); that check was
+	// dead code because tokenUser.User.Sid is always a *user* SID.
+	// If we ever need to admit any process running with admin
+	// privileges, the correct test is to enumerate token groups via
+	// GetTokenGroups, not to compare the user SID.
 	systemSID, _ := windows.StringToSid("S-1-5-18")
-	adminSID, _ := windows.StringToSid("S-1-5-32-544")
-	if (systemSID != nil && sid.Equals(systemSID)) || (adminSID != nil && sid.Equals(adminSID)) {
+	if systemSID != nil && sid.Equals(systemSID) {
 		return nil
 	}
 
@@ -85,6 +89,11 @@ var (
 const (
 	tcpTableOwnerPidConnections = 4
 	afInet                      = 2
+	// MIB_TCP_STATE_ESTAB - matches only fully-established connections.
+	// Without this filter, stale TIME_WAIT entries from prior
+	// connections that reused the same source port could match before
+	// the live ESTABLISHED row and return the wrong owning PID.
+	mibTcpStateEstab = 5
 )
 
 // lookupPIDFromTcpTable finds the PID owning the local TCP endpoint at addr.
@@ -121,11 +130,11 @@ func lookupPIDFromTcpTable(addr *net.TCPAddr) (uint32, error) {
 	targetPort := uint32(addr.Port)<<8&0xff00 | uint32(addr.Port)>>8&0x00ff
 
 	for _, row := range rows {
-		if row.LocalAddr == targetIP && row.LocalPort == targetPort {
+		if row.State == mibTcpStateEstab && row.LocalAddr == targetIP && row.LocalPort == targetPort {
 			return row.OwningPid, nil
 		}
 	}
-	return 0, fmt.Errorf("connection from %s not found in TCP table", addr)
+	return 0, fmt.Errorf("connection from %s not found in TCP table: %w", addr, errPeerNotFound)
 }
 
 func getProcessUserSID(pid uint32) (*windows.SID, error) {

--- a/tools/taskcluster-proxy/connectionverifier_windows.go
+++ b/tools/taskcluster-proxy/connectionverifier_windows.go
@@ -87,12 +87,16 @@ var (
 )
 
 const (
+	// TCP_TABLE_OWNER_PID_CONNECTIONS - GetExtendedTcpTable class
+	// returning per-connection rows annotated with the owning PID.
+	// Not exposed by golang.org/x/sys/windows; defined here from the
+	// IP Helper API headers.
 	tcpTableOwnerPidConnections = 4
-	afInet                      = 2
 	// MIB_TCP_STATE_ESTAB - matches only fully-established connections.
 	// Without this filter, stale TIME_WAIT entries from prior
 	// connections that reused the same source port could match before
-	// the live ESTABLISHED row and return the wrong owning PID.
+	// the live ESTABLISHED row and return the wrong owning PID. Also
+	// not exposed by golang.org/x/sys/windows.
 	mibTcpStateEstab = 5
 )
 
@@ -107,16 +111,27 @@ func lookupPIDFromTcpTable(addr *net.TCPAddr) (uint32, error) {
 		return 0, fmt.Errorf("IPv6 not yet supported on Windows connection verification")
 	}
 
-	// First call to get buffer size
+	// First call to get buffer size. We MUST inspect the return value
+	// here: only ERROR_INSUFFICIENT_BUFFER guarantees the `size`
+	// out-parameter has been written. Other failures (low memory,
+	// ERROR_INVALID_PARAMETER, etc.) leave `size` at zero, in which
+	// case allocating make([]byte, 0) and dereferencing &buf[0] below
+	// would panic and kill the proxy. Fail closed instead.
 	var size uint32
-	procGetExtendedTcpTable.Call(0, uintptr(unsafe.Pointer(&size)), 0,
-		afInet, tcpTableOwnerPidConnections, 0)
+	probe, _, _ := procGetExtendedTcpTable.Call(0, uintptr(unsafe.Pointer(&size)), 0,
+		windows.AF_INET, tcpTableOwnerPidConnections, 0)
+	if syscall.Errno(probe) != windows.ERROR_INSUFFICIENT_BUFFER {
+		return 0, fmt.Errorf("GetExtendedTcpTable size probe failed with code %d", probe)
+	}
+	if size == 0 {
+		return 0, fmt.Errorf("GetExtendedTcpTable returned zero buffer size")
+	}
 
 	buf := make([]byte, size)
 	ret, _, _ := procGetExtendedTcpTable.Call(
 		uintptr(unsafe.Pointer(&buf[0])),
 		uintptr(unsafe.Pointer(&size)),
-		0, afInet, tcpTableOwnerPidConnections, 0,
+		0, windows.AF_INET, tcpTableOwnerPidConnections, 0,
 	)
 	if ret != 0 {
 		return 0, fmt.Errorf("GetExtendedTcpTable failed with code %d", ret)

--- a/tools/taskcluster-proxy/main.go
+++ b/tools/taskcluster-proxy/main.go
@@ -42,37 +42,63 @@ task id.
     --access-token <accessToken>    Use a specific auth.taskcluster hawk access token [default: ].
     --certificate <certificate>     Use a specific auth.taskcluster hawk certificate [default: ].
     --allowed-user <username>       Only allow connections from this OS user [default: ].
+    --allowed-network <cidr>        Additionally allow connections whose remote
+                                    IP falls in the given CIDR when the OS-level
+                                    peer credential lookup is not possible (e.g.,
+                                    container traffic arriving via a Docker
+                                    bridge, where the peer socket lives in a
+                                    different network namespace and is not
+                                    visible in this process's /proc/net/tcp)
+                                    [default: ].
 `
 )
 
 func main() {
-	routes, address, allowedUser, err := ParseCommandArgs(os.Args[1:], true)
+	routes, address, allowedUser, allowedNetwork, err := ParseCommandArgs(os.Args[1:], true)
 	if err != nil {
 		log.Fatalf("%v", err)
 	}
 
-	verifier, err := newConnectionVerifier(allowedUser)
+	verifier, err := newConnectionVerifier(allowedUser, allowedNetwork)
 	if err != nil {
 		log.Fatalf("Failed to create connection verifier: %v", err)
 	}
 
-	listener, err := net.Listen("tcp", address)
-	if err != nil {
-		log.Fatalf("Failed to listen on %s: %v", address, err)
+	addresses := []string{address}
+	if allowedNetwork != nil {
+		// When --allowed-network is set, the primary listener targets
+		// in-namespace peers (typically containers reaching us via a
+		// Docker bridge gateway IP). The launcher itself — generic
+		// worker — usually runs in the host netns and may be unable to
+		// reach that bind address cleanly: kernel routing or iptables
+		// MASQUERADE rules can rewrite the source IP, leaving the
+		// connection invisible in /proc/net/tcp from the proxy's
+		// perspective and outside the allowed-network CIDR. Listen on
+		// 127.0.0.1 too so the launcher has a NAT-free loopback path.
+		// Loopback connections are always visible in /proc/net/tcp, so
+		// the UID-based admission (root and the task user) covers it.
+		_, port, splitErr := net.SplitHostPort(address)
+		if splitErr != nil {
+			log.Fatalf("Failed to split host/port from %s: %v", address, splitErr)
+		}
+		addresses = append(addresses, net.JoinHostPort("127.0.0.1", port))
 	}
 
-	wrappedListener := &verifiedListener{
-		Listener: listener,
-		verifier: verifier,
-	}
+	server := &http.Server{Handler: &routes}
 
-	server := &http.Server{
-		Handler: &routes,
+	errCh := make(chan error, len(addresses))
+	for _, addr := range addresses {
+		listener, listenErr := net.Listen("tcp", addr)
+		if listenErr != nil {
+			log.Fatalf("Failed to listen on %s: %v", addr, listenErr)
+		}
+		log.Printf("Serving on %s", addr)
+		go func(ln net.Listener) {
+			errCh <- server.Serve(&verifiedListener{Listener: ln, verifier: verifier})
+		}(listener)
 	}
-
-	startError := server.Serve(wrappedListener)
-	if startError != nil {
-		log.Fatal(startError)
+	if err := <-errCh; err != nil {
+		log.Fatal(err)
 	}
 }
 
@@ -87,7 +113,7 @@ var getTask = func(rootURL string, taskID string) (task *tcqueue.TaskDefinitionR
 
 // ParseCommandArgs converts command line arguments into a configured Routes
 // and port.
-func ParseCommandArgs(argv []string, exit bool) (routes Routes, address string, allowedUser string, err error) {
+func ParseCommandArgs(argv []string, exit bool) (routes Routes, address string, allowedUser string, allowedNetwork *net.IPNet, err error) {
 	fullversion := "Taskcluster proxy " + version
 	if revision != "" {
 		fullversion += " (git revision " + revision + ")"
@@ -130,6 +156,22 @@ func ParseCommandArgs(argv []string, exit bool) (routes Routes, address string, 
 	allowedUser = arguments["--allowed-user"].(string)
 	if allowedUser != "" {
 		log.Printf("Allowed user: %v", allowedUser)
+	}
+
+	if cidr := arguments["--allowed-network"].(string); cidr != "" {
+		_, allowedNetwork, err = net.ParseCIDR(cidr)
+		if err != nil {
+			err = fmt.Errorf("invalid --allowed-network CIDR %q: %w", cidr, err)
+			return
+		}
+		// Reject overly broad CIDRs that would defeat the point of having
+		// the flag at all (any host can connect from anywhere).
+		ones, bits := allowedNetwork.Mask.Size()
+		if ones == 0 && bits != 0 {
+			err = fmt.Errorf("--allowed-network CIDR %q is too broad (0/%d allows all addresses)", cidr, bits)
+			return
+		}
+		log.Printf("Allowed network: %v", allowedNetwork)
 	}
 
 	rootURL := arguments["--root-url"]

--- a/tools/taskcluster-proxy/parse_test.go
+++ b/tools/taskcluster-proxy/parse_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestNoTaskNoScopes(t *testing.T) {
-	routes, address, err := ParseCommandArgs(
+	routes, address, _, err := ParseCommandArgs(
 		[]string{
 			"--root-url", "https://tc-tests.example.com",
 			"--client-id", "abc",
@@ -28,7 +28,7 @@ func TestNoTaskNoScopes(t *testing.T) {
 }
 
 func TestNondefaultPort(t *testing.T) {
-	_, address, err := ParseCommandArgs(
+	_, address, _, err := ParseCommandArgs(
 		[]string{
 			"--root-url", "https://tc-tests.example.com",
 			"--client-id", "abc",
@@ -46,7 +46,7 @@ func TestNondefaultPort(t *testing.T) {
 }
 
 func TestWithTwoScopes(t *testing.T) {
-	routes, address, err := ParseCommandArgs(
+	routes, address, _, err := ParseCommandArgs(
 		[]string{
 			"--root-url", "https://tc-tests.example.com",
 			"--client-id", "abc",
@@ -97,7 +97,7 @@ func TestWithTaskWithNoScopes(t *testing.T) {
 	defer withFakeTask("abc", &tcqueue.TaskDefinitionResponse{
 		Scopes: nil,
 	})()
-	routes, _, err := ParseCommandArgs(
+	routes, _, _, err := ParseCommandArgs(
 		[]string{
 			"--task-id", "abc",
 			"--root-url", "https://tc-tests.example.com",
@@ -120,7 +120,7 @@ func TestWithTaskWithScopes(t *testing.T) {
 	defer withFakeTask("abc", &tcqueue.TaskDefinitionResponse{
 		Scopes: []string{exampleScope},
 	})()
-	routes, _, err := ParseCommandArgs(
+	routes, _, _, err := ParseCommandArgs(
 		[]string{
 			"--task-id", "abc",
 			"--root-url", "https://tc-tests.example.com",
@@ -139,7 +139,7 @@ func TestWithTaskWithScopes(t *testing.T) {
 }
 
 func TestWithInterface(t *testing.T) {
-	_, address, err := ParseCommandArgs(
+	_, address, _, err := ParseCommandArgs(
 		[]string{
 			"--root-url", "https://tc-tests.example.com",
 			"--client-id", "abc",
@@ -159,7 +159,7 @@ func TestWithInterface(t *testing.T) {
 }
 
 func TestBadPort(t *testing.T) {
-	_, _, err := ParseCommandArgs(
+	_, _, _, err := ParseCommandArgs(
 		[]string{
 			"--port", "-12345",
 			"--ip-address", "172.17.0.44",
@@ -175,7 +175,7 @@ func TestBadPort(t *testing.T) {
 }
 
 func TestBadIPAddress(t *testing.T) {
-	_, _, err := ParseCommandArgs(
+	_, _, _, err := ParseCommandArgs(
 		[]string{
 			"--port", "12345",
 			"--ip-address", "172.17.0.44.66",

--- a/tools/taskcluster-proxy/parse_test.go
+++ b/tools/taskcluster-proxy/parse_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestNoTaskNoScopes(t *testing.T) {
-	routes, address, _, err := ParseCommandArgs(
+	routes, address, _, _, err := ParseCommandArgs(
 		[]string{
 			"--root-url", "https://tc-tests.example.com",
 			"--client-id", "abc",
@@ -28,7 +28,7 @@ func TestNoTaskNoScopes(t *testing.T) {
 }
 
 func TestNondefaultPort(t *testing.T) {
-	_, address, _, err := ParseCommandArgs(
+	_, address, _, _, err := ParseCommandArgs(
 		[]string{
 			"--root-url", "https://tc-tests.example.com",
 			"--client-id", "abc",
@@ -46,7 +46,7 @@ func TestNondefaultPort(t *testing.T) {
 }
 
 func TestWithTwoScopes(t *testing.T) {
-	routes, address, _, err := ParseCommandArgs(
+	routes, address, _, _, err := ParseCommandArgs(
 		[]string{
 			"--root-url", "https://tc-tests.example.com",
 			"--client-id", "abc",
@@ -97,7 +97,7 @@ func TestWithTaskWithNoScopes(t *testing.T) {
 	defer withFakeTask("abc", &tcqueue.TaskDefinitionResponse{
 		Scopes: nil,
 	})()
-	routes, _, _, err := ParseCommandArgs(
+	routes, _, _, _, err := ParseCommandArgs(
 		[]string{
 			"--task-id", "abc",
 			"--root-url", "https://tc-tests.example.com",
@@ -120,7 +120,7 @@ func TestWithTaskWithScopes(t *testing.T) {
 	defer withFakeTask("abc", &tcqueue.TaskDefinitionResponse{
 		Scopes: []string{exampleScope},
 	})()
-	routes, _, _, err := ParseCommandArgs(
+	routes, _, _, _, err := ParseCommandArgs(
 		[]string{
 			"--task-id", "abc",
 			"--root-url", "https://tc-tests.example.com",
@@ -139,7 +139,7 @@ func TestWithTaskWithScopes(t *testing.T) {
 }
 
 func TestWithInterface(t *testing.T) {
-	_, address, _, err := ParseCommandArgs(
+	_, address, _, _, err := ParseCommandArgs(
 		[]string{
 			"--root-url", "https://tc-tests.example.com",
 			"--client-id", "abc",
@@ -159,7 +159,7 @@ func TestWithInterface(t *testing.T) {
 }
 
 func TestBadPort(t *testing.T) {
-	_, _, _, err := ParseCommandArgs(
+	_, _, _, _, err := ParseCommandArgs(
 		[]string{
 			"--port", "-12345",
 			"--ip-address", "172.17.0.44",
@@ -175,7 +175,7 @@ func TestBadPort(t *testing.T) {
 }
 
 func TestBadIPAddress(t *testing.T) {
-	_, _, _, err := ParseCommandArgs(
+	_, _, _, _, err := ParseCommandArgs(
 		[]string{
 			"--port", "12345",
 			"--ip-address", "172.17.0.44.66",

--- a/ui/docs/reference/workers/generic-worker/usage.mdx
+++ b/ui/docs/reference/workers/generic-worker/usage.mdx
@@ -136,7 +136,7 @@ and reports back results to the queue.
                                             multiple tasks in parallel, each in its own task
                                             directory with isolated ports for LiveLog,
                                             Interactive, and TaskclusterProxy features. Requires
-                                            headlessTasks enabled. The runAsCurrentUser and
+                                            headlessTasks enabled. The runTaskAsCurrentUser and
                                             runAsAdministrator task features are automatically
                                             disabled when capacity > 1 to preserve task
                                             isolation. Maximum value is 255.

--- a/ui/docs/reference/workers/generic-worker/usage.mdx
+++ b/ui/docs/reference/workers/generic-worker/usage.mdx
@@ -131,6 +131,16 @@ and reports back results to the queue.
                                             not exist. This may be a relative path to the
                                             current directory, or an absolute path.
                                             [default: "caches"]
+          capacity                          The number of tasks the worker will run concurrently.
+                                            When greater than 1, the worker claims and executes
+                                            multiple tasks in parallel, each in its own task
+                                            directory with isolated ports for LiveLog,
+                                            Interactive, and TaskclusterProxy features. Requires
+                                            headlessTasks enabled. The runAsCurrentUser and
+                                            runAsAdministrator task features are automatically
+                                            disabled when capacity > 1 to preserve task
+                                            isolation. Maximum value is 255.
+                                            [default: 1]
           certificate                       Taskcluster certificate, when using temporary
                                             credentials only.
           cleanUpTaskDirs                   Whether to delete the home directories of the task
@@ -211,7 +221,9 @@ and reports back results to the queue.
           enableLoopbackVideo               Enables the Loopback Video feature to be used in the
                                             task payload. [default: true]
           enableRunTaskAsCurrentUser        Enables the Run Task As Current User feature to be
-                                            used in the task payload. [default: true]
+                                            used in the task payload. Automatically disabled
+                                            when capacity > 1 to preserve task isolation.
+                                            [default: true]
           headlessTasks                     If true, no dedicated graphical session will be available to tasks.
                                             There will also be no reboots between tasks and multiple workers
                                             can be run on the same host. Useful for tasks that don't require

--- a/ui/docs/reference/workers/generic-worker/usage.mdx
+++ b/ui/docs/reference/workers/generic-worker/usage.mdx
@@ -135,8 +135,9 @@ and reports back results to the queue.
                                             When greater than 1, the worker claims and executes
                                             multiple tasks in parallel, each in its own task
                                             directory with isolated ports for LiveLog,
-                                            Interactive, and TaskclusterProxy features. Requires
-                                            headlessTasks enabled. The runTaskAsCurrentUser and
+                                            Interactive, and TaskclusterProxy features. In
+                                            multiuser mode, requires headlessTasks enabled. The
+                                            runTaskAsCurrentUser and
                                             runAsAdministrator task features are automatically
                                             disabled when capacity > 1 to preserve task
                                             isolation. Maximum value is 255.

--- a/workers/generic-worker/Dockerfile.test
+++ b/workers/generic-worker/Dockerfile.test
@@ -1,0 +1,9 @@
+FROM golang:1.26.1-bookworm
+
+# Install user management tools needed by multiuser engine (useradd, chpasswd, etc.)
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    passwd \
+    sudo \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /src

--- a/workers/generic-worker/Dockerfile.test
+++ b/workers/generic-worker/Dockerfile.test
@@ -1,4 +1,4 @@
-FROM golang:1.26.1-bookworm
+FROM golang:1.26.2-bookworm
 
 # Install user management tools needed by multiuser engine (useradd, chpasswd, etc.)
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/workers/generic-worker/README.md
+++ b/workers/generic-worker/README.md
@@ -137,7 +137,7 @@ and reports back results to the queue.
                                             multiple tasks in parallel, each in its own task
                                             directory with isolated ports for LiveLog,
                                             Interactive, and TaskclusterProxy features. Requires
-                                            headlessTasks enabled. The runAsCurrentUser and
+                                            headlessTasks enabled. The runTaskAsCurrentUser and
                                             runAsAdministrator task features are automatically
                                             disabled when capacity > 1 to preserve task
                                             isolation. Maximum value is 255.

--- a/workers/generic-worker/README.md
+++ b/workers/generic-worker/README.md
@@ -132,6 +132,16 @@ and reports back results to the queue.
                                             not exist. This may be a relative path to the
                                             current directory, or an absolute path.
                                             [default: "caches"]
+          capacity                          The number of tasks the worker will run concurrently.
+                                            When greater than 1, the worker claims and executes
+                                            multiple tasks in parallel, each in its own task
+                                            directory with isolated ports for LiveLog,
+                                            Interactive, and TaskclusterProxy features. Requires
+                                            headlessTasks enabled. The runAsCurrentUser and
+                                            runAsAdministrator task features are automatically
+                                            disabled when capacity > 1 to preserve task
+                                            isolation. Maximum value is 255.
+                                            [default: 1]
           certificate                       Taskcluster certificate, when using temporary
                                             credentials only.
           cleanUpTaskDirs                   Whether to delete the home directories of the task
@@ -212,7 +222,9 @@ and reports back results to the queue.
           enableLoopbackVideo               Enables the Loopback Video feature to be used in the
                                             task payload. [default: true]
           enableRunTaskAsCurrentUser        Enables the Run Task As Current User feature to be
-                                            used in the task payload. [default: true]
+                                            used in the task payload. Automatically disabled
+                                            when capacity > 1 to preserve task isolation.
+                                            [default: true]
           headlessTasks                     If true, no dedicated graphical session will be available to tasks.
                                             There will also be no reboots between tasks and multiple workers
                                             can be run on the same host. Useful for tasks that don't require

--- a/workers/generic-worker/README.md
+++ b/workers/generic-worker/README.md
@@ -136,8 +136,9 @@ and reports back results to the queue.
                                             When greater than 1, the worker claims and executes
                                             multiple tasks in parallel, each in its own task
                                             directory with isolated ports for LiveLog,
-                                            Interactive, and TaskclusterProxy features. Requires
-                                            headlessTasks enabled. The runTaskAsCurrentUser and
+                                            Interactive, and TaskclusterProxy features. In
+                                            multiuser mode, requires headlessTasks enabled. The
+                                            runTaskAsCurrentUser and
                                             runAsAdministrator task features are automatically
                                             disabled when capacity > 1 to preserve task
                                             isolation. Maximum value is 255.

--- a/workers/generic-worker/abort_feature.go
+++ b/workers/generic-worker/abort_feature.go
@@ -56,7 +56,7 @@ func (atf *AbortTaskFeature) Start() *CommandExecutionError {
 	// with the reason `worker-shutdown`. Upon such report the queue will
 	// resolve the run as exception and create a new run, if the task has
 	// additional retries left.
-	atf.stopHandlingGracefulTermination = graceful.OnTerminationRequest(func(finishTasks bool) {
+	atf.stopHandlingGracefulTermination = graceful.OnTerminationRequest(atf.task.TaskID, func(finishTasks bool) {
 		if !finishTasks {
 			_ = atf.task.StatusManager.Abort(
 				&CommandExecutionError{

--- a/workers/generic-worker/artifact_feature.go
+++ b/workers/generic-worker/artifact_feature.go
@@ -177,16 +177,17 @@ func (atf *ArtifactTaskFeature) FindArtifacts() {
 		if time.Time(base.Expires).IsZero() {
 			base.Expires = task.Definition.Expires
 		}
+		taskDir := task.TaskDir()
 		switch artifact.Type {
 		case "file":
-			payloadArtifacts = append(payloadArtifacts, resolve(base, "file", basePath, artifact.ContentType, artifact.ContentEncoding, task.pd))
+			payloadArtifacts = append(payloadArtifacts, resolve(base, "file", basePath, artifact.ContentType, artifact.ContentEncoding, task.pd, taskDir))
 		case "directory":
-			if errArtifact := resolve(base, "directory", basePath, artifact.ContentType, artifact.ContentEncoding, task.pd); errArtifact != nil {
+			if errArtifact := resolve(base, "directory", basePath, artifact.ContentType, artifact.ContentEncoding, task.pd, taskDir); errArtifact != nil {
 				payloadArtifacts = append(payloadArtifacts, errArtifact)
 				break
 			}
 			walkFn := func(path string, d os.DirEntry, incomingErr error) error {
-				subPath, err := filepath.Rel(taskContext.TaskDir, path)
+				subPath, err := filepath.Rel(taskDir, path)
 				if err != nil {
 					// this indicates a bug in the code
 					panic(err)
@@ -212,7 +213,7 @@ func (atf *ArtifactTaskFeature) FindArtifacts() {
 				// cause the task to fail, and the cause to be preserved in the
 				// error artifact.
 				case incomingErr != nil:
-					fullPath := fileutil.AbsFrom(taskContext.TaskDir, subPath)
+					fullPath := fileutil.AbsFrom(taskDir, subPath)
 					payloadArtifacts = append(
 						payloadArtifacts,
 						&artifacts.ErrorArtifact{
@@ -223,17 +224,17 @@ func (atf *ArtifactTaskFeature) FindArtifacts() {
 						},
 					)
 				case d.IsDir():
-					if errArtifact := resolve(b, "directory", subPath, artifact.ContentType, artifact.ContentEncoding, task.pd); errArtifact != nil {
+					if errArtifact := resolve(b, "directory", subPath, artifact.ContentType, artifact.ContentEncoding, task.pd, taskDir); errArtifact != nil {
 						payloadArtifacts = append(payloadArtifacts, errArtifact)
 					}
 				default:
-					payloadArtifacts = append(payloadArtifacts, resolve(b, "file", subPath, artifact.ContentType, artifact.ContentEncoding, task.pd))
+					payloadArtifacts = append(payloadArtifacts, resolve(b, "file", subPath, artifact.ContentType, artifact.ContentEncoding, task.pd, taskDir))
 				}
 				return nil
 			}
 			// Any error returned here should already have been handled by
 			// walkFn, so should be safe to ignore.
-			_ = filepath.WalkDir(fileutil.AbsFrom(taskContext.TaskDir, basePath), walkFn)
+			_ = filepath.WalkDir(fileutil.AbsFrom(taskDir, basePath), walkFn)
 		}
 		artifactsChan <- payloadArtifacts
 	}
@@ -270,8 +271,8 @@ func (atf *ArtifactTaskFeature) FindArtifacts() {
 // ErrorArtifact, otherwise if it exists as a file, as
 // "invalid-resource-on-worker" ErrorArtifact
 // TODO: need to also handle "too-large-file-on-worker"
-func resolve(base *artifacts.BaseArtifact, artifactType, path, contentType, contentEncoding string, pd *process.PlatformData) artifacts.TaskArtifact {
-	fullPath := fileutil.AbsFrom(taskContext.TaskDir, path)
+func resolve(base *artifacts.BaseArtifact, artifactType, path, contentType, contentEncoding string, pd *process.PlatformData, taskDir string) artifacts.TaskArtifact {
+	fullPath := fileutil.AbsFrom(taskDir, path)
 	fileReader, err := os.Open(fullPath)
 	if err != nil {
 		// cannot read file/dir, create an error artifact
@@ -313,7 +314,7 @@ func resolve(base *artifacts.BaseArtifact, artifactType, path, contentType, cont
 		return nil
 	}
 
-	tempPath, err := copyToTempFileAsTaskUser(fullPath, pd)
+	tempPath, err := copyToTempFileAsTaskUser(fullPath, pd, taskDir)
 	if err != nil {
 		return &artifacts.ErrorArtifact{
 			BaseArtifact: base,

--- a/workers/generic-worker/artifacts.go
+++ b/workers/generic-worker/artifacts.go
@@ -168,8 +168,8 @@ func (task *TaskRun) classifyCreateArtifactError(artifact artifacts.TaskArtifact
 	}
 }
 
-func copyToTempFileAsTaskUser(filePath string, pd *process.PlatformData) (tempFilePath string, err error) {
-	tempFilePath, err = gwCopyToTempFile(filePath, pd)
+func copyToTempFileAsTaskUser(filePath string, pd *process.PlatformData, taskDir string) (tempFilePath string, err error) {
+	tempFilePath, err = gwCopyToTempFile(filePath, pd, taskDir)
 
 	if runtime.GOOS == "windows" {
 		// Windows syscall logs are sent to stdout, even though the code appears

--- a/workers/generic-worker/artifacts_insecure.go
+++ b/workers/generic-worker/artifacts_insecure.go
@@ -4,6 +4,6 @@ package main
 
 import "github.com/taskcluster/taskcluster/v99/workers/generic-worker/process"
 
-func gwCopyToTempFile(filePath string, pd *process.PlatformData) (string, error) {
+func gwCopyToTempFile(filePath string, pd *process.PlatformData, taskDir string) (string, error) {
 	return filePath, nil
 }

--- a/workers/generic-worker/artifacts_multiuser.go
+++ b/workers/generic-worker/artifacts_multiuser.go
@@ -10,8 +10,8 @@ import (
 	gwruntime "github.com/taskcluster/taskcluster/v99/workers/generic-worker/runtime"
 )
 
-func gwCopyToTempFile(filePath string, pd *process.PlatformData) (string, error) {
-	cmd, err := process.NewCommandNoOutputStreams([]string{gwruntime.GenericWorkerBinary(), "copy-to-temp-file", "--copy-file", filePath}, taskContext.TaskDir, []string{}, pd)
+func gwCopyToTempFile(filePath string, pd *process.PlatformData, taskDir string) (string, error) {
+	cmd, err := process.NewCommandNoOutputStreams([]string{gwruntime.GenericWorkerBinary(), "copy-to-temp-file", "--copy-file", filePath}, taskDir, []string{}, pd)
 	if err != nil {
 		return "", fmt.Errorf("failed to create new command to copy file %s to temporary location as task user: %v", filePath, err)
 	}

--- a/workers/generic-worker/artifacts_multiuser_test.go
+++ b/workers/generic-worker/artifacts_multiuser_test.go
@@ -15,6 +15,9 @@ import (
 )
 
 func TestPrivilegedFileUpload(t *testing.T) {
+	if os.Getenv("GW_IN_DOCKER") == "1" {
+		t.Skip("Skipping in Docker: file permission isolation requires a non-root environment")
+	}
 	setup(t)
 
 	tempFile, err := os.CreateTemp(testdataDir, t.Name())

--- a/workers/generic-worker/artifacts_test.go
+++ b/workers/generic-worker/artifacts_test.go
@@ -30,6 +30,12 @@ func validateArtifacts(t *testing.T, payloadArtifacts []Artifact, expected []art
 	}
 	defaults.SetDefaults(&payload)
 
+	// Get platform data for the test context
+	pd, err := platformDataForTaskContext(taskContext)
+	if err != nil {
+		t.Fatalf("Failed to get platform data: %v", err)
+	}
+
 	// to test, create a dummy task run with given artifacts
 	// and then call Artifacts() method to see what
 	// artifacts would get uploaded...
@@ -38,7 +44,8 @@ func validateArtifacts(t *testing.T, payloadArtifacts []Artifact, expected []art
 		Definition: tcqueue.TaskDefinitionResponse{
 			Expires: inAnHour,
 		},
-		pd: currentPlatformData(),
+		pd:      pd,
+		Context: taskContext,
 	}
 	tr.Payload.Artifacts = append(tr.Payload.Artifacts, payloadArtifacts...)
 	atf := ArtifactTaskFeature{

--- a/workers/generic-worker/backing_log_feature.go
+++ b/workers/generic-worker/backing_log_feature.go
@@ -49,7 +49,7 @@ func (bltf *BackingLogTaskFeature) RequiredScopes() scopes.Required {
 }
 
 func (bltf *BackingLogTaskFeature) Start() *CommandExecutionError {
-	absLogFile := fileutil.AbsFrom(taskContext.TaskDir, logPath)
+	absLogFile := fileutil.AbsFrom(bltf.task.TaskDir(), logPath)
 	logFileHandle, err := os.Create(absLogFile)
 	if err != nil {
 		return executionError(internalError, errored, err)
@@ -75,10 +75,11 @@ func (bltf *BackingLogTaskFeature) Stop(err *ExecutionErrors) {
 		bltf.task.Error(err.Error())
 	}
 	bltf.task.closeLog(bltf.logHandle)
+	taskDir := bltf.task.TaskDir()
 	if bltf.task.Payload.Features.BackingLog {
-		err.add(bltf.task.uploadLog(bltf.task.Payload.Logs.Backing, fileutil.AbsFrom(taskContext.TaskDir, logPath)))
+		err.add(bltf.task.uploadLog(bltf.task.Payload.Logs.Backing, fileutil.AbsFrom(taskDir, logPath)))
 	}
 	if config.CleanUpTaskDirs {
-		_ = os.Remove(fileutil.AbsFrom(taskContext.TaskDir, logPath))
+		_ = os.Remove(fileutil.AbsFrom(taskDir, logPath))
 	}
 }

--- a/workers/generic-worker/cache_test.go
+++ b/workers/generic-worker/cache_test.go
@@ -1,13 +1,243 @@
 package main
 
-import "testing"
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/taskcluster/taskcluster/v99/workers/generic-worker/gwconfig"
+)
 
 func TestIssue5363(t *testing.T) {
 	cacheMap := &CacheMap{}
 	// This cache file has two entries with locations that do not exist on the filesystem, and three that do
 	cacheMap.LoadFromFile("testdata/testcaches.json", "fakedir")
-	// Make sure two entries were removed
-	if len(*cacheMap) != 3 {
-		t.Errorf("Was expecting 3 cache entries in testdata/testcaches.json but found %v", len(*cacheMap))
+	// Count total entries across all slices
+	total := 0
+	for _, entries := range *cacheMap {
+		total += len(entries)
+	}
+	if total != 3 {
+		t.Errorf("Was expecting 3 cache entries in testdata/testcaches.json but found %v", total)
+	}
+}
+
+func TestCacheMapPoolStructure(t *testing.T) {
+	cm := CacheMap{}
+	entry1 := &Cache{Key: "foo", Location: "/tmp/test-pool-1", Created: time.Now()}
+	entry2 := &Cache{Key: "foo", Location: "/tmp/test-pool-2", Created: time.Now()}
+	cm["foo"] = append(cm["foo"], entry1, entry2)
+
+	if len(cm["foo"]) != 2 {
+		t.Errorf("Expected 2 entries for 'foo', got %d", len(cm["foo"]))
+	}
+}
+
+func TestAcquireCacheReturnsAvailableEntry(t *testing.T) {
+	directoryCaches = CacheMap{
+		"mycache": {
+			{Key: "mycache", Location: "/tmp/test-acquire", InUse: false, LastUsed: time.Now()},
+		},
+	}
+	entry := AcquireCache("mycache")
+	if entry == nil {
+		t.Fatal("Expected to acquire a cache entry, got nil")
+	}
+	if !entry.InUse {
+		t.Error("Expected acquired entry to be marked InUse")
+	}
+}
+
+func TestAcquireCacheReturnsNilWhenAllInUse(t *testing.T) {
+	directoryCaches = CacheMap{
+		"mycache": {
+			{Key: "mycache", Location: "/tmp/test-acquire-nil", InUse: true},
+		},
+	}
+	entry := AcquireCache("mycache")
+	if entry != nil {
+		t.Error("Expected nil when all entries are in use")
+	}
+}
+
+func TestAcquireCacheReturnsFreshestEntry(t *testing.T) {
+	old := time.Now().Add(-1 * time.Hour)
+	fresh := time.Now()
+	directoryCaches = CacheMap{
+		"mycache": {
+			{Key: "mycache", Location: "/tmp/old", InUse: false, LastUsed: old},
+			{Key: "mycache", Location: "/tmp/fresh", InUse: false, LastUsed: fresh},
+		},
+	}
+	entry := AcquireCache("mycache")
+	if entry.Location != "/tmp/fresh" {
+		t.Errorf("Expected freshest entry (/tmp/fresh), got %s", entry.Location)
+	}
+}
+
+func TestAcquireCacheReturnsDifferentEntries(t *testing.T) {
+	directoryCaches = CacheMap{
+		"shared": {
+			{Key: "shared", Location: "/tmp/s1", InUse: false, LastUsed: time.Now().Add(-1 * time.Minute)},
+			{Key: "shared", Location: "/tmp/s2", InUse: false, LastUsed: time.Now()},
+		},
+	}
+	first := AcquireCache("shared")
+	second := AcquireCache("shared")
+
+	if first == nil || second == nil {
+		t.Fatal("Expected both acquires to succeed")
+	}
+	if first == second {
+		t.Error("Expected different entries for concurrent acquires")
+	}
+	if first.Location == second.Location {
+		t.Error("Expected different locations")
+	}
+}
+
+func TestAcquireCachePoolExhausted(t *testing.T) {
+	directoryCaches = CacheMap{
+		"build": {
+			{Key: "build", Location: "/tmp/p1", InUse: true},
+			{Key: "build", Location: "/tmp/p2", InUse: true},
+		},
+	}
+	entry := AcquireCache("build")
+	if entry != nil {
+		t.Error("Expected nil when all pool entries are in use")
+	}
+}
+
+func TestReleaseCacheMarksAvailable(t *testing.T) {
+	entry := &Cache{Key: "mycache", InUse: true}
+	directoryCaches = CacheMap{
+		"mycache": {entry},
+	}
+	ReleaseCache(entry)
+	if entry.InUse {
+		t.Error("Expected entry to no longer be InUse after release")
+	}
+	if entry.LastUsed.IsZero() {
+		t.Error("Expected LastUsed to be set after release")
+	}
+}
+
+func TestEvictSinglePoolEntry(t *testing.T) {
+	cm := CacheMap{}
+	e1 := &Cache{Key: "foo", Location: t.TempDir(), Owner: cm}
+	e2 := &Cache{Key: "foo", Location: t.TempDir(), Owner: cm}
+	cm["foo"] = []*Cache{e1, e2}
+
+	err := e1.Evict(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(cm["foo"]) != 1 {
+		t.Errorf("Expected 1 remaining entry, got %d", len(cm["foo"]))
+	}
+	if cm["foo"][0] != e2 {
+		t.Error("Wrong entry remained after eviction")
+	}
+}
+
+func TestEvictLastEntryRemovesKey(t *testing.T) {
+	cm := CacheMap{}
+	e := &Cache{Key: "bar", Location: t.TempDir(), Owner: cm}
+	cm["bar"] = []*Cache{e}
+
+	err := e.Evict(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, exists := cm["bar"]; exists {
+		t.Error("Expected map key to be deleted when last entry is evicted")
+	}
+}
+
+func TestSortedResourcesExcludesInUse(t *testing.T) {
+	cm := CacheMap{
+		"a": {
+			{Key: "a", Location: "/tmp/a1", InUse: true, LastUsed: time.Now()},
+			{Key: "a", Location: "/tmp/a2", InUse: false, LastUsed: time.Now()},
+		},
+	}
+	resources := cm.SortedResources()
+	if len(resources) != 1 {
+		t.Errorf("Expected 1 available resource, got %d", len(resources))
+	}
+}
+
+func TestRatingUsesLastUsed(t *testing.T) {
+	old := &Cache{LastUsed: time.Now().Add(-1 * time.Hour)}
+	fresh := &Cache{LastUsed: time.Now()}
+	if old.Rating() >= fresh.Rating() {
+		t.Error("Fresher cache should have higher rating")
+	}
+}
+
+func TestLoadFromFileResetsInUse(t *testing.T) {
+	dir := t.TempDir()
+	cacheDir := filepath.Join(dir, "cache1")
+	if err := os.MkdirAll(cacheDir, 0700); err != nil {
+		t.Fatal(err)
+	}
+
+	data := fmt.Sprintf(`{"test":[{"key":"test","location":%q,"in_use":true,"created":"2026-01-01T00:00:00Z"}]}`, cacheDir)
+	stateFile := filepath.Join(dir, "test-caches.json")
+	if err := os.WriteFile(stateFile, []byte(data), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	cm := &CacheMap{}
+	cm.LoadFromFile(stateFile, dir)
+
+	entries := (*cm)["test"]
+	if len(entries) != 1 {
+		t.Fatalf("Expected 1 entry, got %d", len(entries))
+	}
+	if entries[0].InUse {
+		t.Error("Expected InUse to be reset to false on load")
+	}
+}
+
+func TestTrimPoolExcess(t *testing.T) {
+	origConfig := config
+	config = &gwconfig.Config{}
+	config.Capacity = 2
+	defer func() { config = origConfig }()
+
+	directoryCaches = CacheMap{
+		"build": {
+			{Key: "build", Location: t.TempDir(), InUse: false, LastUsed: time.Now().Add(-3 * time.Hour), Owner: directoryCaches},
+			{Key: "build", Location: t.TempDir(), InUse: false, LastUsed: time.Now().Add(-2 * time.Hour), Owner: directoryCaches},
+			{Key: "build", Location: t.TempDir(), InUse: false, LastUsed: time.Now().Add(-1 * time.Hour), Owner: directoryCaches},
+			{Key: "build", Location: t.TempDir(), InUse: true, Owner: directoryCaches}, // in-use, should not be counted or trimmed
+		},
+	}
+	// Fix Owner references after map creation
+	for _, entries := range directoryCaches {
+		for _, e := range entries {
+			e.Owner = directoryCaches
+		}
+	}
+
+	trimPoolExcess()
+	remaining := directoryCaches["build"]
+	// Should have 2 available + 1 in-use = 3 total (trimmed the oldest available)
+	if len(remaining) != 3 {
+		t.Errorf("Expected 3 entries after trim, got %d", len(remaining))
+	}
+	// Verify in-use entry survived
+	inUseCount := 0
+	for _, e := range remaining {
+		if e.InUse {
+			inUseCount++
+		}
+	}
+	if inUseCount != 1 {
+		t.Errorf("Expected 1 in-use entry, got %d", inUseCount)
 	}
 }

--- a/workers/generic-worker/chain_of_trust_feature.go
+++ b/workers/generic-worker/chain_of_trust_feature.go
@@ -214,7 +214,7 @@ func (feature *ChainOfTrustTaskFeature) Stop(err *ExecutionErrors) {
 
 	// create detached ed25519 chain-of-trust.json.sig
 	sig := ed25519.Sign(feature.ed25519PrivKey, certBytes)
-	e = os.WriteFile(ed25519SignedCert, sig, 0644)
+	e = os.WriteFile(ed25519SignedCert, sig, 0600)
 	if e != nil {
 		panic(e)
 	}

--- a/workers/generic-worker/chain_of_trust_feature.go
+++ b/workers/generic-worker/chain_of_trust_feature.go
@@ -140,15 +140,16 @@ func (feature *ChainOfTrustTaskFeature) Stop(err *ExecutionErrors) {
 	if feature.disabled {
 		return
 	}
-	logFile := fileutil.AbsFrom(taskContext.TaskDir, logPath)
-	certifiedLogFile := fileutil.AbsFrom(taskContext.TaskDir, certifiedLogPath)
-	unsignedCert := fileutil.AbsFrom(taskContext.TaskDir, unsignedCertPath)
-	ed25519SignedCert := fileutil.AbsFrom(taskContext.TaskDir, ed25519SignedCertPath)
+	taskDir := feature.task.TaskDir()
+	logFile := fileutil.AbsFrom(taskDir, logPath)
+	certifiedLogFile := fileutil.AbsFrom(taskDir, certifiedLogPath)
+	unsignedCert := fileutil.AbsFrom(taskDir, unsignedCertPath)
+	ed25519SignedCert := fileutil.AbsFrom(taskDir, ed25519SignedCertPath)
 	copyErr := copyFileContents(logFile, certifiedLogFile)
 	if copyErr != nil {
 		panic(copyErr)
 	}
-	err.add(feature.task.uploadLog(certifiedLogName, fileutil.AbsFrom(taskContext.TaskDir, certifiedLogPath)))
+	err.add(feature.task.uploadLog(certifiedLogName, fileutil.AbsFrom(taskDir, certifiedLogPath)))
 	artifactHashes := map[string]ArtifactHash{}
 	feature.task.artifactsMux.RLock()
 	for _, artifact := range feature.task.Artifacts {
@@ -209,7 +210,7 @@ func (feature *ChainOfTrustTaskFeature) Stop(err *ExecutionErrors) {
 	if e != nil {
 		panic(e)
 	}
-	err.add(feature.task.uploadLog(unsignedCertName, fileutil.AbsFrom(taskContext.TaskDir, unsignedCertPath)))
+	err.add(feature.task.uploadLog(unsignedCertName, fileutil.AbsFrom(taskDir, unsignedCertPath)))
 
 	// create detached ed25519 chain-of-trust.json.sig
 	sig := ed25519.Sign(feature.ed25519PrivKey, certBytes)
@@ -223,8 +224,8 @@ func (feature *ChainOfTrustTaskFeature) Stop(err *ExecutionErrors) {
 				Name:    ed25519SignedCertName,
 				Expires: feature.task.TaskClaimResponse.Task.Expires,
 			},
-			fileutil.AbsFrom(taskContext.TaskDir, ed25519SignedCertPath),
-			fileutil.AbsFrom(taskContext.TaskDir, ed25519SignedCertPath),
+			fileutil.AbsFrom(taskDir, ed25519SignedCertPath),
+			fileutil.AbsFrom(taskDir, ed25519SignedCertPath),
 			"application/octet-stream",
 			"gzip",
 		),
@@ -245,7 +246,7 @@ func (cot *ChainOfTrustTaskFeature) ensureTaskUserCantReadPrivateCotKey() error 
 }
 
 func (cot *ChainOfTrustTaskFeature) MergeAdditionalData(certBytes []byte) (mergedCert []byte, err error) {
-	additionalDataFile := filepath.Join(taskContext.TaskDir, additionalDataPath)
+	additionalDataFile := filepath.Join(cot.task.TaskDir(), additionalDataPath)
 
 	// Additional data is optional, if file hasn't been created by task, just return the original data
 	if _, err = os.Stat(additionalDataFile); errors.Is(err, os.ErrNotExist) {
@@ -253,7 +254,7 @@ func (cot *ChainOfTrustTaskFeature) MergeAdditionalData(certBytes []byte) (merge
 	}
 
 	// Ensure task user can read the data (e.g. in case somebody creates a symbolic link to a json file owned by root)
-	tempPath, err := copyToTempFileAsTaskUser(additionalDataFile, cot.task.pd)
+	tempPath, err := copyToTempFileAsTaskUser(additionalDataFile, cot.task.pd, cot.task.TaskDir())
 	if err != nil {
 		return
 	}

--- a/workers/generic-worker/chain_of_trust_feature.go
+++ b/workers/generic-worker/chain_of_trust_feature.go
@@ -214,7 +214,12 @@ func (feature *ChainOfTrustTaskFeature) Stop(err *ExecutionErrors) {
 
 	// create detached ed25519 chain-of-trust.json.sig
 	sig := ed25519.Sign(feature.ed25519PrivKey, certBytes)
-	e = os.WriteFile(ed25519SignedCert, sig, 0600)
+	// 0644 (not 0600) so the artifact uploader, which copies via
+	// copy-to-temp-file as the task user, can read this file. The
+	// task dir is already 0700 owned by the task user, so the file
+	// is not exposed beyond that boundary. Same rationale as
+	// chain-of-trust-additional-data.json in d2g_feature.go.
+	e = os.WriteFile(ed25519SignedCert, sig, 0644)
 	if e != nil {
 		panic(e)
 	}

--- a/workers/generic-worker/chain_of_trust_test.go
+++ b/workers/generic-worker/chain_of_trust_test.go
@@ -26,6 +26,9 @@ func TestExitCodeMissingChainOfTrustKey(t *testing.T) {
 }
 
 func TestChainOfTrustUpload(t *testing.T) {
+	if os.Getenv("GW_IN_DOCKER") == "1" {
+		t.Skip("Skipping in Docker: CoT key permission isolation requires a non-root environment")
+	}
 
 	setup(t)
 
@@ -267,6 +270,9 @@ func TestChainOfTrustUploadAsCurrentUser(t *testing.T) {
 }
 
 func TestProtectedArtifactsReplaced(t *testing.T) {
+	if os.Getenv("GW_IN_DOCKER") == "1" {
+		t.Skip("Skipping in Docker: CoT key permission isolation requires a non-root environment")
+	}
 
 	setup(t)
 
@@ -444,6 +450,9 @@ func TestProtectedArtifactsReplacedAsCurrentUser(t *testing.T) {
 }
 
 func TestChainOfTrustAdditionalData(t *testing.T) {
+	if os.Getenv("GW_IN_DOCKER") == "1" {
+		t.Skip("Skipping in Docker: CoT key permission isolation requires a non-root environment")
+	}
 
 	setup(t)
 

--- a/workers/generic-worker/d2g_feature.go
+++ b/workers/generic-worker/d2g_feature.go
@@ -205,19 +205,21 @@ func (dtf *D2GTaskFeature) Start() *CommandExecutionError {
 	if isImageArtifact {
 		if image == nil {
 			var loadErr *CommandExecutionError
-			image, loadedImage, loadErr = dtf.loadImageArtifactLocked(key, loadImage)
+			image, loadedImage, loadErr = dtf.loadImageLocked(key, loadImage)
 			if loadErr != nil {
 				return loadErr
 			}
 		}
 	} else {
+		// Registry pulls also serialize through the same mutex so that
+		// concurrent tasks running with the same `image: foo:tag`
+		// don't issue parallel `docker pull`s and race on the cache
+		// JSON write below.
 		var loadErr *CommandExecutionError
-		image, loadErr = loadImage()
+		image, loadedImage, loadErr = dtf.loadImageLocked(key, loadImage)
 		if loadErr != nil {
 			return loadErr
 		}
-		dtf.imageCache[key] = image
-		loadedImage = true
 	}
 
 	if loadedImage {
@@ -290,9 +292,11 @@ func (dtf *D2GTaskFeature) Start() *CommandExecutionError {
 	return nil
 }
 
-// loadImageArtifactLocked serializes docker image artifact loads so that
-// concurrent tasks don't race on tag -> ID resolution.
-func (dtf *D2GTaskFeature) loadImageArtifactLocked(key string, loadImage func() (*Image, *CommandExecutionError)) (*Image, bool, *CommandExecutionError) {
+// loadImageLocked serializes docker image loads (both artifact-based
+// `docker load` and registry-based `docker pull`) so that concurrent
+// tasks sharing the same image key don't issue redundant work and
+// don't race on the on-disk cache JSON write.
+func (dtf *D2GTaskFeature) loadImageLocked(key string, loadImage func() (*Image, *CommandExecutionError)) (*Image, bool, *CommandExecutionError) {
 	d2gImageLoadMutex.Lock()
 	defer d2gImageLoadMutex.Unlock()
 

--- a/workers/generic-worker/d2g_feature.go
+++ b/workers/generic-worker/d2g_feature.go
@@ -19,6 +19,12 @@ import (
 	"github.com/taskcluster/taskcluster/v99/workers/generic-worker/process"
 )
 
+// Lock ordering (to prevent deadlocks):
+//  1. d2gImageLoadMutex (outermost — serializes docker load/pull)
+//  2. d2gCacheMutex     (protects d2g-image-cache.json)
+//  3. cacheMutex        (innermost — protects file/directory cache maps,
+//     defined in mounts_feature.go; acquired by garbageCollection which
+//     calls removeD2GCacheFile → d2gCacheMutex)
 var (
 	// d2gCacheMutex protects access to the d2g-image-cache.json file
 	// for concurrent task execution (capacity > 1)
@@ -198,31 +204,11 @@ func (dtf *D2GTaskFeature) Start() *CommandExecutionError {
 	// (see https://github.com/taskcluster/taskcluster/issues/8004)
 	if isImageArtifact {
 		if image == nil {
-			// Docker image artifacts frequently reuse tags. Serialize loads so that
-			// tag -> ID resolution isn't raced by another load.
-			d2gImageLoadMutex.Lock()
-
-			// Refresh cache from disk in case another task loaded this image
-			// while we were waiting to acquire the lock.
-			latestCache := ImageCache{}
-			d2gCacheMutex.Lock()
-			latestCache.loadFromFile("d2g-image-cache.json")
-			d2gCacheMutex.Unlock()
-			maps.Copy(dtf.imageCache, latestCache)
-			image = latestCache[key]
-
-			if image == nil {
-				var loadErr *CommandExecutionError
-				image, loadErr = loadImage()
-				if loadErr != nil {
-					d2gImageLoadMutex.Unlock()
-					return loadErr
-				}
-				dtf.imageCache[key] = image
-				loadedImage = true
+			var loadErr *CommandExecutionError
+			image, loadedImage, loadErr = dtf.loadImageArtifactLocked(key, loadImage)
+			if loadErr != nil {
+				return loadErr
 			}
-
-			d2gImageLoadMutex.Unlock()
 		}
 	} else {
 		var loadErr *CommandExecutionError
@@ -302,6 +288,31 @@ func (dtf *D2GTaskFeature) Start() *CommandExecutionError {
 	d2gCacheMutex.Unlock()
 
 	return nil
+}
+
+// loadImageArtifactLocked serializes docker image artifact loads so that
+// concurrent tasks don't race on tag -> ID resolution.
+func (dtf *D2GTaskFeature) loadImageArtifactLocked(key string, loadImage func() (*Image, *CommandExecutionError)) (*Image, bool, *CommandExecutionError) {
+	d2gImageLoadMutex.Lock()
+	defer d2gImageLoadMutex.Unlock()
+
+	// Refresh cache from disk in case another task loaded this image
+	// while we were waiting to acquire the lock.
+	latestCache := ImageCache{}
+	d2gCacheMutex.Lock()
+	latestCache.loadFromFile("d2g-image-cache.json")
+	d2gCacheMutex.Unlock()
+	maps.Copy(dtf.imageCache, latestCache)
+	if image := latestCache[key]; image != nil {
+		return image, false, nil
+	}
+
+	image, loadErr := loadImage()
+	if loadErr != nil {
+		return nil, false, loadErr
+	}
+	dtf.imageCache[key] = image
+	return image, true, nil
 }
 
 func (dtf *D2GTaskFeature) Stop(err *ExecutionErrors) {

--- a/workers/generic-worker/d2g_feature.go
+++ b/workers/generic-worker/d2g_feature.go
@@ -13,25 +13,31 @@ import (
 	"sync"
 
 	"golang.org/x/sync/errgroup"
+	"golang.org/x/sync/singleflight"
 
 	"github.com/taskcluster/taskcluster/v99/internal/scopes"
 	"github.com/taskcluster/taskcluster/v99/workers/generic-worker/fileutil"
 	"github.com/taskcluster/taskcluster/v99/workers/generic-worker/process"
 )
 
-// Lock ordering (to prevent deadlocks):
-//  1. d2gImageLoadMutex (outermost — serializes docker load/pull)
-//  2. d2gCacheMutex     (protects d2g-image-cache.json)
-//  3. cacheMutex        (innermost — protects file/directory cache maps,
-//     defined in mounts_feature.go; acquired by garbageCollection which
-//     calls removeD2GCacheFile → d2gCacheMutex)
+// Concurrency model (capacity > 1):
+//
+//   - d2gImageLoads is a singleflight.Group keyed by image cache key.
+//     Concurrent tasks that resolve to the *same* image key share a
+//     single docker load / docker pull invocation; tasks resolving to
+//     *different* keys run in parallel — that's what capacity > 1 is
+//     for. Mirrors the fileCacheDownloads pattern in mounts_feature.go.
+//
+//   - d2gCacheMutex protects the d2g-image-cache.json file. Held only
+//     across the read or write to that single shared file, never across
+//     a docker invocation, so it doesn't bottleneck unrelated loads.
+//
+// Lock ordering (when both are held): d2gCacheMutex outside cacheMutex
+// (cacheMutex is defined in mounts_feature.go and acquired by
+// garbageCollection → removeD2GCacheFile → d2gCacheMutex).
 var (
-	// d2gCacheMutex protects access to the d2g-image-cache.json file
-	// for concurrent task execution (capacity > 1)
 	d2gCacheMutex sync.Mutex
-	// d2gImageLoadMutex protects concurrent docker image loads
-	// for concurrent task execution (capacity > 1)
-	d2gImageLoadMutex sync.Mutex
+	d2gImageLoads singleflight.Group
 )
 
 type (
@@ -256,6 +262,11 @@ func (dtf *D2GTaskFeature) Start() *CommandExecutionError {
 		}
 
 		chainOfTrustAdditionalDataPath := filepath.Join(taskDir, "chain-of-trust-additional-data.json")
+		// 0644 (not 0600): the worker (root) writes this file, then
+		// the task user reads it via copy-to-temp-file when the
+		// chain-of-trust feature folds it into the signed cert. The
+		// task dir is already 0700 owned by the task user, so this
+		// file is not exposed beyond that boundary.
 		err = os.WriteFile(chainOfTrustAdditionalDataPath, []byte(chainOfTrustAdditionalData), 0644)
 		if err != nil {
 			return executionError(internalError, errored, fmt.Errorf("[d2g] could not write chain of trust additional data file: %v", err))
@@ -292,31 +303,50 @@ func (dtf *D2GTaskFeature) Start() *CommandExecutionError {
 	return nil
 }
 
-// loadImageLocked serializes docker image loads (both artifact-based
-// `docker load` and registry-based `docker pull`) so that concurrent
-// tasks sharing the same image key don't issue redundant work and
-// don't race on the on-disk cache JSON write.
+// loadImageLocked deduplicates concurrent docker image loads (both
+// artifact-based `docker load` and registry-based `docker pull`) per
+// image key. Tasks pulling the *same* key share one docker invocation;
+// tasks pulling *different* keys run in parallel.
+//
+// The first return is whether *this* call actually performed the load
+// (true) versus picked up a result populated by another task (false) —
+// kept for the existing "[d2g] Loaded ..." vs "[d2g] Using cached ..."
+// log distinction in Start.
+type imageLoadResult struct {
+	image  *Image
+	loaded bool
+}
+
 func (dtf *D2GTaskFeature) loadImageLocked(key string, loadImage func() (*Image, *CommandExecutionError)) (*Image, bool, *CommandExecutionError) {
-	d2gImageLoadMutex.Lock()
-	defer d2gImageLoadMutex.Unlock()
+	v, err, _ := d2gImageLoads.Do(key, func() (any, error) {
+		// Re-read the on-disk cache: another task may have completed
+		// the load while we were waiting on singleflight, OR an
+		// unrelated process (a previous worker run) may have left a
+		// fresh entry behind. Done inside Do so the doubled-check
+		// happens under the per-key serialization.
+		latestCache := ImageCache{}
+		d2gCacheMutex.Lock()
+		latestCache.loadFromFile("d2g-image-cache.json")
+		d2gCacheMutex.Unlock()
+		maps.Copy(dtf.imageCache, latestCache)
+		if image := latestCache[key]; image != nil {
+			return imageLoadResult{image: image, loaded: false}, nil
+		}
 
-	// Refresh cache from disk in case another task loaded this image
-	// while we were waiting to acquire the lock.
-	latestCache := ImageCache{}
-	d2gCacheMutex.Lock()
-	latestCache.loadFromFile("d2g-image-cache.json")
-	d2gCacheMutex.Unlock()
-	maps.Copy(dtf.imageCache, latestCache)
-	if image := latestCache[key]; image != nil {
-		return image, false, nil
+		image, loadErr := loadImage()
+		if loadErr != nil {
+			return nil, loadErr
+		}
+		dtf.imageCache[key] = image
+		return imageLoadResult{image: image, loaded: true}, nil
+	})
+	if err != nil {
+		// Only loadImage returns an error from inside Do, and it's
+		// always a *CommandExecutionError.
+		return nil, false, err.(*CommandExecutionError)
 	}
-
-	image, loadErr := loadImage()
-	if loadErr != nil {
-		return nil, false, loadErr
-	}
-	dtf.imageCache[key] = image
-	return image, true, nil
+	r := v.(imageLoadResult)
+	return r.image, r.loaded, nil
 }
 
 func (dtf *D2GTaskFeature) Stop(err *ExecutionErrors) {

--- a/workers/generic-worker/d2g_feature.go
+++ b/workers/generic-worker/d2g_feature.go
@@ -5,6 +5,7 @@ package main
 import (
 	"fmt"
 	"log"
+	"maps"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -16,6 +17,15 @@ import (
 	"github.com/taskcluster/taskcluster/v99/internal/scopes"
 	"github.com/taskcluster/taskcluster/v99/workers/generic-worker/fileutil"
 	"github.com/taskcluster/taskcluster/v99/workers/generic-worker/process"
+)
+
+var (
+	// d2gCacheMutex protects access to the d2g-image-cache.json file
+	// for concurrent task execution (capacity > 1)
+	d2gCacheMutex sync.Mutex
+	// d2gImageLoadMutex protects concurrent docker image loads
+	// for concurrent task execution (capacity > 1)
+	d2gImageLoadMutex sync.Mutex
 )
 
 type (
@@ -68,8 +78,11 @@ func (dtf *D2GTaskFeature) RequiredScopes() scopes.Required {
 func (dtf *D2GTaskFeature) Start() *CommandExecutionError {
 	// load cache on every start in case the garbage
 	// collector has pruned docker images between tasks
+	d2gCacheMutex.Lock()
 	dtf.imageCache.loadFromFile("d2g-image-cache.json")
+	d2gCacheMutex.Unlock()
 
+	taskDir := dtf.task.TaskDir()
 	var isImageArtifact bool
 	var key string
 	if dtf.task.D2GInfo.ImageArtifactSHA256 != "" {
@@ -83,12 +96,8 @@ func (dtf *D2GTaskFeature) Start() *CommandExecutionError {
 	}
 
 	image := dtf.imageCache[key]
-
-	// Always want to re-pull the docker image
-	// if it's not an image artifact, as the
-	// tag could be outdated
-	// (see https://github.com/taskcluster/taskcluster/issues/8004)
-	if image == nil || !isImageArtifact {
+	loadedImage := false
+	loadImage := func() (*Image, *CommandExecutionError) {
 		dtf.task.Info("[d2g] Loading docker image")
 
 		var cmd *process.Command
@@ -99,7 +108,7 @@ func (dtf *D2GTaskFeature) Start() *CommandExecutionError {
 			// the task user process doesn't need file system access.
 			cachedImageFile, err := os.Open(dtf.task.D2GInfo.ImageArtifactPath)
 			if err != nil {
-				return executionError(internalError, errored, fmt.Errorf("[d2g] could not open cached docker image at %v: %v", dtf.task.D2GInfo.ImageArtifactPath, err))
+				return nil, executionError(internalError, errored, fmt.Errorf("[d2g] could not open cached docker image at %v: %v", dtf.task.D2GInfo.ImageArtifactPath, err))
 			}
 			defer cachedImageFile.Close()
 
@@ -107,9 +116,9 @@ func (dtf *D2GTaskFeature) Start() *CommandExecutionError {
 				"docker",
 				"load",
 				"--quiet",
-			}, taskContext.TaskDir, []string{}, dtf.task.pd)
+			}, taskDir, []string{}, dtf.task.pd)
 			if err != nil {
-				return executionError(internalError, errored, fmt.Errorf("[d2g] could not create process to load docker image: %v", err))
+				return nil, executionError(internalError, errored, fmt.Errorf("[d2g] could not create process to load docker image: %v", err))
 			}
 			cmd.Stdin = cachedImageFile
 		} else {
@@ -118,14 +127,14 @@ func (dtf *D2GTaskFeature) Start() *CommandExecutionError {
 				"pull",
 				"--quiet",
 				key,
-			}, taskContext.TaskDir, []string{}, dtf.task.pd)
+			}, taskDir, []string{}, dtf.task.pd)
 			if err != nil {
-				return executionError(internalError, errored, fmt.Errorf("[d2g] could not create process to pull docker image: %v", err))
+				return nil, executionError(internalError, errored, fmt.Errorf("[d2g] could not create process to pull docker image: %v", err))
 			}
 		}
 		out, err := cmd.Output()
 		if err != nil {
-			return executionError(internalError, errored, formatCommandError("[d2g] could not load docker image", err, out))
+			return nil, executionError(internalError, errored, formatCommandError("[d2g] could not load docker image", err, out))
 		}
 
 		// Default to use the first line of output for image
@@ -146,7 +155,7 @@ func (dtf *D2GTaskFeature) Start() *CommandExecutionError {
 			}
 
 			if !imageNameFound {
-				return executionError(internalError, errored, fmt.Errorf("[d2g] could not determine docker image name from docker load output:\n%v", string(out)))
+				return nil, executionError(internalError, errored, fmt.Errorf("[d2g] could not determine docker image name from docker load output:\n%v", string(out)))
 			}
 		}
 		imageID := imageName
@@ -161,13 +170,13 @@ func (dtf *D2GTaskFeature) Start() *CommandExecutionError {
 				"--no-trunc",
 				"--quiet",
 				imageName,
-			}, taskContext.TaskDir, []string{}, dtf.task.pd)
+			}, taskDir, []string{}, dtf.task.pd)
 			if err != nil {
-				return executionError(internalError, errored, fmt.Errorf("[d2g] could not create process to get sha256 of docker image: %v", err))
+				return nil, executionError(internalError, errored, fmt.Errorf("[d2g] could not create process to get sha256 of docker image: %v", err))
 			}
 			out, err = cmd.Output()
 			if err != nil {
-				return executionError(internalError, errored, formatCommandError("[d2g] could not get sha256 of docker image", err, out))
+				return nil, executionError(internalError, errored, formatCommandError("[d2g] could not get sha256 of docker image", err, out))
 			}
 
 			// Only use the first line of output for image ID
@@ -177,11 +186,55 @@ func (dtf *D2GTaskFeature) Start() *CommandExecutionError {
 			imageID = strings.TrimPrefix(idLine, "sha256:")
 		}
 
-		image = &Image{
+		return &Image{
 			ID:   imageID,
 			Name: imageName,
+		}, nil
+	}
+
+	// Always want to re-pull the docker image
+	// if it's not an image artifact, as the
+	// tag could be outdated
+	// (see https://github.com/taskcluster/taskcluster/issues/8004)
+	if isImageArtifact {
+		if image == nil {
+			// Docker image artifacts frequently reuse tags. Serialize loads so that
+			// tag -> ID resolution isn't raced by another load.
+			d2gImageLoadMutex.Lock()
+
+			// Refresh cache from disk in case another task loaded this image
+			// while we were waiting to acquire the lock.
+			latestCache := ImageCache{}
+			d2gCacheMutex.Lock()
+			latestCache.loadFromFile("d2g-image-cache.json")
+			d2gCacheMutex.Unlock()
+			maps.Copy(dtf.imageCache, latestCache)
+			image = latestCache[key]
+
+			if image == nil {
+				var loadErr *CommandExecutionError
+				image, loadErr = loadImage()
+				if loadErr != nil {
+					d2gImageLoadMutex.Unlock()
+					return loadErr
+				}
+				dtf.imageCache[key] = image
+				loadedImage = true
+			}
+
+			d2gImageLoadMutex.Unlock()
+		}
+	} else {
+		var loadErr *CommandExecutionError
+		image, loadErr = loadImage()
+		if loadErr != nil {
+			return loadErr
 		}
 		dtf.imageCache[key] = image
+		loadedImage = true
+	}
+
+	if loadedImage {
 		dtf.task.Infof("[d2g] Loaded docker image %q", image.Name)
 	} else {
 		dtf.task.Infof("[d2g] Using cached docker image %q", image.Name)
@@ -197,7 +250,7 @@ func (dtf *D2GTaskFeature) Start() *CommandExecutionError {
 			"inspect",
 			"--format={{index .Id}}",
 			image.ID,
-		}, taskContext.TaskDir, []string{}, dtf.task.pd)
+		}, taskDir, []string{}, dtf.task.pd)
 		if err != nil {
 			return executionError(internalError, errored, fmt.Errorf("[d2g] could not create process to inspect docker image: %v", err))
 		}
@@ -214,14 +267,14 @@ func (dtf *D2GTaskFeature) Start() *CommandExecutionError {
 			chainOfTrustAdditionalData = fmt.Sprintf(`{"environment":{"imageHash":"%s"}}`, imageHash)
 		}
 
-		chainOfTrustAdditionalDataPath := filepath.Join(taskContext.TaskDir, "chain-of-trust-additional-data.json")
+		chainOfTrustAdditionalDataPath := filepath.Join(taskDir, "chain-of-trust-additional-data.json")
 		err = os.WriteFile(chainOfTrustAdditionalDataPath, []byte(chainOfTrustAdditionalData), 0644)
 		if err != nil {
 			return executionError(internalError, errored, fmt.Errorf("[d2g] could not write chain of trust additional data file: %v", err))
 		}
 	}
 
-	envFile, err := os.Create(filepath.Join(taskContext.TaskDir, "env.list"))
+	envFile, err := os.Create(filepath.Join(taskDir, "env.list"))
 	if err != nil {
 		return executionError(internalError, errored, fmt.Errorf("[d2g] could not create env.list file: %v", err))
 	}
@@ -232,12 +285,27 @@ func (dtf *D2GTaskFeature) Start() *CommandExecutionError {
 		return executionError(internalError, errored, fmt.Errorf("[d2g] could not write to env.list file: %v", err))
 	}
 
-	dtf.evaluateCommandPlaceholders(image.ID)
+	dtf.evaluateCommandPlaceholders(image.ID, taskDir)
+
+	d2gCacheMutex.Lock()
+	mergedCache := ImageCache{}
+	mergedCache.loadFromFile("d2g-image-cache.json")
+	maps.Copy(mergedCache, dtf.imageCache)
+	if writeErr := fileutil.WriteToFileAsJSON(&mergedCache, "d2g-image-cache.json"); writeErr != nil {
+		d2gCacheMutex.Unlock()
+		return executionError(internalError, errored, writeErr)
+	}
+	if secErr := fileutil.SecureFiles("d2g-image-cache.json"); secErr != nil {
+		d2gCacheMutex.Unlock()
+		return executionError(internalError, errored, secErr)
+	}
+	d2gCacheMutex.Unlock()
 
 	return nil
 }
 
 func (dtf *D2GTaskFeature) Stop(err *ExecutionErrors) {
+	taskDir := dtf.task.TaskDir()
 	// Copy artifacts from the stopped container in parallel since
 	// each docker cp reads from an independent path and destinations
 	// are unique (artifact0, artifact1, ...). Limit to 10 concurrent
@@ -253,7 +321,7 @@ func (dtf *D2GTaskFeature) Stop(err *ExecutionErrors) {
 				"cp",
 				fmt.Sprintf("%s:%s", dtf.task.D2GInfo.ContainerName, artifact.SrcPath),
 				artifact.DestPath,
-			}, taskContext.TaskDir, []string{}, dtf.task.pd)
+			}, taskDir, []string{}, dtf.task.pd)
 			if e != nil {
 				execErr := executionError(internalError, errored, fmt.Errorf("[d2g] could not create process to copy artifact: %v", e))
 				mu.Lock()
@@ -278,7 +346,7 @@ func (dtf *D2GTaskFeature) Stop(err *ExecutionErrors) {
 		"rm",
 		"--force",
 		dtf.task.D2GInfo.ContainerName,
-	}, taskContext.TaskDir, []string{}, dtf.task.pd)
+	}, taskDir, []string{}, dtf.task.pd)
 	if e != nil {
 		err.add(executionError(internalError, errored, fmt.Errorf("[d2g] could not create process to remove docker container: %v", e)))
 	}
@@ -287,8 +355,6 @@ func (dtf *D2GTaskFeature) Stop(err *ExecutionErrors) {
 		err.add(executionError(internalError, errored, formatCommandError("[d2g] could not remove docker container", e, out)))
 	}
 
-	err.add(executionError(internalError, errored, fileutil.WriteToFileAsJSON(&dtf.imageCache, "d2g-image-cache.json")))
-	err.add(executionError(internalError, errored, fileutil.SecureFiles("d2g-image-cache.json")))
 }
 
 func (ic *ImageCache) loadFromFile(stateFile string) {
@@ -304,12 +370,16 @@ func (ic *ImageCache) loadFromFile(stateFile string) {
 	}
 }
 
-func (dtf *D2GTaskFeature) evaluateCommandPlaceholders(imageID string) {
+func (dtf *D2GTaskFeature) evaluateCommandPlaceholders(imageID string, taskDir string) {
 	videoDevice, _ := dtf.task.getVariable("TASKCLUSTER_VIDEO_DEVICE")
+	dockerNetwork, _ := dtf.task.getVariable("TASKCLUSTER_DOCKER_NETWORK")
+	proxyGateway, _ := dtf.task.getVariable("TASKCLUSTER_PROXY_GATEWAY")
 	placeholders := strings.NewReplacer(
 		"__D2G_IMAGE_ID__", imageID,
-		"__TASK_DIR__", taskContext.TaskDir,
+		"__TASK_DIR__", taskDir,
 		"__TASKCLUSTER_VIDEO_DEVICE__", videoDevice,
+		"__TASKCLUSTER_DOCKER_NETWORK__", dockerNetwork,
+		"__TASKCLUSTER_PROXY_GATEWAY__", proxyGateway,
 	)
 
 	// Update commands in the payload so that

--- a/workers/generic-worker/d2g_gc_linux.go
+++ b/workers/generic-worker/d2g_gc_linux.go
@@ -1,0 +1,17 @@
+//go:build linux
+
+package main
+
+import "os"
+
+// removeD2GCacheFile safely removes the d2g-image-cache.json file
+// with mutex protection for concurrent task execution (capacity > 1)
+func removeD2GCacheFile() error {
+	d2gCacheMutex.Lock()
+	defer d2gCacheMutex.Unlock()
+	err := os.Remove("d2g-image-cache.json")
+	if os.IsNotExist(err) {
+		return nil
+	}
+	return err
+}

--- a/workers/generic-worker/d2g_gc_other.go
+++ b/workers/generic-worker/d2g_gc_other.go
@@ -1,0 +1,7 @@
+//go:build !linux
+
+package main
+
+func removeD2GCacheFile() error {
+	return nil
+}

--- a/workers/generic-worker/d2g_multiuser_test.go
+++ b/workers/generic-worker/d2g_multiuser_test.go
@@ -13,6 +13,7 @@ import (
 )
 
 func TestD2GWithChainOfTrust(t *testing.T) {
+	skipInDockerIfNoDocker(t)
 	setup(t)
 	payload := dockerworker.DockerWorkerPayload{
 		Command: []string{"/bin/bash", "-c", "echo hello"},

--- a/workers/generic-worker/d2g_test.go
+++ b/workers/generic-worker/d2g_test.go
@@ -16,6 +16,7 @@ import (
 )
 
 func TestD2GWithValidDockerWorkerPayload(t *testing.T) {
+	skipInDockerIfNoDocker(t)
 	setup(t)
 	testTime := tcclient.Time(time.Now().AddDate(0, 0, 1))
 	image := map[string]any{
@@ -71,6 +72,7 @@ func TestD2GWithValidDockerWorkerPayload(t *testing.T) {
 }
 
 func TestD2GVolumeArtifacts(t *testing.T) {
+	skipInDockerIfNoDocker(t)
 	setup(t)
 	testTime := tcclient.Time(time.Now().AddDate(0, 0, 1))
 	image := map[string]any{
@@ -142,6 +144,7 @@ func TestD2GVolumeArtifacts(t *testing.T) {
 }
 
 func TestD2GArtifactDoesNotExist(t *testing.T) {
+	skipInDockerIfNoDocker(t)
 	setup(t)
 	testTime := tcclient.Time(time.Now().AddDate(0, 0, 1))
 	image := map[string]any{
@@ -248,6 +251,7 @@ func TestD2GWithInvalidDockerWorkerPayload(t *testing.T) {
 }
 
 func TestD2GIssue6789(t *testing.T) {
+	skipInDockerIfNoDocker(t)
 	setup(t)
 	payload := dockerworker.DockerWorkerPayload{
 		Command: []string{
@@ -284,6 +288,7 @@ func TestD2GIssue6789(t *testing.T) {
 }
 
 func TestD2GWithValidScopes(t *testing.T) {
+	skipInDockerIfNoDocker(t)
 	setup(t)
 	image := map[string]any{
 		"name": "ubuntu:latest",
@@ -377,6 +382,7 @@ func TestD2GWithInvalidScopes(t *testing.T) {
 }
 
 func TestD2GLoopbackVideoDevice(t *testing.T) {
+	skipInDockerIfNoDocker(t)
 	setup(t)
 	image := map[string]any{
 		"name": "ubuntu:latest",
@@ -422,6 +428,7 @@ func TestD2GLoopbackVideoDevice(t *testing.T) {
 }
 
 func TestD2GLoopbackVideoDeviceWithWorkerPoolScopes(t *testing.T) {
+	skipInDockerIfNoDocker(t)
 	setup(t)
 	image := map[string]any{
 		"name": "ubuntu:latest",
@@ -467,6 +474,7 @@ func TestD2GLoopbackVideoDeviceWithWorkerPoolScopes(t *testing.T) {
 }
 
 func TestD2GLoopbackVideoDeviceNonRootUserInVideoGroup(t *testing.T) {
+	skipInDockerIfNoDocker(t)
 	setup(t)
 	image := map[string]any{
 		"name": "ubuntu:latest",
@@ -518,6 +526,7 @@ func TestD2GLoopbackVideoDeviceNonRootUserInVideoGroup(t *testing.T) {
 }
 
 func TestD2GLoopbackVideoDeviceNonRootUserNotInVideoGroup(t *testing.T) {
+	skipInDockerIfNoDocker(t)
 	setup(t)
 	image := map[string]any{
 		"name": "ubuntu:latest",
@@ -569,6 +578,7 @@ func TestD2GLoopbackVideoDeviceNonRootUserNotInVideoGroup(t *testing.T) {
 }
 
 func TestD2GLoopbackAudioDevice(t *testing.T) {
+	skipInDockerIfNoDocker(t)
 	setup(t)
 	image := map[string]any{
 		"name": "ubuntu:latest",
@@ -617,6 +627,7 @@ func TestD2GLoopbackAudioDevice(t *testing.T) {
 }
 
 func TestD2GLoopbackAudioDeviceWithWorkerPoolScopes(t *testing.T) {
+	skipInDockerIfNoDocker(t)
 	setup(t)
 	image := map[string]any{
 		"name": "ubuntu:latest",
@@ -665,6 +676,7 @@ func TestD2GLoopbackAudioDeviceWithWorkerPoolScopes(t *testing.T) {
 }
 
 func TestD2GLoopbackAudioDeviceNonRootUserInAudioGroup(t *testing.T) {
+	skipInDockerIfNoDocker(t)
 	setup(t)
 	image := map[string]any{
 		"name": "ubuntu:latest",
@@ -718,6 +730,7 @@ func TestD2GLoopbackAudioDeviceNonRootUserInAudioGroup(t *testing.T) {
 }
 
 func TestD2GLoopbackAudioDeviceNonRootUserNotInAudioGroup(t *testing.T) {
+	skipInDockerIfNoDocker(t)
 	setup(t)
 	image := map[string]any{
 		"name": "ubuntu:latest",
@@ -805,6 +818,7 @@ func TestD2GDevicesWithoutAllScopes(t *testing.T) {
 }
 
 func TestD2GHostSharedMemory(t *testing.T) {
+	skipInDockerIfNoDocker(t)
 	setup(t)
 	image := map[string]any{
 		"name": "ubuntu:latest",
@@ -850,6 +864,7 @@ func TestD2GHostSharedMemory(t *testing.T) {
 }
 
 func TestD2GTaskclusterProxy(t *testing.T) {
+	skipInDockerIfNoDocker(t)
 	setup(t)
 
 	dependentTaskID := CreateArtifactFromFile(t, "SampleArtifacts/_/X.txt", "SampleArtifacts/_/X.txt")
@@ -941,6 +956,7 @@ type (
 )
 
 func TestD2GChainOfTrustNamedDockerImage(t *testing.T) {
+	skipInDockerIfNoDocker(t)
 
 	setup(t)
 	image := d2g.NamedDockerImage{
@@ -969,6 +985,7 @@ func TestD2GChainOfTrustNamedDockerImage(t *testing.T) {
 }
 
 func TestD2GChainOfTrustDockerImageName(t *testing.T) {
+	skipInDockerIfNoDocker(t)
 
 	setup(t)
 	image := d2g.DockerImageName("taskcluster/taskcluster-proxy:v81.0.2")
@@ -994,6 +1011,7 @@ func TestD2GChainOfTrustDockerImageName(t *testing.T) {
 }
 
 func TestD2GChainOfTrustDockerImageArtifact(t *testing.T) {
+	skipInDockerIfNoDocker(t)
 
 	setup(t)
 	taskID := CreateArtifactFromFile(t, "docker-images/taskcluster-proxy-v81.0.2.tar.gz", "public/taskcluster-proxy.tar.gz")
@@ -1053,6 +1071,7 @@ func TestD2GChainOfTrustIndexedDockerImage(t *testing.T) {
 // Run 2 (warm): the file cache is hit (no re-download), the d2g image cache
 // is hit (no docker load), and no file is copied to the task directory.
 func TestD2GDockerImageArtifactCaching(t *testing.T) {
+	skipInDockerIfNoDocker(t)
 	setup(t)
 	taskID := CreateArtifactFromFile(t, "docker-images/taskcluster-proxy-v81.0.2.tar.gz", "public/taskcluster-proxy.tar.gz")
 

--- a/workers/generic-worker/feature.go
+++ b/workers/generic-worker/feature.go
@@ -11,6 +11,14 @@ type (
 		Name() string
 	}
 
+	// DisabledReasonProvider is an optional interface that Features can
+	// implement to explain why they are disabled (e.g. incompatible with
+	// the current capacity setting). When a requested feature is not
+	// enabled, the error handler checks for this interface.
+	DisabledReasonProvider interface {
+		DisabledReason() string
+	}
+
 	TaskFeature interface {
 		RequiredScopes() scopes.Required
 		ReservedArtifacts() []string

--- a/workers/generic-worker/fileutil/fileutil.go
+++ b/workers/generic-worker/fileutil/fileutil.go
@@ -123,6 +123,24 @@ func CreateDir(dir string) error {
 	return os.MkdirAll(dir, 0700)
 }
 
+func CopyDir(src, dst string) error {
+	info, err := os.Lstat(src)
+	if err != nil {
+		return err
+	}
+	if !info.IsDir() {
+		return fmt.Errorf("source is not a directory: %s", src)
+	}
+
+	if _, err := os.Stat(dst); err == nil {
+		return fmt.Errorf("destination already exists: %s", dst)
+	} else if !os.IsNotExist(err) {
+		return err
+	}
+
+	return os.CopyFS(dst, os.DirFS(src))
+}
+
 func Unarchive(source, destination, format string) error {
 	f, err := os.Open(source)
 	if err != nil {

--- a/workers/generic-worker/fileutil/fileutil.go
+++ b/workers/generic-worker/fileutil/fileutil.go
@@ -123,24 +123,6 @@ func CreateDir(dir string) error {
 	return os.MkdirAll(dir, 0700)
 }
 
-func CopyDir(src, dst string) error {
-	info, err := os.Lstat(src)
-	if err != nil {
-		return err
-	}
-	if !info.IsDir() {
-		return fmt.Errorf("source is not a directory: %s", src)
-	}
-
-	if _, err := os.Stat(dst); err == nil {
-		return fmt.Errorf("destination already exists: %s", dst)
-	} else if !os.IsNotExist(err) {
-		return err
-	}
-
-	return os.CopyFS(dst, os.DirFS(src))
-}
-
 func Unarchive(source, destination, format string) error {
 	f, err := os.Open(source)
 	if err != nil {

--- a/workers/generic-worker/garbagecollector.go
+++ b/workers/generic-worker/garbagecollector.go
@@ -44,18 +44,24 @@ func (r Resources) Swap(i, j int) {
 	r[i], r[j] = r[j], r[i]
 }
 
-// Note ideally this would run in an independent thread, but since we have one
-// job at a time, we can sequence it between task runs. Also it should be
-// independent of mounts feature, but let's go with it here as currently that
-// is the only feature that uses it.
-func runGarbageCollection(r Resources) error {
+// runGarbageCollection frees disk space by evicting cached resources and,
+// when no tasks are running, pruning unused Docker resources. It runs in
+// the main loop goroutine between claim attempts.
+//
+// When tasksRunning is true, docker prune is skipped because it could
+// remove images that a D2G task has loaded but not yet started a
+// container for.
+//
+// It should be independent of mounts feature, but let's go with it here
+// as currently that is the only feature that uses it.
+func runGarbageCollection(r Resources, tasksRunning bool) error {
 	currentFreeSpace, err := freeDiskSpaceBytes(config.TasksDir)
 	if err != nil {
 		return fmt.Errorf("could not calculate free disk space in dir %v due to error %#v", config.TasksDir, err)
 	}
 	requiredFreeSpace := requiredSpaceBytes()
 
-	if currentFreeSpace < requiredFreeSpace && config.D2GEnabled() {
+	if currentFreeSpace < requiredFreeSpace && config.D2GEnabled() && !tasksRunning {
 		err := host.Run("docker", "volume", "prune", "--all", "--force")
 		if err != nil {
 			return fmt.Errorf("could not run docker volume prune to garbage collect due to error %#v", err)
@@ -67,7 +73,7 @@ func runGarbageCollection(r Resources) error {
 		}
 	}
 
-	if currentFreeSpace < requiredFreeSpace && config.D2GEnabled() {
+	if currentFreeSpace < requiredFreeSpace && config.D2GEnabled() && !tasksRunning {
 		err := host.Run("docker", "system", "prune", "--all", "--force")
 		if err != nil {
 			return fmt.Errorf("could not run docker system prune to garbage collect due to error %#v", err)

--- a/workers/generic-worker/garbagecollector.go
+++ b/workers/generic-worker/garbagecollector.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	"os"
 
 	"github.com/taskcluster/taskcluster/v99/workers/generic-worker/host"
 )
@@ -50,9 +49,9 @@ func (r Resources) Swap(i, j int) {
 // independent of mounts feature, but let's go with it here as currently that
 // is the only feature that uses it.
 func runGarbageCollection(r Resources) error {
-	currentFreeSpace, err := freeDiskSpaceBytes(taskContext.TaskDir)
+	currentFreeSpace, err := freeDiskSpaceBytes(config.TasksDir)
 	if err != nil {
-		return fmt.Errorf("could not calculate free disk space in dir %v due to error %#v", taskContext.TaskDir, err)
+		return fmt.Errorf("could not calculate free disk space in dir %v due to error %#v", config.TasksDir, err)
 	}
 	requiredFreeSpace := requiredSpaceBytes()
 
@@ -62,9 +61,9 @@ func runGarbageCollection(r Resources) error {
 			return fmt.Errorf("could not run docker volume prune to garbage collect due to error %#v", err)
 		}
 
-		currentFreeSpace, err = freeDiskSpaceBytes(taskContext.TaskDir)
+		currentFreeSpace, err = freeDiskSpaceBytes(config.TasksDir)
 		if err != nil {
-			return fmt.Errorf("could not calculate free disk space in dir %v due to error %#v", taskContext.TaskDir, err)
+			return fmt.Errorf("could not calculate free disk space in dir %v due to error %#v", config.TasksDir, err)
 		}
 	}
 
@@ -74,14 +73,14 @@ func runGarbageCollection(r Resources) error {
 			return fmt.Errorf("could not run docker system prune to garbage collect due to error %#v", err)
 		}
 
-		err = os.Remove("d2g-image-cache.json")
-		if err != nil && !os.IsNotExist(err) {
+		err = removeD2GCacheFile()
+		if err != nil {
 			return fmt.Errorf("could not remove d2g-image-cache.json due to error %#v", err)
 		}
 
-		currentFreeSpace, err = freeDiskSpaceBytes(taskContext.TaskDir)
+		currentFreeSpace, err = freeDiskSpaceBytes(config.TasksDir)
 		if err != nil {
-			return fmt.Errorf("could not calculate free disk space in dir %v due to error %#v", taskContext.TaskDir, err)
+			return fmt.Errorf("could not calculate free disk space in dir %v due to error %#v", config.TasksDir, err)
 		}
 	}
 
@@ -96,9 +95,9 @@ func runGarbageCollection(r Resources) error {
 			return err
 		}
 
-		currentFreeSpace, err = freeDiskSpaceBytes(taskContext.TaskDir)
+		currentFreeSpace, err = freeDiskSpaceBytes(config.TasksDir)
 		if err != nil {
-			return fmt.Errorf("could not calculate free disk space in dir %v due to error %#v", taskContext.TaskDir, err)
+			return fmt.Errorf("could not calculate free disk space in dir %v due to error %#v", config.TasksDir, err)
 		}
 	}
 

--- a/workers/generic-worker/graceful/graceful.go
+++ b/workers/generic-worker/graceful/graceful.go
@@ -49,8 +49,11 @@ func OnTerminationRequest(id string, f GracefulTerminationFunc) func() {
 	}
 }
 
-// A graceful termination has been requested. Set a flag so that no further
-// tasks are claimed, and call all registered callbacks.
+// Terminate signals that a graceful termination has been requested. It sets a
+// flag so that no further tasks are claimed, and fires all registered callbacks
+// in separate goroutines (fire-and-forget). Terminate returns before callbacks
+// execute; callers that need to wait for completion should use an external
+// synchronization mechanism (e.g. WaitGroup).
 // If finishTasks is true, tasks should be allowed to complete.
 // If finishTasks is false, tasks should be aborted immediately.
 func Terminate(finishTasks bool) {

--- a/workers/generic-worker/graceful/graceful.go
+++ b/workers/generic-worker/graceful/graceful.go
@@ -1,6 +1,9 @@
 package graceful
 
-import "sync"
+import (
+	"fmt"
+	"sync"
+)
 
 type GracefulTerminationFunc func(bool)
 
@@ -16,6 +19,14 @@ var (
 
 	// callbacks for graceful termination, keyed by unique ID (e.g., task ID)
 	callbacks = make(map[string]GracefulTerminationFunc)
+
+	// callbackWG tracks in-flight callback goroutines launched by Terminate
+	// (or by OnTerminationRequest when termination has already happened),
+	// so a deregister call can wait for the matching goroutine to finish
+	// before returning. Without this, Stop()→deregister could return while
+	// the callback was still racing to mutate per-task state — yielding
+	// use-after-resolve behavior after Stop().
+	callbackWG sync.WaitGroup
 )
 
 // Return true if graceful termination has been requested
@@ -27,33 +38,43 @@ func TerminationRequested() bool {
 }
 
 // OnTerminationRequest sets up to call the given function (in a goroutine) when
-// a termination request is received. The id parameter should be unique (e.g., task ID).
-// Returns a function which, when called, will remove the callback.
-// Multiple callbacks can be registered with different IDs.
+// a termination request is received. The id parameter must be unique (e.g.,
+// task ID); registering with an id that's already in use panics, since silently
+// overwriting would lose the prior caller's callback.
+// Returns a function which, when called, removes the callback and waits for
+// any already-launched callback goroutine to complete before returning.
 func OnTerminationRequest(id string, f GracefulTerminationFunc) func() {
 	m.Lock()
-	defer m.Unlock()
-
+	if _, exists := callbacks[id]; exists {
+		m.Unlock()
+		panic(fmt.Sprintf("graceful: duplicate callback registration for id %q", id))
+	}
 	callbacks[id] = f
 
 	// If termination was already requested, call the callback immediately
 	// with the same finishTasks value that was originally passed to Terminate()
 	if terminationRequested {
-		go f(terminationFinishTasks)
+		callbackWG.Go(func() {
+			f(terminationFinishTasks)
+		})
 	}
+	m.Unlock()
 
 	return func() {
 		m.Lock()
-		defer m.Unlock()
 		delete(callbacks, id)
+		m.Unlock()
+		// Wait outside the mutex: callbacks may themselves try to take
+		// `m` (e.g. via TerminationRequested), and waiting under the
+		// lock would deadlock.
+		callbackWG.Wait()
 	}
 }
 
 // Terminate signals that a graceful termination has been requested. It sets a
 // flag so that no further tasks are claimed, and fires all registered callbacks
-// in separate goroutines (fire-and-forget). Terminate returns before callbacks
-// execute; callers that need to wait for completion should use an external
-// synchronization mechanism (e.g. WaitGroup).
+// in separate goroutines tracked by callbackWG so deregister calls can wait
+// for them to finish. Terminate itself returns before callbacks execute.
 // If finishTasks is true, tasks should be allowed to complete.
 // If finishTasks is false, tasks should be aborted immediately.
 func Terminate(finishTasks bool) {
@@ -68,12 +89,19 @@ func Terminate(finishTasks bool) {
 
 	// Call all registered callbacks
 	for _, cb := range callbacks {
-		go cb(finishTasks)
+		callbackWG.Go(func() {
+			cb(finishTasks)
+		})
 	}
 }
 
-// Reset the package to its initial state (useful in tests)
+// Reset the package to its initial state (useful in tests). Waits for any
+// in-flight callback goroutines from a prior Terminate before clearing
+// state, so a test that calls Reset can rely on no stray goroutines
+// surviving into the next test.
 func Reset() {
+	callbackWG.Wait()
+
 	m.Lock()
 	defer m.Unlock()
 

--- a/workers/generic-worker/gwconfig/config.go
+++ b/workers/generic-worker/gwconfig/config.go
@@ -161,17 +161,19 @@ func (c *Config) Validate() error {
 // Interactive, TaskclusterProxy.
 const PortsPerTask = 4
 
-// ValidatePortConfiguration checks that port ranges don't overlap when capacity > 1.
-// Each concurrent task slot uses an offset of PortsPerTask (4) ports from the base.
-// This validation ensures the configured base ports are spaced far enough apart
-// to avoid collisions.
+// ValidatePortConfiguration checks that port ranges don't overlap.
+// Each concurrent task slot uses an offset of PortsPerTask (4) ports from the
+// base; the validation ensures base ports are spaced far enough apart to
+// avoid collisions across slots.
+//
+// Even at capacity=1 we validate the four feature ports against each other
+// (e.g. livelogPortBase == taskclusterProxyPort would collide at bind time);
+// only the inter-slot spacing checks are skipped when capacity=1, because
+// there is only a single slot.
 func (c *Config) ValidatePortConfiguration() error {
-	if c.Capacity == 1 {
-		return nil
-	}
-
-	// Calculate port ranges for the maximum capacity
-	// Each slot uses offset = slot * PortsPerTask from the base.
+	// At capacity=1 only the base port itself is allocated per feature,
+	// so each "range" is the bare port. With higher capacity, each
+	// range spans PortsPerTask * (capacity-1) extra ports.
 	// Use uint32 to avoid uint16 overflow when base ports are near 65535.
 	maxOffset := uint32(c.Capacity-1) * uint32(PortsPerTask)
 

--- a/workers/generic-worker/gwconfig/config.go
+++ b/workers/generic-worker/gwconfig/config.go
@@ -143,6 +143,10 @@ func (c *Config) Validate() error {
 		}
 	}
 
+	if c.Capacity == 0 {
+		return fmt.Errorf("capacity must be at least 1 (got 0)")
+	}
+
 	// Validate port configuration for concurrent task execution
 	if err := c.ValidatePortConfiguration(); err != nil {
 		return err
@@ -153,7 +157,7 @@ func (c *Config) Validate() error {
 }
 
 // PortsPerTask is the number of ports allocated per concurrent task slot.
-// Used for port spacing validation. The 4 ports are: LiveLog GET, LiveLog PUT,
+// Used for port spacing validation. The 4 ports are: LiveLog PUT, LiveLog GET,
 // Interactive, TaskclusterProxy.
 const PortsPerTask = 4
 
@@ -167,14 +171,15 @@ func (c *Config) ValidatePortConfiguration() error {
 	}
 
 	// Calculate port ranges for the maximum capacity
-	// Each slot uses offset = slot * PortsPerTask from the base
-	maxOffset := uint16((c.Capacity - 1) * PortsPerTask)
+	// Each slot uses offset = slot * PortsPerTask from the base.
+	// Use uint32 to avoid uint16 overflow when base ports are near 65535.
+	maxOffset := uint32(c.Capacity-1) * uint32(PortsPerTask)
 
 	// Define port ranges: [start, end] inclusive
 	type portRange struct {
 		name  string
-		start uint16
-		end   uint16
+		start uint32
+		end   uint32
 	}
 
 	portRanges := []portRange{}
@@ -182,25 +187,36 @@ func (c *Config) ValidatePortConfiguration() error {
 		// LiveLog uses 2 consecutive ports (GET and PUT)
 		portRanges = append(portRanges, portRange{
 			name:  "livelogPortBase",
-			start: c.LiveLogPortBase,
-			end:   c.LiveLogPortBase + maxOffset + 1,
+			start: uint32(c.LiveLogPortBase),
+			end:   uint32(c.LiveLogPortBase) + maxOffset + 1,
 		})
 	}
 	if c.EnableInteractive {
 		// Interactive uses 1 port per slot
 		portRanges = append(portRanges, portRange{
 			name:  "interactivePort",
-			start: c.InteractivePort,
-			end:   c.InteractivePort + maxOffset,
+			start: uint32(c.InteractivePort),
+			end:   uint32(c.InteractivePort) + maxOffset,
 		})
 	}
 	if c.EnableTaskclusterProxy {
 		// TaskclusterProxy uses 1 port per slot
 		portRanges = append(portRanges, portRange{
 			name:  "taskclusterProxyPort",
-			start: c.TaskclusterProxyPort,
-			end:   c.TaskclusterProxyPort + maxOffset,
+			start: uint32(c.TaskclusterProxyPort),
+			end:   uint32(c.TaskclusterProxyPort) + maxOffset,
 		})
+	}
+
+	// Check that no range exceeds the valid port range
+	for _, r := range portRanges {
+		if r.end > 65535 {
+			return fmt.Errorf(
+				"port range for %s exceeds maximum port number with capacity=%d: %s needs ports %d-%d but max port is 65535; "+
+					"use a lower base port or reduce capacity",
+				r.name, c.Capacity, r.name, r.start, r.end,
+			)
+		}
 	}
 
 	if len(portRanges) < 2 {

--- a/workers/generic-worker/gwconfig/config_test.go
+++ b/workers/generic-worker/gwconfig/config_test.go
@@ -1,0 +1,117 @@
+package gwconfig
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidatePortConfiguration(t *testing.T) {
+	// Base config that should always pass validation (other than ports)
+	baseConfig := func() *Config {
+		return &Config{
+			PublicConfig: PublicConfig{
+				Capacity:                  1,
+				EnableInteractive:         true,
+				EnableLiveLog:             true,
+				EnableTaskclusterProxy:    true,
+				LiveLogPortBase:           60000,
+				InteractivePort:           53000,
+				TaskclusterProxyPort:      8080,
+				CachesDir:                 "/tmp/caches",
+				ClientID:                  "test-client",
+				DownloadsDir:              "/tmp/downloads",
+				Ed25519SigningKeyLocation: "/tmp/key",
+				LiveLogExecutable:         "/usr/bin/livelog",
+				ProvisionerID:             "test-provisioner",
+				RootURL:                   "https://example.com",
+				TasksDir:                  "/tmp/tasks",
+				WorkerGroup:               "test-group",
+				WorkerID:                  "test-worker",
+				WorkerType:                "test-type",
+			},
+			PrivateConfig: PrivateConfig{
+				AccessToken: "test-token",
+			},
+		}
+	}
+
+	t.Run("capacity=1 skips validation", func(t *testing.T) {
+		c := baseConfig()
+		c.Capacity = 1
+		// Even with overlapping ports, capacity=1 should skip validation
+		c.LiveLogPortBase = 8080
+		c.TaskclusterProxyPort = 8080
+		err := c.ValidatePortConfiguration()
+		require.NoError(t, err)
+	})
+
+	t.Run("non-overlapping ports pass", func(t *testing.T) {
+		c := baseConfig()
+		c.Capacity = 5
+		c.LiveLogPortBase = 60000     // Uses 60000-60019 (5 slots * 4 ports)
+		c.InteractivePort = 53000     // Uses 53000-53016
+		c.TaskclusterProxyPort = 8080 // Uses 8080-8096
+		err := c.ValidatePortConfiguration()
+		require.NoError(t, err)
+	})
+
+	t.Run("overlapping LiveLog and Interactive fails", func(t *testing.T) {
+		c := baseConfig()
+		c.Capacity = 5
+		c.LiveLogPortBase = 60000
+		c.InteractivePort = 60010 // Overlaps with LiveLog range
+		c.TaskclusterProxyPort = 8080
+		err := c.ValidatePortConfiguration()
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "port range overlap detected")
+		require.Contains(t, err.Error(), "livelogPortBase")
+		require.Contains(t, err.Error(), "interactivePort")
+	})
+
+	t.Run("overlapping LiveLog and TaskclusterProxy fails", func(t *testing.T) {
+		c := baseConfig()
+		c.Capacity = 3
+		c.LiveLogPortBase = 8080
+		c.InteractivePort = 53000
+		c.TaskclusterProxyPort = 8085 // Overlaps with LiveLog range
+		err := c.ValidatePortConfiguration()
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "port range overlap detected")
+	})
+
+	t.Run("identical ports fail", func(t *testing.T) {
+		c := baseConfig()
+		c.Capacity = 2
+		c.LiveLogPortBase = 8080
+		c.InteractivePort = 8080
+		c.TaskclusterProxyPort = 8080
+		err := c.ValidatePortConfiguration()
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "port range overlap detected")
+	})
+
+	t.Run("high capacity requires more spacing", func(t *testing.T) {
+		c := baseConfig()
+		c.Capacity = 10
+		// With capacity 10, each port range spans 36 ports (9 slots * 4 offset)
+		c.LiveLogPortBase = 60000 // 60000-60037
+		c.InteractivePort = 60030 // 60030-60066 - overlaps!
+		c.TaskclusterProxyPort = 8080
+		err := c.ValidatePortConfiguration()
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "port range overlap detected")
+	})
+
+	t.Run("disabled features are excluded", func(t *testing.T) {
+		c := baseConfig()
+		c.Capacity = 5
+		c.EnableLiveLog = false
+		// Overlaps with LiveLog range, but LiveLog is disabled so should pass.
+		c.LiveLogPortBase = 60000
+		c.InteractivePort = 60010
+		c.TaskclusterProxyPort = 8080
+		err := c.ValidatePortConfiguration()
+		require.NoError(t, err)
+	})
+}

--- a/workers/generic-worker/gwconfig/config_test.go
+++ b/workers/generic-worker/gwconfig/config_test.go
@@ -36,11 +36,23 @@ func TestValidatePortConfiguration(t *testing.T) {
 		}
 	}
 
-	t.Run("capacity=1 skips validation", func(t *testing.T) {
+	t.Run("capacity=1 still rejects colliding base ports", func(t *testing.T) {
 		c := baseConfig()
 		c.Capacity = 1
-		// Even with overlapping ports, capacity=1 should skip validation
+		// LiveLogPortBase and TaskclusterProxyPort both 8080 collide at
+		// bind time even at capacity=1, so this must fail validation.
 		c.LiveLogPortBase = 8080
+		c.TaskclusterProxyPort = 8080
+		err := c.ValidatePortConfiguration()
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "port range overlap detected")
+	})
+
+	t.Run("capacity=1 with non-overlapping base ports passes", func(t *testing.T) {
+		c := baseConfig()
+		c.Capacity = 1
+		c.LiveLogPortBase = 60000
+		c.InteractivePort = 53000
 		c.TaskclusterProxyPort = 8080
 		err := c.ValidatePortConfiguration()
 		require.NoError(t, err)

--- a/workers/generic-worker/helper_insecure_test.go
+++ b/workers/generic-worker/helper_insecure_test.go
@@ -3,6 +3,7 @@
 package main
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/taskcluster/taskcluster/v99/workers/generic-worker/gwconfig"
@@ -11,11 +12,23 @@ import (
 
 func engineTestSetup(t *testing.T, testConfig *gwconfig.Config) {
 	t.Helper()
+	runningTests = true
 	testConfig.EnableD2G(t)
 	// Needed for tests that don't call RunWorker()
 	// but test methods/functions directly
 	taskContext = &TaskContext{
 		User:    &gwruntime.OSUser{},
 		TaskDir: testdataDir,
+	}
+}
+
+func printEnvVar(varName string) [][]string {
+	return [][]string{
+		{
+			"/usr/bin/env",
+			"bash",
+			"-c",
+			fmt.Sprintf("echo %s=$%s", varName, varName),
+		},
 	}
 }

--- a/workers/generic-worker/helper_multiuser_test.go
+++ b/workers/generic-worker/helper_multiuser_test.go
@@ -3,12 +3,16 @@
 package main
 
 import (
+	"fmt"
+	"os"
 	"path/filepath"
 	"runtime"
 	"testing"
+	"time"
 
 	"github.com/taskcluster/taskcluster/v99/clients/client-go/tcqueue"
 	"github.com/taskcluster/taskcluster/v99/workers/generic-worker/gwconfig"
+	gwruntime "github.com/taskcluster/taskcluster/v99/workers/generic-worker/runtime"
 )
 
 func expectChainOfTrustKeyNotSecureMessage(t *testing.T, td *tcqueue.TaskDefinitionRequest, payload GenericWorkerPayload) {
@@ -37,11 +41,38 @@ func expectChainOfTrustKeyNotSecureMessage(t *testing.T, td *tcqueue.TaskDefinit
 
 func engineTestSetup(t *testing.T, testConfig *gwconfig.Config) {
 	t.Helper()
-	runningTests = true
-	// macOS CI tests to not run in headless in order to exercise the launch agent as much as possible
+	// macOS CI tests do not run in headless in order to exercise the launch agent as much as possible
 	testConfig.HeadlessTasks = (runtime.GOOS != "darwin")
 	testConfig.EnableRunTaskAsCurrentUser = true
 	testConfig.EnableD2G(t)
+
+	// Set runningTests for both paths so the worker updates global taskContext
+	runningTests = true
+
+	if os.Getenv("GW_IN_DOCKER") == "1" {
+		// In Docker, exercise the real headless user creation path.
+		// CreateTaskContext will see GW_IN_DOCKER and skip the next-task-user.json shortcut.
+		// Create a temporary user for tests that directly access taskContext
+		// without going through RunWorker().
+		taskDirName := fmt.Sprintf("task_%d", time.Now().UnixNano())
+		if len(taskDirName) > 20 {
+			taskDirName = taskDirName[:20]
+		}
+		taskUser := &gwruntime.OSUser{
+			Name:     taskDirName,
+			Password: gwruntime.GeneratePassword(),
+		}
+		err := taskUser.CreateNew(false)
+		if err != nil {
+			t.Fatalf("Could not create test user: %v", err)
+		}
+		taskContext = &TaskContext{
+			User:    taskUser,
+			TaskDir: testdataDir,
+		}
+		return
+	}
+
 	// Needed for tests that don't call RunWorker()
 	// but test methods/functions directly
 	taskUserCredentials, err := StoredUserCredentials(filepath.Join(cwd, "next-task-user.json"))

--- a/workers/generic-worker/helper_posix_test.go
+++ b/workers/generic-worker/helper_posix_test.go
@@ -27,7 +27,17 @@ func makeDirWorldWritable(t *testing.T, dir string) {
 // works directly, and we chmod 0777 the result.
 func worldWritableTempDir(t *testing.T, pattern string) string {
 	t.Helper()
-	dir, err := os.MkdirTemp("", pattern)
+	// In Docker, /tmp may be on a different filesystem than the source mount,
+	// causing cross-device rename failures when persisting caches. Use a temp
+	// dir on the same filesystem as the worker directory instead.
+	tmpBase := ""
+	if os.Getenv("GW_IN_DOCKER") == "1" {
+		tmpBase = filepath.Join(cwd, ".tmp-test")
+		if err := os.MkdirAll(tmpBase, 0777); err != nil {
+			t.Fatalf("Failed to create temp base dir: %v", err)
+		}
+	}
+	dir, err := os.MkdirTemp(tmpBase, pattern)
 	if err != nil {
 		t.Fatalf("Failed to create temp dir: %v", err)
 	}

--- a/workers/generic-worker/helper_test.go
+++ b/workers/generic-worker/helper_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/taskcluster/taskcluster/v99/internal/mocktc/tc"
 	"github.com/taskcluster/taskcluster/v99/tools/d2g/dockerworker"
 	"github.com/taskcluster/taskcluster/v99/workers/generic-worker/fileutil"
+	"github.com/taskcluster/taskcluster/v99/workers/generic-worker/graceful"
 	"github.com/taskcluster/taskcluster/v99/workers/generic-worker/gwconfig"
 )
 
@@ -360,6 +361,7 @@ func GWTest(t *testing.T) *Test {
 			// Need common caches directory across tests, since files
 			// directory-caches.json and file-caches.json are not per-test.
 			CachesDir:       cachesDir,
+			Capacity:        1,
 			CleanUpTaskDirs: false,
 			ClientID:        os.Getenv("TASKCLUSTER_CLIENT_ID"),
 			DisableReboots:  true,
@@ -520,6 +522,7 @@ func (gwtest *Test) Teardown() {
 	taskContext = nil
 	globalTestName = ""
 	config = nil
+	graceful.Reset()
 	// gwtest.srv nil if no services
 	if gwtest.srv != nil {
 		err = gwtest.srv.Shutdown(context.Background())

--- a/workers/generic-worker/helper_test.go
+++ b/workers/generic-worker/helper_test.go
@@ -11,6 +11,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"runtime"
 	"slices"
@@ -41,6 +42,17 @@ var (
 	testdataDir    = filepath.Join(cwd, "testdata")
 	cachesDir      = filepath.Join(cwd, "caches")
 )
+
+// skipInDockerIfNoDocker skips the test when running inside the GW test
+// Docker container and Docker is not available (no Docker-in-Docker).
+func skipInDockerIfNoDocker(t *testing.T) {
+	t.Helper()
+	if os.Getenv("GW_IN_DOCKER") == "1" {
+		if err := exec.Command("docker", "info").Run(); err != nil {
+			t.Skip("Skipping in Docker: test requires Docker-in-Docker which is not available")
+		}
+	}
+}
 
 func setup(t *testing.T) {
 	t.Helper()

--- a/workers/generic-worker/host/host_windows.go
+++ b/workers/generic-worker/host/host_windows.go
@@ -1,6 +1,9 @@
 package host
 
-import "log"
+import (
+	"log"
+	"strings"
+)
 
 func ImmediateReboot() {
 	log.Println("Immediate reboot being issued...")
@@ -8,6 +11,12 @@ func ImmediateReboot() {
 	if err != nil {
 		log.Fatal(err)
 	}
+}
+
+// EscapePowerShellSingleQuote escapes single quotes for use inside a
+// PowerShell single-quoted string by doubling them (e.g. "it's" → "it”s").
+func EscapePowerShellSingleQuote(s string) string {
+	return strings.ReplaceAll(s, "'", "''")
 }
 
 func ImmediateShutdown(cause string) {

--- a/workers/generic-worker/insecure.go
+++ b/workers/generic-worker/insecure.go
@@ -28,8 +28,12 @@ const (
 var runningTests bool = false
 
 // validateEngineConfig validates engine-specific configuration.
-// For insecure engine, capacity > 1 is always allowed.
 func validateEngineConfig() error {
+	if config.Capacity > 1 {
+		log.Printf("WARNING: insecure engine with capacity=%d provides "+
+			"NO credential or file system isolation between concurrent tasks. "+
+			"Use multiuser engine for production workloads.", config.Capacity)
+	}
 	return nil
 }
 

--- a/workers/generic-worker/insecure.go
+++ b/workers/generic-worker/insecure.go
@@ -105,6 +105,12 @@ func platformDataForTaskContext(ctx *TaskContext) (*process.PlatformData, error)
 	return process.TaskUserPlatformData(ctx.User, false)
 }
 
+// deleteTaskUserOnCleanup is a no-op on the insecure engine: tasks
+// share the worker process's user, so there is nothing per-task to
+// remove. The multiuser engine's implementation deletes the headless
+// per-task user.
+func deleteTaskUserOnCleanup(_ *TaskContext) {}
+
 func deleteDir(path string) error {
 	log.Print("Removing directory '" + path + "'...")
 	err := host.Run("/bin/chmod", "-R", "u+w", path)

--- a/workers/generic-worker/insecure_posix.go
+++ b/workers/generic-worker/insecure_posix.go
@@ -8,10 +8,10 @@ import (
 	"github.com/taskcluster/taskcluster/v99/workers/generic-worker/process"
 )
 
-func MkdirAllTaskUser(dir string, pd *process.PlatformData) error {
+func MkdirAllTaskUser(dir string, ctx *TaskContext, pd *process.PlatformData) error {
 	return os.MkdirAll(dir, 0700)
 }
 
-func CreateFileAsTaskUser(file string, pd *process.PlatformData) (*os.File, error) {
+func CreateFileAsTaskUser(file string, ctx *TaskContext, pd *process.PlatformData) (*os.File, error) {
 	return os.Create(file)
 }

--- a/workers/generic-worker/insecure_test.go
+++ b/workers/generic-worker/insecure_test.go
@@ -6,10 +6,13 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/mcuadros/go-defaults"
+	"github.com/stretchr/testify/require"
 )
 
 // Note we don't want to set config.NumberOfTasksToRun on multiuser engine
@@ -17,6 +20,10 @@ import (
 // engine.
 func TestNewTaskDirectoryForEachTask(t *testing.T) {
 	setup(t)
+	origNumberOfTasksToRun := config.NumberOfTasksToRun
+	t.Cleanup(func() {
+		config.NumberOfTasksToRun = origNumberOfTasksToRun
+	})
 	config.NumberOfTasksToRun = 3
 	payload := GenericWorkerPayload{
 		Command:    returnExitCode(0),
@@ -58,4 +65,175 @@ func TestNewTaskDirectoryForEachTask(t *testing.T) {
 	if taskDirs != config.NumberOfTasksToRun*2 {
 		t.Fatalf("Expected to find %v directories in total, but found %v", config.NumberOfTasksToRun*2, taskDirs)
 	}
+}
+
+// TestConcurrentTaskExecution verifies that when capacity > 1, tasks run concurrently.
+// Each task sleeps for a period and writes a timestamp. If tasks run in parallel,
+// total execution time should be approximately equal to one task duration, not the sum.
+func TestConcurrentTaskExecution(t *testing.T) {
+	setup(t)
+
+	// Save original config values and restore after test
+	origCapacity := config.Capacity
+	origNumberOfTasksToRun := config.NumberOfTasksToRun
+	t.Cleanup(func() {
+		config.Capacity = origCapacity
+		config.NumberOfTasksToRun = origNumberOfTasksToRun
+	})
+
+	// Configure for concurrent execution
+	config.Capacity = 2
+	config.NumberOfTasksToRun = 2
+
+	// Each task sleeps for 3 seconds
+	// If running concurrently, total time should be ~3-4 seconds
+	// If running sequentially, total time would be ~6+ seconds
+	taskSleepSeconds := uint(3)
+	payload := GenericWorkerPayload{
+		Command:    sleep(taskSleepSeconds),
+		MaxRunTime: 30,
+	}
+	defaults.SetDefaults(&payload)
+
+	// Schedule 2 tasks
+	td1 := testTask(t)
+	td2 := testTask(t)
+	taskID1 := scheduleTask(t, td1, payload)
+	taskID2 := scheduleTask(t, td2, payload)
+
+	t.Logf("Scheduled tasks: %s, %s", taskID1, taskID2)
+	t.Logf("Capacity: %d, Each task sleeps for %d seconds", config.Capacity, taskSleepSeconds)
+
+	// Measure execution time
+	startTime := time.Now()
+	execute(t, TASKS_COMPLETE)
+	elapsed := time.Since(startTime)
+
+	t.Logf("Total execution time: %v", elapsed)
+
+	// Verify tasks completed successfully
+	queue := serviceFactory.Queue(config.Credentials(), config.RootURL)
+
+	status1, err := queue.Status(taskID1)
+	require.NoError(t, err)
+	require.Equal(t, "completed", status1.Status.Runs[0].State, "Task 1 should complete successfully")
+	require.Equal(t, "completed", status1.Status.Runs[0].ReasonResolved, "Task 1 should resolve as completed")
+
+	status2, err := queue.Status(taskID2)
+	require.NoError(t, err)
+	require.Equal(t, "completed", status2.Status.Runs[0].State, "Task 2 should complete successfully")
+	require.Equal(t, "completed", status2.Status.Runs[0].ReasonResolved, "Task 2 should resolve as completed")
+
+	// Verify concurrent execution by checking timing
+	// Allow some overhead (1.5x single task time) but should be much less than sequential (2x)
+	maxExpectedDuration := time.Duration(float64(taskSleepSeconds)*1.5) * time.Second
+	minSequentialDuration := time.Duration(taskSleepSeconds*2) * time.Second
+
+	t.Logf("Expected max concurrent duration: %v", maxExpectedDuration)
+	t.Logf("Sequential duration would be >= %v", minSequentialDuration)
+
+	if elapsed >= minSequentialDuration {
+		t.Errorf("Tasks appear to have run sequentially (took %v, expected < %v for concurrent execution)", elapsed, minSequentialDuration)
+	}
+
+	// Verify each task ran in its own directory
+	taskDirs := 0
+	err = filepath.WalkDir(config.TasksDir, func(path string, d os.DirEntry, err error) error {
+		if d.IsDir() && strings.HasPrefix(d.Name(), "task_") {
+			taskDirs++
+			t.Logf("Found task directory: %s", d.Name())
+		}
+		return nil
+	})
+	require.NoError(t, err)
+	require.Equal(t, 2, taskDirs, "Should have 2 task directories for 2 concurrent tasks")
+}
+
+// TestConcurrentTaskPortAllocation verifies that concurrent tasks get different ports.
+func TestConcurrentTaskPortAllocation(t *testing.T) {
+	setup(t)
+
+	// Save original config values and restore after test
+	origCapacity := config.Capacity
+	origNumberOfTasksToRun := config.NumberOfTasksToRun
+	t.Cleanup(func() {
+		config.Capacity = origCapacity
+		config.NumberOfTasksToRun = origNumberOfTasksToRun
+	})
+
+	config.Capacity = 2
+	config.NumberOfTasksToRun = 2
+
+	// These tasks will use TaskclusterProxy (different ports per task)
+	// The task prints the TASKCLUSTER_PROXY_URL environment variable
+	// Sleep ensures tasks overlap for concurrent port allocation testing
+	payload := GenericWorkerPayload{
+		Command:    append(printEnvVar("TASKCLUSTER_PROXY_URL"), sleep(2)...),
+		MaxRunTime: 30,
+		Features: FeatureFlags{
+			TaskclusterProxy: true,
+		},
+	}
+	defaults.SetDefaults(&payload)
+
+	td1 := testTask(t)
+	td1.Scopes = []string{"queue:get-artifact:*"}
+	td2 := testTask(t)
+	td2.Scopes = []string{"queue:get-artifact:*"}
+
+	taskID1 := scheduleTask(t, td1, payload)
+	taskID2 := scheduleTask(t, td2, payload)
+
+	t.Logf("Scheduled tasks with TaskclusterProxy: %s, %s", taskID1, taskID2)
+
+	execute(t, TASKS_COMPLETE)
+
+	// Verify both tasks completed
+	queue := serviceFactory.Queue(config.Credentials(), config.RootURL)
+
+	status1, err := queue.Status(taskID1)
+	require.NoError(t, err)
+	require.Equal(t, "completed", status1.Status.Runs[0].State)
+
+	status2, err := queue.Status(taskID2)
+	require.NoError(t, err)
+	require.Equal(t, "completed", status2.Status.Runs[0].State)
+
+	// Read task logs to verify different proxy ports were used
+	// The port manager allocates ports with offset: slot * PortsPerTask (4)
+	// So task on slot 0 gets proxyPort, task on slot 1 gets proxyPort + 4
+
+	// Find task directories and read their logs
+	var proxyPorts []int
+	err = filepath.WalkDir(config.TasksDir, func(path string, d os.DirEntry, err error) error {
+		if !d.IsDir() && d.Name() == "live_backing.log" {
+			content, err := os.ReadFile(path)
+			if err != nil {
+				return err
+			}
+			// Parse TASKCLUSTER_PROXY_URL from log
+			for line := range strings.SplitSeq(string(content), "\n") {
+				if urlPart, ok := strings.CutPrefix(line, "TASKCLUSTER_PROXY_URL="); ok {
+					// Format: TASKCLUSTER_PROXY_URL=http://localhost:PORT
+					// Extract port from URL
+					parts := strings.Split(urlPart, ":")
+					if len(parts) >= 3 {
+						portStr := strings.TrimRight(parts[2], "/")
+						port, _ := strconv.Atoi(portStr)
+						if port > 0 {
+							proxyPorts = append(proxyPorts, port)
+							t.Logf("Found proxy port %d in %s", port, path)
+						}
+					}
+				}
+			}
+		}
+		return nil
+	})
+	require.NoError(t, err)
+
+	// Verify we found 2 different ports
+	require.Len(t, proxyPorts, 2, "Should find 2 proxy port assignments")
+	require.NotEqual(t, proxyPorts[0], proxyPorts[1], "Concurrent tasks should have different proxy ports")
+	t.Logf("Task proxy ports: %v and %v", proxyPorts[0], proxyPorts[1])
 }

--- a/workers/generic-worker/interactive_feature.go
+++ b/workers/generic-worker/interactive_feature.go
@@ -77,9 +77,15 @@ func (it *InteractiveTask) Start() *CommandExecutionError {
 		InteractiveCmd: interactiveCmd,
 	}
 
-	interactive, err := interactive.New(config.InteractivePort, interactiveCommands, ctx)
+	// Get allocated port for this task, fall back to config default
+	interactivePort, ok := it.task.InteractivePort()
+	if !ok {
+		interactivePort = config.InteractivePort
+	}
+
+	interactive, err := interactive.New(interactivePort, interactiveCommands, ctx)
 	if err != nil {
-		it.task.Warnf("[interactive] could not create interactive session: %v", err)
+		it.task.Warnf("[interactive] could not create interactive session on port %d: %v", interactivePort, err)
 		cancel()
 		return nil
 	}

--- a/workers/generic-worker/livelog/livelog.go
+++ b/workers/generic-worker/livelog/livelog.go
@@ -13,6 +13,7 @@ import (
 	"os"
 	"os/exec"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -67,14 +68,30 @@ func New(liveLogExecutable string, putPort, getPort uint16) (*LiveLog, error) {
 	l.setRequestURLs()
 
 	// Set environment variables directly on the command to avoid race conditions
-	// when multiple livelog instances start concurrently
-	l.command.Env = []string{
-		"ACCESS_TOKEN=" + l.secret,
-		"LIVELOG_GET_PORT=" + strconv.Itoa(int(l.GETPort)),
-		"LIVELOG_PUT_PORT=" + strconv.Itoa(int(l.PUTPort)),
-		"LIVELOG_TEMP_DIR=" + tmpDir,
-		// Explicitly omit SERVER_KEY_FILE and SERVER_CRT_FILE to prohibit TLS
+	// when multiple livelog instances start concurrently. Start from the
+	// inherited environment (safe to read since we no longer call os.Setenv)
+	// and filter out vars we want to override or omit.
+	env := []string{}
+	for _, e := range os.Environ() {
+		switch {
+		case strings.HasPrefix(e, "ACCESS_TOKEN="),
+			strings.HasPrefix(e, "LIVELOG_GET_PORT="),
+			strings.HasPrefix(e, "LIVELOG_PUT_PORT="),
+			strings.HasPrefix(e, "LIVELOG_TEMP_DIR="),
+			strings.HasPrefix(e, "SERVER_KEY_FILE="),
+			strings.HasPrefix(e, "SERVER_CRT_FILE="):
+			// Skip — we override or omit these below
+		default:
+			env = append(env, e)
+		}
 	}
+	l.command.Env = append(env,
+		"ACCESS_TOKEN="+l.secret,
+		"LIVELOG_GET_PORT="+strconv.Itoa(int(l.GETPort)),
+		"LIVELOG_PUT_PORT="+strconv.Itoa(int(l.PUTPort)),
+		"LIVELOG_TEMP_DIR="+tmpDir,
+		// Explicitly omit SERVER_KEY_FILE and SERVER_CRT_FILE to prohibit TLS
+	)
 
 	// Context used to cancel the connectInputStream goroutine if the
 	// livelog process exits before the connection is established.

--- a/workers/generic-worker/livelog/livelog.go
+++ b/workers/generic-worker/livelog/livelog.go
@@ -66,13 +66,15 @@ func New(liveLogExecutable string, putPort, getPort uint16) (*LiveLog, error) {
 	}
 	l.setRequestURLs()
 
-	os.Setenv("ACCESS_TOKEN", l.secret)
-	os.Setenv("LIVELOG_GET_PORT", strconv.Itoa(int(l.GETPort)))
-	os.Setenv("LIVELOG_PUT_PORT", strconv.Itoa(int(l.PUTPort)))
-	os.Setenv("LIVELOG_TEMP_DIR", tmpDir)
-	// we want to explicitly prohibit the process to use TLS
-	os.Unsetenv("SERVER_KEY_FILE")
-	os.Unsetenv("SERVER_CRT_FILE")
+	// Set environment variables directly on the command to avoid race conditions
+	// when multiple livelog instances start concurrently
+	l.command.Env = []string{
+		"ACCESS_TOKEN=" + l.secret,
+		"LIVELOG_GET_PORT=" + strconv.Itoa(int(l.GETPort)),
+		"LIVELOG_PUT_PORT=" + strconv.Itoa(int(l.PUTPort)),
+		"LIVELOG_TEMP_DIR=" + tmpDir,
+		// Explicitly omit SERVER_KEY_FILE and SERVER_CRT_FILE to prohibit TLS
+	}
 
 	// Context used to cancel the connectInputStream goroutine if the
 	// livelog process exits before the connection is established.

--- a/workers/generic-worker/livelog_feature.go
+++ b/workers/generic-worker/livelog_feature.go
@@ -62,11 +62,11 @@ func (l *LiveLogTask) RequiredScopes() scopes.Required {
 
 func (l *LiveLogTask) Start() *CommandExecutionError {
 	// Get allocated ports for this task
-	getPort, putPort, ok := l.task.LiveLogPorts()
+	putPort, getPort, ok := l.task.LiveLogPorts()
 	if !ok {
 		// Fall back to config defaults if ports not allocated
-		getPort = config.LiveLogPortBase + 1
 		putPort = config.LiveLogPortBase
+		getPort = config.LiveLogPortBase + 1
 	}
 
 	liveLog, err := livelog.New(config.LiveLogExecutable, putPort, getPort)

--- a/workers/generic-worker/loopback_audio_linux_test.go
+++ b/workers/generic-worker/loopback_audio_linux_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"os"
 	"strings"
 	"testing"
 
@@ -9,6 +10,9 @@ import (
 )
 
 func TestLoopbackAudio(t *testing.T) {
+	if os.Getenv("GW_IN_DOCKER") == "1" {
+		t.Skip("Skipping in Docker: loopback audio requires kernel modules not available in containers")
+	}
 	setup(t)
 
 	devicePaths := []string{
@@ -66,6 +70,9 @@ func TestIncorrectLoopbackAudioScopes(t *testing.T) {
 }
 
 func TestLoopbackAudioNotOwnedByTaskUser(t *testing.T) {
+	if os.Getenv("GW_IN_DOCKER") == "1" {
+		t.Skip("Skipping in Docker: loopback audio requires kernel modules not available in containers")
+	}
 	setup(t)
 
 	devicePaths := []string{

--- a/workers/generic-worker/loopback_video_linux_test.go
+++ b/workers/generic-worker/loopback_video_linux_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"os"
 	"strings"
 	"testing"
 
@@ -9,6 +10,9 @@ import (
 )
 
 func TestLoopbackVideo(t *testing.T) {
+	if os.Getenv("GW_IN_DOCKER") == "1" {
+		t.Skip("Skipping in Docker: loopback video requires kernel modules not available in containers")
+	}
 	setup(t)
 
 	devicePath := fmt.Sprintf("/dev/video%d", config.LoopbackVideoDeviceNumber)

--- a/workers/generic-worker/main.go
+++ b/workers/generic-worker/main.go
@@ -57,8 +57,13 @@ var (
 	trcPath = filepath.Join(cwd, "tasks-resolved-count.txt")
 	// workerReady becomes true when it is able to call queue.claimWork for the first time
 	workerReady = false
-	// General platform independent user settings, such as home directory, username...
-	// Platform specific data should be managed in plat_<platform>.go files
+	// taskContext is a global TaskContext used for:
+	// 1. Tests - many tests access taskContext.TaskDir directly to build file paths
+	// 2. Non-headless multiuser mode (capacity=1) - stores the single shared task context
+	// 3. Capacity>1 - updated to the latest claimed task for test compatibility (tests read logs via LogText)
+	// 4. Directory cleanup - used by purgeOldTasks to skip the current task's directory/user
+	// Production code with capacity>1 uses per-task contexts stored in TaskRun.Context.
+	// This global is initialized in platform-specific init() functions and by engineTestSetup() for tests.
 	taskContext    = &TaskContext{}
 	config         *gwconfig.Config
 	serviceFactory tc.ServiceFactory
@@ -258,6 +263,7 @@ func loadConfig(configFile *gwconfig.File) error {
 			PublicPlatformConfig:           *gwconfig.DefaultPublicPlatformConfig(),
 			AllowedHighMemoryDurationSecs:  5,
 			CachesDir:                      "caches",
+			Capacity:                       1,
 			CleanUpTaskDirs:                true,
 			DisableOOMProtection:           false,
 			DisableReboots:                 false,
@@ -410,12 +416,16 @@ func RunWorker() (exitCode ExitCode) {
 		}
 	}()
 
-	err := config.Validate()
-	if err != nil {
-		log.Printf("Invalid config: %v", err)
-		return INVALID_CONFIG
-	}
+	exitOnError(INVALID_CONFIG, config.Validate(), "Invalid config")
+	exitOnError(INVALID_CONFIG, validateEngineConfig(), "Invalid engine config")
 	engineInit()
+
+	// Ensure tasks directory exists (needed for disk space checks, etc.)
+	err := os.MkdirAll(config.TasksDir, 0755)
+	if err != nil {
+		log.Printf("Failed to create tasks directory %s: %v", config.TasksDir, err)
+		return INTERNAL_ERROR
+	}
 
 	// This *DOESN'T* output secret fields, so is SAFE
 	log.Printf("Config: %v", config)
@@ -464,11 +474,78 @@ func RunWorker() (exitCode ExitCode) {
 
 	sigInterrupt := make(chan os.Signal, 1)
 	signal.Notify(sigInterrupt, os.Interrupt)
-	if RotateTaskEnvironment() {
+
+	// Create TaskManager for concurrent task execution
+	taskManager := NewTaskManager(config.Capacity)
+	log.Printf("Worker capacity: %d", config.Capacity)
+
+	// Create PortManager for dynamic port allocation
+	portManager := NewPortManager(config.LiveLogPortBase, config.InteractivePort, config.TaskclusterProxyPort, config.Capacity)
+
+	// Channel for task completion notifications
+	taskCompleteChan := make(chan taskCompletionResult, config.Capacity)
+
+	// Prepare task environment (may require reboot for non-headless multiuser)
+	if prepareTaskEnvironment() {
 		return REBOOT_REQUIRED
 	}
+
+	// Initial cleanup of old task directories
+	err = purgeOldTasks(taskManager.RunningTaskDirNames()...)
+	if err != nil {
+		log.Printf("WARNING: failed to remove old task directories/users: %v", err)
+	}
+
+mainLoop:
 	for {
+		// Process any completed tasks
+		processedCompletion := false
+		for {
+			select {
+			case result := <-taskCompleteChan:
+				processedCompletion = true
+				tasksResolved++
+				lastActive = time.Now()
+
+				if result.workerShutdown {
+					log.Printf("Task %s requested worker shutdown, waiting for other tasks...", result.taskID)
+					taskManager.WaitForAll()
+					return WORKER_SHUTDOWN
+				}
+
+				// remainingTasks will be -ve, if config.NumberOfTasksToRun is not set (=0)
+				remainingTasks := int(config.NumberOfTasksToRun - tasksResolved)
+				remainingTaskCountText := ""
+				if remainingTasks > 0 {
+					remainingTaskCountText = fmt.Sprintf(" (will exit after resolving %v more)", remainingTasks)
+				}
+				log.Printf("Resolved %v tasks in total so far%v.", tasksResolved, remainingTaskCountText)
+				if remainingTasks == 0 {
+					log.Printf("Completed all task(s) (number of tasks to run = %v)", config.NumberOfTasksToRun)
+					taskManager.WaitForAll()
+					if checkWhetherToTerminate() {
+						return WORKER_MANAGER_SHUTDOWN
+					}
+					return TASKS_COMPLETE
+				}
+				// In non-headless multiuser mode with capacity=1, reboot between tasks
+				if rebootBetweenTasks() {
+					return REBOOT_REQUIRED
+				}
+			default:
+				goto doneProcessingCompletions
+			}
+		}
+	doneProcessingCompletions:
+		if processedCompletion {
+			err := purgeOldTasks(taskManager.RunningTaskDirNames()...)
+			if err != nil {
+				log.Printf("ERROR: purging old tasks: %v", err)
+			}
+		}
+
 		if checkWhetherToTerminate() {
+			taskManager.WaitForAll()
 			return WORKER_MANAGER_SHUTDOWN
 		}
 
@@ -479,68 +556,122 @@ func RunWorker() (exitCode ExitCode) {
 		}
 
 		if graceful.TerminationRequested() {
+			log.Printf("Graceful termination requested, waiting for %d running tasks...", taskManager.TaskCount())
+			taskManager.WaitForAll()
 			return WORKER_SHUTDOWN
 		}
 
-		pdTaskUser := currentPlatformData()
-		err = validateGenericWorkerBinary(pdTaskUser)
-		if err != nil {
-			log.Printf("Invalid generic-worker binary: %v", err)
-			return INTERNAL_ERROR
+		// Calculate available capacity
+		availableCapacity := taskManager.AvailableCapacity()
+		claimCount := availableCapacity
+		if config.NumberOfTasksToRun > 0 {
+			// Account for tasks already running so we don't exceed NumberOfTasksToRun.
+			alreadyStarted := tasksResolved + taskManager.TaskCount()
+			if alreadyStarted >= config.NumberOfTasksToRun {
+				claimCount = 0
+			} else {
+				remainingToStart := config.NumberOfTasksToRun - alreadyStarted
+				if remainingToStart < claimCount {
+					claimCount = remainingToStart
+				}
+			}
 		}
-
-		task := ClaimWork()
 
 		// make sure at least 5 seconds pass between tcqueue.ClaimWork API calls
 		wait5Seconds := time.NewTimer(time.Second * 5)
 
-		if task != nil {
-			logEvent("taskQueued", task, time.Time(task.Definition.Created))
-			logEvent("taskStart", task, time.Now())
-
-			task.pd = pdTaskUser
-			errors := task.Run()
-
-			logEvent("taskFinish", task, time.Now())
-			if errors.Occurred() {
-				log.Printf("ERROR(s) encountered: %v", errors)
-				task.Error(errors.Error())
-			}
-			if errors.WorkerShutdown() {
-				return WORKER_SHUTDOWN
-			}
-			err := task.ReleaseResources()
-			if err != nil {
-				log.Printf("ERROR: releasing resources\n%v", err)
-			}
-			err = purgeOldTasks()
-			if err != nil {
-				panic(err)
-			}
-			tasksResolved++
-			// remainingTasks will be -ve, if config.NumberOfTasksToRun is not set (=0)
-			remainingTasks := int(config.NumberOfTasksToRun - tasksResolved)
-			remainingTaskCountText := ""
-			if remainingTasks > 0 {
-				remainingTaskCountText = fmt.Sprintf(" (will exit after resolving %v more)", remainingTasks)
-			}
-			log.Printf("Resolved %v tasks in total so far%v.", tasksResolved, remainingTaskCountText)
-			if remainingTasks == 0 {
-				log.Printf("Completed all task(s) (number of tasks to run = %v)", config.NumberOfTasksToRun)
-
-				if checkWhetherToTerminate() {
-					return WORKER_MANAGER_SHUTDOWN
+		if claimCount > 0 {
+			// Unified task execution: always use per-task context regardless of capacity
+			tasks := ClaimWork(claimCount)
+			for _, task := range tasks {
+				// Create per-task context
+				// Include runId to avoid collisions when tasks are rerun (same taskId, new runId)
+				// Format: task_<12 chars of taskId>_<runId> (max 20 chars for Windows username limit)
+				taskIDPart := task.TaskID
+				if len(taskIDPart) > 12 {
+					taskIDPart = taskIDPart[:12]
 				}
-				return TASKS_COMPLETE
+				taskDirName := fmt.Sprintf("task_%s_%d", taskIDPart, task.RunID)
+				ctx := CreateTaskContext(taskDirName)
+				task.Context = ctx
+				if runningTests {
+					// Update global taskContext for test compatibility (tests read logs via LogText)
+					taskContext = ctx
+				}
+
+				// Create generic-worker subdirectory for logs, etc.
+				gwDir := filepath.Join(ctx.TaskDir, "generic-worker")
+				err = os.MkdirAll(gwDir, 0700)
+				if err != nil {
+					panic(err)
+				}
+				log.Printf("Created dir: %v", gwDir)
+
+				// Get platform data for this task's context
+				pd, err := platformDataForTaskContext(ctx)
+				if err != nil {
+					log.Printf("ERROR getting platform data for %s: %v", task.TaskID, err)
+					_ = task.StatusManager.ReportException(internalError)
+					return INTERNAL_ERROR
+				}
+				task.pd = pd
+
+				err = validateGenericWorkerBinary(pd, ctx.TaskDir)
+				if err != nil {
+					log.Printf("Invalid generic-worker binary for task %s: %v", task.TaskID, err)
+					_ = task.StatusManager.ReportException(internalError)
+					return INTERNAL_ERROR
+				}
+
+				// Allocate ports for this task
+				allocatedPorts, err := portManager.AllocatePorts(task.TaskID)
+				if err != nil {
+					log.Printf("ERROR allocating ports for task %s: %v", task.TaskID, err)
+					_ = task.StatusManager.ReportException(internalError)
+					return INTERNAL_ERROR
+				}
+				task.AllocatedPorts = allocatedPorts
+				log.Printf("Task %s allocated ports: LiveLog=%d/%d, Interactive=%d, TaskclusterProxy=%d",
+					task.TaskID,
+					allocatedPorts[PortIndexLiveLogGET], allocatedPorts[PortIndexLiveLogPUT],
+					allocatedPorts[PortIndexInteractive], allocatedPorts[PortIndexTaskclusterProxy])
+
+				logEvent("taskQueued", task, time.Time(task.Definition.Created))
+				logEvent("taskStart", task, time.Now())
+
+				taskManager.AddTask(task)
+
+				go func(t *TaskRun) {
+					var errors *ExecutionErrors
+					defer func() {
+						taskManager.RemoveTask(t.TaskID)
+						portManager.ReleasePorts(t.TaskID)
+						workerShutdown := errors != nil && errors.WorkerShutdown()
+						taskCompleteChan <- taskCompletionResult{
+							taskID:         t.TaskID,
+							workerShutdown: workerShutdown,
+						}
+					}()
+
+					errors = t.Run()
+
+					logEvent("taskFinish", t, time.Now())
+					if errors.Occurred() {
+						log.Printf("ERROR(s) encountered for task %s: %v", t.TaskID, errors)
+						t.Error(errors.Error())
+					}
+					err := t.ReleaseResources()
+					if err != nil {
+						log.Printf("ERROR: releasing resources for task %s: %v", t.TaskID, err)
+					}
+				}(task)
+
+				lastActive = time.Now()
 			}
-			if rebootBetweenTasks() {
-				return REBOOT_REQUIRED
-			}
-			lastActive = time.Now()
-			if RotateTaskEnvironment() {
-				return REBOOT_REQUIRED
-			}
-		} else {
+		}
+
+		// Check idle timeout only when no tasks are running
+		if taskManager.IsIdle() {
 			// Round(0) forces wall time calculation instead of monotonic time in case machine slept etc
 			idleTime := time.Now().Round(0).Sub(lastActive)
 			remainingIdleTimeText := ""
@@ -548,7 +679,7 @@ func RunWorker() (exitCode ExitCode) {
 				remainingIdleTimeText = fmt.Sprintf(" (will exit if no task claimed in %v)", time.Second*time.Duration(config.IdleTimeoutSecs)-idleTime)
 				if idleTime.Seconds() > float64(config.IdleTimeoutSecs) {
 					if !withWorkerRunner || checkWhetherToTerminate() {
-						_ = purgeOldTasks()
+						_ = purgeOldTasks(taskManager.RunningTaskDirNames()...)
 						log.Printf("Worker idle for idleShutdownTimeoutSecs seconds (%v)", idleTime)
 						return IDLE_TIMEOUT
 					}
@@ -576,13 +707,30 @@ func RunWorker() (exitCode ExitCode) {
 		// To avoid hammering queue, make sure there is at least 5 seconds
 		// between consecutive requests. Note we do this even if a task ran,
 		// since a task could complete in less than that amount of time.
+		// However, if a task completes, we should process it immediately.
 		select {
 		case <-wait5Seconds.C:
+		case result := <-taskCompleteChan:
+			// A task completed during the wait. Put the result back so
+			// the drain loop at the top of mainLoop processes it along
+			// with any other completions that arrived. This is safe
+			// because the channel buffer is config.Capacity and at most
+			// config.Capacity goroutines can send to it; we just removed
+			// one item, so there is always room to put it back.
+			taskCompleteChan <- result
+			continue mainLoop
 		case <-sigInterrupt:
-			log.Println("Received SIGINT, worker is exiting")
+			log.Printf("Interrupt received, waiting for %d running tasks...", taskManager.TaskCount())
+			taskManager.WaitForAll()
 			return WORKER_STOPPED
 		}
 	}
+}
+
+// taskCompletionResult holds the result of a completed task
+type taskCompletionResult struct {
+	taskID         string
+	workerShutdown bool
 }
 
 func checkWhetherToTerminate() bool {
@@ -604,15 +752,19 @@ func checkWhetherToTerminate() bool {
 	return false
 }
 
-// ClaimWork queries the Queue to find a task.
-func ClaimWork() *TaskRun {
+// ClaimWork queries the Queue to find tasks. The count parameter specifies
+// how many tasks to request (up to available capacity).
+func ClaimWork(count uint) []*TaskRun {
+	if count < 1 {
+		return nil
+	}
 	// only log workerReady the first time queue.claimWork is called
 	if !workerReady {
 		workerReady = true
 		logEvent("workerReady", nil, time.Now())
 	}
 	req := &tcqueue.ClaimWorkRequest{
-		Tasks:       1,
+		Tasks:       int64(count),
 		WorkerGroup: config.WorkerGroup,
 		WorkerID:    config.WorkerID,
 	}
@@ -626,20 +778,14 @@ func ClaimWork() *TaskRun {
 		log.Printf("Could not claim work. %v", err)
 		return nil
 	}
-	switch {
 
-	// no tasks - nothing to return
-	case len(resp.Tasks) < 1:
+	if len(resp.Tasks) == 0 {
 		return nil
+	}
 
-	// more than one task - BUG!
-	case len(resp.Tasks) > 1:
-		panic(fmt.Sprintf("SERIOUS BUG: too many tasks returned from queue - only 1 requested, but %v returned", len(resp.Tasks)))
-
-	// exactly one task - process it!
-	default:
-		log.Print("Task found")
-		taskResponse := resp.Tasks[0]
+	tasks := make([]*TaskRun, 0, len(resp.Tasks))
+	for _, taskResponse := range resp.Tasks {
+		log.Printf("Task found: %s", taskResponse.Status.TaskID)
 		taskQueue := serviceFactory.Queue(
 			&tcclient.Credentials{
 				ClientID:    taskResponse.Credentials.ClientID,
@@ -662,8 +808,9 @@ func ClaimWork() *TaskRun {
 		}
 		defaults.SetDefaults(&task.Payload)
 		task.StatusManager = NewTaskStatusManager(task)
-		return task
+		tasks = append(tasks, task)
 	}
+	return tasks
 }
 
 func (task *TaskRun) validateJSON(input []byte, schema string) *CommandExecutionError {
@@ -725,8 +872,8 @@ func (task *TaskRun) validateJSON(input []byte, schema string) *CommandExecution
 // internally during the artifact upload process. The version string
 // is not returned, since it is not needed. A non-nil error is returned
 // if the `generic-worker --version` command cannot be run successfully.
-func validateGenericWorkerBinary(pd *process.PlatformData) error {
-	cmd, err := gwVersion(pd)
+func validateGenericWorkerBinary(pd *process.PlatformData, taskDir string) error {
+	cmd, err := gwVersion(pd, taskDir)
 	if err != nil {
 		panic(fmt.Errorf("could not create command to determine generic-worker binary version: %v", err))
 	}
@@ -932,12 +1079,6 @@ func (task *TaskRun) Run() (err *ExecutionErrors) {
 
 	err = &ExecutionErrors{}
 
-	workerStatus := &WorkerStatus{
-		CurrentTaskIDs: []string{task.TaskID},
-	}
-	err.add(executionError(internalError, errored, fileutil.WriteToFileAsJSON(workerStatus, workerStatusPath)))
-	defer os.Remove(workerStatusPath)
-
 	defer func() {
 		if r := recover(); r != nil {
 			err.add(executionError(internalError, errored, fmt.Errorf("%#v", r)))
@@ -1032,21 +1173,6 @@ func (task *TaskRun) closeLog(logHandle io.WriteCloser) {
 	}
 }
 
-func PrepareTaskEnvironment() (reboot bool) {
-	// I've discovered windows has a limit of 20 chars
-	taskDirName := fmt.Sprintf("task_%v", time.Now().UnixNano())[:20]
-	if PlatformTaskEnvironmentSetup(taskDirName) {
-		return true
-	}
-	logDir := fileutil.AbsFrom(taskContext.TaskDir, filepath.Dir(logPath))
-	err := os.MkdirAll(logDir, 0700)
-	if err != nil {
-		panic(err)
-	}
-	log.Printf("Created dir: %v", logDir)
-	return false
-}
-
 func taskDirsIn(parentDir string) ([]string, error) {
 	fi, err := os.ReadDir(parentDir)
 	if err != nil {
@@ -1099,20 +1225,6 @@ outer:
 			log.Printf("WARNING: Could not delete task directory %v: %v", taskDir, err)
 		}
 	}
-}
-
-// RotateTaskEnvironment creates a new task environment (for the next task),
-// and purges existing used task environments.
-func RotateTaskEnvironment() (reboot bool) {
-	if PrepareTaskEnvironment() {
-		return true
-	}
-	err := purgeOldTasks()
-	// errors are not fatal
-	if err != nil {
-		log.Printf("WARNING: failed to remove old task directories/users: %v", err)
-	}
-	return false
 }
 
 func exitOnError(exitCode ExitCode, err error, logMessage string, args ...any) {

--- a/workers/generic-worker/main.go
+++ b/workers/generic-worker/main.go
@@ -508,7 +508,8 @@ mainLoop:
 				lastActive = time.Now()
 
 				if result.workerShutdown {
-					log.Printf("Task %s requested worker shutdown, waiting for other tasks...", result.taskID)
+					log.Printf("Task %s requested worker shutdown, aborting other tasks...", result.taskID)
+					graceful.Terminate(false) // Abort other tasks immediately
 					taskManager.WaitForAll()
 					return WORKER_SHUTDOWN
 				}
@@ -549,8 +550,10 @@ mainLoop:
 			return WORKER_MANAGER_SHUTDOWN
 		}
 
-		// Ensure there is enough disk space *before* claiming a task
-		err := garbageCollection()
+		// Ensure there is enough disk space *before* claiming a task.
+		// Pass tasksRunning so docker prune is skipped when tasks may
+		// have loaded images that are not yet running in a container.
+		err := garbageCollection(!taskManager.IsIdle())
 		if err != nil {
 			panic(err)
 		}
@@ -586,16 +589,21 @@ mainLoop:
 			for _, task := range tasks {
 				// Create per-task context
 				// Include runId to avoid collisions when tasks are rerun (same taskId, new runId)
-				// Format: task_<12 chars of taskId>_<runId> (max 20 chars for Windows username limit)
+				// Format: task_<taskIdPart>_<runId> (max 20 chars for Windows username limit)
+				// Dynamically size taskIdPart based on runId length to guarantee <= 20 chars
+				runIDStr := fmt.Sprintf("%d", task.RunID)
+				maxTaskIDLen := 20 - len("task_") - len("_") - len(runIDStr)
 				taskIDPart := task.TaskID
-				if len(taskIDPart) > 12 {
-					taskIDPart = taskIDPart[:12]
+				if len(taskIDPart) > maxTaskIDLen {
+					taskIDPart = taskIDPart[:maxTaskIDLen]
 				}
-				taskDirName := fmt.Sprintf("task_%s_%d", taskIDPart, task.RunID)
+				taskDirName := fmt.Sprintf("task_%s_%s", taskIDPart, runIDStr)
 				ctx := CreateTaskContext(taskDirName)
 				task.Context = ctx
-				if runningTests {
-					// Update global taskContext for test compatibility (tests read logs via LogText)
+				if runningTests && config.Capacity == 1 {
+					// Update global taskContext for test compatibility (tests read logs via LogText).
+					// Only safe when capacity=1; with capacity>1 concurrent goroutines
+					// would race on this global.
 					taskContext = ctx
 				}
 
@@ -607,12 +615,28 @@ mainLoop:
 				}
 				log.Printf("Created dir: %v", gwDir)
 
+				// cleanupTaskSetup removes the task directory and releases
+				// platform resources on early error paths before the task
+				// goroutine is launched.
+				cleanupTaskSetup := func(pd *process.PlatformData) {
+					if pd != nil {
+						if releaseErr := pd.ReleaseResources(); releaseErr != nil {
+							log.Printf("ERROR releasing platform resources for task %s: %v", task.TaskID, releaseErr)
+						}
+					}
+					if removeErr := os.RemoveAll(ctx.TaskDir); removeErr != nil {
+						log.Printf("ERROR removing task directory %s: %v", ctx.TaskDir, removeErr)
+					}
+				}
+
 				// Get platform data for this task's context
 				pd, err := platformDataForTaskContext(ctx)
 				if err != nil {
 					log.Printf("ERROR getting platform data for %s: %v", task.TaskID, err)
 					_ = task.StatusManager.ReportException(internalError)
-					return INTERNAL_ERROR
+					cleanupTaskSetup(nil)
+					taskCompleteChan <- taskCompletionResult{taskID: task.TaskID}
+					continue
 				}
 				task.pd = pd
 
@@ -620,7 +644,9 @@ mainLoop:
 				if err != nil {
 					log.Printf("Invalid generic-worker binary for task %s: %v", task.TaskID, err)
 					_ = task.StatusManager.ReportException(internalError)
-					return INTERNAL_ERROR
+					cleanupTaskSetup(pd)
+					taskCompleteChan <- taskCompletionResult{taskID: task.TaskID}
+					continue
 				}
 
 				// Allocate ports for this task
@@ -628,12 +654,14 @@ mainLoop:
 				if err != nil {
 					log.Printf("ERROR allocating ports for task %s: %v", task.TaskID, err)
 					_ = task.StatusManager.ReportException(internalError)
-					return INTERNAL_ERROR
+					cleanupTaskSetup(pd)
+					taskCompleteChan <- taskCompletionResult{taskID: task.TaskID}
+					continue
 				}
 				task.AllocatedPorts = allocatedPorts
-				log.Printf("Task %s allocated ports: LiveLog=%d/%d, Interactive=%d, TaskclusterProxy=%d",
+				log.Printf("Task %s allocated ports: LiveLog(PUT/GET)=%d/%d, Interactive=%d, TaskclusterProxy=%d",
 					task.TaskID,
-					allocatedPorts[PortIndexLiveLogGET], allocatedPorts[PortIndexLiveLogPUT],
+					allocatedPorts[PortIndexLiveLogPUT], allocatedPorts[PortIndexLiveLogGET],
 					allocatedPorts[PortIndexInteractive], allocatedPorts[PortIndexTaskclusterProxy])
 
 				logEvent("taskQueued", task, time.Time(task.Definition.Created))
@@ -644,6 +672,10 @@ mainLoop:
 				go func(t *TaskRun) {
 					var errors *ExecutionErrors
 					defer func() {
+						if r := recover(); r != nil {
+							log.Printf("PANIC in task %s goroutine: %v", t.TaskID, r)
+							t.Error(fmt.Sprintf("Internal worker error (panic): %v", r))
+						}
 						taskManager.RemoveTask(t.TaskID)
 						portManager.ReleasePorts(t.TaskID)
 						workerShutdown := errors != nil && errors.WorkerShutdown()
@@ -720,7 +752,8 @@ mainLoop:
 			taskCompleteChan <- result
 			continue mainLoop
 		case <-sigInterrupt:
-			log.Printf("Interrupt received, waiting for %d running tasks...", taskManager.TaskCount())
+			log.Printf("Interrupt received, signaling %d running tasks...", taskManager.TaskCount())
+			graceful.Terminate(true)
 			taskManager.WaitForAll()
 			return WORKER_STOPPED
 		}
@@ -1093,6 +1126,14 @@ func (task *TaskRun) Run() (err *ExecutionErrors) {
 	for _, feature := range features {
 		if feature.IsRequested(task) {
 			if !feature.IsEnabled() {
+				// Check if the feature provides a specific reason for being disabled
+				// (e.g. incompatible with capacity > 1)
+				if drp, ok := feature.(DisabledReasonProvider); ok {
+					if reason := drp.DisabledReason(); reason != "" {
+						err.add(MalformedPayloadError(fmt.Errorf("%s", reason)))
+						return
+					}
+				}
 				workerPoolID := config.ProvisionerID + "/" + config.WorkerType
 				workerManagerURL := config.RootURL + "/worker-manager/" + url.PathEscape(workerPoolID)
 				err.add(MalformedPayloadError(fmt.Errorf(`this task is attempting to use feature %q, but it's not enabled on this worker pool (%s)

--- a/workers/generic-worker/main.go
+++ b/workers/generic-worker/main.go
@@ -480,7 +480,7 @@ func RunWorker() (exitCode ExitCode) {
 	log.Printf("Worker capacity: %d", config.Capacity)
 
 	// Create PortManager for dynamic port allocation
-	portManager := NewPortManager(config.LiveLogPortBase, config.InteractivePort, config.TaskclusterProxyPort, config.Capacity)
+	portManager := NewPortManager(&config.PublicConfig)
 
 	// Channel for task completion notifications
 	taskCompleteChan := make(chan taskCompletionResult, config.Capacity)
@@ -496,6 +496,70 @@ func RunWorker() (exitCode ExitCode) {
 		log.Printf("WARNING: failed to remove old task directories/users: %v", err)
 	}
 
+	// processCompletion records bookkeeping for a finished task and
+	// reports back what the main loop should do next. Extracted from
+	// inline drain logic so both the top-of-loop drain and the
+	// wait-window completion path can share a single implementation
+	// (avoiding the prior re-put-on-channel pattern, which relied on
+	// a brittle buffer-size / sender-count invariant).
+	type completionAction int
+	const (
+		completionContinue completionAction = iota
+		completionWorkerShutdown
+		completionWorkerManagerShutdown
+		completionTasksComplete
+		completionRebootRequired
+	)
+	processCompletion := func(result taskCompletionResult) completionAction {
+		tasksResolved++
+		lastActive = time.Now()
+
+		if result.workerShutdown {
+			log.Printf("Task %s requested worker shutdown, aborting other tasks...", result.taskID)
+			graceful.Terminate(false) // Abort other tasks immediately
+			taskManager.WaitForAll()
+			return completionWorkerShutdown
+		}
+
+		// remainingTasks will be -ve, if config.NumberOfTasksToRun is not set (=0)
+		remainingTasks := int(config.NumberOfTasksToRun - tasksResolved)
+		remainingTaskCountText := ""
+		if remainingTasks > 0 {
+			remainingTaskCountText = fmt.Sprintf(" (will exit after resolving %v more)", remainingTasks)
+		}
+		log.Printf("Resolved %v tasks in total so far%v.", tasksResolved, remainingTaskCountText)
+		if remainingTasks == 0 {
+			log.Printf("Completed all task(s) (number of tasks to run = %v)", config.NumberOfTasksToRun)
+			taskManager.WaitForAll()
+			if checkWhetherToTerminate() {
+				return completionWorkerManagerShutdown
+			}
+			return completionTasksComplete
+		}
+		// In non-headless multiuser mode with capacity=1, reboot between tasks
+		if rebootBetweenTasks() {
+			return completionRebootRequired
+		}
+		return completionContinue
+	}
+
+	// processCompletionAction translates an action into the matching
+	// worker exit code. Returns ok=false when the action means "keep
+	// running" so the caller can fall through.
+	processCompletionAction := func(action completionAction) (ExitCode, bool) {
+		switch action {
+		case completionWorkerShutdown:
+			return WORKER_SHUTDOWN, true
+		case completionWorkerManagerShutdown:
+			return WORKER_MANAGER_SHUTDOWN, true
+		case completionTasksComplete:
+			return TASKS_COMPLETE, true
+		case completionRebootRequired:
+			return REBOOT_REQUIRED, true
+		}
+		return 0, false
+	}
+
 mainLoop:
 	for {
 		// Process any completed tasks
@@ -504,34 +568,8 @@ mainLoop:
 			select {
 			case result := <-taskCompleteChan:
 				processedCompletion = true
-				tasksResolved++
-				lastActive = time.Now()
-
-				if result.workerShutdown {
-					log.Printf("Task %s requested worker shutdown, aborting other tasks...", result.taskID)
-					graceful.Terminate(false) // Abort other tasks immediately
-					taskManager.WaitForAll()
-					return WORKER_SHUTDOWN
-				}
-
-				// remainingTasks will be -ve, if config.NumberOfTasksToRun is not set (=0)
-				remainingTasks := int(config.NumberOfTasksToRun - tasksResolved)
-				remainingTaskCountText := ""
-				if remainingTasks > 0 {
-					remainingTaskCountText = fmt.Sprintf(" (will exit after resolving %v more)", remainingTasks)
-				}
-				log.Printf("Resolved %v tasks in total so far%v.", tasksResolved, remainingTaskCountText)
-				if remainingTasks == 0 {
-					log.Printf("Completed all task(s) (number of tasks to run = %v)", config.NumberOfTasksToRun)
-					taskManager.WaitForAll()
-					if checkWhetherToTerminate() {
-						return WORKER_MANAGER_SHUTDOWN
-					}
-					return TASKS_COMPLETE
-				}
-				// In non-headless multiuser mode with capacity=1, reboot between tasks
-				if rebootBetweenTasks() {
-					return REBOOT_REQUIRED
+				if exit, done := processCompletionAction(processCompletion(result)); done {
+					return exit
 				}
 			default:
 				goto doneProcessingCompletions
@@ -607,17 +645,12 @@ mainLoop:
 					taskContext = ctx
 				}
 
-				// Create generic-worker subdirectory for logs, etc.
-				gwDir := filepath.Join(ctx.TaskDir, "generic-worker")
-				err = os.MkdirAll(gwDir, 0700)
-				if err != nil {
-					panic(err)
-				}
-				log.Printf("Created dir: %v", gwDir)
-
-				// cleanupTaskSetup removes the task directory and releases
-				// platform resources on early error paths before the task
-				// goroutine is launched.
+				// cleanupTaskSetup removes the task directory, releases
+				// platform resources, and (in headless multiuser) deletes
+				// the per-task OS user on early error paths before the
+				// task goroutine is launched. Defined before the gwDir
+				// MkdirAll so a failure there doesn't leak the user
+				// account or task directory.
 				cleanupTaskSetup := func(pd *process.PlatformData) {
 					if pd != nil {
 						if releaseErr := pd.ReleaseResources(); releaseErr != nil {
@@ -627,7 +660,20 @@ mainLoop:
 					if removeErr := os.RemoveAll(ctx.TaskDir); removeErr != nil {
 						log.Printf("ERROR removing task directory %s: %v", ctx.TaskDir, removeErr)
 					}
+					deleteTaskUserOnCleanup(ctx)
 				}
+
+				// Create generic-worker subdirectory for logs, etc.
+				gwDir := filepath.Join(ctx.TaskDir, "generic-worker")
+				err = os.MkdirAll(gwDir, 0700)
+				if err != nil {
+					log.Printf("ERROR creating generic-worker dir for task %s: %v", task.TaskID, err)
+					_ = task.StatusManager.ReportException(internalError)
+					cleanupTaskSetup(nil)
+					taskCompleteChan <- taskCompletionResult{taskID: task.TaskID}
+					continue
+				}
+				log.Printf("Created dir: %v", gwDir)
 
 				// Get platform data for this task's context
 				pd, err := platformDataForTaskContext(ctx)
@@ -743,13 +789,15 @@ mainLoop:
 		select {
 		case <-wait5Seconds.C:
 		case result := <-taskCompleteChan:
-			// A task completed during the wait. Put the result back so
-			// the drain loop at the top of mainLoop processes it along
-			// with any other completions that arrived. This is safe
-			// because the channel buffer is config.Capacity and at most
-			// config.Capacity goroutines can send to it; we just removed
-			// one item, so there is always room to put it back.
-			taskCompleteChan <- result
+			// Process the completion in-place, then loop back to the
+			// top to drain any siblings and run the post-completion
+			// purge. This used to re-put the result on the channel
+			// and rely on the top-of-loop drain to pick it up — that
+			// pattern was sensitive to the chan buffer size and
+			// goroutine count invariants.
+			if exit, done := processCompletionAction(processCompletion(result)); done {
+				return exit
+			}
 			continue mainLoop
 		case <-sigInterrupt:
 			log.Printf("Interrupt received, signaling %d running tasks...", taskManager.TaskCount())

--- a/workers/generic-worker/metadata_feature.go
+++ b/workers/generic-worker/metadata_feature.go
@@ -76,6 +76,6 @@ func (mtf *MetadataTaskFeature) Stop(err *ExecutionErrors) {
 	// if we can't write this, something seriously wrong, so cause worker to
 	// report an internal-error to sentry and crash!
 	if e != nil {
-		panic(err)
+		panic(e)
 	}
 }

--- a/workers/generic-worker/metadata_feature.go
+++ b/workers/generic-worker/metadata_feature.go
@@ -3,12 +3,19 @@ package main
 import (
 	"fmt"
 	"path/filepath"
+	"sync"
 
 	"github.com/taskcluster/taskcluster/v99/internal/scopes"
 	"github.com/taskcluster/taskcluster/v99/workers/generic-worker/fileutil"
 )
 
-var metadataFilename = filepath.Join(cwd, "generic-worker-metadata.json")
+var (
+	// metadataMutex protects access to the generic-worker-metadata.json file
+	// for concurrent task execution (capacity > 1)
+	metadataMutex sync.Mutex
+
+	metadataFilename = filepath.Join(cwd, "generic-worker-metadata.json")
+)
 
 type (
 	MetadataFeature struct {
@@ -63,7 +70,9 @@ func (mtf *MetadataTaskFeature) Stop(err *ExecutionErrors) {
 		LastTaskURL: fmt.Sprintf("%v/tasks/%v/runs/%v", config.RootURL, mtf.task.TaskID, mtf.task.RunID),
 	}
 
+	metadataMutex.Lock()
 	e := fileutil.WriteToFileAsJSON(mtf.info, metadataFilename)
+	metadataMutex.Unlock()
 	// if we can't write this, something seriously wrong, so cause worker to
 	// report an internal-error to sentry and crash!
 	if e != nil {

--- a/workers/generic-worker/model.go
+++ b/workers/generic-worker/model.go
@@ -57,6 +57,12 @@ type (
 		FileMountHandlers   map[string]FileMountHandler       `json:"-"`
 		D2GInfo             *d2g.ConversionInfo               `json:"-"`
 		DockerWorkerPayload *dockerworker.DockerWorkerPayload `json:"-"`
+		// Context holds per-task context including task directory and user.
+		// This replaces the global taskContext for concurrent task execution.
+		Context *TaskContext `json:"-"`
+		// AllocatedPorts holds the ports allocated to this task by PortManager.
+		// Indexed by PortIndex* constants.
+		AllocatedPorts []uint16 `json:"-"`
 	}
 
 	TaskStatus       string
@@ -67,6 +73,45 @@ type (
 	// cached file and its SHA256 hash.
 	FileMountHandler func(cachedFile, sha256 string) error
 )
+
+// GetContext returns the task's context.
+// Every task must have a Context set; this method panics if Context is nil.
+func (task *TaskRun) GetContext() *TaskContext {
+	if task.Context == nil {
+		panic("task.Context is nil - every task must have a context assigned")
+	}
+	return task.Context
+}
+
+// TaskDir returns the task's working directory.
+func (task *TaskRun) TaskDir() string {
+	return task.GetContext().TaskDir
+}
+
+// LiveLogPorts returns the GET and PUT ports for livelog.
+// Returns (getPort, putPort, ok) where ok is false if ports weren't allocated.
+func (task *TaskRun) LiveLogPorts() (getPort, putPort uint16, ok bool) {
+	if len(task.AllocatedPorts) < 2 {
+		return 0, 0, false
+	}
+	return task.AllocatedPorts[PortIndexLiveLogGET], task.AllocatedPorts[PortIndexLiveLogPUT], true
+}
+
+// InteractivePort returns the interactive shell port.
+func (task *TaskRun) InteractivePort() (uint16, bool) {
+	if len(task.AllocatedPorts) <= PortIndexInteractive {
+		return 0, false
+	}
+	return task.AllocatedPorts[PortIndexInteractive], true
+}
+
+// TaskclusterProxyPort returns the taskcluster-proxy port.
+func (task *TaskRun) TaskclusterProxyPort() (uint16, bool) {
+	if len(task.AllocatedPorts) <= PortIndexTaskclusterProxy {
+		return 0, false
+	}
+	return task.AllocatedPorts[PortIndexTaskclusterProxy], true
+}
 
 func (task *TaskRun) String() string {
 	response := fmt.Sprintf("Task Id:                 %v\n", task.TaskID)

--- a/workers/generic-worker/model.go
+++ b/workers/generic-worker/model.go
@@ -88,13 +88,13 @@ func (task *TaskRun) TaskDir() string {
 	return task.GetContext().TaskDir
 }
 
-// LiveLogPorts returns the GET and PUT ports for livelog.
-// Returns (getPort, putPort, ok) where ok is false if ports weren't allocated.
-func (task *TaskRun) LiveLogPorts() (getPort, putPort uint16, ok bool) {
+// LiveLogPorts returns the PUT and GET ports for livelog.
+// Returns (putPort, getPort, ok) where ok is false if ports weren't allocated.
+func (task *TaskRun) LiveLogPorts() (putPort, getPort uint16, ok bool) {
 	if len(task.AllocatedPorts) < 2 {
 		return 0, 0, false
 	}
-	return task.AllocatedPorts[PortIndexLiveLogGET], task.AllocatedPorts[PortIndexLiveLogPUT], true
+	return task.AllocatedPorts[PortIndexLiveLogPUT], task.AllocatedPorts[PortIndexLiveLogGET], true
 }
 
 // InteractivePort returns the interactive shell port.

--- a/workers/generic-worker/mounts_feature.go
+++ b/workers/generic-worker/mounts_feature.go
@@ -24,6 +24,7 @@ import (
 	"github.com/taskcluster/taskcluster/v99/internal/mocktc/tc"
 	"github.com/taskcluster/taskcluster/v99/internal/scopes"
 	"github.com/taskcluster/taskcluster/v99/workers/generic-worker/fileutil"
+	"golang.org/x/sync/singleflight"
 )
 
 var (
@@ -32,7 +33,7 @@ var (
 	// downloaded from. The map values are the paths of the downloaded files
 	// relative to the downloads directory specified in the global config file
 	// on the worker.
-	fileCaches CacheMap
+	fileCaches FileCacheMap
 	// writable directory caches that may be preloaded or initially empty. Note
 	// a preloaded cache will have an associated file cache for the archive it
 	// was created from. The key is the cache name.
@@ -42,25 +43,130 @@ var (
 	lastQueriedPurgeCacheService time.Time
 	// cacheMutex protects access to fileCaches, directoryCaches, and
 	// lastQueriedPurgeCacheService for concurrent task execution (capacity > 1)
-	cacheMutex sync.RWMutex
+	cacheMutex sync.Mutex
 
-	// cacheRWLocks provides per-cache RWMutex locks. Mount takes an RLock
-	// while copying from the authoritative cache dir (concurrent reads OK).
-	// Unmount takes a write Lock while swapping the cache dir contents
-	// (exclusive with reads and other writes).
-	cacheRWMu    sync.Mutex
-	cacheRWLocks = map[string]*sync.RWMutex{}
+	// fileCacheDownloads deduplicates concurrent downloads for the same cache key.
+	fileCacheDownloads singleflight.Group
 )
 
 type (
-	CacheMap map[string]*Cache
+	CacheMap     map[string][]*Cache
+	FileCacheMap map[string]*Cache
 )
 
-type cacheMountState struct {
-	baseGeneration uint64
+// CacheOwner allows a Cache to remove itself from its owning map during eviction.
+type CacheOwner interface {
+	Remove(entry *Cache)
 }
 
 func (cm CacheMap) SortedResources() Resources {
+	r := Resources{}
+	for _, entries := range cm {
+		for _, cache := range entries {
+			if !cache.InUse {
+				r = append(r, cache)
+			}
+		}
+	}
+	sort.Sort(r)
+	return r
+}
+
+func (cm CacheMap) Remove(entry *Cache) {
+	entries := cm[entry.Key]
+	for i, e := range entries {
+		if e == entry {
+			cm[entry.Key] = append(entries[:i], entries[i+1:]...)
+			break
+		}
+	}
+	if len(cm[entry.Key]) == 0 {
+		delete(cm, entry.Key)
+	}
+}
+
+// AcquireCache finds an available (not in-use) pool entry for the given cache
+// name, marks it InUse, and returns it. Returns nil if no entry is available.
+// Caller must hold cacheMutex.
+func AcquireCache(name string) *Cache {
+	entries := directoryCaches[name]
+	var best *Cache
+	for _, e := range entries {
+		if !e.InUse {
+			if best == nil || e.LastUsed.After(best.LastUsed) {
+				best = e
+			}
+		}
+	}
+	if best != nil {
+		best.InUse = true
+		best.Hits++
+	}
+	return best
+}
+
+// ReleaseCache marks a pool entry as available and records the current time.
+// If a purge was requested while the entry was in use, the entry is evicted
+// instead of being returned to the pool.
+// Caller must hold cacheMutex.
+func ReleaseCache(entry *Cache) {
+	if entry.NeedsPurge {
+		log.Printf("Evicting cache %v that was marked for purge while in use", entry.Key)
+		_ = entry.Evict(nil)
+		return
+	}
+	entry.InUse = false
+	entry.LastUsed = time.Now()
+}
+
+// newPoolEntry creates a new in-use cache pool entry for the given cache name.
+// Caller must hold cacheMutex.
+func newPoolEntry(cacheName string) (*Cache, error) {
+	basename := slugid.Nice()
+	file := filepath.Join(config.CachesDir, basename)
+	currentUser, err := user.Current()
+	if err != nil {
+		return nil, fmt.Errorf("[mounts] not able to look up UID for current user: %w", err)
+	}
+	return &Cache{
+		Hits:          1,
+		Created:       time.Now(),
+		Location:      file,
+		Owner:         directoryCaches,
+		Key:           cacheName,
+		OwnerUsername: currentUser.Username,
+		OwnerUID:      currentUser.Uid,
+		InUse:         true,
+	}, nil
+}
+
+// trimPoolExcess evicts available entries beyond config.Capacity per cache name.
+// Caller must hold cacheMutex.
+func trimPoolExcess() {
+	for name, entries := range directoryCaches {
+		available := []*Cache{}
+		for _, e := range entries {
+			if !e.InUse {
+				available = append(available, e)
+			}
+		}
+		excess := len(available) - int(config.Capacity)
+		if excess <= 0 {
+			continue
+		}
+		sort.Slice(available, func(i, j int) bool {
+			return available[i].LastUsed.Before(available[j].LastUsed)
+		})
+		for i := range excess {
+			_ = available[i].Evict(nil)
+		}
+		if len(directoryCaches[name]) == 0 {
+			delete(directoryCaches, name)
+		}
+	}
+}
+
+func (cm FileCacheMap) SortedResources() Resources {
 	r := make(Resources, len(cm))
 	i := 0
 	for _, cache := range cm {
@@ -71,16 +177,35 @@ func (cm CacheMap) SortedResources() Resources {
 	return r
 }
 
-// getCacheRWLock returns the per-cache RWMutex, creating one if needed.
-func getCacheRWLock(cacheName string) *sync.RWMutex {
-	cacheRWMu.Lock()
-	defer cacheRWMu.Unlock()
-	rw := cacheRWLocks[cacheName]
-	if rw == nil {
-		rw = &sync.RWMutex{}
-		cacheRWLocks[cacheName] = rw
+func (cm FileCacheMap) Remove(entry *Cache) {
+	delete(cm, entry.Key)
+}
+
+func (cm *FileCacheMap) LoadFromFile(stateFile string, cacheDir string) {
+	_, err := os.Stat(stateFile)
+	if err != nil {
+		log.Printf("No %v file found, creating empty FileCacheMap", stateFile)
+		*cm = FileCacheMap{}
+		perms := os.FileMode(0700)
+		log.Printf("[mounts] Creating worker cache directory %v with permissions 0%o", cacheDir, perms)
+		err := os.MkdirAll(cacheDir, perms)
+		if err != nil {
+			panic(fmt.Errorf("[mounts] Not able to create worker cache directory %v with permissions 0%o: %v", cacheDir, perms, err))
+		}
+		return
 	}
-	return rw
+	err = loadFromJSONFile(cm, stateFile)
+	if err != nil {
+		panic(err)
+	}
+	for i := range *cm {
+		if _, err = os.Stat((*cm)[i].Location); err != nil {
+			log.Printf("WARNING: Cache %#v missing on worker - corrupt internal state, ignoring!", (*cm)[i])
+			delete(*cm, i)
+		} else {
+			(*cm)[i].Owner = *cm
+		}
+	}
 }
 
 type Cache struct {
@@ -90,13 +215,10 @@ type Cache struct {
 	// the number of times this cache has been included in a MountEntry on a
 	// task run on this worker
 	Hits int `json:"hits"`
-	// Generation increments whenever a task successfully promotes its cache
-	// contents back to the authoritative cache location.
-	Generation uint64 `json:"generation,omitempty"`
 	// The map that tracks the cache, needed for expunging the cache
 	// Don't store in json, otherwise we'll have circular structure and create
 	// an infinite file!
-	Owner CacheMap `json:"-"`
+	Owner CacheOwner `json:"-"`
 	// The key used in the CacheMap
 	Key string `json:"key"`
 	// SHA256 of content, if a file (not used for directories)
@@ -115,22 +237,32 @@ type Cache struct {
 	// Since: generic-worker 75.0.0
 	OwnerUsername string `json:"ownerUsername"`
 	OwnerUID      string `json:"mounterUID"`
+	// InUse indicates whether a task currently owns this pool entry.
+	InUse bool `json:"in_use"`
+	// LastUsed records when this entry was last returned to the pool.
+	LastUsed time.Time `json:"last_used"`
+	// NeedsPurge is set when a purge request arrives while the entry is
+	// in use. ReleaseCache checks this flag and evicts the entry instead
+	// of returning it to the pool.
+	NeedsPurge bool `json:"-"`
 }
 
-// Rating determines how valuable the file cache is compared to other file
-// caches. We will base this entirely on how many times it was used before.
-// The more times it was referenced in a task that already ran on this
-// worker, the higher the rating will be. For now we'll disregard disk
-// space taken up.
+// Rating determines how valuable the cache is compared to others.
+// Older entries get lower ratings and are evicted first by GC.
 func (cache *Cache) Rating() float64 {
-	return float64(cache.Hits)
+	if cache.LastUsed.IsZero() {
+		return 0
+	}
+	return float64(cache.LastUsed.Unix())
 }
 
 func (cache *Cache) Evict(taskMount *TaskMount) error {
 	if taskMount != nil {
 		taskMount.Infof("Removing cache %v from cache table", cache.Key)
 	}
-	delete(cache.Owner, cache.Key)
+	if cache.Owner != nil {
+		cache.Owner.Remove(cache)
+	}
 	if taskMount != nil {
 		taskMount.Infof("Deleting cache %v file(s) at %v", cache.Key, cache.Location)
 	}
@@ -192,26 +324,37 @@ func (cm *CacheMap) LoadFromFile(stateFile string, cacheDir string) {
 		}
 		return
 	}
+
+	// Try new pool format (map[string][]*Cache) first
 	err = loadFromJSONFile(cm, stateFile)
 	if err != nil {
-		panic(err)
+		// Try old format (map[string]*Cache) for migration from pre-pool versions
+		var old map[string]*Cache
+		if oldErr := loadFromJSONFile(&old, stateFile); oldErr != nil {
+			panic(oldErr)
+		}
+		*cm = CacheMap{}
+		for k, v := range old {
+			(*cm)[k] = []*Cache{v}
+		}
 	}
-	for i := range *cm {
-		// Github Issues: #5363, #5396
-		// Bugzilla Bug: https://bugzilla.mozilla.org/show_bug.cgi?id=1595217
-		// Loop through cache entries, and remove any that refer to files/dirs that do not exist.
-		// Log a warning in worker log, and don't raise an exception.
-		if _, err = os.Stat((*cm)[i].Location); err != nil {
-			log.Printf("WARNING: Cache %#v missing on worker - corrupt internal state, ignoring!", (*cm)[i])
-			// note, this should be safe, despite looking scary:
-			// https://stackoverflow.com/questions/23229975/is-it-safe-to-remove-selected-keys-from-map-within-a-range-loop
-			delete(*cm, i)
-		} else {
-			(*cm)[i].Owner = *cm
-			// Treat pre-existing caches as initialized to avoid re-applying content.
-			if (*cm)[i].Generation == 0 {
-				(*cm)[i].Generation = 1
+
+	// Validate entries, remove missing directories, set Owner, reset InUse
+	for name, entries := range *cm {
+		valid := entries[:0]
+		for _, cache := range entries {
+			if _, statErr := os.Stat(cache.Location); statErr != nil {
+				log.Printf("WARNING: Cache %#v missing on worker - corrupt internal state, ignoring!", cache)
+				continue
 			}
+			cache.Owner = *cm
+			cache.InUse = false // all entries are available on startup
+			valid = append(valid, cache)
+		}
+		if len(valid) == 0 {
+			delete(*cm, name)
+		} else {
+			(*cm)[name] = valid
 		}
 	}
 }
@@ -235,7 +378,9 @@ type TaskMount struct {
 	requiredScopes    scopes.Required
 	referencedTaskIDs map[string]bool // simple implementation of set of strings
 	index             tc.Index
-	cacheStates       map[*WritableDirectoryCache]cacheMountState
+	// poolEntries tracks which pool entry each WritableDirectoryCache acquired
+	// during Mount, so Unmount can release it back.
+	poolEntries map[*WritableDirectoryCache]*Cache
 }
 
 // Represents an individual Mount listed in task payload - there
@@ -311,7 +456,7 @@ func (feature *MountsFeature) NewTaskFeature(task *TaskRun) TaskFeature {
 		task:        task,
 		mounts:      []MountEntry{},
 		mounted:     []MountEntry{},
-		cacheStates: make(map[*WritableDirectoryCache]cacheMountState),
+		poolEntries: make(map[*WritableDirectoryCache]*Cache),
 	}
 	for i, taskMount := range task.Payload.Mounts {
 		// Each mount must be one of:
@@ -425,14 +570,52 @@ func (taskMount *TaskMount) initIndexClient() {
 // writable directory caches, since writable directory caches are typically the
 // result of a compilation, which is slow, whereas downloading files is
 // relatively quick in comparison.
-func garbageCollection() error {
-	// Hold lock during entire garbage collection to protect cache map modifications
-	// during Evict() calls from runGarbageCollection()
+func garbageCollection(tasksRunning bool) error {
+	// Collect eviction candidates under the lock, then release it before
+	// running potentially slow docker commands (#7).
+	cacheMutex.Lock()
+	fileResources := fileCaches.SortedResources()
+	cacheMutex.Unlock()
+
+	err := runGarbageCollection(fileResources, tasksRunning)
+	if err != nil {
+		return err
+	}
+
 	cacheMutex.Lock()
 	defer cacheMutex.Unlock()
-	r := fileCaches.SortedResources()
-	r = append(r, directoryCaches.SortedResources()...)
-	return runGarbageCollection(r)
+
+	currentFreeSpace, err := freeDiskSpaceBytes(config.TasksDir)
+	if err != nil {
+		return fmt.Errorf("could not calculate free disk space in dir %v due to error %#v", config.TasksDir, err)
+	}
+	if currentFreeSpace >= requiredSpaceBytes() {
+		trimPoolExcess()
+		return nil
+	}
+
+	// SortedResources only returns available (not in-use) entries
+	dirResources := directoryCaches.SortedResources()
+	for _, res := range dirResources {
+		cache := res.(*Cache)
+		evictErr := cache.Evict(nil)
+		if evictErr != nil {
+			return evictErr
+		}
+
+		currentFreeSpace, err = freeDiskSpaceBytes(config.TasksDir)
+		if err != nil {
+			return fmt.Errorf("could not calculate free disk space in dir %v due to error %#v", config.TasksDir, err)
+		}
+		if currentFreeSpace >= requiredSpaceBytes() {
+			return nil
+		}
+	}
+
+	if currentFreeSpace < requiredSpaceBytes() {
+		return fmt.Errorf("not able to free up enough disk space - require %v bytes, but only have %v bytes - and nothing left to delete", requiredSpaceBytes(), currentFreeSpace)
+	}
+	return nil
 }
 
 // called when a task starts
@@ -478,9 +661,11 @@ func (taskMount *TaskMount) Stop(err *ExecutionErrors) {
 		if purgeCaches {
 			switch cache := mount.(type) {
 			case *WritableDirectoryCache:
-				cacheMutex.Lock()
-				err.add(Failure(directoryCaches[cache.CacheName].Evict(taskMount)))
-				cacheMutex.Unlock()
+				if entry, ok := taskMount.poolEntries[cache]; ok {
+					cacheMutex.Lock()
+					err.add(Failure(entry.Evict(taskMount)))
+					cacheMutex.Unlock()
+				}
 				continue
 			}
 		}
@@ -561,94 +746,69 @@ func (f *FileMount) FSContent() (FSContent, error) {
 
 func (w *WritableDirectoryCache) Mount(taskMount *TaskMount) error {
 	target := fileutil.AbsFrom(taskMount.task.TaskDir(), w.Directory)
+
 	cacheMutex.Lock()
-	cache, dirCacheExists := directoryCaches[w.CacheName]
+	entry := AcquireCache(w.CacheName)
 
-	// Verify the physical directory still exists on disk. With capacity > 1,
-	// when a new cache is first registered by one task, its Location directory
-	// may not yet exist on disk (it is populated when that task's Unmount
-	// promotes its copy into place). A concurrent task mounting the same cache
-	// would find the entry in the map but no directory to copy from. The
-	// directory can also go missing if the worker crashed between RemoveAll
-	// and the JSON persist in Unmount. In either case, treat the cache as new
-	// so the task gets a fresh empty directory instead of failing.
-	if dirCacheExists {
-		if _, statErr := os.Stat(cache.Location); os.IsNotExist(statErr) {
-			taskMount.Warnf("Writable directory cache '%v' references %v which does not exist on disk; recreating", w.CacheName, cache.Location)
-			delete(directoryCaches, w.CacheName)
-			dirCacheExists = false
-		}
-	}
+	if entry != nil {
+		cacheLocation := entry.Location
+		cacheMutex.Unlock()
 
-	if dirCacheExists {
-		cache.Hits++
-	} else {
-		// new cache, let's initialise it...
-		basename := slugid.Nice()
-		file := filepath.Join(config.CachesDir, basename)
-		taskMount.Infof("No existing writable directory cache '%v' - creating %v", w.CacheName, file)
-		currentUser, err := user.Current()
-		if err != nil {
-			panic(fmt.Errorf("[mounts] Not able to look up UID for current user: %w", err))
-		}
-		cache = &Cache{
-			Hits:          1,
-			Created:       time.Now(),
-			Location:      file,
-			Owner:         directoryCaches,
-			Key:           w.CacheName,
-			OwnerUsername: currentUser.Username,
-			OwnerUID:      currentUser.Uid,
-			Generation:    0,
-		}
-		directoryCaches[w.CacheName] = cache
-	}
-
-	baseGeneration := cache.Generation
-	cacheLocation := cache.Location
-	cacheMutex.Unlock()
-
-	taskMount.cacheStates[w] = cacheMountState{baseGeneration: baseGeneration}
-
-	// Populate the target directory:
-	//  - Existing cache, capacity=1:  rename (fast, O(1) on same FS)
-	//  - Existing cache, capacity>1:  copy with per-cache read lock
-	//  - New cache with content:      extract preloaded content
-	//  - New empty cache:             create empty directory
-	if dirCacheExists && config.Capacity == 1 {
 		parentDir := filepath.Dir(target)
 		taskMount.Infof("Moving existing writable directory cache %v from %v to %v", w.CacheName, cacheLocation, target)
 		if err := MkdirAll(taskMount, parentDir); err != nil {
+			// MkdirAll failed — release the acquired entry back to the pool
+			cacheMutex.Lock()
+			ReleaseCache(entry)
+			cacheMutex.Unlock()
 			return fmt.Errorf("not able to create directory %v: %v", parentDir, err)
 		}
 		if err := RenameCrossDevice(cacheLocation, target); err != nil {
+			// Rename failed — evict the broken entry from the pool
+			cacheMutex.Lock()
+			evictErr := entry.Evict(taskMount)
+			cacheMutex.Unlock()
+			if evictErr != nil {
+				panic(evictErr)
+			}
 			return fmt.Errorf("not able to move directory %v to %v: %v", cacheLocation, target, err)
 		}
-	} else if dirCacheExists {
-		parentDir := filepath.Dir(target)
-		taskMount.Infof("Copying writable directory cache %v from %v to %v", w.CacheName, cacheLocation, target)
-		if err := MkdirAll(taskMount, parentDir); err != nil {
-			return fmt.Errorf("not able to create directory %v: %v", parentDir, err)
-		}
-		rw := getCacheRWLock(w.CacheName)
-		rw.RLock()
-		copyErr := fileutil.CopyDir(cacheLocation, target)
-		rw.RUnlock()
-		if copyErr != nil {
-			return fmt.Errorf("not able to copy directory %v to %v: %v", cacheLocation, target, copyErr)
-		}
-	} else if w.Content != nil {
-		c, err := FSContentFrom(w.Content)
-		if err != nil {
-			return fmt.Errorf("not able to retrieve FSContent: %v", err)
-		}
-		if err = extract(c, w.Format, target, taskMount); err != nil {
-			return err
-		}
+		taskMount.poolEntries[w] = entry
 	} else {
-		if err := MkdirAll(taskMount, target); err != nil {
-			return fmt.Errorf("not able to create directory %v: %v", target, err)
+		// No available pool entry — create a new one
+		var poolErr error
+		entry, poolErr = newPoolEntry(w.CacheName)
+		if poolErr != nil {
+			cacheMutex.Unlock()
+			return poolErr
 		}
+		taskMount.Infof("No existing writable directory cache '%v' - creating %v", w.CacheName, entry.Location)
+		directoryCaches[w.CacheName] = append(directoryCaches[w.CacheName], entry)
+		cacheMutex.Unlock()
+
+		if w.Content != nil {
+			c, err := FSContentFrom(w.Content)
+			if err != nil {
+				cacheMutex.Lock()
+				_ = entry.Evict(taskMount)
+				cacheMutex.Unlock()
+				return fmt.Errorf("not able to retrieve FSContent: %v", err)
+			}
+			if err = extract(c, w.Format, target, taskMount); err != nil {
+				cacheMutex.Lock()
+				_ = entry.Evict(taskMount)
+				cacheMutex.Unlock()
+				return err
+			}
+		} else {
+			if err := MkdirAll(taskMount, target); err != nil {
+				cacheMutex.Lock()
+				_ = entry.Evict(taskMount)
+				cacheMutex.Unlock()
+				return fmt.Errorf("not able to create directory %v: %v", target, err)
+			}
+		}
+		taskMount.poolEntries[w] = entry
 	}
 
 	// Regardless of whether we are running as current user, grant task
@@ -658,6 +818,10 @@ func (w *WritableDirectoryCache) Mount(taskMount *TaskMount) error {
 	// execute as LocalSystem.
 	err := makeDirReadWritableForTaskUser(taskMount, target)
 	if err != nil {
+		cacheMutex.Lock()
+		_ = entry.Evict(taskMount)
+		cacheMutex.Unlock()
+		delete(taskMount.poolEntries, w)
 		return err
 	}
 	taskMount.Infof("Successfully mounted writable directory cache '%v'", target)
@@ -666,56 +830,35 @@ func (w *WritableDirectoryCache) Mount(taskMount *TaskMount) error {
 
 func (w *WritableDirectoryCache) Unmount(taskMount *TaskMount) error {
 	taskCacheDir := fileutil.AbsFrom(taskMount.task.TaskDir(), w.Directory)
-	state, ok := taskMount.cacheStates[w]
+	entry, ok := taskMount.poolEntries[w]
 	if !ok {
-		return Failure(fmt.Errorf("could not persist cache %q due to missing mount state", w.CacheName))
+		return Failure(fmt.Errorf("could not persist cache %q due to missing pool entry", w.CacheName))
 	}
 
-	rw := getCacheRWLock(w.CacheName)
-	if !rw.TryLock() {
-		taskMount.Warnf("Cache %q busy; skipping promotion", w.CacheName)
-		return nil
-	}
-	defer rw.Unlock()
-
-	cacheMutex.RLock()
-	cache := directoryCaches[w.CacheName]
-	cacheMutex.RUnlock()
-	if cache == nil {
-		return Failure(fmt.Errorf("could not persist cache %q due to missing cache entry", w.CacheName))
-	}
-
-	if cache.Generation != state.baseGeneration {
-		taskMount.Warnf("Cache %q changed (generation %d -> %d); skipping promotion", w.CacheName, state.baseGeneration, cache.Generation)
-		return nil
-	}
-
-	cacheDir := cache.Location
+	cacheDir := entry.Location
 	taskMount.Infof("Preserving cache: Moving %q to %q", taskCacheDir, cacheDir)
-	// Remove the old authoritative cache (may be empty if capacity=1 renamed
-	// it into the task dir, or may contain the original content if capacity>1
-	// copied it). Then rename the task's version into place.
+
+	// Clean up any stale directory at entry.Location. Normally this path
+	// should not exist (it was renamed away during Mount), but if
+	// RenameCrossDevice fell back to copy+delete on a cross-device mount,
+	// an incomplete cleanup could leave remnants.
 	if err := os.RemoveAll(cacheDir); err != nil {
-		return Failure(fmt.Errorf("could not persist cache %q due to %v", cache.Key, err))
+		taskMount.Warnf("Could not remove stale cache dir %q: %v", cacheDir, err)
 	}
+
 	if err := RenameCrossDevice(taskCacheDir, cacheDir); err != nil {
-		// Both old and new cache content are now lost. Evict the cache
-		// entry so it gets recreated fresh on the next mount.
+		// Rename failed — evict the entry
 		cacheMutex.Lock()
-		evictErr := cache.Evict(taskMount)
+		evictErr := entry.Evict(taskMount)
 		cacheMutex.Unlock()
 		if evictErr != nil {
 			panic(evictErr)
 		}
-		// If taskCacheDir is a relative path inside the task directory,
-		// it will be cleaned up when the task folder is deleted. If it
-		// is an absolute path outside the task directory, the orphaned
-		// directory will remain until the machine is reimaged.
-		return Failure(fmt.Errorf("could not persist cache %q due to %v", cache.Key, err))
+		return Failure(fmt.Errorf("could not persist cache %q due to %v", w.CacheName, err))
 	}
 
 	cacheMutex.Lock()
-	cache.Generation++
+	ReleaseCache(entry)
 	cacheMutex.Unlock()
 	return nil
 }
@@ -753,17 +896,10 @@ func (f *FileMount) Mount(taskMount *TaskMount) error {
 	// content is cached and pass the cache info to the handler instead of
 	// copying the file to the task directory.
 	if handler, ok := taskMount.task.FileMountHandlers[f.File]; ok {
-		cachedFile, err := ensureCached(fsContent, taskMount)
+		cachedFile, sha256, err := ensureCached(fsContent, taskMount)
 		if err != nil {
 			return err
 		}
-
-		cacheKey, err := fsContent.UniqueKey(taskMount)
-		if err != nil {
-			return err
-		}
-
-		sha256 := fileCaches[cacheKey].SHA256
 		taskMount.Infof("File mount %q handled by registered handler (cache: %v, SHA256: %v)", f.File, cachedFile, sha256)
 		return handler(cachedFile, sha256)
 	}
@@ -782,12 +918,11 @@ func (f *FileMount) Unmount(taskMount *TaskMount) error {
 }
 
 // ensureCached returns a file containing the given content
-func ensureCached(fsContent FSContent, taskMount *TaskMount) (file string, err error) {
+func ensureCached(fsContent FSContent, taskMount *TaskMount) (file string, sha256 string, err error) {
 	cacheKey, err := fsContent.UniqueKey(taskMount)
 	if err != nil {
-		return "", err
+		return "", "", err
 	}
-	var sha256 string
 	requiredSHA256 := fsContent.RequiredSHA256()
 	cacheMutex.Lock()
 	cachedEntry, inCache := fileCaches[cacheKey]
@@ -819,29 +954,57 @@ func ensureCached(fsContent FSContent, taskMount *TaskMount) (file string, err e
 		}
 		taskMount.Infof("Found existing download of %v (%v) with SHA256 %v but task definition explicitly requires %v so deleting it", cacheKey, file, sha256, requiredSHA256)
 		cacheMutex.Lock()
-		err = fileCaches[cacheKey].Evict(taskMount)
-		cacheMutex.Unlock()
-		if err != nil {
-			panic(fmt.Errorf("could not delete cache entry %v: %v", fileCaches[cacheKey], err))
+		if entry, ok := fileCaches[cacheKey]; ok {
+			err = entry.Evict(taskMount)
+			cacheMutex.Unlock()
+			if err != nil {
+				panic(fmt.Errorf("could not delete cache entry %v: %v", entry, err))
+			}
+		} else {
+			cacheMutex.Unlock()
 		}
 	} else {
 		cacheMutex.Unlock()
 	}
-	file, sha256, err = fsContent.Download(taskMount)
-	if err != nil {
+
+	type downloadResult struct {
+		file   string
+		sha256 string
+	}
+	val, dlErr, _ := fileCacheDownloads.Do(cacheKey, func() (any, error) {
+		// Re-check cache: another goroutine may have completed the download
+		// while we were waiting for the singleflight lock.
+		cacheMutex.Lock()
+		if entry, ok := fileCaches[cacheKey]; ok {
+			cacheMutex.Unlock()
+			return downloadResult{file: entry.Location, sha256: entry.SHA256}, nil
+		}
+		cacheMutex.Unlock()
+
+		f, s, err := fsContent.Download(taskMount)
+		if err != nil {
+			return nil, err
+		}
+		cacheMutex.Lock()
+		fileCaches[cacheKey] = &Cache{
+			Location: f,
+			Hits:     1,
+			Created:  time.Now(),
+			Owner:    fileCaches,
+			Key:      cacheKey,
+			SHA256:   s,
+		}
+		cacheMutex.Unlock()
+		return downloadResult{file: f, sha256: s}, nil
+	})
+	if dlErr != nil {
+		err = dlErr
 		taskMount.Errorf("Could not fetch from %v into file %v due to %v", fsContent, file, err)
 		return
 	}
-	cacheMutex.Lock()
-	fileCaches[cacheKey] = &Cache{
-		Location: file,
-		Hits:     1,
-		Created:  time.Now(),
-		Owner:    fileCaches,
-		Key:      cacheKey,
-		SHA256:   sha256,
-	}
-	cacheMutex.Unlock()
+	dl := val.(downloadResult)
+	file = dl.file
+	sha256 = dl.sha256
 	if requiredSHA256 == "" {
 		taskMount.Warnf("Download %v of %v has SHA256 %v but task payload does not declare a required value, so content authenticity cannot be verified", file, fsContent, sha256)
 		return
@@ -849,10 +1012,14 @@ func ensureCached(fsContent FSContent, taskMount *TaskMount) (file string, err e
 	if requiredSHA256 != sha256 {
 		err = fmt.Errorf("Download %v of %v has SHA256 %v but task definition explicitly requires %v; not retrying download as there were no connection failures and HTTP response status code was 200", file, fsContent, sha256, requiredSHA256)
 		cacheMutex.Lock()
-		err2 := fileCaches[cacheKey].Evict(taskMount)
-		cacheMutex.Unlock()
-		if err2 != nil {
-			panic(fmt.Errorf("could not delete cache entry %v: %v", fileCaches[cacheKey], err2))
+		if entry, ok := fileCaches[cacheKey]; ok {
+			err2 := entry.Evict(taskMount)
+			cacheMutex.Unlock()
+			if err2 != nil {
+				panic(fmt.Errorf("could not delete cache entry %v: %v", entry, err2))
+			}
+		} else {
+			cacheMutex.Unlock()
 		}
 		return
 	}
@@ -862,7 +1029,7 @@ func ensureCached(fsContent FSContent, taskMount *TaskMount) (file string, err e
 
 func extract(fsContent FSContent, format string, dir string, taskMount *TaskMount) (err error) {
 	var cacheFile string
-	cacheFile, err = ensureCached(fsContent, taskMount)
+	cacheFile, _, err = ensureCached(fsContent, taskMount)
 	if err != nil {
 		log.Printf("Could not cache content: %v", err)
 		return
@@ -895,7 +1062,7 @@ func extract(fsContent FSContent, format string, dir string, taskMount *TaskMoun
 }
 
 func decompress(fsContent FSContent, format string, file string, taskMount *TaskMount) error {
-	cacheFile, err := ensureCached(fsContent, taskMount)
+	cacheFile, _, err := ensureCached(fsContent, taskMount)
 	if err != nil {
 		log.Printf("Could not cache content: %v", err)
 		return err
@@ -1245,9 +1412,9 @@ func (taskMount *TaskMount) purgeCaches() error {
 		}
 	}
 	// Round(0) forces wall time calculation instead of monotonic time in case machine slept etc
-	cacheMutex.RLock()
+	cacheMutex.Lock()
 	lastQueried := lastQueriedPurgeCacheService
-	cacheMutex.RUnlock()
+	cacheMutex.Unlock()
 	if len(writableCaches) == 0 && time.Now().Round(0).Sub(lastQueried) < 6*time.Hour {
 		return nil
 	}
@@ -1277,13 +1444,35 @@ func (taskMount *TaskMount) purgeCaches() error {
 	cacheMutex.Lock()
 	defer cacheMutex.Unlock()
 	for _, request := range purgeRequests.Requests {
-		if cache, exists := directoryCaches[request.CacheName]; exists {
+		entries, exists := directoryCaches[request.CacheName]
+		if !exists {
+			continue
+		}
+		// Evict available entries that are older than the purge request.
+		// In-use entries that match are marked for deferred eviction
+		// so they don't return to the pool with stale content.
+		remaining := entries[:0]
+		for _, cache := range entries {
 			if cache.Created.Add(-5 * time.Minute).Before(time.Time(request.Before)) {
-				err := cache.Evict(taskMount)
-				if err != nil {
-					panic(err)
+				if cache.InUse {
+					taskMount.Infof("Marking in-use cache %v for deferred purge", cache.Key)
+					cache.NeedsPurge = true
+					remaining = append(remaining, cache)
+					continue
 				}
+				taskMount.Infof("Removing cache %v from cache table (purge request)", cache.Key)
+				taskMount.Infof("Deleting cache %v file(s) at %v", cache.Key, cache.Location)
+				if err := os.RemoveAll(cache.Location); err != nil {
+					return err
+				}
+			} else {
+				remaining = append(remaining, cache)
 			}
+		}
+		if len(remaining) == 0 {
+			delete(directoryCaches, request.CacheName)
+		} else {
+			directoryCaches[request.CacheName] = remaining
 		}
 	}
 	return nil

--- a/workers/generic-worker/mounts_feature.go
+++ b/workers/generic-worker/mounts_feature.go
@@ -9,7 +9,6 @@ import (
 	"log"
 	"net/http"
 	"os"
-	"os/user"
 	"path/filepath"
 	"sort"
 	"sync"
@@ -124,19 +123,13 @@ func ReleaseCache(entry *Cache) {
 func newPoolEntry(cacheName string) (*Cache, error) {
 	basename := slugid.Nice()
 	file := filepath.Join(config.CachesDir, basename)
-	currentUser, err := user.Current()
-	if err != nil {
-		return nil, fmt.Errorf("[mounts] not able to look up UID for current user: %w", err)
-	}
 	return &Cache{
-		Hits:          1,
-		Created:       time.Now(),
-		Location:      file,
-		Owner:         directoryCaches,
-		Key:           cacheName,
-		OwnerUsername: currentUser.Username,
-		OwnerUID:      currentUser.Uid,
-		InUse:         true,
+		Hits:     1,
+		Created:  time.Now(),
+		Location: file,
+		Owner:    directoryCaches,
+		Key:      cacheName,
+		InUse:    true,
 	}, nil
 }
 
@@ -223,21 +216,12 @@ type Cache struct {
 	Key string `json:"key"`
 	// SHA256 of content, if a file (not used for directories)
 	SHA256 string `json:"sha256"`
-	// Keeps a record of which task user mounts this cache. This is so that
-	// when the cache is mounted as a new task user, file ownership can be
-	// recursively changed from the previous task user to the new task user.
-	//
-	// Note, although uid is typically a uint32, we store as a string since
-	// that is how the standard library passes it to us, and we pass it to
-	// task commands as a string, so this avoids converting from string to
-	// uint32 and then back again. We use a uid rather than username, since
-	// task users get deleted, so the system may no longer recognise the
-	// previous task user username, but uids should remain intact.
-	//
-	// Since: generic-worker 75.0.0
-	OwnerUsername string `json:"ownerUsername"`
-	OwnerUID      string `json:"mounterUID"`
 	// InUse indicates whether a task currently owns this pool entry.
+	// Persisted with json:"in_use" (rather than json:"-") because
+	// loadFromJSONFile uses DisallowUnknownFields — older state files
+	// written by prior workers contain "in_use" and would otherwise
+	// fail the new-format unmarshal. LoadFromFile resets to false
+	// on startup since no task can be running across a worker restart.
 	InUse bool `json:"in_use"`
 	// LastUsed records when this entry was last returned to the pool.
 	LastUsed time.Time `json:"last_used"`
@@ -744,11 +728,30 @@ func (f *FileMount) FSContent() (FSContent, error) {
 	return FSContentFrom(f.Content)
 }
 
-func (w *WritableDirectoryCache) Mount(taskMount *TaskMount) error {
+func (w *WritableDirectoryCache) Mount(taskMount *TaskMount) (err error) {
 	target := fileutil.AbsFrom(taskMount.task.TaskDir(), w.Directory)
 
 	cacheMutex.Lock()
 	entry := AcquireCache(w.CacheName)
+
+	// If Mount panics after the pool entry is registered (e.g. a SHA
+	// panic in a content extract), the entry would otherwise stay
+	// InUse=true forever and trimPoolExcess can't reclaim it — burning
+	// one slot from this cache's pool until worker restart. Recover
+	// here only to release the entry; we re-panic so the worker's
+	// existing crash handling still triggers an internal-error.
+	released := false
+	defer func() {
+		if r := recover(); r != nil {
+			if entry != nil && !released {
+				cacheMutex.Lock()
+				_ = entry.Evict(taskMount)
+				cacheMutex.Unlock()
+				delete(taskMount.poolEntries, w)
+			}
+			panic(r)
+		}
+	}()
 
 	if entry != nil {
 		cacheLocation := entry.Location
@@ -756,22 +759,24 @@ func (w *WritableDirectoryCache) Mount(taskMount *TaskMount) error {
 
 		parentDir := filepath.Dir(target)
 		taskMount.Infof("Moving existing writable directory cache %v from %v to %v", w.CacheName, cacheLocation, target)
-		if err := MkdirAll(taskMount, parentDir); err != nil {
+		if mkErr := MkdirAll(taskMount, parentDir); mkErr != nil {
 			// MkdirAll failed — release the acquired entry back to the pool
 			cacheMutex.Lock()
 			ReleaseCache(entry)
 			cacheMutex.Unlock()
-			return fmt.Errorf("not able to create directory %v: %v", parentDir, err)
+			released = true
+			return fmt.Errorf("not able to create directory %v: %v", parentDir, mkErr)
 		}
-		if err := RenameCrossDevice(cacheLocation, target); err != nil {
+		if mvErr := RenameCrossDevice(cacheLocation, target); mvErr != nil {
 			// Rename failed — evict the broken entry from the pool
 			cacheMutex.Lock()
 			evictErr := entry.Evict(taskMount)
 			cacheMutex.Unlock()
+			released = true
 			if evictErr != nil {
 				panic(evictErr)
 			}
-			return fmt.Errorf("not able to move directory %v to %v: %v", cacheLocation, target, err)
+			return fmt.Errorf("not able to move directory %v to %v: %v", cacheLocation, target, mvErr)
 		}
 		taskMount.poolEntries[w] = entry
 	} else {
@@ -787,25 +792,28 @@ func (w *WritableDirectoryCache) Mount(taskMount *TaskMount) error {
 		cacheMutex.Unlock()
 
 		if w.Content != nil {
-			c, err := FSContentFrom(w.Content)
-			if err != nil {
+			c, fsErr := FSContentFrom(w.Content)
+			if fsErr != nil {
 				cacheMutex.Lock()
 				_ = entry.Evict(taskMount)
 				cacheMutex.Unlock()
-				return fmt.Errorf("not able to retrieve FSContent: %v", err)
+				released = true
+				return fmt.Errorf("not able to retrieve FSContent: %v", fsErr)
 			}
-			if err = extract(c, w.Format, target, taskMount); err != nil {
+			if extractErr := extract(c, w.Format, target, taskMount); extractErr != nil {
 				cacheMutex.Lock()
 				_ = entry.Evict(taskMount)
 				cacheMutex.Unlock()
-				return err
+				released = true
+				return extractErr
 			}
 		} else {
-			if err := MkdirAll(taskMount, target); err != nil {
+			if mkErr := MkdirAll(taskMount, target); mkErr != nil {
 				cacheMutex.Lock()
 				_ = entry.Evict(taskMount)
 				cacheMutex.Unlock()
-				return fmt.Errorf("not able to create directory %v: %v", target, err)
+				released = true
+				return fmt.Errorf("not able to create directory %v: %v", target, mkErr)
 			}
 		}
 		taskMount.poolEntries[w] = entry
@@ -816,13 +824,13 @@ func (w *WritableDirectoryCache) Mount(taskMount *TaskMount) error {
 	// or at an absolute path outside it. Either way, the file system
 	// resources should be owned by the task user, even if commands
 	// execute as LocalSystem.
-	err := makeDirReadWritableForTaskUser(taskMount, target)
-	if err != nil {
+	if chownErr := makeDirReadWritableForTaskUser(taskMount, target); chownErr != nil {
 		cacheMutex.Lock()
 		_ = entry.Evict(taskMount)
 		cacheMutex.Unlock()
 		delete(taskMount.poolEntries, w)
-		return err
+		released = true
+		return chownErr
 	}
 	taskMount.Infof("Successfully mounted writable directory cache '%v'", target)
 	return nil
@@ -940,8 +948,18 @@ func ensureCached(fsContent FSContent, taskMount *TaskMount) (file string, sha25
 		cacheMutex.Unlock()
 
 		// validate SHA256 in case of either tampering or new content at url...
+		// CalculateSHA256 happens without cacheMutex held to keep
+		// concurrent SHA reads parallelisable, but that opens a race
+		// where another task can evict this entry mid-read (a SHA
+		// mismatch path further down does exactly that). If the file
+		// vanishes under us, retry ensureCached so we re-download
+		// rather than blaming a worker bug.
 		sha256, err = fileutil.CalculateSHA256(file)
 		if err != nil {
+			if errors.Is(err, os.ErrNotExist) {
+				taskMount.Infof("Cache entry for %v vanished mid-read (likely concurrent eviction); retrying download", cacheKey)
+				return ensureCached(fsContent, taskMount)
+			}
 			panic(fmt.Sprintf("Internal worker bug! Cannot calculate SHA256 of file %v that I have in my cache: %v", file, err))
 		}
 		if requiredSHA256 == "" {
@@ -1451,7 +1469,10 @@ func (taskMount *TaskMount) purgeCaches() error {
 		// Evict available entries that are older than the purge request.
 		// In-use entries that match are marked for deferred eviction
 		// so they don't return to the pool with stale content.
-		remaining := entries[:0]
+		// Allocate a fresh slice rather than aliasing entries[:0] so a
+		// mid-loop RemoveAll error doesn't leave directoryCaches pointing
+		// at a partially-overwritten backing array.
+		remaining := make([]*Cache, 0, len(entries))
 		for _, cache := range entries {
 			if cache.Created.Add(-5 * time.Minute).Before(time.Time(request.Before)) {
 				if cache.InUse {

--- a/workers/generic-worker/mounts_feature.go
+++ b/workers/generic-worker/mounts_feature.go
@@ -12,6 +12,7 @@ import (
 	"os/user"
 	"path/filepath"
 	"sort"
+	"sync"
 	"time"
 
 	"slices"
@@ -39,11 +40,25 @@ var (
 	// we track this in order to reduce number of results we get back from
 	// purge cache service
 	lastQueriedPurgeCacheService time.Time
+	// cacheMutex protects access to fileCaches, directoryCaches, and
+	// lastQueriedPurgeCacheService for concurrent task execution (capacity > 1)
+	cacheMutex sync.RWMutex
+
+	// cacheRWLocks provides per-cache RWMutex locks. Mount takes an RLock
+	// while copying from the authoritative cache dir (concurrent reads OK).
+	// Unmount takes a write Lock while swapping the cache dir contents
+	// (exclusive with reads and other writes).
+	cacheRWMu    sync.Mutex
+	cacheRWLocks = map[string]*sync.RWMutex{}
 )
 
 type (
 	CacheMap map[string]*Cache
 )
+
+type cacheMountState struct {
+	baseGeneration uint64
+}
 
 func (cm CacheMap) SortedResources() Resources {
 	r := make(Resources, len(cm))
@@ -56,6 +71,18 @@ func (cm CacheMap) SortedResources() Resources {
 	return r
 }
 
+// getCacheRWLock returns the per-cache RWMutex, creating one if needed.
+func getCacheRWLock(cacheName string) *sync.RWMutex {
+	cacheRWMu.Lock()
+	defer cacheRWMu.Unlock()
+	rw := cacheRWLocks[cacheName]
+	if rw == nil {
+		rw = &sync.RWMutex{}
+		cacheRWLocks[cacheName] = rw
+	}
+	return rw
+}
+
 type Cache struct {
 	Created time.Time `json:"created"`
 	// the full path to the cache on disk (could be file or directory)
@@ -63,6 +90,9 @@ type Cache struct {
 	// the number of times this cache has been included in a MountEntry on a
 	// task run on this worker
 	Hits int `json:"hits"`
+	// Generation increments whenever a task successfully promotes its cache
+	// contents back to the authoritative cache location.
+	Generation uint64 `json:"generation,omitempty"`
 	// The map that tracks the cache, needed for expunging the cache
 	// Don't store in json, otherwise we'll have circular structure and create
 	// an infinite file!
@@ -146,7 +176,7 @@ func (taskMount *TaskMount) Error(message string) {
 
 func MkdirAll(taskMount *TaskMount, dir string) error {
 	taskMount.Infof("Creating directory %v", dir)
-	return MkdirAllTaskUser(dir, taskMount.task.pd)
+	return MkdirAllTaskUser(dir, taskMount.task.GetContext(), taskMount.task.pd)
 }
 
 func (cm *CacheMap) LoadFromFile(stateFile string, cacheDir string) {
@@ -178,11 +208,17 @@ func (cm *CacheMap) LoadFromFile(stateFile string, cacheDir string) {
 			delete(*cm, i)
 		} else {
 			(*cm)[i].Owner = *cm
+			// Treat pre-existing caches as initialized to avoid re-applying content.
+			if (*cm)[i].Generation == 0 {
+				(*cm)[i].Generation = 1
+			}
 		}
 	}
 }
 
 func (feature *MountsFeature) Initialise() error {
+	cacheMutex.Lock()
+	defer cacheMutex.Unlock()
 	fileCaches.LoadFromFile("file-caches.json", config.CachesDir)
 	directoryCaches.LoadFromFile("directory-caches.json", config.DownloadsDir)
 	return nil
@@ -199,6 +235,7 @@ type TaskMount struct {
 	requiredScopes    scopes.Required
 	referencedTaskIDs map[string]bool // simple implementation of set of strings
 	index             tc.Index
+	cacheStates       map[*WritableDirectoryCache]cacheMountState
 }
 
 // Represents an individual Mount listed in task payload - there
@@ -271,9 +308,10 @@ func (feature *MountsFeature) IsRequested(task *TaskRun) bool {
 // NewTaskFeature reads payload and initialises state...
 func (feature *MountsFeature) NewTaskFeature(task *TaskRun) TaskFeature {
 	tm := &TaskMount{
-		task:    task,
-		mounts:  []MountEntry{},
-		mounted: []MountEntry{},
+		task:        task,
+		mounts:      []MountEntry{},
+		mounted:     []MountEntry{},
+		cacheStates: make(map[*WritableDirectoryCache]cacheMountState),
 	}
 	for i, taskMount := range task.Payload.Mounts {
 		// Each mount must be one of:
@@ -388,6 +426,10 @@ func (taskMount *TaskMount) initIndexClient() {
 // result of a compilation, which is slow, whereas downloading files is
 // relatively quick in comparison.
 func garbageCollection() error {
+	// Hold lock during entire garbage collection to protect cache map modifications
+	// during Evict() calls from runGarbageCollection()
+	cacheMutex.Lock()
+	defer cacheMutex.Unlock()
 	r := fileCaches.SortedResources()
 	r = append(r, directoryCaches.SortedResources()...)
 	return runGarbageCollection(r)
@@ -436,7 +478,9 @@ func (taskMount *TaskMount) Stop(err *ExecutionErrors) {
 		if purgeCaches {
 			switch cache := mount.(type) {
 			case *WritableDirectoryCache:
+				cacheMutex.Lock()
 				err.add(Failure(directoryCaches[cache.CacheName].Evict(taskMount)))
+				cacheMutex.Unlock()
 				continue
 			}
 		}
@@ -451,9 +495,12 @@ func (taskMount *TaskMount) Stop(err *ExecutionErrors) {
 			err.add(Failure(e))
 		}
 	}
+	// Persist cache state to disk with mutex protection for concurrent tasks
+	cacheMutex.Lock()
 	err.add(executionError(internalError, errored, fileutil.WriteToFileAsJSON(&fileCaches, "file-caches.json")))
 	err.add(executionError(internalError, errored, fileutil.WriteToFileAsJSON(&directoryCaches, "directory-caches.json")))
 	err.add(executionError(internalError, errored, fileutil.SecureFiles("file-caches.json", "directory-caches.json")))
+	cacheMutex.Unlock()
 }
 
 func (taskMount *TaskMount) shouldPurgeCaches() bool {
@@ -513,23 +560,28 @@ func (f *FileMount) FSContent() (FSContent, error) {
 }
 
 func (w *WritableDirectoryCache) Mount(taskMount *TaskMount) error {
-	target := fileutil.AbsFrom(taskContext.TaskDir, w.Directory)
-	// cache already there?
-	if _, dirCacheExists := directoryCaches[w.CacheName]; dirCacheExists {
-		// bump counter
-		directoryCaches[w.CacheName].Hits++
-		// move it into place...
-		src := directoryCaches[w.CacheName].Location
-		parentDir := filepath.Dir(target)
-		taskMount.Infof("Moving existing writable directory cache %v from %v to %v", w.CacheName, src, target)
-		err := MkdirAll(taskMount, parentDir)
-		if err != nil {
-			return fmt.Errorf("not able to create directory %v: %v", parentDir, err)
+	target := fileutil.AbsFrom(taskMount.task.TaskDir(), w.Directory)
+	cacheMutex.Lock()
+	cache, dirCacheExists := directoryCaches[w.CacheName]
+
+	// Verify the physical directory still exists on disk. With capacity > 1,
+	// when a new cache is first registered by one task, its Location directory
+	// may not yet exist on disk (it is populated when that task's Unmount
+	// promotes its copy into place). A concurrent task mounting the same cache
+	// would find the entry in the map but no directory to copy from. The
+	// directory can also go missing if the worker crashed between RemoveAll
+	// and the JSON persist in Unmount. In either case, treat the cache as new
+	// so the task gets a fresh empty directory instead of failing.
+	if dirCacheExists {
+		if _, statErr := os.Stat(cache.Location); os.IsNotExist(statErr) {
+			taskMount.Warnf("Writable directory cache '%v' references %v which does not exist on disk; recreating", w.CacheName, cache.Location)
+			delete(directoryCaches, w.CacheName)
+			dirCacheExists = false
 		}
-		err = RenameCrossDevice(src, target)
-		if err != nil {
-			panic(fmt.Errorf("[mounts] Not able to rename dir %v as %v: %v", src, target, err))
-		}
+	}
+
+	if dirCacheExists {
+		cache.Hits++
 	} else {
 		// new cache, let's initialise it...
 		basename := slugid.Nice()
@@ -539,7 +591,7 @@ func (w *WritableDirectoryCache) Mount(taskMount *TaskMount) error {
 		if err != nil {
 			panic(fmt.Errorf("[mounts] Not able to look up UID for current user: %w", err))
 		}
-		directoryCaches[w.CacheName] = &Cache{
+		cache = &Cache{
 			Hits:          1,
 			Created:       time.Now(),
 			Location:      file,
@@ -547,69 +599,111 @@ func (w *WritableDirectoryCache) Mount(taskMount *TaskMount) error {
 			Key:           w.CacheName,
 			OwnerUsername: currentUser.Username,
 			OwnerUID:      currentUser.Uid,
+			Generation:    0,
 		}
-		// preloaded content?
-		if w.Content != nil {
-			c, err := FSContentFrom(w.Content)
-			if err != nil {
-				return fmt.Errorf("not able to retrieve FSContent: %v", err)
-			}
-			err = extract(c, w.Format, target, taskMount)
-			if err != nil {
-				return err
-			}
-		} else {
-			// no preloaded content => just create dir in place
-			err := MkdirAll(taskMount, target)
-			if err != nil {
-				return fmt.Errorf("not able to create directory %v: %v", target, err)
-			}
+		directoryCaches[w.CacheName] = cache
+	}
+
+	baseGeneration := cache.Generation
+	cacheLocation := cache.Location
+	cacheMutex.Unlock()
+
+	taskMount.cacheStates[w] = cacheMountState{baseGeneration: baseGeneration}
+
+	// Populate the target directory:
+	//  - Existing cache, capacity=1:  rename (fast, O(1) on same FS)
+	//  - Existing cache, capacity>1:  copy with per-cache read lock
+	//  - New cache with content:      extract preloaded content
+	//  - New empty cache:             create empty directory
+	if dirCacheExists && config.Capacity == 1 {
+		parentDir := filepath.Dir(target)
+		taskMount.Infof("Moving existing writable directory cache %v from %v to %v", w.CacheName, cacheLocation, target)
+		if err := MkdirAll(taskMount, parentDir); err != nil {
+			return fmt.Errorf("not able to create directory %v: %v", parentDir, err)
+		}
+		if err := RenameCrossDevice(cacheLocation, target); err != nil {
+			return fmt.Errorf("not able to move directory %v to %v: %v", cacheLocation, target, err)
+		}
+	} else if dirCacheExists {
+		parentDir := filepath.Dir(target)
+		taskMount.Infof("Copying writable directory cache %v from %v to %v", w.CacheName, cacheLocation, target)
+		if err := MkdirAll(taskMount, parentDir); err != nil {
+			return fmt.Errorf("not able to create directory %v: %v", parentDir, err)
+		}
+		rw := getCacheRWLock(w.CacheName)
+		rw.RLock()
+		copyErr := fileutil.CopyDir(cacheLocation, target)
+		rw.RUnlock()
+		if copyErr != nil {
+			return fmt.Errorf("not able to copy directory %v to %v: %v", cacheLocation, target, copyErr)
+		}
+	} else if w.Content != nil {
+		c, err := FSContentFrom(w.Content)
+		if err != nil {
+			return fmt.Errorf("not able to retrieve FSContent: %v", err)
+		}
+		if err = extract(c, w.Format, target, taskMount); err != nil {
+			return err
+		}
+	} else {
+		if err := MkdirAll(taskMount, target); err != nil {
+			return fmt.Errorf("not able to create directory %v: %v", target, err)
 		}
 	}
+
 	// Regardless of whether we are running as current user, grant task
 	// user access. The mounted folder may be inside the task directory
 	// or at an absolute path outside it. Either way, the file system
 	// resources should be owned by the task user, even if commands
 	// execute as LocalSystem.
-	err := exchangeDirectoryOwnership(taskMount, target, directoryCaches[w.CacheName])
+	err := makeDirReadWritableForTaskUser(taskMount, target)
 	if err != nil {
-		panic(err)
+		return err
 	}
 	taskMount.Infof("Successfully mounted writable directory cache '%v'", target)
 	return nil
 }
 
 func (w *WritableDirectoryCache) Unmount(taskMount *TaskMount) error {
+	taskCacheDir := fileutil.AbsFrom(taskMount.task.TaskDir(), w.Directory)
+	state, ok := taskMount.cacheStates[w]
+	if !ok {
+		return Failure(fmt.Errorf("could not persist cache %q due to missing mount state", w.CacheName))
+	}
+
+	rw := getCacheRWLock(w.CacheName)
+	if !rw.TryLock() {
+		taskMount.Warnf("Cache %q busy; skipping promotion", w.CacheName)
+		return nil
+	}
+	defer rw.Unlock()
+
+	cacheMutex.RLock()
 	cache := directoryCaches[w.CacheName]
+	cacheMutex.RUnlock()
+	if cache == nil {
+		return Failure(fmt.Errorf("could not persist cache %q due to missing cache entry", w.CacheName))
+	}
+
+	if cache.Generation != state.baseGeneration {
+		taskMount.Warnf("Cache %q changed (generation %d -> %d); skipping promotion", w.CacheName, state.baseGeneration, cache.Generation)
+		return nil
+	}
+
 	cacheDir := cache.Location
-	taskCacheDir := fileutil.AbsFrom(taskContext.TaskDir, w.Directory)
 	taskMount.Infof("Preserving cache: Moving %q to %q", taskCacheDir, cacheDir)
-	err := RenameCrossDevice(taskCacheDir, cacheDir)
-	if err != nil {
-		// An error can occur for several reasons:
-		//
-		// Task problems:
-		// T1) The move was transformed into copy/delete semantics, e.g. if
-		// cache persistence directory is on a different drive. Perhaps the
-		// delete failed due to file handles being held by orphaned processes.
-		// Test TestAbortAfterMaxRunTime simulates this.
-		// T2) Maybe the task moved/deleted the cache, or altered ACLs which
-		// caused the move to fail.
-		//
-		// Worker problems:
-		// W1) Perhaps a genuine worker issue - disk fault, drive full, etc.
-		//
-		// It is non-trivial to diagnose whether it is a task issue (=> resolve
-		// task as failure) or a worker issue (=> resolve task as exception and
-		// trigger internal-error to quarantine/terminate worker). Therefore
-		// assume it is a task problem not a worker problem, and if we are
-		// wrong, in the worst case we just have performance degredation on
-		// this worker since it cannot persist the cache. Hopefully if there is
-		// a more serious issue, it will be detected via another mechanism and
-		// cause an internal-error.
+	// Remove the old authoritative cache (may be empty if capacity=1 renamed
+	// it into the task dir, or may contain the original content if capacity>1
+	// copied it). Then rename the task's version into place.
+	if err := os.RemoveAll(cacheDir); err != nil {
+		return Failure(fmt.Errorf("could not persist cache %q due to %v", cache.Key, err))
+	}
+	if err := RenameCrossDevice(taskCacheDir, cacheDir); err != nil {
+		// Both old and new cache content are now lost. Evict the cache
+		// entry so it gets recreated fresh on the next mount.
+		cacheMutex.Lock()
 		evictErr := cache.Evict(taskMount)
-		// If we can't remove the cacheDir, then something nasty is going on
-		// since this is in a location that the task shouldn't be writing to...
+		cacheMutex.Unlock()
 		if evictErr != nil {
 			panic(evictErr)
 		}
@@ -619,6 +713,10 @@ func (w *WritableDirectoryCache) Unmount(taskMount *TaskMount) error {
 		// directory will remain until the machine is reimaged.
 		return Failure(fmt.Errorf("could not persist cache %q due to %v", cache.Key, err))
 	}
+
+	cacheMutex.Lock()
+	cache.Generation++
+	cacheMutex.Unlock()
 	return nil
 }
 
@@ -627,7 +725,7 @@ func (r *ReadOnlyDirectory) Mount(taskMount *TaskMount) error {
 	if err != nil {
 		return fmt.Errorf("not able to retrieve FSContent: %v", err)
 	}
-	dir := fileutil.AbsFrom(taskContext.TaskDir, r.Directory)
+	dir := fileutil.AbsFrom(taskMount.task.TaskDir(), r.Directory)
 	err = extract(c, r.Format, dir, taskMount)
 	if err != nil {
 		return err
@@ -646,7 +744,7 @@ func (f *FileMount) Mount(taskMount *TaskMount) error {
 		return err
 	}
 
-	file := fileutil.AbsFrom(taskContext.TaskDir, f.File)
+	file := fileutil.AbsFrom(taskMount.task.TaskDir(), f.File)
 	if info, err := os.Stat(file); err == nil && info.IsDir() {
 		return fmt.Errorf("cannot mount file at path %v since it already exists as a directory", file)
 	}
@@ -691,16 +789,20 @@ func ensureCached(fsContent FSContent, taskMount *TaskMount) (file string, err e
 	}
 	var sha256 string
 	requiredSHA256 := fsContent.RequiredSHA256()
-	if _, inCache := fileCaches[cacheKey]; inCache {
-		file = fileCaches[cacheKey].Location
+	cacheMutex.Lock()
+	cachedEntry, inCache := fileCaches[cacheKey]
+	if inCache {
+		file = cachedEntry.Location
 		// Sanity check - if file is in file map, but not on file system,
 		// something is seriously wrong, so should be a worker exception
 		// (panic), not a task failure
 		_, err = os.Stat(file)
 		if err != nil {
-			panic(fmt.Errorf("file in cache, but not on filesystem: %v", *fileCaches[cacheKey]))
+			cacheMutex.Unlock()
+			panic(fmt.Errorf("file in cache, but not on filesystem: %v", *cachedEntry))
 		}
-		fileCaches[cacheKey].Hits++
+		cachedEntry.Hits++
+		cacheMutex.Unlock()
 
 		// validate SHA256 in case of either tampering or new content at url...
 		sha256, err = fileutil.CalculateSHA256(file)
@@ -716,16 +818,21 @@ func ensureCached(fsContent FSContent, taskMount *TaskMount) (file string, err e
 			return
 		}
 		taskMount.Infof("Found existing download of %v (%v) with SHA256 %v but task definition explicitly requires %v so deleting it", cacheKey, file, sha256, requiredSHA256)
+		cacheMutex.Lock()
 		err = fileCaches[cacheKey].Evict(taskMount)
+		cacheMutex.Unlock()
 		if err != nil {
 			panic(fmt.Errorf("could not delete cache entry %v: %v", fileCaches[cacheKey], err))
 		}
+	} else {
+		cacheMutex.Unlock()
 	}
 	file, sha256, err = fsContent.Download(taskMount)
 	if err != nil {
 		taskMount.Errorf("Could not fetch from %v into file %v due to %v", fsContent, file, err)
 		return
 	}
+	cacheMutex.Lock()
 	fileCaches[cacheKey] = &Cache{
 		Location: file,
 		Hits:     1,
@@ -734,13 +841,16 @@ func ensureCached(fsContent FSContent, taskMount *TaskMount) (file string, err e
 		Key:      cacheKey,
 		SHA256:   sha256,
 	}
+	cacheMutex.Unlock()
 	if requiredSHA256 == "" {
 		taskMount.Warnf("Download %v of %v has SHA256 %v but task payload does not declare a required value, so content authenticity cannot be verified", file, fsContent, sha256)
 		return
 	}
 	if requiredSHA256 != sha256 {
 		err = fmt.Errorf("Download %v of %v has SHA256 %v but task definition explicitly requires %v; not retrying download as there were no connection failures and HTTP response status code was 200", file, fsContent, sha256, requiredSHA256)
+		cacheMutex.Lock()
 		err2 := fileCaches[cacheKey].Evict(taskMount)
+		cacheMutex.Unlock()
 		if err2 != nil {
 			panic(fmt.Errorf("could not delete cache entry %v: %v", fileCaches[cacheKey], err2))
 		}
@@ -761,7 +871,7 @@ func extract(fsContent FSContent, format string, dir string, taskMount *TaskMoun
 	if err != nil {
 		return
 	}
-	copyToPath := filepath.Join(taskContext.TaskDir, filepath.Base(cacheFile))
+	copyToPath := filepath.Join(taskMount.task.TaskDir(), filepath.Base(cacheFile))
 	defer func() {
 		taskMount.Infof("Removing file '%v'", copyToPath)
 		err2 := os.Remove(copyToPath)
@@ -781,7 +891,7 @@ func extract(fsContent FSContent, format string, dir string, taskMount *TaskMoun
 	taskMount.Infof("Extracting %v file %v to '%v'", format, copyToPath, dir)
 	// Useful for worker logs too (not just task logs)
 	log.Printf("[mounts] Extracting %v file %v to '%v'", format, copyToPath, dir)
-	return unarchive(copyToPath, dir, format, taskMount.task.pd)
+	return unarchive(copyToPath, dir, format, taskMount.task.GetContext(), taskMount.task.pd)
 }
 
 func decompress(fsContent FSContent, format string, file string, taskMount *TaskMount) error {
@@ -804,7 +914,7 @@ func decompress(fsContent FSContent, format string, file string, taskMount *Task
 		// Let's copy rather than move, since we want to be totally sure that the
 		// task can't modify the contents, and setting as read-only is not enough -
 		// the user could change the rights and then modify it.
-		dst, err := CreateFileAsTaskUser(file, taskMount.task.pd)
+		dst, err := CreateFileAsTaskUser(file, taskMount.task.GetContext(), taskMount.task.pd)
 		if err != nil {
 			return fmt.Errorf("not able to create %v as task user: %v", file, err)
 		}
@@ -845,7 +955,7 @@ func decompress(fsContent FSContent, format string, file string, taskMount *Task
 	taskMount.Infof("Decompressing %v file %v to '%v'", format, cacheFile, file)
 	// Useful for worker logs too (not just task logs)
 	log.Printf("[mounts] Decompressing %v file %v to '%v'", format, cacheFile, file)
-	dst, err := CreateFileAsTaskUser(file, taskMount.task.pd)
+	dst, err := CreateFileAsTaskUser(file, taskMount.task.GetContext(), taskMount.task.pd)
 	if err != nil {
 		return fmt.Errorf("not able to create %v as task user: %v", file, err)
 	}
@@ -1135,7 +1245,10 @@ func (taskMount *TaskMount) purgeCaches() error {
 		}
 	}
 	// Round(0) forces wall time calculation instead of monotonic time in case machine slept etc
-	if len(writableCaches) == 0 && time.Now().Round(0).Sub(lastQueriedPurgeCacheService) < 6*time.Hour {
+	cacheMutex.RLock()
+	lastQueried := lastQueriedPurgeCacheService
+	cacheMutex.RUnlock()
+	if len(writableCaches) == 0 && time.Now().Round(0).Sub(lastQueried) < 6*time.Hour {
 		return nil
 	}
 	// In case of clock drift, let's query all purge cache requests created
@@ -1147,10 +1260,12 @@ func (taskMount *TaskMount) purgeCaches() error {
 	// request since the worker started, we won't pass in a "since" date at
 	// all.
 	since := ""
+	cacheMutex.Lock()
 	if !lastQueriedPurgeCacheService.IsZero() {
 		since = tcclient.Time(lastQueriedPurgeCacheService.Add(-5 * time.Minute)).String()
 	}
 	lastQueriedPurgeCacheService = time.Now()
+	cacheMutex.Unlock()
 	pc := serviceFactory.PurgeCache(config.Credentials(), config.RootURL)
 	purgeRequests, err := pc.PurgeRequests(fmt.Sprintf("%s/%s", config.ProvisionerID, config.WorkerType), since)
 	if err != nil {
@@ -1159,6 +1274,8 @@ func (taskMount *TaskMount) purgeCaches() error {
 	// Loop through results, and purge caches when we find an entry. Note,
 	// again to account for clock drift, let's remove caches up to 5 minutes
 	// older than the given "before" date.
+	cacheMutex.Lock()
+	defer cacheMutex.Unlock()
 	for _, request := range purgeRequests.Requests {
 		if cache, exists := directoryCaches[request.CacheName]; exists {
 			if cache.Created.Add(-5 * time.Minute).Before(time.Time(request.Before)) {

--- a/workers/generic-worker/mounts_feature.go
+++ b/workers/generic-worker/mounts_feature.go
@@ -84,17 +84,26 @@ func (cm CacheMap) Remove(entry *Cache) {
 	}
 }
 
-// AcquireCache finds an available (not in-use) pool entry for the given cache
-// name, marks it InUse, and returns it. Returns nil if no entry is available.
+// AcquireCache finds an available (not in-use, not awaiting purge) pool
+// entry for the given cache name, marks it InUse, and returns it.
+// Returns nil if no entry is available.
+//
+// NeedsPurge entries are skipped because their on-disk content is in
+// the process of being deleted (or is partially deleted after a failed
+// purgeCaches RemoveAll). Handing one out would either run a task
+// against half-empty cache content or fail with a RenameCrossDevice
+// error when Mount tries to move it into place.
+//
 // Caller must hold cacheMutex.
 func AcquireCache(name string) *Cache {
 	entries := directoryCaches[name]
 	var best *Cache
 	for _, e := range entries {
-		if !e.InUse {
-			if best == nil || e.LastUsed.After(best.LastUsed) {
-				best = e
-			}
+		if e.InUse || e.NeedsPurge {
+			continue
+		}
+		if best == nil || e.LastUsed.After(best.LastUsed) {
+			best = e
 		}
 	}
 	if best != nil {
@@ -731,7 +740,22 @@ func (f *FileMount) FSContent() (FSContent, error) {
 func (w *WritableDirectoryCache) Mount(taskMount *TaskMount) (err error) {
 	target := fileutil.AbsFrom(taskMount.task.TaskDir(), w.Directory)
 
-	cacheMutex.Lock()
+	// Track cacheMutex through every site in this function so the
+	// recover handler below can tell whether we still hold the lock
+	// at panic time. Re-acquiring an already-held mutex from the same
+	// goroutine deadlocks; this is the safety net the reviewer
+	// flagged as fragile in the original recover-and-relock code.
+	mutexHeld := false
+	lock := func() {
+		cacheMutex.Lock()
+		mutexHeld = true
+	}
+	unlock := func() {
+		cacheMutex.Unlock()
+		mutexHeld = false
+	}
+
+	lock()
 	entry := AcquireCache(w.CacheName)
 
 	// If Mount panics after the pool entry is registered (e.g. a SHA
@@ -744,7 +768,17 @@ func (w *WritableDirectoryCache) Mount(taskMount *TaskMount) (err error) {
 	defer func() {
 		if r := recover(); r != nil {
 			if entry != nil && !released {
-				cacheMutex.Lock()
+				// If we already hold the lock (panic happened
+				// inside one of the brief locked windows), skip
+				// the re-Lock. We still always Unlock at the end
+				// — that releases either the lock we just took
+				// or the one that was held when the panic fired.
+				// Asymmetric Lock/Unlock would leak the mutex
+				// and deadlock subsequent goroutines, which was
+				// the reviewer's concern with my prior fix.
+				if !mutexHeld {
+					cacheMutex.Lock()
+				}
 				_ = entry.Evict(taskMount)
 				cacheMutex.Unlock()
 				delete(taskMount.poolEntries, w)
@@ -755,23 +789,23 @@ func (w *WritableDirectoryCache) Mount(taskMount *TaskMount) (err error) {
 
 	if entry != nil {
 		cacheLocation := entry.Location
-		cacheMutex.Unlock()
+		unlock()
 
 		parentDir := filepath.Dir(target)
 		taskMount.Infof("Moving existing writable directory cache %v from %v to %v", w.CacheName, cacheLocation, target)
 		if mkErr := MkdirAll(taskMount, parentDir); mkErr != nil {
 			// MkdirAll failed — release the acquired entry back to the pool
-			cacheMutex.Lock()
+			lock()
 			ReleaseCache(entry)
-			cacheMutex.Unlock()
+			unlock()
 			released = true
 			return fmt.Errorf("not able to create directory %v: %v", parentDir, mkErr)
 		}
 		if mvErr := RenameCrossDevice(cacheLocation, target); mvErr != nil {
 			// Rename failed — evict the broken entry from the pool
-			cacheMutex.Lock()
+			lock()
 			evictErr := entry.Evict(taskMount)
-			cacheMutex.Unlock()
+			unlock()
 			released = true
 			if evictErr != nil {
 				panic(evictErr)
@@ -784,34 +818,34 @@ func (w *WritableDirectoryCache) Mount(taskMount *TaskMount) (err error) {
 		var poolErr error
 		entry, poolErr = newPoolEntry(w.CacheName)
 		if poolErr != nil {
-			cacheMutex.Unlock()
+			unlock()
 			return poolErr
 		}
 		taskMount.Infof("No existing writable directory cache '%v' - creating %v", w.CacheName, entry.Location)
 		directoryCaches[w.CacheName] = append(directoryCaches[w.CacheName], entry)
-		cacheMutex.Unlock()
+		unlock()
 
 		if w.Content != nil {
 			c, fsErr := FSContentFrom(w.Content)
 			if fsErr != nil {
-				cacheMutex.Lock()
+				lock()
 				_ = entry.Evict(taskMount)
-				cacheMutex.Unlock()
+				unlock()
 				released = true
 				return fmt.Errorf("not able to retrieve FSContent: %v", fsErr)
 			}
 			if extractErr := extract(c, w.Format, target, taskMount); extractErr != nil {
-				cacheMutex.Lock()
+				lock()
 				_ = entry.Evict(taskMount)
-				cacheMutex.Unlock()
+				unlock()
 				released = true
 				return extractErr
 			}
 		} else {
 			if mkErr := MkdirAll(taskMount, target); mkErr != nil {
-				cacheMutex.Lock()
+				lock()
 				_ = entry.Evict(taskMount)
-				cacheMutex.Unlock()
+				unlock()
 				released = true
 				return fmt.Errorf("not able to create directory %v: %v", target, mkErr)
 			}
@@ -825,9 +859,9 @@ func (w *WritableDirectoryCache) Mount(taskMount *TaskMount) (err error) {
 	// resources should be owned by the task user, even if commands
 	// execute as LocalSystem.
 	if chownErr := makeDirReadWritableForTaskUser(taskMount, target); chownErr != nil {
-		cacheMutex.Lock()
+		lock()
 		_ = entry.Evict(taskMount)
-		cacheMutex.Unlock()
+		unlock()
 		delete(taskMount.poolEntries, w)
 		released = true
 		return chownErr
@@ -1473,6 +1507,14 @@ func (taskMount *TaskMount) purgeCaches() error {
 		// mid-loop RemoveAll error doesn't leave directoryCaches pointing
 		// at a partially-overwritten backing array.
 		remaining := make([]*Cache, 0, len(entries))
+		// Collect RemoveAll failures and surface them at the end of
+		// the loop so the map writeback below still runs and entries
+		// whose disk content was successfully removed are dropped.
+		// Returning mid-loop would leave directoryCaches[name] still
+		// referencing the now-deleted entry, and the next task to
+		// AcquireCache for that name would be handed a *Cache whose
+		// Location points at a half-removed directory.
+		var removeErrs []error
 		for _, cache := range entries {
 			if cache.Created.Add(-5 * time.Minute).Before(time.Time(request.Before)) {
 				if cache.InUse {
@@ -1483,8 +1525,15 @@ func (taskMount *TaskMount) purgeCaches() error {
 				}
 				taskMount.Infof("Removing cache %v from cache table (purge request)", cache.Key)
 				taskMount.Infof("Deleting cache %v file(s) at %v", cache.Key, cache.Location)
-				if err := os.RemoveAll(cache.Location); err != nil {
-					return err
+				if rmErr := os.RemoveAll(cache.Location); rmErr != nil {
+					taskMount.Errorf("Could not delete cache %v at %v: %v (will retry on next purge)", cache.Key, cache.Location, rmErr)
+					removeErrs = append(removeErrs, rmErr)
+					// Keep the entry so the next purge sweep retries
+					// the deletion. AcquireCache skips NeedsPurge
+					// entries, so it won't be handed to a follow-up
+					// task in the meantime.
+					cache.NeedsPurge = true
+					remaining = append(remaining, cache)
 				}
 			} else {
 				remaining = append(remaining, cache)
@@ -1494,6 +1543,12 @@ func (taskMount *TaskMount) purgeCaches() error {
 			delete(directoryCaches, request.CacheName)
 		} else {
 			directoryCaches[request.CacheName] = remaining
+		}
+		if len(removeErrs) > 0 {
+			// Surface the first failure once per cache name. Joining
+			// preserves the rest in errors.Is/As traversal if a
+			// caller cares.
+			return errors.Join(removeErrs...)
 		}
 	}
 	return nil

--- a/workers/generic-worker/mounts_insecure.go
+++ b/workers/generic-worker/mounts_insecure.go
@@ -19,12 +19,7 @@ func makeDirReadWritableForTaskUser(taskMount *TaskMount, dir string) error {
 	return nil
 }
 
-func exchangeDirectoryOwnership(taskMount *TaskMount, dir string, cache *Cache) error {
-	// No user separation
-	return nil
-}
-
-func unarchive(source, destination, format string, pd *process.PlatformData) error {
+func unarchive(source, destination, format string, ctx *TaskContext, pd *process.PlatformData) error {
 	cmd, err := process.NewCommand([]string{gwruntime.GenericWorkerBinary(), "unarchive", "--archive-src", source, "--archive-dst", destination, "--archive-fmt", format}, "", []string{})
 	if err != nil {
 		return fmt.Errorf("cannot create process to unarchive %v to %v as task user: %v", source, destination, err)

--- a/workers/generic-worker/mounts_insecure_test.go
+++ b/workers/generic-worker/mounts_insecure_test.go
@@ -15,11 +15,6 @@ func grantingDenying(t *testing.T, filetype string, cacheFile bool, taskPath ...
 	return []string{}, []string{}
 }
 
-func updateOwnership(t *testing.T) []string {
-	t.Helper()
-	return []string{}
-}
-
 // Test for upstream issue https://github.com/mholt/archiver/issues/152
 func TestHardLinksInArchive(t *testing.T) {
 	setup(t)

--- a/workers/generic-worker/mounts_multiuser.go
+++ b/workers/generic-worker/mounts_multiuser.go
@@ -14,57 +14,39 @@ func makeFileReadWritableForTaskUser(taskMount *TaskMount, file string) error {
 }
 
 func makeDirReadWritableForTaskUser(taskMount *TaskMount, dir string) error {
-	return makeReadWritableForTaskUser(taskMount, dir, "directory", true)
-}
-
-func exchangeDirectoryOwnership(taskMount *TaskMount, dir string, cache *Cache) error {
-	// Skip ownership changes for d2g tasks since the ownership of files is decided
-	// by the container itself (there's no mapping)
+	// Skip recursive ownership changes for d2g tasks since file ownership
+	// inside the container is determined by the container itself (there's
+	// no UID mapping). Changing ownership to the host task user would break
+	// the container's expectations (e.g., files created as uid=1000 inside
+	// the container would become owned by a different UID).
 	if taskMount.task.D2GInfo != nil {
 		return nil
 	}
-
-	// It doesn't concern us if payload.features.runTaskAsCurrentUser is set or not
-	// because files inside task directory should be owned/managed by task user
-	newOwnerUsername := taskContext.User.Name
-	newOwnerUID, err := taskContext.User.ID()
-	if err != nil {
-		panic(fmt.Errorf("[mounts] Not able to look up UID for user %v: %w", taskContext.User.Name, err))
-	}
-	taskMount.Infof("Updating ownership of files inside directory '%v' from %v to %v", dir, cache.OwnerUsername, newOwnerUsername)
-	err = changeOwnershipInDir(dir, newOwnerUsername, cache)
-	if err != nil {
-		return fmt.Errorf("[mounts] Not able to update ownership of directory %v from %v (UID %v) to %v (UID %v): %w", dir, cache.OwnerUsername, cache.OwnerUID, newOwnerUsername, newOwnerUID, err)
-	}
-	// now set the OwnerUID to the current task user UID, so that the next
-	// time this cache is mounted, the UID find/replace will replace the
-	// current task user with the next task user that uses it
-	cache.OwnerUsername = newOwnerUsername
-	cache.OwnerUID = newOwnerUID
-	return nil
+	return makeReadWritableForTaskUser(taskMount, dir, "directory", true)
 }
 
 func makeReadWritableForTaskUser(taskMount *TaskMount, fileOrDirectory string, filetype string, recurse bool) error {
 	// It doesn't concern us if payload.features.runTaskAsCurrentUser is set or not
 	// because files inside task directory should be owned/managed by task user
 	// However, if running as current user, taskMount.task.pd is not set, so use
-	// taskContext.User.Name instead of credentials inside taskMount.task.pd.
-	taskMount.Infof("Granting %v full control of %v '%v'", taskContext.User.Name, filetype, fileOrDirectory)
-	err := makeFileOrDirReadWritableForUser(recurse, fileOrDirectory, taskContext.User)
+	// task context's User instead of credentials inside taskMount.task.pd.
+	ctx := taskMount.task.GetContext()
+	taskMount.Infof("Granting %v full control of %v '%v'", ctx.User.Name, filetype, fileOrDirectory)
+	err := makeFileOrDirReadWritableForUser(recurse, fileOrDirectory, ctx.User)
 	if err != nil {
-		return fmt.Errorf("[mounts] Not able to make %v %v writable for %v: %v", filetype, fileOrDirectory, taskContext.User.Name, err)
+		return fmt.Errorf("[mounts] Not able to make %v %v writable for %v: %v", filetype, fileOrDirectory, ctx.User.Name, err)
 	}
 	return nil
 }
 
-func unarchive(source, destination, format string, pd *process.PlatformData) error {
-	cmd, err := process.NewCommand([]string{gwruntime.GenericWorkerBinary(), "unarchive", "--archive-src", source, "--archive-dst", destination, "--archive-fmt", format}, taskContext.TaskDir, []string{}, pd)
+func unarchive(source, destination, format string, ctx *TaskContext, pd *process.PlatformData) error {
+	cmd, err := process.NewCommand([]string{gwruntime.GenericWorkerBinary(), "unarchive", "--archive-src", source, "--archive-dst", destination, "--archive-fmt", format}, ctx.TaskDir, []string{}, pd)
 	if err != nil {
-		return fmt.Errorf("cannot create process to unarchive %v to %v as task user %v from directory %v: %v", source, destination, taskContext.User.Name, taskContext.TaskDir, err)
+		return fmt.Errorf("cannot create process to unarchive %v to %v as task user %v from directory %v: %v", source, destination, ctx.User.Name, ctx.TaskDir, err)
 	}
 	result := cmd.Execute()
 	if result.ExitError != nil {
-		return fmt.Errorf("cannot unarchive %v to %v as task user %v from directory %v: %v", source, destination, taskContext.User.Name, taskContext.TaskDir, result)
+		return fmt.Errorf("cannot unarchive %v to %v as task user %v from directory %v: %v", source, destination, ctx.User.Name, ctx.TaskDir, result)
 	}
 	return nil
 }

--- a/workers/generic-worker/mounts_multiuser_test.go
+++ b/workers/generic-worker/mounts_multiuser_test.go
@@ -44,13 +44,6 @@ func grantingDenying(t *testing.T, filetype string, cacheFile bool, taskPath ...
 		}
 }
 
-func updateOwnership(t *testing.T) []string {
-	t.Helper()
-	return []string{
-		"Updating ownership of files inside directory '.*" + t.Name() + "' from .* to task_[0-9]*",
-	}
-}
-
 func TestTaskUserCannotMountInPrivilegedLocation(t *testing.T) {
 	setup(t)
 

--- a/workers/generic-worker/mounts_multiuser_test.go
+++ b/workers/generic-worker/mounts_multiuser_test.go
@@ -23,7 +23,7 @@ func grantingDenying(t *testing.T, filetype string, cacheFile bool, taskPath ...
 	t.Helper()
 	// We need to escape file path that is contained in final regexp, e.g. due
 	// to '\' path separator on Windows. However, the path also includes an
-	// unknown task user (task_[0-9]*) which we don't want to escape. The
+	// unknown task user (task_\S+) which we don't want to escape. The
 	// simplest way to properly escape the expression but without escaping this
 	// one part of it, is to swap out the task user expression with a randomly
 	// generated slugid (122 bits of randomness) which doesn't contain
@@ -35,12 +35,12 @@ func grantingDenying(t *testing.T, filetype string, cacheFile bool, taskPath ...
 		pathRegExp = ".*"
 	} else {
 		slug := slugid.V4()
-		pathRegExp = strings.ReplaceAll(regexp.QuoteMeta(filepath.Join(testdataDir, t.Name(), "tasks", slug, filepath.Join(taskPath...))), slug, "task_[0-9]*")
+		pathRegExp = strings.ReplaceAll(regexp.QuoteMeta(filepath.Join(testdataDir, t.Name(), "tasks", slug, filepath.Join(taskPath...))), slug, "task_\\S+")
 	}
 	return []string{
-			`Granting task_[0-9]* full control of ` + filetype + ` '` + pathRegExp + `'`,
+			`Granting task_\S+ full control of ` + filetype + ` '` + pathRegExp + `'`,
 		}, []string{
-			`Denying task_[0-9]* access to '.*'`,
+			`Denying task_\S+ access to '.*'`,
 		}
 }
 

--- a/workers/generic-worker/mounts_test.go
+++ b/workers/generic-worker/mounts_test.go
@@ -559,7 +559,7 @@ func TestWritableDirectoryCacheNoSHA256(t *testing.T) {
 	// engine or insecure engine but is independent of whether running as current
 	// user or not.
 	grantingCacheFile, _ := grantingDenying(t, "file", true)
-	updatingOwnership := updateOwnership(t)
+	grantingDir, _ := grantingDenying(t, "directory", false, t.Name())
 
 	// No cache on first pass
 	pass1 := append([]string{
@@ -577,7 +577,7 @@ func TestWritableDirectoryCacheNoSHA256(t *testing.T) {
 		`Removing file '.*'`,
 	)
 	pass1 = append(pass1,
-		updatingOwnership...,
+		grantingDir...,
 	)
 	pass1 = append(pass1,
 		`Successfully mounted writable directory cache '.*`+t.Name()+`'`,
@@ -589,7 +589,7 @@ func TestWritableDirectoryCacheNoSHA256(t *testing.T) {
 		`Moving existing writable directory cache banana-cache from .* to .*` + t.Name(),
 		`Creating directory .*`,
 	},
-		updatingOwnership...,
+		grantingDir...,
 	)
 	pass2 = append(pass2,
 		`Successfully mounted writable directory cache '.*`+t.Name()+`'`,
@@ -917,7 +917,7 @@ func TestCacheMoved(t *testing.T) {
 	// engine or insecure engine but is independent of whether running as current
 	// user or not.
 	grantingCacheFile, _ := grantingDenying(t, "file", true)
-	updatingOwnership := updateOwnership(t)
+	grantingDir, _ := grantingDenying(t, "directory", false, t.Name())
 
 	// No cache on first pass
 	pass1 := append([]string{
@@ -935,7 +935,7 @@ func TestCacheMoved(t *testing.T) {
 		`Removing file '.*'`,
 	)
 	pass1 = append(pass1,
-		updatingOwnership...,
+		grantingDir...,
 	)
 	pass1 = append(pass1,
 		`Successfully mounted writable directory cache '.*`+t.Name()+`'`,
@@ -959,7 +959,7 @@ func TestCacheMoved(t *testing.T) {
 		`Removing file '.*'`,
 	)
 	pass2 = append(pass2,
-		updatingOwnership...,
+		grantingDir...,
 	)
 	pass2 = append(pass2,
 		`Successfully mounted writable directory cache '.*`+t.Name()+`'`,

--- a/workers/generic-worker/mounts_test.go
+++ b/workers/generic-worker/mounts_test.go
@@ -798,7 +798,9 @@ func TestMounts(t *testing.T) {
 		"19168d6dc3cc840bd02658e30d761cd555bb1f2bb42da18edf08917dcaa55cf5",
 		filepath.Join(absPathTestDir, "abs-path-dir", "package.json"),
 	)
-	if _, err := os.Stat(directoryCaches["apple-cache"].Location); err != nil {
+	if entries := directoryCaches["apple-cache"]; len(entries) == 0 {
+		t.Error("Expected apple-cache to be persisted, but no pool entries found")
+	} else if _, err := os.Stat(entries[0].Location); err != nil {
 		t.Errorf("Expected apple-cache to be persisted, but got: %v", err)
 	}
 
@@ -837,7 +839,7 @@ func TestMounts(t *testing.T) {
 	checkSHA256(
 		t,
 		"51d818981374a447f0876610fd2baeeb911dd5ad60c6e6b4d2b6b6798ba5c071",
-		filepath.Join(directoryCaches["devtools-app"].Location, "foo.bar"),
+		filepath.Join(directoryCaches["devtools-app"][0].Location, "foo.bar"),
 	)
 }
 
@@ -873,7 +875,7 @@ func TestCachesCanBeModified(t *testing.T) {
 		}
 
 		getCounter := func() int {
-			counterFile := filepath.Join(directoryCaches["test-modifications"].Location, "counter")
+			counterFile := filepath.Join(directoryCaches["test-modifications"][0].Location, "counter")
 			bytes, err := os.ReadFile(counterFile)
 			if err != nil {
 				t.Fatalf("Error when trying to read cache file: %v", err)

--- a/workers/generic-worker/multiuser.go
+++ b/workers/generic-worker/multiuser.go
@@ -117,7 +117,8 @@ func PostRebootSetup(taskUserCredentials *gwruntime.OSUser) *TaskContext {
 // Panics on error (callers should use recover() if needed).
 func CreateTaskContext(taskDirName string) *TaskContext {
 	// For tests, load from the test user file (the daemon is started with this user)
-	if runningTests {
+	// Exception: In Docker, we exercise the real headless user creation path
+	if runningTests && os.Getenv("GW_IN_DOCKER") != "1" {
 		ntuPath := filepath.Join(cwd, "next-task-user.json")
 		taskUser, err := StoredUserCredentials(ntuPath)
 		if err != nil {

--- a/workers/generic-worker/multiuser.go
+++ b/workers/generic-worker/multiuser.go
@@ -241,6 +241,31 @@ func platformDataForTaskContext(ctx *TaskContext) (*process.PlatformData, error)
 	return process.TaskUserPlatformData(ctx.User, config.HeadlessTasks)
 }
 
+// deleteTaskUserOnCleanup removes the OS user associated with the given
+// TaskContext when the task setup fails before the task goroutine
+// launches. Headless multiuser provisions a fresh user per task in
+// CreateTaskContext; without this, a setup failure (platform data /
+// binary validation / port allocation / mkdir) leaves the account
+// behind until the next purgeOldTasks sweep.
+//
+// Non-headless mode reuses a single shared user across tasks (set up
+// in prepareTaskEnvironment), so we must NOT delete it on per-task
+// cleanup.
+//
+// Under runningTests, CreateTaskContext loads the user from
+// next-task-user.json — the *test framework* owns that user's
+// lifecycle and reuses it across the suite. Deleting it here would
+// break subsequent tests and leave dangling SIDs in ACLs the shared
+// user appears in.
+func deleteTaskUserOnCleanup(ctx *TaskContext) {
+	if runningTests || !config.HeadlessTasks || ctx == nil || ctx.User == nil || ctx.User.Name == "" {
+		return
+	}
+	if err := gwruntime.DeleteUser(ctx.User.Name); err != nil {
+		log.Printf("ERROR deleting task user %s during cleanup: %v", ctx.User.Name, err)
+	}
+}
+
 // purgeOldTasks cleans up old task directories and users.
 // skipDirs contains all task directory names to preserve (running tasks, etc.)
 func purgeOldTasks(skipDirs ...string) error {

--- a/workers/generic-worker/multiuser_test.go
+++ b/workers/generic-worker/multiuser_test.go
@@ -66,10 +66,10 @@ func TestTaskUserCredentialsEnvVarIsWrittenAsCurrentUser(t *testing.T) {
 	_ = submitAndAssert(t, td, payload, "completed", "completed")
 }
 
-// TestPrivilegedGenericWorkerBinaryFailsWorkerAndTask tests that when the generic-worker binary
-// is not accessible to task users (e.g., in a secured directory), the worker exits
-// with INTERNAL_ERROR and the task is reported as exception/internal-error.
-func TestPrivilegedGenericWorkerBinaryFailsWorkerAndTask(t *testing.T) {
+// TestPrivilegedGenericWorkerBinaryFailsTask tests that when the generic-worker binary
+// is not accessible to task users (e.g., in a secured directory), the task is
+// reported as exception/internal-error but the worker continues normally.
+func TestPrivilegedGenericWorkerBinaryFailsTask(t *testing.T) {
 	setup(t)
 
 	goPath, err := host.Output("go", "env", "GOPATH")
@@ -107,7 +107,7 @@ func TestPrivilegedGenericWorkerBinaryFailsWorkerAndTask(t *testing.T) {
 	}()
 
 	// Submit a task - it should fail with internal-error because the binary isn't accessible
-	// and the worker should exit with INTERNAL_ERROR (not TASKS_COMPLETE)
+	// but the worker should continue normally (not crash with INTERNAL_ERROR)
 	payload := GenericWorkerPayload{
 		Command:    helloGoodbye(),
 		MaxRunTime: 180,
@@ -118,8 +118,9 @@ func TestPrivilegedGenericWorkerBinaryFailsWorkerAndTask(t *testing.T) {
 	taskID := scheduleTask(t, td, payload)
 	t.Logf("Scheduled task %s", taskID)
 
-	// Worker should exit with INTERNAL_ERROR because binary validation fails
-	execute(t, INTERNAL_ERROR)
+	// Worker continues normally — the failed task is reported as exception
+	// but does not kill the worker
+	execute(t, TASKS_COMPLETE)
 
 	// Verify the task was reported as exception/internal-error
 	queue := serviceFactory.Queue(config.Credentials(), config.RootURL)

--- a/workers/generic-worker/multiuser_windows.go
+++ b/workers/generic-worker/multiuser_windows.go
@@ -68,11 +68,12 @@ func deleteDir(path string) error {
 }
 
 func (task *TaskRun) generateCommand(index int) error {
+	taskDir := task.TaskDir()
 	commandName := fmt.Sprintf("command_%06d", index)
-	wrapper := fileutil.AbsFrom(taskContext.TaskDir, commandName+"_wrapper.bat")
+	wrapper := fileutil.AbsFrom(taskDir, commandName+"_wrapper.bat")
 	log.Printf("Creating wrapper script: %v", wrapper)
 	task.pd.HideCmdWindow = task.Payload.Features.HideCmdWindow
-	command, err := process.NewCommand([]string{wrapper}, taskContext.TaskDir, nil, task.pd)
+	command, err := process.NewCommand([]string{wrapper}, taskDir, nil, task.pd)
 	if err != nil {
 		return err
 	}
@@ -86,11 +87,12 @@ func (task *TaskRun) generateCommand(index int) error {
 func (task *TaskRun) prepareCommand(index int) *CommandExecutionError {
 	// In order that capturing of log files works, create a custom .bat file
 	// for the task which redirects output to a log file...
-	env := fileutil.AbsFrom(taskContext.TaskDir, "env.txt")
-	dir := fileutil.AbsFrom(taskContext.TaskDir, "dir.txt")
+	taskDir := task.TaskDir()
+	env := fileutil.AbsFrom(taskDir, "env.txt")
+	dir := fileutil.AbsFrom(taskDir, "dir.txt")
 	commandName := fmt.Sprintf("command_%06d", index)
-	wrapper := fileutil.AbsFrom(taskContext.TaskDir, commandName+"_wrapper.bat")
-	script := fileutil.AbsFrom(taskContext.TaskDir, commandName+".bat")
+	wrapper := fileutil.AbsFrom(taskDir, commandName+"_wrapper.bat")
+	script := fileutil.AbsFrom(taskDir, commandName+".bat")
 	contents := ":: This script runs command " + strconv.Itoa(index) + " defined in TaskId " + task.TaskID + "..." + "\r\n"
 	contents += "@echo off\r\n"
 
@@ -119,12 +121,11 @@ func (task *TaskRun) prepareCommand(index int) *CommandExecutionError {
 		}
 		contents += setEnvVarCommand("TASK_ID", task.TaskID)
 		contents += setEnvVarCommand("RUN_ID", strconv.Itoa(int(task.RunID)))
-		contents += setEnvVarCommand("TASK_WORKDIR", taskContext.TaskDir)
+		contents += setEnvVarCommand("TASK_WORKDIR", taskDir)
 		contents += setEnvVarCommand("TASK_GROUP_ID", task.TaskGroupID)
 		contents += setEnvVarCommand("TASKCLUSTER_ROOT_URL", config.RootURL)
-		if task.Payload.Features.RunTaskAsCurrentUser {
-			contents += setEnvVarCommand("TASK_USER_CREDENTIALS", ctuPath)
-		}
+		// Note: TASK_USER_CREDENTIALS is set via platformSpecificActions() in
+		// RunTaskAsCurrentUserTask.Start() and comes through task.Payload.Env
 		if config.WorkerLocation != "" {
 			// Note, in contrast to other shells, the cmd shell set command
 			// expects literal bytes between the `=` character and the line
@@ -137,7 +138,7 @@ func (task *TaskRun) prepareCommand(index int) *CommandExecutionError {
 			// ending, i.e. no string escaping required!
 			contents += setEnvVarCommand("TASKCLUSTER_INSTANCE_TYPE", config.InstanceType)
 		}
-		contents += "cd \"" + taskContext.TaskDir + "\"" + "\r\n"
+		contents += "cd \"" + taskDir + "\"" + "\r\n"
 
 		// Otherwise get the env from the previous command
 	} else {
@@ -561,31 +562,6 @@ func PreRebootSetup(nextTaskUser *gwruntime.OSUser) {
 	}
 }
 
-func changeOwnershipInDir(dir, newOwnerUsername string, cache *Cache) error {
-	if dir == "" || newOwnerUsername == "" || cache == nil {
-		return fmt.Errorf("directory path, new owner username, and cache must not be empty")
-	}
-
-	// Do nothing if the current owner is the same as the new owner
-	if cache.OwnerUsername == newOwnerUsername {
-		return nil
-	}
-
-	// Reset to inherited permissions only, recursively
-	out, err := host.Output("icacls", dir, "/reset", "/t", "/c", "/q")
-	if err != nil {
-		return fmt.Errorf("failed to reset permissions on dir %v: %v\n%v", dir, err, out)
-	}
-
-	// Grant full control to new owner, adding to inherited permissions
-	out, err = host.Output("icacls", dir, "/grant", newOwnerUsername+":(OI)(CI)F")
-	if err != nil {
-		return fmt.Errorf("failed to grant permissions to %v on dir %v: %v\n%v", newOwnerUsername, dir, err, out)
-	}
-
-	return nil
-}
-
 func convertNilToEmptyString(val any) string {
 	if val == nil {
 		return ""
@@ -598,7 +574,7 @@ func (task *TaskRun) generateInteractiveCommand(d2gConversionInfo interface{}, c
 	for k, v := range task.Payload.Env {
 		envVars = append(envVars, k+"="+win32.CMDExeEscape(v))
 	}
-	return interactive.StartConPty([]string{"c:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe"}, taskContext.TaskDir, envVars, windows.Token(task.pd.CommandAccessToken))
+	return interactive.StartConPty([]string{"c:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe"}, task.TaskDir(), envVars, windows.Token(task.pd.CommandAccessToken))
 }
 
 func (task *TaskRun) generateInteractiveIsReadyCommand(d2gConversionInfo interface{}, ctx context.Context) (*exec.Cmd, error) {

--- a/workers/generic-worker/os_groups_multiuser.go
+++ b/workers/generic-worker/os_groups_multiuser.go
@@ -23,9 +23,10 @@ func (osGroups *OSGroups) Start() *CommandExecutionError {
 		osGroups.Task.Infof("Not adding task user to group(s) %v since we are running as current user.", groupNames)
 		return nil
 	}
+	ctx := osGroups.Task.GetContext()
 	notAddedGroupNames := []string{}
 	for _, groupName := range groupNames {
-		err := addUserToGroup(taskContext.User.Name, groupName)
+		err := addUserToGroup(ctx.User.Name, groupName)
 		if err != nil {
 			notAddedGroupNames = append(notAddedGroupNames, groupName)
 			osGroups.Task.Errorf("[osGroups] Could not add task user to OS group %v: %v", groupName, err)
@@ -46,9 +47,10 @@ func (osGroups *OSGroups) Start() *CommandExecutionError {
 }
 
 func (osGroups *OSGroups) Stop(err *ExecutionErrors) {
+	ctx := osGroups.Task.GetContext()
 	notRemovedGroupNames := []string{}
 	for _, group := range osGroups.AddedGroups {
-		e := removeUserFromGroup(taskContext.User.Name, group.Name)
+		e := removeUserFromGroup(ctx.User.Name, group.Name)
 		if e != nil {
 			notRemovedGroupNames = append(notRemovedGroupNames, group.Name)
 			osGroups.Task.Errorf("[osGroups] Could not remove task user from OS group %v: %v", group, e)

--- a/workers/generic-worker/os_groups_multiuser_darwin.go
+++ b/workers/generic-worker/os_groups_multiuser_darwin.go
@@ -7,9 +7,9 @@ import (
 )
 
 func addUserToGroup(user, group string) error {
-	return host.Run("/usr/sbin/dseditgroup", "-o", "edit", "-a", taskContext.User.Name, "-t", "user", group)
+	return host.Run("/usr/sbin/dseditgroup", "-o", "edit", "-a", user, "-t", "user", group)
 }
 
 func removeUserFromGroup(user, group string) error {
-	return host.Run("/usr/sbin/dseditgroup", "-o", "edit", "-d", taskContext.User.Name, "-t", "user", group)
+	return host.Run("/usr/sbin/dseditgroup", "-o", "edit", "-d", user, "-t", "user", group)
 }

--- a/workers/generic-worker/os_groups_multiuser_freebsd.go
+++ b/workers/generic-worker/os_groups_multiuser_freebsd.go
@@ -8,10 +8,10 @@ import (
 
 func addUserToGroup(user, group string) error {
 	// TODO copied from Linux version, need to find out what to do for FreeBSD
-	return host.Run("/usr/sbin/usermod", "-aG", group, taskContext.User.Name)
+	return host.Run("/usr/sbin/usermod", "-aG", group, user)
 }
 
 func removeUserFromGroup(user, group string) error {
 	// TODO copied from Linux version, need to find out what to do for FreeBSD
-	return host.Run("/usr/bin/gpasswd", "-d", taskContext.User.Name, group)
+	return host.Run("/usr/bin/gpasswd", "-d", user, group)
 }

--- a/workers/generic-worker/os_groups_multiuser_linux.go
+++ b/workers/generic-worker/os_groups_multiuser_linux.go
@@ -7,9 +7,9 @@ import (
 )
 
 func addUserToGroup(user, group string) error {
-	return host.Run("/usr/sbin/usermod", "-aG", group, taskContext.User.Name)
+	return host.Run("/usr/sbin/usermod", "-aG", group, user)
 }
 
 func removeUserFromGroup(user, group string) error {
-	return host.Run("/usr/bin/gpasswd", "-d", taskContext.User.Name, group)
+	return host.Run("/usr/bin/gpasswd", "-d", user, group)
 }

--- a/workers/generic-worker/os_groups_multiuser_windows.go
+++ b/workers/generic-worker/os_groups_multiuser_windows.go
@@ -7,15 +7,16 @@ import (
 )
 
 func addUserToGroup(user, group string) error {
-	return host.Run("powershell", "-Command", "Add-LocalGroupMember -Group '"+group+"' -Member '"+taskContext.User.Name+"'")
+	return host.Run("powershell", "-Command", "Add-LocalGroupMember -Group '"+group+"' -Member '"+user+"'")
 }
 
 func removeUserFromGroup(user, group string) error {
-	return host.Run("powershell", "-Command", "Remove-LocalGroupMember -Group '"+group+"' -Member '"+taskContext.User.Name+"'")
+	return host.Run("powershell", "-Command", "Remove-LocalGroupMember -Group '"+group+"' -Member '"+user+"'")
 }
 
 func (osGroups *OSGroups) refreshTaskCommands() (err *CommandExecutionError) {
-	osGroups.Task.pd.RefreshLoginSession(taskContext.User.Name, taskContext.User.Password, !config.HeadlessTasks)
+	ctx := osGroups.Task.GetContext()
+	osGroups.Task.pd.RefreshLoginSession(ctx.User.Name, ctx.User.Password, !config.HeadlessTasks)
 	for _, command := range osGroups.Task.Commands {
 		command.SysProcAttr.Token = osGroups.Task.pd.LoginInfo.AccessToken()
 	}

--- a/workers/generic-worker/os_groups_multiuser_windows.go
+++ b/workers/generic-worker/os_groups_multiuser_windows.go
@@ -7,11 +7,13 @@ import (
 )
 
 func addUserToGroup(user, group string) error {
-	return host.Run("powershell", "-Command", "Add-LocalGroupMember -Group '"+group+"' -Member '"+user+"'")
+	return host.Run("powershell", "-Command",
+		"Add-LocalGroupMember -Group '"+host.EscapePowerShellSingleQuote(group)+"' -Member '"+host.EscapePowerShellSingleQuote(user)+"'")
 }
 
 func removeUserFromGroup(user, group string) error {
-	return host.Run("powershell", "-Command", "Remove-LocalGroupMember -Group '"+group+"' -Member '"+user+"'")
+	return host.Run("powershell", "-Command",
+		"Remove-LocalGroupMember -Group '"+host.EscapePowerShellSingleQuote(group)+"' -Member '"+host.EscapePowerShellSingleQuote(user)+"'")
 }
 
 func (osGroups *OSGroups) refreshTaskCommands() (err *CommandExecutionError) {

--- a/workers/generic-worker/port_manager.go
+++ b/workers/generic-worker/port_manager.go
@@ -7,10 +7,11 @@ import (
 	"github.com/taskcluster/taskcluster/v99/workers/generic-worker/gwconfig"
 )
 
-// Port allocation indices within a task's port block
+// Port allocation indices within a task's port block.
+// LiveLog convention: base port = PUT, base+1 = GET.
 const (
-	PortIndexLiveLogGET       = 0
-	PortIndexLiveLogPUT       = 1
+	PortIndexLiveLogPUT       = 0
+	PortIndexLiveLogGET       = 1
 	PortIndexInteractive      = 2
 	PortIndexTaskclusterProxy = 3
 )
@@ -62,8 +63,8 @@ func (pm *PortManager) AllocatePorts(taskID string) ([]uint16, error) {
 	// Calculate ports for this slot
 	offset := uint16(slot) * uint16(gwconfig.PortsPerTask)
 	ports := []uint16{
-		pm.liveLogBase + offset,     // LiveLog GET
-		pm.liveLogBase + offset + 1, // LiveLog PUT
+		pm.liveLogBase + offset,     // LiveLog PUT (base port)
+		pm.liveLogBase + offset + 1, // LiveLog GET (base + 1)
 		pm.interactiveBase + offset, // Interactive
 		pm.proxyBase + offset,       // TaskclusterProxy
 	}
@@ -92,15 +93,15 @@ func (pm *PortManager) GetPorts(taskID string) []uint16 {
 	return pm.allocated[taskID]
 }
 
-// LiveLogPorts returns the LiveLog GET and PUT ports for a task.
-func (pm *PortManager) LiveLogPorts(taskID string) (getPort, putPort uint16, ok bool) {
+// LiveLogPorts returns the LiveLog PUT and GET ports for a task.
+func (pm *PortManager) LiveLogPorts(taskID string) (putPort, getPort uint16, ok bool) {
 	pm.Lock()
 	defer pm.Unlock()
 	ports, exists := pm.allocated[taskID]
 	if !exists || len(ports) < 2 {
 		return 0, 0, false
 	}
-	return ports[PortIndexLiveLogGET], ports[PortIndexLiveLogPUT], true
+	return ports[PortIndexLiveLogPUT], ports[PortIndexLiveLogGET], true
 }
 
 // InteractivePort returns the Interactive port for a task.

--- a/workers/generic-worker/port_manager.go
+++ b/workers/generic-worker/port_manager.go
@@ -20,31 +20,41 @@ const (
 // Each task gets a block of ports based on the configured base ports.
 type PortManager struct {
 	sync.Mutex
-	allocated       map[string][]uint16 // taskID -> allocated ports
-	slots           map[string]uint8    // taskID -> slot index
-	usedSlots       map[uint8]bool      // slot index -> in use
-	liveLogBase     uint16
-	interactiveBase uint16
-	proxyBase       uint16
-	capacity        uint8
+	allocated         map[string][]uint16 // taskID -> allocated ports
+	slots             map[string]uint8    // taskID -> slot index
+	usedSlots         map[uint8]bool      // slot index -> in use
+	liveLogBase       uint16
+	interactiveBase   uint16
+	proxyBase         uint16
+	enableLiveLog     bool
+	enableInteractive bool
+	enableProxy       bool
+	capacity          uint8
 }
 
 // NewPortManager creates a new PortManager.
-// basePort is used to calculate dynamic ports for each task slot.
-func NewPortManager(liveLogBase, interactiveBase, proxyBase uint16, capacity uint8) *PortManager {
+// The base ports and enable* flags must match the worker config; ports
+// for disabled features are returned as 0 to match the validator's
+// behavior (which also skips overlap checks for disabled features).
+func NewPortManager(c *gwconfig.PublicConfig) *PortManager {
 	return &PortManager{
-		allocated:       make(map[string][]uint16),
-		slots:           make(map[string]uint8),
-		usedSlots:       make(map[uint8]bool),
-		liveLogBase:     liveLogBase,
-		interactiveBase: interactiveBase,
-		proxyBase:       proxyBase,
-		capacity:        capacity,
+		allocated:         make(map[string][]uint16),
+		slots:             make(map[string]uint8),
+		usedSlots:         make(map[uint8]bool),
+		liveLogBase:       c.LiveLogPortBase,
+		interactiveBase:   c.InteractivePort,
+		proxyBase:         c.TaskclusterProxyPort,
+		enableLiveLog:     c.EnableLiveLog,
+		enableInteractive: c.EnableInteractive,
+		enableProxy:       c.EnableTaskclusterProxy,
+		capacity:          c.Capacity,
 	}
 }
 
 // AllocatePorts allocates a block of ports for a task.
 // Returns the allocated ports or an error if no slots are available.
+// Disabled features get 0 in their slot — callers should consult the
+// corresponding Enable* config flag before using a port.
 func (pm *PortManager) AllocatePorts(taskID string) ([]uint16, error) {
 	pm.Lock()
 	defer pm.Unlock()
@@ -60,13 +70,17 @@ func (pm *PortManager) AllocatePorts(taskID string) ([]uint16, error) {
 		return nil, fmt.Errorf("no available port slots (capacity=%d, allocated=%d)", pm.capacity, len(pm.allocated))
 	}
 
-	// Calculate ports for this slot
 	offset := uint16(slot) * uint16(gwconfig.PortsPerTask)
-	ports := []uint16{
-		pm.liveLogBase + offset,     // LiveLog PUT (base port)
-		pm.liveLogBase + offset + 1, // LiveLog GET (base + 1)
-		pm.interactiveBase + offset, // Interactive
-		pm.proxyBase + offset,       // TaskclusterProxy
+	ports := make([]uint16, gwconfig.PortsPerTask)
+	if pm.enableLiveLog {
+		ports[PortIndexLiveLogPUT] = pm.liveLogBase + offset
+		ports[PortIndexLiveLogGET] = pm.liveLogBase + offset + 1
+	}
+	if pm.enableInteractive {
+		ports[PortIndexInteractive] = pm.interactiveBase + offset
+	}
+	if pm.enableProxy {
+		ports[PortIndexTaskclusterProxy] = pm.proxyBase + offset
 	}
 
 	pm.allocated[taskID] = ports
@@ -86,11 +100,19 @@ func (pm *PortManager) ReleasePorts(taskID string) {
 	delete(pm.slots, taskID)
 }
 
-// GetPorts returns the ports allocated to a task, or nil if not allocated.
+// GetPorts returns a copy of the ports allocated to a task, or nil if
+// not allocated. A copy is returned so callers can't mutate the
+// internal slice.
 func (pm *PortManager) GetPorts(taskID string) []uint16 {
 	pm.Lock()
 	defer pm.Unlock()
-	return pm.allocated[taskID]
+	ports, ok := pm.allocated[taskID]
+	if !ok {
+		return nil
+	}
+	result := make([]uint16, len(ports))
+	copy(result, ports)
+	return result
 }
 
 // LiveLogPorts returns the LiveLog PUT and GET ports for a task.

--- a/workers/generic-worker/port_manager.go
+++ b/workers/generic-worker/port_manager.go
@@ -1,0 +1,137 @@
+package main
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/taskcluster/taskcluster/v99/workers/generic-worker/gwconfig"
+)
+
+// Port allocation indices within a task's port block
+const (
+	PortIndexLiveLogGET       = 0
+	PortIndexLiveLogPUT       = 1
+	PortIndexInteractive      = 2
+	PortIndexTaskclusterProxy = 3
+)
+
+// PortManager manages dynamic port allocation for concurrent tasks.
+// Each task gets a block of ports based on the configured base ports.
+type PortManager struct {
+	sync.Mutex
+	allocated       map[string][]uint16 // taskID -> allocated ports
+	slots           map[string]uint8    // taskID -> slot index
+	usedSlots       map[uint8]bool      // slot index -> in use
+	liveLogBase     uint16
+	interactiveBase uint16
+	proxyBase       uint16
+	capacity        uint8
+}
+
+// NewPortManager creates a new PortManager.
+// basePort is used to calculate dynamic ports for each task slot.
+func NewPortManager(liveLogBase, interactiveBase, proxyBase uint16, capacity uint8) *PortManager {
+	return &PortManager{
+		allocated:       make(map[string][]uint16),
+		slots:           make(map[string]uint8),
+		usedSlots:       make(map[uint8]bool),
+		liveLogBase:     liveLogBase,
+		interactiveBase: interactiveBase,
+		proxyBase:       proxyBase,
+		capacity:        capacity,
+	}
+}
+
+// AllocatePorts allocates a block of ports for a task.
+// Returns the allocated ports or an error if no slots are available.
+func (pm *PortManager) AllocatePorts(taskID string) ([]uint16, error) {
+	pm.Lock()
+	defer pm.Unlock()
+
+	// Check if already allocated
+	if ports, exists := pm.allocated[taskID]; exists {
+		return ports, nil
+	}
+
+	// Find an available slot
+	slot, ok := pm.findAvailableSlot()
+	if !ok {
+		return nil, fmt.Errorf("no available port slots (capacity=%d, allocated=%d)", pm.capacity, len(pm.allocated))
+	}
+
+	// Calculate ports for this slot
+	offset := uint16(slot) * uint16(gwconfig.PortsPerTask)
+	ports := []uint16{
+		pm.liveLogBase + offset,     // LiveLog GET
+		pm.liveLogBase + offset + 1, // LiveLog PUT
+		pm.interactiveBase + offset, // Interactive
+		pm.proxyBase + offset,       // TaskclusterProxy
+	}
+
+	pm.allocated[taskID] = ports
+	pm.slots[taskID] = slot
+	pm.usedSlots[slot] = true
+	return ports, nil
+}
+
+// ReleasePorts releases the ports allocated to a task.
+func (pm *PortManager) ReleasePorts(taskID string) {
+	pm.Lock()
+	defer pm.Unlock()
+	if slot, exists := pm.slots[taskID]; exists {
+		delete(pm.usedSlots, slot)
+	}
+	delete(pm.allocated, taskID)
+	delete(pm.slots, taskID)
+}
+
+// GetPorts returns the ports allocated to a task, or nil if not allocated.
+func (pm *PortManager) GetPorts(taskID string) []uint16 {
+	pm.Lock()
+	defer pm.Unlock()
+	return pm.allocated[taskID]
+}
+
+// LiveLogPorts returns the LiveLog GET and PUT ports for a task.
+func (pm *PortManager) LiveLogPorts(taskID string) (getPort, putPort uint16, ok bool) {
+	pm.Lock()
+	defer pm.Unlock()
+	ports, exists := pm.allocated[taskID]
+	if !exists || len(ports) < 2 {
+		return 0, 0, false
+	}
+	return ports[PortIndexLiveLogGET], ports[PortIndexLiveLogPUT], true
+}
+
+// InteractivePort returns the Interactive port for a task.
+func (pm *PortManager) InteractivePort(taskID string) (uint16, bool) {
+	pm.Lock()
+	defer pm.Unlock()
+	ports, exists := pm.allocated[taskID]
+	if !exists || len(ports) <= PortIndexInteractive {
+		return 0, false
+	}
+	return ports[PortIndexInteractive], true
+}
+
+// TaskclusterProxyPort returns the TaskclusterProxy port for a task.
+func (pm *PortManager) TaskclusterProxyPort(taskID string) (uint16, bool) {
+	pm.Lock()
+	defer pm.Unlock()
+	ports, exists := pm.allocated[taskID]
+	if !exists || len(ports) <= PortIndexTaskclusterProxy {
+		return 0, false
+	}
+	return ports[PortIndexTaskclusterProxy], true
+}
+
+// findAvailableSlot returns the first available slot index.
+// Must be called with the lock held.
+func (pm *PortManager) findAvailableSlot() (uint8, bool) {
+	for i := uint8(0); i < pm.capacity; i++ {
+		if !pm.usedSlots[i] {
+			return i, true
+		}
+	}
+	return 0, false
+}

--- a/workers/generic-worker/port_manager_test.go
+++ b/workers/generic-worker/port_manager_test.go
@@ -7,8 +7,22 @@ import (
 	"github.com/taskcluster/taskcluster/v99/workers/generic-worker/gwconfig"
 )
 
+// testConfig builds a PublicConfig with all three port-using features
+// enabled, so AllocatePorts populates every slot.
+func testConfig(liveLog, interactive, proxy uint16, capacity uint8) *gwconfig.PublicConfig {
+	return &gwconfig.PublicConfig{
+		Capacity:               capacity,
+		EnableLiveLog:          true,
+		EnableInteractive:      true,
+		EnableTaskclusterProxy: true,
+		LiveLogPortBase:        liveLog,
+		InteractivePort:        interactive,
+		TaskclusterProxyPort:   proxy,
+	}
+}
+
 func TestPortManagerAllocatePorts(t *testing.T) {
-	pm := NewPortManager(60000, 53000, 8080, 3)
+	pm := NewPortManager(testConfig(60000, 53000, 8080, 3))
 
 	// Allocate ports for first task
 	ports1, err := pm.AllocatePorts("task1")
@@ -41,7 +55,7 @@ func TestPortManagerAllocatePorts(t *testing.T) {
 }
 
 func TestPortManagerReleasePorts(t *testing.T) {
-	pm := NewPortManager(60000, 53000, 8080, 2)
+	pm := NewPortManager(testConfig(60000, 53000, 8080, 2))
 
 	// Allocate all capacity
 	_, err := pm.AllocatePorts("task1")
@@ -64,7 +78,7 @@ func TestPortManagerReleasePorts(t *testing.T) {
 }
 
 func TestPortManagerGetPorts(t *testing.T) {
-	pm := NewPortManager(60000, 53000, 8080, 2)
+	pm := NewPortManager(testConfig(60000, 53000, 8080, 2))
 
 	// Not allocated yet
 	require.Nil(t, pm.GetPorts("task1"))
@@ -82,7 +96,7 @@ func TestPortManagerGetPorts(t *testing.T) {
 }
 
 func TestPortManagerLiveLogPorts(t *testing.T) {
-	pm := NewPortManager(60000, 53000, 8080, 2)
+	pm := NewPortManager(testConfig(60000, 53000, 8080, 2))
 
 	// Not allocated
 	_, _, ok := pm.LiveLogPorts("task1")
@@ -99,7 +113,7 @@ func TestPortManagerLiveLogPorts(t *testing.T) {
 }
 
 func TestPortManagerInteractivePort(t *testing.T) {
-	pm := NewPortManager(60000, 53000, 8080, 2)
+	pm := NewPortManager(testConfig(60000, 53000, 8080, 2))
 
 	// Not allocated
 	_, ok := pm.InteractivePort("task1")
@@ -115,7 +129,7 @@ func TestPortManagerInteractivePort(t *testing.T) {
 }
 
 func TestPortManagerTaskclusterProxyPort(t *testing.T) {
-	pm := NewPortManager(60000, 53000, 8080, 2)
+	pm := NewPortManager(testConfig(60000, 53000, 8080, 2))
 
 	// Not allocated
 	_, ok := pm.TaskclusterProxyPort("task1")
@@ -131,7 +145,7 @@ func TestPortManagerTaskclusterProxyPort(t *testing.T) {
 }
 
 func TestPortManagerIdempotentAllocation(t *testing.T) {
-	pm := NewPortManager(60000, 53000, 8080, 2)
+	pm := NewPortManager(testConfig(60000, 53000, 8080, 2))
 
 	// First allocation
 	ports1, err := pm.AllocatePorts("task1")
@@ -144,7 +158,7 @@ func TestPortManagerIdempotentAllocation(t *testing.T) {
 }
 
 func TestPortManagerSlotReuse(t *testing.T) {
-	pm := NewPortManager(60000, 53000, 8080, 3)
+	pm := NewPortManager(testConfig(60000, 53000, 8080, 3))
 
 	// Allocate slots 0, 1, 2
 	_, _ = pm.AllocatePorts("task1") // slot 0
@@ -159,4 +173,37 @@ func TestPortManagerSlotReuse(t *testing.T) {
 	require.NoError(t, err)
 	// Slot 1 means offset of 4 (PortsPerTask)
 	require.Equal(t, uint16(60004), ports[PortIndexLiveLogPUT])
+}
+
+func TestPortManagerDisabledFeaturesGetZero(t *testing.T) {
+	c := &gwconfig.PublicConfig{
+		Capacity:             2,
+		EnableLiveLog:        false,
+		EnableInteractive:    true,
+		LiveLogPortBase:      0,
+		InteractivePort:      53000,
+		TaskclusterProxyPort: 8080,
+		// EnableTaskclusterProxy intentionally unset
+	}
+	pm := NewPortManager(c)
+	ports, err := pm.AllocatePorts("task1")
+	require.NoError(t, err)
+	require.Len(t, ports, gwconfig.PortsPerTask)
+	require.Equal(t, uint16(0), ports[PortIndexLiveLogPUT])
+	require.Equal(t, uint16(0), ports[PortIndexLiveLogGET])
+	require.Equal(t, uint16(53000), ports[PortIndexInteractive])
+	require.Equal(t, uint16(0), ports[PortIndexTaskclusterProxy])
+}
+
+func TestPortManagerGetPortsReturnsCopy(t *testing.T) {
+	pm := NewPortManager(testConfig(60000, 53000, 8080, 2))
+	_, err := pm.AllocatePorts("task1")
+	require.NoError(t, err)
+
+	got := pm.GetPorts("task1")
+	got[0] = 99 // mutate the returned slice
+
+	// Subsequent reads must not see the mutation
+	again := pm.GetPorts("task1")
+	require.Equal(t, uint16(60000), again[PortIndexLiveLogPUT])
 }

--- a/workers/generic-worker/port_manager_test.go
+++ b/workers/generic-worker/port_manager_test.go
@@ -14,8 +14,8 @@ func TestPortManagerAllocatePorts(t *testing.T) {
 	ports1, err := pm.AllocatePorts("task1")
 	require.NoError(t, err)
 	require.Len(t, ports1, gwconfig.PortsPerTask)
-	require.Equal(t, uint16(60000), ports1[PortIndexLiveLogGET])
-	require.Equal(t, uint16(60001), ports1[PortIndexLiveLogPUT])
+	require.Equal(t, uint16(60000), ports1[PortIndexLiveLogPUT])
+	require.Equal(t, uint16(60001), ports1[PortIndexLiveLogGET])
 	require.Equal(t, uint16(53000), ports1[PortIndexInteractive])
 	require.Equal(t, uint16(8080), ports1[PortIndexTaskclusterProxy])
 
@@ -24,8 +24,8 @@ func TestPortManagerAllocatePorts(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, ports2, gwconfig.PortsPerTask)
 	// Ports should be offset by gwconfig.PortsPerTask (4)
-	require.Equal(t, uint16(60004), ports2[PortIndexLiveLogGET])
-	require.Equal(t, uint16(60005), ports2[PortIndexLiveLogPUT])
+	require.Equal(t, uint16(60004), ports2[PortIndexLiveLogPUT])
+	require.Equal(t, uint16(60005), ports2[PortIndexLiveLogGET])
 	require.Equal(t, uint16(53004), ports2[PortIndexInteractive])
 	require.Equal(t, uint16(8084), ports2[PortIndexTaskclusterProxy])
 
@@ -60,7 +60,7 @@ func TestPortManagerReleasePorts(t *testing.T) {
 	ports3, err := pm.AllocatePorts("task3")
 	require.NoError(t, err)
 	// Should reuse slot 0
-	require.Equal(t, uint16(60000), ports3[PortIndexLiveLogGET])
+	require.Equal(t, uint16(60000), ports3[PortIndexLiveLogPUT])
 }
 
 func TestPortManagerGetPorts(t *testing.T) {
@@ -92,10 +92,10 @@ func TestPortManagerLiveLogPorts(t *testing.T) {
 	_, err := pm.AllocatePorts("task1")
 	require.NoError(t, err)
 
-	getPort, putPort, ok := pm.LiveLogPorts("task1")
+	putPort, getPort, ok := pm.LiveLogPorts("task1")
 	require.True(t, ok)
-	require.Equal(t, uint16(60000), getPort)
-	require.Equal(t, uint16(60001), putPort)
+	require.Equal(t, uint16(60000), putPort)
+	require.Equal(t, uint16(60001), getPort)
 }
 
 func TestPortManagerInteractivePort(t *testing.T) {
@@ -158,5 +158,5 @@ func TestPortManagerSlotReuse(t *testing.T) {
 	ports, err := pm.AllocatePorts("task4")
 	require.NoError(t, err)
 	// Slot 1 means offset of 4 (PortsPerTask)
-	require.Equal(t, uint16(60004), ports[PortIndexLiveLogGET])
+	require.Equal(t, uint16(60004), ports[PortIndexLiveLogPUT])
 }

--- a/workers/generic-worker/port_manager_test.go
+++ b/workers/generic-worker/port_manager_test.go
@@ -1,0 +1,162 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/taskcluster/taskcluster/v99/workers/generic-worker/gwconfig"
+)
+
+func TestPortManagerAllocatePorts(t *testing.T) {
+	pm := NewPortManager(60000, 53000, 8080, 3)
+
+	// Allocate ports for first task
+	ports1, err := pm.AllocatePorts("task1")
+	require.NoError(t, err)
+	require.Len(t, ports1, gwconfig.PortsPerTask)
+	require.Equal(t, uint16(60000), ports1[PortIndexLiveLogGET])
+	require.Equal(t, uint16(60001), ports1[PortIndexLiveLogPUT])
+	require.Equal(t, uint16(53000), ports1[PortIndexInteractive])
+	require.Equal(t, uint16(8080), ports1[PortIndexTaskclusterProxy])
+
+	// Allocate ports for second task
+	ports2, err := pm.AllocatePorts("task2")
+	require.NoError(t, err)
+	require.Len(t, ports2, gwconfig.PortsPerTask)
+	// Ports should be offset by gwconfig.PortsPerTask (4)
+	require.Equal(t, uint16(60004), ports2[PortIndexLiveLogGET])
+	require.Equal(t, uint16(60005), ports2[PortIndexLiveLogPUT])
+	require.Equal(t, uint16(53004), ports2[PortIndexInteractive])
+	require.Equal(t, uint16(8084), ports2[PortIndexTaskclusterProxy])
+
+	// Allocate ports for third task
+	ports3, err := pm.AllocatePorts("task3")
+	require.NoError(t, err)
+	require.Len(t, ports3, gwconfig.PortsPerTask)
+
+	// Fourth task should fail (capacity exhausted)
+	_, err = pm.AllocatePorts("task4")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "no available port slots")
+}
+
+func TestPortManagerReleasePorts(t *testing.T) {
+	pm := NewPortManager(60000, 53000, 8080, 2)
+
+	// Allocate all capacity
+	_, err := pm.AllocatePorts("task1")
+	require.NoError(t, err)
+	_, err = pm.AllocatePorts("task2")
+	require.NoError(t, err)
+
+	// Should fail - no capacity
+	_, err = pm.AllocatePorts("task3")
+	require.Error(t, err)
+
+	// Release one task's ports
+	pm.ReleasePorts("task1")
+
+	// Should now succeed
+	ports3, err := pm.AllocatePorts("task3")
+	require.NoError(t, err)
+	// Should reuse slot 0
+	require.Equal(t, uint16(60000), ports3[PortIndexLiveLogGET])
+}
+
+func TestPortManagerGetPorts(t *testing.T) {
+	pm := NewPortManager(60000, 53000, 8080, 2)
+
+	// Not allocated yet
+	require.Nil(t, pm.GetPorts("task1"))
+
+	// Allocate
+	ports, err := pm.AllocatePorts("task1")
+	require.NoError(t, err)
+
+	// Should return same ports
+	require.Equal(t, ports, pm.GetPorts("task1"))
+
+	// Release
+	pm.ReleasePorts("task1")
+	require.Nil(t, pm.GetPorts("task1"))
+}
+
+func TestPortManagerLiveLogPorts(t *testing.T) {
+	pm := NewPortManager(60000, 53000, 8080, 2)
+
+	// Not allocated
+	_, _, ok := pm.LiveLogPorts("task1")
+	require.False(t, ok)
+
+	// Allocate
+	_, err := pm.AllocatePorts("task1")
+	require.NoError(t, err)
+
+	getPort, putPort, ok := pm.LiveLogPorts("task1")
+	require.True(t, ok)
+	require.Equal(t, uint16(60000), getPort)
+	require.Equal(t, uint16(60001), putPort)
+}
+
+func TestPortManagerInteractivePort(t *testing.T) {
+	pm := NewPortManager(60000, 53000, 8080, 2)
+
+	// Not allocated
+	_, ok := pm.InteractivePort("task1")
+	require.False(t, ok)
+
+	// Allocate
+	_, err := pm.AllocatePorts("task1")
+	require.NoError(t, err)
+
+	port, ok := pm.InteractivePort("task1")
+	require.True(t, ok)
+	require.Equal(t, uint16(53000), port)
+}
+
+func TestPortManagerTaskclusterProxyPort(t *testing.T) {
+	pm := NewPortManager(60000, 53000, 8080, 2)
+
+	// Not allocated
+	_, ok := pm.TaskclusterProxyPort("task1")
+	require.False(t, ok)
+
+	// Allocate
+	_, err := pm.AllocatePorts("task1")
+	require.NoError(t, err)
+
+	port, ok := pm.TaskclusterProxyPort("task1")
+	require.True(t, ok)
+	require.Equal(t, uint16(8080), port)
+}
+
+func TestPortManagerIdempotentAllocation(t *testing.T) {
+	pm := NewPortManager(60000, 53000, 8080, 2)
+
+	// First allocation
+	ports1, err := pm.AllocatePorts("task1")
+	require.NoError(t, err)
+
+	// Second allocation for same task should return same ports
+	ports2, err := pm.AllocatePorts("task1")
+	require.NoError(t, err)
+	require.Equal(t, ports1, ports2)
+}
+
+func TestPortManagerSlotReuse(t *testing.T) {
+	pm := NewPortManager(60000, 53000, 8080, 3)
+
+	// Allocate slots 0, 1, 2
+	_, _ = pm.AllocatePorts("task1") // slot 0
+	_, _ = pm.AllocatePorts("task2") // slot 1
+	_, _ = pm.AllocatePorts("task3") // slot 2
+
+	// Release slot 1
+	pm.ReleasePorts("task2")
+
+	// New task should get slot 1
+	ports, err := pm.AllocatePorts("task4")
+	require.NoError(t, err)
+	// Slot 1 means offset of 4 (PortsPerTask)
+	require.Equal(t, uint16(60004), ports[PortIndexLiveLogGET])
+}

--- a/workers/generic-worker/process/posix.go
+++ b/workers/generic-worker/process/posix.go
@@ -5,6 +5,7 @@ package process
 import (
 	"fmt"
 	"log"
+	"strings"
 	"syscall"
 )
 
@@ -53,7 +54,14 @@ func (r *Result) Crashed() bool {
 }
 
 func (c *Command) SetEnv(envVar, value string) {
-	c.Env = append(c.Env, envVar+"="+value)
+	prefix := envVar + "="
+	for i, e := range c.Env {
+		if strings.HasPrefix(e, prefix) {
+			c.Env[i] = prefix + value
+			return
+		}
+	}
+	c.Env = append(c.Env, prefix+value)
 }
 
 func (c *Command) Kill() (killOutput string, err error) {

--- a/workers/generic-worker/process/posix.go
+++ b/workers/generic-worker/process/posix.go
@@ -53,6 +53,8 @@ func (r *Result) Crashed() bool {
 	return false
 }
 
+// SetEnv sets an environment variable for the process, replacing any
+// existing entry with the same name.
 func (c *Command) SetEnv(envVar, value string) {
 	prefix := envVar + "="
 	for i, e := range c.Env {

--- a/workers/generic-worker/rdp_feature_windows.go
+++ b/workers/generic-worker/rdp_feature_windows.go
@@ -77,13 +77,14 @@ func (l *RDPTask) Stop(err *ExecutionErrors) {
 }
 
 func (l *RDPTask) createRDPArtifact() {
+	ctx := l.task.GetContext()
 	l.info = &RDPInfo{
 		Host:     config.PublicIP,
 		Port:     3389,
-		Username: taskContext.User.Name,
-		Password: taskContext.User.Password,
+		Username: ctx.User.Name,
+		Password: ctx.User.Password,
 	}
-	rdpInfoFile := fileutil.AbsFrom(taskContext.TaskDir, rdpInfoPath)
+	rdpInfoFile := fileutil.AbsFrom(ctx.TaskDir, rdpInfoPath)
 	err := fileutil.WriteToFileAsJSON(l.info, rdpInfoFile)
 	// if we can't write this, something seriously wrong, so cause worker to
 	// report an internal-error to sentry and crash!
@@ -93,7 +94,8 @@ func (l *RDPTask) createRDPArtifact() {
 }
 
 func (l *RDPTask) uploadRDPArtifact() *CommandExecutionError {
-	rdpInfoFile := fileutil.AbsFrom(taskContext.TaskDir, rdpInfoPath)
+	taskDir := l.task.TaskDir()
+	rdpInfoFile := fileutil.AbsFrom(taskDir, rdpInfoPath)
 	return l.task.uploadArtifact(
 		createDataArtifact(
 			&artifacts.BaseArtifact{

--- a/workers/generic-worker/run_as_administrator_feature_windows.go
+++ b/workers/generic-worker/run_as_administrator_feature_windows.go
@@ -19,7 +19,10 @@ func (feature *RunAsAdministratorFeature) Initialise() error {
 }
 
 func (feature *RunAsAdministratorFeature) IsEnabled() bool {
-	return config.EnableRunAsAdministrator
+	// Disabled when capacity > 1: running as the worker user would bypass
+	// per-task user isolation, giving the task full access to other tasks'
+	// directories, proxy ports, and credentials.
+	return config.EnableRunAsAdministrator && config.Capacity == 1
 }
 
 func (feature *RunAsAdministratorFeature) IsRequested(task *TaskRun) bool {

--- a/workers/generic-worker/run_as_administrator_feature_windows.go
+++ b/workers/generic-worker/run_as_administrator_feature_windows.go
@@ -25,6 +25,13 @@ func (feature *RunAsAdministratorFeature) IsEnabled() bool {
 	return config.EnableRunAsAdministrator && config.Capacity == 1
 }
 
+func (feature *RunAsAdministratorFeature) DisabledReason() string {
+	if config.Capacity > 1 {
+		return fmt.Sprintf("feature %q is not compatible with capacity > 1 (current capacity: %d) because it would bypass per-task user isolation", feature.Name(), config.Capacity)
+	}
+	return ""
+}
+
 func (feature *RunAsAdministratorFeature) IsRequested(task *TaskRun) bool {
 	return task.Payload.Features.RunAsAdministrator
 }

--- a/workers/generic-worker/run_task_as_current_user_feature.go
+++ b/workers/generic-worker/run_task_as_current_user_feature.go
@@ -18,7 +18,10 @@ func (feature *RunTaskAsCurrentUserFeature) Initialise() error {
 }
 
 func (feature *RunTaskAsCurrentUserFeature) IsEnabled() bool {
-	return config.EnableRunTaskAsCurrentUser
+	// Disabled when capacity > 1: running as the worker user would bypass
+	// per-task user isolation, giving the task full access to other tasks'
+	// directories, proxy ports, and credentials.
+	return config.EnableRunTaskAsCurrentUser && config.Capacity == 1
 }
 
 func (feature *RunTaskAsCurrentUserFeature) IsRequested(task *TaskRun) bool {

--- a/workers/generic-worker/run_task_as_current_user_feature.go
+++ b/workers/generic-worker/run_task_as_current_user_feature.go
@@ -3,6 +3,8 @@
 package main
 
 import (
+	"fmt"
+
 	"github.com/taskcluster/taskcluster/v99/internal/scopes"
 )
 
@@ -22,6 +24,13 @@ func (feature *RunTaskAsCurrentUserFeature) IsEnabled() bool {
 	// per-task user isolation, giving the task full access to other tasks'
 	// directories, proxy ports, and credentials.
 	return config.EnableRunTaskAsCurrentUser && config.Capacity == 1
+}
+
+func (feature *RunTaskAsCurrentUserFeature) DisabledReason() string {
+	if config.Capacity > 1 {
+		return fmt.Sprintf("feature %q is not compatible with capacity > 1 (current capacity: %d) because it would bypass per-task user isolation", feature.Name(), config.Capacity)
+	}
+	return ""
 }
 
 func (feature *RunTaskAsCurrentUserFeature) IsRequested(task *TaskRun) bool {

--- a/workers/generic-worker/run_task_as_current_user_posix.go
+++ b/workers/generic-worker/run_task_as_current_user_posix.go
@@ -3,11 +3,12 @@
 package main
 
 import (
-	"fmt"
+	"path/filepath"
 	"runtime"
 	"strings"
 	"syscall"
 
+	"github.com/taskcluster/taskcluster/v99/workers/generic-worker/fileutil"
 	"github.com/taskcluster/taskcluster/v99/workers/generic-worker/process"
 )
 
@@ -23,10 +24,19 @@ func (r *RunTaskAsCurrentUserTask) platformSpecificActions() *CommandExecutionEr
 		r.task.Payload.Env = make(map[string]string)
 	}
 
-	r.task.Payload.Env["TASK_USER_CREDENTIALS"] = ctuPath
-	err := r.task.setVariable("TASK_USER_CREDENTIALS", ctuPath)
-	if err != nil {
-		return executionError(internalError, errored, fmt.Errorf("could not set TASK_USER_CREDENTIALS environment variable: %v", err))
+	// Write task user credentials to a task-specific file
+	ctx := r.task.GetContext()
+	if ctx != nil && ctx.User != nil {
+		credsPath := filepath.Join(ctx.TaskDir, "task-user-credentials.json")
+		err := fileutil.WriteToFileAsJSON(ctx.User, credsPath)
+		if err == nil {
+			err = fileutil.SecureFiles(credsPath)
+			if err != nil {
+				panic(err)
+			}
+			r.task.Payload.Env["TASK_USER_CREDENTIALS"] = credsPath
+			_ = r.task.setVariable("TASK_USER_CREDENTIALS", credsPath)
+		}
 	}
 
 	if runtime.GOOS == "linux" && !config.HeadlessTasks {

--- a/workers/generic-worker/run_task_as_current_user_posix.go
+++ b/workers/generic-worker/run_task_as_current_user_posix.go
@@ -3,6 +3,7 @@
 package main
 
 import (
+	"fmt"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -29,13 +30,17 @@ func (r *RunTaskAsCurrentUserTask) platformSpecificActions() *CommandExecutionEr
 	if ctx != nil && ctx.User != nil {
 		credsPath := filepath.Join(ctx.TaskDir, "task-user-credentials.json")
 		err := fileutil.WriteToFileAsJSON(ctx.User, credsPath)
-		if err == nil {
-			err = fileutil.SecureFiles(credsPath)
-			if err != nil {
-				panic(err)
-			}
-			r.task.Payload.Env["TASK_USER_CREDENTIALS"] = credsPath
-			_ = r.task.setVariable("TASK_USER_CREDENTIALS", credsPath)
+		if err != nil {
+			return executionError(internalError, errored, fmt.Errorf("could not write task user credentials to %s: %v", credsPath, err))
+		}
+		err = fileutil.SecureFiles(credsPath)
+		if err != nil {
+			return executionError(internalError, errored, fmt.Errorf("could not secure task user credentials file %s: %v", credsPath, err))
+		}
+		r.task.Payload.Env["TASK_USER_CREDENTIALS"] = credsPath
+		err = r.task.setVariable("TASK_USER_CREDENTIALS", credsPath)
+		if err != nil {
+			return executionError(internalError, errored, fmt.Errorf("could not set TASK_USER_CREDENTIALS environment variable: %v", err))
 		}
 	}
 

--- a/workers/generic-worker/run_task_as_current_user_windows.go
+++ b/workers/generic-worker/run_task_as_current_user_windows.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"path/filepath"
 	"syscall"
 
@@ -27,13 +28,17 @@ func (r *RunTaskAsCurrentUserTask) platformSpecificActions() *CommandExecutionEr
 	if ctx != nil && ctx.User != nil {
 		credsPath := filepath.Join(ctx.TaskDir, "task-user-credentials.json")
 		err := fileutil.WriteToFileAsJSON(ctx.User, credsPath)
-		if err == nil {
-			err = fileutil.SecureFiles(credsPath)
-			if err != nil {
-				panic(err)
-			}
-			r.task.Payload.Env["TASK_USER_CREDENTIALS"] = credsPath
-			_ = r.task.setVariable("TASK_USER_CREDENTIALS", credsPath)
+		if err != nil {
+			return executionError(internalError, errored, fmt.Errorf("could not write task user credentials to %s: %v", credsPath, err))
+		}
+		err = fileutil.SecureFiles(credsPath)
+		if err != nil {
+			return executionError(internalError, errored, fmt.Errorf("could not secure task user credentials file %s: %v", credsPath, err))
+		}
+		r.task.Payload.Env["TASK_USER_CREDENTIALS"] = credsPath
+		err = r.task.setVariable("TASK_USER_CREDENTIALS", credsPath)
+		if err != nil {
+			return executionError(internalError, errored, fmt.Errorf("could not set TASK_USER_CREDENTIALS environment variable: %v", err))
 		}
 	}
 

--- a/workers/generic-worker/run_task_as_current_user_windows.go
+++ b/workers/generic-worker/run_task_as_current_user_windows.go
@@ -1,8 +1,10 @@
 package main
 
 import (
+	"path/filepath"
 	"syscall"
 
+	"github.com/taskcluster/taskcluster/v99/workers/generic-worker/fileutil"
 	"github.com/taskcluster/taskcluster/v99/workers/generic-worker/process"
 )
 
@@ -16,5 +18,24 @@ func (r *RunTaskAsCurrentUserTask) resetPlatformData() {
 }
 
 func (r *RunTaskAsCurrentUserTask) platformSpecificActions() *CommandExecutionError {
+	if r.task.Payload.Env == nil {
+		r.task.Payload.Env = make(map[string]string)
+	}
+
+	// Write task user credentials to a task-specific file
+	ctx := r.task.GetContext()
+	if ctx != nil && ctx.User != nil {
+		credsPath := filepath.Join(ctx.TaskDir, "task-user-credentials.json")
+		err := fileutil.WriteToFileAsJSON(ctx.User, credsPath)
+		if err == nil {
+			err = fileutil.SecureFiles(credsPath)
+			if err != nil {
+				panic(err)
+			}
+			r.task.Payload.Env["TASK_USER_CREDENTIALS"] = credsPath
+			_ = r.task.setVariable("TASK_USER_CREDENTIALS", credsPath)
+		}
+	}
+
 	return nil
 }

--- a/workers/generic-worker/runtime/runtime_windows.go
+++ b/workers/generic-worker/runtime/runtime_windows.go
@@ -24,7 +24,7 @@ func (user *OSUser) CreateNew(okIfExists bool) error {
 	log.Print("Creating Windows user " + user.Name + "...")
 	userExisted, err := host.RunIgnoreError(
 		"User "+user.Name+" already exists",
-		"powershell", "-Command", "New-LocalUser -Name '"+user.Name+"' -Password (ConvertTo-SecureString '"+user.Password+"' -AsPlainText -Force) -AccountNeverExpires -PasswordNeverExpires -UserMayNotChangePassword",
+		"powershell", "-Command", "New-LocalUser -Name '"+host.EscapePowerShellSingleQuote(user.Name)+"' -Password (ConvertTo-SecureString '"+host.EscapePowerShellSingleQuote(user.Password)+"' -AsPlainText -Force) -AccountNeverExpires -PasswordNeverExpires -UserMayNotChangePassword",
 	)
 	if err != nil {
 		return err
@@ -35,7 +35,7 @@ func (user *OSUser) CreateNew(okIfExists bool) error {
 	log.Print("Created new OS user!")
 	err = host.RunBatch(
 		userExisted,
-		[]string{"powershell", "-Command", "Add-LocalGroupMember -Group 'Remote Desktop Users' -Member '" + user.Name + "'"},
+		[]string{"powershell", "-Command", "Add-LocalGroupMember -Group 'Remote Desktop Users' -Member '" + host.EscapePowerShellSingleQuote(user.Name) + "'"},
 	)
 	// if user existed, the above commands can fail
 	// if it didn't, they can't
@@ -51,7 +51,7 @@ func (user *OSUser) CreateNew(okIfExists bool) error {
 func (user *OSUser) MakeAdmin() error {
 	_, err := host.RunIgnoreError(
 		user.Name+" is already a member of group administrators",
-		"powershell", "-Command", "Add-LocalGroupMember -Group 'administrators' -Member '"+user.Name+"'",
+		"powershell", "-Command", "Add-LocalGroupMember -Group 'administrators' -Member '"+host.EscapePowerShellSingleQuote(user.Name)+"'",
 	)
 	return err
 }
@@ -153,7 +153,7 @@ func DeleteUser(username string) (err error) {
 	} else {
 		log.Printf("WARNING: not able to look up SID for user %v: %v", username, err)
 	}
-	err2 := host.Run("powershell", "-Command", "Remove-LocalUser -Name '"+username+"'")
+	err2 := host.Run("powershell", "-Command", "Remove-LocalUser -Name '"+host.EscapePowerShellSingleQuote(username)+"'")
 	if err2 != nil {
 		log.Printf("WARNING: not able to delete user account %v: %v", username, err2)
 		if err == nil {

--- a/workers/generic-worker/runtime_insecure.go
+++ b/workers/generic-worker/runtime_insecure.go
@@ -12,6 +12,6 @@ import (
 // This is used during the startup of the worker to
 // ensure that the generic-worker binary is readable/executable
 // by the task user.
-func gwVersion(pd *process.PlatformData) (*process.Command, error) {
-	return process.NewCommand([]string{gwruntime.GenericWorkerBinary(), "--version"}, "", []string{})
+func gwVersion(pd *process.PlatformData, taskDir string) (*process.Command, error) {
+	return process.NewCommand([]string{gwruntime.GenericWorkerBinary(), "--version"}, taskDir, []string{})
 }

--- a/workers/generic-worker/runtime_multiuser.go
+++ b/workers/generic-worker/runtime_multiuser.go
@@ -12,6 +12,6 @@ import (
 // This is used during the startup of the worker to
 // ensure that the generic-worker binary is readable/executable
 // by the task user.
-func gwVersion(pd *process.PlatformData) (*process.Command, error) {
-	return process.NewCommand([]string{gwruntime.GenericWorkerBinary(), "--version"}, taskContext.TaskDir, []string{}, pd)
+func gwVersion(pd *process.PlatformData, taskDir string) (*process.Command, error) {
+	return process.NewCommand([]string{gwruntime.GenericWorkerBinary(), "--version"}, taskDir, []string{}, pd)
 }

--- a/workers/generic-worker/task_manager.go
+++ b/workers/generic-worker/task_manager.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"log"
 	"os"
 	"path/filepath"
 	"sync"
@@ -129,11 +130,15 @@ func (tm *TaskManager) updateWorkerStatusLocked() {
 
 	if len(ids) == 0 {
 		// No tasks running, remove the status file
-		os.Remove(workerStatusPath)
+		if err := os.Remove(workerStatusPath); err != nil && !os.IsNotExist(err) {
+			log.Printf("WARNING: could not remove worker status file: %v", err)
+		}
 	} else {
 		status := &WorkerStatus{
 			CurrentTaskIDs: ids,
 		}
-		_ = fileutil.WriteToFileAsJSON(status, workerStatusPath)
+		if err := fileutil.WriteToFileAsJSON(status, workerStatusPath); err != nil {
+			log.Printf("WARNING: could not write worker status file: %v", err)
+		}
 	}
 }

--- a/workers/generic-worker/task_manager.go
+++ b/workers/generic-worker/task_manager.go
@@ -1,0 +1,139 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+
+	"github.com/taskcluster/taskcluster/v99/workers/generic-worker/fileutil"
+)
+
+// TaskManager manages concurrent task execution and tracks running tasks.
+type TaskManager struct {
+	sync.RWMutex
+	runningTasks map[string]*TaskRun
+	capacity     uint8
+	wg           sync.WaitGroup
+	lastActive   time.Time
+}
+
+// NewTaskManager creates a new TaskManager with the given capacity.
+func NewTaskManager(capacity uint8) *TaskManager {
+	return &TaskManager{
+		runningTasks: make(map[string]*TaskRun),
+		capacity:     capacity,
+		lastActive:   time.Now(),
+	}
+}
+
+// AvailableCapacity returns the number of additional tasks that can be run.
+func (tm *TaskManager) AvailableCapacity() uint {
+	tm.RLock()
+	defer tm.RUnlock()
+	running := uint(len(tm.runningTasks))
+	capacity := uint(tm.capacity)
+	if running >= capacity {
+		return 0
+	}
+	return capacity - running
+}
+
+// AddTask registers a task as running. Must be called before starting the task goroutine.
+// Updates the worker status file with all running task IDs.
+func (tm *TaskManager) AddTask(task *TaskRun) {
+	tm.Lock()
+	defer tm.Unlock()
+	tm.runningTasks[task.TaskID] = task
+	tm.wg.Add(1)
+	tm.lastActive = time.Now()
+	tm.updateWorkerStatusLocked()
+}
+
+// RemoveTask unregisters a task. Must be called when the task goroutine completes.
+// Updates the worker status file with remaining running task IDs.
+func (tm *TaskManager) RemoveTask(taskID string) {
+	tm.Lock()
+	defer tm.Unlock()
+	if _, exists := tm.runningTasks[taskID]; exists {
+		delete(tm.runningTasks, taskID)
+		tm.wg.Done()
+		tm.lastActive = time.Now()
+		tm.updateWorkerStatusLocked()
+	}
+}
+
+// RunningTaskIDs returns a slice of all currently running task IDs.
+func (tm *TaskManager) RunningTaskIDs() []string {
+	tm.RLock()
+	defer tm.RUnlock()
+	ids := make([]string, 0, len(tm.runningTasks))
+	for id := range tm.runningTasks {
+		ids = append(ids, id)
+	}
+	return ids
+}
+
+// TaskCount returns the number of currently running tasks.
+func (tm *TaskManager) TaskCount() uint {
+	tm.RLock()
+	defer tm.RUnlock()
+	return uint(len(tm.runningTasks))
+}
+
+// IsIdle returns true if no tasks are running.
+func (tm *TaskManager) IsIdle() bool {
+	return tm.TaskCount() == 0
+}
+
+// WaitForAll blocks until all running tasks have completed.
+func (tm *TaskManager) WaitForAll() {
+	tm.wg.Wait()
+}
+
+// LastActive returns the time when a task was last added or removed.
+func (tm *TaskManager) LastActive() time.Time {
+	tm.RLock()
+	defer tm.RUnlock()
+	return tm.lastActive
+}
+
+// GetTask returns the TaskRun for the given task ID, or nil if not found.
+func (tm *TaskManager) GetTask(taskID string) *TaskRun {
+	tm.RLock()
+	defer tm.RUnlock()
+	return tm.runningTasks[taskID]
+}
+
+// RunningTaskDirNames returns the base names of all running task directories.
+// This is used to skip these directories during cleanup.
+func (tm *TaskManager) RunningTaskDirNames() []string {
+	tm.RLock()
+	defer tm.RUnlock()
+	names := make([]string, 0, len(tm.runningTasks))
+	for _, task := range tm.runningTasks {
+		if task.Context != nil && task.Context.TaskDir != "" {
+			names = append(names, filepath.Base(task.Context.TaskDir))
+		}
+	}
+	return names
+}
+
+// updateWorkerStatusLocked writes the current running task IDs to the worker status file.
+// Must be called while holding the lock.
+func (tm *TaskManager) updateWorkerStatusLocked() {
+	ids := make([]string, 0, len(tm.runningTasks))
+	for id := range tm.runningTasks {
+		ids = append(ids, id)
+	}
+
+	if len(ids) == 0 {
+		// No tasks running, remove the status file
+		os.Remove(workerStatusPath)
+	} else {
+		status := &WorkerStatus{
+			CurrentTaskIDs: ids,
+		}
+		_ = fileutil.WriteToFileAsJSON(status, workerStatusPath)
+	}
+}

--- a/workers/generic-worker/task_manager_test.go
+++ b/workers/generic-worker/task_manager_test.go
@@ -1,0 +1,143 @@
+package main
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestTaskManagerCapacity(t *testing.T) {
+	tm := NewTaskManager(3)
+	require.Equal(t, uint(3), tm.AvailableCapacity())
+	require.True(t, tm.IsIdle())
+
+	// Add a task
+	task1 := &TaskRun{TaskID: "task1"}
+	tm.AddTask(task1)
+	require.Equal(t, uint(2), tm.AvailableCapacity())
+	require.Equal(t, uint(1), tm.TaskCount())
+	require.False(t, tm.IsIdle())
+
+	// Add more tasks
+	task2 := &TaskRun{TaskID: "task2"}
+	task3 := &TaskRun{TaskID: "task3"}
+	tm.AddTask(task2)
+	tm.AddTask(task3)
+	require.Equal(t, uint(0), tm.AvailableCapacity())
+	require.Equal(t, uint(3), tm.TaskCount())
+
+	// Remove a task
+	tm.RemoveTask("task2")
+	require.Equal(t, uint(1), tm.AvailableCapacity())
+	require.Equal(t, uint(2), tm.TaskCount())
+
+	// Remove remaining tasks
+	tm.RemoveTask("task1")
+	tm.RemoveTask("task3")
+	require.Equal(t, uint(3), tm.AvailableCapacity())
+	require.True(t, tm.IsIdle())
+}
+
+func TestTaskManagerRunningTaskIDs(t *testing.T) {
+	tm := NewTaskManager(5)
+
+	task1 := &TaskRun{TaskID: "task1"}
+	task2 := &TaskRun{TaskID: "task2"}
+	tm.AddTask(task1)
+	tm.AddTask(task2)
+
+	ids := tm.RunningTaskIDs()
+	require.Len(t, ids, 2)
+	require.Contains(t, ids, "task1")
+	require.Contains(t, ids, "task2")
+}
+
+func TestTaskManagerGetTask(t *testing.T) {
+	tm := NewTaskManager(2)
+
+	task1 := &TaskRun{TaskID: "task1"}
+	tm.AddTask(task1)
+
+	require.Equal(t, task1, tm.GetTask("task1"))
+	require.Nil(t, tm.GetTask("nonexistent"))
+}
+
+func TestTaskManagerWaitForAll(t *testing.T) {
+	tm := NewTaskManager(2)
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	task1 := &TaskRun{TaskID: "task1"}
+	task2 := &TaskRun{TaskID: "task2"}
+	tm.AddTask(task1)
+	tm.AddTask(task2)
+
+	// Simulate tasks completing
+	go func() {
+		time.Sleep(10 * time.Millisecond)
+		tm.RemoveTask("task1")
+		wg.Done()
+	}()
+	go func() {
+		time.Sleep(20 * time.Millisecond)
+		tm.RemoveTask("task2")
+		wg.Done()
+	}()
+
+	// WaitForAll should block until all tasks complete
+	done := make(chan struct{})
+	go func() {
+		tm.WaitForAll()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		// Success
+	case <-time.After(1 * time.Second):
+		t.Fatal("WaitForAll timed out")
+	}
+
+	require.True(t, tm.IsIdle())
+	wg.Wait()
+}
+
+func TestTaskManagerLastActive(t *testing.T) {
+	tm := NewTaskManager(2)
+	initialTime := tm.LastActive()
+
+	time.Sleep(5 * time.Millisecond)
+	task := &TaskRun{TaskID: "task1"}
+	tm.AddTask(task)
+	afterAdd := tm.LastActive()
+	require.True(t, afterAdd.After(initialTime))
+
+	time.Sleep(5 * time.Millisecond)
+	tm.RemoveTask("task1")
+	afterRemove := tm.LastActive()
+	require.True(t, afterRemove.After(afterAdd))
+}
+
+func TestTaskManagerConcurrentAccess(t *testing.T) {
+	tm := NewTaskManager(100)
+
+	var wg sync.WaitGroup
+	// Spawn 50 goroutines adding tasks
+	for i := range 50 {
+		wg.Add(1)
+		go func(id int) {
+			defer wg.Done()
+			task := &TaskRun{TaskID: fmt.Sprintf("task-%d", id)}
+			tm.AddTask(task)
+			time.Sleep(time.Millisecond)
+			tm.RemoveTask(task.TaskID)
+		}(i)
+	}
+	wg.Wait()
+
+	require.True(t, tm.IsIdle())
+}

--- a/workers/generic-worker/taskcluster_proxy_feature.go
+++ b/workers/generic-worker/taskcluster_proxy_feature.go
@@ -39,6 +39,8 @@ type TaskclusterProxyTask struct {
 	task                     *TaskRun
 	taskStatusChangeListener *TaskStatusChangeListener
 	taskclusterProxyAddress  string
+	taskclusterProxyPort     uint16
+	dockerNetwork            string // per-task Docker network name (d2g only)
 }
 
 func (l *TaskclusterProxyTask) ReservedArtifacts() []string {
@@ -57,29 +59,49 @@ func (l *TaskclusterProxyTask) RequiredScopes() scopes.Required {
 }
 
 func (l *TaskclusterProxyTask) Start() *CommandExecutionError {
+	// Get allocated port, fall back to config default
+	proxyPort, ok := l.task.TaskclusterProxyPort()
+	if !ok {
+		proxyPort = config.TaskclusterProxyPort
+	}
+
 	switch l.task.Payload.TaskclusterProxyInterface {
 	case "docker-bridge":
-		out, err := host.Output("docker", "network", "inspect", "bridge", "--format", "{{range .IPAM.Config}}{{if .Gateway}}{{.Gateway}} {{end}}{{end}}")
+		// Create a per-task Docker network for isolation. Each container
+		// will only be able to reach its own tc-proxy instance.
+		networkName := fmt.Sprintf("gw-task-%s-%d", l.task.TaskID[:12], l.task.RunID)
+		_, err := host.Output("docker", "network", "create", networkName)
 		if err != nil {
-			return executionError(internalError, errored, fmt.Errorf("could not determine docker bridge IP address: %s", err))
+			return executionError(internalError, errored, fmt.Errorf("could not create Docker network %s: %s", networkName, err))
+		}
+		l.dockerNetwork = networkName
+
+		// Get the gateway IP of the new network
+		out, err := host.Output("docker", "network", "inspect", networkName, "--format", "{{range .IPAM.Config}}{{if .Gateway}}{{.Gateway}} {{end}}{{end}}")
+		if err != nil {
+			return executionError(internalError, errored, fmt.Errorf("could not determine gateway for Docker network %s: %s", networkName, err))
 		}
 		gateways := strings.Split(strings.TrimSpace(out), " ")
-		if len(gateways) == 0 {
-			return executionError(internalError, errored, fmt.Errorf("could not determine docker bridge IP address: no gateways found"))
-		}
 		for _, v := range gateways {
 			ipAddress := net.ParseIP(v)
-			if ipAddress == nil {
-				continue
-			}
-			if ipAddress.To4() == nil {
+			if ipAddress == nil || ipAddress.To4() == nil {
 				continue
 			}
 			l.taskclusterProxyAddress = v
 			break
 		}
 		if l.taskclusterProxyAddress == "" {
-			return executionError(internalError, errored, fmt.Errorf("could not determine docker bridge IP address: no ipv4 gateway found among %v", gateways))
+			return executionError(internalError, errored, fmt.Errorf("no IPv4 gateway found for Docker network %s among %v", networkName, gateways))
+		}
+
+		// Make the network name and gateway available to d2g for docker run
+		err = l.task.setVariable("TASKCLUSTER_DOCKER_NETWORK", networkName)
+		if err != nil {
+			return MalformedPayloadError(err)
+		}
+		err = l.task.setVariable("TASKCLUSTER_PROXY_GATEWAY", l.taskclusterProxyAddress)
+		if err != nil {
+			return MalformedPayloadError(err)
 		}
 	case "localhost":
 		l.taskclusterProxyAddress = "127.0.0.1"
@@ -87,33 +109,54 @@ func (l *TaskclusterProxyTask) Start() *CommandExecutionError {
 		return executionError(internalError, errored, fmt.Errorf("INTERNAL BUG: Unsupported taskcluster proxy interface enum option should not have made it here: %q", l.task.Payload.TaskclusterProxyInterface))
 	}
 
-	// Set TASKCLUSTER_PROXY_URL in the task environment
-	err := l.task.setVariable("TASKCLUSTER_PROXY_URL",
-		fmt.Sprintf("http://%s:%d", l.taskclusterProxyAddress, config.TaskclusterProxyPort))
+	// include all scopes from task.scopes, as well as the scope to create artifacts on
+	// this task (which cannot be represented in task.scopes)
+	taskScopes := append(l.task.TaskClaimResponse.Task.Scopes,
+		fmt.Sprintf("queue:create-artifact:%s/%d", l.task.TaskID, l.task.RunID))
+
+	creds := &tcclient.Credentials{
+		AccessToken:      l.task.TaskClaimResponse.Credentials.AccessToken,
+		Certificate:      l.task.TaskClaimResponse.Credentials.Certificate,
+		ClientID:         l.task.TaskClaimResponse.Credentials.ClientID,
+		AuthorizedScopes: taskScopes,
+	}
+
+	// For native tasks in multiuser mode, use --allowed-user for UID
+	// verification. For d2g tasks, the per-task Docker network provides
+	// isolation instead. In insecure mode, Context.User is nil (no
+	// separate task users), so no UID verification is possible.
+	allowedUser := ""
+	if l.dockerNetwork == "" && l.task.Context.User != nil {
+		allowedUser = l.task.Context.User.Name
+	}
+
+	taskclusterProxy, err := tcproxy.New(
+		config.TaskclusterProxyExecutable,
+		l.taskclusterProxyAddress,
+		proxyPort,
+		config.RootURL,
+		creds,
+		allowedUser,
+	)
+	if err != nil {
+		return executionError(internalError, errored, fmt.Errorf("could not start taskcluster proxy on port %d: %s", proxyPort, err))
+	}
+	l.taskclusterProxy = taskclusterProxy
+	l.taskclusterProxyPort = proxyPort
+
+	err = l.task.setVariable("TASKCLUSTER_PROXY_URL",
+		fmt.Sprintf("http://%s:%d", l.taskclusterProxyAddress, proxyPort))
 	if err != nil {
 		return MalformedPayloadError(err)
 	}
 
-	// include all scopes from task.scopes, as well as the scope to create artifacts on
-	// this task (which cannot be represented in task.scopes)
-	scopes := append(l.task.TaskClaimResponse.Task.Scopes,
-		fmt.Sprintf("queue:create-artifact:%s/%d", l.task.TaskID, l.task.RunID))
-	taskclusterProxy, err := tcproxy.New(
-		config.TaskclusterProxyExecutable,
-		l.taskclusterProxyAddress,
-		config.TaskclusterProxyPort,
-		config.RootURL,
-		&tcclient.Credentials{
-			AccessToken:      l.task.TaskClaimResponse.Credentials.AccessToken,
-			Certificate:      l.task.TaskClaimResponse.Credentials.Certificate,
-			ClientID:         l.task.TaskClaimResponse.Credentials.ClientID,
-			AuthorizedScopes: scopes,
-		},
-	)
-	if err != nil {
-		return executionError(internalError, errored, fmt.Errorf("could not start taskcluster proxy: %s", err))
-	}
-	l.taskclusterProxy = taskclusterProxy
+	l.registerCredentialRefresh()
+	return nil
+}
+
+// registerCredentialRefresh sets up a listener that refreshes proxy credentials
+// when a task is reclaimed.
+func (l *TaskclusterProxyTask) registerCredentialRefresh() {
 	l.taskStatusChangeListener = &TaskStatusChangeListener{
 		Name: "taskcluster-proxy",
 		Callback: func(ts TaskStatus) {
@@ -127,7 +170,7 @@ func (l *TaskclusterProxyTask) Start() *CommandExecutionError {
 				panic(err)
 			}
 			buffer := bytes.NewBuffer(b)
-			putURL := fmt.Sprintf("http://%s:%v/credentials", l.taskclusterProxyAddress, config.TaskclusterProxyPort)
+			putURL := fmt.Sprintf("http://%s:%v/credentials", l.taskclusterProxyAddress, l.taskclusterProxyPort)
 			req, err := http.NewRequest("PUT", putURL, buffer)
 			if err != nil {
 				panic(fmt.Sprintf("Could not create PUT request to taskcluster-proxy /credentials endpoint: %v", err))
@@ -146,18 +189,19 @@ func (l *TaskclusterProxyTask) Start() *CommandExecutionError {
 		},
 	}
 	l.task.StatusManager.RegisterListener(l.taskStatusChangeListener)
-	return nil
 }
 
 func (l *TaskclusterProxyTask) Stop(err *ExecutionErrors) {
 	l.task.StatusManager.DeregisterListener(l.taskStatusChangeListener)
-	if l.taskclusterProxy == nil {
-		return
+	if l.taskclusterProxy != nil {
+		if errTerminate := l.taskclusterProxy.Terminate(); errTerminate != nil {
+			l.task.Warnf("[taskcluster-proxy] Could not terminate taskcluster proxy process: %s", errTerminate)
+			log.Printf("WARNING: could not terminate taskcluster proxy writer: %s", errTerminate)
+		}
 	}
-	errTerminate := l.taskclusterProxy.Terminate()
-	if errTerminate != nil {
-		// no need to raise an exception, machine will reboot anyway
-		l.task.Warnf("[taskcluster-proxy] Could not terminate taskcluster proxy process: %s", errTerminate)
-		log.Printf("WARNING: could not terminate taskcluster proxy writer: %s", errTerminate)
+	if l.dockerNetwork != "" {
+		if _, rmErr := host.Output("docker", "network", "rm", l.dockerNetwork); rmErr != nil {
+			l.task.Warnf("[taskcluster-proxy] Could not remove Docker network %s: %s", l.dockerNetwork, rmErr)
+		}
 	}
 }

--- a/workers/generic-worker/taskcluster_proxy_feature.go
+++ b/workers/generic-worker/taskcluster_proxy_feature.go
@@ -23,7 +23,38 @@ func (feature *TaskclusterProxyFeature) Name() string {
 }
 
 func (feature *TaskclusterProxyFeature) Initialise() error {
+	// Sweep stale per-task Docker networks and containers from prior
+	// worker incarnations. A SIGKILL / OOM / crash leaves the
+	// gw-task-* network and any attached taskcontainer_* container on
+	// the Docker host; the bridge network IPAM pool exhausts after
+	// ~30 leaked entries (default config), at which point new networks
+	// fail to create. Containers must be removed before networks
+	// because containers hold network references.
+	//
+	// The sweep is gated on D2GEnabled() — only D2G tasks create these
+	// resources, and the gate avoids invoking docker on workers that
+	// don't have it installed.
+	if config.D2GEnabled() {
+		sweepStaleDockerResources()
+	}
 	return nil
+}
+
+// sweepStaleDockerResources removes leaked taskcontainer_* containers
+// and gw-task-* networks created by prior worker runs.
+func sweepStaleDockerResources() {
+	out, _ := host.Output("docker", "ps", "-aq", "--filter", "name=taskcontainer_")
+	for c := range strings.FieldsSeq(out) {
+		if rmOut, err := host.Output("docker", "rm", "-f", c); err != nil {
+			log.Printf("startup: could not remove stale container %s: %s (output: %s)", c, err, rmOut)
+		}
+	}
+	out, _ = host.Output("docker", "network", "ls", "--filter", "name=gw-task-", "--format", "{{.Name}}")
+	for n := range strings.FieldsSeq(out) {
+		if rmOut, err := host.Output("docker", "network", "rm", n); err != nil {
+			log.Printf("startup: could not remove stale docker network %s: %s (output: %s)", n, err, rmOut)
+		}
+	}
 }
 
 func (feature *TaskclusterProxyFeature) IsEnabled() bool {
@@ -41,6 +72,7 @@ type TaskclusterProxyTask struct {
 	taskclusterProxyAddress  string
 	taskclusterProxyPort     uint16
 	dockerNetwork            string // per-task Docker network name (d2g only)
+	dockerSubnet             string // per-task Docker network subnet, CIDR (d2g only)
 }
 
 func (l *TaskclusterProxyTask) ReservedArtifacts() []string {
@@ -76,23 +108,33 @@ func (l *TaskclusterProxyTask) Start() *CommandExecutionError {
 		}
 		l.dockerNetwork = networkName
 
-		// Get the gateway IP of the new network
-		out, err := host.Output("docker", "network", "inspect", networkName, "--format", "{{range .IPAM.Config}}{{if .Gateway}}{{.Gateway}} {{end}}{{end}}")
+		// Pull both the gateway IP (for the proxy to bind to) and the
+		// subnet (so tc-proxy can admit in-container traffic by remote
+		// IP) in one inspect call. Format emits "<gateway> <subnet>"
+		// per IPAM.Config entry, separated by newlines.
+		out, err := host.Output("docker", "network", "inspect", networkName, "--format", "{{range .IPAM.Config}}{{if and .Gateway .Subnet}}{{.Gateway}} {{.Subnet}}{{println}}{{end}}{{end}}")
 		if err != nil {
-			return executionError(internalError, errored, fmt.Errorf("could not determine gateway for Docker network %s: %s", networkName, err))
+			return executionError(internalError, errored, fmt.Errorf("could not determine gateway/subnet for Docker network %s: %s", networkName, err))
 		}
-		gateways := strings.Split(strings.TrimSpace(out), " ")
-		for _, v := range gateways {
-			ipAddress := net.ParseIP(v)
+		var dockerSubnet string
+		for line := range strings.SplitSeq(strings.TrimSpace(out), "\n") {
+			fields := strings.Fields(line)
+			if len(fields) != 2 {
+				continue
+			}
+			gw, subnet := fields[0], fields[1]
+			ipAddress := net.ParseIP(gw)
 			if ipAddress == nil || ipAddress.To4() == nil {
 				continue
 			}
-			l.taskclusterProxyAddress = v
+			l.taskclusterProxyAddress = gw
+			dockerSubnet = subnet
 			break
 		}
 		if l.taskclusterProxyAddress == "" {
-			return executionError(internalError, errored, fmt.Errorf("no IPv4 gateway found for Docker network %s among %v", networkName, gateways))
+			return executionError(internalError, errored, fmt.Errorf("no IPv4 gateway found for Docker network %s in %q", networkName, out))
 		}
+		l.dockerSubnet = dockerSubnet
 
 		// Make the network name and gateway available to d2g for docker run
 		err = l.task.setVariable("TASKCLUSTER_DOCKER_NETWORK", networkName)
@@ -121,15 +163,43 @@ func (l *TaskclusterProxyTask) Start() *CommandExecutionError {
 		AuthorizedScopes: taskScopes,
 	}
 
-	// In multiuser mode, use --allowed-user for UID/SID connection
-	// verification. For D2G tasks on docker-bridge, the per-task Docker
-	// network provides isolation instead (the connecting process is the
-	// Docker daemon, not the task user). In insecure mode, Context.User
-	// is nil (no separate task users), so no UID verification is possible.
+	// Connection admission for tc-proxy:
+	//
+	//   - --allowed-user: enforces that the OS-level peer of an
+	//     accepted connection (resolved via /proc/net/tcp on Linux,
+	//     lsof on darwin, GetExtendedTcpTable on Windows) is the
+	//     task user. Set whenever Context.User is non-nil (i.e. on
+	//     the multiuser engine).
+	//
+	//   - --allowed-network: a fallback admission rule used only
+	//     when the peer-credential lookup CANNOT find the connecting
+	//     socket. That happens specifically when the peer is in a
+	//     different network namespace — e.g. a process inside a
+	//     d2g + docker-bridge container whose client socket lives in
+	//     the container's netns and is not visible in the proxy's
+	//     /proc/net/tcp. We pass the per-task Docker subnet here so
+	//     that legitimate in-container traffic to the bridge gateway
+	//     IP is admitted by remote-IP membership.
+	//
+	// Combined, these two flags close the mixed-engine + capacity > 1
+	// security gap: a sibling native task's host process IS visible
+	// in /proc/net/tcp (host netns), so its UID is found and checked
+	// against allowed-user — even if its source IP happens to fall
+	// inside the docker subnet. The networkAdmittingVerifier only
+	// admits-by-network when UID lookup explicitly returns
+	// errPeerNotFound; UID mismatches still reject.
+	//
+	// In insecure mode, Context.User is nil (no separate task users),
+	// so no UID verification is possible and we pass neither flag —
+	// even on docker-bridge — because allowed-network without
+	// allowed-user would put the proxy in a network-only mode we
+	// don't currently support, and insecure capacity > 1 is
+	// explicitly out of scope (no isolation goal anyway).
 	allowedUser := ""
-	isD2GTask := l.task.D2GInfo != nil
-	if l.task.Context.User != nil && (l.dockerNetwork == "" || !isD2GTask) {
+	allowedNetwork := ""
+	if l.task.Context.User != nil {
 		allowedUser = l.task.Context.User.Name
+		allowedNetwork = l.dockerSubnet
 	}
 
 	taskclusterProxy, err := tcproxy.New(
@@ -139,6 +209,7 @@ func (l *TaskclusterProxyTask) Start() *CommandExecutionError {
 		config.RootURL,
 		creds,
 		allowedUser,
+		allowedNetwork,
 	)
 	if err != nil {
 		return executionError(internalError, errored, fmt.Errorf("could not start taskcluster proxy on port %d: %s", proxyPort, err))
@@ -172,7 +243,19 @@ func (l *TaskclusterProxyTask) registerCredentialRefresh() {
 				panic(err)
 			}
 			buffer := bytes.NewBuffer(b)
-			putURL := fmt.Sprintf("http://%s:%v/credentials", l.taskclusterProxyAddress, l.taskclusterProxyPort)
+			// When the proxy is bound to a docker-bridge gateway IP,
+			// the worker (which lives in the host netns) talks to the
+			// proxy's loopback companion listener on 127.0.0.1. That
+			// keeps the control-plane request out of the routing/NAT
+			// path used for container traffic, so the proxy's UID
+			// admission has a clean /proc/net/tcp entry to verify
+			// against. tc-proxy binds 127.0.0.1 in addition to the
+			// configured ip-address whenever --allowed-network is set.
+			refreshHost := l.taskclusterProxyAddress
+			if l.dockerSubnet != "" {
+				refreshHost = "127.0.0.1"
+			}
+			putURL := fmt.Sprintf("http://%s:%v/credentials", refreshHost, l.taskclusterProxyPort)
 			req, err := http.NewRequest("PUT", putURL, buffer)
 			if err != nil {
 				panic(fmt.Sprintf("Could not create PUT request to taskcluster-proxy /credentials endpoint: %v", err))

--- a/workers/generic-worker/taskcluster_proxy_feature.go
+++ b/workers/generic-worker/taskcluster_proxy_feature.go
@@ -121,12 +121,14 @@ func (l *TaskclusterProxyTask) Start() *CommandExecutionError {
 		AuthorizedScopes: taskScopes,
 	}
 
-	// For native tasks in multiuser mode, use --allowed-user for UID
-	// verification. For d2g tasks, the per-task Docker network provides
-	// isolation instead. In insecure mode, Context.User is nil (no
-	// separate task users), so no UID verification is possible.
+	// In multiuser mode, use --allowed-user for UID/SID connection
+	// verification. For D2G tasks on docker-bridge, the per-task Docker
+	// network provides isolation instead (the connecting process is the
+	// Docker daemon, not the task user). In insecure mode, Context.User
+	// is nil (no separate task users), so no UID verification is possible.
 	allowedUser := ""
-	if l.dockerNetwork == "" && l.task.Context.User != nil {
+	isD2GTask := l.task.D2GInfo != nil
+	if l.task.Context.User != nil && (l.dockerNetwork == "" || !isD2GTask) {
 		allowedUser = l.task.Context.User.Name
 	}
 

--- a/workers/generic-worker/tcproxy/tcproxy.go
+++ b/workers/generic-worker/tcproxy/tcproxy.go
@@ -25,8 +25,10 @@ type TaskclusterProxy struct {
 }
 
 // New starts a tcproxy OS process using the executable specified, and returns
-// a *TaskclusterProxy.
-func New(taskclusterProxyExecutable string, ipAddress string, httpPort uint16, rootURL string, creds *tcclient.Credentials) (*TaskclusterProxy, error) {
+// a *TaskclusterProxy. If allowedUser is non-empty, it is passed to the proxy
+// process via the --allowed-user flag, enabling per-connection OS user
+// verification.
+func New(taskclusterProxyExecutable string, ipAddress string, httpPort uint16, rootURL string, creds *tcclient.Credentials, allowedUser string) (*TaskclusterProxy, error) {
 	args := []string{
 		"--port", strconv.Itoa(int(httpPort)),
 		"--root-url", rootURL,
@@ -36,6 +38,9 @@ func New(taskclusterProxyExecutable string, ipAddress string, httpPort uint16, r
 	}
 	if creds.Certificate != "" {
 		args = append(args, "--certificate", creds.Certificate)
+	}
+	if allowedUser != "" {
+		args = append(args, "--allowed-user", allowedUser)
 	}
 	args = append(args, creds.AuthorizedScopes...)
 	l := &TaskclusterProxy{

--- a/workers/generic-worker/tcproxy/tcproxy.go
+++ b/workers/generic-worker/tcproxy/tcproxy.go
@@ -25,10 +25,21 @@ type TaskclusterProxy struct {
 }
 
 // New starts a tcproxy OS process using the executable specified, and returns
-// a *TaskclusterProxy. If allowedUser is non-empty, it is passed to the proxy
-// process via the --allowed-user flag, enabling per-connection OS user
-// verification.
-func New(taskclusterProxyExecutable string, ipAddress string, httpPort uint16, rootURL string, creds *tcclient.Credentials, allowedUser string) (*TaskclusterProxy, error) {
+// a *TaskclusterProxy.
+//
+// If allowedUser is non-empty, it is passed via --allowed-user to enable
+// per-connection OS user verification.
+//
+// If allowedNetwork is non-empty (CIDR form, e.g. "172.18.0.0/16"), it is
+// passed via --allowed-network. Connections whose remote IP falls in this
+// CIDR are admitted when the OS-level peer-credential lookup is not
+// possible (e.g. a container connecting via a Docker bridge gateway —
+// the peer socket lives in the container's network namespace and is not
+// visible in the proxy's /proc/net/tcp). Connections whose UID is found
+// but does not match are still rejected, so a sibling task's host
+// process is not admitted just because its source IP happens to be inside
+// the CIDR.
+func New(taskclusterProxyExecutable string, ipAddress string, httpPort uint16, rootURL string, creds *tcclient.Credentials, allowedUser string, allowedNetwork string) (*TaskclusterProxy, error) {
 	args := []string{
 		"--port", strconv.Itoa(int(httpPort)),
 		"--root-url", rootURL,
@@ -41,6 +52,9 @@ func New(taskclusterProxyExecutable string, ipAddress string, httpPort uint16, r
 	}
 	if allowedUser != "" {
 		args = append(args, "--allowed-user", allowedUser)
+	}
+	if allowedNetwork != "" {
+		args = append(args, "--allowed-network", allowedNetwork)
 	}
 	args = append(args, creds.AuthorizedScopes...)
 	l := &TaskclusterProxy{
@@ -57,8 +71,16 @@ func New(taskclusterProxyExecutable string, ipAddress string, httpPort uint16, r
 	}
 	l.Pid = l.command.Process.Pid
 	log.Printf("Started taskcluster proxy process (PID %v)", l.Pid)
-	// Just to be safe, let's make sure the port is actually active before returning.
-	if err = waitForPortToBeActive(ipAddress, httpPort); err != nil {
+	// Wait on the address the launcher itself can reach. When
+	// allowedNetwork is set the proxy also binds 127.0.0.1, and
+	// dialing that loopback path is more reliable from the host netns
+	// than dialing a docker-bridge gateway IP through whatever NAT
+	// rules the host is running.
+	readinessAddr := ipAddress
+	if allowedNetwork != "" {
+		readinessAddr = "127.0.0.1"
+	}
+	if err = waitForPortToBeActive(readinessAddr, httpPort); err != nil {
 		killErr := l.command.Process.Kill()
 		if killErr != nil {
 			log.Printf("Failed to kill taskcluster-proxy process (PID %v) after readiness timeout: %v", l.Pid, killErr)

--- a/workers/generic-worker/tcproxy/tcproxy.go
+++ b/workers/generic-worker/tcproxy/tcproxy.go
@@ -58,8 +58,18 @@ func New(taskclusterProxyExecutable string, ipAddress string, httpPort uint16, r
 	l.Pid = l.command.Process.Pid
 	log.Printf("Started taskcluster proxy process (PID %v)", l.Pid)
 	// Just to be safe, let's make sure the port is actually active before returning.
-	err = waitForPortToBeActive(ipAddress, httpPort)
-	return l, err
+	if err = waitForPortToBeActive(ipAddress, httpPort); err != nil {
+		killErr := l.command.Process.Kill()
+		if killErr != nil {
+			log.Printf("Failed to kill taskcluster-proxy process (PID %v) after readiness timeout: %v", l.Pid, killErr)
+		} else {
+			// Wait for the process to be reaped to avoid zombies
+			_, _ = l.command.Process.Wait()
+			log.Printf("Killed taskcluster-proxy process (PID %v) after readiness timeout", l.Pid)
+		}
+		return nil, err
+	}
+	return l, nil
 }
 
 func (l *TaskclusterProxy) Terminate() error {

--- a/workers/generic-worker/tcproxy/tcproxy_test.go
+++ b/workers/generic-worker/tcproxy/tcproxy_test.go
@@ -28,7 +28,7 @@ func TestTcProxy(t *testing.T) {
 		Certificate:      certificate,
 		AuthorizedScopes: []string{"queue:get-artifact:SampleArtifacts/_/X.txt"},
 	}
-	ll, err := New(executable, "127.0.0.1", 34570, rootURL, creds)
+	ll, err := New(executable, "127.0.0.1", 34570, rootURL, creds, "")
 	// Do defer before checking err since err could be a different error and
 	// process may have already started up.
 	defer func() {

--- a/workers/generic-worker/tcproxy/tcproxy_test.go
+++ b/workers/generic-worker/tcproxy/tcproxy_test.go
@@ -28,7 +28,7 @@ func TestTcProxy(t *testing.T) {
 		Certificate:      certificate,
 		AuthorizedScopes: []string{"queue:get-artifact:SampleArtifacts/_/X.txt"},
 	}
-	ll, err := New(executable, "127.0.0.1", 34570, rootURL, creds, "")
+	ll, err := New(executable, "127.0.0.1", 34570, rootURL, creds, "", "")
 	// Do defer before checking err since err could be a different error and
 	// process may have already started up.
 	defer func() {

--- a/workers/generic-worker/testdata/check-task-user-credentials.go
+++ b/workers/generic-worker/testdata/check-task-user-credentials.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+)
+
+// This program verifies that TASK_USER_CREDENTIALS is set correctly.
+// It checks that:
+// 1. TASK_USER_CREDENTIALS is set
+// 2. It equals $TASK_WORKDIR/task-user-credentials.json
+// 3. The file exists
+func main() {
+	credsPath := os.Getenv("TASK_USER_CREDENTIALS")
+	if credsPath == "" {
+		log.Fatal("TASK_USER_CREDENTIALS is not set")
+	}
+
+	taskWorkdir := os.Getenv("TASK_WORKDIR")
+	if taskWorkdir == "" {
+		log.Fatal("TASK_WORKDIR is not set")
+	}
+
+	expectedPath := filepath.Join(taskWorkdir, "task-user-credentials.json")
+	if credsPath != expectedPath {
+		log.Fatalf("TASK_USER_CREDENTIALS has unexpected value.\nExpected: %s\nGot: %s", expectedPath, credsPath)
+	}
+
+	// Verify the file exists
+	if _, err := os.Stat(credsPath); os.IsNotExist(err) {
+		log.Fatalf("Credentials file does not exist: %s", credsPath)
+	}
+
+	fmt.Printf("TASK_USER_CREDENTIALS = %s (verified)\n", credsPath)
+	fmt.Println("All ok")
+}

--- a/workers/generic-worker/testmain_multiuser_test.go
+++ b/workers/generic-worker/testmain_multiuser_test.go
@@ -1,0 +1,149 @@
+//go:build multiuser
+
+package main
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+const dockerImage = "gw-test-multiuser"
+
+func TestMain(m *testing.M) {
+	// Already inside Docker — run tests normally
+	if os.Getenv("GW_IN_DOCKER") == "1" {
+		os.Exit(m.Run())
+	}
+
+	// next-task-user.json exists — can run natively (CI or local Linux with setup)
+	if _, err := os.Stat(filepath.Join(cwd, "next-task-user.json")); err == nil {
+		os.Exit(m.Run())
+	}
+
+	// Only route to Docker on Linux (macOS/Windows multiuser tests run natively)
+	if runtime.GOOS != "linux" {
+		os.Exit(m.Run())
+	}
+
+	// Linux + no next-task-user.json + not in Docker — route to Docker
+	os.Exit(runInDocker())
+}
+
+// repoRoot walks up from cwd to find the directory containing go.mod.
+func repoRoot() (string, error) {
+	dir := cwd
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir, nil
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return "", fmt.Errorf("could not find go.mod in any parent of %s", cwd)
+		}
+		dir = parent
+	}
+}
+
+// ensureDockerImage builds the Docker image if it doesn't already exist.
+func ensureDockerImage() error {
+	check := exec.Command("docker", "image", "inspect", dockerImage)
+	if check.Run() == nil {
+		return nil
+	}
+
+	fmt.Fprintf(os.Stderr, "Building Docker image %s...\n", dockerImage)
+	dockerfilePath := filepath.Join(cwd, "Dockerfile.test")
+	build := exec.Command("docker", "build", "-f", dockerfilePath, "-t", dockerImage, cwd)
+	build.Stdout = os.Stdout
+	build.Stderr = os.Stderr
+	return build.Run()
+}
+
+// translateTestFlags converts -test.* flags from os.Args into go test flags.
+// When go test compiles and runs a test binary, the binary receives flags like
+// -test.run=^TestFoo$, -test.v=true, -test.timeout=30s. We translate these
+// back to go test flags (-run, -v, -timeout) for the inner go test invocation.
+func translateTestFlags() []string {
+	var flags []string
+	for _, arg := range os.Args[1:] {
+		switch {
+		case strings.HasPrefix(arg, "-test.run="):
+			flags = append(flags, "-run="+strings.TrimPrefix(arg, "-test.run="))
+		case strings.HasPrefix(arg, "-test.timeout="):
+			flags = append(flags, "-timeout="+strings.TrimPrefix(arg, "-test.timeout="))
+		case arg == "-test.v=true":
+			flags = append(flags, "-v")
+		case strings.HasPrefix(arg, "-test.count="):
+			flags = append(flags, "-count="+strings.TrimPrefix(arg, "-test.count="))
+		case arg == "-test.failfast=true":
+			flags = append(flags, "-failfast")
+		case arg == "-test.short=true":
+			flags = append(flags, "-short")
+		}
+	}
+	return flags
+}
+
+func runInDocker() int {
+	root, err := repoRoot()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error finding repo root: %v\n", err)
+		return 1
+	}
+
+	if err := ensureDockerImage(); err != nil {
+		fmt.Fprintf(os.Stderr, "Error building Docker image: %v\n", err)
+		return 1
+	}
+
+	testFlags := translateTestFlags()
+	parts := []string{
+		"go install ../../tools/livelog &&",
+		"go install ../../tools/taskcluster-proxy &&",
+		"go install -tags multiuser ./... &&",
+		"go test -tags multiuser",
+	}
+	parts = append(parts, testFlags...)
+	parts = append(parts, "./...")
+	innerCmd := strings.Join(parts, " ")
+
+	fmt.Fprintf(os.Stderr, "Running multiuser tests in Docker...\n")
+
+	args := []string{
+		"run", "--rm",
+		"-v", root + ":/src",
+		"-v", "gw-test-gomodcache:/go/pkg/mod",
+		"-v", "gw-test-gobuildcache:/root/.cache/go-build",
+		"-e", "GW_IN_DOCKER=1",
+		"-w", "/src/workers/generic-worker",
+		dockerImage,
+		"sh", "-c", innerCmd,
+	}
+
+	cmd := exec.Command("docker", args...)
+	stdout, _ := cmd.StdoutPipe()
+	stderr, _ := cmd.StderrPipe()
+
+	if err := cmd.Start(); err != nil {
+		fmt.Fprintf(os.Stderr, "Error starting Docker: %v\n", err)
+		return 1
+	}
+
+	go func() { _, _ = io.Copy(os.Stdout, stdout) }()
+	go func() { _, _ = io.Copy(os.Stderr, stderr) }()
+
+	if err := cmd.Wait(); err != nil {
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			return exitErr.ExitCode()
+		}
+		fmt.Fprintf(os.Stderr, "Error running Docker: %v\n", err)
+		return 1
+	}
+	return 0
+}

--- a/workers/generic-worker/testmain_multiuser_test.go
+++ b/workers/generic-worker/testmain_multiuser_test.go
@@ -8,7 +8,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"runtime"
 	"strings"
 	"testing"
 )
@@ -21,18 +20,25 @@ func TestMain(m *testing.M) {
 		os.Exit(m.Run())
 	}
 
-	// next-task-user.json exists — can run natively (CI or local Linux with setup)
+	// next-task-user.json exists — can run natively (CI or production setup)
 	if _, err := os.Stat(filepath.Join(cwd, "next-task-user.json")); err == nil {
 		os.Exit(m.Run())
 	}
 
-	// Only route to Docker on Linux (macOS/Windows multiuser tests run natively)
-	if runtime.GOOS != "linux" {
-		os.Exit(m.Run())
+	// No native setup — route to Docker if available
+	if !dockerAvailable() {
+		fmt.Fprintln(os.Stderr, "Multiuser tests require either Docker or a pre-configured next-task-user.json.")
+		fmt.Fprintln(os.Stderr, "These tests create OS user accounts and are not meant to run directly on your machine.")
+		fmt.Fprintln(os.Stderr, "Ensure Docker is running before running them locally.")
+		os.Exit(1)
 	}
 
-	// Linux + no next-task-user.json + not in Docker — route to Docker
 	os.Exit(runInDocker())
+}
+
+// dockerAvailable checks whether Docker is installed and the daemon is running.
+func dockerAvailable() bool {
+	return exec.Command("docker", "info").Run() == nil
 }
 
 // repoRoot walks up from cwd to find the directory containing go.mod.
@@ -59,10 +65,13 @@ func ensureDockerImage() error {
 
 	fmt.Fprintf(os.Stderr, "Building Docker image %s...\n", dockerImage)
 	dockerfilePath := filepath.Join(cwd, "Dockerfile.test")
-	build := exec.Command("docker", "build", "-f", dockerfilePath, "-t", dockerImage, cwd)
-	build.Stdout = os.Stdout
-	build.Stderr = os.Stderr
-	return build.Run()
+	build := exec.Command("docker", "build", "--quiet", "-f", dockerfilePath, "-t", dockerImage, cwd)
+	out, err := build.CombinedOutput()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%s", out)
+		return err
+	}
+	return nil
 }
 
 // translateTestFlags converts -test.* flags from os.Args into go test flags.
@@ -102,15 +111,29 @@ func runInDocker() int {
 		return 1
 	}
 
+	gitRev, err := exec.Command("git", "rev-parse", "HEAD").Output()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error getting git revision: %v\n", err)
+		return 1
+	}
+	rev := strings.TrimSpace(string(gitRev))
+	modPath, err := exec.Command("go", "list", "-m").Output()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error getting module path: %v\n", err)
+		return 1
+	}
+	ldflags := fmt.Sprintf(`-ldflags=-X %s/workers/generic-worker.revision=%s`, strings.TrimSpace(string(modPath)), rev)
+
 	testFlags := translateTestFlags()
 	parts := []string{
+		"git config --global --add safe.directory /src &&",
 		"go install ../../tools/livelog &&",
 		"go install ../../tools/taskcluster-proxy &&",
 		"go install -tags multiuser ./... &&",
-		"go test -tags multiuser",
+		fmt.Sprintf("go test -tags multiuser %q", ldflags),
 	}
 	parts = append(parts, testFlags...)
-	parts = append(parts, "./...")
+	parts = append(parts, ".")
 	innerCmd := strings.Join(parts, " ")
 
 	fmt.Fprintf(os.Stderr, "Running multiuser tests in Docker...\n")

--- a/workers/generic-worker/usage.go
+++ b/workers/generic-worker/usage.go
@@ -150,6 +150,16 @@ and reports back results to the queue.
                                             not exist. This may be a relative path to the
                                             current directory, or an absolute path.
                                             [default: "caches"]
+          capacity                          The number of tasks the worker will run concurrently.
+                                            When greater than 1, the worker claims and executes
+                                            multiple tasks in parallel, each in its own task
+                                            directory with isolated ports for LiveLog,
+                                            Interactive, and TaskclusterProxy features. Requires
+                                            headlessTasks enabled. The runAsCurrentUser and
+                                            runAsAdministrator task features are automatically
+                                            disabled when capacity > 1 to preserve task
+                                            isolation. Maximum value is 255.
+                                            [default: 1]
           certificate                       Taskcluster certificate, when using temporary
                                             credentials only.
           cleanUpTaskDirs                   Whether to delete the home directories of the task

--- a/workers/generic-worker/usage.go
+++ b/workers/generic-worker/usage.go
@@ -155,7 +155,7 @@ and reports back results to the queue.
                                             multiple tasks in parallel, each in its own task
                                             directory with isolated ports for LiveLog,
                                             Interactive, and TaskclusterProxy features. Requires
-                                            headlessTasks enabled. The runAsCurrentUser and
+                                            headlessTasks enabled. The runTaskAsCurrentUser and
                                             runAsAdministrator task features are automatically
                                             disabled when capacity > 1 to preserve task
                                             isolation. Maximum value is 255.

--- a/workers/generic-worker/usage.go
+++ b/workers/generic-worker/usage.go
@@ -154,8 +154,9 @@ and reports back results to the queue.
                                             When greater than 1, the worker claims and executes
                                             multiple tasks in parallel, each in its own task
                                             directory with isolated ports for LiveLog,
-                                            Interactive, and TaskclusterProxy features. Requires
-                                            headlessTasks enabled. The runTaskAsCurrentUser and
+                                            Interactive, and TaskclusterProxy features. In
+                                            multiuser mode, requires headlessTasks enabled. The
+                                            runTaskAsCurrentUser and
                                             runAsAdministrator task features are automatically
                                             disabled when capacity > 1 to preserve task
                                             isolation. Maximum value is 255.

--- a/workers/generic-worker/usage_multiuser_darwin.go
+++ b/workers/generic-worker/usage_multiuser_darwin.go
@@ -11,7 +11,9 @@ func enableTaskFeatures() string {
           enableInteractive                 Enables the Interactive feature to be used in the
                                             task payload. [default: true]
           enableRunTaskAsCurrentUser        Enables the Run Task As Current User feature to be
-                                            used in the task payload. [default: true]`
+                                            used in the task payload. Automatically disabled
+                                            when capacity > 1 to preserve task isolation.
+                                            [default: true]`
 }
 
 func customTargetsSummary() string {

--- a/workers/generic-worker/usage_multiuser_freebsd.go
+++ b/workers/generic-worker/usage_multiuser_freebsd.go
@@ -7,7 +7,9 @@ func enableTaskFeatures() string {
           enableInteractive                 Enables the Interactive feature to be used in the
                                             task payload. [default: true]
           enableRunTaskAsCurrentUser        Enables the Run Task As Current User feature to be
-                                            used in the task payload. [default: true]`
+                                            used in the task payload. Automatically disabled
+                                            when capacity > 1 to preserve task isolation.
+                                            [default: true]`
 }
 
 func exitCode83() string {

--- a/workers/generic-worker/usage_multiuser_linux.go
+++ b/workers/generic-worker/usage_multiuser_linux.go
@@ -11,7 +11,9 @@ func enableTaskFeatures() string {
           enableLoopbackVideo               Enables the Loopback Video feature to be used in the
                                             task payload. [default: true]
           enableRunTaskAsCurrentUser        Enables the Run Task As Current User feature to be
-                                            used in the task payload. [default: true]`
+                                            used in the task payload. Automatically disabled
+                                            when capacity > 1 to preserve task isolation.
+                                            [default: true]`
 }
 
 func exitCode83() string {

--- a/workers/generic-worker/usage_windows.go
+++ b/workers/generic-worker/usage_windows.go
@@ -82,9 +82,13 @@ func enableTaskFeatures() string {
           enableRDP                         Enables the RDP feature to be used in the task
                                             payload. [default: true]
           enableRunAsAdministrator          Enables the RunAsAdministrator feature to be used in
-                                            the task payload. [default: true]
+                                            the task payload. Automatically disabled when
+                                            capacity > 1 to preserve task isolation.
+                                            [default: true]
           enableRunTaskAsCurrentUser        Enables the Run Task As Current User feature to be
-                                            used in the task payload. [default: true]`
+                                            used in the task payload. Automatically disabled
+                                            when capacity > 1 to preserve task isolation.
+                                            [default: true]`
 }
 
 func loopbackDeviceNumbers() string {

--- a/workers/generic-worker/user_creation_multiuser_test.go
+++ b/workers/generic-worker/user_creation_multiuser_test.go
@@ -21,14 +21,21 @@ func TestRunAfterUserCreation(t *testing.T) {
 		script = "run-after-user.bat"
 	}
 	config.RunAfterUserCreation = filepath.Join(testdataDir, script)
-	PrepareTaskEnvironment()
+
+	// Load the test user credentials directly and call PostRebootSetup
+	taskUser, err := StoredUserCredentials(filepath.Join(cwd, "next-task-user.json"))
+	if err != nil {
+		t.Fatalf("Could not load test user credentials: %v", err)
+	}
+	ctx := PostRebootSetup(taskUser)
+
 	defer func() {
 		err := purgeOldTasks()
 		if err != nil {
 			t.Fatalf("Problem deleting old tasks: %v", err)
 		}
 	}()
-	fileContents, err := os.ReadFile(filepath.Join(taskContext.TaskDir, "run-after-user.txt"))
+	fileContents, err := os.ReadFile(filepath.Join(ctx.TaskDir, "run-after-user.txt"))
 	if err != nil {
 		t.Fatalf("Got error when looking for file run-after-user.txt: %v", err)
 	}

--- a/workers/generic-worker/user_creation_multiuser_test.go
+++ b/workers/generic-worker/user_creation_multiuser_test.go
@@ -3,11 +3,15 @@
 package main
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"runtime"
 	"strings"
 	"testing"
+	"time"
+
+	gwruntime "github.com/taskcluster/taskcluster/v99/workers/generic-worker/runtime"
 )
 
 func TestRunAfterUserCreation(t *testing.T) {
@@ -22,10 +26,27 @@ func TestRunAfterUserCreation(t *testing.T) {
 	}
 	config.RunAfterUserCreation = filepath.Join(testdataDir, script)
 
-	// Load the test user credentials directly and call PostRebootSetup
-	taskUser, err := StoredUserCredentials(filepath.Join(cwd, "next-task-user.json"))
-	if err != nil {
-		t.Fatalf("Could not load test user credentials: %v", err)
+	// In Docker, create a temporary user; otherwise load from next-task-user.json
+	var taskUser *gwruntime.OSUser
+	if os.Getenv("GW_IN_DOCKER") == "1" {
+		taskDirName := fmt.Sprintf("task_%d", time.Now().UnixNano())
+		if len(taskDirName) > 20 {
+			taskDirName = taskDirName[:20]
+		}
+		taskUser = &gwruntime.OSUser{
+			Name:     taskDirName,
+			Password: gwruntime.GeneratePassword(),
+		}
+		err := taskUser.CreateNew(false)
+		if err != nil {
+			t.Fatalf("Could not create test user: %v", err)
+		}
+	} else {
+		var err error
+		taskUser, err = StoredUserCredentials(filepath.Join(cwd, "next-task-user.json"))
+		if err != nil {
+			t.Fatalf("Could not load test user credentials: %v", err)
+		}
 	}
 	ctx := PostRebootSetup(taskUser)
 

--- a/workers/generic-worker/workerrunner_test.go
+++ b/workers/generic-worker/workerrunner_test.go
@@ -45,7 +45,7 @@ func TestGracefulTermination(t *testing.T) {
 
 	done := make(chan bool, 1)
 
-	graceful.OnTerminationRequest(func(finishTasks bool) {
+	graceful.OnTerminationRequest("test-task", func(finishTasks bool) {
 		done <- finishTasks
 	})
 


### PR DESCRIPTION
Fixes #7388.

>Generic Worker now supports running multiple tasks concurrently via the new `capacity` configuration option.
>
>**Configuration:**
>
>- `capacity` (uint8, default: `1`, max: `255`) - the number of tasks the worker will claim and execute in parallel.
>- When `capacity` is `1`, behavior is unchanged from previous releases.
>- When `capacity` > 1, each task slot is allocated a block of 4 ports offset from the configured base ports (`livelogPortBase`, `interactivePort`, `taskclusterProxyPort`). Deployers must ensure these base ports are spaced far enough apart to avoid overlapping ranges. The worker validates this at startup and exits with an error if ranges collide.
>
>**Engine support:**
>
>- Insecure engine: supported.
>- Multiuser engine: supported only when `headlessTasks` is enabled. Non-headless multiuser mode (which reboots between tasks) is restricted to `capacity` = 1.
>
>**Task isolation:**
>
>- Each concurrent task receives its own task directory under `tasksDir`, its own set of dynamically allocated ports for LiveLog, Interactive, and TaskclusterProxy, and (in multiuser mode) its own OS user.
>- Caches and mounts are protected by per-cache read/write locks so that multiple tasks can read from the same cache concurrently while writes are serialized.
>- Docker image loading (D2G) uses file-level locking so parallel tasks sharing the same image coordinate without redundant loads.
>- In multiuser mode, TaskclusterProxy now verifies that incoming connections originate from the OS user running the task, preventing one task from accessing another task's credentials. This is implemented via `/proc/net/tcp` on Linux, `lsof` on macOS, and `GetExtendedTcpTable` on Windows. Note: in insecure mode, all tasks run as the same OS user, so UID-based connection verification is not possible; insecure mode with `capacity` > 1 does not provide credential isolation between concurrent tasks.
>
>**Constraints:**
>
>- The `runTaskAsCurrentUser` and `runAsAdministrator` task features are not supported when `capacity` > 1 and will return a `MalformedPayloadError` if requested.
>- Graceful shutdown waits for all running tasks to complete before the worker exits.
>- `numberOfTasksToRun` is respected across all concurrent slots - the worker will not start more tasks than the configured total.