### PR TITLE
Fix blank page on pending/claimed tasks when errors occur

### DIFF
--- a/changelog/7802.md
+++ b/changelog/7802.md
@@ -1,0 +1,7 @@
+level: patch
+audience: users
+reference: issue 7802
+---
+The pending tasks and claimed tasks pages now correctly display errors (such as
+insufficient scopes) instead of showing a blank page when the worker pool is
+also absent from worker-manager.

--- a/ui/src/views/Provisioners/ClaimedTasks/index.jsx
+++ b/ui/src/views/Provisioners/ClaimedTasks/index.jsx
@@ -102,8 +102,13 @@ export default class WMViewClaimedTasks extends Component {
     } = this.props;
     const { provisionerId, workerType } = this.props.match.params;
     // Claimed tasks could exist for the pools that are not managed by w-m
-    // so one of the request would fail with errors
-    const wpMissing = error?.message?.includes('Worker pool does not exist');
+    // so one of the requests would fail with errors; only suppress the error
+    // panel when ALL errors are the expected "Worker pool does not exist" case
+    const wpMissing =
+      error?.graphQLErrors?.length > 0 &&
+      error.graphQLErrors.every(e =>
+        e.message?.includes('Worker pool does not exist')
+      );
 
     return (
       <Dashboard

--- a/ui/src/views/Provisioners/PendingTasks/index.jsx
+++ b/ui/src/views/Provisioners/PendingTasks/index.jsx
@@ -99,8 +99,13 @@ export default class WMViewPendingTasks extends Component {
     } = this.props;
     const { provisionerId, workerType } = this.props.match.params;
     // Pending tasks could exist for the pools that are not managed by w-m
-    // so one of the request would fail with errors
-    const wpMissing = error?.message?.includes('Worker pool does not exist');
+    // so one of the requests would fail with errors; only suppress the error
+    // panel when ALL errors are the expected "Worker pool does not exist" case
+    const wpMissing =
+      error?.graphQLErrors?.length > 0 &&
+      error.graphQLErrors.every(e =>
+        e.message?.includes('Worker pool does not exist')
+      );
 
     return (
       <Dashboard


### PR DESCRIPTION
## Summary

- The pending tasks (and claimed tasks) pages showed a blank page instead of an error when GraphQL returned errors alongside a missing-worker-pool error.
- Root cause: `wpMissing` used `error.message.includes(...)` on the combined error string, which matched even when an unrelated error (e.g. insufficient scopes) was also present — silencing the `ErrorPanel`.
- Fix: check `error.graphQLErrors.every(...)` so the error panel is only suppressed when **all** errors are the expected "Worker pool does not exist" case.

## Test plan

- [ ] Visit a pending tasks page for a provisioner/worker-type where the worker pool does not exist in worker-manager **and** you lack the required scopes — previously blank, now shows the scope error.
- [ ] Visit a pending tasks page where the worker pool simply does not exist in worker-manager but the query succeeds — error panel still suppressed (no regression).
- [ ] Same two scenarios for the claimed tasks page.

Closes #7802