### PR TITLE
feat(g-w): reporting artifact size at creation time

### DIFF
--- a/changelog/issue-8101.md
+++ b/changelog/issue-8101.md
@@ -1,0 +1,6 @@
+audience: worker-deployers
+level: major
+reference: issue 8101
+---
+Generic worker now reports artifact file sizes to the queue via the optional `contentLength` parameter when creating artifacts. This applies to all file-based artifacts (S3 and object) as well as log artifacts. The reported size is the original file size on disk, before any encoding such as gzip compression.
+This feature relies on the API changes introduced in [v96.7.0](https://github.com/taskcluster/taskcluster/blob/main/CHANGELOG.md#v9670) and will fail schema validation if services are not upgraded.

--- a/internal/mocktc/queue.go
+++ b/internal/mocktc/queue.go
@@ -440,10 +440,19 @@ func (queue *Queue) ListArtifacts(taskId, runId, continuationToken, limit string
 			}
 		case *tcqueue.S3ArtifactRequest:
 			a = tcqueue.Artifact{
-				ContentType: A.ContentType,
-				Expires:     A.Expires,
-				Name:        name,
-				StorageType: A.StorageType,
+				ContentLength: A.ContentLength,
+				ContentType:   A.ContentType,
+				Expires:       A.Expires,
+				Name:          name,
+				StorageType:   A.StorageType,
+			}
+		case *tcqueue.ObjectArtifactRequest:
+			a = tcqueue.Artifact{
+				ContentLength: A.ContentLength,
+				ContentType:   A.ContentType,
+				Expires:       A.Expires,
+				Name:          name,
+				StorageType:   A.StorageType,
 			}
 		default:
 			queue.t.Fatalf("Invalid artifact request type for artifact %#v for task %v runId %v", a, taskId, runId)

--- a/workers/generic-worker/artifacts.go
+++ b/workers/generic-worker/artifacts.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"net"
 	"net/url"
+	"os"
 	"runtime"
 	"strconv"
 	"strings"
@@ -40,12 +41,17 @@ func createDataArtifact(
 	contentType string,
 	contentEncoding string,
 ) artifacts.TaskArtifact {
+	var contentLength int64
+	if info, err := os.Stat(contentPath); err == nil {
+		contentLength = info.Size()
+	}
 	if config.CreateObjectArtifacts {
 		// note that contentEncoding is currently ignored for object artifacts
 		return &artifacts.ObjectArtifact{
-			BaseArtifact: base,
-			Path:         path,
-			ContentType:  contentType,
+			BaseArtifact:  base,
+			Path:          path,
+			ContentType:   contentType,
+			ContentLength: contentLength,
 		}
 	}
 
@@ -55,6 +61,7 @@ func createDataArtifact(
 		ContentPath:     contentPath,
 		ContentType:     contentType,
 		ContentEncoding: contentEncoding,
+		ContentLength:   contentLength,
 	}
 }
 

--- a/workers/generic-worker/artifacts/object.go
+++ b/workers/generic-worker/artifacts/object.go
@@ -18,13 +18,17 @@ type ObjectArtifact struct {
 	Path string
 	// ContentType is used in the Content-Type header.
 	ContentType string
+	// ContentLength is the original file size in bytes, before any
+	// encoding (e.g. gzip). Sent to the queue for monitoring purposes.
+	ContentLength int64
 }
 
 func (a *ObjectArtifact) RequestObject() any {
 	return &tcqueue.ObjectArtifactRequest{
-		ContentType: a.ContentType,
-		Expires:     a.Expires,
-		StorageType: "object",
+		ContentType:   a.ContentType,
+		ContentLength: a.ContentLength,
+		Expires:       a.Expires,
+		StorageType:   "object",
 	}
 }
 
@@ -60,10 +64,11 @@ func (a *ObjectArtifact) FinishArtifact(resp any, queue tc.Queue, taskID, runID,
 }
 
 func (a *ObjectArtifact) String() string {
-	return fmt.Sprintf("Object Artifact - Name: '%v', Path: '%v', Expires: %v, Content-Type: '%v'",
+	return fmt.Sprintf("Object Artifact - Name: '%v', Path: '%v', Expires: %v, Content-Type: '%v', Content-Length: '%v'",
 		a.Name,
 		a.Path,
 		a.Expires,
 		a.ContentType,
+		a.ContentLength,
 	)
 }

--- a/workers/generic-worker/artifacts/s3.go
+++ b/workers/generic-worker/artifacts/s3.go
@@ -28,6 +28,9 @@ type S3Artifact struct {
 	ContentPath     string
 	ContentEncoding string
 	ContentType     string
+	// ContentLength is the original file size in bytes, before any
+	// encoding (e.g. gzip). Sent to the queue for monitoring purposes.
+	ContentLength int64
 }
 
 // createTempFileForPUTBody gzip-compresses the file at Path and
@@ -151,9 +154,10 @@ func (s3Artifact *S3Artifact) ProcessResponse(resp any, logger Logger, serviceFa
 
 func (s3Artifact *S3Artifact) RequestObject() any {
 	return &tcqueue.S3ArtifactRequest{
-		ContentType: s3Artifact.ContentType,
-		Expires:     s3Artifact.Expires,
-		StorageType: "s3",
+		ContentType:   s3Artifact.ContentType,
+		ContentLength: s3Artifact.ContentLength,
+		Expires:       s3Artifact.Expires,
+		StorageType:   "s3",
 	}
 }
 
@@ -162,11 +166,12 @@ func (s3Artifact *S3Artifact) ResponseObject() any {
 }
 
 func (s3Artifact *S3Artifact) String() string {
-	return fmt.Sprintf("S3 Artifact - Name: '%v', Path: '%v', Expires: %v, Content Encoding: '%v', MIME Type: '%v'",
+	return fmt.Sprintf("S3 Artifact - Name: '%v', Path: '%v', Expires: %v, Content Encoding: '%v', MIME Type: '%v', Content Length: '%v'",
 		s3Artifact.Name,
 		s3Artifact.Path,
 		s3Artifact.Expires,
 		s3Artifact.ContentEncoding,
 		s3Artifact.ContentType,
+		s3Artifact.ContentLength,
 	)
 }

--- a/workers/generic-worker/artifacts_test.go
+++ b/workers/generic-worker/artifacts_test.go
@@ -86,6 +86,7 @@ func TestFileArtifactWithNames(t *testing.T) {
 				},
 				ContentType:     "text/plain; charset=utf-8",
 				ContentEncoding: "gzip",
+				ContentLength:   14,
 				Path:            filepath.Join(taskContext.TaskDir, "SampleArtifacts", "_", "X.txt"),
 			},
 		})
@@ -116,6 +117,7 @@ func TestFileArtifactWithContentType(t *testing.T) {
 				},
 				ContentType:     "application/octet-stream",
 				ContentEncoding: "gzip",
+				ContentLength:   14,
 				Path:            filepath.Join(taskContext.TaskDir, "SampleArtifacts", "_", "X.txt"),
 			},
 		})
