### PR TITLE
fix(release): remove npm tarball after copy

### DIFF
--- a/changelog/issue-8013.md
+++ b/changelog/issue-8013.md
@@ -1,0 +1,3 @@
+level: silent
+reference: issue 8013
+---

--- a/clients/client-web/.gitignore
+++ b/clients/client-web/.gitignore
@@ -40,3 +40,4 @@ node_modules
 # Gitbook docs
 _book
 /.vscode
+*.tgz

--- a/clients/client/.gitignore
+++ b/clients/client/.gitignore
@@ -5,3 +5,4 @@ npm-debug.log
 /taskcluster-client.conf.json
 /taskcluster-client.js
 /user-config.yml
+*.tgz

--- a/infrastructure/tooling/src/build/tasks/release.js
+++ b/infrastructure/tooling/src/build/tasks/release.js
@@ -150,10 +150,9 @@ export default ({ tasks, cmdOptions, credentials, baseDir, logsDir }) => {
 
       // npm pack prints the tarball filename on the last line of stdout
       const tarball = output.trim().split('\n').pop();
-      fs.copyFileSync(
-        path.join(dir, tarball),
-        path.join(artifactsDir, tarball),
-      );
+      const tarballPath = path.join(dir, tarball);
+      fs.copyFileSync(tarballPath, path.join(artifactsDir, tarball));
+      fs.unlinkSync(tarballPath);
 
       return {
         'npm-client-artifact': tarball,
@@ -190,10 +189,9 @@ export default ({ tasks, cmdOptions, credentials, baseDir, logsDir }) => {
 
       // npm pack prints the tarball filename on the last line of stdout
       const tarball = output.trim().split('\n').pop();
-      fs.copyFileSync(
-        path.join(dir, tarball),
-        path.join(artifactsDir, tarball),
-      );
+      const tarballPath = path.join(dir, tarball);
+      fs.copyFileSync(tarballPath, path.join(artifactsDir, tarball));
+      fs.unlinkSync(tarballPath);
 
       return {
         'npm-client-web-artifact': tarball,


### PR DESCRIPTION
Previous release hit:

```bash
[16:56:31] Build client-shell artifacts:   • cleaning distribution directory
[16:56:31] Build client-shell artifacts:   • loading environment variables
[16:56:31] Build client-shell artifacts:   • getting and validating git state
[16:56:32] Build client-shell artifacts:     • git state                                      commit=9137b7080aaae0c72c4c9cb0bda7215dc9e91c30 branch=HEAD current_tag=v99.0.1 previous_tag=v99.0.0 dirty=true
[16:56:32] Build client-shell artifacts:   ⨯ release failed after 1s                         
[16:56:32] Build client-shell artifacts:     error=
[16:56:32] Build client-shell artifacts:     │ git is in a dirty state
[16:56:32] Build client-shell artifacts:     │ Please check in your pipeline what can be changing the following files:
[16:56:32] Build client-shell artifacts:     │ ?? clients/client-web/taskcluster-client-web-99.0.1.tgz
[16:56:32] Build client-shell artifacts:     │ ?? clients/client/taskcluster-client-99.0.1.tgz
[16:56:32] Build client-shell artifacts:     │ Learn more at https://goreleaser.com/errors/dirty
[16:56:40] Build client-shell artifacts: failed
[16:56:40] Build client-shell artifacts: fail: Error: Nonzero exit status 1; 
```