### PR TITLE
Disable Happy Eyeballs in tests for the object service

### DIFF
--- a/changelog/cRn6QQeDSQ2Xoi-Vc_bx3Q.md
+++ b/changelog/cRn6QQeDSQ2Xoi-Vc_bx3Q.md
@@ -1,0 +1,2 @@
+level: silent
+---

--- a/services/object/package.json
+++ b/services/object/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "coverage": "c8 yarn test",
     "coverage:report": "c8 yarn test && c8 report --temp-directory ./coverage/tmp --reporter json --report-dir ../../artifacts",
-    "test": "NODE_OPTIONS=--network-family-autoselection=false mocha test/*_test.js test/**/*_test.js",
+    "test": "NODE_OPTIONS=--no-network-family-autoselection mocha test/*_test.js test/**/*_test.js",
     "lint": "eslint src/*.js src/**/*.js test/*.js test/**/*_test.js"
   },
   "devDependencies": {

--- a/services/object/package.json
+++ b/services/object/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "coverage": "c8 yarn test",
     "coverage:report": "c8 yarn test && c8 report --temp-directory ./coverage/tmp --reporter json --report-dir ../../artifacts",
-    "test": "mocha test/*_test.js test/**/*_test.js",
+    "test": "NODE_OPTIONS=--network-family-autoselection=false mocha test/*_test.js test/**/*_test.js",
     "lint": "eslint src/*.js src/**/*.js test/*.js test/**/*_test.js"
   },
   "devDependencies": {


### PR DESCRIPTION
Some tests in the object service (notably the GCS suite) hit external HTTPS endpoints and intermittently fail on CI with `read EINVAL`:

```
Error: read EINVAL
  at tryReadStart (node:net:775:20)
  at Socket._read (node:net:790:5)
  at MockHttpSocket.<anonymous> (node:net:788:37)
  at Object.onceWrapper (node:events:630:28)
  at MockHttpSocket.emit (node:events:509:28)
  at MockHttpSocket.emit (/builds/worker/checkouts/taskcluster/node_modules/@mswjs/interceptors/lib/node/ClientRequest-DFs7FPNi.cjs:429:10)
  at TLSSocket.<anonymous> (/builds/worker/checkouts/taskcluster/node_modules/@mswjs/interceptors/lib/node/ClientRequest-DFs7FPNi.cjs:497:9)
  at TLSSocket.emit (node:events:521:24)
  at afterConnect (node:net:1690:10)
  at afterConnectMultiple (node:net:1797:3)
```

`afterConnectMultiple` is Happy Eyeballs, which races connection attempts for both ipv4/ipv6 if both responded to the DNS query and discards the loser.

The stack trace points through `MockHttpSocket` from `@mswjs/interceptors`. There is an open upstream report for the exact same issue (mswjs/interceptors#753) which isn't fixed yet. From what I can gather from the issue, `MockHttpSocket.passthrough` caches a `_handle` reference from the initial socket which isn't invalidated when Happy Eyeballs swaps in the other-family socket and destroys the loser. Then something tries using said `_handle` which results in some very unhappy syscalls, hence the EINVAL, ECANCELED and so on.

Disabling autoselection eliminates the swap entirely.

I'm fairly certain that other occurrences of network flags in test scripts were added because of the same kind of issues related to ipv6, (libraries/api and root `generate` in the node 18 update 5e5d5dde30, services/github, added without explanation in bbe43468d9) but while the same fix might work, it feels a lot more fragile than disabling happy eyeballs entirely.