### PR TITLE
Use arrow functions instead of `function() {}`

### DIFF
--- a/changelog/DjlRPVHFRZyF9ax9SfPLdg.md
+++ b/changelog/DjlRPVHFRZyF9ax9SfPLdg.md
@@ -1,0 +1,2 @@
+level: silent
+---

--- a/clients/client-web/test/Queue_test.js
+++ b/clients/client-web/test/Queue_test.js
@@ -8,7 +8,7 @@ describe('Queue', function() {
   this.timeout(30000);
 
   let queue;
-  before(function() {
+  before(() => {
     if (helper.rootUrl) {
       queue = new Queue({ rootUrl: helper.rootUrl });
     }

--- a/clients/client-web/test/fromNow_test.js
+++ b/clients/client-web/test/fromNow_test.js
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
 import { fromNow } from '../src';
 
-describe('fromNow', function() {
+describe('fromNow', () => {
   it('should generate current datetime', () => {
     const date1 = new Date();
     const date2 = fromNow();

--- a/clients/client-web/test/helper.js
+++ b/clients/client-web/test/helper.js
@@ -5,7 +5,7 @@
  * available.  Note that the rootUrl shouldn't be used at the suite level, as
  * it will not be set yet.
  */
-exports.withRootUrl = function() {
+exports.withRootUrl = () => {
   before(function() {
     // the rootUrl is passed in via `.neutrinorc.js`
     exports.rootUrl = __karma__.config.args[0];
@@ -19,7 +19,7 @@ exports.withRootUrl = function() {
     }
   });
 
-  after(function() {
+  after(() => {
     exports.rootUrl = undefined;
   });
 };

--- a/clients/client-web/test/parseTime_test.js
+++ b/clients/client-web/test/parseTime_test.js
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
 import { parseTime } from '../src';
 
-describe('parseTime', function() {
+describe('parseTime', () => {
 
   it('should parse year', () => {
     expect(parseTime('1 yr').years).to.equal(1);

--- a/clients/client-web/test/slugid_test.js
+++ b/clients/client-web/test/slugid_test.js
@@ -55,7 +55,7 @@ const spreader = (generator) => {
   return actual;
 };
 
-describe('slugs', function() {
+describe('slugs', () => {
 
   it('should spread v4 slugs', () => {
     const charsAll = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_'.split('').sort().join('');

--- a/db/test/fns/auth_test.js
+++ b/db/test/fns/auth_test.js
@@ -5,10 +5,10 @@ import taskcluster from '@taskcluster/client';
 import { UNIQUE_VIOLATION } from '@taskcluster/lib-postgres';
 import * as uuid from 'uuid';
 
-suite(testing.suiteName(), function() {
+suite(testing.suiteName(), () => {
   helper.withDbForProcs({ serviceName: 'auth' });
 
-  suite('roles', function() {
+  suite('roles', () => {
     // make a role with default values
     const mkrole = ({ role_id, scopes }) => ({
       role_id,
@@ -18,25 +18,25 @@ suite(testing.suiteName(), function() {
       last_modified: new Date(2020, 7, 15),
     });
 
-    setup('truncate roles', async function() {
+    setup('truncate roles', async () => {
       await helper.withDbClient(async client => {
         await client.query('truncate roles');
       });
     });
 
-    helper.dbTest('get_roles when there are none', async function(db) {
+    helper.dbTest('get_roles when there are none', async (db) => {
       const roles = await db.fns.get_roles();
       assert.deepEqual(roles, []);
     });
 
-    helper.dbTest('modify_roles when no roles exist', async function(db) {
+    helper.dbTest('modify_roles when no roles exist', async (db) => {
       const etag = uuid.v4();
       await db.fns.modify_roles(JSON.stringify([mkrole({ role_id: 'abc' })]), etag);
       const roles = await db.fns.get_roles();
       assert.deepEqual(roles.map(({ etag, ...rest }) => rest), [mkrole({ role_id: 'abc' })]);
     });
 
-    helper.dbTest('modify_roles when roles do exist, no conflict', async function(db) {
+    helper.dbTest('modify_roles when roles do exist, no conflict', async (db) => {
       const etag = uuid.v4();
       await db.fns.modify_roles(JSON.stringify([mkrole({ role_id: 'abc' })]), etag);
       const roles1 = await db.fns.get_roles();
@@ -45,7 +45,7 @@ suite(testing.suiteName(), function() {
       assert.deepEqual(roles2.map(r => r.role_id), ['def']);
     });
 
-    helper.dbTest('modify_roles when roles do exist, with conflict', async function(db) {
+    helper.dbTest('modify_roles when roles do exist, with conflict', async (db) => {
       const etag = uuid.v4();
       await db.fns.modify_roles(JSON.stringify([mkrole({ role_id: 'abc' })]), etag);
       await assert.rejects(
@@ -56,8 +56,8 @@ suite(testing.suiteName(), function() {
     });
   });
 
-  suite('clients', function() {
-    setup('truncate clients', async function() {
+  suite('clients', () => {
+    setup('truncate clients', async () => {
       await helper.withDbClient(async client => {
         await client.query('truncate clients');
       });
@@ -75,12 +75,12 @@ suite(testing.suiteName(), function() {
       );
     };
 
-    helper.dbTest('get_client when it does not exixt', async function(db) {
+    helper.dbTest('get_client when it does not exixt', async (db) => {
       const clients = await db.fns.get_client('some-client');
       assert.deepEqual(clients, []);
     });
 
-    helper.dbTest('create and get a client', async function(db) {
+    helper.dbTest('create and get a client', async (db) => {
       const expires = new Date();
       await db.fns.create_client(
         'some-client',
@@ -118,7 +118,7 @@ suite(testing.suiteName(), function() {
       delete_on_expiration_in: false,
     });
 
-    helper.dbTest('create the same client a few times', async function(db) {
+    helper.dbTest('create the same client a few times', async (db) => {
       for (let i = 0; i < 5; i++) {
         // on each iteration, change all of the things that the idempotency doesn't
         // check..
@@ -137,7 +137,7 @@ suite(testing.suiteName(), function() {
       assert.deepEqual(client.delete_on_expiration, false);
     });
 
-    helper.dbTest('create the same client with different descriptions', async function(db) {
+    helper.dbTest('create the same client with different descriptions', async (db) => {
       await db.fns.create_client(baseClient(db));
       await assert.rejects(
         () => db.fns.create_client({ ...baseClient(db), description_in: 'CHANGED' }),
@@ -146,7 +146,7 @@ suite(testing.suiteName(), function() {
       assert.deepEqual(client.description, 'Some client...');
     });
 
-    helper.dbTest('create the same client with different scopes', async function(db) {
+    helper.dbTest('create the same client with different scopes', async (db) => {
       await db.fns.create_client(baseClient(db));
       await assert.rejects(
         () => db.fns.create_client({ ...baseClient(db), scopes_in: JSON.stringify(['scope1']) }),
@@ -155,7 +155,7 @@ suite(testing.suiteName(), function() {
       assert.deepEqual(client.scopes, ['scope1', 'scope2']);
     });
 
-    helper.dbTest('create the same client with different expires', async function(db) {
+    helper.dbTest('create the same client with different expires', async (db) => {
       await db.fns.create_client(baseClient(db));
       await assert.rejects(
         () => db.fns.create_client({ ...baseClient(db), expires_in: taskcluster.fromNow('1 hour') }),
@@ -164,7 +164,7 @@ suite(testing.suiteName(), function() {
       assert.deepEqual(client.expires, expires);
     });
 
-    helper.dbTest('create the same client but it is disabled', async function(db) {
+    helper.dbTest('create the same client but it is disabled', async (db) => {
       await db.fns.create_client(baseClient(db));
       await db.fns.update_client({
         client_id_in: 'some-client',
@@ -182,7 +182,7 @@ suite(testing.suiteName(), function() {
       assert.deepEqual(client.disabled, true);
     });
 
-    helper.dbTest('create the same client but it was created long ago', async function(db) {
+    helper.dbTest('create the same client but it was created long ago', async (db) => {
       await db.fns.create_client(baseClient(db));
       const created = taskcluster.fromNow('-30 minutes');
       await helper.withDbClient(async client => {
@@ -195,7 +195,7 @@ suite(testing.suiteName(), function() {
       assert.deepEqual(client.created, created);
     });
 
-    helper.dbTest('get_clients with a prefix', async function(db) {
+    helper.dbTest('get_clients with a prefix', async (db) => {
       await Promise.all([
         create(db, 'abc/1'),
         create(db, 'abc/2'),
@@ -206,7 +206,7 @@ suite(testing.suiteName(), function() {
       assert.deepEqual(clients.map(c => c.client_id), ['abc/1', 'abc/2', 'abc/3']);
     });
 
-    helper.dbTest('get_clients with pagination', async function(db) {
+    helper.dbTest('get_clients with pagination', async (db) => {
       await Promise.all([
         create(db, 'abc/1'),
         create(db, 'abc/2'),
@@ -219,7 +219,7 @@ suite(testing.suiteName(), function() {
       assert.deepEqual(clients2.map(c => c.client_id), ['abc/3', 'abc/4']);
     });
 
-    helper.dbTest('get_clients with prefix and pagination', async function(db) {
+    helper.dbTest('get_clients with prefix and pagination', async (db) => {
       await Promise.all([
         create(db, 'abc/1'),
         create(db, 'def/2'),
@@ -230,14 +230,14 @@ suite(testing.suiteName(), function() {
       assert.deepEqual(clients.map(c => c.client_id), ['abc/1', 'abc/3']);
     });
 
-    helper.dbTest('delete a client', async function(db) {
+    helper.dbTest('delete a client', async (db) => {
       await create(db, 'some-client');
       await db.fns.delete_client('some-client');
       const clients = await db.fns.get_client('some-client');
       assert.deepEqual(clients, []);
     });
 
-    helper.dbTest('update a client, changing nothing', async function(db) {
+    helper.dbTest('update a client, changing nothing', async (db) => {
       const expires = new Date();
       await db.fns.create_client(
         'some-client',
@@ -271,7 +271,7 @@ suite(testing.suiteName(), function() {
       assert.deepEqual(client1.last_rotated, client2.last_rotated);
     });
 
-    helper.dbTest('update a client, changing everything', async function(db) {
+    helper.dbTest('update a client, changing everything', async (db) => {
       const expires = new Date();
       await db.fns.create_client(
         'some-client',
@@ -314,7 +314,7 @@ suite(testing.suiteName(), function() {
       assert.notDeepEqual(client1.last_rotated, client2.last_rotated);
     });
 
-    helper.dbTest('update a client last_date_used', async function(db) {
+    helper.dbTest('update a client last_date_used', async (db) => {
       const expires = new Date();
       await db.fns.create_client(
         'some-client',
@@ -347,7 +347,7 @@ suite(testing.suiteName(), function() {
       assert.notDeepEqual(client1.last_date_used, client2.last_date_used);
     });
 
-    helper.dbTest('expire clients', async function(db) {
+    helper.dbTest('expire clients', async (db) => {
       await Promise.all([
         create(db, 'old', { expires: taskcluster.fromNow('-1 hour'), delete_on_expiration: true }),
         create(db, 'old-keep', { expires: taskcluster.fromNow('-1 hour'), delete_on_expiration: false }),
@@ -363,14 +363,14 @@ suite(testing.suiteName(), function() {
     });
   });
 
-  suite('audit history', function() {
-    setup('truncate audit_history', async function() {
+  suite('audit history', () => {
+    setup('truncate audit_history', async () => {
       await helper.withDbClient(async client => {
         await client.query('truncate audit_history');
       });
     });
 
-    helper.dbTest('insert and get audit history', async function(db) {
+    helper.dbTest('insert and get audit history', async (db) => {
       await db.fns.insert_auth_audit_history(
         'client-1',
         'client',
@@ -392,7 +392,7 @@ suite(testing.suiteName(), function() {
       assert(results[0].created instanceof Date);
     });
 
-    helper.dbTest('get_audit_history with pagination', async function(db) {
+    helper.dbTest('get_audit_history with pagination', async (db) => {
 
       for (let i = 0; i < 5; i++) {
         await db.fns.insert_auth_audit_history(
@@ -414,7 +414,7 @@ suite(testing.suiteName(), function() {
       assert.equal(page2[1].client_id, 'test-client-3');
     });
 
-    helper.dbTest('purge_audit_history', async function(db) {
+    helper.dbTest('purge_audit_history', async (db) => {
 
       await helper.withDbClient(async client => {
         await client.query(`
@@ -433,7 +433,7 @@ suite(testing.suiteName(), function() {
       assert.equal(results[0].action_type, 'updated');
     });
 
-    helper.dbTest('get_audit_history with non-existent entity', async function(db) {
+    helper.dbTest('get_audit_history with non-existent entity', async (db) => {
       const results = await db.fns.get_combined_audit_history(
         null,
         'non-existent',

--- a/db/test/fns/github_test.js
+++ b/db/test/fns/github_test.js
@@ -5,17 +5,17 @@ const { fromNow } = tc;
 import helper from '../helper.js';
 import slugid from 'slugid';
 
-suite(testing.suiteName(), function() {
+suite(testing.suiteName(), () => {
   helper.withDbForProcs({ serviceName: 'github' });
 
-  setup('reset table', async function() {
+  setup('reset table', async () => {
     await helper.withDbClient(async client => {
       await client.query('delete from github_builds');
       await client.query('delete from github_integrations');
     });
   });
 
-  suite('github_builds', function() {
+  suite('github_builds', () => {
     const task_group_prefix = 'foobar';
     const builds = [];
     for (let i = 0; i < 10; i++) {
@@ -46,7 +46,7 @@ suite(testing.suiteName(), function() {
       build.event_id,
     );
 
-    helper.dbTest('create and get', async function(db, isFake) {
+    helper.dbTest('create and get', async (db, isFake) => {
       await create_build(db, builds[0]);
       const [fetched] = await db.deprecatedFns.get_github_build(builds[0].task_group_id);
       assert(fetched.etag);
@@ -60,7 +60,7 @@ suite(testing.suiteName(), function() {
         await create_build(db, builds[0]);
       }, /duplicate key value violates unique constraint/);
     });
-    helper.dbTest('list', async function(db, isFake) {
+    helper.dbTest('list', async (db, isFake) => {
       for (let i = 0; i < 10; i++) {
         await create_build(db, builds[i]);
       }
@@ -72,7 +72,7 @@ suite(testing.suiteName(), function() {
         assert.deepEqual(build, builds[builds.length - i - 1]);
       });
     });
-    helper.dbTest('delete', async function(db, isFake) {
+    helper.dbTest('delete', async (db, isFake) => {
       await create_build(db, builds[0]);
       const [fetched] = await db.deprecatedFns.get_github_build(builds[0].task_group_id);
       assert(fetched.etag);
@@ -81,7 +81,7 @@ suite(testing.suiteName(), function() {
       await db.fns.delete_github_build(builds[0].task_group_id);
       assert.deepEqual(await db.deprecatedFns.get_github_build(builds[0].task_group_id), []);
     });
-    helper.dbTest('set state', async function(db, isFake) {
+    helper.dbTest('set state', async (db, isFake) => {
       await create_build(db, builds[0]);
       const [fetched] = await db.deprecatedFns.get_github_build(builds[0].task_group_id);
       await db.fns.set_github_build_state(
@@ -111,7 +111,7 @@ suite(testing.suiteName(), function() {
     });
   });
 
-  suite('github_builds with pull_request_number', function() {
+  suite('github_builds with pull_request_number', () => {
     const task_group_prefix = 'foobar';
     const builds = [];
     for (let i = 0; i < 10; i++) {
@@ -144,7 +144,7 @@ suite(testing.suiteName(), function() {
       build.pull_request_number,
     );
 
-    helper.dbTest('create and get', async function(db, isFake) {
+    helper.dbTest('create and get', async (db, isFake) => {
       await create_build(db, builds[0]);
       const [fetched] = await db.fns.get_github_build_pr(builds[0].task_group_id);
       assert(fetched.etag);
@@ -158,7 +158,7 @@ suite(testing.suiteName(), function() {
         await create_build(db, builds[0]);
       }, /duplicate key value violates unique constraint/);
     });
-    helper.dbTest('list', async function(db, isFake) {
+    helper.dbTest('list', async (db, isFake) => {
       for (let i = 0; i < 10; i++) {
         await create_build(db, builds[i]);
       }
@@ -175,7 +175,7 @@ suite(testing.suiteName(), function() {
       assert.equal(prBuilds.length, 1);
       assert.deepEqual(prBuilds[0].pull_request_number, builds[0].pull_request_number);
     });
-    helper.dbTest('list pending', async function(db, isFake) {
+    helper.dbTest('list pending', async (db, isFake) => {
       for (let i = 0; i < 10; i++) {
         await create_build(db, { ...builds[i], state: i < 5 ? 'pending' : 'success' });
       }
@@ -187,7 +187,7 @@ suite(testing.suiteName(), function() {
       assert.equal(prBuilds.length, 1);
       assert.deepEqual(prBuilds[0].pull_request_number, builds[0].pull_request_number);
     });
-    helper.dbTest('delete', async function(db, isFake) {
+    helper.dbTest('delete', async (db, isFake) => {
       await create_build(db, builds[0]);
       const [fetched] = await db.fns.get_github_build_pr(builds[0].task_group_id);
       assert(fetched.etag);
@@ -196,7 +196,7 @@ suite(testing.suiteName(), function() {
       await db.fns.delete_github_build(builds[0].task_group_id);
       assert.deepEqual(await db.fns.get_github_build_pr(builds[0].task_group_id), []);
     });
-    helper.dbTest('set state', async function(db, isFake) {
+    helper.dbTest('set state', async (db, isFake) => {
       await create_build(db, builds[0]);
       const [fetched] = await db.fns.get_github_build_pr(builds[0].task_group_id);
       await db.fns.set_github_build_state(
@@ -226,7 +226,7 @@ suite(testing.suiteName(), function() {
     });
   });
 
-  suite('github_integrations', function() {
+  suite('github_integrations', () => {
     const integrations = [];
     for (let i = 0; i < 10; i++) {
       integrations[i] = {
@@ -240,7 +240,7 @@ suite(testing.suiteName(), function() {
       integration.installation_id,
     );
 
-    helper.dbTest('create and get', async function(db, isFake) {
+    helper.dbTest('create and get', async (db, isFake) => {
       await upsert_integration(db, integrations[0]);
       let [fetched] = await db.fns.get_github_integration(integrations[0].owner);
       assert.deepEqual(fetched, integrations[0]);
@@ -253,7 +253,7 @@ suite(testing.suiteName(), function() {
       [fetched] = await db.fns.get_github_integration(integrations[0].owner);
       assert.deepEqual(fetched, { ...integrations[0], installation_id: 12345 });
     });
-    helper.dbTest('list', async function(db, isFake) {
+    helper.dbTest('list', async (db, isFake) => {
       for (let i = 0; i < 10; i++) {
         await upsert_integration(db, integrations[i]);
       }
@@ -265,7 +265,7 @@ suite(testing.suiteName(), function() {
     });
   });
 
-  suite('github_checks', function() {
+  suite('github_checks', () => {
     const checks = [];
     for (let i = 0; i < 10; i++) {
       checks[i] = {
@@ -283,7 +283,7 @@ suite(testing.suiteName(), function() {
       check.check_run_id,
     );
 
-    helper.dbTest('create and get', async function(db, isFake) {
+    helper.dbTest('create and get', async (db, isFake) => {
       await create_check(db, checks[0]);
       let [fetched] = await db.deprecatedFns.get_github_check_by_task_id(checks[0].task_id);
       assert.deepEqual(fetched, checks[0]);
@@ -297,14 +297,14 @@ suite(testing.suiteName(), function() {
       assert.deepEqual([], await db.deprecatedFns.get_github_check_by_task_id('doesntexist'));
     });
 
-    helper.dbTest('create idempotency', async function(db, isFake) {
+    helper.dbTest('create idempotency', async (db, isFake) => {
       await create_check(db, checks[0]);
       await create_check(db, { ...checks[0], check_run_id: 'abc' });
       let [fetched] = await db.deprecatedFns.get_github_check_by_task_id(checks[0].task_id);
       assert.deepEqual(fetched, { ...checks[0], check_run_id: 'abc' });
     });
 
-    helper.dbTest('get by check run id', async function(db) {
+    helper.dbTest('get by check run id', async (db) => {
       await create_check(db, checks[0]);
       const [fetched] = await db.fns.get_github_check_by_run_id(checks[0].check_suite_id, checks[0].check_run_id);
 
@@ -312,7 +312,7 @@ suite(testing.suiteName(), function() {
       assert.deepEqual([], await db.fns.get_github_check_by_run_id('-not-a-suite-id', 'fake-check-run'));
     });
 
-    helper.dbTest('get by task group id', async function(db) {
+    helper.dbTest('get by task group id', async (db) => {
       await create_check(db, checks[0]);
       const [fetched] = await db.fns.get_github_checks_by_task_group_id({
         page_size_in: 10,

--- a/db/test/fns/hooks_test.js
+++ b/db/test/fns/hooks_test.js
@@ -7,10 +7,10 @@ import helper from '../helper.js';
 import testing from '@taskcluster/lib-testing';
 import { UNIQUE_VIOLATION } from '@taskcluster/lib-postgres';
 
-suite(testing.suiteName(), function() {
+suite(testing.suiteName(), () => {
   helper.withDbForProcs({ serviceName: 'hooks' });
 
-  setup('reset table', async function() {
+  setup('reset table', async () => {
     await helper.withDbClient(async client => {
       await client.query('delete from hooks_last_fires');
       await client.query('delete from hooks_queues');
@@ -58,8 +58,8 @@ suite(testing.suiteName(), function() {
     );
   };
 
-  suite(`${testing.suiteName()} - hooks_last_fires`, function() {
-    helper.dbTest('create_last_fire/get_last_fires_with_task_state', async function(db) {
+  suite(`${testing.suiteName()} - hooks_last_fires`, () => {
+    helper.dbTest('create_last_fire/get_last_fires_with_task_state', async (db) => {
       const now = new Date();
       const taskId = slug.nice();
       await create_last_fire(db, { task_id: taskId, task_create_time: now });
@@ -75,7 +75,7 @@ suite(testing.suiteName(), function() {
       assert.equal(rows[0].error, 'error');
     });
 
-    helper.dbTest('create_last_fire throws when row already exists', async function(db) {
+    helper.dbTest('create_last_fire throws when row already exists', async (db) => {
       const now = new Date();
       const taskId = slug.nice();
       await create_last_fire(db, { task_id: taskId, task_create_time: now });
@@ -88,16 +88,16 @@ suite(testing.suiteName(), function() {
       );
     });
 
-    helper.dbTest('get_last_fires does not throw when no such row', async function(db) {
+    helper.dbTest('get_last_fires does not throw when no such row', async (db) => {
       const rows = await db.deprecatedFns.get_last_fires('hook/group/id', 'hook-id', 10, 0);
       assert.equal(rows.length, 0);
     });
-    helper.dbTest('get_last_fires_with_task_state does not throw when no such row', async function(db) {
+    helper.dbTest('get_last_fires_with_task_state does not throw when no such row', async (db) => {
       const rows = await db.fns.get_last_fires_with_task_state('hook/group/id', 'hook-id', 10, 0);
       assert.equal(rows.length, 0);
     });
 
-    helper.dbTest('get_last_fires full, pagination', async function(db) {
+    helper.dbTest('get_last_fires full, pagination', async (db) => {
       for (let i = 0; i < 10; i++) {
         await create_last_fire(db, { task_id: slug.nice() });
       }
@@ -112,7 +112,7 @@ suite(testing.suiteName(), function() {
       assert.equal(rows.length, 2);
     });
 
-    helper.dbTest('get_last_fires_with_task_state full, pagination', async function(db) {
+    helper.dbTest('get_last_fires_with_task_state full, pagination', async (db) => {
       await helper.withDbClient(async client => {
         const createTask = async (db, options = {}) => {
           const taskId = options.taskId || slug.nice();
@@ -164,7 +164,7 @@ suite(testing.suiteName(), function() {
       });
     });
 
-    helper.dbTest('delete_last_fires', async function(db) {
+    helper.dbTest('delete_last_fires', async (db) => {
       await Promise.all(_.range(5).map(() => {
         const taskId = slug.nice();
         return create_last_fire(db, { task_id: taskId });
@@ -177,11 +177,11 @@ suite(testing.suiteName(), function() {
       assert.equal(rows.length, 0);
     });
 
-    helper.dbTest('delete_last_fires does not throw when no such row', async function(db) {
+    helper.dbTest('delete_last_fires does not throw when no such row', async (db) => {
       await db.fns.delete_last_fires('hook/group/id', 'hook-id');
     });
 
-    helper.dbTest('expire_last_fires does not delete when < 1 year', async function(db) {
+    helper.dbTest('expire_last_fires does not delete when < 1 year', async (db) => {
       await Promise.all(['1 day', '1 month', '1 year'].map(period => {
         return create_last_fire(db, { task_create_time: fromNow(period) });
       }));
@@ -192,7 +192,7 @@ suite(testing.suiteName(), function() {
       assert.equal(rows.length, 3);
     });
 
-    helper.dbTest('expire_last_fires deletes when > 1 year', async function(db) {
+    helper.dbTest('expire_last_fires deletes when > 1 year', async (db) => {
       await Promise.all(['-1 day', '-13 months', '-2 years'].map(period => {
         return create_last_fire(db, { task_create_time: fromNow(period) });
       }));
@@ -205,8 +205,8 @@ suite(testing.suiteName(), function() {
     });
   });
 
-  suite(`${testing.suiteName()} - hooks_queues`, function() {
-    helper.dbTest('create_queue/get_queues', async function(db) {
+  suite(`${testing.suiteName()} - hooks_queues`, () => {
+    helper.dbTest('create_queue/get_queues', async (db) => {
       await create_hooks_queue(db, {});
 
       const rows = await db.fns.get_hooks_queues(10, 0);
@@ -217,7 +217,7 @@ suite(testing.suiteName(), function() {
       assert.deepEqual(rows[0].bindings, []);
     });
 
-    helper.dbTest('create_queue with bindings', async function(db) {
+    helper.dbTest('create_queue with bindings', async (db) => {
       const bindings = [{ exchange: 'exchange', routingKeyPattern: 'routingKeyPattern' }];
       await create_hooks_queue(db, { bindings: JSON.stringify(bindings) });
 
@@ -229,7 +229,7 @@ suite(testing.suiteName(), function() {
       assert.deepEqual(rows[0].bindings, bindings);
     });
 
-    helper.dbTest('create_queue throws when row already exists', async function(db) {
+    helper.dbTest('create_queue throws when row already exists', async (db) => {
       await create_hooks_queue(db, {});
 
       await assert.rejects(
@@ -240,12 +240,12 @@ suite(testing.suiteName(), function() {
       );
     });
 
-    helper.dbTest('get_hooks_queues does not throw when no such row', async function(db) {
+    helper.dbTest('get_hooks_queues does not throw when no such row', async (db) => {
       const rows = await db.fns.get_hooks_queues(10, 0);
       assert.equal(rows.length, 0);
     });
 
-    helper.dbTest('get_hooks_queues full, pagination', async function(db) {
+    helper.dbTest('get_hooks_queues full, pagination', async (db) => {
       for (let i = 0; i < 10; i++) {
         await create_hooks_queue(db, { hook_id: `hook-id/${i}` });
       }
@@ -260,7 +260,7 @@ suite(testing.suiteName(), function() {
       assert.equal(rows.length, 2);
     });
 
-    helper.dbTest('delete_hooks_queue', async function(db) {
+    helper.dbTest('delete_hooks_queue', async (db) => {
       await Promise.all(_.range(5).map(i => {
         return create_hooks_queue(db, { hook_id: `hook-id/${i}` });
       }));
@@ -272,11 +272,11 @@ suite(testing.suiteName(), function() {
       assert.equal(rows.length, 4);
     });
 
-    helper.dbTest('delete_hooks_queue does not throw when no such row', async function(db) {
+    helper.dbTest('delete_hooks_queue does not throw when no such row', async (db) => {
       await db.fns.delete_last_fires('hook/group/id', 'hook-id');
     });
 
-    helper.dbTest('update_hooks_queue_bindings updates bindings', async function(db) {
+    helper.dbTest('update_hooks_queue_bindings updates bindings', async (db) => {
       const bindings = [];
       await create_hooks_queue(db, { bindings });
 
@@ -291,8 +291,8 @@ suite(testing.suiteName(), function() {
     });
   });
 
-  suite(`${testing.suiteName()} - hooks`, function() {
-    helper.dbTest('create_hook/get_hook', async function(db) {
+  suite(`${testing.suiteName()} - hooks`, () => {
+    helper.dbTest('create_hook/get_hook', async (db) => {
       await create_hook(db, {});
 
       const rows = await db.fns.get_hook('hook/group/id', 'hook-id');
@@ -309,7 +309,7 @@ suite(testing.suiteName(), function() {
       assert.deepEqual(rows[0].trigger_schema, {});
     });
 
-    helper.dbTest('create_hook with bindings', async function(db) {
+    helper.dbTest('create_hook with bindings', async (db) => {
       const bindings = [{ exchange: 'exchange', routingKeyPattern: 'routingKeyPattern' }];
       await create_hook(db, { bindings: JSON.stringify(bindings) });
 
@@ -325,7 +325,7 @@ suite(testing.suiteName(), function() {
       assert.deepEqual(rows[0].trigger_schema, {});
     });
 
-    helper.dbTest('create_hook throws when row already exists', async function(db) {
+    helper.dbTest('create_hook throws when row already exists', async (db) => {
       await create_hook(db, {});
 
       await assert.rejects(
@@ -336,7 +336,7 @@ suite(testing.suiteName(), function() {
       );
     });
 
-    helper.dbTest('update_hook, change to a single field', async function(db, isFake) {
+    helper.dbTest('update_hook, change to a single field', async (db, isFake) => {
       await create_hook(db);
       const bindings = [{ exchange: 'exchange', routingKeyPattern: 'routingKeyPattern' }];
       await db.fns.update_hook(
@@ -365,7 +365,7 @@ suite(testing.suiteName(), function() {
       assert.deepEqual(rows[0].trigger_schema, {});
     });
 
-    helper.dbTest('update_hook, change an encrypted field', async function(db, isFake) {
+    helper.dbTest('update_hook, change an encrypted field', async (db, isFake) => {
       await create_hook(db);
       const nextTaskId = slug.v4();
       await db.fns.update_hook(
@@ -394,7 +394,7 @@ suite(testing.suiteName(), function() {
       assert.deepEqual(rows[0].trigger_schema, {});
     });
 
-    helper.dbTest('update_hook, no changes', async function(db, isFake) {
+    helper.dbTest('update_hook, no changes', async (db, isFake) => {
       await create_hook(db);
       const updated = await db.fns.update_hook(
         'hook/group/id',
@@ -425,7 +425,7 @@ suite(testing.suiteName(), function() {
       assert.deepEqual(rows[0].trigger_schema, {});
     });
 
-    helper.dbTest('update_hook, throws when row does not exist', async function(db, isFake) {
+    helper.dbTest('update_hook, throws when row does not exist', async (db, isFake) => {
       await assert.rejects(
         async () => {
           await db.fns.update_hook(
@@ -445,12 +445,12 @@ suite(testing.suiteName(), function() {
       );
     });
 
-    helper.dbTest('get_hooks does not throw when no such row', async function(db) {
+    helper.dbTest('get_hooks does not throw when no such row', async (db) => {
       const rows = await db.fns.get_hooks(null, null, 10, 0);
       assert.equal(rows.length, 0);
     });
 
-    helper.dbTest('get_hooks full, pagination', async function(db) {
+    helper.dbTest('get_hooks full, pagination', async (db) => {
       for (let i = 0; i < 10; i++) {
         await create_hook(db, { hook_id: `hook-id/${i}` });
       }
@@ -465,7 +465,7 @@ suite(testing.suiteName(), function() {
       assert.equal(rows.length, 2);
     });
 
-    helper.dbTest('get_hooks filtered by hook group id', async function(db) {
+    helper.dbTest('get_hooks filtered by hook group id', async (db) => {
       for (let i = 0; i < 10; i++) {
         if (i < 5) {
           await create_hook(db, { hook_group_id: 'foo', hook_id: `hook-id/${i}` });
@@ -479,7 +479,7 @@ suite(testing.suiteName(), function() {
       assert.equal(rows.filter(r => r.hook_group_id === 'foo').length, 5);
     });
 
-    helper.dbTest('get_hooks filtered by next_scheduled_date', async function(db) {
+    helper.dbTest('get_hooks filtered by next_scheduled_date', async (db) => {
       const oneDayAgo = fromNow('-1 day');
       const now = fromNow();
       for (let i = 0; i < 10; i++) {
@@ -497,7 +497,7 @@ suite(testing.suiteName(), function() {
       });
     });
 
-    helper.dbTest('get_hooks filtered by hook_group_id and next_scheduled_date', async function(db) {
+    helper.dbTest('get_hooks filtered by hook_group_id and next_scheduled_date', async (db) => {
       const oneDayAgo = fromNow('-1 day');
       const now = fromNow();
       await create_hook(db, { hook_group_id: 'foo', next_scheduled_date: oneDayAgo });
@@ -517,7 +517,7 @@ suite(testing.suiteName(), function() {
       });
     });
 
-    helper.dbTest('delete_hook', async function(db) {
+    helper.dbTest('delete_hook', async (db) => {
       await Promise.all(_.range(5).map(i => {
         return create_hook(db, { hook_id: `hook-id/${i}` });
       }));
@@ -529,11 +529,11 @@ suite(testing.suiteName(), function() {
       assert.equal(rows.length, 4);
     });
 
-    helper.dbTest('delete_hook does not throw when no such row', async function(db) {
+    helper.dbTest('delete_hook does not throw when no such row', async (db) => {
       await db.fns.delete_hook('hook/group/id', 'hook-id');
     });
 
-    helper.dbTest('get_hook_groups returns unique groups', async function(db) {
+    helper.dbTest('get_hook_groups returns unique groups', async (db) => {
       await create_hook(db, { hook_group_id: 'foo', hook_id: 'hook-id/1', next_scheduled_date: fromNow('1 day') });
       await create_hook(db, { hook_group_id: 'foo', hook_id: 'hook-id/2', next_scheduled_date: fromNow('1 day') });
       await create_hook(db, { hook_group_id: 'baz', hook_id: 'hook-id/3', next_scheduled_date: fromNow('1 day') });
@@ -545,8 +545,8 @@ suite(testing.suiteName(), function() {
     });
   });
 
-  suite(`${testing.suiteName()} - hooks audit history`, function() {
-    helper.dbTest('insert_hooks_audit_history creates audit entry', async function(db) {
+  suite(`${testing.suiteName()} - hooks audit history`, () => {
+    helper.dbTest('insert_hooks_audit_history creates audit entry', async (db) => {
       await db.fns.insert_hooks_audit_history(
         'hook/1',
         'client-1',

--- a/db/test/fns/index_test.js
+++ b/db/test/fns/index_test.js
@@ -6,10 +6,10 @@ import testing from '@taskcluster/lib-testing';
 import tc from '@taskcluster/client';
 const { fromNow } = tc;
 
-suite(testing.suiteName(), function() {
+suite(testing.suiteName(), () => {
   helper.withDbForProcs({ serviceName: 'index' });
 
-  setup('reset table', async function() {
+  setup('reset table', async () => {
     await helper.withDbClient(async client => {
       await client.query('delete from indexed_tasks');
       await client.query('delete from index_namespaces');
@@ -45,8 +45,8 @@ suite(testing.suiteName(), function() {
     );
   };
 
-  suite(`${testing.suiteName()} - index_namespaces`, function() {
-    helper.dbTest('create_index_namespace/get_index_namespace', async function(db, isFake) {
+  suite(`${testing.suiteName()} - index_namespaces`, () => {
+    helper.dbTest('create_index_namespace/get_index_namespace', async (db, isFake) => {
       await create_index_namespace(db, {});
 
       const rows = await db.fns.get_index_namespace('par/ent', 'name');
@@ -54,7 +54,7 @@ suite(testing.suiteName(), function() {
       assert.equal(rows[0].name, 'name');
     });
 
-    helper.dbTest('get_index_namespace does not omit expired indexed namespaces', async function(db, isFake) {
+    helper.dbTest('get_index_namespace does not omit expired indexed namespaces', async (db, isFake) => {
       const now = new Date();
       await create_index_namespace(db, { expires: now });
 
@@ -62,17 +62,17 @@ suite(testing.suiteName(), function() {
       assert.equal(rows.length, 1);
     });
 
-    helper.dbTest('get_index_namespace not found', async function(db, isFake) {
+    helper.dbTest('get_index_namespace not found', async (db, isFake) => {
       const rows = await db.fns.get_index_namespace('par/ent', 'name');
       assert.deepEqual(rows, []);
     });
 
-    helper.dbTest('get_index_namespaces empty', async function(db, isFake) {
+    helper.dbTest('get_index_namespaces empty', async (db, isFake) => {
       const rows = await db.fns.get_index_namespaces(null, null, null, null);
       assert.deepEqual(rows, []);
     });
 
-    helper.dbTest('get_index_namespaces full, pagination', async function(db, isFake) {
+    helper.dbTest('get_index_namespaces full, pagination', async (db, isFake) => {
       const oneDay = fromNow('1 day');
       for (let i = 0; i < 10; i++) {
         await create_index_namespace(db, {
@@ -94,7 +94,7 @@ suite(testing.suiteName(), function() {
         [4, 5].map(i => ({ parent: `parent/${i}`, name: `name/${i}` })));
     });
 
-    helper.dbTest('get_index_namespaces only returns non expired tasks', async function(db, isFake) {
+    helper.dbTest('get_index_namespaces only returns non expired tasks', async (db, isFake) => {
       const oneDay = fromNow('1 day');
       await create_index_namespace(db, {
         parent: `parent/1`,
@@ -114,7 +114,7 @@ suite(testing.suiteName(), function() {
       assert.deepEqual(rows[0].expires, oneDay);
     });
 
-    helper.dbTest('expire_index_namespaces', async function(db, isFake) {
+    helper.dbTest('expire_index_namespaces', async (db, isFake) => {
       await create_index_namespace(db, { parent: 'parent/1', expires: fromNow('- 1 day') });
       await create_index_namespace(db, { parent: 'parent/2', expires: fromNow('- 2 days') });
       await create_index_namespace(db, { parent: 'parent/3', expires: fromNow('1 day') });
@@ -125,7 +125,7 @@ suite(testing.suiteName(), function() {
       assert.equal(rows.length, 1);
     });
 
-    helper.dbTest('update_index_namespace, change to a single field', async function(db, isFake) {
+    helper.dbTest('update_index_namespace, change to a single field', async (db, isFake) => {
       await create_index_namespace(db);
       await db.fns.update_index_namespace(
         'par/ent',
@@ -139,7 +139,7 @@ suite(testing.suiteName(), function() {
       assert.equal(rows[0].expires.toJSON(), new Date(1).toJSON());
     });
 
-    helper.dbTest('update_index_namespace, no changes', async function(db, isFake) {
+    helper.dbTest('update_index_namespace, no changes', async (db, isFake) => {
       await create_index_namespace(db);
       const updated = await db.fns.update_index_namespace(
         'par/ent',
@@ -156,7 +156,7 @@ suite(testing.suiteName(), function() {
       assert(rows[0].expires instanceof Date);
     });
 
-    helper.dbTest('update_index_namespace, throws when row does not exist', async function(db, isFake) {
+    helper.dbTest('update_index_namespace, throws when row does not exist', async (db, isFake) => {
       await create_index_namespace(db);
 
       await assert.rejects(
@@ -172,8 +172,8 @@ suite(testing.suiteName(), function() {
     });
   });
 
-  suite(`${testing.suiteName()} - indexed_tasks`, function() {
-    helper.dbTest('create_indexed_task/get_indexed_task', async function(db, isFake) {
+  suite(`${testing.suiteName()} - indexed_tasks`, () => {
+    helper.dbTest('create_indexed_task/get_indexed_task', async (db, isFake) => {
       const taskId = slug.nice();
       await create_indexed_task(db, { taskId });
 
@@ -183,7 +183,7 @@ suite(testing.suiteName(), function() {
       assert.deepEqual(rows[0].data, { data: true });
     });
 
-    helper.dbTest('get_indexed_task does not omit expired indexed tasks', async function(db, isFake) {
+    helper.dbTest('get_indexed_task does not omit expired indexed tasks', async (db, isFake) => {
       const now = new Date();
       const taskId = slug.nice();
       await create_indexed_task(db, { expires: now, taskId });
@@ -192,7 +192,7 @@ suite(testing.suiteName(), function() {
       assert.equal(rows.length, 1);
     });
 
-    helper.dbTest('get_tasks_from_indexes_and_namespaces does not omit expired indexed tasks', async function(db, isFake) {
+    helper.dbTest('get_tasks_from_indexes_and_namespaces does not omit expired indexed tasks', async (db, isFake) => {
       const now = new Date();
       const taskId = slug.nice();
       await create_indexed_task(db, { expires: now, taskId });
@@ -201,27 +201,27 @@ suite(testing.suiteName(), function() {
       assert.equal(rows.length, 1);
     });
 
-    helper.dbTest('get_tasks_from_indexes_and_namespaces not found', async function(db, isFake) {
+    helper.dbTest('get_tasks_from_indexes_and_namespaces not found', async (db, isFake) => {
       const rows = await db.fns.get_tasks_from_indexes_and_namespaces(JSON.stringify(['name/space.name']), 1000, 0);
       assert.deepEqual(rows, []);
     });
 
-    helper.dbTest('get_indexed_task not found', async function(db, isFake) {
+    helper.dbTest('get_indexed_task not found', async (db, isFake) => {
       const rows = await db.fns.get_indexed_task('name/space', 'name');
       assert.deepEqual(rows, []);
     });
 
-    helper.dbTest('get_tasks_from_indexes_and_namespaces empty', async function(db, isFake) {
+    helper.dbTest('get_tasks_from_indexes_and_namespaces empty', async (db, isFake) => {
       const rows = await db.fns.get_tasks_from_indexes_and_namespaces(null, null, null);
       assert.deepEqual(rows, []);
     });
 
-    helper.dbTest('get_indexed_tasks empty', async function(db, isFake) {
+    helper.dbTest('get_indexed_tasks empty', async (db, isFake) => {
       const rows = await db.fns.get_indexed_tasks(null, null, null, null);
       assert.deepEqual(rows, []);
     });
 
-    helper.dbTest('get_tasks_from_indexes_and_namespaces pagination', async function(db, isFake) {
+    helper.dbTest('get_tasks_from_indexes_and_namespaces pagination', async (db, isFake) => {
       const oneDay = fromNow('1 day');
       const expectedIndexes = [];
       const expectedTasks = [];
@@ -258,7 +258,7 @@ suite(testing.suiteName(), function() {
       assert.equal(rows.length, 0);
     });
 
-    helper.dbTest('get_indexed_tasks full, pagination', async function(db, isFake) {
+    helper.dbTest('get_indexed_tasks full, pagination', async (db, isFake) => {
       const oneDay = fromNow('1 day');
       for (let i = 0; i < 10; i++) {
         await create_indexed_task(db, {
@@ -280,7 +280,7 @@ suite(testing.suiteName(), function() {
         [4, 5].map(i => ({ namespace: `namespace/${i}`, name: `name/${i}` })));
     });
 
-    helper.dbTest('get_indexed_tasks only returns non expired tasks', async function(db, isFake) {
+    helper.dbTest('get_indexed_tasks only returns non expired tasks', async (db, isFake) => {
       const oneDay = fromNow('1 day');
       await create_indexed_task(db, {
         namespace: `namespace/1`,
@@ -304,7 +304,7 @@ suite(testing.suiteName(), function() {
       assert.deepEqual(rows[0].expires, oneDay);
     });
 
-    helper.dbTest('expire_indexed_tasks', async function(db, isFake) {
+    helper.dbTest('expire_indexed_tasks', async (db, isFake) => {
       await create_indexed_task(db, { namespace: 'namespace/1', expires: fromNow('- 1 day') });
       await create_indexed_task(db, { namespace: 'namespace/2', expires: fromNow('- 2 days') });
       await create_indexed_task(db, { namespace: 'namespace/3', expires: fromNow('1 day') });
@@ -315,7 +315,7 @@ suite(testing.suiteName(), function() {
       assert.equal(rows.length, 1);
     });
 
-    helper.dbTest('update_indexed_task, change to a single field', async function(db, isFake) {
+    helper.dbTest('update_indexed_task, change to a single field', async (db, isFake) => {
       await create_indexed_task(db);
       await db.fns.update_indexed_task(
         'name/space',
@@ -335,7 +335,7 @@ suite(testing.suiteName(), function() {
       assert(rows[0].expires instanceof Date);
     });
 
-    helper.dbTest('update_indexed_task, change to a multiple fields', async function(db, isFake) {
+    helper.dbTest('update_indexed_task, change to a multiple fields', async (db, isFake) => {
       await create_indexed_task(db);
       const updated = await db.fns.update_indexed_task(
         'name/space',
@@ -357,7 +357,7 @@ suite(testing.suiteName(), function() {
       assert.deepEqual(updated, rows);
     });
 
-    helper.dbTest('update_indexed_task, no changes', async function(db, isFake) {
+    helper.dbTest('update_indexed_task, no changes', async (db, isFake) => {
       await create_indexed_task(db);
       const updated = await db.fns.update_indexed_task(
         'name/space',
@@ -379,7 +379,7 @@ suite(testing.suiteName(), function() {
       assert(rows[0].expires instanceof Date);
     });
 
-    helper.dbTest('update_indexed_task, indexed task doesn\'t exist', async function(db, isFake) {
+    helper.dbTest('update_indexed_task, indexed task doesn\'t exist', async (db, isFake) => {
       await create_indexed_task(db);
 
       await assert.rejects(
@@ -390,7 +390,7 @@ suite(testing.suiteName(), function() {
       );
     });
 
-    helper.dbTest('update_indexed_task, throws when row does not exist', async function(db, isFake) {
+    helper.dbTest('update_indexed_task, throws when row does not exist', async (db, isFake) => {
       await create_indexed_task(db);
 
       await assert.rejects(
@@ -408,7 +408,7 @@ suite(testing.suiteName(), function() {
       );
     });
 
-    helper.dbTest('delete_indexed_task', async function(db, isFake) {
+    helper.dbTest('delete_indexed_task', async (db, isFake) => {
       const taskId = slug.nice();
       await create_indexed_task(db, { taskId });
 

--- a/db/test/fns/notify_test.js
+++ b/db/test/fns/notify_test.js
@@ -2,21 +2,21 @@ import { strict as assert } from 'node:assert';
 import helper from '../helper.js';
 import testing from '@taskcluster/lib-testing';
 
-suite(testing.suiteName(), function() {
+suite(testing.suiteName(), () => {
   helper.withDbForProcs({ serviceName: 'notify' });
 
-  setup('truncate denylisted_notifications', async function() {
+  setup('truncate denylisted_notifications', async () => {
     await helper.withDbClient(async client => {
       await client.query('truncate denylisted_notifications');
     });
   });
 
-  helper.dbTest('list denylisted notifications when there are none', async function(db) {
+  helper.dbTest('list denylisted notifications when there are none', async (db) => {
     const addresses = await db.fns.all_denylist_addresses(10, 0);
     assert.deepEqual(addresses, []);
   });
 
-  helper.dbTest('list denylisted notifications when there is one row', async function(db) {
+  helper.dbTest('list denylisted notifications when there is one row', async (db) => {
     let n1 = {
       notificationType: "email",
       notificationAddress: "pmoore@mozilla.com",
@@ -28,7 +28,7 @@ suite(testing.suiteName(), function() {
     assert.equal(addresses[0].notification_address, n1.notificationAddress);
   });
 
-  helper.dbTest('add denylist address that already exists', async function(db) {
+  helper.dbTest('add denylist address that already exists', async (db) => {
     let n1 = {
       notificationType: "email",
       notificationAddress: "pmoore@mozilla.com",
@@ -41,7 +41,7 @@ suite(testing.suiteName(), function() {
     assert.equal(addresses[0].notification_address, n1.notificationAddress);
   });
 
-  helper.dbTest('delete denylist address that already exists', async function(db) {
+  helper.dbTest('delete denylist address that already exists', async (db) => {
     let n1 = {
       notificationType: "email",
       notificationAddress: "pmoore@mozilla.com",
@@ -52,7 +52,7 @@ suite(testing.suiteName(), function() {
     assert.equal(addresses.length, 0);
   });
 
-  helper.dbTest("delete denylist address that doesn't already exist", async function(db) {
+  helper.dbTest("delete denylist address that doesn't already exist", async (db) => {
     let n1 = {
       notificationType: "pulse",
       notificationAddress: "routing.key",
@@ -69,7 +69,7 @@ suite(testing.suiteName(), function() {
     assert.equal(addresses[0].notification_address, n1.notificationAddress);
   });
 
-  helper.dbTest('test denylist address pagination', async function(db) {
+  helper.dbTest('test denylist address pagination', async (db) => {
     let n1 = {
       notificationType: "pulse",
       notificationAddress: "routing.key",
@@ -89,7 +89,7 @@ suite(testing.suiteName(), function() {
     assert.equal(addresses[0].notification_address, n1.notificationAddress);
   });
 
-  helper.dbTest('test denylist existence check', async function(db) {
+  helper.dbTest('test denylist existence check', async (db) => {
     let n1 = {
       notificationType: "pulse",
       notificationAddress: "routing.key",
@@ -105,7 +105,7 @@ suite(testing.suiteName(), function() {
     assert(!!exists[0].exists_denylist_address);
   });
 
-  helper.dbTest('test denylist nonexistence check', async function(db) {
+  helper.dbTest('test denylist nonexistence check', async (db) => {
     let n1 = {
       notificationType: "pulse",
       notificationAddress: "routing.key",

--- a/db/test/fns/object_test.js
+++ b/db/test/fns/object_test.js
@@ -7,16 +7,16 @@ import testing from '@taskcluster/lib-testing';
 import { CHECK_VIOLATION, UNIQUE_VIOLATION, FOREIGN_KEY_VIOLATION } from '@taskcluster/lib-postgres';
 import taskcluster from '@taskcluster/client';
 
-suite(testing.suiteName(), function() {
+suite(testing.suiteName(), () => {
   helper.withDbForProcs({ serviceName: 'object' });
 
-  setup('truncate tables', async function() {
+  setup('truncate tables', async () => {
     await helper.withDbClient(async client => {
       await client.query('truncate objects, object_hashes');
     });
   });
 
-  helper.dbTest('create_object same object twice should not raise exception', async function(db, isFake) {
+  helper.dbTest('create_object same object twice should not raise exception', async (db, isFake) => {
     const expires = fromNow('1 year');
     await db.deprecatedFns.create_object('foo', 'projectId', 'backendId', {}, expires);
     await db.deprecatedFns.create_object('foo', 'projectId', 'backendId', {}, expires);
@@ -32,7 +32,7 @@ suite(testing.suiteName(), function() {
     });
   });
 
-  helper.dbTest('create_object with conflict should P0004', async function(db, isFake) {
+  helper.dbTest('create_object with conflict should P0004', async (db, isFake) => {
     const expires = fromNow('1 year');
     await db.deprecatedFns.create_object('foo', 'projectId', 'backendId', {}, expires);
     await assert.rejects(
@@ -50,7 +50,7 @@ suite(testing.suiteName(), function() {
     });
   });
 
-  helper.dbTest('create_object', async function(db, isFake) {
+  helper.dbTest('create_object', async (db, isFake) => {
     const expires = fromNow('1 year');
     await db.deprecatedFns.create_object('foo', 'projectId', 'backendId', {}, expires);
 
@@ -65,7 +65,7 @@ suite(testing.suiteName(), function() {
     });
   });
 
-  helper.dbTest('create_object_for_upload', async function(db, isFake) {
+  helper.dbTest('create_object_for_upload', async (db, isFake) => {
     const expires = fromNow('1 year');
     const uploadExpires = fromNow('1 day');
     const uploadId = taskcluster.slugid();
@@ -84,7 +84,7 @@ suite(testing.suiteName(), function() {
     });
   });
 
-  helper.dbTest('create_object_for_upload is idempotent', async function(db, isFake) {
+  helper.dbTest('create_object_for_upload is idempotent', async (db, isFake) => {
     const expires = fromNow('1 year');
     const uploadExpires = fromNow('1 day');
     const uploadId = taskcluster.slugid();
@@ -92,7 +92,7 @@ suite(testing.suiteName(), function() {
     await db.fns.create_object_for_upload('foo', 'projectId', 'backendId', uploadId, uploadExpires, {}, expires);
   });
 
-  helper.dbTest('create_object_for_upload fails if called again with new uploadId', async function(db, isFake) {
+  helper.dbTest('create_object_for_upload fails if called again with new uploadId', async (db, isFake) => {
     const expires = fromNow('1 year');
     const uploadExpires = fromNow('1 day');
     let uploadId = taskcluster.slugid();
@@ -104,7 +104,7 @@ suite(testing.suiteName(), function() {
       err => err.code === UNIQUE_VIOLATION);
   });
 
-  helper.dbTest('create_object_for_upload fails if two objects use the same uploadId', async function(db, isFake) {
+  helper.dbTest('create_object_for_upload fails if two objects use the same uploadId', async (db, isFake) => {
     const expires = fromNow('1 year');
     const uploadExpires = fromNow('1 day');
     let uploadId = taskcluster.slugid();
@@ -115,7 +115,7 @@ suite(testing.suiteName(), function() {
       err => err.code === UNIQUE_VIOLATION);
   });
 
-  helper.dbTest('object_upload_complete', async function(db, isFake) {
+  helper.dbTest('object_upload_complete', async (db, isFake) => {
     const expires = fromNow('1 year');
     const uploadExpires = fromNow('1 day');
     let uploadId = taskcluster.slugid();
@@ -142,7 +142,7 @@ suite(testing.suiteName(), function() {
     });
   };
 
-  helper.dbTest('get_expired_objects returns only expired rows (including upload_expires)', async function(db) {
+  helper.dbTest('get_expired_objects returns only expired rows (including upload_expires)', async (db) => {
     const expires = fromNow('-1 day');
     const uploadExpires = fromNow('-2 day');
     const future = fromNow('1 day');
@@ -192,7 +192,7 @@ suite(testing.suiteName(), function() {
     ]);
   });
 
-  helper.dbTest('get_expired_objects pagination', async function(db) {
+  helper.dbTest('get_expired_objects pagination', async (db) => {
     await insertData(_.range(100).flatMap(i => ([{
       name: `object-${i}-not-expired`,
       backend_id: 'be-not-expired',
@@ -229,7 +229,7 @@ suite(testing.suiteName(), function() {
     assert.equal(iterations, 11);
   });
 
-  helper.dbTest('get_object', async function(db) {
+  helper.dbTest('get_object', async (db) => {
     const expires = fromNow('1 day');
     await insertData([
       {
@@ -253,7 +253,7 @@ suite(testing.suiteName(), function() {
     ]);
   });
 
-  helper.dbTest('get_object_with_upload', async function(db) {
+  helper.dbTest('get_object_with_upload', async (db) => {
     const expires = fromNow('1 day');
     await insertData([
       {
@@ -281,7 +281,7 @@ suite(testing.suiteName(), function() {
     ]);
   });
 
-  helper.dbTest('get_object_with_upload that is still uploading', async function(db) {
+  helper.dbTest('get_object_with_upload that is still uploading', async (db) => {
     const expires = fromNow('1 day');
     const uploadId = taskcluster.slugid();
     const uploadExpires = fromNow('1 hour');
@@ -311,12 +311,12 @@ suite(testing.suiteName(), function() {
     ]);
   });
 
-  helper.dbTest('get_object_with_upload that does not exist', async function(db) {
+  helper.dbTest('get_object_with_upload that does not exist', async (db) => {
     const res = await db.fns.get_object_with_upload('nosuch');
     assert.deepEqual(res, []);
   });
 
-  helper.dbTest('delete_object', async function(db) {
+  helper.dbTest('delete_object', async (db) => {
     const expires = fromNow('1 day');
     await insertData([
       {
@@ -333,13 +333,13 @@ suite(testing.suiteName(), function() {
     assert.deepEqual(res, []);
   });
 
-  helper.dbTest('delete_object that does not exist', async function(db) {
+  helper.dbTest('delete_object that does not exist', async (db) => {
     await db.fns.delete_object('nosuch');
     const res = await db.fns.get_object_with_upload('nosuch');
     assert.deepEqual(res, []);
   });
 
-  helper.dbTest('delete_object with hashes', async function(db) {
+  helper.dbTest('delete_object with hashes', async (db) => {
     const expires = fromNow('1 day');
     const uploadId = taskcluster.slugid();
     await insertData([
@@ -353,7 +353,7 @@ suite(testing.suiteName(), function() {
     assert.deepEqual(res, []);
   });
 
-  helper.dbTest('add object hashes simple case', async function(db) {
+  helper.dbTest('add object hashes simple case', async (db) => {
     const expires = fromNow('1 day');
     const uploadId = taskcluster.slugid();
     await insertData([
@@ -365,7 +365,7 @@ suite(testing.suiteName(), function() {
       [{ algorithm: 'sha3', hash: '123' }, { algorithm: 'sha5', hash: 'abcde' }]);
   });
 
-  helper.dbTest('add object hashes to a finished object', async function(db) {
+  helper.dbTest('add object hashes to a finished object', async (db) => {
     const expires = fromNow('1 day');
     await insertData([
       { name: 'object-1', backend_id: 'be', project_id: 'prj', data: { }, expires, upload_id: null },
@@ -379,7 +379,7 @@ suite(testing.suiteName(), function() {
       []);
   });
 
-  helper.dbTest('add and get object hashes add more hashes with different algorithms', async function(db) {
+  helper.dbTest('add and get object hashes add more hashes with different algorithms', async (db) => {
     const expires = fromNow('1 day');
     const uploadId = taskcluster.slugid();
     await insertData([
@@ -397,7 +397,7 @@ suite(testing.suiteName(), function() {
       ]);
   });
 
-  helper.dbTest('add object hashes add more hashes with overlapping algorithms, same hashes', async function(db) {
+  helper.dbTest('add object hashes add more hashes with overlapping algorithms, same hashes', async (db) => {
     const expires = fromNow('1 day');
     const uploadId = taskcluster.slugid();
     await insertData([
@@ -414,7 +414,7 @@ suite(testing.suiteName(), function() {
       ]);
   });
 
-  helper.dbTest('add object hashes add more hashes with overlapping algorithms, conflicting hashes', async function(db) {
+  helper.dbTest('add object hashes add more hashes with overlapping algorithms, conflicting hashes', async (db) => {
     const expires = fromNow('1 day');
     const uploadId = taskcluster.slugid();
     await insertData([
@@ -433,7 +433,7 @@ suite(testing.suiteName(), function() {
       ]);
   });
 
-  helper.dbTest('add object hashes for nonexistent object fails', async function(db) {
+  helper.dbTest('add object hashes for nonexistent object fails', async (db) => {
     await assert.rejects(
       () => db.fns.add_object_hashes('foo', JSON.stringify({ 'sha5': 'abcde' })),
       err => err.code === FOREIGN_KEY_VIOLATION);

--- a/db/test/fns/purge_cache_test.js
+++ b/db/test/fns/purge_cache_test.js
@@ -4,7 +4,7 @@ import tc from '@taskcluster/client';
 const { fromNow } = tc;
 import helper from '../helper.js';
 
-suite(testing.suiteName(), function() {
+suite(testing.suiteName(), () => {
   helper.withDbForProcs({ serviceName: 'purge_cache' });
 
   const samples = [
@@ -12,7 +12,7 @@ suite(testing.suiteName(), function() {
     { worker_pool_id: 'prov-2/wt-2', cache_name: 'cache-2', before: fromNow('0 seconds'), expires: fromNow('2 days') },
   ];
 
-  setup('reset table', async function() {
+  setup('reset table', async () => {
     await helper.withDbClient(async client => {
       await client.query('delete from cache_purges');
       await client.query(
@@ -43,12 +43,12 @@ suite(testing.suiteName(), function() {
     }
   }
 
-  helper.dbTest('all_purge_requests_wpid', async function(db) {
+  helper.dbTest('all_purge_requests_wpid', async (db) => {
     const caches = await db.fns.all_purge_requests_wpid(5, 0);
     compare(caches, samples);
   });
 
-  helper.dbTest('all_purge_requests_wpid in pages', async function(db) {
+  helper.dbTest('all_purge_requests_wpid in pages', async (db) => {
     const size = 1;
     let offset = 0;
     let caches = await db.fns.all_purge_requests_wpid(size, offset);
@@ -62,7 +62,7 @@ suite(testing.suiteName(), function() {
     compare(caches[0], samples[1]);
   });
 
-  helper.dbTest('purge_cache (create)', async function(db) {
+  helper.dbTest('purge_cache (create)', async (db) => {
     const sample = { worker_pool_id: 'prov-3/wt-3', cache_name: 'cache-3', before: fromNow('0 seconds'), expires: fromNow('1 day') };
 
     await db.fns.purge_cache_wpid(
@@ -82,7 +82,7 @@ suite(testing.suiteName(), function() {
     assert(!cache.etag);
   });
 
-  helper.dbTest('purge_cache (upsert)', async function(db) {
+  helper.dbTest('purge_cache (upsert)', async (db) => {
     const sample = { worker_pool_id: 'prov-3/wt-3', cache_name: 'cache-3' };
 
     await db.fns.purge_cache_wpid(sample.worker_pool_id, sample.cache_name, fromNow('10 seconds'), fromNow('1 day'));
@@ -106,7 +106,7 @@ suite(testing.suiteName(), function() {
     assert(cache2.before.getTime());
   });
 
-  helper.dbTest('purge_requests', async function(db) {
+  helper.dbTest('purge_requests', async (db) => {
     const samples = [
       { worker_pool_id: 'prov-3/wt-3', cache_name: 'cache-3', before: fromNow('4 days'), expires: fromNow('1 day') },
       { worker_pool_id: 'prov-3/wt-3', cache_name: 'cache-4', before: fromNow('6 days'), expires: fromNow('1 day') },
@@ -127,7 +127,7 @@ suite(testing.suiteName(), function() {
     compare(entries, samples);
   });
 
-  helper.dbTest('expire_cache_purges', async function(db) {
+  helper.dbTest('expire_cache_purges', async (db) => {
     const samples = [
       { worker_pool_id: 'prov-3/wt-3', cache_name: 'cache-3', before: fromNow('4 days'), expires: fromNow('- 1 day') },
       { worker_pool_id: 'prov-3/wt-3', cache_name: 'cache-4', before: fromNow('6 days'), expires: fromNow('- 2 days') },

--- a/db/test/fns/queue_artifacts_test.js
+++ b/db/test/fns/queue_artifacts_test.js
@@ -6,16 +6,16 @@ import _ from 'lodash';
 import helper from '../helper.js';
 import taskcluster from '@taskcluster/client';
 
-suite(testing.suiteName(), function() {
+suite(testing.suiteName(), () => {
   helper.withDbForProcs({ serviceName: 'queue' });
 
-  setup('reset table', async function() {
+  setup('reset table', async () => {
     await helper.withDbClient(async client => {
       await client.query('delete from queue_artifacts');
     });
   });
 
-  helper.dbTest('create_queue_artifact returns the artifact', async function(db) {
+  helper.dbTest('create_queue_artifact returns the artifact', async (db) => {
     const now = new Date();
     const taskId = slugid.nice();
     const [artifact] = await db.fns.create_queue_artifact_2(
@@ -39,7 +39,7 @@ suite(testing.suiteName(), function() {
     assert.equal(artifact.expires.toJSON(), now.toJSON());
   });
 
-  helper.dbTest('create_queue_artifact throws when row exists', async function(db) {
+  helper.dbTest('create_queue_artifact throws when row exists', async (db) => {
     const taskId = slugid.nice();
     await db.fns.create_queue_artifact_2(
       taskId,
@@ -70,7 +70,7 @@ suite(testing.suiteName(), function() {
     );
   });
 
-  helper.dbTest('update_queue_artifacts_2 can update expires, storage_type, and details', async function(db) {
+  helper.dbTest('update_queue_artifacts_2 can update expires, storage_type, and details', async (db) => {
     const taskId = slugid.nice();
     await db.fns.create_queue_artifact_2(
       taskId,
@@ -101,7 +101,7 @@ suite(testing.suiteName(), function() {
     assert.equal(artifact.expires.toJSON(), new Date(2).toJSON());
   });
 
-  helper.dbTest('update_queue_artifact_2 no changes to expires, storage_type, and details', async function(db) {
+  helper.dbTest('update_queue_artifact_2 no changes to expires, storage_type, and details', async (db) => {
     const taskId = slugid.nice();
     const now = new Date();
     await db.fns.create_queue_artifact_2(
@@ -134,7 +134,7 @@ suite(testing.suiteName(), function() {
     assert.equal(artifact.expires.toJSON(), now.toJSON());
   });
 
-  helper.dbTest('queue_artifact_present sets present', async function(db) {
+  helper.dbTest('queue_artifact_present sets present', async (db) => {
     const taskId = slugid.nice();
     const [artifact] = await db.fns.create_queue_artifact_2(
       taskId,
@@ -159,13 +159,13 @@ suite(testing.suiteName(), function() {
     await db.fns.queue_artifact_present({ task_id_in: taskId, run_id_in: 0, name_in: 'name' });
   });
 
-  helper.dbTest('queue_artifact_present returns nothing for missing artifact', async function(db) {
+  helper.dbTest('queue_artifact_present returns nothing for missing artifact', async (db) => {
     const taskId = slugid.nice();
     const [artifact] = await db.fns.queue_artifact_present({ task_id_in: taskId, run_id_in: 0, name_in: 'name' });
     assert(!artifact);
   });
 
-  helper.dbTest('get_queue_artifact gets an artifact', async function(db) {
+  helper.dbTest('get_queue_artifact gets an artifact', async (db) => {
     const taskId = slugid.nice();
     const now = new Date();
     await db.fns.create_queue_artifact_2(
@@ -190,18 +190,18 @@ suite(testing.suiteName(), function() {
     assert.equal(artifact.expires.toJSON(), now.toJSON());
   });
 
-  helper.dbTest('get_queue_artifact does not throw when not found', async function(db) {
+  helper.dbTest('get_queue_artifact does not throw when not found', async (db) => {
     const taskId = slugid.nice();
     const [artifact] = await db.fns.get_queue_artifact_2(taskId, 0, 'name');
     assert(!artifact, 'expected no artifact');
   });
 
-  helper.dbTest('get_queue_artifacts empty', async function(db) {
+  helper.dbTest('get_queue_artifacts empty', async (db) => {
     const rows = await db.deprecatedFns.get_queue_artifacts(null, null, null, null, null);
     assert.deepEqual(rows, []);
   });
 
-  helper.dbTest('get_queue_artifacts full, pagination', async function(db) {
+  helper.dbTest('get_queue_artifacts full, pagination', async (db) => {
     const now = new Date();
     const taskId = slugid.nice();
     for (let i = 0; i < 10; i++) {
@@ -234,7 +234,7 @@ suite(testing.suiteName(), function() {
       [4, 5].map(i => ({ task_id: taskId, run_id: i, name: `name-${i}` })));
   });
 
-  helper.dbTest('get_queue_artifacts full, pagination filtered by task_id and run_id', async function(db) {
+  helper.dbTest('get_queue_artifacts full, pagination filtered by task_id and run_id', async (db) => {
     const now = new Date();
     const taskId = slugid.nice();
     for (let i = 0; i < 10; i++) {
@@ -267,7 +267,7 @@ suite(testing.suiteName(), function() {
       [4, 5].map(i => ({ task_id: taskId, run_id: 0, name: `name-${i}` })));
   });
 
-  helper.dbTest('get_queue_artifacts_paginated empty', async function(db) {
+  helper.dbTest('get_queue_artifacts_paginated empty', async (db) => {
     const rows = await db.fns.get_queue_artifacts_paginated_2({
       task_id_in: null,
       run_id_in: null,
@@ -280,7 +280,7 @@ suite(testing.suiteName(), function() {
     assert.deepEqual(rows, []);
   });
 
-  helper.dbTest('get_queue_artifacts_paginated full, pagination', async function(db) {
+  helper.dbTest('get_queue_artifacts_paginated full, pagination', async (db) => {
     const now = new Date();
     const expected = [];
     const taskIds = [
@@ -388,7 +388,7 @@ suite(testing.suiteName(), function() {
     }
   });
 
-  helper.dbTest('get_queue_artifacts_paginated full, filtered by task_id and run_id', async function(db) {
+  helper.dbTest('get_queue_artifacts_paginated full, filtered by task_id and run_id', async (db) => {
     const now = new Date();
     const taskId = slugid.nice();
     for (let i = 0; i < 10; i++) {
@@ -437,7 +437,7 @@ suite(testing.suiteName(), function() {
       [4, 5].map(i => ({ task_id: taskId, run_id: 0, name: `name-${i}` })));
   });
 
-  helper.dbTest('get_queue_artifacts_paginated get expired tasks', async function(db) {
+  helper.dbTest('get_queue_artifacts_paginated get expired tasks', async (db) => {
     const yesterday = taskcluster.fromNow('-1 day');
     const tomorrow = taskcluster.fromNow('1 day');
     const today = new Date();
@@ -468,7 +468,7 @@ suite(testing.suiteName(), function() {
     assert.deepEqual(rows.map(({ run_id }) => run_id), [0, 2, 4, 6, 8]);
   });
 
-  helper.dbTest('get_expired_artifacts_for_deletion and delete_queue_artifacts', async function(db) {
+  helper.dbTest('get_expired_artifacts_for_deletion and delete_queue_artifacts', async (db) => {
     const yesterday = taskcluster.fromNow('-1 day');
     const tomorrow = taskcluster.fromNow('1 day');
     const today = new Date();
@@ -505,7 +505,7 @@ suite(testing.suiteName(), function() {
     assert.equal(rows.length, 0);
   });
 
-  helper.dbTest('delete_queue_artifact can delete an artifact', async function(db) {
+  helper.dbTest('delete_queue_artifact can delete an artifact', async (db) => {
     const taskId = slugid.nice();
     const now = new Date();
     await db.fns.create_queue_artifact_2(
@@ -524,7 +524,7 @@ suite(testing.suiteName(), function() {
     assert(!artifact);
   });
 
-  helper.dbTest('delete_queue_artifact does not throw when artifact not found', async function(db) {
+  helper.dbTest('delete_queue_artifact does not throw when artifact not found', async (db) => {
     const taskId = slugid.nice();
     await db.fns.delete_queue_artifact(taskId, 0, 'name');
   });

--- a/db/test/fns/queue_test.js
+++ b/db/test/fns/queue_test.js
@@ -9,7 +9,7 @@ import testing from '@taskcluster/lib-testing';
 import { INVALID_PARAMETER_VALUE, UNIQUE_VIOLATION } from '@taskcluster/lib-postgres';
 import taskcluster from '@taskcluster/client';
 
-suite(testing.suiteName(), function() {
+suite(testing.suiteName(), () => {
   helper.withDbForProcs({ serviceName: 'queue' });
 
   const taskId = 'hOTDAv0gRfW6YA2hm4n5FQ';
@@ -73,19 +73,19 @@ suite(testing.suiteName(), function() {
     });
   };
 
-  suite('tests for pending tasks', function() {
-    setup('reset table', async function () {
+  suite('tests for pending tasks', () => {
+    setup('reset table', async () => {
       await helper.withDbClient(async client => {
         await client.query('delete from queue_pending_tasks');
       });
     });
-    helper.dbTest('count empty queue', async function (db) {
+    helper.dbTest('count empty queue', async (db) => {
       assert.deepEqual(
         await db.fns.queue_pending_tasks_count("tq1"),
         [{ queue_pending_tasks_count: 0 }],
       );
     });
-    helper.dbTest('count queue containing messages', async function (db) {
+    helper.dbTest('count queue containing messages', async (db) => {
       await db.fns.queue_pending_tasks_add('tq1', 1, 'task1', 0, 'hint1', fromNow('10 seconds'));
       // this one is the same task and run, so only one record would remain
       await db.fns.queue_pending_tasks_add('tq1', 9, 'task1', 0, 'hint1', fromNow('10 seconds'));
@@ -111,12 +111,12 @@ suite(testing.suiteName(), function() {
     //   assert.deepEquals(notifications, ['tq1']);
     // });
 
-    helper.dbTest('getting tasks on an empty queue', async function (db) {
+    helper.dbTest('getting tasks on an empty queue', async (db) => {
       const result = await db.fns.queue_pending_tasks_get("tq1", fromNow('10 seconds'), 1);
       assert.deepEqual(result, []);
     });
 
-    helper.dbTest('getting tasks on a queue by priority', async function (db) {
+    helper.dbTest('getting tasks on a queue by priority', async (db) => {
       await db.fns.queue_pending_tasks_add(
         'tq1', 2, 'taskLowerPriority', 0, 'hint2', fromNow('20 seconds'));
       await db.fns.queue_pending_tasks_add(
@@ -133,7 +133,7 @@ suite(testing.suiteName(), function() {
       assert.deepEqual(result2, []);
     });
 
-    helper.dbTest('getting and deleting pending tasks', async function (db) {
+    helper.dbTest('getting and deleting pending tasks', async (db) => {
       await db.fns.queue_pending_tasks_add('tq1', 2, 't1', 0, 'hint1', fromNow('20 seconds'));
       const result = await db.fns.queue_pending_tasks_get("tq1", fromNow('10 seconds'), 1);
       assert.deepEqual(result.map(({ task_id }) => task_id), ['t1']);
@@ -142,7 +142,7 @@ suite(testing.suiteName(), function() {
       assert.deepEqual(result2, []);
     });
 
-    helper.dbTest('releasing pending tasks back to queue', async function (db) {
+    helper.dbTest('releasing pending tasks back to queue', async (db) => {
       await db.fns.queue_pending_tasks_add('tq1', 2, 't1', 0, 'hint1', fromNow('20 seconds'));
       const result = await db.fns.queue_pending_tasks_get("tq1", fromNow('10 seconds'), 1);
       assert.deepEqual(result.map(({ task_id }) => task_id), ['t1']);
@@ -153,7 +153,7 @@ suite(testing.suiteName(), function() {
       assert.deepEqual(result3.map(({ task_id }) => task_id), ['t1']);
     });
 
-    helper.dbTest('deleting expired messages', async function (db) {
+    helper.dbTest('deleting expired messages', async (db) => {
       await db.fns.queue_pending_tasks_add('tq1', 0, 't1', 0, 'hint1', fromNow('-1 second'));
       await db.fns.queue_pending_tasks_add('tq1', 0, 't2', 0, 'hint2', fromNow('-1 second'));
       await db.fns.queue_pending_tasks_delete_expired();
@@ -163,7 +163,7 @@ suite(testing.suiteName(), function() {
       });
     });
 
-    helper.dbTest('deleting tasks from pending queue', async function (db) {
+    helper.dbTest('deleting tasks from pending queue', async (db) => {
       await db.fns.queue_pending_tasks_add('tq1', 0, 't1', 0, 'hint1', fromNow('50 second'));
       await db.fns.queue_pending_tasks_add('tq1', 0, 't1', 1, 'hint2', fromNow('50 second'));
 
@@ -176,7 +176,7 @@ suite(testing.suiteName(), function() {
       });
     });
 
-    helper.dbTest('listing pending tasks', async function (db) {
+    helper.dbTest('listing pending tasks', async (db) => {
       const res = await db.fns.get_pending_tasks_by_task_queue_id('task/queue', null, null, null);
       assert.deepEqual(res, []);
 
@@ -198,7 +198,7 @@ suite(testing.suiteName(), function() {
       assert.equal(res4.length, 2);
     });
 
-    helper.dbTest('listing pending tasks excludes expired', async function (db) {
+    helper.dbTest('listing pending tasks excludes expired', async (db) => {
       const tq = 'task/queue-maybe-expired';
       const res = await db.fns.get_pending_tasks_by_task_queue_id(tq, null, null, null);
       assert.deepEqual(res, []);
@@ -219,19 +219,19 @@ suite(testing.suiteName(), function() {
 
   });
 
-  suite('tests for claimed tasks', function() {
-    setup('reset table', async function () {
+  suite('tests for claimed tasks', () => {
+    setup('reset table', async () => {
       await helper.withDbClient(async client => {
         await client.query('delete from queue_claimed_tasks');
       });
     });
 
-    helper.dbTest('getting tasks on an empty claim queue', async function (db) {
+    helper.dbTest('getting tasks on an empty claim queue', async (db) => {
       const result = await db.fns.queue_claimed_task_get(fromNow('10 seconds'), 1);
       assert.deepEqual(result, []);
     });
 
-    helper.dbTest('getting tasks from the claim queue', async function (db) {
+    helper.dbTest('getting tasks from the claim queue', async (db) => {
       await db.fns.queue_claimed_task_put('t1', 0, fromNow('-20 seconds'), 'tq1', 'wg1', 'w1');
       await db.fns.queue_claimed_task_put('t2', 0, fromNow('-10 seconds'), 'tq1', 'wg1', 'w1');
       const result = await db.fns.queue_claimed_task_get(fromNow('10 seconds'), 2);
@@ -241,7 +241,7 @@ suite(testing.suiteName(), function() {
       assert.deepEqual(result2, []);
     });
 
-    helper.dbTest('getting tasks and removing them from the claim queue', async function (db) {
+    helper.dbTest('getting tasks and removing them from the claim queue', async (db) => {
       await db.fns.queue_claimed_task_put('t1', 0, fromNow('-20 seconds'), 'tq1', 'wg1', 'w1');
       await db.fns.queue_claimed_task_put('t2', 0, fromNow('-10 seconds'), 'tq1', 'wg1', 'w1');
 
@@ -257,7 +257,7 @@ suite(testing.suiteName(), function() {
       assert.deepEqual(result2, []);
     });
 
-    helper.dbTest('multiple rows for the same taskId,runId should exist but only visible returned', async function (db) {
+    helper.dbTest('multiple rows for the same taskId,runId should exist but only visible returned', async (db) => {
       const t1 = fromNow('-20 seconds');
       const t2 = fromNow('-10 seconds');
       const t3 = fromNow('60 seconds');
@@ -272,7 +272,7 @@ suite(testing.suiteName(), function() {
       assert.equal(new Date(rows[1].taken_until).toJSON(), t2.toJSON());
     });
 
-    helper.dbTest('resolved before claim expires tasks should be removed from the queue', async function (db) {
+    helper.dbTest('resolved before claim expires tasks should be removed from the queue', async (db) => {
       await db.fns.queue_claimed_task_put('t1', 0, fromNow('-20 seconds'), 'tq1', 'wg1', 'w1');
       await db.fns.queue_claimed_task_put('t2', 0, fromNow('-20 seconds'), 'tq1', 'wg1', 'w1');
 
@@ -283,7 +283,7 @@ suite(testing.suiteName(), function() {
       assert.equal(result[0].task_id, 't2');
     });
 
-    helper.dbTest('listing claimed tasks', async function (db) {
+    helper.dbTest('listing claimed tasks', async (db) => {
       const res = await db.fns.get_claimed_tasks_by_task_queue_id('task/queue', null, null, null);
       assert.deepEqual(res, []);
 
@@ -305,7 +305,7 @@ suite(testing.suiteName(), function() {
       assert.equal(res4.length, 2);
     });
 
-    helper.dbTest('listing claimed tasks by worker', async function (db) {
+    helper.dbTest('listing claimed tasks by worker', async (db) => {
       // empty result when no tasks claimed
       const res = await db.fns.get_claimed_tasks_by_worker('task/queue', 'wg1', 'w1');
       assert.deepEqual(res, []);
@@ -332,19 +332,19 @@ suite(testing.suiteName(), function() {
     });
   });
 
-  suite('tests for resolved tasks', function() {
-    setup('reset table', async function () {
+  suite('tests for resolved tasks', () => {
+    setup('reset table', async () => {
       await helper.withDbClient(async client => {
         await client.query('delete from queue_resolved_tasks');
       });
     });
 
-    helper.dbTest('getting tasks on an empty resolved queue', async function (db) {
+    helper.dbTest('getting tasks on an empty resolved queue', async (db) => {
       const result = await db.fns.queue_resolved_task_get(fromNow('10 seconds'), 1);
       assert.deepEqual(result, []);
     });
 
-    helper.dbTest('getting tasks from the resolved queue', async function (db) {
+    helper.dbTest('getting tasks from the resolved queue', async (db) => {
       await db.fns.queue_resolved_task_put('tg1', 't1', 's1', fromNow('-20 seconds'));
       await db.fns.queue_resolved_task_put('tg2', 't2', 's2', fromNow('-20 seconds'));
       const result = await db.fns.queue_resolved_task_get(fromNow('10 seconds'), 2);
@@ -354,7 +354,7 @@ suite(testing.suiteName(), function() {
       assert.deepEqual(result2, []);
     });
 
-    helper.dbTest('getting tasks and removing them from the claim queue', async function (db) {
+    helper.dbTest('getting tasks and removing them from the claim queue', async (db) => {
       await db.fns.queue_resolved_task_put('tg1', 't1', 's1', fromNow('-20 seconds'));
       await db.fns.queue_resolved_task_put('tg2', 't2', 's2', fromNow('-20 seconds'));
 
@@ -371,19 +371,19 @@ suite(testing.suiteName(), function() {
     });
   });
 
-  suite('tests for task deadlines', function() {
-    setup('reset table', async function () {
+  suite('tests for task deadlines', () => {
+    setup('reset table', async () => {
       await helper.withDbClient(async client => {
         await client.query('delete from queue_task_deadlines');
       });
     });
 
-    helper.dbTest('getting tasks on an empty deadline queue', async function (db) {
+    helper.dbTest('getting tasks on an empty deadline queue', async (db) => {
       const result = await db.fns.queue_task_deadline_get(fromNow('10 seconds'), 1);
       assert.deepEqual(result, []);
     });
 
-    helper.dbTest('getting tasks from the deadline queue', async function (db) {
+    helper.dbTest('getting tasks from the deadline queue', async (db) => {
       await db.fns.queue_task_deadline_put('tg1', 't1', 's1', fromNow('-20 seconds'), fromNow('-20 seconds'));
       await db.fns.queue_task_deadline_put('tg2', 't2', 's2', fromNow('-20 seconds'), fromNow('-20 seconds'));
       const result = await db.fns.queue_task_deadline_get(fromNow('10 seconds'), 2);
@@ -393,7 +393,7 @@ suite(testing.suiteName(), function() {
       assert.deepEqual(result2, []);
     });
 
-    helper.dbTest('getting tasks and removing them from the claim queue', async function (db) {
+    helper.dbTest('getting tasks and removing them from the claim queue', async (db) => {
       await db.fns.queue_task_deadline_put('tg1', 't1', 's1', fromNow('-20 seconds'), fromNow('-20 seconds'));
       await db.fns.queue_task_deadline_put('tg2', 't2', 's2', fromNow('-20 seconds'), fromNow('-20 seconds'));
 
@@ -410,8 +410,8 @@ suite(testing.suiteName(), function() {
     });
   });
 
-  suite('task/task-group functions', function() {
-    setup('reset tables', async function() {
+  suite('task/task-group functions', () => {
+    setup('reset tables', async () => {
       await helper.withDbClient(async client => {
         await client.query('truncate tasks');
         await client.query('truncate task_groups');
@@ -420,8 +420,8 @@ suite(testing.suiteName(), function() {
       });
     });
 
-    suite('ensure_task_group/get_task_group', function () {
-      helper.dbTest('ensure_task_group in parallel with the same scheduler_id', async function (db) {
+    suite('ensure_task_group/get_task_group', () => {
+      helper.dbTest('ensure_task_group in parallel with the same scheduler_id', async (db) => {
         const expires = taskcluster.fromNow('1 hour');
         await Promise.all([
           db.fns.ensure_task_group('0cM7dCL2Rpaz0wdnDG4LLg', 'sched', expires),
@@ -437,7 +437,7 @@ suite(testing.suiteName(), function() {
         assert(tgs[0].expires > expires);
       });
 
-      helper.dbTest('ensure_task_group twice with different scheduler_id', async function (db) {
+      helper.dbTest('ensure_task_group twice with different scheduler_id', async (db) => {
         const expires = taskcluster.fromNow('1 hour');
         await db.fns.ensure_task_group('0cM7dCL2Rpaz0wdnDG4LLg', 'sched1', expires);
         await assert.rejects(
@@ -451,7 +451,7 @@ suite(testing.suiteName(), function() {
         assert(tgs[0].expires > expires);
       });
 
-      helper.dbTest('ensure_task_group twice with different task_group_id and scheduler_id', async function (db) {
+      helper.dbTest('ensure_task_group twice with different task_group_id and scheduler_id', async (db) => {
         const expires = taskcluster.fromNow('1 hour');
         await db.fns.ensure_task_group('0cM7dCL2Rpaz0wdnDG4LLg', 'sched', expires);
         await db.fns.ensure_task_group('jcy-h6_7SFuRuKLPByiFTg', 'sched', expires);
@@ -464,8 +464,8 @@ suite(testing.suiteName(), function() {
       });
     });
 
-    suite('ensure_task_group/get_task_group2', function() {
-      helper.dbTest('ensure_task_group in parallel with the same scheduler_id', async function(db) {
+    suite('ensure_task_group/get_task_group2', () => {
+      helper.dbTest('ensure_task_group in parallel with the same scheduler_id', async (db) => {
         const expires = taskcluster.fromNow('1 hour');
         await Promise.all([
           db.fns.ensure_task_group('0cM7dCL2Rpaz0wdnDG4LLg', 'sched', expires),
@@ -481,7 +481,7 @@ suite(testing.suiteName(), function() {
         assert(tgs[0].expires > expires);
       });
 
-      helper.dbTest('ensure_task_group twice with different scheduler_id', async function(db) {
+      helper.dbTest('ensure_task_group twice with different scheduler_id', async (db) => {
         const expires = taskcluster.fromNow('1 hour');
         await db.fns.ensure_task_group('0cM7dCL2Rpaz0wdnDG4LLg', 'sched1', expires);
         await assert.rejects(
@@ -495,7 +495,7 @@ suite(testing.suiteName(), function() {
         assert(tgs[0].expires > expires);
       });
 
-      helper.dbTest('ensure_task_group twice with different task_group_id and scheduler_id', async function(db) {
+      helper.dbTest('ensure_task_group twice with different task_group_id and scheduler_id', async (db) => {
         const expires = taskcluster.fromNow('1 hour');
         await db.fns.ensure_task_group('0cM7dCL2Rpaz0wdnDG4LLg', 'sched', expires);
         await db.fns.ensure_task_group('jcy-h6_7SFuRuKLPByiFTg', 'sched', expires);
@@ -508,8 +508,8 @@ suite(testing.suiteName(), function() {
       });
     });
 
-    suite('seal task groups', function () {
-      helper.dbTest('seal_task_group', async function (db) {
+    suite('seal task groups', () => {
+      helper.dbTest('seal_task_group', async (db) => {
         const taskGroupId = '111111L2Rpaz0wdnDG4LLg';
         await db.fns.ensure_task_group(taskGroupId, 'sched1', taskcluster.fromNow('1 hour'));
 
@@ -533,8 +533,8 @@ suite(testing.suiteName(), function() {
       });
     });
 
-    suite('expire_task_groups', function() {
-      helper.dbTest('expire expired task groups', async function(db) {
+    suite('expire_task_groups', () => {
+      helper.dbTest('expire expired task groups', async (db) => {
         await Promise.all([
           // 5 hours ago since ensure_task_group rounds up by an hour
           db.fns.ensure_task_group('111111L2Rpaz0wdnDG4LLg', 'sched1', taskcluster.fromNow('-5 hours')),
@@ -552,7 +552,7 @@ suite(testing.suiteName(), function() {
         assert.equal((await db.fns.get_task_group2('444444L2Rpaz0wdnDG4LLg')).length, 1);
       });
 
-      helper.dbTest('ensure_task_group twice with different scheduler_id', async function(db) {
+      helper.dbTest('ensure_task_group twice with different scheduler_id', async (db) => {
         const expires = taskcluster.fromNow('1 hour');
         await db.fns.ensure_task_group('0cM7dCL2Rpaz0wdnDG4LLg', 'sched1', expires);
         await assert.rejects(
@@ -566,7 +566,7 @@ suite(testing.suiteName(), function() {
         assert(tgs[0].expires > expires);
       });
 
-      helper.dbTest('ensure_task_group twice with different task_group_id and scheduler_id', async function(db) {
+      helper.dbTest('ensure_task_group twice with different task_group_id and scheduler_id', async (db) => {
         const expires = taskcluster.fromNow('1 hour');
         await db.fns.ensure_task_group('0cM7dCL2Rpaz0wdnDG4LLg', 'sched', expires);
         await db.fns.ensure_task_group('jcy-h6_7SFuRuKLPByiFTg', 'sched', expires);
@@ -579,7 +579,7 @@ suite(testing.suiteName(), function() {
       });
     });
 
-    helper.dbTest('create_task_projid/get_task_projid', async function(db) {
+    helper.dbTest('create_task_projid/get_task_projid', async (db) => {
       await create(db);
       const res = await db.fns.get_task_projid(taskId);
       assert.equal(res.length, 1);
@@ -606,7 +606,7 @@ suite(testing.suiteName(), function() {
       assert.deepEqual(res[0].taken_until, null);
     });
 
-    helper.dbTest('create_task_tqid/get_task_tqid (deprecated)', async function(db) {
+    helper.dbTest('create_task_tqid/get_task_tqid (deprecated)', async (db) => {
       await db.deprecatedFns.create_task_tqid(
         taskId,
         'prov/wt',
@@ -650,7 +650,7 @@ suite(testing.suiteName(), function() {
       assert.deepEqual(res[0].taken_until, null);
     });
 
-    helper.dbTest('create_task/get_task (deprecated)', async function(db) {
+    helper.dbTest('create_task/get_task (deprecated)', async (db) => {
       await db.deprecatedFns.create_task(
         taskId,
         'prov',
@@ -700,7 +700,7 @@ suite(testing.suiteName(), function() {
       assert.equal(res[0].project_id, 'none'); // default value
     });
 
-    helper.dbTest('get_tasks_by_task_group_projid', async function(db) {
+    helper.dbTest('get_tasks_by_task_group_projid', async (db) => {
       for (let i = 1; i <= 5; i++) {
         await create(db, {
           taskId: `tid-${i}`,
@@ -723,7 +723,7 @@ suite(testing.suiteName(), function() {
       assert.equal(res[0].project_id, 'proj2');
     });
 
-    helper.dbTest('get_tasks_by_task_group_tqid (deprecated)', async function(db) {
+    helper.dbTest('get_tasks_by_task_group_tqid (deprecated)', async (db) => {
       for (let i = 1; i <= 5; i++) {
         await create(db, {
           taskId: `tid-${i}`,
@@ -746,24 +746,24 @@ suite(testing.suiteName(), function() {
       assert.equal(res[0].task_queue_id, 'prov/wt-2');
     });
 
-    helper.dbTest('create_task twice (UNIQUE_VIOLATION)', async function(db) {
+    helper.dbTest('create_task twice (UNIQUE_VIOLATION)', async (db) => {
       await create(db);
       await assert.rejects(
         () => create(db),
         err => err.code === UNIQUE_VIOLATION);
     });
 
-    helper.dbTest('get_task with no such task', async function(db) {
+    helper.dbTest('get_task with no such task', async (db) => {
       const res = await db.fns.get_task_projid('hOTDAv0gRfW6YA2hm4n5FQ');
       assert.deepEqual(res, []);
     });
 
-    helper.dbTest('get_multiple_tasks with empty tasks', async function(db) {
+    helper.dbTest('get_multiple_tasks with empty tasks', async (db) => {
       const res = await db.fns.get_multiple_tasks(JSON.stringify([]), 1000, 0);
       assert.deepEqual(res, []);
     });
 
-    helper.dbTest('get_multiple_tasks with no such tasks', async function(db) {
+    helper.dbTest('get_multiple_tasks with no such tasks', async (db) => {
       const res = await db.fns.get_multiple_tasks(
         JSON.stringify(["these", "do", "not", "exist"]),
         1000,
@@ -772,7 +772,7 @@ suite(testing.suiteName(), function() {
       assert.deepEqual(res, []);
     });
 
-    helper.dbTest('get_multiple_tasks not an array', async function(db) {
+    helper.dbTest('get_multiple_tasks not an array', async (db) => {
       await create(db, { taskId: `tid-1` });
 
       assert.rejects(
@@ -790,7 +790,7 @@ suite(testing.suiteName(), function() {
       );
     });
 
-    helper.dbTest('get_multiple_tasks works', async function(db) {
+    helper.dbTest('get_multiple_tasks works', async (db) => {
       for (let i = 1; i <= 5; i++) {
         await create(db, {
           taskId: `tid-${i}`,
@@ -838,27 +838,27 @@ suite(testing.suiteName(), function() {
 
     });
 
-    helper.dbTest('remove_task', async function(db) {
+    helper.dbTest('remove_task', async (db) => {
       await create(db);
       await db.fns.remove_task(taskId);
       const res = await db.fns.get_task_projid(taskId);
       assert.deepEqual(res, []);
     });
 
-    helper.dbTest('remove_task with no such task', async function(db) {
+    helper.dbTest('remove_task with no such task', async (db) => {
       await db.fns.remove_task(taskId);
       // ..didn't throw an error..
       const res = await db.fns.get_task_projid(taskId);
       assert.deepEqual(res, []);
     });
 
-    suite('schedule_task', function() {
-      helper.dbTest('no such task', async function(db) {
+    suite('schedule_task', () => {
+      helper.dbTest('no such task', async (db) => {
         const res = await db.fns.schedule_task(taskId, 'because');
         assert.deepEqual(res, []);
       });
 
-      helper.dbTest('task with existing runs', async function(db) {
+      helper.dbTest('task with existing runs', async (db) => {
         await create(db);
         await setTaskRuns(db, [{ state: 'pending' }]);
         const res = await db.fns.schedule_task(taskId, 'because');
@@ -868,7 +868,7 @@ suite(testing.suiteName(), function() {
         assert.deepEqual(task[0].runs, [{ state: 'pending' }]);
       });
 
-      helper.dbTest('task with no runs', async function(db) {
+      helper.dbTest('task with no runs', async (db) => {
         await create(db);
         const res = fixRuns(await db.fns.schedule_task(taskId, 'because'));
         assert.equal(res.length, 1);
@@ -881,7 +881,7 @@ suite(testing.suiteName(), function() {
         assert.deepEqual(task[0].runs, res[0].runs);
       });
 
-      helper.dbTest('also inserts queue_pending_tasks row', async function(db) {
+      helper.dbTest('also inserts queue_pending_tasks row', async (db) => {
         await create(db);
         await db.fns.schedule_task(taskId, 'scheduled');
 
@@ -899,14 +899,14 @@ suite(testing.suiteName(), function() {
       });
     });
 
-    suite('rerun_task', function() {
-      helper.dbTest('no such task', async function(db) {
+    suite('rerun_task', () => {
+      helper.dbTest('no such task', async (db) => {
         const res = await db.fns.rerun_task(taskId);
         assert.deepEqual(res, []);
       });
 
       for (let state of ['running', 'pending']) {
-        helper.dbTest(`task with ${state} run`, async function(db) {
+        helper.dbTest(`task with ${state} run`, async (db) => {
           await create(db);
           await setTaskRuns(db, [{ state }]);
           const res = fixRuns(await db.fns.rerun_task(taskId));
@@ -916,14 +916,14 @@ suite(testing.suiteName(), function() {
         });
       }
 
-      helper.dbTest(`task with too many runs`, async function(db) {
+      helper.dbTest(`task with too many runs`, async (db) => {
         await create(db);
         await setTaskRuns(db, range(50).map(() => ({ state: 'exception' })));
         const res = fixRuns(await db.fns.rerun_task(taskId));
         assert.deepEqual(res, []);
       });
 
-      helper.dbTest(`task with almost too many runs`, async function(db) {
+      helper.dbTest(`task with almost too many runs`, async (db) => {
         await create(db);
         await setTaskRuns(db, range(48).map(() => ({ state: 'exception' })));
         const res = fixRuns(await db.fns.rerun_task(taskId));
@@ -939,7 +939,7 @@ suite(testing.suiteName(), function() {
         assert.deepEqual(task[0].runs, res[0].runs);
       });
 
-      helper.dbTest('task with existing run', async function(db) {
+      helper.dbTest('task with existing run', async (db) => {
         await create(db);
         await setTaskRuns(db, [{ state: 'exception' }]);
         const res = fixRuns(await db.fns.rerun_task(taskId));
@@ -952,7 +952,7 @@ suite(testing.suiteName(), function() {
         assert.deepEqual(task[0].runs, res[0].runs);
       });
 
-      helper.dbTest('task with no runs', async function(db) {
+      helper.dbTest('task with no runs', async (db) => {
         await create(db);
         const res = fixRuns(await db.fns.rerun_task(taskId));
         assert.equal(res.length, 1);
@@ -965,7 +965,7 @@ suite(testing.suiteName(), function() {
         assert.deepEqual(task[0].runs, res[0].runs);
       });
 
-      helper.dbTest('also inserts queue_pending_tasks row for the new run', async function(db) {
+      helper.dbTest('also inserts queue_pending_tasks row for the new run', async (db) => {
         await create(db);
         await setTaskRuns(db, [{ state: 'exception', reasonCreated: 'scheduled', reasonResolved: 'failed' }]);
         await db.fns.rerun_task(taskId);
@@ -984,14 +984,14 @@ suite(testing.suiteName(), function() {
       });
     });
 
-    suite('cancel_task', function() {
-      helper.dbTest('no such task', async function(db) {
+    suite('cancel_task', () => {
+      helper.dbTest('no such task', async (db) => {
         const res = await db.fns.cancel_task(taskId, 'because');
         assert.deepEqual(res, []);
       });
 
       for (let state of ['exception', 'completed']) {
-        helper.dbTest(`task with ${state} run`, async function(db) {
+        helper.dbTest(`task with ${state} run`, async (db) => {
           await create(db);
           await setTaskRuns(db, [{ state }]);
           const res = fixRuns(await db.fns.cancel_task(taskId, 'because'));
@@ -1001,7 +1001,7 @@ suite(testing.suiteName(), function() {
         });
       }
 
-      helper.dbTest('task with existing run', async function(db) {
+      helper.dbTest('task with existing run', async (db) => {
         await create(db);
         await setTaskRuns(db, [{ state: 'running' }]);
         await setTaskTakenUntil(db, new Date());
@@ -1015,7 +1015,7 @@ suite(testing.suiteName(), function() {
         assert.deepEqual(task[0].runs, res[0].runs);
       });
 
-      helper.dbTest('task with no runs', async function(db) {
+      helper.dbTest('task with no runs', async (db) => {
         await create(db);
         const res = fixRuns(await db.fns.cancel_task(taskId, 'because'));
         assert.equal(res.length, 1);
@@ -1029,14 +1029,14 @@ suite(testing.suiteName(), function() {
       });
     });
 
-    suite('get_task_group_size', function () {
-      helper.dbTest('no such task group', async function (db) {
+    suite('get_task_group_size', () => {
+      helper.dbTest('no such task group', async (db) => {
         const res = await db.fns.get_task_group_size('noSuchTaskId');
         assert.deepEqual(res.length, 1);
         assert.equal(res[0].get_task_group_size, 0);
       });
 
-      helper.dbTest(`task group with few tasks`, async function (db) {
+      helper.dbTest(`task group with few tasks`, async (db) => {
         const taskGroupId = slugid.v4();
         await create(db, { taskId: slugid.v4(), taskGroupId });
         const res = await db.fns.get_task_group_size(taskGroupId);
@@ -1050,14 +1050,14 @@ suite(testing.suiteName(), function() {
       });
     });
 
-    suite('cancel_task_group', function() {
-      helper.dbTest('no such task group', async function(db) {
+    suite('cancel_task_group', () => {
+      helper.dbTest('no such task group', async (db) => {
         const res = await db.fns.cancel_task_group(taskId, 'because');
         assert.deepEqual(res, []);
       });
 
       for (let state of ['exception', 'completed']) {
-        helper.dbTest(`task group with task with ${state} run`, async function(db) {
+        helper.dbTest(`task group with task with ${state} run`, async (db) => {
           const taskGroupId = slugid.v4();
           const taskId = slugid.v4();
           await create(db, { taskId, taskGroupId });
@@ -1072,7 +1072,7 @@ suite(testing.suiteName(), function() {
         });
       }
 
-      helper.dbTest('task group with existing run', async function(db) {
+      helper.dbTest('task group with existing run', async (db) => {
         const taskGroupId = slugid.v4();
         const taskIds = [slugid.v4(), slugid.v4()];
         await Promise.all(taskIds.map(taskId => create(db, { taskId, taskGroupId })));
@@ -1087,7 +1087,7 @@ suite(testing.suiteName(), function() {
           assert.deepEqual(task[0].runs, res[0].runs);
         });
       });
-      helper.dbTest('task group should only cancel tasks once', async function(db) {
+      helper.dbTest('task group should only cancel tasks once', async (db) => {
         const taskGroupId = slugid.v4();
         const taskIds = [slugid.v4(), slugid.v4()];
         await Promise.all(taskIds.map(taskId => create(db, { taskId, taskGroupId })));
@@ -1114,7 +1114,7 @@ suite(testing.suiteName(), function() {
           reasonCreated: 'exception', reasonResolved: 'because', resolved: 'date', scheduled: 'date', state: 'exception',
         }]);
       });
-      helper.dbTest('task group with expired task', async function(db) {
+      helper.dbTest('task group with expired task', async (db) => {
         const taskGroupId = slugid.v4();
         const taskIds = [slugid.v4(), slugid.v4()];
         await Promise.all(taskIds.map(taskId => create(db, { taskId, taskGroupId, deadline: new Date(0) })));
@@ -1138,21 +1138,21 @@ suite(testing.suiteName(), function() {
       });
     });
 
-    suite('claim_task', function() {
+    suite('claim_task', () => {
       const takenUntil = new Date();
 
-      helper.dbTest('no such task', async function(db) {
+      helper.dbTest('no such task', async (db) => {
         const res = await db.fns.claim_task(taskId, 0, 'wg', 'wi', 'psst', takenUntil);
         assert.deepEqual(res, []);
       });
 
-      helper.dbTest('task with no runs', async function(db) {
+      helper.dbTest('task with no runs', async (db) => {
         await create(db);
         const res = fixRuns(await db.fns.claim_task(taskId, 0, 'wg', 'wi', 'psst', takenUntil));
         assert.deepEqual(res, []);
       });
 
-      helper.dbTest('task with a run but not claiming that run', async function(db) {
+      helper.dbTest('task with a run but not claiming that run', async (db) => {
         await create(db);
         // NOTE: two pending runs is impossible, but we want to see that the function correctly
         // sees that run 0 is not the latest run, even if it is pending
@@ -1162,7 +1162,7 @@ suite(testing.suiteName(), function() {
       });
 
       for (let state of ['exception', 'completed', 'failed', 'running']) {
-        helper.dbTest(`task with ${state} run`, async function(db) {
+        helper.dbTest(`task with ${state} run`, async (db) => {
           await create(db);
           await setTaskRuns(db, [{ state }]);
           const res = fixRuns(await db.fns.claim_task(taskId, 0, 'wg', 'wi', 'psst', takenUntil));
@@ -1172,7 +1172,7 @@ suite(testing.suiteName(), function() {
         });
       }
 
-      helper.dbTest('task with pending run', async function(db) {
+      helper.dbTest('task with pending run', async (db) => {
         await create(db);
         await setTaskRuns(db, [{ state: 'pending' }]);
         const res = fixRuns(await db.fns.claim_task(taskId, 0, 'wg', 'wi', 'psst', takenUntil));
@@ -1194,21 +1194,21 @@ suite(testing.suiteName(), function() {
       });
     });
 
-    suite('reclaim_task', function() {
+    suite('reclaim_task', () => {
       const takenUntil = new Date();
 
-      helper.dbTest('no such task', async function(db) {
+      helper.dbTest('no such task', async (db) => {
         const res = await db.fns.reclaim_task(taskId, 0, takenUntil);
         assert.deepEqual(res, []);
       });
 
-      helper.dbTest('task with no runs', async function(db) {
+      helper.dbTest('task with no runs', async (db) => {
         await create(db);
         const res = fixRuns(await db.fns.reclaim_task(taskId, 0, takenUntil));
         assert.deepEqual(res, []);
       });
 
-      helper.dbTest('task where runId is not latest', async function(db) {
+      helper.dbTest('task where runId is not latest', async (db) => {
         await create(db);
         await setTaskRuns(db, [{ state: 'running' }, { state: 'running' }]);
         const res = fixRuns(await db.fns.reclaim_task(taskId, 0, takenUntil));
@@ -1216,7 +1216,7 @@ suite(testing.suiteName(), function() {
       });
 
       for (let state of ['exception', 'completed', 'failed', 'pending']) {
-        helper.dbTest(`task with ${state} run`, async function(db) {
+        helper.dbTest(`task with ${state} run`, async (db) => {
           await create(db);
           await setTaskRuns(db, [{ state }]);
           const res = fixRuns(await db.fns.reclaim_task(taskId, 0, takenUntil));
@@ -1226,7 +1226,7 @@ suite(testing.suiteName(), function() {
         });
       }
 
-      helper.dbTest('task with running run', async function(db) {
+      helper.dbTest('task with running run', async (db) => {
         await create(db);
         await setTaskRuns(db, [
           { state: 'exception' },
@@ -1250,19 +1250,19 @@ suite(testing.suiteName(), function() {
       });
     });
 
-    suite('resolve_task', function() {
-      helper.dbTest('no such task', async function(db) {
+    suite('resolve_task', () => {
+      helper.dbTest('no such task', async (db) => {
         const res = await db.fns.resolve_task(taskId, 0, 'exception', 'because', null);
         assert.deepEqual(res, []);
       });
 
-      helper.dbTest('task with no runs', async function(db) {
+      helper.dbTest('task with no runs', async (db) => {
         await create(db);
         const res = fixRuns(await db.fns.resolve_task(taskId, 0, 'exception', 'because', null));
         assert.deepEqual(res, []);
       });
 
-      helper.dbTest('task where runId is not latest', async function(db) {
+      helper.dbTest('task where runId is not latest', async (db) => {
         await create(db);
         await setTaskRuns(db, [{ state: 'running' }, { state: 'running' }]);
         const res = fixRuns(await db.fns.resolve_task(taskId, 0, 'exception', 'because', null));
@@ -1270,7 +1270,7 @@ suite(testing.suiteName(), function() {
       });
 
       for (let state of ['exception', 'completed', 'failed', 'pending']) {
-        helper.dbTest(`task with ${state} run`, async function(db) {
+        helper.dbTest(`task with ${state} run`, async (db) => {
           await create(db);
           await setTaskRuns(db, [{ state }]);
           const res = fixRuns(await db.fns.resolve_task(taskId, 0, 'exception', 'because', null));
@@ -1280,7 +1280,7 @@ suite(testing.suiteName(), function() {
         });
       }
 
-      helper.dbTest('task with running run', async function(db) {
+      helper.dbTest('task with running run', async (db) => {
         const oldTakenUntil = new Date();
         await create(db);
         await setTaskRuns(db, [
@@ -1305,7 +1305,7 @@ suite(testing.suiteName(), function() {
         assert.deepEqual(task[0].taken_until, res[0].taken_until);
       });
 
-      helper.dbTest('task with running run, with retry reason', async function(db) {
+      helper.dbTest('task with running run, with retry reason', async (db) => {
         const oldTakenUntil = new Date();
         await create(db);
         await setTaskRuns(db, [
@@ -1327,7 +1327,7 @@ suite(testing.suiteName(), function() {
         assert.deepEqual(task[0].taken_until, res[0].taken_until);
       });
 
-      helper.dbTest('resolve with retry inserts queue_pending_tasks row for the retry run', async function(db) {
+      helper.dbTest('resolve with retry inserts queue_pending_tasks row for the retry run', async (db) => {
         await create(db);
         await setTaskRuns(db, [{ state: 'running' }]);
         await db.fns.resolve_task(taskId, 0, 'exception', 'worker-shutdown', 'retry');
@@ -1343,7 +1343,7 @@ suite(testing.suiteName(), function() {
         assert.equal(rows[0].run_id, 1);
       });
 
-      helper.dbTest('resolve without retry does not insert queue_pending_tasks row', async function(db) {
+      helper.dbTest('resolve without retry does not insert queue_pending_tasks row', async (db) => {
         await create(db);
         await setTaskRuns(db, [{ state: 'running' }]);
         await db.fns.resolve_task(taskId, 0, 'exception', 'worker-shutdown', null);
@@ -1358,7 +1358,7 @@ suite(testing.suiteName(), function() {
         assert.equal(count, 0);
       });
 
-      helper.dbTest('resolve with retry_reason but retries_left=0 does not insert', async function(db) {
+      helper.dbTest('resolve with retry_reason but retries_left=0 does not insert', async (db) => {
         await create(db);
         await setTaskRuns(db, [{ state: 'running' }]);
         await helper.withDbClient(async client => {
@@ -1377,22 +1377,22 @@ suite(testing.suiteName(), function() {
       });
     });
 
-    suite('check_task_claim', function() {
+    suite('check_task_claim', () => {
       const takenUntil = new Date();
 
-      helper.dbTest('no such task', async function(db) {
+      helper.dbTest('no such task', async (db) => {
         const res = await db.fns.check_task_claim(taskId, 0, takenUntil);
         assert.deepEqual(res, []);
       });
 
-      helper.dbTest('task with no runs', async function(db) {
+      helper.dbTest('task with no runs', async (db) => {
         await create(db);
         await setTaskTakenUntil(db, takenUntil);
         const res = fixRuns(await db.fns.check_task_claim(taskId, 0, takenUntil));
         assert.deepEqual(res, []);
       });
 
-      helper.dbTest('task where runId is not latest', async function(db) {
+      helper.dbTest('task where runId is not latest', async (db) => {
         await create(db);
         await setTaskTakenUntil(db, takenUntil);
         await setTaskRuns(db, [{ state: 'running' }, { state: 'running' }]);
@@ -1401,7 +1401,7 @@ suite(testing.suiteName(), function() {
       });
 
       for (let state of ['exception', 'completed', 'failed', 'pending']) {
-        helper.dbTest(`task with ${state} run`, async function(db) {
+        helper.dbTest(`task with ${state} run`, async (db) => {
           await create(db);
           await setTaskTakenUntil(db, takenUntil);
           await setTaskRuns(db, [{ state }]);
@@ -1412,7 +1412,7 @@ suite(testing.suiteName(), function() {
         });
       }
 
-      helper.dbTest('task with running run, null task.takenUntil', async function(db) {
+      helper.dbTest('task with running run, null task.takenUntil', async (db) => {
         await create(db);
         await setTaskTakenUntil(db, null);
         await setTaskRuns(db, [
@@ -1422,7 +1422,7 @@ suite(testing.suiteName(), function() {
         assert.deepEqual(res, []);
       });
 
-      helper.dbTest('task with running run, mismatched task.takenUntil', async function(db) {
+      helper.dbTest('task with running run, mismatched task.takenUntil', async (db) => {
         await create(db);
         await setTaskTakenUntil(db, taskcluster.fromNow('1 hour'));
         await setTaskRuns(db, [
@@ -1432,7 +1432,7 @@ suite(testing.suiteName(), function() {
         assert.deepEqual(res, []);
       });
 
-      helper.dbTest('task with running run, mismatched run.takenUntil', async function(db) {
+      helper.dbTest('task with running run, mismatched run.takenUntil', async (db) => {
         await create(db);
         await setTaskTakenUntil(db, takenUntil);
         await setTaskRuns(db, [
@@ -1442,7 +1442,7 @@ suite(testing.suiteName(), function() {
         assert.deepEqual(res, []);
       });
 
-      helper.dbTest('task with deadline exceeded', async function(db) {
+      helper.dbTest('task with deadline exceeded', async (db) => {
         await create(db, { deadline: taskcluster.fromNow('-1 hour') });
         await setTaskTakenUntil(db, takenUntil);
         await setTaskRuns(db, [
@@ -1452,7 +1452,7 @@ suite(testing.suiteName(), function() {
         assert.deepEqual(res, []);
       });
 
-      helper.dbTest('task with running run', async function(db) {
+      helper.dbTest('task with running run', async (db) => {
         await create(db);
         await setTaskTakenUntil(db, takenUntil);
         await setTaskRuns(db, [
@@ -1477,7 +1477,7 @@ suite(testing.suiteName(), function() {
         assert.deepEqual(task[0].taken_until, res[0].taken_until);
       });
 
-      helper.dbTest('task with running run, no retries left', async function(db) {
+      helper.dbTest('task with running run, no retries left', async (db) => {
         await create(db);
         await setTaskTakenUntil(db, takenUntil);
         await setTaskRetriesLeft(db, 0);
@@ -1502,7 +1502,7 @@ suite(testing.suiteName(), function() {
         assert.deepEqual(task[0].taken_until, res[0].taken_until);
       });
 
-      helper.dbTest('claim-expired with retry inserts queue_pending_tasks row', async function(db) {
+      helper.dbTest('claim-expired with retry inserts queue_pending_tasks row', async (db) => {
         await create(db);
         const takenUntil = new Date(Date.now() + 60_000);
         await setTaskRuns(db, [{ state: 'running', takenUntil: takenUntil.toISOString() }]);
@@ -1523,7 +1523,7 @@ suite(testing.suiteName(), function() {
         assert.equal(rows[0].run_id, 1);
       });
 
-      helper.dbTest('claim-expired with retries_left=0 does not insert', async function(db) {
+      helper.dbTest('claim-expired with retries_left=0 does not insert', async (db) => {
         await create(db);
         const takenUntil = new Date(Date.now() + 60_000);
         await setTaskRuns(db, [{ state: 'running', takenUntil: takenUntil.toISOString() }]);
@@ -1544,8 +1544,8 @@ suite(testing.suiteName(), function() {
       });
     });
 
-    suite('get_dependent_tasks', function() {
-      setup('reset dependencies', async function() {
+    suite('get_dependent_tasks', () => {
+      setup('reset dependencies', async () => {
         await helper.withDbClient(async client => {
           await client.query('truncate task_dependencies');
         });
@@ -1561,7 +1561,7 @@ suite(testing.suiteName(), function() {
         });
       };
 
-      helper.dbTest('simple dependent task', async function(db) {
+      helper.dbTest('simple dependent task', async (db) => {
         const simpleDep = slugid.v4();
         const simpleReq = slugid.v4();
         await makeDeps([
@@ -1572,7 +1572,7 @@ suite(testing.suiteName(), function() {
         assert.deepEqual(res, [{ dependent_task_id: simpleDep, requires: 'all-completed', satisfied: false }]);
       });
 
-      helper.dbTest('filtering by satisfied', async function(db) {
+      helper.dbTest('filtering by satisfied', async (db) => {
         let res;
 
         const req = slugid.v4();
@@ -1596,7 +1596,7 @@ suite(testing.suiteName(), function() {
         assert.deepEqual(res.map(row => row.dependent_task_id), [unsatDep]);
       });
 
-      helper.dbTest('numeric pagination and filtering by satisfied', async function(db) {
+      helper.dbTest('numeric pagination and filtering by satisfied', async (db) => {
         const req = slugid.v4();
         const deps = range(200).map(() => slugid.v4());
         await makeDeps(deps.map((dep, i) => [dep, req, Boolean(i & 1)]));
@@ -1632,7 +1632,7 @@ suite(testing.suiteName(), function() {
         }
       });
 
-      helper.dbTest('taskId-based pagination and filtering by satisfied', async function(db) {
+      helper.dbTest('taskId-based pagination and filtering by satisfied', async (db) => {
         const req = slugid.v4();
         const deps = range(200).map(() => slugid.v4());
         await makeDeps(deps.map((dep, i) => [dep, req, Boolean(i & 1)]));
@@ -1668,7 +1668,7 @@ suite(testing.suiteName(), function() {
         }
       });
 
-      helper.dbTest('bulk insert task dependencies', async function (db) {
+      helper.dbTest('bulk insert task dependencies', async (db) => {
         const totalDeps = 9999;
         const halfDeps = 5000;
         const taskId = slugid.v4();
@@ -1688,14 +1688,14 @@ suite(testing.suiteName(), function() {
       });
     });
 
-    suite('expire_tasks', function() {
-      helper.dbTest('no expired tasks', async function(db) {
+    suite('expire_tasks', () => {
+      helper.dbTest('no expired tasks', async (db) => {
         await create(db);
         const res = await db.fns.expire_tasks(new Date());
         assert.equal(res[0].expire_tasks, 0);
       });
 
-      helper.dbTest('expired task gets deleted, counted', async function(db) {
+      helper.dbTest('expired task gets deleted, counted', async (db) => {
         await create(db, { expires: taskcluster.fromNow('-1 hour') });
         const res = await db.fns.expire_tasks(new Date());
         assert.equal(res[0].expire_tasks, 1);
@@ -1705,8 +1705,8 @@ suite(testing.suiteName(), function() {
     });
   });
 
-  suite('queue_workers', function() {
-    setup('reset tables', async function() {
+  suite('queue_workers', () => {
+    setup('reset tables', async () => {
       await helper.withDbClient(async client => {
         await client.query('truncate queue_workers');
       });
@@ -1742,12 +1742,12 @@ suite(testing.suiteName(), function() {
       }
     };
 
-    helper.dbTest('no such queue worker', async function(db) {
+    helper.dbTest('no such queue worker', async (db) => {
       const res = await db.deprecatedFns.get_queue_worker_with_wm_join_2('prov/wt', 'wg', 'wi', new Date());
       assert.deepEqual(res, []);
     });
 
-    helper.dbTest('get_queue_worker_with_wm_join_2 doesn\'t return expired workers', async function(db) {
+    helper.dbTest('get_queue_worker_with_wm_join_2 doesn\'t return expired workers', async (db) => {
       await create(db, {
         quarantineUntil: null,
         expires: taskcluster.fromNow('-2 hours'),
@@ -1756,7 +1756,7 @@ suite(testing.suiteName(), function() {
       assert.deepEqual(res, []);
     });
 
-    helper.dbTest('get_queue_worker_with_wm_join_2 returns expired but quarantined workers', async function(db) {
+    helper.dbTest('get_queue_worker_with_wm_join_2 returns expired but quarantined workers', async (db) => {
       await create(db, {
         expires: taskcluster.fromNow('-2 hours'),
         quarantineUntil: taskcluster.fromNow('2 hours'),
@@ -1770,18 +1770,18 @@ suite(testing.suiteName(), function() {
       assert.deepEqual(res[0].quarantine_details, [{ a: 'b' }]);
     });
 
-    helper.dbTest('get_queue_workers_with_wm_join empty', async function(db) {
+    helper.dbTest('get_queue_workers_with_wm_join empty', async (db) => {
       const res = await db.deprecatedFns.get_queue_workers_with_wm_join(null, null, null, null);
       assert.deepEqual(res, []);
     });
 
-    helper.dbTest('get_queue_workers_with_wm_join null options', async function(db) {
+    helper.dbTest('get_queue_workers_with_wm_join null options', async (db) => {
       await create(db);
       const res = await db.deprecatedFns.get_queue_workers_with_wm_join(null, null, null, null);
       assert.equal(res.length, 1);
     });
 
-    helper.dbTest('get_queue_workers_with_wm_join doesn\'t return expired workers', async function(db) {
+    helper.dbTest('get_queue_workers_with_wm_join doesn\'t return expired workers', async (db) => {
       await create(db, {
         quarantineUntil: null,
         expires: taskcluster.fromNow('-2 hours'),
@@ -1790,7 +1790,7 @@ suite(testing.suiteName(), function() {
       assert.deepEqual(res, []);
     });
 
-    helper.dbTest('get_queue_workers_with_wm_join returns expired quarantined workers', async function(db) {
+    helper.dbTest('get_queue_workers_with_wm_join returns expired quarantined workers', async (db) => {
       await create(db, {
         expires: taskcluster.fromNow('-2 hours'),
         quarantineUntil: taskcluster.fromNow('2 hours'),
@@ -1799,7 +1799,7 @@ suite(testing.suiteName(), function() {
       assert.deepEqual(res, []);
     });
 
-    helper.dbTest('get_queue_workers_with_wm_join full results', async function(db) {
+    helper.dbTest('get_queue_workers_with_wm_join full results', async (db) => {
       for (let i = 0; i < 10; i++) {
         await create(db, { taskQueueId: `prov/w/${i}` });
       }
@@ -1810,7 +1810,7 @@ suite(testing.suiteName(), function() {
       assert.equal(res[5].worker_pool_id, 'prov/w/5');
     });
 
-    helper.dbTest('get_queue_workers_with_wm_join with pagination', async function(db) {
+    helper.dbTest('get_queue_workers_with_wm_join with pagination', async (db) => {
       for (let i = 0; i < 10; i++) {
         await create(db, { taskQueueId: `prov/w/${i}` });
       }
@@ -1829,17 +1829,17 @@ suite(testing.suiteName(), function() {
       assert.equal(results[5].worker_pool_id, 'prov/w/5');
     });
 
-    helper.dbTest('get_queue_workers_with_wm_join_state empty', async function(db) {
+    helper.dbTest('get_queue_workers_with_wm_join_state empty', async (db) => {
       const res = await db.deprecatedFns.get_queue_workers_with_wm_join_state(null, null, null, null, null);
       assert.deepEqual(res, []);
     });
 
-    helper.dbTest('get_queue_workers_with_wm_join_quarantined_2 empty', async function(db) {
+    helper.dbTest('get_queue_workers_with_wm_join_quarantined_2 empty', async (db) => {
       const res = await db.deprecatedFns.get_queue_workers_with_wm_join_quarantined_2(null, null, null);
       assert.deepEqual(res, []);
     });
 
-    helper.dbTest('update_queue_worker_tqid (deprecated)', async function(db) {
+    helper.dbTest('update_queue_worker_tqid (deprecated)', async (db) => {
       await create(db);
       const res = await db.deprecatedFns.update_queue_worker_tqid(
         'prov/wt',
@@ -1854,7 +1854,7 @@ suite(testing.suiteName(), function() {
       assert.deepEqual(res[0].recent_tasks, []);
     });
 
-    helper.dbTest('queue_worker_seen (deprecated)', async function(db) {
+    helper.dbTest('queue_worker_seen (deprecated)', async (db) => {
       const expires = taskcluster.fromNow('1 day');
       await db.deprecatedFns.queue_worker_seen({
         task_queue_id_in: 'prov/wt',
@@ -1873,7 +1873,7 @@ suite(testing.suiteName(), function() {
       assert.deepEqual(res[0].recent_tasks, []);
     });
 
-    helper.dbTest('queue_worker_seen_with_last_date_active creates rows', async function(db) {
+    helper.dbTest('queue_worker_seen_with_last_date_active creates rows', async (db) => {
       const expires = taskcluster.fromNow('1 day');
       await db.fns.queue_worker_seen_with_last_date_active({
         task_queue_id_in: 'prov/wt',
@@ -1892,7 +1892,7 @@ suite(testing.suiteName(), function() {
       assert.deepEqual(res[0].recent_tasks, []);
     });
 
-    helper.dbTest('queue_worker_seen_with_last_date_active updates rows', async function(db) {
+    helper.dbTest('queue_worker_seen_with_last_date_active updates rows', async (db) => {
       // only the expires field gets updated (#4366 would add last_active_date as well)
       const expireses = [
         taskcluster.fromNow('1 day'),
@@ -1911,12 +1911,12 @@ suite(testing.suiteName(), function() {
       assert.deepEqual(res[0].expires, expireses[1]);
     });
 
-    helper.dbTest('quarantine_queue_worker_with_last_date_active does nothing on nonexistent worker', async function(db) {
+    helper.dbTest('quarantine_queue_worker_with_last_date_active does nothing on nonexistent worker', async (db) => {
       const res = await db.deprecatedFns.quarantine_queue_worker_with_last_date_active('prov/wt', 'wg', 'wi', new Date());
       assert.deepEqual(res, []);
     });
 
-    helper.dbTest('quarantine_queue_worker_with_last_date_active updates quarantine date + expires, returns row', async function(db) {
+    helper.dbTest('quarantine_queue_worker_with_last_date_active updates quarantine date + expires, returns row', async (db) => {
       await create(db);
       const quarantineUntil = taskcluster.fromNow('1 year');
       const res = await db.deprecatedFns.quarantine_queue_worker_with_last_date_active('prov/wt', 'wg', 'wi', quarantineUntil);
@@ -1927,7 +1927,7 @@ suite(testing.suiteName(), function() {
       assert.deepEqual(res[0].recent_tasks, [{ taskId: 'recent', runId: 0 }]);
     });
 
-    helper.dbTest('quarantine_queue_worker_with_last_date_active_and_details updates quarantine date + expires, returns row', async function(db) {
+    helper.dbTest('quarantine_queue_worker_with_last_date_active_and_details updates quarantine date + expires, returns row', async (db) => {
       await create(db);
       const quarantineUntil = taskcluster.fromNow('1 year');
       const res = await db.fns.quarantine_queue_worker_with_last_date_active_and_details('prov/wt', 'wg', 'wi', quarantineUntil, { reason: 'testing' });
@@ -1939,12 +1939,12 @@ suite(testing.suiteName(), function() {
       assert.deepEqual(res[0].recent_tasks, [{ taskId: 'recent', runId: 0 }]);
     });
 
-    helper.dbTest('queue_worker_task_seen does nothing on nonexistent worker', async function(db) {
+    helper.dbTest('queue_worker_task_seen does nothing on nonexistent worker', async (db) => {
       await db.fns.queue_worker_task_seen('prov/wt', 'wg', 'wi', { taskId: 'new-task', runId: 0 });
       // .. doesn't throw anything
     });
 
-    helper.dbTest('queue_worker_task_seen updates tasks, limiting to 20', async function(db) {
+    helper.dbTest('queue_worker_task_seen updates tasks, limiting to 20', async (db) => {
       await create(db);
       const tasks = range(30).map(i => ({ taskId: `task-${i}`, runId: 0 }));
       let res;
@@ -1960,7 +1960,7 @@ suite(testing.suiteName(), function() {
       assert.equal(res[0].recent_tasks.length, 20);
     });
 
-    helper.dbTest('expire_queue_workers deletes expired workers', async function(db) {
+    helper.dbTest('expire_queue_workers deletes expired workers', async (db) => {
       await create(db, {
         quarantineUntil: null,
         expires: taskcluster.fromNow('-2 hours'),
@@ -1971,7 +1971,7 @@ suite(testing.suiteName(), function() {
       assert.equal(res.length, 0);
     });
 
-    helper.dbTest('expire_queue_workers doesn\'t delete quarantined expired workers', async function(db) {
+    helper.dbTest('expire_queue_workers doesn\'t delete quarantined expired workers', async (db) => {
       await create(db, {
         quarantineUntil: taskcluster.fromNow('2 hours'),
         expires: taskcluster.fromNow('-2 hours'),
@@ -1983,8 +1983,8 @@ suite(testing.suiteName(), function() {
     });
   });
 
-  suite('task_queues', function() {
-    setup('reset tables', async function() {
+  suite('task_queues', () => {
+    setup('reset tables', async () => {
       await helper.withDbClient(async client => {
         await client.query('truncate task_queues');
       });
@@ -2000,12 +2000,12 @@ suite(testing.suiteName(), function() {
       );
     };
 
-    helper.dbTest('no such task queue', async function(db) {
+    helper.dbTest('no such task queue', async (db) => {
       const res = await db.fns.get_task_queue('prov/wt', new Date());
       assert.deepEqual(res, []);
     });
 
-    helper.dbTest('create_task_queue (deprecated)', async function(db) {
+    helper.dbTest('create_task_queue (deprecated)', async (db) => {
       await db.deprecatedFns.create_task_queue(
         'prov/wt',
         expires,
@@ -2020,7 +2020,7 @@ suite(testing.suiteName(), function() {
       assert.deepEqual(res[0].description, 'desc');
     });
 
-    helper.dbTest('get_task_queues', async function(db) {
+    helper.dbTest('get_task_queues', async (db) => {
       await create(db);
       const res = await db.fns.get_task_queues('prov/wt', new Date(), null, null);
       assert.equal(res[0].task_queue_id, 'prov/wt');
@@ -2029,24 +2029,24 @@ suite(testing.suiteName(), function() {
       assert.deepEqual(res[0].description, 'desc');
     });
 
-    helper.dbTest('get_task_queues doesn\'t return expired task_queues', async function(db) {
+    helper.dbTest('get_task_queues doesn\'t return expired task_queues', async (db) => {
       await create(db, { expires: taskcluster.fromNow('-2 hours') });
       const res = await db.fns.get_task_queues('prov/wt', new Date(), null, null);
       assert.deepEqual(res, []);
     });
 
-    helper.dbTest('get_task_queues empty', async function(db) {
+    helper.dbTest('get_task_queues empty', async (db) => {
       const res = await db.fns.get_task_queues(null, null, null, null);
       assert.deepEqual(res, []);
     });
 
-    helper.dbTest('get_task_queues null options', async function(db) {
+    helper.dbTest('get_task_queues null options', async (db) => {
       await create(db);
       const res = await db.fns.get_task_queues(null, null, null, null);
       assert.equal(res.length, 1);
     });
 
-    helper.dbTest('get_task_queues full results', async function(db) {
+    helper.dbTest('get_task_queues full results', async (db) => {
       for (let i = 0; i < 10; i++) {
         await create(db, { taskQueueId: `prov/wt-${i}` });
       }
@@ -2057,7 +2057,7 @@ suite(testing.suiteName(), function() {
       assert.equal(res[5].task_queue_id, 'prov/wt-5');
     });
 
-    helper.dbTest('get_task_queues with pagination', async function(db) {
+    helper.dbTest('get_task_queues with pagination', async (db) => {
       for (let i = 0; i < 10; i++) {
         await create(db, { taskQueueId: `prov/wt-${i}` });
       }
@@ -2075,7 +2075,7 @@ suite(testing.suiteName(), function() {
       assert.equal(result[5].task_queue_id, 'prov/wt-5');
     });
 
-    helper.dbTest('update_task_queue (deprecated)', async function(db) {
+    helper.dbTest('update_task_queue (deprecated)', async (db) => {
       await create(db);
       const res = await db.deprecatedFns.update_task_queue(
         'prov/wt',
@@ -2089,7 +2089,7 @@ suite(testing.suiteName(), function() {
       assert.equal(res[0].description, 'new_desc');
     });
 
-    helper.dbTest('task_queue_seen', async function(db) {
+    helper.dbTest('task_queue_seen', async (db) => {
       const expires1 = taskcluster.fromNow('1 day');
       const expires2 = taskcluster.fromNow('2 days');
 
@@ -2182,7 +2182,7 @@ suite(testing.suiteName(), function() {
       });
     });
 
-    helper.dbTest('expire_task_queues deletes expired worker types', async function(db) {
+    helper.dbTest('expire_task_queues deletes expired worker types', async (db) => {
       await create(db, { expires: taskcluster.fromNow('-2 hours') });
       let res = await db.fns.expire_task_queues(new Date());
       assert.equal(res[0].expire_task_queues, 1);
@@ -2191,8 +2191,8 @@ suite(testing.suiteName(), function() {
     });
   });
 
-  suite('queue_provisioners (deprecated)', function() {
-    setup('reset tables', async function() {
+  suite('queue_provisioners (deprecated)', () => {
+    setup('reset tables', async () => {
       await helper.withDbClient(async client => {
         await client.query('truncate task_queues');
       });
@@ -2213,12 +2213,12 @@ suite(testing.suiteName(), function() {
       );
     };
 
-    helper.dbTest('no such queue provisioner', async function(db) {
+    helper.dbTest('no such queue provisioner', async (db) => {
       const res = await db.deprecatedFns.get_queue_provisioner('prov', new Date());
       assert.deepEqual(res, []);
     });
 
-    helper.dbTest('create_task_queues / get_queue_provisioners', async function(db) {
+    helper.dbTest('create_task_queues / get_queue_provisioners', async (db) => {
       await create(db);
       const res = await db.deprecatedFns.get_queue_provisioners(new Date(), null, null);
       assert.equal(res[0].provisioner_id, 'prov');
@@ -2226,30 +2226,30 @@ suite(testing.suiteName(), function() {
       assert.deepEqual(res[0].last_date_active, lastDateActive);
     });
 
-    helper.dbTest('get_queue_provisioners doesn\'t return expired provisioner', async function(db) {
+    helper.dbTest('get_queue_provisioners doesn\'t return expired provisioner', async (db) => {
       await create(db, { expires: taskcluster.fromNow('-2 hours') });
       const res = await db.deprecatedFns.get_queue_provisioners(new Date(), null, null);
       assert.deepEqual(res, []);
     });
 
-    helper.dbTest('get_queue_provisioners empty', async function(db) {
+    helper.dbTest('get_queue_provisioners empty', async (db) => {
       const res = await db.deprecatedFns.get_queue_provisioners(null, null, null);
       assert.deepEqual(res, []);
     });
 
-    helper.dbTest('get_queue_provisioners null options', async function(db) {
+    helper.dbTest('get_queue_provisioners null options', async (db) => {
       await create(db);
       const res = await db.deprecatedFns.get_queue_provisioners(null, null, null);
       assert.equal(res.length, 1);
     });
 
-    helper.dbTest('get_queue_provisioners doesn\'t return expired provisioners', async function(db) {
+    helper.dbTest('get_queue_provisioners doesn\'t return expired provisioners', async (db) => {
       await create(db, { expires: taskcluster.fromNow('-2 hours') });
       const res = await db.deprecatedFns.get_queue_provisioners(new Date(), null, null);
       assert.deepEqual(res, []);
     });
 
-    helper.dbTest('get_queue_provisioners full result', async function(db) {
+    helper.dbTest('get_queue_provisioners full result', async (db) => {
       for (let i = 0; i < 10; i++) {
         await create(db, { taskQueueId: `p-${i}/wt` });
       }
@@ -2260,7 +2260,7 @@ suite(testing.suiteName(), function() {
       assert.equal(res[5].provisioner_id, 'p-5');
     });
 
-    helper.dbTest('get_queue_provisioners pagination', async function(db) {
+    helper.dbTest('get_queue_provisioners pagination', async (db) => {
       for (let i = 0; i < 10; i++) {
         await create(db, { taskQueueId: `p-${i}/wt` });
       }
@@ -2278,7 +2278,7 @@ suite(testing.suiteName(), function() {
       assert.equal(results[5].provisioner_id, 'p-5');
     });
 
-    helper.dbTest('update_queue_provisioner is no-op', async function(db) {
+    helper.dbTest('update_queue_provisioner is no-op', async (db) => {
       await create(db);
       let res = await db.deprecatedFns.update_queue_provisioner(
         'prov',
@@ -2292,13 +2292,13 @@ suite(testing.suiteName(), function() {
       assert.deepEqual(res[0].last_date_active, lastDateActive);
     });
 
-    helper.dbTest('expire_queue_provisioners return 0', async function(db) {
+    helper.dbTest('expire_queue_provisioners return 0', async (db) => {
       // expire_queue_provisioners is now a no-op, and returns 0 to be consistent
       let res = await db.deprecatedFns.expire_queue_provisioners(new Date());
       assert.equal(res[0].expire_queue_provisioners, 0);
     });
 
-    helper.dbTest('get_queue_provisioners infers provisioners from task_queues', async function(db) {
+    helper.dbTest('get_queue_provisioners infers provisioners from task_queues', async (db) => {
       await create(db, { taskQueueId: 'prov1/wt' });
       await create(db, {
         taskQueueId: 'prov2/wt',
@@ -2313,8 +2313,8 @@ suite(testing.suiteName(), function() {
     });
   });
 
-  suite('queue_worker_types (deprecated)', function() {
-    setup('reset tables', async function() {
+  suite('queue_worker_types (deprecated)', () => {
+    setup('reset tables', async () => {
       await helper.withDbClient(async client => {
         await client.query('truncate task_queues');
       });
@@ -2333,12 +2333,12 @@ suite(testing.suiteName(), function() {
       );
     };
 
-    helper.dbTest('no such queue worker type', async function(db) {
+    helper.dbTest('no such queue worker type', async (db) => {
       const res = await db.deprecatedFns.get_queue_worker_type('prov', 'wt', new Date());
       assert.deepEqual(res, []);
     });
 
-    helper.dbTest('create_queue_worker_type / get_queue_worker_types', async function(db) {
+    helper.dbTest('create_queue_worker_type / get_queue_worker_types', async (db) => {
       await create(db);
       const res = await db.deprecatedFns.get_queue_worker_types('prov', 'wt', new Date(), null, null);
       assert.equal(res[0].provisioner_id, 'prov');
@@ -2348,30 +2348,30 @@ suite(testing.suiteName(), function() {
       assert.deepEqual(res[0].description, 'desc');
     });
 
-    helper.dbTest('get_queue_worker_types doesn\'t return expired worker types', async function(db) {
+    helper.dbTest('get_queue_worker_types doesn\'t return expired worker types', async (db) => {
       await create(db, { expires: taskcluster.fromNow('-2 hours') });
       const res = await db.deprecatedFns.get_queue_worker_types('prov', 'wt', new Date(), null, null);
       assert.deepEqual(res, []);
     });
 
-    helper.dbTest('get_queue_worker_types empty', async function(db) {
+    helper.dbTest('get_queue_worker_types empty', async (db) => {
       const res = await db.deprecatedFns.get_queue_worker_types(null, null, null, null, null);
       assert.deepEqual(res, []);
     });
 
-    helper.dbTest('get_queue_worker_types null options', async function(db) {
+    helper.dbTest('get_queue_worker_types null options', async (db) => {
       await create(db);
       const res = await db.deprecatedFns.get_queue_worker_types(null, null, null, null, null);
       assert.equal(res.length, 1);
     });
 
-    helper.dbTest('get_queue_worker_types doesn\'t return expired worker types', async function(db) {
+    helper.dbTest('get_queue_worker_types doesn\'t return expired worker types', async (db) => {
       await create(db, { expires: taskcluster.fromNow('-2 hours') });
       const res = await db.deprecatedFns.get_queue_worker_types(new Date(), null, null, null, null);
       assert.deepEqual(res, []);
     });
 
-    helper.dbTest('get_queue_worker_types full results', async function(db) {
+    helper.dbTest('get_queue_worker_types full results', async (db) => {
       for (let i = 0; i < 10; i++) {
         await create(db, { workerType: `wt-${i}` });
       }
@@ -2382,7 +2382,7 @@ suite(testing.suiteName(), function() {
       assert.equal(res[5].worker_type, 'wt-5');
     });
 
-    helper.dbTest('get_queue_worker_types with pagination', async function(db) {
+    helper.dbTest('get_queue_worker_types with pagination', async (db) => {
       for (let i = 0; i < 10; i++) {
         await create(db, { workerType: `wt-${i}` });
       }
@@ -2400,7 +2400,7 @@ suite(testing.suiteName(), function() {
       assert.equal(result[5].worker_type, 'wt-5');
     });
 
-    helper.dbTest('update_queue_worker_type', async function(db) {
+    helper.dbTest('update_queue_worker_type', async (db) => {
       await create(db);
       const res = await db.deprecatedFns.update_queue_worker_type(
         'prov',
@@ -2415,7 +2415,7 @@ suite(testing.suiteName(), function() {
       assert.equal(res[0].description, 'new_desc');
     });
 
-    helper.dbTest('expire_queue_worker_types deletes expired worker types', async function(db) {
+    helper.dbTest('expire_queue_worker_types deletes expired worker types', async (db) => {
       await create(db, { expires: taskcluster.fromNow('-2 hours') });
       let res = await db.deprecatedFns.expire_queue_worker_types(new Date());
       assert.equal(res[0].expire_queue_worker_types, 1);
@@ -2424,8 +2424,8 @@ suite(testing.suiteName(), function() {
     });
   });
 
-  suite('queue_worker_stats method', function() {
-    setup(async function() {
+  suite('queue_worker_stats method', () => {
+    setup(async () => {
       // Clean up tables before each test
       await helper.withDbClient(async client => {
         await client.query('DELETE FROM queue_workers');
@@ -2434,12 +2434,12 @@ suite(testing.suiteName(), function() {
       });
     });
 
-    helper.dbTest('returns empty result when no data exists', async function(db) {
+    helper.dbTest('returns empty result when no data exists', async (db) => {
       const result = await db.fns.queue_worker_stats();
       assert.deepEqual(result, []);
     });
 
-    helper.dbTest('returns correct stats when some tables have data', async function(db) {
+    helper.dbTest('returns correct stats when some tables have data', async (db) => {
       const taskQueueId = 'p2/wt2';
       const expectStats = async (stats) => {
         const result = await db.fns.queue_worker_stats();
@@ -2496,8 +2496,8 @@ suite(testing.suiteName(), function() {
     });
   });
 
-  suite('priority change helpers', function() {
-    setup('reset tables', async function() {
+  suite('priority change helpers', () => {
+    setup('reset tables', async () => {
       await helper.withDbClient(async client => {
         await client.query('truncate queue_pending_tasks');
         await client.query('truncate tasks');
@@ -2506,7 +2506,7 @@ suite(testing.suiteName(), function() {
       });
     });
 
-    helper.dbTest('queue_change_task_priority updates pending rows', async function(db) {
+    helper.dbTest('queue_change_task_priority updates pending rows', async (db) => {
       const id = slugid.v4();
       await create(db, { taskId: id });
       await db.fns.queue_pending_tasks_add('prov/wt', 5, id, 0, 'hint-a', fromNow('10 minutes'));
@@ -2523,7 +2523,7 @@ suite(testing.suiteName(), function() {
       });
     });
 
-    helper.dbTest('queue_change_task_priority skips resolved or expired tasks', async function(db) {
+    helper.dbTest('queue_change_task_priority skips resolved or expired tasks', async (db) => {
       const id = slugid.v4();
       await create(db, { taskId: id });
       await db.fns.queue_pending_tasks_add('prov/wt', 5, id, 0, 'hint-b', fromNow('10 minutes'));
@@ -2549,7 +2549,7 @@ suite(testing.suiteName(), function() {
       });
     });
 
-    helper.dbTest('queue_change_task_group_priority batches updates', async function(db) {
+    helper.dbTest('queue_change_task_group_priority batches updates', async (db) => {
       const groupId = slugid.v4();
       const taskIds = [];
       for (let i = 0; i < 150; i++) {
@@ -2576,7 +2576,7 @@ suite(testing.suiteName(), function() {
       });
     });
 
-    helper.dbTest('queue_change_task_priority records previous value on subsequent updates', async function(db) {
+    helper.dbTest('queue_change_task_priority records previous value on subsequent updates', async (db) => {
       const id = slugid.v4();
       await create(db, { taskId: id });
 
@@ -2590,8 +2590,8 @@ suite(testing.suiteName(), function() {
     });
   });
 
-  suite('queue_pending_tasks_add_for_task', function() {
-    setup('reset tables', async function() {
+  suite('queue_pending_tasks_add_for_task', () => {
+    setup('reset tables', async () => {
       await helper.withDbClient(async client => {
         await client.query('truncate queue_pending_tasks');
         await client.query('truncate tasks');
@@ -2600,7 +2600,7 @@ suite(testing.suiteName(), function() {
       });
     });
 
-    helper.dbTest('inserts a queue_pending_tasks row matching task metadata', async function(db) {
+    helper.dbTest('inserts a queue_pending_tasks row matching task metadata', async (db) => {
       await create(db);
       await setTaskRuns(db, [{ state: 'pending', reasonCreated: 'scheduled', scheduled: new Date().toISOString() }]);
 
@@ -2622,7 +2622,7 @@ suite(testing.suiteName(), function() {
       assert.ok(rows[0].expires instanceof Date);
     });
 
-    helper.dbTest('is idempotent on repeated calls (ON CONFLICT DO UPDATE)', async function(db) {
+    helper.dbTest('is idempotent on repeated calls (ON CONFLICT DO UPDATE)', async (db) => {
       await create(db);
       await setTaskRuns(db, [{ state: 'pending', reasonCreated: 'scheduled', scheduled: new Date().toISOString() }]);
 

--- a/db/test/fns/secrets_test.js
+++ b/db/test/fns/secrets_test.js
@@ -5,10 +5,10 @@ const { fromNow } = tc;
 import helper from '../helper.js';
 import slugid from 'slugid';
 
-suite(testing.suiteName(), function () {
+suite(testing.suiteName(), () => {
   helper.withDbForProcs({ serviceName: 'secrets' });
 
-  setup('reset table', async function () {
+  setup('reset table', async () => {
     await helper.withDbClient(async client => {
       await client.query('delete from secrets');
       await client.query('delete from audit_history');
@@ -24,7 +24,7 @@ suite(testing.suiteName(), function () {
     };
   }
 
-  helper.dbTest('create and get', async function (db, isFake) {
+  helper.dbTest('create and get', async (db, isFake) => {
     for await (const s of Object.values(secrets)) {
       await db.fns.upsert_secret(s.name, db.encrypt({
         value: Buffer.from(JSON.stringify(s.encrypted_secret), 'utf8'),
@@ -40,7 +40,7 @@ suite(testing.suiteName(), function () {
       }
     }
   });
-  helper.dbTest('list', async function (db, isFake) {
+  helper.dbTest('list', async (db, isFake) => {
     for await (const s of Object.values(secrets)) {
       await db.fns.upsert_secret(s.name, db.encrypt({
         value: Buffer.from(JSON.stringify(s.encrypted_secret), 'utf8'),
@@ -54,7 +54,7 @@ suite(testing.suiteName(), function () {
       assert(s.expires > new Date());
     });
   });
-  helper.dbTest('delete', async function (db, isFake) {
+  helper.dbTest('delete', async (db, isFake) => {
     for await (const s of Object.values(secrets)) {
       await db.fns.upsert_secret(s.name, db.encrypt({
         value: Buffer.from(JSON.stringify(s.encrypted_secret), 'utf8'),
@@ -71,7 +71,7 @@ suite(testing.suiteName(), function () {
     });
     assert.deepEqual([], await db.fns.get_secret('secret-9'));
   });
-  helper.dbTest('update', async function (db, isFake) {
+  helper.dbTest('update', async (db, isFake) => {
     for await (const s of Object.values(secrets)) {
       await db.fns.upsert_secret(s.name, db.encrypt({
         value: Buffer.from(JSON.stringify(s.encrypted_secret), 'utf8'),
@@ -98,7 +98,7 @@ suite(testing.suiteName(), function () {
       }
     }
   });
-  helper.dbTest('expire', async function (db, isFake) {
+  helper.dbTest('expire', async (db, isFake) => {
     for await (const s of Object.values(secrets)) {
       await db.fns.upsert_secret(s.name, db.encrypt({
         value: Buffer.from(JSON.stringify(s.encrypted_secret), 'utf8'),
@@ -121,7 +121,7 @@ suite(testing.suiteName(), function () {
       assert.equal(count, '4');
     });
   });
-  helper.dbTest('insert into secrets in audit history', async function (db, isFake) {
+  helper.dbTest('insert into secrets in audit history', async (db, isFake) => {
 
     await db.fns.insert_secrets_audit_history(
       'secret/1',

--- a/db/test/fns/web_server_test.js
+++ b/db/test/fns/web_server_test.js
@@ -7,10 +7,10 @@ import helper from '../helper.js';
 import testing from '@taskcluster/lib-testing';
 import { UNIQUE_VIOLATION } from '@taskcluster/lib-postgres';
 
-suite(testing.suiteName(), function() {
+suite(testing.suiteName(), () => {
   helper.withDbForProcs({ serviceName: 'web_server' });
 
-  setup('truncate tables', async function() {
+  setup('truncate tables', async () => {
     await helper.withDbClient(async client => {
       await client.query('truncate github_access_tokens');
       await client.query('truncate sessions');
@@ -19,8 +19,8 @@ suite(testing.suiteName(), function() {
     });
   });
 
-  suite(`${testing.suiteName()} - github_access_tokens`, function() {
-    helper.dbTest('add github access token that already exists', async function(db) {
+  suite(`${testing.suiteName()} - github_access_tokens`, () => {
+    helper.dbTest('add github access token that already exists', async (db) => {
       let n1 = {
         userId: "benjaminrabbit",
         encryptedAccessToken: db.encrypt({ value: Buffer.from("carrots", 'utf8') }),
@@ -32,7 +32,7 @@ suite(testing.suiteName(), function() {
       assert.deepEqual(encryptedAccessTokenAsTable[0].encrypted_access_token, n1.encryptedAccessToken);
     });
 
-    helper.dbTest('update existing github access token', async function(db) {
+    helper.dbTest('update existing github access token', async (db) => {
       for (let accessToken of ["carrots", "sprouts"]) {
         let n1 = {
           userId: "benjaminrabbit",
@@ -45,7 +45,7 @@ suite(testing.suiteName(), function() {
       }
     });
 
-    helper.dbTest('load non-existent github access token', async function(db) {
+    helper.dbTest('load non-existent github access token', async (db) => {
       const encryptedAccessTokenAsTable = await db.fns.load_github_access_token("pretend-user");
       assert.equal(encryptedAccessTokenAsTable.length, 0);
     });
@@ -58,8 +58,8 @@ suite(testing.suiteName(), function() {
       .digest('hex');
   };
 
-  suite(`${testing.suiteName()} - sessions`, function() {
-    helper.dbTest('add session data', async function(db) {
+  suite(`${testing.suiteName()} - sessions`, () => {
+    helper.dbTest('add session data', async (db) => {
       const sessionId = 'sEssI0n#Id';
       let sessionData1 = {
         hashedSessionId: hash(sessionId),
@@ -82,7 +82,7 @@ suite(testing.suiteName(), function() {
       assert.deepEqual(sessionAsTable[0].expires, sessionData1.expires);
     });
 
-    helper.dbTest('add session data can overwrite', async function(db) {
+    helper.dbTest('add session data can overwrite', async (db) => {
       const sessionId = 'sEssI0n#Id';
       let sessionData1 = {
         hashedSessionId: hash(sessionId),
@@ -117,7 +117,7 @@ suite(testing.suiteName(), function() {
       assert.deepEqual(sessionAsTable[0].expires, sessionData2.expires);
     });
 
-    helper.dbTest('get session data does not throw when not found', async function(db) {
+    helper.dbTest('get session data does not throw when not found', async (db) => {
       const sessionId = 'sEssI0n#Id';
       let sessionData1 = {
         hashedSessionId: hash(sessionId),
@@ -131,7 +131,7 @@ suite(testing.suiteName(), function() {
       assert.equal(sessionAsTable.length, 0);
     });
 
-    helper.dbTest('remove session data', async function(db) {
+    helper.dbTest('remove session data', async (db) => {
       const sessionId = 'sEssI0n#Id';
       let sessionData1 = {
         hashedSessionId: hash(sessionId),
@@ -158,7 +158,7 @@ suite(testing.suiteName(), function() {
       assert.equal(sessionAsTable.length, 0);
     });
 
-    helper.dbTest('touch a session', async function(db) {
+    helper.dbTest('touch a session', async (db) => {
       const sessionId = 'sEssI0n#Id';
       let sessionData1 = {
         hashedSessionId: hash(sessionId),
@@ -188,7 +188,7 @@ suite(testing.suiteName(), function() {
       assert.deepEqual(sessionAsTable[0].expires, new Date(2));
     });
 
-    helper.dbTest('touch throws a P0002 when no such row', async function(db) {
+    helper.dbTest('touch throws a P0002 when no such row', async (db) => {
       const sessionId = 'sEssI0n#Id';
       await assert.rejects(
         async () => {
@@ -198,11 +198,11 @@ suite(testing.suiteName(), function() {
       );
     });
 
-    helper.dbTest('remove session data does not throw when not found', async function(db) {
+    helper.dbTest('remove session data does not throw when not found', async (db) => {
       await db.fns.session_remove(hash('not-found'));
     });
 
-    helper.dbTest('expire_sessions', async function(db) {
+    helper.dbTest('expire_sessions', async (db) => {
       const sessionIds = [
         'sEssI0n#Id',
         'sEssI1n#Id',
@@ -241,7 +241,7 @@ suite(testing.suiteName(), function() {
     });
   });
 
-  suite(`${testing.suiteName()} - authorization_codes`, function() {
+  suite(`${testing.suiteName()} - authorization_codes`, () => {
     const code = slug.v4();
     const now = new Date();
     const clientDetails = {
@@ -263,7 +263,7 @@ suite(testing.suiteName(), function() {
       );
     };
 
-    helper.dbTest('get_authorization_code returns an entry', async function(db) {
+    helper.dbTest('get_authorization_code returns an entry', async (db) => {
       await mkAuthorizationCode(db);
       const [authorizationCode] = await db.deprecatedFns.get_authorization_code(code);
       assert.equal(authorizationCode.code, code);
@@ -275,11 +275,11 @@ suite(testing.suiteName(), function() {
       assert.deepEqual(authorizationCode.client_details, clientDetails);
     });
 
-    helper.dbTest('get_authorization_code does not throw when not found', async function(db) {
+    helper.dbTest('get_authorization_code does not throw when not found', async (db) => {
       await db.deprecatedFns.get_authorization_code('not-found');
     });
 
-    helper.dbTest('create_authorization_code returns the authorization code', async function(db) {
+    helper.dbTest('create_authorization_code returns the authorization code', async (db) => {
       const [authorizationCode] = await mkAuthorizationCode(db);
       assert.equal(authorizationCode.code, code);
       assert.equal(authorizationCode.client_id, 'client-id');
@@ -290,7 +290,7 @@ suite(testing.suiteName(), function() {
       assert.deepEqual(authorizationCode.client_details, clientDetails);
     });
 
-    helper.dbTest('create_authorization_code throws when row exists', async function(db) {
+    helper.dbTest('create_authorization_code throws when row exists', async (db) => {
       await mkAuthorizationCode(db);
       await assert.rejects(
         async () => {
@@ -300,7 +300,7 @@ suite(testing.suiteName(), function() {
       );
     });
 
-    helper.dbTest('expire_authorization_codes returns the count', async function(db) {
+    helper.dbTest('expire_authorization_codes returns the count', async (db) => {
       const slugs = [
         slug.v4(),
         slug.v4(),
@@ -313,7 +313,7 @@ suite(testing.suiteName(), function() {
       assert.equal(count, 2);
     });
 
-    helper.dbTest('consume_authorization_code returns the row and deletes it', async function(db) {
+    helper.dbTest('consume_authorization_code returns the row and deletes it', async (db) => {
       await mkAuthorizationCode(db);
       const [consumed] = await db.fns.consume_authorization_code(code);
       assert.equal(consumed.code, code);
@@ -327,12 +327,12 @@ suite(testing.suiteName(), function() {
       assert.equal(rows.length, 0);
     });
 
-    helper.dbTest('consume_authorization_code returns empty for unknown code', async function(db) {
+    helper.dbTest('consume_authorization_code returns empty for unknown code', async (db) => {
       const rows = await db.fns.consume_authorization_code('not-found');
       assert.equal(rows.length, 0);
     });
 
-    helper.dbTest('consume_authorization_code only succeeds once for the same code', async function(db) {
+    helper.dbTest('consume_authorization_code only succeeds once for the same code', async (db) => {
       await mkAuthorizationCode(db);
       const first = await db.fns.consume_authorization_code(code);
       const second = await db.fns.consume_authorization_code(code);
@@ -341,7 +341,7 @@ suite(testing.suiteName(), function() {
     });
   });
 
-  suite(`${testing.suiteName()} - access_tokens`, function() {
+  suite(`${testing.suiteName()} - access_tokens`, () => {
     const accessToken = 'womp';
     const now = new Date();
     const clientDetails = {
@@ -364,7 +364,7 @@ suite(testing.suiteName(), function() {
       );
     };
 
-    helper.dbTest('get_access_token returns an entry', async function(db) {
+    helper.dbTest('get_access_token returns an entry', async (db) => {
       await mkAcessToken(db);
       const [at] = await db.fns.get_access_token(hash(accessToken));
       assert.equal(at.hashed_access_token, hash(accessToken));
@@ -377,11 +377,11 @@ suite(testing.suiteName(), function() {
       assert.deepEqual(at.client_details, clientDetails);
     });
 
-    helper.dbTest('get_access_token does not throw when not found', async function(db) {
+    helper.dbTest('get_access_token does not throw when not found', async (db) => {
       await db.fns.get_access_token('not-found');
     });
 
-    helper.dbTest('create_access_token returns the authorization code', async function(db) {
+    helper.dbTest('create_access_token returns the authorization code', async (db) => {
       const [at] = await mkAcessToken(db);
       assert.equal(at.hashed_access_token, hash(accessToken));
       assert.equal(db.decrypt({ value: at.encrypted_access_token }).toString('utf8'), accessToken);
@@ -393,7 +393,7 @@ suite(testing.suiteName(), function() {
       assert.deepEqual(at.client_details, clientDetails);
     });
 
-    helper.dbTest('create_access_token throws when row exists', async function(db) {
+    helper.dbTest('create_access_token throws when row exists', async (db) => {
       await mkAcessToken(db);
       await assert.rejects(
         async () => {
@@ -403,7 +403,7 @@ suite(testing.suiteName(), function() {
       );
     });
 
-    helper.dbTest('expire_authorization_codes returns the count', async function(db) {
+    helper.dbTest('expire_authorization_codes returns the count', async (db) => {
       const slugs = [
         slug.v4(),
         slug.v4(),

--- a/db/test/fns/worker_manager_test.js
+++ b/db/test/fns/worker_manager_test.js
@@ -8,10 +8,10 @@ const { fromNow } = tc;
 
 /** @typedef {import('@taskcluster/lib-postgres').Database} Database */
 
-suite(testing.suiteName(), function () {
+suite(testing.suiteName(), () => {
   helper.withDbForProcs({ serviceName: 'worker_manager' });
 
-  setup('reset table', async function () {
+  setup('reset table', async () => {
     await helper.withDbClient(async client => {
       await client.query('delete from worker_pools');
       await client.query('delete from worker_pool_errors');
@@ -176,8 +176,8 @@ suite(testing.suiteName(), function () {
     return with_cap;
   };
 
-  suite(`${testing.suiteName()} - worker_pools`, function () {
-    helper.dbTest('create_worker_pool/get_worker_pool', async function (db) {
+  suite(`${testing.suiteName()} - worker_pools`, () => {
+    helper.dbTest('create_worker_pool/get_worker_pool', async (db) => {
       const now = new Date();
       await create_worker_pool(db, { created: now, last_modified: now });
 
@@ -194,17 +194,17 @@ suite(testing.suiteName(), function () {
       assert.deepEqual(rows[0].provider_data, { providerdata: true });
     });
 
-    helper.dbTest('get_worker_pool not found', async function (db) {
+    helper.dbTest('get_worker_pool not found', async (db) => {
       const rows = await get_worker_pool(db, 'wp/id');
       assert.deepEqual(rows, []);
     });
 
-    helper.dbTest('get_worker_pools empty', async function (db) {
+    helper.dbTest('get_worker_pools empty', async (db) => {
       const rows = await get_worker_pools(db, null, null);
       assert.deepEqual(rows, []);
     });
 
-    helper.dbTest('get_worker_pools full, pagination', async function (db) {
+    helper.dbTest('get_worker_pools full, pagination', async (db) => {
       for (let i = 0; i < 10; i++) {
         await create_worker_pool(db, { worker_pool_id: `wp/${i}` });
       }
@@ -223,7 +223,7 @@ suite(testing.suiteName(), function () {
       assert.deepEqual(rows.map(r => r.worker_pool_id), [4, 5].map(i => `wp/${i}`));
     });
 
-    helper.dbTest('update_worker_pool, change to providerId', async function (db) {
+    helper.dbTest('update_worker_pool, change to providerId', async (db) => {
       await create_worker_pool(db);
       const upd = await update_worker_pool(db, { provider_id: 'provider2' });
       assert.deepEqual(upd[0].previous_provider_id, 'provider');
@@ -232,7 +232,7 @@ suite(testing.suiteName(), function () {
       assert.deepEqual(rows[0].previous_provider_ids, ['provider']);
     });
 
-    helper.dbTest('update_worker_pool, change to providerId, new provider already in previous', async function (db) {
+    helper.dbTest('update_worker_pool, change to providerId, new provider already in previous', async (db) => {
       await create_worker_pool(db, { previous_provider_ids: JSON.stringify(['provider2']) });
       const upd = await update_worker_pool(db, { provider_id: 'provider2' });
       assert.deepEqual(upd[0].previous_provider_id, 'provider');
@@ -241,7 +241,7 @@ suite(testing.suiteName(), function () {
       assert.deepEqual(rows[0].previous_provider_ids, ['provider']);
     });
 
-    helper.dbTest('update_worker_pool, change to providerId, old provider already in previous', async function (db) {
+    helper.dbTest('update_worker_pool, change to providerId, old provider already in previous', async (db) => {
       await create_worker_pool(db, { previous_provider_ids: JSON.stringify(['provider']) });
       const upd = await update_worker_pool(db, { provider_id: 'provider2' });
       assert.deepEqual(upd[0].previous_provider_id, 'provider');
@@ -250,7 +250,7 @@ suite(testing.suiteName(), function () {
       assert.deepEqual(rows[0].previous_provider_ids, ['provider']);
     });
 
-    helper.dbTest('expire_worker_pool', async function (db) {
+    helper.dbTest('expire_worker_pool', async (db) => {
       await create_worker_pool(db, {
         worker_pool_id: 'done',
         provider_id: 'null-provider',
@@ -271,7 +271,7 @@ suite(testing.suiteName(), function () {
       assert.deepEqual(rows.map(r => r.worker_pool_id), ['done']);
     });
 
-    helper.dbTest('delete_worker_pool', async function (db) {
+    helper.dbTest('delete_worker_pool', async (db) => {
       await create_worker_pool(db);
 
       await db.fns.delete_worker_pool('wp/id');
@@ -280,7 +280,7 @@ suite(testing.suiteName(), function () {
       assert.deepEqual(rows, []);
     });
 
-    helper.dbTest('remove_worker_pool_previous_provider_id', async function (db) {
+    helper.dbTest('remove_worker_pool_previous_provider_id', async (db) => {
       await create_worker_pool(db, { previous_provider_ids: JSON.stringify(['old1', 'old2']) });
 
       await db.fns.remove_worker_pool_previous_provider_id('wp/id', 'old1');
@@ -289,14 +289,14 @@ suite(testing.suiteName(), function () {
       assert.deepEqual(rows[0].previous_provider_ids, ['old2']);
     });
 
-    helper.dbTest('remove_worker_pool_previous_provider_id, no worker-pool', async function (db) {
+    helper.dbTest('remove_worker_pool_previous_provider_id, no worker-pool', async (db) => {
       await db.fns.remove_worker_pool_previous_provider_id('wp/id', 'old1');
 
       const rows = await get_worker_pool(db, 'wp/id');
       assert.deepEqual(rows, []);
     });
 
-    helper.dbTest('remove_worker_pool_previous_provider_id, no such provider', async function (db) {
+    helper.dbTest('remove_worker_pool_previous_provider_id, no such provider', async (db) => {
       await create_worker_pool(db, { previous_provider_ids: JSON.stringify(['old1', 'old2']) });
 
       await db.fns.remove_worker_pool_previous_provider_id('wp/id', 'unknown');
@@ -305,7 +305,7 @@ suite(testing.suiteName(), function () {
       assert.deepEqual(rows[0].previous_provider_ids, ['old1', 'old2']);
     });
 
-    helper.dbTest('update_worker_pool_provider_data', async function (db) {
+    helper.dbTest('update_worker_pool_provider_data', async (db) => {
       await create_worker_pool(db, { provider_data: { someprov: { somedata: true } } });
 
       await db.fns.update_worker_pool_provider_data('wp/id', 'another', { moredata: true });
@@ -318,8 +318,8 @@ suite(testing.suiteName(), function () {
     });
   });
 
-  suite(`${testing.suiteName()} - worker_pool_errors`, function () {
-    helper.dbTest('create_worker_pool_error/get_worker_pool_error', async function (db) {
+  suite(`${testing.suiteName()} - worker_pool_errors`, () => {
+    helper.dbTest('create_worker_pool_error/get_worker_pool_error', async (db) => {
       const now = new Date();
       await create_worker_pool_error(db, { reported: now, launch_config_id: 'lc/id' });
       const rows = await db.fns.get_worker_pool_error_launch_config('e/id', 'wp/id');
@@ -333,17 +333,17 @@ suite(testing.suiteName(), function () {
       assert.deepEqual(rows[0].extra, { extra: true });
     });
 
-    helper.dbTest('get_worker_pool_error not found', async function (db) {
+    helper.dbTest('get_worker_pool_error not found', async (db) => {
       const rows = await db.fns.get_worker_pool_error_launch_config('e/id', 'wp/id');
       assert.deepEqual(rows, []);
     });
 
-    helper.dbTest('get_worker_pool_errors_for_worker_pool empty', async function (db) {
+    helper.dbTest('get_worker_pool_errors_for_worker_pool empty', async (db) => {
       const rows = await db.fns.get_worker_pool_errors_for_worker_pool2(null, null, null, null, null);
       assert.deepEqual(rows, []);
     });
 
-    helper.dbTest('get_worker_pool_errors_for_worker_pool empty query', async function (db) {
+    helper.dbTest('get_worker_pool_errors_for_worker_pool empty query', async (db) => {
       const now = new Date();
       await create_worker_pool_error(db, { reported: now });
       const rows = await db.fns.get_worker_pool_errors_for_worker_pool2(null, null, null, null, null);
@@ -356,7 +356,7 @@ suite(testing.suiteName(), function () {
       assert.deepEqual(rows[0].extra, { extra: true });
     });
 
-    helper.dbTest('get_worker_pool_errors_for_worker_pool full, pagination', async function (db) {
+    helper.dbTest('get_worker_pool_errors_for_worker_pool full, pagination', async (db) => {
       let newestDate;
       for (let i = 9; i >= 0; i--) {
         newestDate = fromNow(`- ${i} days`);
@@ -383,7 +383,7 @@ suite(testing.suiteName(), function () {
         [4, 5].map(i => ({ error_id: `e/${i}`, worker_pool_id: `wp/${i}` })));
     });
 
-    helper.dbTest('expire_worker_pool_errors', async function (db) {
+    helper.dbTest('expire_worker_pool_errors', async (db) => {
       await create_worker_pool_error(db, { error_id: 'done', reported: fromNow('- 1 day') });
       await create_worker_pool_error(db, { error_id: 'also-done', reported: fromNow('- 2 days') });
       await create_worker_pool_error(db, { error_id: 'still-running', reported: fromNow('1 day') });
@@ -394,7 +394,7 @@ suite(testing.suiteName(), function () {
       assert.equal(rows.length, 1);
     });
 
-    helper.dbTest('delete_worker_pool_errors', async function (db) {
+    helper.dbTest('delete_worker_pool_errors', async (db) => {
       await create_worker_pool_error(db);
 
       await db.fns.delete_worker_pool_error('e/id', 'wp/id');
@@ -402,7 +402,7 @@ suite(testing.suiteName(), function () {
       const rows = await db.fns.get_worker_pool_error_launch_config('e/id', 'wp/id');
       assert.deepEqual(rows, []);
     });
-    helper.dbTest('get_worker_pool_error_stats_last_24_hours', async function (db) {
+    helper.dbTest('get_worker_pool_error_stats_last_24_hours', async (db) => {
       await create_worker_pool_error(db, { error_id: 'id1', worker_pool_id: 'wp/id1' });
       await create_worker_pool_error(db, { error_id: 'id2', worker_pool_id: 'wp/id2' });
 
@@ -418,7 +418,7 @@ suite(testing.suiteName(), function () {
       assert.equal(res3.length, 24);
       assert.equal(res3[23].count, 1);
     });
-    helper.dbTest('get_worker_pool_error_stats_last_7_days', async function (db) {
+    helper.dbTest('get_worker_pool_error_stats_last_7_days', async (db) => {
       await create_worker_pool_error(db, { error_id: 'id1', worker_pool_id: 'wp/id1' });
       await create_worker_pool_error(db, { error_id: 'id2', worker_pool_id: 'wp/id2' });
 
@@ -434,7 +434,7 @@ suite(testing.suiteName(), function () {
       assert.equal(res3.length, 7);
       assert.equal(res3[6].count, 1);
     });
-    helper.dbTest('get_worker_pool_error_titles', async function (db) {
+    helper.dbTest('get_worker_pool_error_titles', async (db) => {
       await create_worker_pool_error(db, { error_id: 'id1', title: 'title1', worker_pool_id: 'wp/id1' });
       await create_worker_pool_error(db, { error_id: 'id2', title: 'title2', worker_pool_id: 'wp/id2' });
 
@@ -443,7 +443,7 @@ suite(testing.suiteName(), function () {
       assert.equal(res[0].count, 1);
       assert.equal(res[1].count, 1);
     });
-    helper.dbTest('get_worker_pool_error_codes', async function (db) {
+    helper.dbTest('get_worker_pool_error_codes', async (db) => {
       await create_worker_pool_error(db, { error_id: 'id1', kind: 'kind1', worker_pool_id: 'wp/id1', extra: { code: 'c1' } });
       await create_worker_pool_error(db, { error_id: 'id2', kind: 'kind2', worker_pool_id: 'wp/id2', extra: { code: 'c2' } });
 
@@ -455,8 +455,8 @@ suite(testing.suiteName(), function () {
 
   });
 
-  suite(`${testing.suiteName()} - workers`, function () {
-    helper.dbTest('create_worker/get_worker', async function (db) {
+  suite(`${testing.suiteName()} - workers`, () => {
+    helper.dbTest('create_worker/get_worker', async (db) => {
       const now = new Date();
       await create_worker(db, { created: now, last_modified: now, last_checked: now, expires: now });
 
@@ -474,7 +474,7 @@ suite(testing.suiteName(), function () {
       assert.deepEqual(rows[0].last_checked, now);
     });
 
-    helper.dbTest('create_worker/get_worker_3', async function (db) {
+    helper.dbTest('create_worker/get_worker_3', async (db) => {
       const now = new Date();
       await create_worker(db, {
         created: now,
@@ -498,17 +498,17 @@ suite(testing.suiteName(), function () {
       assert.equal(rows[0].secret, null);
     });
 
-    helper.dbTest('get_worker not found', async function (db) {
+    helper.dbTest('get_worker not found', async (db) => {
       const rows = await db.deprecatedFns.get_worker('wp/id', 'w/group', 'w/id');
       assert.deepEqual(rows, []);
     });
 
-    helper.dbTest('get_worker_3 not found', async function (db) {
+    helper.dbTest('get_worker_3 not found', async (db) => {
       const rows = await db.fns.get_worker_3('wp/id', 'w/group', 'w/id');
       assert.deepEqual(rows, []);
     });
 
-    helper.dbTest('expire_workers', async function (db) {
+    helper.dbTest('expire_workers', async (db) => {
       await create_worker(db, { worker_pool_id: 'done', provider_id: 'null-provider', expires: fromNow('- 1 day') });
       await create_worker(db, { worker_pool_id: 'also-done', expires: fromNow('- 2 days') });
       await create_worker(db, { worker_pool_id: 'still-running', expires: fromNow('1 day') });
@@ -519,7 +519,7 @@ suite(testing.suiteName(), function () {
       assert.equal(rows.length, 1);
     });
 
-    helper.dbTest('get workers without provider_data', async function (db) {
+    helper.dbTest('get workers without provider_data', async (db) => {
       const now = new Date();
       for (let i = 0; i < 2; i++) {
         await create_worker(db, {
@@ -553,7 +553,7 @@ suite(testing.suiteName(), function () {
       }
     });
 
-    helper.dbTest('get non-stopped workers', async function (db) {
+    helper.dbTest('get non-stopped workers', async (db) => {
       const now = new Date();
 
       let i = 0;
@@ -597,7 +597,7 @@ suite(testing.suiteName(), function () {
       }
     });
 
-    helper.dbTest('get non-stopped workers with quarantine_until', async function (db) {
+    helper.dbTest('get non-stopped workers with quarantine_until', async (db) => {
       const now = new Date();
 
       let i = 0;
@@ -660,7 +660,7 @@ suite(testing.suiteName(), function () {
       }
     });
 
-    helper.dbTest('get non-stopped workers with queue view timestamps ', async function (db) {
+    helper.dbTest('get non-stopped workers with queue view timestamps ', async (db) => {
       const now = new Date();
 
       let i = 0;
@@ -727,7 +727,7 @@ suite(testing.suiteName(), function () {
       }
     });
 
-    helper.dbTest('get non-stopped workers by provider', async function (db) {
+    helper.dbTest('get non-stopped workers by provider', async (db) => {
       const now = new Date();
 
       let i = 0;
@@ -765,7 +765,7 @@ suite(testing.suiteName(), function () {
       }
     });
 
-    helper.dbTest('get_non_stopped_workers_with_launch_config_scanner_after paginates by (worker_pool_id, worker_group, worker_id)', async function (db) {
+    helper.dbTest('get_non_stopped_workers_with_launch_config_scanner_after paginates by (worker_pool_id, worker_group, worker_id)', async (db) => {
       const now = new Date();
 
       // Insert in randomized order; the function must return them sorted.
@@ -824,7 +824,7 @@ suite(testing.suiteName(), function () {
       assert.equal(page4.length, 0);
     });
 
-    helper.dbTest('get_non_stopped_workers_with_launch_config_scanner_after is robust to inserts mid-scan', async function (db) {
+    helper.dbTest('get_non_stopped_workers_with_launch_config_scanner_after is robust to inserts mid-scan', async (db) => {
       const now = new Date();
 
       // Seed with three workers covering the keyspace.
@@ -870,7 +870,7 @@ suite(testing.suiteName(), function () {
         'keyset cursor must skip rows behind it and never re-yield rows in front of it');
     });
 
-    helper.dbTest('get_non_stopped_workers_with_launch_config_scanner_after honors providers_filter alongside keyset cursor', async function (db) {
+    helper.dbTest('get_non_stopped_workers_with_launch_config_scanner_after honors providers_filter alongside keyset cursor', async (db) => {
       const now = new Date();
 
       // Mix of providers across the keyspace to exercise the WHERE clause's
@@ -918,7 +918,7 @@ suite(testing.suiteName(), function () {
         [['wp/a', 'id2'], ['wp/b', 'id1']]);
     });
 
-    helper.dbTest('update_worker, change to a single field', async function (db) {
+    helper.dbTest('update_worker, change to a single field', async (db) => {
       const etag = await create_worker(db);
       await db.deprecatedFns.update_worker(
         'wp/id',
@@ -949,7 +949,7 @@ suite(testing.suiteName(), function () {
       assert(rows[0].last_checked instanceof Date);
     });
 
-    helper.dbTest('update_worker_3, change to a single field', async function (db) {
+    helper.dbTest('update_worker_3, change to a single field', async (db) => {
       const etag = await create_worker(db);
       const secret = `${slug.v4()}${slug.v4()}`;
       const encryptedSecret = db.encrypt({ value: Buffer.from(secret, 'utf8') });
@@ -984,7 +984,7 @@ suite(testing.suiteName(), function () {
       assert.deepEqual(rows[0].secret, encryptedSecret);
     });
 
-    helper.dbTest('update_worker, change to a multiple fields', async function (db) {
+    helper.dbTest('update_worker, change to a multiple fields', async (db) => {
       const etag = await create_worker(db);
       const updated = await db.deprecatedFns.update_worker(
         'wp/id',
@@ -1007,7 +1007,7 @@ suite(testing.suiteName(), function () {
       assert.deepEqual(updated, rows);
     });
 
-    helper.dbTest('update_worker_3, change to a multiple fields', async function (db) {
+    helper.dbTest('update_worker_3, change to a multiple fields', async (db) => {
       const etag = await create_worker(db);
       const updated = await db.fns.update_worker_3(
         'wp/id',
@@ -1031,7 +1031,7 @@ suite(testing.suiteName(), function () {
       assert.deepEqual(updated, rows);
     });
 
-    helper.dbTest('update_worker, no changes', async function (db) {
+    helper.dbTest('update_worker, no changes', async (db) => {
       const etag = await create_worker(db);
       const updated = await db.deprecatedFns.update_worker(
         'wp/id',
@@ -1055,7 +1055,7 @@ suite(testing.suiteName(), function () {
       assert.equal(rows[0].state, 'state');
     });
 
-    helper.dbTest('update_worker_3, no changes', async function (db) {
+    helper.dbTest('update_worker_3, no changes', async (db) => {
       const etag = await create_worker(db);
       const updated = await db.fns.update_worker_3(
         'wp/id',
@@ -1080,7 +1080,7 @@ suite(testing.suiteName(), function () {
       assert.equal(rows[0].state, 'state');
     });
 
-    helper.dbTest('update_worker, worker doesn\'t exist', async function (db) {
+    helper.dbTest('update_worker, worker doesn\'t exist', async (db) => {
       const etag = await create_worker(db);
 
       await assert.rejects(
@@ -1091,7 +1091,7 @@ suite(testing.suiteName(), function () {
       );
     });
 
-    helper.dbTest('update_worker_3, worker doesn\'t exist', async function (db) {
+    helper.dbTest('update_worker_3, worker doesn\'t exist', async (db) => {
       const etag = await create_worker(db);
 
       await assert.rejects(
@@ -1102,7 +1102,7 @@ suite(testing.suiteName(), function () {
       );
     });
 
-    helper.dbTest('update_worker, override when etag not specified', async function (db) {
+    helper.dbTest('update_worker, override when etag not specified', async (db) => {
       await create_worker(db);
       await db.deprecatedFns.update_worker(
         'wp/id',
@@ -1123,7 +1123,7 @@ suite(testing.suiteName(), function () {
       assert.equal(rows[0].capacity, 2);
     });
 
-    helper.dbTest('update_worker_3, override when etag not specified', async function (db) {
+    helper.dbTest('update_worker_3, override when etag not specified', async (db) => {
       await create_worker(db);
       await db.fns.update_worker_3(
         'wp/id',
@@ -1145,7 +1145,7 @@ suite(testing.suiteName(), function () {
       assert.equal(rows[0].capacity, 2);
     });
 
-    helper.dbTest('update_worker, throws when etag is wrong', async function (db) {
+    helper.dbTest('update_worker, throws when etag is wrong', async (db) => {
       await create_worker(db);
       await assert.rejects(
         async () => {
@@ -1168,7 +1168,7 @@ suite(testing.suiteName(), function () {
       );
     });
 
-    helper.dbTest('update_worker_3, throws when etag is wrong', async function (db) {
+    helper.dbTest('update_worker_3, throws when etag is wrong', async (db) => {
       await create_worker(db);
       await assert.rejects(
         async () => {
@@ -1192,7 +1192,7 @@ suite(testing.suiteName(), function () {
       );
     });
 
-    helper.dbTest('update_worker, throws when row does not exist', async function (db) {
+    helper.dbTest('update_worker, throws when row does not exist', async (db) => {
       const etag = await create_worker(db);
       await assert.rejects(
         async () => {
@@ -1215,7 +1215,7 @@ suite(testing.suiteName(), function () {
       );
     });
 
-    helper.dbTest('update_worker_3, throws when row does not exist', async function (db) {
+    helper.dbTest('update_worker_3, throws when row does not exist', async (db) => {
       const etag = await create_worker(db);
       await assert.rejects(
         async () => {
@@ -1239,7 +1239,7 @@ suite(testing.suiteName(), function () {
       );
     });
 
-    helper.dbTest('delete_worker', async function (db) {
+    helper.dbTest('delete_worker', async (db) => {
       await create_worker_pool(db);
 
       await db.fns.delete_worker('wp/id', 'w/group', 'w/id');
@@ -1249,8 +1249,8 @@ suite(testing.suiteName(), function () {
     });
   });
 
-  suite('existing capacity', function () {
-    helper.dbTest('no workers', async function (db) {
+  suite('existing capacity', () => {
+    helper.dbTest('no workers', async (db) => {
       await create_worker_pool(db);
       const row = (await db.fns.get_worker_pool_counts_and_capacity('wp/id'))[0];
       assert.equal(row.current_capacity, 0);
@@ -1263,7 +1263,7 @@ suite(testing.suiteName(), function () {
       assert.equal(row.stopping_capacity, 0);
       assert.equal(row.stopped_capacity, 0);
     });
-    helper.dbTest('single worker, capacity 1', async function (db) {
+    helper.dbTest('single worker, capacity 1', async (db) => {
       await create_worker_pool(db);
       await create_worker(db, { capacity: 1, state: 'running' });
       const row = (await db.fns.get_worker_pool_counts_and_capacity('wp/id'))[0];
@@ -1277,7 +1277,7 @@ suite(testing.suiteName(), function () {
       assert.equal(row.stopping_capacity, 0);
       assert.equal(row.stopped_capacity, 0);
     });
-    helper.dbTest('single worker, capacity > 1', async function (db) {
+    helper.dbTest('single worker, capacity > 1', async (db) => {
       await create_worker_pool(db);
       await create_worker(db, { capacity: 64, state: 'running' });
       const row = (await db.fns.get_worker_pool_counts_and_capacity('wp/id'))[0];
@@ -1291,7 +1291,7 @@ suite(testing.suiteName(), function () {
       assert.equal(row.stopping_capacity, 0);
       assert.equal(row.stopped_capacity, 0);
     });
-    helper.dbTest('multiple workers, capacity 1', async function (db) {
+    helper.dbTest('multiple workers, capacity 1', async (db) => {
       await create_worker_pool(db);
       await create_worker(db, { worker_id: 'foo1', capacity: 1, state: 'running' });
       await create_worker(db, { worker_id: 'foo2', capacity: 1, state: 'running' });
@@ -1308,7 +1308,7 @@ suite(testing.suiteName(), function () {
       assert.equal(row.stopping_capacity, 0);
       assert.equal(row.stopped_capacity, 0);
     });
-    helper.dbTest('multiple workers, capacity > 1', async function (db) {
+    helper.dbTest('multiple workers, capacity > 1', async (db) => {
       await create_worker_pool(db);
       await create_worker(db, { worker_id: 'foo1', capacity: 32, state: 'running' });
       await create_worker(db, { worker_id: 'foo2', capacity: 64, state: 'running' });
@@ -1325,7 +1325,7 @@ suite(testing.suiteName(), function () {
       assert.equal(row.stopping_capacity, 0);
       assert.equal(row.stopped_capacity, 0);
     });
-    helper.dbTest('multiple workers, multiple states', async function (db) {
+    helper.dbTest('multiple workers, multiple states', async (db) => {
       await create_worker_pool(db);
       await create_worker(db, { worker_id: 'foo1', capacity: 32, state: 'running' });
       await create_worker(db, { worker_id: 'foo2', capacity: 64, state: 'stopped' });
@@ -1342,14 +1342,14 @@ suite(testing.suiteName(), function () {
       assert.equal(row.stopping_capacity, 0);
       assert.equal(row.stopped_capacity, 64);
     });
-    helper.dbTest('no workers (multiple pools)', async function (db) {
+    helper.dbTest('no workers (multiple pools)', async (db) => {
       await create_worker_pool(db);
       await create_worker_pool(db, { worker_pool_id: 'ff/tt' });
       const pools = (await db.fns.get_worker_pools_counts_and_capacity(null, null)).sort();
       assert.equal(pools[0].current_capacity, 0);
       assert.equal(pools[1].current_capacity, 0);
     });
-    helper.dbTest('single worker (multiple pools)', async function (db) {
+    helper.dbTest('single worker (multiple pools)', async (db) => {
       await create_worker_pool(db);
       await create_worker_pool(db, { worker_pool_id: 'ff/tt' });
       await create_worker(db, { capacity: 4, state: 'running' });
@@ -1359,7 +1359,7 @@ suite(testing.suiteName(), function () {
       assert.equal(pools[0].current_capacity, 0);
       assert.equal(pools[1].current_capacity, 4);
     });
-    helper.dbTest('multiple workers (multiple pools)', async function (db) {
+    helper.dbTest('multiple workers (multiple pools)', async (db) => {
       await create_worker_pool(db);
       await create_worker_pool(db, { worker_pool_id: 'ff/tt' });
       await create_worker(db, { worker_id: 'foo1', capacity: 4, state: 'running' });
@@ -1374,8 +1374,8 @@ suite(testing.suiteName(), function () {
       assert.equal(pools[1].current_capacity, 5);
     });
 
-    suite('launch configs', function () {
-      helper.dbTest('launch configs statistics for a worker pool', async function (db) {
+    suite('launch configs', () => {
+      helper.dbTest('launch configs statistics for a worker pool', async (db) => {
         await create_worker_pool(db, { worker_pool_id: 'll/cc' });
         await create_worker(db, { worker_id: 'foo1', capacity: 4, worker_pool_id: 'll/cc', state: 'running', launch_config_id: 'lc1' });
         await create_worker(db, { worker_id: 'foo2', capacity: 1, worker_pool_id: 'll/cc', state: 'running', launch_config_id: 'lc1' });
@@ -1412,26 +1412,26 @@ suite(testing.suiteName(), function () {
     });
   });
 
-  suite(`${testing.suiteName()} - TaskQueue`, function () {
-    helper.dbTest('no such task queue', async function (db) {
+  suite(`${testing.suiteName()} - TaskQueue`, () => {
+    helper.dbTest('no such task queue', async (db) => {
       const res = await db.fns.get_task_queue_wm_2('prov/wt', new Date());
       assert.deepEqual(res, []);
     });
 
-    helper.dbTest('get_task_queues_wm empty', async function (db) {
+    helper.dbTest('get_task_queues_wm empty', async (db) => {
       const res = await db.fns.get_task_queues_wm(null, null, null, null);
       assert.deepEqual(res, []);
     });
   });
 
-  suite(`${testing.suiteName()} - Worker Pool Launch Configs`, function () {
+  suite(`${testing.suiteName()} - Worker Pool Launch Configs`, () => {
     const assertEqualSorted = (arr1, arr2) => {
       arr1.sort();
       arr2.sort();
       assert.deepEqual(arr1, arr2);
     };
 
-    helper.dbTest('create_worker_pool_launch_config/get_worker_pool_launch_configs', async function (db) {
+    helper.dbTest('create_worker_pool_launch_config/get_worker_pool_launch_configs', async (db) => {
       const wpId = 'w/i1';
       await db.fns.create_worker_pool_launch_config('lc1', wpId, false, { config: '1' }, fromNow('0s'), fromNow('0s'));
       await db.fns.create_worker_pool_launch_config('lc2', wpId, false, {
@@ -1457,7 +1457,7 @@ suite(testing.suiteName(), function () {
       });
     });
 
-    helper.dbTest('upsert_worker_pool_launch_configs returns expected ids', async function (db) {
+    helper.dbTest('upsert_worker_pool_launch_configs returns expected ids', async (db) => {
       const launchConfigs = [
         { cfg: 'c1', workerManager: { maxCapacity: 5 } },
         { cfg: 'c2', workerManager: { maxCapacity: 5 } },
@@ -1512,7 +1512,7 @@ suite(testing.suiteName(), function () {
       assert.equal(res5.archived_launch_configs.length, 2);
     });
 
-    helper.dbTest('expire_worker_pool_launch_configs', async function (db) {
+    helper.dbTest('expire_worker_pool_launch_configs', async (db) => {
       // make sure all previous launch configs are expired
       await db.fns.expire_worker_pool_launch_configs();
 
@@ -1532,7 +1532,7 @@ suite(testing.suiteName(), function () {
       assert.deepEqual(await db.fns.expire_worker_pool_launch_configs(), [{ launch_config_id: 'lc2' }]);
     });
 
-    helper.dbTest('get_worker_pool_launch_config_stats', async function (db) {
+    helper.dbTest('get_worker_pool_launch_config_stats', async (db) => {
       // test stats are being returned for workers groupped by state
     });
 

--- a/db/test/helper.js
+++ b/db/test/helper.js
@@ -31,13 +31,13 @@ export default helper;
  * should implement a `setup` method that sets state for all relevant tables
  * before each test case.
  */
-helper.withDbForVersion = function() {
+helper.withDbForVersion = () => {
   let pool;
   let dbs = {};
 
   const showProgress = Debug('showProgress');
 
-  suiteSetup('setup database', async function() {
+  suiteSetup('setup database', async () => {
     pool = new Pool({ connectionString: dbUrl });
 
     helper.withDbClient = async (cb) => {
@@ -125,7 +125,7 @@ helper.withDbForVersion = function() {
     await resetDb({ testDbUrl: dbUrl });
   });
 
-  suiteTeardown('teardown database', async function() {
+  suiteTeardown('teardown database', async () => {
     if (pool) {
       await pool.end();
     }
@@ -149,9 +149,9 @@ helper.withDbForVersion = function() {
  * should implement a `setup` method that sets state for all relevant tables
  * before each test case.
  */
-helper.withDbForProcs = function({ serviceName }) {
+helper.withDbForProcs = ({ serviceName }) => {
   let db;
-  suiteSetup('setup database', async function() {
+  suiteSetup('setup database', async () => {
     db = await tcdb.setup({
       writeDbUrl: dbUrl,
       readDbUrl: dbUrl,
@@ -179,7 +179,7 @@ helper.withDbForProcs = function({ serviceName }) {
     });
   });
 
-  suiteTeardown('teardown database', async function() {
+  suiteTeardown('teardown database', async () => {
     if (db) {
       await db.close();
     }
@@ -192,9 +192,7 @@ helper.withDbForProcs = function({ serviceName }) {
    * test function both with a real and fake db.  This is used for testing functions.
    */
   helper.dbTest = (description, testFn) => {
-    test(description, async function() {
-      return testFn(db);
-    });
+    test(description, async () => testFn(db));
   };
 };
 
@@ -383,8 +381,8 @@ helper.dbVersionTest = ({
     }
   };
 
-  suite(`dbVersionTest for v${version}`, function() {
-    setup(async function() {
+  suite(`dbVersionTest for v${version}`, () => {
+    setup(async () => {
       sawMigrationBatches = false;
       sawDowngradeBatches = false;
       await resetDb({ testDbUrl: dbUrl });
@@ -392,11 +390,11 @@ helper.dbVersionTest = ({
       await helper.withDbClient(createData);
     });
 
-    teardown(async function() {
+    teardown(async () => {
       runOnlineBatches.resetHooks();
     });
 
-    test('successful upgrade, downgrade process', async function() {
+    test('successful upgrade, downgrade process', async () => {
       await helper.withDbClient(async client => {
         await startCheck(client);
         await withCheckpoints('up', {
@@ -422,7 +420,7 @@ helper.dbVersionTest = ({
       return;
     }
 
-    test('upgrade fails mid-online, restarted, downgrade fails mid-online, restarted', async function() {
+    test('upgrade fails mid-online, restarted, downgrade fails mid-online, restarted', async () => {
       await helper.withDbClient(async client => {
         await startCheck(client);
         await withCheckpoints('up', {
@@ -449,7 +447,7 @@ helper.dbVersionTest = ({
       });
     });
 
-    test('restart upgrades and downgrades repeatedly', async function() {
+    test('restart upgrades and downgrades repeatedly', async () => {
       await helper.withDbClient(async client => {
         await startCheck(client);
         await withCheckpoints('up', {
@@ -475,7 +473,7 @@ helper.dbVersionTest = ({
       });
     });
 
-    test('upgrade fails mid-online, downgrade', async function() {
+    test('upgrade fails mid-online, downgrade', async () => {
       await helper.withDbClient(async client => {
         await withCheckpoints('up', {
           midOnline: async () => { throw abort; },

--- a/db/test/timestamp_test.js
+++ b/db/test/timestamp_test.js
@@ -2,10 +2,10 @@ import { strict as assert } from 'node:assert';
 import testing from '@taskcluster/lib-testing';
 import tcdb from '@taskcluster/db';
 
-suite(testing.suiteName(), function() {
+suite(testing.suiteName(), () => {
   const schema = tcdb.schema({ useDbDirectory: true });
 
-  test('DB has no timezone-less timestamp columns', function() {
+  test('DB has no timezone-less timestamp columns', () => {
     /* Postgres TIMESTAMP columns, by default, lack a timezone.  While it's possible to
      * design a DB with the implicit assumption that all timestamps are in UTC, this is
      * a source of confusion and errors.  Instead, we require that every TIMESTAMP column

--- a/db/test/upgrade_downgrade_test.js
+++ b/db/test/upgrade_downgrade_test.js
@@ -3,7 +3,7 @@ import testing from '@taskcluster/lib-testing';
 import tcdb from '@taskcluster/db';
 import helper from './helper.js';
 
-suite(testing.suiteName(), function() {
+suite(testing.suiteName(), () => {
   helper.withDbForVersion();
 
   const schema = tcdb.schema({ useDbDirectory: true });
@@ -58,21 +58,21 @@ suite(testing.suiteName(), function() {
     });
   };
 
-  test('upgrade to latest version', async function() {
+  test('upgrade to latest version', async () => {
     await helper.upgradeTo(latestVersion.version);
   });
 
-  test('downgrade to version 0', async function() {
+  test('downgrade to version 0', async () => {
     await helper.downgradeTo(0);
     await assertEmptySchema();
     await assertNoPermissions();
   });
 
-  test('upgrade to latest version again', async function() {
+  test('upgrade to latest version again', async () => {
     await helper.upgradeTo(latestVersion.version);
   });
 
-  test('downgrade to version 0', async function() {
+  test('downgrade to version 0', async () => {
     await helper.downgradeTo(0);
     await assertEmptySchema();
     await assertNoPermissions();

--- a/db/test/versions/0001_test.js
+++ b/db/test/versions/0001_test.js
@@ -1,10 +1,10 @@
 import helper from '../helper.js';
 import testing from '@taskcluster/lib-testing';
 
-suite(testing.suiteName(), function() {
+suite(testing.suiteName(), () => {
   helper.withDbForVersion();
 
-  test('widgets table created', async function() {
+  test('widgets table created', async () => {
     await helper.assertNoTable("widgets");
     await helper.upgradeTo(1);
     await helper.assertTable("widgets");

--- a/db/test/versions/0002_test.js
+++ b/db/test/versions/0002_test.js
@@ -48,12 +48,12 @@ const azureTableNames = [
   'WMWorkerPoolErrors',
 ];
 
-suite(testing.suiteName(), function() {
+suite(testing.suiteName(), () => {
   helper.withDbForVersion();
 
   /* Note that these tests run in order */
 
-  test(`tables created on upgrade`, async function () {
+  test(`tables created on upgrade`, async () => {
     await helper.upgradeTo(1);
 
     for (let azureTableName of azureTableNames) {
@@ -67,7 +67,7 @@ suite(testing.suiteName(), function() {
     }
   });
 
-  test(`tables dropped on downgrade`, async function () {
+  test(`tables dropped on downgrade`, async () => {
     await helper.downgradeTo(1);
     for (let azureTableName of azureTableNames) {
       await helper.assertNoTable(postgresTableName(azureTableName));

--- a/db/test/versions/0003_test.js
+++ b/db/test/versions/0003_test.js
@@ -1,10 +1,10 @@
 import helper from '../helper.js';
 import testing from '@taskcluster/lib-testing';
 
-suite(testing.suiteName(), function() {
+suite(testing.suiteName(), () => {
   helper.withDbForVersion();
 
-  test('azure_queue_messages table created', async function() {
+  test('azure_queue_messages table created', async () => {
     await helper.assertNoTable('azure_queue_messages');
     await helper.upgradeTo(3);
     await helper.assertTable('azure_queue_messages');

--- a/db/test/versions/0004_test.js
+++ b/db/test/versions/0004_test.js
@@ -1,6 +1,6 @@
 import testing from '@taskcluster/lib-testing';
 
-suite(testing.suiteName(), function() {
+suite(testing.suiteName(), () => {
   // this version only redefines a method, which is tested in unit tests,
   // so there is nothing to test on upgrade
 });

--- a/db/test/versions/0005_test.js
+++ b/db/test/versions/0005_test.js
@@ -1,6 +1,6 @@
 import testing from '@taskcluster/lib-testing';
 
-suite(testing.suiteName(), function() {
+suite(testing.suiteName(), () => {
   // this version only redefines a method, which is tested in unit tests,
   // so there is nothing to test on upgrade
 });

--- a/db/test/versions/0006_test.js
+++ b/db/test/versions/0006_test.js
@@ -1,6 +1,6 @@
 import testing from '@taskcluster/lib-testing';
 
-suite(testing.suiteName(), function() {
+suite(testing.suiteName(), () => {
   // this version only redefines a method, which is tested in unit tests,
   // so there is nothing to test on upgrade
 });

--- a/db/test/versions/0007_test.js
+++ b/db/test/versions/0007_test.js
@@ -1,6 +1,6 @@
 import testing from '@taskcluster/lib-testing';
 
-suite(testing.suiteName(), function() {
+suite(testing.suiteName(), () => {
   // this version only redefines methods, which were tested in unit tests,
   // until taskcluster-lib-entities was dropped, so there is nothing to test
   // on upgrade

--- a/db/test/versions/0008_test.js
+++ b/db/test/versions/0008_test.js
@@ -8,7 +8,7 @@ const ASCII = _.range(1, 128).map(i => String.fromCharCode(i)).join(' ');
 const THIS_VERSION = parseInt(/.*\/0*(\d+)_test\.js/.exec(import.meta.url)[1], 10);
 
 // (copied from azure-entities)
-const encodeStringKey = function(str) {
+const encodeStringKey = (str) => {
   if (str === '') {
     return '!';
   }
@@ -18,7 +18,7 @@ const encodeStringKey = function(str) {
     .replace(/%/g, '!');
 };
 
-const decodeStringKey = function(str) {
+const decodeStringKey = (str) => {
   if (str === '!') {
     return '';
   }
@@ -29,21 +29,17 @@ const decodeStringKey = function(str) {
   return decodeURIComponent(str.replace(/!/g, '%'));
 };
 
-const encodeCompositeKey = function(key1, key2) {
-  return `${encodeStringKey(key1)}~${encodeStringKey(key2)}`;
-};
+const encodeCompositeKey = (key1, key2) => `${encodeStringKey(key1)}~${encodeStringKey(key2)}`;
 
-const decodeCompositeKey = function(key) {
-  return key.split('~').map(decodeStringKey);
-};
+const decodeCompositeKey = (key) => key.split('~').map(decodeStringKey);
 
 // (this is used by 0010_test.js, too)
 export let entityBufDecodeTest = null;
 
-suite(testing.suiteName(), function() {
+suite(testing.suiteName(), () => {
   helper.withDbForVersion();
 
-  suiteSetup(async function() {
+  suiteSetup(async () => {
     await testing.resetDb({ testDbUrl: helper.dbUrl });
     await helper.upgradeTo(THIS_VERSION);
   });
@@ -51,7 +47,7 @@ suite(testing.suiteName(), function() {
   const b64 = x => Buffer.from(x).toString('base64');
 
   entityBufDecodeTest = (name, encoded, expected, xfail) => {
-    test(`entity_buf_decode: ${name}${xfail && ' (XFAIL)'}`, async function() {
+    test(`entity_buf_decode: ${name}${xfail && ' (XFAIL)'}`, async () => {
       await helper.withDbClient(async client => {
         const t = await client.query(`
           select entity_buf_decode($1, 'val') as decoded
@@ -73,7 +69,7 @@ suite(testing.suiteName(), function() {
   entityBufDecodeTest('2 huge bufs', hugeBufs.encoded, hugeBufs.decoded, true);
 
   const entityBufEncodeTest = (name, value) => {
-    test(`entity_buf_encode: ${name}`, async function() {
+    test(`entity_buf_encode: ${name}`, async () => {
       await helper.withDbClient(async client => {
         const t = await client.query(`
           select entity_buf_encode('{}'::jsonb, 'val', $1) as encoded
@@ -90,7 +86,7 @@ suite(testing.suiteName(), function() {
   entityBufEncodeTest('all ascii', ASCII);
 
   const entityBufRoundTrip = (name, value) => {
-    test(`entity_buf_en/decode round-trip: ${name}`, async function() {
+    test(`entity_buf_en/decode round-trip: ${name}`, async () => {
       await helper.withDbClient(async client => {
         const res = await client.query(`
           select entity_buf_decode(
@@ -108,7 +104,7 @@ suite(testing.suiteName(), function() {
   entityBufRoundTrip('json with backslashes', JSON.stringify(["back\\slash"]));
 
   const encodeStringKeyTest = (name, input) => {
-    test(`encode_string_key: ${name}`, async function() {
+    test(`encode_string_key: ${name}`, async () => {
       await helper.withDbClient(async client => {
         const res = await client.query(
           'select encode_string_key($1) as output',
@@ -123,7 +119,7 @@ suite(testing.suiteName(), function() {
   encodeStringKeyTest('slashed worker pool id', 'worker/pool');
 
   const decodeStringKeyTest = (name, input) => {
-    test(`decode_string_key: ${name}`, async function() {
+    test(`decode_string_key: ${name}`, async () => {
       await helper.withDbClient(async client => {
         const res = await client.query(
           'select decode_string_key($1) as output',
@@ -147,7 +143,7 @@ suite(testing.suiteName(), function() {
   decodeStringKeyTest('multiple escapes', '!7ea!5eb!25c');
 
   const encodeDecodeRoundTrip = (name, value) => {
-    test(`en/decode_string_key: ${name}`, async function() {
+    test(`en/decode_string_key: ${name}`, async () => {
       await helper.withDbClient(async client => {
         const res = await client.query(
           'select decode_string_key(encode_string_key($1)) as output',
@@ -163,7 +159,7 @@ suite(testing.suiteName(), function() {
   encodeDecodeRoundTrip('tilde', '~');
 
   const encodeCompositeKeyTest = (name, input) => {
-    test(`decode_composite_key: ${name}`, async function() {
+    test(`decode_composite_key: ${name}`, async () => {
       await helper.withDbClient(async client => {
         const res = await client.query(
           'select encode_composite_key($1, $2) as output',
@@ -180,7 +176,7 @@ suite(testing.suiteName(), function() {
   encodeCompositeKeyTest('weird chars', [ASCII, 'def']);
 
   const decodeCompositeKeyTest = (name, input) => {
-    test(`decode_composite_key: ${name}`, async function() {
+    test(`decode_composite_key: ${name}`, async () => {
       await helper.withDbClient(async client => {
         const res = await client.query(
           'select decode_composite_key($1) as output',
@@ -195,7 +191,7 @@ suite(testing.suiteName(), function() {
   decodeCompositeKeyTest('encoded', 'foo!2fbar~bar!5cfoo');
 
   const compositeKeyRoundTripTest = (name, value) => {
-    test(`en/decode_composite_key: ${name}`, async function() {
+    test(`en/decode_composite_key: ${name}`, async () => {
       await helper.withDbClient(async client => {
         const res = await client.query(
           'select decode_composite_key(encode_composite_key($1, $2)) as output',

--- a/db/test/versions/0009_test.js
+++ b/db/test/versions/0009_test.js
@@ -4,13 +4,13 @@ import testing from '@taskcluster/lib-testing';
 const THIS_VERSION = parseInt(/.*\/0*(\d+)_test\.js/.exec(import.meta.url)[1], 10);
 const PREV_VERSION = THIS_VERSION - 1;
 
-suite(testing.suiteName(), function() {
+suite(testing.suiteName(), () => {
   helper.withDbForVersion();
 
   // note that this test suite initially tested the migration much more thoroughly, but did
   // so using tc-lib-entities, which has since been removed from the codebase.
 
-  test('cache_purges table created / removed on upgrade and downgrade', async function() {
+  test('cache_purges table created / removed on upgrade and downgrade', async () => {
     await testing.resetDb({ testDbUrl: helper.dbUrl });
     await helper.upgradeTo(PREV_VERSION);
 

--- a/db/test/versions/0010_test.js
+++ b/db/test/versions/0010_test.js
@@ -6,15 +6,15 @@ import { entityBufDecodeTest } from './0008_test.js';
 const THIS_VERSION = parseInt(/.*\/0*(\d+)_test\.js/.exec(import.meta.url)[1], 10);
 const PREV_VERSION = THIS_VERSION - 1;
 
-suite(testing.suiteName(), function() {
+suite(testing.suiteName(), () => {
   helper.withDbForVersion();
 
   // note that this test suite initially tested the migration much more thoroughly, but did
   // so using tc-lib-entities, which has since been removed from the codebase.
 
   // version 10 updates entity_buf_decode to fix a bug, so we re-test that function here
-  suite('entity_buf_decode bugfix', function() {
-    suiteSetup(async function() {
+  suite('entity_buf_decode bugfix', () => {
+    suiteSetup(async () => {
       await testing.resetDb({ testDbUrl: helper.dbUrl });
       await helper.upgradeTo(THIS_VERSION);
     });
@@ -27,7 +27,7 @@ suite(testing.suiteName(), function() {
     entityBufDecodeTest('2 huge bufs', hugeBufs.encoded, hugeBufs.decoded);
   });
 
-  test('tables created / removed on upgrade and downgrade', async function() {
+  test('tables created / removed on upgrade and downgrade', async () => {
     await testing.resetDb({ testDbUrl: helper.dbUrl });
     await helper.upgradeTo(PREV_VERSION);
 

--- a/db/test/versions/0011_test.js
+++ b/db/test/versions/0011_test.js
@@ -4,10 +4,10 @@ import testing from '@taskcluster/lib-testing';
 const THIS_VERSION = parseInt(/.*\/0*(\d+)_test\.js/.exec(import.meta.url)[1], 10);
 const PREV_VERSION = THIS_VERSION - 1;
 
-suite(testing.suiteName(), function() {
+suite(testing.suiteName(), () => {
   helper.withDbForVersion();
 
-  test('widgets table dropped', async function() {
+  test('widgets table dropped', async () => {
     await helper.upgradeTo(PREV_VERSION);
     await helper.assertTable("widgets");
     await helper.upgradeTo(THIS_VERSION);

--- a/db/test/versions/0012_test.js
+++ b/db/test/versions/0012_test.js
@@ -4,13 +4,13 @@ import testing from '@taskcluster/lib-testing';
 const THIS_VERSION = parseInt(/.*\/0*(\d+)_test\.js/.exec(import.meta.url)[1], 10);
 const PREV_VERSION = THIS_VERSION - 1;
 
-suite(testing.suiteName(), function() {
+suite(testing.suiteName(), () => {
   helper.withDbForVersion();
 
   // note that this test suite initially tested the migration much more thoroughly, but did
   // so using tc-lib-entities, which has since been removed from the codebase.
 
-  test('workers table created / removed on upgrade and downgrade', async function() {
+  test('workers table created / removed on upgrade and downgrade', async () => {
     await testing.resetDb({ testDbUrl: helper.dbUrl });
     await helper.upgradeTo(PREV_VERSION);
 

--- a/db/test/versions/0013_test.js
+++ b/db/test/versions/0013_test.js
@@ -1,6 +1,6 @@
 import testing from '@taskcluster/lib-testing';
 
-suite(testing.suiteName(), function() {
+suite(testing.suiteName(), () => {
   // this version only adds/redefines methods, which is tested in unit tests,
   // so there is nothing to test on upgrade
 });

--- a/db/test/versions/0014_test.js
+++ b/db/test/versions/0014_test.js
@@ -5,7 +5,7 @@ import testing from '@taskcluster/lib-testing';
 const THIS_VERSION = parseInt(/.*\/0*(\d+)_test\.js/.exec(import.meta.url)[1], 10);
 const PREV_VERSION = THIS_VERSION - 1;
 
-suite(testing.suiteName(), function() {
+suite(testing.suiteName(), () => {
   helper.withDbForVersion();
 
   const assertNoColumn = async columnName => {
@@ -26,7 +26,7 @@ suite(testing.suiteName(), function() {
     });
   };
 
-  test('secret column added', async function() {
+  test('secret column added', async () => {
     await helper.upgradeTo(PREV_VERSION);
     await assertNoColumn('secret');
     await helper.upgradeTo(THIS_VERSION);

--- a/db/test/versions/0015_test.js
+++ b/db/test/versions/0015_test.js
@@ -3,11 +3,11 @@ import testing from '@taskcluster/lib-testing';
 import { strict as assert } from 'node:assert';
 import crypto from 'node:crypto';
 
-suite(testing.suiteName(), function() {
+suite(testing.suiteName(), () => {
   const THIS_VERSION = parseInt(/.*\/0*(\d+)_test\.js/.exec(import.meta.url)[1], 10);
   helper.withDbForVersion();
 
-  suiteSetup(async function() {
+  suiteSetup(async () => {
     await testing.resetDb({ testDbUrl: helper.dbUrl });
     await helper.upgradeTo(THIS_VERSION);
   });
@@ -19,7 +19,7 @@ suite(testing.suiteName(), function() {
       .digest('hex');
   };
 
-  test('hashes a key', async function() {
+  test('hashes a key', async () => {
     await helper.withDbClient(async client => {
       const result = await client.query(
         `select sha512('foo/bar')`);

--- a/db/test/versions/0016_test.js
+++ b/db/test/versions/0016_test.js
@@ -3,11 +3,11 @@ import testing from '@taskcluster/lib-testing';
 import { strict as assert } from 'node:assert';
 import slugid from 'slugid';
 
-suite(testing.suiteName(), function() {
+suite(testing.suiteName(), () => {
   const THIS_VERSION = parseInt(/.*\/0*(\d+)_test\.js/.exec(import.meta.url)[1], 10);
   helper.withDbForVersion();
 
-  suiteSetup(async function() {
+  suiteSetup(async () => {
     await testing.resetDb({ testDbUrl: helper.dbUrl });
     await helper.upgradeTo(THIS_VERSION);
 
@@ -27,7 +27,7 @@ suite(testing.suiteName(), function() {
     });
   });
 
-  test('uuid_to_slugid', async function() {
+  test('uuid_to_slugid', async () => {
     await helper.withDbClient(async client => {
       const bugs = await client.query(
         `select
@@ -40,7 +40,7 @@ suite(testing.suiteName(), function() {
     });
   });
 
-  test('slugid_to_uuid', async function() {
+  test('slugid_to_uuid', async () => {
     await helper.withDbClient(async client => {
       const bugs = await client.query(
         `select

--- a/db/test/versions/0017_test.js
+++ b/db/test/versions/0017_test.js
@@ -4,13 +4,13 @@ import testing from '@taskcluster/lib-testing';
 const THIS_VERSION = parseInt(/.*\/0*(\d+)_test\.js/.exec(import.meta.url)[1], 10);
 const PREV_VERSION = THIS_VERSION - 1;
 
-suite(testing.suiteName(), function() {
+suite(testing.suiteName(), () => {
   helper.withDbForVersion();
 
   // note that this test suite initially tested the migration much more thoroughly, but did
   // so using tc-lib-entities, which has since been removed from the codebase.
 
-  test('denylisted_notifications table created / removed on upgrade and downgrade', async function() {
+  test('denylisted_notifications table created / removed on upgrade and downgrade', async () => {
     await testing.resetDb({ testDbUrl: helper.dbUrl });
     await helper.upgradeTo(PREV_VERSION);
 

--- a/db/test/versions/0018_test.js
+++ b/db/test/versions/0018_test.js
@@ -4,13 +4,13 @@ import testing from '@taskcluster/lib-testing';
 const THIS_VERSION = parseInt(/.*\/0*(\d+)_test\.js/.exec(import.meta.url)[1], 10);
 const PREV_VERSION = THIS_VERSION - 1;
 
-suite(`${testing.suiteName()}`, function() {
+suite(`${testing.suiteName()}`, () => {
   helper.withDbForVersion();
 
   // note that this test suite initially tested the migration much more thoroughly, but did
   // so using tc-lib-entities, which has since been removed from the codebase.
 
-  test('indexed_tasks table created / removed on upgrade and downgrade', async function() {
+  test('indexed_tasks table created / removed on upgrade and downgrade', async () => {
     await testing.resetDb({ testDbUrl: helper.dbUrl });
     await helper.upgradeTo(PREV_VERSION);
 
@@ -24,7 +24,7 @@ suite(`${testing.suiteName()}`, function() {
     await helper.assertNoTable('indexed_tasks');
   });
 
-  test('namespaces table created / removed on upgrade and downgrade', async function() {
+  test('namespaces table created / removed on upgrade and downgrade', async () => {
     await testing.resetDb({ testDbUrl: helper.dbUrl });
     await helper.upgradeTo(PREV_VERSION);
 

--- a/db/test/versions/0019_test.js
+++ b/db/test/versions/0019_test.js
@@ -4,13 +4,13 @@ import testing from '@taskcluster/lib-testing';
 const THIS_VERSION = parseInt(/.*\/0*(\d+)_test\.js/.exec(import.meta.url)[1], 10);
 const PREV_VERSION = THIS_VERSION - 1;
 
-suite(testing.suiteName(), function() {
+suite(testing.suiteName(), () => {
   helper.withDbForVersion();
 
   // note that this test suite initially tested the migration much more thoroughly, but did
   // so using tc-lib-entities, which has since been removed from the codebase.
 
-  test('queue_artifacts table created / removed on upgrade and downgrade', async function() {
+  test('queue_artifacts table created / removed on upgrade and downgrade', async () => {
     await testing.resetDb({ testDbUrl: helper.dbUrl });
     await helper.upgradeTo(PREV_VERSION);
 

--- a/db/test/versions/0020_test.js
+++ b/db/test/versions/0020_test.js
@@ -4,13 +4,13 @@ import testing from '@taskcluster/lib-testing';
 const THIS_VERSION = parseInt(/.*\/0*(\d+)_test\.js/.exec(import.meta.url)[1], 10);
 const PREV_VERSION = THIS_VERSION - 1;
 
-suite(testing.suiteName(), function() {
+suite(testing.suiteName(), () => {
   helper.withDbForVersion();
 
   // note that this test suite initially tested the migration much more thoroughly, but did
   // so using tc-lib-entities, which has since been removed from the codebase.
 
-  test('tables created / removed on upgrade and downgrade', async function() {
+  test('tables created / removed on upgrade and downgrade', async () => {
     await testing.resetDb({ testDbUrl: helper.dbUrl });
     await helper.upgradeTo(PREV_VERSION);
 

--- a/db/test/versions/0021_test.js
+++ b/db/test/versions/0021_test.js
@@ -4,13 +4,13 @@ import testing from '@taskcluster/lib-testing';
 const THIS_VERSION = parseInt(/.*\/0*(\d+)_test\.js/.exec(import.meta.url)[1], 10);
 const PREV_VERSION = THIS_VERSION - 1;
 
-suite(testing.suiteName(), function() {
+suite(testing.suiteName(), () => {
   helper.withDbForVersion();
 
   // note that this test suite initially tested the migration much more thoroughly, but did
   // so using tc-lib-entities, which has since been removed from the codebase.
 
-  test('tables created / removed on upgrade and downgrade', async function() {
+  test('tables created / removed on upgrade and downgrade', async () => {
     await testing.resetDb({ testDbUrl: helper.dbUrl });
     await helper.upgradeTo(PREV_VERSION);
 

--- a/db/test/versions/0022_test.js
+++ b/db/test/versions/0022_test.js
@@ -4,13 +4,13 @@ import testing from '@taskcluster/lib-testing';
 const THIS_VERSION = parseInt(/.*\/0*(\d+)_test\.js/.exec(import.meta.url)[1], 10);
 const PREV_VERSION = THIS_VERSION - 1;
 
-suite(testing.suiteName(), function() {
+suite(testing.suiteName(), () => {
   helper.withDbForVersion();
 
   // note that this test suite initially tested the migration much more thoroughly, but did
   // so using tc-lib-entities, which has since been removed from the codebase.
 
-  test('tables created / removed on upgrade and downgrade', async function() {
+  test('tables created / removed on upgrade and downgrade', async () => {
     await testing.resetDb({ testDbUrl: helper.dbUrl });
     await helper.upgradeTo(PREV_VERSION);
 

--- a/db/test/versions/0023_test.js
+++ b/db/test/versions/0023_test.js
@@ -4,13 +4,13 @@ import testing from '@taskcluster/lib-testing';
 const THIS_VERSION = parseInt(/.*\/0*(\d+)_test\.js/.exec(import.meta.url)[1], 10);
 const PREV_VERSION = THIS_VERSION - 1;
 
-suite(testing.suiteName(), function() {
+suite(testing.suiteName(), () => {
   helper.withDbForVersion();
 
   // note that this test suite initially tested the migration much more thoroughly, but did
   // so using tc-lib-entities, which has since been removed from the codebase.
 
-  test('builds table created / removed on upgrade and downgrade', async function() {
+  test('builds table created / removed on upgrade and downgrade', async () => {
     await testing.resetDb({ testDbUrl: helper.dbUrl });
     await helper.upgradeTo(PREV_VERSION);
 

--- a/db/test/versions/0024_test.js
+++ b/db/test/versions/0024_test.js
@@ -1,6 +1,6 @@
 import testing from '@taskcluster/lib-testing';
 
-suite(testing.suiteName(), function() {
+suite(testing.suiteName(), () => {
   // this version only redefines a method, which is tested in unit tests,
   // so there is nothing to test on upgrade
 });

--- a/db/test/versions/0025_test.js
+++ b/db/test/versions/0025_test.js
@@ -4,13 +4,13 @@ import testing from '@taskcluster/lib-testing';
 const THIS_VERSION = parseInt(/.*\/0*(\d+)_test\.js/.exec(import.meta.url)[1], 10);
 const PREV_VERSION = THIS_VERSION - 1;
 
-suite(`${testing.suiteName()} - roles`, function() {
+suite(`${testing.suiteName()} - roles`, () => {
   helper.withDbForVersion();
 
   // note that this test suite initially tested the migration much more thoroughly, but did
   // so using tc-lib-entities, which has since been removed from the codebase.
 
-  test('roles table created / removed on upgrade and downgrade', async function() {
+  test('roles table created / removed on upgrade and downgrade', async () => {
     await testing.resetDb({ testDbUrl: helper.dbUrl });
     await helper.upgradeTo(PREV_VERSION);
 

--- a/db/test/versions/0026_test.js
+++ b/db/test/versions/0026_test.js
@@ -1,6 +1,6 @@
 import testing from '@taskcluster/lib-testing';
 
-suite(testing.suiteName(), function() {
+suite(testing.suiteName(), () => {
   // this version only adds/redefines methods, which is tested in unit tests,
   // so there is nothing to test on upgrade
 });

--- a/db/test/versions/0027_test.js
+++ b/db/test/versions/0027_test.js
@@ -7,10 +7,10 @@ const PREV_VERSION = THIS_VERSION - 1;
 // Since we don't migrate data from previous version, no need for tests for
 // validating data migration.
 
-suite(testing.suiteName(), function() {
+suite(testing.suiteName(), () => {
   helper.withDbForVersion();
 
-  test('github_access_tokens table created / removed on upgrade and downgrade', async function() {
+  test('github_access_tokens table created / removed on upgrade and downgrade', async () => {
     await testing.resetDb({ testDbUrl: helper.dbUrl });
     await helper.upgradeTo(PREV_VERSION);
 

--- a/db/test/versions/0028_test.js
+++ b/db/test/versions/0028_test.js
@@ -1,6 +1,6 @@
 import testing from '@taskcluster/lib-testing';
 
-suite(testing.suiteName(), function() {
+suite(testing.suiteName(), () => {
   // this version only adds/redefines methods, which is tested in unit tests,
   // so there is nothing to test on upgrade
 });

--- a/db/test/versions/0029_test.js
+++ b/db/test/versions/0029_test.js
@@ -4,13 +4,13 @@ import testing from '@taskcluster/lib-testing';
 const THIS_VERSION = parseInt(/.*\/0*(\d+)_test\.js/.exec(import.meta.url)[1], 10);
 const PREV_VERSION = THIS_VERSION - 1;
 
-suite(testing.suiteName(), function() {
+suite(testing.suiteName(), () => {
   helper.withDbForVersion();
 
   // note that this test suite initially tested the migration much more thoroughly, but did
   // so using tc-lib-entities, which has since been removed from the codebase.
 
-  test('worker_pool_errors table created / removed on upgrade and downgrade', async function() {
+  test('worker_pool_errors table created / removed on upgrade and downgrade', async () => {
     await testing.resetDb({ testDbUrl: helper.dbUrl });
     await helper.upgradeTo(PREV_VERSION);
 

--- a/db/test/versions/0030_test.js
+++ b/db/test/versions/0030_test.js
@@ -3,11 +3,11 @@ import testing from '@taskcluster/lib-testing';
 import { strict as assert } from 'node:assert';
 import crypto from 'node:crypto';
 
-suite(testing.suiteName(), function() {
+suite(testing.suiteName(), () => {
   const THIS_VERSION = parseInt(/.*\/0*(\d+)_test\.js/.exec(import.meta.url)[1], 10);
   helper.withDbForVersion();
 
-  suiteSetup(async function() {
+  suiteSetup(async () => {
     await testing.resetDb({ testDbUrl: helper.dbUrl });
     await helper.upgradeTo(THIS_VERSION);
   });
@@ -19,7 +19,7 @@ suite(testing.suiteName(), function() {
       .digest('hex');
   };
 
-  test('hashes a key', async function() {
+  test('hashes a key', async () => {
     await helper.withDbClient(async client => {
       const result = await client.query(
         `select sha512('foo/bar')`);

--- a/db/test/versions/0031_test.js
+++ b/db/test/versions/0031_test.js
@@ -1,6 +1,6 @@
 import testing from '@taskcluster/lib-testing';
 
-suite(testing.suiteName(), function() {
+suite(testing.suiteName(), () => {
   // this version only adds/redefines methods, which is tested in unit tests,
   // so there is nothing to test on upgrade
 });

--- a/db/test/versions/0032_test.js
+++ b/db/test/versions/0032_test.js
@@ -4,10 +4,10 @@ import testing from '@taskcluster/lib-testing';
 const THIS_VERSION = parseInt(/.*\/0*(\d+)_test\.js/.exec(import.meta.url)[1], 10);
 const PREV_VERSION = THIS_VERSION - 1;
 
-suite(testing.suiteName(), function() {
+suite(testing.suiteName(), () => {
   helper.withDbForVersion();
 
-  test('hooks_last_fires table created / removed on upgrade and downgrade', async function() {
+  test('hooks_last_fires table created / removed on upgrade and downgrade', async () => {
     await testing.resetDb({ testDbUrl: helper.dbUrl });
     await helper.upgradeTo(PREV_VERSION);
 

--- a/db/test/versions/0033_test.js
+++ b/db/test/versions/0033_test.js
@@ -4,10 +4,10 @@ import testing from '@taskcluster/lib-testing';
 const THIS_VERSION = parseInt(/.*\/0*(\d+)_test\.js/.exec(import.meta.url)[1], 10);
 const PREV_VERSION = THIS_VERSION - 1;
 
-suite(testing.suiteName(), function() {
+suite(testing.suiteName(), () => {
   helper.withDbForVersion();
 
-  test('hooks_queues table created / removed on upgrade and downgrade', async function() {
+  test('hooks_queues table created / removed on upgrade and downgrade', async () => {
     await testing.resetDb({ testDbUrl: helper.dbUrl });
     await helper.upgradeTo(PREV_VERSION);
 

--- a/db/test/versions/0034_test.js
+++ b/db/test/versions/0034_test.js
@@ -4,10 +4,10 @@ import { strict as assert } from 'node:assert';
 
 const THIS_VERSION = parseInt(/.*\/0*(\d+)_test\.js/.exec(import.meta.url)[1], 10);
 
-suite(testing.suiteName(), function() {
+suite(testing.suiteName(), () => {
   helper.withDbForVersion();
 
-  suiteSetup(async function() {
+  suiteSetup(async () => {
     await testing.resetDb({ testDbUrl: helper.dbUrl });
     await helper.upgradeTo(THIS_VERSION);
   });
@@ -41,7 +41,7 @@ suite(testing.suiteName(), function() {
     });
   };
   const entityToCryptoContainerV0 = (name, properties, expected) => {
-    test(`entity_to_crypto_container_v0: ${name}`, async function() {
+    test(`entity_to_crypto_container_v0: ${name}`, async () => {
       const c = await mkContainer(properties);
       assert.deepEqual(c, expected);
     });
@@ -55,7 +55,7 @@ suite(testing.suiteName(), function() {
   entityToCryptoContainerV0('multiple chunks', samples[4], { ...container, ...samples[4] });
 
   const encryptedEntityBufEncode = (name, properties) => {
-    test(`entity_buf_encode: ${name}`, async function() {
+    test(`entity_buf_encode: ${name}`, async () => {
       const c = await mkContainer(properties);
       const e = await encodeContainer(c);
       assert.equal(e.__bufchunks_fooBar, c.__bufchunks_val);

--- a/db/test/versions/0035_test.js
+++ b/db/test/versions/0035_test.js
@@ -4,13 +4,13 @@ import testing from '@taskcluster/lib-testing';
 const THIS_VERSION = parseInt(/.*\/0*(\d+)_test\.js/.exec(import.meta.url)[1], 10);
 const PREV_VERSION = THIS_VERSION - 1;
 
-suite(testing.suiteName(), function() {
+suite(testing.suiteName(), () => {
   helper.withDbForVersion();
 
   // note that this test suite initially tested the migration much more thoroughly, but did
   // so using tc-lib-entities, which has since been removed from the codebase.
 
-  test('hooks table created / removed on upgrade and downgrade', async function() {
+  test('hooks table created / removed on upgrade and downgrade', async () => {
     await testing.resetDb({ testDbUrl: helper.dbUrl });
     await helper.upgradeTo(PREV_VERSION);
 

--- a/db/test/versions/0036_test.js
+++ b/db/test/versions/0036_test.js
@@ -4,13 +4,13 @@ import testing from '@taskcluster/lib-testing';
 const THIS_VERSION = parseInt(/.*\/0*(\d+)_test\.js/.exec(import.meta.url)[1], 10);
 const PREV_VERSION = THIS_VERSION - 1;
 
-suite(testing.suiteName(), function() {
+suite(testing.suiteName(), () => {
   helper.withDbForVersion();
 
   // note that this test suite initially tested the migration much more thoroughly, but did
   // so using tc-lib-entities, which has since been removed from the codebase.
 
-  test('builds table created / removed on upgrade and downgrade', async function() {
+  test('builds table created / removed on upgrade and downgrade', async () => {
     await testing.resetDb({ testDbUrl: helper.dbUrl });
     await helper.upgradeTo(PREV_VERSION);
 

--- a/db/test/versions/0037_test.js
+++ b/db/test/versions/0037_test.js
@@ -4,13 +4,13 @@ import testing from '@taskcluster/lib-testing';
 const THIS_VERSION = parseInt(/.*\/0*(\d+)_test\.js/.exec(import.meta.url)[1], 10);
 const PREV_VERSION = THIS_VERSION - 1;
 
-suite(testing.suiteName(), function() {
+suite(testing.suiteName(), () => {
   helper.withDbForVersion();
 
   // note that this test suite initially tested the migration much more thoroughly, but did
   // so using tc-lib-entities, which has since been removed from the codebase.
 
-  test('builds table created / removed on upgrade and downgrade', async function() {
+  test('builds table created / removed on upgrade and downgrade', async () => {
     await testing.resetDb({ testDbUrl: helper.dbUrl });
     await helper.upgradeTo(PREV_VERSION);
 

--- a/db/test/versions/0038_test.js
+++ b/db/test/versions/0038_test.js
@@ -4,10 +4,10 @@ import testing from '@taskcluster/lib-testing';
 const THIS_VERSION = parseInt(/.*\/0*(\d+)_test\.js/.exec(import.meta.url)[1], 10);
 const PREV_VERSION = THIS_VERSION - 1;
 
-suite(testing.suiteName(), function() {
+suite(testing.suiteName(), () => {
   helper.withDbForVersion();
 
-  test('sessions table created / removed on upgrade and downgrade', async function() {
+  test('sessions table created / removed on upgrade and downgrade', async () => {
     await testing.resetDb({ testDbUrl: helper.dbUrl });
     await helper.upgradeTo(PREV_VERSION);
 

--- a/db/test/versions/0039_test.js
+++ b/db/test/versions/0039_test.js
@@ -4,10 +4,10 @@ import testing from '@taskcluster/lib-testing';
 const THIS_VERSION = parseInt(/.*\/0*(\d+)_test\.js/.exec(import.meta.url)[1], 10);
 const PREV_VERSION = THIS_VERSION - 1;
 
-suite(testing.suiteName(), function() {
+suite(testing.suiteName(), () => {
   helper.withDbForVersion();
 
-  test('authorization_codes table created / removed on upgrade and downgrade', async function() {
+  test('authorization_codes table created / removed on upgrade and downgrade', async () => {
     await testing.resetDb({ testDbUrl: helper.dbUrl });
     await helper.upgradeTo(PREV_VERSION);
 

--- a/db/test/versions/0040_test.js
+++ b/db/test/versions/0040_test.js
@@ -4,10 +4,10 @@ import testing from '@taskcluster/lib-testing';
 const THIS_VERSION = parseInt(/.*\/0*(\d+)_test\.js/.exec(import.meta.url)[1], 10);
 const PREV_VERSION = THIS_VERSION - 1;
 
-suite(testing.suiteName(), function() {
+suite(testing.suiteName(), () => {
   helper.withDbForVersion();
 
-  test('access_tokens table created / removed on upgrade and downgrade', async function() {
+  test('access_tokens table created / removed on upgrade and downgrade', async () => {
     await testing.resetDb({ testDbUrl: helper.dbUrl });
     await helper.upgradeTo(PREV_VERSION);
 

--- a/db/test/versions/0041_test.js
+++ b/db/test/versions/0041_test.js
@@ -4,10 +4,10 @@ import testing from '@taskcluster/lib-testing';
 const THIS_VERSION = parseInt(/.*\/0*(\d+)_test\.js/.exec(import.meta.url)[1], 10);
 const PREV_VERSION = THIS_VERSION - 1;
 
-suite(`${testing.suiteName()}`, function() {
+suite(`${testing.suiteName()}`, () => {
   helper.withDbForVersion();
 
-  test('clients table created / removed on upgrade and downgrade', async function() {
+  test('clients table created / removed on upgrade and downgrade', async () => {
     await testing.resetDb({ testDbUrl: helper.dbUrl });
     await helper.upgradeTo(PREV_VERSION);
 

--- a/db/test/versions/0042_test.js
+++ b/db/test/versions/0042_test.js
@@ -4,13 +4,13 @@ import testing from '@taskcluster/lib-testing';
 const THIS_VERSION = parseInt(/.*\/0*(\d+)_test\.js/.exec(import.meta.url)[1], 10);
 const PREV_VERSION = THIS_VERSION - 1;
 
-suite(testing.suiteName(), function() {
+suite(testing.suiteName(), () => {
   helper.withDbForVersion();
 
   // note that this test suite initially tested the migration much more thoroughly, but did
   // so using tc-lib-entities, which has since been removed from the codebase.
 
-  test('secrets table created / removed on upgrade and downgrade', async function() {
+  test('secrets table created / removed on upgrade and downgrade', async () => {
     await testing.resetDb({ testDbUrl: helper.dbUrl });
     await helper.upgradeTo(PREV_VERSION);
 

--- a/db/test/versions/0043_test.js
+++ b/db/test/versions/0043_test.js
@@ -4,13 +4,13 @@ import testing from '@taskcluster/lib-testing';
 const THIS_VERSION = parseInt(/.*\/0*(\d+)_test\.js/.exec(import.meta.url)[1], 10);
 const PREV_VERSION = THIS_VERSION - 1;
 
-suite(testing.suiteName(), function() {
+suite(testing.suiteName(), () => {
   helper.withDbForVersion();
 
   // note that this test suite initially tested the migration much more thoroughly, but did
   // so using tc-lib-entities, which has since been removed from the codebase.
 
-  test('queue_workers table created / removed on upgrade and downgrade', async function() {
+  test('queue_workers table created / removed on upgrade and downgrade', async () => {
     await testing.resetDb({ testDbUrl: helper.dbUrl });
     await helper.upgradeTo(PREV_VERSION);
 

--- a/db/test/versions/0044_test.js
+++ b/db/test/versions/0044_test.js
@@ -4,13 +4,13 @@ import testing from '@taskcluster/lib-testing';
 const THIS_VERSION = parseInt(/.*\/0*(\d+)_test\.js/.exec(import.meta.url)[1], 10);
 const PREV_VERSION = THIS_VERSION - 1;
 
-suite(testing.suiteName(), function() {
+suite(testing.suiteName(), () => {
   helper.withDbForVersion();
 
   // note that this test suite initially tested the migration much more thoroughly, but did
   // so using tc-lib-entities, which has since been removed from the codebase.
 
-  test('queue_worker_types table created / removed on upgrade and downgrade', async function() {
+  test('queue_worker_types table created / removed on upgrade and downgrade', async () => {
     await testing.resetDb({ testDbUrl: helper.dbUrl });
     await helper.upgradeTo(PREV_VERSION);
 

--- a/db/test/versions/0045_test.js
+++ b/db/test/versions/0045_test.js
@@ -4,13 +4,13 @@ import testing from '@taskcluster/lib-testing';
 const THIS_VERSION = parseInt(/.*\/0*(\d+)_test\.js/.exec(import.meta.url)[1], 10);
 const PREV_VERSION = THIS_VERSION - 1;
 
-suite(testing.suiteName(), function() {
+suite(testing.suiteName(), () => {
   helper.withDbForVersion();
 
   // note that this test suite initially tested the migration much more thoroughly, but did
   // so using tc-lib-entities, which has since been removed from the codebase.
 
-  test('queue_provisioners table created / removed on upgrade and downgrade', async function() {
+  test('queue_provisioners table created / removed on upgrade and downgrade', async () => {
     await testing.resetDb({ testDbUrl: helper.dbUrl });
     await helper.upgradeTo(PREV_VERSION);
 

--- a/db/test/versions/0046_test.js
+++ b/db/test/versions/0046_test.js
@@ -1,6 +1,6 @@
 import testing from '@taskcluster/lib-testing';
 
-suite(testing.suiteName(), function() {
+suite(testing.suiteName(), () => {
   // this version only redefines a method, which is tested in unit tests,
   // so there is nothing to test on upgrade
 });

--- a/db/test/versions/0047_test.js
+++ b/db/test/versions/0047_test.js
@@ -1,6 +1,6 @@
 import testing from '@taskcluster/lib-testing';
 
-suite(testing.suiteName(), function() {
+suite(testing.suiteName(), () => {
   // this version only creates a method, which is tested in unit tests,
   // so there is nothing to test on upgrade
 });

--- a/db/test/versions/0048_test.js
+++ b/db/test/versions/0048_test.js
@@ -1,6 +1,6 @@
 import testing from '@taskcluster/lib-testing';
 
-suite(testing.suiteName(), function() {
+suite(testing.suiteName(), () => {
   // this version only creates a method and an index, which is tested in unit tests,
   // so there is nothing to test on upgrade
 });

--- a/db/test/versions/0049_test.js
+++ b/db/test/versions/0049_test.js
@@ -1,6 +1,6 @@
 import testing from '@taskcluster/lib-testing';
 
-suite(testing.suiteName(), function() {
+suite(testing.suiteName(), () => {
   // this version only removes attributes from tables, which is tested in unit tests,
   // so there is nothing to test on upgrade
 });

--- a/db/test/versions/0050_test.js
+++ b/db/test/versions/0050_test.js
@@ -5,7 +5,7 @@ import testing from '@taskcluster/lib-testing';
 
 const THIS_VERSION = parseInt(/.*\/0*(\d+)_test\.js/.exec(import.meta.url)[1], 10);
 
-suite(testing.suiteName(), function() {
+suite(testing.suiteName(), () => {
   helper.withDbForVersion();
 
   helper.dbVersionTest({

--- a/db/test/versions/0051_test.js
+++ b/db/test/versions/0051_test.js
@@ -1,6 +1,6 @@
 import testing from '@taskcluster/lib-testing';
 
-suite(testing.suiteName(), function() {
+suite(testing.suiteName(), () => {
   // this version only creates a method, which is tested in unit tests,
   // so there is nothing to test on upgrade
 });

--- a/db/test/versions/0052_test.js
+++ b/db/test/versions/0052_test.js
@@ -1,6 +1,6 @@
 import testing from '@taskcluster/lib-testing';
 
-suite(testing.suiteName(), function() {
+suite(testing.suiteName(), () => {
   // this version only deprecates a method,
   // so there is nothing to test on upgrade
 });

--- a/db/test/versions/0053_test.js
+++ b/db/test/versions/0053_test.js
@@ -5,10 +5,10 @@ import testing from '@taskcluster/lib-testing';
 const THIS_VERSION = parseInt(/.*\/0*(\d+)_test\.js/.exec(import.meta.url)[1], 10);
 const PREV_VERSION = THIS_VERSION - 1;
 
-suite(testing.suiteName(), function() {
+suite(testing.suiteName(), () => {
   helper.withDbForVersion();
 
-  test('task_queue_id, provisioner_id, worker_type columns created / removed appropriately and table named changed correctly for queue_worker_types -> task_queues', async function() {
+  test('task_queue_id, provisioner_id, worker_type columns created / removed appropriately and table named changed correctly for queue_worker_types -> task_queues', async () => {
     await testing.resetDb({ testDbUrl: helper.dbUrl });
 
     await helper.upgradeTo(PREV_VERSION);
@@ -45,7 +45,7 @@ suite(testing.suiteName(), function() {
     });
   });
 
-  test('task_queue_id, provisioner_id, worker_type columns created / removed appropriately for queue_workers', async function() {
+  test('task_queue_id, provisioner_id, worker_type columns created / removed appropriately for queue_workers', async () => {
     await testing.resetDb({ testDbUrl: helper.dbUrl });
 
     await helper.upgradeTo(PREV_VERSION);
@@ -82,7 +82,7 @@ suite(testing.suiteName(), function() {
     });
   });
 
-  test('queue_provisioners deleted and recreated appropriately', async function() {
+  test('queue_provisioners deleted and recreated appropriately', async () => {
     await testing.resetDb({ testDbUrl: helper.dbUrl });
 
     await helper.upgradeTo(PREV_VERSION);

--- a/db/test/versions/0054_test.js
+++ b/db/test/versions/0054_test.js
@@ -4,10 +4,10 @@ import testing from '@taskcluster/lib-testing';
 const THIS_VERSION = parseInt(/.*\/0*(\d+)_test\.js/.exec(import.meta.url)[1], 10);
 const PREV_VERSION = THIS_VERSION - 1;
 
-suite(testing.suiteName(), function() {
+suite(testing.suiteName(), () => {
   helper.withDbForVersion();
 
-  test('objects table created / removed on upgrade and downgrade', async function() {
+  test('objects table created / removed on upgrade and downgrade', async () => {
     await testing.resetDb({ testDbUrl: helper.dbUrl });
     await helper.upgradeTo(PREV_VERSION);
 

--- a/db/test/versions/0055_test.js
+++ b/db/test/versions/0055_test.js
@@ -1,6 +1,6 @@
 import testing from '@taskcluster/lib-testing';
 
-suite(testing.suiteName(), function() {
+suite(testing.suiteName(), () => {
   // this version only adds an index and some methods,
   // so there is nothing to test on upgrade
 });

--- a/db/test/versions/0056_test.js
+++ b/db/test/versions/0056_test.js
@@ -4,7 +4,7 @@ import testing from '@taskcluster/lib-testing';
 
 const THIS_VERSION = parseInt(/.*\/0*(\d+)_test\.js/.exec(import.meta.url)[1], 10);
 
-suite(testing.suiteName(), function() {
+suite(testing.suiteName(), () => {
   helper.withDbForVersion();
 
   const expires = new Date();

--- a/db/test/versions/0057_test.js
+++ b/db/test/versions/0057_test.js
@@ -1,6 +1,6 @@
 import testing from '@taskcluster/lib-testing';
 
-suite(testing.suiteName(), function() {
+suite(testing.suiteName(), () => {
   // this version only adds a method,
   // so there is nothing to test on upgrade
 });

--- a/db/test/versions/0058_test.js
+++ b/db/test/versions/0058_test.js
@@ -1,6 +1,6 @@
 import testing from '@taskcluster/lib-testing';
 
-suite(testing.suiteName(), function() {
+suite(testing.suiteName(), () => {
   // this version only adds a method,
   // so there is nothing to test on upgrade
 });

--- a/db/test/versions/0059_test.js
+++ b/db/test/versions/0059_test.js
@@ -6,7 +6,7 @@ import { UNDEFINED_COLUMN } from '@taskcluster/lib-postgres';
 
 const THIS_VERSION = parseInt(/.*\/0*(\d+)_test\.js/.exec(import.meta.url)[1], 10);
 
-suite(testing.suiteName(), function() {
+suite(testing.suiteName(), () => {
 
   // A helper to make it easier to create tasks with dummy values within queries
   const makeFieldsForCreation = (opts) => {

--- a/db/test/versions/0060_test.js
+++ b/db/test/versions/0060_test.js
@@ -6,7 +6,7 @@ import { UNDEFINED_COLUMN } from '@taskcluster/lib-postgres';
 
 const THIS_VERSION = parseInt(/.*\/0*(\d+)_test\.js/.exec(import.meta.url)[1], 10);
 
-suite(testing.suiteName(), function() {
+suite(testing.suiteName(), () => {
 
   // A helper to make it easier to create tasks with dummy values within queries
   const makeFieldsForCreation = (opts) => {

--- a/db/test/versions/0061_test.js
+++ b/db/test/versions/0061_test.js
@@ -1,6 +1,6 @@
 import testing from '@taskcluster/lib-testing';
 
-suite(testing.suiteName(), function() {
+suite(testing.suiteName(), () => {
   // this version only deprecates and adds methods,
   // so there is nothing to test on upgrade
 });

--- a/db/test/versions/0062_test.js
+++ b/db/test/versions/0062_test.js
@@ -1,6 +1,6 @@
 import testing from '@taskcluster/lib-testing';
 
-suite(testing.suiteName(), function() {
+suite(testing.suiteName(), () => {
   // this version only deprecates and adds methods,
   // so there is nothing to test on upgrade
 });

--- a/db/test/versions/0063_test.js
+++ b/db/test/versions/0063_test.js
@@ -4,7 +4,7 @@ import { strict as assert } from 'node:assert';
 
 const THIS_VERSION = parseInt(/.*\/0*(\d+)_test\.js/.exec(import.meta.url)[1], 10);
 
-suite(testing.suiteName(), function() {
+suite(testing.suiteName(), () => {
   helper.withDbForVersion();
 
   const taskId = 'WuonSu7CQDeZ0hh-cR_6Ag';

--- a/db/test/versions/0064_test.js
+++ b/db/test/versions/0064_test.js
@@ -1,6 +1,6 @@
 import testing from '@taskcluster/lib-testing';
 
-suite(testing.suiteName(), function() {
+suite(testing.suiteName(), () => {
   // this version only deprecates and adds methods,
   // so there is nothing to test on upgrade
 });

--- a/db/test/versions/0065_test.js
+++ b/db/test/versions/0065_test.js
@@ -1,5 +1,5 @@
 import testing from '@taskcluster/lib-testing';
 
-suite(testing.suiteName(), function() {
+suite(testing.suiteName(), () => {
   // this version only adds new functions so there is nothing to test on upgrade
 });

--- a/db/test/versions/0066_test.js
+++ b/db/test/versions/0066_test.js
@@ -1,5 +1,5 @@
 import testing from '@taskcluster/lib-testing';
 
-suite(testing.suiteName(), function() {
+suite(testing.suiteName(), () => {
   // this version only adds new functions so there is nothing to test on upgrade
 });

--- a/db/test/versions/0067_test.js
+++ b/db/test/versions/0067_test.js
@@ -4,10 +4,10 @@ import testing from '@taskcluster/lib-testing';
 const THIS_VERSION = parseInt(/.*\/0*(\d+)_test\.js/.exec(import.meta.url)[1], 10);
 const PREV_VERSION = THIS_VERSION - 1;
 
-suite(testing.suiteName(), function() {
+suite(testing.suiteName(), () => {
   helper.withDbForVersion();
 
-  test('object_hashes table created / dropped', async function() {
+  test('object_hashes table created / dropped', async () => {
     await testing.resetDb({ testDbUrl: helper.dbUrl });
     await helper.upgradeTo(PREV_VERSION);
 

--- a/db/test/versions/0068_test.js
+++ b/db/test/versions/0068_test.js
@@ -1,5 +1,5 @@
 import testing from '@taskcluster/lib-testing';
 
-suite(testing.suiteName(), function() {
+suite(testing.suiteName(), () => {
   // this version only adds new functions so there is nothing to test on upgrade
 });

--- a/db/test/versions/0069_test.js
+++ b/db/test/versions/0069_test.js
@@ -1,6 +1,6 @@
 import testing from '@taskcluster/lib-testing';
 
-suite(testing.suiteName(), function() {
+suite(testing.suiteName(), () => {
   // this version only updates method,
   // to trigger index usage, so no tests are needed
 });

--- a/db/test/versions/0070_test.js
+++ b/db/test/versions/0070_test.js
@@ -1,6 +1,6 @@
 import testing from '@taskcluster/lib-testing';
 
-suite(testing.suiteName(), function() {
+suite(testing.suiteName(), () => {
   // this version only updates method,
   // to trigger index usage, so no tests are needed
 });

--- a/db/test/versions/0071_test.js
+++ b/db/test/versions/0071_test.js
@@ -1,6 +1,6 @@
 import testing from '@taskcluster/lib-testing';
 
-suite(testing.suiteName(), function() {
+suite(testing.suiteName(), () => {
   // this version only updates method,
   // to trigger index usage, so no tests are needed
 });

--- a/db/test/versions/0072_test.js
+++ b/db/test/versions/0072_test.js
@@ -4,10 +4,10 @@ import testing from '@taskcluster/lib-testing';
 const THIS_VERSION = parseInt(/.*\/0*(\d+)_test\.js/.exec(import.meta.url)[1], 10);
 const PREV_VERSION = THIS_VERSION - 1;
 
-suite(testing.suiteName(), function() {
+suite(testing.suiteName(), () => {
   helper.withDbForVersion();
 
-  test('last_date_active column created / removed on upgrade and downgrade', async function() {
+  test('last_date_active column created / removed on upgrade and downgrade', async () => {
     await testing.resetDb({ testDbUrl: helper.dbUrl });
     await helper.upgradeTo(PREV_VERSION);
 

--- a/db/test/versions/0073_test.js
+++ b/db/test/versions/0073_test.js
@@ -1,6 +1,6 @@
 import testing from '@taskcluster/lib-testing';
 
-suite(testing.suiteName(), function() {
+suite(testing.suiteName(), () => {
   // this version only updates method,
   // to trigger index usage, so no tests are needed
 });

--- a/db/test/versions/0074_test.js
+++ b/db/test/versions/0074_test.js
@@ -1,6 +1,6 @@
 import testing from '@taskcluster/lib-testing';
 
-suite(testing.suiteName(), function() {
+suite(testing.suiteName(), () => {
   // this version only updates method,
   // to trigger index usage, so no tests are needed
 });

--- a/db/test/versions/0075_test.js
+++ b/db/test/versions/0075_test.js
@@ -1,6 +1,6 @@
 import testing from '@taskcluster/lib-testing';
 
-suite(testing.suiteName(), function() {
+suite(testing.suiteName(), () => {
   // this version only updates method,
   // to trigger index usage, so no tests are needed
 });

--- a/db/test/versions/0076_test.js
+++ b/db/test/versions/0076_test.js
@@ -1,6 +1,6 @@
 import testing from '@taskcluster/lib-testing';
 
-suite(testing.suiteName(), function() {
+suite(testing.suiteName(), () => {
   // no tests here,
   // functions are being tested in fns/github_test.js
 });

--- a/db/test/versions/0077_test.js
+++ b/db/test/versions/0077_test.js
@@ -1,6 +1,6 @@
 import testing from '@taskcluster/lib-testing';
 
-suite(testing.suiteName(), function() {
+suite(testing.suiteName(), () => {
   // this version only updates method,
   // to trigger index usage, so no tests are needed
 });

--- a/db/test/versions/0078_test.js
+++ b/db/test/versions/0078_test.js
@@ -1,6 +1,6 @@
 import testing from '@taskcluster/lib-testing';
 
-suite(testing.suiteName(), function() {
+suite(testing.suiteName(), () => {
   // this version only updates method,
   // to trigger index usage, so no tests are needed
 });

--- a/db/test/versions/0079_test.js
+++ b/db/test/versions/0079_test.js
@@ -4,10 +4,10 @@ import testing from '@taskcluster/lib-testing';
 const THIS_VERSION = parseInt(/.*\/0*(\d+)_test\.js/.exec(import.meta.url)[1], 10);
 const PREV_VERSION = THIS_VERSION - 1;
 
-suite(testing.suiteName(), function() {
+suite(testing.suiteName(), () => {
   helper.withDbForVersion();
 
-  test('hooks last fires index added / removed on upgrade and downgrade', async function() {
+  test('hooks last fires index added / removed on upgrade and downgrade', async () => {
     await testing.resetDb({ testDbUrl: helper.dbUrl });
     await helper.upgradeTo(PREV_VERSION);
 

--- a/db/test/versions/0080_test.js
+++ b/db/test/versions/0080_test.js
@@ -6,7 +6,7 @@ import helper from '../helper.js';
 const THIS_VERSION = parseInt(/.*\/0*(\d+)_test\.js/.exec(import.meta.url)[1], 10);
 const PREV_VERSION = THIS_VERSION - 1;
 
-suite(testing.suiteName(), function () {
+suite(testing.suiteName(), () => {
   helper.withDbForVersion();
 
   const expires = taskcluster.fromNow('2 hours');
@@ -20,7 +20,7 @@ suite(testing.suiteName(), function () {
     });
   };
 
-  test('queue_workers', async function () {
+  test('queue_workers', async () => {
     await testing.resetDb({ testDbUrl: helper.dbUrl });
     await helper.upgradeTo(PREV_VERSION);
 

--- a/db/test/versions/0081_test.js
+++ b/db/test/versions/0081_test.js
@@ -6,10 +6,10 @@ import slugid from 'slugid';
 const THIS_VERSION = parseInt(/.*\/0*(\d+)_test\.js/.exec(import.meta.url)[1], 10);
 const PREV_VERSION = THIS_VERSION - 1;
 
-suite(testing.suiteName(), function() {
+suite(testing.suiteName(), () => {
   helper.withDbForVersion();
 
-  test('task group seal column', async function() {
+  test('task group seal column', async () => {
     await testing.resetDb({ testDbUrl: helper.dbUrl });
     await helper.upgradeTo(PREV_VERSION);
 
@@ -21,7 +21,7 @@ suite(testing.suiteName(), function() {
     await helper.assertTableColumn('task_groups', 'sealed');
   });
 
-  test('seal function', async function() {
+  test('seal function', async () => {
     await testing.resetDb({ testDbUrl: helper.dbUrl });
     await helper.upgradeTo(THIS_VERSION);
     const db = await helper.setupDb('queue');

--- a/db/test/versions/0082_test.js
+++ b/db/test/versions/0082_test.js
@@ -5,10 +5,10 @@ import slugid from 'slugid';
 
 const THIS_VERSION = parseInt(/.*\/0*(\d+)_test\.js/.exec(import.meta.url)[1], 10);
 
-suite(testing.suiteName(), function() {
+suite(testing.suiteName(), () => {
   helper.withDbForVersion();
 
-  test('cancel task group function', async function() {
+  test('cancel task group function', async () => {
     await testing.resetDb({ testDbUrl: helper.dbUrl });
     await helper.upgradeTo(THIS_VERSION);
     const db = await helper.setupDb('queue');

--- a/db/test/versions/0083_test.js
+++ b/db/test/versions/0083_test.js
@@ -6,10 +6,10 @@ import taskcluster from '@taskcluster/client';
 const THIS_VERSION = parseInt(/.*\/0*(\d+)_test\.js/.exec(import.meta.url)[1], 10);
 const PREV_VERSION = THIS_VERSION - 1;
 
-suite(testing.suiteName(), function () {
+suite(testing.suiteName(), () => {
   helper.withDbForVersion();
 
-  test('queue worker quarantine details', async function () {
+  test('queue worker quarantine details', async () => {
     await testing.resetDb({ testDbUrl: helper.dbUrl });
     await helper.upgradeTo(PREV_VERSION);
 
@@ -21,7 +21,7 @@ suite(testing.suiteName(), function () {
     await helper.assertTableColumn('queue_workers', 'quarantine_details');
   });
 
-  test('quarantine details function', async function () {
+  test('quarantine details function', async () => {
     await testing.resetDb({ testDbUrl: helper.dbUrl });
     await helper.upgradeTo(THIS_VERSION);
     const db = await helper.setupDb('queue');

--- a/db/test/versions/0084_test.js
+++ b/db/test/versions/0084_test.js
@@ -1,5 +1,5 @@
 import testing from '@taskcluster/lib-testing';
 
-suite(testing.suiteName(), function () {
+suite(testing.suiteName(), () => {
   // only adding new function, nothing to test yet
 });

--- a/db/test/versions/0085_test.js
+++ b/db/test/versions/0085_test.js
@@ -6,10 +6,10 @@ import taskcluster from '@taskcluster/client';
 const THIS_VERSION = parseInt(/.*\/0*(\d+)_test\.js/.exec(import.meta.url)[1], 10);
 const PREV_VERSION = THIS_VERSION - 1;
 
-suite(testing.suiteName(), function () {
+suite(testing.suiteName(), () => {
   helper.withDbForVersion();
 
-  test('github_builds with pull request number', async function () {
+  test('github_builds with pull request number', async () => {
     await testing.resetDb({ testDbUrl: helper.dbUrl });
     await helper.upgradeTo(PREV_VERSION);
 
@@ -21,7 +21,7 @@ suite(testing.suiteName(), function () {
     await helper.assertTableColumn('github_builds', 'pull_request_number');
   });
 
-  test('github functions use new column', async function () {
+  test('github functions use new column', async () => {
     await testing.resetDb({ testDbUrl: helper.dbUrl });
     await helper.upgradeTo(THIS_VERSION);
     const db = await helper.setupDb('github');

--- a/db/test/versions/0086_test.js
+++ b/db/test/versions/0086_test.js
@@ -1,5 +1,5 @@
 import testing from '@taskcluster/lib-testing';
 
-suite(testing.suiteName(), function() {
+suite(testing.suiteName(), () => {
   // this version only adds a method
 });

--- a/db/test/versions/0087_test.js
+++ b/db/test/versions/0087_test.js
@@ -1,6 +1,6 @@
 import testing from '@taskcluster/lib-testing';
 
-suite(testing.suiteName(), function() {
+suite(testing.suiteName(), () => {
   // this version only updates method,
   // to trigger index usage, so no tests are needed
 });

--- a/db/test/versions/0088_test.js
+++ b/db/test/versions/0088_test.js
@@ -1,6 +1,6 @@
 import testing from '@taskcluster/lib-testing';
 
-suite(testing.suiteName(), function() {
+suite(testing.suiteName(), () => {
   // this version only updates method,
   // which is tested in hooks_test.js
 });

--- a/db/test/versions/0089_test.js
+++ b/db/test/versions/0089_test.js
@@ -1,5 +1,5 @@
 import testing from '@taskcluster/lib-testing';
 
-suite(testing.suiteName(), function() {
+suite(testing.suiteName(), () => {
   // this version only updates method
 });

--- a/db/test/versions/0090_test.js
+++ b/db/test/versions/0090_test.js
@@ -4,10 +4,10 @@ import testing from '@taskcluster/lib-testing';
 const THIS_VERSION = parseInt(/.*\/0*(\d+)_test\.js/.exec(import.meta.url)[1], 10);
 const PREV_VERSION = THIS_VERSION - 1;
 
-suite(testing.suiteName(), function () {
+suite(testing.suiteName(), () => {
   helper.withDbForVersion();
 
-  test('azure_queue_messages define extra fields for upcoming migration', async function () {
+  test('azure_queue_messages define extra fields for upcoming migration', async () => {
     await testing.resetDb({ testDbUrl: helper.dbUrl });
     await helper.upgradeTo(PREV_VERSION);
 

--- a/db/test/versions/0091_test.js
+++ b/db/test/versions/0091_test.js
@@ -6,7 +6,7 @@ import taskcluster from '@taskcluster/client';
 const THIS_VERSION = parseInt(/.*\/0*(\d+)_test\.js/.exec(import.meta.url)[1], 10);
 const PREV_VERSION = THIS_VERSION - 1;
 
-suite(testing.suiteName(), function () {
+suite(testing.suiteName(), () => {
   helper.withDbForVersion();
 
   const insertOldRecords = async (db, dt1, dt2) => {
@@ -70,7 +70,7 @@ suite(testing.suiteName(), function () {
     assert.equal(deadlines[0].deadline.toJSON(), dt2.toJSON());
   };
 
-  test('new tables are created', async function () {
+  test('new tables are created', async () => {
     await testing.resetDb({ testDbUrl: helper.dbUrl });
     await helper.upgradeTo(PREV_VERSION);
 
@@ -89,7 +89,7 @@ suite(testing.suiteName(), function () {
     await helper.assertTable('queue_task_deadlines');
     await helper.assertIndexOnColumn('queue_task_deadlines', 'queue_task_deadline_idx', 'task_id');
   });
-  test('UP: data is being migrated into new tables', async function () {
+  test('UP: data is being migrated into new tables', async () => {
     await testing.resetDb({ testDbUrl: helper.dbUrl });
     await helper.upgradeTo(PREV_VERSION);
     const db = await helper.setupDb('queue');
@@ -103,7 +103,7 @@ suite(testing.suiteName(), function () {
     await assertRecordsExistInNewTables(db, dt1, dt2);
   });
 
-  test('existing functions should be patched to use new tables', async function () {
+  test('existing functions should be patched to use new tables', async () => {
     await testing.resetDb({ testDbUrl: helper.dbUrl });
     await helper.upgradeTo(THIS_VERSION);
     const db = await helper.setupDb('queue');
@@ -117,7 +117,7 @@ suite(testing.suiteName(), function () {
     await assertRecordsExistInNewTables(db, dt1, dt2);
   });
 
-  test('DOWN: data is being put back into azure messages table', async function () {
+  test('DOWN: data is being put back into azure messages table', async () => {
     await testing.resetDb({ testDbUrl: helper.dbUrl });
     await helper.upgradeTo(THIS_VERSION);
     const db = await helper.setupDb('queue');

--- a/db/test/versions/0092_test.js
+++ b/db/test/versions/0092_test.js
@@ -1,5 +1,5 @@
 import testing from '@taskcluster/lib-testing';
 
-suite(testing.suiteName(), function () {
+suite(testing.suiteName(), () => {
   // this version only updates method
 });

--- a/db/test/versions/0093_test.js
+++ b/db/test/versions/0093_test.js
@@ -1,5 +1,5 @@
 import testing from '@taskcluster/lib-testing';
 
-suite(testing.suiteName(), function() {
+suite(testing.suiteName(), () => {
   // this version only updates method
 });

--- a/db/test/versions/0094_test.js
+++ b/db/test/versions/0094_test.js
@@ -1,5 +1,5 @@
 import testing from '@taskcluster/lib-testing';
 
-suite(testing.suiteName(), function() {
+suite(testing.suiteName(), () => {
   // add tests if necessary
 });

--- a/db/test/versions/0095_test.js
+++ b/db/test/versions/0095_test.js
@@ -1,5 +1,5 @@
 import testing from '@taskcluster/lib-testing';
 
-suite(testing.suiteName(), function() {
+suite(testing.suiteName(), () => {
   // add tests if necessary
 });

--- a/db/test/versions/0096_test.js
+++ b/db/test/versions/0096_test.js
@@ -1,5 +1,5 @@
 import testing from '@taskcluster/lib-testing';
 
-suite(testing.suiteName(), function() {
+suite(testing.suiteName(), () => {
   // add tests if necessary
 });

--- a/db/test/versions/0097_test.js
+++ b/db/test/versions/0097_test.js
@@ -1,5 +1,5 @@
 import testing from '@taskcluster/lib-testing';
 
-suite(testing.suiteName(), function() {
+suite(testing.suiteName(), () => {
   // add tests if necessary
 });

--- a/db/test/versions/0098_test.js
+++ b/db/test/versions/0098_test.js
@@ -1,6 +1,6 @@
 import testing from '@taskcluster/lib-testing';
 
-suite(testing.suiteName(), function() {
+suite(testing.suiteName(), () => {
   // this version only adds a method, which is tested in unit tests,
   // so there is nothing to test on upgrade
 });

--- a/db/test/versions/0099_test.js
+++ b/db/test/versions/0099_test.js
@@ -1,6 +1,6 @@
 import testing from '@taskcluster/lib-testing';
 
-suite(testing.suiteName(), function() {
+suite(testing.suiteName(), () => {
   // this version only adds a method, which is tested in unit tests,
   // so there is nothing to test on upgrade
 });

--- a/db/test/versions/0100_test.js
+++ b/db/test/versions/0100_test.js
@@ -1,6 +1,6 @@
 import testing from '@taskcluster/lib-testing';
 
-suite(testing.suiteName(), function() {
+suite(testing.suiteName(), () => {
   // this version only adds a method, which is tested in unit tests,
   // so there is nothing to test on upgrade
 });

--- a/db/test/versions/0101_test.js
+++ b/db/test/versions/0101_test.js
@@ -1,6 +1,6 @@
 import testing from '@taskcluster/lib-testing';
 
-suite(testing.suiteName(), function() {
+suite(testing.suiteName(), () => {
   // this version only adds a method, which is tested in unit tests,
   // so there is nothing to test on upgrade
 });

--- a/db/test/versions/0102_test.js
+++ b/db/test/versions/0102_test.js
@@ -1,5 +1,5 @@
 import testing from '@taskcluster/lib-testing';
 
-suite(testing.suiteName(), function() {
+suite(testing.suiteName(), () => {
   // add tests if necessary
 });

--- a/db/test/versions/0103_test.js
+++ b/db/test/versions/0103_test.js
@@ -1,5 +1,5 @@
 import testing from '@taskcluster/lib-testing';
 
-suite(testing.suiteName(), function() {
+suite(testing.suiteName(), () => {
   // add tests if necessary
 });

--- a/db/test/versions/0104_test.js
+++ b/db/test/versions/0104_test.js
@@ -1,5 +1,5 @@
 import testing from '@taskcluster/lib-testing';
 
-suite(testing.suiteName(), function() {
+suite(testing.suiteName(), () => {
   // add tests if necessary
 });

--- a/db/test/versions/0105_test.js
+++ b/db/test/versions/0105_test.js
@@ -5,10 +5,10 @@ import helper from '../helper.js';
 const THIS_VERSION = parseInt(/.*\/0*(\d+)_test\.js/.exec(import.meta.url)[1], 10);
 const PREV_VERSION = THIS_VERSION - 1;
 
-suite(testing.suiteName(), function () {
+suite(testing.suiteName(), () => {
   helper.withDbForVersion();
 
-  test('tables and columns are created, data is migrated', async function () {
+  test('tables and columns are created, data is migrated', async () => {
     await testing.resetDb({ testDbUrl: helper.dbUrl });
     const db = await helper.setupDb('worker_manager');
 

--- a/db/test/versions/0106_test.js
+++ b/db/test/versions/0106_test.js
@@ -4,11 +4,11 @@ import testing from '@taskcluster/lib-testing';
 const THIS_VERSION = parseInt(/.*\/0*(\d+)_test\.js/.exec(import.meta.url)[1], 10);
 const PREV_VERSION = THIS_VERSION - 1;
 
-suite(testing.suiteName(), function() {
+suite(testing.suiteName(), () => {
 
   helper.withDbForVersion();
 
-  test('new tables are created', async function () {
+  test('new tables are created', async () => {
     await testing.resetDb({ testDbUrl: helper.dbUrl });
     await helper.upgradeTo(PREV_VERSION);
 

--- a/db/test/versions/0107_test.js
+++ b/db/test/versions/0107_test.js
@@ -1,5 +1,5 @@
 import testing from '@taskcluster/lib-testing';
 
-suite(testing.suiteName(), function() {
+suite(testing.suiteName(), () => {
   // add tests if necessary
 });

--- a/db/test/versions/0108_test.js
+++ b/db/test/versions/0108_test.js
@@ -1,5 +1,5 @@
 import testing from '@taskcluster/lib-testing';
 
-suite(testing.suiteName(), function() {
+suite(testing.suiteName(), () => {
   // add tests if necessary
 });

--- a/db/test/versions/0109_test.js
+++ b/db/test/versions/0109_test.js
@@ -1,5 +1,5 @@
 import testing from '@taskcluster/lib-testing';
 
-suite(testing.suiteName(), function() {
+suite(testing.suiteName(), () => {
   // method is tested in fns/worker_manager_test.js
 });

--- a/db/test/versions/0110_test.js
+++ b/db/test/versions/0110_test.js
@@ -1,5 +1,5 @@
 import testing from '@taskcluster/lib-testing';
 
-suite(testing.suiteName(), function() {
+suite(testing.suiteName(), () => {
   // add tests if necessary
 });

--- a/db/test/versions/0112_test.js
+++ b/db/test/versions/0112_test.js
@@ -4,10 +4,10 @@ import testing from '@taskcluster/lib-testing';
 const THIS_VERSION = parseInt(/.*\/0*(\d+)_test\.js/.exec(import.meta.url)[1], 10);
 const PREV_VERSION = THIS_VERSION - 1;
 
-suite(testing.suiteName(), function() {
+suite(testing.suiteName(), () => {
   helper.withDbForVersion();
 
-  test('queue_workers index added / removed on upgrade and downgrade', async function() {
+  test('queue_workers index added / removed on upgrade and downgrade', async () => {
     await testing.resetDb({ testDbUrl: helper.dbUrl });
     await helper.upgradeTo(PREV_VERSION);
 

--- a/db/test/versions/0113_test.js
+++ b/db/test/versions/0113_test.js
@@ -6,10 +6,10 @@ import helper from '../helper.js';
 const THIS_VERSION = parseInt(/.*\/0*(\d+)_test\.js/.exec(import.meta.url)[1], 10);
 const PREV_VERSION = THIS_VERSION - 1;
 
-suite(testing.suiteName(), function () {
+suite(testing.suiteName(), () => {
   helper.withDbForVersion();
 
-  test('multiple claimed records are counted once for stats', async function () {
+  test('multiple claimed records are counted once for stats', async () => {
     await testing.resetDb({ testDbUrl: helper.dbUrl });
     const db = await helper.setupDb('queue');
 

--- a/db/test/versions/0114_test.js
+++ b/db/test/versions/0114_test.js
@@ -1,5 +1,5 @@
 import testing from '@taskcluster/lib-testing';
 
-suite(testing.suiteName(), function() {
+suite(testing.suiteName(), () => {
   // new function is covered in fns/secrets_test.js
 });

--- a/db/test/versions/0115_test.js
+++ b/db/test/versions/0115_test.js
@@ -4,10 +4,10 @@ import testing from '@taskcluster/lib-testing';
 const THIS_VERSION = parseInt(/.*\/0*(\d+)_test\.js/.exec(import.meta.url)[1], 10);
 const PREV_VERSION = THIS_VERSION - 1;
 
-suite(testing.suiteName(), function() {
+suite(testing.suiteName(), () => {
   helper.withDbForVersion();
 
-  test('indexes added and removed', async function() {
+  test('indexes added and removed', async () => {
     await testing.resetDb({ testDbUrl: helper.dbUrl });
     await helper.upgradeTo(PREV_VERSION);
 

--- a/db/test/versions/0116_test.js
+++ b/db/test/versions/0116_test.js
@@ -1,5 +1,5 @@
 import testing from '@taskcluster/lib-testing';
 
-suite(testing.suiteName(), function() {
+suite(testing.suiteName(), () => {
   // add tests if necessary
 });

--- a/db/test/versions/0117_test.js
+++ b/db/test/versions/0117_test.js
@@ -1,5 +1,5 @@
 import testing from '@taskcluster/lib-testing';
 
-suite(testing.suiteName(), function() {
+suite(testing.suiteName(), () => {
   // add tests if necessary
 });

--- a/db/test/versions/0118_test.js
+++ b/db/test/versions/0118_test.js
@@ -1,5 +1,5 @@
 import testing from '@taskcluster/lib-testing';
 
-suite(testing.suiteName(), function() {
+suite(testing.suiteName(), () => {
   // add tests if necessary
 });

--- a/db/test/versions/0119_test.js
+++ b/db/test/versions/0119_test.js
@@ -1,5 +1,5 @@
 import testing from '@taskcluster/lib-testing';
 
-suite(testing.suiteName(), function() {
+suite(testing.suiteName(), () => {
   // methods are tested separately
 });

--- a/db/test/versions/0120_test.js
+++ b/db/test/versions/0120_test.js
@@ -1,5 +1,5 @@
 import testing from '@taskcluster/lib-testing';
 
-suite(testing.suiteName(), function() {
+suite(testing.suiteName(), () => {
   // add tests if necessary
 });

--- a/db/test/versions/0121_test.js
+++ b/db/test/versions/0121_test.js
@@ -5,10 +5,10 @@ import testing from '@taskcluster/lib-testing';
 const THIS_VERSION = parseInt(/.*\/0*(\d+)_test\.js/.exec(import.meta.url)[1], 10);
 const PREV_VERSION = THIS_VERSION - 1;
 
-suite(testing.suiteName(), function() {
+suite(testing.suiteName(), () => {
   helper.withDbForVersion();
 
-  test('column added and functions work', async function() {
+  test('column added and functions work', async () => {
     await testing.resetDb({ testDbUrl: helper.dbUrl });
     await helper.upgradeTo(PREV_VERSION);
     await helper.assertNoTableColumn('queue_artifacts', 'content_length');
@@ -61,7 +61,7 @@ suite(testing.suiteName(), function() {
     assert.equal(expArt.content_length, 99999);
   });
 
-  test('downgrade removes column', async function() {
+  test('downgrade removes column', async () => {
     await testing.resetDb({ testDbUrl: helper.dbUrl });
     await helper.upgradeTo(THIS_VERSION);
     await helper.assertTableColumn('queue_artifacts', 'content_length');

--- a/db/test/versions/0122_test.js
+++ b/db/test/versions/0122_test.js
@@ -5,10 +5,10 @@ import taskcluster from '@taskcluster/client';
 
 const THIS_VERSION = parseInt(/.*\/0*(\d+)_test\.js/.exec(import.meta.url)[1], 10);
 
-suite(testing.suiteName(), function() {
+suite(testing.suiteName(), () => {
   helper.withDbForVersion();
 
-  test('pagination returns tasks in stable order', async function() {
+  test('pagination returns tasks in stable order', async () => {
     await testing.resetDb({ testDbUrl: helper.dbUrl });
     await helper.upgradeTo(THIS_VERSION);
 

--- a/db/test/versions/0123_test.js
+++ b/db/test/versions/0123_test.js
@@ -6,10 +6,10 @@ import taskcluster from '@taskcluster/client';
 const THIS_VERSION = parseInt(/.*\/0*(\d+)_test\.js/.exec(import.meta.url)[1], 10);
 const PREV_VERSION = THIS_VERSION - 1;
 
-suite(testing.suiteName(), function() {
+suite(testing.suiteName(), () => {
   helper.withDbForVersion();
 
-  test('migration deduplicates deadline rows and enforces task_id uniqueness', async function() {
+  test('migration deduplicates deadline rows and enforces task_id uniqueness', async () => {
     await testing.resetDb({ testDbUrl: helper.dbUrl });
     await helper.upgradeTo(PREV_VERSION);
 
@@ -57,7 +57,7 @@ suite(testing.suiteName(), function() {
     });
   });
 
-  test('migration deduplicates rows with identical (created, deadline)', async function() {
+  test('migration deduplicates rows with identical (created, deadline)', async () => {
     await testing.resetDb({ testDbUrl: helper.dbUrl });
     await helper.upgradeTo(PREV_VERSION);
 
@@ -104,7 +104,7 @@ suite(testing.suiteName(), function() {
     });
   });
 
-  test('downgrade restores the previous primary key', async function() {
+  test('downgrade restores the previous primary key', async () => {
     await testing.resetDb({ testDbUrl: helper.dbUrl });
     await helper.upgradeTo(THIS_VERSION);
     await helper.downgradeTo(PREV_VERSION);

--- a/db/test/versions/0124_test.js
+++ b/db/test/versions/0124_test.js
@@ -6,10 +6,10 @@ import taskcluster from '@taskcluster/client';
 const THIS_VERSION = parseInt(/.*\/0*(\d+)_test\.js/.exec(import.meta.url)[1], 10);
 const PREV_VERSION = THIS_VERSION - 1;
 
-suite(testing.suiteName(), function() {
+suite(testing.suiteName(), () => {
   helper.withDbForVersion();
 
-  test('schedule_task atomically inserts into queue_pending_tasks after upgrade', async function() {
+  test('schedule_task atomically inserts into queue_pending_tasks after upgrade', async () => {
     await testing.resetDb({ testDbUrl: helper.dbUrl });
     await helper.upgradeTo(THIS_VERSION);
 
@@ -41,7 +41,7 @@ suite(testing.suiteName(), function() {
     assert.equal(rows[0].run_id, 0);
   });
 
-  test('downgrade removes queue_pending_tasks_add_for_task / create_task_atomic and reverts schedule_task', async function() {
+  test('downgrade removes queue_pending_tasks_add_for_task / create_task_atomic and reverts schedule_task', async () => {
     await testing.resetDb({ testDbUrl: helper.dbUrl });
     await helper.upgradeTo(THIS_VERSION);
     await helper.downgradeTo(PREV_VERSION);
@@ -86,7 +86,7 @@ suite(testing.suiteName(), function() {
     assert.equal(pendingRows, 0, 'post-downgrade schedule_task must not enqueue into queue_pending_tasks');
   });
 
-  test('create_task_atomic inserts task and queue_task_deadlines atomically', async function() {
+  test('create_task_atomic inserts task and queue_task_deadlines atomically', async () => {
     await testing.resetDb({ testDbUrl: helper.dbUrl });
     await helper.upgradeTo(THIS_VERSION);
 
@@ -125,7 +125,7 @@ suite(testing.suiteName(), function() {
     assert.equal(deadlineRow.visible.getTime(), expectedVisibleMs);
   });
 
-  test('create_task_atomic overwrites stale orphan deadline metadata via ON CONFLICT DO UPDATE', async function() {
+  test('create_task_atomic overwrites stale orphan deadline metadata via ON CONFLICT DO UPDATE', async () => {
     await testing.resetDb({ testDbUrl: helper.dbUrl });
     await helper.upgradeTo(THIS_VERSION);
 

--- a/db/test/versions/0125_test.js
+++ b/db/test/versions/0125_test.js
@@ -1,6 +1,6 @@
 import testing from '@taskcluster/lib-testing';
 
-suite(testing.suiteName(), function() {
+suite(testing.suiteName(), () => {
   // The new keyset-paginated function is exercised in
   // db/test/fns/worker_manager_test.js
   // (`get_non_stopped_workers_with_launch_config_scanner_after` cases).

--- a/db/test/versions/0126_test.js
+++ b/db/test/versions/0126_test.js
@@ -1,5 +1,5 @@
 import testing from '@taskcluster/lib-testing';
 
-suite(testing.suiteName(), function() {
+suite(testing.suiteName(), () => {
   // methods are tested separately
 });

--- a/db/test/versions_test.js
+++ b/db/test/versions_test.js
@@ -4,7 +4,7 @@ import testing from '@taskcluster/lib-testing';
 
 import { newVersion, renumberVersions } from '../src/versions.js';
 
-suite(testing.suiteName(), function() {
+suite(testing.suiteName(), () => {
   test('new migration', async () => {
     const next1 = await newVersion({ runGit: false });
     const next2 = await newVersion({ runGit: false });

--- a/infrastructure/tooling/src/meta/checks/depcheck.js
+++ b/infrastructure/tooling/src/meta/checks/depcheck.js
@@ -22,7 +22,7 @@ if (isMainThread) {
     run: async (requirements, utils) => {
       return new Promise((resolve, reject) => {
         const worker = new Worker(__filename, {});
-        worker.on('message', function ({ err, message }) {
+        worker.on('message', ({ err, message }) => {
           err ? reject(err) : utils.status({ message });
         });
         worker.on('error', reject);

--- a/libraries/api/src/index.js
+++ b/libraries/api/src/index.js
@@ -55,7 +55,7 @@ const ping = {
     'Respond without doing anything.',
     'This endpoint is used to check that the service is up.',
   ].join('\n'),
-  handler: function(req, res) {
+  handler: (req, res) => {
     res.status(200).json({
       alive: true,
       uptime: process.uptime(),
@@ -80,7 +80,7 @@ const lbHeartbeat = {
     'Respond without doing anything.',
     'This endpoint is used to check that the service is up.',
   ].join('\n'),
-  handler: function(_req, res) {
+  handler: (_req, res) => {
     res.json({});
   },
 };
@@ -101,7 +101,7 @@ const version = {
     'Respond with the JSON version object.',
     'https://github.com/mozilla-services/Dockerflow/blob/main/docs/version_object.md',
   ].join('\n'),
-  handler: async function(_req, res) {
+  handler: async (_req, res) => {
     res.json(await loadVersion());
   },
 };
@@ -120,7 +120,7 @@ export class APIBuilder {
     assert(!options.schemaPrefix, 'schemaPrefix is no longer allowed!');
     assert(!options.version, 'version is now apiVersion');
     /** @satisfies {Array<keyof APIBuilderOptions<TContext>>} */
-    (['title', 'description', 'serviceName', 'apiVersion']).forEach(function(key) {
+    (['title', 'description', 'serviceName', 'apiVersion']).forEach((key) => {
       assert(options[key], 'Option \'' + key + '\' must be provided');
     });
     assert(/^[a-z][a-z0-9_-]*$/.test(options.serviceName), `api serviceName "${options.serviceName}" is not valid`);
@@ -207,7 +207,7 @@ export class APIBuilder {
    */
   declare(options, handler) {
     /** @satisfies {Array<keyof APIEntryOptions<TContext>>} */
-    (['name', 'method', 'route', 'title', 'description', 'category']).forEach(function(key) {
+    (['name', 'method', 'route', 'title', 'description', 'category']).forEach((key) => {
       assert(options[key], 'Option \'' + key + '\' must be provided');
     });
     // unlike other options above, scopes is allowed to be null, but not undefined...

--- a/libraries/api/test/auth_test.js
+++ b/libraries/api/test/auth_test.js
@@ -235,7 +235,7 @@ suite(testing.suiteName(), function() {
         label: 'request scopes from caller',
         id: 'test-client',
         tester: (auth, url) => requestWithHawk(url, auth)
-          .then(function(res) {
+          .then((res) => {
             assert(res.ok, 'Request failed');
             assert(res.body.scopes.length === 1, 'wrong number of scopes');
             assert(res.body.scopes[0] === 'service:magic', 'failed scopes');
@@ -410,7 +410,7 @@ suite(testing.suiteName(), function() {
         label: 'client has sufficient scopes',
         id: 'admin',
         tester: (auth, url) => requestWithHawk(url, auth)
-          .then(function(res) {
+          .then((res) => {
             assert(res.body.clientId === 'admin');
             return res;
           }),

--- a/libraries/api/test/compression_test.js
+++ b/libraries/api/test/compression_test.js
@@ -7,7 +7,7 @@ import helper from './helper.js';
 import libUrls from 'taskcluster-lib-urls';
 import testing from '@taskcluster/lib-testing';
 
-suite(testing.suiteName(), function() {
+suite(testing.suiteName(), () => {
   const u = path => libUrls.api(helper.rootUrl, 'test', 'v1', path);
 
   const builder = new APIBuilder({
@@ -28,7 +28,7 @@ suite(testing.suiteName(), function() {
     category: 'API Library',
     stability: APIBuilder.stability.stable,
     description: 'Returns a large JSON payload',
-  }, function(req, res) {
+  }, (req, res) => {
     res.reply({ data: 'x'.repeat(2000) });
   });
 
@@ -42,7 +42,7 @@ suite(testing.suiteName(), function() {
     category: 'API Library',
     stability: APIBuilder.stability.stable,
     description: 'Returns a small JSON payload',
-  }, function(req, res) {
+  }, (req, res) => {
     res.reply({ ok: true });
   });
 
@@ -58,7 +58,7 @@ suite(testing.suiteName(), function() {
     category: 'API Library',
     stability: APIBuilder.stability.stable,
     description: 'Returns a pre-gzipped payload',
-  }, function(req, res) {
+  }, (req, res) => {
     const payload = Buffer.from('y'.repeat(2000));
     const gzipped = gzipSync(payload);
     res.set('Content-Type', 'application/json');
@@ -66,15 +66,15 @@ suite(testing.suiteName(), function() {
     res.send(gzipped);
   });
 
-  suiteSetup(async function() {
+  suiteSetup(async () => {
     await helper.setupServer({ builder, context: {} });
   });
 
-  suiteTeardown(async function() {
+  suiteTeardown(async () => {
     await helper.teardownServer();
   });
 
-  test('large response is gzip-compressed when client accepts gzip', async function() {
+  test('large response is gzip-compressed when client accepts gzip', async () => {
     const res = await request
       .get(u('/large-payload'))
       .set('Accept-Encoding', 'gzip');
@@ -84,7 +84,7 @@ suite(testing.suiteName(), function() {
     assert.strictEqual(res.body.data.length, 2000);
   });
 
-  test('small response is not compressed (below 1024-byte threshold)', async function() {
+  test('small response is not compressed (below 1024-byte threshold)', async () => {
     const res = await request
       .get(u('/small-payload'))
       .set('Accept-Encoding', 'gzip');
@@ -92,7 +92,7 @@ suite(testing.suiteName(), function() {
       'Expected no Content-Encoding for small payload below threshold');
   });
 
-  test('response is not compressed when client does not accept gzip', async function() {
+  test('response is not compressed when client does not accept gzip', async () => {
     const res = await request
       .get(u('/large-payload'))
       .set('Accept-Encoding', 'identity');
@@ -101,7 +101,7 @@ suite(testing.suiteName(), function() {
     assert.strictEqual(res.body.data.length, 2000);
   });
 
-  test('pre-set Content-Encoding is preserved (no double compression)', async function() {
+  test('pre-set Content-Encoding is preserved (no double compression)', async () => {
     // Fetch raw response bytes without client-side decompression. If the
     // middleware had re-gzipped, gunzipping once would yield still-gzipped
     // bytes (starting with 0x1f 0x8b) instead of the plaintext body.

--- a/libraries/api/test/context_test.js
+++ b/libraries/api/test/context_test.js
@@ -11,7 +11,7 @@ import testing from '@taskcluster/lib-testing';
 
 const __dirname = new URL('.', import.meta.url).pathname;
 
-suite(testing.suiteName(), function() {
+suite(testing.suiteName(), () => {
   const rootUrl = 'http://localhost:4321';
 
   setup(async () => {
@@ -68,15 +68,11 @@ suite(testing.suiteName(), function() {
 
     await request
       .get('http://localhost:60872/api/test/v1/context')
-      .then(function(res) {
+      .then((res) => {
         assert(res.body.myProp === value);
-      }).then(function() {
-        return server.terminate();
-      }, function(err) {
-        return server.terminate().then(function() {
-          throw err;
-        });
-      });
+      }).then(() => server.terminate(), (err) => server.terminate().then(() => {
+        throw err;
+      }));
   });
 
   test('Context properties can be required', async () => {
@@ -222,16 +218,12 @@ suite(testing.suiteName(), function() {
     await request
       .get('http://localhost:60872/api/test/v1/context')
       .set('x-taskcluster-trace-id', 'foo/bar')
-      .then(function(res) {
+      .then((res) => {
         assert.equal(res.body.foo, 'foo/bar');
         assert(res.body.bar);
-      }).then(function() {
-        return server.terminate();
-      }, function(err) {
-        return server.terminate().then(function() {
-          throw err;
-        });
-      });
+      }).then(() => server.terminate(), (err) => server.terminate().then(() => {
+        throw err;
+      }));
 
     assert.equal(fooFake.callCount, 1);
   });

--- a/libraries/api/test/errors_test.js
+++ b/libraries/api/test/errors_test.js
@@ -7,7 +7,7 @@ import libUrls from 'taskcluster-lib-urls';
 import { setIsProduction } from '../src/middleware/express-error.js';
 import testing from '@taskcluster/lib-testing';
 
-suite(testing.suiteName(), function() {
+suite(testing.suiteName(), () => {
   // Create test api
   const builder = new APIBuilder({
     title: 'Test Api',
@@ -24,8 +24,8 @@ suite(testing.suiteName(), function() {
   teardown(helper.teardownServer);
 
   // we want to test the production behavior..
-  suiteSetup(function() { setIsProduction(true); });
-  suiteTeardown(function() { setIsProduction(false); });
+  suiteSetup(() => { setIsProduction(true); });
+  suiteTeardown(() => { setIsProduction(false); });
 
   builder.declare({
     method: 'get',
@@ -35,11 +35,11 @@ suite(testing.suiteName(), function() {
     title: 'Test End-Point',
     category: 'API Library',
     description: 'Place we can call to test something',
-  }, function(req, res) {
+  }, (req, res) => {
     res.reportError('InputError', 'Testing Error', { dee: 'tails' });
   });
 
-  test('InputError response', async function() {
+  test('InputError response', async () => {
     const url = libUrls.api(helper.rootUrl, 'test', 'v1', '/inputerror');
     return request.get(url).then(res => assert(false, 'should have failed!')).catch(res => {
       if (!res.status) {
@@ -66,7 +66,7 @@ suite(testing.suiteName(), function() {
     category: 'API Library',
     description: 'Place we can call to test something',
     scopes: null,
-  }, function(req, res) {
+  }, (req, res) => {
     req.body.foos = [4, 5];
     res.reportError(
       'TooManyFoos',
@@ -74,7 +74,7 @@ suite(testing.suiteName(), function() {
       { foos: [1, 2, 3] });
   });
 
-  test('TooManyFoos response', async function() {
+  test('TooManyFoos response', async () => {
     const url = libUrls.api(helper.rootUrl, 'test', 'v1', '/toomanyfoos');
     return request.get(url).then(res => assert(false, 'should have failed!')).catch(res => {
       assert(res.status === 472);
@@ -116,11 +116,11 @@ suite(testing.suiteName(), function() {
     category: 'API Library',
     description: 'Place we can call to test something',
     scopes: null,
-  }, function(req, res) {
+  }, (req, res) => {
     throw new Error('uhoh');
   });
 
-  test('ISE response', async function() {
+  test('ISE response', async () => {
     const url = libUrls.api(helper.rootUrl, 'test', 'v1', '/ISE');
     return request.get(url).then(res => assert(false, 'should have failed!')).catch(res => {
       assert(res.status === 500);
@@ -150,10 +150,10 @@ suite(testing.suiteName(), function() {
       return payload;
     },
     scopes: null,
-  }, function(req, res) {
+  }, (req, res) => {
   });
 
-  test('InputValidationError response', async function() {
+  test('InputValidationError response', async () => {
     const url = libUrls.api(helper.rootUrl, 'test', 'v1', '/inputvalidationerror');
     return request.post(url).send({ invalid: 'yep', secret: 's3kr!t' })
       .then(res => assert(false, 'should have failed!'))

--- a/libraries/api/test/expressions_test.js
+++ b/libraries/api/test/expressions_test.js
@@ -2,7 +2,7 @@ import assert from 'node:assert';
 import ScopeExpressionTemplate from '../src/expressions.js';
 import testing from '@taskcluster/lib-testing';
 
-suite(testing.suiteName(), function() {
+suite(testing.suiteName(), () => {
 
   function scenario(expr, params, result, shouldFail = false) {
     return () => {

--- a/libraries/api/test/helper.js
+++ b/libraries/api/test/helper.js
@@ -13,7 +13,7 @@ export const rootUrl = 'http://localhost:23525';
 export let monitor = null;
 export let monitorManager = null;
 
-suiteSetup('set up monitorManager', async function() {
+suiteSetup('set up monitorManager', async () => {
   monitor = MonitorManager.setup({
     serviceName: 'lib-api',
     fake: true,
@@ -24,7 +24,7 @@ suiteSetup('set up monitorManager', async function() {
   monitorManager = monitor.manager;
 });
 
-teardown(function() {
+teardown(() => {
   monitorManager.reset();
 });
 
@@ -60,8 +60,8 @@ export const setupServer = async ({ builder, context }) => {
 
 export const teardownServer = async () => {
   if (runningServer) {
-    await new Promise(function(accept) {
-      runningServer.once('close', function() {
+    await new Promise((accept) => {
+      runningServer.once('close', () => {
         runningServer = null;
         accept();
       });

--- a/libraries/api/test/logging_test.js
+++ b/libraries/api/test/logging_test.js
@@ -7,7 +7,7 @@ import libUrls from 'taskcluster-lib-urls';
 import testing from '@taskcluster/lib-testing';
 import { LEVELS } from '@taskcluster/lib-monitor';
 
-suite(testing.suiteName(), function() {
+suite(testing.suiteName(), () => {
   // Create test api
   const builder = new APIBuilder({
     title: 'Test Api',
@@ -36,7 +36,7 @@ suite(testing.suiteName(), function() {
         { AllOf: ['bb', 'dd'] },
       ],
     },
-  }, function(req, res) {
+  }, (req, res) => {
     res.reply({});
   });
 
@@ -48,7 +48,7 @@ suite(testing.suiteName(), function() {
     category: 'API Library',
     description: 'Place we can call to test something',
     scopes: null,
-  }, function(req, res) {
+  }, (req, res) => {
     res.reply({});
   });
 
@@ -66,7 +66,7 @@ suite(testing.suiteName(), function() {
       if: 'private',
       then: 'aa',
     },
-  }, async function(req, res) {
+  }, async (req, res) => {
     await req.authorize({ private: req.query.private === '1' });
     res.reply({});
   });
@@ -79,7 +79,7 @@ suite(testing.suiteName(), function() {
     category: 'API Library',
     description: 'Place we can call to test something',
     scopes: 'XXXX',
-  }, function(req, res) {
+  }, (req, res) => {
     res.reply({});
   });
 
@@ -94,11 +94,11 @@ suite(testing.suiteName(), function() {
     title: 'Bewit having endpoint',
     description: 'Place we can call to test something',
     scopes: null,
-  }, function(req, res) {
+  }, (req, res) => {
     res.reply({});
   });
 
-  test('successful api method is logged', async function() {
+  test('successful api method is logged', async () => {
     const url = libUrls.api(helper.rootUrl, 'test', 'v1', '/require-some-scopes');
     const { header } = hawk.client.header(url, 'GET', {
       credentials: { id: 'client-with-aa-bb-dd', key: 'ignored', algorithm: 'sha256' },
@@ -136,7 +136,7 @@ suite(testing.suiteName(), function() {
     }, 3, 100);
   });
 
-  test('scope-less api method is logged', async function() {
+  test('scope-less api method is logged', async () => {
     const url = libUrls.api(helper.rootUrl, 'test', 'v1', '/require-no-scopes');
     const { header } = hawk.client.header(url, 'GET', {
       credentials: { id: 'client-with-aa-bb-dd', key: 'ignored', algorithm: 'sha256' },
@@ -171,7 +171,7 @@ suite(testing.suiteName(), function() {
     }, 3, 100);
   });
 
-  test('optionally scope-less api method is logged without scopes', async function() {
+  test('optionally scope-less api method is logged without scopes', async () => {
     const url = libUrls.api(helper.rootUrl, 'test', 'v1', '/sometimes-require-no-scopes?private=0');
     const { header } = hawk.client.header(url, 'GET', {
       credentials: { id: 'client-with-aa-bb-dd', key: 'ignored', algorithm: 'sha256' },
@@ -212,7 +212,7 @@ suite(testing.suiteName(), function() {
     }, 3, 100);
   });
 
-  test('optionally scope-less api method is logged with scopes', async function() {
+  test('optionally scope-less api method is logged with scopes', async () => {
     const url = libUrls.api(helper.rootUrl, 'test', 'v1', '/sometimes-require-no-scopes?private=1');
     const { header } = hawk.client.header(url, 'GET', {
       credentials: { id: 'client-with-aa-bb-dd', key: 'ignored', algorithm: 'sha256' },
@@ -247,7 +247,7 @@ suite(testing.suiteName(), function() {
     }, 3, 100);
   });
 
-  test('unauthorized api method is logged', async function() {
+  test('unauthorized api method is logged', async () => {
     const url = libUrls.api(helper.rootUrl, 'test', 'v1', '/require-extra-scopes');
     const { header } = hawk.client.header(url, 'GET', {
       credentials: { id: 'client-with-aa-bb-dd', key: 'ignored', algorithm: 'sha256' },
@@ -286,7 +286,7 @@ suite(testing.suiteName(), function() {
     }, 3, 100);
   });
 
-  test('bewit is elided', async function() {
+  test('bewit is elided', async () => {
     const url = libUrls.api(helper.rootUrl, 'test', 'v1', '/bewitiful?bewit=Y2xpZW50LXdpdGgtYWEtYmItZGRcMTYwMjE3NTYxM1xyVUErZWE1TWxUaWlZR1Vaak5KbE5pTFhnNnhCbXdhRDFxbnozQU1HZ2hJPVw&foo=abc');
     await request.get(url);
 
@@ -319,7 +319,7 @@ suite(testing.suiteName(), function() {
     }, 3, 100);
   });
 
-  test('unknown query params are not logged', async function() {
+  test('unknown query params are not logged', async () => {
     const url = libUrls.api(helper.rootUrl, 'test', 'v1', '/bewitiful?bar=abc');
     const { header } = hawk.client.header(url, 'GET', {
       credentials: { id: 'client-with-aa-bb-dd', key: 'ignored', algorithm: 'sha256' },
@@ -358,7 +358,7 @@ suite(testing.suiteName(), function() {
     }, 3, 100);
   });
 
-  test('invalid query params are not logged', async function() {
+  test('invalid query params are not logged', async () => {
     const url = libUrls.api(helper.rootUrl, 'test', 'v1', '/bewitiful?foo=def');
     const { header } = hawk.client.header(url, 'GET', {
       credentials: { id: 'client-with-aa-bb-dd', key: 'ignored', algorithm: 'sha256' },

--- a/libraries/api/test/middleware_test.js
+++ b/libraries/api/test/middleware_test.js
@@ -2,8 +2,8 @@ import assert from 'node:assert';
 import { APIBuilder } from '../src/index.js';
 import testing from '@taskcluster/lib-testing';
 
-suite(testing.suiteName(), function() {
-  test('middleware is exported', function() {
+suite(testing.suiteName(), () => {
+  test('middleware is exported', () => {
     assert(APIBuilder.middleware);
   });
 });

--- a/libraries/api/test/pagination_test.js
+++ b/libraries/api/test/pagination_test.js
@@ -4,51 +4,51 @@ import { paginateResults } from '../src/pagination.js';
 import testing from '@taskcluster/lib-testing';
 import Hashids from 'hashids';
 
-suite(testing.suiteName(), function() {
-  suite('offset/limit', function() {
+suite(testing.suiteName(), () => {
+  suite('offset/limit', () => {
     const fetcher = n => async (size, offset) => _.range(offset, Math.min(n, offset + size));
     const hashids = new Hashids('salt', 10);
 
-    test('paginate with limit higher than returned rows', async function() {
+    test('paginate with limit higher than returned rows', async () => {
       assert.deepEqual(
         await paginateResults({ query: { limit: 10 }, fetch: fetcher(7) }),
         { rows: _.range(0, 7) });
     });
 
-    test('paginate with limit equal to returned rows', async function() {
+    test('paginate with limit equal to returned rows', async () => {
       assert.deepEqual(
         await paginateResults({ query: { limit: 7 }, fetch: fetcher(7) }),
         { rows: _.range(0, 7) }); // notably no continuationToken
     });
 
-    test('paginate with limit less than returned rows', async function() {
+    test('paginate with limit less than returned rows', async () => {
       assert.deepEqual(
         await paginateResults({ query: { limit: 4 }, fetch: fetcher(7) }),
         { rows: _.range(0, 4), continuationToken: hashids.encode(4) });
     });
 
-    test('paginate with continuationToken', async function() {
+    test('paginate with continuationToken', async () => {
       const continuationToken = hashids.encode(5);
       assert.deepEqual(
         await paginateResults({ query: { limit: 100, continuationToken }, fetch: fetcher(7) }),
         { rows: _.range(5, 7) });
     });
 
-    test('paginate with continuationToken and limit ending at returned rows', async function() {
+    test('paginate with continuationToken and limit ending at returned rows', async () => {
       const continuationToken = hashids.encode(5);
       assert.deepEqual(
         await paginateResults({ query: { limit: 2, continuationToken }, fetch: fetcher(7) }),
         { rows: _.range(5, 7) });
     });
 
-    test('paginate with continuationToken and limit returning another page', async function() {
+    test('paginate with continuationToken and limit returning another page', async () => {
       const continuationToken = hashids.encode(3);
       assert.deepEqual(
         await paginateResults({ query: { limit: 2, continuationToken }, fetch: fetcher(7) }),
         { rows: _.range(3, 5), continuationToken: hashids.encode(5) });
     });
 
-    test('paginate with invalid continuationToken throws error', async function() {
+    test('paginate with invalid continuationToken throws error', async () => {
       const continuationToken = 'this-is-rubbish';
       await assert.rejects(
         () => paginateResults({ query: { limit: 2, continuationToken }, fetch: fetcher(7) }),
@@ -56,7 +56,7 @@ suite(testing.suiteName(), function() {
     });
   });
 
-  suite('index-based', function() {
+  suite('index-based', () => {
     const indexColumns = ['a', 'b'];
     const data = (A, B) => _.range(0, A).flatMap(a => _.range(0, B).map(b => ({ a, b })));
     const fetcher = (A, B) => {
@@ -71,19 +71,19 @@ suite(testing.suiteName(), function() {
 
     const token = (a, b) => Buffer.from(JSON.stringify([a, b])).toString('base64');
 
-    test('paginate with a limit higher than returned rows', async function() {
+    test('paginate with a limit higher than returned rows', async () => {
       assert.deepEqual(
         await paginateResults({ query: { limit: 110 }, indexColumns, fetch: fetcher(20, 5) }),
         { rows: data(20, 5).slice(0, 110) });
     });
 
-    test('paginate with a limit equal to returned rows', async function() {
+    test('paginate with a limit equal to returned rows', async () => {
       assert.deepEqual(
         await paginateResults({ query: { limit: 100 }, indexColumns, fetch: fetcher(20, 5) }),
         { rows: data(20, 5) });
     });
 
-    test('paginate with a limit one less than returned rows', async function() {
+    test('paginate with a limit one less than returned rows', async () => {
       assert.deepEqual(
         await paginateResults({ query: { limit: 99 }, indexColumns, fetch: fetcher(20, 5) }),
         { rows: data(20, 5).slice(0, 99), continuationToken: token(19, 3) });
@@ -96,7 +96,7 @@ suite(testing.suiteName(), function() {
         { rows: data(20, 5).slice(99, 100) });
     });
 
-    test('iterate over entire data set', async function() {
+    test('iterate over entire data set', async () => {
       let got = [];
       const query = { limit: 1 };
       while (true) {
@@ -111,28 +111,28 @@ suite(testing.suiteName(), function() {
       assert.deepEqual(got, data(10, 7));
     });
 
-    test('invalid base64 in token starts at first row', async function() {
+    test('invalid base64 in token starts at first row', async () => {
       const continuationToken = '!@$%!@';
       assert.deepEqual(
         await paginateResults({ query: { limit: 1, continuationToken }, indexColumns, fetch: fetcher(5, 5) }),
         { rows: data(5, 5).slice(0, 1), continuationToken: token(0, 0) });
     });
 
-    test('invalid JSON in token starts at first row', async function() {
+    test('invalid JSON in token starts at first row', async () => {
       const continuationToken = Buffer.from('{"abc": 123').toString('base64');
       assert.deepEqual(
         await paginateResults({ query: { limit: 1, continuationToken }, indexColumns, fetch: fetcher(5, 5) }),
         { rows: data(5, 5).slice(0, 1), continuationToken: token(0, 0) });
     });
 
-    test('non-array JSON in token starts at first row', async function() {
+    test('non-array JSON in token starts at first row', async () => {
       const continuationToken = Buffer.from('{"abc": 123}').toString('base64');
       assert.deepEqual(
         await paginateResults({ query: { limit: 1, continuationToken }, indexColumns, fetch: fetcher(5, 5) }),
         { rows: data(5, 5).slice(0, 1), continuationToken: token(0, 0) });
     });
 
-    test('bad-length array JSON in token starts at first row', async function() {
+    test('bad-length array JSON in token starts at first row', async () => {
       const continuationToken = Buffer.from('[1, 2, 3]').toString('base64');
       assert.deepEqual(
         await paginateResults({ query: { limit: 1, continuationToken }, indexColumns, fetch: fetcher(5, 5) }),

--- a/libraries/api/test/responsetimer_test.js
+++ b/libraries/api/test/responsetimer_test.js
@@ -5,8 +5,8 @@ import helper, { monitorManager } from './helper.js';
 import libUrls from 'taskcluster-lib-urls';
 import testing from '@taskcluster/lib-testing';
 
-suite(testing.suiteName(), function() {
-  setup(async function() {
+suite(testing.suiteName(), () => {
+  setup(async () => {
     await helper.setupServer({ builder });
   });
   teardown(helper.teardownServer);
@@ -27,7 +27,7 @@ suite(testing.suiteName(), function() {
     category: 'API Library',
     description: 'Place we can call to test something',
     scopes: null,
-  }, function(req, res) {
+  }, (req, res) => {
     res.status(200).send(req.params.myparam);
   });
 
@@ -39,7 +39,7 @@ suite(testing.suiteName(), function() {
     category: 'API Library',
     description: 'Place we can call to test something',
     scopes: null,
-  }, function(req, res) {
+  }, (req, res) => {
     res.status(404).send(req.params.name);
   });
 
@@ -51,11 +51,11 @@ suite(testing.suiteName(), function() {
     category: 'API Library',
     description: 'Place we can call to test something',
     scopes: null,
-  }, function(req, res) {
+  }, (req, res) => {
     res.status(500).send(req.params.name);
   });
 
-  test('single parameter', async function() {
+  test('single parameter', async () => {
     const u = path => libUrls.api(helper.rootUrl, 'test', 'v1', path);
     await request.get(u('/single-param/Hello'));
     await request.get(u('/single-param/Goodbye'));

--- a/libraries/api/test/route_test.js
+++ b/libraries/api/test/route_test.js
@@ -6,7 +6,7 @@ import helper from './helper.js';
 import libUrls from 'taskcluster-lib-urls';
 import testing from '@taskcluster/lib-testing';
 
-suite(testing.suiteName(), function() {
+suite(testing.suiteName(), () => {
   const u = path => libUrls.api(helper.rootUrl, 'test', 'v1', path);
 
   // Create test api
@@ -33,7 +33,7 @@ suite(testing.suiteName(), function() {
     category: 'API Library',
     stability: APIBuilder.stability.stable,
     description: 'Place we can call to test something',
-  }, function(req, res) {
+  }, (req, res) => {
     res.status(200).send(req.params.myparam);
   });
 
@@ -46,7 +46,7 @@ suite(testing.suiteName(), function() {
     stability: APIBuilder.stability.stable,
     category: 'API Library',
     description: 'Place we can call to test something',
-  }, function(req, res) {
+  }, (req, res) => {
     res.status(200).send(req.params.myparam);
   });
 
@@ -61,7 +61,7 @@ suite(testing.suiteName(), function() {
     category: 'API Library',
     description: 'Place we can call to test something',
     scopes: null,
-  }, function(req, res) {
+  }, (req, res) => {
     res.status(200).send(req.query.nextPage || 'empty');
   });
 
@@ -80,7 +80,7 @@ suite(testing.suiteName(), function() {
     title: 'Test End-Point',
     category: 'API Library',
     description: 'Place we can call to test something',
-  }, function(req, res) {
+  }, (req, res) => {
     res.status(200).send(req.query.incantation);
   });
 
@@ -92,7 +92,7 @@ suite(testing.suiteName(), function() {
     title: 'Test End-Point',
     category: 'API Library',
     description: 'Place we can call to test something',
-  }, function(req, res) {
+  }, (req, res) => {
     res.status(200).send(req.params.name);
   });
 
@@ -104,7 +104,7 @@ suite(testing.suiteName(), function() {
     title: 'Test End-Point',
     category: 'API Library',
     description: 'Place we can call to test something',
-  }, function(req, res) {
+  }, (req, res) => {
     res.status(200).send(req.params.taskId);
   });
 
@@ -123,7 +123,7 @@ suite(testing.suiteName(), function() {
       },
     },
     description: 'Place we can call to test something',
-  }, function(req, res) {
+  }, (req, res) => {
     res.status(200).send(req.params.fnValidated);
   });
 
@@ -136,13 +136,13 @@ suite(testing.suiteName(), function() {
     description: 'Place we can call to test something',
     category: 'API Library',
     params: {
-      param2: function(value) {
+      param2: (value) => {
         if (value !== 'correct') {
           return 'Wrong value passed!';
         }
       },
     },
-  }, function(req, res) {
+  }, (req, res) => {
     res.status(200).send(req.params.param2);
   });
 
@@ -158,90 +158,90 @@ suite(testing.suiteName(), function() {
   });
   teardown(helper.teardownServer);
 
-  test('single parameter', function() {
+  test('single parameter', () => {
     const url = u('/single-param/Hello');
     return request
       .get(url)
-      .then(function(res) {
+      .then((res) => {
         assert(res.ok, 'Request failed');
         assert(res.text === 'Hello', 'Got wrong value');
       });
   });
 
-  test('single parameter, trailing slash', function() {
+  test('single parameter, trailing slash', () => {
     const url = u('/single-param/Hello/');
     return request
       .get(url)
-      .then(function(res) {
+      .then((res) => {
         assert(res.ok, 'Request failed');
         assert(res.text === 'Hello', 'Got wrong value');
       });
   });
 
-  test('single parameter with slashes', function() {
+  test('single parameter with slashes', () => {
     const url = u('/single-param-with-slashes/Hello/world');
     return request
       .get(url)
-      .then(function(res) {
+      .then((res) => {
         assert(res.ok, 'Request failed');
         assert.equal(res.text, 'Hello/world', 'Got wrong value');
       });
   });
 
-  test('single parameter allowing slashes without slashes', function() {
+  test('single parameter allowing slashes without slashes', () => {
     const url = u('/single-param-with-slashes/Helloworld');
     return request
       .get(url)
-      .then(function(res) {
+      .then((res) => {
         assert(res.ok, 'Request failed');
         assert.equal(res.text, 'Helloworld', 'Got wrong value');
       });
   });
 
-  test('single parameter with encoded slashes', function() {
+  test('single parameter with encoded slashes', () => {
     const url = u('/single-param-with-slashes/Hello%2Fworld');
     return request
       .get(url)
-      .then(function(res) {
+      .then((res) => {
         assert(res.ok, 'Request failed');
         assert.equal(res.text, 'Hello/world', 'Got wrong value');
       });
   });
 
-  test('query parameter', function() {
+  test('query parameter', () => {
     const url = u('/query-param/');
     return request
       .get(url)
       .query({ nextPage: '352' })
-      .catch(function(res) {
+      .catch((res) => {
         assert(res.ok, 'Request failed');
         assert(res.text === '352', 'Got wrong value');
       });
   });
 
-  test('query parameter (is optional)', function() {
+  test('query parameter (is optional)', () => {
     const url = u('/query-param/');
     return request
       .get(url)
-      .then(function(res) {
+      .then((res) => {
         assert(res.ok, 'Request failed');
         assert(res.text === 'empty', 'Got wrong value');
       });
   });
 
-  test('query parameter (validation works)', function() {
+  test('query parameter (validation works)', () => {
     const url = u('/query-param/');
     return request
       .get(url)
       .query({ nextPage: 'abc' })
       .then(res => assert(false, 'should have failed!'))
-      .catch(function(res) {
+      .catch((res) => {
         assert(!res.ok, 'Expected request failure!');
         assert(res.status === 400, 'Expected a 400 error');
       });
   });
 
-  test('query parameter with function + context (valid)', function() {
+  test('query parameter with function + context (valid)', () => {
     const url = u('/query-param-fn/');
     return request
       .get(url)
@@ -252,72 +252,72 @@ suite(testing.suiteName(), function() {
       });
   });
 
-  test('query parameter with function + context (invalid)', function() {
+  test('query parameter with function + context (invalid)', () => {
     const url = u('/query-param-fn/');
     return request
       .get(url)
       .query({ incantation: 'alohomora' })
       .then(res => assert(false, 'should have failed!'))
-      .catch(function(res) {
+      .catch((res) => {
         assert(!res.ok, 'Expected request failure!');
         assert(res.status === 400, 'Expected a 400 error');
       });
   });
 
-  test('slash parameter', function() {
+  test('slash parameter', () => {
     const url = u('/slash-param/Hello/World');
     return request
       .get(url)
-      .then(function(res) {
+      .then((res) => {
         assert(res.ok, 'Request failed');
         assert(res.text === 'Hello/World', 'Got wrong value');
       });
   });
 
-  test('validated reg-exp parameter (valid)', function() {
+  test('validated reg-exp parameter (valid)', () => {
     const id = slugid.v4();
     const url = u('/validated-param/') + id;
     return request
       .get(url)
-      .then(function(res) {
+      .then((res) => {
         assert(res.ok, 'Request failed');
         assert(res.text === id, 'Got wrong value');
       });
   });
 
-  test('validated reg-exp parameter (invalid)', function() {
+  test('validated reg-exp parameter (invalid)', () => {
     const url = u('/validated-param/-');
     return request
       .get(url)
       .then(res => assert(false, 'should have failed!'))
-      .catch(function(res) {
+      .catch((res) => {
         assert(!res.ok, 'Expected a failure');
         assert(res.status === 400, 'Expected a 400 error');
       });
   });
 
-  test('validated function parameter (valid)', function() {
+  test('validated function parameter (valid)', () => {
     const url = u('/validated-param-2/correct');
     return request
       .get(url)
-      .then(function(res) {
+      .then((res) => {
         assert(res.ok, 'Request failed');
         assert(res.text === 'correct', 'Got wrong value');
       });
   });
 
-  test('validated function parameter (invalid)', function() {
+  test('validated function parameter (invalid)', () => {
     const url = u('/validated-param-2/incorrect');
     return request
       .get(url)
       .then(res => assert(false, 'should have failed!'))
-      .catch(function(res) {
+      .catch((res) => {
         assert(!res.ok, 'Expected a failure');
         assert(res.status === 400, 'Expected a 400 error');
       });
   });
 
-  test('validated function parameter using context (valid)', function() {
+  test('validated function parameter using context (valid)', () => {
     const url = u('/function-validated-param/open-sesame');
     return request
       .get(url)
@@ -327,51 +327,51 @@ suite(testing.suiteName(), function() {
       });
   });
 
-  test('validated function parameter using context (invalid)', function() {
+  test('validated function parameter using context (invalid)', () => {
     const url = u('/function-validated-param/open-amaranth');
     return request
       .get(url)
       .then(res => assert(false, 'should have failed!'))
-      .catch(function(res) {
+      .catch((res) => {
         assert(!res.ok, 'Expected request failure!');
         assert(res.status === 400, 'Expected a 400 error');
       });
   });
 
-  test('cors header', function() {
+  test('cors header', () => {
     const url = u('/single-param/Hello');
     return request
       .get(url)
       .set('origin', 'https://tc.example.com')
-      .then(function(res) {
+      .then((res) => {
         assert(res.ok, 'Request failed');
         assert.equal(res.header['access-control-allow-origin'], '*');
       });
   });
 
-  test('cache header', function() {
+  test('cache header', () => {
     const url = u('/single-param/Hello');
     return request
       .get(url)
-      .then(function(res) {
+      .then((res) => {
         assert(res.ok, 'Request failed');
         assert(res.header['cache-control'] === 'no-store no-cache must-revalidate', 'Got wrong header');
       });
   });
 
-  test('cache header on 404s', function() {
+  test('cache header on 404s', () => {
     const url = u('/unknown');
     return request
       .get(url)
       .then(res => assert(false, 'should have failed!'))
-      .catch(function(err) {
+      .catch((err) => {
         assert(err.response.header['cache-control'] === 'no-store no-cache must-revalidate', 'Got wrong header');
       });
   });
 
-  test('reference', async function() {
+  test('reference', async () => {
     const ref = builder.reference();
-    ref.entries.forEach(function(entry) {
+    ref.entries.forEach((entry) => {
       if (entry.name === 'testSlashParam') {
         assert(entry.route === '/slash-param/<name>',
           'not parsing route correctly');
@@ -381,7 +381,7 @@ suite(testing.suiteName(), function() {
     });
   });
 
-  test('no duplicate route and method', function() {
+  test('no duplicate route and method', () => {
     builder.declare({
       method: 'get',
       route: '/test',
@@ -390,9 +390,9 @@ suite(testing.suiteName(), function() {
       title: 'Test',
       category: 'API Library',
       description: 'Test',
-    }, function(req, res) {});
+    }, (req, res) => {});
 
-    assert.throws(function() {
+    assert.throws(() => {
       builder.declare({
         method: 'get',
         route: '/test',
@@ -401,17 +401,17 @@ suite(testing.suiteName(), function() {
         title: 'Test',
         category: 'API Library',
         description: 'Test',
-      }, function(req, res) {});
+      }, (req, res) => {});
     }, /Identical route and method/);
   });
 
-  test('routes are case-sensitive', function() {
+  test('routes are case-sensitive', () => {
     const url = u('/SiNgLe-pArAm/Hello');
     return request
       .get(url)
-      .then(function(res) {
+      .then((res) => {
         assert(!res.ok, 'Request succeeded');
-      }, function(err) {
+      }, (err) => {
         assert.equal(err.status, 404);
       });
   });

--- a/libraries/api/test/scopes_test.js
+++ b/libraries/api/test/scopes_test.js
@@ -2,7 +2,7 @@ import assert from 'node:assert';
 import { APIBuilder } from '../src/index.js';
 import testing from '@taskcluster/lib-testing';
 
-suite(testing.suiteName(), function() {
+suite(testing.suiteName(), () => {
   // Create test api
   const builder = new APIBuilder({
     title: 'Test Api',
@@ -11,7 +11,7 @@ suite(testing.suiteName(), function() {
     apiVersion: 'v1',
   });
 
-  test('no scopes is OK', function() {
+  test('no scopes is OK', () => {
     // doesn't throw
     builder.declare({
       method: 'get',
@@ -21,10 +21,10 @@ suite(testing.suiteName(), function() {
       category: 'API Library',
       title: 'Test',
       description: 'Test',
-    }, function(req, res) {});
+    }, (req, res) => {});
   });
 
-  test('string scope works', function() {
+  test('string scope works', () => {
     builder.declare({
       method: 'get',
       route: '/testString/:myparam',
@@ -33,11 +33,11 @@ suite(testing.suiteName(), function() {
       category: 'API Library',
       title: 'Test',
       description: 'Test',
-    }, function(req, res) {});
+    }, (req, res) => {});
   });
 
-  test('array of string scope rejected', function() {
-    assert.throws(function() {
+  test('array of string scope rejected', () => {
+    assert.throws(() => {
       builder.declare({
         method: 'get',
         route: '/testArr/:myparam',
@@ -46,12 +46,12 @@ suite(testing.suiteName(), function() {
         category: 'API Library',
         title: 'Test',
         description: 'Test',
-      }, function(req, res) {});
+      }, (req, res) => {});
     }, /Invalid scope expression/);
   });
 
-  test('array of arrays of scope rejected', function() {
-    assert.throws(function() {
+  test('array of arrays of scope rejected', () => {
+    assert.throws(() => {
       builder.declare({
         method: 'get',
         route: '/testArrArr/:myparam',
@@ -60,11 +60,11 @@ suite(testing.suiteName(), function() {
         category: 'API Library',
         title: 'Test',
         description: 'Test',
-      }, function(req, res) {});
+      }, (req, res) => {});
     }, /Invalid scope expression/);
   });
 
-  test('scope expression not rejected', function() {
+  test('scope expression not rejected', () => {
     builder.declare({
       method: 'get',
       route: '/testScope/:myparam',
@@ -73,10 +73,10 @@ suite(testing.suiteName(), function() {
       category: 'API Library',
       title: 'Test',
       description: 'Test',
-    }, function(req, res) {});
+    }, (req, res) => {});
   });
 
-  test('scope expression with looping template not rejected', function() {
+  test('scope expression with looping template not rejected', () => {
     builder.declare({
       method: 'get',
       route: '/testScope2/:myparam',
@@ -85,6 +85,6 @@ suite(testing.suiteName(), function() {
       category: 'API Library',
       title: 'Test',
       description: 'Test',
-    }, function(req, res) {});
+    }, (req, res) => {});
   });
 });

--- a/libraries/api/test/utils_test.js
+++ b/libraries/api/test/utils_test.js
@@ -2,21 +2,21 @@ import { cleanRouteAndParams } from '../src/utils.js';
 import testing from '@taskcluster/lib-testing';
 import { strict as assert } from 'node:assert';
 
-suite(testing.suiteName(), function() {
-  suite('cleanRouteAndParams', function() {
-    test('for a plain route', function() {
+suite(testing.suiteName(), () => {
+  suite('cleanRouteAndParams', () => {
+    test('for a plain route', () => {
       assert.deepEqual(
         cleanRouteAndParams('/ab/cd'),
         ['/ab/cd', [], []]);
     });
 
-    test('for a route with "regular" params', function() {
+    test('for a route with "regular" params', () => {
       assert.deepEqual(
         cleanRouteAndParams('/foo/:foo/bar/:bar'),
         ['/foo/<foo>/bar/<bar>', ['foo', 'bar'], []]);
     });
 
-    test('for a route with an optional param', function() {
+    test('for a route with an optional param', () => {
       assert.deepEqual(
         cleanRouteAndParams('/foo/:foo/bar/:bar?'),
         ['/foo/<foo>/bar/<bar>', ['foo', 'bar'], ['bar']]);

--- a/libraries/api/test/validate_test.js
+++ b/libraries/api/test/validate_test.js
@@ -9,7 +9,7 @@ import testing from '@taskcluster/lib-testing';
 
 const __dirname = new URL('.', import.meta.url).pathname;
 
-suite(testing.suiteName(), function() {
+suite(testing.suiteName(), () => {
   const u = path => libUrls.api(helper.rootUrl, 'test', 'v1', path);
 
   setup(async () => {
@@ -37,7 +37,7 @@ suite(testing.suiteName(), function() {
     title: 'Test End-Point',
     category: 'API Library',
     description: 'Place we can call to test something',
-  }, function(req, res) {
+  }, (req, res) => {
     res.status(200).send('Hello World');
   });
 
@@ -51,7 +51,7 @@ suite(testing.suiteName(), function() {
     title: 'Test End-Point',
     category: 'API Library',
     description: 'Place we can call to test something',
-  }, function(req, res) {
+  }, (req, res) => {
     res.reply({ value: 4 });
   });
 
@@ -65,7 +65,7 @@ suite(testing.suiteName(), function() {
     title: 'Test End-Point',
     category: 'API Library',
     description: 'Place we can call to test something',
-  }, function(req, res) {
+  }, (req, res) => {
     res.reply({ value: 12 });
   });
 
@@ -80,7 +80,7 @@ suite(testing.suiteName(), function() {
     title: 'Test End-Point',
     category: 'API Library',
     description: 'Place we can call to test something',
-  }, function(req, res) {
+  }, (req, res) => {
     res.status(200).send('Hello World');
   });
 
@@ -95,7 +95,7 @@ suite(testing.suiteName(), function() {
     category: 'API Library',
     title: 'Test End-Point',
     description: 'Place we can call to test something',
-  }, function(req, res) {
+  }, (req, res) => {
     res.reply({ value: 12 });
   });
 
@@ -109,7 +109,7 @@ suite(testing.suiteName(), function() {
     title: 'Test End-Point',
     category: 'API Library',
     description: 'Place we can call to test something',
-  }, function(req, res) {
+  }, (req, res) => {
     res.reply({ value: 'Hello World' });
   });
 
@@ -122,7 +122,7 @@ suite(testing.suiteName(), function() {
     title: 'Test End-Point',
     category: 'API Library',
     description: 'Place we can call to test something',
-  }, function(req, res) {
+  }, (req, res) => {
     res.reply();
   });
 
@@ -135,7 +135,7 @@ suite(testing.suiteName(), function() {
     title: 'Test End-Point',
     category: 'API Library',
     description: 'Place we can call to test something',
-  }, function(req, res) {
+  }, (req, res) => {
     res.reply();
   });
 
@@ -148,7 +148,7 @@ suite(testing.suiteName(), function() {
     category: 'API Library',
     title: 'Test End-Point',
     description: 'place to call to trigger a double send',
-  }, function(req, res) {
+  }, (req, res) => {
     res.status(400).json({ error: 'yep' });
     res.status(200).reply({ value: 1 });
   });
@@ -162,53 +162,53 @@ suite(testing.suiteName(), function() {
     category: 'API Library',
     title: 'Test End-Point',
     description: 'place to call to trigger a double send',
-  }, function(req, res) {
+  }, (req, res) => {
     res.status(400).reply({ value: 1 });
     res.reportError('InputError', 'uhoh', {});
   });
 
   // Test valid input
-  test('input (valid)', function() {
+  test('input (valid)', () => {
     const url = u('/test-input');
     return request
       .post(url)
       .send({ value: 5 })
-      .then(function(res) {
+      .then((res) => {
         assert(res.ok, 'Request failed');
         assert(res.text === 'Hello World', 'Got wrong value');
       });
   });
 
   // Test invalid input
-  test('input (invalid)', function() {
+  test('input (invalid)', () => {
     const url = u('/test-input');
     return request
       .post(url)
       .send({ value: 11 })
       .then(res => assert(false, 'should have failed!'))
-      .catch(function(err) {
+      .catch((err) => {
         assert(err.status === 400, 'Request wasn\'t rejected');
       });
   });
 
   // Test valid output
-  test('output (valid)', function() {
+  test('output (valid)', () => {
     const url = u('/test-output');
     return request
       .get(url)
-      .then(function(res) {
+      .then((res) => {
         assert(res.ok, 'Request okay');
         assert(res.body.value === 4, 'Got wrong value');
       });
   });
 
   // test invalid output
-  test('output (invalid)', function() {
+  test('output (invalid)', () => {
     const url = u('/test-invalid-output');
     return request
       .get(url)
       .then(res => assert(false, 'should have failed!'))
-      .catch(function(err) {
+      .catch((err) => {
         assert.equal(err.status, 500);
         // the HTTP error should not contain details
         assert(!err.toString().match(/data.value must be/));
@@ -218,80 +218,80 @@ suite(testing.suiteName(), function() {
   });
 
   // test skipping input validation
-  test('skip input validation', function() {
+  test('skip input validation', () => {
     const url = u('/test-skip-input-validation');
     return request
       .post(url)
       .send({ value: 100 })
-      .then(function(res) {
+      .then((res) => {
         assert(res.ok, 'Request failed');
         assert(res.text === 'Hello World', 'Got wrong value');
       });
   });
 
   // test skipping output validation
-  test('skip output validation', function() {
+  test('skip output validation', () => {
     const url = u('/test-skip-output-validation');
     return request
       .get(url)
-      .then(function(res) {
+      .then((res) => {
         assert(res.ok, 'Request failed');
         assert(res.body.value === 12, 'Got wrong value');
       });
   });
 
   // test blob output
-  test('blob output', function() {
+  test('blob output', () => {
     const url = u('/test-blob-output');
     return request
       .get(url)
-      .then(function(res) {
+      .then((res) => {
         assert(res.ok, 'Request failed');
         assert(res.body.value === 'Hello World', 'Got wrong value');
       });
   });
 
-  test('input (correct content-type)', function() {
+  test('input (correct content-type)', () => {
     const url = u('/test-input');
     return request
       .post(url)
       .send(JSON.stringify({ value: 5 }))
       .set('content-type', 'application/json')
-      .then(function(res) {
+      .then((res) => {
         assert(res.status === 200, 'Request rejected');
       });
   });
 
-  test('input (wrong content-type)', function() {
+  test('input (wrong content-type)', () => {
     const url = u('/test-input');
     return request
       .post(url)
       .send(JSON.stringify({ value: 5 }))
       .set('content-type', 'text/x-json')
       .then(res => assert(false, 'should have failed!'))
-      .catch(function(err) {
+      .catch((err) => {
         assert(err.status === 400, 'Request wasn\'t rejected');
       });
   });
 
   // Test res.reply with empty body for get request
-  test('res reply with empty body get request without output schema', function() {
+  test('res reply with empty body get request without output schema', () => {
     const url = u('/test-res-reply');
     return request
       .get(url)
-      .then(function(res) {
+      .then((res) => {
         assert(res.status === 204, 'Got 204 status code with empty body');
       });
   });
 
   // Test res.reply with empty body for post request
-  test('res reply with empty body post request with output schema', function() {
+  test('res reply with empty body post request with output schema', () => {
     const url = u('/test-res-reply-post');
     return request
       .post(url)
-      .then(function(res) {
+      .then((res) => {
         assert(false, 'Request validation failed');
-      }).catch(function(err) {
+      }).catch((err) => {
         assert.equal(err.status, 500);
         // the HTTP error should not contain details
         assert(!err.toString().match(/data must be object/));
@@ -300,7 +300,7 @@ suite(testing.suiteName(), function() {
       });
   });
 
-  test('nonexistent schemas are caught at setup time', async function() {
+  test('nonexistent schemas are caught at setup time', async () => {
     const builder = new APIBuilder({
       title: 'Test Api',
       description: 'Another test api',
@@ -317,7 +317,7 @@ suite(testing.suiteName(), function() {
       category: 'API Library',
       title: 'Test End-Point',
       description: '..',
-    }, function(req, res) {});
+    }, (req, res) => {});
 
     const schemaset = new SchemaSet({
       serviceName: 'test',

--- a/libraries/app/test/app_test.js
+++ b/libraries/app/test/app_test.js
@@ -10,13 +10,13 @@ import mockFs from 'mock-fs';
 const __dirname = new URL('.', import.meta.url).pathname;
 const REPO_ROOT = path.join(__dirname, '../../../');
 
-suite(testing.suiteName(), function() {
+suite(testing.suiteName(), () => {
 
   // Test app creation
-  suite('app({port: 1459})', function() {
+  suite('app({port: 1459})', () => {
     let server;
 
-    suiteSetup(async function() {
+    suiteSetup(async () => {
       mockFs({
         [path.resolve(REPO_ROOT, 'version.json')]: JSON.stringify({ version: 'v99.99.99' }),
       });
@@ -25,10 +25,10 @@ suite(testing.suiteName(), function() {
       const fakeApi = {
         express(app) {
           const router = express.Router();
-          router.get('/test', function(req, res) {
+          router.get('/test', (req, res) => {
             res.status(200).send('Okay this works');
           });
-          router.get('/req-id', function(req, res) {
+          router.get('/req-id', (req, res) => {
             res.status(200).send(JSON.stringify({
               valueSet: req.traceId,
             }));
@@ -48,18 +48,18 @@ suite(testing.suiteName(), function() {
       });
     });
 
-    test('get /test', async function() {
+    test('get /test', async () => {
       const res = await request.get('http://localhost:1459/api/test/v1/test');
       assert(res.ok, 'Got response');
       assert.equal(res.text, 'Okay this works', 'Got the right text');
     });
 
-    test('hsts header', async function() {
+    test('hsts header', async () => {
       const res = await request.get('http://localhost:1459/api/test/v1/test');
       assert.equal(res.headers['strict-transport-security'], 'max-age=7776000000; includeSubDomains');
     });
 
-    test('trace ids', async function() {
+    test('trace ids', async () => {
       const res = await request
         .get('http://localhost:1459/api/test/v1/req-id')
         .set('x-taskcluster-trace-id', 'foo/123')
@@ -69,7 +69,7 @@ suite(testing.suiteName(), function() {
       assert.equal(body.valueSet, 'foo/123');
     });
 
-    test('trace ids (created when none passed in)', async function() {
+    test('trace ids (created when none passed in)', async () => {
       const res = await request
         .get('http://localhost:1459/api/test/v1/req-id')
         .buffer();
@@ -79,28 +79,28 @@ suite(testing.suiteName(), function() {
       assert(isUUID.v4(body.valueSet));
     });
 
-    test('/__version__', async function() {
+    test('/__version__', async () => {
       const res = await request.get('http://localhost:1459/__version__');
       assert(res.ok, 'Got response');
       assert.equal(res.body.version, 'v99.99.99', 'Got the right version');
       assert.equal(res.headers['content-type'], 'application/json; charset=utf-8');
     });
 
-    test('/__heartbeat__', async function() {
+    test('/__heartbeat__', async () => {
       const res = await request.get('http://localhost:1459/__heartbeat__');
       assert(res.ok, 'Got response');
       assert.equal(res.status, 200);
       assert.equal(res.headers['content-type'], 'application/json; charset=utf-8');
     });
 
-    test('/__lbheartbeat__', async function() {
+    test('/__lbheartbeat__', async () => {
       const res = await request.get('http://localhost:1459/__lbheartbeat__');
       assert(res.ok, 'Got response');
       assert.equal(res.status, 200);
       assert.equal(res.headers['content-type'], 'application/json; charset=utf-8');
     });
 
-    test('/not-found', async function() {
+    test('/not-found', async () => {
       try {
         await request.get('http://localhost:1459/api/test/v1/notfound');
       } catch (err) {
@@ -117,7 +117,7 @@ suite(testing.suiteName(), function() {
       throw new Error('expected exception not seen');
     });
 
-    test('graceful shutdown', async function() {
+    test('graceful shutdown', async () => {
       const conn = request.get('http://localhost:1459/__heartbeat__')
         .set('Connection', 'keep-alive');
 
@@ -132,12 +132,10 @@ suite(testing.suiteName(), function() {
       }
     });
 
-    teardown(function() {
+    teardown(() => {
       mockFs.restore();
     });
 
-    suiteTeardown(function() {
-      return server.terminate();
-    });
+    suiteTeardown(() => server.terminate());
   });
 });

--- a/libraries/app/test/bin/app.js
+++ b/libraries/app/test/bin/app.js
@@ -7,7 +7,7 @@ const debug = debugFactory('base:test:bin:app.js');
 let global_state = 0;
 
 /** Launch a simple test app */
-const launch = function() {
+const launch = () => {
   // Create a simple app we can use for testing
   const app = base.app({
     port: Number(process.argv[2]) || 62827,
@@ -17,19 +17,19 @@ const launch = function() {
   });
 
   // Respond 'Hello World' for /test
-  app.get('/test', function(req, res) {
+  app.get('/test', (req, res) => {
     res.status(200).send('Hello World');
   });
 
   // Respond request count in process for /request-count
-  app.get('/request-count', function(req, res) {
+  app.get('/request-count', (req, res) => {
     global_state += 1;
     res.status(200).send('Count: ' + global_state);
   });
 
   // Kill process in crash case for testing
   if (process.argv[2] === 'CRASH') {
-    setTimeout(function() {
+    setTimeout(() => {
       process.exit(1);
     }, 1000);
   }
@@ -41,9 +41,9 @@ const launch = function() {
 // If is executed run launch
 // If this file is executed launch component from first argument
 if (process.argv[1] === fileURLToPath(import.meta.url)) {
-  launch().then(function() {
+  launch().then(() => {
     debug('Launched app.js successfully');
-  }).catch(function(err) {
+  }).catch((err) => {
     debug('Failed to start app.js, err: %s, as JSON: %j', err, err, err.stack);
     process.exit(1);
   });

--- a/libraries/config/test/config_test.js
+++ b/libraries/config/test/config_test.js
@@ -5,7 +5,7 @@ import testing from '@taskcluster/lib-testing';
 
 const __dirname = new URL('.', import.meta.url).pathname;
 
-suite(testing.suiteName(), function() {
+suite(testing.suiteName(), () => {
 
   test('load yaml', () => {
     let cfg = config({

--- a/libraries/iterate/test/iterate_test.js
+++ b/libraries/iterate/test/iterate_test.js
@@ -70,7 +70,7 @@ suite(testing.suiteName(), () => {
     });
   };
 
-  test('should be able to start and stop', runWithFakeTime(async function() {
+  test('should be able to start and stop', runWithFakeTime(async () => {
     let iterations = 0;
 
     const i = new subject({
@@ -105,7 +105,7 @@ suite(testing.suiteName(), () => {
     });
   }));
 
-  test('should stop after current iteration completes', runWithFakeTime(async function() {
+  test('should stop after current iteration completes', runWithFakeTime(async () => {
     const i = new subject({
       name: 'foo',
       monitor,
@@ -127,7 +127,7 @@ suite(testing.suiteName(), () => {
     assume(Date.now()).atleast(500);
   }));
 
-  test('should stop in the midst of waitTime', runWithFakeTime(async function() {
+  test('should stop in the midst of waitTime', runWithFakeTime(async () => {
     const i = new subject({
       name: 'foo',
       monitor,
@@ -147,7 +147,7 @@ suite(testing.suiteName(), () => {
     assume(Date.now()).between(1000, 1100);
   }));
 
-  test('should stop after correct number of iterations', runWithFakeTime(async function() {
+  test('should stop after correct number of iterations', runWithFakeTime(async () => {
     let iterations = 0;
 
     const i = new subject({
@@ -174,7 +174,7 @@ suite(testing.suiteName(), () => {
     assume(i.keepGoing).is.not.ok();
   }));
 
-  test('should emit error when iteration watchdog expires', runWithFakeTime(async function() {
+  test('should emit error when iteration watchdog expires', runWithFakeTime(async () => {
     const i = new subject({
       name: 'foo',
       monitor,
@@ -198,7 +198,7 @@ suite(testing.suiteName(), () => {
     assume(err).matches(/watchdog exceeded/);
   }));
 
-  test('should emit error when overall iteration limit is hit', runWithFakeTime(async function() {
+  test('should emit error when overall iteration limit is hit', runWithFakeTime(async () => {
     const i = new subject({
       name: 'foo',
       monitor,
@@ -226,7 +226,7 @@ suite(testing.suiteName(), () => {
     assume(err).matches(/Iteration exceeded maximum time allowed/);
   }));
 
-  test('should emit iteration-failure when async handler fails', runWithFakeTime(async function() {
+  test('should emit iteration-failure when async handler fails', runWithFakeTime(async () => {
     const i = new subject({
       name: 'foo',
       monitor,
@@ -249,7 +249,7 @@ suite(testing.suiteName(), () => {
     assume(sawEvent).is.ok();
   }));
 
-  test('should emit iteration-failure when sync handler fails', runWithFakeTime(async function() {
+  test('should emit iteration-failure when sync handler fails', runWithFakeTime(async () => {
     const i = new subject({
       name: 'foo',
       monitor,
@@ -272,7 +272,7 @@ suite(testing.suiteName(), () => {
     assume(sawEvent).is.ok();
   }));
 
-  test('should emit iteration-failure when iteration is too quick', runWithFakeTime(async function() {
+  test('should emit iteration-failure when iteration is too quick', runWithFakeTime(async () => {
     const i = new subject({
       name: 'foo',
       monitor,
@@ -295,7 +295,7 @@ suite(testing.suiteName(), () => {
     assume(iterFailed).is.ok();
   }));
 
-  test('should emit error after too many failures', runWithFakeTime(async function() {
+  test('should emit error after too many failures', runWithFakeTime(async () => {
     const i = new subject({
       name: 'foo',
       monitor,
@@ -318,7 +318,7 @@ suite(testing.suiteName(), () => {
     assume(err).matches(/uhoh/);
   }));
 
-  test('should emit correct events for single iteration', runWithFakeTime(async function() {
+  test('should emit correct events for single iteration', runWithFakeTime(async () => {
     const i = new subject({
       name: 'foo',
       monitor,
@@ -343,7 +343,7 @@ suite(testing.suiteName(), () => {
     events.assert();
   }));
 
-  test('should emit correct events with maxIterations', runWithFakeTime(async function() {
+  test('should emit correct events with maxIterations', runWithFakeTime(async () => {
     const i = new subject({
       name: 'foo',
       monitor,
@@ -372,7 +372,7 @@ suite(testing.suiteName(), () => {
 
   suite('event emission ordering', () => {
 
-    test('should be correct with maxFailures and maxIterations', runWithFakeTime(async function() {
+    test('should be correct with maxFailures and maxIterations', runWithFakeTime(async () => {
       const i = new subject({
         name: 'foo',
         monitor,
@@ -401,7 +401,7 @@ suite(testing.suiteName(), () => {
       events.assert();
     }));
 
-    test('should be correct with maxFailures only', runWithFakeTime(async function() {
+    test('should be correct with maxFailures only', runWithFakeTime(async () => {
       const i = new subject({
         name: 'foo',
         monitor,
@@ -429,7 +429,7 @@ suite(testing.suiteName(), () => {
       events.assert();
     }));
 
-    test('should be correct when handler takes too little time', runWithFakeTime(async function() {
+    test('should be correct when handler takes too little time', runWithFakeTime(async () => {
       const i = new subject({
         name: 'foo',
         monitor,
@@ -457,7 +457,7 @@ suite(testing.suiteName(), () => {
       events.assert();
     }));
 
-    test('should be correct when handler takes too long (incremental watchdog)', runWithFakeTime(async function() {
+    test('should be correct when handler takes too long (incremental watchdog)', runWithFakeTime(async () => {
       const i = new subject({
         name: 'foo',
         monitor,
@@ -485,7 +485,7 @@ suite(testing.suiteName(), () => {
       events.assert();
     }));
 
-    test('should be correct when handler takes too long (overall time)', runWithFakeTime(async function() {
+    test('should be correct when handler takes too long (overall time)', runWithFakeTime(async () => {
       const i = new subject({
         name: 'foo',
         monitor,
@@ -512,7 +512,7 @@ suite(testing.suiteName(), () => {
       events.assert();
     }));
 
-    test('should be correct with mixed results', runWithFakeTime(async function() {
+    test('should be correct with mixed results', runWithFakeTime(async () => {
       let iterations = 0;
 
       const i = new subject({

--- a/libraries/iterate/test/watchdog_test.js
+++ b/libraries/iterate/test/watchdog_test.js
@@ -2,7 +2,7 @@ import subject from '../src/watchdog.js';
 import assume from 'assume';
 import testing from '@taskcluster/lib-testing';
 
-suite(testing.suiteName(), function() {
+suite(testing.suiteName(), () => {
   let events;
 
   const runWithFakeTime = fn => {
@@ -16,7 +16,7 @@ suite(testing.suiteName(), function() {
     w.on('expired', () => events.push(['expired', Date.now()]));
   };
 
-  test('should emit expired event', runWithFakeTime(async function() {
+  test('should emit expired event', runWithFakeTime(async () => {
     const w = new subject(1 * 1000);
     listen(w);
     w.start();
@@ -26,7 +26,7 @@ suite(testing.suiteName(), function() {
     ]);
   }));
 
-  test('should not expire early', runWithFakeTime(async function() {
+  test('should not expire early', runWithFakeTime(async () => {
     const w = new subject(1 * 1000);
     listen(w);
     w.start();
@@ -35,7 +35,7 @@ suite(testing.suiteName(), function() {
     assume(events).to.deeply.equal([]);
   }));
 
-  test('should expire on time', runWithFakeTime(async function() {
+  test('should expire on time', runWithFakeTime(async () => {
     const w = new subject(1 * 1000);
     listen(w);
     w.start();
@@ -46,7 +46,7 @@ suite(testing.suiteName(), function() {
     ]);
   }));
 
-  test('should not expire twice', runWithFakeTime(async function() {
+  test('should not expire twice', runWithFakeTime(async () => {
     const w = new subject(1 * 1000);
     listen(w);
     w.start();
@@ -57,7 +57,7 @@ suite(testing.suiteName(), function() {
     ]);
   }));
 
-  test('touching should reset timer', runWithFakeTime(async function() {
+  test('touching should reset timer', runWithFakeTime(async () => {
     const w = new subject(1 * 1000);
     listen(w);
     w.start();

--- a/libraries/loader/src/index.js
+++ b/libraries/loader/src/index.js
@@ -65,7 +65,7 @@ function loader(componentDirectory, virtualComponents = {}) {
   }
   tsort.sort();
 
-  let load = function(target, options = {}) {
+  let load = (target, options = {}) => {
     options = Object.assign({}, options);
 
     if (typeof target !== 'string') {
@@ -111,7 +111,7 @@ function loader(componentDirectory, virtualComponents = {}) {
             } catch (err) {
               reject(err);
             }
-          }).catch(function(err) {
+          }).catch((err) => {
             debug(`error while loading component '${target}': ${err}`);
             throw err;
           });
@@ -122,7 +122,7 @@ function loader(componentDirectory, virtualComponents = {}) {
     return recursiveLoad(target);
   };
 
-  load.crashOnError = function(target) {
+  load.crashOnError = (target) => {
     load(target).catch(err => {
       console.log(err.stack);
       process.exit(1);

--- a/libraries/loader/test/loader_tests.js
+++ b/libraries/loader/test/loader_tests.js
@@ -441,7 +441,7 @@ suite('component loader', () => {
       },
     });
 
-    assert.throws(function() { load.crashOnError(true); }, 'false');
+    assert.throws(() => { load.crashOnError(true); }, 'false');
   });
 
   test('should pass own name to setup', async () => {

--- a/libraries/monitor/test/logger_test.js
+++ b/libraries/monitor/test/logger_test.js
@@ -9,10 +9,10 @@ import path from 'node:path';
 
 const __dirname = new URL('.', import.meta.url).pathname;
 
-suite(testing.suiteName(), function() {
+suite(testing.suiteName(), () => {
   let monitorManager, monitor;
 
-  setup(function() {
+  setup(() => {
     monitor = MonitorManager.setup({
       serviceName: 'testing-service',
       level: 'debug',
@@ -26,22 +26,22 @@ suite(testing.suiteName(), function() {
       message => monitorManager.messages.push(message);
   });
 
-  teardown(async function() {
+  teardown(async () => {
     await monitor.terminate();
   });
 
-  test('logger moves explicitly set traceId up', function() {
+  test('logger moves explicitly set traceId up', () => {
     monitor.info({ traceId: 'foo/bar' });
     assert.equal(monitorManager.messages[0].traceId, 'foo/bar');
     assert.equal(monitorManager.messages[0].Fields.traceId, undefined);
   });
 
-  test('logger with no traceId leaves it out', function() {
+  test('logger with no traceId leaves it out', () => {
     monitor.info({ something: 123 });
     assert.equal(monitorManager.messages[0].traceId, undefined);
   });
 
-  test('logger conforms to schema', function() {
+  test('logger conforms to schema', () => {
     const schema = JSON.parse(fs.readFileSync(path.resolve(__dirname, './mozlog_schema.json'), 'utf8'));
     monitor.info('something', { test: 123 });
     const event = monitorManager.messages[0];
@@ -51,7 +51,7 @@ suite(testing.suiteName(), function() {
     assert(ajv.validate(schema, event), ajv.errorsText());
   });
 
-  test('logger separates lines with newlines', function() {
+  test('logger separates lines with newlines', () => {
     let results = Buffer.alloc(0);
     const destination = new stream.Writable({
       write: (chunk, encoding, next) => {
@@ -76,50 +76,50 @@ suite(testing.suiteName(), function() {
     JSON.parse(results[2]);
   });
 
-  test('simple eliding', function() {
+  test('simple eliding', () => {
     monitor.info({ credentials: 5 });
     assert.equal(monitorManager.messages[0].Type, 'monitor.generic');
     assert.equal(monitorManager.messages[0].Fields.credentials, '...');
   });
 
-  test('nested eliding', function() {
+  test('nested eliding', () => {
     monitor.info({ whatever: [{ accessToken: 'hi' }] });
     assert.equal(monitorManager.messages[0].Type, 'monitor.generic');
     assert.equal(monitorManager.messages[0].Fields.whatever[0].accessToken, '...');
   });
 
-  test('null eliding does not crash', function() {
+  test('null eliding does not crash', () => {
     monitor.info({ something: null });
     assert.equal(monitorManager.messages[0].Type, 'monitor.generic');
     assert.equal(monitorManager.messages[0].Fields.something, null);
   });
 
-  test('empty data still logs', function() {
+  test('empty data still logs', () => {
     monitor.info({ whatever: 5 });
     assert.equal(monitorManager.messages[0].Type, 'monitor.generic');
     assert.equal(monitorManager.messages[0].Fields.whatever, 5);
   });
 
-  test('string data still logs', function() {
+  test('string data still logs', () => {
     monitor.info('baz', 'hello');
     assert.equal(monitorManager.messages[0].Type, 'baz');
     assert.equal(monitorManager.messages[0].Fields.message, 'hello');
   });
 
-  test('number data still logs', function() {
+  test('number data still logs', () => {
     monitor.info('foobar', 5.0);
     assert.equal(monitorManager.messages[0].Type, 'foobar');
     assert.equal(monitorManager.messages[0].Fields.message, 5.0);
   });
 
-  test('multiline fields.message is truncated in message', function() {
+  test('multiline fields.message is truncated in message', () => {
     monitor.info('foobar', { message: 'title\nmore info\neven more' });
     assert.equal(monitorManager.messages[0].Type, 'foobar');
     assert.equal(monitorManager.messages[0].message, 'title');
     assert.equal(monitorManager.messages[0].Fields.message, 'title\nmore info\neven more');
   });
 
-  test('null data still logs', function() {
+  test('null data still logs', () => {
     monitor.info('something', null);
     assert.equal(monitorManager.messages[0].Type, 'monitor.loggingError');
     assert.equal(monitorManager.messages[0].Fields.error, 'Invalid field to be logged.');
@@ -127,7 +127,7 @@ suite(testing.suiteName(), function() {
     assert.equal(monitorManager.messages[0].Fields.orig, null);
   });
 
-  test('boolean data still logs', function() {
+  test('boolean data still logs', () => {
     monitor.info('something', true);
     assert.equal(monitorManager.messages[0].Type, 'monitor.loggingError');
     assert.equal(monitorManager.messages[0].Fields.error, 'Invalid field to be logged.');
@@ -135,7 +135,7 @@ suite(testing.suiteName(), function() {
     assert.equal(monitorManager.messages[0].Fields.orig, true);
   });
 
-  test('metadata still logs but alerts', function() {
+  test('metadata still logs but alerts', () => {
     monitor.info('something', { meta: 'foo' });
     assert.equal(monitorManager.messages[0].Type, 'monitor.loggingError');
     assert.equal(monitorManager.messages[0].Fields.error, 'You may not set meta fields on logs directly.');
@@ -143,7 +143,7 @@ suite(testing.suiteName(), function() {
     assert.equal(monitorManager.messages[0].Fields.orig.meta, 'foo');
   });
 
-  test('all logging levels represented', function() {
+  test('all logging levels represented', () => {
     const levels = [
       'emerg',
       'alert',
@@ -166,7 +166,7 @@ suite(testing.suiteName(), function() {
     });
   });
 
-  test('levels work', function() {
+  test('levels work', () => {
     const m = MonitorManager.setup({
       serviceName: 'taskcluster-level',
       level: 'alert',

--- a/libraries/monitor/test/monitor_test.js
+++ b/libraries/monitor/test/monitor_test.js
@@ -7,11 +7,11 @@ import MonitorManager from '../src/monitormanager.js';
 
 const __dirname = new URL('.', import.meta.url).pathname;
 
-suite(testing.suiteName(), function() {
+suite(testing.suiteName(), () => {
   let monitorManager, monitor;
   let errorBucket = [];
 
-  suiteSetup(function() {
+  suiteSetup(() => {
     monitor = MonitorManager.setup({
       serviceName: 'testing-service',
       level: 'debug',
@@ -31,13 +31,13 @@ suite(testing.suiteName(), function() {
       message => monitorManager.messages.push(message);
   });
 
-  teardown(function() {
+  teardown(() => {
     errorBucket.splice(0);
     monitorManager.reset();
     mockFs.restore();
   });
 
-  suite('timer', function() {
+  suite('timer', () => {
     const takes100ms = () => new Promise(resolve => setTimeout(() => resolve(13), 100));
     const checkMonitor = (len) => {
       // check this after a short delay, as otherwise the Promise.resolve
@@ -52,25 +52,25 @@ suite(testing.suiteName(), function() {
       });
     };
 
-    test('of a sync function', async function() {
+    test('of a sync function', async () => {
       assert.equal(monitor.timer('pfx', () => 13), 13);
       await checkMonitor(1);
     });
 
-    test('of a sync function that fails', async function() {
+    test('of a sync function that fails', async () => {
       assert.throws(() => {
         monitor.timer('pfx', () => { throw new Error('uhoh'); });
       }, /uhoh/);
       await checkMonitor(1);
     });
 
-    test('of an async function', async function() {
+    test('of an async function', async () => {
       assert.equal(await monitor.timer('pfx', takes100ms), 13);
       await checkMonitor(1);
       assert(monitorManager.messages[0].Fields.duration >= 90);
     });
 
-    test('of an async function that fails', async function() {
+    test('of an async function that fails', async () => {
       let err;
       try {
         await monitor.timer('pfx', async () => { throw new Error('uhoh'); });
@@ -81,13 +81,13 @@ suite(testing.suiteName(), function() {
       await checkMonitor(1);
     });
 
-    test('of a promise', async function() {
+    test('of a promise', async () => {
       assert.equal(await monitor.timer('pfx', takes100ms()), 13);
       await checkMonitor(1);
       assert(monitorManager.messages[0].Fields.duration >= 90);
     });
 
-    test('of a failed promise', async function() {
+    test('of a failed promise', async () => {
       let err;
       try {
         await monitor.timer('pfx', Promise.reject(new Error('uhoh')));
@@ -99,23 +99,23 @@ suite(testing.suiteName(), function() {
     });
   });
 
-  suite('oneShot', function() {
+  suite('oneShot', () => {
     const oldExit = process.exit;
     let exitStatus = null;
 
-    suiteSetup('mock exit', function() {
+    suiteSetup('mock exit', () => {
       process.exit = (s) => { exitStatus = s; };
     });
 
-    suiteTeardown('unmock exit', function() {
+    suiteTeardown('unmock exit', () => {
       process.exit = oldExit;
     });
 
-    setup('clear exitStatus', function() {
+    setup('clear exitStatus', () => {
       exitStatus = null;
     });
 
-    test('successful async function', async function() {
+    test('successful async function', async () => {
       await monitor.oneShot('expire', async () => {});
       assert.equal(exitStatus, 0);
       assert.equal(monitorManager.messages.length, 1);
@@ -127,7 +127,7 @@ suite(testing.suiteName(), function() {
       assert.equal(errorBucket.length, 0);
     });
 
-    test('unsuccessful async function', async function() {
+    test('unsuccessful async function', async () => {
       await monitor.oneShot('expire', async () => { throw new Error('uhoh'); });
       assert.equal(exitStatus, 1);
       assert.equal(monitorManager.messages.length, 2);
@@ -139,7 +139,7 @@ suite(testing.suiteName(), function() {
       assert.equal(errorBucket.length, 1);
     });
 
-    test('missing name', async function() {
+    test('missing name', async () => {
       await monitor.oneShot(async () => { throw new Error('uhoh'); });
       assert.equal(exitStatus, 1);
       assert.equal(monitorManager.messages.length, 2);
@@ -149,8 +149,8 @@ suite(testing.suiteName(), function() {
     });
   });
 
-  suite('child monitors', function() {
-    test('..make sense', function() {
+  suite('child monitors', () => {
+    test('..make sense', () => {
       const child = monitor.childMonitor('api');
       monitor.count('foobar', 5);
       child.count('foobar', 6);
@@ -162,7 +162,7 @@ suite(testing.suiteName(), function() {
       assert.equal(monitorManager.messages[1].Fields.val, 6);
     });
 
-    test('can double prefix', function() {
+    test('can double prefix', () => {
       const child = monitor.childMonitor('api');
       const grandchild = monitor.childMonitor('api.something');
       monitor.count('foobar', 5);
@@ -178,7 +178,7 @@ suite(testing.suiteName(), function() {
       assert.equal(monitorManager.messages[2].Fields.val, 7);
     });
 
-    test('traceId becomes top-level', function() {
+    test('traceId becomes top-level', () => {
       const child = monitor.taskclusterPerRequestInstance({ entryName: 'what', traceId: 'foo/bar', requestId: '123/456' });
       monitor.measure('bazbing', 5);
       child.measure('bazbing', 6);
@@ -194,7 +194,7 @@ suite(testing.suiteName(), function() {
       assert.equal(monitorManager.messages[1].requestId, '123/456');
     });
 
-    test('metadata is merged', function() {
+    test('metadata is merged', () => {
       const child = monitor.childMonitor('api', { addition: 1000 });
       monitor.measure('bazbing', 5);
       child.measure('bazbing', 6);
@@ -206,7 +206,7 @@ suite(testing.suiteName(), function() {
       assert.equal(monitorManager.messages[1].Fields.addition, 1000);
     });
 
-    test('can configure child loggers with specific levels and default to root', function() {
+    test('can configure child loggers with specific levels and default to root', () => {
       const m = MonitorManager.setup({
         serviceName: 'testing-service',
         level: 'root:info api:debug',
@@ -224,7 +224,7 @@ suite(testing.suiteName(), function() {
       assert.equal(m.manager.messages[0].Logger, 'taskcluster.testing-service.api');
     });
 
-    test('if using child logger levels, must specify root', function() {
+    test('if using child logger levels, must specify root', () => {
       assert.throws(() => MonitorManager.setup({
         serviceName: 'testing-service',
         level: 'root.api:debug',
@@ -234,7 +234,7 @@ suite(testing.suiteName(), function() {
     });
   });
 
-  suite('uncaught and unhandled', function() {
+  suite('uncaught and unhandled', () => {
     const testExits = (done, args, check) => {
       let output = '';
 
@@ -253,7 +253,7 @@ suite(testing.suiteName(), function() {
       });
     };
 
-    test('normal', function(done) {
+    test('normal', (done) => {
       testExits(done, [], (done, code, output) => {
         assert.equal(code, 0);
         assert.equal(output, '');
@@ -261,7 +261,7 @@ suite(testing.suiteName(), function() {
       });
     });
 
-    test('thrown but with no interception', function(done) {
+    test('thrown but with no interception', (done) => {
       testExits(done, [
         '--shouldError',
       ], (done, code, output) => {
@@ -272,7 +272,7 @@ suite(testing.suiteName(), function() {
       });
     });
 
-    test('thrown with interception', function(done) {
+    test('thrown with interception', (done) => {
       testExits(done, [
         '--shouldError',
         '--patchGlobal',
@@ -285,7 +285,7 @@ suite(testing.suiteName(), function() {
       });
     });
 
-    test('unhandled but with no interception', function(done) {
+    test('unhandled but with no interception', (done) => {
       testExits(done, [
         '--shouldUnhandle',
       ], (done, code, output) => {
@@ -296,7 +296,7 @@ suite(testing.suiteName(), function() {
       });
     });
 
-    test('unhandled with interception', function(done) {
+    test('unhandled with interception', (done) => {
       testExits(done, [
         '--shouldUnhandle',
         '--patchGlobal',
@@ -310,7 +310,7 @@ suite(testing.suiteName(), function() {
       });
     });
 
-    test('unhandled with interception but continues', function(done) {
+    test('unhandled with interception but continues', (done) => {
       testExits(done, [
         '--shouldUnhandle',
         '--patchGlobal',
@@ -324,8 +324,8 @@ suite(testing.suiteName(), function() {
 
   });
 
-  suite('other basics', function() {
-    test('should record errors', function() {
+  suite('other basics', () => {
+    test('should record errors', () => {
       monitor.reportError(new Error('oh no'));
       assert.equal(monitorManager.messages.length, 1);
       assert.equal(monitorManager.messages[0].Severity, 3);
@@ -335,7 +335,7 @@ suite(testing.suiteName(), function() {
       assert.equal(monitorManager.messages[0].message, monitorManager.messages[0].Fields.stack);
     });
 
-    test('should record first line of multiline errors', function() {
+    test('should record first line of multiline errors', () => {
       monitor.reportError(new Error('uhoh\nsomething went wrong\n..again'));
       assert.equal(monitorManager.messages.length, 1);
       // the toplevel message has the first line of the error plus stack
@@ -350,7 +350,7 @@ suite(testing.suiteName(), function() {
         'uhoh\nsomething went wrong\n..again');
     });
 
-    test('should record top-level string or numeric fields of errors, but no more', function() {
+    test('should record top-level string or numeric fields of errors, but no more', () => {
       const err = new Error('uhoh');
       err.color = "prussian blue";
       err.temperature = 290.8; // Kelvin, obviously
@@ -367,7 +367,7 @@ suite(testing.suiteName(), function() {
       assert.equal(monitorManager.messages[0].Fields.array, undefined); // omitted
     });
 
-    test('should record errors with extra', function() {
+    test('should record errors with extra', () => {
       monitor.reportError(new Error('oh no'), { foo: 5 });
       assert.equal(monitorManager.messages.length, 1);
       assert.equal(monitorManager.messages[0].Severity, 3);
@@ -378,7 +378,7 @@ suite(testing.suiteName(), function() {
       assert(monitorManager.messages[0].Fields.stack);
     });
 
-    test('should record errors with extra and level', function() {
+    test('should record errors with extra and level', () => {
       monitor.reportError(new Error('oh no'), 'warning', { foo: 5 });
       assert.equal(monitorManager.messages.length, 1);
       assert.equal(monitorManager.messages[0].Severity, 4);
@@ -389,7 +389,7 @@ suite(testing.suiteName(), function() {
       assert(monitorManager.messages[0].Fields.stack);
     });
 
-    test('should record errors that are strings', function() {
+    test('should record errors that are strings', () => {
       monitor.reportError('oh no');
       assert.equal(monitorManager.messages.length, 1);
       assert.equal(monitorManager.messages[0].Fields.name, 'Error');
@@ -397,7 +397,7 @@ suite(testing.suiteName(), function() {
       assert(monitorManager.messages[0].Fields.stack);
     });
 
-    test('should count', function() {
+    test('should count', () => {
       monitor.count('something', 5);
       assert.equal(monitorManager.messages.length, 1);
       assert.equal(monitorManager.messages[0].Fields.key, 'something');
@@ -405,7 +405,7 @@ suite(testing.suiteName(), function() {
       assert.equal(monitorManager.messages[0].Severity, 6);
     });
 
-    test('should count with default', function() {
+    test('should count with default', () => {
       monitor.count('something');
       assert.equal(monitorManager.messages.length, 1);
       assert.equal(monitorManager.messages[0].Fields.key, 'something');
@@ -413,7 +413,7 @@ suite(testing.suiteName(), function() {
       assert.equal(monitorManager.messages[0].Severity, 6);
     });
 
-    test('should measure', function() {
+    test('should measure', () => {
       monitor.measure('whatever', 50);
       assert.equal(monitorManager.messages.length, 1);
       assert.equal(monitorManager.messages[0].Fields.key, 'whatever');
@@ -421,21 +421,21 @@ suite(testing.suiteName(), function() {
       assert.equal(monitorManager.messages[0].Severity, 6);
     });
 
-    test('should reject malformed counts', function() {
+    test('should reject malformed counts', () => {
       monitor.count('something', 'foo');
       assert.equal(monitorManager.messages.length, 1);
       assert.equal(monitorManager.messages[0].Severity, 3);
       assert.equal(monitorManager.messages[0].Fields.name, 'AssertionError');
     });
 
-    test('should reject malformed measures', function() {
+    test('should reject malformed measures', () => {
       monitor.measure('something', 'bar');
       assert.equal(monitorManager.messages.length, 1);
       assert.equal(monitorManager.messages[0].Severity, 3);
       assert.equal(monitorManager.messages[0].Fields.name, 'AssertionError');
     });
 
-    test('should monitor resource usage', async function() {
+    test('should monitor resource usage', async () => {
       monitor._resources('testy', 0.1);
       await testing.poll(async () => {
         assert(monitorManager.messages.some(message => message.Fields.lastCpuUsage !== undefined));

--- a/libraries/monitor/test/prometheus_test.js
+++ b/libraries/monitor/test/prometheus_test.js
@@ -44,7 +44,7 @@ MonitorManager.registerMetric('testingGlobalCounter', {
 
 const TEST_PORT = 39090;
 
-suite(testing.suiteName(), function() {
+suite(testing.suiteName(), () => {
   const configDefaults = {
     serviceName: 'testing-service',
     level: 'debug',
@@ -64,11 +64,11 @@ suite(testing.suiteName(), function() {
     },
   };
 
-  suiteTeardown(async function() {
+  suiteTeardown(async () => {
     nock.cleanAll();
   });
 
-  test('starts server and responds to metrics', async function() {
+  test('starts server and responds to metrics', async () => {
     const monitor = MonitorManager.setup(configDefaults);
     monitor.exposeMetrics();
     monitor.metric.testingServiceTestCounter(1);
@@ -82,7 +82,7 @@ suite(testing.suiteName(), function() {
     await monitor.terminate();
   });
 
-  test('server ignores other urls and methods', async function () {
+  test('server ignores other urls and methods', async () => {
     const monitor = MonitorManager.setup(configDefaults);
     monitor.exposeMetrics();
     await assert.rejects(
@@ -96,7 +96,7 @@ suite(testing.suiteName(), function() {
     await monitor.terminate();
   });
 
-  test('global metrics propagate to non-default registries on exposeMetrics', async function() {
+  test('global metrics propagate to non-default registries on exposeMetrics', async () => {
     const monitor = MonitorManager.setup({
       ...configDefaults,
       prometheusConfig: { server: { port: TEST_PORT } },
@@ -118,7 +118,7 @@ suite(testing.suiteName(), function() {
     }
   });
 
-  test('global metrics appear in default registry', async function() {
+  test('global metrics appear in default registry', async () => {
     const monitor = MonitorManager.setup({
       ...configDefaults,
       prometheusConfig: { server: { port: TEST_PORT } },
@@ -135,7 +135,7 @@ suite(testing.suiteName(), function() {
     }
   });
 
-  test('push gateway successfully sends metrics', async function() {
+  test('push gateway successfully sends metrics', async () => {
     const pushGateway = nock('http://push-gateway.test:9091')
       .put('/metrics/job/push-test-job/instance/test-instance', (body) => {
         return body.includes('http_requests_total') &&

--- a/libraries/monitor/test/registry_test.js
+++ b/libraries/monitor/test/registry_test.js
@@ -51,8 +51,8 @@ MonitorManager.register({
   },
 });
 
-suite(testing.suiteName(), function() {
-  test('can add custom message types', function() {
+suite(testing.suiteName(), () => {
+  test('can add custom message types', () => {
     const monitor = MonitorManager.setup({
       serviceName: 'taskcluster-testing-service',
       level: 'debug',
@@ -63,7 +63,7 @@ suite(testing.suiteName(), function() {
     assert.equal(monitor.manager.messages.length, 1);
   });
 
-  test('can verify custom types', function() {
+  test('can verify custom types', () => {
     const monitor = MonitorManager.setup({
       serviceName: 'taskcluster-testing-service',
       level: 'debug',
@@ -75,7 +75,7 @@ suite(testing.suiteName(), function() {
     assert.throws(() => monitor.log.auditLog({ foo: null }), /"auditLog" must include field "bar"/);
   });
 
-  test('can publish types', function() {
+  test('can publish types', () => {
     const serviceName = 'taskcluster-testing-service';
     assert.equal(MonitorManager.reference(serviceName).serviceName, serviceName);
     const ref = _.find(MonitorManager.reference(serviceName).types, { name: 'auditLog' });
@@ -86,7 +86,7 @@ suite(testing.suiteName(), function() {
     assert.deepEqual(ref.version, 1);
   });
 
-  test('can publish metrics in metrics reference', function() {
+  test('can publish metrics in metrics reference', () => {
     const serviceName = 'taskcluster-testing-service';
     const ref = MonitorManager.metricsReference(serviceName);
 
@@ -103,7 +103,7 @@ suite(testing.suiteName(), function() {
     assert.deepEqual(serviceMetric.buckets, [0.05, 0.1, 0.5, 1.0]);
   });
 
-  test('throws on duplicate metric registration', function() {
+  test('throws on duplicate metric registration', () => {
     assert.throws(() => {
       MonitorManager.registerMetric('aa1', {
         name: 'test_counter_xx',
@@ -124,7 +124,7 @@ suite(testing.suiteName(), function() {
     }, /Cannot register metric service_histogram_xx twice/);
   });
 
-  test('validates metric type and labels', function() {
+  test('validates metric type and labels', () => {
     assert.throws(() => {
       MonitorManager.registerMetric('aa3', {
         name: 'invalid_type_metric',
@@ -143,7 +143,7 @@ suite(testing.suiteName(), function() {
       });
     }, /Invalid label name 0invalid/);
   });
-  test('validates registers', function() {
+  test('validates registers', () => {
     assert.throws(() => {
       MonitorManager.registerMetric('aa5', {
         name: 'empty_registers',
@@ -155,7 +155,7 @@ suite(testing.suiteName(), function() {
     }, /Must provide at least one register/);
   });
 
-  test('can use metrics', async function() {
+  test('can use metrics', async () => {
     const monitor = MonitorManager.setup({
       serviceName: 'taskcluster-testing-service',
       level: 'debug',
@@ -191,7 +191,7 @@ suite(testing.suiteName(), function() {
       'expected shared metric in special registry');
   });
 
-  test('throws error when invalid metric names are used', async function () {
+  test('throws error when invalid metric names are used', async () => {
     const monitor = MonitorManager.setup({
       serviceName: 'taskcluster-testing-service',
       level: 'debug',

--- a/libraries/monitor/test/reporter_test.js
+++ b/libraries/monitor/test/reporter_test.js
@@ -2,11 +2,11 @@ import assert from 'node:assert';
 import testing from '@taskcluster/lib-testing';
 import MonitorManager from '../src/monitormanager.js';
 
-suite(testing.suiteName(), function() {
+suite(testing.suiteName(), () => {
 
-  suite('sentry', function() {
+  suite('sentry', () => {
     let monitor, reported;
-    setup(function() {
+    setup(() => {
       reported = null;
       monitor = MonitorManager.setup({
         serviceName: 'testing-service',
@@ -30,12 +30,12 @@ suite(testing.suiteName(), function() {
       });
     });
 
-    teardown(async function() {
+    teardown(async () => {
       await monitor.terminate();
       reported = null;
     });
 
-    test('simple error report', async function() {
+    test('simple error report', async () => {
       monitor.reportError(new Error('hi'));
       await monitor.terminate();
       assert.equal(reported.tags.service, 'testing-service');
@@ -43,7 +43,7 @@ suite(testing.suiteName(), function() {
       assert.equal(reported.release, '123:foo');
       assert.equal(reported.level, 'error');
     });
-    test('error report with level', async function() {
+    test('error report with level', async () => {
       monitor.reportError(new Error('hi'), 'notice');
       await monitor.terminate();
       assert.equal(reported.tags.service, 'testing-service');
@@ -51,7 +51,7 @@ suite(testing.suiteName(), function() {
       assert.equal(reported.release, '123:foo');
       assert.equal(reported.level, 'info');
     });
-    test('error report with tags', async function() {
+    test('error report with tags', async () => {
       monitor.reportError(new Error('hi'), { baz: 'bing' });
       await monitor.terminate();
       assert.equal(reported.tags.service, 'testing-service');
@@ -60,7 +60,7 @@ suite(testing.suiteName(), function() {
       assert.equal(reported.release, '123:foo');
       assert.equal(reported.level, 'error');
     });
-    test('error report with level and tags', async function() {
+    test('error report with level and tags', async () => {
       monitor.reportError(new Error('hi'), 'warning', { baz: 'bing' });
       await monitor.terminate();
       assert.equal(reported.tags.service, 'testing-service');

--- a/libraries/monitor/test/util_test.js
+++ b/libraries/monitor/test/util_test.js
@@ -2,27 +2,27 @@ import assert from 'node:assert';
 import { cleanupDescription } from '../src/util.js';
 import testing from '@taskcluster/lib-testing';
 
-suite(testing.suiteName(), function() {
-  test('empty string', function() {
+suite(testing.suiteName(), () => {
+  test('empty string', () => {
     assert.equal(cleanupDescription(''), '');
   });
 
-  test('one-line string', function() {
+  test('one-line string', () => {
     assert.equal(cleanupDescription('hello'), 'hello');
   });
 
-  test('two-line string with no indentation', function() {
+  test('two-line string with no indentation', () => {
     assert.equal(cleanupDescription('hello\nworld'), 'hello\nworld');
   });
 
-  test('two-line string with all but first indented', function() {
+  test('two-line string with all but first indented', () => {
     assert.equal(cleanupDescription(
       `hello
       world`),
     'hello\nworld');
   });
 
-  test('two-line string with all lines indented', function() {
+  test('two-line string with all lines indented', () => {
     assert.equal(cleanupDescription(
       `
       hello

--- a/libraries/postgres/src/Database.js
+++ b/libraries/postgres/src/Database.js
@@ -645,7 +645,7 @@ class Database {
        * @param {...any[]} args
        * @returns {Promise<pg.QueryResult>}
        */
-      query: async function(query, ...args) {
+      query: async (query, ...args) => {
         try {
           // it is important to keep await here, as we need to catch the error
           return await client.query(query, ...args);

--- a/libraries/postgres/test/access_test.js
+++ b/libraries/postgres/test/access_test.js
@@ -4,29 +4,29 @@ import { strict as assert } from 'node:assert';
 
 const __filename = new URL('', import.meta.url).pathname;
 
-suite(path.basename(__filename), function() {
-  suite('checking', function() {
-    test('not an object', function() {
+suite(path.basename(__filename), () => {
+  suite('checking', () => {
+    test('not an object', () => {
       assert.throws(
         () => Access.fromSerializable([]),
         /should define an object/);
     });
-    test('not an object of objects', function() {
+    test('not an object of objects', () => {
       assert.throws(
         () => Access.fromSerializable({ test: [] }),
         /should define an object/);
     });
-    test('service has keys aside from tables', function() {
+    test('service has keys aside from tables', () => {
       assert.throws(
         () => Access.fromSerializable({ test: { views: [] } }),
         /should only have a 'tables' property/);
     });
-    test('service tables is an array', function() {
+    test('service tables is an array', () => {
       assert.throws(
         () => Access.fromSerializable({ test: { tables: [] } }),
         /should be an object/);
     });
-    test('service tables has invalid mode', function() {
+    test('service tables has invalid mode', () => {
       assert.throws(
         () => Access.fromSerializable({ test: { tables: { test: 'admin' } } }),
         /should be read or write/);

--- a/libraries/postgres/test/database_test.js
+++ b/libraries/postgres/test/database_test.js
@@ -19,7 +19,7 @@ const monitor = helper.monitor;
 const __dirnname = new URL('.', import.meta.url).pathname;
 const __filename = new URL('', import.meta.url).pathname;
 
-helper.dbSuite(path.basename(__filename), function() {
+helper.dbSuite(path.basename(__filename), () => {
   let db;
 
   const versions = [
@@ -168,12 +168,12 @@ helper.dbSuite(path.basename(__filename), function() {
     });
   };
 
-  suiteTeardown(async function() {
+  suiteTeardown(async () => {
     db = new Database({ urlsByMode: { admin: helper.dbUrl } });
     await resetRoles(db);
   });
 
-  teardown(async function() {
+  teardown(async () => {
     if (db) {
       try {
         await db.close();
@@ -183,16 +183,16 @@ helper.dbSuite(path.basename(__filename), function() {
     }
   });
 
-  suite('db.currentVersion', function() {
-    setup(function() {
+  suite('db.currentVersion', () => {
+    setup(() => {
       db = new Database({ urlsByMode: { [READ]: helper.dbUrl, [WRITE]: helper.dbUrl } });
     });
 
-    test('currentVersion with no version set', async function() {
+    test('currentVersion with no version set', async () => {
       assert.equal(await db.currentVersion(), 0);
     });
 
-    test('currentVersion after set', async function() {
+    test('currentVersion after set', async () => {
       await db._withClient(WRITE, async client => {
         await client.query('begin');
         await client.query(`
@@ -207,19 +207,19 @@ helper.dbSuite(path.basename(__filename), function() {
     });
   });
 
-  suite('Database._checkPermissions', function() {
+  suite('Database._checkPermissions', () => {
     let db;
 
-    suiteSetup(async function() {
+    suiteSetup(async () => {
       db = new Database({ urlsByMode: { admin: helper.dbUrl } });
     });
 
-    suiteTeardown(async function() {
+    suiteTeardown(async () => {
       db = new Database({ urlsByMode: { admin: helper.dbUrl } });
       await resetRoles(db);
     });
 
-    setup(async function() {
+    setup(async () => {
       await createUsers(db);
       await db._withClient('admin', async client => {
         // create some tables for permissions
@@ -230,19 +230,19 @@ helper.dbSuite(path.basename(__filename), function() {
       });
     });
 
-    suiteTeardown(async function() {
+    suiteTeardown(async () => {
       await db.close();
     });
 
     const withAccess = access => Schema.fromSerializable({ access, tables: {}, versions: [] });
 
-    test('empty access.yml', async function() {
+    test('empty access.yml', async () => {
       const schema = withAccess({ service1: { tables: {} }, service2: { tables: {} } });
       await Database._checkPermissions({ db, schema, usernamePrefix: 'test' });
       // does not fail
     });
 
-    test('permissions missing', async function() {
+    test('permissions missing', async () => {
       const schema = withAccess({
         service1: { tables: { foo: 'read' } },
         service2: { tables: { foo: 'write' } },
@@ -251,7 +251,7 @@ helper.dbSuite(path.basename(__filename), function() {
         /missing database user grant: test_service1: SELECT on foo/);
     });
 
-    test('extra permissions', async function() {
+    test('extra permissions', async () => {
       await db._withClient('admin', async client => {
         await client.query('grant select on foo to test_service1');
         await client.query('grant select, insert, update, delete on foo to test_service2');
@@ -265,7 +265,7 @@ helper.dbSuite(path.basename(__filename), function() {
         /unexpected database user grant: test_service2: SELECT on bar/);
     });
 
-    test('extra column permissions', async function() {
+    test('extra column permissions', async () => {
       await db._withClient('admin', async client => {
         await client.query('grant select on foo to test_service1');
         await client.query('grant select, insert, update, delete on foo to test_service2');
@@ -280,7 +280,7 @@ helper.dbSuite(path.basename(__filename), function() {
         /unexpected database user grant: test_service2: SELECT on bar/);
     });
 
-    test('correct permissions', async function() {
+    test('correct permissions', async () => {
       await db._withClient('admin', async client => {
         await client.query('grant select on foo to test_service1');
         await client.query('grant select, insert, update, delete on foo to test_service2');
@@ -294,7 +294,7 @@ helper.dbSuite(path.basename(__filename), function() {
     });
 
     for (const attr of ['superuser', 'createdb', 'createrole', 'replication']) {
-      test(`user with ${attr} attribute`, async function() {
+      test(`user with ${attr} attribute`, async () => {
         await db._withClient('admin', async client => {
           await client.query('grant select on foo to test_service1');
           await client.query('grant select, insert, update, delete on foo to test_service2');
@@ -309,7 +309,7 @@ helper.dbSuite(path.basename(__filename), function() {
       });
     }
 
-    test(`user a member of badrole`, async function() {
+    test(`user a member of badrole`, async () => {
       await db._withClient('admin', async client => {
         await client.query('grant select on foo to test_service1');
         await client.query('grant select, insert, update, delete on foo to test_service2');
@@ -324,8 +324,8 @@ helper.dbSuite(path.basename(__filename), function() {
     });
   });
 
-  suite('Database.setup', function() {
-    test('setup creates JS methods that can be called', async function() {
+  suite('Database.setup', () => {
+    test('setup creates JS methods that can be called', async () => {
       await Database.upgrade({ schema, adminDbUrl: helper.dbUrl, usernamePrefix: 'test' });
       db = await Database.setup({ schema, readDbUrl: helper.dbUrl, writeDbUrl: helper.dbUrl, serviceName: 'service-1', monitor });
       await db.fns.testdata();
@@ -333,7 +333,7 @@ helper.dbSuite(path.basename(__filename), function() {
       assert.deepEqual(res.map(r => r.total).sort(), [16, 20]);
     });
 
-    test('setup moves deprecated methods to deprecatedFns', async function() {
+    test('setup moves deprecated methods to deprecatedFns', async () => {
       await Database.upgrade({ schema, adminDbUrl: helper.dbUrl, usernamePrefix: 'test' });
       db = await Database.setup({ schema, readDbUrl: helper.dbUrl, writeDbUrl: helper.dbUrl, serviceName: 'service-1', monitor });
       assert(!db.fns.old);
@@ -341,7 +341,7 @@ helper.dbSuite(path.basename(__filename), function() {
       assert.equal((await db.deprecatedFns.old('hi'))[0].old, 'got hi');
     });
 
-    test('non-numeric statementTimeout is not allowed', async function() {
+    test('non-numeric statementTimeout is not allowed', async () => {
       await assert.rejects(() => Database.setup({
         schema,
         readDbUrl: helper.dbUrl,
@@ -352,12 +352,12 @@ helper.dbSuite(path.basename(__filename), function() {
       }), err => err.code === 'ERR_ASSERTION');
     });
 
-    test('setup creates keyring', async function() {
+    test('setup creates keyring', async () => {
       db = await Database.setup({ schema, readDbUrl: helper.dbUrl, writeDbUrl: helper.dbUrl, serviceName: 'service-1', monitor });
       assert(db.keyring);
     });
 
-    test('methods do not allow SQL injection', async function() {
+    test('methods do not allow SQL injection', async () => {
       await Database.upgrade({ schema, adminDbUrl: helper.dbUrl, usernamePrefix: 'test' });
       db = await Database.setup({ schema, readDbUrl: helper.dbUrl, writeDbUrl: helper.dbUrl, serviceName: 'service-1', monitor });
       await db.fns.testdata();
@@ -365,7 +365,7 @@ helper.dbSuite(path.basename(__filename), function() {
       assert.equal(res[0].stringparam, "got ' or 1=1; --");
     });
 
-    test('passing too few parameters fails', async function() {
+    test('passing too few parameters fails', async () => {
       await Database.upgrade({ schema, adminDbUrl: helper.dbUrl, usernamePrefix: 'test' });
       db = await Database.setup({ schema, readDbUrl: helper.dbUrl, writeDbUrl: helper.dbUrl, serviceName: 'service-1', monitor });
       await db.fns.testdata();
@@ -374,7 +374,7 @@ helper.dbSuite(path.basename(__filename), function() {
         err => err.code === UNDEFINED_FUNCTION);
     });
 
-    test('passing too many parameters fails', async function() {
+    test('passing too many parameters fails', async () => {
       await Database.upgrade({ schema, adminDbUrl: helper.dbUrl, usernamePrefix: 'test' });
       db = await Database.setup({ schema, readDbUrl: helper.dbUrl, writeDbUrl: helper.dbUrl, serviceName: 'service-1', monitor });
       await db.fns.testdata();
@@ -383,7 +383,7 @@ helper.dbSuite(path.basename(__filename), function() {
         err => err.code === UNDEFINED_FUNCTION);
     });
 
-    test('slow methods are aborted if statementTimeout is set', async function() {
+    test('slow methods are aborted if statementTimeout is set', async () => {
       await Database.upgrade({ schema, adminDbUrl: helper.dbUrl, usernamePrefix: 'test' });
       db = await Database.setup({
         schema,
@@ -397,21 +397,21 @@ helper.dbSuite(path.basename(__filename), function() {
         err => err.code === QUERY_CANCELED);
     });
 
-    test('read-only methods are called in read-only transactions', async function() {
+    test('read-only methods are called in read-only transactions', async () => {
       await Database.upgrade({ schema, adminDbUrl: helper.dbUrl, usernamePrefix: 'test' });
       db = await Database.setup({ schema, readDbUrl: helper.dbUrl, writeDbUrl: helper.dbUrl, serviceName: 'service-1', monitor });
       await assert.rejects(() => db.fns.readonlywrites(),
         err => err.code === READ_ONLY_SQL_TRANSACTION);
     });
 
-    test('failing methods correctly reject', async function() {
+    test('failing methods correctly reject', async () => {
       await Database.upgrade({ schema, adminDbUrl: helper.dbUrl, usernamePrefix: 'test' });
       db = await Database.setup({ schema, readDbUrl: helper.dbUrl, writeDbUrl: helper.dbUrl, serviceName: 'service-1', monitor });
       await assert.rejects(() => db.fns.fail(),
         err => err.code === '0A000');
     });
 
-    test('do not allow service A to call any methods for service B which have mode=WRITE', async function() {
+    test('do not allow service A to call any methods for service B which have mode=WRITE', async () => {
       await Database.upgrade({ schema, adminDbUrl: helper.dbUrl, usernamePrefix: 'test' });
       const db = await Database.setup({ schema, readDbUrl: helper.dbUrl, writeDbUrl: helper.dbUrl, serviceName: 'service-2', monitor });
 
@@ -421,7 +421,7 @@ helper.dbSuite(path.basename(__filename), function() {
       await db.close();
     });
 
-    test('allow service A to call any methods for service A which have mode=WRITE', async function() {
+    test('allow service A to call any methods for service A which have mode=WRITE', async () => {
       await Database.upgrade({ schema, adminDbUrl: helper.dbUrl, usernamePrefix: 'test' });
       const db = await Database.setup({ schema, readDbUrl: helper.dbUrl, writeDbUrl: helper.dbUrl, serviceName: 'service-1', monitor });
 
@@ -431,7 +431,7 @@ helper.dbSuite(path.basename(__filename), function() {
       await db.close();
     });
 
-    test('allow service A to call any methods for service B which have mode=READ', async function() {
+    test('allow service A to call any methods for service B which have mode=READ', async () => {
       await Database.upgrade({ schema, adminDbUrl: helper.dbUrl, usernamePrefix: 'test' });
       const db = await Database.setup({ schema, readDbUrl: helper.dbUrl, writeDbUrl: helper.dbUrl, serviceName: 'service-1', monitor });
 
@@ -442,7 +442,7 @@ helper.dbSuite(path.basename(__filename), function() {
     });
   });
 
-  test('_validUsernamePrefix', function() {
+  test('_validUsernamePrefix', () => {
     assert(Database._validUsernamePrefix('a_b_c'));
     assert(!Database._validUsernamePrefix(''));
     assert(!Database._validUsernamePrefix('abc_123'));
@@ -452,8 +452,8 @@ helper.dbSuite(path.basename(__filename), function() {
     assert(!Database._validUsernamePrefix(`'; drop table clients`));
   });
 
-  suite('_checkTableColumns', function() {
-    setup(async function() {
+  suite('_checkTableColumns', () => {
+    setup(async () => {
       db = new Database({ urlsByMode: { admin: helper.dbUrl } });
       await createUsers(db);
     });
@@ -468,7 +468,7 @@ helper.dbSuite(path.basename(__filename), function() {
       return Schema.fromSerializable({ versions, access: {}, tables });
     };
 
-    test('validates a simple table with integer, timestamp, and text cols', async function() {
+    test('validates a simple table with integer, timestamp, and text cols', async () => {
       const schema = makeSchema(`
         begin
           create table testtable (
@@ -488,7 +488,7 @@ helper.dbSuite(path.basename(__filename), function() {
       await Database._checkTableColumns({ db, schema });
     });
 
-    test('fails when not null is omitted', async function() {
+    test('fails when not null is omitted', async () => {
       const schema = makeSchema(`
         begin
           create table testtable (
@@ -507,16 +507,16 @@ helper.dbSuite(path.basename(__filename), function() {
     });
   });
 
-  suite('encrypt/decrypt', function() {
+  suite('encrypt/decrypt', () => {
     const azureCryptoKey = 'aGVsbG8gZnV0dXJlIHBlcnNvbi4gaSdtIGJzdGFjawo=';
     const pgCryptoKey = 'aSdtIGJzdGFjayEgaGVsbG8gZnV0dXJlIHBlcnNvbgo=';
 
-    setup(async function() {
+    setup(async () => {
       db = await Database.setup({ schema, readDbUrl: helper.dbUrl, writeDbUrl: helper.dbUrl,
         serviceName: 'service-2', monitor, azureCryptoKey });
     });
 
-    test('encrypt/decrypt simple', async function() {
+    test('encrypt/decrypt simple', async () => {
       const encrypted = db.encrypt({ value: Buffer.from('hi') });
       assert.equal(encrypted.v, 0);
       assert.equal(encrypted.kid, 'azure');
@@ -529,7 +529,7 @@ helper.dbSuite(path.basename(__filename), function() {
       assert.equal(decrypted.toString(), 'hi');
     });
 
-    test('encrypt/decrypt multiple keys', async function() {
+    test('encrypt/decrypt multiple keys', async () => {
       const encrypted = db.encrypt({ value: Buffer.from('hi') });
       assert.equal(encrypted.v, 0);
       assert.equal(encrypted.kid, 'azure');
@@ -556,7 +556,7 @@ helper.dbSuite(path.basename(__filename), function() {
       }, /Crypto key not found: `foo`/);
     });
 
-    test('decrypt simple from lib-entities', async function() {
+    test('decrypt simple from lib-entities', async () => {
       // generated with:
       //   const entity = Entity.types.EncryptedText('val');
       //   const encrypted = {v: 0, kid: 'azure'};
@@ -572,7 +572,7 @@ helper.dbSuite(path.basename(__filename), function() {
       assert.equal(decrypted.toString(), 'abc');
     });
 
-    test('decrypt multi-chunk from lib-entities', async function() {
+    test('decrypt multi-chunk from lib-entities', async () => {
       const content = new Array(50000).fill(0).map((v, i) => String.fromCharCode(i % 65535)).join('');
 
       // generated with:
@@ -589,7 +589,7 @@ helper.dbSuite(path.basename(__filename), function() {
       assert.equal(decrypted.toString(), content);
     });
 
-    test('encrypt/decrypt errors without keys', async function() {
+    test('encrypt/decrypt errors without keys', async () => {
       const bad_db = await Database.setup({ schema, readDbUrl: helper.dbUrl, writeDbUrl: helper.dbUrl,
         serviceName: 'service-2', monitor });
       assert.throws(() => {
@@ -602,15 +602,15 @@ helper.dbSuite(path.basename(__filename), function() {
       }, /Crypto key not found: `azure`/);
     });
 
-    test('encrypt errors for non-buffers', async function() {
+    test('encrypt errors for non-buffers', async () => {
       assert.throws(() => {
         db.encrypt({ value: 'i am just a string' });
       }, /Encrypted values must be Buffers/);
     });
   });
 
-  suite('named arguments', async function () {
-    test('subtract two numbers', async function() {
+  suite('named arguments', async () => {
+    test('subtract two numbers', async () => {
       await Database.upgrade({ schema, adminDbUrl: helper.dbUrl, usernamePrefix: 'test' });
       db = await Database.setup({ schema, readDbUrl: helper.dbUrl, writeDbUrl: helper.dbUrl, serviceName: 'service-1', monitor });
 
@@ -622,7 +622,7 @@ helper.dbSuite(path.basename(__filename), function() {
       assert.equal(res[0].total, 3);
     });
 
-    test('throws when arguments do not end with "_in"', async function() {
+    test('throws when arguments do not end with "_in"', async () => {
       await Database.upgrade({ schema, adminDbUrl: helper.dbUrl, usernamePrefix: 'test' });
       db = await Database.setup({ schema, readDbUrl: helper.dbUrl, writeDbUrl: helper.dbUrl, serviceName: 'service-1', monitor });
       await assert.rejects(

--- a/libraries/postgres/test/helper.js
+++ b/libraries/postgres/test/helper.js
@@ -25,10 +25,10 @@ const helper = {
 if (testDbUrl) {
   helper.dbSuite = (...args) => {
     suite(...args.slice(0, -1), function() {
-      suiteSetup('setup database', function() {
+      suiteSetup('setup database', () => {
         helper.dbUrl = testDbUrl;
       });
-      setup('clear database', async function() {
+      setup('clear database', async () => {
         await clearDb(testDbUrl);
       });
       args[args.length - 1].call(this);
@@ -36,11 +36,11 @@ if (testDbUrl) {
   };
 } else {
   helper.dbSuite = (...args) => {
-    suite(...args.slice(0, -1), function() {
+    suite(...args.slice(0, -1), () => {
       if (process.env.NO_TEST_SKIP) {
         throw new Error(`TEST_DB_URL not set and NO_TEST_SKIP is set`);
       }
-      test.skip('(TEST_DB_URL is not set)', function() { });
+      test.skip('(TEST_DB_URL is not set)', () => { });
     });
   };
 }

--- a/libraries/postgres/test/keyring_test.js
+++ b/libraries/postgres/test/keyring_test.js
@@ -4,33 +4,33 @@ import { strict as assert } from 'node:assert';
 
 const __filename = new URL('', import.meta.url).pathname;
 
-suite(path.basename(__filename), function() {
+suite(path.basename(__filename), () => {
   const azureCryptoKey = 'aGVsbG8gZnV0dXJlIHBlcnNvbi4gaSdtIGJzdGFjawo=';
   const pgCryptoKey = 'aSdtIGJzdGFjayEgaGVsbG8gZnV0dXJlIHBlcnNvbgo=';
   const pgCryptoKey2 = 'dGhpcyBzdHJpbmcgaXMgbmljZSwgaSdtIGJzdGFjawo=';
 
-  test('no keys', function() {
+  test('no keys', () => {
     const keyring = new Keyring({});
     assert.throws(() => {
       keyring.currentCryptoKey('aes-256');
     }, /no current key is configured/);
   });
 
-  test('only azure', function() {
+  test('only azure', () => {
     const keyring = new Keyring({ azureCryptoKey });
     const { id, key } = keyring.currentCryptoKey('aes-256');
     assert.equal(id, 'azure');
     assert.equal(key.toString('base64'), azureCryptoKey);
   });
 
-  test('only pg (single key)', function() {
+  test('only pg (single key)', () => {
     const keyring = new Keyring({ dbCryptoKeys: [{ id: 'foo', algo: 'aes-256', key: pgCryptoKey }] });
     const { id, key } = keyring.currentCryptoKey('aes-256');
     assert.equal(id, 'foo');
     assert.equal(key.toString('base64'), pgCryptoKey);
   });
 
-  test('only pg (multiple keys)', function() {
+  test('only pg (multiple keys)', () => {
     const keyring = new Keyring({ dbCryptoKeys: [
       { id: 'foo', algo: 'aes-256', key: pgCryptoKey },
       { id: 'bar', algo: 'aes-256', key: pgCryptoKey2 },
@@ -43,14 +43,14 @@ suite(path.basename(__filename), function() {
     assert.equal(pgCryptoKey2, keyring.getCryptoKey('bar', 'aes-256').toString('base64'));
   });
 
-  test('pg and azure (single key)', function() {
+  test('pg and azure (single key)', () => {
     const keyring = new Keyring({ dbCryptoKeys: [{ id: 'foo', algo: 'aes-256', key: pgCryptoKey }] });
     const { id, key } = keyring.currentCryptoKey('aes-256');
     assert.equal(id, 'foo');
     assert.equal(key.toString('base64'), pgCryptoKey);
   });
 
-  test('pg and azure (multiple keys)', function() {
+  test('pg and azure (multiple keys)', () => {
     const keyring = new Keyring({ azureCryptoKey, dbCryptoKeys: [
       { id: 'foo', algo: 'aes-256', key: pgCryptoKey },
       { id: 'bar', algo: 'aes-256', key: pgCryptoKey2 },
@@ -64,31 +64,31 @@ suite(path.basename(__filename), function() {
     assert.equal(azureCryptoKey, keyring.getCryptoKey('azure', 'aes-256').toString('base64'));
   });
 
-  test('nonexistent algo', function() {
+  test('nonexistent algo', () => {
     assert.throws(() => {
       new Keyring({ dbCryptoKeys: [{ id: 'foo', algo: 'bad-algo', key: pgCryptoKey }] });
     }, /Got bad-algo for foo/);
   });
 
-  test('missing key', function() {
+  test('missing key', () => {
     assert.throws(() => {
       new Keyring({ dbCryptoKeys: [{ id: 'foo', algo: 'aes-256' }] });
     }, /Keyring crypto keys must have `key`/);
   });
 
-  test('missing id', function() {
+  test('missing id', () => {
     assert.throws(() => {
       new Keyring({ dbCryptoKeys: [{ algo: 'aes-256', key: pgCryptoKey }] });
     }, /Keyring crypto keys must have `id`/);
   });
 
-  test('missing algo', function() {
+  test('missing algo', () => {
     assert.throws(() => {
       new Keyring({ dbCryptoKeys: [{ id: 'foo', key: pgCryptoKey }] });
     }, /Keyring crypto keys must have `algo`/);
   });
 
-  test('bad key', function() {
+  test('bad key', () => {
     assert.throws(() => {
       new Keyring({ dbCryptoKeys: [{ id: 'foo', algo: 'aes-256', key: 'too-short' }] });
     }, /aes-256 key must be 32 bytes in base64 in foo/);

--- a/libraries/postgres/test/method_test.js
+++ b/libraries/postgres/test/method_test.js
@@ -7,8 +7,8 @@ const { omit } = _;
 
 const __filename = new URL('', import.meta.url).pathname;
 
-suite(path.basename(__filename), function() {
-  suite('_check', function() {
+suite(path.basename(__filename), () => {
+  suite('_check', () => {
     const method = {
       description: 'a method',
       mode: 'read',
@@ -18,55 +18,55 @@ suite(path.basename(__filename), function() {
       body: 'select *',
     };
 
-    test('name must be lowercase', function() {
+    test('name must be lowercase', () => {
       assert.throws(
         () => Method.fromYamlFileContent('tEsTmEthOd', method, 'file.yml'),
         /has capital letters/);
     });
 
-    test('description must exist', function() {
+    test('description must exist', () => {
       assert.throws(
         () => Method.fromYamlFileContent('testmethod', omit(method, ['description']), 'file.yml'),
         /is missing description/);
     });
 
-    test('mode must exist', function() {
+    test('mode must exist', () => {
       assert.throws(
         () => Method.fromYamlFileContent('testmethod', omit(method, ['mode']), 'file.yml'),
         /missing or bad mode/);
     });
 
-    test('mode must be valid', function() {
+    test('mode must be valid', () => {
       assert.throws(
         () => Method.fromYamlFileContent('testmethod', { ...omit(method, ['mode']), mode: 'admin' }, 'file.yml'),
         /missing or bad mode/);
     });
 
-    test('serviceName must exist', function() {
+    test('serviceName must exist', () => {
       assert.throws(
         () => Method.fromYamlFileContent('testmethod', omit(method, ['serviceName']), 'file.yml'),
         /missing serviceName/);
     });
 
-    test('args must exist', function() {
+    test('args must exist', () => {
       assert.throws(
         () => Method.fromYamlFileContent('testmethod', omit(method, ['args']), 'file.yml'),
         /missing args/);
     });
 
-    test('returns must exist', function() {
+    test('returns must exist', () => {
       assert.throws(
         () => Method.fromYamlFileContent('testmethod', omit(method, ['returns']), 'file.yml'),
         /missing returns/);
     });
 
-    test('body must exist', function() {
+    test('body must exist', () => {
       assert.throws(
         () => Method.fromYamlFileContent('testmethod', omit(method, ['body']), 'file.yml'),
         /missing body/);
     });
 
-    test('extra props forbidden', function() {
+    test('extra props forbidden', () => {
       assert.throws(
         () => Method.fromYamlFileContent('testmethod', { ...method, uhoh: 10 }, 'file.yml'),
         /unexpected properties/);

--- a/libraries/postgres/test/migration_test.js
+++ b/libraries/postgres/test/migration_test.js
@@ -27,7 +27,7 @@ import {
 
 const __filename = new URL('', import.meta.url).pathname;
 
-helper.dbSuite(path.basename(__filename), function() {
+helper.dbSuite(path.basename(__filename), () => {
   let db;
 
   const showProgress = debug('showProgress');
@@ -66,12 +66,12 @@ helper.dbSuite(path.basename(__filename), function() {
     });
   };
 
-  suiteTeardown(async function() {
+  suiteTeardown(async () => {
     db = new Database({ urlsByMode: { admin: helper.dbUrl } });
     await resetRoles(db);
   });
 
-  teardown(async function() {
+  teardown(async () => {
     if (db) {
       try {
         await db.close();
@@ -81,17 +81,17 @@ helper.dbSuite(path.basename(__filename), function() {
     }
   });
 
-  suite('runMigration', function() {
-    suiteSetup(async function() {
+  suite('runMigration', () => {
+    suiteSetup(async () => {
       db = new Database({ urlsByMode: { admin: helper.dbUrl } });
       await createUsers(db);
     });
 
-    setup(function() {
+    setup(() => {
       db = new Database({ urlsByMode: { [READ]: helper.dbUrl, 'admin': helper.dbUrl } });
     });
 
-    test('runs upgrade script with multiple statements and $db_user_prefix$', async function() {
+    test('runs upgrade script with multiple statements and $db_user_prefix$', async () => {
       await db._withClient('admin', async client => {
         await runMigration({
           client,
@@ -118,7 +118,7 @@ helper.dbSuite(path.basename(__filename), function() {
       });
     });
 
-    test('failure does not modify version', async function() {
+    test('failure does not modify version', async () => {
       try {
         await db._withClient('admin', async client => {
           await runMigration({
@@ -143,7 +143,7 @@ helper.dbSuite(path.basename(__filename), function() {
       throw new Error('runMigration did not fail');
     });
 
-    test('allows deprecated methods without failing', async function() {
+    test('allows deprecated methods without failing', async () => {
       await db._withClient('admin', async client => {
         await runMigration({
           client,
@@ -186,13 +186,13 @@ helper.dbSuite(path.basename(__filename), function() {
     });
   });
 
-  suite('runOnlineMigration/runOnlineDowngrade', function() {
-    suiteSetup(async function() {
+  suite('runOnlineMigration/runOnlineDowngrade', () => {
+    suiteSetup(async () => {
       db = new Database({ urlsByMode: { admin: helper.dbUrl } });
       await createUsers(db);
     });
 
-    setup(async function() {
+    setup(async () => {
       runOnlineBatches.resetHooks();
       db = new Database({ urlsByMode: { [READ]: helper.dbUrl, 'admin': helper.dbUrl } });
       await db._withClient('admin', async client => {
@@ -211,7 +211,7 @@ helper.dbSuite(path.basename(__filename), function() {
       });
     });
 
-    teardown(async function() {
+    teardown(async () => {
       await db._withClient('admin', async client => {
         await ignorePgErrors(client.query('drop table online_test'), UNDEFINED_TABLE);
       });
@@ -233,14 +233,14 @@ helper.dbSuite(path.basename(__filename), function() {
         language plpgsql`);
     };
 
-    test('does nothing when there is no batch function', async function() {
+    test('does nothing when there is no batch function', async () => {
       await db._withClient('admin', async client => {
         await runOnlineMigration({ client, showProgress, version: { version: 1 } });
       });
       // just doesn't throw anything..
     });
 
-    test('does nothing when the online migration is already complete', async function() {
+    test('does nothing when the online migration is already complete', async () => {
       await db._withClient('admin', async client => {
         await mkBatchFn({
           client,
@@ -261,7 +261,7 @@ helper.dbSuite(path.basename(__filename), function() {
       // just doesn't throw anything..
     });
 
-    test('runs a real migration', async function() {
+    test('runs a real migration', async () => {
       await db._withClient('admin', async client => {
         await client.query(`
           create table online_test as
@@ -323,7 +323,7 @@ helper.dbSuite(path.basename(__filename), function() {
       });
     });
 
-    test('batch function that just does one item per iteration', testing.runWithFakeTime(async function() {
+    test('batch function that just does one item per iteration', testing.runWithFakeTime(async () => {
       let itemsComplete = 0;
       runOnlineBatches.setHook('runBatch', async (batchSize, state) => {
         if (itemsComplete >= 1000) {
@@ -340,7 +340,7 @@ helper.dbSuite(path.basename(__filename), function() {
       assert.equal(itemsComplete, 1000);
     }, { maxTime: Infinity }));
 
-    test('batch function that returns 0 items early', testing.runWithFakeTime(async function() {
+    test('batch function that returns 0 items early', testing.runWithFakeTime(async () => {
       let itemsComplete = 0;
       let isCompleteCalls = 0;
       runOnlineBatches.setHook('runBatch', async (batchSize, state) => {
@@ -365,7 +365,7 @@ helper.dbSuite(path.basename(__filename), function() {
       assert.equal(isCompleteCalls, 12);
     }, { maxTime: Infinity }));
 
-    test('(downgrade) batch function that just does more items than requested per iteration', testing.runWithFakeTime(async function() {
+    test('(downgrade) batch function that just does more items than requested per iteration', testing.runWithFakeTime(async () => {
       let itemsComplete = 0;
       runOnlineBatches.setHook('runBatch', async (batchSize, state) => {
         if (itemsComplete >= 1000) {
@@ -384,8 +384,8 @@ helper.dbSuite(path.basename(__filename), function() {
     }));
   });
 
-  suite('runDowngrade', function() {
-    suiteSetup(async function() {
+  suite('runDowngrade', () => {
+    suiteSetup(async () => {
       db = new Database({ urlsByMode: { admin: helper.dbUrl } });
       await createUsers(db);
     });
@@ -455,7 +455,7 @@ helper.dbSuite(path.basename(__filename), function() {
       assert.equal(res.rows[0].test, v);
     };
 
-    setup(async function() {
+    setup(async () => {
       db = new Database({ urlsByMode: { [READ]: helper.dbUrl, 'admin': helper.dbUrl } });
       for (let version of [schema.getVersion(1), schema.getVersion(2), schema.getVersion(3)]) {
         await db._withClient('admin', async client => {
@@ -470,7 +470,7 @@ helper.dbSuite(path.basename(__filename), function() {
       }
     });
 
-    test('runs downgrade script with multiple statements and $db_user_prefix$', async function() {
+    test('runs downgrade script with multiple statements and $db_user_prefix$', async () => {
       await db._withClient('admin', async client => {
         await runDowngrade({
           client,
@@ -492,7 +492,7 @@ helper.dbSuite(path.basename(__filename), function() {
       });
     });
 
-    test('failure does not modify version', async function() {
+    test('failure does not modify version', async () => {
       await db._withClient('admin', async client => {
         await assert.rejects(
           async () => runDowngrade({
@@ -517,7 +517,7 @@ helper.dbSuite(path.basename(__filename), function() {
       });
     });
 
-    test('allows deprecated methods without failing', async function() {
+    test('allows deprecated methods without failing', async () => {
       await db._withClient('admin', async client => {
         await runMigration({
           client,

--- a/libraries/postgres/test/relations_test.js
+++ b/libraries/postgres/test/relations_test.js
@@ -4,19 +4,19 @@ import { strict as assert } from 'node:assert';
 
 const __filename = new URL('', import.meta.url).pathname;
 
-suite(path.basename(__filename), function() {
-  suite('checking', function() {
-    test('not an object', function() {
+suite(path.basename(__filename), () => {
+  suite('checking', () => {
+    test('not an object', () => {
       assert.throws(
         () => Relations._check([], 'f'),
         /should define an object/);
     });
-    test('not an object of objects', function() {
+    test('not an object of objects', () => {
       assert.throws(
         () => Relations.fromSerializable({ test: [] }, 'f'),
         /should define an object/);
     });
-    test('table column values are not strings', function() {
+    test('table column values are not strings', () => {
       assert.throws(
         () => Relations.fromSerializable({ test: { name: [] } }),
         /should be a string/);

--- a/libraries/postgres/test/schema_test.js
+++ b/libraries/postgres/test/schema_test.js
@@ -5,9 +5,9 @@ import { strict as assert } from 'node:assert';
 const __dirname = new URL('.', import.meta.url).pathname;
 const __filename = new URL('', import.meta.url).pathname;
 
-suite(path.basename(__filename), function() {
-  suite('fromDbDirectory', function() {
-    test('fromDbDirectory', function() {
+suite(path.basename(__filename), () => {
+  suite('fromDbDirectory', () => {
+    test('fromDbDirectory', () => {
       const sch = Schema.fromDbDirectory(path.join(__dirname, 'db-simple'));
       const ver2 = sch.latestVersion();
       assert.equal(ver2.version, 2);
@@ -30,7 +30,7 @@ suite(path.basename(__filename), function() {
       });
     });
 
-    test('fromDbDirectory with external SQL files', function() {
+    test('fromDbDirectory with external SQL files', () => {
       const sch = Schema.fromDbDirectory(path.join(__dirname, 'db-simple'));
       const ver1 = sch.getVersion(1);
       assert(ver1.migrationScript.startsWith('begin'));
@@ -39,33 +39,33 @@ suite(path.basename(__filename), function() {
       assert(ver2.methods.list_secrets.body.startsWith('begin'));
     });
 
-    test('disallow duplicate method names', function () {
+    test('disallow duplicate method names', () => {
       assert.throws(() => {
         Schema.fromDbDirectory(path.join(__dirname, 'db-with-duplicate-method-names'));
       }, /duplicated mapping key/);
     });
 
-    test('disallow gaps in version numbers', function () {
+    test('disallow gaps in version numbers', () => {
       assert.throws(() => {
         Schema.fromDbDirectory(path.join(__dirname, 'db-with-gaps'));
       }, /version 2 is missing/);
     });
 
-    test('disallow duplicate version numbers', function () {
+    test('disallow duplicate version numbers', () => {
       assert.throws(() => {
         Schema.fromDbDirectory(path.join(__dirname, 'db-with-dupes'));
       }, /duplicate version number 1 in/);
     });
 
-    test('allow method deprecations', function () {
+    test('allow method deprecations', () => {
       Schema.fromDbDirectory(path.join(__dirname, 'db-with-depr'));
       // does not crash..
     });
 
   });
 
-  suite('fromSerializable', function() {
-    test('fromSerializable', function() {
+  suite('fromSerializable', () => {
+    test('fromSerializable', () => {
       const sch = Schema.fromSerializable({
         access: {},
         tables: {},
@@ -90,7 +90,7 @@ suite(path.basename(__filename), function() {
     });
   });
 
-  suite('_checkMethodUpdates', function() {
+  suite('_checkMethodUpdates', () => {
     const versions = v2overrides => Schema.fromSerializable({
       versions: [
         {
@@ -125,32 +125,32 @@ suite(path.basename(__filename), function() {
       tables: {},
     }).versions;
 
-    test('method changes mode', function() {
+    test('method changes mode', () => {
       assert.throws(
         () => Schema._checkMethodUpdates(versions({ mode: 'write' })),
         /method whatever changed mode in version 2/);
     });
 
-    test('method changes serviceName', function() {
+    test('method changes serviceName', () => {
       assert.throws(
         () => Schema._checkMethodUpdates(versions({ serviceName: 'queue' })),
         /method whatever changed serviceName in version 2/);
     });
 
-    test('method changes args', function() {
+    test('method changes args', () => {
       assert.throws(
         () => Schema._checkMethodUpdates(versions({ args: 'x text' })),
         /method whatever changed args in version 2/);
     });
 
-    test('method changes returns', function() {
+    test('method changes returns', () => {
       assert.throws(
         () => Schema._checkMethodUpdates(versions({ returns: 'text' })),
         /method whatever changed returns in version 2/);
     });
   });
 
-  test('allMethods', function() {
+  test('allMethods', () => {
     const sch = Schema.fromDbDirectory(path.join(__dirname, 'db-simple'));
     assert.deepEqual([...sch.allMethods().map(meth => meth.name)].sort(),
       ['get_secret', 'list_secrets']);

--- a/libraries/postgres/test/util_test.js
+++ b/libraries/postgres/test/util_test.js
@@ -6,20 +6,20 @@ import path from 'node:path';
 const { range } = _;
 const __filename = new URL('', import.meta.url).pathname;
 
-suite(path.basename(__filename), function() {
-  suite('dollarQuote', function() {
-    test('simple string', function() {
+suite(path.basename(__filename), () => {
+  suite('dollarQuote', () => {
+    test('simple string', () => {
       assert.equal(dollarQuote('abcd'), '$$abcd$$');
     });
 
-    test('string containing $$', function() {
+    test('string containing $$', () => {
       assert.equal(dollarQuote('pre $$abcd$$ post'), '$x$pre $$abcd$$ post$x$');
     });
   });
 
-  suite('paginatedIterator', function() {
-    suite('offset/limit', function() {
-      test('iterate in a few batches', async function() {
+  suite('paginatedIterator', () => {
+    suite('offset/limit', () => {
+      test('iterate in a few batches', async () => {
         const calls = [];
         const fetch = async (size, offset) => {
           calls.push([size, offset]);
@@ -35,7 +35,7 @@ suite(path.basename(__filename), function() {
         assert.deepEqual(calls, range(0, 1000, 13).map(i => [13, i]).concat([[13, 1000]]));
       });
 
-      test('batch size smaller than requested', async function() {
+      test('batch size smaller than requested', async () => {
         const fetch = async (size, offset) => {
           return range(1000).slice(offset, offset + 10);
         };
@@ -48,7 +48,7 @@ suite(path.basename(__filename), function() {
         assert.deepEqual(got, range(1000));
       });
 
-      test('fetch fails', async function() {
+      test('fetch fails', async () => {
         const fetch = async (size, offset) => {
           if (offset > 300) {
             throw new Error('oh noes');
@@ -65,7 +65,7 @@ suite(path.basename(__filename), function() {
       });
     });
 
-    suite('index-based', function() {
+    suite('index-based', () => {
       const indexColumns = ['a', 'b'];
       const data = (A, B) => range(0, A).flatMap(a => range(0, B).map(b => ({ a, b })));
       let calls;
@@ -83,7 +83,7 @@ suite(path.basename(__filename), function() {
         };
       };
 
-      test('iterate in a few batches', async function() {
+      test('iterate in a few batches', async () => {
         calls = [];
         const got = [];
         for await (let v of paginatedIterator({
@@ -117,7 +117,7 @@ suite(path.basename(__filename), function() {
         ]);
       });
 
-      test('batch size smaller than requested', async function() {
+      test('batch size smaller than requested', async () => {
         const got = [];
         for await (let v of paginatedIterator({
           indexColumns,
@@ -130,7 +130,7 @@ suite(path.basename(__filename), function() {
         assert.deepEqual(got, data(20, 12));
       });
 
-      test('fetch fails', async function() {
+      test('fetch fails', async () => {
         assert.rejects(async () => {
           for await (let _ of paginatedIterator({
             indexColumns,

--- a/libraries/postgres/test/version_test.js
+++ b/libraries/postgres/test/version_test.js
@@ -4,37 +4,37 @@ import { strict as assert } from 'node:assert';
 
 const __filename = new URL('', import.meta.url).pathname;
 
-suite(path.basename(__filename), function() {
-  suite('Version._checkContent', function() {
-    test('version field required', function() {
+suite(path.basename(__filename), () => {
+  suite('Version._checkContent', () => {
+    test('version field required', () => {
       assert.throws(
         () => Version._checkContent({ migrationScript: 'yup', downgradeScript: 'check', methods: {} }, '0001.yml'),
         /version field missing/);
     });
 
-    test('downgradeScript field required if migrationScript present', function() {
+    test('downgradeScript field required if migrationScript present', () => {
       assert.throws(
         () => Version._checkContent({ version: 1, methods: {}, migrationScript: 'yep' }, '0001.yml'),
         /Cannot specify just one of/);
     });
 
-    test('migrationScript field required if downgradeScript present', function() {
+    test('migrationScript field required if downgradeScript present', () => {
       assert.throws(
         () => Version._checkContent({ version: 1, methods: {}, downgradeScript: 'yep' }, '0001.yml'),
         /Cannot specify just one of/);
     });
 
-    test('missing migrationScript and downgradeScript is OK', function() {
+    test('missing migrationScript and downgradeScript is OK', () => {
       Version._checkContent({ version: 1, methods: {} }, '0001.yml');
     });
 
-    test('methods field required', function() {
+    test('methods field required', () => {
       assert.throws(
         () => Version._checkContent({ version: 1, migrationScript: 'yep', downgradeScript: 'check' }, '0001.yml'),
         /methods field missing/);
     });
 
-    test('version does not match filename', function() {
+    test('version does not match filename', () => {
       assert.throws(
         () => Version._checkContent({ version: 2, migrationScript: 'yep', downgradeScript: 'check', methods: {} }, '0001.yml'),
         /must match version/);

--- a/libraries/pulse/src/consumer.js
+++ b/libraries/pulse/src/consumer.js
@@ -271,10 +271,10 @@ export class PulseConsumer {
 
     // Find CC'ed routes
     if (msg.properties?.headers && Array.isArray(msg.properties.headers.CC)) {
-      message.routes = msg.properties.headers.CC.filter(function(route) {
+      message.routes = msg.properties.headers.CC.filter((route) => {
         // Only return the CC'ed routes that starts with "route."
         return /^route\.(.*)$/.test(route);
-      }).map(function(route) {
+      }).map((route) => {
         // Remove the "route."
         return /^route\.(.*)$/.exec(route)[1];
       });

--- a/libraries/pulse/test/client_test.js
+++ b/libraries/pulse/test/client_test.js
@@ -6,7 +6,7 @@ import slugid from 'slugid';
 import helper from './helper.js';
 import { suiteName } from '@taskcluster/lib-testing';
 
-helper.secrets.mockSuite(suiteName(), ['pulse'], function(mock, skipping) {
+helper.secrets.mockSuite(suiteName(), ['pulse'], (mock, skipping) => {
   if (mock) {
     return; // Only test with real creds
   }
@@ -21,7 +21,7 @@ helper.secrets.mockSuite(suiteName(), ['pulse'], function(mock, skipping) {
   const debug = debugModule('test');
   const monitor = helper.monitor;
 
-  setup(async function() {
+  setup(async () => {
     connectionString = helper.secrets.get('pulse').connectionString;
     credentials = connectionStringCredentials(connectionString);
   });
@@ -44,7 +44,7 @@ helper.secrets.mockSuite(suiteName(), ['pulse'], function(mock, skipping) {
     debug('publish complete');
   };
 
-  test('start and immediately stop', async function() {
+  test('start and immediately stop', async () => {
     let gotConnection = false;
     const client = new Client({
       credentials,
@@ -58,7 +58,7 @@ helper.secrets.mockSuite(suiteName(), ['pulse'], function(mock, skipping) {
     assume(gotConnection).to.equal(false);
   });
 
-  test('activeConnection', async function() {
+  test('activeConnection', async () => {
     const client = new Client({
       credentials,
       retirementDelay: 50,
@@ -81,7 +81,7 @@ helper.secrets.mockSuite(suiteName(), ['pulse'], function(mock, skipping) {
     assume(client.activeConnection).to.equal(undefined);
   });
 
-  test('recycle interval', async function() {
+  test('recycle interval', async () => {
     let recycles = 0;
     const client = new Client({
       credentials,
@@ -103,7 +103,7 @@ helper.secrets.mockSuite(suiteName(), ['pulse'], function(mock, skipping) {
     assume(recycles).is.gt(5);
   });
 
-  test('minReconnectionInterval', async function() {
+  test('minReconnectionInterval', async () => {
     let connections = 0;
     const oldConnect = amqplib.connect;
     amqplib.connect = async () => {
@@ -131,7 +131,7 @@ helper.secrets.mockSuite(suiteName(), ['pulse'], function(mock, skipping) {
     assume(connections).is.between(5, 15);
   });
 
-  test('start and stop after connection is established', async function() {
+  test('start and stop after connection is established', async () => {
     const client = new Client({
       credentials,
       retirementDelay: 50,
@@ -147,7 +147,7 @@ helper.secrets.mockSuite(suiteName(), ['pulse'], function(mock, skipping) {
     });
   });
 
-  test('start, fail, and then stop', async function() {
+  test('start, fail, and then stop', async () => {
     const client = new Client({
       credentials,
       retirementDelay: 50,
@@ -166,7 +166,7 @@ helper.secrets.mockSuite(suiteName(), ['pulse'], function(mock, skipping) {
     });
   });
 
-  test('withConnection', async function() {
+  test('withConnection', async () => {
     const client = new Client({
       credentials,
       retirementDelay: 50,
@@ -192,10 +192,10 @@ helper.secrets.mockSuite(suiteName(), ['pulse'], function(mock, skipping) {
     assume([gotConnection, finishedWithConnection]).to.eqls([true, true]);
   });
 
-  suite('withChannel', function() {
+  suite('withChannel', () => {
     let client;
 
-    setup(function() {
+    setup(() => {
       if (skipping()) {
         return;
       }
@@ -209,7 +209,7 @@ helper.secrets.mockSuite(suiteName(), ['pulse'], function(mock, skipping) {
       });
     });
 
-    teardown(async function() {
+    teardown(async () => {
       if (skipping()) {
         return;
       }
@@ -217,7 +217,7 @@ helper.secrets.mockSuite(suiteName(), ['pulse'], function(mock, skipping) {
       await client.stop();
     });
 
-    test('asserting a queue', async function() {
+    test('asserting a queue', async () => {
       const queueName = client.fullObjectName('queue', slugid.v4());
 
       await client.withChannel(async chan => {
@@ -233,7 +233,7 @@ helper.secrets.mockSuite(suiteName(), ['pulse'], function(mock, skipping) {
       assume(queueInfo.queue).to.equal(queueName);
     });
 
-    test('with an error', async function() {
+    test('with an error', async () => {
       const queueName = client.fullObjectName('queue', slugid.v4());
 
       let gotException;
@@ -261,7 +261,7 @@ helper.secrets.mockSuite(suiteName(), ['pulse'], function(mock, skipping) {
       assume(client.connections.length).to.equal(1);
     });
 
-    test('binding nonexistent exchange', async function() {
+    test('binding nonexistent exchange', async () => {
       const queueName = client.fullObjectName('queue', slugid.v4());
 
       await client.withChannel(async chan => {
@@ -288,7 +288,7 @@ helper.secrets.mockSuite(suiteName(), ['pulse'], function(mock, skipping) {
     });
   });
 
-  test('consumer (with failures)', async function() {
+  test('consumer (with failures)', async () => {
     const client = new Client({
       credentials,
       retirementDelay: 50,

--- a/libraries/pulse/test/consumer_test.js
+++ b/libraries/pulse/test/consumer_test.js
@@ -7,18 +7,18 @@ import assert from 'node:assert';
 import helper from './helper.js';
 import { suiteName } from '@taskcluster/lib-testing';
 
-helper.secrets.mockSuite(suiteName(), ['pulse'], function(mock, skipping) {
+helper.secrets.mockSuite(suiteName(), ['pulse'], (mock, skipping) => {
   if (mock) {
     return; // Only test with real creds
   }
   let connectionString;
   const monitor = helper.monitor;
 
-  setup(async function() {
+  setup(async () => {
     connectionString = helper.secrets.get('pulse').connectionString;
   });
 
-  suite('PulseConsumer', function() {
+  suite('PulseConsumer', () => {
     // use a unique name for each test run, just to ensure nothing interferes
     const unique = Date.now().toString();
     const exchangeName = `exchanges/test/${unique}`;
@@ -30,7 +30,7 @@ helper.secrets.mockSuite(suiteName(), ['pulse'], function(mock, skipping) {
     ];
     const debug = debugModule('test');
 
-    suiteSetup(async function() {
+    suiteSetup(async () => {
 
       // otherwise, set up the exchange
       const conn = await amqplib.connect(connectionString);
@@ -69,7 +69,7 @@ helper.secrets.mockSuite(suiteName(), ['pulse'], function(mock, skipping) {
       });
     };
 
-    test('consume messages', async function() {
+    test('consume messages', async () => {
       const client = new Client({
         credentials: connectionStringCredentials(connectionString),
         retirementDelay: 50,
@@ -139,7 +139,7 @@ helper.secrets.mockSuite(suiteName(), ['pulse'], function(mock, skipping) {
       monitor.manager.messages = [];
     });
 
-    test('handle connection failure during consumption', async function() {
+    test('handle connection failure during consumption', async () => {
       const client = new Client({
         credentials: connectionStringCredentials(connectionString),
         retirementDelay: 50,
@@ -185,7 +185,7 @@ helper.secrets.mockSuite(suiteName(), ['pulse'], function(mock, skipping) {
       assume(numbers).to.deeply.equal([0, 1, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
     });
 
-    test('consume messages ephemerally', async function() {
+    test('consume messages ephemerally', async () => {
       const client = new Client({
         credentials: connectionStringCredentials(connectionString),
         retirementDelay: 50,
@@ -278,7 +278,7 @@ helper.secrets.mockSuite(suiteName(), ['pulse'], function(mock, skipping) {
       monitor.manager.messages = [];
     });
 
-    test('no queueName is an error', async function() {
+    test('no queueName is an error', async () => {
       const client = new Client({
         credentials: connectionStringCredentials(connectionString),
         retirementDelay: 50,

--- a/libraries/pulse/test/credentials_test.js
+++ b/libraries/pulse/test/credentials_test.js
@@ -3,8 +3,8 @@ import assert from 'node:assert';
 import assume from 'assume';
 import testing from '@taskcluster/lib-testing';
 
-suite(testing.suiteName(), function() {
-  test('missing arguments are an error', async function() {
+suite(testing.suiteName(), () => {
+  test('missing arguments are an error', async () => {
     assume(() => pulseCredentials({ password: 'pw', hostname: 'h', vhost: 'v' }))
       .throws(/username/);
     assume(() => pulseCredentials({ username: 'me', hostname: 'h', vhost: 'v' }))
@@ -15,7 +15,7 @@ suite(testing.suiteName(), function() {
       .throws(/vhost/);
   });
 
-  test('builds a connection string with given host', async function() {
+  test('builds a connection string with given host', async () => {
     const credentials = await pulseCredentials({
       username: 'me',
       password: 'letmein',
@@ -28,7 +28,7 @@ suite(testing.suiteName(), function() {
       'amqps://me:letmein@pulse.abc.com:5671/%2F?frameMax=0');
   });
 
-  test('builds a connection string with urlencoded values', async function() {
+  test('builds a connection string with urlencoded values', async () => {
     const credentials = await pulseCredentials({
       username: 'ali-escaper:/@\\|()<>&',
       password: 'bobby-tables:/@\\|()<>&',

--- a/libraries/pulse/test/publisher_test.js
+++ b/libraries/pulse/test/publisher_test.js
@@ -10,7 +10,7 @@ import { suiteName, poll } from '@taskcluster/lib-testing';
 
 const __dirname = new URL('.', import.meta.url).pathname;
 
-helper.secrets.mockSuite(suiteName(), ['pulse'], function(mock, skipping) {
+helper.secrets.mockSuite(suiteName(), ['pulse'], (mock, skipping) => {
   if (mock) {
     return; // Only test with real creds
   }
@@ -61,27 +61,27 @@ helper.secrets.mockSuite(suiteName(), ['pulse'], function(mock, skipping) {
 
   const monitor = helper.monitor;
 
-  setup(async function() {
+  setup(async () => {
     connectionString = helper.secrets.get('pulse').connectionString;
   });
 
-  suite('Exchanges', function() {
-    test('constructor args required', function() {
+  suite('Exchanges', () => {
+    test('constructor args required', () => {
       assume(() => new Exchanges({})).to.throw(/is required/);
     });
 
-    test('declare args required', function() {
+    test('declare args required', () => {
       const exchanges = new Exchanges(exchangeOptions);
       assume(() => exchanges.declare({})).to.throw(/is required/);
     });
 
-    test('declare routing key args required', function() {
+    test('declare routing key args required', () => {
       const exchanges = new Exchanges(exchangeOptions);
       assume(() => exchanges.declare({ ...declarationNoConstant, routingKey: [{}] }))
         .to.throw(/is required/);
     });
 
-    test('declare routing key too long fails', function() {
+    test('declare routing key too long fails', () => {
       const exchanges = new Exchanges(exchangeOptions);
       const routingKey = [
         {
@@ -108,27 +108,27 @@ helper.secrets.mockSuite(suiteName(), ['pulse'], function(mock, skipping) {
         .to.throw(/cannot be larger than/);
     });
 
-    test('declaration with same name fails', function() {
+    test('declaration with same name fails', () => {
       const exchanges = new Exchanges(exchangeOptions);
       exchanges.declare({ ...declarationNoConstant, name: 'x', exchange: 'xx' });
       assume(() => exchanges.declare({ ...declarationNoConstant, name: 'x', exchange: 'yy' }))
         .to.throw(/already declared/);
     });
 
-    test('declaration with same exchange fails', function() {
+    test('declaration with same exchange fails', () => {
       const exchanges = new Exchanges(exchangeOptions);
       exchanges.declare({ ...declarationNoConstant, name: 'x', exchange: 'xx' });
       assume(() => exchanges.declare({ ...declarationNoConstant, name: 'y', exchange: 'xx' }))
         .to.throw(/already declared/);
     });
 
-    test('sucessful declaration', function() {
+    test('sucessful declaration', () => {
       const exchanges = new Exchanges(exchangeOptions);
       exchanges.declare(declarationNoConstant);
       // doesn't throw anything..
     });
 
-    test('reference is correct, no constant routing key', function() {
+    test('reference is correct, no constant routing key', () => {
       const exchanges = new Exchanges(exchangeOptions);
       exchanges.declare(declarationNoConstant);
       assume(exchanges.reference()).to.deeply.equal({
@@ -156,7 +156,7 @@ helper.secrets.mockSuite(suiteName(), ['pulse'], function(mock, skipping) {
       });
     });
 
-    test('reference is correct, constant in the routing key', function() {
+    test('reference is correct, constant in the routing key', () => {
       const exchanges = new Exchanges(exchangeOptions);
       exchanges.declare(declarationConstant);
       assume(exchanges.reference()).to.deeply.equal({
@@ -185,12 +185,12 @@ helper.secrets.mockSuite(suiteName(), ['pulse'], function(mock, skipping) {
     });
   });
 
-  suite('PulsePublisher', function() {
+  suite('PulsePublisher', () => {
     // use a unique name for each test run, just to ensure nothing interferes
     const unique = `test-${Date.now()}`;
     let client, conn, chan, exchanges, schemaset, publisher, messages;
 
-    suiteSetup(async function() {
+    suiteSetup(async () => {
 
       client = new Client({
         credentials: connectionStringCredentials(connectionString),
@@ -236,21 +236,21 @@ helper.secrets.mockSuite(suiteName(), ['pulse'], function(mock, skipping) {
       });
     });
 
-    setup(function() {
+    setup(() => {
       messages = [];
     });
 
-    test('invalid message fails', async function() {
+    test('invalid message fails', async () => {
       await assume(publisher.eggHatched({ bogusThing: 'uhoh' }))
         .rejects();
     });
 
-    test('message with too-long routingKey fails', async function() {
+    test('message with too-long routingKey fails', async () => {
       await assume(publisher.eggHatched({ eggId: 'uhoh! '.repeat(100) }))
         .rejects();
     });
 
-    test('publish a message', async function() {
+    test('publish a message', async () => {
       await publisher.eggHatched({ eggId: 'yolks-on-you' });
 
       await poll(async () => {
@@ -276,7 +276,7 @@ helper.secrets.mockSuite(suiteName(), ['pulse'], function(mock, skipping) {
       });
     });
 
-    test('publish messages in parallel (with failed connections)', async function() {
+    test('publish messages in parallel (with failed connections)', async () => {
       await Promise.all(['a', 'b', 'c'].map(eggId => publisher.eggHatched({ eggId })));
       client.connections[0].amqp.close(); // force closure..
       await Promise.all(['i', 'j', 'k', 'l', 'm'].map(eggId => publisher.eggHatched({ eggId })));
@@ -289,7 +289,7 @@ helper.secrets.mockSuite(suiteName(), ['pulse'], function(mock, skipping) {
       });
     });
 
-    suiteTeardown(async function() {
+    suiteTeardown(async () => {
       if (!connectionString) {
         return;
       }

--- a/libraries/references/test/action_schema_test.js
+++ b/libraries/references/test/action_schema_test.js
@@ -3,7 +3,7 @@ import libUrls from 'taskcluster-lib-urls';
 import References from '../src/index.js';
 import testing from '@taskcluster/lib-testing';
 
-suite(testing.suiteName(), function() {
+suite(testing.suiteName(), () => {
   const rootUrl = libUrls.testRootUrl();
 
   let ajv;
@@ -36,7 +36,7 @@ suite(testing.suiteName(), function() {
     }
   };
 
-  test('empty list is OK', async function() {
+  test('empty list is OK', async () => {
     await validate({
       version: 1,
       variables: {},
@@ -44,7 +44,7 @@ suite(testing.suiteName(), function() {
     });
   });
 
-  test('action with bogus kind fails', async function() {
+  test('action with bogus kind fails', async () => {
     await validateFails({
       version: 1,
       variables: {},
@@ -54,7 +54,7 @@ suite(testing.suiteName(), function() {
     });
   });
 
-  test('task kind is OK', async function() {
+  test('task kind is OK', async () => {
     await validate({
       version: 1,
       variables: {},
@@ -70,7 +70,7 @@ suite(testing.suiteName(), function() {
     });
   });
 
-  test('hook kind is OK', async function() {
+  test('hook kind is OK', async () => {
     await validate({
       version: 1,
       variables: {},
@@ -88,7 +88,7 @@ suite(testing.suiteName(), function() {
     });
   });
 
-  test('action.extra is allowed', async function() {
+  test('action.extra is allowed', async () => {
     await validate({
       version: 1,
       variables: {},

--- a/libraries/references/test/built-services_test.js
+++ b/libraries/references/test/built-services_test.js
@@ -5,18 +5,18 @@ import References from '../src/index.js';
 import { getCommonSchemas } from '../src/common-schemas.js';
 import testing from '@taskcluster/lib-testing';
 
-suite(testing.suiteName(), function() {
-  suiteSetup(async function() {
+suite(testing.suiteName(), () => {
+  suiteSetup(async () => {
     // getCommonSchemas is memoized, but references files that are not present in the
     // mockFs, so fetch it once before setting up the mockFs.
     await getCommonSchemas();
   });
 
-  teardown(function() {
+  teardown(() => {
     mockFs.restore();
   });
 
-  test('fails on files in the input dir', async function() {
+  test('fails on files in the input dir', async () => {
     mockFs({ '/test/input/some.data': 'junk' });
 
     try {
@@ -39,7 +39,7 @@ suite(testing.suiteName(), function() {
     });
   };
 
-  test('reads references', async function() {
+  test('reads references', async () => {
     setupFs();
     const { references, schemas } = await load({ directory: '/test/input' });
     assert.deepEqual(references.map(ref => JSON.stringify(ref.content)).sort(), [
@@ -51,7 +51,7 @@ suite(testing.suiteName(), function() {
     assert.deepEqual(schemas, []);
   });
 
-  test('References.fromBuiltServices reads references and adds common', async function() {
+  test('References.fromBuiltServices reads references and adds common', async () => {
     setupFs();
     const references = await References.fromBuiltServices({ directory: '/test/input' });
     assert.deepEqual(references.references.map(ref => JSON.stringify(ref.content)).sort(), [
@@ -65,7 +65,7 @@ suite(testing.suiteName(), function() {
     assert(ids.some(id => id === '/schemas/common/manifest-v3.json#'));
   });
 
-  test('reads schemas at all nesting levels', async function() {
+  test('reads schemas at all nesting levels', async () => {
     mockFs({
       '/test/input/svc1/metadata.json': '{"version": 1}',
       '/test/input/svc1/schemas': {

--- a/libraries/references/test/common-schemas_test.js
+++ b/libraries/references/test/common-schemas_test.js
@@ -2,8 +2,8 @@ import assert from 'node:assert';
 import { getCommonSchemas } from '../src/common-schemas.js';
 import testing from '@taskcluster/lib-testing';
 
-suite(testing.suiteName(), function() {
-  test('loads common schemas', async function() {
+suite(testing.suiteName(), () => {
+  test('loads common schemas', async () => {
     const schemas = await getCommonSchemas();
     assert(schemas.some(
       ({ content, filename }) => content.$id === '/schemas/common/api-reference-v0.json#'));

--- a/libraries/references/test/metaschema_test.js
+++ b/libraries/references/test/metaschema_test.js
@@ -3,10 +3,10 @@ import References from '../src/index.js';
 import libUrls from 'taskcluster-lib-urls';
 import testing from '@taskcluster/lib-testing';
 
-suite(testing.suiteName(), function() {
+suite(testing.suiteName(), () => {
   let validate;
 
-  suiteSetup('setup Ajv', function() {
+  suiteSetup('setup Ajv', () => {
     let _ajv;
     const getAjv = async () => {
       if (!_ajv) {
@@ -43,38 +43,38 @@ suite(testing.suiteName(), function() {
     };
   });
 
-  suite('metadata-metaschema', function() {
+  suite('metadata-metaschema', () => {
     const $schema = 'https://tc-tests.example.com/schemas/common/metadata-metaschema.json#';
     const metadata = { name: 'sch', version: 1 };
 
-    test('metadata is required', async function() {
+    test('metadata is required', async () => {
       await validate({
         $schema,
       }, f => f.match(/schema must have required property 'metadata'/));
     });
 
-    test('metadata.name is required', async function() {
+    test('metadata.name is required', async () => {
       await validate({
         $schema,
         metadata: { version: 0 },
       }, f => f.match(/schema.metadata must have required property 'name'/));
     });
 
-    test('metadata.version is required', async function() {
+    test('metadata.version is required', async () => {
       await validate({
         $schema,
         metadata: { name: 'foo' },
       }, f => f.match(/schema.metadata must have required property 'version'/));
     });
 
-    test('metadata.otherProperty is forbidden', async function() {
+    test('metadata.otherProperty is forbidden', async () => {
       await validate({
         $schema,
         metadata: { name: 'foo', version: 0, otherProperty: 'foo' },
       }, f => f.match(/schema.metadata must NOT have additional properties/));
     });
 
-    test('fully specified schema is valid', async function() {
+    test('fully specified schema is valid', async () => {
       await validate({
         $schema, metadata,
       });

--- a/libraries/references/test/references_test.js
+++ b/libraries/references/test/references_test.js
@@ -6,8 +6,8 @@ import mockFs from 'mock-fs';
 import References from '../src/index.js';
 import testing from '@taskcluster/lib-testing';
 
-suite(testing.suiteName(), function() {
-  teardown(function() {
+suite(testing.suiteName(), () => {
+  teardown(() => {
     mockFs.restore();
   });
 
@@ -18,13 +18,13 @@ suite(testing.suiteName(), function() {
     });
   };
 
-  test('getSchema', async function() {
+  test('getSchema', async () => {
     assert.equal(
       (await getReferences()).getSchema('/schemas/common/manifest-v3.json#').$id,
       '/schemas/common/manifest-v3.json#');
   });
 
-  test('fromService', async function() {
+  test('fromService', async () => {
     // mock SchemaSet from @taskcluster/lib-validate
     const schemaset = {
       abstractSchemas() {
@@ -49,14 +49,14 @@ suite(testing.suiteName(), function() {
     assert(references.schemas.some(s => s.content.$id === 'somefile.json#'));
   });
 
-  test('makeSerializable', async function() {
+  test('makeSerializable', async () => {
     const references = await getReferences();
     assert.deepEqual(
       references.makeSerializable(),
       makeSerializable({ references }));
   });
 
-  test('writes uri-structured', async function() {
+  test('writes uri-structured', async () => {
     mockFs({});
     const references = new References({
       references: [
@@ -103,12 +103,12 @@ suite(testing.suiteName(), function() {
     });
   });
 
-  test('empty references pass validation', function() {
+  test('empty references pass validation', () => {
     const references = new References({ references: [], schemas: [] });
     references.validate();
   });
 
-  test('bogus references fail validation', function() {
+  test('bogus references fail validation', () => {
     const references = new References({ references: [], schemas: [
       { filename: 'bogus.json', content: {} },
     ] });

--- a/libraries/references/test/serializable_test.js
+++ b/libraries/references/test/serializable_test.js
@@ -5,7 +5,7 @@ import { getCommonSchemas } from '../src/common-schemas.js';
 import libUrls from 'taskcluster-lib-urls';
 import testing from '@taskcluster/lib-testing';
 
-suite(testing.suiteName(), function() {
+suite(testing.suiteName(), () => {
   const rootUrl = libUrls.testRootUrl();
 
   const assert_file = (serializable, filename, content) => {
@@ -49,7 +49,7 @@ suite(testing.suiteName(), function() {
     }],
   });
 
-  test('generates an abstract manifest', async function() {
+  test('generates an abstract manifest', async () => {
     const references = await getReferences();
     const serializable = makeSerializable({ references });
     assert_file(serializable, 'references/manifest.json', {
@@ -61,7 +61,7 @@ suite(testing.suiteName(), function() {
     });
   });
 
-  test('generates an absolute manifest', async function() {
+  test('generates an absolute manifest', async () => {
     const references = await getReferences();
     const serializable = makeSerializable({ references: references.asAbsolute(rootUrl) });
     assert_file(serializable, 'references/manifest.json', {
@@ -73,7 +73,7 @@ suite(testing.suiteName(), function() {
     });
   });
 
-  test('generates abstract schema filenames', async function() {
+  test('generates abstract schema filenames', async () => {
     const references = await getReferences();
     const serializable = makeSerializable({ references });
     assert_file(serializable, 'schemas/common/api-reference-v0.json', content => {
@@ -82,7 +82,7 @@ suite(testing.suiteName(), function() {
     });
   });
 
-  test('generates absolute schema filenames', async function() {
+  test('generates absolute schema filenames', async () => {
     const references = await getReferences();
     const serializable = makeSerializable({ references: references.asAbsolute(rootUrl) });
     assert_file(serializable, 'schemas/common/api-reference-v0.json', content => {
@@ -91,7 +91,7 @@ suite(testing.suiteName(), function() {
     });
   });
 
-  test('generates an API reference filename', async function() {
+  test('generates an API reference filename', async () => {
     const references = await getReferences();
     const serializable = makeSerializable({ references });
     assert_file(serializable, 'references/test/v1/api.json', {
@@ -104,7 +104,7 @@ suite(testing.suiteName(), function() {
     });
   });
 
-  test('generates an exchanges reference filename', async function() {
+  test('generates an exchanges reference filename', async () => {
     const references = await getReferences();
     const serializable = makeSerializable({ references });
     assert_file(serializable, 'references/test2/v2/exchanges.json', {
@@ -118,7 +118,7 @@ suite(testing.suiteName(), function() {
     });
   });
 
-  test('References.fromSerializable', function() {
+  test('References.fromSerializable', () => {
     References.fromSerializable({
       serializable: [{
         filename: 'schemas/common/foo.json',

--- a/libraries/references/test/uri-structured_test.js
+++ b/libraries/references/test/uri-structured_test.js
@@ -5,12 +5,12 @@ import { readUriStructured, writeUriStructured } from '../src/uri-structured.js'
 import mockFs from 'mock-fs';
 import testing from '@taskcluster/lib-testing';
 
-suite(testing.suiteName(), function() {
-  teardown(function() {
+suite(testing.suiteName(), () => {
+  teardown(() => {
     mockFs.restore();
   });
 
-  test('writes files', async function() {
+  test('writes files', async () => {
     mockFs({});
 
     // write some data to check later that it's deleted
@@ -35,7 +35,7 @@ suite(testing.suiteName(), function() {
     assert.equal(await fs.readFile('/refdata/abc.json'), '"abc"');
   });
 
-  test('reads files', async function() {
+  test('reads files', async () => {
     mockFs({
       '/data/schemas/common/foo.json': '{"foo": "true"}',
       '/data/references/something/bar.json': '{"bar": "true"}',
@@ -50,7 +50,7 @@ suite(testing.suiteName(), function() {
     }]);
   });
 
-  test('fromUriStructured', async function() {
+  test('fromUriStructured', async () => {
     mockFs({
       '/data/schemas/common/foo.json':
         '{"foo": "true", "$id": "/schemas/common/foo.json", "$schema": "http://json-schema.org/draft-06/schema#"}',

--- a/libraries/references/test/validate_test.js
+++ b/libraries/references/test/validate_test.js
@@ -85,7 +85,7 @@ class RefBuilder {
   }
 }
 
-suite(testing.suiteName(), function() {
+suite(testing.suiteName(), () => {
   const assertProblems = (references, expected) => {
     try {
       validate(references);
@@ -101,14 +101,14 @@ suite(testing.suiteName(), function() {
     }
   };
 
-  test('empty references pass', async function() {
+  test('empty references pass', async () => {
     (new RefBuilder()).then(references => {
       references.end();
       assertProblems(references, []);
     });
   });
 
-  test('schema with no $id fails', async function() {
+  test('schema with no $id fails', async () => {
     (new RefBuilder()).then(async (references) => {
       references.schema({ omitPaths: ['$id'] })
         .end();
@@ -116,7 +116,7 @@ suite(testing.suiteName(), function() {
     });
   });
 
-  test('schema with invalid $id fails', async function() {
+  test('schema with invalid $id fails', async () => {
     (new RefBuilder()).then(async (references) => {
       references.schema({ $id: '/schemas/foo.yml' })
         .end();
@@ -127,7 +127,7 @@ suite(testing.suiteName(), function() {
     });
   });
 
-  test('schema with invalid absolute $ref fails', async function() {
+  test('schema with invalid absolute $ref fails', async () => {
     (new RefBuilder()).then(async (references) => {
       references.schema({
         type: 'object',
@@ -142,7 +142,7 @@ suite(testing.suiteName(), function() {
     });
   });
 
-  test('schema with invalid relative $ref fails', async function() {
+  test('schema with invalid relative $ref fails', async () => {
     (new RefBuilder()).then(async (references) => {
       references.schema({
         type: 'object',
@@ -157,7 +157,7 @@ suite(testing.suiteName(), function() {
     });
   });
 
-  test('schema with no metaschema fails', async function() {
+  test('schema with no metaschema fails', async () => {
     (new RefBuilder()).then(async (references) => {
       references.schema({ omitPaths: ['$schema'] })
         .end();
@@ -165,7 +165,7 @@ suite(testing.suiteName(), function() {
     });
   });
 
-  test('common schema with custom metaschema passes', async function() {
+  test('common schema with custom metaschema passes', async () => {
     (new RefBuilder()).then(async (references) => {
       references.schema({
         $id: '/schemas/common/some-format.json#',
@@ -177,7 +177,7 @@ suite(testing.suiteName(), function() {
     });
   });
 
-  test('invalid schema fails', async function() {
+  test('invalid schema fails', async () => {
     (new RefBuilder()).then(async (references) => {
       references.schema({
         type: 'object',
@@ -194,7 +194,7 @@ suite(testing.suiteName(), function() {
     });
   });
 
-  test('schema with "entries" but no "type" fails', async function() {
+  test('schema with "entries" but no "type" fails', async () => {
     (new RefBuilder()).then(async (references) => {
       references.schema({
         entries: { type: 'string' },
@@ -207,7 +207,7 @@ suite(testing.suiteName(), function() {
     });
   });
 
-  test('schema with "entries" but no "uniqueItems" fails', async function() {
+  test('schema with "entries" but no "uniqueItems" fails', async () => {
     (new RefBuilder()).then(async (references) => {
       references.schema({
         type: 'array',
@@ -220,7 +220,7 @@ suite(testing.suiteName(), function() {
     });
   });
 
-  test('schema with "properties" but no "type" fails', async function() {
+  test('schema with "properties" but no "type" fails', async () => {
     (new RefBuilder()).then(async (references) => {
       references.schema({
         properties: {},
@@ -233,7 +233,7 @@ suite(testing.suiteName(), function() {
     });
   });
 
-  test('schema with "properties" but no "additionalProperties" fails', async function() {
+  test('schema with "properties" but no "additionalProperties" fails', async () => {
     (new RefBuilder()).then(async (references) => {
       references.schema({
         type: 'object',
@@ -246,7 +246,7 @@ suite(testing.suiteName(), function() {
     });
   });
 
-  test('invalid schema with custom metaschema fails', async function() {
+  test('invalid schema with custom metaschema fails', async () => {
     (new RefBuilder()).then(async (references) => {
       references.schema({
         $schema: '/schemas/common/metadata-metaschema.json#',
@@ -259,7 +259,7 @@ suite(testing.suiteName(), function() {
     });
   });
 
-  test('schema with undefined metaschema fails', async function() {
+  test('schema with undefined metaschema fails', async () => {
     (new RefBuilder()).then(async (references) => {
       references.schema({ $schema: '/schemas/nosuch.json#' })
         .end();
@@ -269,7 +269,7 @@ suite(testing.suiteName(), function() {
     });
   });
 
-  test('api reference with no $schema fails', async function() {
+  test('api reference with no $schema fails', async () => {
     (new RefBuilder()).then(async (references) => {
       references.apiref({ omitPaths: ['$schema'] })
         .end();
@@ -277,7 +277,7 @@ suite(testing.suiteName(), function() {
     });
   });
 
-  test('exchanges reference with no $schema fails', async function() {
+  test('exchanges reference with no $schema fails', async () => {
     (new RefBuilder()).then(async (references) => {
       references.exchangesref({ omitPaths: ['$schema'] })
         .end();
@@ -285,7 +285,7 @@ suite(testing.suiteName(), function() {
     });
   });
 
-  test('invalid api reference fails', async function() {
+  test('invalid api reference fails', async () => {
     (new RefBuilder()).then(async (references) => {
       references.apiref({ serviceName: true })
         .end();
@@ -295,7 +295,7 @@ suite(testing.suiteName(), function() {
     });
   });
 
-  test('invalid exchanges reference fails', async function() {
+  test('invalid exchanges reference fails', async () => {
     (new RefBuilder()).then(async (references) => {
       references.schema({ $id: '/schemas/test/v2/message.json#' })
         .exchangesref({ title: false })
@@ -306,7 +306,7 @@ suite(testing.suiteName(), function() {
     });
   });
 
-  test('reference with undefined $schema fails', async function() {
+  test('reference with undefined $schema fails', async () => {
     (new RefBuilder()).then(async (references) => {
       references.apiref({ $schema: '/schemas/nosuch.json#' })
         .end();
@@ -316,7 +316,7 @@ suite(testing.suiteName(), function() {
     });
   });
 
-  test('reference with non-metadata metaschema fails', async function() {
+  test('reference with non-metadata metaschema fails', async () => {
     (new RefBuilder()).then(async (references) => {
       references.apiref({ $schema: '/schemas/common/metadata-metaschema.json#' })
         .end();
@@ -328,7 +328,7 @@ suite(testing.suiteName(), function() {
     });
   });
 
-  test('exchanges reference with absolute entry schema URL fails', async function() {
+  test('exchanges reference with absolute entry schema URL fails', async () => {
     (new RefBuilder()).then(async (references) => {
       references.exchangesref({ entries: [{ schema: 'https://schemas.exmaple.com/message.json#' }] })
         .end();
@@ -338,7 +338,7 @@ suite(testing.suiteName(), function() {
     });
   });
 
-  test('exchanges reference with /-relative entry schema (that exists) fails', async function() {
+  test('exchanges reference with /-relative entry schema (that exists) fails', async () => {
     (new RefBuilder()).then(async (references) => {
       references.schema({ $id: '/schemas/test/v2/message.json#' })
         .exchangesref({ entries: [{ schema: '/schemas/test/v2/message.json#' }] })
@@ -349,7 +349,7 @@ suite(testing.suiteName(), function() {
     });
   });
 
-  test('exchanges reference with ../-relative entry schema (that exists) fails', async function() {
+  test('exchanges reference with ../-relative entry schema (that exists) fails', async () => {
     (new RefBuilder()).then(async (references) => {
       references.schema({ $id: '/schemas/test/v2/message.json#' })
         .exchangesref({ entries: [{ schema: '../test/v2/message.json#' }] })
@@ -360,7 +360,7 @@ suite(testing.suiteName(), function() {
     });
   });
 
-  test('exchanges reference with entry schema that does not exist fails', async function() {
+  test('exchanges reference with entry schema that does not exist fails', async () => {
     (new RefBuilder()).then(async (references) => {
       references.exchangesref({ entries: [{ schema: 'v2/message.json#' }] })
         .end();
@@ -370,7 +370,7 @@ suite(testing.suiteName(), function() {
     });
   });
 
-  test('api reference with absolute entry input URL fails', async function() {
+  test('api reference with absolute entry input URL fails', async () => {
     (new RefBuilder()).then(async (references) => {
       references.apiref({ entries: [{ input: 'https://schemas.exmaple.com/resource.json#' }] })
         .end();
@@ -380,7 +380,7 @@ suite(testing.suiteName(), function() {
     });
   });
 
-  test('api reference with /-relative entry input (that exists) fails', async function() {
+  test('api reference with /-relative entry input (that exists) fails', async () => {
     (new RefBuilder()).then(async (references) => {
       references.schema({ $id: '/schemas/test/v2/resource.json#' })
         .apiref({ entries: [{ input: '/schemas/test/v2/resource.json#' }] })
@@ -391,7 +391,7 @@ suite(testing.suiteName(), function() {
     });
   });
 
-  test('api reference with entry input that does not exist fails', async function() {
+  test('api reference with entry input that does not exist fails', async () => {
     (new RefBuilder()).then(async (references) => {
       references.apiref({ entries: [{ input: 'v2/resource.json#' }] })
         .end();
@@ -401,7 +401,7 @@ suite(testing.suiteName(), function() {
     });
   });
 
-  test('api reference with absolute entry output URL fails', async function() {
+  test('api reference with absolute entry output URL fails', async () => {
     (new RefBuilder()).then(async (references) => {
       references.apiref({ entries: [{ output: 'https://schemas.exmaple.com/resource.json#' }] })
         .end();
@@ -411,7 +411,7 @@ suite(testing.suiteName(), function() {
     });
   });
 
-  test('api reference with /-relative entry output (that exists) fails', async function() {
+  test('api reference with /-relative entry output (that exists) fails', async () => {
     (new RefBuilder()).then(async (references) => {
       references.schema({ $id: '/schemas/test/v2/resource.json#' })
         .apiref({ entries: [{ output: '/schemas/test/v2/resource.json#' }] })
@@ -422,7 +422,7 @@ suite(testing.suiteName(), function() {
     });
   });
 
-  test('api reference with entry output that does not exist fails', async function() {
+  test('api reference with entry output that does not exist fails', async () => {
     (new RefBuilder()).then(async (references) => {
       references.apiref({ entries: [{ output: 'v2/resource.json#' }] })
         .end();
@@ -432,7 +432,7 @@ suite(testing.suiteName(), function() {
     });
   });
 
-  test('api reference with entry output that exists but has wrong $schema fails', async function() {
+  test('api reference with entry output that exists but has wrong $schema fails', async () => {
     (new RefBuilder()).then(async (references) => {
       references.schema({
         $schema: 'http://json-schema.org/draft-06/schema#',
@@ -446,7 +446,7 @@ suite(testing.suiteName(), function() {
     });
   });
 
-  test('api reference with entry output that exists but has right $schema passes', async function() {
+  test('api reference with entry output that exists but has right $schema passes', async () => {
     (new RefBuilder()).then(async (references) => {
       references.schema({
         $schema: 'https://tc-tests.example.com/schemas/common/metaschema.json#',
@@ -458,7 +458,7 @@ suite(testing.suiteName(), function() {
     });
   });
 
-  test('service schema referenced by service passes', async function() {
+  test('service schema referenced by service passes', async () => {
     (new RefBuilder()).then(async (references) => {
       references.schema({
         $id: '/schemas/test/test.json#',
@@ -471,7 +471,7 @@ suite(testing.suiteName(), function() {
     });
   });
 
-  test('service schema *not* referenced by service fails', async function() {
+  test('service schema *not* referenced by service fails', async () => {
     (new RefBuilder()).then(async (references) => {
       references.schema({
         $id: '/schemas/test/test.json#',

--- a/libraries/testing/src/fakeauth.js
+++ b/libraries/testing/src/fakeauth.js
@@ -8,7 +8,7 @@ import taskcluster from '@taskcluster/client';
 
 let anonymousScopes = [];
 
-export const start = function(clients, { rootUrl } = {}) {
+export const start = (clients, { rootUrl } = {}) => {
   assert(rootUrl, 'rootUrl option is required');
   const authPath = URL.parse(libUrls.api(rootUrl, 'auth', 'v1', '/authenticate-hawk'))?.pathname;
   assert(authPath, 'invalid rootUrl');
@@ -16,7 +16,7 @@ export const start = function(clients, { rootUrl } = {}) {
     .persist()
     .filteringRequestBody(/.*/, '*')
     .post(authPath, '*')
-    .reply(200, function(uri, body) {
+    .reply(200, (uri, body) => {
       let scopes = [];
       let from = 'client config';
       let ext = null;
@@ -80,7 +80,7 @@ export const start = function(clients, { rootUrl } = {}) {
     });
 };
 
-export const stop = function() {
+export const stop = () => {
   // this is a bit more aggressive than we want to be, since it clears
   // all nock interceptors, not just the one we installed.  See
   // https://github.com/pgte/nock/issues/438

--- a/libraries/testing/src/schemas.js
+++ b/libraries/testing/src/schemas.js
@@ -24,21 +24,21 @@ import path from 'node:path';
  *   basePath:      path.join(__dirname, 'validate')  // basePath test cases
  * }
  */
-let schemas = function(options) {
+let schemas = (options) => {
   // Validate options
   assert(options.schemasetOptions, 'Options must be given for validator');
   assert(Array.isArray(options.cases), 'Array of cases must be given');
   assert(options.serviceName);
 
   let validate;
-  setup(async function() {
+  setup(async () => {
     const schemaset = new SchemaSet(options.schemasetOptions);
     validate = await schemaset.validator(libUrls.testRootUrl());
   });
 
   // Create test cases
-  options.cases.forEach(function(testCase) {
-    test(testCase.path, function() {
+  options.cases.forEach((testCase) => {
+    test(testCase.path, () => {
       // Load test data
       let filePath = testCase.path;
       // Prefix with basePath if a basePath is given

--- a/libraries/testing/src/secrets.js
+++ b/libraries/testing/src/secrets.js
@@ -122,7 +122,7 @@ class Secrets {
     // if no secrets are required, just run this as a regular suite with no "(real)" suffix
     if (secretList.length === 0) {
       suite(title, function() {
-        suiteSetup(async function() {
+        suiteSetup(async () => {
           if (that.load) {
             that.load.save();
           }
@@ -130,7 +130,7 @@ class Secrets {
 
         fn.call(this, false, () => skipping);
 
-        suiteTeardown(function() {
+        suiteTeardown(() => {
           if (that.load) {
             that.load.restore();
           }
@@ -144,7 +144,7 @@ class Secrets {
     }
 
     suite(`${title} (mock)`, function() {
-      suiteSetup(async function() {
+      suiteSetup(async () => {
         skipping = false;
         await that.setup();
         if (that.load) {
@@ -163,7 +163,7 @@ class Secrets {
 
       fn.call(this, true, () => skipping);
 
-      suiteTeardown(function() {
+      suiteTeardown(() => {
         if (that.load) {
           that.load.restore();
         }
@@ -202,7 +202,7 @@ class Secrets {
 
       fn.call(this, false, () => skipping);
 
-      suiteTeardown(function() {
+      suiteTeardown(() => {
         if (saveOccured) {
           that.load.restore();
         }

--- a/libraries/testing/src/time.js
+++ b/libraries/testing/src/time.js
@@ -2,11 +2,9 @@ import zurvan from 'zurvan';
 import timers from 'node:timers';
 
 /** Return promise that is resolved in `delay` ms */
-export const sleep = function(delay) {
-  return new Promise(function(accept) {
-    setTimeout(accept, delay);
-  });
-};
+export const sleep = (delay) => new Promise((accept) => {
+  setTimeout(accept, delay);
+});
 
 export const runWithFakeTime = (fn, { mock = true, maxTime = 30000, ...zurvanOptions } = {}) => {
   if (!mock) {

--- a/libraries/testing/src/with-db.js
+++ b/libraries/testing/src/with-db.js
@@ -65,7 +65,7 @@ export const withDb = (mock, skipping, helper, serviceName) => {
   assert(testDbUrl,
     "TEST_DB_URL must be set to run these tests - see dev-docs/development-process.md for more information");
 
-  suiteSetup('withDb', async function() {
+  suiteSetup('withDb', async () => {
     if (skipping()) {
       return;
     }
@@ -116,7 +116,7 @@ export const withDb = (mock, skipping, helper, serviceName) => {
     }
   });
 
-  suiteTeardown('withDb', async function() {
+  suiteTeardown('withDb', async () => {
     if (skipping()) {
       return;
     }

--- a/libraries/testing/src/with-monitor.js
+++ b/libraries/testing/src/with-monitor.js
@@ -17,7 +17,7 @@ export default (helper, options = {}) => {
     helper.load.inject('monitor', monitor);
   }
 
-  teardown(async function() {
+  teardown(async () => {
     // any messages at the ERROR level of above should cause a test failure
     if (monitor) {
       const errors = monitor.manager.messages

--- a/libraries/testing/src/with-pulse.js
+++ b/libraries/testing/src/with-pulse.js
@@ -7,7 +7,7 @@ export default ({ helper, skipping, namespace }) => {
   let client;
   const debugPulseAssertion = debug('withPulse');
 
-  suiteSetup('withPulse', async function () {
+  suiteSetup('withPulse', async () => {
     if (skipping?.()) {
       return;
     }
@@ -79,7 +79,7 @@ export default ({ helper, skipping, namespace }) => {
     };
   });
 
-  setup('withPulse', function() {
+  setup('withPulse', () => {
     if (skipping?.()) {
       return;
     }

--- a/libraries/testing/test/fakeauth_test.js
+++ b/libraries/testing/test/fakeauth_test.js
@@ -15,7 +15,7 @@ import testing from '@taskcluster/lib-testing';
 const __dirname = new URL('.', import.meta.url).pathname;
 
 let monitor;
-suiteSetup(function() {
+suiteSetup(() => {
   monitor = MonitorManager.setup({
     serviceName: 'whatever',
     fake: true,
@@ -39,7 +39,7 @@ builder.declare({
   title: 'Test function',
   description: 'for testing',
   category: 'Testing library',
-}, async function(req, res) {
+}, async (req, res) => {
   try {
     await req.authorize();
     return res.reply({ hasTestScope: true });
@@ -51,12 +51,12 @@ builder.declare({
   }
 });
 
-suite(testing.suiteName(), function() {
+suite(testing.suiteName(), () => {
   const rootUrl = 'http://localhost:1208';
   let fakeauth = testing.fakeauth;
   let server;
 
-  suiteSetup(async function() {
+  suiteSetup(async () => {
     const schemaset = new SchemaSet({
       rootUrl,
       serviceName: 'lib-testing',
@@ -85,11 +85,9 @@ suite(testing.suiteName(), function() {
     server.setTimeout(500);
   });
 
-  suiteTeardown(function() {
-    return server.terminate();
-  });
+  suiteTeardown(() => server.terminate());
 
-  teardown(function() {
+  teardown(() => {
     fakeauth.stop();
   });
 
@@ -116,49 +114,49 @@ suite(testing.suiteName(), function() {
       request
         .get(reqUrl)
         .set('Authorization', header)
-        .then(function(res) {
+        .then((res) => {
           debug(res.body);
           return res;
         }),
       request
         .get(bewitUrl)
-        .then(function(res) {
+        .then((res) => {
           debug(res.body);
           return res;
         }),
     ]);
   };
 
-  test('using a rawClientId', function() {
+  test('using a rawClientId', () => {
     fakeauth.start({ client1: ['test.scope'] }, { rootUrl });
-    return callApi('client1').then(function(responses) {
+    return callApi('client1').then((responses) => {
       for (let res of responses) {
         assert(res.ok && res.body.hasTestScope, 'Request failed');
       }
     });
   });
 
-  test('using an unconfigured rawClientId', function() {
+  test('using an unconfigured rawClientId', () => {
     fakeauth.start({ client1: ['test.scope'] }, { rootUrl });
     return callApi('unconfiguredClient')
       .then(() => {assert(false, 'should have failed');})
-      .catch(function(err) {
+      .catch((err) => {
         assert.equal(err.status, 401, 'wrong error code returned');
       });
   });
 
-  test('using authorizedScopes', function() {
+  test('using authorizedScopes', () => {
     fakeauth.start({ client1: ['some.other.scope'] }, { rootUrl });
     return callApi('client1', {
       authorizedScopes: ['test.scope'],
-    }).then(function(responses) {
+    }).then((responses) => {
       for (let res of responses) {
         assert(res.ok && res.body.hasTestScope, 'Request failed');
       }
     });
   });
 
-  test('using temp creds', function() {
+  test('using temp creds', () => {
     fakeauth.start({ client1: ['some.other.scope'] }, { rootUrl });
     let tempCreds = taskcluster.createTemporaryCredentials({
       scopes: ['test.scope'],
@@ -170,7 +168,7 @@ suite(testing.suiteName(), function() {
     });
     return callApi('client1', {
       certificate: JSON.parse(tempCreds.certificate),
-    }).then(function(responses) {
+    }).then((responses) => {
       for (let res of responses) {
         assert(res.ok && res.body.hasTestScope, 'Request failed');
       }

--- a/libraries/testing/test/schemas_test.js
+++ b/libraries/testing/test/schemas_test.js
@@ -3,7 +3,7 @@ import testing from '@taskcluster/lib-testing';
 
 const __dirname = new URL('.', import.meta.url).pathname;
 
-suite(testing.suiteName(), function() {
+suite(testing.suiteName(), () => {
   testing.schemas({
     schemasetOptions: {
       folder: path.join(__dirname, 'schemas'),

--- a/libraries/testing/test/secrets_test.js
+++ b/libraries/testing/test/secrets_test.js
@@ -3,24 +3,24 @@ import _ from 'lodash';
 import assert from 'node:assert';
 import nock from 'nock';
 
-suite(suiteName(), function() {
+suite(suiteName(), () => {
   let oldTaskId;
   let savedEnv;
 
-  suiteSetup(function() {
+  suiteSetup(() => {
     // make sure $TASK_ID isn't set for the duration of this suite
     oldTaskId = process.env.TASK_ID;
     delete process.env.TASK_ID;
     savedEnv = _.cloneDeep(process.env);
   });
 
-  teardown(function() {
+  teardown(() => {
     // reset process.env back to savedEnv, in-place (without $TASK_ID)
     Object.keys(process.env).forEach(k => delete process.env[k]);
     Object.entries(savedEnv).forEach(([k, v]) => process.env[k] = v);
   });
 
-  suiteTeardown(function() {
+  suiteTeardown(() => {
     if (oldTaskId) {
       process.env.TASK_ID = oldTaskId;
     }
@@ -35,17 +35,17 @@ suite(suiteName(), function() {
   };
   const sticky = stickyLoader(loader);
 
-  setup(function() {
+  setup(() => {
     sticky.save();
   });
 
-  teardown(function() {
+  teardown(() => {
     sticky.restore();
   });
 
-  suite('have / get', function() {
+  suite('have / get', () => {
     let secrets;
-    setup(function() {
+    setup(() => {
       secrets = new Secrets({
         secretName: 'path/to/secret',
         secrets: {
@@ -62,7 +62,7 @@ suite(suiteName(), function() {
       sticky.inject('cfg', {});
     });
 
-    test('with nothing', async function() {
+    test('with nothing', async () => {
       await secrets.setup();
       assert(!secrets.have('envOnly'));
       assert.throws(() => secrets.get('envOnly'));
@@ -72,7 +72,7 @@ suite(suiteName(), function() {
       assert.throws(() => secrets.get('envAndCfg'));
     });
 
-    test('with no cfg properties', async function() {
+    test('with no cfg properties', async () => {
       secrets = new Secrets({
         secretName: 'path/to/secret',
         secrets: {
@@ -87,7 +87,7 @@ suite(suiteName(), function() {
       assert.throws(() => secrets.get('envOnly'));
     });
 
-    test('with config', async function() {
+    test('with config', async () => {
       sticky.inject('cfg', { cfgonly: { pass: 'PP' }, both: { pass: 'P2' } });
       await secrets.setup();
       assert(!secrets.have('envOnly'));
@@ -98,14 +98,14 @@ suite(suiteName(), function() {
       assert.deepEqual(secrets.get('envAndCfg'), { PASS_IN_BOTH: 'P2' });
     });
 
-    test('have with a false value', async function() {
+    test('have with a false value', async () => {
       sticky.inject('cfg', { cfgonly: { pass: false } });
       await secrets.setup();
       assert(secrets.have('cfgOnly'));
       assert.deepEqual(secrets.get('cfgOnly'), { cfgonly: false });
     });
 
-    test('with env', async function() {
+    test('with env', async () => {
       process.env.PASS_IN_ENV = 'PIE';
       process.env.PASS_IN_BOTH = 'PIB';
       await secrets.setup();
@@ -118,7 +118,7 @@ suite(suiteName(), function() {
       assert(!process.env.PASS_IN_ENV, '$PASS_IN_ENV is still set');
     });
 
-    test('with env via secrets service', async function() {
+    test('with env via secrets service', async () => {
       process.env.TASK_ID = 'abc123'; // so fetching occurs
       secrets._fetchSecrets = async () => ({ PASS_IN_ENV: 'PIE', PASS_IN_BOTH: 'PIB' });
       await secrets.setup();
@@ -131,7 +131,7 @@ suite(suiteName(), function() {
       assert(!process.env.PASS_IN_ENV, '$PASS_IN_ENV is set');
     });
 
-    test('with env and config', async function() {
+    test('with env and config', async () => {
       process.env.PASS_IN_ENV = 'PIE';
       process.env.PASS_IN_BOTH = 'PIB';
       sticky.inject('cfg', { cfgonly: { pass: 'PP' }, both: { pass: 'P2' } });
@@ -147,7 +147,7 @@ suite(suiteName(), function() {
     });
   });
 
-  suite('mockSuite with secrets missing', function() {
+  suite('mockSuite with secrets missing', () => {
     const secrets = new Secrets({
       secretName: 'path/to/secret',
       secrets: {
@@ -157,18 +157,18 @@ suite(suiteName(), function() {
     });
     let testsRun = [];
 
-    secrets.mockSuite('outer', ['sec'], function(mock) {
+    secrets.mockSuite('outer', ['sec'], (mock) => {
       test('inner', () => {
         testsRun.push(mock);
       });
     });
 
-    suiteTeardown(function() {
+    suiteTeardown(() => {
       assert.deepEqual(testsRun, [true], 'expected just the mock run');
     });
   });
 
-  suite('mockSuite with secrets present', function() {
+  suite('mockSuite with secrets present', () => {
     const secrets = new Secrets({
       secretName: 'path/to/secret',
       secrets: {
@@ -178,23 +178,23 @@ suite(suiteName(), function() {
     });
     let testsRun = [];
 
-    suiteSetup(function() {
+    suiteSetup(() => {
       sticky.inject('cfg', { sec: 'here' });
     });
 
-    secrets.mockSuite('outer', ['sec'], function(secrets) {
+    secrets.mockSuite('outer', ['sec'], (secrets) => {
       test('inner', () => {
         testsRun.push(secrets);
       });
     });
 
-    suiteTeardown(function() {
+    suiteTeardown(() => {
       assert.deepEqual(testsRun, [true, false], 'expected both runs');
     });
   });
   // NOTE: testing NO_TEST_SKIP would generate a failed test, so we do not attempt to test that.
 
-  suite('_fetchSecrets', function() {
+  suite('_fetchSecrets', () => {
     const secrets = new Secrets({
       secretName: 'path/to/secret',
       secrets: {
@@ -202,7 +202,7 @@ suite(suiteName(), function() {
       },
     });
 
-    suiteSetup(function() {
+    suiteSetup(() => {
       nock('http://proxy')
         .get('/api/secrets/v1/secret/path%2Fto%2Fsecret')
         .reply(200, (uri, requestBody) => {
@@ -210,11 +210,11 @@ suite(suiteName(), function() {
         });
     });
 
-    suiteTeardown(function() {
+    suiteTeardown(() => {
       nock.cleanAll();
     });
 
-    test('with TASK_ID set', async function() {
+    test('with TASK_ID set', async () => {
       process.env.TASK_ID = '1234';
       process.env.TASKCLUSTER_PROXY_URL = 'http://proxy';
       assert.deepEqual(await secrets._fetchSecrets(), { SECRET_VALUE: '13' });

--- a/libraries/testing/test/stickyloader_test.js
+++ b/libraries/testing/test/stickyloader_test.js
@@ -2,7 +2,7 @@ import _ from 'lodash';
 import assert from 'node:assert';
 import { stickyLoader, suiteName } from '../src/index.js';
 
-suite(suiteName(), function() {
+suite(suiteName(), () => {
   let loads, sticky;
 
   const loader = (component, overwrites) => {
@@ -13,12 +13,12 @@ suite(suiteName(), function() {
     return Promise.resolve({ component });
   };
 
-  setup(function() {
+  setup(() => {
     loads = [];
     sticky = stickyLoader(loader);
   });
 
-  test('returns same component twice', async function() {
+  test('returns same component twice', async () => {
     const first = await sticky('abc');
     const second = await sticky('abc');
     const third = await sticky('def');
@@ -27,7 +27,7 @@ suite(suiteName(), function() {
     assert(second !== third);
   });
 
-  test('includes result in overwrites', async function() {
+  test('includes result in overwrites', async () => {
     await sticky('abc');
     await sticky('def');
     assert.deepEqual(loads, [{
@@ -39,7 +39,7 @@ suite(suiteName(), function() {
     }]);
   });
 
-  test('inject adds to overwrites', async function() {
+  test('inject adds to overwrites', async () => {
     await sticky.inject('inj', { inj: true });
     await sticky('inj');
     assert.deepEqual(loads, [{
@@ -48,7 +48,7 @@ suite(suiteName(), function() {
     }]);
   });
 
-  test('cfg fails if cfg is not loaded', async function() {
+  test('cfg fails if cfg is not loaded', async () => {
     try {
       sticky.cfg('app.secret', 'donttell');
     } catch (e) {
@@ -58,13 +58,13 @@ suite(suiteName(), function() {
     assert(false, 'expected error');
   });
 
-  test('cfg', async function() {
+  test('cfg', async () => {
     sticky.inject('cfg', {});
     sticky.cfg('a.b.c', 'd');
     assert(_.isEqual(await sticky('cfg'), { a: { b: { c: 'd' } } }));
   });
 
-  test('save/restore', async function() {
+  test('save/restore', async () => {
     const first = await sticky('abc');
     sticky.save();
     const second = await sticky('def');
@@ -75,7 +75,7 @@ suite(suiteName(), function() {
     assert((await sticky('abc')).updated, 'in-place modification to abc persists');
   });
 
-  test('save/restore with inject', async function() {
+  test('save/restore with inject', async () => {
     sticky.inject('abc', 'AAA');
     sticky.save();
     sticky.inject('abc', 'BBB');
@@ -84,7 +84,7 @@ suite(suiteName(), function() {
     assert((await sticky('abc')) === 'AAA', 'should get the original injected value');
   });
 
-  test('save/restore with remove', async function() {
+  test('save/restore with remove', async () => {
     sticky.inject('abc', 'AAA');
     sticky.save();
     sticky.remove('abc');
@@ -93,7 +93,7 @@ suite(suiteName(), function() {
     assert((await sticky('abc')) === 'AAA', 'should get the original injected value');
   });
 
-  test('save/restore with cfg', async function() {
+  test('save/restore with cfg', async () => {
     sticky.inject('cfg', {});
     sticky.cfg('app.secret', 'donttell');
     assert((await sticky('cfg')).app.secret === 'donttell');

--- a/libraries/testing/test/utils_test.js
+++ b/libraries/testing/test/utils_test.js
@@ -1,8 +1,8 @@
 import assert from 'node:assert';
 import testing from '@taskcluster/lib-testing';
 
-suite(testing.suiteName(), function() {
-  test('sleep', async function() {
+suite(testing.suiteName(), () => {
+  test('sleep', async () => {
     let start = Date.now();
     await testing.sleep(10);
     const end = Date.now();
@@ -23,13 +23,13 @@ suite(testing.suiteName(), function() {
     };
   };
 
-  test('poll (success)', async function() {
+  test('poll (success)', async () => {
     const poll = pollFunc();
     await testing.poll(poll, 4, 5);
     assert.equal(countDown, 0);
   });
 
-  test('poll (too-few iterations)', async function() {
+  test('poll (too-few iterations)', async () => {
     const poll = pollFunc();
     try {
       await testing.poll(poll, 3, 5);

--- a/libraries/validate/src/index.js
+++ b/libraries/validate/src/index.js
@@ -135,7 +135,7 @@ class SchemaSet {
       }
       ajv.validate(id, obj);
       if (ajv.errors) {
-        _.forEach(ajv.errors, function(error) {
+        _.forEach(ajv.errors, (error) => {
           if (error.params['additionalProperty']) {
             error.message += ': ' + JSON.stringify(error.params['additionalProperty']);
           }

--- a/libraries/validate/test/util_test.js
+++ b/libraries/validate/test/util_test.js
@@ -2,8 +2,8 @@ import assert from 'node:assert';
 import { checkRefs } from '../src/util.js';
 import testing from '@taskcluster/lib-testing';
 
-suite(testing.suiteName(), function() {
-  suite('checkRefs', function() {
+suite(testing.suiteName(), () => {
+  suite('checkRefs', () => {
     // include some arrays and objects to test the "deepness" of the check
     const schemaWith = innards => ({
       anyOf: [{
@@ -14,29 +14,29 @@ suite(testing.suiteName(), function() {
       }],
     });
 
-    test('on a schema with no refs', function() {
+    test('on a schema with no refs', () => {
       checkRefs(schemaWith({ type: 'string' }), 'thisservice');
     });
 
-    test('on a schema with a local ref', function() {
+    test('on a schema with a local ref', () => {
       checkRefs(schemaWith({ $ref: 'another-file.json' }), 'thisservice');
     });
 
-    test('on a schema with a rooted ref (not allowed)', function() {
+    test('on a schema with a rooted ref (not allowed)', () => {
       assert.throws(
         () => checkRefs(schemaWith({ $ref: '/schemas/thisservice/file.json' }), 'thisservice'),
         Error,
         /rooted URIs *. are not allowed/);
     });
 
-    test('on a schema with a /-relative ref (not allowed)', function() {
+    test('on a schema with a /-relative ref (not allowed)', () => {
       assert.throws(
         () => checkRefs(schemaWith({ $ref: '/schemas/foo.json' }), 'thisservice'),
         Error,
         /absolute URIs *. are not allowed/);
     });
 
-    test('on a schema with an "https:.." ref (not allowed)', function() {
+    test('on a schema with an "https:.." ref (not allowed)', () => {
       assert.throws(
         () => checkRefs(schemaWith({ $ref: 'https://schemas.taskcluster.net/foo.json' }), 'thisservice'),
         Error,

--- a/services/auth/src/api.js
+++ b/services/auth/src/api.js
@@ -1180,9 +1180,7 @@ builder.declare({
     'of scopes and scope restrictions (temporary credentials, assumeScopes, client scopes,',
     'and roles).',
   ].join('\n'),
-}, async function(req, res) {
-  return res.reply({ scopes: await req.scopes() });
-});
+}, async (req, res) => res.reply({ scopes: await req.scopes() }));
 
 // Load aws and azure API implementations, these loads API and declares methods
 // on the API object exported from this file
@@ -1348,7 +1346,7 @@ builder.declare({
     'This endpoint is used to check on backing services this service',
     'depends on.',
   ].join('\n'),
-}, function(_req, res) {
+}, (_req, res) => {
   // TODO: add implementation
   res.reply({});
 });

--- a/services/auth/src/signaturevalidator.js
+++ b/services/auth/src/signaturevalidator.js
@@ -63,7 +63,7 @@ export const determineSchemeFromRequest = (req) => {
  * applies scope restrictions, certificate validation and returns a clone if
  * modified (otherwise it returns the original).
  */
-const parseExt = function(ext) {
+const parseExt = (ext) => {
   // Attempt to parse ext
   try {
     ext = JSON.parse(Buffer.from(ext, 'base64').toString('utf-8'));
@@ -81,8 +81,8 @@ const parseExt = function(ext) {
  * applies scope restrictions, certificate validation and returns a clone if
  * modified (otherwise it returns the original).
  */
-const limitClientWithExt = function(credentialName, issuingClientId, accessToken, scopes,
-  expires, ext, expandScopes) {
+const limitClientWithExt = (credentialName, issuingClientId, accessToken, scopes,
+  expires, ext, expandScopes) => {
   let issuingScopes = scopes;
   let res = { scopes, expires, accessToken };
 
@@ -256,13 +256,13 @@ const limitClientWithExt = function(credentialName, issuingClientId, accessToken
  * The method returned by this function works as `signatureValidator` for
  * `remoteAuthentication`.
  */
-const createSignatureValidator = function(options) {
+const createSignatureValidator = (options) => {
   assert(typeof options === 'object', 'options must be an object');
   assert(options.clientLoader instanceof Function,
     'options.clientLoader must be a function');
   if (!options.expandScopes) {
     // Default to the identity function
-    options.expandScopes = function(scopes) { return scopes; };
+    options.expandScopes = (scopes) => scopes;
   }
   assert(options.expandScopes instanceof Function,
     'options.expandScopes must be a function');
@@ -314,7 +314,7 @@ const createSignatureValidator = function(options) {
     };
   };
 
-  return async function(req) {
+  return async (req) => {
     let credentials, attributes, result, authResult, scheme;
 
     try {

--- a/services/auth/src/static-clients.js
+++ b/services/auth/src/static-clients.js
@@ -16,7 +16,7 @@ const __dirname = new URL('.', import.meta.url).pathname;
  * , where description will be amended with a section explaining that this
  * client is static and can't be modified at runtime.
  */
-export const syncStaticClients = async function(db, clients = []) {
+export const syncStaticClients = async (db, clients = []) => {
   const staticScopes = JSON.parse(await fs.readFile(path.join(__dirname, 'static-scopes.json'), 'utf8'));
 
   // Validate input for sanity (we hardly need perfect validation here...)

--- a/services/auth/test/audit_history_test.js
+++ b/services/auth/test/audit_history_test.js
@@ -4,7 +4,7 @@ import slugid from 'slugid';
 import testing from '@taskcluster/lib-testing';
 import taskcluster from '@taskcluster/client';
 
-helper.secrets.mockSuite('audit', ['gcp'], function(mock, skipping) {
+helper.secrets.mockSuite('audit', ['gcp'], (mock, skipping) => {
   helper.withDb(mock, skipping);
   helper.withCfg(mock, skipping);
   helper.withPulse(mock, skipping);
@@ -19,7 +19,7 @@ helper.secrets.mockSuite('audit', ['gcp'], function(mock, skipping) {
     }
   });
 
-  setup(async function() {
+  setup(async () => {
     await testing.resetTables({ tableNames: [
       'audit_history',
     ] });

--- a/services/auth/test/client_test.js
+++ b/services/auth/test/client_test.js
@@ -5,7 +5,7 @@ import assume from 'assume';
 import testing from '@taskcluster/lib-testing';
 import taskcluster from '@taskcluster/client';
 
-helper.secrets.mockSuite(testing.suiteName(), ['azure', 'gcp'], function(mock, skipping) {
+helper.secrets.mockSuite(testing.suiteName(), ['azure', 'gcp'], (mock, skipping) => {
   helper.withDb(mock, skipping);
   helper.withCfg(mock, skipping);
   helper.withPulse(mock, skipping);
@@ -19,7 +19,7 @@ helper.secrets.mockSuite(testing.suiteName(), ['azure', 'gcp'], function(mock, s
     );
   };
 
-  teardown(async function() {
+  teardown(async () => {
     helper.onPulsePublish(); // don't fail to publish this time!
     helper.setupScopes();
     await helper.apiClient.deleteRole('anonymous');
@@ -514,7 +514,7 @@ helper.secrets.mockSuite(testing.suiteName(), ['azure', 'gcp'], function(mock, s
       { scopes: ['assume:anonymous', 'myapi:x', 'auth:current-scopes'] });
   });
 
-  suite('auth.listClients', function() {
+  suite('auth.listClients', () => {
     const suffixes = ['/aa', '/bb', '/bb/1', '/bb/2', '/bb/3', '/bb/4', '/bb/5'];
 
     setup(async function() {

--- a/services/auth/test/containers_test.js
+++ b/services/auth/test/containers_test.js
@@ -8,18 +8,18 @@ const sorted = (arr) => {
   return arr;
 };
 
-helper.secrets.mockSuite(testing.suiteName(), ['azure', 'gcp'], function(mock, skipping) {
+helper.secrets.mockSuite(testing.suiteName(), ['azure', 'gcp'], (mock, skipping) => {
   helper.withDb(mock, skipping);
   helper.withCfg(mock, skipping);
   helper.withPulse(mock, skipping);
   helper.withServers(mock, skipping);
   helper.resetTables(mock, skipping);
 
-  test('get when blob is empty', async function() {
+  test('get when blob is empty', async () => {
     assert.deepEqual(await helper.db.fns.get_roles(), []);
   });
 
-  test('first modification of an empty blob', async function() {
+  test('first modification of an empty blob', async () => {
     await modifyRoles(helper.db, ({ roles }) => {
       roles.push({
         role_id: 'my-role',
@@ -34,7 +34,7 @@ helper.secrets.mockSuite(testing.suiteName(), ['azure', 'gcp'], function(mock, s
       sorted(['my-role']));
   });
 
-  test('add a second role', async function() {
+  test('add a second role', async () => {
     await modifyRoles(helper.db, ({ roles }) => {
       roles.push({
         role_id: 'my-role',

--- a/services/auth/test/gcp_test.js
+++ b/services/auth/test/gcp_test.js
@@ -2,7 +2,7 @@ import assert from 'node:assert';
 import helper from './helper.js';
 import testing from '@taskcluster/lib-testing';
 
-helper.secrets.mockSuite(testing.suiteName(), ['gcp', 'azure'], function(mock, skipping) {
+helper.secrets.mockSuite(testing.suiteName(), ['gcp', 'azure'], (mock, skipping) => {
   helper.withCfg(mock, skipping);
   helper.withDb(mock, skipping);
   helper.withGcp(mock, skipping);

--- a/services/auth/test/helper.js
+++ b/services/auth/test/helper.js
@@ -21,7 +21,7 @@ export const load = stickyLoader(mainLoad);
 
 const __dirname = new URL('.', import.meta.url).pathname;
 
-suiteSetup(async function() {
+suiteSetup(async () => {
   process.env.GCP_ALLOWED_SERVICE_ACCOUNTS = JSON.stringify([
     'invalid@mozilla.com',
   ]);
@@ -68,7 +68,7 @@ helper.withCfg = (mock, skipping) => {
   if (skipping()) {
     return;
   }
-  suiteSetup(async function() {
+  suiteSetup(async () => {
     if (skipping()) {
       return;
     }
@@ -95,7 +95,7 @@ helper.withCfg = (mock, skipping) => {
     }
   });
 
-  suiteTeardown(async function() {
+  suiteTeardown(async () => {
     if (skipping()) {
       return;
     }
@@ -113,7 +113,7 @@ helper.withDb = (mock, skipping) => {
  */
 helper.withSentry = (mock, skipping) => {
   const sentryOrgs = {};
-  suiteSetup(async function() {
+  suiteSetup(async () => {
     if (skipping()) {
       return;
     }
@@ -181,7 +181,7 @@ testServiceBuilder.declare({
   title: 'Get Resource',
   category: 'Auth Service',
   description: '...',
-}, function(req, res) {
+}, (req, res) => {
   res.status(200).json({
     message: 'Hello World',
   });
@@ -199,7 +199,7 @@ testServiceBuilder.declare({
 helper.withServers = (mock, skipping) => {
   let webServer;
 
-  suiteSetup(async function() {
+  suiteSetup(async () => {
     if (skipping()) {
       return;
     }
@@ -258,7 +258,7 @@ helper.withServers = (mock, skipping) => {
     helper.setupScopes();
   });
 
-  suiteTeardown(async function() {
+  suiteTeardown(async () => {
     if (skipping()) {
       return;
     }
@@ -381,7 +381,7 @@ helper.withGcp = (mock, skipping) => {
 };
 
 helper.resetTables = (mock, skipping) => {
-  setup('reset tables', async function() {
+  setup('reset tables', async () => {
     await libTesting.resetTables({ tableNames: [
       'roles',
       'clients',

--- a/services/auth/test/purgeExpiredClients_test.js
+++ b/services/auth/test/purgeExpiredClients_test.js
@@ -3,7 +3,7 @@ import assume from 'assume';
 import taskcluster from '@taskcluster/client';
 import testing from '@taskcluster/lib-testing';
 
-helper.secrets.mockSuite(testing.suiteName(), ['azure', 'gcp'], function(mock, skipping) {
+helper.secrets.mockSuite(testing.suiteName(), ['azure', 'gcp'], (mock, skipping) => {
   helper.withCfg(mock, skipping);
   helper.withDb(mock, skipping);
   helper.withPulse(mock, skipping);

--- a/services/auth/test/remotevalidation_test.js
+++ b/services/auth/test/remotevalidation_test.js
@@ -5,7 +5,7 @@ import taskcluster from '@taskcluster/client';
 import request from 'superagent';
 import testing from '@taskcluster/lib-testing';
 
-helper.secrets.mockSuite(testing.suiteName(), ['azure', 'gcp'], function(mock, skipping) {
+helper.secrets.mockSuite(testing.suiteName(), ['azure', 'gcp'], (mock, skipping) => {
   helper.withCfg(mock, skipping);
   helper.withDb(mock, skipping);
   helper.withPulse(mock, skipping);
@@ -13,7 +13,7 @@ helper.secrets.mockSuite(testing.suiteName(), ['azure', 'gcp'], function(mock, s
 
   let rootCredentials;
 
-  suiteSetup(function() {
+  suiteSetup(() => {
     helper.setupScopes(['*']);
     rootCredentials = {
       clientId: 'static/taskcluster/root',

--- a/services/auth/test/role_test.js
+++ b/services/auth/test/role_test.js
@@ -7,7 +7,7 @@ import assume from 'assume';
 import testing from '@taskcluster/lib-testing';
 import taskcluster from '@taskcluster/client';
 
-helper.secrets.mockSuite(testing.suiteName(), ['gcp'], function(mock, skipping) {
+helper.secrets.mockSuite(testing.suiteName(), ['gcp'], (mock, skipping) => {
   helper.withCfg(mock, skipping);
   helper.withDb(mock, skipping);
   helper.withPulse(mock, skipping);
@@ -123,7 +123,7 @@ helper.secrets.mockSuite(testing.suiteName(), ['gcp'], function(mock, skipping) 
       err => assert(err.statusCode === 400, 'Expected 400'));
   });
 
-  test('createRole twice with identical roles', async function() {
+  test('createRole twice with identical roles', async () => {
     await helper.apiClient.createRole('double', {
       description: 'double-add',
       scopes: ['foo'],
@@ -140,7 +140,7 @@ helper.secrets.mockSuite(testing.suiteName(), ['gcp'], function(mock, skipping) 
     await helper.apiClient.deleteRole('double');
   });
 
-  test('createRole but pulse publish fails', async function() {
+  test('createRole but pulse publish fails', async () => {
     helper.onPulsePublish(() => {
       throw new Error('uhoh');
     });
@@ -168,7 +168,7 @@ helper.secrets.mockSuite(testing.suiteName(), ['gcp'], function(mock, skipping) 
     });
   });
 
-  test('createRole twice with different roles', async function() {
+  test('createRole twice with different roles', async () => {
     await helper.apiClient.createRole('double', {
       description: 'double-add',
       scopes: ['foo'],
@@ -192,7 +192,7 @@ helper.secrets.mockSuite(testing.suiteName(), ['gcp'], function(mock, skipping) 
     await helper.apiClient.deleteRole('double');
   });
 
-  test('createRole twice at the same time, with identical roles', async function() {
+  test('createRole twice at the same time, with identical roles', async () => {
     await Promise.all([
       helper.apiClient.createRole('double', {
         description: 'double-add',
@@ -476,7 +476,7 @@ helper.secrets.mockSuite(testing.suiteName(), ['gcp'], function(mock, skipping) 
     );
   });
 
-  suite('updateRole', function() {
+  suite('updateRole', () => {
     let roleId = `thing-id:${clientId}`;
     let roleId2 = `sub-thing:${clientId}`;
     let auth;
@@ -487,7 +487,7 @@ helper.secrets.mockSuite(testing.suiteName(), ['gcp'], function(mock, skipping) 
       }
     });
 
-    setup(async function() {
+    setup(async () => {
       auth = new helper.AuthClient({
         rootUrl: helper.rootUrl,
         credentials: {
@@ -515,7 +515,7 @@ helper.secrets.mockSuite(testing.suiteName(), ['gcp'], function(mock, skipping) 
       });
     });
 
-    teardown(async function() {
+    teardown(async () => {
       await modifyRoles(helper.db, ({ roles }) => roles.splice(0));
     });
 

--- a/services/auth/test/rolelogic_test.js
+++ b/services/auth/test/rolelogic_test.js
@@ -4,7 +4,7 @@ import taskcluster from '@taskcluster/client';
 import mocha from 'mocha';
 import testing from '@taskcluster/lib-testing';
 
-helper.secrets.mockSuite(testing.suiteName(), ['azure', 'gcp'], function(mock, skipping) {
+helper.secrets.mockSuite(testing.suiteName(), ['azure', 'gcp'], (mock, skipping) => {
   helper.withDb(mock, skipping);
   helper.withCfg(mock, skipping);
   helper.withPulse(mock, skipping);

--- a/services/auth/test/s3_test.js
+++ b/services/auth/test/s3_test.js
@@ -11,7 +11,7 @@ import debugFactory from 'debug';
 const debug = debugFactory('s3_test');
 import testing from '@taskcluster/lib-testing';
 
-helper.secrets.mockSuite(testing.suiteName(), ['azure', 'gcp'], function(mock, skipping) {
+helper.secrets.mockSuite(testing.suiteName(), ['azure', 'gcp'], (mock, skipping) => {
   if (mock) {
     return; // This is actually testing sts tokens and we are not going to mock those
   }
@@ -22,7 +22,7 @@ helper.secrets.mockSuite(testing.suiteName(), ['azure', 'gcp'], function(mock, s
   helper.withServers(mock, skipping);
 
   let bucket;
-  setup(function() {
+  setup(() => {
     const secret = helper.secrets.get('aws');
     bucket = secret.testBucket;
     helper.load.cfg('awsCredentials.allowedBuckets', [{

--- a/services/auth/test/scoperesolver_test.js
+++ b/services/auth/test/scoperesolver_test.js
@@ -11,14 +11,14 @@ import { readFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-helper.secrets.mockSuite('setup and listening', ['azure', 'gcp'], function (mock, skipping) {
+helper.secrets.mockSuite('setup and listening', ['azure', 'gcp'], (mock, skipping) => {
   let scopeResolver;
 
   helper.withDb(mock, skipping);
   helper.withPulse(mock, skipping);
   let reloads = [];
 
-  setup('mock scoperesolver reloading', async function () {
+  setup('mock scoperesolver reloading', async () => {
     reloads = [];
 
     let monitor = await helper.load('monitor');
@@ -40,11 +40,11 @@ helper.secrets.mockSuite('setup and listening', ['azure', 'gcp'], function (mock
     reloads = [];
   });
 
-  teardown(async function () {
+  teardown(async () => {
     await scopeResolver.stop();
   });
 
-  test('client messages reload specific clients', async function () {
+  test('client messages reload specific clients', async () => {
     await helper.fakePulseMessage({
       exchange: 'exchange/taskcluster-auth/v1/client-created',
       routingKey: '-',
@@ -54,12 +54,12 @@ helper.secrets.mockSuite('setup and listening', ['azure', 'gcp'], function (mock
     assume(reloads).to.deeply.equal(['clid']);
   });
 
-  test('reconnection reloads everything', async function () {
+  test('reconnection reloads everything', async () => {
     await scopeResolver._clientPq.connected();
     assume(reloads).to.deeply.equal(['all']);
   });
 
-  test('role messages reload all roles', async function () {
+  test('role messages reload all roles', async () => {
     assume(reloads).to.deeply.equal([]);
     await helper.fakePulseMessage({
       exchange: 'exchange/taskcluster-auth/v1/role-created',
@@ -76,9 +76,9 @@ suite(testing.suiteName(), () => {
   const fakeMonitor = {};
   const scopeResolver = new ScopeResolver({ monitor: fakeMonitor, disableCache: true });
 
-  suite('buildResolver', function() {
+  suite('buildResolver', () => {
     const testResolver = (title, { roles, scopes, expected }) => {
-      test(title, function() {
+      test(title, () => {
         const resolver = scopeResolver.buildResolver(roles);
         expected.sort(scopeCompare);
         assume(resolver(scopes)).eql(expected);
@@ -418,7 +418,7 @@ suite(testing.suiteName(), () => {
     }
 
     const testResolver = (title, { roles, scopes, expected }) => {
-      test(title, function() {
+      test(title, () => {
         let resolver = time('setup', () => scopeResolver.buildResolver(roles));
         time('execute', () => resolver(scopes));
         if (expected) {

--- a/services/auth/test/sentry_test.js
+++ b/services/auth/test/sentry_test.js
@@ -5,16 +5,16 @@ import assert from 'node:assert';
 import testing from '@taskcluster/lib-testing';
 import nock from 'nock';
 
-suite('SentryApiClient', function() {
+suite('SentryApiClient', () => {
   const origin = 'https://sentry.example.com';
   const token = 'secret-token';
   let client;
 
-  setup(function() {
+  setup(() => {
     client = new SentryApiClient(origin, { token });
   });
 
-  teardown(function() {
+  teardown(() => {
     nock.cleanAll();
   });
 
@@ -24,7 +24,7 @@ suite('SentryApiClient', function() {
     },
   });
 
-  test('initializes the API surface auth uses', function() {
+  test('initializes the API surface auth uses', () => {
     assert.equal(typeof client.organizations.projects, 'function');
     assert.equal(typeof client.projects.keys, 'function');
     assert.equal(typeof client.projects.createKey, 'function');
@@ -32,7 +32,7 @@ suite('SentryApiClient', function() {
     assert.equal(typeof client.teams.createProject, 'function');
   });
 
-  test('uses bearer auth and parses organization projects', async function() {
+  test('uses bearer auth and parses organization projects', async () => {
     const sentry = sentryApi()
       .get('/api/0/organizations/taskcluster/projects/')
       .reply(200, [{ slug: 'project-one' }]);
@@ -41,7 +41,7 @@ suite('SentryApiClient', function() {
     assert.equal(true, sentry.isDone());
   });
 
-  test('parses project keys', async function() {
+  test('parses project keys', async () => {
     const sentry = sentryApi()
       .get('/api/0/projects/taskcluster/project-one/keys/')
       .reply(200, [{ id: 'key-one' }]);
@@ -50,7 +50,7 @@ suite('SentryApiClient', function() {
     assert.equal(true, sentry.isDone());
   });
 
-  test('creates projects with JSON bodies', async function() {
+  test('creates projects with JSON bodies', async () => {
     const project = { name: 'project-one', slug: 'project-one' };
     const sentry = sentryApi()
       .post('/api/0/teams/taskcluster/team-one/projects/', project)
@@ -63,7 +63,7 @@ suite('SentryApiClient', function() {
     assert.equal(true, sentry.isDone());
   });
 
-  test('creates client keys with JSON bodies', async function() {
+  test('creates client keys with JSON bodies', async () => {
     const sentry = sentryApi()
       .post('/api/0/projects/taskcluster/project-one/keys/', { name: 'key-one' })
       .reply(201, { id: 'key-one' });
@@ -75,7 +75,7 @@ suite('SentryApiClient', function() {
     assert.equal(true, sentry.isDone());
   });
 
-  test('deletes client keys', async function() {
+  test('deletes client keys', async () => {
     const sentry = sentryApi()
       .delete('/api/0/projects/taskcluster/project-one/keys/key-one/')
       .reply(204);
@@ -84,7 +84,7 @@ suite('SentryApiClient', function() {
     assert.equal(true, sentry.isDone());
   });
 
-  test('surfaces Sentry detail errors', async function() {
+  test('surfaces Sentry detail errors', async () => {
     const sentry = sentryApi()
       .get('/api/0/projects/taskcluster/missing/keys/')
       .reply(404, { detail: 'Project not found' });
@@ -96,7 +96,7 @@ suite('SentryApiClient', function() {
     assert.equal(true, sentry.isDone());
   });
 
-  test('surfaces HTTP status errors', async function() {
+  test('surfaces HTTP status errors', async () => {
     const sentry = sentryApi()
       .get('/api/0/projects/taskcluster/missing/keys/')
       .reply(400);
@@ -109,11 +109,11 @@ suite('SentryApiClient', function() {
   });
 });
 
-helper.secrets.mockSuite(testing.suiteName(), ['azure', 'gcp'], function(mock, skipping) {
+helper.secrets.mockSuite(testing.suiteName(), ['azure', 'gcp'], (mock, skipping) => {
   if (!mock) {
     return; // We don't test this with real credentials for now!
   }
-  suite('regular SentryManager with fake client', function() {
+  suite('regular SentryManager with fake client', () => {
     helper.withCfg(mock, skipping);
     helper.withDb(mock, skipping);
     helper.withSentry(mock, skipping);
@@ -142,8 +142,8 @@ helper.secrets.mockSuite(testing.suiteName(), ['azure', 'gcp'], function(mock, s
     });
   });
 
-  suite('NullSentryManager', function() {
-    suiteSetup('zero out sentry config', function() {
+  suite('NullSentryManager', () => {
+    suiteSetup('zero out sentry config', () => {
       helper.load.cfg('app.sentry', {});
     });
     helper.withDb(mock, skipping);
@@ -159,7 +159,7 @@ helper.secrets.mockSuite(testing.suiteName(), ['azure', 'gcp'], function(mock, s
         err => err.statusCode === 404);
     });
 
-    test('purgeExpiredKeys', async function() {
+    test('purgeExpiredKeys', async () => {
       const sm = await helper.load('sentryManager');
       assert.strictEqual(await sm.purgeExpiredKeys(), 0);
     });

--- a/services/auth/test/signaturevalidator_test.js
+++ b/services/auth/test/signaturevalidator_test.js
@@ -11,7 +11,7 @@ import helper from './helper.js';
 
 import { normalizeClientId } from '../src/signaturevalidator.js';
 
-suite(testing.suiteName(), function() {
+suite(testing.suiteName(), () => {
   let one_hour = taskcluster.fromNow('1 hour');
   let two_hours = taskcluster.fromNow('2 hour');
   let three_hours = taskcluster.fromNow('3 hour');
@@ -46,7 +46,7 @@ suite(testing.suiteName(), function() {
     return scopes;
   };
 
-  suiteSetup(async function() {
+  suiteSetup(async () => {
     validator = createSignatureValidator({
       clientLoader: async clientId => {
         if (!clients[clientId]) {
@@ -59,8 +59,8 @@ suite(testing.suiteName(), function() {
     });
   });
 
-  let makeTest = function(name, input, expected) {
-    test(name, async function() {
+  let makeTest = (name, input, expected) => {
+    test(name, async () => {
       // defer creation of input until the test runs, if necessary
       if (typeof input === 'function') {
         input = input();
@@ -130,7 +130,7 @@ suite(testing.suiteName(), function() {
     });
   };
 
-  let testWithTemp = function(name, options, inputFn, expected) {
+  let testWithTemp = (name, options, inputFn, expected) => {
     /**
      * Options is on the form
      * {
@@ -213,7 +213,7 @@ suite(testing.suiteName(), function() {
   };
 
   // shorthands
-  let success = function(scopes, options) {
+  let success = (scopes, options) => {
     options = options || {};
     let exp = {
       clientId: options.clientId || 'root',
@@ -231,9 +231,7 @@ suite(testing.suiteName(), function() {
     return exp;
   };
 
-  let failed = function(message) {
-    return { status: 'auth-failed', message };
-  };
+  let failed = (message) => ({ status: 'auth-failed', message });
 
   makeTest('simple credentials', {
     authorization: {

--- a/services/auth/test/staticclients_test.js
+++ b/services/auth/test/staticclients_test.js
@@ -6,7 +6,7 @@ import assume from 'assume';
 import testing from '@taskcluster/lib-testing';
 import { syncStaticClients } from '../src/static-clients.js';
 
-helper.secrets.mockSuite(testing.suiteName(), ['azure', 'gcp'], function(mock, skipping) {
+helper.secrets.mockSuite(testing.suiteName(), ['azure', 'gcp'], (mock, skipping) => {
   helper.withDb(mock, skipping);
   helper.withCfg(mock, skipping);
   helper.withPulse(mock, skipping);

--- a/services/auth/test/stories_test.js
+++ b/services/auth/test/stories_test.js
@@ -4,13 +4,13 @@ import assume from 'assume';
 import taskcluster from '@taskcluster/client';
 import testing from '@taskcluster/lib-testing';
 
-helper.secrets.mockSuite(testing.suiteName(), ['azure', 'gcp'], function(mock, skipping) {
+helper.secrets.mockSuite(testing.suiteName(), ['azure', 'gcp'], (mock, skipping) => {
   helper.withCfg(mock, skipping);
   helper.withDb(mock, skipping);
   helper.withPulse(mock, skipping);
   helper.withServers(mock, skipping);
 
-  suite('charlene creates permanent credentials for a test runner', function() {
+  suite('charlene creates permanent credentials for a test runner', () => {
     suiteSetup(async function() {
       if (skipping()) {
         this.skip();
@@ -170,7 +170,7 @@ helper.secrets.mockSuite(testing.suiteName(), ['azure', 'gcp'], function(mock, s
       });
     });
 
-    test('A disabled travis-tests client can\'t do things anymore', async function() {
+    test('A disabled travis-tests client can\'t do things anymore', async () => {
       // give the user a scope we can use as a probe
       await helper.apiClient.updateClient('test-users/charlene/travis-tests', {
         description: 'Permacred created by test',

--- a/services/auth/test/testauth_test.js
+++ b/services/auth/test/testauth_test.js
@@ -12,8 +12,8 @@ const badcreds = {
   accessToken: 'wrong',
 };
 
-suite(testing.suiteName(), function() {
-  helper.secrets.mockSuite(testing.suiteName(), ['azure', 'gcp'], function(mock, skipping) {
+suite(testing.suiteName(), () => {
+  helper.secrets.mockSuite(testing.suiteName(), ['azure', 'gcp'], (mock, skipping) => {
     helper.withDb(mock, skipping);
     helper.withCfg(mock, skipping);
     helper.withPulse(mock, skipping);
@@ -100,7 +100,7 @@ suite(testing.suiteName(), function() {
     });
   });
 
-  helper.secrets.mockSuite('testAuthGet', ['azure', 'gcp'], function(mock, skipping) {
+  helper.secrets.mockSuite('testAuthGet', ['azure', 'gcp'], (mock, skipping) => {
     helper.withDb(mock, skipping);
     helper.withCfg(mock, skipping);
     helper.withPulse(mock, skipping);

--- a/services/auth/test/validate_test.js
+++ b/services/auth/test/validate_test.js
@@ -70,7 +70,7 @@ const testCases = [
   },
 ];
 
-suite(testing.suiteName(), function() {
+suite(testing.suiteName(), () => {
   // Run test cases using schemas testing utility from @taskcluster/lib-testing
   testing.schemas({
     schemasetOptions: {

--- a/services/auth/test/websocktunnel_test.js
+++ b/services/auth/test/websocktunnel_test.js
@@ -3,7 +3,7 @@ import assert from 'node:assert';
 import jwt from 'jsonwebtoken';
 import testing from '@taskcluster/lib-testing';
 
-helper.secrets.mockSuite(testing.suiteName(), ['azure', 'gcp'], function(mock, skipping) {
+helper.secrets.mockSuite(testing.suiteName(), ['azure', 'gcp'], (mock, skipping) => {
   helper.withDb(mock, skipping);
   helper.withCfg(mock, skipping);
   helper.withPulse(mock, skipping);

--- a/services/built-in-workers/test/helper.js
+++ b/services/built-in-workers/test/helper.js
@@ -7,7 +7,7 @@ const load = stickyLoader(_load);
 const helper = { load };
 export default helper;
 
-suiteSetup(async function() {
+suiteSetup(async () => {
   load.inject('profile', 'test');
   load.inject('process', 'test');
 });
@@ -22,7 +22,7 @@ suiteSetup(async function() {
 helper.rootUrl = 'http://localhost:8080';
 
 helper.withFakeQueue = () => {
-  suiteSetup(function() {
+  suiteSetup(() => {
     const queue = stubbedQueue(helper);
     load.inject('queue', queue);
   });
@@ -52,7 +52,7 @@ const stubbedQueue = (fakeQueue) => {
       accessToken: 'none',
     },
     fake: {
-      task: async function (taskId) {
+      task: async (taskId) => {
         const task = tasks[taskId];
         assert(task, `fake queue has no task ${taskId}`);
         return task;

--- a/services/built-in-workers/test/index_test.js
+++ b/services/built-in-workers/test/index_test.js
@@ -2,10 +2,10 @@ import helper from './helper.js';
 import slugid from 'slugid';
 import testing from '@taskcluster/lib-testing';
 
-suite(testing.suiteName(), function() {
+suite(testing.suiteName(), () => {
   helper.withFakeQueue();
 
-  test('check succeed worker', async function() {
+  test('check succeed worker', async () => {
     const tq = await helper.load('succeedTaskQueue');
     const taskId = slugid.nice();
     helper.claimableWork.push({
@@ -26,7 +26,7 @@ suite(testing.suiteName(), function() {
     helper.assertTaskResolved(taskId, { completed: true });
   });
 
-  test('Check Fail worker', async function() {
+  test('Check Fail worker', async () => {
     const tq = await helper.load('failTaskQueue');
     const taskId = slugid.nice();
     helper.claimableWork.push({
@@ -47,7 +47,7 @@ suite(testing.suiteName(), function() {
     helper.assertTaskResolved(taskId, { failed: true });
   });
 
-  test('Check non empty payloadd for succeed', async function() {
+  test('Check non empty payloadd for succeed', async () => {
     const tq = await helper.load('succeedTaskQueue');
     const taskId = slugid.nice();
     helper.claimableWork.push({
@@ -74,7 +74,7 @@ suite(testing.suiteName(), function() {
     helper.assertTaskResolved(taskId, { exception: expectedPayload });
   });
 
-  test('Check non empty payload for fail', async function() {
+  test('Check non empty payload for fail', async () => {
     const tq = await helper.load('failTaskQueue');
     const taskId = slugid.nice();
     helper.claimableWork.push({

--- a/services/github/src/api.js
+++ b/services/github/src/api.js
@@ -981,7 +981,7 @@ builder.declare({
     'This endpoint is used to check on backing services this service',
     'depends on.',
   ].join('\n'),
-}, function(_req, res) {
+}, (_req, res) => {
   // TODO: add implementation
   res.reply({});
 });

--- a/services/github/src/exchanges.js
+++ b/services/github/src/exchanges.js
@@ -4,7 +4,7 @@ import assert from 'node:assert';
 import { PUBLISHERS } from './constants.js';
 
 /** Build common routing key construct for `exchanges.declare` */
-const commonRoutingKey = function(options) {
+const commonRoutingKey = (options) => {
   options = options || {};
   let routingKey = [
     {
@@ -44,7 +44,7 @@ const commonRoutingKey = function(options) {
   return routingKey;
 };
 
-const commonMessageBuilder = function(msg) {
+const commonMessageBuilder = (msg) => {
   msg.version = 1;
   return msg;
 };

--- a/services/github/src/intree.js
+++ b/services/github/src/intree.js
@@ -9,10 +9,10 @@ import TcYaml from './tc-yaml.js';
  *    schema:             url,   Url to the taskcluster config schema
  *  }
  **/
-export const setup = async function({ cfg, schemaset }) {
+export const setup = async ({ cfg, schemaset }) => {
   const validate = await schemaset.validator(cfg.taskcluster.rootUrl);
 
-  return function({ config, payload, schema, now }) {
+  return ({ config, payload, schema, now }) => {
     const version = config.version;
 
     const errors = validate(config, schema[version]);

--- a/services/github/test/api_test.js
+++ b/services/github/test/api_test.js
@@ -9,14 +9,14 @@ import testing from '@taskcluster/lib-testing';
  * the github webhook endpoint which is tested
  * in webhook_test.js
  */
-helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
+helper.secrets.mockSuite(testing.suiteName(), [], (mock, skipping) => {
   helper.withDb(mock, skipping);
   helper.withFakeGithub(mock, skipping);
   helper.withFakeQueue(mock, skipping);
   helper.withPulse(mock, skipping);
   helper.withServer(mock, skipping);
 
-  suiteSetup(async function() {
+  suiteSetup(async () => {
     if (skipping()) {
       return;
     }
@@ -87,7 +87,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
 
   let github;
 
-  setup(async function() {
+  setup(async () => {
     github = await helper.load('github');
     github.inst(9090).setRepositories('coolRepo', 'anotherCoolRepo', 'awesomeRepo', 'nonTCGHRepo', 'checksRepo',
       'softStatusRepo');
@@ -269,7 +269,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
     });
   });
 
-  test('all builds', async function() {
+  test('all builds', async () => {
     let builds = await helper.apiClient.builds();
     assert.equal(builds.builds.length, 4);
     builds.builds = _.orderBy(builds.builds, ['organization', 'repository']);
@@ -279,21 +279,21 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
     assert.equal(builds.builds[3].organization, 'ghi789');
   });
 
-  test('all builds without scopes', async function() {
+  test('all builds without scopes', async () => {
     const client = new helper.GithubClient({ rootUrl: helper.rootUrl });
     await assert.rejects(
       () => client.builds(),
       err => err.code === 'InsufficientScopes');
   });
 
-  test('org builds', async function() {
+  test('org builds', async () => {
     let builds = await helper.apiClient.builds({ organization: 'abc123' });
     assert.equal(builds.builds.length, 3);
     builds.builds = _.orderBy(builds.builds, ['organization', 'repository']);
     assert.equal(builds.builds[0].organization, 'abc123');
   });
 
-  test('repo builds', async function() {
+  test('repo builds', async () => {
     let builds = await helper.apiClient.builds({ organization: 'abc123', repository: 'xyz' });
     assert.equal(builds.builds.length, 2);
     builds.builds = _.orderBy(builds.builds, ['organization', 'repository']);
@@ -301,7 +301,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
     assert.equal(builds.builds[0].repository, 'xyz');
   });
 
-  test('sha builds', async function() {
+  test('sha builds', async () => {
     let builds = await helper.apiClient.builds({
       organization: 'abc123',
       repository: 'xyz',
@@ -314,7 +314,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
     assert.equal(builds.builds[0].sha, 'y650871208002a13ba35cf232c0e30d2c3d64783');
   });
 
-  test('pull request builds', async function() {
+  test('pull request builds', async () => {
     let builds = await helper.apiClient.builds({
       organization: 'abc123',
       repository: 'xyz',
@@ -328,7 +328,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
     assert.equal(builds.builds[0].pullRequestNumber, 2);
   });
 
-  test('builds invalid queries are rejected', async function() {
+  test('builds invalid queries are rejected', async () => {
     await assert.rejects(async () => {
       await helper.apiClient.builds({
         repository: 'xyz',
@@ -343,18 +343,18 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
     }, /Error: Must provide/);
   });
 
-  suite('cancel builds', function() {
-    setup(async function() {
+  suite('cancel builds', () => {
+    setup(async () => {
       // reset build states
       const builds = await helper.db.fns.get_github_builds_pr(null, null, null, null, null, null);
       await Promise.all(builds.map(build => helper.db.fns.set_github_build_state(build.task_group_id, 'pending')));
     });
-    test('nothing to cancel', async function () {
+    test('nothing to cancel', async () => {
       await assert.rejects(async () => {
         await helper.apiClient.cancelBuilds('no-such-org', 'no-repo');
       }, /Error: No cancellable builds found/);
     });
-    test('cancel running builds for repo', async function() {
+    test('cancel running builds for repo', async () => {
       let builds = await helper.apiClient.cancelBuilds('abc123', 'xyz');
       assert.equal(builds.builds.length, 2);
       builds.builds = _.orderBy(builds.builds, ['organization', 'repository']);
@@ -362,7 +362,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       assert.equal(builds.builds[0].repository, 'xyz');
       assert.equal(builds.builds[0].state, 'cancelled');
     });
-    test('cancel running builds for PR', async function() {
+    test('cancel running builds for PR', async () => {
       let builds = await helper.apiClient.cancelBuilds('abc123', 'xyz', { pullRequest: 2 });
       assert.equal(builds.builds.length, 1);
       builds.builds = _.orderBy(builds.builds, ['organization', 'repository']);
@@ -370,20 +370,20 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       assert.equal(builds.builds[0].repository, 'xyz');
       assert.equal(builds.builds[0].state, 'cancelled');
     });
-    test('cannot cancel twice same builds', async function() {
+    test('cannot cancel twice same builds', async () => {
       let builds = await helper.apiClient.cancelBuilds('abc123', 'xyz', { pullRequest: 2 });
       assert.equal(builds.builds.length, 1);
       await assert.rejects(async () => {
         await helper.apiClient.cancelBuilds('no-such-org', 'no-repo');
       }, /Error: No cancellable builds found/);
     });
-    test('no scopes', async function() {
+    test('no scopes', async () => {
       const noScopesClient = new helper.GithubClient({ rootUrl: helper.rootUrl });
       await assert.rejects(async () => {
         await noScopesClient.cancelBuilds('abc123', 'xyz');
       }, err => err.code === 'InsufficientScopes');
     });
-    test('scopes: wrong org and repo', async function () {
+    test('scopes: wrong org and repo', async () => {
       await testing.fakeauth.withAnonymousScopes(['github:cancel-builds:wrong-org:wrong-repo'], async () => {
         await assert.rejects(
           () => got.post(helper.apiClient.buildUrl(helper.apiClient.cancelBuilds, 'abc123', 'xyz')),
@@ -391,7 +391,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
         );
       });
     });
-    test('scopes: wrong repo', async function () {
+    test('scopes: wrong repo', async () => {
       await testing.fakeauth.withAnonymousScopes(['github:cancel-builds:abc123:wrong-repo'], async () => {
         await assert.rejects(
           () => got.post(helper.apiClient.buildUrl(helper.apiClient.cancelBuilds, 'abc123', 'xyz', {})),
@@ -399,7 +399,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
         );
       });
     });
-    test('scopes: expand scopes works', async function () {
+    test('scopes: expand scopes works', async () => {
       await testing.fakeauth.withAnonymousScopes(['github:cancel-builds:abc123:*'], async () => {
         const builds = await got.post(
           helper.apiClient.buildUrl(helper.apiClient.cancelBuilds, 'abc123', 'xyz'),
@@ -410,7 +410,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
     });
   });
 
-  test('integration installation', async function() {
+  test('integration installation', async () => {
     let result = await helper.apiClient.repository('abc123', 'coolRepo');
     assert.deepEqual(result, { installed: true });
     result = await helper.apiClient.repository('abc123', 'unknownRepo');
@@ -419,14 +419,14 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
     assert.deepEqual(result, { installed: false });
   });
 
-  test('repository() without scopes', async function() {
+  test('repository() without scopes', async () => {
     const client = new helper.GithubClient({ rootUrl: helper.rootUrl });
     await assert.rejects(
       () => client.repository('a', 'b'),
       err => err.code === 'InsufficientScopes');
   });
 
-  test('build badges - status:failure', async function() {
+  test('build badges - status:failure', async () => {
     await testing.fakeauth.withAnonymousScopes(['github:get-badge:abc123:*'], async () => {
       let res = await got(helper.apiClient.buildUrl(helper.apiClient.badge, 'abc123', 'coolRepo', 'master'));
       assert.equal(res.headers['x-taskcluster-status'], 'failure');
@@ -434,7 +434,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
     });
   });
 
-  test('build badges - status:failure (checks API)', async function() {
+  test('build badges - status:failure (checks API)', async () => {
     await testing.fakeauth.withAnonymousScopes(['github:get-badge:abc123:*'], async () => {
       let res = await got(helper.apiClient.buildUrl(helper.apiClient.badge, 'abc123', 'checksRepo', 'failure'));
       assert.equal(res.headers['x-taskcluster-status'], 'failure');
@@ -442,7 +442,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
     });
   });
 
-  test('build badges - status:failure (combined status and checks)', async function() {
+  test('build badges - status:failure (combined status and checks)', async () => {
     await testing.fakeauth.withAnonymousScopes(['github:get-badge:abc123:*'], async () => {
       let res = await got(helper.apiClient.buildUrl(helper.apiClient.badge, 'abc123', 'checksRepo', 'combined'));
       assert.equal(res.headers['x-taskcluster-status'], 'failure');
@@ -455,7 +455,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
     });
   });
 
-  test('build badges - status: success', async function() {
+  test('build badges - status: success', async () => {
     await testing.fakeauth.withAnonymousScopes(['github:get-badge:abc123:*'], async () => {
       let res = await got(helper.apiClient.buildUrl(helper.apiClient.badge, 'abc123', 'awesomeRepo', 'master'));
       assert.equal(res.headers['x-taskcluster-status'], 'success');
@@ -463,7 +463,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
     });
   });
 
-  test('build badges - status: success (checks API)', async function() {
+  test('build badges - status: success (checks API)', async () => {
     await testing.fakeauth.withAnonymousScopes(['github:get-badge:abc123:*'], async () => {
       let res = await got(helper.apiClient.buildUrl(helper.apiClient.badge, 'abc123', 'checksRepo', 'success'));
       assert.equal(res.headers['x-taskcluster-status'], 'success');
@@ -471,7 +471,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
     });
   });
 
-  test('build badges - status: pending (checks API)', async function() {
+  test('build badges - status: pending (checks API)', async () => {
     await testing.fakeauth.withAnonymousScopes(['github:get-badge:abc123:*'], async () => {
       let res = await got(helper.apiClient.buildUrl(helper.apiClient.badge, 'abc123', 'checksRepo', 'pending'));
       assert.equal(res.headers['x-taskcluster-status'], 'pending');
@@ -479,7 +479,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
     });
   });
 
-  test('build badges - error', async function() {
+  test('build badges - error', async () => {
     await testing.fakeauth.withAnonymousScopes(['github:get-badge:abc123:*'], async () => {
       let res = await got(helper.apiClient.buildUrl(helper.apiClient.badge, 'abc123', 'errorRepo', 'master'));
       assert.equal(res.headers['x-taskcluster-status'], 'error');
@@ -487,7 +487,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
     });
   });
 
-  test('build badges - no such status', async function() {
+  test('build badges - no such status', async () => {
     await testing.fakeauth.withAnonymousScopes(['github:get-badge:abc123:*'], async () => {
       let res = await got(helper.apiClient.buildUrl(helper.apiClient.badge, 'abc123', 'unknownRepo', 'master'));
       assert.equal(res.headers['x-taskcluster-status'], 'newrepo');
@@ -495,7 +495,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
     });
   });
 
-  test('build badges - new repo (no info yet)', async function() {
+  test('build badges - new repo (no info yet)', async () => {
     await testing.fakeauth.withAnonymousScopes(['github:get-badge:abc123:*'], async () => {
       let res = await got(helper.apiClient.buildUrl(helper.apiClient.badge, 'abc123', 'nonTCGHRepo', 'master'));
       assert.equal(res.headers['x-taskcluster-status'], 'newrepo');
@@ -503,42 +503,42 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
     });
   });
 
-  test('build badges - checks conclusion - timed out', async function() {
+  test('build badges - checks conclusion - timed out', async () => {
     await testing.fakeauth.withAnonymousScopes(['github:get-badge:abc123:*'], async () => {
       let res = await got(helper.apiClient.buildUrl(helper.apiClient.badge, 'abc123', 'softStatusRepo', 'timedout'));
       assert.equal(res.headers['x-taskcluster-status'], 'timed_out');
       assert.equal(res.body.length, 7159);
     });
   });
-  test('build badges - checks conclusion - action required', async function() {
+  test('build badges - checks conclusion - action required', async () => {
     await testing.fakeauth.withAnonymousScopes(['github:get-badge:abc123:*'], async () => {
       let res = await got(helper.apiClient.buildUrl(helper.apiClient.badge, 'abc123', 'softStatusRepo', 'actionRequired'));
       assert.equal(res.headers['x-taskcluster-status'], 'action_required');
       assert.equal(res.body.length, 10864);
     });
   });
-  test('build badges - checks conclusion - skipped', async function() {
+  test('build badges - checks conclusion - skipped', async () => {
     await testing.fakeauth.withAnonymousScopes(['github:get-badge:abc123:*'], async () => {
       let res = await got(helper.apiClient.buildUrl(helper.apiClient.badge, 'abc123', 'softStatusRepo', 'skipped'));
       assert.equal(res.headers['x-taskcluster-status'], 'skipped');
       assert.equal(res.body.length, 7248);
     });
   });
-  test('build badges - checks conclusion - stale', async function() {
+  test('build badges - checks conclusion - stale', async () => {
     await testing.fakeauth.withAnonymousScopes(['github:get-badge:abc123:*'], async () => {
       let res = await got(helper.apiClient.buildUrl(helper.apiClient.badge, 'abc123', 'softStatusRepo', 'stale'));
       assert.equal(res.headers['x-taskcluster-status'], 'stale');
       assert.equal(res.body.length, 5509);
     });
   });
-  test('build badges - checks conclusion - neutral', async function() {
+  test('build badges - checks conclusion - neutral', async () => {
     await testing.fakeauth.withAnonymousScopes(['github:get-badge:abc123:*'], async () => {
       let res = await got(helper.apiClient.buildUrl(helper.apiClient.badge, 'abc123', 'softStatusRepo', 'neutral'));
       assert.equal(res.headers['x-taskcluster-status'], 'neutral');
       assert.equal(res.body.length, 5775);
     });
   });
-  test('build badges - checks conclusion - cancelled', async function() {
+  test('build badges - checks conclusion - cancelled', async () => {
     await testing.fakeauth.withAnonymousScopes(['github:get-badge:abc123:*'], async () => {
       let res = await got(helper.apiClient.buildUrl(helper.apiClient.badge, 'abc123', 'softStatusRepo', 'cancelled'));
       assert.equal(res.headers['x-taskcluster-status'], 'cancelled');
@@ -546,14 +546,14 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
     });
   });
 
-  test('build badges without scopes', async function() {
+  test('build badges without scopes', async () => {
     const client = new helper.GithubClient({ rootUrl: helper.rootUrl });
     await assert.rejects(
       () => client.badge('a', 'b', 'c'),
       err => err.code === 'InsufficientScopes');
   });
 
-  test('link for clickable badges with status', async function() {
+  test('link for clickable badges with status', async () => {
     let res;
 
     await testing.fakeauth.withAnonymousScopes(['github:latest-status:abc123:*'], async () => {
@@ -569,7 +569,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
     });
   });
 
-  test('link for clickable badges with checks', async function() {
+  test('link for clickable badges with checks', async () => {
     let res;
 
     await testing.fakeauth.withAnonymousScopes(['github:latest-status:abc123:*'], async () => {
@@ -585,7 +585,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
     });
   });
 
-  test('link for clickable badges when no such thing exists', async function() {
+  test('link for clickable badges when no such thing exists', async () => {
     await testing.fakeauth.withAnonymousScopes(['github:latest-status:abc123:*'], async () => {
       await assert.rejects(() => got(
         helper.apiClient.buildUrl(helper.apiClient.latest, 'abc123', 'unknownRepo', 'nosuch'),
@@ -593,7 +593,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
     });
   });
 
-  test('link for clickable badges when no branch exists', async function() {
+  test('link for clickable badges when no branch exists', async () => {
     await testing.fakeauth.withAnonymousScopes(['github:latest-status:abc123:*'], async () => {
       await assert.rejects(() => got(
         helper.apiClient.buildUrl(helper.apiClient.latest, 'abc123', 'checksRepo', 'noSuchBranch'),
@@ -601,7 +601,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
     });
   });
 
-  test('link for clickable badges when no installation exists', async function() {
+  test('link for clickable badges when no installation exists', async () => {
     await testing.fakeauth.withAnonymousScopes(['github:latest-status:noSuchOwner:*'], async () => {
       await assert.rejects(() => got(
         helper.apiClient.buildUrl(helper.apiClient.latest, 'noSuchOwner', 'noSuchRepo', 'noSuchBranch'),
@@ -609,14 +609,14 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
     });
   });
 
-  test('latest link without scopes', async function() {
+  test('latest link without scopes', async () => {
     const client = new helper.GithubClient({ rootUrl: helper.rootUrl });
     await assert.rejects(
       () => client.latest('a', 'b', 'c'),
       err => err.code === 'InsufficientScopes');
   });
 
-  test('simple status creation', async function() {
+  test('simple status creation', async () => {
     await helper.apiClient.createStatus('abc123', 'awesomeRepo', 'master', {
       state: 'error',
     });
@@ -632,7 +632,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
     assert.equal(status.context, 'default');
   });
 
-  test('advanced status creation', async function() {
+  test('advanced status creation', async () => {
     await helper.apiClient.createStatus('abc123', 'awesomeRepo', 'master', {
       state: 'failure',
       target_url: 'http://test.com',
@@ -651,7 +651,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
     assert.equal(status.context, 'customContext');
   });
 
-  test('status creation where integration lacks permission', async function() {
+  test('status creation where integration lacks permission', async () => {
     try {
       await helper.apiClient.createStatus('abc123', 'no-permission', 'master', {
         state: 'failure',
@@ -665,7 +665,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
     }
     throw new Error('endpoint should have failed');
   });
-  test('pull request comment', async function() {
+  test('pull request comment', async () => {
     await helper.apiClient.createComment('abc123', 'awesomeRepo', 1, {
       body: 'Task failed here',
     });
@@ -678,7 +678,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
     assert.equal(comment.body, 'Task failed here');
   });
 
-  test('pull request comment where integration lacks permission', async function() {
+  test('pull request comment where integration lacks permission', async () => {
     try {
       await helper.apiClient.createComment('abc123', 'no-permission', 1, { body: 'x' });
     } catch (e) {
@@ -688,7 +688,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
     throw new Error('endpoint should have failed');
   });
 
-  suite('render taskcluster.yml', function() {
+  suite('render taskcluster.yml', () => {
     const tcYaml = `version: 1
 reporting: checks-v1
 policy:
@@ -730,7 +730,7 @@ tasks:
       { fakeEvent: { type: 'github-release', action: 'released' }, tasksCount: 0, scopesCount: 3, scope: 'release:released' },
     ];
     eventTypes.map(({ fakeEvent, tasksCount, scopesCount, scope }) =>
-      test(`render .tc.yml for event ${fakeEvent.type} ${fakeEvent.action || ''} ${scope}`, async function() {
+      test(`render .tc.yml for event ${fakeEvent.type} ${fakeEvent.action || ''} ${scope}`, async () => {
         const { tasks, scopes } = await helper.apiClient.renderTaskclusterYml({
           body: tcYaml,
           fakeEvent,
@@ -747,7 +747,7 @@ tasks:
         ]);
       }),
     );
-    test('invalid branch name is properly escaped', async function () {
+    test('invalid branch name is properly escaped', async () => {
       const tcYaml = `version: 1
 reporting: checks-v1
 tasks: []

--- a/services/github/test/fake_github_test.js
+++ b/services/github/test/fake_github_test.js
@@ -4,7 +4,7 @@ import { Octokit as github } from '@octokit/rest';
 import fakeGithubAuth from './github-auth.js';
 import testing from '@taskcluster/lib-testing';
 
-suite(testing.suiteName(), function() {
+suite(testing.suiteName(), () => {
 
   function checkKeys(obj, platonic) {
     let ours = _.filter(Object.keys(obj), k => !k.startsWith('_'));
@@ -17,7 +17,7 @@ suite(testing.suiteName(), function() {
     });
   }
 
-  test('matches real lib', async function() {
+  test('matches real lib', async () => {
     let inst = await fakeGithubAuth().getInstallationGithub('doesntmatter');
     checkKeys(inst, new github());
   });

--- a/services/github/test/github-auth_test.js
+++ b/services/github/test/github-auth_test.js
@@ -37,9 +37,9 @@ ZcJjRIt8w8g/s4X6MhKasBYm9s3owALzCuJjGzUKcDHiO2DKu1xXAb0SzRcTzUCn
 x//0u+zd/R/QRUzLOw4N72/Hu+UG6MNt5iDZFCtapRaKt6OvSBwy8w==
 -----END RSA PRIVATE KEY-----`;
 
-suite(testing.suiteName(), function() {
-  suite('octokit wrapping', function() {
-    test('getAppGithub', async function() {
+suite(testing.suiteName(), () => {
+  suite('octokit wrapping', () => {
+    test('getAppGithub', async () => {
       nock('https://api.github.com:443')
         .post('/app/installations/100/access_tokens')
         .reply(200);
@@ -59,18 +59,18 @@ suite(testing.suiteName(), function() {
       await gh.getInstallationGithub(100);
     });
   });
-  suite('getPrivatePEM', function() {
-    test('with actual newlines', function() {
+  suite('getPrivatePEM', () => {
+    test('with actual newlines', () => {
       const cfg = { github: { credentials: { privatePEM: WITH_NEWLINES } } };
       assert.equal(getPrivatePEM(cfg), WITH_NEWLINES);
     });
 
-    test('with escaped newlines', function() {
+    test('with escaped newlines', () => {
       const cfg = { github: { credentials: { privatePEM: WITH_ESCAPED_NEWLINES } } };
       assert.equal(getPrivatePEM(cfg), WITH_NEWLINES);
     });
 
-    test('with invalid value', function() {
+    test('with invalid value', () => {
       const cfg = { github: { credentials: { privatePEM: 'somekey' } } };
       assert.throws(() => getPrivatePEM(cfg), err => {
         assert(/must match/.test(err.toString()));
@@ -79,7 +79,7 @@ suite(testing.suiteName(), function() {
       });
     });
   });
-  suite('getCachedInstallationToken', function () {
+  suite('getCachedInstallationToken', () => {
     const getGh = async () => {
       const gh = await githubAuth({
         monitor: await helper.load('monitor'),
@@ -95,7 +95,7 @@ suite(testing.suiteName(), function() {
       return gh.getAppGithub();
     };
 
-    test('cache responses', async function() {
+    test('cache responses', async () => {
       nock('https://api.github.com:443')
         .post('/app/installations/500/access_tokens')
         .reply(200, { expires_at: new Date('3000-01-01T00:00:00Z'), token: 'abc' });
@@ -110,7 +110,7 @@ suite(testing.suiteName(), function() {
       assert.equal(true, nock.isDone());
     });
 
-    test('cache responses and checks expiration dates', async function() {
+    test('cache responses and checks expiration dates', async () => {
       nock('https://api.github.com:443')
         .post('/app/installations/505/access_tokens')
         .times(2)

--- a/services/github/test/handler_test.js
+++ b/services/github/test/handler_test.js
@@ -19,7 +19,7 @@ const loadJson = filename => JSON.parse(fs.readFileSync(path.join(dataDir, filen
  * This tests the event handlers, faking out all of the services they
  * interact with.
  */
-helper.secrets.mockSuite(testing.suiteName(), [], function (mock, skipping) {
+helper.secrets.mockSuite(testing.suiteName(), [], (mock, skipping) => {
   helper.withDb(mock, skipping);
   helper.withFakeGithub(mock, skipping);
   helper.withPulse(mock, skipping);
@@ -125,7 +125,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function (mock, skipping) {
     await handlerComplete;
   }
 
-  setup(async function () {
+  setup(async () => {
     helper.load.save();
 
     helper.load.cfg('taskcluster.rootUrl', libUrls.testRootUrl());
@@ -206,12 +206,12 @@ helper.secrets.mockSuite(testing.suiteName(), [], function (mock, skipping) {
     });
   });
 
-  teardown(async function () {
+  teardown(async () => {
     await handlers.terminate();
     helper.load.restore();
   });
 
-  suite('createTasks', function () {
+  suite('createTasks', () => {
     let createdTasks;
 
     suiteSetup(function () {
@@ -220,7 +220,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function (mock, skipping) {
       }
     });
 
-    setup(function () {
+    setup(() => {
       createdTasks = [];
 
       handlers.queueClient = new taskcluster.Queue({
@@ -237,12 +237,12 @@ helper.secrets.mockSuite(testing.suiteName(), [], function (mock, skipping) {
       });
     });
 
-    test('does not call queue.createTask if given no tasks', async function () {
+    test('does not call queue.createTask if given no tasks', async () => {
       await handlers.realCreateTasks({ scopes: [], tasks: [] });
       assert.equal(createdTasks.length, 0);
     });
 
-    test('calls queue.createTask in order', async function () {
+    test('calls queue.createTask in order', async () => {
       await handlers.realCreateTasks({
         scopes: [], tasks: [
           { taskId: 'aa', task: { payload: 'a' } },
@@ -253,7 +253,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function (mock, skipping) {
       assert.deepEqual(createdTasks.map(({ payload }) => payload), ['a', 'b', 'c']);
     });
 
-    test('propagates unknown errors', async function () {
+    test('propagates unknown errors', async () => {
       await assert.rejects(
         handlers.realCreateTasks({
           scopes: [], tasks: [
@@ -264,7 +264,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function (mock, skipping) {
       );
     });
 
-    test('handles InsufficientScopes errors', async function () {
+    test('handles InsufficientScopes errors', async () => {
       await assert.rejects(
         handlers.realCreateTasks({
           scopes: ['assume:repo:github.com/a/b:branch:master', 'queue:route:statuses'],
@@ -300,7 +300,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function (mock, skipping) {
     });
   });
 
-  suite('cancelPreviousTaskGroups', function () {
+  suite('cancelPreviousTaskGroups', () => {
     let sealedTaskGroups;
     let cancelledTaskGroups;
 
@@ -310,7 +310,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function (mock, skipping) {
       }
     });
 
-    setup(function () {
+    setup(() => {
       sealedTaskGroups = [];
       cancelledTaskGroups = [];
 
@@ -327,7 +327,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function (mock, skipping) {
       });
     });
 
-    test('does not call queue.sealTaskGroup/cancelTaskGroup if no previous builds', async function () {
+    test('does not call queue.sealTaskGroup/cancelTaskGroup if no previous builds', async () => {
       await handlers.realCancelPreviousTaskGroups({
         instGithub: sinon.stub(),
         debug: sinon.stub(),
@@ -337,7 +337,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function (mock, skipping) {
       assert.equal(cancelledTaskGroups.length, 0);
     });
 
-    test('errors in queue.sealTask/cancelTaskGroup group are logged', async function () {
+    test('errors in queue.sealTask/cancelTaskGroup group are logged', async () => {
       handlers.queueClient = new taskcluster.Queue({
         rootUrl: 'https://tc.example.com',
         fake: {
@@ -376,7 +376,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function (mock, skipping) {
       monitor.manager.reset();
     });
 
-    test('non-existent task groups queue.sealTask/cancelTaskGroup group are ignored', async function () {
+    test('non-existent task groups queue.sealTask/cancelTaskGroup group are ignored', async () => {
       const err = new Error('ResourceNotFound');
       err.code = 'ResourceNotFound';
       err.statusCode = 404;
@@ -424,7 +424,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function (mock, skipping) {
       assert.equal(buildB.state, 'cancelled');
     });
 
-    test('calls queue.sealTaskGroup/cancelTaskGroup for pulNumber excluding new task group id', async function () {
+    test('calls queue.sealTaskGroup/cancelTaskGroup for pulNumber excluding new task group id', async () => {
       await addBuild({ state: 'pending', taskGroupId: 'aa', pullNumber: 1, eventType: 'pull_request.opened' });
       await addBuild({ state: 'pending', taskGroupId: 'bb', pullNumber: 1, eventType: 'pull_request.synchronize' });
       await addBuild({ state: 'pending', taskGroupId: 'cc', pullNumber: 1, eventType: 'pull_request.synchronize' });
@@ -448,7 +448,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function (mock, skipping) {
       assert.equal(buildC.state, 'cancelled');
     });
 
-    test('calls queue.sealTaskGroup/cancelTaskGroup for SHA excluding new task group id', async function () {
+    test('calls queue.sealTaskGroup/cancelTaskGroup for SHA excluding new task group id', async () => {
       await addBuild({ state: 'pending', taskGroupId: 'aa' });
       await addBuild({ state: 'pending', taskGroupId: 'bb' });
       await addBuild({ state: 'pending', taskGroupId: 'cc' });
@@ -466,7 +466,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function (mock, skipping) {
       assert.deepEqual(cancelledTaskGroups, []);
     });
 
-    test('respects same event types for pull_request', async function () {
+    test('respects same event types for pull_request', async () => {
       await addBuild({ state: 'pending', taskGroupId: 'aa', pullNumber: 3, eventType: 'pull_request.opened' });
       await addBuild({ state: 'pending', taskGroupId: 'bb', pullNumber: 3, eventType: 'pull_request.synchronize' });
       await addBuild({ state: 'pending', taskGroupId: 'cc', pullNumber: 3, eventType: 'pull_request.closed' });
@@ -490,7 +490,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function (mock, skipping) {
       assert.deepEqual(cancelledTaskGroups, ['aa']);
     });
 
-    test('cancels nothing on release event', async function () {
+    test('cancels nothing on release event', async () => {
       await addBuild({ state: 'pending', taskGroupId: 'aa', pullNumber: null, eventType: 'release' });
       await addBuild({ state: 'pending', taskGroupId: 'bb', pullNumber: 1012, eventType: 'pull_request.opened' });
       await addBuild({ state: 'pending', taskGroupId: 'ee', pullNumber: null, eventType: 'tag' });
@@ -511,7 +511,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function (mock, skipping) {
       assert.deepEqual(sealedTaskGroups, []);
       assert.deepEqual(cancelledTaskGroups, []);
     });
-    test('cancels nothing on unknown event', async function () {
+    test('cancels nothing on unknown event', async () => {
       await addBuild({ state: 'pending', taskGroupId: 'aa', pullNumber: null, eventType: 'release' });
       await addBuild({ state: 'pending', taskGroupId: 'bb', pullNumber: 1012, eventType: 'pull_request.opened' });
       await addBuild({ state: 'pending', taskGroupId: 'ee', pullNumber: null, eventType: 'tag' });
@@ -534,7 +534,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function (mock, skipping) {
     });
   });
 
-  suite('jobHandler', function () {
+  suite('jobHandler', () => {
     suiteSetup(function () {
       if (skipping()) {
         this.skip();
@@ -635,7 +635,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function (mock, skipping) {
       await handlerComplete;
     }
 
-    test('tasks generated as non-list', async function () {
+    test('tasks generated as non-list', async () => {
       github.inst(INST_ID).setTaskclusterYml({
         owner: 'TaskclusterRobot',
         repo: 'hooks-testing',
@@ -652,7 +652,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function (mock, skipping) {
       assert(args[0][0].body.indexOf('tasks field  of .taskcluster.yml must be array of tasks or empty array') !== -1);
     });
 
-    test('tasks generated as undefined is OK', async function () {
+    test('tasks generated as undefined is OK', async () => {
       github.inst(INST_ID).setTaskclusterYml({
         owner: 'TaskclusterRobot',
         repo: 'hooks-testing',
@@ -664,7 +664,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function (mock, skipping) {
       assert(github.inst(INST_ID).repos.createCommitComment.notCalled);
     });
 
-    test('valid push (owner is collaborator) creates a taskGroup', async function () {
+    test('valid push (owner is collaborator) creates a taskGroup', async () => {
       github.inst(INST_ID).setTaskclusterYml({
         owner: 'TaskclusterRobot',
         repo: 'hooks-testing',
@@ -683,7 +683,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function (mock, skipping) {
       assert.equal(build.state, 'pending');
     });
 
-    test('valid pull_request (user is collaborator) creates a taskGroup', async function () {
+    test('valid pull_request (user is collaborator) creates a taskGroup', async () => {
       github.inst(INST_ID).setRepoCollaborator({
         owner: 'TaskclusterRobot',
         repo: 'hooks-testing',
@@ -714,7 +714,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function (mock, skipping) {
       assert.equal(build.state, 'pending');
     });
 
-    test('valid pull_request (user is not a collaborator) does not create tasks', async function() {
+    test('valid pull_request (user is not a collaborator) does not create tasks', async () => {
       github.inst(INST_ID).setTaskclusterYml({
         owner: 'TaskclusterRobot',
         repo: 'hooks-testing',
@@ -733,7 +733,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function (mock, skipping) {
       assert(handlers.createTasks.notCalled);
     });
 
-    test('valid pull_request (user is not a collaborator, policy is public) creates a taskGroup', async function() {
+    test('valid pull_request (user is not a collaborator, policy is public) creates a taskGroup', async () => {
       let tcyaml = { ...validYamlV1Json };
       tcyaml['policy'] = { 'pullRequests': 'public' };
 
@@ -764,7 +764,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function (mock, skipping) {
       assert.equal(build.state, 'pending');
     });
 
-    test('valid pull_request (user is not a collaborator, policy is public_restricted) creates a taskGroup', async function() {
+    test('valid pull_request (user is not a collaborator, policy is public_restricted) creates a taskGroup', async () => {
       let tcyaml = { ...validYamlV1Json };
       tcyaml['policy'] = { 'pullRequests': 'public_restricted' };
 
@@ -795,7 +795,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function (mock, skipping) {
       assert.equal(build.state, 'pending');
     });
 
-    test('valid push (but not collaborator) creates a taskGroup', async function() {
+    test('valid push (but not collaborator) creates a taskGroup', async () => {
       github.inst(INST_ID).setTaskclusterYml({
         owner: 'TaskclusterRobot',
         repo: 'hooks-testing',
@@ -814,7 +814,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function (mock, skipping) {
       assert.equal(build.state, 'pending');
     });
 
-    test('valid tag push (but not collaborator) creates a taskGroup', async function () {
+    test('valid tag push (but not collaborator) creates a taskGroup', async () => {
       github.inst(INST_ID).setTaskclusterYml({
         owner: 'TaskclusterRobot',
         repo: 'hooks-testing',
@@ -838,7 +838,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function (mock, skipping) {
       assert.equal(build.state, 'pending');
     });
 
-    test('invalid task list results in a comment', async function () {
+    test('invalid task list results in a comment', async () => {
       github.inst(INST_ID).setTaskclusterYml({
         owner: 'TaskclusterRobot',
         repo: 'hooks-testing',
@@ -856,7 +856,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function (mock, skipping) {
       assert(args[0][0].body.indexOf('data/tasks must be array') !== -1);
     });
 
-    test('invalid YAML results in a comment', async function () {
+    test('invalid YAML results in a comment', async () => {
       github.inst(INST_ID).setTaskclusterYml({
         owner: 'TaskclusterRobot',
         repo: 'hooks-testing',
@@ -874,7 +874,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function (mock, skipping) {
       assert(args[0][0].body.indexOf('data must NOT have additional properties') !== -1);
     });
 
-    test('error creating task is reported correctly', async function () {
+    test('error creating task is reported correctly', async () => {
       github.inst(INST_ID).setTaskclusterYml({
         owner: 'TaskclusterRobot',
         repo: 'hooks-testing',
@@ -892,7 +892,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function (mock, skipping) {
       assert(args[0][0].body.indexOf('oh noes') !== -1);
     });
 
-    suite('Issue comment', function () {
+    suite('Issue comment', () => {
       async function simulateIssueCommentMessage({ user, body = null }) {
         if (!body) {
           body = webhookCommentEditedJson.body;
@@ -929,7 +929,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function (mock, skipping) {
 
       let instGithub;
 
-      setup(function () {
+      setup(() => {
         instGithub = github.inst(INST_ID);
         instGithub.setRepoCollaborator({
           owner: 'taskcluster',
@@ -970,7 +970,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function (mock, skipping) {
         });
       });
 
-      test('valid issue_comment (user is collaborator) creates a taskGroup', async function () {
+      test('valid issue_comment (user is collaborator) creates a taskGroup', async () => {
         await simulateIssueCommentMessage({ user: 'lotas' });
 
         assert(handlers.createTasks.calledWith({ scopes: sinon.match.array, tasks: sinon.match.array }));
@@ -983,7 +983,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function (mock, skipping) {
         assert.equal(build.state, 'pending');
       });
 
-      test('valid issue_comment (user is collaborator) no tasks created', async function () {
+      test('valid issue_comment (user is collaborator) no tasks created', async () => {
         instGithub.setTaskclusterYml({
           owner: 'taskcluster',
           repo: 'tc-dev-integration-test',
@@ -1000,7 +1000,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function (mock, skipping) {
         assert(instGithub.issues.createComment.calledOnce);
       });
 
-      test('valid issue_comment (user is not a collaborator) skips task creation', async function () {
+      test('valid issue_comment (user is not a collaborator) skips task creation', async () => {
         await simulateIssueCommentMessage({ user: 'notCollaborator' });
 
         assert(handlers.createTasks.notCalled);
@@ -1012,7 +1012,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function (mock, skipping) {
         assert(args[0][0].body.indexOf('is not a collaborator') !== -1);
       });
 
-      test('.taskcluster.yml does not allow comments - no tasks created ', async function () {
+      test('.taskcluster.yml does not allow comments - no tasks created ', async () => {
         instGithub.setTaskclusterYml({
           owner: 'taskcluster',
           repo: 'tc-dev-integration-test',
@@ -1032,8 +1032,8 @@ helper.secrets.mockSuite(testing.suiteName(), [], function (mock, skipping) {
       });
     });
 
-    suite('Cancel running task groups', function () {
-      test('should not cancel task groups on the default branch', async function () {
+    suite('Cancel running task groups', () => {
+      test('should not cancel task groups on the default branch', async () => {
         const tcYaml = validYamlV1Json;
         github.inst(INST_ID).setRepoCollaborator({
           owner: 'TaskclusterRobot',
@@ -1059,7 +1059,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function (mock, skipping) {
 
         assert(handlers.cancelPreviousTaskGroups.notCalled);
       });
-      test('should respect .taskcluster.yml autoCancelPreviousChecks config', async function () {
+      test('should respect .taskcluster.yml autoCancelPreviousChecks config', async () => {
         const tcYaml = validYamlV1Json;
         tcYaml['autoCancelPreviousChecks'] = false;
         github.inst(INST_ID).setTaskclusterYml({
@@ -1092,7 +1092,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function (mock, skipping) {
         assert.equal(cancelCallArgs.newBuild.sha, COMMIT_SHA);
         assert.equal(cancelCallArgs.newBuild.pull_number, null);
       });
-      test('should cancel by default', async function () {
+      test('should cancel by default', async () => {
         const tcYaml = validYamlV1Json;
         github.inst(INST_ID).setRepoCollaborator({
           owner: 'TaskclusterRobot',
@@ -1109,7 +1109,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function (mock, skipping) {
         assert(handlers.createTasks.calledWith({ scopes: sinon.match.array, tasks: sinon.match.array }));
         assert(handlers.cancelPreviousTaskGroups.calledOnce);
       });
-      test('should cancel task groups for same pull request number', async function () {
+      test('should cancel task groups for same pull request number', async () => {
         const tcYaml = validYamlV1Json;
         tcYaml['autoCancelPreviousChecks'] = true;
         github.inst(INST_ID).setRepoCollaborator({
@@ -1151,9 +1151,9 @@ helper.secrets.mockSuite(testing.suiteName(), [], function (mock, skipping) {
       });
     });
 
-    suite('PR permissions (collaborators)', function () {
+    suite('PR permissions (collaborators)', () => {
       const testPermissions = (name, { opener, headUser, succeed }) => {
-        test(name, async function () {
+        test(name, async () => {
           github.inst(INST_ID).setRepoCollaborator({
             owner: 'TaskclusterRobot',
             repo: 'hooks-testing',
@@ -1201,7 +1201,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function (mock, skipping) {
       testPermissions('collaborator opens PR for another repo', { opener: 'goodBuddy', headUser: 'some-other-repo', succeed: false });
     });
 
-    test('specifying allowPullRequests: public in the default branch allows all', async function () {
+    test('specifying allowPullRequests: public in the default branch allows all', async () => {
       github.inst(INST_ID).setTaskclusterYml({
         owner: 'TaskclusterRobot',
         repo: 'hooks-testing',
@@ -1219,7 +1219,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function (mock, skipping) {
       assert(github.inst(INST_ID).issues.createComment.callCount === 0);
     });
 
-    test('specifying allowPullRequests: collaborators in the default branch disallows public', async function () {
+    test('specifying allowPullRequests: collaborators in the default branch disallows public', async () => {
       github.inst(INST_ID).setTaskclusterYml({
         owner: 'TaskclusterRobot',
         repo: 'hooks-testing',
@@ -1238,7 +1238,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function (mock, skipping) {
       assert(github.inst(INST_ID).issues.createComment.callCount === 1);
     });
 
-    test('user name not checked for pushes, so status is created', async function () {
+    test('user name not checked for pushes, so status is created', async () => {
       github.inst(INST_ID).setTaskclusterYml({
         owner: 'TaskclusterRobot',
         repo: 'hooks-testing',
@@ -1250,7 +1250,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function (mock, skipping) {
       assert(github.inst(INST_ID).repos.createCommitComment.callCount === 0);
     });
 
-    test('sha for release fetched correctly', async function () {
+    test('sha for release fetched correctly', async () => {
       github.inst(INST_ID).setTaskclusterYml({
         owner: 'TaskclusterRobot',
         repo: 'hooks-testing',
@@ -1269,7 +1269,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function (mock, skipping) {
       assert(github.inst(INST_ID).repos.createCommitComment.callCount === 0);
     });
 
-    test('no .taskcluster.yml, using collaborators policy', async function () {
+    test('no .taskcluster.yml, using collaborators policy', async () => {
       github.inst(INST_ID).setRepoCollaborator({
         owner: 'TaskclusterRobot',
         repo: 'hooks-testing',
@@ -1292,7 +1292,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function (mock, skipping) {
       assert(handlers.createTasks.calledWith({ scopes: sinon.match.array, tasks: sinon.match.array }));
     });
 
-    test('using collaborators_quiet policy should not create comment', async function () {
+    test('using collaborators_quiet policy should not create comment', async () => {
       github.inst(INST_ID).setTaskclusterYml({
         owner: 'TaskclusterRobot',
         repo: 'hooks-testing',
@@ -1305,17 +1305,17 @@ helper.secrets.mockSuite(testing.suiteName(), [], function (mock, skipping) {
       assert(github.inst(INST_ID).issues.createComment.callCount === 0);
     });
 
-    suite('hooks', function () {
+    suite('hooks', () => {
       let mockTriggerHook;
       let mockUse;
 
-      setup(function () {
+      setup(() => {
         mockTriggerHook = sinon.stub().resolves({ taskId: taskcluster.slugid() });
         mockUse = sinon.stub().returns({ triggerHook: mockTriggerHook });
         handlers.context.hooksClient = { use: mockUse };
       });
 
-      test('hooks-only config triggers hook and creates build record', async function () {
+      test('hooks-only config triggers hook and creates build record', async () => {
         github.inst(INST_ID).setTaskclusterYml({
           owner: 'TaskclusterRobot',
           repo: 'hooks-testing',
@@ -1353,7 +1353,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function (mock, skipping) {
         assert(handlers.createTasks.notCalled);
       });
 
-      test('hook returning no taskId cleans up the build record', async function () {
+      test('hook returning no taskId cleans up the build record', async () => {
         mockTriggerHook.resolves({});
 
         github.inst(INST_ID).setTaskclusterYml({
@@ -1374,7 +1374,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function (mock, skipping) {
         assert.deepEqual(builds, [], 'build record should be deleted when hook returns no taskId');
       });
 
-      test('multiple hooks each get their own build record', async function () {
+      test('multiple hooks each get their own build record', async () => {
         github.inst(INST_ID).setTaskclusterYml({
           owner: 'TaskclusterRobot',
           repo: 'hooks-testing',
@@ -1402,7 +1402,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function (mock, skipping) {
         assert(handlers.createTasks.notCalled);
       });
 
-      test('hooks and tasks both run when present in config', async function () {
+      test('hooks and tasks both run when present in config', async () => {
         github.inst(INST_ID).setTaskclusterYml({
           owner: 'TaskclusterRobot',
           repo: 'hooks-testing',
@@ -1419,7 +1419,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function (mock, skipping) {
         assert(handlers.createTasks.calledOnce, 'tasks should also be created');
       });
 
-      test('hook trigger failure creates exception comment and cleans up build record', async function () {
+      test('hook trigger failure creates exception comment and cleans up build record', async () => {
         mockTriggerHook.rejects(Object.assign(new Error('hook trigger failed'), { body: { error: 'hook error details' } }));
 
         github.inst(INST_ID).setTaskclusterYml({
@@ -1446,7 +1446,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function (mock, skipping) {
         assert.deepEqual(builds, [], 'build record should be deleted when hook trigger fails');
       });
 
-      test('hook failure does not prevent tasks from running', async function () {
+      test('hook failure does not prevent tasks from running', async () => {
         mockTriggerHook.rejects(Object.assign(new Error('hook failed'), { body: { error: 'hook error' } }));
 
         github.inst(INST_ID).setTaskclusterYml({
@@ -1465,7 +1465,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function (mock, skipping) {
         assert(handlers.createTasks.calledOnce, 'tasks should still run despite hook failure');
       });
 
-      test('triggerHook reformats InsufficientScopes error with context', async function () {
+      test('triggerHook reformats InsufficientScopes error with context', async () => {
         const insufficientScopesErr = Object.assign(new Error('original scope error'), { code: 'InsufficientScopes' });
         mockTriggerHook.rejects(insufficientScopesErr);
 
@@ -1480,7 +1480,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function (mock, skipping) {
         );
       });
 
-      test('triggerHook throws on invalid name format without calling use()', async function () {
+      test('triggerHook throws on invalid name format without calling use()', async () => {
         await assert.rejects(
           () => handlers.triggerHook({ scopes: [], name: 'invalid-no-slash', payload: {} }),
           /Invalid hook name format/,
@@ -1490,7 +1490,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function (mock, skipping) {
     });
   });
 
-  suite('Statuses API: result status handler', function () {
+  suite('Statuses API: result status handler', () => {
     const TASKGROUPID = 'AXB-sjV-SoCyibyq3P32o1';
 
     suiteSetup(function () {
@@ -1499,7 +1499,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function (mock, skipping) {
       }
     });
 
-    teardown(async function () {
+    teardown(async () => {
       await helper.db.fns.delete_github_build(TASKGROUPID);
     });
 
@@ -1520,7 +1520,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function (mock, skipping) {
       assert.equal(build.state, state);
     }
 
-    test('taskgroup success gets a success status', async function () {
+    test('taskgroup success gets a success status', async () => {
       await addBuild({ state: 'pending', taskGroupId: TASKGROUPID });
       await simulateExchangeMessage({
         taskGroupId: TASKGROUPID,
@@ -1532,7 +1532,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function (mock, skipping) {
       await assertBuildState('success');
     });
 
-    test('task failure gets a failure status', async function () {
+    test('task failure gets a failure status', async () => {
       await addBuild({ state: 'pending', taskGroupId: TASKGROUPID });
       await simulateExchangeMessage({
         taskGroupId: TASKGROUPID,
@@ -1544,7 +1544,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function (mock, skipping) {
       await assertBuildState('failure');
     });
 
-    test('task exception gets a failure status', async function () {
+    test('task exception gets a failure status', async () => {
       await addBuild({ state: 'pending', taskGroupId: TASKGROUPID });
       await simulateExchangeMessage({
         taskGroupId: TASKGROUPID,
@@ -1555,7 +1555,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function (mock, skipping) {
       await assertStatusUpdate('failure');
       await assertBuildState('failure');
     });
-    test('task rerun sets status to pending from running', async function() {
+    test('task rerun sets status to pending from running', async () => {
       await addBuild({ state: 'success', taskGroupId: TASKGROUPID });
       await simulateExchangeMessage({
         taskGroupId: TASKGROUPID,
@@ -1567,7 +1567,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function (mock, skipping) {
       await assertStatusUpdate('pending');
       await assertBuildState('pending');
     });
-    test('task rerun sets status to pending', async function() {
+    test('task rerun sets status to pending', async () => {
       await addBuild({ state: 'success', taskGroupId: TASKGROUPID });
       await simulateExchangeMessage({
         taskGroupId: TASKGROUPID,
@@ -1579,7 +1579,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function (mock, skipping) {
       await assertStatusUpdate('pending');
       await assertBuildState('pending');
     });
-    test('task rerun sets status back from failure to pending', async function() {
+    test('task rerun sets status back from failure to pending', async () => {
       await addBuild({ state: 'failure', taskGroupId: TASKGROUPID });
       await simulateExchangeMessage({
         taskGroupId: TASKGROUPID,
@@ -1591,7 +1591,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function (mock, skipping) {
       await assertStatusUpdate('pending');
       await assertBuildState('pending');
     });
-    test('task running not changing state if it is pending', async function() {
+    test('task running not changing state if it is pending', async () => {
       await addBuild({ state: 'pending', taskGroupId: TASKGROUPID });
       await simulateExchangeMessage({
         taskGroupId: TASKGROUPID,
@@ -1603,7 +1603,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function (mock, skipping) {
       assert(github.inst(9988).repos.createCommitStatus.calledOnce === false);
       await assertBuildState('pending');
     });
-    test('task failure does not change cancelled build state', async function() {
+    test('task failure does not change cancelled build state', async () => {
       await addBuild({ state: 'cancelled', taskGroupId: TASKGROUPID });
       await simulateExchangeMessage({
         taskGroupId: TASKGROUPID,
@@ -1616,7 +1616,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function (mock, skipping) {
     });
   });
 
-  suite('Checks API: result status handler', function () {
+  suite('Checks API: result status handler', () => {
     suiteSetup(function () {
       if (skipping()) {
         this.skip();
@@ -1624,13 +1624,13 @@ helper.secrets.mockSuite(testing.suiteName(), [], function (mock, skipping) {
     });
 
     const TASKGROUPID = 'AXB-sjV-SoCyibyq3P32o2';
-    setup(function () {
+    setup(() => {
       sinon.stub(global, "fetch").resolves({ ok: false, body: { cancel: async () => {} } });
       sinon.stub(utils, "extractLog").resolves('');
       sinon.stub(utils, "throttleRequest").returns({ status: 404, response: { error: { text: "Resource not found" } } });
     });
 
-    teardown(async function () {
+    teardown(async () => {
       await helper.db.fns.delete_github_build(TASKGROUPID);
       sinon.restore();
     });
@@ -1679,7 +1679,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function (mock, skipping) {
       });
     }
 
-    test('task success gets a success check result', async function () {
+    test('task success gets a success check result', async () => {
       await addBuild({ state: 'pending', taskGroupId: TASKGROUPID });
       await addCheckRun({ taskGroupId: TASKGROUPID, taskId: TASKID });
       await simulateExchangeMessage({
@@ -1693,7 +1693,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function (mock, skipping) {
       await assertChecksUpdate('completed');
     });
 
-    test('task failure gets a failure check result', async function () {
+    test('task failure gets a failure check result', async () => {
       await addBuild({ state: 'pending', taskGroupId: TASKGROUPID });
       await addCheckRun({ taskGroupId: TASKGROUPID, taskId: TASKID });
       await simulateExchangeMessage({
@@ -1707,7 +1707,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function (mock, skipping) {
       await assertChecksUpdate('failed');
     });
 
-    test('task exception gets a failure check result', async function () {
+    test('task exception gets a failure check result', async () => {
       await addBuild({ state: 'pending', taskGroupId: TASKGROUPID });
       await addCheckRun({ taskGroupId: TASKGROUPID, taskId: TASKID });
       await simulateExchangeMessage({
@@ -1721,7 +1721,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function (mock, skipping) {
       await assertChecksUpdate('failed');
     });
 
-    test('intermittent task with retries left gets neutral check result', async function () {
+    test('intermittent task with retries left gets neutral check result', async () => {
       await addBuild({ state: 'pending', taskGroupId: TASKGROUPID });
       await addCheckRun({ taskGroupId: TASKGROUPID, taskId: TASKID });
       await simulateExchangeMessage({
@@ -1736,7 +1736,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function (mock, skipping) {
       await assertChecksUpdate('intermittent-task');
     });
 
-    test('intermittent task with no retries left gets failure check result', async function () {
+    test('intermittent task with no retries left gets failure check result', async () => {
       await addBuild({ state: 'pending', taskGroupId: TASKGROUPID });
       await addCheckRun({ taskGroupId: TASKGROUPID, taskId: TASKID });
       await simulateExchangeMessage({
@@ -1757,7 +1757,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function (mock, skipping) {
       assert.equal(args.conclusion, 'failure');
     });
 
-    test('successful task started by decision task gets a success comment', async function () {
+    test('successful task started by decision task gets a success comment', async () => {
       await addBuild({ state: 'pending', taskGroupId: TASKGROUPID });
       await simulateExchangeMessage({
         taskGroupId: TASKGROUPID,
@@ -1770,7 +1770,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function (mock, skipping) {
       await assertChecksCreate('completed');
     });
 
-    test('Undefined state/reasonResolved in the task exchange message -> neutral status, log error', async function () {
+    test('Undefined state/reasonResolved in the task exchange message -> neutral status, log error', async () => {
       await addBuild({ state: 'pending', taskGroupId: TASKGROUPID });
       await simulateExchangeMessage({
         taskGroupId: TASKGROUPID,
@@ -1787,7 +1787,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function (mock, skipping) {
       monitor.manager.reset();
     });
 
-    test('successfully adds custom check run text from an artifact', async function () {
+    test('successfully adds custom check run text from an artifact', async () => {
       await addBuild({ state: 'pending', taskGroupId: TASKGROUPID });
       await addCheckRun({ taskGroupId: TASKGROUPID, taskId: CUSTOM_CHECKRUN_TASKID });
       sinon.restore();
@@ -1820,7 +1820,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function (mock, skipping) {
       sinon.restore();
     });
 
-    test('uses github service credentials to fetch artifact from hook task', async function () {
+    test('uses github service credentials to fetch artifact from hook task', async () => {
       await addBuild({ state: 'pending', taskGroupId: TASKGROUPID });
       await addCheckRun({ taskGroupId: TASKGROUPID, taskId: CUSTOM_CHECKRUN_HOOK_TASKID });
       sinon.restore();
@@ -1849,7 +1849,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function (mock, skipping) {
       sinon.restore();
     });
 
-    test('successfully adds live log text from an artifact', async function () {
+    test('successfully adds live log text from an artifact', async () => {
       await addBuild({ state: 'pending', taskGroupId: TASKGROUPID });
       await addCheckRun({ taskGroupId: TASKGROUPID, taskId: CUSTOM_CHECKRUN_TASKID });
       sinon.restore();
@@ -1878,7 +1878,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function (mock, skipping) {
       sinon.restore();
     });
 
-    test('successfully adds live log text from an artifact with a custom livelog name', async function () {
+    test('successfully adds live log text from an artifact with a custom livelog name', async () => {
       await addBuild({ state: 'pending', taskGroupId: TASKGROUPID });
       await addCheckRun({ taskGroupId: TASKGROUPID, taskId: CUSTOM_LIVELOG_NAME_TASKID });
       sinon.restore();
@@ -1907,7 +1907,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function (mock, skipping) {
       sinon.restore();
     });
 
-    test('ignores when list artifacts sends 404', async function () {
+    test('ignores when list artifacts sends 404', async () => {
       handlers.queueClient.listArtifacts = async () => {
         const error = new Error('Not found');
         error.statusCode = 404;
@@ -1943,7 +1943,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function (mock, skipping) {
       sinon.restore();
     });
 
-    test('fails to get custom check run text from an artifact - should log an error', async function () {
+    test('fails to get custom check run text from an artifact - should log an error', async () => {
       // note: production code doesn't throw the error, just logs it, so the handlers is not interrupted
       await addBuild({ state: 'pending', taskGroupId: TASKGROUPID });
       await addCheckRun({ taskGroupId: TASKGROUPID, taskId: CUSTOM_CHECKRUN_TASKID });
@@ -1969,7 +1969,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function (mock, skipping) {
       sinon.restore();
     });
 
-    test('successfully adds custom check run annotations from an artifact', async function () {
+    test('successfully adds custom check run annotations from an artifact', async () => {
       await addBuild({ state: 'pending', taskGroupId: TASKGROUPID });
       await addCheckRun({ taskGroupId: TASKGROUPID, taskId: CUSTOM_CHECKRUN_TASKID });
       sinon.restore();
@@ -1995,7 +1995,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function (mock, skipping) {
       sinon.restore();
     });
 
-    test('generate error report when the returned text is not valid JSON', async function () {
+    test('generate error report when the returned text is not valid JSON', async () => {
       await addBuild({ state: 'pending', taskGroupId: TASKGROUPID });
       await addCheckRun({ taskGroupId: TASKGROUPID, taskId: CUSTOM_CHECKRUN_TASKID });
       sinon.restore();
@@ -2023,7 +2023,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function (mock, skipping) {
       sinon.restore();
     });
 
-    test('fails to get custom check run annotations from an artifact - should log an error', async function () {
+    test('fails to get custom check run annotations from an artifact - should log an error', async () => {
       // note: production code doesn't throw the error, just logs it, so the handlers is not interrupted
       await addBuild({ state: 'pending', taskGroupId: TASKGROUPID });
       await addCheckRun({ taskGroupId: TASKGROUPID, taskId: CUSTOM_CHECKRUN_TASKID });
@@ -2049,7 +2049,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function (mock, skipping) {
       sinon.restore();
     });
 
-    test('skip status update when build is not defined', async function () {
+    test('skip status update when build is not defined', async () => {
       // Some tasks will be create without github events, like periodic cron hooks
       await simulateExchangeMessage({
         taskGroupId: TASKGROUPID,
@@ -2061,7 +2061,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function (mock, skipping) {
       assert.equal(false, github.inst(9988).checks.create.called);
     });
 
-    test('undefined started and resolved timestamps in check run output', async function () {
+    test('undefined started and resolved timestamps in check run output', async () => {
       await addBuild({ state: 'pending', taskGroupId: TASKGROUPID });
       await addCheckRun({ taskGroupId: TASKGROUPID, taskId: CUSTOM_LIVELOG_NAME_TASKID });
       sinon.restore();
@@ -2091,20 +2091,20 @@ helper.secrets.mockSuite(testing.suiteName(), [], function (mock, skipping) {
     });
   });
 
-  suite('Checks API: rerequest task status handler', function () {
+  suite('Checks API: rerequest task status handler', () => {
     suiteSetup(function () {
       if (skipping()) {
         this.skip();
       }
     });
 
-    setup(function () {
+    setup(() => {
       sinon.stub(global, "fetch").resolves({ ok: false, body: { cancel: async () => {} } });
       sinon.stub(utils, "extractLog").resolves('');
       sinon.stub(utils, "throttleRequest").returns({ status: 404, response: { error: { text: "Resource not found" } } });
     });
 
-    teardown(async function () {
+    teardown(async () => {
       await helper.db.fns.delete_github_build(TASKGROUPID);
       sinon.restore();
     });
@@ -2132,7 +2132,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function (mock, skipping) {
       assert.equal(args.repo, 'hooks-testing');
     }
 
-    test('task is running gets a queued check result', async function () {
+    test('task is running gets a queued check result', async () => {
       await addBuild({ state: 'running', taskGroupId: TASKGROUPID });
       await addCheckRun({ taskGroupId: TASKGROUPID, taskId: TASKID });
       await simulateExchangeMessage({
@@ -2146,7 +2146,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function (mock, skipping) {
       await assertCheckRunStatus('in_progress');
     });
 
-    test('task is running gets a in_progress check result', async function () {
+    test('task is running gets a in_progress check result', async () => {
       await addBuild({ state: 'running', taskGroupId: TASKGROUPID });
       await addCheckRun({ taskGroupId: TASKGROUPID, taskId: TASKID });
       await simulateExchangeMessage({
@@ -2159,7 +2159,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function (mock, skipping) {
       await assertCheckRunStatus('in_progress');
     });
 
-    test('in_progress update sends started_at matching the worker claim time, not the queue time', async function () {
+    test('in_progress update sends started_at matching the worker claim time, not the queue time', async () => {
       const claimedAt = '2026-05-15T10:00:00.000Z';
       await addBuild({ state: 'running', taskGroupId: TASKGROUPID });
       await addCheckRun({ taskGroupId: TASKGROUPID, taskId: TASKID });
@@ -2179,7 +2179,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function (mock, skipping) {
         'started_at must come from runs[runId].started, not GitHub defaults');
     });
 
-    test('task is rerun and queued gets a queued check result and rerequested run', async function () {
+    test('task is rerun and queued gets a queued check result and rerequested run', async () => {
       await addBuild({ state: 'running', taskGroupId: TASKGROUPID });
       await addCheckRun({ taskGroupId: TASKGROUPID, taskId: TASKID });
       await simulateExchangeMessage({
@@ -2193,7 +2193,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function (mock, skipping) {
       await assertCheckRunCreated();
     });
 
-    test('task is completed after rerun', async function () {
+    test('task is completed after rerun', async () => {
       await addBuild({ state: 'completed', taskGroupId: TASKGROUPID });
       await addCheckRun({ taskGroupId: TASKGROUPID, taskId: TASKID });
       await simulateExchangeMessage({
@@ -2210,14 +2210,14 @@ helper.secrets.mockSuite(testing.suiteName(), [], function (mock, skipping) {
 
   });
 
-  suite('Statuses API: initial status handler', function () {
+  suite('Statuses API: initial status handler', () => {
     suiteSetup(function () {
       if (skipping()) {
         this.skip();
       }
     });
 
-    teardown(async function () {
+    teardown(async () => {
       await helper.db.fns.delete_github_build(TASKGROUPID);
     });
 
@@ -2240,7 +2240,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function (mock, skipping) {
       });
     }
 
-    test('create pending status when task is defined', async function () {
+    test('create pending status when task is defined', async () => {
       await addBuild({ state: 'pending', taskGroupId: TASKGROUPID });
       await simulateExchangeMessage({
         taskGroupId: TASKGROUPID,
@@ -2251,14 +2251,14 @@ helper.secrets.mockSuite(testing.suiteName(), [], function (mock, skipping) {
     });
   });
 
-  suite('Checks API: initial status handler', function () {
+  suite('Checks API: initial status handler', () => {
     suiteSetup(function () {
       if (skipping()) {
         this.skip();
       }
     });
 
-    teardown(async function () {
+    teardown(async () => {
       await helper.db.fns.delete_github_build(TASKGROUPID);
     });
 
@@ -2282,7 +2282,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function (mock, skipping) {
       });
     }
 
-    test('create pending check result when task is defined', async function () {
+    test('create pending check result when task is defined', async () => {
       await addBuild({ state: 'pending', taskGroupId: TASKGROUPID });
       await simulateExchangeMessage({
         taskGroupId: TASKGROUPID,
@@ -2293,7 +2293,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function (mock, skipping) {
       assertStatusCreate('pending');
     });
 
-    test('taskDefined create omits started_at so GitHub does not anchor elapsed time to queue time', async function () {
+    test('taskDefined create omits started_at so GitHub does not anchor elapsed time to queue time', async () => {
       await addBuild({ state: 'pending', taskGroupId: TASKGROUPID });
       await simulateExchangeMessage({
         taskGroupId: TASKGROUPID,
@@ -2308,7 +2308,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function (mock, skipping) {
         'started_at must be omitted before the worker claims the task');
     });
 
-    test('skip check when build is not defined', async function () {
+    test('skip check when build is not defined', async () => {
       // Some tasks will be create without github events, like periodic cron hooks
       await simulateExchangeMessage({
         taskGroupId: TASKGROUPID,
@@ -2320,14 +2320,14 @@ helper.secrets.mockSuite(testing.suiteName(), [], function (mock, skipping) {
     });
   });
 
-  suite('Statuses API: initial status handler', function () {
+  suite('Statuses API: initial status handler', () => {
     suiteSetup(function () {
       if (skipping()) {
         this.skip();
       }
     });
 
-    teardown(async function () {
+    teardown(async () => {
       await helper.db.fns.delete_github_build(TASKGROUPID);
     });
 
@@ -2350,7 +2350,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function (mock, skipping) {
       });
     }
 
-    test('create pending status when task is defined', async function () {
+    test('create pending status when task is defined', async () => {
       await addBuild({ state: 'pending', taskGroupId: TASKGROUPID });
       await simulateExchangeMessage({
         taskGroupId: TASKGROUPID,
@@ -2361,7 +2361,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function (mock, skipping) {
     });
   });
 
-  suite('Checks API: rerun handler', function () {
+  suite('Checks API: rerun handler', () => {
     const taskGroupId = 'AXB-sjV-SoCyibyq3P5555';
     const taskId = 'failingone';
     const checkSuiteId = '6781240077';
@@ -2387,13 +2387,13 @@ helper.secrets.mockSuite(testing.suiteName(), [], function (mock, skipping) {
       };
     });
 
-    teardown(async function () {
+    teardown(async () => {
       await helper.db.fns.delete_github_build(taskGroupId);
       reruns = [];
       usedScopes = [];
     });
 
-    test('create task rerun', async function () {
+    test('create task rerun', async () => {
       await addBuild({ state: 'failure', taskGroupId });
       await addCheckRun({ taskGroupId, taskId, checkSuiteId, checkRunId });
 
@@ -2431,7 +2431,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function (mock, skipping) {
         authorizedScopes: ['assume:repo:github.com/taskcluster/taskcluster:rerun'],
       }]);
     });
-    test('do nothing if invalid payload is provided', async function () {
+    test('do nothing if invalid payload is provided', async () => {
       await addBuild({ state: 'failure', taskGroupId });
       await addCheckRun({ taskGroupId, taskId, checkSuiteId, checkRunId });
 

--- a/services/github/test/handler_utils_test.js
+++ b/services/github/test/handler_utils_test.js
@@ -8,16 +8,16 @@ import { CHECK_RUN_STATES } from '../src/constants.js';
 /**
  * Tests of installation syncing
  */
-helper.secrets.mockSuite(testing.suiteName(), [], function() {
-  setup(async function () {
+helper.secrets.mockSuite(testing.suiteName(), [], () => {
+  setup(async () => {
     MockDate.set('2000-05-05T12:12:12.000Z');
   });
 
-  teardown(function () {
+  teardown(() => {
     MockDate.reset();
   });
 
-  test('GithubCheckOutput', function() {
+  test('GithubCheckOutput', () => {
     const gco = new GithubCheckOutput({ title: 'a', summary: 'b', text: 'c', annotations: [] });
 
     // 60000 max - 'a'.length - 'b'.length - 'c'.length = '[]'.length (json)
@@ -41,7 +41,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function() {
     assert.equal(0, gco.getRemainingMaxSize());
   });
 
-  test('GithubCheck', function() {
+  test('GithubCheck', () => {
     const gc = new GithubCheck({
       check_run_id: 1,
       status: CHECK_RUN_STATES.QUEUED,
@@ -107,7 +107,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function() {
     }, gc.getRerequestPayload());
   });
 
-  test('Get Time Difference', function() {
+  test('Get Time Difference', () => {
 
     const START_TIMESTAMP = new Date('2024-07-16T18:23:18.118Z');
     const END_TIMESTAMP_MILLISECONDS = new Date('2024-07-16T18:23:18.128Z');

--- a/services/github/test/helper.js
+++ b/services/github/test/helper.js
@@ -17,7 +17,7 @@ const helper = {
 };
 export default helper;
 
-suiteSetup(async function() {
+suiteSetup(async () => {
   load.inject('profile', 'test');
   load.inject('process', 'test');
 });
@@ -32,7 +32,7 @@ helper.secrets = new testing.Secrets({
 
 // Build an http request from a json file with fields describing
 // headers and a body
-helper.jsonHttpRequest = function(jsonFile, options) {
+helper.jsonHttpRequest = (jsonFile, options) => {
   let defaultOptions = {
     hostname: 'localhost',
     port: 60415,
@@ -43,7 +43,7 @@ helper.jsonHttpRequest = function(jsonFile, options) {
   let jsonData = JSON.parse(fs.readFileSync(jsonFile));
   options.headers = jsonData.headers;
 
-  return new Promise(function(accept, reject) {
+  return new Promise((accept, reject) => {
     try {
       let req = http.request(options, accept);
       req.write(JSON.stringify(jsonData.body));
@@ -67,15 +67,15 @@ helper.withPulse = (mock, skipping) => {
  * This is reset before each test.  Call this before withServer.
  */
 helper.withFakeGithub = (mock, skipping) => {
-  suiteSetup(function() {
+  suiteSetup(() => {
     load.inject('github', fakeGithubAuth());
   });
 
-  suiteTeardown(function() {
+  suiteTeardown(() => {
     load.remove('github');
   });
 
-  setup(async function() {
+  setup(async () => {
     let fakeGithub = await load('github');
     fakeGithub.resetStubs();
   });
@@ -94,11 +94,11 @@ helper.withFakeQueue = (mock, skipping) => {
     },
   });
 
-  suiteSetup(function() {
+  suiteSetup(() => {
     load.inject('queueClient', fakeQueueClient());
   });
 
-  suiteTeardown(function() {
+  suiteTeardown(() => {
     load.remove('queueClient');
   });
 };
@@ -112,7 +112,7 @@ helper.withFakeQueue = (mock, skipping) => {
 helper.withServer = (mock, skipping) => {
   let webServer;
 
-  suiteSetup(async function() {
+  suiteSetup(async () => {
     if (skipping()) {
       return;
     }
@@ -137,7 +137,7 @@ helper.withServer = (mock, skipping) => {
     webServer = await load('server');
   });
 
-  suiteTeardown(async function() {
+  suiteTeardown(async () => {
     if (skipping()) {
       return;
     }
@@ -150,7 +150,7 @@ helper.withServer = (mock, skipping) => {
 };
 
 helper.resetTables = (mock, skipping) => {
-  setup('reset tables', async function() {
+  setup('reset tables', async () => {
     await testing.resetTables({ tableNames: [
       'github_builds',
       'github_checks',

--- a/services/github/test/intree_test.js
+++ b/services/github/test/intree_test.js
@@ -10,7 +10,7 @@ import testing from '@taskcluster/lib-testing';
 const webhookDir = new URL('./data/webhooks/', import.meta.url).pathname;
 const loadWebhook = filename => JSON.parse(fs.readFileSync(path.join(webhookDir, filename), 'utf8'));
 
-suite(testing.suiteName(), function() {
+suite(testing.suiteName(), () => {
   let intree;
 
   const webhookPullRequestJson = loadWebhook('webhook.pull_request.open.json');
@@ -20,14 +20,14 @@ suite(testing.suiteName(), function() {
   const webhookReleaseJson = loadWebhook('webhook.release.json');
   const webhookTagPushJson = loadWebhook('webhook.tag_push.json');
 
-  suiteSetup(async function() {
+  suiteSetup(async () => {
     helper.load.save();
     await helper.load('cfg');
     helper.load.cfg('taskcluster.rootUrl', libUrls.testRootUrl());
     intree = await helper.load('intree');
   });
 
-  suiteTeardown(function() {
+  suiteTeardown(() => {
     helper.load.restore();
   });
 
@@ -71,8 +71,8 @@ suite(testing.suiteName(), function() {
    * expected:    {}, keys=>values expected to exist in the compiled config
    * shouldError: if you want intree to throw an exception, set this to true
    **/
-  let buildConfigTest = function(testName, configPath, params, expected, count = -1, shouldError = false) {
-    test(testName, async function() {
+  let buildConfigTest = (testName, configPath, params, expected, count = -1, shouldError = false) => {
+    test(testName, async () => {
       params.config = yaml.load(fs.readFileSync(configPath));
       params.schema = {
         0: libUrls.schema(libUrls.testRootUrl(), 'github', 'v1/taskcluster-github-config.yml'),

--- a/services/github/test/pulse_test.js
+++ b/services/github/test/pulse_test.js
@@ -14,7 +14,7 @@ const loadWebhookJson = async filename => {
 // https://github.com/organizations/taskcluster/settings/apps/community-tc-integration/advanced
 // It keeps list of recent webhooks
 
-helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
+helper.secrets.mockSuite(testing.suiteName(), [], (mock, skipping) => {
   helper.withDb(mock, skipping);
   helper.withPulse(mock, skipping);
   helper.withFakeGithub(mock, skipping);
@@ -23,7 +23,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
 
   let github = null;
 
-  setup(async function() {
+  setup(async () => {
     await helper.load('cfg');
     helper.load.cfg('taskcluster.rootUrl', libUrls.testRootUrl());
 
@@ -46,7 +46,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
    *  branch:       'the head branch name; for v1'
    **/
   function pulseTest(params) {
-    test(params.testName, async function() {
+    test(params.testName, async () => {
       // Trigger a pull-request message
       let res = await helper.jsonHttpRequest('./test/data/webhooks/' + params.jsonFile);
       res.connection?.destroy();

--- a/services/github/test/queue-lock_test.js
+++ b/services/github/test/queue-lock_test.js
@@ -2,9 +2,9 @@ import assert from 'node:assert';
 import testing from '@taskcluster/lib-testing';
 import QueueLock from '../src/queue-lock.js';
 
-suite(testing.suiteName(), function() {
-  suite('Lock', function() {
-    test('should lock by name', async function () {
+suite(testing.suiteName(), () => {
+  suite('Lock', () => {
+    test('should lock by name', async () => {
       const lock = new QueueLock();
 
       let counter = 0;
@@ -28,7 +28,7 @@ suite(testing.suiteName(), function() {
       await Promise.all(more);
       assert.equal(5, counter);
     });
-    test('should run sequentially and not block other locks', async function () {
+    test('should run sequentially and not block other locks', async () => {
       const lock = new QueueLock();
       let results = [];
       const coroutine = async (name, result) => {
@@ -59,7 +59,7 @@ suite(testing.suiteName(), function() {
       assert.deepEqual([1, 2, 4, 3, 5, 6], results);
     });
 
-    test('should auto release after given timeout', async function () {
+    test('should auto release after given timeout', async () => {
       const lock = new QueueLock({ maxLockTimeMs: 1 });
 
       const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));

--- a/services/github/test/sync_test.js
+++ b/services/github/test/sync_test.js
@@ -5,7 +5,7 @@ import testing from '@taskcluster/lib-testing';
 /**
  * Tests of installation syncing
  */
-helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
+helper.secrets.mockSuite(testing.suiteName(), [], (mock, skipping) => {
   helper.withDb(mock, skipping);
   helper.withFakeGithub(mock, skipping);
   helper.withPulse(mock, skipping);
@@ -14,7 +14,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
 
   let github;
 
-  suiteSetup(async function() {
+  suiteSetup(async () => {
     if (skipping()) {
       return;
     }
@@ -22,7 +22,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
     github = await helper.load('github');
   });
 
-  test('integration installation', async function() {
+  test('integration installation', async () => {
     let result = await helper.apiClient.repository('abc123', 'coolRepo');
     assert.deepEqual(result, { installed: false });
     github.createInstall(12345, 'abc123', ['coolRepo']);

--- a/services/github/test/tc-yaml_test.js
+++ b/services/github/test/tc-yaml_test.js
@@ -2,8 +2,8 @@ import TcYaml from '../src/tc-yaml.js';
 import assume from 'assume';
 import testing from '@taskcluster/lib-testing';
 
-suite(testing.suiteName(), function() {
-  suite('VersionZero', function() {
+suite(testing.suiteName(), () => {
+  suite('VersionZero', () => {
     const tcyaml = TcYaml.instantiate(0);
     const cfg = {
       taskcluster: {
@@ -16,7 +16,7 @@ suite(testing.suiteName(), function() {
     };
     const now = new Date().toJSON();
 
-    test('compileTasks for a pull-request sets scopes correctly', function() {
+    test('compileTasks for a pull-request sets scopes correctly', () => {
       const config = {
         tasks: [{}],
       };
@@ -33,7 +33,7 @@ suite(testing.suiteName(), function() {
       ]);
     });
 
-    test('compileTasks for a push sets scopes correctly', function() {
+    test('compileTasks for a push sets scopes correctly', () => {
       const config = {
         tasks: [{}],
       };
@@ -50,7 +50,7 @@ suite(testing.suiteName(), function() {
       ]);
     });
 
-    test('compileTasks for a tag sets scopes correctly', function() {
+    test('compileTasks for a tag sets scopes correctly', () => {
       const config = {
         tasks: [{}],
       };
@@ -67,7 +67,7 @@ suite(testing.suiteName(), function() {
       ]);
     });
 
-    test('compileTasks for a release sets scopes correctly', function() {
+    test('compileTasks for a release sets scopes correctly', () => {
       const config = {
         tasks: [{}],
       };
@@ -86,7 +86,7 @@ suite(testing.suiteName(), function() {
 
   });
 
-  suite('VersionOne', function() {
+  suite('VersionOne', () => {
     const tcyaml = TcYaml.instantiate(1);
     const cfg = {
       taskcluster: {
@@ -99,7 +99,7 @@ suite(testing.suiteName(), function() {
     };
     const now = new Date().toJSON();
 
-    test('compileTasks with no tasks', function() {
+    test('compileTasks with no tasks', () => {
       const config = {
         tasks: [],
       };
@@ -111,7 +111,7 @@ suite(testing.suiteName(), function() {
       ]);
     });
 
-    test('compileTasks with one task sets default properties', function() {
+    test('compileTasks with one task sets default properties', () => {
       const config = {
         tasks: [{}],
       };
@@ -132,8 +132,8 @@ suite(testing.suiteName(), function() {
       ]);
     });
 
-    suite('scopes', function() {
-      test('compileTasks with collaborators policy for a pull-request sets scopes correctly', function() {
+    suite('scopes', () => {
+      test('compileTasks with collaborators policy for a pull-request sets scopes correctly', () => {
         const config = {
           policy: { pullRequests: "collaborators" },
           tasks: [{}],
@@ -151,7 +151,7 @@ suite(testing.suiteName(), function() {
         ]);
       });
 
-      test('compileTasks with public_restricted policy for a untrusted pull-request sets scopes correctly', function() {
+      test('compileTasks with public_restricted policy for a untrusted pull-request sets scopes correctly', () => {
         const config = {
           policy: { pullRequests: "public_restricted" },
           tasks: [{}],
@@ -172,7 +172,7 @@ suite(testing.suiteName(), function() {
         assume(payload.tasks_for).to.deeply.equal("github-pull-request-untrusted");
       });
 
-      test('compileTasks with public_restricted policy for a trusted pull-request sets scopes correctly', function() {
+      test('compileTasks with public_restricted policy for a trusted pull-request sets scopes correctly', () => {
         const config = {
           policy: { pullRequests: "public_restricted" },
           tasks: [{}],
@@ -193,7 +193,7 @@ suite(testing.suiteName(), function() {
         assume(payload.tasks_for).to.deeply.equal("github-pull-request");
       });
 
-      test('compileTasks with public policy for a pull-request sets scopes correctly', function() {
+      test('compileTasks with public policy for a pull-request sets scopes correctly', () => {
         const config = {
           policy: { pullRequests: "public" },
           tasks: [{}],
@@ -214,7 +214,7 @@ suite(testing.suiteName(), function() {
         assume(payload.tasks_for).to.deeply.equal("github-pull-request");
       });
 
-      test('compileTasks for a pull-request with checks sets scopes correctly', function() {
+      test('compileTasks for a pull-request with checks sets scopes correctly', () => {
         const config = {
           policy: { pullRequests: "collaborators" },
           tasks: [{}],
@@ -233,7 +233,7 @@ suite(testing.suiteName(), function() {
         ]);
       });
 
-      test('compileTasks for a push sets scopes correctly', function() {
+      test('compileTasks for a push sets scopes correctly', () => {
         const config = {
           tasks: [{}],
         };
@@ -252,7 +252,7 @@ suite(testing.suiteName(), function() {
         ]);
       });
 
-      test('compileTasks for a tag sets scopes correctly', function() {
+      test('compileTasks for a tag sets scopes correctly', () => {
         const config = {
           tasks: [{}],
         };
@@ -271,7 +271,7 @@ suite(testing.suiteName(), function() {
         ]);
       });
 
-      test('compileTasks for a release sets scopes correctly', function() {
+      test('compileTasks for a release sets scopes correctly', () => {
         const config = {
           tasks: [{}],
         };
@@ -289,7 +289,7 @@ suite(testing.suiteName(), function() {
         ]);
       });
 
-      test('compileTasks for a pre-release sets scopes correctly', function() {
+      test('compileTasks for a pre-release sets scopes correctly', () => {
         const config = {
           tasks: [{}],
         };
@@ -309,7 +309,7 @@ suite(testing.suiteName(), function() {
         ]);
       });
 
-      test('compileTasks with one taskId sets taskGroupId', function() {
+      test('compileTasks with one taskId sets taskGroupId', () => {
         const config = {
           tasks: [{
             taskId: 'task-1',
@@ -327,7 +327,7 @@ suite(testing.suiteName(), function() {
         }]);
       });
     });
-    test('compileTasks with taskGroupId and one task sets taskId', function() {
+    test('compileTasks with taskGroupId and one task sets taskId', () => {
       const config = {
         tasks: [{
           taskGroupId: 'tgid-1',
@@ -345,7 +345,7 @@ suite(testing.suiteName(), function() {
       }]);
     });
 
-    test('compileTasks with two tasks sets default properties', function() {
+    test('compileTasks with two tasks sets default properties', () => {
       const config = {
         tasks: [{}, {}],
       };
@@ -359,7 +359,7 @@ suite(testing.suiteName(), function() {
       assume(config.tasks[1].taskId).to.not.equal(config.tasks[1].task.taskGroupId);
     });
 
-    test('compileTasks uses user-supplied taskId/taskGroupId/schedulerId', function() {
+    test('compileTasks uses user-supplied taskId/taskGroupId/schedulerId', () => {
       const config = {
         tasks: [{
           taskId: 'task-1',
@@ -391,8 +391,8 @@ suite(testing.suiteName(), function() {
       }]);
     });
 
-    suite('status/checks routes', function() {
-      test('compileTasks sets checks route if we have reporting in the YML', function() {
+    suite('status/checks routes', () => {
+      test('compileTasks sets checks route if we have reporting in the YML', () => {
         const config = {
           tasks: [{
             taskId: 'task-1',
@@ -411,7 +411,7 @@ suite(testing.suiteName(), function() {
         }]);
       });
 
-      test('compileTasks sets statuses route by default', function() {
+      test('compileTasks sets statuses route by default', () => {
         const config = {
           tasks: [{
             taskId: 'task-1',
@@ -429,7 +429,7 @@ suite(testing.suiteName(), function() {
         }]);
       });
 
-      test('compileTasks sets statuses just once', function() {
+      test('compileTasks sets statuses just once', () => {
         const config = {
           tasks: [{
             taskId: 'task-1',
@@ -448,7 +448,7 @@ suite(testing.suiteName(), function() {
         }]);
       });
 
-      test('compileTasks allows both statuses and checks to be defined', function() {
+      test('compileTasks allows both statuses and checks to be defined', () => {
         const config = {
           tasks: [{
             taskId: 'task-1',
@@ -468,7 +468,7 @@ suite(testing.suiteName(), function() {
         }]);
       });
 
-      test('compileTasks does not erase existing routes', function() {
+      test('compileTasks does not erase existing routes', () => {
         const config = {
           tasks: [{
             taskId: 'task-1',

--- a/services/github/test/utils_test.js
+++ b/services/github/test/utils_test.js
@@ -17,19 +17,19 @@ import {
 /** Create a readable stream from a string */
 const toStream = (str) => Readable.from([Buffer.from(str)]);
 
-suite(testing.suiteName(), function() {
-  suite('throttleRequest', function() {
+suite(testing.suiteName(), () => {
+  suite('throttleRequest', () => {
     let oldRequest;
 
-    suiteSetup(function() {
+    suiteSetup(() => {
       oldRequest = throttleRequest.request;
     });
 
-    teardown(function() {
+    teardown(() => {
       throttleRequest.request = oldRequest;
     });
 
-    test('calls with the given method and url and returns a success result immediately', async function() {
+    test('calls with the given method and url and returns a success result immediately', async () => {
       throttleRequest.request = async (method, url) => {
         assert.equal(method, 'GET');
         assert.equal(url, 'https://foo');
@@ -40,7 +40,7 @@ suite(testing.suiteName(), function() {
       assert.deepEqual(res, { result: true });
     });
 
-    test('4xx statuses are returned (not thrown) immediately', async function() {
+    test('4xx statuses are returned (not thrown) immediately', async () => {
       let calls = 0;
 
       throttleRequest.request = async (method, url) => {
@@ -55,7 +55,7 @@ suite(testing.suiteName(), function() {
       assert.equal(calls, 1); // didn't retry
     });
 
-    test('5xx statuses are retried', async function() {
+    test('5xx statuses are retried', async () => {
       let calls = 0;
 
       throttleRequest.request = async (method, url) => {
@@ -71,7 +71,7 @@ suite(testing.suiteName(), function() {
       assert.equal(calls, 5);
     });
 
-    test('5xx status retried once returns successful result', async function() {
+    test('5xx status retried once returns successful result', async () => {
       let calls = 0;
 
       throttleRequest.request = async (method, url) => {
@@ -89,7 +89,7 @@ suite(testing.suiteName(), function() {
       assert.equal(calls, 1);
     });
 
-    test('connection errors are thrown directly', async function() {
+    test('connection errors are thrown directly', async () => {
       throttleRequest.request = async (method, url) => {
         const err = new Error('uhoh');
         err.code = 'ECONNREFUSED';
@@ -101,7 +101,7 @@ suite(testing.suiteName(), function() {
         err => err.code === 'ECONNREFUSED');
     });
   });
-  suite('shouldSkipCommit', function() {
+  suite('shouldSkipCommit', () => {
     const skipMessages = [
       '[CI Skip] this is not ready',
       'this is WIP [ci skip]',
@@ -109,7 +109,7 @@ suite(testing.suiteName(), function() {
       'testing things out [skip CI] .. please wait',
     ];
 
-    test('should not skip commit', function() {
+    test('should not skip commit', () => {
       assert.equal(false, shouldSkipCommit({
         commits: [{
           message: 'first commit',
@@ -148,7 +148,7 @@ suite(testing.suiteName(), function() {
         commits: [{ message }, { message: 'this commit is the last' }],
       })));
     });
-    test('should skip commit', function() {
+    test('should skip commit', () => {
       skipMessages.forEach(message => assert.equal(true, shouldSkipCommit({
         commits: [{ message: 'this commit is the first' }, { message }],
       })));
@@ -158,8 +158,8 @@ suite(testing.suiteName(), function() {
       })));
     });
   });
-  suite('shouldSkipPullRequest', function() {
-    test('should not skip pull request', function() {
+  suite('shouldSkipPullRequest', () => {
+    test('should not skip pull request', () => {
       assert.equal(false, shouldSkipPullRequest({
         pull_request: {
           title: 'Regular pr title',
@@ -169,7 +169,7 @@ suite(testing.suiteName(), function() {
         something: 'This one does not include pull_request for some reason',
       }));
     });
-    test('should skip pull request', function() {
+    test('should skip pull request', () => {
       const skipMessages = [
         'PR: [CI Skip] this is not ready',
         'PR: this is WIP [skip ci]',
@@ -183,8 +183,8 @@ suite(testing.suiteName(), function() {
     });
   });
 
-  suite('shouldSkipComment', function() {
-    test('should not skip comment', function() {
+  suite('shouldSkipComment', () => {
+    test('should not skip comment', () => {
       assert.equal(false, shouldSkipComment({
         action: 'created',
         comment: {
@@ -210,7 +210,7 @@ suite(testing.suiteName(), function() {
         },
       }));
     });
-    test('should skip comment', function() {
+    test('should skip comment', () => {
       assert.equal(true, shouldSkipComment({
         action: 'deleted',
         comment: {},
@@ -248,8 +248,8 @@ suite(testing.suiteName(), function() {
     });
   });
 
-  suite('getTaskclusterCommand', function() {
-    test('should return taskcluster command', function() {
+  suite('getTaskclusterCommand', () => {
+    test('should return taskcluster command', () => {
       assert.equal('cmd-with-dashes1', getTaskclusterCommand({
         body: ' /taskcluster cmd-with-dashes1 ',
       }));
@@ -268,8 +268,8 @@ suite(testing.suiteName(), function() {
     });
   });
 
-  suite('ansi2txt', function() {
-    test('it should remove control sequences', function() {
+  suite('ansi2txt', () => {
+    test('it should remove control sequences', () => {
       const src = [
         '[0m[7m[1m[32m PASS [39m[22m[27m[0m [2msrc/utils/[22m[1misDateWithin.test.js[22m',
         '[2K[1G[2m$ webpack --mode production[22m',
@@ -286,7 +286,7 @@ suite(testing.suiteName(), function() {
     });
   });
 
-  suite('extractLog', function() {
+  suite('extractLog', () => {
     // Reference implementation: the original sync extractLog from before the
     // streaming rewrite. Used to verify the new streaming version produces
     // identical output for all edge cases.
@@ -347,85 +347,85 @@ suite(testing.suiteName(), function() {
       assert.strictEqual(actual, expected);
     };
 
-    test('empty log', async function() {
+    test('empty log', async () => {
       await assertMatchesOriginal('');
     });
 
-    test('short log (3 lines)', async function() {
+    test('short log (3 lines)', async () => {
       await assertMatchesOriginal(generateLog(3));
     });
 
-    test('log with exactly headLines lines (20), no tail', async function() {
+    test('log with exactly headLines lines (20), no tail', async () => {
       await assertMatchesOriginal(generateLog(20));
     });
 
-    test('log with headLines + 1 (21 lines)', async function() {
+    test('log with headLines + 1 (21 lines)', async () => {
       await assertMatchesOriginal(generateLog(21));
     });
 
-    test('log with exactly headLines + tailLines (220 lines, 0 hidden)', async function() {
+    test('log with exactly headLines + tailLines (220 lines, 0 hidden)', async () => {
       await assertMatchesOriginal(generateLog(220));
     });
 
-    test('log with headLines + tailLines + 1 (221 lines, 1 hidden)', async function() {
+    test('log with headLines + tailLines + 1 (221 lines, 1 hidden)', async () => {
       await assertMatchesOriginal(generateLog(221));
     });
 
-    test('log with 100 lines hidden', async function() {
+    test('log with 100 lines hidden', async () => {
       await assertMatchesOriginal(generateLog(320));
     });
 
-    test('large log (1000 lines)', async function() {
+    test('large log (1000 lines)', async () => {
       await assertMatchesOriginal(generateLog(1000));
     });
 
-    test('long single line exceeding maxPayloadLength', async function() {
+    test('long single line exceeding maxPayloadLength', async () => {
       const payload = Array.from({ length: 10 }).map((_, i) => `line: ${i}`);
       payload.push('A'.repeat(100000));
       await assertMatchesOriginal(payload.join('\n'), 20, 200, 60000);
     });
 
-    test('head alone exceeds maxPayloadLength', async function() {
+    test('head alone exceeds maxPayloadLength', async () => {
       // 20 lines of 2000 chars each = 40000 chars in head
       const log = Array.from({ length: 500 }, (_, i) => `line ${i}: ${'x'.repeat(2000)}`).join('\n');
       await assertMatchesOriginal(log, 20, 200, 30000);
     });
 
-    test('respects custom maxPayloadLength', async function() {
+    test('respects custom maxPayloadLength', async () => {
       await assertMatchesOriginal(generateLog(500), 20, 200, 5000);
     });
 
-    test('respects custom maxPayloadLength (60000)', async function() {
+    test('respects custom maxPayloadLength (60000)', async () => {
       await assertMatchesOriginal(generateLog(500), 20, 200, 60000);
     });
 
-    test('strips ANSI control sequences', async function() {
+    test('strips ANSI control sequences', async () => {
       const payload = '\u001b[32mgreen text\u001b[0m\nnormal line';
       await assertMatchesOriginal(payload);
     });
   });
 
-  suite('generateXHubSignature', function() {
-    test('supports sha1', function () {
+  suite('generateXHubSignature', () => {
+    test('supports sha1', () => {
       assert.equal(
         generateXHubSignature('secret', '{payload}', 'sha1'),
         'sha1=ab20ad67182f5ac039c105be046648f980d60558',
       );
     });
-    test('supports sha256', function () {
+    test('supports sha256', () => {
       assert.equal(
         generateXHubSignature('secret', '{payload}', 'sha256'),
         'sha256=f3529481beccfe73834584412ff46b39f067c6664ab34a409f4ef4b3790a80be',
       );
     });
-    test('throws on invalid algorithm', function () {
+    test('throws on invalid algorithm', () => {
       assert.throws(() => {
         generateXHubSignature('secret', 'payload', 'sha999');
       }, /Invalid algorithm/);
     });
   });
-  suite('checkGithubSignature', function() {
-    test('supports sha1', function () {
+  suite('checkGithubSignature', () => {
+    test('supports sha1', () => {
       assert.equal(
         checkGithubSignature('secret', '{payload}', 'sha1=ab20ad67182f5ac039c105be046648f980d60558'),
         true,
@@ -435,7 +435,7 @@ suite(testing.suiteName(), function() {
         false,
       );
     });
-    test('supports sha256', function () {
+    test('supports sha256', () => {
       assert.equal(
         checkGithubSignature('secret', '{payload}', 'sha256=f3529481beccfe73834584412ff46b39f067c6664ab34a409f4ef4b3790a80be'),
         true,

--- a/services/github/test/webhook_test.js
+++ b/services/github/test/webhook_test.js
@@ -6,7 +6,7 @@ import { LEVELS } from '@taskcluster/lib-monitor';
 
 const TC_DEV_INSTALLATION_ID = 28513985;
 
-helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
+helper.secrets.mockSuite(testing.suiteName(), [], (mock, skipping) => {
   helper.withDb(mock, skipping);
   helper.withFakeGithub(mock, skipping);
   helper.withPulse(mock, skipping);
@@ -16,7 +16,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
   let github = null;
   let monitor;
 
-  setup(async function() {
+  setup(async () => {
     github = await helper.load('github');
     github.inst(5808).setUser({ id: 14795478, email: 'someuser@github.com', username: 'TaskclusterRobot' });
     github.inst(5808).setUser({ id: 18102552, email: 'anotheruser@github.com', username: 'owlishDeveloper' });
@@ -26,7 +26,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
 
   // Check the status code returned from a request containing some test data
   function statusTest(testName, jsonFile, statusCode, installationId = 5808, check = () => {}) {
-    test(testName, async function() {
+    test(testName, async () => {
       const filename = './test/data/webhooks/' + jsonFile;
       let request = JSON.parse(fs.readFileSync(filename));
       let response = await helper.jsonHttpRequest(filename);
@@ -80,7 +80,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
   statusTest('Issue Comment created', 'webhook.issue_comment.created.json', 200, TC_DEV_INSTALLATION_ID);
   statusTest('Issue Comment deleted', 'webhook.issue_comment.deleted.json', 200, TC_DEV_INSTALLATION_ID);
 
-  test('Pull Request Opened without a known sender user still succeeds', async function() {
+  test('Pull Request Opened without a known sender user still succeeds', async () => {
     const installation = github.inst(5808);
     // drop user to cause 404 error
     installation._github_users = installation._github_users.filter(({ username }) => username !== 'owlishDeveloper');
@@ -131,7 +131,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
     'webhook.push.invalid_ref.json', 400);
 
   // Test that OneOf pattern correctly validates different event types
-  test('OneOf schema validates all supported webhook event types', async function() {
+  test('OneOf schema validates all supported webhook event types', async () => {
     const validEvents = [
       { file: 'webhook.pull_request.open.json', eventType: 'pull_request' },
       { file: 'webhook.push.json', eventType: 'push' },
@@ -151,7 +151,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
   });
 
   // Test that validation properly rejects malformed payloads
-  test('Schema validation rejects malformed payloads for each event type', async function() {
+  test('Schema validation rejects malformed payloads for each event type', async () => {
     const invalidEvents = [
       { file: 'webhook.pull_request.missing_head_repo.json', reason: 'missing required field' },
       { file: 'webhook.pull_request.invalid_sha.json', reason: 'invalid SHA format' },
@@ -168,7 +168,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
   });
 
   // Test refactored schema with common fields extracted
-  test('Common fields are validated at base schema level', async function() {
+  test('Common fields are validated at base schema level', async () => {
     // Test that sender field is validated as a common field
     const validPayloads = [
       'webhook.pull_request.open.json',
@@ -188,7 +188,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
     }
   });
 
-  test('Schema validates common and event-specific fields together', async function() {
+  test('Schema validates common and event-specific fields together', async () => {
     // Test that both common fields (sender, repository, installation)
     // and event-specific fields are validated together
     const testCases = [
@@ -226,7 +226,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
     }
   });
 
-  test('OneOf pattern correctly discriminates between event types', async function() {
+  test('OneOf pattern correctly discriminates between event types', async () => {
     // Test that the oneOf correctly identifies and validates each event type
     const eventTypes = [
       { file: 'webhook.pull_request.open.json', hasAction: true, hasPushFields: false },

--- a/services/hooks/src/api.js
+++ b/services/hooks/src/api.js
@@ -768,7 +768,7 @@ builder.declare({
     'This endpoint is used to check on backing services this service',
     'depends on.',
   ].join('\n'),
-}, function(_req, res) {
+}, (_req, res) => {
   // TODO: add implementation
   res.reply({});
 });

--- a/services/hooks/src/exchanges.js
+++ b/services/hooks/src/exchanges.js
@@ -37,23 +37,17 @@ let buildCommonRoutingKey = (options) => {
 };
 
 /** Build an AMQP compatible message from a message */
-let commonMessageBuilder = function(message) {
-  return message;
-};
+let commonMessageBuilder = (message) => message;
 
 /** Build a routingKey from message */
 /** Empty now, might be useful in the future */
 /** when this comment should be removed */
-let commonRoutingKeyBuilder = function(message, routing) {
-  return '';
-};
+let commonRoutingKeyBuilder = (message, routing) => '';
 
 /** Build list of routing keys to CC */
 /** Empty now, might be useful in the future */
 /** when this comment should be removed */
-let commonCCBuilder = function(message, routes) {
-  return [];
-};
+let commonCCBuilder = (message, routes) => [];
 
 // Hook created exchange
 exchanges.declare({

--- a/services/hooks/src/nextdate.js
+++ b/services/hooks/src/nextdate.js
@@ -5,7 +5,7 @@ const FUTURE = new Date(4000, 1, 1);
 
 /** Return the next scheduled date that is greater than the reference, in UTC.
  */
-const nextDate = function(schedule, reference) {
+const nextDate = (schedule, reference) => {
   reference = typeof reference !== 'undefined' ? reference : new Date();
 
   let next;

--- a/services/hooks/test/api_test.js
+++ b/services/hooks/test/api_test.js
@@ -9,7 +9,7 @@ import testing from '@taskcluster/lib-testing';
 
 import taskDefinition from './test_definition.js';
 
-helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
+helper.secrets.mockSuite(testing.suiteName(), [], (mock, skipping) => {
   helper.withDb(mock, skipping);
   helper.withTaskCreator(mock, skipping);
   helper.withPulse(mock, skipping);
@@ -123,7 +123,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
     });
   };
 
-  suite('createHook', function() {
+  suite('createHook', () => {
     subSkip();
     test("creates a hook", async () => {
       const r1 = await helper.hooks.createHook('foo', 'bar', hookWithTriggerSchema);
@@ -265,7 +265,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
     });
   });
 
-  suite('updateHook', function() {
+  suite('updateHook', () => {
     subSkip();
     test('updates a hook', async () => {
       const inputWithTriggerSchema = _.defaults({
@@ -295,7 +295,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       await auditRecordExists('foo/bar', 'updated');
     });
 
-    test('fails if pulse publisher fails', async function() {
+    test('fails if pulse publisher fails', async () => {
       await helper.hooks.createHook('foo', 'bar', hookWithTriggerSchema);
       helper.onPulsePublish(() => {
         throw new Error('uhoh');
@@ -341,7 +341,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
     });
   });
 
-  suite('removeHook', function() {
+  suite('removeHook', () => {
     subSkip();
     test('removes a hook', async () => {
       await helper.hooks.createHook('foo', 'bar', hookWithTriggerSchema);
@@ -357,7 +357,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       await auditRecordExists('foo/bar', 'deleted');
     });
 
-    test('fails if pulse publisher fails', async function() {
+    test('fails if pulse publisher fails', async () => {
       await helper.hooks.createHook('foo', 'bar', hookWithTriggerSchema);
       helper.onPulsePublish(() => {
         throw new Error('uhoh');
@@ -399,10 +399,10 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
     });
   });
 
-  suite('listHookGroups', function() {
+  suite('listHookGroups', () => {
     subSkip();
 
-    test('without scopes', async function() {
+    test('without scopes', async () => {
       const client = new helper.Hooks({ rootUrl: helper.rootUrl });
       await assert.rejects(
         () => client.listHookGroups(),
@@ -422,10 +422,10 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
     });
   });
 
-  suite('listHooks', function() {
+  suite('listHooks', () => {
     subSkip();
 
-    test('without scopes', async function() {
+    test('without scopes', async () => {
       const client = new helper.Hooks({ rootUrl: helper.rootUrl });
       await assert.rejects(
         () => client.listHooks('foo'),
@@ -446,10 +446,10 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
     });
   });
 
-  suite('hook', function() {
+  suite('hook', () => {
     subSkip();
 
-    test('without scopes', async function() {
+    test('without scopes', async () => {
       const client = new helper.Hooks({ rootUrl: helper.rootUrl });
       await assert.rejects(
         () => client.hook('gp', 'hk'),
@@ -469,7 +469,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
     });
   });
 
-  suite('getTriggerToken', function() {
+  suite('getTriggerToken', () => {
     subSkip();
 
     test('returns the same token', async () => {
@@ -486,10 +486,10 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
     });
   });
 
-  suite('getHookStatus', function() {
+  suite('getHookStatus', () => {
     subSkip();
 
-    test('without scopes', async function() {
+    test('without scopes', async () => {
       const client = new helper.Hooks({ rootUrl: helper.rootUrl });
       await assert.rejects(
         () => client.getHookStatus('gp', 'hk'),
@@ -570,7 +570,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
     });
   });
 
-  suite('triggerHook', function() {
+  suite('triggerHook', () => {
     subSkip();
     test('should launch task with the given payload', async () => {
       await helper.hooks.createHook('foo', 'bar', hookWithTriggerSchema);
@@ -692,7 +692,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
     });
   });
 
-  suite('schemaTests', function() {
+  suite('schemaTests', () => {
     subSkip();
 
     test('checking schema validation', async () => {
@@ -764,7 +764,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
     });
   });
 
-  suite('resetTriggerToken', function() {
+  suite('resetTriggerToken', () => {
     subSkip();
     test('creates a new token', async () => {
       await helper.hooks.createHook('foo', 'bar', hookWithTriggerSchema);
@@ -783,7 +783,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
     });
   });
 
-  suite('triggerHookWithToken', function() {
+  suite('triggerHookWithToken', () => {
     subSkip();
     test('successfully triggers task with the given payload', async () => {
       await helper.hooks.createHook('foo', 'bar', hookWithTriggerSchema);
@@ -867,7 +867,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
     });
   });
 
-  suite('listLastFires', function() {
+  suite('listLastFires', () => {
     subSkip();
     let creator = null;
     suiteSetup(async function() {
@@ -913,7 +913,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       });
     };
 
-    test('without scopes', async function() {
+    test('without scopes', async () => {
       const client = new helper.Hooks({ rootUrl: helper.rootUrl });
       await assert.rejects(
         () => client.listLastFires('gp', 'hk'),
@@ -957,7 +957,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
     });
   });
 
-  suite('pulseHooks', function() {
+  suite('pulseHooks', () => {
     subSkip();
     test('createing a hook sends a pulse message', async () => {
       const r1 = await helper.hooks.createHook('foo', 'bar', hookWithBindings);

--- a/services/hooks/test/expires_test.js
+++ b/services/hooks/test/expires_test.js
@@ -2,12 +2,12 @@ import helper from './helper.js';
 import assume from 'assume';
 import testing from '@taskcluster/lib-testing';
 
-suite(testing.suiteName(), function() {
-  helper.secrets.mockSuite('expires_test.js', [], function(mock, skipping) {
+suite(testing.suiteName(), () => {
+  helper.secrets.mockSuite('expires_test.js', [], (mock, skipping) => {
     helper.withDb(mock, skipping);
     helper.resetTables(mock, skipping);
 
-    test('expire nothing', async function() {
+    test('expire nothing', async () => {
       const count = (await helper.db.fns.expire_last_fires())[0].expire_last_fires;
       assume(count).to.equal(0);
     });

--- a/services/hooks/test/helper.js
+++ b/services/hooks/test/helper.js
@@ -35,7 +35,7 @@ helper.withDb = (mock, skipping) => {
  * helper.creator.shouldFail to make the TaskCreator fail.
  * Call this before withServer.
  */
-helper.withTaskCreator = function(mock, skipping) {
+helper.withTaskCreator = (mock, skipping) => {
   suiteSetup(async () => {
     if (skipping()) {
       return;
@@ -47,7 +47,7 @@ helper.withTaskCreator = function(mock, skipping) {
     helper.load.inject('taskcreator', helper.creator);
   });
 
-  setup(function() {
+  setup(() => {
     helper.creator.fireCalls = [];
     helper.creator.shouldFail = false;
     helper.creator.shouldNotProduceTask = false;
@@ -68,7 +68,7 @@ helper.withPulse = (mock, skipping) => {
 helper.withServer = (mock, skipping) => {
   let webServer;
 
-  suiteSetup(async function() {
+  suiteSetup(async () => {
     if (skipping()) {
       return;
     }
@@ -103,11 +103,11 @@ helper.withServer = (mock, skipping) => {
     webServer = await helper.load('server');
   });
 
-  setup(function() {
+  setup(() => {
     helper.scopes();
   });
 
-  suiteTeardown(async function() {
+  suiteTeardown(async () => {
     if (webServer) {
       await webServer.terminate();
       webServer = null;
@@ -116,7 +116,7 @@ helper.withServer = (mock, skipping) => {
 };
 
 helper.resetTables = (mock, skipping) => {
-  setup('reset tables', async function() {
+  setup('reset tables', async () => {
     await testing.resetTables({ tableNames: [
       'hooks',
       'hooks_queues',

--- a/services/hooks/test/listeners_test.js
+++ b/services/hooks/test/listeners_test.js
@@ -6,7 +6,7 @@ import helper from './helper.js';
 import testing from '@taskcluster/lib-testing';
 import { queueUtils } from '../src/utils.js';
 
-helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
+helper.secrets.mockSuite(testing.suiteName(), [], (mock, skipping) => {
   helper.withDb(mock, skipping);
   helper.withTaskCreator(mock, skipping);
   helper.withPulse(mock, skipping);
@@ -62,7 +62,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
 
   const qn = (hookGroupId, hookId) => `${hookGroupId}/${hookId}`;
 
-  suite('syncBindings', function() {
+  suite('syncBindings', () => {
     let hookListeners;
     let channels = [];
 
@@ -118,7 +118,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       };
     });
 
-    setup(function() {
+    setup(() => {
       channels = [];
     });
 
@@ -137,7 +137,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       routingKeyPattern,
     });
 
-    test('add bindings', async function() {
+    test('add bindings', async () => {
       const res = await hookListeners.syncBindings('qn',
         [binding('e', 'r1'), binding('e', 'r2')],
         [binding('e', 'r2')]);
@@ -149,7 +149,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       assert.deepEqual(channels[0].unbindings, []);
     });
 
-    test('add bindings with nonexistent exchange', async function() {
+    test('add bindings with nonexistent exchange', async () => {
       const res = await hookListeners.syncBindings('qn',
         [binding('e', 'r1'), binding('nonexistent', 'xx'), binding('e', 'r2')],
         []);
@@ -164,7 +164,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       assert.deepEqual(channels[2].unbindings, []);
     });
 
-    test('add bindings with error', async function() {
+    test('add bindings with error', async () => {
       assert.rejects(async () => {
         await hookListeners.syncBindings('qn',
           [binding('explode', 'xx')],
@@ -172,7 +172,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       }, /boom/);
     });
 
-    test('remove bindings', async function() {
+    test('remove bindings', async () => {
       const res = await hookListeners.syncBindings('qn',
         [binding('e', 'r2')],
         [binding('e', 'r1'), binding('e', 'r2')]);
@@ -184,7 +184,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       assert.deepEqual(channels[0].unbindings, [namedbinding('qn', 'e', 'r1')]);
     });
 
-    test('no change', async function() {
+    test('no change', async () => {
       const res = await hookListeners.syncBindings('qn',
         [binding('e', 'r1'), binding('e', 'r2')],
         [binding('e', 'r1'), binding('e', 'r2')]);
@@ -195,12 +195,12 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
     });
   });
 
-  suite('reconcileConsumers', function() {
+  suite('reconcileConsumers', () => {
     let hookListeners;
     let createdListeners;
     let createdQueues;
 
-    setup('load and mock HookListeners', async function() {
+    setup('load and mock HookListeners', async () => {
       hookListeners = await helper.load('listeners');
 
       createdListeners = new Set();
@@ -221,7 +221,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
         });
     });
 
-    test('with no changes does nothing', async function() {
+    test('with no changes does nothing', async () => {
       await hookListeners.reconcileConsumers();
 
       sinon.assert.callCount(hookListeners.createListener, 0);
@@ -230,7 +230,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       sinon.assert.callCount(hookListeners.syncBindings, 0);
     });
 
-    test('with a newly-minted hook creates listener, bindings', async function() {
+    test('with a newly-minted hook creates listener, bindings', async () => {
       const bindings = [{ exchange: 'e', routingKeyPattern: 'foo.#' }];
 
       await makeHookEntities({ hookId, bindings });
@@ -249,7 +249,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       await assertQueueEntities({ hookId, bindings });
     });
 
-    test('with bindings already in Queues', async function() {
+    test('with bindings already in Queues', async () => {
       const bindings = [{ exchange: 'e', routingKeyPattern: 'foo.#' }];
 
       await makeHookEntities({ hookId, bindings });
@@ -269,7 +269,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       await assertQueueEntities({ hookId, bindings });
     });
 
-    test('with changed bindings', async function() {
+    test('with changed bindings', async () => {
       const bindings = [{ exchange: 'e', routingKeyPattern: 'foo.#' }];
       const newBindings = [{ exchange: 'e2', routingKeyPattern: '#' }];
 
@@ -290,7 +290,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       await assertQueueEntities({ hookId, bindings: newBindings });
     });
 
-    test('with deleted bindings and no listener', async function() {
+    test('with deleted bindings and no listener', async () => {
       const bindings = [{ exchange: 'e', routingKeyPattern: 'foo.#' }];
       const newBindings = [];
 
@@ -308,7 +308,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       await assertQueueEntities();
     });
 
-    test('with deleted hook and active listener', async function() {
+    test('with deleted hook and active listener', async () => {
       const bindings = [{ exchange: 'e', routingKeyPattern: 'foo.#' }];
 
       await makeQueueEntities({ hookId, bindings });
@@ -327,7 +327,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
     });
   });
 
-  suite('firing hooks', function() {
+  suite('firing hooks', () => {
     let hookListeners;
 
     suiteSetup(function() {
@@ -336,7 +336,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       }
     });
 
-    setup('load and mock HookListeners', async function() {
+    setup('load and mock HookListeners', async () => {
       // force-reload the listeners component for each test
       helper.load.remove('listeners');
       hookListeners = await helper.load('listeners');

--- a/services/hooks/test/schedule_hooks_test.js
+++ b/services/hooks/test/schedule_hooks_test.js
@@ -4,11 +4,11 @@ import helper from './helper.js';
 import libUrls from 'taskcluster-lib-urls';
 import testing from '@taskcluster/lib-testing';
 
-helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
+helper.secrets.mockSuite(testing.suiteName(), [], (mock, skipping) => {
   helper.withDb(mock, skipping);
   helper.resetTables(mock, skipping);
 
-  suiteSetup(async function() {
+  suiteSetup(async () => {
     await helper.load('cfg');
     helper.load.cfg('taskcluster.rootUrl', libUrls.testRootUrl());
   });

--- a/services/hooks/test/scheduler_test.js
+++ b/services/hooks/test/scheduler_test.js
@@ -13,7 +13,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
 
   this.slow(500);
 
-  setup(function() {
+  setup(() => {
     helper.load.cfg('app.scheduler.pollingDelay', 1);
     helper.load.inject('notify', new taskcluster.Notify({
       rootUrl: helper.rootUrl,
@@ -67,7 +67,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
     assume(callCount).equals(newCallCount);
   });
 
-  suite('poll method', function() {
+  suite('poll method', () => {
     subSkip();
     setup(async () => {
       const hookParams = {
@@ -118,7 +118,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
     });
   });
 
-  suite('handleHook method', function() {
+  suite('handleHook method', () => {
     subSkip();
     let hook;
 

--- a/services/hooks/test/taskcreator_test.js
+++ b/services/hooks/test/taskcreator_test.js
@@ -10,7 +10,7 @@ import libUrls from 'taskcluster-lib-urls';
 import testing from '@taskcluster/lib-testing';
 import { hookUtils } from '../src/utils.js';
 
-suite(testing.suiteName(), function() {
+suite(testing.suiteName(), () => {
   helper.secrets.mockSuite('TaskCreator', [], function(mock, skipping) {
     helper.withDb(mock, skipping);
     helper.resetTables(mock, skipping);
@@ -71,7 +71,7 @@ suite(testing.suiteName(), function() {
       },
     };
 
-    const createTestHook = async function(scopes, extra) {
+    const createTestHook = async (scopes, extra) => {
       let hook = _.cloneDeep(defaultHook);
       hook.task.then.extra = extra;
       hook.task.then.scopes = scopes;
@@ -118,10 +118,10 @@ suite(testing.suiteName(), function() {
         });
 
     let monitor;
-    suiteSetup(async function() {
+    suiteSetup(async () => {
       monitor = await helper.load('monitor');
     });
-    test('firing a real task succeeds', async function() {
+    test('firing a real task succeeds', async () => {
       let hook = await createTestHook([], {
         context: '${context}',
         firedBy: '${firedBy}',
@@ -133,7 +133,7 @@ suite(testing.suiteName(), function() {
       assertFireLogged({ firedBy: "schedule", taskId, result: 'success' });
     });
 
-    test('firing a real task with a JSON-e context succeeds', async function() {
+    test('firing a real task with a JSON-e context succeeds', async () => {
       let hook = await createTestHook([], {
         context: {
           valueFromContext: { $eval: 'someValue + 13' },
@@ -164,7 +164,7 @@ suite(testing.suiteName(), function() {
       assertFireLogged({ firedBy: "schedule", taskId, result: 'success' });
     });
 
-    test('firing a hook where the json-e renders to nothing does nothing', async function() {
+    test('firing a hook where the json-e renders to nothing does nothing', async () => {
       const hook = _.cloneDeep(defaultHook);
       hook.task = { $if: 'false', then: hook.task };
       await helper.db.fns.create_hook(
@@ -186,7 +186,7 @@ suite(testing.suiteName(), function() {
       assert.ok(!res, `expected falsy return from declined fire(), got ${JSON.stringify(res)}`);
     });
 
-    test('firing a hook where the json-e fails to render fails', async function() {
+    test('firing a hook where the json-e fails to render fails', async () => {
       const hook = _.cloneDeep(defaultHook);
       hook.task = { $if: 'uhoh, this is invalid' };
       await helper.db.fns.create_hook(
@@ -226,7 +226,7 @@ suite(testing.suiteName(), function() {
       throw new Error('should have seen an error from .fire');
     });
 
-    test('firing a real task that sets its own task times works', async function() {
+    test('firing a real task that sets its own task times works', async () => {
       let hook = _.cloneDeep(defaultHook);
       hook.task.then.created = { $fromNow: '0 seconds' };
       hook.task.then.deadline = { $fromNow: '1 minute' };
@@ -251,7 +251,7 @@ suite(testing.suiteName(), function() {
       assume(new Date(task.expires) - new Date(task.created)).to.equal(120000);
     });
 
-    test('firing a real task that sets its own taskGroupId works', async function() {
+    test('firing a real task that sets its own taskGroupId works', async () => {
       let hook = _.cloneDeep(defaultHook);
       hook.task.then.taskGroupId = taskcluster.slugid();
       await helper.db.fns.create_hook(
@@ -273,7 +273,7 @@ suite(testing.suiteName(), function() {
       assume(task.taskGroupId).equals(hook.task.then.taskGroupId);
     });
 
-    test('firing a task with options.created always generates the same task', async function() {
+    test('firing a task with options.created always generates the same task', async () => {
       await helper.db.fns.create_hook(
         defaultHook.hookGroupId,
         defaultHook.hookId,
@@ -302,7 +302,7 @@ suite(testing.suiteName(), function() {
       assume(taskA.expires).deeply.equal(taskB.expires);
     });
 
-    test('firing a real task includes values from context', async function() {
+    test('firing a real task includes values from context', async () => {
       let hook = await createTestHook([], {
         env: { DUSTIN_LOCATION: '${location}' },
         firedBy: '${firedBy}',
@@ -320,7 +320,7 @@ suite(testing.suiteName(), function() {
       });
     });
 
-    test('adds a taskId if one is not specified', async function() {
+    test('adds a taskId if one is not specified', async () => {
       let hook = await createTestHook(['project:taskcluster:tests:tc-hooks:scope/required/for/task/1'],
         { context: '${context}' });
       let resp = await creator.fire(hook, { context: true, firedBy: 'foo' });
@@ -328,7 +328,7 @@ suite(testing.suiteName(), function() {
       assume(task.workerType).equals(hook.task.then.workerType);
     });
 
-    test('adds a new row to lastFire', async function() {
+    test('adds a new row to lastFire', async () => {
       let hook = _.cloneDeep(defaultHook);
       let taskCreateTime = new Date();
       await creator.appendLastFire({
@@ -350,7 +350,7 @@ suite(testing.suiteName(), function() {
       assume(res.task_id).equals(hook.nextTaskId);
     });
 
-    test('Fetch two appended lastFire rows independently', async function() {
+    test('Fetch two appended lastFire rows independently', async () => {
       let hook = _.cloneDeep(defaultHook);
       let hook2 = _.cloneDeep({ ...defaultHook,
         hookId: 'tc-test-hook2',
@@ -395,13 +395,13 @@ suite(testing.suiteName(), function() {
     });
   });
 
-  suite('MockTaskCreator', function() {
+  suite('MockTaskCreator', () => {
     let creator = null;
     setup(async () => {
       creator = new taskcreator.MockTaskCreator();
     });
 
-    test('the fire method records calls', async function() {
+    test('the fire method records calls', async () => {
       const hook = _.cloneDeep(hookDef);
       hook.hookGroupId = 'g';
       hook.hookId = 'h';

--- a/services/hooks/test/validate_test.js
+++ b/services/hooks/test/validate_test.js
@@ -3,7 +3,7 @@ import path from 'node:path';
 
 const __dirname = new URL('.', import.meta.url).pathname;
 
-suite(testing.suiteName(), function() {
+suite(testing.suiteName(), () => {
   testing.schemas({
     schemasetOptions: {
       folder: path.join(__dirname, '..', 'schemas'),

--- a/services/index/src/api.js
+++ b/services/index/src/api.js
@@ -287,7 +287,7 @@ builder.declare({
     this.db,
     namespace,
     input,
-  ).then(function(task) {
+  ).then((task) => {
     res.reply(helpers.taskUtils.serialize(task));
   });
 });
@@ -410,7 +410,7 @@ builder.declare({
     'This endpoint is used to check on backing services this service',
     'depends on.',
   ].join('\n'),
-}, function(_req, res) {
+}, (_req, res) => {
   // TODO: add implementation
   res.reply({});
 });

--- a/services/index/src/handlers.js
+++ b/services/index/src/handlers.js
@@ -74,13 +74,10 @@ Handlers.prototype.completed = function(message) {
   let that = this;
 
   // Find namespaces to index under
-  let namespaces = message.routes.filter(function(route) {
-    return that.routeRegexp.test(route);
-  }).map(function(route) {
-    return that.routeRegexp.exec(route)[1];
-  }).filter(function(namespace) {
-    return helpers.namespaceFormat.test(namespace);
-  });
+  let namespaces = message.routes
+    .filter((route) => that.routeRegexp.test(route))
+    .map((route) => that.routeRegexp.exec(route)[1])
+    .filter((namespace) => helpers.namespaceFormat.test(namespace));
 
   // If there is no namespace we better log this
   if (namespaces.length === 0) {
@@ -89,7 +86,7 @@ Handlers.prototype.completed = function(message) {
   }
 
   // Get task definition
-  return this.queue.task(message.payload.status.taskId).then(function(task) {
+  return this.queue.task(message.payload.status.taskId).then((task) => {
 
     // Create default expiration date
     let expires;
@@ -125,14 +122,12 @@ Handlers.prototype.completed = function(message) {
     }
 
     // Insert everything into the index
-    return Promise.all(namespaces.map(function(namespace) {
-      return helpers.taskUtils.insertTask(that.db, namespace, {
-        taskId: message.payload.status.taskId,
-        data: options.data,
-        expires: expires,
-        rank: options.rank,
-      });
-    })).then(function() {
+    return Promise.all(namespaces.map((namespace) => helpers.taskUtils.insertTask(that.db, namespace, {
+      taskId: message.payload.status.taskId,
+      data: options.data,
+      expires: expires,
+      rank: options.rank,
+    }))).then(() => {
       debug('Indexed: %s', message.payload.status.taskId);
     });
   });

--- a/services/index/test/api_test.js
+++ b/services/index/test/api_test.js
@@ -9,7 +9,7 @@ import assume from 'assume';
 import libUrls from 'taskcluster-lib-urls';
 import testing from '@taskcluster/lib-testing';
 
-helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
+helper.secrets.mockSuite(testing.suiteName(), [], (mock, skipping) => {
   helper.withDb(mock, skipping);
   helper.withFakeQueue(mock, skipping);
   helper.withFakeAnonymousScopeCache(mock, skipping);
@@ -17,7 +17,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
   helper.withServer(mock, skipping);
   helper.resetTables(mock, skipping);
 
-  test('insert (and rank)', async function() {
+  test('insert (and rank)', async () => {
     const myns = slugid.v4();
     const taskId = slugid.v4();
     const taskId2 = slugid.v4();
@@ -40,7 +40,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
     assert(result.taskId === taskId2, 'Wrong taskId');
   });
 
-  test('find (non-existing)', async function() {
+  test('find (non-existing)', async () => {
     const ns = slugid.v4() + '.' + slugid.v4();
     try {
       await helper.index.findTask(ns);
@@ -51,12 +51,12 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
     assert(false, 'This shouldn\'t have worked');
   });
 
-  test('delete (non-existing)', async function() {
+  test('delete (non-existing)', async () => {
     const ns = slugid.v4() + '.' + slugid.v4();
     await helper.index.deleteTask(ns);
   });
 
-  test('find (no scopes)', async function() {
+  test('find (no scopes)', async () => {
     const myns = slugid.v4();
     const taskId = slugid.v4();
     await helper.index.insertTask(myns + '.my-task', {
@@ -71,7 +71,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       err => err.code === 'InsufficientScopes');
   });
 
-  test('delete (no scopes)', async function() {
+  test('delete (no scopes)', async () => {
     const ns = slugid.v4() + '.' + slugid.v4();
     helper.scopes('none');
     await assert.rejects(
@@ -79,14 +79,14 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       err => err.code === 'InsufficientScopes');
   });
 
-  suite('listing things', function() {
+  suite('listing things', () => {
     suiteSetup(async function() {
       if (skipping()) {
         this.skip();
       }
     });
 
-    setup('insert tasks to list', async function() {
+    setup('insert tasks to list', async () => {
       if (skipping()) {
         return;
       }
@@ -115,29 +115,29 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       ]);
     });
 
-    const testValidNamespaces = function(list, VALID_PREFIXES = ['abc', 'bbc', 'cbc']) {
+    const testValidNamespaces = (list, VALID_PREFIXES = ['abc', 'bbc', 'cbc']) => {
       const namespaces = [];
       const INVALID_PREFIXES = ['pqr', 'ppt'];
-      list.forEach(function(ns) {
+      list.forEach((ns) => {
         namespaces.push(ns.namespace);
         assert(ns.namespace.indexOf('.') === -1, 'shouldn\'t have any dots');
       });
 
-      VALID_PREFIXES.forEach(function(prefix) {
+      VALID_PREFIXES.forEach((prefix) => {
         assume(namespaces).contains(prefix);
       });
 
-      INVALID_PREFIXES.forEach(function(prefix) {
+      INVALID_PREFIXES.forEach((prefix) => {
         assume(namespaces).not.contains(prefix);
       });
     };
 
-    test('list top-level namespaces', async function() {
+    test('list top-level namespaces', async () => {
       const result = await helper.index.listNamespaces('', {});
       testValidNamespaces(result.namespaces, ['abc', 'bbc', 'cbc', 'dbc']);
     });
 
-    test('list top-level namespaces with continuation', async function() {
+    test('list top-level namespaces with continuation', async () => {
       const opts = { limit: 1 };
       let results = [];
       let iterations = 0;
@@ -156,19 +156,19 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       testValidNamespaces(results, ['abc', 'bbc', 'cbc', 'dbc']);
     });
 
-    test('list top-level namespaces (without auth)', async function() {
+    test('list top-level namespaces (without auth)', async () => {
       helper.scopes('none');
       await assert.rejects(
         () => helper.index.listNamespaces('', {}),
         err => err.code === 'InsufficientScopes');
     });
 
-    test('list top-level tasks', async function() {
+    test('list top-level tasks', async () => {
       const result = await helper.index.listTasks('', {});
       testValidNamespaces(result.tasks);
     });
 
-    test('list top-level tasks with continuation', async function() {
+    test('list top-level tasks with continuation', async () => {
       const opts = { limit: 1 };
       let results = [];
 
@@ -185,19 +185,19 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       testValidNamespaces(results);
     });
 
-    test('list top-level tasks', async function() {
+    test('list top-level tasks', async () => {
       const result = await helper.index.listTasks('', {});
       testValidNamespaces(result.tasks);
     });
 
-    test('list top-level tasks (without auth)', async function() {
+    test('list top-level tasks (without auth)', async () => {
       helper.scopes('none');
       await assert.rejects(
         () => helper.index.listTasks('', {}),
         err => err.code === 'InsufficientScopes');
     });
 
-    test('findTask throws 404 for expired tasks', async function() {
+    test('findTask throws 404 for expired tasks', async () => {
       const myns = slugid.v4();
       const taskId = slugid.v4();
       const expired = new Date();
@@ -220,7 +220,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       assert(false, "should have caught");
     });
 
-    test('findTasksAtIndexes finds tasks', async function() {
+    test('findTasksAtIndexes finds tasks', async () => {
       const myns = slugid.v4();
 
       let date = new Date();
@@ -311,7 +311,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
 
   });
 
-  test('access artifact using anonymous scopes', async function() {
+  test('access artifact using anonymous scopes', async () => {
     const taskId = slugid.nice();
     debug('### Insert task into index');
     await helper.index.insertTask('my.name.space', {
@@ -335,9 +335,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
 
     helper.setAnonymousScopes(['queue:get-artifact:xyz/abc.zip']);
     await testing.fakeauth.withAnonymousScopes(['queue:get-artifact:xyz/abc.zip'], async () => {
-      const res = await request.get(url).redirects(0).catch(function(err) {
-        return err.response;
-      });
+      const res = await request.get(url).redirects(0).catch((err) => err.response);
       assert.equal(res.statusCode, 303, 'Expected 303 redirect');
       const location = res.headers.location;
       assert(!location.includes('bewit='), 'Public artifact URL should not contain bewit');
@@ -345,7 +343,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
     });
   });
 
-  test('access private artifact (with * scope)', async function() {
+  test('access private artifact (with * scope)', async () => {
     const taskId = slugid.nice();
     debug('### Insert task into index');
     await helper.index.insertTask('my.name.space', {
@@ -361,16 +359,14 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       'my.name.space',
       'not-public/abc.zip',
     );
-    const res = await request.get(url).redirects(0).catch(function(err) {
-      return err.response;
-    });
+    const res = await request.get(url).redirects(0).catch((err) => err.response);
     assert.equal(res.statusCode, 303, 'Expected 303 redirect');
     const location = res.headers.location.replace(/bewit=.*/, 'bewit=xyz');
     assert.equal(location,
       libUrls.api(helper.rootUrl, 'queue', 'v1', `/task/${taskId}/artifacts/not-public%2Fabc.zip?bewit=xyz`));
   });
 
-  test('access private artifact (with no scopes)', async function() {
+  test('access private artifact (with no scopes)', async () => {
     const taskId = slugid.nice();
     debug('### Insert task into index');
     await helper.index.insertTask('my.name.space', {
@@ -387,13 +383,11 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       'my.name.space',
       'not-public/abc.zip',
     );
-    const res = await request.get(url).redirects(0).catch(function(err) {
-      return err.response;
-    });
+    const res = await request.get(url).redirects(0).catch((err) => err.response);
     assert.equal(res.statusCode, 403, 'Expected 403 Forbidden');
   });
 
-  test('authenticated request to public artifact omits bewit', async function() {
+  test('authenticated request to public artifact omits bewit', async () => {
     const taskId = slugid.nice();
     await helper.index.insertTask('my.name.space', {
       taskId: taskId,
@@ -413,16 +407,14 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       'my.name.space',
       'public/build.zip',
     );
-    const res = await request.get(url).redirects(0).catch(function(err) {
-      return err.response;
-    });
+    const res = await request.get(url).redirects(0).catch((err) => err.response);
     assert.equal(res.statusCode, 303, 'Expected 303 redirect');
     const location = res.headers.location;
     assert(!location.includes('bewit='), 'Public artifact URL should not contain bewit');
     assert.equal(location, 'https://cdn.example.com/artifact');
   });
 
-  test('falls back to signed URL if anonymous scope check fails', async function() {
+  test('falls back to signed URL if anonymous scope check fails', async () => {
     const taskId = slugid.nice();
     await helper.index.insertTask('my.name.space', {
       taskId: taskId,
@@ -440,14 +432,12 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       'my.name.space',
       'public/build.zip',
     );
-    const res = await request.get(url).redirects(0).catch(function(err) {
-      return err.response;
-    });
+    const res = await request.get(url).redirects(0).catch((err) => err.response);
     assert.equal(res.statusCode, 303, 'Expected 303 redirect');
     assert(res.headers.location.includes('bewit='), 'Should fall back to signed URL with bewit');
   });
 
-  test('public artifact falls back to queue redirect when latestArtifact returns no url', async function() {
+  test('public artifact falls back to queue redirect when latestArtifact returns no url', async () => {
     const taskId = slugid.nice();
     await helper.index.insertTask('my.name.space', {
       taskId: taskId,
@@ -469,16 +459,14 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
         'my.name.space',
         'public/build.zip',
       );
-      const res = await request.get(url).redirects(0).catch(function(err) {
-        return err.response;
-      });
+      const res = await request.get(url).redirects(0).catch((err) => err.response);
       assert.equal(res.statusCode, 303, 'Expected 303 redirect');
       assert.equal(res.headers.location,
         libUrls.api(helper.rootUrl, 'queue', 'v1', `/task/${taskId}/artifacts/public%2Fbuild.zip`));
     });
   });
 
-  test('public artifact falls back to queue redirect when latestArtifact call fails', async function() {
+  test('public artifact falls back to queue redirect when latestArtifact call fails', async () => {
     const taskId = slugid.nice();
     await helper.index.insertTask('my.name.space', {
       taskId: taskId,
@@ -496,16 +484,14 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
         'my.name.space',
         'public/build.zip',
       );
-      const res = await request.get(url).redirects(0).catch(function(err) {
-        return err.response;
-      });
+      const res = await request.get(url).redirects(0).catch((err) => err.response);
       assert.equal(res.statusCode, 303, 'Expected 303 redirect');
       assert.equal(res.headers.location,
         libUrls.api(helper.rootUrl, 'queue', 'v1', `/task/${taskId}/artifacts/public%2Fbuild.zip`));
     });
   });
 
-  test('delete task', async function() {
+  test('delete task', async () => {
     const taskId = slugid.nice();
     debug('### Insert task into index');
     await helper.index.insertTask('some.testing.name.space', {

--- a/services/index/test/helper.js
+++ b/services/index/test/helper.js
@@ -12,7 +12,7 @@ export const load = testing.stickyLoader(loadMain);
 const helper = { load };
 export default helper;
 
-suiteSetup(async function() {
+suiteSetup(async () => {
   load.inject('profile', 'test');
   load.inject('process', 'test');
 });
@@ -47,7 +47,7 @@ helper.withPulse = withPulse;
  * The component is available at `helper.queue`.
  */
 export const withFakeQueue = (mock, skipping) => {
-  suiteSetup(function() {
+  suiteSetup(() => {
     if (skipping()) {
       return;
     }
@@ -65,7 +65,7 @@ helper.setAnonymousScopes = (scopes) => {
 };
 
 export const withFakeAnonymousScopeCache = (mock, skipping) => {
-  suiteSetup(function() {
+  suiteSetup(() => {
     if (skipping()) {
       return;
     }
@@ -75,7 +75,7 @@ export const withFakeAnonymousScopeCache = (mock, skipping) => {
     });
   });
 
-  setup(function() {
+  setup(() => {
     if (skipping()) {
       return;
     }
@@ -94,7 +94,7 @@ helper.withFakeAnonymousScopeCache = withFakeAnonymousScopeCache;
 export const withServer = (mock, skipping) => {
   let webServer;
 
-  suiteSetup(async function() {
+  suiteSetup(async () => {
     if (skipping()) {
       return;
     }
@@ -132,7 +132,7 @@ export const withServer = (mock, skipping) => {
     webServer = await load('server');
   });
 
-  setup(async function() {
+  setup(async () => {
     if (skipping()) {
       return;
     }
@@ -140,7 +140,7 @@ export const withServer = (mock, skipping) => {
     helper.scopes();
   });
 
-  suiteTeardown(async function() {
+  suiteTeardown(async () => {
     if (skipping()) {
       return;
     }
@@ -181,11 +181,11 @@ const stubbedQueue = () => {
     },
   });
 
-  queue.addTask = function(taskId, task) {
+  queue.addTask = (taskId, task) => {
     tasks[taskId] = task;
   };
 
-  queue.setArtifact = function(taskId, name, response) {
+  queue.setArtifact = (taskId, name, response) => {
     artifacts[`${taskId}/${name}`] = response;
   };
 
@@ -193,7 +193,7 @@ const stubbedQueue = () => {
 };
 
 export const resetTables = (mock, skipping) => {
-  setup('reset tables', async function() {
+  setup('reset tables', async () => {
     await testing.resetTables({ tableNames: [
       'indexed_tasks',
       'index_namespaces',

--- a/services/index/test/helpers_test.js
+++ b/services/index/test/helpers_test.js
@@ -3,36 +3,36 @@ import testing from '@taskcluster/lib-testing';
 import helpers from '../src/helpers.js';
 import { _satisfiesArtifactScope } from '../src/helpers.js';
 
-suite(testing.suiteName(), function() {
-  suite('satisfiesArtifactScope', function() {
-    test('returns true for exact scope match', async function() {
+suite(testing.suiteName(), () => {
+  suite('satisfiesArtifactScope', () => {
+    test('returns true for exact scope match', async () => {
       const cache = async () => ['queue:get-artifact:public/foo.zip'];
       assert.equal(await _satisfiesArtifactScope(cache, 'public/foo.zip'), true);
     });
 
-    test('returns true for wildcard scope match', async function() {
+    test('returns true for wildcard scope match', async () => {
       const cache = async () => ['queue:get-artifact:public/*'];
       assert.equal(await _satisfiesArtifactScope(cache, 'public/foo.zip'), true);
     });
 
-    test('returns false for private artifact', async function() {
+    test('returns false for private artifact', async () => {
       const cache = async () => ['queue:get-artifact:public/*'];
       assert.equal(await _satisfiesArtifactScope(cache, 'private/secret.zip'), false);
     });
 
-    test('returns false when cache throws', async function() {
+    test('returns false when cache throws', async () => {
       const cache = async () => { throw new Error('auth failure'); };
       assert.equal(await _satisfiesArtifactScope(cache, 'public/foo.zip'), false);
     });
 
-    test('returns false when no matching scope', async function() {
+    test('returns false when no matching scope', async () => {
       const cache = async () => ['some:other:scope'];
       assert.equal(await _satisfiesArtifactScope(cache, 'public/foo.zip'), false);
     });
   });
 
-  suite('isPublicArtifact', function() {
-    test('returns true for public artifact', async function() {
+  suite('isPublicArtifact', () => {
+    test('returns true for public artifact', async () => {
       const auth = {
         expandScopes: async () => ({ scopes: ['queue:get-artifact:public/*'] }),
       };
@@ -40,7 +40,7 @@ suite(testing.suiteName(), function() {
       assert.equal(await check('public/foo.zip'), true);
     });
 
-    test('returns false for private artifact', async function() {
+    test('returns false for private artifact', async () => {
       const auth = {
         expandScopes: async () => ({ scopes: ['queue:get-artifact:public/*'] }),
       };
@@ -48,7 +48,7 @@ suite(testing.suiteName(), function() {
       assert.equal(await check('private/secret.zip'), false);
     });
 
-    test('caches scope expansion result', async function() {
+    test('caches scope expansion result', async () => {
       let callCount = 0;
       const auth = {
         expandScopes: async () => {
@@ -63,26 +63,26 @@ suite(testing.suiteName(), function() {
     });
   });
 
-  suite('splitNamespace', function() {
-    test('of a multi-part namespace', function() {
+  suite('splitNamespace', () => {
+    test('of a multi-part namespace', () => {
       const [namespace, name] = helpers.splitNamespace('foo.bar.bing');
       assert.equal(namespace, 'foo.bar');
       assert.equal(name, 'bing');
     });
 
-    test('of a two-part namespace', function() {
+    test('of a two-part namespace', () => {
       const [namespace, name] = helpers.splitNamespace('foo.bar');
       assert.equal(namespace, 'foo');
       assert.equal(name, 'bar');
     });
 
-    test('of a single-part namespace', function() {
+    test('of a single-part namespace', () => {
       const [namespace, name] = helpers.splitNamespace('foo');
       assert.equal(namespace, '');
       assert.equal(name, 'foo');
     });
 
-    test('of an empty namespace', function() {
+    test('of an empty namespace', () => {
       const [namespace, name] = helpers.splitNamespace('');
       assert.equal(namespace, '');
       assert.equal(name, '');

--- a/services/index/test/index_test.js
+++ b/services/index/test/index_test.js
@@ -7,45 +7,43 @@ import _ from 'lodash';
 import testing from '@taskcluster/lib-testing';
 import taskcluster from '@taskcluster/client';
 
-helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
+helper.secrets.mockSuite(testing.suiteName(), [], (mock, skipping) => {
   helper.withDb(mock, skipping);
   helper.withFakeQueue(mock, skipping);
   helper.withPulse(mock, skipping);
   helper.withServer(mock, skipping);
   helper.resetTables(mock, skipping);
 
-  const makeTask = function() {
-    return {
-      provisionerId: 'dummy-test-provisioner',
-      workerType: 'dummy-test-worker-type',
-      scopes: [],
-      routes: [
-        'index',
-        'index.my-ns',
-        'index.my-ns.my-indexed-thing',
-        'index.my-ns.my-indexed-thing-again',
-        'index.my-ns.one-ns.my-indexed-thing',
-        'index.my-ns.another-ns.my-indexed-thing-again',
-        'index.my-ns.slash/things-are-ignored',
-      ],
-      retries: 3,
-      created: (new Date()).toJSON(),
-      deadline: (new Date()).toJSON(),
-      expires: taskcluster.fromNow('1 day'),
-      payload: {},
-      metadata: {
-        name: 'Print `"Hello World"` Once',
-        description: 'This task will prìnt `"Hello World"` **once**!',
-        owner: 'jojensen@mozilla.com',
-        source: 'https://github.com/taskcluster/taskcluster-index',
-      },
-      tags: {
-        objective: 'Test task indexing',
-      },
-    };
-  };
+  const makeTask = () => ({
+    provisionerId: 'dummy-test-provisioner',
+    workerType: 'dummy-test-worker-type',
+    scopes: [],
+    routes: [
+      'index',
+      'index.my-ns',
+      'index.my-ns.my-indexed-thing',
+      'index.my-ns.my-indexed-thing-again',
+      'index.my-ns.one-ns.my-indexed-thing',
+      'index.my-ns.another-ns.my-indexed-thing-again',
+      'index.my-ns.slash/things-are-ignored',
+    ],
+    retries: 3,
+    created: (new Date()).toJSON(),
+    deadline: (new Date()).toJSON(),
+    expires: taskcluster.fromNow('1 day'),
+    payload: {},
+    metadata: {
+      name: 'Print `"Hello World"` Once',
+      description: 'This task will prìnt `"Hello World"` **once**!',
+      owner: 'jojensen@mozilla.com',
+      source: 'https://github.com/taskcluster/taskcluster-index',
+    },
+    tags: {
+      objective: 'Test task indexing',
+    },
+  });
 
-  suiteSetup('load handlers', async function() {
+  suiteSetup('load handlers', async () => {
     if (skipping()) {
       return;
     }
@@ -54,7 +52,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
     await helper.load('handlers');
   });
 
-  test('Run task and test indexing', async function() {
+  test('Run task and test indexing', async () => {
     const taskId = slugid.nice();
     const task = makeTask();
     helper.queue.addTask(taskId, task);
@@ -90,32 +88,28 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       debug('### List task in namespace');
       result = await helper.index.listTasks('my-ns', {});
       assert.equal(result.tasks.length, 2, 'Expected 2 tasks');
-      result.tasks.forEach(function(task) {
+      result.tasks.forEach((task) => {
         assert.equal(task.taskId, taskId, 'Wrong taskId');
       });
 
       debug('### List namespaces in namespace');
       result = await helper.index.listNamespaces('my-ns', {});
       assert.equal(result.namespaces.length, 2, 'Expected 2 namespaces');
-      assert(result.namespaces.some(function(ns) {
-        return ns.name === 'one-ns';
-      }), 'Expected to find one-ns');
-      assert(result.namespaces.some(function(ns) {
-        return ns.name === 'another-ns';
-      }), 'Expected to find another-ns');
+      assert(result.namespaces.some((ns) => ns.name === 'one-ns'), 'Expected to find one-ns');
+      assert(result.namespaces.some((ns) => ns.name === 'another-ns'), 'Expected to find another-ns');
 
       debug('### Find task in index');
       await helper.index.findTask(
         'my-ns.slash/things-are-ignored',
-      ).then(function() {
+      ).then(() => {
         assert(false, 'Expected ill formated namespaces to be ignored!');
-      }, function(err) {
+      }, (err) => {
         assert.equal(err.statusCode, 400, 'Expected 400');
       });
     });
   });
 
-  test('Run task with a .extra and test indexing', async function() {
+  test('Run task with a .extra and test indexing', async () => {
     const taskId = slugid.nice();
     const task = makeTask();
     task.extra = {
@@ -141,9 +135,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
     await helper.fakePulseMessage(message);
 
     debug('### Find task in index');
-    let result = await testing.poll(function() {
-      return helper.index.findTask('my-ns.my-indexed-thing');
-    });
+    let result = await testing.poll(() => helper.index.findTask('my-ns.my-indexed-thing'));
     assert.equal(result.taskId, taskId, 'Wrong taskId');
     assert.equal(result.rank, 42, 'Expected rank 42');
     assert.equal(result.data.hello, 'world', 'Expected data');
@@ -153,7 +145,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
     assert.equal(result.taskId, taskId, 'Wrong taskId');
   });
 
-  test('Expiring Indexed Tasks', async function() {
+  test('Expiring Indexed Tasks', async () => {
     // Create expiration
     const expiry = new Date();
 
@@ -200,7 +192,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
 
   });
 
-  test('Expiring Namespace', async function() {
+  test('Expiring Namespace', async () => {
     // Create expiration
     const expiry = new Date();
     expiry.setDate(expiry.getDate() - 1);
@@ -238,13 +230,11 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
 
     result = await helper.index.listNamespaces(myns, {});
     assert.equal(result.namespaces.length, 1, 'Expected 1 namespace');
-    assert(result.namespaces.some(function(ns) {
-      return ns.name === 'one-ns';
-    }), 'Expected to find one-ns');
+    assert(result.namespaces.some((ns) => ns.name === 'one-ns'), 'Expected to find one-ns');
 
   });
 
-  const insert10Tasks = async function(myns) {
+  const insert10Tasks = async (myns) => {
     const expiry = new Date();
     expiry.setDate(expiry.getDate() + 10);
     const res = [];
@@ -263,7 +253,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
     return res;
   };
 
-  test('list top-level namespaces test limit and continuationToken params', async function() {
+  test('list top-level namespaces test limit and continuationToken params', async () => {
     const myns = slugid.v4();
     await insert10Tasks(myns);
     debug('listNamespaces returns continuationToken after limit = 10');

--- a/services/notify/src/api.js
+++ b/services/notify/src/api.js
@@ -247,7 +247,7 @@ builder.declare({
     'This endpoint is used to check on backing services this service',
     'depends on.',
   ].join('\n'),
-}, function(_req, res) {
+}, (_req, res) => {
   // TODO: add implementation
   res.reply({});
 });

--- a/services/notify/src/exchanges.js
+++ b/services/notify/src/exchanges.js
@@ -18,7 +18,7 @@ const exchanges = new Exchanges({
 export default exchanges;
 
 /** Build common routing key construct for `exchanges.declare` */
-const buildCommonRoutingKey = function(options) {
+const buildCommonRoutingKey = (options) => {
   options = options || {};
   return [
     {
@@ -39,20 +39,18 @@ const buildCommonRoutingKey = function(options) {
 };
 
 /** Build an AMQP compatible message from a message */
-const commonMessageBuilder = function(message) {
+const commonMessageBuilder = (message) => {
   message.version = 1;
   return message;
 };
 
 /** Build a message from message */
-const commonRoutingKeyBuilder = function(message, routing) {
-  return {
-    topic: routing[0],
-  };
-};
+const commonRoutingKeyBuilder = (message, routing) => ({
+  topic: routing[0],
+});
 
 /** Build list of routing keys to CC */
-const commonCCBuilder = function(message, routes) {
+const commonCCBuilder = (message, routes) => {
   assert(Array.isArray(routes), 'Routes must be an array');
   return routes.map(route => 'route.' + route);
 };

--- a/services/notify/test/api_test.js
+++ b/services/notify/test/api_test.js
@@ -3,7 +3,7 @@ import { strict as assert } from 'node:assert';
 import helper from './helper.js';
 import testing from '@taskcluster/lib-testing';
 
-helper.secrets.mockSuite(testing.suiteName(), ['aws'], function(mock, skipping) {
+helper.secrets.mockSuite(testing.suiteName(), ['aws'], (mock, skipping) => {
   helper.withDb(mock, skipping);
   helper.withPulse(mock, skipping);
   helper.withFakeMatrix(mock, skipping);
@@ -22,23 +22,23 @@ helper.secrets.mockSuite(testing.suiteName(), ['aws'], function(mock, skipping) 
     notificationAddress: "username",
   };
 
-  setup('reset notifier', async function() {
+  setup('reset notifier', async () => {
     const notifier = helper.load('notifier');
     notifier.hashCache = [];
   });
 
-  test('ping', async function() {
+  test('ping', async () => {
     await helper.apiClient.ping();
   });
 
-  test('pulse', async function() {
+  test('pulse', async () => {
     await helper.apiClient.pulse({ routingKey: 'notify-test', message: { test: 123 } });
     helper.assertPulseMessage('notification', m => (
       _.isEqual(m.payload.message, { test: 123 }) &&
       _.isEqual(m.CCs, ['route.notify-test'])));
   });
 
-  test('pulse() fails if pulse publish fails', async function() {
+  test('pulse() fails if pulse publish fails', async () => {
     helper.onPulsePublish(() => {
       throw new Error('uhoh');
     });
@@ -56,7 +56,7 @@ helper.secrets.mockSuite(testing.suiteName(), ['aws'], function(mock, skipping) 
     monitor.manager.reset();
   });
 
-  test('does not send notifications to denylisted pulse address', async function() {
+  test('does not send notifications to denylisted pulse address', async () => {
     // Add an address to the denylist
     await helper.apiClient.addDenylistAddress({
       notificationType: 'pulse',
@@ -73,7 +73,7 @@ helper.secrets.mockSuite(testing.suiteName(), ['aws'], function(mock, skipping) 
     helper.assertNoPulseMessage('notification');
   });
 
-  test('email', async function() {
+  test('email', async () => {
     await helper.apiClient.email({
       address: 'success@simulator.amazonses.com',
       subject: 'Task Z-tDsP4jQ3OUTjN0Q6LNKQ is Complete',
@@ -85,7 +85,7 @@ helper.secrets.mockSuite(testing.suiteName(), ['aws'], function(mock, skipping) 
     });
   });
 
-  test('does not send notifications to denylisted email address', async function() {
+  test('does not send notifications to denylisted email address', async () => {
     // Add an address to the denylist
     await helper.apiClient.addDenylistAddress({
       notificationType: 'email',
@@ -108,7 +108,7 @@ helper.secrets.mockSuite(testing.suiteName(), ['aws'], function(mock, skipping) 
     throw new Error('expected an error');
   });
 
-  test('email without link', async function() {
+  test('email without link', async () => {
     await helper.apiClient.email({
       address: 'success@simulator.amazonses.com',
       subject: 'Task Z-tDsP4jQ3OUTjN0Q6LNKo is Complete',
@@ -119,7 +119,7 @@ helper.secrets.mockSuite(testing.suiteName(), ['aws'], function(mock, skipping) 
     });
   });
 
-  test('email with fullscreen template', async function() {
+  test('email with fullscreen template', async () => {
     await helper.apiClient.email({
       address: 'success@simulator.amazonses.com',
       subject: 'Task Z-tDsP4jQ3OUTjN0Q6LNKp is Complete',
@@ -131,7 +131,7 @@ helper.secrets.mockSuite(testing.suiteName(), ['aws'], function(mock, skipping) 
     });
   });
 
-  test('matrix', async function() {
+  test('matrix', async () => {
     await helper.apiClient.matrix({ body: 'Does this work?', roomId: '!foobar:baz.com', msgtype: 'm.text' });
     assert.equal(helper.matrixClient.sendEvent.callCount, 1);
     assert.equal(helper.matrixClient.sendEvent.args[0][0], '!foobar:baz.com');
@@ -142,7 +142,7 @@ helper.secrets.mockSuite(testing.suiteName(), ['aws'], function(mock, skipping) 
     assert(monitor.manager.messages.find(m => m.Type === 'matrix-forbidden') === undefined);
   });
 
-  test('matrix (default msgtype)', async function() {
+  test('matrix (default msgtype)', async () => {
     await helper.apiClient.matrix({ body: 'Does this work?', roomId: '!foobar:baz.com' });
     assert.equal(helper.matrixClient.sendEvent.callCount, 1);
     assert.equal(helper.matrixClient.sendEvent.args[0][0], '!foobar:baz.com');
@@ -153,7 +153,7 @@ helper.secrets.mockSuite(testing.suiteName(), ['aws'], function(mock, skipping) 
     assert(monitor.manager.messages.find(m => m.Type === 'matrix-forbidden') === undefined);
   });
 
-  test('matrix (rejected)', async function() {
+  test('matrix (rejected)', async () => {
     try {
       await helper.apiClient.matrix({ body: 'Does this work?', roomId: '!rejected:baz.com' });
       throw new Error('should have failed');
@@ -166,7 +166,7 @@ helper.secrets.mockSuite(testing.suiteName(), ['aws'], function(mock, skipping) 
     }
   });
 
-  test('matrix (denylisted)', async function() {
+  test('matrix (denylisted)', async () => {
     await helper.apiClient.addDenylistAddress({ notificationType: 'matrix-room', notificationAddress: '!foo:baz.com' });
     try {
       await helper.apiClient.matrix({ body: 'Does this work?', roomId: '!foo:baz.com' });
@@ -178,7 +178,7 @@ helper.secrets.mockSuite(testing.suiteName(), ['aws'], function(mock, skipping) 
     }
   });
 
-  test('slack', async function() {
+  test('slack', async () => {
     await helper.apiClient.slack({ channelId: 'C123456', text: 'Does this work?' });
     assert.equal(helper.slackClient.chat.postMessage.callCount, 1);
     assert.deepStrictEqual(helper.slackClient.chat.postMessage.args[0][0], {
@@ -191,7 +191,7 @@ helper.secrets.mockSuite(testing.suiteName(), ['aws'], function(mock, skipping) 
     assert(monitor.manager.messages.find(m => m.Type === 'slack'));
   });
 
-  test('slack (denylisted)', async function() {
+  test('slack (denylisted)', async () => {
     await helper.apiClient.addDenylistAddress({ notificationType: 'slack-channel', notificationAddress: 'C123456' });
     try {
       await helper.apiClient.slack({ channelId: 'C123456', text: 'Does this work?' });
@@ -203,7 +203,7 @@ helper.secrets.mockSuite(testing.suiteName(), ['aws'], function(mock, skipping) 
     }
   });
 
-  test('Denylist: addDenylistAddress()', async function() {
+  test('Denylist: addDenylistAddress()', async () => {
     // Try adding an address to the denylist
     await helper.apiClient.addDenylistAddress(dummyAddress1);
 
@@ -224,7 +224,7 @@ helper.secrets.mockSuite(testing.suiteName(), ['aws'], function(mock, skipping) 
     await helper.apiClient.addDenylistAddress(dummyAddress1);
   });
 
-  test('Denylist: deleteDenylistAddress()', async function() {
+  test('Denylist: deleteDenylistAddress()', async () => {
     // Add some items
     await helper.apiClient.addDenylistAddress(dummyAddress1);
     await helper.apiClient.addDenylistAddress(dummyAddress2);
@@ -247,7 +247,7 @@ helper.secrets.mockSuite(testing.suiteName(), ['aws'], function(mock, skipping) 
     await helper.apiClient.deleteDenylistAddress(dummyAddress1);
   });
 
-  test('Denylist: listDenylist()', async function() {
+  test('Denylist: listDenylist()', async () => {
     // Call listDenylist() on an empty table
     let addressList = await helper.apiClient.listDenylist();
     assert(addressList.addresses, []);

--- a/services/notify/test/handler_test.js
+++ b/services/notify/test/handler_test.js
@@ -3,7 +3,7 @@ import assert from 'node:assert';
 import helper from './helper.js';
 import testing from '@taskcluster/lib-testing';
 
-helper.secrets.mockSuite(testing.suiteName(), ['aws'], function(mock, skipping) {
+helper.secrets.mockSuite(testing.suiteName(), ['aws'], (mock, skipping) => {
   helper.withDb(mock, skipping);
   helper.withDenier(mock, skipping);
   helper.withFakeQueue(mock, skipping);
@@ -17,29 +17,27 @@ helper.secrets.mockSuite(testing.suiteName(), ['aws'], function(mock, skipping) 
   const deadline = new Date();
   deadline.setMinutes(deadline.getMinutes() + 25);
 
-  let makeTask = function(routes) {
-    return {
-      provisionerId: 'dummy-test-provisioner',
-      workerType: 'dummy-test-worker-type',
-      scopes: [],
-      routes: routes,
-      retries: 3,
-      created: created.toJSON(),
-      deadline: deadline.toJSON(),
-      payload: {
-        desiredResolution: 'success',
-      },
-      metadata: {
-        name: 'Print `"Hello World"` Once',
-        description: 'This task will prìnt `"Hello World"` **once**!',
-        owner: 'jojensen@mozilla.com', // Because this is stolen from tc-index tests!
-        source: 'https://github.com/taskcluster/taskcluster-notify',
-      },
-      tags: {
-        objective: 'Test task notifications',
-      },
-    };
-  };
+  let makeTask = (routes) => ({
+    provisionerId: 'dummy-test-provisioner',
+    workerType: 'dummy-test-worker-type',
+    scopes: [],
+    routes: routes,
+    retries: 3,
+    created: created.toJSON(),
+    deadline: deadline.toJSON(),
+    payload: {
+      desiredResolution: 'success',
+    },
+    metadata: {
+      name: 'Print `"Hello World"` Once',
+      description: 'This task will prìnt `"Hello World"` **once**!',
+      owner: 'jojensen@mozilla.com', // Because this is stolen from tc-index tests!
+      source: 'https://github.com/taskcluster/taskcluster-notify',
+    },
+    tags: {
+      objective: 'Test task notifications',
+    },
+  });
 
   let baseStatus = {
     taskId: 'DKPZPsvvQEiw67Pb3rkdNg',
@@ -74,7 +72,7 @@ helper.secrets.mockSuite(testing.suiteName(), ['aws'], function(mock, skipping) 
   };
 
   let monitor;
-  suiteSetup('create handler', async function() {
+  suiteSetup('create handler', async () => {
     if (skipping()) {
       return;
     }

--- a/services/notify/test/helper.js
+++ b/services/notify/test/helper.js
@@ -41,7 +41,7 @@ const load = testing.stickyLoader(mainLoad);
 const helper = { load, rootUrl, suiteName };
 export default helper;
 
-suiteSetup(async function() {
+suiteSetup(async () => {
   load.inject('profile', 'test');
   load.inject('process', 'test');
 });
@@ -66,7 +66,7 @@ helper.secrets = new testing.Secrets({
  * Define a fake denier that will deny anything with 'denied' in the address
  */
 helper.withDenier = (mock, skipping) => {
-  suiteSetup('withDenier', async function() {
+  suiteSetup('withDenier', async () => {
     if (skipping()) {
       return;
     }
@@ -82,7 +82,7 @@ helper.withSES = (mock, skipping) => {
   let ses;
   let sqs;
 
-  suiteSetup('withSES', async function() {
+  suiteSetup('withSES', async () => {
     if (skipping()) {
       return;
     }
@@ -200,7 +200,7 @@ helper.withSES = (mock, skipping) => {
     }
   });
 
-  suiteTeardown('withSES', async function() {
+  suiteTeardown('withSES', async () => {
     if (skipping()) {
       return;
     }
@@ -231,7 +231,7 @@ const stubbedQueue = () => {
     },
   });
 
-  queue.addTask = function(taskId, task) {
+  queue.addTask = (taskId, task) => {
     tasks[taskId] = task;
   };
 
@@ -246,7 +246,7 @@ const stubbedQueue = () => {
  * The component is available at `helper.queue`.
  */
 helper.withFakeQueue = (mock, skipping) => {
-  suiteSetup('withFakeQueue', function() {
+  suiteSetup('withFakeQueue', () => {
     if (skipping()) {
       return;
     }
@@ -265,7 +265,7 @@ const fakeMatrixSend = () => sinon.fake(roomId => {
 });
 
 helper.withFakeMatrix = (mock, skipping) => {
-  suiteSetup('withFakeMatrix', function() {
+  suiteSetup('withFakeMatrix', () => {
     if (skipping()) {
       return;
     }
@@ -277,7 +277,7 @@ helper.withFakeMatrix = (mock, skipping) => {
     load.inject('matrixClient', helper.matrixClient);
   });
 
-  setup(function() {
+  setup(() => {
     helper.matrixClient.sendEvent = fakeMatrixSend();
   });
 };
@@ -285,7 +285,7 @@ helper.withFakeMatrix = (mock, skipping) => {
 helper.withFakeSlack = (mock, skipping) => {
   const fakeSlackSend = () => sinon.fake(() => ({ ok: true }));
 
-  suiteSetup('withFakeSlack', async function() {
+  suiteSetup('withFakeSlack', async () => {
     if (skipping()) {
       return;
     }
@@ -299,7 +299,7 @@ helper.withFakeSlack = (mock, skipping) => {
     load.inject('slackClient', helper.slackClient);
   });
 
-  setup(function() {
+  setup(() => {
     helper.slackClient.chat.postMessage = fakeSlackSend();
   });
 };
@@ -314,7 +314,7 @@ helper.withPulse = (mock, skipping) => {
 helper.withServer = (mock, skipping) => {
   let webServer;
 
-  suiteSetup('withServer', async function() {
+  suiteSetup('withServer', async () => {
     if (skipping()) {
       return;
     }
@@ -344,7 +344,7 @@ helper.withServer = (mock, skipping) => {
     webServer = await load('server');
   });
 
-  suiteTeardown(async function() {
+  suiteTeardown(async () => {
     if (skipping()) {
       return;
     }
@@ -361,7 +361,7 @@ helper.withDb = (mock, skipping) => {
 };
 
 helper.resetTables = (mock, skipping) => {
-  setup('reset tables', async function() {
+  setup('reset tables', async () => {
     await testing.resetTables({ tableNames: [
       'denylisted_notifications',
     ] });

--- a/services/notify/test/notifier_test.js
+++ b/services/notify/test/notifier_test.js
@@ -2,7 +2,7 @@ import assert from 'node:assert';
 import helper from './helper.js';
 import testing from '@taskcluster/lib-testing';
 
-helper.secrets.mockSuite(testing.suiteName(), ['aws'], function(mock, skipping) {
+helper.secrets.mockSuite(testing.suiteName(), ['aws'], (mock, skipping) => {
   if (!mock) {
     return;
   }

--- a/services/notify/test/ratelimit_test.js
+++ b/services/notify/test/ratelimit_test.js
@@ -4,10 +4,10 @@ import MockDate from 'mockdate';
 import RateLimit from '../src/ratelimit.js';
 import testing from '@taskcluster/lib-testing';
 
-suite(testing.suiteName(), function() {
+suite(testing.suiteName(), () => {
   let rateLimit;
 
-  setup(async function() {
+  setup(async () => {
     rateLimit = new RateLimit({
       count: 5,
       time: 10,
@@ -17,7 +17,7 @@ suite(testing.suiteName(), function() {
     MockDate.set('1/1/2000');
   });
 
-  teardown(function() {
+  teardown(() => {
     MockDate.reset();
   });
 
@@ -27,11 +27,11 @@ suite(testing.suiteName(), function() {
     MockDate.set(newTime);
   };
 
-  test('does not rate-limit a single send', function() {
+  test('does not rate-limit a single send', () => {
     assert(rateLimit.remaining('foo@taskcluster.net') >= 0);
   });
 
-  test('does rate-limit sends at higher than 5 per 10 seconds', function() {
+  test('does rate-limit sends at higher than 5 per 10 seconds', () => {
     // send at 1 per second..
     const limited = _.range(10).map(() => {
       timeFlies(1);
@@ -47,7 +47,7 @@ suite(testing.suiteName(), function() {
     ]);
   });
 
-  test('lifts the rate limit maxMessageTime after a message is sent', function() {
+  test('lifts the rate limit maxMessageTime after a message is sent', () => {
     // send 3 all at once
     _.range(3).forEach(() => {
       rateLimit.markEvent('foo@taskcluster.net');
@@ -66,7 +66,7 @@ suite(testing.suiteName(), function() {
     assert.equal(rateLimit.remaining('foo@taskcluster.net'), 5);
   });
 
-  test('purgeAllOldTimes purges things', function() {
+  test('purgeAllOldTimes purges things', () => {
     _.range(20).forEach(() => {
       rateLimit.markEvent('foo@taskcluster.net');
       rateLimit.markEvent('bar@taskcluster.net');

--- a/services/object/src/api.js
+++ b/services/object/src/api.js
@@ -411,7 +411,7 @@ builder.declare({
     'This endpoint is used to check on backing services this service',
     'depends on.',
   ].join('\n'),
-}, function(_req, res) {
+}, (_req, res) => {
   // TODO: add implementation
   res.reply({});
 });

--- a/services/object/test/api_test.js
+++ b/services/object/test/api_test.js
@@ -6,7 +6,7 @@ import request from 'superagent';
 import crypto from 'node:crypto';
 import { toDataUrl, TestBackend } from '../src/backends/test.js';
 
-helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
+helper.secrets.mockSuite(testing.suiteName(), [], (mock, skipping) => {
   helper.withDb(mock, skipping);
   helper.resetTables(mock, skipping);
   helper.withBackends(mock, skipping);
@@ -38,12 +38,12 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
     return data;
   };
 
-  test('ping', async function() {
+  test('ping', async () => {
     await helper.apiClient.ping();
   });
 
-  suite('createUpload method', function() {
-    test('should be able to upload with a dataInline method', async function() {
+  suite('createUpload method', () => {
+    test('should be able to upload with a dataInline method', async () => {
       const data = crypto.randomBytes(128);
       const uploadId = taskcluster.slugid();
       await helper.apiClient.createUpload('public/foo', {
@@ -67,7 +67,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       assert.deepEqual(rows[0].data, {});
     });
 
-    test('should fail if backend is not found', async function() {
+    test('should fail if backend is not found', async () => {
       const data = crypto.randomBytes(128);
       const uploadId = taskcluster.slugid();
 
@@ -87,7 +87,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
         err => err.statusCode === 400);
     });
 
-    test('should return 409 if object is already uploaded', async function() {
+    test('should return 409 if object is already uploaded', async () => {
       const data = crypto.randomBytes(128);
       const uploadId = taskcluster.slugid();
       const expires = taskcluster.fromNow('1 day');
@@ -120,7 +120,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       );
     });
 
-    test('should return 409 if upload is started with different expires or uploadId', async function() {
+    test('should return 409 if upload is started with different expires or uploadId', async () => {
       const uploadId = taskcluster.slugid();
       const expires = taskcluster.fromNow('1 day');
       const proposedUploadMethods = {}; // propose nothing
@@ -152,7 +152,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       );
     });
 
-    test('should succeed on second attempt to create an upload', async function() {
+    test('should succeed on second attempt to create an upload', async () => {
       const data = crypto.randomBytes(128);
       const uploadId = taskcluster.slugid();
       const expires = taskcluster.fromNow('1 day');
@@ -186,7 +186,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       assert.deepEqual(res.uploadMethod, { dataInline: true });
     });
 
-    test('should allow adding new hashes', async function() {
+    test('should allow adding new hashes', async () => {
       const data = crypto.randomBytes(128);
       const uploadId = taskcluster.slugid();
       const expires = taskcluster.fromNow('1 day');
@@ -227,7 +227,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       assert.deepEqual(objRes.hashes, { sha256, sha512 });
     });
 
-    test('should disallow changing hashes', async function() {
+    test('should disallow changing hashes', async () => {
       const sha256a = 'e38808a4dbfdd9c82a351cc9a6055dffc7b4cc8e12020b2685f8eef92f5d1544';
       const sha256b = 'ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff';
       const uploadId = taskcluster.slugid();
@@ -252,7 +252,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
         err => err.statusCode === 409);
     });
 
-    test('should allow a putUrl method', async function() {
+    test('should allow a putUrl method', async () => {
       const uploadId = taskcluster.slugid();
       const expires = taskcluster.fromNow('1 day');
       const proposedUploadMethods = {
@@ -275,7 +275,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       assert.deepEqual(res.uploadMethod, {});
     });
 
-    test('should succeed on a subsequent attempt if the upload fails', async function() {
+    test('should succeed on a subsequent attempt if the upload fails', async () => {
       const data = crypto.randomBytes(128);
       const uploadId = taskcluster.slugid();
       const expires = taskcluster.fromNow('1 day');
@@ -348,7 +348,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
     });
   });
 
-  suite('finishUpload method', function() {
+  suite('finishUpload method', () => {
     const projectId = 'proj';
     const makeUpload = async name => {
       const data = crypto.randomBytes(128);
@@ -367,28 +367,28 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       return uploadId;
     };
 
-    test('fails for a nonexistent object', async function() {
+    test('fails for a nonexistent object', async () => {
       const uploadId = taskcluster.slugid();
       await assert.rejects(
         () => helper.apiClient.finishUpload('no/such', { uploadId, projectId }),
         err => err.statusCode === 404);
     });
 
-    test('fails with incorrect uploadId', async function() {
+    test('fails with incorrect uploadId', async () => {
       await makeUpload('foo/bar');
       await assert.rejects(
         () => helper.apiClient.finishUpload('foo/bar', { uploadId: taskcluster.slugid(), projectId }),
         err => err.statusCode === 409);
     });
 
-    test('fails with incorrect projectId', async function() {
+    test('fails with incorrect projectId', async () => {
       const uploadId = await makeUpload('foo/bar');
       await assert.rejects(
         () => helper.apiClient.finishUpload('foo/bar', { uploadId, projectId: 'different' }),
         err => err.statusCode === 400);
     });
 
-    test('completes an upload, including hashes', async function() {
+    test('completes an upload, including hashes', async () => {
       const uploadId = await makeUpload('foo/bar');
 
       // can't download this object yet..
@@ -405,13 +405,13 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       assert.deepEqual(res.hashes, { sha256 });
     });
 
-    test('succeeds for an already-completed upload', async function() {
+    test('succeeds for an already-completed upload', async () => {
       const uploadId = await makeUpload('foo/bar');
       await helper.apiClient.finishUpload('foo/bar', { uploadId, projectId });
       await helper.apiClient.finishUpload('foo/bar', { uploadId, projectId });
     });
 
-    test('fails for an already-completed upload with different projectId', async function() {
+    test('fails for an already-completed upload with different projectId', async () => {
       const uploadId = await makeUpload('foo/bar');
       await helper.apiClient.finishUpload('foo/bar', { uploadId, projectId });
       await assert.rejects(
@@ -419,13 +419,13 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
         err => err.statusCode === 400);
     });
 
-    test('succeeds for an already-completed upload with hashes', async function() {
+    test('succeeds for an already-completed upload with hashes', async () => {
       const uploadId = await makeUpload('foo/bar');
       await helper.apiClient.finishUpload('foo/bar', { uploadId, projectId, hashes: { sha256, sha512 } });
       await helper.apiClient.finishUpload('foo/bar', { uploadId, projectId, hashes: { sha256 } });
     });
 
-    test('fails for an already-completed upload with new hashes', async function() {
+    test('fails for an already-completed upload with new hashes', async () => {
       const uploadId = await makeUpload('foo/bar');
       await helper.apiClient.finishUpload('foo/bar', { uploadId, projectId, hashes: { sha256 } });
       await assert.rejects(
@@ -433,7 +433,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
         err => err.statusCode === 409);
     });
 
-    test('fails for an already-completed upload with changed hashes', async function() {
+    test('fails for an already-completed upload with changed hashes', async () => {
       const uploadId = await makeUpload('foo/bar');
       await helper.apiClient.finishUpload('foo/bar', { uploadId, projectId, hashes: { sha256 } });
       const badSha256 = 'ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff';
@@ -442,7 +442,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
         err => err.statusCode === 409);
     });
 
-    test('completes an upload, even if there are no hashes for the object', async function() {
+    test('completes an upload, even if there are no hashes for the object', async () => {
       const uploadId = await makeUpload('foo/bar');
       await helper.apiClient.finishUpload('foo/bar', { uploadId, projectId });
       const res = await helper.apiClient.object('foo/bar');
@@ -451,8 +451,8 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
 
   });
 
-  suite('object method', function() {
-    test('succeeds for an object that exists', async function() {
+  suite('object method', () => {
+    test('succeeds for an object that exists', async () => {
       await createTestObject('public/foo');
       const res = await helper.apiClient.object('public/foo');
       assert.equal(res.projectId, 'x');
@@ -460,7 +460,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       assert.deepEqual(res.hashes, {});
     });
 
-    test('contains hashes from upload', async function() {
+    test('contains hashes from upload', async () => {
       await createTestObject('public/foo', { hashes: { sha256 } });
       const res = await helper.apiClient.object('public/foo');
       assert.equal(res.projectId, 'x');
@@ -468,15 +468,15 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       assert.deepEqual(res.hashes, { sha256 });
     });
 
-    test('404s for an object that does not exist', async function() {
+    test('404s for an object that does not exist', async () => {
       await assert.rejects(
         () => helper.apiClient.object('public/foo'),
         err => err.statusCode === 404);
     });
   });
 
-  suite('startDownload method', function() {
-    test('startDownload for simple method succeeds', async function() {
+  suite('startDownload method', () => {
+    test('startDownload for simple method succeeds', async () => {
       const data = await createTestObject('public/foo');
       const res = await helper.apiClient.startDownload('public/foo', {
         acceptDownloadMethods: { 'simple': true },
@@ -487,7 +487,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       });
     });
 
-    test('startDownload fails when backend is not defined', async function() {
+    test('startDownload fails when backend is not defined', async () => {
       await createTestObject('public/foo');
       await helper.setBackendConfig({ backends: {}, backendMap: [] });
       await assert.rejects(
@@ -497,7 +497,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
         err => err.statusCode === 400);
     });
 
-    test('startDownload for a supported method succeeds', async function() {
+    test('startDownload for a supported method succeeds', async () => {
       const data = await createTestObject('public/foo');
       const res = await helper.apiClient.startDownload('public/foo', {
         acceptDownloadMethods: { 'simple': true },
@@ -508,7 +508,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       });
     });
 
-    test('startDownload handles middleware', async function() {
+    test('startDownload handles middleware', async () => {
       await createTestObject('dl/intercept');
 
       const res = await helper.apiClient.startDownload('dl/intercept', {
@@ -521,7 +521,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       });
     });
 
-    test('startDownload for an unsupported method returns 406', async function() {
+    test('startDownload for an unsupported method returns 406', async () => {
       await createTestObject('has/no/methods');
       await assert.rejects(
         () => helper.apiClient.startDownload('has/no/methods', {
@@ -532,8 +532,8 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
     });
   });
 
-  suite('simple download method', function() {
-    test('simple download redirects to a URL', async function() {
+  suite('simple download method', () => {
+    test('simple download redirects to a URL', async () => {
       const data = await createTestObject('foo/bar');
       const downloadUrl = helper.apiClient.externalBuildSignedUrl(helper.apiClient.download, 'foo/bar');
       const res = await request.get(downloadUrl).redirects(0).ok(res => res.status < 400);
@@ -541,7 +541,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       assert.equal(res.headers.location, toDataUrl(data));
     });
 
-    test('simple download handles middleware', async function() {
+    test('simple download handles middleware', async () => {
       await createTestObject('simple/intercept');
       const downloadUrl = helper.apiClient.externalBuildSignedUrl(helper.apiClient.download, 'simple/intercept');
       const res = await request.get(downloadUrl).redirects(0).ok(res => res.status < 400);
@@ -549,13 +549,13 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       assert.equal(res.headers.location, 'http://intercepted');
     });
 
-    test('simple download for missing object returns 404', async function() {
+    test('simple download for missing object returns 404', async () => {
       const downloadUrl = helper.apiClient.externalBuildSignedUrl(helper.apiClient.download, 'no/such');
       const res = await request.get(downloadUrl).redirects(0).ok(res => res.status === 404);
       assert.equal(res.statusCode, 404);
     });
 
-    test('simple download fails when backend is not defined', async function() {
+    test('simple download fails when backend is not defined', async () => {
       await createTestObject('public/foo');
       await await helper.setBackendConfig({ backends: {}, backendMap: [] });
       await assert.rejects(
@@ -563,7 +563,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
         err => err.statusCode === 400);
     });
 
-    test('simple download for object that does not support the method returns 406', async function() {
+    test('simple download for object that does not support the method returns 406', async () => {
       await createTestObject('has/no/methods');
       const downloadUrl = helper.apiClient.externalBuildSignedUrl(helper.apiClient.download, 'has/no/methods');
       const res = await request.get(downloadUrl).redirects(0).ok(res => res.status === 406);

--- a/services/object/test/backends/aws_test.js
+++ b/services/object/test/backends/aws_test.js
@@ -17,7 +17,7 @@ import zlib from 'node:zlib';
 
 const gzip = promisify(zlib.gzip);
 
-helper.secrets.mockSuite(testing.suiteName(), ['aws'], function(mock, skipping) {
+helper.secrets.mockSuite(testing.suiteName(), ['aws'], (mock, skipping) => {
   if (mock) {
     // tests for this backend require real AWS access, and aren't even defined
     // for the mock case
@@ -32,7 +32,7 @@ helper.secrets.mockSuite(testing.suiteName(), ['aws'], function(mock, skipping) 
   // unique object name prefix for this test run
   const prefix = taskcluster.slugid() + '/';
 
-  suiteSetup(async function() {
+  suiteSetup(async () => {
     await helper.load('cfg');
 
     secret = helper.secrets.get('aws');
@@ -53,7 +53,7 @@ helper.secrets.mockSuite(testing.suiteName(), ['aws'], function(mock, skipping) 
     s3 = new S3Client(options);
   });
 
-  setup(async function() {
+  setup(async () => {
     // set up a backend with a public bucket, and separately with a private
     // bucket; these are in fact the same bucket, and we'll just check that the
     // URLs have a signature for the non-public version.  S3 verifies
@@ -161,8 +161,8 @@ helper.secrets.mockSuite(testing.suiteName(), ['aws'], function(mock, skipping) 
     }
   };
 
-  suite('setup', function() {
-    test('invalid tags are rejected', async function() {
+  suite('setup', () => {
+    test('invalid tags are rejected', async () => {
       const backend = new AwsBackend({
         backendId: 'broken',
         db: helper.db,
@@ -187,7 +187,7 @@ helper.secrets.mockSuite(testing.suiteName(), ['aws'], function(mock, skipping) 
     mock, skipping, prefix,
     backendId: 'awsPublic',
     makeObject,
-  }, async function() {
+  }, async () => {
     teardown(cleanup);
   });
 
@@ -201,7 +201,7 @@ helper.secrets.mockSuite(testing.suiteName(), ['aws'], function(mock, skipping) 
       assert(!url.match(/X-Amz-Credential=/), `got ${url}`);
       assert(!url.match(/X-Amz-Signature=/), `got ${url}`);
     },
-  }, async function() {
+  }, async () => {
     teardown(cleanup);
   });
 
@@ -217,7 +217,7 @@ helper.secrets.mockSuite(testing.suiteName(), ['aws'], function(mock, skipping) 
       assert(url.match(/X-Amz-Credential=/), `got ${url}`);
       assert(url.match(/X-Amz-Signature=/), `got ${url}`);
     },
-  }, async function() {
+  }, async () => {
     teardown(cleanup);
   });
 
@@ -230,7 +230,7 @@ helper.secrets.mockSuite(testing.suiteName(), ['aws'], function(mock, skipping) 
       assert(url.match(/X-Amz-Credential=/), `got ${url}`);
       assert(url.match(/X-Amz-Signature=/), `got ${url}`);
     },
-  }, async function() {
+  }, async () => {
     teardown(cleanup);
   });
 
@@ -238,7 +238,7 @@ helper.secrets.mockSuite(testing.suiteName(), ['aws'], function(mock, skipping) 
     mock, skipping, prefix,
     backendId: 'awsPrivate',
     getObjectContent,
-  }, async function() {
+  }, async () => {
     teardown(cleanup);
   });
 
@@ -246,14 +246,14 @@ helper.secrets.mockSuite(testing.suiteName(), ['aws'], function(mock, skipping) 
     mock, skipping, prefix,
     backendId: 'awsPrivate',
     getObjectContent,
-  }, async function() {
+  }, async () => {
     teardown(cleanup);
   });
 
-  suite('expireObject', function() {
+  suite('expireObject', () => {
     teardown(cleanup);
 
-    test('expires an object', async function() {
+    test('expires an object', async () => {
       const name = 'some/object';
       const object = await makeObject({ name, data: Buffer.from('abc') });
 
@@ -270,7 +270,7 @@ helper.secrets.mockSuite(testing.suiteName(), ['aws'], function(mock, skipping) 
       err => err.Code === 'NoSuchKey');
     });
 
-    test('succeeds for an object that no longer exists', async function() {
+    test('succeeds for an object that no longer exists', async () => {
       const name = 'some/object';
       const uploadId = taskcluster.slugid();
       await helper.db.fns.create_object_for_upload(

--- a/services/object/test/backends/google_test.js
+++ b/services/object/test/backends/google_test.js
@@ -16,7 +16,7 @@ import { toEndpointV1 } from '@aws-sdk/middleware-endpoint';
 
 const gzip = promisify(zlib.gzip);
 
-helper.secrets.mockSuite(testing.suiteName(), ['google'], function(mock, skipping) {
+helper.secrets.mockSuite(testing.suiteName(), ['google'], (mock, skipping) => {
   if (mock) {
     // tests for this backend require real google cloud storage access, and
     // aren't even defined for the mock case
@@ -31,7 +31,7 @@ helper.secrets.mockSuite(testing.suiteName(), ['google'], function(mock, skippin
   // unique object name prefix for this test run
   const prefix = taskcluster.slugid() + '/';
 
-  suiteSetup(async function() {
+  suiteSetup(async () => {
     await helper.load('cfg');
 
     secret = helper.secrets.get('google');
@@ -51,7 +51,7 @@ helper.secrets.mockSuite(testing.suiteName(), ['google'], function(mock, skippin
     });
   });
 
-  setup(async function() {
+  setup(async () => {
     // set up a backend with a public bucket, and separately with a private
     // bucket; these are in fact the same bucket, and we'll just check that the
     // URLs have a signature for the non-public version.  S3 verifies
@@ -125,8 +125,8 @@ helper.secrets.mockSuite(testing.suiteName(), ['google'], function(mock, skippin
     }
   };
 
-  suite('setup', function() {
-    test('any tags are rejected', async function() {
+  suite('setup', () => {
+    test('any tags are rejected', async () => {
       const backend = new AwsBackend({
         backendId: 'broken',
         db: helper.db,
@@ -152,7 +152,7 @@ helper.secrets.mockSuite(testing.suiteName(), ['google'], function(mock, skippin
     mock, skipping, prefix,
     backendId: 'googlePublic',
     makeObject,
-  }, async function() {
+  }, async () => {
     teardown(cleanup);
   });
 
@@ -166,7 +166,7 @@ helper.secrets.mockSuite(testing.suiteName(), ['google'], function(mock, skippin
       assert(!url.match(/X-Amz-Credential=/), `got ${url}`);
       assert(!url.match(/X-Amz-Signature=/), `got ${url}`);
     },
-  }, async function() {
+  }, async () => {
     teardown(cleanup);
   });
 
@@ -182,7 +182,7 @@ helper.secrets.mockSuite(testing.suiteName(), ['google'], function(mock, skippin
       assert(url.match(/X-Amz-Credential=/), `got ${url}`);
       assert(url.match(/X-Amz-Signature=/), `got ${url}`);
     },
-  }, async function() {
+  }, async () => {
     teardown(cleanup);
   });
 
@@ -194,7 +194,7 @@ helper.secrets.mockSuite(testing.suiteName(), ['google'], function(mock, skippin
       assert(url.match(/X-Amz-Credential=/), `got ${url}`);
       assert(url.match(/X-Amz-Signature=/), `got ${url}`);
     },
-  }, async function() {
+  }, async () => {
     teardown(cleanup);
   });
 
@@ -212,7 +212,7 @@ helper.secrets.mockSuite(testing.suiteName(), ['google'], function(mock, skippin
       }));
       return { data: await res.Body.transformToByteArray(), contentType: res.ContentType };
     },
-  }, async function() {
+  }, async () => {
     teardown(cleanup);
   });
 
@@ -230,14 +230,14 @@ helper.secrets.mockSuite(testing.suiteName(), ['google'], function(mock, skippin
       }));
       return { data: await res.Body.transformToByteArray(), contentType: res.ContentType };
     },
-  }, async function() {
+  }, async () => {
     teardown(cleanup);
   });
 
-  suite('expireObject', function() {
+  suite('expireObject', () => {
     teardown(cleanup);
 
-    test('expires an object', async function() {
+    test('expires an object', async () => {
       const name = 'some/object';
       const object = await makeObject({ name, data: Buffer.from('abc') });
 
@@ -254,7 +254,7 @@ helper.secrets.mockSuite(testing.suiteName(), ['google'], function(mock, skippin
       err => err.Code === 'NoSuchKey');
     });
 
-    test('succeeds for an object that no longer exists', async function() {
+    test('succeeds for an object that no longer exists', async () => {
       const name = 'some/object';
       const uploadId = taskcluster.slugid();
       await helper.db.fns.create_object_for_upload(

--- a/services/object/test/backends_test.js
+++ b/services/object/test/backends_test.js
@@ -4,12 +4,12 @@ import testing from '@taskcluster/lib-testing';
 import { Backends } from '../src/backends/index.js';
 import { TestBackend } from '../src/backends/test.js';
 
-helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
+helper.secrets.mockSuite(testing.suiteName(), [], (mock, skipping) => {
   helper.withDb(mock, skipping);
   helper.withBackends(mock, skipping);
 
   let db, monitor, cfg;
-  setup(async function() {
+  setup(async () => {
     db = helper.db;
     monitor = await helper.load('monitor');
     cfg = await helper.load('cfg');
@@ -17,7 +17,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
     helper.load.cfg('backendMap', []);
   });
 
-  test('fails when unknown backend type is given', async function() {
+  test('fails when unknown backend type is given', async () => {
     await assert.rejects(
       () => new Backends().setup({ cfg: {
         ...cfg,
@@ -28,7 +28,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       /Unknown backendType/);
   });
 
-  test('sets up multiple backends with the same type', async function() {
+  test('sets up multiple backends with the same type', async () => {
     const backends = await new Backends().setup({ cfg: {
       ...cfg,
       backends: {
@@ -42,7 +42,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
     assert.equal(backends.get('test2').backendId, 'test2');
   });
 
-  test('get returns undefined for unknown backends', async function() {
+  test('get returns undefined for unknown backends', async () => {
     const backends = await new Backends().setup({ cfg: {
       ...cfg,
       backends: [],
@@ -50,7 +50,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
     assert.deepEqual(backends.get('nosuch'), undefined);
   });
 
-  test('backendMap can be an empty object', async function() {
+  test('backendMap can be an empty object', async () => {
     await new Backends().setup({ cfg: {
       ...cfg,
       backendMap: {},
@@ -59,7 +59,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
   });
 
   const testBackendMap = (title, { backendMap, check, rejects }) => {
-    test(title, async function() {
+    test(title, async () => {
       const backends = {
         t1: { backendType: 'test' },
         t2: { backendType: 'test' },

--- a/services/object/test/expire_test.js
+++ b/services/object/test/expire_test.js
@@ -3,20 +3,20 @@ import taskcluster from '@taskcluster/client';
 import helper from './helper/index.js';
 import testing from '@taskcluster/lib-testing';
 
-helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
+helper.secrets.mockSuite(testing.suiteName(), [], (mock, skipping) => {
   helper.withDb(mock, skipping);
   helper.resetTables(mock, skipping);
   helper.withBackends(mock, skipping);
 
-  setup(async function() {
+  setup(async () => {
     helper.load.save();
   });
 
-  teardown(async function() {
+  teardown(async () => {
     helper.load.restore();
   });
 
-  test('expiration deletes row when backend returns true', async function() {
+  test('expiration deletes row when backend returns true', async () => {
     await helper.db.fns.create_object_for_upload({
       name_in: 'test-obj',
       project_id_in: 'proj',
@@ -33,7 +33,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
     assert.deepEqual(res, []);
   });
 
-  test('expiration does not delete row when backend returns false', async function() {
+  test('expiration does not delete row when backend returns false', async () => {
     await helper.db.fns.create_object_for_upload({
       name_in: 'test-obj',
       project_id_in: 'proj',
@@ -50,7 +50,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
     assert.deepEqual(res.map(obj => obj.name), ['test-obj']);
   });
 
-  test('expiration does not fail row when backend fails', async function() {
+  test('expiration does not fail row when backend fails', async () => {
     await helper.db.fns.create_object_for_upload({
       name_in: 'test-obj',
       project_id_in: 'proj',
@@ -75,7 +75,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
     monitor.manager.reset();
   });
 
-  test('expiration does not fail row when backend does not exist', async function() {
+  test('expiration does not fail row when backend does not exist', async () => {
     await helper.db.fns.create_object_for_upload({
       name_in: 'test-obj',
       project_id_in: 'proj',

--- a/services/object/test/helper/backend-general.js
+++ b/services/object/test/helper/backend-general.js
@@ -34,12 +34,12 @@ export const testBackend = ({
     (suiteDefinition || (() => {})).call(this);
 
     let backend;
-    setup(async function() {
+    setup(async () => {
       const backends = await load('backends');
       backend = backends.get(backendId);
     });
 
-    test('supports only defined downlad methods', async function() {
+    test('supports only defined downlad methods', async () => {
       const data = crypto.randomBytes(256);
       const name = testObjectName(prefix);
       const object = await makeObject({ name, data, hashes: { }, gzipped: false });

--- a/services/object/test/helper/data-inline-upload.js
+++ b/services/object/test/helper/data-inline-upload.js
@@ -37,7 +37,7 @@ export const testDataInlineUpload = ({
     (suiteDefinition || (() => {})).call(this);
 
     let backend;
-    suiteSetup(async function() {
+    suiteSetup(async () => {
       const backends = await helper.load('backends');
       backend = backends.get(backendId);
     });
@@ -53,7 +53,7 @@ export const testDataInlineUpload = ({
     };
 
     for (const length of [0, 1024]) {
-      test(`upload an object (length=${length})`, async function() {
+      test(`upload an object (length=${length})`, async () => {
         const data = crypto.randomBytes(length);
         const name = helper.testObjectName(prefix);
 
@@ -76,7 +76,7 @@ export const testDataInlineUpload = ({
     }
 
     if (!omit.includes('htmlContentDisposition')) {
-      test(`upload of type text/html has attachment disposition`, async function() {
+      test(`upload of type text/html has attachment disposition`, async () => {
         const data = crypto.randomBytes(256);
         const name = helper.testObjectName(prefix);
 

--- a/services/object/test/helper/geturl-download.js
+++ b/services/object/test/helper/geturl-download.js
@@ -43,13 +43,13 @@ export const testGetUrlDownloadMethod = ({
     (suiteDefinition || (() => {})).call(this);
 
     let backend;
-    setup(async function() {
+    setup(async () => {
       const backends = await load('backends');
       backend = backends.get(backendId);
     });
 
     [true, false].forEach(gzipped => {
-      test(`supports getUrl downloads (Content-Encoding: ${gzipped ? "gzip" : "identity"})`, async function() {
+      test(`supports getUrl downloads (Content-Encoding: ${gzipped ? "gzip" : "identity"})`, async () => {
         const data = crypto.randomBytes(256);
         const name = testObjectName(prefix);
         const object = await makeObject({ name, data, hashes: { sha256, sha512 }, gzipped });

--- a/services/object/test/helper/index.js
+++ b/services/object/test/helper/index.js
@@ -27,7 +27,7 @@ const helper = {
   testPutUrlUpload,
 };
 
-suiteSetup(async function() {
+suiteSetup(async () => {
   load.inject('profile', 'test');
   load.inject('process', 'test');
 });
@@ -70,7 +70,7 @@ helper.withBackends = (mock, skipping) => {
     { backendId: 'testBackend', when: 'all' },
   ];
 
-  suiteSetup('withBackends', async function() {
+  suiteSetup('withBackends', async () => {
     if (skipping()) {
       return;
     }
@@ -100,12 +100,12 @@ helper.withBackends = (mock, skipping) => {
     };
   });
 
-  setup('withBackends', async function() {
+  setup('withBackends', async () => {
     // reset to default
     await helper.setBackendConfig();
   });
 
-  suiteTeardown('withBackends', async function() {
+  suiteTeardown('withBackends', async () => {
     if (skipping()) {
       return;
     }
@@ -118,7 +118,7 @@ helper.withBackends = (mock, skipping) => {
 };
 
 helper.withMiddleware = (mock, skipping, config) => {
-  suiteSetup('withMiddleware', async function() {
+  suiteSetup('withMiddleware', async () => {
     if (skipping()) {
       return;
     }
@@ -132,7 +132,7 @@ helper.withMiddleware = (mock, skipping, config) => {
     ]);
   });
 
-  suiteTeardown('withMiddleware', async function() {
+  suiteTeardown('withMiddleware', async () => {
     delete MIDDLEWARE_TYPES.test;
   });
 };
@@ -140,7 +140,7 @@ helper.withMiddleware = (mock, skipping, config) => {
 helper.withServer = (mock, skipping) => {
   let webServer;
 
-  suiteSetup('withServer', async function() {
+  suiteSetup('withServer', async () => {
     if (skipping()) {
       return;
     }
@@ -172,7 +172,7 @@ helper.withServer = (mock, skipping) => {
     webServer = await load('server');
   });
 
-  suiteTeardown(async function() {
+  suiteTeardown(async () => {
     if (skipping()) {
       return;
     }
@@ -189,7 +189,7 @@ helper.withDb = (mock, skipping) => {
 };
 
 helper.resetTables = (mock, skipping) => {
-  setup('reset tables', async function() {
+  setup('reset tables', async () => {
     await testing.resetTables({
       tableNames: ['objects', 'object_hashes'],
     });

--- a/services/object/test/helper/put-url-upload.js
+++ b/services/object/test/helper/put-url-upload.js
@@ -39,7 +39,7 @@ export const testPutUrlUpload = ({
     (suiteDefinition || (() => {})).call(this);
 
     let backend;
-    suiteSetup(async function() {
+    suiteSetup(async () => {
       const backends = await helper.load('backends');
       backend = backends.get(backendId);
     });
@@ -79,7 +79,7 @@ export const testPutUrlUpload = ({
     };
 
     for (const length of [0, 1024]) {
-      test(`upload an object (length=${length})`, async function() {
+      test(`upload an object (length=${length})`, async () => {
         const { name, data, res, object, uploadId } = await makeUpload({ length });
         await performUpload({ name, data, res, uploadId });
         await finishUpload({ name, uploadId, object });
@@ -90,7 +90,7 @@ export const testPutUrlUpload = ({
       });
     }
 
-    test('upload an object with a bad Content-Type', async function() {
+    test('upload an object with a bad Content-Type', async () => {
       const { data, res } = await makeUpload();
 
       let req = request.put(res.putUrl.url);
@@ -106,7 +106,7 @@ export const testPutUrlUpload = ({
     });
 
     if (!omit.includes('htmlContentDisposition')) {
-      test(`upload of type text/html has attachment disposition`, async function() {
+      test(`upload of type text/html has attachment disposition`, async () => {
         const { name, data, res, object, uploadId } = await makeUpload({ contentType: 'text/html' });
 
         await performUpload({ name, data, res, uploadId });

--- a/services/object/test/helper/simple-download.js
+++ b/services/object/test/helper/simple-download.js
@@ -37,12 +37,12 @@ export const testSimpleDownloadMethod = ({
     (suiteDefinition || (() => {})).call(this);
 
     let backend;
-    setup(async function() {
+    setup(async () => {
       const backends = await load('backends');
       backend = backends.get(backendId);
     });
 
-    test('supports simple downloads', async function() {
+    test('supports simple downloads', async () => {
       const data = crypto.randomBytes(256);
       const name = testObjectName(prefix);
       const object = await makeObject({ name, data });

--- a/services/object/test/middleware/cdn_test.js
+++ b/services/object/test/middleware/cdn_test.js
@@ -5,7 +5,7 @@ import request from 'superagent';
 import crypto from 'node:crypto';
 import taskcluster from '@taskcluster/client';
 
-helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
+helper.secrets.mockSuite(testing.suiteName(), [], (mock, skipping) => {
   helper.withDb(mock, skipping);
   helper.resetTables(mock, skipping);
   helper.withBackends(mock, skipping);
@@ -33,7 +33,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
     await helper.apiClient.finishUpload(name, { projectId: 'x', uploadId });
   };
 
-  test('intercepts matching simple downloads', async function() {
+  test('intercepts matching simple downloads', async () => {
     await makeObject('public/foo/bar');
     const downloadUrl = helper.apiClient.externalBuildSignedUrl(helper.apiClient.download, 'public/foo/bar');
     const res = await request.get(downloadUrl).redirects(0).ok(res => res.status < 400);
@@ -41,7 +41,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
     assert.equal(res.headers.location, "https://cdn.example.com/public/foo/bar");
   });
 
-  test('ignores non-matching simple downloads', async function() {
+  test('ignores non-matching simple downloads', async () => {
     await makeObject('private/foo/bar');
     const downloadUrl = helper.apiClient.externalBuildSignedUrl(helper.apiClient.download, 'private/foo/bar');
     const res = await request.get(downloadUrl).redirects(0).ok(res => res.status < 400);

--- a/services/object/test/middleware_test.js
+++ b/services/object/test/middleware_test.js
@@ -2,13 +2,13 @@ import { strict as assert } from 'node:assert';
 import helper from './helper/index.js';
 import testing from '@taskcluster/lib-testing';
 
-helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
+helper.secrets.mockSuite(testing.suiteName(), [], (mock, skipping) => {
   helper.withMiddleware(mock, skipping, [
     { 'middlewareType': 'test', startDownload: { intercept: 'dl' } },
     { 'middlewareType': 'test', download: { intercept: 'simple' } },
   ]);
 
-  test('calls middleware for startDownloadRequest', async function() {
+  test('calls middleware for startDownloadRequest', async () => {
     const middleware = await helper.load('middleware');
 
     let reply;
@@ -19,7 +19,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
     assert.deepEqual(reply, { method: 'simple', url: 'http://intercepted' });
   });
 
-  test('calls middleware for downloadRequest', async function() {
+  test('calls middleware for downloadRequest', async () => {
     const middleware = await helper.load('middleware');
 
     let redirect;

--- a/services/purge-cache/src/api.js
+++ b/services/purge-cache/src/api.js
@@ -176,7 +176,7 @@ builder.declare({
     'This endpoint is used to check on backing services this service',
     'depends on.',
   ].join('\n'),
-}, function(_req, res) {
+}, (_req, res) => {
   // TODO: add implementation
   res.reply({});
 });

--- a/services/purge-cache/test/expire_test.js
+++ b/services/purge-cache/test/expire_test.js
@@ -3,15 +3,15 @@ import taskcluster from '@taskcluster/client';
 import assume from 'assume';
 import testing from '@taskcluster/lib-testing';
 
-helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
+helper.secrets.mockSuite(testing.suiteName(), [], (mock, skipping) => {
   helper.withDb(mock, skipping);
 
-  test('expire nothing', async function() {
+  test('expire nothing', async () => {
     const count = (await helper.db.fns.expire_cache_purges(new Date()))[0].expire_cache_purges;
     assume(count).to.equal(0);
   });
 
-  test('expire something', async function() {
+  test('expire something', async () => {
     const wpid = 'pid/wt';
     const times = [
       taskcluster.fromNow('-3 hours'),

--- a/services/purge-cache/test/helper.js
+++ b/services/purge-cache/test/helper.js
@@ -16,7 +16,7 @@ const load = testing.stickyLoader(loadMain);
 const helper = { load, rootUrl, suiteName };
 export default helper;
 
-suiteSetup(async function() {
+suiteSetup(async () => {
   load.inject('profile', 'test');
   load.inject('process', 'test');
 });
@@ -40,7 +40,7 @@ helper.withServer = (mock, skipping) => {
   let webServer;
   let cachePurgeCache = {};
 
-  suiteSetup(async function() {
+  suiteSetup(async () => {
     if (skipping()) {
       return;
     }
@@ -72,11 +72,11 @@ helper.withServer = (mock, skipping) => {
     webServer = await load('server');
   });
 
-  setup(function() {
+  setup(() => {
     Object.keys(cachePurgeCache).forEach(k => delete cachePurgeCache[k]);
   });
 
-  suiteTeardown(async function() {
+  suiteTeardown(async () => {
     if (skipping()) {
       return;
     }

--- a/services/purge-cache/test/purgecache_test.js
+++ b/services/purge-cache/test/purgecache_test.js
@@ -5,7 +5,7 @@ import sinon from 'sinon';
 import assert from 'node:assert';
 import taskcluster from '@taskcluster/client';
 
-helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
+helper.secrets.mockSuite(testing.suiteName(), [], (mock, skipping) => {
   helper.withDb(mock, skipping);
   helper.withServer(mock, skipping);
 
@@ -13,14 +13,14 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
     return helper.apiClient.ping();
   });
 
-  test('allPurgeRequests without scopes', async function() {
+  test('allPurgeRequests without scopes', async () => {
     const client = new helper.PurgeCacheClient({ rootUrl: helper.rootUrl });
     await assert.rejects(
       () => client.allPurgeRequests(),
       err => err.code === 'InsufficientScopes');
   });
 
-  test('purgeRequests without scopes', async function() {
+  test('purgeRequests without scopes', async () => {
     const client = new helper.PurgeCacheClient({ rootUrl: helper.rootUrl });
     await assert.rejects(
       () => client.purgeRequests('dummy-provisioner-extended-extended-2/dummy-worker-extended-extended'),
@@ -97,7 +97,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
     assume(spec.requests.length).equals(0);
   });
 
-  test('purgeRequest caching', async function() {
+  test('purgeRequest caching', async () => {
     sinon.stub(helper.db.fns, 'purge_requests_wpid').callsFake(async (query) => []);
     try {
       const since = taskcluster.fromNow('-1 hour').toString();
@@ -113,7 +113,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
     }
   });
 
-  test('purgeRequest with a failed postgres query', async function() {
+  test('purgeRequest with a failed postgres query', async () => {
     // client retries could confuse the picture here, so don't do them
     const client = helper.apiClient.use({ retries: 0 });
 

--- a/services/queue/src/api.js
+++ b/services/queue/src/api.js
@@ -677,7 +677,7 @@ builder.declare({
 /**
  * Generate the list of acceptable priorities for a task with this priority
  */
-const authorizeTaskCreation = async function(req, taskId, taskDef) {
+const authorizeTaskCreation = async (req, taskId, taskDef) => {
   const priority = taskDef.priority === 'normal' ? 'lowest' : taskDef.priority;
   const priorities = PRIORITY_LEVELS.slice(0, PRIORITY_LEVELS.indexOf(priority) + 1);
   assert(priorities.length > 0, 'must have a non-empty list of priorities');
@@ -697,7 +697,7 @@ const authorizeTaskCreation = async function(req, taskId, taskDef) {
 };
 
 /** Construct default values and validate dates */
-let patchAndValidateTaskDef = function(taskId, taskDef, maxTaskDeadlineDays) {
+let patchAndValidateTaskDef = (taskId, taskDef, maxTaskDeadlineDays) => {
   // Set taskGroupId to taskId if not provided
   if (!taskDef.taskGroupId) {
     taskDef.taskGroupId = taskId;
@@ -2792,7 +2792,7 @@ builder.declare({
     'This endpoint is used to check on backing services this service',
     'depends on.',
   ].join('\n'),
-}, function(_req, res) {
+}, (_req, res) => {
   // TODO: add implementation
   res.reply({});
 });

--- a/services/queue/src/bucket.js
+++ b/services/queue/src/bucket.js
@@ -156,11 +156,9 @@ Bucket.prototype.deleteObjects = function(prefixes, quiet = false) {
   return this.s3.send(new DeleteObjectsCommand({
     Bucket: this.bucket,
     Delete: {
-      Objects: prefixes.map(function(prefix) {
-        return {
-          Key: prefix,
-        };
-      }),
+      Objects: prefixes.map((prefix) => ({
+        Key: prefix,
+      })),
       ...(quiet ? { Quiet: true } : {}),
     },
   }));

--- a/services/queue/src/exchanges.js
+++ b/services/queue/src/exchanges.js
@@ -62,7 +62,7 @@ let exchanges = new Exchanges({
 export default exchanges;
 
 /** Build common routing key construct for `exchanges.declare` */
-let buildCommonRoutingKey = function(options) {
+let buildCommonRoutingKey = (options) => {
   options = options || {};
   return [
     {
@@ -127,7 +127,7 @@ let buildCommonRoutingKey = function(options) {
 };
 
 /** Build common routing key construct for task-group-messages for `exchanges.declare` */
-let buildTaskGroupRoutingKey = function(options) {
+let buildTaskGroupRoutingKey = (options) => {
   options = options || {};
   return [
     {
@@ -158,35 +158,31 @@ let buildTaskGroupRoutingKey = function(options) {
 };
 
 /** Build an AMQP compatible message from a message */
-let commonMessageBuilder = function(message) {
+let commonMessageBuilder = (message) => {
   message.version = 1;
   return message;
 };
 
 /** Build a message from message */
-let commonRoutingKeyBuilder = function(message, routing) {
-  return {
-    taskId: message.status.taskId,
-    runId: message.runId,
-    workerGroup: message.workerGroup,
-    workerId: message.workerId,
-    provisionerId: message.status.provisionerId,
-    workerType: message.status.workerType,
-    schedulerId: message.status.schedulerId,
-    taskGroupId: message.status.taskGroupId,
-  };
-};
+let commonRoutingKeyBuilder = (message, routing) => ({
+  taskId: message.status.taskId,
+  runId: message.runId,
+  workerGroup: message.workerGroup,
+  workerId: message.workerId,
+  provisionerId: message.status.provisionerId,
+  workerType: message.status.workerType,
+  schedulerId: message.status.schedulerId,
+  taskGroupId: message.status.taskGroupId,
+});
 
 /** Build a message from message for task-group messages */
-let taskGroupRoutingKeyBuilder = function(message, routing) {
-  return {
-    schedulerId: message.schedulerId,
-    taskGroupId: message.taskGroupId,
-  };
-};
+let taskGroupRoutingKeyBuilder = (message, routing) => ({
+  schedulerId: message.schedulerId,
+  taskGroupId: message.taskGroupId,
+});
 
 /** Build list of routing keys to CC */
-let commonCCBuilder = function(message, routes) {
+let commonCCBuilder = (message, routes) => {
   assert(Array.isArray(routes), 'Routes must be an array');
   return routes.map(route => 'route.' + route);
 };

--- a/services/queue/src/task-creds.js
+++ b/services/queue/src/task-creds.js
@@ -3,7 +3,7 @@ import taskcluster from '@taskcluster/client';
 /**
  * Creates temporary credentials for a task run.
  */
-let taskCredentials = function(taskId, runId, workerGroup, workerId, takenUntil, scopes, permaCreds) {
+let taskCredentials = (taskId, runId, workerGroup, workerId, takenUntil, scopes, permaCreds) => {
   let clientId = [
     'task-client',
     taskId,

--- a/services/queue/test/artifact_test.js
+++ b/services/queue/test/artifact_test.js
@@ -560,7 +560,7 @@ helper.secrets.mockSuite(testing.suiteName(), ['aws'], function(mock, skipping) 
       assume(res.statusCode).equals(303);
     });
 
-    test('Listing artifacts without scopes', async function() {
+    test('Listing artifacts without scopes', async () => {
       const taskId = slugid.nice();
 
       helper.scopes('none');
@@ -720,13 +720,13 @@ helper.secrets.mockSuite(testing.suiteName(), ['aws'], function(mock, skipping) 
       assume(r3.artifacts.length).equals(0);
     });
 
-    test('finish an artifact for a task that does not exist', async function() {
+    test('finish an artifact for a task that does not exist', async () => {
       await assert.rejects(
         () => helper.queue.finishArtifact(taskId, 0, 'public/foo.json', { uploadId: taskcluster.slugid() }),
         err => err.statusCode === 404);
     });
 
-    test('finish an artifact that does not exist', async function() {
+    test('finish an artifact that does not exist', async () => {
       await makeAndClaimTask();
       await assert.rejects(
         () => helper.queue.finishArtifact(taskId, 0, 'public/foo.json', { uploadId: taskcluster.slugid() }),
@@ -1167,7 +1167,7 @@ helper.secrets.mockSuite(testing.suiteName(), ['aws'], function(mock, skipping) 
     });
   });
 
-  suite('createArtifactCallsCompatible', function() {
+  suite('createArtifactCallsCompatible', () => {
     const sooner = taskcluster.fromNow('1 day');
     const later = taskcluster.fromNow('2 day');
     const base = {
@@ -1177,18 +1177,18 @@ helper.secrets.mockSuite(testing.suiteName(), ['aws'], function(mock, skipping) 
       details: { x: 10 },
     };
 
-    test('same call is compatible', function() {
+    test('same call is compatible', () => {
       assume(createArtifactCallsCompatible(base, base)).is.ok();
     });
 
-    test('extending expires is compatible', function() {
+    test('extending expires is compatible', () => {
       assume(createArtifactCallsCompatible(
         base,
         { ...base, expires: later }))
         .is.ok();
     });
 
-    test('reducing expires is not compatible', function() {
+    test('reducing expires is not compatible', () => {
       assume(createArtifactCallsCompatible(
         { ...base, expires: later },
         { ...base, expires: sooner }))
@@ -1197,7 +1197,7 @@ helper.secrets.mockSuite(testing.suiteName(), ['aws'], function(mock, skipping) 
 
     for (const storageType of ['error', 's3', 'object', 'link']) {
       // NOTE: the list above omits 'reference', as it allows detail changes
-      test(`changing details for storageType ${storageType} is not allowed`, function() {
+      test(`changing details for storageType ${storageType} is not allowed`, () => {
         assume(createArtifactCallsCompatible(
           { ...base, storageType, details: { x: 10 } },
           { ...base, storageType, details: { x: 20 } }))
@@ -1205,7 +1205,7 @@ helper.secrets.mockSuite(testing.suiteName(), ['aws'], function(mock, skipping) 
       });
     }
 
-    test('changing details for storageType reference is allowed', function() {
+    test('changing details for storageType reference is allowed', () => {
       assume(createArtifactCallsCompatible(
         { ...base, storageType: 'reference', details: { x: 10 } },
         { ...base, storageType: 'reference', details: { x: 20 } }))
@@ -1218,7 +1218,7 @@ helper.secrets.mockSuite(testing.suiteName(), ['aws'], function(mock, skipping) 
         if (original === update || (original === 'reference' && update === 'link')) {
           continue;
         }
-        test(`storageType ${original} -> ${update} is not allowed`, function() {
+        test(`storageType ${original} -> ${update} is not allowed`, () => {
           assume(createArtifactCallsCompatible(
             { ...base, storageType: original },
             { ...base, storageType: update }))
@@ -1227,7 +1227,7 @@ helper.secrets.mockSuite(testing.suiteName(), ['aws'], function(mock, skipping) 
       }
     }
 
-    test(`storageType reference -> link is allowed, and content-type is ignored in this case`, function() {
+    test(`storageType reference -> link is allowed, and content-type is ignored in this case`, () => {
       assume(createArtifactCallsCompatible(
         { ...base, storageType: 'reference', details: { url: 'abc' }, contentType: 'old/content-type' },
         { ...base, storageType: 'link', details: { artiact: 'def' }, contentType: 'new/content-type' }))

--- a/services/queue/test/bucket_test.js
+++ b/services/queue/test/bucket_test.js
@@ -7,7 +7,7 @@ import request from 'superagent';
 import helper from './helper.js';
 import testing from '@taskcluster/lib-testing';
 
-helper.secrets.mockSuite(testing.suiteName(), ['aws'], function(mock, skipping) {
+helper.secrets.mockSuite(testing.suiteName(), ['aws'], (mock, skipping) => {
   helper.withS3(mock, skipping);
 
   if (mock) {
@@ -18,14 +18,14 @@ helper.secrets.mockSuite(testing.suiteName(), ['aws'], function(mock, skipping) 
   }
 
   let bucket;
-  setup('load bucket', async function() {
+  setup('load bucket', async () => {
     if (!skipping()) {
       bucket = await helper.load('publicArtifactBucket');
     }
   });
 
   // Test that put to signed url works
-  test('createPutUrl', async function() {
+  test('createPutUrl', async () => {
     const key = slugid.v4();
     const url = await bucket.createPutUrl(key, {
       contentType: 'application/json',
@@ -45,32 +45,32 @@ helper.secrets.mockSuite(testing.suiteName(), ['aws'], function(mock, skipping) 
   };
 
   // Test we can delete an object
-  test('deleteObject', async function() {
+  test('deleteObject', async () => {
     const { key } = await uploadTestFile();
     await bucket.deleteObject(key);
   });
 
   // Test we can delete an object a non-existing object
-  test('deleteObject (non-existing object)', async function() {
+  test('deleteObject (non-existing object)', async () => {
     const key = slugid.v4();
     await bucket.deleteObject(key);
   });
 
   // Test we can delete multiple objects
-  test('deleteObjects', async function () {
+  test('deleteObjects', async () => {
     const { key: key1 } = await uploadTestFile();
     const { key: key2 } = await uploadTestFile();
 
     await bucket.deleteObjects([key1, key2]);
   });
-  test('deleteObjects quiet', async function () {
+  test('deleteObjects quiet', async () => {
     const { key: key1 } = await uploadTestFile();
     const { key: key2 } = await uploadTestFile();
 
     await bucket.deleteObjects([key1, key2], true);
   });
 
-  test('createGetUrl', async function() {
+  test('createGetUrl', async () => {
     const key = slugid.v4();
     const putUrl = await bucket.createPutUrl(key, {
       contentType: 'application/json',
@@ -88,7 +88,7 @@ helper.secrets.mockSuite(testing.suiteName(), ['aws'], function(mock, skipping) 
     assert(res.body.message === 'Hello', 'wrong message');
   });
 
-  test('uses bucketCDN', async function() {
+  test('uses bucketCDN', async () => {
     const cfg = await helper.load('cfg');
 
     // Create bucket instance
@@ -104,7 +104,7 @@ helper.secrets.mockSuite(testing.suiteName(), ['aws'], function(mock, skipping) 
     assert(urlWithSpaces === 'https://example.com/test%20with%20spaces');
   });
 
-  test('default endpoint', async function() {
+  test('default endpoint', async () => {
     const cfg = await helper.load('cfg');
 
     // Create bucket instance
@@ -117,7 +117,7 @@ helper.secrets.mockSuite(testing.suiteName(), ['aws'], function(mock, skipping) 
     assert.equal(url, `https://${cfg.app.publicArtifactBucket}.s3.${cfg.aws.region}.amazonaws.com/testX`);
   });
 
-  test('handles slashes', async function() {
+  test('handles slashes', async () => {
     const cfg = await helper.load('cfg');
 
     // Create bucket instance
@@ -134,7 +134,7 @@ helper.secrets.mockSuite(testing.suiteName(), ['aws'], function(mock, skipping) 
     assert.equal(url, `http://taskcluster/${cfg.app.publicArtifactBucket}/testX`);
   });
 
-  test('custom endpoint + forcePathStyle', async function() {
+  test('custom endpoint + forcePathStyle', async () => {
     const cfg = await helper.load('cfg');
     const customEndpoint = 'http://localhost:45678';
 

--- a/services/queue/test/canceltask_test.js
+++ b/services/queue/test/canceltask_test.js
@@ -8,7 +8,7 @@ import assume from 'assume';
 import helper from './helper.js';
 import testing from '@taskcluster/lib-testing';
 
-helper.secrets.mockSuite(testing.suiteName(), ['aws'], function(mock, skipping) {
+helper.secrets.mockSuite(testing.suiteName(), ['aws'], (mock, skipping) => {
   helper.withDb(mock, skipping);
   helper.withAmazonIPRanges(mock, skipping);
   helper.withPulse(mock, skipping);

--- a/services/queue/test/canceltaskgroup_test.js
+++ b/services/queue/test/canceltaskgroup_test.js
@@ -8,7 +8,7 @@ import assume from 'assume';
 import helper from './helper.js';
 import testing from '@taskcluster/lib-testing';
 
-helper.secrets.mockSuite(testing.suiteName(), ['aws'], function (mock, skipping) {
+helper.secrets.mockSuite(testing.suiteName(), ['aws'], (mock, skipping) => {
   helper.withDb(mock, skipping);
   helper.withAmazonIPRanges(mock, skipping);
   helper.withPulse(mock, skipping);

--- a/services/queue/test/claimresolver_test.js
+++ b/services/queue/test/claimresolver_test.js
@@ -7,7 +7,7 @@ import helper from './helper.js';
 import testing from '@taskcluster/lib-testing';
 import { LEVELS } from '@taskcluster/lib-monitor';
 
-helper.secrets.mockSuite(testing.suiteName(), ['aws'], function(mock, skipping) {
+helper.secrets.mockSuite(testing.suiteName(), ['aws'], (mock, skipping) => {
   helper.withDb(mock, skipping);
   helper.withAmazonIPRanges(mock, skipping);
   helper.withPollingServices(mock, skipping);
@@ -37,7 +37,7 @@ helper.secrets.mockSuite(testing.suiteName(), ['aws'], function(mock, skipping) 
   };
 
   let monitor;
-  suiteSetup(async function() {
+  suiteSetup(async () => {
     monitor = await helper.load('monitor');
   });
 

--- a/services/queue/test/claimtask_test.js
+++ b/services/queue/test/claimtask_test.js
@@ -6,7 +6,7 @@ import assume from 'assume';
 import helper from './helper.js';
 import testing from '@taskcluster/lib-testing';
 
-helper.secrets.mockSuite(testing.suiteName(), ['aws'], function(mock, skipping) {
+helper.secrets.mockSuite(testing.suiteName(), ['aws'], (mock, skipping) => {
   helper.withDb(mock, skipping);
   helper.withAmazonIPRanges(mock, skipping);
   helper.withPulse(mock, skipping);
@@ -36,7 +36,7 @@ helper.secrets.mockSuite(testing.suiteName(), ['aws'], function(mock, skipping) 
     },
   });
 
-  test('can claimTask', async function() {
+  test('can claimTask', async () => {
     const taskId = slugid.v4();
 
     debug('### Creating task');

--- a/services/queue/test/claimwork_test.js
+++ b/services/queue/test/claimwork_test.js
@@ -8,7 +8,7 @@ import helper from './helper.js';
 import testing from '@taskcluster/lib-testing';
 import { LEVELS } from '@taskcluster/lib-monitor';
 
-helper.secrets.mockSuite(testing.suiteName(), ['aws'], function(mock, skipping) {
+helper.secrets.mockSuite(testing.suiteName(), ['aws'], (mock, skipping) => {
   helper.withDb(mock, skipping);
   helper.withAmazonIPRanges(mock, skipping);
   helper.withPulse(mock, skipping);
@@ -36,11 +36,11 @@ helper.secrets.mockSuite(testing.suiteName(), ['aws'], function(mock, skipping) 
   };
 
   let monitor;
-  suiteSetup(async function() {
+  suiteSetup(async () => {
     monitor = await helper.load('monitor');
   });
 
-  test('claimWork from empty queue', async function() {
+  test('claimWork from empty queue', async () => {
     helper.scopes(
       'queue:claim-work:' + taskQueueId,
       'queue:worker-id:my-worker-group-extended-extended/my-worker-extended-extended',

--- a/services/queue/test/createtask_test.js
+++ b/services/queue/test/createtask_test.js
@@ -10,7 +10,7 @@ import testing from '@taskcluster/lib-testing';
 import { LEVELS } from '@taskcluster/lib-monitor';
 import { splitTaskQueueId } from '../src/utils.js';
 
-helper.secrets.mockSuite(testing.suiteName(), ['aws'], function(mock, skipping) {
+helper.secrets.mockSuite(testing.suiteName(), ['aws'], (mock, skipping) => {
   helper.withDb(mock, skipping);
   helper.withAmazonIPRanges(mock, skipping);
   helper.withS3(mock, skipping);
@@ -53,7 +53,7 @@ helper.secrets.mockSuite(testing.suiteName(), ['aws'], function(mock, skipping) 
   };
 
   let monitor;
-  suiteSetup(async function() {
+  suiteSetup(async () => {
     monitor = await helper.load('monitor');
   });
 

--- a/services/queue/test/deadline_test.js
+++ b/services/queue/test/deadline_test.js
@@ -9,7 +9,7 @@ import helper from './helper.js';
 import testing from '@taskcluster/lib-testing';
 import { LEVELS } from '@taskcluster/lib-monitor';
 
-helper.secrets.mockSuite(testing.suiteName(), ['aws'], function(mock, skipping) {
+helper.secrets.mockSuite(testing.suiteName(), ['aws'], (mock, skipping) => {
   helper.withDb(mock, skipping);
   helper.withPollingServices(mock, skipping);
   helper.withAmazonIPRanges(mock, skipping);
@@ -41,7 +41,7 @@ helper.secrets.mockSuite(testing.suiteName(), ['aws'], function(mock, skipping) 
   };
 
   let monitor;
-  suiteSetup(async function() {
+  suiteSetup(async () => {
     monitor = await helper.load('monitor');
   });
 

--- a/services/queue/test/dependency_test.js
+++ b/services/queue/test/dependency_test.js
@@ -9,7 +9,7 @@ import assume from 'assume';
 import helper from './helper.js';
 import { LEVELS } from '@taskcluster/lib-monitor';
 
-helper.secrets.mockSuite(testing.suiteName(), ['aws'], function(mock, skipping) {
+helper.secrets.mockSuite(testing.suiteName(), ['aws'], (mock, skipping) => {
   helper.withDb(mock, skipping);
   helper.withAmazonIPRanges(mock, skipping);
   helper.withPollingServices(mock, skipping);
@@ -33,7 +33,7 @@ helper.secrets.mockSuite(testing.suiteName(), ['aws'], function(mock, skipping) 
   });
 
   let monitor;
-  suiteSetup(async function() {
+  suiteSetup(async () => {
     monitor = await helper.load('monitor');
   });
 

--- a/services/queue/test/ec2regionresolver_test.js
+++ b/services/queue/test/ec2regionresolver_test.js
@@ -6,22 +6,22 @@ import EC2RegionResolver from '../src/ec2regionresolver.js';
 import { LEVELS } from '@taskcluster/lib-monitor';
 
 const __dirname = new URL('.', import.meta.url).pathname;
-suite(testing.suiteName(), function() {
+suite(testing.suiteName(), () => {
   helper.withAmazonIPRanges(false, () => false);
 
   let monitor;
-  setup(async function() {
+  setup(async () => {
     monitor = await helper.load('monitor');
   });
 
   const reqWithIp = ip => ({ headers: { 'x-client-ip': ip } });
 
-  test('newly-constructed state returns null', function() {
+  test('newly-constructed state returns null', () => {
     const res = new EC2RegionResolver(['us-west-1'], monitor);
     assert.equal(res.getRegion(reqWithIp('1.2.3.4')), null);
   });
 
-  test('loading ip ranges results in lookups for named regions', async function() {
+  test('loading ip ranges results in lookups for named regions', async () => {
     const res = new EC2RegionResolver(['us-west-1', 'us-west-2'], monitor);
     res.start();
     try {
@@ -34,7 +34,7 @@ suite(testing.suiteName(), function() {
     }
   });
 
-  test('when loading ip ranges fails, it is retried', async function() {
+  test('when loading ip ranges fails, it is retried', async () => {
     nock.cleanAll();
 
     // fail once, then succeed

--- a/services/queue/test/expireartifacts_test.js
+++ b/services/queue/test/expireartifacts_test.js
@@ -7,7 +7,7 @@ import helper from './helper.js';
 import testing from '@taskcluster/lib-testing';
 import { ListObjectsCommand, PutObjectCommand } from '@aws-sdk/client-s3';
 
-helper.secrets.mockSuite(testing.suiteName(), ['aws'], function (mock, skipping) {
+helper.secrets.mockSuite(testing.suiteName(), ['aws'], (mock, skipping) => {
   helper.withDb(mock, skipping);
   helper.withAmazonIPRanges(mock, skipping);
   helper.withPulse(mock, skipping);
@@ -196,7 +196,7 @@ helper.secrets.mockSuite(testing.suiteName(), ['aws'], function (mock, skipping)
 });
 
 // GCS specific mock
-helper.secrets.mockSuite(testing.suiteName(), ['aws'], function (mock, skipping) {
+helper.secrets.mockSuite(testing.suiteName(), ['aws'], (mock, skipping) => {
   if (!mock) {
     // see https://github.com/taskcluster/taskcluster/issues/6416 for details
     // at the moment real tests are done against AWS S3 and those patches would make no sense
@@ -214,7 +214,7 @@ helper.secrets.mockSuite(testing.suiteName(), ['aws'], function (mock, skipping)
   const MAX_ARTIFACTS = 5;
 
   let monitor;
-  suiteSetup(async function () {
+  suiteSetup(async () => {
     monitor = await helper.load('monitor');
   });
 

--- a/services/queue/test/expirequeues_test.js
+++ b/services/queue/test/expirequeues_test.js
@@ -1,7 +1,7 @@
 import helper from './helper.js';
 import testing from '@taskcluster/lib-testing';
 
-helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
+helper.secrets.mockSuite(testing.suiteName(), [], (mock, skipping) => {
   helper.withDb(mock, skipping);
 
   // test functionality elsewhere, here we just test that it can actually run

--- a/services/queue/test/expiretask_test.js
+++ b/services/queue/test/expiretask_test.js
@@ -6,7 +6,7 @@ import assume from 'assume';
 import helper from './helper.js';
 import testing from '@taskcluster/lib-testing';
 
-helper.secrets.mockSuite(testing.suiteName(), ['aws'], function(mock, skipping) {
+helper.secrets.mockSuite(testing.suiteName(), ['aws'], (mock, skipping) => {
   helper.withDb(mock, skipping);
   helper.withAmazonIPRanges(mock, skipping);
   helper.withPulse(mock, skipping);

--- a/services/queue/test/gettask_test.js
+++ b/services/queue/test/gettask_test.js
@@ -5,7 +5,7 @@ import assume from 'assume';
 import helper from './helper.js';
 import testing from '@taskcluster/lib-testing';
 
-helper.secrets.mockSuite(testing.suiteName(), ['aws'], function (mock, skipping) {
+helper.secrets.mockSuite(testing.suiteName(), ['aws'], (mock, skipping) => {
   helper.withDb(mock, skipping);
   helper.withAmazonIPRanges(mock, skipping);
   helper.withPulse(mock, skipping);
@@ -62,7 +62,7 @@ helper.secrets.mockSuite(testing.suiteName(), ['aws'], function (mock, skipping)
     return { taskId: slugid.v4(), task };
   };
 
-  setup(async function () {
+  setup(async () => {
     taskId = slugid.v4();
     await helper.queue.createTask(taskId, taskDef);
   });

--- a/services/queue/test/helper.js
+++ b/services/queue/test/helper.js
@@ -24,7 +24,7 @@ const __dirname = new URL('.', import.meta.url).pathname;
 
 const helper = { load };
 
-suiteSetup(async function() {
+suiteSetup(async () => {
   load.inject('profile', 'test');
   load.inject('process', 'test');
 });
@@ -57,7 +57,7 @@ helper.rootUrl = 'http://localhost:60401';
  * Set up to use aws-sdk-client-mock for S3 operations when mocking.
  */
 export const withS3 = (mock, skipping) => {
-  suiteSetup('setup withS3', async function() {
+  suiteSetup('setup withS3', async () => {
     if (skipping()) {
       return;
     }
@@ -116,7 +116,7 @@ helper.withS3 = withS3;
  * - DeleteObjects not supported
  */
 export const withGCS = (mock, skipping) => {
-  suiteSetup('setup withGCS', async function() {
+  suiteSetup('setup withGCS', async () => {
     if (skipping()) {
       return;
     }
@@ -183,7 +183,7 @@ helper.withGCS = withGCS;
 export const withAmazonIPRanges = (mock, skipping) => {
   let interceptor;
 
-  suiteSetup(async function() {
+  suiteSetup(async () => {
     if (skipping()) {
       return;
     }
@@ -194,7 +194,7 @@ export const withAmazonIPRanges = (mock, skipping) => {
       .replyWithFile(200, __dirname + '/fake-ip-ranges.json', { 'Content-Type': 'application/json' });
   });
 
-  suiteTeardown(async function() {
+  suiteTeardown(async () => {
     if (interceptor) {
       nock.removeInterceptor(interceptor);
       interceptor = undefined;
@@ -213,7 +213,7 @@ helper.withDb = withDb;
  */
 export const withObjectService = (mock, skipping) => {
   let objects = new Map();
-  suiteSetup(async function() {
+  suiteSetup(async () => {
     const err404 = message => {
       const err = new Error(message);
       err.statusCode = 404;
@@ -266,7 +266,7 @@ export const withObjectService = (mock, skipping) => {
     load.inject('objectService', helper.objectService);
   });
 
-  setup(function() {
+  setup(() => {
     objects = new Map();
   });
 };
@@ -282,7 +282,7 @@ helper.withObjectService = withObjectService;
 export const withServer = (mock, skipping) => {
   let webServer;
 
-  suiteSetup(async function() {
+  suiteSetup(async () => {
     if (skipping()) {
       return;
     }
@@ -326,7 +326,7 @@ export const withServer = (mock, skipping) => {
     webServer = await helper.load('server');
   });
 
-  setup(async function() {
+  setup(async () => {
     if (skipping()) {
       return;
     }
@@ -334,7 +334,7 @@ export const withServer = (mock, skipping) => {
     helper.scopes();
   });
 
-  suiteTeardown(async function() {
+  suiteTeardown(async () => {
     if (skipping()) {
       return;
     }
@@ -361,7 +361,7 @@ helper.withPulse = withPulse;
 export const withPollingServices = (mock, skipping) => {
   let svc;
 
-  suiteSetup(async function() {
+  suiteSetup(async () => {
     if (skipping()) {
       return;
     }
@@ -383,13 +383,13 @@ export const withPollingServices = (mock, skipping) => {
     };
   });
 
-  teardown(async function() {
+  teardown(async () => {
     if (svc) {
       throw new Error('Must call stopPollingService if you have started a service');
     }
   });
 
-  suiteTeardown(function() {
+  suiteTeardown(() => {
     helper.startPollingService = null;
   });
 };
@@ -439,7 +439,7 @@ export const checkDates = ({ status }) => {
 helper.checkDates = checkDates;
 
 export const resetTables = (mock, skipping) => {
-  setup('reset tables', async function() {
+  setup('reset tables', async () => {
     await testing.resetTables({ tableNames: [
       'tasks',
       'task_groups',

--- a/services/queue/test/hintpoller_test.js
+++ b/services/queue/test/hintpoller_test.js
@@ -3,7 +3,7 @@ import HintPoller from '../src/hintpoller.js';
 import helper from './helper.js';
 import testing from '@taskcluster/lib-testing';
 
-helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
+helper.secrets.mockSuite(testing.suiteName(), [], (mock, skipping) => {
   test('calls pollPendingQueue', async () => {
     const monitor = await helper.load('monitor');
 

--- a/services/queue/test/priority_test.js
+++ b/services/queue/test/priority_test.js
@@ -4,7 +4,7 @@ import taskcluster from '@taskcluster/client';
 import helper from './helper.js';
 import testing from '@taskcluster/lib-testing';
 
-helper.secrets.mockSuite(testing.suiteName(), ['aws'], function(mock, skipping) {
+helper.secrets.mockSuite(testing.suiteName(), ['aws'], (mock, skipping) => {
   helper.withDb(mock, skipping);
   helper.withAmazonIPRanges(mock, skipping);
   helper.withPulse(mock, skipping);

--- a/services/queue/test/querytasks_test.js
+++ b/services/queue/test/querytasks_test.js
@@ -7,7 +7,7 @@ import assume from 'assume';
 import helper from './helper.js';
 import testing from '@taskcluster/lib-testing';
 
-helper.secrets.mockSuite(testing.suiteName(), ['aws'], function (mock, skipping) {
+helper.secrets.mockSuite(testing.suiteName(), ['aws'], (mock, skipping) => {
   helper.withDb(mock, skipping);
   helper.withAmazonIPRanges(mock, skipping);
   helper.withPulse(mock, skipping);

--- a/services/queue/test/queueservice_test.js
+++ b/services/queue/test/queueservice_test.js
@@ -7,7 +7,7 @@ const debug = debugFactory('test:queueservice');
 import testing from '@taskcluster/lib-testing';
 import helper from './helper.js';
 
-helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
+helper.secrets.mockSuite(testing.suiteName(), [], (mock, skipping) => {
   helper.withDb(mock, skipping);
   let queueService;
 
@@ -42,7 +42,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
     }
   });
 
-  suiteTeardown(function() {
+  suiteTeardown(() => {
     if (skipping()) {
       return;
     }

--- a/services/queue/test/reruntask_test.js
+++ b/services/queue/test/reruntask_test.js
@@ -6,7 +6,7 @@ import taskcluster from '@taskcluster/client';
 import helper from './helper.js';
 import testing from '@taskcluster/lib-testing';
 
-helper.secrets.mockSuite(testing.suiteName(), ['aws'], function(mock, skipping) {
+helper.secrets.mockSuite(testing.suiteName(), ['aws'], (mock, skipping) => {
   helper.withDb(mock, skipping);
   helper.withAmazonIPRanges(mock, skipping);
   helper.withPulse(mock, skipping);

--- a/services/queue/test/resolvetask_test.js
+++ b/services/queue/test/resolvetask_test.js
@@ -9,7 +9,7 @@ import helper from './helper.js';
 import testing from '@taskcluster/lib-testing';
 import { LEVELS } from '@taskcluster/lib-monitor';
 
-helper.secrets.mockSuite(testing.suiteName(), ['aws'], function(mock, skipping) {
+helper.secrets.mockSuite(testing.suiteName(), ['aws'], (mock, skipping) => {
   helper.withDb(mock, skipping);
   helper.withAmazonIPRanges(mock, skipping);
   helper.withPulse(mock, skipping);
@@ -40,7 +40,7 @@ helper.secrets.mockSuite(testing.suiteName(), ['aws'], function(mock, skipping) 
   };
 
   let monitor;
-  suiteSetup(async function() {
+  suiteSetup(async () => {
     monitor = await helper.load('monitor');
   });
 
@@ -425,9 +425,9 @@ helper.secrets.mockSuite(testing.suiteName(), ['aws'], function(mock, skipping) 
     helper.scopes(
       'assume:worker-id:my-worker-group-extended-extended/my-worker-extended-extended',
     );
-    await helper.queue.reportCompleted(taskId, 0).then(function() {
+    await helper.queue.reportCompleted(taskId, 0).then(() => {
       throw new Error('Expected authentication error');
-    }, function(err) {
+    }, (err) => {
       if (err.code !== 'InsufficientScopes') {
         throw err;
       }
@@ -498,7 +498,7 @@ helper.secrets.mockSuite(testing.suiteName(), ['aws'], function(mock, skipping) 
       m.payload.status.runs.length === 2));
   });
 
-  test('regression: pulse taskPending failure during reportException retry does not orphan the retry run', async function() {
+  test('regression: pulse taskPending failure during reportException retry does not orphan the retry run', async () => {
     const taskId = slugid.v4();
 
     debug('### Creating task');

--- a/services/queue/test/retry_test.js
+++ b/services/queue/test/retry_test.js
@@ -6,7 +6,7 @@ import assume from 'assume';
 import helper from './helper.js';
 import testing from '@taskcluster/lib-testing';
 
-helper.secrets.mockSuite(testing.suiteName(), ['aws'], function(mock, skipping) {
+helper.secrets.mockSuite(testing.suiteName(), ['aws'], (mock, skipping) => {
   helper.withDb(mock, skipping);
   helper.withAmazonIPRanges(mock, skipping);
   helper.withPulse(mock, skipping);

--- a/services/queue/test/scheduletask_test.js
+++ b/services/queue/test/scheduletask_test.js
@@ -6,7 +6,7 @@ import taskcluster from '@taskcluster/client';
 import helper from './helper.js';
 import testing from '@taskcluster/lib-testing';
 
-helper.secrets.mockSuite(testing.suiteName(), ['aws'], function(mock, skipping) {
+helper.secrets.mockSuite(testing.suiteName(), ['aws'], (mock, skipping) => {
   helper.withDb(mock, skipping);
   helper.withAmazonIPRanges(mock, skipping);
   helper.withPulse(mock, skipping);

--- a/services/queue/test/taskgroup_test.js
+++ b/services/queue/test/taskgroup_test.js
@@ -8,7 +8,7 @@ import assume from 'assume';
 import helper from './helper.js';
 import testing from '@taskcluster/lib-testing';
 
-helper.secrets.mockSuite(testing.suiteName(), ['aws'], function(mock, skipping) {
+helper.secrets.mockSuite(testing.suiteName(), ['aws'], (mock, skipping) => {
   helper.withDb(mock, skipping);
   helper.withAmazonIPRanges(mock, skipping);
   helper.withPollingServices(mock, skipping);
@@ -237,7 +237,7 @@ helper.secrets.mockSuite(testing.suiteName(), ['aws'], function(mock, skipping) 
     });
   });
 
-  suite('get task group', function () {
+  suite('get task group', () => {
     test('get task-group -- doesn\'t exist', async () => {
       let taskGroupId = slugid.v4();
       await helper.queue.getTaskGroup(taskGroupId).then(
@@ -283,7 +283,7 @@ helper.secrets.mockSuite(testing.suiteName(), ['aws'], function(mock, skipping) 
     });
   });
 
-  suite('task group sealing', function () {
+  suite('task group sealing', () => {
     test('sealing empty task group', async () => {
       let taskGroupId = slugid.v4();
       await helper.queue.sealTaskGroup(taskGroupId).then(() => {

--- a/services/queue/test/workclaimer_test.js
+++ b/services/queue/test/workclaimer_test.js
@@ -5,7 +5,7 @@ import testing from '@taskcluster/lib-testing';
 import taskcluster from '@taskcluster/client';
 import WorkClaimer from '../src/workclaimer.js';
 
-helper.secrets.mockSuite(testing.suiteName(), ['aws'], function (mock, skipping) {
+helper.secrets.mockSuite(testing.suiteName(), ['aws'], (mock, skipping) => {
   helper.withDb(mock, skipping);
   helper.withPulse(mock, skipping);
   helper.withS3(mock, skipping);

--- a/services/queue/test/workerinfo_test.js
+++ b/services/queue/test/workerinfo_test.js
@@ -6,7 +6,7 @@ import testing from '@taskcluster/lib-testing';
 import { Worker, TaskQueue } from '../src/data.js';
 import { splitTaskQueueId } from '../src/utils.js';
 
-helper.secrets.mockSuite(testing.suiteName(), ['aws'], function(mock, skipping) {
+helper.secrets.mockSuite(testing.suiteName(), ['aws'], (mock, skipping) => {
   helper.withDb(mock, skipping);
   helper.withAmazonIPRanges(mock, skipping);
   helper.withPulse(mock, skipping);
@@ -63,7 +63,7 @@ helper.secrets.mockSuite(testing.suiteName(), ['aws'], function(mock, skipping) 
   };
 
   let workerInfo;
-  suiteSetup('load workerInfo', async function() {
+  suiteSetup('load workerInfo', async () => {
     if (skipping()) {
       return;
     }

--- a/services/queue/test/workerremovedresolver_test.js
+++ b/services/queue/test/workerremovedresolver_test.js
@@ -5,7 +5,7 @@ import helper from './helper.js';
 import testing from '@taskcluster/lib-testing';
 import { LEVELS } from '@taskcluster/lib-monitor';
 
-helper.secrets.mockSuite(testing.suiteName(), ['aws'], function(mock, skipping) {
+helper.secrets.mockSuite(testing.suiteName(), ['aws'], (mock, skipping) => {
   helper.withDb(mock, skipping);
   helper.withAmazonIPRanges(mock, skipping);
   helper.withPulse(mock, skipping);
@@ -33,7 +33,7 @@ helper.secrets.mockSuite(testing.suiteName(), ['aws'], function(mock, skipping) 
   };
 
   let monitor;
-  suiteSetup(async function() {
+  suiteSetup(async () => {
     monitor = await helper.load('monitor');
   });
 

--- a/services/secrets/src/api.js
+++ b/services/secrets/src/api.js
@@ -191,7 +191,7 @@ builder.declare({
     'This endpoint is used to check on backing services this service',
     'depends on.',
   ].join('\n'),
-}, function(_req, res) {
+}, (_req, res) => {
   // TODO: add implementation
   res.reply({});
 });

--- a/services/secrets/test/api_test.js
+++ b/services/secrets/test/api_test.js
@@ -4,7 +4,7 @@ import slugid from 'slugid';
 import taskcluster from '@taskcluster/client';
 import testing from '@taskcluster/lib-testing';
 
-helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
+helper.secrets.mockSuite(testing.suiteName(), [], (mock, skipping) => {
   helper.withDb(mock, skipping);
   helper.withServer(mock, skipping);
 
@@ -62,7 +62,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
     });
   };
 
-  test('set allowed key (twice)', async function() {
+  test('set allowed key (twice)', async () => {
     await makeApiCall({
       clientName: 'captain-write',
       apiCall: 'set',
@@ -81,7 +81,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
     });
   });
 
-  test('set disallowed key', async function() {
+  test('set disallowed key', async () => {
     await makeApiCall({
       clientName: 'captain-write',
       apiCall: 'set',
@@ -91,7 +91,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
     });
   });
 
-  test('get with only "set" scope fails to read', async function() {
+  test('get with only "set" scope fails to read', async () => {
     const client = await helper.client('captain-write');
     await client.set(SECRET_NAME, testValueFoo);
     await makeApiCall({
@@ -102,7 +102,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
     });
   });
 
-  test('get with read-only scopes reads the secret', async function() {
+  test('get with read-only scopes reads the secret', async () => {
     const client = await helper.client('captain-write');
     await client.set(SECRET_NAME, testValueFoo);
     await makeApiCall({
@@ -113,7 +113,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
     });
   });
 
-  test('get with read-only scopes reads an updated secret after set', async function() {
+  test('get with read-only scopes reads an updated secret after set', async () => {
     const client = await helper.client('captain-write');
     await client.set(SECRET_NAME, testValueFoo);
     await client.set(SECRET_NAME, testValueBar);
@@ -125,7 +125,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
     });
   });
 
-  test('remove with read-only scopes fails', async function() {
+  test('remove with read-only scopes fails', async () => {
     const client = await helper.client('captain-write');
     await client.set(SECRET_NAME, testValueBar);
     await makeApiCall({
@@ -136,7 +136,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
     });
   });
 
-  test('remove with write-only scopes succeeds', async function() {
+  test('remove with write-only scopes succeeds', async () => {
     const client = await helper.client('captain-write');
     await client.set(SECRET_NAME, testValueBar);
     await makeApiCall({
@@ -149,7 +149,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
     assert.equal(result, undefined);
   });
 
-  test('getting a missing secret is a 404', async function() {
+  test('getting a missing secret is a 404', async () => {
     await makeApiCall({
       clientName: 'captain-read',
       apiCall: 'get',
@@ -159,16 +159,14 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
     });
   });
 
-  test('deleting a missing secret "succeeds"', function() {
-    return makeApiCall({
-      clientName: 'captain-write',
-      apiCall: 'remove',
-      name: SECRET_NAME,
-      res: {},
-    });
-  });
+  test('deleting a missing secret "succeeds"', () => makeApiCall({
+    clientName: 'captain-write',
+    apiCall: 'remove',
+    name: SECRET_NAME,
+    res: {},
+  }));
 
-  test('reading an expired secret is a 410', async function() {
+  test('reading an expired secret is a 410', async () => {
     const client = await helper.client('captain-write');
     await client.set(SECRET_NAME, testValueExpired);
     await makeApiCall({

--- a/services/secrets/test/helper.js
+++ b/services/secrets/test/helper.js
@@ -8,7 +8,7 @@ export const load = testing.stickyLoader(loadMain);
 const helper = { load };
 export default helper;
 
-suiteSetup(async function() {
+suiteSetup(async () => {
   load.inject('profile', 'test');
   load.inject('process', 'test');
 });
@@ -47,7 +47,7 @@ let testClients = {
 helper.withServer = (mock, skipping) => {
   let webServer;
 
-  suiteSetup(async function() {
+  suiteSetup(async () => {
     if (skipping()) {
       return;
     }
@@ -73,7 +73,7 @@ helper.withServer = (mock, skipping) => {
     webServer = await load('server');
   });
 
-  suiteTeardown(async function() {
+  suiteTeardown(async () => {
     if (skipping()) {
       return;
     }

--- a/services/web-server/src/api.js
+++ b/services/web-server/src/api.js
@@ -192,7 +192,7 @@ builder.declare({
     'This endpoint is used to check on backing services this service',
     'depends on.',
   ].join('\n'),
-}, function(_req, res) {
+}, (_req, res) => {
   // TODO: add implementation
   res.reply({});
 });

--- a/services/web-server/src/utils/verifyJwtAuth0/index.js
+++ b/services/web-server/src/utils/verifyJwtAuth0/index.js
@@ -24,7 +24,7 @@ export default async ({ token, domain, audience }) => new Promise((resolve, reje
       issuer: `https://${domain}/`,
       algorithms: ['RS256'],
     },
-    function(err, decoded) {
+    (err, decoded) => {
       if (err) {
         reject(err);
       } else {

--- a/services/web-server/test/auth_test.js
+++ b/services/web-server/test/auth_test.js
@@ -3,12 +3,12 @@ import request from 'superagent';
 import helper from './helper.js';
 import testing from '@taskcluster/lib-testing';
 
-helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
+helper.secrets.mockSuite(testing.suiteName(), [], (mock, skipping) => {
   helper.withDb(mock, skipping);
   helper.withServer(mock, skipping);
   helper.resetTables(mock, skipping);
 
-  test('Unauthorized', async function() {
+  test('Unauthorized', async () => {
     const credentialsQuery = await helper.loadFixture('credentials.graphql');
     const res = await request
       .post(`http://localhost:${helper.serverPort}/graphql`)

--- a/services/web-server/test/graphql/artifacts_graphql_test.js
+++ b/services/web-server/test/graphql/artifacts_graphql_test.js
@@ -3,15 +3,15 @@ import gql from 'graphql-tag';
 import testing from '@taskcluster/lib-testing';
 import helper from '../helper.js';
 
-helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
+helper.secrets.mockSuite(testing.suiteName(), [], (mock, skipping) => {
   helper.withFakeAuthFactory(mock, skipping);
   helper.withDb(mock, skipping);
   helper.withClients(mock, skipping);
   helper.withServer(mock, skipping);
   helper.resetTables(mock, skipping);
 
-  suite('Artifact Queries GraphQL', function() {
-    test('artifacts query works', async function() {
+  suite('Artifact Queries GraphQL', () => {
+    test('artifacts query works', async () => {
       const client = helper.getHttpClient();
       const taskId = "artifact-id";
       const runId = 123456;
@@ -30,7 +30,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       assert.equal(response.data.artifacts.edges[0].node.name.includes('artifact-'), true);
     });
 
-    test('latest artifacts query works', async function() {
+    test('latest artifacts query works', async () => {
       const client = helper.getHttpClient();
       const taskId = "artifact-id";
       const getLatestArtifacts = await helper.loadFixture('latestArtifacts.graphql');
@@ -48,10 +48,10 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
     });
   });
 
-  suite('Artifact Subscriptions', function() {
+  suite('Artifact Subscriptions', () => {
     helper.withMockedEventIterator();
 
-    test('subscribe works', async function() {
+    test('subscribe works', async () => {
       let subscriptionClient = await helper.createSubscriptionClient();
       const client = helper.getWebsocketClient(subscriptionClient);
       const artifactsCreated = await helper.loadFixture('artifactsCreated.graphql');

--- a/services/web-server/test/graphql/hooks_test.js
+++ b/services/web-server/test/graphql/hooks_test.js
@@ -3,14 +3,14 @@ import gql from 'graphql-tag';
 import testing from '@taskcluster/lib-testing';
 import helper from '../helper.js';
 
-helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
+helper.secrets.mockSuite(testing.suiteName(), [], (mock, skipping) => {
   helper.withDb(mock, skipping);
   helper.withClients(mock, skipping);
   helper.withServer(mock, skipping);
   helper.resetTables(mock, skipping);
 
-  suite('Hooks GraphQL', function() {
-    test('hooks query works', async function() {
+  suite('Hooks GraphQL', () => {
+    test('hooks query works', async () => {
       const client = helper.getHttpClient();
       const hookGroupId = 'hook-group';
       const hookId = 'hook';

--- a/services/web-server/test/graphql/roles_test.js
+++ b/services/web-server/test/graphql/roles_test.js
@@ -4,14 +4,14 @@ import gql from 'graphql-tag';
 import testing from '@taskcluster/lib-testing';
 import helper from '../helper.js';
 
-helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
+helper.secrets.mockSuite(testing.suiteName(), [], (mock, skipping) => {
   helper.withDb(mock, skipping);
   helper.withClients(mock, skipping);
   helper.withServer(mock, skipping);
   helper.resetTables(mock, skipping);
 
-  suite('Roles GraphQL', function() {
-    test('role query works', async function() {
+  suite('Roles GraphQL', () => {
+    test('role query works', async () => {
       const client = helper.getHttpClient();
       const roleId = taskcluster.slugid();
       const role = {
@@ -42,7 +42,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       assert.equal(response.data.role.roleId, roleId);
     });
 
-    test('roles query works', async function() {
+    test('roles query works', async () => {
       const client = helper.getHttpClient();
       const roleId = taskcluster.slugid();
       const role = {
@@ -71,7 +71,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       assert.equal(response.data.roles[0].roleId, roleId);
     });
 
-    test('list role ids query works', async function() {
+    test('list role ids query works', async () => {
       const client = helper.getHttpClient();
       const roleId = taskcluster.slugid();
       const role = {
@@ -99,7 +99,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       assert.equal(response.data.listRoleIds.edges[0].node.roleId, roleId);
     });
 
-    test('create role mutation works', async function() {
+    test('create role mutation works', async () => {
       const client = helper.getHttpClient();
       const roleId = taskcluster.slugid();
       const role = {
@@ -120,7 +120,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       assert.equal(response.data.createRole.roleId, roleId);
     });
 
-    test('update role mutation works', async function() {
+    test('update role mutation works', async () => {
       const client = helper.getHttpClient();
       const roleId = taskcluster.slugid();
       const role = {
@@ -163,7 +163,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       assert.equal(response.data.role.scopes[0], role.scopes[0]);
     });
 
-    test('delete role mutation works', async function() {
+    test('delete role mutation works', async () => {
       const client = helper.getHttpClient();
       const roleId = taskcluster.slugid();
       const role = {

--- a/services/web-server/test/graphql/tasks_graphql_test.js
+++ b/services/web-server/test/graphql/tasks_graphql_test.js
@@ -6,11 +6,11 @@ import helper from '../helper.js';
 import WebSocket from 'ws';
 import { SubscriptionClient } from 'subscriptions-transport-ws';
 
-helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
+helper.secrets.mockSuite(testing.suiteName(), [], (mock, skipping) => {
   // Use mutable scopeOverride to allow tests to dynamically change auth scopes
   let scopeOverride = null;
 
-  suiteSetup('withMutableAuthFactory', function() {
+  suiteSetup('withMutableAuthFactory', () => {
     if (skipping()) {
       return;
     }
@@ -26,7 +26,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
     );
   });
 
-  suiteTeardown(function() {
+  suiteTeardown(() => {
     helper.load.remove('authFactory');
   });
 
@@ -36,8 +36,8 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
   helper.withPulse(helper, skipping);
   helper.resetTables(mock, skipping);
 
-  suite('Task Queries and Mutations', function() {
-    test('query works', async function() {
+  suite('Task Queries and Mutations', () => {
+    test('query works', async () => {
       const client = helper.getHttpClient();
       const taskId = taskcluster.slugid();
       const createTaskQuery = await helper.loadFixture('createTask.graphql');
@@ -63,7 +63,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       assert.equal(response.data.task.taskId, taskId);
     });
 
-    test('mutation works', async function() {
+    test('mutation works', async () => {
       const client = helper.getHttpClient();
       const taskId = taskcluster.slugid();
       const createTaskQuery = await helper.loadFixture('createTask.graphql');
@@ -80,10 +80,10 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
     });
   });
 
-  suite('Task Subscriptions', function() {
+  suite('Task Subscriptions', () => {
     helper.withMockedEventIterator();
 
-    test('subscribe works', async function() {
+    test('subscribe works', async () => {
       let subscriptionClient = await helper.createSubscriptionClient();
       const client = helper.getWebsocketClient(subscriptionClient);
 
@@ -130,7 +130,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       subscriptionClient.close();
     });
 
-    test('connection rejected without web:read-pulse scope', async function() {
+    test('connection rejected without web:read-pulse scope', async () => {
       scopeOverride = [];
       let subscriptionClient;
       try {

--- a/services/web-server/test/graphql/validation_test.js
+++ b/services/web-server/test/graphql/validation_test.js
@@ -3,14 +3,14 @@ import gql from 'graphql-tag';
 import testing from '@taskcluster/lib-testing';
 import helper from '../helper.js';
 
-helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
+helper.secrets.mockSuite(testing.suiteName(), [], (mock, skipping) => {
   helper.withDb(mock, skipping);
   helper.withClients(mock, skipping);
   helper.withServer(mock, skipping);
   helper.resetTables(mock, skipping);
 
-  suite('GraphQL Validation', function() {
-    test('max tokens in request', async function() {
+  suite('GraphQL Validation', () => {
+    test('max tokens in request', async () => {
       const client = helper.getHttpClient({ suppressErrors: true });
 
       try {
@@ -28,7 +28,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
 
       helper.expectMonitorError('PayloadTooLargeError');
     });
-    test('max queries in request', async function() {
+    test('max queries in request', async () => {
       const client = helper.getHttpClient({ suppressErrors: true });
 
       try {
@@ -44,7 +44,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
         assert.ok(/validation errors/.test(JSON.stringify(err.networkError.result)));
       }
     });
-    test('max depth in request', async function() {
+    test('max depth in request', async () => {
       const client = helper.getHttpClient({ suppressErrors: true });
 
       try {
@@ -60,7 +60,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
         assert.ok(/exceeds maximum operation depth/.test(JSON.stringify(err.networkError.result)));
       }
     });
-    test('circular fragments return a validation error', async function() {
+    test('circular fragments return a validation error', async () => {
       const client = helper.getHttpClient({ suppressErrors: true });
 
       try {

--- a/services/web-server/test/graphql/workermanager_test.js
+++ b/services/web-server/test/graphql/workermanager_test.js
@@ -3,14 +3,14 @@ import gql from 'graphql-tag';
 import testing from '@taskcluster/lib-testing';
 import helper from '../helper.js';
 
-helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
+helper.secrets.mockSuite(testing.suiteName(), [], (mock, skipping) => {
   helper.withDb(mock, skipping);
   helper.withClients(mock, skipping);
   helper.withServer(mock, skipping);
   helper.resetTables(mock, skipping);
 
-  suite('WorkerPools', function() {
-    test('deleting a worker pool calls deleteWorkerPool', async function() {
+  suite('WorkerPools', () => {
+    test('deleting a worker pool calls deleteWorkerPool', async () => {
       const workerPoolId = 'ww/pp';
       helper.fakes.makeWorkerPool(workerPoolId, {});
 
@@ -29,7 +29,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
     });
   });
 
-  test('get single workerpool', async function() {
+  test('get single workerpool', async () => {
     helper.fakes.makeWorkerPool('baz/bing', { owner: 'foo@example.com', currentCapacity: 4, requestedCount: 0, runningCount: 1, stoppingCount: 0, stoppedCount: 0, requestedCapacity: 0, runningCapacity: 1, stoppingCapacity: 0, stoppedCapacity: 0 });
     const client = helper.getHttpClient();
     const workerPoolQuery = await helper.loadFixture('workerPool.graphql');
@@ -53,7 +53,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
     assert.equal(single.data.WorkerPool.stoppedCapacity, 0);
   });
 
-  test('list workerpools', async function() {
+  test('list workerpools', async () => {
     helper.fakes.makeWorkerPool('foo/bar', { providerId: 'baz', currentCapacity: 0, requestedCount: 0, runningCount: 0, stoppingCount: 0, stoppedCount: 0, requestedCapacity: 0, runningCapacity: 0, stoppingCapacity: 0, stoppedCapacity: 0 });
     helper.fakes.makeWorkerPool('baz/bing', { providerId: 'wow', currentCapacity: 2, requestedCount: 1, runningCount: 0, stoppingCount: 1, stoppedCount: 0, requestedCapacity: 1, runningCapacity: 0, stoppingCapacity: 1, stoppedCapacity: 0 });
     const client = helper.getHttpClient();

--- a/services/web-server/test/helper.js
+++ b/services/web-server/test/helper.js
@@ -20,7 +20,7 @@ const helper = {};
 export default helper;
 helper.load = stickyLoader(load);
 
-suiteSetup(async function() {
+suiteSetup(async () => {
   helper.load.inject('profile', 'test');
   helper.load.inject('process', 'test');
 });
@@ -80,7 +80,7 @@ helper.withMockedEventIterator = () => {
 };
 
 helper.withFakeAuth = (mock, skipping) => {
-  suiteSetup('withFakeAuth', function() {
+  suiteSetup('withFakeAuth', () => {
     if (skipping()) {
       return;
     }
@@ -90,7 +90,7 @@ helper.withFakeAuth = (mock, skipping) => {
 };
 
 helper.withFakeAuthFactory = (mock, skipping) => {
-  suiteSetup('withFakeAuthFactory', function() {
+  suiteSetup('withFakeAuthFactory', () => {
     if (skipping()) {
       return;
     }
@@ -98,13 +98,13 @@ helper.withFakeAuthFactory = (mock, skipping) => {
     helper.load.inject('authFactory', stubbedAuthFactory());
   });
 
-  suiteTeardown(function() {
+  suiteTeardown(() => {
     helper.load.remove('authFactory');
   });
 };
 
 helper.withClients = (mock, skipping) => {
-  suiteSetup('withClients', async function() {
+  suiteSetup('withClients', async () => {
     if (skipping()) {
       return;
     }
@@ -115,7 +115,7 @@ helper.withClients = (mock, skipping) => {
     helper.clients = clients;
   });
 
-  suiteTeardown(function () {
+  suiteTeardown(() => {
     helper.load.remove('clients');
   });
 };
@@ -130,7 +130,7 @@ helper.withServer = (mock, skipping) => {
     return agent;
   };
 
-  suiteSetup('withServer', async function() {
+  suiteSetup('withServer', async () => {
     if (skipping()) {
       return;
     }
@@ -139,7 +139,7 @@ helper.withServer = (mock, skipping) => {
     webServer = await helper.load('httpServer');
     await new Promise((resolve, reject) => {
       webServer.once('error', reject);
-      webServer.listen(cfg.server.port, function() {
+      webServer.listen(cfg.server.port, () => {
         resolve();
       });
     });
@@ -150,7 +150,7 @@ helper.withServer = (mock, skipping) => {
     helper.load.cfg('app.publicUrl', `http://127.0.0.1:${helper.serverPort}`);
   });
 
-  suiteTeardown(async function() {
+  suiteTeardown(async () => {
     if (skipping()) {
       return;
     }
@@ -340,7 +340,7 @@ helper.createSubscriptionClient = async () => {
     accessToken: 'testing',
   };
 
-  return new Promise(function(resolve, reject) {
+  return new Promise((resolve, reject) => {
     const subscriptionClient = new SubscriptionClient(
       `ws://localhost:${helper.serverPort}/subscription`,
       {
@@ -353,10 +353,10 @@ helper.createSubscriptionClient = async () => {
       },
       WebSocket,
     );
-    subscriptionClient.onConnected(function() {
+    subscriptionClient.onConnected(() => {
       resolve(subscriptionClient);
     });
-    subscriptionClient.onError(function(err) {
+    subscriptionClient.onError((err) => {
       reject(err);
     });
   });
@@ -607,7 +607,7 @@ const stubbedClients = () => {
 };
 
 helper.resetTables = (mock, skipping) => {
-  setup('reset tables', async function() {
+  setup('reset tables', async () => {
     await resetTables({ tableNames: [
       'authorization_codes',
       'access_tokens',

--- a/services/web-server/test/loaders/roles_loader_test.js
+++ b/services/web-server/test/loaders/roles_loader_test.js
@@ -5,14 +5,14 @@ import testing from '@taskcluster/lib-testing';
 import helper from '../helper.js';
 import loader from '../../src/loaders/roles.js';
 
-helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
+helper.secrets.mockSuite(testing.suiteName(), [], (mock, skipping) => {
   helper.withDb(mock, skipping);
   helper.withClients(mock, skipping);
   helper.withServer(mock, skipping);
   helper.resetTables(mock, skipping);
 
-  suite('roles loaders', function() {
-    test('load role while gracefully handling errors', async function() {
+  suite('roles loaders', () => {
+    test('load role while gracefully handling errors', async () => {
       const client = helper.getHttpClient();
       const roleId = taskcluster.slugid();
       const role = {
@@ -45,7 +45,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       assert(roleThatDoesNotExist.reason instanceof Error);
     });
 
-    test('load roles', async function() {
+    test('load roles', async () => {
       const client = helper.getHttpClient();
       const roleId = taskcluster.slugid();
       const role = {

--- a/services/web-server/test/loaders/tasks_loader_test.js
+++ b/services/web-server/test/loaders/tasks_loader_test.js
@@ -5,15 +5,15 @@ import testing from '@taskcluster/lib-testing';
 import helper from '../helper.js';
 import loader from '../../src/loaders/tasks.js';
 
-helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
+helper.secrets.mockSuite(testing.suiteName(), [], (mock, skipping) => {
   helper.withDb(mock, skipping);
   helper.withClients(mock, skipping);
   helper.withServer(mock, skipping);
   helper.resetTables(mock, skipping);
 
-  suite('tasks loaders', function() {
+  suite('tasks loaders', () => {
     // Make sure we still get tasks even if we end up loading some tasks that don't exist
-    test('load multiple tasks while gracefully handling errors', async function() {
+    test('load multiple tasks while gracefully handling errors', async () => {
       const client = helper.getHttpClient();
       const taskId = taskcluster.slugid();
 

--- a/services/web-server/test/login_scanner_test.js
+++ b/services/web-server/test/login_scanner_test.js
@@ -39,7 +39,7 @@ suite(testing.suiteName(), () => {
     clients[clientId] = { clientId, disabled, expandedScopes };
   };
 
-  setup(function() {
+  setup(() => {
     clients = {};
   });
 
@@ -63,7 +63,7 @@ suite(testing.suiteName(), () => {
 
   const strategies = { test: new TestStrategy({ name: 'test' }) };
 
-  test('test strategy with valid clients', async function() {
+  test('test strategy with valid clients', async () => {
     addClient('test/user1/', ['assume:also:user1']);
     addClient('test/user1/another', ['assume:is:user1']);
     addClient('test/user2/hi', ['assume:also:user2']);
@@ -75,7 +75,7 @@ suite(testing.suiteName(), () => {
     assert.equal(clients['test/user2/ho'].disabled, false);
   });
 
-  test('test strategy with some invalid clients', async function() {
+  test('test strategy with some invalid clients', async () => {
     addClient('test/user1/', ['assume:also:user1']);
     addClient('test/user1/another', ['assume:NOSUCH']);
     addClient('test/user2/hi', ['assume:also:user2']);
@@ -87,7 +87,7 @@ suite(testing.suiteName(), () => {
     assert.equal(clients['test/user2/ho'].disabled, true);
   });
 
-  test('test strategy with some clients that have no user', async function() {
+  test('test strategy with some clients that have no user', async () => {
     addClient('test/user1/x', ['assume:is:user1']);
     addClient('test/NOSUCH/hi', ['assume:NOSUCH']);
     await scan(auth, strategies);
@@ -95,7 +95,7 @@ suite(testing.suiteName(), () => {
     assert.equal(clients['test/NOSUCH/hi'].disabled, true);
   });
 
-  test('test strategy with valid but disabled client', async function() {
+  test('test strategy with valid but disabled client', async () => {
     addClient('test/user1/', ['assume:also:user1'], true);
     await scan(auth, strategies);
     assert.equal(clients['test/user1/'].disabled, true);

--- a/services/web-server/test/login_strategies_github_test.js
+++ b/services/web-server/test/login_strategies_github_test.js
@@ -3,7 +3,7 @@ import testing from '@taskcluster/lib-testing';
 import helper from './helper.js';
 import Github from '../src/login/strategies/github.js';
 
-helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
+helper.secrets.mockSuite(testing.suiteName(), [], (mock, skipping) => {
   helper.withDb(mock, skipping);
   helper.withGithubClient();
   helper.resetTables(mock, skipping);
@@ -40,7 +40,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       return strategy;
     };
 
-    test('userFromIdentity with matching ID', async function() {
+    test('userFromIdentity with matching ID', async () => {
       const userId = String(helper.githubFixtures.users.octocat);
       const strategy = getStrategy();
       await makeUser(userId);
@@ -49,7 +49,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       assert.equal(user.identity, `github/${userId}|octocat`);
     });
 
-    test('userFromIdentity with non-matching ID', async function() {
+    test('userFromIdentity with non-matching ID', async () => {
       const userId = String(helper.githubFixtures.users.octocat);
       const strategy = getStrategy();
       await makeUser(userId);
@@ -57,7 +57,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       assert(!user, "did not return undefined");
     });
 
-    test('userFromIdentity with encoded userId', async function() {
+    test('userFromIdentity with encoded userId', async () => {
       const userId = String(helper.githubFixtures.users['a/c']);
       const strategy = getStrategy();
       await makeUser(userId);
@@ -66,14 +66,14 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       assert.equal(user.identity, `github/${userId}|a!2Fc`);
     });
 
-    test('userFromIdentity with unknown user', async function() {
+    test('userFromIdentity with unknown user', async () => {
       const strategy = getStrategy();
       await makeUser('99');
       const user = await strategy.userFromIdentity('github/20|NOSUCH');
       assert(!user, "did not return undefined");
     });
 
-    test('userFromIdentity with GitHub failure', async function() {
+    test('userFromIdentity with GitHub failure', async () => {
       await assert.rejects(async () => {
         const strategy = getStrategy();
         await makeUser(String(20));
@@ -82,7 +82,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       }, /uhoh/);
     });
 
-    test('userFromIdentity roles with known user', async function() {
+    test('userFromIdentity roles with known user', async () => {
       const userId = String(helper.githubFixtures.users.taskcluster);
       const strategy = getStrategy();
       await makeUser(userId);
@@ -90,7 +90,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       assert.deepEqual(user.roles.sort(), ['github-team:neutrinojs/team-1', 'github-team:taskcluster/team-3', 'github-org-admin:taskcluster', 'github-org-admin:neutrinojs'].sort());
     });
 
-    test('userFromIdentity user with empty roles', async function() {
+    test('userFromIdentity user with empty roles', async () => {
       const userId = String(helper.githubFixtures.users['a/c']);
       const strategy = getStrategy();
       await makeUser(userId);
@@ -98,7 +98,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       assert.deepEqual(user.roles, []);
     });
 
-    test('userFromIdentity only has org roles in which they are admin', async function() {
+    test('userFromIdentity only has org roles in which they are admin', async () => {
       const userId = String(helper.githubFixtures.users.octocat);
       const strategy = getStrategy();
       await makeUser(userId);

--- a/services/web-server/test/login_strategies_mozilla_auth0_test.js
+++ b/services/web-server/test/login_strategies_mozilla_auth0_test.js
@@ -149,55 +149,55 @@ suite(testing.suiteName(), () => {
   });
 
   suite('userFromIdentity', () => {
-    test('LDAP and LDAP groups', async function () {
+    test('LDAP and LDAP groups', async () => {
       const user = await strategy.userFromIdentity('mozilla-auth0/ad|Mozilla-LDAP|tcperson');
       assert.equal(user.identity, 'mozilla-auth0/ad|Mozilla-LDAP|tcperson');
       assert.deepEqual(user.roles, ['mozilla-group:taskcluster']);
     });
 
-    test('LDAP and HRIS groups', async function () {
+    test('LDAP and HRIS groups', async () => {
       const user = await strategy.userFromIdentity('mozilla-auth0/ad|Mozilla-LDAP|torperson');
       assert.equal(user.identity, 'mozilla-auth0/ad|Mozilla-LDAP|torperson');
       assert.deepEqual(user.roles, ['mozilla-hris:office-tor']);
     });
 
-    test('LDAP and Mozillians groups', async function () {
+    test('LDAP and Mozillians groups', async () => {
       const user = await strategy.userFromIdentity('mozilla-auth0/ad|Mozilla-LDAP|mozillian');
       assert.equal(user.identity, 'mozilla-auth0/ad|Mozilla-LDAP|mozillian');
       assert.deepEqual(user.roles, ['mozillians-group:foxy']);
     });
 
-    test('GitHub', async function () {
+    test('GitHub', async () => {
       const user = await strategy.userFromIdentity('mozilla-auth0/github|1234');
       assert.equal(user.identity, 'mozilla-auth0/github|1234');
       assert.deepEqual(user.roles, []);
     });
 
-    test('GitHub inactive', async function () {
+    test('GitHub inactive', async () => {
       const user = await strategy.userFromIdentity('mozilla-auth0/github|9999');
       assert.equal(user, undefined);
     });
 
-    test('Firefox Accounts', async function () {
+    test('Firefox Accounts', async () => {
       const user = await strategy.userFromIdentity('mozilla-auth0/oauth2|firefoxaccounts|abcdef');
       assert.equal(user.identity, 'mozilla-auth0/oauth2|firefoxaccounts|abcdef');
       assert.deepEqual(user.roles, []);
     });
 
-    test('Email (with a slash)', async function () {
+    test('Email (with a slash)', async () => {
       const user = await strategy.userFromIdentity('mozilla-auth0/email|slashy!2Fslashy');
       assert.equal(user.identity, 'mozilla-auth0/email|slashy!2Fslashy');
       assert.deepEqual(user.roles, []);
     });
 
-    test('profile without identities should not have no roles', async function () {
+    test('profile without identities should not have no roles', async () => {
       const user = await strategy.userFromIdentity('mozilla-auth0/oauth2|firefoxaccounts|012345abcdef');
       assert.deepEqual(user.roles, []);
     });
   });
 
   suite('access token expiration', () => {
-    test('token should be requested once', async function() {
+    test('token should be requested once', async () => {
       let calls = 0;
       sinon.stub(strategy, 'fetchAccessToken').callsFake(() => {
         calls++;
@@ -209,7 +209,7 @@ suite(testing.suiteName(), () => {
 
       assert.equal(calls, 1);
     });
-    test('token should be re-fetched after expiry', async function() {
+    test('token should be re-fetched after expiry', async () => {
       let calls = 0;
       sinon.stub(strategy, 'fetchAccessToken').callsFake(() => {
         calls++;

--- a/services/web-server/test/profiler/log-profile_test.js
+++ b/services/web-server/test/profiler/log-profile_test.js
@@ -13,10 +13,10 @@ const mockTask = {
   },
 };
 
-suite('profiler/log-profile', function() {
+suite('profiler/log-profile', () => {
 
-  suite('lineIterator', function() {
-    test('yields complete lines from a stream', async function() {
+  suite('lineIterator', () => {
+    test('yields complete lines from a stream', async () => {
       const input = 'line one\nline two\nline three\n';
       const stream = Readable.from([Buffer.from(input)]);
       const lines = [];
@@ -26,7 +26,7 @@ suite('profiler/log-profile', function() {
       assert.deepEqual(lines, ['line one', 'line two', 'line three']);
     });
 
-    test('handles lines split across chunks', async function() {
+    test('handles lines split across chunks', async () => {
       const stream = Readable.from([
         Buffer.from('partial li'),
         Buffer.from('ne one\nline t'),
@@ -39,7 +39,7 @@ suite('profiler/log-profile', function() {
       assert.deepEqual(lines, ['partial line one', 'line two']);
     });
 
-    test('yields final line without trailing newline', async function() {
+    test('yields final line without trailing newline', async () => {
       const stream = Readable.from([Buffer.from('line one\nno newline at end')]);
       const lines = [];
       for await (const line of lineIterator(stream)) {
@@ -48,7 +48,7 @@ suite('profiler/log-profile', function() {
       assert.deepEqual(lines, ['line one', 'no newline at end']);
     });
 
-    test('tracks bytes read via callback', async function() {
+    test('tracks bytes read via callback', async () => {
       const stream = Readable.from([Buffer.from('hello\nworld\n')]);
       let totalBytes = 0;
       for await (const _ of lineIterator(stream, (n) => { totalBytes += n; })) {
@@ -58,8 +58,8 @@ suite('profiler/log-profile', function() {
     });
   });
 
-  suite('StreamingProfileBuilder', function() {
-    test('builds a valid profile from lines', function() {
+  suite('StreamingProfileBuilder', () => {
+    test('builds a valid profile from lines', () => {
       const builder = new StreamingProfileBuilder(mockTask, 'task-123', 'https://tc.example.com');
       builder.addLine('[taskcluster:info 2024-01-01T10:00:00.000Z] Starting task');
       builder.addLine('[setup:warn 2024-01-01T10:00:01.000Z] Installing dependencies');
@@ -74,7 +74,7 @@ suite('profiler/log-profile', function() {
       assert.equal(profile.threads[0].markers.length, 4);
     });
 
-    test('skips empty lines', function() {
+    test('skips empty lines', () => {
       const builder = new StreamingProfileBuilder(mockTask, 'task-123', 'https://tc.example.com');
       builder.addLine('[taskcluster:info 2024-01-01T10:00:00.000Z] Start');
       builder.addLine('');
@@ -86,7 +86,7 @@ suite('profiler/log-profile', function() {
       assert.equal(profile.threads[0].markers.length, 3);
     });
 
-    test('uses component as marker name', function() {
+    test('uses component as marker name', () => {
       const builder = new StreamingProfileBuilder(mockTask, 'task-123', 'https://tc.example.com');
       builder.addLine('[taskcluster:info 2024-01-01T10:00:00.000Z] Hello');
       builder.addLine('[setup:warn 2024-01-01T10:00:01.000Z] Warning');
@@ -99,7 +99,7 @@ suite('profiler/log-profile', function() {
       assert.equal(name2, 'setup');
     });
 
-    test('stores messages as unique-string indices', function() {
+    test('stores messages as unique-string indices', () => {
       const builder = new StreamingProfileBuilder(mockTask, 'task-123', 'https://tc.example.com');
       builder.addLine('[taskcluster:info 2024-01-01T10:00:00.000Z] Hello world');
       const profile = builder.finalize();
@@ -110,7 +110,7 @@ suite('profiler/log-profile', function() {
       assert.equal(thread.stringArray[data.message], 'Hello world');
     });
 
-    test('deduplicates repeated messages in stringArray', function() {
+    test('deduplicates repeated messages in stringArray', () => {
       const builder = new StreamingProfileBuilder(mockTask, 'task-123', 'https://tc.example.com');
       builder.addLine('[taskcluster:info 2024-01-01T10:00:00.000Z] same message');
       builder.addLine('[taskcluster:info 2024-01-01T10:00:01.000Z] same message');
@@ -124,7 +124,7 @@ suite('profiler/log-profile', function() {
       assert.notEqual(thread.markers.data[1].message, thread.markers.data[3].message);
     });
 
-    test('strips duplicate timestamps from messages', function() {
+    test('strips duplicate timestamps from messages', () => {
       const builder = new StreamingProfileBuilder(mockTask, 'task-123', 'https://tc.example.com');
       builder.addLine('[task 2024-01-01T10:00:00.000Z] [2024-01-01T10:00:00.000Z] actual message');
       const profile = builder.finalize();
@@ -134,7 +134,7 @@ suite('profiler/log-profile', function() {
       assert.equal(thread.stringArray[msgIndex], 'actual message');
     });
 
-    test('handles lines without timestamps', function() {
+    test('handles lines without timestamps', () => {
       const builder = new StreamingProfileBuilder(mockTask, 'task-123', 'https://tc.example.com');
       builder.addLine('[taskcluster:info 2024-01-01T10:00:00.000Z] Start');
       builder.addLine('plain text line');
@@ -146,7 +146,7 @@ suite('profiler/log-profile', function() {
       assert.equal(name, 'no timestamp');
     });
 
-    test('maps component to category', function() {
+    test('maps component to category', () => {
       const builder = new StreamingProfileBuilder(mockTask, 'task-123', 'https://tc.example.com');
       builder.addLine('[vcs:info 2024-01-01T10:00:00.000Z] cloning');
       builder.addLine('[fetches:info 2024-01-01T10:00:01.000Z] downloading');
@@ -157,14 +157,14 @@ suite('profiler/log-profile', function() {
       assert.equal(cats[profile.threads[0].markers.category[2]].name, 'fetches');
     });
 
-    test('returns empty if no timestamps found', function() {
+    test('returns empty if no timestamps found', () => {
       const builder = new StreamingProfileBuilder(mockTask, 'task-123', 'https://tc.example.com');
       builder.addLine('no timestamps here');
       const profile = builder.finalize();
       assert.ok(profile.threads[0].markers.data.length === 1);
     });
 
-    test('includes task duration marker with URLs', function() {
+    test('includes task duration marker with URLs', () => {
       const builder = new StreamingProfileBuilder(mockTask, 'task-123', 'https://tc.example.com');
       builder.addLine('[taskcluster:info 2024-01-01T10:00:00.000Z] Start');
       builder.addLine('[taskcluster:info 2024-01-01T10:00:05.000Z] End');

--- a/services/web-server/test/profiler/profile_test.js
+++ b/services/web-server/test/profiler/profile_test.js
@@ -6,7 +6,7 @@ import {
   UniqueStringArray,
 } from '../../src/profiler/profile.js';
 
-suite('profiler/profile', function() {
+suite('profiler/profile', () => {
   const mockTaskGroup = {
     taskGroupId: 'group-1',
     schedulerId: 'test-scheduler',
@@ -67,8 +67,8 @@ suite('profiler/profile', function() {
     ],
   };
 
-  suite('getProfile', function() {
-    test('generates a valid Firefox Profiler profile', function() {
+  suite('getProfile', () => {
+    test('generates a valid Firefox Profiler profile', () => {
       const rootUrl = 'https://taskcluster.net';
       const profile = getProfile([mockTaskGroup], rootUrl);
       assert.equal(profile.meta.version, 27);
@@ -76,28 +76,28 @@ suite('profiler/profile', function() {
       assert.equal(profile.meta.symbolicationNotSupported, true);
     });
 
-    test('creates one thread per task group', function() {
+    test('creates one thread per task group', () => {
       const rootUrl = 'https://taskcluster.net';
       const profile = getProfile([mockTaskGroup], rootUrl);
       assert.equal(profile.threads.length, 1);
       assert.equal(profile.threads[0].name, 'group-1');
     });
 
-    test('creates markers for tasks', function() {
+    test('creates markers for tasks', () => {
       const rootUrl = 'https://taskcluster.net';
       const profile = getProfile([mockTaskGroup], rootUrl);
       const thread = profile.threads[0];
       assert(thread.markers.length >= 2);
     });
 
-    test('sets correct startTime from earliest run', function() {
+    test('sets correct startTime from earliest run', () => {
       const rootUrl = 'https://taskcluster.net';
       const profile = getProfile([mockTaskGroup], rootUrl);
       const expectedStart = new Date('2024-01-01T10:00:00.000Z').valueOf();
       assert.equal(profile.meta.startTime, expectedStart);
     });
 
-    test('includes task URLs pointing to the deployment', function() {
+    test('includes task URLs pointing to the deployment', () => {
       const rootUrl = 'https://taskcluster.net';
       const profile = getProfile([mockTaskGroup], rootUrl);
       const thread = profile.threads[0];
@@ -107,7 +107,7 @@ suite('profiler/profile', function() {
       assert(taskMarkerData.taskURL.includes('taskcluster.net'));
     });
 
-    test('includes internal profiler URL for task profiles', function() {
+    test('includes internal profiler URL for task profiles', () => {
       const rootUrl = 'https://taskcluster.net';
       const profile = getProfile([mockTaskGroup], rootUrl);
       const thread = profile.threads[0];
@@ -117,7 +117,7 @@ suite('profiler/profile', function() {
       assert(taskMarkerData.taskProfile.includes('/profiler'));
     });
 
-    test('handles task groups with no runs', function() {
+    test('handles task groups with no runs', () => {
       const emptyGroup = {
         ...mockTaskGroup,
         tasks: [{
@@ -131,7 +131,7 @@ suite('profiler/profile', function() {
       assert.equal(profile.meta.startTime, 0);
     });
 
-    test('handles multiple task groups', function() {
+    test('handles multiple task groups', () => {
       const secondGroup = { ...mockTaskGroup, taskGroupId: 'group-2' };
       const rootUrl = 'https://taskcluster.net';
       const profile = getProfile([mockTaskGroup, secondGroup], rootUrl);
@@ -139,8 +139,8 @@ suite('profiler/profile', function() {
     });
   });
 
-  suite('getEmptyProfile', function() {
-    test('has required meta fields', function() {
+  suite('getEmptyProfile', () => {
+    test('has required meta fields', () => {
       const profile = getEmptyProfile();
       assert.equal(profile.meta.version, 27);
       assert.equal(profile.meta.preprocessedProfileVersion, 47);
@@ -150,8 +150,8 @@ suite('profiler/profile', function() {
     });
   });
 
-  suite('getEmptyThread', function() {
-    test('has required marker fields', function() {
+  suite('getEmptyThread', () => {
+    test('has required marker fields', () => {
       const thread = getEmptyThread();
       assert.deepEqual(thread.markers.data, []);
       assert.deepEqual(thread.markers.name, []);
@@ -161,24 +161,24 @@ suite('profiler/profile', function() {
     });
   });
 
-  suite('UniqueStringArray', function() {
-    test('returns consistent indices for the same string', function() {
+  suite('UniqueStringArray', () => {
+    test('returns consistent indices for the same string', () => {
       const arr = new UniqueStringArray();
       assert.equal(arr.indexForString('hello'), arr.indexForString('hello'));
     });
 
-    test('returns different indices for different strings', function() {
+    test('returns different indices for different strings', () => {
       const arr = new UniqueStringArray();
       assert.notEqual(arr.indexForString('hello'), arr.indexForString('world'));
     });
 
-    test('retrieves strings by index', function() {
+    test('retrieves strings by index', () => {
       const arr = new UniqueStringArray();
       const idx = arr.indexForString('test');
       assert.equal(arr.getString(idx), 'test');
     });
 
-    test('serializes to array', function() {
+    test('serializes to array', () => {
       const arr = new UniqueStringArray();
       arr.indexForString('a');
       arr.indexForString('b');

--- a/services/web-server/test/profiler/routes_test.js
+++ b/services/web-server/test/profiler/routes_test.js
@@ -39,7 +39,7 @@ function startServer(app) {
   });
 }
 
-suite('profiler/routes', function() {
+suite('profiler/routes', () => {
   const completedTask = {
     task: {
       schedulerId: 'test-scheduler',
@@ -68,10 +68,10 @@ suite('profiler/routes', function() {
     },
   };
 
-  suite('task group profile endpoint', function() {
+  suite('task group profile endpoint', () => {
     let server, port;
 
-    suiteSetup(async function() {
+    suiteSetup(async () => {
       const app = await createTestApp(() => ({
         queue: {
           listTaskGroup: async () => ({ tasks: [completedTask] }),
@@ -80,11 +80,11 @@ suite('profiler/routes', function() {
       ({ server, port } = await startServer(app));
     });
 
-    suiteTeardown(function(done) {
+    suiteTeardown((done) => {
       server.close(done);
     });
 
-    test('returns a valid profile for a task group', async function() {
+    test('returns a valid profile for a task group', async () => {
       const res = await request
         .get(`http://localhost:${port}/api/web-server/v1/task-group/${VALID_SLUGID}/profile`)
         .ok(() => true);
@@ -96,7 +96,7 @@ suite('profiler/routes', function() {
       assert.equal(res.headers['cache-control'], 'public, max-age=86400');
     });
 
-    test('returns 400 for invalid task group ID', async function() {
+    test('returns 400 for invalid task group ID', async () => {
       const res = await request
         .get(`http://localhost:${port}/api/web-server/v1/task-group/not valid!/profile`)
         .ok(() => true);
@@ -106,10 +106,10 @@ suite('profiler/routes', function() {
     });
   });
 
-  suite('cache headers', function() {
+  suite('cache headers', () => {
     let server, port;
 
-    suiteSetup(async function() {
+    suiteSetup(async () => {
       const app = await createTestApp(() => ({
         queue: {
           listTaskGroup: async () => ({
@@ -141,11 +141,11 @@ suite('profiler/routes', function() {
       ({ server, port } = await startServer(app));
     });
 
-    suiteTeardown(function(done) {
+    suiteTeardown((done) => {
       server.close(done);
     });
 
-    test('returns no-cache for running tasks', async function() {
+    test('returns no-cache for running tasks', async () => {
       const res = await request
         .get(`http://localhost:${port}/api/web-server/v1/task-group/${VALID_SLUGID}/profile`)
         .ok(() => true);
@@ -155,10 +155,10 @@ suite('profiler/routes', function() {
     });
   });
 
-  suite('error handling', function() {
+  suite('error handling', () => {
     let server, port;
 
-    suiteSetup(async function() {
+    suiteSetup(async () => {
       const app = await createTestApp(() => ({
         queue: {
           listTaskGroup: async () => {
@@ -181,11 +181,11 @@ suite('profiler/routes', function() {
       ({ server, port } = await startServer(app));
     });
 
-    suiteTeardown(function(done) {
+    suiteTeardown((done) => {
       server.close(done);
     });
 
-    test('returns 404 when task group not found', async function() {
+    test('returns 404 when task group not found', async () => {
       const res = await request
         .get(`http://localhost:${port}/api/web-server/v1/task-group/${VALID_SLUGID}/profile`)
         .ok(() => true);
@@ -194,7 +194,7 @@ suite('profiler/routes', function() {
       assert.equal(res.body.code, 'ResourceNotFound');
     });
 
-    test('returns 404 when task not found', async function() {
+    test('returns 404 when task not found', async () => {
       const res = await request
         .get(`http://localhost:${port}/api/web-server/v1/task/${VALID_SLUGID_2}/profile`)
         .ok(() => true);
@@ -204,19 +204,19 @@ suite('profiler/routes', function() {
     });
   });
 
-  suite('CORS', function() {
+  suite('CORS', () => {
     let server, port;
 
-    suiteSetup(async function() {
+    suiteSetup(async () => {
       const app = await createTestApp(() => ({ queue: {} }));
       ({ server, port } = await startServer(app));
     });
 
-    suiteTeardown(function(done) {
+    suiteTeardown((done) => {
       server.close(done);
     });
 
-    test('responds to OPTIONS preflight for task group profile', async function() {
+    test('responds to OPTIONS preflight for task group profile', async () => {
       const res = await request
         .options(`http://localhost:${port}/api/web-server/v1/task-group/${VALID_SLUGID}/profile`)
         .set('Origin', 'https://profiler.firefox.com')
@@ -226,7 +226,7 @@ suite('profiler/routes', function() {
       assert.equal(res.headers['access-control-allow-origin'], '*');
     });
 
-    test('responds to OPTIONS preflight for task log profile', async function() {
+    test('responds to OPTIONS preflight for task log profile', async () => {
       const res = await request
         .options(`http://localhost:${port}/api/web-server/v1/task/${VALID_SLUGID}/profile`)
         .set('Origin', 'https://profiler.firefox.com')
@@ -254,7 +254,7 @@ suite('profiler/routes', function() {
     return () => { global.fetch = original; };
   }
 
-  suite('task log profile endpoint', function() {
+  suite('task log profile endpoint', () => {
     const logContent = [
       '[taskcluster:info 2024-01-01T10:00:00.000Z] Starting task',
       '[setup:warn 2024-01-01T10:00:01.000Z] Installing dependencies',
@@ -263,7 +263,7 @@ suite('profiler/routes', function() {
 
     let server, port, restoreFetch;
 
-    suiteSetup(async function() {
+    suiteSetup(async () => {
       restoreFetch = mockFetch({
         'live.log': () => ({
           ok: true,
@@ -288,12 +288,12 @@ suite('profiler/routes', function() {
       ({ server, port } = await startServer(app));
     });
 
-    suiteTeardown(function(done) {
+    suiteTeardown((done) => {
       restoreFetch();
       server.close(done);
     });
 
-    test('returns gzip-compressed profile', async function() {
+    test('returns gzip-compressed profile', async () => {
       const res = await request
         .get(`http://localhost:${port}/api/web-server/v1/task/${VALID_SLUGID_2}/profile`)
         .buffer(true)
@@ -310,7 +310,7 @@ suite('profiler/routes', function() {
       assert.equal(profile.threads[0].name, 'Live Log');
     });
 
-    test('returns cache headers for completed task', async function() {
+    test('returns cache headers for completed task', async () => {
       const res = await request
         .get(`http://localhost:${port}/api/web-server/v1/task/${VALID_SLUGID_2}/profile`)
         .buffer(true)
@@ -321,10 +321,10 @@ suite('profiler/routes', function() {
     });
   });
 
-  suite('task log profile size limit', function() {
+  suite('task log profile size limit', () => {
     let server, port, restoreFetch;
 
-    suiteSetup(async function() {
+    suiteSetup(async () => {
       restoreFetch = mockFetch({
         'live.log': () => ({
           ok: true,
@@ -344,12 +344,12 @@ suite('profiler/routes', function() {
       ({ server, port } = await startServer(app));
     });
 
-    suiteTeardown(function(done) {
+    suiteTeardown((done) => {
       restoreFetch();
       server.close(done);
     });
 
-    test('returns 413 for oversized logs', async function() {
+    test('returns 413 for oversized logs', async () => {
       const res = await request
         .get(`http://localhost:${port}/api/web-server/v1/task/${VALID_SLUGID_2}/profile`)
         .ok(() => true);

--- a/services/web-server/test/pulseengine_test.js
+++ b/services/web-server/test/pulseengine_test.js
@@ -20,13 +20,13 @@ class FakePulseEngine {
   }
 }
 
-suite(testing.suiteName(), function() {
+suite(testing.suiteName(), () => {
   // pause for "a beat" to let async things filter out; `for await` in particular
   // does not activate immediately
   const beat = () => new Promise(resolve => setTimeout(resolve, 1));
 
-  suite('PulseIterator', function() {
-    test('queues up pushed messages', async function() {
+  suite('PulseIterator', () => {
+    test('queues up pushed messages', async () => {
       const engine = new FakePulseEngine();
       const pi = new PulseIterator(engine, []);
 
@@ -56,7 +56,7 @@ suite(testing.suiteName(), function() {
       assert.deepEqual(received, ['M1', 'M2', 'M3']);
     });
 
-    test('waits for pushed messages', async function() {
+    test('waits for pushed messages', async () => {
       const engine = new FakePulseEngine();
       const pi = new PulseIterator(engine, []);
 
@@ -91,7 +91,7 @@ suite(testing.suiteName(), function() {
       assert.equal(engine.subscribed, false, "should have been unsubscribed");
     });
 
-    test('throws errors into the iterator', async function() {
+    test('throws errors into the iterator', async () => {
       const engine = new FakePulseEngine();
       const pi = new PulseIterator(engine, []);
 

--- a/services/web-server/test/scanner_test.js
+++ b/services/web-server/test/scanner_test.js
@@ -4,7 +4,7 @@ import scanner from '../src/login/scanner.js';
 import testing from '@taskcluster/lib-testing';
 import Test from '../src/login/strategies/test.js';
 
-helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
+helper.secrets.mockSuite(testing.suiteName(), [], (mock, skipping) => {
   helper.withDb(mock, skipping);
   helper.withFakeAuth(mock, skipping);
   helper.resetTables(mock, skipping);
@@ -26,17 +26,17 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
     },
   };
 
-  setup(function() {
+  setup(() => {
     strategies = { test: new Test() };
     clients = [];
     disabled = [];
   });
 
-  test('scanner does nothing with no clients', async function() {
+  test('scanner does nothing with no clients', async () => {
     await scanner(auth, strategies);
   });
 
-  test('scanner does nothing to clients with sufficient scopes', async function() {
+  test('scanner does nothing to clients with sufficient scopes', async () => {
     clients.push({
       clientId: 'test/client-1',
       expandedScopes: ['assume:role1'],
@@ -46,7 +46,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
     assert.deepEqual(disabled, []);
   });
 
-  test('scanner does nothing to clients with explicit assume:anonymous', async function() {
+  test('scanner does nothing to clients with explicit assume:anonymous', async () => {
     clients.push({
       clientId: 'test/client-1',
       expandedScopes: ['assume:anonymous'],
@@ -56,7 +56,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
     assert.deepEqual(disabled, []);
   });
 
-  test('scanner disables clients with more scopes than the user', async function() {
+  test('scanner disables clients with more scopes than the user', async () => {
     clients.push({
       clientId: 'test/client-1',
       expandedScopes: ['assume:anonymous', 'assume:role1', 'assume:role2'],

--- a/services/web-server/test/search_filter_test.js
+++ b/services/web-server/test/search_filter_test.js
@@ -9,46 +9,46 @@ suite(testing.suiteName(), () => {
     { clientId: 'project/releng/fxci-config/apply' },
   ];
 
-  test('null array returns empty array', function() {
+  test('null array returns empty array', () => {
     assert.deepEqual(substringFilter('anything', 'clientId', null), []);
     assert.deepEqual(substringFilter('anything', 'clientId', undefined), []);
   });
 
-  test('empty/absent searchTerm returns the array unchanged', function() {
+  test('empty/absent searchTerm returns the array unchanged', () => {
     assert.deepEqual(substringFilter('', 'clientId', clients), clients);
     assert.deepEqual(substringFilter(null, 'clientId', clients), clients);
     assert.deepEqual(substringFilter(undefined, 'clientId', clients), clients);
   });
 
-  test('matches a case-insensitive substring on the named field', function() {
+  test('matches a case-insensitive substring on the named field', () => {
     assert.deepEqual(
       substringFilter('RELENG', 'clientId', clients),
       [{ clientId: 'project/releng/fxci-config/apply' }],
     );
   });
 
-  test('returns all rows whose field contains the term', function() {
+  test('returns all rows whose field contains the term', () => {
     const result = substringFilter('mozilla', 'clientId', clients);
     assert.equal(result.length, 1);
     assert.equal(result[0].clientId, 'mozilla-auth0/ad|Mozilla-LDAP|alice/treeherder');
   });
 
-  test('non-matching term returns empty array', function() {
+  test('non-matching term returns empty array', () => {
     assert.deepEqual(substringFilter('nonexistent-zzz', 'clientId', clients), []);
   });
 
-  test('treats a missing/null field value as no match', function() {
+  test('treats a missing/null field value as no match', () => {
     const rows = [{ clientId: 'abc' }, { other: 'def' }, { clientId: null }];
     assert.deepEqual(substringFilter('a', 'clientId', rows), [{ clientId: 'abc' }]);
   });
 
-  test('the search term is treated as a literal string, not a regex', function() {
+  test('the search term is treated as a literal string, not a regex', () => {
     const rows = [{ name: 'a.b' }, { name: 'axb' }];
     // '.' must match only the literal dot, not "any character"
     assert.deepEqual(substringFilter('a.b', 'name', rows), [{ name: 'a.b' }]);
   });
 
-  test('a $where-style payload is just an inert literal string (no execution path)', function() {
+  test('a $where-style payload is just an inert literal string (no execution path)', () => {
     const rows = [{ name: 'safe' }];
     // Nothing interprets operators anymore; this can only ever fail to match.
     assert.deepEqual(substringFilter('(function(){return true})()', 'name', rows), []);

--- a/services/web-server/test/server_test.js
+++ b/services/web-server/test/server_test.js
@@ -3,25 +3,25 @@ import helper from './helper.js';
 import request from 'superagent';
 import testing from '@taskcluster/lib-testing';
 
-helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
+helper.secrets.mockSuite(testing.suiteName(), [], (mock, skipping) => {
   helper.withDb(mock, skipping);
   helper.resetTables(mock, skipping);
 
   const makeSuite = (allowedCORSOrigins, requestOrigin, responseOrigin) => {
-    suite(`with ${JSON.stringify(allowedCORSOrigins)}, request origin = ${requestOrigin}`, function() {
-      suiteSetup(async function() {
+    suite(`with ${JSON.stringify(allowedCORSOrigins)}, request origin = ${requestOrigin}`, () => {
+      suiteSetup(async () => {
         await helper.load('cfg');
         helper.load.save();
         helper.load.cfg('server.allowedCORSOrigins', allowedCORSOrigins);
       });
 
-      suiteTeardown(function() {
+      suiteTeardown(() => {
         helper.load.restore();
       });
 
       helper.withServer(mock, skipping);
 
-      test('request', async function() {
+      test('request', async () => {
         try {
           await request
             .post(`http://localhost:${helper.serverPort}/graphql`)
@@ -46,30 +46,30 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
     'https://deploy-preview-897--taskcluster-web.netlify.com/',
     'https://deploy-preview-897--taskcluster-web.netlify.com/');
 
-  suite('auth endpoints', function () {
+  suite('auth endpoints', () => {
     helper.withServer(mock, skipping);
 
-    test('login/logout', async function () {
+    test('login/logout', async () => {
       const logout = await request.post(`http://localhost:${helper.serverPort}/login/logout`);
       assert(logout.body);
     });
   });
 
-  suite('service endpoints', function() {
+  suite('service endpoints', () => {
     helper.withServer(mock, skipping);
 
-    test('version', async function() {
+    test('version', async () => {
       const version = await request.get(`http://localhost:${helper.serverPort}/api/web-server/v1/__version__`);
       assert(typeof version.body.version !== 'undefined');
       assert(typeof version.body.commit !== 'undefined');
       assert(typeof version.body.source !== 'undefined');
       assert(typeof version.body.build !== 'undefined');
     });
-    test('heartbeat', async function() {
+    test('heartbeat', async () => {
       const heartbeat = await request.get(`http://localhost:${helper.serverPort}/api/web-server/v1/__heartbeat__`);
       assert(heartbeat.body);
     });
-    test('lbheartbeat', async function() {
+    test('lbheartbeat', async () => {
       const heartbeat = await request.get(`http://localhost:${helper.serverPort}/api/web-server/v1/__lbheartbeat__`);
       assert(heartbeat.body);
     });

--- a/services/web-server/test/session_store_test.js
+++ b/services/web-server/test/session_store_test.js
@@ -6,7 +6,7 @@ import helper from './helper.js';
 import PostgresSessionStore from '../src/login/PostgresSessionStore.js';
 import hash from '../src/utils/hash.js';
 
-helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
+helper.secrets.mockSuite(testing.suiteName(), [], (mock, skipping) => {
   helper.withDb(mock, skipping);
   helper.withFakeAuth(mock, skipping);
   helper.withServer(mock, skipping);
@@ -35,8 +35,8 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
     return store;
   };
 
-  suite('destroy', function() {
-    test('it should destroy the specified session', async function () {
+  suite('destroy', () => {
+    test('it should destroy the specified session', async () => {
       const store = getStore();
 
       await store.set('foo', { cookie: {} });
@@ -49,17 +49,17 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       val = await store.get('foo');
       assert.equal(val, undefined, 'entry actually deleted');
     });
-    test('it should destroy the specified session and call back', function (done) {
+    test('it should destroy the specified session and call back', (done) => {
       const store = getStore(false /* shouldPromisify */);
 
-      store.set('foo', { cookie: {} }, function() {
+      store.set('foo', { cookie: {} }, () => {
         store.destroy('foo', done);
       });
     });
   });
 
-  suite('get', function() {
-    test('it should get the specified session', async function () {
+  suite('get', () => {
+    test('it should get the specified session', async () => {
       const store = getStore();
 
       await store.set('foo', { cookie: {} });
@@ -68,7 +68,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
 
       assert.ok(val, 'entry exists');
     });
-    test('it shouldn\'t get the specified session when only the hash matches', async function () {
+    test('it shouldn\'t get the specified session when only the hash matches', async () => {
       const store = getStore();
 
       const currentSession = 'sessionid1';
@@ -90,14 +90,14 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
 
       assert.equal(val, undefined);
     });
-    test('it should get the specified session and call back', function (done) {
+    test('it should get the specified session and call back', (done) => {
       const store = getStore(false /* shouldPromisify */);
 
       store.set('foo', { cookie: {} }, () => {
         store.get('foo', done);
       });
     });
-    test('it should not error when session doesn\'t exist', async function () {
+    test('it should not error when session doesn\'t exist', async () => {
       const store = getStore();
       const val = await store.get('foo');
 
@@ -105,8 +105,8 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
     });
   });
 
-  suite('set', function() {
-    test('it should set the specified session', async function () {
+  suite('set', () => {
+    test('it should set the specified session', async () => {
       const store = getStore();
       const data = { cookie: { foo: 'bar' } };
 
@@ -116,15 +116,15 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
 
       assert.deepEqual(val, data);
     });
-    test('it should set the specified session and call back', function (done) {
+    test('it should set the specified session and call back', (done) => {
       const store = getStore(false /* shouldPromisify */);
 
       store.set('foo', { cookie: {} }, done);
     });
   });
 
-  suite('touch', function() {
-    test('it should touch the specified session', async function () {
+  suite('touch', () => {
+    test('it should touch the specified session', async () => {
       const store = getStore();
 
       await store.set('foo', { cookie: { maxAge: 50 } });
@@ -134,14 +134,14 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
 
       assert.equal(val.cookie.maxAge, 300, 'entry should be touched');
     });
-    test('it should touch the specified session and call back', function (done) {
+    test('it should touch the specified session and call back', (done) => {
       const store = getStore(false /* shouldPromisify */);
 
       store.set('foo', { cookie: { maxAge: 50 } }, () => {
         store.touch('foo', { cookie: { maxAge: 300 } }, done);
       });
     });
-    test('it should error when touching the session', async function () {
+    test('it should error when touching the session', async () => {
       const store = getStore();
 
       await assert.rejects(
@@ -151,8 +151,8 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
     });
   });
 
-  suite('other', function() {
-    test('it should inherit from the session Store', function () {
+  suite('other', () => {
+    test('it should inherit from the session Store', () => {
       const store = getStore();
 
       assert(store instanceof session.Store);

--- a/services/web-server/test/third_party_test.js
+++ b/services/web-server/test/third_party_test.js
@@ -9,7 +9,7 @@ import helper from './helper.js';
 import tryCatch from '../src/utils/tryCatch.js';
 import hash from '../src/utils/hash.js';
 
-helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
+helper.secrets.mockSuite(testing.suiteName(), [], (mock, skipping) => {
   helper.withDb(mock, skipping);
   helper.withFakeAuth(mock, skipping);
   helper.withServer(mock, skipping);
@@ -24,8 +24,8 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
     return new URLSearchParams(url.slice(qmark + 1));
   };
 
-  suite('unit', function() {
-    test('authorization endpoint redirects to the third party page if user is not logged in', async function() {
+  suite('unit', () => {
+    test('authorization endpoint redirects to the third party page if user is not logged in', async () => {
       const registeredClientId = 'test-code';
       const query = new URLSearchParams({
         response_type: 'token',
@@ -45,7 +45,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
 
       assert.equal(res.header.location, `/third-party?${query}`);
     });
-    test('decision endpoint redirects to the third party page if user is not logged in', async function() {
+    test('decision endpoint redirects to the third party page if user is not logged in', async () => {
       const formData = new URLSearchParams({
         clientId: `test/test/test`,
         transaction_id: '123',
@@ -64,7 +64,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
 
       assert.equal(res.header.location, '/third-party');
     });
-    test('unauthorized_client when mismatch in redirect_uri', async function() {
+    test('unauthorized_client when mismatch in redirect_uri', async () => {
       const agent = await helper.signedInAgent();
 
       // user sent to /login/oauth/authorize with query arg
@@ -84,7 +84,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
 
       await helper.expectMonitorError('unauthorized_client');
     });
-    test('unauthorized_client when client_id is not registered', async function() {
+    test('unauthorized_client when client_id is not registered', async () => {
       const agent = await helper.signedInAgent();
       const redirectUri = 'https://test.example.com/cb';
 
@@ -105,7 +105,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
 
       await helper.expectMonitorError('unauthorized_client');
     });
-    test('invalid_request when missing required parameters', async function() {
+    test('invalid_request when missing required parameters', async () => {
       const agent = await helper.signedInAgent();
       const registeredClientId = 'test-token';
       const state = 'abc123';
@@ -139,7 +139,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
         await helper.expectMonitorError('invalid_request');
       }
     });
-    test('invalid_scope', async function() {
+    test('invalid_scope', async () => {
       const agent = await helper.signedInAgent();
       const registeredClientId = 'test-token';
       const state = 'abc123';
@@ -180,7 +180,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       assert.equal(query.get('error'), 'invalid_scope');
       assert.equal(query.get('state'), state);
     });
-    test('unsupported_response_type', async function() {
+    test('unsupported_response_type', async () => {
       const agent = await helper.signedInAgent();
       const registeredClientId = 'test-token';
       const state = 'abc123';
@@ -221,7 +221,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       assert.equal(query.get('error'), 'unsupported_response_type');
       assert.equal(query.get('state'), state);
     });
-    test('invalid transactionID', async function() {
+    test('invalid transactionID', async () => {
       const agent = await helper.signedInAgent();
       const registeredClientId = 'test-code';
       const state = 'abc123';
@@ -260,7 +260,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
 
       await helper.expectMonitorError('ForbiddenError');
     });
-    test('maxExpires is respected', async function() {
+    test('maxExpires is respected', async () => {
       const agent = await helper.signedInAgent();
       const registeredClientId = 'test-token';
 
@@ -296,7 +296,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
 
       assert(new Date(res.body.expires) < taskcluster.fromNow('1 year'));
     });
-    test('can request a client with expires less than maxExpires when client is whitelisted', async function() {
+    test('can request a client with expires less than maxExpires when client is whitelisted', async () => {
       const agent = await helper.signedInAgent();
       const registeredClientId = 'test-code-whitelisted';
       const redirectUri = 'https://test.example.com/cb';
@@ -332,7 +332,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
 
       assert(new Date(res.body.expires) < taskcluster.fromNow(fifteenMinutes));
     });
-    test('skip decision step when client is whitelisted', async function() {
+    test('skip decision step when client is whitelisted', async () => {
       const agent = await helper.signedInAgent();
       const registeredClientId = 'test-code-whitelisted';
 
@@ -351,7 +351,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
 
       assert(query.get('code').length > 1);
     });
-    test('invalid_grant - invalid code does not return an access token', async function() {
+    test('invalid_grant - invalid code does not return an access token', async () => {
       const agent = await helper.signedInAgent();
       const registeredClientId = 'test-code-whitelisted';
       const redirectUri = 'https://test.example.com/cb';
@@ -379,7 +379,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       assert.equal(error.response.body.error, 'invalid_grant');
       assert(!response);
     });
-    test('invalid_grant - authorization code cannot be exchanged twice', async function() {
+    test('invalid_grant - authorization code cannot be exchanged twice', async () => {
       const agent = await helper.signedInAgent();
       const registeredClientId = 'test-code-whitelisted';
       const redirectUri = 'https://test.example.com/cb';
@@ -419,7 +419,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
         `expected code replay to be rejected, but exchange succeeded with status ${response?.status}`);
       assert.equal(error.response.body.error, 'invalid_grant');
     });
-    test('invalid_grant - authorization code past its lifetime cannot be exchanged', async function() {
+    test('invalid_grant - authorization code past its lifetime cannot be exchanged', async () => {
       const agent = await helper.signedInAgent();
       const registeredClientId = 'test-code-whitelisted';
       const redirectUri = 'https://test.example.com/cb';
@@ -458,7 +458,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
         `expected expired code to be rejected, but exchange succeeded with status ${response?.status}`);
       assert.equal(error.response.body.error, 'invalid_grant');
     });
-    test('InputError when trying to get credentials of an expired client', async function() {
+    test('InputError when trying to get credentials of an expired client', async () => {
       const agent = await helper.signedInAgent();
       const registeredClientId = 'test-token';
 
@@ -498,7 +498,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
 
       await helper.expectMonitorError('InputError');
     });
-    test('InputError when the access token is past its own 10 minute lifetime', async function() {
+    test('InputError when the access token is past its own 10 minute lifetime', async () => {
       const agent = await helper.signedInAgent();
       const registeredClientId = 'test-token';
 
@@ -546,8 +546,8 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       await helper.expectMonitorError('InputError');
     });
   });
-  suite('scope tampering defense', function() {
-    test('implicit flow: tampered scope in decision is rejected', async function() {
+  suite('scope tampering defense', () => {
+    test('implicit flow: tampered scope in decision is rejected', async () => {
       const agent = await helper.signedInAgent();
       const registeredClientId = 'test-token';
       const state = 'abc123';
@@ -584,7 +584,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       assert.equal(query.get('error'), 'invalid_scope');
       assert.equal(query.get('state'), state);
     });
-    test('authorization code flow: tampered scope in decision is rejected', async function() {
+    test('authorization code flow: tampered scope in decision is rejected', async () => {
       const agent = await helper.signedInAgent();
       const registeredClientId = 'test-code';
       const redirectUri = 'https://test.example.com/cb';
@@ -622,8 +622,8 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       assert.equal(query.get('state'), state);
     });
   });
-  suite('integration', function() {
-    test('implicit flow', async function() {
+  suite('integration', () => {
+    test('implicit flow', async () => {
       const agent = await helper.signedInAgent();
       const registeredClientId = 'test-token';
 
@@ -691,7 +691,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       assert(res.body.credentials.clientId.startsWith(`test/test/${registeredClientId}-`));
     });
 
-    test('authorization code flow', async function() {
+    test('authorization code flow', async () => {
       const agent = await helper.signedInAgent();
       const registeredClientId = 'test-code';
       const redirectUri = 'https://test.example.com/cb';

--- a/services/web-server/test/unpromisify_test.js
+++ b/services/web-server/test/unpromisify_test.js
@@ -7,7 +7,7 @@ suite(testing.suiteName(), () => {
   // sleep until the next event-loop round
   const sleep = () => new Promise(resolve => setTimeout(resolve, 1));
 
-  test('Successful callback', function(done) {
+  test('Successful callback', (done) => {
     const success = unpromisify(async (a, b) => {
       await sleep();
       return a + b;
@@ -23,7 +23,7 @@ suite(testing.suiteName(), () => {
     });
   });
 
-  test('Successful callback returning an array', function(done) {
+  test('Successful callback returning an array', (done) => {
     const success = unpromisify(async (a, b) => {
       await sleep();
       return [a + b, a * b];
@@ -40,7 +40,7 @@ suite(testing.suiteName(), () => {
     });
   });
 
-  test('Unsuccessful callback', function(done) {
+  test('Unsuccessful callback', (done) => {
     const success = unpromisify(async () => {
       await sleep();
       throw new Error('uhoh');

--- a/services/worker-manager/src/api.js
+++ b/services/worker-manager/src/api.js
@@ -1399,7 +1399,7 @@ builder.declare({
     'This endpoint is used to check on backing services this service',
     'depends on.',
   ].join('\n'),
-}, function(_req, res) {
+}, (_req, res) => {
   // TODO: add implementation
   res.reply({});
 });

--- a/services/worker-manager/src/exchanges.js
+++ b/services/worker-manager/src/exchanges.js
@@ -66,11 +66,9 @@ let buildCommonRoutingKey = (options) => {
   ];
 };
 
-let commonMessageBuilder = function(message) {
-  return message;
-};
+let commonMessageBuilder = (message) => message;
 
-let commonRoutingKeyBuilder = function(message, routing) {
+let commonRoutingKeyBuilder = (message, routing) => {
   const mapping = {
     workerGroup: message.workerGroup,
     providerId: message.providerId,

--- a/services/worker-manager/test/api_test.js
+++ b/services/worker-manager/test/api_test.js
@@ -7,7 +7,7 @@ import testing from '@taskcluster/lib-testing';
 import fs from 'node:fs';
 import path from 'node:path';
 
-helper.secrets.mockSuite(testing.suiteName(), [], function (mock, skipping) {
+helper.secrets.mockSuite(testing.suiteName(), [], (mock, skipping) => {
   helper.withDb(mock, skipping);
   helper.withPulse(mock, skipping);
   helper.withProviders(mock, skipping);
@@ -79,11 +79,11 @@ helper.secrets.mockSuite(testing.suiteName(), [], function (mock, skipping) {
     capacityPerInstance: 1,
   });
 
-  test('ping', async function () {
+  test('ping', async () => {
     await helper.workerManager.ping();
   });
 
-  test('list providers', async function () {
+  test('list providers', async () => {
     const { providers } = await helper.workerManager.listProviders();
     assert.deepStrictEqual(providers, [
       { providerId: 'testing1', providerType: 'testing' },
@@ -95,7 +95,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function (mock, skipping) {
     ]);
   });
 
-  test('list providers pagination', async function () {
+  test('list providers pagination', async () => {
     let pages = 0;
     let providerIds = [];
     let query = { limit: 1 };
@@ -144,7 +144,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function (mock, skipping) {
     assert.deepStrictEqual({ workerPoolId, ...input }, definition);
   };
 
-  test('create worker pool', async function () {
+  test('create worker pool', async () => {
     const input = {
       providerId: 'testing1',
       description: 'bar',
@@ -169,7 +169,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function (mock, skipping) {
       await helper.workerManager.createWorkerPool(workerPoolId2, input2));
   });
 
-  test('schema validation - queueInactivityTimeout', async function () {
+  test('schema validation - queueInactivityTimeout', async () => {
     const input = {
       providerId: 'aws',
       description: 'bar',
@@ -195,7 +195,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function (mock, skipping) {
       ));
   });
 
-  test('create worker pool - launchConfigIds are added/preserved', async function () {
+  test('create worker pool - launchConfigIds are added/preserved', async () => {
     const input = {
       providerId: 'aws',
       description: 'bar',
@@ -219,7 +219,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function (mock, skipping) {
     workerPoolCompare(workerPoolId, input, created);
   });
 
-  test('create worker pool fails when pulse publish fails', async function () {
+  test('create worker pool fails when pulse publish fails', async () => {
     const input = {
       providerId: 'testing1',
       description: 'bar',
@@ -244,7 +244,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function (mock, skipping) {
     monitor.manager.reset();
   });
 
-  test('update worker pool', async function () {
+  test('update worker pool', async () => {
     let messages = capturePulseMessages();
     const input = {
       providerId: 'testing1',
@@ -279,7 +279,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function (mock, skipping) {
     assert.equal(messages[1].exchange, 'exchange/taskcluster-worker-manager/v1/worker-pool-updated');
   });
 
-  test('update worker pool - launch config events emitted', async function () {
+  test('update worker pool - launch config events emitted', async () => {
     let messages = capturePulseMessages();
     const input = {
       providerId: 'aws',
@@ -353,7 +353,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function (mock, skipping) {
       ['lc1', 'lc3']);
   });
 
-  test('update worker pool - launchConfigs are always updated with full config', async function () {
+  test('update worker pool - launchConfigs are always updated with full config', async () => {
     const wpId = 'up/date';
     const input = {
       providerId: 'aws',
@@ -386,7 +386,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function (mock, skipping) {
     assert.equal(updated.config.launchConfigs[1].workerManager.capacityPerInstance, 8);
   });
 
-  test('launchConfigIds should be unique across worker pool - create worker pool', async function () {
+  test('launchConfigIds should be unique across worker pool - create worker pool', async () => {
     const input = {
       providerId: 'aws',
       description: 'bar',
@@ -420,7 +420,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function (mock, skipping) {
     );
   });
 
-  test('launchConfigIds should be unique across worker pool - update worker pool', async function () {
+  test('launchConfigIds should be unique across worker pool - update worker pool', async () => {
     const input = {
       providerId: 'aws',
       description: 'bar',
@@ -459,7 +459,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function (mock, skipping) {
     assert.equal(wp.config.launchConfigs[0].workerManager.launchConfigId, 'lc1');
   });
 
-  test('launchConfigIds can be non unique across different worker pools', async function () {
+  test('launchConfigIds can be non unique across different worker pools', async () => {
     await helper.workerManager.createWorkerPool('wp/p1', {
       providerId: 'aws',
       description: 'bar',
@@ -488,7 +488,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function (mock, skipping) {
     assert.equal(pools[1].config.launchConfigs[0].workerManager.launchConfigId, 'lc1');
   });
 
-  test('update worker pool fails when pulse publish fails', async function () {
+  test('update worker pool fails when pulse publish fails', async () => {
     const input = {
       providerId: 'testing1',
       description: 'bar',
@@ -517,7 +517,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function (mock, skipping) {
     monitor.manager.reset();
   });
 
-  test('create worker pool (invalid providerId)', async function () {
+  test('create worker pool (invalid providerId)', async () => {
     try {
       await helper.workerManager.createWorkerPool('pp/oo', {
         providerId: 'foo',
@@ -535,7 +535,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function (mock, skipping) {
     throw new Error('Allowed to specify an invalid providerId');
   });
 
-  test('update worker pool (invalid workerPoolId)', async function () {
+  test('update worker pool (invalid workerPoolId)', async () => {
     await helper.workerManager.createWorkerPool('pp/oo', {
       providerId: 'testing1',
       description: 'e',
@@ -561,7 +561,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function (mock, skipping) {
     throw new Error('Allowed to specify an invalid workerPoolId');
   });
 
-  test('update worker pool (invalid providerId)', async function () {
+  test('update worker pool (invalid providerId)', async () => {
     await helper.workerManager.createWorkerPool('pp/oo', {
       providerId: 'testing1',
       description: 'e',
@@ -586,7 +586,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function (mock, skipping) {
     throw new Error('Allowed to specify an invalid providerId');
   });
 
-  test('update worker pool to providerId = null-provider', async function () {
+  test('update worker pool to providerId = null-provider', async () => {
     await helper.workerManager.createWorkerPool('pp/oo', {
       providerId: 'testing1',
       description: 'e',
@@ -605,7 +605,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function (mock, skipping) {
     assert.equal(wp.providerId, 'null-provider');
   });
 
-  test('delete worker pool', async function () {
+  test('delete worker pool', async () => {
     await helper.workerManager.createWorkerPool('pp/oo', {
       providerId: 'testing1',
       description: 'e',
@@ -618,7 +618,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function (mock, skipping) {
     assert.equal(wp.providerId, 'null-provider');
   });
 
-  test('delete worker pool - archives launch configs', async function () {
+  test('delete worker pool - archives launch configs', async () => {
     await helper.workerManager.createWorkerPool(workerPoolId, {
       providerId: 'aws',
       description: 'bar',
@@ -643,7 +643,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function (mock, skipping) {
     assert.equal(messages[2].data.launchConfigId, 'lc2');
   });
 
-  test('create worker pool (already exists)', async function () {
+  test('create worker pool (already exists)', async () => {
     await helper.workerManager.createWorkerPool('pp/oo', {
       providerId: 'testing1',
       description: 'e',
@@ -668,7 +668,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function (mock, skipping) {
     throw new Error('creation of an already existing worker pool succeeded');
   });
 
-  test('update worker pool (does not exist)', async function () {
+  test('update worker pool (does not exist)', async () => {
     try {
       await helper.workerManager.updateWorkerPool('pp/oo', {
         providerId: 'testing1',
@@ -686,7 +686,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function (mock, skipping) {
     throw new Error('update of non-existent worker pool succeeded');
   });
 
-  test('create worker pool (invalid config)', async function () {
+  test('create worker pool (invalid config)', async () => {
     try {
       await helper.workerManager.createWorkerPool('pp/oo', {
         providerId: 'testing1',
@@ -704,7 +704,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function (mock, skipping) {
     throw new Error('Allowed to specify an invalid config');
   });
 
-  test('update worker pool (invalid config)', async function () {
+  test('update worker pool (invalid config)', async () => {
     await helper.workerManager.createWorkerPool('pp/oo', {
       providerId: 'testing1',
       description: 'e',
@@ -729,7 +729,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function (mock, skipping) {
     throw new Error('Allowed to specify an invalid config');
   });
 
-  test('get worker pool', async function () {
+  test('get worker pool', async () => {
     const input = {
       providerId: 'testing1',
       description: 'bar',
@@ -741,7 +741,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function (mock, skipping) {
     workerPoolCompare(workerPoolId, input, await helper.workerManager.workerPool(workerPoolId));
   });
 
-  test('get worker pool (does not exist)', async function () {
+  test('get worker pool (does not exist)', async () => {
     try {
       await helper.workerManager.workerPool('pp/oo');
     } catch (err) {
@@ -753,7 +753,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function (mock, skipping) {
     throw new Error('get of non-existent worker pool succeeded');
   });
 
-  test('get worker pools - one worker pool', async function () {
+  test('get worker pools - one worker pool', async () => {
     const input = {
       providerId: 'testing1',
       description: 'bar',
@@ -794,7 +794,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function (mock, skipping) {
     return input;
   };
 
-  test('get worker pools - >1 worker pools', async function () {
+  test('get worker pools - >1 worker pools', async () => {
     const input = await makeWorkerPools();
     const data = await helper.workerManager.listWorkerPools();
     assert(!data.continuationToken);
@@ -803,7 +803,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function (mock, skipping) {
     });
   });
 
-  test('get worker pools, paginated', async function () {
+  test('get worker pools, paginated', async () => {
     const input = await makeWorkerPools();
     let data = await helper.workerManager.listWorkerPools({ limit: 1 });
     assert.equal(data.workerPools.length, 1);
@@ -821,19 +821,19 @@ helper.secrets.mockSuite(testing.suiteName(), [], function (mock, skipping) {
     assert(!data.continuationToken);
   });
 
-  test('get worker pools - no worker pools in db', async function () {
+  test('get worker pools - no worker pools in db', async () => {
     let data = await helper.workerManager.listWorkerPools();
 
     assert.deepStrictEqual(data.workerPools, [], 'Should return an empty array of worker pools');
   });
 
-  test('get 404 status when worker pool is not present', async function () {
+  test('get 404 status when worker pool is not present', async () => {
     const workerPoolId = 'no/such';
     await assert.rejects(() => helper.workerManager.listWorkersForWorkerPool(workerPoolId),
       /Worker Pool does not exist/);
   });
 
-  test('get one worker for a given worker pool', async function () {
+  test('get one worker for a given worker pool', async () => {
     const now = new Date();
     const input = {
       workerPoolId,
@@ -868,7 +868,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function (mock, skipping) {
     assert.deepStrictEqual(data.workers, [input]);
   });
 
-  test('get many workers for a given worker pool', async function () {
+  test('get many workers for a given worker pool', async () => {
     let input = [
       {
         workerPoolId,
@@ -924,7 +924,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function (mock, skipping) {
     assert.deepStrictEqual(data.workers, input);
   });
 
-  test('get workers for a given worker pool with filters', async function () {
+  test('get workers for a given worker pool with filters', async () => {
     let input = [
       {
         workerPoolId,
@@ -971,7 +971,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function (mock, skipping) {
     assert.equal(byLc.workers[0].workerId, input[0].workerId);
   });
 
-  test('get workers for a given worker pool - no workers', async function () {
+  test('get workers for a given worker pool - no workers', async () => {
     await createWorkerPool();
     let data = await helper.workerManager.listWorkersForWorkerPool(workerPoolId);
     data.workers.forEach(worker => {
@@ -981,7 +981,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function (mock, skipping) {
     assert.deepStrictEqual(data.workers, []);
   });
 
-  test('list workers for a given worker pool and group', async function () {
+  test('list workers for a given worker pool and group', async () => {
     const workerPoolId = 'apple/apple';
     let input = ['wg-a', 'wg-b'].map(workerGroup => ({
       workerPoolId,
@@ -1020,7 +1020,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function (mock, skipping) {
     assert.deepStrictEqual(data.workers, [input[0]]);
   });
 
-  test('get a specific worker', async function () {
+  test('get a specific worker', async () => {
     const workerPoolId = 'apple/apple';
     const input = {
       workerPoolId,
@@ -1052,13 +1052,13 @@ helper.secrets.mockSuite(testing.suiteName(), [], function (mock, skipping) {
     assert.deepStrictEqual(data, expected);
   });
 
-  test('get a specific worker that does not exist', async function () {
+  test('get a specific worker that does not exist', async () => {
     const workerPoolId = 'apple/apple';
     await assert.rejects(() =>
       helper.workerManager.worker(workerPoolId, 'wg-a', 's-3434'), { statusCode: 404 });
   });
 
-  test('worker pools stats', async function () {
+  test('worker pools stats', async () => {
     const workerPoolId = 'wp/stats';
     await createWorker({
       workerPoolId,
@@ -1091,8 +1091,8 @@ helper.secrets.mockSuite(testing.suiteName(), [], function (mock, skipping) {
     assert.equal(data.workerPoolsStats[0].runningCapacity, 1);
   });
 
-  suite('worker creation / update / removal', function () {
-    test('create a worker for a worker pool that does not exist', async function () {
+  suite('worker creation / update / removal', () => {
+    test('create a worker for a worker pool that does not exist', async () => {
       await assert.rejects(() =>
         helper.workerManager.createWorker(workerPoolId, workerGroup, workerId, {
           expires: taskcluster.fromNow('1 hour'),
@@ -1100,7 +1100,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function (mock, skipping) {
         }), new RegExp(`Worker pool ${workerPoolId} does not exist`));
     });
 
-    test('create a pre-expired worker', async function () {
+    test('create a pre-expired worker', async () => {
       await createWorkerPool({});
       await assert.rejects(() =>
         helper.workerManager.createWorker(workerPoolId, workerGroup, workerId, {
@@ -1109,7 +1109,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function (mock, skipping) {
         }), /expires must be in the future/);
     });
 
-    test('create a worker for a worker pool with invalid providerId', async function () {
+    test('create a worker for a worker pool with invalid providerId', async () => {
       await createWorkerPool({ providerId: 'nosuch' });
       await assert.rejects(() =>
         helper.workerManager.createWorker(workerPoolId, workerGroup, workerId, {
@@ -1118,7 +1118,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function (mock, skipping) {
         }), /Provider nosuch for worker pool/);
     });
 
-    test('create a worker for a provider that does not want it', async function () {
+    test('create a worker for a provider that does not want it', async () => {
       await createWorkerPool({});
       await assert.rejects(() =>
         helper.workerManager.createWorker(workerPoolId, workerGroup, workerId, {
@@ -1127,7 +1127,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function (mock, skipping) {
         }), /creating workers is not supported/);
     });
 
-    test('create a worker with a too-long workerId', async function () {
+    test('create a worker with a too-long workerId', async () => {
       const longWorkerId = 'a-really-long-worker-id-123456789123456789';
       await assert.rejects(() =>
         helper.workerManager.createWorker(workerPoolId, workerGroup, longWorkerId, {
@@ -1136,7 +1136,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function (mock, skipping) {
         }), /workerId.*must match regular/);
     });
 
-    test('create a worker with a too-long workerGroup', async function () {
+    test('create a worker with a too-long workerGroup', async () => {
       const longWorkerGroup = 'a-really-long-worker-group-123456789123456789';
       await assert.rejects(() =>
         helper.workerManager.createWorker(workerPoolId, longWorkerGroup, workerId, {
@@ -1145,7 +1145,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function (mock, skipping) {
         }), /workerGroup.*must match regular/);
     });
 
-    test('create a worker with existing workerId', async function () {
+    test('create a worker with existing workerId', async () => {
       await createWorkerPool({
         providerId: 'static',
       });
@@ -1168,7 +1168,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function (mock, skipping) {
         return true;
       });
     });
-    test('create a worker for a provider that does want it', async function () {
+    test('create a worker for a provider that does want it', async () => {
       await createWorkerPool({
         providerData: { allowCreateWorker: true },
       });
@@ -1186,7 +1186,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function (mock, skipping) {
       assert.equal(worker.expires, expires.toJSON());
     });
 
-    test('update a worker for a worker pool that does not exist', async function () {
+    test('update a worker for a worker pool that does not exist', async () => {
       await assert.rejects(() =>
         helper.workerManager.updateWorker(workerPoolId, workerGroup, workerId, {
           expires: taskcluster.fromNow('1 hour'),
@@ -1194,7 +1194,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function (mock, skipping) {
         }), new RegExp(`Worker pool ${workerPoolId} does not exist`));
     });
 
-    test('update a worker for a worker pool with invalid providerId', async function () {
+    test('update a worker for a worker pool with invalid providerId', async () => {
       await createWorkerPool({ providerId: 'nosuch' });
       await assert.rejects(() =>
         helper.workerManager.updateWorker(workerPoolId, workerGroup, workerId, {
@@ -1203,7 +1203,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function (mock, skipping) {
         }), /Provider nosuch for worker pool/);
     });
 
-    test('update a worker for a provider that does not want it', async function () {
+    test('update a worker for a provider that does not want it', async () => {
       await createWorkerPool({});
       await createWorker({});
       await assert.rejects(() =>
@@ -1213,7 +1213,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function (mock, skipping) {
         }), /updating workers is not supported/);
     });
 
-    test('update a worker for a provider that wants and appreciates it', async function () {
+    test('update a worker for a provider that wants and appreciates it', async () => {
       await createWorkerPool({
         providerData: { allowUpdateWorker: true },
       });
@@ -1228,13 +1228,13 @@ helper.secrets.mockSuite(testing.suiteName(), [], function (mock, skipping) {
       assert.deepEqual(worker.capacity, 2);
     });
 
-    test('remove a worker that does not exist', async function () {
+    test('remove a worker that does not exist', async () => {
       await assert.rejects(() =>
         helper.workerManager.removeWorker(workerPoolId, workerGroup, workerId),
       /Worker not found/);
     });
 
-    test('remove a worker that has an invalid provider', async function () {
+    test('remove a worker that has an invalid provider', async () => {
       await createWorker({
         providerId: 'nosuch',
       });
@@ -1243,7 +1243,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function (mock, skipping) {
       /Provider nosuch for this worker does not exist/);
     });
 
-    test('remove a worker for a provider that does not want to', async function () {
+    test('remove a worker for a provider that does not want to', async () => {
       await createWorker({
         providerData: { allowRemoveWorker: false },
       });
@@ -1252,7 +1252,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function (mock, skipping) {
       /removing workers is not supported/);
     });
 
-    test('remove a worker for a provider that does want to', async function () {
+    test('remove a worker for a provider that does want to', async () => {
       await createWorker({
         providerData: { allowRemoveWorker: true },
       });
@@ -1262,7 +1262,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function (mock, skipping) {
     });
   });
 
-  test('Report a worker error', async function () {
+  test('Report a worker error', async () => {
     const workerPoolId = 'foobar/baz';
     const input = {
       providerId: 'testing1',
@@ -1355,7 +1355,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function (mock, skipping) {
     assert.equal(messages[0].data.launchConfigId, 'lc-id-1');
   });
 
-  test('Report a worker error, no such pool', async function () {
+  test('Report a worker error, no such pool', async () => {
     await assert.rejects(async () =>
       await helper.workerManager.reportWorkerError('no/such', {
         workerGroup: 'wg',
@@ -1369,13 +1369,13 @@ helper.secrets.mockSuite(testing.suiteName(), [], function (mock, skipping) {
     );
   });
 
-  test('get worker pool errors - no errors in db', async function () {
+  test('get worker pool errors - no errors in db', async () => {
     let data = await helper.workerManager.listWorkerPoolErrors('foobar/baz');
 
     assert.deepStrictEqual(data.workerPoolErrors, [], 'Should return an empty array of worker pool errors');
   });
 
-  test('get worker pool errors - single', async function () {
+  test('get worker pool errors - single', async () => {
     const workerPoolId = 'foobar/baz';
     const input = {
       providerId: 'testing1',
@@ -1422,7 +1422,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function (mock, skipping) {
     ]);
   });
 
-  test('get worker pool errors - query filters', async function () {
+  test('get worker pool errors - query filters', async () => {
     const workerPoolId = 'foobar/baz';
     const input = {
       providerId: 'testing1',
@@ -1468,7 +1468,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function (mock, skipping) {
 
   });
 
-  test('get worker pool errors - multiple', async function () {
+  test('get worker pool errors - multiple', async () => {
     const workerPoolId = 'foobar/baz';
     const input = {
       providerId: 'testing1',
@@ -1542,7 +1542,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function (mock, skipping) {
     ]);
   });
 
-  test('get worker pool error stats - all worker pools', async function () {
+  test('get worker pool error stats - all worker pools', async () => {
     const workerPoolId1 = 'foobar/baz1';
     const workerPoolId2 = 'foobar/baz2';
     const input = {
@@ -1607,7 +1607,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function (mock, skipping) {
     });
   });
 
-  test('get worker pool error stats - single worker pools', async function () {
+  test('get worker pool error stats - single worker pools', async () => {
     const workerPoolId1 = 'foobar/baz1';
     const workerPoolId2 = 'foobar/baz2';
     const input = {
@@ -1696,18 +1696,18 @@ helper.secrets.mockSuite(testing.suiteName(), [], function (mock, skipping) {
     emailOnError: false,
   };
 
-  test('create (google) worker pool', async function () {
+  test('create (google) worker pool', async () => {
     workerPoolCompare(workerPoolId, googleInput,
       await helper.workerManager.createWorkerPool(workerPoolId, googleInput));
   });
 
-  suite('registerWorker', function () {
+  suite('registerWorker', () => {
     const providerId = 'testing1';
     const workerGroup = 'wg';
     const workerId = 'wi';
     const workerIdentityProof = { 'token': 'tok' };
 
-    suiteSetup(function () {
+    suiteSetup(() => {
       helper.load.save();
 
       // create fake clientId / accessToken for temporary creds
@@ -1715,7 +1715,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function (mock, skipping) {
       helper.load.cfg('taskcluster.credentials.accessToken', 'fake');
     });
 
-    suiteTeardown(function () {
+    suiteTeardown(() => {
       helper.load.restore();
     });
 
@@ -1723,14 +1723,14 @@ helper.secrets.mockSuite(testing.suiteName(), [], function (mock, skipping) {
       workerPoolId, providerId, workerGroup, workerId, workerIdentityProof,
     };
 
-    test('no such workerPool', async function () {
+    test('no such workerPool', async () => {
       await assert.rejects(() => helper.workerManager.registerWorker({
         ...defaultRegisterWorker,
         workerPoolId: 'no/such',
       }), /Worker pool no\/such does not exist/);
     });
 
-    test('no such provider', async function () {
+    test('no such provider', async () => {
       const providerId = 'no-such';
       await createWorkerPool({
         providerId,
@@ -1741,7 +1741,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function (mock, skipping) {
       }), /Provider no-such does not exist/);
     });
 
-    test('provider not associated', async function () {
+    test('provider not associated', async () => {
       await createWorkerPool({
         providerId: 'testing2',
       });
@@ -1751,7 +1751,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function (mock, skipping) {
       }), /Worker pool pp\/ee not associated with provider testing1/);
     });
 
-    test('no such worker', async function () {
+    test('no such worker', async () => {
       await createWorkerPool({
       });
       await assert.rejects(() => helper.workerManager.registerWorker({
@@ -1759,7 +1759,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function (mock, skipping) {
       }), /Worker wg\/wi in worker pool pp\/ee does not exist/);
     });
 
-    test('worker requests across pools', async function () {
+    test('worker requests across pools', async () => {
       await createWorkerPool({ workerPoolId: 'ff/ee' });
       await createWorkerPool({ workerPoolId: 'ff/tt' });
       await createWorker({
@@ -1773,7 +1773,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function (mock, skipping) {
 
     });
 
-    test('worker does not have providerId', async function () {
+    test('worker does not have providerId', async () => {
       await createWorkerPool({});
       await createWorker({
         providerId: 'testing2',
@@ -1783,7 +1783,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function (mock, skipping) {
       }), /Worker wg\/wi does not have provider testing1/);
     });
 
-    test('error from prov.registerWorker', async function () {
+    test('error from prov.registerWorker', async () => {
       await createWorkerPool({});
       await createWorker({
         providerData: { failRegister: 'uhoh' },
@@ -1793,7 +1793,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function (mock, skipping) {
       }), /uhoh/);
     });
 
-    test('sweet success', async function () {
+    test('sweet success', async () => {
       await createWorkerPool({});
       await createWorker({
         providerData: {
@@ -1821,7 +1821,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function (mock, skipping) {
       assert(scopes.has(`worker-manager:reregister-worker:${workerPoolId}/${workerGroup}/${workerId}`), msg);
     });
 
-    test('registers with systemBootTime and records metrics', async function () {
+    test('registers with systemBootTime and records metrics', async () => {
       const monitor = await helper.load('monitor');
 
       // Install a fake prometheus recorder on the shared manager to capture
@@ -1868,7 +1868,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function (mock, skipping) {
       }
     });
 
-    test('sweet success for a previous providerId', async function () {
+    test('sweet success for a previous providerId', async () => {
       await createWorkerPool({
         providerId: 'testing2',
         previousProviderIds: ['testing1'],
@@ -1882,7 +1882,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function (mock, skipping) {
         `worker/${providerId}/${workerPoolId}/${workerGroup}/${workerId}`);
     });
 
-    test('[Integration] Successful registering an AWS worker', async function () {
+    test('[Integration] Successful registering an AWS worker', async () => {
       const __dirname = new URL('.', import.meta.url).pathname;
       const awsProviderId = 'aws';
       const awsWorkerIdentityProof = {
@@ -1929,13 +1929,13 @@ helper.secrets.mockSuite(testing.suiteName(), [], function (mock, skipping) {
     });
   });
 
-  suite('reregisterWorker', function () {
+  suite('reregisterWorker', () => {
     const providerId = 'testing1';
     const workerGroup = 'wg';
     const workerId = 'wi';
     const workerIdentityProof = { 'token': 'tok' };
 
-    suiteSetup(function () {
+    suiteSetup(() => {
       helper.load.save();
 
       // create fake clientId / accessToken for temporary creds
@@ -1943,7 +1943,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function (mock, skipping) {
       helper.load.cfg('taskcluster.credentials.accessToken', 'fake');
     });
 
-    suiteTeardown(function () {
+    suiteTeardown(() => {
       helper.load.restore();
     });
 
@@ -2007,7 +2007,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function (mock, skipping) {
       }
     };
 
-    test('works without reregistrationTimeout', async function () {
+    test('works without reregistrationTimeout', async () => {
       const config = {
         providerData: {
           workerConfig: {
@@ -2018,7 +2018,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function (mock, skipping) {
       await testExpires(config);
     });
 
-    test('works with reregistrationTimeout', async function () {
+    test('works with reregistrationTimeout', async () => {
       const config = {
         providerData: {
           workerConfig: {
@@ -2031,7 +2031,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function (mock, skipping) {
       await testExpires(config);
     });
 
-    test('works with terminateAfter', async function () {
+    test('works with terminateAfter', async () => {
       const config = {
         providerData: {
           workerConfig: {
@@ -2045,7 +2045,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function (mock, skipping) {
       await testExpires(config);
     });
 
-    test('throws when secret is bad', async function () {
+    test('throws when secret is bad', async () => {
       await createWorkerPool({});
       await createWorker({
         providerData: {
@@ -2074,7 +2074,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function (mock, skipping) {
       );
     });
 
-    test('throws when worker does not exist', async function () {
+    test('throws when worker does not exist', async () => {
       await createWorkerPool({});
       await createWorker({
         providerData: {
@@ -2103,7 +2103,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function (mock, skipping) {
       );
     });
 
-    test('throws when secret is not defined', async function () {
+    test('throws when secret is not defined', async () => {
       await createWorkerPool({});
       await createWorker({
         providerData: {
@@ -2133,44 +2133,44 @@ helper.secrets.mockSuite(testing.suiteName(), [], function (mock, skipping) {
     });
   });
 
-  suite('ensure 403s when required', function () {
-    test('listProviders without scopes', async function () {
+  suite('ensure 403s when required', () => {
+    test('listProviders without scopes', async () => {
       const client = new helper.WorkerManager({ rootUrl: helper.rootUrl });
       await assert.rejects(
         () => client.listProviders(),
         err => err.code === 'InsufficientScopes');
     });
-    test('workerPool without scopes', async function () {
+    test('workerPool without scopes', async () => {
       const client = new helper.WorkerManager({ rootUrl: helper.rootUrl });
       await assert.rejects(
         () => client.workerPool('aa/bb'),
         err => err.code === 'InsufficientScopes');
     });
-    test('listWorkerPools without scopes', async function () {
+    test('listWorkerPools without scopes', async () => {
       const client = new helper.WorkerManager({ rootUrl: helper.rootUrl });
       await assert.rejects(
         () => client.listWorkerPools(),
         err => err.code === 'InsufficientScopes');
     });
-    test('listWorkerPoolErrors without scopes', async function () {
+    test('listWorkerPoolErrors without scopes', async () => {
       const client = new helper.WorkerManager({ rootUrl: helper.rootUrl });
       await assert.rejects(
         () => client.listWorkerPoolErrors('aa/bb'),
         err => err.code === 'InsufficientScopes');
     });
-    test('listWorkersForWorkerPool without scopes', async function () {
+    test('listWorkersForWorkerPool without scopes', async () => {
       const client = new helper.WorkerManager({ rootUrl: helper.rootUrl });
       await assert.rejects(
         () => client.listWorkersForWorkerPool('aa/bb'),
         err => err.code === 'InsufficientScopes');
     });
-    test('listWorkersForWorkerGroup without scopes', async function () {
+    test('listWorkersForWorkerGroup without scopes', async () => {
       const client = new helper.WorkerManager({ rootUrl: helper.rootUrl });
       await assert.rejects(
         () => client.listWorkersForWorkerGroup('aa/bb', 'ff'),
         err => err.code === 'InsufficientScopes');
     });
-    test('worker without scopes', async function () {
+    test('worker without scopes', async () => {
       const client = new helper.WorkerManager({ rootUrl: helper.rootUrl });
       await assert.rejects(
         () => client.worker('aa/bb', 'ff', 'i-123'),
@@ -2178,7 +2178,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function (mock, skipping) {
     });
   });
 
-  suite('worker metadata', function () {
+  suite('worker metadata', () => {
     const makeQueueVisible = async (workerPoolId, workerGroup, workerId) => {
       // make it visible to the queue
       // we cannot directly call queue_worker_seen_with_last_date_active
@@ -2197,7 +2197,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function (mock, skipping) {
       });
     };
 
-    test('get worker/workers with queue metadata', async function () {
+    test('get worker/workers with queue metadata', async () => {
       await createWorkerPool({});
       await createWorker({});
 
@@ -2216,7 +2216,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function (mock, skipping) {
       assert.deepEqual(res.quarantineDetails, []);
     });
 
-    test('get workers with queue metadata', async function () {
+    test('get workers with queue metadata', async () => {
       const wpId = 'tt/cc2';
       await createWorkerPool({ workerPoolId: wpId });
       await createWorker({
@@ -2236,7 +2236,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function (mock, skipping) {
     });
   });
 
-  suite('worker metadata', function () {
+  suite('worker metadata', () => {
     const makeQueueVisible = async (wp, wg, wid) => {
       // we cannot directly call queue_worker_seen_with_last_date_active
       // because worker-manager client doesn't have write access to that tables
@@ -2254,7 +2254,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function (mock, skipping) {
       });
     };
 
-    test('get worker with queue metadata', async function () {
+    test('get worker with queue metadata', async () => {
       const workerPoolId2 = 'pp/ee2';
       const workerGroup2 = 'wg2';
       const workerId2 = 'wi2';
@@ -2277,7 +2277,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function (mock, skipping) {
       assert.deepEqual(res.quarantineDetails, []);
     });
 
-    test('get workers with queue metadata', async function () {
+    test('get workers with queue metadata', async () => {
       const workerPoolId3 = 'pp/ee3';
       const workerGroup3 = 'wg3';
       const workerId3 = 'wi3';
@@ -2295,7 +2295,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function (mock, skipping) {
       assert.equal(workers[0].workerId, workerId3);
     });
 
-    test('get workers with queue metadata and filters', async function () {
+    test('get workers with queue metadata and filters', async () => {
       const workerPoolId4 = 'pp/ee4';
       const workerGroup4 = 'wg4';
       const workerId4 = 'wi4';
@@ -2339,8 +2339,8 @@ helper.secrets.mockSuite(testing.suiteName(), [], function (mock, skipping) {
     });
   });
 
-  suite('shouldWorkerTerminate', function() {
-    test('worker marked terminate: true returns true', async function() {
+  suite('shouldWorkerTerminate', () => {
+    test('worker marked terminate: true returns true', async () => {
       await createWorkerPool();
       await createWorker({
         providerData: {
@@ -2356,7 +2356,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function (mock, skipping) {
       assert.strictEqual(result.reason, 'over capacity');
     });
 
-    test('worker marked terminate: false returns false', async function() {
+    test('worker marked terminate: false returns false', async () => {
       await createWorkerPool();
       await createWorker({
         providerData: {
@@ -2372,7 +2372,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function (mock, skipping) {
       assert.strictEqual(result.reason, 'needed');
     });
 
-    test('no decision yet returns terminate: false', async function() {
+    test('no decision yet returns terminate: false', async () => {
       await createWorkerPool();
       await createWorker();
       const result = await helper.workerManager.shouldWorkerTerminate(workerPoolId, workerGroup, workerId);
@@ -2380,7 +2380,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function (mock, skipping) {
       assert.strictEqual(result.reason, 'none');
     });
 
-    test('non-existent worker returns 404', async function() {
+    test('non-existent worker returns 404', async () => {
       await assert.rejects(
         () => helper.workerManager.shouldWorkerTerminate('no/such', 'wg', 'wi'),
         err => err.statusCode === 404,

--- a/services/worker-manager/test/cloudapi_test.js
+++ b/services/worker-manager/test/cloudapi_test.js
@@ -6,7 +6,7 @@ import { CloudAPI } from '../src/providers/cloudapi.js';
 
 const sleep = (ms) => new Promise(resolve => setTimeout(resolve, ms));
 
-suite(testing.suiteName(), function() {
+suite(testing.suiteName(), () => {
   let cloud;
 
   const initCloudApi = async (options = {}) => {
@@ -42,7 +42,7 @@ suite(testing.suiteName(), function() {
     cloud = await initCloudApi();
   });
 
-  test('non existing queue', async function() {
+  test('non existing queue', async () => {
     try {
       await cloud.enqueue('nonexisting', () => {});
     } catch (err) {
@@ -52,12 +52,12 @@ suite(testing.suiteName(), function() {
     throw new Error('should have thrown an error');
   });
 
-  test('simple', async function() {
+  test('simple', async () => {
     const result = await cloud.enqueue('query', () => 5);
     assert.equal(result, 5);
   });
 
-  test('one 500', async function() {
+  test('one 500', async () => {
     const remote = sinon.stub();
     remote.onCall(0).throws({ code: 500 });
     remote.onCall(1).returns(10);
@@ -65,7 +65,7 @@ suite(testing.suiteName(), function() {
     assert.equal(result, 10);
     assert.equal(remote.callCount, 2);
   });
-  test('multiple 500', async function() {
+  test('multiple 500', async () => {
     const remote = sinon.stub();
     remote.onCall(0).throws({ code: 500 });
     remote.onCall(1).throws({ code: 520 });
@@ -75,7 +75,7 @@ suite(testing.suiteName(), function() {
     assert.equal(result, 15);
     assert.equal(remote.callCount, 4);
   });
-  test('500s forever should throw', async function() {
+  test('500s forever should throw', async () => {
     const remote = sinon.stub();
     remote.throws({ code: 500 });
 
@@ -89,7 +89,7 @@ suite(testing.suiteName(), function() {
     throw new Error('should have thrown an error');
   });
 
-  test('operations timing out', async function() {
+  test('operations timing out', async () => {
     const cloudWithTimeout = await initCloudApi({ timeout: 1 });
     const remote = sinon.stub();
     remote.onCall(0).resolves(sleep(5));
@@ -103,13 +103,13 @@ suite(testing.suiteName(), function() {
     assert.equal(remote.callCount, 1);
   });
 
-  test('metrics not counted if not enabled', async function() {
+  test('metrics not counted if not enabled', async () => {
     cloud = await initCloudApi({ collectMetrics: false });
     await cloud.enqueue('query', () => 5);
     assert.equal(cloud.metrics.total, 0);
   });
 
-  test('metrics should be collected and logged', async function () {
+  test('metrics should be collected and logged', async () => {
     const monitor = await helper.load('monitor');
     cloud = await initCloudApi({ collectMetrics: true, monitor });
 

--- a/services/worker-manager/test/data_test.js
+++ b/services/worker-manager/test/data_test.js
@@ -4,7 +4,7 @@ import testing from '@taskcluster/lib-testing';
 import taskcluster from '@taskcluster/client';
 import { Worker, WorkerPoolError, WorkerPoolStats } from '../src/data.js';
 
-helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
+helper.secrets.mockSuite(testing.suiteName(), [], (mock, skipping) => {
   helper.withDb(mock, skipping);
   helper.resetTables(mock, skipping);
 
@@ -21,7 +21,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
    * 17:55:16 worker is terminated for `terminateAfter` reasons
    *          (terminateAfter being set to exactly 30 minutes after requested)
    */
-  test('worker lifecycle data race', async function() {
+  test('worker lifecycle data race', async () => {
     const origTerminateAfter = Date.now() + 1800000;
     // First create a "requested worker"
     let w = Worker.fromApi({
@@ -63,7 +63,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
     assert.equal(now.getTime() + 50000000, w.providerData.terminateAfter);
   });
 
-  test('worker pool error expire', async function () {
+  test('worker pool error expire', async () => {
     const err1 = WorkerPoolError.fromApi({
       errorId: 'e/id',
       workerPoolId: 'wp/id',
@@ -97,7 +97,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
     assert(!removedError2);
   });
 
-  test('WorkerPoolStats', async function () {
+  test('WorkerPoolStats', async () => {
     const wps = new WorkerPoolStats('wp/id', {});
 
     wps.updateFromWorker(new Worker({
@@ -135,7 +135,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
     });
   });
 
-  test('WorkerPoolStats tracks capacity by workerGroup', async function () {
+  test('WorkerPoolStats tracks capacity by workerGroup', async () => {
     const wps = new WorkerPoolStats('wp/id', {});
 
     // Add workers in us-west-2
@@ -190,7 +190,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
     });
   });
 
-  test('WorkerPoolStats workerGroup with quarantined workers', async function () {
+  test('WorkerPoolStats workerGroup with quarantined workers', async () => {
     const wps = new WorkerPoolStats('wp/id', {});
 
     // Add a quarantined worker
@@ -222,8 +222,8 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
     });
   });
 
-  suite('Worker.updateInstanceFields', function() {
-    test('preserves queue fields when undefined', function() {
+  suite('Worker.updateInstanceFields', () => {
+    test('preserves queue fields when undefined', () => {
       const worker = Worker.fromApi({
         workerPoolId: 'test/pool',
         workerGroup: 'test-group',
@@ -257,7 +257,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       assert.deepEqual(worker.providerData, { updated: true });
     });
 
-    test('allows explicit null for queue fields', function() {
+    test('allows explicit null for queue fields', () => {
       const worker = Worker.fromApi({});
       worker.firstClaim = new Date('2025-01-01');
 

--- a/services/worker-manager/test/estimator_test.js
+++ b/services/worker-manager/test/estimator_test.js
@@ -2,18 +2,18 @@ import assert from 'node:assert';
 import helper from './helper.js';
 import testing from '@taskcluster/lib-testing';
 
-helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
+helper.secrets.mockSuite(testing.suiteName(), [], (mock, skipping) => {
   helper.withFakeQueue(mock, skipping);
   helper.withFakeNotify(mock, skipping);
 
   let estimator, monitor;
 
-  setup(async function() {
+  setup(async () => {
     estimator = await helper.load('estimator');
     monitor = await helper.load('monitor');
   });
 
-  test('empty estimation', async function() {
+  test('empty estimation', async () => {
     const workerInfo = {
       existingCapacity: 0,
       requestedCapacity: 0,
@@ -33,7 +33,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
     assert(monitor.manager.messages.some(({ Type, Severity }) => Type === 'simple-estimate' && Severity === 5));
   });
 
-  test('single estimation', async function() {
+  test('single estimation', async () => {
     const workerInfo = {
       existingCapacity: 0,
       requestedCapacity: 0,
@@ -52,7 +52,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
     assert(monitor.manager.messages.some(({ Type, Severity }) => Type === 'simple-estimate' && Severity === 5));
   });
 
-  test('satisfied estimation', async function() {
+  test('satisfied estimation', async () => {
     const workerInfo = {
       existingCapacity: 0,
       requestedCapacity: 1,
@@ -71,7 +71,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
     assert(monitor.manager.messages.some(({ Type, Severity }) => Type === 'simple-estimate' && Severity === 5));
   });
 
-  test('scaling ratio 1:1 scale-up', async function() {
+  test('scaling ratio 1:1 scale-up', async () => {
     const workerInfo = {
       existingCapacity: 0,
       requestedCapacity: 0,
@@ -92,7 +92,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
     assert(monitor.manager.messages.some(({ Type, Severity }) => Type === 'simple-estimate' && Severity === 5));
   });
 
-  test('scaling ratio 1:1 scale-up with lesser max capacity', async function() {
+  test('scaling ratio 1:1 scale-up with lesser max capacity', async () => {
     const workerInfo = {
       existingCapacity: 0,
       requestedCapacity: 0,
@@ -113,7 +113,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
     assert(monitor.manager.messages.some(({ Type, Severity }) => Type === 'simple-estimate' && Severity === 5));
   });
 
-  test('scaling ratio 1:2 scale-up', async function() {
+  test('scaling ratio 1:2 scale-up', async () => {
     const workerInfo = {
       existingCapacity: 0,
       requestedCapacity: 0,
@@ -134,7 +134,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
     assert(monitor.manager.messages.some(({ Type, Severity }) => Type === 'simple-estimate' && Severity === 5));
   });
 
-  test('scaling ratio 1:2 scale-up with existing capacity', async function() {
+  test('scaling ratio 1:2 scale-up with existing capacity', async () => {
     const workerInfo = {
       existingCapacity: 25,
       requestedCapacity: 0,
@@ -156,7 +156,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
     assert(monitor.manager.messages.some(({ Type, Severity }) => Type === 'simple-estimate' && Severity === 5));
   });
 
-  test('over-satisfied estimation', async function() {
+  test('over-satisfied estimation', async () => {
     const workerInfo = {
       existingCapacity: 50,
       requestedCapacity: 0,
@@ -182,7 +182,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
     monitor.manager.reset();
   });
 
-  test('over-satisfied estimation (false positive is not raised)', async function() {
+  test('over-satisfied estimation (false positive is not raised)', async () => {
     const workerInfo = {
       existingCapacity: 5,
       requestedCapacity: 0,
@@ -202,7 +202,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
     monitor.manager.reset();
   });
 
-  test('empty estimation', async function () {
+  test('empty estimation', async () => {
     const workerInfo = {
       existingCapacity: 0,
       requestedCapacity: 0,
@@ -222,7 +222,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
     assert(monitor.manager.messages.some(({ Type, Severity }) => Type === 'simple-estimate' && Severity === 5));
   });
 
-  test('stopping capacity non zero', async function () {
+  test('stopping capacity non zero', async () => {
     const workerInfo = {
       existingCapacity: 10,
       requestedCapacity: 10,
@@ -241,7 +241,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
     assert.strictEqual(monitor.manager.messages.length, 1);
     assert(monitor.manager.messages.some(({ Type, Severity }) => Type === 'simple-estimate' && Severity === 5));
   });
-  test('stopping capacity exceeds max capacity', async function () {
+  test('stopping capacity exceeds max capacity', async () => {
     const workerInfo = {
       existingCapacity: 10,
       requestedCapacity: 10,
@@ -260,7 +260,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
     assert.strictEqual(monitor.manager.messages.length, 1);
     assert(monitor.manager.messages.some(({ Type, Severity }) => Type === 'simple-estimate' && Severity === 5));
   });
-  test('stopping + requested capacity exceeds pending', async function () {
+  test('stopping + requested capacity exceeds pending', async () => {
     const workerInfo = {
       existingCapacity: 0,
       requestedCapacity: 10,
@@ -281,7 +281,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
     assert.strictEqual(monitor.manager.messages.length, 1);
     assert(monitor.manager.messages.some(({ Type, Severity }) => Type === 'simple-estimate' && Severity === 5));
   });
-  test('idle capacity', async function () {
+  test('idle capacity', async () => {
     const workerInfo = {
       existingCapacity: 10,
     };
@@ -316,8 +316,8 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
     }
   });
 
-  suite('desiredCapacity', function() {
-    test('returns minCapacity when no pending tasks', async function() {
+  suite('desiredCapacity', () => {
+    test('returns minCapacity when no pending tasks', async () => {
       helper.queue.setPending('foo/bar', 0);
       helper.queue.setClaimed('foo/bar', 0);
       const result = await estimator.desiredCapacity({
@@ -330,7 +330,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       assert.strictEqual(result, 5);
     });
 
-    test('respects maxCapacity ceiling', async function() {
+    test('respects maxCapacity ceiling', async () => {
       helper.queue.setPending('foo/bar', 200);
       helper.queue.setClaimed('foo/bar', 0);
       const result = await estimator.desiredCapacity({
@@ -343,7 +343,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       assert.strictEqual(result, 50);
     });
 
-    test('accounts for existing capacity and pending tasks', async function() {
+    test('accounts for existing capacity and pending tasks', async () => {
       helper.queue.setPending('foo/bar', 20);
       helper.queue.setClaimed('foo/bar', 5);
       const result = await estimator.desiredCapacity({
@@ -359,7 +359,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       assert.strictEqual(result, 25);
     });
 
-    test('includes stopping capacity in total', async function() {
+    test('includes stopping capacity in total', async () => {
       helper.queue.setPending('foo/bar', 10);
       helper.queue.setClaimed('foo/bar', 0);
       const result = await estimator.desiredCapacity({
@@ -376,7 +376,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       assert.strictEqual(result, 20);
     });
 
-    test('applies scaling ratio', async function() {
+    test('applies scaling ratio', async () => {
       helper.queue.setPending('foo/bar', 100);
       helper.queue.setClaimed('foo/bar', 0);
       const result = await estimator.desiredCapacity({
@@ -391,8 +391,8 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
     });
   });
 
-  suite('targetCapacity', function() {
-    test('returns minCapacity when no tasks', async function() {
+  suite('targetCapacity', () => {
+    test('returns minCapacity when no tasks', async () => {
       helper.queue.setPending('foo/bar', 0);
       helper.queue.setClaimed('foo/bar', 0);
       const result = await estimator.targetCapacity({
@@ -401,7 +401,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       assert.strictEqual(result, 3);
     });
 
-    test('counts both pending and claimed tasks as demand', async function() {
+    test('counts both pending and claimed tasks as demand', async () => {
       helper.queue.setPending('foo/bar', 2);
       helper.queue.setClaimed('foo/bar', 3);
       const result = await estimator.targetCapacity({
@@ -411,7 +411,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       assert.strictEqual(result, 5);
     });
 
-    test('respects maxCapacity ceiling', async function() {
+    test('respects maxCapacity ceiling', async () => {
       helper.queue.setPending('foo/bar', 50);
       helper.queue.setClaimed('foo/bar', 50);
       const result = await estimator.targetCapacity({
@@ -420,7 +420,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       assert.strictEqual(result, 10);
     });
 
-    test('applies scaling ratio', async function() {
+    test('applies scaling ratio', async () => {
       helper.queue.setPending('foo/bar', 10);
       helper.queue.setClaimed('foo/bar', 0);
       const result = await estimator.targetCapacity({
@@ -430,7 +430,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       assert.strictEqual(result, 5);
     });
 
-    test('minCapacity wins over zero demand', async function() {
+    test('minCapacity wins over zero demand', async () => {
       helper.queue.setPending('foo/bar', 0);
       helper.queue.setClaimed('foo/bar', 0);
       const result = await estimator.targetCapacity({

--- a/services/worker-manager/test/expiration_test.js
+++ b/services/worker-manager/test/expiration_test.js
@@ -4,7 +4,7 @@ import testing from '@taskcluster/lib-testing';
 import { WorkerPool, WorkerPoolError, Worker } from '../src/data.js';
 import taskcluster from '@taskcluster/client';
 
-helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
+helper.secrets.mockSuite(testing.suiteName(), [], (mock, skipping) => {
   helper.withDb(mock, skipping);
   helper.resetTables(mock, skipping);
 
@@ -33,40 +33,40 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
     await worker.create(helper.db);
   };
 
-  suite('expireWorkerPools', function() {
+  suite('expireWorkerPools', () => {
     const checkWP = async workerPoolId => {
       return WorkerPool.fromDbRows(
         await helper.db.fns.get_worker_pool_with_launch_configs(workerPoolId));
     };
 
-    setup(function() {
+    setup(() => {
       helper.load.remove('expireWorkerPools');
     });
 
-    test('scan of empty set of worker pools', async function() {
+    test('scan of empty set of worker pools', async () => {
       await helper.load('expireWorkerPools');
     });
 
-    test('worker pool with an active providerId', async function() {
+    test('worker pool with an active providerId', async () => {
       await makeWP({ workerPoolId: 'pp/wt', providerId: 'testing' });
       await helper.load('expireWorkerPools');
       assert(await checkWP('pp/wt'));
     });
 
-    test('worker pool with null-provider but previousProviderIds', async function() {
+    test('worker pool with null-provider but previousProviderIds', async () => {
       await makeWP({ workerPoolId: 'pp/wt', providerId: 'null-provider', previousProviderIds: ['something'] });
       await helper.load('expireWorkerPools');
       assert(await checkWP('pp/wt'));
     });
 
-    test('worker pool with null-provider and empty previousProviderIds', async function() {
+    test('worker pool with null-provider and empty previousProviderIds', async () => {
       await makeWP({ workerPoolId: 'pp/wt', providerId: 'null-provider', previousProviderIds: [] });
       await helper.load('expireWorkerPools');
       assert.equal(await checkWP('pp/wt'), undefined);
     });
   });
 
-  suite('expireLaunchConfigs', function () {
+  suite('expireLaunchConfigs', () => {
     const getWPLCs = async (workerPoolId, providerId) => {
       return helper.db.fns.get_worker_pool_launch_configs(workerPoolId, null, null, null);
     };
@@ -82,15 +82,15 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
         false);
     };
 
-    setup(function() {
+    setup(() => {
       helper.load.remove('expireLaunchConfigs');
     });
 
-    test('nothing to remove', async function() {
+    test('nothing to remove', async () => {
       await helper.load('expireLaunchConfigs');
     });
 
-    test('does not remove active launch configs', async function () {
+    test('does not remove active launch configs', async () => {
       const workerPoolId = 'pp/wt';
       const providerId = 'testing';
 
@@ -113,7 +113,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       const configs2 = (await getWPLCs(workerPoolId, providerId)).map(c => c.configuration).sort();
       assert.deepEqual(configs2, ['lc3', 'lc4']);
     });
-    test('does not remove archived launch configs with workers', async function () {
+    test('does not remove archived launch configs with workers', async () => {
       const workerPoolId = 'pp/wt';
       const providerId = 'testing';
 
@@ -134,33 +134,33 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
     });
   });
 
-  suite('expireWorkers', function() {
+  suite('expireWorkers', () => {
     const checkWorker = async (workerPoolId = 'pp/wt', workerGroup = 'wg', workerId = 'wid') => {
       return await Worker.get(helper.db, { workerPoolId, workerGroup, workerId });
     };
 
-    setup(function() {
+    setup(() => {
       helper.load.remove('expireWorkers');
     });
 
-    test('scan of empty set of workers', async function() {
+    test('scan of empty set of workers', async () => {
       await helper.load('expireWorkers');
     });
 
-    test('active worker', async function() {
+    test('active worker', async () => {
       await makeWorker({ expires: taskcluster.fromNow('1 hour') });
       await helper.load('expireWorkers');
       assert(await checkWorker());
     });
 
-    test('expired worker', async function() {
+    test('expired worker', async () => {
       await makeWorker({ expires: taskcluster.fromNow('-1 hour') });
       await helper.load('expireWorkers');
       assert.equal(await checkWorker(), undefined);
     });
   });
 
-  suite('expireErrors', function() {
+  suite('expireErrors', () => {
     const eid = taskcluster.slugid();
     const makeWPE = async values => {
       const now = new Date();
@@ -187,28 +187,28 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       await helper.load('expireErrors');
     };
 
-    setup(function() {
+    setup(() => {
       helper.load.remove('expireErrors');
     });
 
-    test('expire an empty set of errors', async function() {
+    test('expire an empty set of errors', async () => {
       await helper.load('expireErrors');
       assert.equal((await checkWPE()).length, 0);
     });
 
-    test('active error', async function() {
+    test('active error', async () => {
       await makeWPE({ reported: taskcluster.fromNow('10 hours') });
       await expireWithRetentionDays(1);
       assert.equal((await checkWPE()).length, 1);
     });
 
-    test('old error', async function() {
+    test('old error', async () => {
       await makeWPE({ reported: taskcluster.fromNow('-3 days') });
       await expireWithRetentionDays(2);
       assert.equal((await checkWPE()).length, 0);
     });
 
-    test('old error', async function() {
+    test('old error', async () => {
       await makeWPE({ reported: taskcluster.fromNow('-3 days') });
       await expireWithRetentionDays(2);
       assert.equal((await checkWPE()).length, 0);

--- a/services/worker-manager/test/fakes/google.js
+++ b/services/worker-manager/test/fakes/google.js
@@ -32,9 +32,7 @@ export class FakeGoogle extends FakeCloud {
     // OAuth2 must be a constructor, so we have to use `function` here, but
     // we want to refer to the FakeGoogle instance.
     const self = this;
-    google.auth.OAuth2 = function() {
-      return self.oauth2;
-    };
+    google.auth.OAuth2 = function () { return self.oauth2; };
 
     this.sinon.stub(google, 'compute').callsFake(({ version, auth }) => {
       assert.equal(version, 'v1');

--- a/services/worker-manager/test/helper.js
+++ b/services/worker-manager/test/helper.js
@@ -47,7 +47,7 @@ helper.withProviders = (mock, skipping) => {
 helper.withProvisioner = (mock, skipping) => {
   let provisioner;
 
-  suiteSetup(async function() {
+  suiteSetup(async () => {
     if (skipping()) {
       return;
     }
@@ -70,7 +70,7 @@ helper.withProvisioner = (mock, skipping) => {
     };
   });
 
-  teardown(function() {
+  teardown(() => {
     if (provisioner) {
       throw new Error('Must call terminateProvisioner if you have started it');
     }
@@ -80,7 +80,7 @@ helper.withProvisioner = (mock, skipping) => {
 helper.withWorkerScanner = (mock, skipping) => {
   let scanner;
 
-  suiteSetup(async function() {
+  suiteSetup(async () => {
     if (skipping()) {
       return;
     }
@@ -100,7 +100,7 @@ helper.withWorkerScanner = (mock, skipping) => {
     };
   });
 
-  teardown(function() {
+  teardown(() => {
     if (scanner) {
       throw new Error('Must call terminateWorkerScanner if you have started it');
     }
@@ -115,7 +115,7 @@ helper.withWorkerScanner = (mock, skipping) => {
  * The component is available at `helper.queue`.
  */
 helper.withFakeQueue = (mock, skipping) => {
-  suiteSetup(function() {
+  suiteSetup(() => {
     if (skipping()) {
       return;
     }
@@ -135,7 +135,7 @@ helper.withFakeQueue = (mock, skipping) => {
  * We consider any emailing to be test-failing at the moment
  */
 helper.withFakeNotify = (mock, skipping) => {
-  suiteSetup(function() {
+  suiteSetup(() => {
     if (skipping()) {
       return;
     }
@@ -143,7 +143,7 @@ helper.withFakeNotify = (mock, skipping) => {
     helper.notify = stubbedNotify();
     helper.load.inject('notify', helper.notify);
 
-    setup(async function() {
+    setup(async () => {
       helper.notify.emails.splice(0);
     });
   });
@@ -152,7 +152,7 @@ helper.withFakeNotify = (mock, skipping) => {
 helper.withServer = (mock, skipping) => {
   let webServer;
 
-  suiteSetup(async function() {
+  suiteSetup(async () => {
     if (skipping()) {
       return;
     }
@@ -183,7 +183,7 @@ helper.withServer = (mock, skipping) => {
     webServer = await load('server');
   });
 
-  suiteTeardown(async function() {
+  suiteTeardown(async () => {
     if (webServer) {
       await webServer.terminate();
       webServer = null;
@@ -218,11 +218,11 @@ const stubbedQueue = () => {
     },
   });
 
-  queue.setPending = function(taskQueueId, pending) {
+  queue.setPending = (taskQueueId, pending) => {
     pendingCounts[taskQueueId] = pending;
   };
 
-  queue.setClaimed = function(taskQueueId, claimed) {
+  queue.setClaimed = (taskQueueId, claimed) => {
     claimedCounts[taskQueueId] = claimed;
   };
 
@@ -267,7 +267,7 @@ helper.getWorkers = async () =>
     }));
 
 helper.resetTables = (mock, skipping) => {
-  setup('reset tables', async function() {
+  setup('reset tables', async () => {
     await testing.resetTables({ tableNames: [
       'workers',
       'worker_pools',

--- a/services/worker-manager/test/launch_config_selector_test.js
+++ b/services/worker-manager/test/launch_config_selector_test.js
@@ -3,7 +3,7 @@ import helper from './helper.js';
 import testing from '@taskcluster/lib-testing';
 import { WorkerPoolStats } from '../src/data.js';
 
-helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
+helper.secrets.mockSuite(testing.suiteName(), [], (mock, skipping) => {
   helper.withDb(mock, skipping);
   helper.withPulse(mock, skipping);
   helper.withProviders(mock, skipping);
@@ -64,17 +64,17 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
     monitor.manager.reset();
   };
 
-  setup(async function() {
+  setup(async () => {
     launchConfigSelector = await helper.load('launchConfigSelector');
   });
 
-  test('missing launch configs', async function() {
+  test('missing launch configs', async () => {
     const wp = await createWorkerPool();
     const wrc = await launchConfigSelector.forWorkerPool(wp);
     assert.deepEqual(wrc.getAll(), []);
   });
 
-  test('equal weights launch configs', async function () {
+  test('equal weights launch configs', async () => {
     const wp = await createWorkerPool([
       genAwsLaunchConfig({ launchConfigId: 'lc1', initialWeight: 1 }),
       genAwsLaunchConfig({ launchConfigId: 'lc2', initialWeight: 1 }),
@@ -88,7 +88,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
     await assertDebugMessage(wp.workerPoolId, { lc1: 1, lc2: 1 }, { lc1: maxCapacity, lc2: maxCapacity });
   });
 
-  test('zero weights launch configs will not be used', async function () {
+  test('zero weights launch configs will not be used', async () => {
     const wp = await createWorkerPool([
       genAwsLaunchConfig({ launchConfigId: 'lc1', initialWeight: 1 }),
       genAwsLaunchConfig({ launchConfigId: 'lc2', initialWeight: 0 }),
@@ -102,7 +102,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
     await assertDebugMessage(wp.workerPoolId, { lc1: 1, lc2: 0 }, { lc1: maxCapacity, lc2: maxCapacity });
   });
 
-  test('respects weights in random selection', async function () {
+  test('respects weights in random selection', async () => {
     const wp = await createWorkerPool([
       genAwsLaunchConfig({ launchConfigId: 'lc1', initialWeight: 1 }),
       genAwsLaunchConfig({ launchConfigId: 'lc2', initialWeight: 0.5 }),
@@ -118,7 +118,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       { lc1: maxCapacity, lc2: maxCapacity, lc3: maxCapacity });
   });
 
-  test('selectCapacity', async function () {
+  test('selectCapacity', async () => {
     const wp = await createWorkerPool([
       genAwsLaunchConfig({ launchConfigId: 'lc1', initialWeight: 1, capacityPerInstance: 1 }),
       genAwsLaunchConfig({ launchConfigId: 'lc2', initialWeight: 1, capacityPerInstance: 1 }),
@@ -130,7 +130,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
     assert.equal(wrc.selectCapacity(15).length, 15);
   });
 
-  test('selectCapacity with special case', async function () {
+  test('selectCapacity with special case', async () => {
     const wp = await createWorkerPool([
       genAwsLaunchConfig({ launchConfigId: 'lc1', initialWeight: 1, capacityPerInstance: 2 }),
     ]);
@@ -139,7 +139,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
     assert.equal(wrc.selectCapacity(5).length, 3);
   });
 
-  test('selectCapacity with wm.capacityPerInstance > 1', async function () {
+  test('selectCapacity with wm.capacityPerInstance > 1', async () => {
     const wp = await createWorkerPool([
       genAwsLaunchConfig({ launchConfigId: 'lc1', initialWeight: 1, capacityPerInstance: 3 }),
       genAwsLaunchConfig({ launchConfigId: 'lc2', initialWeight: 1, capacityPerInstance: 3 }),
@@ -148,7 +148,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
     assert.equal(wrc.selectCapacity(6).length, 2);
   });
 
-  test('selectCapacity with capacityPerInstance > 1', async function () {
+  test('selectCapacity with capacityPerInstance > 1', async () => {
     const wp = await createWorkerPool([
       {
         ...genAwsLaunchConfig({ launchConfigId: 'lc1', initialWeight: 1 }),
@@ -163,7 +163,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
     assert.equal(wrc.selectCapacity(6).length, 2);
   });
 
-  test('using workerPoolStats to respect maxCapacity per LC', async function () {
+  test('using workerPoolStats to respect maxCapacity per LC', async () => {
     const wp = await createWorkerPool([
       genAwsLaunchConfig({ launchConfigId: 'lc1', initialWeight: 1, maxCapacity: 10 }),
       genAwsLaunchConfig({ launchConfigId: 'lc2', initialWeight: 1, maxCapacity: 10 }),
@@ -182,7 +182,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       { lc1: 0, lc2: 5, lc3: 0 });
   });
 
-  test('using workerPoolStats to respect errors by LC', async function () {
+  test('using workerPoolStats to respect errors by LC', async () => {
     const wp = await createWorkerPool([
       genAwsLaunchConfig({ launchConfigId: 'lc1', initialWeight: 1 }),
       genAwsLaunchConfig({ launchConfigId: 'lc2', initialWeight: 1 }),
@@ -198,7 +198,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
     await assertDebugMessage(wp.workerPoolId, { lc1: 0, lc2: 1 }, { lc1: maxCapacity, lc2: maxCapacity });
   });
 
-  test('select capacity should respect individual max capacity', async function () {
+  test('select capacity should respect individual max capacity', async () => {
     const wp = await createWorkerPool([
       genAwsLaunchConfig({ launchConfigId: 'lc1', initialWeight: 1, maxCapacity: 1 }),
       genAwsLaunchConfig({ launchConfigId: 'lc2', initialWeight: 1, maxCapacity: 2 }),
@@ -215,7 +215,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
     await assertDebugMessage(wp.workerPoolId, { lc1: 1, lc2: 1, lc3: 1 }, { lc1: 1, lc2: 2, lc3: maxCapacity });
   });
 
-  test('select capacity should consider capacityPerInstance', async function () {
+  test('select capacity should consider capacityPerInstance', async () => {
     const wp = await createWorkerPool([
       genAwsLaunchConfig({ launchConfigId: 'lc1', initialWeight: 1, capacityPerInstance: 5 }),
       genAwsLaunchConfig({ launchConfigId: 'lc2', initialWeight: 1, capacityPerInstance: 5 }),
@@ -228,7 +228,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
     assert.equal(wrc.selectCapacity(25).length, 5);
   });
 
-  test('single LC with negative weight due to errors still provisions when it has capacity', async function() {
+  test('single LC with negative weight due to errors still provisions when it has capacity', async () => {
     const wp = await createWorkerPool([
       genAwsLaunchConfig({ launchConfigId: 'lc1', initialWeight: 1, maxCapacity: 100 }),
     ]);

--- a/services/worker-manager/test/provider_aws_test.js
+++ b/services/worker-manager/test/provider_aws_test.js
@@ -12,7 +12,7 @@ import { FakeEC2 } from './fakes/index.js';
 
 const __dirname = new URL('.', import.meta.url).pathname;
 
-helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
+helper.secrets.mockSuite(testing.suiteName(), [], (mock, skipping) => {
   helper.withDb(mock, skipping);
   helper.withPulse(mock, skipping);
   helper.withFakeQueue(mock, skipping);
@@ -63,7 +63,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
   const fake = new FakeEC2();
   fake.forSuite();
 
-  setup(async function() {
+  setup(async () => {
     provider = new AwsProvider({
       providerId,
       notify: await helper.load('notify'),
@@ -126,9 +126,9 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
     assert.equal(tag.Value, Value);
   };
 
-  suite('AWS provider - provision', function() {
+  suite('AWS provider - provision', () => {
     const provisionTest = (name, { config, expectedWorkers }, check) => {
-      test(name, async function() {
+      test(name, async () => {
         const workerPool = await makeWorkerPool({ config });
         const workerPoolStats = new WorkerPoolStats('wpid');
         await provider.provision({ workerPool, workerPoolStats });
@@ -153,7 +153,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
         },
       },
       expectedWorkers: 0,
-    }, async function(workers) {
+    }, async (workers) => {
       assert.equal(workers.length, 0);
     });
 
@@ -168,7 +168,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
         },
       },
       expectedWorkers: 1,
-    }, async function(workers) {
+    }, async (workers) => {
       const now = Date.now();
       workers.forEach(w => {
         assert.strictEqual(w.workerPoolId, workerPoolId, 'Worker was created for a wrong worker pool');
@@ -213,7 +213,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       },
       // capacity 34 at 6 per instance should be 6 instances..
       expectedWorkers: 6,
-    }, async function(workers) {
+    }, async (workers) => {
       // spawn two each in three launchConfigs; spawning one each would only get us 5 instances since there
       // are only 5 launchConfigs
       assert.deepEqual(fake.rgn('us-west-2').runInstancesCalls.map(({ MinCount }) => MinCount), [2, 2, 2]);
@@ -238,7 +238,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
           scalingRatio: 1,
         },
         expectedWorkers: 1,
-      }, async function(workers) {
+      }, async (workers) => {
         assert.equal(fake.rgn('us-west-2').runInstancesCalls.length, 1);
         assertHasTag(fake.rgn('us-west-2').runInstancesCalls[0], ResourceType, 'mytag', 'testy');
         assertHasTag(fake.rgn('us-west-2').runInstancesCalls[0], 'instance', 'CreatedBy', 'taskcluster-wm-aws');
@@ -270,7 +270,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
         scalingRatio: 1,
       },
       expectedWorkers: 1,
-    }, async function(workers) {
+    }, async (workers) => {
       const decoded = JSON.parse(Buffer.from(
         fake.rgn('us-west-2').runInstancesCalls[0].UserData,
         'base64',
@@ -288,9 +288,9 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
     });
   });
 
-  suite('[UNIT] AWS provider - registerWorker', function() {
+  suite('[UNIT] AWS provider - registerWorker', () => {
 
-    test('registerWorker - verifyInstanceIdentityDocument - document is not string', async function() {
+    test('registerWorker - verifyInstanceIdentityDocument - document is not string', async () => {
       const workerPool = await makeWorkerPool();
       const workerIdentityProof = {
         "document": { 'instanceId': 'abc' },
@@ -304,7 +304,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       helper.assertNoPulseMessage('worker-running');
     });
 
-    test('registerWorker - verifyInstanceIdentityDocument - bad document', async function() {
+    test('registerWorker - verifyInstanceIdentityDocument - bad document', async () => {
       const workerPool = await makeWorkerPool();
       const workerIdentityProof = {
         "document": fs.readFileSync(path.resolve(__dirname, 'fixtures/aws_iid_DOCUMENT_bad')).toString(),
@@ -319,7 +319,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       helper.assertNoPulseMessage('worker-running');
     });
 
-    test('registerWorker - verifyInstanceIdentityDocument - signature was produced with a wrong key', async function() {
+    test('registerWorker - verifyInstanceIdentityDocument - signature was produced with a wrong key', async () => {
       const workerPool = await makeWorkerPool();
       const workerIdentityProof = {
         "document": fs.readFileSync(path.resolve(__dirname, 'fixtures/aws_iid_DOCUMENT')).toString(),
@@ -333,7 +333,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       helper.assertNoPulseMessage('worker-running');
     });
 
-    test('registerWorker - verifyInstanceIdentityDocument - signature is wrong', async function() {
+    test('registerWorker - verifyInstanceIdentityDocument - signature is wrong', async () => {
       const workerPool = await makeWorkerPool();
       const workerIdentityProof = {
         "document": fs.readFileSync(path.resolve(__dirname, 'fixtures/aws_iid_DOCUMENT')).toString(),
@@ -347,7 +347,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       helper.assertNoPulseMessage('worker-running');
     });
 
-    test('registerWorker - verifyWorkerInstance - document is legit but differs from what we know about the instance', async function() {
+    test('registerWorker - verifyWorkerInstance - document is legit but differs from what we know about the instance', async () => {
       const workerPool = await makeWorkerPool();
       const differentWorkerInDB = {
         ...defaultWorker,
@@ -376,7 +376,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       helper.assertNoPulseMessage('worker-running');
     });
 
-    test('registerWorker - no signature', async function() {
+    test('registerWorker - no signature', async () => {
       const workerPool = await makeWorkerPool();
       const workerIdentityProof = {
         "document": fs.readFileSync(path.resolve(__dirname, 'fixtures/aws_iid_DOCUMENT')).toString(),
@@ -389,7 +389,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       helper.assertNoPulseMessage('worker-running');
     });
 
-    test('registerWorker - worker is already running', async function() {
+    test('registerWorker - worker is already running', async () => {
       const workerPool = await makeWorkerPool();
       const runningWorker = {
         ...workerInDB,
@@ -409,7 +409,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       helper.assertNoPulseMessage('worker-running');
     });
 
-    test('registerWorker - success', async function() {
+    test('registerWorker - success', async () => {
       const workerPool = await makeWorkerPool();
       const runningWorker = await Worker.fromApi({
         workerId: 'i-02312cd4f06c990ca',
@@ -442,7 +442,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       helper.assertPulseMessage('worker-running', m => m.payload.launchConfigId === runningWorker.launchConfigId);
     });
 
-    test('registerWorker - success (different reregister)', async function() {
+    test('registerWorker - success (different reregister)', async () => {
       const workerPool = await makeWorkerPool();
       const runningWorker = await Worker.fromApi({
         workerId: 'i-02312cd4f06c990ca',
@@ -477,9 +477,9 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
     });
   });
 
-  suite('AWS provider - checkWorker', function() {
+  suite('AWS provider - checkWorker', () => {
 
-    test('stopped instances - should be marked as STOPPED in DB, should not add to seen', async function() {
+    test('stopped instances - should be marked as STOPPED in DB, should not add to seen', async () => {
       fake.rgn('us-west-2').instanceStatuses['i-123'] = 'stopped';
       const worker = await Worker.fromApi({
         ...workerInDB,
@@ -498,7 +498,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       helper.assertPulseMessage('worker-stopped', m => m.payload.workerId === worker.workerId);
     });
 
-    test('pending/running,/shutting-down/stopping instances - should not reject', async function() {
+    test('pending/running,/shutting-down/stopping instances - should not reject', async () => {
       fake.rgn('us-west-2').instanceStatuses['i-123'] = 'running';
       const worker = await Worker.fromApi({
         ...workerInDB,
@@ -517,7 +517,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       helper.assertNoPulseMessage('worker-stopped');
     });
 
-    test('some strange status - should reject', async function() {
+    test('some strange status - should reject', async () => {
       fake.rgn('us-west-2').instanceStatuses['i-123'] = 'banana';
       const worker = Worker.fromApi({
         ...workerInDB,
@@ -530,7 +530,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       assert.strictEqual(provider.seen[worker.workerPoolId], 0);
     });
 
-    test('no such instance error should be handled', async function() {
+    test('no such instance error should be handled', async () => {
       fake.rgn('us-west-2').instanceStatuses['i-amgone'] = 'srsly';
       const worker = Worker.fromApi({
         ...workerInDB,
@@ -550,7 +550,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       helper.assertPulseMessage('worker-stopped', m => m.payload.launchConfigId === worker.launchConfigId);
     });
 
-    test('instance terminated by hand - should be marked as STOPPED in DB; should not reject', async function() {
+    test('instance terminated by hand - should be marked as STOPPED in DB; should not reject', async () => {
       fake.rgn('us-west-2').instanceStatuses['i-123'] = 'terminated';
       const worker = Worker.fromApi({
         ...workerInDB,
@@ -569,7 +569,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       helper.assertPulseMessage('worker-stopped', m => m.payload.workerId === worker.workerId);
     });
 
-    test('remove unregistered workers', async function() {
+    test('remove unregistered workers', async () => {
       fake.rgn('us-west-2').instanceStatuses['i-123'] = 'running';
       const worker = Worker.fromApi({
         ...workerInDB,
@@ -587,7 +587,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       helper.assertPulseMessage('worker-removed', m => m.payload.workerId === worker.workerId);
     });
 
-    test('don\'t remove unregistered workers that are new', async function() {
+    test('don\'t remove unregistered workers that are new', async () => {
       fake.rgn('us-west-2').instanceStatuses['i-123'] = 'running';
       const worker = Worker.fromApi({
         ...workerInDB,
@@ -605,7 +605,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       helper.assertNoPulseMessage('worker-removed');
     });
 
-    test('do not remove registered workers with stale terminateAfter', async function () {
+    test('do not remove registered workers with stale terminateAfter', async () => {
       fake.rgn('us-west-2').instanceStatuses['i-123'] = 'running';
       const worker = Worker.fromApi({
         ...workerInDB,
@@ -627,7 +627,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       helper.assertNoPulseMessage('worker-removed');
     });
 
-    test('remove very old workers', async function() {
+    test('remove very old workers', async () => {
       fake.rgn('us-west-2').instanceStatuses['i-123'] = 'running';
       const worker = Worker.fromApi({
         ...workerInDB,
@@ -645,7 +645,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
         m.payload.reason === 'terminateAfter time exceeded');
     });
 
-    test('don\'t remove current workers', async function() {
+    test('don\'t remove current workers', async () => {
       fake.rgn('us-west-2').instanceStatuses['i-123'] = 'running';
       const worker = Worker.fromApi({
         ...workerInDB,
@@ -662,7 +662,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       helper.assertNoPulseMessage('worker-removed');
     });
 
-    test('remove zombie workers with no queue activity', async function () {
+    test('remove zombie workers with no queue activity', async () => {
       fake.rgn('us-west-2').instanceStatuses['i-123'] = 'running';
       const worker = Worker.fromApi({
         ...workerInDB,
@@ -683,7 +683,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       assert.deepEqual(fake.rgn('us-west-2').terminatedInstances, ['i-123']);
       helper.assertPulseMessage('worker-removed', m => m.payload.workerId === worker.workerId);
     });
-    test('remove zombie workers that were not active recently', async function () {
+    test('remove zombie workers that were not active recently', async () => {
       fake.rgn('us-west-2').instanceStatuses['i-123'] = 'running';
       const worker = Worker.fromApi({
         ...workerInDB,
@@ -705,7 +705,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       helper.assertPulseMessage('worker-removed', m => m.payload.workerId === worker.workerId);
       helper.assertPulseMessage('worker-removed', m => m.payload.launchConfigId === worker.launchConfigId);
     });
-    test('don\'t remove zombie workers that were active recently', async function () {
+    test('don\'t remove zombie workers that were active recently', async () => {
       fake.rgn('us-west-2').instanceStatuses['i-123'] = 'running';
       const worker = Worker.fromApi({
         ...workerInDB,
@@ -728,9 +728,9 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
     });
   });
 
-  suite('AWS provider - removeWorker', function() {
+  suite('AWS provider - removeWorker', () => {
 
-    test('successfully terminated instance', async function() {
+    test('successfully terminated instance', async () => {
       const worker = Worker.fromApi({
         ...workerInDB,
         workerId: 'i-123',

--- a/services/worker-manager/test/provider_azure_test.js
+++ b/services/worker-manager/test/provider_azure_test.js
@@ -18,7 +18,7 @@ import { loadCertificates } from '../src/providers/azure/azure-ca-certs/index.js
 const debug = Debug('provider_azure_test');
 const __dirname = new URL('.', import.meta.url).pathname;
 
-helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
+helper.secrets.mockSuite(testing.suiteName(), [], (mock, skipping) => {
   helper.withDb(mock, skipping);
   helper.withPulse(mock, skipping);
   helper.withFakeQueue(mock, skipping);
@@ -50,7 +50,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
   };
 
   let monitor;
-  suiteSetup(async function() {
+  suiteSetup(async () => {
     monitor = await helper.load('monitor');
   });
 
@@ -174,26 +174,26 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
     return Buffer.from(forge.asn1.toDer(message.toAsn1()).getBytes(), 'binary').toString('base64');
   };
 
-  suite('helpers', function() {
+  suite('helpers', () => {
     const testCert = forge.pki.certificateFromPem(fs.readFileSync(intermediateCertPath, 'utf-8'));
 
-    test('dnToString of subject', async function() {
+    test('dnToString of subject', async () => {
       const dn = dnToString(testCert.subject);
       assert.equal(dn, intermediateCertSubject);
     });
 
-    test('dnToString of issuer', async function() {
+    test('dnToString of issuer', async () => {
       const dn = dnToString(testCert.issuer);
       assert.equal(dn, intermediateCertIssuer);
     });
 
-    test('getCertFingerprint', async function() {
+    test('getCertFingerprint', async () => {
       const fingerprint = getCertFingerprint(testCert);
       // this matches the "thumbprint" (?) on https://www.microsoft.com/pki/mscorp/cps/default.htm
       assert.equal(fingerprint, intermediateCertFingerprint);
     });
 
-    test('getAuthorityAccessInfo', async function() {
+    test('getAuthorityAccessInfo', async () => {
       const info = getAuthorityAccessInfo(testCert);
       assert.deepEqual(
         info,
@@ -203,7 +203,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
         ]);
     });
 
-    test('isAllowedAiaLocation allows trusted Azure CA hosts', async function() {
+    test('isAllowedAiaLocation allows trusted Azure CA hosts', async () => {
       assert.equal(
         isAllowedAiaLocation('http://www.microsoft.com/pkiops/certs/Microsoft%20Azure%20RSA%20TLS%20Issuing%20CA%2008.crt'),
         true,
@@ -222,7 +222,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       );
     });
 
-    test('isAllowedAiaLocation rejects untrusted or malformed URLs', async function() {
+    test('isAllowedAiaLocation rejects untrusted or malformed URLs', async () => {
       assert.equal(isAllowedAiaLocation('http://169.254.169.254/metadata/attested/document'), false);
       assert.equal(isAllowedAiaLocation('http://[::1]/cert.crt'), false);
       assert.equal(isAllowedAiaLocation('http://localhost/cert.crt'), false);
@@ -234,14 +234,14 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       assert.equal(isAllowedAiaLocation('not a url'), false);
     });
 
-    test('cloneCaStore handles invalid inputs', async function() {
+    test('cloneCaStore handles invalid inputs', async () => {
       assert.throws(() => cloneCaStore(null), /Invalid input/);
       assert.throws(() => cloneCaStore(undefined), /Invalid input/);
       assert.throws(() => cloneCaStore({}), /Invalid input/);
       assert.throws(() => cloneCaStore({ certs: 'not an object' }), /Invalid input/);
     });
 
-    test('cloneCaStore creates independent store', async function() {
+    test('cloneCaStore creates independent store', async () => {
       const originalStore = forge.pki.createCaStore();
       originalStore.addCertificate(testCert);
 
@@ -259,7 +259,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
     });
   });
 
-  setup(async function() {
+  setup(async () => {
     provider = new AzureProvider({
       providerId,
       notify: await helper.load('notify'),
@@ -343,8 +343,8 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
     }[resourceType];
   };
 
-  suite('setup', function() {
-    test('has all Azure root certificates', async function() {
+  suite('setup', () => {
+    test('has all Azure root certificates', async () => {
       // https://docs.microsoft.com/en-us/azure/security/fundamentals/tls-certificate-changes
       const azureRootCAs = new Map([
         ['df3c24f9bfd666761b268073fe06d1cc8d4f82a4', 'DigiCert Global Root G2'],
@@ -379,7 +379,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
     });
   });
 
-  suite('provisioning', function() {
+  suite('provisioning', () => {
     const provisionWorkerPool = async (launchConfig, overrides) => {
       const workerPool = await makeWorkerPool({
         config: {
@@ -429,7 +429,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       return worker;
     };
 
-    test('provision with no launch configs', async function() {
+    test('provision with no launch configs', async () => {
       const workerPool = await makeWorkerPool({
         config: {
           minCapacity: 1,
@@ -446,7 +446,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       assert.equal(workers.length, 0);
     });
 
-    test('provision a simple worker', async function() {
+    test('provision a simple worker', async () => {
       const worker = await provisionWorkerPool({});
 
       assert.equal(worker.workerPoolId, workerPoolId);
@@ -483,7 +483,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       helper.assertPulseMessage('worker-requested', m => m.payload.launchConfigId === worker.launchConfigId);
     });
 
-    test('provision with custom tags', async function() {
+    test('provision with custom tags', async () => {
       const worker = await provisionWorkerPool({
         tags: { mytag: 'myvalue' },
       });
@@ -491,7 +491,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       helper.assertPulseMessage('worker-requested', m => m.payload.workerId === worker.workerId);
     });
 
-    test('provision with lifecycle', async function() {
+    test('provision with lifecycle', async () => {
       const worker = await provisionWorkerPool({}, {
         lifecycle: {
           registrationTimeout: 6,
@@ -503,7 +503,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       helper.assertPulseMessage('worker-requested', m => m.payload.workerId === worker.workerId);
     });
 
-    test('provision with custom tags named after built-in tags', async function() {
+    test('provision with custom tags named after built-in tags', async () => {
       const worker = await provisionWorkerPool({
         tags: { 'created-by': 'me!' },
       });
@@ -511,14 +511,14 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       helper.assertPulseMessage('worker-requested', m => m.payload.workerId === worker.workerId);
     });
 
-    test('provision with workerConfig', async function() {
+    test('provision with workerConfig', async () => {
       const worker = await provisionWorkerPool({
         workerConfig: { runTasksFaster: true },
       });
       assert.equal(worker.providerData.workerConfig.runTasksFaster, true);
     });
 
-    test('provision with named disks ignores names', async function() {
+    test('provision with named disks ignores names', async () => {
       const worker = await provisionWorkerPool({
         storageProfile: {
           osDisk: {
@@ -538,7 +538,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       assert.equal(vmConfig.storageProfile.dataDisks[0].testProperty, 2);
     });
 
-    test('provision with several osDisks', async function() {
+    test('provision with several osDisks', async () => {
       const worker = await provisionWorkerPool({
         storageProfile: {
           osDisk: {
@@ -568,7 +568,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       assert.equal(vmConfig.storageProfile.dataDisks[3].testProperty, 5);
     });
 
-    test('provision with extra azure profiles', async function() {
+    test('provision with extra azure profiles', async () => {
       const worker = await provisionWorkerPool({
         billingProfile: {
           maxPrice: 10,
@@ -597,7 +597,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       assert(vmConfig.networkProfile.networkInterfaces); // still set..
     });
 
-    test('provision with ARM template config creates deployment worker', async function() {
+    test('provision with ARM template config creates deployment worker', async () => {
       await provisionWorkerPool({
         armDeployment: {
           mode: 'Incremental',
@@ -623,7 +623,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       assert.equal(worker.providerData.armDeployment.mode, 'Incremental');
     });
 
-    test('ARM deployment is cleaned up after successful provisioning', async function() {
+    test('ARM deployment is cleaned up after successful provisioning', async () => {
       await provisionWorkerPool({
         armDeployment: {
           mode: 'Incremental',
@@ -663,7 +663,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
         'deployment operation should have started at this point');
     });
 
-    test('keeps ARM deployment when keepDeployment is true', async function() {
+    test('keeps ARM deployment when keepDeployment is true', async () => {
       await provisionWorkerPool({
         workerManager: {
           capacityPerInstance: 1,
@@ -699,7 +699,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       assert.equal(worker.providerData.deployment.id, `id/${deploymentName}`);
     });
 
-    test('handles 409 conflict when deleting active ARM deployment', async function() {
+    test('handles 409 conflict when deleting active ARM deployment', async () => {
       await provisionWorkerPool({
         armDeployment: {
           mode: 'Incremental',
@@ -745,7 +745,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
         'deployment should be deleted on retry');
     });
 
-    test('failed ARM deployment resources are cleaned up', async function() {
+    test('failed ARM deployment resources are cleaned up', async () => {
       await provisionWorkerPool({
         armDeployment: {
           mode: 'Incremental',
@@ -865,7 +865,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
         'failed deployment should be deleted');
     });
 
-    test('failed ARM deployment stops re-removing workers once stopping', async function() {
+    test('failed ARM deployment stops re-removing workers once stopping', async () => {
       await provisionWorkerPool({
         armDeployment: {
           mode: 'Incremental',
@@ -941,7 +941,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       }
     });
 
-    test('deployment operation expired does not remove RUNNING worker', async function() {
+    test('deployment operation expired does not remove RUNNING worker', async () => {
       await provisionWorkerPool({
         armDeployment: {
           mode: 'Incremental',
@@ -991,7 +991,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       }
     });
 
-    test('deployment operation expired removes REQUESTED worker', async function() {
+    test('deployment operation expired removes REQUESTED worker', async () => {
       await provisionWorkerPool({
         armDeployment: {
           mode: 'Incremental',
@@ -1030,7 +1030,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       }
     });
 
-    test('failed ARM deployment does not remove RUNNING worker', async function() {
+    test('failed ARM deployment does not remove RUNNING worker', async () => {
       await provisionWorkerPool({
         armDeployment: {
           mode: 'Incremental',
@@ -1082,7 +1082,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       }
     });
 
-    test('checkWorker continues after completed ARM deployment', async function() {
+    test('checkWorker continues after completed ARM deployment', async () => {
       await provisionWorkerPool({
         armDeployment: {
           mode: 'Incremental',
@@ -1122,7 +1122,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
 
   });
 
-  suite('ARM deployment resource group management', function() {
+  suite('ARM deployment resource group management', () => {
     const provisionWorkerPool = async (launchConfig, overrides) => {
       const workerPool = await makeWorkerPool({
         config: {
@@ -1151,7 +1151,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       await provider.provision({ workerPool, workerPoolStats });
     };
 
-    test('creates resource group if it does not exist', async function() {
+    test('creates resource group if it does not exist', async () => {
       const customRgName = 'test-custom-rg';
       assert.ok(!fake.resourcesClient.resourceGroups.hasFakeResourceGroup(customRgName),
         'custom RG should not exist before provisioning');
@@ -1183,7 +1183,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       assert.equal(rg.location, 'eastus', 'RG should be created with correct location');
     });
 
-    test('does not create resource group if using fallback from provider config', async function() {
+    test('does not create resource group if using fallback from provider config', async () => {
       const checkExistenceSpy = sinon.spy(fake.resourcesClient.resourceGroups, 'checkExistence');
       const createOrUpdateSpy = sinon.spy(fake.resourcesClient.resourceGroups, 'createOrUpdate');
 
@@ -1214,7 +1214,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       createOrUpdateSpy.restore();
     });
 
-    test('does not check resource group if it already exists', async function() {
+    test('does not check resource group if it already exists', async () => {
       const customRgName = 'test-existing-rg';
 
       // Pre-create the resource group
@@ -1248,7 +1248,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       createOrUpdateSpy.restore();
     });
 
-    test('evicts cache and retries after checkExistence failure', async function() {
+    test('evicts cache and retries after checkExistence failure', async () => {
       const customRgName = 'test-failing-rg';
       const launchConfig = {
         armDeploymentResourceGroup: customRgName,
@@ -1302,7 +1302,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       createSpy.restore();
     });
 
-    test('second provision reuses cached promise without new API calls', async function() {
+    test('second provision reuses cached promise without new API calls', async () => {
       const customRgName = 'test-cached-rg';
       const launchConfig = {
         armDeploymentResourceGroup: customRgName,
@@ -1353,11 +1353,11 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
     });
   });
 
-  suite('provisionResources', function() {
+  suite('provisionResources', () => {
     let worker, ipName, nicName, vmName;
     const sandbox = sinon.createSandbox({});
 
-    setup('create un-provisioned worker', async function () {
+    setup('create un-provisioned worker', async () => {
       const workerPool = await makeWorkerPool({}, {
         workerManager: {
           publicIp: true,
@@ -1383,11 +1383,11 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       provider.errors[workerPoolId] = [];
     });
 
-    teardown(function() {
+    teardown(() => {
       sandbox.restore();
     });
 
-    test('successful provisioning process', async function() {
+    test('successful provisioning process', async () => {
       // Ip provisioning should have already started inside the provision() call
       await assertProvisioningState({ ip: 'inprogress' });
       const ipName = worker.providerData.ip.name;
@@ -1476,7 +1476,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       assert(!provider.removeWorker.called);
     });
 
-    test('provisioning process fails creating IP', async function() {
+    test('provisioning process fails creating IP', async () => {
       debug('first call');
       await provider.provisionResources({ worker, monitor });
       await assertProvisioningState({ ip: 'inprogress' });
@@ -1490,7 +1490,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       assert(provider.removeWorker.called);
     });
 
-    test('provisioning process fails creating IP with provisioningState=Failed', async function() {
+    test('provisioning process fails creating IP with provisioningState=Failed', async () => {
       debug('first call');
       await provider.provisionResources({ worker, monitor });
       await assertProvisioningState({ ip: 'inprogress' });
@@ -1507,7 +1507,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       assert(provider.removeWorker.called);
     });
 
-    test('provisioning process fails creating NIC', async function() {
+    test('provisioning process fails creating NIC', async () => {
       debug('first call');
       await provider.provisionResources({ worker, monitor });
       await assertProvisioningState({ ip: 'inprogress' });
@@ -1528,7 +1528,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       assert(provider.removeWorker.called);
     });
 
-    test('provisioning process fails creating VM', async function() {
+    test('provisioning process fails creating VM', async () => {
       debug('first call');
       await provider.provisionResources({ worker, monitor });
       await assertProvisioningState({ ip: 'inprogress' });
@@ -1557,7 +1557,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
     });
   });
 
-  suite('provisionResources with or without public IP', function () {
+  suite('provisionResources with or without public IP', () => {
     let worker, nicName, vmName, ipName;
     const sandbox = sinon.createSandbox({});
 
@@ -1582,11 +1582,11 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       provider.errors[workerPoolId] = [];
     };
 
-    teardown(function() {
+    teardown(() => {
       sandbox.restore();
     });
 
-    test('successful provisioning of VM without public ip', async function() {
+    test('successful provisioning of VM without public ip', async () => {
       await prepareProvision({
         workerConfig: {
           workerManager: {
@@ -1609,7 +1609,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       assert(!provider.removeWorker.called);
     });
 
-    test('successful provision of VM with public ip', async function () {
+    test('successful provision of VM with public ip', async () => {
       await prepareProvision({
         workerConfig: {
           genericWorker: {
@@ -1639,7 +1639,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
     });
   });
 
-  suite('removeWorker', function() {
+  suite('removeWorker', () => {
     let worker, ipName, nicName, vmName;
     const sandbox = sinon.createSandbox({});
 
@@ -1650,7 +1650,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
     // scheduling internals.
     const flushInlineBeginDelete = () => new Promise(resolve => setImmediate(resolve));
 
-    setup('create un-provisioned worker', async function() {
+    setup('create un-provisioned worker', async () => {
       const workerPool = await makeWorkerPool();
       const workerPoolStats = new WorkerPoolStats('wpid');
 
@@ -1755,7 +1755,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       }
     };
 
-    test('full removeWorker process', async function() {
+    test('full removeWorker process', async () => {
       await makeResource('ip', true);
       await makeResource('nic', true);
       await makeResource('disks', true, 0); // creates disks0
@@ -1834,7 +1834,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       helper.assertPulseMessage('worker-stopped', m => m.payload.workerId === worker.workerId);
     });
 
-    test('vm removal fails (keeps waiting)', async function() {
+    test('vm removal fails (keeps waiting)', async () => {
       await makeResource('ip', true);
       await makeResource('nic', true);
       await makeResource('disks', true, 0);
@@ -1859,7 +1859,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       await assertRemovalState({ ip: 'allocated', nic: 'allocated', disks: ['allocated'], vm: 'deleting' });
     });
 
-    test('deletes VM by name if id is missing', async function() {
+    test('deletes VM by name if id is missing', async () => {
       await makeResource('ip', true);
       await makeResource('nic', true);
       await makeResource('disks', true, 0);
@@ -1876,7 +1876,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       assert.deepEqual(await fake.computeClient.virtualMachines.getFakeRequestParameters('rgrp', vmName), {});
     });
 
-    test('deletes disk by name if no VM/IP/NIC and disk id is missing', async function() {
+    test('deletes disk by name if no VM/IP/NIC and disk id is missing', async () => {
       await makeResource('disks', false, 0);
       const diskName = worker.providerData.disks[0].name;
 
@@ -1893,7 +1893,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       assert.deepEqual(await fake.computeClient.disks.getFakeRequestParameters('rgrp', diskName), {});
     });
 
-    test('beginDelete 404 race between pre-flight GET and DELETE is handled', async function() {
+    test('beginDelete 404 race between pre-flight GET and DELETE is handled', async () => {
       // Defense-in-depth for the narrow race where the pre-flight GET sees
       // the resource but it is deleted by another actor before our DELETE
       // lands. Azure's REST contract uses 204 (not 404) for an idempotent
@@ -1951,7 +1951,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       helper.assertPulseMessage('worker-stopped', m => m.payload.workerId === reloaded.workerId);
     });
 
-    test('pre-flight GET 404 reaps ghost resources in a single cycle (issue #8526)', async function() {
+    test('pre-flight GET 404 reaps ghost resources in a single cycle (issue #8526)', async () => {
       // Seed the worker with ids so typeData.id is truthy for each resource -
       // this is the state produced by a normal provision/run. Then simulate
       // ARM cascade-delete (deleteOption: 'Delete' on the VM) having already
@@ -2017,7 +2017,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
     });
 
     for (const midDeleteState of ['Deleting', 'Deallocating', 'Deallocated']) {
-      test(`pre-flight GET finds ${midDeleteState}; beginDelete is not re-fired even when typeData.id is truthy`, async function() {
+      test(`pre-flight GET finds ${midDeleteState}; beginDelete is not re-fired even when typeData.id is truthy`, async () => {
         // When the VM is already in one of the mid-delete states, the old
         // code's `if (typeData.id || shouldDelete)` gate would re-fire
         // beginDelete against it. The fix gates solely on shouldDelete, so
@@ -2062,8 +2062,8 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
     // Tests for the inline beginDelete behaviour added in removeWorker (#8574).
     // Each test uses a fresh sinon spy on the fake's beginDelete so we can
     // assert exactly when the inline call fires.
-    suite('inline beginDelete', function() {
-      test('RUNNING worker with vm.id set: fires inline beginDelete and clears vm.id', async function() {
+    suite('inline beginDelete', () => {
+      test('RUNNING worker with vm.id set: fires inline beginDelete and clears vm.id', async () => {
         await makeResource('vm', true);
         await worker.update(helper.db, w => {
           w.state = 'running';
@@ -2083,7 +2083,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
         assert.equal(fake.computeClient.virtualMachines.getFakeResource('rgrp', vmName).provisioningState, 'Deleting');
       });
 
-      test('REQUESTED worker without provisioningComplete: skips inline beginDelete', async function() {
+      test('REQUESTED worker without provisioningComplete: skips inline beginDelete', async () => {
         await makeResource('vm', true);
         // worker stays in REQUESTED, provisioningComplete is unset / falsy
         const beginDeleteSpy = sandbox.spy(fake.computeClient.virtualMachines, 'beginDelete');
@@ -2098,7 +2098,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
         assert.equal(fake.computeClient.virtualMachines.getFakeResource('rgrp', vmName).provisioningState, 'Succeeded');
       });
 
-      test('REQUESTED worker with provisioningComplete=true and vm.id set: fires inline beginDelete', async function() {
+      test('REQUESTED worker with provisioningComplete=true and vm.id set: fires inline beginDelete', async () => {
         await makeResource('vm', true);
         await worker.update(helper.db, w => {
           // worker is still REQUESTED but provisioningComplete has been
@@ -2116,7 +2116,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
         assert.equal(reloaded.providerData.vm.id, false);
       });
 
-      test('RUNNING worker with vm.id falsy (already requested): skips inline beginDelete', async function() {
+      test('RUNNING worker with vm.id falsy (already requested): skips inline beginDelete', async () => {
         // simulate the resource record produced by deprovisionResource
         // submitting beginDelete: id has been cleared, deleted not yet set
         await makeResource('vm', false);
@@ -2133,7 +2133,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
           'must not fire when vm.id is falsy: nothing to delete or delete already in flight');
       });
 
-      test('RUNNING worker with vm.deleted=true: skips inline beginDelete', async function() {
+      test('RUNNING worker with vm.deleted=true: skips inline beginDelete', async () => {
         await makeResource('vm', true);
         await worker.update(helper.db, w => {
           w.state = 'running';
@@ -2149,7 +2149,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
           'must not re-fire delete on a resource already marked deleted');
       });
 
-      test('inline beginDelete failure does not break removeWorker', async function() {
+      test('inline beginDelete failure does not break removeWorker', async () => {
         await makeResource('vm', true);
         await worker.update(helper.db, w => {
           w.state = 'running';
@@ -2178,7 +2178,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
         assert.equal(reloaded.providerData.vm.id, false);
       });
 
-      test('idempotent: second removeWorker call does not re-fire inline beginDelete', async function() {
+      test('idempotent: second removeWorker call does not re-fire inline beginDelete', async () => {
         await makeResource('vm', true);
         await worker.update(helper.db, w => {
           w.state = 'running';
@@ -2200,8 +2200,8 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
     });
   });
 
-  suite('deprovision', function () {
-    test('de-provisioning loop', async function () {
+  suite('deprovision', () => {
+    test('de-provisioning loop', async () => {
       const workerPool = await makeWorkerPool({
         // simulate previous provisionig and deleting the workerpool
         providerId: 'null-provider',
@@ -2213,10 +2213,10 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
     });
   });
 
-  suite('checkWorker', function() {
+  suite('checkWorker', () => {
     let worker;
     const sandbox = sinon.createSandbox({});
-    setup('set up for checkWorker', async function() {
+    setup('set up for checkWorker', async () => {
       await provider.scanPrepare();
 
       worker = Worker.fromApi({
@@ -2240,7 +2240,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       sandbox.stub(provider, 'deprovisionResources').returns('requested');
     });
 
-    teardown(function() {
+    teardown(() => {
       sandbox.restore();
     });
 
@@ -2255,7 +2255,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       }
     };
 
-    test('calls provisionResources for still-running workers', async function() {
+    test('calls provisionResources for still-running workers', async () => {
       await setState({ state: 'running', powerStates: ['ProvisioningState/succeeded', 'PowerState/running'] });
       await provider.checkWorker({ worker });
       await worker.reload(helper.db);
@@ -2264,7 +2264,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       assert(provider.provisionResources.called);
     });
 
-    test('calls provisionResources for requested workers that have no instanceView', async function() {
+    test('calls provisionResources for requested workers that have no instanceView', async () => {
       await setState({ state: 'requested', powerStates: null });
       await provider.checkWorker({ worker });
       await worker.reload(helper.db);
@@ -2273,7 +2273,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       assert(provider.provisionResources.called);
     });
 
-    test('calls removeWorker after repeated instanceView 404s, even if vm get succeeds', async function() {
+    test('calls removeWorker after repeated instanceView 404s, even if vm get succeeds', async () => {
       await setState({ state: 'running', powerStates: null });
       fake.computeClient.virtualMachines.makeFakeResource('rgrp', baseProviderData.vm.name, {
         provisioningState: 'Succeeded',
@@ -2290,7 +2290,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       assert.equal(provider.provisionResources.callCount, 2);
     });
 
-    test('calls provisionResources for requested workers that are fully started', async function() {
+    test('calls provisionResources for requested workers that are fully started', async () => {
       await setState({ state: 'requested', powerStates: ['ProvisioningState/succeeded', 'PowerState/running'] });
       await provider.checkWorker({ worker });
       await worker.reload(helper.db);
@@ -2299,7 +2299,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       assert(provider.provisionResources.called);
     });
 
-    test('calls removeWorker() for a running worker that is stopping', async function() {
+    test('calls removeWorker() for a running worker that is stopping', async () => {
       await setState({ state: 'running', powerStates: ['PowerState/stopping'] });
       await provider.checkWorker({ worker });
       await worker.reload(helper.db);
@@ -2307,7 +2307,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       assert(!provider.provisionResources.called);
     });
 
-    test('calls removeWorker() for a running worker that is stopped', async function() {
+    test('calls removeWorker() for a running worker that is stopped', async () => {
       await setState({ state: 'running', powerStates: ['PowerState/stopped'] });
       await provider.checkWorker({ worker });
       await worker.reload(helper.db);
@@ -2315,7 +2315,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       assert(!provider.provisionResources.called);
     });
 
-    test('calls removeWorker() for a running worker that is deallocating', async function() {
+    test('calls removeWorker() for a running worker that is deallocating', async () => {
       await setState({ state: 'running', powerStates: ['PowerState/deallocating'] });
       await provider.checkWorker({ worker });
       await worker.reload(helper.db);
@@ -2323,7 +2323,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       assert(!provider.provisionResources.called);
     });
 
-    test('calls removeWorker() for a running worker that is deallocated', async function() {
+    test('calls removeWorker() for a running worker that is deallocated', async () => {
       await setState({ state: 'running', powerStates: ['PowerState/deallocated'] });
       await provider.checkWorker({ worker });
       await worker.reload(helper.db);
@@ -2331,7 +2331,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       assert(!provider.provisionResources.called);
     });
 
-    test('calls removeWorker() for a requested worker that has failed OS Provisioning', async function() {
+    test('calls removeWorker() for a requested worker that has failed OS Provisioning', async () => {
       await setState({ state: 'requested', powerStates: ['ProvisioningState/failed/OSProvisioningTimedOut'] });
       await provider.checkWorker({ worker });
       await worker.reload(helper.db);
@@ -2339,7 +2339,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       assert(!provider.provisionResources.called);
     });
 
-    test('does not call removeWorker() for a requested worker with failed provisioning but PowerState/running', async function() {
+    test('does not call removeWorker() for a requested worker with failed provisioning but PowerState/running', async () => {
       await setState({ state: 'requested', powerStates: ['ProvisioningState/failed/OSProvisioningClientError', 'PowerState/running'] });
       await provider.checkWorker({ worker });
       await worker.reload(helper.db);
@@ -2347,7 +2347,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       assert(provider.provisionResources.called);
     });
 
-    test('calls removeWorker() for a requested worker with failed provisioning and no PowerState/running', async function() {
+    test('calls removeWorker() for a requested worker with failed provisioning and no PowerState/running', async () => {
       await setState({ state: 'requested', powerStates: ['ProvisioningState/failed/OSProvisioningClientError', 'PowerState/stopped'] });
       await provider.checkWorker({ worker });
       await worker.reload(helper.db);
@@ -2355,7 +2355,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       assert(!provider.provisionResources.called);
     });
 
-    test('removes worker with failed provisioning + PowerState/running after terminateAfter expires', async function() {
+    test('removes worker with failed provisioning + PowerState/running after terminateAfter expires', async () => {
       await setState({ state: 'requested', powerStates: ['ProvisioningState/failed/OSProvisioningClientError', 'PowerState/running'] });
       await worker.update(helper.db, worker => {
         worker.providerData.terminateAfter = Date.now() - 1000;
@@ -2365,7 +2365,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       assert(!provider.provisionResources.called);
     });
 
-    test('calls provisionResources for a requested worker that is present but has failed OS Provisioning, if ignoring that', async function() {
+    test('calls provisionResources for a requested worker that is present but has failed OS Provisioning, if ignoring that', async () => {
       await worker.update(helper.db, worker => {
         worker.providerData.ignoreFailedProvisioningStates = ['OSProvisioningTimedOut', 'SomethingElse'];
       });
@@ -2376,7 +2376,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       assert(provider.provisionResources.called);
     });
 
-    test('calls removeWorker() for a requested worker that has failed with an internal error that is not ignored', async function() {
+    test('calls removeWorker() for a requested worker that has failed with an internal error that is not ignored', async () => {
       await worker.update(helper.db, worker => {
         worker.providerData.ignoreFailedProvisioningStates = ['OSProvisioningTimedOut', 'SomethingElse'];
       });
@@ -2387,7 +2387,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       assert(!provider.provisionResources.called);
     });
 
-    test('calls deprovisionResources() for a stopping worker that is running', async function() {
+    test('calls deprovisionResources() for a stopping worker that is running', async () => {
       // this is the state of a worker after a `removeWorker` API call, for example
       await setState({ state: 'stopping', powerStates: ['PowerState/running'] });
       await provider.checkWorker({ worker });
@@ -2397,7 +2397,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       assert(provider.deprovisionResources.called);
     });
 
-    test('calls deprovisionResources() for a stopping worker that is stopped', async function() {
+    test('calls deprovisionResources() for a stopping worker that is stopped', async () => {
       await setState({ state: 'stopping', powerStates: ['PowerState/stopped'] });
       await provider.checkWorker({ worker });
       await worker.reload(helper.db);
@@ -2406,7 +2406,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       assert(provider.deprovisionResources.called);
     });
 
-    test('remove unregistered workers after terminateAfter', async function() {
+    test('remove unregistered workers after terminateAfter', async () => {
       await setState({ state: 'requested', powerStates: ['ProvisioningState/succeeded', 'PowerState/running'] });
       await worker.update(helper.db, worker => {
         worker.providerData.terminateAfter = Date.now() - 1000;
@@ -2416,7 +2416,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       assert(!provider.provisionResources.called);
     });
 
-    test('do not remove unregistered workers before terminateAfter', async function() {
+    test('do not remove unregistered workers before terminateAfter', async () => {
       await setState({ state: 'requested', powerStates: ['ProvisioningState/succeeded', 'PowerState/running'] });
       await worker.update(helper.db, worker => {
         worker.providerData.terminateAfter = Date.now() + 1000;
@@ -2428,7 +2428,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       assert(provider.provisionResources.called);
     });
 
-    test('do not remove registered workers with stale terminateAfter', async function() {
+    test('do not remove registered workers with stale terminateAfter', async () => {
       await setState({ state: 'requested', powerStates: ['ProvisioningState/succeeded', 'PowerState/running'] });
       // simulate situation where worker scanner was running slow and in-memory worker was already updated in db
       await worker.update(helper.db, worker => {
@@ -2450,7 +2450,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       assert(provider.provisionResources.called);
     });
 
-    test('remove zombie worker with no queue activity', async function () {
+    test('remove zombie worker with no queue activity', async () => {
       await setState({ state: 'running', powerStates: ['ProvisioningState/succeeded', 'PowerState/running'] });
       await worker.update(helper.db, worker => {
         worker.providerData.queueInactivityTimeout = 1;
@@ -2460,7 +2460,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       await provider.checkWorker({ worker });
       assert(provider.removeWorker.called);
     });
-    test('remove zombie worker that was active long ago', async function () {
+    test('remove zombie worker that was active long ago', async () => {
       await setState({ state: 'running', powerStates: ['ProvisioningState/succeeded', 'PowerState/running'] });
       await worker.update(helper.db, worker => {
         worker.created = taskcluster.fromNow('-120 minutes');
@@ -2471,7 +2471,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       await provider.checkWorker({ worker });
       assert(provider.removeWorker.called);
     });
-    test('doesn\'t remove zombie worker that was recently active', async function () {
+    test('doesn\'t remove zombie worker that was recently active', async () => {
       await setState({ state: 'running', powerStates: ['ProvisioningState/succeeded', 'PowerState/running'] });
       await worker.update(helper.db, worker => {
         worker.created = taskcluster.fromNow('-120 minutes');
@@ -2483,7 +2483,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       assert(!provider.removeWorker.called);
     });
 
-    test('reports worker-pool error when ARM deployment fails', async function() {
+    test('reports worker-pool error when ARM deployment fails', async () => {
       const reportErrorStub = sandbox.stub(provider, 'reportError').resolves();
       const existingWorkerPool = await WorkerPool.get(helper.db, workerPoolId);
       if (!existingWorkerPool) {
@@ -2557,7 +2557,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
     });
   });
 
-  suite('registerWorker', function() {
+  suite('registerWorker', () => {
     const workerGroup = 'westus';
     const vmId = azureSignatures[0].vmId;
     const baseWorker = {
@@ -2580,7 +2580,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       },
     };
 
-    setup('create vm', function() {
+    setup('create vm', () => {
       fake.computeClient.virtualMachines.makeFakeResource('rgrp', 'some-vm', {
         vmId,
       });
@@ -2601,8 +2601,8 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
         },
       },
     ]) {
-      suite(name, function () {
-        test('Test same certificate multiple times', async function () {
+      suite(name, () => {
+        test('Test same certificate multiple times', async () => {
           // https://github.com/taskcluster/taskcluster/issues/7685
           // verification can fail if same cert is present twice in CA Store but with different parents
           // if we check same cert few times, it would start failing
@@ -2621,7 +2621,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
             await helper.db.fns.delete_worker(worker.workerPoolId, worker.workerGroup, worker.workerId);
           }
         });
-        test('document is not a valid PKCS#7 message', async function() {
+        test('document is not a valid PKCS#7 message', async () => {
           const workerPool = await makeWorkerPool();
           const worker = Worker.fromApi({
             ...defaultWorker,
@@ -2637,7 +2637,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
           helper.assertNoPulseMessage('worker-running');
         });
 
-        test('document is empty', async function() {
+        test('document is empty', async () => {
           const workerPool = await makeWorkerPool();
           const worker = Worker.fromApi({
             ...defaultWorker,
@@ -2652,7 +2652,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
           helper.assertNoPulseMessage('worker-running');
         });
 
-        test('message does not match signature', async function() {
+        test('message does not match signature', async () => {
           const workerPool = await makeWorkerPool();
           const worker = Worker.fromApi({
             ...defaultWorker,
@@ -2668,7 +2668,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
           helper.assertNoPulseMessage('worker-running');
         });
 
-        test('malformed signature', async function() {
+        test('malformed signature', async () => {
           const workerPool = await makeWorkerPool();
           const worker = Worker.fromApi({
             ...defaultWorker,
@@ -2684,7 +2684,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
           helper.assertNoPulseMessage('worker-running');
         });
 
-        test('wrong signer subject', async function() {
+        test('wrong signer subject', async () => {
           const workerPool = await makeWorkerPool();
           const worker = Worker.fromApi({
             ...defaultWorker,
@@ -2706,7 +2706,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
             'Error: Unparsed DER bytes remain after ASN.1 parsing.');
         });
 
-        test('expired message', async function() {
+        test('expired message', async () => {
           const workerPool = await makeWorkerPool();
           const worker = Worker.fromApi({
             ...defaultWorker,
@@ -2724,7 +2724,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
           )[0].Fields.message.includes('Expired message'));
         });
 
-        test('fail to download cert', async function() {
+        test('fail to download cert', async () => {
           const workerPool = await makeWorkerPool();
           const worker = Worker.fromApi({
             ...defaultWorker,
@@ -2769,7 +2769,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
           provider.downloadBinaryResponse = oldDownloadBinaryResponse;
         });
 
-        test('certificate download timeout', async function() {
+        test('certificate download timeout', async () => {
           const workerPool = await makeWorkerPool();
           const worker = Worker.fromApi({
             ...defaultWorker,
@@ -2816,7 +2816,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
           helper.assertNoPulseMessage('worker-running');
         });
 
-        test('download is not binary cert', async function() {
+        test('download is not binary cert', async () => {
           const workerPool = await makeWorkerPool();
           const worker = Worker.fromApi({
             ...defaultWorker,
@@ -2858,7 +2858,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
           provider.downloadBinaryResponse = oldDownloadBinaryResponse;
         });
 
-        test('logs rejected intermediate certificate URL', async function() {
+        test('logs rejected intermediate certificate URL', async () => {
           const workerPool = await makeWorkerPool();
           const worker = Worker.fromApi({
             ...defaultWorker,
@@ -2885,7 +2885,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
           restoreAllCerts();
         });
 
-        test('bad cert', async function() {
+        test('bad cert', async () => {
           const workerPool = await makeWorkerPool();
           const worker = Worker.fromApi({
             ...defaultWorker,
@@ -2918,7 +2918,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
           helper.assertNoPulseMessage('worker-running');
         });
 
-        test('wrong worker state (duplicate call to registerWorker)', async function() {
+        test('wrong worker state (duplicate call to registerWorker)', async () => {
           const workerPool = await makeWorkerPool();
           const worker = Worker.fromApi({
             ...defaultWorker,
@@ -2932,7 +2932,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
           assert(monitor.manager.messages[0].Fields.error.includes('already running'));
         });
 
-        test('wrong vmID', async function() {
+        test('wrong vmID', async () => {
           const workerPool = await makeWorkerPool();
           const worker = Worker.fromApi({
             ...defaultWorker,
@@ -2956,7 +2956,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
           helper.assertNoPulseMessage('worker-running');
         });
 
-        test('sweet success', async function() {
+        test('sweet success', async () => {
           const workerPool = await makeWorkerPool();
           const worker = Worker.fromApi({
             ...defaultWorker,
@@ -2976,7 +2976,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
           assert.equal(res.workerConfig.someKey, 'someValue');
         });
 
-        test('sweet success (different reregister)', async function() {
+        test('sweet success (different reregister)', async () => {
           const workerPool = await makeWorkerPool();
           let worker = Worker.fromApi({
             ...defaultWorker,
@@ -3002,7 +3002,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
           helper.assertPulseMessage('worker-running', m => m.payload.launchConfigId === worker.launchConfigId);
         });
 
-        test('success after downloading missing intermediate', async function() {
+        test('success after downloading missing intermediate', async () => {
           const workerPool = await makeWorkerPool();
           const worker = Worker.fromApi({
             ...defaultWorker,
@@ -3038,9 +3038,9 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
     }
   });
 
-  suite('FakeRestClient throttle / header support', function() {
+  suite('FakeRestClient throttle / header support', () => {
     let worker;
-    setup(async function() {
+    setup(async () => {
       await makeWorkerPool();
       worker = Worker.fromApi({
         workerPoolId,
@@ -3061,7 +3061,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       await worker.create(helper.db);
     });
 
-    test('setThrottle causes 429 error through CloudAPI.enqueue', async function() {
+    test('setThrottle causes 429 error through CloudAPI.enqueue', async () => {
       // Configure the fake to throw 429 on the next request.
       // Use a small retry-after (1s) so the dynamic backoff doesn't
       // cause the test to time out — this test verifies the error path,
@@ -3095,7 +3095,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       assert.equal(pauseMsg.Fields.queueName, 'opRead');
     });
 
-    test('setThrottle error carries statusCode and response headers', async function() {
+    test('setThrottle error carries statusCode and response headers', async () => {
       fake.restClient.setThrottle(1, {
         'retry-after': '45',
         'x-ms-ratelimit-remaining-subscription-reads': '10',
@@ -3117,7 +3117,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       }
     });
 
-    test('successful response includes rate-limit headers when setResponseHeaders is used', async function() {
+    test('successful response includes rate-limit headers when setResponseHeaders is used', async () => {
       fake.restClient.setResponseHeaders({
         'x-ms-ratelimit-remaining-subscription-reads': '150',
         'x-ms-ratelimit-remaining-subscription-writes': '450',
@@ -3133,7 +3133,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       assert.equal(resp.headers.get('x-ms-ratelimit-remaining-subscription-deletes'), '300');
     });
 
-    test('successful 200 response includes rate-limit headers', async function() {
+    test('successful 200 response includes rate-limit headers', async () => {
       // Set up a pending operation so the fake returns 200
       await fake.computeClient.virtualMachines.beginCreateOrUpdate('rgrp', 'throttle-vm', {
         subnetId: 'some/subnet',
@@ -3156,13 +3156,13 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       assert.equal(resp.parsedBody.status, 'InProgress');
     });
 
-    test('response has null headers when setResponseHeaders is not used', async function() {
+    test('response has null headers when setResponseHeaders is not used', async () => {
       const resp = await fake.restClient.sendLongRunningRequest({ url: 'op/vm/rgrp/throttle-vm' });
       assert.equal(resp.status, 404);
       assert.strictEqual(resp.headers, null);
     });
 
-    test('throttle counter decrements and subsequent requests succeed', async function() {
+    test('throttle counter decrements and subsequent requests succeed', async () => {
       fake.restClient.setThrottle(2, { 'retry-after': '10' });
 
       // First two calls throw 429
@@ -3180,7 +3180,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       assert.equal(resp.status, 404); // no matching request, but no throw
     });
 
-    test('FakeHttpHeaders.get is case-insensitive', function() {
+    test('FakeHttpHeaders.get is case-insensitive', () => {
       const headers = new FakeHttpHeaders({
         'X-Ms-RateLimit-Remaining-Subscription-Reads': '42',
         'Retry-After': '30',
@@ -3193,8 +3193,8 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
     });
   });
 
-  suite('_recordRateLimitHeaders', function() {
-    test('emits azureThrottled log on 429 with all headers', function() {
+  suite('_recordRateLimitHeaders', () => {
+    test('emits azureThrottled log on 429 with all headers', () => {
       const headers = new FakeHttpHeaders({
         'x-ms-ratelimit-remaining-subscription-reads': '100',
         'x-ms-ratelimit-remaining-subscription-writes': '200',
@@ -3222,7 +3222,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       assert.equal(throttleMsg.Fields.remainingResource, 'Microsoft.Compute/GetOperation3Min;99');
     });
 
-    test('does not emit azureThrottled log on non-429 response', function() {
+    test('does not emit azureThrottled log on non-429 response', () => {
       const headers = new FakeHttpHeaders({
         'x-ms-ratelimit-remaining-subscription-reads': '500',
       });
@@ -3239,7 +3239,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       assert.ok(!throttleMsg, 'should not emit azure-throttled for 200 response');
     });
 
-    test('handles partial headers gracefully', function() {
+    test('handles partial headers gracefully', () => {
       const headers = new FakeHttpHeaders({
         'x-ms-ratelimit-remaining-subscription-reads': '42',
       });
@@ -3261,7 +3261,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       assert.equal(throttleMsg.Fields.retryAfterSeconds, null);
     });
 
-    test('handles malformed header values', function() {
+    test('handles malformed header values', () => {
       const headers = new FakeHttpHeaders({
         'x-ms-ratelimit-remaining-subscription-reads': 'not-a-number',
         'x-ms-ratelimit-remaining-subscription-writes': '',
@@ -3287,7 +3287,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       assert.equal(throttleMsg.Fields.retryAfterSeconds, null);
     });
 
-    test('is a no-op when headers is null', function() {
+    test('is a no-op when headers is null', () => {
       // Should not throw
       provider._recordRateLimitHeaders({
         headers: null,
@@ -3301,7 +3301,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       assert.ok(!throttleMsg, 'should not emit log with null headers');
     });
 
-    test('is a no-op when headers lacks .get() method', function() {
+    test('is a no-op when headers lacks .get() method', () => {
       provider._recordRateLimitHeaders({
         headers: { 'retry-after': '30' },
         statusCode: 429,
@@ -3314,7 +3314,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       assert.ok(!throttleMsg, 'should not emit log without .get() method');
     });
 
-    test('calls gauge metrics for remaining-* headers', function() {
+    test('calls gauge metrics for remaining-* headers', () => {
       const recorded = [];
       const origMetric = provider.monitor._metric.azureRateLimitRemaining;
       provider.monitor._metric.azureRateLimitRemaining = (value, labels) => {
@@ -3341,7 +3341,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       }
     });
 
-    test('calls counter metric on 429', function() {
+    test('calls counter metric on 429', () => {
       const recorded = [];
       const origMetric = provider.monitor._metric.azureThrottleCount;
       provider.monitor._metric.azureThrottleCount = (value, labels) => {
@@ -3367,9 +3367,9 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
     });
   });
 
-  suite('handleOperation observability', function() {
+  suite('handleOperation observability', () => {
     let worker;
-    setup(async function() {
+    setup(async () => {
       await makeWorkerPool();
       worker = Worker.fromApi({
         workerPoolId,
@@ -3390,7 +3390,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       await worker.create(helper.db);
     });
 
-    test('records rate-limit headers from successful handleOperation response', async function() {
+    test('records rate-limit headers from successful handleOperation response', async () => {
       // Set up a pending operation so the fake returns 200 with parsedBody
       await fake.computeClient.virtualMachines.beginCreateOrUpdate('rgrp', 'obs-vm', {
         subnetId: 'some/subnet',
@@ -3441,7 +3441,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       }
     });
 
-    test('transient restClient 429 does not emit azureThrottled (handled by CloudAPI backoff only)', async function() {
+    test('transient restClient 429 does not emit azureThrottled (handled by CloudAPI backoff only)', async () => {
       // setThrottle(1): first call throws 429, CloudAPI retries, second call succeeds.
       // errorHandler no longer records headers (to avoid double-counting SDK clients),
       // so transient restClient 429s only show up in the generic cloudApiPaused log.
@@ -3471,7 +3471,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       assert.ok(!throttleMsg, 'transient restClient 429 should not produce azureThrottled');
     });
 
-    test('persistent restClient 429 emits azureThrottled once from handleOperation catch', async function() {
+    test('persistent restClient 429 emits azureThrottled once from handleOperation catch', async () => {
       // setThrottle(6): exceeds CloudAPI's 5 retries (tries > 4), so the error
       // propagates to handleOperation's catch which records it exactly once.
       fake.restClient.setThrottle(6, {
@@ -3517,7 +3517,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
     });
   });
 
-  suite('errorHandler dynamic backoff', function() {
+  suite('errorHandler dynamic backoff', () => {
     // Test the error handler directly via provider.cloudApi.errorHandler
     // to verify Retry-After parsing and cap logic without waiting for
     // actual queue pauses.
@@ -3533,7 +3533,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       return err;
     };
 
-    test('uses Retry-After header value for backoff', function() {
+    test('uses Retry-After header value for backoff', () => {
       const result = provider.cloudApi.errorHandler({
         err: make429Error(60),
         tries: 0,
@@ -3544,7 +3544,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       assert.equal(result.level, 'notice');
     });
 
-    test('caps Retry-After at 120 seconds', function() {
+    test('caps Retry-After at 120 seconds', () => {
       const result = provider.cloudApi.errorHandler({
         err: make429Error(300),
         tries: 0,
@@ -3553,7 +3553,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       assert.equal(result.backoff, 120000);
     });
 
-    test('falls back to default backoff when Retry-After is absent', function() {
+    test('falls back to default backoff when Retry-After is absent', () => {
       const err = new Error('Too Many Requests');
       err.statusCode = 429;
       err.response = { headers: new FakeHttpHeaders({}) };
@@ -3562,7 +3562,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       assert.equal(result.backoff, 50);
     });
 
-    test('falls back to default backoff when Retry-After is non-numeric', function() {
+    test('falls back to default backoff when Retry-After is non-numeric', () => {
       const result = provider.cloudApi.errorHandler({
         err: make429Error('not-a-number'),
         tries: 0,
@@ -3570,7 +3570,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       assert.equal(result.backoff, 50);
     });
 
-    test('falls back to default backoff when Retry-After is zero', function() {
+    test('falls back to default backoff when Retry-After is zero', () => {
       const result = provider.cloudApi.errorHandler({
         err: make429Error(0),
         tries: 0,
@@ -3579,7 +3579,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       assert.equal(result.backoff, 50);
     });
 
-    test('falls back to default backoff when Retry-After is negative', function() {
+    test('falls back to default backoff when Retry-After is negative', () => {
       const result = provider.cloudApi.errorHandler({
         err: make429Error(-5),
         tries: 0,
@@ -3587,7 +3587,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       assert.equal(result.backoff, 50);
     });
 
-    test('integration: dynamic backoff observed in cloud-api-paused log', async function() {
+    test('integration: dynamic backoff observed in cloud-api-paused log', async () => {
       await makeWorkerPool();
       const worker = Worker.fromApi({
         workerPoolId,
@@ -3631,29 +3631,29 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
     });
   });
 
-  suite('Track 2 pipeline policy', function() {
+  suite('Track 2 pipeline policy', () => {
     let policy;
 
-    setup(function() {
+    setup(() => {
       // provider.setup() registers the policy on every Track 2 client's pipeline
       policy = fake.computeClient.pipeline.getPolicy('rateLimitObservabilityPolicy');
       assert.ok(policy, 'expected rateLimitObservabilityPolicy on computeClient pipeline');
     });
 
-    test('policy is registered with afterPhase: Retry', function() {
+    test('policy is registered with afterPhase: Retry', () => {
       const options = fake.computeClient.pipeline.getPolicyOptions('rateLimitObservabilityPolicy');
       assert.ok(options, 'expected addPolicy options');
       assert.equal(options.afterPhase, 'Retry');
     });
 
-    test('policy is registered on all Track 2 clients', function() {
+    test('policy is registered on all Track 2 clients', () => {
       for (const client of [fake.computeClient, fake.networkClient, fake.resourcesClient, fake.deploymentsClient]) {
         const p = client.pipeline.getPolicy('rateLimitObservabilityPolicy');
         assert.ok(p, 'expected policy on every Track 2 client');
       }
     });
 
-    test('records rate-limit gauge from 200 response', async function() {
+    test('records rate-limit gauge from 200 response', async () => {
       const gaugeRecords = [];
       const origMetric = provider.monitor._metric.azureRateLimitRemaining;
       provider.monitor._metric.azureRateLimitRemaining = (value, labels) => {
@@ -3686,7 +3686,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       }
     });
 
-    test('emits azureThrottled log and counter on 429 response', async function() {
+    test('emits azureThrottled log and counter on 429 response', async () => {
       const counterRecords = [];
       const origCounter = provider.monitor._metric.azureThrottleCount;
       provider.monitor._metric.azureThrottleCount = (value, labels) => {
@@ -3718,7 +3718,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       }
     });
 
-    test('derives operationType from HTTP method', async function() {
+    test('derives operationType from HTTP method', async () => {
       const methods = {
         'GET': 'read',
         'PUT': 'write',
@@ -3743,7 +3743,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       }
     });
 
-    test('passes response through unmodified', async function() {
+    test('passes response through unmodified', async () => {
       const mockResponse = {
         status: 200,
         headers: new FakeHttpHeaders({}),
@@ -3755,7 +3755,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
     });
   });
 
-  suite('scanCleanup', function() {
+  suite('scanCleanup', () => {
     const sandbox = sinon.createSandbox({});
     let reportedErrors = [];
 
@@ -3763,11 +3763,11 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       reportedErrors = [];
     });
 
-    teardown(function () {
+    teardown(() => {
       sandbox.restore();
     });
 
-    test('iterates all seen workers', async function() {
+    test('iterates all seen workers', async () => {
       sandbox.stub(provider, 'reportError');
       const workerPool1 = await makeWorkerPool({ workerPoolId: 'foo/bar1' });
       const workerPool2 = await makeWorkerPool({ workerPoolId: 'foo/bar2' });
@@ -3784,7 +3784,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       assert.equal(0, reportedErrors.length);
     });
 
-    test('iterates and reports errors', async function() {
+    test('iterates and reports errors', async () => {
       sandbox.replace(provider, 'reportError', (error) => {
         reportedErrors.push(error);
       });

--- a/services/worker-manager/test/provider_google_test.js
+++ b/services/worker-manager/test/provider_google_test.js
@@ -6,7 +6,7 @@ import { GoogleProvider } from '../src/providers/google.js';
 import testing from '@taskcluster/lib-testing';
 import { WorkerPool, WorkerPoolError, Worker, WorkerPoolStats } from '../src/data.js';
 
-helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
+helper.secrets.mockSuite(testing.suiteName(), [], (mock, skipping) => {
   helper.withDb(mock, skipping);
   helper.withPulse(mock, skipping);
   helper.withFakeQueue(mock, skipping);
@@ -21,7 +21,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
   const fake = new FakeGoogle;
   fake.forSuite();
 
-  setup(async function() {
+  setup(async () => {
     provider = new GoogleProvider({
       providerId,
       notify: await helper.load('notify'),
@@ -95,7 +95,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
   };
 
   const constructorTest = (name, creds) => {
-    test(name, async function() {
+    test(name, async () => {
       // this just has to not fail -- the google.auth.fromJSON call will fail if the creds
       // are malformed
       new GoogleProvider({
@@ -123,9 +123,9 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
   constructorTest('constructor with creds as string', '{"client_id": "fake-creds"}');
   constructorTest('constructor with creds as base64', Buffer.from('{"client_id": "fake-creds"}', 'utf8').toString('base64'));
 
-  suite('provisioning', function() {
+  suite('provisioning', () => {
     const provisionTest = (name, { config, expectedWorkers }, check) => {
-      test(name, async function() {
+      test(name, async () => {
         const workerPool = await makeWorkerPool({ config });
         const workerPoolStats = new WorkerPoolStats('wpid');
         await provider.provision({ workerPool, workerPoolStats });
@@ -414,7 +414,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       });
     });
 
-    test('failure from compute.insert', async function() {
+    test('failure from compute.insert', async () => {
       const workerPool = await makeWorkerPool();
       const workerPoolStats = new WorkerPoolStats('wpid');
 
@@ -429,7 +429,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       assert.equal(workers.length, 0); // nothing created
     });
 
-    test('rate-limiting from compute.insert', async function() {
+    test('rate-limiting from compute.insert', async () => {
       const workerPool = await makeWorkerPool();
       const workerPoolStats = new WorkerPoolStats('wpid');
 
@@ -449,7 +449,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
     });
   });
 
-  test('deprovision', async function() {
+  test('deprovision', async () => {
     const workerPool = await makeWorkerPool({
       // simulate previous provisionig and deleting the workerpool
       providerId: 'null-provider',
@@ -461,7 +461,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
     assert(workerPool.previousProviderIds.includes('google'));
   });
 
-  test('removeWorker', async function() {
+  test('removeWorker', async () => {
     const workerId = '12345';
     const worker = await makeWorker({
       workerPoolId,
@@ -484,7 +484,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
     assert.equal(worker.state, Worker.states.STOPPING);
   });
 
-  suite('checkWorker', function() {
+  suite('checkWorker', () => {
     const workerId = 'wkrid';
     const suiteMakeWorker = async (overrides) => {
       return await makeWorker({
@@ -512,7 +512,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       return worker;
     };
 
-    test('for a still-requested worker', async function() {
+    test('for a still-requested worker', async () => {
       await makeWorkerPool();
       let worker = await suiteMakeWorker({ state: 'requested' });
       fake.compute.instances.setFakeInstanceStatus(
@@ -525,7 +525,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       assert.equal(worker.state, Worker.states.REQUESTED);
     });
 
-    test('for a running worker', async function() {
+    test('for a running worker', async () => {
       await makeWorkerPool();
       let worker = await suiteMakeWorker({ state: 'running' });
       fake.compute.instances.setFakeInstanceStatus(
@@ -536,7 +536,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       assert.equal(worker.state, Worker.states.RUNNING);
     });
 
-    test('for a terminated instance', async function() {
+    test('for a terminated instance', async () => {
       await makeWorkerPool();
       let worker = await suiteMakeWorker({ state: 'running' });
       fake.compute.instances.setFakeInstanceStatus(
@@ -548,7 +548,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       helper.assertPulseMessage('worker-stopped', m => m.payload.launchConfigId === worker.launchConfigId);
     });
 
-    test('for a stopped instance', async function() {
+    test('for a stopped instance', async () => {
       await makeWorkerPool();
       let worker = await suiteMakeWorker({ state: 'running' });
       fake.compute.instances.setFakeInstanceStatus(
@@ -559,7 +559,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       helper.assertPulseMessage('worker-stopped', m => m.payload.workerId === workerId);
     });
 
-    test('for a nonexistent instance', async function() {
+    test('for a nonexistent instance', async () => {
       await makeWorkerPool();
       let worker = await suiteMakeWorker({ state: 'requested' });
       worker = await runCheckWorker(worker);
@@ -567,7 +567,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       helper.assertPulseMessage('worker-stopped', m => m.payload.workerId === workerId);
     });
 
-    test('for a nonexistent instance with a running operation', async function() {
+    test('for a nonexistent instance with a running operation', async () => {
       await makeWorkerPool();
       const operation = fake.compute.zoneOperations.fakeOperation({ zone: 'us-east1-a' });
       let worker = await suiteMakeWorker({ state: 'requested', providerData: { operation } });
@@ -576,7 +576,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       helper.assertNoPulseMessage('worker-stopped');
     });
 
-    test('for a nonexistent instance with a failed operation', async function() {
+    test('for a nonexistent instance with a failed operation', async () => {
       await makeWorkerPool();
       const operation = fake.compute.zoneOperations.fakeOperation({
         zone: 'us-east1-a',
@@ -597,7 +597,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       helper.assertPulseMessage('worker-stopped', m => m.payload.launchConfigId === 'lc1');
     });
 
-    test('remove unregistered workers after terminateAfter', async function() {
+    test('remove unregistered workers after terminateAfter', async () => {
       const terminateAfter = Date.now() - 1000;
       let worker = await suiteMakeWorker({ providerData: { terminateAfter } });
       fake.compute.instances.setFakeInstanceStatus(
@@ -619,7 +619,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       helper.assertPulseMessage('worker-stopped', m => m.payload.workerId === workerId);
     });
 
-    test('don\'t remove unregistered before terminateAfter', async function() {
+    test('don\'t remove unregistered before terminateAfter', async () => {
       const terminateAfter = Date.now() + 1000;
       let worker = await suiteMakeWorker({
         created: taskcluster.fromNow('-30 minutes'),
@@ -633,7 +633,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       assert.equal(worker.state, Worker.states.RUNNING);
       helper.assertNoPulseMessage('worker-stopped');
     });
-    test('do not remove registered workers with stale terminateAfter', async function () {
+    test('do not remove registered workers with stale terminateAfter', async () => {
       const terminateAfter = Date.now() - 1000;
       let worker = await suiteMakeWorker({
         created: taskcluster.fromNow('-30 minutes'),
@@ -651,7 +651,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       assert(!fake.compute.instances.delete_called);
       assert.equal(worker.state, 'running');
     });
-    test('remove zombie worker with no queue activity', async function () {
+    test('remove zombie worker with no queue activity', async () => {
       const queueInactivityTimeout = 1;
       let worker = await suiteMakeWorker({ providerData: { queueInactivityTimeout } });
       fake.compute.instances.setFakeInstanceStatus(
@@ -672,7 +672,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       assert.equal(worker.state, Worker.states.STOPPED);
       helper.assertPulseMessage('worker-stopped', m => m.payload.workerId === workerId);
     });
-    test('remove zombie worker that was active long ago', async function () {
+    test('remove zombie worker that was active long ago', async () => {
       const queueInactivityTimeout = 120;
       let worker = await suiteMakeWorker({ providerData: { queueInactivityTimeout } });
       fake.compute.instances.setFakeInstanceStatus(
@@ -695,7 +695,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       assert.equal(worker.state, Worker.states.STOPPED);
       helper.assertPulseMessage('worker-stopped', m => m.payload.workerId === workerId);
     });
-    test('don\'t remove zombie worker that was recently active', async function () {
+    test('don\'t remove zombie worker that was recently active', async () => {
       const queueInactivityTimeout = 60 * 60 * 4 * 1000; // 4 hours
       let worker = await suiteMakeWorker({ providerData: { queueInactivityTimeout } });
       fake.compute.instances.setFakeInstanceStatus(
@@ -714,7 +714,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
     });
   });
 
-  suite('registerWorker', function() {
+  suite('registerWorker', () => {
     const workerGroup = 'us-east1-a';
     const workerId = 'abc123';
 
@@ -732,7 +732,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       providerData: {},
     };
 
-    test('no token', async function() {
+    test('no token', async () => {
       const workerPool = await makeWorkerPool();
       const worker = await makeWorker({
         ...defaultWorker,
@@ -743,7 +743,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       /Token validation error/);
     });
 
-    test('invalid token', async function() {
+    test('invalid token', async () => {
       const workerPool = await makeWorkerPool();
       const worker = await makeWorker({
         ...defaultWorker,
@@ -754,7 +754,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       /Token validation error/);
     });
 
-    test('wrong project', async function() {
+    test('wrong project', async () => {
       const workerPool = await makeWorkerPool();
       const worker = await makeWorker({
         ...defaultWorker,
@@ -765,7 +765,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       /Token validation error/);
     });
 
-    test('wrong sub', async function() {
+    test('wrong sub', async () => {
       const workerPool = await makeWorkerPool();
       const worker = await makeWorker({
         ...defaultWorker,
@@ -776,7 +776,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       /Token validation error/);
     });
 
-    test('wrong instance ID', async function() {
+    test('wrong instance ID', async () => {
       const workerPool = await makeWorkerPool();
       const worker = await makeWorker({
         ...defaultWorker,
@@ -787,7 +787,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       /Token validation error/);
     });
 
-    test('wrong worker state (duplicate call to registerWorker)', async function() {
+    test('wrong worker state (duplicate call to registerWorker)', async () => {
       const workerPool = await makeWorkerPool();
       const worker = await makeWorker({
         ...defaultWorker,
@@ -800,7 +800,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       helper.assertNoPulseMessage('worker-running');
     });
 
-    test('sweet success', async function() {
+    test('sweet success', async () => {
       const workerPool = await makeWorkerPool();
       const worker = await makeWorker({
         ...defaultWorker,
@@ -819,7 +819,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       helper.assertPulseMessage('worker-running', m => m.payload.workerId === worker.workerId);
     });
 
-    test('sweet success (different reregister)', async function() {
+    test('sweet success (different reregister)', async () => {
       const workerPool = await makeWorkerPool();
       const worker = await makeWorker({
         ...defaultWorker,

--- a/services/worker-manager/test/provider_static_test.js
+++ b/services/worker-manager/test/provider_static_test.js
@@ -5,7 +5,7 @@ import { StaticProvider } from '../src/providers/static.js';
 import testing from '@taskcluster/lib-testing';
 import { WorkerPool, Worker } from '../src/data.js';
 
-helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
+helper.secrets.mockSuite(testing.suiteName(), [], (mock, skipping) => {
   helper.withDb(mock, skipping);
   helper.withPulse(mock, skipping);
   helper.withFakeQueue(mock, skipping);
@@ -50,7 +50,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
     emailOnError: false,
   };
 
-  setup(async function() {
+  setup(async () => {
     provider = new StaticProvider({
       providerId,
       db: helper.db,
@@ -72,7 +72,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
     await provider.setup();
   });
 
-  test('updateWorker updates expires, capacity, secret', async function() {
+  test('updateWorker updates expires, capacity, secret', async () => {
     let worker = Worker.fromApi(defaultWorker);
     await worker.create(helper.db);
 
@@ -96,7 +96,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
     ]);
   });
 
-  test('removeWorker marks the worker as stopped', async function() {
+  test('removeWorker marks the worker as stopped', async () => {
     const worker = Worker.fromApi(defaultWorker);
     await worker.create(helper.db);
 
@@ -108,7 +108,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
     ]);
   });
 
-  suite('registerWorker', function() {
+  suite('registerWorker', () => {
     // create a test worker pool directly in the DB
     const createWorker = overrides => {
       const worker = Worker.fromApi(
@@ -116,7 +116,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       return worker.create(helper.db);
     };
 
-    test('no token', async function() {
+    test('no token', async () => {
       const worker = await createWorker({ state: 'running' });
       const workerIdentityProof = {};
       await assert.rejects(() =>
@@ -124,7 +124,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       /missing staticSecret/);
     });
 
-    test('not running', async function() {
+    test('not running', async () => {
       const worker = await createWorker({ state: 'stopped' });
       const workerIdentityProof = { staticSecret: 'good' };
       await assert.rejects(() =>
@@ -132,7 +132,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       /worker is not running/);
     });
 
-    test('invalid token', async function() {
+    test('invalid token', async () => {
       const worker = await createWorker({ state: 'running' });
       const workerIdentityProof = { staticSecret: 'invalid' };
       await assert.rejects(() =>
@@ -140,7 +140,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       /bad staticSecret/);
     });
 
-    test('successful registration', async function() {
+    test('successful registration', async () => {
       const pool = WorkerPool.fromApi({
         ...defaultWorkerPool,
         workerPoolId: 'pool/config',

--- a/services/worker-manager/test/provider_test.js
+++ b/services/worker-manager/test/provider_test.js
@@ -6,24 +6,24 @@ import testing from '@taskcluster/lib-testing';
 import { WorkerPool, WorkerPoolError, Worker } from '../src/data.js';
 import { LEVELS } from '@taskcluster/lib-monitor';
 
-helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
+helper.secrets.mockSuite(testing.suiteName(), [], (mock, skipping) => {
   helper.withDb(mock, skipping);
   helper.withPulse(mock, skipping);
   helper.withFakeNotify(mock, skipping);
   helper.resetTables(mock, skipping);
 
   let monitor;
-  suiteSetup(async function() {
+  suiteSetup(async () => {
     monitor = await helper.load('monitor');
   });
 
   let oldnow;
-  setup(function() {
+  setup(() => {
     oldnow = Date.now;
     Date.now = () => 100;
   });
 
-  teardown(function() {
+  teardown(() => {
     Date.now = oldnow;
   });
 
@@ -55,25 +55,25 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       launchConfigSelector: await helper.load('launchConfigSelector'),
     });
 
-  suite('interpretLifecycle', function() {
-    test('no lifecycle', async function() {
+  suite('interpretLifecycle', () => {
+    test('no lifecycle', async () => {
       assert.equal(345600100, Provider.interpretLifecycle({}).terminateAfter);
     });
 
-    test('empty lifecycle', async function() {
+    test('empty lifecycle', async () => {
       assert.equal(345600100, Provider.interpretLifecycle({ lifecycle: {} }).terminateAfter);
     });
 
-    test('no queueInactivityTimeout', async function () {
+    test('no queueInactivityTimeout', async () => {
       assert.equal(7200000, Provider.interpretLifecycle({}).queueInactivityTimeout);
     });
 
-    test('only queueInactivityTimeout', async function () {
+    test('only queueInactivityTimeout', async () => {
       assert.equal(4000, Provider.interpretLifecycle({
         lifecycle: { queueInactivityTimeout: 4 } }).queueInactivityTimeout);
     });
 
-    test('only registrationTimeout', async function() {
+    test('only registrationTimeout', async () => {
       assert.deepEqual({
         terminateAfter: 10100,
         reregistrationTimeout: 345600000,
@@ -81,7 +81,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       }, Provider.interpretLifecycle({ lifecycle: { registrationTimeout: 10 } }));
     });
 
-    test('only reregistrationTimeout', async function() {
+    test('only reregistrationTimeout', async () => {
       assert.deepEqual({
         terminateAfter: 10100,
         reregistrationTimeout: 10000,
@@ -89,7 +89,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       }, Provider.interpretLifecycle({ lifecycle: { reregistrationTimeout: 10 } }));
     });
 
-    test('greater registrationTimeout', async function() {
+    test('greater registrationTimeout', async () => {
       assert.deepEqual({
         terminateAfter: 10100,
         reregistrationTimeout: 10000,
@@ -101,7 +101,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       } }));
     });
 
-    test('greater reregistrationTimeout', async function() {
+    test('greater reregistrationTimeout', async () => {
       assert.deepEqual({
         terminateAfter: 10100,
         reregistrationTimeout: 100000,
@@ -113,8 +113,8 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
     });
   });
 
-  suite('isZombie', function() {
-    test('default queue inactivity timeout', function() {
+  suite('isZombie', () => {
+    test('default queue inactivity timeout', () => {
       Date.now = oldnow;
       const worker = Worker.fromApi({});
       worker.created = taskcluster.fromNow('-4 hours');
@@ -124,7 +124,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       assert.equal(res.isZombie, true);
       assert.match(res.reason, /queueInactivityTimeout=7200s/);
     });
-    test('no firstClaim', function() {
+    test('no firstClaim', () => {
       Date.now = oldnow;
       const worker = Worker.fromApi({});
       worker.created = taskcluster.fromNow('-4 hours');
@@ -134,7 +134,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       assert.equal(res.isZombie, true);
       assert.match(res.reason, /worker never claimed work/);
     });
-    test('not active within queueInactivityTimeout', function() {
+    test('not active within queueInactivityTimeout', () => {
       Date.now = oldnow;
       const worker = Worker.fromApi({
         providerData: {
@@ -148,7 +148,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       assert.equal(res.isZombie, true);
       assert.match(res.reason, /worker inactive/);
     });
-    test('not a zombie', function() {
+    test('not a zombie', () => {
       Date.now = oldnow;
       const worker = Worker.fromApi({
         providerData: {
@@ -161,7 +161,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       const res = Provider.isZombie({ worker });
       assert.equal(res.isZombie, false);
     });
-    test('fields not fetched from database (defensive check)', function() {
+    test('fields not fetched from database (defensive check)', () => {
       Date.now = oldnow;
       const worker = Worker.fromApi({});
       worker.created = taskcluster.fromNow('-4 hours');
@@ -172,13 +172,13 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
     });
   });
 
-  suite('reportError', function() {
+  suite('reportError', () => {
     let provider;
-    suiteSetup(async function() {
+    suiteSetup(async () => {
       provider = await createProvider();
     });
 
-    test('report errors (no email)', async function() {
+    test('report errors (no email)', async () => {
       const workerPool = await createWP();
 
       await provider.reportError({
@@ -197,7 +197,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       assert.equal(helper.notify.emails.length, 0);
     });
 
-    test('report errors (w/ email)', async function() {
+    test('report errors (w/ email)', async () => {
       const workerPool = await createWP({ emailOnError: true });
 
       await provider.reportError({
@@ -217,7 +217,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       assert.equal(helper.notify.emails[0].address, 'whatever@example.com');
     });
 
-    test('report errors (no duplicate emails)', async function() {
+    test('report errors (no duplicate emails)', async () => {
       const workerPool = await createWP({ emailOnError: true });
       const errorDetails = {
         workerPool,
@@ -244,7 +244,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       assert.equal(helper.notify.emails.length, 1);
     });
 
-    test('report errors (w/ email and extraInfo)', async function() {
+    test('report errors (w/ email and extraInfo)', async () => {
       const workerPool = await createWP({ emailOnError: true });
 
       await provider.reportError({
@@ -302,14 +302,14 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
     });
   });
 
-  suite('selectLaunchConfigsForSpawn', function () {
+  suite('selectLaunchConfigsForSpawn', () => {
     let provider;
 
-    suiteSetup(async function() {
+    suiteSetup(async () => {
       provider = await createProvider();
     });
 
-    test('selects configs', async function () {
+    test('selects configs', async () => {
       const workerPool = await createWP();
 
       const configs = await provider.selectLaunchConfigsForSpawn({ workerPool, toSpawn: 1 });
@@ -325,10 +325,10 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
     });
   });
 
-  suite('worker metrics', function() {
+  suite('worker metrics', () => {
     let provider;
 
-    suiteSetup(async function() {
+    suiteSetup(async () => {
       provider = await createProvider();
     });
 
@@ -350,7 +350,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       return worker;
     };
 
-    test('records registration duration on workerRunning', async function() {
+    test('records registration duration on workerRunning', async () => {
       const worker = await createWorker();
 
       let metricRecorded = false;
@@ -368,7 +368,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       monitor.metric.workerRegistrationDuration = originalMetric;
     });
 
-    test('includes workerAge and runningDuration on workerStopped', async function() {
+    test('includes workerAge and runningDuration on workerStopped', async () => {
       const worker = await createWorker({
         workerId: 'wi-stopped',
         state: Worker.states.RUNNING,
@@ -393,7 +393,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       monitor.metric.workerLifetime = originalMetric;
     });
 
-    test('includes workerAge and runningDuration on workerRemoved', async function() {
+    test('includes workerAge and runningDuration on workerRemoved', async () => {
       const worker = await createWorker({
         workerId: 'wi-removed',
         state: Worker.states.RUNNING,
@@ -419,7 +419,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       monitor.metric.workerLifetime = originalMetric;
     });
 
-    test('omits runningDuration when worker never registered', async function() {
+    test('omits runningDuration when worker never registered', async () => {
       const worker = await createWorker({
         workerId: 'wi-never-reg',
         state: Worker.states.REQUESTED,
@@ -439,7 +439,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       monitor.metric.workerRegistrationFailure = originalMetric;
     });
 
-    test('records lifetime on workerStopped', async function() {
+    test('records lifetime on workerStopped', async () => {
       const worker = await createWorker({
         workerId: 'wi2',
         state: Worker.states.RUNNING,
@@ -460,7 +460,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       monitor.metric.workerLifetime = originalMetric;
     });
 
-    test('records registration failure when worker never registered', async function() {
+    test('records registration failure when worker never registered', async () => {
       const worker = await createWorker({ workerId: 'wi3' });
 
       let metricRecorded = false;
@@ -473,7 +473,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       monitor.metric.workerRegistrationFailure = originalMetric;
     });
 
-    test('does not double-record lifetime', async function() {
+    test('does not double-record lifetime', async () => {
       const worker = await createWorker({
         workerId: 'wi4',
         state: Worker.states.RUNNING,

--- a/services/worker-manager/test/providers_test.js
+++ b/services/worker-manager/test/providers_test.js
@@ -3,16 +3,16 @@ import helper from './helper.js';
 import testing from '@taskcluster/lib-testing';
 import { setSetupRetryInterval } from '../src/providers/index.js';
 
-helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
+helper.secrets.mockSuite(testing.suiteName(), [], (mock, skipping) => {
   helper.withDb(mock, skipping);
   helper.withPulse(mock, skipping);
   helper.withFakeNotify(mock, skipping);
   helper.withProviders(mock, skipping);
   helper.resetTables(mock, skipping);
 
-  suite('failing provider setup', function() {
+  suite('failing provider setup', () => {
     let monitor;
-    setup(async function() {
+    setup(async () => {
       monitor = await helper.load('monitor');
 
       setSetupRetryInterval(100); // 100ms by default, to avoid providers retrying for too long
@@ -24,7 +24,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       helper.load.remove('providers');
     });
 
-    teardown(function() {
+    teardown(() => {
       // check for and flush the errors about the provider starting up
       assert(
         monitor.manager.messages.every(
@@ -32,20 +32,20 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       monitor.manager.reset();
     });
 
-    test('failed provider is not included in forAll, but has returns true', async function() {
+    test('failed provider is not included in forAll, but has returns true', async () => {
       helper.load.cfg('providers.testing1.setupFailure', 1);
       const providers = await helper.load('providers');
       await providers.forAll(prov => assert.notEqual(prov.providerId, 'testing1'));
       assert(providers.has('testing1'));
     });
 
-    test('failed provider is returned by get with `setupFailed` property', async function() {
+    test('failed provider is returned by get with `setupFailed` property', async () => {
       helper.load.cfg('providers.testing1.setupFailure', 1);
       const providers = await helper.load('providers');
       assert.deepEqual(providers.get('testing1'), { setupFailed: true });
     });
 
-    test('provider is returned by get once it succeeds', async function() {
+    test('provider is returned by get once it succeeds', async () => {
       setSetupRetryInterval(5); // very short, since we want this to recover quickly
       helper.load.cfg('providers.testing1.setupFailure', 2);
       const providers = await helper.load('providers');

--- a/services/worker-manager/test/provisioner_test.js
+++ b/services/worker-manager/test/provisioner_test.js
@@ -6,7 +6,7 @@ import { LEVELS } from '@taskcluster/lib-monitor';
 import { WorkerPool, Worker } from '../src/data.js';
 import { ApiError } from '../src/providers/provider.js';
 
-helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
+helper.secrets.mockSuite(testing.suiteName(), [], (mock, skipping) => {
   helper.withDb(mock, skipping);
   helper.withPulse(mock, skipping);
   helper.withFakeNotify(mock, skipping);
@@ -17,7 +17,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
   helper.resetTables(mock, skipping);
 
   let monitor;
-  suiteSetup(async function() {
+  suiteSetup(async () => {
     monitor = await helper.load('monitor');
   });
   const makeDurationPredictable = (msg) => {
@@ -27,7 +27,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
     return msg;
   };
 
-  suite('provisioning loop', function() {
+  suite('provisioning loop', () => {
     const testCase = async ({ workers = [], workerPools = [], assertion, expectErrors = false }) => {
       await Promise.all(workers.map(async w => {
         const worker = Worker.fromApi(w);
@@ -313,8 +313,8 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
     }));
   });
 
-  suite('provision', function() {
-    test('provision scan provisions a worker pool', async function() {
+  suite('provision', () => {
+    test('provision scan provisions a worker pool', async () => {
       await WorkerPool.fromApi({
         workerPoolId: 'pp/ww',
         providerId: 'testing1',
@@ -338,7 +338,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       });
     });
 
-    test('provision scan skips worker pools with unknown providerId', async function() {
+    test('provision scan skips worker pools with unknown providerId', async () => {
       await WorkerPool.fromApi({
         workerPoolId: 'pp/ww',
         providerId: 'NO-SUCH',
@@ -366,7 +366,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
         });
     });
 
-    test('provision scan skips worker pools with unknown previous providerId', async function() {
+    test('provision scan skips worker pools with unknown previous providerId', async () => {
       await WorkerPool.fromApi({
         workerPoolId: 'pp/ww',
         providerId: 'testing1',
@@ -397,7 +397,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
         });
     });
 
-    test("provision loop is not running in parallel", async function() {
+    test("provision loop is not running in parallel", async () => {
       await WorkerPool.fromApi({
         workerPoolId: 'pp/ww',
         providerId: 'testing1',
@@ -430,8 +430,8 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
     });
   });
 
-  suite('deprovisioning loop', function() {
-    test('create and destroy', async function() {
+  suite('deprovisioning loop', () => {
+    test('create and destroy', async () => {
       const workerPool = {
         workerPoolId: 'pp/ee',
         input: {
@@ -477,7 +477,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
         });
     });
 
-    test('create and change', async function() {
+    test('create and change', async () => {
       const workerPool = {
         workerPoolId: 'pp/ee',
         input: {

--- a/services/worker-manager/test/util_test.js
+++ b/services/worker-manager/test/util_test.js
@@ -2,35 +2,35 @@ import assert from 'node:assert';
 import * as util from '../src/util.js';
 import testing from '@taskcluster/lib-testing';
 
-suite(testing.suiteName(), function () {
-  suite('workerPoolId', function () {
-    test('splitWorkerPoolId for valid workerPoolId', function () {
+suite(testing.suiteName(), () => {
+  suite('workerPoolId', () => {
+    test('splitWorkerPoolId for valid workerPoolId', () => {
       assert.deepEqual(util.splitWorkerPoolId('provFoo/wtFoo'),
         { provisionerId: 'provFoo', workerType: 'wtFoo' });
     });
 
-    test('splitWorkerPoolId for invalid workerPoolId', function () {
+    test('splitWorkerPoolId for invalid workerPoolId', () => {
       assert.throws(() => util.splitWorkerPoolId('noSlashes'), /invalid workerPoolId/);
     });
 
-    test('joinWorkerPoolId for valid inputs', function () {
+    test('joinWorkerPoolId for valid inputs', () => {
       assert.equal(util.joinWorkerPoolId('myProv', 'myWt'), 'myProv/myWt');
     });
 
-    test('joinWorkerPoolId for undefined provisionerId', function () {
+    test('joinWorkerPoolId for undefined provisionerId', () => {
       assert.throws(() => util.joinWorkerPoolId(undefined, 'myWt'), /provisionerId omitted/);
     });
 
-    test('joinWorkerPoolId for invalid provisionerId', function () {
+    test('joinWorkerPoolId for invalid provisionerId', () => {
       assert.throws(() => util.joinWorkerPoolId('a/b', 'myWt'), /provisionerId cannot contain/);
     });
 
-    test('joinWorkerPoolId for undefined workerTypoe', function () {
+    test('joinWorkerPoolId for undefined workerTypoe', () => {
       assert.throws(() => util.joinWorkerPoolId('myProv', undefined), /workerType omitted/);
     });
   });
 
-  suite('sanitizeRegisterWorkerPayload', function () {
+  suite('sanitizeRegisterWorkerPayload', () => {
     const testPairs = [
       [{}, {}],
       [{ one: 1, two: '2', arr: [] }, { one: 1, two: '2', arr: [] }],
@@ -43,13 +43,13 @@ suite(testing.suiteName(), function () {
     }));
   });
 
-  suite('measureTime', function () {
-    test('measureTime returns function that returns total time', function () {
+  suite('measureTime', () => {
+    test('measureTime returns function that returns total time', () => {
       const start = util.measureTime();
       const total = start();
       assert(total > 0);
     });
-    test('measureTime uses different precision', function () {
+    test('measureTime uses different precision', () => {
       const start1 = util.measureTime(1e9);
       const start2 = util.measureTime(1e6);
 

--- a/services/worker-manager/test/worker_scanner_test.js
+++ b/services/worker-manager/test/worker_scanner_test.js
@@ -5,7 +5,7 @@ import taskcluster from '@taskcluster/client';
 import { LEVELS } from '@taskcluster/lib-monitor';
 import { Worker, WorkerPool } from '../src/data.js';
 
-helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
+helper.secrets.mockSuite(testing.suiteName(), [], (mock, skipping) => {
   helper.withDb(mock, skipping);
   helper.withPulse(mock, skipping);
   helper.withFakeQueue(mock, skipping);
@@ -16,7 +16,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
   helper.resetTables(mock, skipping);
 
   let monitor;
-  suiteSetup(async function() {
+  suiteSetup(async () => {
     monitor = await helper.load('monitor');
   });
 
@@ -256,7 +256,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
     await scanner.terminate();
   });
 
-  test('scan loop is not running in parallel', async function() {
+  test('scan loop is not running in parallel', async () => {
     const providers = await helper.load('providers');
     const estimator = await helper.load('estimator');
     const scanner = new (await import('../src/worker-scanner.js')).WorkerScanner({
@@ -285,10 +285,10 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
     monitor.manager.reset();
   });
 
-  suite('termination decisions', function() {
+  suite('termination decisions', () => {
     let scanner, providers, estimator;
 
-    suiteSetup(async function() {
+    suiteSetup(async () => {
       if (skipping()) {
         return;
       }
@@ -296,7 +296,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       estimator = await helper.load('estimator');
     });
 
-    setup(async function() {
+    setup(async () => {
       // Create a fresh scanner for each test (no iterate loop, just call scan() directly)
       scanner = new (await import('../src/worker-scanner.js')).WorkerScanner({
         ownName: 'test-scanner',
@@ -336,7 +336,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       return worker.create(helper.db);
     };
 
-    test('worker with archived launch config is marked for termination', async function() {
+    test('worker with archived launch config is marked for termination', async () => {
       const poolId = 'pp/archived';
       await createPool(poolId, { maxCapacity: 10 });
       await createLaunchConfig('lc-archived', poolId, true);
@@ -367,7 +367,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       assert(worker.providerData.shouldTerminate.decidedAt);
     });
 
-    test('idle workers with minCapacity=0 and no pending tasks are terminated', async function() {
+    test('idle workers with minCapacity=0 and no pending tasks are terminated', async () => {
       const poolId = 'pp/overcap';
       await createPool(poolId, { maxCapacity: 10, minCapacity: 0 });
       await createLaunchConfig('lc-active', poolId, false);
@@ -406,7 +406,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       assert.strictEqual(wNewest.providerData.shouldTerminate.terminate, true);
     });
 
-    test('all workers needed when pending tasks require them', async function() {
+    test('all workers needed when pending tasks require them', async () => {
       const poolId = 'pp/needed';
       await createPool(poolId, { maxCapacity: 10, minCapacity: 0 });
       await createLaunchConfig('lc-needed', poolId, false);
@@ -445,7 +445,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       assert.strictEqual(wNewest.providerData.shouldTerminate.terminate, false);
     });
 
-    test('excess workers with maxCapacity=1 — oldest terminated', async function() {
+    test('excess workers with maxCapacity=1 — oldest terminated', async () => {
       const poolId = 'pp/excess';
       await createPool(poolId, { maxCapacity: 1, minCapacity: 0 });
       await createLaunchConfig('lc-active2', poolId, false);
@@ -478,7 +478,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       assert.strictEqual(wNew.providerData.shouldTerminate.reason, 'needed');
     });
 
-    test('workers with claimed tasks and pending tasks are not terminated', async function() {
+    test('workers with claimed tasks and pending tasks are not terminated', async () => {
       const poolId = 'pp/claimed';
       await createPool(poolId, { maxCapacity: 10, minCapacity: 0 });
       await createLaunchConfig('lc-claimed', poolId, false);
@@ -518,7 +518,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       assert.strictEqual(w3.providerData.shouldTerminate.terminate, false);
     });
 
-    test('workers at minCapacity are not marked even with no pending tasks', async function() {
+    test('workers at minCapacity are not marked even with no pending tasks', async () => {
       const poolId = 'pp/mincap';
       await createPool(poolId, { maxCapacity: 10, minCapacity: 2 });
       await createLaunchConfig('lc-min', poolId, false);
@@ -549,7 +549,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       assert.strictEqual(w2.providerData.shouldTerminate.terminate, false);
     });
 
-    test('decision is reversible when demand returns', async function() {
+    test('decision is reversible when demand returns', async () => {
       const poolId = 'pp/reverse';
       await createPool(poolId, { maxCapacity: 10, minCapacity: 0 });
       await createLaunchConfig('lc-rev', poolId, false);
@@ -586,7 +586,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       assert.strictEqual(w.providerData.shouldTerminate.reason, 'needed');
     });
 
-    test('reducing minCapacity marks workers for termination on next scan', async function() {
+    test('reducing minCapacity marks workers for termination on next scan', async () => {
       const poolId = 'pp/minchange';
       await createPool(poolId, { maxCapacity: 10, minCapacity: 1 });
       await createLaunchConfig('lc-minchange', poolId, false);
@@ -626,7 +626,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       assert.strictEqual(w.providerData.shouldTerminate.reason, 'over capacity');
     });
 
-    test('static provider workers do not get shouldTerminate set', async function() {
+    test('static provider workers do not get shouldTerminate set', async () => {
       await createWorker({
         workerPoolId: 'pp/static',
         workerGroup: 'wg',
@@ -649,7 +649,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       assert.strictEqual(worker.providerData.shouldTerminate, undefined);
     });
 
-    test('emits workersToTerminate metric with correct values and labels', async function() {
+    test('emits workersToTerminate metric with correct values and labels', async () => {
       const poolId = 'pp/metrics';
       await createPool(poolId, { maxCapacity: 1, minCapacity: 0 });
       await createLaunchConfig('lc-metric-active', poolId, false);
@@ -708,7 +708,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       }
     });
 
-    test('integration: scanner decision is returned by API endpoint', async function() {
+    test('integration: scanner decision is returned by API endpoint', async () => {
       const poolId = 'pp/integ';
       await createPool(poolId, { maxCapacity: 1, minCapacity: 0 });
       await createLaunchConfig('lc-integ', poolId, false);

--- a/services/worker-manager/test/worker_test.js
+++ b/services/worker-manager/test/worker_test.js
@@ -3,7 +3,7 @@ import testing from '@taskcluster/lib-testing';
 import helper from './helper.js';
 import { Worker } from '../src/data.js';
 
-helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
+helper.secrets.mockSuite(testing.suiteName(), [], (mock, skipping) => {
   helper.withDb(mock, skipping);
   helper.resetTables(mock, skipping);
 
@@ -20,8 +20,8 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
     return worker.create(helper.db);
   };
 
-  suite('worker.update', function() {
-    test('worker.update', async function() {
+  suite('worker.update', () => {
+    test('worker.update', async () => {
       const worker = await createWorker();
       await worker.update(helper.db, worker => {
         worker.capacity = 2;
@@ -32,7 +32,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       assert.equal(worker.providerId, 'updated');
     });
 
-    test('worker.update (concurrent)', async function() {
+    test('worker.update (concurrent)', async () => {
       // worker.capacity defaults to 1
       const worker = await createWorker();
       await Promise.all([


### PR DESCRIPTION
These are less verbose but mostly, they avoid the huge javascript footgun of having this not being inherited from the parent scope and instead being the function itself which is pretty much never what you want...

There was only one case where the fix broke something and it was in a mock for google oauth2 in worker-manager because we're using that function as a constructor which arrow functions can't be used as (IMO, also a win...). I applied `useArrowFunction` in this commit and reverted that one change manually which will explain why a second run would get that different. Since biome's not in yet I decided to keep the `biome-ignore` rule for a later commit where it'll actually make sense.

Fixes biome's useArrowFunction lint
