### PR TITLE
Fix typos where `,` was used instead of `;` as the end of line

### DIFF
--- a/changelog/R61vsEw-TUmEc_uNdQhFAg.md
+++ b/changelog/R61vsEw-TUmEc_uNdQhFAg.md
@@ -1,0 +1,2 @@
+level: silent
+---

--- a/libraries/api/test/responsetimer_test.js
+++ b/libraries/api/test/responsetimer_test.js
@@ -57,10 +57,10 @@ suite(testing.suiteName(), function() {
 
   test('single parameter', async function() {
     const u = path => libUrls.api(helper.rootUrl, 'test', 'v1', path);
-    await request.get(u('/single-param/Hello')),
-    await request.get(u('/single-param/Goodbye')),
-    await request.get(u('/slash-param/Slash')).catch(err => {}),
-    await request.get(u('/another-param/Another')).catch(err => {}),
+    await request.get(u('/single-param/Hello'));
+    await request.get(u('/single-param/Goodbye'));
+    await request.get(u('/slash-param/Slash')).catch(err => {});
+    await request.get(u('/another-param/Another')).catch(err => {});
     assert.equal(monitorManager.messages.length, 4);
     monitorManager.messages.forEach(event => {
       assert.equal(event.Type, 'monitor.apiMethod');

--- a/libraries/monitor/src/logger.js
+++ b/libraries/monitor/src/logger.js
@@ -118,7 +118,7 @@ export class Logger {
     if (fields === null || typeof fields === 'boolean') {
       level = LEVELS.err;
       const origType = type;
-      type = 'monitor.loggingError',
+      type = 'monitor.loggingError';
       fields = {
         error: 'Invalid field to be logged.',
         origType,
@@ -128,7 +128,7 @@ export class Logger {
     if (fields.meta !== undefined) {
       level = LEVELS.err;
       const origType = type;
-      type = 'monitor.loggingError',
+      type = 'monitor.loggingError';
       fields = {
         error: 'You may not set meta fields on logs directly.',
         origType,


### PR DESCRIPTION
This fixes biome's `noCommaOperator` lint. Those typos didn't hide any bug and behavior is unchanged.