### PR TITLE
Transfer ownership of mounts to the task on windows

### DIFF
--- a/changelog/issue-6561.md
+++ b/changelog/issue-6561.md
@@ -1,0 +1,6 @@
+audience: worker-deployers
+level: patch
+reference: issue 6561
+---
+On Windows, generic-worker now transfers ownership of mounts in addition to
+giving the task user full control.

--- a/workers/generic-worker/mounts_multiuser_windows_test.go
+++ b/workers/generic-worker/mounts_multiuser_windows_test.go
@@ -1,0 +1,85 @@
+//go:build multiuser
+
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/mcuadros/go-defaults"
+	"github.com/taskcluster/taskcluster/v100/workers/generic-worker/host"
+)
+
+func ownerOf(t *testing.T, path string) string {
+	t.Helper()
+	out, err := host.Output("powershell", "-NoProfile", "-NonInteractive", "-Command",
+		"(Get-Acl -LiteralPath '"+path+"').Owner")
+	if err != nil {
+		t.Fatalf("could not read owner of %q: %v", path, err)
+	}
+	owner := strings.TrimSpace(out)
+	return owner[strings.LastIndex(owner, `\`)+1:]
+}
+
+func TestWritableDirectoryCacheReclaimsOwnership(t *testing.T) {
+	setup(t)
+
+	mounts := []MountEntry{
+		&WritableDirectoryCache{
+			CacheName: "banana-cache",
+			Directory: "ownership-cache",
+		},
+	}
+
+	payload := GenericWorkerPayload{
+		Mounts:     toMountArray(t, &mounts),
+		Command:    helloGoodbye(),
+		MaxRunTime: 180,
+	}
+	defaults.SetDefaults(&payload)
+
+	runTask := func() {
+		td := testTask(t)
+		td.Scopes = append(td.Scopes, "generic-worker:cache:banana-cache")
+		_ = submitAndAssert(t, td, payload, "completed", "completed")
+	}
+
+	cacheLocation := func() string {
+		entries := directoryCaches["banana-cache"]
+		if len(entries) == 0 {
+			t.Fatal("expected a persisted banana-cache entry after the task ran")
+		}
+		return entries[0].Location
+	}
+
+	runTask()
+	location := cacheLocation()
+
+	nested := filepath.Join(location, "sub", "file.txt")
+	if err := os.MkdirAll(filepath.Dir(nested), 0700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(nested, []byte("data"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	// *S-1-5-32-544 is the BUILTIN\Administrators group
+	if err := host.Run("icacls", location, "/setowner", "*S-1-5-32-544", "/T"); err != nil {
+		t.Fatalf("could not reassign cache ownership: %v", err)
+	}
+	if owner := ownerOf(t, location); owner == taskContext.User.Name {
+		t.Fatalf("cache %q is still owned by task user %q before reuse", location, taskContext.User.Name)
+	}
+
+	runTask()
+	location = cacheLocation()
+	nested = filepath.Join(location, "sub", "file.txt")
+
+	for _, p := range []string{location, nested} {
+		if owner := ownerOf(t, p); owner != taskContext.User.Name {
+			t.Errorf("expected %q to be owned by task user %q after cache reuse, but owner is %q", p, taskContext.User.Name, owner)
+		}
+	}
+}

--- a/workers/generic-worker/multiuser_windows.go
+++ b/workers/generic-worker/multiuser_windows.go
@@ -267,8 +267,20 @@ func install(arguments map[string]any) (err error) {
 }
 
 func makeFileOrDirReadWritableForUser(recurse bool, dir string, user *gwruntime.OSUser) error {
-	// see http://ss64.com/nt/icacls.html
-	return host.Run("icacls", dir, "/grant:r", user.Name+":(OI)(CI)F")
+	// On windows, grant:r or ownership aren't enough on their own. Ownership
+	// doesn't mean it's going to be readable, and ownership is necessary for
+	// programs like git that check that files haven't been tampered with (see #6561)
+
+	// http://ss64.com/nt/icacls.html
+	if err := host.Run("icacls", dir, "/grant:r", user.Name+":(OI)(CI)F"); err != nil {
+		return err
+	}
+
+	setOwnerArgs := []string{dir, "/setowner", user.Name}
+	if recurse {
+		setOwnerArgs = append(setOwnerArgs, "/T")
+	}
+	return host.Run("icacls", setOwnerArgs...)
 }
 
 // The windows implementation of os.Rename(...) doesn't allow renaming files


### PR DESCRIPTION
The multiuser engine on windows was granting full access to mounts (yes, that `/grant:r` is to grant `(OI)(CI)F`, full access, by *replacing* the ACL for the given user, not read access... I don't want to talk about how much I got confused by this) but not ownership. This led to those mounts working fine despite being owned by the wrong user, but git didn't like that at all and it was complaining about dubious ownership.

So now we also use `icacls /setowner` to transfer ownership properly which mirrors what we do on POSIX platforms (`chown -R`). I left the full access grant because ownership doesn't imply that you'll have any right on the file (yay windows).

Note that the new `icacls` uses `/T` for ~~Trecursion~~ recursion, which the `/grant` one doesn't. The reason is that while ACLs are applied recursively by `(OI)(CI)`, ownership isn't and doesn't have any similar mechanism, so we have to pay the price of walking the tree. This is the same thing as our `chown -R` so hopefully it won't lead to big caches being really slow because of it...

Writing a test for this was a huge PITA. Two reasons for that, the test suite always reuses the same next-user, and the first cache creation is always done by said next-user.

I worked around this by running a task that does nothing but creates the cache entry, filling said cache from the testing code and giving everything to admin (via its SID, because windows is amazing, so the admin group name is localized and `Administrators` doesn't work for all locales). Then rerunning the task and checking that the cache ownership flip flops between Admin/next-user.

Fixes #6561
