### PR TITLE
fix(github): create build records for all unique taskGroupIds

### DIFF
--- a/changelog/issue-8751.md
+++ b/changelog/issue-8751.md
@@ -1,0 +1,7 @@
+audience: users
+level: patch
+reference: issue 8751
+---
+The GitHub service now creates a build record for every unique `taskGroupId` defined in
+`.taskcluster.yml`, so checks and statuses are reported for all task groups, not just
+the first task's group.

--- a/services/github/src/handlers/job.js
+++ b/services/github/src/handlers/job.js
@@ -436,32 +436,37 @@ export async function jobHandler(message) {
 
   // Create tasks (if present)
   if (graphConfig.tasks && graphConfig.tasks.length > 0) {
-    let routes;
-    let taskGroupId;
-
+    const taskGroupMap = new Map();
     try {
-      routes = graphConfig.tasks[0].task.routes;
-      taskGroupId = graphConfig.tasks[0].task.taskGroupId;
+      for (const { task } of graphConfig.tasks) {
+        if (!taskGroupMap.has(task.taskGroupId)) {
+          taskGroupMap.set(task.taskGroupId, task.routes);
+        }
+      }
     } catch (e) {
       return await this.createExceptionComment({ debug, instGithub, organization, repository, sha, error: e });
     }
 
-    const build = await createGithubBuildRecord({
-      context,
-      organization,
-      repository,
-      sha,
-      taskGroupId,
-      groupState,
-      installationId: message.payload.installationId,
-      eventType: message.payload.details['event.type'],
-      eventId: message.payload.eventId,
-      pullNumber,
-      debug,
-    });
+    const builds = await Promise.all(
+      [...taskGroupMap.keys()].map(taskGroupId =>
+        createGithubBuildRecord({
+          context,
+          organization,
+          repository,
+          sha,
+          taskGroupId,
+          groupState,
+          installationId: message.payload.installationId,
+          eventType: message.payload.details['event.type'],
+          eventId: message.payload.eventId,
+          pullNumber,
+          debug,
+        }),
+      ),
+    );
 
     try {
-      debug(`Creating tasks for ${organization}/${repository}@${sha} (taskGroupId: ${taskGroupId})`);
+      debug(`Creating tasks for ${organization}/${repository}@${sha} (${taskGroupMap.size} task group(s))`);
       await this.createTasks({ scopes: graphConfig.scopes, tasks: graphConfig.tasks });
     } catch (e) {
       debug(`Creating tasks for ${organization}/${repository}@${sha} failed! Leaving comment on Github.`);
@@ -470,28 +475,32 @@ export async function jobHandler(message) {
 
     // Only cancel previous tasks after we have successfully created new ones.
     // Cancel existing builds for non-default branches.
+    // All sibling builds from this event share the same event_id, so they are already
+    // excluded by the event_id filter inside cancelPreviousTaskGroups.
     if (graphConfig.autoCancelPreviousChecks !== false) {
       if (pullNumber || message.payload.body.ref !== defaultBranch) {
-        await this.cancelPreviousTaskGroups({ instGithub, debug, newBuild: build });
+        await this.cancelPreviousTaskGroups({ instGithub, debug, newBuild: builds[0] });
       }
     }
 
-    try {
-      debug(`Publishing status exchange for ${organization}/${repository}@${sha} (${groupState})`);
-      await context.publisher.taskGroupCreationRequested(
-        {
-          taskGroupId,
-          organization: organization.replace(/\./g, '%'),
-          repository: repository.replace(/\./g, '%'),
-        },
-        routes
-      );
-    } catch (e) {
-      debug(`Failed to publish to taskGroupCreationRequested exchange.
-      Parameters: ${taskGroupId}, ${organization}, ${repository}, ${routes}`);
-      debug(`Stack: ${e.stack}`);
-      return debug(`Failed to publish to taskGroupCreationRequested exchange
-      for ${organization}/${repository}@${sha} with the error: ${stringify(e, null, 2)}`);
+    for (const [taskGroupId, routes] of taskGroupMap.entries()) {
+      try {
+        debug(`Publishing status exchange for ${organization}/${repository}@${sha} (${groupState}, taskGroupId: ${taskGroupId})`);
+        await context.publisher.taskGroupCreationRequested(
+          {
+            taskGroupId,
+            organization: organization.replace(/\./g, '%'),
+            repository: repository.replace(/\./g, '%'),
+          },
+          routes
+        );
+      } catch (e) {
+        debug(`Failed to publish to taskGroupCreationRequested exchange.
+        Parameters: ${taskGroupId}, ${organization}, ${repository}, ${routes}`);
+        debug(`Stack: ${e.stack}`);
+        return debug(`Failed to publish to taskGroupCreationRequested exchange
+        for ${organization}/${repository}@${sha} with the error: ${stringify(e, null, 2)}`);
+      }
     }
   }
 

--- a/services/github/src/handlers/job.js
+++ b/services/github/src/handlers/job.js
@@ -436,32 +436,43 @@ export async function jobHandler(message) {
 
   // Create tasks (if present)
   if (graphConfig.tasks && graphConfig.tasks.length > 0) {
-    let routes;
-    let taskGroupId;
-
+    const taskGroupMap = new Map();
     try {
-      routes = graphConfig.tasks[0].task.routes;
-      taskGroupId = graphConfig.tasks[0].task.taskGroupId;
+      for (const { task } of graphConfig.tasks) {
+        let routes = taskGroupMap.get(task.taskGroupId);
+        if (!routes) {
+          routes = new Set();
+          taskGroupMap.set(task.taskGroupId, routes);
+        }
+        for (const route of task.routes || []) {
+          routes.add(route);
+        }
+      }
     } catch (e) {
       return await this.createExceptionComment({ debug, instGithub, organization, repository, sha, error: e });
     }
 
-    const build = await createGithubBuildRecord({
-      context,
-      organization,
-      repository,
-      sha,
-      taskGroupId,
-      groupState,
-      installationId: message.payload.installationId,
-      eventType: message.payload.details['event.type'],
-      eventId: message.payload.eventId,
-      pullNumber,
-      debug,
-    });
+    const builds = [];
+    for (const taskGroupId of taskGroupMap.keys()) {
+      builds.push(
+        await createGithubBuildRecord({
+          context,
+          organization,
+          repository,
+          sha,
+          taskGroupId,
+          groupState,
+          installationId: message.payload.installationId,
+          eventType: message.payload.details['event.type'],
+          eventId: message.payload.eventId,
+          pullNumber,
+          debug,
+        })
+      );
+    }
 
     try {
-      debug(`Creating tasks for ${organization}/${repository}@${sha} (taskGroupId: ${taskGroupId})`);
+      debug(`Creating tasks for ${organization}/${repository}@${sha} (${taskGroupMap.size} task group(s))`);
       await this.createTasks({ scopes: graphConfig.scopes, tasks: graphConfig.tasks });
     } catch (e) {
       debug(`Creating tasks for ${organization}/${repository}@${sha} failed! Leaving comment on Github.`);
@@ -470,28 +481,34 @@ export async function jobHandler(message) {
 
     // Only cancel previous tasks after we have successfully created new ones.
     // Cancel existing builds for non-default branches.
+    // All sibling builds from this event share the same event_id, so they are already
+    // excluded by the event_id filter inside cancelPreviousTaskGroups.
     if (graphConfig.autoCancelPreviousChecks !== false) {
       if (pullNumber || message.payload.body.ref !== defaultBranch) {
-        await this.cancelPreviousTaskGroups({ instGithub, debug, newBuild: build });
+        await this.cancelPreviousTaskGroups({ instGithub, debug, newBuild: builds[0] });
       }
     }
 
-    try {
-      debug(`Publishing status exchange for ${organization}/${repository}@${sha} (${groupState})`);
-      await context.publisher.taskGroupCreationRequested(
-        {
-          taskGroupId,
-          organization: organization.replace(/\./g, '%'),
-          repository: repository.replace(/\./g, '%'),
-        },
-        routes
-      );
-    } catch (e) {
-      debug(`Failed to publish to taskGroupCreationRequested exchange.
-      Parameters: ${taskGroupId}, ${organization}, ${repository}, ${routes}`);
-      debug(`Stack: ${e.stack}`);
-      return debug(`Failed to publish to taskGroupCreationRequested exchange
-      for ${organization}/${repository}@${sha} with the error: ${stringify(e, null, 2)}`);
+    for (const [taskGroupId, routes] of taskGroupMap.entries()) {
+      try {
+        debug(
+          `Publishing status exchange for ${organization}/${repository}@${sha} (${groupState}, taskGroupId: ${taskGroupId})`
+        );
+        await context.publisher.taskGroupCreationRequested(
+          {
+            taskGroupId,
+            organization: organization.replace(/\./g, '%'),
+            repository: repository.replace(/\./g, '%'),
+          },
+          [...routes]
+        );
+      } catch (e) {
+        debug(`Failed to publish to taskGroupCreationRequested exchange.
+        Parameters: ${taskGroupId}, ${organization}, ${repository}, ${[...routes]}`);
+        debug(`Stack: ${e.stack}`);
+        debug(`Failed to publish to taskGroupCreationRequested exchange
+        for ${organization}/${repository}@${sha} with the error: ${stringify(e, null, 2)}`);
+      }
     }
   }
 

--- a/services/github/test/data/yml/valid-yaml-v1-multi-group.json
+++ b/services/github/test/data/yml/valid-yaml-v1-multi-group.json
@@ -1,0 +1,101 @@
+{
+  "version": 1,
+  "tasks": [
+    {
+      "taskGroupId": "AAAAAAAAAAAAAAAAAAAAAA",
+      "provisionerId": "dummy-provisioner",
+      "workerType": "dummy-worker",
+      "extra": {
+        "github": {
+          "env": true,
+          "events": [
+            "pull_request.opened",
+            "pull_request.synchronize",
+            "pull_request.reopened",
+            "push",
+            "tag"
+          ]
+        }
+      },
+      "payload": {
+        "maxRunTime": 3600,
+        "image": "node:5",
+        "command": [
+          "/bin/bash",
+          "-lc",
+          "echo 'Task 1 (group A)'"
+        ]
+      },
+      "metadata": {
+        "name": "Multi-Group Test Task 1 (Group A)",
+        "description": "Task in group A",
+        "owner": "{{ event.head.user.email }}",
+        "source": "{{ event.head.repo.url }}"
+      }
+    },
+    {
+      "taskGroupId": "AAAAAAAAAAAAAAAAAAAAAA",
+      "provisionerId": "dummy-provisioner",
+      "workerType": "dummy-worker",
+      "extra": {
+        "github": {
+          "env": true,
+          "events": [
+            "pull_request.opened",
+            "pull_request.synchronize",
+            "pull_request.reopened",
+            "push",
+            "tag"
+          ]
+        }
+      },
+      "payload": {
+        "maxRunTime": 3600,
+        "image": "node:5",
+        "command": [
+          "/bin/bash",
+          "-lc",
+          "echo 'Task 2 (group A)'"
+        ]
+      },
+      "metadata": {
+        "name": "Multi-Group Test Task 2 (Group A)",
+        "description": "Task in group A",
+        "owner": "{{ event.head.user.email }}",
+        "source": "{{ event.head.repo.url }}"
+      }
+    },
+    {
+      "taskGroupId": "BBBBBBBBBBBBBBBBBBBBBB",
+      "provisionerId": "dummy-provisioner",
+      "workerType": "dummy-worker",
+      "extra": {
+        "github": {
+          "env": true,
+          "events": [
+            "pull_request.opened",
+            "pull_request.synchronize",
+            "pull_request.reopened",
+            "push",
+            "tag"
+          ]
+        }
+      },
+      "payload": {
+        "maxRunTime": 3600,
+        "image": "node:5",
+        "command": [
+          "/bin/bash",
+          "-lc",
+          "echo 'Task 3 (group B)'"
+        ]
+      },
+      "metadata": {
+        "name": "Multi-Group Test Task 3 (Group B)",
+        "description": "Task in group B",
+        "owner": "{{ event.head.user.email }}",
+        "source": "{{ event.head.repo.url }}"
+      }
+    }
+  ]
+}

--- a/services/github/test/data/yml/valid-yaml-v1-multi-group.json
+++ b/services/github/test/data/yml/valid-yaml-v1-multi-group.json
@@ -1,0 +1,135 @@
+{
+  "version": 1,
+  "tasks": [
+    {
+      "taskGroupId": "AAAAAAAAAAAAAAAAAAAAAA",
+      "provisionerId": "dummy-provisioner",
+      "workerType": "dummy-worker",
+      "extra": {
+        "github": {
+          "env": true,
+          "events": [
+            "pull_request.opened",
+            "pull_request.synchronize",
+            "pull_request.reopened",
+            "push",
+            "tag"
+          ]
+        }
+      },
+      "payload": {
+        "maxRunTime": 3600,
+        "image": "node:5",
+        "command": [
+          "/bin/bash",
+          "-lc",
+          "echo 'Task 0 (group A, no routes)'"
+        ]
+      },
+      "metadata": {
+        "name": "Multi-Group Test Task 0 (Group A, no routes)",
+        "description": "Task in group A declaring no routes of its own",
+        "owner": "{{ event.head.user.email }}",
+        "source": "{{ event.head.repo.url }}"
+      }
+    },
+    {
+      "taskGroupId": "AAAAAAAAAAAAAAAAAAAAAA",
+      "routes": ["route-a-1", "multi-group-shared"],
+      "provisionerId": "dummy-provisioner",
+      "workerType": "dummy-worker",
+      "extra": {
+        "github": {
+          "env": true,
+          "events": [
+            "pull_request.opened",
+            "pull_request.synchronize",
+            "pull_request.reopened",
+            "push",
+            "tag"
+          ]
+        }
+      },
+      "payload": {
+        "maxRunTime": 3600,
+        "image": "node:5",
+        "command": [
+          "/bin/bash",
+          "-lc",
+          "echo 'Task 1 (group A)'"
+        ]
+      },
+      "metadata": {
+        "name": "Multi-Group Test Task 1 (Group A)",
+        "description": "Task in group A",
+        "owner": "{{ event.head.user.email }}",
+        "source": "{{ event.head.repo.url }}"
+      }
+    },
+    {
+      "taskGroupId": "AAAAAAAAAAAAAAAAAAAAAA",
+      "routes": ["route-a-2", "multi-group-shared"],
+      "provisionerId": "dummy-provisioner",
+      "workerType": "dummy-worker",
+      "extra": {
+        "github": {
+          "env": true,
+          "events": [
+            "pull_request.opened",
+            "pull_request.synchronize",
+            "pull_request.reopened",
+            "push",
+            "tag"
+          ]
+        }
+      },
+      "payload": {
+        "maxRunTime": 3600,
+        "image": "node:5",
+        "command": [
+          "/bin/bash",
+          "-lc",
+          "echo 'Task 2 (group A)'"
+        ]
+      },
+      "metadata": {
+        "name": "Multi-Group Test Task 2 (Group A)",
+        "description": "Task in group A",
+        "owner": "{{ event.head.user.email }}",
+        "source": "{{ event.head.repo.url }}"
+      }
+    },
+    {
+      "taskGroupId": "BBBBBBBBBBBBBBBBBBBBBB",
+      "provisionerId": "dummy-provisioner",
+      "workerType": "dummy-worker",
+      "extra": {
+        "github": {
+          "env": true,
+          "events": [
+            "pull_request.opened",
+            "pull_request.synchronize",
+            "pull_request.reopened",
+            "push",
+            "tag"
+          ]
+        }
+      },
+      "payload": {
+        "maxRunTime": 3600,
+        "image": "node:5",
+        "command": [
+          "/bin/bash",
+          "-lc",
+          "echo 'Task 3 (group B)'"
+        ]
+      },
+      "metadata": {
+        "name": "Multi-Group Test Task 3 (Group B)",
+        "description": "Task in group B",
+        "owner": "{{ event.head.user.email }}",
+        "source": "{{ event.head.repo.url }}"
+      }
+    }
+  ]
+}

--- a/services/github/test/handler_test.js
+++ b/services/github/test/handler_test.js
@@ -27,6 +27,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], (mock, skipping) => {
 
   const validYamlJson = loadJson('yml/valid-yaml.json');
   const validYamlV1Json = loadJson('yml/valid-yaml-v1.json');
+  const validYamlV1MultiGroupJson = loadJson('yml/valid-yaml-v1-multi-group.json');
   const validYamlCommentsJson = loadJson('yml/valid-yaml-comments.json');
   const invalidTaskJson = loadJson('yml/invalid-task.json');
   const invalidYamlJson = loadJson('yml/invalid-yaml.json');
@@ -474,6 +475,47 @@ helper.secrets.mockSuite(testing.suiteName(), [], (mock, skipping) => {
       assert.equal(buildC.state, 'cancelled');
     });
 
+    test('does not cancel sibling task groups from the same event', async () => {
+      // Old build from a previous event
+      await helper.db.fns.create_github_build_pr(
+        'TaskclusterRobot', 'hooks-testing', COMMIT_SHA, 'old-group', 'pending',
+        new Date(), new Date(), 9988, 'pull_request.opened', 'old-event-id', 1,
+      );
+      // Two sibling builds from the current event — share the same event_id
+      await helper.db.fns.create_github_build_pr(
+        'TaskclusterRobot', 'hooks-testing', COMMIT_SHA, 'new-group-a', 'pending',
+        new Date(), new Date(), 9988, 'pull_request.opened', 'new-event-id', 1,
+      );
+      await helper.db.fns.create_github_build_pr(
+        'TaskclusterRobot', 'hooks-testing', COMMIT_SHA, 'new-group-b', 'pending',
+        new Date(), new Date(), 9988, 'pull_request.opened', 'new-event-id', 1,
+      );
+
+      await handlers.realCancelPreviousTaskGroups({
+        instGithub: sinon.stub(),
+        debug: sinon.stub(),
+        newBuild: {
+          sha: COMMIT_SHA,
+          task_group_id: 'new-group-a',
+          organization: 'TaskclusterRobot',
+          repository: 'hooks-testing',
+          pull_number: 1,
+          event_type: 'pull_request.opened',
+          event_id: 'new-event-id',
+        },
+      });
+
+      // Only the old build (different event_id) should be cancelled
+      assert.deepEqual(sealedTaskGroups, ['old-group']);
+      assert.deepEqual(cancelledTaskGroups, ['old-group']);
+
+      // Sibling builds (same event_id) must NOT be cancelled — neither of them
+      const [buildA] = await helper.db.fns.get_github_build_pr('new-group-a');
+      const [buildB] = await helper.db.fns.get_github_build_pr('new-group-b');
+      assert.equal(buildA.state, 'pending');
+      assert.equal(buildB.state, 'pending');
+    });
+
     test('calls queue.sealTaskGroup/cancelTaskGroup for SHA excluding new task group id', async () => {
       await addBuild({ state: 'pending', taskGroupId: 'aa' });
       await addBuild({ state: 'pending', taskGroupId: 'bb' });
@@ -720,6 +762,84 @@ helper.secrets.mockSuite(testing.suiteName(), [], (mock, skipping) => {
       assert.equal(build.repository, 'hooks-testing');
       assert.equal(build.sha, COMMIT_SHA);
       assert.equal(build.state, 'pending');
+    });
+
+    test('multi-group yml creates one build record per unique taskGroupId', async () => {
+      const GROUP_A = 'AAAAAAAAAAAAAAAAAAAAAA';
+      const GROUP_B = 'BBBBBBBBBBBBBBBBBBBBBB';
+
+      github.inst(INST_ID).setTaskclusterYml({
+        owner: 'TaskclusterRobot',
+        repo: 'hooks-testing',
+        ref: COMMIT_SHA,
+        content: validYamlV1MultiGroupJson,
+      });
+
+      await simulateJobMessage({ user: 'TaskclusterRobot' });
+
+      assert(handlers.createTasks.calledOnce, 'createTasks should be called once');
+
+      const [buildA] = await helper.db.fns.get_github_build_pr(GROUP_A);
+      const [buildB] = await helper.db.fns.get_github_build_pr(GROUP_B);
+      assert.ok(buildA, 'build record for group A should exist');
+      assert.ok(buildB, 'build record for group B should exist');
+      assert.equal(buildA.state, 'pending');
+      assert.equal(buildB.state, 'pending');
+      assert.equal(buildA.organization, 'TaskclusterRobot');
+      assert.equal(buildB.organization, 'TaskclusterRobot');
+      assert.equal(buildA.sha, COMMIT_SHA);
+      assert.equal(buildB.sha, COMMIT_SHA);
+    });
+
+    test('multi-group yml publishes taskGroupCreationRequested once per unique group', async () => {
+      const GROUP_A = 'AAAAAAAAAAAAAAAAAAAAAA';
+      const GROUP_B = 'BBBBBBBBBBBBBBBBBBBBBB';
+
+      github.inst(INST_ID).setTaskclusterYml({
+        owner: 'TaskclusterRobot',
+        repo: 'hooks-testing',
+        ref: COMMIT_SHA,
+        content: validYamlV1MultiGroupJson,
+      });
+
+      const publishedGroupIds = [];
+      helper.onPulsePublish((exchange, routingKey, payload) => {
+        if (exchange.endsWith('task-group-creation-requested')) {
+          publishedGroupIds.push(JSON.parse(payload).taskGroupId);
+        }
+      });
+
+      await simulateJobMessage({ user: 'TaskclusterRobot' });
+
+      assert.equal(publishedGroupIds.length, 2, 'should publish once per unique taskGroupId');
+      assert(publishedGroupIds.includes(GROUP_A), 'should publish for group A');
+      assert(publishedGroupIds.includes(GROUP_B), 'should publish for group B');
+    });
+
+    test('multi-group yml calls cancelPreviousTaskGroups once for pull_request', async () => {
+      github.inst(INST_ID).setRepoCollaborator({
+        owner: 'TaskclusterRobot',
+        repo: 'hooks-testing',
+        username: 'goodBuddy',
+      });
+      github.inst(INST_ID).setTaskclusterYml({
+        owner: 'TaskclusterRobot',
+        repo: 'hooks-testing',
+        ref: COMMIT_SHA,
+        content: validYamlV1MultiGroupJson,
+      });
+      github.inst(INST_ID).setTaskclusterYml({
+        owner: 'TaskclusterRobot',
+        repo: 'hooks-testing',
+        ref: 'development',
+        content: validYamlV1MultiGroupJson,
+      });
+
+      await simulateJobMessage({ user: 'goodBuddy', eventType: 'pull_request.opened', pullNumber: 1001 });
+
+      assert(handlers.createTasks.calledOnce, 'createTasks should be called once');
+      // cancelPreviousTaskGroups should be called exactly once regardless of how many groups exist
+      assert(handlers.cancelPreviousTaskGroups.calledOnce, 'cancelPreviousTaskGroups should be called once');
     });
 
     test('valid pull_request (user is collaborator) creates a taskGroup', async () => {

--- a/services/github/test/handler_test.js
+++ b/services/github/test/handler_test.js
@@ -34,6 +34,22 @@ helper.secrets.mockSuite(testing.suiteName(), [], (mock, skipping) => {
 
   const webhookCommentEditedJson = loadJson('webhooks/webhook.issue_comment.edited.json');
 
+  // Generated per suite: the queue enforces slugid-pattern on taskGroupIds, so multi-group
+  // tests must use real slugids (the fixture's "A"/"B" placeholders are not valid ones).
+  const GROUP_A = taskcluster.slugid();
+  const GROUP_B = taskcluster.slugid();
+  const multiGroupConfig = () => {
+    const config = loadJson('yml/valid-yaml-v1-multi-group.json');
+    for (const task of config.tasks) {
+      if (task.taskGroupId === 'AAAAAAAAAAAAAAAAAAAAAA') {
+        task.taskGroupId = GROUP_A;
+      } else if (task.taskGroupId === 'BBBBBBBBBBBBBBBBBBBBBB') {
+        task.taskGroupId = GROUP_B;
+      }
+    }
+    return config;
+  };
+
   const URL_PREFIX = 'https://tc-tests.example.com/tasks/groups/';
   const CUSTOM_CHECKRUN_TASKID = 'apple';
   const CUSTOM_CHECKRUN_HOOK_TASKID = 'apple-hook';
@@ -507,6 +523,74 @@ helper.secrets.mockSuite(testing.suiteName(), [], (mock, skipping) => {
       assert.equal(buildC.state, 'cancelled');
     });
 
+    test('does not cancel sibling task groups from the same event', async () => {
+      // Old build from a previous event
+      await helper.db.fns.create_github_build_pr(
+        'TaskclusterRobot',
+        'hooks-testing',
+        COMMIT_SHA,
+        'old-group',
+        'pending',
+        new Date(),
+        new Date(),
+        9988,
+        'pull_request.opened',
+        'old-event-id',
+        1
+      );
+      // Two sibling builds from the current event — share the same event_id
+      await helper.db.fns.create_github_build_pr(
+        'TaskclusterRobot',
+        'hooks-testing',
+        COMMIT_SHA,
+        'new-group-a',
+        'pending',
+        new Date(),
+        new Date(),
+        9988,
+        'pull_request.opened',
+        'new-event-id',
+        1
+      );
+      await helper.db.fns.create_github_build_pr(
+        'TaskclusterRobot',
+        'hooks-testing',
+        COMMIT_SHA,
+        'new-group-b',
+        'pending',
+        new Date(),
+        new Date(),
+        9988,
+        'pull_request.opened',
+        'new-event-id',
+        1
+      );
+
+      await handlers.realCancelPreviousTaskGroups({
+        instGithub: sinon.stub(),
+        debug: sinon.stub(),
+        newBuild: {
+          sha: COMMIT_SHA,
+          task_group_id: 'new-group-a',
+          organization: 'TaskclusterRobot',
+          repository: 'hooks-testing',
+          pull_number: 1,
+          event_type: 'pull_request.opened',
+          event_id: 'new-event-id',
+        },
+      });
+
+      // Only the old build (different event_id) should be cancelled
+      assert.deepEqual(sealedTaskGroups, ['old-group']);
+      assert.deepEqual(cancelledTaskGroups, ['old-group']);
+
+      // Sibling builds (same event_id) must NOT be cancelled — neither of them
+      const [buildA] = await helper.db.fns.get_github_build_pr('new-group-a');
+      const [buildB] = await helper.db.fns.get_github_build_pr('new-group-b');
+      assert.equal(buildA.state, 'pending');
+      assert.equal(buildB.state, 'pending');
+    });
+
     test('calls queue.sealTaskGroup/cancelTaskGroup for SHA excluding new task group id', async () => {
       await addBuild({ state: 'pending', taskGroupId: 'aa' });
       await addBuild({ state: 'pending', taskGroupId: 'bb' });
@@ -753,6 +837,149 @@ helper.secrets.mockSuite(testing.suiteName(), [], (mock, skipping) => {
       assert.equal(build.repository, 'hooks-testing');
       assert.equal(build.sha, COMMIT_SHA);
       assert.equal(build.state, 'pending');
+    });
+
+    test('multi-group fixture injects valid slugids for all taskGroupIds', () => {
+      const config = multiGroupConfig();
+      const ids = config.tasks.map(task => task.taskGroupId);
+      assert.deepEqual(
+        [...new Set(ids)].sort(),
+        [GROUP_A, GROUP_B].sort(),
+        'fixture placeholders should be replaced by the generated group ids'
+      );
+      // slugid-pattern from schemas/constants.yml:32 (enforced by the queue's createTasks)
+      for (const id of ids) {
+        assert.match(
+          id,
+          /^[A-Za-z0-9_-]{8}[Q-T][A-Za-z0-9_-][CGKOSWaeimquy26-][A-Za-z0-9_-]{10}[AQgw]$/,
+          `taskGroupId ${id} must satisfy the queue's slugid-pattern`
+        );
+      }
+    });
+
+    test('multi-group yml creates one build record per unique taskGroupId', async () => {
+      github.inst(INST_ID).setTaskclusterYml({
+        owner: 'TaskclusterRobot',
+        repo: 'hooks-testing',
+        ref: COMMIT_SHA,
+        content: multiGroupConfig(),
+      });
+
+      await simulateJobMessage({ user: 'TaskclusterRobot' });
+
+      assert(handlers.createTasks.calledOnce, 'createTasks should be called once');
+
+      const [buildA] = await helper.db.fns.get_github_build_pr(GROUP_A);
+      const [buildB] = await helper.db.fns.get_github_build_pr(GROUP_B);
+      assert.ok(buildA, 'build record for group A should exist');
+      assert.ok(buildB, 'build record for group B should exist');
+      assert.equal(buildA.state, 'pending');
+      assert.equal(buildB.state, 'pending');
+      assert.equal(buildA.organization, 'TaskclusterRobot');
+      assert.equal(buildB.organization, 'TaskclusterRobot');
+      assert.equal(buildA.sha, COMMIT_SHA);
+      assert.equal(buildB.sha, COMMIT_SHA);
+    });
+
+    test('multi-group yml publishes taskGroupCreationRequested once per unique group', async () => {
+      github.inst(INST_ID).setTaskclusterYml({
+        owner: 'TaskclusterRobot',
+        repo: 'hooks-testing',
+        ref: COMMIT_SHA,
+        content: multiGroupConfig(),
+      });
+
+      const publishedGroupIds = [];
+      helper.onPulsePublish((exchange, _routingKey, payload) => {
+        if (exchange.endsWith('task-group-creation-requested')) {
+          publishedGroupIds.push(JSON.parse(payload).taskGroupId);
+        }
+      });
+
+      await simulateJobMessage({ user: 'TaskclusterRobot' });
+
+      assert.equal(publishedGroupIds.length, 2, 'should publish once per unique taskGroupId');
+      assert(publishedGroupIds.includes(GROUP_A), 'should publish for group A');
+      assert(publishedGroupIds.includes(GROUP_B), 'should publish for group B');
+    });
+
+    test("multi-group yml publishes the union of all tasks' routes per group", async () => {
+      github.inst(INST_ID).setTaskclusterYml({
+        owner: 'TaskclusterRobot',
+        repo: 'hooks-testing',
+        ref: COMMIT_SHA,
+        content: multiGroupConfig(),
+      });
+
+      const publishedRoutes = {};
+      helper.onPulsePublish((exchange, _routingKey, payload, CCs) => {
+        if (exchange.endsWith('task-group-creation-requested')) {
+          const taskGroupId = JSON.parse(payload).taskGroupId;
+          publishedRoutes[taskGroupId] = [...(publishedRoutes[taskGroupId] || []), ...CCs];
+        }
+      });
+
+      await simulateJobMessage({ user: 'TaskclusterRobot' });
+
+      assert.deepEqual(
+        [...publishedRoutes[GROUP_A]].sort(),
+        ['route.multi-group-shared', 'route.route-a-1', 'route.route-a-2', 'route.statuses'],
+        "group A's publish should carry the deduplicated union of both tasks' routes"
+      );
+      assert.deepEqual(
+        [...publishedRoutes[GROUP_B]].sort(),
+        ['route.statuses'],
+        "group B's publish should carry the injected statuses route only"
+      );
+    });
+
+    test('multi-group yml still publishes remaining groups when one publish fails', async () => {
+      github.inst(INST_ID).setTaskclusterYml({
+        owner: 'TaskclusterRobot',
+        repo: 'hooks-testing',
+        ref: COMMIT_SHA,
+        content: multiGroupConfig(),
+      });
+
+      helper.onPulsePublish((exchange, _routingKey, payload) => {
+        if (exchange.endsWith('task-group-creation-requested')) {
+          if (JSON.parse(payload).taskGroupId === GROUP_A) {
+            throw new Error('simulated publish failure for group A');
+          }
+        }
+      });
+
+      await simulateJobMessage({ user: 'TaskclusterRobot' });
+
+      // group B's publish should still land after group A's fails
+      helper.assertPulseMessage('task-group-creation-requested', m => m.payload.taskGroupId === GROUP_B);
+      helper.assertNoPulseMessage('task-group-creation-requested', m => m.payload.taskGroupId === GROUP_A);
+    });
+
+    test('multi-group yml calls cancelPreviousTaskGroups once for pull_request', async () => {
+      github.inst(INST_ID).setRepoCollaborator({
+        owner: 'TaskclusterRobot',
+        repo: 'hooks-testing',
+        username: 'goodBuddy',
+      });
+      github.inst(INST_ID).setTaskclusterYml({
+        owner: 'TaskclusterRobot',
+        repo: 'hooks-testing',
+        ref: COMMIT_SHA,
+        content: multiGroupConfig(),
+      });
+      github.inst(INST_ID).setTaskclusterYml({
+        owner: 'TaskclusterRobot',
+        repo: 'hooks-testing',
+        ref: 'development',
+        content: multiGroupConfig(),
+      });
+
+      await simulateJobMessage({ user: 'goodBuddy', eventType: 'pull_request.opened', pullNumber: 1001 });
+
+      assert(handlers.createTasks.calledOnce, 'createTasks should be called once');
+      // cancelPreviousTaskGroups should be called exactly once regardless of how many groups exist
+      assert(handlers.cancelPreviousTaskGroups.calledOnce, 'cancelPreviousTaskGroups should be called once');
     });
 
     test('valid pull_request (user is collaborator) creates a taskGroup', async () => {

--- a/ui/docs/reference/integrations/github/taskcluster-yml-v1.mdx
+++ b/ui/docs/reference/integrations/github/taskcluster-yml-v1.mdx
@@ -155,6 +155,13 @@ produces multiple tasks, then the same default `taskGroupId` will apply to all
 tasks, with each task getting a unique `taskId` distinct from the
 `taskGroupId`.
 
+Tasks may also set distinct `taskGroupId` values to form multiple task groups
+within the same `.taskcluster.yml`.  In that case tc-github creates one build
+record per unique `taskGroupId`.  Multiple task groups are supported under
+`reporting: checks-v1`, which reports results per group and per task; the
+legacy Statuses API cannot distinguish between them, as it posts a single
+commit-status context per commit (sha) and event type.
+
 ### Task Definition and Examples
 
 #### Github Events


### PR DESCRIPTION
## Problem

When a `.taskcluster.yml` defines tasks with different `taskGroupId` values, the GitHub service only recorded `tasks[0]`'s `taskGroupId` in the `github_builds` table and only published `taskGroupCreationRequested` for that first group. All other task groups were invisible to GitHub checks and statuses — the build record was never created, so no status was ever posted.

## What changed

**`services/github/src/handlers/job.js`**

The `graphConfig.tasks` processing block now:
1. Builds an ordered `Map<taskGroupId, routes>` over all tasks, keeping the routes of the first task in each group.
2. Creates one `github_builds` row per unique `taskGroupId` (parallel, like the hooks path).
3. Calls `createTasks` unchanged (still a single call with all tasks).
4. Calls `cancelPreviousTaskGroups` once with the first new build. Sibling builds from the same event share the same `event_id` and are already excluded by the existing `event_id` filter inside `cancelPreviousTaskGroups`, so no interface change was needed there.
5. Publishes `taskGroupCreationRequested` once per unique `taskGroupId` (mirroring the hooks code path).

No database schema or API changes are needed — `github_builds` already supports multiple rows per SHA with different `task_group_id` values, and downstream handlers (`status.js`, `deprecatedStatus.js`, `taskGroupCreation.js`) look up builds by `taskGroupId` and need no changes.

## Test coverage

- New fixture `valid-yaml-v1-multi-group.json`: 3 tasks — task1 and task2 in group A, task3 in group B.
- `multi-group yml creates one build record per unique taskGroupId` — verifies 2 `github_builds` rows (one per group), both `pending`.
- `multi-group yml publishes taskGroupCreationRequested once per unique group` — verifies exactly 2 publishes, one per group ID.
- `multi-group yml calls cancelPreviousTaskGroups once for pull_request` — verifies the function is called exactly once regardless of group count.
- `does not cancel sibling task groups from the same event` (in `cancelPreviousTaskGroups` unit suite) — verifies that builds from the same event (same `event_id`) are not cancelled when `cancelPreviousTaskGroups` is called for one of them.

## Maintainer note

I followed the hooks code path (`job.js:335-392`) as the structural model, which already publishes `taskGroupCreationRequested` once per hook. I'd welcome feedback on whether publishing once per unique `taskGroupId` is the right behaviour, or whether there are downstream consumers that expect a single publish per job event.

Fixes #8751