### PR TITLE
Don't return and assign from functions in a single expression

### DIFF
--- a/changelog/S7z3njaZQM2eCjGvh2OkIA.md
+++ b/changelog/S7z3njaZQM2eCjGvh2OkIA.md
@@ -1,0 +1,2 @@
+level: silent
+---

--- a/libraries/loader/src/index.js
+++ b/libraries/loader/src/index.js
@@ -100,7 +100,7 @@ function loader(componentDirectory, virtualComponents = {}) {
         // Initialize component, this won't cause an infinite loop because
         // we've already check that the componentDirectory is a DAG
         const requires = def.requires || [];
-        return loaded[target] = Promise.all(requires.map(recursiveLoad)).then(deps => {
+        loaded[target] = Promise.all(requires.map(recursiveLoad)).then(deps => {
           const ctx = {};
           for (let i = 0; i < deps.length; i++) {
             ctx[def.requires[i]] = deps[i];
@@ -116,6 +116,7 @@ function loader(componentDirectory, virtualComponents = {}) {
             throw err;
           });
         });
+        return loaded[target];
       }
       return loaded[target];
     }

--- a/services/auth/src/scoperesolver.js
+++ b/services/auth/src/scoperesolver.js
@@ -146,7 +146,8 @@ class ScopeResolver extends events.EventEmitter {
    * functions are executed in serial.
    */
   _syncReload(reloader) {
-    return this._reloadDone = this._reloadDone.catch(() => {}).then(reloader);
+    this._reloadDone = this._reloadDone.catch(() => {}).then(reloader);
+    return this._reloadDone;
   }
 
   reloadClient(clientId) {

--- a/services/auth/src/scopesetbuilder.js
+++ b/services/auth/src/scopesetbuilder.js
@@ -157,8 +157,10 @@ class ScopeSetBuilder {
     // Take scopes from tree until it's empty, ie. tree.next() returns null
     // Notice: that we must call tree.next() before we read the first value.
     const result = [];
-    while (tree = tree.next()) { // eslint-disable-line no-cond-assign
+    tree = tree.next();
+    while (tree) {
       result.push(tree.value);
+      tree = tree.next();
     }
     return result;
   }

--- a/services/auth/src/sentrymanager.js
+++ b/services/auth/src/sentrymanager.js
@@ -201,7 +201,8 @@ class SentryManager {
     }
 
     // Save to cache and return
-    return this._projectDSNCache[project] = key;
+    this._projectDSNCache[project] = key;
+    return key;
   }
 
   /** Remove old expired keys, returns number of keys deleted */

--- a/services/github/src/tc-yaml.js
+++ b/services/github/src/tc-yaml.js
@@ -223,7 +223,8 @@ class VersionOne extends TcYaml {
       if (rv) {
         return rv;
       } else {
-        return slugids[label] = slugid.nice();
+        slugids[label] = slugid.nice();
+        return slugids[label];
       }
     };
 

--- a/services/hooks/src/listeners.js
+++ b/services/hooks/src/listeners.js
@@ -182,9 +182,10 @@ class HookListeners {
    * Run only one exeuction of this function at a time, reporting any errors to the monitor.
    */
   _synchronise(asyncfunc) {
-    return this._reconcileDone = this._reconcileDone
+    this._reconcileDone = this._reconcileDone
       .then(asyncfunc)
       .catch(err => this.monitor.reportError(err));
+    return this._reconcileDone;
   }
 
   /**

--- a/services/queue/src/hintpoller.js
+++ b/services/queue/src/hintpoller.js
@@ -79,10 +79,13 @@ class HintPoller {
 
       // While limit of hints requested is greater zero, and we are getting
       // hints from the queue we continue to claim from this queue
-      let limit, hints;
       let i = 10; // count iterations a limit to 10, before we start over
-      while ((limit = _.sumBy(this.requests, 'count')) > 0 &&
-          (hints = await this.pollPendingQueue(limit)).length > 0 && i-- > 0) {
+      let limit = _.sumBy(this.requests, 'count');
+      while (limit > 0) {
+        const hints = await this.pollPendingQueue(limit);
+        if (hints.length === 0 || i-- <= 0) {
+          break;
+        }
         // Count hints claimed
         claimed += hints.length;
 
@@ -95,6 +98,8 @@ class HintPoller {
         // Release remaining hints (this shouldn't happen often!)
         await Promise.all(hints.map(hint => hint.release()));
         released += hints.length;
+
+        limit = _.sumBy(this.requests, 'count');
       }
 
       // If nothing was claimed, we sleep 1000ms before polling again


### PR DESCRIPTION
This is usually hiding actual typos (missing `=` for example) and is always a bit unclear just to save what's most of the time a single line of code.

The hintpoller one is substantial because the previous bespoke implementation was something that you'd normally only ever see in C code golf. There should be no behavior change but it's slightly more readable now.

Fix biome's noAssignInExpressions lint