### PR TITLE
Relax the go version check a bit

### DIFF
--- a/changelog/OFAW8O0lTIam0BJIyxeX8Q.md
+++ b/changelog/OFAW8O0lTIam0BJIyxeX8Q.md
@@ -1,0 +1,3 @@
+audience: developers
+level: silent
+---

--- a/infrastructure/tooling/src/generate/generators/go-version.js
+++ b/infrastructure/tooling/src/generate/generators/go-version.js
@@ -26,7 +26,8 @@ export const tasks = [{
         throw new Error(`Cannot find \`go\`.  ${errmsg}`);
       }
     }
-    if (version !== goVersion) {
+    const versionPrefix = version?.match(/^go[0-9]+\.[0-9]+\.[0-9]+/)?.[0];
+    if (versionPrefix !== goVersion) {
       throw new Error(`Found ${version}.  ${errmsg}`);
     }
 


### PR DESCRIPTION
On my machine, `go version` resolves to `go version go1.26.2-X:nodwarf5 linux/amd64` which didn't exactly match what was expected despite it being the right version. I'd rather avoid having to deal with gvm when my package manager provides me with the right go version and I'm tired of commenting out the `throw`. This commit relaxes the version check to ignore architecture specific flags and only focus on the actual go version. If, at some point, those differences actually create any divergence in the generated output, CI will catch it anyway (to be quite honest I'd be in the camp of "remove the check entirely and let people deal with their own go version")