### PR TITLE
fix(d2g): avoid unnecessary I/O with docker image loads

### DIFF
--- a/changelog/Gm2XF1zkR02sqoJ7Yx60WQ.md
+++ b/changelog/Gm2XF1zkR02sqoJ7Yx60WQ.md
@@ -1,0 +1,4 @@
+audience: worker-deployers
+level: patch
+---
+D2G: avoids unnecessary I/O of copying cached docker image to task user's directory.

--- a/tools/d2g/d2g.go
+++ b/tools/d2g/d2g.go
@@ -36,6 +36,11 @@ type (
 		CopyArtifacts []CopyArtifact
 		EnvVars       string
 		Image         Image
+		// Populated by mounts feature when a docker image artifact is
+		// downloaded to the file cache. Used by d2g feature to avoid
+		// copying the image to the task directory.
+		ImageArtifactPath   string
+		ImageArtifactSHA256 string
 	}
 	CopyArtifact struct {
 		Name     string

--- a/workers/generic-worker/model.go
+++ b/workers/generic-worker/model.go
@@ -48,13 +48,24 @@ type (
 		// the feature name that caused the upload to be skipped, which may
 		// be useful for the user. Normally this map would get appended to by
 		// features when they are started.
-		featureArtifacts    map[string]string
+		featureArtifacts map[string]string
+		// FileMountHandlers allows features to intercept file mounts
+		// by filename. When a handler is registered for a filename,
+		// the mounts feature calls ensureCached and passes the cache
+		// path and SHA256 to the handler instead of copying the file
+		// to the task directory.
+		FileMountHandlers   map[string]FileMountHandler       `json:"-"`
 		D2GInfo             *d2g.ConversionInfo               `json:"-"`
 		DockerWorkerPayload *dockerworker.DockerWorkerPayload `json:"-"`
 	}
 
 	TaskStatus       string
 	TaskUpdateReason string
+
+	// FileMountHandler is called by the mounts feature instead of copying
+	// a file mount to the task directory. It receives the path to the
+	// cached file and its SHA256 hash.
+	FileMountHandler func(cachedFile, sha256 string) error
 )
 
 func (task *TaskRun) String() string {

--- a/workers/generic-worker/payload_linux.go
+++ b/workers/generic-worker/payload_linux.go
@@ -64,6 +64,19 @@ func (task *TaskRun) convertDockerWorkerPayload() *CommandExecutionError {
 	task.Definition.Payload = json.RawMessage(d2gConvertedPayloadJSON)
 	task.D2GInfo = &conversionInfo
 
+	// Register a file mount handler for docker image artifacts so the
+	// mounts feature stores the cache info on D2GInfo instead of copying
+	// the image to the task directory. The d2g feature will pipe it to
+	// docker load via stdin.
+	if task.FileMountHandlers == nil {
+		task.FileMountHandlers = map[string]FileMountHandler{}
+	}
+	task.FileMountHandlers["dockerimage"] = func(cachedFile, sha256 string) error {
+		task.D2GInfo.ImageArtifactPath = cachedFile
+		task.D2GInfo.ImageArtifactSHA256 = sha256
+		return nil
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
>D2G: avoids unnecessary I/O of copying cached docker image to task user's directory.

Inspired by https://github.com/Eijebong/taskcluster/commit/0273d9975d48b6e905b40122c36ce5ab0a3d3fec.