### PR TITLE
Use a `Set` instead of a `Map` with `undefined` values in `TaskGroup`

### DIFF
--- a/changelog/Wr2mIsbrRqeqOOnskEjmdQ.md
+++ b/changelog/Wr2mIsbrRqeqOOnskEjmdQ.md
@@ -1,0 +1,2 @@
+level: silent
+---

--- a/ui/src/views/Tasks/TaskGroup/index.jsx
+++ b/ui/src/views/Tasks/TaskGroup/index.jsx
@@ -271,7 +271,7 @@ export default class TaskGroup extends Component {
 
     this.previousCursor = INITIAL_CURSOR;
     this.listener = null;
-    this.tasks = new Map();
+    this.tasks = new Set();
 
     // Batching for table updates
     this.pendingTableUpdate = null;
@@ -436,7 +436,7 @@ export default class TaskGroup extends Component {
           });
         } else {
           // unseen task, so keep the Task and TaskStatus values
-          this.tasks.set(tasksSubscriptions.taskId);
+          this.tasks.add(tasksSubscriptions.taskId);
           edges = previousResult.taskGroup.edges.concat({
             // eslint-disable-next-line no-underscore-dangle
             __typename: 'TasksEdge',
@@ -726,7 +726,7 @@ export default class TaskGroup extends Component {
               return false;
             }
 
-            this.tasks.set(edge.node.taskId);
+            this.tasks.add(edge.node.taskId);
 
             return true;
           });
@@ -907,7 +907,9 @@ export default class TaskGroup extends Component {
     this.subscribe({ taskGroupId, subscribeToMore });
 
     if (!this.tasks.size && taskGroup && isFromSameTaskGroupId) {
-      taskGroup.edges.forEach(edge => this.tasks.set(edge.node.taskId));
+      taskGroup.edges.forEach(edge => {
+        this.tasks.add(edge.node.taskId);
+      });
     }
 
     const title = ['Task Group'];


### PR DESCRIPTION
`this.tasks` was declared as a `Map` but only ever used for membership checks (insertion was `set(key)`, no value which defaulted to `undefined`). This is a sign that it's a `Set` wearing a `Map` costume.

Convert it to an actual `Set` and fix what prompted me to look at this code while I'm touching it, `forEach` was returning whatever `this.tasks.set(...)` was returning which triggered biome's `useIterableCallbackReturn`.

This map was never needed and should've been a set in 3c330c362ad7348a6eee38ea868f412cd2b28116 already.
