### PR TITLE
Don't emit success github statuses when a task group still has pending tasks

### DIFF
--- a/changelog/issue-8009.md
+++ b/changelog/issue-8009.md
@@ -1,0 +1,5 @@
+audience: users
+level: patch
+reference: issue 8009
+---
+Fixed a bug where the github status API was marked resolved as `success` before any re-ran tasks were resolved

--- a/services/github/src/handlers/deprecatedStatus.js
+++ b/services/github/src/handlers/deprecatedStatus.js
@@ -37,18 +37,28 @@ export async function deprecatedStatusHandler(message) {
       usesChecks = true;
     }
 
+    let hasUnresolvedTask = false;
     const params = {};
     do {
       const group = await this.queueClient.listTaskGroup(message.payload.taskGroupId, params);
       params.continuationToken = group.continuationToken;
 
       for (let i = 0; i < group.tasks.length; i++) {
-        if (['failed', 'exception'].includes(group.tasks[i].status.state)) {
+        const taskState = group.tasks[i].status.state;
+        if (['failed', 'exception'].includes(taskState)) {
           state = GITHUB_BUILD_STATES.FAILURE;
           break; // one failure is enough
         }
+
+        if (['unscheduled', 'pending', 'running'].includes(taskState)) {
+          hasUnresolvedTask = true;
+        }
       }
     } while (params.continuationToken && state === GITHUB_BUILD_STATES.SUCCESS);
+
+    if (state === GITHUB_BUILD_STATES.SUCCESS && hasUnresolvedTask) {
+      state = GITHUB_BUILD_STATES.PENDING;
+    }
   } else if ([exchangeNames.taskException, exchangeNames.taskFailed].includes(message.exchange)) {
     state = GITHUB_BUILD_STATES.FAILURE;
   } else if ([exchangeNames.taskRunning, exchangeNames.taskPending].includes(message.exchange)) {

--- a/services/github/test/handler_test.js
+++ b/services/github/test/handler_test.js
@@ -1612,6 +1612,26 @@ helper.secrets.mockSuite(testing.suiteName(), [], (mock, skipping) => {
       await assertBuildState('failure');
     });
 
+    test('taskgroup resolved while a reran task is still pending does not report success', async () => {
+      await addBuild({ state: 'pending', taskGroupId: TASKGROUPID });
+      handlers.queueClient.listTaskGroup = async () => ({
+        tasks: [
+          { status: { taskId: 'finished-task', state: 'completed' } },
+          { status: { taskId: 'reran-task', state: 'pending' } },
+        ],
+      });
+
+      await simulateExchangeMessage({
+        taskGroupId: TASKGROUPID,
+        exchange: 'exchange/taskcluster-queue/v1/task-group-resolved',
+        routingKey: 'primary.foo.tc-gh-devel.foo',
+        taskId: null,
+      });
+
+      await assertStatusUpdate('pending');
+      await assertBuildState('pending');
+    });
+
     test('task exception gets a failure status', async () => {
       await addBuild({ state: 'pending', taskGroupId: TASKGROUPID });
       await simulateExchangeMessage({


### PR DESCRIPTION
A PR using github statuses instead of checks could have its status from taskcluster reported as success before the task group would actually be completed.

The queue service emits a `task-group-resolved` event as soon as all tasks in the group have had a resolved run (and then every time a run resolves). The github service listens to that, and when it happens, grabs all tasks, checks for failures and computes the status from it. Except that if a task had been retried and was either pending or running, it would still mark the status as success. Instead, we now also check if there's any task in a non final state and downgrade the status from success to pending in that case.

While statuses are deprecated and we could just ignore the issue, the fix is simple enough and the implications are that a broken PR might get auto merged because a task got retried on any project using statuses instead of checks.

Fixes #8009