@@ -145,8 +147,9 @@ func TestFileArtifactAsObjectWithContentType(t *testing.T) {
 					Name:    "public/build/firefox.exe",
 					Expires: inAnHour,
 				},
-				ContentType: "application/octet-stream",
-				Path:        filepath.Join(taskContext.TaskDir, "SampleArtifacts", "_", "X.txt"),
+				ContentType:   "application/octet-stream",
+				ContentLength: 14,
+				Path:          filepath.Join(taskContext.TaskDir, "SampleArtifacts", "_", "X.txt"),
 			},
 		})
 }
@@ -214,6 +217,7 @@ func TestFileArtifactWithContentEncoding(t *testing.T) {
 				},
 				ContentType:     "text/plain; charset=utf-8",
 				ContentEncoding: "gzip",
+				ContentLength:   14,
 				Path:            filepath.Join(taskContext.TaskDir, "SampleArtifacts", "_", "X.txt"),
 			},
 			&artifacts.S3Artifact{
@@ -223,6 +227,7 @@ func TestFileArtifactWithContentEncoding(t *testing.T) {
 				},
 				ContentType:     "text/plain; charset=utf-8",
 				ContentEncoding: "gzip",
+				ContentLength:   14,
 				Path:            filepath.Join(taskContext.TaskDir, "SampleArtifacts", "_", "X.txt"),
 			},
 			&artifacts.S3Artifact{
@@ -232,6 +237,7 @@ func TestFileArtifactWithContentEncoding(t *testing.T) {
 				},
 				ContentType:     "text/plain; charset=utf-8",
 				ContentEncoding: "identity",
+				ContentLength:   14,
 				Path:            filepath.Join(taskContext.TaskDir, "SampleArtifacts", "_", "X.txt"),
 			},
 			&artifacts.S3Artifact{
@@ -241,6 +247,7 @@ func TestFileArtifactWithContentEncoding(t *testing.T) {
 				},
 				ContentType:     "image/jpeg",
 				ContentEncoding: "gzip",
+				ContentLength:   17,
 				Path:            filepath.Join(taskContext.TaskDir, "SampleArtifacts", "b", "c", "d.jpg"),
 			},
 			&artifacts.S3Artifact{
@@ -250,6 +257,7 @@ func TestFileArtifactWithContentEncoding(t *testing.T) {
 				},
 				ContentType:     "image/jpeg",
 				ContentEncoding: "identity",
+				ContentLength:   17,
 				Path:            filepath.Join(taskContext.TaskDir, "SampleArtifacts", "b", "c", "d.jpg"),
 			},
 			&artifacts.S3Artifact{
@@ -259,6 +267,7 @@ func TestFileArtifactWithContentEncoding(t *testing.T) {
 				},
 				ContentType:     "image/jpeg",
 				ContentEncoding: "identity",
+				ContentLength:   17,
 				Path:            filepath.Join(taskContext.TaskDir, "SampleArtifacts", "b", "c", "d.jpg"),
 			},
 		})
