### PR TITLE
feat(index): resolve public artifact URL server-side to reduce redirects

### DIFF
--- a/changelog/issue-8035.md
+++ b/changelog/issue-8035.md
@@ -2,4 +2,4 @@ audience: users
 level: minor
 reference: issue 8035
 ---
-The index service no longer adds a bewit (time-limited auth token) to redirect URLs for public artifacts. Artifacts are considered public if the anonymous role has the necessary scopes to get them. The index service caches the scopes associated to the anonymous role and refreshes them from the auth service every 5 minutes.
+The index service no longer adds a bewit (time-limited auth token) to redirect URLs for public artifacts. Artifacts are considered public if the anonymous role has the necessary scopes to get them. The index service caches the scopes associated to the anonymous role and refreshes them from the auth service every 5 minutes. Additionally, for public artifacts, the index service now resolves the final artifact URL server-side by calling the queue's `latestArtifact` endpoint, reducing the redirect chain from two hops (Index → Queue → storage) to one (Index → storage).

--- a/services/index/src/api.js
+++ b/services/index/src/api.js
@@ -369,22 +369,30 @@ builder.declare({
     isPublic = false;
   }
 
-  let url;
   if (isPublic) {
-    url = that.queue.externalBuildUrl(
+    try {
+      const artifact = await that.queue.latestArtifact(task.taskId, artifactName);
+      if (artifact.url) {
+        return res.redirect(303, artifact.url);
+      }
+    } catch {
+      // fall through to queue redirect
+    }
+    const url = that.queue.externalBuildUrl(
       that.queue.getLatestArtifact,
       task.taskId,
       artifactName,
     );
-  } else {
-    url = that.queue.externalBuildSignedUrl(
-      that.queue.getLatestArtifact,
-      task.taskId,
-      artifactName, {
-        expiration: 15 * 60,
-      },
-    );
+    return res.redirect(303, url);
   }
+
+  const url = that.queue.externalBuildSignedUrl(
+    that.queue.getLatestArtifact,
+    task.taskId,
+    artifactName, {
+      expiration: 15 * 60,
+    },
+  );
   return res.redirect(303, url);
 });
 

--- a/services/index/test/helper.js
+++ b/services/index/test/helper.js
@@ -159,6 +159,7 @@ helper.withServer = withServer;
  */
 const stubbedQueue = () => {
   const tasks = {};
+  const artifacts = {};
   const queue = new taskcluster.Queue({
     rootUrl: helper.rootUrl,
     credentials: {
@@ -171,11 +172,21 @@ const stubbedQueue = () => {
         assert(task, `fake queue has no task ${taskId}`);
         return task;
       },
+      latestArtifact: async (taskId, name) => {
+        const key = `${taskId}/${name}`;
+        const artifact = artifacts[key];
+        assert(artifact, `fake queue has no artifact ${key}`);
+        return artifact;
+      },
     },
   });
 
   queue.addTask = function(taskId, task) {
     tasks[taskId] = task;
+  };
+
+  queue.setArtifact = function(taskId, name, response) {
+    artifacts[`${taskId}/${name}`] = response;
   };
 
   return queue;


### PR DESCRIPTION
Github Issue: Fixes #8035

Depends on #8283. This PR just adds one commit, the last one. The other ones come from #8283. Patch also tested manually:

## Before

```
curl -IL http://taskcluster/api/index/v1/task/e2e-test.bewit.artifacts/artifacts/public/hello.txt

HTTP/1.1 303 See Other
Content-Type: text/plain; charset=utf-8
Content-Length: 114
[...]
Location: http://taskcluster/api/queue/v1/task/TVtOlb97THWZYG36WoNxZg/artifacts/public%2Fhello.txt
[...]

HTTP/1.1 303 See Other
Content-Type: application/json; charset=utf-8
Content-Length: 112
[...]
location: http://taskcluster/public-bucket/TVtOlb97THWZYG36WoNxZg/0/public/hello.txt
[...]

HTTP/1.1 200 OK
Content-Type: text/plain; charset=utf-8
Content-Length: 6
[...]
Last-Modified: Mon, 16 Feb 2026 17:35:55 GMT
ETag: "79790eaf1bb29e4a543a90d69d8dbd9b"
[...]
```

## After

```
HTTP/1.1 303 See Other
Content-Type: text/plain; charset=utf-8
Content-Length: 100
[...]
Location: http://taskcluster/public-bucket/TVtOlb97THWZYG36WoNxZg/0/public/hello.txt
[...]

HTTP/1.1 200 OK
Date: Tue, 17 Feb 2026 10:34:35 GMT
Content-Type: text/plain; charset=utf-8
Content-Length: 6
[...]
Last-Modified: Mon, 16 Feb 2026 17:35:55 GMT
ETag: "79790eaf1bb29e4a543a90d69d8dbd9b"
[...]
```