### PR TITLE
fix(worker-runner): Tighten permissions on runner config file

### DIFF
--- a/changelog/bug-2032277.md
+++ b/changelog/bug-2032277.md
@@ -1,0 +1,5 @@
+audience: worker-deployers
+level: patch
+reference: bug 2032277
+---
+worker-runner now tightens the permissions of its configuration file (typically `runner.yml` / `worker-runner.json`) to be readable only by its owner before reading it, and logs a warning if the file was previously group- or world-readable. This closes an exposure where a task running on a worker using the `static` provider could read the `staticSecret` out of a loosely-permissioned runner config and impersonate the worker via `registerWorker`. Worker deployers using the static provider should update their provisioning so the runner config is created with mode `0600` (or the equivalent owner-only ACL on Windows) from the start.

--- a/tools/worker-runner/cfg/runnerconfig.go
+++ b/tools/worker-runner/cfg/runnerconfig.go
@@ -1,8 +1,10 @@
 package cfg
 
 import (
-	"os"
+	"fmt"
+	"log"
 
+	"github.com/taskcluster/taskcluster/v99/tools/worker-runner/perms"
 	"gopkg.in/yaml.v3"
 )
 
@@ -17,9 +19,24 @@ type RunnerConfig struct {
 	CacheOverRestarts    string                     `yaml:"cacheOverRestarts"`
 }
 
