### PR TITLE
feat(w-m): fast-track azure vm deletion when resources are cascade-deleted

### DIFF
--- a/changelog/issue-8161.md
+++ b/changelog/issue-8161.md
@@ -1,0 +1,10 @@
+audience: deployers
+level: minor
+reference: issue 8161
+---
+The Azure provider now detects if resources will be cascade-deleted with the VM (`deleteOption: 'Delete'`).
+When they provably cascade, deprovisioning skips the per-resource GET/delete walk and just calls VM delete + 404 confirm,
+cutting the redundant Azure API calls.
+Detection is best-effort and fails open: any uncertainty (multi-NIC/IP, `Detach`, missing fields, probe error/timeout, or
+tracked resources that are not VM-owned) falls back to the existing resource-by-resource deletion.
+New log type: `azure-teardown-mode` and `worker_manager_azure_teardown_total` metric record whether each teardown used the fast or slow path.

--- a/generated/references.json
+++ b/generated/references.json
@@ -18102,6 +18102,20 @@
           "type": "gauge"
         },
         {
+          "description": "Count of Azure worker teardowns by mode: 'fast' (cascade short-circuit) vs 'slow' (per-resource walk), per worker pool",
+          "labels": {
+            "mode": "Teardown mode: 'fast' or 'slow'",
+            "providerId": "ID of the provider",
+            "workerPoolId": "The worker pool ID"
+          },
+          "name": "worker_manager_azure_teardown_total",
+          "registers": [
+            "scan"
+          ],
+          "title": "Azure worker teardowns",
+          "type": "counter"
+        },
+        {
           "description": "Count of HTTP 429 responses from Azure ARM API",
           "labels": {
             "operationType": "HTTP operation category: read, write, or delete",
@@ -18489,6 +18503,21 @@
           "name": "azureResourceGroupEnsured",
           "title": "Azure Resource Group Create or Update Information",
           "type": "azure-resource-group-ensure",
+          "version": 1
+        },
+        {
+          "description": "Records how an Azure worker's resources were torn down: 'fast' when the VM's\nNIC/IP/disks cascade-delete with the VM (so the per-resource GET/delete walk\nis skipped), or 'slow' for the resource-by-resource walk. Lets us measure the\nAPI-call reduction and confirm the fast path engages on cascading ARM pools.",
+          "fields": {
+            "launchConfigId": "Launch Config ID",
+            "mode": "Teardown mode: 'fast' (cascade short-circuit) or 'slow' (full walk)",
+            "providerId": "Provider ID",
+            "workerId": "Worker ID",
+            "workerPoolId": "Worker Pool ID"
+          },
+          "level": "info",
+          "name": "azureTeardownMode",
+          "title": "Azure Worker Teardown Mode",
+          "type": "azure-teardown-mode",
           "version": 1
         },
         {

--- a/services/worker-manager/src/monitor.js
+++ b/services/worker-manager/src/monitor.js
@@ -323,6 +323,27 @@ MonitorManager.register({
   },
 });
 
+MonitorManager.register({
+  name: 'azureTeardownMode',
+  title: 'Azure Worker Teardown Mode',
+  type: 'azure-teardown-mode',
+  version: 1,
+  level: 'info',
+  description: `
+    Records how an Azure worker's resources were torn down: 'fast' when the VM's
+    NIC/IP/disks cascade-delete with the VM (so the per-resource GET/delete walk
+    is skipped), or 'slow' for the resource-by-resource walk. Lets us measure the
+    API-call reduction and confirm the fast path engages on cascading ARM pools.
+  `,
+  fields: {
+    providerId: 'Provider ID',
+    workerPoolId: 'Worker Pool ID',
+    launchConfigId: 'Launch Config ID',
+    workerId: 'Worker ID',
+    mode: "Teardown mode: 'fast' (cascade short-circuit) or 'slow' (full walk)",
+  },
+});
+
 const commonLabels = {
   workerPoolId: 'The worker pool ID',
   providerId: 'ID of the provider',
@@ -543,6 +564,20 @@ MonitorManager.registerMetric('azureThrottleCount', {
     operationType: 'HTTP operation category: read, write, or delete',
   },
   registers: ['provision', 'scan'],
+});
+
+MonitorManager.registerMetric('azureTeardownCount', {
+  name: 'worker_manager_azure_teardown_total',
+  type: 'counter',
+  title: 'Azure worker teardowns',
+  description:
+    "Count of Azure worker teardowns by mode: 'fast' (cascade short-circuit) vs 'slow' (per-resource walk), per worker pool",
+  labels: {
+    providerId: 'ID of the provider',
+    workerPoolId: 'The worker pool ID',
+    mode: "Teardown mode: 'fast' or 'slow'",
+  },
+  registers: ['scan'],
 });
 
 MonitorManager.registerMetric('azureArmDeploymentError', {

--- a/services/worker-manager/src/providers/azure/index.js
+++ b/services/worker-manager/src/providers/azure/index.js
@@ -58,6 +58,24 @@ const InstanceStates = {
 const failProvisioningStates = new Set(['Failed', 'Deleting', 'Canceled', 'Deallocating']);
 
 const DEPLOYMENT_METHOD_ARM = 'arm-template';
+const CASCADE_PROBE_TIMEOUT_MS = 30000;
+
+/**
+ * All identity comparisons normalize ARM-id casing
+ * to avoid VM/NIC model and deployment operations mismatch
+ * @param {String|Object} id
+ */
+const normalizeArmId = id => (typeof id === 'string' ? id.toLowerCase() : id);
+
+/** @param {Record<string, unknown>} resource } */
+const markResourceGone = resource => {
+  if (resource) {
+    resource.operation = undefined;
+    resource.id = false;
+    resource.deleted = true;
+  }
+};
+
 const UNKNOWN_METRIC_LABEL = 'unknown';
 const MAX_METRIC_LABEL_LENGTH = 200;
 const maxInstanceView404Streak = 2;
@@ -1425,6 +1443,10 @@ export class AzureProvider extends Provider {
     });
     await this.onWorkerRunning({ worker });
 
+    // detect resource cascade in the background, to avoid blocking registration
+    // the result is only consumed much later, at deprovision time
+    this._backgroundCascadeProbe = this.#detectCascadeInBackground({ worker, monitor });
+
     const workerConfig = worker.providerData.workerConfig || {};
     return {
       expires,
@@ -1837,6 +1859,133 @@ export class AzureProvider extends Provider {
     return { provisioningState, vmId };
   }
 
+  /**
+   * Run #probeCascade and persist its result to providerData.cascade. Intended
+   * to be called fire-and-forget from registerWorker: it never throws, so it
+   * cannot affect the registration that scheduled it. The persisting update is
+   * etag-safe (worker.update reloads and retries on conflict), so it merges
+   * cleanly with concurrent scanner updates.
+   *
+   * @param {{ worker: Worker, monitor: import('@taskcluster/lib-monitor').Monitor }} opts
+   * @returns {Promise<void>}
+   */
+  async #detectCascadeInBackground({ worker, monitor }) {
+    try {
+      const cascade = await this.#probeCascade(worker, monitor);
+      if (cascade) {
+        await worker.update(this.db, worker => {
+          worker.providerData.cascade = cascade;
+        });
+      }
+    } catch (err) {
+      monitor.debug({ message: 'background cascade detection failed', error: err.message });
+    }
+  }
+
+  /**
+   * Best-effort probe of whether a worker's VM-owned resources (NIC, public IP,
+   * disks) are configured to cascade-delete with the VM (`deleteOption: 'Delete'`).
+   *
+   * Reads `Delete`/`Detach` off the *materialized* resources (the VM model, plus
+   * its single NIC for the public IP), never from template/operator intent. The
+   * returned object is persisted to `providerData.cascade` by the caller and
+   * consumed by `deprovisionResources` to skip the per-resource GET/delete walk
+   * when the whole set provably cascades and the tracked resources match the
+   * VM-owned set.
+   *
+   * @param {Worker} worker
+   * @param {import('@taskcluster/lib-monitor').Monitor} monitor
+   * @returns {Promise<object|null>}
+   */
+  async #probeCascade(worker, monitor) {
+    if (worker.providerData.deploymentMethod !== DEPLOYMENT_METHOD_ARM) {
+      return null;
+    }
+
+    const cascade = {
+      all: false,
+      nic: false,
+      ip: null,
+      disks: false,
+      vmOwnedNicId: null,
+      vmOwnedDiskIds: [],
+      vmOwnedPublicIpId: null,
+      detectedAt: new Date().toISOString(),
+      source: 'register',
+    };
+
+    const abortController = new AbortController();
+    // cascadeProbeTimeoutMs is for tests
+    const timeoutMs = this.cascadeProbeTimeoutMs ?? CASCADE_PROBE_TIMEOUT_MS;
+    const timer = setTimeout(() => abortController.abort(), timeoutMs);
+    const abortSignal = abortController.signal;
+    const resourceGroupName = worker.providerData.resourceGroupName;
+
+    try {
+      const vm = await this._enqueue('get', () =>
+        this.computeClient.virtualMachines.get(resourceGroupName, worker.providerData.vm.name, { abortSignal })
+      );
+
+      // Disk set: osDisk + dataDisks. Collect each managed disk identity and
+      // require every one to cascade.
+      const osDisk = vm.storageProfile?.osDisk;
+      const dataDisks = vm.storageProfile?.dataDisks || [];
+      const allDisks = [osDisk, ...dataDisks].filter(Boolean);
+      let disksCascade = allDisks.length > 0;
+      for (const disk of allDisks) {
+        const diskId = disk.managedDisk?.id;
+        if (diskId) {
+          cascade.vmOwnedDiskIds.push(diskId);
+        }
+        if (disk.deleteOption !== 'Delete') {
+          disksCascade = false;
+        }
+      }
+      cascade.disks = disksCascade;
+
+      // provider tracks single NIC/IP per worker, so if there are none or more than 1
+      // we assume it requires individual deprovision instead
+      const nics = vm.networkProfile?.networkInterfaces || [];
+      if (nics.length !== 1) {
+        return cascade;
+      }
+      const vmNic = nics[0];
+      cascade.vmOwnedNicId = vmNic.id || null;
+      cascade.nic = vmNic.deleteOption === 'Delete';
+
+      // The public IP's cascade is not on the VM model; it lives on the NIC's
+      // ipConfiguration. GET the NIC to read it.
+      const nicName = vmNic.id?.split('/')?.pop();
+      if (!nicName) {
+        return cascade;
+      }
+      const nic = await this._enqueue('get', () =>
+        this.networkClient.networkInterfaces.get(resourceGroupName, nicName, { abortSignal })
+      );
+      const publicIpConfigs = (nic.ipConfigurations || []).filter(c => c.publicIPAddress);
+      if (publicIpConfigs.length > 1) {
+        return cascade;
+      }
+      if (publicIpConfigs.length === 0) {
+        cascade.ip = null;
+        cascade.vmOwnedPublicIpId = null;
+      } else {
+        const publicIp = publicIpConfigs[0].publicIPAddress;
+        cascade.vmOwnedPublicIpId = publicIp.id || null;
+        cascade.ip = publicIp.deleteOption === 'Delete';
+      }
+
+      // cascade only when the NIC and all disks cascade and the public IP either cascades or is absent
+      cascade.all = cascade.nic && cascade.disks && cascade.ip !== false;
+      return cascade;
+    } catch (err) {
+      monitor.debug({ message: 'cascade probe failed; falling back to slow teardown walk', error: err.message });
+      return cascade;
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+
   /** @param {{ worker: Worker }} opts */
   async checkWorker({ worker }) {
     const monitor = this.workerMonitor({
@@ -2143,9 +2292,7 @@ export class AzureProvider extends Provider {
       worker.update(this.db, worker => {
         const resource =
           index !== undefined ? worker.providerData[resourceType][index] : worker.providerData[resourceType];
-        resource.operation = undefined;
-        resource.id = false;
-        resource.deleted = true;
+        markResourceGone(resource);
       });
 
     if (typeData?.deleted === true) {
@@ -2295,6 +2442,49 @@ export class AzureProvider extends Provider {
     }
   }
 
+  /**
+   * Verify that the resources currently tracked in providerData (nic/ip/disks)
+   * are exactly the ones the VM cascade-deletes, as captured by #probeCascade.
+   *
+   * providerData.{disks,ip} can contain resources the VM does NOT own (a
+   * template's standalone disk, or a standalone public IP that landed in the
+   * single `ip` slot). Those are not removed by the VM cascade, so we must only
+   * short-circuit when every tracked resource matches a VM-owned identity;
+   * otherwise we fall through to the slow walk so they still get deleted.
+   *
+   * @param {Worker} worker
+   * @returns {boolean}
+   */
+  #cascadeTrackedMatches(worker) {
+    const cascade = worker.providerData.cascade;
+    if (!cascade) {
+      return false;
+    }
+
+    const trackedNic = worker.providerData.nic;
+    if (!trackedNic || normalizeArmId(trackedNic.id) !== normalizeArmId(cascade.vmOwnedNicId)) {
+      return false;
+    }
+
+    const vmOwnedDiskIds = new Set((cascade.vmOwnedDiskIds || []).map(normalizeArmId));
+    for (const disk of worker.providerData.disks || []) {
+      if (!vmOwnedDiskIds.has(normalizeArmId(disk.id))) {
+        return false;
+      }
+    }
+
+    const trackedIp = worker.providerData.ip;
+    if (cascade.vmOwnedPublicIpId) {
+      if (!trackedIp || normalizeArmId(trackedIp.id) !== normalizeArmId(cascade.vmOwnedPublicIpId)) {
+        return false;
+      }
+    } else if (trackedIp?.id) {
+      return false;
+    }
+
+    return true;
+  }
+
   /*
    * deprovisionResources removes resources corresponding to a VM,
    * while the worker is in the STOPPING state.  Like provisionResources,
@@ -2320,42 +2510,58 @@ export class AzureProvider extends Provider {
       if (!vmDeleted || worker.providerData.vm.id) {
         return;
       }
-      const nicDeleted = await this.deprovisionResource({
-        worker,
-        client: this.networkClient.networkInterfaces,
-        resourceType: 'nic',
-        monitor,
-      });
-      if (!nicDeleted || worker.providerData.nic.id) {
-        return;
-      }
-      const ipDeleted = await this.deprovisionResource({
-        worker,
-        client: this.networkClient.publicIPAddresses,
-        resourceType: 'ip',
-        monitor,
-      });
-      if (!ipDeleted || worker.providerData.ip.id) {
-        return;
-      }
 
-      // handles deleting osDisks and dataDisks
-      let disksDeleted = true;
-      for (let i = 0; i < worker.providerData.disks.length; i++) {
-        const success = await this.deprovisionResource({
-          worker,
-          client: this.computeClient.disks,
-          resourceType: 'disks',
-          monitor,
-          index: i,
+      // Cascade fast path: `deleteOption: 'Delete'` resources will be deleted with the VM.
+      // Skip the per-resource GET/delete walk entirely only when the tracked resources are
+      // exactly the VM-owned set, so a standalone disk/IP still gets deleted
+      const useFastPath = worker.providerData.cascade?.all === true && this.#cascadeTrackedMatches(worker);
+      const teardownMode = useFastPath ? 'fast' : 'slow';
+
+      if (useFastPath) {
+        // Mark the cascaded resource records deleted as we trust cascade delete option
+        await worker.update(this.db, worker => {
+          markResourceGone(worker.providerData.nic);
+          markResourceGone(worker.providerData.ip);
+          (worker.providerData.disks || []).forEach(markResourceGone);
         });
-        if (!success) {
-          disksDeleted = false;
+      } else {
+        const nicDeleted = await this.deprovisionResource({
+          worker,
+          client: this.networkClient.networkInterfaces,
+          resourceType: 'nic',
+          monitor,
+        });
+        if (!nicDeleted || worker.providerData.nic.id) {
+          return;
         }
-      }
-      // check for un-deleted disks
-      if (!disksDeleted || _.some(worker.providerData.disks.map(i => i.id))) {
-        return;
+        const ipDeleted = await this.deprovisionResource({
+          worker,
+          client: this.networkClient.publicIPAddresses,
+          resourceType: 'ip',
+          monitor,
+        });
+        if (!ipDeleted || worker.providerData.ip.id) {
+          return;
+        }
+
+        // handles deleting osDisks and dataDisks
+        let disksDeleted = true;
+        for (let i = 0; i < worker.providerData.disks.length; i++) {
+          const success = await this.deprovisionResource({
+            worker,
+            client: this.computeClient.disks,
+            resourceType: 'disks',
+            monitor,
+            index: i,
+          });
+          if (!success) {
+            disksDeleted = false;
+          }
+        }
+        // check for un-deleted disks
+        if (!disksDeleted || _.some(worker.providerData.disks.map(i => i.id))) {
+          return;
+        }
       }
 
       // If this was an ARM deployment, delete the deployment if it still exists at this point
@@ -2385,6 +2591,19 @@ export class AzureProvider extends Provider {
         worker.lastModified = now;
         worker.lastChecked = now;
         worker.state = Worker.states.STOPPED;
+      });
+
+      this.monitor.log.azureTeardownMode({
+        providerId: this.providerId,
+        workerPoolId: worker.workerPoolId,
+        launchConfigId: worker.launchConfigId,
+        workerId: worker.workerId,
+        mode: teardownMode,
+      });
+      this.monitor.metric.azureTeardownCount(1, {
+        providerId: this.providerId,
+        workerPoolId: worker.workerPoolId,
+        mode: teardownMode,
       });
     } catch (err) {
       // if this is called directly and not via checkWorker may not exist

--- a/services/worker-manager/test/provider_azure_test.js
+++ b/services/worker-manager/test/provider_azure_test.js
@@ -2322,6 +2322,432 @@ helper.secrets.mockSuite(testing.suiteName(), [], (mock, skipping) => {
     });
   });
 
+  suite('cascade deprovisioning', () => {
+    const workerGroup = 'westus';
+    const rg = 'rgrp';
+    const nicId = `/subscriptions/sub/resourceGroups/${rg}/providers/Microsoft.Network/networkInterfaces/cascade-nic`;
+    const ipId = `/subscriptions/sub/resourceGroups/${rg}/providers/Microsoft.Network/publicIPAddresses/cascade-ip`;
+    const diskId = `/subscriptions/sub/resourceGroups/${rg}/providers/Microsoft.Compute/disks/cascade-disk`;
+
+    const baseCascade = () => ({
+      all: true,
+      nic: true,
+      ip: true,
+      disks: true,
+      vmOwnedNicId: nicId,
+      vmOwnedDiskIds: [diskId],
+      vmOwnedPublicIpId: ipId,
+      detectedAt: new Date().toISOString(),
+      source: 'register',
+    });
+
+    // Builds a STOPPING ARM worker whose tracked nic/ip/disks match a cascading
+    // VM. Pass `cascade: false` for a worker with no cascade field (slow walk),
+    // or override providerData keys (e.g. nic/ip/disks/cascade) directly.
+    const makeStoppingWorker = async ({ cascade, ...pd } = {}) => {
+      const providerData = {
+        ...baseProviderData,
+        deploymentMethod: 'arm-template',
+        vm: { name: 'cascade-vm', id: 'id/cascade-vm' },
+        nic: { name: 'cascade-nic', id: nicId },
+        ip: { name: 'cascade-ip', id: ipId },
+        disks: [{ name: 'cascade-disk', id: diskId }],
+        ...pd,
+      };
+      if (cascade !== false) {
+        providerData.cascade = cascade || baseCascade();
+      }
+      const worker = Worker.fromApi({
+        workerPoolId,
+        workerGroup,
+        workerId: 'cascade-vm',
+        providerId,
+        created: taskcluster.fromNow('0 seconds'),
+        lastModified: taskcluster.fromNow('0 seconds'),
+        lastChecked: taskcluster.fromNow('0 seconds'),
+        capacity: 1,
+        expires: taskcluster.fromNow('1 hour'),
+        state: 'stopping',
+        providerData,
+      });
+      await worker.create(helper.db);
+      provider.errors = provider.errors || {};
+      provider.errors[workerPoolId] = [];
+      return worker;
+    };
+
+    const spyChildClients = sandbox => ({
+      'nic.get': sandbox.spy(fake.networkClient.networkInterfaces, 'get'),
+      'nic.beginDelete': sandbox.spy(fake.networkClient.networkInterfaces, 'beginDelete'),
+      'ip.get': sandbox.spy(fake.networkClient.publicIPAddresses, 'get'),
+      'ip.beginDelete': sandbox.spy(fake.networkClient.publicIPAddresses, 'beginDelete'),
+      'disks.get': sandbox.spy(fake.computeClient.disks, 'get'),
+      'disks.beginDelete': sandbox.spy(fake.computeClient.disks, 'beginDelete'),
+    });
+
+    test('cascade.all short-circuits: VM delete + STOPPED with zero NIC/IP/disk calls', async () => {
+      const sandbox = sinon.createSandbox({});
+      const spies = spyChildClients(sandbox);
+      monitor.manager.reset();
+      // No fake VM resource: deprovisionResource('vm') GETs a 404 and marks the
+      // VM deleted in a single pass, so the cascade fast path can engage.
+      const worker = await makeStoppingWorker();
+      try {
+        await provider.deprovisionResources({ worker, monitor });
+      } finally {
+        sandbox.restore();
+      }
+
+      const [reloaded] = await helper.getWorkers();
+      assert.equal(reloaded.state, 'stopped');
+      assert.equal(reloaded.providerData.nic.deleted, true);
+      assert.equal(reloaded.providerData.nic.id, false);
+      assert.equal(reloaded.providerData.ip.deleted, true);
+      assert.equal(reloaded.providerData.disks[0].deleted, true);
+      for (const [name, spy] of Object.entries(spies)) {
+        assert.equal(spy.callCount, 0, `${name} must not be called on the cascade fast path`);
+      }
+      const teardownLogs = monitor.manager.messages.filter(m => m.Type === 'azure-teardown-mode');
+      assert(
+        teardownLogs.some(m => m.Fields.mode === 'fast' && m.Fields.workerId === 'cascade-vm'),
+        'a fast teardown log should be emitted'
+      );
+      assert.deepEqual(provider.errors[workerPoolId], []);
+      helper.assertPulseMessage('worker-stopped', m => m.payload.workerId === reloaded.workerId);
+    });
+
+    test('cascade absent - slow walk (regression guard)', async () => {
+      const sandbox = sinon.createSandbox({});
+      const spies = spyChildClients(sandbox);
+      monitor.manager.reset();
+      const worker = await makeStoppingWorker({ cascade: false });
+      try {
+        await provider.deprovisionResources({ worker, monitor });
+      } finally {
+        sandbox.restore();
+      }
+      const [reloaded] = await helper.getWorkers();
+      // With no fake resources the slow walk 404s through every child, reaching STOPPED,
+      // but it must have issued the per-resource pre-flight GETs (fast path skips them).
+      assert.equal(reloaded.state, 'stopped');
+      assert(spies['nic.get'].called, 'slow walk must issue the NIC pre-flight GET');
+      assert(spies['disks.get'].called, 'slow walk must issue the disk pre-flight GET');
+      const teardownLogs = monitor.manager.messages.filter(m => m.Type === 'azure-teardown-mode');
+      assert(teardownLogs.some(m => m.Fields.mode === 'slow'));
+    });
+
+    test('cascade.all but standalone disk not VM-owned - slow walk', async () => {
+      const sandbox = sinon.createSandbox({});
+      const spies = spyChildClients(sandbox);
+      // tracked disks include a standalone disk the VM does not cascade
+      const worker = await makeStoppingWorker({
+        disks: [
+          { name: 'cascade-disk', id: diskId },
+          { name: 'standalone-disk', id: '/subscriptions/sub/.../disks/standalone-disk' },
+        ],
+      });
+      try {
+        await provider.deprovisionResources({ worker, monitor });
+      } finally {
+        sandbox.restore();
+      }
+      assert(spies['nic.get'].called, 'identity mismatch must fall back to the slow walk');
+      assert(spies['disks.get'].called, 'the standalone disk must be deleted, not skipped');
+    });
+
+    test('cascade.all but tracked IP not VM-owned - slow walk', async () => {
+      const sandbox = sinon.createSandbox({});
+      const spies = spyChildClients(sandbox);
+      const worker = await makeStoppingWorker({
+        ip: { name: 'standalone-ip', id: '/subscriptions/sub/.../publicIPAddresses/standalone-ip' },
+      });
+      try {
+        await provider.deprovisionResources({ worker, monitor });
+      } finally {
+        sandbox.restore();
+      }
+      assert(spies['nic.get'].called, 'a standalone public IP must fall back to the slow walk');
+      assert(spies['ip.get'].called, 'the standalone IP must be deleted, not skipped');
+    });
+
+    test('cascade.all, VM has no public IP but a standalone IP is tracked - slow walk', async () => {
+      const sandbox = sinon.createSandbox({});
+      const spies = spyChildClients(sandbox);
+      const cascade = baseCascade();
+      cascade.ip = null;
+      cascade.vmOwnedPublicIpId = null;
+      // tracked ip slot still holds a (standalone) public IP
+      const worker = await makeStoppingWorker({ cascade });
+      try {
+        await provider.deprovisionResources({ worker, monitor });
+      } finally {
+        sandbox.restore();
+      }
+      assert(spies['ip.get'].called, 'a standalone IP with no VM-owned IP must be deleted, not skipped');
+    });
+
+    test('cascade.all matches case-divergent ARM ids - fast path', async () => {
+      const sandbox = sinon.createSandbox({});
+      const spies = spyChildClients(sandbox);
+      monitor.manager.reset();
+      // ARM resource ids are case-insensitive. The probe (VM model) and the
+      // tracked ids (deployment operations) can come back with different casing
+      // for the same resource; the identity match must not be defeated by that.
+      const cascade = baseCascade();
+      cascade.vmOwnedNicId = nicId.toUpperCase();
+      cascade.vmOwnedPublicIpId = ipId.toUpperCase();
+      cascade.vmOwnedDiskIds = [diskId.toUpperCase()];
+      const worker = await makeStoppingWorker({ cascade });
+      try {
+        await provider.deprovisionResources({ worker, monitor });
+      } finally {
+        sandbox.restore();
+      }
+      const [reloaded] = await helper.getWorkers();
+      assert.equal(reloaded.state, 'stopped');
+      for (const [name, spy] of Object.entries(spies)) {
+        assert.equal(spy.callCount, 0, `${name} must not be called when ids match case-insensitively`);
+      }
+      const teardownLogs = monitor.manager.messages.filter(m => m.Type === 'azure-teardown-mode');
+      assert(
+        teardownLogs.some(m => m.Fields.mode === 'fast'),
+        'fast teardown should still engage'
+      );
+    });
+
+    test('teardown mode is not recorded unless the worker reaches STOPPED', async () => {
+      const sandbox = sinon.createSandbox({});
+      monitor.manager.reset();
+      const worker = await makeStoppingWorker();
+      // Fail the worker-stopped transition so deprovision never commits STOPPED.
+      // The teardown log/metric must be emitted only after a completed teardown,
+      // so a re-scan can't double-count (or flip the recorded mode).
+      sandbox.stub(provider, 'onWorkerStopped').rejects(new Error('boom'));
+      try {
+        await provider.deprovisionResources({ worker, monitor });
+      } finally {
+        sandbox.restore();
+      }
+      const [reloaded] = await helper.getWorkers();
+      assert.notEqual(reloaded.state, 'stopped', 'worker should not have reached STOPPED');
+      const teardownLogs = monitor.manager.messages.filter(m => m.Type === 'azure-teardown-mode');
+      assert.equal(teardownLogs.length, 0, 'teardown mode must not be recorded for an incomplete teardown');
+    });
+
+    // ===== register-time cascade probe =====
+
+    const probeNicName = 'probe-nic';
+    const probeNicId = `/subscriptions/sub/resourceGroups/${rg}/providers/Microsoft.Network/networkInterfaces/${probeNicName}`;
+    const probeIpId = `/subscriptions/sub/resourceGroups/${rg}/providers/Microsoft.Network/publicIPAddresses/probe-ip`;
+    const probeOsDiskId = `/subscriptions/sub/resourceGroups/${rg}/providers/Microsoft.Compute/disks/probe-os`;
+    const probeDataDiskId = `/subscriptions/sub/resourceGroups/${rg}/providers/Microsoft.Compute/disks/probe-data`;
+
+    const cascadingVmModel = () => ({
+      networkProfile: { networkInterfaces: [{ id: probeNicId, deleteOption: 'Delete' }] },
+      storageProfile: {
+        osDisk: { managedDisk: { id: probeOsDiskId }, deleteOption: 'Delete' },
+        dataDisks: [{ managedDisk: { id: probeDataDiskId }, deleteOption: 'Delete' }],
+      },
+    });
+    const cascadingNicModel = () => ({
+      ipConfigurations: [{ publicIPAddress: { id: probeIpId, deleteOption: 'Delete' } }],
+    });
+
+    // Registers an ARM worker after seeding a fake VM (and optionally NIC),
+    // returning the reloaded worker so its providerData.cascade can be asserted.
+    const registerArmWorker = async ({ vmModel, nicModel, nicName = probeNicName } = {}) => {
+      const workerPool = await makeWorkerPool();
+      const { vmId, document } = azureSignatures[0];
+      const worker = Worker.fromApi({
+        workerPoolId,
+        workerGroup,
+        workerId: vmId,
+        providerId,
+        created: taskcluster.fromNow('0 seconds'),
+        lastModified: taskcluster.fromNow('0 seconds'),
+        lastChecked: taskcluster.fromNow('0 seconds'),
+        capacity: 1,
+        expires: taskcluster.fromNow('90 seconds'),
+        state: 'requested',
+        providerData: {
+          ...baseProviderData,
+          deploymentMethod: 'arm-template',
+          vm: { name: 'probe-vm', vmId },
+        },
+      });
+      await worker.create(helper.db);
+      if (vmModel) {
+        fake.computeClient.virtualMachines.makeFakeResource(rg, 'probe-vm', { vmId, ...vmModel });
+      }
+      if (nicModel) {
+        fake.networkClient.networkInterfaces.makeFakeResource(rg, nicName, nicModel);
+      }
+      await provider.registerWorker({ workerPool, worker, workerIdentityProof: { document } });
+      // The cascade probe runs in the background after registration returns;
+      // await its handle so the persisted providerData.cascade is observable.
+      await provider._backgroundCascadeProbe;
+      const [reloaded] = await helper.getWorkers();
+      return reloaded;
+    };
+
+    test('probe: all resources cascade - cascade.all true with VM-owned identities', async () => {
+      const reloaded = await registerArmWorker({ vmModel: cascadingVmModel(), nicModel: cascadingNicModel() });
+      const cascade = reloaded.providerData.cascade;
+      assert(cascade, 'cascade should be recorded');
+      assert.equal(cascade.all, true);
+      assert.equal(cascade.nic, true);
+      assert.equal(cascade.ip, true);
+      assert.equal(cascade.disks, true);
+      assert.equal(cascade.vmOwnedNicId, probeNicId);
+      assert.deepEqual(cascade.vmOwnedDiskIds.sort(), [probeOsDiskId, probeDataDiskId].sort());
+      assert.equal(cascade.vmOwnedPublicIpId, probeIpId);
+      assert.equal(cascade.source, 'register');
+      assert(cascade.detectedAt);
+    });
+
+    test('probe: osDisk Detach - cascade.all false', async () => {
+      const vmModel = cascadingVmModel();
+      vmModel.storageProfile.osDisk.deleteOption = 'Detach';
+      const reloaded = await registerArmWorker({ vmModel, nicModel: cascadingNicModel() });
+      assert.equal(reloaded.providerData.cascade.all, false);
+      assert.equal(reloaded.providerData.cascade.disks, false);
+    });
+
+    test('probe: NIC Detach - cascade.all false', async () => {
+      const vmModel = cascadingVmModel();
+      vmModel.networkProfile.networkInterfaces[0].deleteOption = 'Detach';
+      const reloaded = await registerArmWorker({ vmModel, nicModel: cascadingNicModel() });
+      assert.equal(reloaded.providerData.cascade.all, false);
+      assert.equal(reloaded.providerData.cascade.nic, false);
+    });
+
+    test('probe: no public IP - cascade.ip null, cascade.all true', async () => {
+      const reloaded = await registerArmWorker({
+        vmModel: cascadingVmModel(),
+        nicModel: { ipConfigurations: [{ privateIPAddress: '10.0.0.4' }] },
+      });
+      const cascade = reloaded.providerData.cascade;
+      assert.equal(cascade.ip, null);
+      assert.equal(cascade.vmOwnedPublicIpId, null);
+      assert.equal(cascade.all, true);
+    });
+
+    test('probe: multi-NIC - cascade.all false', async () => {
+      const vmModel = cascadingVmModel();
+      vmModel.networkProfile.networkInterfaces.push({ id: `${probeNicId}-2`, deleteOption: 'Delete' });
+      const reloaded = await registerArmWorker({ vmModel });
+      assert.equal(reloaded.providerData.cascade.all, false);
+    });
+
+    test('probe: multi-public-IP - cascade.all false', async () => {
+      const reloaded = await registerArmWorker({
+        vmModel: cascadingVmModel(),
+        nicModel: {
+          ipConfigurations: [
+            { publicIPAddress: { id: probeIpId, deleteOption: 'Delete' } },
+            { publicIPAddress: { id: `${probeIpId}-2`, deleteOption: 'Delete' } },
+          ],
+        },
+      });
+      assert.equal(reloaded.providerData.cascade.all, false);
+    });
+
+    test('probe: missing networkProfile - cascade.all false, no throw', async () => {
+      const reloaded = await registerArmWorker({
+        vmModel: { storageProfile: { osDisk: { managedDisk: { id: probeOsDiskId }, deleteOption: 'Delete' } } },
+      });
+      assert.equal(reloaded.providerData.cascade.all, false);
+      // registration still succeeded
+      assert.equal(reloaded.state, 'running');
+    });
+
+    test('probe: VM GET failure - cascade.all false, registration still succeeds', async () => {
+      const sandbox = sinon.createSandbox({});
+      sandbox.stub(fake.computeClient.virtualMachines, 'get').rejects(new Error('boom'));
+      let reloaded;
+      try {
+        reloaded = await registerArmWorker({ vmModel: cascadingVmModel(), nicModel: cascadingNicModel() });
+      } finally {
+        sandbox.restore();
+      }
+      assert.equal(reloaded.providerData.cascade.all, false);
+      assert.equal(reloaded.state, 'running');
+      helper.assertPulseMessage('worker-running', m => m.payload.workerId === reloaded.workerId);
+    });
+
+    test('registration does not block on a slow/hung cascade probe', async () => {
+      const sandbox = sinon.createSandbox({});
+      // The probe's VM GET hangs (e.g. a backed-up CloudAPI queue), so if the
+      // probe were on the registration path it would stall registerWorker.
+      let releaseHang;
+      sandbox.stub(fake.computeClient.virtualMachines, 'get').callsFake(
+        () =>
+          new Promise(resolve => {
+            releaseHang = () => resolve({});
+          })
+      );
+
+      const workerPool = await makeWorkerPool();
+      const { vmId, document } = azureSignatures[0];
+      const worker = Worker.fromApi({
+        workerPoolId,
+        workerGroup,
+        workerId: vmId,
+        providerId,
+        created: taskcluster.fromNow('0 seconds'),
+        lastModified: taskcluster.fromNow('0 seconds'),
+        lastChecked: taskcluster.fromNow('0 seconds'),
+        capacity: 1,
+        expires: taskcluster.fromNow('90 seconds'),
+        state: 'requested',
+        providerData: { ...baseProviderData, deploymentMethod: 'arm-template', vm: { name: 'probe-vm', vmId } },
+      });
+      await worker.create(helper.db);
+
+      try {
+        // registration returns promptly despite the hung probe GET
+        const res = await provider.registerWorker({ workerPool, worker, workerIdentityProof: { document } });
+        assert(res.expires, 'registration should complete and return expires');
+
+        const [reloaded] = await helper.getWorkers();
+        assert.equal(reloaded.state, 'running', 'worker should be RUNNING even though the probe has not finished');
+        assert.equal(
+          reloaded.providerData.cascade,
+          undefined,
+          'cascade is not set until the background probe finishes'
+        );
+      } finally {
+        // let the hung GET resolve and drain the background probe so nothing lingers
+        releaseHang?.();
+        await provider._backgroundCascadeProbe;
+        sandbox.restore();
+      }
+    });
+
+    test('probe: timeout aborts the in-flight GET, fails open, registration succeeds', async () => {
+      const sandbox = sinon.createSandbox({});
+      provider.cascadeProbeTimeoutMs = 50;
+      let sawAbortSignal = false;
+      sandbox.stub(fake.computeClient.virtualMachines, 'get').callsFake(
+        (_resourceGroupName, _name, options) =>
+          new Promise((_resolve, reject) => {
+            sawAbortSignal = options?.abortSignal instanceof AbortSignal;
+            options?.abortSignal?.addEventListener('abort', () => reject(new Error('aborted')));
+          })
+      );
+      let reloaded;
+      try {
+        reloaded = await registerArmWorker({ vmModel: cascadingVmModel(), nicModel: cascadingNicModel() });
+      } finally {
+        sandbox.restore();
+        delete provider.cascadeProbeTimeoutMs;
+      }
+      assert(sawAbortSignal, 'the probe GET must receive an abortSignal');
+      assert.equal(reloaded.providerData.cascade.all, false);
+      assert.equal(reloaded.state, 'running');
+    });
+  });
+
   suite('deprovision', () => {
     test('de-provisioning loop', async () => {
       const workerPool = await makeWorkerPool({


### PR DESCRIPTION
Since Azure supports fast resource removal with the VM (`deleteOption: 'Delete'`) and our ARM templates are enforcing this, we could save some time by not trying to deprovision each resource manually as before.

We also cannot rely/control what template is used, so we have to check the actual VM model and NIC response from Azure when worker registers. Only after checking that and making sure all resources are "cascadable" we could short-circuit deprovision loop.

Deprovision now becomes: 1. delete VM. 2. if cascade exists, mark all done.
This would skip NIC/IP/Disks steps

Additionally we log new metric and log type to see how it performs.

This should reduce total number of STOPPING workers that are usuallly blocking worker-scanner-azure.

Fixes #8161 - instead of excluding stopping capacity from estimator, we just do this