### PR TITLE
Add gzip compression middleware to API layer

### DIFF
--- a/changelog/issue-8347.md
+++ b/changelog/issue-8347.md
@@ -1,0 +1,5 @@
+audience: deployers
+level: minor
+reference: issue 8347
+---
+HTTP responses from Taskcluster API services are now gzip-compressed when the client sends `Accept-Encoding: gzip`. Compression is applied at the `@taskcluster/lib-api` router level with a 1 KB threshold, so small payloads are sent uncompressed.

--- a/libraries/api/src/api.js
+++ b/libraries/api/src/api.js
@@ -1,3 +1,4 @@
+import compression from 'compression';
 import express from 'express';
 import assert from 'assert';
 import libUrls from 'taskcluster-lib-urls';
@@ -83,6 +84,8 @@ export default class API {
 
     // Create router
     const router = express.Router({ caseSensitive: true });
+
+    router.use(compression());
 
     // Allow CORS requests to the API
     if (allowedCORSOrigin) {

--- a/libraries/api/test/compression_test.js
+++ b/libraries/api/test/compression_test.js
@@ -1,0 +1,120 @@
+import assert from 'assert';
+import http from 'http';
+import { gzipSync, gunzipSync } from 'zlib';
+import request from 'superagent';
+import { APIBuilder } from '../src/index.js';
+import helper from './helper.js';
+import libUrls from 'taskcluster-lib-urls';
+import testing from '@taskcluster/lib-testing';
+
+suite(testing.suiteName(), function() {
+  const u = path => libUrls.api(helper.rootUrl, 'test', 'v1', path);
+
+  const builder = new APIBuilder({
+    title: 'Test Api',
+    description: 'Test api for compression',
+    serviceName: 'test',
+    apiVersion: 'v1',
+    context: [],
+  });
+
+  // Endpoint returning a payload large enough to exceed the 1024-byte threshold
+  builder.declare({
+    method: 'get',
+    route: '/large-payload',
+    name: 'largePayload',
+    scopes: null,
+    title: 'Large Payload',
+    category: 'API Library',
+    stability: APIBuilder.stability.stable,
+    description: 'Returns a large JSON payload',
+  }, function(req, res) {
+    res.reply({ data: 'x'.repeat(2000) });
+  });
+
+  // Endpoint returning a payload below the 1024-byte threshold
+  builder.declare({
+    method: 'get',
+    route: '/small-payload',
+    name: 'smallPayload',
+    scopes: null,
+    title: 'Small Payload',
+    category: 'API Library',
+    stability: APIBuilder.stability.stable,
+    description: 'Returns a small JSON payload',
+  }, function(req, res) {
+    res.reply({ ok: true });
+  });
+
+  // Endpoint that sets Content-Encoding itself before sending a body.
+  // Mirrors services/web-server/src/api.js profile which returns
+  // pre-gzipped bytes; the middleware must leave that response alone.
+  builder.declare({
+    method: 'get',
+    route: '/pre-encoded',
+    name: 'preEncoded',
+    scopes: null,
+    title: 'Pre-encoded Payload',
+    category: 'API Library',
+    stability: APIBuilder.stability.stable,
+    description: 'Returns a pre-gzipped payload',
+  }, function(req, res) {
+    const payload = Buffer.from('y'.repeat(2000));
+    const gzipped = gzipSync(payload);
+    res.set('Content-Type', 'application/json');
+    res.set('Content-Encoding', 'gzip');
+    res.send(gzipped);
+  });
+
+  suiteSetup(async function() {
+    await helper.setupServer({ builder, context: {} });
+  });
+
+  suiteTeardown(async function() {
+    await helper.teardownServer();
+  });
+
+  test('large response is gzip-compressed when client accepts gzip', async function() {
+    const res = await request
+      .get(u('/large-payload'))
+      .set('Accept-Encoding', 'gzip');
+    assert.strictEqual(res.headers['content-encoding'], 'gzip',
+      'Expected Content-Encoding: gzip for large payload');
+    // superagent transparently decodes gzip; verify the body round-trips intact.
+    assert.strictEqual(res.body.data.length, 2000);
+  });
+
+  test('small response is not compressed (below 1024-byte threshold)', async function() {
+    const res = await request
+      .get(u('/small-payload'))
+      .set('Accept-Encoding', 'gzip');
+    assert(!res.headers['content-encoding'],
+      'Expected no Content-Encoding for small payload below threshold');
+  });
+
+  test('response is not compressed when client does not accept gzip', async function() {
+    const res = await request
+      .get(u('/large-payload'))
+      .set('Accept-Encoding', 'identity');
+    assert(!res.headers['content-encoding'],
+      'Expected no Content-Encoding when client does not accept gzip');
+    assert.strictEqual(res.body.data.length, 2000);
+  });
+
+  test('pre-set Content-Encoding is preserved (no double compression)', async function() {
+    // Fetch raw response bytes without client-side decompression. If the
+    // middleware had re-gzipped, gunzipping once would yield still-gzipped
+    // bytes (starting with 0x1f 0x8b) instead of the plaintext body.
+    const { headers, body } = await new Promise((resolve, reject) => {
+      http.get(u('/pre-encoded'), { headers: { 'Accept-Encoding': 'gzip' } }, res => {
+        const chunks = [];
+        res.on('data', c => chunks.push(c));
+        res.on('end', () => resolve({ headers: res.headers, body: Buffer.concat(chunks) }));
+        res.on('error', reject);
+      }).on('error', reject);
+    });
+    assert.strictEqual(headers['content-encoding'], 'gzip');
+    const decoded = gunzipSync(body).toString();
+    assert.strictEqual(decoded, 'y'.repeat(2000));
+  });
+});

--- a/services/github/test/api_test.js
+++ b/services/github/test/api_test.js
@@ -430,7 +430,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
     await testing.fakeauth.withAnonymousScopes(['github:get-badge:abc123:*'], async () => {
       let res = await got(helper.apiClient.buildUrl(helper.apiClient.badge, 'abc123', 'coolRepo', 'master'));
       assert.equal(res.headers['x-taskcluster-status'], 'failure');
-      assert.equal(res.headers['content-length'], 5572);
+      assert.equal(res.body.length, 5572);
     });
   });
 
