### PR TITLE
Fix biome's useBlockStatements lint

### DIFF
--- a/changelog/Sy6MJLz-ScmmuqT1lLtQng.md
+++ b/changelog/Sy6MJLz-ScmmuqT1lLtQng.md
@@ -1,0 +1,2 @@
+level: silent
+---

--- a/services/worker-manager/src/providers/aws.js
+++ b/services/worker-manager/src/providers/aws.js
@@ -116,7 +116,10 @@ export class AwsProvider extends Provider {
     let toSpawnCounter = toSpawn;
     for await (const lc of shuffledConfigs) {
       const config = lc.configuration;
-      if (toSpawnCounter <= 0) break; // eslint-disable-line
+      if (toSpawnCounter <= 0) {
+        break;
+      }
+
       // Make sure we don't get "The same resource type may not be specified
       // more than once in tag specifications" errors
       const TagSpecifications = config.launchConfig.TagSpecifications || [];


### PR DESCRIPTION
I have no idea why this got eslint ignored to save a pair of curly braces. This isn't the kind of braces you want to ignore to not get bankrupt...
