### PR TITLE
feat(dev): Use multi-arch tc-admin version

### DIFF
--- a/changelog/issue-8341.md
+++ b/changelog/issue-8341.md
@@ -1,0 +1,6 @@
+audience: users
+level: patch
+reference: issue 8341
+---
+
+Fixes issues with local dev env where tc-admin image was built for single architecture. tc-admin:5.2.0 publishes multi-arch image

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -136,7 +136,7 @@ services:
     ports:
       - '80:80'
   tc_admin_init:
-    image: taskcluster/tc-admin:5.1.1
+    image: taskcluster/tc-admin:5.2.0
     networks:
       - local
     volumes:

--- a/infrastructure/tooling/src/generate/generators/docker-compose.js
+++ b/infrastructure/tooling/src/generate/generators/docker-compose.js
@@ -381,7 +381,7 @@ tasks.push({
           healthcheck: healthcheck('curl -I http://localhost/'),
         }),
         tc_admin_init: serviceDefinition('tc_admin_init', {
-          image: 'taskcluster/tc-admin:5.1.1',
+          image: 'taskcluster/tc-admin:5.2.0',
           volumes: ['./docker/tc-admin:/app'],
           working_dir: '/app',
           'x-info': 'This script provisions taskcluster configuration. See docker/tc-admin for details',


### PR DESCRIPTION
Previously it was built for a single architecture and would have caused issues.

Fixes #8341


https://github.com/taskcluster/tc-admin/releases/tag/v5.2.0