### PR TITLE
feat(w-m): Let azure vm register

### DIFF
--- a/changelog/6898.md
+++ b/changelog/6898.md
@@ -1,0 +1,5 @@
+level: patch
+audience: deployers
+reference: issue 6898
+---
+Azure workers that report a failed provisioning state (e.g., `OSProvisioningClientError`) but are actually running (`PowerState/running`) are no longer immediately terminated. Instead, they are allowed to attempt registration, with the existing `terminateAfter` timeout serving as a safety net for truly broken workers.

--- a/services/worker-manager/src/providers/azure/index.js
+++ b/services/worker-manager/src/providers/azure/index.js
@@ -1601,21 +1601,32 @@ export class AzureProvider extends Provider {
 
       if (worker.state === states.REQUESTED) {
         // It's possible for a newly-requested VM to be running (PowerState/running), but have failed
-        // provisioning.  In this case the VM isn't doing any work, but billing continues.  So, we want
-        // to catch this case and also consider it failed.  These state codes have the form
-        // `ProvisioningState/failed/<SomeCode>`.  We allow the user to ignore specific codes.
+        // provisioning.  These state codes have the form `ProvisioningState/failed/<SomeCode>`.
+        // We allow the user to ignore specific codes via ignoreFailedProvisioningStates.
         let ignore = new Set(worker.providerData.ignoreFailedProvisioningStates || []);
         let failedProvisioningCodes = powerStates
           .filter(state => state.startsWith('ProvisioningState/failed/'))
           .map(state => state.split('/')[2])
           .filter(code => !ignore.has(code));
 
-        // any failed-provisioning code is treated as a failure
         if (failedProvisioningCodes.length > 0) {
-          return {
-            instanceState: InstanceStates.FAILED,
-            instanceStateReason: `failed provisioning power state; powerStates=${powerStates.join(', ')}`,
-          };
+          const isRunning = powerStates.includes('PowerState/running');
+          if (isRunning) {
+            // VM is running despite provisioning error — let it attempt
+            // registration. terminateAfter will catch truly broken workers.
+            monitor.warning({
+              message: 'VM has failed provisioning state but is running',
+              workerPoolId: worker.workerPoolId,
+              workerId: worker.workerId,
+              powerStates,
+              failedProvisioningCodes,
+            });
+          } else {
+            return {
+              instanceState: InstanceStates.FAILED,
+              instanceStateReason: `failed provisioning power state; powerStates=${powerStates.join(', ')}`,
+            };
+          }
         }
       }
 

--- a/services/worker-manager/test/provider_azure_test.js
+++ b/services/worker-manager/test/provider_azure_test.js
@@ -1684,6 +1684,32 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       assert(!provider.provisionResources.called);
     });
 
+    test('does not call removeWorker() for a requested worker with failed provisioning but PowerState/running', async function() {
+      await setState({ state: 'requested', powerStates: ['ProvisioningState/failed/OSProvisioningClientError', 'PowerState/running'] });
+      await provider.checkWorker({ worker });
+      await worker.reload(helper.db);
+      assert(!provider.removeWorker.called);
+      assert(provider.provisionResources.called);
+    });
+
+    test('calls removeWorker() for a requested worker with failed provisioning and no PowerState/running', async function() {
+      await setState({ state: 'requested', powerStates: ['ProvisioningState/failed/OSProvisioningClientError', 'PowerState/stopped'] });
+      await provider.checkWorker({ worker });
+      await worker.reload(helper.db);
+      assert(provider.removeWorker.called);
+      assert(!provider.provisionResources.called);
+    });
+
+    test('removes worker with failed provisioning + PowerState/running after terminateAfter expires', async function() {
+      await setState({ state: 'requested', powerStates: ['ProvisioningState/failed/OSProvisioningClientError', 'PowerState/running'] });
+      await worker.update(helper.db, worker => {
+        worker.providerData.terminateAfter = Date.now() - 1000;
+      });
+      await provider.checkWorker({ worker });
+      assert(provider.removeWorker.called);
+      assert(!provider.provisionResources.called);
+    });
+
     test('calls provisionResources for a requested worker that is present but has failed OS Provisioning, if ignoring that', async function() {
       await worker.update(helper.db, worker => {
         worker.providerData.ignoreFailedProvisioningStates = ['OSProvisioningTimedOut', 'SomethingElse'];


### PR DESCRIPTION
This should prevent some workers that managed to launch and call registerWorker even when azure reports some failed provisioning state. If provisionining is truly failed, worker would later be removed with terminateAfter logic

Fixes #6898


around 50 workers were dropped last week, so this is definitely ongoing