### PR TITLE
chore(lint): ignore node modules during golangci-lint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -19,6 +19,7 @@ linters:
       - third_party$
       - builtin$
       - examples$
+      - node_modules
 formatters:
   exclusions:
     generated: lax
@@ -26,3 +27,4 @@ formatters:
       - third_party$
       - builtin$
       - examples$
+      - node_modules

--- a/changelog/ehaPd969TgKybszutE7W5A.md
+++ b/changelog/ehaPd969TgKybszutE7W5A.md
@@ -1,0 +1,2 @@
+level: silent
+---


### PR DESCRIPTION
Results like these don't help us:

```bash
➜  taskcluster git:(main) yarn lint:go                      
Running gofmt..
Running golangci-lint for multiuser engine..
clients/client-web/node_modules/flatted/golang/pkg/flatted/flatted.go:35:88: inline: Constant reflect.Ptr should be inlined (govet)
                if kind == reflect.String || kind == reflect.Slice || kind == reflect.Map || kind == reflect.Ptr {
                                                                                                     ^
node_modules/flatted/golang/pkg/flatted/flatted.go:35:88: inline: Constant reflect.Ptr should be inlined (govet)
                if kind == reflect.String || kind == reflect.Slice || kind == reflect.Map || kind == reflect.Ptr {
                                                                                                     ^
node_modules/flatted/golang/pkg/flatted/flatted.go:62:20: inline: Constant reflect.Ptr should be inlined (govet)
                for rv.Kind() == reflect.Ptr && !rv.IsNil() {
                                 ^
3 issues:
* govet: 3
```