### PR TITLE
Use `obj.foo` instead of `obj['foo']` to fix biome's useLiteralKeys

### DIFF
--- a/changelog/PkqtscKrSXursC1KItcLxQ.md
+++ b/changelog/PkqtscKrSXursC1KItcLxQ.md
@@ -1,0 +1,2 @@
+level: silent
+---

--- a/db/test/fns/notify_test.js
+++ b/db/test/fns/notify_test.js
@@ -24,8 +24,8 @@ suite(testing.suiteName(), function() {
     await db.fns.add_denylist_address(n1.notificationType, n1.notificationAddress);
     const addresses = await db.fns.all_denylist_addresses(10, 0);
     assert.equal(addresses.length, 1);
-    assert.equal(addresses[0]["notification_type"], n1.notificationType);
-    assert.equal(addresses[0]["notification_address"], n1.notificationAddress);
+    assert.equal(addresses[0].notification_type, n1.notificationType);
+    assert.equal(addresses[0].notification_address, n1.notificationAddress);
   });
 
   helper.dbTest('add denylist address that already exists', async function(db) {
@@ -37,8 +37,8 @@ suite(testing.suiteName(), function() {
     await db.fns.add_denylist_address(n1.notificationType, n1.notificationAddress);
     const addresses = await db.fns.all_denylist_addresses(10, 0);
     assert.equal(addresses.length, 1);
-    assert.equal(addresses[0]["notification_type"], n1.notificationType);
-    assert.equal(addresses[0]["notification_address"], n1.notificationAddress);
+    assert.equal(addresses[0].notification_type, n1.notificationType);
+    assert.equal(addresses[0].notification_address, n1.notificationAddress);
   });
 
   helper.dbTest('delete denylist address that already exists', async function(db) {
@@ -65,8 +65,8 @@ suite(testing.suiteName(), function() {
     await db.fns.delete_denylist_address(n2.notificationType, n2.notificationAddress);
     const addresses = await db.fns.all_denylist_addresses(10, 0);
     assert.equal(addresses.length, 1);
-    assert.equal(addresses[0]["notification_type"], n1.notificationType);
-    assert.equal(addresses[0]["notification_address"], n1.notificationAddress);
+    assert.equal(addresses[0].notification_type, n1.notificationType);
+    assert.equal(addresses[0].notification_address, n1.notificationAddress);
   });
 
   helper.dbTest('test denylist address pagination', async function(db) {
@@ -85,8 +85,8 @@ suite(testing.suiteName(), function() {
     // so returned record should be n1 not n2
     const addresses = await db.fns.all_denylist_addresses(10, 1);
     assert.equal(addresses.length, 1);
-    assert.equal(addresses[0]["notification_type"], n1.notificationType);
-    assert.equal(addresses[0]["notification_address"], n1.notificationAddress);
+    assert.equal(addresses[0].notification_type, n1.notificationType);
+    assert.equal(addresses[0].notification_address, n1.notificationAddress);
   });
 
   helper.dbTest('test denylist existence check', async function(db) {
@@ -102,7 +102,7 @@ suite(testing.suiteName(), function() {
     await db.fns.add_denylist_address(n2.notificationType, n2.notificationAddress);
     const exists = await db.fns.exists_denylist_address(n2.notificationType, n2.notificationAddress);
     assert.equal(exists.length, 1);
-    assert(!!exists[0]["exists_denylist_address"]);
+    assert(!!exists[0].exists_denylist_address);
   });
 
   helper.dbTest('test denylist nonexistence check', async function(db) {
@@ -122,6 +122,6 @@ suite(testing.suiteName(), function() {
     await db.fns.add_denylist_address(n2.notificationType, n2.notificationAddress);
     const exists = await db.fns.exists_denylist_address(n3.notificationType, n3.notificationAddress);
     assert.equal(exists.length, 1);
-    assert(!exists[0]["exists_denylist_address"]);
+    assert(!exists[0].exists_denylist_address);
   });
 });

--- a/db/test/fns/web_server_test.js
+++ b/db/test/fns/web_server_test.js
@@ -29,7 +29,7 @@ suite(testing.suiteName(), function() {
       await db.fns.add_github_access_token(n1.userId, n1.encryptedAccessToken);
       const encryptedAccessTokenAsTable = await db.fns.load_github_access_token(n1.userId);
       assert.equal(encryptedAccessTokenAsTable.length, 1);
-      assert.deepEqual(encryptedAccessTokenAsTable[0]["encrypted_access_token"], n1.encryptedAccessToken);
+      assert.deepEqual(encryptedAccessTokenAsTable[0].encrypted_access_token, n1.encryptedAccessToken);
     });
 
     helper.dbTest('update existing github access token', async function(db) {
@@ -41,7 +41,7 @@ suite(testing.suiteName(), function() {
         await db.fns.add_github_access_token(n1.userId, n1.encryptedAccessToken);
         const encryptedAccessTokenAsTable = await db.fns.load_github_access_token(n1.userId);
         assert.equal(encryptedAccessTokenAsTable.length, 1);
-        assert.deepEqual(encryptedAccessTokenAsTable[0]["encrypted_access_token"], n1.encryptedAccessToken);
+        assert.deepEqual(encryptedAccessTokenAsTable[0].encrypted_access_token, n1.encryptedAccessToken);
       }
     });
 
@@ -78,8 +78,8 @@ suite(testing.suiteName(), function() {
       const sessionAsTable = await db.fns.session_load(sessionData1.hashedSessionId);
       assert.equal(sessionAsTable.length, 1);
       assert(typeof sessionAsTable[0].encrypted_session_id === 'object');
-      assert.deepEqual(sessionAsTable[0]["data"], sessionData1.data);
-      assert.deepEqual(sessionAsTable[0]["expires"], sessionData1.expires);
+      assert.deepEqual(sessionAsTable[0].data, sessionData1.data);
+      assert.deepEqual(sessionAsTable[0].expires, sessionData1.expires);
     });
 
     helper.dbTest('add session data can overwrite', async function(db) {
@@ -113,8 +113,8 @@ suite(testing.suiteName(), function() {
       const sessionAsTable = await db.fns.session_load(sessionData1.hashedSessionId);
       assert.equal(sessionAsTable.length, 1);
       assert(typeof sessionAsTable[0].encrypted_session_id === 'object');
-      assert.deepEqual(sessionAsTable[0]["data"], sessionData2.data);
-      assert.deepEqual(sessionAsTable[0]["expires"], sessionData2.expires);
+      assert.deepEqual(sessionAsTable[0].data, sessionData2.data);
+      assert.deepEqual(sessionAsTable[0].expires, sessionData2.expires);
     });
 
     helper.dbTest('get session data does not throw when not found', async function(db) {
@@ -150,8 +150,8 @@ suite(testing.suiteName(), function() {
       let sessionAsTable = await db.fns.session_load(sessionData1.hashedSessionId);
       assert.equal(sessionAsTable.length, 1);
       assert(typeof sessionAsTable[0].encrypted_session_id === 'object');
-      assert.deepEqual(sessionAsTable[0]["data"], sessionData1.data);
-      assert.deepEqual(sessionAsTable[0]["expires"], sessionData1.expires);
+      assert.deepEqual(sessionAsTable[0].data, sessionData1.data);
+      assert.deepEqual(sessionAsTable[0].expires, sessionData1.expires);
 
       await db.fns.session_remove(sessionData1.hashedSessionId);
       sessionAsTable = await db.fns.session_load(sessionData1.hashedSessionId);
@@ -177,15 +177,15 @@ suite(testing.suiteName(), function() {
       let sessionAsTable = await db.fns.session_load(sessionData1.hashedSessionId);
       assert.equal(sessionAsTable.length, 1);
       assert(typeof sessionAsTable[0].encrypted_session_id === 'object');
-      assert.deepEqual(sessionAsTable[0]["data"], sessionData1.data);
-      assert.deepEqual(sessionAsTable[0]["expires"], sessionData1.expires);
+      assert.deepEqual(sessionAsTable[0].data, sessionData1.data);
+      assert.deepEqual(sessionAsTable[0].expires, sessionData1.expires);
 
       await db.fns.session_touch(sessionData1.hashedSessionId, { bar: 'baz' }, new Date(2));
       sessionAsTable = await db.fns.session_load(sessionData1.hashedSessionId);
       assert.equal(sessionAsTable.length, 1);
       assert(typeof sessionAsTable[0].encrypted_session_id === 'object');
-      assert.deepEqual(sessionAsTable[0]["data"], { bar: 'baz' });
-      assert.deepEqual(sessionAsTable[0]["expires"], new Date(2));
+      assert.deepEqual(sessionAsTable[0].data, { bar: 'baz' });
+      assert.deepEqual(sessionAsTable[0].expires, new Date(2));
     });
 
     helper.dbTest('touch throws a P0002 when no such row', async function(db) {

--- a/infrastructure/tooling/src/build/index.js
+++ b/infrastructure/tooling/src/build/index.js
@@ -11,8 +11,8 @@ class Base {
   constructor(cmdOptions) {
     this.cmdOptions = cmdOptions;
 
-    this.baseDir = cmdOptions['baseDir'] || '/tmp/taskcluster-builder-build';
-    this.logsDir = cmdOptions['logsDir'] || path.join(this.baseDir, 'logs');
+    this.baseDir = cmdOptions.baseDir || '/tmp/taskcluster-builder-build';
+    this.logsDir = cmdOptions.logsDir || path.join(this.baseDir, 'logs');
   }
 
   // credentials for the tasks

--- a/infrastructure/tooling/src/build/tasks/generic-worker-image.js
+++ b/infrastructure/tooling/src/build/tasks/generic-worker-image.js
@@ -109,7 +109,7 @@ export default ({ tasks, baseDir, cmdOptions, credentials, logsDir }) => {
     ],
     run: async (requirements, utils) => {
       const tag = requirements[`generic-worker-docker-image`];
-      const provides = { [`generic-worker-push`]: tag };
+      const provides = { 'generic-worker-push': tag };
 
       if (!cmdOptions.push) {
         return utils.skip({ provides });

--- a/infrastructure/tooling/src/build/tasks/monoimage.js
+++ b/infrastructure/tooling/src/build/tasks/monoimage.js
@@ -196,7 +196,7 @@ const generateMonoimageTasks = ({ tasks, baseDir, cmdOptions, credentials, logsD
     ],
     run: async (requirements, utils) => {
       const tag = requirements[`monoimage-docker-image`];
-      const provides = { [`monoimage-push`]: tag };
+      const provides = { 'monoimage-push': tag };
 
       if (!cmdOptions.push) {
         return utils.skip({ provides });
@@ -237,7 +237,7 @@ const generateMonoimageTasks = ({ tasks, baseDir, cmdOptions, credentials, logsD
     ],
     run: async (requirements, utils) => {
       const tag = requirements[`monoimage-devel-docker-image`];
-      const provides = { [`monoimage-devel-push`]: tag };
+      const provides = { 'monoimage-devel-push': tag };
 
       if (!cmdOptions.push) {
         return utils.skip(provides);

--- a/infrastructure/tooling/src/generate/generators/docker-compose.js
+++ b/infrastructure/tooling/src/generate/generators/docker-compose.js
@@ -524,20 +524,20 @@ tasks.push({
         };
 
         if (isWeb) {
-          serviceOptions['healthcheck'] = healthcheck(`wget -q --spider http://localhost:${serviceHostPort(name)}/api/${name}/v1/ping`);
+          serviceOptions.healthcheck = healthcheck(`wget -q --spider http://localhost:${serviceHostPort(name)}/api/${name}/v1/ping`);
         }
 
         let serviceSuffix = '';
         if (!allowedBackgroundJob && (isCron || isBackground)) {
-          serviceOptions['profiles'] = [type, name, `${name}-${type}`];
-          serviceOptions['_noPorts'] = true;
+          serviceOptions.profiles = [type, name, `${name}-${type}`];
+          serviceOptions._noPorts = true;
           serviceSuffix = `-${type}`;
         }
 
         const svcName = `${name}${serviceSuffix}-${proc}`;
         dockerCompose.services[svcName] = serviceDefinition(name, serviceOptions);
-        dockerComposeProd.services[svcName] = serviceDefinitionProd(name, serviceOptions['profiles']);
-        dockerComposeDev.services[svcName] = serviceDefinitionDev(name, serviceOptions['profiles'], procs[proc].command);
+        dockerComposeProd.services[svcName] = serviceDefinitionProd(name, serviceOptions.profiles);
+        dockerComposeDev.services[svcName] = serviceDefinitionDev(name, serviceOptions.profiles, procs[proc].command);
         envFiles[name] = serviceEnv(name);
       });
     }

--- a/infrastructure/tooling/src/generate/generators/k8s.js
+++ b/infrastructure/tooling/src/generate/generators/k8s.js
@@ -271,16 +271,16 @@ const renderTemplates = async (name, vars, procs, templates) => {
       IMAGE_PULL_SECRETS_STRING: '{{ if .Values.imagePullSecret }}{{ toJson (list (dict "name" .Values.imagePullSecret)) }}{{ else }}[]{{ end }}',
     };
 
-    switch (conf['type']) {
+    switch (conf.type) {
       case 'web': {
         tmpl = 'deployment';
-        context['needsService'] = true;
-        context['wrapReplicas'] = true;
-        const rendered = jsone(templates['service'], context);
+        context.needsService = true;
+        context.wrapReplicas = true;
+        const rendered = jsone(templates.service, context);
         const file = `taskcluster-${name}-service-${proc}.yaml`;
         ingresses.push({
           projectName: `taskcluster-${name}`,
-          paths: conf['paths'] || [`/api/${name}/*`], // TODO: This version of config is only for gcp ingress :(
+          paths: conf.paths || [`/api/${name}/*`], // TODO: This version of config is only for gcp ingress :(
         });
         healthChecks.push({
           projectName: `taskcluster-${name}`,
@@ -295,7 +295,7 @@ const renderTemplates = async (name, vars, procs, templates) => {
           maxReplicas: `{{ .Values.${context.configName}.autoscaling.maxReplicas }}`,
           targetCPUUtilizationPercentage: `{{ .Values.${context.configName}.autoscaling.targetCPUUtilizationPercentage }}`,
         };
-        const hpaRendered = jsone(templates['hpa'], hpaContext);
+        const hpaRendered = jsone(templates.hpa, hpaContext);
         const hpaFilename = `taskcluster-${name}-hpa-${proc}.yaml`;
         await writeRepoFile(path.join(TMPL_DIR, hpaFilename), postProcessHorizontalPodAutoscaler(hpaRendered, context));
         break;
@@ -309,8 +309,8 @@ const renderTemplates = async (name, vars, procs, templates) => {
       }
       case 'cron': {
         tmpl = 'cron';
-        context['schedule'] = conf.schedule;
-        context['deadlineSeconds'] = conf.deadline;
+        context.schedule = conf.schedule;
+        context.deadlineSeconds = conf.deadline;
         break;
       }
       default: continue; // We don't do anything with build/heroku-only
@@ -457,7 +457,7 @@ tasks.push({
     const templates = requirements['k8s-templates'];
 
     // Generate legacy Ingress resource
-    const rendered = jsone(templates['ingress'], {
+    const rendered = jsone(templates.ingress, {
       ingresses,
       labels: labels(`taskcluster-ingress`, 'ingress'),
     });
@@ -465,7 +465,7 @@ tasks.push({
     await writeRepoFile(path.join(TMPL_DIR, 'ingress.yaml'), processed);
 
     // Generate Gateway API resources (Gateway + HTTPRoutes + TLS redirect)
-    const gatewayRendered = jsone(templates['gateway'], {
+    const gatewayRendered = jsone(templates.gateway, {
       labels: labels(`taskcluster-gateway`, 'gateway'),
     });
     await writeRepoFile(
@@ -480,7 +480,7 @@ tasks.push({
     for (let i = 0; i < chunks.length; i++) {
       const suffix = `-${i + 1}`;
       const routeName = `taskcluster-routes${suffix}`;
-      const httprouteRendered = jsone(templates['httproute'], {
+      const httprouteRendered = jsone(templates.httproute, {
         routeName,
         ingresses: chunks[i],
         labels: labels(routeName, 'httproute'),
@@ -507,7 +507,7 @@ tasks.push({
     // Gateway Fabric) don't fail with "no matches for kind".
     for (const hc of healthChecks) {
       const hcName = `${hc.projectName}-${hc.procName}-hc`;
-      const hcRendered = jsone(templates['healthcheckpolicy'], {
+      const hcRendered = jsone(templates.healthcheckpolicy, {
         projectName: hc.projectName,
         hcName,
         readinessPath: hc.readinessPath,
@@ -530,7 +530,7 @@ tasks.push({
     const templates = requirements['k8s-templates'];
 
     // podmonitoring for prometheus metrics
-    const podmon = jsone(templates['podmonitoring'], {
+    const podmon = jsone(templates.podmonitoring, {
       projectName: 'taskcluster-monitoring',
       labels: labels('taskcluster-monitoring', 'podmonitoring'),
       selectorLabels: metricsSelectorLabels('taskcluster-monitoring'),

--- a/infrastructure/tooling/src/generate/generators/tc-client-py.js
+++ b/infrastructure/tooling/src/generate/generators/tc-client-py.js
@@ -211,7 +211,7 @@ export const tasks = [{
   requires: ['apis'],
   provides: ['target-taskcluster-client-py'],
   run: async (requirements, utils) => {
-    const apis = requirements['apis'];
+    const apis = requirements.apis;
     const moduleDir = path.join(REPO_ROOT, 'clients', 'client-py', 'taskcluster', 'generated');
 
     // clean up the clients directory to eliminate any "leftovers"

--- a/infrastructure/tooling/src/generate/generators/tc-client-rs.js
+++ b/infrastructure/tooling/src/generate/generators/tc-client-rs.js
@@ -246,7 +246,7 @@ export const tasks = [{
   requires: ['apis'],
   provides: ['target-taskcluster-client-rust'],
   run: async (requirements, utils) => {
-    const apis = requirements['apis'];
+    const apis = requirements.apis;
     const moduleDir = path.join(REPO_ROOT, 'clients', 'client-rust', 'client', 'src', 'generated');
 
     // clean up the clients directory to eliminate any "leftovers"

--- a/infrastructure/tooling/src/generate/generators/tc-client-web.js
+++ b/infrastructure/tooling/src/generate/generators/tc-client-web.js
@@ -12,7 +12,7 @@ export const tasks = [{
   requires: ['apis'],
   provides: ['target-taskcluster-client-web'],
   run: async (requirements, utils) => {
-    const apis = requirements['apis'];
+    const apis = requirements.apis;
 
     // clean up the clients directory to eliminate any "leftovers"
     await rimraf(path.join(REPO_ROOT, 'clients/client-web/src/clients'));

--- a/infrastructure/tooling/src/generate/generators/tc-client.js
+++ b/infrastructure/tooling/src/generate/generators/tc-client.js
@@ -6,7 +6,7 @@ export const tasks = [{
   requires: ['apis'],
   provides: ['target-taskcluster-client'],
   run: async (requirements, utils) => {
-    const apis = requirements['apis'];
+    const apis = requirements.apis;
 
     await writeRepoFile('clients/client/src/apis.js',
       '/* eslint-disable */\nexport default ' + stringify(apis, { space: 2 }) + ';\n');

--- a/infrastructure/tooling/src/release/tasks.js
+++ b/infrastructure/tooling/src/release/tasks.js
@@ -59,7 +59,7 @@ export default ({ tasks, cmdOptions, credentials }) => {
         throw new Error(`Version ${pkgJson.version} in package.json is not valid`);
       }
 
-      const level = requirements['changelog'].level();
+      const level = requirements.changelog.level();
 
       return {
         'release-version': semver.inc(pkgJson.version, level),
@@ -367,12 +367,12 @@ export default ({ tasks, cmdOptions, credentials }) => {
       await writeRepoFile('CHANGELOG.md',
         oldCL.slice(0, breakpoint) +
           `\n## v${requirements['release-version']}\n\n` +
-          (await requirements['changelog'].format()) +
+          (await requirements.changelog.format()) +
           '\n' +
           oldCL.slice(breakpoint));
       changed.push('CHANGELOG.md');
 
-      for (let filename of requirements['changelog'].filenames()) {
+      for (let filename of requirements.changelog.filenames()) {
         await removeRepoFile(filename);
         changed.push(filename);
       }

--- a/infrastructure/tooling/src/smoketest/checks/dependencies.js
+++ b/infrastructure/tooling/src/smoketest/checks/dependencies.js
@@ -66,7 +66,7 @@ tasks.push({
       utils.status({ message: message });
       if (statuses[statuses.length - 1].status.state === 'completed') {
         return {
-          ['target-dependencies']: statuses[statuses.length - 1].status.state,
+          'target-dependencies': statuses[statuses.length - 1].status.state,
         };
       }
 

--- a/libraries/api/src/middleware/logging.js
+++ b/libraries/api/src/middleware/logging.js
@@ -77,8 +77,8 @@ export const logRequest = ({ builder, entry }) => {
           query[k] = req.query[k];
         });
       }
-      if (req.query['bewit']) {
-        query['bewit'] = '...';
+      if (req.query.bewit) {
+        query.bewit = '...';
       }
 
       const end = hrtime.bigint();

--- a/libraries/api/test/errors_test.js
+++ b/libraries/api/test/errors_test.js
@@ -49,7 +49,7 @@ suite(testing.suiteName(), function() {
       const response = JSON.parse(res.response.text);
       assert(response.code === 'InputError');
       assert(/Testing Error\n\n---\n\n/.test(response.message));
-      delete response.requestInfo['time'];
+      delete response.requestInfo.time;
       assert(_.isEqual(response.requestInfo, {
         method: 'InputError',
         params: {},
@@ -128,7 +128,7 @@ suite(testing.suiteName(), function() {
       assert(response.code === 'InternalServerError');
       assert(/^Internal/.test(response.message));
       assert(!/uhoh/.test(response.message)); // error doesn't go to user
-      delete response.requestInfo['time'];
+      delete response.requestInfo.time;
       assert(_.isEqual(response.requestInfo, {
         method: 'ISE',
         params: {},
@@ -163,7 +163,7 @@ suite(testing.suiteName(), function() {
         assert(!/s3kr!t/.test(res.text)); // secret does not appear in response
         assert(response.code === 'InputValidationError');
         assert(response.requestInfo.payload.secret === '<HIDDEN>'); // replaced payload appears in response
-        delete response.requestInfo['time'];
+        delete response.requestInfo.time;
         assert(_.isEqual(response.requestInfo, {
           method: 'InputValidationError',
           params: {},

--- a/libraries/monitor/src/logger.js
+++ b/libraries/monitor/src/logger.js
@@ -116,7 +116,7 @@ export class Logger {
     }
 
     if (fields === null || typeof fields === 'boolean') {
-      level = LEVELS['err'];
+      level = LEVELS.err;
       const origType = type;
       type = 'monitor.loggingError',
       fields = {
@@ -126,7 +126,7 @@ export class Logger {
       };
     }
     if (fields.meta !== undefined) {
-      level = LEVELS['err'];
+      level = LEVELS.err;
       const origType = type;
       type = 'monitor.loggingError',
       fields = {
@@ -190,34 +190,34 @@ export class Logger {
   }
 
   emerg(type, fields) {
-    this._log(LEVELS['emerg'], type, fields);
+    this._log(LEVELS.emerg, type, fields);
   }
 
   alert(type, fields) {
-    this._log(LEVELS['alert'], type, fields);
+    this._log(LEVELS.alert, type, fields);
   }
 
   crit(type, fields) {
-    this._log(LEVELS['crit'], type, fields);
+    this._log(LEVELS.crit, type, fields);
   }
 
   err(type, fields) {
-    this._log(LEVELS['err'], type, fields);
+    this._log(LEVELS.err, type, fields);
   }
 
   warning(type, fields) {
-    this._log(LEVELS['warning'], type, fields);
+    this._log(LEVELS.warning, type, fields);
   }
 
   notice(type, fields) {
-    this._log(LEVELS['notice'], type, fields);
+    this._log(LEVELS.notice, type, fields);
   }
 
   info(type, fields) {
-    this._log(LEVELS['info'], type, fields);
+    this._log(LEVELS.info, type, fields);
   }
 
   debug(type, fields) {
-    this._log(LEVELS['debug'], type, fields);
+    this._log(LEVELS.debug, type, fields);
   }
 }

--- a/libraries/monitor/src/monitor.js
+++ b/libraries/monitor/src/monitor.js
@@ -50,7 +50,7 @@ class Monitor {
     this._log = new Logger({
       name: ['taskcluster', this.manager.serviceName, ...this.name].join('.'),
       service: this.manager.serviceName,
-      level: this.manager.levels[name.join('.')] || this.manager.levels['root'],
+      level: this.manager.levels[name.join('.')] || this.manager.levels.root,
       destination: this.manager.destination,
       metadata,
       taskclusterVersion: this.manager.taskclusterVersion,
@@ -318,7 +318,7 @@ class Monitor {
     }
 
     if (this.manager._reporter) {
-      extra['reportId'] = this.manager._reporter.report(err, level, extra);
+      extra.reportId = this.manager._reporter.report(err, level, extra);
     }
     this.log.errorReport({ ...serialized, ...extra }, { level });
   }

--- a/libraries/monitor/src/monitormanager.js
+++ b/libraries/monitor/src/monitormanager.js
@@ -173,7 +173,7 @@ export class MonitorManager {
     assert(!MonitorManager.#registeredTypes[name], `Cannot register event ${name} twice`);
     assert(level === 'any' || LEVELS[level] !== undefined, `${level} is not a valid level.`);
     assert(Number.isInteger(version), 'Version must be an integer');
-    assert(!fields['v'], '"v" is a reserved field for messages');
+    assert(!fields.v, '"v" is a reserved field for messages');
     /** @type {Record<string, string>} */
     const cleaned = {};
     Object.entries(fields).forEach(([field, desc]) => {
@@ -263,9 +263,9 @@ export class MonitorManager {
         o[c[0]] = c[1];
         return o;
       }, levels);
-      assert(levels['root'], 'Must specify `root:` level if using child-specific levels.');
+      assert(levels.root, 'Must specify `root:` level if using child-specific levels.');
     } else {
-      levels['root'] = level;
+      levels.root = level;
     }
     manager.levels = levels;
 

--- a/libraries/postgres/src/Database.js
+++ b/libraries/postgres/src/Database.js
@@ -790,7 +790,7 @@ class Database {
   decrypt({ value }) {
     const key = this.keyring.getCryptoKey(value.kid, 'aes-256');
 
-    const n = value['__bufchunks_val'];
+    const n = value.__bufchunks_val;
     const chunks = [];
     for (let i = 0; i < n; i++) {
       chunks[i] = Buffer.from(value['__buf' + i + '_val'], 'base64');

--- a/libraries/postgres/src/migration.js
+++ b/libraries/postgres/src/migration.js
@@ -138,7 +138,7 @@ export const runOnlineBatches = async ({ client, showProgress, versionNum, kind 
   const batchFn = `online_${kind}_v${versionNum}_batch`;
   const isCompleteFn = `online_${kind}_v${versionNum}_is_complete`;
 
-  const runBatch = hooks['runBatch'] || (async (batchSize, state) => {
+  const runBatch = hooks.runBatch || (async (batchSize, state) => {
     let res;
     // expect the version to already be incremented (migration) or decremented (downgrade)
     const expectedVersion = kind === 'migration' ? versionNum : versionNum - 1;
@@ -153,14 +153,14 @@ export const runOnlineBatches = async ({ client, showProgress, versionNum, kind 
     return { state: res.rows[0].state, count: res.rows[0].count };
   });
 
-  const isComplete = hooks['isComplete'] || (async () => {
+  const isComplete = hooks.isComplete || (async () => {
     const res = await client.query(
       `select * from ${isCompleteFn}()`);
     return res.rows[0][isCompleteFn];
   });
 
   // if there is no online-migration function, there's nothing to do
-  if (!hooks['runBatch'] && !(await fnExists({ client, name: batchFn }))) {
+  if (!hooks.runBatch && !(await fnExists({ client, name: batchFn }))) {
     return;
   }
 
@@ -185,8 +185,8 @@ export const runOnlineBatches = async ({ client, showProgress, versionNum, kind 
 
     eta.measurement(0);
     while (true) {
-      if (hooks['preBatch']) {
-        await hooks['preBatch'](outerCount, count);
+      if (hooks.preBatch) {
+        await hooks.preBatch(outerCount, count);
       }
       const res = await runBatch(batchSize, state);
       state = res.state;
@@ -203,8 +203,8 @@ export const runOnlineBatches = async ({ client, showProgress, versionNum, kind 
       if (!isNaN(rate)) {
         batchSize = Math.round(Math.max(1, rate * batchTime));
       }
-      if (hooks['batchSize']) {
-        batchSize = await hooks['batchSize'](batchSize);
+      if (hooks.batchSize) {
+        batchSize = await hooks.batchSize(batchSize);
       }
 
       if (nextReport <= Date.now()) {

--- a/libraries/postgres/test/schema_test.js
+++ b/libraries/postgres/test/schema_test.js
@@ -36,7 +36,7 @@ suite(path.basename(__filename), function() {
       assert(ver1.migrationScript.startsWith('begin'));
 
       const ver2 = sch.getVersion(2);
-      assert(ver2.methods['list_secrets'].body.startsWith('begin'));
+      assert(ver2.methods.list_secrets.body.startsWith('begin'));
     });
 
     test('disallow duplicate method names', function () {

--- a/libraries/testing/src/stickyloader.js
+++ b/libraries/testing/src/stickyloader.js
@@ -40,7 +40,7 @@ const stickyLoader = load => {
   // edit the cfg component in-place, at the given dotted path
   sticky.cfg = (path, value) => {
     assert('cfg' in overwrites, 'cannot call `load.cfg` until the `cfg` component is loaded');
-    _.set(overwrites['cfg'], path, value);
+    _.set(overwrites.cfg, path, value);
   };
 
   // inject a dependency

--- a/libraries/testing/test/fakeauth_test.js
+++ b/libraries/testing/test/fakeauth_test.js
@@ -105,7 +105,7 @@ suite(testing.suiteName(), function() {
       },
     };
     if (extContent) {
-      content['ext'] = Buffer.from(JSON.stringify(extContent)).toString('base64');
+      content.ext = Buffer.from(JSON.stringify(extContent)).toString('base64');
     }
 
     let { header } = hawk.client.header(reqUrl, 'GET', content);

--- a/services/auth/test/signaturevalidator_test.js
+++ b/services/auth/test/signaturevalidator_test.js
@@ -90,7 +90,7 @@ suite(testing.suiteName(), function() {
 
         // create the authorization "header"
         let url = 'https://' + input.host + input.resource;
-        input['authorization'] = hawk.client.header(
+        input.authorization = hawk.client.header(
           url, input.method, input.authorization).header;
       }
 

--- a/services/index/test/helper.js
+++ b/services/index/test/helper.js
@@ -120,11 +120,11 @@ export const withServer = (mock, skipping) => {
       };
       // if called as scopes('none'), don't pass credentials at all
       if (scopes && scopes[0] !== 'none') {
-        options['credentials'] = {
+        options.credentials = {
           clientId: 'test-client',
           accessToken: 'none',
         };
-        options['authorizedScopes'] = scopes.length > 0 ? scopes : undefined;
+        options.authorizedScopes = scopes.length > 0 ? scopes : undefined;
       }
       helper.index = new helper.Index(options);
     };

--- a/services/notify/test/api_test.js
+++ b/services/notify/test/api_test.js
@@ -216,7 +216,7 @@ helper.secrets.mockSuite(testing.suiteName(), ['aws'], function(mock, skipping) 
       dummyAddress1.notificationType,
       dummyAddress1.notificationAddress,
     );
-    let exists = existsTable[0]["exists_denylist_address"];
+    let exists = existsTable[0].exists_denylist_address;
 
     assert(exists);
 
@@ -240,8 +240,8 @@ helper.secrets.mockSuite(testing.suiteName(), ['aws'], function(mock, skipping) 
 
     // Only dummyAddress2 should be left in the table
     let item = items[0];
-    assert.equal(item["notification_address"], dummyAddress2["notificationAddress"]);
-    assert.equal(item["notification_type"], dummyAddress2["notificationType"]);
+    assert.equal(item.notification_address, dummyAddress2.notificationAddress);
+    assert.equal(item.notification_type, dummyAddress2.notificationType);
 
     // Removing non-existant addresses should not throw an exception
     await helper.apiClient.deleteDenylistAddress(dummyAddress1);

--- a/services/object/test/helper/index.js
+++ b/services/object/test/helper/index.js
@@ -78,7 +78,7 @@ helper.withBackends = (mock, skipping) => {
     load.save();
 
     // add the 'test' backend type only for testing
-    BACKEND_TYPES['test'] = TestBackend;
+    BACKEND_TYPES.test = TestBackend;
 
     await load('cfg');
     load.cfg('middleware', [
@@ -111,7 +111,7 @@ helper.withBackends = (mock, skipping) => {
     }
 
     load.restore();
-    delete BACKEND_TYPES['test'];
+    delete BACKEND_TYPES.test;
     delete helper.setBackendConfig;
     _backends = null;
   });
@@ -124,7 +124,7 @@ helper.withMiddleware = (mock, skipping, config) => {
     }
 
     // add the 'test' middleware type only for testing
-    MIDDLEWARE_TYPES['test'] = TestMiddleware;
+    MIDDLEWARE_TYPES.test = TestMiddleware;
 
     await load('cfg');
     load.cfg('middleware', config || [
@@ -133,7 +133,7 @@ helper.withMiddleware = (mock, skipping, config) => {
   });
 
   suiteTeardown('withMiddleware', async function() {
-    delete MIDDLEWARE_TYPES['test'];
+    delete MIDDLEWARE_TYPES.test;
   });
 };
 

--- a/services/queue/test/helper.js
+++ b/services/queue/test/helper.js
@@ -314,11 +314,11 @@ export const withServer = (mock, skipping) => {
       };
       // if called as scopes('none'), don't pass credentials at all
       if (scopes && scopes[0] !== 'none') {
-        options['credentials'] = {
+        options.credentials = {
           clientId: 'test-client',
           accessToken: 'none',
         };
-        options['authorizedScopes'] = scopes.length > 0 ? scopes : undefined;
+        options.authorizedScopes = scopes.length > 0 ? scopes : undefined;
       }
       helper.queue = new helper.Queue(options);
     };

--- a/services/web-server/src/login/strategies/github.js
+++ b/services/web-server/src/login/strategies/github.js
@@ -106,7 +106,7 @@ export default class Github {
 
   useStrategy(app, cfg) {
     const { credentials } = cfg.taskcluster;
-    const strategyCfg = cfg.login.strategies['github'];
+    const strategyCfg = cfg.login.strategies.github;
     const loginMiddleware = login(cfg.app.publicUrl);
 
     if (!strategyCfg.clientId || !strategyCfg.clientSecret) {

--- a/services/worker-manager/src/providers/azure/index.js
+++ b/services/worker-manager/src/providers/azure/index.js
@@ -2174,7 +2174,7 @@ export class AzureProvider extends Provider {
         }
       }
       // check for un-deleted disks
-      if (!disksDeleted || _.some(worker.providerData.disks.map(i => i['id']))) {
+      if (!disksDeleted || _.some(worker.providerData.disks.map(i => i.id))) {
         return;
       }
 

--- a/services/worker-manager/test/fakes/azure.js
+++ b/services/worker-manager/test/fakes/azure.js
@@ -59,20 +59,20 @@ export class FakeAzure extends FakeCloud {
     };
 
     this.computeClient = {
-      virtualMachines: this._managers['vm'],
-      disks: this._managers['disk'],
+      virtualMachines: this._managers.vm,
+      disks: this._managers.disk,
       pipeline: new FakePipeline(),
     };
     this.networkClient = {
-      networkInterfaces: this._managers['nic'],
-      publicIPAddresses: this._managers['ip'],
+      networkInterfaces: this._managers.nic,
+      publicIPAddresses: this._managers.ip,
       pipeline: new FakePipeline(),
     };
     this.resourcesClient = {
-      resourceGroups: this._managers['resourceGroup'],
+      resourceGroups: this._managers.resourceGroup,
       pipeline: new FakePipeline(),
     };
-    this.deploymentsClient = Object.assign(this._managers['deployment'], {
+    this.deploymentsClient = Object.assign(this._managers.deployment, {
       pipeline: new FakePipeline(),
     });
 

--- a/services/worker-manager/test/fakes/fake.js
+++ b/services/worker-manager/test/fakes/fake.js
@@ -89,8 +89,8 @@ export class FakeCloud {
       return;
     }
     for (let error of this.ajv.errors) {
-      if (error.params['additionalProperty']) {
-        error.message += ': ' + JSON.stringify(error.params['additionalProperty']);
+      if (error.params.additionalProperty) {
+        error.message += ': ' + JSON.stringify(error.params.additionalProperty);
       }
     }
     throw new Error([

--- a/services/worker-manager/test/provider_azure_test.js
+++ b/services/worker-manager/test/provider_azure_test.js
@@ -472,7 +472,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       assert.equal(providerData.tags['worker-group'], 'westus');
       assert.equal(providerData.tags['worker-pool-id'], workerPoolId);
       assert.equal(providerData.tags['root-url'], helper.rootUrl);
-      assert.equal(providerData.tags['owner'], 'whatever@example.com');
+      assert.equal(providerData.tags.owner, 'whatever@example.com');
 
       const customData = JSON.parse(Buffer.from(providerData.vm.config.osProfile.customData, 'base64'));
       assert.equal(customData.workerPoolId, workerPoolId);
@@ -488,7 +488,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       const worker = await provisionWorkerPool({
         tags: { mytag: 'myvalue' },
       });
-      assert.equal(worker.providerData.tags['mytag'], 'myvalue');
+      assert.equal(worker.providerData.tags.mytag, 'myvalue');
       helper.assertPulseMessage('worker-requested', m => m.payload.workerId === worker.workerId);
     });
 
@@ -1461,7 +1461,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       assert.equal(vmParams.tags['worker-group'], 'westus');
       assert.equal(vmParams.tags['worker-pool-id'], workerPoolId);
       assert.equal(vmParams.tags['root-url'], helper.rootUrl);
-      assert.equal(vmParams.tags['owner'], 'whatever@example.com');
+      assert.equal(vmParams.tags.owner, 'whatever@example.com');
 
       debug('sixth call');
       await provider.provisionResources({ worker, monitor });


### PR DESCRIPTION
The two are equivalent but biome complains by default on the latter. Replacing it is free and mechanical and makes it more obvious when `[]` is used that keys are dynamic or not valid identifiers which might reveal problems.
