### PR TITLE
feat(w-m): Worker scanner loop fixes

### DIFF
--- a/changelog/fix-azure-undefined-issue.md
+++ b/changelog/fix-azure-undefined-issue.md
@@ -1,4 +1,5 @@
 audience: deployers
 level: patch
+reference: issue 8470
 ---
 The worker-manager scanner now guards against overlapping scan loops and adds a per-worker timeout to `checkWorker` calls. Previously, when a scan exceeded `maxIterationTime` (common with large Azure worker pools), `lib-iterate` would start a new iteration while the old one was still running, resetting shared state and causing crashes in provider `checkWorker` methods. The scanner now detects loop overlap to prevent silent state corruption, and times out individual `checkWorker` calls after 60 seconds so a single hung cloud API call cannot abort the entire scan.

--- a/changelog/fix-azure-undefined-issue.md
+++ b/changelog/fix-azure-undefined-issue.md
@@ -1,0 +1,4 @@
+audience: deployers
+level: patch
+---
+The worker-manager scanner now guards against overlapping scan loops and adds a per-worker timeout to `checkWorker` calls. Previously, when a scan exceeded `maxIterationTime` (common with large Azure worker pools), `lib-iterate` would start a new iteration while the old one was still running, resetting shared state and causing crashes in provider `checkWorker` methods. The scanner now detects loop overlap to prevent silent state corruption, and times out individual `checkWorker` calls after 60 seconds so a single hung cloud API call cannot abort the entire scan.

