### PR TITLE
Remove useless constructors in worker-manager tests

### DIFF
--- a/changelog/VN0mQ3jGSfOaIjJnw3R7JA.md
+++ b/changelog/VN0mQ3jGSfOaIjJnw3R7JA.md
@@ -1,0 +1,2 @@
+level: silent
+---

--- a/services/worker-manager/test/fakes/aws.js
+++ b/services/worker-manager/test/fakes/aws.js
@@ -19,9 +19,6 @@ const TEST_REGIONS = [
  * Fake the EC2 AWS SDK.
  */
 export class FakeEC2 extends FakeCloud {
-  constructor() {
-    super();
-  }
 
   _patch() {
     this._reset();

--- a/services/worker-manager/test/fakes/azure.js
+++ b/services/worker-manager/test/fakes/azure.js
@@ -12,9 +12,6 @@ import slugid from 'slugid';
  * that allow access to fakes for those interfaces.
  */
 export class FakeAzure extends FakeCloud {
-  constructor() {
-    super();
-  }
 
   _patch() {
     this.sinon.stub(azureApi, 'AzureServiceClient').callsFake((creds) => {

--- a/services/worker-manager/test/fakes/google.js
+++ b/services/worker-manager/test/fakes/google.js
@@ -18,9 +18,6 @@ const PROJECT = 'testy';
  * the instance returned from the constructor is available at `fake.oauth2`.
  */
 export class FakeGoogle extends FakeCloud {
-  constructor() {
-    super();
-  }
 
   _patch() {
     this.sinon.stub(google, 'auth');


### PR DESCRIPTION
Those constructors are exactly what JS does, biome doesn't like them, doesn't change any behavior

Fixes biome's noUselessConstructor lint