### PR TITLE
Fix auth test in client-web not actually checking its expectation

### DIFF
--- a/changelog/C0lf15N9S0epOChdCYnUJA.md
+++ b/changelog/C0lf15N9S0epOChdCYnUJA.md
@@ -1,0 +1,2 @@
+level: silent
+---

--- a/clients/client-web/test/Auth_test.js
+++ b/clients/client-web/test/Auth_test.js
@@ -31,8 +31,8 @@ describe('Auth', function () {
       },
     });
 
-    expect(auth.buildSignedUrl(auth.client, 'test')).to.eventually.match(
-      new RegExp(`^${helper.rootUrl}/auth/v1/clients/test\\?bewit`)
+    return expect(auth.buildSignedUrl(auth.client, 'test')).to.eventually.match(
+      new RegExp(`^${helper.rootUrl}/api/auth/v1/clients/test\\?bewit`)
     );
   });
 


### PR DESCRIPTION
Because the `expect` line returns a Promise, in the previous form it was never resolved which means the test was never checking anything. Instead, the testing framework expects us to return the promise so it can await it itself before calling the test complete. This makes the test actually check something which revealed that the expectation was wrong.
