### PR TITLE
Remove useless `this` aliases in the index service

### DIFF
--- a/changelog/IhKbQchATJCBF-vqmNdWbg.md
+++ b/changelog/IhKbQchATJCBF-vqmNdWbg.md
@@ -1,0 +1,2 @@
+level: silent
+---

--- a/services/index/src/api.js
+++ b/services/index/src/api.js
@@ -344,7 +344,6 @@ builder.declare({
     'If no task exists for the given index path, this API end-point responds with 404.',
   ].join('\n'),
 }, async function(req, res) {
-  let that = this;
   let indexPath = req.params.indexPath || '';
   const artifactName = req.params.name;
 
@@ -364,30 +363,30 @@ builder.declare({
 
   let isPublic = false;
   try {
-    isPublic = await that.isPublicArtifact(artifactName);
+    isPublic = await this.isPublicArtifact(artifactName);
   } catch {
     isPublic = false;
   }
 
   if (isPublic) {
     try {
-      const artifact = await that.queue.latestArtifact(task.taskId, artifactName);
+      const artifact = await this.queue.latestArtifact(task.taskId, artifactName);
       if (artifact.url) {
         return res.redirect(303, artifact.url);
       }
     } catch {
       // fall through to queue redirect
     }
-    const url = that.queue.externalBuildUrl(
-      that.queue.getLatestArtifact,
+    const url = this.queue.externalBuildUrl(
+      this.queue.getLatestArtifact,
       task.taskId,
       artifactName,
     );
     return res.redirect(303, url);
   }
 
-  const url = that.queue.externalBuildSignedUrl(
-    that.queue.getLatestArtifact,
+  const url = this.queue.externalBuildSignedUrl(
+    this.queue.getLatestArtifact,
     task.taskId,
     artifactName, {
       expiration: 15 * 60,

--- a/services/index/src/handlers.js
+++ b/services/index/src/handlers.js
@@ -71,12 +71,11 @@ Handlers.prototype.terminate = async function() {
 
 /** Handle notifications of completed messages */
 Handlers.prototype.completed = function(message) {
-  const that = this;
 
   // Find namespaces to index under
   const namespaces = message.routes
-    .filter((route) => that.routeRegexp.test(route))
-    .map((route) => that.routeRegexp.exec(route)[1])
+    .filter((route) => this.routeRegexp.test(route))
+    .map((route) => this.routeRegexp.exec(route)[1])
     .filter((namespace) => helpers.namespaceFormat.test(namespace));
 
   // If there is no namespace we better log this
@@ -122,7 +121,7 @@ Handlers.prototype.completed = function(message) {
     }
 
     // Insert everything into the index
-    return Promise.all(namespaces.map((namespace) => helpers.taskUtils.insertTask(that.db, namespace, {
+    return Promise.all(namespaces.map((namespace) => helpers.taskUtils.insertTask(this.db, namespace, {
       taskId: message.payload.status.taskId,
       data: options.data,
       expires: expires,


### PR DESCRIPTION
Because #8745 transformed those functions into arrow functions, we don't need the weird `that = this` alias anymore which biome catches and complain about.

Fix biome's noUselessThisAlias lint
