### PR TITLE
fix(generic-worker): avoid reclaim creds deadlock

### DIFF
--- a/changelog/issue-8289.md
+++ b/changelog/issue-8289.md
@@ -1,0 +1,5 @@
+audience: worker-deployers
+level: patch
+reference: issue 8289
+---
+Generic Worker: fixes credential expiration during high-volume artifact uploads by narrowing the scope of the queue client lock so that credential refresh is no longer blocked by in-flight HTTP calls.

--- a/workers/generic-worker/mounts_feature.go
+++ b/workers/generic-worker/mounts_feature.go
@@ -887,7 +887,10 @@ func (ac *ArtifactContent) Download(taskMount *TaskMount) (file string, sha256 s
 	taskMount.Infof("Downloading %v to %v", ac, file)
 
 	var runID int64 = -1 // use the latest run
-	_, contentLength, err := taskMount.task.Queue.DownloadArtifactToFile(ac.TaskID, runID, ac.Artifact, file)
+	taskMount.task.queueMux.RLock()
+	queue := taskMount.task.Queue
+	taskMount.task.queueMux.RUnlock()
+	_, contentLength, err := queue.DownloadArtifactToFile(ac.TaskID, runID, ac.Artifact, file)
 	if err != nil {
 		return
 	}

--- a/workers/generic-worker/taskstatus.go
+++ b/workers/generic-worker/taskstatus.go
@@ -90,8 +90,9 @@ func (tsm *TaskStatusManager) ReportException(reason TaskUpdateReason) error {
 			tsm.stopReclaims()
 			ter := tcqueue.TaskExceptionRequest{Reason: string(reason)}
 			task.queueMux.RLock()
-			tsr, err := task.Queue.ReportException(task.TaskID, strconv.FormatInt(int64(task.RunID), 10), &ter)
+			queue := task.Queue
 			task.queueMux.RUnlock()
+			tsr, err := queue.ReportException(task.TaskID, strconv.FormatInt(int64(task.RunID), 10), &ter)
 			if err != nil {
 				log.Printf("Not able to report exception for task %v:", task.TaskID)
 				log.Printf("%v", err)
@@ -113,8 +114,9 @@ func (tsm *TaskStatusManager) ReportFailed() error {
 		func(task *TaskRun) error {
 			tsm.stopReclaims()
 			task.queueMux.RLock()
-			tsr, err := task.Queue.ReportFailed(task.TaskID, strconv.FormatInt(int64(task.RunID), 10))
+			queue := task.Queue
 			task.queueMux.RUnlock()
+			tsr, err := queue.ReportFailed(task.TaskID, strconv.FormatInt(int64(task.RunID), 10))
 			if err != nil {
 				log.Printf("Not able to report failed completion for task %v:", task.TaskID)
 				log.Printf("%v", err)
@@ -137,8 +139,9 @@ func (tsm *TaskStatusManager) ReportCompleted() error {
 			tsm.stopReclaims()
 			log.Printf("Task %v finished successfully!", task.TaskID)
 			task.queueMux.RLock()
-			tsr, err := task.Queue.ReportCompleted(task.TaskID, strconv.FormatInt(int64(task.RunID), 10))
+			queue := task.Queue
 			task.queueMux.RUnlock()
+			tsr, err := queue.ReportCompleted(task.TaskID, strconv.FormatInt(int64(task.RunID), 10))
 			if err != nil {
 				log.Printf("Not able to report successful completion for task %v:", task.TaskID)
 				log.Printf("%v", err)
@@ -159,8 +162,9 @@ func (tsm *TaskStatusManager) reclaim() error {
 		func(task *TaskRun) error {
 			log.Printf("Reclaiming task %v...", task.TaskID)
 			task.queueMux.RLock()
-			tcrsp, err := task.Queue.ReclaimTask(task.TaskID, fmt.Sprintf("%d", task.RunID))
+			queue := task.Queue
 			task.queueMux.RUnlock()
+			tcrsp, err := queue.ReclaimTask(task.TaskID, fmt.Sprintf("%d", task.RunID))
 
 			// check if an error occurred...
 			if err != nil {


### PR DESCRIPTION
Fixes #8289.

>Generic Worker: fixes credential expiration during high-volume artifact uploads by narrowing the scope of the queue client lock so that credential refresh is no longer blocked by in-flight HTTP calls.