### PR TITLE
Remove our direct dependency on chai/chai-as-promised in client-web

### DIFF
--- a/changelog/TZIkgUiFTNKdLSfUIIVOLg.md
+++ b/changelog/TZIkgUiFTNKdLSfUIIVOLg.md
@@ -1,0 +1,2 @@
+level: silent
+---

--- a/clients/client-web/package.json
+++ b/clients/client-web/package.json
@@ -18,8 +18,6 @@
     "@biomejs/biome": "^2.4.15",
     "@vitest/browser": "^4.1.9",
     "@vitest/browser-playwright": "^4.1.9",
-    "chai": "^6.2.2",
-    "chai-as-promised": "^8.0.2",
     "playwright": "1.60.0",
     "vite-plugin-node-polyfills": "^0.28.0",
     "vitest": "^4.1.9"

--- a/clients/client-web/test/Auth_test.js
+++ b/clients/client-web/test/Auth_test.js
@@ -1,9 +1,5 @@
-import { expect, use } from 'chai';
-import chaiAsPromised from 'chai-as-promised';
 import { Auth, createTemporaryCredentials, fromNow, request } from '../src';
 import helper from './helper';
-
-use(chaiAsPromised);
 
 helper.describe('Auth', () => {
   it('should successfully ping', () => {
@@ -27,7 +23,7 @@ helper.describe('Auth', () => {
       },
     });
 
-    return expect(auth.buildSignedUrl(auth.client, 'test')).to.eventually.match(
+    return expect(auth.buildSignedUrl(auth.client, 'test')).resolves.toMatch(
       new RegExp(`^${helper.rootUrl}/api/auth/v1/clients/test\\?bewit`)
     );
   });

--- a/clients/client-web/test/Queue_test.js
+++ b/clients/client-web/test/Queue_test.js
@@ -1,4 +1,3 @@
-import { expect } from 'chai';
 import { Queue } from '../src';
 import helper from './helper';
 

--- a/clients/client-web/test/buildUrl_test.js
+++ b/clients/client-web/test/buildUrl_test.js
@@ -1,30 +1,11 @@
-import { expect, use } from 'chai';
-import chaiAsPromised from 'chai-as-promised';
 import { Client } from '../src';
 import reference from './reference-harness';
-
-use(chaiAsPromised);
 
 // This suite exercises the request and response functionality of
 // a client against a fake service defined by this reference
 
 const signed = url =>
   url.includes('?') ? new RegExp(`^${url.replace('?', '\\?')}&bewit=(.*)`) : new RegExp(`^${url}\\?bewit=(.*)`);
-
-// assert that the given promise is rejected; chai-as-promised's
-// .rejected appears not to work
-const assertRejected = promise => {
-  let rejected = false;
-  return promise
-    .catch(() => {
-      rejected = true;
-    })
-    .then(() => {
-      if (!rejected) {
-        throw new Error('expected rejection');
-      }
-    });
-};
 
 describe('Building URLs', () => {
   const Fake = Client.create(reference);
@@ -43,7 +24,7 @@ describe('Building URLs', () => {
   });
 
   it('should build signed URL', () => {
-    return expect(client.buildSignedUrl(client.get)).to.eventually.match(
+    return expect(client.buildSignedUrl(client.get)).resolves.toMatch(
       signed('https://tc-tests\\.example\\.com/api/fake/v1/get-test')
     );
   });
@@ -61,7 +42,7 @@ describe('Building URLs', () => {
   });
 
   it('should build signed URL with parameter', () => {
-    return expect(client.buildSignedUrl(client.param, 'test')).to.eventually.match(
+    return expect(client.buildSignedUrl(client.param, 'test')).resolves.toMatch(
       signed('https://tc-tests\\.example\\.com/api/fake/v1/url-param/test/list')
     );
   });
@@ -73,7 +54,7 @@ describe('Building URLs', () => {
   });
 
   it('should build signed URL with 2 parameters', () => {
-    return expect(client.buildSignedUrl(client.param2, 'test', 'te/st')).to.eventually.match(
+    return expect(client.buildSignedUrl(client.param2, 'test', 'te/st')).resolves.toMatch(
       signed('https://tc-tests\\.example\\.com/api/fake/v1/url-param2/test/te%2Fst/list')
     );
   });
@@ -83,7 +64,7 @@ describe('Building URLs', () => {
   });
 
   it('should not build signed URL with missing parameter', () => {
-    return assertRejected(client.buildSignedUrl(client.param2, 'te/st'));
+    return expect(client.buildSignedUrl(client.param2, 'te/st')).rejects.toThrow();
   });
 
   it('should build URL with query options', () => {
@@ -93,7 +74,7 @@ describe('Building URLs', () => {
   });
 
   it('should build signed URL with query options', () => {
-    return expect(client.buildSignedUrl(client.query, { option: 2 })).to.eventually.match(
+    return expect(client.buildSignedUrl(client.query, { option: 2 })).resolves.toMatch(
       signed('https://tc-tests\\.example\\.com/api/fake/v1/query/test?option=2')
     );
   });
@@ -103,7 +84,7 @@ describe('Building URLs', () => {
   });
 
   it('should build signed URL with empty query options', () => {
-    return expect(client.buildSignedUrl(client.query, {})).to.eventually.match(
+    return expect(client.buildSignedUrl(client.query, {})).resolves.toMatch(
       /^https:\/\/tc-tests\.example\.com\/api\/fake\/v1\/query\/test/
     );
   });
@@ -113,7 +94,7 @@ describe('Building URLs', () => {
   });
 
   it('should not build signed URL with incorrect query option', () => {
-    return assertRejected(client.buildSignedUrl(client.query, { wrongKey: 2 }));
+    return expect(client.buildSignedUrl(client.query, { wrongKey: 2 })).rejects.toThrow();
   });
 
   it('should build URL with parameter and query option', () => {
@@ -123,7 +104,7 @@ describe('Building URLs', () => {
   });
 
   it('should build signed URL with parameter and query option', () => {
-    return expect(client.buildSignedUrl(client.paramQuery, 'test', { option: 2 })).to.eventually.match(
+    return expect(client.buildSignedUrl(client.paramQuery, 'test', { option: 2 })).resolves.toMatch(
       signed('https://tc-tests\\.example\\.com/api/fake/v1/param-query/test?option=2')
     );
   });
@@ -135,7 +116,7 @@ describe('Building URLs', () => {
   });
 
   it('should build signed URL with parameter and empty query options', () => {
-    return expect(client.buildSignedUrl(client.paramQuery, 'test', {})).to.eventually.match(
+    return expect(client.buildSignedUrl(client.paramQuery, 'test', {})).resolves.toMatch(
       signed('https://tc-tests\\.example\\.com/api/fake/v1/param-query/test')
     );
   });
@@ -153,6 +134,6 @@ describe('Building URLs', () => {
   });
 
   it('should not build signed URL for non-existent method', () => {
-    return assertRejected(client.buildSignedUrl('non-existent'));
+    return expect(client.buildSignedUrl('non-existent')).rejects.toThrow();
   });
 });

--- a/clients/client-web/test/fromNow_test.js
+++ b/clients/client-web/test/fromNow_test.js
@@ -1,4 +1,3 @@
-import { expect } from 'chai';
 import { fromNow } from '../src';
 
 describe('fromNow', () => {

--- a/clients/client-web/test/parseTime_test.js
+++ b/clients/client-web/test/parseTime_test.js
@@ -1,4 +1,3 @@
-import { expect } from 'chai';
 import { parseTime } from '../src';
 
 describe('parseTime', () => {

--- a/clients/client-web/test/slugid_test.js
+++ b/clients/client-web/test/slugid_test.js
@@ -1,4 +1,3 @@
-import { expect } from 'chai';
 import { nice, v4 } from '../src';
 
 /**

--- a/clients/client-web/yarn.lock
+++ b/clients/client-web/yarn.lock
@@ -387,8 +387,6 @@ __metadata:
     "@biomejs/biome": "npm:^2.4.15"
     "@vitest/browser": "npm:^4.1.9"
     "@vitest/browser-playwright": "npm:^4.1.9"
-    chai: "npm:^6.2.2"
-    chai-as-promised: "npm:^8.0.2"
     crypto-js: "npm:^4.2.0"
     hawk: "npm:^9.0.2"
     playwright: "npm:1.60.0"
@@ -888,28 +886,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"chai-as-promised@npm:^8.0.2":
-  version: 8.0.2
-  resolution: "chai-as-promised@npm:8.0.2"
-  dependencies:
-    check-error: "npm:^2.1.1"
-  peerDependencies:
-    chai: ">= 2.1.2 < 7"
-  checksum: 10c0/829bcd98c04f0b108b2f7379efd33c668e53fbf0bda8d460dc63c96a709fd5de79909392aa78b4256de16a4d57640641d7affc516111e371d6e9f6aec1cc6c8a
-  languageName: node
-  linkType: hard
-
 "chai@npm:^6.2.2":
   version: 6.2.2
   resolution: "chai@npm:6.2.2"
   checksum: 10c0/e6c69e5f0c11dffe6ea13d0290936ebb68fcc1ad688b8e952e131df6a6d5797d5e860bc55cef1aca2e950c3e1f96daf79e9d5a70fb7dbaab4e46355e2635ed53
-  languageName: node
-  linkType: hard
-
-"check-error@npm:^2.1.1":
-  version: 2.1.1
-  resolution: "check-error@npm:2.1.1"
-  checksum: 10c0/979f13eccab306cf1785fa10941a590b4e7ea9916ea2a4f8c87f0316fc3eab07eabefb6e587424ef0f88cbcd3805791f172ea739863ca3d7ce2afc54641c7f0e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
When I switched to vitest in #8792, I missed that vitest had a dependency on chai (another version from ours too...) and was exposing it in their public API through their `expect` wrappers. So I removed our direct dependency on chai so we can't get weird dependency resolution in the future.

Vitest also allows us to use their own `.resolves` and `.rejects` from `@vitest/expect` which means we can remove our dependency on `chai-as-promised` as well and remove that hacky `assertRejected`.

It's not as big a win as I'd like dependency count wise but I'll take it.