### PR TITLE
fix(github): stream backing log in extractLog to prevent OOM on large artifacts

### DIFF
--- a/changelog/issue-8388.md
+++ b/changelog/issue-8388.md
@@ -1,0 +1,5 @@
+audience: deployers
+level: patch
+reference: issue 8388
+---
+The GitHub service now streams backing log artifacts instead of downloading them entirely into memory. Previously, tasks with very large logs (e.g. ~98MB) caused the status handler to crash with an out-of-memory error, leaving GitHub check runs stuck as `in_progress` indefinitely.

--- a/services/github/src/handlers/status.js
+++ b/services/github/src/handlers/status.js
@@ -11,7 +11,8 @@ import {
 } from '../constants.js';
 
 import QueueLock from '../queue-lock.js';
-import { markdownLog, markdownAnchor, extractLog } from '../utils.js';
+import utils from '../utils.js';
+const { markdownLog, markdownAnchor } = utils;
 import { requestArtifact } from './requestArtifact.js';
 import { taskUI, makeDebug, taskLogUI, GithubCheck, getTimeDifference, taskGroupUI, buildUrl, buildLogUrl } from './utils.js';
 
@@ -132,8 +133,7 @@ export async function statusHandler(message) {
     const textArtifactName = extraCheckRun?.textArtifactName || CUSTOM_CHECKRUN_TEXT_ARTIFACT_NAME;
     const annotationsArtifactName = extraCheckRun?.annotationsArtifactName || CUSTOM_CHECKRUN_ANNOTATIONS_ARTIFACT_NAME;
 
-    const [ liveLogText, customCheckRunText, customCheckRunAnnotationsText ] = await Promise.all([
-      fetchArtifact(LIVE_BACKING_LOG_ARTIFACT_NAME),
+    const [ customCheckRunText, customCheckRunAnnotationsText ] = await Promise.all([
       fetchArtifact(textArtifactName),
       fetchArtifact(annotationsArtifactName),
     ]);
@@ -246,8 +246,28 @@ export async function statusHandler(message) {
     if (customCheckRunText) {
       output.addText(customCheckRunText);
     }
-    if (liveLogText) {
-      output.addText(markdownLog(extractLog(liveLogText, 20, 200, githubCheck.output.getRemainingMaxSize())));
+    if (!taskDefined && runId !== undefined) {
+      try {
+        const limitedQueueClient = this.queueClient.use({
+          authorizedScopes: taskDefinition.scopes,
+        });
+        const url = limitedQueueClient.buildSignedUrl(
+          limitedQueueClient.getArtifact, taskId, runId, LIVE_BACKING_LOG_ARTIFACT_NAME,
+        );
+        const response = await fetch(url, { redirect: 'follow' });
+        if (response.ok) {
+          const logText = await utils.extractLog(
+            response.body, 20, 200, githubCheck.output.getRemainingMaxSize(),
+          );
+          if (logText) {
+            output.addText(markdownLog(logText));
+          }
+        } else {
+          await response.body?.cancel();
+        }
+      } catch (e) {
+        await this.monitor.reportError(e);
+      }
     }
 
     let [checkRun] = await this.context.db.fns.get_github_check_by_task_group_and_task_id(taskGroupId, taskId);

--- a/services/github/src/utils.js
+++ b/services/github/src/utils.js
@@ -160,95 +160,102 @@ export const ansi2txt = (src) => {
 };
 
 /**
- * Github checks API call is limited to 64kb
- * @param {string} log
- * @param {number} maxLines
- * @param {number} maxPayloadLength
- * @returns string
- */
-export const tailLog = (log, maxLines = 250, maxPayloadLength = 30000) => {
-  return ansi2txt(log).substring(log.length - maxPayloadLength)
-    .split('\n')
-    .slice(-maxLines)
-    .join('\n');
-};
-
-/**
+ * Github checks API call is limited to 64kb.
  *
- * @param {string} logString
- * @param {number} maxPayloadLength
- * @param {number} tailLines
- * @returns string or null
- */
-export const extractTailLinesFromLog = (logString, maxPayloadLength, tailLines) => {
-
-  if (tailLines === 0) {
-    return null;
-  }
-
-  const tailLog = logString.split("\n").slice(-tailLines).join("\n");
-
-  if (logString.length <= maxPayloadLength) {
-    return tailLog;
-  }
-
-  let tailLogMaxPayload = logString.slice(-maxPayloadLength);
-  const newLinePosition = tailLogMaxPayload.indexOf('\n');
-  tailLogMaxPayload = tailLogMaxPayload.slice(newLinePosition + 1);
-
-  return tailLog.length <= tailLogMaxPayload.length ? tailLog : tailLogMaxPayload;
-};
-
-/**
+ * Streams a log from an async iterable (e.g. a fetch response body),
+ * extracting the first headLines and last tailLines with bounded memory.
+ * Uses a head buffer and a tail buffer that evicts old entries, so memory
+ * usage is O(headLines + tailLines) regardless of log size.
  *
- * @param {string} logString
- * @param {number} maxPayloadLength
- * @returns string
+ * @param {AsyncIterable} stream - async iterable yielding byte chunks
+ * @param {number} headLines - number of lines to keep from the start
+ * @param {number} tailLines - number of lines to keep from the end
+ * @param {number} maxPayloadLength - maximum output length in bytes
+ * @returns {Promise<string>} formatted log extract
  */
-export const extractHeadLinesFromLog = (logString, maxPayloadLength) => {
-
-  if (logString.length <= maxPayloadLength) {
-    return logString;
-  }
-
-  const headLog = logString.slice(0, maxPayloadLength);
-  const lastNewLinePosition = headLog.lastIndexOf('\n');
-  return headLog.substring(0, lastNewLinePosition);
-};
-
-/**
- * Github checks API call is limited to 64kb
- * @param {string} log
- * @param {number} headLines
- * @param {number} tailLines
- * @param {number} maxPayloadLength
- * @returns string
- */
-export const extractLog = (log, headLines = 20, tailLines = 200, maxPayloadLength = 30000) => {
-  const logString = ansi2txt(log);
-  const lines = logString.split('\n');
+export const extractLog = async (stream, headLines = 20, tailLines = 200, maxPayloadLength = 30000) => {
   const LOG_BUFFER = 42;
+  const decoder = new TextDecoder('utf-8', { stream: true });
+  const head = [];
+  const tail = [];
+  let totalLines = 0;
+  let headFull = false;
+  let leftover = '';
 
-  if (lines.length <= headLines + tailLines && logString.length <= maxPayloadLength) {
-    return logString;
+  for await (const chunk of stream) {
+    const text = leftover + decoder.decode(chunk, { stream: true });
+    const lines = text.split('\n');
+    leftover = lines.pop();
+
+    for (const line of lines) {
+      const clean = ansi2txt(line);
+      totalLines++;
+      if (!headFull) {
+        head.push(clean);
+        if (head.length >= headLines) {
+          headFull = true;
+        }
+      } else {
+        tail.push(clean);
+        if (tail.length > tailLines) {
+          tail.shift();
+        }
+      }
+    }
   }
 
-  const headLogArray = lines.slice(0, headLines);
-  const headLog = headLogArray.join('\n');
+  // Flush any remaining bytes from the decoder
+  const finalText = leftover + decoder.decode();
+  if (finalText) {
+    const clean = ansi2txt(finalText);
+    totalLines++;
+    if (!headFull) {
+      head.push(clean);
+    } else {
+      tail.push(clean);
+      if (tail.length > tailLines) {
+        tail.shift();
+      }
+    }
+  }
 
+  const headLog = head.join('\n');
+  const tailLog = tail.join('\n');
+  const fullLog = tailLog ? headLog + '\n' + tailLog : headLog;
+
+  // Small log: return full content if it fits
+  if (totalLines <= headLines + tailLines && fullLog.length <= maxPayloadLength) {
+    return fullLog;
+  }
+
+  // If head alone exceeds the payload budget, truncate at a line boundary
   if (maxPayloadLength <= headLog.length) {
-    return extractHeadLinesFromLog(logString, maxPayloadLength);
+    const truncated = headLog.slice(0, maxPayloadLength);
+    const lastNewLine = truncated.lastIndexOf('\n');
+    return lastNewLine > 0 ? truncated.substring(0, lastNewLine) : truncated;
   }
 
-  const tailLog = extractTailLinesFromLog(logString, maxPayloadLength - headLog.length - LOG_BUFFER, tailLines);
+  // Budget remaining for the tail after head + separator
+  const tailBudget = maxPayloadLength - headLog.length - LOG_BUFFER;
 
-  if (!tailLog) {
-    return `${headLog}\n\n...(${lines.length - headLogArray.length} lines hidden)...\n\n`;
+  if (tailBudget <= 0 || !tailLog) {
+    return `${headLog}\n\n...(${totalLines - head.length} lines hidden)...\n\n`;
   }
 
-  const availableTailLines = tailLog.split('\n').length;
+  // Trim tail to fit the byte budget
+  let finalTail = tailLog;
+  if (finalTail.length > tailBudget) {
+    finalTail = finalTail.slice(-tailBudget);
+    const newLinePos = finalTail.indexOf('\n');
+    if (newLinePos >= 0) {
+      finalTail = finalTail.slice(newLinePos + 1);
+    }
+  }
 
-  return `${headLog}\n\n...(${lines.length - headLines - availableTailLines} lines hidden)...\n\n${tailLog}`;
+  const availableTailLines = finalTail.split('\n').length;
+  const finalHiddenLines = totalLines - head.length - availableTailLines;
+
+  return `${headLog}\n\n...(${finalHiddenLines} lines hidden)...\n\n${finalTail}`;
 };
 
 export const markdownLog = (log) => ['\n---\n\n```bash\n', log, '\n```'].join('');
@@ -295,7 +302,6 @@ export default {
   shouldSkipCommit,
   shouldSkipPullRequest,
   ansi2txt,
-  tailLog,
   extractLog,
   markdownLog,
   markdownAnchor,

--- a/services/github/test/handler_test.js
+++ b/services/github/test/handler_test.js
@@ -1440,6 +1440,8 @@ helper.secrets.mockSuite(testing.suiteName(), [], function (mock, skipping) {
 
     const TASKGROUPID = 'AXB-sjV-SoCyibyq3P32o2';
     setup(function () {
+      sinon.stub(global, "fetch").resolves({ ok: false, body: { cancel: async () => {} } });
+      sinon.stub(utils, "extractLog").resolves('');
       sinon.stub(utils, "throttleRequest").returns({ status: 404, response: { error: { text: "Resource not found" } } });
     });
 
@@ -1604,12 +1606,12 @@ helper.secrets.mockSuite(testing.suiteName(), [], function (mock, skipping) {
       await addBuild({ state: 'pending', taskGroupId: TASKGROUPID });
       await addCheckRun({ taskGroupId: TASKGROUPID, taskId: CUSTOM_CHECKRUN_TASKID });
       sinon.restore();
+      sinon.stub(global, "fetch").resolves({ ok: true, body: { cancel: async () => {} } });
+      sinon.stub(utils, "extractLog").resolves('');
       sinon.stub(utils, "throttleRequest")
         .onFirstCall()
-        .returns({ status: 404 })
-        .onSecondCall()
         .returns({ status: 200, text: CUSTOM_CHECKRUN_TEXT })
-        .onThirdCall()
+        .onSecondCall()
         .returns({ status: 404 });
       await simulateExchangeMessage({
         taskGroupId: TASKGROUPID,
@@ -1637,13 +1639,9 @@ helper.secrets.mockSuite(testing.suiteName(), [], function (mock, skipping) {
       await addBuild({ state: 'pending', taskGroupId: TASKGROUPID });
       await addCheckRun({ taskGroupId: TASKGROUPID, taskId: CUSTOM_CHECKRUN_TASKID });
       sinon.restore();
-      sinon.stub(utils, "throttleRequest")
-        .onFirstCall()
-        .returns({ status: 200, text: LIVE_LOG_TEXT })
-        .onSecondCall()
-        .returns({ status: 404 })
-        .onThirdCall()
-        .returns({ status: 404 });
+      sinon.stub(global, "fetch").resolves({ ok: true, body: { cancel: async () => {} } });
+      sinon.stub(utils, "extractLog").resolves(LIVE_LOG_TEXT);
+      sinon.stub(utils, "throttleRequest").returns({ status: 404 });
       await simulateExchangeMessage({
         taskGroupId: TASKGROUPID,
         exchange: 'exchange/taskcluster-queue/v1/task-completed',
@@ -1670,13 +1668,9 @@ helper.secrets.mockSuite(testing.suiteName(), [], function (mock, skipping) {
       await addBuild({ state: 'pending', taskGroupId: TASKGROUPID });
       await addCheckRun({ taskGroupId: TASKGROUPID, taskId: CUSTOM_LIVELOG_NAME_TASKID });
       sinon.restore();
-      sinon.stub(utils, "throttleRequest")
-        .onFirstCall()
-        .returns({ status: 200, text: LIVE_LOG_TEXT })
-        .onSecondCall()
-        .returns({ status: 404 })
-        .onThirdCall()
-        .returns({ status: 404 });
+      sinon.stub(global, "fetch").resolves({ ok: true, body: { cancel: async () => {} } });
+      sinon.stub(utils, "extractLog").resolves(LIVE_LOG_TEXT);
+      sinon.stub(utils, "throttleRequest").returns({ status: 404 });
       await simulateExchangeMessage({
         taskGroupId: TASKGROUPID,
         exchange: 'exchange/taskcluster-queue/v1/task-completed',
@@ -1709,13 +1703,9 @@ helper.secrets.mockSuite(testing.suiteName(), [], function (mock, skipping) {
       await addBuild({ state: 'pending', taskGroupId: TASKGROUPID });
       await addCheckRun({ taskGroupId: TASKGROUPID, taskId: CUSTOM_LIVELOG_NAME_TASKID });
       sinon.restore();
-      sinon.stub(utils, "throttleRequest")
-        .onFirstCall()
-        .returns({ status: 200, text: LIVE_LOG_TEXT })
-        .onSecondCall()
-        .returns({ status: 404 })
-        .onThirdCall()
-        .returns({ status: 404 });
+      sinon.stub(global, "fetch").resolves({ ok: true, body: { cancel: async () => {} } });
+      sinon.stub(utils, "extractLog").resolves(LIVE_LOG_TEXT);
+      sinon.stub(utils, "throttleRequest").returns({ status: 404 });
       await simulateExchangeMessage({
         taskGroupId: TASKGROUPID,
         exchange: 'exchange/taskcluster-queue/v1/task-completed',
@@ -1744,6 +1734,8 @@ helper.secrets.mockSuite(testing.suiteName(), [], function (mock, skipping) {
       await addBuild({ state: 'pending', taskGroupId: TASKGROUPID });
       await addCheckRun({ taskGroupId: TASKGROUPID, taskId: CUSTOM_CHECKRUN_TASKID });
       sinon.restore();
+      sinon.stub(global, "fetch").resolves({ ok: true, body: { cancel: async () => {} } });
+      sinon.stub(utils, "extractLog").resolves('');
       sinon.stub(utils, "throttleRequest")
         .onFirstCall()
         .returns({ status: 418, response: { error: { text: "I'm a tea pot" } } })
@@ -1767,12 +1759,12 @@ helper.secrets.mockSuite(testing.suiteName(), [], function (mock, skipping) {
       await addBuild({ state: 'pending', taskGroupId: TASKGROUPID });
       await addCheckRun({ taskGroupId: TASKGROUPID, taskId: CUSTOM_CHECKRUN_TASKID });
       sinon.restore();
+      sinon.stub(global, "fetch").resolves({ ok: true, body: { cancel: async () => {} } });
+      sinon.stub(utils, "extractLog").resolves(LIVE_LOG_TEXT);
       sinon.stub(utils, "throttleRequest")
         .onFirstCall()
-        .returns({ status: 200, text: LIVE_LOG_TEXT })
-        .onSecondCall()
         .returns({ status: 404 })
-        .onThirdCall()
+        .onSecondCall()
         .returns({ status: 200, text: CUSTOM_CHECKRUN_ANNOTATIONS });
       await simulateExchangeMessage({
         taskGroupId: TASKGROUPID,
@@ -1793,12 +1785,12 @@ helper.secrets.mockSuite(testing.suiteName(), [], function (mock, skipping) {
       await addBuild({ state: 'pending', taskGroupId: TASKGROUPID });
       await addCheckRun({ taskGroupId: TASKGROUPID, taskId: CUSTOM_CHECKRUN_TASKID });
       sinon.restore();
+      sinon.stub(global, "fetch").resolves({ ok: true, body: { cancel: async () => {} } });
+      sinon.stub(utils, "extractLog").resolves('');
       sinon.stub(utils, "throttleRequest")
         .onFirstCall()
         .returns({ status: 404 })
         .onSecondCall()
-        .returns({ status: 404 })
-        .onThirdCall()
         .returns({ status: 200, text: "{{{invalid json!!" });
 
       await simulateExchangeMessage({
@@ -1822,6 +1814,8 @@ helper.secrets.mockSuite(testing.suiteName(), [], function (mock, skipping) {
       await addBuild({ state: 'pending', taskGroupId: TASKGROUPID });
       await addCheckRun({ taskGroupId: TASKGROUPID, taskId: CUSTOM_CHECKRUN_TASKID });
       sinon.restore();
+      sinon.stub(global, "fetch").resolves({ ok: true, body: { cancel: async () => {} } });
+      sinon.stub(utils, "extractLog").resolves('');
       sinon.stub(utils, "throttleRequest")
         .onFirstCall()
         .returns({ status: 404 })
@@ -1857,13 +1851,9 @@ helper.secrets.mockSuite(testing.suiteName(), [], function (mock, skipping) {
       await addBuild({ state: 'pending', taskGroupId: TASKGROUPID });
       await addCheckRun({ taskGroupId: TASKGROUPID, taskId: CUSTOM_LIVELOG_NAME_TASKID });
       sinon.restore();
-      sinon.stub(utils, "throttleRequest")
-        .onFirstCall()
-        .returns({ status: 200, text: LIVE_LOG_TEXT })
-        .onSecondCall()
-        .returns({ status: 404 })
-        .onThirdCall()
-        .returns({ status: 404 });
+      sinon.stub(global, "fetch").resolves({ ok: true, body: { cancel: async () => {} } });
+      sinon.stub(utils, "extractLog").resolves(LIVE_LOG_TEXT);
+      sinon.stub(utils, "throttleRequest").returns({ status: 404 });
       await simulateExchangeMessage({
         taskGroupId: TASKGROUPID,
         exchange: 'exchange/taskcluster-queue/v1/task-completed',
@@ -1895,6 +1885,8 @@ helper.secrets.mockSuite(testing.suiteName(), [], function (mock, skipping) {
     });
 
     setup(function () {
+      sinon.stub(global, "fetch").resolves({ ok: false, body: { cancel: async () => {} } });
+      sinon.stub(utils, "extractLog").resolves('');
       sinon.stub(utils, "throttleRequest").returns({ status: 404, response: { error: { text: "Resource not found" } } });
     });
 

--- a/services/github/test/utils_test.js
+++ b/services/github/test/utils_test.js
@@ -1,4 +1,5 @@
 import assert from 'assert';
+import { Readable } from 'stream';
 import testing from '@taskcluster/lib-testing';
 
 import {
@@ -7,14 +8,14 @@ import {
   shouldSkipPullRequest,
   shouldSkipComment,
   getTaskclusterCommand,
-  tailLog,
   extractLog,
-  extractHeadLinesFromLog,
-  extractTailLinesFromLog,
   ansi2txt,
   generateXHubSignature,
   checkGithubSignature,
 } from '../src/utils.js';
+
+/** Create a readable stream from a string */
+const toStream = (str) => Readable.from([Buffer.from(str)]);
 
 suite(testing.suiteName(), function() {
   suite('throttleRequest', function() {
@@ -285,58 +286,122 @@ suite(testing.suiteName(), function() {
     });
   });
 
-  suite('tailLog', function() {
-    test('should get max lines', function () {
-      const payload = Array.from({ length: 500 }).map(line => `line: ${line}`).join('\n');
-      assert.equal(250, tailLog(payload).split('\n').length);
-      assert.equal(25, tailLog(payload, 25).split('\n').length);
-
-      const payloadLong = Array.from({ length: 10 }).map(line => 'line'.repeat(1000)).join('\n');
-      assert.equal(1, tailLog(payloadLong, 10, 20).split('\n').length);
-      assert.equal('line', tailLog(payloadLong, 10, 4));
-    });
-  });
-
   suite('extractLog', function() {
-    test('extract log', function () {
-      const payload = Array.from({ length: 100 }).map(line => `line: ${line}`).join('\n');
-      assert.equal(100, extractLog(payload, 20, 200).split('\n').length);
-      assert.equal(100, extractLog(payload).split('\n').length);
+    // Reference implementation: the original sync extractLog from before the
+    // streaming rewrite. Used to verify the new streaming version produces
+    // identical output for all edge cases.
+    const extractTailLinesFromLog = (logString, maxPayloadLength, tailLines) => {
+      if (tailLines === 0) {
+        return null;
+      }
+      const tl = logString.split('\n').slice(-tailLines).join('\n');
+      if (logString.length <= maxPayloadLength) {
+        return tl;
+      }
+      let tailLogMaxPayload = logString.slice(-maxPayloadLength);
+      const newLinePosition = tailLogMaxPayload.indexOf('\n');
+      tailLogMaxPayload = tailLogMaxPayload.slice(newLinePosition + 1);
+      return tl.length <= tailLogMaxPayload.length ? tl : tailLogMaxPayload;
+    };
 
-      const payloadLong = Array.from({ length: 500 }).map(line => 'line'.repeat(10)).join('\n');
-      assert.equal(223, extractLog(payloadLong, 20, 200).split('\n').length);
+    const extractHeadLinesFromLog = (logString, maxPayloadLength) => {
+      if (logString.length <= maxPayloadLength) {
+        return logString;
+      }
+      const headLog = logString.slice(0, maxPayloadLength);
+      const lastNewLinePosition = headLog.lastIndexOf('\n');
+      return headLog.substring(0, lastNewLinePosition);
+    };
+
+    const originalExtractLog = (log, headLines = 20, tailLines = 200, maxPayloadLength = 30000) => {
+      const logString = ansi2txt(log);
+      const lines = logString.split('\n');
+      const LOG_BUFFER = 42;
+      if (lines.length <= headLines + tailLines && logString.length <= maxPayloadLength) {
+        return logString;
+      }
+      const headLogArray = lines.slice(0, headLines);
+      const headLog = headLogArray.join('\n');
+      if (maxPayloadLength <= headLog.length) {
+        return extractHeadLinesFromLog(logString, maxPayloadLength);
+      }
+      const tl = extractTailLinesFromLog(logString, maxPayloadLength - headLog.length - LOG_BUFFER, tailLines);
+      if (!tl) {
+        return `${headLog}\n\n...(${lines.length - headLogArray.length} lines hidden)...\n\n`;
+      }
+      const availableTailLines = tl.split('\n').length;
+      return `${headLog}\n\n...(${lines.length - headLines - availableTailLines} lines hidden)...\n\n${tl}`;
+    };
+
+    /** Generate a log with the given number of lines */
+    const generateLog = (numLines) =>
+      Array.from({ length: numLines }, (_, i) => `line ${i}: ${'x'.repeat(20)}`).join('\n');
+
+    /**
+     * Assert that the streaming extractLog produces identical output to the
+     * original string-based implementation for the given input.
+     */
+    const assertMatchesOriginal = async (log, headLines = 20, tailLines = 200, maxPayloadLength = 30000) => {
+      const expected = originalExtractLog(log, headLines, tailLines, maxPayloadLength);
+      const actual = await extractLog(toStream(log), headLines, tailLines, maxPayloadLength);
+      assert.strictEqual(actual, expected);
+    };
+
+    test('empty log', async function() {
+      await assertMatchesOriginal('');
     });
-  });
 
-  suite('extractHeadLinesFromLog', function() {
-    test('should get the complete head lines corresponding to the max payload length', function() {
-      const payload = Array.from({ length: 4 }, (_, i) => Array(i + 1).fill(`line ${i + 1}`).join(' ')).join('\n');
-      const payloadWithIncompleteLine = `${payload}\nline 5 line 5 line`;
-
-      assert.equal(payload, extractHeadLinesFromLog(payloadWithIncompleteLine, 80));
-      assert.equal(payload, extractHeadLinesFromLog(payload, 72));
+    test('short log (3 lines)', async function() {
+      await assertMatchesOriginal(generateLog(3));
     });
-  });
 
-  suite('extractLogWithLongLine', function() {
-    test('should get the complete head lines corresponding to the max payload length', function() {
-      const payload = Array.from({ length: 10 }).map(line => `line: ${line}`);
+    test('log with exactly headLines lines (20), no tail', async function() {
+      await assertMatchesOriginal(generateLog(20));
+    });
+
+    test('log with headLines + 1 (21 lines)', async function() {
+      await assertMatchesOriginal(generateLog(21));
+    });
+
+    test('log with exactly headLines + tailLines (220 lines, 0 hidden)', async function() {
+      await assertMatchesOriginal(generateLog(220));
+    });
+
+    test('log with headLines + tailLines + 1 (221 lines, 1 hidden)', async function() {
+      await assertMatchesOriginal(generateLog(221));
+    });
+
+    test('log with 100 lines hidden', async function() {
+      await assertMatchesOriginal(generateLog(320));
+    });
+
+    test('large log (1000 lines)', async function() {
+      await assertMatchesOriginal(generateLog(1000));
+    });
+
+    test('long single line exceeding maxPayloadLength', async function() {
+      const payload = Array.from({ length: 10 }).map((_, i) => `line: ${i}`);
       payload.push('A'.repeat(100000));
-
-      // Those values (20, 200, 60000) are what the github worker would use in "worst case scenarios".
-      // We append a line that far exceeds that within the `tail+head` of what it tries to get to make
-      // sure that the return value ignores it (doesn't include a cut line, doesn't exceed max payload)
-      assert.equal(extractLog(payload.join('\n'), 20, 200, 60000).length, 159);
+      await assertMatchesOriginal(payload.join('\n'), 20, 200, 60000);
     });
-  });
 
-  suite('extractTailLinesFromLog', function() {
-    test('should get complete tail lines corresponding to may payload length or taiLines whichever is minimum', function() {
-      const payload = Array.from({ length: 4 }, (_, i) => Array(i + 1).fill(`line ${i + 1}`).join(' ')).join('\n');
+    test('head alone exceeds maxPayloadLength', async function() {
+      // 20 lines of 2000 chars each = 40000 chars in head
+      const log = Array.from({ length: 500 }, (_, i) => `line ${i}: ${'x'.repeat(2000)}`).join('\n');
+      await assertMatchesOriginal(log, 20, 200, 30000);
+    });
 
-      assert.equal(null, extractTailLinesFromLog(payload, 100, 0));
-      assert.equal('line 4 line 4 line 4 line 4', extractTailLinesFromLog(payload, 100, 1));
-      assert.equal(payload, extractTailLinesFromLog(payload, 100, 4));
+    test('respects custom maxPayloadLength', async function() {
+      await assertMatchesOriginal(generateLog(500), 20, 200, 5000);
+    });
+
+    test('respects custom maxPayloadLength (60000)', async function() {
+      await assertMatchesOriginal(generateLog(500), 20, 200, 60000);
+    });
+
+    test('strips ANSI control sequences', async function() {
+      const payload = '\u001b[32mgreen text\u001b[0m\nnormal line';
+      await assertMatchesOriginal(payload);
     });
   });
 


### PR DESCRIPTION
## Summary

Change `extractLog` to accept an async iterable (readable stream) instead of a string. It streams the response line-by-line, keeping only the first 20 and last 200 lines in memory via a head buffer and a circular tail buffer. The formatted output is identical to before.

- The backing log is now fetched via `fetch()` and streamed directly to `extractLog`, instead of being downloaded entirely into memory via `requestArtifact`
- Other artifact fetches (custom text, annotations JSON) continue using `requestArtifact` unchanged
- The helper functions `tailLog`, `extractTailLinesFromLog`, and `extractHeadLinesFromLog` are removed as they are no longer needed
- No new files — all changes are in existing files

Fixes #8388

## Test plan

- [x] All 265 github service tests pass
- [x] `extractLog` tests updated to pass in-memory streams via `Readable.from()`
- [x] Tests cover: small logs, large logs, long single lines, empty streams, ANSI stripping, accurate hidden line count

🤖 Generated with [Claude Code](https://claude.com/claude-code)