@@ -297,6 +306,7 @@ func TestDirectoryArtifactWithNames(t *testing.T) {
 				},
 				ContentType:     "text/plain; charset=utf-8",
 				ContentEncoding: "gzip",
+				ContentLength:   14,
 				Path:            filepath.Join(taskContext.TaskDir, "SampleArtifacts", "_", "X.txt"),
 			},
 			&artifacts.S3Artifact{
@@ -306,6 +316,7 @@ func TestDirectoryArtifactWithNames(t *testing.T) {
 				},
 				ContentType:     "image/jpeg",
 				ContentEncoding: "identity",
+				ContentLength:   17,
 				Path:            filepath.Join(taskContext.TaskDir, "SampleArtifacts", "b", "c", "d.jpg"),
 			},
 		})
@@ -345,6 +356,7 @@ func TestDirectoryArtifactWithContentType(t *testing.T) {
 				},
 				ContentType:     "text/plain; charset=utf-8",
 				ContentEncoding: "gzip",
+				ContentLength:   14,
 				Path:            filepath.Join(taskContext.TaskDir, "SampleArtifacts", "_", "X.txt"),
 			},
 			&artifacts.S3Artifact{
@@ -354,6 +366,7 @@ func TestDirectoryArtifactWithContentType(t *testing.T) {
 				},
 				ContentType:     "text/plain; charset=utf-8",
 				ContentEncoding: "identity",
+				ContentLength:   17,
 				Path:            filepath.Join(taskContext.TaskDir, "SampleArtifacts", "b", "c", "d.jpg"),
 			},
 		})
@@ -411,6 +424,7 @@ func TestDirectoryArtifactWithContentEncoding(t *testing.T) {
 				},
 				ContentType:     "text/plain; charset=utf-8",
 				ContentEncoding: "gzip",
+				ContentLength:   14,
 				Path:            filepath.Join(taskContext.TaskDir, "SampleArtifacts", "_", "X.txt"),
 			},
 			&artifacts.S3Artifact{
@@ -420,6 +434,7 @@ func TestDirectoryArtifactWithContentEncoding(t *testing.T) {
 				},
 				ContentType:     "text/plain; charset=utf-8",
 				ContentEncoding: "identity",
+				ContentLength:   14,
 				Path:            filepath.Join(taskContext.TaskDir, "SampleArtifacts", "_", "X.txt"),
 			},
 			&artifacts.S3Artifact{
@@ -429,6 +444,7 @@ func TestDirectoryArtifactWithContentEncoding(t *testing.T) {
 				},
 				ContentType:     "text/plain; charset=utf-8",
 				ContentEncoding: "gzip",
+				ContentLength:   17,
 				Path:            filepath.Join(taskContext.TaskDir, "SampleArtifacts", "b", "c", "d.jpg"),
 			},
 			&artifacts.S3Artifact{
@@ -438,6 +454,7 @@ func TestDirectoryArtifactWithContentEncoding(t *testing.T) {
 				},
 				ContentType:     "text/plain; charset=utf-8",
 				ContentEncoding: "identity",
+				ContentLength:   17,
 				Path:            filepath.Join(taskContext.TaskDir, "SampleArtifacts", "b", "c", "d.jpg"),
 			},
 		})
@@ -477,6 +494,7 @@ func TestDirectoryArtifacts(t *testing.T) {
 				},
 				ContentType:     "text/plain; charset=utf-8",
 				ContentEncoding: "gzip",
+				ContentLength:   14,
 				Path:            filepath.Join(taskContext.TaskDir, "SampleArtifacts", "_", "X.txt"),
 			},
 			&artifacts.S3Artifact{
@@ -486,6 +504,7 @@ func TestDirectoryArtifacts(t *testing.T) {
 				},
 				ContentType:     "image/jpeg",
 				ContentEncoding: "identity",
+				ContentLength:   17,
 				Path:            filepath.Join(taskContext.TaskDir, "SampleArtifacts", "b", "c", "d.jpg"),
 			},
 		})
