### PR TITLE
Bug 2053380 - Validate oauth state in the github login flow

### DIFF
--- a/changelog/bug-2053380.md
+++ b/changelog/bug-2053380.md
@@ -1,0 +1,5 @@
+audience: users
+level: patch
+reference: bug 2053380
+---
+Fix login CSRF in the github login flow by validating the oauth state parameter

--- a/services/web-server/src/login/strategies/github.js
+++ b/services/web-server/src/login/strategies/github.js
@@ -126,6 +126,7 @@ export default class Github {
           clientSecret: strategyCfg.clientSecret,
           callbackURL: `${cfg.app.publicUrl}${callback}`,
           scope: 'repo',
+          state: true,
         },
         async (accessToken, _refreshToken, profile, next) => {
           await this.db.fns.add_github_access_token(

--- a/services/web-server/test/login_strategies_github_test.js
+++ b/services/web-server/test/login_strategies_github_test.js
@@ -1,4 +1,9 @@
 import assert from 'node:assert';
+import http from 'node:http';
+import express from 'express';
+import session from 'express-session';
+import passport from 'passport';
+import request from 'superagent';
 import testing from '@taskcluster/lib-testing';
 import helper from './helper.js';
 import Github from '../src/login/strategies/github.js';
@@ -118,6 +123,52 @@ helper.secrets.mockSuite(testing.suiteName(), [], (mock, skipping) => {
         user.roles.filter(role => role.startsWith('github-org-')),
         ['github-org-admin:taskcluster'].sort()
       );
+    });
+
+    suite('oauth state parameter', () => {
+      const serverCfg = {
+        ...cfg,
+        app: { publicUrl: 'https://tc.example.com' },
+        taskcluster: { credentials: { clientId: 'client-id', accessToken: 'access-token' } },
+      };
+
+      let server, port;
+
+      suiteSetup(async () => {
+        const app = express();
+        app.use(session({ secret: 'test-secret', resave: false, saveUninitialized: false }));
+        app.use(passport.initialize());
+        app.use(passport.session());
+
+        const strategy = new Github({
+          name: 'github',
+          cfg: serverCfg,
+          monitor: { debug: () => {} },
+          db: {},
+        });
+        strategy.useStrategy(app, serverCfg);
+
+        server = http.createServer(app);
+        await new Promise(resolve => server.listen(0, resolve));
+        port = server.address().port;
+      });
+
+      suiteTeardown(async () => {
+        if (server) {
+          await new Promise(resolve => server.close(resolve));
+        }
+      });
+
+      test('the authorization request includes a state parameter', async () => {
+        const res = await request
+          .get(`http://127.0.0.1:${port}/login/github`)
+          .redirects(0)
+          .ok(res => res.status === 302);
+
+        const location = new URL(res.header.location);
+        assert.equal(location.origin + location.pathname, 'https://github.com/login/oauth/authorize');
+        assert(location.searchParams.get('state'));
+      });
     });
   });
 });


### PR DESCRIPTION
The github login strategy was configured without `state: true` which means passport-oauth2 never generated nor checked state nonces. That means that someone could generate a callback URL, share it and have someone logged in to their account. In practice this is pretty useless, you'd get the scopes from the attacker account, and ownership of secrets, tasks and such isn't a thing that exists in taskcluster.

I do not understand why passport-oauth2 defaults state to false when it seems like such a no brainer but it is what it is...

Happy to drop the test if you think it's too complex for the win, it was just an easier way to test this locally. I ended up going through the pain of local testing anyway to check that the cookie did survive the redirects properly. This also matches the auth0 strategy.