### PR TITLE
feat(queue): Report missing metrics for claim and deadline resolvers

### DIFF
--- a/changelog/issue-8292.md
+++ b/changelog/issue-8292.md
@@ -1,0 +1,5 @@
+audience: developers
+level: patch
+reference: issue 8292
+---
+Add missing `queue_exception_tasks` metric to the claim-resolver and deadline-resolver.

--- a/docker/prometheus.yml
+++ b/docker/prometheus.yml
@@ -12,6 +12,8 @@ scrape_configs:
           - object-web:9100
           - purge-cache-web:9100
           - queue-web:9100
+          - queue-background-claimResolver:9100
+          - queue-background-deadlineResolver:9100
           - queue-background-workerMetrics:9100
           - secrets-web:9100
           - web-server-web:9100

--- a/infrastructure/k8s/templates/taskcluster-queue-deployment-claimResolver.yaml
+++ b/infrastructure/k8s/templates/taskcluster-queue-deployment-claimResolver.yaml
@@ -15,7 +15,13 @@ spec:
     metadata:
       annotations:
         checksum/secret: '{{ include (print $.Template.BasePath "/taskcluster-queue-secret.yaml") . | sha256sum }}'
-      labels: *ref_0
+      labels:
+        app.kubernetes.io/name: taskcluster-queue
+        app.kubernetes.io/instance: '{{ .Release.Name }}'
+        app.kubernetes.io/component: taskcluster-queue-claimresolver
+        app.kubernetes.io/part-of: taskcluster
+        prometheus.io/scrape: 'true'
+        prometheus.io/port: '9100'
     spec:
       serviceAccountName: taskcluster-queue
       imagePullSecrets: {{ if .Values.imagePullSecret }}{{ toJson (list (dict "name" .Values.imagePullSecret)) }}{{ else }}[]{{ end }}
@@ -46,7 +52,10 @@ spec:
                 name: taskcluster-queue
             - configMapRef:
                 name: taskcluster-queue
-          ports: []
+          ports:
+            - name: prometheus
+              containerPort: 9100
+              protocol: TCP
           livenessProbe:
             exec:
               command:

--- a/infrastructure/k8s/templates/taskcluster-queue-deployment-deadlineResolver.yaml
+++ b/infrastructure/k8s/templates/taskcluster-queue-deployment-deadlineResolver.yaml
@@ -15,7 +15,13 @@ spec:
     metadata:
       annotations:
         checksum/secret: '{{ include (print $.Template.BasePath "/taskcluster-queue-secret.yaml") . | sha256sum }}'
-      labels: *ref_0
+      labels:
+        app.kubernetes.io/name: taskcluster-queue
+        app.kubernetes.io/instance: '{{ .Release.Name }}'
+        app.kubernetes.io/component: taskcluster-queue-deadlineresolver
+        app.kubernetes.io/part-of: taskcluster
+        prometheus.io/scrape: 'true'
+        prometheus.io/port: '9100'
     spec:
       serviceAccountName: taskcluster-queue
       imagePullSecrets: {{ if .Values.imagePullSecret }}{{ toJson (list (dict "name" .Values.imagePullSecret)) }}{{ else }}[]{{ end }}
@@ -46,7 +52,10 @@ spec:
                 name: taskcluster-queue
             - configMapRef:
                 name: taskcluster-queue
-          ports: []
+          ports:
+            - name: prometheus
+              containerPort: 9100
+              protocol: TCP
           livenessProbe:
             exec:
               command:

--- a/infrastructure/k8s/values.yaml
+++ b/infrastructure/k8s/values.yaml
@@ -175,10 +175,12 @@ queue:
       replicas: 1
       cpu: 50m
       memory: 50Mi
+      metrics: true
     deadlineResolver:
       replicas: 1
       cpu: 50m
       memory: 100Mi
+      metrics: true
     dependencyResolver:
       replicas: 1
       cpu: 100m

--- a/services/queue/procs.yml
+++ b/services/queue/procs.yml
@@ -9,10 +9,12 @@ claimResolver:
   type: background
   subType: 'iterate'
   command: node services/queue/src/main.js claim-resolver
