### PR TITLE
Update sha2 to 0.11.0 in the rust client

### DIFF
--- a/changelog/CEf8xPOSQL-BrK7H7n1Kgw.md
+++ b/changelog/CEf8xPOSQL-BrK7H7n1Kgw.md
@@ -1,0 +1,4 @@
+audience: users
+level: patch
+---
+Update sha2 dependency in the rust client

--- a/clients/client-rust/Cargo.lock
+++ b/clients/client-rust/Cargo.lock
@@ -118,6 +118,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "base16ct"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd307490d624467aa6f74b0eabb77633d1f758a7b25f12bceb0b22e08d9726f6"
+
+[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -131,11 +137,11 @@ checksum = "1be3f42a67d6d345ecd59f675f3f012d6974981560836e938c22b424b85ce1be"
 
 [[package]]
 name = "block-buffer"
-version = "0.10.4"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
 dependencies = [
- "generic-array",
+ "hybrid-array",
 ]
 
 [[package]]
@@ -202,9 +208,9 @@ checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
 
 [[package]]
 name = "cfg-if"
-version = "1.0.0"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "cfg_aliases"
@@ -246,6 +252,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
 name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -273,9 +285,9 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.16"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16b80225097f2e5ae4e7179dd2266824648f3e2f49d9134d584b76389d31c4c3"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -306,21 +318,21 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crypto-common"
-version = "0.1.6"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+checksum = "77727bb15fa921304124b128af125e7e3b968275d1b108b379190264f4423710"
 dependencies = [
- "generic-array",
- "typenum",
+ "hybrid-array",
 ]
 
 [[package]]
 name = "digest"
-version = "0.10.7"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+checksum = "4850db49bf08e663084f7fb5c87d202ef91a3907271aff24a94eb97ff039153c"
 dependencies = [
  "block-buffer",
+ "const-oid",
  "crypto-common",
 ]
 
@@ -486,16 +498,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "generic-array"
-version = "0.14.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
-dependencies = [
- "typenum",
- "version_check",
-]
-
-[[package]]
 name = "getrandom"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -648,6 +650,15 @@ dependencies = [
  "serde_json",
  "serde_urlencoded",
  "tokio",
+]
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d46837a0ed51fe95bd3b05de33cd64a1ee88fc797477ca48446872504507c5"
+dependencies = [
+ "typenum",
 ]
 
 [[package]]
@@ -958,9 +969,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.182"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "linux-raw-sys"
@@ -1460,9 +1471,9 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.10.9"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -1617,6 +1628,7 @@ version = "99.2.0"
 dependencies = [
  "anyhow",
  "async-trait",
+ "base16ct",
  "flate2",
  "futures-util",
  "httptest",
@@ -1653,6 +1665,7 @@ version = "99.2.0"
 dependencies = [
  "anyhow",
  "async-trait",
+ "base16ct",
  "base64",
  "httptest",
  "reqwest",
@@ -1871,9 +1884,9 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "typenum"
-version = "1.17.0"
+version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
+checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
 
 [[package]]
 name = "unicode-ident"
@@ -1909,12 +1922,6 @@ name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
-
-[[package]]
-name = "version_check"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "walkdir"

--- a/clients/client-rust/download/Cargo.toml
+++ b/clients/client-rust/download/Cargo.toml
@@ -17,7 +17,8 @@ serde = "1.0.228"
 tokio = { version = "1.50", features = ["macros", "time", "fs"] }
 tokio-util = { version = "0.7.18", features = ["codec", "io"] }
 futures-util = "0.3"
-sha2 = "0.10.9"
+sha2 = "0.11.0"
+base16ct = { version = "1.0", features = ["alloc"] }
 
 [dev-dependencies]
 httptest = "0.16"

--- a/clients/client-rust/download/src/hashing.rs
+++ b/clients/client-rust/download/src/hashing.rs
@@ -80,11 +80,11 @@ impl Hasher {
         let mut result = HashMap::new();
         result.insert(
             "sha256".into(),
-            format!("{:x}", inner.sha256.finalize_reset()),
+            base16ct::lower::encode_string(&inner.sha256.finalize_reset()),
         );
         result.insert(
             "sha512".into(),
-            format!("{:x}", inner.sha512.finalize_reset()),
+            base16ct::lower::encode_string(&inner.sha512.finalize_reset()),
         );
         result
     }

--- a/clients/client-rust/upload/Cargo.toml
+++ b/clients/client-rust/upload/Cargo.toml
@@ -18,7 +18,8 @@ tokio = { version = "1.50", features = ["macros", "time", "fs"] }
 tokio-util = { version = "0.7.18", features = ["codec", "io"] }
 slugid = "1.0.0"
 base64 = "0.22.0"
-sha2 = "0.10.9"
+sha2 = "0.11.0"
+base16ct = { version = "1.0", features = ["alloc"] }
 
 [dev-dependencies]
 httptest = "0.16"

--- a/clients/client-rust/upload/src/hashing.rs
+++ b/clients/client-rust/upload/src/hashing.rs
@@ -89,8 +89,8 @@ impl Hasher {
             );
         }
         json!({
-            "sha256": format!("{:x}", inner.sha256.finalize_reset()),
-            "sha512": format!("{:x}", inner.sha512.finalize_reset()),
+            "sha256": base16ct::lower::encode_string(&inner.sha256.finalize_reset()),
+            "sha512": base16ct::lower::encode_string(&inner.sha512.finalize_reset()),
         })
     }
 }


### PR DESCRIPTION
I'm really unhappy with this. `sha2` 0.11 pulls in `digest` 0.11, which replaced its dependency on `generic-array` with `hybrid-array`. The old dependency shipped a `LowerHex` impl on its array type which the new one doesn't. This means we cannot use `format!("{:x}", ...)` anymore and have to resort to either writing a helper ourselves to render it or use what the authors are recommending which is their own [`base16ct`]. I really feel bad about adding a leftpad style dependency here but the alternative is duplicating a handrolled helper which might be slower in both the upload and download crate which isn't great either.

In the end, the crate is small and maintained by the same team so I think it's fine. But not happy.

Closes #8426
