### PR TITLE
Prevent log viewer from scrolling to bottom on window resize

### DIFF
--- a/changelog/issue-8170.md
+++ b/changelog/issue-8170.md
@@ -1,0 +1,8 @@
+audience: users
+level: patch
+reference: issue 8170
+---
+The log viewer no longer scrolls to the bottom of the log when the browser window
+is resized. Previously, resizing the window (for example, when using a tiling
+window manager) would cause the log to snap to the bottom, losing the user's
+scroll position.

--- a/ui/src/components/Log/index.jsx
+++ b/ui/src/components/Log/index.jsx
@@ -236,7 +236,7 @@ export default class Log extends Component {
 
   handleScroll = ({ scrollTop, scrollHeight, clientHeight }) => {
     if (
-      this.state.follow &&
+      this.state.follow !== false &&
       scrollHeight - scrollTop !== clientHeight &&
       // LazyLog triggers `handleScroll` on initial load.
       // This will make sure it doesn't set follow to false on log load.


### PR DESCRIPTION
## Summary

Fixes #8170.

When a user scrolled up in the log viewer to inspect earlier output and then resized
the browser window, the viewer snapped back to the bottom — losing their position.

The root cause: `handleScroll` only set `follow: false` when `this.state.follow` was
truthy. Since the initial state is `null` (not `true`), scrolling up from the default
position left `follow` as `null`. On window resize, `AutoSizer` (react-virtualized)
triggers a re-render; `shouldStartFollowing()` sees `follow === null` and defaults
to `true`, causing the snap-to-bottom.

**Fix:** Change the guard from `this.state.follow &&` to `this.state.follow !== false &&`
so that when a user scrolls up from the initial position, `follow` is set to `false`
(not left as `null`), disabling the auto-scroll-to-bottom behaviour on subsequent
resize events.

## Changes
- `ui/src/components/Log/index.jsx` — 1-character change in `handleScroll`
- `changelog/issue-8170.md` — add changelog entry

## Test Plan
- [ ] Open a task with a long log
- [ ] Scroll up to a position in the middle
- [ ] Resize the browser window — scroll position should be preserved
- [ ] On a live/running log with `follow=true`, new output should still scroll to bottom
- [ ] Run existing UI tests: `cd ui && yarn test`