### PR TITLE
fix(monitor): correct 'succesfully' -> 'successfully' in basicTimer field

### DIFF
--- a/changelog/monitor-succesfully-typo.md
+++ b/changelog/monitor-succesfully-typo.md
@@ -1,0 +1,4 @@
+audience: developers
+level: silent
+---
+Fix `succesfully` -> `successfully` typo in the `basicTimer` field description in `@taskcluster/lib-monitor`.

--- a/generated/references.json
+++ b/generated/references.json
@@ -18611,7 +18611,7 @@
           "fields": {
             "duration": "The duration in ms of the function.",
             "name": "The name of the handler.",
-            "status": "Whether or not the handler resolved succesfully."
+            "status": "Whether or not the handler resolved successfully."
           },
           "level": "info",
           "name": "handlerTimer",
@@ -20239,7 +20239,7 @@
           "fields": {
             "duration": "The duration in ms of the function.",
             "name": "The name of the handler.",
-            "status": "Whether or not the handler resolved succesfully."
+            "status": "Whether or not the handler resolved successfully."
           },
           "level": "info",
           "name": "handlerTimer",
@@ -20672,7 +20672,7 @@
           "fields": {
             "duration": "The duration in ms of the function.",
             "name": "The name of the handler.",
-            "status": "Whether or not the handler resolved succesfully."
+            "status": "Whether or not the handler resolved successfully."
           },
           "level": "info",
           "name": "handlerTimer",
@@ -21221,7 +21221,7 @@
           "fields": {
             "duration": "The duration in ms of the function.",
             "name": "The name of the handler.",
-            "status": "Whether or not the handler resolved succesfully."
+            "status": "Whether or not the handler resolved successfully."
           },
           "level": "info",
           "name": "handlerTimer",
@@ -23500,7 +23500,7 @@
           "fields": {
             "duration": "The duration in ms of the function.",
             "name": "The name of the handler.",
-            "status": "Whether or not the handler resolved succesfully."
+            "status": "Whether or not the handler resolved successfully."
           },
           "level": "info",
           "name": "handlerTimer",
@@ -23901,7 +23901,7 @@
           "fields": {
             "duration": "The duration in ms of the function.",
             "name": "The name of the handler.",
-            "status": "Whether or not the handler resolved succesfully."
+            "status": "Whether or not the handler resolved successfully."
           },
           "level": "info",
           "name": "handlerTimer",
@@ -24346,7 +24346,7 @@
           "fields": {
             "duration": "The duration in ms of the function.",
             "name": "The name of the handler.",
-            "status": "Whether or not the handler resolved succesfully."
+            "status": "Whether or not the handler resolved successfully."
           },
           "level": "info",
           "name": "handlerTimer",
@@ -24981,7 +24981,7 @@
           "fields": {
             "duration": "The duration in ms of the function.",
             "name": "The name of the handler.",
-            "status": "Whether or not the handler resolved succesfully."
+            "status": "Whether or not the handler resolved successfully."
           },
           "level": "info",
           "name": "handlerTimer",
@@ -25494,7 +25494,7 @@
           "fields": {
             "duration": "The duration in ms of the function.",
             "name": "The name of the handler.",
-            "status": "Whether or not the handler resolved succesfully."
+            "status": "Whether or not the handler resolved successfully."
           },
           "level": "info",
           "name": "handlerTimer",
@@ -26210,7 +26210,7 @@
           "fields": {
             "duration": "The duration in ms of the function.",
             "name": "The name of the handler.",
-            "status": "Whether or not the handler resolved succesfully."
+            "status": "Whether or not the handler resolved successfully."
           },
           "level": "info",
           "name": "handlerTimer",
@@ -26869,7 +26869,7 @@
           "fields": {
             "duration": "The duration in ms of the function.",
             "name": "The name of the handler.",
-            "status": "Whether or not the handler resolved succesfully."
+            "status": "Whether or not the handler resolved successfully."
           },
           "level": "info",
           "name": "handlerTimer",
@@ -27175,7 +27175,7 @@
           "fields": {
             "duration": "The duration in ms of the function.",
             "name": "The name of the handler.",
-            "status": "Whether or not the handler resolved succesfully."
+            "status": "Whether or not the handler resolved successfully."
           },
           "level": "info",
           "name": "handlerTimer",

--- a/libraries/monitor/src/builtins.js
+++ b/libraries/monitor/src/builtins.js
@@ -36,7 +36,7 @@ MonitorManager.register({
   description: 'A basic timer applied to a function.',
   fields: {
     name: 'The name of the handler.',
-    status: 'Whether or not the handler resolved succesfully.',
+    status: 'Whether or not the handler resolved successfully.',
     duration: 'The duration in ms of the function.',
   },
 });


### PR DESCRIPTION
## Summary
Single-word typo fix in `libraries/monitor/src/builtins.js` line 39 (the `status` field description of the built-in `basicTimer` log metric):

```diff
-    status: 'Whether or not the handler resolved succesfully.',
+    status: 'Whether or not the handler resolved successfully.',
```

Includes a `silent`-level changelog snippet per `dev-docs/best-practices/changelog.md`.

## Scope note (deliberately narrow)
The same misspelling also appears in `db/versions/0065.yml` (the `delete_indexed_task` description), which is in turn rendered into the auto-generated `db/fns.md` at line 1910. Per this repo's CLAUDE.md guidance "Never modify existing version files; always add new versions for changes", I left both of those alone — happy to follow up with whatever approach the maintainers prefer (new version, or an exception for typo-only edits).

## Verification
- `grep -n succesfully libraries/monitor/src/builtins.js` → no matches after the change.
- Changelog file added under `changelog/monitor-succesfully-typo.md` (audience: developers, level: silent).

## Note
Co-developed with AI assistance; reviewed and tested by submitter.