+  metrics: true
 deadlineResolver:
   type: background
   subType: 'iterate'
   command: node services/queue/src/main.js deadline-resolver
+  metrics: true
 dependencyResolver:
   type: background
   subType: 'iterate'

--- a/services/queue/src/api.js
+++ b/services/queue/src/api.js
@@ -440,6 +440,12 @@ const cancelSingleTask = async (task, ctx) => {
       task: { tags: task.tags || {} },
     }, _.pick(run, 'workerGroup', 'workerId')), task.routes);
     ctx.monitor.log.taskException({ taskId: task.taskId, runId });
+
+    const metricLabels = splitTaskQueueId(task.taskQueueId);
+    ctx.monitor.metric.exceptionTasks(1, {
+      ...metricLabels,
+      reasonResolved: run.reasonResolved,
+    });
   }
 
   return status;

--- a/services/queue/src/claimresolver.js
+++ b/services/queue/src/claimresolver.js
@@ -2,7 +2,7 @@ import assert from 'assert';
 import QueueService from './queueservice.js';
 import Iterate from '@taskcluster/lib-iterate';
 import { Task } from './data.js';
-import { sleep } from './utils.js';
+import { sleep, splitTaskQueueId } from './utils.js';
 
 /**
  * Facade that handles resolution of claims by takenUntil, using the advisory
@@ -154,6 +154,12 @@ class ClaimResolver {
       workerId: run.workerId,
     }, task.routes);
     this.monitor.log.taskException({ taskId, runId });
+
+    const metricLabels = splitTaskQueueId(task.taskQueueId);
+    this.monitor.metric.exceptionTasks(1, {
+      ...metricLabels,
+      reasonResolved: run.reasonResolved,
+    });
 
     // If a newRun was created and it is a retry with state pending then we
     // better publish messages about it

--- a/services/queue/src/deadlineresolver.js
+++ b/services/queue/src/deadlineresolver.js
@@ -5,7 +5,7 @@ import _ from 'lodash';
 import QueueService from './queueservice.js';
 import Iterate from '@taskcluster/lib-iterate';
 import { Task } from './data.js';
-import { sleep } from './utils.js';
+import { sleep, splitTaskQueueId } from './utils.js';
 
 /**
  * Facade that handles resolution tasks by deadline, using the advisory messages
@@ -151,6 +151,12 @@ class DeadlineResolver {
         task: { tags: task.tags || {} },
       }, task.routes);
       this.monitor.log.taskException({ taskId, runId });
+
+      const metricLabels = splitTaskQueueId(task.taskQueueId);
+      this.monitor.metric.exceptionTasks(1, {
+        ...metricLabels,
+        reasonResolved: run.reasonResolved,
+      });
 
       // Task should no longer be available in the pending queue
       await this.queueService.removePendingMessage(taskId, runId);

--- a/ui/docs/manual/deploying/monitoring.mdx
+++ b/ui/docs/manual/deploying/monitoring.mdx
@@ -109,6 +109,8 @@ Below is the list of services and jobs that expose metrics:
 | object         | web                 | web        | [reference](/docs/reference/platform/object/metrics)     |
 | purge-cache    | web                 | web        | [reference](/docs/reference/core/purge-cache/metrics)    |
 | queue          | web                 | web        | [reference](/docs/reference/platform/queue/metrics)      |
+| queue          | claimResolver       | background | [reference](/docs/reference/platform/queue/metrics)      |
+| queue          | deadlineResolver    | background | [reference](/docs/reference/platform/queue/metrics)      |
 | queue          | workerMetrics       | background | [reference](/docs/reference/platform/queue/metrics)      |
 | secrets        | web                 | web        | [reference](/docs/reference/core/secrets/metrics)        |
 | web-server     | web                 | web        | [reference](/docs/reference/core/web-server/metrics)     |


### PR DESCRIPTION
`queue_exception_tasks` metric was only reported from queue api endpoint, when workers  reported exceptions, but not from the background jobs - claim & deadline resolvers, which made whole picture incomplete. 




Fixes #8292
