### PR TITLE
Remove useless outer `<React.Fragment/>`

### DIFF
--- a/changelog/aeHd2o95ROypj26wmmv95g.md
+++ b/changelog/aeHd2o95ROypj26wmmv95g.md
@@ -1,0 +1,2 @@
+level: silent
+---

--- a/ui/src/components/Dashboard/index.jsx
+++ b/ui/src/components/Dashboard/index.jsx
@@ -406,14 +406,12 @@ export default class Dashboard extends Component {
               ModalProps={{
                 keepMounted: true,
               }}>
-              <Fragment>
-                <IconButton
-                  onClick={this.handleHelpViewToggle}
-                  className={classes.helpCloseIcon}>
-                  <CloseIcon />
-                </IconButton>
-                {helpView}
-              </Fragment>
+              <IconButton
+                onClick={this.handleHelpViewToggle}
+                className={classes.helpCloseIcon}>
+                <CloseIcon />
+              </IconButton>
+              {helpView}
             </Drawer>
           </Fragment>
         )}

--- a/ui/src/components/HooksListTable/index.jsx
+++ b/ui/src/components/HooksListTable/index.jsx
@@ -118,13 +118,9 @@ export default class HooksListTable extends Component {
                 {<code>{schedule[0]}</code>}
                 {schedule.length > 1 && (
                   <Tooltip
-                    title={
-                      <React.Fragment>
-                        {schedule.slice(1, 10).map(b => (
-                          <pre key={b}>{b}</pre>
-                        ))}
-                      </React.Fragment>
-                    }>
+                    title={schedule.slice(1, 10).map(b => (
+                      <pre key={b}>{b}</pre>
+                    ))}>
                     <Badge
                       badgeContent={`+${schedule.length - 1}`}
                       color="secondary"
@@ -146,13 +142,9 @@ export default class HooksListTable extends Component {
                 }
                 {bindings.length > 1 && (
                   <Tooltip
-                    title={
-                      <React.Fragment>
-                        {bindings.slice(1, 10).map(b => (
-                          <pre key={b.exchange}>{b.exchange}</pre>
-                        ))}
-                      </React.Fragment>
-                    }>
+                    title={bindings.slice(1, 10).map(b => (
+                      <pre key={b.exchange}>{b.exchange}</pre>
+                    ))}>
                     <Badge
                       badgeContent={`+${bindings.length - 1}`}
                       color="secondary"

--- a/ui/src/components/PageNavigation/index.jsx
+++ b/ui/src/components/PageNavigation/index.jsx
@@ -1,4 +1,4 @@
-import React, { Fragment, Component } from 'react';
+import React, { Component } from 'react';
 import { withStyles } from '@material-ui/core/styles';
 import Typography from '@material-ui/core/Typography';
 import ArrowRightIcon from 'mdi-react/ArrowRightIcon';
@@ -51,25 +51,21 @@ export default class PageNavigation extends Component {
     return (
       <Link className={classes.link} to={to}>
         <Button variant="outlined" className={classes.button} {...props}>
-          <Fragment>
-            {variant === 'prev' && (
-              <ArrowLeftIcon className={classes.leftIcon} />
-            )}
-            <div
-              className={
-                variant === 'prev'
-                  ? classes.leftButtonText
-                  : classes.rightButtonText
-              }>
-              <Typography variant="caption" color="textSecondary">
-                {variant}
-              </Typography>
-              <Typography variant="button">{children}</Typography>
-            </div>
-            {variant === 'next' && (
-              <ArrowRightIcon className={classes.rightIcon} />
-            )}
-          </Fragment>
+          {variant === 'prev' && <ArrowLeftIcon className={classes.leftIcon} />}
+          <div
+            className={
+              variant === 'prev'
+                ? classes.leftButtonText
+                : classes.rightButtonText
+            }>
+            <Typography variant="caption" color="textSecondary">
+              {variant}
+            </Typography>
+            <Typography variant="button">{children}</Typography>
+          </div>
+          {variant === 'next' && (
+            <ArrowRightIcon className={classes.rightIcon} />
+          )}
         </Button>
       </Link>
     );

--- a/ui/src/components/UserMenu/UserMenuList.jsx
+++ b/ui/src/components/UserMenu/UserMenuList.jsx
@@ -80,28 +80,26 @@ export default class UserMenuList extends Component {
     const profileName = username(user);
 
     return (
-      <Fragment>
-        <List component="nav">
-          <ListItem
-            className={classes.userMenu}
-            button
-            aria-haspopup="true"
-            aria-controls="user-menu"
-            aria-label="user menu"
-            onClick={onMenuClick}>
-            {avatarSrc ? (
-              <Avatar alt={profileName} src={avatarSrc} />
-            ) : (
-              <Avatar alt={profileName}>{profileName[0]}</Avatar>
-            )}
-            <ListItemText
-              primary={profileName}
-              primaryTypographyProps={{ className: classes.username }}
-              title={profileName}
-            />
-          </ListItem>
-        </List>
-      </Fragment>
+      <List component="nav">
+        <ListItem
+          className={classes.userMenu}
+          button
+          aria-haspopup="true"
+          aria-controls="user-menu"
+          aria-label="user menu"
+          onClick={onMenuClick}>
+          {avatarSrc ? (
+            <Avatar alt={profileName} src={avatarSrc} />
+          ) : (
+            <Avatar alt={profileName}>{profileName[0]}</Avatar>
+          )}
+          <ListItemText
+            primary={profileName}
+            primaryTypographyProps={{ className: classes.username }}
+            title={profileName}
+          />
+        </ListItem>
+      </List>
     );
   }
 }

--- a/ui/src/components/WMWorkerPoolEditor/index.jsx
+++ b/ui/src/components/WMWorkerPoolEditor/index.jsx
@@ -477,50 +477,46 @@ export default class WMWorkerPoolEditor extends Component {
       <Fragment>
         <ErrorPanel fixed error={error} />
         {!isNewWorkerPool && (
-          <Fragment>
-            <Paper component="ul" className={classes.overviewList}>
-              {workerPoolStats.map(
-                ({ label, value, className, Icon, href }) => {
-                  return (
-                    <ButtonBase
-                      focusRipple
-                      key={className}
-                      name={className}
-                      variant="contained"
-                      href={href}
+          <Paper component="ul" className={classes.overviewList}>
+            {workerPoolStats.map(({ label, value, className, Icon, href }) => {
+              return (
+                <ButtonBase
+                  focusRipple
+                  key={className}
+                  name={className}
+                  variant="contained"
+                  href={href}
+                  className={classNames(
+                    classes[className],
+                    classes.statusButton
+                  )}>
+                  <div>
+                    <Icon
+                      color="white"
+                      className={classes.statusIcon}
+                      size={32}
+                    />
+                  </div>
+                  <div>
+                    <Typography
+                      align="right"
+                      className={classes.statusButtonTypography}
+                      variant="h4">
+                      {value || 0}
+                    </Typography>
+                    <Typography
                       className={classNames(
-                        classes[className],
-                        classes.statusButton
-                      )}>
-                      <div>
-                        <Icon
-                          color="white"
-                          className={classes.statusIcon}
-                          size={32}
-                        />
-                      </div>
-                      <div>
-                        <Typography
-                          align="right"
-                          className={classes.statusButtonTypography}
-                          variant="h4">
-                          {value || 0}
-                        </Typography>
-                        <Typography
-                          className={classNames(
-                            classes.statusTitle,
-                            classes.statusButtonTypography
-                          )}
-                          variant="caption">
-                          {titleCase(label)}
-                        </Typography>
-                      </div>
-                    </ButtonBase>
-                  );
-                }
-              )}
-            </Paper>
-          </Fragment>
+                        classes.statusTitle,
+                        classes.statusButtonTypography
+                      )}
+                      variant="caption">
+                      {titleCase(label)}
+                    </Typography>
+                  </div>
+                </ButtonBase>
+              );
+            })}
+          </Paper>
         )}
         <List>
           <div>

--- a/ui/src/components/WorkerDetailsCard/index.jsx
+++ b/ui/src/components/WorkerDetailsCard/index.jsx
@@ -1,4 +1,4 @@
-import React, { Component, Fragment } from 'react';
+import React, { Component } from 'react';
 import { format, parseISO } from 'date-fns';
 import {
   List,
@@ -82,119 +82,117 @@ export default class WorkerDetailsCard extends Component {
       : [];
 
     return (
-      <Fragment>
-        <List>
-          <Grid container spacing={2}>
-            <Grid item xs={6}>
+      <List>
+        <Grid container spacing={2}>
+          <Grid item xs={6}>
+            <ListItem>
+              <ListItemText
+                primary="Last Active"
+                secondary={
+                  lastDateActive ? (
+                    <DateDistance from={lastDateActive} />
+                  ) : (
+                    'n/a'
+                  )
+                }
+              />
+            </ListItem>
+            <ListItem>
+              <ListItemText
+                primary="First Claim"
+                secondary={
+                  firstClaim ? <DateDistance from={firstClaim} /> : 'n/a'
+                }
+              />
+            </ListItem>
+            <ListItem>
+              <ListItemText
+                primary="Quarantine Until"
+                secondary={
+                  quarantineUntil
+                    ? format(parseISO(quarantineUntil), 'yyyy/MM/dd')
+                    : 'n/a'
+                }
+              />
+            </ListItem>
+            {sortedQuarantineDetails?.length > 0 && (
               <ListItem>
                 <ListItemText
-                  primary="Last Active"
+                  primary="Quarantine History"
                   secondary={
-                    lastDateActive ? (
-                      <DateDistance from={lastDateActive} />
-                    ) : (
-                      'n/a'
-                    )
+                    <DataTable
+                      items={sortedQuarantineDetails}
+                      renderRow={this.renderQuarantineRow}
+                      headers={[
+                        { id: 'clientId', label: 'Client ID' },
+                        { id: 'updatedAt', label: 'Date' },
+                        { id: 'quarantineUntil', label: 'Until' },
+                        { id: 'quarantineInfo', label: 'Reason' },
+                      ]}
+                      paginate
+                      noItemsMessage="No quarantine history available."
+                    />
                   }
                 />
               </ListItem>
+            )}
+            <ListItem>
+              <ListItemText
+                primary="Worker State"
+                secondary={
+                  state ? (
+                    <StatusLabel state={state.toUpperCase()} />
+                  ) : (
+                    <em>n/a</em>
+                  )
+                }
+              />
+            </ListItem>
+            {state === 'stopping' && (
               <ListItem>
-                <ListItemText
-                  primary="First Claim"
-                  secondary={
-                    firstClaim ? <DateDistance from={firstClaim} /> : 'n/a'
-                  }
-                />
+                <Label mini status="warning">
+                  Scheduled for termination
+                </Label>
               </ListItem>
-              <ListItem>
-                <ListItemText
-                  primary="Quarantine Until"
-                  secondary={
-                    quarantineUntil
-                      ? format(parseISO(quarantineUntil), 'yyyy/MM/dd')
-                      : 'n/a'
-                  }
-                />
-              </ListItem>
-              {sortedQuarantineDetails?.length > 0 && (
-                <ListItem>
-                  <ListItemText
-                    primary="Quarantine History"
-                    secondary={
-                      <DataTable
-                        items={sortedQuarantineDetails}
-                        renderRow={this.renderQuarantineRow}
-                        headers={[
-                          { id: 'clientId', label: 'Client ID' },
-                          { id: 'updatedAt', label: 'Date' },
-                          { id: 'quarantineUntil', label: 'Until' },
-                          { id: 'quarantineInfo', label: 'Reason' },
-                        ]}
-                        paginate
-                        noItemsMessage="No quarantine history available."
-                      />
-                    }
-                  />
-                </ListItem>
-              )}
-              <ListItem>
-                <ListItemText
-                  primary="Worker State"
-                  secondary={
-                    state ? (
-                      <StatusLabel state={state.toUpperCase()} />
-                    ) : (
-                      <em>n/a</em>
-                    )
-                  }
-                />
-              </ListItem>
-              {state === 'stopping' && (
-                <ListItem>
-                  <Label mini status="warning">
-                    Scheduled for termination
-                  </Label>
-                </ListItem>
-              )}
-            </Grid>
-            <Grid item xs={6}>
-              {/* worker-manager view specific info */}
-              {created && (
-                <ListItem>
-                  <ListItemText
-                    primary="Worker created"
-                    secondary={<DateDistance from={created} />}
-                  />
-                </ListItem>
-              )}
-              {expires && (
-                <ListItem>
-                  <ListItemText
-                    primary="Worker expires"
-                    secondary={<DateDistance from={expires} />}
-                  />
-                </ListItem>
-              )}
-              {lastModified && (
-                <ListItem>
-                  <ListItemText
-                    primary="Worker last modified"
-                    secondary={<DateDistance from={lastModified} />}
-                  />
-                </ListItem>
-              )}
-              {lastChecked && (
-                <ListItem>
-                  <ListItemText
-                    primary="Last checked by worker-manager"
-                    secondary={<DateDistance from={lastChecked} />}
-                  />
-                </ListItem>
-              )}
-            </Grid>
+            )}
           </Grid>
-        </List>
-      </Fragment>
+          <Grid item xs={6}>
+            {/* worker-manager view specific info */}
+            {created && (
+              <ListItem>
+                <ListItemText
+                  primary="Worker created"
+                  secondary={<DateDistance from={created} />}
+                />
+              </ListItem>
+            )}
+            {expires && (
+              <ListItem>
+                <ListItemText
+                  primary="Worker expires"
+                  secondary={<DateDistance from={expires} />}
+                />
+              </ListItem>
+            )}
+            {lastModified && (
+              <ListItem>
+                <ListItemText
+                  primary="Worker last modified"
+                  secondary={<DateDistance from={lastModified} />}
+                />
+              </ListItem>
+            )}
+            {lastChecked && (
+              <ListItem>
+                <ListItemText
+                  primary="Last checked by worker-manager"
+                  secondary={<DateDistance from={lastChecked} />}
+                />
+              </ListItem>
+            )}
+          </Grid>
+        </Grid>
+      </List>
     );
   }
 }

--- a/ui/src/views/CachePurges/CreatePurgeCacheRequest/index.jsx
+++ b/ui/src/views/CachePurges/CreatePurgeCacheRequest/index.jsx
@@ -1,4 +1,4 @@
-import React, { Component, Fragment } from 'react';
+import React, { Component } from 'react';
 import { withApollo } from 'react-apollo';
 import { withStyles } from '@material-ui/core/styles';
 import List from '@material-ui/core/List';
@@ -73,52 +73,50 @@ export default class CreatePurgeCacheRequest extends Component {
 
     return (
       <Dashboard title="Create Purge Cache Request">
-        <Fragment>
-          <ErrorPanel fixed error={error} />
-          <List>
-            <ListItem>
-              <TextField
-                label="Provisioner ID"
-                name="provisionerId"
-                onChange={this.handleInputChange}
-                fullWidth
-                value={provisionerId}
-              />
-            </ListItem>
-            <ListItem>
-              <TextField
-                label="Worker Type"
-                name="workerType"
-                onChange={this.handleInputChange}
-                fullWidth
-                value={workerType}
-              />
-            </ListItem>
-            <ListItem>
-              <TextField
-                label="Cache Name"
-                name="cacheName"
-                onChange={this.handleInputChange}
-                fullWidth
-                value={cacheName}
-              />
-            </ListItem>
-          </List>
-          <Button
-            spanProps={{ className: classes.contentSaveButtonSpan }}
-            tooltipProps={{
-              title: 'Create Request',
-              id: 'create-purge-cache-request-tooltip',
-              enterDelay: 300,
-            }}
-            requiresAuth
-            disabled={!this.isFormFilled() || actionLoading}
-            onClick={this.handleCreate}
-            variant="circular"
-            classes={{ root: classes.contentSaveIcon }}>
-            <ContentSaveIcon />
-          </Button>
-        </Fragment>
+        <ErrorPanel fixed error={error} />
+        <List>
+          <ListItem>
+            <TextField
+              label="Provisioner ID"
+              name="provisionerId"
+              onChange={this.handleInputChange}
+              fullWidth
+              value={provisionerId}
+            />
+          </ListItem>
+          <ListItem>
+            <TextField
+              label="Worker Type"
+              name="workerType"
+              onChange={this.handleInputChange}
+              fullWidth
+              value={workerType}
+            />
+          </ListItem>
+          <ListItem>
+            <TextField
+              label="Cache Name"
+              name="cacheName"
+              onChange={this.handleInputChange}
+              fullWidth
+              value={cacheName}
+            />
+          </ListItem>
+        </List>
+        <Button
+          spanProps={{ className: classes.contentSaveButtonSpan }}
+          tooltipProps={{
+            title: 'Create Request',
+            id: 'create-purge-cache-request-tooltip',
+            enterDelay: 300,
+          }}
+          requiresAuth
+          disabled={!this.isFormFilled() || actionLoading}
+          onClick={this.handleCreate}
+          variant="circular"
+          classes={{ root: classes.contentSaveIcon }}>
+          <ContentSaveIcon />
+        </Button>
       </Dashboard>
     );
   }

--- a/ui/src/views/CachePurges/ViewCachePurges/index.jsx
+++ b/ui/src/views/CachePurges/ViewCachePurges/index.jsx
@@ -1,4 +1,4 @@
-import React, { Component, Fragment } from 'react';
+import React, { Component } from 'react';
 import { graphql } from 'react-apollo';
 import dotProp from 'dot-prop-immutable';
 import { withStyles } from '@material-ui/core/styles';
@@ -109,29 +109,27 @@ export default class ViewCachePurges extends Component {
             placeholder="Cache Name contains"
           />
         }>
-        <Fragment>
-          {!cachePurges && loading && <Spinner loading />}
-          <ErrorPanel fixed error={error} />
-          {cachePurges && (
-            <CachePurgesTable
-              searchTerm={cacheSearch}
-              cachePurgesConnection={cachePurges}
-              onPageChange={this.handlePageChange}
-            />
-          )}
-          <Button
-            spanProps={{ className: classes.plusIconSpan }}
-            tooltipProps={{
-              title: 'Create Purge Cache Request',
-              id: 'create-purge-cache-tooltip',
-              delay: 300,
-            }}
-            onClick={this.handleCreate}
-            variant="circular"
-            color="secondary">
-            <PlusIcon />
-          </Button>
-        </Fragment>
+        {!cachePurges && loading && <Spinner loading />}
+        <ErrorPanel fixed error={error} />
+        {cachePurges && (
+          <CachePurgesTable
+            searchTerm={cacheSearch}
+            cachePurgesConnection={cachePurges}
+            onPageChange={this.handlePageChange}
+          />
+        )}
+        <Button
+          spanProps={{ className: classes.plusIconSpan }}
+          tooltipProps={{
+            title: 'Create Purge Cache Request',
+            id: 'create-purge-cache-tooltip',
+            delay: 300,
+          }}
+          onClick={this.handleCreate}
+          variant="circular"
+          color="secondary">
+          <PlusIcon />
+        </Button>
       </Dashboard>
     );
   }

--- a/ui/src/views/Clients/ViewClient/index.jsx
+++ b/ui/src/views/Clients/ViewClient/index.jsx
@@ -323,6 +323,52 @@ export default class ViewClient extends Component {
       this.props.history.replace({ state });
     }
 
+    const clientContent = isNewClient ? (
+      <Fragment>
+        <ErrorPanel fixed error={error} />
+        <ClientForm
+          key={this.getClientFormKey(initialClient)}
+          loading={loading}
+          client={initialClient}
+          isNewClient
+          onSaveClient={this.handleSaveClient}
+        />
+      </Fragment>
+    ) : (
+      <Fragment>
+        {(clientData?.loading || currentScopesData?.loading) && (
+          <Spinner loading />
+        )}
+        <ErrorPanel
+          fixed
+          warning={isClientDisabled}
+          error={
+            (isClientDisabled && 'Disabled') ||
+            error ||
+            clientData?.error ||
+            currentScopesData?.error
+          }
+        />
+        {clientData?.client && (
+          <ClientForm
+            dialogError={dialogError}
+            loading={loading}
+            client={clientData.client}
+            onResetAccessToken={this.handleResetAccessToken}
+            onSaveClient={this.handleSaveClient}
+            onDeleteClient={this.handleDeleteClient}
+            onDisableClient={this.handleDisableClient}
+            onEnableClient={this.handleEnableClient}
+            dialogOpen={dialogOpen}
+            onDialogActionError={this.handleDialogActionError}
+            onDialogActionComplete={this.handleDialogActionComplete}
+            onDialogActionClose={this.handleDialogActionClose}
+            onDialogActionOpen={this.handleDialogActionOpen}
+          />
+        )}
+      </Fragment>
+    );
+
     return (
       <Dashboard title={isNewClient ? 'Create Client' : 'Client'}>
         <Collapse in={accessToken}>
@@ -355,57 +401,7 @@ export default class ViewClient extends Component {
             </CardContent>
           </Card>
         </Collapse>
-        {!isCliLogin || user ? (
-          <Fragment>
-            {isNewClient ? (
-              <Fragment>
-                <ErrorPanel fixed error={error} />
-                <ClientForm
-                  key={this.getClientFormKey(initialClient)}
-                  loading={loading}
-                  client={initialClient}
-                  isNewClient
-                  onSaveClient={this.handleSaveClient}
-                />
-              </Fragment>
-            ) : (
-              <Fragment>
-                {(clientData?.loading || currentScopesData?.loading) && (
-                  <Spinner loading />
-                )}
-                <ErrorPanel
-                  fixed
-                  warning={isClientDisabled}
-                  error={
-                    (isClientDisabled && 'Disabled') ||
-                    error ||
-                    clientData?.error ||
-                    currentScopesData?.error
-                  }
-                />
-                {clientData?.client && (
-                  <ClientForm
-                    dialogError={dialogError}
-                    loading={loading}
-                    client={clientData.client}
-                    onResetAccessToken={this.handleResetAccessToken}
-                    onSaveClient={this.handleSaveClient}
-                    onDeleteClient={this.handleDeleteClient}
-                    onDisableClient={this.handleDisableClient}
-                    onEnableClient={this.handleEnableClient}
-                    dialogOpen={dialogOpen}
-                    onDialogActionError={this.handleDialogActionError}
-                    onDialogActionComplete={this.handleDialogActionComplete}
-                    onDialogActionClose={this.handleDialogActionClose}
-                    onDialogActionOpen={this.handleDialogActionOpen}
-                  />
-                )}
-              </Fragment>
-            )}
-          </Fragment>
-        ) : (
-          <SignInDialog open />
-        )}
+        {!isCliLogin || user ? clientContent : <SignInDialog open />}
         <Snackbar onClose={this.handleSnackbarClose} {...snackbar} />
       </Dashboard>
     );

--- a/ui/src/views/Clients/ViewClients/index.jsx
+++ b/ui/src/views/Clients/ViewClients/index.jsx
@@ -1,4 +1,4 @@
-import React, { PureComponent, Fragment } from 'react';
+import React, { PureComponent } from 'react';
 import { graphql, withApollo } from 'react-apollo';
 import { parse, stringify } from 'qs';
 import { withStyles } from '@material-ui/core/styles';
@@ -179,42 +179,40 @@ export default class ViewClients extends PureComponent {
             placeholder="Client contains"
           />
         }>
-        <Fragment>
-          {loading && <Spinner loading />}
-          <ErrorPanel fixed error={error} />
-          {clients && (
-            <ClientsTable
-              searchTerm={searchTerm}
-              onPageChange={this.handlePageChange}
-              clientsConnection={clients}
-              onDialogActionOpen={this.handleDialogActionOpen}
-            />
-          )}
-          <Button
-            onClick={this.handleCreate}
-            variant="circular"
-            color="secondary"
-            className={classes.plusIcon}>
-            <PlusIcon />
-          </Button>
-          {dialogOpen && (
-            <DialogAction
-              open={dialogOpen}
-              onSubmit={this.handleDeleteClient}
-              onComplete={this.handleDialogActionComplete}
-              onClose={this.handleDialogActionClose}
-              onError={this.handleDialogActionError}
-              error={dialogError}
-              title="Delete Client?"
-              body={
-                <Typography variant="body2">
-                  This will delete the {deleteClientId} client.
-                </Typography>
-              }
-              confirmText="Delete Client"
-            />
-          )}
-        </Fragment>
+        {loading && <Spinner loading />}
+        <ErrorPanel fixed error={error} />
+        {clients && (
+          <ClientsTable
+            searchTerm={searchTerm}
+            onPageChange={this.handlePageChange}
+            clientsConnection={clients}
+            onDialogActionOpen={this.handleDialogActionOpen}
+          />
+        )}
+        <Button
+          onClick={this.handleCreate}
+          variant="circular"
+          color="secondary"
+          className={classes.plusIcon}>
+          <PlusIcon />
+        </Button>
+        {dialogOpen && (
+          <DialogAction
+            open={dialogOpen}
+            onSubmit={this.handleDeleteClient}
+            onComplete={this.handleDialogActionComplete}
+            onClose={this.handleDialogActionClose}
+            onError={this.handleDialogActionError}
+            error={dialogError}
+            title="Delete Client?"
+            body={
+              <Typography variant="body2">
+                This will delete the {deleteClientId} client.
+              </Typography>
+            }
+            confirmText="Delete Client"
+          />
+        )}
       </Dashboard>
     );
   }

--- a/ui/src/views/Hooks/ViewHook/index.jsx
+++ b/ui/src/views/Hooks/ViewHook/index.jsx
@@ -201,15 +201,13 @@ export default class ViewHook extends Component {
         </Breadcrumbs>
         <ErrorPanel fixed error={error} />
         {isNewHook ? (
-          <Fragment>
-            <HookForm
-              isNewHook
-              dialogError={dialogError}
-              actionLoading={actionLoading}
-              onCreateHook={this.handleCreateHook}
-              exchangesDictionary={exchangesDictionary}
-            />
-          </Fragment>
+          <HookForm
+            isNewHook
+            dialogError={dialogError}
+            actionLoading={actionLoading}
+            onCreateHook={this.handleCreateHook}
+            exchangesDictionary={exchangesDictionary}
+          />
         ) : (
           <Fragment>
             {!data.hook && data.loading && <Spinner loading />}

--- a/ui/src/views/Provisioners/ViewWorker/index.jsx
+++ b/ui/src/views/Provisioners/ViewWorker/index.jsx
@@ -343,12 +343,10 @@ export default class ViewWorker extends Component {
               title="Quarantine?"
               body={
                 <Fragment>
-                  <Fragment>
-                    Quarantining a worker allows the machine to remain alive but
-                    not accept jobs. Note that a quarantine can be lifted by
-                    setting &quot;Quarantine Until&quot; to the present time or
-                    somewhere in the past.
-                  </Fragment>
+                  Quarantining a worker allows the machine to remain alive but
+                  not accept jobs. Note that a quarantine can be lifted by
+                  setting &quot;Quarantine Until&quot; to the present time or
+                  somewhere in the past.
                   <br />
                   <br />
                   <TextField
@@ -441,12 +439,10 @@ export default class ViewWorker extends Component {
 
     return (
       <Dashboard title="Worker">
-        <Fragment>
-          {loading && <Spinner loading />}
-          <ErrorPanel fixed error={graphqlError} />
-          {worker && this.renderQueueWorker()}
-          {!worker && WorkerManagerWorker && this.renderWorkerManagerWorker()}
-        </Fragment>
+        {loading && <Spinner loading />}
+        <ErrorPanel fixed error={graphqlError} />
+        {worker && this.renderQueueWorker()}
+        {!worker && WorkerManagerWorker && this.renderWorkerManagerWorker()}
       </Dashboard>
     );
   }

--- a/ui/src/views/Provisioners/ViewWorkerTypes/index.jsx
+++ b/ui/src/views/Provisioners/ViewWorkerTypes/index.jsx
@@ -97,50 +97,46 @@ export default class ViewWorkerTypes extends Component {
 
     return (
       <Dashboard title="Worker Types">
-        <Fragment>
-          {!workerTypes && loading && <Spinner loading />}
-          <ErrorPanel fixed error={error} />
-          {provisioners && workerTypes && (
-            <Fragment>
-              <div className={classes.bar}>
-                <Breadcrumbs classes={{ paper: classes.breadcrumbsPaper }}>
-                  <Link to="/provisioners">
-                    <Typography variant="body2" className={classes.link}>
-                      Workers
-                    </Typography>
-                  </Link>
-                  <Typography variant="body2" color="textSecondary">
-                    {`${provisionerId}`}
+        {!workerTypes && loading && <Spinner loading />}
+        <ErrorPanel fixed error={error} />
+        {provisioners && workerTypes && (
+          <Fragment>
+            <div className={classes.bar}>
+              <Breadcrumbs classes={{ paper: classes.breadcrumbsPaper }}>
+                <Link to="/provisioners">
+                  <Typography variant="body2" className={classes.link}>
+                    Workers
                   </Typography>
-                </Breadcrumbs>
-                <TextField
-                  disabled={loading}
-                  className={classes.dropdown}
-                  select
-                  label="Provisioner ID"
-                  value={provisionerId}
-                  onChange={this.handleProvisionerChange}>
-                  <MenuItem value="">
-                    <em>None</em>
+                </Link>
+                <Typography variant="body2" color="textSecondary">
+                  {`${provisionerId}`}
+                </Typography>
+              </Breadcrumbs>
+              <TextField
+                disabled={loading}
+                className={classes.dropdown}
+                select
+                label="Provisioner ID"
+                value={provisionerId}
+                onChange={this.handleProvisionerChange}>
+                <MenuItem value="">
+                  <em>None</em>
+                </MenuItem>
+                {provisioners.edges.map(({ node }) => (
+                  <MenuItem key={node.provisionerId} value={node.provisionerId}>
+                    {node.provisionerId}
                   </MenuItem>
-                  {provisioners.edges.map(({ node }) => (
-                    <MenuItem
-                      key={node.provisionerId}
-                      value={node.provisionerId}>
-                      {node.provisionerId}
-                    </MenuItem>
-                  ))}
-                </TextField>
-              </div>
-              <br />
-              <WorkerTypesTable
-                workerTypesConnection={workerTypes}
-                provisionerId={provisionerId}
-                onPageChange={this.handlePageChange}
-              />
-            </Fragment>
-          )}
-        </Fragment>
+                ))}
+              </TextField>
+            </div>
+            <br />
+            <WorkerTypesTable
+              workerTypesConnection={workerTypes}
+              provisionerId={provisionerId}
+              onPageChange={this.handlePageChange}
+            />
+          </Fragment>
+        )}
       </Dashboard>
     );
   }

--- a/ui/src/views/Provisioners/ViewWorkers/index.jsx
+++ b/ui/src/views/Provisioners/ViewWorkers/index.jsx
@@ -1,4 +1,4 @@
-import React, { Component, Fragment } from 'react';
+import React, { Component } from 'react';
 import { graphql } from 'react-apollo';
 import dotProp from 'dot-prop-immutable';
 import { parse, stringify } from 'qs';
@@ -230,91 +230,89 @@ export default class ViewWorkers extends Component {
 
     return (
       <Dashboard title="Workers">
-        <Fragment>
-          {(!workers || !workerType) && loading && <Spinner loading />}
-          {!shouldIgnoreGraphqlError && <ErrorPanel fixed error={error} />}
+        {(!workers || !workerType) && loading && <Spinner loading />}
+        {!shouldIgnoreGraphqlError && <ErrorPanel fixed error={error} />}
 
-          {shouldIgnoreGraphqlError && this.state.error && (
-            <ErrorPanel fixed error={this.state.error} />
-          )}
-          <Box className={classes.bar}>
-            <Breadcrumbs classes={{ paper: classes.breadcrumbsPaper }}>
-              <Link to="/provisioners">
-                <Typography variant="body2" className={classes.link}>
-                  Workers
-                </Typography>
-              </Link>
-              <Link to={`/provisioners/${params.provisionerId}`}>
-                <Typography variant="body2" className={classes.link}>
-                  {params.provisionerId}
-                </Typography>
-              </Link>
-              <Typography variant="body2" color="textSecondary">
-                {`${params.workerType}`}
+        {shouldIgnoreGraphqlError && this.state.error && (
+          <ErrorPanel fixed error={this.state.error} />
+        )}
+        <Box className={classes.bar}>
+          <Breadcrumbs classes={{ paper: classes.breadcrumbsPaper }}>
+            <Link to="/provisioners">
+              <Typography variant="body2" className={classes.link}>
+                Workers
               </Typography>
-              <WorkersNavbar
-                provisionerId={params.provisionerId}
-                workerType={params.workerType}
-                hasWorkerPool={!!WorkerPool?.workerPoolId}
-              />
-            </Breadcrumbs>
-
-            <Box marginTop={-2}>
-              <TextField
-                disabled={loading}
-                className={classes.dropdown}
-                select
-                label="Filter By"
-                value={query.filterBy || ''}
-                onChange={this.handleFilterChange}>
-                <MenuItem value="">
-                  <em>None</em>
-                </MenuItem>
-                <MenuItem value="quarantined">Quarantined</MenuItem>
-                <MenuItem value="running">Running</MenuItem>
-                <MenuItem value="stopping">Stopping</MenuItem>
-                <MenuItem value="stopped">Stopped</MenuItem>
-              </TextField>
-            </Box>
-          </Box>
-          <br />
-          <WorkersTable
-            workersConnection={workers}
-            onPageChange={this.handlePageChange}
-            workerType={params.workerType}
-            provisionerId={params.provisionerId}
-          />
-          {workerType?.actions?.length ? (
-            <SpeedDial>
-              {workerType.actions.map(action => (
-                <SpeedDialAction
-                  requiresAuth
-                  tooltipOpen
-                  key={action.title}
-                  FabProps={{
-                    disabled: actionLoading,
-                  }}
-                  icon={<HammerIcon />}
-                  tooltipTitle={action.title}
-                  onClick={() => this.handleActionClick(action)}
-                />
-              ))}
-            </SpeedDial>
-          ) : null}
-          {dialogOpen && (
-            <DialogAction
-              error={dialogError}
-              open={dialogOpen}
-              title={`${selectedAction.title}?`}
-              body={selectedAction.description}
-              confirmText={selectedAction.title}
-              onSubmit={this.handleActionSubmit}
-              onError={this.handleActionError}
-              onComplete={this.handleDialogClose}
-              onClose={this.handleDialogClose}
+            </Link>
+            <Link to={`/provisioners/${params.provisionerId}`}>
+              <Typography variant="body2" className={classes.link}>
+                {params.provisionerId}
+              </Typography>
+            </Link>
+            <Typography variant="body2" color="textSecondary">
+              {`${params.workerType}`}
+            </Typography>
+            <WorkersNavbar
+              provisionerId={params.provisionerId}
+              workerType={params.workerType}
+              hasWorkerPool={!!WorkerPool?.workerPoolId}
             />
-          )}
-        </Fragment>
+          </Breadcrumbs>
+
+          <Box marginTop={-2}>
+            <TextField
+              disabled={loading}
+              className={classes.dropdown}
+              select
+              label="Filter By"
+              value={query.filterBy || ''}
+              onChange={this.handleFilterChange}>
+              <MenuItem value="">
+                <em>None</em>
+              </MenuItem>
+              <MenuItem value="quarantined">Quarantined</MenuItem>
+              <MenuItem value="running">Running</MenuItem>
+              <MenuItem value="stopping">Stopping</MenuItem>
+              <MenuItem value="stopped">Stopped</MenuItem>
+            </TextField>
+          </Box>
+        </Box>
+        <br />
+        <WorkersTable
+          workersConnection={workers}
+          onPageChange={this.handlePageChange}
+          workerType={params.workerType}
+          provisionerId={params.provisionerId}
+        />
+        {workerType?.actions?.length ? (
+          <SpeedDial>
+            {workerType.actions.map(action => (
+              <SpeedDialAction
+                requiresAuth
+                tooltipOpen
+                key={action.title}
+                FabProps={{
+                  disabled: actionLoading,
+                }}
+                icon={<HammerIcon />}
+                tooltipTitle={action.title}
+                onClick={() => this.handleActionClick(action)}
+              />
+            ))}
+          </SpeedDial>
+        ) : null}
+        {dialogOpen && (
+          <DialogAction
+            error={dialogError}
+            open={dialogOpen}
+            title={`${selectedAction.title}?`}
+            body={selectedAction.description}
+            confirmText={selectedAction.title}
+            onSubmit={this.handleActionSubmit}
+            onError={this.handleActionError}
+            onComplete={this.handleDialogClose}
+            onClose={this.handleDialogClose}
+          />
+        )}
       </Dashboard>
     );
   }

--- a/ui/src/views/PulseMessages/index.jsx
+++ b/ui/src/views/PulseMessages/index.jsx
@@ -1,4 +1,4 @@
-import React, { Component, Fragment } from 'react';
+import React, { Component } from 'react';
 import { withApollo } from 'react-apollo';
 import { withStyles } from '@material-ui/core/styles';
 import List from '@material-ui/core/List';
@@ -260,148 +260,144 @@ export default class PulseMessages extends Component {
             </Typography>
           </HelpView>
         }>
-        <Fragment>
-          <ErrorPanel error={error} />
-          <PulseBindings
-            bindings={bindings}
-            onBindingAdd={this.handleAddBinding}
-            onBindingRemove={this.handleDeleteBinding}
-            onRoutingKeyPatternChange={this.handleRoutingKeyPatternChange}
-            onPulseExchangeChange={this.handlePulseExchangeChange}
-            pulseExchange={pulseExchange}
-            pattern={pattern}
-            exchangesDictionary={exchangesDictionary}
+        <ErrorPanel error={error} />
+        <PulseBindings
+          bindings={bindings}
+          onBindingAdd={this.handleAddBinding}
+          onBindingRemove={this.handleDeleteBinding}
+          onRoutingKeyPatternChange={this.handleRoutingKeyPatternChange}
+          onPulseExchangeChange={this.handlePulseExchangeChange}
+          pulseExchange={pulseExchange}
+          pattern={pattern}
+          exchangesDictionary={exchangesDictionary}
+        />
+        <List>
+          <Toolbar>
+            <Typography variant="body2" id="tableTitle">
+              Messages
+            </Typography>
+          </Toolbar>
+          <DataTable
+            items={messages}
+            noItemsMessage="No messages received."
+            renderRow={message => (
+              <TableRow
+                key={`message-${message.routingKey}-${message.exchange}`}>
+                <TableCell>
+                  <IconButton
+                    className={classes.infoButton}
+                    onClick={() => this.handleMessageDrawerOpen(message)}>
+                    <InformationVariantIcon size={iconSize} />
+                  </IconButton>
+                  {message.exchange}
+                </TableCell>
+                <TableCell>{message.routingKey}</TableCell>
+              </TableRow>
+            )}
+            headers={headers}
           />
-          <List>
-            <Toolbar>
-              <Typography variant="body2" id="tableTitle">
-                Messages
-              </Typography>
-            </Toolbar>
-            <DataTable
-              items={messages}
-              noItemsMessage="No messages received."
-              renderRow={message => (
-                <TableRow
-                  key={`message-${message.routingKey}-${message.exchange}`}>
-                  <TableCell>
-                    <IconButton
-                      className={classes.infoButton}
-                      onClick={() => this.handleMessageDrawerOpen(message)}>
-                      <InformationVariantIcon size={iconSize} />
-                    </IconButton>
-                    {message.exchange}
-                  </TableCell>
-                  <TableCell>{message.routingKey}</TableCell>
-                </TableRow>
-              )}
-              headers={headers}
-            />
-          </List>
-          {listening ? (
-            <Button
-              variant="circular"
-              spanProps={{ className: classes.startStopIconSpan }}
-              tooltipProps={{ title: 'Stop Listening' }}
-              onClick={this.handleStopListening}
-              className={classes.stopIcon}>
-              <StopIcon />
-            </Button>
-          ) : (
-            <Button
-              variant="circular"
-              spanProps={{ className: classes.startStopIconSpan }}
-              tooltipProps={{ title: 'Start Listening' }}
-              onClick={this.handleStartListening}
-              className={classes.playIcon}
-              disabled={!bindings.length}>
-              <PlayIcon />
-            </Button>
-          )}
-          <SpeedDial>
-            <SpeedDialAction
-              tooltipOpen
-              icon={<DownloadIcon />}
-              tooltipTitle="Download Messages"
-              onClick={this.handleDownloadMessagesClick}
-              FabProps={{ disabled: !messages[0] }}
-            />
-          </SpeedDial>
-          <Drawer
-            anchor="right"
-            open={drawerOpen}
-            classes={{
-              paper: classes.drawerPaper,
-            }}
-            onClose={this.handleMessageDrawerClose}>
-            <Fragment>
-              <IconButton
-                onClick={this.handleMessageDrawerClose}
-                className={classes.drawerCloseIcon}>
-                <CloseIcon />
-              </IconButton>
-              <div className={classes.drawerContainer}>
-                <Typography variant="h5" className={classes.drawerHeadline}>
-                  Message
-                </Typography>
-                <List>
-                  <ListItem>
-                    <ListItemText
-                      primary="Exchange"
-                      secondary={<code>{drawerMessage?.exchange}</code>}
-                    />
-                  </ListItem>
-                  <ListItem>
-                    <ListItemText
-                      primary="Routing Key"
-                      secondary={<code>{drawerMessage?.routingKey}</code>}
-                    />
-                  </ListItem>
-                  <ListItem>
-                    <ListItemText
-                      primary="Redelivered"
-                      secondary={drawerMessage?.redelivered ? 'True' : 'False'}
-                    />
-                  </ListItem>
-                  <ListItem>
-                    <ListItemText
-                      primary="CC Routes"
-                      secondary={
-                        drawerMessage?.cc.length ? (
-                          <List className={classes.ccContainer}>
-                            {drawerMessage.cc.map(route => (
-                              <ListItem key={route} className={classes.ccRoute}>
-                                <code>{route}</code>
-                              </ListItem>
-                            ))}
-                          </List>
-                        ) : (
-                          'n/a'
-                        )
-                      }
-                    />
-                  </ListItem>
-                  <ListItem>
-                    <ListItemText
-                      primary="Payload"
-                      secondaryTypographyProps={{
-                        component: 'div',
-                      }}
-                      secondary={
-                        drawerMessage && (
-                          <JsonDisplay
-                            syntax="json"
-                            objectContent={drawerMessage.payload}
-                          />
-                        )
-                      }
-                    />
-                  </ListItem>
-                </List>
-              </div>
-            </Fragment>
-          </Drawer>
-        </Fragment>
+        </List>
+        {listening ? (
+          <Button
+            variant="circular"
+            spanProps={{ className: classes.startStopIconSpan }}
+            tooltipProps={{ title: 'Stop Listening' }}
+            onClick={this.handleStopListening}
+            className={classes.stopIcon}>
+            <StopIcon />
+          </Button>
+        ) : (
+          <Button
+            variant="circular"
+            spanProps={{ className: classes.startStopIconSpan }}
+            tooltipProps={{ title: 'Start Listening' }}
+            onClick={this.handleStartListening}
+            className={classes.playIcon}
+            disabled={!bindings.length}>
+            <PlayIcon />
+          </Button>
+        )}
+        <SpeedDial>
+          <SpeedDialAction
+            tooltipOpen
+            icon={<DownloadIcon />}
+            tooltipTitle="Download Messages"
+            onClick={this.handleDownloadMessagesClick}
+            FabProps={{ disabled: !messages[0] }}
+          />
+        </SpeedDial>
+        <Drawer
+          anchor="right"
+          open={drawerOpen}
+          classes={{
+            paper: classes.drawerPaper,
+          }}
+          onClose={this.handleMessageDrawerClose}>
+          <IconButton
+            onClick={this.handleMessageDrawerClose}
+            className={classes.drawerCloseIcon}>
+            <CloseIcon />
+          </IconButton>
+          <div className={classes.drawerContainer}>
+            <Typography variant="h5" className={classes.drawerHeadline}>
+              Message
+            </Typography>
+            <List>
+              <ListItem>
+                <ListItemText
+                  primary="Exchange"
+                  secondary={<code>{drawerMessage?.exchange}</code>}
+                />
+              </ListItem>
+              <ListItem>
+                <ListItemText
+                  primary="Routing Key"
+                  secondary={<code>{drawerMessage?.routingKey}</code>}
+                />
+              </ListItem>
+              <ListItem>
+                <ListItemText
+                  primary="Redelivered"
+                  secondary={drawerMessage?.redelivered ? 'True' : 'False'}
+                />
+              </ListItem>
+              <ListItem>
+                <ListItemText
+                  primary="CC Routes"
+                  secondary={
+                    drawerMessage?.cc.length ? (
+                      <List className={classes.ccContainer}>
+                        {drawerMessage.cc.map(route => (
+                          <ListItem key={route} className={classes.ccRoute}>
+                            <code>{route}</code>
+                          </ListItem>
+                        ))}
+                      </List>
+                    ) : (
+                      'n/a'
+                    )
+                  }
+                />
+              </ListItem>
+              <ListItem>
+                <ListItemText
+                  primary="Payload"
+                  secondaryTypographyProps={{
+                    component: 'div',
+                  }}
+                  secondary={
+                    drawerMessage && (
+                      <JsonDisplay
+                        syntax="json"
+                        objectContent={drawerMessage.payload}
+                      />
+                    )
+                  }
+                />
+              </ListItem>
+            </List>
+          </div>
+        </Drawer>
       </Dashboard>
     );
   }

--- a/ui/src/views/Quickstart/index.jsx
+++ b/ui/src/views/Quickstart/index.jsx
@@ -361,297 +361,289 @@ export default class QuickStart extends Component {
           <HelpView
             description="Create a configuration file and
                 plug the CI into your repository.">
-            <Fragment>
-              <Typography variant="body2" paragraph>
-                This tool lets you easily generate a simple generic{' '}
-                <code>.taskcluster.yml</code> file, which should live in the
-                root of your repository. It defines tasks that you want{' '}
-                {window.env.APPLICATION_NAME} to run for you. The tasks will run
-                when certain GitHub events happen. You will choose the events
-                you are interested in while creating the file.
-              </Typography>
-              <Typography variant="body2" paragraph>
-                For independent developers and organization owners: How to set
-                up your repository with {window.env.APPLICATION_NAME}
-              </Typography>
-              <ul>
-                <li>
-                  <Typography paragraph>
-                    Fill out the form below. All changes in the form will
-                    instantly show up in the code field.
-                  </Typography>
-                </li>
-                <li>
-                  <Typography paragraph>
-                    When you are done editing, copy the contents of the code
-                    field and paste it into a file named{' '}
-                    <code>.taskcluster.yml</code> in the root of your
-                    repository.
-                  </Typography>
-                </li>
-                <li>
-                  <SiteSpecific>
-                    Make sure to install the [GitHub app](%github_app_url%) on
-                    your repo. If you do not have permission, you may need to
-                    ask the repository or organization owners to do so.
-                  </SiteSpecific>
-                </li>
-              </ul>
-              <Typography variant="body2" paragraph>
-                Optionally, after you create your file, you can edit it here or
-                in you favorite editor to add more functionality. Please refer
-                to the{' '}
-                <a
-                  href={urls.docs(
-                    'reference/integrations/github/taskcluster-yml-v1'
-                  )}
-                  target="_blank"
-                  rel="noopener noreferrer">
-                  full documentation on our configuration files
-                </a>
-                .
-              </Typography>
-            </Fragment>
+            <Typography variant="body2" paragraph>
+              This tool lets you easily generate a simple generic{' '}
+              <code>.taskcluster.yml</code> file, which should live in the root
+              of your repository. It defines tasks that you want{' '}
+              {window.env.APPLICATION_NAME} to run for you. The tasks will run
+              when certain GitHub events happen. You will choose the events you
+              are interested in while creating the file.
+            </Typography>
+            <Typography variant="body2" paragraph>
+              For independent developers and organization owners: How to set up
+              your repository with {window.env.APPLICATION_NAME}
+            </Typography>
+            <ul>
+              <li>
+                <Typography paragraph>
+                  Fill out the form below. All changes in the form will
+                  instantly show up in the code field.
+                </Typography>
+              </li>
+              <li>
+                <Typography paragraph>
+                  When you are done editing, copy the contents of the code field
+                  and paste it into a file named <code>.taskcluster.yml</code>{' '}
+                  in the root of your repository.
+                </Typography>
+              </li>
+              <li>
+                <SiteSpecific>
+                  Make sure to install the [GitHub app](%github_app_url%) on
+                  your repo. If you do not have permission, you may need to ask
+                  the repository or organization owners to do so.
+                </SiteSpecific>
+              </li>
+            </ul>
+            <Typography variant="body2" paragraph>
+              Optionally, after you create your file, you can edit it here or in
+              you favorite editor to add more functionality. Please refer to the{' '}
+              <a
+                href={urls.docs(
+                  'reference/integrations/github/taskcluster-yml-v1'
+                )}
+                target="_blank"
+                rel="noopener noreferrer">
+                full documentation on our configuration files
+              </a>
+              .
+            </Typography>
           </HelpView>
         }>
-        <Fragment>
-          <div className={classes.orgRepoStatus}>
-            <div className={classes.orgRepoTextFields}>
-              <TextField
-                label="Org Name"
-                name="owner"
-                fullWidth
-                onChange={this.handleOrgRepoChange}
-                value={owner}
-                autoFocus
-              />
-              <Typography className={classes.separator} variant="h5">
-                /
-              </Typography>
-              <TextField
-                label="Repo Name"
-                name="repo"
-                fullWidth
-                onChange={this.handleOrgRepoChange}
-                value={repo}
-              />
-            </div>
-            <div className={classes.iconContainer}>
-              {(installedState === 'success' && (
-                <CheckIcon className={classes.checkIcon} />
-              )) ||
-                (installedState === 'error' && (
-                  <AlertCircleOutlineIcon className={classes.errorIcon} />
-                )) ||
-                (installedState === 'loading' && <Spinner size={24} />)}
-            </div>
+        <div className={classes.orgRepoStatus}>
+          <div className={classes.orgRepoTextFields}>
+            <TextField
+              label="Org Name"
+              name="owner"
+              fullWidth
+              onChange={this.handleOrgRepoChange}
+              value={owner}
+              autoFocus
+            />
+            <Typography className={classes.separator} variant="h5">
+              /
+            </Typography>
+            <TextField
+              label="Repo Name"
+              name="repo"
+              fullWidth
+              onChange={this.handleOrgRepoChange}
+              value={repo}
+            />
           </div>
+          <div className={classes.iconContainer}>
+            {(installedState === 'success' && (
+              <CheckIcon className={classes.checkIcon} />
+            )) ||
+              (installedState === 'error' && (
+                <AlertCircleOutlineIcon className={classes.errorIcon} />
+              )) ||
+              (installedState === 'loading' && <Spinner size={24} />)}
+          </div>
+        </div>
 
-          {installedState === 'error' && (
-            <Fragment>
-              <ErrorPanel
-                warning
-                className={classes.errorPanels}
-                error={
-                  new Error(
-                    'The integration has not been set up for this repository.'
-                  )
-                }
-              />
-              <SiteSpecific>
-                To use Taskcluster on this repository, add [this
-                app](%github_app_url%). If you do not have permission, you may
-                need to ask the repository or organization owners to do so.
-              </SiteSpecific>
-            </Fragment>
-          )}
-          <Typography className={classes.mainHeading} variant="h6">
-            Create Your Task Definition
-          </Typography>
-          <List>
-            <ListItem>
-              <TextField
-                label="Name"
-                name="taskName"
-                onChange={this.handleInputChange}
-                fullWidth
-                value={taskName}
-              />
-            </ListItem>
-            <ListItem className={classes.descriptionTextField}>
-              <TextField
-                label="Description"
-                name="taskDescription"
-                onChange={this.handleInputChange}
-                fullWidth
-                multiline
-                minRows={3}
-                value={taskDescription}
-              />
-            </ListItem>
-            <ListItem>
-              <FormControl component="fieldset">
-                <FormLabel component="legend" focused={false}>
-                  This task should run on
-                </FormLabel>
-                <div className={classes.taskShouldRunFlex}>
-                  <FormGroup>
-                    <FormControlLabel
-                      control={
-                        <Checkbox
-                          checked={events.has('pull_request.opened')}
-                          onChange={this.handleEventsSelection}
-                          value="pull_request.opened"
-                        />
-                      }
-                      label="Pull request opened"
-                    />
-                    <FormControlLabel
-                      control={
-                        <Checkbox
-                          checked={events.has('pull_request.closed')}
-                          onChange={this.handleEventsSelection}
-                          value="pull_request.closed"
-                        />
-                      }
-                      label="Pull request merged or closed"
-                    />
-                    <FormControlLabel
-                      control={
-                        <Checkbox
-                          checked={events.has('pull_request.reopened')}
-                          onChange={this.handleEventsSelection}
-                          value="pull_request.reopened"
-                        />
-                      }
-                      label="Pull request re-opened"
-                    />
-                  </FormGroup>
-                  <FormGroup>
-                    <FormControlLabel
-                      control={
-                        <Checkbox
-                          checked={events.has('pull_request.synchronize')}
-                          onChange={this.handleEventsSelection}
-                          value="pull_request.synchronize"
-                        />
-                      }
-                      label="New commit made in an opened pull request"
-                    />
-                    <FormControlLabel
-                      control={
-                        <Checkbox
-                          checked={events.has('push')}
-                          onChange={this.handleEventsSelection}
-                          value="push"
-                        />
-                      }
-                      label="Push"
-                    />
+        {installedState === 'error' && (
+          <Fragment>
+            <ErrorPanel
+              warning
+              className={classes.errorPanels}
+              error={
+                new Error(
+                  'The integration has not been set up for this repository.'
+                )
+              }
+            />
+            <SiteSpecific>
+              To use Taskcluster on this repository, add [this
+              app](%github_app_url%). If you do not have permission, you may
+              need to ask the repository or organization owners to do so.
+            </SiteSpecific>
+          </Fragment>
+        )}
+        <Typography className={classes.mainHeading} variant="h6">
+          Create Your Task Definition
+        </Typography>
+        <List>
+          <ListItem>
+            <TextField
+              label="Name"
+              name="taskName"
+              onChange={this.handleInputChange}
+              fullWidth
+              value={taskName}
+            />
+          </ListItem>
+          <ListItem className={classes.descriptionTextField}>
+            <TextField
+              label="Description"
+              name="taskDescription"
+              onChange={this.handleInputChange}
+              fullWidth
+              multiline
+              minRows={3}
+              value={taskDescription}
+            />
+          </ListItem>
+          <ListItem>
+            <FormControl component="fieldset">
+              <FormLabel component="legend" focused={false}>
+                This task should run on
+              </FormLabel>
+              <div className={classes.taskShouldRunFlex}>
+                <FormGroup>
+                  <FormControlLabel
+                    control={
+                      <Checkbox
+                        checked={events.has('pull_request.opened')}
+                        onChange={this.handleEventsSelection}
+                        value="pull_request.opened"
+                      />
+                    }
+                    label="Pull request opened"
+                  />
+                  <FormControlLabel
+                    control={
+                      <Checkbox
+                        checked={events.has('pull_request.closed')}
+                        onChange={this.handleEventsSelection}
+                        value="pull_request.closed"
+                      />
+                    }
+                    label="Pull request merged or closed"
+                  />
+                  <FormControlLabel
+                    control={
+                      <Checkbox
+                        checked={events.has('pull_request.reopened')}
+                        onChange={this.handleEventsSelection}
+                        value="pull_request.reopened"
+                      />
+                    }
+                    label="Pull request re-opened"
+                  />
+                </FormGroup>
+                <FormGroup>
+                  <FormControlLabel
+                    control={
+                      <Checkbox
+                        checked={events.has('pull_request.synchronize')}
+                        onChange={this.handleEventsSelection}
+                        value="pull_request.synchronize"
+                      />
+                    }
+                    label="New commit made in an opened pull request"
+                  />
+                  <FormControlLabel
+                    control={
+                      <Checkbox
+                        checked={events.has('push')}
+                        onChange={this.handleEventsSelection}
+                        value="push"
+                      />
+                    }
+                    label="Push"
+                  />
 
-                    <FormControlLabel
-                      control={
-                        <Checkbox
-                          checked={events.has('release')}
-                          onChange={this.handleEventsSelection}
-                          value="release"
-                        />
-                      }
-                      label="Release or tag created"
-                    />
-                  </FormGroup>
-                  <FormGroup>
-                    <FormControlLabel
-                      control={
-                        <Checkbox
-                          checked={events.has('issue_comment.created')}
-                          onChange={this.handleEventsSelection}
-                          value="issue_comment.created"
-                        />
-                      }
-                      label="New comment on pull request"
-                    />
-                    <FormControlLabel
-                      control={
-                        <Checkbox
-                          checked={events.has('issue_comment.edited')}
-                          onChange={this.handleEventsSelection}
-                          value="issue_comment.edited"
-                        />
-                      }
-                      label="Comment was edited on pull request"
-                    />
-                  </FormGroup>
-                </div>
-              </FormControl>
-            </ListItem>
-            <ListItem>
-              <TextField
-                id="select-access"
-                select
-                label="Access"
-                helperText="Who can trigger tasks from PRs?"
-                value={access}
-                name="access"
-                onChange={this.handleInputChange}
-                margin="normal">
-                <MenuItem value="public">Public</MenuItem>
-                <MenuItem value="collaborators">Collaborators</MenuItem>
-              </TextField>
-            </ListItem>
-            <ListItem>
-              <TextField
-                id="select-language"
-                select
-                label="Project Language"
-                helperText="This will select a corresponding docker image"
-                value={language}
-                name="language"
-                onChange={this.handleLanguageChange}
-                margin="normal">
-                <MenuItem value="node">Node.js</MenuItem>
-                <MenuItem value="python">Python</MenuItem>
-                <MenuItem value="rust">Rust</MenuItem>
-                <MenuItem value="go">Go</MenuItem>
-              </TextField>
-            </ListItem>
-            <ListItem>
-              <TextField
-                id="select-commands"
-                select
-                label="Commands"
-                value={commandSelection}
-                onChange={this.handleCommandsChange}
-                margin="normal">
-                <MenuItem value="standard">
-                  Clone repo and run my tests
-                </MenuItem>
-                <MenuItem value="custom">I will define them myself</MenuItem>
-              </TextField>
-            </ListItem>
-            <ListItem>
-              <ListItemText
-                disableTypography
-                primary={
-                  <Typography variant="subtitle1">
-                    Your .taskcluster.yml
-                  </Typography>
-                }
-              />
-            </ListItem>
-            <ListItem className={classes.editorListItem}>
-              {this.renderEditor()}
-            </ListItem>
-          </List>
-          <Button
-            spanProps={{ className: classes.resetButtonSpan }}
-            tooltipProps={{ title: 'Reset Form & File' }}
-            variant="circular"
-            onClick={this.handleReset}
-            color="secondary">
-            <RestartIcon />
-          </Button>
-        </Fragment>
+                  <FormControlLabel
+                    control={
+                      <Checkbox
+                        checked={events.has('release')}
+                        onChange={this.handleEventsSelection}
+                        value="release"
+                      />
+                    }
+                    label="Release or tag created"
+                  />
+                </FormGroup>
+                <FormGroup>
+                  <FormControlLabel
+                    control={
+                      <Checkbox
+                        checked={events.has('issue_comment.created')}
+                        onChange={this.handleEventsSelection}
+                        value="issue_comment.created"
+                      />
+                    }
+                    label="New comment on pull request"
+                  />
+                  <FormControlLabel
+                    control={
+                      <Checkbox
+                        checked={events.has('issue_comment.edited')}
+                        onChange={this.handleEventsSelection}
+                        value="issue_comment.edited"
+                      />
+                    }
+                    label="Comment was edited on pull request"
+                  />
+                </FormGroup>
+              </div>
+            </FormControl>
+          </ListItem>
+          <ListItem>
+            <TextField
+              id="select-access"
+              select
+              label="Access"
+              helperText="Who can trigger tasks from PRs?"
+              value={access}
+              name="access"
+              onChange={this.handleInputChange}
+              margin="normal">
+              <MenuItem value="public">Public</MenuItem>
+              <MenuItem value="collaborators">Collaborators</MenuItem>
+            </TextField>
+          </ListItem>
+          <ListItem>
+            <TextField
+              id="select-language"
+              select
+              label="Project Language"
+              helperText="This will select a corresponding docker image"
+              value={language}
+              name="language"
+              onChange={this.handleLanguageChange}
+              margin="normal">
+              <MenuItem value="node">Node.js</MenuItem>
+              <MenuItem value="python">Python</MenuItem>
+              <MenuItem value="rust">Rust</MenuItem>
+              <MenuItem value="go">Go</MenuItem>
+            </TextField>
+          </ListItem>
+          <ListItem>
+            <TextField
+              id="select-commands"
+              select
+              label="Commands"
+              value={commandSelection}
+              onChange={this.handleCommandsChange}
+              margin="normal">
+              <MenuItem value="standard">Clone repo and run my tests</MenuItem>
+              <MenuItem value="custom">I will define them myself</MenuItem>
+            </TextField>
+          </ListItem>
+          <ListItem>
+            <ListItemText
+              disableTypography
+              primary={
+                <Typography variant="subtitle1">
+                  Your .taskcluster.yml
+                </Typography>
+              }
+            />
+          </ListItem>
+          <ListItem className={classes.editorListItem}>
+            {this.renderEditor()}
+          </ListItem>
+        </List>
+        <Button
+          spanProps={{ className: classes.resetButtonSpan }}
+          tooltipProps={{ title: 'Reset Form & File' }}
+          variant="circular"
+          onClick={this.handleReset}
+          color="secondary">
+          <RestartIcon />
+        </Button>
       </Dashboard>
     );
   }

--- a/ui/src/views/Roles/ViewRole/index.jsx
+++ b/ui/src/views/Roles/ViewRole/index.jsx
@@ -112,36 +112,34 @@ export default class ViewRole extends Component {
 
     return (
       <Dashboard title={isNewRole ? 'Create Role' : 'Role'}>
-        <Fragment>
-          <ErrorPanel fixed error={error} />
-          {isNewRole ? (
-            <RoleForm
-              isNewRole
-              loading={loading}
-              onRoleSave={this.handleSaveRole}
-            />
-          ) : (
-            <Fragment>
-              {data.loading && <Spinner loading />}
-              {data && <ErrorPanel fixed error={data.error} />}
-              {data?.role && (
-                <RoleForm
-                  dialogError={dialogError}
-                  key={data.role.roleId}
-                  role={data.role}
-                  loading={loading}
-                  onRoleDelete={this.handleDeleteRole}
-                  onRoleSave={this.handleSaveRole}
-                  dialogOpen={dialogOpen}
-                  onDialogActionError={this.handleDialogActionError}
-                  onDialogActionComplete={this.handleDialogActionComplete}
-                  onDialogActionClose={this.handleDialogActionClose}
-                  onDialogActionOpen={this.handleDialogActionOpen}
-                />
-              )}
-            </Fragment>
-          )}
-        </Fragment>
+        <ErrorPanel fixed error={error} />
+        {isNewRole ? (
+          <RoleForm
+            isNewRole
+            loading={loading}
+            onRoleSave={this.handleSaveRole}
+          />
+        ) : (
+          <Fragment>
+            {data.loading && <Spinner loading />}
+            {data && <ErrorPanel fixed error={data.error} />}
+            {data?.role && (
+              <RoleForm
+                dialogError={dialogError}
+                key={data.role.roleId}
+                role={data.role}
+                loading={loading}
+                onRoleDelete={this.handleDeleteRole}
+                onRoleSave={this.handleSaveRole}
+                dialogOpen={dialogOpen}
+                onDialogActionError={this.handleDialogActionError}
+                onDialogActionComplete={this.handleDialogActionComplete}
+                onDialogActionClose={this.handleDialogActionClose}
+                onDialogActionOpen={this.handleDialogActionOpen}
+              />
+            )}
+          </Fragment>
+        )}
         <Snackbar onClose={this.handleSnackbarClose} {...snackbar} />
       </Dashboard>
     );

--- a/ui/src/views/Scopes/ScopesetComparison/index.jsx
+++ b/ui/src/views/Scopes/ScopesetComparison/index.jsx
@@ -1,4 +1,4 @@
-import React, { Component, Fragment } from 'react';
+import React, { Component } from 'react';
 import { withStyles } from '@material-ui/core/styles';
 import { equals } from 'ramda';
 import { scopeUnion, scopeIntersection } from 'taskcluster-lib-scopes';
@@ -125,72 +125,68 @@ export default class ScopesetComparison extends Component {
 
     return (
       <Dashboard title="Compare Scopes">
-        <Fragment>
-          <Grid className={classes.editorGrid} container spacing={1}>
-            <Grid item xs={12} md={6}>
-              <Typography gutterBottom variant="subtitle1">
-                Scope A
-              </Typography>
-              <CodeEditor
-                className={classes.editor}
-                onChange={this.handleScopesAChange}
-                placeholder="new-scope:for-something:*"
-                mode="scopemode"
-                value={scopeTextA}
-              />
-            </Grid>
-            <Grid item xs={12} md={6}>
-              <Typography gutterBottom variant="subtitle1">
-                Scope B
-              </Typography>
-              <CodeEditor
-                className={classes.editor}
-                onChange={this.handleScopesBChange}
-                placeholder="new-scope:for-something:*"
-                mode="scopemode"
-                value={scopeTextB}
-              />
-            </Grid>
+        <Grid className={classes.editorGrid} container spacing={1}>
+          <Grid item xs={12} md={6}>
+            <Typography gutterBottom variant="subtitle1">
+              Scope A
+            </Typography>
+            <CodeEditor
+              className={classes.editor}
+              onChange={this.handleScopesAChange}
+              placeholder="new-scope:for-something:*"
+              mode="scopemode"
+              value={scopeTextA}
+            />
           </Grid>
-          {scopesetDiff && cellColors && (
-            <Fragment>
-              {scopesetDiff.map((scopes, index) => (
-                <Grid key={scopes} container>
-                  <Grid item xs={6} className={classes[cellColors[index][0]]}>
-                    {scopes[0].length > 0 &&
-                      scopes[0].map(scope => (
-                        <Typography
-                          key={scope}
-                          variant="body2"
-                          className={classes.cellGrid}>
-                          {scope}
-                        </Typography>
-                      ))}
-                  </Grid>
-                  <Grid item xs={6} className={classes[cellColors[index][1]]}>
-                    {scopes[1].length > 0 &&
-                      scopes[1].map(scope => (
-                        <Typography
-                          key={scope}
-                          variant="body2"
-                          className={classes.cellGrid}>
-                          {scope}
-                        </Typography>
-                      ))}
-                  </Grid>
-                </Grid>
-              ))}
-            </Fragment>
-          )}
-          <Button
-            spanProps={{ className: classes.actionButton }}
-            tooltipProps={{ title: 'Compare Scopes' }}
-            color="secondary"
-            variant="circular"
-            onClick={this.handleCompareScopesClick}>
-            <ScaleBalanceIcon />
-          </Button>
-        </Fragment>
+          <Grid item xs={12} md={6}>
+            <Typography gutterBottom variant="subtitle1">
+              Scope B
+            </Typography>
+            <CodeEditor
+              className={classes.editor}
+              onChange={this.handleScopesBChange}
+              placeholder="new-scope:for-something:*"
+              mode="scopemode"
+              value={scopeTextB}
+            />
+          </Grid>
+        </Grid>
+        {scopesetDiff &&
+          cellColors &&
+          scopesetDiff.map((scopes, index) => (
+            <Grid key={scopes} container>
+              <Grid item xs={6} className={classes[cellColors[index][0]]}>
+                {scopes[0].length > 0 &&
+                  scopes[0].map(scope => (
+                    <Typography
+                      key={scope}
+                      variant="body2"
+                      className={classes.cellGrid}>
+                      {scope}
+                    </Typography>
+                  ))}
+              </Grid>
+              <Grid item xs={6} className={classes[cellColors[index][1]]}>
+                {scopes[1].length > 0 &&
+                  scopes[1].map(scope => (
+                    <Typography
+                      key={scope}
+                      variant="body2"
+                      className={classes.cellGrid}>
+                      {scope}
+                    </Typography>
+                  ))}
+              </Grid>
+            </Grid>
+          ))}
+        <Button
+          spanProps={{ className: classes.actionButton }}
+          tooltipProps={{ title: 'Compare Scopes' }}
+          color="secondary"
+          variant="circular"
+          onClick={this.handleCompareScopesClick}>
+          <ScaleBalanceIcon />
+        </Button>
       </Dashboard>
     );
   }

--- a/ui/src/views/Scopes/ScopesetExpander/index.jsx
+++ b/ui/src/views/Scopes/ScopesetExpander/index.jsx
@@ -80,47 +80,45 @@ export default class ScopesetExpander extends Component {
       <Dashboard
         title="Expand Scopes"
         helpView={<HelpView description={description} />}>
-        <Fragment>
-          <CodeEditor
-            className={classes.editor}
-            onChange={this.handleScopesChange}
-            placeholder="new-scope:for-something:*"
-            mode="scopemode"
-            value={scopeText}
-          />
-          {scopes && (
-            <Query query={scopesetQuery} variables={{ scopes }}>
-              {({ loading, error, data }) => (
-                <Fragment>
-                  <ErrorPanel error={error} />
-                  <List dense>
-                    {loading && (
-                      <ListItem>
-                        <Spinner />
+        <CodeEditor
+          className={classes.editor}
+          onChange={this.handleScopesChange}
+          placeholder="new-scope:for-something:*"
+          mode="scopemode"
+          value={scopeText}
+        />
+        {scopes && (
+          <Query query={scopesetQuery} variables={{ scopes }}>
+            {({ loading, error, data }) => (
+              <Fragment>
+                <ErrorPanel error={error} />
+                <List dense>
+                  {loading && (
+                    <ListItem>
+                      <Spinner />
+                    </ListItem>
+                  )}
+                  {data?.expandScopes?.map(scope => (
+                    <Link key={scope} to={scopeLink(scope)}>
+                      <ListItem button className={classes.listItemButton}>
+                        <code>{scope}</code>
+                        <LinkIcon size={16} />
                       </ListItem>
-                    )}
-                    {data?.expandScopes?.map(scope => (
-                      <Link key={scope} to={scopeLink(scope)}>
-                        <ListItem button className={classes.listItemButton}>
-                          <code>{scope}</code>
-                          <LinkIcon size={16} />
-                        </ListItem>
-                      </Link>
-                    ))}
-                  </List>
-                </Fragment>
-              )}
-            </Query>
-          )}
-          <Button
-            tooltipProps={{ title: 'Expand Scopes' }}
-            spanProps={{ className: classes.actionButton }}
-            color="secondary"
-            variant="circular"
-            onClick={this.handleExpandScopesClick}>
-            <ArrowExpandVerticalIcon />
-          </Button>
-        </Fragment>
+                    </Link>
+                  ))}
+                </List>
+              </Fragment>
+            )}
+          </Query>
+        )}
+        <Button
+          tooltipProps={{ title: 'Expand Scopes' }}
+          spanProps={{ className: classes.actionButton }}
+          color="secondary"
+          variant="circular"
+          onClick={this.handleExpandScopesClick}>
+          <ArrowExpandVerticalIcon />
+        </Button>
       </Dashboard>
     );
   }

--- a/ui/src/views/Scopes/ViewScope/index.jsx
+++ b/ui/src/views/Scopes/ViewScope/index.jsx
@@ -1,4 +1,4 @@
-import React, { Component, Fragment } from 'react';
+import React, { Component } from 'react';
 import { graphql } from 'react-apollo';
 import { parse, stringify } from 'qs';
 import dotProp from 'dot-prop-immutable';
@@ -111,33 +111,31 @@ export default class ViewScope extends Component {
             defaultValue={searchTerm}
           />
         }>
-        <Fragment>
-          <Tabs
-            className={classes.tabs}
-            variant="fullWidth"
-            value={currentTabIndex}
-            onChange={this.handleTabChange}>
-            <Tab label="Roles" />
-            <Tab label="Clients" />
-          </Tabs>
-          {loading && <Spinner loading />}
-          <ErrorPanel fixed error={error} />
-          {roles && currentTabIndex === 0 && (
-            <RoleScopesTable
-              roles={roles}
-              searchTerm={searchTerm}
-              selectedScope={selectedScope}
-            />
-          )}
-          {clients && currentTabIndex === 1 && (
-            <ClientScopesTable
-              clientsConnection={clients}
-              onPageChange={this.handleClientsPageChange}
-              searchTerm={searchTerm}
-              selectedScope={selectedScope}
-            />
-          )}
-        </Fragment>
+        <Tabs
+          className={classes.tabs}
+          variant="fullWidth"
+          value={currentTabIndex}
+          onChange={this.handleTabChange}>
+          <Tab label="Roles" />
+          <Tab label="Clients" />
+        </Tabs>
+        {loading && <Spinner loading />}
+        <ErrorPanel fixed error={error} />
+        {roles && currentTabIndex === 0 && (
+          <RoleScopesTable
+            roles={roles}
+            searchTerm={searchTerm}
+            selectedScope={selectedScope}
+          />
+        )}
+        {clients && currentTabIndex === 1 && (
+          <ClientScopesTable
+            clientsConnection={clients}
+            onPageChange={this.handleClientsPageChange}
+            searchTerm={searchTerm}
+            selectedScope={selectedScope}
+          />
+        )}
       </Dashboard>
     );
   }

