### PR TITLE
Fix a few issues on the changelog UI page

### DIFF
--- a/changelog/QUJY-xBnRNSRE2V6_EkXyQ.md
+++ b/changelog/QUJY-xBnRNSRE2V6_EkXyQ.md
@@ -1,0 +1,4 @@
+audience: users
+level: patch
+---
+Fix the changelog page filters to actually reflect what's in the URL.

--- a/ui/src/views/Documentation/Changelog/index.jsx
+++ b/ui/src/views/Documentation/Changelog/index.jsx
@@ -18,12 +18,20 @@ const parseMarkdownIntoSections = markdown => {
   let version = '';
   let audience = '';
   let content = [];
-  let id = 0;
+  const pushSection = () => {
+    sections.push({
+      id: sections.length,
+      version,
+      audience,
+      content,
+      html: content.join('\n'),
+    });
+  };
 
   lines.forEach(line => {
     if (line.startsWith('## ')) {
       if (version) {
-        sections.push({ version, audience, content, html: content.join('\n') });
+        pushSection();
       }
 
       version = line.slice(3);
@@ -31,7 +39,7 @@ const parseMarkdownIntoSections = markdown => {
       content = [];
     } else if (line.startsWith('### ')) {
       if (audience) {
-        sections.push({ version, audience, content, html: content.join('\n') });
+        pushSection();
         audience = '';
         content = [];
       }
@@ -42,9 +50,8 @@ const parseMarkdownIntoSections = markdown => {
     }
   });
 
-  if (version && version && content.length) {
-    sections.push({ version, audience, content, html: content.join('\n'), id });
-    id += 1;
+  if (version && content.length) {
+    pushSection();
   }
 
   return sections;

--- a/ui/src/views/Documentation/Changelog/index.jsx
+++ b/ui/src/views/Documentation/Changelog/index.jsx
@@ -104,12 +104,12 @@ export default class Changelog extends Component {
     const search = new URLSearchParams(this.props.location.search);
 
     this.state = {
-      version: search.get('version', ''),
-      from: search.get('from', ''),
-      to: search.get('to', ''),
-      q: search.get('q', ''),
-      all: search.get('all', ''),
-      audience: search.get('audience', ''),
+      version: search.get('version') || '',
+      from: search.get('from') || '',
+      to: search.get('to') || '',
+      q: search.get('q') || '',
+      all: search.get('all') === 'true',
+      audience: search.get('audience') || '',
     };
   }
 

--- a/ui/src/views/Documentation/Changelog/index.jsx
+++ b/ui/src/views/Documentation/Changelog/index.jsx
@@ -91,6 +91,11 @@ const FILTERS = ['version', 'from', 'to', 'q', 'all', 'audience'];
   },
   version: {
     cursor: 'pointer',
+    background: 'none',
+    border: 'none',
+    padding: 0,
+    font: 'inherit',
+    color: 'inherit',
   },
 }))
 export default class Changelog extends Component {
@@ -252,11 +257,12 @@ export default class Changelog extends Component {
         {this.filteredSections(this.state).map(section => (
           <Grid key={section.id} item xs={12} className={classes.section}>
             <h1>
-              <span
+              <button
+                type="button"
                 className={classes.version}
                 onClick={() => onToggleFilter('version', section.version)}>
                 {section.version}
-              </span>
+              </button>
               {section.audience && (
                 <Chip
                   className={classes.chip}

--- a/ui/src/views/Documentation/Changelog/index.jsx
+++ b/ui/src/views/Documentation/Changelog/index.jsx
@@ -205,8 +205,9 @@ export default class Changelog extends Component {
             <Autocomplete
               options={this.versions}
               getOptionLabel={option => option.label}
-              onInputChange={(event, value) => this.setState({ [key]: value })}
-              defaultValue={{ label: this.state[key], value: this.state[key] }}
+              freeSolo
+              inputValue={this.state[key]}
+              onInputChange={(_event, value) => this.setState({ [key]: value })}
               renderInput={params => (
                 <TextField {...params} label={label} fullWidth />
               )}
@@ -225,11 +226,11 @@ export default class Changelog extends Component {
           <Autocomplete
             options={this.audiences}
             getOptionLabel={option => option.label}
-            onInputChange={(event, value) => this.setState({ audience: value })}
-            defaultValue={{
-              label: this.state.audience,
-              value: this.state.audience,
-            }}
+            freeSolo
+            inputValue={this.state.audience}
+            onInputChange={(_event, value) =>
+              this.setState({ audience: value })
+            }
             renderInput={params => (
               <TextField {...params} label="Audience" fullWidth />
             )}


### PR DESCRIPTION
See individual commits. Basically fixes a bunch of warnings thrown by react/MUI because of bad usage of APIs, missing IDs. Fixed 2 biome a11y lints and fixed the filters to properly reflect what the filters are in the URL and to update when clicking on a version number in the changelog.