### PR TITLE
Fix the `pg` require meta check

### DIFF
--- a/changelog/issue-8761.md
+++ b/changelog/issue-8761.md
@@ -1,0 +1,3 @@
+level: silent
+reference: issue 8761
+---

--- a/infrastructure/tooling/src/meta/checks/node-pg.js
+++ b/infrastructure/tooling/src/meta/checks/node-pg.js
@@ -10,7 +10,7 @@ export const tasks = [
     run: async () => {
       // This checks one of the tc-lib-postgres security invariants, that
       // services are not using postgres directly
-      for (const pattern of ['require(.pg)', '_withClient']) {
+      for (const pattern of ['require(.pg.)', 'import.* from .pg.;', '_withClient']) {
         try {
           const res = await execFileAsync('git', ['grep', pattern, '--', 'services/']);
           // if the grep succeeded, then something matched


### PR DESCRIPTION
There were two issues there. `require("pgfoo")` would've matched and it wasn't checking anything anymore since the switch to esmodules.

Fixes #8761