### PR TITLE
chore(generic-worker): prefer x/sys/windows + syscall constants over locally redefined Win32 values

### DIFF
--- a/changelog/OG6Pf2zWQTqSNi2LaAGuJQ.md
+++ b/changelog/OG6Pf2zWQTqSNi2LaAGuJQ.md
@@ -1,0 +1,4 @@
+audience: developers
+level: patch
+---
+Replaced locally-redefined Win32 constants in `workers/generic-worker` with their equivalents from `golang.org/x/sys/windows` and `syscall`. No behavior change.

--- a/workers/generic-worker/interactive/conpty_windows.go
+++ b/workers/generic-worker/interactive/conpty_windows.go
@@ -31,10 +31,6 @@ func CanUseConPty() bool {
 		procUpdateProcThreadAttribute.Find() == nil
 }
 
-const (
-	PROC_THREAD_ATTRIBUTE_PSEUDOCONSOLE uintptr = 0x20016
-)
-
 type COORD struct {
 	width, height int16
 }
@@ -122,7 +118,7 @@ func getStartupInfoExForConPty(hpc HPCON) (*_StartupInfoEx, error) {
 	ret, _, err = procUpdateProcThreadAttribute.Call(
 		uintptr(unsafe.Pointer(&siEx.attributeList[0])),
 		0,
-		PROC_THREAD_ATTRIBUTE_PSEUDOCONSOLE,
+		windows.PROC_THREAD_ATTRIBUTE_PSEUDOCONSOLE,
 		uintptr(hpc),
 		unsafe.Sizeof(hpc),
 		0,

--- a/workers/generic-worker/process/logininfo_multiuser_windows.go
+++ b/workers/generic-worker/process/logininfo_multiuser_windows.go
@@ -10,6 +10,8 @@ import (
 	"time"
 	"unsafe"
 
+	"golang.org/x/sys/windows"
+
 	"github.com/taskcluster/taskcluster/v99/workers/generic-worker/win32"
 )
 
@@ -167,7 +169,7 @@ func (loginInfo *LoginInfo) SetActiveConsoleSessionId() (err error) {
 	log.Printf("Setting active console session ID to %#x", sessionId)
 	err = win32.SetTokenInformation(
 		loginInfo.hUser,
-		win32.TokenSessionId,
+		windows.TokenSessionId,
 		(*byte)(unsafe.Pointer(&sessionId)),
 		uint32(unsafe.Sizeof(sessionId)),
 	)

--- a/workers/generic-worker/process/multiuser_windows.go
+++ b/workers/generic-worker/process/multiuser_windows.go
@@ -11,6 +11,8 @@ import (
 	"syscall"
 	"time"
 
+	"golang.org/x/sys/windows"
+
 	"github.com/taskcluster/taskcluster/v99/workers/generic-worker/host"
 	gwruntime "github.com/taskcluster/taskcluster/v99/workers/generic-worker/runtime"
 	"github.com/taskcluster/taskcluster/v99/workers/generic-worker/win32"
@@ -90,16 +92,16 @@ func newCommand(f func() *exec.Cmd, workingDirectory string, env []string, pd *P
 	cmd.Env = *combined
 	cmd.Dir = workingDirectory
 	isWindows8OrGreater := win32.IsWindows8OrGreater()
-	creationFlags := uint32(win32.CREATE_NEW_PROCESS_GROUP)
+	creationFlags := uint32(windows.CREATE_NEW_PROCESS_GROUP)
 
 	if pd.HideCmdWindow {
-		creationFlags |= win32.CREATE_NO_WINDOW
+		creationFlags |= windows.CREATE_NO_WINDOW
 	} else {
-		creationFlags |= win32.CREATE_NEW_CONSOLE
+		creationFlags |= windows.CREATE_NEW_CONSOLE
 	}
 
 	if !isWindows8OrGreater {
-		creationFlags |= win32.CREATE_BREAKAWAY_FROM_JOB
+		creationFlags |= windows.CREATE_BREAKAWAY_FROM_JOB
 	}
 
 	if accessToken != 0 {

--- a/workers/generic-worker/runtime/runtime_windows.go
+++ b/workers/generic-worker/runtime/runtime_windows.go
@@ -122,7 +122,7 @@ func (osUser *OSUser) CreateUserProfile() error {
 	}
 
 	// Allocate buffer for profile path (MAX_PATH = 260)
-	profilePath := make([]uint16, 260)
+	profilePath := make([]uint16, syscall.MAX_PATH)
 
 	err = win32.CreateProfile(sidPtr, namePtr, &profilePath[0], uint32(len(profilePath)))
 	if err != nil {

--- a/workers/generic-worker/win32/win32_windows.go
+++ b/workers/generic-worker/win32/win32_windows.go
@@ -59,20 +59,18 @@ var (
 	FOLDERID_RoamingAppData = syscall.GUID{Data1: 0x3EB685DB, Data2: 0x65F9, Data3: 0x4CF6, Data4: [8]byte{0xA0, 0x3A, 0xE3, 0xEF, 0x65, 0x72, 0x9F, 0x3D}}
 )
 
+// Win32 constants not exposed by golang.org/x/sys/windows. Constants
+// that ARE provided there — CREATE_BREAKAWAY_FROM_JOB,
+// CREATE_NEW_CONSOLE, CREATE_NEW_PROCESS_GROUP, CREATE_NO_WINDOW,
+// KF_FLAG_CREATE, and the TokenInformationClass enum (TokenUser
+// through MaxTokenInfoClass) — are referenced via windows.X at the
+// call sites rather than redefined here.
 const (
 	LOGON32_PROVIDER_DEFAULT = 0
 
 	LOGON32_LOGON_INTERACTIVE = 2
 
 	PI_NOUI = 1
-
-	KF_FLAG_CREATE uint32 = 0x00008000
-
-	// https://learn.microsoft.com/en-us/windows/win32/procthread/process-creation-flags
-	CREATE_BREAKAWAY_FROM_JOB = 0x01000000
-	CREATE_NEW_CONSOLE        = 0x00000010
-	CREATE_NEW_PROCESS_GROUP  = 0x00000200
-	CREATE_NO_WINDOW          = 0x08000000
 
 	VER_MAJORVERSION     = 0x0000002
 	VER_MINORVERSION     = 0x0000001
@@ -81,51 +79,6 @@ const (
 	VER_GREATER_EQUAL    = 3
 
 	ERROR_OLD_WIN_VERSION syscall.Errno = 1150
-
-	// https://msdn.microsoft.com/en-us/library/windows/hardware/ff556838(v=vs.85).aspx
-	// TOKEN_INFORMATION_CLASS enumeration
-	TokenUser                            TOKEN_INFORMATION_CLASS = 1
-	TokenGroups                          TOKEN_INFORMATION_CLASS = 2
-	TokenPrivileges                      TOKEN_INFORMATION_CLASS = 3
-	TokenOwner                           TOKEN_INFORMATION_CLASS = 4
-	TokenPrimaryGroup                    TOKEN_INFORMATION_CLASS = 5
-	TokenDefaultDacl                     TOKEN_INFORMATION_CLASS = 6
-	TokenSourceX                         TOKEN_INFORMATION_CLASS = 7
-	TokenType                            TOKEN_INFORMATION_CLASS = 8
-	TokenImpersonationLevel              TOKEN_INFORMATION_CLASS = 9
-	TokenStatistics                      TOKEN_INFORMATION_CLASS = 10
-	TokenRestrictedSids                  TOKEN_INFORMATION_CLASS = 11
-	TokenSessionId                       TOKEN_INFORMATION_CLASS = 12
-	TokenGroupsAndPrivileges             TOKEN_INFORMATION_CLASS = 13
-	TokenSessionReference                TOKEN_INFORMATION_CLASS = 14
-	TokenSandBoxInert                    TOKEN_INFORMATION_CLASS = 15
-	TokenAuditPolicy                     TOKEN_INFORMATION_CLASS = 16
-	TokenOrigin                          TOKEN_INFORMATION_CLASS = 17
-	TokenElevationType                   TOKEN_INFORMATION_CLASS = 18
-	TokenLinkedToken                     TOKEN_INFORMATION_CLASS = 19
-	TokenElevation                       TOKEN_INFORMATION_CLASS = 20
-	TokenHasRestrictions                 TOKEN_INFORMATION_CLASS = 21
-	TokenAccessInformation               TOKEN_INFORMATION_CLASS = 22
-	TokenVirtualizationAllowed           TOKEN_INFORMATION_CLASS = 23
-	TokenVirtualizationEnabled           TOKEN_INFORMATION_CLASS = 24
-	TokenIntegrityLevel                  TOKEN_INFORMATION_CLASS = 25
-	TokenUIAccess                        TOKEN_INFORMATION_CLASS = 26
-	TokenMandatoryPolicy                 TOKEN_INFORMATION_CLASS = 27
-	TokenLogonSid                        TOKEN_INFORMATION_CLASS = 28
-	TokenIsAppContainer                  TOKEN_INFORMATION_CLASS = 29
-	TokenCapabilities                    TOKEN_INFORMATION_CLASS = 30
-	TokenAppContainerSid                 TOKEN_INFORMATION_CLASS = 31
-	TokenAppContainerNumber              TOKEN_INFORMATION_CLASS = 32
-	TokenUserClaimAttributes             TOKEN_INFORMATION_CLASS = 33
-	TokenDeviceClaimAttributes           TOKEN_INFORMATION_CLASS = 34
-	TokenRestrictedUserClaimAttributes   TOKEN_INFORMATION_CLASS = 35
-	TokenRestrictedDeviceClaimAttributes TOKEN_INFORMATION_CLASS = 36
-	TokenDeviceGroups                    TOKEN_INFORMATION_CLASS = 37
-	TokenRestrictedDeviceGroups          TOKEN_INFORMATION_CLASS = 38
-	TokenSecurityAttributes              TOKEN_INFORMATION_CLASS = 39
-	TokenIsRestricted                    TOKEN_INFORMATION_CLASS = 40
-	TokenProcessTrustLevel               TOKEN_INFORMATION_CLASS = 41
-	MaxTokenInfoClass                    TOKEN_INFORMATION_CLASS = 42
 )
 
 type TOKEN_INFORMATION_CLASS uint32
@@ -367,7 +320,7 @@ func SetAndCreateFolder(hUser syscall.Token, folder *syscall.GUID, value string)
 	if err != nil {
 		return
 	}
-	_, err = GetFolder(hUser, folder, KF_FLAG_CREATE)
+	_, err = GetFolder(hUser, folder, windows.KF_FLAG_CREATE)
 	return
 }
 
@@ -573,7 +526,7 @@ func GetLinkedToken(hToken syscall.Token) (syscall.Token, error) {
 	var linkedToken TOKEN_LINKED_TOKEN
 	tokenInformationLength := uint32(unsafe.Sizeof(linkedToken))
 	returnLength := uint32(0)
-	err := GetTokenInformation(hToken, TokenLinkedToken, (*byte)(unsafe.Pointer(&linkedToken)), tokenInformationLength, &returnLength)
+	err := GetTokenInformation(hToken, windows.TokenLinkedToken, (*byte)(unsafe.Pointer(&linkedToken)), tokenInformationLength, &returnLength)
 	if returnLength != tokenInformationLength {
 		return 0, fmt.Errorf("was expecting %v bytes of data from GetTokenInformation, but got %v bytes", returnLength, tokenInformationLength)
 	}
@@ -614,7 +567,7 @@ func GetTokenSessionID(hToken syscall.Token) (uint32, error) {
 	var tokenSessionID uint32
 	tokenInformationLength := uint32(unsafe.Sizeof(tokenSessionID))
 	returnLength := uint32(0)
-	err := GetTokenInformation(hToken, TokenSessionId, (*byte)(unsafe.Pointer(&tokenSessionID)), tokenInformationLength, &returnLength)
+	err := GetTokenInformation(hToken, windows.TokenSessionId, (*byte)(unsafe.Pointer(&tokenSessionID)), tokenInformationLength, &returnLength)
 	if returnLength != tokenInformationLength {
 		return 0, fmt.Errorf("was expecting %v bytes of data from GetTokenInformation, but got %v bytes", returnLength, tokenInformationLength)
 	}
@@ -628,7 +581,7 @@ func GetTokenUIAccess(hToken syscall.Token) (uint32, error) {
 	var tokenUIAccess uint32
 	tokenInformationLength := uint32(unsafe.Sizeof(tokenUIAccess))
 	returnLength := uint32(0)
-	err := GetTokenInformation(hToken, TokenUIAccess, (*byte)(unsafe.Pointer(&tokenUIAccess)), tokenInformationLength, &returnLength)
+	err := GetTokenInformation(hToken, windows.TokenUIAccess, (*byte)(unsafe.Pointer(&tokenUIAccess)), tokenInformationLength, &returnLength)
 	if returnLength != tokenInformationLength {
 		return 0, fmt.Errorf("was expecting %v bytes of data from GetTokenInformation, but got %v bytes", returnLength, tokenInformationLength)
 	}

--- a/workers/generic-worker/win32/win32acl_windows.go
+++ b/workers/generic-worker/win32/win32acl_windows.go
@@ -4,6 +4,8 @@ import (
 	"os"
 	"syscall"
 	"unsafe"
+
+	"golang.org/x/sys/windows"
 )
 
 var (
@@ -24,34 +26,31 @@ var (
 	procAddAccessAllowedAceEx = advapi32.NewProc("AddAccessAllowedAceEx")
 )
 
+// Win32 ACL constants not exposed by golang.org/x/sys/windows. Constants
+// that ARE provided there (DACL_SECURITY_INFORMATION, READ_CONTROL,
+// CONTAINER_INHERIT_ACE, INHERIT_ONLY_ACE, OBJECT_INHERIT_ACE,
+// NO_PROPAGATE_INHERIT_ACE) are referenced via windows.X at the call
+// sites below rather than redefined here.
 const (
-	DACL_SECURITY_INFORMATION    = 0x00000004
 	SECURITY_DESCRIPTOR_REVISION = 1
 	ACL_REVISION                 = 2
 
-	DESKTOP_CREATEMENU       = 0x4
-	DESKTOP_CREATEWINDOW     = 0x2
-	DESKTOP_ENUMERATE        = 0x40
-	DESKTOP_HOOKCONTROL      = 0x8
-	DESKTOP_JOURNALPLAYBACK  = 0x20
-	DESKTOP_JOURNALRECORD    = 0x10
-	DESKTOP_READOBJECTS      = 0x1
-	DESKTOP_SWITCHDESKTOP    = 0x100
-	DESKTOP_WRITEOBJECTS     = 0x80
-	STANDARD_RIGHTS_REQUIRED = 0x000F0000
-	READ_CONTROL             = 0x00020000
+	DESKTOP_CREATEMENU      = 0x4
+	DESKTOP_CREATEWINDOW    = 0x2
+	DESKTOP_ENUMERATE       = 0x40
+	DESKTOP_HOOKCONTROL     = 0x8
+	DESKTOP_JOURNALPLAYBACK = 0x20
+	DESKTOP_JOURNALRECORD   = 0x10
+	DESKTOP_READOBJECTS     = 0x1
+	DESKTOP_SWITCHDESKTOP   = 0x100
+	DESKTOP_WRITEOBJECTS    = 0x80
 
 	DESKTOP_ALL = DESKTOP_CREATEMENU | DESKTOP_CREATEWINDOW | DESKTOP_ENUMERATE | DESKTOP_HOOKCONTROL |
 		DESKTOP_JOURNALPLAYBACK | DESKTOP_JOURNALRECORD | DESKTOP_READOBJECTS | DESKTOP_SWITCHDESKTOP |
-		DESKTOP_WRITEOBJECTS | READ_CONTROL
+		DESKTOP_WRITEOBJECTS | windows.READ_CONTROL
 
 	WINSTA_ALL_ACCESS = 0x37F
-	WINSTA_ALL        = WINSTA_ALL_ACCESS | READ_CONTROL
-
-	CONTAINER_INHERIT_ACE    = 2
-	INHERIT_ONLY_ACE         = 8
-	OBJECT_INHERIT_ACE       = 1
-	NO_PROPAGATE_INHERIT_ACE = 4
+	WINSTA_ALL        = WINSTA_ALL_ACCESS | windows.READ_CONTROL
 )
 
 func SetAclTo(obj syscall.Handle, acl *Acl) error {
@@ -62,7 +61,7 @@ func SetAclTo(obj syscall.Handle, acl *Acl) error {
 	if err = SetSecurityDescriptorDacl(desc, true, acl, false); err != nil {
 		return err
 	}
-	return SetUserObjectSecurity(obj, DACL_SECURITY_INFORMATION, desc)
+	return SetUserObjectSecurity(obj, windows.DACL_SECURITY_INFORMATION, desc)
 }
 
 func CreateDesktopAllowAcl(sid *syscall.SID) (*Acl, error) {
@@ -89,11 +88,11 @@ func CreateWinstaAllowAcl(sid *syscall.SID) (*Acl, error) {
 	if err != nil {
 		return nil, err
 	}
-	if err = AddAccessAllowedAceEx(acl, ACL_REVISION, CONTAINER_INHERIT_ACE|INHERIT_ONLY_ACE|OBJECT_INHERIT_ACE,
+	if err = AddAccessAllowedAceEx(acl, ACL_REVISION, windows.CONTAINER_INHERIT_ACE|windows.INHERIT_ONLY_ACE|windows.OBJECT_INHERIT_ACE,
 		syscall.GENERIC_ALL, sid); err != nil {
 		return nil, err
 	}
-	if err = AddAccessAllowedAceEx(acl, ACL_REVISION, NO_PROPAGATE_INHERIT_ACE,
+	if err = AddAccessAllowedAceEx(acl, ACL_REVISION, windows.NO_PROPAGATE_INHERIT_ACE,
 		WINSTA_ALL, sid); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
>Replaced locally-redefined Win32 constants in `workers/generic-worker` with their equivalents from `golang.org/x/sys/windows` and `syscall`. No behavior change.