### PR TITLE
Fix typos in hooks triggerSchema and client docs

### DIFF
--- a/changelog/L7j346Q4RSOb688p7NZ2dg.md
+++ b/changelog/L7j346Q4RSOb688p7NZ2dg.md
@@ -1,0 +1,2 @@
+level: silent
+---

--- a/clients/client-go/tcauth/tcauth.go
+++ b/clients/client-go/tcauth/tcauth.go
@@ -919,7 +919,7 @@ func (auth *Auth) SentryDSN_SignedURL(project string, duration time.Duration) (*
 // [websocktunnel](https://github.com/taskcluster/taskcluster/tree/main/tools/websocktunnel) server.
 //
 // The resulting token will only be accepted by servers with a matching audience
-// value.  Reaching such a server is the callers responsibility.  In general,
+// value.  Reaching such a server is the caller's responsibility.  In general,
 // a server URL or set of URLs should be provided to the caller as configuration
 // along with the audience value.
 //

--- a/clients/client-go/tchooks/tchooks.go
+++ b/clients/client-go/tchooks/tchooks.go
@@ -281,7 +281,7 @@ func (hooks *Hooks) RemoveHook(hookGroupId, hookId string) error {
 
 // This endpoint will trigger the creation of a task from a hook definition.
 //
-// The HTTP payload must match the hooks `triggerSchema`.  If it does, it is
+// The HTTP payload must match the hook's `triggerSchema`.  If it does, it is
 // provided as the `payload` property of the JSON-e context used to render the
 // task template.
 //
@@ -341,7 +341,7 @@ func (hooks *Hooks) ResetTriggerToken(hookGroupId, hookId string) (*TriggerToken
 
 // This endpoint triggers a defined hook with a valid token.
 //
-// The HTTP payload must match the hooks `triggerSchema`.  If it does, it is
+// The HTTP payload must match the hook's `triggerSchema`.  If it does, it is
 // provided as the `payload` property of the JSON-e context used to render the
 // task template.
 //

--- a/clients/client-py/taskcluster/generated/aio/auth.py
+++ b/clients/client-py/taskcluster/generated/aio/auth.py
@@ -490,7 +490,7 @@ class Auth(AsyncBaseClient):
         [websocktunnel](https://github.com/taskcluster/taskcluster/tree/main/tools/websocktunnel) server.
 
         The resulting token will only be accepted by servers with a matching audience
-        value.  Reaching such a server is the callers responsibility.  In general,
+        value.  Reaching such a server is the caller's responsibility.  In general,
         a server URL or set of URLs should be provided to the caller as configuration
         along with the audience value.
 

--- a/clients/client-py/taskcluster/generated/aio/hooks.py
+++ b/clients/client-py/taskcluster/generated/aio/hooks.py
@@ -152,7 +152,7 @@ class Hooks(AsyncBaseClient):
 
         This endpoint will trigger the creation of a task from a hook definition.
 
-        The HTTP payload must match the hooks `triggerSchema`.  If it does, it is
+        The HTTP payload must match the hook's `triggerSchema`.  If it does, it is
         provided as the `payload` property of the JSON-e context used to render the
         task template.
 
@@ -198,7 +198,7 @@ class Hooks(AsyncBaseClient):
 
         This endpoint triggers a defined hook with a valid token.
 
-        The HTTP payload must match the hooks `triggerSchema`.  If it does, it is
+        The HTTP payload must match the hook's `triggerSchema`.  If it does, it is
         provided as the `payload` property of the JSON-e context used to render the
         task template.
 

--- a/clients/client-py/taskcluster/generated/auth.py
+++ b/clients/client-py/taskcluster/generated/auth.py
@@ -478,7 +478,7 @@ class Auth(BaseClient):
         [websocktunnel](https://github.com/taskcluster/taskcluster/tree/main/tools/websocktunnel) server.
 
         The resulting token will only be accepted by servers with a matching audience
-        value.  Reaching such a server is the callers responsibility.  In general,
+        value.  Reaching such a server is the caller's responsibility.  In general,
         a server URL or set of URLs should be provided to the caller as configuration
         along with the audience value.
 

--- a/clients/client-py/taskcluster/generated/hooks.py
+++ b/clients/client-py/taskcluster/generated/hooks.py
@@ -152,7 +152,7 @@ class Hooks(BaseClient):
 
         This endpoint will trigger the creation of a task from a hook definition.
 
-        The HTTP payload must match the hooks `triggerSchema`.  If it does, it is
+        The HTTP payload must match the hook's `triggerSchema`.  If it does, it is
         provided as the `payload` property of the JSON-e context used to render the
         task template.
 
@@ -194,7 +194,7 @@ class Hooks(BaseClient):
 
         This endpoint triggers a defined hook with a valid token.
 
-        The HTTP payload must match the hooks `triggerSchema`.  If it does, it is
+        The HTTP payload must match the hook's `triggerSchema`.  If it does, it is
         provided as the `payload` property of the JSON-e context used to render the
         task template.
 

--- a/clients/client-rust/client/src/generated/auth.rs
+++ b/clients/client-rust/client/src/generated/auth.rs
@@ -988,7 +988,7 @@ impl Auth {
     /// [websocktunnel](https://github.com/taskcluster/taskcluster/tree/main/tools/websocktunnel) server.
     ///
     /// The resulting token will only be accepted by servers with a matching audience
-    /// value.  Reaching such a server is the callers responsibility.  In general,
+    /// value.  Reaching such a server is the caller's responsibility.  In general,
     /// a server URL or set of URLs should be provided to the caller as configuration
     /// along with the audience value.
     ///

--- a/clients/client-rust/client/src/generated/hooks.rs
+++ b/clients/client-rust/client/src/generated/hooks.rs
@@ -323,7 +323,7 @@ impl Hooks {
     ///
     /// This endpoint will trigger the creation of a task from a hook definition.
     ///
-    /// The HTTP payload must match the hooks `triggerSchema`.  If it does, it is
+    /// The HTTP payload must match the hook's `triggerSchema`.  If it does, it is
     /// provided as the `payload` property of the JSON-e context used to render the
     /// task template.
     ///
@@ -401,7 +401,7 @@ impl Hooks {
     ///
     /// This endpoint triggers a defined hook with a valid token.
     ///
-    /// The HTTP payload must match the hooks `triggerSchema`.  If it does, it is
+    /// The HTTP payload must match the hook's `triggerSchema`.  If it does, it is
     /// provided as the `payload` property of the JSON-e context used to render the
     /// task template.
     ///

--- a/clients/client-shell/apis/services.go
+++ b/clients/client-shell/apis/services.go
@@ -401,7 +401,7 @@ var services = map[string]definitions.Service{
 			definitions.Entry{
 				Name:        "websocktunnelToken",
 				Title:       "Get a client token for the Websocktunnel service",
-				Description: "Get a temporary token suitable for use connecting to a\n[websocktunnel](https://github.com/taskcluster/taskcluster/tree/main/tools/websocktunnel) server.\n\nThe resulting token will only be accepted by servers with a matching audience\nvalue.  Reaching such a server is the callers responsibility.  In general,\na server URL or set of URLs should be provided to the caller as configuration\nalong with the audience value.\n\nThe token is valid for a limited time (on the scale of hours). Callers should\nrefresh it before expiration.",
+				Description: "Get a temporary token suitable for use connecting to a\n[websocktunnel](https://github.com/taskcluster/taskcluster/tree/main/tools/websocktunnel) server.\n\nThe resulting token will only be accepted by servers with a matching audience\nvalue.  Reaching such a server is the caller's responsibility.  In general,\na server URL or set of URLs should be provided to the caller as configuration\nalong with the audience value.\n\nThe token is valid for a limited time (on the scale of hours). Callers should\nrefresh it before expiration.",
 				Stability:   "stable",
 				Method:      "get",
 				Route:       "/websocktunnel/<wstAudience>/<wstClient>",
@@ -780,7 +780,7 @@ var services = map[string]definitions.Service{
 			definitions.Entry{
 				Name:        "triggerHook",
 				Title:       "Trigger a hook",
-				Description: "This endpoint will trigger the creation of a task from a hook definition.\n\nThe HTTP payload must match the hooks `triggerSchema`.  If it does, it is\nprovided as the `payload` property of the JSON-e context used to render the\ntask template.\n\nOptionally, a `taskId` can be provided in the payload which the hook task\nwill use. It must be unique and follow the slugid format.",
+				Description: "This endpoint will trigger the creation of a task from a hook definition.\n\nThe HTTP payload must match the hook's `triggerSchema`.  If it does, it is\nprovided as the `payload` property of the JSON-e context used to render the\ntask template.\n\nOptionally, a `taskId` can be provided in the payload which the hook task\nwill use. It must be unique and follow the slugid format.",
 				Stability:   "stable",
 				Method:      "post",
 				Route:       "/hooks/<hookGroupId>/<hookId>/trigger",
@@ -822,7 +822,7 @@ var services = map[string]definitions.Service{
 			definitions.Entry{
 				Name:        "triggerHookWithToken",
 				Title:       "Trigger a hook with a token",
-				Description: "This endpoint triggers a defined hook with a valid token.\n\nThe HTTP payload must match the hooks `triggerSchema`.  If it does, it is\nprovided as the `payload` property of the JSON-e context used to render the\ntask template.\n\nOptionally, a `taskId` can be provided in the payload which the hook task\nwill use. It must be unique and follow the slugid format.",
+				Description: "This endpoint triggers a defined hook with a valid token.\n\nThe HTTP payload must match the hook's `triggerSchema`.  If it does, it is\nprovided as the `payload` property of the JSON-e context used to render the\ntask template.\n\nOptionally, a `taskId` can be provided in the payload which the hook task\nwill use. It must be unique and follow the slugid format.",
 				Stability:   "stable",
 				Method:      "post",
 				Route:       "/hooks/<hookGroupId>/<hookId>/trigger/<token>",

--- a/clients/client-web/src/clients/Auth.js
+++ b/clients/client-web/src/clients/Auth.js
@@ -381,7 +381,7 @@ export default class Auth extends Client {
   // Get a temporary token suitable for use connecting to a
   // [websocktunnel](https://github.com/taskcluster/taskcluster/tree/main/tools/websocktunnel) server.
   // The resulting token will only be accepted by servers with a matching audience
-  // value.  Reaching such a server is the callers responsibility.  In general,
+  // value.  Reaching such a server is the caller's responsibility.  In general,
   // a server URL or set of URLs should be provided to the caller as configuration
   // along with the audience value.
   // The token is valid for a limited time (on the scale of hours). Callers should

--- a/clients/client-web/src/clients/Hooks.js
+++ b/clients/client-web/src/clients/Hooks.js
@@ -120,7 +120,7 @@ export default class Hooks extends Client {
   }
   /* eslint-disable max-len */
   // This endpoint will trigger the creation of a task from a hook definition.
-  // The HTTP payload must match the hooks `triggerSchema`.  If it does, it is
+  // The HTTP payload must match the hook's `triggerSchema`.  If it does, it is
   // provided as the `payload` property of the JSON-e context used to render the
   // task template.
   // Optionally, a `taskId` can be provided in the payload which the hook task
@@ -151,7 +151,7 @@ export default class Hooks extends Client {
   }
   /* eslint-disable max-len */
   // This endpoint triggers a defined hook with a valid token.
-  // The HTTP payload must match the hooks `triggerSchema`.  If it does, it is
+  // The HTTP payload must match the hook's `triggerSchema`.  If it does, it is
   // provided as the `payload` property of the JSON-e context used to render the
   // task template.
   // Optionally, a `taskId` can be provided in the payload which the hook task

--- a/clients/client/src/apis.js
+++ b/clients/client/src/apis.js
@@ -576,7 +576,7 @@ export default {
             "wstClient"
           ],
           "category": "Websocktunnel Credentials",
-          "description": "Get a temporary token suitable for use connecting to a\n[websocktunnel](https://github.com/taskcluster/taskcluster/tree/main/tools/websocktunnel) server.\n\nThe resulting token will only be accepted by servers with a matching audience\nvalue.  Reaching such a server is the callers responsibility.  In general,\na server URL or set of URLs should be provided to the caller as configuration\nalong with the audience value.\n\nThe token is valid for a limited time (on the scale of hours). Callers should\nrefresh it before expiration.",
+          "description": "Get a temporary token suitable for use connecting to a\n[websocktunnel](https://github.com/taskcluster/taskcluster/tree/main/tools/websocktunnel) server.\n\nThe resulting token will only be accepted by servers with a matching audience\nvalue.  Reaching such a server is the caller's responsibility.  In general,\na server URL or set of URLs should be provided to the caller as configuration\nalong with the audience value.\n\nThe token is valid for a limited time (on the scale of hours). Callers should\nrefresh it before expiration.",
           "method": "get",
           "name": "websocktunnelToken",
           "output": "v1/websocktunnel-token-response.json#",
@@ -1352,7 +1352,7 @@ export default {
             "hookId"
           ],
           "category": "Hooks",
-          "description": "This endpoint will trigger the creation of a task from a hook definition.\n\nThe HTTP payload must match the hooks `triggerSchema`.  If it does, it is\nprovided as the `payload` property of the JSON-e context used to render the\ntask template.\n\nOptionally, a `taskId` can be provided in the payload which the hook task\nwill use. It must be unique and follow the slugid format.",
+          "description": "This endpoint will trigger the creation of a task from a hook definition.\n\nThe HTTP payload must match the hook's `triggerSchema`.  If it does, it is\nprovided as the `payload` property of the JSON-e context used to render the\ntask template.\n\nOptionally, a `taskId` can be provided in the payload which the hook task\nwill use. It must be unique and follow the slugid format.",
           "input": "v1/trigger-hook.json#",
           "method": "post",
           "name": "triggerHook",
@@ -1408,7 +1408,7 @@ export default {
             "token"
           ],
           "category": "Hooks",
-          "description": "This endpoint triggers a defined hook with a valid token.\n\nThe HTTP payload must match the hooks `triggerSchema`.  If it does, it is\nprovided as the `payload` property of the JSON-e context used to render the\ntask template.\n\nOptionally, a `taskId` can be provided in the payload which the hook task\nwill use. It must be unique and follow the slugid format.",
+          "description": "This endpoint triggers a defined hook with a valid token.\n\nThe HTTP payload must match the hook's `triggerSchema`.  If it does, it is\nprovided as the `payload` property of the JSON-e context used to render the\ntask template.\n\nOptionally, a `taskId` can be provided in the payload which the hook task\nwill use. It must be unique and follow the slugid format.",
           "input": "v1/trigger-hook.json#",
           "method": "post",
           "name": "triggerHookWithToken",

--- a/generated/references.json
+++ b/generated/references.json
@@ -25861,7 +25861,7 @@
             "hookId"
           ],
           "category": "Hooks",
-          "description": "This endpoint will trigger the creation of a task from a hook definition.\n\nThe HTTP payload must match the hooks `triggerSchema`.  If it does, it is\nprovided as the `payload` property of the JSON-e context used to render the\ntask template.\n\nOptionally, a `taskId` can be provided in the payload which the hook task\nwill use. It must be unique and follow the slugid format.",
+          "description": "This endpoint will trigger the creation of a task from a hook definition.\n\nThe HTTP payload must match the hook's `triggerSchema`.  If it does, it is\nprovided as the `payload` property of the JSON-e context used to render the\ntask template.\n\nOptionally, a `taskId` can be provided in the payload which the hook task\nwill use. It must be unique and follow the slugid format.",
           "input": "v1/trigger-hook.json#",
           "method": "post",
           "name": "triggerHook",
@@ -25917,7 +25917,7 @@
             "token"
           ],
           "category": "Hooks",
-          "description": "This endpoint triggers a defined hook with a valid token.\n\nThe HTTP payload must match the hooks `triggerSchema`.  If it does, it is\nprovided as the `payload` property of the JSON-e context used to render the\ntask template.\n\nOptionally, a `taskId` can be provided in the payload which the hook task\nwill use. It must be unique and follow the slugid format.",
+          "description": "This endpoint triggers a defined hook with a valid token.\n\nThe HTTP payload must match the hook's `triggerSchema`.  If it does, it is\nprovided as the `payload` property of the JSON-e context used to render the\ntask template.\n\nOptionally, a `taskId` can be provided in the payload which the hook task\nwill use. It must be unique and follow the slugid format.",
           "input": "v1/trigger-hook.json#",
           "method": "post",
           "name": "triggerHookWithToken",
@@ -27963,7 +27963,7 @@
             "wstClient"
           ],
           "category": "Websocktunnel Credentials",
-          "description": "Get a temporary token suitable for use connecting to a\n[websocktunnel](https://github.com/taskcluster/taskcluster/tree/main/tools/websocktunnel) server.\n\nThe resulting token will only be accepted by servers with a matching audience\nvalue.  Reaching such a server is the callers responsibility.  In general,\na server URL or set of URLs should be provided to the caller as configuration\nalong with the audience value.\n\nThe token is valid for a limited time (on the scale of hours). Callers should\nrefresh it before expiration.",
+          "description": "Get a temporary token suitable for use connecting to a\n[websocktunnel](https://github.com/taskcluster/taskcluster/tree/main/tools/websocktunnel) server.\n\nThe resulting token will only be accepted by servers with a matching audience\nvalue.  Reaching such a server is the caller's responsibility.  In general,\na server URL or set of URLs should be provided to the caller as configuration\nalong with the audience value.\n\nThe token is valid for a limited time (on the scale of hours). Callers should\nrefresh it before expiration.",
           "method": "get",
           "name": "websocktunnelToken",
           "output": "v1/websocktunnel-token-response.json#",

--- a/services/auth/src/websocktunnel.js
+++ b/services/auth/src/websocktunnel.js
@@ -18,7 +18,7 @@ export const websocktunnelBuilder = builder => builder.declare({
     '[websocktunnel](https://github.com/taskcluster/taskcluster/tree/main/tools/websocktunnel) server.',
     '',
     'The resulting token will only be accepted by servers with a matching audience',
-    'value.  Reaching such a server is the caller\s responsibility.  In general,',
+    'value.  Reaching such a server is the caller\'s responsibility.  In general,',
     'a server URL or set of URLs should be provided to the caller as configuration',
     'along with the audience value.',
     '',

--- a/services/hooks/src/api.js
+++ b/services/hooks/src/api.js
@@ -478,7 +478,7 @@ builder.declare({
   description: [
     'This endpoint will trigger the creation of a task from a hook definition.',
     '',
-    'The HTTP payload must match the hook\s `triggerSchema`.  If it does, it is',
+    'The HTTP payload must match the hook\'s `triggerSchema`.  If it does, it is',
     'provided as the `payload` property of the JSON-e context used to render the',
     'task template.',
     '',
@@ -594,7 +594,7 @@ builder.declare({
   description: [
     'This endpoint triggers a defined hook with a valid token.',
     '',
-    'The HTTP payload must match the hook\s `triggerSchema`.  If it does, it is',
+    'The HTTP payload must match the hook\'s `triggerSchema`.  If it does, it is',
     'provided as the `payload` property of the JSON-e context used to render the',
     'task template.',
     '',


### PR DESCRIPTION
Found this because biome's unused escape lint was flashing red at the `\s` in both.