### PR TITLE
Move material-ui-json-schema-viewer to this repository

### DIFF
--- a/changelog/axQ8AobzQPuAl5tPW-P0fQ.md
+++ b/changelog/axQ8AobzQPuAl5tPW-P0fQ.md
@@ -1,0 +1,2 @@
+level: silent
+---

--- a/ui/package.json
+++ b/ui/package.json
@@ -68,7 +68,6 @@
     "markdown-it": "^14.2.0",
     "markdown-it-highlightjs": "^3.0.0",
     "markdown-it-link-attributes": "^4.0.1",
-    "material-ui-json-schema-viewer": "^2.0.0",
     "mdi-react": "^6.2.0",
     "mitt": "^3.0.1",
     "param-case": "^3.0.3",

--- a/ui/src/components/JsonSchemaViewer/components/Chip/index.jsx
+++ b/ui/src/components/JsonSchemaViewer/components/Chip/index.jsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import { node, element } from 'prop-types';
+import { makeStyles } from '@material-ui/core/styles';
+import MuiChip from '@material-ui/core/Chip';
+
+const useStyles = makeStyles(theme => ({
+  /**
+   * Chips used for keyword notations.
+   */
+  chip: {
+    color: theme.palette.text.primary,
+    borderColor: theme.palette.text.secondary,
+  },
+}));
+
+function Chip({ label, icon }) {
+  /**
+   * Generate classes to use styles for chips.
+   */
+  const classes = useStyles();
+
+  return (
+    <MuiChip
+      className={classes.chip}
+      label={label}
+      icon={icon}
+      size="small"
+      variant="outlined"
+    />
+  );
+}
+
+Chip.propTypes = {
+  /** Label for chip to display */
+  label: node.isRequired,
+  /** Icon for chip to display */
+  icon: element,
+};
+
+Chip.defaultProps = {
+  icon: null,
+};
+
+export default React.memo(Chip);

--- a/ui/src/components/JsonSchemaViewer/components/Header/index.jsx
+++ b/ui/src/components/JsonSchemaViewer/components/Header/index.jsx
@@ -1,0 +1,62 @@
+import React from 'react';
+import { bool, func } from 'prop-types';
+import { makeStyles } from '@material-ui/core/styles';
+import Typography from '@material-ui/core/Typography';
+import Button from '@material-ui/core/Button';
+import Markdown from '../Markdown';
+import { schema } from '../../utils/prop-types';
+
+const useStyles = makeStyles(theme => ({
+  container: {
+    backgroundColor: theme.palette.background.paper,
+    color: theme.palette.text.primary,
+    padding: `${theme.spacing(1.5)}px ${theme.spacing(1)}px`,
+  },
+  title: {
+    color: theme.palette.text.primary,
+    margin: 0,
+  },
+  description: {
+    color: theme.palette.text.primary,
+  },
+  button: {
+    margin: theme.spacing(1),
+  },
+}));
+
+function Header({ schema, sourceMode, toggleMode }) {
+  /**
+   * Generate classes to define overall style for the schema table.
+   */
+  const classes = useStyles();
+
+  return (
+    <div className={classes.container}>
+      <Typography component="div" variant="h6" className={classes.title}>
+        <Markdown>{schema.title}</Markdown>
+
+        <Button
+          className={classes.button}
+          color="secondary"
+          size="small"
+          onClick={toggleMode}>
+          {sourceMode ? 'hide' : 'show'} source
+        </Button>
+      </Typography>
+      <Typography
+        component="div"
+        variant="subtitle2"
+        className={classes.description}>
+        <Markdown>{schema.description}</Markdown>
+      </Typography>
+    </div>
+  );
+}
+
+Header.propTypes = {
+  schema: schema.isRequired,
+  sourceMode: bool.isRequired,
+  toggleMode: func.isRequired,
+};
+
+export default React.memo(Header);

--- a/ui/src/components/JsonSchemaViewer/components/Markdown/index.jsx
+++ b/ui/src/components/JsonSchemaViewer/components/Markdown/index.jsx
@@ -1,0 +1,59 @@
+import React from 'react';
+import { string, bool } from 'prop-types';
+import { makeStyles } from '@material-ui/core/styles';
+import classNames from 'classnames';
+import parser from 'markdown-it';
+
+const useStyles = makeStyles(theme => ({
+  /** Default styles applied to markdown content. */
+  markdown: {
+    '& code': {
+      color: theme.palette.text.primary,
+      backgroundColor: theme.palette.text.disabled,
+      padding: theme.spacing(0.25),
+    },
+  },
+  /** Inverse styles applied to markdown content (used for tooltip titles) */
+  inverse: {
+    '& code': {
+      color: theme.palette.common.black,
+      backgroundColor: theme.palette.common.white,
+      padding: theme.spacing(0.25),
+    },
+  },
+}));
+
+function Markdown({ children, inverse }) {
+  /**
+   * Generate classes to define overall style for the schema table.
+   */
+  const classes = useStyles();
+  const markdown = parser({ linkify: true });
+
+  return (
+    <span
+      className={classNames(
+        { [`${classes.markdown}`]: !inverse },
+        { [`${classes.inverse}`]: inverse }
+      )}
+      // biome-ignore lint/security/noDangerouslySetInnerHtml: rendering markdown is the purpose of this component
+      dangerouslySetInnerHTML={{
+        __html: markdown.renderInline(children),
+      }}
+    />
+  );
+}
+
+Markdown.propTypes = {
+  /** Markdown content */
+  children: string,
+  /** Whether an inverse style should be applied or not */
+  inverse: bool,
+};
+
+Markdown.defaultProps = {
+  children: '',
+  inverse: false,
+};
+
+export default React.memo(Markdown);

