### PR TITLE
fix(worker-manager): add missing worker scope for `ShouldWorkerTerminate`

### DIFF
--- a/changelog/issue-8339.md
+++ b/changelog/issue-8339.md
@@ -1,0 +1,5 @@
+audience: worker-deployers
+level: patch
+reference: issue 8339
+---
+Worker Manager: provides `worker-manager:should-worker-terminate:<workerPoolId>/<workerGroup>/<workerId>` scope to worker during (re)registration so the worker can properly call out to the `ShouldWorkerTerminate` API.

--- a/services/worker-manager/src/util.js
+++ b/services/worker-manager/src/util.js
@@ -43,6 +43,7 @@ export const createCredentials = (worker, expires, cfg) => {
       `queue:claim-work:${worker.workerPoolId}`,
       `worker-manager:remove-worker:${worker.workerPoolId}/${worker.workerGroup}/${worker.workerId}`,
       `worker-manager:reregister-worker:${worker.workerPoolId}/${worker.workerGroup}/${worker.workerId}`,
+      `worker-manager:should-worker-terminate:${worker.workerPoolId}/${worker.workerGroup}/${worker.workerId}`,
     ],
     start: taskcluster.fromNow('-15 minutes'),
     expiry: expires,


### PR DESCRIPTION
Fixes #8339.

>Worker Manager: provides `worker-manager:should-worker-terminate:<workerPoolId>/<workerGroup>/<workerId>` scope to worker during (re)registration so the worker can properly call out to the `ShouldWorkerTerminate` API.