### PR TITLE
fix(pulse): bump `sendDeadline` from 12 -> 30s to help continue to publish under rmq load

### DIFF
--- a/changelog/pulse-send-deadline.md
+++ b/changelog/pulse-send-deadline.md
@@ -1,0 +1,4 @@
+audience: deployers
+level: patch
+---
+The default `sendDeadline` for the pulse publisher has been raised from 12 seconds to 30 seconds. Under load, RabbitMQ blocking and client reconnects could consume most of the 12-second budget before a single publish-confirm round-trip completed, causing cascading `PulsePublisher.sendDeadline exceeded` errors. The new default gives more headroom while still remaining below typical HTTP proxy timeouts. Services can override this per-publisher via the `sendDeadline` option to `exchanges.publisher()`.

--- a/libraries/pulse/README.md
+++ b/libraries/pulse/README.md
@@ -468,7 +468,7 @@ const publisher = await exchanges.publisher({
   rootUrl: cfg.taskcluster.rootUrl,
   schemaset, // from @taskcluster/lib-validate
   client,    // @taskcluster/lib-pulse Client instance
-  sendDeadline: 12000,
+  sendDeadline: 30000,
 });
 ```
 
@@ -479,7 +479,7 @@ will resolve when the AMQP server has confirmed receipt of the message.
 The `sendDeadline` option gives a time (in ms) after which a send operation
 will not be retried.  This value is typically chosen so that operations sending
 messages (such as REST API handlers) can return an error instead of timing out.
-Default is 12 seconds.
+Default is 30 seconds.
 
 For compatibility with the deployment at `taskcluster.net`, this function also
 accepts parameters `publish` and `aws`, which control publishing the references

--- a/libraries/pulse/src/publisher.js
+++ b/libraries/pulse/src/publisher.js
@@ -176,7 +176,7 @@ export class PulsePublisher {
     this.schemaset = schemaset;
     this.client = client;
     this.exchanges = exchanges;
-    this.sendDeadline = sendDeadline || 12000;
+    this.sendDeadline = sendDeadline || 30000;
     this.blocked = true;
 
     if (process.env.NODE_ENV === 'production') {


### PR DESCRIPTION
>The default `sendDeadline` for the pulse publisher has been raised from 12 seconds to 30 seconds. Under load, RabbitMQ blocking and client reconnects could consume most of the 12-second budget before a single publish-confirm round-trip completed, causing cascading `PulsePublisher.sendDeadline exceeded` errors. The new default gives more headroom while still remaining below typical HTTP proxy timeouts. Services can override this per-publisher via the `sendDeadline` option to `exchanges.publisher()`.