### PR TITLE
Log SIGINT signal on graceful shutdown in generic-worker

### DIFF
--- a/changelog/issue-7901.md
+++ b/changelog/issue-7901.md
@@ -1,0 +1,7 @@
+audience: worker-deployers
+level: silent
+reference: issue 7901
+---
+The generic-worker now logs a message when it receives SIGINT (Ctrl+C), making it
+clear that the signal was received and the worker is exiting. Previously, no message was logged,
+leaving users unsure whether the signal had been received.

--- a/workers/generic-worker/main.go
+++ b/workers/generic-worker/main.go
@@ -580,6 +580,7 @@ func RunWorker() (exitCode ExitCode) {
 		select {
 		case <-wait5Seconds.C:
 		case <-sigInterrupt:
+			log.Println("Received SIGINT, worker is exiting")
 			return WORKER_STOPPED
 		}
 	}


### PR DESCRIPTION
## Summary

Fixes #7901.

When the generic-worker receives `SIGINT` (Ctrl+C), it now logs a message indicating
graceful shutdown has been initiated. Previously, no message was logged, which left
users unsure whether the signal had been caught — especially confusing when shutdown
takes several seconds.

This mirrors the existing behavior for `SIGTERM`, which already logs:
> "Received SIGTERM, initiating graceful termination"

## Changes
- `workers/generic-worker/main.go` — add log message in SIGINT handler (1 line)
- `changelog/issue-7901.md` — add changelog entry

## Test Plan
- Build generic-worker and verify `SIGINT` (Ctrl+C) now prints the log message
- Existing tests pass: `cd workers/generic-worker && go test ./...`