### PR TITLE
Derive go example version from the build instead of a hardcoded '93' and remove unused function arguments in doc generation

### DIFF
--- a/changelog/IYvZA22yTE64owyDAnRaOQ.md
+++ b/changelog/IYvZA22yTE64owyDAnRaOQ.md
@@ -1,0 +1,4 @@
+audience: users
+level: patch
+---
+Use the current version for taskcluster in API code examples instead of a hardcoded '93'.

--- a/changelog/W-YPxVYjT8a7DeTq5r486g.md
+++ b/changelog/W-YPxVYjT8a7DeTq5r486g.md
@@ -1,0 +1,2 @@
+level: silent
+---

--- a/ui/src/utils/api-examples/go.js
+++ b/ui/src/utils/api-examples/go.js
@@ -2,6 +2,7 @@
  * Generate Go client library examples for API endpoints
  */
 
+import { version as taskclusterVersion } from '../../../package.json';
 import {
   PLACEHOLDERS,
   getPlaceholderValue,
@@ -9,6 +10,8 @@ import {
   capitalize,
   formatPayloadJson,
 } from './helpers';
+
+const TASKCLUSTER_MAJOR_VERSION = taskclusterVersion.split('.')[0];
 
 /**
  * Convert hyphenated service name to valid Go identifier
@@ -37,7 +40,6 @@ function formatGoIdentifier(name) {
  * @param {string} serviceName - Service name (e.g., 'queue')
  * @param {string} apiVersion - API version (e.g., 'v1')
  * @param {object} entry - API entry metadata
- * @param {string} version - Taskcluster version (default: '93')
  * @param {object} payloadExample - Example payload object (optional)
  * @returns {string} Go code example
  */
@@ -45,7 +47,6 @@ export default function generateGoExample(
   serviceName,
   apiVersion,
   entry,
-  version = '93',
   payloadExample = null
 ) {
   const methodName = capitalize(entry.name);
@@ -142,8 +143,8 @@ export default function generateGoExample(
 import (
 ${importStatements}
 
-	tcclient "github.com/taskcluster/taskcluster/v${version}/clients/client-go"
-	"github.com/taskcluster/taskcluster/v${version}/clients/client-go/${packageName}"
+	tcclient "github.com/taskcluster/taskcluster/v${TASKCLUSTER_MAJOR_VERSION}/clients/client-go"
+	"github.com/taskcluster/taskcluster/v${TASKCLUSTER_MAJOR_VERSION}/clients/client-go/${packageName}"
 )
 
 func main() {

--- a/ui/src/utils/api-examples/go.js
+++ b/ui/src/utils/api-examples/go.js
@@ -38,14 +38,12 @@ function formatGoIdentifier(name) {
  * Generate a Go example for an API endpoint
  *
  * @param {string} serviceName - Service name (e.g., 'queue')
- * @param {string} apiVersion - API version (e.g., 'v1')
  * @param {object} entry - API entry metadata
  * @param {object} payloadExample - Example payload object (optional)
  * @returns {string} Go code example
  */
 export default function generateGoExample(
   serviceName,
-  apiVersion,
   entry,
   payloadExample = null
 ) {

--- a/ui/src/utils/api-examples/index.js
+++ b/ui/src/utils/api-examples/index.js
@@ -67,31 +67,15 @@ function generateSingleExample(language, serviceName, apiVersion, entry) {
   const generators = {
     curl: () =>
       generateCurlExample(serviceName, apiVersion, entry, payloadExample),
-    go: () => generateGoExample(serviceName, apiVersion, entry, payloadExample),
+    go: () => generateGoExample(serviceName, entry, payloadExample),
     python: () =>
-      generatePythonExample(
-        serviceName,
-        apiVersion,
-        entry,
-        false,
-        payloadExample
-      ),
+      generatePythonExample(serviceName, entry, false, payloadExample),
     pythonAsync: () =>
-      generatePythonExample(
-        serviceName,
-        apiVersion,
-        entry,
-        true,
-        payloadExample
-      ),
-    node: () =>
-      generateNodeExample(serviceName, apiVersion, entry, payloadExample),
-    web: () =>
-      generateWebExample(serviceName, apiVersion, entry, payloadExample),
-    rust: () =>
-      generateRustExample(serviceName, apiVersion, entry, payloadExample),
-    shell: () =>
-      generateShellExample(serviceName, apiVersion, entry, payloadExample),
+      generatePythonExample(serviceName, entry, true, payloadExample),
+    node: () => generateNodeExample(serviceName, entry, payloadExample),
+    web: () => generateWebExample(serviceName, entry, payloadExample),
+    rust: () => generateRustExample(serviceName, entry, payloadExample),
+    shell: () => generateShellExample(serviceName, entry, payloadExample),
   };
   const generator = generators[language];
 

--- a/ui/src/utils/api-examples/index.js
+++ b/ui/src/utils/api-examples/index.js
@@ -14,8 +14,6 @@ import generateRustExample from './rust';
 import generateShellExample from './shell';
 import generatePayloadExample from './payload-generator';
 
-// Default version - should match the current Taskcluster version
-const DEFAULT_VERSION = '93';
 // Import references for schema lookup
 let references = [];
 
@@ -50,16 +48,9 @@ function getSchemaContent(schemaId) {
  * @param {string} serviceName - Service name (e.g., 'queue', 'auth')
  * @param {string} apiVersion - API version (e.g., 'v1')
  * @param {object} entry - API entry metadata from references.json
- * @param {string} version - Taskcluster version (e.g., '93')
  * @returns {string|null} Code example or null if not found
  */
-function generateSingleExample(
-  language,
-  serviceName,
-  apiVersion,
-  entry,
-  version = DEFAULT_VERSION
-) {
+function generateSingleExample(language, serviceName, apiVersion, entry) {
   // Generate payload example if entry has input schema
   let payloadExample = null;
 
@@ -76,14 +67,7 @@ function generateSingleExample(
   const generators = {
     curl: () =>
       generateCurlExample(serviceName, apiVersion, entry, payloadExample),
-    go: () =>
-      generateGoExample(
-        serviceName,
-        apiVersion,
-        entry,
-        version,
-        payloadExample
-      ),
+    go: () => generateGoExample(serviceName, apiVersion, entry, payloadExample),
     python: () =>
       generatePythonExample(
         serviceName,
@@ -125,15 +109,13 @@ function generateSingleExample(
  * @param {string} apiVersion - API version (e.g., 'v1')
  * @param {object} entry - API entry metadata
  * @param {string} [language] - Optional language to generate
- * @param {string} [version] - Optional Taskcluster version
  * @returns {object|string|null} Examples object or string or null
  */
 export default function generateExamples(
   serviceName,
   apiVersion,
   entry,
-  language = null,
-  version = DEFAULT_VERSION
+  language = null
 ) {
   // Only generate examples for function entries (not exchanges, logs, etc.)
   if (entry.type !== 'function') {
@@ -142,61 +124,24 @@ export default function generateExamples(
 
   // If a specific language is requested, generate only that one (lazy loading)
   if (language) {
-    return generateSingleExample(
-      language,
-      serviceName,
-      apiVersion,
-      entry,
-      version
-    );
+    return generateSingleExample(language, serviceName, apiVersion, entry);
   }
 
   // Generate all examples
   const examples = {
-    curl: generateSingleExample(
-      'curl',
-      serviceName,
-      apiVersion,
-      entry,
-      version
-    ),
-    go: generateSingleExample('go', serviceName, apiVersion, entry, version),
-    python: generateSingleExample(
-      'python',
-      serviceName,
-      apiVersion,
-      entry,
-      version
-    ),
+    curl: generateSingleExample('curl', serviceName, apiVersion, entry),
+    go: generateSingleExample('go', serviceName, apiVersion, entry),
+    python: generateSingleExample('python', serviceName, apiVersion, entry),
     pythonAsync: generateSingleExample(
       'pythonAsync',
       serviceName,
       apiVersion,
-      entry,
-      version
+      entry
     ),
-    node: generateSingleExample(
-      'node',
-      serviceName,
-      apiVersion,
-      entry,
-      version
-    ),
-    web: generateSingleExample('web', serviceName, apiVersion, entry, version),
-    rust: generateSingleExample(
-      'rust',
-      serviceName,
-      apiVersion,
-      entry,
-      version
-    ),
-    shell: generateSingleExample(
-      'shell',
-      serviceName,
-      apiVersion,
-      entry,
-      version
-    ),
+    node: generateSingleExample('node', serviceName, apiVersion, entry),
+    web: generateSingleExample('web', serviceName, apiVersion, entry),
+    rust: generateSingleExample('rust', serviceName, apiVersion, entry),
+    shell: generateSingleExample('shell', serviceName, apiVersion, entry),
   };
 
   return examples;

--- a/ui/src/utils/api-examples/node.js
+++ b/ui/src/utils/api-examples/node.js
@@ -14,14 +14,12 @@ import {
  * Generate a Node.js example for an API endpoint
  *
  * @param {string} serviceName - Service name (e.g., 'queue')
- * @param {string} apiVersion - API version (e.g., 'v1')
  * @param {object} entry - API entry metadata
  * @param {object} payloadExample - Example payload object (optional)
  * @returns {string} Node.js code example
  */
 export default function generateNodeExample(
   serviceName,
-  apiVersion,
   entry,
   payloadExample = null
 ) {

--- a/ui/src/utils/api-examples/python.js
+++ b/ui/src/utils/api-examples/python.js
@@ -14,7 +14,6 @@ import {
  * Generate a Python example for an API endpoint
  *
  * @param {string} serviceName - Service name (e.g., 'queue')
- * @param {string} apiVersion - API version (e.g., 'v1')
  * @param {object} entry - API entry metadata
  * @param {boolean} isAsync - Generate async or sync version
  * @param {object} payloadExample - Example payload object (optional)
@@ -22,7 +21,6 @@ import {
  */
 export default function generatePythonExample(
   serviceName,
-  apiVersion,
   entry,
   isAsync,
   payloadExample = null

--- a/ui/src/utils/api-examples/rust.js
+++ b/ui/src/utils/api-examples/rust.js
@@ -14,14 +14,12 @@ import {
  * Generate a Rust example for an API endpoint
  *
  * @param {string} serviceName - Service name (e.g., 'queue')
- * @param {string} apiVersion - API version (e.g., 'v1')
  * @param {object} entry - API entry metadata
  * @param {object} payloadExample - Example payload object (optional)
  * @returns {string} Rust code example
  */
 export default function generateRustExample(
   serviceName,
-  apiVersion,
   entry,
   payloadExample = null
 ) {

--- a/ui/src/utils/api-examples/shell.js
+++ b/ui/src/utils/api-examples/shell.js
@@ -14,14 +14,12 @@ import {
  * Generate a taskcluster-cli example for an API endpoint
  *
  * @param {string} serviceName - Service name (e.g., 'queue')
- * @param {string} apiVersion - API version (e.g., 'v1')
  * @param {object} entry - API entry metadata
  * @param {object} payloadExample - Example payload object (optional)
  * @returns {string} taskcluster-cli command example
  */
 export default function generateShellExample(
   serviceName,
-  apiVersion,
   entry,
   payloadExample = null
 ) {

--- a/ui/src/utils/api-examples/web.js
+++ b/ui/src/utils/api-examples/web.js
@@ -14,14 +14,12 @@ import {
  * Generate a Web example for an API endpoint
  *
  * @param {string} serviceName - Service name (e.g., 'queue')
- * @param {string} apiVersion - API version (e.g., 'v1')
  * @param {object} entry - API entry metadata
  * @param {object} payloadExample - Example payload object (optional)
  * @returns {string} Web/browser code example
  */
 export default function generateWebExample(
   serviceName,
-  apiVersion,
   entry,
   payloadExample = null
 ) {


### PR DESCRIPTION
This removes 12 unused arguments from the doc example generators which were added in ced6eaa3830f033d2e082b92c585a7dff1c52bd8. Both `version` and `apiVersion` were only ever used by a single generator but were threaded to every single one of them for some reason. On top of that, version was hardcoded to `93` which means go examples were showing imports for `v93` which is already 7 major versions behind.

This was found while fixing biomes `noUnusedFunctionParameters` lint.