### PR TITLE
feat(taskgraph): lower priority of Dependabot PR tasks

### DIFF
--- a/changelog/lower-dependabot-task-priority.md
+++ b/changelog/lower-dependabot-task-priority.md
@@ -1,0 +1,2 @@
+level: silent
+---

--- a/taskcluster/src/transforms/__init__.py
+++ b/taskcluster/src/transforms/__init__.py
@@ -70,6 +70,12 @@ def add_task_env(config, tasks):
         # We want to set this everywhere other than lib-testing
         if task["name"] != "testing":
             env["NO_TEST_SKIP"] = "true"
+
+        # Dependabot PRs can saturate contended worker pools (e.g. macOS) and delay
+        # human work, so lower the priority of every task they generate.
+        if config.params["head_ref"].startswith("dependabot/"):
+            task["priority"] = "low"
+
         yield task
 
 


### PR DESCRIPTION
Cunningly(!!) I created this PR using a branch with prefix `dependabot/` to simultaneously test that this feature works outside of a dependabot PR. If all goes well, the CI tasks should be created in this PR with `low` priority... ;-)

Note, obviously this can be faked (as I demonstrate here), but since it just lowers priority, it is a pretty harmless.