### PR TITLE
fix(changelog): don't assume PR is running against taskcluster/taskcluster

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -134,7 +134,7 @@ tasks:
                 REPOSITORIES: { $json: { taskcluster: Taskcluster } }
               - $if: "isPullRequest"
                 then:
-                  TASKCLUSTER_PULL_REQUEST_NUMBER: "${event.pull_request.number}"
+                  TASKCLUSTER_PULL_REQUEST_URL: "${event.pull_request.url}"
 
           cache:
             "${trustDomain}-level-${level}-checkouts-sparse-v2": /builds/worker/checkouts

--- a/changelog/Sqfg5YYQTi-f0APJmNSUSQ.md
+++ b/changelog/Sqfg5YYQTi-f0APJmNSUSQ.md
@@ -1,0 +1,2 @@
+level: silent
+---

--- a/infrastructure/tooling/src/changelog/index.js
+++ b/infrastructure/tooling/src/changelog/index.js
@@ -236,14 +236,19 @@ export class ChangeLog {
   }
 }
 
-const check_pr = async pr => {
+const check_pr = async prUrl => {
   const octokit = new Octokit();
-  const options = octokit.pulls.listFiles.endpoint.merge({
-    owner: 'taskcluster',
-    repo: 'taskcluster',
-    pull_number: pr,
-  });
-  const files = await octokit.paginate(options, response => response.data.map(({ filename }) => filename));
+  if (!prUrl) {
+    throw new Error(
+      'Cannot check the changelog: --pull-request-url is unset. This check should only run in github pull requests.'
+    );
+  }
+  console.log(`Checking changelog requirement for ${prUrl}`);
+  const files = await octokit.paginate(`GET ${prUrl}/files`, response => response.data.map(({ filename }) => filename));
+  if (!files.length) {
+    throw new Error(`no changed files found for ${prUrl}; the pull request lookup returned nothing`);
+  }
+  console.log(`changed files (${files.length}):\n${files.map(f => `  ${f}`).join('\n')}`);
 
   // files that do not require a changelog entry if they are the only thing changed.  This
   // is similar to the list in .gitattributes., along with yarn and package.json
@@ -273,7 +278,7 @@ const check_pr = async pr => {
   const hasImportantFiles = files.some(filename => boringFiles.every(r => !r.test(filename)));
 
   if (!hasImportantFiles) {
-    console.log(`${chalk.bold.green(`PR ${pr} OK:`)} does not contain any changes requiring a changelog`);
+    console.log(`${chalk.bold.green(`PR ${prUrl} OK:`)} does not contain any changes requiring a changelog`);
     return true;
   }
 
@@ -281,16 +286,16 @@ const check_pr = async pr => {
 
   if (changelogFiles.some(filename => !filename.endsWith('.md'))) {
     console.log(
-      `${chalk.bold.red('ERROR:')} Pull Request ${pr} has an invalid file in 'changelog/'. All files must be '.md'`
+      `${chalk.bold.red('ERROR:')} Pull Request ${prUrl} has an invalid file in 'changelog/'. All files must be '.md'`
     );
     return false;
   }
 
   if (hasImportantFiles && !changelogFiles.length) {
-    console.log(`${chalk.bold.red('ERROR:')} Pull Request ${pr} does not modify any files in 'changelog/'`);
+    console.log(`${chalk.bold.red('ERROR:')} Pull Request ${prUrl} does not modify any files in 'changelog/'`);
     return false;
   }
-  console.log(chalk.bold.green(`PR ${pr} OK`));
+  console.log(chalk.bold.green(`PR ${prUrl} OK`));
   return true;
 };
 
@@ -401,8 +406,8 @@ export const check = async options => {
   await cl.load();
   console.log(chalk.bold.green('Changelog OK'));
 
-  if (options.pr) {
-    if (!(await check_pr(options.pr))) {
+  if (options.pullRequestUrl) {
+    if (!(await check_pr(options.pullRequestUrl))) {
       process.exit(1);
     }
   }

--- a/infrastructure/tooling/src/main.js
+++ b/infrastructure/tooling/src/main.js
@@ -197,7 +197,7 @@ program
 program
   .command('changelog:check')
   .description('Check the changelog')
-  .option('--pr <pr>', 'Check that this pull request contains a changelog')
+  .option('--pull-request-url <url>', 'Check that this pull request contains a changelog')
   .action(
     actFn(async ({ options }) => {
       const { check } = await import('./changelog/index.js');

--- a/taskcluster/kinds/meta/kind.yml
+++ b/taskcluster/kinds/meta/kind.yml
@@ -55,7 +55,7 @@ tasks:
     run:
       command: >-
         corepack yarn --immutable &> /dev/null &&
-        corepack yarn changelog:check --pr $TASKCLUSTER_PULL_REQUEST_NUMBER
+        corepack yarn changelog:check --pull-request-url $TASKCLUSTER_PULL_REQUEST_URL
   changelog-push:
     description: taskcluster changelog checks
     run-on-tasks-for: [github-push]

--- a/taskcluster/src/transforms/__init__.py
+++ b/taskcluster/src/transforms/__init__.py
@@ -52,7 +52,7 @@ def add_task_env(config, tasks):
         env["GIT_BRANCH"] = config.params["head_ref"]
 
         # Passing through some things the decision task wants to child tasks
-        env["TASKCLUSTER_PULL_REQUEST_NUMBER"] = os.environ.get("TASKCLUSTER_PULL_REQUEST_NUMBER", "")
+        env["TASKCLUSTER_PULL_REQUEST_URL"] = os.environ.get("TASKCLUSTER_PULL_REQUEST_URL", "")
 
         # Make dependency versions available for use
         env["NODE_VERSION"] = node_version


### PR DESCRIPTION
While working on integrating https://github.com/mozilla/blender with taskcluster, I set up a staging taskcluster repo at https://github.com/petemoore/taskcluster to test the dependabot approval process before we applied it to the production repo. In the process, I discovered that we check which files changed in a PR to decide whether a changelog is necessary. Since we perform a shallow clone (depth 20) we may not have enough information to locally determine what the full set of changed files is in the PR. Therefore we use octokit to query the PR directly to find the list of changed files (rather than computing locally). The flow is basically, find out what PR we are on, and then query github for the list of changed files in _that_ PR. However, the code was assuming that the PR was raised against github.com/taskcluster/taskcluster. This does not work when you have a staged repo. It is also a little fragile if orgs or repos get renamed, or a third party forks taskcluster as the basis for their own project etc.

So this PR looks up the real owner and repo names, and logs them too. We should see when the CI runs for this PR, that it reports that it looks up the diff for the exact PR that gets created when I submit this pull request! To be extra safe, I also created a local PR to my fork, which correctly identified the PR (`Checking changelog requirement for petemoore/taskcluster#392`) in https://github.com/petemoore/taskcluster/pull/392/checks?check_run_id=85878636336.