### PR TITLE
feat(w-m): add Azure ARM deployment error metrics

### DIFF
--- a/changelog/azure-arm-deployment-error-metrics.md
+++ b/changelog/azure-arm-deployment-error-metrics.md
@@ -1,0 +1,9 @@
+audience: deployers
+level: minor
+---
+The worker-manager Azure provider now exposes ARM deployment creation failures and failed deployment operations as a Prometheus counter for observability.
+
+New Prometheus metric:
+- `worker_manager_azure_arm_deployment_errors_total` (counter) - incremented once for each ARM deployment creation failure or failed deployment operation, labeled by `providerId`, `workerPoolId`, `workerGroup`, `errorKind`, `errorCode`, `statusCode`, `provisioningState`, `provisioningOperation`, `targetResourceType`, `vmSize`, and `priority`.
+
+This lets deployers chart Azure ARM deployment creation failures and failed operations by worker pool, region, Azure error code, and VM size in Prometheus/Grafana.

--- a/generated/references.json
+++ b/generated/references.json
@@ -18065,6 +18065,29 @@
           "type": "gauge"
         },
         {
+          "description": "Count of Azure ARM deployment creation failures and failed deployment operations by worker pool, location, and Azure error details",
+          "labels": {
+            "errorCode": "Azure error code",
+            "errorKind": "Worker-manager error kind",
+            "priority": "Azure VM priority",
+            "providerId": "ID of the provider",
+            "provisioningOperation": "Azure provisioning operation",
+            "provisioningState": "Azure provisioning state",
+            "statusCode": "Operation status code from the resource provider",
+            "targetResourceType": "Azure target resource type",
+            "vmSize": "Azure VM size",
+            "workerGroup": "Worker group (region/zone/location)",
+            "workerPoolId": "The worker pool ID"
+          },
+          "name": "worker_manager_azure_arm_deployment_errors_total",
+          "registers": [
+            "provision",
+            "scan"
+          ],
+          "title": "Azure ARM deployment errors",
+          "type": "counter"
+        },
+        {
           "description": "Most recently observed value of Azure x-ms-ratelimit-remaining-subscription-* headers",
           "labels": {
             "limitType": "Rate limit category: reads, writes, or deletes",

--- a/services/worker-manager/src/monitor.js
+++ b/services/worker-manager/src/monitor.js
@@ -545,6 +545,27 @@ MonitorManager.registerMetric('azureThrottleCount', {
   registers: ['provision', 'scan'],
 });
 
+MonitorManager.registerMetric('azureArmDeploymentError', {
+  name: 'worker_manager_azure_arm_deployment_errors_total',
+  type: 'counter',
+  title: 'Azure ARM deployment errors',
+  description: 'Count of Azure ARM deployment creation failures and failed deployment operations by worker pool, location, and Azure error details',
+  labels: {
+    providerId: 'ID of the provider',
+    workerPoolId: 'The worker pool ID',
+    workerGroup: 'Worker group (region/zone/location)',
+    errorKind: 'Worker-manager error kind',
+    errorCode: 'Azure error code',
+    statusCode: 'Operation status code from the resource provider',
+    provisioningState: 'Azure provisioning state',
+    provisioningOperation: 'Azure provisioning operation',
+    targetResourceType: 'Azure target resource type',
+    vmSize: 'Azure VM size',
+    priority: 'Azure VM priority',
+  },
+  registers: ['provision', 'scan'],
+});
+
 MonitorManager.registerMetric('azureRateLimitRemaining', {
   name: 'worker_manager_azure_ratelimit_remaining',
   type: 'gauge',

--- a/services/worker-manager/src/providers/azure/index.js
+++ b/services/worker-manager/src/providers/azure/index.js
@@ -49,6 +49,8 @@ const InstanceStates = {
 const failProvisioningStates = new Set(['Failed', 'Deleting', 'Canceled', 'Deallocating']);
 
 const DEPLOYMENT_METHOD_ARM = 'arm-template';
+const UNKNOWN_METRIC_LABEL = 'unknown';
+const MAX_METRIC_LABEL_LENGTH = 200;
 const maxInstanceView404Streak = 2;
 // Per Azure Certificate Authority details, these are the HTTP AIA hosts
 // clients may need to reach for Azure certificate chain building.
@@ -90,6 +92,77 @@ export function isAllowedAiaLocation(location) {
   return allowedAiaLocations.some(entry =>
     hostname === entry.hostname &&
     (!entry.pathPrefix || parsedUrl.pathname.startsWith(entry.pathPrefix)));
+}
+
+function metricLabel(value) {
+  if (value === undefined || value === null || value === '') {
+    return UNKNOWN_METRIC_LABEL;
+  }
+  if (typeof value === 'object') {
+    return UNKNOWN_METRIC_LABEL;
+  }
+  return String(value).slice(0, MAX_METRIC_LABEL_LENGTH);
+}
+
+function firstMetricLabel(...values) {
+  for (const value of values) {
+    const label = metricLabel(value);
+    if (label !== UNKNOWN_METRIC_LABEL) {
+      return label;
+    }
+  }
+  return UNKNOWN_METRIC_LABEL;
+}
+
+function armParameterValue(parameters, name) {
+  const param = parameters?.[name];
+  if (param && typeof param === 'object' && 'value' in param) {
+    return param.value;
+  }
+  return param;
+}
+
+function extractAzureMetricError(error) {
+  const queue = [
+    error?.response?.parsedBody?.error,
+    error?.parsedBody?.error,
+    error?.body?.error,
+    error?.error,
+    error,
+  ];
+  const seen = new Set();
+  let fallbackError;
+
+  while (queue.length > 0) {
+    const current = queue.shift();
+    if (!current || typeof current !== 'object' || seen.has(current)) {
+      continue;
+    }
+    seen.add(current);
+
+    if (!fallbackError && (current.code || current.message || current.target)) {
+      fallbackError = current;
+    }
+
+    for (const nested of [
+      current.response?.parsedBody?.error,
+      current.parsedBody?.error,
+      current.body?.error,
+      current.error,
+    ]) {
+      if (nested && typeof nested === 'object') {
+        queue.push(nested);
+      }
+    }
+
+    if (Array.isArray(current.details) && current.details.length > 0) {
+      queue.push(...current.details);
+    } else if (current.code || current.message || current.target) {
+      return current;
+    }
+  }
+
+  return fallbackError;
 }
 
 export class AzureProvider extends Provider {
@@ -631,6 +704,14 @@ export class AzureProvider extends Provider {
         error: err,
       });
 
+      this.#recordAzureArmDeploymentError({
+        worker,
+        errorKind: 'creation-error',
+        error: err,
+        statusCode: err?.statusCode ?? err?.response?.status,
+        provisioningOperation: 'Create',
+      });
+
       await this.reportError({
         workerPool,
         kind: 'creation-error',
@@ -651,6 +732,38 @@ export class AzureProvider extends Provider {
       });
       await this.removeWorker({ worker, reason: `ARM Deployment failure: ${err.message}` });
     }
+  }
+
+  #recordAzureArmDeploymentError({
+    worker,
+    errorKind,
+    error,
+    statusCode,
+    provisioningState,
+    provisioningOperation,
+    targetResource,
+  }) {
+    const azureError = extractAzureMetricError(error);
+    const parameters = worker.providerData?.armDeployment?.parameters ?? {};
+
+    // Still emit a sample when Azure did not provide a structured error body.
+    // The labels below will fall back to the top-level error or "unknown".
+    this.monitor.metric.azureArmDeploymentError(1, {
+      providerId: this.providerId,
+      workerPoolId: worker.workerPoolId,
+      workerGroup: firstMetricLabel(worker.workerGroup, worker.providerData?.location),
+      errorKind: metricLabel(errorKind),
+      errorCode: firstMetricLabel(azureError?.code, error?.code, error?.name),
+      statusCode: firstMetricLabel(statusCode, error?.statusCode, error?.response?.status),
+      provisioningState: metricLabel(provisioningState),
+      provisioningOperation: metricLabel(provisioningOperation),
+      targetResourceType: metricLabel(targetResource?.resourceType),
+      vmSize: firstMetricLabel(
+        armParameterValue(parameters, 'vmSize'),
+        worker.providerData?.vm?.config?.hardwareProfile?.vmSize,
+      ),
+      priority: firstMetricLabel(armParameterValue(parameters, 'priority'), worker.providerData?.vm?.config?.priority),
+    });
   }
 
   /**
@@ -848,6 +961,16 @@ export class AzureProvider extends Provider {
         trackingId: properties.trackingId,
         timestamp: properties.timestamp,
       });
+
+      this.#recordAzureArmDeploymentError({
+        worker,
+        errorKind: 'arm-deployment-error',
+        error: operationError ?? status,
+        statusCode: properties.statusCode,
+        provisioningState: properties.provisioningState ?? status.status,
+        provisioningOperation: properties.provisioningOperation,
+        targetResource: properties.targetResource,
+      });
     }
 
     if (failingOperations.length === 0 && !defaultMessage) {
@@ -865,6 +988,15 @@ export class AzureProvider extends Provider {
     }
 
     const workerPool = await WorkerPool.get(this.db, worker.workerPoolId);
+
+    if (failingOperations.length === 0) {
+      this.#recordAzureArmDeploymentError({
+        worker,
+        errorKind: 'arm-deployment-error',
+        error: deployment.properties?.error ?? { message: defaultMessage },
+        provisioningState: deployment.properties?.provisioningState,
+      });
+    }
 
     await this.reportError({
       workerPool,

--- a/services/worker-manager/test/provider_azure_test.js
+++ b/services/worker-manager/test/provider_azure_test.js
@@ -623,6 +623,72 @@ helper.secrets.mockSuite(testing.suiteName(), [], (mock, skipping) => {
       assert.equal(worker.providerData.armDeployment.mode, 'Incremental');
     });
 
+    test('records metric when ARM deployment creation fails', async () => {
+      const recordedMetrics = [];
+      const originalMetric = provider.monitor._metric.azureArmDeploymentError;
+      const originalBeginCreateOrUpdate = fake.deploymentsClient.deployments.beginCreateOrUpdate;
+      provider.monitor._metric.azureArmDeploymentError = (value, labels) => {
+        recordedMetrics.push({ value, labels });
+      };
+      fake.deploymentsClient.deployments.beginCreateOrUpdate = async () => {
+        const err = new Error('Task timed out after 180000ms (queue has 4 running, 0 waiting)');
+        err.name = 'TimeoutError';
+        throw err;
+      };
+
+      try {
+        const workerPool = await makeWorkerPool({
+          config: {
+            minCapacity: 1,
+            maxCapacity: 1,
+            scalingRatio: 1,
+            launchConfigs: [{
+              workerManager: {
+                capacityPerInstance: 1,
+              },
+              armDeployment: {
+                mode: 'Incremental',
+                templateLink: {
+                  id: '/subscriptions/test/resourceGroups/test/providers/Microsoft.Resources/templateSpecs/test/versions/1.0.0',
+                },
+                parameters: {
+                  location: { value: 'east' },
+                  vmSize: { value: 'Standard_F8s_v2' },
+                  priority: { value: 'Spot' },
+                  imageId: {
+                    value: '/subscriptions/fake/resourceGroups/images/providers/Microsoft.Compute/galleries/g/images/i/versions/1.0.3',
+                  },
+                },
+              },
+            }],
+          },
+        });
+        const workerPoolStats = new WorkerPoolStats('wpid');
+
+        await provider.provision({ workerPool, workerPoolStats });
+
+        assert.deepEqual(recordedMetrics, [{
+          value: 1,
+          labels: {
+            providerId,
+            workerPoolId,
+            workerGroup: 'east',
+            errorKind: 'creation-error',
+            errorCode: 'TimeoutError',
+            statusCode: 'unknown',
+            provisioningState: 'unknown',
+            provisioningOperation: 'Create',
+            targetResourceType: 'unknown',
+            vmSize: 'Standard_F8s_v2',
+            priority: 'Spot',
+          },
+        }]);
+      } finally {
+        provider.monitor._metric.azureArmDeploymentError = originalMetric;
+        fake.deploymentsClient.deployments.beginCreateOrUpdate = originalBeginCreateOrUpdate;
+      }
+    });
+
     test('ARM deployment is cleaned up after successful provisioning', async () => {
       await provisionWorkerPool({
         armDeployment: {
@@ -2485,75 +2551,117 @@ helper.secrets.mockSuite(testing.suiteName(), [], (mock, skipping) => {
 
     test('reports worker-pool error when ARM deployment fails', async () => {
       const reportErrorStub = sandbox.stub(provider, 'reportError').resolves();
+      const recordedMetrics = [];
+      const originalMetric = provider.monitor._metric.azureArmDeploymentError;
+      provider.monitor._metric.azureArmDeploymentError = (value, labels) => {
+        recordedMetrics.push({ value, labels });
+      };
       const existingWorkerPool = await WorkerPool.get(helper.db, workerPoolId);
       if (!existingWorkerPool) {
         await makeWorkerPool();
       }
 
-      const deploymentName = 'deploy-failure';
-      await worker.update(helper.db, worker => {
-        worker.providerData = {
-          ...worker.providerData,
-          deploymentMethod: 'arm-template',
-          deployment: {
-            name: deploymentName,
-            operation: 'op/deployment',
-            id: false,
-          },
-          provisioningComplete: false,
-        };
-      });
-
-      await fake.deploymentsClient.deployments.beginCreateOrUpdate('rgrp', deploymentName, {
-        parameters: {
-          vmName: { value: worker.providerData.vm.name },
-        },
-      });
-      fake.deploymentsClient.deployments.setFakeDeploymentState(
-        'rgrp',
-        deploymentName,
-        'Failed',
-        'Ephemeral OS disk is not supported for VM size Standard_D32ads_v6.',
-      );
-
-      const operation = {
-        id: '/fake-operation/1',
-        properties: {
-          provisioningState: 'Failed',
-          provisioningOperation: 'Create',
-          statusCode: 'Conflict',
-          statusMessage: {
-            status: 'Failed',
-            error: {
-              code: 'NotSupported',
-              message: 'Ephemeral OS disk is not supported for VM size Standard_D32ads_v6.',
+      try {
+        const deploymentName = 'deploy-failure';
+        await worker.update(helper.db, worker => {
+          worker.providerData = {
+            ...worker.providerData,
+            deploymentMethod: 'arm-template',
+            armDeployment: {
+              parameters: {
+                vmSize: { value: 'Standard_D32ads_v6' },
+                priority: { value: 'Spot' },
+                imageId: {
+                  value: '/subscriptions/fake-sub/resourceGroups/images/providers/Microsoft.Compute/galleries/images/versions/1.2.3',
+                },
+              },
             },
+            deployment: {
+              name: deploymentName,
+              operation: 'op/deployment',
+              id: false,
+            },
+            provisioningComplete: false,
+          };
+        });
+
+        await fake.deploymentsClient.deployments.beginCreateOrUpdate('rgrp', deploymentName, {
+          parameters: {
+            vmName: { value: worker.providerData.vm.name },
+          },
+        });
+        fake.deploymentsClient.deployments.setFakeDeploymentState(
+          'rgrp',
+          deploymentName,
+          'Failed',
+          'At least one resource deployment operation failed.',
+        );
+
+        const operation = {
+          id: '/fake-operation/1',
+          properties: {
+            provisioningState: 'Failed',
+            provisioningOperation: 'Create',
+            statusCode: 'Conflict',
+            statusMessage: {
+              status: 'Failed',
+              error: {
+                code: 'DeploymentFailed',
+                message: 'At least one resource deployment operation failed.',
+                details: [{
+                  code: 'NotSupported',
+                  message: 'Ephemeral OS disk is not supported for VM size Standard_D32ads_v6.',
+                }, {
+                  code: 'AnotherNestedError',
+                  message: 'Second nested detail should not create another metric sample.',
+                }],
+              },
+            },
+            targetResource: {
+              id: `/subscriptions/fake-sub/resourceGroups/rgrp/providers/Microsoft.Compute/virtualMachines/${worker.providerData.vm.name}`,
+              resourceType: 'Microsoft.Compute/virtualMachines',
+              resourceName: worker.providerData.vm.name,
+            },
+            timestamp: '2025-11-12T18:25:38.128Z',
             trackingId: 'tracking-id',
           },
-          targetResource: {
-            id: `/subscriptions/fake-sub/resourceGroups/rgrp/providers/Microsoft.Compute/virtualMachines/${worker.providerData.vm.name}`,
-            resourceType: 'Microsoft.Compute/virtualMachines',
-            resourceName: worker.providerData.vm.name,
+        };
+        fake.deploymentsClient.deploymentOperations.setFakeDeploymentOperations('rgrp', deploymentName, [operation]);
+
+        await setState({ state: 'requested' });
+
+        await provider.checkWorker({ worker });
+
+        sandbox.assert.calledOnce(reportErrorStub);
+        const reportedError = reportErrorStub.firstCall.args[0];
+        assert.equal(reportedError.kind, 'arm-deployment-error');
+        assert.equal(reportedError.title, 'ARM Deployment Error');
+        assert(reportedError.description.includes('At least one resource deployment operation failed'));
+        assert.equal(reportedError.workerPool.workerPoolId, workerPoolId);
+        assert.equal(reportedError.extra.operations.length, 1);
+        assert.equal(reportedError.extra.operations[0].statusMessage.error.code, 'DeploymentFailed');
+        assert.equal(reportedError.extra.operations[0].statusMessage.error.details[0].code, 'NotSupported');
+        assert.equal(reportedError.extra.operations[0].statusMessage.error.details[1].code, 'AnotherNestedError');
+        assert.equal(reportedError.extra.operations[0].targetResource.resourceType, 'Microsoft.Compute/virtualMachines');
+        assert.deepEqual(recordedMetrics, [{
+          value: 1,
+          labels: {
+            providerId,
+            workerPoolId,
+            workerGroup: 'westus',
+            errorKind: 'arm-deployment-error',
+            errorCode: 'NotSupported',
+            statusCode: 'Conflict',
+            provisioningState: 'Failed',
+            provisioningOperation: 'Create',
+            targetResourceType: 'Microsoft.Compute/virtualMachines',
+            vmSize: 'Standard_D32ads_v6',
+            priority: 'Spot',
           },
-          timestamp: '2025-11-12T18:25:38.128Z',
-          trackingId: 'tracking-id',
-        },
-      };
-      fake.deploymentsClient.deploymentOperations.setFakeDeploymentOperations('rgrp', deploymentName, [operation]);
-
-      await setState({ state: 'requested' });
-
-      await provider.checkWorker({ worker });
-
-      sandbox.assert.calledOnce(reportErrorStub);
-      const reportedError = reportErrorStub.firstCall.args[0];
-      assert.equal(reportedError.kind, 'arm-deployment-error');
-      assert.equal(reportedError.title, 'ARM Deployment Error');
-      assert(reportedError.description.includes('Ephemeral OS disk is not supported'));
-      assert.equal(reportedError.workerPool.workerPoolId, workerPoolId);
-      assert.equal(reportedError.extra.operations.length, 1);
-      assert.equal(reportedError.extra.operations[0].statusMessage.error.code, 'NotSupported');
-      assert.equal(reportedError.extra.operations[0].targetResource.resourceType, 'Microsoft.Compute/virtualMachines');
+        }]);
+      } finally {
+        provider.monitor._metric.azureArmDeploymentError = originalMetric;
+      }
     });
   });
 


### PR DESCRIPTION
Exposes a new worker-manager Azure Prometheus counter for ARM deployment creation failures and failed deployment operations.

The new `worker_manager_azure_arm_deployment_errors_total` metric increments once for each failed ARM deployment creation or failed deployment operation. It includes labels for `providerId`, `workerPoolId`, `workerGroup`, Azure error code/state details, target resource type, VM size, and priority so deployers can chart which pools, regions, VM sizes, and Azure error codes are producing ARM deployment failures in Yardstick/Grafana.

Follows the Azure observability shape from #8504.

## Testing

- [x] `git diff --check`
- [x] `NODE24_BIN_DIR=$(dirname "$(npx -y -p node@24.16.0 which node)") && PATH="$NODE24_BIN_DIR:$PATH" TEST_DB_URL=postgresql://postgres@localhost:5432/taskcluster-test yarn generate`
- [x] `NODE24_BIN_DIR=$(dirname "$(npx -y -p node@24.16.0 which node)") && PATH="$NODE24_BIN_DIR:$PATH" yarn workspace @taskcluster/worker-manager exec eslint src/providers/azure/index.js src/monitor.js test/provider_azure_test.js`
- [x] `NODE24_BIN_DIR=$(dirname "$(npx -y -p node@24.16.0 which node)") && PATH="$NODE24_BIN_DIR:$PATH" TEST_DB_URL=postgresql://postgres@localhost:5432/taskcluster-test yarn workspace @taskcluster/worker-manager exec mocha test/provider_azure_test.js --grep "records metric when ARM deployment creation fails|reports worker-pool error when ARM deployment fails"` - 2 passing
- [x] `NODE24_BIN_DIR=$(dirname "$(npx -y -p node@24.16.0 which node)") && PATH="$NODE24_BIN_DIR:$PATH" TEST_DB_URL=postgresql://postgres@localhost:5432/taskcluster-test yarn workspace @taskcluster/worker-manager exec mocha test/provider_azure_test.js` - 148 passing