### PR TITLE
fix(tc-proxy): stub freebsd connection verifier (fixes release build)

### DIFF
--- a/changelog/issue-7388.md
+++ b/changelog/issue-7388.md
@@ -1,0 +1,5 @@
+audience: worker-deployers
+level: patch
+reference: issue 7388
+---
+Generic Worker (FreeBSD): taskcluster-proxy now cross-compiles for freebsd/amd64 and freebsd/arm64 again. The new connection-verification feature (`--allowed-user` / `--allowed-network`) only has darwin, linux, and windows implementations; on FreeBSD the proxy refuses to start if either flag is set. FreeBSD support for taskcluster-proxy is experimental.

--- a/tools/taskcluster-proxy/README.md
+++ b/tools/taskcluster-proxy/README.md
@@ -17,6 +17,11 @@ native executable.
 See [releases page](https://github.com/taskcluster/taskcluster/releases)
 and choose a download that matches your platform.
 
+> **Note:** FreeBSD builds are **experimental**. The `--allowed-user`
+> and `--allowed-network` connection-verification options are not
+> implemented on FreeBSD; the proxy will refuse to start if either is
+> set on that platform.
+
 ## Download source and install via `go get`
 
 Alternatively you can build and install from source. For this it is recommended

--- a/tools/taskcluster-proxy/connectionverifier_freebsd.go
+++ b/tools/taskcluster-proxy/connectionverifier_freebsd.go
@@ -1,0 +1,25 @@
+//go:build freebsd
+
+package main
+
+import "errors"
+
+// freebsd support for taskcluster-proxy is experimental: connection
+// verification (--allowed-user / --allowed-network) is not yet
+// implemented. The build still produces a working binary for the
+// non-verifying path, but newPlatformVerifier fails closed if the
+// operator asks for verification, rather than silently admitting all
+// connections.
+//
+// A native implementation would most likely use sockstat(1) from the
+// FreeBSD base system (lsof is a port, not base); see the darwin
+// implementation for the shape of the lookup.
+
+var errFreebsdVerifierNotImplemented = errors.New(
+	"connection verification (--allowed-user / --allowed-network) is not implemented on freebsd; " +
+		"freebsd support for taskcluster-proxy is experimental",
+)
+
+func newPlatformVerifier(_ string) (ConnectionVerifier, error) {
+	return nil, errFreebsdVerifierNotImplemented
+}


### PR DESCRIPTION
Followup to #8278.

>Generic Worker (FreeBSD): taskcluster-proxy now cross-compiles for freebsd/amd64 and freebsd/arm64 again. The new connection-verification feature (`--allowed-user` / `--allowed-network`) only has darwin, linux, and windows implementations; on FreeBSD the proxy refuses to start if either flag is set. FreeBSD support for taskcluster-proxy is experimental.