--- a/ui/src/components/JsonSchemaViewer/components/SchemaTable/LeftCell.jsx
+++ b/ui/src/components/JsonSchemaViewer/components/SchemaTable/LeftCell.jsx
@@ -1,0 +1,303 @@
+import React from 'react';
+import { oneOf, func, object } from 'prop-types';
+import { makeStyles } from '@material-ui/core/styles';
+import classNames from 'classnames';
+import Typography from '@material-ui/core/Typography';
+import IconButton from '@material-ui/core/IconButton';
+import ExpandIcon from 'mdi-react/MenuRightIcon';
+import ShrinkIcon from 'mdi-react/MenuDownIcon';
+import WarningIcon from 'mdi-react/AlertOutlineIcon';
+import Tooltip from '../Tooltip';
+import { basicTreeNode, NOOP } from '../../utils/prop-types';
+import { expandRefNode, shrinkRefNode } from '../../utils/schemaTree';
+import {
+  COMBINATION_TYPES,
+  LITERAL_TYPES,
+  NESTED_TYPES,
+  BRACKET_SYMBOLS,
+  COMBINATION_SYMBOLS,
+  TOOLTIP_DESCRIPTIONS,
+} from '../../utils/constants';
+
+const useStyles = makeStyles(theme => ({
+  /**
+   * Dynamically generate styles for indentations to be used for
+   * displaying the data structure of the schemas.
+   */
+  indentation: {
+    marginTop: theme.spacing(1),
+    marginBottom: theme.spacing(1),
+    marginLeft: indent => theme.spacing(indent * 2),
+  },
+
+  /**
+   * Typography within the cell
+   */
+  typography: {
+    color: theme.palette.text.primary,
+    display: 'flex',
+    alignItems: 'center',
+  },
+
+  /**
+   * Name text displayed within a LeftCell.
+   */
+  name: {
+    marginRight: theme.spacing(0.5),
+    fontFamily: 'monospace',
+  },
+  /**
+   * Highlight the type for the schema or sub-schema displayed
+   * within a LeftCell.
+   */
+  code: {
+    backgroundColor: theme.palette.text.primary,
+    color: theme.palette.getContrastText(theme.palette.text.primary),
+    padding: `0 ${theme.spacing(0.5)}px`,
+    fontSize: theme.typography.subtitle2.fontSize,
+    fontWeight: theme.typography.subtitle2.fontWeight,
+    fontFamily: 'monospace',
+  },
+  /**
+   * Warning icon to inform missing type in LeftCell.
+   */
+  missingType: {
+    display: 'flex',
+    alignItems: 'center',
+  },
+  /**
+   * Comments used for combination types in LeftCell.
+   */
+  comment: {
+    color: theme.palette.text.hint,
+  },
+  /**
+   * Prefixes used to notate special properties of data types in
+   * lines of LeftCell. (ex. 'required', 'contains' keywords)
+   */
+  prefix: {
+    color: theme.palette.error.main,
+    padding: `0 ${theme.spacing(0.5)}px`,
+  },
+  /**
+   * Button used to expand or shrink a $ref.
+   */
+  refButton: {
+    marginLeft: theme.spacing(1),
+  },
+}));
+
+function LeftCell({ treeNode, refType, setSchemaTree, references }) {
+  const { schema, path } = treeNode;
+  const schemaType = schema._type;
+  const name = schema._name;
+  /**
+   * Dynamically generate indent styles using the length of the path.
+   * (length of path = depth of the current treeNode)
+   */
+  const indentSize = path.length;
+  const classes = useStyles(indentSize);
+  /**
+   * Create a text for the name of the schema.
+   */
+  const nameText = (function createNameText(name, type) {
+    if (COMBINATION_TYPES.includes(type)) {
+      return <span className={classes.name}>{`${name}:`}</span>;
+    }
+
+    return <span className={classes.name}>{`${name}:`}</span>;
+  })(name, schemaType);
+  /**
+   * Create a type symbol corresponding to the specified type.
+   */
+  const typeSymbol = (function createTypeSymbol(type) {
+    const bracketTypes = [
+      ...NESTED_TYPES,
+      LITERAL_TYPES.array,
+      LITERAL_TYPES.object,
+    ];
+    const combinationTypes = [
+      ...COMBINATION_TYPES,
+      ...COMBINATION_TYPES.map(type => LITERAL_TYPES[type]),
+    ];
+
+    /**
+     * If type is not specified, create a tooltip with an icon
+     * to indicate that the schema is missing a type property.
+     */
+    if (!type) {
+      return (
+        <Tooltip title={TOOLTIP_DESCRIPTIONS.noType}>
+          <div className={classes.missingType}>
+            <WarningIcon />
+          </div>
+        </Tooltip>
+      );
+    }
+
+    /**
+     * Types with nested structures use a single bracket symbol.
+     * (either for opening a bracket or closing a bracket)
+     */
+    if (bracketTypes.includes(type)) {
+      return BRACKET_SYMBOLS[type];
+    }
+
+    /**
+     * Combination types (allOf, anyOf, oneOf, no) use comments.
+     */
+    if (combinationTypes.includes(type)) {
+      return (
+        <span className={classes.comment}>{COMBINATION_SYMBOLS[type]}</span>
+      );
+    }
+
+    /**
+     * In case of an array of types (multiple types),
+     * create an array of type symbols with highlighted text format,
+     * with each symbol separated with a comma with each other.
+     */
+    if (Array.isArray(type)) {
+      const typeArray = [];
+
+      type.forEach((eachType, i) => {
+        if (i > 0) {
+          typeArray.push(<span key={`${eachType}-comma`}>,</span>);
+        }
+
+        typeArray.push(
+          <code key={eachType} className={classes.code}>
+            {eachType}
+          </code>
+        );
+      });
+
+      return typeArray;
+    }
+
+    /**
+     * By default, types use highlighted code format.
+     */
+    return <code className={classes.code}>{type}</code>;
+  })(schemaType);
+  /**
+   * Create a required/contains mark if needed for schema.
+   */
+  const requiredMark = (function createPrefix(schema) {
+    if (schema._required) {
+      return (
+        <Tooltip title={TOOLTIP_DESCRIPTIONS.required}>
+          <span className={classes.prefix}>*</span>
+        </Tooltip>
+      );
+    }
+
+    if (schema._contains) {
+      return (
+        <Tooltip title={TOOLTIP_DESCRIPTIONS.contains}>
+          <span className={classes.prefix}>⊃</span>
+        </Tooltip>
+      );
+    }
+
+    return null;
+  })(schema);
+  /**
+   * If treeNode is $ref type, create $ref icon button for expanding
+   * or shrinking the row depending on the the refType prop.
+   */
+  const refButton = {
+    none: null,
+    default: (
+      <IconButton
+        className={classes.refButton}
+        aria-label="expand-ref"
+        size="small">
+        <ExpandIcon size={24} />
+      </IconButton>
+    ),
+    expanded: (
+      <IconButton
+        className={classes.refButton}
+        aria-label="shrink-ref"
+        size="small">
+        <ShrinkIcon size={24} />
+      </IconButton>
+    ),
+  }[refType];
+  /**
+   * If treeNode is $ref type, create ref expand/shrink action
+   * to be used to expand or collapse a row depending on the refType prop.
+   * (will be applied to the first line of the row)
+   */
+  const onRefClick = {
+    none: () => {},
+    default: () =>
+      setSchemaTree(prev => expandRefNode(prev, treeNode, references)),
+    expanded: () => setSchemaTree(prev => shrinkRefNode(prev, treeNode)),
+  }[refType];
+
+  const isInteractive = refType !== 'none';
+  const interactiveProps = isInteractive
+    ? {
+        onClick: onRefClick,
+        onKeyDown: event => {
+          if (event.key === 'Enter' || event.key === ' ') {
+            event.preventDefault();
+            onRefClick();
+          }
+        },
+        role: 'button',
+        tabIndex: 0,
+      }
+    : {};
+
+  return (
+    <div key={schemaType} {...interactiveProps}>
+      <Typography
+        component="div"
+        variant="subtitle2"
+        className={classNames(classes.typography, classes.indentation)}>
+        {name && nameText}
+        {typeSymbol}
+        {requiredMark}
+        {refButton}
+      </Typography>
+    </div>
+  );
+}
+
+LeftCell.propTypes = {
+  /**
+   * Tree node object data structure.
+   */
+  treeNode: basicTreeNode.isRequired,
+  /**
+   * Identification of row's type. Can be one of the following:
+   * 'none': the row is not a ref row, so no button is necessary.
+   * 'default': the row is a ref row in collapsed form.
+   *            A plus button will be displayed in order to expand the $ref.
+   * 'expanded': the row is a ref row in expanded form.
+   *             A minus button will be displayed in order to srhink the $ref.
+   */
+  refType: oneOf(['none', 'default', 'expanded']).isRequired,
+  /**
+   * The method to update the state of the schemaTree.
+   * Only necessary for ref rows for expanding or shrinking a $ref.
+   */
+  setSchemaTree: func,
+  /**
+   * Object where all schemas are stored so that the table
+   * can dereference $ref schemas by their '$id' as keys.
+   * (ex. references['/schemas/example.json#'] = exampleJson schema)
+   * Only necessary for ref rows.
+   */
+  references: object,
+};
+
+LeftCell.defaultProps = {
+  setSchemaTree: NOOP,
+  references: {},
+};
+
+export default React.memo(LeftCell);

