### PR TITLE
fix(ui): include runId in worker recent tasks row key to prevent duplicate rows on sort

### DIFF
--- a/changelog/issue-5431.md
+++ b/changelog/issue-5431.md
@@ -1,0 +1,5 @@
+audience: users
+level: patch
+reference: issue 5431
+---
+Fix the worker view's recent tasks table rendering duplicate rows when the same task has been run more than once on the worker.

--- a/ui/src/components/WorkerTable/index.jsx
+++ b/ui/src/components/WorkerTable/index.jsx
@@ -145,7 +145,7 @@ export default class WorkerTable extends Component {
       <DataTable
         items={items}
         renderRow={task => (
-          <TableRow key={`recent-task-${task.taskId}`}>
+          <TableRow key={`recent-task-${task.taskId}-${task.runId}`}>
             <TableCell>
               {task.state ? <StatusLabel state={task.state} /> : <em>n/a</em>}
             </TableCell>


### PR DESCRIPTION
Fixes #5431.

>Fix the worker view's recent tasks table rendering duplicate rows when the same task has been run more than once on the worker.