### PR TITLE
feat(w-m): Fix azure stuck resource deletion

### DIFF
--- a/changelog/issue-8517.md
+++ b/changelog/issue-8517.md
@@ -1,0 +1,5 @@
+audience: deployers
+level: patch
+reference: issue 8517
+---
+Fixed Azure provider workers getting stuck in `STOPPING` indefinitely when their backing Azure resources (VM, NIC, IP, disks, or ARM deployment) were deleted out-of-band (e.g. Spot preemption, ARM cascade delete). The `deprovisionResource` helper now treats a `404` from `beginDelete` the same way as a `404` from `get`: mark the resource as deleted and let the reap path continue.

--- a/services/worker-manager/src/providers/azure/index.js
+++ b/services/worker-manager/src/providers/azure/index.js
@@ -1906,6 +1906,15 @@ export class AzureProvider extends Provider {
       resourceName: typeData.name,
     });
 
+    const markDeleted = () => worker.update(this.db, worker => {
+      const resource = index !== undefined
+        ? worker.providerData[resourceType][index]
+        : worker.providerData[resourceType];
+      resource.operation = undefined;
+      resource.id = false;
+      resource.deleted = true;
+    });
+
     if (typeData?.deleted === true) {
       // if resource was already deleted we don't have to query api by name again to make sure it is 404
       // and avoid being queried multiple times during deprovision cycles
@@ -1932,18 +1941,7 @@ export class AzureProvider extends Provider {
       } catch (err) {
         if (err.statusCode === 404) {
           debug(`resource ${typeData.name} not found; removing its id and marking as deleted`);
-          await worker.update(this.db, worker => {
-            if (index !== undefined) {
-              worker.providerData[resourceType][index].operation = undefined;
-              worker.providerData[resourceType][index].id = false;
-              worker.providerData[resourceType][index].deleted = true;
-            } else {
-              worker.providerData[resourceType].operation = undefined;
-              worker.providerData[resourceType].id = false;
-              worker.providerData[resourceType].deleted = true;
-            }
-          });
-
+          await markDeleted();
           return true;
         }
         throw err;
@@ -1963,6 +1961,13 @@ export class AzureProvider extends Provider {
           typeData.name,
         ));
       } catch (err) {
+        if (err.statusCode === 404) {
+          // resource was deleted out-of-band (e.g. Spot preemption or ARM cascade delete);
+          // treat the same way as the get()->404 branch above so the worker can progress
+          debug(`resource ${typeData.name} already absent on delete; marking as deleted`);
+          await markDeleted();
+          return true;
+        }
         if (err.statusCode === 409 &&
             /previous deployment.*still active/i.test(err.message ?? '')) {
           debug('deployment still active; will retry deletion later');

--- a/services/worker-manager/test/fakes/azure.js
+++ b/services/worker-manager/test/fakes/azure.js
@@ -193,6 +193,15 @@ class ResourceManager {
   }
 
   /**
+   * Remove a fake resource directly, simulating out-of-band deletion
+   * (e.g. Spot preemption or ARM cascade delete)
+   */
+  removeFakeResource(resourceGroupName, name) {
+    const key = `${resourceGroupName}/${name}`;
+    this._resources.delete(key);
+  }
+
+  /**
    * Modify a fake resource
    */
   modifyFakeResource(resourceGroupName, name, modifier) {

--- a/services/worker-manager/test/provider_azure_test.js
+++ b/services/worker-manager/test/provider_azure_test.js
@@ -1788,6 +1788,55 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       // check that there's a request to delete the disk (by name)
       assert.deepEqual(await fake.computeClient.disks.getFakeRequestParameters('rgrp', diskName), {});
     });
+
+    test('beginDelete 404 is treated as already-deleted (ghost worker reaps)', async function() {
+      // Seed the worker with ids for every resource so deprovision goes down
+      // the beginDelete branch, then remove the backing fakes to simulate
+      // Azure having already deleted them out-of-band (Spot preemption,
+      // ARM cascade delete, manual cleanup, etc.).
+      await makeResource('ip', true);
+      await makeResource('nic', true);
+      await makeResource('disks', true, 0);
+      await makeResource('disks', true, 1);
+      await makeResource('vm', true);
+      await worker.update(helper.db, worker => {
+        worker.state = 'running';
+      });
+
+      await provider.removeWorker({ worker, reason: 'test' });
+
+      // remove backing resources so beginDelete throws 404 for each
+      fake.computeClient.virtualMachines.removeFakeResource('rgrp', vmName);
+      fake.networkClient.networkInterfaces.removeFakeResource('rgrp', nicName);
+      fake.networkClient.publicIPAddresses.removeFakeResource('rgrp', ipName);
+      fake.computeClient.disks.removeFakeResource('rgrp', 'disks0');
+      fake.computeClient.disks.removeFakeResource('rgrp', 'disks1');
+
+      // reset errors so we can assert no deletion-error is recorded
+      provider.errors = provider.errors || {};
+      provider.errors[workerPoolId] = [];
+
+      // drive the reap loop. Each call advances one resource (VM -> NIC -> IP -> disks).
+      for (let i = 0; i < 6; i++) {
+        await provider.deprovisionResources({ worker, monitor });
+      }
+
+      const [reloaded] = await helper.getWorkers();
+      assert.equal(reloaded.state, 'stopped', 'ghost worker should progress to stopped');
+      assert.equal(reloaded.providerData.vm.deleted, true);
+      assert.equal(reloaded.providerData.nic.deleted, true);
+      assert.equal(reloaded.providerData.ip.deleted, true);
+      assert.equal(reloaded.providerData.disks[0].deleted, true);
+      assert.equal(reloaded.providerData.disks[1].deleted, true);
+      assert.equal(reloaded.providerData.vm.id, false);
+      assert.equal(reloaded.providerData.nic.id, false);
+      assert.equal(reloaded.providerData.ip.id, false);
+      assert.equal(reloaded.providerData.disks[0].id, false);
+      assert.equal(reloaded.providerData.disks[1].id, false);
+      assert.deepEqual(provider.errors[workerPoolId], [],
+        'no deletion-error should be recorded for out-of-band deletions');
+      helper.assertPulseMessage('worker-stopped', m => m.payload.workerId === reloaded.workerId);
+    });
   });
 
   suite('deprovision', function () {


### PR DESCRIPTION
deprovisionResource didn't handle deletion of resources that were removed already. After the fixes introduced in #8059 404 check was not handled properly in the delete call. As a result some workers stayed in the stopping state forever because that error wasn't handled

Fixes: #8517
