### PR TITLE
generic-worker: avoid status-listener callback lock reentrancy

### DIFF
--- a/changelog/generic-worker-status-listener-and-artifact-errors.md
+++ b/changelog/generic-worker-status-listener-and-artifact-errors.md
@@ -1,0 +1,6 @@
+level: patch
+audience: users
+---
+The generic-worker now notifies task status listeners outside of the internal status lock, reducing the risk of lock contention or deadlock when listeners query task status during callbacks.
+
+Internal artifact upload error handling was also refactored into a dedicated classifier helper without changing runtime behavior.


### PR DESCRIPTION
## Summary
- notify task status listeners outside `TaskStatusManager` lock to avoid callback re-entrancy deadlock risk
- keep behavior the same while refactoring artifact upload error handling into `classifyCreateArtifactError`
- add a regression test ensuring listeners can query status during callback
- add a changelog snippet for the worker behavior fix

## Validation
- `cd workers/generic-worker && GOCACHE=/tmp/go-build-cache go generate ./...`
- `cd /Users/pmoore/git/taskcluster && VER=$(cat .golangci-lint-version) && PATH="/tmp/golangci-lint-${VER}-darwin-arm64:$PATH" GOCACHE=/tmp/go-build-cache GOLANGCI_LINT_CACHE=/tmp/golangci-lint-cache bash test/go-lint.sh`
- `cd workers/generic-worker && GOCACHE=/tmp/go-build-cache go test -tags multiuser -run TestStatusListenerCanCallBackIntoManager`
