### PR TITLE
Fix changelog filters being cleared from the URL on page load

### DIFF
--- a/changelog/issue-8688.md
+++ b/changelog/issue-8688.md
@@ -1,0 +1,5 @@
+audience: users
+level: patch
+reference: issue 8688
+---
+Fix the changelog page so it doesn't ignore URL parameters anymore

--- a/ui/src/views/Documentation/Changelog/index.jsx
+++ b/ui/src/views/Documentation/Changelog/index.jsx
@@ -44,7 +44,7 @@ const parseMarkdownIntoSections = markdown => {
         content = [];
       }
 
-      audience = line.slice(4);
+      audience = titleCase(line.slice(4).toLowerCase());
     } else {
       content.push(line);
     }
@@ -78,10 +78,6 @@ const FILTERS = ['version', 'from', 'to', 'q', 'all', 'audience'];
   },
   chip: {
     marginLeft: theme.spacing(2),
-    textTransform: 'lowercase',
-    'span::first-letter': {
-      textTransform: 'uppercase',
-    },
   },
   section: {
     '&.MuiGrid-item': {
@@ -105,13 +101,10 @@ export default class Changelog extends Component {
     super(props);
 
     this.sections = parseMarkdownIntoSections(ChangelogMd);
-    this.versions = [
-      ...new Set([...this.sections.map(section => section.version)]),
-    ].map(version => ({ label: version, value: version }));
-
+    this.versions = [...new Set(this.sections.map(section => section.version))];
     this.audiences = [
-      ...new Set([...this.sections.map(section => section.audience)]),
-    ].map(audience => ({ label: titleCase(audience), value: audience }));
+      ...new Set(this.sections.map(section => section.audience)),
+    ].filter(Boolean);
 
     const search = new URLSearchParams(this.props.location.search);
 
@@ -128,7 +121,10 @@ export default class Changelog extends Component {
   filteredSections = memoize(
     ({ version, from, to, q, all, audience }) => {
       return this.sections.filter(section => {
-        if (audience && section.audience !== audience) {
+        if (
+          audience &&
+          section.audience.toLowerCase() !== audience.toLowerCase()
+        ) {
           return false;
         }
 
@@ -196,7 +192,7 @@ export default class Changelog extends Component {
     const maybeHighlight = (text, q) =>
       q ? text.replace(new RegExp(`(${q})(?![^<>]*>)`, 'gi'), '**$1**') : text;
     const onToggleFilter = (key, value) => {
-      if (this.state[key] === value) {
+      if (this.state[key].toLowerCase() === value.toLowerCase()) {
         this.setState({ [key]: '' });
       } else {
         this.setState({ [key]: value });
@@ -209,9 +205,12 @@ export default class Changelog extends Component {
           <Grid item xs={4} key={key}>
             <Autocomplete
               options={this.versions}
-              getOptionLabel={option => option.label}
               freeSolo
+              value={this.state[key] || null}
               inputValue={this.state[key]}
+              onChange={(_event, value) =>
+                this.setState({ [key]: value || '' })
+              }
               onInputChange={(_event, value) => this.setState({ [key]: value })}
               renderInput={params => (
                 <TextField {...params} label={label} fullWidth />
@@ -230,9 +229,12 @@ export default class Changelog extends Component {
         <Grid item xs={4}>
           <Autocomplete
             options={this.audiences}
-            getOptionLabel={option => option.label}
             freeSolo
+            value={this.state.audience || null}
             inputValue={this.state.audience}
+            onChange={(_event, value) =>
+              this.setState({ audience: value || '' })
+            }
             onInputChange={(_event, value) =>
               this.setState({ audience: value })
             }


### PR DESCRIPTION
In e8a5685be60b5d982b763ce7c88c77a2bceced62, I switched the changelog `Autocomplete` filters to a controlled `inputValue` + `freeSolo` so that clicking a version header or audience chip would be reflected in the fields. But what I missed is that because `value` was left uncontrolled, MUI's `resetInputValue` effect on mount saw a null `value`, computed an empty input, found it differed from the controlled one, and fired `onInputChange(null, '', 'reset')`. That cleared the filter state and stripped the query string, so links such as
`/docs/changelog?version=v100.1.0` immediately redirected back to an unfiltered view.

We could've fixed it by ignoring those `reset` in `onInputChange` but that felt hacky to me so instead I chose to spend a bit more time and fix the inputs control properly. While doing so I found two more issues that predated e8a5685be60b5d982b763ce7c88c77a2bceced62 which I also missed in that commit. The audience section names were all caps (except for the automated package updates), and there was an empty value in the dropdown (regression from 2d63c1177311acf77c2687cd98292baa12ae82b6 which allowed empty audience in changelogs).

Onto the fixes:

- Filters are now fully controlled with plain strings. The options are now simple string arrays (the `{label, value}` wrapper was useless, labels always equalled values). Both `value` and `inputValue` are driven from the same state. That fixes the fields being empty on mount.

- Audience values are now lowercased before title casing at parse time, so all caps headers like ADMINS now render as "Admins" everywhere (apparently the `title-case` package leaves all caps sentences untouched). This also lets us drop the `.chip` CSS that was trying to do the same but was mangling audiences like "Automated Package Updates". Note that this would've broken URLs so I changed audience comparison to be case insensitive to keep existing links working (not that I'm expecting many of those in the wild, but you never know)

- Filter empty audience values. That does mean that we don't have a filter for those, but the previous one wasn't working either and was just adding an empty line in the changelog dropdown... Since no audience changelogs are used for silent entries anyway, I'm not going to lose time or sleep over that

Fixes #8688 