### PR TITLE
Bump playwright to 1.60.0

### DIFF
--- a/changelog/YS1ItUDCRDq2EqMC75N-NA.md
+++ b/changelog/YS1ItUDCRDq2EqMC75N-NA.md
@@ -1,0 +1,2 @@
+level: silent
+---

--- a/taskcluster/docker/browser-test/Dockerfile
+++ b/taskcluster/docker/browser-test/Dockerfile
@@ -6,7 +6,7 @@ VOLUME /builds/worker/checkouts
 # re-download it (~200MB) every time. Must match the playwright version
 # in ui/package.json.
 ENV PLAYWRIGHT_BROWSERS_PATH=/ms-playwright
-ENV PLAYWRIGHT_VERSION=1.59.1
+ENV PLAYWRIGHT_VERSION=1.60.0
 
 # Add worker user
 RUN mkdir -p /builds && \

--- a/ui/package.json
+++ b/ui/package.json
@@ -113,7 +113,7 @@
     "@babel/register": "^7.24.6",
     "@biomejs/biome": "^2.4.15",
     "@date-io/date-fns": "1.3.13",
-    "@playwright/test": "1.59.1",
+    "@playwright/test": "1.60.0",
     "@testing-library/react": "^12.1.3",
     "apollo-client-mock": "^0.0.9",
     "babel-jest": "26.6.3",

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -2444,14 +2444,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@playwright/test@npm:1.59.1":
-  version: 1.59.1
-  resolution: "@playwright/test@npm:1.59.1"
+"@playwright/test@npm:1.60.0":
+  version: 1.60.0
+  resolution: "@playwright/test@npm:1.60.0"
   dependencies:
-    playwright: "npm:1.59.1"
+    playwright: "npm:1.60.0"
   bin:
     playwright: cli.js
-  checksum: 10c0/8c2d94a860d3c254a0b114df2f888ad0a0e9310f45b6059bd5d4da196d965cadf6922267cef0881cfa9784d4bef6d78363d2c2d94caa64be67ff644c41162137
+  checksum: 10c0/86b06e6437933e741c7cd43f362024e857e7bc28a55fcbb0553ef55e01a2a403c64f4786868de8af86a6e303fe99e98a18a42ba19489f43ae122e457f9e2d189
   languageName: node
   linkType: hard
 
@@ -2565,7 +2565,7 @@ __metadata:
     "@material-ui/pickers": "npm:3.3.11"
     "@mdx-js/react": "npm:^1.0.20"
     "@mdx-js/runtime": "npm:^1.0.20"
-    "@playwright/test": "npm:1.59.1"
+    "@playwright/test": "npm:1.60.0"
     "@sentry/browser": "npm:^10.47.0"
     "@taskcluster/client-web": "npm:^88.0.1"
     "@testing-library/react": "npm:^12.1.3"
@@ -11142,27 +11142,27 @@ __metadata:
   languageName: node
   linkType: hard
 
-"playwright-core@npm:1.59.1":
-  version: 1.59.1
-  resolution: "playwright-core@npm:1.59.1"
+"playwright-core@npm:1.60.0":
+  version: 1.60.0
+  resolution: "playwright-core@npm:1.60.0"
   bin:
     playwright-core: cli.js
-  checksum: 10c0/d41a74d9681ce3beb3d5239e9ed577710b4ad099a6ca2476219c6599d51e9cb4b80bd72ed82c528da6a5d929c18ae3b872cf02bb83f78fa1c2cb9199c501abee
+  checksum: 10c0/99ccd43923b6e9355e0723b7fe221e6326efd4687f8dafff951313662aea11db51f542a9c2122c704c445fb9baae1c9ec9fa6f895126bbddd9fe92313f6942c9
   languageName: node
   linkType: hard
 
-"playwright@npm:1.59.1":
-  version: 1.59.1
-  resolution: "playwright@npm:1.59.1"
+"playwright@npm:1.60.0":
+  version: 1.60.0
+  resolution: "playwright@npm:1.60.0"
   dependencies:
     fsevents: "npm:2.3.2"
-    playwright-core: "npm:1.59.1"
+    playwright-core: "npm:1.60.0"
   dependenciesMeta:
     fsevents:
       optional: true
   bin:
     playwright: cli.js
-  checksum: 10c0/dfe38396e616e5c4f98825ce90037bb96e477c5a2bd9258a24854f8ce72a8a41427b19098863866f85aa0216e70287dd537c4438d761aca93995e31ae099c533
+  checksum: 10c0/714ad76d85b4865d7e43c0012f9039800c1485373388973ed39d79339cee5ad467052d1e2f1eaeca107a1cb6e65342186a8578a4c3504853d84c3a691250d5db
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This version fixes a bug with more recent versions of nodejs where the browser download could end up hanging at 100%. See https://github.com/microsoft/playwright/pull/40747 and linked issues there for some details.