--- a/ui/src/views/Secrets/ViewSecrets/index.jsx
+++ b/ui/src/views/Secrets/ViewSecrets/index.jsx
@@ -1,4 +1,4 @@
-import React, { Component, Fragment } from 'react';
+import React, { Component } from 'react';
 import { graphql, withApollo } from 'react-apollo';
 import dotProp from 'dot-prop-immutable';
 import { withStyles } from '@material-ui/core/styles';
@@ -169,47 +169,45 @@ export default class ViewSecrets extends Component {
             placeholder="Secret contains"
           />
         }>
-        <Fragment>
-          {loading && <Spinner loading />}
-          <ErrorPanel fixed error={error} />
-          {secrets && (
-            <SecretsTable
-              searchTerm={secretSearch}
-              onPageChange={this.handlePageChange}
-              secretsConnection={secrets}
-              onDialogActionOpen={this.handleDialogActionOpen}
-            />
-          )}
-          <Button
-            spanProps={{ className: classes.plusIconSpan }}
-            tooltipProps={{
-              title: 'Create Secret',
-              id: 'create-secret-tooltip',
-              enterDelay: 300,
-            }}
-            onClick={this.handleCreate}
-            variant="circular"
-            color="secondary">
-            <PlusIcon />
-          </Button>
-          {dialogOpen && (
-            <DialogAction
-              open={dialogOpen}
-              onSubmit={this.handleDeleteSecret}
-              onComplete={this.handleDialogActionComplete}
-              onClose={this.handleDialogActionClose}
-              onError={this.handleDialogActionError}
-              error={dialogError}
-              title="Delete Secret?"
-              body={
-                <Typography variant="body2">
-                  This will delete the secret {deleteSecretName}.
-                </Typography>
-              }
-              confirmText="Delete Secret"
-            />
-          )}
-        </Fragment>
+        {loading && <Spinner loading />}
+        <ErrorPanel fixed error={error} />
+        {secrets && (
+          <SecretsTable
+            searchTerm={secretSearch}
+            onPageChange={this.handlePageChange}
+            secretsConnection={secrets}
+            onDialogActionOpen={this.handleDialogActionOpen}
+          />
+        )}
+        <Button
+          spanProps={{ className: classes.plusIconSpan }}
+          tooltipProps={{
+            title: 'Create Secret',
+            id: 'create-secret-tooltip',
+            enterDelay: 300,
+          }}
+          onClick={this.handleCreate}
+          variant="circular"
+          color="secondary">
+          <PlusIcon />
+        </Button>
+        {dialogOpen && (
+          <DialogAction
+            open={dialogOpen}
+            onSubmit={this.handleDeleteSecret}
+            onComplete={this.handleDialogActionComplete}
+            onClose={this.handleDialogActionClose}
+            onError={this.handleDialogActionError}
+            error={dialogError}
+            title="Delete Secret?"
+            body={
+              <Typography variant="body2">
+                This will delete the secret {deleteSecretName}.
+              </Typography>
+            }
+            confirmText="Delete Secret"
+          />
+        )}
       </Dashboard>
     );
   }

