### PR TITLE
feat(w-m): Double-check Azure 404 instanceView

### DIFF
--- a/changelog/issue-8314.md
+++ b/changelog/issue-8314.md
@@ -1,0 +1,7 @@
+audience: worker-deployers
+level: patch
+reference: issue 8314
+---
+
+Azure double-checks if vm is gone by calling virtualMachines.get after instanceView returns 404.
+This is to prevent situations when worker is being removed based on one failed instanceView call.

--- a/generated/references.json
+++ b/generated/references.json
@@ -18270,6 +18270,23 @@
           "version": 1
         },
         {
+          "description": "Azure VM instanceView returned 404 repeatedly for the same worker.\nWorker Manager treats this as missing to avoid getting stuck in a transient loop.",
+          "fields": {
+            "instanceView404Streak": "Consecutive count of instanceView 404 responses",
+            "providerId": "Provider ID",
+            "provisioningState": "Provisioning state returned by virtualMachines.get",
+            "vmName": "Azure VM name",
+            "workerGroup": "Worker Group",
+            "workerId": "Worker ID",
+            "workerPoolId": "Worker Pool ID"
+          },
+          "level": "warning",
+          "name": "azureInstanceViewRepeated404",
+          "title": "Azure InstanceView Repeated 404",
+          "type": "azure-instance-view-repeated-404",
+          "version": 1
+        },
+        {
           "description": "When ARM template is being deployed with custom resource group name,\nAzure provider would create or update the resource group.\nThis is to make sure that deployment is run in the existing resource group.",
           "fields": {
             "location": "Location",

--- a/services/worker-manager/src/monitor.js
+++ b/services/worker-manager/src/monitor.js
@@ -262,6 +262,27 @@ MonitorManager.register({
   },
 });
 
+MonitorManager.register({
+  name: 'azureInstanceViewRepeated404',
+  title: 'Azure InstanceView Repeated 404',
+  type: 'azure-instance-view-repeated-404',
+  version: 1,
+  level: 'warning',
+  description: `
+    Azure VM instanceView returned 404 repeatedly for the same worker.
+    Worker Manager treats this as missing to avoid getting stuck in a transient loop.
+  `,
+  fields: {
+    providerId: 'Provider ID',
+    workerPoolId: 'Worker Pool ID',
+    workerGroup: 'Worker Group',
+    workerId: 'Worker ID',
+    vmName: 'Azure VM name',
+    provisioningState: 'Provisioning state returned by virtualMachines.get',
+    instanceView404Streak: 'Consecutive count of instanceView 404 responses',
+  },
+});
+
 const commonLabels = {
   workerPoolId: 'The worker pool ID',
   providerId: 'ID of the provider',


### PR DESCRIPTION
Looks like it might be eventually consistent and sometimes return 404 when we know the worker was doing something around that time. We can double-check with checking virtualMachines.get if vm is still there. If both return that instance is gone, we remove it. If not, we tolerate up to 2 times for now this inconsistency in scanner's memory and removing if it fails 3 times in a row


Fixes #8314 
