### PR TITLE
Disable happy eyeballs for the client-web tests

### DIFF
--- a/changelog/GNC5uZFYRb-GCwYPRqFNrQ.md
+++ b/changelog/GNC5uZFYRb-GCwYPRqFNrQ.md
@@ -1,0 +1,2 @@
+level: silent
+---

--- a/clients/client-web/package.json
+++ b/clients/client-web/package.json
@@ -10,7 +10,7 @@
   ],
   "scripts": {
     "lint": "eslint src/*.js test/*.js",
-    "test": "NODE_OPTIONS=--openssl-legacy-provider karma start --single-run"
+    "test": "NODE_OPTIONS='--openssl-legacy-provider --network-family-autoselection=false' karma start --single-run"
   },
   "devDependencies": {
     "@babel/core": "^7.29.0",


### PR DESCRIPTION
See f253e8c23ce7bfe285bbfdeae8e7b7df89e7b1bc and
0414d861277047b2d2866598874e3c017c484fd3

Example of failure:

```

  1) clients/client/file:/builds/worker/checkouts/taskcluster/clients/client/test/upload_download_test.js
       downloadArtifact
         s3 artifact:
     RequestError: read EINVAL
      at emitRequestError (file:///builds/worker/checkouts/taskcluster/clients/client/node_modules/got/dist/source/core/index.js:1088:120)
      at ClientRequest.<anonymous> (file:///builds/worker/checkouts/taskcluster/clients/client/node_modules/got/dist/source/core/index.js:1111:13)
      at Object.onceWrapper (node:events:631:26)
      at ClientRequest.emit (node:events:521:24)
      at emitErrorEvent (node:_http_client:109:11)
      at MockHttpSocket.socketErrorListener (node:_http_client:593:5)
      at MockHttpSocket.emit (node:events:509:28)
      at MockHttpSocket.emit (node_modules/@mswjs/interceptors/lib/node/ClientRequest-DFs7FPNi.cjs:429:10)
      at MockHttpSocket.destroy (node_modules/@mswjs/interceptors/lib/node/ClientRequest-DFs7FPNi.cjs:433:19)
      at tryReadStart (node:net:775:12)
      at Socket._read (node:net:790:5)
      at MockHttpSocket.<anonymous> (node:net:788:37)
      at Object.onceWrapper (node:events:630:28)
      at MockHttpSocket.emit (node:events:521:24)
      at MockHttpSocket.emit (node_modules/@mswjs/interceptors/lib/node/ClientRequest-DFs7FPNi.cjs:429:10)
      at TLSSocket.<anonymous> (node_modules/@mswjs/interceptors/lib/node/ClientRequest-DFs7FPNi.cjs:497:9)
      at TLSSocket.emit (node:events:521:24)
      at afterConnect (node:net:1690:10)
      at tryReadStart (node:net:775:20)
      at Socket._read (node:net:790:5)
      at MockHttpSocket.<anonymous> (node:net:788:37)
      at Object.onceWrapper (node:events:630:28)
      at MockHttpSocket.emit (node:events:521:24)
      at MockHttpSocket.emit (node_modules/@mswjs/interceptors/lib/node/ClientRequest-DFs7FPNi.cjs:429:10)
      at TLSSocket.<anonymous> (node_modules/@mswjs/interceptors/lib/node/ClientRequest-DFs7FPNi.cjs:497:9)
      at TLSSocket.emit (node:events:521:24)
      at afterConnect (node:net:1690:10)
      at afterConnectMultiple (node:net:1797:3)
     Caused by: Error: read EINVAL
      at tryReadStart (node:net:775:20)
      at Socket._read (node:net:790:5)
      at MockHttpSocket.<anonymous> (node:net:788:37)
      at Object.onceWrapper (node:events:630:28)
      at MockHttpSocket.emit (node:events:521:24)
      at MockHttpSocket.emit (node_modules/@mswjs/interceptors/lib/node/ClientRequest-DFs7FPNi.cjs:429:10)
      at TLSSocket.<anonymous> (node_modules/@mswjs/interceptors/lib/node/ClientRequest-DFs7FPNi.cjs:497:9)
      at TLSSocket.emit (node:events:521:24)
      at afterConnect (node:net:1690:10)
      at afterConnectMultiple (node:net:1797:3)
```
