### PR TITLE
Drop our dependency on `json-loader`

### DIFF
--- a/changelog/IFi3e7EsTU2flROVUy76sg.md
+++ b/changelog/IFi3e7EsTU2flROVUy76sg.md
@@ -1,0 +1,2 @@
+level: silent
+---

--- a/ui/package.json
+++ b/ui/package.json
@@ -59,7 +59,6 @@
     "is-absolute-url": "^4.0.1",
     "js-yaml": "^4.1.1",
     "json-e": "^4.7.1",
-    "json-loader": "^0.5.7",
     "json-schema-defaults": "^0.4.0",
     "jsonlint-mod": "^1.7.6",
     "localforage": "^1.7.3",

--- a/ui/webpack.config.js
+++ b/ui/webpack.config.js
@@ -300,7 +300,7 @@ module.exports = (_, { mode }) => ({
       },
       {
         test: /\.all-contributorsrc$/,
-        loader: "json-loader",
+        type: "json",
       },
     ],
   },

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -3429,7 +3429,6 @@ __metadata:
     jest-transform-graphql: "npm:^2.1.0"
     js-yaml: "npm:^4.1.1"
     json-e: "npm:^4.7.1"
-    json-loader: "npm:^0.5.7"
     json-schema-defaults: "npm:^0.4.0"
     jsonlint-mod: "npm:^1.7.6"
     localforage: "npm:^1.7.3"
@@ -11147,13 +11146,6 @@ __metadata:
   dependencies:
     json-stable-stringify-without-jsonify: "npm:^1.0.1"
   checksum: 10c0/b338aae43610b6b27ce6b0d4662371a2af7e96faea6d1464f294ddda78fb757fd6b6010fe048ebc54ad4fd334d5cae97ae94998a17ecbbb998cc3a59951cf594
-  languageName: node
-  linkType: hard
-
-"json-loader@npm:^0.5.7":
-  version: 0.5.7
-  resolution: "json-loader@npm:0.5.7"
-  checksum: 10c0/b155b81f644693b5418e595c127c552c34373f749d2d125df24cfe753de6b3b0af88dda5d58e7b65940ed03ec46c19fc3d09f53b932b45c9ae3ca1fb55e44a15
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This has been redundant with webpack since webpack v2 (2016). Their readme says:

> Since webpack >= v2.0.0, importing of JSON files will work by
> default. You might still want to use this if you use a custom file
> extension.

The repository for it is archived since 2018, before it was even introduced in this project (b5a07368291a598f0c2c4289225f3a7974d44b91).

The only non trivial use is for the contributors page which needed custom file extension support for the .all-contributorsrc file. But that was also fixed *before* `json-loader` was introduced in this repo (The ability to specify a rule type for a file was added in webpack 4, which this repo was on before b5a07368291a598f0c2c4289225f3a7974d44b91 already) so it had no reason to be here in the first place.
