### PR TITLE
Remove the interactive viewer for the now removed docker-worker

### DIFF
--- a/changelog/bV-iyQTcQdadZeiclzug2A.md
+++ b/changelog/bV-iyQTcQdadZeiclzug2A.md
@@ -1,0 +1,4 @@
+audience: users
+level: patch
+---
+Removed the interactive shell viewer for docker-worker in the UI

--- a/ui/package.json
+++ b/ui/package.json
@@ -49,7 +49,6 @@
     "deep-sort-object": "^1.0.2",
     "deepmerge": "^4.3.1",
     "dexie": "^3.2.6",
-    "docker-exec-websocket-client": "^3.0.0",
     "dot-prop-immutable": "^2.0.0",
     "error-stack-parser": "^2.0.6",
     "escape-string-regexp": "^5.0.0",

--- a/ui/src/components/Shell/index.jsx
+++ b/ui/src/components/Shell/index.jsx
@@ -2,28 +2,9 @@ import React, { Component } from 'react';
 import { withStyles } from '@material-ui/core/styles';
 import { string } from 'prop-types';
 import { hterm, lib } from 'hterm-umdjs';
-import { DockerExecClient } from 'docker-exec-websocket-client';
 import withAlertOnClose from '../../utils/withAlertOnClose';
 
 const DECODER = new TextDecoder('utf-8', { fatal: false });
-const defaultCommand = [
-  'sh',
-  '-c',
-  [
-    'if [ -f "/etc/taskcluster-motd" ]; then cat /etc/taskcluster-motd; fi;',
-    'if [ -z "$TERM" ]; then export TERM=xterm; fi;',
-    'if [ -z "$HOME" ]; then export HOME=/root; fi;',
-    'if [ -z "$USER" ]; then export USER=root; fi;',
-    'if [ -z "$LOGNAME" ]; then export LOGNAME=root; fi;',
-    'if [ -z `which "$SHELL"` ]; then export SHELL=bash; fi;',
-    'if [ -z `which "$SHELL"` ]; then export SHELL=sh; fi;',
-    'if [ -z `which "$SHELL"` ]; then export SHELL="/.taskclusterutils/busybox sh"; fi;',
-    'SPAWN="$SHELL";',
-    'if [ "$SHELL" = "bash" ]; then SPAWN="bash -li"; fi;',
-    'if [ -f "/bin/taskcluster-interactive-shell" ]; then SPAWN="/bin/taskcluster-interactive-shell"; fi;',
-    'exec $SPAWN;',
-  ].join(''),
-];
 // Keep these in sync with the go code
 const MSG_PTY_DATA = 1;
 const MSG_RESIZE_DATA = 2;
