### PR TITLE
Update js-yaml to 4.2.0

### DIFF
--- a/changelog/RwoJMxL5RkSAP1gEu3ZMQw.md
+++ b/changelog/RwoJMxL5RkSAP1gEu3ZMQw.md
@@ -1,0 +1,2 @@
+level: silent
+---

--- a/libraries/config/src/index.js
+++ b/libraries/config/src/index.js
@@ -9,6 +9,19 @@ import buildSchema from './schema.js';
 
 const __dirname = new URL('.', import.meta.url).pathname;
 
+const dedupeEnvVars = vars => {
+  const seen = new Set();
+  return vars.filter(({ type, var: name, optional, secret }) => {
+    // None of the fields can contain a | so this is safe to use as a key
+    const key = `${type}|${name}|${optional}|${secret}`;
+    if (seen.has(key)) {
+      return false;
+    }
+    seen.add(key);
+    return true;
+  });
+};
+
 const REPO_ROOT = path.join(__dirname, '../../../');
 
 const config = ({
@@ -54,7 +67,7 @@ const config = ({
 
     // If the user requested environment variables list, return it and stop
     if (envVars) {
-      return envVars;
+      return dedupeEnvVars(envVars);
     }
 
     // Add defaults to list of configurations if present

--- a/libraries/config/test/config_test.js
+++ b/libraries/config/test/config_test.js
@@ -176,6 +176,23 @@ suite(testing.suiteName(), () => {
     ]);
   });
 
+  test('load !env listing dedupes repeated descriptors', () => {
+    const vars = config({
+      serviceName: 'test',
+      files: [{ path: path.join(__dirname, 'test-env-dupes.yml'), required: true }],
+      env: {},
+      getEnvVars: true,
+    });
+
+    assume(vars).deep.equals([
+      { type: '!env', var: 'DUP_VARIABLE', optional: false, secret: false },
+      { type: '!env:number', var: 'DUP_VARIABLE', optional: false, secret: false },
+      { type: '!env', var: 'DUP_VARIABLE', optional: true, secret: false },
+      { type: '!env', var: 'DUP_OPTIONAL', optional: true, secret: false },
+      { type: '!env', var: 'OTHER_VARIABLE', optional: false, secret: false },
+    ]);
+  });
+
   test('load !env listing with secrets', () => {
     const vars = config({
       serviceName: 'test',

--- a/libraries/config/test/test-env-dupes.yml
+++ b/libraries/config/test/test-env-dupes.yml
@@ -1,0 +1,8 @@
+defaults:
+  text:        !env          DUP_VARIABLE
+  textAgain:   !env          DUP_VARIABLE
+  asNumber:    !env:number   DUP_VARIABLE
+  sameTypeOpt: !env:optional DUP_VARIABLE
+  optionalA:   !env:optional DUP_OPTIONAL
+  optionalB:   !env:optional DUP_OPTIONAL
+  other:       !env          OTHER_VARIABLE

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "hsts": "^2.1.0",
     "immutable": "^4.3.8",
     "iterall": "^1.2.2",
-    "js-yaml": "^4.1.1",
+    "js-yaml": "^4.2.0",
     "json-e": "^4.8.2",
     "json-parameterization": "^2.0.1",
     "jsonwebtoken": "^9.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8821,14 +8821,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"js-yaml@npm:^4.1.0, js-yaml@npm:^4.1.1":
-  version: 4.1.1
-  resolution: "js-yaml@npm:4.1.1"
+"js-yaml@npm:^4.1.0, js-yaml@npm:^4.2.0":
+  version: 4.2.0
+  resolution: "js-yaml@npm:4.2.0"
   dependencies:
     argparse: "npm:^2.0.1"
   bin:
     js-yaml: bin/js-yaml.js
-  checksum: 10c0/561c7d7088c40a9bb53cc75becbfb1df6ae49b34b5e6e5a81744b14ae8667ec564ad2527709d1a6e7d5e5fa6d483aa0f373a50ad98d42fde368ec4a190d4fae7
+  checksum: 10c0/1916456c118746603b067d74bbcbb0445d9a1d5e474ad4ae775e7b20525bed902e01d9d97dd0c81fcd8d4f596162309d0eb057f4aa38f3e9647f14075e9dea45
   languageName: node
   linkType: hard
 
@@ -12703,7 +12703,7 @@ __metadata:
     inquirer: "npm:^8.0.0"
     is-uuid: "npm:^1.0.2"
     iterall: "npm:^1.2.2"
-    js-yaml: "npm:^4.1.1"
+    js-yaml: "npm:^4.2.0"
     json-e: "npm:^4.8.2"
     json-parameterization: "npm:^2.0.1"
     json-stable-stringify: "npm:^1.3.0"


### PR DESCRIPTION
Version 4.2.0 of js-yaml fixed its block mapping parser to support tagged mapping keys (`!env FOO: bar` would now work for example when before it would've thrown on `!env FOO`). To achieve this, they're parsing nodes twice and throwing one of them away, which ends up calling our type `construct` twice. Since we were collecting potential env variable names as a side effect of the node construction to be able to return a listing of it for documentation purpose, every single env variable was inserted twice.

This whole thing does not spark any joy but I've tried a few things and nothing came up that I liked and this is the least invasive change that I could get to keep things working.

Namely, I tried making the constructor polymorphic and return a different value type with a unique `Symbol` as a key and then walking the final tree returned by js-yaml and collecting those items, but it ended up being quite complex *and* slightly wrong because it was ignoring keys (*technically* you could have `!env FOO` as a key name and it would've missed those). Because it was fragile, made the diff a lot bigger and was in my opinion as vile as the current code, I ended up scrapping it.

I also tried using the listener hooks from js-yaml but no luck there either, they're getting fired twice, would need their own dedupe and blergh....

So I went the "simple" way, by deduping values *after* they're inserted in the `vars`. Note that the dedupe has to be on the full descriptor (`type`, `name`, `flags`) so the same variable being used multiple times under different types survives twice. It also changes the behavior slightly by not emitting duplicates at all anymore, which isn't a problem, all dowstream consumers were already deduping things themselves, but I added a test to encode this behavior so we don't get surprised in the future.

I am not happy about this but I'm out of ideas.

Closes #8773
