### PR TITLE
Fix a few things zizmor is unhappy about

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -22,6 +22,7 @@ jobs:
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: '24'
+          package-manager-cache: false
           # registry-url is REQUIRED for trusted publishing — triggers setup-node
           # to write a .npmrc with proper authentication configuration
           registry-url: 'https://registry.npmjs.org'

--- a/.github/workflows/staticcheck.yml
+++ b/.github/workflows/staticcheck.yml
@@ -24,7 +24,7 @@ jobs:
       with:
         fetch-depth: 1
         persist-credentials: false
-    - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
+    - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
       with:
         go-version-file: go.mod
     - uses: dominikh/staticcheck-action@9716614d4101e79b4340dd97b10e54d68234e431 # v1.4.1
@@ -46,7 +46,7 @@ jobs:
       with:
         fetch-depth: 1
         persist-credentials: false
-    - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
+    - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
       with:
         go-version-file: go.mod
     - uses: dominikh/staticcheck-action@9716614d4101e79b4340dd97b10e54d68234e431 # v1.4.1
@@ -68,7 +68,7 @@ jobs:
       with:
         fetch-depth: 1
         persist-credentials: false
-    - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
+    - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
       with:
         go-version-file: go.mod
     - uses: dominikh/staticcheck-action@9716614d4101e79b4340dd97b10e54d68234e431 # v1.4.1

--- a/changelog/DCapD8vqTsiOMVI5qjN3Ig.md
+++ b/changelog/DCapD8vqTsiOMVI5qjN3Ig.md
@@ -1,0 +1,2 @@
+level: silent
+---


### PR DESCRIPTION
Some sha not matching the version in the comment on the same line (the horror :scream:). And fix one false positive in the release workflow that could potentially have been an issue had we decided to install a package in said workflow because they're enabling package caches by default in `setup-node`. In practice even that would probably have been impossible but eh, costs nothing to disable the cache and silence a warning.