### PR TITLE
Disable happy eyeballs for the queue service tests

### DIFF
--- a/changelog/OyjV6BktTxaU_eNVvA8crw.md
+++ b/changelog/OyjV6BktTxaU_eNVvA8crw.md
@@ -1,0 +1,2 @@
+level: silent
+---

--- a/services/queue/package.json
+++ b/services/queue/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "coverage": "c8 yarn test",
     "coverage:report": "c8 yarn test && c8 report --temp-directory ./coverage/tmp --reporter json --report-dir ../../artifacts",
-    "test": "mocha test/*_test.js",
+    "test": "NODE_OPTIONS=--network-family-autoselection=false mocha test/*_test.js",
     "lint": "eslint src/*.js test/*.js"
   },
   "devDependencies": {


### PR DESCRIPTION
This is the same fix as 0414d861277047b2d2866598874e3c017c484fd3 but for the queue service. Not going to re-explain everything, go read that one commit to understand why we still can't have nice things.

Example of failure:

```
2) services/queue/file:/builds/worker/checkouts/taskcluster/services/queue/test/artifact_test.js (real)
     without public artifact signing
       Can not update content type of artifact:
   Error: read EINVAL
    at tryReadStart (node:net:775:20)
    at Socket._read (node:net:790:5)
    at MockHttpSocket.<anonymous> (node:net:788:37)
    at Object.onceWrapper (node:events:630:28)
    at MockHttpSocket.emit (node:events:509:28)
    at MockHttpSocket.emit (/builds/worker/checkouts/taskcluster/node_modules/@mswjs/interceptors/lib/node/ClientRequest-DFs7FPNi.cjs:429:10)
    at TLSSocket.<anonymous> (/builds/worker/checkouts/taskcluster/node_modules/@mswjs/interceptors/lib/node/ClientRequest-DFs7FPNi.cjs:497:9)
    at TLSSocket.emit (node:events:521:24)
    at afterConnect (node:net:1690:10)
    at afterConnectMultiple (node:net:1797:3)

```