### PR TITLE
Bug 2042324 - Bind TC credential issuance through oauth to the access token's lifetime

### DIFF
--- a/changelog/bug-2042324-part-3.md
+++ b/changelog/bug-2042324-part-3.md
@@ -1,0 +1,5 @@
+audience: users
+level: patch
+reference: bug 2042324
+---
+Enforce oauth2 access token lifetimes when issuing Taskcluster credentials

--- a/services/web-server/src/servers/oauth2.js
+++ b/services/web-server/src/servers/oauth2.js
@@ -326,8 +326,10 @@ export default (cfg, db, strategies, auth, monitor) => {
     }
 
     // Although we eventually delete expired rows, that only happens once per day
-    // so we need to check that the accessToken is not expired.
-    if (new Date(entry.client_details.expires) < new Date()) {
+    // so we need to check that the access token is not past its own lifetime, as
+    // well as that the requested credentials have not already expired.
+    const now = new Date();
+    if (new Date(entry.expires) < now || new Date(entry.client_details.expires) < now) {
       throw inputError;
     }
 

--- a/services/web-server/test/third_party_test.js
+++ b/services/web-server/test/third_party_test.js
@@ -7,6 +7,7 @@ import request from 'superagent';
 import moment from 'moment';
 import helper from './helper.js';
 import tryCatch from '../src/utils/tryCatch.js';
+import hash from '../src/utils/hash.js';
 
 helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
   helper.withDb(mock, skipping);
@@ -492,6 +493,53 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       const [error] = await tryCatch(agent.get(url('/login/oauth/credentials'))
         .set('authorization', `${query.get('token_type')} ${query.get('access_token')}`));
 
+      assert.equal(error.response.body.name, 'InputError');
+      assert.equal(error.response.body.message, 'Could not generate credentials for this access token');
+
+      await helper.expectMonitorError('InputError');
+    });
+    test('InputError when the access token is past its own 10 minute lifetime', async function() {
+      const agent = await helper.signedInAgent();
+      const registeredClientId = 'test-token';
+
+      let res = await agent.get(url('/login/oauth/authorize' +
+        '?response_type=token' +
+        `&client_id=${registeredClientId}` +
+        '&redirect_uri=' + encodeURIComponent('https://test.example.com/cb') +
+        '&scope=tags:get:*' +
+        '&state=abc123' +
+        '&expires=3+days'))
+        .redirects(0)
+        .ok(res => res.status === 302);
+
+      let query = getQuery(res.header.location);
+      const scope = query.get('scope');
+
+      const expiry = moment(new Date()).startOf('day').add(3, 'days').format('YYYY/MM/DD');
+
+      res = await agent.post(url('/login/oauth/authorize/decision'))
+        .send(`clientId=${query.get('clientId')}`)
+        .send(`transaction_id=${query.get('transactionID')}`)
+        .send(`scope=${scope}`)
+        .send(`description='test'`)
+        .send(`expires=${expiry}`)
+        .redirects(0)
+        .ok(res => res.status === 302);
+
+      query = getQuery(res.header.location, '#');
+      const accessToken = query.get('access_token');
+
+      await helper.withDbClient(async client => {
+        await client.query(
+          `update access_tokens set expires = now() - interval '1 minute' where hashed_access_token = $1`,
+          [hash(accessToken)],
+        );
+      });
+
+      const [error] = await tryCatch(agent.get(url('/login/oauth/credentials'))
+        .set('authorization', `${query.get('token_type')} ${accessToken}`));
+
+      assert(error, 'expected an expired access token to be rejected');
       assert.equal(error.response.body.name, 'InputError');
       assert.equal(error.response.body.message, 'Could not generate credentials for this access token');
 


### PR DESCRIPTION
Taskcluster was happily issuing credentials for an expired access token if the requested credentials wouldn't have expired yet and the daily cronjob hadn't cleaned it. This is the same class of bug as what 5e609add5151e231d42024102a6707b10c917c72 fixed (I even looked at this condition there and missed that it was incomplete), we were checking against the resulting credentials lifetime instead of the access token that was passed to us. In this case though we check against both, we don't want to give credentials that have expired already (makes no sense).

Note that the diff looks weird for the test because git tries to be smart, I didn't touch the test above the new one.