### PR TITLE
Remove unused function arguments or mark them as unused with a _ prefix

### DIFF
--- a/changelog/Ze9Iki6OTK-tQWLTZ0YkLA.md
+++ b/changelog/Ze9Iki6OTK-tQWLTZ0YkLA.md
@@ -1,0 +1,2 @@
+level: silent
+---

--- a/db/src/versions.js
+++ b/db/src/versions.js
@@ -130,9 +130,8 @@ methods:
 
 /**
  * test for new migration
- * @param {number} version
  */
-const testTemplate = version => `import testing from '@taskcluster/lib-testing';
+const testTemplate = () => `import testing from '@taskcluster/lib-testing';
 
 suite(testing.suiteName(), function() {
   // add tests if necessary
@@ -164,7 +163,7 @@ export const newVersion = async (options = { runGit: true }) => {
 
   try {
     const fd = fs.openSync(newTestFile, 'wx');
-    fs.writeFileSync(fd, testTemplate(nextVersion), 'utf8');
+    fs.writeFileSync(fd, testTemplate(), 'utf8');
     fs.closeSync(fd);
     console.log(`${newVersion}_test.js written`);
   } catch (err) {

--- a/db/test/fns/github_test.js
+++ b/db/test/fns/github_test.js
@@ -46,7 +46,7 @@ suite(testing.suiteName(), () => {
       build.event_id,
     );
 
-    helper.dbTest('create and get', async (db, isFake) => {
+    helper.dbTest('create and get', async (db, _isFake) => {
       await create_build(db, builds[0]);
       const [fetched] = await db.deprecatedFns.get_github_build(builds[0].task_group_id);
       assert(fetched.etag);
@@ -60,7 +60,7 @@ suite(testing.suiteName(), () => {
         await create_build(db, builds[0]);
       }, /duplicate key value violates unique constraint/);
     });
-    helper.dbTest('list', async (db, isFake) => {
+    helper.dbTest('list', async (db, _isFake) => {
       for (let i = 0; i < 10; i++) {
         await create_build(db, builds[i]);
       }
@@ -72,7 +72,7 @@ suite(testing.suiteName(), () => {
         assert.deepEqual(build, builds[builds.length - i - 1]);
       });
     });
-    helper.dbTest('delete', async (db, isFake) => {
+    helper.dbTest('delete', async (db, _isFake) => {
       await create_build(db, builds[0]);
       const [fetched] = await db.deprecatedFns.get_github_build(builds[0].task_group_id);
       assert(fetched.etag);
@@ -81,7 +81,7 @@ suite(testing.suiteName(), () => {
       await db.fns.delete_github_build(builds[0].task_group_id);
       assert.deepEqual(await db.deprecatedFns.get_github_build(builds[0].task_group_id), []);
     });
-    helper.dbTest('set state', async (db, isFake) => {
+    helper.dbTest('set state', async (db, _isFake) => {
       await create_build(db, builds[0]);
       const [fetched] = await db.deprecatedFns.get_github_build(builds[0].task_group_id);
       await db.fns.set_github_build_state(
@@ -144,7 +144,7 @@ suite(testing.suiteName(), () => {
       build.pull_request_number,
     );
 
-    helper.dbTest('create and get', async (db, isFake) => {
+    helper.dbTest('create and get', async (db, _isFake) => {
       await create_build(db, builds[0]);
       const [fetched] = await db.fns.get_github_build_pr(builds[0].task_group_id);
       assert(fetched.etag);
@@ -158,7 +158,7 @@ suite(testing.suiteName(), () => {
         await create_build(db, builds[0]);
       }, /duplicate key value violates unique constraint/);
     });
-    helper.dbTest('list', async (db, isFake) => {
+    helper.dbTest('list', async (db, _isFake) => {
       for (let i = 0; i < 10; i++) {
         await create_build(db, builds[i]);
       }
@@ -175,7 +175,7 @@ suite(testing.suiteName(), () => {
       assert.equal(prBuilds.length, 1);
       assert.deepEqual(prBuilds[0].pull_request_number, builds[0].pull_request_number);
     });
-    helper.dbTest('list pending', async (db, isFake) => {
+    helper.dbTest('list pending', async (db, _isFake) => {
       for (let i = 0; i < 10; i++) {
         await create_build(db, { ...builds[i], state: i < 5 ? 'pending' : 'success' });
       }
@@ -187,7 +187,7 @@ suite(testing.suiteName(), () => {
       assert.equal(prBuilds.length, 1);
       assert.deepEqual(prBuilds[0].pull_request_number, builds[0].pull_request_number);
     });
-    helper.dbTest('delete', async (db, isFake) => {
+    helper.dbTest('delete', async (db, _isFake) => {
       await create_build(db, builds[0]);
       const [fetched] = await db.fns.get_github_build_pr(builds[0].task_group_id);
       assert(fetched.etag);
@@ -196,7 +196,7 @@ suite(testing.suiteName(), () => {
       await db.fns.delete_github_build(builds[0].task_group_id);
       assert.deepEqual(await db.fns.get_github_build_pr(builds[0].task_group_id), []);
     });
-    helper.dbTest('set state', async (db, isFake) => {
+    helper.dbTest('set state', async (db, _isFake) => {
       await create_build(db, builds[0]);
       const [fetched] = await db.fns.get_github_build_pr(builds[0].task_group_id);
       await db.fns.set_github_build_state(
@@ -240,7 +240,7 @@ suite(testing.suiteName(), () => {
       integration.installation_id,
     );
 
-    helper.dbTest('create and get', async (db, isFake) => {
+    helper.dbTest('create and get', async (db, _isFake) => {
       await upsert_integration(db, integrations[0]);
       let [fetched] = await db.fns.get_github_integration(integrations[0].owner);
       assert.deepEqual(fetched, integrations[0]);
@@ -253,7 +253,7 @@ suite(testing.suiteName(), () => {
       [fetched] = await db.fns.get_github_integration(integrations[0].owner);
       assert.deepEqual(fetched, { ...integrations[0], installation_id: 12345 });
     });
-    helper.dbTest('list', async (db, isFake) => {
+    helper.dbTest('list', async (db, _isFake) => {
       for (let i = 0; i < 10; i++) {
         await upsert_integration(db, integrations[i]);
       }
@@ -283,7 +283,7 @@ suite(testing.suiteName(), () => {
       check.check_run_id,
     );
 
-    helper.dbTest('create and get', async (db, isFake) => {
+    helper.dbTest('create and get', async (db, _isFake) => {
       await create_check(db, checks[0]);
       const [fetched] = await db.deprecatedFns.get_github_check_by_task_id(checks[0].task_id);
       assert.deepEqual(fetched, checks[0]);
@@ -297,7 +297,7 @@ suite(testing.suiteName(), () => {
       assert.deepEqual([], await db.deprecatedFns.get_github_check_by_task_id('doesntexist'));
     });
 
-    helper.dbTest('create idempotency', async (db, isFake) => {
+    helper.dbTest('create idempotency', async (db, _isFake) => {
       await create_check(db, checks[0]);
       await create_check(db, { ...checks[0], check_run_id: 'abc' });
       const [fetched] = await db.deprecatedFns.get_github_check_by_task_id(checks[0].task_id);

--- a/db/test/fns/hooks_test.js
+++ b/db/test/fns/hooks_test.js
@@ -114,7 +114,7 @@ suite(testing.suiteName(), () => {
 
     helper.dbTest('get_last_fires_with_task_state full, pagination', async (db) => {
       await helper.withDbClient(async client => {
-        const createTask = async (db, options = {}) => {
+        const createTask = async (_db, options = {}) => {
           const taskId = options.taskId || slug.nice();
           await client.query(
             'select create_task_projid($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18);',
@@ -336,7 +336,7 @@ suite(testing.suiteName(), () => {
       );
     });
 
-    helper.dbTest('update_hook, change to a single field', async (db, isFake) => {
+    helper.dbTest('update_hook, change to a single field', async (db, _isFake) => {
       await create_hook(db);
       const bindings = [{ exchange: 'exchange', routingKeyPattern: 'routingKeyPattern' }];
       await db.fns.update_hook(
@@ -365,7 +365,7 @@ suite(testing.suiteName(), () => {
       assert.deepEqual(rows[0].trigger_schema, {});
     });
 
-    helper.dbTest('update_hook, change an encrypted field', async (db, isFake) => {
+    helper.dbTest('update_hook, change an encrypted field', async (db, _isFake) => {
       await create_hook(db);
       const nextTaskId = slug.v4();
       await db.fns.update_hook(
@@ -394,7 +394,7 @@ suite(testing.suiteName(), () => {
       assert.deepEqual(rows[0].trigger_schema, {});
     });
 
-    helper.dbTest('update_hook, no changes', async (db, isFake) => {
+    helper.dbTest('update_hook, no changes', async (db, _isFake) => {
       await create_hook(db);
       const updated = await db.fns.update_hook(
         'hook/group/id',
@@ -425,7 +425,7 @@ suite(testing.suiteName(), () => {
       assert.deepEqual(rows[0].trigger_schema, {});
     });
 
-    helper.dbTest('update_hook, throws when row does not exist', async (db, isFake) => {
+    helper.dbTest('update_hook, throws when row does not exist', async (db, _isFake) => {
       await assert.rejects(
         async () => {
           await db.fns.update_hook(

--- a/db/test/fns/index_test.js
+++ b/db/test/fns/index_test.js
@@ -46,7 +46,7 @@ suite(testing.suiteName(), () => {
   };
 
   suite(`${testing.suiteName()} - index_namespaces`, () => {
-    helper.dbTest('create_index_namespace/get_index_namespace', async (db, isFake) => {
+    helper.dbTest('create_index_namespace/get_index_namespace', async (db, _isFake) => {
       await create_index_namespace(db, {});
 
       const rows = await db.fns.get_index_namespace('par/ent', 'name');
@@ -54,7 +54,7 @@ suite(testing.suiteName(), () => {
       assert.equal(rows[0].name, 'name');
     });
 
-    helper.dbTest('get_index_namespace does not omit expired indexed namespaces', async (db, isFake) => {
+    helper.dbTest('get_index_namespace does not omit expired indexed namespaces', async (db, _isFake) => {
       const now = new Date();
       await create_index_namespace(db, { expires: now });
 
@@ -62,17 +62,17 @@ suite(testing.suiteName(), () => {
       assert.equal(rows.length, 1);
     });
 
-    helper.dbTest('get_index_namespace not found', async (db, isFake) => {
+    helper.dbTest('get_index_namespace not found', async (db, _isFake) => {
       const rows = await db.fns.get_index_namespace('par/ent', 'name');
       assert.deepEqual(rows, []);
     });
 
-    helper.dbTest('get_index_namespaces empty', async (db, isFake) => {
+    helper.dbTest('get_index_namespaces empty', async (db, _isFake) => {
       const rows = await db.fns.get_index_namespaces(null, null, null, null);
       assert.deepEqual(rows, []);
     });
 
-    helper.dbTest('get_index_namespaces full, pagination', async (db, isFake) => {
+    helper.dbTest('get_index_namespaces full, pagination', async (db, _isFake) => {
       const oneDay = fromNow('1 day');
       for (let i = 0; i < 10; i++) {
         await create_index_namespace(db, {
@@ -94,7 +94,7 @@ suite(testing.suiteName(), () => {
         [4, 5].map(i => ({ parent: `parent/${i}`, name: `name/${i}` })));
     });
 
-    helper.dbTest('get_index_namespaces only returns non expired tasks', async (db, isFake) => {
+    helper.dbTest('get_index_namespaces only returns non expired tasks', async (db, _isFake) => {
       const oneDay = fromNow('1 day');
       await create_index_namespace(db, {
         parent: `parent/1`,
@@ -114,7 +114,7 @@ suite(testing.suiteName(), () => {
       assert.deepEqual(rows[0].expires, oneDay);
     });
 
-    helper.dbTest('expire_index_namespaces', async (db, isFake) => {
+    helper.dbTest('expire_index_namespaces', async (db, _isFake) => {
       await create_index_namespace(db, { parent: 'parent/1', expires: fromNow('- 1 day') });
       await create_index_namespace(db, { parent: 'parent/2', expires: fromNow('- 2 days') });
       await create_index_namespace(db, { parent: 'parent/3', expires: fromNow('1 day') });
@@ -125,7 +125,7 @@ suite(testing.suiteName(), () => {
       assert.equal(rows.length, 1);
     });
 
-    helper.dbTest('update_index_namespace, change to a single field', async (db, isFake) => {
+    helper.dbTest('update_index_namespace, change to a single field', async (db, _isFake) => {
       await create_index_namespace(db);
       await db.fns.update_index_namespace(
         'par/ent',
@@ -139,7 +139,7 @@ suite(testing.suiteName(), () => {
       assert.equal(rows[0].expires.toJSON(), new Date(1).toJSON());
     });
 
-    helper.dbTest('update_index_namespace, no changes', async (db, isFake) => {
+    helper.dbTest('update_index_namespace, no changes', async (db, _isFake) => {
       await create_index_namespace(db);
       const updated = await db.fns.update_index_namespace(
         'par/ent',
@@ -156,7 +156,7 @@ suite(testing.suiteName(), () => {
       assert(rows[0].expires instanceof Date);
     });
 
-    helper.dbTest('update_index_namespace, throws when row does not exist', async (db, isFake) => {
+    helper.dbTest('update_index_namespace, throws when row does not exist', async (db, _isFake) => {
       await create_index_namespace(db);
 
       await assert.rejects(
@@ -173,7 +173,7 @@ suite(testing.suiteName(), () => {
   });
 
   suite(`${testing.suiteName()} - indexed_tasks`, () => {
-    helper.dbTest('create_indexed_task/get_indexed_task', async (db, isFake) => {
+    helper.dbTest('create_indexed_task/get_indexed_task', async (db, _isFake) => {
       const taskId = slug.nice();
       await create_indexed_task(db, { taskId });
 
@@ -183,7 +183,7 @@ suite(testing.suiteName(), () => {
       assert.deepEqual(rows[0].data, { data: true });
     });
 
-    helper.dbTest('get_indexed_task does not omit expired indexed tasks', async (db, isFake) => {
+    helper.dbTest('get_indexed_task does not omit expired indexed tasks', async (db, _isFake) => {
       const now = new Date();
       const taskId = slug.nice();
       await create_indexed_task(db, { expires: now, taskId });
@@ -192,7 +192,7 @@ suite(testing.suiteName(), () => {
       assert.equal(rows.length, 1);
     });
 
-    helper.dbTest('get_tasks_from_indexes_and_namespaces does not omit expired indexed tasks', async (db, isFake) => {
+    helper.dbTest('get_tasks_from_indexes_and_namespaces does not omit expired indexed tasks', async (db, _isFake) => {
       const now = new Date();
       const taskId = slug.nice();
       await create_indexed_task(db, { expires: now, taskId });
@@ -201,27 +201,27 @@ suite(testing.suiteName(), () => {
       assert.equal(rows.length, 1);
     });
 
-    helper.dbTest('get_tasks_from_indexes_and_namespaces not found', async (db, isFake) => {
+    helper.dbTest('get_tasks_from_indexes_and_namespaces not found', async (db, _isFake) => {
       const rows = await db.fns.get_tasks_from_indexes_and_namespaces(JSON.stringify(['name/space.name']), 1000, 0);
       assert.deepEqual(rows, []);
     });
 
-    helper.dbTest('get_indexed_task not found', async (db, isFake) => {
+    helper.dbTest('get_indexed_task not found', async (db, _isFake) => {
       const rows = await db.fns.get_indexed_task('name/space', 'name');
       assert.deepEqual(rows, []);
     });
 
-    helper.dbTest('get_tasks_from_indexes_and_namespaces empty', async (db, isFake) => {
+    helper.dbTest('get_tasks_from_indexes_and_namespaces empty', async (db, _isFake) => {
       const rows = await db.fns.get_tasks_from_indexes_and_namespaces(null, null, null);
       assert.deepEqual(rows, []);
     });
 
-    helper.dbTest('get_indexed_tasks empty', async (db, isFake) => {
+    helper.dbTest('get_indexed_tasks empty', async (db, _isFake) => {
       const rows = await db.fns.get_indexed_tasks(null, null, null, null);
       assert.deepEqual(rows, []);
     });
 
-    helper.dbTest('get_tasks_from_indexes_and_namespaces pagination', async (db, isFake) => {
+    helper.dbTest('get_tasks_from_indexes_and_namespaces pagination', async (db, _isFake) => {
       const oneDay = fromNow('1 day');
       const expectedIndexes = [];
       const expectedTasks = [];
@@ -258,7 +258,7 @@ suite(testing.suiteName(), () => {
       assert.equal(rows.length, 0);
     });
 
-    helper.dbTest('get_indexed_tasks full, pagination', async (db, isFake) => {
+    helper.dbTest('get_indexed_tasks full, pagination', async (db, _isFake) => {
       const oneDay = fromNow('1 day');
       for (let i = 0; i < 10; i++) {
         await create_indexed_task(db, {
@@ -280,7 +280,7 @@ suite(testing.suiteName(), () => {
         [4, 5].map(i => ({ namespace: `namespace/${i}`, name: `name/${i}` })));
     });
 
-    helper.dbTest('get_indexed_tasks only returns non expired tasks', async (db, isFake) => {
+    helper.dbTest('get_indexed_tasks only returns non expired tasks', async (db, _isFake) => {
       const oneDay = fromNow('1 day');
       await create_indexed_task(db, {
         namespace: `namespace/1`,
@@ -304,7 +304,7 @@ suite(testing.suiteName(), () => {
       assert.deepEqual(rows[0].expires, oneDay);
     });
 
-    helper.dbTest('expire_indexed_tasks', async (db, isFake) => {
+    helper.dbTest('expire_indexed_tasks', async (db, _isFake) => {
       await create_indexed_task(db, { namespace: 'namespace/1', expires: fromNow('- 1 day') });
       await create_indexed_task(db, { namespace: 'namespace/2', expires: fromNow('- 2 days') });
       await create_indexed_task(db, { namespace: 'namespace/3', expires: fromNow('1 day') });
@@ -315,7 +315,7 @@ suite(testing.suiteName(), () => {
       assert.equal(rows.length, 1);
     });
 
-    helper.dbTest('update_indexed_task, change to a single field', async (db, isFake) => {
+    helper.dbTest('update_indexed_task, change to a single field', async (db, _isFake) => {
       await create_indexed_task(db);
       await db.fns.update_indexed_task(
         'name/space',
@@ -335,7 +335,7 @@ suite(testing.suiteName(), () => {
       assert(rows[0].expires instanceof Date);
     });
 
-    helper.dbTest('update_indexed_task, change to a multiple fields', async (db, isFake) => {
+    helper.dbTest('update_indexed_task, change to a multiple fields', async (db, _isFake) => {
       await create_indexed_task(db);
       const updated = await db.fns.update_indexed_task(
         'name/space',
@@ -357,7 +357,7 @@ suite(testing.suiteName(), () => {
       assert.deepEqual(updated, rows);
     });
 
-    helper.dbTest('update_indexed_task, no changes', async (db, isFake) => {
+    helper.dbTest('update_indexed_task, no changes', async (db, _isFake) => {
       await create_indexed_task(db);
       const updated = await db.fns.update_indexed_task(
         'name/space',
@@ -379,7 +379,7 @@ suite(testing.suiteName(), () => {
       assert(rows[0].expires instanceof Date);
     });
 
-    helper.dbTest('update_indexed_task, indexed task doesn\'t exist', async (db, isFake) => {
+    helper.dbTest('update_indexed_task, indexed task doesn\'t exist', async (db, _isFake) => {
       await create_indexed_task(db);
 
       await assert.rejects(
@@ -390,7 +390,7 @@ suite(testing.suiteName(), () => {
       );
     });
 
-    helper.dbTest('update_indexed_task, throws when row does not exist', async (db, isFake) => {
+    helper.dbTest('update_indexed_task, throws when row does not exist', async (db, _isFake) => {
       await create_indexed_task(db);
 
       await assert.rejects(
@@ -408,7 +408,7 @@ suite(testing.suiteName(), () => {
       );
     });
 
-    helper.dbTest('delete_indexed_task', async (db, isFake) => {
+    helper.dbTest('delete_indexed_task', async (db, _isFake) => {
       const taskId = slug.nice();
       await create_indexed_task(db, { taskId });
 

--- a/db/test/fns/object_test.js
+++ b/db/test/fns/object_test.js
@@ -16,7 +16,7 @@ suite(testing.suiteName(), () => {
     });
   });
 
-  helper.dbTest('create_object same object twice should not raise exception', async (db, isFake) => {
+  helper.dbTest('create_object same object twice should not raise exception', async (db, _isFake) => {
     const expires = fromNow('1 year');
     await db.deprecatedFns.create_object('foo', 'projectId', 'backendId', {}, expires);
     await db.deprecatedFns.create_object('foo', 'projectId', 'backendId', {}, expires);
@@ -32,7 +32,7 @@ suite(testing.suiteName(), () => {
     });
   });
 
-  helper.dbTest('create_object with conflict should P0004', async (db, isFake) => {
+  helper.dbTest('create_object with conflict should P0004', async (db, _isFake) => {
     const expires = fromNow('1 year');
     await db.deprecatedFns.create_object('foo', 'projectId', 'backendId', {}, expires);
     await assert.rejects(
@@ -50,7 +50,7 @@ suite(testing.suiteName(), () => {
     });
   });
 
-  helper.dbTest('create_object', async (db, isFake) => {
+  helper.dbTest('create_object', async (db, _isFake) => {
     const expires = fromNow('1 year');
     await db.deprecatedFns.create_object('foo', 'projectId', 'backendId', {}, expires);
 
@@ -65,7 +65,7 @@ suite(testing.suiteName(), () => {
     });
   });
 
-  helper.dbTest('create_object_for_upload', async (db, isFake) => {
+  helper.dbTest('create_object_for_upload', async (db, _isFake) => {
     const expires = fromNow('1 year');
     const uploadExpires = fromNow('1 day');
     const uploadId = taskcluster.slugid();
@@ -84,7 +84,7 @@ suite(testing.suiteName(), () => {
     });
   });
 
-  helper.dbTest('create_object_for_upload is idempotent', async (db, isFake) => {
+  helper.dbTest('create_object_for_upload is idempotent', async (db, _isFake) => {
     const expires = fromNow('1 year');
     const uploadExpires = fromNow('1 day');
     const uploadId = taskcluster.slugid();
@@ -92,7 +92,7 @@ suite(testing.suiteName(), () => {
     await db.fns.create_object_for_upload('foo', 'projectId', 'backendId', uploadId, uploadExpires, {}, expires);
   });
 
-  helper.dbTest('create_object_for_upload fails if called again with new uploadId', async (db, isFake) => {
+  helper.dbTest('create_object_for_upload fails if called again with new uploadId', async (db, _isFake) => {
     const expires = fromNow('1 year');
     const uploadExpires = fromNow('1 day');
     let uploadId = taskcluster.slugid();
@@ -104,7 +104,7 @@ suite(testing.suiteName(), () => {
       err => err.code === UNIQUE_VIOLATION);
   });
 
-  helper.dbTest('create_object_for_upload fails if two objects use the same uploadId', async (db, isFake) => {
+  helper.dbTest('create_object_for_upload fails if two objects use the same uploadId', async (db, _isFake) => {
     const expires = fromNow('1 year');
     const uploadExpires = fromNow('1 day');
     const uploadId = taskcluster.slugid();
@@ -115,7 +115,7 @@ suite(testing.suiteName(), () => {
       err => err.code === UNIQUE_VIOLATION);
   });
 
-  helper.dbTest('object_upload_complete', async (db, isFake) => {
+  helper.dbTest('object_upload_complete', async (db, _isFake) => {
     const expires = fromNow('1 year');
     const uploadExpires = fromNow('1 day');
     const uploadId = taskcluster.slugid();

--- a/db/test/fns/queue_test.js
+++ b/db/test/fns/queue_test.js
@@ -55,19 +55,19 @@ suite(testing.suiteName(), () => {
     return rows;
   };
 
-  const setTaskRuns = async (db, runs) => {
+  const setTaskRuns = async (_db, runs) => {
     await helper.withDbClient(async client => {
       await client.query('update tasks set runs = $2 where task_id = $1', [taskId, JSON.stringify(runs)]);
     });
   };
 
-  const setTaskTakenUntil = async (db, taken_until) => {
+  const setTaskTakenUntil = async (_db, taken_until) => {
     await helper.withDbClient(async client => {
       await client.query('update tasks set taken_until = $2 where task_id = $1', [taskId, taken_until]);
     });
   };
 
-  const setTaskRetriesLeft = async (db, retries_left) => {
+  const setTaskRetriesLeft = async (_db, retries_left) => {
     await helper.withDbClient(async client => {
       await client.query('update tasks set retries_left = $2 where task_id = $1', [taskId, retries_left]);
     });
@@ -1621,12 +1621,12 @@ suite(testing.suiteName(), () => {
           } else if (sat === true) {
             assert.deepEqual(
               rows.map(row => row.dependent_task_id).sort(),
-              deps.filter((d, i) => i & 1).sort(),
+              deps.filter((_d, i) => i & 1).sort(),
               'sat = true');
           } else if (sat === false) {
             assert.deepEqual(
               rows.map(row => row.dependent_task_id).sort(),
-              deps.filter((d, i) => !(i & 1)).sort(),
+              deps.filter((_d, i) => !(i & 1)).sort(),
               'sat = false');
           }
         }
@@ -1657,12 +1657,12 @@ suite(testing.suiteName(), () => {
           } else if (sat === true) {
             assert.deepEqual(
               rows.map(row => row.dependent_task_id).sort(),
-              deps.filter((d, i) => i & 1).sort(),
+              deps.filter((_d, i) => i & 1).sort(),
               'sat = true');
           } else if (sat === false) {
             assert.deepEqual(
               rows.map(row => row.dependent_task_id).sort(),
-              deps.filter((d, i) => !(i & 1)).sort(),
+              deps.filter((_d, i) => !(i & 1)).sort(),
               'sat = false');
           }
         }

--- a/db/test/fns/secrets_test.js
+++ b/db/test/fns/secrets_test.js
@@ -24,7 +24,7 @@ suite(testing.suiteName(), () => {
     };
   }
 
-  helper.dbTest('create and get', async (db, isFake) => {
+  helper.dbTest('create and get', async (db, _isFake) => {
     for await (const s of Object.values(secrets)) {
       await db.fns.upsert_secret(s.name, db.encrypt({
         value: Buffer.from(JSON.stringify(s.encrypted_secret), 'utf8'),
@@ -40,7 +40,7 @@ suite(testing.suiteName(), () => {
       }
     }
   });
-  helper.dbTest('list', async (db, isFake) => {
+  helper.dbTest('list', async (db, _isFake) => {
     for await (const s of Object.values(secrets)) {
       await db.fns.upsert_secret(s.name, db.encrypt({
         value: Buffer.from(JSON.stringify(s.encrypted_secret), 'utf8'),
@@ -48,13 +48,13 @@ suite(testing.suiteName(), () => {
     }
     const fetched = await db.fns.get_secrets(null, null);
     assert.equal(fetched.length, 4);
-    fetched.forEach((secret, i) => {
+    fetched.forEach((secret, _i) => {
       const s = secrets[secret.name];
       assert(s);
       assert(s.expires > new Date());
     });
   });
-  helper.dbTest('delete', async (db, isFake) => {
+  helper.dbTest('delete', async (db, _isFake) => {
     for await (const s of Object.values(secrets)) {
       await db.fns.upsert_secret(s.name, db.encrypt({
         value: Buffer.from(JSON.stringify(s.encrypted_secret), 'utf8'),
@@ -64,14 +64,14 @@ suite(testing.suiteName(), () => {
     await db.fns.delete_secret('secret-9');
     const fetched = await db.fns.get_secrets(null, null);
     assert.equal(fetched.length, 3);
-    fetched.forEach((secret, i) => {
+    fetched.forEach((secret, _i) => {
       const s = secrets[secret.name];
       assert(s);
       assert(s.expires > new Date());
     });
     assert.deepEqual([], await db.fns.get_secret('secret-9'));
   });
-  helper.dbTest('update', async (db, isFake) => {
+  helper.dbTest('update', async (db, _isFake) => {
     for await (const s of Object.values(secrets)) {
       await db.fns.upsert_secret(s.name, db.encrypt({
         value: Buffer.from(JSON.stringify(s.encrypted_secret), 'utf8'),
@@ -98,7 +98,7 @@ suite(testing.suiteName(), () => {
       }
     }
   });
-  helper.dbTest('expire', async (db, isFake) => {
+  helper.dbTest('expire', async (db, _isFake) => {
     for await (const s of Object.values(secrets)) {
       await db.fns.upsert_secret(s.name, db.encrypt({
         value: Buffer.from(JSON.stringify(s.encrypted_secret), 'utf8'),
@@ -121,7 +121,7 @@ suite(testing.suiteName(), () => {
       assert.equal(count, '4');
     });
   });
-  helper.dbTest('insert into secrets in audit history', async (db, isFake) => {
+  helper.dbTest('insert into secrets in audit history', async (db, _isFake) => {
 
     await db.fns.insert_secrets_audit_history(
       'secret/1',

--- a/db/test/fns/worker_manager_test.js
+++ b/db/test/fns/worker_manager_test.js
@@ -1532,7 +1532,7 @@ suite(testing.suiteName(), () => {
       assert.deepEqual(await db.fns.expire_worker_pool_launch_configs(), [{ launch_config_id: 'lc2' }]);
     });
 
-    helper.dbTest('get_worker_pool_launch_config_stats', async (db) => {
+    helper.dbTest('get_worker_pool_launch_config_stats', async (_db) => {
       // test stats are being returned for workers groupped by state
     });
 

--- a/db/test/versions/0056_test.js
+++ b/db/test/versions/0056_test.js
@@ -17,7 +17,7 @@ suite(testing.suiteName(), () => {
         insert into objects (name, project_id, backend_id, data, expires)
         values ('public/foo', 'p', 'b', '{}', $1)`, [expires]);
     },
-    startCheck: async client => {
+    startCheck: async _client => {
       await helper.assertNoTableColumn('objects', 'upload_id');
       await helper.assertNoTableColumn('objects', 'upload_expires');
     },
@@ -30,7 +30,7 @@ suite(testing.suiteName(), () => {
       assert.deepEqual(rows[0].data, {});
       assert.equal(rows[0].expires.toJSON(), expires.toJSON());
     },
-    finishedCheck: async client => {
+    finishedCheck: async _client => {
       await helper.assertTableColumn('objects', 'upload_id');
       await helper.assertTableColumn('objects', 'upload_expires');
     },

--- a/db/test/versions/0091_test.js
+++ b/db/test/versions/0091_test.js
@@ -37,7 +37,7 @@ suite(testing.suiteName(), () => {
     ]);
   };
 
-  const assertRecordsExistInNewTables = async (db, dt1, dt2) => {
+  const assertRecordsExistInNewTables = async (db, _dt1, dt2) => {
     const visibleIn = taskcluster.fromNow('1 minute');
 
     const [pending, claimed, resolved, deadlines] = await Promise.all([

--- a/infrastructure/tooling/src/build/tasks/client-shell.js
+++ b/infrastructure/tooling/src/build/tasks/client-shell.js
@@ -1,7 +1,7 @@
 import path from 'node:path';
 import { ensureTask, execCommand, REPO_ROOT } from '../../utils/index.js';
 
-export default ({ tasks, cmdOptions, credentials, baseDir, logsDir }) => {
+export default ({ tasks, cmdOptions }) => {
   ensureTask(tasks, {
     title: 'Build client-shell artifacts',
     requires: ['clean-artifacts-dir'],
@@ -69,7 +69,7 @@ export default ({ tasks, cmdOptions, credentials, baseDir, logsDir }) => {
     provides: [
       'target-client-shell',
     ],
-    run: async (requirements, utils) => {
+    run: async (requirements, _utils) => {
       const artifactsDir = requirements['clean-artifacts-dir'];
       return {
         'target-client-shell': [

--- a/infrastructure/tooling/src/build/tasks/common.js
+++ b/infrastructure/tooling/src/build/tasks/common.js
@@ -3,7 +3,7 @@ import mkdirp from 'mkdirp';
 import { ensureTask } from '../../utils/index.js';
 import { rimraf } from 'rimraf';
 
-export default ({ tasks, cmdOptions, credentials, baseDir, logsDir }) => {
+export default ({ tasks, baseDir }) => {
   const artifactsDir = path.join(baseDir, 'release-artifacts');
 
   // Clean the artifacts directory and return it
@@ -11,7 +11,7 @@ export default ({ tasks, cmdOptions, credentials, baseDir, logsDir }) => {
     title: 'Clean release-artifacts',
     requires: [],
     provides: ['clean-artifacts-dir'],
-    run: async (requirements, utils) => {
+    run: async (_requirements, _utils) => {
       await rimraf(artifactsDir);
       await mkdirp(artifactsDir);
       return { 'clean-artifacts-dir': artifactsDir };

--- a/infrastructure/tooling/src/build/tasks/generic-worker-image.js
+++ b/infrastructure/tooling/src/build/tasks/generic-worker-image.js
@@ -147,7 +147,7 @@ export default ({ tasks, baseDir, cmdOptions, credentials, logsDir }) => {
     provides: [
       `generic-worker-image`,
     ],
-    run: async (requirements, utils) => {
+    run: async (requirements, _utils) => {
       return {
         'generic-worker-image': `Generic worker docker image: ${requirements['generic-worker-push']}`,
       };

--- a/infrastructure/tooling/src/build/tasks/generic-worker.js
+++ b/infrastructure/tooling/src/build/tasks/generic-worker.js
@@ -2,7 +2,7 @@ import glob from 'glob';
 import path from 'node:path';
 import { ensureTask, execCommand, REPO_ROOT } from '../../utils/index.js';
 
-export default ({ tasks, cmdOptions, credentials, baseDir, logsDir }) => {
+export default ({ tasks }) => {
   ensureTask(tasks, {
     title: 'Build generic-worker artifacts',
     requires: ['clean-artifacts-dir'],
@@ -33,7 +33,7 @@ export default ({ tasks, cmdOptions, credentials, baseDir, logsDir }) => {
     provides: [
       'target-generic-worker',
     ],
-    run: async (requirements, utils) => {
+    run: async (requirements, _utils) => {
       const artifactsDir = requirements['clean-artifacts-dir'];
       return {
         'target-generic-worker': [

--- a/infrastructure/tooling/src/build/tasks/livelog.js
+++ b/infrastructure/tooling/src/build/tasks/livelog.js
@@ -130,7 +130,7 @@ export default ({ tasks, cmdOptions, credentials, baseDir, logsDir }) => {
     provides: [
       'target-livelog',
     ],
-    run: async (requirements, utils) => {
+    run: async (requirements, _utils) => {
       const artifactsDir = requirements['clean-artifacts-dir'];
       return {
         'target-livelog': [

--- a/infrastructure/tooling/src/build/tasks/monoimage.js
+++ b/infrastructure/tooling/src/build/tasks/monoimage.js
@@ -273,7 +273,7 @@ const generateMonoimageTasks = ({ tasks, baseDir, cmdOptions, credentials, logsD
     provides: [
       `target-monoimage`,
     ],
-    run: async (requirements, utils) => {
+    run: async (requirements, _utils) => {
       return {
         'target-monoimage': `Monoimage docker image: ${requirements['monoimage-push']}`,
       };
@@ -288,7 +288,7 @@ const generateMonoimageTasks = ({ tasks, baseDir, cmdOptions, credentials, logsD
     provides: [
       `target-monoimage-devel`,
     ],
-    run: async (requirements, utils) => {
+    run: async (requirements, _utils) => {
       return {
         'target-monoimage-devel': `Monoimage devel docker image: ${requirements['monoimage-devel-push']}`,
       };

--- a/infrastructure/tooling/src/build/tasks/release.js
+++ b/infrastructure/tooling/src/build/tasks/release.js
@@ -14,14 +14,14 @@ import {
 
 const readFile = util.promisify(fs.readFile);
 
-export default ({ tasks, cmdOptions, credentials, baseDir, logsDir }) => {
+export default ({ tasks, cmdOptions, credentials, logsDir }) => {
   ensureTask(tasks, {
     title: 'Get ChangeLog',
     requires: ['release-version'],
     provides: [
       'changelog-text',
     ],
-    run: async (requirements, utils) => {
+    run: async (requirements, _utils) => {
       if (cmdOptions.staging) {
         return {
           'changelog-text': '(staging release)',
@@ -207,7 +207,7 @@ export default ({ tasks, cmdOptions, credentials, baseDir, logsDir }) => {
     provides: [
       `publish-clients/client-py`,
     ],
-    run: async (requirements, utils) => {
+    run: async (_requirements, utils) => {
       if (cmdOptions.staging || !cmdOptions.push) {
         return utils.skip();
       }
@@ -229,7 +229,7 @@ export default ({ tasks, cmdOptions, credentials, baseDir, logsDir }) => {
     provides: [
       `publish-clients/client-rust`,
     ],
-    run: async (requirements, utils) => {
+    run: async (_requirements, utils) => {
       // upload each of the individual crates, in dependency order; note that
       // integration-tests does not get published!
       for (const dir of ['client', 'download', 'upload']) {
@@ -255,7 +255,7 @@ export default ({ tasks, cmdOptions, credentials, baseDir, logsDir }) => {
     provides: [
       'target-publish',
     ],
-    run: async (requirements, utils) => {
+    run: async (requirements, _utils) => {
       return {
         'target-publish': [
           `Release version: ${requirements['release-version']}`,

--- a/infrastructure/tooling/src/build/tasks/taskcluster-proxy.js
+++ b/infrastructure/tooling/src/build/tasks/taskcluster-proxy.js
@@ -122,7 +122,7 @@ export default ({ tasks, cmdOptions, credentials, baseDir, logsDir }) => {
     provides: [
       'target-taskcluster-proxy',
     ],
-    run: async (requirements, utils) => {
+    run: async (requirements, _utils) => {
       const artifactsDir = requirements['clean-artifacts-dir'];
       return {
         'target-taskcluster-proxy': [

--- a/infrastructure/tooling/src/build/tasks/websocktunnel.js
+++ b/infrastructure/tooling/src/build/tasks/websocktunnel.js
@@ -99,7 +99,7 @@ export default ({ tasks, cmdOptions, credentials, baseDir, logsDir }) => {
     provides: [
       'target-websocktunnel',
     ],
-    run: async (requirements, utils) => {
+    run: async (requirements, _utils) => {
       return {
         'target-websocktunnel': `Websocktunnel docker image: ${requirements['websocktunnel-docker-image']}`,
       };

--- a/infrastructure/tooling/src/build/tasks/worker-runner.js
+++ b/infrastructure/tooling/src/build/tasks/worker-runner.js
@@ -2,7 +2,7 @@ import glob from 'glob';
 import path from 'node:path';
 import { ensureTask, execCommand, REPO_ROOT } from '../../utils/index.js';
 
-export default ({ tasks, cmdOptions, credentials, baseDir, logsDir }) => {
+export default ({ tasks }) => {
   ensureTask(tasks, {
     title: 'Build worker-runner artifacts',
     requires: ['clean-artifacts-dir'],
@@ -33,7 +33,7 @@ export default ({ tasks, cmdOptions, credentials, baseDir, logsDir }) => {
     provides: [
       'target-worker-runner',
     ],
-    run: async (requirements, utils) => {
+    run: async (requirements, _utils) => {
       const artifactsDir = requirements['clean-artifacts-dir'];
       return {
         'target-worker-runner': [

--- a/infrastructure/tooling/src/changelog/index.js
+++ b/infrastructure/tooling/src/changelog/index.js
@@ -385,7 +385,7 @@ export const add = async (options) => {
   }
 };
 
-export const show = async (options) => {
+export const show = async (_options) => {
   const cl = new ChangeLog({ skipUpdates: true });
   await cl.load();
   console.log(`${chalk.bold.cyan('Level:')}        ${cl.level()}`);

--- a/infrastructure/tooling/src/dev/aws.js
+++ b/infrastructure/tooling/src/dev/aws.js
@@ -51,7 +51,7 @@ const setupIam = async ({ iam = new IAMClient(), iamName, iamPolicy }) => {
   return accessKey;
 };
 
-export default async ({ userConfig, answer, configTmpl }) => {
+export default async ({ userConfig, answer }) => {
   const iam = new IAMClient();
   const s3 = new S3Client();
   const prefix = answer.meta?.deploymentPrefix || userConfig.meta?.deploymentPrefix;

--- a/infrastructure/tooling/src/dev/azure.js
+++ b/infrastructure/tooling/src/dev/azure.js
@@ -1,4 +1,4 @@
-export const azureResources = async ({ userConfig, answer, configTmpl }) => {
+export const azureResources = async ({ userConfig }) => {
   // this exists only to drop now-unused Azure bits
   if (userConfig.auth) {
     delete userConfig.auth.azure_account_key;

--- a/infrastructure/tooling/src/dev/common.js
+++ b/infrastructure/tooling/src/dev/common.js
@@ -1,4 +1,4 @@
-export default ({ userConfig, prompts, configTmpl }) => {
+export default ({ userConfig, prompts }) => {
 
   prompts.push({
     type: 'input',

--- a/infrastructure/tooling/src/dev/helm.js
+++ b/infrastructure/tooling/src/dev/helm.js
@@ -28,7 +28,7 @@ const actions = [
     title: 'Check dev-config.yml',
     requires: [],
     provides: ['dev-config'],
-    run: async (requirements, utils) => {
+    run: async (_requirements, _utils) => {
       const config = await readRepoYAML('dev-config.yml');
       if (!config.meta?.deploymentPrefix) {
         throw new Error('Must have configured dev-config.yml to deploy.');
@@ -49,7 +49,7 @@ const actions = [
     title: 'Helm version detection',
     requires: [],
     provides: ['helm-version'],
-    run: async (requirements, utils) => {
+    run: async (_requirements, utils) => {
       const res = await execCommand({
         command: ['helm', 'version'],
         dir: REPO_ROOT,
@@ -136,7 +136,7 @@ const actions = [
     title: `Dump kubernetes templates to ${dumpFileLocation}`,
     requires: ['target-templates'],
     provides: ['target-dump-templates'],
-    run: async (requirements, utils) => {
+    run: async (requirements, _utils) => {
       await writeRepoFile(dumpFileLocation, requirements['target-templates']);
       return { 'target-dump-templates': dumpFileLocation };
     },
@@ -159,7 +159,7 @@ const actions = [
     title: 'Delete Your Deployment',
     requires: ['namespace-switch'],
     provides: ['target-delete'],
-    run: async (requirements, utils) => {
+    run: async (_requirements, utils) => {
       const coreOutput = await execCommand({
         command: ['kubectl', 'delete', resourceTypes.join(','), '-l', 'app.kubernetes.io/part-of=taskcluster'],
         dir: REPO_ROOT,

--- a/infrastructure/tooling/src/dev/index.js
+++ b/infrastructure/tooling/src/dev/index.js
@@ -35,7 +35,7 @@ export const readUserConfig = async () => {
   return userConfig;
 };
 
-export const init = async (options) => {
+export const init = async (_options) => {
   const configTmpl = await readRepoYAML(path.join('dev-docs', 'dev-config-example.yml'));
   let userConfig = await readUserConfig();
 
@@ -102,25 +102,25 @@ export const dbDowngrade = async (options) => {
   await downgrade({ showProgress, adminDbUrl, usernamePrefix, toVersion });
 };
 
-export const apply = async (options) => {
+export const apply = async (_options) => {
   await helm('apply');
 };
 
-export const verify = async (options) => {
+export const verify = async (_options) => {
   await helm('verify');
 };
 
-export const templates = async (options) => {
+export const templates = async (_options) => {
   const templates = await helm('dump-templates');
   return templates;
 };
 
-export const ensureDb = async (options) => {
+export const ensureDb = async (_options) => {
   const userConfig = await readUserConfig();
   await postgresEnsureDb({ userConfig });
 };
 
-export const ensureRabbit = async (options) => {
+export const ensureRabbit = async (_options) => {
   const userConfig = await readUserConfig();
   const prompts = [];
 
@@ -130,7 +130,7 @@ export const ensureRabbit = async (options) => {
   await rabbitEnsureResources({ userConfig, answer });
 };
 
-export const delete_ = async (options) => {
+export const delete_ = async (_options) => {
   await helm('delete');
 };
 

--- a/infrastructure/tooling/src/dev/k8s.js
+++ b/infrastructure/tooling/src/dev/k8s.js
@@ -1,6 +1,6 @@
 import _ from 'lodash';
 
-export const k8sResources = async ({ userConfig, answer, configTmpl }) => {
+export const k8sResources = async ({ userConfig, configTmpl }) => {
   function setDefault(path, val) {
     if (!_.has(userConfig, path, val)) {
       _.set(userConfig, path, val);

--- a/infrastructure/tooling/src/dev/postgres.js
+++ b/infrastructure/tooling/src/dev/postgres.js
@@ -4,7 +4,7 @@ import pg from 'pg';
 import { makePgUrl } from './util.js';
 import URL from 'node:url';
 
-export const postgresPrompts = ({ userConfig, prompts, configTmpl }) => {
+export const postgresPrompts = ({ userConfig, prompts }) => {
   prompts.push({
     when: () => !userConfig.meta?.dbPublicIp,
     type: 'input',

--- a/infrastructure/tooling/src/dev/rabbit.js
+++ b/infrastructure/tooling/src/dev/rabbit.js
@@ -120,7 +120,7 @@ export const rabbitResources = async ({ userConfig, answer, configTmpl }) => {
   return userConfig;
 };
 
-export const rabbitAdminPasswordPrompt = ({ userConfig, prompts }) => {
+export const rabbitAdminPasswordPrompt = ({ prompts }) => {
   prompts.push({
     type: 'password',
     name: 'rabbitAdminPassword',

--- a/infrastructure/tooling/src/generate/generators/apis.js
+++ b/infrastructure/tooling/src/generate/generators/apis.js
@@ -5,7 +5,7 @@ export const tasks = [{
   title: 'APIs data structure',
   requires: ['references-json'],
   provides: ['apis'],
-  run: async (requirements, utils) => {
+  run: async (requirements, _utils) => {
     const refs = References.fromSerializable({ serializable: requirements['references-json'] });
 
     const apis = {};

--- a/infrastructure/tooling/src/generate/generators/d2g.js
+++ b/infrastructure/tooling/src/generate/generators/d2g.js
@@ -5,7 +5,7 @@ export const tasks = [{
   title: 'Generate d2g',
   requires: ['references-json', 'target-go-version'],
   provides: ['target-d2g'],
-  run: async (requirements, utils) => {
+  run: async (_requirements, utils) => {
     await execCommand({
       dir: path.join(REPO_ROOT, 'tools', 'd2g'),
       command: ['go', 'generate', './...'],

--- a/infrastructure/tooling/src/generate/generators/db-fns.js
+++ b/infrastructure/tooling/src/generate/generators/db-fns.js
@@ -5,7 +5,7 @@ export const tasks = [{
   title: 'README DB Functions',
   requires: ['db-schema-serializable'],
   provides: ['db-fns-readme'],
-  run: async (requirements, utils) => {
+  run: async (requirements, _utils) => {
     const currentTcVersion = (await readRepoJSON('package.json')).version;
     const schema = Schema.fromSerializable(requirements['db-schema-serializable']);
     const releases = await getDbReleases();

--- a/infrastructure/tooling/src/generate/generators/db-schema.js
+++ b/infrastructure/tooling/src/generate/generators/db-schema.js
@@ -6,7 +6,7 @@ export const tasks = [{
   title: 'DB Schema',
   requires: [],
   provides: ['db-schema-serializable'],
-  run: async (requirements, utils) => {
+  run: async (_requirements, _utils) => {
     const schema = tcdb.schema({ useDbDirectory: true });
 
     const serializable = schema.asSerializable();

--- a/infrastructure/tooling/src/generate/generators/db-types.js
+++ b/infrastructure/tooling/src/generate/generators/db-types.js
@@ -5,7 +5,7 @@ export const tasks = [{
   title: 'Database types',
   requires: ['db-schema-serializable'],
   provides: ['db-types'],
-  run: async (requirements, utils) => {
+  run: async (requirements, _utils) => {
     const currentTcVersion = (await readRepoJSON('package.json')).version;
     const schema = Schema.fromSerializable(requirements['db-schema-serializable']);
     const releases = await getDbReleases();

--- a/infrastructure/tooling/src/generate/generators/db-users.js
+++ b/infrastructure/tooling/src/generate/generators/db-users.js
@@ -6,7 +6,7 @@ export const tasks = [{
   title: 'Users in DB Deployment Docs',
   requires: ['db-schema-serializable'],
   provides: [],
-  run: async (requirements, utils) => {
+  run: async (requirements, _utils) => {
     const schema = Schema.fromSerializable(requirements['db-schema-serializable']);
     const services = schema.access.serviceNames().sort();
 
@@ -28,7 +28,7 @@ export const tasks = [{
   title: 'Users in db/test-setup.sh',
   requires: ['db-schema-serializable'],
   provides: [],
-  run: async (requirements, utils) => {
+  run: async (requirements, _utils) => {
     const schema = Schema.fromSerializable(requirements['db-schema-serializable']);
     const services = schema.access.serviceNames().sort();
 

--- a/infrastructure/tooling/src/generate/generators/db-versions.js
+++ b/infrastructure/tooling/src/generate/generators/db-versions.js
@@ -5,7 +5,7 @@ export const tasks = [{
   title: '`db/versions/README`',
   requires: ['db-schema-serializable'],
   provides: ['db-versions-readme'],
-  run: async (requirements, utils) => {
+  run: async (requirements, _utils) => {
     const schema = Schema.fromSerializable(requirements['db-schema-serializable']);
     const releases = await getDbReleases();
     await updateVersionsReadme(schema, releases);

--- a/infrastructure/tooling/src/generate/generators/docker-compose.js
+++ b/infrastructure/tooling/src/generate/generators/docker-compose.js
@@ -178,7 +178,7 @@ tasks.push({
     'target-docker-compose.prod.yml',
     'target-env-files',
   ],
-  run: async (requirements, utils) => {
+  run: async (requirements, _utils) => {
     const currentRelease = await readRepoYAML(path.join('infrastructure', 'tooling', 'current-release.yml'));
     const [, currentVersion] = currentRelease.image.split(':');
 
@@ -240,7 +240,7 @@ tasks.push({
         ? { ports: opts.ports || servicePorts(name) } : {}),
     });
 
-    const serviceDefinitionProd = (name, profiles = null) => ({
+    const serviceDefinitionProd = (_name, profiles = null) => ({
       environment: {
         NODE_ENV: 'production',
       },
@@ -578,7 +578,7 @@ tasks.push({
   title: `Generate nginx.conf`,
   requires: [],
   provides: ['target-nginx.conf'],
-  run: async (requirements, utils) => {
+  run: async (_requirements, _utils) => {
     const extraDirectives = `proxy_hide_header Content-Security-Policy;
       proxy_set_header Host taskcluster;
 
@@ -675,7 +675,7 @@ tasks.push({
   title: `Generate prometheus.yml`,
   requires: [...SERVICES.map(name => `procslist-${name}`)],
   provides: ['target-prometheus.yml'],
-  run: async (requirements, utils) => {
+  run: async (requirements, _utils) => {
     const targets = [];
 
     SERVICES.forEach(name => {

--- a/infrastructure/tooling/src/generate/generators/docker-worker.js
+++ b/infrastructure/tooling/src/generate/generators/docker-worker.js
@@ -6,7 +6,7 @@ export const tasks = [{
   provides: [
     'docker-worker-schemas',
   ],
-  run: async (requirements, utils) => {
+  run: async (_requirements, _utils) => {
     const schemaFile = 'tools/d2g/schemas/docker-worker/v1/payload.yml';
     const content = await readRepoYAML(schemaFile);
 

--- a/infrastructure/tooling/src/generate/generators/docs-search.js
+++ b/infrastructure/tooling/src/generate/generators/docs-search.js
@@ -32,7 +32,7 @@ export const tasks = [{
   title: 'Docs Search',
   requires: ['target-gw-docs', 'target-worker-runner'],
   provides: ['docs-search'],
-  run: (requirements, utils) => {
+  run: (_requirements, _utils) => {
     const docsSearch = [];
     const files = walkSync(DOCS_DIR).filter(path => path.endsWith('.mdx'));
     const textFromHash = text => text.replace(/(^#{1,6}\s)/, '');

--- a/infrastructure/tooling/src/generate/generators/docs-tocs.js
+++ b/infrastructure/tooling/src/generate/generators/docs-tocs.js
@@ -107,7 +107,7 @@ function makeToc({ files, rootPath }) {
       item.path
         .replace(rootPath, '')
         .split('/')
-        .forEach((name, idx) => {
+        .forEach((name, _idx) => {
           path.push(name);
 
           let child = ptr.children.find(child => child.name === name);
@@ -156,7 +156,7 @@ export const tasks = [{
   title: 'Docs TOCs',
   requires: ['target-gw-docs', 'target-worker-runner'],
   provides: ['docs-toc'],
-  run: async (requirements, utils) => {
+  run: async (_requirements, _utils) => {
     const filesWithExtensions = await mdParseDir(DOCS_DIR, { dirnames: true, filter: '**/*.mdx' });
     // strip .md and .mdx extensions from those filenames..
     const files = Object.assign({},

--- a/infrastructure/tooling/src/generate/generators/entry-script.js
+++ b/infrastructure/tooling/src/generate/generators/entry-script.js
@@ -11,7 +11,7 @@ export const tasks = [{
     'entrypoint-script',
   ],
   locks: [],
-  run: async (requirements, utils) => {
+  run: async (_requirements, _utils) => {
     const procs = {};
     const packageJson = await readRepoJSON('package.json');
 

--- a/infrastructure/tooling/src/generate/generators/generic-worker.js
+++ b/infrastructure/tooling/src/generate/generators/generic-worker.js
@@ -10,7 +10,7 @@ tasks.push({
   title: 'Generate Generic-Worker',
   requires: ['references-json', 'target-go-version'],
   provides: ['target-generic-worker'],
-  run: async (requirements, utils) => {
+  run: async (_requirements, utils) => {
     await execCommand({
       dir: path.join(REPO_ROOT, 'workers', 'generic-worker'),
       command: ['go', 'generate', './...'],
@@ -25,7 +25,7 @@ tasks.push({
   provides: [
     'generic-worker-schemas',
   ],
-  run: async (requirements, utils) => {
+  run: async (_requirements, _utils) => {
     const schemaFiles = glob.sync('workers/generic-worker/schemas/*.yml', { cwd: REPO_ROOT });
     return {
       'generic-worker-schemas': await Promise.all(schemaFiles.map(async filename => {
@@ -50,7 +50,7 @@ tasks.push({
   title: 'Update generic-worker README',
   requires: ['target-generic-worker'],
   provides: ['generic-worker-readme'],
-  run: async (requirements, utils) => {
+  run: async (_requirements, utils) => {
     const binary = path.join(tempDir, 'generic-worker');
     // we have to build this binary, rather than just using `go run`, because otherwise `go run` spews
     // its own output into stdout
@@ -108,7 +108,7 @@ tasks.push({
   title: 'Update generic-worker payload formats',
   requires: ['generic-worker-schemas'],
   provides: ['target-gw-docs'],
-  run: async (requirements, utils) => {
+  run: async (requirements, _utils) => {
     const gwDocsDir = path.join('ui', 'docs', 'reference', 'workers', 'generic-worker');
 
     // begin by deleting all *-payload--schema.mdx files
@@ -116,7 +116,7 @@ tasks.push({
       await rimraf(path.join(REPO_ROOT, file));
     }
 
-    const schemaFiles = requirements['generic-worker-schemas'].map(({ filename, content }) => ({
+    const schemaFiles = requirements['generic-worker-schemas'].map(({ content }) => ({
       $id: content.$id,
       title: content.title,
       filename_base: `${path.basename(content.$id, '.json#').replace('_', '-')}-payload`,

--- a/infrastructure/tooling/src/generate/generators/go-mod-tidy.js
+++ b/infrastructure/tooling/src/generate/generators/go-mod-tidy.js
@@ -10,7 +10,7 @@ export const tasks = [{
     'target-generic-worker',
   ],
   provides: ['target-go-mod-tidy'],
-  run: async (requirements, utils) => {
+  run: async (_requirements, _utils) => {
     await promisify(execFile)('go', ['mod', 'tidy']);
   },
 }];

--- a/infrastructure/tooling/src/generate/generators/go-version.js
+++ b/infrastructure/tooling/src/generate/generators/go-version.js
@@ -10,7 +10,7 @@ const exec = util.promisify(execFile);
 export const tasks = [{
   title: 'Go Version',
   provides: ['target-go-version'],
-  run: async (requirements, utils) => {
+  run: async (_requirements, utils) => {
     const goVersion = (await readRepoFile('.go-version')).trim();
     const goVersionMajor = goVersion.replace(/^go([0-9]+)\.[0-9]+\.[0-9]+$/, '$1');
     const goVersionMinor = goVersion.replace(/^go[0-9]+\.([0-9]+)\.[0-9]+$/, '$1');

--- a/infrastructure/tooling/src/generate/generators/k8s.js
+++ b/infrastructure/tooling/src/generate/generators/k8s.js
@@ -117,7 +117,7 @@ const labels = (projectName, component) => ({
   'app.kubernetes.io/component': `${projectName}-${component.toLowerCase()}`,
   'app.kubernetes.io/part-of': 'taskcluster',
 });
-const metricsSelectorLabels = (projectName) => ({
+const metricsSelectorLabels = (_projectName) => ({
   'app.kubernetes.io/part-of': 'taskcluster',
   'app.kubernetes.io/instance': '{{ .Release.Name }}',
   'prometheus.io/scrape': 'true',
@@ -127,7 +127,7 @@ const metricsSelectorLabels = (projectName) => ({
 // we have to do some post-processing to use "advanced" go template features
 const postJsoneProcessing = (rendered, replacements, context) => {
   let result = yaml.dump(rendered, { lineWidth: -1 })
-    .replaceAll(new RegExp(`(${Object.keys(replacements).join('|')})`, 'g'), (match, p1) => replacements[match]);
+    .replaceAll(new RegExp(`(${Object.keys(replacements).join('|')})`, 'g'), (match, _p1) => replacements[match]);
 
   // Add conditional replicas configuration
   if (context.wrapReplicas) {
@@ -330,7 +330,7 @@ tasks.push({
   title: `Load k8s templates`,
   requires: [],
   provides: ['k8s-templates'],
-  run: async (requirements, utils) => {
+  run: async (_requirements, _utils) => {
 
     const templateFiles = glob.sync('infrastructure/tooling/templates/k8s/*.yaml', { cwd: REPO_ROOT });
     const templates = {};
@@ -347,7 +347,7 @@ tasks.push({
   title: `Clear k8s/templates directory`,
   requires: [],
   provides: ['k8s-templates-dir'],
-  run: async (requirements, utils) => {
+  run: async (_requirements, _utils) => {
     await rimraf(TMPL_DIR);
     await mkdirp(TMPL_DIR);
   },
@@ -358,7 +358,7 @@ SERVICES.forEach(name => {
     title: `Generate helm templates for ${name}`,
     requires: [`configs-${name}`, `procslist-${name}`, 'k8s-templates', 'k8s-templates-dir'],
     provides: [`ingresses-${name}`, `healthchecks-${name}`],
-    run: async (requirements, utils) => {
+    run: async (requirements, _utils) => {
       const procs = requirements[`procslist-${name}`];
       const templates = requirements['k8s-templates'];
       const vars = requirements[`configs-${name}`];
@@ -412,7 +412,7 @@ Object.entries(extras).forEach(([name, { procs, vars }]) => {
     title: `Generate helm templates for ${name}`,
     requires: ['k8s-templates'],
     provides: [`ingresses-${name}`, `healthchecks-${name}`],
-    run: async (requirements, utils) => {
+    run: async (requirements, _utils) => {
       const templates = requirements['k8s-templates'];
       const result = await renderTemplates(name, vars, procs, templates);
       return {
@@ -434,7 +434,7 @@ tasks.push({
     ...['ui', 'references', ...SERVICES].map(name => `healthchecks-${name}`),
   ],
   provides: [],
-  run: async (requirements, utils) => {
+  run: async (requirements, _utils) => {
     const ingresses = [];
     const healthChecks = [];
     for (const [name, req] of Object.entries(requirements)) {
@@ -526,7 +526,7 @@ tasks.push({
   title: `Generate pod monitoring`,
   requires: ['k8s-templates'],
   provides: [],
-  run: async (requirements, utils) => {
+  run: async (requirements, _utils) => {
     const templates = requirements['k8s-templates'];
 
     // podmonitoring for prometheus metrics
@@ -554,7 +554,7 @@ tasks.push({
     'config-values',
     'target-k8s',
   ],
-  run: async (requirements, utils) => {
+  run: async (requirements, _utils) => {
     const schema = {
       '$schema': 'http://json-schema.org/draft-06/schema#',
       '$id': '/schemas/common/values.schema.json#',

--- a/infrastructure/tooling/src/generate/generators/metadata.js
+++ b/infrastructure/tooling/src/generate/generators/metadata.js
@@ -11,7 +11,7 @@ SERVICES.forEach(name => {
     title: `Fetch service metadata for ${name}`,
     requires: [],
     provides: [`configs-${name}`, `procslist-${name}`, `scopes-${name}`],
-    run: async (requirements, utils) => {
+    run: async (_requirements, _utils) => {
       const envVars = config({
         serviceName: name,
         // only list config.yml, to avoid grabbing information from user-config.yml

--- a/infrastructure/tooling/src/generate/generators/monitoring.js
+++ b/infrastructure/tooling/src/generate/generators/monitoring.js
@@ -28,7 +28,7 @@ SERVICES.forEach(name => {
       `procs-${name}`,
     ],
     provides: [`monitoring-hints-${name}`],
-    run: async (requirements, utils) => {
+    run: async (requirements, _utils) => {
       const res = [];
       Object.entries(requirements[`procs-${name}`]).forEach(([proc, ext]) => {
         if (ext.type === 'cron') {
@@ -48,7 +48,7 @@ tasks.push({
   title: `Generate Monitoring Suggestions`,
   requires: SERVICES.map(name => `monitoring-hints-${name}`),
   provides: [],
-  run: async (requirements, utils) => {
+  run: async (requirements, _utils) => {
     let res = [['Service', 'Name', 'Logger', 'Deadline (seconds)', 'Schedule']];
     SERVICES.forEach(name => {
       res = res.concat(requirements[`monitoring-hints-${name}`]);
@@ -66,7 +66,7 @@ tasks.push({
   title: `Generate Metrics Table`,
   requires: SERVICES.map(name => `procs-${name}`),
   provides: [],
-  run: async (requirements, utils) => {
+  run: async (requirements, _utils) => {
     const res = [['Service', 'Name', 'Type', 'Reference']];
     SERVICES.forEach(name => {
       const procs = requirements[`procs-${name}`];

--- a/infrastructure/tooling/src/generate/generators/node-version.js
+++ b/infrastructure/tooling/src/generate/generators/node-version.js
@@ -15,7 +15,7 @@ export const tasks = [];
 tasks.push({
   title: 'Node Version',
   provides: ['target-node-version'],
-  run: async (requirements, utils) => {
+  run: async (_requirements, utils) => {
     const nodeVersion = (await readRepoJSON('package.json')).engines.node;
     if (!nodeVersion?.match(/[0-9.]+/)) {
       throw new Error(`invalid node version ${nodeVersion} in package.json`);
@@ -86,7 +86,7 @@ tasks.push({
 tasks.push({
   title: 'Yarn Version',
   provides: ['target-yarn-version'],
-  run: async (requirements, utils) => {
+  run: async (_requirements, utils) => {
     const yarnVersion = (await readRepoJSON('package.json')).packageManager;
     if (!yarnVersion?.match(/yarn@[0-9.]+/)) {
       throw new Error(`invalid yarn version ${yarnVersion} in package.json`);

--- a/infrastructure/tooling/src/generate/generators/procfiles.js
+++ b/infrastructure/tooling/src/generate/generators/procfiles.js
@@ -9,7 +9,7 @@ tasks.push({
   title: `Read procs.yml for all services`,
   requires: [],
   provides: SERVICES.map(name => `procs-${name}`),
-  run: async (requirements, utils) => {
+  run: async (_requirements, _utils) => {
     const provides = {};
     for (const name of SERVICES) {
       provides[`procs-${name}`] = await readRepoYAML(path.join('services', name, 'procs.yml'));

--- a/infrastructure/tooling/src/generate/generators/readme-tocs.js
+++ b/infrastructure/tooling/src/generate/generators/readme-tocs.js
@@ -11,7 +11,7 @@ export const tasks = [{
     'db-versions-readme',
     'db-fns-readme',
   ],
-  run: async (requirements, utils) => {
+  run: async (_requirements, utils) => {
     utils.status({ message: 'gathering READMEs' });
     let readmes = (await gitLsFiles())
       .filter(file => file.endsWith('README.md'))
@@ -58,7 +58,7 @@ export const tasks = [{
     };
 
     // recursively write out TOC's
-    const rewrite = async ({ content, dir, title, children }) => {
+    const rewrite = async ({ content, dir, children }) => {
       const lines = tocLines([], '', dir, children);
       if (lines.length > 0) {
         utils.status({ message: `rewriting ${path.join(dir, 'README.md')}` });

--- a/infrastructure/tooling/src/generate/generators/service-refs.js
+++ b/infrastructure/tooling/src/generate/generators/service-refs.js
@@ -27,7 +27,7 @@ SERVICES.forEach(name => {
     title: `Generate References for ${name} `,
     requires: [],
     provides: [`refs-${name}`],
-    run: async (requirements, utils) => {
+    run: async (_requirements, _utils) => {
       const svcDir = path.join(genDir, name);
 
       await mkdirp(genDir);
@@ -58,7 +58,7 @@ tasks.push({
     'target-references',
     'references-json',
   ],
-  run: async (requirements, utils) => {
+  run: async (requirements, _utils) => {
     await mkdirp(genDir);
 
     // combine all of the references, using a map to eliminate duplicate files

--- a/infrastructure/tooling/src/generate/generators/static-clients.js
+++ b/infrastructure/tooling/src/generate/generators/static-clients.js
@@ -11,7 +11,7 @@ tasks.push({
     ...SERVICES.map(name => `scopes-${name}`),
   ],
   provides: ['static-clients'],
-  run: async (requirements, utils) => {
+  run: async (requirements, _utils) => {
     const staticClients = [];
     SERVICES.forEach(name => {
       // auth defines scopes, so it doesn't need any of its own.
@@ -40,7 +40,7 @@ tasks.push({
   title: 'Configure static client scopes',
   requires: ['static-clients'],
   provides: [],
-  run: async (requirements, utils) => {
+  run: async (requirements, _utils) => {
     const staticClients = requirements['static-clients'];
     const staticScopes = staticClients.map(({ clientId, scopes }) => ({ clientId, scopes }));
 

--- a/infrastructure/tooling/src/generate/generators/tc-client-go.js
+++ b/infrastructure/tooling/src/generate/generators/tc-client-go.js
@@ -5,7 +5,7 @@ export const tasks = [{
   title: 'Generate Taskcluster-Client-Go',
   requires: ['references-json', 'target-go-version'],
   provides: ['target-taskcluster-client-go'],
-  run: async (requirements, utils) => {
+  run: async (_requirements, utils) => {
     await execCommand({
       dir: path.join(REPO_ROOT, 'clients', 'client-go'),
       command: ['go', 'generate', './...'],

--- a/infrastructure/tooling/src/generate/generators/tc-client-shell.js
+++ b/infrastructure/tooling/src/generate/generators/tc-client-shell.js
@@ -5,7 +5,7 @@ export const tasks = [{
   title: 'Generate Taskcluster-Client-Shell',
   requires: ['references-json', 'target-go-version'],
   provides: ['target-taskcluster-client-shell'],
-  run: async (requirements, utils) => {
+  run: async (_requirements, utils) => {
     await execCommand({
       dir: path.join(REPO_ROOT, 'clients', 'client-shell'),
       command: ['go', 'generate', './...'],

--- a/infrastructure/tooling/src/generate/generators/tc-client.js
+++ b/infrastructure/tooling/src/generate/generators/tc-client.js
@@ -5,7 +5,7 @@ export const tasks = [{
   title: 'Generate Taskcluster-Client',
   requires: ['apis'],
   provides: ['target-taskcluster-client'],
-  run: async (requirements, utils) => {
+  run: async (requirements, _utils) => {
     const apis = requirements.apis;
 
     await writeRepoFile('clients/client/src/apis.js',

--- a/infrastructure/tooling/src/generate/generators/worker-runner.js
+++ b/infrastructure/tooling/src/generate/generators/worker-runner.js
@@ -10,7 +10,7 @@ tasks.push({
   title: 'Update worker-runner README file',
   requires: ['references-json', 'target-go-version'],
   provides: ['target-worker-runner'],
-  run: async (requirements, utils) => {
+  run: async (_requirements, utils) => {
     const binary = path.join(tempDir, 'w-r-generate-docs');
     // we have to build this binary, rather than just using `go run`, because otherwise `go run` spews
     // its own output into stdout

--- a/infrastructure/tooling/src/meta/checks/depcheck.js
+++ b/infrastructure/tooling/src/meta/checks/depcheck.js
@@ -19,7 +19,7 @@ if (isMainThread) {
     title: 'Dependencies are used and installed',
     requires: [],
     provides: [],
-    run: async (requirements, utils) => {
+    run: async (_requirements, utils) => {
       return new Promise((resolve, reject) => {
         const worker = new Worker(__filename, {});
         worker.on('message', ({ err, message }) => {

--- a/infrastructure/tooling/src/meta/checks/docs-headings.js
+++ b/infrastructure/tooling/src/meta/checks/docs-headings.js
@@ -6,7 +6,7 @@ export const tasks = [{
   title: 'Docs headings match expectations',
   requires: [],
   provides: [],
-  run: async (requirements, utils) => {
+  run: async (_requirements, _utils) => {
     const markdowns = glob.sync(
       'ui/docs/**/*.mdx',
       { cwd: REPO_ROOT });

--- a/infrastructure/tooling/src/meta/checks/workspace-packages.js
+++ b/infrastructure/tooling/src/meta/checks/workspace-packages.js
@@ -6,7 +6,7 @@ export const tasks = [{
   title: 'Workspace package.json files do not have forbidden fields',
   requires: [],
   provides: [],
-  run: async (requirements, utils) => {
+  run: async (_requirements, _utils) => {
     const packageJsons = glob.sync(
       '{services,libraries}/*/package.json',
       { cwd: REPO_ROOT });

--- a/infrastructure/tooling/src/meta/index.js
+++ b/infrastructure/tooling/src/meta/index.js
@@ -1,7 +1,7 @@
 import { loadChecks } from './checks/index.js';
 import { TaskGraph } from 'console-taskgraph';
 
-export const main = async (options) => {
+export const main = async (_options) => {
   const checks = await loadChecks();
   const taskgraph = new TaskGraph(checks, {});
   await taskgraph.run();

--- a/infrastructure/tooling/src/release/tasks.js
+++ b/infrastructure/tooling/src/release/tasks.js
@@ -29,7 +29,7 @@ import { schema as readSchema } from '@taskcluster/db';
 
 const UPSTREAM_REMOTE = 'git@github.com:taskcluster/taskcluster';
 
-export default ({ tasks, cmdOptions, credentials }) => {
+export default ({ tasks, cmdOptions }) => {
   ensureTask(tasks, {
     title: 'Get Changelog',
     requires: [
@@ -38,7 +38,7 @@ export default ({ tasks, cmdOptions, credentials }) => {
     provides: [
       'changelog',
     ],
-    run: async (requirements, utils) => {
+    run: async (_requirements, _utils) => {
       const changelog = new ChangeLog();
       await changelog.load();
       return { changelog };
@@ -53,7 +53,7 @@ export default ({ tasks, cmdOptions, credentials }) => {
     provides: [
       'release-version',
     ],
-    run: async (requirements, utils) => {
+    run: async (requirements, _utils) => {
       const pkgJson = await readRepoJSON('package.json');
       if (!semver.valid(pkgJson.version)) {
         throw new Error(`Version ${pkgJson.version} in package.json is not valid`);
@@ -74,7 +74,7 @@ export default ({ tasks, cmdOptions, credentials }) => {
       'repo-clean',
     ],
     locks: ['git'],
-    run: async (requirements, utils) => {
+    run: async (_requirements, _utils) => {
       if (await gitIsDirty({ dir: REPO_ROOT })) {
         throw new Error([
           'The current git working copy is not clean.  Releases can only be made from a clean',
@@ -91,7 +91,7 @@ export default ({ tasks, cmdOptions, credentials }) => {
       'repo-up-to-date',
     ],
     locks: ['git'],
-    run: async (requirements, utils) => {
+    run: async (_requirements, utils) => {
       const { revision: localRevision } = await gitDescribe({ dir: REPO_ROOT, utils });
       const { revision: remoteRevision } = await gitRemoteRev({
         dir: REPO_ROOT,
@@ -274,7 +274,7 @@ export default ({ tasks, cmdOptions, credentials }) => {
       'db-releases',
       'db-releases-txt',
     ],
-    run: async (requirements, utils) => {
+    run: async (requirements, _utils) => {
       const schema = await readSchema();
       const tcVersion = `v${requirements['release-version']}`;
       const dbVersion = schema.latestVersion().version;
@@ -303,7 +303,7 @@ export default ({ tasks, cmdOptions, credentials }) => {
     provides: [
       'db-version-updated',
     ],
-    run: async (requirements, utils) => {
+    run: async (requirements, _utils) => {
       const schema = await readSchema();
 
       // then, regenerate the versions reference
@@ -327,7 +327,7 @@ export default ({ tasks, cmdOptions, credentials }) => {
     provides: [
       'db-fns-updated',
     ],
-    run: async (requirements, utils) => {
+    run: async (requirements, _utils) => {
       const schema = await readSchema();
 
       // then, regenerate the versions reference
@@ -352,7 +352,7 @@ export default ({ tasks, cmdOptions, credentials }) => {
     provides: [
       'changed-files',
     ],
-    run: async (requirements, utils) => {
+    run: async (requirements, _utils) => {
       const changed = [];
 
       const marker = '<!-- NEXT RELEASE HERE -->\n';

--- a/infrastructure/tooling/src/smoketest/checks/builtin.js
+++ b/infrastructure/tooling/src/smoketest/checks/builtin.js
@@ -22,7 +22,7 @@ export const tasks = [];
     provides: [
       `target-built-in/${taskType}`,
     ],
-    run: async (requirements, utils) => {
+    run: async (_requirements, utils) => {
       const task = {
         provisionerId: 'built-in',
         workerType: taskType,

--- a/infrastructure/tooling/src/smoketest/checks/createClient.js
+++ b/infrastructure/tooling/src/smoketest/checks/createClient.js
@@ -17,7 +17,7 @@ tasks.push({
   provides: [
     'target-client',
   ],
-  run: async (requirements, utils) => {
+  run: async (_requirements, utils) => {
     const auth = new taskcluster.Auth(taskcluster.fromEnvVars());
     const randomId = taskcluster.slugid();
 

--- a/infrastructure/tooling/src/smoketest/checks/dependencies.js
+++ b/infrastructure/tooling/src/smoketest/checks/dependencies.js
@@ -16,7 +16,7 @@ tasks.push({
   provides: [
     'target-dependencies',
   ],
-  run: async (requirements, utils) => {
+  run: async (_requirements, utils) => {
     const taskCount = 3;
     const taskIds = [];
     const queue = new taskcluster.Queue(taskcluster.fromEnvVars());

--- a/infrastructure/tooling/src/smoketest/checks/dockerflow.js
+++ b/infrastructure/tooling/src/smoketest/checks/dockerflow.js
@@ -13,7 +13,7 @@ SERVICES.forEach((name) => {
     title: `__lbheartbeat__ endpoint for ${name}`,
     requires: [],
     provides: [`lbheartbeat-${name}`],
-    run: async (requirements, utils) => {
+    run: async (_requirements, utils) => {
       const procs = await readRepoYAML(
         path.join("services", name, "procs.yml"),
       );
@@ -51,7 +51,7 @@ SERVICES.forEach((name) => {
     title: `__heartbeat__ endpoint for ${name}`,
     requires: [],
     provides: [`heartbeat-${name}`],
-    run: async (requirements, utils) => {
+    run: async (_requirements, utils) => {
       const procs = await readRepoYAML(
         path.join("services", name, "procs.yml"),
       );
@@ -89,7 +89,7 @@ SERVICES.forEach((name) => {
     title: `__version__ endpoint for ${name}`,
     requires: [],
     provides: [`version-${name}`],
-    run: async (requirements, utils) => {
+    run: async (_requirements, utils) => {
       const procs = await readRepoYAML(
         path.join("services", name, "procs.yml"),
       );
@@ -134,5 +134,5 @@ tasks.push({
     ]),
   ],
   provides: [`target-dockerflow`],
-  run: async (requirements, utils) => {},
+  run: async (_requirements, _utils) => {},
 });

--- a/infrastructure/tooling/src/smoketest/checks/indexTask.js
+++ b/infrastructure/tooling/src/smoketest/checks/indexTask.js
@@ -17,7 +17,7 @@ tasks.push({
   provides: [
     'target-index',
   ],
-  run: async (requirements, utils) => {
+  run: async (_requirements, utils) => {
     const queue = new taskcluster.Queue(taskcluster.fromEnvVars());
     const randomId = taskcluster.slugid();
     const taskIndex = `project.taskcluster.smoketest.${randomId}`;

--- a/infrastructure/tooling/src/smoketest/checks/ping.js
+++ b/infrastructure/tooling/src/smoketest/checks/ping.js
@@ -14,7 +14,7 @@ tasks.push({
   provides: [
     `deployment-version`,
   ],
-  run: async (requirements, utils) => {
+  run: async (_requirements, _utils) => {
     const dunderVersion = `${process.env.TASKCLUSTER_ROOT_URL}/__version__`;
     const resp = await got(dunderVersion, { throwHttpErrors: true });
 
@@ -34,7 +34,7 @@ SERVICES.forEach(name => {
     provides: [
       `ping-${name}`,
     ],
-    run: async (requirements, utils) => {
+    run: async (_requirements, utils) => {
       const procs = await readRepoYAML(path.join('services', name, 'procs.yml'));
 
       let checked = false;
@@ -70,5 +70,5 @@ tasks.push({
   provides: [
     `target-ping`,
   ],
-  run: async (requirements, utils) => {},
+  run: async (_requirements, _utils) => {},
 });

--- a/infrastructure/tooling/src/smoketest/checks/role.js
+++ b/infrastructure/tooling/src/smoketest/checks/role.js
@@ -20,7 +20,7 @@ tasks.push({
   provides: [
     'target-roles',
   ],
-  run: async (requirements, utils) => {
+  run: async (_requirements, utils) => {
     const auth = new taskcluster.Auth(taskcluster.fromEnvVars());
     const randomId = taskcluster.slugid();
     const roleId = `project:taskcluster:smoketest:${randomId}:*`;

--- a/infrastructure/tooling/src/utils/command.js
+++ b/infrastructure/tooling/src/utils/command.js
@@ -69,7 +69,7 @@ export const execCommand = async ({
   }
 
   const stream = new Transform({
-    transform: (chunk, encoding, callback) => {
+    transform: (chunk, _encoding, callback) => {
       if (keepAllOutput) {
         output += chunk.toString();
       } else {

--- a/infrastructure/tooling/src/utils/db.js
+++ b/infrastructure/tooling/src/utils/db.js
@@ -329,7 +329,7 @@ export const generateDbTypes = async (schema) => {
       output.push(` ): Promise<${returnType}>;`);
       output.push(` (params: {`);
       if (args.length > 0) {
-        args.forEach((arg, i) => {
+        args.forEach((arg, _i) => {
           const isOptional = isArgOptional(arg.name, method.body);
           const argType = `${arg.type}${isOptional ? ' | null' : ''}`;
           output.push(`  ${arg.name}${isOptional ? '?' : ''}: ${argType};`);

--- a/infrastructure/tooling/src/utils/docker.js
+++ b/infrastructure/tooling/src/utils/docker.js
@@ -131,7 +131,7 @@ class DemuxDockerStream extends Transform {
     this.buffer = Buffer.alloc(0);
   }
 
-  _transform(chunk, encoding, callback) {
+  _transform(chunk, _encoding, callback) {
     if (this.buffer.length) {
       this.buffer = Buffer.concat([this.buffer, chunk]);
     } else {

--- a/infrastructure/tooling/src/utils/git.js
+++ b/infrastructure/tooling/src/utils/git.js
@@ -17,7 +17,7 @@ const exec = util.promisify(execFile);
  *   changed: ..,      // true if the repo was cloned or the revision changed
  * }
  */
-export const gitClone = async ({ dir, url, sha, utils }) => {
+export const gitClone = async ({ dir, url }) => {
   const [repo, ref = 'main'] = url.split('#');
   const opts = { cwd: dir };
 
@@ -60,7 +60,7 @@ export const gitClone = async ({ dir, url, sha, utils }) => {
  *   revision: .., // the sha of the remote ref
  * }
  */
-export const gitRemoteRev = async ({ dir, remote, ref, utils }) => {
+export const gitRemoteRev = async ({ dir, remote, ref }) => {
   const opts = { cwd: dir };
 
   assert(fs.existsSync(dir), `${dir} does not exist`);
@@ -126,7 +126,7 @@ export const gitDescribe = async ({ dir }) => {
  *   ref: ..., // abbreviated ref
  * }
  */
-export const gitCurrentBranch = async ({ dir, utils }) => {
+export const gitCurrentBranch = async ({ dir }) => {
   const opts = { cwd: dir };
 
   assert(fs.existsSync(dir), `${dir} does not exist`);
@@ -155,7 +155,7 @@ export const gitAdd = async ({ dir, files }) => {
  * - files -- files to include in the commit (anything staged will get committed too..)
  * - utils -- taskgraph utils (waitFor, etc.)
  */
-export const gitCommit = async ({ dir, message, files, utils }) => {
+export const gitCommit = async ({ dir, message, files }) => {
   const opts = { cwd: dir };
   await exec('git', ['commit', '-m', message, ...files], opts);
 };
@@ -167,7 +167,7 @@ export const gitCommit = async ({ dir, message, files, utils }) => {
  * - rev -- revision to tag
  * - tag -- tag to apply
  */
-export const gitTag = async ({ dir, rev, tag, utils }) => {
+export const gitTag = async ({ dir, rev, tag }) => {
   const opts = { cwd: dir };
   await exec('git', ['tag', tag, rev], opts);
 };
@@ -180,7 +180,7 @@ export const gitTag = async ({ dir, rev, tag, utils }) => {
  * - refs -- refs to push
  * - force -- if true, -f
  */
-export const gitPush = async ({ dir, remote, refs, force, utils }) => {
+export const gitPush = async ({ dir, remote, refs, force }) => {
   const opts = { cwd: dir };
   await exec('git', ['push', ...(force ? ['-f'] : []), remote, ...refs], opts);
 };

--- a/libraries/api/src/api.js
+++ b/libraries/api/src/api.js
@@ -136,7 +136,7 @@ export default class API {
  * @returns {import('express').RequestHandler}}
  */
 const cacheHeaders = () => {
-  return (req, res, next) => {
+  return (_req, res, next) => {
     res.header('Cache-Control', 'no-store no-cache must-revalidate');
     next();
   };
@@ -149,7 +149,7 @@ const cacheHeaders = () => {
  * @returns {import('express').RequestHandler}
  */
 const corsHeaders = allowedCORSOrigin => {
-  return (req, res, next) => {
+  return (_req, res, next) => {
     res.header('Access-Control-Allow-Origin', allowedCORSOrigin);
     res.header('Access-Control-Max-Age', '900');
     res.header('Access-Control-Allow-Methods', [

--- a/libraries/api/src/expressions.js
+++ b/libraries/api/src/expressions.js
@@ -104,7 +104,7 @@ const extractParams = (compiledTemplate) => {
   const ctmpl = compiledTemplate;
   if (Array.isArray(ctmpl)) {
     return ctmpl
-      .filter((value, i) => i % 2 === 1)
+      .filter((_value, i) => i % 2 === 1)
       .map(p => ({ [p]: 'string' }))
       .reduce(mergeParams, {});
   }
@@ -205,7 +205,7 @@ export default class ScopeExpressionTemplate {
     this.template = template;
     this._compiledTemplate = compileTemplate(template);
     this._paramTypes = Object.entries(extractParams(this._compiledTemplate));
-    this.params = this._paramTypes.map(([p, T]) => p);
+    this.params = this._paramTypes.map(([p, _T]) => p);
   }
 
   /** Render this scope expression template into a scope expression given params */

--- a/libraries/api/src/index.js
+++ b/libraries/api/src/index.js
@@ -55,7 +55,7 @@ const ping = {
     'Respond without doing anything.',
     'This endpoint is used to check that the service is up.',
   ].join('\n'),
-  handler: (req, res) => {
+  handler: (_req, res) => {
     res.status(200).json({
       alive: true,
       uptime: process.uptime(),

--- a/libraries/api/src/middleware/errors.js
+++ b/libraries/api/src/middleware/errors.js
@@ -22,7 +22,7 @@ export const ERROR_CODES = {
  * @returns {import('../../@types/index.d.ts').APIRequestHandler<{}>}
  */
 export const buildReportErrorMethod = () => {
-  return (req, res, next) => {
+  return (_req, res, next) => {
     res.reportError = reportError;
     next();
   };

--- a/libraries/api/src/middleware/express-error.js
+++ b/libraries/api/src/middleware/express-error.js
@@ -24,7 +24,7 @@ export const setIsProduction = value => isProduction = value;
  */
 export const expressError = ({ errorCodes, entry }) => {
   const { name: method, cleanPayload } = entry;
-  return (err, req, res, next) => {
+  return (err, req, res, _next) => {
 
     if (res.headersSent) {
       req.tcContext.monitor.reportError(new Error('API method implementation called res.send twice'));

--- a/libraries/api/src/middleware/handle.js
+++ b/libraries/api/src/middleware/handle.js
@@ -14,7 +14,7 @@ import assert from 'node:assert';
  * }} options
  * @returns {import('../../@types/index.d.ts').APIRequestHandler<TContext>}
  */
-export const callHandler = ({ entry, context, monitor }) => {
+export const callHandler = ({ entry, context: _context, monitor }) => {
   assert(entry.handler, 'No handler is provided');
   return (req, res, next) => {
     Promise.resolve(null).then(() => {

--- a/libraries/api/src/middleware/per-request-context.js
+++ b/libraries/api/src/middleware/per-request-context.js
@@ -10,7 +10,7 @@
  * @returns {import('../../@types/index.d.ts').APIRequestHandler<TContext>}
  */
 export const perRequestContext = ({ entry, context }) => {
-  return (req, res, next) => {
+  return (req, _res, next) => {
     /** @type {{ [key: string | symbol]: any }} */
     const cache = {};
     req.tcContext = new Proxy(context, {
@@ -32,10 +32,10 @@ export const perRequestContext = ({ entry, context }) => {
         });
         return cache[prop];
       },
-      set(target, prop, value) {
+      set(_target, _prop, _value) {
         throw new Error('Cannot set values in context inside a handler!');
       },
-      deleteProperty(target, prop) {
+      deleteProperty(_target, _prop) {
         throw new Error('Cannot delete values in context inside a handler!');
       },
     });

--- a/libraries/api/test/auth_test.js
+++ b/libraries/api/test/auth_test.js
@@ -166,7 +166,7 @@ suite(testing.suiteName(), function() {
     route: '/test-static-scope',
     name: 'testStaticScope',
     scopes: { AllOf: ['service:magic'] },
-    handler: (req, res) => {
+    handler: (_req, res) => {
       res.status(200).json({ ok: true });
     },
     tests: [
@@ -344,7 +344,7 @@ suite(testing.suiteName(), function() {
         label: 'insufficient scopes without auth has documented details',
         shouldCallAuth: true,
         desiredStatus: 403,
-        tester: (auth, url) => noAuthRequest(url),
+        tester: (_auth, url) => noAuthRequest(url),
       },
     ],
   });
@@ -390,7 +390,7 @@ suite(testing.suiteName(), function() {
       {
         shouldCallAuth: false,
         label: 'public unauthenticated endpoint',
-        tester: (auth, url) => noAuthRequest(url),
+        tester: (_auth, url) => noAuthRequest(url),
       },
     ],
   });
@@ -583,7 +583,7 @@ suite(testing.suiteName(), function() {
       {
         label: 'scope expression if/then (success with no client)',
         shouldCallAuth: false,
-        tester: (auth, url) => request
+        tester: (_auth, url) => request
           .get(url)
           .set('x-taskcluster-trace-id', 'foo/bar')
           .send({
@@ -606,7 +606,7 @@ suite(testing.suiteName(), function() {
         label: 'scope expression if/then (failure with no client)',
         shouldCallAuth: false,
         desiredStatus: 403,
-        tester: (auth, url) => request
+        tester: (_auth, url) => request
           .get(url)
           .set('x-taskcluster-trace-id', 'foo/bar')
           .send({
@@ -624,7 +624,7 @@ suite(testing.suiteName(), function() {
       'some:scope:nobody:has',
       { if: 'public', then: { AllOf: [] } },
     ] },
-    handler: async (req, res) => {
+    handler: async (_req, res) => {
       return res.reply({});
     },
     tests: [
@@ -643,7 +643,7 @@ suite(testing.suiteName(), function() {
     route: '/test-dyn-auth-no-authorize',
     name: 'testDynNoAuth',
     scopes: { AllOf: [{ for: 'scope', in: 'scopes', each: '<scope>' }] },
-    handler: async (req, res) => {
+    handler: async (_req, res) => {
       return res.reply({});
     },
     tests: [

--- a/libraries/api/test/compression_test.js
+++ b/libraries/api/test/compression_test.js
@@ -28,7 +28,7 @@ suite(testing.suiteName(), () => {
     category: 'API Library',
     stability: APIBuilder.stability.stable,
     description: 'Returns a large JSON payload',
-  }, (req, res) => {
+  }, (_req, res) => {
     res.reply({ data: 'x'.repeat(2000) });
   });
 
@@ -42,7 +42,7 @@ suite(testing.suiteName(), () => {
     category: 'API Library',
     stability: APIBuilder.stability.stable,
     description: 'Returns a small JSON payload',
-  }, (req, res) => {
+  }, (_req, res) => {
     res.reply({ ok: true });
   });
 
@@ -58,7 +58,7 @@ suite(testing.suiteName(), () => {
     category: 'API Library',
     stability: APIBuilder.stability.stable,
     description: 'Returns a pre-gzipped payload',
-  }, (req, res) => {
+  }, (_req, res) => {
     const payload = Buffer.from('y'.repeat(2000));
     const gzipped = gzipSync(payload);
     res.set('Content-Type', 'application/json');

--- a/libraries/api/test/context_test.js
+++ b/libraries/api/test/context_test.js
@@ -40,7 +40,7 @@ suite(testing.suiteName(), () => {
       title: 'Test End-Point',
       category: 'API Library',
       description: 'Place we can call to test something',
-    }, function(req, res) {
+    }, function(_req, res) {
       res.status(200).json({ myProp: this.myProp });
     });
 
@@ -186,7 +186,7 @@ suite(testing.suiteName(), () => {
       title: 'Test End-Point',
       category: 'API Library',
       description: 'Place we can call to test something',
-    }, function(req, res) {
+    }, function(_req, res) {
       res.status(200).json(this.foo());
     });
 

--- a/libraries/api/test/errors_test.js
+++ b/libraries/api/test/errors_test.js
@@ -35,13 +35,13 @@ suite(testing.suiteName(), () => {
     title: 'Test End-Point',
     category: 'API Library',
     description: 'Place we can call to test something',
-  }, (req, res) => {
+  }, (_req, res) => {
     res.reportError('InputError', 'Testing Error', { dee: 'tails' });
   });
 
   test('InputError response', async () => {
     const url = libUrls.api(helper.rootUrl, 'test', 'v1', '/inputerror');
-    return request.get(url).then(res => assert(false, 'should have failed!')).catch(res => {
+    return request.get(url).then(() => assert(false, 'should have failed!')).catch(res => {
       if (!res.status) {
         throw res;
       }
@@ -76,7 +76,7 @@ suite(testing.suiteName(), () => {
 
   test('TooManyFoos response', async () => {
     const url = libUrls.api(helper.rootUrl, 'test', 'v1', '/toomanyfoos');
-    return request.get(url).then(res => assert(false, 'should have failed!')).catch(res => {
+    return request.get(url).then(() => assert(false, 'should have failed!')).catch(res => {
       assert(res.status === 472);
       const response = JSON.parse(res.response.text);
       response.message = response.message.replace(response.requestInfo.time, '<nowish>');
@@ -116,13 +116,13 @@ suite(testing.suiteName(), () => {
     category: 'API Library',
     description: 'Place we can call to test something',
     scopes: null,
-  }, (req, res) => {
+  }, (_req, _res) => {
     throw new Error('uhoh');
   });
 
   test('ISE response', async () => {
     const url = libUrls.api(helper.rootUrl, 'test', 'v1', '/ISE');
-    return request.get(url).then(res => assert(false, 'should have failed!')).catch(res => {
+    return request.get(url).then(() => assert(false, 'should have failed!')).catch(res => {
       assert(res.status === 500);
       const response = JSON.parse(res.response.text);
       assert(response.code === 'InternalServerError');
@@ -150,13 +150,13 @@ suite(testing.suiteName(), () => {
       return payload;
     },
     scopes: null,
-  }, (req, res) => {
+  }, (_req, _res) => {
   });
 
   test('InputValidationError response', async () => {
     const url = libUrls.api(helper.rootUrl, 'test', 'v1', '/inputvalidationerror');
     return request.post(url).send({ invalid: 'yep', secret: 's3kr!t' })
-      .then(res => assert(false, 'should have failed!'))
+      .then(() => assert(false, 'should have failed!'))
       .catch(res => {
         assert.equal(res.status, 400);
         const response = JSON.parse(res.response.text);

--- a/libraries/api/test/logging_test.js
+++ b/libraries/api/test/logging_test.js
@@ -36,7 +36,7 @@ suite(testing.suiteName(), () => {
         { AllOf: ['bb', 'dd'] },
       ],
     },
-  }, (req, res) => {
+  }, (_req, res) => {
     res.reply({});
   });
 
@@ -48,7 +48,7 @@ suite(testing.suiteName(), () => {
     category: 'API Library',
     description: 'Place we can call to test something',
     scopes: null,
-  }, (req, res) => {
+  }, (_req, res) => {
     res.reply({});
   });
 
@@ -79,7 +79,7 @@ suite(testing.suiteName(), () => {
     category: 'API Library',
     description: 'Place we can call to test something',
     scopes: 'XXXX',
-  }, (req, res) => {
+  }, (_req, res) => {
     res.reply({});
   });
 
@@ -94,7 +94,7 @@ suite(testing.suiteName(), () => {
     title: 'Bewit having endpoint',
     description: 'Place we can call to test something',
     scopes: null,
-  }, (req, res) => {
+  }, (_req, res) => {
     res.reply({});
   });
 

--- a/libraries/api/test/responsetimer_test.js
+++ b/libraries/api/test/responsetimer_test.js
@@ -59,8 +59,8 @@ suite(testing.suiteName(), () => {
     const u = path => libUrls.api(helper.rootUrl, 'test', 'v1', path);
     await request.get(u('/single-param/Hello'));
     await request.get(u('/single-param/Goodbye'));
-    await request.get(u('/slash-param/Slash')).catch(err => {});
-    await request.get(u('/another-param/Another')).catch(err => {});
+    await request.get(u('/slash-param/Slash')).catch(() => {});
+    await request.get(u('/another-param/Another')).catch(() => {});
     assert.equal(monitorManager.messages.length, 4);
     monitorManager.messages.forEach(event => {
       assert.equal(event.Type, 'monitor.apiMethod');

--- a/libraries/api/test/route_test.js
+++ b/libraries/api/test/route_test.js
@@ -234,7 +234,7 @@ suite(testing.suiteName(), () => {
     return request
       .get(url)
       .query({ nextPage: 'abc' })
-      .then(res => assert(false, 'should have failed!'))
+      .then(() => assert(false, 'should have failed!'))
       .catch((res) => {
         assert(!res.ok, 'Expected request failure!');
         assert(res.status === 400, 'Expected a 400 error');
@@ -257,7 +257,7 @@ suite(testing.suiteName(), () => {
     return request
       .get(url)
       .query({ incantation: 'alohomora' })
-      .then(res => assert(false, 'should have failed!'))
+      .then(() => assert(false, 'should have failed!'))
       .catch((res) => {
         assert(!res.ok, 'Expected request failure!');
         assert(res.status === 400, 'Expected a 400 error');
@@ -289,7 +289,7 @@ suite(testing.suiteName(), () => {
     const url = u('/validated-param/-');
     return request
       .get(url)
-      .then(res => assert(false, 'should have failed!'))
+      .then(() => assert(false, 'should have failed!'))
       .catch((res) => {
         assert(!res.ok, 'Expected a failure');
         assert(res.status === 400, 'Expected a 400 error');
@@ -310,7 +310,7 @@ suite(testing.suiteName(), () => {
     const url = u('/validated-param-2/incorrect');
     return request
       .get(url)
-      .then(res => assert(false, 'should have failed!'))
+      .then(() => assert(false, 'should have failed!'))
       .catch((res) => {
         assert(!res.ok, 'Expected a failure');
         assert(res.status === 400, 'Expected a 400 error');
@@ -331,7 +331,7 @@ suite(testing.suiteName(), () => {
     const url = u('/function-validated-param/open-amaranth');
     return request
       .get(url)
-      .then(res => assert(false, 'should have failed!'))
+      .then(() => assert(false, 'should have failed!'))
       .catch((res) => {
         assert(!res.ok, 'Expected request failure!');
         assert(res.status === 400, 'Expected a 400 error');
@@ -363,7 +363,7 @@ suite(testing.suiteName(), () => {
     const url = u('/unknown');
     return request
       .get(url)
-      .then(res => assert(false, 'should have failed!'))
+      .then(() => assert(false, 'should have failed!'))
       .catch((err) => {
         assert(err.response.header['cache-control'] === 'no-store no-cache must-revalidate', 'Got wrong header');
       });
@@ -390,7 +390,7 @@ suite(testing.suiteName(), () => {
       title: 'Test',
       category: 'API Library',
       description: 'Test',
-    }, (req, res) => {});
+    }, (_req, _res) => {});
 
     assert.throws(() => {
       builder.declare({
@@ -401,7 +401,7 @@ suite(testing.suiteName(), () => {
         title: 'Test',
         category: 'API Library',
         description: 'Test',
-      }, (req, res) => {});
+      }, (_req, _res) => {});
     }, /Identical route and method/);
   });
 

--- a/libraries/api/test/scopes_test.js
+++ b/libraries/api/test/scopes_test.js
@@ -21,7 +21,7 @@ suite(testing.suiteName(), () => {
       category: 'API Library',
       title: 'Test',
       description: 'Test',
-    }, (req, res) => {});
+    }, (_req, _res) => {});
   });
 
   test('string scope works', () => {
@@ -33,7 +33,7 @@ suite(testing.suiteName(), () => {
       category: 'API Library',
       title: 'Test',
       description: 'Test',
-    }, (req, res) => {});
+    }, (_req, _res) => {});
   });
 
   test('array of string scope rejected', () => {
@@ -46,7 +46,7 @@ suite(testing.suiteName(), () => {
         category: 'API Library',
         title: 'Test',
         description: 'Test',
-      }, (req, res) => {});
+      }, (_req, _res) => {});
     }, /Invalid scope expression/);
   });
 
@@ -60,7 +60,7 @@ suite(testing.suiteName(), () => {
         category: 'API Library',
         title: 'Test',
         description: 'Test',
-      }, (req, res) => {});
+      }, (_req, _res) => {});
     }, /Invalid scope expression/);
   });
 
@@ -73,7 +73,7 @@ suite(testing.suiteName(), () => {
       category: 'API Library',
       title: 'Test',
       description: 'Test',
-    }, (req, res) => {});
+    }, (_req, _res) => {});
   });
 
   test('scope expression with looping template not rejected', () => {
@@ -85,6 +85,6 @@ suite(testing.suiteName(), () => {
       category: 'API Library',
       title: 'Test',
       description: 'Test',
-    }, (req, res) => {});
+    }, (_req, _res) => {});
   });
 });

--- a/libraries/api/test/validate_test.js
+++ b/libraries/api/test/validate_test.js
@@ -37,7 +37,7 @@ suite(testing.suiteName(), () => {
     title: 'Test End-Point',
     category: 'API Library',
     description: 'Place we can call to test something',
-  }, (req, res) => {
+  }, (_req, res) => {
     res.status(200).send('Hello World');
   });
 
@@ -51,7 +51,7 @@ suite(testing.suiteName(), () => {
     title: 'Test End-Point',
     category: 'API Library',
     description: 'Place we can call to test something',
-  }, (req, res) => {
+  }, (_req, res) => {
     res.reply({ value: 4 });
   });
 
@@ -65,7 +65,7 @@ suite(testing.suiteName(), () => {
     title: 'Test End-Point',
     category: 'API Library',
     description: 'Place we can call to test something',
-  }, (req, res) => {
+  }, (_req, res) => {
     res.reply({ value: 12 });
   });
 
@@ -80,7 +80,7 @@ suite(testing.suiteName(), () => {
     title: 'Test End-Point',
     category: 'API Library',
     description: 'Place we can call to test something',
-  }, (req, res) => {
+  }, (_req, res) => {
     res.status(200).send('Hello World');
   });
 
@@ -95,7 +95,7 @@ suite(testing.suiteName(), () => {
     category: 'API Library',
     title: 'Test End-Point',
     description: 'Place we can call to test something',
-  }, (req, res) => {
+  }, (_req, res) => {
     res.reply({ value: 12 });
   });
 
@@ -109,7 +109,7 @@ suite(testing.suiteName(), () => {
     title: 'Test End-Point',
     category: 'API Library',
     description: 'Place we can call to test something',
-  }, (req, res) => {
+  }, (_req, res) => {
     res.reply({ value: 'Hello World' });
   });
 
@@ -122,7 +122,7 @@ suite(testing.suiteName(), () => {
     title: 'Test End-Point',
     category: 'API Library',
     description: 'Place we can call to test something',
-  }, (req, res) => {
+  }, (_req, res) => {
     res.reply();
   });
 
@@ -135,7 +135,7 @@ suite(testing.suiteName(), () => {
     title: 'Test End-Point',
     category: 'API Library',
     description: 'Place we can call to test something',
-  }, (req, res) => {
+  }, (_req, res) => {
     res.reply();
   });
 
@@ -148,7 +148,7 @@ suite(testing.suiteName(), () => {
     category: 'API Library',
     title: 'Test End-Point',
     description: 'place to call to trigger a double send',
-  }, (req, res) => {
+  }, (_req, res) => {
     res.status(400).json({ error: 'yep' });
     res.status(200).reply({ value: 1 });
   });
@@ -162,7 +162,7 @@ suite(testing.suiteName(), () => {
     category: 'API Library',
     title: 'Test End-Point',
     description: 'place to call to trigger a double send',
-  }, (req, res) => {
+  }, (_req, res) => {
     res.status(400).reply({ value: 1 });
     res.reportError('InputError', 'uhoh', {});
   });
@@ -185,7 +185,7 @@ suite(testing.suiteName(), () => {
     return request
       .post(url)
       .send({ value: 11 })
-      .then(res => assert(false, 'should have failed!'))
+      .then(() => assert(false, 'should have failed!'))
       .catch((err) => {
         assert(err.status === 400, 'Request wasn\'t rejected');
       });
@@ -207,7 +207,7 @@ suite(testing.suiteName(), () => {
     const url = u('/test-invalid-output');
     return request
       .get(url)
-      .then(res => assert(false, 'should have failed!'))
+      .then(() => assert(false, 'should have failed!'))
       .catch((err) => {
         assert.equal(err.status, 500);
         // the HTTP error should not contain details
@@ -268,7 +268,7 @@ suite(testing.suiteName(), () => {
       .post(url)
       .send(JSON.stringify({ value: 5 }))
       .set('content-type', 'text/x-json')
-      .then(res => assert(false, 'should have failed!'))
+      .then(() => assert(false, 'should have failed!'))
       .catch((err) => {
         assert(err.status === 400, 'Request wasn\'t rejected');
       });
@@ -289,7 +289,7 @@ suite(testing.suiteName(), () => {
     const url = u('/test-res-reply-post');
     return request
       .post(url)
-      .then((res) => {
+      .then((_res) => {
         assert(false, 'Request validation failed');
       }).catch((err) => {
         assert.equal(err.status, 500);
@@ -317,7 +317,7 @@ suite(testing.suiteName(), () => {
       category: 'API Library',
       title: 'Test End-Point',
       description: '..',
-    }, (req, res) => {});
+    }, (_req, _res) => {});
 
     const schemaset = new SchemaSet({
       serviceName: 'test',

--- a/libraries/app/src/index.js
+++ b/libraries/app/src/index.js
@@ -41,7 +41,7 @@ let listenersAdded = false;
  */
 const createServer = function() {
   // 404 Error handler
-  this.use((req, res, next) => {
+  this.use((_req, res, _next) => {
     res.setHeader('Content-Type', 'application/json');
     res.status(404).json({ error: 'Not found' });
   });
@@ -93,7 +93,7 @@ const createServer = function() {
         res.on('finish', () => req.socket.destroy());
       });
 
-      return new Promise((accept, reject) => {
+      return new Promise((accept, _reject) => {
         server.close(accept);
         // force-close all open connections so the port is released immediately;
         // called after server.close per Node.js docs to avoid race conditions
@@ -198,7 +198,7 @@ export const App = async (options) => {
 
   // keep cheap security vuln scanners happy..
   app.disable('x-powered-by');
-  app.use((req, res, next) => {
+  app.use((_req, res, next) => {
     res.setHeader('x-content-type-options', 'nosniff');
     next();
   });
@@ -207,7 +207,7 @@ export const App = async (options) => {
   app.use(traceMiddleware);
 
   if (options.robotsTxt) {
-    app.use('/robots.txt', (req, res) => {
+    app.use('/robots.txt', (_req, res) => {
       res.header('Content-Type', 'text/plain');
       res.send('User-Agent: *\nDisallow: /\n');
     });
@@ -215,12 +215,12 @@ export const App = async (options) => {
 
   try {
     const taskclusterVersion = await loadVersion();
-    app.use('/__version__', (req, res) => {
+    app.use('/__version__', (_req, res) => {
       res.header('Content-Type', 'application/json');
       res.send(taskclusterVersion);
     });
   } catch {
-    app.use('/__version__', (req, res) => {
+    app.use('/__version__', (_req, res) => {
       res.header('Content-Type', 'application/json');
       res.status(500).send({ error: 'Not found' });
     });
@@ -228,12 +228,12 @@ export const App = async (options) => {
 
   // TODO: heartbeat endpoint should verify all dependent taskcluster services
   // captured in https://github.com/taskcluster/taskcluster/issues/4597
-  app.use('/__heartbeat__', (req, res) => {
+  app.use('/__heartbeat__', (_req, res) => {
     res.header('Content-Type', 'application/json');
     res.status(200).send({});
   });
 
-  app.use('/__lbheartbeat__', (req, res) => {
+  app.use('/__lbheartbeat__', (_req, res) => {
     res.header('Content-Type', 'application/json');
     res.status(200).send({});
   });

--- a/libraries/app/test/app_test.js
+++ b/libraries/app/test/app_test.js
@@ -25,7 +25,7 @@ suite(testing.suiteName(), () => {
       const fakeApi = {
         express(app) {
           const router = express.Router();
-          router.get('/test', (req, res) => {
+          router.get('/test', (_req, res) => {
             res.status(200).send('Okay this works');
           });
           router.get('/req-id', (req, res) => {

--- a/libraries/app/test/bin/app.js
+++ b/libraries/app/test/bin/app.js
@@ -17,12 +17,12 @@ const launch = () => {
   });
 
   // Respond 'Hello World' for /test
-  app.get('/test', (req, res) => {
+  app.get('/test', (_req, res) => {
     res.status(200).send('Hello World');
   });
 
   // Respond request count in process for /request-count
-  app.get('/request-count', (req, res) => {
+  app.get('/request-count', (_req, res) => {
     global_state += 1;
     res.status(200).send(`Count: ${global_state}`);
   });

--- a/libraries/config/src/schema.js
+++ b/libraries/config/src/schema.js
@@ -5,7 +5,7 @@ import yaml from 'js-yaml';
 /*
  * Create a YAML type that loads from environment variable
  */
-const createType = (env, vars, basename, typeName, deserialize) => {
+const createType = (env, vars, basename, _typeName, deserialize) => {
   return [basename, `${basename}:secret`, `${basename}:optional`, `${basename}:secret:optional`].map(name => {
     return new yaml.Type(name, {
       kind: 'scalar', // Takes a string as input

--- a/libraries/iterate/src/index.js
+++ b/libraries/iterate/src/index.js
@@ -88,7 +88,7 @@ class Iterate extends events.EventEmitter {
 
     // build a promise that will reject when either the watchdog
     // times out or the maxIterationTimeTimer expires
-    const timeoutRejector = new Promise((resolve, reject) => {
+    const timeoutRejector = new Promise((_resolve, reject) => {
       watchdog.on('expired', () => {
         debug('watchdog expired');
         reject(new Error('watchdog exceeded'));

--- a/libraries/iterate/test/iterate_test.js
+++ b/libraries/iterate/test/iterate_test.js
@@ -79,7 +79,7 @@ suite(testing.suiteName(), () => {
       maxIterationTime: 3000,
       waitTime: 1000,
       watchDog: 0,
-      handler: async watchdog => {
+      handler: async _watchdog => {
         debug('iterate!');
         iterations++;
         return 1;
@@ -113,7 +113,7 @@ suite(testing.suiteName(), () => {
       waitTime: 10,
       maxIterations: 5,
       watchDog: 0,
-      handler: async watchdog => {
+      handler: async _watchdog => {
         await testing.sleep(500);
       },
     });
@@ -135,7 +135,7 @@ suite(testing.suiteName(), () => {
       waitTime: 1000,
       maxIterations: 2,
       watchDog: 0,
-      handler: async watchdog => {
+      handler: async _watchdog => {
         await testing.sleep(500);
       },
     });
@@ -157,7 +157,7 @@ suite(testing.suiteName(), () => {
       waitTime: 10,
       maxIterations: 5,
       watchDog: 0,
-      handler: async watchdog => {
+      handler: async _watchdog => {
         debug('iterate!');
         iterations++;
         return 1;
@@ -182,7 +182,7 @@ suite(testing.suiteName(), () => {
       watchdogTime: 1000,
       waitTime: 1000,
       maxFailures: 1,
-      handler: async watchdog => {
+      handler: async _watchdog => {
         return testing.sleep(2000);
       },
     });
@@ -207,7 +207,7 @@ suite(testing.suiteName(), () => {
       maxFailures: 1,
       handler: async watchdog => {
         watchdog.stop();
-        return new Promise((res, rej) => {
+        return new Promise((res, _rej) => {
           setTimeout(() => {
             return res();
           }, 5000);
@@ -233,7 +233,7 @@ suite(testing.suiteName(), () => {
       maxIterationTime: 1000,
       waitTime: 1000,
       maxFailures: 100,
-      handler: async watchdog => {
+      handler: async _watchdog => {
         throw new Error('uhoh');
       },
     });
@@ -256,7 +256,7 @@ suite(testing.suiteName(), () => {
       maxIterationTime: 1000,
       waitTime: 1000,
       maxFailures: 100,
-      handler: watchdog => {
+      handler: _watchdog => {
         throw new Error('uhoh');
       },
     });
@@ -280,7 +280,7 @@ suite(testing.suiteName(), () => {
       minIterationTime: 10000,
       waitTime: 1000,
       watchDog: 0,
-      handler: async watchdog => {
+      handler: async _watchdog => {
         await testing.sleep(100);
       },
     });
@@ -302,7 +302,7 @@ suite(testing.suiteName(), () => {
       maxIterationTime: 12000,
       maxFailures: 1,
       waitTime: 1000,
-      handler: async watchdog => {
+      handler: async _watchdog => {
         throw new Error('uhoh');
       },
     });
@@ -324,7 +324,7 @@ suite(testing.suiteName(), () => {
       monitor,
       maxIterationTime: 3000,
       waitTime: 1000,
-      handler: async watchdog => {
+      handler: async _watchdog => {
         debug('iterate!');
       },
     });
@@ -350,7 +350,7 @@ suite(testing.suiteName(), () => {
       maxIterationTime: 3000,
       maxIterations: 1,
       waitTime: 1000,
-      handler: async watchdog => {
+      handler: async _watchdog => {
         debug('iterate!');
       },
     });
@@ -380,7 +380,7 @@ suite(testing.suiteName(), () => {
         maxIterations: 1,
         maxFailures: 1,
         waitTime: 1000,
-        handler: async watchdog => {
+        handler: async _watchdog => {
           debug('iterate!');
           throw new Error('hi');
         },
@@ -408,7 +408,7 @@ suite(testing.suiteName(), () => {
         maxIterationTime: 3000,
         maxFailures: 1,
         waitTime: 1000,
-        handler: async watchdog => {
+        handler: async _watchdog => {
           debug('iterate!');
           throw new Error('hi');
         },
@@ -437,7 +437,7 @@ suite(testing.suiteName(), () => {
         minIterationTime: 100000,
         maxFailures: 1,
         waitTime: 1000,
-        handler: async watchdog => {
+        handler: async _watchdog => {
           return true;
         },
       });
@@ -465,7 +465,7 @@ suite(testing.suiteName(), () => {
         maxFailures: 1,
         watchdogTime: 100,
         waitTime: 1000,
-        handler: async watchdog => {
+        handler: async _watchdog => {
           await testing.sleep(3000);
         },
       });
@@ -492,7 +492,7 @@ suite(testing.suiteName(), () => {
         maxIterationTime: 3000,
         maxFailures: 1,
         waitTime: 1000,
-        handler: async watchdog => {
+        handler: async _watchdog => {
           await testing.sleep(6000);
         },
       });
@@ -522,7 +522,7 @@ suite(testing.suiteName(), () => {
         maxIterations: 6,
         maxFailures: 5,
         waitTime: 1000,
-        handler: async watchdog=> {
+        handler: async _watchdog=> {
           if (iterations++ % 2 === 0) {
             throw new Error('even, so failing');
           } else {

--- a/libraries/monitor/src/monitor.js
+++ b/libraries/monitor/src/monitor.js
@@ -403,7 +403,7 @@ class Monitor {
     await this._exit(1);
   }
 
-  async _unhandledRejectionHandler(reason, p) {
+  async _unhandledRejectionHandler(reason, _p) {
     this.reportError(reason);
     if (!this.bailOnUnhandledRejection) {
       return;
@@ -423,7 +423,7 @@ class Monitor {
    * OS-level usage statistics like CPU and Memory
    * on a minute-by-minute basis.
    */
-  _resources(procName, interval) {
+  _resources(_procName, interval) {
     if (this._resourceInterval) {
       clearInterval(this._resourceInterval);
     }

--- a/libraries/monitor/src/monitormanager.js
+++ b/libraries/monitor/src/monitormanager.js
@@ -278,7 +278,7 @@ export class MonitorManager {
     } else if (fake || debug) {
       manager.messages = [];
       manager.destination = new stream.Writable({
-        write: (chunk, encoding, next) => {
+        write: (chunk, _encoding, next) => {
           manager._handleMessage(JSON.parse(chunk));
           next();
         },
@@ -392,7 +392,7 @@ export class MonitorManager {
    * Handle a message from any logger. This is only used in testing
    * and development.
    */
-  _handleMessage({ Type, Fields, Logger, Severity, severity, message }) {
+  _handleMessage({ Type, Fields, Logger, Severity, message }) {
     if (this.fake) {
       this.messages.push({ Type, Fields, Logger, Severity });
     }

--- a/libraries/monitor/src/plugins/testreporter.js
+++ b/libraries/monitor/src/plugins/testreporter.js
@@ -7,14 +7,14 @@ export class TestReporter {
     this.log = log;
   }
 
-  report(error, level, extra) {
+  report(error, _level, _extra) {
     this.internal.push(error);
     return slugid.v4();
   }
 
   // Try to simulate this needing to be awaited
   async flush() {
-    await new Promise((accept, reject) => {
+    await new Promise((accept, _reject) => {
       setTimeout(accept, 500);
     });
     this.internal.forEach(e => {

--- a/libraries/monitor/test/logger_test.js
+++ b/libraries/monitor/test/logger_test.js
@@ -54,7 +54,7 @@ suite(testing.suiteName(), () => {
   test('logger separates lines with newlines', () => {
     let results = Buffer.alloc(0);
     const destination = new stream.Writable({
-      write: (chunk, encoding, next) => {
+      write: (chunk, _encoding, next) => {
         results = Buffer.concat([results, chunk]);
         next();
       },

--- a/libraries/postgres/src/Database.js
+++ b/libraries/postgres/src/Database.js
@@ -570,7 +570,7 @@ class Database {
       //
       // So Pool will handle those errors properly, and we must only register an
       // handler so that Node does not complain of an unhandled error event.
-      pool.on('error', client => {});
+      pool.on('error', () => {});
       pool.on('connect', async client => {
         if (statementTimeout) {
           // For web API servers, we want to abort queries that take too long, sa

--- a/libraries/postgres/test/database_test.js
+++ b/libraries/postgres/test/database_test.js
@@ -573,7 +573,7 @@ helper.dbSuite(path.basename(__filename), () => {
     });
 
     test('decrypt multi-chunk from lib-entities', async () => {
-      const content = new Array(50000).fill(0).map((v, i) => String.fromCharCode(i % 65535)).join('');
+      const content = new Array(50000).fill(0).map((_v, i) => String.fromCharCode(i % 65535)).join('');
 
       // generated with:
       //  const entity = Entity.types.EncryptedText('val');

--- a/libraries/postgres/test/migration_test.js
+++ b/libraries/postgres/test/migration_test.js
@@ -325,7 +325,7 @@ helper.dbSuite(path.basename(__filename), () => {
 
     test('batch function that just does one item per iteration', testing.runWithFakeTime(async () => {
       let itemsComplete = 0;
-      runOnlineBatches.setHook('runBatch', async (batchSize, state) => {
+      runOnlineBatches.setHook('runBatch', async (_batchSize, state) => {
         if (itemsComplete >= 1000) {
           return { state, count: 0 };
         }
@@ -343,7 +343,7 @@ helper.dbSuite(path.basename(__filename), () => {
     test('batch function that returns 0 items early', testing.runWithFakeTime(async () => {
       let itemsComplete = 0;
       let isCompleteCalls = 0;
-      runOnlineBatches.setHook('runBatch', async (batchSize, state) => {
+      runOnlineBatches.setHook('runBatch', async (_batchSize, state) => {
         state.counter = (state.counter || 0) + 1;
         if (state.counter === 100 || itemsComplete >= 1000) {
           // this will trigger an isComplete call, and if not complete, starts over with

--- a/libraries/postgres/test/util_test.js
+++ b/libraries/postgres/test/util_test.js
@@ -36,7 +36,7 @@ suite(path.basename(__filename), () => {
       });
 
       test('batch size smaller than requested', async () => {
-        const fetch = async (size, offset) => {
+        const fetch = async (_size, offset) => {
           return range(1000).slice(offset, offset + 10);
         };
 
@@ -49,7 +49,7 @@ suite(path.basename(__filename), () => {
       });
 
       test('fetch fails', async () => {
-        const fetch = async (size, offset) => {
+        const fetch = async (_size, offset) => {
           if (offset > 300) {
             throw new Error('oh noes');
           }

--- a/libraries/pulse/src/client.js
+++ b/libraries/pulse/src/client.js
@@ -363,7 +363,7 @@ export class Connection extends events.EventEmitter {
         }
       });
 
-      amqp.on('close', err => {
+      amqp.on('close', () => {
         if (this.state === 'connected') {
           this.monitor.log.pulseDisconnected({ error: 'connection closed unexpectedly' });
           this.failed();
@@ -402,7 +402,7 @@ export class Connection extends events.EventEmitter {
     setTimeout(() => {
       if (this.amqp) {
         // ignore errors in close
-        this.amqp.close().catch(err => {});
+        this.amqp.close().catch(() => {});
       }
       this.amqp = null;
       this.state = 'finished';

--- a/libraries/pulse/test/client_test.js
+++ b/libraries/pulse/test/client_test.js
@@ -177,7 +177,7 @@ helper.secrets.mockSuite(suiteName(), ['pulse'], (mock, skipping) => {
 
     let gotConnection = false;
     let finishedWithConnection = false;
-    client.withConnection(conn => { gotConnection = true; })
+    client.withConnection(() => { gotConnection = true; })
       .then(() => { finishedWithConnection = true; });
 
     assume(finishedWithConnection).to.equal(false);
@@ -238,7 +238,7 @@ helper.secrets.mockSuite(suiteName(), ['pulse'], (mock, skipping) => {
 
       let gotException;
       try {
-        await client.withChannel(async chan => {
+        await client.withChannel(async () => {
           // throw an error to exercise error-handling code
           throw new Error('uhoh');
         });

--- a/libraries/pulse/test/consumer_test.js
+++ b/libraries/pulse/test/consumer_test.js
@@ -7,7 +7,7 @@ import assert from 'node:assert';
 import helper from './helper.js';
 import { suiteName } from '@taskcluster/lib-testing';
 
-helper.secrets.mockSuite(suiteName(), ['pulse'], (mock, skipping) => {
+helper.secrets.mockSuite(suiteName(), ['pulse'], (mock, _skipping) => {
   if (mock) {
     return; // Only test with real creds
   }
@@ -56,7 +56,7 @@ helper.secrets.mockSuite(suiteName(), ['pulse'], (mock, skipping) => {
 
     // wait until the pq stops
     const waitUntilStopped = pq => {
-      return new Promise((resolve, reject) => {
+      return new Promise((resolve, _reject) => {
         pq._stoppedCallback = resolve;
       });
     };

--- a/libraries/pulse/test/publisher_test.js
+++ b/libraries/pulse/test/publisher_test.js
@@ -10,7 +10,7 @@ import { suiteName, poll } from '@taskcluster/lib-testing';
 
 const __dirname = new URL('.', import.meta.url).pathname;
 
-helper.secrets.mockSuite(suiteName(), ['pulse'], (mock, skipping) => {
+helper.secrets.mockSuite(suiteName(), ['pulse'], (mock, _skipping) => {
   if (mock) {
     return; // Only test with real creds
   }
@@ -38,7 +38,7 @@ helper.secrets.mockSuite(suiteName(), ['pulse'], (mock, skipping) => {
     }],
     messageBuilder: msg => msg,
     routingKeyBuilder: msg => msg,
-    CCBuilder: msg => [],
+    CCBuilder: () => [],
   };
 
   const declarationConstant = {
@@ -56,7 +56,7 @@ helper.secrets.mockSuite(suiteName(), ['pulse'], (mock, skipping) => {
     }],
     messageBuilder: msg => msg,
     routingKeyBuilder: msg => msg,
-    CCBuilder: msg => [],
+    CCBuilder: () => [],
   };
 
   const monitor = helper.monitor;

--- a/libraries/references/src/serializable.js
+++ b/libraries/references/src/serializable.js
@@ -13,7 +13,7 @@ export const makeSerializable = ({ references }) => {
     return `references/${serviceName}/${apiVersion || 'v1'}/${kind}.json`;
   };
 
-  const namedReferences = references.references.map(({ filename, content }) => ({
+  const namedReferences = references.references.map(({ content }) => ({
     content,
     filename: referenceFilename(content),
   }));
@@ -26,7 +26,7 @@ export const makeSerializable = ({ references }) => {
   }
   const schemaFilename = content => content.$id.replace(urlPattern, 'schemas/$1');
 
-  const namedSchemas = references.schemas.map(({ filename, content }) => ({
+  const namedSchemas = references.schemas.map(({ content }) => ({
     content,
     filename: schemaFilename(content),
   }));

--- a/libraries/references/src/validate.js
+++ b/libraries/references/src/validate.js
@@ -294,7 +294,7 @@ export const validate = (references) => {
       seen.add(schemaDoc);
       const schema = references.getSchema(schemaId, { skipValidation: true });
 
-      forAllRefs(schema, (ref, path) => {
+      forAllRefs(schema, (ref, _path) => {
         const refId = new URL(ref, schemaId).toString();
         recurse(refId);
       });

--- a/libraries/references/test/common-schemas_test.js
+++ b/libraries/references/test/common-schemas_test.js
@@ -6,8 +6,8 @@ suite(testing.suiteName(), () => {
   test('loads common schemas', async () => {
     const schemas = await getCommonSchemas();
     assert(schemas.some(
-      ({ content, filename }) => content.$id === '/schemas/common/api-reference-v0.json#'));
+      ({ content }) => content.$id === '/schemas/common/api-reference-v0.json#'));
     assert(schemas.some(
-      ({ content, filename }) => filename === 'schemas/metadata-metaschema.yml'));
+      ({ filename }) => filename === 'schemas/metadata-metaschema.yml'));
   });
 });

--- a/libraries/testing/src/fakeauth.js
+++ b/libraries/testing/src/fakeauth.js
@@ -16,7 +16,7 @@ export const start = (clients, { rootUrl } = {}) => {
     .persist()
     .filteringRequestBody(/.*/, '*')
     .post(authPath, '*')
-    .reply(200, (uri, body) => {
+    .reply(200, (_uri, body) => {
       let scopes = [];
       let from = 'client config';
       let ext = null;

--- a/libraries/testing/src/with-db.js
+++ b/libraries/testing/src/with-db.js
@@ -61,7 +61,7 @@ export const resetTables = async ({ tableNames }) => {
  *
  * It's up to the caller to set up and clear any data between test cases.
  */
-export const withDb = (mock, skipping, helper, serviceName) => {
+export const withDb = (_mock, skipping, helper, serviceName) => {
   assert(testDbUrl,
     "TEST_DB_URL must be set to run these tests - see dev-docs/development-process.md for more information");
 

--- a/libraries/testing/src/with-pulse.js
+++ b/libraries/testing/src/with-pulse.js
@@ -147,7 +147,7 @@ class FakeClient {
 }
 
 class FakePulseConsumer {
-  constructor({ client, bindings, queueName, prefetch, ephemeral, onConnected, handleMessage, ...queueOptions }) {
+  constructor({ client, bindings, queueName, ephemeral, onConnected, handleMessage }) {
     assert(handleMessage, 'Must provide a message handler function');
 
     this.client = client;

--- a/libraries/testing/test/secrets_test.js
+++ b/libraries/testing/test/secrets_test.js
@@ -209,7 +209,7 @@ suite(suiteName(), () => {
     suiteSetup(() => {
       nock('http://proxy')
         .get('/api/secrets/v1/secret/path%2Fto%2Fsecret')
-        .reply(200, (uri, requestBody) => {
+        .reply(200, (_uri, _requestBody) => {
           return { secret: { SECRET_VALUE: '13' } };
         });
     });

--- a/libraries/validate/src/util.js
+++ b/libraries/validate/src/util.js
@@ -35,7 +35,7 @@ export function renderConstants(schema, constants) {
  * isn't foolproof: it will allow {$ref: '../../otherservice/v1/someschema.json'}.
  * But this is enough to dissuade users from inter-service linking.
  */
-export const checkRefs = (schema, serviceName) => {
+export const checkRefs = (schema, _serviceName) => {
   const check = val => {
     if (_.isObject(val)) {
       if (typeof val.$ref === 'string' && _.keys(val).length === 1) {

--- a/services/auth/src/api.js
+++ b/services/auth/src/api.js
@@ -783,7 +783,7 @@ builder.declare({
     '',
     'To get paginated results, use `listRoles2`.',
   ].join('\n'),
-}, async function(req, res) {
+}, async function(_req, res) {
   // Load all roles
   const roles = await this.db.fns.get_roles();
   res.reply(roles.map(r => roleToJson(r, this)));

--- a/services/auth/src/azure.js
+++ b/services/auth/src/azure.js
@@ -26,7 +26,7 @@ export const azureBuilder = builder => {
     description: [
       'Retrieve a list of all Azure accounts managed by Taskcluster Auth.',
     ].join('\n'),
-  }, function(req, res) {
+  }, function(_req, res) {
     return res.reply({ accounts: _.keys(getAzureAccounts(this)) });
   });
 

--- a/services/auth/src/exchanges.js
+++ b/services/auth/src/exchanges.js
@@ -22,7 +22,7 @@ const exchanges = new Exchanges({
 export default exchanges;
 
 /** Build routing key construct for `exchanges.declare` */
-const buildRoutingKey = (options) => {
+const buildRoutingKey = (_options) => {
   return [
     {
       name: 'reserved',

--- a/services/auth/src/main.js
+++ b/services/auth/src/main.js
@@ -69,15 +69,15 @@ const load = Loader({
   },
 
   schemaset: {
-    requires: ['cfg'],
-    setup: ({ cfg }) => new SchemaSet({
+    requires: [],
+    setup: () => new SchemaSet({
       serviceName: 'auth',
     }),
   },
 
   generateReferences: {
-    requires: ['cfg', 'schemaset'],
-    setup: async ({ cfg, schemaset }) => libReferences.fromService({
+    requires: ['schemaset'],
+    setup: async ({ schemaset }) => libReferences.fromService({
       schemaset,
       references: [builder.reference(), exchanges.reference(), MonitorManager.reference('auth'), MonitorManager.metricsReference('auth')],
     }).then(ref => ref.generateReferences()),
@@ -223,8 +223,8 @@ const load = Loader({
   },
 
   'purge-expired-clients': {
-    requires: ['cfg', 'db', 'monitor'],
-    setup: ({ cfg, db, monitor }, ownName) => {
+    requires: ['db', 'monitor'],
+    setup: ({ db, monitor }, ownName) => {
       return monitor.oneShot(ownName, async () => {
         debug('Purging expired clients');
         const records = await db.fns.expire_clients_return_client_ids();

--- a/services/auth/src/scoperesolver.js
+++ b/services/auth/src/scoperesolver.js
@@ -14,8 +14,8 @@ const ASSUME_PREFIX = /^(:?(:?|a|as|ass|assu|assum|assum|assume)\*$|assume:)/;
 
 /** ZeroCache is an LRU cache instance that contains nothing for caching is disabled */
 const ZeroCache = {
-  get: (k) => null,
-  set: (k, v) => null,
+  get: (_k) => null,
+  set: (_k, _v) => null,
 };
 
 class ScopeResolver extends events.EventEmitter {
@@ -136,7 +136,7 @@ class ScopeResolver extends events.EventEmitter {
       // no need for both _clientPq and _rolePq to call this.reload()
       // for the same reconnection..
       onConnected: () => {},
-      handleMessage: m => this.reloadRoles(),
+      handleMessage: () => this.reloadRoles(),
     });
   }
 

--- a/services/auth/src/sentrymanager.js
+++ b/services/auth/src/sentrymanager.js
@@ -235,11 +235,11 @@ class SentryManager {
 }
 
 class NullSentryManager {
-  async projectDSN(project) {
+  async projectDSN(_project) {
     return null;
   }
 
-  async purgeExpiredKeys(now) {
+  async purgeExpiredKeys(_now) {
     return 0;
   }
 }

--- a/services/auth/test/audit_history_test.js
+++ b/services/auth/test/audit_history_test.js
@@ -7,9 +7,9 @@ import taskcluster from '@taskcluster/client';
 helper.secrets.mockSuite('audit', ['gcp'], (mock, skipping) => {
   helper.withDb(mock, skipping);
   helper.withCfg(mock, skipping);
-  helper.withPulse(mock, skipping);
-  helper.withServers(mock, skipping);
-  helper.resetTables(mock, skipping);
+  helper.withPulse(skipping);
+  helper.withServers(skipping);
+  helper.resetTables();
 
   let clientId;
   clientId = slugid.v4();

--- a/services/auth/test/client_test.js
+++ b/services/auth/test/client_test.js
@@ -8,9 +8,9 @@ import taskcluster from '@taskcluster/client';
 helper.secrets.mockSuite(testing.suiteName(), ['azure', 'gcp'], (mock, skipping) => {
   helper.withDb(mock, skipping);
   helper.withCfg(mock, skipping);
-  helper.withPulse(mock, skipping);
-  helper.withServers(mock, skipping);
-  helper.resetTables(mock, skipping);
+  helper.withPulse(skipping);
+  helper.withServers(skipping);
+  helper.resetTables();
 
   const setAnonymousRole = async (...scopes) => {
     await helper.apiClient.createRole(
@@ -61,7 +61,7 @@ helper.secrets.mockSuite(testing.suiteName(), ['azure', 'gcp'], (mock, skipping)
     })).deleteClient(CLIENT_ID).then(() => {
       assert(false, 'Expected an error');
       helper.assertNoPulseMessage();
-    }, err => {
+    }, () => {
     });
   });
 
@@ -73,7 +73,7 @@ helper.secrets.mockSuite(testing.suiteName(), ['azure', 'gcp'], (mock, skipping)
     })).deleteClient(CLIENT_ID).then(() => {
       assert(false, 'Expected an error');
       helper.assertNoPulseMessage();
-    }, err => {
+    }, () => {
       // Expected error
     });
   });
@@ -387,7 +387,7 @@ helper.secrets.mockSuite(testing.suiteName(), ['azure', 'gcp'], (mock, skipping)
 
     await helper.apiClient.client(CLIENT_ID).then(() => {
       assert(false, 'Expected an error');
-    }, err => {
+    }, () => {
       // Expected error
     });
   });

--- a/services/auth/test/containers_test.js
+++ b/services/auth/test/containers_test.js
@@ -11,9 +11,9 @@ const sorted = (arr) => {
 helper.secrets.mockSuite(testing.suiteName(), ['azure', 'gcp'], (mock, skipping) => {
   helper.withDb(mock, skipping);
   helper.withCfg(mock, skipping);
-  helper.withPulse(mock, skipping);
-  helper.withServers(mock, skipping);
-  helper.resetTables(mock, skipping);
+  helper.withPulse(skipping);
+  helper.withServers(skipping);
+  helper.resetTables();
 
   test('get when blob is empty', async () => {
     assert.deepEqual(await helper.db.fns.get_roles(), []);

--- a/services/auth/test/gcp_test.js
+++ b/services/auth/test/gcp_test.js
@@ -6,9 +6,9 @@ helper.secrets.mockSuite(testing.suiteName(), ['gcp', 'azure'], (mock, skipping)
   helper.withCfg(mock, skipping);
   helper.withDb(mock, skipping);
   helper.withGcp(mock, skipping);
-  helper.withPulse(mock, skipping);
-  helper.withServers(mock, skipping);
-  helper.resetTables(mock, skipping);
+  helper.withPulse(skipping);
+  helper.withServers(skipping);
+  helper.resetTables();
 
   test('gcpCredentials invalid account', async () => {
     try {

--- a/services/auth/test/helper.js
+++ b/services/auth/test/helper.js
@@ -111,7 +111,7 @@ helper.withDb = (mock, skipping) => {
 /**
  * Setup a fake sentry
  */
-helper.withSentry = (mock, skipping) => {
+helper.withSentry = skipping => {
   const sentryOrgs = {};
   suiteSetup(async () => {
     if (skipping()) {
@@ -125,7 +125,7 @@ helper.withSentry = (mock, skipping) => {
         projects: org => Object.values(sentryOrgs[org]),
       },
       teams: {
-        createProject: (org, team, info) => {
+        createProject: (org, _team, info) => {
           if (!sentryOrgs[org]) {
             sentryOrgs[org] = {};
           }
@@ -162,7 +162,7 @@ helper.withSentry = (mock, skipping) => {
   });
 };
 
-helper.withPulse = (mock, skipping) => {
+helper.withPulse = skipping => {
   libTesting.withPulse({ helper, skipping, namespace: 'taskcluster-auth' });
 };
 
@@ -181,7 +181,7 @@ testServiceBuilder.declare({
   title: 'Get Resource',
   category: 'Auth Service',
   description: '...',
-}, (req, res) => {
+}, (_req, res) => {
   res.status(200).json({
     message: 'Hello World',
   });
@@ -196,7 +196,7 @@ testServiceBuilder.declare({
  *
  * This also sets up helper.apiClient as a client of the service API.
  */
-helper.withServers = (mock, skipping) => {
+helper.withServers = skipping => {
   let webServer;
 
   suiteSetup(async () => {
@@ -380,7 +380,7 @@ helper.withGcp = (mock, skipping) => {
   });
 };
 
-helper.resetTables = (mock, skipping) => {
+helper.resetTables = () => {
   setup('reset tables', async () => {
     await libTesting.resetTables({ tableNames: [
       'roles',

--- a/services/auth/test/purgeExpiredClients_test.js
+++ b/services/auth/test/purgeExpiredClients_test.js
@@ -6,8 +6,8 @@ import testing from '@taskcluster/lib-testing';
 helper.secrets.mockSuite(testing.suiteName(), ['azure', 'gcp'], (mock, skipping) => {
   helper.withCfg(mock, skipping);
   helper.withDb(mock, skipping);
-  helper.withPulse(mock, skipping);
-  helper.withServers(mock, skipping);
+  helper.withPulse(skipping);
+  helper.withServers(skipping);
 
   const CLIENT_ID = 'nobody/sds:ad_asd/df-sAdSfchsdfsdfs';
 

--- a/services/auth/test/remotevalidation_test.js
+++ b/services/auth/test/remotevalidation_test.js
@@ -8,8 +8,8 @@ import testing from '@taskcluster/lib-testing';
 helper.secrets.mockSuite(testing.suiteName(), ['azure', 'gcp'], (mock, skipping) => {
   helper.withCfg(mock, skipping);
   helper.withDb(mock, skipping);
-  helper.withPulse(mock, skipping);
-  helper.withServers(mock, skipping);
+  helper.withPulse(skipping);
+  helper.withServers(skipping);
 
   let rootCredentials;
 

--- a/services/auth/test/role_test.js
+++ b/services/auth/test/role_test.js
@@ -10,8 +10,8 @@ import taskcluster from '@taskcluster/client';
 helper.secrets.mockSuite(testing.suiteName(), ['gcp'], (mock, skipping) => {
   helper.withCfg(mock, skipping);
   helper.withDb(mock, skipping);
-  helper.withPulse(mock, skipping);
-  helper.withServers(mock, skipping);
+  helper.withPulse(skipping);
+  helper.withServers(skipping);
 
   const sorted = (arr) => {
     arr.sort();

--- a/services/auth/test/rolelogic_test.js
+++ b/services/auth/test/rolelogic_test.js
@@ -7,9 +7,9 @@ import testing from '@taskcluster/lib-testing';
 helper.secrets.mockSuite(testing.suiteName(), ['azure', 'gcp'], (mock, skipping) => {
   helper.withDb(mock, skipping);
   helper.withCfg(mock, skipping);
-  helper.withPulse(mock, skipping);
-  helper.withServers(mock, skipping);
-  helper.resetTables(mock, skipping);
+  helper.withPulse(skipping);
+  helper.withServers(skipping);
+  helper.resetTables();
 
   /**
    * Customized test function, taking an object as follows:

--- a/services/auth/test/s3_test.js
+++ b/services/auth/test/s3_test.js
@@ -18,8 +18,8 @@ helper.secrets.mockSuite(testing.suiteName(), ['azure', 'gcp'], (mock, skipping)
   // pulse/azure aren't under test, so we always mock them out
   helper.withDb(mock, skipping);
   helper.withCfg(mock, skipping);
-  helper.withPulse(mock, skipping);
-  helper.withServers(mock, skipping);
+  helper.withPulse(skipping);
+  helper.withServers(skipping);
 
   let bucket;
   setup(() => {

--- a/services/auth/test/scoperesolver_test.js
+++ b/services/auth/test/scoperesolver_test.js
@@ -15,7 +15,7 @@ helper.secrets.mockSuite('setup and listening', ['azure', 'gcp'], (mock, skippin
   let scopeResolver;
 
   helper.withDb(mock, skipping);
-  helper.withPulse(mock, skipping);
+  helper.withPulse(skipping);
   let reloads = [];
 
   setup('mock scoperesolver reloading', async () => {
@@ -414,7 +414,7 @@ suite(testing.suiteName(), () => {
         return result;
       };
     } else {
-      time = (step, fn) => fn();
+      time = (_step, fn) => fn();
     }
 
     const testResolver = (title, { roles, scopes, expected }) => {

--- a/services/auth/test/sentry_test.js
+++ b/services/auth/test/sentry_test.js
@@ -116,9 +116,9 @@ helper.secrets.mockSuite(testing.suiteName(), ['azure', 'gcp'], (mock, skipping)
   suite('regular SentryManager with fake client', () => {
     helper.withCfg(mock, skipping);
     helper.withDb(mock, skipping);
-    helper.withSentry(mock, skipping);
-    helper.withPulse(mock, skipping);
-    helper.withServers(mock, skipping);
+    helper.withSentry(skipping);
+    helper.withPulse(skipping);
+    helper.withServers(skipping);
 
     test('sentryDSN api method', async () => {
       await helper.apiClient.sentryDSN('playground');
@@ -148,10 +148,10 @@ helper.secrets.mockSuite(testing.suiteName(), ['azure', 'gcp'], (mock, skipping)
     });
     helper.withDb(mock, skipping);
     helper.withCfg(mock, skipping);
-    helper.withSentry(mock, skipping);
-    helper.withPulse('mock', skipping);
-    helper.withServers(mock, skipping);
-    helper.resetTables(mock, skipping);
+    helper.withSentry(skipping);
+    helper.withPulse(skipping);
+    helper.withServers(skipping);
+    helper.resetTables();
 
     test('sentryDSN api method', async () => {
       await assert.rejects(

--- a/services/auth/test/staticclients_test.js
+++ b/services/auth/test/staticclients_test.js
@@ -9,8 +9,8 @@ import { syncStaticClients } from '../src/static-clients.js';
 helper.secrets.mockSuite(testing.suiteName(), ['azure', 'gcp'], (mock, skipping) => {
   helper.withDb(mock, skipping);
   helper.withCfg(mock, skipping);
-  helper.withPulse(mock, skipping);
-  helper.withServers(mock, skipping);
+  helper.withPulse(skipping);
+  helper.withServers(skipping);
 
   test('static/taskcluster/root exists', async () => {
     await helper.apiClient.client('static/taskcluster/root');

--- a/services/auth/test/stories_test.js
+++ b/services/auth/test/stories_test.js
@@ -7,8 +7,8 @@ import testing from '@taskcluster/lib-testing';
 helper.secrets.mockSuite(testing.suiteName(), ['azure', 'gcp'], (mock, skipping) => {
   helper.withCfg(mock, skipping);
   helper.withDb(mock, skipping);
-  helper.withPulse(mock, skipping);
-  helper.withServers(mock, skipping);
+  helper.withPulse(skipping);
+  helper.withServers(skipping);
 
   suite('charlene creates permanent credentials for a test runner', () => {
     suiteSetup(async function() {

--- a/services/auth/test/testauth_test.js
+++ b/services/auth/test/testauth_test.js
@@ -16,9 +16,9 @@ suite(testing.suiteName(), () => {
   helper.secrets.mockSuite(testing.suiteName(), ['azure', 'gcp'], (mock, skipping) => {
     helper.withDb(mock, skipping);
     helper.withCfg(mock, skipping);
-    helper.withPulse(mock, skipping);
-    helper.withServers(mock, skipping);
-    helper.resetTables(mock, skipping);
+    helper.withPulse(skipping);
+    helper.withServers(skipping);
+    helper.resetTables();
 
     const testAuth = (name, { config, requiredScopes, clientScopes, errorCode }) => {
       test(name, async () => {
@@ -103,9 +103,9 @@ suite(testing.suiteName(), () => {
   helper.secrets.mockSuite('testAuthGet', ['azure', 'gcp'], (mock, skipping) => {
     helper.withDb(mock, skipping);
     helper.withCfg(mock, skipping);
-    helper.withPulse(mock, skipping);
-    helper.withServers(mock, skipping);
-    helper.resetTables(mock, skipping);
+    helper.withPulse(skipping);
+    helper.withServers(skipping);
+    helper.resetTables();
 
     const testAuthGet = (name, { config, errorCode }) => {
       test(name, async () => {

--- a/services/auth/test/trie_test.js
+++ b/services/auth/test/trie_test.js
@@ -529,7 +529,7 @@ suite(testing.suiteName(), () => {
   });
 
   /** Walk all paths in a trie, calling visit(path, node) for all nodes in the trie */
-  const walk = (trie, visit = (path, node) => {}, prefix = '') => {
+  const walk = (trie, visit = (_path, _node) => {}, prefix = '') => {
     visit(prefix, trie);
     for (const [character, child] of trie.children) {
       walk(child, visit, prefix + character);

--- a/services/auth/test/websocktunnel_test.js
+++ b/services/auth/test/websocktunnel_test.js
@@ -6,9 +6,9 @@ import testing from '@taskcluster/lib-testing';
 helper.secrets.mockSuite(testing.suiteName(), ['azure', 'gcp'], (mock, skipping) => {
   helper.withDb(mock, skipping);
   helper.withCfg(mock, skipping);
-  helper.withPulse(mock, skipping);
-  helper.withServers(mock, skipping);
-  helper.resetTables(mock, skipping);
+  helper.withPulse(skipping);
+  helper.withServers(skipping);
+  helper.resetTables();
 
   test('websocktunnelToken', async () => {
     const wstAudience = 'websocktunnel-usw2';

--- a/services/built-in-workers/src/TaskQueue.js
+++ b/services/built-in-workers/src/TaskQueue.js
@@ -1,7 +1,7 @@
 import assert from 'node:assert';
 
 class TaskQueue {
-  constructor(cfg, queue, monitor, type) {
+  constructor(queue, monitor, type) {
     assert(queue, 'Instance of taskcluster queue is required');
     this.queue = queue;
     this.builtinType = type;

--- a/services/built-in-workers/src/main.js
+++ b/services/built-in-workers/src/main.js
@@ -35,20 +35,20 @@ const load = loader({
   },
 
   generateReferences: {
-    requires: ['cfg'],
-    setup: async ({ cfg }) => libReferences.fromService({
+    requires: [],
+    setup: async () => libReferences.fromService({
       references: [MonitorManager.reference('built-in-workers'), MonitorManager.metricsReference('built-in-workers')],
     }).then(ref => ref.generateReferences()),
   },
 
   succeedTaskQueue: {
-    requires: ['queue', 'cfg', 'monitor'],
-    setup: ({ cfg, queue, monitor }) => new TaskQueue(cfg, queue, monitor.childMonitor('succeed'), 'succeed'),
+    requires: ['queue', 'monitor'],
+    setup: ({ queue, monitor }) => new TaskQueue(queue, monitor.childMonitor('succeed'), 'succeed'),
   },
 
   failTaskQueue: {
-    requires: ['queue', 'cfg', 'monitor'],
-    setup: ({ cfg, queue, monitor }) => new TaskQueue(cfg, queue, monitor.childMonitor('fail'), 'fail'),
+    requires: ['queue', 'monitor'],
+    setup: ({ queue, monitor }) => new TaskQueue(queue, monitor.childMonitor('fail'), 'fail'),
   },
 
   server: {

--- a/services/built-in-workers/test/helper.js
+++ b/services/built-in-workers/test/helper.js
@@ -57,7 +57,7 @@ const stubbedQueue = (fakeQueue) => {
         assert(task, `fake queue has no task ${taskId}`);
         return task;
       },
-      claimWork: async function (taskQueueId, payload) {
+      claimWork: async function (_taskQueueId, payload) {
         assert.equal(this._options.credentials.clientId, 'built-in-workers');
         const work = fakeQueue.claimableWork.pop();
         work.tasks.map(task => task.credentials = {
@@ -68,17 +68,17 @@ const stubbedQueue = (fakeQueue) => {
         work.workerId = payload.workerId;
         return work;
       },
-      reportCompleted: async function (taskId, runId) {
+      reportCompleted: async function (taskId, _runId) {
         assert.equal(this._options.credentials.clientId, 'task-creds');
         fakeQueue.taskResolutions[taskId] = { completed: true };
         return {};
       },
-      reportFailed: async function (taskId, runId) {
+      reportFailed: async function (taskId, _runId) {
         assert.equal(this._options.credentials.clientId, 'task-creds');
         fakeQueue.taskResolutions[taskId] = { failed: true };
         return {};
       },
-      reportException: async function (taskId, runId, payload) {
+      reportException: async function (taskId, _runId, payload) {
         assert.equal(this._options.credentials.clientId, 'task-creds');
         fakeQueue.taskResolutions[taskId] = { exception: payload };
         return {};

--- a/services/github/src/exchanges.js
+++ b/services/github/src/exchanges.js
@@ -50,7 +50,7 @@ const commonMessageBuilder = (msg) => {
 };
 
 /** Build list of routing keys to CC */
-const commonCCBuilder = (message, routes) => {
+const commonCCBuilder = (_message, routes) => {
   assert(Array.isArray(routes), 'Routes must be an array');
   return routes.map(route => `route.${route}`);
 };

--- a/services/github/src/github-auth.js
+++ b/services/github/src/github-auth.js
@@ -71,7 +71,7 @@ export default async ({ cfg, monitor }) => {
           return true;
         }
       },
-      onSecondaryRateLimit: (retryAfter, options, octokit) => {
+      onSecondaryRateLimit: (_retryAfter, options, octokit) => {
         octokit.log.warn(
           `SecondaryRateLimit detected for request ${options.method} ${options.url}`,
         );

--- a/services/github/src/handlers/index.js
+++ b/services/github/src/handlers/index.js
@@ -73,7 +73,7 @@ class Handlers {
   /**
    * Set up the handlers.
    */
-  async setup(options = {}) {
+  async setup(_options = {}) {
     assert(!this.jobPq, 'Cannot setup twice!');
     assert(!this.resultStatusPq, 'Cannot setup twice!');
     assert(!this.deprecatedResultStatusPq, 'Cannot setup twice!');

--- a/services/github/src/main.js
+++ b/services/github/src/main.js
@@ -38,8 +38,8 @@ const load = loader({
   },
 
   schemaset: {
-    requires: ['cfg'],
-    setup: ({ cfg }) => new SchemaSet({
+    requires: [],
+    setup: () => new SchemaSet({
       serviceName: 'github',
     }),
   },
@@ -59,8 +59,8 @@ const load = loader({
   },
 
   generateReferences: {
-    requires: ['cfg', 'schemaset'],
-    setup: async ({ cfg, schemaset }) => libReferences.fromService({
+    requires: ['schemaset'],
+    setup: async ({ schemaset }) => libReferences.fromService({
       schemaset,
       references: [builder.reference(), exchanges.reference(), MonitorManager.reference('github'), MonitorManager.metricsReference('github')],
     }).then(ref => ref.generateReferences()),
@@ -113,7 +113,7 @@ const load = loader({
     // where taskcluster-github is acting of its own accord
     // Where it is acting on behalf of a task, use this.queueClient.use({authorizedScopes: scopes}).blahblah
     // (see handlers.createTasks for example)
-    setup: ({ cfg, monitor }) => new taskcluster.Queue({
+    setup: ({ cfg }) => new taskcluster.Queue({
       rootUrl: cfg.taskcluster.rootUrl,
       credentials: cfg.taskcluster.credentials,
     }),

--- a/services/github/src/tc-yaml.js
+++ b/services/github/src/tc-yaml.js
@@ -104,7 +104,7 @@ class VersionZero extends TcYaml {
       'taskcluster.docker.workerType': cfg.intree.workerType || 'unknown',
     }));
   }
-  compileTasks(config, cfg, payload, now) {
+  compileTasks(config, cfg, payload, _now) {
     config.tasks = config.tasks.map((task) => {
       task.routes = task.routes || [];
       task.routes = Array.from(new Set([

--- a/services/github/test/api_test.js
+++ b/services/github/test/api_test.js
@@ -11,10 +11,10 @@ import testing from '@taskcluster/lib-testing';
  */
 helper.secrets.mockSuite(testing.suiteName(), [], (mock, skipping) => {
   helper.withDb(mock, skipping);
-  helper.withFakeGithub(mock, skipping);
-  helper.withFakeQueue(mock, skipping);
-  helper.withPulse(mock, skipping);
-  helper.withServer(mock, skipping);
+  helper.withFakeGithub();
+  helper.withFakeQueue();
+  helper.withPulse(skipping);
+  helper.withServer(skipping);
 
   suiteSetup(async () => {
     if (skipping()) {

--- a/services/github/test/github-auth.js
+++ b/services/github/test/github-auth.js
@@ -133,7 +133,7 @@ class FakeGithub {
           throwError(404);
         }
       },
-      'checks.create': async ({ owner, repo, name, head_sha, output, details_url, actions, status, conclusion }) => {
+      'checks.create': async ({ owner, repo, name, head_sha, status, conclusion }) => {
         if (repo === 'no-permission') {
           throwError(403);
         }
@@ -189,7 +189,7 @@ class FakeGithub {
           throwError(404);
         }
       },
-      'reactions.createForIssueComment': async ({ owner, repo, commentId, body }) => {
+      'reactions.createForIssueComment': async ({ repo }) => {
         if (repo === 'no-permission') {
           throwError(403);
         }

--- a/services/github/test/handler_test.js
+++ b/services/github/test/handler_test.js
@@ -21,9 +21,9 @@ const loadJson = filename => JSON.parse(fs.readFileSync(path.join(dataDir, filen
  */
 helper.secrets.mockSuite(testing.suiteName(), [], (mock, skipping) => {
   helper.withDb(mock, skipping);
-  helper.withFakeGithub(mock, skipping);
-  helper.withPulse(mock, skipping);
-  helper.resetTables(mock, skipping);
+  helper.withFakeGithub();
+  helper.withPulse(skipping);
+  helper.resetTables();
 
   const validYamlJson = loadJson('yml/valid-yaml.json');
   const validYamlV1Json = loadJson('yml/valid-yaml-v1.json');
@@ -178,7 +178,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], (mock, skipping) => {
         }
       },
       listTaskGroup: async () => ({ tasks: [] }),
-      listArtifacts: async (taskId, runId, options) => {
+      listArtifacts: async (_taskId, _runId, options) => {
 
         const artifacts = [];
 
@@ -341,10 +341,10 @@ helper.secrets.mockSuite(testing.suiteName(), [], (mock, skipping) => {
       handlers.queueClient = new taskcluster.Queue({
         rootUrl: 'https://tc.example.com',
         fake: {
-          sealTaskGroup: async (taskGroupId) => {
+          sealTaskGroup: async (_taskGroupId) => {
             throw new Error('sealTaskGroup error: missing scopes');
           },
-          cancelTaskGroup: async (taskGroupId) => {
+          cancelTaskGroup: async (_taskGroupId) => {
             throw new Error('cancelTaskGroup error: missing scopes');
           },
         },
@@ -383,11 +383,11 @@ helper.secrets.mockSuite(testing.suiteName(), [], (mock, skipping) => {
       handlers.queueClient = new taskcluster.Queue({
         rootUrl: 'https://tc.example.com',
         fake: {
-          sealTaskGroup: async (taskGroupId) => {
+          sealTaskGroup: async (_taskGroupId) => {
             err.method = 'sealTaskGroup';
             throw err;
           },
-          cancelTaskGroup: async (taskGroupId) => {
+          cancelTaskGroup: async (_taskGroupId) => {
             err.method = 'cancelTaskGroup';
             throw err;
           },

--- a/services/github/test/helper.js
+++ b/services/github/test/helper.js
@@ -58,7 +58,7 @@ helper.withDb = (mock, skipping) => {
   testing.withDb(mock, skipping, helper, 'github');
 };
 
-helper.withPulse = (mock, skipping) => {
+helper.withPulse = skipping => {
   testing.withPulse({ helper, skipping, namespace: 'taskcluster-github' });
 };
 
@@ -66,7 +66,7 @@ helper.withPulse = (mock, skipping) => {
  * Set the `github` loader component to a fake version.
  * This is reset before each test.  Call this before withServer.
  */
-helper.withFakeGithub = (mock, skipping) => {
+helper.withFakeGithub = () => {
   suiteSetup(() => {
     load.inject('github', fakeGithubAuth());
   });
@@ -84,7 +84,7 @@ helper.withFakeGithub = (mock, skipping) => {
 /**
  * Set the `queueClient` loader component to a fake version.
  */
-helper.withFakeQueue = (mock, skipping) => {
+helper.withFakeQueue = () => {
   const fakeQueueClient = () => new taskcluster.Queue({
     rootUrl: 'https://tc.example.com',
     fake: {
@@ -109,7 +109,7 @@ helper.withFakeQueue = (mock, skipping) => {
  *
  * This also sets up helper.apiClient as a client of the service API.
  */
-helper.withServer = (mock, skipping) => {
+helper.withServer = skipping => {
   let webServer;
 
   suiteSetup(async () => {
@@ -149,7 +149,7 @@ helper.withServer = (mock, skipping) => {
   });
 };
 
-helper.resetTables = (mock, skipping) => {
+helper.resetTables = () => {
   setup('reset tables', async () => {
     await testing.resetTables({ tableNames: [
       'github_builds',

--- a/services/github/test/pulse_test.js
+++ b/services/github/test/pulse_test.js
@@ -16,10 +16,10 @@ const loadWebhookJson = async filename => {
 
 helper.secrets.mockSuite(testing.suiteName(), [], (mock, skipping) => {
   helper.withDb(mock, skipping);
-  helper.withPulse(mock, skipping);
-  helper.withFakeGithub(mock, skipping);
-  helper.withServer(mock, skipping);
-  helper.resetTables(mock, skipping);
+  helper.withPulse(skipping);
+  helper.withFakeGithub();
+  helper.withServer(skipping);
+  helper.resetTables();
 
   let github = null;
 

--- a/services/github/test/sync_test.js
+++ b/services/github/test/sync_test.js
@@ -7,10 +7,10 @@ import testing from '@taskcluster/lib-testing';
  */
 helper.secrets.mockSuite(testing.suiteName(), [], (mock, skipping) => {
   helper.withDb(mock, skipping);
-  helper.withFakeGithub(mock, skipping);
-  helper.withPulse(mock, skipping);
-  helper.withServer(mock, skipping);
-  helper.resetTables(mock, skipping);
+  helper.withFakeGithub();
+  helper.withPulse(skipping);
+  helper.withServer(skipping);
+  helper.resetTables();
 
   let github;
 

--- a/services/github/test/utils_test.js
+++ b/services/github/test/utils_test.js
@@ -43,7 +43,7 @@ suite(testing.suiteName(), () => {
     test('4xx statuses are returned (not thrown) immediately', async () => {
       let calls = 0;
 
-      throttleRequest.request = async (method, url) => {
+      throttleRequest.request = async (_method, _url) => {
         calls++;
         const err = new Error('uhoh');
         err.status = 424;
@@ -58,7 +58,7 @@ suite(testing.suiteName(), () => {
     test('5xx statuses are retried', async () => {
       let calls = 0;
 
-      throttleRequest.request = async (method, url) => {
+      throttleRequest.request = async (_method, _url) => {
         calls++;
         const err = new Error('uhoh');
         err.status = 543;
@@ -74,7 +74,7 @@ suite(testing.suiteName(), () => {
     test('5xx status retried once returns successful result', async () => {
       let calls = 0;
 
-      throttleRequest.request = async (method, url) => {
+      throttleRequest.request = async (_method, _url) => {
         calls++;
         if (calls >= 1) {
           return { status: 200 };
@@ -90,7 +90,7 @@ suite(testing.suiteName(), () => {
     });
 
     test('connection errors are thrown directly', async () => {
-      throttleRequest.request = async (method, url) => {
+      throttleRequest.request = async (_method, _url) => {
         const err = new Error('uhoh');
         err.code = 'ECONNREFUSED';
         throw err;

--- a/services/github/test/webhook_test.js
+++ b/services/github/test/webhook_test.js
@@ -8,10 +8,10 @@ const TC_DEV_INSTALLATION_ID = 28513985;
 
 helper.secrets.mockSuite(testing.suiteName(), [], (mock, skipping) => {
   helper.withDb(mock, skipping);
-  helper.withFakeGithub(mock, skipping);
-  helper.withPulse(mock, skipping);
-  helper.withServer(mock, skipping);
-  helper.resetTables(mock, skipping);
+  helper.withFakeGithub();
+  helper.withPulse(skipping);
+  helper.withServer(skipping);
+  helper.resetTables();
 
   let github = null;
   let monitor;

--- a/services/hooks/src/api.js
+++ b/services/hooks/src/api.js
@@ -48,7 +48,7 @@ builder.declare({
   description: [
     'This endpoint will return a list of all hook groups with at least one hook.',
   ].join('\n'),
-}, async function(req, res) {
+}, async function(_req, res) {
   const hookGroups = await this.db.fns.get_hook_groups();
   const groups = hookGroups.map(row => row.hook_group_id);
   return res.reply({ groups });
@@ -623,7 +623,7 @@ builder.declare({
 /**
  * Common implementation of triggerHook and triggerHookWithToken
  */
-const triggerHookCommon = async function({ req, res, hook, payload, clientId, firedBy }) {
+const triggerHookCommon = async function({ res, hook, payload, clientId, firedBy }) {
   const ajv = new Ajv.default({ validateFormats: true, verbose: true, allErrors: true });
   addFormats(ajv);
 

--- a/services/hooks/src/exchanges.js
+++ b/services/hooks/src/exchanges.js
@@ -23,7 +23,7 @@ const exchanges = new Exchanges({
 export default exchanges;
 
 /** Build common routing key construct for `exchanges.declare` */
-const buildCommonRoutingKey = (options) => {
+const buildCommonRoutingKey = (_options) => {
   return [
     {
       name: 'reserved',
@@ -42,12 +42,12 @@ const commonMessageBuilder = (message) => message;
 /** Build a routingKey from message */
 /** Empty now, might be useful in the future */
 /** when this comment should be removed */
-const commonRoutingKeyBuilder = (message, routing) => '';
+const commonRoutingKeyBuilder = (_message, _routing) => '';
 
 /** Build list of routing keys to CC */
 /** Empty now, might be useful in the future */
 /** when this comment should be removed */
-const commonCCBuilder = (message, routes) => [];
+const commonCCBuilder = (_message, _routes) => [];
 
 // Hook created exchange
 exchanges.declare({

--- a/services/hooks/src/listeners.js
+++ b/services/hooks/src/listeners.js
@@ -55,7 +55,7 @@ class HookListeners {
       }],
       queueName: 'hookChanged',
       maxLength: 50,
-    }, (msg) => this.reconcileConsumers(),
+    }, (_msg) => this.reconcileConsumers(),
     );
     this.monitor.debug('Listening to hook exchanges');
     this.pulseHookChangedListener = consumer;

--- a/services/hooks/src/main.js
+++ b/services/hooks/src/main.js
@@ -52,8 +52,8 @@ const load = loader({
   },
 
   schemaset: {
-    requires: ['cfg'],
-    setup: ({ cfg }) => {
+    requires: [],
+    setup: () => {
       return new SchemaSet({
         serviceName: 'hooks',
       });
@@ -135,8 +135,8 @@ const load = loader({
   },
 
   generateReferences: {
-    requires: ['cfg', 'schemaset'],
-    setup: async ({ cfg, schemaset }) => libReferences.fromService({
+    requires: ['schemaset'],
+    setup: async ({ schemaset }) => libReferences.fromService({
       schemaset,
       references: [builder.reference(), exchanges.reference(), MonitorManager.reference('hooks'), MonitorManager.metricsReference('hooks')],
     }).then(ref => ref.generateReferences()),
@@ -173,8 +173,8 @@ const load = loader({
   },
 
   expires: {
-    requires: ['cfg', 'db', 'monitor'],
-    setup: ({ cfg, db, monitor }, ownName) => {
+    requires: ['db', 'monitor'],
+    setup: ({ db, monitor }, ownName) => {
       return monitor.oneShot(ownName, async () => {
         debug('Expiring lastFires rows');
         const count = (await db.fns.expire_last_fires())[0].expire_last_fires;

--- a/services/hooks/test/api_test.js
+++ b/services/hooks/test/api_test.js
@@ -11,10 +11,10 @@ import taskDefinition from './test_definition.js';
 
 helper.secrets.mockSuite(testing.suiteName(), [], (mock, skipping) => {
   helper.withDb(mock, skipping);
-  helper.withTaskCreator(mock, skipping);
-  helper.withPulse(mock, skipping);
-  helper.withServer(mock, skipping);
-  helper.resetTables(mock, skipping);
+  helper.withTaskCreator(skipping);
+  helper.withPulse(skipping);
+  helper.withServer(skipping);
+  helper.resetTables();
 
   // Use the same hook definition for everything
   const hookDef = _.cloneDeep(taskDefinition);

--- a/services/hooks/test/expires_test.js
+++ b/services/hooks/test/expires_test.js
@@ -5,7 +5,7 @@ import testing from '@taskcluster/lib-testing';
 suite(testing.suiteName(), () => {
   helper.secrets.mockSuite('expires_test.js', [], (mock, skipping) => {
     helper.withDb(mock, skipping);
-    helper.resetTables(mock, skipping);
+    helper.resetTables();
 
     test('expire nothing', async () => {
       const count = (await helper.db.fns.expire_last_fires())[0].expire_last_fires;

--- a/services/hooks/test/helper.js
+++ b/services/hooks/test/helper.js
@@ -35,7 +35,7 @@ helper.withDb = (mock, skipping) => {
  * helper.creator.shouldFail to make the TaskCreator fail.
  * Call this before withServer.
  */
-helper.withTaskCreator = (mock, skipping) => {
+helper.withTaskCreator = skipping => {
   suiteSetup(async () => {
     if (skipping()) {
       return;
@@ -54,7 +54,7 @@ helper.withTaskCreator = (mock, skipping) => {
   });
 };
 
-helper.withPulse = (mock, skipping) => {
+helper.withPulse = skipping => {
   testing.withPulse({ helper, skipping, namespace: 'taskcluster-hooks' });
 };
 
@@ -65,7 +65,7 @@ helper.withPulse = (mock, skipping) => {
  * This also sets up helper.hooks as an API client, using scopes configurable
  * with helper.scopes([..]); and configures fakeAuth to support that.
  */
-helper.withServer = (mock, skipping) => {
+helper.withServer = skipping => {
   let webServer;
 
   suiteSetup(async () => {
@@ -115,7 +115,7 @@ helper.withServer = (mock, skipping) => {
   });
 };
 
-helper.resetTables = (mock, skipping) => {
+helper.resetTables = () => {
   setup('reset tables', async () => {
     await testing.resetTables({ tableNames: [
       'hooks',

--- a/services/hooks/test/listeners_test.js
+++ b/services/hooks/test/listeners_test.js
@@ -8,9 +8,9 @@ import { queueUtils } from '../src/utils.js';
 
 helper.secrets.mockSuite(testing.suiteName(), [], (mock, skipping) => {
   helper.withDb(mock, skipping);
-  helper.withTaskCreator(mock, skipping);
-  helper.withPulse(mock, skipping);
-  helper.resetTables(mock, skipping);
+  helper.withTaskCreator(skipping);
+  helper.withPulse(skipping);
+  helper.resetTables();
 
   const hookGroupId = 't';
   const hookId = 'h';
@@ -215,7 +215,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], (mock, skipping) => {
       hookListeners.deleteQueue = sinon.fake(
         async queueName => createdQueues.delete(queueName));
       hookListeners.syncBindings = sinon.fake(
-        async (queueName, newBindings, oldBindings) => {
+        async (queueName, newBindings, _oldBindings) => {
           createdQueues.set(queueName, newBindings);
           return newBindings;
         });

--- a/services/hooks/test/schedule_hooks_test.js
+++ b/services/hooks/test/schedule_hooks_test.js
@@ -6,7 +6,7 @@ import testing from '@taskcluster/lib-testing';
 
 helper.secrets.mockSuite(testing.suiteName(), [], (mock, skipping) => {
   helper.withDb(mock, skipping);
-  helper.resetTables(mock, skipping);
+  helper.resetTables();
 
   suiteSetup(async () => {
     await helper.load('cfg');

--- a/services/hooks/test/scheduler_test.js
+++ b/services/hooks/test/scheduler_test.js
@@ -8,8 +8,8 @@ import { hookUtils } from '../src/utils.js';
 
 helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
   helper.withDb(mock, skipping);
-  helper.withTaskCreator(mock, skipping);
-  helper.resetTables(mock, skipping);
+  helper.withTaskCreator(skipping);
+  helper.resetTables();
 
   this.slow(500);
 
@@ -18,7 +18,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
     helper.load.inject('notify', new taskcluster.Notify({
       rootUrl: helper.rootUrl,
       fake: {
-        email: email => null,
+        email: () => null,
       },
     }));
   });
@@ -173,7 +173,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       };
 
       let emailSent = false;
-      scheduler.sendFailureEmail = async (hook, err) => { emailSent = true; };
+      scheduler.sendFailureEmail = async (_hook, _err) => { emailSent = true; };
 
       await scheduler.handleHook(hook);
 
@@ -191,7 +191,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       };
 
       let emailSent = false;
-      scheduler.sendFailureEmail = async (hook, err) => { emailSent = true; throw new Error('uhoh'); };
+      scheduler.sendFailureEmail = async (_hook, _err) => { emailSent = true; throw new Error('uhoh'); };
 
       await scheduler.handleHook(hook);
 
@@ -215,7 +215,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], function(mock, skipping) {
       };
 
       let emailSent = false;
-      scheduler.sendFailureEmail = async (hook, err) => { emailSent = true; };
+      scheduler.sendFailureEmail = async (_hook, _err) => { emailSent = true; };
 
       await scheduler.handleHook(hook);
 

--- a/services/hooks/test/taskcreator_test.js
+++ b/services/hooks/test/taskcreator_test.js
@@ -13,7 +13,7 @@ import { hookUtils } from '../src/utils.js';
 suite(testing.suiteName(), () => {
   helper.secrets.mockSuite('TaskCreator', [], function(mock, skipping) {
     helper.withDb(mock, skipping);
-    helper.resetTables(mock, skipping);
+    helper.resetTables();
 
     this.slow(500);
 
@@ -98,7 +98,7 @@ suite(testing.suiteName(), () => {
       return creator.lastCreateTask.task;
     };
 
-    const assertNoTask = async taskId => {
+    const assertNoTask = async () => {
       assert(!creator.lastCreateTask);
     };
 
@@ -181,7 +181,7 @@ suite(testing.suiteName(), () => {
       );
       const taskId = taskcluster.slugid();
       const res = await creator.fire(hook, { firedBy: 'schedule' }, { taskId });
-      await assertNoTask(taskId);
+      await assertNoTask();
       assertFireLogged({ firedBy: "schedule", taskId, result: 'declined' });
       assert.ok(!res, `expected falsy return from declined fire(), got ${JSON.stringify(res)}`);
     });

--- a/services/index/src/main.js
+++ b/services/index/src/main.js
@@ -38,8 +38,8 @@ export const load = loader({
 
   // Create a validator
   schemaset: {
-    requires: ['cfg'],
-    setup: ({ cfg }) => new SchemaSet({
+    requires: [],
+    setup: () => new SchemaSet({
       serviceName: 'index',
     }),
   },
@@ -83,8 +83,8 @@ export const load = loader({
   },
 
   generateReferences: {
-    requires: ['cfg', 'schemaset'],
-    setup: async ({ cfg, schemaset }) => libReferences.fromService({
+    requires: ['schemaset'],
+    setup: async ({ schemaset }) => libReferences.fromService({
       schemaset,
       references: [builder.reference(), MonitorManager.reference('index'), MonitorManager.metricsReference('index')],
     }).then(ref => ref.generateReferences()),
@@ -154,8 +154,8 @@ export const load = loader({
   },
 
   expire: {
-    requires: ['cfg', 'monitor', 'db'],
-    setup: ({ cfg, monitor, db }, ownName) => {
+    requires: ['monitor', 'db'],
+    setup: ({ monitor, db }, ownName) => {
       return monitor.oneShot(ownName, async () => {
         debug('Expiring namespaces');
         const namespaces = (await db.fns.expire_index_namespaces())[0].expire_index_namespaces;

--- a/services/index/test/api_test.js
+++ b/services/index/test/api_test.js
@@ -11,11 +11,11 @@ import testing from '@taskcluster/lib-testing';
 
 helper.secrets.mockSuite(testing.suiteName(), [], (mock, skipping) => {
   helper.withDb(mock, skipping);
-  helper.withFakeQueue(mock, skipping);
-  helper.withFakeAnonymousScopeCache(mock, skipping);
-  helper.withPulse(mock, skipping);
-  helper.withServer(mock, skipping);
-  helper.resetTables(mock, skipping);
+  helper.withFakeQueue(skipping);
+  helper.withFakeAnonymousScopeCache(skipping);
+  helper.withPulse(skipping);
+  helper.withServer(skipping);
+  helper.resetTables();
 
   test('insert (and rank)', async () => {
     const myns = slugid.v4();

--- a/services/index/test/helper.js
+++ b/services/index/test/helper.js
@@ -34,7 +34,7 @@ export const withDb = (mock, skipping) => {
 };
 helper.withDb = withDb;
 
-export const withPulse = (mock, skipping) => {
+export const withPulse = skipping => {
   testing.withPulse({ helper, skipping, namespace: 'taskcluster-index' });
 };
 helper.withPulse = withPulse;
@@ -46,7 +46,7 @@ helper.withPulse = withPulse;
  *
  * The component is available at `helper.queue`.
  */
-export const withFakeQueue = (mock, skipping) => {
+export const withFakeQueue = skipping => {
   suiteSetup(() => {
     if (skipping()) {
       return;
@@ -64,7 +64,7 @@ helper.setAnonymousScopes = (scopes) => {
   anonymousScopes = scopes;
 };
 
-export const withFakeAnonymousScopeCache = (mock, skipping) => {
+export const withFakeAnonymousScopeCache = skipping => {
   suiteSetup(() => {
     if (skipping()) {
       return;
@@ -91,7 +91,7 @@ helper.withFakeAnonymousScopeCache = withFakeAnonymousScopeCache;
  * This also sets up helper.scopes to set the scopes for helper.queue, the
  * API client object, and stores a client class a helper.Index.
  */
-export const withServer = (mock, skipping) => {
+export const withServer = skipping => {
   let webServer;
 
   suiteSetup(async () => {
@@ -192,7 +192,7 @@ const stubbedQueue = () => {
   return queue;
 };
 
-export const resetTables = (mock, skipping) => {
+export const resetTables = () => {
   setup('reset tables', async () => {
     await testing.resetTables({ tableNames: [
       'indexed_tasks',

--- a/services/index/test/index_test.js
+++ b/services/index/test/index_test.js
@@ -9,10 +9,10 @@ import taskcluster from '@taskcluster/client';
 
 helper.secrets.mockSuite(testing.suiteName(), [], (mock, skipping) => {
   helper.withDb(mock, skipping);
-  helper.withFakeQueue(mock, skipping);
-  helper.withPulse(mock, skipping);
-  helper.withServer(mock, skipping);
-  helper.resetTables(mock, skipping);
+  helper.withFakeQueue(skipping);
+  helper.withPulse(skipping);
+  helper.withServer(skipping);
+  helper.resetTables();
 
   const makeTask = () => ({
     provisionerId: 'dummy-test-provisioner',

--- a/services/notify/src/exchanges.js
+++ b/services/notify/src/exchanges.js
@@ -45,12 +45,12 @@ const commonMessageBuilder = (message) => {
 };
 
 /** Build a message from message */
-const commonRoutingKeyBuilder = (message, routing) => ({
+const commonRoutingKeyBuilder = (_message, routing) => ({
   topic: routing[0],
 });
 
 /** Build list of routing keys to CC */
-const commonCCBuilder = (message, routes) => {
+const commonCCBuilder = (_message, routes) => {
   assert(Array.isArray(routes), 'Routes must be an array');
   return routes.map(route => `route.${route}`);
 };

--- a/services/notify/src/main.js
+++ b/services/notify/src/main.js
@@ -43,8 +43,8 @@ const load = loader({
   },
 
   schemaset: {
-    requires: ['cfg'],
-    setup: ({ cfg }) => new SchemaSet({
+    requires: [],
+    setup: () => new SchemaSet({
       serviceName: 'notify',
     }),
   },
@@ -69,8 +69,8 @@ const load = loader({
   },
 
   generateReferences: {
-    requires: ['cfg', 'schemaset'],
-    setup: async ({ cfg, schemaset }) => libReferences.fromService({
+    requires: ['schemaset'],
+    setup: async ({ schemaset }) => libReferences.fromService({
       schemaset,
       references: [builder.reference(), exchanges.reference(), MonitorManager.reference('notify'), MonitorManager.metricsReference('notify')],
     }).then(ref => ref.generateReferences()),

--- a/services/notify/src/matrix.js
+++ b/services/notify/src/matrix.js
@@ -10,14 +10,14 @@ class MatrixBot {
     // we will override the methods and stick them all in trace messages
     // for structured logging instead since it also throws errors like normal
     const matrixLog = loglevel.getLogger('matrix');
-    matrixLog.methodFactory = (methodName, level, loggerName) => message => {
+    matrixLog.methodFactory = (_methodName, level, _loggerName) => message => {
       this._monitor.log.matrixSdkDebug({ level, message });
     };
     matrixLog.setLevel(matrixLog.getLevel()); // This makes the methodFactory stuff work
   }
 
   async start() {
-    this._client.on('RoomMember.membership', async (event, member) => {
+    this._client.on('RoomMember.membership', async (_event, member) => {
       if (member.membership === "invite" && member.userId === this._userId) {
         await this._client.joinRoom(member.roomId);
       }
@@ -25,7 +25,7 @@ class MatrixBot {
     await this._client.startClient();
   }
 
-  async sendMessage({ roomId, format, formattedBody, body, notice, msgtype }) {
+  async sendMessage({ roomId, format, formattedBody, body, msgtype }) {
     await this._client.sendEvent(roomId, 'm.room.message', { formatted_body: formattedBody, body, msgtype, format }, '');
   }
 }

--- a/services/notify/src/notifier.js
+++ b/services/notify/src/notifier.js
@@ -122,7 +122,7 @@ class Notifier {
     return true;
   }
 
-  async matrix({ roomId, format, formattedBody, body, notice, msgtype }) {
+  async matrix({ roomId, format, formattedBody, body, msgtype }) {
     if (this.isDuplicate(roomId, format, formattedBody, body, msgtype)) {
       debug('Duplicate matrix send detected. Not attempting resend.');
       return false;
@@ -133,7 +133,7 @@ class Notifier {
       return false;
     }
 
-    await this._matrix.sendMessage({ roomId, format, formattedBody, body, notice, msgtype });
+    await this._matrix.sendMessage({ roomId, format, formattedBody, body, msgtype });
     this.markSent(roomId, format, formattedBody, body, msgtype);
     this.monitor.log.matrix({ dest: roomId });
     return true;

--- a/services/notify/src/ratelimit.js
+++ b/services/notify/src/ratelimit.js
@@ -63,7 +63,7 @@ class RateLimit {
    * keys with no events in the window.
    */
   purgeAllOldTimes() {
-    this.times = _.pickBy(this.times, (times, key) => {
+    this.times = _.pickBy(this.times, times => {
       this.purgeOldTimes(times);
       return times.length > 0;
     });

--- a/services/notify/test/api_test.js
+++ b/services/notify/test/api_test.js
@@ -5,12 +5,12 @@ import testing from '@taskcluster/lib-testing';
 
 helper.secrets.mockSuite(testing.suiteName(), ['aws'], (mock, skipping) => {
   helper.withDb(mock, skipping);
-  helper.withPulse(mock, skipping);
-  helper.withFakeMatrix(mock, skipping);
-  helper.withFakeSlack(mock, skipping);
+  helper.withPulse(skipping);
+  helper.withFakeMatrix(skipping);
+  helper.withFakeSlack(skipping);
   helper.withSES(mock, skipping);
-  helper.withServer(mock, skipping);
-  helper.resetTables(mock, skipping);
+  helper.withServer(skipping);
+  helper.resetTables();
 
   // Dummy address for denylist tests
   const dummyAddress1 = {

--- a/services/notify/test/handler_test.js
+++ b/services/notify/test/handler_test.js
@@ -5,13 +5,13 @@ import testing from '@taskcluster/lib-testing';
 
 helper.secrets.mockSuite(testing.suiteName(), ['aws'], (mock, skipping) => {
   helper.withDb(mock, skipping);
-  helper.withDenier(mock, skipping);
-  helper.withFakeQueue(mock, skipping);
-  helper.withFakeMatrix(mock, skipping);
-  helper.withFakeSlack(mock, skipping);
+  helper.withDenier(skipping);
+  helper.withFakeQueue(skipping);
+  helper.withFakeMatrix(skipping);
+  helper.withFakeSlack(skipping);
   helper.withSES(mock, skipping);
-  helper.withPulse(mock, skipping);
-  helper.withServer(mock, skipping);
+  helper.withPulse(skipping);
+  helper.withServer(skipping);
 
   const created = new Date();
   const deadline = new Date();

--- a/services/notify/test/helper.js
+++ b/services/notify/test/helper.js
@@ -65,14 +65,14 @@ helper.secrets = new testing.Secrets({
 /**
  * Define a fake denier that will deny anything with 'denied' in the address
  */
-helper.withDenier = (mock, skipping) => {
+helper.withDenier = skipping => {
   suiteSetup('withDenier', async () => {
     if (skipping()) {
       return;
     }
 
     load.inject('denier', {
-      isDenied: async (notificationType, notificationAddress) =>
+      isDenied: async (_notificationType, notificationAddress) =>
         /denied/.test(notificationAddress),
     });
   });
@@ -245,7 +245,7 @@ const stubbedQueue = () => {
  *
  * The component is available at `helper.queue`.
  */
-helper.withFakeQueue = (mock, skipping) => {
+helper.withFakeQueue = skipping => {
   suiteSetup('withFakeQueue', () => {
     if (skipping()) {
       return;
@@ -264,7 +264,7 @@ const fakeMatrixSend = () => sinon.fake(roomId => {
   }
 });
 
-helper.withFakeMatrix = (mock, skipping) => {
+helper.withFakeMatrix = skipping => {
   suiteSetup('withFakeMatrix', () => {
     if (skipping()) {
       return;
@@ -282,7 +282,7 @@ helper.withFakeMatrix = (mock, skipping) => {
   });
 };
 
-helper.withFakeSlack = (mock, skipping) => {
+helper.withFakeSlack = skipping => {
   const fakeSlackSend = () => sinon.fake(() => ({ ok: true }));
 
   suiteSetup('withFakeSlack', async () => {
@@ -304,14 +304,14 @@ helper.withFakeSlack = (mock, skipping) => {
   });
 };
 
-helper.withPulse = (mock, skipping) => {
+helper.withPulse = skipping => {
   testing.withPulse({ helper, skipping, namespace: 'taskcluster-notify' });
 };
 
 /**
  * Set up an API server.
  */
-helper.withServer = (mock, skipping) => {
+helper.withServer = skipping => {
   let webServer;
 
   suiteSetup('withServer', async () => {
@@ -360,7 +360,7 @@ helper.withDb = (mock, skipping) => {
   testing.withDb(mock, skipping, helper, 'notify');
 };
 
-helper.resetTables = (mock, skipping) => {
+helper.resetTables = () => {
   setup('reset tables', async () => {
     await testing.resetTables({ tableNames: [
       'denylisted_notifications',

--- a/services/notify/test/notifier_test.js
+++ b/services/notify/test/notifier_test.js
@@ -7,12 +7,12 @@ helper.secrets.mockSuite(testing.suiteName(), ['aws'], (mock, skipping) => {
     return;
   }
 
-  helper.withDenier(mock, skipping);
-  helper.withFakeQueue(mock, skipping);
-  helper.withFakeMatrix(mock, skipping);
-  helper.withFakeSlack(mock, skipping);
+  helper.withDenier(skipping);
+  helper.withFakeQueue(skipping);
+  helper.withFakeMatrix(skipping);
+  helper.withFakeSlack(skipping);
   helper.withSES(mock, skipping);
-  helper.withPulse(mock, skipping);
+  helper.withPulse(skipping);
 
   test('isDuplicate', async () => {
     const notifier = await helper.load('notifier');

--- a/services/object/src/backends/aws.js
+++ b/services/object/src/backends/aws.js
@@ -59,7 +59,7 @@ export class AwsBackend extends Backend {
 
     if (this.isAws) {
       this.tags = this.config.tags || {};
-      if (Object.entries(this.tags).some(([k, v]) => typeof v !== 'string')) {
+      if (Object.values(this.tags).some(v => typeof v !== 'string')) {
         throw new Error(`backend ${this.backendId} has invalid 'tags' configuration`);
       }
     } else if (this.config.tags) {
@@ -163,11 +163,11 @@ export class AwsBackend extends Backend {
     }
   }
 
-  async availableDownloadMethods(object) {
+  async availableDownloadMethods(_object) {
     return ['simple', 'getUrl'];
   }
 
-  async startDownload(object, method, params) {
+  async startDownload(object, method, _params) {
     switch (method) {
       case 'simple': {
         let downloadUrl;

--- a/services/object/src/backends/base.js
+++ b/services/object/src/backends/base.js
@@ -1,5 +1,5 @@
 export class Backend {
-  constructor({ backendId, db, monitor, rootUrl, config }) {
+  constructor({ backendId, db, monitor, rootUrl }) {
     this.backendId = backendId;
     this.db = db;
     this.monitor = monitor;
@@ -26,7 +26,7 @@ export class Backend {
    *
    * Implementations may use @taskcluster/lib-api's `reportError` method.
    */
-  async createUpload(object, proposedUploadMethods) {
+  async createUpload(_object, _proposedUploadMethods) {
     return {};
   }
 
@@ -39,7 +39,7 @@ export class Backend {
    * downloaded.  But, implementations may use @taskcluster/lib-api's
    * `reportError` method to report errors.
    */
-  async finishUpload(object) {
+  async finishUpload(_object) {
     return;
   }
 
@@ -49,7 +49,7 @@ export class Backend {
    *
    * Subclasses should override this.
    */
-  async availableDownloadMethods(object) {
+  async availableDownloadMethods(_object) {
     return [];
   }
 
@@ -63,7 +63,7 @@ export class Backend {
    *
    * Subclasses should override this.
    */
-  async startDownload(object, method, params) {
+  async startDownload(_object, _method, _params) {
     throw new Error('startDownload is not implemented for this backend');
   }
 
@@ -75,7 +75,7 @@ export class Backend {
    * return false, prepared to be called again for the same object at a later
    * time (such as by the next object-expiration crontask run).
    */
-  async expireObject(object) {
+  async expireObject(_object) {
     throw new Error('expiration is not implemented for this backend');
   }
 }

--- a/services/object/src/main.js
+++ b/services/object/src/main.js
@@ -32,8 +32,8 @@ const load = loader({
   },
 
   schemaset: {
-    requires: ['cfg'],
-    setup: ({ cfg }) => new SchemaSet({
+    requires: [],
+    setup: () => new SchemaSet({
       serviceName: 'object',
     }),
   },
@@ -51,8 +51,8 @@ const load = loader({
   },
 
   generateReferences: {
-    requires: ['cfg', 'schemaset'],
-    setup: async ({ cfg, schemaset }) => libReferences.fromService({
+    requires: ['schemaset'],
+    setup: async ({ schemaset }) => libReferences.fromService({
       schemaset,
       references: [builder.reference(), MonitorManager.reference('object'), MonitorManager.metricsReference('object')],
     }).then(ref => ref.generateReferences()),

--- a/services/object/src/middleware/base.js
+++ b/services/object/src/middleware/base.js
@@ -1,5 +1,5 @@
 export class Middleware {
-  constructor({ monitor, rootUrl, config }) {
+  constructor({ monitor, rootUrl }) {
     this.monitor = monitor;
     this.rootUrl = rootUrl;
   }
@@ -26,14 +26,14 @@ export class Middleware {
    *
    * Subclasses may override this method; the default does nothing.
    */
-  async startDownloadRequest(req, res, object, method, params) {
+  async startDownloadRequest(_req, _res, _object, _method, _params) {
     return true;
   }
 
   /**
    * Similar to startDownloadRequest, but for the simple-download API.
    */
-  async downloadRequest(req, res, object) {
+  async downloadRequest(_req, _res, _object) {
     return true;
   }
 }

--- a/services/object/src/middleware/cdn.js
+++ b/services/object/src/middleware/cdn.js
@@ -12,7 +12,7 @@ export class CdnMiddleware extends Middleware {
     this.baseUrl = config.baseUrl;
   }
 
-  async downloadRequest(req, res, object) {
+  async downloadRequest(_req, res, object) {
     // If the regular expression matches, then redirect to the CDN URL instead of
     // allowing the backend URL to serve this request.
     if (this.regexp.test(object.name)) {

--- a/services/object/src/middleware/test.js
+++ b/services/object/src/middleware/test.js
@@ -6,7 +6,7 @@ export class TestMiddleware extends Middleware {
     this.config = options.config;
   }
 
-  async startDownloadRequest(req, res, object, method, params) {
+  async startDownloadRequest(_req, res, object, _method, _params) {
     switch (object.name) {
       case 'dl/intercept': {
         res.reply({
@@ -20,7 +20,7 @@ export class TestMiddleware extends Middleware {
     }
   }
 
-  async downloadRequest(req, res, object) {
+  async downloadRequest(_req, res, object) {
     switch (object.name) {
       case 'simple/intercept': {
         res.redirect(303, 'http://intercepted');

--- a/services/object/test/api_test.js
+++ b/services/object/test/api_test.js
@@ -8,10 +8,10 @@ import { toDataUrl, TestBackend } from '../src/backends/test.js';
 
 helper.secrets.mockSuite(testing.suiteName(), [], (mock, skipping) => {
   helper.withDb(mock, skipping);
-  helper.resetTables(mock, skipping);
-  helper.withBackends(mock, skipping);
-  helper.withMiddleware(mock, skipping);
-  helper.withServer(mock, skipping);
+  helper.resetTables();
+  helper.withBackends(skipping);
+  helper.withMiddleware(skipping);
+  helper.withServer(skipping);
 
   // these don't have to be hashes of anything, just have the right format
   const sha256 = 'e38808a4dbfdd9c82a351cc9a6055dffc7b4cc8e12020b2685f8eef92f5d1544';

--- a/services/object/test/backends/aws_test.js
+++ b/services/object/test/backends/aws_test.js
@@ -25,7 +25,7 @@ helper.secrets.mockSuite(testing.suiteName(), ['aws'], (mock, skipping) => {
   }
 
   helper.withDb(mock, skipping);
-  helper.withBackends(mock, skipping);
+  helper.withBackends(skipping);
 
   let secret, s3;
 
@@ -196,7 +196,7 @@ helper.secrets.mockSuite(testing.suiteName(), ['aws'], (mock, skipping) => {
     title: 'public bucket',
     backendId: 'awsPublic',
     makeObject,
-    async checkUrl({ name, url }) {
+    async checkUrl({ url }) {
       // *not* signed
       assert(!url.match(/X-Amz-Credential=/), `got ${url}`);
       assert(!url.match(/X-Amz-Signature=/), `got ${url}`);
@@ -210,7 +210,7 @@ helper.secrets.mockSuite(testing.suiteName(), ['aws'], (mock, skipping) => {
     title: 'private bucket',
     backendId: 'awsPrivate',
     makeObject,
-    async checkUrl({ name, url }) {
+    async checkUrl({ url }) {
       // ..contains S3 signature query args (note that testSimpleDownloadMethod
       // will verify that the URL actually works; this just verifies that it
       // is not un-signed).
@@ -225,7 +225,7 @@ helper.secrets.mockSuite(testing.suiteName(), ['aws'], (mock, skipping) => {
     mock, skipping, prefix,
     backendId: 'awsPrivate',
     makeObject,
-    async checkUrl({ name, url }) {
+    async checkUrl({ url }) {
       // URL should always be signed
       assert(url.match(/X-Amz-Credential=/), `got ${url}`);
       assert(url.match(/X-Amz-Signature=/), `got ${url}`);

--- a/services/object/test/backends/google_test.js
+++ b/services/object/test/backends/google_test.js
@@ -24,7 +24,7 @@ helper.secrets.mockSuite(testing.suiteName(), ['google'], (mock, skipping) => {
   }
 
   helper.withDb(mock, skipping);
-  helper.withBackends(mock, skipping);
+  helper.withBackends(skipping);
 
   let secret, s3;
 
@@ -81,7 +81,7 @@ helper.secrets.mockSuite(testing.suiteName(), ['google'], (mock, skipping) => {
 
   const projectId = 'test-proj';
 
-  const makeObject = async ({ name, data, hashes, gzipped }) => {
+  const makeObject = async ({ name, data, hashes }) => {
     const expires = taskcluster.fromNow('1 hour');
     const uploadId = taskcluster.slugid();
 
@@ -161,7 +161,7 @@ helper.secrets.mockSuite(testing.suiteName(), ['google'], (mock, skipping) => {
     title: 'public bucket',
     backendId: 'googlePublic',
     makeObject,
-    async checkUrl({ name, url }) {
+    async checkUrl({ url }) {
       // *not* signed
       assert(!url.match(/X-Amz-Credential=/), `got ${url}`);
       assert(!url.match(/X-Amz-Signature=/), `got ${url}`);
@@ -175,7 +175,7 @@ helper.secrets.mockSuite(testing.suiteName(), ['google'], (mock, skipping) => {
     title: 'private bucket',
     backendId: 'googlePrivate',
     makeObject,
-    async checkUrl({ name, url }) {
+    async checkUrl({ url }) {
       // ..contains S3 signature query args (note that testSimpleDownloadMethod
       // will verify that the URL actually works; this just verifies that it
       // is not un-signed).
@@ -190,7 +190,7 @@ helper.secrets.mockSuite(testing.suiteName(), ['google'], (mock, skipping) => {
     mock, skipping, prefix,
     backendId: 'googlePrivate',
     makeObject,
-    async checkUrl({ name, url }) {
+    async checkUrl({ url }) {
       assert(url.match(/X-Amz-Credential=/), `got ${url}`);
       assert(url.match(/X-Amz-Signature=/), `got ${url}`);
     },

--- a/services/object/test/backends_test.js
+++ b/services/object/test/backends_test.js
@@ -6,7 +6,7 @@ import { TestBackend } from '../src/backends/test.js';
 
 helper.secrets.mockSuite(testing.suiteName(), [], (mock, skipping) => {
   helper.withDb(mock, skipping);
-  helper.withBackends(mock, skipping);
+  helper.withBackends(skipping);
 
   let db, monitor, cfg;
   setup(async () => {

--- a/services/object/test/expire_test.js
+++ b/services/object/test/expire_test.js
@@ -5,8 +5,8 @@ import testing from '@taskcluster/lib-testing';
 
 helper.secrets.mockSuite(testing.suiteName(), [], (mock, skipping) => {
   helper.withDb(mock, skipping);
-  helper.resetTables(mock, skipping);
-  helper.withBackends(mock, skipping);
+  helper.resetTables();
+  helper.withBackends(skipping);
 
   setup(async () => {
     helper.load.save();

--- a/services/object/test/helper/backend-general.js
+++ b/services/object/test/helper/backend-general.js
@@ -7,8 +7,6 @@ import { DOWNLOAD_METHODS } from '../../src/api.js';
  * Test properties general to all backends.
  */
 export const testBackend = ({
-  mock, skipping,
-
   // optional title suffix
   title,
 

--- a/services/object/test/helper/data-inline-upload.js
+++ b/services/object/test/helper/data-inline-upload.js
@@ -10,8 +10,6 @@ const responseSchema = 'https://tc-testing.example.com/schemas/object/v1/create-
  * of tests.
  */
 export const testDataInlineUpload = ({
-  mock, skipping,
-
   // optional title suffix
   title,
 
@@ -42,7 +40,7 @@ export const testDataInlineUpload = ({
       backend = backends.get(backendId);
     });
 
-    const createUpload = async ({ name, data, proposedUploadMethods }) => {
+    const createUpload = async ({ name, proposedUploadMethods }) => {
       const expires = taskcluster.fromNow('1 hour');
       const uploadId = taskcluster.slugid();
 

--- a/services/object/test/helper/geturl-download.js
+++ b/services/object/test/helper/geturl-download.js
@@ -8,8 +8,6 @@ import { load, testObjectName } from '../helper/index.js';
  * of tests.
  */
 export const testGetUrlDownloadMethod = ({
-  mock, skipping,
-
   // optional title suffix
   title,
 

--- a/services/object/test/helper/index.js
+++ b/services/object/test/helper/index.js
@@ -61,7 +61,7 @@ const testclients = {
  *  helper.setBackendConfig({ backends, backendMap }) - set and activate the backends config,
  *    or if no args then reset it to the default.
  */
-helper.withBackends = (mock, skipping) => {
+helper.withBackends = skipping => {
   let _backends;
   const defaultBackends = {
     testBackend: { backendType: 'test' },
@@ -117,7 +117,7 @@ helper.withBackends = (mock, skipping) => {
   });
 };
 
-helper.withMiddleware = (mock, skipping, config) => {
+helper.withMiddleware = (skipping, config) => {
   suiteSetup('withMiddleware', async () => {
     if (skipping()) {
       return;
@@ -137,7 +137,7 @@ helper.withMiddleware = (mock, skipping, config) => {
   });
 };
 
-helper.withServer = (mock, skipping) => {
+helper.withServer = skipping => {
   let webServer;
 
   suiteSetup('withServer', async () => {
@@ -188,7 +188,7 @@ helper.withDb = (mock, skipping) => {
   testing.withDb(mock, skipping, helper, 'object');
 };
 
-helper.resetTables = (mock, skipping) => {
+helper.resetTables = () => {
   setup('reset tables', async () => {
     await testing.resetTables({
       tableNames: ['objects', 'object_hashes'],

--- a/services/object/test/helper/put-url-upload.js
+++ b/services/object/test/helper/put-url-upload.js
@@ -11,8 +11,6 @@ const responseSchema = 'https://tc-testing.example.com/schemas/object/v1/create-
  * of tests.
  */
 export const testPutUrlUpload = ({
-  mock, skipping,
-
   // optional title suffix
   title,
 
@@ -62,7 +60,7 @@ export const testPutUrlUpload = ({
       return { name, data, res, uploadId, object };
     };
 
-    const performUpload = async ({ name, data, res, uploadId }) => {
+    const performUpload = async ({ data, res }) => {
       assert(new Date(res.putUrl.expires) > new Date());
 
       let req = request.put(res.putUrl.url);

--- a/services/object/test/helper/simple-download.js
+++ b/services/object/test/helper/simple-download.js
@@ -8,8 +8,6 @@ import { load, testObjectName } from '../helper/index.js';
  * of tests.
  */
 export const testSimpleDownloadMethod = ({
-  mock, skipping,
-
   // optional title suffix
   title,
 

--- a/services/object/test/middleware/cdn_test.js
+++ b/services/object/test/middleware/cdn_test.js
@@ -7,12 +7,12 @@ import taskcluster from '@taskcluster/client';
 
 helper.secrets.mockSuite(testing.suiteName(), [], (mock, skipping) => {
   helper.withDb(mock, skipping);
-  helper.resetTables(mock, skipping);
-  helper.withBackends(mock, skipping);
-  helper.withMiddleware(mock, skipping, [
+  helper.resetTables();
+  helper.withBackends(skipping);
+  helper.withMiddleware(skipping, [
     { 'middlewareType': 'cdn', regexp: "^public/.*", baseUrl: "https://cdn.example.com/" },
   ]);
-  helper.withServer(mock, skipping);
+  helper.withServer(skipping);
 
   const makeObject = async name => {
     const data = crypto.randomBytes(128);

--- a/services/object/test/middleware_test.js
+++ b/services/object/test/middleware_test.js
@@ -2,8 +2,8 @@ import { strict as assert } from 'node:assert';
 import helper from './helper/index.js';
 import testing from '@taskcluster/lib-testing';
 
-helper.secrets.mockSuite(testing.suiteName(), [], (mock, skipping) => {
-  helper.withMiddleware(mock, skipping, [
+helper.secrets.mockSuite(testing.suiteName(), [], (_mock, skipping) => {
+  helper.withMiddleware(skipping, [
     { 'middlewareType': 'test', startDownload: { intercept: 'dl' } },
     { 'middlewareType': 'test', download: { intercept: 'simple' } },
   ]);

--- a/services/purge-cache/src/main.js
+++ b/services/purge-cache/src/main.js
@@ -22,8 +22,8 @@ const load = loader({
   },
 
   schemaset: {
-    requires: ['cfg'],
-    setup: ({ cfg }) => new SchemaSet({
+    requires: [],
+    setup: () => new SchemaSet({
       serviceName: 'purge-cache',
     }),
   },
@@ -64,8 +64,8 @@ const load = loader({
   },
 
   generateReferences: {
-    requires: ['cfg', 'schemaset'],
-    setup: async ({ cfg, schemaset }) => libReferences.fromService({
+    requires: ['schemaset'],
+    setup: async ({ schemaset }) => libReferences.fromService({
       schemaset,
       references: [builder.reference(), MonitorManager.reference('purge-cache'), MonitorManager.metricsReference('purge-cache')],
     }).then(ref => ref.generateReferences()),

--- a/services/purge-cache/test/helper.js
+++ b/services/purge-cache/test/helper.js
@@ -36,7 +36,7 @@ helper.withDb = (mock, skipping) => {
 /**
  * Set up an API server.
  */
-helper.withServer = (mock, skipping) => {
+helper.withServer = skipping => {
   let webServer;
   const cachePurgeCache = {};
 

--- a/services/purge-cache/test/purgecache_test.js
+++ b/services/purge-cache/test/purgecache_test.js
@@ -7,7 +7,7 @@ import taskcluster from '@taskcluster/client';
 
 helper.secrets.mockSuite(testing.suiteName(), [], (mock, skipping) => {
   helper.withDb(mock, skipping);
-  helper.withServer(mock, skipping);
+  helper.withServer(skipping);
 
   test('ping', () => {
     return helper.apiClient.ping();
@@ -98,7 +98,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], (mock, skipping) => {
   });
 
   test('purgeRequest caching', async () => {
-    sinon.stub(helper.db.fns, 'purge_requests_wpid').callsFake(async (query) => []);
+    sinon.stub(helper.db.fns, 'purge_requests_wpid').callsFake(async () => []);
     try {
       const since = taskcluster.fromNow('-1 hour').toString();
       await helper.apiClient.purgeRequests('pp/wt', { since });
@@ -119,7 +119,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], (mock, skipping) => {
 
     sinon.stub(helper.db.fns, 'purge_requests_wpid')
       .onFirstCall().throws(new Error('uhoh'))
-      .onSecondCall().callsFake(async (query) => []);
+      .onSecondCall().callsFake(async () => []);
     try {
       const since = taskcluster.fromNow('-1 hour').toString();
       await assert.rejects(() => client.purgeRequests('pp/wt', { since }));

--- a/services/queue/src/api.js
+++ b/services/queue/src/api.js
@@ -776,7 +776,7 @@ const patchAndValidateTaskDef = (taskId, taskDef, maxTaskDeadlineDays) => {
 };
 
 /** Ensure the taskGroup exists and that membership is declared */
-const ensureTaskGroup = async (ctx, taskId, taskDef, res) => {
+const ensureTaskGroup = async (ctx, _taskId, taskDef, res) => {
   const taskGroupId = taskDef.taskGroupId;
   const schedulerId = taskDef.schedulerId;
   const expires = new Date(taskDef.expires);

--- a/services/queue/src/artifacts.js
+++ b/services/queue/src/artifacts.js
@@ -552,7 +552,7 @@ export const loadArtifactsRoutes = (builder) => {
    * names is used internally for tracking artifact names that have already been seen
    * when traversing links.
    */
-  const replyWithArtifactDownload = async function({ taskId, runId, name, req, res, names }) {
+  const replyWithArtifactDownload = async function({ taskId, runId, name, req, res }) {
     const artifact = await getArtifactFollowingLinks.call(this, { taskId, runId, name, req, res });
 
     const { storageType } = artifact;
@@ -885,7 +885,7 @@ export const loadArtifactsRoutes = (builder) => {
    * does not return information about the artifact's content (which would require a
    * `queue:get-artifact:..` scope).
    */
-  const replyWithArtifactInfo = async function({ taskId, runId, name, req, res }) {
+  const replyWithArtifactInfo = async function({ taskId, runId, name, res }) {
     const artifact = artifactUtils.fromDbRows(
       await this.db.fns.get_queue_artifact_2(taskId, runId, name));
 

--- a/services/queue/src/data.js
+++ b/services/queue/src/data.js
@@ -276,7 +276,7 @@ export class Provisioner {
   // Get a provisioner from the DB, or undefined
   // This is emulated using the task_queues table as there is no
   // longer a queue_provisioners table.
-  static async get(db, provisionerId, expires) {
+  static async get(db, provisionerId, _expires) {
     const allTaskQueues = await TaskQueue.getAllTaskQueues(db, new Date());
     const taskQueuesForProvisioner = allTaskQueues.filter(
       tq => (provisionerId === splitTaskQueueId(tq.taskQueueId).provisionerId),
@@ -309,9 +309,7 @@ export class Provisioner {
   // is emulated by using the data from the task_queues table
   static async getProvisioners(
     db,
-    {
-      expires,
-    },
+    _options,
     {
       query,
     } = {},

--- a/services/queue/src/exchanges.js
+++ b/services/queue/src/exchanges.js
@@ -164,7 +164,7 @@ const commonMessageBuilder = (message) => {
 };
 
 /** Build a message from message */
-const commonRoutingKeyBuilder = (message, routing) => ({
+const commonRoutingKeyBuilder = (message, _routing) => ({
   taskId: message.status.taskId,
   runId: message.runId,
   workerGroup: message.workerGroup,
@@ -176,13 +176,13 @@ const commonRoutingKeyBuilder = (message, routing) => ({
 });
 
 /** Build a message from message for task-group messages */
-const taskGroupRoutingKeyBuilder = (message, routing) => ({
+const taskGroupRoutingKeyBuilder = (message, _routing) => ({
   schedulerId: message.schedulerId,
   taskGroupId: message.taskGroupId,
 });
 
 /** Build list of routing keys to CC */
-const commonCCBuilder = (message, routes) => {
+const commonCCBuilder = (_message, routes) => {
   assert(Array.isArray(routes), 'Routes must be an array');
   return routes.map(route => `route.${route}`);
 };

--- a/services/queue/src/main.js
+++ b/services/queue/src/main.js
@@ -68,8 +68,8 @@ const load = loader({
 
   // Validator and publisher
   schemaset: {
-    requires: ['cfg'],
-    setup: ({ cfg }) => new SchemaSet({
+    requires: [],
+    setup: () => new SchemaSet({
       serviceName: 'queue',
     }),
   },
@@ -204,8 +204,8 @@ const load = loader({
   },
 
   generateReferences: {
-    requires: ['cfg', 'schemaset'],
-    setup: async ({ cfg, schemaset }) => libReferences.fromService({
+    requires: ['schemaset'],
+    setup: async ({ schemaset }) => libReferences.fromService({
       schemaset,
       references: [builder.reference(), exchanges.reference(), MonitorManager.reference('queue'), MonitorManager.metricsReference('queue')],
     }).then(ref => ref.generateReferences()),
@@ -384,8 +384,8 @@ const load = loader({
 
   // Create the queue-message expiration process (periodic job)
   'expire-queue-messages': {
-    requires: ['cfg', 'queueService', 'monitor'],
-    setup: ({ cfg, queueService, monitor }, ownName) => {
+    requires: ['queueService', 'monitor'],
+    setup: ({ queueService, monitor }, ownName) => {
       return monitor.oneShot(ownName, async () => {
         debug('Expiring pending messages at: %s', new Date());
         await queueService.deleteExpired();

--- a/services/queue/test/artifact_test.js
+++ b/services/queue/test/artifact_test.js
@@ -92,13 +92,13 @@ helper.secrets.mockSuite(testing.suiteName(), ['aws'], function(mock, skipping) 
 
   suite('without public artifact signing', () => {
     withCleanLoaderState();
-    helper.withObjectService(mock, skipping);
+    helper.withObjectService();
     helper.withDb(mock, skipping);
-    helper.withAmazonIPRanges(mock, skipping);
-    helper.withPulse(mock, skipping);
+    helper.withAmazonIPRanges(skipping);
+    helper.withPulse(skipping);
     helper.withS3(mock, skipping);
-    helper.withServer(mock, skipping);
-    helper.resetTables(mock, skipping);
+    helper.withServer(skipping);
+    helper.resetTables();
 
     let taskId, taskCredentials;
 
@@ -1117,10 +1117,10 @@ helper.secrets.mockSuite(testing.suiteName(), ['aws'], function(mock, skipping) 
       helper.load.cfg('app.signPublicArtifactUrls', true);
     });
     helper.withDb(mock, skipping);
-    helper.withPulse(mock, skipping);
+    helper.withPulse(skipping);
     helper.withS3(mock, skipping);
-    helper.withServer(mock, skipping);
-    helper.resetTables(mock, skipping);
+    helper.withServer(skipping);
+    helper.resetTables();
 
     test('S3 artifacts contain a Signature field in the redirect', async () => {
       const taskId = slugid.v4();

--- a/services/queue/test/canceltask_test.js
+++ b/services/queue/test/canceltask_test.js
@@ -10,11 +10,11 @@ import testing from '@taskcluster/lib-testing';
 
 helper.secrets.mockSuite(testing.suiteName(), ['aws'], (mock, skipping) => {
   helper.withDb(mock, skipping);
-  helper.withAmazonIPRanges(mock, skipping);
-  helper.withPulse(mock, skipping);
+  helper.withAmazonIPRanges(skipping);
+  helper.withPulse(skipping);
   helper.withS3(mock, skipping);
-  helper.withServer(mock, skipping);
-  helper.resetTables(mock, skipping);
+  helper.withServer(skipping);
+  helper.resetTables();
 
   // Use the same task definition for everything
   const taskDef = {

--- a/services/queue/test/canceltaskgroup_test.js
+++ b/services/queue/test/canceltaskgroup_test.js
@@ -10,11 +10,11 @@ import testing from '@taskcluster/lib-testing';
 
 helper.secrets.mockSuite(testing.suiteName(), ['aws'], (mock, skipping) => {
   helper.withDb(mock, skipping);
-  helper.withAmazonIPRanges(mock, skipping);
-  helper.withPulse(mock, skipping);
+  helper.withAmazonIPRanges(skipping);
+  helper.withPulse(skipping);
   helper.withS3(mock, skipping);
-  helper.withServer(mock, skipping);
-  helper.resetTables(mock, skipping);
+  helper.withServer(skipping);
+  helper.resetTables();
 
   const taskDef = (name, extra = {}) => ({
     taskQueueId: 'no-provisioner-extended-extended/test-worker-extended-extended',

--- a/services/queue/test/claimresolver_test.js
+++ b/services/queue/test/claimresolver_test.js
@@ -9,12 +9,12 @@ import { LEVELS } from '@taskcluster/lib-monitor';
 
 helper.secrets.mockSuite(testing.suiteName(), ['aws'], (mock, skipping) => {
   helper.withDb(mock, skipping);
-  helper.withAmazonIPRanges(mock, skipping);
-  helper.withPollingServices(mock, skipping);
-  helper.withPulse(mock, skipping);
+  helper.withAmazonIPRanges(skipping);
+  helper.withPollingServices(skipping);
+  helper.withPulse(skipping);
   helper.withS3(mock, skipping);
-  helper.withServer(mock, skipping);
-  helper.resetTables(mock, skipping);
+  helper.withServer(skipping);
+  helper.resetTables();
 
   // Generate random task queue id to use for this test
   const taskQueueId = helper.makeTaskQueueId('no-provisioner-extended-extended');

--- a/services/queue/test/claimtask_test.js
+++ b/services/queue/test/claimtask_test.js
@@ -8,11 +8,11 @@ import testing from '@taskcluster/lib-testing';
 
 helper.secrets.mockSuite(testing.suiteName(), ['aws'], (mock, skipping) => {
   helper.withDb(mock, skipping);
-  helper.withAmazonIPRanges(mock, skipping);
-  helper.withPulse(mock, skipping);
+  helper.withAmazonIPRanges(skipping);
+  helper.withPulse(skipping);
   helper.withS3(mock, skipping);
-  helper.withServer(mock, skipping);
-  helper.resetTables(mock, skipping);
+  helper.withServer(skipping);
+  helper.resetTables();
 
   // Use the same task definition for everything
   const taskDef = () => ({

--- a/services/queue/test/claimwork_test.js
+++ b/services/queue/test/claimwork_test.js
@@ -10,11 +10,11 @@ import { LEVELS } from '@taskcluster/lib-monitor';
 
 helper.secrets.mockSuite(testing.suiteName(), ['aws'], (mock, skipping) => {
   helper.withDb(mock, skipping);
-  helper.withAmazonIPRanges(mock, skipping);
-  helper.withPulse(mock, skipping);
+  helper.withAmazonIPRanges(skipping);
+  helper.withPulse(skipping);
   helper.withS3(mock, skipping);
-  helper.withServer(mock, skipping);
-  helper.resetTables(mock, skipping);
+  helper.withServer(skipping);
+  helper.resetTables();
 
   // Generate random task queue id to use for this test
   const taskQueueId = helper.makeTaskQueueId('no-provisioner-extended-extended');

--- a/services/queue/test/createtask_test.js
+++ b/services/queue/test/createtask_test.js
@@ -12,11 +12,11 @@ import { splitTaskQueueId } from '../src/utils.js';
 
 helper.secrets.mockSuite(testing.suiteName(), ['aws'], (mock, skipping) => {
   helper.withDb(mock, skipping);
-  helper.withAmazonIPRanges(mock, skipping);
+  helper.withAmazonIPRanges(skipping);
   helper.withS3(mock, skipping);
-  helper.withPulse(mock, skipping);
-  helper.withServer(mock, skipping);
-  helper.resetTables(mock, skipping);
+  helper.withPulse(skipping);
+  helper.withServer(skipping);
+  helper.resetTables();
 
   // Use the same task definition for everything
   const taskDef = {
@@ -399,7 +399,7 @@ helper.secrets.mockSuite(testing.suiteName(), ['aws'], (mock, skipping) => {
     );
     await helper.queue.createTask(slugid.v4(), makePriorityTask('high')).then(() => {
       assert(false, 'Expected 400 error!');
-    }, err => {
+    }, () => {
       debug('Got error as expected');
     });
   });

--- a/services/queue/test/deadline_test.js
+++ b/services/queue/test/deadline_test.js
@@ -11,12 +11,12 @@ import { LEVELS } from '@taskcluster/lib-monitor';
 
 helper.secrets.mockSuite(testing.suiteName(), ['aws'], (mock, skipping) => {
   helper.withDb(mock, skipping);
-  helper.withPollingServices(mock, skipping);
-  helper.withAmazonIPRanges(mock, skipping);
+  helper.withPollingServices(skipping);
+  helper.withAmazonIPRanges(skipping);
   helper.withS3(mock, skipping);
-  helper.withPulse(mock, skipping);
-  helper.withServer(mock, skipping);
-  helper.resetTables(mock, skipping);
+  helper.withPulse(skipping);
+  helper.withServer(skipping);
+  helper.resetTables();
 
   // Use the same task definition for everything
   const makeTask = () => {

--- a/services/queue/test/dependency_test.js
+++ b/services/queue/test/dependency_test.js
@@ -11,12 +11,12 @@ import { LEVELS } from '@taskcluster/lib-monitor';
 
 helper.secrets.mockSuite(testing.suiteName(), ['aws'], (mock, skipping) => {
   helper.withDb(mock, skipping);
-  helper.withAmazonIPRanges(mock, skipping);
-  helper.withPollingServices(mock, skipping);
-  helper.withPulse(mock, skipping);
+  helper.withAmazonIPRanges(skipping);
+  helper.withPollingServices(skipping);
+  helper.withPulse(skipping);
   helper.withS3(mock, skipping);
-  helper.withServer(mock, skipping);
-  helper.resetTables(mock, skipping);
+  helper.withServer(skipping);
+  helper.resetTables();
 
   const taskDef = () => ({
     taskQueueId: 'no-provisioner-extended-extended/test-worker-extended-extended',

--- a/services/queue/test/ec2regionresolver_test.js
+++ b/services/queue/test/ec2regionresolver_test.js
@@ -7,7 +7,7 @@ import { LEVELS } from '@taskcluster/lib-monitor';
 
 const __dirname = new URL('.', import.meta.url).pathname;
 suite(testing.suiteName(), () => {
-  helper.withAmazonIPRanges(false, () => false);
+  helper.withAmazonIPRanges(() => false);
 
   let monitor;
   setup(async () => {

--- a/services/queue/test/expireartifacts_test.js
+++ b/services/queue/test/expireartifacts_test.js
@@ -9,11 +9,11 @@ import { ListObjectsCommand, PutObjectCommand } from '@aws-sdk/client-s3';
 
 helper.secrets.mockSuite(testing.suiteName(), ['aws'], (mock, skipping) => {
   helper.withDb(mock, skipping);
-  helper.withAmazonIPRanges(mock, skipping);
-  helper.withPulse(mock, skipping);
+  helper.withAmazonIPRanges(skipping);
+  helper.withPulse(skipping);
   helper.withS3(mock, skipping);
-  helper.withServer(mock, skipping);
-  helper.resetTables(mock, skipping);
+  helper.withServer(skipping);
+  helper.resetTables();
 
   const MAX_ARTIFACTS = 5;
 
@@ -207,11 +207,11 @@ helper.secrets.mockSuite(testing.suiteName(), ['aws'], (mock, skipping) => {
   }
 
   helper.withDb(mock, skipping);
-  helper.withAmazonIPRanges(mock, skipping);
-  helper.withPulse(mock, skipping);
+  helper.withAmazonIPRanges(skipping);
+  helper.withPulse(skipping);
   helper.withGCS(mock, skipping);
-  helper.withServer(mock, skipping);
-  helper.resetTables(mock, skipping);
+  helper.withServer(skipping);
+  helper.resetTables();
 
   const MAX_ARTIFACTS = 5;
 

--- a/services/queue/test/expiretask_test.js
+++ b/services/queue/test/expiretask_test.js
@@ -8,11 +8,11 @@ import testing from '@taskcluster/lib-testing';
 
 helper.secrets.mockSuite(testing.suiteName(), ['aws'], (mock, skipping) => {
   helper.withDb(mock, skipping);
-  helper.withAmazonIPRanges(mock, skipping);
-  helper.withPulse(mock, skipping);
+  helper.withAmazonIPRanges(skipping);
+  helper.withPulse(skipping);
   helper.withS3(mock, skipping);
-  helper.withServer(mock, skipping);
-  helper.resetTables(mock, skipping);
+  helper.withServer(skipping);
+  helper.resetTables();
 
   // Use the same task definition for everything
   const makeTask = (expiration) => {

--- a/services/queue/test/gettask_test.js
+++ b/services/queue/test/gettask_test.js
@@ -7,11 +7,11 @@ import testing from '@taskcluster/lib-testing';
 
 helper.secrets.mockSuite(testing.suiteName(), ['aws'], (mock, skipping) => {
   helper.withDb(mock, skipping);
-  helper.withAmazonIPRanges(mock, skipping);
-  helper.withPulse(mock, skipping);
+  helper.withAmazonIPRanges(skipping);
+  helper.withPulse(skipping);
   helper.withS3(mock, skipping);
-  helper.withServer(mock, skipping);
-  helper.resetTables(mock, skipping);
+  helper.withServer(skipping);
+  helper.resetTables();
 
   const taskDef = {
     taskQueueId: 'no-provisioner-extended-extended/test-worker-extended-extended',

--- a/services/queue/test/helper.js
+++ b/services/queue/test/helper.js
@@ -180,7 +180,7 @@ helper.withGCS = withGCS;
  *
  * Note that this file is *always* mocked, regardless of any secrets.
  */
-export const withAmazonIPRanges = (mock, skipping) => {
+export const withAmazonIPRanges = skipping => {
   let interceptor;
 
   suiteSetup(async () => {
@@ -211,7 +211,7 @@ helper.withDb = withDb;
 /**
  * Set up a fake object service that supports uploads and downlods.
  */
-export const withObjectService = (mock, skipping) => {
+export const withObjectService = () => {
   let objects = new Map();
   suiteSetup(async () => {
     const err404 = message => {
@@ -222,14 +222,14 @@ export const withObjectService = (mock, skipping) => {
     helper.objectService = new taskcluster.Object({
       rootUrl: helper.rootUrl,
       fake: {
-        createUpload: async (name, { expires, hashes, projectId, proposedUploadMethods, uploadId }) => {
+        createUpload: async (name, { expires, hashes, projectId, uploadId }) => {
           if (objects.has(name)) {
             throw new Error(`Object ${name} already exists`);
           }
           objects.set(name, { uploadId, expires, projectId, hashes });
           return { expires, projectId, uploadId, uploadMethod: {} };
         },
-        finishUpload: async (name, { expires, hashes, projectId, uploadId }) => {
+        finishUpload: async (name, { uploadId }) => {
           const object = objects.get(name);
           if (!object) {
             throw err404(`No such object ${name}`);
@@ -279,7 +279,7 @@ helper.withObjectService = withObjectService;
  * This also sets up helper.scopes to set the scopes for helper.queue, the
  * API client object, and stores a client class a helper.Queue.
  */
-export const withServer = (mock, skipping) => {
+export const withServer = skipping => {
   let webServer;
 
   suiteSetup(async () => {
@@ -347,7 +347,7 @@ export const withServer = (mock, skipping) => {
 };
 helper.withServer = withServer;
 
-export const withPulse = (mock, skipping) => {
+export const withPulse = skipping => {
   testing.withPulse({ helper, skipping, namespace: 'taskcluster-queue' });
 };
 helper.withPulse = withPulse;
@@ -358,7 +358,7 @@ helper.withPulse = withPulse;
  * helper.startPollingService will start the service.  Note that the
  * caller must stop the service *before* returning.
  */
-export const withPollingServices = (mock, skipping) => {
+export const withPollingServices = skipping => {
   let svc;
 
   suiteSetup(async () => {
@@ -438,7 +438,7 @@ export const checkDates = ({ status }) => {
 };
 helper.checkDates = checkDates;
 
-export const resetTables = (mock, skipping) => {
+export const resetTables = () => {
   setup('reset tables', async () => {
     await testing.resetTables({ tableNames: [
       'tasks',

--- a/services/queue/test/hintpoller_test.js
+++ b/services/queue/test/hintpoller_test.js
@@ -3,7 +3,7 @@ import HintPoller from '../src/hintpoller.js';
 import helper from './helper.js';
 import testing from '@taskcluster/lib-testing';
 
-helper.secrets.mockSuite(testing.suiteName(), [], (mock, skipping) => {
+helper.secrets.mockSuite(testing.suiteName(), [], (_mock, _skipping) => {
   test('calls pollPendingQueue', async () => {
     const monitor = await helper.load('monitor');
 

--- a/services/queue/test/priority_test.js
+++ b/services/queue/test/priority_test.js
@@ -6,11 +6,11 @@ import testing from '@taskcluster/lib-testing';
 
 helper.secrets.mockSuite(testing.suiteName(), ['aws'], (mock, skipping) => {
   helper.withDb(mock, skipping);
-  helper.withAmazonIPRanges(mock, skipping);
-  helper.withPulse(mock, skipping);
+  helper.withAmazonIPRanges(skipping);
+  helper.withPulse(skipping);
   helper.withS3(mock, skipping);
-  helper.withServer(mock, skipping);
-  helper.resetTables(mock, skipping);
+  helper.withServer(skipping);
+  helper.resetTables();
 
   const taskDef = {
     taskQueueId: 'no-provisioner/prio-worker',

--- a/services/queue/test/querytasks_test.js
+++ b/services/queue/test/querytasks_test.js
@@ -9,11 +9,11 @@ import testing from '@taskcluster/lib-testing';
 
 helper.secrets.mockSuite(testing.suiteName(), ['aws'], (mock, skipping) => {
   helper.withDb(mock, skipping);
-  helper.withAmazonIPRanges(mock, skipping);
-  helper.withPulse(mock, skipping);
+  helper.withAmazonIPRanges(skipping);
+  helper.withPulse(skipping);
   helper.withS3(mock, skipping);
-  helper.withServer(mock, skipping);
-  helper.resetTables(mock, skipping);
+  helper.withServer(skipping);
+  helper.resetTables();
 
   const taskDef = {
     taskQueueId: 'no-provisioner-extended-extended/query-test-worker-extended-extended',

--- a/services/queue/test/reruntask_test.js
+++ b/services/queue/test/reruntask_test.js
@@ -8,11 +8,11 @@ import testing from '@taskcluster/lib-testing';
 
 helper.secrets.mockSuite(testing.suiteName(), ['aws'], (mock, skipping) => {
   helper.withDb(mock, skipping);
-  helper.withAmazonIPRanges(mock, skipping);
-  helper.withPulse(mock, skipping);
+  helper.withAmazonIPRanges(skipping);
+  helper.withPulse(skipping);
   helper.withS3(mock, skipping);
-  helper.withServer(mock, skipping);
-  helper.resetTables(mock, skipping);
+  helper.withServer(skipping);
+  helper.resetTables();
 
   // Use the same task definition for everything
   const taskDef = {

--- a/services/queue/test/resolvetask_test.js
+++ b/services/queue/test/resolvetask_test.js
@@ -11,11 +11,11 @@ import { LEVELS } from '@taskcluster/lib-monitor';
 
 helper.secrets.mockSuite(testing.suiteName(), ['aws'], (mock, skipping) => {
   helper.withDb(mock, skipping);
-  helper.withAmazonIPRanges(mock, skipping);
-  helper.withPulse(mock, skipping);
+  helper.withAmazonIPRanges(skipping);
+  helper.withPulse(skipping);
   helper.withS3(mock, skipping);
-  helper.withServer(mock, skipping);
-  helper.resetTables(mock, skipping);
+  helper.withServer(skipping);
+  helper.resetTables();
 
   // Use the same task definition for everything
   const taskDef = {

--- a/services/queue/test/retry_test.js
+++ b/services/queue/test/retry_test.js
@@ -8,12 +8,12 @@ import testing from '@taskcluster/lib-testing';
 
 helper.secrets.mockSuite(testing.suiteName(), ['aws'], (mock, skipping) => {
   helper.withDb(mock, skipping);
-  helper.withAmazonIPRanges(mock, skipping);
-  helper.withPulse(mock, skipping);
+  helper.withAmazonIPRanges(skipping);
+  helper.withPulse(skipping);
   helper.withS3(mock, skipping);
-  helper.withServer(mock, skipping);
-  helper.withPollingServices(mock, skipping);
-  helper.resetTables(mock, skipping);
+  helper.withServer(skipping);
+  helper.withPollingServices(skipping);
+  helper.resetTables();
 
   // Use the same task definition for everything
   const taskDef = {

--- a/services/queue/test/scheduletask_test.js
+++ b/services/queue/test/scheduletask_test.js
@@ -8,11 +8,11 @@ import testing from '@taskcluster/lib-testing';
 
 helper.secrets.mockSuite(testing.suiteName(), ['aws'], (mock, skipping) => {
   helper.withDb(mock, skipping);
-  helper.withAmazonIPRanges(mock, skipping);
-  helper.withPulse(mock, skipping);
+  helper.withAmazonIPRanges(skipping);
+  helper.withPulse(skipping);
   helper.withS3(mock, skipping);
-  helper.withServer(mock, skipping);
-  helper.resetTables(mock, skipping);
+  helper.withServer(skipping);
+  helper.resetTables();
 
   // Use the same task definition for everything
   const taskDef = {

--- a/services/queue/test/taskgroup_test.js
+++ b/services/queue/test/taskgroup_test.js
@@ -10,12 +10,12 @@ import testing from '@taskcluster/lib-testing';
 
 helper.secrets.mockSuite(testing.suiteName(), ['aws'], (mock, skipping) => {
   helper.withDb(mock, skipping);
-  helper.withAmazonIPRanges(mock, skipping);
-  helper.withPollingServices(mock, skipping);
-  helper.withPulse(mock, skipping);
+  helper.withAmazonIPRanges(skipping);
+  helper.withPollingServices(skipping);
+  helper.withPulse(skipping);
   helper.withS3(mock, skipping);
-  helper.withServer(mock, skipping);
-  helper.resetTables(mock, skipping);
+  helper.withServer(skipping);
+  helper.resetTables();
 
   // Use the same task definition for everything
   const taskDef = {

--- a/services/queue/test/workclaimer_test.js
+++ b/services/queue/test/workclaimer_test.js
@@ -7,10 +7,10 @@ import WorkClaimer from '../src/workclaimer.js';
 
 helper.secrets.mockSuite(testing.suiteName(), ['aws'], (mock, skipping) => {
   helper.withDb(mock, skipping);
-  helper.withPulse(mock, skipping);
+  helper.withPulse(skipping);
   helper.withS3(mock, skipping);
-  helper.withServer(mock, skipping);
-  helper.resetTables(mock, skipping);
+  helper.withServer(skipping);
+  helper.resetTables();
 
   const taskDef = () => ({
     taskGroupId: slugid.v4(),
@@ -70,7 +70,7 @@ helper.secrets.mockSuite(testing.suiteName(), ['aws'], (mock, skipping) => {
       monitor,
       publisher,
       queueService: {
-        pollPendingQueue: (taskQueueId) => () => [{
+        pollPendingQueue: (_taskQueueId) => () => [{
           taskId,
           runId: 0,
           hintId: 'hint1',
@@ -107,7 +107,7 @@ helper.secrets.mockSuite(testing.suiteName(), ['aws'], (mock, skipping) => {
       monitor,
       publisher,
       queueService: {
-        pollPendingQueue: (taskQueueId) => () => {
+        pollPendingQueue: (_taskQueueId) => () => {
           calls++;
           if (calls < 3) {
             throw new Error('error');

--- a/services/queue/test/workerinfo_test.js
+++ b/services/queue/test/workerinfo_test.js
@@ -8,11 +8,11 @@ import { splitTaskQueueId } from '../src/utils.js';
 
 helper.secrets.mockSuite(testing.suiteName(), ['aws'], (mock, skipping) => {
   helper.withDb(mock, skipping);
-  helper.withAmazonIPRanges(mock, skipping);
-  helper.withPulse(mock, skipping);
+  helper.withAmazonIPRanges(skipping);
+  helper.withPulse(skipping);
   helper.withS3(mock, skipping);
-  helper.withServer(mock, skipping);
-  helper.resetTables(mock, skipping);
+  helper.withServer(skipping);
+  helper.resetTables();
 
   const makeTaskQueue = async (opts) => {
     const taskQueueId = opts.taskQueueId || 'prov1-extended-extended-extended/gecko-b-2-linux-extended-extended';

--- a/services/queue/test/workerremovedresolver_test.js
+++ b/services/queue/test/workerremovedresolver_test.js
@@ -7,11 +7,11 @@ import { LEVELS } from '@taskcluster/lib-monitor';
 
 helper.secrets.mockSuite(testing.suiteName(), ['aws'], (mock, skipping) => {
   helper.withDb(mock, skipping);
-  helper.withAmazonIPRanges(mock, skipping);
-  helper.withPulse(mock, skipping);
+  helper.withAmazonIPRanges(skipping);
+  helper.withPulse(skipping);
   helper.withS3(mock, skipping);
-  helper.withServer(mock, skipping);
-  helper.resetTables(mock, skipping);
+  helper.withServer(skipping);
+  helper.resetTables();
 
   const taskQueueId = helper.makeTaskQueueId('no-provisioner-extended-extended');
 

--- a/services/secrets/src/main.js
+++ b/services/secrets/src/main.js
@@ -32,8 +32,8 @@ const load = loader({
   },
 
   schemaset: {
-    requires: ['cfg'],
-    setup: ({ cfg }) => new SchemaSet({
+    requires: [],
+    setup: () => new SchemaSet({
       serviceName: 'secrets',
     }),
   },
@@ -52,8 +52,8 @@ const load = loader({
   },
 
   generateReferences: {
-    requires: ['cfg', 'schemaset'],
-    setup: async ({ cfg, schemaset }) => libReferences.fromService({
+    requires: ['schemaset'],
+    setup: async ({ schemaset }) => libReferences.fromService({
       schemaset,
       references: [builder.reference(), MonitorManager.reference('secrets'), MonitorManager.metricsReference('secrets')],
     }).then(ref => ref.generateReferences()),
@@ -91,8 +91,8 @@ const load = loader({
   },
 
   expire: {
-    requires: ['cfg', 'db', 'monitor'],
-    setup: ({ cfg, db, monitor }, ownName) => {
+    requires: ['db', 'monitor'],
+    setup: ({ db, monitor }, ownName) => {
       return monitor.oneShot(ownName, async () => {
         debug('Expiring secrets');
         const records = (await db.fns.expire_secrets_return_names());

--- a/services/secrets/test/api_test.js
+++ b/services/secrets/test/api_test.js
@@ -6,7 +6,7 @@ import testing from '@taskcluster/lib-testing';
 
 helper.secrets.mockSuite(testing.suiteName(), [], (mock, skipping) => {
   helper.withDb(mock, skipping);
-  helper.withServer(mock, skipping);
+  helper.withServer(skipping);
 
   const SECRET_NAME = `captain:${slugid.v4()}`;
   const testValueFoo = {

--- a/services/secrets/test/helper.js
+++ b/services/secrets/test/helper.js
@@ -44,7 +44,7 @@ const testClients = {
  * This also sets up helper.client as an API client generator, using the
  * "captain" clients.
  */
-helper.withServer = (mock, skipping) => {
+helper.withServer = skipping => {
   let webServer;
 
   suiteSetup(async () => {

--- a/services/web-server/src/PulseEngine/Subscription.js
+++ b/services/web-server/src/PulseEngine/Subscription.js
@@ -94,7 +94,7 @@ export default class Subscription {
         }
         await bindChannel.close();
 
-        const { consumerTag } = await channel.consume(queueName, (amqpMsg, err) => {
+        const { consumerTag } = await channel.consume(queueName, (amqpMsg, _err) => {
           // "If the consumer is cancelled by RabbitMQ, the message callback will be invoked with null."
           // This is most likely due to the queue being deleted, so we just report it to the user.
           if (!amqpMsg) {

--- a/services/web-server/src/loaders/artifacts.js
+++ b/services/web-server/src/loaders/artifacts.js
@@ -1,7 +1,7 @@
 import ConnectionLoader from '../ConnectionLoader.js';
 import Artifacts from '../entities/Artifacts.js';
 
-export default ({ queue }, isAuthed, rootUrl, monitor, strategies, req, cfg, requestId) => {
+export default ({ queue }, _isAuthed, _rootUrl, _monitor, _strategies, _req, _cfg, _requestId) => {
   const artifacts = new ConnectionLoader(
     async ({ taskId, runId, options }) => {
       const raw = await queue.listArtifacts(taskId, runId, options);

--- a/services/web-server/src/loaders/auth.js
+++ b/services/web-server/src/loaders/auth.js
@@ -3,7 +3,7 @@ import WebServerError from '../utils/WebServerError.js';
 import regenerateSession from '../utils/regenerateSession.js';
 import generateCredentials from '../utils/generateCredentials.js';
 
-export default (clients, isAuthed, rootUrl, monitor, strategies, req, cfg, requestId) => {
+export default (_clients, _isAuthed, _rootUrl, monitor, strategies, req, cfg, _requestId) => {
   const getCredentials = new DataLoader(queries => {
     return Promise.all(
       queries.map(async () => {

--- a/services/web-server/src/loaders/cachePurges.js
+++ b/services/web-server/src/loaders/cachePurges.js
@@ -1,6 +1,6 @@
 import ConnectionLoader from '../ConnectionLoader.js';
 
-export default ({ purgeCache }, isAuthed, rootUrl, monitor, strategies, req, cfg, requestId) => {
+export default ({ purgeCache }, _isAuthed, _rootUrl, _monitor, _strategies, _req, _cfg, _requestId) => {
   const cachePurges = new ConnectionLoader(async ({ options }) => {
     const raw = await purgeCache.allPurgeRequests(options);
 

--- a/services/web-server/src/loaders/clients.js
+++ b/services/web-server/src/loaders/clients.js
@@ -2,7 +2,7 @@ import DataLoader from 'dataloader';
 import substringFilter from '../utils/searchFilter.js';
 import ConnectionLoader from '../ConnectionLoader.js';
 
-export default ({ auth }, isAuthed, rootUrl, monitor, strategies, req, cfg, requestId) => {
+export default ({ auth }, _isAuthed, _rootUrl, _monitor, _strategies, _req, _cfg, _requestId) => {
   const clients = new ConnectionLoader(
     async ({ searchTerm, options, clientOptions }) => {
       const raw = await auth.listClients({ ...clientOptions, ...options });

--- a/services/web-server/src/loaders/github.js
+++ b/services/web-server/src/loaders/github.js
@@ -1,6 +1,6 @@
 import DataLoader from 'dataloader';
 
-export default ({ github }, isAuthed, rootUrl, monitor, strategies, req, cfg, requestId) => {
+export default ({ github }, _isAuthed, _rootUrl, _monitor, _strategies, _req, _cfg, _requestId) => {
   const githubRepository = new DataLoader(queries =>
     Promise.all(
       queries.map(async ({ owner, repo }) => {

--- a/services/web-server/src/loaders/hooks.js
+++ b/services/web-server/src/loaders/hooks.js
@@ -1,7 +1,7 @@
 import DataLoader from 'dataloader';
 import ConnectionLoader from '../ConnectionLoader.js';
 
-export default ({ hooks }, isAuthed, rootUrl, monitor, strategies, req, cfg, requestId) => {
+export default ({ hooks }, _isAuthed, _rootUrl, _monitor, _strategies, _req, _cfg, _requestId) => {
   const hookGroups = new DataLoader(queries =>
     Promise.all(
       queries.map(async ({ hookGroupId }) => {

--- a/services/web-server/src/loaders/namespaces.js
+++ b/services/web-server/src/loaders/namespaces.js
@@ -1,6 +1,6 @@
 import ConnectionLoader from '../ConnectionLoader.js';
 
-export default ({ index }, isAuthed, rootUrl, monitor, strategies, req, cfg, requestId) => {
+export default ({ index }, _isAuthed, _rootUrl, _monitor, _strategies, _req, _cfg, _requestId) => {
   const namespaces = new ConnectionLoader(
     async ({ namespace, options }) => {
       const raw = await index.listNamespaces(namespace, options);

--- a/services/web-server/src/loaders/notify.js
+++ b/services/web-server/src/loaders/notify.js
@@ -1,7 +1,7 @@
 import substringFilter from '../utils/searchFilter.js';
 import ConnectionLoader from '../ConnectionLoader.js';
 
-export default ({ notify }, isAuthed, rootUrl, monitor, strategies, req, cfg, requestId) => {
+export default ({ notify }, _isAuthed, _rootUrl, _monitor, _strategies, _req, _cfg, _requestId) => {
   const listDenylistAddresses = new ConnectionLoader(async ({ searchTerm, options }) => {
     const raw = await notify.listDenylist(options);
     const addresses = raw.addresses.map(address => {

--- a/services/web-server/src/loaders/provisioners.js
+++ b/services/web-server/src/loaders/provisioners.js
@@ -1,7 +1,7 @@
 import DataLoader from 'dataloader';
 import ConnectionLoader from '../ConnectionLoader.js';
 
-export default ({ queue }, isAuthed, rootUrl, monitor, strategies, req, cfg, requestId) => {
+export default ({ queue }, _isAuthed, _rootUrl, _monitor, _strategies, _req, _cfg, _requestId) => {
   const provisioner = new DataLoader(provisionerIds =>
     Promise.all(
       provisionerIds.map(async provisionerId => {

--- a/services/web-server/src/loaders/roles.js
+++ b/services/web-server/src/loaders/roles.js
@@ -2,7 +2,7 @@ import DataLoader from 'dataloader';
 import substringFilter from '../utils/searchFilter.js';
 import ConnectionLoader from '../ConnectionLoader.js';
 
-export default ({ auth }, isAuthed, rootUrl, monitor, strategies, req, cfg, requestId) => {
+export default ({ auth }, _isAuthed, _rootUrl, _monitor, _strategies, _req, _cfg, _requestId) => {
   const roles = new DataLoader(queries =>
     Promise.all(
       queries.map(async ({ searchTerm }) => {

--- a/services/web-server/src/loaders/scopes.js
+++ b/services/web-server/src/loaders/scopes.js
@@ -1,6 +1,6 @@
 import DataLoader from 'dataloader';
 
-export default ({ auth }, isAuthed, rootUrl, monitor, strategies, req, cfg, requestId) => {
+export default ({ auth }, _isAuthed, _rootUrl, _monitor, _strategies, _req, _cfg, _requestId) => {
   const currentScopes = new DataLoader(queries =>
     Promise.all(
       queries.map(async () => {

--- a/services/web-server/src/loaders/secrets.js
+++ b/services/web-server/src/loaders/secrets.js
@@ -2,7 +2,7 @@ import DataLoader from 'dataloader';
 import substringFilter from '../utils/searchFilter.js';
 import ConnectionLoader from '../ConnectionLoader.js';
 
-export default ({ secrets }, isAuthed, rootUrl, monitor, strategies, req, cfg, requestId) => {
+export default ({ secrets }, _isAuthed, _rootUrl, _monitor, _strategies, _req, _cfg, _requestId) => {
   const secretsList = new ConnectionLoader(async ({ searchTerm, options }) => {
     const raw = await secrets.list(options);
     const secretsList = raw.secrets.map(name => ({ name }));

--- a/services/web-server/src/loaders/taskStatuses.js
+++ b/services/web-server/src/loaders/taskStatuses.js
@@ -1,7 +1,7 @@
 import DataLoader from 'dataloader';
 import TaskStatus from '../entities/TaskStatus.js';
 
-export default ({ queue }, isAuthed, rootUrl, monitor, strategies, req, cfg, requestId) => {
+export default ({ queue }, _isAuthed, _rootUrl, _monitor, _strategies, _req, _cfg, _requestId) => {
   const status = new DataLoader(taskIds =>
     Promise.all(
       taskIds.map(async taskId => {

--- a/services/web-server/src/loaders/tasks.js
+++ b/services/web-server/src/loaders/tasks.js
@@ -21,7 +21,7 @@ const filterTaskActions = (actions, contextScope) =>
       : !isContextSize(action.context, 0);
   });
 
-export default ({ queue, index }, isAuthed, rootUrl, monitor, strategies, req, cfg, requestId) => {
+export default ({ queue, index }, isAuthed, _rootUrl, _monitor, _strategies, _req, _cfg, _requestId) => {
   const task = new DataLoader(taskIds =>
     Promise.all(
       taskIds.map(async (taskId) => {

--- a/services/web-server/src/loaders/workerManager.js
+++ b/services/web-server/src/loaders/workerManager.js
@@ -2,7 +2,7 @@ import DataLoader from 'dataloader';
 import substringFilter from '../utils/searchFilter.js';
 import ConnectionLoader from '../ConnectionLoader.js';
 
-export default ({ workerManager }, isAuthed, rootUrl, monitor, strategies, req, cfg, requestId) => {
+export default ({ workerManager }, _isAuthed, _rootUrl, _monitor, _strategies, _req, _cfg, _requestId) => {
   const WorkerManagerWorkerPoolSummaries = new ConnectionLoader(
     async ({ searchTerm, options }) => {
       const [pools, stats] = await Promise.all([

--- a/services/web-server/src/loaders/workerTypes.js
+++ b/services/web-server/src/loaders/workerTypes.js
@@ -1,7 +1,7 @@
 import DataLoader from 'dataloader';
 import ConnectionLoader from '../ConnectionLoader.js';
 
-export default ({ queue }, isAuthed, rootUrl, monitor, strategies, req, cfg, requestId) => {
+export default ({ queue }, _isAuthed, _rootUrl, _monitor, _strategies, _req, _cfg, _requestId) => {
   const workerType = new DataLoader(queries =>
     Promise.all(
       queries.map(async ({ provisionerId, workerType }) => {

--- a/services/web-server/src/loaders/workers.js
+++ b/services/web-server/src/loaders/workers.js
@@ -2,7 +2,7 @@ import DataLoader from 'dataloader';
 import ConnectionLoader from '../ConnectionLoader.js';
 import WorkerCompact from '../entities/WorkerCompact.js';
 
-export default ({ workerManager }, isAuthed, rootUrl, monitor, strategies, req, cfg, requestId) => {
+export default ({ workerManager }, _isAuthed, _rootUrl, _monitor, _strategies, _req, _cfg, _requestId) => {
   const worker = new DataLoader(queries =>
     Promise.all(
       queries.map(async ({ provisionerId, workerType, workerGroup, workerId }) => {

--- a/services/web-server/src/login/strategies/github.js
+++ b/services/web-server/src/login/strategies/github.js
@@ -64,7 +64,7 @@ export default class Github {
     return user;
   }
 
-  async addRoles(username, userId, user) {
+  async addRoles(_username, userId, user) {
     const [token] = await this.db.fns.load_github_access_token(String(userId));
 
     if (!token) {
@@ -131,7 +131,7 @@ export default class Github {
           callbackURL: `${cfg.app.publicUrl}${callback}`,
           scope: 'repo',
         },
-        async (accessToken, refreshToken, profile, next) => {
+        async (accessToken, _refreshToken, profile, next) => {
           await this.db.fns.add_github_access_token(
             profile.id,
             this.db.encrypt({ value: Buffer.from(accessToken, 'utf8') }),

--- a/services/web-server/src/login/strategies/mozilla-auth0.js
+++ b/services/web-server/src/login/strategies/mozilla-auth0.js
@@ -196,7 +196,7 @@ export default class MozillaAuth0 {
         // accessToken is the token to call Auth0 API (not needed in most cases)
         // extraParams.id_token has the JSON Web Token
         // profile has all the information from the user
-        async (accessToken, refreshToken, extraParams, profile, done) => {
+        async (_accessToken, _refreshToken, extraParams, profile, done) => {
           const [userErr, user] = await tryCatch(this.getUser({ userId: profile.user_id }));
 
           if (userErr) {

--- a/services/web-server/src/login/strategies/test.js
+++ b/services/web-server/src/login/strategies/test.js
@@ -29,7 +29,7 @@ export default class Test {
     return this.getUser({ userId });
   }
 
-  useStrategy(app, cfg) {
+  useStrategy(app, _cfg) {
     // unconditionally log in the user 'test'
     app.get('/login/test', (req, res, next) => {
       const user = {

--- a/services/web-server/src/main.js
+++ b/services/web-server/src/main.js
@@ -124,8 +124,8 @@ const load = loader(
     },
 
     schemaset: {
-      requires: ['cfg'],
-      setup: ({ cfg }) => new SchemaSet({
+      requires: [],
+      setup: () => new SchemaSet({
         serviceName: 'web-server',
       }),
     },
@@ -141,8 +141,8 @@ const load = loader(
     },
 
     generateReferences: {
-      requires: ['cfg', 'schemaset'],
-      setup: async ({ cfg, schemaset }) => libReferences.fromService({
+      requires: ['schemaset'],
+      setup: async ({ schemaset }) => libReferences.fromService({
         schemaset,
         references: [builder.reference(), MonitorManager.reference('web-server'), MonitorManager.metricsReference('web-server')],
       }).then(ref => ref.generateReferences()),
@@ -284,8 +284,8 @@ const load = loader(
     },
 
     'cleanup-session-storage': {
-      requires: ['cfg', 'monitor', 'db'],
-      setup: ({ cfg, monitor, db }) => {
+      requires: ['monitor', 'db'],
+      setup: ({ monitor, db }) => {
         return monitor.oneShot('cleanup-expire-session-storage', async () => {
           debug('Expiring session storage entries');
           const count = (await db.fns.expire_sessions())[0].expire_sessions;

--- a/services/web-server/src/resolvers/Artifacts.js
+++ b/services/web-server/src/resolvers/Artifacts.js
@@ -7,16 +7,16 @@ export default {
     ERROR: 'error',
   },
   Query: {
-    artifacts(parent, { taskId, runId, connection }, { loaders }) {
+    artifacts(_parent, { taskId, runId, connection }, { loaders }) {
       return loaders.artifacts.load({ taskId, runId, connection });
     },
-    latestArtifacts(parent, { taskId, connection }, { loaders }) {
+    latestArtifacts(_parent, { taskId, connection }, { loaders }) {
       return loaders.latestArtifacts.load({ taskId, connection });
     },
   },
   Subscription: {
     artifactsCreated: {
-      subscribe(parent, { taskGroupId }, { clients, pulseEngine }) {
+      subscribe(_parent, { taskGroupId }, { clients, pulseEngine }) {
         const routingKey = { taskGroupId };
         const binding = clients.queueEvents.artifactCreated(routingKey);
 

--- a/services/web-server/src/resolvers/Auth.js
+++ b/services/web-server/src/resolvers/Auth.js
@@ -1,9 +1,9 @@
 export default {
   Query: {
-    getCredentials(parent, args, { loaders }) {
+    getCredentials(_parent, args, { loaders }) {
       return loaders.getCredentials.load(args);
     },
-    isLoggedIn(parent, args, { loaders }) {
+    isLoggedIn(_parent, args, { loaders }) {
       return loaders.isLoggedIn.load(args);
     },
   },

--- a/services/web-server/src/resolvers/CachePurges.js
+++ b/services/web-server/src/resolvers/CachePurges.js
@@ -1,12 +1,12 @@
 export default {
   Query: {
-    cachePurges(parent, { connection }, { loaders }) {
+    cachePurges(_parent, { connection }, { loaders }) {
       return loaders.cachePurges.load({ connection });
     },
   },
   Mutation: {
     async purgeCache(
-      parent,
+      _parent,
       { provisionerId, workerType, payload },
       { clients },
     ) {

--- a/services/web-server/src/resolvers/Clients.js
+++ b/services/web-server/src/resolvers/Clients.js
@@ -1,29 +1,29 @@
 export default {
   Query: {
-    clients(parent, { clientOptions, connection, searchTerm }, { loaders }) {
+    clients(_parent, { clientOptions, connection, searchTerm }, { loaders }) {
       return loaders.clients.load({ clientOptions, connection, searchTerm });
     },
-    client(parent, { clientId }, { loaders }) {
+    client(_parent, { clientId }, { loaders }) {
       return loaders.client.load(clientId);
     },
   },
   Mutation: {
-    resetAccessToken(parent, { clientId }, { clients }) {
+    resetAccessToken(_parent, { clientId }, { clients }) {
       return clients.auth.resetAccessToken(clientId);
     },
-    createClient(parent, { clientId, client }, { clients }) {
+    createClient(_parent, { clientId, client }, { clients }) {
       return clients.auth.createClient(clientId, client);
     },
-    updateClient(parent, { clientId, client }, { clients }) {
+    updateClient(_parent, { clientId, client }, { clients }) {
       return clients.auth.updateClient(clientId, client);
     },
-    enableClient(parent, { clientId }, { clients }) {
+    enableClient(_parent, { clientId }, { clients }) {
       return clients.auth.enableClient(clientId);
     },
-    disableClient(parent, { clientId }, { clients }) {
+    disableClient(_parent, { clientId }, { clients }) {
       return clients.auth.disableClient(clientId);
     },
-    async deleteClient(parent, { clientId }, { clients }) {
+    async deleteClient(_parent, { clientId }, { clients }) {
       await clients.auth.deleteClient(clientId);
 
       return clientId;

--- a/services/web-server/src/resolvers/Github.js
+++ b/services/web-server/src/resolvers/Github.js
@@ -1,9 +1,9 @@
 export default {
   Query: {
-    githubRepository(parent, { owner, repo }, { loaders }) {
+    githubRepository(_parent, { owner, repo }, { loaders }) {
       return loaders.githubRepository.load({ owner, repo });
     },
-    renderTaskclusterYml(parent, payload, { loaders }) {
+    renderTaskclusterYml(_parent, payload, { loaders }) {
       return loaders.renderTaskclusterYml.load(payload);
     },
   },

--- a/services/web-server/src/resolvers/Hooks.js
+++ b/services/web-server/src/resolvers/Hooks.js
@@ -33,40 +33,40 @@ export default {
     UNKNOWN: 'unknown', // task not found
   },
   Hook: {
-    status({ hookGroupId, hookId }, args, { loaders }) {
+    status({ hookGroupId, hookId }, _args, { loaders }) {
       // this is deprecated
       return loaders.hookStatus.load({ hookGroupId, hookId });
     },
-    lastFire({ hookGroupId, hookId }, args, { loaders }) {
+    lastFire({ hookGroupId, hookId }, _args, { loaders }) {
       return loaders.hookLastFires.load({
         hookGroupId, hookId, connection: { limit: 1 },
       }).then(({ lastFires }) => lastFires?.[0]);
     },
   },
   HookGroup: {
-    hooks({ hookGroupId }, args, { loaders }) {
+    hooks({ hookGroupId }, _args, { loaders }) {
       return loaders.hooks.load({ hookGroupId });
     },
   },
   Query: {
-    hookGroups(parent, { hookGroupId }, { loaders }) {
+    hookGroups(_parent, { hookGroupId }, { loaders }) {
       return loaders.hookGroups.load({ hookGroupId });
     },
-    hooks(parent, { hookGroupId }, { loaders }) {
+    hooks(_parent, { hookGroupId }, { loaders }) {
       return loaders.hooks.load({ hookGroupId });
     },
-    hook(parent, { hookGroupId, hookId }, { loaders }) {
+    hook(_parent, { hookGroupId, hookId }, { loaders }) {
       return loaders.hook.load({ hookGroupId, hookId });
     },
-    hookStatus(parent, { hookGroupId, hookId }, { loaders }) {
+    hookStatus(_parent, { hookGroupId, hookId }, { loaders }) {
       return loaders.hookStatus.load({ hookGroupId, hookId });
     },
-    hookLastFires(parent, { hookGroupId, hookId, connection, options }, { loaders }) {
+    hookLastFires(_parent, { hookGroupId, hookId, connection, options }, { loaders }) {
       return loaders.hookLastFires.load({ hookGroupId, hookId, connection, options });
     },
   },
   Mutation: {
-    async triggerHook(parent, { hookGroupId, hookId, payload }, { clients }) {
+    async triggerHook(_parent, { hookGroupId, hookId, payload }, { clients }) {
       const { status } = await clients.hooks.triggerHook(
         hookGroupId,
         hookId,
@@ -75,13 +75,13 @@ export default {
 
       return status;
     },
-    createHook(parent, { hookGroupId, hookId, payload }, { clients }) {
+    createHook(_parent, { hookGroupId, hookId, payload }, { clients }) {
       return clients.hooks.createHook(hookGroupId, hookId, payload);
     },
-    updateHook(parent, { hookGroupId, hookId, payload }, { clients }) {
+    updateHook(_parent, { hookGroupId, hookId, payload }, { clients }) {
       return clients.hooks.updateHook(hookGroupId, hookId, payload);
     },
-    async deleteHook(parent, { hookGroupId, hookId }, { clients }) {
+    async deleteHook(_parent, { hookGroupId, hookId }, { clients }) {
       await clients.hooks.removeHook(hookGroupId, hookId);
 
       return { hookGroupId, hookId };

--- a/services/web-server/src/resolvers/Namespaces.js
+++ b/services/web-server/src/resolvers/Namespaces.js
@@ -1,9 +1,9 @@
 export default {
   Query: {
-    namespaces(parent, { namespace, connection }, { loaders }) {
+    namespaces(_parent, { namespace, connection }, { loaders }) {
       return loaders.namespaces.load({ namespace, connection });
     },
-    taskNamespace(parent, { namespace, connection }, { loaders }) {
+    taskNamespace(_parent, { namespace, connection }, { loaders }) {
       return loaders.taskNamespace.load({ namespace, connection });
     },
   },

--- a/services/web-server/src/resolvers/Notify.js
+++ b/services/web-server/src/resolvers/Notify.js
@@ -6,17 +6,17 @@ export default {
     SLACK_CHANNEL: 'slack-channel',
   },
   Query: {
-    listDenylistAddresses(parent, { connection, searchTerm }, { loaders }) {
+    listDenylistAddresses(_parent, { connection, searchTerm }, { loaders }) {
       return loaders.listDenylistAddresses.load({ connection, searchTerm });
     },
   },
   Mutation: {
-    async addDenylistAddress(parent, { address }, { clients }) {
+    async addDenylistAddress(_parent, { address }, { clients }) {
       await clients.notify.addDenylistAddress(address);
 
       return address;
     },
-    async deleteDenylistAddress(parent, { address }, { clients }) {
+    async deleteDenylistAddress(_parent, { address }, { clients }) {
       await clients.notify.deleteDenylistAddress(address);
 
       return address;

--- a/services/web-server/src/resolvers/Provisioners.js
+++ b/services/web-server/src/resolvers/Provisioners.js
@@ -24,10 +24,10 @@ export default {
     },
   },
   Query: {
-    provisioner(parent, { provisionerId }, { loaders }) {
+    provisioner(_parent, { provisionerId }, { loaders }) {
       return loaders.provisioner.load(provisionerId);
     },
-    provisioners(parent, { connection }, { loaders }) {
+    provisioners(_parent, { connection }, { loaders }) {
       return loaders.provisioners.load({ connection });
     },
   },

--- a/services/web-server/src/resolvers/PulseMessages.js
+++ b/services/web-server/src/resolvers/PulseMessages.js
@@ -1,7 +1,7 @@
 export default {
   Subscription: {
     pulseMessages: {
-      subscribe(parent, { subscriptions }, { pulseEngine }) {
+      subscribe(_parent, { subscriptions }, { pulseEngine }) {
         return pulseEngine.messageIterator('pulseMessages', subscriptions);
       },
     },

--- a/services/web-server/src/resolvers/Roles.js
+++ b/services/web-server/src/resolvers/Roles.js
@@ -1,23 +1,23 @@
 export default {
   Query: {
-    roles(parent, { searchTerm }, { loaders }) {
+    roles(_parent, { searchTerm }, { loaders }) {
       return loaders.roles.load({ searchTerm });
     },
-    listRoleIds(parent, { connection, searchTerm }, { loaders }) {
+    listRoleIds(_parent, { connection, searchTerm }, { loaders }) {
       return loaders.roleIds.load({ searchTerm, connection });
     },
-    role(parent, { roleId }, { loaders }) {
+    role(_parent, { roleId }, { loaders }) {
       return loaders.role.load(roleId);
     },
   },
   Mutation: {
-    createRole(parent, { roleId, role }, { clients }) {
+    createRole(_parent, { roleId, role }, { clients }) {
       return clients.auth.createRole(roleId, role);
     },
-    updateRole(parent, { roleId, role }, { clients }) {
+    updateRole(_parent, { roleId, role }, { clients }) {
       return clients.auth.updateRole(roleId, role);
     },
-    async deleteRole(parent, { roleId }, { clients }) {
+    async deleteRole(_parent, { roleId }, { clients }) {
       await clients.auth.deleteRole(roleId);
 
       return roleId;

--- a/services/web-server/src/resolvers/Scopes.js
+++ b/services/web-server/src/resolvers/Scopes.js
@@ -1,9 +1,9 @@
 export default {
   Query: {
-    currentScopes(parent, args, { loaders }) {
+    currentScopes(_parent, _args, { loaders }) {
       return loaders.currentScopes.load({});
     },
-    expandScopes(parent, { scopes }, { loaders }) {
+    expandScopes(_parent, { scopes }, { loaders }) {
       return loaders.expandScopes.load({ scopes });
     },
   },

--- a/services/web-server/src/resolvers/Secrets.js
+++ b/services/web-server/src/resolvers/Secrets.js
@@ -1,24 +1,24 @@
 export default {
   Query: {
-    secrets(parent, { connection, searchTerm }, { loaders }) {
+    secrets(_parent, { connection, searchTerm }, { loaders }) {
       return loaders.secrets.load({ connection, searchTerm });
     },
-    secret(parent, { name }, { loaders }) {
+    secret(_parent, { name }, { loaders }) {
       return loaders.secret.load(name);
     },
   },
   Mutation: {
-    async createSecret(parent, { name, secret }, { clients }) {
+    async createSecret(_parent, { name, secret }, { clients }) {
       await clients.secrets.set(name, secret);
 
       return secret;
     },
-    async updateSecret(parent, { name, secret }, { clients }) {
+    async updateSecret(_parent, { name, secret }, { clients }) {
       await clients.secrets.set(name, secret);
 
       return secret;
     },
-    async deleteSecret(parent, { name }, { clients }) {
+    async deleteSecret(_parent, { name }, { clients }) {
       await clients.secrets.remove(name);
 
       return name;

--- a/services/web-server/src/resolvers/TaskStatuses.js
+++ b/services/web-server/src/resolvers/TaskStatuses.js
@@ -8,15 +8,15 @@ export default {
     EXCEPTION: 'exception',
   },
   TaskStatus: {
-    task(parent, args, { loaders }) {
+    task(parent, _args, { loaders }) {
       return loaders.task.load(parent.taskId);
     },
-    runs(parent, args) {
+    runs(parent, _args) {
       return parent.runs;
     },
   },
   Query: {
-    status(parent, { taskId }, { loaders }) {
+    status(_parent, { taskId }, { loaders }) {
       return loaders.status.load(taskId);
     },
   },

--- a/services/web-server/src/resolvers/Tasks.js
+++ b/services/web-server/src/resolvers/Tasks.js
@@ -24,14 +24,14 @@ export default {
     tasksException: 'tasksException',
   },
   Task: {
-    status(parent, args, { loaders }) {
+    status(parent, _args, { loaders }) {
       if (parent.status) {
         return parent.status;
       }
 
       return loaders.status.load(parent.taskId);
     },
-    taskActions(parent, args, { loaders }) {
+    taskActions(parent, _args, { loaders }) {
       if (parent.taskActions) {
         return parent.taskActions;
       }
@@ -41,7 +41,7 @@ export default {
         contextScope: 'task',
       });
     },
-    async decisionTask(parent, args, { loaders }) {
+    async decisionTask(parent, _args, { loaders }) {
       if (parent.decisionTask) {
         return parent.decisionTask;
       }
@@ -66,7 +66,7 @@ export default {
     },
   },
   DependentTask: {
-    async status(parent, args, { loaders }) {
+    async status(parent, _args, { loaders }) {
       // parent.status might be null if dependentTasks already determined that
       // this task does not exist, in which case skip the status load
       if ('status' in parent) {
@@ -84,10 +84,10 @@ export default {
     },
   },
   Query: {
-    task(parent, { taskId }, { loaders }) {
+    task(_parent, { taskId }, { loaders }) {
       return loaders.task.load(taskId);
     },
-    tasks(parent, { taskIds }, { loaders }) {
+    tasks(_parent, { taskIds }, { loaders }) {
       return Promise.all(taskIds.map(async (taskId) => {
         try {
           return await loaders.task.load(taskId);
@@ -96,7 +96,7 @@ export default {
         }
       }));
     },
-    async dependentTasks(parent, args, { loaders }) {
+    async dependentTasks(_parent, args, { loaders }) {
       const task = await loaders.task.load(args.taskId);
 
       return Promise.all(task.dependencies.map(async (dependency) => {
@@ -113,52 +113,52 @@ export default {
         }
       }));
     },
-    async dependents(parent, { taskId, connection }, { loaders }) {
+    async dependents(_parent, { taskId, connection }, { loaders }) {
       return loaders.dependents.load({ taskId, connection });
     },
-    indexedTask(parent, { indexPath }, { loaders }) {
+    indexedTask(_parent, { indexPath }, { loaders }) {
       return loaders.indexedTask.load(indexPath);
     },
-    taskGroup(parent, { taskGroupId, connection }, { loaders }) {
+    taskGroup(_parent, { taskGroupId, connection }, { loaders }) {
       return loaders.taskGroup.load({ taskGroupId, connection });
     },
-    taskActions(parent, { taskGroupId }, { loaders }) {
+    taskActions(_parent, { taskGroupId }, { loaders }) {
       return loaders.taskActions.load({ taskGroupId, contextScope: 'group' });
     },
-    listPendingTasks(parent, { taskQueueId, connection }, { loaders }) {
+    listPendingTasks(_parent, { taskQueueId, connection }, { loaders }) {
       return loaders.listPendingTasks.load({ taskQueueId, connection });
     },
-    listClaimedTasks(parent, { taskQueueId, connection }, { loaders }) {
+    listClaimedTasks(_parent, { taskQueueId, connection }, { loaders }) {
       return loaders.listClaimedTasks.load({ taskQueueId, connection });
     },
   },
   Mutation: {
-    async createTask(parent, { taskId, task }, { clients }) {
+    async createTask(_parent, { taskId, task }, { clients }) {
       const { options: _, ...taskWithoutOptions } = task;
       const { status } = await clients.queue.createTask(taskId, taskWithoutOptions);
 
       return new TaskStatus(taskId, status);
     },
-    async scheduleTask(parent, { taskId }, { clients }) {
+    async scheduleTask(_parent, { taskId }, { clients }) {
       const { status } = await clients.queue.scheduleTask(taskId);
 
       return new TaskStatus(taskId, status);
     },
-    async cancelTask(parent, { taskId }, { clients }) {
+    async cancelTask(_parent, { taskId }, { clients }) {
       const { status } = await clients.queue.cancelTask(taskId);
 
       return new TaskStatus(taskId, status);
     },
-    async rerunTask(parent, { taskId }, { clients }) {
+    async rerunTask(_parent, { taskId }, { clients }) {
       const { status } = await clients.queue.rerunTask(taskId);
 
       return new TaskStatus(taskId, status);
     },
-    async sealTaskGroup(parent, { taskGroupId }, { clients }) {
+    async sealTaskGroup(_parent, { taskGroupId }, { clients }) {
       const taskGroup = await clients.queue.sealTaskGroup(taskGroupId);
       return taskGroup;
     },
-    async cancelTaskGroup(parent, { taskGroupId }, { clients }) {
+    async cancelTaskGroup(_parent, { taskGroupId }, { clients }) {
       const taskGroup = await clients.queue.cancelTaskGroup(taskGroupId);
       return taskGroup;
     },
@@ -167,7 +167,7 @@ export default {
     // by taskGroupId
     tasksSubscriptions: {
       subscribe(
-        parent,
+        _parent,
         { taskGroupId, subscriptions },
         { pulseEngine, clients },
       ) {
@@ -193,7 +193,7 @@ export default {
     // by taskId
     taskSubscriptions: {
       subscribe(
-        parent,
+        _parent,
         { taskId, subscriptions },
         { pulseEngine, clients },
       ) {

--- a/services/web-server/src/resolvers/WorkerManager.js
+++ b/services/web-server/src/resolvers/WorkerManager.js
@@ -2,7 +2,7 @@ import { splitWorkerPoolId } from '../utils/workerPool.js';
 
 export default {
   WorkerManagerWorkerPoolSummary: {
-    pendingTasks({ workerPoolId }, args, { loaders }) {
+    pendingTasks({ workerPoolId }, _args, { loaders }) {
       const { provisionerId, workerType } = splitWorkerPoolId(workerPoolId);
       return loaders.pendingTasks.load({
         provisionerId,
@@ -11,42 +11,42 @@ export default {
     },
   },
   Query: {
-    WorkerManagerWorkerPoolSummaries(parent, { connection, searchTerm }, { loaders }) {
+    WorkerManagerWorkerPoolSummaries(_parent, { connection, searchTerm }, { loaders }) {
       return loaders.WorkerManagerWorkerPoolSummaries.load({ connection, searchTerm });
     },
-    WorkerManagerErrors(parent, { workerPoolId, launchConfigId, connection }, { loaders }) {
+    WorkerManagerErrors(_parent, { workerPoolId, launchConfigId, connection }, { loaders }) {
       return loaders.WorkerManagerErrors.load({ workerPoolId, launchConfigId, connection });
     },
-    WorkerManagerErrorsStats(parent, { workerPoolId }, { loaders }) {
+    WorkerManagerErrorsStats(_parent, { workerPoolId }, { loaders }) {
       return loaders.WorkerManagerErrorsStats.load({ workerPoolId });
     },
-    WorkerPool(parent, { workerPoolId }, { loaders }) {
+    WorkerPool(_parent, { workerPoolId }, { loaders }) {
       return loaders.WorkerPool.load({ workerPoolId });
     },
-    WorkerPoolLaunchConfigs(parent, { workerPoolId, includeArchived, connection }, { loaders }) {
+    WorkerPoolLaunchConfigs(_parent, { workerPoolId, includeArchived, connection }, { loaders }) {
       return loaders.WorkerPoolLaunchConfigs.load({ workerPoolId, includeArchived, connection });
     },
-    WorkerManagerWorker(parent, { workerPoolId, workerGroup, workerId }, { loaders }) {
+    WorkerManagerWorker(_parent, { workerPoolId, workerGroup, workerId }, { loaders }) {
       return loaders.WorkerManagerWorker.load({ workerPoolId, workerGroup, workerId });
     },
-    WorkerManagerWorkers(parent, { workerPoolId, launchConfigId, state, connection }, { loaders }) {
+    WorkerManagerWorkers(_parent, { workerPoolId, launchConfigId, state, connection }, { loaders }) {
       return loaders.WorkerManagerWorkers.load({ workerPoolId, launchConfigId, state, connection });
     },
-    WorkerManagerProviders(parent, { connection }, { loaders }) {
+    WorkerManagerProviders(_parent, { connection }, { loaders }) {
       return loaders.WorkerManagerProviders.load({ connection });
     },
-    WorkerPoolStats(parent, { workerPoolId }, { loaders }) {
+    WorkerPoolStats(_parent, { workerPoolId }, { loaders }) {
       return loaders.WorkerPoolStats.load({ workerPoolId });
     },
   },
   Mutation: {
-    createWorkerPool(parent, { workerPoolId, payload }, { clients }) {
+    createWorkerPool(_parent, { workerPoolId, payload }, { clients }) {
       return clients.workerManager.createWorkerPool(workerPoolId, payload);
     },
-    updateWorkerPool(parent, { workerPoolId, payload }, { clients }) {
+    updateWorkerPool(_parent, { workerPoolId, payload }, { clients }) {
       return clients.workerManager.updateWorkerPool(workerPoolId, payload);
     },
-    async deleteWorkerPool(parent, { workerPoolId }, { clients }) {
+    async deleteWorkerPool(_parent, { workerPoolId }, { clients }) {
       await clients.workerManager.deleteWorkerPool(workerPoolId);
 
       return workerPoolId;

--- a/services/web-server/src/resolvers/WorkerTypes.js
+++ b/services/web-server/src/resolvers/WorkerTypes.js
@@ -28,18 +28,18 @@ export default {
         workerId,
       });
     },
-    pendingTasks({ provisionerId, workerType }, args, { loaders }) {
+    pendingTasks({ provisionerId, workerType }, _args, { loaders }) {
       return loaders.pendingTasks.load({ provisionerId, workerType });
     },
   },
   Query: {
-    workerType(parent, { provisionerId, workerType }, { loaders }) {
+    workerType(_parent, { provisionerId, workerType }, { loaders }) {
       return loaders.workerType.load({ provisionerId, workerType });
     },
-    pendingTasks(parent, { provisionerId, workerType }, { loaders }) {
+    pendingTasks(_parent, { provisionerId, workerType }, { loaders }) {
       return loaders.pendingTasks.load({ provisionerId, workerType });
     },
-    workerTypes(parent, { provisionerId, connection }, { loaders }) {
+    workerTypes(_parent, { provisionerId, connection }, { loaders }) {
       return loaders.workerTypes.load({ provisionerId, connection });
     },
   },

--- a/services/web-server/src/resolvers/Workers.js
+++ b/services/web-server/src/resolvers/Workers.js
@@ -1,13 +1,13 @@
 export default {
   LatestTask: {
-    async run(parent, args, { loaders }) {
+    async run(parent, _args, { loaders }) {
       const status = await loaders.status.load(parent.taskId);
 
       return status.runs[parent.runId];
     },
   },
   Worker: {
-    latestTasks(parent, args, { loaders }) {
+    latestTasks(parent, _args, { loaders }) {
       return Promise.all(parent.recentTasks.map(async ({ taskId }) => {
         try {
           return await loaders.task.load(taskId);
@@ -19,7 +19,7 @@ export default {
   },
   Query: {
     worker(
-      parent,
+      _parent,
       { provisionerId, workerType, workerGroup, workerId },
       { loaders },
     ) {
@@ -31,7 +31,7 @@ export default {
       });
     },
     workers(
-      parent,
+      _parent,
       {
         provisionerId,
         workerType,
@@ -52,7 +52,7 @@ export default {
   },
   Mutation: {
     quarantineWorker(
-      parent,
+      _parent,
       { provisionerId, workerType, workerGroup, workerId, payload },
       { clients },
     ) {

--- a/services/web-server/src/servers/createApp.js
+++ b/services/web-server/src/servers/createApp.js
@@ -17,7 +17,7 @@ import { traceMiddleware } from '@taskcluster/lib-app';
 
 const __dirname = new URL('.', import.meta.url).pathname;
 
-export default async ({ cfg, strategies, auth, monitor, db, clients, rootUrl, api }) => {
+export default async ({ cfg, strategies, auth, monitor, db, api }) => {
   const app = express();
 
   app.set('trust proxy', cfg.server.trustProxy);
@@ -155,7 +155,7 @@ export default async ({ cfg, strategies, auth, monitor, db, clients, rootUrl, ap
   }
 
   // Error handling middleware
-  app.use((err, req, res, next) => {
+  app.use((err, _req, res, _next) => {
     // Minimize the amount of information we disclose. The err could potentially disclose something to an attacker.
     const error = { code: err.code, name: err.name };
     monitor.reportError(err);

--- a/services/web-server/src/servers/createSubscriptionServer.js
+++ b/services/web-server/src/servers/createSubscriptionServer.js
@@ -69,7 +69,7 @@ export default ({ cfg, server, schema, context, path, authFactory }) => {
         clearTimeout(timeout);
         timeoutMap.delete(socket);
       },
-      async onOperation(message, connection) {
+      async onOperation(_message, connection) {
         // formatResponse should be replaced when
         // SubscriptionServer accepts a formatError
         // parameter for custom error formatting.

--- a/services/web-server/src/servers/credentials.js
+++ b/services/web-server/src/servers/credentials.js
@@ -1,6 +1,6 @@
 import { decryptToken } from "./decryptToken.js";
 
-export default () => async (request, response, next) => {
+export default () => async (request, _response, next) => {
   if (
     (!request.credentials && !request.headers.authorization) ||
     !request.headers.authorization.startsWith('Bearer')

--- a/services/web-server/src/servers/formatError.js
+++ b/services/web-server/src/servers/formatError.js
@@ -1,5 +1,5 @@
 // https://www.apollographql.com/docs/apollo-server/migration#error-formatting-changes
-export default (formattedError, error) => {
+export default (_formattedError, error) => {
   const data = error?.toJson?.() || error;
 
   if (

--- a/services/web-server/src/servers/oauth2.js
+++ b/services/web-server/src/servers/oauth2.js
@@ -162,7 +162,7 @@ export default (cfg, db, strategies, auth, monitor) => {
    * are validated, the application issues a Taskcluster token on behalf of the user who
    * authorized the code.
    */
-  server.exchange(oauth2orize.exchange.code(unpromisify(async (client, code, redirectURI) => {
+  server.exchange(oauth2orize.exchange.code(unpromisify(async (_client, code, redirectURI) => {
     const [entry] = await db.fns.consume_authorization_code(code);
 
     if (!entry) {
@@ -201,7 +201,7 @@ export default (cfg, db, strategies, auth, monitor) => {
   const authorization = [
     ensureLoggedIn(),
     (req, res, done) => {
-      server.authorization(unpromisify(async (clientID, redirectURI, scope) => {
+      server.authorization(unpromisify(async (clientID, redirectURI, _scope) => {
         const client = findRegisteredClient(clientID);
 
         if (!client) {

--- a/services/web-server/src/servers/oauth2AccessToken.js
+++ b/services/web-server/src/servers/oauth2AccessToken.js
@@ -1,4 +1,4 @@
-export default () => (request, response, next) => {
+export default () => (request, _response, next) => {
   if (
     (!request.accessToken && !request.headers.authorization) ||
     !request.headers.authorization.startsWith('Bearer')

--- a/services/web-server/src/utils/headers.js
+++ b/services/web-server/src/utils/headers.js
@@ -5,7 +5,7 @@
  * @param {import('express').Response} res
  * @param {import('express').NextFunction} next
  */
-export const applySecurityHeaders = (req, res, next) => {
+export const applySecurityHeaders = (_req, res, next) => {
   res.setHeader('X-Frame-Options', 'SAMEORIGIN');
   res.setHeader('Cross-Origin-Opener-Policy', 'same-origin-allow-popups');
   next();

--- a/services/web-server/src/utils/regenerateSession.js
+++ b/services/web-server/src/utils/regenerateSession.js
@@ -2,13 +2,13 @@
 export default req => new Promise((resolve) => {
   const temp = req.session.passport;
 
-  req.session.regenerate((err) => {
+  req.session.regenerate((_err) => {
     // Passport adds a passport key to req.session. When req.session.regenerate runs,
     // req.session.passport becomes undefined because req.session is recreated.
     // The callback makes the necessary changes to make passport aware of the current user.
     // For more information, see https://stackoverflow.com/a/26394156/6150432
     req.session.passport = temp;
-    req.session.save((err) => {
+    req.session.save((_err) => {
       resolve();
     });
   });

--- a/services/web-server/test/auth_test.js
+++ b/services/web-server/test/auth_test.js
@@ -5,8 +5,8 @@ import testing from '@taskcluster/lib-testing';
 
 helper.secrets.mockSuite(testing.suiteName(), [], (mock, skipping) => {
   helper.withDb(mock, skipping);
-  helper.withServer(mock, skipping);
-  helper.resetTables(mock, skipping);
+  helper.withServer(skipping);
+  helper.resetTables();
 
   test('Unauthorized', async () => {
     const credentialsQuery = await helper.loadFixture('credentials.graphql');

--- a/services/web-server/test/graphql/artifacts_graphql_test.js
+++ b/services/web-server/test/graphql/artifacts_graphql_test.js
@@ -4,11 +4,11 @@ import testing from '@taskcluster/lib-testing';
 import helper from '../helper.js';
 
 helper.secrets.mockSuite(testing.suiteName(), [], (mock, skipping) => {
-  helper.withFakeAuthFactory(mock, skipping);
+  helper.withFakeAuthFactory(skipping);
   helper.withDb(mock, skipping);
-  helper.withClients(mock, skipping);
-  helper.withServer(mock, skipping);
-  helper.resetTables(mock, skipping);
+  helper.withClients(skipping);
+  helper.withServer(skipping);
+  helper.resetTables();
 
   suite('Artifact Queries GraphQL', () => {
     test('artifacts query works', async () => {

--- a/services/web-server/test/graphql/hooks_test.js
+++ b/services/web-server/test/graphql/hooks_test.js
@@ -5,9 +5,9 @@ import helper from '../helper.js';
 
 helper.secrets.mockSuite(testing.suiteName(), [], (mock, skipping) => {
   helper.withDb(mock, skipping);
-  helper.withClients(mock, skipping);
-  helper.withServer(mock, skipping);
-  helper.resetTables(mock, skipping);
+  helper.withClients(skipping);
+  helper.withServer(skipping);
+  helper.resetTables();
 
   suite('Hooks GraphQL', () => {
     test('hooks query works', async () => {

--- a/services/web-server/test/graphql/roles_test.js
+++ b/services/web-server/test/graphql/roles_test.js
@@ -6,9 +6,9 @@ import helper from '../helper.js';
 
 helper.secrets.mockSuite(testing.suiteName(), [], (mock, skipping) => {
   helper.withDb(mock, skipping);
-  helper.withClients(mock, skipping);
-  helper.withServer(mock, skipping);
-  helper.resetTables(mock, skipping);
+  helper.withClients(skipping);
+  helper.withServer(skipping);
+  helper.resetTables();
 
   suite('Roles GraphQL', () => {
     test('role query works', async () => {

--- a/services/web-server/test/graphql/tasks_graphql_test.js
+++ b/services/web-server/test/graphql/tasks_graphql_test.js
@@ -14,7 +14,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], (mock, skipping) => {
     if (skipping()) {
       return;
     }
-    helper.load.inject('authFactory', ({ credentials }) =>
+    helper.load.inject('authFactory', () =>
       new taskcluster.Auth({
         rootUrl: helper.rootUrl,
         fake: {
@@ -31,10 +31,10 @@ helper.secrets.mockSuite(testing.suiteName(), [], (mock, skipping) => {
   });
 
   helper.withDb(mock, skipping);
-  helper.withClients(mock, skipping);
-  helper.withServer(mock, skipping);
+  helper.withClients(skipping);
+  helper.withServer(skipping);
   helper.withPulse(helper, skipping);
-  helper.resetTables(mock, skipping);
+  helper.resetTables();
 
   suite('Task Queries and Mutations', () => {
     test('query works', async () => {

--- a/services/web-server/test/graphql/validation_test.js
+++ b/services/web-server/test/graphql/validation_test.js
@@ -5,9 +5,9 @@ import helper from '../helper.js';
 
 helper.secrets.mockSuite(testing.suiteName(), [], (mock, skipping) => {
   helper.withDb(mock, skipping);
-  helper.withClients(mock, skipping);
-  helper.withServer(mock, skipping);
-  helper.resetTables(mock, skipping);
+  helper.withClients(skipping);
+  helper.withServer(skipping);
+  helper.resetTables();
 
   suite('GraphQL Validation', () => {
     test('max tokens in request', async () => {

--- a/services/web-server/test/graphql/workermanager_test.js
+++ b/services/web-server/test/graphql/workermanager_test.js
@@ -5,9 +5,9 @@ import helper from '../helper.js';
 
 helper.secrets.mockSuite(testing.suiteName(), [], (mock, skipping) => {
   helper.withDb(mock, skipping);
-  helper.withClients(mock, skipping);
-  helper.withServer(mock, skipping);
-  helper.resetTables(mock, skipping);
+  helper.withClients(skipping);
+  helper.withServer(skipping);
+  helper.resetTables();
 
   suite('WorkerPools', () => {
     test('deleting a worker pool calls deleteWorkerPool', async () => {

--- a/services/web-server/test/helper.js
+++ b/services/web-server/test/helper.js
@@ -65,7 +65,7 @@ helper.withMockedEventIterator = () => {
     PulseEngineCopy.NextAsyncIterator = asyncIterator;
   };
 
-  PulseEngineCopy.eventIterator = (eventName, subscriptions) => {
+  PulseEngineCopy.eventIterator = (_eventName, _subscriptions) => {
     if (!PulseEngineCopy.NextAsyncIterator) {
       throw new Error(`No async iterator to return. Set one up with SetNextAsyncIterator`);
     }
@@ -79,7 +79,7 @@ helper.withMockedEventIterator = () => {
   });
 };
 
-helper.withFakeAuth = (mock, skipping) => {
+helper.withFakeAuth = skipping => {
   suiteSetup('withFakeAuth', () => {
     if (skipping()) {
       return;
@@ -89,7 +89,7 @@ helper.withFakeAuth = (mock, skipping) => {
   });
 };
 
-helper.withFakeAuthFactory = (mock, skipping) => {
+helper.withFakeAuthFactory = skipping => {
   suiteSetup('withFakeAuthFactory', () => {
     if (skipping()) {
       return;
@@ -103,7 +103,7 @@ helper.withFakeAuthFactory = (mock, skipping) => {
   });
 };
 
-helper.withClients = (mock, skipping) => {
+helper.withClients = skipping => {
   suiteSetup('withClients', async () => {
     if (skipping()) {
       return;
@@ -120,7 +120,7 @@ helper.withClients = (mock, skipping) => {
   });
 };
 
-helper.withServer = (mock, skipping) => {
+helper.withServer = skipping => {
   let webServer;
 
   // return a signed-in Superagent agent
@@ -386,7 +386,7 @@ const stubbedAuth = () => {
 };
 
 const stubbedAuthFactory = () => {
-  return ({ credentials }) => new taskcluster.Auth({
+  return () => new taskcluster.Auth({
     rootUrl: helper.rootUrl,
     fake: {
       currentScopes: async () => ({ scopes: ['web:read-pulse'] }),
@@ -443,7 +443,7 @@ const stubbedClients = () => {
             hookId,
           });
         },
-        listLastFires: async (hookGroupId, hookId, filter) => {
+        listLastFires: async (hookGroupId, hookId, _filter) => {
           const taskStates = ['unscheduled', 'pending', 'running', 'completed', 'failed', 'exception', 'unknown'];
           const fireResults = ['success', 'error', 'no-fire'];
           const lastFires = taskStates.map((taskState, i) => ({
@@ -581,7 +581,7 @@ const stubbedClients = () => {
           };
           return Promise.resolve(artifact);
         },
-        listArtifacts: async (taskId, runId, options) => {
+        listArtifacts: async (taskId, runId, _options) => {
           const artifacts = ["1", "2", "3"].map(artifactSuffix => {
             return {
               taskId,
@@ -591,7 +591,7 @@ const stubbedClients = () => {
           });
           return Promise.resolve({ artifacts });
         },
-        listLatestArtifacts: async (taskId, options) => {
+        listLatestArtifacts: async (taskId, _options) => {
           const artifacts = ["1", "2", "3"].map(artifactSuffix => {
             return {
               taskId,
@@ -600,13 +600,13 @@ const stubbedClients = () => {
           });
           return Promise.resolve({ artifacts });
         },
-        pendingTasks: async (taskQueueId) => 0,
+        pendingTasks: async (_taskQueueId) => 0,
       },
     }),
   });
 };
 
-helper.resetTables = (mock, skipping) => {
+helper.resetTables = () => {
   setup('reset tables', async () => {
     await resetTables({ tableNames: [
       'authorization_codes',

--- a/services/web-server/test/loaders/roles_loader_test.js
+++ b/services/web-server/test/loaders/roles_loader_test.js
@@ -7,9 +7,9 @@ import loader from '../../src/loaders/roles.js';
 
 helper.secrets.mockSuite(testing.suiteName(), [], (mock, skipping) => {
   helper.withDb(mock, skipping);
-  helper.withClients(mock, skipping);
-  helper.withServer(mock, skipping);
-  helper.resetTables(mock, skipping);
+  helper.withClients(skipping);
+  helper.withServer(skipping);
+  helper.resetTables();
 
   suite('roles loaders', () => {
     test('load role while gracefully handling errors', async () => {

--- a/services/web-server/test/loaders/tasks_loader_test.js
+++ b/services/web-server/test/loaders/tasks_loader_test.js
@@ -7,9 +7,9 @@ import loader from '../../src/loaders/tasks.js';
 
 helper.secrets.mockSuite(testing.suiteName(), [], (mock, skipping) => {
   helper.withDb(mock, skipping);
-  helper.withClients(mock, skipping);
-  helper.withServer(mock, skipping);
-  helper.resetTables(mock, skipping);
+  helper.withClients(skipping);
+  helper.withServer(skipping);
+  helper.resetTables();
 
   suite('tasks loaders', () => {
     // Make sure we still get tasks even if we end up loading some tasks that don't exist

--- a/services/web-server/test/login_scanner_test.js
+++ b/services/web-server/test/login_scanner_test.js
@@ -44,7 +44,7 @@ suite(testing.suiteName(), () => {
   });
 
   class TestStrategy {
-    constructor({ name, cfg }) {
+    constructor({ name }) {
       this.identityProviderId = name;
     }
 

--- a/services/web-server/test/login_strategies_github_test.js
+++ b/services/web-server/test/login_strategies_github_test.js
@@ -6,7 +6,7 @@ import Github from '../src/login/strategies/github.js';
 helper.secrets.mockSuite(testing.suiteName(), [], (mock, skipping) => {
   helper.withDb(mock, skipping);
   helper.withGithubClient();
-  helper.resetTables(mock, skipping);
+  helper.resetTables();
 
   suite(testing.suiteName(), () => {
     const makeUser = (userId) => {

--- a/services/web-server/test/profiler/routes_test.js
+++ b/services/web-server/test/profiler/routes_test.js
@@ -281,7 +281,7 @@ suite('profiler/routes', () => {
         queue: {
           task: async () => completedTask.task,
           status: async () => ({ status: completedTask.status }),
-          buildUrl: (method, taskId, name) =>
+          buildUrl: (_method, taskId, name) =>
             `https://queue.test/task/${taskId}/artifacts/${name}`,
         },
       }));
@@ -337,7 +337,7 @@ suite('profiler/routes', () => {
         queue: {
           task: async () => completedTask.task,
           status: async () => ({ status: completedTask.status }),
-          buildUrl: (method, taskId, name) =>
+          buildUrl: (_method, taskId, name) =>
             `https://queue.test/task/${taskId}/artifacts/${name}`,
         },
       }));

--- a/services/web-server/test/pulseengine_test.js
+++ b/services/web-server/test/pulseengine_test.js
@@ -6,7 +6,7 @@ import testing from '@taskcluster/lib-testing';
 import './helper.js';
 
 class FakePulseEngine {
-  subscribe(subscriptions, handleMessage, handleError) {
+  subscribe(_subscriptions, handleMessage, handleError) {
     this.handleMessage = handleMessage;
     this.handleError = handleError;
     this.subscribed = true;

--- a/services/web-server/test/scanner_test.js
+++ b/services/web-server/test/scanner_test.js
@@ -6,8 +6,8 @@ import Test from '../src/login/strategies/test.js';
 
 helper.secrets.mockSuite(testing.suiteName(), [], (mock, skipping) => {
   helper.withDb(mock, skipping);
-  helper.withFakeAuth(mock, skipping);
-  helper.resetTables(mock, skipping);
+  helper.withFakeAuth(skipping);
+  helper.resetTables();
 
   let strategies;
   let clients;

--- a/services/web-server/test/server_test.js
+++ b/services/web-server/test/server_test.js
@@ -5,7 +5,7 @@ import testing from '@taskcluster/lib-testing';
 
 helper.secrets.mockSuite(testing.suiteName(), [], (mock, skipping) => {
   helper.withDb(mock, skipping);
-  helper.resetTables(mock, skipping);
+  helper.resetTables();
 
   const makeSuite = (allowedCORSOrigins, requestOrigin, responseOrigin) => {
     suite(`with ${JSON.stringify(allowedCORSOrigins)}, request origin = ${requestOrigin}`, () => {
@@ -19,7 +19,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], (mock, skipping) => {
         helper.load.restore();
       });
 
-      helper.withServer(mock, skipping);
+      helper.withServer(skipping);
 
       test('request', async () => {
         try {
@@ -47,7 +47,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], (mock, skipping) => {
     'https://deploy-preview-897--taskcluster-web.netlify.com/');
 
   suite('auth endpoints', () => {
-    helper.withServer(mock, skipping);
+    helper.withServer(skipping);
 
     test('login/logout', async () => {
       const logout = await request.post(`http://localhost:${helper.serverPort}/login/logout`);
@@ -56,7 +56,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], (mock, skipping) => {
   });
 
   suite('service endpoints', () => {
-    helper.withServer(mock, skipping);
+    helper.withServer(skipping);
 
     test('version', async () => {
       const version = await request.get(`http://localhost:${helper.serverPort}/api/web-server/v1/__version__`);

--- a/services/web-server/test/session_store_test.js
+++ b/services/web-server/test/session_store_test.js
@@ -8,9 +8,9 @@ import hash from '../src/utils/hash.js';
 
 helper.secrets.mockSuite(testing.suiteName(), [], (mock, skipping) => {
   helper.withDb(mock, skipping);
-  helper.withFakeAuth(mock, skipping);
-  helper.withServer(mock, skipping);
-  helper.resetTables(mock, skipping);
+  helper.withFakeAuth(skipping);
+  helper.withServer(skipping);
+  helper.resetTables();
 
   const getStore = (shouldPromisify = true, options) => {
     const SessionStore = PostgresSessionStore({

--- a/services/web-server/test/third_party_test.js
+++ b/services/web-server/test/third_party_test.js
@@ -11,9 +11,9 @@ import hash from '../src/utils/hash.js';
 
 helper.secrets.mockSuite(testing.suiteName(), [], (mock, skipping) => {
   helper.withDb(mock, skipping);
-  helper.withFakeAuth(mock, skipping);
-  helper.withServer(mock, skipping);
-  helper.resetTables(mock, skipping);
+  helper.withFakeAuth(skipping);
+  helper.withServer(skipping);
+  helper.resetTables();
 
   const url = path => `http://127.0.0.1:${helper.serverPort}${path}`;
   const getQuery = (url, sep = '?') => {

--- a/services/web-server/test/unpromisify_test.js
+++ b/services/web-server/test/unpromisify_test.js
@@ -47,7 +47,7 @@ suite(testing.suiteName(), () => {
     });
     assert.equal(success.length, 1); // done
 
-    success((err, sum) => {
+    success((err, _sum) => {
       if (!err?.toString().match(/uhoh/)) {
         return done(new Error('expected an error'));
       }

--- a/services/worker-manager/src/data.js
+++ b/services/worker-manager/src/data.js
@@ -375,7 +375,7 @@ export class WorkerPoolLaunchConfig {
   }
 
   // remove launch configurations that no longer have workers associated with them
-  static async expire({ db, monitor }) {
+  static async expire({ db }) {
     const rows = await db.fns.expire_worker_pool_launch_configs();
     return rows.map(row => row.launch_config_id);
   }
@@ -657,7 +657,7 @@ export class Worker {
 
   // Expire workers,
   // returning the count of workers expired.
-  static async expire({ db, monitor }) {
+  static async expire({ db }) {
     return (await db.fns.expire_workers(new Date()))[0].expire_workers;
   }
 
@@ -855,7 +855,7 @@ export class Worker {
 
     this._properties = {
       ...worker,
-      ..._.pickBy(_.pick(this, queueFields), (v, k) => worker[k] === undefined),
+      ..._.pickBy(_.pick(this, queueFields), (_v, k) => worker[k] === undefined),
     };
   }
 

--- a/services/worker-manager/src/estimator.js
+++ b/services/worker-manager/src/estimator.js
@@ -59,7 +59,7 @@ export class Estimator {
     minCapacity,
     maxCapacity,
     scalingRatio = 1.0,
-    workerInfo: { existingCapacity = 0, stoppingCapacity = 0, requestedCapacity = 0 },
+    workerInfo: { existingCapacity = 0, stoppingCapacity = 0 },
   }) {
     const { pendingTasks, claimedTasks } = await this.queue.taskQueueCounts(workerPoolId);
     const { desiredCapacity } = this.#calculateCapacity({

--- a/services/worker-manager/src/exchanges.js
+++ b/services/worker-manager/src/exchanges.js
@@ -68,7 +68,7 @@ const buildCommonRoutingKey = (options) => {
 
 const commonMessageBuilder = (message) => message;
 
-const commonRoutingKeyBuilder = (message, routing) => {
+const commonRoutingKeyBuilder = (message, _routing) => {
   const mapping = {
     workerGroup: message.workerGroup,
     providerId: message.providerId,

--- a/services/worker-manager/src/main.js
+++ b/services/worker-manager/src/main.js
@@ -51,8 +51,8 @@ const load = loader({
   },
 
   expireWorkerPools: {
-    requires: ['cfg', 'monitor', 'db'],
-    setup: ({ cfg, monitor, db }, ownName) => {
+    requires: ['monitor', 'db'],
+    setup: ({ monitor, db }, ownName) => {
       return monitor.childMonitor('expireWorkerPools').oneShot(ownName, async () => {
         const expired = await WorkerPool.expire({ db, monitor });
         for (const workerPoolId of expired) {
@@ -63,8 +63,8 @@ const load = loader({
   },
 
   expireLaunchConfigs: {
-    requires: ['cfg', 'monitor', 'db'],
-    setup: ({ cfg, monitor, db }, ownName) => {
+    requires: ['monitor', 'db'],
+    setup: ({ monitor, db }, ownName) => {
       return monitor.childMonitor('expireLaunchConfigs').oneShot(ownName, async () => {
         const expired = await WorkerPoolLaunchConfig.expire({ db, monitor });
         for (const launchConfigId of expired) {
@@ -75,8 +75,8 @@ const load = loader({
   },
 
   expireWorkers: {
-    requires: ['cfg', 'monitor', 'db'],
-    setup: ({ cfg, monitor, db }, ownName) => {
+    requires: ['monitor', 'db'],
+    setup: ({ monitor, db }, ownName) => {
       return monitor.childMonitor('expireWorkers').oneShot(ownName, async () => {
         const count = await Worker.expire({ db, monitor });
         monitor.info(`deleted ${count} workers`);
@@ -98,8 +98,8 @@ const load = loader({
   },
 
   schemaset: {
-    requires: ['cfg'],
-    setup: ({ cfg }) => new SchemaSet({
+    requires: [],
+    setup: () => new SchemaSet({
       serviceName: 'worker-manager',
     }),
   },
@@ -110,8 +110,8 @@ const load = loader({
   },
 
   generateReferences: {
-    requires: ['cfg', 'schemaset'],
-    setup: async ({ cfg, schemaset }) => libReferences.fromService({
+    requires: ['schemaset'],
+    setup: async ({ schemaset }) => libReferences.fromService({
       schemaset,
       references: [builder.reference(), exchanges.reference(), MonitorManager.reference('worker-manager'), MonitorManager.metricsReference('worker-manager')],
     }).then(ref => ref.generateReferences()),
@@ -189,8 +189,8 @@ const load = loader({
   },
 
   estimator: {
-    requires: ['cfg', 'queue', 'monitor'],
-    setup: ({ cfg, queue, monitor }) => new Estimator({
+    requires: ['queue', 'monitor'],
+    setup: ({ queue, monitor }) => new Estimator({
       queue,
       monitor: monitor.childMonitor('estimator'),
     }),
@@ -207,8 +207,8 @@ const load = loader({
   },
 
   providers: {
-    requires: ['cfg', 'monitor', 'notify', 'db', 'estimator', 'schemaset', 'publisher', 'validator', 'launchConfigSelector'],
-    setup: async ({ cfg, monitor, notify, db, estimator, schemaset, publisher, validator, launchConfigSelector }) =>
+    requires: ['cfg', 'monitor', 'notify', 'db', 'estimator', 'publisher', 'validator', 'launchConfigSelector'],
+    setup: async ({ cfg, monitor, notify, db, estimator, publisher, validator, launchConfigSelector }) =>
       new Providers().setup({ cfg, monitor, notify, db, estimator, publisher, validator, launchConfigSelector }),
   },
 

--- a/services/worker-manager/src/providers/aws.js
+++ b/services/worker-manager/src/providers/aws.js
@@ -278,7 +278,7 @@ export class AwsProvider extends Provider {
    * This method checks instance identity document authenticity
    * If it's authentic it checks whether the data in it corresponds to the worker
    */
-  async registerWorker({ worker, workerPool, workerIdentityProof }) {
+  async registerWorker({ worker, workerIdentityProof }) {
     const monitor = this.workerMonitor({ worker });
 
     if (worker.state !== Worker.states.REQUESTED) {

--- a/services/worker-manager/src/providers/azure/index.js
+++ b/services/worker-manager/src/providers/azure/index.js
@@ -1100,7 +1100,7 @@ export class AzureProvider extends Provider {
     return resources;
   }
 
-  async deprovision({ workerPool }) {
+  async deprovision() {
     // nothing to do: we just wait for workers to terminate themselves
   }
 
@@ -2032,7 +2032,7 @@ export class AzureProvider extends Provider {
 
     this.cloudApi?.logAndResetMetrics();
 
-    await Promise.all(Object.entries(this.errors).filter(([workerPoolId, errors]) => errors.length > 0).map(
+    await Promise.all(Object.entries(this.errors).filter(([_workerPoolId, errors]) => errors.length > 0).map(
       async ([workerPoolId, errors]) => {
         const workerPool = await WorkerPool.get(this.db, workerPoolId);
 

--- a/services/worker-manager/src/providers/google.js
+++ b/services/worker-manager/src/providers/google.js
@@ -106,7 +106,7 @@ export class GoogleProvider extends Provider {
     this.workerServiceAccountEmail = workerServiceAccount.email;
   }
 
-  async registerWorker({ worker, workerPool, workerIdentityProof }) {
+  async registerWorker({ worker, workerIdentityProof }) {
     const { token } = workerIdentityProof;
     const monitor = this.workerMonitor({ worker });
 
@@ -176,7 +176,7 @@ export class GoogleProvider extends Provider {
     };
   }
 
-  async deprovision({ workerPool }) {
+  async deprovision() {
     // nothing to do: we just wait for workers to terminate themselves
   }
 
@@ -482,7 +482,7 @@ export class GoogleProvider extends Provider {
       total: Provider.calcSeenTotal(this.seen),
     });
     this.cloudApi?.logAndResetMetrics();
-    await Promise.all(Object.entries(this.seen).map(async ([workerPoolId, seen]) => {
+    await Promise.all(Object.entries(this.seen).map(async ([workerPoolId, _seen]) => {
       const workerPool = await WorkerPool.get(this.db, workerPoolId);
       if (!workerPool) {
         return; // In this case, the workertype has been deleted so we can just move on

--- a/services/worker-manager/src/providers/provider.js
+++ b/services/worker-manager/src/providers/provider.js
@@ -92,19 +92,19 @@ export class Provider {
   /**
    * @param {{ workerPool: WorkerPool, workerPoolStats: WorkerPoolStats }} opts
    */
-  async provision({ workerPool, workerPoolStats }) {
+  async provision() {
   }
 
   /**
    * @param {{ workerPool: WorkerPool }} opts
    */
-  async deprovision({ workerPool }) {
+  async deprovision() {
   }
 
   /**
    * @param {{ workerPool: WorkerPool, worker: Worker, workerIdentityProof: Record<string, any> }} opts
    */
-  async registerWorker({ worker, workerPool, workerIdentityProof }) {
+  async registerWorker() {
     throw new ApiError('not supported for this provider');
   }
 
@@ -117,7 +117,7 @@ export class Provider {
   /**
    * @param {{ worker: Worker }} opts
    */
-  async checkWorker({ worker }) {
+  async checkWorker() {
   }
 
   async scanCleanup() {
@@ -156,21 +156,21 @@ export class Provider {
   /**
    * @param {{ workerPool: WorkerPool, workerId: string, workerGroup: string, input: object }} opts
    */
-  async createWorker({ workerPool, workerGroup, workerId, input }) {
+  async createWorker() {
     throw new ApiError('not supported for this provider');
   }
 
   /**
    * @param {{ workerPool: WorkerPool, worker: Worker, input: object }} opts
    */
-  async updateWorker({ workerPool, worker, input }) {
+  async updateWorker() {
     throw new ApiError('not supported for this provider');
   }
 
   /**
    * @param {{ worker: Worker, reason: string }} opts
    */
-  async removeWorker({ worker, reason }) {
+  async removeWorker() {
     throw new ApiError('not supported for this provider');
   }
 

--- a/services/worker-manager/src/providers/static.js
+++ b/services/worker-manager/src/providers/static.js
@@ -44,7 +44,7 @@ export class StaticProvider extends Provider {
     return worker;
   }
 
-  async updateWorker({ workerPool, worker, input }) {
+  async updateWorker({ worker, input }) {
     await worker.update(this.db, worker => {
       worker.expires = input.expires;
       worker.capacity = input.capacity;

--- a/services/worker-manager/src/providers/testing.js
+++ b/services/worker-manager/src/providers/testing.js
@@ -45,7 +45,7 @@ export class TestingProvider extends Provider {
     this.monitor.notice('scan-cleanup', {});
   }
 
-  async registerWorker({ worker, workerPool, workerIdentityProof }) {
+  async registerWorker({ worker }) {
     await worker.update(this.db, worker => {
       worker.state = Worker.states.RUNNING;
     });

--- a/services/worker-manager/test/api_test.js
+++ b/services/worker-manager/test/api_test.js
@@ -9,10 +9,10 @@ import path from 'node:path';
 
 helper.secrets.mockSuite(testing.suiteName(), [], (mock, skipping) => {
   helper.withDb(mock, skipping);
-  helper.withPulse(mock, skipping);
-  helper.withProviders(mock, skipping);
-  helper.withServer(mock, skipping);
-  helper.resetTables(mock, skipping);
+  helper.withPulse(skipping);
+  helper.withProviders();
+  helper.withServer(skipping);
+  helper.resetTables();
 
   const workerPoolId = 'pp/ee';
   const providerId = 'testing1';

--- a/services/worker-manager/test/data_test.js
+++ b/services/worker-manager/test/data_test.js
@@ -6,7 +6,7 @@ import { Worker, WorkerPoolError, WorkerPoolStats } from '../src/data.js';
 
 helper.secrets.mockSuite(testing.suiteName(), [], (mock, skipping) => {
   helper.withDb(mock, skipping);
-  helper.resetTables(mock, skipping);
+  helper.resetTables();
 
   /**
    * Avoid an issue that looks like the following:

--- a/services/worker-manager/test/estimator_test.js
+++ b/services/worker-manager/test/estimator_test.js
@@ -2,9 +2,9 @@ import assert from 'node:assert';
 import helper from './helper.js';
 import testing from '@taskcluster/lib-testing';
 
-helper.secrets.mockSuite(testing.suiteName(), [], (mock, skipping) => {
-  helper.withFakeQueue(mock, skipping);
-  helper.withFakeNotify(mock, skipping);
+helper.secrets.mockSuite(testing.suiteName(), [], (_mock, skipping) => {
+  helper.withFakeQueue(skipping);
+  helper.withFakeNotify(skipping);
 
   let estimator, monitor;
 

--- a/services/worker-manager/test/expiration_test.js
+++ b/services/worker-manager/test/expiration_test.js
@@ -6,7 +6,7 @@ import taskcluster from '@taskcluster/client';
 
 helper.secrets.mockSuite(testing.suiteName(), [], (mock, skipping) => {
   helper.withDb(mock, skipping);
-  helper.resetTables(mock, skipping);
+  helper.resetTables();
 
   const makeWP = async values => {
     const workerPool = WorkerPool.fromApi({
@@ -67,7 +67,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], (mock, skipping) => {
   });
 
   suite('expireLaunchConfigs', () => {
-    const getWPLCs = async (workerPoolId, providerId) => {
+    const getWPLCs = async (workerPoolId, _providerId) => {
       return helper.db.fns.get_worker_pool_launch_configs(workerPoolId, null, null, null);
     };
 
@@ -177,7 +177,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], (mock, skipping) => {
       await e.create(helper.db);
     };
 
-    const checkWPE = async (workerPoolId = 'pp/wt', errorId = eid) => {
+    const checkWPE = async (_workerPoolId = 'pp/wt', _errorId = eid) => {
       return await helper.db.fns.get_worker_pool_errors_for_worker_pool2(eid, 'pp/wt', null, null, null);
     };
 

--- a/services/worker-manager/test/fakes/azure.js
+++ b/services/worker-manager/test/fakes/azure.js
@@ -18,19 +18,19 @@ export class FakeAzure extends FakeCloud {
       assert.equal(creds?.getToken()?.token, 'fake-credentials');
       return this.restClient;
     });
-    this.sinon.stub(azureApi, 'ComputeManagementClient').callsFake((creds, subId) => {
+    this.sinon.stub(azureApi, 'ComputeManagementClient').callsFake((creds, _subId) => {
       assert.equal(creds?.getToken()?.token, 'fake-credentials');
       return this.computeClient;
     });
-    this.sinon.stub(azureApi, 'NetworkManagementClient').callsFake((creds, subId) => {
+    this.sinon.stub(azureApi, 'NetworkManagementClient').callsFake((creds, _subId) => {
       assert.equal(creds?.getToken()?.token, 'fake-credentials');
       return this.networkClient;
     });
-    this.sinon.stub(azureApi, 'ResourceManagementClient').callsFake((creds, subId) => {
+    this.sinon.stub(azureApi, 'ResourceManagementClient').callsFake((creds, _subId) => {
       assert.equal(creds?.getToken()?.token, 'fake-credentials');
       return this.resourcesClient;
     });
-    this.sinon.stub(azureApi, 'DeploymentsClient').callsFake((creds, subId) => {
+    this.sinon.stub(azureApi, 'DeploymentsClient').callsFake((creds, _subId) => {
       assert.equal(creds?.getToken()?.token, 'fake-credentials');
       return this.deploymentsClient;
     });

--- a/services/worker-manager/test/helper.js
+++ b/services/worker-manager/test/helper.js
@@ -29,11 +29,11 @@ helper.withDb = (mock, skipping) => {
   testing.withDb(mock, skipping, helper, 'worker_manager');
 };
 
-helper.withPulse = (mock, skipping) => {
+helper.withPulse = skipping => {
   testing.withPulse({ helper, skipping, namespace: 'taskcluster-worker-manager' });
 };
 
-helper.withProviders = (mock, skipping) => {
+helper.withProviders = () => {
   const fakeEC2 = new FakeEC2();
   fakeEC2.forSuite();
 
@@ -44,7 +44,7 @@ helper.withProviders = (mock, skipping) => {
   fakeGoogle.forSuite();
 };
 
-helper.withProvisioner = (mock, skipping) => {
+helper.withProvisioner = skipping => {
   let provisioner;
 
   suiteSetup(async () => {
@@ -77,7 +77,7 @@ helper.withProvisioner = (mock, skipping) => {
   });
 };
 
-helper.withWorkerScanner = (mock, skipping) => {
+helper.withWorkerScanner = skipping => {
   let scanner;
 
   suiteSetup(async () => {
@@ -114,7 +114,7 @@ helper.withWorkerScanner = (mock, skipping) => {
  *
  * The component is available at `helper.queue`.
  */
-helper.withFakeQueue = (mock, skipping) => {
+helper.withFakeQueue = skipping => {
   suiteSetup(() => {
     if (skipping()) {
       return;
@@ -134,7 +134,7 @@ helper.withFakeQueue = (mock, skipping) => {
  *
  * We consider any emailing to be test-failing at the moment
  */
-helper.withFakeNotify = (mock, skipping) => {
+helper.withFakeNotify = skipping => {
   suiteSetup(() => {
     if (skipping()) {
       return;
@@ -149,7 +149,7 @@ helper.withFakeNotify = (mock, skipping) => {
   });
 };
 
-helper.withServer = (mock, skipping) => {
+helper.withServer = skipping => {
   let webServer;
 
   suiteSetup(async () => {
@@ -266,7 +266,7 @@ helper.getWorkers = async () =>
       });
     }));
 
-helper.resetTables = (mock, skipping) => {
+helper.resetTables = () => {
   setup('reset tables', async () => {
     await testing.resetTables({ tableNames: [
       'workers',

--- a/services/worker-manager/test/launch_config_selector_test.js
+++ b/services/worker-manager/test/launch_config_selector_test.js
@@ -5,10 +5,10 @@ import { WorkerPoolStats } from '../src/data.js';
 
 helper.secrets.mockSuite(testing.suiteName(), [], (mock, skipping) => {
   helper.withDb(mock, skipping);
-  helper.withPulse(mock, skipping);
-  helper.withProviders(mock, skipping);
-  helper.withServer(mock, skipping);
-  helper.resetTables(mock, skipping);
+  helper.withPulse(skipping);
+  helper.withProviders();
+  helper.withServer(skipping);
+  helper.resetTables();
 
   /** @type {import('../src/launch-config-selector.js').LaunchConfigSelector} */
   let launchConfigSelector;

--- a/services/worker-manager/test/provider_aws_test.js
+++ b/services/worker-manager/test/provider_aws_test.js
@@ -14,10 +14,10 @@ const __dirname = new URL('.', import.meta.url).pathname;
 
 helper.secrets.mockSuite(testing.suiteName(), [], (mock, skipping) => {
   helper.withDb(mock, skipping);
-  helper.withPulse(mock, skipping);
-  helper.withFakeQueue(mock, skipping);
-  helper.withFakeNotify(mock, skipping);
-  helper.resetTables(mock, skipping);
+  helper.withPulse(skipping);
+  helper.withFakeQueue(skipping);
+  helper.withFakeNotify(skipping);
+  helper.resetTables();
 
   let provider;
   const providerId = 'aws';
@@ -213,7 +213,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], (mock, skipping) => {
       },
       // capacity 34 at 6 per instance should be 6 instances..
       expectedWorkers: 6,
-    }, async (workers) => {
+    }, async (_workers) => {
       // spawn two each in three launchConfigs; spawning one each would only get us 5 instances since there
       // are only 5 launchConfigs
       assert.deepEqual(fake.rgn('us-west-2').runInstancesCalls.map(({ MinCount }) => MinCount), [2, 2, 2]);
@@ -238,7 +238,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], (mock, skipping) => {
           scalingRatio: 1,
         },
         expectedWorkers: 1,
-      }, async (workers) => {
+      }, async (_workers) => {
         assert.equal(fake.rgn('us-west-2').runInstancesCalls.length, 1);
         assertHasTag(fake.rgn('us-west-2').runInstancesCalls[0], ResourceType, 'mytag', 'testy');
         assertHasTag(fake.rgn('us-west-2').runInstancesCalls[0], 'instance', 'CreatedBy', 'taskcluster-wm-aws');

--- a/services/worker-manager/test/provider_azure_test.js
+++ b/services/worker-manager/test/provider_azure_test.js
@@ -20,10 +20,10 @@ const __dirname = new URL('.', import.meta.url).pathname;
 
 helper.secrets.mockSuite(testing.suiteName(), [], (mock, skipping) => {
   helper.withDb(mock, skipping);
-  helper.withPulse(mock, skipping);
-  helper.withFakeQueue(mock, skipping);
-  helper.withFakeNotify(mock, skipping);
-  helper.resetTables(mock, skipping);
+  helper.withPulse(skipping);
+  helper.withFakeQueue(skipping);
+  helper.withFakeNotify(skipping);
+  helper.resetTables();
 
   let provider;
   const providerId = 'azure';
@@ -2847,8 +2847,8 @@ helper.secrets.mockSuite(testing.suiteName(), [], (mock, skipping) => {
           const intermediateCert = getIntermediateCert();
 
           // Disable downloads
-          provider.downloadBinaryResponse = (url) => {
-            return new Promise((resolve, reject) => {
+          provider.downloadBinaryResponse = (_url) => {
+            return new Promise((_resolve, reject) => {
               reject(Error('Mocked downloadBinaryResponse'));
             });
           };
@@ -2939,7 +2939,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], (mock, skipping) => {
           const intermediateCert = getIntermediateCert();
 
           // Download is not a binary certificate
-          provider.downloadBinaryResponse = async url =>
+          provider.downloadBinaryResponse = async () =>
             '<html><body><h1>Apache2 Default Page</h1></body></html>';
 
           await assert.rejects(() =>

--- a/services/worker-manager/test/provider_google_test.js
+++ b/services/worker-manager/test/provider_google_test.js
@@ -8,10 +8,10 @@ import { WorkerPool, WorkerPoolError, Worker, WorkerPoolStats } from '../src/dat
 
 helper.secrets.mockSuite(testing.suiteName(), [], (mock, skipping) => {
   helper.withDb(mock, skipping);
-  helper.withPulse(mock, skipping);
-  helper.withFakeQueue(mock, skipping);
-  helper.withFakeNotify(mock, skipping);
-  helper.resetTables(mock, skipping);
+  helper.withPulse(skipping);
+  helper.withFakeQueue(skipping);
+  helper.withFakeNotify(skipping);
+  helper.resetTables();
 
   let provider;
   const providerId = 'google';
@@ -300,7 +300,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], (mock, skipping) => {
         }],
       },
       expectedWorkers: 1,
-    }, async workers => {
+    }, async () => {
       const parameters = fake.compute.instances.insertCalls[0];
       assert.deepEqual(parameters.requestBody.disks, [
         {
@@ -352,7 +352,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], (mock, skipping) => {
         }],
       },
       expectedWorkers: 1,
-    }, async workers => {
+    }, async () => {
       const parameters = fake.compute.instances.insertCalls[0];
       assert.equal(parameters.requestBody.testProperty, 'foo');
     });
@@ -366,7 +366,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], (mock, skipping) => {
         }],
       },
       expectedWorkers: 1,
-    }, async workers => {
+    }, async () => {
       const parameters = fake.compute.instances.insertCalls[0];
       assert.equal(parameters.requestBody.scheduling.testProperty, 'foo');
     });
@@ -384,7 +384,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], (mock, skipping) => {
         }],
       },
       expectedWorkers: 1,
-    }, async workers => {
+    }, async () => {
       const parameters = fake.compute.instances.insertCalls[0];
       assert.equal(parameters.requestBody.metadata.items.length, 2);
       const meta = parameters.requestBody.metadata.items[0];
@@ -403,7 +403,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], (mock, skipping) => {
         }],
       },
       expectedWorkers: 1,
-    }, async workers => {
+    }, async () => {
       const parameters = fake.compute.instances.insertCalls[0];
       assert.equal(parameters.requestBody.metadata.items.length, 1);
       const meta = parameters.requestBody.metadata.items[0];

--- a/services/worker-manager/test/provider_static_test.js
+++ b/services/worker-manager/test/provider_static_test.js
@@ -7,10 +7,10 @@ import { WorkerPool, Worker } from '../src/data.js';
 
 helper.secrets.mockSuite(testing.suiteName(), [], (mock, skipping) => {
   helper.withDb(mock, skipping);
-  helper.withPulse(mock, skipping);
-  helper.withFakeQueue(mock, skipping);
-  helper.withFakeNotify(mock, skipping);
-  helper.resetTables(mock, skipping);
+  helper.withPulse(skipping);
+  helper.withFakeQueue(skipping);
+  helper.withFakeNotify(skipping);
+  helper.resetTables();
 
   let provider;
   let workerPool;

--- a/services/worker-manager/test/provider_test.js
+++ b/services/worker-manager/test/provider_test.js
@@ -8,9 +8,9 @@ import { LEVELS } from '@taskcluster/lib-monitor';
 
 helper.secrets.mockSuite(testing.suiteName(), [], (mock, skipping) => {
   helper.withDb(mock, skipping);
-  helper.withPulse(mock, skipping);
-  helper.withFakeNotify(mock, skipping);
-  helper.resetTables(mock, skipping);
+  helper.withPulse(skipping);
+  helper.withFakeNotify(skipping);
+  helper.resetTables();
 
   let monitor;
   suiteSetup(async () => {

--- a/services/worker-manager/test/providers_test.js
+++ b/services/worker-manager/test/providers_test.js
@@ -5,10 +5,10 @@ import { setSetupRetryInterval } from '../src/providers/index.js';
 
 helper.secrets.mockSuite(testing.suiteName(), [], (mock, skipping) => {
   helper.withDb(mock, skipping);
-  helper.withPulse(mock, skipping);
-  helper.withFakeNotify(mock, skipping);
-  helper.withProviders(mock, skipping);
-  helper.resetTables(mock, skipping);
+  helper.withPulse(skipping);
+  helper.withFakeNotify(skipping);
+  helper.withProviders();
+  helper.resetTables();
 
   suite('failing provider setup', () => {
     let monitor;

--- a/services/worker-manager/test/provisioner_test.js
+++ b/services/worker-manager/test/provisioner_test.js
@@ -8,13 +8,13 @@ import { ApiError } from '../src/providers/provider.js';
 
 helper.secrets.mockSuite(testing.suiteName(), [], (mock, skipping) => {
   helper.withDb(mock, skipping);
-  helper.withPulse(mock, skipping);
-  helper.withFakeNotify(mock, skipping);
-  helper.withFakeQueue(mock, skipping);
-  helper.withProviders(mock, skipping);
-  helper.withServer(mock, skipping);
-  helper.withProvisioner(mock, skipping);
-  helper.resetTables(mock, skipping);
+  helper.withPulse(skipping);
+  helper.withFakeNotify(skipping);
+  helper.withFakeQueue(skipping);
+  helper.withProviders();
+  helper.withServer(skipping);
+  helper.withProvisioner(skipping);
+  helper.resetTables();
 
   let monitor;
   suiteSetup(async () => {

--- a/services/worker-manager/test/util_test.js
+++ b/services/worker-manager/test/util_test.js
@@ -38,7 +38,7 @@ suite(testing.suiteName(), () => {
       [{ workerId: 'mac-m1', workerIdentityProof: { secret: 'noway' } }, { workerId: 'mac-m1', workerIdentityProof: '*' }],
       [{ inner: { workerIdentityProof: 'noway' } }, { inner: { workerIdentityProof: 'noway' } }],
     ];
-    testPairs.forEach((pair, i) => {
+    testPairs.forEach((pair, _i) => {
       test(`sanitizeRegisterWorkerPayload: ${JSON.stringify(pair[1])}`, () => {
         assert.deepEqual(util.sanitizeRegisterWorkerPayload(pair[0]), pair[1]);
       });

--- a/services/worker-manager/test/worker_scanner_test.js
+++ b/services/worker-manager/test/worker_scanner_test.js
@@ -7,13 +7,13 @@ import { Worker, WorkerPool } from '../src/data.js';
 
 helper.secrets.mockSuite(testing.suiteName(), [], (mock, skipping) => {
   helper.withDb(mock, skipping);
-  helper.withPulse(mock, skipping);
-  helper.withFakeQueue(mock, skipping);
-  helper.withFakeNotify(mock, skipping);
-  helper.withProviders(mock, skipping);
-  helper.withServer(mock, skipping);
-  helper.withWorkerScanner(mock, skipping);
-  helper.resetTables(mock, skipping);
+  helper.withPulse(skipping);
+  helper.withFakeQueue(skipping);
+  helper.withFakeNotify(skipping);
+  helper.withProviders();
+  helper.withServer(skipping);
+  helper.withWorkerScanner(skipping);
+  helper.resetTables();
 
   let monitor;
   suiteSetup(async () => {

--- a/services/worker-manager/test/worker_test.js
+++ b/services/worker-manager/test/worker_test.js
@@ -5,7 +5,7 @@ import { Worker } from '../src/data.js';
 
 helper.secrets.mockSuite(testing.suiteName(), [], (mock, skipping) => {
   helper.withDb(mock, skipping);
-  helper.resetTables(mock, skipping);
+  helper.resetTables();
 
   const defaultWorker = {
     workerPoolId: 'wp',


### PR DESCRIPTION
There's 4 big classes of fixes in there.

Anything related to `cfg` as a dependency in pretty much every service is vestigial from previous use/copy-paste between services. `cfg` was very often declared and then unused so I just removed it when unnecessary.
We were passing a mock object around a lot in tests and then not using it. I removed those.

The rest is a case by case. When I could trace all calls and the last argument of a function was unused, I removed it unless it was necessary to keep it for documentation and/or interface declaration purposes. The rest I prefixed with a `_`.

This was mostly done by going service by service, having biome autofix everything by prefixing a `_`, running tests and then reviewing them one by one on what could get removed vs what had to stay.