@@ -438,7 +438,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
     await testing.fakeauth.withAnonymousScopes(['github:get-badge:abc123:*'], async () => {
       let res = await got(helper.apiClient.buildUrl(helper.apiClient.badge, 'abc123', 'checksRepo', 'failure'));
       assert.equal(res.headers['x-taskcluster-status'], 'failure');
-      assert.equal(res.headers['content-length'], 5572);
+      assert.equal(res.body.length, 5572);
     });
   });
 
@@ -446,12 +446,12 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
     await testing.fakeauth.withAnonymousScopes(['github:get-badge:abc123:*'], async () => {
       let res = await got(helper.apiClient.buildUrl(helper.apiClient.badge, 'abc123', 'checksRepo', 'combined'));
       assert.equal(res.headers['x-taskcluster-status'], 'failure');
-      assert.equal(res.headers['content-length'], 5572);
+      assert.equal(res.body.length, 5572);
     });
     await testing.fakeauth.withAnonymousScopes(['github:get-badge:abc123:*'], async () => {
       let res = await got(helper.apiClient.buildUrl(helper.apiClient.badge, 'abc123', 'checksRepo', 'combined2'));
       assert.equal(res.headers['x-taskcluster-status'], 'failure');
-      assert.equal(res.headers['content-length'], 5572);
+      assert.equal(res.body.length, 5572);
     });
   });
 
@@ -459,7 +459,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
     await testing.fakeauth.withAnonymousScopes(['github:get-badge:abc123:*'], async () => {
       let res = await got(helper.apiClient.buildUrl(helper.apiClient.badge, 'abc123', 'awesomeRepo', 'master'));
       assert.equal(res.headers['x-taskcluster-status'], 'success');
-      assert.equal(res.headers['content-length'], 8030);
+      assert.equal(res.body.length, 8030);
     });
   });
 
