### PR TITLE
Fix nginx log dir permissions for non-root container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -71,6 +71,9 @@ WORKDIR /app
 # Create /references directory for references service with proper ownership
 RUN mkdir -p /references && chown 1000:1000 /references
 
+# Allow nginx to write its default log path when running as non-root
+RUN mkdir -p /var/lib/nginx/logs && chown -R 1000:1000 /var/lib/nginx
+
 # use non-root, node user
 # https://github.com/nodejs/docker-node/blob/main/docs/BestPractices.md#non-root-user
 USER 1000

--- a/changelog/issue-8270.md
+++ b/changelog/issue-8270.md
@@ -1,0 +1,6 @@
+audience: deployers
+level: patch
+reference: issue 8270
+---
+Fixed a permission error on startup where nginx could not open its default error log
+at `/var/lib/nginx/logs/error.log` when the container runs as a non-root user (UID 1000).


### PR DESCRIPTION
Github Bug/Issue: Fixes #8270

## Summary
- Fix permission error where nginx cannot open its default error log at `/var/lib/nginx/logs/error.log` when the container runs as non-root (UID 1000)
- Add `RUN mkdir -p /var/lib/nginx/logs && chown -R 1000:1000 /var/lib/nginx` to the Dockerfile before `USER 1000`
- nginx opens the compiled-in default log path *before* reading the config that redirects to stderr — this ensures the directory is writable at startup

## Test plan
- [ ] `docker build -t tc-test .` completes without error
- [ ] `docker compose up references` starts with no `Permission denied` alert for `/var/lib/nginx/logs/error.log`
- [ ] `/__heartbeat__` returns `{}` from the references container