### PR TITLE
Copy UI yarn patches in the root docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,7 @@ COPY /.yarn /base/yarn/.yarn/
 RUN mkdir -p /base/yarn-ui
 COPY /ui/yarn.lock /.yarnrc.yml /ui/package.json /base/yarn-ui/
 COPY /.yarn /base/yarn-ui/.yarn/
+COPY /ui/.yarn/patches /base/yarn-ui/.yarn/patches/
 # prepare clients/client dependencies
 RUN mkdir -p /base/yarn-client
 COPY /clients/client/yarn.lock /.yarnrc.yml /clients/client/package.json /base/yarn-client/

--- a/changelog/asFHU6GIQlmNJqjteQxhhg.md
+++ b/changelog/asFHU6GIQlmNJqjteQxhhg.md
@@ -1,0 +1,2 @@
+level: silent
+---


### PR DESCRIPTION
I kinda missed that when I migrated from webpack to vite, we had to patch react-virtualized but I missed that this docker image build process needed those patches too and we were not copying them
