### PR TITLE
Always provide the base when using parseInt

### DIFF
--- a/changelog/S4iN2MfSSJOozCEuPXr29w.md
+++ b/changelog/S4iN2MfSSJOozCEuPXr29w.md
@@ -1,0 +1,2 @@
+level: silent
+---

--- a/db/src/versions.js
+++ b/db/src/versions.js
@@ -54,7 +54,7 @@ export const renumberVersions = async (fromVersion, toVersion, opts = {}) => {
   let versionContent = fs.readFileSync(fromVersionFile, 'utf8');
   const version = yaml.load(versionContent);
 
-  versionContent = versionContent.replace(/^version: \d+/, `version: ${parseInt(toVersion)}`);
+  versionContent = versionContent.replace(/^version: \d+/, `version: ${parseInt(toVersion, 10)}`);
 
   if (version.migrationScript && !version.migrationScript.includes('\n')) {
     const newMigrationScript = version.migrationScript.replace(fromVersion, toVersion);
@@ -146,7 +146,7 @@ export const newVersion = async (options = { runGit: true }) => {
   // find latest version
   const versions = fs.readdirSync(filePath(''));
   const latestVersion = versions.filter(name => name.endsWith('.yml')).sort().pop()?.replace(/\.yml$/, '');
-  const nextVersion = parseInt(latestVersion || '0') + 1;
+  const nextVersion = parseInt(latestVersion || '0', 10) + 1;
   const newVersion = nextVersion.toString().padStart(4, '0');
 
   const newVersionFile = filePath(`${newVersion}.yml`);

--- a/db/test/versions/0008_test.js
+++ b/db/test/versions/0008_test.js
@@ -5,7 +5,7 @@ import { strict as assert } from 'assert';
 import * as hugeBufs from './fixtures/huge_bufs.js';
 
 const ASCII = _.range(1, 128).map(i => String.fromCharCode(i)).join(' ');
-const THIS_VERSION = parseInt(/.*\/0*(\d+)_test\.js/.exec(import.meta.url)[1]);
+const THIS_VERSION = parseInt(/.*\/0*(\d+)_test\.js/.exec(import.meta.url)[1], 10);
 
 // (copied from azure-entities)
 const encodeStringKey = function(str) {

--- a/db/test/versions/0009_test.js
+++ b/db/test/versions/0009_test.js
@@ -2,7 +2,7 @@ import _ from 'lodash';
 import helper from '../helper.js';
 import testing from '@taskcluster/lib-testing';
 
-const THIS_VERSION = parseInt(/.*\/0*(\d+)_test\.js/.exec(import.meta.url)[1]);
+const THIS_VERSION = parseInt(/.*\/0*(\d+)_test\.js/.exec(import.meta.url)[1], 10);
 const PREV_VERSION = THIS_VERSION - 1;
 
 suite(testing.suiteName(), function() {

--- a/db/test/versions/0010_test.js
+++ b/db/test/versions/0010_test.js
@@ -4,7 +4,7 @@ import testing from '@taskcluster/lib-testing';
 import * as hugeBufs from './fixtures/huge_bufs.js';
 import { entityBufDecodeTest } from './0008_test.js';
 
-const THIS_VERSION = parseInt(/.*\/0*(\d+)_test\.js/.exec(import.meta.url)[1]);
+const THIS_VERSION = parseInt(/.*\/0*(\d+)_test\.js/.exec(import.meta.url)[1], 10);
 const PREV_VERSION = THIS_VERSION - 1;
 
 suite(testing.suiteName(), function() {

--- a/db/test/versions/0011_test.js
+++ b/db/test/versions/0011_test.js
@@ -1,7 +1,7 @@
 import helper from '../helper.js';
 import testing from '@taskcluster/lib-testing';
 
-const THIS_VERSION = parseInt(/.*\/0*(\d+)_test\.js/.exec(import.meta.url)[1]);
+const THIS_VERSION = parseInt(/.*\/0*(\d+)_test\.js/.exec(import.meta.url)[1], 10);
 const PREV_VERSION = THIS_VERSION - 1;
 
 suite(testing.suiteName(), function() {

--- a/db/test/versions/0012_test.js
+++ b/db/test/versions/0012_test.js
@@ -2,7 +2,7 @@ import _ from 'lodash';
 import helper from '../helper.js';
 import testing from '@taskcluster/lib-testing';
 
-const THIS_VERSION = parseInt(/.*\/0*(\d+)_test\.js/.exec(import.meta.url)[1]);
+const THIS_VERSION = parseInt(/.*\/0*(\d+)_test\.js/.exec(import.meta.url)[1], 10);
 const PREV_VERSION = THIS_VERSION - 1;
 
 suite(testing.suiteName(), function() {

--- a/db/test/versions/0014_test.js
+++ b/db/test/versions/0014_test.js
@@ -2,7 +2,7 @@ import { strict as assert } from 'assert';
 import helper from '../helper.js';
 import testing from '@taskcluster/lib-testing';
 
-const THIS_VERSION = parseInt(/.*\/0*(\d+)_test\.js/.exec(import.meta.url)[1]);
+const THIS_VERSION = parseInt(/.*\/0*(\d+)_test\.js/.exec(import.meta.url)[1], 10);
 const PREV_VERSION = THIS_VERSION - 1;
 
 suite(testing.suiteName(), function() {

--- a/db/test/versions/0015_test.js
+++ b/db/test/versions/0015_test.js
@@ -4,7 +4,7 @@ import { strict as assert } from 'assert';
 import crypto from 'crypto';
 
 suite(testing.suiteName(), function() {
-  const THIS_VERSION = parseInt(/.*\/0*(\d+)_test\.js/.exec(import.meta.url)[1]);
+  const THIS_VERSION = parseInt(/.*\/0*(\d+)_test\.js/.exec(import.meta.url)[1], 10);
   helper.withDbForVersion();
 
   suiteSetup(async function() {

--- a/db/test/versions/0016_test.js
+++ b/db/test/versions/0016_test.js
@@ -5,7 +5,7 @@ import { strict as assert } from 'assert';
 import slugid from 'slugid';
 
 suite(testing.suiteName(), function() {
-  const THIS_VERSION = parseInt(/.*\/0*(\d+)_test\.js/.exec(import.meta.url)[1]);
+  const THIS_VERSION = parseInt(/.*\/0*(\d+)_test\.js/.exec(import.meta.url)[1], 10);
   helper.withDbForVersion();
 
   suiteSetup(async function() {

--- a/db/test/versions/0017_test.js
+++ b/db/test/versions/0017_test.js
@@ -2,7 +2,7 @@ import _ from 'lodash';
 import helper from '../helper.js';
 import testing from '@taskcluster/lib-testing';
 
-const THIS_VERSION = parseInt(/.*\/0*(\d+)_test\.js/.exec(import.meta.url)[1]);
+const THIS_VERSION = parseInt(/.*\/0*(\d+)_test\.js/.exec(import.meta.url)[1], 10);
 const PREV_VERSION = THIS_VERSION - 1;
 
 suite(testing.suiteName(), function() {

--- a/db/test/versions/0018_test.js
+++ b/db/test/versions/0018_test.js
@@ -2,7 +2,7 @@ import _ from 'lodash';
 import helper from '../helper.js';
 import testing from '@taskcluster/lib-testing';
 
-const THIS_VERSION = parseInt(/.*\/0*(\d+)_test\.js/.exec(import.meta.url)[1]);
+const THIS_VERSION = parseInt(/.*\/0*(\d+)_test\.js/.exec(import.meta.url)[1], 10);
 const PREV_VERSION = THIS_VERSION - 1;
 
 suite(`${testing.suiteName()}`, function() {

--- a/db/test/versions/0019_test.js
+++ b/db/test/versions/0019_test.js
@@ -2,7 +2,7 @@ import _ from 'lodash';
 import helper from '../helper.js';
 import testing from '@taskcluster/lib-testing';
 
-const THIS_VERSION = parseInt(/.*\/0*(\d+)_test\.js/.exec(import.meta.url)[1]);
+const THIS_VERSION = parseInt(/.*\/0*(\d+)_test\.js/.exec(import.meta.url)[1], 10);
 const PREV_VERSION = THIS_VERSION - 1;
 
 suite(testing.suiteName(), function() {

--- a/db/test/versions/0020_test.js
+++ b/db/test/versions/0020_test.js
@@ -2,7 +2,7 @@ import _ from 'lodash';
 import helper from '../helper.js';
 import testing from '@taskcluster/lib-testing';
 
-const THIS_VERSION = parseInt(/.*\/0*(\d+)_test\.js/.exec(import.meta.url)[1]);
+const THIS_VERSION = parseInt(/.*\/0*(\d+)_test\.js/.exec(import.meta.url)[1], 10);
 const PREV_VERSION = THIS_VERSION - 1;
 
 suite(testing.suiteName(), function() {

--- a/db/test/versions/0021_test.js
+++ b/db/test/versions/0021_test.js
@@ -2,7 +2,7 @@ import _ from 'lodash';
 import helper from '../helper.js';
 import testing from '@taskcluster/lib-testing';
 
-const THIS_VERSION = parseInt(/.*\/0*(\d+)_test\.js/.exec(import.meta.url)[1]);
+const THIS_VERSION = parseInt(/.*\/0*(\d+)_test\.js/.exec(import.meta.url)[1], 10);
 const PREV_VERSION = THIS_VERSION - 1;
 
 suite(testing.suiteName(), function() {

--- a/db/test/versions/0022_test.js
+++ b/db/test/versions/0022_test.js
@@ -2,7 +2,7 @@ import _ from 'lodash';
 import helper from '../helper.js';
 import testing from '@taskcluster/lib-testing';
 
-const THIS_VERSION = parseInt(/.*\/0*(\d+)_test\.js/.exec(import.meta.url)[1]);
+const THIS_VERSION = parseInt(/.*\/0*(\d+)_test\.js/.exec(import.meta.url)[1], 10);
 const PREV_VERSION = THIS_VERSION - 1;
 
 suite(testing.suiteName(), function() {

--- a/db/test/versions/0023_test.js
+++ b/db/test/versions/0023_test.js
@@ -2,7 +2,7 @@ import _ from 'lodash';
 import helper from '../helper.js';
 import testing from '@taskcluster/lib-testing';
 
-const THIS_VERSION = parseInt(/.*\/0*(\d+)_test\.js/.exec(import.meta.url)[1]);
+const THIS_VERSION = parseInt(/.*\/0*(\d+)_test\.js/.exec(import.meta.url)[1], 10);
 const PREV_VERSION = THIS_VERSION - 1;
 
 suite(testing.suiteName(), function() {

--- a/db/test/versions/0025_test.js
+++ b/db/test/versions/0025_test.js
@@ -1,7 +1,7 @@
 import helper from '../helper.js';
 import testing from '@taskcluster/lib-testing';
 
-const THIS_VERSION = parseInt(/.*\/0*(\d+)_test\.js/.exec(import.meta.url)[1]);
+const THIS_VERSION = parseInt(/.*\/0*(\d+)_test\.js/.exec(import.meta.url)[1], 10);
 const PREV_VERSION = THIS_VERSION - 1;
 
 suite(`${testing.suiteName()} - roles`, function() {

--- a/db/test/versions/0027_test.js
+++ b/db/test/versions/0027_test.js
@@ -2,7 +2,7 @@ import _ from 'lodash';
 import helper from '../helper.js';
 import testing from '@taskcluster/lib-testing';
 
-const THIS_VERSION = parseInt(/.*\/0*(\d+)_test\.js/.exec(import.meta.url)[1]);
+const THIS_VERSION = parseInt(/.*\/0*(\d+)_test\.js/.exec(import.meta.url)[1], 10);
 const PREV_VERSION = THIS_VERSION - 1;
 
 // Since we don't migrate data from previous version, no need for tests for

--- a/db/test/versions/0029_test.js
+++ b/db/test/versions/0029_test.js
@@ -1,7 +1,7 @@
 import helper from '../helper.js';
 import testing from '@taskcluster/lib-testing';
 
-const THIS_VERSION = parseInt(/.*\/0*(\d+)_test\.js/.exec(import.meta.url)[1]);
+const THIS_VERSION = parseInt(/.*\/0*(\d+)_test\.js/.exec(import.meta.url)[1], 10);
 const PREV_VERSION = THIS_VERSION - 1;
 
 suite(testing.suiteName(), function() {

--- a/db/test/versions/0030_test.js
+++ b/db/test/versions/0030_test.js
@@ -4,7 +4,7 @@ import { strict as assert } from 'assert';
 import crypto from 'crypto';
 
 suite(testing.suiteName(), function() {
-  const THIS_VERSION = parseInt(/.*\/0*(\d+)_test\.js/.exec(import.meta.url)[1]);
+  const THIS_VERSION = parseInt(/.*\/0*(\d+)_test\.js/.exec(import.meta.url)[1], 10);
   helper.withDbForVersion();
 
   suiteSetup(async function() {

--- a/db/test/versions/0032_test.js
+++ b/db/test/versions/0032_test.js
@@ -1,7 +1,7 @@
 import helper from '../helper.js';
 import testing from '@taskcluster/lib-testing';
 
-const THIS_VERSION = parseInt(/.*\/0*(\d+)_test\.js/.exec(import.meta.url)[1]);
+const THIS_VERSION = parseInt(/.*\/0*(\d+)_test\.js/.exec(import.meta.url)[1], 10);
 const PREV_VERSION = THIS_VERSION - 1;
 
 suite(testing.suiteName(), function() {

--- a/db/test/versions/0033_test.js
+++ b/db/test/versions/0033_test.js
@@ -1,7 +1,7 @@
 import helper from '../helper.js';
 import testing from '@taskcluster/lib-testing';
 
-const THIS_VERSION = parseInt(/.*\/0*(\d+)_test\.js/.exec(import.meta.url)[1]);
+const THIS_VERSION = parseInt(/.*\/0*(\d+)_test\.js/.exec(import.meta.url)[1], 10);
 const PREV_VERSION = THIS_VERSION - 1;
 
 suite(testing.suiteName(), function() {

--- a/db/test/versions/0034_test.js
+++ b/db/test/versions/0034_test.js
@@ -2,7 +2,7 @@ import helper from '../helper.js';
 import testing from '@taskcluster/lib-testing';
 import { strict as assert } from 'assert';
 
-const THIS_VERSION = parseInt(/.*\/0*(\d+)_test\.js/.exec(import.meta.url)[1]);
+const THIS_VERSION = parseInt(/.*\/0*(\d+)_test\.js/.exec(import.meta.url)[1], 10);
 
 suite(testing.suiteName(), function() {
   helper.withDbForVersion();

--- a/db/test/versions/0035_test.js
+++ b/db/test/versions/0035_test.js
@@ -1,7 +1,7 @@
 import helper from '../helper.js';
 import testing from '@taskcluster/lib-testing';
 
-const THIS_VERSION = parseInt(/.*\/0*(\d+)_test\.js/.exec(import.meta.url)[1]);
+const THIS_VERSION = parseInt(/.*\/0*(\d+)_test\.js/.exec(import.meta.url)[1], 10);
 const PREV_VERSION = THIS_VERSION - 1;
 
 suite(testing.suiteName(), function() {

--- a/db/test/versions/0036_test.js
+++ b/db/test/versions/0036_test.js
@@ -1,7 +1,7 @@
 import helper from '../helper.js';
 import testing from '@taskcluster/lib-testing';
 
-const THIS_VERSION = parseInt(/.*\/0*(\d+)_test\.js/.exec(import.meta.url)[1]);
+const THIS_VERSION = parseInt(/.*\/0*(\d+)_test\.js/.exec(import.meta.url)[1], 10);
 const PREV_VERSION = THIS_VERSION - 1;
 
 suite(testing.suiteName(), function() {

--- a/db/test/versions/0037_test.js
+++ b/db/test/versions/0037_test.js
@@ -1,7 +1,7 @@
 import helper from '../helper.js';
 import testing from '@taskcluster/lib-testing';
 
-const THIS_VERSION = parseInt(/.*\/0*(\d+)_test\.js/.exec(import.meta.url)[1]);
+const THIS_VERSION = parseInt(/.*\/0*(\d+)_test\.js/.exec(import.meta.url)[1], 10);
 const PREV_VERSION = THIS_VERSION - 1;
 
 suite(testing.suiteName(), function() {

--- a/db/test/versions/0038_test.js
+++ b/db/test/versions/0038_test.js
@@ -2,7 +2,7 @@ import _ from 'lodash';
 import helper from '../helper.js';
 import testing from '@taskcluster/lib-testing';
 
-const THIS_VERSION = parseInt(/.*\/0*(\d+)_test\.js/.exec(import.meta.url)[1]);
+const THIS_VERSION = parseInt(/.*\/0*(\d+)_test\.js/.exec(import.meta.url)[1], 10);
 const PREV_VERSION = THIS_VERSION - 1;
 
 suite(testing.suiteName(), function() {

--- a/db/test/versions/0039_test.js
+++ b/db/test/versions/0039_test.js
@@ -1,7 +1,7 @@
 import helper from '../helper.js';
 import testing from '@taskcluster/lib-testing';
 
-const THIS_VERSION = parseInt(/.*\/0*(\d+)_test\.js/.exec(import.meta.url)[1]);
+const THIS_VERSION = parseInt(/.*\/0*(\d+)_test\.js/.exec(import.meta.url)[1], 10);
 const PREV_VERSION = THIS_VERSION - 1;
 
 suite(testing.suiteName(), function() {

--- a/db/test/versions/0040_test.js
+++ b/db/test/versions/0040_test.js
@@ -1,7 +1,7 @@
 import helper from '../helper.js';
 import testing from '@taskcluster/lib-testing';
 
-const THIS_VERSION = parseInt(/.*\/0*(\d+)_test\.js/.exec(import.meta.url)[1]);
+const THIS_VERSION = parseInt(/.*\/0*(\d+)_test\.js/.exec(import.meta.url)[1], 10);
 const PREV_VERSION = THIS_VERSION - 1;
 
 suite(testing.suiteName(), function() {

--- a/db/test/versions/0041_test.js
+++ b/db/test/versions/0041_test.js
@@ -2,7 +2,7 @@ import _ from 'lodash';
 import helper from '../helper.js';
 import testing from '@taskcluster/lib-testing';
 
-const THIS_VERSION = parseInt(/.*\/0*(\d+)_test\.js/.exec(import.meta.url)[1]);
+const THIS_VERSION = parseInt(/.*\/0*(\d+)_test\.js/.exec(import.meta.url)[1], 10);
 const PREV_VERSION = THIS_VERSION - 1;
 
 suite(`${testing.suiteName()}`, function() {

--- a/db/test/versions/0042_test.js
+++ b/db/test/versions/0042_test.js
@@ -1,7 +1,7 @@
 import helper from '../helper.js';
 import testing from '@taskcluster/lib-testing';
 
-const THIS_VERSION = parseInt(/.*\/0*(\d+)_test\.js/.exec(import.meta.url)[1]);
+const THIS_VERSION = parseInt(/.*\/0*(\d+)_test\.js/.exec(import.meta.url)[1], 10);
 const PREV_VERSION = THIS_VERSION - 1;
 
 suite(testing.suiteName(), function() {

--- a/db/test/versions/0043_test.js
+++ b/db/test/versions/0043_test.js
@@ -1,7 +1,7 @@
 import helper from '../helper.js';
 import testing from '@taskcluster/lib-testing';
 
-const THIS_VERSION = parseInt(/.*\/0*(\d+)_test\.js/.exec(import.meta.url)[1]);
+const THIS_VERSION = parseInt(/.*\/0*(\d+)_test\.js/.exec(import.meta.url)[1], 10);
 const PREV_VERSION = THIS_VERSION - 1;
 
 suite(testing.suiteName(), function() {

--- a/db/test/versions/0044_test.js
+++ b/db/test/versions/0044_test.js
@@ -1,7 +1,7 @@
 import helper from '../helper.js';
 import testing from '@taskcluster/lib-testing';
 
-const THIS_VERSION = parseInt(/.*\/0*(\d+)_test\.js/.exec(import.meta.url)[1]);
+const THIS_VERSION = parseInt(/.*\/0*(\d+)_test\.js/.exec(import.meta.url)[1], 10);
 const PREV_VERSION = THIS_VERSION - 1;
 
 suite(testing.suiteName(), function() {

--- a/db/test/versions/0045_test.js
+++ b/db/test/versions/0045_test.js
@@ -1,7 +1,7 @@
 import helper from '../helper.js';
 import testing from '@taskcluster/lib-testing';
 
-const THIS_VERSION = parseInt(/.*\/0*(\d+)_test\.js/.exec(import.meta.url)[1]);
+const THIS_VERSION = parseInt(/.*\/0*(\d+)_test\.js/.exec(import.meta.url)[1], 10);
 const PREV_VERSION = THIS_VERSION - 1;
 
 suite(testing.suiteName(), function() {

--- a/db/test/versions/0050_test.js
+++ b/db/test/versions/0050_test.js
@@ -3,7 +3,7 @@ import helper from '../helper.js';
 import assert from 'assert';
 import testing from '@taskcluster/lib-testing';
 
-const THIS_VERSION = parseInt(/.*\/0*(\d+)_test\.js/.exec(import.meta.url)[1]);
+const THIS_VERSION = parseInt(/.*\/0*(\d+)_test\.js/.exec(import.meta.url)[1], 10);
 
 suite(testing.suiteName(), function() {
   helper.withDbForVersion();

--- a/db/test/versions/0053_test.js
+++ b/db/test/versions/0053_test.js
@@ -2,7 +2,7 @@ import helper from '../helper.js';
 import assert from 'assert';
 import testing from '@taskcluster/lib-testing';
 
-const THIS_VERSION = parseInt(/.*\/0*(\d+)_test\.js/.exec(import.meta.url)[1]);
+const THIS_VERSION = parseInt(/.*\/0*(\d+)_test\.js/.exec(import.meta.url)[1], 10);
 const PREV_VERSION = THIS_VERSION - 1;
 
 suite(testing.suiteName(), function() {

--- a/db/test/versions/0054_test.js
+++ b/db/test/versions/0054_test.js
@@ -2,7 +2,7 @@ import _ from 'lodash';
 import helper from '../helper.js';
 import testing from '@taskcluster/lib-testing';
 
-const THIS_VERSION = parseInt(/.*\/0*(\d+)_test\.js/.exec(import.meta.url)[1]);
+const THIS_VERSION = parseInt(/.*\/0*(\d+)_test\.js/.exec(import.meta.url)[1], 10);
 const PREV_VERSION = THIS_VERSION - 1;
 
 suite(testing.suiteName(), function() {

--- a/db/test/versions/0056_test.js
+++ b/db/test/versions/0056_test.js
@@ -3,7 +3,7 @@ import { strict as assert } from 'assert';
 import helper from '../helper.js';
 import testing from '@taskcluster/lib-testing';
 
-const THIS_VERSION = parseInt(/.*\/0*(\d+)_test\.js/.exec(import.meta.url)[1]);
+const THIS_VERSION = parseInt(/.*\/0*(\d+)_test\.js/.exec(import.meta.url)[1], 10);
 
 suite(testing.suiteName(), function() {
   helper.withDbForVersion();

--- a/db/test/versions/0059_test.js
+++ b/db/test/versions/0059_test.js
@@ -4,7 +4,7 @@ import assert from 'assert';
 import testing from '@taskcluster/lib-testing';
 import { UNDEFINED_COLUMN } from '@taskcluster/lib-postgres';
 
-const THIS_VERSION = parseInt(/.*\/0*(\d+)_test\.js/.exec(import.meta.url)[1]);
+const THIS_VERSION = parseInt(/.*\/0*(\d+)_test\.js/.exec(import.meta.url)[1], 10);
 
 suite(testing.suiteName(), function() {
 
@@ -77,7 +77,7 @@ suite(testing.suiteName(), function() {
     concurrentCheck: async client => {
       // get number of rows to infer next task id
       const countRes = await client.query('select count(*) from tasks');
-      const nextTaskId = parseInt(countRes.rows[0].count) + 1;
+      const nextTaskId = parseInt(countRes.rows[0].count, 10) + 1;
 
       // check that get_task function works with items that may not yet have
       // task_queue_id during an upgrade

--- a/db/test/versions/0060_test.js
+++ b/db/test/versions/0060_test.js
@@ -4,7 +4,7 @@ import assert from 'assert';
 import testing from '@taskcluster/lib-testing';
 import { UNDEFINED_COLUMN } from '@taskcluster/lib-postgres';
 
-const THIS_VERSION = parseInt(/.*\/0*(\d+)_test\.js/.exec(import.meta.url)[1]);
+const THIS_VERSION = parseInt(/.*\/0*(\d+)_test\.js/.exec(import.meta.url)[1], 10);
 
 suite(testing.suiteName(), function() {
 
@@ -80,7 +80,7 @@ suite(testing.suiteName(), function() {
     concurrentCheck: async client => {
       // get number of rows to infer next task id
       const countRes = await client.query('select count(*) from tasks');
-      const nextTaskId = parseInt(countRes.rows[0].count) + 1;
+      const nextTaskId = parseInt(countRes.rows[0].count, 10) + 1;
 
       // check that get_task function works with items that may not yet have
       // provisioner_id and worker_type during a downgrade

--- a/db/test/versions/0063_test.js
+++ b/db/test/versions/0063_test.js
@@ -2,7 +2,7 @@ import testing from '@taskcluster/lib-testing';
 import helper from '../helper.js';
 import { strict as assert } from 'assert';
 
-const THIS_VERSION = parseInt(/.*\/0*(\d+)_test\.js/.exec(import.meta.url)[1]);
+const THIS_VERSION = parseInt(/.*\/0*(\d+)_test\.js/.exec(import.meta.url)[1], 10);
 
 suite(testing.suiteName(), function() {
   helper.withDbForVersion();

--- a/db/test/versions/0067_test.js
+++ b/db/test/versions/0067_test.js
@@ -1,7 +1,7 @@
 import helper from '../helper.js';
 import testing from '@taskcluster/lib-testing';
 
-const THIS_VERSION = parseInt(/.*\/0*(\d+)_test\.js/.exec(import.meta.url)[1]);
+const THIS_VERSION = parseInt(/.*\/0*(\d+)_test\.js/.exec(import.meta.url)[1], 10);
 const PREV_VERSION = THIS_VERSION - 1;
 
 suite(testing.suiteName(), function() {

--- a/db/test/versions/0072_test.js
+++ b/db/test/versions/0072_test.js
@@ -2,7 +2,7 @@ import _ from 'lodash';
 import helper from '../helper.js';
 import testing from '@taskcluster/lib-testing';
 
-const THIS_VERSION = parseInt(/.*\/0*(\d+)_test\.js/.exec(import.meta.url)[1]);
+const THIS_VERSION = parseInt(/.*\/0*(\d+)_test\.js/.exec(import.meta.url)[1], 10);
 const PREV_VERSION = THIS_VERSION - 1;
 
 suite(testing.suiteName(), function() {

--- a/db/test/versions/0079_test.js
+++ b/db/test/versions/0079_test.js
@@ -1,7 +1,7 @@
 import helper from '../helper.js';
 import testing from '@taskcluster/lib-testing';
 
-const THIS_VERSION = parseInt(/.*\/0*(\d+)_test\.js/.exec(import.meta.url)[1]);
+const THIS_VERSION = parseInt(/.*\/0*(\d+)_test\.js/.exec(import.meta.url)[1], 10);
 const PREV_VERSION = THIS_VERSION - 1;
 
 suite(testing.suiteName(), function() {

--- a/db/test/versions/0080_test.js
+++ b/db/test/versions/0080_test.js
@@ -3,7 +3,7 @@ import testing from '@taskcluster/lib-testing';
 import taskcluster from '@taskcluster/client';
 import helper from '../helper.js';
 
-const THIS_VERSION = parseInt(/.*\/0*(\d+)_test\.js/.exec(import.meta.url)[1]);
+const THIS_VERSION = parseInt(/.*\/0*(\d+)_test\.js/.exec(import.meta.url)[1], 10);
 const PREV_VERSION = THIS_VERSION - 1;
 
 suite(testing.suiteName(), function () {

--- a/db/test/versions/0081_test.js
+++ b/db/test/versions/0081_test.js
@@ -3,7 +3,7 @@ import helper from '../helper.js';
 import testing from '@taskcluster/lib-testing';
 import slugid from 'slugid';
 
-const THIS_VERSION = parseInt(/.*\/0*(\d+)_test\.js/.exec(import.meta.url)[1]);
+const THIS_VERSION = parseInt(/.*\/0*(\d+)_test\.js/.exec(import.meta.url)[1], 10);
 const PREV_VERSION = THIS_VERSION - 1;
 
 suite(testing.suiteName(), function() {

--- a/db/test/versions/0082_test.js
+++ b/db/test/versions/0082_test.js
@@ -3,7 +3,7 @@ import helper from '../helper.js';
 import testing from '@taskcluster/lib-testing';
 import slugid from 'slugid';
 
-const THIS_VERSION = parseInt(/.*\/0*(\d+)_test\.js/.exec(import.meta.url)[1]);
+const THIS_VERSION = parseInt(/.*\/0*(\d+)_test\.js/.exec(import.meta.url)[1], 10);
 
 suite(testing.suiteName(), function() {
   helper.withDbForVersion();

--- a/db/test/versions/0083_test.js
+++ b/db/test/versions/0083_test.js
@@ -3,7 +3,7 @@ import helper from '../helper.js';
 import testing from '@taskcluster/lib-testing';
 import taskcluster from '@taskcluster/client';
 
-const THIS_VERSION = parseInt(/.*\/0*(\d+)_test\.js/.exec(import.meta.url)[1]);
+const THIS_VERSION = parseInt(/.*\/0*(\d+)_test\.js/.exec(import.meta.url)[1], 10);
 const PREV_VERSION = THIS_VERSION - 1;
 
 suite(testing.suiteName(), function () {

--- a/db/test/versions/0085_test.js
+++ b/db/test/versions/0085_test.js
@@ -3,7 +3,7 @@ import helper from '../helper.js';
 import testing from '@taskcluster/lib-testing';
 import taskcluster from '@taskcluster/client';
 
-const THIS_VERSION = parseInt(/.*\/0*(\d+)_test\.js/.exec(import.meta.url)[1]);
+const THIS_VERSION = parseInt(/.*\/0*(\d+)_test\.js/.exec(import.meta.url)[1], 10);
 const PREV_VERSION = THIS_VERSION - 1;
 
 suite(testing.suiteName(), function () {

--- a/db/test/versions/0090_test.js
+++ b/db/test/versions/0090_test.js
@@ -1,7 +1,7 @@
 import helper from '../helper.js';
 import testing from '@taskcluster/lib-testing';
 
-const THIS_VERSION = parseInt(/.*\/0*(\d+)_test\.js/.exec(import.meta.url)[1]);
+const THIS_VERSION = parseInt(/.*\/0*(\d+)_test\.js/.exec(import.meta.url)[1], 10);
 const PREV_VERSION = THIS_VERSION - 1;
 
 suite(testing.suiteName(), function () {

--- a/db/test/versions/0091_test.js
+++ b/db/test/versions/0091_test.js
@@ -3,7 +3,7 @@ import helper from '../helper.js';
 import testing from '@taskcluster/lib-testing';
 import taskcluster from '@taskcluster/client';
 
-const THIS_VERSION = parseInt(/.*\/0*(\d+)_test\.js/.exec(import.meta.url)[1]);
+const THIS_VERSION = parseInt(/.*\/0*(\d+)_test\.js/.exec(import.meta.url)[1], 10);
 const PREV_VERSION = THIS_VERSION - 1;
 
 suite(testing.suiteName(), function () {

--- a/db/test/versions/0105_test.js
+++ b/db/test/versions/0105_test.js
@@ -2,7 +2,7 @@ import { strict as assert } from 'assert';
 import testing from '@taskcluster/lib-testing';
 import helper from '../helper.js';
 
-const THIS_VERSION = parseInt(/.*\/0*(\d+)_test\.js/.exec(import.meta.url)[1]);
+const THIS_VERSION = parseInt(/.*\/0*(\d+)_test\.js/.exec(import.meta.url)[1], 10);
 const PREV_VERSION = THIS_VERSION - 1;
 
 suite(testing.suiteName(), function () {

--- a/db/test/versions/0106_test.js
+++ b/db/test/versions/0106_test.js
@@ -1,7 +1,7 @@
 import helper from '../helper.js';
 import testing from '@taskcluster/lib-testing';
 
-const THIS_VERSION = parseInt(/.*\/0*(\d+)_test\.js/.exec(import.meta.url)[1]);
+const THIS_VERSION = parseInt(/.*\/0*(\d+)_test\.js/.exec(import.meta.url)[1], 10);
 const PREV_VERSION = THIS_VERSION - 1;
 
 suite(testing.suiteName(), function() {

--- a/db/test/versions/0112_test.js
+++ b/db/test/versions/0112_test.js
@@ -1,7 +1,7 @@
 import helper from '../helper.js';
 import testing from '@taskcluster/lib-testing';
 
-const THIS_VERSION = parseInt(/.*\/0*(\d+)_test\.js/.exec(import.meta.url)[1]);
+const THIS_VERSION = parseInt(/.*\/0*(\d+)_test\.js/.exec(import.meta.url)[1], 10);
 const PREV_VERSION = THIS_VERSION - 1;
 
 suite(testing.suiteName(), function() {

--- a/db/test/versions/0113_test.js
+++ b/db/test/versions/0113_test.js
@@ -3,7 +3,7 @@ import testing from '@taskcluster/lib-testing';
 import tc from '@taskcluster/client';
 import helper from '../helper.js';
 
-const THIS_VERSION = parseInt(/.*\/0*(\d+)_test\.js/.exec(import.meta.url)[1]);
+const THIS_VERSION = parseInt(/.*\/0*(\d+)_test\.js/.exec(import.meta.url)[1], 10);
 const PREV_VERSION = THIS_VERSION - 1;
 
 suite(testing.suiteName(), function () {

--- a/db/test/versions/0115_test.js
+++ b/db/test/versions/0115_test.js
@@ -1,7 +1,7 @@
 import helper from '../helper.js';
 import testing from '@taskcluster/lib-testing';
 
-const THIS_VERSION = parseInt(/.*\/0*(\d+)_test\.js/.exec(import.meta.url)[1]);
+const THIS_VERSION = parseInt(/.*\/0*(\d+)_test\.js/.exec(import.meta.url)[1], 10);
 const PREV_VERSION = THIS_VERSION - 1;
 
 suite(testing.suiteName(), function() {

--- a/db/test/versions/0121_test.js
+++ b/db/test/versions/0121_test.js
@@ -2,7 +2,7 @@ import assert from 'assert';
 import helper from '../helper.js';
 import testing from '@taskcluster/lib-testing';
 
-const THIS_VERSION = parseInt(/.*\/0*(\d+)_test\.js/.exec(import.meta.url)[1]);
+const THIS_VERSION = parseInt(/.*\/0*(\d+)_test\.js/.exec(import.meta.url)[1], 10);
 const PREV_VERSION = THIS_VERSION - 1;
 
 suite(testing.suiteName(), function() {

--- a/db/test/versions/0122_test.js
+++ b/db/test/versions/0122_test.js
@@ -3,7 +3,7 @@ import helper from '../helper.js';
 import testing from '@taskcluster/lib-testing';
 import taskcluster from '@taskcluster/client';
 
-const THIS_VERSION = parseInt(/.*\/0*(\d+)_test\.js/.exec(import.meta.url)[1]);
+const THIS_VERSION = parseInt(/.*\/0*(\d+)_test\.js/.exec(import.meta.url)[1], 10);
 
 suite(testing.suiteName(), function() {
   helper.withDbForVersion();

--- a/db/test/versions/0123_test.js
+++ b/db/test/versions/0123_test.js
@@ -3,7 +3,7 @@ import helper from '../helper.js';
 import testing from '@taskcluster/lib-testing';
 import taskcluster from '@taskcluster/client';
 
-const THIS_VERSION = parseInt(/.*\/0*(\d+)_test\.js/.exec(import.meta.url)[1]);
+const THIS_VERSION = parseInt(/.*\/0*(\d+)_test\.js/.exec(import.meta.url)[1], 10);
 const PREV_VERSION = THIS_VERSION - 1;
 
 suite(testing.suiteName(), function() {

--- a/db/test/versions/0124_test.js
+++ b/db/test/versions/0124_test.js
@@ -3,7 +3,7 @@ import helper from '../helper.js';
 import testing from '@taskcluster/lib-testing';
 import taskcluster from '@taskcluster/client';
 
-const THIS_VERSION = parseInt(/.*\/0*(\d+)_test\.js/.exec(import.meta.url)[1]);
+const THIS_VERSION = parseInt(/.*\/0*(\d+)_test\.js/.exec(import.meta.url)[1], 10);
 const PREV_VERSION = THIS_VERSION - 1;
 
 suite(testing.suiteName(), function() {

--- a/infrastructure/tooling/src/dev/index.js
+++ b/infrastructure/tooling/src/dev/index.js
@@ -74,7 +74,7 @@ export const dbUpgrade = async (options) => {
   const meta = userConfig.meta || {};
 
   const { dbVersion } = options;
-  const toVersion = dbVersion ? parseInt(dbVersion) : undefined;
+  const toVersion = dbVersion ? parseInt(dbVersion, 10) : undefined;
 
   const { adminDbUrl, usernamePrefix } = dbParams(meta);
   const showProgress = message => {
@@ -89,7 +89,7 @@ export const dbDowngrade = async (options) => {
   const meta = userConfig.meta || {};
 
   const { dbVersion } = options;
-  const toVersion = parseInt(dbVersion);
+  const toVersion = parseInt(dbVersion, 10);
   if (!dbVersion.match(/^[0-9]+$/) || isNaN(toVersion)) {
     throw new Error('Missing or invalid --db-version');
   }

--- a/services/worker-manager/src/api.js
+++ b/services/worker-manager/src/api.js
@@ -110,8 +110,8 @@ builder.declare({
     'Retrieve a list of providers that are available for worker pools.',
   ].join('\n'),
 }, function(req, res) {
-  const start = req.query.continuationToken ? parseInt(req.query.continuationToken) : 0;
-  const limit = req.query.limit ? parseInt(req.query.limit) : 100;
+  const start = req.query.continuationToken ? parseInt(req.query.continuationToken, 10) : 0;
+  const limit = req.query.limit ? parseInt(req.query.limit, 10) : 100;
 
   const providers = Object.entries(this.cfg.providers).map(([providerId, { providerType }]) => ({
     providerId,


### PR DESCRIPTION
This avoids javascript parsing strings as a wrong number instead of raising an exception and fixes biome's useParseIntRadix lint.

In practice all of those are internal except for the worker manager ones, and every single one of those should always be base 10 so behavior is unchanged
