### PR TITLE
Remove the apollo-cache-persist dependency

### DIFF
--- a/changelog/VCOiLvopRs2lZwMw5Tp0iQ.md
+++ b/changelog/VCOiLvopRs2lZwMw5Tp0iQ.md
@@ -1,0 +1,2 @@
+level: silent
+---

--- a/ui/package.json
+++ b/ui/package.json
@@ -34,7 +34,6 @@
     "ajv": "^8.18.0",
     "ajv-formats": "^2.1.1",
     "apollo-cache-inmemory": "^1.5.1",
-    "apollo-cache-persist": "^0.1.1",
     "apollo-client": "^2.5.1",
     "apollo-link": "^1.2.11",
     "apollo-link-context": "^1.0.11",

--- a/ui/src/App/index.jsx
+++ b/ui/src/App/index.jsx
@@ -1,6 +1,5 @@
 import React, { Component } from 'react';
 import { arrayOf } from 'prop-types';
-import storage from 'localforage';
 import { ApolloProvider } from 'react-apollo';
 import { ApolloClient } from 'apollo-client';
 import { WebSocketLink } from 'apollo-link-ws';
@@ -14,7 +13,6 @@ import {
   IntrospectionFragmentMatcher,
   defaultDataIdFromObject,
 } from 'apollo-cache-inmemory';
-import { CachePersistor } from 'apollo-cache-persist';
 import ReactGA from 'react-ga';
 import { init as initSentry } from '@sentry/browser';
 import { MuiThemeProvider } from '@material-ui/core/styles';
@@ -67,11 +65,6 @@ export default class App extends Component {
         }
       }
     },
-  });
-
-  persistence = new CachePersistor({
-    cache: this.cache,
-    storage,
   });
 
   httpLink = createHttpLink({

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -1457,7 +1457,6 @@ __metadata:
     ajv: "npm:^8.18.0"
     ajv-formats: "npm:^2.1.1"
     apollo-cache-inmemory: "npm:^1.5.1"
-    apollo-cache-persist: "npm:^0.1.1"
     apollo-client: "npm:^2.5.1"
     apollo-client-mock: "npm:^0.0.9"
     apollo-link: "npm:^1.2.11"
@@ -2098,13 +2097,6 @@ __metadata:
   peerDependencies:
     graphql: ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0
   checksum: 10c0/a7c49babd139edbdcf4087ec4096b87864f46f67dd45c84da22bcc239af770358ec1fd9285e364c74ad726c8b77580bc2d8ee1c513972029123f97ceb47f9562
-  languageName: node
-  linkType: hard
-
-"apollo-cache-persist@npm:^0.1.1":
-  version: 0.1.1
-  resolution: "apollo-cache-persist@npm:0.1.1"
-  checksum: 10c0/816bde128e7cef4319340c4b733c262740223760be59e788ba4d130368cb8f89c28517d50c2f926849fdf3bc7a271d71a31b2801cd77a4f5137c979493bbf0c7
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This was supposed to add persistence to the cache so it survives hard refreshes (not navigation, that's a different cache layer which we still have). Except that it never actually called `restore()` making it a no-op. Well not exactly a no-op because the write side of it has been working fine so we've been caching query results into users indexdb for years without ever using them.

Here's the funnier part here and why I'm removing this dependency instead of calling restore. Every single query I checked that might maybe have benefited from this has a `fetchPolicy` set to `network-only` which means it wouldn't even look at the cache in the first place...

Add to that that we want to get rid of graphql, I ain't even going to think about it, it's been broken for years, into the trash it goes :put_litter_in_its_place: 