### PR TITLE
feat(w-m): Handle checkWorker timeouts as a warning not as an error

### DIFF
--- a/changelog/issue-8664.md
+++ b/changelog/issue-8664.md
@@ -1,0 +1,6 @@
+audience: worker-deployers
+level: patch
+reference: issue 8664
+---
+
+When a worker-manager `checkWorker` call times out, the scanner now aborts the in-flight provider API call and logs a warning instead of reporting an error, since the worker is re-checked on the next loop. Other `checkWorker` failures are still reported as errors.

--- a/services/worker-manager/src/providers/aws.js
+++ b/services/worker-manager/src/providers/aws.js
@@ -337,7 +337,7 @@ export class AwsProvider extends Provider {
     };
   }
 
-  async checkWorker({ worker }) {
+  async checkWorker({ worker, abortSignal }) {
     this.seen[worker.workerPoolId] = this.seen[worker.workerPoolId] || 0;
     this.seenByWorkerGroup[worker.workerPoolId] = this.seenByWorkerGroup[worker.workerPoolId] || {};
     const monitor = this.workerMonitor({ worker });
@@ -351,7 +351,8 @@ export class AwsProvider extends Provider {
             new DescribeInstanceStatusCommand({
               InstanceIds: [worker.workerId.toString()],
               IncludeAllInstances: true,
-            })
+            }),
+            { abortSignal }
           )
         )
       ).InstanceStatuses;

--- a/services/worker-manager/src/providers/azure/index.js
+++ b/services/worker-manager/src/providers/azure/index.js
@@ -1986,8 +1986,8 @@ export class AzureProvider extends Provider {
     }
   }
 
