### PR TITLE
Don't use `Object.prototype` builtin methods

### DIFF
--- a/changelog/flIxFRQ0SEiH_47ojTo0oA.md
+++ b/changelog/flIxFRQ0SEiH_47ojTo0oA.md
@@ -1,0 +1,2 @@
+level: silent
+---

--- a/libraries/monitor/src/monitor.js
+++ b/libraries/monitor/src/monitor.js
@@ -294,7 +294,7 @@ class Monitor {
    *
    */
   reportError(err, level = 'err', extra = {}) {
-    if (!(Object.prototype.hasOwnProperty.call(err, 'stack') || Object.prototype.hasOwnProperty.call(err, 'message'))) {
+    if (!(Object.hasOwn(err, 'stack') || Object.hasOwn(err, 'message'))) {
       err = new Error(err);
     }
     if (typeof level !== 'string') {

--- a/services/github/test/webhook_test.js
+++ b/services/github/test/webhook_test.js
@@ -220,7 +220,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], (mock, skipping) => {
 
       // Verify event-specific fields
       for (const field of specificFields) {
-        assert.ok(Object.prototype.hasOwnProperty.call(payload.body, field),
+        assert.ok(Object.hasOwn(payload.body, field),
           `${file} should have event-specific field: ${field}`);
       }
     }

--- a/services/queue/src/utils.js
+++ b/services/queue/src/utils.js
@@ -209,7 +209,7 @@ export const joinTaskQueueId = (provisionerId, workerType) => {
  * taskQueueId field to maintain public interface compatibility
  */
 export const addSplitFields = (obj) => {
-  assert(Object.prototype.hasOwnProperty.call(obj, 'taskQueueId'), 'object is missing property `taskQueueId`');
+  assert(Object.hasOwn(obj, 'taskQueueId'), 'object is missing property `taskQueueId`');
   const { provisionerId, workerType } = splitTaskQueueId(obj.taskQueueId);
   obj.provisionerId = provisionerId;
   obj.workerType = workerType;
@@ -220,8 +220,8 @@ export const addSplitFields = (obj) => {
  * equivalent taskQueueId.
  */
 export const useOnlyTaskQueueId = (obj) => {
-  assert(Object.prototype.hasOwnProperty.call(obj, 'provisionerId'), 'object is missing property `provisionerId`');
-  assert(Object.prototype.hasOwnProperty.call(obj, 'workerType'), 'object is missing property `workerType`');
+  assert(Object.hasOwn(obj, 'provisionerId'), 'object is missing property `provisionerId`');
+  assert(Object.hasOwn(obj, 'workerType'), 'object is missing property `workerType`');
   const taskQueueId = joinTaskQueueId(obj.provisionerId, obj.workerType);
   obj.taskQueueId = taskQueueId;
   delete obj.provisionerId;


### PR DESCRIPTION
This is very easy to misuse and introduce bugs because once again, javascript is showing how awesome it is at not being able to distinguish between a builtin method and an object attribute. So the following happens:

```
> {}.hasOwnProperty("bar")
false
> {"hasOwnProperty": 1}.hasOwnProperty("bar")
Uncaught TypeError: {(intermediate value)}.hasOwnProperty is not a function
```

All changes in this commit are actually "false positives" reported by biome because `Object.prototype.hasOwnProperty.call` is already safe in that regard. But we definitely want to keep that lint and the result is a lot more readable anyway.

Fixes biome's noPrototypeBuiltins lint
