### PR TITLE
Convert some commonJS to ESM in the UI

### DIFF
--- a/changelog/XpEXsvTERMuaVE_NTMWevg.md
+++ b/changelog/XpEXsvTERMuaVE_NTMWevg.md
@@ -1,0 +1,2 @@
+level: silent
+---

--- a/ui/src/utils/mapUtils.js
+++ b/ui/src/utils/mapUtils.js
@@ -10,7 +10,7 @@
  * @param value {any}
  * @returns key {any | undefined}
  */
-exports.findKeyInMap = ({ map, value }) => {
+export const findKeyInMap = ({ map, value }) => {
   const found = Array.from(map).find(kv => kv[1] === value);
 
   return found ? found[0] : found;

--- a/ui/src/utils/workerPool.js
+++ b/ui/src/utils/workerPool.js
@@ -1,4 +1,4 @@
-const assert = require('assert');
+import assert from 'assert';
 
 /**
  * We consider a "workerPoolId" to be a string
@@ -11,7 +11,7 @@ const assert = require('assert');
  *
  * These two functions serve to split and join workerPoolIds.
  */
-const splitWorkerPoolId = workerPoolId => {
+export const splitWorkerPoolId = workerPoolId => {
   const split = workerPoolId.split('/');
 
   assert.strictEqual(split.length, 2, `invalid workerPoolId ${workerPoolId}`);
@@ -19,9 +19,7 @@ const splitWorkerPoolId = workerPoolId => {
   return { provisionerId: split[0], workerType: split[1] };
 };
 
-exports.splitWorkerPoolId = splitWorkerPoolId;
-
-const joinWorkerPoolId = (provisionerId, workerType) => {
+export const joinWorkerPoolId = (provisionerId, workerType) => {
   assert(typeof provisionerId === 'string', 'provisionerId omitted');
   assert(typeof workerType === 'string', 'workerType omitted');
   assert(provisionerId.indexOf('/') === -1, 'provisionerId cannot contain `/`');
@@ -29,7 +27,5 @@ const joinWorkerPoolId = (provisionerId, workerType) => {
   return `${provisionerId}/${workerType}`;
 };
 
-exports.joinWorkerPoolId = joinWorkerPoolId;
-
-exports.isWorkerPoolIdSecondHalfValid = workerType =>
+export const isWorkerPoolIdSecondHalfValid = workerType =>
   /^[a-z]([-a-z0-9]{0,36}[a-z0-9])?$/.test(workerType);


### PR DESCRIPTION
`exports.foo` -> `export const foo` and `require` -> `import`.

Found those while looking at migrating to vite and they can land on their own as webpack 4 is perfectly happy with them.

There are a few more CJS things that need to be converted but I cannot (namely a `require.context` and a few `require()`) but I can't do that as fixing them breaks or can't be done while keeping feature parity under webpack 4.