### PR TITLE
Remove useless escapes in regexes

### DIFF
--- a/changelog/JwuLcfzjQfeKSMdAp4XvFg.md
+++ b/changelog/JwuLcfzjQfeKSMdAp4XvFg.md
@@ -1,0 +1,2 @@
+level: silent
+---

--- a/infrastructure/tooling/src/meta/checks/docs-headings.js
+++ b/infrastructure/tooling/src/meta/checks/docs-headings.js
@@ -21,7 +21,7 @@ export const tasks = [{
 
       //remove the markdown code blocks which may include python # comment
       // which can be confused with # markdown heading, as in, ui/docs/manual/using/s3-uploads.mdx
-      md = md.replace(/```[a-z]*[\s\S]*?\```/g, "");
+      md = md.replace(/```[a-z]*[\s\S]*?```/g, "");
       const hd = [];
 
       //hd[i] stores the number of headings with level i

--- a/libraries/testing/src/fakeauth.js
+++ b/libraries/testing/src/fakeauth.js
@@ -26,7 +26,7 @@ export const start = function(clients, { rootUrl } = {}) {
         clientId = authorization.id;
         scopes = clients[clientId];
         ext = authorization.ext;
-      } else if (/^\/.*[\?&]bewit\=/.test(body.resource)) {
+      } else if (/^\/.*[?&]bewit=/.test(body.resource)) {
         // The following is a hacky reproduction of the bewit logic in
         // https://github.com/hueniverse/hawk/blob/0833f99ba64558525995a7e21d4093da1f3e15fa/lib/server.js#L366-L383
         let bewitString = URL.parse(body.resource, rootUrl)?.searchParams?.get('bewit');

--- a/libraries/validate/src/index.js
+++ b/libraries/validate/src/index.js
@@ -92,7 +92,7 @@ class SchemaSet {
       const newSchema = _.clone(schema);
       newSchema.$id = libUrls.schema(rootUrl, this.cfg.serviceName, jsonName + '#');
       // rewrite a relative `/schemas/<service>/<path>..` URI to point to a full URL
-      const match = /^\/schemas\/([^\/]*)\/(.*)$/.exec(newSchema.$schema);
+      const match = /^\/schemas\/([^/]*)\/(.*)$/.exec(newSchema.$schema);
       if (match) {
         newSchema.$schema = libUrls.schema(rootUrl, match[1], match[2]);
       }

--- a/services/auth/src/signaturevalidator.js
+++ b/services/auth/src/signaturevalidator.js
@@ -50,7 +50,7 @@ export const determineSchemeFromRequest = (req) => {
   if (req.authorization) {
     return 'hawk';
   }
-  if (/bewit\=/.test(req.resource)) {
+  if (/bewit=/.test(req.resource)) {
     return 'bewit';
   }
   return 'unknown';
@@ -354,7 +354,7 @@ const createSignatureValidator = function(options) {
 
         credentials = authResult.credentials;
         attributes = authResult.artifacts; // Hawk uses "artifacts" and "attributes"
-      } else if (/^\/.*[\?&]bewit\=/.test(req.resource)) { // using regex because query parsing is disabled
+      } else if (/^\/.*[?&]bewit=/.test(req.resource)) { // using regex because query parsing is disabled
         scheme = 'bewit';
         // Bewit present
         authResult = await hawk.uri.authenticate({
@@ -367,12 +367,12 @@ const createSignatureValidator = function(options) {
 
           // Get bewit string (stolen from hawk)
           let parts = req.resource.match(
-            /^(\/.*)([\?&])bewit\=([^&$]*)(?:&(.+))?$/,
+            /^(\/.*)([?&])bewit=([^&$]*)(?:&(.+))?$/,
           );
 
           let bewitString;
           try {
-            if (!/^[\w\-]*$/.test(parts[3])) {
+            if (!/^[\w-]*$/.test(parts[3])) {
               throw new Error('invalid character in bewit');
             }
             bewitString = Buffer.from(parts[3], 'base64').toString('binary');

--- a/services/auth/test/trie_test.js
+++ b/services/auth/test/trie_test.js
@@ -226,7 +226,7 @@ suite(testing.suiteName(), () => {
         if (pattern.endsWith('*')) {
           const remaining = patternMatch(pattern, input) ? input.slice(pattern.length - 1) : '*';
           if (input.endsWith('*')) {
-            newScopes = scopes.map(s => s.replace(/\<\.\.\>.*$/, remaining));
+            newScopes = scopes.map(s => s.replace(/<\.\.>.*$/, remaining));
           } else {
             newScopes = scopes.map(s => s.replace('<..>', remaining));
           }

--- a/services/github/src/api.js
+++ b/services/github/src/api.js
@@ -21,7 +21,7 @@ import { getEventPayload } from './fake-payloads.js';
 // Strips/replaces undesirable characters which GitHub allows in
 // repository/organization names (notably .)
 function sanitizeGitHubField(field) {
-  return field.replace(/[^a-zA-Z0-9-_\.]/gi, '').replace(/\./g, '%');
+  return field.replace(/[^a-zA-Z0-9-_.]/gi, '').replace(/\./g, '%');
 }
 
 // Reduce a pull request WebHook's data to only fields needed to checkout a

--- a/services/hooks/src/api.js
+++ b/services/hooks/src/api.js
@@ -28,7 +28,7 @@ const builder = new APIBuilder({
   apiVersion: 'v1',
   params: {
     hookGroupId: /^[a-zA-Z0-9-_]{1,1000}$/,
-    hookId: /^[a-zA-Z0-9-_\/]{1,1000}$/,
+    hookId: /^[a-zA-Z0-9-_/]{1,1000}$/,
   },
   context: ['db', 'taskcreator', 'publisher', 'denylist', 'monitor'],
 });

--- a/services/queue/src/bucket.js
+++ b/services/queue/src/bucket.js
@@ -41,7 +41,7 @@ let Bucket = function(options) {
   assert(options.monitor, 'options.monitor is required');
   if (options.bucketCDN) {
     assert(/^https?:\/\//.test(options.bucketCDN), 'bucketCDN must be http(s)');
-    assert(/[^\/]$/.test(options.bucketCDN),
+    assert(/[^/]$/.test(options.bucketCDN),
       'bucketCDN shouldn\'t end with slash');
   }
   // Store the monitor

--- a/services/web-server/src/utils/constants.js
+++ b/services/web-server/src/utils/constants.js
@@ -1,4 +1,4 @@
 // The second capturing group is used to catch a user's github username
 
-export const CLIENT_ID_PATTERN = /^([^\/]*\/[^\/]*)(\/([^\/]*).*)?$/;
+export const CLIENT_ID_PATTERN = /^([^/]*\/[^/]*)(\/([^/]*).*)?$/;
 export const NOOP = () => {};

--- a/services/worker-manager/src/providers/google.js
+++ b/services/worker-manager/src/providers/google.js
@@ -245,7 +245,7 @@ export class GoogleProvider extends Provider {
       // The lost entropy from downcasing, etc should be ok due to the fact that
       // only running instances need not be identical. We do not use this name to identify
       // workers in taskcluster.
-      const poolName = workerPoolId.replace(/[\/_]/g, '-').slice(0, 38);
+      const poolName = workerPoolId.replace(/[/_]/g, '-').slice(0, 38);
       const instanceName = `${poolName}-${slugid.nice().replace(/_/g, '-').toLowerCase()}`;
       // Historically we set workerGroup to cfg.region (e.g. 'us-east1') but
       // cfg.zone (e.g. 'us-east1-d') is more specific, and required for e.g.

--- a/services/worker-manager/test/fakes/google.js
+++ b/services/worker-manager/test/fakes/google.js
@@ -196,7 +196,7 @@ export class ServiceAccounts {
   }
 
   async get({ name }) {
-    const [_, proj, acct] = /^projects\/([^\/]*)\/serviceAccounts\/([^\/]*)$/.exec(name);
+    const [_, proj, acct] = /^projects\/([^/]*)\/serviceAccounts\/([^/]*)$/.exec(name);
     return { data: { email: `${proj}-${acct}@example.com` } };
   }
 }


### PR DESCRIPTION
Because we're using literal regexes (and not `new Regex("..")`), there's a few places where escape sequences are not necessary. Removing them makes regexes more "readable".

Fixes biome's noUselessEscapeInRegex lint
