### PR TITLE
Actually throw an error if a fake client is used in a prod environment

### DIFF
--- a/changelog/NKrOqSAaTEK3QQsth-h48w.md
+++ b/changelog/NKrOqSAaTEK3QQsth-h48w.md
@@ -1,0 +1,4 @@
+audience: users
+level: patch
+---
+Fake taskcluster clients now properly raise an error when used in a production `NODE_ENV`

--- a/clients/client/src/client.js
+++ b/clients/client/src/client.js
@@ -302,7 +302,7 @@ export const createClient = function(reference, name) {
       reference.entries.filter(e => e.type === 'function').forEach(e => this.fakeCalls[e.name] = []);
       // Throw an error if creating fakes in production
       if (process.env.NODE_ENV === 'production') {
-        new Error('@taskcluster/client object created in "fake" mode, when NODE_ENV == "production"');
+        throw new Error('@taskcluster/client object created in "fake" mode, when NODE_ENV == "production"');
       }
     }
   };


### PR DESCRIPTION
The previous code was creating the error but never throwing it so clients in fake mode and production NODE_ENV would just happily continue working

