### PR TITLE
Don't publish task-exception for runs that have already been resolved

### DIFF
--- a/changelog/ZnTl7-FASdmwh2aWQ14vKQ.md
+++ b/changelog/ZnTl7-FASdmwh2aWQ14vKQ.md
@@ -1,0 +1,4 @@
+audience: users
+level: patch
+---
+Prevent a worker preemption to be reported twice for the same run when the worker had time to report it itself

--- a/services/queue/src/workerremovedresolver.js
+++ b/services/queue/src/workerremovedresolver.js
@@ -71,25 +71,22 @@ class WorkerRemovedResolver {
     }
 
     // resolve as exception/worker-shutdown with retry
-    task.updateStatusWith(await this.db.fns.resolve_task(taskId, runId, 'exception', 'worker-shutdown', 'retry'));
+    const resolved = task.updateStatusWith(
+      await this.db.fns.resolve_task(taskId, runId, 'exception', 'worker-shutdown', 'retry')
+    );
 
-    // we no longer need existing claimed queue message
-    // because we just resolved the task, so remove it to
-    // prevent it from being processed by the claim resolver
+    // we no longer need the existing claimed queue message
+    // because the task has already been resolved, either by us or by the worker,
+    // so remove it if it still exists to prevent it from being processed by the
+    // claim resolver
     await this.db.fns.queue_claimed_task_resolved(taskId, runId);
 
