### PR TITLE
Update nock to 14.0.13 in clients/client

### DIFF
--- a/changelog/O-ejoMW-T62u6CYS5rBHcw.md
+++ b/changelog/O-ejoMW-T62u6CYS5rBHcw.md
@@ -1,0 +1,2 @@
+level: silent
+---

--- a/clients/client/package.json
+++ b/clients/client/package.json
@@ -20,7 +20,7 @@
   "devDependencies": {
     "http-proxy": "^1.18.0",
     "mocha": "^11.7.1",
-    "nock": "^13.5.5"
+    "nock": "^14.0.13"
   },
   "engines": {
     "node": "24.15.0"

--- a/clients/client/test/client_test.js
+++ b/clients/client/test/client_test.js
@@ -700,7 +700,7 @@ suite(testing.suiteName(), function() {
         rootUrl: 'https://tc.example.com',
       });
       await assert.rejects(
-        taskcluster.makeRequest(client, 'GET', 'https://127.0.0.1:' + server.address().port),
+        taskcluster.makeRequest(client, 'GET', 'http://127.0.0.1:' + server.address().port),
         err => err.code === 'ECONNABORTED');
     } finally {
       await new Promise(resolve => server.close(resolve));

--- a/clients/client/yarn.lock
+++ b/clients/client/yarn.lock
@@ -60,6 +60,44 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@mswjs/interceptors@npm:^0.41.0":
+  version: 0.41.7
+  resolution: "@mswjs/interceptors@npm:0.41.7"
+  dependencies:
+    "@open-draft/deferred-promise": "npm:^2.2.0"
+    "@open-draft/logger": "npm:^0.3.0"
+    "@open-draft/until": "npm:^2.0.0"
+    is-node-process: "npm:^1.2.0"
+    outvariant: "npm:^1.4.3"
+    strict-event-emitter: "npm:^0.5.1"
+  checksum: 10c0/10ff5ed50ee48c665e3639381f4e3624e1dd088a8955c12506de9db331a41169f753bd5e64f2ad47a46b549686d361d3da036d87505cc4eb99b6127b4e2f970e
+  languageName: node
+  linkType: hard
+
+"@open-draft/deferred-promise@npm:^2.2.0":
+  version: 2.2.0
+  resolution: "@open-draft/deferred-promise@npm:2.2.0"
+  checksum: 10c0/eafc1b1d0fc8edb5e1c753c5e0f3293410b40dde2f92688211a54806d4136887051f39b98c1950370be258483deac9dfd17cf8b96557553765198ef2547e4549
+  languageName: node
+  linkType: hard
+
+"@open-draft/logger@npm:^0.3.0":
+  version: 0.3.0
+  resolution: "@open-draft/logger@npm:0.3.0"
+  dependencies:
+    is-node-process: "npm:^1.2.0"
+    outvariant: "npm:^1.4.0"
+  checksum: 10c0/90010647b22e9693c16258f4f9adb034824d1771d3baa313057b9a37797f571181005bc50415a934eaf7c891d90ff71dcd7a9d5048b0b6bb438f31bef2c7c5c1
+  languageName: node
+  linkType: hard
+
+"@open-draft/until@npm:^2.0.0":
+  version: 2.1.0
+  resolution: "@open-draft/until@npm:2.1.0"
+  checksum: 10c0/61d3f99718dd86bb393fee2d7a785f961dcaf12f2055f0c693b27f4d0cd5f7a03d498a6d9289773b117590d794a43cd129366fd8e99222e4832f67b1653d54cf
+  languageName: node
+  linkType: hard
+
 "@pkgjs/parseargs@npm:^0.11.0":
   version: 0.11.0
   resolution: "@pkgjs/parseargs@npm:0.11.0"
@@ -91,7 +129,7 @@ __metadata:
     http-proxy: "npm:^1.18.0"
     lodash: "npm:^4.17.4"
     mocha: "npm:^11.7.1"
-    nock: "npm:^13.5.5"
+    nock: "npm:^14.0.13"
     slugid: "npm:^5.0.1"
     taskcluster-lib-urls: "npm:^13.0.0"
   languageName: unknown
@@ -264,7 +302,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"debug@npm:^4.1.0, debug@npm:^4.1.1, debug@npm:^4.3.5":
+"debug@npm:^4.1.1, debug@npm:^4.3.5":
   version: 4.4.3
   resolution: "debug@npm:4.4.3"
   dependencies:
@@ -496,6 +534,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"is-node-process@npm:^1.2.0":
+  version: 1.2.0
+  resolution: "is-node-process@npm:1.2.0"
+  checksum: 10c0/5b24fda6776d00e42431d7bcd86bce81cb0b6cabeb944142fe7b077a54ada2e155066ad06dbe790abdb397884bdc3151e04a9707b8cd185099efbc79780573ed
+  languageName: node
+  linkType: hard
+
 "is-path-inside@npm:^3.0.3":
   version: 3.0.3
   resolution: "is-path-inside@npm:3.0.3"
@@ -680,14 +725,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"nock@npm:^13.5.5":
-  version: 13.5.6
-  resolution: "nock@npm:13.5.6"
+"nock@npm:^14.0.13":
+  version: 14.0.13
+  resolution: "nock@npm:14.0.13"
   dependencies:
-    debug: "npm:^4.1.0"
+    "@mswjs/interceptors": "npm:^0.41.0"
     json-stringify-safe: "npm:^5.0.1"
     propagate: "npm:^2.0.0"
-  checksum: 10c0/94249a294176a6e521bbb763c214de4aa6b6ab63dff1e299aaaf455886a465d38906891d7f24570d94a43b1e376c239c54d89ff7697124bc57ef188006acc25e
+  checksum: 10c0/636f46b6c7f94b4d0d4c0a4db7c0084f309b7f5f64ff04a4e693d36a76286b1c16d2652045503a3f9eadca152a0a34365ec1c7f06a4b97f020c92216de5b415e
   languageName: node
   linkType: hard
 
@@ -695,6 +740,13 @@ __metadata:
   version: 8.1.1
   resolution: "normalize-url@npm:8.1.1"
   checksum: 10c0/1beb700ce42acb2288f39453cdf8001eead55bbf046d407936a40404af420b8c1c6be97a869884ae9e659d7b1c744e40e905c875ac9290644eec2e3e6fb0b370
+  languageName: node
+  linkType: hard
+
+"outvariant@npm:^1.4.0, outvariant@npm:^1.4.3":
+  version: 1.4.3
+  resolution: "outvariant@npm:1.4.3"
+  checksum: 10c0/5976ca7740349cb8c71bd3382e2a762b1aeca6f33dc984d9d896acdf3c61f78c3afcf1bfe9cc633a7b3c4b295ec94d292048f83ea2b2594fae4496656eba992c
   languageName: node
   linkType: hard
 
@@ -859,6 +911,13 @@ __metadata:
   dependencies:
     uuid: "npm:^9.0.0"
   checksum: 10c0/08cc043cc5937ced8314efb5e47dec9c71ac99da5835fd012b948f991239147e8011c727cd74ce9e99ce2923b6047d35f20e4f8dc9b3bbfea1bbea20277ee915
+  languageName: node
+  linkType: hard
+
+"strict-event-emitter@npm:^0.5.1":
+  version: 0.5.1
+  resolution: "strict-event-emitter@npm:0.5.1"
+  checksum: 10c0/f5228a6e6b6393c57f52f62e673cfe3be3294b35d6f7842fc24b172ae0a6e6c209fa83241d0e433fc267c503bc2f4ffdbe41a9990ff8ffd5ac425ec0489417f7
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
While the test itself doesn't use nock directly, the fact that other tests surrounding it do means that the request from got was going through nock's monkeypatched http modules anyway.And nock 14 started letting `write ECANCELED` errors bubble up instead of swallowing them. The test was trying to talk https to a plain TCP server which was wrong in the first place. It was only passing because nock was eating the error and got was timing out as expected.

Closes #8557
