### PR TITLE
Replace usage of `new Date().getTime()` with `Date.now()`

### DIFF
--- a/changelog/b4q6llG6QGWq-hcSByinwQ.md
+++ b/changelog/b4q6llG6QGWq-hcSByinwQ.md
@@ -1,0 +1,2 @@
+level: silent
+---

--- a/ui/src/components/WorkersTable/index.jsx
+++ b/ui/src/components/WorkersTable/index.jsx
@@ -318,7 +318,7 @@ export default class WorkersTable extends Component {
               )}
               <TableCell>
                 {quarantineUntil &&
-                parseISO(quarantineUntil).getTime() > new Date().getTime() ? (
+                parseISO(quarantineUntil).getTime() > Date.now() ? (
                   formatDistanceStrict(new Date(), parseISO(quarantineUntil), {
                     unit: 'day',
                   })

--- a/ui/src/utils/fromNow.test.js
+++ b/ui/src/utils/fromNow.test.js
@@ -22,9 +22,7 @@ describe('fromNow', () => {
 
   it('should generate with year+month format', () => {
     const day = 24 * 60 * 60 * 1000;
-    const date1 = new Date(
-      new Date().getTime() + 2 * 365 * day + 55 * 30 * day
-    );
+    const date1 = new Date(Date.now() + 2 * 365 * day + 55 * 30 * day);
     const date2 = fromNow('2 years 55mo');
 
     // Allow for 10ms margin
@@ -32,9 +30,7 @@ describe('fromNow', () => {
   });
 
   it('should generate with month format', () => {
-    const date1 = new Date(
-      new Date().getTime() + 240 * 30 * 24 * 60 * 60 * 1000
-    );
+    const date1 = new Date(Date.now() + 240 * 30 * 24 * 60 * 60 * 1000);
     const date2 = fromNow('240 months');
 
     // Allow for 10ms margin
@@ -42,9 +38,7 @@ describe('fromNow', () => {
   });
 
   it('should generate with -month format', () => {
-    const date1 = new Date(
-      new Date().getTime() - 240 * 30 * 24 * 60 * 60 * 1000
-    );
+    const date1 = new Date(Date.now() - 240 * 30 * 24 * 60 * 60 * 1000);
     const date2 = fromNow('-240 months');
 
     // Allow for 10ms margin

--- a/ui/src/utils/parameterizeTask.test.js
+++ b/ui/src/utils/parameterizeTask.test.js
@@ -21,12 +21,12 @@ it('should enhance task', () => {
 
   expect(enhancedTask).toHaveProperty('retries', 0);
   expect(enhancedTask).toHaveProperty('deadline');
-  expect(
-    new Date().getTime() - new Date(enhancedTask.deadline).getTime()
-  ).toBeLessThan(12 * 60 * 60 * 1000);
-  expect(
-    new Date().getTime() - new Date(enhancedTask.created).getTime()
-  ).toBeLessThan(1000);
+  expect(Date.now() - new Date(enhancedTask.deadline).getTime()).toBeLessThan(
+    12 * 60 * 60 * 1000
+  );
+  expect(Date.now() - new Date(enhancedTask.created).getTime()).toBeLessThan(
+    1000
+  );
   expect(enhancedTask).toHaveProperty('scopes', ['scope1', 'scope2:subscope3']);
   expect(enhancedTask).toHaveProperty('payload');
   expect(enhancedTask.payload).toEqual({

--- a/ui/src/utils/task.js
+++ b/ui/src/utils/task.js
@@ -33,7 +33,7 @@ export const taskRunEarliestStart = task => {
     .filter(item => item)
     .sort((a, b) => a.started - b.started);
 
-  return started.length ? new Date(started[0]).getTime() : new Date().getTime();
+  return started.length ? new Date(started[0]).getTime() : Date.now();
 };
 
 export const taskRunLatestResolve = task => {
@@ -42,7 +42,7 @@ export const taskRunLatestResolve = task => {
     .filter(item => item)
     .sort((a, b) => b - a);
 
-  return resolved.length ? resolved[0] : new Date().getTime();
+  return resolved.length ? resolved[0] : Date.now();
 };
 
 export const filterTasksByState = curry((filter, tasks) =>


### PR DESCRIPTION
This fixes a biome lint (`complexity/useDateNow`).

This avoids allocating a Date object just to extract ms from it. The behavior is otherwise unchanged.
