### PR TITLE
chore(codeql): point to full version tag to fix code scanning alerts [skip ci]

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -56,7 +56,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4
+      uses: github/codeql-action/init@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4.35.2
       with:
         languages: ${{ matrix.language }}
         build-mode: ${{ matrix.build-mode }}
@@ -75,4 +75,4 @@ jobs:
         ./workers/generic-worker/build.sh
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4
+      uses: github/codeql-action/analyze@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4.35.2

--- a/changelog/QDsotBE0Re63s4je-m4JKQ.md
+++ b/changelog/QDsotBE0Re63s4je-m4JKQ.md
@@ -1,0 +1,2 @@
+level: silent
+---


### PR DESCRIPTION
Fixes https://github.com/taskcluster/taskcluster/security/code-scanning/413 and https://github.com/taskcluster/taskcluster/security/code-scanning/414