### PR TITLE
feat(ui): display artifact sizes when reported by workers

### DIFF
--- a/changelog/issue-8537.md
+++ b/changelog/issue-8537.md
@@ -1,0 +1,5 @@
+audience: users
+level: minor
+reference: issue 8537
+---
+The web UI now displays artifact sizes in the task-runs and indexed-task artifact lists, when reported by the worker. Workers that do not report a size show a blank size column.

--- a/services/web-server/src/graphql/Artifacts.graphql
+++ b/services/web-server/src/graphql/Artifacts.graphql
@@ -18,6 +18,11 @@ type Artifact {
 
   # Mime-type for the artifact.
   contentType: String!
+
+  # Size of the artifact content in bytes, if reported by the worker.
+  # Null when the worker did not report a size. Float is used because
+  # artifact sizes can exceed the 32-bit GraphQL Int range.
+  contentLength: Float
 }
 
 enum ArtifactStorageType {

--- a/ui/src/components/IndexedEntry/index.jsx
+++ b/ui/src/components/IndexedEntry/index.jsx
@@ -17,6 +17,7 @@ import { ARTIFACTS_PAGE_SIZE } from '../../utils/constants';
 import Link from '../../utils/Link';
 import { findArtifactFromTaskUrl } from '../../utils/getArtifactUrl';
 import getIconFromMime from '../../utils/getIconFromMime';
+import formatBytes from '../../utils/formatBytes';
 import { withAuth } from '../../utils/Auth';
 
 const buildArtifactUrl = ({ user, namespace, name, contentType }) => {
@@ -67,6 +68,12 @@ const buildArtifactUrl = ({ user, namespace, name, contentType }) => {
   },
   latestArtifactsListItem: {
     paddingBottom: 0,
+  },
+  sizeCell: {
+    whiteSpace: 'nowrap',
+    color: theme.palette.text.secondary,
+    marginRight: theme.spacing(1),
+    alignSelf: 'center',
   },
 }))
 export default class IndexedEntry extends Component {
@@ -148,6 +155,9 @@ export default class IndexedEntry extends Component {
                     {artifact.icon && <artifact.icon />}
                   </div>
                   {artifact.name}
+                </div>
+                <div className={classes.sizeCell}>
+                  {formatBytes(artifact.contentLength)}
                 </div>
                 <div>
                   <OpenInNewIcon />

--- a/ui/src/components/TaskRunsCard/__snapshots__/index.test.jsx.snap
+++ b/ui/src/components/TaskRunsCard/__snapshots__/index.test.jsx.snap
@@ -89,7 +89,7 @@ exports[`should render TaskRunsCard 1`] = `
                 class="MuiTypography-root MuiListItemText-secondary MuiTypography-body2 MuiTypography-colorTextSecondary MuiTypography-displayBlock"
               >
                 <button
-                  class="MuiButtonBase-root MuiButton-root MuiButton-text Label-mini-22 MuiButton-textSizeSmall MuiButton-sizeSmall Label-dense-21 Mui-disabled Label-success-25 Label-disabled-23 Mui-disabled"
+                  class="MuiButtonBase-root MuiButton-root MuiButton-text Label-mini-23 MuiButton-textSizeSmall MuiButton-sizeSmall Label-dense-22 Mui-disabled Label-success-26 Label-disabled-24 Mui-disabled"
                   disabled=""
                   tabindex="-1"
                   type="button"
@@ -120,7 +120,7 @@ exports[`should render TaskRunsCard 1`] = `
                 >
                   View Live Log 
                   <button
-                    class="MuiButtonBase-root MuiButton-root MuiButton-text TaskRunsCard-liveLogLabel-15 Label-mini-22 MuiButton-textSizeSmall MuiButton-sizeSmall Label-dense-21 Mui-disabled Label-info-28 Label-disabled-23 Mui-disabled"
+                    class="MuiButtonBase-root MuiButton-root MuiButton-text TaskRunsCard-liveLogLabel-15 Label-mini-23 MuiButton-textSizeSmall MuiButton-sizeSmall Label-dense-22 Mui-disabled Label-info-29 Label-disabled-24 Mui-disabled"
                     disabled=""
                     tabindex="-1"
                     type="button"
@@ -190,7 +190,7 @@ exports[`should render TaskRunsCard 1`] = `
                     class="MuiListItem-root TaskRunsCard-artifactsListItemContainer-7"
                   >
                     <div
-                      class="ConnectionDataTable-tableWrapper-31"
+                      class="ConnectionDataTable-tableWrapper-32"
                     >
                       <table
                         class="MuiTable-root"
@@ -227,7 +227,7 @@ exports[`should render TaskRunsCard 1`] = `
                                   class="TaskRunsCard-artifactNameWrapper-13"
                                 >
                                   <button
-                                    class="MuiButtonBase-root MuiButton-root MuiButton-text TaskRunsCard-logButton-6 Label-mini-22 MuiButton-textSizeSmall MuiButton-sizeSmall Label-dense-21 Mui-disabled Label-info-28 Label-disabled-23 Mui-disabled"
+                                    class="MuiButtonBase-root MuiButton-root MuiButton-text TaskRunsCard-logButton-6 Label-mini-23 MuiButton-textSizeSmall MuiButton-sizeSmall Label-dense-22 Mui-disabled Label-info-29 Label-disabled-24 Mui-disabled"
                                     disabled=""
                                     tabindex="-1"
                                     type="button"
@@ -244,6 +244,9 @@ exports[`should render TaskRunsCard 1`] = `
                                     public/logs/live_backing.log
                                   </div>
                                 </div>
+                                <div
+                                  class="TaskRunsCard-sizeCell-20"
+                                />
                                 <div>
                                   <svg
                                     class="mdi-icon "
@@ -312,6 +315,9 @@ exports[`should render TaskRunsCard 1`] = `
                                     public/coverage-final.json
                                   </div>
                                 </div>
+                                <div
+                                  class="TaskRunsCard-sizeCell-20"
+                                />
                                 <div>
                                   <svg
                                     class="mdi-icon "
@@ -373,7 +379,7 @@ exports[`should render TaskRunsCard 1`] = `
                                   class="TaskRunsCard-artifactNameWrapper-13"
                                 >
                                   <button
-                                    class="MuiButtonBase-root MuiButton-root MuiButton-text TaskRunsCard-logButton-6 Label-mini-22 MuiButton-textSizeSmall MuiButton-sizeSmall Label-dense-21 Mui-disabled Label-info-28 Label-disabled-23 Mui-disabled"
+                                    class="MuiButtonBase-root MuiButton-root MuiButton-text TaskRunsCard-logButton-6 Label-mini-23 MuiButton-textSizeSmall MuiButton-sizeSmall Label-dense-22 Mui-disabled Label-info-29 Label-disabled-24 Mui-disabled"
                                     disabled=""
                                     tabindex="-1"
                                     type="button"
@@ -390,6 +396,9 @@ exports[`should render TaskRunsCard 1`] = `
                                     apple/banana.log
                                   </div>
                                 </div>
+                                <div
+                                  class="TaskRunsCard-sizeCell-20"
+                                />
                                 <div>
                                   <svg
                                     class="mdi-icon "
@@ -448,7 +457,7 @@ exports[`should render TaskRunsCard 1`] = `
                 class="MuiTypography-root MuiListItemText-secondary MuiTypography-body2 MuiTypography-colorTextSecondary MuiTypography-displayBlock"
               >
                 <button
-                  class="MuiButtonBase-root MuiButton-root MuiButton-text Label-mini-22 MuiButton-textSizeSmall MuiButton-sizeSmall Label-dense-21 Mui-disabled Label-default-27 Label-disabled-23 Mui-disabled"
+                  class="MuiButtonBase-root MuiButton-root MuiButton-text Label-mini-23 MuiButton-textSizeSmall MuiButton-sizeSmall Label-dense-22 Mui-disabled Label-default-28 Label-disabled-24 Mui-disabled"
                   disabled=""
                   tabindex="-1"
                   type="button"
@@ -464,7 +473,7 @@ exports[`should render TaskRunsCard 1`] = `
           </li>
           <div
             aria-disabled="false"
-            class="MuiButtonBase-root MuiListItem-root makeStyles-listItemButtonRoot-35 MuiListItem-gutters MuiListItem-button"
+            class="MuiButtonBase-root MuiListItem-root makeStyles-listItemButtonRoot-36 MuiListItem-gutters MuiListItem-button"
             role="button"
             tabindex="0"
             title="2022-02-03T14:41:19.706Z (Copy)"
@@ -500,7 +509,7 @@ exports[`should render TaskRunsCard 1`] = `
           </div>
           <div
             aria-disabled="false"
-            class="MuiButtonBase-root MuiListItem-root makeStyles-listItemButtonRoot-35 MuiListItem-gutters MuiListItem-button"
+            class="MuiButtonBase-root MuiListItem-root makeStyles-listItemButtonRoot-36 MuiListItem-gutters MuiListItem-button"
             role="button"
             tabindex="0"
             title="2022-02-03T14:43:54.086Z (Copy)"
@@ -536,7 +545,7 @@ exports[`should render TaskRunsCard 1`] = `
           </div>
           <div
             aria-disabled="false"
-            class="MuiButtonBase-root MuiListItem-root makeStyles-listItemButtonRoot-35 MuiListItem-gutters MuiListItem-button"
+            class="MuiButtonBase-root MuiListItem-root makeStyles-listItemButtonRoot-36 MuiListItem-gutters MuiListItem-button"
             role="button"
             tabindex="0"
             title="2022-02-03T14:45:28.396Z (Copy)"
@@ -589,7 +598,7 @@ exports[`should render TaskRunsCard 1`] = `
                 class="MuiTypography-root MuiListItemText-secondary MuiTypography-body2 MuiTypography-colorTextSecondary MuiTypography-displayBlock"
               >
                 <button
-                  class="MuiButtonBase-root MuiButton-root MuiButton-text Label-mini-22 MuiButton-textSizeSmall MuiButton-sizeSmall Label-dense-21 Mui-disabled Label-default-27 Label-disabled-23 Mui-disabled"
+                  class="MuiButtonBase-root MuiButton-root MuiButton-text Label-mini-23 MuiButton-textSizeSmall MuiButton-sizeSmall Label-dense-22 Mui-disabled Label-default-28 Label-disabled-24 Mui-disabled"
                   disabled=""
                   tabindex="-1"
                   type="button"
@@ -663,7 +672,7 @@ exports[`should render TaskRunsCard 1`] = `
           </a>
           <div
             aria-disabled="false"
-            class="MuiButtonBase-root MuiListItem-root makeStyles-listItemButtonRoot-35 MuiListItem-gutters MuiListItem-button"
+            class="MuiButtonBase-root MuiListItem-root makeStyles-listItemButtonRoot-36 MuiListItem-gutters MuiListItem-button"
             role="button"
             tabindex="0"
             title="2022-02-03T15:03:54.082Z (Copy)"

--- a/ui/src/components/TaskRunsCard/index.jsx
+++ b/ui/src/components/TaskRunsCard/index.jsx
@@ -35,6 +35,7 @@ import { ARTIFACTS_PAGE_SIZE, ARTIFACTS_SHOW_MAX } from '../../utils/constants';
 import { runs } from '../../utils/prop-types';
 import { withAuth } from '../../utils/Auth';
 import { getArtifactUrl } from '../../utils/getArtifactUrl';
+import formatBytes from '../../utils/formatBytes';
 import splitTaskQueueId from '../../utils/splitTaskQueueId';
 import Link from '../../utils/Link';
 import { sortArtifacts } from './sort';
@@ -124,6 +125,12 @@ const DOTS_VARIANT_LIMIT = 5;
     },
     copyButton: {
       width: 30,
+    },
+    sizeCell: {
+      whiteSpace: 'nowrap',
+      color: theme.palette.text.secondary,
+      marginRight: theme.spacing(1),
+      alignSelf: 'center',
     },
   }),
   { withTheme: true }
