### PR TITLE
fix(ui): keep `Queue Workers` table sorted after navigation

### DIFF
--- a/changelog/issue-8658.md
+++ b/changelog/issue-8658.md
@@ -1,0 +1,5 @@
+audience: users
+level: patch
+reference: issue 8658
+---
+UI: fixes `Queue Workers` table appearing unsorted after navigating away and back to the page.

--- a/ui/src/components/WorkersTable/index.jsx
+++ b/ui/src/components/WorkersTable/index.jsx
@@ -86,20 +86,18 @@ export default class WorkersTable extends Component {
         return workersConnection;
       }
 
+      const direction = sortDirection === 'desc' ? -1 : 1;
+
       return {
         ...workersConnection,
-        edges: [...workersConnection.edges].sort((a, b) => {
-          const firstElement =
-            sortDirection === 'desc'
-              ? this.valueFromNode(b.node)
-              : this.valueFromNode(a.node);
-          const secondElement =
-            sortDirection === 'desc'
-              ? this.valueFromNode(a.node)
-              : this.valueFromNode(b.node);
-
-          return sort(firstElement, secondElement);
-        }),
+        edges: [...workersConnection.edges].sort(
+          (a, b) =>
+            direction *
+            sort(
+              this.valueFromNode(a.node, sortBy),
+              this.valueFromNode(b.node, sortBy)
+            )
+        ),
       };
     },
     {
@@ -167,8 +165,7 @@ export default class WorkersTable extends Component {
     });
   };
 
-  valueFromNode(node) {
-    const query = parse(this.props.location.search.slice(1));
+  valueFromNode(node, sortBy) {
     const mapping = {
       'Worker Group': node.workerGroup,
       'Worker ID': node.workerId,
@@ -183,7 +180,7 @@ export default class WorkersTable extends Component {
       Quarantined: node.quarantineUntil,
     };
 
-    return mapping[query.sortBy];
+    return mapping[sortBy];
   }
 
   componentDidMount() {


### PR DESCRIPTION
When returning to the page with no sort params in the URL, the sort ran once before componentDidMount added the defaults and cached an unsorted result. The comparator was reading sortBy from the URL instead of its argument, so the cache didn't invalidate when the params showed up.

Fixes #8658

>UI: fixes `Queue Workers` table appearing unsorted after navigating away and back to the page.