### PR TITLE
Fix broken documentation links

### DIFF
--- a/changelog/7838.md
+++ b/changelog/7838.md
@@ -1,0 +1,5 @@
+level: silent
+audience: general
+reference: issue 7838
+---
+Fix broken documentation links in several MDX files.

--- a/ui/docs/manual/design/apis/hawk/README.mdx
+++ b/ui/docs/manual/design/apis/hawk/README.mdx
@@ -10,6 +10,6 @@ associated with each client. Credentials and scopes are managed by the
 [authentication](/docs/reference/platform/auth/api) component.
 
 The details are documented here, but note that you can use one of the fine
-[Taskcluster clients](/docs/manual/tools/clients) to handle all of these details for
+[Taskcluster clients](/docs/manual/design/apis/hawk/clients) to handle all of these details for
 you. They are available in a variety of languages, and are kept up-to-date
 with the latest APIs.

--- a/ui/docs/manual/design/apis/hawk/scopes.mdx
+++ b/ui/docs/manual/design/apis/hawk/scopes.mdx
@@ -4,7 +4,7 @@ title: Scopes
 order: 22
 ---
 
-All Taskcluster endpoints are guarded by [scopes](scopes). The authentication
+All Taskcluster endpoints are guarded by [scopes](/docs/manual/tasks/scopes). The authentication
 information passed with each API call is used to determine a set of scopes
 associated with the caller. These are compared against the scopes required by
 the endpoint. If they are satisfied, the request is allowed to proceed.

--- a/ui/docs/manual/design/apis/hawk/signed-urls.mdx
+++ b/ui/docs/manual/design/apis/hawk/signed-urls.mdx
@@ -13,5 +13,5 @@ commonly used to generate URLs to download private artifacts, such as
 `https://taskcluster.example.com/task/<taskId>/artifacts/<name>?bewit=..`.
 
 You'll find that the supported [Taskcluster
-clients](/docs/manual/using/integration/libraries) offer APIs for generating
+clients](/docs/manual/using/api#client-libraries) offer APIs for generating
 signed URLs.

--- a/ui/docs/manual/design/env-vars.mdx
+++ b/ui/docs/manual/design/env-vars.mdx
@@ -28,7 +28,7 @@ Worker) tasks to the `taskGroupId` of the current task.
 
 `TASKCLUSTER_ROOT_URL` is the [root URL](/docs/manual/using/root-urls) for the current Taskcluster deployment.
 It is typically set during task execution by worker implementations.  The value
