### PR TITLE
Make biome ignore the generated `env.js` file in the UI

### DIFF
--- a/changelog/R60fOL3ISSOB3t6ZN6PZsg.md
+++ b/changelog/R60fOL3ISSOB3t6ZN6PZsg.md
@@ -1,0 +1,2 @@
+level: silent
+---

--- a/ui/biome.json
+++ b/ui/biome.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://biomejs.dev/schemas/2.4.15/schema.json",
   "files": {
-    "includes": ["**/*.js", "**/*.jsx", "!**/test/e2e/**"]
+    "includes": ["**/*.js", "**/*.jsx", "!**/test/e2e/**", "!**/static/env.js"]
   },
   "formatter": {
     "enabled": true,


### PR DESCRIPTION
Otherwise it trips on the file when it gets reused from a previous generation (either locally or due to caching on CI).
