### PR TITLE
Feat/d2g capability scopes

### DIFF
--- a/changelog/bug-2055467.md
+++ b/changelog/bug-2055467.md
@@ -1,0 +1,6 @@
+audience: users
+level: patch
+reference: bug 2055467
+---
+
+D2G scope validation now handles the legacy `disableSeccomp` capability consistently with docker worker.

--- a/tools/d2g/d2g.go
+++ b/tools/d2g/d2g.go
@@ -275,6 +275,12 @@ func validateDockerWorkerScopes(
 		)
 	}
 
+	if dwPayload.Capabilities.DisableSeccomp {
+		requiredScopes = append(requiredScopes,
+			[]string{"docker-worker:capability:disableSeccomp"},
+		)
+	}
+
 	if dwPayload.Capabilities.Devices.HostSharedMemory {
 		requiredScopes = append(requiredScopes,
 			[]string{"docker-worker:capability:device:hostSharedMemory"},

--- a/tools/d2g/d2g.go
+++ b/tools/d2g/d2g.go
@@ -266,61 +266,81 @@ func validateDockerWorkerScopes(
 	}
 
 	dummyExpander := scopes.DummyExpander()
-	var requiredScopes scopes.Required
+	var requiredScopes []scopes.Required
 
 	if dwPayload.Capabilities.Privileged {
 		requiredScopes = append(requiredScopes,
-			[]string{"docker-worker:capability:privileged"},
-			[]string{fmt.Sprintf("docker-worker:capability:privileged:%s", taskQueueID)},
+			scopes.Required{
+				{"docker-worker:capability:privileged"},
+				{fmt.Sprintf("docker-worker:capability:privileged:%s", taskQueueID)},
+			},
 		)
 	}
 
 	if dwPayload.Capabilities.DisableSeccomp {
 		requiredScopes = append(requiredScopes,
-			[]string{"docker-worker:capability:disableSeccomp"},
+			scopes.Required{
+				{"docker-worker:capability:disableSeccomp"},
+			},
 		)
 	}
 
 	if dwPayload.Capabilities.Devices.HostSharedMemory {
 		requiredScopes = append(requiredScopes,
-			[]string{"docker-worker:capability:device:hostSharedMemory"},
-			[]string{fmt.Sprintf("docker-worker:capability:device:hostSharedMemory:%s", taskQueueID)},
+			scopes.Required{
+				{"docker-worker:capability:device:hostSharedMemory"},
+				{fmt.Sprintf("docker-worker:capability:device:hostSharedMemory:%s", taskQueueID)},
+			},
 		)
 	}
 
 	if dwPayload.Capabilities.Devices.KVM {
 		requiredScopes = append(requiredScopes,
-			[]string{"docker-worker:capability:device:kvm"},
-			[]string{fmt.Sprintf("docker-worker:capability:device:kvm:%s", taskQueueID)},
+			scopes.Required{
+				{"docker-worker:capability:device:kvm"},
+				{fmt.Sprintf("docker-worker:capability:device:kvm:%s", taskQueueID)},
+			},
 		)
 	}
 
 	if dwPayload.Capabilities.Devices.LoopbackAudio {
 		requiredScopes = append(requiredScopes,
-			[]string{"docker-worker:capability:device:loopbackAudio"},
-			[]string{fmt.Sprintf("docker-worker:capability:device:loopbackAudio:%s", taskQueueID)},
+			scopes.Required{
+				{"docker-worker:capability:device:loopbackAudio"},
+				{fmt.Sprintf("docker-worker:capability:device:loopbackAudio:%s", taskQueueID)},
+			},
 		)
 	}
 
 	if dwPayload.Capabilities.Devices.LoopbackVideo {
 		requiredScopes = append(requiredScopes,
-			[]string{"docker-worker:capability:device:loopbackVideo"},
-			[]string{fmt.Sprintf("docker-worker:capability:device:loopbackVideo:%s", taskQueueID)},
+			scopes.Required{
+				{"docker-worker:capability:device:loopbackVideo"},
+				{fmt.Sprintf("docker-worker:capability:device:loopbackVideo:%s", taskQueueID)},
+			},
 		)
 	}
 
 	if dwPayload.Features.AllowPtrace {
 		requiredScopes = append(requiredScopes,
-			[]string{"docker-worker:feature:allowPtrace"},
+			scopes.Required{
+				{"docker-worker:feature:allowPtrace"},
+			},
 		)
 	}
 
-	scopesSatisfied, err := expandedScopes.Satisfies(requiredScopes, dummyExpander)
-	if err != nil {
-		return nil, fmt.Errorf("error expanding scopes: %v", err)
+	var missingScopes []string
+	for _, required := range requiredScopes {
+		scopesSatisfied, err := expandedScopes.Satisfies(required, dummyExpander)
+		if err != nil {
+			return nil, fmt.Errorf("error expanding scopes: %v", err)
+		}
+		if !scopesSatisfied {
+			missingScopes = append(missingScopes, fmt.Sprintf("(%s)", required.String()))
+		}
 	}
-	if !scopesSatisfied {
-		return nil, fmt.Errorf("d2g task requires scopes:\n\n%v\n\nbut task only has scopes:\n\n%v\n\nYou probably should add some scopes to your task definition", requiredScopes, expandedScopes)
+	if len(missingScopes) > 0 {
+		return nil, fmt.Errorf("d2g task requires scopes:\n\n%s\n\nbut task only has scopes:\n\n%v\n\nYou probably should add some scopes to your task definition", strings.Join(missingScopes, "\nAND\n"), expandedScopes)
 	}
 
 	return expandedScopes, nil

--- a/tools/d2g/d2gtest/d2g_test.go
+++ b/tools/d2g/d2gtest/d2g_test.go
@@ -8,6 +8,7 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/mcuadros/go-defaults"
@@ -65,6 +66,48 @@ func ExampleConvertScopes_mixture() {
 	//	"generic-worker:os-group:x/y/z/kvm"
 	//	"generic-worker:os-group:x/y/z/libvirt"
 	//	"generic-worker:teapot"
+}
+
+func TestConvertScopesRequiresDisableSeccompScope(t *testing.T) {
+	const disableSeccompScope = "docker-worker:capability:disableSeccomp"
+
+	dwPayload := dockerworker.DockerWorkerPayload{}
+	defaults.SetDefaults(&dwPayload)
+	dwPayload.Capabilities.DisableSeccomp = true
+
+	tests := []struct {
+		name    string
+		scopes  []string
+		wantErr bool
+	}{
+		{
+			name:    "missing scope",
+			scopes:  []string{},
+			wantErr: true,
+		},
+		{
+			name:   "required scope present",
+			scopes: []string{disableSeccompScope},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, err := d2g.ConvertScopes(test.scopes, &dwPayload, "proj-taskcluster/ci", scopes.DummyExpander())
+			if test.wantErr {
+				if err == nil {
+					t.Fatal("ConvertScopes succeeded without the disableSeccomp scope")
+				}
+				if !strings.Contains(err.Error(), disableSeccompScope) {
+					t.Fatalf("ConvertScopes error does not identify the missing scope: %v", err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("ConvertScopes failed with the disableSeccomp scope: %v", err)
+			}
+		})
+	}
 }
 
 type mockedDirEntry struct {

--- a/tools/d2g/d2gtest/d2g_test.go
+++ b/tools/d2g/d2gtest/d2g_test.go
@@ -110,6 +110,46 @@ func TestConvertScopesRequiresDisableSeccompScope(t *testing.T) {
 	}
 }
 
+func TestConvertScopesRequiresEveryCapabilityScope(t *testing.T) {
+	dwPayload := dockerworker.DockerWorkerPayload{}
+	defaults.SetDefaults(&dwPayload)
+	dwPayload.Capabilities.DisableSeccomp = true
+	dwPayload.Capabilities.Devices.LoopbackAudio = true
+
+	_, err := d2g.ConvertScopes(
+		[]string{"docker-worker:capability:device:loopbackAudio"},
+		&dwPayload,
+		"proj-taskcluster/ci",
+		scopes.DummyExpander(),
+	)
+	if err == nil {
+		t.Fatal("ConvertScopes succeeded without the disableSeccomp scope")
+	}
+}
+
+func TestConvertScopesReportsEveryMissingCapabilityScope(t *testing.T) {
+	const disableSeccompScope = "docker-worker:capability:disableSeccomp"
+	const loopbackAudioScope = "docker-worker:capability:device:loopbackAudio"
+
+	dwPayload := dockerworker.DockerWorkerPayload{}
+	defaults.SetDefaults(&dwPayload)
+	dwPayload.Capabilities.DisableSeccomp = true
+	dwPayload.Capabilities.Devices.LoopbackAudio = true
+
+	_, err := d2g.ConvertScopes(nil, &dwPayload, "proj-taskcluster/ci", scopes.DummyExpander())
+	if err == nil {
+		t.Fatal("ConvertScopes succeeded without the required capability scopes")
+	}
+	for _, missingScope := range []string{disableSeccompScope, loopbackAudioScope} {
+		if !strings.Contains(err.Error(), missingScope) {
+			t.Errorf("ConvertScopes error does not identify missing scope %q: %v", missingScope, err)
+		}
+	}
+	if !strings.Contains(err.Error(), "\nAND\n") {
+		t.Errorf("ConvertScopes error does not join capability requirements with AND: %v", err)
+	}
+}
+
 type mockedDirEntry struct {
 	name string
 }


### PR DESCRIPTION
This brings `disableSeccomp` capability handling on par with docker worker (checking scopes) and also improves scope checks or large set of scopes

Bugzilla Bug: [2055467](https://bugzilla.mozilla.org/show_bug.cgi?id=2055467)