-    const run = task.runs[runId];
-
-    // If run wasn't resolved to exception/worker-shutdown, it was already
-    // resolved by the worker or another mechanism — nothing to do
-    if (
-      !run ||
-      task.runs.length - 1 > runId + 1 ||
-      run.state !== 'exception' ||
-      run.reasonResolved !== 'worker-shutdown'
-    ) {
+    // If the run was already resolved before by the worker, nothing else to do here
+    if (!resolved) {
       return;
     }
+
+    const run = task.runs[runId];
 
     this.monitor.log.taskResolvedByWorkerRemoved({
       taskId,

--- a/services/queue/test/workerremovedresolver_test.js
+++ b/services/queue/test/workerremovedresolver_test.js
@@ -286,8 +286,10 @@ helper.secrets.mockSuite(testing.suiteName(), ['aws'], (mock, skipping) => {
     assert.equal(status1.status.runs[0].state, 'exception');
     assert.equal(status1.status.runs[0].reasonResolved, 'worker-shutdown');
     assert.equal(status1.status.runs.length, 2);
+    helper.assertPulseMessage('task-exception');
+    helper.clearPulseMessages();
 
-    // second event should be a no-op (no errors, no duplicate runs)
+    // second event should be a no-op (no errors, no duplicate runs, no pulse message)
     await resolver.handleWorkerRemoved(workerRemovedPayload);
 
     const status2 = await helper.queue.status(taskId);
@@ -295,6 +297,56 @@ helper.secrets.mockSuite(testing.suiteName(), ['aws'], (mock, skipping) => {
     assert.equal(status2.status.runs[0].reasonResolved, 'worker-shutdown');
     // still only 2 runs, not 3
     assert.equal(status2.status.runs.length, 2);
+    helper.assertNoPulseMessage('task-exception');
+
+    await resolver.terminate();
+  });
+
+  test('workerRemoved does not re-publish exception for a run already resolved by the worker', async () => {
+    const taskId = slugid.v4();
+    const task = makeTask(1);
+
+    await helper.queue.createTask(taskId, task);
+    await helper.queue.claimWork(taskQueueId, {
+      workerGroup: 'my-worker-group-extended-extended',
+      workerId: 'my-worker-extended-extended',
+      tasks: 1,
+    });
+
+    // The worker itself reports worker-shutdown via the API (the happy path on
+    // a preemption).
+    await helper.queue.reportException(taskId, 0, { reason: 'worker-shutdown' });
+    helper.assertPulseMessage('task-exception');
+    helper.clearPulseMessages();
+
+    const resolver = await helper.load('worker-removed-resolver');
+    helper.load.remove('worker-removed-resolver');
+
+    // worker-manager later reports the instance as removed.
+    await resolver.handleWorkerRemoved({
+      payload: {
+        workerPoolId: taskQueueId,
+        providerId: 'test-provider',
+        workerGroup: 'my-worker-group-extended-extended',
+        workerId: 'my-worker-extended-extended',
+        capacity: 1,
+        reason: 'terminateAfter time exceeded',
+        timestamp: new Date().toISOString(),
+      },
+    });
+
+    // The resolver must **not** re-publish a task-exception.
+    helper.assertNoPulseMessage('task-exception');
+    assert.equal(
+      monitor.manager.messages.filter(({ Type }) => Type === 'task-resolved-by-worker-removed').length,
+      0,
+      'resolver should not claim to have resolved an already-resolved run'
+    );
+
+    // task should be unchanged. run 0 is exception/worker-shutdown, run 1 still pending.
+    const status = await helper.queue.status(taskId);
+    assert.equal(status.status.runs.length, 2);
+    assert.equal(status.status.runs[0].reasonResolved, 'worker-shutdown');
 
     await resolver.terminate();
   });


### PR DESCRIPTION
When a worker gets preempted, it has a chance to resolve the task it's currently working on as "exception, worker-shutdown". Because sometimes GCP doesn't give us enough time for this, `WorkerRemovedResolver` was added in 4c992393174b70f8728cc6682b34066b8491d7e1 to catch those cases where the worker hasn't had time and resolve their task as worker-shutdown which speeds up retries, instead of waiting for the worker claims to expire (20 minutes).

That resolver failed to see the case where the worker did have time to resolve the run itself as `worker-shutdown` and while the database run status update is idempotent, said resolver was re-emitting a pulse message for it.

This led to some funny things where a task could start, get its run 0 resolved as worker-shutdown (by the worker), retried, resolve as failure (run 1) and *then* handled by `WorkerRemovedResolver` which would emit a `task-exception` for run 0. In practice, the task in database has the right state, the problem lies with consumers that now receive an extra run state for an old run.

I saw this on #8785, the `meta-changelog-pr` check is marked as neutral on github despite the task's latest run being failed. As one can probably guess from context above, run 0 was a `worker-shutdown` exception, and the github service marks checks as neutral in those cases (since they're about to get retried and marked pending again). This is very visible from the logs:

```
2026-06-23T13:43:21.939776191Z  taskcluster.queue.api                      task-defined                     runId=null
2026-06-23T13:47:45.379937053Z  taskcluster.queue.dependency-tracker       task-pending                     runId=0
2026-06-23T13:48:36.571272205Z  taskcluster.queue.work-claimer             task-running                     runId=0
2026-06-23T13:48:36.572049107Z  taskcluster.queue.api                      task-claimed                     runId=0
2026-06-23T13:50:09.306277489Z  taskcluster.queue.api                      task-exception                   runId=0
2026-06-23T13:50:09.311832941Z  taskcluster.queue.api                      task-pending                     runId=1
2026-06-23T13:50:09.540267011Z  taskcluster.queue.work-claimer             task-running                     runId=1
2026-06-23T13:50:09.540858475Z  taskcluster.queue.api                      task-claimed                     runId=1
2026-06-23T13:52:00.802547640Z  taskcluster.queue.api                      task-failed                      runId=1
2026-06-23T13:52:35.764825231Z  taskcluster.queue.worker-removed-resolver  task-resolved-by-worker-removed  runId=0
2026-06-23T13:52:35.772203627Z  taskcluster.queue.worker-removed-resolver  task-exception                   runId=0
```

Now the fix is fairly easy, the original author missed that `updateStatusWith` would return whether or not it had resolved the task or if it was a no-op and tried to emulate that with a large condition checking for the task state after trying to resolve it to see if said state matched what it just tried to insert. But of course, a `worker-shutdown` inserted by the worker itself or by the `WorkerRemovedResolver` looks exactly the same so it thought that it had just resolved the run, and emitted the duplicate pulse message. Instead, just take the return value from `updateStatusWith`, and roll with it.