### PR TITLE
feat(dev): Upgrade local nginx version

### DIFF
--- a/changelog/cve-2026-42945.md
+++ b/changelog/cve-2026-42945.md
@@ -1,0 +1,4 @@
+audience: developers
+level: patch
+---
+Bump local-dev nginx image from 1.29.4 to 1.30.1 (CVE-2026-42945).

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -119,7 +119,7 @@ services:
     ports:
       - '3023:8080'
   taskcluster:
-    image: nginx:1.29.4
+    image: nginx:1.30.1
     networks:
       - local
     depends_on:

--- a/infrastructure/tooling/src/generate/generators/docker-compose.js
+++ b/infrastructure/tooling/src/generate/generators/docker-compose.js
@@ -373,7 +373,7 @@ tasks.push({
           },
         }),
         taskcluster: serviceDefinition('taskcluster', {
-          image: 'nginx:1.29.4',
+          image: 'nginx:1.30.1',
           depends_on: ['ui', 'web-server-web'],
           volumes: [
             './docker/nginx.conf:/etc/nginx/nginx.conf',


### PR DESCRIPTION
Even though we are not affected by the NGINX Rift vulnerability, we still can patch it to avoid future abuse.
Attack needs set+rewrite used in combination with `?` which we don't

