### PR TITLE
Add a way to disable the database version check

### DIFF
--- a/changelog/J9SJd8lZRC6mFZA75Ip1Iw.md
+++ b/changelog/J9SJd8lZRC6mFZA75Ip1Iw.md
@@ -1,0 +1,6 @@
+audience: developers
+level: patch
+---
+Setting the `TASKCLUSTER_SKIP_DB_VERSION_CHECK` variable to any value now skips
+the postgresql version check, allowing you to run a different major version
+locally.

--- a/dev-docs/development-process.md
+++ b/dev-docs/development-process.md
@@ -34,6 +34,11 @@ The easiest and best way to do this is to use docker, but if you prefer you can 
 *NOTE* the test suites repeatedly drop the `public` schema and re-create it, effectively deleting all data in the database.
 Do not run these tests against a database instance that contains any useful data!
 
+If you want to run against another major version locally, set
+`TASKCLUSTER_SKIP_DB_VERSION_CHECK=1` to skip the version check performed on
+startup. Just be aware that `yarn generate` might generate unrelated changes
+and that you might unknowingly be using features not available yet.
+
 `pg_dump` is being used to detect schema changes. If it is not present on your system,
 `yarn generate` might attempt to run this inside the `postgres` docker container, which is one of the `docker-compose.yml` services.
 

--- a/libraries/postgres/src/Database.js
+++ b/libraries/postgres/src/Database.js
@@ -479,6 +479,10 @@ class Database {
 
   /** @private */
   async _checkVersion() {
+    if (process.env.TASKCLUSTER_SKIP_DB_VERSION_CHECK) {
+      console.warn('WARNING: skipping the Postgres version check because TASKCLUSTER_SKIP_DB_VERSION_CHECK is set');
+      return;
+    }
     await this._withClient('admin', async client => {
       const version = await client.query(`
         SELECT current_setting('server_version_num');


### PR DESCRIPTION
I personally run a local postgres installation on arch which is 3 major versions ahead and I find it easier to just remove the check rather than bother running pg 15 instead every time. I finally got tired enough of seeing that message to add a way out of the check...

Note that while tests are passing with pg 18, `yarn generate` will generate a tiny diff in the documentation because of some constraints difference in database schemas. But CI will catch the diff anyway and go red if someone ever commits it.