@@ -321,6 +328,9 @@ export default class TaskRunsCard extends Component {
                 </Label>
               )}
               <div className={classes.artifactName}>{artifact.name}</div>
+            </div>
+            <div className={classes.sizeCell}>
+              {formatBytes(artifact.contentLength)}
             </div>
             <div>{isLogFile ? <LinkIcon /> : <OpenInNewIcon />}</div>
           </Link>

--- a/ui/src/fragments/artifacts.graphql
+++ b/ui/src/fragments/artifacts.graphql
@@ -11,6 +11,7 @@ fragment Artifacts on ArtifactsConnection {
     node {
       name
       contentType
+      contentLength
     }
   }
 }

--- a/ui/src/utils/formatBytes.js
+++ b/ui/src/utils/formatBytes.js
@@ -1,0 +1,23 @@
+const UNITS = ['B', 'KB', 'MB', 'GB', 'TB', 'PB'];
+
+export default function formatBytes(bytes) {
+  if (bytes === null || bytes === undefined || Number.isNaN(bytes)) {
+    return '';
+  }
+
+  if (bytes < 1) {
+    return `${bytes} B`;
+  }
+
+  const exponent = Math.min(
+    Math.floor(Math.log10(bytes) / 3),
+    UNITS.length - 1
+  );
+  const value = bytes / 1000 ** exponent;
+  const formatted =
+    exponent === 0 || value >= 100
+      ? value.toFixed(0)
+      : value.toFixed(1).replace(/\.0$/, '');
+
+  return `${formatted} ${UNITS[exponent]}`;
+}

