### PR TITLE
Use the exponent operator instead of `Math.pow`

### DIFF
--- a/changelog/chM7J3-JTlS4q_krtsnuMw.md
+++ b/changelog/chM7J3-JTlS4q_krtsnuMw.md
@@ -1,0 +1,2 @@
+level: silent
+---

--- a/services/worker-manager/src/providers/aws.js
+++ b/services/worker-manager/src/providers/aws.js
@@ -64,7 +64,7 @@ export class AwsProvider extends Provider {
       providerId: this.providerId,
       errorHandler: ({ err, tries }) => {
         if (err.code === 'RequestLimitExceeded') {
-          return { backoff: this.providerConfig._backoffDelay * Math.pow(2, tries), reason: 'RequestLimitExceeded', level: 'warning' };
+          return { backoff: this.providerConfig._backoffDelay * 2 ** tries, reason: 'RequestLimitExceeded', level: 'warning' };
         }
         throw err;
       },

--- a/services/worker-manager/src/providers/azure/index.js
+++ b/services/worker-manager/src/providers/azure/index.js
@@ -201,7 +201,7 @@ export class AzureProvider extends Provider {
           }
           return { backoff, reason: 'rateLimit', level: 'notice' };
         } else if (err.statusCode >= 500) { // For 500s, let's take a shorter backoff
-          return { backoff: _backoffDelay * Math.pow(2, tries), reason: 'errors', level: 'warning' };
+          return { backoff: _backoffDelay * 2 ** tries, reason: 'errors', level: 'warning' };
         }
         // If we don't want to do anything special here, just throw and let the
         // calling code figure out what to do

--- a/services/worker-manager/src/providers/google.js
+++ b/services/worker-manager/src/providers/google.js
@@ -44,7 +44,7 @@ export class GoogleProvider extends Provider {
           // google's interval is 100 seconds so let's try once optimistically and a second time to get it for sure
           return { backoff: _backoffDelay * 50, reason: 'rateLimit', level: 'notice' };
         } else if (err.code === 403 || err.code >= 500) { // For 500s, let's take a shorter backoff
-          return { backoff: _backoffDelay * Math.pow(2, tries), reason: 'errors', level: 'warning' };
+          return { backoff: _backoffDelay * 2 ** tries, reason: 'errors', level: 'warning' };
         }
         // If we don't want to do anything special here, just throw and let the
         // calling code figure out what to do

--- a/services/worker-manager/test/cloudapi_test.js
+++ b/services/worker-manager/test/cloudapi_test.js
@@ -28,7 +28,7 @@ suite(testing.suiteName(), () => {
           };
         } else if (err.code === 403 || err.code >= 500) {
           return {
-            backoff: _backoffDelay * Math.pow(2, tries),
+            backoff: _backoffDelay * 2 ** tries,
             reason: 'errors',
             level: 'warning',
           };


### PR DESCRIPTION
Fixes biome's useExponentiationOperator lint, no behavior change. I chose to keep this despite it being somewhat opinionated for very little gain because the codebase had a mishmash of Math.pow and `**`. Now it's consistent everywhere.
