### PR TITLE
fix(worker-manager): scanner scanPrepare/scanCleanup isolation

### DIFF
--- a/changelog/issue-8470.md
+++ b/changelog/issue-8470.md
@@ -1,0 +1,5 @@
+audience: deployers
+level: patch
+reference: issue 8470
+---
+Worker Manager: fix a race condition where concurrent worker scanners could reset each other's tracking state via scanPrepare, causing a TypeError in the Azure provider's checkWorker. Each scanner now only calls scanPrepare/scanCleanup on the providers it is responsible for.

--- a/services/worker-manager/src/worker-scanner.js
+++ b/services/worker-manager/src/worker-scanner.js
@@ -23,6 +23,10 @@ export class WorkerScanner {
     this.providers = providers;
     this.monitor = monitor;
     this.providersFilter = providersFilter;
+    this._filteredProviderIds = new Set(
+      (providersFilter.value || '').split(',').filter(Boolean),
+    );
+    this._filterIsInclusive = providersFilter.cond === '=';
     this.estimator = estimator;
     this.iterate = new Iterate({
       maxFailures: 10,
@@ -51,8 +55,13 @@ export class WorkerScanner {
     await this.iterate.stop();
   }
 
+  #ownsProvider(provider) {
+    const match = this._filteredProviderIds.has(provider.providerId);
+    return this._filterIsInclusive ? match : !match;
+  }
+
   async scan() {
-    await this.providers.forAll(p => p.scanPrepare());
+    await this.providers.forAll(p => this.#ownsProvider(p) && p.scanPrepare());
 
     this.monitor.info(`WorkerScanner providers filter: ${this.providersFilter.cond} ${this.providersFilter.value}`);
 
@@ -106,7 +115,7 @@ export class WorkerScanner {
       }
     }
 
-    await this.providers.forAll(p => p.scanCleanup());
+    await this.providers.forAll(p => this.#ownsProvider(p) && p.scanCleanup());
 
     // Phase 2: Compute termination decisions
     await this.#computeTerminationDecisions(poolCandidates);

--- a/services/worker-manager/test/worker_scanner_test.js
+++ b/services/worker-manager/test/worker_scanner_test.js
@@ -246,6 +246,48 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
     },
   }));
 
+  test('scanPrepare and scanCleanup only run for providers matching the filter', async function() {
+    const { WorkerScanner } = await import('../src/worker-scanner.js');
+    const providers = await helper.load('providers');
+    const estimator = await helper.load('estimator');
+
+    // Create a scanner that only handles testing1 (like the azure-only scanner in production)
+    const filteredScanner = new WorkerScanner({
+      ownName: 'filtered-scanner',
+      providers,
+      monitor,
+      db: helper.db,
+      providersFilter: { cond: '=', value: 'testing1' },
+      estimator,
+    });
+
+    monitor.manager.reset();
+    await filteredScanner.scan();
+
+    // scanPrepare should have been called for testing1
+    const prepareMessages = monitor.manager.messages.filter(msg => msg.Type === 'scan-prepare');
+    const cleanupMessages = monitor.manager.messages.filter(msg => msg.Type === 'scan-cleanup');
+
+    assert(
+      prepareMessages.some(msg => msg.Logger.endsWith('testing1')),
+      'scanPrepare should be called for testing1',
+    );
+    assert(
+      cleanupMessages.some(msg => msg.Logger.endsWith('testing1')),
+      'scanCleanup should be called for testing1',
+    );
+
+    // scanPrepare should NOT have been called for testing2
+    assert(
+      !prepareMessages.some(msg => msg.Logger.endsWith('testing2')),
+      'scanPrepare should NOT be called for testing2',
+    );
+    assert(
+      !cleanupMessages.some(msg => msg.Logger.endsWith('testing2')),
+      'scanCleanup should NOT be called for testing2',
+    );
+  });
+
   test('default providers filter applied', async () => {
     const azureScanner = await helper.load('workerScannerAzure');
     assert.deepEqual(azureScanner.providersFilter, { cond: '=', value: 'azure' });


### PR DESCRIPTION
Fixes #8470.

>Worker Manager: fix a race condition where concurrent worker scanners could reset each other's tracking state via scanPrepare, causing a TypeError in the Azure provider's checkWorker. Each scanner now only calls scanPrepare/scanCleanup on the providers it is responsible for.