-// Load a configuration file
+// LoadRunnerConfig loads a worker-runner configuration file.
+//
+// The runner config may contain sensitive credentials (for example, the
+// staticSecret used by the static provider to prove worker identity), so the
+// file is tightened to owner-only permissions before being read. If the file
+// had loose permissions on disk, a warning is logged so that operators can
+// fix their provisioning; the worker continues to start because the immediate
+// exposure has been closed.
 func LoadRunnerConfig(filename string) (*RunnerConfig, error) {
-	data, err := os.ReadFile(filename)
+	wasLoose, err := perms.MakeFilePrivate(filename)
+	if err != nil {
+		return nil, fmt.Errorf("cannot secure runner config file %s: %w", filename, err)
+	}
+	if wasLoose {
+		log.Printf("WARNING: runner config file %s had insecure permissions and has been tightened to be readable only by its owner; please update your provisioning so the file is created privately", filename)
+	}
+
+	data, err := perms.ReadPrivateFile(filename)
 	if err != nil {
 		return nil, err
 	}

--- a/tools/worker-runner/cfg/runnerconfig_test.go
+++ b/tools/worker-runner/cfg/runnerconfig_test.go
@@ -14,7 +14,9 @@ import (
 
 // copyTestConfigToTempFile copies the checked-in test-config.yml into a
 // temporary directory so tests that need to mutate file permissions don't
-// touch the source tree.
+// touch the source tree. An explicit Chmod is applied after the write so
+// the resulting mode is deterministic regardless of the test runner's
+// umask (which would otherwise mask the mode passed to os.WriteFile).
 func copyTestConfigToTempFile(t *testing.T, mode os.FileMode) string {
 	t.Helper()
 	_, sourceFilename, _, _ := runtime.Caller(0)
@@ -23,6 +25,7 @@ func copyTestConfigToTempFile(t *testing.T, mode os.FileMode) string {
 	require.NoError(t, err)
 	dst := filepath.Join(t.TempDir(), "runner.yml")
 	require.NoError(t, os.WriteFile(dst, data, mode))
+	require.NoError(t, os.Chmod(dst, mode))
 	return dst
 }
 

--- a/tools/worker-runner/cfg/runnerconfig_test.go
+++ b/tools/worker-runner/cfg/runnerconfig_test.go
@@ -1,18 +1,35 @@
 package cfg
 
 import (
+	"os"
 	"path"
+	"path/filepath"
 	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/taskcluster/taskcluster/v99/tools/worker-runner/perms"
 )
 
-func TestLoadConfig(t *testing.T) {
+// copyTestConfigToTempFile copies the checked-in test-config.yml into a
+// temporary directory so tests that need to mutate file permissions don't
+// touch the source tree.
+func copyTestConfigToTempFile(t *testing.T, mode os.FileMode) string {
+	t.Helper()
 	_, sourceFilename, _, _ := runtime.Caller(0)
-	testConfig := path.Join(path.Dir(sourceFilename), "test-config.yml")
+	src := path.Join(path.Dir(sourceFilename), "test-config.yml")
+	data, err := os.ReadFile(src)
+	require.NoError(t, err)
+	dst := filepath.Join(t.TempDir(), "runner.yml")
+	require.NoError(t, os.WriteFile(dst, data, mode))
+	return dst
+}
 
-	runnercfg, err := LoadRunnerConfig(testConfig)
+func TestLoadConfig(t *testing.T) {
+	cfgPath := copyTestConfigToTempFile(t, 0600)
+
+	runnercfg, err := LoadRunnerConfig(cfgPath)
 	if err != nil {
 		t.Fatalf("failed to load: %s", err)
 	}
@@ -20,4 +37,23 @@ func TestLoadConfig(t *testing.T) {
 	assert.Equal(t, "ec2", runnercfg.Provider.ProviderType, "should read providerType correctly")
 	assert.Equal(t, 10.0, runnercfg.WorkerConfig.MustGet("x"), "should read workerConfig correctly")
 	assert.Equal(t, true, runnercfg.GetSecrets, "getSecrets should default to true")
+}
+
+// TestLoadConfig_InsecurePerms verifies that LoadRunnerConfig tightens the
+// permissions of a runner config file that was deployed with loose (group-
+// or world-readable) permissions, closing the attack surface where a task
+// user could exfiltrate credentials (e.g. staticSecret) from the file.
+func TestLoadConfig_InsecurePerms(t *testing.T) {
+	cfgPath := copyTestConfigToTempFile(t, 0644)
+
+	runnercfg, err := LoadRunnerConfig(cfgPath)
+	require.NoError(t, err, "LoadRunnerConfig should tighten perms and succeed")
+	assert.Equal(t, "ec2", runnercfg.Provider.ProviderType)
+
+	// Verify the file is now private per the platform's semantics (0600 on
+	// POSIX, owner-only ACL on Windows). A second call to MakeFilePrivate
+	// should be a no-op, indicating the file is already private.
+	wasLoose, err := perms.MakeFilePrivate(cfgPath)
+	require.NoError(t, err)
+	assert.False(t, wasLoose, "runner config file should already be private after LoadRunnerConfig")
 }

--- a/tools/worker-runner/perms/perms_posix.go
+++ b/tools/worker-runner/perms/perms_posix.go
@@ -41,7 +41,12 @@ func ReadPrivateFile(filename string) ([]byte, error) {
 // verifyPrivateToOwner verifies that the given file can only be read by the
 // file's owner, returning an error if this is not the case, or cannot be
 // determined.  Returns an error satisfying os.IsNotExist when the file does
-// not exist.
+// not exist.  A file is considered private if no group or other permission
+// bits are set AND the owner-read bit is set (e.g. 0400, 0500, 0600, 0700);
+// operators who deliberately tighten permissions beyond 0600 should not be
+// forced to loosen them, but an owner-unreadable config (e.g. 0200) is
+// treated as a provisioning error because worker-runner must be able to
+// read the file.
 func verifyPrivateToOwner(filename string) error {
 	stat, err := os.Stat(filename)
 	if err != nil {
@@ -54,39 +59,74 @@ func verifyPrivateToOwner(filename string) error {
 	}
 	// (note: we don't check gid since the group has no permission to the file)
 
-	if stat.Mode().Perm() != os.FileMode(0600) {
-		return fmt.Errorf("%s has mode %#o, not 0600", filename, stat.Mode().Perm())
+	perm := stat.Mode().Perm()
+	if perm&0o077 != 0 {
+		return fmt.Errorf("%s has mode %#o; must not be group- or other-accessible", filename, perm)
+	}
+	if perm&0o400 == 0 {
+		return fmt.Errorf("%s has mode %#o; owner-read bit must be set", filename, perm)
 	}
 	return nil
 }
 
-// MakeFilePrivate ensures that the given file is readable only by its owner.
-// If the file already has private permissions (mode 0600, owned by the current
-// user), this is a no-op and the returned bool is false. If the file had
-// looser permissions, they are tightened to 0600 and the returned bool is
-// true. An error is returned if the file cannot be stat'd, if it is owned by
-// a different user, or if chmod fails.
+// MakeFilePrivate ensures that the given file is accessible only by its
+// owner. A file is considered already private if no group or other bits are
+// set in its mode (e.g. 0600, 0400, 0500); in that case this is a no-op and
+// the returned bool is false. If the file had looser permissions, they are
+// tightened to 0600 and the returned bool is true. An error is returned if
+// the file cannot be opened, if it is not a regular file, if chmod is
+// required but the file is owned by a different user, or if chmod fails.
+//
+// The file is opened with O_NOFOLLOW and subsequent stat/chmod operations
+// use the file descriptor rather than the path, to close the TOCTOU window
+// where the path could be replaced between operations. O_NONBLOCK prevents
+// a FIFO planted at the config path from blocking the open indefinitely;
+// the regular-file check below then rejects it.
 func MakeFilePrivate(filename string) (bool, error) {
-	stat, err := os.Stat(filename)
+	f, err := os.OpenFile(filename, os.O_RDONLY|syscall.O_NOFOLLOW|syscall.O_NONBLOCK, 0)
+	if err != nil {
+		return false, err
+	}
+	defer f.Close()
+
+	stat, err := f.Stat()
 	if err != nil {
 		return false, err
 	}
 
+	// Refuse FIFOs, devices, sockets, and anything else that isn't a plain
+	// regular file. Without this check, a FIFO with 0600 perm bits would
+	// pass as "private" and worker-runner would then block reading from it
+	// (or return whatever a device file produces).
+	if !stat.Mode().IsRegular() {
+		return false, fmt.Errorf("%s is not a regular file (mode %v)", filename, stat.Mode())
+	}
+
+	perm := stat.Mode().Perm()
+
+	// Refuse owner-unreadable modes (e.g. 0200, 0300) even if they have no
+	// group/other bits set. Worker-runner must be able to read the file, so
+	// this is a provisioning error; silently widening to 0600 would mask
+	// the mistake.
+	if perm&0o400 == 0 {
+		return false, fmt.Errorf("%s has mode %#o; owner-read bit must be set", filename, perm)
+	}
+
+	// Already private if no group/other bits are set (e.g. 0600, 0400, 0500).
+	// This path doesn't need to modify the file, so we accept it regardless
+	// of who owns it; a file we don't own at 0400 is still private.
+	if perm&0o077 == 0 {
+		return false, nil
+	}
+
+	// Past this point we need to chmod, which requires ownership.
 	uid := int(stat.Sys().(*syscall.Stat_t).Uid)
 	if uid != os.Getuid() {
 		return false, fmt.Errorf("%s has incorrect owner id %d (expected %d); refusing to tighten permissions on a file owned by another user", filename, uid, os.Getuid())
 	}
 
-	if stat.Mode().Perm() == os.FileMode(0600) {
-		return false, nil
-	}
-
-	if err := os.Chmod(filename, 0600); err != nil {
+	if err := f.Chmod(0600); err != nil {
 		return false, fmt.Errorf("could not chmod %s to 0600: %w", filename, err)
-	}
-
-	if err := verifyPrivateToOwner(filename); err != nil {
-		return true, fmt.Errorf("file %s is still not private after chmod: %w", filename, err)
 	}
 
 	return true, nil

--- a/tools/worker-runner/perms/perms_posix.go
+++ b/tools/worker-runner/perms/perms_posix.go
@@ -54,8 +54,40 @@ func verifyPrivateToOwner(filename string) error {
 	}
 	// (note: we don't check gid since the group has no permission to the file)
 
-	if stat.Mode() != os.FileMode(0600) {
-		return fmt.Errorf("%s has mode %#o, not 0600", filename, stat.Mode())
+	if stat.Mode().Perm() != os.FileMode(0600) {
+		return fmt.Errorf("%s has mode %#o, not 0600", filename, stat.Mode().Perm())
 	}
 	return nil
+}
+
+// MakeFilePrivate ensures that the given file is readable only by its owner.
+// If the file already has private permissions (mode 0600, owned by the current
+// user), this is a no-op and the returned bool is false. If the file had
+// looser permissions, they are tightened to 0600 and the returned bool is
+// true. An error is returned if the file cannot be stat'd, if it is owned by
+// a different user, or if chmod fails.
+func MakeFilePrivate(filename string) (bool, error) {
+	stat, err := os.Stat(filename)
+	if err != nil {
+		return false, err
+	}
+
+	uid := int(stat.Sys().(*syscall.Stat_t).Uid)
+	if uid != os.Getuid() {
+		return false, fmt.Errorf("%s has incorrect owner id %d (expected %d); refusing to tighten permissions on a file owned by another user", filename, uid, os.Getuid())
+	}
+
+	if stat.Mode().Perm() == os.FileMode(0600) {
+		return false, nil
+	}
+
+	if err := os.Chmod(filename, 0600); err != nil {
+		return false, fmt.Errorf("could not chmod %s to 0600: %w", filename, err)
+	}
+
+	if err := verifyPrivateToOwner(filename); err != nil {
+		return true, fmt.Errorf("file %s is still not private after chmod: %w", filename, err)
+	}
+
+	return true, nil
 }

--- a/tools/worker-runner/perms/perms_posix_test.go
+++ b/tools/worker-runner/perms/perms_posix_test.go
@@ -4,12 +4,98 @@ package perms
 
 import (
 	"os"
+	"path/filepath"
 	"testing"
 
+	"github.com/Flaque/filet"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/sys/unix"
 )
 
 func makePermsBad(t *testing.T, filename string) {
 	t.Helper()
 	require.NoError(t, os.Chmod(filename, 0666))
+}
+
+// TestMakeFilePrivate_DoesNotWidenTighterModes verifies that an operator who
+// has deliberately set a stricter mode than 0600 (e.g. 0400) does not have
+// that mode silently widened. The file is already private as far as group
+// and other are concerned, so MakeFilePrivate must no-op. It also verifies
+// that ReadPrivateFile accepts such a file rather than rejecting it for not
+// being exactly 0600.
+func TestMakeFilePrivate_DoesNotWidenTighterModes(t *testing.T) {
+	defer filet.CleanUp(t)
+	dir := filet.TmpDir(t, "")
+
+	for _, mode := range []os.FileMode{0400, 0500, 0600, 0700} {
+		t.Run(mode.String(), func(t *testing.T) {
+			filename := filepath.Join(dir, "tightmode-"+mode.String())
+			require.NoError(t, os.WriteFile(filename, []byte("secret"), 0600))
+			require.NoError(t, os.Chmod(filename, mode))
+
+			wasLoose, err := MakeFilePrivate(filename)
+			require.NoError(t, err)
+			require.False(t, wasLoose, "mode %v should be treated as already private", mode)
+
+			stat, err := os.Stat(filename)
+			require.NoError(t, err)
+			require.Equal(t, mode, stat.Mode().Perm(),
+				"MakeFilePrivate must not modify a file that is already private")
+
+			// A file that is private (no group/other bits) but not exactly
+			// 0600 must still be readable via ReadPrivateFile; otherwise
+			// operators who tighten permissions break the config load path.
+			content, err := ReadPrivateFile(filename)
+			require.NoError(t, err, "ReadPrivateFile should accept mode %v", mode)
+			require.Equal(t, []byte("secret"), content)
+		})
+	}
+}
+
+// TestMakeFilePrivate_RefusesNonRegularFile verifies that MakeFilePrivate
+// rejects a FIFO at the config path. Without the regular-file guard, a FIFO
+// with 0600 perm bits would pass as "private" and worker-runner would then
+// block trying to read from it (or consume arbitrary attacker-supplied data
+// if it's a FIFO the attacker controls).
+func TestMakeFilePrivate_RefusesNonRegularFile(t *testing.T) {
+	defer filet.CleanUp(t)
+	dir := filet.TmpDir(t, "")
+	filename := filepath.Join(dir, "fifo")
+	require.NoError(t, unix.Mkfifo(filename, 0600))
+
+	// O_NOFOLLOW + O_RDONLY on a FIFO blocks unless O_NONBLOCK is also set;
+	// we use O_NONBLOCK indirectly by ensuring the open doesn't hang here.
+	// The guard in MakeFilePrivate should reject before any blocking occurs.
+	_, err := MakeFilePrivate(filename)
+	require.Error(t, err, "MakeFilePrivate must refuse a FIFO at the config path")
+	require.Contains(t, err.Error(), "not a regular file")
+}
+
+// TestReadPrivateFile_RefusesOwnerUnreadable verifies that a file with no
+// group/other bits but also no owner-read bit (e.g. 0200) is rejected by
+// verifyPrivateToOwner via ReadPrivateFile. Accepting such a mode would
+// mask a provisioning mistake or (under root, where DAC is bypassed) pass
+// through and leave the broken mode in place.
+//
+// This test targets verifyPrivateToOwner specifically because MakeFilePrivate's
+// identical check is unreachable under non-root: its O_RDONLY open fails
+// with EACCES before the mode check runs on an owner-unreadable file.
+func TestReadPrivateFile_RefusesOwnerUnreadable(t *testing.T) {
+	defer filet.CleanUp(t)
+	dir := filet.TmpDir(t, "")
+
+	// Only modes with no group/other bits are tested here; the loose-perms
+	// path is already covered elsewhere. 0200 = write only; 0300 = write +
+	// execute; 0100 = execute only.
+	for _, mode := range []os.FileMode{0100, 0200, 0300} {
+		t.Run(mode.String(), func(t *testing.T) {
+			filename := filepath.Join(dir, "unreadable-"+mode.String())
+			require.NoError(t, os.WriteFile(filename, []byte("secret"), 0600))
+			require.NoError(t, os.Chmod(filename, mode))
+
+			_, err := ReadPrivateFile(filename)
+			require.Error(t, err, "ReadPrivateFile must refuse mode %v", mode)
+			require.Contains(t, err.Error(), "owner-read bit must be set")
+		})
+	}
 }

--- a/tools/worker-runner/perms/perms_test.go
+++ b/tools/worker-runner/perms/perms_test.go
@@ -38,3 +38,40 @@ func TestPerms(t *testing.T) {
 		require.True(t, os.IsNotExist(err))
 	})
 }
+
+func TestMakeFilePrivate(t *testing.T) {
+	defer filet.CleanUp(t)
+	dir := filet.TmpDir(t, "")
+
+	t.Run("AlreadyPrivate", func(t *testing.T) {
+		filename := filepath.Join(dir, "already-private")
+		require.NoError(t, WritePrivateFile(filename, []byte("secret")))
+		wasLoose, err := MakeFilePrivate(filename)
+		require.NoError(t, err)
+		require.False(t, wasLoose, "expected no fix needed when file is already private")
+		// still readable as a private file
+		content, err := ReadPrivateFile(filename)
+		require.NoError(t, err)
+		require.Equal(t, []byte("secret"), content)
+	})
+
+	t.Run("LoosePerms", func(t *testing.T) {
+		filename := filepath.Join(dir, "loose")
+		require.NoError(t, WritePrivateFile(filename, []byte("secret")))
+		makePermsBad(t, filename)
+		wasLoose, err := MakeFilePrivate(filename)
+		require.NoError(t, err)
+		require.True(t, wasLoose, "expected fix to be reported when file had loose perms")
+		// file is now private and readable via ReadPrivateFile
+		content, err := ReadPrivateFile(filename)
+		require.NoError(t, err)
+		require.Equal(t, []byte("secret"), content)
+	})
+
+	t.Run("NonExistent", func(t *testing.T) {
+		filename := filepath.Join(dir, "does-not-exist")
+		_, err := MakeFilePrivate(filename)
+		require.Error(t, err)
+		require.True(t, os.IsNotExist(err))
+	})
+}

--- a/tools/worker-runner/perms/perms_windows.go
+++ b/tools/worker-runner/perms/perms_windows.go
@@ -168,10 +168,12 @@ func getCurrentUser() (*windows.SID, error) {
 
 // MakeFilePrivate ensures that the given file is accessible only by its
 // owner. If the file already has an owner-only ACL, this is a no-op and the
-// returned bool is false. If the file had looser ACLs (or an unexpected
-// owner/group), they are tightened to owner-only and the returned bool is
-// true. An error is returned if the file cannot be stat'd or if the ACLs
-// cannot be modified.
+// returned bool is false. If the file had looser ACLs, they are tightened
+// to owner-only and the returned bool is true. To match the POSIX
+// semantics, this function refuses to rewrite the owner of a file that
+// belongs to a different user (which would also require SeTakeOwnership on
+// Windows). An error is returned if the file cannot be stat'd, if it is
+// owned by a different user, or if the ACLs cannot be modified.
 func MakeFilePrivate(filename string) (bool, error) {
 	if _, err := os.Stat(filename); err != nil {
 		return false, err
@@ -179,6 +181,26 @@ func MakeFilePrivate(filename string) (bool, error) {
 
 	if verifyErr := verifyPrivateToOwner(filename); verifyErr == nil {
 		return false, nil
+	}
+
+	// Refuse to take ownership of a file owned by a different user.
+	si, err := windows.GetNamedSecurityInfo(
+		filename,
+		windows.SE_FILE_OBJECT,
+		windows.OWNER_SECURITY_INFORMATION)
+	if err != nil {
+		return false, fmt.Errorf("could not read owner of %s: %w", filename, err)
+	}
+	owner, _, err := si.Owner()
+	if err != nil {
+		return false, fmt.Errorf("could not read owner of %s: %w", filename, err)
+	}
+	currentUser, err := getCurrentUser()
+	if err != nil {
+		return false, err
+	}
+	if owner.String() != currentUser.String() {
+		return false, fmt.Errorf("%s is owned by %s (expected %s); refusing to tighten permissions on a file owned by another user", filename, owner, currentUser)
 	}
 
 	if err := makePrivateToOwner(filename); err != nil {

--- a/tools/worker-runner/perms/perms_windows.go
+++ b/tools/worker-runner/perms/perms_windows.go
@@ -165,3 +165,29 @@ func getCurrentUser() (*windows.SID, error) {
 	sid := tokenuser.User.Sid
 	return sid, err
 }
+
+// MakeFilePrivate ensures that the given file is accessible only by its
+// owner. If the file already has an owner-only ACL, this is a no-op and the
+// returned bool is false. If the file had looser ACLs (or an unexpected
+// owner/group), they are tightened to owner-only and the returned bool is
+// true. An error is returned if the file cannot be stat'd or if the ACLs
+// cannot be modified.
+func MakeFilePrivate(filename string) (bool, error) {
+	if _, err := os.Stat(filename); err != nil {
+		return false, err
+	}
+
+	if verifyErr := verifyPrivateToOwner(filename); verifyErr == nil {
+		return false, nil
+	}
+
+	if err := makePrivateToOwner(filename); err != nil {
+		return false, fmt.Errorf("could not tighten ACLs on %s: %w", filename, err)
+	}
+
+	if err := verifyPrivateToOwner(filename); err != nil {
+		return true, fmt.Errorf("file %s is still not private after tightening: %w", filename, err)
+	}
+
+	return true, nil
+}

--- a/tools/worker-runner/perms/perms_windows_test.go
+++ b/tools/worker-runner/perms/perms_windows_test.go
@@ -3,8 +3,11 @@
 package perms
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
+	"github.com/Flaque/filet"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/sys/windows"
 )
@@ -26,4 +29,54 @@ func makePermsBad(t *testing.T, filename string) {
 		nil,
 		dacl,
 		nil))
+}
+
+// TestMakeFilePrivate_Windows_AlreadyPrivate covers the no-op path: a file
+// created via WritePrivateFile (owner-only DACL) should be recognized as
+// private and returned unchanged.
+func TestMakeFilePrivate_Windows_AlreadyPrivate(t *testing.T) {
+	defer filet.CleanUp(t)
+	dir := filet.TmpDir(t, "")
+	filename := filepath.Join(dir, "already-private")
+	require.NoError(t, WritePrivateFile(filename, []byte("secret")))
+
+	wasLoose, err := MakeFilePrivate(filename)
+	require.NoError(t, err)
+	require.False(t, wasLoose, "expected no fix when file is already private")
+
+	content, err := ReadPrivateFile(filename)
+	require.NoError(t, err)
+	require.Equal(t, []byte("secret"), content)
+}
+
+// TestMakeFilePrivate_Windows_LoosePerms covers the tightening path: a file
+// whose DACL grants access to other principals should be detected and
+// rewritten to owner-only.
+func TestMakeFilePrivate_Windows_LoosePerms(t *testing.T) {
+	defer filet.CleanUp(t)
+	dir := filet.TmpDir(t, "")
+	filename := filepath.Join(dir, "loose")
+	require.NoError(t, WritePrivateFile(filename, []byte("secret")))
+	makePermsBad(t, filename)
+
+	wasLoose, err := MakeFilePrivate(filename)
+	require.NoError(t, err)
+	require.True(t, wasLoose, "expected fix to be reported when DACL was loose")
+
+	// file is now private again; reading via ReadPrivateFile succeeds
+	content, err := ReadPrivateFile(filename)
+	require.NoError(t, err)
+	require.Equal(t, []byte("secret"), content)
+}
+
+// TestMakeFilePrivate_Windows_NonExistent covers the error path for a
+// missing file.
+func TestMakeFilePrivate_Windows_NonExistent(t *testing.T) {
+	defer filet.CleanUp(t)
+	dir := filet.TmpDir(t, "")
+	filename := filepath.Join(dir, "does-not-exist")
+
+	_, err := MakeFilePrivate(filename)
+	require.Error(t, err)
+	require.True(t, os.IsNotExist(err))
 }

--- a/tools/worker-runner/runner/run_test.go
+++ b/tools/worker-runner/runner/run_test.go
@@ -63,7 +63,7 @@ worker:
   path: %s
 `, workerConfigPath, workerPath)
 
-	err := os.WriteFile(configPath, []byte(configData), 0755)
+	err := os.WriteFile(configPath, []byte(configData), 0600)
 	require.NoError(t, err)
 
 	// checks exit code of running fake worker
@@ -98,7 +98,7 @@ provider:
 getSecrets: false
 worker:
   implementation: dummy
-`), 0755)
+`), 0600)
 	require.NoError(t, err)
 
 	run, err := Run(configPath)
@@ -132,7 +132,7 @@ workerConfig:
   fromFirstRun: true
 worker:
   implementation: dummy
-`, cachePath), 0755)
+`, cachePath), 0600)
 	require.NoError(t, err)
 
 	run, err := Run(configPath)
@@ -157,7 +157,7 @@ getSecrets: false
 cacheOverRestarts: %s
 worker:
   implementation: dummy
-`, cachePath), 0755)
+`, cachePath), 0600)
 	require.NoError(t, err)
 
 	run, err = Run(configPath)

--- a/ui/docs/reference/workers/generic-worker/installing.mdx
+++ b/ui/docs/reference/workers/generic-worker/installing.mdx
@@ -192,6 +192,22 @@ launches generic-worker (set to demand-start) when work is available.
     it manually. Local `workerConfig` values have the lowest precedence and can
     be overridden by the worker pool definition in worker-manager.
 
+    **Permissions:** the runner config may contain credentials such as the
+    static-provider `staticSecret`. The file must be owned by the service
+    account that runs worker-runner, and must not grant access to other
+    principals. The simplest approach is to create the file as the service
+    account and let worker-runner set the DACL on first start:
+
+    ```
+    icacls C:\worker-runner\runner.yml /setowner "%USERNAME%"
+    ```
+
+    If the ACL is looser than owner-only on startup, worker-runner rewrites
+    it to grant full access only to the file's owner and logs a warning.
+    Worker-runner does not attempt to take ownership; if the file is owned
+    by a different user, it refuses to start. Treat the warning as a signal
+    that your provisioning should be fixed.
+
  7. Ensure host 'taskcluster' resolves to localhost by adding the following
     line to `C:\Windows\System32\drivers\etc\hosts`:
 
@@ -313,6 +329,19 @@ starting worker-runner.
     assembles the final generic-worker config file automatically — do not create
     it manually. Local `workerConfig` values have the lowest precedence and can
     be overridden by the worker pool definition in worker-manager.
+
+    **Permissions:** the runner config may contain credentials such as the
+    static-provider `staticSecret`. Restrict it to root so it cannot be read
+    by a running task:
+
+    ```
+    chown root:wheel /etc/generic-worker/runner.yml
+    chmod 0600 /etc/generic-worker/runner.yml
+    ```
+
+    Worker-runner will tighten the permissions on startup if they are looser
+    than owner-only and log a warning; treat the warning as a signal that
+    your provisioning should be fixed.
 
  7. Create the launch daemon plist at
     `/Library/LaunchDaemons/com.mozilla.genericworker.plist`.
@@ -478,6 +507,19 @@ manages the generic-worker process.
     assembles the final generic-worker config file automatically — do not create
     it manually. Local `workerConfig` values have the lowest precedence and can
     be overridden by the worker pool definition in worker-manager.
+
+    **Permissions:** the runner config may contain credentials such as the
+    static-provider `staticSecret`. Restrict it to root so it cannot be read
+    by a running task:
+
+    ```
+    chown root:root /etc/start-worker.yml
+    chmod 0600 /etc/start-worker.yml
+    ```
+
+    Worker-runner will tighten the permissions on startup if they are looser
+    than owner-only and log a warning; treat the warning as a signal that
+    your provisioning should be fixed.
 
 12. Create a systemd service file at `/lib/systemd/system/worker.service`:
 

--- a/workers/entrypoint.sh
+++ b/workers/entrypoint.sh
@@ -68,7 +68,14 @@ run_static() {
   echo '{"expires": "2033-01-01 12:12:12", "providerInfo": { "staticSecret": "NMd5YFgrZZHmAejHUNhNWKcEtfRwtHeME6wdESMf798V"}}' | \
     taskcluster api workerManager createWorker docker-compose/generic-worker local vm-1
 
-  start-worker /etc/generic-worker/worker-runner.json
+  # Copy the bind-mounted config into the container and chmod it to 0600
+  # before handing it to worker-runner. Without the copy, worker-runner's
+  # auto-tightening would chmod the host-side file via the bind mount.
+  runner_config=/run/worker-runner.json
+  cp /etc/generic-worker/worker-runner.json "${runner_config}"
+  chmod 0600 "${runner_config}"
+
+  start-worker "${runner_config}"
 }
 
 case "${1}" in


### PR DESCRIPTION
worker-runner now ensures its config file (runner.yml / worker-runner.json) is readable only by its owner before reading, chmod'ing to 0600 (or tightening to an owner-only ACL on Windows) and warning if it was previously group- or world-readable. Closes an exposure where a task on a static-provider worker could read the staticSecret and impersonate the worker via registerWorker.

References bug 2032277.

>worker-runner now tightens the permissions of its configuration file (typically `runner.yml` / `worker-runner.json`) to be readable only by its owner before reading it, and logs a warning if the file was previously group- or world-readable. This closes an exposure where a task running on a worker using the `static` provider could read the `staticSecret` out of a loosely-permissioned runner config and impersonate the worker via `registerWorker`. Worker deployers using the static provider should update their provisioning so the runner config is created with mode `0600` (or the equivalent owner-only ACL on Windows) from the start.