### PR TITLE
fix: restore v prefix on websocktunnel Docker Hub tags

### DIFF
--- a/changelog/WlHhqxwnSQKAB5qZwxpHgg.md
+++ b/changelog/WlHhqxwnSQKAB5qZwxpHgg.md
@@ -1,0 +1,4 @@
+audience: users
+level: major
+---
+The `taskcluster/websocktunnel` Docker image tags now include a `v` prefix (e.g., `v99.0.0` instead of `99.0.0`), matching the convention used by all other Taskcluster Docker images. A duplicate task definition in the release tooling was silently overriding the correct tag format since v36.0.0. If you reference websocktunnel images by tag, update your configurations to use the `v`-prefixed format.

--- a/infrastructure/tooling/src/build/tasks/release.js
+++ b/infrastructure/tooling/src/build/tasks/release.js
@@ -10,7 +10,6 @@ import {
   execCommand,
   pyClientRelease,
   readRepoFile,
-  dockerPush,
   REPO_ROOT,
 } from '../../utils/index.js';
 
@@ -42,94 +41,6 @@ export default ({ tasks, cmdOptions, credentials, baseDir, logsDir }) => {
       return {
         'changelog-text': match[1],
       };
-    },
-  });
-
-  ensureTask(tasks, {
-    title: 'Build Websocktunnel Docker Image',
-    requires: [
-      'release-version',
-      'docker-flow-version',
-    ],
-    provides: [
-      'websocktunnel-docker-image', // image tag
-    ],
-    locks: ['docker'],
-    run: async (requirements, utils) => {
-      utils.step({ title: 'Check Repository' });
-
-      const tag = `taskcluster/websocktunnel:${requirements['release-version']}`;
-      const provides = {
-        'websocktunnel-docker-image': tag,
-      };
-
-      utils.step({ title: 'Building Websocktunnel' });
-
-      const contextDir = path.join(baseDir, 'websocktunnel-build');
-      await execCommand({
-        command: [
-          'go', 'build',
-          '-o', path.join(contextDir, 'websocktunnel'),
-          './tools/websocktunnel/cmd/websocktunnel',
-        ],
-        dir: REPO_ROOT,
-        logfile: path.join(logsDir, 'websocktunnel-build.log'),
-        utils,
-        env: { CGO_ENABLED: '0', ...process.env },
-      });
-
-      utils.step({ title: 'Building Docker Image' });
-
-      fs.writeFileSync(
-        path.join(contextDir, 'version.json'),
-        requirements['docker-flow-version']);
-
-      // this simple Dockerfile just packages the binary into a Docker image
-      const dockerfile = path.join(contextDir, 'Dockerfile');
-      fs.writeFileSync(dockerfile, [
-        'FROM scratch',
-        'COPY websocktunnel /websocktunnel',
-        'COPY version.json /app/version.json',
-        'ENTRYPOINT ["/websocktunnel"]',
-      ].join('\n'));
-      let command = [
-        'docker', 'build',
-        '--no-cache',
-        '--progress', 'plain',
-        '--tag', tag,
-        contextDir,
-      ];
-      await execCommand({
-        command,
-        dir: REPO_ROOT,
-        logfile: path.join(logsDir, 'websocktunnel-docker-build.log'),
-        utils,
-        env: { DOCKER_BUILDKIT: 1, ...process.env },
-      });
-
-      if (cmdOptions.staging || !cmdOptions.push) {
-        return provides;
-      }
-
-      utils.step({ title: 'Pushing Docker Image' });
-
-      const dockerPushOptions = {};
-      if (credentials.dockerUsername && credentials.dockerPassword) {
-        dockerPushOptions.credentials = {
-          username: credentials.dockerUsername,
-          password: credentials.dockerPassword,
-        };
-      }
-
-      await dockerPush({
-        logfile: path.join(logsDir, 'websocktunnel-docker-push.log'),
-        tag,
-        utils,
-        baseDir,
-        ...dockerPushOptions,
-      });
-
-      return provides;
     },
   });
 

--- a/ui/docs/manual/deploying/websocktunnel.mdx
+++ b/ui/docs/manual/deploying/websocktunnel.mdx
@@ -28,7 +28,7 @@ In non-production mode, the service logs its activities to stdout in a human-rea
 ## Deployment
 
 The service is deployed from a Docker image containing only the single, statically-linked binary.
-You can find the docker image on Docker hub at `taskcluster/websocktunnel:<version>` or build it yourself with `docker build .`.
+You can find the docker image on Docker hub at `taskcluster/websocktunnel:v<version>` or build it yourself with `docker build .`.
 The image should be run with the environment variables described above, and the container's port exposed on the Docker host.
 Use the same value for PORT as the port exposed on the host (typically 443), as the service will include that port in the URLs it generates.
 


### PR DESCRIPTION
release.js contained a duplicate 'Build Websocktunnel Docker Image' task that shadowed the one in websocktunnel.js due to ensureTask's title-based dedup and alphabetical file loading. The duplicate was missing the v prefix in the tag, so all published tags since 2020 were unprefixed despite the v36.0.0 changelog claiming otherwise.

Remove the duplicate task from release.js so the correct definition in websocktunnel.js (which includes the v prefix) takes effect. Also revert the docs workaround from 791ca06cd9 that adjusted the documented tag format to match the buggy behavior.

>The `taskcluster/websocktunnel` Docker image tags now include a `v` prefix (e.g., `v99.0.0` instead of `99.0.0`), matching the convention used by all other Taskcluster Docker images. A duplicate task definition in the release tooling was silently overriding the correct tag format since v36.0.0. If you reference websocktunnel images by tag, update your configurations to use the `v`-prefixed format.