### PR TITLE
feat(ui): Close auth window on 3rd-party login flow

### DIFF
--- a/changelog/issue-8357.md
+++ b/changelog/issue-8357.md
@@ -1,0 +1,6 @@
+audience: users
+level: patch
+reference: issue 8357
+---
+
+Fix third-party login flow with extra window not being closed.

--- a/ui/src/App/Main.jsx
+++ b/ui/src/App/Main.jsx
@@ -11,6 +11,7 @@ import { route } from '../utils/prop-types';
 import { withAuth } from '../utils/Auth';
 import isThirdPartyLogin from '../utils/isThirdPartyLogin';
 import isLoggedInQuery from './isLoggedIn.graphql';
+import { AUTH_STARTED } from '../utils/constants';
 
 @withApollo
 @withStyles(theme => ({
@@ -91,6 +92,7 @@ export default class Main extends Component {
       !sessionStorage.getItem(THIRD_PARTY_DID_AUTO_LOGIN_KEY)
     ) {
       sessionStorage.setItem(THIRD_PARTY_DID_AUTO_LOGIN_KEY, 'true');
+      localStorage.setItem(AUTH_STARTED, window.env.UI_LOGIN_STRATEGY_NAMES);
       window.open(`/login/${window.env.UI_LOGIN_STRATEGY_NAMES}`);
 
       return;

--- a/ui/src/utils/constants.js
+++ b/ui/src/utils/constants.js
@@ -205,9 +205,6 @@ export const DENYLIST_NOTIFICATION_TYPES = {
 export const KNOWN_ACRONYMS = ['IRC', 'API'];
 export const AUTH_STORE = '@@TASKCLUSTER_WEB_AUTH';
 export const AUTH_STARTED = '@@TASKCLUSTER_AUTH_STARTED';
-// The delay (in milliseconds) for `setTimeout` is a 32 bit signed quantity,
-// which limits it to 2^31-1 ms (2147483647 ms) or 24.855 days.
-export const MAX_SET_TIMEOUT_DELAY = 2 ** 31 - 1;
 export const GROUP_NOTIFY_TASK_FAILED_KEY = 'group-notify-task-failed';
 export const GROUP_NOTIFY_SUCCESS_KEY = 'group-notify-success';
 


### PR DESCRIPTION
Extra window that was opened on 3rd party login was not closing, leaving extra taskcluster homepage

Fixes: #8357
