### PR TITLE
Use `Array.isArray` instead of `instanceof Array` to fix biome's useIsArray

### DIFF
--- a/changelog/fpsSGZHLSzOeusHyRqelCg.md
+++ b/changelog/fpsSGZHLSzOeusHyRqelCg.md
@@ -1,0 +1,2 @@
+level: silent
+---

--- a/db/test/fns/purge_cache_test.js
+++ b/db/test/fns/purge_cache_test.js
@@ -32,7 +32,7 @@ suite(testing.suiteName(), function() {
       }
     };
 
-    if (caches instanceof Array) {
+    if (Array.isArray(caches)) {
       caches = caches.sort();
       samples = samples.sort();
       caches.forEach((cache, idx) => {

--- a/libraries/api/src/expressions.js
+++ b/libraries/api/src/expressions.js
@@ -102,7 +102,7 @@ const mergeParams = (paramsA, paramsB = {}) => {
  */
 const extractParams = (compiledTemplate) => {
   const ctmpl = compiledTemplate;
-  if (ctmpl instanceof Array) {
+  if (Array.isArray(ctmpl)) {
     return ctmpl
       .filter((value, i) => i % 2 === 1)
       .map(p => ({ [p]: 'string' }))
@@ -134,7 +134,7 @@ const extractParams = (compiledTemplate) => {
 /** Render a scope expression from a compiled scope expression template and parameters */
 const render = (compiledTemplate, params) => {
   const ctmpl = compiledTemplate;
-  if (ctmpl instanceof Array) {
+  if (Array.isArray(ctmpl)) {
     return ctmpl.map((value, i) => {
       if (i % 2 === 1) {
         if (typeof params[value] !== 'string' && typeof params[value] !== 'number') {
@@ -150,7 +150,7 @@ const render = (compiledTemplate, params) => {
     ctmpl.AllOf.forEach(t => {
       const result = render(t, params);
       if (result !== null) {
-        if (result instanceof Array) {
+        if (Array.isArray(result)) {
           AllOf.push(...result);
         } else {
           AllOf.push(result);
@@ -164,7 +164,7 @@ const render = (compiledTemplate, params) => {
     ctmpl.AnyOf.forEach(t => {
       const result = render(t, params);
       if (result !== null) {
-        if (result instanceof Array) {
+        if (Array.isArray(result)) {
           AnyOf.push(...result);
         } else {
           AnyOf.push(result);
@@ -175,7 +175,7 @@ const render = (compiledTemplate, params) => {
   }
   if ('for' in ctmpl) {
     const value = params[ctmpl.in];
-    if (value instanceof Array) {
+    if (Array.isArray(value)) {
       const nestedParams = _.assign({}, params);
       return value.map(val => {
         nestedParams[ctmpl.for] = val;
@@ -227,7 +227,7 @@ export default class ScopeExpressionTemplate {
         return typeof val === 'string' || typeof val === 'number';
       }
       if (T === 'array') {
-        return val instanceof Array && val.every(v => typeof v === 'string');
+        return Array.isArray(val) && val.every(v => typeof v === 'string');
       }
       if (T === 'boolean') {
         return typeof val === 'boolean';

--- a/libraries/config/src/index.js
+++ b/libraries/config/src/index.js
@@ -21,7 +21,7 @@ const config = ({
   serviceName,
   getEnvVars = false,
 }) => {
-  assert(files instanceof Array, 'Expected an array of files');
+  assert(Array.isArray(files), 'Expected an array of files');
   assert(typeof env === 'object', 'Expected env to be an object');
   assert(serviceName, 'serviceName is required');
 

--- a/libraries/loader/src/index.js
+++ b/libraries/loader/src/index.js
@@ -18,7 +18,7 @@ function validateComponent(def, name) {
   }
   // If requires is defined, then we check that it's an array of strings
   if (def.requires) {
-    if (!(def.requires instanceof Array)) {
+    if (!Array.isArray(def.requires)) {
       throw new Error(e + ' if present, requires must be array');
     }
     // Check that all entries in def.requires are strings
@@ -34,7 +34,7 @@ function validateComponent(def, name) {
  */
 function loader(componentDirectory, virtualComponents = {}) {
   assert(typeof componentDirectory === 'object');
-  if (virtualComponents instanceof Array) {
+  if (Array.isArray(virtualComponents)) {
     virtualComponents = virtualComponents.reduce((acc, k) => {
       acc[k] = null;
       return acc;

--- a/libraries/pulse/src/consumer.js
+++ b/libraries/pulse/src/consumer.js
@@ -270,8 +270,7 @@ export class PulseConsumer {
     };
 
     // Find CC'ed routes
-    if (msg.properties && msg.properties.headers &&
-        msg.properties.headers.CC instanceof Array) {
+    if (msg.properties && msg.properties.headers && Array.isArray(msg.properties.headers.CC)) {
       message.routes = msg.properties.headers.CC.filter(function(route) {
         // Only return the CC'ed routes that starts with "route."
         return /^route\.(.*)$/.test(route);

--- a/libraries/pulse/src/publisher.js
+++ b/libraries/pulse/src/publisher.js
@@ -307,7 +307,7 @@ export class PulsePublisher {
           entry.routingKeyBuilder.apply(undefined, args));
 
         const CCs = entry.CCBuilder.apply(undefined, args);
-        assert(CCs instanceof Array, 'CCBuilder must return an array');
+        assert(Array.isArray(CCs), 'CCBuilder must return an array');
 
         // Serialize message to buffer
         const payload = Buffer.from(JSON.stringify(message), 'utf8');

--- a/libraries/testing/src/schemas.js
+++ b/libraries/testing/src/schemas.js
@@ -27,7 +27,7 @@ import path from 'path';
 let schemas = function(options) {
   // Validate options
   assert(options.schemasetOptions, 'Options must be given for validator');
-  assert(options.cases instanceof Array, 'Array of cases must be given');
+  assert(Array.isArray(options.cases), 'Array of cases must be given');
   assert(options.serviceName);
 
   let validate;

--- a/libraries/validate/src/util.js
+++ b/libraries/validate/src/util.js
@@ -7,7 +7,7 @@ export function renderConstants(schema, constants) {
   // Replace val with constant, if it is an {$const: <key>} schema
   let substitute = (val) => {
     // Primitives and arrays shouldn't event be considered
-    if (!(val instanceof Object) || val instanceof Array) {
+    if (!(val instanceof Object) || Array.isArray(val)) {
       return undefined;
     }
 

--- a/services/auth/src/signaturevalidator.js
+++ b/services/auth/src/signaturevalidator.js
@@ -108,7 +108,7 @@ const limitClientWithExt = function(credentialName, issuingClientId, accessToken
     if (typeof cert.expiry !== 'number') {
       throw new Error('ext.certificate.expiry must be a number');
     }
-    if (!(cert.scopes instanceof Array)) {
+    if (!Array.isArray(cert.scopes)) {
       throw new Error('ext.certificate.scopes must be an array');
     }
     if (!cert.scopes.every(utils.validScope)) {
@@ -195,7 +195,7 @@ const limitClientWithExt = function(credentialName, issuingClientId, accessToken
   // Handle scope restriction with authorizedScopes
   if (ext.authorizedScopes) {
     // Validate input format
-    if (!(ext.authorizedScopes instanceof Array)) {
+    if (!Array.isArray(ext.authorizedScopes)) {
       throw new Error('ext.authorizedScopes must be an array');
     }
     if (!ext.authorizedScopes.every(utils.validScope)) {

--- a/services/auth/src/static-clients.js
+++ b/services/auth/src/static-clients.js
@@ -20,7 +20,7 @@ export const syncStaticClients = async function(db, clients = []) {
   const staticScopes = JSON.parse(await fs.readFile(path.join(__dirname, 'static-scopes.json'), 'utf8'));
 
   // Validate input for sanity (we hardly need perfect validation here...)
-  assert(clients instanceof Array, 'Expected clients to be am array');
+  assert(Array.isArray(clients), 'Expected clients to be am array');
   for (const client of clients) {
     assert(typeof client.clientId === 'string', 'expected clientId to be a string');
     assert(typeof client.accessToken === 'string', 'expected accessToken to be a string');
@@ -30,7 +30,7 @@ export const syncStaticClients = async function(db, clients = []) {
     if (client.clientId.startsWith('static/taskcluster')) {
       assert(!client.scopes, 'scopes are not allowed in configuration for static/taskcluster clients');
     } else {
-      assert(client.scopes instanceof Array, 'expected scopes to be an array of strings');
+      assert(Array.isArray(client.scopes), 'expected scopes to be an array of strings');
       assert(typeof client.description === 'string', 'expected description to be a string');
       assert(client.scopes.every(s => typeof s === 'string'), 'scopes must be strings');
     }

--- a/services/index/src/helpers.js
+++ b/services/index/src/helpers.js
@@ -286,7 +286,7 @@ export const namespaceUtils = {
     );
 
     // Parse namespace
-    if (!(namespace instanceof Array)) {
+    if (!Array.isArray(namespace)) {
       namespace = namespace.split('.');
     }
     // Find parent and folder name

--- a/services/notify/src/exchanges.js
+++ b/services/notify/src/exchanges.js
@@ -53,7 +53,7 @@ const commonRoutingKeyBuilder = function(message, routing) {
 
 /** Build list of routing keys to CC */
 const commonCCBuilder = function(message, routes) {
-  assert(routes instanceof Array, 'Routes must be an array');
+  assert(Array.isArray(routes), 'Routes must be an array');
   return routes.map(route => 'route.' + route);
 };
 

--- a/services/queue/src/bucket.js
+++ b/services/queue/src/bucket.js
@@ -150,7 +150,7 @@ Bucket.prototype.deleteObject = function(prefix) {
 
 /** Delete a list of objects */
 Bucket.prototype.deleteObjects = function(prefixes, quiet = false) {
-  assert(prefixes instanceof Array, 'prefixes must be an array');
+  assert(Array.isArray(prefixes), 'prefixes must be an array');
   // S3 API limit: https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteObjects.html
   assert(prefixes.length <= 1000, 'not more than 1000 prefixes can be deleted');
   return this.s3.send(new DeleteObjectsCommand({

--- a/services/queue/src/ec2regionresolver.js
+++ b/services/queue/src/ec2regionresolver.js
@@ -15,7 +15,7 @@ const LOCAL_IP_RANGES = path.join(__dirname, 'ip-ranges.json');
 class EC2RegionResolver {
   /** Construct EC2RegionResolver given a list of regions we care about */
   constructor(regions, monitor) {
-    assert(regions instanceof Array, 'regions must be an array');
+    assert(Array.isArray(regions), 'regions must be an array');
     this.regions = regions;
     this.monitor = monitor;
     this.ipRanges = [];

--- a/services/queue/src/exchanges.js
+++ b/services/queue/src/exchanges.js
@@ -187,7 +187,7 @@ let taskGroupRoutingKeyBuilder = function(message, routing) {
 
 /** Build list of routing keys to CC */
 let commonCCBuilder = function(message, routes) {
-  assert(routes instanceof Array, 'Routes must be an array');
+  assert(Array.isArray(routes), 'Routes must be an array');
   return routes.map(route => 'route.' + route);
 };
 


### PR DESCRIPTION
In practice this is going to make no difference whatsoever. But biome calls it out because in theory you could get an array from a different domain (an iframe), which would get checked against the Array prototype of the current domain and differ. In this case, that's never going to happen, but this follows what MDN
[recommends](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/isArray#instanceof_vs._array.isarray), works, and silences a biome warning.
