### PR TITLE
Use `indexOf` instead of `findIndex`

### DIFF
--- a/changelog/Kn0VeqpdQnWJ4xxCJxWi4w.md
+++ b/changelog/Kn0VeqpdQnWJ4xxCJxWi4w.md
@@ -1,0 +1,2 @@
+level: silent
+---

--- a/services/web-server/test/login_scanner_test.js
+++ b/services/web-server/test/login_scanner_test.js
@@ -16,7 +16,7 @@ suite(testing.suiteName(), () => {
         // client name as the continuationToken
         let names = Object.keys(clients).filter(n => n.startsWith(prefix));
         if (continuationToken) {
-          names = names.slice(names.findIndex(n => n === continuationToken));
+          names = names.slice(names.indexOf(continuationToken));
         }
         if (names.length > 1) {
           continuationToken = names[1];


### PR DESCRIPTION
This fixes biome's `useIndexOf` lint, is a bit more explicit about what it's doing and is functionally identical.
