### PR TITLE
Use `on-resolved` in the publish route for notifications instead of on-any

### DIFF
--- a/changelog/issue-3684.md
+++ b/changelog/issue-3684.md
@@ -1,0 +1,3 @@
+level: silent
+reference: issue 3684
+---

--- a/taskcluster/kinds/release/kind.yml
+++ b/taskcluster/kinds/release/kind.yml
@@ -59,8 +59,7 @@ tasks:
     run:
       command: yarn release:publish --logs-dir $(pwd)/release-debug-logs
     routes:
-      # TODO: (taskcluster/taskcluster#3684) replace with on-resolved
-      - notify.email.taskcluster-notifications@mozilla.com.on-any
+      - notify.email.taskcluster-notifications@mozilla.com.on-resolved
     scopes:
       - secrets:get:project/taskcluster/release
     extra:


### PR DESCRIPTION
On-any has been deprecated by #3662, we should show the example and stop using deprecated stuff. On-resolved does the exact same thing but isn't deprecated

Fixes #3684