### PR TITLE
feat(infra): Expose duration metrics for peridodic tasks

### DIFF
--- a/changelog/issue-8502.md
+++ b/changelog/issue-8502.md
@@ -1,0 +1,12 @@
+audience: deployers
+level: minor
+reference: issue 8502
+---
+A new Prometheus histogram metric `iterate_duration_seconds` is now emitted by
+all background iteration loops (provisioner, worker-scanner, queue resolvers,
+etc.) via `lib-iterate`.
+
+The metric is registered as a global builtin, meaning it automatically
+propagates to whichever Prometheus registry a process exposes — no per-service
+configuration is required. It is a no-op in deployments without Prometheus
+configured.

--- a/generated/references.json
+++ b/generated/references.json
@@ -18010,6 +18010,33 @@
           "type": "counter"
         },
         {
+          "buckets": [
+            1,
+            5,
+            10,
+            30,
+            60,
+            120,
+            300,
+            600,
+            1200,
+            1800,
+            3600,
+            6000
+          ],
+          "description": "Duration of a single background iteration loop",
+          "labels": {
+            "name": "Name of the iterate loop",
+            "status": "Result: success or exception"
+          },
+          "name": "iterate_duration_seconds",
+          "registers": [
+            "default"
+          ],
+          "title": "Background iteration duration",
+          "type": "histogram"
+        },
+        {
           "description": "This number represents difference in pending tasks and idle capacity.\nAdjustment is needed to make sure workers that are still running and are currently\nnot doing any work, will soon pick up those tasks, so we don't need additional workers for those.\nAssumption is that those idling workers would pick up tasks soon.",
           "labels": {
             "providerId": "ID of the provider",
@@ -19947,6 +19974,33 @@
           ],
           "title": "Total number of HTTP requests",
           "type": "counter"
+        },
+        {
+          "buckets": [
+            1,
+            5,
+            10,
+            30,
+            60,
+            120,
+            300,
+            600,
+            1200,
+            1800,
+            3600,
+            6000
+          ],
+          "description": "Duration of a single background iteration loop",
+          "labels": {
+            "name": "Name of the iterate loop",
+            "status": "Result: success or exception"
+          },
+          "name": "iterate_duration_seconds",
+          "registers": [
+            "default"
+          ],
+          "title": "Background iteration duration",
+          "type": "histogram"
         }
       ],
       "serviceName": "web-server"
@@ -20377,6 +20431,33 @@
           ],
           "title": "Total number of HTTP requests",
           "type": "counter"
+        },
+        {
+          "buckets": [
+            1,
+            5,
+            10,
+            30,
+            60,
+            120,
+            300,
+            600,
+            1200,
+            1800,
+            3600,
+            6000
+          ],
+          "description": "Duration of a single background iteration loop",
+          "labels": {
+            "name": "Name of the iterate loop",
+            "status": "Result: success or exception"
+          },
+          "name": "iterate_duration_seconds",
+          "registers": [
+            "default"
+          ],
+          "title": "Background iteration duration",
+          "type": "histogram"
         }
       ],
       "serviceName": "secrets"
@@ -20766,6 +20847,33 @@
           ],
           "title": "Total number of HTTP requests",
           "type": "counter"
+        },
+        {
+          "buckets": [
+            1,
+            5,
+            10,
+            30,
+            60,
+            120,
+            300,
+            600,
+            1200,
+            1800,
+            3600,
+            6000
+          ],
+          "description": "Duration of a single background iteration loop",
+          "labels": {
+            "name": "Name of the iterate loop",
+            "status": "Result: success or exception"
+          },
+          "name": "iterate_duration_seconds",
+          "registers": [
+            "default"
+          ],
+          "title": "Background iteration duration",
+          "type": "histogram"
         },
         {
           "description": "Total number of claimed tasks",
@@ -23151,6 +23259,33 @@
           ],
           "title": "Total number of HTTP requests",
           "type": "counter"
+        },
+        {
+          "buckets": [
+            1,
+            5,
+            10,
+            30,
+            60,
+            120,
+            300,
+            600,
+            1200,
+            1800,
+            3600,
+            6000
+          ],
+          "description": "Duration of a single background iteration loop",
+          "labels": {
+            "name": "Name of the iterate loop",
+            "status": "Result: success or exception"
+          },
+          "name": "iterate_duration_seconds",
+          "registers": [
+            "default"
+          ],
+          "title": "Background iteration duration",
+          "type": "histogram"
         }
       ],
       "serviceName": "purge-cache"
@@ -23525,6 +23660,33 @@
           ],
           "title": "Total number of HTTP requests",
           "type": "counter"
