### PR TITLE
Switch `TERM` from `hterm-256color` to `xterm-256color` in interactiv…

### DIFF
--- a/changelog/issue-4585.md
+++ b/changelog/issue-4585.md
@@ -1,0 +1,6 @@
+level: patch
+audience: users
+reference: issue 4585
+---
+Generic worker interactive shells now set `TERM` to `xterm-256color` instead of
+`hterm-256color` which fixes some whitespace quirks on copy

--- a/workers/generic-worker/insecure.go
+++ b/workers/generic-worker/insecure.go
@@ -70,7 +70,7 @@ func (task *TaskRun) newCommandForInteractive(cmd []string, env []string, ctx co
 	var processCmd *process.Command
 	var err error
 
-	env = append(env, "TERM=hterm-256color")
+	env = append(env, "TERM=xterm-256color")
 
 	if ctx == nil {
 		processCmd, err = process.NewCommand(cmd, task.TaskDir(), env)

--- a/workers/generic-worker/multiuser_posix.go
+++ b/workers/generic-worker/multiuser_posix.go
@@ -82,7 +82,7 @@ func (task *TaskRun) newCommandForInteractive(cmd []string, env []string, ctx co
 	var processCmd *process.Command
 	var err error
 
-	env = append(env, "TERM=hterm-256color")
+	env = append(env, "TERM=xterm-256color")
 	taskDir := task.TaskDir()
 
 	if ctx == nil {


### PR DESCRIPTION
When I added a `TERM` in e04e4d96dcc8696bbb9fe845033016aaab046e44, I picked `hterm-256color` because it worked on my machine (hterm-256color is a legit term, which on arch is in the ncurses package). I was able to reproduce #4585 by running a debian image, which does *not* contain that term file by default [1]. In fact, it requires a very specific package to be installed (`ncurses-term` [2]) which is probably not the case anywhere as it's not a dependency for anything [3].

Instead switch to `xterm-256color` which is supported by default and is the default [4] for the hterm library anyway...

For any curious person reading this, the capability in question is `clr_eol` which allows programs to erase the rest of the current line in a single step instead of blanking it out with spaces (which we would end up copying).

Fixes #4585

[1]: https://packages.debian.org/sid/all/ncurses-base/filelist
[2]: https://packages.debian.org/sid/all/ncurses-term/filelist
[3]: https://packages.debian.org/sid/ncurses-term
[4]: https://github.com/macton/hterm/blob/master/README.md#how-do-i-change-the-term-environment-variable
