### PR TITLE
fix(generic-worker): ensure `ProfSvc` is running before profile ops

### DIFF
--- a/changelog/issue-8083.md
+++ b/changelog/issue-8083.md
@@ -1,0 +1,5 @@
+audience: worker-deployers
+level: patch
+reference: issue 8083
+---
+Generic Worker (windows): waits for the User Profile Service (`ProfSvc`) to be running before performing profile operations on first boot, and fixes a bug where `LoadUserProfile` retry logic for "device not ready" errors never actually retried due to an incorrect error type assertion.

--- a/workers/generic-worker/process/logininfo_multiuser_windows.go
+++ b/workers/generic-worker/process/logininfo_multiuser_windows.go
@@ -3,6 +3,7 @@
 package process
 
 import (
+	"errors"
 	"fmt"
 	"log"
 	"syscall"
@@ -74,7 +75,8 @@ func loadProfile(user syscall.Token, username string) (syscall.Handle, error) {
 			return pinfo.Profile, nil
 		}
 
-		if errno, ok := err.(syscall.Errno); ok && errno == 21 { // ERROR_NOT_READY
+		var errno syscall.Errno
+		if errors.As(err, &errno) && errno == 21 { // ERROR_NOT_READY
 			if i < maxRetries-1 {
 				log.Printf("LoadUserProfile failed with 'device not ready' (attempt %d/%d), retrying in %v: %v", i+1, maxRetries, delay, err)
 				time.Sleep(delay)


### PR DESCRIPTION
Fixes #8083 (hopefully 🤞🏻)

>Generic Worker (windows): waits for the User Profile Service (`ProfSvc`) to be running before performing profile operations on first boot, and fixes a bug where `LoadUserProfile` retry logic for "device not ready" errors never actually retried due to an incorrect error type assertion.