### PR TITLE
feat(queue): listen to workerStopped events

### DIFF
--- a/changelog/issue-7472.md
+++ b/changelog/issue-7472.md
@@ -1,0 +1,5 @@
+audience: deployers
+level: patch
+reference: issue 7472
+---
+The queue service's `workerRemovedResolver` now also listens for `workerStopped` events from worker-manager, in addition to `workerRemoved` events. This ensures claimed tasks are resolved as `exception/worker-shutdown` as early as possible when a worker disappears. Both events are handled idempotently, so receiving both for the same worker is safe.


### PR DESCRIPTION
- Subscribe to workerStopped in addition to workerRemoved so tasks are resolved as early as possible when a worker disappears
- All operations are idempotent so receiving both events is safe
- Add tests for workerStopped handling, idempotency, and claimed record cleanup

Followup to https://github.com/taskcluster/taskcluster/pull/8304.

>The queue service's `workerRemovedResolver` now also listens for `workerStopped` events from worker-manager, in addition to `workerRemoved` events. This ensures claimed tasks are resolved as `exception/worker-shutdown` as early as possible when a worker disappears. Both events are handled idempotently, so receiving both for the same worker is safe.