### PR TITLE
Avoid a 500 when a triggered hook produces no task

### DIFF
--- a/changelog/issue-8534.md
+++ b/changelog/issue-8534.md
@@ -1,0 +1,7 @@
+audience: users
+level: patch
+reference: issue 8534
+---
+Fix a 500 raised from hooks.triggerHook when a hook's task template evaluates
+to nothing. The endpoint now correctly replies with an empty object in that
+case.

--- a/services/hooks/src/taskcreator.js
+++ b/services/hooks/src/taskcreator.js
@@ -120,7 +120,7 @@ export class TaskCreator {
 
       if (!task) {
         this.monitor.count(`fire.${context.firedBy}.declined`);
-        return { response: {}, declined: true };
+        return { declined: true };
       }
       this.monitor.count(`fire.${context.firedBy}.created`);
 

--- a/services/hooks/test/taskcreator_test.js
+++ b/services/hooks/test/taskcreator_test.js
@@ -180,9 +180,10 @@ suite(testing.suiteName(), function() {
         hook.triggerSchema,
       );
       let taskId = taskcluster.slugid();
-      await creator.fire(hook, { firedBy: 'schedule' }, { taskId });
+      const res = await creator.fire(hook, { firedBy: 'schedule' }, { taskId });
       await assertNoTask(taskId);
       assertFireLogged({ firedBy: "schedule", taskId, result: 'declined' });
+      assert.ok(!res, `expected falsy return from declined fire(), got ${JSON.stringify(res)}`);
     });
 
     test('firing a hook where the json-e fails to render fails', async function() {


### PR DESCRIPTION
`TaskCreator.fire` was returning an empty object, which is truthy in JS, on the declined path.  defeating the `if (!resp)` guard in `triggerHookCommon` and causing a 500 by trying to read `resp.status.taskId` on an undefined `resp.status` whenever a hook's template evaluated to nothing. Return undefined instead.

Fixes #8534
