### PR TITLE
Fix intermittent failures in meta-generate

### DIFF
--- a/changelog/Rtm8qPIMSC2gds-RJYTMLA.md
+++ b/changelog/Rtm8qPIMSC2gds-RJYTMLA.md
@@ -1,0 +1,3 @@
+audience: developers
+level: silent
+---

--- a/infrastructure/tooling/src/generate/generators/generic-worker.js
+++ b/infrastructure/tooling/src/generate/generators/generic-worker.js
@@ -81,17 +81,17 @@ tasks.push({
     gwHelp = gwHelp.replace(/\[default \(varies by platform\): .*\]/, '[default varies by platform]');
 
     const ticks = '```';
-    [
+    for (const file of [
       path.join('workers', 'generic-worker', 'README.md'),
       path.join('ui', 'docs', 'reference', 'workers', 'generic-worker', 'usage.mdx'),
-    ].forEach(async file => {
+    ]) {
       await modifyRepoFile(
         file,
         async content => content
           .replace(
             /(<!-- HELP BEGIN -->)(?:.|\n)*(<!-- HELP END -->)/m,
             `$1\n${ticks}\n${gwHelp.trimRight()}\n${ticks}\n$2`));
-    });
+    }
   },
 });
 

--- a/infrastructure/tooling/src/generate/generators/go-version.js
+++ b/infrastructure/tooling/src/generate/generators/go-version.js
@@ -66,16 +66,16 @@ export const tasks = [{
         /MIN_GO_MINOR_VERSION=[0-9]+/,
         `MIN_GO_MINOR_VERSION=${goVersionMinor}`));
 
-    [
+    for (const file of [
       'generic-worker.Dockerfile',
       'taskcluster/docker/ci/Dockerfile',
-    ].forEach(async file => {
+    ]) {
       utils.status({ message: file });
       await modifyRepoFile(file,
         contents => contents.replace(
           /FROM golang:[0-9]+\.[0-9]+\.[0-9]+/,
           `FROM golang:${goVersionMajor}.${goVersionMinor}.${goVersionBugfix}`,
         ));
-    });
+    }
   },
 }];

--- a/infrastructure/tooling/src/generate/generators/node-version.js
+++ b/infrastructure/tooling/src/generate/generators/node-version.js
@@ -28,20 +28,20 @@ tasks.push({
         /^( *node: ')[0-9.]+(')$/m,
         `$1${nodeVersion}$2`));
 
-    [
+    for (const file of [
       'Dockerfile',
       'workers/docker-worker/test/images/test/Dockerfile',
       'ui/Dockerfile',
       'taskcluster/docker/browser-test/Dockerfile',
       'taskcluster/docker/ci/Dockerfile',
       'taskcluster/docker/rabbit-test/Dockerfile',
-    ].forEach(async file => {
+    ]) {
       utils.status({ message: file });
       await modifyRepoFile(file,
         contents => contents.replace(
           /^FROM node:[0-9.]+(.*)$/gm,
           `FROM node:${nodeVersion}$1`));
-    });
+    }
 
     utils.status({ message: '.nvmrc' });
     await writeRepoFile('.nvmrc', nodeVersion + '\n');
@@ -58,19 +58,19 @@ tasks.push({
         /^( *NODE_VERSION *= *")[0-9.]+(")$/m,
         `$1${nodeVersion}$2`));
 
-    [
+    for (const file of [
       'ui/package.json',
       'workers/docker-worker/package.json',
       'clients/client/package.json',
       'clients/client-test/package.json',
-    ].forEach(async file => {
+    ]) {
       utils.status({ message: file });
       await modifyRepoJSON(file,
         contents => {
           contents.engines.node = nodeVersion;
           return contents;
         });
-    });
+    }
 
     utils.status({ message: 'cloudbuild.yaml' });
     await modifyRepoYAML('cloudbuild.yaml',
@@ -95,16 +95,16 @@ tasks.push({
     }
     utils.step({ title: `Setting yarn version ${yarnVersion}` });
 
-    [
+    for (const file of [
       'ui/package.json',
       'workers/docker-worker/package.json',
-    ].forEach(file => {
+    ]) {
       utils.status({ message: file });
-      modifyRepoJSON(file,
+      await modifyRepoJSON(file,
         contents => {
           contents.packageManager = yarnVersion;
           return contents;
         });
-    });
+    }
   },
 });


### PR DESCRIPTION
The task that's updating the generic worker README was using `forEach(async ...)` which was completely ignoring the returned promises. So the task ended up resolving before the `modifyRepoFile` calls were done writing. So the README TOC task was firing before the generic worker README was done writing. The TOC task was then trying to figure out titles, and in cases where the writes from the previous tasks were a bit slow, couldn't and wrote the file name as the title instead. So on CI we would intermittently see diffs like this:

```diff
diff --git a/README.md b/README.md
index eec02a18e..1482ae7ac 100644
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ This repository is used to develop, build, and release the Taskcluster services.
     * [ui/src/components/StatusLabel](ui/src/components/StatusLabel#readme)
 * [Workers](workers#readme)
     * [Docker Worker](workers/docker-worker#readme)
-    * [Generic Worker](workers/generic-worker#readme)
+    * [workers/generic-worker](workers/generic-worker#readme)
 <!-- TOC END -->

 ## Team Mentions
diff --git a/workers/README.md b/workers/README.md
index ca39135fe..08da7f7ed 100644
--- a/workers/README.md
+++ b/workers/README.md
@@ -10,7 +10,7 @@ Generic-worker runs on several platforms, with several engines, and is written i

 <!-- TOC BEGIN -->
 * [Docker Worker](docker-worker#readme)
-* [Generic Worker](generic-worker#readme)
+* [generic-worker](generic-worker#readme)
 <!-- TOC END -->

 ## Docker image with generic worker
```

While fixing this I realized that the pattern was also present in the `go-version` and `node-version`. Instead of fixing it by using `Promise.all` and then having nested maps, just use `for of { await }`. The `modifyRepoFile` is not parallelizable anyway because it uses `pSynchronize` without passing it a key.