+        },
+        {
+          "buckets": [
+            1,
+            5,
+            10,
+            30,
+            60,
+            120,
+            300,
+            600,
+            1200,
+            1800,
+            3600,
+            6000
+          ],
+          "description": "Duration of a single background iteration loop",
+          "labels": {
+            "name": "Name of the iterate loop",
+            "status": "Result: success or exception"
+          },
+          "name": "iterate_duration_seconds",
+          "registers": [
+            "default"
+          ],
+          "title": "Background iteration duration",
+          "type": "histogram"
         }
       ],
       "serviceName": "object"
@@ -23932,6 +24094,33 @@
           ],
           "title": "Total number of HTTP requests",
           "type": "counter"
+        },
+        {
+          "buckets": [
+            1,
+            5,
+            10,
+            30,
+            60,
+            120,
+            300,
+            600,
+            1200,
+            1800,
+            3600,
+            6000
+          ],
+          "description": "Duration of a single background iteration loop",
+          "labels": {
+            "name": "Name of the iterate loop",
+            "status": "Result: success or exception"
+          },
+          "name": "iterate_duration_seconds",
+          "registers": [
+            "default"
+          ],
+          "title": "Background iteration duration",
+          "type": "histogram"
         }
       ],
       "serviceName": "notify"
@@ -24551,6 +24740,33 @@
           ],
           "title": "Total number of HTTP requests",
           "type": "counter"
+        },
+        {
+          "buckets": [
+            1,
+            5,
+            10,
+            30,
+            60,
+            120,
+            300,
+            600,
+            1200,
+            1800,
+            3600,
+            6000
+          ],
+          "description": "Duration of a single background iteration loop",
+          "labels": {
+            "name": "Name of the iterate loop",
+            "status": "Result: success or exception"
+          },
+          "name": "iterate_duration_seconds",
+          "registers": [
+            "default"
+          ],
+          "title": "Background iteration duration",
+          "type": "histogram"
         }
       ],
       "serviceName": "index"
@@ -25037,6 +25253,33 @@
           ],
           "title": "Total number of HTTP requests",
           "type": "counter"
+        },
+        {
+          "buckets": [
+            1,
+            5,
+            10,
+            30,
+            60,
+            120,
+            300,
+            600,
+            1200,
+            1800,
+            3600,
+            6000
+          ],
+          "description": "Duration of a single background iteration loop",
+          "labels": {
+            "name": "Name of the iterate loop",
+            "status": "Result: success or exception"
+          },
+          "name": "iterate_duration_seconds",
+          "registers": [
+            "default"
+          ],
+          "title": "Background iteration duration",
+          "type": "histogram"
         }
       ],
       "serviceName": "hooks"
@@ -25694,6 +25937,33 @@
           ],
           "title": "Total number of HTTP requests",
           "type": "counter"
+        },
+        {
+          "buckets": [
+            1,
+            5,
+            10,
+            30,
+            60,
+            120,
+            300,
+            600,
+            1200,
+            1800,
+            3600,
+            6000
+          ],
+          "description": "Duration of a single background iteration loop",
+          "labels": {
+            "name": "Name of the iterate loop",
+            "status": "Result: success or exception"
+          },
+          "name": "iterate_duration_seconds",
+          "registers": [
+            "default"
+          ],
+          "title": "Background iteration duration",
+          "type": "histogram"
         }
       ],
       "serviceName": "github"
@@ -26406,6 +26676,33 @@
           ],
           "title": "Total number of HTTP requests",
           "type": "counter"
+        },
+        {
+          "buckets": [
+            1,
+            5,
+            10,
+            30,
+            60,
+            120,
+            300,
+            600,
+            1200,
+            1800,
+            3600,
+            6000
+          ],
+          "description": "Duration of a single background iteration loop",
+          "labels": {
+            "name": "Name of the iterate loop",
+            "status": "Result: success or exception"
+          },
+          "name": "iterate_duration_seconds",
+          "registers": [
+            "default"
+          ],
+          "title": "Background iteration duration",
+          "type": "histogram"
         }
       ],
       "serviceName": "built-in-workers"
@@ -26637,6 +26934,33 @@
           ],
           "title": "Total number of HTTP requests",
           "type": "counter"
+        },
+        {
+          "buckets": [
+            1,
+            5,
+            10,
+            30,
+            60,
+            120,
+            300,
+            600,
+            1200,
+            1800,
+            3600,
+            6000
+          ],
+          "description": "Duration of a single background iteration loop",
+          "labels": {
+            "name": "Name of the iterate loop",
+            "status": "Result: success or exception"
+          },
+          "name": "iterate_duration_seconds",
+          "registers": [
+            "default"
+          ],
+          "title": "Background iteration duration",
+          "type": "histogram"
         }
       ],
       "serviceName": "auth"