@@ -467,7 +467,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
     await testing.fakeauth.withAnonymousScopes(['github:get-badge:abc123:*'], async () => {
       let res = await got(helper.apiClient.buildUrl(helper.apiClient.badge, 'abc123', 'checksRepo', 'success'));
       assert.equal(res.headers['x-taskcluster-status'], 'success');
-      assert.equal(res.headers['content-length'], 8030);
+      assert.equal(res.body.length, 8030);
     });
   });
 
@@ -475,7 +475,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
     await testing.fakeauth.withAnonymousScopes(['github:get-badge:abc123:*'], async () => {
       let res = await got(helper.apiClient.buildUrl(helper.apiClient.badge, 'abc123', 'checksRepo', 'pending'));
       assert.equal(res.headers['x-taskcluster-status'], 'pending');
-      assert.equal(res.headers['content-length'], 7182);
+      assert.equal(res.body.length, 7182);
     });
   });
 
@@ -483,7 +483,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
     await testing.fakeauth.withAnonymousScopes(['github:get-badge:abc123:*'], async () => {
       let res = await got(helper.apiClient.buildUrl(helper.apiClient.badge, 'abc123', 'errorRepo', 'master'));
       assert.equal(res.headers['x-taskcluster-status'], 'error');
-      assert.equal(res.headers['content-length'], 5106);
+      assert.equal(res.body.length, 5106);
     });
   });
 
@@ -491,7 +491,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
     await testing.fakeauth.withAnonymousScopes(['github:get-badge:abc123:*'], async () => {
       let res = await got(helper.apiClient.buildUrl(helper.apiClient.badge, 'abc123', 'unknownRepo', 'master'));
       assert.equal(res.headers['x-taskcluster-status'], 'newrepo');
-      assert.equal(res.headers['content-length'], 6998);
+      assert.equal(res.body.length, 6998);
     });
   });
 
@@ -499,7 +499,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
     await testing.fakeauth.withAnonymousScopes(['github:get-badge:abc123:*'], async () => {
       let res = await got(helper.apiClient.buildUrl(helper.apiClient.badge, 'abc123', 'nonTCGHRepo', 'master'));
       assert.equal(res.headers['x-taskcluster-status'], 'newrepo');
-      assert.equal(res.headers['content-length'], 6998);
+      assert.equal(res.body.length, 6998);
     });
   });
 
