### PR TITLE
Fix invalid curl and tc-cli examples in API reference

### DIFF
--- a/changelog/8198.md
+++ b/changelog/8198.md
@@ -1,0 +1,11 @@
+level: patch
+audience: developers
+reference: issue 8198
+---
+The API reference pages now show correct example commands for curl and the
+taskcluster CLI. The curl examples previously showed an invalid
+`Authorization: Bearer` header (Taskcluster uses Hawk authentication); they
+now explain that taskcluster-proxy should be used instead. The taskcluster CLI
+examples previously showed path arguments as named flags (`--taskId value`)
+when the CLI actually requires positional arguments; they are now shown
+correctly.

--- a/ui/src/utils/api-examples/curl.js
+++ b/ui/src/utils/api-examples/curl.js
@@ -46,10 +46,13 @@ export default function generateCurlExample(
   let example = `# ${entry.title}\n`;
 
   if (requiresAuth(entry)) {
-    example += `# This endpoint requires authentication\n`;
-    example += `# Set your credentials in environment variables:\n`;
-    example += `#   TASKCLUSTER_CLIENT_ID=your-client-id\n`;
-    example += `#   TASKCLUSTER_ACCESS_TOKEN=your-access-token\n\n`;
+    example += `# This endpoint requires Hawk authentication (not Bearer tokens).\n`;
+    example += `# The easiest way to call this with curl is inside a Taskcluster task\n`;
+    example += `# using taskcluster-proxy, which handles auth automatically:\n`;
+    example += `#\n`;
+    example += `#   export TASKCLUSTER_ROOT_URL=$TASKCLUSTER_PROXY_URL\n`;
+    example += `#\n`;
+    example += `# For other environments, use the taskcluster CLI or a language client.\n\n`;
   }
 
   let command = `curl`;
@@ -57,11 +60,6 @@ export default function generateCurlExample(
   // Add method if not GET
   if (method.toUpperCase() !== 'GET') {
     command += ` -X ${method.toUpperCase()}`;
-  }
-
-  // Add headers
-  if (requiresAuth(entry)) {
-    command += ` \\\n  -H "Authorization: Bearer \${TASKCLUSTER_ACCESS_TOKEN}"`;
   }
 
   // Add request body for methods that typically have one

--- a/ui/src/utils/api-examples/shell.js
+++ b/ui/src/utils/api-examples/shell.js
@@ -40,11 +40,11 @@ export default function generateShellExample(
   // Build base command
   let command = `taskcluster api ${serviceName} ${methodName}`;
 
-  // Add path parameters
+  // Add path parameters (positional, not named flags)
   entry.args.forEach(arg => {
     const placeholder = getPlaceholderValue(arg);
 
-    command += ` --${arg} "${placeholder}"`;
+    command += ` "${placeholder}"`;
   });
 
   // Add query parameters if present
@@ -62,7 +62,7 @@ export default function generateShellExample(
       inputPayload = formatPayloadJson(payloadExample, 0);
     }
 
-    command += ` \\\n  --input - <<'EOF'\n${inputPayload}\nEOF`;
+    command += ` <<'EOF'\n${inputPayload}\nEOF`;
   }
 
   // Build output formatting hint


### PR DESCRIPTION
## Summary

- The curl examples in the API reference were showing `Authorization: Bearer` headers, which is not valid for Taskcluster (Taskcluster uses Hawk authentication). The examples now explain that `taskcluster-proxy` should be used instead.
- The `taskcluster` CLI examples were showing path arguments as named flags (e.g. `--taskId "value"`) when the CLI actually requires positional arguments. The examples now use the correct positional syntax.
- The CLI examples also used `--input -` for stdin body input, but no such flag exists; the CLI reads from stdin directly. This is now corrected.

## Test plan

- [ ] Visit an API reference page for an authenticated endpoint, check the curl tab — should no longer show `Authorization: Bearer`, instead shows taskcluster-proxy guidance
- [ ] Visit an API reference page for an endpoint with path parameters (e.g. queue's `task`), check the Shell tab — should show positional args (e.g. `taskcluster api queue task "dSlITZ4yQgmvxxAi4A8fHQ"`) not named flags
- [ ] For an endpoint with a request body, the shell example should use `<<'EOF'` redirection without `--input -`

Fixes: #8198