### PR TITLE
Fix worker-manager provider doc links

### DIFF
--- a/changelog/issue-8540.md
+++ b/changelog/issue-8540.md
@@ -1,0 +1,5 @@
+audience: general
+level: silent
+reference: issue 8540
+---
+Update the Worker Manager launch configuration docs to link to the published provider routes instead of `.mdx` file paths.

--- a/ui/docs/reference/core/worker-manager/launch-configurations.mdx
+++ b/ui/docs/reference/core/worker-manager/launch-configurations.mdx
@@ -9,9 +9,9 @@ import WeightPlayground from '@taskcluster/ui/views/Documentation/components/Wei
 
 Launch configurations define how Worker-Manager should create and manage cloud instances for worker pools.
 This feature is supported by the following cloud providers:
-- [AWS Provider](/docs/reference/core/worker-manager/aws.mdx)
-- [Azure Provider](/docs/reference/core/worker-manager/azure.mdx)
-- [Google Provider](/docs/reference/core/worker-manager/google.mdx)
+- [AWS Provider](/docs/reference/core/worker-manager/aws)
+- [Azure Provider](/docs/reference/core/worker-manager/azure)
+- [Google Provider](/docs/reference/core/worker-manager/google)
 
 ## Configuration
 


### PR DESCRIPTION
Github Bug/Issue: Fixes #8540
I fixed the broken provider links in the `launch-configurations` Worker Manager documentation.
The page was linking to `.mdx` file paths, which results in 404s on the published docs site. I updated the links to point to the correct published documentation routes for:
- AWS
- Azure
- Google

## Testing
I verified that the links in `ui/docs/reference/core/worker-manager/launch-configurations.mdx` now point to the published documentation routes instead of `.mdx` file paths.
