### PR TITLE
feat(queue): Fix incorrect import

### DIFF
--- a/changelog/issue-8377.md
+++ b/changelog/issue-8377.md
@@ -1,0 +1,4 @@
+level: silent
+audience: developers
+reference: issue 8377
+---

--- a/services/queue/src/metricscollector.js
+++ b/services/queue/src/metricscollector.js
@@ -1,6 +1,6 @@
 import assert from 'assert';
 import Iterate from '@taskcluster/lib-iterate';
-import { TaskQueue } from '../../worker-manager/src/queue-data.js';
+import { TaskQueue } from './data.js';
 import { splitTaskQueueId } from './utils.js';
 
 /**


### PR DESCRIPTION
Probably due to the wrong auto-import in IDE `TaskQueue` was imported from a different service, which violates cross-service imports


Fixes #8377
