### PR TITLE
Stop injecting content-type in taskcluster-proxy when it's not present

### DIFF
--- a/changelog/issue-3521.md
+++ b/changelog/issue-3521.md
@@ -1,0 +1,5 @@
+audience: users
+level: major
+reference: issue 3521
+---
+The taskcluster proxy no longer inserts a `Content-Type: application/json` requests missing a content type and having a non empty body

--- a/tools/taskcluster-proxy/authorization_test.go
+++ b/tools/taskcluster-proxy/authorization_test.go
@@ -378,7 +378,7 @@ func TestAPICallPOST(t *testing.T) {
 		testWithPermCreds(t, test([]string{}, true), 200)
 	})
 	t.Run("Test with perm creds without Content-Type header", func(t *testing.T) {
-		testWithPermCreds(t, test([]string{}, false), 200)
+		testWithPermCreds(t, test([]string{}, false), 400)
 	})
 	t.Run("Test with perm creds with authorizedScopes", func(t *testing.T) {
 		testWithPermCreds(t, test([]string{"test:authenticate-post"}, true), 200)

--- a/tools/taskcluster-proxy/routes.go
+++ b/tools/taskcluster-proxy/routes.go
@@ -255,13 +255,6 @@ func (routes *Routes) commonHandler(res http.ResponseWriter, req *http.Request, 
 		}
 		maps.Copy(proxyreq.Header, req.Header)
 
-		// for compatibility, if there is no request Content-Type and the body
-		// has nonzero length, we add a Content-Type header.  See #3521.
-		if _, ok := req.Header["Content-Type"]; !ok && len(body) != 0 {
-			log.Printf("Adding missing Content-Type header (#3521)")
-			proxyreq.Header["Content-Type"] = []string{"application/json"}
-		}
-
 		// Refresh Authorization header with each call...
 		err = routes.Credentials.SignRequest(proxyreq)
 		if err != nil {


### PR DESCRIPTION
This removes a years old workaround for misbehaving clients. The workaround was added in ef7164fb5 (#3671) to restore some behavior that was accidentally dropped in f3c2473d4 when the proxy got put in the monorepo. Before that move, the proxy was delegating outgoing requests to `tcclient.Client.Request` which was unconditionally setting `Content-Type` for any non-empty body. The monorepo version is calling `http.NewRequest` directly which does not have that kind of behavior (so the header disappeared).

I think it's time to let this debt go and do what was decided in #3521, which is to not touch headers in the proxy. I think it makes no sense to try and fix a buggy client by hiding its behavior since it might also be run directly talking to taskcluster and not through the proxy.

Worth noting, I checked papertrail for that log line and found one offending client for which I opened a PR
(https://github.com/mozilla-services/updatebot/pull/415).

Closes #3521 