### PR TITLE
Generic Worker (macOS): wait for launch agent readiness before claiming task

### DIFF
--- a/changelog/issue-8859.md
+++ b/changelog/issue-8859.md
@@ -1,0 +1,12 @@
+audience: worker-deployers
+level: patch
+reference: issue 8859
+---
+generic-worker (multiuser engine, macOS) now determines that the task user is
+ready by running `id -un` through the task user's launch agent and checking it
+reports the expected user, instead of parsing `last -t console` output. Because
+the probe only succeeds once the user's Aqua session is up and its launch agent
+is serving, the worker no longer claims a task before it can actually run
+commands as the task user (which resolved as `exception`/`internal-error`, e.g.
+when a boot-time macOS installer held the login window). This also removes the
+fragile `last` output parsing (issue 5006).

--- a/workers/generic-worker/multiuser.go
+++ b/workers/generic-worker/multiuser.go
@@ -64,9 +64,8 @@ func PostRebootSetup(taskUserCredentials *gwruntime.OSUser) *TaskContext {
 	// if the task directory is also the user profile home, this
 	// would mess up the windows logon process.
 	if !config.HeadlessTasks && !runningTests {
-		err := gwruntime.WaitForLoginCompletion(5*time.Minute, ctx.User.Name)
-		if err != nil {
-			panic(fmt.Errorf("timed out waiting for login for user %s: %v", ctx.User.Name, err))
+		if err := waitForTaskUserSession(ctx); err != nil {
+			panic(fmt.Errorf("task user session not ready for %s: %v", ctx.User.Name, err))
 		}
 	}
 	// Ensure the parent TasksDir exists and is traversable by all users.

--- a/workers/generic-worker/multiuser_darwin.go
+++ b/workers/generic-worker/multiuser_darwin.go
@@ -3,6 +3,7 @@
 package main
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -11,6 +12,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"syscall"
 	"time"
 
@@ -72,6 +74,50 @@ func PreRebootSetup(nextTaskUser *gwruntime.OSUser) {
 			panic(err)
 		}
 	}
+}
+
+// If there are system updates, this could take several minutes, let's be generous here
+const launchAgentReadyTimeout = 15 * time.Minute
+
+// waitForTaskUserSession blocks until the task user's launch agent is working
+func waitForTaskUserSession(ctx *TaskContext) error {
+	pd, err := process.TaskUserPlatformData(ctx.User, config.HeadlessTasks)
+	if err != nil {
+		return fmt.Errorf("could not build platform data for task user %v: %w", ctx.User.Name, err)
+	}
+	log.Printf("Waiting (up to %v) for launch agent of task user %v to become ready...", launchAgentReadyTimeout, ctx.User.Name)
+	deadline := time.Now().Add(launchAgentReadyTimeout)
+	for attempt := 1; ; attempt++ {
+		gotUser, probeErr := taskUserName(pd, ctx.TaskDir)
+		if probeErr == nil && gotUser == ctx.User.Name {
+			log.Printf("Launch agent of task user %v is ready", ctx.User.Name)
+			return nil
+		}
+		if time.Now().After(deadline) {
+			if probeErr != nil {
+				return fmt.Errorf("launch agent of task user %v did not become ready within %v: %w", ctx.User.Name, launchAgentReadyTimeout, probeErr)
+			}
+			return fmt.Errorf("launch agent reported user %q, want %q, within %v", gotUser, ctx.User.Name, launchAgentReadyTimeout)
+		}
+		log.Printf("Launch agent of task user %v not ready yet (attempt %d): user=%q err=%v", ctx.User.Name, attempt, gotUser, probeErr)
+		time.Sleep(2 * time.Second)
+	}
+}
+
+// taskUserName runs `id -un` as the task user via its launch agent and
+// returns the username.
+func taskUserName(pd *process.PlatformData, taskDir string) (string, error) {
+	cmd, err := process.NewCommand([]string{"/usr/bin/id", "-un"}, taskDir, []string{}, pd)
+	if err != nil {
+		return "", fmt.Errorf("could not create `id -un` command: %w", err)
+	}
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	result := cmd.Execute()
+	if !result.Succeeded() {
+		return "", fmt.Errorf("`id -un` could not be run as the task user: %v", result)
+	}
+	return strings.TrimSpace(out.String()), nil
 }
 
 func platformTargets(arguments map[string]any) ExitCode {

--- a/workers/generic-worker/multiuser_linux.go
+++ b/workers/generic-worker/multiuser_linux.go
@@ -4,6 +4,7 @@ package main
 
 import (
 	"log"
+	"time"
 
 	gwruntime "github.com/taskcluster/taskcluster/v101/workers/generic-worker/runtime"
 )
@@ -33,6 +34,10 @@ func platformFeatures() []Feature {
 }
 
 func PreRebootSetup(nextTaskUser *gwruntime.OSUser) {
+}
+
+func waitForTaskUserSession(ctx *TaskContext) error {
+	return gwruntime.WaitForLoginCompletion(5*time.Minute, ctx.User.Name)
 }
 
 func platformTargets(arguments map[string]any) ExitCode {

--- a/workers/generic-worker/multiuser_windows.go
+++ b/workers/generic-worker/multiuser_windows.go
@@ -543,6 +543,10 @@ func GrantSIDFullControlOfInteractiveWindowsStationAndDesktop(sid string) (err e
 	return
 }
 
+func waitForTaskUserSession(ctx *TaskContext) error {
+	return gwruntime.WaitForLoginCompletion(5*time.Minute, ctx.User.Name)
+}
+
 func PreRebootSetup(nextTaskUser *gwruntime.OSUser) {
 	// Wait for the User Profile Service to be running before any profile operations.
 	// On first boot after sysprep, ProfSvc may not be initialized yet.

--- a/workers/generic-worker/runtime/runtime_darwin.go
+++ b/workers/generic-worker/runtime/runtime_darwin.go
@@ -1,18 +1,13 @@
 package runtime
 
 import (
-	"errors"
 	"fmt"
 	"log"
-	"os"
 	"strings"
-	"time"
 
 	"github.com/taskcluster/taskcluster/v101/workers/generic-worker/host"
 	"github.com/taskcluster/taskcluster/v101/workers/generic-worker/kc"
 )
-
-var cachedInteractiveUsername string = ""
 
 func (user *OSUser) CreateNew(okIfExists bool) (err error) {
 	if okIfExists {
@@ -70,72 +65,6 @@ func ListUserAccounts() (usernames []string, err error) {
 
 func UserHomeDirectoriesParent() string {
 	return "/Users"
-}
-
-func WaitForLoginCompletion(timeout time.Duration, username string) (err error) {
-	deadline := time.Now().Add(timeout)
-	log.Print("Checking if user is logged in...")
-	var interactiveUsername string
-	for time.Now().Before(deadline) {
-		interactiveUsername, err = InteractiveUsername()
-		if err != nil {
-			log.Printf("WARNING: Error checking for interactive user: %v", err)
-			time.Sleep(time.Second)
-			continue
-		}
-		if interactiveUsername != username {
-			log.Printf("WARNING: user %v appears to be logged in but was expecting %v.", interactiveUsername, username)
-			cachedInteractiveUsername = ""
-			time.Sleep(time.Second)
-			continue
-		}
-		var fi os.FileInfo
-		fi, err = os.Stat("/Library/Preferences/com.apple.loginwindow.plist")
-		if err != nil {
-			return fmt.Errorf("could not read file /Library/Preferences/com.apple.loginwindow.plist to determine when last login occurred: %v", err)
-		}
-		modTime := fi.ModTime()
-		log.Printf("User %v logged in at %v", interactiveUsername, modTime)
-		// See https://bugzilla.mozilla.org/show_bug.cgi?id=1560388#c3
-		sleepUntil := modTime.Add(10 * time.Second)
-		now := time.Now()
-		if sleepUntil.After(now) {
-			log.Printf("Sleeping until %v (10 seconds after login) due to https://bugzilla.mozilla.org/show_bug.cgi?id=1560388#c3", sleepUntil)
-			time.Sleep(sleepUntil.Sub(now))
-		}
-		return
-	}
-	log.Print("Timed out waiting for user login")
-	var output string
-	output, err = host.Output("/usr/bin/last")
-	if err != nil {
-		log.Printf("Not able to execute /usr/bin/last due to %v", err)
-	} else {
-		log.Print(output)
-	}
-	if interactiveUsername == "" {
-		return errors.New("no user logged in with console session")
-	}
-	return fmt.Errorf("interactive username %v does not match task user %v", interactiveUsername, username)
-}
-
-func InteractiveUsername() (string, error) {
-	// The /usr/bin/last call is extremely expensive, and the logged in user
-	// does not change during lifetime of generic-worker process, so we can
-	// cache result. This has huge impact on integration test runtime (see
-	// http://bugzil.la/1567632)
-	if cachedInteractiveUsername != "" {
-		return cachedInteractiveUsername, nil
-	}
-	output, err := host.Output("/usr/bin/last", "-t", "console", "-1")
-	if err != nil {
-		return "", err
-	}
-	if !strings.Contains(output, "logged in") {
-		return "", fmt.Errorf("could not parse username from %q", output)
-	}
-	cachedInteractiveUsername = output[:strings.Index(output, " ")]
-	return cachedInteractiveUsername, nil
 }
 
 func SetAutoLogin(user *OSUser) error {


### PR DESCRIPTION
Fixes #8859
Fixes #5006 