--- a/services/worker-manager/src/providers/azure/index.js
+++ b/services/worker-manager/src/providers/azure/index.js
@@ -139,7 +139,7 @@ export class AzureProvider extends Provider {
       apiRateLimits,
       intervalDefault: 100 * 1000, // Intervals are enforced every 100 seconds
       intervalCapDefault: 2000, // The calls we make are all limited 20/sec so 20 * 100 are allowed
-      timeout: 10 * 60 * 1000, // each cloud call should not take longer than 10 minutes
+      timeout: 3 * 60 * 1000, // each cloud call should not take longer than 3 minutes
       throwOnTimeout: true,
       monitor: this.monitor,
       providerId: this.providerId,
@@ -267,31 +267,46 @@ export class AzureProvider extends Provider {
   }
 
   /**
-   * Ensure that a resource group exists, creating it if necessary
-   * Uses in-memory cache to avoid redundant API calls
+   * Ensure that a resource group exists, creating it if necessary.
+   * Concurrent callers for the same resource group coalesce behind a single
+   * in-flight promise so only one check/create cycle runs at a time.
+   * On failure the cache entry is evicted so the next attempt retries.
    *
    * @param {string} resourceGroupName
    * @param {string} location
    * @param {string} workerPoolId
    */
   async #ensureResourceGroup(resourceGroupName, location, workerPoolId) {
-    if (this.resourceGroupCache.has(resourceGroupName)) {
-      return;
+    const runEnsureRG = async () => {
+      const { body: exists } = await this._enqueue('query', () =>
+        this.resourcesClient.resourceGroups.checkExistence(resourceGroupName));
+
+      if (!exists) {
+        await this._enqueue('query', () =>
+          this.resourcesClient.resourceGroups.createOrUpdate(resourceGroupName, { location }));
+
+        this.monitor.log.azureResourceGroupEnsured({
+          workerPoolId, resourceGroupName, location,
+        });
+      }
+
+      return true;
+    };
+
+    let pending = this.resourceGroupCache.get(resourceGroupName);
+    if (!pending) {
+      pending = Promise.resolve().then(runEnsureRG);
+      this.resourceGroupCache.set(resourceGroupName, pending);
     }
 
-    const { body: exists } = await this._enqueue('query', () =>
-      this.resourcesClient.resourceGroups.checkExistence(resourceGroupName));
-
-    if (!exists) {
-      await this._enqueue('query', () =>
-        this.resourcesClient.resourceGroups.createOrUpdate(resourceGroupName, { location }));
-
-      this.monitor.log.azureResourceGroupEnsured({
-        workerPoolId, resourceGroupName, location,
-      });
+    try {
+      return await pending;
+    } catch (err) {
+      if (this.resourceGroupCache.get(resourceGroupName) === pending) {
+        this.resourceGroupCache.delete(resourceGroupName);
+      }
+      throw err;
     }
-
-    this.resourceGroupCache.set(resourceGroupName, true);
   }
 
   /** @param {ProvisionOptions} opts */

--- a/services/worker-manager/src/util.js
+++ b/services/worker-manager/src/util.js
@@ -82,3 +82,18 @@ export const measureTime = (precision = 1e6) => {
   const start = hrtime.bigint();
   return () => Number(hrtime.bigint() - start) / precision;
 };
+
+/**
+ * Run a promise with a timeout. If the promise does not settle
+ * within `ms` milliseconds, the returned promise rejects with `message`.
+ * The timer is always cleaned up to avoid leaks.
+ */
+export const withTimeout = (promise, ms, message) => {
+  let timer;
+  return Promise.race([
+    promise,
+    new Promise((_, reject) => {
+      timer = setTimeout(() => reject(new Error(message)), ms);
+    }),
+  ]).finally(() => clearTimeout(timer));
+};

--- a/services/worker-manager/src/worker-scanner.js
+++ b/services/worker-manager/src/worker-scanner.js
@@ -3,6 +3,7 @@ import Iterate from '@taskcluster/lib-iterate';
 import taskcluster from '@taskcluster/client';
 import { paginatedIterator } from '@taskcluster/lib-postgres';
 import { Worker, WorkerPool } from './data.js';
+import { withTimeout } from './util.js';
 
 /**
  * Make sure that we visit each worker relatively frequently to update its state
@@ -24,6 +25,7 @@ export class WorkerScanner {
     this.monitor = monitor;
     this.providersFilter = providersFilter;
     this.estimator = estimator;
+    this.scanLoopAlive = false;
     this.iterate = new Iterate({
       maxFailures: 10,
       watchdogTime: 0,
@@ -52,6 +54,19 @@ export class WorkerScanner {
   }
 
   async scan() {
+    if (this.scanLoopAlive) {
+      this.monitor.alert('scan-loop-interference', {});
+      throw new Error('scan loop interference');
+    }
+    this.scanLoopAlive = true;
+    try {
+      await this._scanImpl();
+    } finally {
+      this.scanLoopAlive = false;
+    }
+  }
+
+  async _scanImpl() {
     await this.providers.forAll(p => p.scanPrepare());
 
     this.monitor.info(`WorkerScanner providers filter: ${this.providersFilter.cond} ${this.providersFilter.value}`);
@@ -72,7 +87,11 @@ export class WorkerScanner {
           continue;
         }
         try {
-          await provider.checkWorker({ worker });
+          await withTimeout(
+            provider.checkWorker({ worker }),
+            60_000, // 1 minute
+            `checkWorker timed out for ${worker.workerPoolId}/${worker.workerId}`,
+          );
         } catch (err) {
           this.monitor.reportError(err); // Just report it and move on so this doesn't block other providers
         }
@@ -104,6 +123,7 @@ export class WorkerScanner {
           poolCandidates.get(poolId).push(worker);
         }
       }
+
     }
 
     await this.providers.forAll(p => p.scanCleanup());

--- a/services/worker-manager/test/provider_azure_test.js
+++ b/services/worker-manager/test/provider_azure_test.js
@@ -1155,6 +1155,110 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       checkExistenceSpy.restore();
       createOrUpdateSpy.restore();
     });
+
+    test('evicts cache and retries after checkExistence failure', async function() {
+      const customRgName = 'test-failing-rg';
+      const launchConfig = {
+        armDeploymentResourceGroup: customRgName,
+        armDeployment: {
+          mode: 'Incremental',
+          templateLink: {
+            id: '/subscriptions/test/resourceGroups/test/providers/Microsoft.Resources/templateSpecs/test/versions/1.0.0',
+          },
+          parameters: { location: { value: 'eastus' } },
+        },
+      };
+
+      // Create the pool once; call provision() separately each time
+      const workerPool = await makeWorkerPool({
+        config: {
+          minCapacity: 1,
+          maxCapacity: 1,
+          scalingRatio: 1,
+          launchConfigs: [{
+            workerManager: { capacityPerInstance: 1 },
+            subnetId: 'some/subnet',
+            location: 'westus',
+            hardwareProfile: { vmSize: 'Basic_A2' },
+            storageProfile: { osDisk: {} },
+            ...launchConfig,
+          }],
+        },
+      });
+
+      const checkStub = sinon.stub(fake.resourcesClient.resourceGroups, 'checkExistence');
+      checkStub.onFirstCall().rejects(new Error('Azure transient failure'));
+      checkStub.onSecondCall().resolves({ body: false });
+
+      const createSpy = sinon.spy(fake.resourcesClient.resourceGroups, 'createOrUpdate');
+
+      // First attempt should fail
+      await assert.rejects(
+        () => provider.provision({ workerPool, workerPoolStats: new WorkerPoolStats('wpid') }),
+        /Azure transient failure/,
+      );
+      assert.ok(!provider.resourceGroupCache.has(customRgName),
+        'cache entry should be evicted after failure');
+
+      // Second attempt should succeed (cache was cleared)
+      await provider.provision({ workerPool, workerPoolStats: new WorkerPoolStats('wpid') });
+
+      assert.equal(checkStub.callCount, 2, 'should retry checkExistence after cache eviction');
+      assert.equal(createSpy.callCount, 1, 'should create RG on successful retry');
+
+      checkStub.restore();
+      createSpy.restore();
+    });
+
+    test('second provision reuses cached promise without new API calls', async function() {
+      const customRgName = 'test-cached-rg';
+      const launchConfig = {
+        armDeploymentResourceGroup: customRgName,
+        armDeployment: {
+          mode: 'Incremental',
+          templateLink: {
+            id: '/subscriptions/test/resourceGroups/test/providers/Microsoft.Resources/templateSpecs/test/versions/1.0.0',
+          },
+          parameters: { location: { value: 'eastus' } },
+        },
+      };
+
+      const workerPool = await makeWorkerPool({
+        config: {
+          minCapacity: 1,
+          maxCapacity: 1,
+          scalingRatio: 1,
+          launchConfigs: [{
+            workerManager: { capacityPerInstance: 1 },
+            subnetId: 'some/subnet',
+            location: 'westus',
+            hardwareProfile: { vmSize: 'Basic_A2' },
+            storageProfile: { osDisk: {} },
+            ...launchConfig,
+          }],
+        },
+      });
+
+      await provider.provision({ workerPool, workerPoolStats: new WorkerPoolStats('wpid') });
+
+      // Cache should now hold a resolved promise
+      assert.ok(provider.resourceGroupCache.has(customRgName),
+        'cache should have entry after successful provisioning');
+      assert.ok(provider.resourceGroupCache.get(customRgName) instanceof Promise,
+        'cache entry should be a promise');
+
+      // Spy after the first call so we can verify the second makes no API calls
+      const checkSpy = sinon.spy(fake.resourcesClient.resourceGroups, 'checkExistence');
+      const createSpy = sinon.spy(fake.resourcesClient.resourceGroups, 'createOrUpdate');
+
+      await provider.provision({ workerPool, workerPoolStats: new WorkerPoolStats('wpid') });
+
+      assert.equal(checkSpy.callCount, 0, 'should not call checkExistence when promise is cached');
+      assert.equal(createSpy.callCount, 0, 'should not call createOrUpdate when promise is cached');
+
+      checkSpy.restore();
+      createSpy.restore();
+    });
   });
 
   suite('provisionResources', function() {

--- a/services/worker-manager/test/worker_scanner_test.js
+++ b/services/worker-manager/test/worker_scanner_test.js
@@ -256,6 +256,35 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
     await scanner.terminate();
   });
 
+  test('scan loop is not running in parallel', async function() {
+    const providers = await helper.load('providers');
+    const estimator = await helper.load('estimator');
+    const scanner = new (await import('../src/worker-scanner.js')).WorkerScanner({
+      ownName: 'test-overlap',
+      providers,
+      monitor,
+      db: helper.db,
+      providersFilter: { cond: '<>', value: '' },
+      estimator,
+    });
+
+    await assert.rejects(async () => {
+      await Promise.all([
+        scanner.scan(),
+        scanner.scan(),
+      ]);
+    }, /scan loop interference/);
+
+    assert.deepEqual(
+      monitor.manager.messages.find(msg => msg.Type === 'scan-loop-interference'), {
+        Fields: {},
+        Logger: 'taskcluster.test',
+        Severity: 1,
+        Type: 'scan-loop-interference',
+      });
+    monitor.manager.reset();
+  });
+
   suite('termination decisions', function() {
     let scanner, providers, estimator;
 


### PR DESCRIPTION
- Prevents concurrent scan loops - detect running loop
- Limits Azure call timeout to 1min (p95 calls showed ~35s calls)
- Mark RG as existing early to prevent multiple creation attempts
- `checkWorker` is wrapped with timeout to not take longer than 1min