--- a/ui/src/components/JsonSchemaViewer/components/SchemaTable/RightCell.jsx
+++ b/ui/src/components/JsonSchemaViewer/components/SchemaTable/RightCell.jsx
@@ -1,0 +1,152 @@
+import React, { Fragment } from 'react';
+import { makeStyles } from '@material-ui/core/styles';
+import { isEmpty } from 'ramda';
+import classNames from 'classnames';
+import InfoIcon from 'mdi-react/InformationOutlineIcon';
+import Typography from '@material-ui/core/Typography';
+import Markdown from '../Markdown';
+import Chip from '../Chip';
+import Tooltip from '../Tooltip';
+import { basicTreeNode } from '../../utils/prop-types';
+import { SKIP_KEYWORDS, TOOLTIP_DESCRIPTIONS } from '../../utils/constants';
+
+const useStyles = makeStyles(theme => ({
+  typography: {
+    color: theme.palette.text.primary,
+  },
+  infoBlock: {
+    marginTop: theme.spacing(1),
+    marginBottom: theme.spacing(1),
+  },
+}));
+
+function RightCell({ treeNode }) {
+  const { schema } = treeNode;
+  const classes = useStyles();
+  /**
+   * Identify keywords that define specifications of the given schema.
+   * (skip over keywords that do not need to be displayed).
+   * Each keyword will be displayed as a chip.
+   */
+  const specKeywords = Object.keys(schema).filter(
+    key => !SKIP_KEYWORDS.includes(key)
+  );
+
+  /**
+   * Create a chip to display keyword properties.
+   * This is used to display specification keywords.
+   */
+  function createKeywordChip(keyword) {
+    /**
+     * If keyword's property is defined complex, display the chip within
+     * a tooltip to inform users to refer to the source for more details.
+     */
+    if (
+      typeof schema[keyword] === 'object' &&
+      !Array.isArray(schema[keyword]) &&
+      !isEmpty(schema[keyword])
+    ) {
+      /**
+       * Generate tooltip descriptions to match the keyword.
+       */
+      const tooltipTitle = TOOLTIP_DESCRIPTIONS[keyword];
+      const infoIcon = <InfoIcon fontSize="inherit" />;
+
+      return (
+        <Fragment key={keyword}>
+          <Tooltip key={keyword} title={tooltipTitle}>
+            <Chip label={keyword} icon={infoIcon} />
+          </Tooltip>
+          <wbr />
+        </Fragment>
+      );
+    }
+
+    /**
+     * Typecast the keyword's property to string format for proper display.
+     */
+    const keyValue = (function keyValueToString(key) {
+      if (Array.isArray(schema[keyword])) {
+        if (schema[keyword].length === 0) {
+          return '[ ]';
+        }
+
+        return schema[keyword];
+      }
+
+      if (
+        typeof schema[keyword] === 'object' &&
+        Object.keys(schema[keyword].length === 0)
+      ) {
+        return '{ }';
+      }
+
+      return schema[key];
+    })(keyword);
+
+    return (
+      <Fragment key={keyword}>
+        <Chip label={`${keyword}: ${keyValue}`} />
+        <wbr />
+      </Fragment>
+    );
+  }
+
+  /**
+   * Each specification keyword is displayed as a chip.
+   */
+  function createKeywordChips() {
+    return (
+      <div className={classNames(classes.typography, classes.infoBlock)}>
+        {specKeywords.map(keyword => createKeywordChip(keyword))}
+      </div>
+    );
+  }
+
+  /**
+   * Display the title keyword in a single line.
+   */
+  function createTitle() {
+    return (
+      schema.title && (
+        <Typography className={classes.typography} variant="subtitle2">
+          <strong>{schema.title}</strong>
+        </Typography>
+      )
+    );
+  }
+
+  /**
+   * Display the descriptive keyword in a single line.
+   */
+  function createDescription() {
+    return (
+      schema.description && (
+        <Typography className={classes.typography} variant="body2">
+          <Markdown>{schema.description}</Markdown>
+        </Typography>
+      )
+    );
+  }
+
+  return (
+    <div>
+      {(schema.title || schema.description) && (
+        <div className={classes.infoBlock}>
+          {createTitle()}
+          {createDescription()}
+        </div>
+      )}
+      {specKeywords.length > 0 && createKeywordChips()}
+    </div>
+  );
+}
+
+RightCell.propTypes = {
+  /**
+   * Tree node object data structure.
+   */
+  treeNode: basicTreeNode.isRequired,
+};
+
+export default React.memo(RightCell);

--- a/ui/src/components/JsonSchemaViewer/components/SchemaTable/TableLayout.jsx
+++ b/ui/src/components/JsonSchemaViewer/components/SchemaTable/TableLayout.jsx
@@ -1,0 +1,64 @@
+import React, { Fragment } from 'react';
+import classNames from 'classnames';
+import { array } from 'prop-types';
+import { makeStyles } from '@material-ui/core/styles';
+
+const useStyles = makeStyles(theme => ({
+  wrapper: {
+    display: 'block',
+    overflow: 'hidden',
+    position: 'relative',
+    backgroundColor: theme.palette.background.paper,
+  },
+
+  cell: {
+    float: 'left',
+    boxSizing: 'border-box',
+    borderTop: `${theme.spacing(0.125)}px solid ${theme.palette.divider}`,
+    overflowX: 'auto',
+  },
+  left: {
+    width: '50%',
+    paddingLeft: theme.spacing(1),
+  },
+  right: {
+    width: '50%',
+  },
+  break: {
+    clear: 'both',
+  },
+}));
+
+function TableLayout({ rows }) {
+  const classes = useStyles();
+
+  /* the approach here is to alternate divs for the left and right, with the
+   * CSS configuring them so they fit side-by-side with a clear=all after each
+   * right-side diff */
+
+  return (
+    <div className={classes.wrapper}>
+      {rows.map(({ left, right }, i) => {
+        return (
+          // biome-ignore lint/suspicious/noArrayIndexKey: row order is fully determined by the input schema.R ows are never reordered or filtered between renders
+          <Fragment key={`row-${i}`}>
+            <div className={classNames(classes.cell, classes.left)}>{left}</div>
+            <div className={classNames(classes.cell, classes.right)}>
+              {right}
+            </div>
+            <div className={classes.break} />
+          </Fragment>
+        );
+      })}
+    </div>
+  );
+}
+
+TableLayout.propTypes = {
+  /**
+   * Array of elements containing {left, right}
+   */
+  rows: array.isRequired,
+};
+
+export default React.memo(TableLayout);

