### PR TITLE
Fix sorting functions in task utils

### DIFF
--- a/changelog/Ha6kUhscQDiGduil9C3FFw.md
+++ b/changelog/Ha6kUhscQDiGduil9C3FFw.md
@@ -1,0 +1,2 @@
+level: silent
+---

--- a/changelog/WXvKcTsVR4y3fMzQ9PMWXg.md
+++ b/changelog/WXvKcTsVR4y3fMzQ9PMWXg.md
@@ -1,0 +1,2 @@
+level: silent
+---

--- a/ui/src/utils/task.js
+++ b/ui/src/utils/task.js
@@ -31,17 +31,17 @@ export const taskRunDurationInMs = run => {
 
 export const taskRunEarliestStart = task => {
   const started = (task?.status?.runs ?? [])
-    .map(run => run.started)
-    .filter(item => item)
-    .sort((a, b) => a.started - b.started);
+    .filter(run => run.started)
+    .map(run => new Date(run.started).getTime())
+    .sort((a, b) => a - b);
 
-  return started.length ? new Date(started[0]).getTime() : Date.now();
+  return started.length ? started[0] : Date.now();
 };
 
 export const taskRunLatestResolve = task => {
   const resolved = (task?.status?.runs ?? [])
-    .map(run => run.resolved && new Date(run.resolved).getTime())
-    .filter(item => item)
+    .filter(run => run.resolved)
+    .map(run => new Date(run.resolved).getTime())
     .sort((a, b) => b - a);
 
   return resolved.length ? resolved[0] : Date.now();

--- a/ui/src/utils/task.js
+++ b/ui/src/utils/task.js
@@ -2,7 +2,9 @@ import { curry, pipe, map, dropRepeatsWith } from 'ramda';
 import { memoize } from './memoize';
 
 export const taskLastRun = task => {
-  const sorted = [...task?.status?.runs].sort((a, b) => b.runId - a.runId);
+  const sorted = (task?.status?.runs ?? []).toSorted(
+    (a, b) => b.runId - a.runId
+  );
 
   if (sorted.length === 0 || !sorted[0].started) {
     return null;
@@ -28,7 +30,7 @@ export const taskRunDurationInMs = run => {
 };
 
 export const taskRunEarliestStart = task => {
-  const started = [...task?.status?.runs]
+  const started = (task?.status?.runs ?? [])
     .map(run => run.started)
     .filter(item => item)
     .sort((a, b) => a.started - b.started);
@@ -37,7 +39,7 @@ export const taskRunEarliestStart = task => {
 };
 
 export const taskRunLatestResolve = task => {
-  const resolved = [...task?.status?.runs]
+  const resolved = (task?.status?.runs ?? [])
     .map(run => run.resolved && new Date(run.resolved).getTime())
     .filter(item => item)
     .sort((a, b) => b - a);

--- a/ui/src/utils/task.test.js
+++ b/ui/src/utils/task.test.js
@@ -73,6 +73,28 @@ it('should return latest task run resolve time', () => {
   );
 });
 
+it('handles missing data in taskLastRun', () => {
+  expect(taskLastRun(undefined)).toBeNull();
+  expect(taskLastRun({})).toBeNull();
+  expect(taskLastRun({ status: {} })).toBeNull();
+});
+
+it('handles missing data in taskRunEarliestStart', () => {
+  const before = Date.now();
+
+  expect(taskRunEarliestStart(undefined)).toBeGreaterThanOrEqual(before);
+  expect(taskRunEarliestStart({})).toBeGreaterThanOrEqual(before);
+  expect(taskRunEarliestStart({ status: {} })).toBeGreaterThanOrEqual(before);
+});
+
+it('handles missing data in taskRunLatestResolve', () => {
+  const before = Date.now();
+
+  expect(taskRunLatestResolve(undefined)).toBeGreaterThanOrEqual(before);
+  expect(taskRunLatestResolve({})).toBeGreaterThanOrEqual(before);
+  expect(taskRunLatestResolve({ status: {} })).toBeGreaterThanOrEqual(before);
+});
+
 it('should filter tasks by state', () => {
   expect(filterTasksByState(['started'], [])).toEqual([]);
   expect(

--- a/ui/src/utils/task.test.js
+++ b/ui/src/utils/task.test.js
@@ -45,9 +45,9 @@ it('should return earliest task run start time', () => {
   const task = {
     status: {
       runs: [
-        { runId: 0, started: new Date('2022-05-05T05:05:05.000') },
-        { runId: 1, started: new Date('2022-05-05T05:05:10.000') },
-        { runId: 2, started: new Date('2022-05-05T05:05:15.000') },
+        { runId: 0, started: new Date('2022-05-05T05:05:10.000') },
+        { runId: 1, started: new Date('2022-05-05T05:05:15.000') },
+        { runId: 2, started: new Date('2022-05-05T05:05:05.000') },
       ],
     },
   };


### PR DESCRIPTION
This fixes 3 things.

First, those 3 functions were using `[...task?.status?.runs]`, which would explode if any of those `?.` would return `undefined`. Instead, we now use `task?.status?.runs ?? []` which coerces it back to an empty array.
Second, the 3 functions were always copying the input array by using the spread operator, despite only one of them actually needing said copy. I changed that to only copy it when needed and use `toSorted` which makes it slightly more readable than `[...runs]`.

Finally, `taskRunEarliestStart` was plain wrong and not sorting the input at all because it was mapping a value and then sorting on it as it hadn't been mapped.

Best reviewed commit by commit.

Found this while fixing biome's `noUnsafeOptionalChaining` lint.