### PR TITLE
Remove an accumulating spread in web-server

### DIFF
--- a/changelog/E4xW5Sv5RoiXZAX9oAwCmg.md
+++ b/changelog/E4xW5Sv5RoiXZAX9oAwCmg.md
@@ -1,0 +1,2 @@
+level: silent
+---

--- a/services/web-server/src/loaders/index.js
+++ b/services/web-server/src/loaders/index.js
@@ -37,10 +37,7 @@ const loaders = [
 ];
 
 export default (clients, isAuthed, rootUrl, monitor, strategies, req, cfg, requestId, traceId) =>
-  loaders.reduce(
-    (loaders, loader) => ({
-      ...loaders,
-      ...loader(clients, isAuthed, rootUrl, monitor, strategies, req, cfg, requestId, traceId),
-    }),
+  Object.assign(
     {},
+    ...loaders.map(loader => loader(clients, isAuthed, rootUrl, monitor, strategies, req, cfg, requestId, traceId)),
   );


### PR DESCRIPTION
This avoid having reduce copy the accumulator over and over again. Given the code was just iterating over all loaders to call `loader(...)`, I transformed it into a simpler `Object.assign({}, ...loaders.map(...))` instead.

This fixes biome's `noAccumulatingSpread` lint