--- a/ui/src/components/JsonSchemaViewer/components/SchemaTable/index.jsx
+++ b/ui/src/components/JsonSchemaViewer/components/SchemaTable/index.jsx
@@ -1,0 +1,181 @@
+import React from 'react';
+import { func, object } from 'prop-types';
+import TableLayout from './TableLayout';
+import LeftCell from './LeftCell';
+import RightCell from './RightCell';
+import { treeNodeTypes } from '../../utils/prop-types';
+import { createSchemaTree } from '../../utils/schemaTree';
+import {
+  COMBINATION_TYPES,
+  NESTED_TYPES,
+  LITERAL_TYPES,
+} from '../../utils/constants';
+
+function SchemaTable({ schemaTree, setSchemaTree, references }) {
+  const rows = [];
+
+  /**
+   * Create a single normal row with a left and right column each, composed
+   * of a left and right element
+   */
+  function createSingleRow(treeNode, refType = 'none') {
+    /**
+     * If the row to create is a refType (either 'default' or 'expanded'),
+     * make sure to pass 'setSchemaTree' method to change the state of the
+     * schemaTree. Else, pass null as prop instead.
+     */
+    const updateFunc = refType === 'none' ? null : setSchemaTree;
+    const refs = refType === 'none' ? null : references;
+
+    return {
+      left: (
+        <LeftCell
+          key={`left-row-${rows.length + 1}`}
+          treeNode={treeNode}
+          refType={refType}
+          setSchemaTree={updateFunc}
+          references={refs}
+        />
+      ),
+      right: (
+        <RightCell key={`right-row-${rows.length + 1}`} treeNode={treeNode} />
+      ),
+    };
+  }
+
+  /**
+   * Create a literal row for displaying descriptive rows.
+   * This is only used to create rows for the following:
+   * - a closing row for nested types (arrays and objects) to display a
+   *   close bracket symbol
+   * - a separator row for combination types (allOf, anyOf, oneOf, not)
+   *   to visually separate options.
+   */
+  function createLiteralRow(treeNode) {
+    const { schema, path } = treeNode;
+    const schemaType = schema._type;
+    const literalSchema = {
+      $id: schema._id,
+      type: LITERAL_TYPES[schemaType],
+    };
+    const literalPath = COMBINATION_TYPES.includes(schemaType)
+      ? [...path, 0]
+      : path;
+    const literalTreeNode = createSchemaTree(literalSchema, literalPath);
+
+    return createSingleRow(literalTreeNode);
+  }
+
+  /**
+   * Create rows by traversing the tree structure,
+   * starting from the rootNode, in pre-order.
+   * First, a single row based on the root node will be created.
+   * Then, if the root node has children, this method may be called
+   * recursively to create rows for the subtree structures.
+   */
+  function renderNodeToRows(rootNode, refType = 'none') {
+    /**
+     * If rootNode is a $ref type, render rows based on ref node.
+     */
+    if ('isExpanded' in rootNode) {
+      renderRefNodeToRows(rootNode);
+
+      return;
+    }
+
+    /**
+     * Create a single row based on the rootNode.
+     */
+    const { schema, children } = rootNode;
+    const schemaType = schema._type;
+    const rootNodeRow = createSingleRow(rootNode, refType);
+
+    rows.push(rootNodeRow);
+
+    /**
+     * If the root node has children (indicating a nested structure),
+     * create rows for each of the child nodes using recursion.
+     */
+    if (children) {
+      children.forEach((childNode, i) => {
+        /**
+         * If root node's schema defines a combination type,
+         * add separator rows in between the option rows
+         */
+        if (COMBINATION_TYPES.includes(schemaType) && i > 0) {
+          const separatorRow = createLiteralRow(rootNode);
+
+          rows.push(separatorRow);
+        }
+
+        renderNodeToRows(childNode);
+      });
+    }
+
+    /**
+     * If root node's schema defines a nested structure,
+     * add a row at the end to close off the nested structure
+     */
+    if (NESTED_TYPES.includes(schemaType)) {
+      const closeRow = createLiteralRow(rootNode);
+
+      rows.push(closeRow);
+    }
+  }
+
+  /**
+   * Depending on the refTreeNode's 'isExpanded' state,
+   * create either a default collapsed version of a refRow
+   * or an expanded version of possibly multiple rows.
+   */
+  function renderRefNodeToRows(refTreeNode) {
+    const { defaultNode, expandedNode, isExpanded } = refTreeNode;
+    const refType = isExpanded ? 'expanded' : 'default';
+
+    /**
+     * If ref node has shrunk state, which is the default,
+     * create a single row based on the defaultNode structure
+     * defined within the ref node.
+     */
+    if (!isExpanded) {
+      const refRow = createSingleRow(defaultNode, refType);
+
+      rows.push(refRow);
+    } else {
+      /**
+       * Else, the ref node has expanded state,
+       * create rows based on the expandedNode structure.
+       */
+      renderNodeToRows(expandedNode, refType);
+    }
+  }
+
+  /**
+   * Create left and right rows each for the schema table by traversing
+   * the schemaTree starting from the root node. The resulting rows will
+   * be stored in the 'rows' array.
+   */
+  renderNodeToRows(schemaTree);
+
+  return <TableLayout rows={rows} />;
+}
+
+SchemaTable.propTypes = {
+  /**
+   * Schema tree structure defining the overall structure
+   * for the schema table component.
+   */
+  schemaTree: treeNodeTypes.isRequired,
+  /**
+   * Function to update schemaTree structure.
+   * Used specifically for expanding or shrinking a $ref.
+   */
+  setSchemaTree: func.isRequired,
+  /**
+   * Object where all schemas are stored so that the table
+   * can reference to for dereferencing $ref schemas.
+   */
+  references: object.isRequired,
+};
+
+export default React.memo(SchemaTable);

--- a/ui/src/components/JsonSchemaViewer/components/SchemaViewer/index.jsx
+++ b/ui/src/components/JsonSchemaViewer/components/SchemaViewer/index.jsx
@@ -1,0 +1,73 @@
+import React, { useState, Fragment } from 'react';
+import { arrayOf } from 'prop-types';
+import Header from '../Header';
+import SchemaTable from '../SchemaTable';
+import SourceView from '../SourceView';
+import { schema } from '../../utils/prop-types';
+import { createSchemaTree } from '../../utils/schemaTree';
+
+function SchemaViewer({ schema, references }) {
+  /**
+   * Create a tree structure based on the given schema.
+   * This acts as an intermediary data structure to define the overall
+   * structure the schemaTable component will create based upon.
+   * the entire tree structure will be updated to re-create and re-render
+   * the schema table when a $ref is expanded or shrunk.
+   */
+  const [schemaTree, setSchemaTree] = useState(createSchemaTree(schema));
+  /**
+   * Track the mode of the schema viewer.
+   * By default, the mode is set to a table mode to display a schemaTable.
+   * If the mode is set to a source mode, displays the schema source instead.
+   */
+  const [sourceMode, setSourceMode] = useState(false);
+  /**
+   * Create a reference map where all the references schemas are stored
+   * in ($id, schema) key-value format. This will be used as a database
+   * to which the schema viewer can refer to when expanding a $ref.
+   */
+  const referenceMap = references.reduce((acc, schema) => {
+    acc[schema.$id] = schema;
+    return acc;
+  }, {});
+
+  function handleViewToggle() {
+    setSourceMode(prev => !prev);
+  }
+
+  return (
+    <Fragment>
+      <Header
+        schema={schema}
+        sourceMode={sourceMode}
+        toggleMode={handleViewToggle}
+      />
+      {sourceMode ? (
+        <SourceView schema={schema} />
+      ) : (
+        <SchemaTable
+          schemaTree={schemaTree}
+          setSchemaTree={setSchemaTree}
+          references={referenceMap}
+        />
+      )}
+    </Fragment>
+  );
+}
+
+SchemaViewer.propTypes = {
+  /** Schema input given to render */
+  schema,
+  references: arrayOf(schema),
+};
+
+SchemaViewer.defaultProps = {
+  /** Null type schema is set as default prop */
+  schema: {
+    type: 'null',
+  },
+  /** References is set to empty array as default */
+  references: [],
+};
+
+export default React.memo(SchemaViewer);

--- a/ui/src/components/JsonSchemaViewer/components/SourceView/index.jsx
+++ b/ui/src/components/JsonSchemaViewer/components/SourceView/index.jsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import { makeStyles } from '@material-ui/core/styles';
+import { schema } from '../../utils/prop-types';
+
+const useStyles = makeStyles(theme => ({
+  view: {
+    backgroundColor: theme.palette.background.paper,
+    color: theme.palette.text.primary,
+    overflowX: 'auto',
+    padding: theme.spacing(1),
+    margin: 0,
+  },
+}));
+
+function SourceView({ schema }) {
+  /**
+   * Generate classes to define overall style for the schema table.
+   */
+  const classes = useStyles();
+  const source = JSON.stringify(schema, undefined, 2);
+
+  return (
+    <pre className={classes.view}>
+      <code>{source}</code>
+    </pre>
+  );
+}
+
+SourceView.propTypes = {
+  /** Schema to display */
+  schema: schema.isRequired,
+};
+
+export default React.memo(SourceView);

--- a/ui/src/components/JsonSchemaViewer/components/Tooltip/index.jsx
+++ b/ui/src/components/JsonSchemaViewer/components/Tooltip/index.jsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import { node } from 'prop-types';
+import { makeStyles } from '@material-ui/core/styles';
+import MuiTooltip from '@material-ui/core/Tooltip';
+
+const useStyles = makeStyles({
+  root: {
+    display: 'inline',
+  },
+});
+
+/**
+ * Tooltip accessible by hovering mouse or touching mobile screen; this is
+ * used to display chips, so its display mode is 'inline'
+ */
+function Tooltip({ title, children }) {
+  const classes = useStyles();
+
+  return (
+    <MuiTooltip
+      title={title}
+      arrow
+      placement="bottom-start"
+      disableFocusListener
+      enterTouchDelay={1}
+      className={classes.root}>
+      <div>{children}</div>
+    </MuiTooltip>
+  );
+}
+
+Tooltip.propTypes = {
+  /** Keyword to display with tooltip feature */
+  title: node.isRequired,
+  /** Nodes for tooltip to apply and point to */
+  children: node,
+};
+
+export default Tooltip;

