### PR TITLE
Relax the go version check from `yarn generate`

### DIFF
--- a/changelog/Nvah8zb7TomLkyTi1wTUvg.md
+++ b/changelog/Nvah8zb7TomLkyTi1wTUvg.md
@@ -1,0 +1,2 @@
+level: silent
+---

--- a/infrastructure/tooling/src/generate/generators/go-version.js
+++ b/infrastructure/tooling/src/generate/generators/go-version.js
@@ -18,7 +18,7 @@ export const tasks = [
       const goVersionBugfix = goVersion.replace(/^go[0-9]+\.[0-9]+\.([0-9]+)$/, '$1');
       utils.step({ title: 'Checking go version' });
 
-      const errmsg = `'yarn generate' requires ${goVersion}.  Consider using https://github.com/moovweb/gvm.`;
+      const errmsg = `'yarn generate' requires go${goVersionMajor}.${goVersionMinor}.x.  Consider using https://github.com/moovweb/gvm.`;
       let version;
       try {
         version = (await exec('go', ['version'])).stdout.split(/\s+/)[2];
@@ -27,8 +27,8 @@ export const tasks = [
           throw new Error(`Cannot find \`go\`.  ${errmsg}`);
         }
       }
-      const versionPrefix = version?.match(/^go[0-9]+\.[0-9]+\.[0-9]+/)?.[0];
-      if (versionPrefix !== goVersion) {
+      const versionPrefix = version?.match(/^go[0-9]+\.[0-9]+/)?.[0];
+      if (versionPrefix !== `go${goVersionMajor}.${goVersionMinor}`) {
         throw new Error(`Found ${version}.  ${errmsg}`);
       }
 


### PR DESCRIPTION
In 32fbdf38addff1e9bd95af10c85e0f62db2a993b, I relaxed the go version check to not check for suffixes on versions to allow devs to use their package manager's version. I'm running into `yarn generate` being annoying again because my local golang updated to 1.26.5... I didn't go as far (yet) as what I'd really want to, because I don't know how common compiler breakage is with go, having never seen any issue, but I'm definitely tired of removing that check all the time. I think this is a safe middle ground.