### PR TITLE
feat(d2g): minor performance improvements

### DIFF
--- a/changelog/NWnIr8mLQOKFu1rynCjBEg.md
+++ b/changelog/NWnIr8mLQOKFu1rynCjBEg.md
@@ -1,0 +1,4 @@
+audience: worker-deployers
+level: patch
+---
+D2G: performance improvements to `docker run` for d2g tasks. Adds `--pull=never` to skip redundant registry checks (image is already loaded), `--log-driver=none` to eliminate duplicate log writes, and parallelizes artifact extraction from stopped containers.

--- a/tools/d2g/d2g.go
+++ b/tools/d2g/d2g.go
@@ -398,6 +398,18 @@ func runCommand(
 	// https://docs.docker.com/reference/cli/docker/container/run/
 	args = append(args, "--memory-swap", "-1", "--pids-limit", "-1")
 
+	// The d2g task feature always ensures that the image is
+	// available locally (via docker pull or docker load) before running
+	// the container. Skip the local image lookup since we know the
+	// image is already present.
+	args = append(args, "--pull=never")
+
+	// Generic worker captures task output directly via process
+	// stdout/stderr. Docker's log driver would write a redundant copy
+	// of all output to disk that is never read (the container is
+	// removed after the task). Disable it to save disk I/O.
+	args = append(args, "--log-driver=none")
+
 	if dwPayload.Capabilities.Privileged && config.AllowPrivileged {
 		args = append(args, "--privileged")
 	} else if dwPayload.Features.AllowPtrace && config.AllowPtrace {

--- a/tools/d2g/d2gtest/testdata/testcases/artifacts_test.yml
+++ b/tools/d2g/d2gtest/testdata/testcases/artifacts_test.yml
@@ -51,6 +51,8 @@ testSuite:
         - "-1"
         - --pids-limit
         - "-1"
+        - --pull=never
+        - --log-driver=none
         - --add-host=localhost.localdomain:127.0.0.1
         - --env-file
         - env.list
@@ -108,6 +110,8 @@ testSuite:
         - "-1"
         - --pids-limit
         - "-1"
+        - --pull=never
+        - --log-driver=none
         - --add-host=localhost.localdomain:127.0.0.1
         - -v
         - __TASK_DIR__/volume0:/home/worker/artifacts

--- a/tools/d2g/d2gtest/testdata/testcases/chain_of_trust_test.yml
+++ b/tools/d2g/d2gtest/testdata/testcases/chain_of_trust_test.yml
@@ -42,6 +42,8 @@ testSuite:
         - "-1"
         - --pids-limit
         - "-1"
+        - --pull=never
+        - --log-driver=none
         - --add-host=localhost.localdomain:127.0.0.1
         - --env-file
         - env.list
@@ -101,6 +103,8 @@ testSuite:
         - "-1"
         - --pids-limit
         - "-1"
+        - --pull=never
+        - --log-driver=none
         - --add-host=localhost.localdomain:127.0.0.1
         - --env-file
         - env.list
@@ -166,6 +170,8 @@ testSuite:
         - "-1"
         - --pids-limit
         - "-1"
+        - --pull=never
+        - --log-driver=none
         - --add-host=localhost.localdomain:127.0.0.1
         - --env-file
         - env.list
@@ -227,6 +233,8 @@ testSuite:
         - "-1"
         - --pids-limit
         - "-1"
+        - --pull=never
+        - --log-driver=none
         - --add-host=localhost.localdomain:127.0.0.1
         - --env-file
         - env.list

--- a/tools/d2g/d2gtest/testdata/testcases/container_engine_test.yml
+++ b/tools/d2g/d2gtest/testdata/testcases/container_engine_test.yml
@@ -34,6 +34,8 @@ testSuite:
         - "-1"
         - --pids-limit
         - "-1"
+        - --pull=never
+        - --log-driver=none
         - --add-host=localhost.localdomain:127.0.0.1
         - --env-file
         - env.list

--- a/tools/d2g/d2gtest/testdata/testcases/decision_task_tests.yml
+++ b/tools/d2g/d2gtest/testdata/testcases/decision_task_tests.yml
@@ -85,6 +85,8 @@ testSuite:
         - "-1"
         - --pids-limit
         - "-1"
+        - --pull=never
+        - --log-driver=none
         - --privileged
         - --add-host=localhost.localdomain:127.0.0.1
         - -v

--- a/tools/d2g/d2gtest/testdata/testcases/devices_tests.yml
+++ b/tools/d2g/d2gtest/testdata/testcases/devices_tests.yml
@@ -37,6 +37,8 @@ testSuite:
         - "-1"
         - --pids-limit
         - "-1"
+        - --pull=never
+        - --log-driver=none
         - --add-host=localhost.localdomain:127.0.0.1
         - -v
         - /dev/shm:/dev/shm
@@ -90,6 +92,8 @@ testSuite:
         - "-1"
         - --pids-limit
         - "-1"
+        - --pull=never
+        - --log-driver=none
         - --add-host=localhost.localdomain:127.0.0.1
         - --env-file
         - env.list
@@ -141,6 +145,8 @@ testSuite:
         - "-1"
         - --pids-limit
         - "-1"
+        - --pull=never
+        - --log-driver=none
         - --add-host=localhost.localdomain:127.0.0.1
         - --device=/dev/kvm
         - --env-file
@@ -193,6 +199,8 @@ testSuite:
         - "-1"
         - --pids-limit
         - "-1"
+        - --pull=never
+        - --log-driver=none
         - --add-host=localhost.localdomain:127.0.0.1
         - --env-file
         - env.list
@@ -244,6 +252,8 @@ testSuite:
         - "-1"
         - --pids-limit
         - "-1"
+        - --pull=never
+        - --log-driver=none
         - --add-host=localhost.localdomain:127.0.0.1
         - --device=__TASKCLUSTER_VIDEO_DEVICE__
         - --env-file
@@ -297,6 +307,8 @@ testSuite:
         - "-1"
         - --pids-limit
         - "-1"
+        - --pull=never
+        - --log-driver=none
         - --add-host=localhost.localdomain:127.0.0.1
         - --env-file
         - env.list
@@ -348,6 +360,8 @@ testSuite:
         - "-1"
         - --pids-limit
         - "-1"
+        - --pull=never
+        - --log-driver=none
         - --add-host=localhost.localdomain:127.0.0.1
         - --device=/dev/snd
         - --env-file
@@ -401,6 +415,8 @@ testSuite:
         - "-1"
         - --pids-limit
         - "-1"
+        - --pull=never
+        - --log-driver=none
         - --add-host=localhost.localdomain:127.0.0.1
         - --env-file
         - env.list
@@ -449,6 +465,8 @@ testSuite:
         - "-1"
         - --pids-limit
         - "-1"
+        - --pull=never
+        - --log-driver=none
         - --add-host=localhost.localdomain:127.0.0.1
         - --gpus
         - all
@@ -501,6 +519,8 @@ testSuite:
         - "-1"
         - --pids-limit
         - "-1"
+        - --pull=never
+        - --log-driver=none
         - --add-host=localhost.localdomain:127.0.0.1
         - --gpus
         - device=GPU-3a23c669-1f69-c64e-cf85-44e9b07e7a2a

--- a/tools/d2g/d2gtest/testdata/testcases/docker_image_tests.yml
+++ b/tools/d2g/d2gtest/testdata/testcases/docker_image_tests.yml
@@ -32,6 +32,8 @@ testSuite:
         - "-1"
         - --pids-limit
         - "-1"
+        - --pull=never
+        - --log-driver=none
         - --add-host=localhost.localdomain:127.0.0.1
         - --env-file
         - env.list
@@ -81,6 +83,8 @@ testSuite:
         - "-1"
         - --pids-limit
         - "-1"
+        - --pull=never
+        - --log-driver=none
         - --add-host=localhost.localdomain:127.0.0.1
         - --env-file
         - env.list
@@ -131,6 +135,8 @@ testSuite:
         - "-1"
         - --pids-limit
         - "-1"
+        - --pull=never
+        - --log-driver=none
         - --add-host=localhost.localdomain:127.0.0.1
         - --env-file
         - env.list
@@ -187,6 +193,8 @@ testSuite:
         - "-1"
         - --pids-limit
         - "-1"
+        - --pull=never
+        - --log-driver=none
         - --add-host=localhost.localdomain:127.0.0.1
         - --env-file
         - env.list
@@ -244,6 +252,8 @@ testSuite:
         - "-1"
         - --pids-limit
         - "-1"
+        - --pull=never
+        - --log-driver=none
         - --add-host=localhost.localdomain:127.0.0.1
         - --env-file
         - env.list
@@ -300,6 +310,8 @@ testSuite:
         - "-1"
         - --pids-limit
         - "-1"
+        - --pull=never
+        - --log-driver=none
         - --add-host=localhost.localdomain:127.0.0.1
         - --env-file
         - env.list
@@ -355,6 +367,8 @@ testSuite:
         - "-1"
         - --pids-limit
         - "-1"
+        - --pull=never
+        - --log-driver=none
         - --add-host=localhost.localdomain:127.0.0.1
         - --env-file
         - env.list
@@ -411,6 +425,8 @@ testSuite:
         - "-1"
         - --pids-limit
         - "-1"
+        - --pull=never
+        - --log-driver=none
         - --add-host=localhost.localdomain:127.0.0.1
         - --env-file
         - env.list
@@ -468,6 +484,8 @@ testSuite:
         - "-1"
         - --pids-limit
         - "-1"
+        - --pull=never
+        - --log-driver=none
         - --add-host=localhost.localdomain:127.0.0.1
         - -v
         - __TASK_DIR__/cache0:/builds/worker/checkouts

--- a/tools/d2g/d2gtest/testdata/testcases/dw_features_tests.yml
+++ b/tools/d2g/d2gtest/testdata/testcases/dw_features_tests.yml
@@ -37,6 +37,8 @@ testSuite:
         - "-1"
         - --pids-limit
         - "-1"
+        - --pull=never
+        - --log-driver=none
         - --cap-add=SYS_PTRACE
         - --security-opt=seccomp=unconfined
         - --add-host=localhost.localdomain:127.0.0.1
@@ -94,6 +96,8 @@ testSuite:
         - "-1"
         - --pids-limit
         - "-1"
+        - --pull=never
+        - --log-driver=none
         - --add-host=localhost.localdomain:127.0.0.1
         - --env-file
         - env.list
@@ -143,6 +147,8 @@ testSuite:
         - "-1"
         - --pids-limit
         - "-1"
+        - --pull=never
+        - --log-driver=none
         - --privileged
         - --add-host=localhost.localdomain:127.0.0.1
         - --env-file
@@ -194,6 +200,8 @@ testSuite:
         - "-1"
         - --pids-limit
         - "-1"
+        - --pull=never
+        - --log-driver=none
         - --add-host=localhost.localdomain:127.0.0.1
         - --env-file
         - env.list

--- a/tools/d2g/d2gtest/testdata/testcases/env_test.yml
+++ b/tools/d2g/d2gtest/testdata/testcases/env_test.yml
@@ -41,6 +41,8 @@ testSuite:
         - "-1"
         - --pids-limit
         - "-1"
+        - --pull=never
+        - --log-driver=none
         - --add-host=localhost.localdomain:127.0.0.1
         - -e
         - |2-

--- a/tools/d2g/d2gtest/testdata/testcases/fuzzing_tests.yml
+++ b/tools/d2g/d2gtest/testdata/testcases/fuzzing_tests.yml
@@ -57,6 +57,8 @@ testSuite:
         - "-1"
         - --pids-limit
         - "-1"
+        - --pull=never
+        - --log-driver=none
         - --privileged
         - --security-opt=seccomp=unconfined
         - --add-host=localhost.localdomain:127.0.0.1

--- a/tools/d2g/d2gtest/testdata/testcases/no_artifacts_test.yml
+++ b/tools/d2g/d2gtest/testdata/testcases/no_artifacts_test.yml
@@ -40,6 +40,8 @@ testSuite:
         - "-1"
         - --pids-limit
         - "-1"
+        - --pull=never
+        - --log-driver=none
         - --add-host=localhost.localdomain:127.0.0.1
         - --env-file
         - env.list

--- a/tools/d2g/d2gtest/testdata/testcases/task_def_test.yml
+++ b/tools/d2g/d2gtest/testdata/testcases/task_def_test.yml
@@ -75,6 +75,8 @@ testSuite:
           - "-1"
           - --pids-limit
           - "-1"
+          - --pull=never
+          - --log-driver=none
           - --add-host=localhost.localdomain:127.0.0.1
           - --device=/dev/kvm
           - --env-file
@@ -184,6 +186,8 @@ testSuite:
           - "-1"
           - --pids-limit
           - "-1"
+          - --pull=never
+          - --log-driver=none
           - --add-host=localhost.localdomain:127.0.0.1
           - --device=/dev/kvm
           - --env-file
@@ -296,6 +300,8 @@ testSuite:
           - "-1"
           - --pids-limit
           - "-1"
+          - --pull=never
+          - --log-driver=none
           - --add-host=localhost.localdomain:127.0.0.1
           - --device=/dev/kvm
           - --env-file

--- a/workers/generic-worker/d2g_feature.go
+++ b/workers/generic-worker/d2g_feature.go
@@ -9,6 +9,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"sync"
 
 	"github.com/taskcluster/taskcluster/v98/internal/scopes"
 	"github.com/taskcluster/taskcluster/v98/workers/generic-worker/fileutil"
@@ -235,20 +236,36 @@ func (dtf *D2GTaskFeature) Start() *CommandExecutionError {
 }
 
 func (dtf *D2GTaskFeature) Stop(err *ExecutionErrors) {
+	// Copy artifacts from the stopped container in parallel since
+	// each docker cp reads from an independent path and destinations
+	// are unique (artifact0, artifact1, ...).
+	var wg sync.WaitGroup
+	var mu sync.Mutex
+	var copyErrs []*CommandExecutionError
 	for _, artifact := range dtf.task.D2GInfo.CopyArtifacts {
-		cmd, e := process.NewCommandNoOutputStreams([]string{
-			"docker",
-			"cp",
-			fmt.Sprintf("%s:%s", dtf.task.D2GInfo.ContainerName, artifact.SrcPath),
-			artifact.DestPath,
-		}, taskContext.TaskDir, []string{}, dtf.task.pd)
-		if e != nil {
-			err.add(executionError(internalError, errored, fmt.Errorf("[d2g] could not create process to copy artifact: %v", e)))
-		}
-		out, e := cmd.CombinedOutput()
-		if e != nil {
-			dtf.task.Warnf("%v", formatCommandError(fmt.Sprintf("[d2g] Artifact %q not found at %q", artifact.Name, artifact.SrcPath), e, out))
-		}
+		wg.Go(func() {
+			cmd, e := process.NewCommandNoOutputStreams([]string{
+				"docker",
+				"cp",
+				fmt.Sprintf("%s:%s", dtf.task.D2GInfo.ContainerName, artifact.SrcPath),
+				artifact.DestPath,
+			}, taskContext.TaskDir, []string{}, dtf.task.pd)
+			if e != nil {
+				execErr := executionError(internalError, errored, fmt.Errorf("[d2g] could not create process to copy artifact: %v", e))
+				mu.Lock()
+				copyErrs = append(copyErrs, execErr)
+				mu.Unlock()
+				return
+			}
+			out, e := cmd.CombinedOutput()
+			if e != nil {
+				dtf.task.Warnf("%v", formatCommandError(fmt.Sprintf("[d2g] Artifact %q not found at %q", artifact.Name, artifact.SrcPath), e, out))
+			}
+		})
+	}
+	wg.Wait()
+	for _, e := range copyErrs {
+		err.add(e)
 	}
 
 	cmd, e := process.NewCommandNoOutputStreams([]string{


### PR DESCRIPTION
>D2G: performance improvements to `docker run` for d2g tasks. Adds `--pull=never` to skip redundant registry checks (image is already loaded), `--log-driver=none` to eliminate duplicate log writes, and parallelizes artifact extraction from stopped containers.