--- a/ui/src/components/JsonSchemaViewer/components/index.js
+++ b/ui/src/components/JsonSchemaViewer/components/index.js
@@ -1,0 +1,4 @@
+import SchemaViewer from './SchemaViewer';
+
+export { SchemaViewer };
+export default SchemaViewer;

--- a/ui/src/components/JsonSchemaViewer/index.js
+++ b/ui/src/components/JsonSchemaViewer/index.js
@@ -1,0 +1,1 @@
+export { SchemaViewer, default } from './components';

--- a/ui/src/components/JsonSchemaViewer/utils/constants.js
+++ b/ui/src/components/JsonSchemaViewer/utils/constants.js
@@ -67,7 +67,7 @@ export const CUSTOM_KEYWORDS = [
   '_id',
 ];
 /**
- * Keywords used in schemas that will be ignored when 
+ * Keywords used in schemas that will be ignored when
  * creating lines for the rows in the left and right panels.
  * These are typically skipped over since they may already be
  * illustrated in other formats within the SchemaTable.

--- a/ui/src/components/JsonSchemaViewer/utils/constants.js
+++ b/ui/src/components/JsonSchemaViewer/utils/constants.js
@@ -1,0 +1,134 @@
+/**
+ * Keywords used in schemas to define the basic types.
+ */
+export const BASIC_TYPES = ['string', 'integer', 'number', 'boolean', 'null'];
+/**
+ * Keywords used in schema to define nested types.
+ * Define schemas for structure with an open row, child rows, and close row.
+ */
+export const NESTED_TYPES = ['object', 'array'];
+/**
+ * Keywords used in schema to define combination types.
+ */
+export const COMBINATION_TYPES = ['allOf', 'anyOf', 'oneOf', 'not'];
+/**
+ * Keyword used in schema to define $ref types.
+ */
+export const REF_TYPE = '$ref';
+/**
+ * Custom type keywords used to define schemas used for literal schemas,
+ * which are used to create literal rows, such as a closing or separating row.
+ */
+export const LITERAL_TYPES = {
+  array: 'closeArray',
+  object: 'closeObject',
+  allOf: 'and',
+  anyOf: 'or',
+  oneOf: 'or',
+  not: 'nor',
+};
+/**
+ * Custom type keyword used to define schema with errors.
+ * (used specifically for when a $ref schema cannot be found)
+ */
+export const ERROR_TYPE = 'error';
+/**
+ * Types supported by json schemas:
+ * https://json-schema.org/understanding-json-schema/reference/type.html#type
+ */
+export const SUPPORTED_TYPES = [...BASIC_TYPES, ...NESTED_TYPES];
+/**
+ * All the keywords used to define the possible types used for the schemaTable.
+ */
+export const ALL_TYPES = [
+  ...BASIC_TYPES,
+  ...NESTED_TYPES,
+  ...COMBINATION_TYPES,
+  ...Object.values(LITERAL_TYPES),
+  REF_TYPE,
+  ERROR_TYPE,
+];
+/**
+ * Keywords used in schema that are descriptors.
+ * These are used to display in the rows of the right panel
+ * in separation with specification keywords by a blank line.
+ */
+export const DESCRIPTIVE_KEYWORDS = ['title', 'description'];
+/**
+ * Custom keywords created within the schemas of the tree nodes.
+ * An underscore is prefixed for these keywords in order to
+ * distinguish them with the built-in keywords for schemas.
+ */
+export const CUSTOM_KEYWORDS = [
+  '_type',
+  '_contains',
+  '_required',
+  '_name',
+  '_id',
+];
+/**
+ * Keywords used in schemas that will be ignored when 
+ * creating lines for the rows in the left and right panels.
+ * These are typically skipped over since they may already be
+ * illustrated in other formats within the SchemaTable.
+   (ex. symbols in the left panel)
+ */
+export const SKIP_KEYWORDS = [
+  ...CUSTOM_KEYWORDS,
+  '$id',
+  '$schema',
+  'type',
+  'name',
+  'title',
+  'description',
+  'items',
+  'contains',
+  'properties',
+  'required',
+  'allOf',
+  'anyOf',
+  'oneOf',
+  'not',
+  '$ref',
+  'definitions',
+];
+/**
+ * Symbols used to display bracket types.
+ */
+export const BRACKET_SYMBOLS = {
+  array: '[',
+  object: '{',
+  closeArray: ']',
+  closeObject: '}',
+};
+/**
+ * Symbols (text) used to display combination types.
+ */
+export const COMBINATION_SYMBOLS = {
+  allOf: '// All of',
+  anyOf: '// Any of',
+  oneOf: '// One of',
+  not: '// Not',
+  and: '// and',
+  or: '// or',
+  nor: '// nor',
+};
+/**
+ * Descriptions used for keywords displayed with tooltip.
+ */
+export const TOOLTIP_DESCRIPTIONS = {
+  additionalItems:
+    'Additional items must match a sub-schema. See the JSON-schema source for details.',
+  additionalProperties:
+    'Additional properties must match a sub-schema. See the JSON-schema source for details.',
+  dependencies:
+    'The schema of the object may change based on the presence of certain special properties. See the JSON-schema source for details.',
+  propertyNames:
+    'Names of properties must follow a specified convention. See the JSON-schema source for details.',
+  patternProperties:
+    'Property names or values should match the specified pattern. See the JSON-schema source for details.',
+  required: 'Required property',
+  contains: 'Only needs to validate against one or more items in the array',
+  noType:
+    'Type of schema is not specified. See the JSON-schema source for details.',
+};

--- a/ui/src/components/JsonSchemaViewer/utils/prop-types.js
+++ b/ui/src/components/JsonSchemaViewer/utils/prop-types.js
@@ -1,0 +1,98 @@
+import {
+  shape,
+  string,
+  arrayOf,
+  number,
+  array,
+  oneOf,
+  oneOfType,
+  bool,
+} from 'prop-types';
+import { SUPPORTED_TYPES, ALL_TYPES } from './constants';
+
+/**
+ * Schema prop-type for SchemaViewer component.
+ */
+export const schema = shape({
+  /**
+   * A unique identifier for the schema.
+   * (required as a key to find $ref schema or also as a base URI
+   *  against which $ref URIs are resolved)
+   */
+  $id: string.isRequired,
+  /**
+   * Type of schema (either a single type or an array of types).
+   */
+  type: oneOfType([arrayOf(oneOf(SUPPORTED_TYPES)), oneOf(SUPPORTED_TYPES)]),
+});
+/**
+ * Basic tree node structure for schema trees.
+ * (denotes the shape of a non-$ref type tree node)
+ */
+export const basicTreeNode = shape({
+  /**
+   * Schema or sub-schema given to render upon.
+   * (Must be in a sanitized form which uses custom keywords prefixed
+   *  with an underscore '_' since those are used as identifiers to
+   *  create parts of the rows and lines of the schema table.)
+   */
+  schema: shape({
+    /**
+     * A unique identifier for the schema.
+     * (used as a key to find $ref schema or also as a base URI
+     *  against which $ref URIs are resolved)
+     */
+    _id: string.isRequired,
+    /**
+     * Type of schema (either a single type or an array of types).
+     * '_type' is used as custom property distinguished from built-in
+     * 'type' property.
+     */
+    _type: oneOfType([arrayOf(oneOf(ALL_TYPES)), oneOf(ALL_TYPES)]),
+    /**
+     * Descriptive information about schema.
+     */
+    title: string,
+    description: string,
+    _name: string,
+  }).isRequired,
+  /**
+   * Path from root to current tree node.
+   * Necessary to calculate the indent size for the row.
+   */
+  path: arrayOf(number).isRequired,
+  /**
+   * Children nodes of the current node.
+   * (include array items, object properties, combination options)
+   */
+  children: array,
+});
+
+/**
+ * $Ref Tree node structure for schema trees.
+ * (denotes the shape of a $ref type tree node)
+ */
+export const refTreeNode = shape({
+  /**
+   * The default tree node version when a $ref is shrunk.
+   */
+  defaultNode: basicTreeNode.isRequired,
+  /**
+   * The expanded tree node version when a $ref is expanded.
+   * (not a required fields since it is set to null by default)
+   */
+  expandedNode: basicTreeNode,
+  /**
+   * whether the node is expanded or not
+   */
+  isExpanded: bool.isRequired,
+});
+/**
+ * Tree node prop-types within a schema tree.
+ * Can either be a basic tree node type or a ref tree node type.
+ */
+export const treeNodeTypes = oneOfType([basicTreeNode, refTreeNode]);
+/**
+ * Empty Function to use for default props
+ */
+export const NOOP = () => {};

