### PR TITLE
Fix a typo in the github service intree scope normalization tests

### DIFF
--- a/changelog/VMpee6_KR2e9j1nmTOpvzA.md
+++ b/changelog/VMpee6_KR2e9j1nmTOpvzA.md
@@ -1,0 +1,2 @@
+level: silent
+---

--- a/services/github/test/intree_test.js
+++ b/services/github/test/intree_test.js
@@ -94,7 +94,7 @@ suite(testing.suiteName(), function() {
         assert.equal(config.tasks.length, count);
       }
       for (let key of Object.keys(expected)) {
-        if ('key' === 'scopes') {
+        if (key === 'scopes') {
           expected[key].sort();
         }
         assert.deepEqual(_.get(config, key), expected[key]);
@@ -125,9 +125,9 @@ suite(testing.suiteName(), function() {
       'tasks[0].task.extra.github.events': ['push'],
       'metadata.owner': 'test@test.com',
       scopes: [
-        'assume:repo:github.com/testorg/testrepo:branch:default_branch',
-        'queue:route:statuses',
         'queue:scheduler-id:tc-gh-devel',
+        'queue:route:statuses',
+        'assume:repo:github.com/testorg/testrepo:branch:default_branch',
       ],
     });
 


### PR DESCRIPTION
The test was comparing two strings which means that code block was dead. That `'key'` is quite clearly a typo given it's defined on the line above. I reordered one of the fixtures to get the scopes out of order on purpose so the code would need to be exercised for tests to pass.