--- a/ui/src/views/Tasks/CreateTask/index.jsx
+++ b/ui/src/views/Tasks/CreateTask/index.jsx
@@ -362,123 +362,121 @@ export default class CreateTask extends Component {
             </Typography>
           </HelpView>
         }>
-        <Fragment>
-          {error ? (
-            <ErrorPanel fixed error={error} />
-          ) : (
-            <Fragment>
-              <ErrorPanel fixed error={createdTaskError} />
-              <Box style={{ display: 'flex', marginBottom: 10 }}>
-                <FormControlLabel
-                  style={{ flexBasis: 0, flexGrow: 1 }}
-                  control={
-                    <Switch
-                      checked={interactive}
-                      onChange={this.handleInteractiveChange}
-                      color="secondary"
-                    />
-                  }
-                  label="Interactive"
-                />
-                <FormControlLabel
-                  style={{ alignSelf: 'flex-end' }}
-                  control={
-                    <TextField
-                      select
-                      labelId="payload-schema-label"
-                      id="payload-schema"
-                      value={payloadSchema}
-                      defaultChecked
-                      onChange={this.handlePayloadSchemaChange}>
-                      {Object.entries(TASK_PAYLOAD_SCHEMAS).map(
-                        ([key, schema]) => (
-                          <MenuItem key={key} value={key}>
-                            {schema.label}
-                          </MenuItem>
-                        )
-                      )}
-                    </TextField>
-                  }
-                />
-                <Button
-                  style={{ alignSelf: 'flex-end' }}
-                  size="small"
-                  onClick={this.handleLint}>
-                  Validate schema
-                </Button>
-              </Box>
-              {validationErrors && (
-                <MuiErrorPanel
-                  className={classes.validationErrors}
-                  error={validationErrors}
-                />
-              )}
-              <CodeEditor
-                mode="yaml"
-                lint
-                value={task || ''}
-                onChange={this.handleTaskChange}
+        {error ? (
+          <ErrorPanel fixed error={error} />
+        ) : (
+          <Fragment>
+            <ErrorPanel fixed error={createdTaskError} />
+            <Box style={{ display: 'flex', marginBottom: 10 }}>
+              <FormControlLabel
+                style={{ flexBasis: 0, flexGrow: 1 }}
+                control={
+                  <Switch
+                    checked={interactive}
+                    onChange={this.handleInteractiveChange}
+                    color="secondary"
+                  />
+                }
+                label="Interactive"
               />
-              <br />
-              {Boolean(recentTaskDefinitions.length) && (
-                <List
-                  dense
-                  subheader={
-                    <ListSubheader component="div">
-                      Recent Task Definitions
-                    </ListSubheader>
-                  }>
-                  {this.state.recentTaskDefinitions.map(task => (
-                    <ListItem
-                      className={classes.listItemButton}
-                      button
-                      onClick={() => {
-                        this.handleRecentTaskDefinitionClick(task);
-                      }}
-                      key={task.metadata.name}>
-                      <ListItemText
-                        disableTypography
-                        primary={
-                          <Typography variant="body2">
-                            {task.metadata.name}
-                          </Typography>
-                        }
-                      />
-                      <LinkIcon />
-                    </ListItem>
-                  ))}
-                </List>
-              )}
+              <FormControlLabel
+                style={{ alignSelf: 'flex-end' }}
+                control={
+                  <TextField
+                    select
+                    labelId="payload-schema-label"
+                    id="payload-schema"
+                    value={payloadSchema}
+                    defaultChecked
+                    onChange={this.handlePayloadSchemaChange}>
+                    {Object.entries(TASK_PAYLOAD_SCHEMAS).map(
+                      ([key, schema]) => (
+                        <MenuItem key={key} value={key}>
+                          {schema.label}
+                        </MenuItem>
+                      )
+                    )}
+                  </TextField>
+                }
+              />
               <Button
-                spanProps={{ className: classes.createIconSpan }}
-                tooltipProps={{ title: 'Create Task' }}
-                requiresAuth
-                disabled={!task || invalid || loading}
-                variant="circular"
-                className={classes.createIcon}
-                onClick={this.handleCreateTask}>
-                <ContentSaveIcon />
+                style={{ alignSelf: 'flex-end' }}
+                size="small"
+                onClick={this.handleLint}>
+                Validate schema
               </Button>
-              <SpeedDial>
-                <SpeedDialAction
-                  tooltipOpen
-                  icon={<RotateLeftIcon />}
-                  onClick={this.handleResetEditor}
-                  tooltipTitle="Reset Editor"
-                />
-                <SpeedDialAction
-                  tooltipOpen
-                  icon={<ClockOutlineIcon />}
-                  onClick={this.handleUpdateTimestamps}
-                  tooltipTitle="Update Timestamps"
-                  FabProps={{
-                    disabled: !task || invalid,
-                  }}
-                />
-              </SpeedDial>
-            </Fragment>
-          )}
-        </Fragment>
+            </Box>
+            {validationErrors && (
+              <MuiErrorPanel
+                className={classes.validationErrors}
+                error={validationErrors}
+              />
+            )}
+            <CodeEditor
+              mode="yaml"
+              lint
+              value={task || ''}
+              onChange={this.handleTaskChange}
+            />
+            <br />
+            {Boolean(recentTaskDefinitions.length) && (
+              <List
+                dense
+                subheader={
+                  <ListSubheader component="div">
+                    Recent Task Definitions
+                  </ListSubheader>
+                }>
+                {this.state.recentTaskDefinitions.map(task => (
+                  <ListItem
+                    className={classes.listItemButton}
+                    button
+                    onClick={() => {
+                      this.handleRecentTaskDefinitionClick(task);
+                    }}
+                    key={task.metadata.name}>
+                    <ListItemText
+                      disableTypography
+                      primary={
+                        <Typography variant="body2">
+                          {task.metadata.name}
+                        </Typography>
+                      }
+                    />
+                    <LinkIcon />
+                  </ListItem>
+                ))}
+              </List>
+            )}
+            <Button
+              spanProps={{ className: classes.createIconSpan }}
+              tooltipProps={{ title: 'Create Task' }}
+              requiresAuth
+              disabled={!task || invalid || loading}
+              variant="circular"
+              className={classes.createIcon}
+              onClick={this.handleCreateTask}>
+              <ContentSaveIcon />
+            </Button>
+            <SpeedDial>
+              <SpeedDialAction
+                tooltipOpen
+                icon={<RotateLeftIcon />}
+                onClick={this.handleResetEditor}
+                tooltipTitle="Reset Editor"
+              />
+              <SpeedDialAction
+                tooltipOpen
+                icon={<ClockOutlineIcon />}
+                onClick={this.handleUpdateTimestamps}
+                tooltipTitle="Update Timestamps"
+                FabProps={{
+                  disabled: !task || invalid,
+                }}
+              />
+            </SpeedDial>
+          </Fragment>
+        )}
       </Dashboard>
     );
   }