-  /** @param {{ worker: Worker }} opts */
-  async checkWorker({ worker }) {
+  /** @param {{ worker: Worker, abortSignal?: AbortSignal }} opts */
+  async checkWorker({ worker, abortSignal }) {
     const monitor = this.workerMonitor({
       worker,
       extra: {
@@ -2027,7 +2027,7 @@ export class AzureProvider extends Provider {
       return;
     }
 
-    const { instanceState, instanceStateReason } = await this.queryInstance({ worker, monitor });
+    const { instanceState, instanceStateReason } = await this.queryInstance({ worker, monitor, abortSignal });
 
     switch (instanceState) {
       case InstanceStates.OK: {
@@ -2098,7 +2098,7 @@ export class AzureProvider extends Provider {
    * See https://docs.microsoft.com/en-us/azure/virtual-machines/states-lifecycle
    * for background on the VM lifecycle.
    */
-  async queryInstance({ worker, monitor }) {
+  async queryInstance({ worker, monitor, abortSignal }) {
     const states = Worker.states;
     const workerKey = `${worker.workerPoolId}/${worker.workerGroup}/${worker.workerId}`;
     try {
@@ -2106,7 +2106,8 @@ export class AzureProvider extends Provider {
       const instanceView = await this._enqueue('get', () =>
         this.computeClient.virtualMachines.instanceView(
           worker.providerData.resourceGroupName,
-          worker.providerData.vm.name
+          worker.providerData.vm.name,
+          { abortSignal }
         )
       );
       this.instanceView404Streaks.delete(workerKey);

--- a/services/worker-manager/src/providers/google.js
+++ b/services/worker-manager/src/providers/google.js
@@ -402,7 +402,7 @@ export class GoogleProvider extends Provider {
    * Called for every worker on a schedule so that we can update the state of
    * the worker locally
    */
-  async checkWorker({ worker }) {
+  async checkWorker({ worker, abortSignal }) {
     const states = Worker.states;
     this.seen[worker.workerPoolId] = this.seen[worker.workerPoolId] || 0;
     this.seenByWorkerGroup[worker.workerPoolId] = this.seenByWorkerGroup[worker.workerPoolId] || {};
@@ -413,11 +413,14 @@ export class GoogleProvider extends Provider {
     let state;
     try {
       const { data } = await this._enqueue('get', () =>
-        this.compute.instances.get({
-          project: worker.providerData.project,
-          zone: worker.providerData.zone,
-          instance: worker.workerId,
-        })
+        this.compute.instances.get(
+          {
+            project: worker.providerData.project,
+            zone: worker.providerData.zone,
+            instance: worker.workerId,
+          },
+          { signal: abortSignal }
+        )
       );
       const { status } = data;
       monitor.debug(`instance status is ${status}`);

--- a/services/worker-manager/src/providers/provider.js
+++ b/services/worker-manager/src/providers/provider.js
@@ -107,7 +107,7 @@ export class Provider {
   async scanPrepare() {}
 
   /**
-   * @param {{ worker: Worker }} opts
+   * @param {{ worker: Worker; abortSignal?: AbortSignal }} opts
    */
   async checkWorker() {}
 

--- a/services/worker-manager/src/util.js
+++ b/services/worker-manager/src/util.js
@@ -83,17 +83,33 @@ export const measureTime = (precision = 1e6) => {
   return () => Number(hrtime.bigint() - start) / precision;
 };
 
+export class TimeoutError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = 'TimeoutError';
+  }
+}
+
 /**
  * Run a promise with a timeout. If the promise does not settle
- * within `ms` milliseconds, the returned promise rejects with `message`.
+ * within `ms` milliseconds, the returned promise rejects with a
+ * `TimeoutError` carrying `message`.
  * The timer is always cleaned up to avoid leaks.
+ *
+ * @param {(abortSignal: AbortSignal) => Promise<*>} cb
+ * @param {number} ms
+ * @param {string} message
  */
-export const withTimeout = (promise, ms, message) => {
+export const withTimeout = (cb, ms, message) => {
   let timer;
+  const abortController = new AbortController();
   return Promise.race([
-    promise,
+    cb(abortController.signal),
     new Promise((_, reject) => {
-      timer = setTimeout(() => reject(new Error(message)), ms);
+      timer = setTimeout(() => reject(new TimeoutError(message)), ms);
     }),
-  ]).finally(() => clearTimeout(timer));
+  ]).finally(() => {
+    abortController.abort();
+    clearTimeout(timer);
+  });
 };

--- a/services/worker-manager/src/worker-scanner.js
+++ b/services/worker-manager/src/worker-scanner.js
@@ -2,7 +2,7 @@ import Iterate from '@taskcluster/lib-iterate';
 import taskcluster from '@taskcluster/client';
 import { paginatedIterator } from '@taskcluster/lib-postgres';
 import { Worker, WorkerPool } from './data.js';
-import { withTimeout } from './util.js';
+import { withTimeout, TimeoutError } from './util.js';
 
 /**
  * Make sure that we visit each worker relatively frequently to update its state
@@ -19,6 +19,7 @@ export class WorkerScanner {
     providersFilter = {},
     estimator,
     concurrency = 1,
+    checkWorkerTimeoutMs = 60_000,
   }) {
     this.WorkerPool = WorkerPool;
     this.providers = providers;
@@ -26,6 +27,7 @@ export class WorkerScanner {
     this.providersFilter = providersFilter;
     this.estimator = estimator;
     this.concurrency = Math.max(1, concurrency);
+    this.checkWorkerTimeoutMs = checkWorkerTimeoutMs;
     this.scanLoopAlive = false;
     this.iterate = new Iterate({
       maxFailures: 10,
@@ -128,12 +130,17 @@ export class WorkerScanner {
       }
       try {
         await withTimeout(
-          provider.checkWorker({ worker }),
-          60_000, // 1 minute
+          abortSignal => provider.checkWorker({ worker, abortSignal }),
+          this.checkWorkerTimeoutMs,
           `checkWorker timed out for ${worker.workerPoolId}/${worker.workerId}`
         );
       } catch (err) {
-        this.monitor.reportError(err);
+        if (err instanceof TimeoutError) {
+          // the provider API call hung past the budget, aborting re-checking next loop
+          this.monitor.warning(err.message);
+        } else {
+          this.monitor.reportError(err);
+        }
       }
     } else {
       this.monitor.info(

--- a/services/worker-manager/test/provider_aws_test.js
+++ b/services/worker-manager/test/provider_aws_test.js
@@ -503,6 +503,31 @@ helper.secrets.mockSuite(testing.suiteName(), [], (mock, skipping) => {
   });
 
   suite('AWS provider - checkWorker', () => {
+    test('passes the abort signal to the EC2 client', async () => {
+      fake.rgn('us-west-2').instanceStatuses['i-123'] = 'running';
+      const worker = await Worker.fromApi({
+        ...workerInDB,
+        workerId: 'i-123',
+        state: Worker.states.REQUESTED,
+      });
+      await worker.create(helper.db);
+
+      const client = provider.ec2s['us-west-2'];
+      const origSend = client.send.bind(client);
+      let sendOptions;
+      client.send = (command, options) => {
+        sendOptions = options;
+        return origSend(command, options);
+      };
+      const abortSignal = new AbortController().signal;
+      try {
+        await provider.checkWorker({ worker, abortSignal });
+      } finally {
+        client.send = origSend;
+      }
+      assert.equal(sendOptions?.abortSignal, abortSignal, 'ec2 send should receive the abort signal');
+    });
+
     test('stopped instances - should be marked as STOPPED in DB, should not add to seen', async () => {
       fake.rgn('us-west-2').instanceStatuses['i-123'] = 'stopped';
       const worker = await Worker.fromApi({

--- a/services/worker-manager/test/provider_azure_test.js
+++ b/services/worker-manager/test/provider_azure_test.js
@@ -4404,4 +4404,38 @@ helper.secrets.mockSuite(testing.suiteName(), [], (mock, skipping) => {
       assert.equal('error2', reportedErrors[1].error);
     });
   });
+
+  suite('checkWorker abort signal', () => {
+    const sandbox = sinon.createSandbox({});
+    teardown(() => sandbox.restore());
+
+    test('checkWorker passes the abort signal to instanceView', async () => {
+      await provider.scanPrepare();
+
+      const worker = Worker.fromApi({
+        workerPoolId,
+        workerGroup: 'westus',
+        workerId: 'vm-1',
+        providerId,
+        created: taskcluster.fromNow('0 seconds'),
+        lastModified: taskcluster.fromNow('0 seconds'),
+        lastChecked: taskcluster.fromNow('0 seconds'),
+        expires: taskcluster.fromNow('90 seconds'),
+        capacity: 1,
+        state: 'running',
+        providerData: baseProviderData,
+      });
+      await worker.create(helper.db);
+      sandbox.stub(provider, 'provisionResources').returns('running');
+      fake.computeClient.virtualMachines.setFakeInstanceView('rgrp', baseProviderData.vm.name, {
+        statuses: [{ code: 'ProvisioningState/succeeded' }, { code: 'PowerState/running' }],
+      });
+
+      const spy = sandbox.spy(provider.computeClient.virtualMachines, 'instanceView');
+      const abortSignal = new AbortController().signal;
+      await provider.checkWorker({ worker, abortSignal });
+
+      assert.equal(spy.firstCall.args[2]?.abortSignal, abortSignal, 'instanceView should receive the abort signal');
+    });
+  });
 });

--- a/services/worker-manager/test/provider_google_test.js
+++ b/services/worker-manager/test/provider_google_test.js
@@ -604,6 +604,27 @@ helper.secrets.mockSuite(testing.suiteName(), [], (mock, skipping) => {
       assert.equal(worker.state, Worker.states.RUNNING);
     });
 
+    test('passes the abort signal to the compute client', async () => {
+      await makeWorkerPool();
+      const worker = await suiteMakeWorker({ state: 'running' });
+      fake.compute.instances.setFakeInstanceStatus(project, 'us-east1-a', workerId, 'RUNNING');
+      const origGet = fake.compute.instances.get.bind(fake.compute.instances);
+      let getOptions;
+      fake.compute.instances.get = async (params, options) => {
+        getOptions = options;
+        return origGet(params);
+      };
+      const abortSignal = new AbortController().signal;
+      try {
+        await provider.scanPrepare();
+        await provider.checkWorker({ worker, abortSignal });
+        await provider.scanCleanup();
+      } finally {
+        fake.compute.instances.get = origGet;
+      }
+      assert.equal(getOptions?.signal, abortSignal, 'instances.get should receive the abort signal');
+    });
+
     test('for a terminated instance', async () => {
       await makeWorkerPool();
       let worker = await suiteMakeWorker({ state: 'running' });

--- a/services/worker-manager/test/worker_scanner_test.js
+++ b/services/worker-manager/test/worker_scanner_test.js
@@ -427,6 +427,64 @@ helper.secrets.mockSuite(testing.suiteName(), [], (mock, skipping) => {
     monitor.manager.reset();
   });
 
+  test('a checkWorker that times out is warned, not reported as an error', async () => {
+    await Worker.fromApi({
+      workerPoolId: 'cc/pool',
+      workerGroup: 'wg',
+      workerId: 'slow-worker',
+      providerId: 'testing1',
+      created: new Date(),
+      lastModified: new Date(),
+      lastChecked: new Date(),
+      expires: taskcluster.fromNow('8 days'),
+      capacity: 1,
+      state: Worker.states.REQUESTED,
+      providerData: {},
+    }).create(helper.db);
+
+    let seenSignal;
+    const fakeProvider = {
+      providerId: 'testing1',
+      providerType: 'testing',
+      setupFailed: false,
+      scanPrepare: async () => {},
+      scanCleanup: async () => {},
+      checkWorker: async ({ abortSignal }) => {
+        seenSignal = abortSignal;
+        return new Promise(resolve => setTimeout(resolve, 100));
+      },
+    };
+    const fakeProviders = {
+      forAll: async fn => {
+        await fn(fakeProvider);
+      },
+      get: id => (id === 'testing1' ? fakeProvider : undefined),
+    };
+
+    const scanner = new WorkerScanner({
+      ownName: 'test-timeout',
+      providers: fakeProviders,
+      monitor,
+      db: helper.db,
+      providersFilter: {},
+      concurrency: 1,
+      checkWorkerTimeoutMs: 10,
+    });
+
+    await scanner.scan();
+
+    const reported = monitor.manager.messages.find(({ Type }) => Type === 'monitor.error');
+    assert(!reported, `checkWorker timeout should not be reported as an error: ${JSON.stringify(reported)}`);
+    const warned = monitor.manager.messages.find(
+      msg =>
+        msg.Severity === LEVELS.warning &&
+        /checkWorker timed out for cc\/pool\/slow-worker/.test(msg.Fields?.message || '')
+    );
+    assert(warned, 'expected a warning for the timed-out checkWorker');
+    assert(seenSignal?.aborted, 'expected the checkWorker abort signal to be aborted on timeout');
+    monitor.manager.reset();
+  });
+
   test('a rejecting worker update is reported, not left as an unhandled rejection', async () => {
     // The failing worker has a near expiry so the expires-refresh worker.update()
     // runs (and throws) outside checkWorker's own catch. Under concurrency that


### PR DESCRIPTION
Most of the failures happen in bursts and logs show that it's happening on the cloud provider side where instance.get or instanceView calls hang or take longer than the 60s timeout.

We emit those as a warning instead of error, since worker will be retried on the next run.

Additionally, we now pass the abort signal to also abort requests that might have stayed pending after we abandon them in Promise.race()

Fixes #8664
