### PR TITLE
Don't return values from callbacks that are expecting no return value

### DIFF
--- a/changelog/Zk5dNq2HS6qC6O5idnxTsw.md
+++ b/changelog/Zk5dNq2HS6qC6O5idnxTsw.md
@@ -1,0 +1,2 @@
+level: silent
+---

--- a/clients/client-web/src/emitter.js
+++ b/clients/client-web/src/emitter.js
@@ -53,6 +53,8 @@ export default class Emitter {
       return;
     }
 
-    handlers.forEach(handler => handler(...args));
+    handlers.forEach(handler => {
+      handler(...args);
+    });
   }
 }

--- a/db/test/fns/queue_test.js
+++ b/db/test/fns/queue_test.js
@@ -2572,7 +2572,9 @@ suite(testing.suiteName(), () => {
           [taskIds],
         );
         assert.equal(rows.length, 150);
-        rows.forEach(row => assert.equal(row.priority, 2));
+        rows.forEach(row => {
+          assert.equal(row.priority, 2);
+        });
       });
     });
 

--- a/infrastructure/tooling/src/generate/generators/docs-tocs.js
+++ b/infrastructure/tooling/src/generate/generators/docs-tocs.js
@@ -86,7 +86,9 @@ function addNav(node, parentNode) {
   prevNode = node;
   parentNode = node;
 
-  node.children.forEach(child => addNav(child, parentNode));
+  node.children.forEach(child => {
+    addNav(child, parentNode);
+  });
 }
 
 function makeToc({ files, rootPath }) {

--- a/infrastructure/tooling/src/generate/generators/service-refs.js
+++ b/infrastructure/tooling/src/generate/generators/service-refs.js
@@ -64,13 +64,17 @@ tasks.push({
     // combine all of the references, using a map to eliminate duplicate files
     // (the common schemas will be duplicated, for example)
     const files = new Map();
-    SERVICES.forEach(
-      name => requirements[`refs-${name}`].forEach(
-        ({ filename, content }) => files.set(filename, content)));
-    requirements['generic-worker-schemas'].forEach(
-      ({ filename, content }) => files.set(filename, content));
-    requirements['docker-worker-schemas'].forEach(
-      ({ filename, content }) => files.set(filename, content));
+    SERVICES.forEach(name => {
+      requirements[`refs-${name}`].forEach(({ filename, content }) => {
+        files.set(filename, content);
+      });
+    });
+    requirements['generic-worker-schemas'].forEach(({ filename, content }) => {
+      files.set(filename, content);
+    });
+    requirements['docker-worker-schemas'].forEach(({ filename, content }) => {
+      files.set(filename, content);
+    });
 
     // add config-values-schema, mostly so that it can be referenced in the manual
     files.set('schemas/common/values.schema.json', requirements['config-values-schema']);

--- a/infrastructure/tooling/src/utils/crates.js
+++ b/infrastructure/tooling/src/utils/crates.js
@@ -69,7 +69,9 @@ export const cargoPublish = async ({ dir, token, push, logfile, utils }) => {
       }
 
       const loglines = data =>
-        data.toString('utf-8').trimRight().split(/[\r\n]+/).forEach(l => observer.next(l));
+        data.toString('utf-8').trimRight().split(/[\r\n]+/).forEach(l => {
+          observer.next(l);
+        });
       proc.stdout.on('data', loglines);
       proc.stderr.on('data', loglines);
       proc.on('close', code => {

--- a/infrastructure/tooling/src/utils/load-tasks.js
+++ b/infrastructure/tooling/src/utils/load-tasks.js
@@ -25,7 +25,9 @@ export const loadTasks = async (dirname) => {
 
   await Promise.all(files.map(async (file) => {
     const { tasks } = await import(path.join(dirname, file));
-    tasks.forEach(val => ensureTask(result, val));
+    tasks.forEach(val => {
+      ensureTask(result, val);
+    });
   }));
 
   return result;

--- a/infrastructure/tooling/src/utils/pypi.js
+++ b/infrastructure/tooling/src/utils/pypi.js
@@ -59,7 +59,9 @@ export const pyClientRelease = async ({ dir, username, password, logfile, utils 
       }
 
       const loglines = data =>
-        data.toString('utf-8').trimRight().split(/[\r\n]+/).forEach(l => observer.next(l));
+        data.toString('utf-8').trimRight().split(/[\r\n]+/).forEach(l => {
+          observer.next(l);
+        });
       proc.stdout.on('data', loglines);
       proc.stderr.on('data', loglines);
       proc.on('close', code => {

--- a/libraries/monitor/src/monitor.js
+++ b/libraries/monitor/src/monitor.js
@@ -354,7 +354,9 @@ class Monitor {
         assert(level !== 'any' || overrides.level !== undefined, 'Must provide `overrides.level` if registered level is `any`.');
         const providedFields = Object.keys(fields);
         assert(!providedFields.includes('v'), '"v" is a reserved field for logging messages.');
-        requiredFields.forEach(f => assert(providedFields.includes(f), `Log message "${name}" must include field "${f}".`));
+        requiredFields.forEach(f => {
+          assert(providedFields.includes(f), `Log message "${name}" must include field "${f}".`);
+        });
       }
       const lv = level === 'any' ? overrides.level : level;
       this._log[lv](type, { v: version, ...fields });

--- a/libraries/references/src/validate.js
+++ b/libraries/references/src/validate.js
@@ -53,10 +53,14 @@ const recurseJSON = (content, callbacks) => {
   const recurse = (value, path) => {
     if (Array.isArray(value)) {
       callbacks.array(value, path);
-      value.forEach((v, i) => recurse(v, `${path}[${i}]`));
+      value.forEach((v, i) => {
+        recurse(v, `${path}[${i}]`);
+      });
     } else if (typeof value === 'object') {
       callbacks.object(value, path);
-      Object.entries(value).forEach(([k, v]) => recurse(v, `${path}.${k}`));
+      Object.entries(value).forEach(([k, v]) => {
+        recurse(v, `${path}.${k}`);
+      });
     } else {
       callbacks.scalar(value, path);
     }
@@ -167,7 +171,9 @@ export const validate = (references) => {
         ajv
           .errorsText(ajv.errors, { separator: '%%/%%', dataVar: 'schema' })
           .split('%%/%%')
-          .forEach(err => problems.push(`${filename}: ${err}`));
+          .forEach(err => {
+            problems.push(`${filename}: ${err}`);
+          });
       }
     }
 
@@ -182,7 +188,9 @@ export const validate = (references) => {
         ajv
           .errorsText(ajv.errors, { separator: '%%/%%', dataVar: 'reference' })
           .split('%%/%%')
-          .forEach(err => problems.push(`${filename}: ${err}`));
+          .forEach(err => {
+            problems.push(`${filename}: ${err}`);
+          });
       }
     }
   }

--- a/libraries/references/test/metaschema_test.js
+++ b/libraries/references/test/metaschema_test.js
@@ -28,7 +28,9 @@ suite(testing.suiteName(), () => {
           ajv
             .errorsText(ajv.errors, { separator: '%%/%%', dataVar: 'schema' })
             .split('%%/%%')
-            .forEach(err => problems.push(err));
+            .forEach(err => {
+              problems.push(err);
+            });
         }
       } catch (err) {
         problems.push(err.toString());

--- a/libraries/testing/src/with-pulse.js
+++ b/libraries/testing/src/with-pulse.js
@@ -28,8 +28,9 @@ export default ({ helper, skipping, namespace }) => {
     helper.assertPulseMessage = (exchange, check) => {
       if (!matchingMessageExists(exchange, check)) {
         debugPulseAssertion(`${client.messages.length} pulse messages recorded:`);
-        client.messages.forEach(({ exchange, routingKey }) =>
-          debugPulseAssertion(`${exchange} - ${routingKey}`));
+        client.messages.forEach(({ exchange, routingKey }) => {
+          debugPulseAssertion(`${exchange} - ${routingKey}`);
+        });
         throw new Error(`No matching messages found with exchange ${exchange}`);
       }
     };
@@ -37,8 +38,9 @@ export default ({ helper, skipping, namespace }) => {
     helper.assertNoPulseMessage = (exchange, check) => {
       if (matchingMessageExists(exchange, check)) {
         debugPulseAssertion(`${client.messages.length} pulse messages recorded:`);
-        client.messages.forEach(({ exchange, routingKey }) =>
-          debugPulseAssertion(`${exchange} - ${routingKey}`));
+        client.messages.forEach(({ exchange, routingKey }) => {
+          debugPulseAssertion(`${exchange} - ${routingKey}`);
+        });
         throw new Error(`Matching messages found with exchange ${exchange}`);
       }
     };
@@ -70,9 +72,10 @@ export default ({ helper, skipping, namespace }) => {
       }
       if (!delivered) {
         debugPulseAssertion(`${client.consumers.length} consumers registered:`);
-        client.consumers.forEach(cons =>
+        client.consumers.forEach(cons => {
           debugPulseAssertion(`- ${cons.bindings.map(({ exchange, routingKeyPattern }) =>
-            `${exchange} - ${routingKeyPattern}`).join('; ')}`));
+            `${exchange} - ${routingKeyPattern}`).join('; ')}`);
+        });
 
         throw new Error('Fake message not delivered to any consumers');
       }

--- a/libraries/testing/test/secrets_test.js
+++ b/libraries/testing/test/secrets_test.js
@@ -16,8 +16,12 @@ suite(suiteName(), () => {
 
   teardown(() => {
     // reset process.env back to savedEnv, in-place (without $TASK_ID)
-    Object.keys(process.env).forEach(k => delete process.env[k]);
-    Object.entries(savedEnv).forEach(([k, v]) => process.env[k] = v);
+    Object.keys(process.env).forEach(k => {
+      delete process.env[k];
+    });
+    Object.entries(savedEnv).forEach(([k, v]) => {
+      process.env[k] = v;
+    });
   });
 
   suiteTeardown(() => {

--- a/services/auth/test/scoperesolver_test.js
+++ b/services/auth/test/scoperesolver_test.js
@@ -461,7 +461,9 @@ suite(testing.suiteName(), () => {
       const recur = (prefix, h) => {
         const role_ids = _.range(W).map(w => `${prefix}-${w}`);
         if (h !== H) {
-          role_ids.forEach(role_id => recur(role_id, h + 1));
+          role_ids.forEach(role_id => {
+            recur(role_id, h + 1);
+          });
         }
         roles.push({
           role_id: prefix,

--- a/services/auth/test/scopesetbuilder_test.js
+++ b/services/auth/test/scopesetbuilder_test.js
@@ -57,31 +57,37 @@ suite(testing.suiteName(), () => {
     ],
   ].map(sets => sets.map(s => s.sort(scopeCompare)));
 
-  testCases.forEach((sets, index) => test(`...add().scopes() (${index + 1})`, () => {
-    const builder = new ScopeSetBuilder();
-    for (const s of sets) {
-      builder.add(s);
-    }
-    assume(builder.scopes()).eql(sets.reduce(mergeScopeSets, []));
-  }));
-
-  testCases.forEach((sets, index) => test(`...add().scopes() shuffled (${index + 1})`, () => {
-    for (let i = 0; i < 100; i++) {
+  testCases.forEach((sets, index) => {
+    test(`...add().scopes() (${index + 1})`, () => {
       const builder = new ScopeSetBuilder();
-      for (const s of _.shuffle(sets)) {
+      for (const s of sets) {
         builder.add(s);
       }
       assume(builder.scopes()).eql(sets.reduce(mergeScopeSets, []));
-    }
-  }));
+    });
+  });
 
-  testCases.forEach((sets, index) => test(`...add().scopes() optionallyClone (${index + 1})`, () => {
-    const builder = new ScopeSetBuilder({ optionallyClone: true });
-    for (const s of sets) {
-      builder.add(s);
-    }
-    assume(builder.scopes()).eql(sets.reduce(mergeScopeSets, []));
-  }));
+  testCases.forEach((sets, index) => {
+    test(`...add().scopes() shuffled (${index + 1})`, () => {
+      for (let i = 0; i < 100; i++) {
+        const builder = new ScopeSetBuilder();
+        for (const s of _.shuffle(sets)) {
+          builder.add(s);
+        }
+        assume(builder.scopes()).eql(sets.reduce(mergeScopeSets, []));
+      }
+    });
+  });
+
+  testCases.forEach((sets, index) => {
+    test(`...add().scopes() optionallyClone (${index + 1})`, () => {
+      const builder = new ScopeSetBuilder({ optionallyClone: true });
+      for (const s of sets) {
+        builder.add(s);
+      }
+      assume(builder.scopes()).eql(sets.reduce(mergeScopeSets, []));
+    });
+  });
 
   test('.scopes() optionallyClone: true', () => {
     const builder = new ScopeSetBuilder({ optionallyClone: true });
@@ -101,18 +107,22 @@ suite(testing.suiteName(), () => {
     assume(sets[0] === builder.scopes()).is.false('expected to get a clone');
   });
 
-  testCases.forEach((sets, index) => test(`normalizeScopeSet() shuffled (${index + 1})`, () => {
-    for (let i = 0; i < 100; i++) {
-      const scopes = _.shuffle([].concat(...sets));
-      assume(ScopeSetBuilder.normalizeScopeSet(scopes)).eql(sets.reduce(mergeScopeSets, []));
-    }
-  }));
+  testCases.forEach((sets, index) => {
+    test(`normalizeScopeSet() shuffled (${index + 1})`, () => {
+      for (let i = 0; i < 100; i++) {
+        const scopes = _.shuffle([].concat(...sets));
+        assume(ScopeSetBuilder.normalizeScopeSet(scopes)).eql(sets.reduce(mergeScopeSets, []));
+      }
+    });
+  });
 
-  testCases.forEach((sets, index) => test(`mergeScopeSets() shuffled (${index + 1})`, () => {
-    for (let i = 0; i < 100; i++) {
-      assume(_.shuffle(sets).reduce(ScopeSetBuilder.mergeScopeSets, [])).eql(sets.reduce(mergeScopeSets, []));
-    }
-  }));
+  testCases.forEach((sets, index) => {
+    test(`mergeScopeSets() shuffled (${index + 1})`, () => {
+      for (let i = 0; i < 100; i++) {
+        assume(_.shuffle(sets).reduce(ScopeSetBuilder.mergeScopeSets, [])).eql(sets.reduce(mergeScopeSets, []));
+      }
+    });
+  });
 
   test('mergeScopeSets(A, [])', () => {
     const A = ['a', 'b', 'c'];

--- a/services/auth/test/trie_test.js
+++ b/services/auth/test/trie_test.js
@@ -47,15 +47,17 @@ suite(testing.suiteName(), () => {
         { pattern: 'a*', scopes: ['b<..>z'] },
         { pattern: 'c*', scopes: ['d<..>'] },
       ],
-    ].forEach((rules, index) => test(`independent rules (${index + 1})`, () => {
-      _.range(50).forEach(() => { // run 50 times with different shuffling
-        const ordering = trie.dependencyOrdering(_.shuffle(rules));
-        assume(ordering).has.length(rules.length);
-        for (const { pattern } of rules) {
-          assume(ordering.map(r => r.pattern)).contains(pattern);
-        }
+    ].forEach((rules, index) => {
+      test(`independent rules (${index + 1})`, () => {
+        _.range(50).forEach(() => { // run 50 times with different shuffling
+          const ordering = trie.dependencyOrdering(_.shuffle(rules));
+          assume(ordering).has.length(rules.length);
+          for (const { pattern } of rules) {
+            assume(ordering.map(r => r.pattern)).contains(pattern);
+          }
+        });
       });
-    }));
+    });
 
     [ // rules must be strictly dependent and ordered by dependency
       [
@@ -89,12 +91,14 @@ suite(testing.suiteName(), () => {
         { pattern: 'bbb', scopes: ['cb'] },
         { pattern: 'a*', scopes: ['b<..>c'] },
       ],
-    ].forEach((rules, index) => test(`acyclic rules (${index + 1})`, () => {
-      _.range(50).forEach(() => { // run 50 times with different shuffling
-        const ordering = trie.dependencyOrdering(_.shuffle(rules));
-        assume(ordering.map(r => r.pattern)).eql(rules.map(r => r.pattern));
+    ].forEach((rules, index) => {
+      test(`acyclic rules (${index + 1})`, () => {
+        _.range(50).forEach(() => { // run 50 times with different shuffling
+          const ordering = trie.dependencyOrdering(_.shuffle(rules));
+          assume(ordering.map(r => r.pattern)).eql(rules.map(r => r.pattern));
+        });
       });
-    }));
+    });
 
     [
       [
@@ -134,11 +138,13 @@ suite(testing.suiteName(), () => {
         { pattern: 'bbb', scopes: ['cb'] },
         { pattern: 'a*', scopes: ['b<..>c'] },
       ],
-    ].forEach((rules, index) => test(`cyclic rules (${index + 1})`, () => {
-      assume(() => {
-        trie.dependencyOrdering(rules);
-      }).throws('cycle');
-    }));
+    ].forEach((rules, index) => {
+      test(`cyclic rules (${index + 1})`, () => {
+        assume(() => {
+          trie.dependencyOrdering(rules);
+        }).throws('cycle');
+      });
+    });
 
     [
       [
@@ -152,11 +158,13 @@ suite(testing.suiteName(), () => {
       ], [
         { pattern: 'a*', scopes: ['bc*<..>'] },
       ],
-    ].forEach((rules, index) => test(`illegal scopes (${index + 1})`, () => {
-      assume(() => {
-        trie.dependencyOrdering(rules);
-      }).throws('scope', 'expected illegal scope');
-    }));
+    ].forEach((rules, index) => {
+      test(`illegal scopes (${index + 1})`, () => {
+        assume(() => {
+          trie.dependencyOrdering(rules);
+        }).throws('scope', 'expected illegal scope');
+      });
+    });
   });
 
   /**

--- a/services/github/test/utils_test.js
+++ b/services/github/test/utils_test.js
@@ -144,18 +144,24 @@ suite(testing.suiteName(), () => {
         },
       }));
       // should not skip as this is not present in latest commit
-      skipMessages.forEach(message => assert.equal(false, shouldSkipCommit({
-        commits: [{ message }, { message: 'this commit is the last' }],
-      })));
+      skipMessages.forEach(message => {
+        assert.equal(false, shouldSkipCommit({
+          commits: [{ message }, { message: 'this commit is the last' }],
+        }));
+      });
     });
     test('should skip commit', () => {
-      skipMessages.forEach(message => assert.equal(true, shouldSkipCommit({
-        commits: [{ message: 'this commit is the first' }, { message }],
-      })));
+      skipMessages.forEach(message => {
+        assert.equal(true, shouldSkipCommit({
+          commits: [{ message: 'this commit is the first' }, { message }],
+        }));
+      });
 
-      skipMessages.forEach(message => assert.equal(true, shouldSkipCommit({
-        head_commit: { message },
-      })));
+      skipMessages.forEach(message => {
+        assert.equal(true, shouldSkipCommit({
+          head_commit: { message },
+        }));
+      });
     });
   });
   suite('shouldSkipPullRequest', () => {
@@ -174,12 +180,16 @@ suite(testing.suiteName(), () => {
         'PR: [CI Skip] this is not ready',
         'PR: this is WIP [skip ci]',
       ];
-      skipMessages.forEach(title => assert.equal(true, shouldSkipPullRequest({
-        pull_request: { title },
-      })));
-      skipMessages.forEach(body => assert.equal(false, shouldSkipPullRequest({
-        pull_request: { title: 'regular title', body },
-      })));
+      skipMessages.forEach(title => {
+        assert.equal(true, shouldSkipPullRequest({
+          pull_request: { title },
+        }));
+      });
+      skipMessages.forEach(body => {
+        assert.equal(false, shouldSkipPullRequest({
+          pull_request: { title: 'regular title', body },
+        }));
+      });
     });
   });
 

--- a/services/purge-cache/test/helper.js
+++ b/services/purge-cache/test/helper.js
@@ -73,7 +73,9 @@ helper.withServer = (mock, skipping) => {
   });
 
   setup(() => {
-    Object.keys(cachePurgeCache).forEach(k => delete cachePurgeCache[k]);
+    Object.keys(cachePurgeCache).forEach(k => {
+      delete cachePurgeCache[k];
+    });
   });
 
   suiteTeardown(async () => {

--- a/services/queue/test/expireartifacts_test.js
+++ b/services/queue/test/expireartifacts_test.js
@@ -21,7 +21,7 @@ helper.secrets.mockSuite(testing.suiteName(), ['aws'], (mock, skipping) => {
     ['expire s3 artifacts using bulk delete', true, undefined],
     ['expire s3 artifacts using single delete', false, undefined],
     ['expire s3 artifacts using single delete and batch size 1', false, 1],
-  ].forEach(([name, useBulkDelete, batchSize]) =>
+  ].forEach(([name, useBulkDelete, batchSize]) => {
     test(name, async () => {
       const yesterday = taskcluster.fromNow('-1 day');
       const today = new Date();
@@ -86,75 +86,77 @@ helper.secrets.mockSuite(testing.suiteName(), ['aws'], (mock, skipping) => {
         Prefix: `${taskId}/`,
       }));
       assume(objects.Contents.length).equals(0);
-    }),
-  );
+    });
+  });
 
   [
     ['expire s3 artifacts handle missing ones using bulk delete', true],
     ['expire s3 artifacts handle missing ones using single delete', false],
-  ].forEach(([name, useBulkDelete]) => test(name, async () => {
-    const yesterday = taskcluster.fromNow('-1 day');
-    const today = new Date();
-    const taskId = slugid.nice();
-    const bucket = await helper.load('publicArtifactBucket');
+  ].forEach(([name, useBulkDelete]) => {
+    test(name, async () => {
+      const yesterday = taskcluster.fromNow('-1 day');
+      const today = new Date();
+      const taskId = slugid.nice();
+      const bucket = await helper.load('publicArtifactBucket');
 
-    await helper.load('cfg');
-    helper.load.cfg('aws.useBulkDelete', useBulkDelete);
+      await helper.load('cfg');
+      helper.load.cfg('aws.useBulkDelete', useBulkDelete);
 
-    const maxUploads = 1;
+      const maxUploads = 1;
 
-    for (let i = 0; i < MAX_ARTIFACTS; i++) {
-      await helper.db.fns.create_queue_artifact_2(
-        taskId,
-        i,
-        `name-${i}`,
-        's3',
-        'content-type',
-        {
-          bucket: bucket.bucket,
-          prefix: `${taskId}/${i}/log.log`,
-        },
-        false,
-        yesterday,
-        null,
-      );
-    }
-    // don't "upload" all files, just one to make them all fail during deletion
-    await bucket.s3.send(new PutObjectCommand({
-      Bucket: bucket.bucket,
-      Key: `${taskId}/1/log.log`,
-      Body: 'there can be only one',
-    }));
+      for (let i = 0; i < MAX_ARTIFACTS; i++) {
+        await helper.db.fns.create_queue_artifact_2(
+          taskId,
+          i,
+          `name-${i}`,
+          's3',
+          'content-type',
+          {
+            bucket: bucket.bucket,
+            prefix: `${taskId}/${i}/log.log`,
+          },
+          false,
+          yesterday,
+          null,
+        );
+      }
+      // don't "upload" all files, just one to make them all fail during deletion
+      await bucket.s3.send(new PutObjectCommand({
+        Bucket: bucket.bucket,
+        Key: `${taskId}/1/log.log`,
+        Body: 'there can be only one',
+      }));
 
-    // check that the s3 objects exist
-    let objects = await bucket.s3.send(new ListObjectsCommand({
-      Bucket: bucket.bucket,
-      Prefix: `${taskId}/`,
-    }));
-    assume(objects.Contents.length).equals(maxUploads);
+      // check that the s3 objects exist
+      let objects = await bucket.s3.send(new ListObjectsCommand({
+        Bucket: bucket.bucket,
+        Prefix: `${taskId}/`,
+      }));
+      assume(objects.Contents.length).equals(maxUploads);
 
-    let rows = await helper.db.fns.get_expired_artifacts_for_deletion_2({
-      expires_in: today,
-      page_size_in: 1000,
+      let rows = await helper.db.fns.get_expired_artifacts_for_deletion_2({
+        expires_in: today,
+        page_size_in: 1000,
+      });
+      assume(rows.length).equals(MAX_ARTIFACTS);
+
+      debug('### Expire artifacts');
+      await helper.runExpiration('expire-artifacts');
+
+      rows = await helper.db.fns.get_expired_artifacts_for_deletion_2({
+        expires_in: today,
+        page_size_in: 1000,
+      });
+      assume(rows.length).equals(0);
+
+      // check that the s3 objects are gone
+      objects = await bucket.s3.send(new ListObjectsCommand({
+        Bucket: bucket.bucket,
+        Prefix: `${taskId}/`,
+      }));
+      assume(objects.Contents.length).equals(0);
     });
-    assume(rows.length).equals(MAX_ARTIFACTS);
-
-    debug('### Expire artifacts');
-    await helper.runExpiration('expire-artifacts');
-
-    rows = await helper.db.fns.get_expired_artifacts_for_deletion_2({
-      expires_in: today,
-      page_size_in: 1000,
-    });
-    assume(rows.length).equals(0);
-
-    // check that the s3 objects are gone
-    objects = await bucket.s3.send(new ListObjectsCommand({
-      Bucket: bucket.bucket,
-      Prefix: `${taskId}/`,
-    }));
-    assume(objects.Contents.length).equals(0);
-  }));
+  });
 
   test('expire non s3 artifacts', async () => {
     const yesterday = taskcluster.fromNow('-1 day');

--- a/services/web-server/src/PulseEngine/PulseIterator.js
+++ b/services/web-server/src/PulseEngine/PulseIterator.js
@@ -74,7 +74,9 @@ export default class PulseIterator {
 
       // reject any pending pushes and then replace with a single, persistent push
       const err = new Error('iterator cancelled');
-      this.pushQueue.forEach(({ reject }) => reject(err));
+      this.pushQueue.forEach(({ reject }) => {
+        reject(err);
+      });
       this.pushQueue = this.pushQueue.clear().push(push);
     }
     this.match();

--- a/services/web-server/src/PulseEngine/index.js
+++ b/services/web-server/src/PulseEngine/index.js
@@ -42,7 +42,9 @@ export default class PulseEngine {
 
   connected(connection) {
     // reset everything and reconcile
-    Array.from(this.subscriptions.values()).forEach(sub => sub.reset());
+    Array.from(this.subscriptions.values()).forEach(sub => {
+      sub.reset();
+    });
     this.reset();
     this.connection = connection;
     this.reconcileSubscriptions();
@@ -108,7 +110,9 @@ export default class PulseEngine {
     // clean up any garbage
     Array.from(this.subscriptions.values())
       .filter(sub => sub.garbage)
-      .forEach(sub => this.subscriptions.delete(sub.subscriptionId));
+      .forEach(sub => {
+        this.subscriptions.delete(sub.subscriptionId);
+      });
   }
 
   /**

--- a/services/worker-manager/src/providers/aws.js
+++ b/services/worker-manager/src/providers/aws.js
@@ -437,13 +437,15 @@ export class AwsProvider extends Provider {
 
     this.cloudApi?.logAndResetMetrics();
 
-    Object.entries(this.seenByWorkerGroup).forEach(([workerPoolId, seenByGroup]) =>
-      Object.entries(seenByGroup).forEach(([workerGroup, seen]) =>
+    Object.entries(this.seenByWorkerGroup).forEach(([workerPoolId, seenByGroup]) => {
+      Object.entries(seenByGroup).forEach(([workerGroup, seen]) => {
         this.monitor.metric.scanSeen(seen, {
           providerId: this.providerId,
           workerPoolId,
           workerGroup,
-        })));
+        });
+      });
+    });
   }
 
   /**

--- a/services/worker-manager/src/providers/azure/index.js
+++ b/services/worker-manager/src/providers/azure/index.js
@@ -286,7 +286,9 @@ export class AzureProvider extends Provider {
 
     // Load root certificates from Node, which get them from the Mozilla CA store.
     this.caStore = forge.pki.createCaStore();
-    rootCertificates.forEach(pem => this.addRootCertPem(pem));
+    rootCertificates.forEach(pem => {
+      this.addRootCertPem(pem);
+    });
 
     // load known microsoft intermediate certs from disk
     loadCertificates().forEach(cert => {
@@ -2046,13 +2048,15 @@ export class AzureProvider extends Provider {
       }),
     );
 
-    Object.entries(this.seenByWorkerGroup).forEach(([workerPoolId, seenByGroup]) =>
-      Object.entries(seenByGroup).forEach(([workerGroup, seen]) =>
+    Object.entries(this.seenByWorkerGroup).forEach(([workerPoolId, seenByGroup]) => {
+      Object.entries(seenByGroup).forEach(([workerGroup, seen]) => {
         this.monitor.metric.scanSeen(seen, {
           providerId: this.providerId,
           workerPoolId,
           workerGroup,
-        })));
+        });
+      });
+    });
   }
 
   /**

--- a/services/worker-manager/src/providers/google.js
+++ b/services/worker-manager/src/providers/google.js
@@ -489,12 +489,13 @@ export class GoogleProvider extends Provider {
       }
 
       const seenByGroup = this.seenByWorkerGroup[workerPoolId] || {};
-      Object.entries(seenByGroup).forEach(([workerGroup, groupSeen]) =>
+      Object.entries(seenByGroup).forEach(([workerGroup, groupSeen]) => {
         this.monitor.metric.scanSeen(groupSeen, {
           providerId: this.providerId,
           workerPoolId,
           workerGroup,
-        }));
+        });
+      });
 
       if (this.errors[workerPoolId].length) {
         await Promise.all(this.errors[workerPoolId].map(error => this.reportError({ workerPool, ...error })));

--- a/services/worker-manager/test/api_test.js
+++ b/services/worker-manager/test/api_test.js
@@ -102,7 +102,9 @@ helper.secrets.mockSuite(testing.suiteName(), [], (mock, skipping) => {
     while (true) {
       const res = await helper.workerManager.listProviders(query);
       pages += 1;
-      res.providers.forEach(({ providerId }) => providerIds.push(providerId));
+      res.providers.forEach(({ providerId }) => {
+        providerIds.push(providerId);
+      });
       if (res.continuationToken) {
         query.continuationToken = res.continuationToken;
       } else {

--- a/services/worker-manager/test/provider_aws_test.js
+++ b/services/worker-manager/test/provider_aws_test.js
@@ -492,8 +492,9 @@ helper.secrets.mockSuite(testing.suiteName(), [], (mock, skipping) => {
 
       const workers = await helper.getWorkers();
       assert.notStrictEqual(workers.length, 0);
-      workers.forEach(w =>
-        assert.strictEqual(w.state, Worker.states.STOPPED));
+      workers.forEach(w => {
+        assert.strictEqual(w.state, Worker.states.STOPPED);
+      });
       assert.strictEqual(provider.seen[worker.workerPoolId], 0);
       helper.assertPulseMessage('worker-stopped', m => m.payload.workerId === worker.workerId);
     });
@@ -511,8 +512,9 @@ helper.secrets.mockSuite(testing.suiteName(), [], (mock, skipping) => {
 
       const workers = await helper.getWorkers();
       assert.notStrictEqual(workers.length, 0);
-      workers.forEach(w =>
-        assert.strictEqual(w.state, Worker.states.REQUESTED));
+      workers.forEach(w => {
+        assert.strictEqual(w.state, Worker.states.REQUESTED);
+      });
       assert.strictEqual(provider.seen[worker.workerPoolId], 1);
       helper.assertNoPulseMessage('worker-stopped');
     });
@@ -544,8 +546,9 @@ helper.secrets.mockSuite(testing.suiteName(), [], (mock, skipping) => {
       // should be marked as stopped because it was missing
       const workers = await helper.getWorkers();
       assert.notStrictEqual(workers.length, 0);
-      workers.forEach(w =>
-        assert.strictEqual(w.state, Worker.states.STOPPED));
+      workers.forEach(w => {
+        assert.strictEqual(w.state, Worker.states.STOPPED);
+      });
       helper.assertPulseMessage('worker-stopped', m => m.payload.workerId === worker.workerId);
       helper.assertPulseMessage('worker-stopped', m => m.payload.launchConfigId === worker.launchConfigId);
     });
@@ -563,8 +566,9 @@ helper.secrets.mockSuite(testing.suiteName(), [], (mock, skipping) => {
 
       const workers = await helper.getWorkers();
       assert.notStrictEqual(workers.length, 0);
-      workers.forEach(w =>
-        assert.strictEqual(w.state, Worker.states.STOPPED));
+      workers.forEach(w => {
+        assert.strictEqual(w.state, Worker.states.STOPPED);
+      });
       assert.strictEqual(provider.seen[worker.workerPoolId], 0);
       helper.assertPulseMessage('worker-stopped', m => m.payload.workerId === worker.workerId);
     });

--- a/services/worker-manager/test/util_test.js
+++ b/services/worker-manager/test/util_test.js
@@ -38,9 +38,11 @@ suite(testing.suiteName(), () => {
       [{ workerId: 'mac-m1', workerIdentityProof: { secret: 'noway' } }, { workerId: 'mac-m1', workerIdentityProof: '*' }],
       [{ inner: { workerIdentityProof: 'noway' } }, { inner: { workerIdentityProof: 'noway' } }],
     ];
-    testPairs.forEach((pair, i) => test(`sanitizeRegisterWorkerPayload: ${JSON.stringify(pair[1])}`, () => {
-      assert.deepEqual(util.sanitizeRegisterWorkerPayload(pair[0]), pair[1]);
-    }));
+    testPairs.forEach((pair, i) => {
+      test(`sanitizeRegisterWorkerPayload: ${JSON.stringify(pair[1])}`, () => {
+        assert.deepEqual(util.sanitizeRegisterWorkerPayload(pair[0]), pair[1]);
+      });
+    });
   });
 
   suite('measureTime', () => {


### PR DESCRIPTION
These callbacks are passed to iterable methods (forEach, map, ...) which don't expect said callbacks to return any value. But because they're written as single expression arrow functions, they were returning implicitly which biome flags as suspicious. Easy but noisy solution, just wrap bodies in blocks.

Fix biome's useIterableCallbackReturn lint. This diff is better viewed when hiding whitespaces as git tries to be clever but is making it very hard to understand what actually happens...
