### PR TITLE
Use optional chains in ui/ when applicable

### DIFF
--- a/changelog/DBTEo-SxQ36RnSYRH_pb4A.md
+++ b/changelog/DBTEo-SxQ36RnSYRH_pb4A.md
@@ -1,0 +1,2 @@
+level: silent
+---

--- a/ui/src/App/index.jsx
+++ b/ui/src/App/index.jsx
@@ -101,7 +101,7 @@ export default class App extends Component {
       connectionParams: async () => {
         const user = await this.authController.getUser();
 
-        if (user && user.credentials) {
+        if (user?.credentials) {
           return {
             Authorization: `Bearer ${btoa(JSON.stringify(user.credentials))}`,
           };
@@ -122,7 +122,7 @@ export default class App extends Component {
 
     const user = await this.authController.getUser();
 
-    if (!user || !user.credentials) {
+    if (!user?.credentials) {
       return {};
     }
 
@@ -262,7 +262,7 @@ export default class App extends Component {
                     error={error}
                     subscriptionError={subscriptionError}
                     key={
-                      auth.user && auth.user.credentials
+                      auth.user?.credentials
                         ? auth.user.credentials.clientId
                         : ''
                     }

--- a/ui/src/components/Button/index.jsx
+++ b/ui/src/components/Button/index.jsx
@@ -96,7 +96,7 @@ export default class Button extends Component {
         {children}
       </MuiComponent>
     );
-    const tooltipTitle = tooltipProps && tooltipProps.title;
+    const tooltipTitle = tooltipProps?.title;
 
     return tooltipProps ? (
       <Tooltip

--- a/ui/src/components/ConnectionDataTable/index.jsx
+++ b/ui/src/components/ConnectionDataTable/index.jsx
@@ -286,7 +286,7 @@ export default class ConnectionDataTable extends Component {
       rowHeight,
     } = this.props;
     const { count } = this.getPaginationMetadata();
-    const colSpan = columnsSize || (headers && headers.length) || 1;
+    const colSpan = columnsSize || headers?.length || 1;
     const { filterValue } = this.state;
     const { edges } = connection;
     const rows =

--- a/ui/src/components/Dashboard/DocsSidebarList.jsx
+++ b/ui/src/components/Dashboard/DocsSidebarList.jsx
@@ -189,7 +189,7 @@ export default class DocsSidebarList extends Component {
     const href = removeReadmeFromPath(join(DOCS_PATH_PREFIX, node.path));
     const isLinkActive = removeReadmeFromPath(location.pathname) === href;
 
-    if (node.children && node.children.length) {
+    if (node.children?.length) {
       const [nodes, inlineNodes] = node.children.reduce(
         (acc, curr) => {
           if (curr.data.inline) {

--- a/ui/src/components/DataTable/index.jsx
+++ b/ui/src/components/DataTable/index.jsx
@@ -145,7 +145,7 @@ export default class DataTable extends Component {
       size,
       ...props
     } = this.props;
-    const colSpan = columnsSize || (headers && headers.length) || 0;
+    const colSpan = columnsSize || headers?.length || 0;
     const { page } = this.state;
     const elements = paginate
       ? items.slice(page * rowsPerPage, page * rowsPerPage + rowsPerPage)

--- a/ui/src/components/HookForm/index.jsx
+++ b/ui/src/components/HookForm/index.jsx
@@ -294,12 +294,11 @@ export default class HookForm extends Component {
       hook: { hookId, hookGroupId },
     } = this.state;
 
-    onCreateHook &&
-      onCreateHook({
-        hookId,
-        hookGroupId,
-        payload: this.getHookDefinition(),
-      });
+    onCreateHook?.({
+      hookId,
+      hookGroupId,
+      payload: this.getHookDefinition(),
+    });
   };
 
   handleDeleteCronJob = ({ currentTarget: { name } }) => {
@@ -411,12 +410,11 @@ export default class HookForm extends Component {
       hook: { hookId, hookGroupId },
     } = this.state;
 
-    onUpdateHook &&
-      onUpdateHook({
-        hookId,
-        hookGroupId,
-        payload: this.getHookDefinition(),
-      });
+    onUpdateHook?.({
+      hookId,
+      hookGroupId,
+      payload: this.getHookDefinition(),
+    });
   };
 
   validHook = () => {
@@ -942,17 +940,16 @@ export default class HookForm extends Component {
           onClose={this.handleDrawerClose}>
           <div className={classes.metadataContainer}>
             <Typography variant="h6" className={classes.headline}>
-              {drawerData && drawerData.taskId}
+              {drawerData?.taskId}
             </Typography>
             <List>
               <ListItem>
                 <ListItemText
                   primary={
-                    drawerData &&
-                    drawerData.error && (
+                    drawerData?.error && (
                       <ErrorPanel
                         className={classes.errorPanel}
-                        error={drawerData && drawerData.error}
+                        error={drawerData?.error}
                         onClose={null}
                       />
                     )

--- a/ui/src/components/Log/index.jsx
+++ b/ui/src/components/Log/index.jsx
@@ -212,7 +212,7 @@ export default class Log extends Component {
   };
 
   handleHighlight = range => {
-    if (this.highlightRange && this.highlightRange.equals(range)) {
+    if (this.highlightRange?.equals(range)) {
       return;
     }
 
@@ -315,8 +315,7 @@ export default class Log extends Component {
               <Button
                 size="small"
                 spanProps={{
-                  className:
-                    FollowLogButtonProps && FollowLogButtonProps.className,
+                  className: FollowLogButtonProps?.className,
                 }}
                 tooltipProps={{
                   title: follow && stream ? 'Unfollow Log' : 'Follow Log',

--- a/ui/src/components/ProvisionerDetailsTable/index.jsx
+++ b/ui/src/components/ProvisionerDetailsTable/index.jsx
@@ -181,14 +181,14 @@ export default class ProvisionerDetailsTable extends Component {
     return (
       <div className={classes.metadataContainer}>
         <Typography variant="h5" className={classes.headline}>
-          {drawerProvisioner && drawerProvisioner.provisionerId}
+          {drawerProvisioner?.provisionerId}
         </Typography>
         <List>
           <ListItem>
             <ListItemText
               primary="Description"
               secondary={
-                drawerProvisioner && drawerProvisioner.description ? (
+                drawerProvisioner?.description ? (
                   <Markdown>{drawerProvisioner.description}</Markdown>
                 ) : (
                   'n/a'
@@ -200,9 +200,7 @@ export default class ProvisionerDetailsTable extends Component {
             <ListItemText
               primary="Actions"
               secondary={
-                drawerProvisioner && drawerProvisioner.actions.length
-                  ? this.renderActions()
-                  : 'n/a'
+                drawerProvisioner?.actions.length ? this.renderActions() : 'n/a'
               }
             />
           </ListItem>

--- a/ui/src/components/TaskDetailsCard/index.jsx
+++ b/ui/src/components/TaskDetailsCard/index.jsx
@@ -355,7 +355,7 @@ export default class TaskDetailsCard extends Component {
                   />
                 </ListItem>
               )}
-              {dependents && dependents.edges && dependents.edges.length ? (
+              {dependents?.edges?.length ? (
                 <Fragment>
                   <ListItem>
                     <ListItemText

--- a/ui/src/components/WorkerTypesTable/index.jsx
+++ b/ui/src/components/WorkerTypesTable/index.jsx
@@ -219,14 +219,14 @@ export default class WorkerTypesTable extends Component {
           onClose={this.handleDrawerClose}>
           <div className={classes.metadataContainer}>
             <Typography variant="h5" className={classes.headline}>
-              {drawerWorkerType && drawerWorkerType.workerType}
+              {drawerWorkerType?.workerType}
             </Typography>
             <List>
               <ListItem>
                 <ListItemText
                   primary="Description"
                   secondary={
-                    drawerWorkerType && drawerWorkerType.description ? (
+                    drawerWorkerType?.description ? (
                       <Markdown>{drawerWorkerType.description}</Markdown>
                     ) : (
                       'n/a'

--- a/ui/src/utils/api-examples/payload-generator.js
+++ b/ui/src/utils/api-examples/payload-generator.js
@@ -168,7 +168,7 @@ function resolveRef(ref, currentSchemaId, allSchemas, visitedRefs = new Set()) {
     );
 
     // If resolved schema has a $ref, resolve it recursively
-    if (resolved && resolved.$ref) {
+    if (resolved?.$ref) {
       return resolveRef(
         resolved.$ref,
         currentSchemaId,
@@ -181,9 +181,7 @@ function resolveRef(ref, currentSchemaId, allSchemas, visitedRefs = new Set()) {
   }
 
   // External reference - find schema by filename in $id
-  targetSchema = allSchemas.find(
-    s => s.content && s.content.$id && s.content.$id.endsWith(fileRef)
-  );
+  targetSchema = allSchemas.find(s => s.content?.$id?.endsWith(fileRef));
 
   if (!targetSchema) {
     return null;
@@ -197,7 +195,7 @@ function resolveRef(ref, currentSchemaId, allSchemas, visitedRefs = new Set()) {
 
   // If resolved schema has a $ref, resolve it recursively with the new
   // schema context
-  if (resolved && resolved.$ref) {
+  if (resolved?.$ref) {
     return resolveRef(
       resolved.$ref,
       targetSchema.content.$id,

--- a/ui/src/utils/formatError.js
+++ b/ui/src/utils/formatError.js
@@ -1,10 +1,5 @@
 export default err => {
-  const error =
-    (err &&
-      err.networkError &&
-      err.networkError.result &&
-      err.networkError.result.errors[0].message) ||
-    err;
+  const error = err?.networkError?.result?.errors[0].message || err;
 
   return error;
 };

--- a/ui/src/utils/getPictureFromUser.js
+++ b/ui/src/utils/getPictureFromUser.js
@@ -14,9 +14,7 @@ export default user => {
 
     // http://www.passportjs.org/docs/profile/
     case 'github': {
-      return user.profile.photos && user.profile.photos.length
-        ? user.profile.photos[0].value
-        : null;
+      return user.profile.photos?.length ? user.profile.photos[0].value : null;
     }
 
     default: {

--- a/ui/src/utils/memoize.js
+++ b/ui/src/utils/memoize.js
@@ -120,7 +120,7 @@ export { BoundedCache };
  */
 export const clearAllCaches = memoizedFunctions => {
   memoizedFunctions.forEach(fn => {
-    if (fn && fn.cache && typeof fn.cache.clear === 'function') {
+    if (fn?.cache && typeof fn.cache.clear === 'function') {
       fn.cache.clear();
     }
   });

--- a/ui/src/utils/parameterizeTask.js
+++ b/ui/src/utils/parameterizeTask.js
@@ -27,10 +27,7 @@ export default task =>
       // Delete cache scopes
       scopes: task.scopes.filter(scope => !/^docker-worker:cache:/.test(scope)),
       payload: merge(omit(['artifacts', 'cache'], task.payload || {}), {
-        maxRunTime: Math.max(
-          task.payload && task.payload.maxRunTime,
-          3 * 60 * 60
-        ),
+        maxRunTime: Math.max(task.payload?.maxRunTime, 3 * 60 * 60),
         features: {
           interactive: true,
         },

--- a/ui/src/utils/task.js
+++ b/ui/src/utils/task.js
@@ -17,7 +17,7 @@ export const taskLastRun = task => {
 };
 
 export const taskRunDurationInMs = run => {
-  if (!run || !run.from) {
+  if (!run?.from) {
     return 0;
   }
 

--- a/ui/src/views/Clients/ViewClient/index.jsx
+++ b/ui/src/views/Clients/ViewClient/index.jsx
@@ -303,16 +303,10 @@ export default class ViewClient extends Component {
       disabled: false,
     };
     const isCliLogin = Boolean(query.callback_url);
-    const isClientDisabled =
-      clientData && clientData.client && clientData.client.disabled;
+    const isClientDisabled = clientData?.client?.disabled;
 
     // CLI login
-    if (
-      isCliLogin &&
-      user &&
-      currentScopesData &&
-      currentScopesData.currentScopes
-    ) {
+    if (isCliLogin && user && currentScopesData?.currentScopes) {
       Object.assign(initialClient, {
         clientId: `${user.credentials.clientId}/${query.name}`,
         scopes: scopeIntersection(
@@ -322,7 +316,7 @@ export default class ViewClient extends Component {
       });
     }
 
-    if (location.state && location.state.accessToken) {
+    if (location.state?.accessToken) {
       const state = { ...location.state };
 
       delete state.accessToken;
@@ -376,8 +370,7 @@ export default class ViewClient extends Component {
               </Fragment>
             ) : (
               <Fragment>
-                {((clientData && clientData.loading) ||
-                  (currentScopesData && currentScopesData.loading)) && (
+                {(clientData?.loading || currentScopesData?.loading) && (
                   <Spinner loading />
                 )}
                 <ErrorPanel
@@ -386,11 +379,11 @@ export default class ViewClient extends Component {
                   error={
                     (isClientDisabled && 'Disabled') ||
                     error ||
-                    (clientData && clientData.error) ||
-                    (currentScopesData && currentScopesData.error)
+                    clientData?.error ||
+                    currentScopesData?.error
                   }
                 />
-                {clientData && clientData.client && (
+                {clientData?.client && (
                   <ClientForm
                     dialogError={dialogError}
                     loading={loading}

--- a/ui/src/views/Denylist/ViewDenylistAddress/index.jsx
+++ b/ui/src/views/Denylist/ViewDenylistAddress/index.jsx
@@ -97,9 +97,7 @@ export default class ViewDenylistAddress extends Component {
       match: { params },
     } = this.props;
     const hasDenylistAddresses = Boolean(
-      data &&
-        data.listDenylistAddresses &&
-        data.listDenylistAddresses.edges.length
+      data?.listDenylistAddresses?.edges.length
     );
 
     return (

--- a/ui/src/views/Documentation/PageMeta.jsx
+++ b/ui/src/views/Documentation/PageMeta.jsx
@@ -42,8 +42,8 @@ export default class PageMeta extends Component {
 
   render() {
     const { classes, pageInfo } = this.props;
-    const hasPreviousPage = pageInfo.prev && pageInfo.prev.path;
-    const hasNextPage = pageInfo.next && pageInfo.next.path;
+    const hasPreviousPage = pageInfo.prev?.path;
+    const hasNextPage = pageInfo.next?.path;
 
     return (
       <Fragment>

--- a/ui/src/views/Documentation/Reference/ApiReference.jsx
+++ b/ui/src/views/Documentation/Reference/ApiReference.jsx
@@ -47,8 +47,9 @@ export default class ApiReference extends Component {
       throw new Error(`Reference document version ${version} not supported`);
     }
 
-    const functionEntries =
-      ref.entries && ref.entries.filter(({ type }) => type === 'function');
+    const functionEntries = ref.entries?.filter(
+      ({ type }) => type === 'function'
+    );
     const groupedEntries = Array.from(
       this.groupBy(functionEntries, entry => entry.category)
     );

--- a/ui/src/views/Documentation/Reference/ExchangesReference.jsx
+++ b/ui/src/views/Documentation/Reference/ExchangesReference.jsx
@@ -28,9 +28,9 @@ export default class ExchangesReference extends Component {
       throw new Error(`Reference document version ${version} not supported`);
     }
 
-    const topicExchangeEntries =
-      ref.entries &&
-      ref.entries.filter(({ type }) => type === 'topic-exchange');
+    const topicExchangeEntries = ref.entries?.filter(
+      ({ type }) => type === 'topic-exchange'
+    );
 
     return (
       <div>

--- a/ui/src/views/Documentation/index.jsx
+++ b/ui/src/views/Documentation/index.jsx
@@ -149,11 +149,7 @@ export default class Documentation extends Component {
         className={classes.documentation}
         docs
         disableTitleFormatting
-        title={
-          pageInfo && pageInfo.data.title
-            ? pageInfo.data.title
-            : 'Documentation'
-        }
+        title={pageInfo?.data.title ? pageInfo.data.title : 'Documentation'}
         search={<DocSearch options={docsSearchOptions} />}>
         <ScrollToTop scrollKey={Page ? Page.toString() : null}>
           {error && error.code === 'MODULE_NOT_FOUND' && <NotFound isDocs />}

--- a/ui/src/views/Hooks/ViewHook/index.jsx
+++ b/ui/src/views/Hooks/ViewHook/index.jsx
@@ -181,7 +181,7 @@ export default class ViewHook extends Component {
       snackbar,
       exchangesDictionary,
     } = this.state;
-    const error = (data && data.error) || err;
+    const error = data?.error || err;
     const hookLastFires = data?.hookLastFires?.edges
       ?.map(({ node }) => node)
       .sort((a, b) => new Date(b.taskCreateTime) - new Date(a.taskCreateTime));

--- a/ui/src/views/Provisioners/ViewWorker/index.jsx
+++ b/ui/src/views/Provisioners/ViewWorker/index.jsx
@@ -56,10 +56,9 @@ export default class ViewWorker extends Component {
       terminateDialogTitle: '',
       terminateDialogBody: '',
       terminateDialogConfirmText: '',
-      quarantineUntilInput:
-        props.worker && props.worker.quarantineUntil
-          ? parseISO(props.worker.quarantineUntil)
-          : addYears(new Date(), 1000),
+      quarantineUntilInput: props.worker?.quarantineUntil
+        ? parseISO(props.worker.quarantineUntil)
+        : addYears(new Date(), 1000),
       quarantineInfo: '',
     };
   }

--- a/ui/src/views/Provisioners/ViewWorkers/index.jsx
+++ b/ui/src/views/Provisioners/ViewWorkers/index.jsx
@@ -195,7 +195,7 @@ export default class ViewWorkers extends Component {
     const { data } = this.props;
     const workers = path(['workers', 'edges'], data);
 
-    if (error && error.graphQLErrors && workers) {
+    if (error?.graphQLErrors && workers) {
       error.graphQLErrors.map(error => {
         const taskId = path(['requestInfo', 'params', 'taskId'], error);
 

--- a/ui/src/views/PulseMessages/index.jsx
+++ b/ui/src/views/PulseMessages/index.jsx
@@ -348,34 +348,26 @@ export default class PulseMessages extends Component {
                   <ListItem>
                     <ListItemText
                       primary="Exchange"
-                      secondary={
-                        <code>{drawerMessage && drawerMessage.exchange}</code>
-                      }
+                      secondary={<code>{drawerMessage?.exchange}</code>}
                     />
                   </ListItem>
                   <ListItem>
                     <ListItemText
                       primary="Routing Key"
-                      secondary={
-                        <code>{drawerMessage && drawerMessage.routingKey}</code>
-                      }
+                      secondary={<code>{drawerMessage?.routingKey}</code>}
                     />
                   </ListItem>
                   <ListItem>
                     <ListItemText
                       primary="Redelivered"
-                      secondary={
-                        drawerMessage && drawerMessage.redelivered
-                          ? 'True'
-                          : 'False'
-                      }
+                      secondary={drawerMessage?.redelivered ? 'True' : 'False'}
                     />
                   </ListItem>
                   <ListItem>
                     <ListItemText
                       primary="CC Routes"
                       secondary={
-                        drawerMessage && drawerMessage.cc.length ? (
+                        drawerMessage?.cc.length ? (
                           <List className={classes.ccContainer}>
                             {drawerMessage.cc.map(route => (
                               <ListItem key={route} className={classes.ccRoute}>

--- a/ui/src/views/Roles/ViewRole/index.jsx
+++ b/ui/src/views/Roles/ViewRole/index.jsx
@@ -124,7 +124,7 @@ export default class ViewRole extends Component {
             <Fragment>
               {data.loading && <Spinner loading />}
               {data && <ErrorPanel fixed error={data.error} />}
-              {data && data.role && (
+              {data?.role && (
                 <RoleForm
                   dialogError={dialogError}
                   key={data.role.roleId}

--- a/ui/src/views/Scopes/ScopesetExpander/index.jsx
+++ b/ui/src/views/Scopes/ScopesetExpander/index.jsx
@@ -99,16 +99,14 @@ export default class ScopesetExpander extends Component {
                         <Spinner />
                       </ListItem>
                     )}
-                    {data &&
-                      data.expandScopes &&
-                      data.expandScopes.map(scope => (
-                        <Link key={scope} to={scopeLink(scope)}>
-                          <ListItem button className={classes.listItemButton}>
-                            <code>{scope}</code>
-                            <LinkIcon size={16} />
-                          </ListItem>
-                        </Link>
-                      ))}
+                    {data?.expandScopes?.map(scope => (
+                      <Link key={scope} to={scopeLink(scope)}>
+                        <ListItem button className={classes.listItemButton}>
+                          <code>{scope}</code>
+                          <LinkIcon size={16} />
+                        </ListItem>
+                      </Link>
+                    ))}
                   </List>
                 </Fragment>
               )}

--- a/ui/src/views/Secrets/ViewSecret/index.jsx
+++ b/ui/src/views/Secrets/ViewSecret/index.jsx
@@ -125,7 +125,7 @@ export default class ViewSecret extends Component {
           <Fragment>
             {data.loading && <Spinner loading />}
             {data && <ErrorPanel fixed error={data.error} />}
-            {data && data.secret && (
+            {data?.secret && (
               <SecretForm
                 loading={loading}
                 secret={data.secret}

--- a/ui/src/views/Tasks/CreateTask/index.jsx
+++ b/ui/src/views/Tasks/CreateTask/index.jsx
@@ -149,7 +149,7 @@ export default class CreateTask extends Component {
       return task;
     }
 
-    if (location.state && location.state.task) {
+    if (location.state?.task) {
       return location.state.task;
     }
 
@@ -266,8 +266,8 @@ export default class CreateTask extends Component {
     const input = load(task);
     const errors = await validateTaskPayloadSchemas(
       input,
-      schema && schema.type,
-      schema && schema.schema
+      schema?.type,
+      schema?.schema
     );
 
     this.setState({

--- a/ui/src/views/Tasks/InteractiveConnect/index.jsx
+++ b/ui/src/views/Tasks/InteractiveConnect/index.jsx
@@ -132,7 +132,7 @@ export default class InteractiveConnect extends Component {
           sessionReady ||
           getInteractiveStatus({
             shellArtifact: interactives.shellArtifact,
-            taskStatusState: task && task.status.state,
+            taskStatusState: task?.status.state,
           }) === INTERACTIVE_TASK_STATUS.READY,
       };
     }
@@ -178,11 +178,7 @@ export default class InteractiveConnect extends Component {
     }
 
     // We're done fetching
-    if (
-      !task ||
-      !task.latestArtifacts ||
-      !task.latestArtifacts.pageInfo.hasNextPage
-    ) {
+    if (!task?.latestArtifacts?.pageInfo.hasNextPage) {
       previousCursor = INITIAL_CURSOR;
 
       return;
@@ -272,7 +268,7 @@ export default class InteractiveConnect extends Component {
     const { shellArtifact, notifyOnReady } = this.state;
     const interactiveStatus = getInteractiveStatus({
       shellArtifact,
-      taskStatusState: task && task.status.state,
+      taskStatusState: task?.status.state,
     });
     const isSessionReady = interactiveStatus === INTERACTIVE_TASK_STATUS.READY;
     const isSessionResolved =

--- a/ui/src/views/Tasks/TaskGroup/index.jsx
+++ b/ui/src/views/Tasks/TaskGroup/index.jsx
@@ -172,7 +172,7 @@ export default class TaskGroup extends Component {
       unscheduled: 0,
     };
 
-    if (taskGroup && taskGroup.edges) {
+    if (taskGroup?.edges) {
       taskGroup.edges.forEach(({ node }) => {
         const { state } = node.status;
 
@@ -213,10 +213,9 @@ export default class TaskGroup extends Component {
     const taskGroupLoaded = taskGroup && !taskGroup.pageInfo.hasNextPage;
     // Make sure data is not from another task group which
     // can happen when a user searches for a different task group
-    const isFromSameTaskGroupId =
-      taskGroup && taskGroup.edges[0]
-        ? taskGroup.edges[0].node.taskGroupId === taskGroupId
-        : true;
+    const isFromSameTaskGroupId = taskGroup?.edges[0]
+      ? taskGroup.edges[0].node.taskGroupId === taskGroupId
+      : true;
     const statusCount =
       isFromSameTaskGroupId && taskGroup
         ? TaskGroup.calculateStatusCountStatic(taskGroup)
@@ -394,11 +393,7 @@ export default class TaskGroup extends Component {
         const isFromSameTaskGroupId =
           tasksSubscriptions.taskGroupId === taskGroupId;
 
-        if (
-          !previousResult ||
-          !previousResult.taskGroup ||
-          !isFromSameTaskGroupId
-        ) {
+        if (!previousResult?.taskGroup || !isFromSameTaskGroupId) {
           return previousResult;
         }
 
@@ -513,7 +508,7 @@ export default class TaskGroup extends Component {
         return !taskGroupInfo || !!taskGroupInfo.sealed;
 
       case 'cancelTaskGroup':
-        return !taskGroupInfo || !taskGroupInfo.sealed;
+        return !taskGroupInfo?.sealed;
 
       default:
         return false;
@@ -902,10 +897,9 @@ export default class TaskGroup extends Component {
     } = this.props;
     // Make sure data is not from another task group which
     // can happen when a user searches for a different task group
-    const isFromSameTaskGroupId =
-      taskGroup && taskGroup.edges[0]
-        ? taskGroup.edges[0].node.taskGroupId === taskGroupId
-        : true;
+    const isFromSameTaskGroupId = taskGroup?.edges[0]
+      ? taskGroup.edges[0].node.taskGroupId === taskGroupId
+      : true;
     const notificationsCount = Object.values(notifyPreferences).filter(Boolean)
       .length;
     const graphqlError = this.getError(error);
@@ -1033,21 +1027,20 @@ export default class TaskGroup extends Component {
               tooltipTitle="Open in Profiler"
               onClick={this.handleOpenProfiler}
             />
-            {groupActions &&
-              groupActions.map(action => (
-                <SpeedDialAction
-                  requiresAuth
-                  tooltipOpen
-                  key={action.title}
-                  FabProps={{
-                    disabled:
-                      actionLoading || this.groupActionDisabled(action.name),
-                  }}
-                  icon={<HammerIcon />}
-                  tooltipTitle={action.title}
-                  onClick={this.handleActionClick(action.name)}
-                />
-              ))}
+            {groupActions?.map(action => (
+              <SpeedDialAction
+                requiresAuth
+                tooltipOpen
+                key={action.title}
+                FabProps={{
+                  disabled:
+                    actionLoading || this.groupActionDisabled(action.name),
+                }}
+                icon={<HammerIcon />}
+                tooltipTitle={action.title}
+                onClick={this.handleActionClick(action.name)}
+              />
+            ))}
           </SpeedDial>
         )}
         {dialogOpen && (

--- a/ui/src/views/Tasks/TaskIndex/IndexedTask/index.jsx
+++ b/ui/src/views/Tasks/TaskIndex/IndexedTask/index.jsx
@@ -33,7 +33,7 @@ import Link from '../../../../utils/Link';
   options: ({ indexedTaskData }) => ({
     variables: {
       skip: !indexedTaskData.indexedTask,
-      taskId: indexedTaskData.indexedTask && indexedTaskData.indexedTask.taskId,
+      taskId: indexedTaskData.indexedTask?.taskId,
       entryConnection: {
         limit: ARTIFACTS_PAGE_SIZE,
       },

--- a/ui/src/views/Tasks/TaskIndex/IndexedTask/taskGroupRedirect.jsx
+++ b/ui/src/views/Tasks/TaskIndex/IndexedTask/taskGroupRedirect.jsx
@@ -20,7 +20,7 @@ import indexedTaskQuery from './indexedTask.graphql';
   options: ({ indexedTaskData }) => ({
     variables: {
       skip: !indexedTaskData.indexedTask,
-      taskId: indexedTaskData.indexedTask && indexedTaskData.indexedTask.taskId,
+      taskId: indexedTaskData.indexedTask?.taskId,
       entryConnection: {
         limit: 1, // we don't need much for redirect, but we need the task
       },

--- a/ui/src/views/Tasks/TaskIndex/ListNamespaces/index.jsx
+++ b/ui/src/views/Tasks/TaskIndex/ListNamespaces/index.jsx
@@ -167,9 +167,8 @@ export default class ListNamespaces extends Component {
     } = this.props;
     const { indexPathInput } = this.state;
     const hasIndexedTasks =
-      taskNamespace && taskNamespace.edges && taskNamespace.edges.length > 0;
-    const hasNamespaces =
-      namespaces && namespaces.edges && namespaces.edges.length > 0;
+      taskNamespace?.edges && taskNamespace.edges.length > 0;
+    const hasNamespaces = namespaces?.edges && namespaces.edges.length > 0;
     const loading = namespacesLoading || taskNamespaceLoading;
     const indexPaths = indexPathInput.split('.');
     const isSinglePath = indexPaths.length === 1;

--- a/ui/src/views/Tasks/TaskLog/index.jsx
+++ b/ui/src/views/Tasks/TaskLog/index.jsx
@@ -40,10 +40,7 @@ import { withAuth } from '../../../utils/Auth';
 })
 export default class TaskLog extends Component {
   getCurrentRun() {
-    return (
-      this.props.data.task &&
-      this.props.data.task.status.runs[this.props.match.params.runId]
-    );
+    return this.props.data.task?.status.runs[this.props.match.params.runId];
   }
 
   getLogUrl() {
@@ -109,7 +106,7 @@ export default class TaskLog extends Component {
             onSubmit={this.handleTaskSearchSubmit}
           />
         }>
-        <Helmet state={run && run.state} />
+        <Helmet state={run?.state} />
         <Log
           url={url}
           stream={stream}

--- a/ui/src/views/Tasks/ViewTask/index.jsx
+++ b/ui/src/views/Tasks/ViewTask/index.jsx
@@ -162,8 +162,7 @@ export default class ViewTask extends Component {
         // if an action with this name has already been selected,
         // don't consider this version
         if (
-          task &&
-          task.tags &&
+          task?.tags &&
           taskInContext(action.context, task.tags) &&
           !taskActions.some(({ name }) => name === action.name)
         ) {
@@ -907,7 +906,7 @@ export default class ViewTask extends Component {
             defaultValue={match.params.taskId}
           />
         }>
-        <Helmet state={task && task.status.state} />
+        <Helmet state={task?.status.state} />
         {loading && (
           <Fragment>
             <Spinner loading />
@@ -1077,8 +1076,7 @@ export default class ViewTask extends Component {
                 tooltipTitle="Profile Task Log"
                 onClick={this.handleOpenLogProfiler}
               />
-              {taskActions &&
-                taskActions.length &&
+              {taskActions?.length &&
                 taskActions.map(action => (
                   <SpeedDialAction
                     requiresAuth

--- a/ui/src/views/ThirdPartyLogin/index.jsx
+++ b/ui/src/views/ThirdPartyLogin/index.jsx
@@ -96,7 +96,7 @@ export default class ThirdPartyLogin extends Component {
 
     return (
       <Dashboard title="Third Party Login">
-        {data && data.loading && <Spinner loading />}
+        {data?.loading && <Spinner loading />}
         {formData && (
           <AuthConsent
             transactionID={this.parsedQuery.transactionID}

--- a/ui/src/views/WorkerManager/WMEditWorkerPool/index.jsx
+++ b/ui/src/views/WorkerManager/WMEditWorkerPool/index.jsx
@@ -100,10 +100,7 @@ export default class WMEditWorkerPool extends Component {
     const { isNewWorkerPool, data, providersData, match } = this.props;
 
     // detect a ridiculous number of providers and let the user know
-    if (
-      providersData.WorkerManagerProviders &&
-      providersData.WorkerManagerProviders.pageInfo.hasNextPage
-    ) {
+    if (providersData.WorkerManagerProviders?.pageInfo.hasNextPage) {
       const err = new Error(
         'This deployment has a lot of providers; not all can be displayed here.'
       );
@@ -115,12 +112,10 @@ export default class WMEditWorkerPool extends Component {
       ? providersData.WorkerManagerProviders.edges.map(({ node }) => node)
       : [];
     const loading =
-      !providersData ||
-      !providersData.WorkerManagerProviders ||
+      !providersData?.WorkerManagerProviders ||
       providersData.loading ||
-      (!isNewWorkerPool && (!data || !data.WorkerPool || data.loading));
-    const error =
-      (providersData && providersData.error) || (data && data.error);
+      (!isNewWorkerPool && (!data?.WorkerPool || data.loading));
+    const error = providersData?.error || data?.error;
     const workerPoolId = decodeURIComponent(match.params.workerPoolId ?? '');
 
     return (

--- a/ui/src/views/WorkerManager/WMLaunchConfigs/index.jsx
+++ b/ui/src/views/WorkerManager/WMLaunchConfigs/index.jsx
@@ -132,7 +132,7 @@ export default class WMLaunchConfigs extends Component {
       workerPool,
       highlightedLaunchConfigId
     ) => {
-      if (!launchConfigsConnection || !launchConfigsConnection.edges) {
+      if (!launchConfigsConnection?.edges) {
         return launchConfigsConnection;
       }
 
@@ -223,7 +223,7 @@ export default class WMLaunchConfigs extends Component {
         workerPool,
         highlightedLaunchConfigId,
       ]) => {
-        if (!launchConfigsConnection || !launchConfigsConnection.edges) {
+        if (!launchConfigsConnection?.edges) {
           return 'empty';
         }
 
@@ -243,7 +243,7 @@ export default class WMLaunchConfigs extends Component {
    */
   sortConnection = memoize(
     (enrichedConnection, sortBy, sortDirection) => {
-      if (!enrichedConnection || !enrichedConnection.edges || !sortBy) {
+      if (!enrichedConnection?.edges || !sortBy) {
         return enrichedConnection;
       }
 
@@ -276,7 +276,7 @@ export default class WMLaunchConfigs extends Component {
     },
     {
       serializer: ([enrichedConnection, sortBy, sortDirection]) => {
-        if (!enrichedConnection || !enrichedConnection.edges) {
+        if (!enrichedConnection?.edges) {
           return `empty-${sortBy}-${sortDirection}`;
         }
 
@@ -456,8 +456,8 @@ export default class WMLaunchConfigs extends Component {
   render() {
     const { data, match, location, classes } = this.props;
     const { sortBy, sortDirection, selectedLaunchConfig } = this.state;
-    const loading = !data || !data.WorkerPoolLaunchConfigs || data.loading;
-    const error = data && data.error;
+    const loading = !data?.WorkerPoolLaunchConfigs || data.loading;
+    const error = data?.error;
     const workerPoolId = decodeURIComponent(match.params.workerPoolId ?? '');
     const errorsStats = data?.WorkerManagerErrorsStats?.totals ?? {};
     const workerPoolStats = data?.WorkerPoolStats;


### PR DESCRIPTION
This fixes the biome `useOptionalChain` lint by converting `a && a.b` to `a?.b`.

This change was done with biome with `cd ui && biome lint --only=complexity/useOptionalChain --write --unsafe src`.

Note the `--unsafe`, because the two ways of writing are not 100% the same and have a slightly different semantic in `a?.b` when `a` is `false/0/''`. All the cases here are protecting objects, arrays and graphQL result wrappers so it's safe.