--- a/ui/src/components/JsonSchemaViewer/utils/schemaTree.js
+++ b/ui/src/components/JsonSchemaViewer/utils/schemaTree.js
@@ -1,0 +1,473 @@
+import { clone } from 'ramda';
+import { isAbsolute, dirname, resolve } from 'path';
+import { COMBINATION_TYPES, REF_TYPE, CUSTOM_KEYWORDS } from './constants';
+
+/**
+ * Generate a tree that illustrates the recursive structure of a schema.
+ * A single node within the tree defines the following structure:
+ * {
+ *   schema: ..       // the schema the node is representing
+ *   children: [..]   // node objects of the same structure (for subschemas)
+ *   path: [..]       // the path from root to node, array of child indexes in
+ *                       sequential order (for $refs and indentation level)
+ *                       ex. [1, 0] = node at root.children[1].children[0]
+ *                                    also has depth of 1 for indent size.
+ * }
+ *
+ * If node is a ref node, it may have a difference structure:
+ * {
+ *   defaultNode: {..}  // the default node version when a $ref is shrunk
+ *                         (a node object as illustrated above)
+ *   expandedNode: {..} // the expanded node version when a $ref is expanded
+ *                         (a node object as illustrated above)
+ *   isExpanded: ..     // whether the node is expanded or not
+ * }
+ *
+ * @param {object} schema
+ * @param {array} path path to current node/subtree (ex. [1, 0])
+ */
+export function createSchemaTree(schema, path = []) {
+  /**
+   * Create a root node object for the tree/subtree based on the schema.
+   * (make sure that node store only schemas transformed appropriately
+   *  to the tree node's schema formats)
+   */
+  const rootNode = {
+    schema: transformSchema(schema),
+    children: [],
+    path,
+  };
+
+  /**
+   * If schema is a $ref type, create a ref node object instead.
+   * (By default, 'isExpanded' is false to render ref row in collapsed form)
+   */
+  if ('$ref' in rootNode.schema) {
+    return {
+      defaultNode: rootNode,
+      expandedNode: null,
+      isExpanded: false,
+    };
+  }
+
+  /**
+   * Depending on whether the schema has a nested structure,
+   * create children nodes according to its type and append them
+   * sequentially as children to the root node.
+   */
+  const schemaType = rootNode.schema._type;
+
+  if (COMBINATION_TYPES.includes(schemaType)) {
+    createCombinationTree(rootNode);
+  } else if (schemaType === 'array') {
+    createArrayTree(rootNode);
+  } else if (schemaType === 'object') {
+    createObjectTree(rootNode);
+  }
+
+  return rootNode;
+}
+
+/**
+ * Transform schema into a form to be stored within a schema tree.
+ * * make sure it is a copy separated from the original schema
+ * * add custom properties (keywords) for the schema table to utilize
+ *   (distinguish added properties with schema's original properties)
+ * @param {object} schema
+ */
+export function transformSchema(schema) {
+  const cloneSchema = clone(schema);
+
+  /**
+   * Make sure schema has a '_type' property to render according to its type.
+   */
+  if ('type' in cloneSchema) {
+    cloneSchema._type = cloneSchema.type;
+  } else {
+    /**
+     * If type is specified via a keyword for combination or $ref,
+     * define the _type property according to that keyword.
+     * (if the type is not specified purposely for other reasons,
+     *  leave as undefined instead)
+     */
+    const complexTypes = [...COMBINATION_TYPES, REF_TYPE];
+
+    complexTypes.forEach(type => {
+      if (type in cloneSchema) {
+        cloneSchema._type = type;
+      }
+    });
+  }
+
+  /**
+   * The custom keyword '_id' should be used instead of build-in
+   * keyword '$id' for NormalLeftRow to read properly.
+   */
+  if ('$id' in cloneSchema) {
+    cloneSchema._id = cloneSchema.$id;
+  }
+
+  /**
+   * The custom keyword '_name' should be used instead of build-in
+   * keyword 'name' for NormalLeftRow to read properly.
+   */
+  if ('name' in cloneSchema) {
+    cloneSchema._name = cloneSchema.name;
+  }
+
+  return cloneSchema;
+}
+
+/**
+ * Create a child node based on the given subschema and append it to
+ * the parentNode. (the child node may be a single node or a subtree)
+ * @param {object} parentNode parent node of subschema
+ * @param {object} subschema schema of child node to create and append
+ * @param {number} childIndex index of the child node (used for its path)
+ */
+export function createChildNode(parentNode, subschema, childIndex) {
+  /**
+   * Child node's schema should inherit parent's _id property
+   * to ensure all schemas have a reference point.
+   */
+  const cloneSubschema = clone(subschema);
+
+  cloneSubschema._id = parentNode.schema._id;
+
+  /**
+   * Create a child node or subtree based on the subschema
+   * and append it to the parent node.
+   */
+  const childNode = createSchemaTree(cloneSubschema, [
+    ...parentNode.path,
+    childIndex,
+  ]);
+
+  parentNode.children.push(childNode);
+}
+
+/**
+ * Create a tree for combination data type schemas (allOf, anyOf, oneOf, not).
+ * Possible options should be created as children nodes by calling back on
+ * the createSchemaTree method and appended the results to given root node.
+ * @param {object} rootNode root tree node
+ */
+export function createCombinationTree(rootNode) {
+  const { schema } = rootNode;
+  const combType = schema._type;
+
+  /**
+   * If there are multiple options (defined in array form),
+   * create option child nodes and append them in sequential order.
+   */
+  if (Array.isArray(schema[combType])) {
+    const optionList = schema[combType];
+
+    optionList.forEach((subschema, childIndex) => {
+      createChildNode(rootNode, subschema, childIndex);
+    });
+  } else {
+    /**
+     * else, if only one option exists, create one child node and append.
+     */
+    createChildNode(rootNode, schema[combType], 0);
+  }
+}
+
+/**
+ * Create a tree for array data type schemas.
+ * Array items should be created as children nodes by calling
+ * back on the createSchemaTree method and appended to given root node.
+ * @param {object} rootNode root tree node
+ */
+export function createArrayTree(rootNode) {
+  const { schema } = rootNode;
+
+  /**
+   * Create child nodes only if array items are defined.
+   */
+  if ('items' in schema) {
+    /**
+     * If array items are defined by tuple vaidation (each item may
+     * have a different schema and the order of items is important),
+     * create array items as child nodes in sequential order.
+     */
+    if (Array.isArray(schema.items)) {
+      schema.items.forEach((subschema, childIndex) => {
+        createChildNode(rootNode, subschema, childIndex);
+      });
+    } else {
+      /**
+       * else, items are defined by list vaidation (each item matches
+       * the same schema), create only one child node.
+       */
+      createChildNode(rootNode, schema.items, 0);
+    }
+  }
+
+  /**
+   * If array items are defined via 'contains' keyword,
+   * (add a 'contains' key set to true to the subschema
+   *  in order to use the contains symbol in NormalLeftRow)
+   * @param {object} rootNode root tree node
+   */
+  if ('contains' in schema) {
+    const subschema = schema.contains;
+    const childIndex = rootNode.children.length;
+
+    subschema._contains = true;
+    createChildNode(rootNode, subschema, childIndex);
+  }
+}
+
+/**
+ * Create a tree for object data type schemas.
+ * Object properties should be created as children nodes by calling
+ * back on the createSchemaTree method and appended to given root node.
+ * @param {object} rootNode root tree node
+ */
+export function createObjectTree(rootNode) {
+  const { schema } = rootNode;
+
+  /**
+   * Create child nodes only if object properties are defined.
+   */
+  if ('properties' in schema) {
+    /**
+     * Memoize required properties in advance for checking if a certain
+     * property is required within the object type schema.
+     */
+    const requiredList =
+      'required' in schema ? new Set(schema.required) : new Set();
+    const propertyList = Object.keys(schema.properties);
+
+    /**
+     * Create object properties as child nodes in sequential order.
+     * Make sure to add a name and required field for each of the subschemas
+     * so that they are displayed accordingly when creating schemaTable rows.
+     */
+    propertyList.forEach((property, childIndex) => {
+      const cloneSubschema = clone(schema.properties[property]);
+
+      cloneSubschema._name = property;
+
+      if (requiredList.has(property)) {
+        cloneSubschema._required = true;
+      }
+
+      createChildNode(rootNode, cloneSubschema, childIndex);
+    });
+  }
+}
+
+/**
+ * Create a clone of the original schemaTree so that the schemaTree
+ * object can be updated without mutating the original schemaTree.
+ * Also, create a reference pointer to the corresponding ref node
+ * so that it can be used for updating the ref node's value.
+ * @param {object} refDefaultNode reference to refNode's defaultNode field
+ * @returns {array} [schema Tree clone, ref node pointer]
+ */
+export function findRefNodeClone(schemaTree, refDefaultNode) {
+  /**
+   * Create a clone of the schemaTree to maintain immutability.
+   */
+  const cloneTree = clone(schemaTree);
+  /**
+   * Traverse the clone tree using the refDefaultNode's path
+   * to find the corresponding ref node within the clone tree.
+   * ('nodePtr' ultimately points to a refNode with a structure
+   *   of defaultNode, expandedNode, isExpanded fields)
+   */
+  let nodePtr = cloneTree;
+
+  refDefaultNode.path.forEach(childIndex => {
+    /**
+     * If nodePtr points to a ref node,
+     * direct the nodePtr to it's expandedNode field.
+     */
+    if ('isExpanded' in nodePtr) {
+      nodePtr = nodePtr.expandedNode;
+    }
+
+    nodePtr = nodePtr.children[childIndex];
+  });
+
+  return [cloneTree, nodePtr];
+}
+
+/**
+ * Update the refNode's state to collapsed form.
+ * (creates a new schemaTree object to maintain immutability
+ *  of the original schemaTree state)
+ * @param {object} refDefaultNode a refNode's defaultNode field
+ * @returns {object} a schemaTree clone with refNode updated
+ */
+export function shrinkRefNode(schemaTree, refDefaultNode) {
+  /**
+   * Create a clone tree and find the corresponding clone ref node.
+   */
+  const [cloneTree, refNode] = findRefNodeClone(schemaTree, refDefaultNode);
+
+  /**
+   * Update the 'isExpanded' state of the ref node so that
+   * the ref row will now display a collapsed version instead.
+   */
+  refNode.isExpanded = false;
+
+  return cloneTree;
+}
+
+/**
+ * Update the refNode's state to expanded form.
+ * (creates a new schemaTree object to maintain immutability
+ *  of the original schemaTree state)
+ * @param {object} refDefaultNode a refNode's defaultNode field
+ * @param {object} references an object of schema references
+ * @returns {object} a schemaTree clone with refNode updated
+ */
+export function expandRefNode(schemaTree, refDefaultNode, references) {
+  /**
+   * Create a clone tree and find the corresponding clone ref node.
+   */
+  const [cloneTree, refNode] = findRefNodeClone(schemaTree, refDefaultNode);
+
+  /**
+   * Update the 'isExpanded' state of the ref node so that
+   * the ref row will now display an expanded version instead.
+   */
+  refNode.isExpanded = true;
+
+  /**
+   * If ref tree node has never referenced the $ref schema before,
+   * fetch the schema and store in expandedNode field in order to
+   * cache the referenced schema within the ref node.
+   */
+  if (!refNode.expandedNode) {
+    const referencedSchema = fetchRefSchema(
+      refDefaultNode.schema._id,
+      refDefaultNode.schema.$ref,
+      references
+    );
+
+    /**
+     * If the ref node's default node has custom fields,
+     * also include those same fields within the expanded node.
+     */
+    CUSTOM_KEYWORDS.forEach(keyword => {
+      if (keyword in refDefaultNode.schema && !(keyword in referencedSchema)) {
+        referencedSchema[keyword] = refDefaultNode.schema[keyword];
+      }
+    });
+
+    /**
+     * Create a subschema tree based on the fetched ref schema
+     * and store the result within the expandedNode field.
+     */
+    refNode.expandedNode = createSchemaTree(
+      referencedSchema,
+      refDefaultNode.path
+    );
+  }
+
+  return cloneTree;
+}
+
+/**
+ * Fetch the reference schema defined by the $ref
+ * @param {string} refNodeId ref default node schema's $id value
+ * @param {string} refString ref default node schema's $ref value
+ * @param {object} references collection of schema references
+ * @returns {object} $ref schema
+ */
+function fetchRefSchema(refNodeId, refString, references) {
+  const [sourcePath, definitionPath] = refString.split('#');
+  const refNodePath = refNodeId.slice(0, -1);
+
+  try {
+    /**
+     * Find the source for the reference.
+     */
+    const refSchemaPath = resolveFullPath(sourcePath, refNodePath);
+    const refSchemaId = refSchemaPath.concat('#');
+    let ptr = references[refSchemaId];
+
+    if (!ptr) {
+      throw new Error(`Cannot find reference to \`${refSchemaId}\`.`);
+    }
+
+    /**
+     * Find the definition within the source.
+     */
+    const parameters = definitionPath.split('/');
+
+    parameters.forEach((parameter, i) => {
+      // skip over first parameter since it defaults to empty string ""
+      if (i > 0) {
+        if (!(parameter in ptr)) {
+          throw new Error(
+            `Cannot find \`${definitionPath}\` in \`${refSchemaId}\`.`
+          );
+        }
+
+        ptr = ptr[parameter];
+      }
+    });
+
+    return ptr;
+  } catch (error) {
+    /**
+     * If cannot find the $ref,
+     */
+    const errorSchema = {
+      type: 'error',
+      description: error.message,
+    };
+
+    return errorSchema;
+  }
+}
+
+/**
+ * Find the full path of the given source path.
+ * @param {string} sourcePath  path of source to find
+ * @param {string} currentPath path to resolve when source has relative path
+ * @returns {string} full path of the source
+ */
+function resolveFullPath(sourcePath, currentPath) {
+  /**
+   * If the source is empty (self-reference to itself),
+   * return the current path.
+   */
+  if (sourcePath.length === 0) {
+    return currentPath;
+  }
+
+  if (!isAbsolute(sourcePath)) {
+    try {
+      /**
+       * If the source is a URI (ex. "http://json-schema.org/draft-06/schema"),
+       * return the path as-is.
+       */
+      const uri = new URL(sourcePath);
+
+      return uri.toString();
+    } catch (error) {
+      /**
+       * If the source has a relative path (ex. "example.json"),
+       * resolve the path against the current path.
+       */
+      if (error instanceof TypeError) {
+        const currentDir = dirname(currentPath);
+
+        return resolve(currentDir, sourcePath);
+      }
+    }
+  }
+
+  /**
+   * Else, the source has an absolute path (ex. "schemas/example.json")
+   * return the path as-is.
+   */
+  return sourcePath;
+}