--- a/ui/src/views/Tasks/InteractiveConnect/index.jsx
+++ b/ui/src/views/Tasks/InteractiveConnect/index.jsx
@@ -377,11 +377,9 @@ export default class InteractiveConnect extends Component {
 
     return (
       <Dashboard title="Interactive Connect">
-        <Fragment>
-          {!error && artifactsLoading && <Spinner loading />}
-          <ErrorPanel fixed error={error} />
-          {!artifactsLoading && task && this.renderTask()}
-        </Fragment>
+        {!error && artifactsLoading && <Spinner loading />}
+        <ErrorPanel fixed error={error} />
+        {!artifactsLoading && task && this.renderTask()}
       </Dashboard>
     );
   }

--- a/ui/src/views/Tasks/TaskIndex/ListNamespaces/index.jsx
+++ b/ui/src/views/Tasks/TaskIndex/ListNamespaces/index.jsx
@@ -187,75 +187,71 @@ export default class ListNamespaces extends Component {
             placeholder="Search path.to.index"
           />
         }>
-        <Fragment>
-          {loading && <Spinner loading />}
-          <ErrorPanel fixed error={namespacesError || taskNamespaceError} />
-          {!loading && !hasNamespaces && !hasIndexedTasks && !isSinglePath && (
-            <Redirect
-              to={`/tasks/index/${indexPathInput
-                .split('.')
-                .slice(0, -1)
-                .join('.')}/${indexPathInput.split('.').slice(-1)[0]}`}
-            />
-          )}
-          {!loading && params.namespace && (
-            <Fragment>
-              <Breadcrumbs>
-                <Link to="/tasks/index">
-                  <Typography variant="body2" className={classes.link}>
-                    Indexes
+        {loading && <Spinner loading />}
+        <ErrorPanel fixed error={namespacesError || taskNamespaceError} />
+        {!loading && !hasNamespaces && !hasIndexedTasks && !isSinglePath && (
+          <Redirect
+            to={`/tasks/index/${indexPathInput
+              .split('.')
+              .slice(0, -1)
+              .join('.')}/${indexPathInput.split('.').slice(-1)[0]}`}
+          />
+        )}
+        {!loading && params.namespace && (
+          <Fragment>
+            <Breadcrumbs>
+              <Link to="/tasks/index">
+                <Typography variant="body2" className={classes.link}>
+                  Indexes
+                </Typography>
+              </Link>
+              {indexPaths.map((indexName, i) =>
+                indexPaths.length === i + 1 ? (
+                  <Typography
+                    key={indexName}
+                    variant="body2"
+                    color="textSecondary">
+                    {indexName}
                   </Typography>
-                </Link>
-                {indexPaths.map((indexName, i) =>
-                  indexPaths.length === i + 1 ? (
-                    <Typography
-                      key={indexName}
-                      variant="body2"
-                      color="textSecondary">
+                ) : (
+                  <Link
+                    to={`/tasks/index/${indexPaths.slice(0, i + 1).join('.')}`}>
+                    <Typography variant="body2" className={classes.link}>
                       {indexName}
                     </Typography>
-                  ) : (
-                    <Link
-                      to={`/tasks/index/${indexPaths
-                        .slice(0, i + 1)
-                        .join('.')}`}>
-                      <Typography variant="body2" className={classes.link}>
-                        {indexName}
-                      </Typography>
-                    </Link>
-                  )
-                )}
-              </Breadcrumbs>
-              <br />
-              <br />
-            </Fragment>
-          )}
-          {!loading && !hasNamespaces && !hasIndexedTasks && isSinglePath && (
-            <Typography>
-              {searchTerm
-                ? `No items for this page with search term ${searchTerm}.`
-                : 'No items for this page.'}
-            </Typography>
-          )}
-          {!loading && hasNamespaces && (
-            <Fragment>
-              <Typography variant="subtitle1">Namespaces</Typography>
-              <IndexNamespacesTable
-                onPageChange={this.handleNamespacesPageChange}
-                connection={namespaces}
-              />
-            </Fragment>
-          )}
-          {!loading && hasIndexedTasks && (
-            <Fragment>
-              <Typography variant="subtitle1">Indexed Tasks</Typography>
-              <IndexTaskNamespaceTable
-                onPageChange={this.handleTaskNamespacePageChange}
-                connection={taskNamespace}
-              />
-            </Fragment>
-          )}
-        </Fragment>
+                  </Link>
+                )
+              )}
+            </Breadcrumbs>
+            <br />
+            <br />
+          </Fragment>
+        )}
+        {!loading && !hasNamespaces && !hasIndexedTasks && isSinglePath && (
+          <Typography>
+            {searchTerm
+              ? `No items for this page with search term ${searchTerm}.`
+              : 'No items for this page.'}
+          </Typography>
+        )}
+        {!loading && hasNamespaces && (
+          <Fragment>
+            <Typography variant="subtitle1">Namespaces</Typography>
+            <IndexNamespacesTable
+              onPageChange={this.handleNamespacesPageChange}
+              connection={namespaces}
+            />
+          </Fragment>
+        )}
+        {!loading && hasIndexedTasks && (
+          <Fragment>
+            <Typography variant="subtitle1">Indexed Tasks</Typography>
+            <IndexTaskNamespaceTable
+              onPageChange={this.handleTaskNamespacePageChange}
+              connection={taskNamespace}
+            />
+          </Fragment>
+        )}
       </Dashboard>
     );
   }

