### PR TITLE
feat(web-server): Return empty profile instead of error

### DIFF
--- a/changelog/issue-8300.md
+++ b/changelog/issue-8300.md
@@ -1,0 +1,5 @@
+audience: users
+level: patch
+reference: issue 8300
+---
+Task log profiler returns empty profile when log doesn't have correct time markers instead of throwing an error.

--- a/services/web-server/src/profiler/log-profile.js
+++ b/services/web-server/src/profiler/log-profile.js
@@ -127,15 +127,14 @@ export class StreamingProfileBuilder {
   }
 
   finalize() {
-    if (this.profileStartTime === null) {
-      throw new Error('Could not find a time in the log rows');
+    if (this.profileStartTime !== null) {
+      const lastTime = this.lastTime || this.profileStartTime;
+      this.profile.meta.startTime = this.profileStartTime;
+
+      // Patch the task duration marker (slot 0)
+      this.markers.endTime[0] = lastTime - this.profileStartTime;
     }
 
-    const lastTime = this.lastTime || this.profileStartTime;
-    this.profile.meta.startTime = this.profileStartTime;
-
-    // Patch the task duration marker (slot 0)
-    this.markers.endTime[0] = lastTime - this.profileStartTime;
     this.markers.data[0] = {
       type: 'Task',
       name: 'Task',

--- a/services/web-server/test/profiler/log-profile_test.js
+++ b/services/web-server/test/profiler/log-profile_test.js
@@ -157,10 +157,11 @@ suite('profiler/log-profile', function() {
       assert.equal(cats[profile.threads[0].markers.category[2]].name, 'fetches');
     });
 
-    test('throws if no timestamps found', function() {
+    test('returns empty if no timestamps found', function() {
       const builder = new StreamingProfileBuilder(mockTask, 'task-123', 'https://tc.example.com');
       builder.addLine('no timestamps here');
-      assert.throws(() => builder.finalize(), /Could not find a time/);
+      const profile = builder.finalize();
+      assert.ok(profile.threads[0].markers.data.length === 1);
     });
 
     test('includes task duration marker with URLs', function() {


### PR DESCRIPTION
This was throwing 500 and firefox profiler would be not showing anything if logs contain no timestempas (or it was in a format that was not expected)

Related to the #8303 

Fixes:

```
Error
Could not find a time in the log rows
Error: Could not find a time in the log rows at StreamingProfileBuilder.finalize (file:///app/services/web-server/src/profiler/log-profile.js:131:13) at Proxy.<anonymous> (file:///app/services/web-server/src/api.js:163:34) at process.processTicksAndRejections (node:internal/process/task_queues:103:5)
```