--- a/ui/src/components/SchemaTable/index.jsx
+++ b/ui/src/components/SchemaTable/index.jsx
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import { withRouter } from 'react-router-dom';
 import { string } from 'prop-types';
-import SchemaViewer from 'material-ui-json-schema-viewer';
+import SchemaViewer from '../JsonSchemaViewer';
 import jsonSchemaDraft06 from 'ajv/lib/refs/json-schema-draft-06.json';
 import jsonSchemaDraft07 from 'ajv/lib/refs/json-schema-draft-07.json';
 import Spinner from '../Spinner';

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -1497,7 +1497,6 @@ __metadata:
     markdown-it: "npm:^14.2.0"
     markdown-it-highlightjs: "npm:^3.0.0"
     markdown-it-link-attributes: "npm:^4.0.1"
-    material-ui-json-schema-viewer: "npm:^2.0.0"
     mdi-react: "npm:^6.2.0"
     mitt: "npm:^3.0.1"
     param-case: "npm:^3.0.3"
@@ -2270,7 +2269,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"argparse@npm:^1.0.7, argparse@npm:^1.0.9":
+"argparse@npm:^1.0.9":
   version: 1.0.10
   resolution: "argparse@npm:1.0.10"
   dependencies:
@@ -2758,7 +2757,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"classnames@npm:^2.2.6, classnames@npm:^2.5.1":
+"classnames@npm:^2.5.1":
   version: 2.5.1
   resolution: "classnames@npm:2.5.1"
   checksum: 10c0/afff4f77e62cea2d79c39962980bf316bacb0d7c49e13a21adaadb9221e1c6b9d3cdb829d8bb1b23c406f4e740507f37e1dcf506f7e3b7113d17c5bab787aa69