--- a/libraries/iterate/src/index.js
+++ b/libraries/iterate/src/index.js
@@ -147,6 +147,11 @@ class Iterate extends events.EventEmitter {
         status: iterError ? 'exception' : 'success',
       }, { level: iterError ? 'err' : 'notice' });
 
+      this.monitor.metric.iterateDuration(duration / 1000, {
+        name: this.name,
+        status: iterError ? 'exception' : 'success',
+      });
+
       if (iterError) {
         this.monitor.reportError(iterError, 'warning', {
           consecutiveErrors: failures.length,

--- a/libraries/monitor/src/builtins.js
+++ b/libraries/monitor/src/builtins.js
@@ -185,3 +185,16 @@ MonitorManager.registerMetric('httpRequestDurationSeconds', {
   },
   buckets: [0.01, 0.05, 0.1, 0.5, 1, 5, 10],
 });
+
+MonitorManager.registerMetric('iterateDuration', {
+  name: 'iterate_duration_seconds',
+  type: 'histogram',
+  title: 'Background iteration duration',
+  description: 'Duration of a single background iteration loop',
+  labels: {
+    name: 'Name of the iterate loop',
+    status: 'Result: success or exception',
+  },
+  buckets: [1, 5, 10, 30, 60, 120, 300, 600, 1200, 1800, 3600, 6000],
+  global: true,
+});

--- a/libraries/monitor/src/monitormanager.js
+++ b/libraries/monitor/src/monitormanager.js
@@ -100,6 +100,7 @@ export class MonitorManager {
     buckets = undefined,
     percentiles = undefined,
     serviceName = undefined,
+    global = false,
   }) {
     assert(id, `Must provide an internal metric name for this metric ${name}`);
     assert(name, `Must provide a name for this metric ${type} ${title}`);
@@ -148,6 +149,7 @@ export class MonitorManager {
       percentiles,
       serviceName,
       registers,
+      global,
     };
   }
 
@@ -356,7 +358,7 @@ export class MonitorManager {
       metrics: Object.entries(metrics).map(([name, metric]) => {
         return {
           name,
-          ..._.omit(metric, ['serviceName']),
+          ..._.omit(metric, ['serviceName', 'global']),
         };
       }).sort((a, b) => a.name.localeCompare(b.name)),
     };

--- a/libraries/monitor/src/plugins/prometheus.js
+++ b/libraries/monitor/src/plugins/prometheus.js
@@ -35,6 +35,7 @@ import { Counter, Gauge, Histogram, Summary, Registry as PromClientRegistry, Pus
  * @property {number[]} [buckets] - Buckets for histograms.
  * @property {number[]} [percentiles] - Percentiles for summaries.
  * @property {string} [serviceName] - Service this metric belongs to.
+ * @property {boolean} [global=false] - If true, metric is propagated to any registry exposed via exposeMetrics.
  */
 
 /**
@@ -42,6 +43,7 @@ import { Counter, Gauge, Histogram, Summary, Registry as PromClientRegistry, Pus
  * @property {'counter' | 'gauge' | 'histogram' | 'summary'} type - Type of the metric
  * @property {Record<string, string>} labels - Object of allowed labels and their descriptions
  * @property {import('prom-client').Metric<string>} metric - The actual metric instance
+ * @property {boolean} global - If true, metric is propagated to any registry exposed via exposeMetrics
  */
 
 export class PrometheusPlugin {
@@ -86,6 +88,13 @@ export class PrometheusPlugin {
    * @param {string} [exposedRegistry='default'] - Registry to expose
    */
   exposeMetrics(exposedRegistry = 'default') {
+    // Propagate global metrics into non-default registries so they
+    // appear on every process's /metrics endpoint regardless of which
+    // registry the process serves.
+    if (exposedRegistry !== 'default') {
+      this.#propagateGlobalMetrics(exposedRegistry);
+    }
+
     // Start server if configured
     if (this.serverOptions) {
       this.startHttpServer(this.serverOptions, exposedRegistry);
@@ -94,10 +103,14 @@ export class PrometheusPlugin {
     // Start push if configured
     if (this.pushOptions) {
       assert(this.pushOptions.gateway, 'Push gateway URL is required');
+      const pushRegistry = this.pushOptions.registry || exposedRegistry;
+      if (pushRegistry !== 'default' && pushRegistry !== exposedRegistry) {
+        this.#propagateGlobalMetrics(pushRegistry);
+      }
       this.pushGateway = new Pushgateway(
         this.pushOptions.gateway,
         null,
-        this.#getRegistry(this.pushOptions.registry || exposedRegistry),
+        this.#getRegistry(pushRegistry),
       );
     }
   }
@@ -114,6 +127,20 @@ export class PrometheusPlugin {
   }
 
   /**
+   * Copy metrics marked as `global` into the given registry.
+   * prom-client's registerMetric no-ops when the same instance is already present.
+   * @param {string} registryName
+   */
+  #propagateGlobalMetrics(registryName) {
+    const registry = this.#getRegistry(registryName);
+    for (const info of Object.values(this.metricsStore)) {
+      if (info.global) {
+        registry.registerMetric(info.metric);
+      }
+    }
+  }
+
+  /**
    * Register a metric with the Prometheus registry.
    * @param {string} name - The name of the metric.
    * @param {MetricDefinition} definition - The metric definition.
@@ -126,6 +153,7 @@ export class PrometheusPlugin {
     buckets,
     percentiles,
     registers = ['default'],
+    global = false,
   }) {
     /** @type {import('prom-client').Metric<string>} */
     let metric;
@@ -165,6 +193,7 @@ export class PrometheusPlugin {
       type,
       metric,
       labels,
+      global,
     };
 
     return metric;

--- a/libraries/monitor/test/prometheus_test.js
+++ b/libraries/monitor/test/prometheus_test.js
@@ -34,6 +34,15 @@ MonitorManager.registerMetric('testingServiceGauge', {
   registers: ['extra'],
 });
 
+MonitorManager.registerMetric('testingGlobalCounter', {
+  name: 'testing_global_counter',
+  type: 'counter',
+  title: 'A global test counter',
+  description: 'A global counter that should propagate to any exposed registry',
+  labels: { op: 'Operation name' },
+  global: true,
+});
+
 const TEST_PORT = 39090;
 
 suite(testing.suiteName(), function() {
@@ -86,6 +95,45 @@ suite(testing.suiteName(), function() {
       /Not Found/);
 
     await monitor.terminate();
+  });
+
+  test('global metrics propagate to non-default registries on exposeMetrics', async function() {
+    const monitor = MonitorManager.setup({
+      ...configDefaults,
+      prometheusConfig: { server: { port: TEST_PORT } },
+    });
+    try {
+      // Expose a non-default registry — global metrics should be copied into it
+      monitor.exposeMetrics('extra');
+      monitor.metric.testingGlobalCounter(1, { op: 'test-op' });
+
+      const res = await request.get(`http://localhost:${TEST_PORT}/metrics`);
+      assert(res.ok);
+      // Global counter appears in the 'extra' registry
+      assert.match(res.text, /testing_global_counter/);
+      assert.match(res.text, /op="test-op"/);
+      // The non-global default-only counter does NOT appear
+      assert.doesNotMatch(res.text, /testing_service_test_counter/);
+    } finally {
+      await monitor.terminate();
+    }
+  });
+
+  test('global metrics appear in default registry', async function() {
+    const monitor = MonitorManager.setup({
+      ...configDefaults,
+      prometheusConfig: { server: { port: TEST_PORT } },
+    });
+    try {
+      monitor.exposeMetrics(); // default registry
+      monitor.metric.testingGlobalCounter(1, { op: 'default-op' });
+
+      const res = await request.get(`http://localhost:${TEST_PORT}/metrics`);
+      assert(res.ok);
+      assert.match(res.text, /testing_global_counter/);
+    } finally {
+      await monitor.terminate();
+    }
   });
 
   test('push gateway successfully sends metrics', async function() {


### PR DESCRIPTION
this bridges the gap between previously log-based metrics that were used in grafana


This replaces the GCP log-based metric
`logging_googleapis_com:user_taskcluster_background_operation_sum` which is not
available in newer cluster deployments.

**Grafana migration:** Replace queries like:

```promql
sum by (container_name, status)(increase(logging_googleapis_com:user_taskcluster_background_operation_sum{cluster_name="...", container_name="..."}[$__interval]))
```

with:

```promql
sum by (name, status)(increase(iterate_duration_seconds_sum{name="workerScanner"}[$__interval]))
```

The `name` label replaces `container_name` filtering. Values match the loader
component names: `provisioner`, `workerScanner`, `workerScannerAzure`,
`claim-resolver`, `deadline-resolver`, etc.

Histogram buckets cover 1 second to 100 minutes, matching the worker-scanner's
maximum iteration time.



Fixes #8502
