### PR TITLE
Bug 2053178 - Make sure v1 github policy is respected when a fork uses v0

### DIFF
--- a/changelog/cG4RCE2BT9ibjBCNQmTM_g.md
+++ b/changelog/cG4RCE2BT9ibjBCNQmTM_g.md
@@ -1,0 +1,6 @@
+audience: users
+level: patch
+reference: bug 2053178
+---
+Fix a way for PRs from forks to bypass the `public_restricted` policy by
+declaring `version: 0` in their own taskcluster.yml

--- a/services/github/src/tc-yaml.js
+++ b/services/github/src/tc-yaml.js
@@ -39,8 +39,10 @@ class VersionZero extends TcYaml {
     branchTest(payload.details['event.base.repo.branch']);
     branchTest(payload.details['event.head.repo.branch']);
 
-    if (payload.details['event.type'].startsWith('pull_request')) {
+    if (payload.tasks_for === GITHUB_TASKS_FOR.PULL_REQUEST) {
       config.scopes = [`assume:repo:github.com/${payload.organization}/${payload.repository}:pull-request`];
+    } else if (payload.tasks_for === GITHUB_TASKS_FOR.PULL_REQUEST_UNTRUSTED) {
+      config.scopes = [`assume:repo:github.com/${payload.organization}/${payload.repository}:pull-request-untrusted`];
     } else if (payload.details['event.type'] === 'push') {
       const prefix = `assume:repo:github.com/${payload.organization}/${payload.repository}:branch:`;
       config.scopes = [prefix + payload.details['event.base.repo.branch']];

--- a/services/github/test/handler_test.js
+++ b/services/github/test/handler_test.js
@@ -834,6 +834,31 @@ helper.secrets.mockSuite(testing.suiteName(), [], (mock, skipping) => {
       assert.equal(build.state, 'pending');
     });
 
+    test('pull_request (not a collaborator, base policy public_restricted, fork declares its own v0 yml) uses the untrusted scope', async () => {
+      const baseYaml = { ...validYamlV1Json };
+      baseYaml.policy = { pullRequests: 'public_restricted' };
+
+      github.inst(INST_ID).setTaskclusterYml({
+        owner: 'TaskclusterRobot',
+        repo: 'hooks-testing',
+        ref: COMMIT_SHA,
+        content: validYamlJson,
+      });
+      github.inst(INST_ID).setTaskclusterYml({
+        owner: 'TaskclusterRobot',
+        repo: 'hooks-testing',
+        ref: 'development',
+        content: baseYaml,
+      });
+
+      await simulateJobMessage({ user: 'goodBuddy', eventType: 'pull_request.opened' });
+
+      assert(handlers.createTasks.calledWith({ scopes: sinon.match.array, tasks: sinon.match.array }));
+      const args = handlers.createTasks.firstCall.args[0];
+      assert.ok(args.scopes.includes('assume:repo:github.com/TaskclusterRobot/hooks-testing:pull-request-untrusted'));
+      assert.ok(!args.scopes.includes('assume:repo:github.com/TaskclusterRobot/hooks-testing:pull-request'));
+    });
+
     test('valid push (but not collaborator) creates a taskGroup', async () => {
       github.inst(INST_ID).setTaskclusterYml({
         owner: 'TaskclusterRobot',

--- a/services/github/test/intree_test.js
+++ b/services/github/test/intree_test.js
@@ -6,6 +6,7 @@ import helper from './helper.js';
 import libUrls from 'taskcluster-lib-urls';
 import yaml from 'js-yaml';
 import testing from '@taskcluster/lib-testing';
+import { GITHUB_TASKS_FOR } from '../src/constants.js';
 
 const webhookDir = new URL('./data/webhooks/', import.meta.url).pathname;
 const loadWebhook = filename => JSON.parse(fs.readFileSync(path.join(webhookDir, filename), 'utf8'));
@@ -57,7 +58,17 @@ suite(testing.suiteName(), () => {
         'event.head.user.email': 'test@test.com',
       },
     };
-    return _.merge(defaultMessage, params);
+    const message = _.merge(defaultMessage, params);
+    if (message.tasks_for === undefined) {
+      if (message.details['event.type'].startsWith('pull_request')) {
+        message.tasks_for = GITHUB_TASKS_FOR.PULL_REQUEST;
+      } else if (message.details['event.type'] === 'release') {
+        message.tasks_for = GITHUB_TASKS_FOR.RELEASE;
+      } else {
+        message.tasks_for = GITHUB_TASKS_FOR.PUSH;
+      }
+    }
+    return message;
   }
 
   /**

--- a/services/github/test/tc-yaml_test.js
+++ b/services/github/test/tc-yaml_test.js
@@ -27,6 +27,7 @@ suite(testing.suiteName(), () => {
         {
           organization: 'org',
           repository: 'repo',
+          tasks_for: 'github-pull-request',
           details: { 'event.type': 'pull_request.opened' },
         },
         now


### PR DESCRIPTION
The scopes list for a rendered TC YML comes from the full rendering for a given version of a taskcluster.yml, which in the case of a PR, is whatever is at the PR HEAD. So a fork with a v0 YAML at their HEAD will unconditionally get v0 scopes which includes `:pull-request` which is the trusted version, ignoring the v1 policy upstream despite the PR correctly being considered untrusted and tasks_for being set to `PULL_REQUEST_UNTRUSTED`.

The fix is fairly easy although it feels a bit dirty. We have `tasks_for` in the payload (which, while not exposed to the user in v0, is still present). That field already contains the trust level decision made against the base repo's policy, it just isn't respected by v0 because it didn't have that concept of trusted PRs. So now if we have a tasks_for that is untrusted, we honor it even with v0, and give the untrusted scope instead of reverting to the `:pull-request` one.