--- a/ui/src/utils/formatBytes.test.js
+++ b/ui/src/utils/formatBytes.test.js
@@ -1,0 +1,38 @@
+import formatBytes from './formatBytes';
+
+describe('formatBytes', () => {
+  it('returns empty string for null or undefined', () => {
+    expect(formatBytes(null)).toBe('');
+    expect(formatBytes(undefined)).toBe('');
+  });
+
+  it('returns empty string for NaN', () => {
+    expect(formatBytes(NaN)).toBe('');
+  });
+
+  it('formats bytes', () => {
+    expect(formatBytes(0)).toBe('0 B');
+    expect(formatBytes(512)).toBe('512 B');
+    expect(formatBytes(999)).toBe('999 B');
+  });
+
+  it('formats kilobytes', () => {
+    expect(formatBytes(1000)).toBe('1 KB');
+    expect(formatBytes(1500)).toBe('1.5 KB');
+  });
+
+  it('formats megabytes', () => {
+    expect(formatBytes(1_000_000)).toBe('1 MB');
+    expect(formatBytes(2_500_000)).toBe('2.5 MB');
+  });
+
+  it('formats gigabytes and larger', () => {
+    expect(formatBytes(1e9)).toBe('1 GB');
+    expect(formatBytes(1e12)).toBe('1 TB');
+    expect(formatBytes(1e15)).toBe('1 PB');
+  });
+
+  it('drops fractional digit when value is large', () => {
+    expect(formatBytes(150_000)).toBe('150 KB');
+  });
+});

