### PR TITLE
feat(web): Enable brotli support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -63,7 +63,7 @@ RUN /bin/bash -c "\
 # build the final image
 
 FROM node:24.16.0-alpine AS image
-RUN apk --no-cache add --update nginx bash
+RUN apk --no-cache add --update bash nginx nginx-mod-http-brotli
 COPY --from=build --chown=1000:1000 /base/app /app
 ENV HOME=/app
 WORKDIR /app

--- a/changelog/issue-8721.md
+++ b/changelog/issue-8721.md
@@ -1,0 +1,6 @@
+audience: deployers
+level: patch
+reference: issue 8721
+---
+
+The UI and references nginx servers now support Brotli compression in addition to gzip, allowing browser requests that prefer Brotli to receive compressed static assets, schemas, and references.

--- a/infrastructure/references/nginx.conf
+++ b/infrastructure/references/nginx.conf
@@ -5,6 +5,8 @@ worker_processes 1;
 error_log stderr;
 pid /tmp/nginx.pid;
 
+include /etc/nginx/modules/*.conf;
+
 events {
     worker_connections 1024;
 }
@@ -30,6 +32,25 @@ http {
 
     gzip on;
     gzip_types
+        text/css
+        text/javascript
+        text/xml
+        text/plain
+        application/javascript
+        application/x-javascript
+        application/json
+        application/xml
+        application/rss+xml
+        application/atom+xml
+        font/truetype
+        font/opentype
+        image/svg+xml;
+
+    brotli on;
+    brotli_static on;
+    brotli_comp_level 5;
+    brotli_min_length 256;
+    brotli_types
         text/css
         text/javascript
         text/xml

--- a/ui/web-ui-nginx-site.conf
+++ b/ui/web-ui-nginx-site.conf
@@ -5,6 +5,8 @@ worker_processes  1;
 error_log  stderr;
 pid        /tmp/nginx.pid;
 
+include /etc/nginx/modules/*.conf;
+
 events {
     worker_connections  1024;
 }
@@ -91,6 +93,25 @@ http {
 
     gzip on;
     gzip_types
+      text/css
+      text/javascript
+      text/xml
+      text/plain
+      application/javascript
+      application/x-javascript
+      application/json
+      application/xml
+      application/rss+xml
+      application/atom+xml
+      font/truetype
+      font/opentype
+      image/svg+xml;
+
+    brotli on;
+    brotli_static on;
+    brotli_comp_level 5;
+    brotli_min_length 256;
+    brotli_types
       text/css
       text/javascript
       text/xml


### PR DESCRIPTION
This is related to #8721 and #8347 where we enabled compression support for the api/graphql, but static assets and references only had gzip enabled.
This adds a "native" support for brotli compression to match what api is doing.

There is still some uncertainty with how Fastly edge handles brotli (which has an active workaround to use gzip by default) but if it gets ever fixed, we could drop our gzip fix and make this whole negotiation transparent