--- a/ui/src/views/Tasks/TaskRedirect/index.jsx
+++ b/ui/src/views/Tasks/TaskRedirect/index.jsx
@@ -29,31 +29,29 @@ export default class TaskRedirect extends Component {
 
     return (
       <Dashboard>
-        <Fragment>
-          {error ? (
-            <ErrorPanel fixed error={error} />
-          ) : (
-            <Fragment>
-              {loading && <Spinner />}
-              {!loading && task && (
-                <Redirect
-                  to={{
-                    pathname:
+        {error ? (
+          <ErrorPanel fixed error={error} />
+        ) : (
+          <Fragment>
+            {loading && <Spinner />}
+            {!loading && task && (
+              <Redirect
+                to={{
+                  pathname:
+                    action === 'interactive'
+                      ? '/tasks/create?interactive=1'
+                      : '/tasks/create',
+                  state: {
+                    task:
                       action === 'interactive'
-                        ? '/tasks/create?interactive=1'
-                        : '/tasks/create',
-                    state: {
-                      task:
-                        action === 'interactive'
-                          ? parameterizeTask(sanitizedTask)
-                          : sanitizedTask,
-                    },
-                  }}
-                />
-              )}
-            </Fragment>
-          )}
-        </Fragment>
+                        ? parameterizeTask(sanitizedTask)
+                        : sanitizedTask,
+                  },
+                }}
+              />
+            )}
+          </Fragment>
+        )}
       </Dashboard>
     );
   }

