### PR TITLE
Ensure the hooks service cannot fail to serialize errors from the queue

### DIFF
--- a/changelog/issue-8758.md
+++ b/changelog/issue-8758.md
@@ -1,0 +1,6 @@
+audience: users
+level: patch
+reference: issue 8758
+---
+The hooks service now properly forwards network errors from failures to contact
+the queue service instead of masking it with some serialization error

--- a/services/hooks/src/taskcreator.js
+++ b/services/hooks/src/taskcreator.js
@@ -141,10 +141,17 @@ export class TaskCreator {
         // of the LastFire table
         let lfError;
 
-        if (typeof err === 'object') {
-          lfError = JSON.stringify(err, null, 2);
+        if (err && typeof err === 'object') {
+          lfError = JSON.stringify({
+            name: err.name,
+            message: err.message,
+            code: err.code,
+            statusCode: err.statusCode ?? err.response?.statusCode,
+            url: err.options?.url?.href,
+            body: err.body,
+          }, null, 2);
         } else {
-          lfError = err.toString();
+          lfError = String(err);
         }
         if (lfError.length > 256 * 1024 / 2) {
           lfError = lfError.substring(0, 256 * 1024 / 2);

--- a/services/hooks/test/taskcreator_test.js
+++ b/services/hooks/test/taskcreator_test.js
@@ -226,6 +226,47 @@ suite(testing.suiteName(), () => {
       throw new Error('should have seen an error from .fire');
     });
 
+    test('firing a hook where the queue throws a network error stores a serialized error', async () => {
+      const hook = await createTestHook([], { firedBy: '${firedBy}' });
+      const taskId = taskcluster.slugid();
+
+      // Build an error with the same shape a failed `got` request carries
+      const circErr = new Error('connect ECONNREFUSED taskcluster-queue:80');
+      circErr.code = 'ECONNREFUSED';
+      const agent = { sockets: {} };
+      const clientRequest = { agent };
+      agent.sockets['taskcluster-queue:80:'] = [{ _httpMessage: clientRequest }];
+      circErr.options = {
+        agent: { http: agent, https: undefined, http2: undefined },
+      };
+
+      creator.fakeCreate = false;
+      const realCreateTask = taskcluster.Queue.prototype.createTask;
+      taskcluster.Queue.prototype.createTask = async () => { throw circErr; };
+
+      let caught;
+      try {
+        await creator.fire(hook, { firedBy: 'me' }, { taskId });
+      } catch (err) {
+        caught = err;
+      } finally {
+        taskcluster.Queue.prototype.createTask = realCreateTask;
+      }
+
+      assert.ok(caught, 'expected fire() to throw');
+      assert.ok(caught === circErr, 'should rethrow the original queue error');
+
+      const [lf] = await helper.db.fns.get_last_fire(
+        hook.hookGroupId,
+        hook.hookId,
+        taskId,
+      );
+      assume(lf.result).to.equal('error');
+      assume(lf.error).to.match(/ECONNREFUSED/);
+      assume(lf.fired_by).to.equal('me');
+      assertFireLogged({ firedBy: 'me', taskId, result: 'failure' });
+    });
+
     test('firing a real task that sets its own task times works', async () => {
       const hook = _.cloneDeep(defaultHook);
       hook.task.then.created = { $fromNow: '0 seconds' };


### PR DESCRIPTION
When `queue.createTask` failed with some network error, the hooks service tried to `JSON.stringify` it to store it in the `lastFire` table. But errors from `got` contain a circular reference which makes them non JSON serializable. This serialization failure ends up being reported to the client.

Instead of serializing the entire object, pick out the useful fields that would be necessary to debugging why it's failing in the first place and serialize those instead. I also made sure if the error is ever `null` that it can't fail because javascript is awesome and `typeof null` is `object`, as one would definitely expect.

Fixes #8758