### PR TITLE
fix(client-shell): panic on task status/artifacts when task has no runs

### DIFF
--- a/changelog/fix-task-status-no-runs.md
+++ b/changelog/fix-task-status-no-runs.md
@@ -1,0 +1,4 @@
+level: patch
+audience: users
+---
+Fix a panic in `taskcluster task status` and `taskcluster task artifacts` when the task has no runs (e.g., is in the `unscheduled` state). These commands now return a clear error message instead of crashing.

--- a/clients/client-shell/cmds/task/fetchers.go
+++ b/clients/client-shell/cmds/task/fetchers.go
@@ -45,11 +45,14 @@ func runStatus(credentials *tcclient.Credentials, args []string, out io.Writer, 
 		return nil
 	}
 
-	if runID >= len(s.Status.Runs) {
-		return fmt.Errorf("there is no run #%v", runID)
-	}
 	if runID == -1 {
 		runID = len(s.Status.Runs) - 1
+	}
+	if runID < 0 {
+		return fmt.Errorf("task has no runs")
+	}
+	if runID >= len(s.Status.Runs) {
+		return fmt.Errorf("there is no run #%v", runID)
 	}
 
 	fmt.Fprintln(out, getRunStatusString(s.Status.Runs[runID].State, s.Status.Runs[runID].ReasonResolved))
@@ -169,11 +172,14 @@ func runArtifacts(credentials *tcclient.Credentials, args []string, out io.Write
 	}
 
 	runID, _ := flagSet.GetInt("run")
-	if runID >= len(s.Status.Runs) {
-		return fmt.Errorf("there is no run #%v", runID)
-	}
 	if runID == -1 {
 		runID = len(s.Status.Runs) - 1
+	}
+	if runID < 0 {
+		return fmt.Errorf("task has no runs")
+	}
+	if runID >= len(s.Status.Runs) {
+		return fmt.Errorf("there is no run #%v", runID)
 	}
 
 	buf := bytes.NewBufferString("")

--- a/clients/client-shell/cmds/task/fetchers_test.go
+++ b/clients/client-shell/cmds/task/fetchers_test.go
@@ -194,6 +194,63 @@ func (suite *FakeServerSuite) TestGroupCommand() {
 	suite.Equal("my-test\n", buf.String())
 }
 
+type EmptyRunsSuite struct {
+	suite.Suite
+	testServer *httptest.Server
+}
+
+func (suite *EmptyRunsSuite) SetupSuite() {
+	handler := http.NewServeMux()
+	handler.HandleFunc("/api/queue/v1/task/"+fakeTaskID+"/status", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, `{"status": {"state": "unscheduled", "runs": []}}`)
+	})
+	suite.testServer = httptest.NewServer(handler)
+	config.SetRootURL(suite.testServer.URL)
+}
+
+func (suite *EmptyRunsSuite) TearDownSuite() {
+	suite.testServer.Close()
+	config.SetRootURL("")
+}
+
+func TestEmptyRunsSuite(t *testing.T) {
+	suite.Run(t, new(EmptyRunsSuite))
+}
+
+func (suite *EmptyRunsSuite) TestStatusEmptyRuns() {
+	_, cmd := setUpCommand()
+	cmd.Flags().IntP("run", "r", -1, "Specifies which run to consider.")
+	cmd.Flags().BoolP("all-runs", "a", false, "Check all runs of the task.")
+
+	err := runStatus(&tcclient.Credentials{}, []string{fakeTaskID}, cmd.OutOrStdout(), cmd.Flags())
+	suite.EqualError(err, "task has no runs")
+}
+
+func (suite *EmptyRunsSuite) TestArtifactsEmptyRuns() {
+	_, cmd := setUpCommand()
+	cmd.Flags().IntP("run", "r", -1, "Specifies which run to consider.")
+
+	err := runArtifacts(&tcclient.Credentials{}, []string{fakeTaskID}, cmd.OutOrStdout(), cmd.Flags())
+	suite.EqualError(err, "task has no runs")
+}
+
+func (suite *FakeServerSuite) TestStatusOutOfRangeRun() {
+	_, cmd := setUpCommand()
+	cmd.Flags().IntP("run", "r", 1, "Specifies which run to consider.")
+	cmd.Flags().BoolP("all-runs", "a", false, "Check all runs of the task.")
+
+	err := runStatus(&tcclient.Credentials{}, []string{fakeTaskID}, cmd.OutOrStdout(), cmd.Flags())
+	suite.EqualError(err, "there is no run #1")
+}
+
+func (suite *FakeServerSuite) TestArtifactsOutOfRangeRun() {
+	_, cmd := setUpCommand()
+	cmd.Flags().IntP("run", "r", 1, "Specifies which run to consider.")
+
+	err := runArtifacts(&tcclient.Credentials{}, []string{fakeTaskID}, cmd.OutOrStdout(), cmd.Flags())
+	suite.EqualError(err, "there is no run #1")
+}
+
 func (suite *FakeServerSuite) TestStatusCommand() {
 	// set up to run a command and capture output
 	buf, cmd := setUpCommand()


### PR DESCRIPTION
`taskcluster task status` and `taskcluster task artifacts` panic with `index out of range [-1]` when the task has no runs (e.g. when in `unscheduled` state). `-1` is the default run ID which usually returns the last run (when there's at least one).

This PR moves `len(runs)-1` after the bounds check, then guard with `runID < 0 || runID >= len(runs)` to return a clear error instead of crashing. 

## Steps to reproduce

```
TASKCLUSTER_ROOT_URL=https://stage.taskcluster.nonprod.webservices.mozgcp.net taskcluster task status SYsSg4zsQOai5hLDN6HrdQ
panic: runtime error: index out of range [-1]

goroutine 1 [running]:
github.com/taskcluster/taskcluster/v97/clients/client-shell/cmds/task.runStatus(0x0, {0x7269b4d5ec20, 0x1, 0x0?}, {0x104d39e18, 0x7269b4ad4040}, 0x7269b4d67700)
	/home/task_177315401789203/taskcluster/clients/client-shell/cmds/task/fetchers.go:55 +0x3c4
github.com/taskcluster/taskcluster/v97/clients/client-shell/cmds/task.init.executeHelperE.func1(0x104dc01a0, {0x7269b4d5ec20, 0x1, 0x1})
	/home/task_177315401789203/taskcluster/clients/client-shell/cmds/task/utils.go:35 +0xec
github.com/spf13/cobra.(*Command).execute(0x104dc01a0, {0x7269b4d5ebe0, 0x1, 0x1})
	/home/task_177315401789203/go/path/pkg/mod/github.com/spf13/cobra@v1.10.2/command.go:1015 +0x814
github.com/spf13/cobra.(*Command).ExecuteC(0x7269b4c58008)
	/home/task_177315401789203/go/path/pkg/mod/github.com/spf13/cobra@v1.10.2/command.go:1148 +0x350
github.com/spf13/cobra.(*Command).Execute(0x104d65868?)
	/home/task_177315401789203/go/path/pkg/mod/github.com/spf13/cobra@v1.10.2/command.go:1071 +0x1c
main.main()
	/home/task_177315401789203/taskcluster/clients/client-shell/main.go:15 +0x28
```

## Additional context

I stumbled upon this bug by trying to get Claude to autonomously monitor task statuses. It ended up being too fast when a task doesn't start immediately because it has some unresolved upstream tasks.