--- a/ui/src/views/TcYamlDebug/index.jsx
+++ b/ui/src/views/TcYamlDebug/index.jsx
@@ -1,4 +1,4 @@
-import React, { Component, Fragment } from 'react';
+import React, { Component } from 'react';
 import { withApollo } from 'react-apollo';
 import { withStyles } from '@material-ui/core/styles';
 import List from '@material-ui/core/List';
@@ -557,13 +557,11 @@ export default class TcYamlDebug extends Component {
                   secondary={message}
                 />
                 {scopes?.length ? (
-                  <React.Fragment>
-                    <JsonDisplay
-                      wrapperClassName={classes.scopes}
-                      syntax="yaml"
-                      objectContent={{ scopes }}
-                    />
-                  </React.Fragment>
+                  <JsonDisplay
+                    wrapperClassName={classes.scopes}
+                    syntax="yaml"
+                    objectContent={{ scopes }}
+                  />
                 ) : (
                   ''
                 )}
@@ -607,127 +605,124 @@ export default class TcYamlDebug extends Component {
 
     return (
       <Dashboard title="GitHub .taskcluster.yml debug" disableTitleFormatting>
-        <Fragment>
-          <Typography className={classes.mainHeading} variant="h6">
-            Lint your <code>.taskcluster.yml</code>
-          </Typography>
-          <List>
-            <ListItem>
-              <ListItemText
-                disableTypography
-                primary={
-                  <Typography variant="subtitle1">
-                    Your .taskcluster.yml
-                  </Typography>
-                }
-              />
-              <TextField
-                label="Link to .taskcluster.yml"
-                name="taskclusterYmlUrl"
-                onChange={this.handleTaskclusterYmlUrlChange}
-                value={taskclusterYmlUrl || ''}
-                className={classes.textField}
-                error={taskclusterYmlUrl !== '' && !isValidUrl}
-                helperText={validationMessage}
-              />
-            </ListItem>
-            <ListItem className={classes.editorListItem}>
-              <CodeEditor
-                onChange={this.handleEditorChange}
-                mode="yaml"
-                value={this.state.editorValue}
-                className={this.props.classes.codeEditor}
-              />
-            </ListItem>
-            <ListItem>
-              <ListItemText
-                disableTypography
-                primary={
-                  <Typography variant="subtitle2">Extra context</Typography>
-                }
-              />
-            </ListItem>
-            <ListItem className={classes.contextListItem}>
-              <CodeEditor
-                onChange={this.handleExtraContextChange}
-                mode="yaml"
-                value={this.state.extraContext}
-                className={classes.contextEditor}
-              />
-            </ListItem>
-            <ListItem>
-              <Grid container spacing={2} alignItems="flex-end">
-                <Grid item>
-                  <Button
-                    spanProps={{ className: classes.analyzeButton }}
-                    tooltipProps={{ title: 'Analyze' }}
-                    onClick={this.handleAnalyze}
-                    variant="contained"
-                    color="primary">
-                    Analyze
-                  </Button>
-                </Grid>
-                <Grid item>
-                  <TextField
-                    className={classes.dropdown}
-                    select
-                    label="Simulate custom event"
-                    value=""
-                    onChange={this.handleCustomEventSimulate}>
-                    {releaseActions.map(action => (
-                      <MenuItem
-                        key={`gr-${action}`}
-                        value={`github-release.${action}`}>
-                        <code>github-release</code>.<strong>{action}</strong>
-                      </MenuItem>
-                    ))}
-                    {pullRequestActions.map(action => (
-                      <MenuItem
-                        key={`gpr-${action}`}
-                        value={`github-pull-request.${action}`}>
-                        <code>github-pull-request</code>.
-                        <strong>{action}</strong>
-                      </MenuItem>
-                    ))}
-                    {pullRequestActions.map(action => (
-                      <MenuItem
-                        key={`gpru-${action}`}
-                        value={`github-pull-request-untrusted.${action}`}>
-                        <code>github-pull-request-untrusted</code>.
-                        <strong>{action}</strong>
-                      </MenuItem>
-                    ))}
-                    {issueCommentActions.map(action => (
-                      <MenuItem
-                        key={`gic-${action}`}
-                        value={`github-issue-comment.${action}`}>
-                        <code>github-issue-comment</code>.
-                        <strong>{action}</strong>
-                      </MenuItem>
-                    ))}
-                  </TextField>
-                </Grid>
-                {parsed && (
-                  <Grid item>
-                    <div>{parserOk ? '' : '⛔️ could not parse YAML'}</div>
-                    <div>
-                      {parserVersion === 0
-                        ? ` ⚠️ Uses v0, please migrate to v1`
-                        : ''}
-                    </div>
-                    <div>{parserChecks ? '' : ' ⚠️ not using checks'}</div>
-                    <div>
-                      {parserAutoCancel
-                        ? ''
-                        : ' ⚠️ not using autoCancelPreviousChecks: true'}
-                    </div>
-                  </Grid>
-                )}
+        <Typography className={classes.mainHeading} variant="h6">
+          Lint your <code>.taskcluster.yml</code>
+        </Typography>
+        <List>
+          <ListItem>
+            <ListItemText
+              disableTypography
+              primary={
+                <Typography variant="subtitle1">
+                  Your .taskcluster.yml
+                </Typography>
+              }
+            />
+            <TextField
+              label="Link to .taskcluster.yml"
+              name="taskclusterYmlUrl"
+              onChange={this.handleTaskclusterYmlUrlChange}
+              value={taskclusterYmlUrl || ''}
+              className={classes.textField}
+              error={taskclusterYmlUrl !== '' && !isValidUrl}
+              helperText={validationMessage}
+            />
+          </ListItem>
+          <ListItem className={classes.editorListItem}>
+            <CodeEditor
+              onChange={this.handleEditorChange}
+              mode="yaml"
+              value={this.state.editorValue}
+              className={this.props.classes.codeEditor}
+            />
+          </ListItem>
+          <ListItem>
+            <ListItemText
+              disableTypography
+              primary={
+                <Typography variant="subtitle2">Extra context</Typography>
+              }
+            />
+          </ListItem>
+          <ListItem className={classes.contextListItem}>
+            <CodeEditor
+              onChange={this.handleExtraContextChange}
+              mode="yaml"
+              value={this.state.extraContext}
+              className={classes.contextEditor}
+            />
+          </ListItem>
+          <ListItem>
+            <Grid container spacing={2} alignItems="flex-end">
+              <Grid item>
+                <Button
+                  spanProps={{ className: classes.analyzeButton }}
+                  tooltipProps={{ title: 'Analyze' }}
+                  onClick={this.handleAnalyze}
+                  variant="contained"
+                  color="primary">
+                  Analyze
+                </Button>
               </Grid>
-            </ListItem>
-            <ListItem>{this.renderFindings()}</ListItem>
-          </List>
-        </Fragment>
+              <Grid item>
+                <TextField
+                  className={classes.dropdown}
+                  select
+                  label="Simulate custom event"
+                  value=""
+                  onChange={this.handleCustomEventSimulate}>
+                  {releaseActions.map(action => (
+                    <MenuItem
+                      key={`gr-${action}`}
+                      value={`github-release.${action}`}>
+                      <code>github-release</code>.<strong>{action}</strong>
+                    </MenuItem>
+                  ))}
+                  {pullRequestActions.map(action => (
+                    <MenuItem
+                      key={`gpr-${action}`}
+                      value={`github-pull-request.${action}`}>
+                      <code>github-pull-request</code>.<strong>{action}</strong>
+                    </MenuItem>
+                  ))}
+                  {pullRequestActions.map(action => (
+                    <MenuItem
+                      key={`gpru-${action}`}
+                      value={`github-pull-request-untrusted.${action}`}>
+                      <code>github-pull-request-untrusted</code>.
+                      <strong>{action}</strong>
+                    </MenuItem>
+                  ))}
+                  {issueCommentActions.map(action => (
+                    <MenuItem
+                      key={`gic-${action}`}
+                      value={`github-issue-comment.${action}`}>
+                      <code>github-issue-comment</code>.
+                      <strong>{action}</strong>
+                    </MenuItem>
+                  ))}
+                </TextField>
+              </Grid>
+              {parsed && (
+                <Grid item>
+                  <div>{parserOk ? '' : '⛔️ could not parse YAML'}</div>
+                  <div>
+                    {parserVersion === 0
+                      ? ` ⚠️ Uses v0, please migrate to v1`
+                      : ''}
+                  </div>
+                  <div>{parserChecks ? '' : ' ⚠️ not using checks'}</div>
+                  <div>
+                    {parserAutoCancel
+                      ? ''
+                      : ' ⚠️ not using autoCancelPreviousChecks: true'}
+                  </div>
+                </Grid>
+              )}
+            </Grid>
+          </ListItem>
+          <ListItem>{this.renderFindings()}</ListItem>
+        </List>
       </Dashboard>
     );
   }

--- a/ui/src/views/WorkerManager/WMViewWorkerPools/index.jsx
+++ b/ui/src/views/WorkerManager/WMViewWorkerPools/index.jsx
@@ -1,4 +1,4 @@
-import React, { Component, Fragment } from 'react';
+import React, { Component } from 'react';
 import { withApollo, graphql } from 'react-apollo';
 import PlusIcon from 'mdi-react/PlusIcon';
 import escapeStringRegexp from 'escape-string-regexp';
@@ -193,37 +193,33 @@ export default class WorkerManagerWorkerPoolsView extends Component {
             placeholder="Worker pool ID contains"
           />
         }>
-        <Fragment>
-          {!WorkerManagerWorkerPoolSummaries && loading && <Spinner loading />}
-          <ErrorPanel fixed error={error} />
-          <ErrorPanel
-            warning
-            error={
-              errorStatsError &&
-              `Failed to load worker pool error stats: ${errorStatsError.message}`
-            }
+        {!WorkerManagerWorkerPoolSummaries && loading && <Spinner loading />}
+        <ErrorPanel fixed error={error} />
+        <ErrorPanel
+          warning
+          error={
+            errorStatsError &&
+            `Failed to load worker pool error stats: ${errorStatsError.message}`
+          }
+        />
+        {WorkerManagerWorkerPoolSummaries && (
+          <WorkerManagerWorkerPoolsTable
+            searchTerm={workerPoolSearch}
+            onPageChange={this.handlePageChange}
+            workerPoolsConnection={WorkerManagerWorkerPoolSummaries}
+            deleteRequest={this.deleteRequest}
+            errorStatsLoading={this.state.errorStatsLoading}
           />
-          {WorkerManagerWorkerPoolSummaries && (
-            <Fragment>
-              <WorkerManagerWorkerPoolsTable
-                searchTerm={workerPoolSearch}
-                onPageChange={this.handlePageChange}
-                workerPoolsConnection={WorkerManagerWorkerPoolSummaries}
-                deleteRequest={this.deleteRequest}
-                errorStatsLoading={this.state.errorStatsLoading}
-              />
-            </Fragment>
-          )}
-          <Button
-            spanProps={{ className: classes.createIconSpan }}
-            tooltipProps={{ title: 'Create Worker Pool' }}
-            requiresAuth
-            color="secondary"
-            variant="circular"
-            onClick={this.handleCreate}>
-            <PlusIcon />
-          </Button>
-        </Fragment>
+        )}
+        <Button
+          spanProps={{ className: classes.createIconSpan }}
+          tooltipProps={{ title: 'Create Worker Pool' }}
+          requiresAuth
+          color="secondary"
+          variant="circular"
+          onClick={this.handleCreate}>
+          <PlusIcon />
+        </Button>
       </Dashboard>
     );
   }


### PR DESCRIPTION
This was found by biome's noUselessFragments lint. It change no behavior, those fragments were in fact not useful
(`<Fragment><elem>...</elem></Fragment>` can just be `<elem>...</elem>`)

This commit is better viewed with whitespaces hidden since a lot of it is just reindenting the content of the fragments down by one.