@@ -3349,13 +3348,6 @@ __metadata:
   version: 8.0.0
   resolution: "entities@npm:8.0.0"
   checksum: 10c0/938e631664c19451823344a351aeeafd74fae2d5fa51e4d5b6ff635afaefd4bacf0f609989888c04c42733f46ffdac15211608267ebb02488005891a4793e94d
-  languageName: node
-  linkType: hard
-
-"entities@npm:~2.0.0":
-  version: 2.0.3
-  resolution: "entities@npm:2.0.3"
-  checksum: 10c0/81463fde5f1e4432df6faa65afa00021f3979ac8387f81d3d111beeb08179e626130a4b7488e8c3cc3d74e0d04e99d3033ff7db80e05f4a1e961b5e1efe17731
   languageName: node
   linkType: hard
 
@@ -4906,15 +4898,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"linkify-it@npm:^2.0.0":
-  version: 2.2.0
-  resolution: "linkify-it@npm:2.2.0"
-  dependencies:
-    uc.micro: "npm:^1.0.1"
-  checksum: 10c0/640f926fa71d46f9451b4dc999c94b2dcad920abf5fe174a85f120b420cbb34b8f950e251846ed73db715ec9aaadadf1f2482d27088dddd21b1c84761f6a0b5a
-  languageName: node
-  linkType: hard
-
 "linkify-it@npm:^5.0.1":
   version: 5.0.1
   resolution: "linkify-it@npm:5.0.1"
@@ -5115,21 +5098,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"markdown-it@npm:^10.0.0":
-  version: 10.0.0
-  resolution: "markdown-it@npm:10.0.0"
-  dependencies:
-    argparse: "npm:^1.0.7"
-    entities: "npm:~2.0.0"
-    linkify-it: "npm:^2.0.0"
-    mdurl: "npm:^1.0.1"
-    uc.micro: "npm:^1.0.5"
-  bin:
-    markdown-it: bin/markdown-it.js
-  checksum: 10c0/7b2876599adb4c8bed0b45030db835d6e3e352e20b1c26624975d1b0f6d9ef54bbf6b63d29cb31b0cebb65b5ad7300aad063dc5d586a03c3745345bfc945c8fd
-  languageName: node
-  linkType: hard
-
 "markdown-it@npm:^14.2.0":
   version: 14.2.0
   resolution: "markdown-it@npm:14.2.0"
@@ -5150,23 +5118,6 @@ __metadata:
   version: 3.0.4
   resolution: "markdown-table@npm:3.0.4"
   checksum: 10c0/1257b31827629a54c24a5030a3dac952256c559174c95ce3ef89bebd6bff0cb1444b1fd667b1a1bb53307f83278111505b3e26f0c4e7b731e0060d435d2d930b
-  languageName: node
-  linkType: hard
-
-"material-ui-json-schema-viewer@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "material-ui-json-schema-viewer@npm:2.0.0"
-  dependencies:
-    classnames: "npm:^2.2.6"
-    markdown-it: "npm:^10.0.0"
-    mdi-react: "npm:^6.7.0"
-    prop-types: "npm:^15.7.2"
-    ramda: "npm:^0.26.1"
-  peerDependencies:
-    "@material-ui/core": ^4.7.1
-    react: ^16.12.0
-    react-dom: ^16.12.0
-  checksum: 10c0/03ba8f9150ef0fb3b6aeb25a04cbeb37c99411bf59e51d6996eec77f73b4db8fc836b716198936cefc32ae0f8918d616a64a09fc2007b8fa71a46416173624d3
   languageName: node
   linkType: hard
 
@@ -5411,7 +5362,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"mdi-react@npm:^6.2.0, mdi-react@npm:^6.7.0":
+"mdi-react@npm:^6.2.0":
   version: 6.7.0
   resolution: "mdi-react@npm:6.7.0"
   peerDependencies:
@@ -5424,13 +5375,6 @@ __metadata:
   version: 2.27.1
   resolution: "mdn-data@npm:2.27.1"
   checksum: 10c0/eb8abf5d22e4d1e090346f5e81b67d23cef14c83940e445da5c44541ad874dc8fb9f6ca236e8258c3a489d9fb5884188a4d7d58773adb9089ac2c0b966796393
-  languageName: node
-  linkType: hard
-
-"mdurl@npm:^1.0.1":
-  version: 1.0.1
-  resolution: "mdurl@npm:1.0.1"
-  checksum: 10c0/ea8534341eb002aaa532a722daef6074cd8ca66202e10a2b4cda46722c1ebdb1da92197ac300bc953d3ef1bf41cd6561ef2cc69d82d5d0237dae00d4a61a4eee
   languageName: node
   linkType: hard
 
@@ -6656,13 +6600,6 @@ __metadata:
   version: 0.2.1
   resolution: "querystring-es3@npm:0.2.1"
   checksum: 10c0/476938c1adb45c141f024fccd2ffd919a3746e79ed444d00e670aad68532977b793889648980e7ca7ff5ffc7bfece623118d0fbadcaf217495eeb7059ae51580
-  languageName: node
-  linkType: hard
-
-"ramda@npm:^0.26.1":
-  version: 0.26.1
-  resolution: "ramda@npm:0.26.1"
-  checksum: 10c0/af591bdb593a7bd4c715af306f9a1c591ed0eccabc9bb5166dd17e68b182e6ff313b35c057f9dc300715d060c3ed2f56e424a42499fe2b27b40446fb447838ba
   languageName: node
   linkType: hard
 
@@ -8032,13 +7969,6 @@ __metadata:
     tsc: bin/tsc
     tsserver: bin/tsserver
   checksum: 10c0/39117e346ff8ebd87ae1510b3a77d5d92dae5a89bde588c747d25da5c146603a99c8ee588c7ef80faaf123d89ed46f6dbd918d534d641083177d5fac38b8a1cb
-  languageName: node
-  linkType: hard
-
-"uc.micro@npm:^1.0.1, uc.micro@npm:^1.0.5":
-  version: 1.0.6
-  resolution: "uc.micro@npm:1.0.6"
-  checksum: 10c0/9bde2afc6f2e24b899db6caea47dae778b88862ca76688d844ef6e6121dec0679c152893a74a6cfbd2e6fde34654e6bd8424fee8e0166cdfa6c9ae5d42b8a17b
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
We haven't been maintaining it as a dependency for years, if there are external users of it, I sure hope that they forked it and updated dependencies... In any case, this dep is currently blocking the react update in this repository and I don't see any value in contorting ourselves to keep it externally, so move it in here. After this merges, we can archive the original repository.

The code in `ui/src/components/JsonSchemaViewer/` is exactly what was in the original repo, minus the theme.js file which is not used and one biome annotation.

Original repository is at
https://github.com/taskcluster/material-ui-json-schema-viewer/
