### PR TITLE
Generic Worker: don't race claim work with reboot

### DIFF
--- a/changelog/issue-8863.md
+++ b/changelog/issue-8863.md
@@ -1,0 +1,9 @@
+audience: users
+level: patch
+reference: issue 8863
+---
+Fix for Generic Worker multiuser (non-headless) bug where occasionally tasks
+would resolve as `exception/claim-expired`. The cause was a race condition
+allowing a second task to be claimed just before rebooting. That task could
+never be resolved by the worker, so the Queue service would eventually resolve
+it as `exception/claim-expired`.

--- a/workers/generic-worker/main.go
+++ b/workers/generic-worker/main.go
@@ -511,6 +511,7 @@ func RunWorker() (exitCode ExitCode) {
 		completionRebootRequired
 	)
 	processCompletion := func(result taskCompletionResult) completionAction {
+		taskManager.RemoveTask(result.taskID)
 		tasksResolved++
 		lastActive = time.Now()
 
@@ -722,7 +723,6 @@ mainLoop:
 							log.Printf("PANIC in task %s goroutine: %v", t.TaskID, r)
 							t.Error(fmt.Sprintf("Internal worker error (panic): %v", r))
 						}
-						taskManager.RemoveTask(t.TaskID)
 						portManager.ReleasePorts(t.TaskID)
 						workerShutdown := errors != nil && errors.WorkerShutdown()
 						taskCompleteChan <- taskCompletionResult{


### PR DESCRIPTION
Fixes #8863

The race condition is avoided by releasing the capacity slot in the same thread as the reboot-or-continue decision.