### PR TITLE
Fix biome's `useExhaustiveDependencies` lint

### DIFF
--- a/changelog/UMw2wS4aTEO9mSV24lIaYw.md
+++ b/changelog/UMw2wS4aTEO9mSV24lIaYw.md
@@ -1,0 +1,2 @@
+level: silent
+---

--- a/ui/src/components/SpeedDial/index.jsx
+++ b/ui/src/components/SpeedDial/index.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useRef, useEffect } from 'react';
+import React, { useState, useRef, useEffect, useCallback } from 'react';
 import classNames from 'classnames';
 import { arrayOf, node, oneOfType } from 'prop-types';
 import { withRouter } from 'react-router-dom';
@@ -21,13 +21,12 @@ function SpeedDial(props) {
   const { classes, children, className, location, ...rest } = props;
   const [open, setOpen] = useState(false);
   const timeout = useRef(null);
-
-  function resetTimeout() {
+  const resetTimeout = useCallback(() => {
     if (timeout.current) {
       clearTimeout(timeout.current);
       timeout.current = null;
     }
-  }
+  }, []);
 
   // hide upon navigation
   useEffect(() => {
@@ -35,12 +34,12 @@ function SpeedDial(props) {
       resetTimeout();
       setOpen(false);
     };
-  }, []);
+  }, [resetTimeout]);
 
   useEffect(() => {
     resetTimeout();
     setOpen(false);
-  }, [location.pathname]);
+  }, [location.pathname, resetTimeout]);
 
   function handleClose(evt) {
     if (evt.type === 'click') {

--- a/ui/src/components/StatusDashboard/StatsFetcher.jsx
+++ b/ui/src/components/StatusDashboard/StatsFetcher.jsx
@@ -28,7 +28,11 @@ export default function StatsFetcher() {
     }, refreshInterval);
 
     return () => clearInterval(intervalRef.current);
-  }, [workerPools, refreshInterval]);
+    // TODO(borivel): Don't forget about this when switching to biome.
+    // It's ignored now because eslint want the `refreshInterval` which
+    // is a literal constant as an effect.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [workerPools]);
 
   return (
     <StatusDashboard


### PR DESCRIPTION
For `SpeedDial`, wrap `resetTimeout` in `useCallback` so its identity is stable across renders. Then list it in both effects that need it. `resetTimeout` itself only touches a ref, so an empty dependency list for `useCallback` is the right thing.

For `StatsFetcher`, drop the constant `refreshInterval` from the dependency array. Eslint doesn't complain about it but biome is unhappy about using a literal const as a dependency.

The second one sent me down a tiny rabbit hole, it currently works because the `workerPools` query identity is stable after it resolves properly once (if it wasn't then that interval would get cleared on every render).
I also don't understand why `workerPools` is the only one getting refreshed automatically here. Might be worth a follow up to either not, or to include the other queries as well. The commit that added that refresh (2ecc626ee037a36e2f9d8c2bb5ebf9434ac33712) doesn't give any reason as to why it's like this and even suggests that everything should be refreshing given the plural wording (`Values are being automatically refreshed every 30s`).

Another thing worth noting, running biome to check for more `useExhaustiveDependencies` will give a few more that are false positives. I will mark those as ignored once we switch to biome
properly.