### PR TITLE
feat(ui,web): Remove sift dependency and simplify filtering

### DIFF
--- a/changelog/issue-8716.md
+++ b/changelog/issue-8716.md
@@ -1,0 +1,5 @@
+level: minor
+audience: deployers
+reference: issue 8716
+---
+Removed the `sift` dependency from the web-server. The GraphQL `filter: JSON` argument was only ever used for simple case-insensitive substring search, so it has been replaced with a typed `searchTerm: String` argument on the list queries that support search (clients, roles, secrets, worker pools, denylist addresses). Task-action filtering is now applied server-side, and the unused `filter` argument has been removed from the remaining GraphQL queries.

--- a/dev-docs/best-practices/microservices.md
+++ b/dev-docs/best-practices/microservices.md
@@ -196,7 +196,7 @@ the `extend type Query|Mutation|Subscription` blocks. Refer to the docs on
 +}
 +
  extend type Query {
-   listDenylistAddresses(filter: JSON, connection: PageConnection): NotificationAddressConnection
+   listDenylistAddresses(searchTerm: String, connection: PageConnection): NotificationAddressConnection
 +  # "!" means graphql will enforce that a widgetId is provided, otherwise it won't go through to the resolver.
 +  widgets(widgetId: ID!): Widget
  }
@@ -235,8 +235,8 @@ index 77a966ca4..87e05414e 100644
 +++ b/services/web-server/src/resolvers/Notify.js
 @@ -6,10 +6,17 @@ module.exports = {
    Query: {
-     listDenylistAddresses(parent, { connection, filter }, { loaders }) {
-       return loaders.listDenylistAddresses.load({ connection, filter });
+     listDenylistAddresses(parent, { connection, searchTerm }, { loaders }) {
+       return loaders.listDenylistAddresses.load({ connection, searchTerm });
      },
 +    widgets(parent, { widget }, { loaders }) {
 +      return loaders.widget.load(widget);
@@ -249,7 +249,7 @@ index 23655e845..8e0d4d69b 100644
 --- a/services/web-server/src/loaders/notify.js
 +++ b/services/web-server/src/loaders/notify.js
 @@ -16,8 +16,20 @@ module.exports = ({ notify }, isAuthed, rootUrl, monitor, strategies, req, cfg,
-       items: sift(filter, addresses),
+       items: addresses,
      };
    });
 +  const widget = new DataLoader(widgetIds =>

--- a/package.json
+++ b/package.json
@@ -120,7 +120,6 @@
     "request-ip": "^3.3.0",
     "rimraf": "^5.0.7",
     "sanitize-html": "^2.17.4",
-    "sift": "^17.1.3",
     "slugid": "^5.0.1",
     "subscriptions-transport-ws": "^0.11.0",
     "superagent": "^6.0.0",

--- a/services/web-server/src/graphql/Artifacts.graphql
+++ b/services/web-server/src/graphql/Artifacts.graphql
@@ -67,7 +67,7 @@ extend type Query {
   # It **may return less**, even if more artifacts are available.
   # It may also return a page connection even though there are no more results.
   # Use the connection limit to specify smaller page sizes.
-  artifacts(taskId: ID!, runId: Int!, connection: PageConnection, filter: JSON): ArtifactsConnection
+  artifacts(taskId: ID!, runId: Int!, connection: PageConnection): ArtifactsConnection
 
   # Returns a list of the artifacts and associated metadata for latest run of a task.
   # As a task run may have many artifacts, this may return cursors to page through artifacts.
@@ -76,7 +76,7 @@ extend type Query {
   # It **may return less**, even if more artifacts are available.
   # It may also return a page connection even though there are no more results.
   # Use the connection limit to specify smaller page sizes.
-  latestArtifacts(taskId: ID!, connection: PageConnection, filter: JSON): ArtifactsConnection
+  latestArtifacts(taskId: ID!, connection: PageConnection): ArtifactsConnection
 }
 
 extend type Subscription {

--- a/services/web-server/src/graphql/CachePurges.graphql
+++ b/services/web-server/src/graphql/CachePurges.graphql
@@ -36,7 +36,7 @@ extend type Query {
   # Query the list of open purge requests. It should not be used by workers.
   # Workers should use the `purgeRequests` endpoint that is specific to their
   # `workerType` and `provisionerId`.
-  cachePurges(filter: JSON, connection: PageConnection): CachePurgesConnection
+  cachePurges(connection: PageConnection): CachePurgesConnection
 }
 
 extend type Mutation {

--- a/services/web-server/src/graphql/Clients.graphql
+++ b/services/web-server/src/graphql/Clients.graphql
@@ -56,7 +56,7 @@ input ClientsOptions {
 }
 
 extend type Query {
-  clients(clientOptions: ClientsOptions, connection: PageConnection, filter: JSON): ClientsConnection
+  clients(clientOptions: ClientsOptions, connection: PageConnection, searchTerm: String): ClientsConnection
   client(clientId: ID!): Client
 }
 

--- a/services/web-server/src/graphql/Hooks.graphql
+++ b/services/web-server/src/graphql/Hooks.graphql
@@ -128,11 +128,11 @@ type HookLastFireEdge implements Edge {
 }
 
 extend type Query {
-  hookGroups(filter: JSON): [HookGroup]
-  hooks(hookGroupId: ID!, filter: JSON): [Hook]
+  hookGroups(hookGroupId: ID): [HookGroup]
+  hooks(hookGroupId: ID!): [Hook]
   hook(hookGroupId: ID!, hookId: ID!): Hook
   hookStatus(hookGroupId: ID!, hookId: ID!): HookStatus
-  hookLastFires(hookGroupId: ID!, hookId: ID!, filter: JSON, connection: PageConnection): HookLastFireConnection
+  hookLastFires(hookGroupId: ID!, hookId: ID!, connection: PageConnection): HookLastFireConnection
 }
 
 extend type Mutation {

--- a/services/web-server/src/graphql/Namespaces.graphql
+++ b/services/web-server/src/graphql/Namespaces.graphql
@@ -25,6 +25,6 @@ type NamespacesConnection implements Connection {
 }
 
 extend type Query {
-  taskNamespace(namespace: String!, connection: PageConnection, filter: JSON): TaskNamespaceConnection
-  namespaces(namespace: String = "", connection: PageConnection, filter: JSON): NamespacesConnection
+  taskNamespace(namespace: String!, connection: PageConnection): TaskNamespaceConnection
+  namespaces(namespace: String = "", connection: PageConnection): NamespacesConnection
 }

--- a/services/web-server/src/graphql/Notify.graphql
+++ b/services/web-server/src/graphql/Notify.graphql
@@ -26,7 +26,7 @@ type NotificationAddressConnection implements Connection {
 }
 
 extend type Query {
-  listDenylistAddresses(filter: JSON, connection: PageConnection): NotificationAddressConnection
+  listDenylistAddresses(searchTerm: String, connection: PageConnection): NotificationAddressConnection
 }
 
 extend type Mutation {

--- a/services/web-server/src/graphql/Provisioners.graphql
+++ b/services/web-server/src/graphql/Provisioners.graphql
@@ -34,7 +34,7 @@ type Provisioner {
   lastDateActive: DateTime!
   actions: [ProvisionerAction]!
   # Note: This field will trigger an additional request.
-  workerTypes(provisionerId: String = provisionerId, connection: PageConnection, filter: JSON): WorkerTypesConnection
+  workerTypes(provisionerId: String = provisionerId, connection: PageConnection): WorkerTypesConnection
   # Note: This field will trigger an additional request.
   workerType(provisionerId: String = provisionerId, workerType: String!): WorkerType
 }
@@ -51,7 +51,7 @@ type ProvisionersConnection implements Connection {
 
 extend type Query {
   provisioner(provisionerId: String!): Provisioner
-  provisioners(connection: PageConnection, filter: JSON): ProvisionersConnection
+  provisioners(connection: PageConnection): ProvisionersConnection
 }
 
 # TODO: Provisioner mutations

--- a/services/web-server/src/graphql/Roles.graphql
+++ b/services/web-server/src/graphql/Roles.graphql
@@ -29,9 +29,9 @@ input RoleInput {
 extend type Query {
   # Get a list of all roles, each role object also includes the list of
   # scopes it expands to.
-  roles(filter: JSON): [Role]
+  roles(searchTerm: String): [Role]
   # List Role IDs
-  listRoleIds(connection: PageConnection, filter: JSON): RolesConnection
+  listRoleIds(connection: PageConnection, searchTerm: String): RolesConnection
   # Get information about a single role, including the set of scopes that the
   # role expands to.
   role(roleId: ID!): Role

--- a/services/web-server/src/graphql/Scopes.graphql
+++ b/services/web-server/src/graphql/Scopes.graphql
@@ -1,4 +1,4 @@
 extend type Query {
-  currentScopes(filter: JSON): [String]!
-  expandScopes(scopes: [String]!, filter: JSON): [String]!
+  currentScopes: [String]!
+  expandScopes(scopes: [String]!): [String]!
 }

--- a/services/web-server/src/graphql/Secrets.graphql
+++ b/services/web-server/src/graphql/Secrets.graphql
@@ -24,7 +24,7 @@ type SecretsConnection implements Connection {
 }
 
 extend type Query {
-  secrets(filter: JSON, connection: PageConnection): SecretsConnection
+  secrets(searchTerm: String, connection: PageConnection): SecretsConnection
   secret(name: String!): Secret
 }
 

--- a/services/web-server/src/graphql/TaskRuns.graphql
+++ b/services/web-server/src/graphql/TaskRuns.graphql
@@ -90,5 +90,5 @@ type TaskRun {
   # It **may return less**, even if more artifacts are available.
   # It may also return a page connection even though there are no more results.
   # Use the connection limit to specify smaller page sizes.
-  artifacts(taskId: ID = taskId, runId: Int = runId, connection: PageConnection, filter: JSON): ArtifactsConnection
+  artifacts(taskId: ID = taskId, runId: Int = runId, connection: PageConnection): ArtifactsConnection
 }

--- a/services/web-server/src/graphql/TaskStatuses.graphql
+++ b/services/web-server/src/graphql/TaskStatuses.graphql
@@ -49,7 +49,7 @@ type TaskStatus {
 
   # Ordered list of runs where run `n` is at `runs[n]`, e.g. Run 0 is `runs[0]`.
   # Always starts at `0`.
-  runs(filter: JSON): [TaskRun]!
+  runs: [TaskRun]!
 
   # The task definition associated with this status.
   task(taskId: ID = taskId): Task

--- a/services/web-server/src/graphql/Tasks.graphql
+++ b/services/web-server/src/graphql/Tasks.graphql
@@ -161,7 +161,7 @@ type Task {
   status(taskId: ID = taskId): TaskStatus!
 
   # Actions exposed by the decision task defined in the public/actions.json artifact.
-  taskActions(taskGroupId: String = taskGroupId, filter: JSON): TaskActionsJson
+  taskActions(taskGroupId: String = taskGroupId): TaskActionsJson
 
   # Definition of the task group ID (decision task).
   decisionTask: Task
@@ -173,7 +173,7 @@ type Task {
   # It **may return less**, even if more artifacts are available.
   # It may also return a page connection even though there are no more results.
   # Use the connection limit to specify smaller page sizes.
-  latestArtifacts(taskId: ID! = taskId, connection: PageConnection, filter: JSON): ArtifactsConnection
+  latestArtifacts(taskId: ID! = taskId, connection: PageConnection): ArtifactsConnection
 
   # the "raw" JSON task definition, without any interpretation
   rawDefinition: JSON
@@ -288,7 +288,7 @@ extend type Query {
   dependentTasks(taskId: ID!): [DependentTask]
 
   # List tasks that depend on the given `taskId`.
-  dependents(taskId: ID!, connection: PageConnection, filter: JSON): TasksConnection
+  dependents(taskId: ID!, connection: PageConnection): TasksConnection
 
   # Find a task by index path, returning the highest-ranked task with that path.
   # Will be empty if no task exists for the given path.
@@ -305,10 +305,10 @@ extend type Query {
   # It **may return less**, even if more tasks are available.
   # It may also return a page connection even though there are no more results.
   # Use the connection limit to specify smaller page sizes.
-  taskGroup(taskGroupId: ID!, connection: PageConnection, filter: JSON): TaskGroupConnection
+  taskGroup(taskGroupId: ID!, connection: PageConnection): TaskGroupConnection
 
   # Actions exposed by the decision task defined in the public/actions.json artifact.
-  taskActions(taskGroupId: ID!, filter: JSON): TaskActionsJson
+  taskActions(taskGroupId: ID!): TaskActionsJson
 
   # pending tasks paginated
   listPendingTasks(taskQueueId: String!, connection: PageConnection): PendingTasksConnection

--- a/services/web-server/src/graphql/WorkerManager.graphql
+++ b/services/web-server/src/graphql/WorkerManager.graphql
@@ -154,16 +154,16 @@ type WorkerPoolStats {
 }
 
 extend type Query {
-    WorkerManagerWorkerPoolSummaries(connection: PageConnection, filter: JSON): WorkerManagerWorkerPoolSummaryConnection!
+    WorkerManagerWorkerPoolSummaries(connection: PageConnection, searchTerm: String): WorkerManagerWorkerPoolSummaryConnection!
 
-    WorkerManagerErrors(workerPoolId: String, launchConfigId: String, connection: PageConnection, filter: JSON): WorkerManagerErrorsConnection!
+    WorkerManagerErrors(workerPoolId: String, launchConfigId: String, connection: PageConnection): WorkerManagerErrorsConnection!
     WorkerManagerErrorsStats(workerPoolId: String): WorkerManagerErrorsStats!
 
     WorkerPool(workerPoolId: String!): WorkerManagerWorkerPoolSummary
     WorkerPoolLaunchConfigs(workerPoolId: String!, includeArchived: Boolean, connection: PageConnection): WorkerPoolLaunchConfigConnection!
     WorkerPoolStats(workerPoolId: String!): WorkerPoolStats!
 
-    WorkerManagerProviders(connection: PageConnection, filter: JSON): WorkerManagerProvidersConnection!
+    WorkerManagerProviders(connection: PageConnection): WorkerManagerProvidersConnection!
 
     WorkerManagerWorkers(workerPoolId: String!, state: String, launchConfigId: String, connection: PageConnection): WorkerManagerWorkerConnection!
 

--- a/services/web-server/src/graphql/WorkerTypes.graphql
+++ b/services/web-server/src/graphql/WorkerTypes.graphql
@@ -16,8 +16,7 @@ type WorkerType {
   workers(
     provisionerId: String = provisionerId,
     workerType: String = workerType,
-    connection: PageConnection,
-    filter: JSON
+    connection: PageConnection
   ): WorkersCompactConnection
   # Note: This field will trigger an additional request.
   worker(
@@ -43,5 +42,5 @@ type WorkerTypesConnection implements Connection {
 extend type Query {
   workerType(provisionerId: String!, workerType: String!): WorkerType
   pendingTasks(provisionerId: String!, workerType: String!): Int!  # count of pending tasks
-  workerTypes(provisionerId: String!, connection: PageConnection, filter: JSON): WorkerTypesConnection
+  workerTypes(provisionerId: String!, connection: PageConnection): WorkerTypesConnection
 }

--- a/services/web-server/src/graphql/Workers.graphql
+++ b/services/web-server/src/graphql/Workers.graphql
@@ -114,7 +114,7 @@ type WorkersConnection implements Connection {
 
 extend type Query {
   worker(provisionerId: String!, workerType: String!, workerGroup: String!, workerId: ID!): Worker
-  workers(provisionerId: String!, workerType: String!, connection: PageConnection, filter: JSON, isQuarantined: Boolean, workerState: String): WorkersCompactConnection
+  workers(provisionerId: String!, workerType: String!, connection: PageConnection, isQuarantined: Boolean, workerState: String): WorkersCompactConnection
 }
 
 extend type Mutation {

--- a/services/web-server/src/loaders/artifacts.js
+++ b/services/web-server/src/loaders/artifacts.js
@@ -1,22 +1,19 @@
-import sift from '../utils/sift.js';
 import ConnectionLoader from '../ConnectionLoader.js';
 import Artifacts from '../entities/Artifacts.js';
 
 export default ({ queue }, isAuthed, rootUrl, monitor, strategies, req, cfg, requestId) => {
   const artifacts = new ConnectionLoader(
-    async ({ taskId, runId, filter, options }) => {
+    async ({ taskId, runId, options }) => {
       const raw = await queue.listArtifacts(taskId, runId, options);
-      const artifacts = sift(filter, raw.artifacts);
 
-      return new Artifacts(taskId, runId, { ...raw, artifacts });
+      return new Artifacts(taskId, runId, { ...raw, artifacts: raw.artifacts });
     },
   );
   const latestArtifacts = new ConnectionLoader(
-    async ({ taskId, filter, options }) => {
+    async ({ taskId, options }) => {
       const raw = await queue.listLatestArtifacts(taskId, options);
-      const artifacts = sift(filter, raw.artifacts);
 
-      return new Artifacts(taskId, null, { ...raw, artifacts });
+      return new Artifacts(taskId, null, { ...raw, artifacts: raw.artifacts });
     },
   );
 

--- a/services/web-server/src/loaders/cachePurges.js
+++ b/services/web-server/src/loaders/cachePurges.js
@@ -1,13 +1,12 @@
-import sift from '../utils/sift.js';
 import ConnectionLoader from '../ConnectionLoader.js';
 
 export default ({ purgeCache }, isAuthed, rootUrl, monitor, strategies, req, cfg, requestId) => {
-  const cachePurges = new ConnectionLoader(async ({ filter, options }) => {
+  const cachePurges = new ConnectionLoader(async ({ options }) => {
     const raw = await purgeCache.allPurgeRequests(options);
 
     return {
       ...raw,
-      items: sift(filter, raw.requests),
+      items: raw.requests,
     };
   });
 

--- a/services/web-server/src/loaders/clients.js
+++ b/services/web-server/src/loaders/clients.js
@@ -1,12 +1,12 @@
 import DataLoader from 'dataloader';
-import sift from '../utils/sift.js';
+import substringFilter from '../utils/searchFilter.js';
 import ConnectionLoader from '../ConnectionLoader.js';
 
 export default ({ auth }, isAuthed, rootUrl, monitor, strategies, req, cfg, requestId) => {
   const clients = new ConnectionLoader(
-    async ({ filter, options, clientOptions }) => {
+    async ({ searchTerm, options, clientOptions }) => {
       const raw = await auth.listClients({ ...clientOptions, ...options });
-      const clients = sift(filter, raw.clients);
+      const clients = substringFilter(searchTerm, 'clientId', raw.clients);
 
       return {
         ...raw,

--- a/services/web-server/src/loaders/hooks.js
+++ b/services/web-server/src/loaders/hooks.js
@@ -1,16 +1,17 @@
 import DataLoader from 'dataloader';
-import sift from '../utils/sift.js';
 import ConnectionLoader from '../ConnectionLoader.js';
 
 export default ({ hooks }, isAuthed, rootUrl, monitor, strategies, req, cfg, requestId) => {
   const hookGroups = new DataLoader(queries =>
     Promise.all(
-      queries.map(async ({ filter }) => {
+      queries.map(async ({ hookGroupId }) => {
         try {
           const { groups } = await hooks.listHookGroups();
-          const raw = groups.map(hookGroupId => ({ hookGroupId }));
+          const allGroups = groups.map(group => ({ hookGroupId: group }));
 
-          return sift(filter, raw);
+          return hookGroupId
+            ? allGroups.filter(group => group.hookGroupId === hookGroupId)
+            : allGroups;
         } catch (err) {
           return err;
         }
@@ -19,11 +20,11 @@ export default ({ hooks }, isAuthed, rootUrl, monitor, strategies, req, cfg, req
   );
   const hooksForGroup = new DataLoader(queries =>
     Promise.all(
-      queries.map(async ({ hookGroupId, filter }) => {
+      queries.map(async ({ hookGroupId }) => {
         try {
           const { hooks: hooksForGroup } = await hooks.listHooks(hookGroupId);
 
-          return sift(filter, hooksForGroup);
+          return hooksForGroup;
         } catch (err) {
           return err;
         }
@@ -55,7 +56,7 @@ export default ({ hooks }, isAuthed, rootUrl, monitor, strategies, req, cfg, req
   );
 
   const hookLastFires = new ConnectionLoader(
-    async ({ hookGroupId, hookId, filter, options }) => {
+    async ({ hookGroupId, hookId, options }) => {
       try {
         const raw = await hooks.listLastFires(hookGroupId, hookId, options);
 

--- a/services/web-server/src/loaders/namespaces.js
+++ b/services/web-server/src/loaders/namespaces.js
@@ -1,24 +1,23 @@
-import sift from '../utils/sift.js';
 import ConnectionLoader from '../ConnectionLoader.js';
 
 export default ({ index }, isAuthed, rootUrl, monitor, strategies, req, cfg, requestId) => {
   const namespaces = new ConnectionLoader(
-    async ({ namespace, options, filter }) => {
+    async ({ namespace, options }) => {
       const raw = await index.listNamespaces(namespace, options);
 
       return {
         ...raw,
-        items: sift(filter, raw.namespaces),
+        items: raw.namespaces,
       };
     },
   );
   const taskNamespace = new ConnectionLoader(
-    async ({ namespace, options, filter }) => {
+    async ({ namespace, options }) => {
       const raw = await index.listTasks(namespace, options);
 
       return {
         ...raw,
-        items: sift(filter, raw.tasks),
+        items: raw.tasks,
       };
     },
   );

--- a/services/web-server/src/loaders/notify.js
+++ b/services/web-server/src/loaders/notify.js
@@ -1,8 +1,8 @@
-import sift from '../utils/sift.js';
+import substringFilter from '../utils/searchFilter.js';
 import ConnectionLoader from '../ConnectionLoader.js';
 
 export default ({ notify }, isAuthed, rootUrl, monitor, strategies, req, cfg, requestId) => {
-  const listDenylistAddresses = new ConnectionLoader(async ({ filter, options }) => {
+  const listDenylistAddresses = new ConnectionLoader(async ({ searchTerm, options }) => {
     const raw = await notify.listDenylist(options);
     const addresses = raw.addresses.map(address => {
       return {
@@ -13,7 +13,7 @@ export default ({ notify }, isAuthed, rootUrl, monitor, strategies, req, cfg, re
 
     return {
       ...raw,
-      items: sift(filter, addresses),
+      items: substringFilter(searchTerm, 'notificationAddress', addresses),
     };
   });
 

--- a/services/web-server/src/loaders/provisioners.js
+++ b/services/web-server/src/loaders/provisioners.js
@@ -1,5 +1,4 @@
 import DataLoader from 'dataloader';
-import sift from '../utils/sift.js';
 import ConnectionLoader from '../ConnectionLoader.js';
 
 export default ({ queue }, isAuthed, rootUrl, monitor, strategies, req, cfg, requestId) => {
@@ -14,11 +13,10 @@ export default ({ queue }, isAuthed, rootUrl, monitor, strategies, req, cfg, req
       }),
     ),
   );
-  const provisioners = new ConnectionLoader(async ({ options, filter }) => {
+  const provisioners = new ConnectionLoader(async ({ options }) => {
     const raw = await queue.listProvisioners(options);
-    const provisioners = sift(filter, raw.provisioners);
 
-    return { ...raw, items: provisioners };
+    return { ...raw, items: raw.provisioners };
   });
 
   return {

--- a/services/web-server/src/loaders/roles.js
+++ b/services/web-server/src/loaders/roles.js
@@ -1,25 +1,25 @@
 import DataLoader from 'dataloader';
-import sift from '../utils/sift.js';
+import substringFilter from '../utils/searchFilter.js';
 import ConnectionLoader from '../ConnectionLoader.js';
 
 export default ({ auth }, isAuthed, rootUrl, monitor, strategies, req, cfg, requestId) => {
   const roles = new DataLoader(queries =>
     Promise.all(
-      queries.map(async ({ filter }) => {
+      queries.map(async ({ searchTerm }) => {
         try {
           const roles = await auth.listRoles();
 
-          return sift(filter, roles);
+          return substringFilter(searchTerm, 'roleId', roles);
         } catch (err) {
           return err;
         }
       }),
     ),
   );
-  const roleIds = new ConnectionLoader(async ({ filter, options }) => {
+  const roleIds = new ConnectionLoader(async ({ searchTerm, options }) => {
     const raw = await auth.listRoleIds(options);
     const roleIds = raw.roleIds.map(roleId => ({ roleId }));
-    const roles = sift(filter, roleIds);
+    const roles = substringFilter(searchTerm, 'roleId', roleIds);
 
     return {
       ...raw,

--- a/services/web-server/src/loaders/scopes.js
+++ b/services/web-server/src/loaders/scopes.js
@@ -1,14 +1,13 @@
 import DataLoader from 'dataloader';
-import sift from '../utils/sift.js';
 
 export default ({ auth }, isAuthed, rootUrl, monitor, strategies, req, cfg, requestId) => {
   const currentScopes = new DataLoader(queries =>
     Promise.all(
-      queries.map(async ({ filter }) => {
+      queries.map(async () => {
         try {
           const { scopes } = await auth.currentScopes();
 
-          return sift(filter, scopes);
+          return scopes;
         } catch (err) {
           return err;
         }
@@ -17,11 +16,11 @@ export default ({ auth }, isAuthed, rootUrl, monitor, strategies, req, cfg, requ
   );
   const expandScopes = new DataLoader(queries =>
     Promise.all(
-      queries.map(async ({ scopes, filter }) => {
+      queries.map(async ({ scopes }) => {
         try {
           const { scopes: expandedScopes } = await auth.expandScopes({ scopes });
 
-          return sift(filter, expandedScopes);
+          return expandedScopes;
         } catch (err) {
           return err;
         }

--- a/services/web-server/src/loaders/secrets.js
+++ b/services/web-server/src/loaders/secrets.js
@@ -1,15 +1,15 @@
 import DataLoader from 'dataloader';
-import sift from '../utils/sift.js';
+import substringFilter from '../utils/searchFilter.js';
 import ConnectionLoader from '../ConnectionLoader.js';
 
 export default ({ secrets }, isAuthed, rootUrl, monitor, strategies, req, cfg, requestId) => {
-  const secretsList = new ConnectionLoader(async ({ filter, options }) => {
+  const secretsList = new ConnectionLoader(async ({ searchTerm, options }) => {
     const raw = await secrets.list(options);
     const secretsList = raw.secrets.map(name => ({ name }));
 
     return {
       ...raw,
-      items: sift(filter, secretsList),
+      items: substringFilter(searchTerm, 'name', secretsList),
     };
   });
   const secret = new DataLoader(names =>

--- a/services/web-server/src/loaders/tasks.js
+++ b/services/web-server/src/loaders/tasks.js
@@ -1,9 +1,25 @@
 import DataLoader from 'dataloader';
-import sift from '../utils/sift.js';
 import got from 'got';
 import ConnectionLoader from '../ConnectionLoader.js';
 import Task from '../entities/Task.js';
 import maybeSignedUrl from '../utils/maybeSignedUrl.js';
+
+// Task actions were previously filtered with a client-supplied sift query. The
+// UI only ever sent two fixed shapes, encoded here as a `contextScope`:
+//   - 'task'  (single-task view):  kind in {task,hook} AND context is a non-empty array
+//   - 'group' (task-group view):   kind in {task,hook} AND context array has 0 or 1 entries
+const TASK_ACTION_KINDS = new Set(['task', 'hook']);
+const isContextSize = (context, n) => Array.isArray(context) && context.length === n;
+const filterTaskActions = (actions, contextScope) =>
+  actions.filter((action) => {
+    if (!TASK_ACTION_KINDS.has(action.kind)) {
+      return false;
+    }
+
+    return contextScope === 'group'
+      ? isContextSize(action.context, 0) || isContextSize(action.context, 1)
+      : !isContextSize(action.context, 0);
+  });
 
 export default ({ queue, index }, isAuthed, rootUrl, monitor, strategies, req, cfg, requestId) => {
   const task = new DataLoader(taskIds =>
@@ -29,10 +45,10 @@ export default ({ queue, index }, isAuthed, rootUrl, monitor, strategies, req, c
     ),
   );
   const taskGroup = new ConnectionLoader(
-    async ({ taskGroupId, options, filter }) => {
+    async ({ taskGroupId, options }) => {
       const taskGroup = await queue.getTaskGroup(taskGroupId);
       const raw = await queue.listTaskGroup(taskGroupId, options);
-      const tasks = sift(filter, raw.tasks);
+      const tasks = raw.tasks;
 
       return {
         taskGroup,
@@ -45,7 +61,7 @@ export default ({ queue, index }, isAuthed, rootUrl, monitor, strategies, req, c
   );
   const taskActions = new DataLoader(queries =>
     Promise.all(
-      queries.map(async ({ taskGroupId, filter }) => {
+      queries.map(async ({ taskGroupId, contextScope }) => {
         try {
           const url = await maybeSignedUrl(queue, isAuthed)(
             queue.getLatestArtifact,
@@ -58,7 +74,7 @@ export default ({ queue, index }, isAuthed, rootUrl, monitor, strategies, req, c
           return raw.actions
             ? {
               ...raw,
-              actions: sift(filter, raw.actions),
+              actions: filterTaskActions(raw.actions, contextScope),
             }
             : null;
         } catch (err) {
@@ -73,9 +89,9 @@ export default ({ queue, index }, isAuthed, rootUrl, monitor, strategies, req, c
     ),
   );
   const dependents = new ConnectionLoader(
-    async ({ taskId, options, filter }) => {
+    async ({ taskId, options }) => {
       const raw = await queue.listDependentTasks(taskId, options);
-      const tasks = sift(filter, raw.tasks);
+      const tasks = raw.tasks;
 
       return {
         ...raw,

--- a/services/web-server/src/loaders/workerManager.js
+++ b/services/web-server/src/loaders/workerManager.js
@@ -1,16 +1,16 @@
 import DataLoader from 'dataloader';
-import sift from '../utils/sift.js';
+import substringFilter from '../utils/searchFilter.js';
 import ConnectionLoader from '../ConnectionLoader.js';
 
 export default ({ workerManager }, isAuthed, rootUrl, monitor, strategies, req, cfg, requestId) => {
   const WorkerManagerWorkerPoolSummaries = new ConnectionLoader(
-    async ({ filter, options }) => {
+    async ({ searchTerm, options }) => {
       const [pools, stats] = await Promise.all([
         workerManager.listWorkerPools(options),
         workerManager.listWorkerPoolsStats(options),
       ]);
 
-      const workerPools = sift(filter, pools.workerPools);
+      const workerPools = substringFilter(searchTerm, 'workerPoolId', pools.workerPools);
 
       const fullWorkerPools = workerPools.map((wp) => {
         const poolStats = stats.workerPoolsStats.find((stat) => stat.workerPoolId === wp.workerPoolId) ?? {};
@@ -75,12 +75,12 @@ export default ({ workerManager }, isAuthed, rootUrl, monitor, strategies, req, 
   );
 
   const WorkerManagerErrors = new ConnectionLoader(
-    async ({ workerPoolId, launchConfigId, filter, options }) => {
+    async ({ workerPoolId, launchConfigId, options }) => {
       if (launchConfigId) {
         options.launchConfigId = launchConfigId;
       }
       const raw = await workerManager.listWorkerPoolErrors(workerPoolId, options);
-      const errors = sift(filter, raw.workerPoolErrors);
+      const errors = raw.workerPoolErrors;
 
       return {
         ...raw,
@@ -96,9 +96,9 @@ export default ({ workerManager }, isAuthed, rootUrl, monitor, strategies, req, 
   ));
 
   const WorkerManagerProviders = new ConnectionLoader(
-    async ({ filter, options }) => {
+    async ({ options }) => {
       const raw = await workerManager.listProviders(options);
-      const providers = sift(filter, raw.providers);
+      const providers = raw.providers;
 
       return {
         ...raw,

--- a/services/web-server/src/loaders/workerTypes.js
+++ b/services/web-server/src/loaders/workerTypes.js
@@ -1,5 +1,4 @@
 import DataLoader from 'dataloader';
-import sift from '../utils/sift.js';
 import ConnectionLoader from '../ConnectionLoader.js';
 
 export default ({ queue }, isAuthed, rootUrl, monitor, strategies, req, cfg, requestId) => {
@@ -15,10 +14,9 @@ export default ({ queue }, isAuthed, rootUrl, monitor, strategies, req, cfg, req
     ),
   );
   const workerTypes = new ConnectionLoader(
-    async ({ provisionerId, options, filter }) => {
+    async ({ provisionerId, options }) => {
       const raw = await queue.listWorkerTypes(provisionerId, options);
-      const workerTypes = sift(filter, raw.workerTypes);
-      return { ...raw, items: workerTypes };
+      return { ...raw, items: raw.workerTypes };
     },
   );
   const pendingTasks = new DataLoader(queries =>

--- a/services/web-server/src/loaders/workers.js
+++ b/services/web-server/src/loaders/workers.js
@@ -1,5 +1,4 @@
 import DataLoader from 'dataloader';
-import sift from '../utils/sift.js';
 import ConnectionLoader from '../ConnectionLoader.js';
 import WorkerCompact from '../entities/WorkerCompact.js';
 
@@ -21,7 +20,6 @@ export default ({ workerManager }, isAuthed, rootUrl, monitor, strategies, req, 
       provisionerId,
       workerType,
       options,
-      filter,
       isQuarantined,
       workerState,
     }) => {
@@ -37,7 +35,7 @@ export default ({ workerManager }, isAuthed, rootUrl, monitor, strategies, req, 
         workerType,
         opts,
       );
-      const workers = sift(filter, raw.workers);
+      const workers = raw.workers;
 
       return {
         ...raw,

--- a/services/web-server/src/resolvers/Artifacts.js
+++ b/services/web-server/src/resolvers/Artifacts.js
@@ -7,11 +7,11 @@ export default {
     ERROR: 'error',
   },
   Query: {
-    artifacts(parent, { taskId, runId, connection, filter }, { loaders }) {
-      return loaders.artifacts.load({ taskId, runId, connection, filter });
+    artifacts(parent, { taskId, runId, connection }, { loaders }) {
+      return loaders.artifacts.load({ taskId, runId, connection });
     },
-    latestArtifacts(parent, { taskId, connection, filter }, { loaders }) {
-      return loaders.latestArtifacts.load({ taskId, connection, filter });
+    latestArtifacts(parent, { taskId, connection }, { loaders }) {
+      return loaders.latestArtifacts.load({ taskId, connection });
     },
   },
   Subscription: {

--- a/services/web-server/src/resolvers/CachePurges.js
+++ b/services/web-server/src/resolvers/CachePurges.js
@@ -1,7 +1,7 @@
 export default {
   Query: {
-    cachePurges(parent, { connection, filter }, { loaders }) {
-      return loaders.cachePurges.load({ connection, filter });
+    cachePurges(parent, { connection }, { loaders }) {
+      return loaders.cachePurges.load({ connection });
     },
   },
   Mutation: {

--- a/services/web-server/src/resolvers/Clients.js
+++ b/services/web-server/src/resolvers/Clients.js
@@ -1,7 +1,7 @@
 export default {
   Query: {
-    clients(parent, { clientOptions, connection, filter }, { loaders }) {
-      return loaders.clients.load({ clientOptions, connection, filter });
+    clients(parent, { clientOptions, connection, searchTerm }, { loaders }) {
+      return loaders.clients.load({ clientOptions, connection, searchTerm });
     },
     client(parent, { clientId }, { loaders }) {
       return loaders.client.load(clientId);

--- a/services/web-server/src/resolvers/Hooks.js
+++ b/services/web-server/src/resolvers/Hooks.js
@@ -44,16 +44,16 @@ export default {
     },
   },
   HookGroup: {
-    hooks({ hookGroupId }, { filter }, { loaders }) {
-      return loaders.hooks.load({ hookGroupId, filter });
+    hooks({ hookGroupId }, args, { loaders }) {
+      return loaders.hooks.load({ hookGroupId });
     },
   },
   Query: {
-    hookGroups(parent, { filter }, { loaders }) {
-      return loaders.hookGroups.load({ filter });
+    hookGroups(parent, { hookGroupId }, { loaders }) {
+      return loaders.hookGroups.load({ hookGroupId });
     },
-    hooks(parent, { hookGroupId, filter }, { loaders }) {
-      return loaders.hooks.load({ hookGroupId, filter });
+    hooks(parent, { hookGroupId }, { loaders }) {
+      return loaders.hooks.load({ hookGroupId });
     },
     hook(parent, { hookGroupId, hookId }, { loaders }) {
       return loaders.hook.load({ hookGroupId, hookId });
@@ -61,8 +61,8 @@ export default {
     hookStatus(parent, { hookGroupId, hookId }, { loaders }) {
       return loaders.hookStatus.load({ hookGroupId, hookId });
     },
-    hookLastFires(parent, { hookGroupId, hookId, filter, connection, options }, { loaders }) {
-      return loaders.hookLastFires.load({ hookGroupId, hookId, filter, connection, options });
+    hookLastFires(parent, { hookGroupId, hookId, connection, options }, { loaders }) {
+      return loaders.hookLastFires.load({ hookGroupId, hookId, connection, options });
     },
   },
   Mutation: {

--- a/services/web-server/src/resolvers/Namespaces.js
+++ b/services/web-server/src/resolvers/Namespaces.js
@@ -1,10 +1,10 @@
 export default {
   Query: {
-    namespaces(parent, { namespace, connection, filter }, { loaders }) {
-      return loaders.namespaces.load({ namespace, connection, filter });
+    namespaces(parent, { namespace, connection }, { loaders }) {
+      return loaders.namespaces.load({ namespace, connection });
     },
-    taskNamespace(parent, { namespace, connection, filter }, { loaders }) {
-      return loaders.taskNamespace.load({ namespace, connection, filter });
+    taskNamespace(parent, { namespace, connection }, { loaders }) {
+      return loaders.taskNamespace.load({ namespace, connection });
     },
   },
 };

--- a/services/web-server/src/resolvers/Notify.js
+++ b/services/web-server/src/resolvers/Notify.js
@@ -6,8 +6,8 @@ export default {
     SLACK_CHANNEL: 'slack-channel',
   },
   Query: {
-    listDenylistAddresses(parent, { connection, filter }, { loaders }) {
-      return loaders.listDenylistAddresses.load({ connection, filter });
+    listDenylistAddresses(parent, { connection, searchTerm }, { loaders }) {
+      return loaders.listDenylistAddresses.load({ connection, searchTerm });
     },
   },
   Mutation: {

--- a/services/web-server/src/resolvers/Provisioners.js
+++ b/services/web-server/src/resolvers/Provisioners.js
@@ -16,8 +16,8 @@ export default {
     PATCH: 'patch',
   },
   Provisioner: {
-    workerTypes({ provisionerId }, { connection, filter }, { loaders }) {
-      return loaders.workerTypes.load({ provisionerId, connection, filter });
+    workerTypes({ provisionerId }, { connection }, { loaders }) {
+      return loaders.workerTypes.load({ provisionerId, connection });
     },
     workerType({ provisionerId }, { workerType }, { loaders }) {
       return loaders.workerType.load({ provisionerId, workerType });
@@ -27,8 +27,8 @@ export default {
     provisioner(parent, { provisionerId }, { loaders }) {
       return loaders.provisioner.load(provisionerId);
     },
-    provisioners(parent, { connection, filter }, { loaders }) {
-      return loaders.provisioners.load({ connection, filter });
+    provisioners(parent, { connection }, { loaders }) {
+      return loaders.provisioners.load({ connection });
     },
   },
 };

--- a/services/web-server/src/resolvers/Roles.js
+++ b/services/web-server/src/resolvers/Roles.js
@@ -1,10 +1,10 @@
 export default {
   Query: {
-    roles(parent, { filter }, { loaders }) {
-      return loaders.roles.load({ filter });
+    roles(parent, { searchTerm }, { loaders }) {
+      return loaders.roles.load({ searchTerm });
     },
-    listRoleIds(parent, { connection, filter }, { loaders }) {
-      return loaders.roleIds.load({ filter, connection });
+    listRoleIds(parent, { connection, searchTerm }, { loaders }) {
+      return loaders.roleIds.load({ searchTerm, connection });
     },
     role(parent, { roleId }, { loaders }) {
       return loaders.role.load(roleId);

--- a/services/web-server/src/resolvers/Scopes.js
+++ b/services/web-server/src/resolvers/Scopes.js
@@ -1,10 +1,10 @@
 export default {
   Query: {
-    currentScopes(parent, { filter }, { loaders }) {
-      return loaders.currentScopes.load({ filter });
+    currentScopes(parent, args, { loaders }) {
+      return loaders.currentScopes.load({});
     },
-    expandScopes(parent, { scopes, filter }, { loaders }) {
-      return loaders.expandScopes.load({ scopes, filter });
+    expandScopes(parent, { scopes }, { loaders }) {
+      return loaders.expandScopes.load({ scopes });
     },
   },
 };

--- a/services/web-server/src/resolvers/Secrets.js
+++ b/services/web-server/src/resolvers/Secrets.js
@@ -1,7 +1,7 @@
 export default {
   Query: {
-    secrets(parent, { connection, filter }, { loaders }) {
-      return loaders.secrets.load({ connection, filter });
+    secrets(parent, { connection, searchTerm }, { loaders }) {
+      return loaders.secrets.load({ connection, searchTerm });
     },
     secret(parent, { name }, { loaders }) {
       return loaders.secret.load(name);

--- a/services/web-server/src/resolvers/TaskRuns.js
+++ b/services/web-server/src/resolvers/TaskRuns.js
@@ -33,7 +33,6 @@ export default {
         taskId: parent.taskId,
         runId: parent.runId,
         connection: args.connection,
-        filter: args.filter,
       });
     },
   },

--- a/services/web-server/src/resolvers/TaskStatuses.js
+++ b/services/web-server/src/resolvers/TaskStatuses.js
@@ -1,5 +1,3 @@
-import sift from '../utils/sift.js';
-
 export default {
   TaskState: {
     UNSCHEDULED: 'unscheduled',
@@ -14,7 +12,7 @@ export default {
       return loaders.task.load(parent.taskId);
     },
     runs(parent, args) {
-      return sift(args.filter, parent.runs);
+      return parent.runs;
     },
   },
   Query: {

--- a/services/web-server/src/resolvers/Tasks.js
+++ b/services/web-server/src/resolvers/Tasks.js
@@ -31,14 +31,14 @@ export default {
 
       return loaders.status.load(parent.taskId);
     },
-    taskActions(parent, { filter }, { loaders }) {
+    taskActions(parent, args, { loaders }) {
       if (parent.taskActions) {
         return parent.taskActions;
       }
 
       return loaders.taskActions.load({
         taskGroupId: parent.taskGroupId,
-        filter,
+        contextScope: 'task',
       });
     },
     async decisionTask(parent, args, { loaders }) {
@@ -57,12 +57,12 @@ export default {
         return e;
       }
     },
-    latestArtifacts(parent, { taskId, connection, filter }, { loaders }) {
+    latestArtifacts(parent, { taskId, connection }, { loaders }) {
       if (parent.latestArtifacts) {
         return parent.latestArtifacts;
       }
 
-      return loaders.latestArtifacts.load({ taskId, connection, filter });
+      return loaders.latestArtifacts.load({ taskId, connection });
     },
   },
   DependentTask: {
@@ -113,17 +113,17 @@ export default {
         }
       }));
     },
-    async dependents(parent, { taskId, connection, filter }, { loaders }) {
-      return loaders.dependents.load({ taskId, connection, filter });
+    async dependents(parent, { taskId, connection }, { loaders }) {
+      return loaders.dependents.load({ taskId, connection });
     },
     indexedTask(parent, { indexPath }, { loaders }) {
       return loaders.indexedTask.load(indexPath);
     },
-    taskGroup(parent, { taskGroupId, connection, filter }, { loaders }) {
-      return loaders.taskGroup.load({ taskGroupId, connection, filter });
+    taskGroup(parent, { taskGroupId, connection }, { loaders }) {
+      return loaders.taskGroup.load({ taskGroupId, connection });
     },
-    taskActions(parent, { taskGroupId, filter }, { loaders }) {
-      return loaders.taskActions.load({ taskGroupId, filter });
+    taskActions(parent, { taskGroupId }, { loaders }) {
+      return loaders.taskActions.load({ taskGroupId, contextScope: 'group' });
     },
     listPendingTasks(parent, { taskQueueId, connection }, { loaders }) {
       return loaders.listPendingTasks.load({ taskQueueId, connection });

--- a/services/web-server/src/resolvers/WorkerManager.js
+++ b/services/web-server/src/resolvers/WorkerManager.js
@@ -11,11 +11,11 @@ export default {
     },
   },
   Query: {
-    WorkerManagerWorkerPoolSummaries(parent, { connection, filter }, { loaders }) {
-      return loaders.WorkerManagerWorkerPoolSummaries.load({ connection, filter });
+    WorkerManagerWorkerPoolSummaries(parent, { connection, searchTerm }, { loaders }) {
+      return loaders.WorkerManagerWorkerPoolSummaries.load({ connection, searchTerm });
     },
-    WorkerManagerErrors(parent, { workerPoolId, launchConfigId, connection, filter }, { loaders }) {
-      return loaders.WorkerManagerErrors.load({ workerPoolId, launchConfigId, connection, filter });
+    WorkerManagerErrors(parent, { workerPoolId, launchConfigId, connection }, { loaders }) {
+      return loaders.WorkerManagerErrors.load({ workerPoolId, launchConfigId, connection });
     },
     WorkerManagerErrorsStats(parent, { workerPoolId }, { loaders }) {
       return loaders.WorkerManagerErrorsStats.load({ workerPoolId });
@@ -32,8 +32,8 @@ export default {
     WorkerManagerWorkers(parent, { workerPoolId, launchConfigId, state, connection }, { loaders }) {
       return loaders.WorkerManagerWorkers.load({ workerPoolId, launchConfigId, state, connection });
     },
-    WorkerManagerProviders(parent, { connection, filter }, { loaders }) {
-      return loaders.WorkerManagerProviders.load({ connection, filter });
+    WorkerManagerProviders(parent, { connection }, { loaders }) {
+      return loaders.WorkerManagerProviders.load({ connection });
     },
     WorkerPoolStats(parent, { workerPoolId }, { loaders }) {
       return loaders.WorkerPoolStats.load({ workerPoolId });

--- a/services/web-server/src/resolvers/WorkerTypes.js
+++ b/services/web-server/src/resolvers/WorkerTypes.js
@@ -7,14 +7,13 @@ export default {
   WorkerType: {
     workers(
       { provisionerId, workerType },
-      { connection, filter },
+      { connection },
       { loaders },
     ) {
       return loaders.workers.load({
         provisionerId,
         workerType,
         connection,
-        filter,
       });
     },
     worker(
@@ -40,8 +39,8 @@ export default {
     pendingTasks(parent, { provisionerId, workerType }, { loaders }) {
       return loaders.pendingTasks.load({ provisionerId, workerType });
     },
-    workerTypes(parent, { provisionerId, connection, filter }, { loaders }) {
-      return loaders.workerTypes.load({ provisionerId, connection, filter });
+    workerTypes(parent, { provisionerId, connection }, { loaders }) {
+      return loaders.workerTypes.load({ provisionerId, connection });
     },
   },
 };

--- a/services/web-server/src/resolvers/Workers.js
+++ b/services/web-server/src/resolvers/Workers.js
@@ -38,7 +38,6 @@ export default {
         isQuarantined,
         workerState,
         connection,
-        filter,
       },
       { loaders },
     ) {
@@ -48,7 +47,6 @@ export default {
         isQuarantined,
         workerState,
         connection,
-        filter,
       });
     },
   },

--- a/services/web-server/src/utils/searchFilter.js
+++ b/services/web-server/src/utils/searchFilter.js
@@ -1,0 +1,25 @@
+/**
+ * Case-insensitive literal-substring filter over an array of objects, matching on a single named field.
+ * This replaces the previous sift-based filtering for the UI's search boxes:
+ * the UI only ever sent a single escaped substring per
+ * field, so there is no need for a general query interpreter.
+ * The search term is matched literally — it is never compiled or interpreted as a regex or expression.
+ * @param {string} searchTerm
+ * @param {string} field
+ * @param {Array<{[key: string]: unknown}>} array
+ */
+export default (searchTerm, field, array) => {
+  if (!array) {
+    return [];
+  }
+
+  if (!searchTerm) {
+    return array;
+  }
+
+  const needle = String(searchTerm).toLowerCase();
+
+  return array.filter(item =>
+    String(item?.[field] ?? '').toLowerCase().includes(needle),
+  );
+};

--- a/services/web-server/src/utils/sift.js
+++ b/services/web-server/src/utils/sift.js
@@ -1,9 +1,0 @@
-import sift from 'sift';
-
-// Utility function for guarding against undefined/null arrays when using sift
-export default (filter, array) => {
-  if (!array) {
-    return [];
-  }
-  return filter ? array.filter(sift(filter)) : array;
-};

--- a/services/web-server/test/fixtures/hookLastFires.graphql
+++ b/services/web-server/test/fixtures/hookLastFires.graphql
@@ -1,5 +1,5 @@
-query HookLastFires($hookGroupId: ID!, $hookId: ID!, $filter: JSON, $connection: PageConnection) {
-  hookLastFires(hookGroupId: $hookGroupId, hookId: $hookId, filter: $filter, connection: $connection) {
+query HookLastFires($hookGroupId: ID!, $hookId: ID!, $connection: PageConnection) {
+  hookLastFires(hookGroupId: $hookGroupId, hookId: $hookId, connection: $connection) {
     edges {
       node {
         taskId

--- a/services/web-server/test/fixtures/hooks.graphql
+++ b/services/web-server/test/fixtures/hooks.graphql
@@ -1,5 +1,5 @@
-query Hooks($hookGroupId: ID!, $filter: JSON) {
-  hooks(hookGroupId: $hookGroupId, filter: $filter) {
+query Hooks($hookGroupId: ID!) {
+  hooks(hookGroupId: $hookGroupId) {
     hookId,
   }
 }

--- a/services/web-server/test/fixtures/listRoleIds.graphql
+++ b/services/web-server/test/fixtures/listRoleIds.graphql
@@ -1,5 +1,5 @@
-query ListRoleIds($connection: PageConnection, $filter: JSON){
-  listRoleIds(connection: $connection, filter: $filter){
+query ListRoleIds($connection: PageConnection){
+  listRoleIds(connection: $connection){
     edges{
       node{
         roleId

--- a/services/web-server/test/fixtures/roles.graphql
+++ b/services/web-server/test/fixtures/roles.graphql
@@ -1,5 +1,5 @@
-query Roles($filter: JSON){
-  roles(filter: $filter){
+query Roles {
+  roles {
     roleId,
     scopes
   }

--- a/services/web-server/test/fixtures/workerPools.graphql
+++ b/services/web-server/test/fixtures/workerPools.graphql
@@ -1,5 +1,5 @@
-query ListWorkerPools($connection: PageConnection, $filter: JSON){
-  WorkerManagerWorkerPoolSummaries(connection: $connection, filter: $filter){
+query ListWorkerPools($connection: PageConnection){
+  WorkerManagerWorkerPoolSummaries(connection: $connection){
     edges{
       node{
         workerPoolId

--- a/services/web-server/test/graphql/validation_test.js
+++ b/services/web-server/test/graphql/validation_test.js
@@ -67,7 +67,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
         await client.query({
           query: gql`
             query CircularFragment {
-              secrets(filter: {}) {
+              secrets {
                 ...FragA
               }
             }

--- a/services/web-server/test/search_filter_test.js
+++ b/services/web-server/test/search_filter_test.js
@@ -1,0 +1,56 @@
+import assert from 'assert';
+import testing from '@taskcluster/lib-testing';
+import substringFilter from '../src/utils/searchFilter.js';
+
+suite(testing.suiteName(), () => {
+  const clients = [
+    { clientId: 'static/taskcluster/web-server' },
+    { clientId: 'mozilla-auth0/ad|Mozilla-LDAP|alice/treeherder' },
+    { clientId: 'project/releng/fxci-config/apply' },
+  ];
+
+  test('null array returns empty array', function() {
+    assert.deepEqual(substringFilter('anything', 'clientId', null), []);
+    assert.deepEqual(substringFilter('anything', 'clientId', undefined), []);
+  });
+
+  test('empty/absent searchTerm returns the array unchanged', function() {
+    assert.deepEqual(substringFilter('', 'clientId', clients), clients);
+    assert.deepEqual(substringFilter(null, 'clientId', clients), clients);
+    assert.deepEqual(substringFilter(undefined, 'clientId', clients), clients);
+  });
+
+  test('matches a case-insensitive substring on the named field', function() {
+    assert.deepEqual(
+      substringFilter('RELENG', 'clientId', clients),
+      [{ clientId: 'project/releng/fxci-config/apply' }],
+    );
+  });
+
+  test('returns all rows whose field contains the term', function() {
+    const result = substringFilter('mozilla', 'clientId', clients);
+    assert.equal(result.length, 1);
+    assert.equal(result[0].clientId, 'mozilla-auth0/ad|Mozilla-LDAP|alice/treeherder');
+  });
+
+  test('non-matching term returns empty array', function() {
+    assert.deepEqual(substringFilter('nonexistent-zzz', 'clientId', clients), []);
+  });
+
+  test('treats a missing/null field value as no match', function() {
+    const rows = [{ clientId: 'abc' }, { other: 'def' }, { clientId: null }];
+    assert.deepEqual(substringFilter('a', 'clientId', rows), [{ clientId: 'abc' }]);
+  });
+
+  test('the search term is treated as a literal string, not a regex', function() {
+    const rows = [{ name: 'a.b' }, { name: 'axb' }];
+    // '.' must match only the literal dot, not "any character"
+    assert.deepEqual(substringFilter('a.b', 'name', rows), [{ name: 'a.b' }]);
+  });
+
+  test('a $where-style payload is just an inert literal string (no execution path)', function() {
+    const rows = [{ name: 'safe' }];
+    // Nothing interprets operators anymore; this can only ever fail to match.
+    assert.deepEqual(substringFilter('(function(){return true})()', 'name', rows), []);
+  });
+});

--- a/ui/package.json
+++ b/ui/package.json
@@ -53,7 +53,6 @@
     "dexie": "^3.2.6",
     "dot-prop-immutable": "^2.0.0",
     "error-stack-parser": "^2.0.6",
-    "escape-string-regexp": "^5.0.0",
     "fast-memoize": "^2.5.1",
     "graphql": "^16.9.0",
     "highlight.js": "^11.10.0",

--- a/ui/src/utils/constants.js
+++ b/ui/src/utils/constants.js
@@ -133,7 +133,6 @@ export const MIMETYPE_ICONS = [
   [FileMusicIcon, [/^audio\//]],
   [FileIcon, [/.*/]],
 ];
-export const ACTIONS_JSON_KNOWN_KINDS = ['task', 'hook'];
 // Before doing a mutation on a task, be sure to
 // remove parent fields added by the GraphQL gateway.
 export const TASK_ADDED_FIELDS = [

--- a/ui/src/views/Clients/ViewClients/clients.graphql
+++ b/ui/src/views/Clients/ViewClients/clients.graphql
@@ -1,5 +1,5 @@
-query Clients($clientsConnection: PageConnection, $clientOptions: ClientsOptions, $filter: JSON) {
-  clients(connection: $clientsConnection, clientOptions: $clientOptions, filter: $filter) {
+query Clients($clientsConnection: PageConnection, $clientOptions: ClientsOptions, $searchTerm: String) {
+  clients(connection: $clientsConnection, clientOptions: $clientOptions, searchTerm: $searchTerm) {
     pageInfo {
       hasNextPage
       hasPreviousPage

--- a/ui/src/views/Clients/ViewClients/index.jsx
+++ b/ui/src/views/Clients/ViewClients/index.jsx
@@ -5,7 +5,6 @@ import { withStyles } from '@material-ui/core/styles';
 import Typography from '@material-ui/core/Typography';
 import PlusIcon from 'mdi-react/PlusIcon';
 import dotProp from 'dot-prop-immutable';
-import escapeStringRegexp from 'escape-string-regexp';
 import Spinner from '../../../components/Spinner';
 import Dashboard from '../../../components/Dashboard';
 import Search from '../../../components/Search';
@@ -27,15 +26,8 @@ import ErrorPanel from '../../../components/ErrorPanel';
       clientsConnection: {
         limit: VIEW_CLIENTS_PAGE_SIZE,
       },
-      filter: props.history.location.search
-        ? {
-            clientId: {
-              $regex: escapeStringRegexp(
-                parse(props.history.location.search.slice(1)).search
-              ),
-              $options: 'i',
-            },
-          }
+      searchTerm: props.history.location.search
+        ? parse(props.history.location.search.slice(1)).search
         : null,
     },
   }),
@@ -65,9 +57,7 @@ export default class ViewClients extends PureComponent {
       clientsConnection: {
         limit: VIEW_CLIENTS_PAGE_SIZE,
       },
-      filter: search
-        ? { clientId: { $regex: escapeStringRegexp(search), $options: 'i' } }
-        : null,
+      searchTerm: search || null,
     });
 
     if (search !== searchQuery) {
@@ -131,14 +121,7 @@ export default class ViewClients extends PureComponent {
         clientOptions: null,
         ...(history.location.search
           ? {
-              filter: {
-                clientId: {
-                  $regex: escapeStringRegexp(
-                    parse(history.location.search.slice(1)).search
-                  ),
-                  $options: 'i',
-                },
-              },
+              searchTerm: parse(history.location.search.slice(1)).search,
             }
           : null),
       },

--- a/ui/src/views/Denylist/ViewDenylistAddress/denylistAddress.graphql
+++ b/ui/src/views/Denylist/ViewDenylistAddress/denylistAddress.graphql
@@ -1,5 +1,5 @@
-query DenylistedNotifications($filter: JSON) {
-  listDenylistAddresses(filter: $filter) {
+query DenylistedNotifications($searchTerm: String) {
+  listDenylistAddresses(searchTerm: $searchTerm) {
     edges {
       node {
         notificationAddress

--- a/ui/src/views/Denylist/ViewDenylistAddress/index.jsx
+++ b/ui/src/views/Denylist/ViewDenylistAddress/index.jsx
@@ -16,9 +16,7 @@ import deleteAddressQuery from './deleteAddress.graphql';
   options: ({ match: { params } }) => ({
     fetchPolicy: 'network-only',
     variables: {
-      filter: {
-        notificationAddress: decodeURIComponent(params.notificationAddress),
-      },
+      searchTerm: decodeURIComponent(params.notificationAddress),
     },
   }),
 })
@@ -96,9 +94,13 @@ export default class ViewDenylistAddress extends Component {
       data,
       match: { params },
     } = this.props;
-    const hasDenylistAddresses = Boolean(
-      data?.listDenylistAddresses?.edges.length
-    );
+    // This detail route looks up one exact address, but the only available server argument is `searchTerm`
+    // result may contain look-alike addresses. Select the exact match rather than trusting the first edge.
+    const targetAddress = decodeURIComponent(params.notificationAddress);
+    const matchedAddress = data?.listDenylistAddresses?.edges.find(
+      edge => edge.node.notificationAddress === targetAddress
+    )?.node;
+    const hasDenylistAddresses = Boolean(matchedAddress);
 
     return (
       <Dashboard
@@ -123,7 +125,7 @@ export default class ViewDenylistAddress extends Component {
                 onDialogActionComplete={this.handleDialogActionComplete}
                 onDialogActionClose={this.handleDialogActionClose}
                 onDialogActionOpen={this.handleDialogActionOpen}
-                address={data.listDenylistAddresses.edges[0].node}
+                address={matchedAddress}
                 onAddressDelete={this.handleAddressDelete}
               />
             )}

--- a/ui/src/views/Denylist/ViewDenylistAddresses/Denylist.jsx
+++ b/ui/src/views/Denylist/ViewDenylistAddresses/Denylist.jsx
@@ -15,11 +15,7 @@ import { VIEW_DENYLIST_PAGE_SIZE } from '../../../utils/constants';
       notificationsConnection: {
         limit: VIEW_DENYLIST_PAGE_SIZE,
       },
-      filter: {
-        ...(props.searchTerm
-          ? { notificationAddress: { $regex: props.searchTerm } }
-          : null),
-      },
+      searchTerm: props.searchTerm || null,
     },
   }),
 })
@@ -46,11 +42,7 @@ export default class Denylist extends PureComponent {
           cursor,
           previousCursor,
         },
-        filter: {
-          ...(searchTerm
-            ? { notificationAddress: { $regex: searchTerm } }
-            : null),
-        },
+        searchTerm: searchTerm || null,
       },
       updateQuery(previousResult, { fetchMoreResult }) {
         const { edges, pageInfo } = fetchMoreResult.listDenylistAddresses;

--- a/ui/src/views/Denylist/ViewDenylistAddresses/denylist.graphql
+++ b/ui/src/views/Denylist/ViewDenylistAddresses/denylist.graphql
@@ -1,5 +1,5 @@
-query DenylistedNotification($notificationsConnection: PageConnection, $filter: JSON) {
-  listDenylistAddresses(connection: $notificationsConnection, filter: $filter) {
+query DenylistedNotification($notificationsConnection: PageConnection, $searchTerm: String) {
+  listDenylistAddresses(connection: $notificationsConnection, searchTerm: $searchTerm) {
     pageInfo {
       hasNextPage
       hasPreviousPage

--- a/ui/src/views/Hooks/ListHooks/hooks.graphql
+++ b/ui/src/views/Hooks/ListHooks/hooks.graphql
@@ -1,5 +1,5 @@
-query Hooks($filter: JSON) {
-  hookGroups(filter: $filter) {
+query Hooks($hookGroupId: ID) {
+  hookGroups(hookGroupId: $hookGroupId) {
     hookGroupId
     hooks {
       hookId

--- a/ui/src/views/Hooks/ListHooks/index.jsx
+++ b/ui/src/views/Hooks/ListHooks/index.jsx
@@ -20,9 +20,7 @@ import Link from '../../../utils/Link';
   options: ({ match: { params } }) => ({
     fetchPolicy: 'network-only',
     variables: {
-      filter: {
-        hookGroupId: params.hookGroupId,
-      },
+      hookGroupId: params.hookGroupId || null,
     },
   }),
 })

--- a/ui/src/views/Roles/ViewRoles/Roles.jsx
+++ b/ui/src/views/Roles/ViewRoles/Roles.jsx
@@ -3,7 +3,6 @@ import { graphql, withApollo } from 'react-apollo';
 import { string } from 'prop-types';
 import Typography from '@material-ui/core/Typography';
 import dotProp from 'dot-prop-immutable';
-import escapeStringRegexp from 'escape-string-regexp';
 import Spinner from '../../../components/Spinner';
 import RolesTable from '../../../components/RolesTable';
 import ErrorPanel from '../../../components/ErrorPanel';
@@ -20,16 +19,7 @@ import { VIEW_ROLES_PAGE_SIZE } from '../../../utils/constants';
       rolesConnection: {
         limit: VIEW_ROLES_PAGE_SIZE,
       },
-      filter: {
-        ...(props.searchTerm
-          ? {
-              roleId: {
-                $regex: escapeStringRegexp(props.searchTerm),
-                $options: 'i',
-              },
-            }
-          : null),
-      },
+      searchTerm: props.searchTerm || null,
     },
   }),
 })
@@ -63,16 +53,7 @@ export default class Roles extends PureComponent {
           cursor,
           previousCursor,
         },
-        filter: {
-          ...(searchTerm
-            ? {
-                roleId: {
-                  $regex: escapeStringRegexp(searchTerm),
-                  $options: 'i',
-                },
-              }
-            : null),
-        },
+        searchTerm: searchTerm || null,
       },
       updateQuery(previousResult, { fetchMoreResult }) {
         const { edges, pageInfo } = fetchMoreResult.listRoleIds;

--- a/ui/src/views/Roles/ViewRoles/roles.graphql
+++ b/ui/src/views/Roles/ViewRoles/roles.graphql
@@ -1,5 +1,5 @@
-query RoleIds($rolesConnection: PageConnection, $filter: JSON) {
-  listRoleIds(connection: $rolesConnection, filter: $filter) {
+query RoleIds($rolesConnection: PageConnection, $searchTerm: String) {
+  listRoleIds(connection: $rolesConnection, searchTerm: $searchTerm) {
     pageInfo {
       hasNextPage
       hasPreviousPage

--- a/ui/src/views/Secrets/ViewSecrets/index.jsx
+++ b/ui/src/views/Secrets/ViewSecrets/index.jsx
@@ -4,7 +4,6 @@ import dotProp from 'dot-prop-immutable';
 import { withStyles } from '@material-ui/core/styles';
 import Typography from '@material-ui/core/Typography';
 import PlusIcon from 'mdi-react/PlusIcon';
-import escapeStringRegexp from 'escape-string-regexp';
 import qs from 'qs';
 import Spinner from '../../../components/Spinner';
 import Dashboard from '../../../components/Dashboard';
@@ -29,9 +28,7 @@ import deleteSecretQuery from './deleteSecret.graphql';
         secretsConnection: {
           limit: VIEW_SECRETS_PAGE_SIZE,
         },
-        filter: search
-          ? { name: { $regex: escapeStringRegexp(search), $options: 'i' } }
-          : null,
+        searchTerm: search || null,
       },
     };
   },
@@ -57,9 +54,7 @@ export default class ViewSecrets extends Component {
       secretsConnection: {
         limit: VIEW_SECRETS_PAGE_SIZE,
       },
-      filter: secretSearch
-        ? { name: { $regex: escapeStringRegexp(secretSearch), $options: 'i' } }
-        : null,
+      searchTerm: secretSearch || null,
     });
 
     const query = qs.parse(window.location.search.slice(1));
@@ -91,14 +86,7 @@ export default class ViewSecrets extends Component {
           cursor,
           previousCursor,
         },
-        filter: secretSearch
-          ? {
-              name: {
-                $regex: escapeStringRegexp(secretSearch),
-                $options: 'i',
-              },
-            }
-          : null,
+        searchTerm: secretSearch || null,
       },
       updateQuery(previousResult, { fetchMoreResult }) {
         const { edges, pageInfo } = fetchMoreResult.secrets;

--- a/ui/src/views/Secrets/ViewSecrets/secrets.graphql
+++ b/ui/src/views/Secrets/ViewSecrets/secrets.graphql
@@ -1,5 +1,5 @@
-query Secrets($secretsConnection: PageConnection, $filter: JSON) {
-  secrets(connection: $secretsConnection, filter: $filter) {
+query Secrets($secretsConnection: PageConnection, $searchTerm: String) {
+  secrets(connection: $secretsConnection, searchTerm: $searchTerm) {
     pageInfo {
       hasNextPage
       hasPreviousPage

--- a/ui/src/views/Tasks/TaskGroup/index.jsx
+++ b/ui/src/views/Tasks/TaskGroup/index.jsx
@@ -31,7 +31,6 @@ import Snackbar from '../../../components/Snackbar';
 import {
   TASK_GROUP_PAGE_SIZE,
   VALID_TASK,
-  ACTIONS_JSON_KNOWN_KINDS,
   INITIAL_CURSOR,
   TASK_STATE,
   INITIAL_TASK_GROUP_NOTIFICATION_PREFERENCES,
@@ -111,12 +110,6 @@ const updateTaskGroupIdHistory = id => {
       taskGroupId: props.match.params.taskGroupId,
       taskGroupConnection: {
         limit: 20,
-      },
-      taskActionsFilter: {
-        kind: {
-          $in: ACTIONS_JSON_KNOWN_KINDS,
-        },
-        $or: [{ context: { $size: 0 } }, { context: { $size: 1 } }],
       },
     },
   }),
@@ -700,12 +693,6 @@ export default class TaskGroup extends Component {
           limit: TASK_GROUP_PAGE_SIZE,
           cursor: taskGroup.pageInfo.nextCursor,
           previousCursor: taskGroup.pageInfo.cursor,
-        },
-        taskActionsFilter: {
-          kind: {
-            $in: ACTIONS_JSON_KNOWN_KINDS,
-          },
-          $or: [{ context: { $size: 0 } }, { context: { $size: 1 } }],
         },
       },
       updateQuery: (previousResult = {}, { fetchMoreResult, variables }) => {

--- a/ui/src/views/Tasks/TaskGroup/taskGroup.graphql
+++ b/ui/src/views/Tasks/TaskGroup/taskGroup.graphql
@@ -1,5 +1,5 @@
-query TaskGroup($taskGroupId: ID!, $taskGroupConnection: PageConnection, $filter: JSON, $taskActionsFilter: JSON) {
-  taskGroup(taskGroupId: $taskGroupId, connection: $taskGroupConnection, filter: $filter) {
+query TaskGroup($taskGroupId: ID!, $taskGroupConnection: PageConnection) {
+  taskGroup(taskGroupId: $taskGroupId, connection: $taskGroupConnection) {
     pageInfo {
       hasNextPage
       hasPreviousPage
@@ -59,7 +59,7 @@ query TaskGroup($taskGroupId: ID!, $taskGroupConnection: PageConnection, $filter
     extra
   }
 
-  taskActions(taskGroupId: $taskGroupId, filter: $taskActionsFilter) {
+  taskActions(taskGroupId: $taskGroupId) {
     actions
     variables
     version

--- a/ui/src/views/Tasks/ViewTask/index.jsx
+++ b/ui/src/views/Tasks/ViewTask/index.jsx
@@ -38,7 +38,6 @@ import Breadcrumbs from '../../../components/Breadcrumbs';
 import splitTaskQueueId from '../../../utils/splitTaskQueueId';
 import { gqlTaskToApi } from '../../../utils/gqlToApi';
 import {
-  ACTIONS_JSON_KNOWN_KINDS,
   ARTIFACTS_PAGE_SIZE,
   DEPENDENTS_PAGE_SIZE,
   VALID_TASK,
@@ -112,16 +111,6 @@ const getCachesFromTask = task =>
       },
       dependentsConnection: {
         limit: DEPENDENTS_PAGE_SIZE,
-      },
-      taskActionsFilter: {
-        kind: {
-          $in: ACTIONS_JSON_KNOWN_KINDS,
-        },
-        context: {
-          $not: {
-            $size: 0,
-          },
-        },
       },
     },
   }),

--- a/ui/src/views/Tasks/ViewTask/task.graphql
+++ b/ui/src/views/Tasks/ViewTask/task.graphql
@@ -1,6 +1,6 @@
 #import "../../../fragments/artifacts.graphql"
 
-query Task($taskId: ID!, $artifactsConnection: PageConnection, $dependentsConnection: PageConnection, $taskActionsFilter: JSON) {
+query Task($taskId: ID!, $artifactsConnection: PageConnection, $dependentsConnection: PageConnection) {
   task(taskId: $taskId) {
     taskId
     taskGroupId
@@ -49,7 +49,7 @@ query Task($taskId: ID!, $artifactsConnection: PageConnection, $dependentsConnec
       }
     }
 
-    taskActions(filter: $taskActionsFilter) {
+    taskActions {
       actions
       variables
       version

--- a/ui/src/views/WorkerManager/WMEditWorkerPool/providers.graphql
+++ b/ui/src/views/WorkerManager/WMEditWorkerPool/providers.graphql
@@ -1,5 +1,5 @@
-query Providers($providersConnection: PageConnection, $filter: JSON) {
-    WorkerManagerProviders(connection: $providersConnection, filter: $filter) {
+query Providers($providersConnection: PageConnection) {
+    WorkerManagerProviders(connection: $providersConnection) {
         pageInfo {
           hasNextPage
         }

--- a/ui/src/views/WorkerManager/WMViewErrorCenter/errors.graphql
+++ b/ui/src/views/WorkerManager/WMViewErrorCenter/errors.graphql
@@ -1,5 +1,5 @@
-query WorkerManagerErrors($workerPoolId: String, $errorsConnection: PageConnection, $filter: JSON) {
-  WorkerManagerErrors(workerPoolId: $workerPoolId, connection: $errorsConnection, filter: $filter) {
+query WorkerManagerErrors($workerPoolId: String, $errorsConnection: PageConnection) {
+  WorkerManagerErrors(workerPoolId: $workerPoolId, connection: $errorsConnection) {
     pageInfo {
       hasNextPage
       hasPreviousPage

--- a/ui/src/views/WorkerManager/WMViewErrors/errors.graphql
+++ b/ui/src/views/WorkerManager/WMViewErrors/errors.graphql
@@ -1,5 +1,5 @@
-query WorkerManagerErrors($workerPoolId: String, $errorsConnection: PageConnection, $launchConfigId: String, $filter: JSON) {
-  WorkerManagerErrors(workerPoolId: $workerPoolId, launchConfigId: $launchConfigId, connection: $errorsConnection, filter: $filter) {
+query WorkerManagerErrors($workerPoolId: String, $errorsConnection: PageConnection, $launchConfigId: String) {
+  WorkerManagerErrors(workerPoolId: $workerPoolId, launchConfigId: $launchConfigId, connection: $errorsConnection) {
     pageInfo {
       hasNextPage
       hasPreviousPage

--- a/ui/src/views/WorkerManager/WMViewWorkerPools/WMWorkerPools.graphql
+++ b/ui/src/views/WorkerManager/WMViewWorkerPools/WMWorkerPools.graphql
@@ -1,5 +1,5 @@
-query workerPools($connection: PageConnection, $filter: JSON) {
-  WorkerManagerWorkerPoolSummaries(connection: $connection, filter: $filter) {
+query workerPools($connection: PageConnection, $searchTerm: String) {
+  WorkerManagerWorkerPoolSummaries(connection: $connection, searchTerm: $searchTerm) {
     pageInfo {
       hasNextPage
       hasPreviousPage

--- a/ui/src/views/WorkerManager/WMViewWorkerPools/index.jsx
+++ b/ui/src/views/WorkerManager/WMViewWorkerPools/index.jsx
@@ -1,7 +1,6 @@
 import React, { Component } from 'react';
 import { withApollo, graphql } from 'react-apollo';
 import PlusIcon from 'mdi-react/PlusIcon';
-import escapeStringRegexp from 'escape-string-regexp';
 import dotProp from 'dot-prop-immutable';
 import { withStyles } from '@material-ui/core/styles';
 import Spinner from '../../../components/Spinner';
@@ -78,14 +77,7 @@ export default class WorkerManagerWorkerPoolsView extends Component {
       workerPoolsConnection: {
         limit: VIEW_WORKER_POOLS_PAGE_SIZE,
       },
-      filter: workerPoolSearch
-        ? {
-            workerPoolId: {
-              $regex: escapeStringRegexp(workerPoolSearch),
-              $options: 'i',
-            },
-          }
-        : null,
+      searchTerm: workerPoolSearch || null,
     });
     this.setState({ workerPoolSearch });
   };
@@ -122,14 +114,7 @@ export default class WorkerManagerWorkerPoolsView extends Component {
           cursor,
           previousCursor,
         },
-        filter: this.state.workerPoolSearch
-          ? {
-              workerPoolId: {
-                $regex: escapeStringRegexp(this.state.workerPoolSearch),
-                $options: 'i',
-              },
-            }
-          : null,
+        searchTerm: this.state.workerPoolSearch || null,
       },
       updateQuery(previousResult, { fetchMoreResult }) {
         const { edges, pageInfo } =

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -2601,7 +2601,6 @@ __metadata:
     dot-prop-immutable: "npm:^2.0.0"
     dotenv-cli: "npm:^6.0.0"
     error-stack-parser: "npm:^2.0.6"
-    escape-string-regexp: "npm:^5.0.0"
     fast-memoize: "npm:^2.5.1"
     file-loader: "npm:^6.2.0"
     graphql: "npm:^16.9.0"
@@ -6191,13 +6190,6 @@ __metadata:
   version: 4.0.0
   resolution: "escape-string-regexp@npm:4.0.0"
   checksum: 10c0/9497d4dd307d845bd7f75180d8188bb17ea8c151c1edbf6b6717c100e104d629dc2dfb687686181b0f4b7d732c7dfdc4d5e7a8ff72de1b0ca283a75bbb3a9cd9
-  languageName: node
-  linkType: hard
-
-"escape-string-regexp@npm:^5.0.0":
-  version: 5.0.0
-  resolution: "escape-string-regexp@npm:5.0.0"
-  checksum: 10c0/6366f474c6f37a802800a435232395e04e9885919873e382b157ab7e8f0feb8fed71497f84a6f6a81a49aab41815522f5839112bd38026d203aea0c91622df95
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -12340,13 +12340,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"sift@npm:^17.1.3":
-  version: 17.1.3
-  resolution: "sift@npm:17.1.3"
-  checksum: 10c0/bb05d1d65cc9b549b402c1366ba1fcf685311808b6d5c2f4fa2f477d7b524218bbf6c99587562d5613d407820a6b5a7cad809f89c3f75c513ff5d8c0e0a0cead
-  languageName: node
-  linkType: hard
-
 "signal-exit@npm:^3.0.0, signal-exit@npm:^3.0.2":
   version: 3.0.7
   resolution: "signal-exit@npm:3.0.7"
@@ -13056,7 +13049,6 @@ __metadata:
     rimraf: "npm:^5.0.7"
     sanitize-html: "npm:^2.17.4"
     semver: "npm:^7.8.0"
-    sift: "npm:^17.1.3"
     sinon: "npm:^21.1.2"
     slugid: "npm:^5.0.1"
     snake-case: "npm:^3.0.3"


### PR DESCRIPTION
UI was using graphql filter:JSON to do additional filtering on the server side, but all it did was simply matching strings in best case. Sift library provided support for various complex queries that we either didn't use, or should have done on the server side directly. This removes sift library from web-server and just passes searchTerm to simplify server-side filtering.

Some of the existing filters were never  used at all by UI, so they are dropped from graphql as well

Fixes: #8716
