### PR TITLE
Remove a useless `continue` in the queue service

### DIFF
--- a/changelog/SW0CNI0jTbOHZFDlk2NCUg.md
+++ b/changelog/SW0CNI0jTbOHZFDlk2NCUg.md
@@ -1,0 +1,2 @@
+level: silent
+---

--- a/services/queue/src/utils.js
+++ b/services/queue/src/utils.js
@@ -80,7 +80,6 @@ export const artifactUtils = {
             err.taskId = entry.taskId;
             err.runId = entry.runId;
             monitor.reportError(err);
-            continue;
           }
         }
       }


### PR DESCRIPTION
Fixes biome's noUselessContinue lint
