### PR TITLE
Wait on tasks running `go generate` before running go-mod-tidy in `yarn generate`

### DIFF
--- a/changelog/GBGkg7L8SViaF75B-SRUgA.md
+++ b/changelog/GBGkg7L8SViaF75B-SRUgA.md
@@ -1,0 +1,2 @@
+level: silent
+---

--- a/infrastructure/tooling/src/generate/generators/go-mod-tidy.js
+++ b/infrastructure/tooling/src/generate/generators/go-mod-tidy.js
@@ -3,6 +3,12 @@ import { execFile } from 'child_process';
 
 export const tasks = [{
   title: 'Go Mod Tidy',
+  requires: [
+    'target-taskcluster-client-go',
+    'target-taskcluster-client-shell',
+    'target-d2g',
+    'target-generic-worker',
+  ],
   provides: ['target-go-mod-tidy'],
   run: async (requirements, utils) => {
     await promisify(execFile)('go', ['mod', 'tidy']);


### PR DESCRIPTION
I think this is causing an intermittent failure in CI where the error looks like this:

```
go: finding module for package github.com/taskcluster/taskcluster/v99/infrastructure/k8s/templates
go: github.com/taskcluster/taskcluster/v99/infrastructure/k8s/templates: module github.com/taskcluster/taskcluster@latest found (v24.3.1+incompatible), but does not contain package github.com/taskcluster/taskcluster/v99/infrastructure/k8s/templates
```

This import path is completely nonsensical and it's clear that something went wrong.

The `go-mod-tidy` task in `yarn generate` wasn't declaring any dependency and this was scheduled pretty much immediately. At the same time, there were 4 different tasks running `go generate` which was rewriting go files. It's fairly easy to understand why that might be a problem if one of those generation tasks rewrites a file while the tidy one is reading it.