@@ -593,6 +612,7 @@ func TestDefaultArtifactExpiry(t *testing.T) {
 				},
 				ContentType:     "image/jpeg",
 				ContentEncoding: "identity",
+				ContentLength:   17,
 				Path:            filepath.Join(taskContext.TaskDir, "SampleArtifacts", "b", "c", "d.jpg"),
 			},
 		},
@@ -877,27 +897,27 @@ func TestPublicDirectoryArtifact(t *testing.T) {
 
 	taskID := submitAndAssert(t, td, payload, "completed", "completed")
 
-	queue := serviceFactory.Queue(nil, config.RootURL)
-	artifacts, err := queue.ListArtifacts(taskID, "0", "", "")
-
-	if err != nil {
-		t.Fatalf("Error listing artifacts: %v", err)
+	expectedArtifacts := ExpectedArtifacts{
+		"public/build/X.txt": {
+			ContentType:     "text/plain; charset=utf-8",
+			ContentEncoding: "gzip",
+			ContentLength:   14,
+			Expires:         expires,
+		},
+		"public/logs/live_backing.log": {
+			ContentType:      "text/plain; charset=utf-8",
+			ContentEncoding:  "gzip",
+			Expires:          td.Expires,
+			SkipContentCheck: true,
+		},
+		"public/logs/live.log": {
+			ContentType:      "text/plain; charset=utf-8",
+			ContentEncoding:  "gzip",
+			Expires:          td.Expires,
+			SkipContentCheck: true,
+		},
 	}
-
-	if l := len(artifacts.Artifacts); l != 3 {
-		t.Fatalf("Was expecting 3 artifacts, but got %v: %#v", l, artifacts)
-	}
-
-	// use the artifact names as keys in a map, so we can look up that each key exists
-	a := map[string]bool{
-		artifacts.Artifacts[0].Name: true,
-		artifacts.Artifacts[1].Name: true,
-		artifacts.Artifacts[2].Name: true,
-	}
-
-	if !a["public/build/X.txt"] || !a["public/logs/live.log"] || !a["public/logs/live_backing.log"] {
-		t.Fatalf("Wrong artifacts presented in task %v: %#v", taskID, a)
-	}
+	expectedArtifacts.Validate(t, taskID, 0)
 }
 
 func TestConflictingFileArtifactsInPayload(t *testing.T) {

--- a/workers/generic-worker/helper_test.go
+++ b/workers/generic-worker/helper_test.go
@@ -336,6 +336,7 @@ type (
 		Extracts         []string
 		ContentType      string
 		ContentEncoding  string
+		ContentLength    int64
 		Expires          tcclient.Time
 		SkipContentCheck bool
 		StorageType      string
@@ -559,6 +560,11 @@ func (expectedArtifacts ExpectedArtifacts) Validate(t *testing.T, taskID string,
 		if expected.StorageType != "" {
 			if actual.StorageType != expected.StorageType {
 				t.Errorf("Artifact %s should have storage type '%v' but has '%s'", artifactName, expected.StorageType, actual.StorageType)
+			}
+		}
+		if expected.ContentLength != 0 {
+			if actual.ContentLength != expected.ContentLength {
+				t.Errorf("Artifact %s should have contentLength %d but has %d", artifactName, expected.ContentLength, actual.ContentLength)
 			}
 		}
 		if !time.Time(expected.Expires).IsZero() {

--- a/workers/generic-worker/rdp_feature_windows.go
+++ b/workers/generic-worker/rdp_feature_windows.go
@@ -93,6 +93,7 @@ func (l *RDPTask) createRDPArtifact() {
 }
 
 func (l *RDPTask) uploadRDPArtifact() *CommandExecutionError {
+	rdpInfoFile := filepath.Join(taskContext.TaskDir, rdpInfoPath)
 	return l.task.uploadArtifact(
 		createDataArtifact(
 			&artifacts.BaseArtifact{
@@ -100,8 +101,8 @@ func (l *RDPTask) uploadRDPArtifact() *CommandExecutionError {
 				// RDP info expires one day after task
 				Expires: tcclient.Time(time.Now().Add(time.Hour * 24)),
 			},
-			filepath.Join(taskContext.TaskDir, rdpInfoPath),
-			filepath.Join(taskContext.TaskDir, rdpInfoPath),
+			rdpInfoFile,
+			rdpInfoFile,
 			"application/json",
 			"gzip",
 		),


### PR DESCRIPTION
Generic-worker will send contentLength of the original artifact before compression to the queue.createArtifact

This will be a breaking change for worker deployers, since it depends on the schema validation in services, ath needs to be deployed before this.

Second part of #8101


