### PR TITLE
build(deps): bump json-e from v4.8.0 to v4.8.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "immutable": "^4.3.8",
     "iterall": "^1.2.2",
     "js-yaml": "^4.1.1",
-    "json-e": "^4.8.0",
+    "json-e": "^4.8.2",
     "json-parameterization": "^2.0.1",
     "jsonwebtoken": "^9.0.0",
     "jwks-rsa": "^2.1.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10448,12 +10448,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"json-e@npm:^4.8.0":
-  version: 4.8.0
-  resolution: "json-e@npm:4.8.0"
+"json-e@npm:^4.8.2":
+  version: 4.8.2
+  resolution: "json-e@npm:4.8.2"
   dependencies:
     json-stable-stringify-without-jsonify: "npm:^1.0.1"
-  checksum: 10c0/650e686c5a6e05cbe73239780c8ee87e085cfe48f0d2167da47ce116975f22b297f76c55d385cd347e895ea68d895e1e8b6ce1558937e98882098e16af1a89e9
+  checksum: 10c0/ecbd655cb800c4e5907548014807ee11a6074fc10b645fd477ce821110dd2d038339f7b192605b8855edf82fb66057c30b1859a87453b1a0112e39c3401fc2a1
   languageName: node
   linkType: hard
 
@@ -14474,7 +14474,7 @@ __metadata:
     is-uuid: "npm:^1.0.2"
     iterall: "npm:^1.2.2"
     js-yaml: "npm:^4.1.1"
-    json-e: "npm:^4.8.0"
+    json-e: "npm:^4.8.2"
     json-parameterization: "npm:^2.0.1"
     json-stable-stringify: "npm:^1.3.0"
     jsonwebtoken: "npm:^9.0.0"


### PR DESCRIPTION
This specifically is to pick up:
https://github.com/json-e/json-e/commit/c764fe6a7eb3828253a5b9bea6254a14acb90b8d

Which caused:
https://github.com/taskcluster/taskgraph/commit/2afefff7b52b9a8fecf4c50db6276732428dbbca#commitcomment-181954809

I'm surprised by two things though:

1. That we haven't hit this error before in fxci
2. That dependabot / renovate hasn't updated this dep yet given `packages.json` wasn't precluding it...

Is there a bug in the dependency auto-updating config?
