### PR TITLE
Remove unused jest config line with a hardcoded path

### DIFF
--- a/changelog/SwhoS_KLT6mgFtVPxDegdg.md
+++ b/changelog/SwhoS_KLT6mgFtVPxDegdg.md
@@ -1,0 +1,2 @@
+level: silent
+---

--- a/ui/jest.config.js
+++ b/ui/jest.config.js
@@ -8,7 +8,6 @@ module.exports = {
     "\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$":
       "<rootDir>/__jest__/fileMock.js",
     "\\.(css|less|sass|scss)$": "<rootDir>/__jest__/styleMock.js",
-    "^@taskcluster/ui$": "/home/eijemoz/code/taskcluster/ui/src",
   },
   bail: true,
   collectCoverageFrom: ["src/**/*.{mjs,jsx,js}"],


### PR DESCRIPTION
This comes from the neutrinoff migration (8edf1b7555b2bb6856f82faecd89504423e2d9a0). I probably got what neutrino was generating and didn't triple check it properly so it passed through as is. At least we know it's not used anywhere since tests have been passing for CI and other people...