### PR TITLE
Fix `on-defined` routes not firing notifications

### DIFF
--- a/changelog/issue-8689.md
+++ b/changelog/issue-8689.md
@@ -1,0 +1,5 @@
+audience: users
+level: patch
+reference: issue 8689
+---
+Fixed `on-defined` route notifications not firing

--- a/services/notify/src/handler.js
+++ b/services/notify/src/handler.js
@@ -78,6 +78,10 @@ class Handler {
       return true;
     }
 
+    if (decider === 'defined') {
+      return state === 'unscheduled';
+    }
+
     return decider === state;
   }
 

--- a/services/notify/test/handler_test.js
+++ b/services/notify/test/handler_test.js
@@ -67,6 +67,12 @@ helper.secrets.mockSuite(testing.suiteName(), ['aws'], function(mock, skipping) 
     ],
   };
 
+  const definedStatus = {
+    ..._.cloneDeep(baseStatus),
+    state: 'unscheduled',
+    runs: [],
+  };
+
   let monitor;
   suiteSetup('create handler', async function() {
     if (skipping()) {
@@ -106,6 +112,20 @@ helper.secrets.mockSuite(testing.suiteName(), ['aws'], function(mock, skipping) 
     await helper.fakePulseMessage({
       payload: {
         status: baseStatus,
+      },
+      exchange: 'exchange/taskcluster-queue/v1/task-defined',
+      routingKey: 'doesnt-matter',
+      routes: [route],
+    });
+    helper.assertPulseMessage('notification', m => m.CCs[0] === 'route.notify-test');
+  });
+
+  test('pulse on-defined', async () => {
+    const route = 'test-notify.pulse.notify-test.on-defined';
+    helper.queue.addTask(definedStatus.taskId, makeTask([route]));
+    await helper.fakePulseMessage({
+      payload: {
+        status: definedStatus,
       },
       exchange: 'exchange/taskcluster-queue/v1/task-defined',
       routingKey: 'doesnt-matter',


### PR DESCRIPTION
Routes like `notify.pulse.foo.on-defined` are supposed to send a message on the `foo` routing key of the notify service pulse exchange when the task gets defined but it was never wired up correctly.

aa326d8218b0477d061d838fe608acc7a8dad973 added the possibility to add `on-defined` but never tested it and missed that a task that got created would have `unscheduled` as its state and not `defined`.

I fixed the problem by matching `defined` as decider to the `unscheduled` state of task. If a task switched to the `unscheduled` state then it just got created.

Fixes #8689
