### PR TITLE
Use triple equals instead of double ones

### DIFF
--- a/changelog/IGKFHwKWTbqo9LnyC_x-dQ.md
+++ b/changelog/IGKFHwKWTbqo9LnyC_x-dQ.md
@@ -1,0 +1,2 @@
+level: silent
+---

--- a/libraries/pulse/src/publisher.js
+++ b/libraries/pulse/src/publisher.js
@@ -156,7 +156,7 @@ export class Entry {
       }
 
       // Check that we have a maxSize
-      assert(typeof key.maxSize == 'number' && key.maxSize > 0,
+      assert(typeof key.maxSize === 'number' && key.maxSize > 0,
         `routingKey declaration ${key.name} must have maxSize > 0`);
 
       // Check size left in routingKey space

--- a/libraries/validate/src/util.js
+++ b/libraries/validate/src/util.js
@@ -13,7 +13,7 @@ export function renderConstants(schema, constants) {
 
     // Check if there is a key and only one key
     let key = val.$const;
-    if (key === undefined || typeof key != 'string' || _.keys(val).length !== 1) {
+    if (key === undefined || typeof key !== 'string' || _.keys(val).length !== 1) {
       return undefined;
     }
 

--- a/services/auth/test/signaturevalidator_test.js
+++ b/services/auth/test/signaturevalidator_test.js
@@ -62,7 +62,7 @@ suite(testing.suiteName(), function() {
   let makeTest = function(name, input, expected) {
     test(name, async function() {
       // defer creation of input until the test runs, if necessary
-      if (typeof input == 'function') {
+      if (typeof input === 'function') {
         input = input();
       }
 


### PR DESCRIPTION
This is because javascript is awesome and `==` isn't at all a footgun that would coerce things around 17 times to try and match types. Anyway, those were not hiding any bugs as typeof always returns a string, but biome flagged them anyway just in case and it's free to fix them
