### PR TITLE
chore(go): address modernize warnings failing CI

### DIFF
--- a/changelog/EmXa31w5Qua8a774C0Fw0A.md
+++ b/changelog/EmXa31w5Qua8a774C0Fw0A.md
@@ -1,0 +1,2 @@
+level: silent
+---

--- a/clients/client-shell/cmds/signin/signin.go
+++ b/clients/client-shell/cmds/signin/signin.go
@@ -127,14 +127,16 @@ func cmdSignin(cmd *cobra.Command, _ []string) error {
 		loginURL += libUrls.UI(config.RootURL(), "/auth/clients/create")
 	}
 
+	var scopeBuilder strings.Builder
 	for i := range scopes {
 		if i == 0 {
-			loginURL += "?"
+			scopeBuilder.WriteString("?")
 		} else {
-			loginURL += "&"
+			scopeBuilder.WriteString("&")
 		}
-		loginURL += "scope=" + url.QueryEscape(scopes[i])
+		scopeBuilder.WriteString("scope=" + url.QueryEscape(scopes[i]))
 	}
+	loginURL += scopeBuilder.String()
 
 	loginURL += "&name=" + url.QueryEscape(name) + "-" + slugid.Nice()[0:6]
 	loginURL += "&expires=" + url.QueryEscape(expires)

--- a/tools/jsonschema2go/jsonschema.go
+++ b/tools/jsonschema2go/jsonschema.go
@@ -342,22 +342,28 @@ func (jsonSubSchema *JsonSubSchema) typeDefinition(disableNested bool, enableDef
 		metadata += "// Maximum:    " + strconv.Itoa(*maximum) + "\n"
 	}
 	if allOf := jsonSubSchema.AllOf; allOf != nil {
-		metadata += "// All of:\n"
+		var b strings.Builder
+		b.WriteString("// All of:\n")
 		for _, o := range allOf.Items {
-			metadata += "//   * " + o.getTypeName() + "\n"
+			b.WriteString("//   * " + o.getTypeName() + "\n")
 		}
+		metadata += b.String()
 	}
 	if anyOf := jsonSubSchema.AnyOf; anyOf != nil {
-		metadata += "// Any of:\n"
+		var b strings.Builder
+		b.WriteString("// Any of:\n")
 		for _, o := range anyOf.Items {
-			metadata += "//   * " + o.getTypeName() + "\n"
+			b.WriteString("//   * " + o.getTypeName() + "\n")
 		}
+		metadata += b.String()
 	}
 	if oneOf := jsonSubSchema.OneOf; oneOf != nil {
-		metadata += "// One of:\n"
+		var b strings.Builder
+		b.WriteString("// One of:\n")
 		for _, o := range oneOf.Items {
-			metadata += "//   * " + o.getTypeName() + "\n"
+			b.WriteString("//   * " + o.getTypeName() + "\n")
 		}
+		metadata += b.String()
 	}
 	// Here we check if metadata was specified, and only create new
 	// paragraph (`//\n`) if something was.
@@ -1021,12 +1027,13 @@ func (job *Job) Execute() (*Result, error) {
 package ` + job.Package + `
 
 `
-	extraPackagesContent := ""
+	var extraPackagesBuilder strings.Builder
 	for j, k := range extraPackages {
 		if k {
-			extraPackagesContent += text.Indent(""+j+"\n", "\t")
+			extraPackagesBuilder.WriteString(text.Indent(""+j+"\n", "\t"))
 		}
 	}
+	extraPackagesContent := extraPackagesBuilder.String()
 
 	if extraPackagesContent != "" {
 		content += `import (

--- a/tools/jsonschema2go/text/text.go
+++ b/tools/jsonschema2go/text/text.go
@@ -98,11 +98,12 @@ func Indent(text, indent string) string {
 		}
 		return result.String()
 	}
-	result := ""
+	var result strings.Builder
 	for j := range strings.SplitSeq(strings.TrimRight(text, "\n"), "\n") {
-		result += indent + j + "\n"
+		result.WriteString(indent + j + "\n")
 	}
-	return result[:len(result)-1]
+	s := result.String()
+	return s[:len(s)-1]
 }
 
 // Underline returns the provided text together with a new line character and a

--- a/workers/generic-worker/d2g_feature.go
+++ b/workers/generic-worker/d2g_feature.go
@@ -194,7 +194,7 @@ func (dtf *D2GTaskFeature) Start() *CommandExecutionError {
 			// Only use the first line of output for image ID
 			// as docker images can output multiple sha256's for the
 			// same image (see https://github.com/taskcluster/taskcluster/issues/7967)
-			idLine := strings.Split(strings.TrimSpace(string(out)), "\n")[0]
+			idLine, _, _ := strings.Cut(strings.TrimSpace(string(out)), "\n")
 			imageID = strings.TrimPrefix(idLine, "sha256:")
 		}
 


### PR DESCRIPTION
Latest commit to main fails the `go-modernize` task https://community-tc.services.mozilla.com/tasks/dnd6oYmXSRGP6huWIso-bg with the following:

```bash
GOFLAGS="-tags=insecure" go run golang.org/x/tools/gopls/internal/analysis/modernize/cmd/modernize@latest -test ./...
+ GOFLAGS=-tags=insecure
+ go run golang.org/x/tools/gopls/internal/analysis/modernize/cmd/modernize@latest -test ./...
go: downloading golang.org/x/tools v0.45.0
go: downloading golang.org/x/tools/gopls v0.22.0
go: downloading golang.org/x/tools v0.44.1-0.20260513175300-635ae9663724
go: downloading golang.org/x/sync v0.20.0
go: downloading golang.org/x/mod v0.35.0
/home/task_dnd6oYmXSRGP6_0/taskcluster/workers/generic-worker/d2g_feature.go:197:14: strings.Split call can be simplified using strings.Cut
/home/task_dnd6oYmXSRGP6_0/taskcluster/tools/jsonschema2go/text/text.go:103:3: using string += string in a loop is inefficient
/home/task_dnd6oYmXSRGP6_0/taskcluster/tools/jsonschema2go/jsonschema.go:347:4: using string += string in a loop is inefficient
/home/task_dnd6oYmXSRGP6_0/taskcluster/tools/jsonschema2go/jsonschema.go:1027:4: using string += string in a loop is inefficient
/home/task_dnd6oYmXSRGP6_0/taskcluster/clients/client-shell/cmds/signin/signin.go:132:4: using string += string in a loop is inefficient
exit status 3
```