### PR TITLE
feat(queue): Fix metrics exposure in resolvers

### DIFF
--- a/changelog/issue-8292.md
+++ b/changelog/issue-8292.md
@@ -1,0 +1,5 @@
+audience: deployers
+level: patch
+reference: issue 8292
+---
+Claim-resolver and deadline-resolver expose metrics.

--- a/generated/references.json
+++ b/generated/references.json
@@ -20662,7 +20662,8 @@
           },
           "name": "queue_exception_tasks",
           "registers": [
-            "default"
+            "default",
+            "resolvers"
           ],
           "title": "Counter for task exception",
           "type": "counter"

--- a/services/queue/src/main.js
+++ b/services/queue/src/main.js
@@ -278,6 +278,7 @@ let load = loader({
         monitor: monitor.childMonitor('claim-resolver'),
       });
       await resolver.start();
+      monitor.exposeMetrics('resolvers');
       return resolver;
     },
   },
@@ -300,6 +301,7 @@ let load = loader({
         monitor: monitor.childMonitor('deadline-resolver'),
       });
       await resolver.start();
+      monitor.exposeMetrics('resolvers');
       return resolver;
     },
   },

--- a/services/queue/src/monitor.js
+++ b/services/queue/src/monitor.js
@@ -268,7 +268,7 @@ MonitorManager.registerMetric('exceptionTasks', {
     ...commonLabels,
     reasonResolved: 'Reason for task exception',
   },
-  registers: ['default'],
+  registers: ['default', 'resolvers'],
 });
 
 MonitorManager.registerMetric('pendingTasks', {


### PR DESCRIPTION
Claim/Deadline resolvers were not running exposeMetrics

Addition to #8296 
Fixes #8292
