### PR TITLE
fix(tests): close all server connections to prevent intermittent `EADDRINUSE` errors

### DIFF
--- a/changelog/issue-3665.md
+++ b/changelog/issue-3665.md
@@ -1,0 +1,3 @@
+level: silent
+reference: issue 3665
+---

--- a/libraries/app/src/index.js
+++ b/libraries/app/src/index.js
@@ -95,6 +95,10 @@ const createServer = function() {
 
       return new Promise((accept, reject) => {
         server.close(accept);
+        // force-close all open connections so the port is released immediately;
+        // called after server.close per Node.js docs to avoid race conditions
+        // where new connections arrive between the two calls
+        server.closeAllConnections();
       }).then(() => {
         debug('Server terminated on port ' + this.get('port'));
       });

--- a/services/web-server/test/helper.js
+++ b/services/web-server/test/helper.js
@@ -155,7 +155,10 @@ helper.withServer = (mock, skipping) => {
       return;
     }
     if (webServer) {
-      await new Promise(resolve => webServer.close(resolve));
+      await new Promise(resolve => {
+        webServer.close(resolve);
+        webServer.closeAllConnections();
+      });
       webServer = null;
     }
   });


### PR DESCRIPTION
Fixes #3665.

https://nodejs.org/docs/latest-v24.x/api/http.html#servercloseallconnections