### PR TITLE
Drop `application/graphql` support as a valid content type for web-server

### DIFF
--- a/changelog/BqX5LHLxQtaT4JhK_jUhuw.md
+++ b/changelog/BqX5LHLxQtaT4JhK_jUhuw.md
@@ -1,0 +1,6 @@
+audience: users
+level: major
+---
+Drop support for `application/graphql` as the request content type on
+`/graphql`. Use `application/json` instead as is specified in the graphql over
+http spec.

--- a/package.json
+++ b/package.json
@@ -57,7 +57,6 @@
     "ajv-formats": "^2.1.1",
     "amqplib": "^0.10.8",
     "body-parser": "1.20.3",
-    "body-parser-graphql": "^1.0.0",
     "bottleneck": "^2.15.3",
     "chalk": "^5.6.2",
     "compression": "^1.8.1",

--- a/services/web-server/src/servers/createApp.js
+++ b/services/web-server/src/servers/createApp.js
@@ -1,6 +1,5 @@
 import bodyParser from 'body-parser';
 import path from 'node:path';
-import bodyParserGraphql from 'body-parser-graphql';
 import session from 'express-session';
 import cors from 'cors';
 import express from 'express';
@@ -85,14 +84,7 @@ export default async ({ cfg, strategies, auth, monitor, db, api }) => {
   app.use(bodyParser.urlencoded({ extended: true }));
   app.use(bodyParser.json());
   app.options('/graphql', cors(corsOptions));
-  app.post(
-    '/graphql',
-    cors(corsOptions),
-    credentials(),
-    bodyParserGraphql.graphql({
-      limit: '1mb',
-    })
-  );
+  app.post('/graphql', cors(corsOptions), credentials());
 
   if (cfg.app.playground) {
     app.get(

--- a/yarn.lock
+++ b/yarn.lock
@@ -4955,15 +4955,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"body-parser-graphql@npm:^1.0.0":
-  version: 1.1.0
-  resolution: "body-parser-graphql@npm:1.1.0"
-  dependencies:
-    body-parser: "npm:^1.18.2"
-  checksum: 10c0/3eac018356358b48ddbc84e2e502c6a5eaf3b7fc161e0c99138493aab97541f9ba879e184cf65be46a3214e252ec5f6b1d3953dad3a58236eb157fa1560d7e1e
-  languageName: node
-  linkType: hard
-
 "body-parser@npm:1.20.3":
   version: 1.20.3
   resolution: "body-parser@npm:1.20.3"
@@ -4984,7 +4975,24 @@ __metadata:
   languageName: node
   linkType: hard
 
-"body-parser@npm:^1.18.2, body-parser@npm:~1.20.3":
+"body-parser@npm:^2.2.2":
+  version: 2.2.2
+  resolution: "body-parser@npm:2.2.2"
+  dependencies:
+    bytes: "npm:^3.1.2"
+    content-type: "npm:^1.0.5"
+    debug: "npm:^4.4.3"
+    http-errors: "npm:^2.0.0"
+    iconv-lite: "npm:^0.7.0"
+    on-finished: "npm:^2.4.1"
+    qs: "npm:^6.14.1"
+    raw-body: "npm:^3.0.1"
+    type-is: "npm:^2.0.1"
+  checksum: 10c0/95a830a003b38654b75166ca765358aa92ee3d561bf0e41d6ccdde0e1a0c9783cab6b90b20eb635d23172c010b59d3563a137a738e74da4ba714463510d05137
+  languageName: node
+  linkType: hard
+
+"body-parser@npm:~1.20.3":
   version: 1.20.4
   resolution: "body-parser@npm:1.20.4"
   dependencies:
@@ -5001,23 +5009,6 @@ __metadata:
     type-is: "npm:~1.6.18"
     unpipe: "npm:~1.0.0"
   checksum: 10c0/569c1e896297d1fcd8f34026c8d0ab70b90d45343c15c5d8dff5de2bad08125fc1e2f8c2f3f4c1ac6c0caaad115218202594d37dcb8d89d9b5dcae1c2b736aa9
-  languageName: node
-  linkType: hard
-
-"body-parser@npm:^2.2.2":
-  version: 2.2.2
-  resolution: "body-parser@npm:2.2.2"
-  dependencies:
-    bytes: "npm:^3.1.2"
-    content-type: "npm:^1.0.5"
-    debug: "npm:^4.4.3"
-    http-errors: "npm:^2.0.0"
-    iconv-lite: "npm:^0.7.0"
-    on-finished: "npm:^2.4.1"
-    qs: "npm:^6.14.1"
-    raw-body: "npm:^3.0.1"
-    type-is: "npm:^2.0.1"
-  checksum: 10c0/95a830a003b38654b75166ca765358aa92ee3d561bf0e41d6ccdde0e1a0c9783cab6b90b20eb635d23172c010b59d3563a137a738e74da4ba714463510d05137
   languageName: node
   linkType: hard
 
@@ -12383,7 +12374,6 @@ __metadata:
     assume: "npm:^2.1.0"
     aws-sdk-client-mock: "npm:^4.1.0"
     body-parser: "npm:1.20.3"
-    body-parser-graphql: "npm:^1.0.0"
     bottleneck: "npm:^2.15.3"
     builtin-modules: "npm:^3.1.0"
     c8: "npm:^8.0.1"


### PR DESCRIPTION
We were supporting that content type through `body-parser-graphql` which has not seen any update in 8 years and is now making updating `body-parser` itself in web-server impossible as it expects body-parser 1, not 2. The API changed slightly and it ends up double consuming the body which doesn't work very well as one can expect.

Since `application/graphql` isn't even mentioned in the graphql over HTTP spec[1] and nothing in this repo uses it, we can just drop support for it.

The 1mb limit that was set on the body parser was dead code as `bodyParser.json()` was running first without respecting that limit (it has its own limit set to 100kB).

[1]: https://github.com/graphql/graphql-over-http/blob/main/spec/GraphQLOverHTTP.md