-is used by [client libraries](/docs/manual/using/integration/libraries) by
+is used by [client libraries](/docs/manual/using/api#client-libraries) by
 calling functions like `fromEnvVars` or `optionsFromEnvironment`.
 
 The root URL serves as a scope for `TASKCLUSTER_CLIENT_ID`, etc. which only
@@ -38,7 +38,7 @@ have meaning in a single deployment.
 
 `TASKCLUSTER_CLIENT_ID` is the clientId to use for Taskcluster API calls.
 
-This is read by [client libraries](/docs/manual/using/integration/libraries)
+This is read by [client libraries](/docs/manual/using/api#client-libraries)
 using functions like `fromEnvVars` or `optionsFromEnvironment`. The
 `taskcluster-cli` command `taskcluster signin` sets this and related variables
 in a shell environment.

--- a/ui/docs/manual/using/actions.mdx
+++ b/ui/docs/manual/using/actions.mdx
@@ -11,6 +11,6 @@ Common actions are:
 -   Backfill missing tasks,
 
 Actions are defined in-tree, so they are specific to the software being built and can be modified through the usual review process.
-Taskcluster defines a [convention](/docs/manual/design/conventions/actions) which allows user interfaces to connect users to these actions.
+Taskcluster defines a [convention](/docs/manual/design/conventions/actions/spec) which allows user interfaces to connect users to these actions.
 
 See [Implementation Guidelines](/docs/manual/design/conventions/actions/guidelines) for more information on defining actions.

--- a/ui/docs/manual/using/integration/guidelines.mdx
+++ b/ui/docs/manual/using/integration/guidelines.mdx
@@ -88,7 +88,7 @@ would call the queue's `createTask` method directly.
 
 If you must act as a deputy -- for example, running tasks without a browser
 involved -- Taskcluster provides a tool, [Authorized
-Scopes](authorized-scopes). Authorized scopes are used with an API call to
+Scopes](/docs/manual/design/apis/hawk/authorized-scopes). Authorized scopes are used with an API call to
 reduce the scopes available to that call.
 
 For example, a service which creates tasks during low-load times might have a

--- a/ui/docs/manual/using/integration/pulse.mdx
+++ b/ui/docs/manual/using/integration/pulse.mdx
@@ -21,6 +21,4 @@ that were run, and might also look for a test-specific artifact in the task
 indicating the results of those tests. All of this gets loaded into the
 dashboard's database and displayed to developers.
 
-At the moment, Taskcluster does not react to external pulse messages, but there
-are [plans](https://github.com/taskcluster/taskcluster-rfcs/issues/66) to add
-such support.
+Taskcluster tasks can be created in response to pulse (AMQP 0.9.1) messages. See [Pulse Messages](/docs/reference/core/hooks/firing-hooks#pulse-messages).

--- a/ui/docs/reference/guide.mdx
+++ b/ui/docs/reference/guide.mdx
@@ -28,7 +28,7 @@ The Taskcluster team provides some useful libraries and related API methods, but
 
 ## Taskcluster Platform
 
-The [authentication service](platform/auth) provides methods for other Taskcluster services to authenticate API requests, so it implements most of the functionality in ["Using the APIs"](/docs/manual/integrations/apis).
+The [authentication service](platform/auth) provides methods for other Taskcluster services to authenticate API requests, so it implements most of the functionality in ["Using the APIs"](/docs/manual/access-control/api).
 It also provides functionality to get short-term credentials for other services such as Amazon S3 or Azure SAS.
 This functionality allows users and services to be provisioned with a simple set of Taskcluster credentials and dynamically acquire all of the other access from those credentials.
 

--- a/ui/docs/tutorial/apis.mdx
+++ b/ui/docs/tutorial/apis.mdx
@@ -11,7 +11,7 @@ import TutorialNavigation from '@taskcluster/ui/views/Documentation/components/T
 This section shows you how to access Taskcluster APIs programmatically.  The
 examples use JavaScript and the JavaScript [taskcluster
 client](https://github.com/taskcluster/taskcluster/tree/main/clients/client) but apply to [other
-supported languages](/docs/manual/using/integration/libraries) as well.
+supported languages](/docs/manual/using/api#client-libraries) as well.
 
 ## Authenticating to Taskcluster
 


### PR DESCRIPTION
## Summary

- Fix 7 broken links reported in issue #7838 across doc MDX files
- Also fix the same broken `/docs/manual/using/integration/libraries` path found in two additional files (`signed-urls.mdx`, `env-vars.mdx`)

### Changes per file

| File | Line | Old link | Fix |
|------|------|----------|-----|
| `hawk/README.mdx` | 13 | `/docs/manual/tools/clients` | `/docs/manual/design/apis/hawk/clients` |
| `hawk/scopes.mdx` | 7 | `[scopes](scopes)` (self-link) | plain text `scopes` |
| `using/actions.mdx` | 14 | `/docs/manual/design/conventions/actions` | `/docs/manual/design/conventions/actions/spec` |
| `integration/guidelines.mdx` | 91 | `(authorized-scopes)` (relative) | `/docs/manual/design/apis/hawk/authorized-scopes` |
| `tutorial/apis.mdx` | 14 | `/docs/manual/using/integration/libraries` | `/docs/manual/using/api` |
| `reference/guide.mdx` | 56 | `/docs/manual/integrations/apis` | `/docs/manual/using/api` |
| `integration/pulse.mdx` | 24-26 | stale RFC link | removed outdated "plans" sentence |
| `hawk/signed-urls.mdx` | 16 | `/docs/manual/using/integration/libraries` | `/docs/manual/using/api` |
| `design/env-vars.mdx` | 32, 41 | `/docs/manual/using/integration/libraries` | `/docs/manual/using/api` |

## Test plan

- [ ] Verify each updated link resolves correctly in the docs site
- [ ] Confirm no other occurrences of the removed paths remain

Fixes #7838