### PR TITLE
Remove use of `.map().flat()` in favor of `.flatMap`/`map`

### DIFF
--- a/changelog/d9uYuwDuSbWIwF9dtbBLNQ.md
+++ b/changelog/d9uYuwDuSbWIwF9dtbBLNQ.md
@@ -1,0 +1,2 @@
+level: silent
+---

--- a/ui/src/views/Hooks/ListHookGroups/index.jsx
+++ b/ui/src/views/Hooks/ListHookGroups/index.jsx
@@ -61,7 +61,7 @@ export default class ListHookGroups extends Component {
       data: { loading, error, hookGroups },
     } = this.props;
     const { search } = parse(window.location.search.slice(1));
-    const hookGroupIds = hookGroups?.map(group => group?.hookGroupId).flat();
+    const hookGroupIds = hookGroups?.map(group => group?.hookGroupId);
 
     return (
       <Dashboard

--- a/ui/src/views/Hooks/ListHooks/index.jsx
+++ b/ui/src/views/Hooks/ListHooks/index.jsx
@@ -69,7 +69,7 @@ export default class ListHooks extends Component {
       match,
     } = this.props;
     const { search } = parse(window.location.search.slice(1));
-    const hooks = hookGroups?.map(group => group?.hooks).flat();
+    const hooks = hookGroups?.flatMap(group => group?.hooks);
 
     return (
       <Dashboard


### PR DESCRIPTION
This fixes a biome warning (`complexity/useFlatMap`).

There were only two callsites flagged by biome. The first one actually requires the flat map; `group.hooks` is an array so the change is easy enough, switch to `flatMap`, enjoy the one saved allocation.

The second callsite actually did not need the flat map so I just dropped the `flat` part of it. Both the API and graphQL schemas type `hookGroupId` as a string. This has been working because, despite strings being iterable, they're not flattened:

```
>  ["ab", "cd"].flat()
[ 'ab', 'cd' ]
> [["ab"], ["cd"]].flat()
[ 'ab', 'cd' ]
```

(for reference, python's closest equivalent,
`itertools.chain.from_iterable`, would do `["ab", "cd"]` -> `['a', 'b', 'c', 'd']`)

After digging a bit, that code was introduced in 1dca82decf but was already useless back then and was probably copy/pasted from neighbouring code.