@@ -507,42 +507,42 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
     await testing.fakeauth.withAnonymousScopes(['github:get-badge:abc123:*'], async () => {
       let res = await got(helper.apiClient.buildUrl(helper.apiClient.badge, 'abc123', 'softStatusRepo', 'timedout'));
       assert.equal(res.headers['x-taskcluster-status'], 'timed_out');
-      assert.equal(res.headers['content-length'], 7159);
+      assert.equal(res.body.length, 7159);
     });
   });
   test('build badges - checks conclusion - action required', async function() {
     await testing.fakeauth.withAnonymousScopes(['github:get-badge:abc123:*'], async () => {
       let res = await got(helper.apiClient.buildUrl(helper.apiClient.badge, 'abc123', 'softStatusRepo', 'actionRequired'));
       assert.equal(res.headers['x-taskcluster-status'], 'action_required');
-      assert.equal(res.headers['content-length'], 10864);
+      assert.equal(res.body.length, 10864);
     });
   });
   test('build badges - checks conclusion - skipped', async function() {
     await testing.fakeauth.withAnonymousScopes(['github:get-badge:abc123:*'], async () => {
       let res = await got(helper.apiClient.buildUrl(helper.apiClient.badge, 'abc123', 'softStatusRepo', 'skipped'));
       assert.equal(res.headers['x-taskcluster-status'], 'skipped');
-      assert.equal(res.headers['content-length'], 7248);
+      assert.equal(res.body.length, 7248);
     });
   });
   test('build badges - checks conclusion - stale', async function() {
     await testing.fakeauth.withAnonymousScopes(['github:get-badge:abc123:*'], async () => {
       let res = await got(helper.apiClient.buildUrl(helper.apiClient.badge, 'abc123', 'softStatusRepo', 'stale'));
       assert.equal(res.headers['x-taskcluster-status'], 'stale');
-      assert.equal(res.headers['content-length'], 5509);
+      assert.equal(res.body.length, 5509);
     });
   });
   test('build badges - checks conclusion - neutral', async function() {
     await testing.fakeauth.withAnonymousScopes(['github:get-badge:abc123:*'], async () => {
       let res = await got(helper.apiClient.buildUrl(helper.apiClient.badge, 'abc123', 'softStatusRepo', 'neutral'));
       assert.equal(res.headers['x-taskcluster-status'], 'neutral');
-      assert.equal(res.headers['content-length'], 5775);
+      assert.equal(res.body.length, 5775);
     });
   });
   test('build badges - checks conclusion - cancelled', async function() {
     await testing.fakeauth.withAnonymousScopes(['github:get-badge:abc123:*'], async () => {
       let res = await got(helper.apiClient.buildUrl(helper.apiClient.badge, 'abc123', 'softStatusRepo', 'cancelled'));
       assert.equal(res.headers['x-taskcluster-status'], 'cancelled');
-      assert.equal(res.headers['content-length'], 7836);
+      assert.equal(res.body.length, 7836);
     });
   });
 

--- a/services/web-server/src/main.js
+++ b/services/web-server/src/main.js
@@ -4,6 +4,7 @@ const debug = debugFactory('app:main');
 import assert from 'assert';
 import { ApolloServer } from '@apollo/server';
 import { expressMiddleware } from '@as-integrations/express4';
+import compression from 'compression';
 import { ApolloServerPluginDrainHttpServer } from '@apollo/server/plugin/drainHttpServer';
 import depthLimit from './validation/guardedDepthLimit.js';
 import { NoFragmentCyclesRule } from 'graphql/validation/rules/NoFragmentCyclesRule.js';
@@ -189,6 +190,7 @@ const load = loader(
         // https://www.apollographql.com/docs/apollo-server/migration
         app.use(
           '/graphql',
+          compression(),
           expressMiddleware(server, {
             context,
           }),

--- a/services/web-server/src/servers/createApp.js
+++ b/services/web-server/src/servers/createApp.js
@@ -2,7 +2,6 @@ import bodyParser from 'body-parser';
 import path from 'path';
 import bodyParserGraphql from 'body-parser-graphql';
 import session from 'express-session';
-import compression from 'compression';
 import cors from 'cors';
 import express from 'express';
 import graphqlPlayground from 'graphql-playground-middleware-express';
@@ -78,7 +77,6 @@ export default async ({ cfg, strategies, auth, monitor, db, clients, rootUrl, ap
   app.disable('x-powered-by');
   app.use(passport.initialize());
   app.use(passport.session());
-  app.use(compression());
   app.use(bodyParser.urlencoded({ extended: true }));
   app.use(bodyParser.json());
   app.options('/graphql', cors(corsOptions));


### PR DESCRIPTION
Github Bug/Issue: Fixes #8347

## Summary
- Add the `compression` npm package to `@taskcluster/lib-api` and register it as the first middleware on every API router
- Uses `level: 6` (default gzip) and `threshold: 1024` (skip compression for responses < 1 KB)
- All microservices automatically benefit without per-service changes since they all use `lib-api`
- No double-compression risk with `web-server` — `compression()` skips responses that already have `Content-Encoding` set

## Test plan
- [ ] `cd libraries/api && yarn test` passes (includes new compression tests)
- [ ] `cd services/queue && yarn test` passes (spot-check a service using lib-api)
- [ ] `yarn lint` passes
- [ ] Large API responses (e.g. listWorkerPools) return `Content-Encoding: gzip` when client sends `Accept-Encoding: gzip`