### PR TITLE
Replace global `isFinite` with targeted `Number.isFinite`

### DIFF
--- a/changelog/WB6MIKGxTHGRt50h25lPEQ.md
+++ b/changelog/WB6MIKGxTHGRt50h25lPEQ.md
@@ -1,0 +1,2 @@
+level: silent
+---

--- a/services/queue/src/queueservice.js
+++ b/services/queue/src/queueservice.js
@@ -80,7 +80,7 @@ export class QueueService {
     assert(workerId, 'workerId must be given');
     assert(typeof runId === 'number', 'runId must be a number');
     assert(takenUntil instanceof Date, 'takenUntil must be a date');
-    assert(isFinite(takenUntil), 'takenUntil must be a valid date');
+    assert(Number.isFinite(takenUntil.getTime()), 'takenUntil must be a valid date');
 
     await this.db.fns.queue_claimed_task_put(
       taskId,
@@ -207,7 +207,7 @@ export class QueueService {
     assert(taskGroupId, 'taskGroupId must be given');
     assert(schedulerId, 'schedulerId must be given');
     assert(deadline instanceof Date, 'deadline must be a date');
-    assert(isFinite(deadline), 'deadline must be a valid date');
+    assert(Number.isFinite(deadline.getTime()), 'deadline must be a valid date');
 
     const delay = Math.floor(this.deadlineDelay / 1000);
     debug('Put deadline message to be visible in %s seconds',


### PR DESCRIPTION
This is similar to what was done in
fd850ae900aa7b775eb664f56d45e80e37a36fad for isNaN. For the same reason (isFinite doesn't try to coerce non numbers before checking), one should use `Number.isFinite` instead of the global `isFinite`. See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/isFinite#description

Fix biome's noGlobalIsFinite lint
