### PR TITLE
Replace global `isNaN` usage with targeted `Number.isNaN`

### DIFF
--- a/changelog/ATlBdXcPQwCoaa4uW_ENsg.md
+++ b/changelog/ATlBdXcPQwCoaa4uW_ENsg.md
@@ -1,0 +1,2 @@
+level: silent
+---

--- a/db/src/main.js
+++ b/db/src/main.js
@@ -19,7 +19,7 @@ const main = async () => {
   };
 
   const toVersion = process.argv[3] ? parseInt(process.argv[3], 10) : undefined;
-  if (toVersion !== undefined && (!process.argv[3].match(/^[0-9]+$/) || isNaN(toVersion))) {
+  if (toVersion !== undefined && (!process.argv[3].match(/^[0-9]+$/) || Number.isNaN(toVersion))) {
     throw new Error('invalid db version specified -- must be an integer DB version, not a TC release version');
   }
 

--- a/db/test/fns/queue_test.js
+++ b/db/test/fns/queue_test.js
@@ -46,7 +46,7 @@ suite(testing.suiteName(), () => {
     for (const row of rows) {
       for (const run of row.runs) {
         for (const prop of ['scheduled', 'started', 'resolved', 'takenUntil']) {
-          if (prop in run && typeof run[prop] === 'string' && !isNaN(new Date(run[prop]))) {
+          if (prop in run && typeof run[prop] === 'string' && !Number.isNaN(new Date(run[prop]).getTime())) {
             run[prop] = 'date';
           }
         }

--- a/infrastructure/tooling/src/dev/index.js
+++ b/infrastructure/tooling/src/dev/index.js
@@ -90,7 +90,7 @@ export const dbDowngrade = async (options) => {
 
   const { dbVersion } = options;
   const toVersion = parseInt(dbVersion, 10);
-  if (!dbVersion.match(/^[0-9]+$/) || isNaN(toVersion)) {
+  if (!dbVersion.match(/^[0-9]+$/) || Number.isNaN(toVersion)) {
     throw new Error('Missing or invalid --db-version');
   }
 

--- a/libraries/postgres/src/migration.js
+++ b/libraries/postgres/src/migration.js
@@ -200,7 +200,7 @@ export const runOnlineBatches = async ({ client, showProgress, versionNum, kind 
 
       // update the batch size to try to get to batchTime (but minimum of one)
       const rate = eta.rate();
-      if (!isNaN(rate)) {
+      if (!Number.isNaN(rate)) {
         batchSize = Math.round(Math.max(1, rate * batchTime));
       }
       if (hooks.batchSize) {

--- a/libraries/postgres/src/util.js
+++ b/libraries/postgres/src/util.js
@@ -184,7 +184,7 @@ export class ETA {
     }
 
     const rate = this.rate();
-    if (isNaN(rate) || !rate) {
+    if (Number.isNaN(rate) || !rate) {
       return undefined;
     }
 

--- a/services/auth/src/sentrymanager.js
+++ b/services/auth/src/sentrymanager.js
@@ -95,7 +95,7 @@ const parseKeys = (keys, prefix) => {
       continue;
     }
     const expires = new Date(match[1]);
-    if (isNaN(expires)) {
+    if (Number.isNaN(expires.getTime())) {
       continue;
     }
     results.push({

--- a/services/github/src/handlers/utils.js
+++ b/services/github/src/handlers/utils.js
@@ -201,7 +201,7 @@ export const isCollaborator = async (instGithub, organization, repository, login
 export const getTimeDifference = (timestamp1, timestamp2) => {
 
   const isValidDate = (date) => {
-    return !isNaN(Date.parse(date));
+    return !Number.isNaN(Date.parse(date));
   };
 
   if (timestamp1 === undefined || timestamp2 === undefined) {


### PR DESCRIPTION
For some reason, which I'm sure made sense in 1990, they don't have the same behavior. `Number.isNaN` doesn't try to coerce args, unlike `isNaN` which makes it a better candidate to actually detect NaNs instead of "anything that might be NaN but also maybe a string, or undefined or..."

Note that there were 2 call sites that actually depended on the implicit coercion to work, so I had to fix them up (`new Date(...)` -> `new Date(...).getTime()`

See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/isNaN#description

Fix biome's noGlobalIsNan lint

