### PR TITLE
Fix flaky weighted distribution test in launch config selector

### DIFF
--- a/changelog/issue-8325.md
+++ b/changelog/issue-8325.md
@@ -1,0 +1,5 @@
+audience: developers
+level: patch
+reference: issue 8325
+---
+Fixed a flaky test in the worker-manager launch config selector suite by increasing the statistical sample size from 100 to 500 draws.

--- a/services/worker-manager/test/launch_config_selector_test.js
+++ b/services/worker-manager/test/launch_config_selector_test.js
@@ -110,7 +110,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
     ]);
     const wrc = await launchConfigSelector.forWorkerPool(wp);
 
-    const counts = getDistribution(wrc, 100);
+    const counts = getDistribution(wrc, 500);
     assert.ok(counts.lc1 > counts.lc2, 'lc1 should be chosen more often than lc2');
     assert.ok(counts.lc2 > counts.lc3, 'lc2 should be chosen more often than lc3');
     assert.ok(counts.unknown === undefined);


### PR DESCRIPTION
Github Bug/Issue: Fixes #8325

## Summary
- Increase statistical sample size from 100 to 500 in the `respects weights in random selection` test
- With weights 0.5 vs 0.1, the failure probability per run was ~1.2×10⁻⁷ at 100 samples; at 500 samples it becomes ~10⁻⁵⁰ (effectively zero)
- 500 samples stays well within the `maxCapacity=1000` limit so `selectCapacity` won't exhaust any config

## Test plan
- [ ] `cd services/worker-manager && yarn test --grep "respects weights"` passes
- [ ] Full `cd services/worker-manager && yarn test` suite passes
- [ ] `yarn lint` passes