### PR TITLE
Use regex literals across the codebase

### DIFF
--- a/changelog/SZ56Od2yQjKZOMZbtoCt5Q.md
+++ b/changelog/SZ56Od2yQjKZOMZbtoCt5Q.md
@@ -1,0 +1,2 @@
+level: silent
+---

--- a/clients/client-web/test/buildUrl_test.js
+++ b/clients/client-web/test/buildUrl_test.js
@@ -100,7 +100,7 @@ describe('Building URLs', function() {
 
   it('should build signed URL with empty query options', () => {
     return expect(client.buildSignedUrl(client.query, {}))
-      .to.eventually.match(new RegExp('^https://tc-tests\\.example\\.com/api/fake/v1/query/test'));
+      .to.eventually.match(/^https:\/\/tc-tests\.example\.com\/api\/fake\/v1\/query\/test/);
   });
 
   it('should not build URL with incorrect query option', () => {

--- a/libraries/postgres/test/database_test.js
+++ b/libraries/postgres/test/database_test.js
@@ -320,7 +320,7 @@ helper.dbSuite(path.basename(__filename), function() {
         service2: { tables: { foo: 'write' } },
       });
       await assert.rejects(() => Database._checkPermissions({ db, schema, usernamePrefix: 'test' }),
-        new RegExp(`test_service2 has unexpected role badrole`));
+        /test_service2 has unexpected role badrole/);
     });
   });
 

--- a/services/github/src/utils.js
+++ b/services/github/src/utils.js
@@ -48,7 +48,7 @@ export const throttleRequest = async ({ url, method, response = { status: 0 }, a
 // for overriding in testing..
 throttleRequest.request = request;
 
-export const ciSkipRegexp = new RegExp('\\[(skip ci|ci skip)\\]', 'i');
+export const ciSkipRegexp = /\[(skip ci|ci skip)\]/i;
 
 /**
  * Check if push event should be skipped.
@@ -88,7 +88,7 @@ export const shouldSkipPullRequest = ({ pull_request }) => {
   return pull_request !== undefined && ciSkipRegexp.test(pull_request.title);
 };
 
-export const taskclusterCommandRegExp = new RegExp('^\\s*/taskcluster\\s+(.+)$', 'm');
+export const taskclusterCommandRegExp = /^\s*\/taskcluster\s+(.+)$/m;
 
 /**
  * Check if comment event should be skipped.

--- a/services/index/test/index_test.js
+++ b/services/index/test/index_test.js
@@ -282,7 +282,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       debug('listNamespaces entries match the namespace regex');
       assert.equal(
         new RegExp(myns + '.my-task').test(obj.namespace) &&
-        new RegExp('my-task').test(obj.name),
+        /my-task/.test(obj.name),
         true, 'Expect namespace to match regex');
       continuationToken = result.continuationToken;
       i ++;

--- a/services/queue/src/api.js
+++ b/services/queue/src/api.js
@@ -60,7 +60,7 @@ const PRIORITY_LEVELS = [
 const SLUGID_PATTERN = /^[A-Za-z0-9_-]{8}[Q-T][A-Za-z0-9_-][CGKOSWaeimquy26-][A-Za-z0-9_-]{10}[AQgw]$/;
 const GENERIC_ID_PATTERN = /^[a-zA-Z0-9-_]{1,38}$/;
 const RUN_ID_PATTERN = /^[1-9]*[0-9]+$/;
-const TASK_QUEUE_ID_PATTERN = new RegExp('^[a-zA-Z0-9-_]{1,38}/[a-z]([-a-z0-9]{0,36}[a-z0-9])?$');
+const TASK_QUEUE_ID_PATTERN = /^[a-zA-Z0-9-_]{1,38}\/[a-z]([-a-z0-9]{0,36}[a-z0-9])?$/;
 
 /**
  * API end-point for version v1/

--- a/services/worker-manager/test/api_test.js
+++ b/services/worker-manager/test/api_test.js
@@ -2206,7 +2206,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function (mock, skipping) {
       // worker is not yet visible to the queue so this method will fail
       await assert.rejects(() =>
         helper.workerManager.getWorker(provisionerId, workerType, workerGroup, workerId),
-      new RegExp(`Worker with workerId.+not found`),
+      /Worker with workerId.+not found/,
       );
 
       await makeQueueVisible(workerPoolId, workerGroup, workerId);
@@ -2267,7 +2267,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function (mock, skipping) {
       // worker is not yet visible to the queue so this method will fail
       await assert.rejects(() =>
         helper.workerManager.getWorker(provisionerId, workerType, workerGroup2, workerId2),
-      new RegExp(`Worker with workerId.+not found`),
+      /Worker with workerId.+not found/,
       );
 
       await makeQueueVisible(workerPoolId2, workerGroup2, workerId2);


### PR DESCRIPTION
Instead of using `new Regex(...)`, use `/.../` to fix biome's useRegexLiterals lint. In most cases it doesn't change anything, but when quotes are involved this way avoid having to write complex escaping sequences.
