### PR TITLE
chore(publish): remove dry run options from npm publishing since tests were successful

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -2,15 +2,6 @@ name: Publish NPM Packages
 on:
   release:
     types: [published]
-  workflow_dispatch:
-    inputs:
-      tag:
-        description: 'Release tag to publish (e.g. v99.0.0)'
-        required: true
-      dry-run:
-        description: 'Dry run (do not actually publish)'
-        type: boolean
-        default: true
 
 jobs:
   publish:
@@ -53,14 +44,8 @@ jobs:
 
             gh release download "$RELEASE_TAG" --repo taskcluster/taskcluster --pattern "$PACKAGE"
 
-            if [ "$DRY_RUN" = "true" ]; then
-              echo "DRY RUN: would publish ${PACKAGE}"
-              npm publish "$PACKAGE" --provenance --access public --dry-run
-            else
-              npm publish "$PACKAGE" --provenance --access public
-            fi
+            npm publish "$PACKAGE" --provenance --access public
           done
         env:
           GH_TOKEN: ${{ github.token }}
-          RELEASE_TAG: ${{ github.event.release.tag_name || inputs.tag }}
-          DRY_RUN: ${{ inputs.dry-run }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}

--- a/changelog/issue-8013-1.md
+++ b/changelog/issue-8013-1.md
@@ -1,0 +1,3 @@
+level: silent
+reference: issue 8013
+---


### PR DESCRIPTION
Followup to https://github.com/taskcluster/taskcluster/pull/8413 (cleanup)

Tests look good https://github.com/taskcluster/taskcluster/actions/runs/23810052076/job/69394263966