@@ -53,11 +34,6 @@ export default class Shell extends Component {
       // We do this before we connect, so that the terminal window size is known
       // when we send the window size.
       const io = terminal.io.push();
-      const options = {
-        url,
-        tty: true,
-        command: defaultCommand,
-      };
 
       io.onTerminalResize = () => null;
       terminal.setCursorPosition(0, 0);
@@ -72,42 +48,13 @@ export default class Shell extends Component {
       // Create a shell client, with interface similar to child_process
       // With an additional method client.resize(cols, rows) for TTY sizing.
       switch (version) {
-        // docker worker
+        // legacy docker worker (removed)
         case '1':
-          io.sendString = d => this.client?.stdin.write(d);
-          io.onVTKeystroke = io.sendString;
-
-          this.client = new DockerExecClient(options);
-          await this.client.execute();
-
-          this.client.resize.apply(this.client, [
-            terminal.screenSize.height,
-            terminal.screenSize.width,
-          ]);
-
-          this.client.on('exit', code => {
-            io.writeUTF8(`\r\nRemote shell exited: ${code}\r\n`);
-            terminal.uninstallKeyboard();
-            terminal.setCursorVisible(false);
-          });
-
-          this.client.resize(
-            terminal.screenSize.height,
-            terminal.screenSize.width
+          io.println(
+            'Interactive shell API version 1 (docker-worker) is no longer supported. Docker-worker has been removed, use generic-worker instead.'
           );
-          // onTerminalResize provides width then height;
-          // DockerExecClient.resize needs height then width
-          io.onTerminalResize = (cols, rows) => this.client.resize(rows, cols);
-          this.client.stdout.on('data', data =>
-            io.writeUTF8(DECODER.decode(data))
-          );
-          this.client.stderr.on('data', data =>
-            io.writeUTF8(DECODER.decode(data))
-          );
-          this.client.stdout.resume();
-          this.client.stderr.resume();
 
-          break;
+          return;
         // generic worker
         case '2':
           this.wsClient = new WebSocket(url);

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -3401,7 +3401,6 @@ __metadata:
     deep-sort-object: "npm:^1.0.2"
     deepmerge: "npm:^4.3.1"
     dexie: "npm:^3.2.6"
-    docker-exec-websocket-client: "npm:^3.0.0"
     dot-prop-immutable: "npm:^2.0.0"
     dotenv-cli: "npm:^6.0.0"
     error-stack-parser: "npm:^2.0.6"
@@ -6983,17 +6982,6 @@ __metadata:
   dependencies:
     buffer-indexof: "npm:^1.0.0"
   checksum: 10c0/71703e65156a2d626216157e6c4fddd844e7e790b6cd3cec830ef8eed80e7ea2697e5f4f2f3eb3aae809be3c91e370cad7a5d91b05ce6b6fcd5e191e7e3d31ca
-  languageName: node
-  linkType: hard
-
-"docker-exec-websocket-client@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "docker-exec-websocket-client@npm:3.0.0"
-  dependencies:
-    debug: "npm:^4.1.1"
-    through2: "npm:^4.0.2"
-    ws: "npm:^8.4.2"
-  checksum: 10c0/ba07ce147044715742aa7f2dab503a93c1eea2a9b5a3529d73399f3f76b8d6fcaa2ff8e0b187b3bd024ce6aa314aeedeee368734ddb8139ada82f89595528aa2
   languageName: node
   linkType: hard
 
@@ -14374,7 +14362,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"readable-stream@npm:3, readable-stream@npm:^3.0.6, readable-stream@npm:^3.6.0":
+"readable-stream@npm:^3.0.6, readable-stream@npm:^3.6.0":
   version: 3.6.0
   resolution: "readable-stream@npm:3.6.0"
   dependencies:
@@ -16374,15 +16362,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"through2@npm:^4.0.2":
-  version: 4.0.2
-  resolution: "through2@npm:4.0.2"
-  dependencies:
-    readable-stream: "npm:3"
-  checksum: 10c0/3741564ae99990a4a79097fe7a4152c22348adc4faf2df9199a07a66c81ed2011da39f631e479fdc56483996a9d34a037ad64e76d79f18c782ab178ea9b6778c
-  languageName: node
-  linkType: hard
-
 "through@npm:~2.3.6":
   version: 2.3.8
   resolution: "through@npm:2.3.8"
@@ -17900,21 +17879,6 @@ __metadata:
   dependencies:
     async-limiter: "npm:~1.0.0"
   checksum: 10c0/d628a1e95668a296644b4f51ce5debb43d9f1d89ebb2e32fef205a685b9439378eb824d60ce3a40bbc3bad0e887d84a56b343f2076f48d74f17c4c0800c42967
-  languageName: node
-  linkType: hard
-
-"ws@npm:^8.4.2":
-  version: 8.5.0
-  resolution: "ws@npm:8.5.0"
-  peerDependencies:
-    bufferutil: ^4.0.1
-    utf-8-validate: ^5.0.2
-  peerDependenciesMeta:
-    bufferutil:
-      optional: true
-    utf-8-validate:
-      optional: true
-  checksum: 10c0/0baeee03e97865accda8fad51e8e5fa17d19b8e264529efdf662bbba2acc1c7f1de8316287e6df5cb639231a96009e6d5234b57e6ff36ee2d04e49a0995fec2f
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Docker-worker was removed by #8555, the v1 of the interactive viewer was specially made for it and is thus useless now. Just in case someone would somehow stumble their way onto this, I added a nice message telling them that they should be using generic-worker instead.

I initially wrote the changelog as a `major` change with some reservation since docker-worker was already removed and thus this wasn't exactly a supported feature getting removed. Upon agreement in the review, I downgraded it to `patch`.

