### PR TITLE
fix(generic-worker): clean temp livelog streaming files

### DIFF
--- a/changelog/issue-7652.md
+++ b/changelog/issue-7652.md
@@ -1,0 +1,5 @@
+audience: worker-deployers
+level: minor
+reference: issue 7652
+---
+Generic Worker & Livelog: fix livelog temporary streaming files not being cleaned up. The livelog process creates a temp directory per stream, but since the generic worker kills it with SIGKILL, the process never has a chance to clean up. Fixed by having the generic worker create a dedicated temp directory for each livelog process (via the new `LIVELOG_TEMP_DIR` env var) and removing it after the process is killed.

--- a/tools/livelog/README.md
+++ b/tools/livelog/README.md
@@ -134,3 +134,4 @@ The following environment variables can be used to configure the server.
  * `DEBUG` set to '*' to see debug logs (optional)
  * `LIVELOG_PUT_PORT` PUT port number (optional - default is 60022)
  * `LIVELOG_GET_PORT` GET port number (optional - default is 60023)
+ * `LIVELOG_TEMP_DIR` directory for temporary streaming files (optional - default is system temp dir)

--- a/tools/livelog/main.go
+++ b/tools/livelog/main.go
@@ -30,6 +30,7 @@ Environment:
  ACCESS_TOKEN			an arbitrary url-safe string
  SERVER_CRT_FILE		path to a file containing a certificate, if not provided, the server will run without TLS
  SERVER_KEY_FILE		path to a file containing a key, if not provided, the server will run without TLS
+ LIVELOG_TEMP_DIR		directory for temporary streaming files, defaults to the system temp dir
 
 Options:
 -h --help       Show help


### PR DESCRIPTION
Fixes #7652.

>Generic Worker & Livelog: fix livelog temporary streaming files not being cleaned up. The livelog process creates a temp directory per stream, but since the generic worker kills it with SIGKILL, the process never has a chance to clean up. Fixed by having the generic worker create a dedicated temp directory for each livelog process (via the new `LIVELOG_TEMP_DIR` env var) and removing it after the process is killed.