### PR TITLE
fix(github): set check run `started_at` to task claim time

### DIFF
--- a/changelog/issue-8631.md
+++ b/changelog/issue-8631.md
@@ -1,0 +1,5 @@
+audience: users
+level: patch
+reference: issue 8631
+---
+GitHub check runs now report `started_at` based on the time the task was actually claimed by a worker, rather than when the task was first defined. Previously, the GitHub Checks UI showed elapsed time from when a task was first scheduled, making queued/pending time appear as running time.

--- a/services/github/src/handlers/status.js
+++ b/services/github/src/handlers/status.js
@@ -165,6 +165,7 @@ export async function statusHandler(message) {
       details_url: taskUI(this.context.cfg.taskcluster.rootUrl, taskGroupId, taskId),
       status: checkRunStatus,
       conclusion,
+      started_at: runs[runId]?.started,
 
       output_title: outputTitle || `${this.context.cfg.app.statusContext} (${event_type.split('.')[0]})`,
       output_summary: outputSummary || taskDefinition.metadata.description,

--- a/services/github/src/handlers/utils.js
+++ b/services/github/src/handlers/utils.js
@@ -86,6 +86,7 @@ export class GithubCheck {
     // task resolution and status
     status = null,
     conclusion = null,
+    started_at = null,
 
     // output shown in check run details page
     output_title = '',
@@ -104,6 +105,7 @@ export class GithubCheck {
 
     this.status = status;
     this.conclusion = conclusion;
+    this.started_at = started_at;
 
     this.output = new GithubCheckOutput({
       title: output_title,
@@ -119,8 +121,11 @@ export class GithubCheck {
    * automatically resolve check run as completed
    */
   getStatusPayload() {
-    const { status, conclusion } = this;
+    const { status, conclusion, started_at } = this;
     const resolution = { status };
+    if (started_at) {
+      resolution.started_at = started_at;
+    }
     if (status === CHECK_RUN_STATES.COMPLETED) {
       resolution.conclusion = conclusion;
       resolution.completed_at = new Date().toISOString();

--- a/services/github/test/handler_test.js
+++ b/services/github/test/handler_test.js
@@ -2129,6 +2129,26 @@ helper.secrets.mockSuite(testing.suiteName(), [], function (mock, skipping) {
       await assertCheckRunStatus('in_progress');
     });
 
+    test('in_progress update sends started_at matching the worker claim time, not the queue time', async function () {
+      const claimedAt = '2026-05-15T10:00:00.000Z';
+      await addBuild({ state: 'running', taskGroupId: TASKGROUPID });
+      await addCheckRun({ taskGroupId: TASKGROUPID, taskId: TASKID });
+      await simulateExchangeMessage({
+        taskGroupId: TASKGROUPID,
+        exchange: 'exchange/taskcluster-queue/v1/task-running',
+        routingKey: 'route.checks',
+        taskId: TASKID,
+        state: 'running',
+        started: claimedAt,
+      });
+
+      assert(github.inst(9988).checks.update.calledOnce, 'checks.update was not called');
+      const [args] = github.inst(9988).checks.update.firstCall.args;
+      assert.equal(args.status, 'in_progress');
+      assert.equal(args.started_at, claimedAt,
+        'started_at must come from runs[runId].started, not GitHub defaults');
+    });
+
     test('task is rerun and queued gets a queued check result and rerequested run', async function () {
       await addBuild({ state: 'running', taskGroupId: TASKGROUPID });
       await addCheckRun({ taskGroupId: TASKGROUPID, taskId: TASKID });
@@ -2241,6 +2261,21 @@ helper.secrets.mockSuite(testing.suiteName(), [], function (mock, skipping) {
         taskId: TASKID,
       });
       assertStatusCreate('pending');
+    });
+
+    test('taskDefined create omits started_at so GitHub does not anchor elapsed time to queue time', async function () {
+      await addBuild({ state: 'pending', taskGroupId: TASKGROUPID });
+      await simulateExchangeMessage({
+        taskGroupId: TASKGROUPID,
+        exchange: 'exchange/taskcluster-queue/v1/task-defined',
+        routingKey: 'route.checks',
+        taskId: TASKID,
+      });
+
+      assert(github.inst(9988).checks.create.called, 'checks.create was not called');
+      const [args] = github.inst(9988).checks.create.firstCall.args;
+      assert.equal(args.started_at, undefined,
+        'started_at must be omitted before the worker claims the task');
     });
 
     test('skip check when build is not defined', async function () {


### PR DESCRIPTION
Fixes #8631.

>GitHub check runs now report `started_at` based on the time the task was actually claimed by a worker, rather than when the task was first defined. Previously, the GitHub Checks UI showed elapsed time from when a task was first scheduled, making queued/pending time appear as running time.