### PR TITLE
feat(w-m): Remove stale check and change level to notice for transient gcp errors

### DIFF
--- a/changelog/Jue6EqshQeaxZtN_hH02GQ.md
+++ b/changelog/Jue6EqshQeaxZtN_hH02GQ.md
@@ -1,0 +1,4 @@
+audience: worker-deployers
+level: patch
+---
+The Google provider in worker-manager now logs a single transient GCP compute 5xx at `notice` rather than `warning` level.

--- a/services/worker-manager/src/providers/google.js
+++ b/services/worker-manager/src/providers/google.js
@@ -40,9 +40,9 @@ export class GoogleProvider extends Provider {
           // google hands out 403 for rate limiting; back off significantly
           // google's interval is 100 seconds so let's try once optimistically and a second time to get it for sure
           return { backoff: _backoffDelay * 50, reason: 'rateLimit', level: 'notice' };
-        } else if (err.code === 403 || err.code >= 500) {
+        } else if (err.code >= 500) {
           // For 500s, let's take a shorter backoff
-          return { backoff: _backoffDelay * 2 ** tries, reason: 'errors', level: 'warning' };
+          return { backoff: _backoffDelay * 2 ** tries, reason: 'errors', level: tries === 0 ? 'notice' : 'warning' };
         }
         // If we don't want to do anything special here, just throw and let the
         // calling code figure out what to do

--- a/services/worker-manager/test/provider_google_test.js
+++ b/services/worker-manager/test/provider_google_test.js
@@ -904,4 +904,41 @@ helper.secrets.mockSuite(testing.suiteName(), [], (mock, skipping) => {
       helper.assertPulseMessage('worker-running', m => m.payload.launchConfigId === worker.launchConfigId);
     });
   });
+
+  suite('errorHandler', () => {
+    // _backoffDelay is 1 in test config, so backoffs below are 1 * <multiplier>.
+    const make500 = () => {
+      const err = new Error('Internal error, unknown error code: InternalError');
+      err.code = 500;
+      return err;
+    };
+
+    test('single transient 500 (tries=0) backs off short and logs at notice', () => {
+      const result = provider.cloudApi.errorHandler({ err: make500(), tries: 0 });
+      assert.equal(result.reason, 'errors');
+      assert.equal(result.backoff, 1); // 1 * 2**0
+      assert.equal(result.level, 'notice');
+    });
+
+    test('sustained 500s (tries>0) escalate to warning with growing backoff', () => {
+      const result = provider.cloudApi.errorHandler({ err: make500(), tries: 2 });
+      assert.equal(result.reason, 'errors');
+      assert.equal(result.backoff, 4); // 1 * 2**2
+      assert.equal(result.level, 'warning');
+    });
+
+    test('403 is treated as rateLimit at notice with a long backoff', () => {
+      const err = new Error('Rate Limit Exceeded');
+      err.code = 403;
+      const result = provider.cloudApi.errorHandler({ err, tries: 0 });
+      assert.equal(result.reason, 'rateLimit');
+      assert.equal(result.backoff, 50); // 1 * 50
+      assert.equal(result.level, 'notice');
+    });
+
+    test('non-4xx/5xx errors are rethrown', () => {
+      const err = new Error('nope');
+      assert.throws(() => provider.cloudApi.errorHandler({ err, tries: 0 }), /nope/);
+    });
+  });
 });


### PR DESCRIPTION
403 is already handled by the previous check.
To avoid logging all 5xx from GCP as warning, it is now a notice for a first try. Request would be retried in 1s

