### PR TITLE
Use `Date.now()` instead of `new Date().getTime()`

### DIFF
--- a/changelog/Ouq6CAJUQfmKHNoweg41vA.md
+++ b/changelog/Ouq6CAJUQfmKHNoweg41vA.md
@@ -1,0 +1,2 @@
+level: silent
+---

--- a/clients/client-web/test/fromNow_test.js
+++ b/clients/client-web/test/fromNow_test.js
@@ -25,7 +25,7 @@ describe('fromNow', function() {
 
   it('should generate with year+month format', () => {
     const day = 24 * 60 * 60 * 1000;
-    const date1 = new Date(new Date().getTime() + 2 * 365 * day + 55 * 30 * day);
+    const date1 = new Date(Date.now() + 2 * 365 * day + 55 * 30 * day);
     const date2 = fromNow('2 years 55mo');
 
     // Allow for 10ms margin
@@ -34,7 +34,7 @@ describe('fromNow', function() {
   });
 
   it('should generate with month format', () => {
-    const date1 = new Date(new Date().getTime() + 240 * 30 * 24 * 60 * 60 * 1000);
+    const date1 = new Date(Date.now() + 240 * 30 * 24 * 60 * 60 * 1000);
     const date2 = fromNow('240 months');
 
     // Allow for 10ms margin
@@ -43,7 +43,7 @@ describe('fromNow', function() {
   });
 
   it('should generate with -month format', () => {
-    const date1 = new Date(new Date().getTime() - 240 * 30 * 24 * 60 * 60 * 1000);
+    const date1 = new Date(Date.now() - 240 * 30 * 24 * 60 * 60 * 1000);
     const date2 = fromNow('-240 months');
 
     // Allow for 10ms margin

--- a/infrastructure/tooling/src/smoketest/checks/builtin.js
+++ b/infrastructure/tooling/src/smoketest/checks/builtin.js
@@ -42,7 +42,7 @@ export const tasks = [];
       let queue = new taskcluster.Queue(taskcluster.fromEnvVars());
       await queue.createTask(taskId, task);
       let pollForStatusStart = new Date();
-      while ((new Date() - pollForStatusStart) < 120000) {
+      while ((Date.now() - pollForStatusStart) < 120000) {
         let status = await queue.status(taskId);
         if (status.status.state === 'pending' || status.status.state === 'running') {
           utils.status({

--- a/infrastructure/tooling/src/smoketest/checks/dependencies.js
+++ b/infrastructure/tooling/src/smoketest/checks/dependencies.js
@@ -41,7 +41,7 @@ tasks.push({
       utils.status({ message: 'Created task ' + taskIds[i] });
     }
     let pollStartTime = new Date();
-    while (new Date() - pollStartTime < 1200000) {
+    while (Date.now() - pollStartTime < 1200000) {
       let statuses = [];
       let message = 'Task execution status:';
       for (let i = 0; i < taskCount; i++) {

--- a/infrastructure/tooling/src/smoketest/checks/indexTask.js
+++ b/infrastructure/tooling/src/smoketest/checks/indexTask.js
@@ -41,7 +41,7 @@ tasks.push({
     await queue.createTask(randomId, task);
     let index = new taskcluster.Index(taskcluster.fromEnvVars());
     let pollForStatusStart = new Date();
-    while ((new Date() - pollForStatusStart) < 120000) {
+    while ((Date.now() - pollForStatusStart) < 120000) {
       let status = await queue.status(randomId);
       if (status.status.state === 'pending' || status.status.state === 'running') {
         utils.status({

--- a/libraries/iterate/src/index.js
+++ b/libraries/iterate/src/index.js
@@ -111,7 +111,7 @@ class Iterate extends events.EventEmitter {
       watchdog.stop();
     }
 
-    const duration = new Date() - start;
+    const duration = Date.now() - start;
     if (this.minIterationTime > 0 && duration < this.minIterationTime) {
       throw new Error('Handler duration was less than minIterationTime');
     }

--- a/libraries/iterate/test/iterate_test.js
+++ b/libraries/iterate/test/iterate_test.js
@@ -124,7 +124,7 @@ suite(testing.suiteName(), () => {
     assume(monitor.manager.messages.length).atleast(5);
     assume(monitor.manager.messages[0].Type).equals('monitor.periodic');
 
-    assume(+new Date()).atleast(500);
+    assume(Date.now()).atleast(500);
   }));
 
   test('should stop in the midst of waitTime', runWithFakeTime(async function() {
@@ -144,7 +144,7 @@ suite(testing.suiteName(), () => {
     await testing.sleep(1000);
     await i.stop();
 
-    assume(+new Date()).between(1000, 1100);
+    assume(Date.now()).between(1000, 1100);
   }));
 
   test('should stop after correct number of iterations', runWithFakeTime(async function() {

--- a/libraries/iterate/test/watchdog_test.js
+++ b/libraries/iterate/test/watchdog_test.js
@@ -13,7 +13,7 @@ suite(testing.suiteName(), function() {
 
   const listen = w => {
     events = [];
-    w.on('expired', () => events.push(['expired', +new Date()]));
+    w.on('expired', () => events.push(['expired', Date.now()]));
   };
 
   test('should emit expired event', runWithFakeTime(async function() {

--- a/libraries/pulse/src/client.js
+++ b/libraries/pulse/src/client.js
@@ -153,7 +153,7 @@ export class Client extends events.EventEmitter {
 
     // don't actually start connecting until at least minReconnectionInterval has passed
     const earliestConnectionTime = this.lastConnectionTime + this._minReconnectionInterval;
-    const now = new Date().getTime();
+    const now = Date.now();
     setTimeout(async () => {
       if (newConn.state !== 'waiting') {
         // the connection is no longer waiting, so don't proceed with
@@ -163,7 +163,7 @@ export class Client extends events.EventEmitter {
       }
 
       try {
-        this.lastConnectionTime = new Date().getTime();
+        this.lastConnectionTime = Date.now();
         const { connectionString } = await this.credentials();
         newConn.connect(connectionString).catch(err => {
           // .connect should be infallible, but just in case..

--- a/libraries/pulse/test/client_test.js
+++ b/libraries/pulse/test/client_test.js
@@ -13,7 +13,7 @@ helper.secrets.mockSuite(suiteName(), ['pulse'], function(mock, skipping) {
   let connectionString, credentials;
 
   // use a unique name for each test run, just to ensure nothing interferes
-  const unique = new Date().getTime().toString();
+  const unique = Date.now().toString();
   const exchangeName = `exchanges/test/${unique}`;
   const queueName = `queues/test/${unique}`;
   const routingKey = 'greetings';

--- a/libraries/pulse/test/consumer_test.js
+++ b/libraries/pulse/test/consumer_test.js
@@ -20,7 +20,7 @@ helper.secrets.mockSuite(suiteName(), ['pulse'], function(mock, skipping) {
 
   suite('PulseConsumer', function() {
     // use a unique name for each test run, just to ensure nothing interferes
-    const unique = new Date().getTime().toString();
+    const unique = Date.now().toString();
     const exchangeName = `exchanges/test/${unique}`;
     const routingKey = 'greetings.earthling.foo.bar.bing';
     const routingKeyReference = [

--- a/libraries/pulse/test/publisher_test.js
+++ b/libraries/pulse/test/publisher_test.js
@@ -187,7 +187,7 @@ helper.secrets.mockSuite(suiteName(), ['pulse'], function(mock, skipping) {
 
   suite('PulsePublisher', function() {
     // use a unique name for each test run, just to ensure nothing interferes
-    const unique = `test-${new Date().getTime()}`;
+    const unique = `test-${Date.now()}`;
     let client, conn, chan, exchanges, schemaset, publisher, messages;
 
     suiteSetup(async function() {

--- a/libraries/testing/src/poll.js
+++ b/libraries/testing/src/poll.js
@@ -15,13 +15,13 @@ const poll = async (doPoll, iterations, delay) => {
   delay = delay || 250;
   iterations = iterations === undefined ? 20 : iterations;
   const errors = [];
-  const start = +new Date();
+  const start = Date.now();
 
   while (true) {
     try {
       return await doPoll();
     } catch (err) {
-      errors.push({ err, when: new Date() - start });
+      errors.push({ err, when: Date.now() - start });
 
       // Re-throw unless we're out of iterations
       if (iterations !== undefined && iterations <= 0) {

--- a/libraries/testing/test/utils_test.js
+++ b/libraries/testing/test/utils_test.js
@@ -3,9 +3,9 @@ import testing from '@taskcluster/lib-testing';
 
 suite(testing.suiteName(), function() {
   test('sleep', async function() {
-    const start = new Date().getTime();
+    let start = Date.now();
     await testing.sleep(10);
-    const end = new Date().getTime();
+    const end = Date.now();
     // as long as it waited 5ms or more we'll call it good..
     assert(end - start > 5, 'did not wait long enough');
   });

--- a/services/auth/src/azure.js
+++ b/services/auth/src/azure.js
@@ -125,7 +125,7 @@ export const azureBuilder = builder => {
     if (level === 'read-write') {
       // only try to create if we haven't done so in this process recently
       const key = `${account}/${tableName}`;
-      if (!tableLastCreated[key] || new Date() - tableLastCreated[key] > 6 * 3600 * 1000) {
+      if (!tableLastCreated[key] || Date.now() - tableLastCreated[key] > 6 * 3600 * 1000) {
         try {
           await table.createTable(tableName);
         } catch (err) {
@@ -248,7 +248,7 @@ export const azureBuilder = builder => {
     // Create container ignore error, if it already exists
     if (level === 'read-write') {
       const key = `${account}/${container}`;
-      if (!containerLastCreated[key] || new Date() - containerLastCreated[key] > 6 * 3600 * 1000) {
+      if (!containerLastCreated[key] || Date.now() - containerLastCreated[key] > 6 * 3600 * 1000) {
         try {
           await blob.createContainer(container);
         } catch (err) {

--- a/services/auth/src/signaturevalidator.js
+++ b/services/auth/src/signaturevalidator.js
@@ -116,7 +116,7 @@ const limitClientWithExt = function(credentialName, issuingClientId, accessToken
     }
 
     // Check start and expiry
-    let now = new Date().getTime();
+    let now = Date.now();
     if (cert.start > now + 5 * 60 * 1000) {
       throw new Error('ext.certificate.start > now');
     }

--- a/services/auth/test/s3_test.js
+++ b/services/auth/test/s3_test.js
@@ -40,7 +40,7 @@ helper.secrets.mockSuite(testing.suiteName(), ['azure', 'gcp'], function(mock, s
       bucket,
       'folder1/folder2/',
     );
-    assert(new Date(result.expires).getTime() > new Date().getTime(),
+    assert(new Date(result.expires).getTime() > Date.now(),
       'Expected expires to be in the future');
 
     // Create aws credentials
@@ -81,7 +81,7 @@ helper.secrets.mockSuite(testing.suiteName(), ['azure', 'gcp'], function(mock, s
       bucket,
       '',
     );
-    assert(new Date(result.expires).getTime() > new Date().getTime(),
+    assert(new Date(result.expires).getTime() > Date.now(),
       'Expected expires to be in the future');
 
     // Create aws credentials
@@ -122,7 +122,7 @@ helper.secrets.mockSuite(testing.suiteName(), ['azure', 'gcp'], function(mock, s
       bucket,
       'folder1/',
     );
-    assert(new Date(result.expires).getTime() > new Date().getTime(),
+    assert(new Date(result.expires).getTime() > Date.now(),
       'Expected expires to be in the future');
 
     // Create aws credentials

--- a/services/github/src/github-auth.js
+++ b/services/github/src/github-auth.js
@@ -19,7 +19,7 @@ export const getCachedInstallationToken = async (gh, inst_id) => {
   let tokenData = tokenCache.get(inst_id);
   const timeMargin = 10 * 60 * 1000; // 10min before expiry
   if (tokenData) {
-    if (new Date(tokenData.expires_at).getTime() > new Date().getTime() + timeMargin) {
+    if (new Date(tokenData.expires_at).getTime() > Date.now() + timeMargin) {
       return tokenData;
     }
   }

--- a/services/hooks/test/api_test.js
+++ b/services/hooks/test/api_test.js
@@ -72,7 +72,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
   const invalidHookDef = _.defaults({
     schedule: ['0 0 3 0 * *'],
   }, hookWithTriggerSchema);
-  const unique = new Date().getTime().toString();
+  const unique = Date.now().toString();
   const hookWithBindings = _.defaults({
     bindings: [{ exchange: `exchange/test/${unique}`, routingKeyPattern: 'amongst.rockets.wizards' }],
   }, hookWithHookIds);

--- a/services/queue/src/api.js
+++ b/services/queue/src/api.js
@@ -706,14 +706,14 @@ let patchAndValidateTaskDef = function(taskId, taskDef, maxTaskDeadlineDays) {
   // Ensure: created < now < deadline (with drift up to 15 min)
   let created = new Date(taskDef.created);
   let deadline = new Date(taskDef.deadline);
-  if (created.getTime() < new Date().getTime() - 15 * 60 * 1000) {
+  if (created.getTime() < Date.now() - 15 * 60 * 1000) {
     return {
       code: 'InputError',
       message: '`created` cannot be in the past (max 15min drift)',
       details: { created: taskDef.created },
     };
   }
-  if (created.getTime() > new Date().getTime() + 15 * 60 * 1000) {
+  if (created.getTime() > Date.now() + 15 * 60 * 1000) {
     return {
       code: 'InputError',
       message: '`created` cannot be in the future (max 15min drift)',
@@ -727,7 +727,7 @@ let patchAndValidateTaskDef = function(taskId, taskDef, maxTaskDeadlineDays) {
       details: { created: taskDef.created, deadline: taskDef.deadline },
     };
   }
-  if (deadline.getTime() < new Date().getTime()) {
+  if (deadline.getTime() < Date.now()) {
     return {
       code: 'InputError',
       message: '`deadline` cannot be in the past',
@@ -735,7 +735,7 @@ let patchAndValidateTaskDef = function(taskId, taskDef, maxTaskDeadlineDays) {
     };
   }
 
-  let msToDeadline = deadline.getTime() - new Date().getTime();
+  let msToDeadline = deadline.getTime() - Date.now();
   // Validate that deadline is less than maxTaskDeadlineDays from now, allow 15 min drift
   if (msToDeadline > maxTaskDeadlineDays * 24 * 60 * 60 * 1000 + 15 * 60 * 1000) {
     return {
@@ -1134,7 +1134,7 @@ builder.declare({
   });
 
   // Validate deadline
-  if (task.deadline.getTime() < new Date().getTime()) {
+  if (task.deadline.getTime() < Date.now()) {
     return res.reportError(
       'RequestConflict',
       'Task `{{taskId}}` can\'t be rescheduled past its deadline of ' +
@@ -1240,7 +1240,7 @@ builder.declare({
   });
 
   // Validate deadline
-  if (task.deadline.getTime() < new Date().getTime()) {
+  if (task.deadline.getTime() < Date.now()) {
     return res.reportError(
       'RequestConflict',
       'Task `{{taskId}}` can\'t be canceled past its deadline of ' +
@@ -1458,7 +1458,7 @@ builder.declare({
   // Don't claim tasks when worker is quarantined (but do record the worker
   // being seen, and be sure to wait the 20 seconds so as not to cause a
   // tight loop of claimWork calls from the worker
-  if (worker && worker.quarantineUntil.getTime() > new Date().getTime()) {
+  if (worker && worker.quarantineUntil.getTime() > Date.now()) {
     await Promise.all([
       this.workerInfo.seen(taskQueueId, workerGroup, workerId),
       sleep20Seconds(),
@@ -1558,7 +1558,7 @@ builder.declare({
   const worker = await Worker.get(this.db, task.taskQueueId, workerGroup, workerId, new Date());
 
   // Don't record task when worker is quarantined
-  if (worker && worker.quarantineUntil.getTime() > new Date().getTime()) {
+  if (worker && worker.quarantineUntil.getTime() > Date.now()) {
     return res.reply({});
   }
 

--- a/services/queue/src/artifacts.js
+++ b/services/queue/src/artifacts.js
@@ -414,7 +414,7 @@ export const loadArtifactsRoutes = (builder) => {
 
       case 's3': {
       // Reply with signed S3 URL
-        let expiry = new Date(new Date().getTime() + 45 * 60 * 1000);
+        let expiry = new Date(Date.now() + 45 * 60 * 1000);
         let bucket = null;
         if (artifact.details.bucket === this.publicBucket.bucket) {
           bucket = this.publicBucket;

--- a/services/queue/src/dependencytracker.js
+++ b/services/queue/src/dependencytracker.js
@@ -254,7 +254,7 @@ class DependencyTracker {
     }
 
     // Don't attempt to schedule tasks past their deadline
-    if (task.deadline.getTime() < new Date().getTime()) {
+    if (task.deadline.getTime() < Date.now()) {
       return null;
     }
 

--- a/services/queue/test/claimwork_test.js
+++ b/services/queue/test/claimwork_test.js
@@ -53,7 +53,7 @@ helper.secrets.mockSuite(testing.suiteName(), ['aws'], function(mock, skipping) 
       tasks: 2,
     });
     assert(result.tasks.length === 0, 'Did not expect any claims');
-    assert(new Date() - started >= 20 * 1000, 'Expected 20s sleep');
+    assert(Date.now() - started >= 20 * 1000, 'Expected 20s sleep');
   });
 
   test('claimWork requires scopes', async () => {

--- a/services/queue/test/queueservice_test.js
+++ b/services/queue/test/queueservice_test.js
@@ -60,7 +60,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
     const taskId = slugid.v4();
     const taskGroupId = slugid.v4();
     const schedulerId = slugid.v4();
-    const deadline = new Date(new Date().getTime() + 1 * 1000);
+    const deadline = new Date(Date.now() + 1 * 1000);
     debug('Putting message with taskId: %s, taskGroupId: %s', taskId, taskGroupId);
     // Put message
     await queueService.putDeadlineMessage(taskId, taskGroupId, schedulerId, deadline);
@@ -86,7 +86,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
 
   test('putClaimMessage, pollClaimQueue', async () => {
     const taskId = slugid.v4();
-    const takenUntil = new Date(new Date().getTime() + 2 * 1000);
+    const takenUntil = new Date(Date.now() + 2 * 1000);
     debug('Putting message with taskId: %s', taskId);
     // Put message
     await queueService.putClaimMessage(taskId, 0, takenUntil, 'tq/id', 'wg', 'wi');
@@ -117,7 +117,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
     debug('Putting message with taskId: %s, taskGroupId: %s', taskId, taskGroupId);
 
     // when task is resolved, existing claim and pending message should be removed
-    const futureDate = new Date(new Date().getTime() + 24 * 60 * 1000);
+    const futureDate = new Date(Date.now() + 24 * 60 * 1000);
     await queueService.putClaimMessage(taskId, 0, futureDate, 'tq/id', 'wg', 'wi');
     await queueService.putDeadlineMessage(taskId, taskGroupId, schedulerId, futureDate);
     await queueService.putPendingMessage({ taskId, taskGroupId, deadline: futureDate, taskQueueId: 't/q' }, 0);
@@ -171,7 +171,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       taskId: taskId,
       taskQueueId: `${provisionerId}/${workerType}`,
       priority: 'lowest',
-      deadline: new Date(new Date().getTime() + 5 * 60 * 1000),
+      deadline: new Date(Date.now() + 5 * 60 * 1000),
     };
 
     // Put message into pending queue

--- a/services/queue/test/retry_test.js
+++ b/services/queue/test/retry_test.js
@@ -43,7 +43,7 @@ helper.secrets.mockSuite(testing.suiteName(), ['aws'], function(mock, skipping) 
       workerGroup: 'my-worker-group-extended-extended',
       workerId: 'my-worker-extended-extended',
     });
-    debug(`claimed until ${r2.takenUntil}, ${new Date(r2.takenUntil) - new Date()}ms from now`);
+    debug(`claimed until ${r2.takenUntil}, ${new Date(r2.takenUntil) - Date.now()}ms from now`);
     helper.assertPulseMessage('task-running');
 
     debug('### Start claim-resolver');
@@ -72,7 +72,7 @@ helper.secrets.mockSuite(testing.suiteName(), ['aws'], function(mock, skipping) 
       workerId: 'my-worker-extended-extended',
     });
     assume(r4.status.retriesLeft).equals(0);
-    debug(`claimed until ${r4.takenUntil}, ${new Date(r2.takenUntil) - new Date()}ms from now`);
+    debug(`claimed until ${r4.takenUntil}, ${new Date(r2.takenUntil) - Date.now()}ms from now`);
 
     debug('### Start claimResolver (again)');
     await helper.startPollingService('claim-resolver');

--- a/services/queue/test/workerinfo_test.js
+++ b/services/queue/test/workerinfo_test.js
@@ -567,7 +567,7 @@ helper.secrets.mockSuite(testing.suiteName(), ['aws'], function(mock, skipping) 
     let [provisionerId, workerType] = tQueue.taskQueueId.split('/');
     result = await helper.queue.getWorkerType(provisionerId, workerType);
 
-    assert(Math.abs(new Date(result.lastDateActive) - new Date()) < 3600);
+    assert(Math.abs(new Date(result.lastDateActive) - Date.now()) < 3600);
   });
 
   test('provisioner lastDateActive updates', async () => {
@@ -581,7 +581,7 @@ helper.secrets.mockSuite(testing.suiteName(), ['aws'], function(mock, skipping) 
     let { provisionerId } = splitTaskQueueId(tQueue.taskQueueId);
     result = await helper.queue.getProvisioner(provisionerId);
 
-    assert(Math.abs(new Date(result.lastDateActive) - new Date()) < 3600);
+    assert(Math.abs(new Date(result.lastDateActive) - Date.now()) < 3600);
   });
 
   test('queue.getWorker returns a worker', async () => {

--- a/services/web-server/src/login/strategies/mozilla-auth0.js
+++ b/services/web-server/src/login/strategies/mozilla-auth0.js
@@ -42,7 +42,7 @@ export default class MozillaAuth0 {
       access_token: accessToken,
       expires_in: expiresIn,
     } = JSON.parse(res.text);
-    const expires = new Date().getTime() + (expiresIn * 1000);
+    const expires = Date.now() + (expiresIn * 1000);
 
     if (!accessToken) {
       throw new Error('did not receive a token from Auth0 /oauth/token endpoint');
@@ -53,7 +53,7 @@ export default class MozillaAuth0 {
 
   get isTokenExpired() {
     const offset = 10 * 60 * 1000; // expire a bit earlier to be safe
-    return this._personApiExp - offset < new Date().getTime();
+    return this._personApiExp - offset < Date.now();
   }
 
   async getPersonApi() {

--- a/services/web-server/test/login_strategies_mozilla_auth0_test.js
+++ b/services/web-server/test/login_strategies_mozilla_auth0_test.js
@@ -139,7 +139,7 @@ suite(testing.suiteName(), () => {
     strategy.fetchAccessToken = () => {
       return {
         accessToken: 'fakeToken',
-        expires: new Date().getTime() + 60 * 1000,
+        expires: Date.now() + 60 * 1000,
       };
     };
   });
@@ -201,7 +201,7 @@ suite(testing.suiteName(), () => {
       let calls = 0;
       sinon.stub(strategy, 'fetchAccessToken').callsFake(() => {
         calls++;
-        return { accessToken: `a_${calls}`, expires: new Date().getTime() + 24 * 60 * 60 * 1000 };
+        return { accessToken: `a_${calls}`, expires: Date.now() + 24 * 60 * 60 * 1000 };
       });
 
       await strategy.userFromIdentity('mozilla-auth0/ad|Mozilla-LDAP|tcperson');
@@ -213,7 +213,7 @@ suite(testing.suiteName(), () => {
       let calls = 0;
       sinon.stub(strategy, 'fetchAccessToken').callsFake(() => {
         calls++;
-        return { accessToken: `b_${calls}`, expires: new Date().getTime() + 9 * 60 * 1000 };
+        return { accessToken: `b_${calls}`, expires: Date.now() + 9 * 60 * 1000 };
       });
 
       await strategy.userFromIdentity('mozilla-auth0/ad|Mozilla-LDAP|tcperson');

--- a/services/worker-manager/test/api_test.js
+++ b/services/worker-manager/test/api_test.js
@@ -1977,8 +1977,8 @@ helper.secrets.mockSuite(testing.suiteName(), [], function (mock, skipping) {
         secret: firstResponse.secret,
       });
 
-      assert(new Date(secondResponse.expires) - new Date() > reregistrationTimeout - 250);
-      assert(new Date(secondResponse.expires) - new Date() < reregistrationTimeout + 250);
+      assert(new Date(secondResponse.expires) - Date.now() > reregistrationTimeout - 250);
+      assert(new Date(secondResponse.expires) - Date.now() < reregistrationTimeout + 250);
       assert.equal(firstResponse.credentials.clientId, secondResponse.credentials.clientId);
       assert.notStrictEqual(firstResponse.secret, secondResponse.secret);
 
@@ -1996,8 +1996,8 @@ helper.secrets.mockSuite(testing.suiteName(), [], function (mock, skipping) {
         secret: secondResponse.secret,
       });
 
-      assert(new Date(thirdResponse.expires) - new Date() > reregistrationTimeout - 250);
-      assert(new Date(thirdResponse.expires) - new Date() < reregistrationTimeout + 250);
+      assert(new Date(thirdResponse.expires) - Date.now() > reregistrationTimeout - 250);
+      assert(new Date(thirdResponse.expires) - Date.now() < reregistrationTimeout + 250);
       assert.equal(secondResponse.credentials.clientId, thirdResponse.credentials.clientId);
       assert.notStrictEqual(secondResponse.secret, thirdResponse.secret);
 

--- a/services/worker-manager/test/provider_aws_test.js
+++ b/services/worker-manager/test/provider_aws_test.js
@@ -435,8 +435,8 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       };
 
       const resp = await provider.registerWorker({ worker: runningWorker, workerPool, workerIdentityProof });
-      assert(resp.expires - new Date() + 10000 > 96 * 3600 * 1000);
-      assert(resp.expires - new Date() - 10000 < 96 * 3600 * 1000);
+      assert(resp.expires - Date.now() + 10000 > 96 * 3600 * 1000);
+      assert(resp.expires - Date.now() - 10000 < 96 * 3600 * 1000);
       assert.equal(resp.workerConfig.someConfig, 'someConfigValue');
       helper.assertPulseMessage('worker-running', m => m.payload.workerId === runningWorker.workerId);
       helper.assertPulseMessage('worker-running', m => m.payload.launchConfigId === runningWorker.launchConfigId);
@@ -469,8 +469,8 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       };
 
       const resp = await provider.registerWorker({ worker: runningWorker, workerPool, workerIdentityProof });
-      assert(resp.expires - new Date() + 10000 > 10 * 3600 * 1000);
-      assert(resp.expires - new Date() - 10000 < 10 * 3600 * 1000);
+      assert(resp.expires - Date.now() + 10000 > 10 * 3600 * 1000);
+      assert(resp.expires - Date.now() - 10000 < 10 * 3600 * 1000);
       assert.equal(resp.workerConfig.someKey, 'someValue');
       helper.assertPulseMessage('worker-running', m => m.payload.workerId === runningWorker.workerId);
       helper.assertPulseMessage('worker-running', m => m.payload.launchConfigId === runningWorker.launchConfigId);

--- a/services/worker-manager/test/provider_azure_test.js
+++ b/services/worker-manager/test/provider_azure_test.js
@@ -2972,8 +2972,8 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
           const workerIdentityProof = { document: azureSignatures[0].document };
           const res = await provider.registerWorker({ workerPool, worker, workerIdentityProof });
           // allow +- 10 seconds since time passes while the test executes
-          assert(res.expires - new Date() + 10000 > 96 * 3600 * 1000, res.expires);
-          assert(res.expires - new Date() - 10000 < 96 * 3600 * 1000, res.expires);
+          assert(res.expires - Date.now() + 10000 > 96 * 3600 * 1000, res.expires);
+          assert(res.expires - Date.now() - 10000 < 96 * 3600 * 1000, res.expires);
           assert.equal(res.workerConfig.someKey, 'someValue');
         });
 
@@ -2996,8 +2996,8 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
           const workerIdentityProof = { document: azureSignatures[0].document };
           const res = await provider.registerWorker({ workerPool, worker, workerIdentityProof });
           // allow +- 10 seconds since time passes while the test executes
-          assert(res.expires - new Date() + 10000 > 10 * 3600 * 1000, res.expires);
-          assert(res.expires - new Date() - 10000 < 10 * 3600 * 1000, res.expires);
+          assert(res.expires - Date.now() + 10000 > 10 * 3600 * 1000, res.expires);
+          assert(res.expires - Date.now() - 10000 < 10 * 3600 * 1000, res.expires);
           assert.equal(res.workerConfig.someKey, 'someValue');
           helper.assertPulseMessage('worker-running', m => m.payload.workerId === worker.workerId);
           helper.assertPulseMessage('worker-running', m => m.payload.launchConfigId === worker.launchConfigId);
@@ -3021,8 +3021,8 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
 
           const res = await provider.registerWorker({ workerPool, worker, workerIdentityProof });
           // allow +- 10 seconds since time passes while the test executes
-          assert(res.expires - new Date() + 10000 > 96 * 3600 * 1000, res.expires);
-          assert(res.expires - new Date() - 10000 < 96 * 3600 * 1000, res.expires);
+          assert(res.expires - Date.now() + 10000 > 96 * 3600 * 1000, res.expires);
+          assert(res.expires - Date.now() - 10000 < 96 * 3600 * 1000, res.expires);
           assert.equal(res.workerConfig.someKey, 'someValue');
 
           let log0 = monitor.manager.messages[0];

--- a/services/worker-manager/test/provider_google_test.js
+++ b/services/worker-manager/test/provider_google_test.js
@@ -214,7 +214,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       const worker = workers[0];
       // Check that this is setting times correctly to within a second or so to allow for some time
       // for the provisioning loop
-      assert(worker.providerData.terminateAfter - new Date() - (6000 * 1000) < 5000);
+      assert(worker.providerData.terminateAfter - Date.now() - (6000 * 1000) < 5000);
     });
 
     provisionTest('queueInactivityTimeout', {
@@ -813,8 +813,8 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       const workerIdentityProof = { token: 'good' };
       const res = await provider.registerWorker({ workerPool, worker, workerIdentityProof });
       // allow +- 10 seconds since time passes while the test executes
-      assert(res.expires - new Date() + 10000 > 96 * 3600 * 1000, res.expires);
-      assert(res.expires - new Date() - 10000 < 96 * 3600 * 1000, res.expires);
+      assert(res.expires - Date.now() + 10000 > 96 * 3600 * 1000, res.expires);
+      assert(res.expires - Date.now() - 10000 < 96 * 3600 * 1000, res.expires);
       assert.equal(res.workerConfig.someKey, 'someValue');
       helper.assertPulseMessage('worker-running', m => m.payload.workerId === worker.workerId);
     });
@@ -833,8 +833,8 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       const workerIdentityProof = { token: 'good' };
       const res = await provider.registerWorker({ workerPool, worker, workerIdentityProof });
       // allow +- 10 seconds since time passes while the test executes
-      assert(res.expires - new Date() + 10000 > 10 * 3600 * 1000, res.expires);
-      assert(res.expires - new Date() - 10000 < 10 * 3600 * 1000, res.expires);
+      assert(res.expires - Date.now() + 10000 > 10 * 3600 * 1000, res.expires);
+      assert(res.expires - Date.now() - 10000 < 10 * 3600 * 1000, res.expires);
       assert.equal(res.workerConfig.someKey, 'someValue');
       helper.assertPulseMessage('worker-running', m => m.payload.workerId === worker.workerId);
       helper.assertPulseMessage('worker-running', m => m.payload.launchConfigId === worker.launchConfigId);


### PR DESCRIPTION
This avoids allocating objects just to get the current time and fixes biome's `useDateNow` lint

