### PR TITLE
feat(docs): Launch config weight distribution playground

### DIFF
--- a/changelog/eemNgWEmQgyW9GqAy0gyxg.md
+++ b/changelog/eemNgWEmQgyW9GqAy0gyxg.md
@@ -1,0 +1,5 @@
+audience: worker-deployers
+level: patch
+---
+Adds Weight Distribution Playground for Launch Configurations in documentation
+to see how initialWeight value change affect distribution

--- a/generated/docs-search.json
+++ b/generated/docs-search.json
@@ -2478,6 +2478,13 @@
     "title": "Worker-Manager - Launch Configurations"
   },
   {
+    "element": "h4",
+    "id": "weight-distribution-playground",
+    "path": "/reference/core/worker-manager/launch-configurations",
+    "subtitle": "Weight Distribution Playground",
+    "title": "Worker-Manager - Launch Configurations"
+  },
+  {
     "element": "h1",
     "id": "static-provider-type",
     "path": "/reference/core/worker-manager/static",

--- a/ui/docs/reference/core/worker-manager/launch-configurations.mdx
+++ b/ui/docs/reference/core/worker-manager/launch-configurations.mdx
@@ -3,6 +3,8 @@ title: Worker-Manager - Launch Configurations
 order: 100
 ---
 
+import WeightPlayground from '@taskcluster/ui/views/Documentation/components/WeightPlayground';
+
 # Worker-Manager - Launch Configurations
 
 Launch configurations define how Worker-Manager should create and manage cloud instances for worker pools.
@@ -54,6 +56,12 @@ Initial weight determines how likely a configuration will be selected during pro
 **Three Configurations:**
 - Config A: `1.0`, Config B: `0.5`, Config C: `0.5`
 - Result: `~50%` A, `~25%` B, `~25%` C
+
+#### Weight Distribution Playground
+
+Adjust weights below to see how workers would be distributed across configurations (out of 1000).
+
+<WeightPlayground />
 
 #### Use Cases
 - Cost optimization: Assign higher weights to cheaper regions

--- a/ui/src/views/Documentation/components/WeightPlayground/index.jsx
+++ b/ui/src/views/Documentation/components/WeightPlayground/index.jsx
@@ -1,0 +1,156 @@
+import React, { useState } from 'react';
+import { withStyles } from '@material-ui/core/styles';
+import Table from '@material-ui/core/Table';
+import TableHead from '@material-ui/core/TableHead';
+import TableRow from '@material-ui/core/TableRow';
+import TableCell from '@material-ui/core/TableCell';
+import TableBody from '@material-ui/core/TableBody';
+import TextField from '@material-ui/core/TextField';
+import LinearProgress from '@material-ui/core/LinearProgress';
+import IconButton from '@material-ui/core/IconButton';
+import Button from '@material-ui/core/Button';
+import Typography from '@material-ui/core/Typography';
+import DeleteIcon from 'mdi-react/DeleteIcon';
+import PlusIcon from 'mdi-react/PlusIcon';
+import computeWeightDistribution from './utils';
+
+const styles = theme => ({
+  root: {
+    marginTop: theme.spacing(2),
+    marginBottom: theme.spacing(4),
+    overflowX: 'auto',
+  },
+  addButton: {
+    marginTop: theme.spacing(2),
+  },
+  progress: {
+    height: 10,
+    borderRadius: 5,
+    minWidth: 80,
+    '& .MuiLinearProgress-barColorPrimary': {
+      backgroundColor:
+        theme.palette.type === 'dark'
+          ? theme.palette.primary.light
+          : theme.palette.primary.dark,
+    },
+  },
+  naText: {
+    color: theme.palette.text.disabled,
+  },
+  weightInput: {
+    width: 80,
+  },
+});
+const DEFAULT_CONFIGS = [
+  { id: 1, weight: 1.0 },
+  { id: 2, weight: 0.5 },
+  { id: 3, weight: 0.1 },
+];
+let nextId = DEFAULT_CONFIGS.length + 1;
+
+function WeightPlayground({ classes }) {
+  const [configs, setConfigs] = useState(DEFAULT_CONFIGS);
+  const distributedConfigs = computeWeightDistribution(configs);
+  const handleWeightChange = (id, value) => {
+    const parsed = parseFloat(value);
+    const weight = Number.isNaN(parsed) || parsed < 0 ? 0 : Math.min(parsed, 1);
+
+    setConfigs(prev => prev.map(c => (c.id === id ? { ...c, weight } : c)));
+  };
+
+  const handleAdd = () => {
+    // eslint-disable-next-line no-plusplus
+    setConfigs(prev => [...prev, { id: nextId++, weight: 1.0 }]);
+  };
+
+  const handleRemove = id => {
+    setConfigs(prev => prev.filter(c => c.id !== id));
+  };
+
+  return (
+    <div className={classes.root}>
+      <Table size="small">
+        <TableHead>
+          <TableRow>
+            <TableCell>Config ID</TableCell>
+            <TableCell>Weight</TableCell>
+            <TableCell>% Share</TableCell>
+            <TableCell>Workers (of 1000)</TableCell>
+            <TableCell>Distribution</TableCell>
+            <TableCell />
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          {distributedConfigs.map((config, index) => {
+            const { share, workers } = config;
+
+            return (
+              <TableRow key={config.id}>
+                <TableCell>
+                  <Typography variant="body2">config-{index + 1}</Typography>
+                </TableCell>
+                <TableCell>
+                  <TextField
+                    className={classes.weightInput}
+                    type="number"
+                    value={config.weight}
+                    onChange={e =>
+                      handleWeightChange(config.id, e.target.value)
+                    }
+                    inputProps={{ min: 0, max: 1, step: 0.1 }}
+                    size="small"
+                    variant="outlined"
+                  />
+                </TableCell>
+                <TableCell>
+                  {share !== null ? (
+                    `${share.toFixed(1)}%`
+                  ) : (
+                    <span className={classes.naText}>N/A</span>
+                  )}
+                </TableCell>
+                <TableCell>
+                  {workers !== null ? (
+                    workers
+                  ) : (
+                    <span className={classes.naText}>N/A</span>
+                  )}
+                </TableCell>
+                <TableCell>
+                  {share !== null ? (
+                    <LinearProgress
+                      className={classes.progress}
+                      variant="determinate"
+                      value={share}
+                    />
+                  ) : (
+                    <span className={classes.naText}>N/A</span>
+                  )}
+                </TableCell>
+                <TableCell>
+                  <IconButton
+                    size="small"
+                    onClick={() => handleRemove(config.id)}
+                    disabled={configs.length === 1}
+                    aria-label="remove config">
+                    <DeleteIcon />
+                  </IconButton>
+                </TableCell>
+              </TableRow>
+            );
+          })}
+        </TableBody>
+      </Table>
+      <Button
+        className={classes.addButton}
+        variant="outlined"
+        size="small"
+        onClick={handleAdd}
+        startIcon={<PlusIcon />}>
+        Add Config
+      </Button>
+    </div>
+  );
+}
+
+export default withStyles(styles)(WeightPlayground);

--- a/ui/src/views/Documentation/components/WeightPlayground/utils.js
+++ b/ui/src/views/Documentation/components/WeightPlayground/utils.js
@@ -1,0 +1,24 @@
+/**
+ * Compute weight distribution for an array of configs.
+ * Formula matches WeightedRandomConfig in
+ *  services/worker-manager/src/launch-config-selector.js.
+ *
+ * @param {Array<{ id: number, weight: number }>} configs
+ * @returns {Array<{
+ *  id: number, weight: number, share: number|null, workers: number|null
+ * }>}
+ */
+export default function computeWeightDistribution(configs) {
+  const totalWeight = configs.reduce((sum, c) => sum + c.weight, 0);
+
+  return configs.map(c => {
+    if (totalWeight === 0) {
+      return { ...c, share: null, workers: null };
+    }
+
+    const share = (c.weight / totalWeight) * 100;
+    const workers = Math.round((share / 100) * 1000);
+
+    return { ...c, share, workers };
+  });
+}

--- a/ui/src/views/Documentation/components/WeightPlayground/utils.test.js
+++ b/ui/src/views/Documentation/components/WeightPlayground/utils.test.js
@@ -1,0 +1,53 @@
+import computeWeightDistribution from './utils';
+
+describe('computeWeightDistribution', () => {
+  it('default 3-config case: weights [1.0, 0.5, 0.1]', () => {
+    const configs = [
+      { id: 1, weight: 1.0 },
+      { id: 2, weight: 0.5 },
+      { id: 3, weight: 0.1 },
+    ];
+    const result = computeWeightDistribution(configs);
+
+    expect(result[0].share).toBeCloseTo(62.5);
+    expect(result[1].share).toBeCloseTo(31.25);
+    expect(result[2].share).toBeCloseTo(6.25);
+    expect(result[0].workers).toBe(625);
+    expect(result[1].workers).toBe(313);
+    expect(result[2].workers).toBe(63);
+  });
+
+  it('all zeros: all share and workers are null', () => {
+    const configs = [
+      { id: 1, weight: 0 },
+      { id: 2, weight: 0 },
+    ];
+    const result = computeWeightDistribution(configs);
+
+    expect(result[0].share).toBeNull();
+    expect(result[0].workers).toBeNull();
+    expect(result[1].share).toBeNull();
+    expect(result[1].workers).toBeNull();
+  });
+
+  it('single config: 100% share, 1000 workers', () => {
+    const configs = [{ id: 1, weight: 1.0 }];
+    const result = computeWeightDistribution(configs);
+
+    expect(result[0].share).toBe(100);
+    expect(result[0].workers).toBe(1000);
+  });
+
+  it('equal weights: both configs get 50% share, 500 workers', () => {
+    const configs = [
+      { id: 1, weight: 0.5 },
+      { id: 2, weight: 0.5 },
+    ];
+    const result = computeWeightDistribution(configs);
+
+    expect(result[0].share).toBe(50);
+    expect(result[1].share).toBe(50);
+    expect(result[0].workers).toBe(500);
+    expect(result[1].workers).toBe(500);
+  });
+});


### PR DESCRIPTION
This adds a playground in documentation to test how initial weights of launch config change distributions by showing how many workers out of 1000 would roughly be created for a given weight

`/docs/reference/core/worker-manager/launch-configurations`

<img width="1163" height="1111" alt="image" src="https://github.com/user-attachments/assets/89b63481-753a-45ed-aee2-2e180f665d14" />

<img width="855" height="294" alt="image" src="https://github.com/user-attachments/assets/c3d8b8e6-e9c9-42e4-ad16-f0c399e8e69e" />


Should give a better picture how those weights would affect distribution