### PR TITLE
fix(gw/livelog): `address already in use` on get/put ports

### DIFF
--- a/changelog/issue-8318.md
+++ b/changelog/issue-8318.md
@@ -1,0 +1,5 @@
+audience: worker-deployers
+level: patch
+reference: issue 8318
+---
+Generic Worker & Livelog: fix intermittent "address already in use" error on livelog ports. When a livelog process failed to start, an orphaned goroutine would keep polling the port and later send a duplicate PUT request to the next task's livelog process, causing its GET server to fail binding. Fixed by cancelling the goroutine on early process exit, killing orphaned livelog processes on connection failure, and fixing the livelog binary's duplicate PUT request guard which was checked but never set.

--- a/tools/livelog/main.go
+++ b/tools/livelog/main.go
@@ -238,6 +238,7 @@ func serve(putAddr, getAddr string) {
 			mutex.Unlock() // used instead of defer so we don't block other rejections
 			return
 		}
+		handlingPut = true
 		mutex.Unlock() // So we don't block other rejections...
 
 		stream, streamErr := stream.NewStream(r.Body)


### PR DESCRIPTION
Fixes #8318.

>Generic Worker & Livelog: fix intermittent "address already in use" error on livelog ports. When a livelog process failed to start, an orphaned goroutine would keep polling the port and later send a duplicate PUT request to the next task's livelog process, causing its GET server to fail binding. Fixed by cancelling the goroutine on early process exit, killing orphaned livelog processes on connection failure, and fixing the livelog binary's duplicate PUT request guard which was checked but never set.