### PR TITLE
Fix the octokit secondary rate limiter by telling it to do something

### DIFF
--- a/changelog/issue-7773.md
+++ b/changelog/issue-7773.md
@@ -1,0 +1,6 @@
+audience: users
+level: patch
+reference: issue 7773
+---
+The github service will now respect secondary rate limits and retry those
+requests instead of just commenting that they failed.

--- a/services/github/src/github-auth.js
+++ b/services/github/src/github-auth.js
@@ -74,6 +74,7 @@ export default async ({ cfg, monitor }) => {
       },
       onSecondaryRateLimit: (_retryAfter, options, octokit) => {
         octokit.log.warn(`SecondaryRateLimit detected for request ${options.method} ${options.url}`);
+        return true;
       },
     },
     retry: {

--- a/services/github/test/github-auth_test.js
+++ b/services/github/test/github-auth_test.js
@@ -56,7 +56,36 @@ suite(testing.suiteName(), () => {
       await gh.getAppGithub();
       await gh.getInstallationGithub(100);
     });
+
+    test('secondary rate limits get retried instead of throwing', async () => {
+      nock('https://api.github.com:443')
+        .get('/app')
+        .reply(403, { message: 'secondary rate limit' }, { 'retry-after': '0.001' })
+        .get('/app')
+        .reply(200, { id: 12345 });
+
+      const monitor = await helper.load('monitor');
+      const gh = await githubAuth({
+        monitor,
+        cfg: {
+          github: {
+            credentials: {
+              appId: 12345,
+              privatePEM: FAKE_KEY,
+            },
+          },
+        },
+      });
+      const ghApp = await gh.getAppGithub();
+      const res = await ghApp.apps.getAuthenticated();
+
+      assert.equal(res.status, 200);
+      assert.equal(res.data?.id, 12345);
+      assert.equal(true, nock.isDone());
+      monitor.manager.reset();
+    });
   });
+
   suite('getPrivatePEM', () => {
     test('with actual newlines', () => {
       const cfg = { github: { credentials: { privatePEM: WITH_NEWLINES } } };


### PR DESCRIPTION
When I added back the rate limiter in #7732, I mostly copied the example from their readme because it matched the original implementation which was also wrong (and probably got backed out because of the exact same bug).

It was still a lot better because it forced *some* delay between requests and was still detecting primary rate limits and backing off on that. But not returning true from `onSecondaryRateLimit` means this was doing **nothing** except logging that we hit the limit and then going through and throwing, which lead to the service putting a comment on the commit/PR, which helped exhaust the app write quota which means the next write would hit the limit again and yeah... Not great.

I chose to not add an upper bound on the number of retries because secondary rate limits should be very short lived and resolve on their own and we'd rather not lose events going towards github as those might leave checks in a stuck state which might prevent merging PRs for example. If it becomes an issue, we should review the architecture and stop ACK-ing pulse messages *before* calling github's API.

(If only there was some way to encode that this function needed to make a choice and return a value... We could call it a type system for example...)

Fixes #7773
