### PR TITLE
fix(generic-worker): prevent panic on double Command.Kill()

### DIFF
--- a/changelog/issue-8410.md
+++ b/changelog/issue-8410.md
@@ -1,0 +1,5 @@
+audience: worker-deployers
+level: patch
+reference: issue 8410
+---
+Generic Worker: Fix panic "close of closed channel" in `Command.Kill()` when multiple abort paths (e.g., reclaim failure and graceful termination) race to kill a task's processes.

--- a/workers/generic-worker/process/multiuser_darwin.go
+++ b/workers/generic-worker/process/multiuser_darwin.go
@@ -37,7 +37,8 @@ type (
 		// abort channel is closed when Kill() is called so that Execute() can
 		// return even if cmd.Wait() is blocked. This is useful since cmd.Wait()
 		// sometimes does not return promptly.
-		abort chan struct{}
+		abort     chan struct{}
+		abortOnce sync.Once
 		// Once command has run, Result is updated (similar to cmd.ProcessState)
 		result *Result
 		conn   net.Conn

--- a/workers/generic-worker/process/multiuser_windows.go
+++ b/workers/generic-worker/process/multiuser_windows.go
@@ -134,7 +134,7 @@ func NewCommandNoOutputStreams(commandLine []string, workingDirectory string, en
 
 func (c *Command) Kill() (killOutput string, err error) {
 	// abort even if process hasn't started
-	close(c.abort)
+	c.abortOnce.Do(func() { close(c.abort) })
 	c.mutex.Lock()
 	defer c.mutex.Unlock()
 	if c.Process == nil {

--- a/workers/generic-worker/process/other.go
+++ b/workers/generic-worker/process/other.go
@@ -19,7 +19,8 @@ type (
 		// abort channel is closed when Kill() is called so that Execute() can
 		// return even if cmd.Wait() is blocked. This is useful since cmd.Wait()
 		// sometimes does not return promptly.
-		abort chan struct{}
+		abort     chan struct{}
+		abortOnce sync.Once
 		// Once command has run, Result is updated (similar to cmd.ProcessState)
 		result *Result
 	}

--- a/workers/generic-worker/process/posix.go
+++ b/workers/generic-worker/process/posix.go
@@ -58,7 +58,7 @@ func (c *Command) SetEnv(envVar, value string) {
 
 func (c *Command) Kill() (killOutput string, err error) {
 	// abort even if process hasn't started
-	close(c.abort)
+	c.abortOnce.Do(func() { close(c.abort) })
 	c.mutex.Lock()
 	defer c.mutex.Unlock()
 	// if pid has been set in result, use that


### PR DESCRIPTION
Use sync.Once to guard close(c.abort) so concurrent abort paths (reclaim failure + graceful termination) cannot panic with "close of closed channel".

Fixes #8410

>Generic Worker: Fix panic "close of closed channel" in `Command.Kill()` when multiple abort paths (e.g., reclaim failure and graceful termination) race to kill a task's processes.