### PR TITLE
Relax the node version requirement for `taskcluster-client` to `^major`

### DIFF
--- a/changelog/issue-8660.md
+++ b/changelog/issue-8660.md
@@ -1,0 +1,5 @@
+audience: users
+level: minor
+reference: issue 8660
+---
+Relax the required node version for `taskcluster-client` from `24.17.0` to `^24`

--- a/clients/client/package.json
+++ b/clients/client/package.json
@@ -23,7 +23,7 @@
     "nock": "^14.0.13"
   },
   "engines": {
-    "node": "24.17.0"
+    "node": "^24"
   },
   "type": "module",
   "files": [

--- a/infrastructure/tooling/src/generate/generators/node-version.js
+++ b/infrastructure/tooling/src/generate/generators/node-version.js
@@ -47,13 +47,20 @@ tasks.push({
       contents.replace(/^( *NODE_VERSION *= *")[0-9.]+(")$/m, `$1${nodeVersion}$2`)
     );
 
-    for (const file of ['ui/package.json', 'clients/client/package.json', 'clients/client-test/package.json']) {
+    for (const file of ['ui/package.json', 'clients/client-test/package.json']) {
       utils.status({ message: file });
       await modifyRepoJSON(file, contents => {
         contents.engines.node = nodeVersion;
         return contents;
       });
     }
+
+    // Relax the engine requirement for published packages
+    utils.status({ message: 'clients/client/package.json' });
+    await modifyRepoJSON('clients/client/package.json', contents => {
+      contents.engines.node = `^${nodeVersion.split('.')[0]}`;
+      return contents;
+    });
 
     utils.status({ message: 'cloudbuild.yaml' });
     await modifyRepoYAML('cloudbuild.yaml', contents => {


### PR DESCRIPTION
Users of our published libraries are currently stuck on the exact same version as the one we use for development which makes it painful to update as they have to keep their node version in sync with us. This relaxes the requirement to only require the same major version as the one we're using, trusting node to not introduce breaking changes during a major cycle.

I didn't relax the requirement further because we already have proof that node breaking changes will break this client (current tests don't pass with node 26).

Note that right now I only relaxed the requirement for taskcluster-client. We also publish client-web, but that one doesn't currently have an engine bound so I didn't add one. Other packages aren't published so they're unaffected.

Fixes #7331
Fixes #8660
Closes #8691 
