### PR TITLE
Fix intermittent interactive task test hang

### DIFF
--- a/changelog/issue-6822.md
+++ b/changelog/issue-6822.md
@@ -1,0 +1,3 @@
+level: silent
+reference: issue 6822
+---

--- a/workers/generic-worker/interactive/interactive_test.go
+++ b/workers/generic-worker/interactive/interactive_test.go
@@ -86,7 +86,7 @@ func testInteractive(t *testing.T, port uint16, interactiveCommands InteractiveC
 			t.Fatalf("read error: %v", err)
 		}
 		completeOutput = append(completeOutput, output...)
-		if bytes.Count(completeOutput, expectedBytes) == 3 {
+		if bytes.Count(completeOutput, expectedBytes) == 2 {
 			ok = true
 			break
 		}

--- a/workers/generic-worker/interactive/interactivejob_posix.go
+++ b/workers/generic-worker/interactive/interactivejob_posix.go
@@ -7,8 +7,10 @@ import (
 	"os"
 	"os/exec"
 	"syscall"
+	"time"
 
 	"github.com/creack/pty"
+	"golang.org/x/sys/unix"
 )
 
 type CmdPty struct {
@@ -39,6 +41,29 @@ func (itj *InteractiveJob) Setup(cmd InteractiveCmdType) {
 		close(itj.done)
 	}()
 
+	// Wait for the spawned shell to clear ICANON before returning. Until that
+	// happens, any input we forward from the websocket goes through the
+	// kernel's canonical mode line discipline (line buffering + echo), and the
+	// resulting echo trail depends on which side wins the race between our
+	// write and readline taking over.
+	waitForICANONOff(itj.inner.pty, itj.done)
+}
+
+func waitForICANONOff(p *os.File, done <-chan struct{}) {
+	fd := int(p.Fd())
+	ticker := time.NewTicker(2 * time.Millisecond)
+	defer ticker.Stop()
+	for {
+		t, err := unix.IoctlGetTermios(fd, ioctlGetTermios)
+		if err == nil && t.Lflag&unix.ICANON == 0 {
+			return
+		}
+		select {
+		case <-done:
+			return
+		case <-ticker.C:
+		}
+	}
 }
 
 func (itj *InteractiveJob) resizePty(width uint16, height uint16) error {

--- a/workers/generic-worker/interactive/termios_bsd.go
+++ b/workers/generic-worker/interactive/termios_bsd.go
@@ -1,0 +1,7 @@
+//go:build darwin || freebsd
+
+package interactive
+
+import "golang.org/x/sys/unix"
+
+const ioctlGetTermios = unix.TIOCGETA

--- a/workers/generic-worker/interactive/termios_linux.go
+++ b/workers/generic-worker/interactive/termios_linux.go
@@ -1,0 +1,7 @@
+//go:build linux
+
+package interactive
+
+import "golang.org/x/sys/unix"
+
+const ioctlGetTermios = unix.TCGETS

--- a/workers/generic-worker/interactive_test.go
+++ b/workers/generic-worker/interactive_test.go
@@ -117,7 +117,7 @@ func TestInteractiveCommand(t *testing.T) {
 						t.Fatalf("read error: %v", err)
 					}
 					completeOutput = append(completeOutput, output...)
-					if bytes.Count(completeOutput, expectedBytes) == 3 {
+					if bytes.Count(completeOutput, expectedBytes) == 2 {
 						ok = true
 						break
 					}


### PR DESCRIPTION
The interactive task test was sometimes hanging forever on:

```
goroutine 6 [IO wait]:
  ...
  github.com/gorilla/websocket.(*Conn).read(0x14000150160, 0x100f64ce4?)
        /Users/task_170723770270584/gopath1.21.6/pkg/mod/github.com/gorilla/websocket@v1.5.1/conn.go:378 +0x28
  github.com/gorilla/websocket.(*Conn).advanceFrame(0x14000150160)
        /Users/task_170723770270584/gopath1.21.6/pkg/mod/github.com/gorilla/websocket@v1.5.1/conn.go:824 +0x64
  github.com/gorilla/websocket.(*Conn).NextReader(0x14000150160)
        /Users/task_170723770270584/gopath1.21.6/pkg/mod/github.com/gorilla/websocket@v1.5.1/conn.go:1034 +0xfc
  github.com/gorilla/websocket.(*Conn).ReadMessage(0x14000206000?)
        /Users/task_170723770270584/gopath1.21.6/pkg/mod/github.com/gorilla/websocket@v1.5.1/conn.go:1120 +0x1c
  github.com/taskcluster/taskcluster/v60/workers/generic-worker/interactive.TestInteractive(0x1400013e340)
        /Users/task_170723770270584/taskcluster/workers/generic-worker/interactive/interactive_test.go:52 +0x3c8
  ...
```

The hang is very intermittent and most CI runs pass. The test sends "echo SENTINEL\n" over the websocket immediately after dialling and expects the sentinel to appear three times in the response stream (kernel canonical mode echo, readline echo as bash reads the bytes, the actual command output).

Reproducing locally with the existing test against current main, the failure mode shows up as:

```
Couldn't find expected output: "S3ntin3lValue".
Complete output: "echo S3ntin3lValue\r\n\x1b]0;...\a\x1b[?2004h
                  [user@host dir]$ echo S3ntin3lValue\r\n"
```

We can only see two sentinel matches (the kernel canonical mode echo and readline echoing the same characters as it reads them after taking over), but no third match, bash never executed the command. So the test sits there forever waiting for a third match.

After investigation it turns out that the race lives in the bash startup window, not in the test itself. When `pty.StartWithAttrs` returns, the pty is in its default termios state with `ICANON` set, so the kernel buffers input line by line and echoes it back to our side of the pty [1]. Bash then initialises readline, which calls `rl_prep_terminal` -> `tcsetattr(...)` to flip the pty out of canonical mode (clears `ICANON`, `ECHO` and a bunch of other flags).

If the websocket forwards "echo SENTINEL\n" to the pty before that transition happens, the bytes go through the canonical mode buffer first:

- the kernel echoes them back to our side of the pty, which we forward to the websocket (sentinel 1)
- the line is queued for bash's side of the pty

Bash then transitions to raw mode. Per Linux `n_tty_set_termios` [2], queued bytes are preserved across that transition (only `TCSAFLUSH` would have flushed them, and readline uses `TCSANOW`), so readline ends up reading "echo SENTINEL\n" as raw bytes. It echoes them as it reads (sentinel 2), but for reasons buried in the canonical->raw handoff, the trailing "\n" doesn't reliably trigger accept-line and bash never executes the command, the third sentinel never appears, the test waits there forever.

The solution is to wait for the spawned shell to clear ICANON itself (via `rl_prep_terminal`) before letting the websocket pumps start forwarding bytes. We do that by polling termios on the pty fd until `ICANON` is observed off, with a 2ms backoff and an early exit if the command exits before reaching that state.

Once the shell is in raw mode, the kernel's line discipline is no longer in play, the canonical mode echo path is gone, and forwarded input flows straight to readline. The resulting output is deterministic: readline echoes the typed characters (sentinel 1) and runs accept-line, the command executes (sentinel 2). The test's assertion drops from `==3` to `==2` to match.

Alternatives I tried first and rejected:

- Clearing `ICANON` ourselves with `tcsetattr` after `pty.StartWithAttrs`: works in isolation but races with readline's own `rl_prep_terminal`. If our get/set happens at the wrong time, our set writes a stale termios snapshot over bash's raw mode setup and bash hangs in startup.
- Same as above but moving the `tcsetattr` to before `cmd.Start()` so bash inherits a pre modified termios. Eliminates the get/set race, but introduces a different one: we can't clear `ECHO` at the same time (readline treats a pty whose `ECHO` is already off as intentional, password prompt style, and skips its own per-character echo). With `ECHO` left on, the kernel echoes whatever the websocket forwards, and depending on whether the write lands before or after bash's own `tcsetattr` clears `ECHO`, the test sees either two or three sentinel matches in the output. The strict equality check then fails about as often as before, just with a different reason.
- Using `term.MakeRaw`: turns off `ECHO` (and a bunch of other flags) before bash starts which as explained in the point above, we cannot do.

The fix uses `unix.IoctlGetTermios` from `golang.org/x/sys/unix`. The ioctl request number for "get termios" differs between Linux (`TCGETS`) and BSDs (`TIOCGETA`). `x/term` hides this split but only exposes `MakeRaw`, which as noted above does too much. cgo + tcgetattr(3) would also work at the cost of pulling cgo into a binary that currently doesn't have it. So two tiny platform specific files defining a single `ioctlGetTermios` constant it is...

It's worth noting that this fix is bash specific and will be a problem and need to be revisited if our interactive feature ever supports any custom command.

This was tested running `TestInteractive(Normal|WithReadyCommand)` 10000 times. It failed after a few hundred iterations before and passes now.

Fixes #6822

[1]: https://man7.org/linux/man-pages/man3/termios.3.html
[2]: https://github.com/torvalds/linux/blob/master/drivers/tty/n_tty.c