--- a/ui/src/utils/prop-types.js
+++ b/ui/src/utils/prop-types.js
@@ -58,6 +58,7 @@ export const docsPageInfo = shape({
 export const artifact = shape({
   name: string,
   contentType: string,
+  contentLength: number,
 });
 
 export const artifacts = shape({

--- a/ui/src/views/Tasks/TaskIndex/IndexedTask/artifacts.graphql
+++ b/ui/src/views/Tasks/TaskIndex/IndexedTask/artifacts.graphql
@@ -11,6 +11,7 @@ query IndexEntry($taskId: ID!, $entryConnection: PageConnection, $skip: Boolean!
       node {
         name
         contentType
+        contentLength
       }
     }
   }


### PR DESCRIPTION
Closes #8537

Adds a `contentLength` field to the GraphQL Artifact type and surfaces it in the task-runs and indexed-task artifact lists as a muted size label next to each artifact link. Workers that don't report a size render a blank cell.

>The web UI now displays artifact sizes in the task-runs and indexed-task artifact lists, when reported by the worker. Workers that do not report a size show a blank size column.

For https://community-tc.services.mozilla.com/tasks/RBPq5vCdRWSY3jz8M3_SFg, the UI changes produces:

<img width="791" height="302" alt="Screenshot 2026-05-04 at 5 31 04 PM" src="https://github.com/user-attachments/assets/3ff3896f-4898-4f6e-8889-64cc0a5cbf6e" />