### PR TITLE
generic-worker: skip gzip compression for artifacts in `.aab`, `.apk`…

### DIFF
--- a/changelog/bug-2045069.md
+++ b/changelog/bug-2045069.md
@@ -1,0 +1,5 @@
+audience: users
+level: minor
+reference: bug 2045069
+---
+Generic-worker: skip gzip compression for artifacts with extensions matching `.aab`, `.apk`, `.jar`, `.xpi`.

--- a/generated/references.json
+++ b/generated/references.json
@@ -10757,7 +10757,7 @@
             "additionalProperties": false,
             "properties": {
               "contentEncoding": {
-                "description": "Content-Encoding for the artifact. If not provided, `gzip` will be used, except for the\nfollowing file extensions, where `identity` will be used, since they are already\ncompressed:\n\n* 7z\n* bz2\n* deb\n* dmg\n* flv\n* gif\n* gz\n* jpeg\n* jpg\n* npz\n* png\n* swf\n* tbz\n* tgz\n* webp\n* whl\n* woff\n* woff2\n* xz\n* zip\n* zst\n\nNote, setting `contentEncoding` on a directory artifact will apply the same content\nencoding to all the files contained in the directory.\n\nSince: generic-worker 16.2.0",
+                "description": "Content-Encoding for the artifact. If not provided, `gzip` will be used, except for the\nfollowing file extensions, where `identity` will be used, since they are already\ncompressed:\n\n* 7z\n* aab\n* apk\n* bz2\n* deb\n* dmg\n* flv\n* gif\n* gz\n* jar\n* jpeg\n* jpg\n* npz\n* png\n* swf\n* tbz\n* tgz\n* webp\n* whl\n* woff\n* woff2\n* xpi\n* xz\n* zip\n* zst\n\nNote, setting `contentEncoding` on a directory artifact will apply the same content\nencoding to all the files contained in the directory.\n\nSince: generic-worker 16.2.0",
                 "enum": [
                   "identity",
                   "gzip"
@@ -11302,7 +11302,7 @@
                 "additionalProperties": false,
                 "properties": {
                   "contentEncoding": {
-                    "description": "Content-Encoding for the artifact. If not provided, `gzip` will be used, except for the\nfollowing file extensions, where `identity` will be used, since they are already\ncompressed:\n\n* 7z\n* bz2\n* deb\n* dmg\n* flv\n* gif\n* gz\n* jpeg\n* jpg\n* npz\n* png\n* swf\n* tbz\n* tgz\n* webp\n* whl\n* woff\n* woff2\n* xz\n* zip\n* zst\n\nNote, setting `contentEncoding` on a directory artifact will apply the same content\nencoding to all the files contained in the directory.\n\nSince: generic-worker 16.2.0",
+                    "description": "Content-Encoding for the artifact. If not provided, `gzip` will be used, except for the\nfollowing file extensions, where `identity` will be used, since they are already\ncompressed:\n\n* 7z\n* aab\n* apk\n* bz2\n* deb\n* dmg\n* flv\n* gif\n* gz\n* jar\n* jpeg\n* jpg\n* npz\n* png\n* swf\n* tbz\n* tgz\n* webp\n* whl\n* woff\n* woff2\n* xpi\n* xz\n* zip\n* zst\n\nNote, setting `contentEncoding` on a directory artifact will apply the same content\nencoding to all the files contained in the directory.\n\nSince: generic-worker 16.2.0",
                     "enum": [
                       "identity",
                       "gzip"
@@ -12123,7 +12123,7 @@
                 "additionalProperties": false,
                 "properties": {
                   "contentEncoding": {
-                    "description": "Content-Encoding for the artifact. If not provided, `gzip` will be used, except for the\nfollowing file extensions, where `identity` will be used, since they are already\ncompressed:\n\n* 7z\n* bz2\n* deb\n* dmg\n* flv\n* gif\n* gz\n* jpeg\n* jpg\n* npz\n* png\n* swf\n* tbz\n* tgz\n* webp\n* whl\n* woff\n* woff2\n* xz\n* zip\n* zst\n\nNote, setting `contentEncoding` on a directory artifact will apply the same content\nencoding to all the files contained in the directory.\n\nSince: generic-worker 16.2.0",
+                    "description": "Content-Encoding for the artifact. If not provided, `gzip` will be used, except for the\nfollowing file extensions, where `identity` will be used, since they are already\ncompressed:\n\n* 7z\n* aab\n* apk\n* bz2\n* deb\n* dmg\n* flv\n* gif\n* gz\n* jar\n* jpeg\n* jpg\n* npz\n* png\n* swf\n* tbz\n* tgz\n* webp\n* whl\n* woff\n* woff2\n* xpi\n* xz\n* zip\n* zst\n\nNote, setting `contentEncoding` on a directory artifact will apply the same content\nencoding to all the files contained in the directory.\n\nSince: generic-worker 16.2.0",
                     "enum": [
                       "identity",
                       "gzip"

--- a/tools/d2g/genericworker/generated_types.go
+++ b/tools/d2g/genericworker/generated_types.go
@@ -17,12 +17,15 @@ type (
 		// compressed:
 		//
 		// * 7z
+		// * aab
+		// * apk
 		// * bz2
 		// * deb
 		// * dmg
 		// * flv
 		// * gif
 		// * gz
+		// * jar
 		// * jpeg
 		// * jpg
 		// * npz
@@ -34,6 +37,7 @@ type (
 		// * whl
 		// * woff
 		// * woff2
+		// * xpi
 		// * xz
 		// * zip
 		// * zst
@@ -1138,7 +1142,7 @@ func JSONSchema() string {
             "additionalProperties": false,
             "properties": {
               "contentEncoding": {
-                "description": "Content-Encoding for the artifact. If not provided, ` + "`" + `gzip` + "`" + ` will be used, except for the\nfollowing file extensions, where ` + "`" + `identity` + "`" + ` will be used, since they are already\ncompressed:\n\n* 7z\n* bz2\n* deb\n* dmg\n* flv\n* gif\n* gz\n* jpeg\n* jpg\n* npz\n* png\n* swf\n* tbz\n* tgz\n* webp\n* whl\n* woff\n* woff2\n* xz\n* zip\n* zst\n\nNote, setting ` + "`" + `contentEncoding` + "`" + ` on a directory artifact will apply the same content\nencoding to all the files contained in the directory.\n\nSince: generic-worker 16.2.0",
+                "description": "Content-Encoding for the artifact. If not provided, ` + "`" + `gzip` + "`" + ` will be used, except for the\nfollowing file extensions, where ` + "`" + `identity` + "`" + ` will be used, since they are already\ncompressed:\n\n* 7z\n* aab\n* apk\n* bz2\n* deb\n* dmg\n* flv\n* gif\n* gz\n* jar\n* jpeg\n* jpg\n* npz\n* png\n* swf\n* tbz\n* tgz\n* webp\n* whl\n* woff\n* woff2\n* xpi\n* xz\n* zip\n* zst\n\nNote, setting ` + "`" + `contentEncoding` + "`" + ` on a directory artifact will apply the same content\nencoding to all the files contained in the directory.\n\nSince: generic-worker 16.2.0",
                 "enum": [
                   "identity",
                   "gzip"

--- a/workers/generic-worker/artifact_feature.go
+++ b/workers/generic-worker/artifact_feature.go
@@ -346,12 +346,15 @@ func resolve(base *artifacts.BaseArtifact, artifactType, path, contentType, cont
 		SkipCompressionExtensions := map[string]bool{
 			".7z":    true,
 			".br":    true,
+			".aab":   true,
+			".apk":   true,
 			".bz2":   true,
 			".deb":   true,
 			".dmg":   true,
 			".flv":   true,
 			".gif":   true,
 			".gz":    true,
+			".jar":   true,
 			".jpeg":  true,
 			".jpg":   true,
 			".lz":    true,
@@ -367,6 +370,7 @@ func resolve(base *artifacts.BaseArtifact, artifactType, path, contentType, cont
 			".whl":   true, // Python wheel are already zip file
 			".woff":  true,
 			".woff2": true,
+			".xpi":   true,
 			".xz":    true,
 			".zip":   true,
 			".zst":   true,

--- a/workers/generic-worker/generated_insecure_darwin.go
+++ b/workers/generic-worker/generated_insecure_darwin.go
@@ -19,12 +19,15 @@ type (
 		// compressed:
 		//
 		// * 7z
+		// * aab
+		// * apk
 		// * bz2
 		// * deb
 		// * dmg
 		// * flv
 		// * gif
 		// * gz
+		// * jar
 		// * jpeg
 		// * jpg
 		// * npz
@@ -36,6 +39,7 @@ type (
 		// * whl
 		// * woff
 		// * woff2
+		// * xpi
 		// * xz
 		// * zip
 		// * zst
@@ -1095,7 +1099,7 @@ func JSONSchema() string {
             "additionalProperties": false,
             "properties": {
               "contentEncoding": {
-                "description": "Content-Encoding for the artifact. If not provided, ` + "`" + `gzip` + "`" + ` will be used, except for the\nfollowing file extensions, where ` + "`" + `identity` + "`" + ` will be used, since they are already\ncompressed:\n\n* 7z\n* bz2\n* deb\n* dmg\n* flv\n* gif\n* gz\n* jpeg\n* jpg\n* npz\n* png\n* swf\n* tbz\n* tgz\n* webp\n* whl\n* woff\n* woff2\n* xz\n* zip\n* zst\n\nNote, setting ` + "`" + `contentEncoding` + "`" + ` on a directory artifact will apply the same content\nencoding to all the files contained in the directory.\n\nSince: generic-worker 16.2.0",
+                "description": "Content-Encoding for the artifact. If not provided, ` + "`" + `gzip` + "`" + ` will be used, except for the\nfollowing file extensions, where ` + "`" + `identity` + "`" + ` will be used, since they are already\ncompressed:\n\n* 7z\n* aab\n* apk\n* bz2\n* deb\n* dmg\n* flv\n* gif\n* gz\n* jar\n* jpeg\n* jpg\n* npz\n* png\n* swf\n* tbz\n* tgz\n* webp\n* whl\n* woff\n* woff2\n* xpi\n* xz\n* zip\n* zst\n\nNote, setting ` + "`" + `contentEncoding` + "`" + ` on a directory artifact will apply the same content\nencoding to all the files contained in the directory.\n\nSince: generic-worker 16.2.0",
                 "enum": [
                   "identity",
                   "gzip"

--- a/workers/generic-worker/generated_insecure_freebsd.go
+++ b/workers/generic-worker/generated_insecure_freebsd.go
@@ -19,12 +19,15 @@ type (
 		// compressed:
 		//
 		// * 7z
+		// * aab
+		// * apk
 		// * bz2
 		// * deb
 		// * dmg
 		// * flv
 		// * gif
 		// * gz
+		// * jar
 		// * jpeg
 		// * jpg
 		// * npz
@@ -36,6 +39,7 @@ type (
 		// * whl
 		// * woff
 		// * woff2
+		// * xpi
 		// * xz
 		// * zip
 		// * zst
@@ -1095,7 +1099,7 @@ func JSONSchema() string {
             "additionalProperties": false,
             "properties": {
               "contentEncoding": {
-                "description": "Content-Encoding for the artifact. If not provided, ` + "`" + `gzip` + "`" + ` will be used, except for the\nfollowing file extensions, where ` + "`" + `identity` + "`" + ` will be used, since they are already\ncompressed:\n\n* 7z\n* bz2\n* deb\n* dmg\n* flv\n* gif\n* gz\n* jpeg\n* jpg\n* npz\n* png\n* swf\n* tbz\n* tgz\n* webp\n* whl\n* woff\n* woff2\n* xz\n* zip\n* zst\n\nNote, setting ` + "`" + `contentEncoding` + "`" + ` on a directory artifact will apply the same content\nencoding to all the files contained in the directory.\n\nSince: generic-worker 16.2.0",
+                "description": "Content-Encoding for the artifact. If not provided, ` + "`" + `gzip` + "`" + ` will be used, except for the\nfollowing file extensions, where ` + "`" + `identity` + "`" + ` will be used, since they are already\ncompressed:\n\n* 7z\n* aab\n* apk\n* bz2\n* deb\n* dmg\n* flv\n* gif\n* gz\n* jar\n* jpeg\n* jpg\n* npz\n* png\n* swf\n* tbz\n* tgz\n* webp\n* whl\n* woff\n* woff2\n* xpi\n* xz\n* zip\n* zst\n\nNote, setting ` + "`" + `contentEncoding` + "`" + ` on a directory artifact will apply the same content\nencoding to all the files contained in the directory.\n\nSince: generic-worker 16.2.0",
                 "enum": [
                   "identity",
                   "gzip"

--- a/workers/generic-worker/generated_insecure_linux.go
+++ b/workers/generic-worker/generated_insecure_linux.go
@@ -19,12 +19,15 @@ type (
 		// compressed:
 		//
 		// * 7z
+		// * aab
+		// * apk
 		// * bz2
 		// * deb
 		// * dmg
 		// * flv
 		// * gif
 		// * gz
+		// * jar
 		// * jpeg
 		// * jpg
 		// * npz
@@ -36,6 +39,7 @@ type (
 		// * whl
 		// * woff
 		// * woff2
+		// * xpi
 		// * xz
 		// * zip
 		// * zst
@@ -1095,7 +1099,7 @@ func JSONSchema() string {
             "additionalProperties": false,
             "properties": {
               "contentEncoding": {
-                "description": "Content-Encoding for the artifact. If not provided, ` + "`" + `gzip` + "`" + ` will be used, except for the\nfollowing file extensions, where ` + "`" + `identity` + "`" + ` will be used, since they are already\ncompressed:\n\n* 7z\n* bz2\n* deb\n* dmg\n* flv\n* gif\n* gz\n* jpeg\n* jpg\n* npz\n* png\n* swf\n* tbz\n* tgz\n* webp\n* whl\n* woff\n* woff2\n* xz\n* zip\n* zst\n\nNote, setting ` + "`" + `contentEncoding` + "`" + ` on a directory artifact will apply the same content\nencoding to all the files contained in the directory.\n\nSince: generic-worker 16.2.0",
+                "description": "Content-Encoding for the artifact. If not provided, ` + "`" + `gzip` + "`" + ` will be used, except for the\nfollowing file extensions, where ` + "`" + `identity` + "`" + ` will be used, since they are already\ncompressed:\n\n* 7z\n* aab\n* apk\n* bz2\n* deb\n* dmg\n* flv\n* gif\n* gz\n* jar\n* jpeg\n* jpg\n* npz\n* png\n* swf\n* tbz\n* tgz\n* webp\n* whl\n* woff\n* woff2\n* xpi\n* xz\n* zip\n* zst\n\nNote, setting ` + "`" + `contentEncoding` + "`" + ` on a directory artifact will apply the same content\nencoding to all the files contained in the directory.\n\nSince: generic-worker 16.2.0",
                 "enum": [
                   "identity",
                   "gzip"

--- a/workers/generic-worker/generated_multiuser_darwin.go
+++ b/workers/generic-worker/generated_multiuser_darwin.go
@@ -19,12 +19,15 @@ type (
 		// compressed:
 		//
 		// * 7z
+		// * aab
+		// * apk
 		// * bz2
 		// * deb
 		// * dmg
 		// * flv
 		// * gif
 		// * gz
+		// * jar
 		// * jpeg
 		// * jpg
 		// * npz
@@ -36,6 +39,7 @@ type (
 		// * whl
 		// * woff
 		// * woff2
+		// * xpi
 		// * xz
 		// * zip
 		// * zst
@@ -1140,7 +1144,7 @@ func JSONSchema() string {
             "additionalProperties": false,
             "properties": {
               "contentEncoding": {
-                "description": "Content-Encoding for the artifact. If not provided, ` + "`" + `gzip` + "`" + ` will be used, except for the\nfollowing file extensions, where ` + "`" + `identity` + "`" + ` will be used, since they are already\ncompressed:\n\n* 7z\n* bz2\n* deb\n* dmg\n* flv\n* gif\n* gz\n* jpeg\n* jpg\n* npz\n* png\n* swf\n* tbz\n* tgz\n* webp\n* whl\n* woff\n* woff2\n* xz\n* zip\n* zst\n\nNote, setting ` + "`" + `contentEncoding` + "`" + ` on a directory artifact will apply the same content\nencoding to all the files contained in the directory.\n\nSince: generic-worker 16.2.0",
+                "description": "Content-Encoding for the artifact. If not provided, ` + "`" + `gzip` + "`" + ` will be used, except for the\nfollowing file extensions, where ` + "`" + `identity` + "`" + ` will be used, since they are already\ncompressed:\n\n* 7z\n* aab\n* apk\n* bz2\n* deb\n* dmg\n* flv\n* gif\n* gz\n* jar\n* jpeg\n* jpg\n* npz\n* png\n* swf\n* tbz\n* tgz\n* webp\n* whl\n* woff\n* woff2\n* xpi\n* xz\n* zip\n* zst\n\nNote, setting ` + "`" + `contentEncoding` + "`" + ` on a directory artifact will apply the same content\nencoding to all the files contained in the directory.\n\nSince: generic-worker 16.2.0",
                 "enum": [
                   "identity",
                   "gzip"

--- a/workers/generic-worker/generated_multiuser_freebsd.go
+++ b/workers/generic-worker/generated_multiuser_freebsd.go
@@ -19,12 +19,15 @@ type (
 		// compressed:
 		//
 		// * 7z
+		// * aab
+		// * apk
 		// * bz2
 		// * deb
 		// * dmg
 		// * flv
 		// * gif
 		// * gz
+		// * jar
 		// * jpeg
 		// * jpg
 		// * npz
@@ -36,6 +39,7 @@ type (
 		// * whl
 		// * woff
 		// * woff2
+		// * xpi
 		// * xz
 		// * zip
 		// * zst
@@ -1140,7 +1144,7 @@ func JSONSchema() string {
             "additionalProperties": false,
             "properties": {
               "contentEncoding": {
-                "description": "Content-Encoding for the artifact. If not provided, ` + "`" + `gzip` + "`" + ` will be used, except for the\nfollowing file extensions, where ` + "`" + `identity` + "`" + ` will be used, since they are already\ncompressed:\n\n* 7z\n* bz2\n* deb\n* dmg\n* flv\n* gif\n* gz\n* jpeg\n* jpg\n* npz\n* png\n* swf\n* tbz\n* tgz\n* webp\n* whl\n* woff\n* woff2\n* xz\n* zip\n* zst\n\nNote, setting ` + "`" + `contentEncoding` + "`" + ` on a directory artifact will apply the same content\nencoding to all the files contained in the directory.\n\nSince: generic-worker 16.2.0",
+                "description": "Content-Encoding for the artifact. If not provided, ` + "`" + `gzip` + "`" + ` will be used, except for the\nfollowing file extensions, where ` + "`" + `identity` + "`" + ` will be used, since they are already\ncompressed:\n\n* 7z\n* aab\n* apk\n* bz2\n* deb\n* dmg\n* flv\n* gif\n* gz\n* jar\n* jpeg\n* jpg\n* npz\n* png\n* swf\n* tbz\n* tgz\n* webp\n* whl\n* woff\n* woff2\n* xpi\n* xz\n* zip\n* zst\n\nNote, setting ` + "`" + `contentEncoding` + "`" + ` on a directory artifact will apply the same content\nencoding to all the files contained in the directory.\n\nSince: generic-worker 16.2.0",
                 "enum": [
                   "identity",
                   "gzip"

--- a/workers/generic-worker/generated_multiuser_linux.go
+++ b/workers/generic-worker/generated_multiuser_linux.go
@@ -19,12 +19,15 @@ type (
 		// compressed:
 		//
 		// * 7z
+		// * aab
+		// * apk
 		// * bz2
 		// * deb
 		// * dmg
 		// * flv
 		// * gif
 		// * gz
+		// * jar
 		// * jpeg
 		// * jpg
 		// * npz
@@ -36,6 +39,7 @@ type (
 		// * whl
 		// * woff
 		// * woff2
+		// * xpi
 		// * xz
 		// * zip
 		// * zst
@@ -1140,7 +1144,7 @@ func JSONSchema() string {
             "additionalProperties": false,
             "properties": {
               "contentEncoding": {
-                "description": "Content-Encoding for the artifact. If not provided, ` + "`" + `gzip` + "`" + ` will be used, except for the\nfollowing file extensions, where ` + "`" + `identity` + "`" + ` will be used, since they are already\ncompressed:\n\n* 7z\n* bz2\n* deb\n* dmg\n* flv\n* gif\n* gz\n* jpeg\n* jpg\n* npz\n* png\n* swf\n* tbz\n* tgz\n* webp\n* whl\n* woff\n* woff2\n* xz\n* zip\n* zst\n\nNote, setting ` + "`" + `contentEncoding` + "`" + ` on a directory artifact will apply the same content\nencoding to all the files contained in the directory.\n\nSince: generic-worker 16.2.0",
+                "description": "Content-Encoding for the artifact. If not provided, ` + "`" + `gzip` + "`" + ` will be used, except for the\nfollowing file extensions, where ` + "`" + `identity` + "`" + ` will be used, since they are already\ncompressed:\n\n* 7z\n* aab\n* apk\n* bz2\n* deb\n* dmg\n* flv\n* gif\n* gz\n* jar\n* jpeg\n* jpg\n* npz\n* png\n* swf\n* tbz\n* tgz\n* webp\n* whl\n* woff\n* woff2\n* xpi\n* xz\n* zip\n* zst\n\nNote, setting ` + "`" + `contentEncoding` + "`" + ` on a directory artifact will apply the same content\nencoding to all the files contained in the directory.\n\nSince: generic-worker 16.2.0",
                 "enum": [
                   "identity",
                   "gzip"

--- a/workers/generic-worker/generated_multiuser_windows.go
+++ b/workers/generic-worker/generated_multiuser_windows.go
@@ -18,12 +18,15 @@ type (
 		// compressed:
 		//
 		// * 7z
+		// * aab
+		// * apk
 		// * bz2
 		// * deb
 		// * dmg
 		// * flv
 		// * gif
 		// * gz
+		// * jar
 		// * jpeg
 		// * jpg
 		// * npz
@@ -35,6 +38,7 @@ type (
 		// * whl
 		// * woff
 		// * woff2
+		// * xpi
 		// * xz
 		// * zip
 		// * zst
@@ -911,7 +915,7 @@ func JSONSchema() string {
         "additionalProperties": false,
         "properties": {
           "contentEncoding": {
-            "description": "Content-Encoding for the artifact. If not provided, ` + "`" + `gzip` + "`" + ` will be used, except for the\nfollowing file extensions, where ` + "`" + `identity` + "`" + ` will be used, since they are already\ncompressed:\n\n* 7z\n* bz2\n* deb\n* dmg\n* flv\n* gif\n* gz\n* jpeg\n* jpg\n* npz\n* png\n* swf\n* tbz\n* tgz\n* webp\n* whl\n* woff\n* woff2\n* xz\n* zip\n* zst\n\nNote, setting ` + "`" + `contentEncoding` + "`" + ` on a directory artifact will apply the same content\nencoding to all the files contained in the directory.\n\nSince: generic-worker 16.2.0",
+            "description": "Content-Encoding for the artifact. If not provided, ` + "`" + `gzip` + "`" + ` will be used, except for the\nfollowing file extensions, where ` + "`" + `identity` + "`" + ` will be used, since they are already\ncompressed:\n\n* 7z\n* aab\n* apk\n* bz2\n* deb\n* dmg\n* flv\n* gif\n* gz\n* jar\n* jpeg\n* jpg\n* npz\n* png\n* swf\n* tbz\n* tgz\n* webp\n* whl\n* woff\n* woff2\n* xpi\n* xz\n* zip\n* zst\n\nNote, setting ` + "`" + `contentEncoding` + "`" + ` on a directory artifact will apply the same content\nencoding to all the files contained in the directory.\n\nSince: generic-worker 16.2.0",
             "enum": [
               "identity",
               "gzip"

--- a/workers/generic-worker/schemas/insecure_posix.yml
+++ b/workers/generic-worker/schemas/insecure_posix.yml
@@ -152,12 +152,15 @@ oneOf:
               compressed:
 
               * 7z
+              * aab
+              * apk
               * bz2
               * deb
               * dmg
               * flv
               * gif
               * gz
+              * jar
               * jpeg
               * jpg
               * npz
@@ -169,6 +172,7 @@ oneOf:
               * whl
               * woff
               * woff2
+              * xpi
               * xz
               * zip
               * zst

--- a/workers/generic-worker/schemas/multiuser_posix.yml
+++ b/workers/generic-worker/schemas/multiuser_posix.yml
@@ -164,12 +164,15 @@ oneOf:
               compressed:
 
               * 7z
+              * aab
+              * apk
               * bz2
               * deb
               * dmg
               * flv
               * gif
               * gz
+              * jar
               * jpeg
               * jpg
               * npz
@@ -181,6 +184,7 @@ oneOf:
               * whl
               * woff
               * woff2
+              * xpi
               * xz
               * zip
               * zst

--- a/workers/generic-worker/schemas/multiuser_windows.yml
+++ b/workers/generic-worker/schemas/multiuser_windows.yml
@@ -157,12 +157,15 @@ properties:
             compressed:
 
             * 7z
+            * aab
+            * apk
             * bz2
             * deb
             * dmg
             * flv
             * gif
             * gz
+            * jar
             * jpeg
             * jpg
             * npz
@@ -174,6 +177,7 @@ properties:
             * whl
             * woff
             * woff2
+            * xpi
             * xz
             * zip
             * zst


### PR DESCRIPTION
…, `.jar`, `.xpi`

Bugzilla Bug: [2045069](https://bugzilla.mozilla.org/show_bug.cgi?id=2045069)
