### PR TITLE
Update query-string to 9 in client-web

### DIFF
--- a/changelog/Ex3gd7BgQOuAmmLCvJ0XeQ.md
+++ b/changelog/Ex3gd7BgQOuAmmLCvJ0XeQ.md
@@ -1,0 +1,2 @@
+level: silent
+---

--- a/clients/client-web/package.json
+++ b/clients/client-web/package.json
@@ -27,7 +27,7 @@
   "dependencies": {
     "crypto-js": "^4.2.0",
     "hawk": "^9.0.2",
-    "query-string": "^7.0.0",
+    "query-string": "^9.0.0",
     "taskcluster-lib-urls": "^13.0.2"
   },
   "publishConfig": {

--- a/clients/client-web/src/Client.js
+++ b/clients/client-web/src/Client.js
@@ -1,5 +1,5 @@
 import { withRootUrl } from 'taskcluster-lib-urls';
-import { stringify } from 'query-string';
+import queryString from 'query-string';
 import hawk from 'hawk';
 import fetch from './fetch';
 
@@ -170,7 +170,7 @@ export default class Client {
       });
     }
 
-    const queryArgs = args[arity] && stringify(args[arity]);
+    const queryArgs = args[arity] && queryString.stringify(args[arity]);
     const query = queryArgs ? `?${queryArgs}` : '';
 
     return withRootUrl(this.options.rootUrl).api(
@@ -315,7 +315,7 @@ export default class Client {
   async request(entry, args) {
     const expectedArity = this.getMethodExpectedArity(entry);
     const endpoint = this.buildEndpoint(entry, args);
-    const query = args[expectedArity] ? `?${stringify(args[expectedArity])}` : '';
+    const query = args[expectedArity] ? `?${queryString.stringify(args[expectedArity])}` : '';
     const url = withRootUrl(this.options.rootUrl).api(
       this.options.serviceName,
       this.options.serviceVersion,

--- a/clients/client-web/yarn.lock
+++ b/clients/client-web/yarn.lock
@@ -392,7 +392,7 @@ __metadata:
     crypto-js: "npm:^4.2.0"
     hawk: "npm:^9.0.2"
     playwright: "npm:1.60.0"
-    query-string: "npm:^7.0.0"
+    query-string: "npm:^9.0.0"
     taskcluster-lib-urls: "npm:^13.0.2"
     vite-plugin-node-polyfills: "npm:^0.28.0"
     vitest: "npm:^4.1.9"
@@ -1072,10 +1072,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"decode-uri-component@npm:^0.2.0":
-  version: 0.2.2
-  resolution: "decode-uri-component@npm:0.2.2"
-  checksum: 10c0/1f4fa54eb740414a816b3f6c24818fbfcabd74ac478391e9f4e2282c994127db02010ce804f3d08e38255493cfe68608b3f5c8e09fd6efc4ae46c807691f7a31
+"decode-uri-component@npm:^0.4.1":
+  version: 0.4.1
+  resolution: "decode-uri-component@npm:0.4.1"
+  checksum: 10c0/a180bbdb5398ec8270d236a3ac07cb988bbf6097428481780b85840f088951dc0318a8d8f9d56796e1a322b55b29859cea29982f22f9b03af0bc60974c54e591
   languageName: node
   linkType: hard
 
@@ -1289,10 +1289,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"filter-obj@npm:^1.1.0":
-  version: 1.1.0
-  resolution: "filter-obj@npm:1.1.0"
-  checksum: 10c0/071e0886b2b50238ca5026c5bbf58c26a7c1a1f720773b8c7813d16ba93d0200de977af14ac143c5ac18f666b2cfc83073f3a5fe6a4e996c49e0863d5500fccf
+"filter-obj@npm:^5.1.0":
+  version: 5.1.0
+  resolution: "filter-obj@npm:5.1.0"
+  checksum: 10c0/716e8ad2bc352e206556b3e5695b3cdff8aab80c53ea4b00c96315bbf467b987df3640575100aef8b84e812cf5ea4251db4cd672bbe33b1e78afea88400c67dd
   languageName: node
   linkType: hard
 
@@ -2516,15 +2516,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"query-string@npm:^7.0.0":
-  version: 7.1.1
-  resolution: "query-string@npm:7.1.1"
+"query-string@npm:^9.0.0":
+  version: 9.4.0
+  resolution: "query-string@npm:9.4.0"
   dependencies:
-    decode-uri-component: "npm:^0.2.0"
-    filter-obj: "npm:^1.1.0"
-    split-on-first: "npm:^1.0.0"
-    strict-uri-encode: "npm:^2.0.0"
-  checksum: 10c0/85c1ee90f25b936134153df71fa9c12f05922e328188270039f5d4344568c2e9ae5247b09bf118d0656d31dc0e24002e5e1f2a44fae1b96e3d6e64cd552e0518
+    decode-uri-component: "npm:^0.4.1"
+    filter-obj: "npm:^5.1.0"
+    split-on-first: "npm:^3.0.0"
+  checksum: 10c0/44bf989e7f766f99165be27fcd223bbb7a8feca05cacceb8df97bef700bdc9d0a629009554c739adb19527e10813d08a615f794c2aa0de22abafa07019abfbc7
   languageName: node
   linkType: hard
 
@@ -2886,10 +2885,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"split-on-first@npm:^1.0.0":
-  version: 1.1.0
-  resolution: "split-on-first@npm:1.1.0"
-  checksum: 10c0/56df8344f5a5de8521898a5c090023df1d8b8c75be6228f56c52491e0fc1617a5236f2ac3a066adb67a73231eac216ccea7b5b4a2423a543c277cb2f48d24c29
+"split-on-first@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "split-on-first@npm:3.0.0"
+  checksum: 10c0/a1262eae12b68de235e1a08e011bf5b42c42621985ddf807e6221fb1e2b3304824913ae7019f18436b96b8fab8aef5f1ad80dedd2385317fdc51b521c3882cd0
   languageName: node
   linkType: hard
 
@@ -2935,13 +2934,6 @@ __metadata:
     readable-stream: "npm:^3.6.0"
     xtend: "npm:^4.0.2"
   checksum: 10c0/f128fb8076d60cd548f229554b6a1a70c08a04b7b2afd4dbe7811d20f27f7d4112562eb8bce86d72a8691df3b50573228afcf1271e55e81f981536c67498bc41
-  languageName: node
-  linkType: hard
-
-"strict-uri-encode@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "strict-uri-encode@npm:2.0.0"
-  checksum: 10c0/010cbc78da0e2cf833b0f5dc769e21ae74cdc5d5f5bd555f14a4a4876c8ad2c85ab8b5bdf9a722dc71a11dcd3184085e1c3c0bd50ec6bb85fffc0f28cf82597d
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Query-string v8 switched to pure ESM, removing named imports from their entry point, only re-exporting their functions as `default` which forces us to import the module and then pick functions from it instead of being able to only get said functions on import.

Closes #8798 