### PR TITLE
fix(generic-worker): handle `SIGTERM` to properly terminate the worker

### DIFF
--- a/changelog/issue-8291.md
+++ b/changelog/issue-8291.md
@@ -1,0 +1,5 @@
+audience: worker-deployers
+level: patch
+reference: issue 8291
+---
+Generic Worker: handles `SIGTERM` during task execution by triggering graceful termination, ensuring preempted tasks are properly resolved as `exception/worker-shutdown` instead of `exception/claim-expired`.

--- a/workers/generic-worker/graceful/graceful.go
+++ b/workers/generic-worker/graceful/graceful.go
@@ -49,6 +49,9 @@ func Terminate(finishTasks bool) {
 	m.Lock()
 	defer m.Unlock()
 
+	if terminationRequested {
+		return
+	}
 	terminationRequested = true
 	if callback != nil {
 		callback(finishTasks)


### PR DESCRIPTION
Fixes #8291.

>Generic Worker: handles `SIGTERM` during task execution by triggering graceful termination, ensuring preempted tasks are properly resolved as `exception/worker-shutdown` instead of `exception/claim-expired`.

cc @bhearsum