### PR TITLE
Fix a typo in WMErrorsTable propTypes

### DIFF
--- a/changelog/TRUbX8gFTTqx8Jhro7EuGA.md
+++ b/changelog/TRUbX8gFTTqx8Jhro7EuGA.md
@@ -1,0 +1,2 @@
+level: silent
+---

--- a/ui/src/components/WMErrorsTable/index.jsx
+++ b/ui/src/components/WMErrorsTable/index.jsx
@@ -70,7 +70,7 @@ export default class WorkerManagerErrorsTable extends Component {
     searchTerm: string,
     workerPoolId: string,
     errorsConnection: shape({
-      edges: arrayOf(shape({ node: WMError.isRequred }).isRequired).isRequired,
+      edges: arrayOf(shape({ node: WMError.isRequired }).isRequired).isRequired,
       pageInfo: pageInfo.isRequired,
     }).isRequired,
   };


### PR DESCRIPTION
Introduced in 28fb725c885b34346ea70392b88fe8280ff94fc4, has been throwing warnings like this since then:

```
Warning: Failed prop type: WorkerManagerErrorsTable: prop type `errorsConnection.edges[0].node` is invalid; it must be a function, usually from the `prop-types` package, but received `undefined`.
    in WorkerManagerErrorsTable (created by WithStyles(WorkerManagerErrorsTable))
    in WithStyles(WorkerManagerErrorsTable) (at WMViewErrors/index.jsx:178)
    in ErrorBoundary (at Dashboard/index.jsx:427)
```
