### PR TITLE
Use `@ts-expect-error` instead of `ts-ignore`

### DIFF
--- a/changelog/fRJCRzvER0CqGwHgAyL2Jg.md
+++ b/changelog/fRJCRzvER0CqGwHgAyL2Jg.md
@@ -1,0 +1,2 @@
+level: silent
+---

--- a/libraries/api/src/index.js
+++ b/libraries/api/src/index.js
@@ -136,7 +136,7 @@ export class APIBuilder {
         },
       },
     };
-    // @ts-ignore - we know that options.errorCodes is defined
+    // @ts-expect-error - we know that options.errorCodes is defined
     Object.entries(options.errorCodes).forEach(([key, value]) => {
       assert(/[A-Z][A-Za-z0-9]*/.test(key), `Invalid error code: ${key}`);
       assert(typeof value === 'number', 'Expected HTTP status code to be int');

--- a/libraries/api/src/middleware/handle.js
+++ b/libraries/api/src/middleware/handle.js
@@ -18,7 +18,7 @@ export const callHandler = ({ entry, context, monitor }) => {
   assert(entry.handler, 'No handler is provided');
   return (req, res, next) => {
     Promise.resolve(null).then(() => {
-      // @ts-ignore - we check this above already
+      // @ts-expect-error - we check this above already
       return entry.handler.call(req.tcContext, req, res);
     }).then(() => {
       if (!req.public && !req.satisfyingScopes) {

--- a/libraries/monitor/src/plugins/prometheus.js
+++ b/libraries/monitor/src/plugins/prometheus.js
@@ -173,14 +173,14 @@ export class PrometheusPlugin {
         break;
       case 'histogram':
         if (buckets) {
-          // @ts-ignore
+          // @ts-expect-error
           metricOptions.buckets = buckets;
         }
         metric = new Histogram(metricOptions);
         break;
       case 'summary':
         if (percentiles) {
-          // @ts-ignore
+          // @ts-expect-error
           metricOptions.percentiles = percentiles;
         }
         metric = new Summary(metricOptions);

--- a/libraries/postgres/src/Database.js
+++ b/libraries/postgres/src/Database.js
@@ -115,7 +115,7 @@ class Database {
         collection = this.deprecatedFns;
       }
 
-      // @ts-ignore method name is known to be correct for DbFunctions
+      // @ts-expect-error method name is known to be correct for DbFunctions
       collection[method.name] = async (...args) => {
         if (serviceName !== method.serviceName && method.mode !== READ) {
           throw new Error(
@@ -599,7 +599,7 @@ class Database {
 
     this.pools = /** @type {Record<DbAccessMode, pg.Pool>} */({});
     for (const mode of Object.keys(urlsByMode)) {
-      // @ts-ignore mode is of a type DbAccessMode
+      // @ts-expect-error mode is of a type DbAccessMode
       this.pools[mode] = makePool(urlsByMode[mode]);
     }
 

--- a/services/worker-manager/src/providers/index.js
+++ b/services/worker-manager/src/providers/index.js
@@ -150,7 +150,7 @@ export class Providers {
     if (p?.setupFailed) {
       // If setup failed, we do not return the provider, but just an empty object.  This
       // avoids mistakes where the caller does not check for failed setup.
-      // @ts-ignore
+      // @ts-expect-error
       return { setupFailed: true };
     }
     return p;


### PR DESCRIPTION
They basically do the same (silence the compiler), but the expect-error one will emit something if the error ever gets fixed which means we cannot end up with useless erroneous annotations stating that code is buggy when it is in fact not anymore

Fix biome's noTsIgnore lint
