### PR TITLE
Update glob from 8 to 13

### DIFF
--- a/changelog/cyRb-jJES0WE5dN9Fn_PKw.md
+++ b/changelog/cyRb-jJES0WE5dN9Fn_PKw.md
@@ -1,0 +1,2 @@
+level: silent
+---

--- a/infrastructure/tooling/src/build/tasks/generic-worker.js
+++ b/infrastructure/tooling/src/build/tasks/generic-worker.js
@@ -1,4 +1,4 @@
-import glob from 'glob';
+import { globSync } from 'glob';
 import path from 'node:path';
 import { ensureTask, execCommand, REPO_ROOT } from '../../utils/index.js';
 
@@ -16,7 +16,7 @@ export default ({ tasks }) => {
         utils,
       });
 
-      const artifacts = glob.sync('generic-worker-*', { cwd: artifactsDir });
+      const artifacts = globSync('generic-worker-*', { cwd: artifactsDir });
 
       return {
         'generic-worker-artifacts': artifacts,

--- a/infrastructure/tooling/src/build/tasks/livelog.js
+++ b/infrastructure/tooling/src/build/tasks/livelog.js
@@ -1,5 +1,5 @@
 import fs from 'node:fs';
-import glob from 'glob';
+import { globSync } from 'glob';
 import path from 'node:path';
 import { ensureTask, execCommand, dockerPush, REPO_ROOT } from '../../utils/index.js';
 
@@ -17,7 +17,7 @@ export default ({ tasks, cmdOptions, credentials, baseDir, logsDir }) => {
         utils,
       });
 
-      const artifacts = glob.sync('livelog-*', { cwd: artifactsDir });
+      const artifacts = globSync('livelog-*', { cwd: artifactsDir });
 
       return {
         'livelog-artifacts': artifacts,

--- a/infrastructure/tooling/src/build/tasks/taskcluster-proxy.js
+++ b/infrastructure/tooling/src/build/tasks/taskcluster-proxy.js
@@ -1,4 +1,4 @@
-import glob from 'glob';
+import { globSync } from 'glob';
 import fs from 'node:fs';
 import path from 'node:path';
 import { ensureTask, execCommand, dockerPush, REPO_ROOT } from '../../utils/index.js';
@@ -17,7 +17,7 @@ export default ({ tasks, cmdOptions, credentials, baseDir, logsDir }) => {
         utils,
       });
 
-      const artifacts = glob.sync('taskcluster-proxy-*', { cwd: artifactsDir });
+      const artifacts = globSync('taskcluster-proxy-*', { cwd: artifactsDir });
 
       return {
         'taskcluster-proxy-artifacts': artifacts,

--- a/infrastructure/tooling/src/build/tasks/worker-runner.js
+++ b/infrastructure/tooling/src/build/tasks/worker-runner.js
@@ -1,4 +1,4 @@
-import glob from 'glob';
+import { globSync } from 'glob';
 import path from 'node:path';
 import { ensureTask, execCommand, REPO_ROOT } from '../../utils/index.js';
 
@@ -16,7 +16,7 @@ export default ({ tasks }) => {
         utils,
       });
 
-      const artifacts = glob.sync('start-worker-*', { cwd: artifactsDir });
+      const artifacts = globSync('start-worker-*', { cwd: artifactsDir });
 
       return {
         'worker-runner-artifacts': artifacts,

--- a/infrastructure/tooling/src/changelog/index.js
+++ b/infrastructure/tooling/src/changelog/index.js
@@ -1,6 +1,6 @@
 import yaml from 'js-yaml';
 import semver from 'semver';
-import glob from 'glob';
+import { globSync } from 'glob';
 import chalk from 'chalk';
 import appRootDir from 'app-root-dir';
 
@@ -71,9 +71,9 @@ export class ChangeLog {
   }
 
   async loadSnippets() {
-    const snippetFiles = glob
-      .sync('changelog/*.md', { cwd: appRootDir.get() })
-      .filter(filename => filename !== 'changelog/README.md');
+    const snippetFiles = globSync('changelog/*.md', { cwd: appRootDir.get() }).filter(
+      filename => filename !== 'changelog/README.md'
+    );
 
     this.snippets = await Promise.all(
       snippetFiles.map(async filename => {

--- a/infrastructure/tooling/src/generate/generators/generic-worker.js
+++ b/infrastructure/tooling/src/generate/generators/generic-worker.js
@@ -1,5 +1,5 @@
 import path from 'node:path';
-import glob from 'glob';
+import { globSync } from 'glob';
 import { REPO_ROOT, readRepoYAML, modifyRepoFile, writeRepoFile, execCommand } from '../../utils/index.js';
 import { rimraf } from 'rimraf';
 export const tasks = [];
@@ -24,7 +24,7 @@ tasks.push({
   requires: [],
   provides: ['generic-worker-schemas'],
   run: async (_requirements, _utils) => {
-    const schemaFiles = glob.sync('workers/generic-worker/schemas/*.yml', { cwd: REPO_ROOT });
+    const schemaFiles = globSync('workers/generic-worker/schemas/*.yml', { cwd: REPO_ROOT }).sort();
     return {
       'generic-worker-schemas': await Promise.all(
         schemaFiles.map(async filename => {
@@ -124,7 +124,7 @@ tasks.push({
     const gwDocsDir = path.join('ui', 'docs', 'reference', 'workers', 'generic-worker');
 
     // begin by deleting all *-payload--schema.mdx files
-    for (const file of glob.sync(`${gwDocsDir}/*-payload.mdx`, { cwd: REPO_ROOT })) {
+    for (const file of globSync(`${gwDocsDir}/*-payload.mdx`, { cwd: REPO_ROOT })) {
       await rimraf(path.join(REPO_ROOT, file));
     }
 

--- a/infrastructure/tooling/src/generate/generators/k8s.js
+++ b/infrastructure/tooling/src/generate/generators/k8s.js
@@ -1,6 +1,6 @@
 import _ from 'lodash';
 import path from 'node:path';
-import glob from 'glob';
+import { globSync } from 'glob';
 import yaml from 'js-yaml';
 import jsone from 'json-e';
 import mkdirp from 'mkdirp';
@@ -339,7 +339,7 @@ tasks.push({
   requires: [],
   provides: ['k8s-templates'],
   run: async (_requirements, _utils) => {
-    const templateFiles = glob.sync('infrastructure/tooling/templates/k8s/*.yaml', { cwd: REPO_ROOT });
+    const templateFiles = globSync('infrastructure/tooling/templates/k8s/*.yaml', { cwd: REPO_ROOT });
     const templates = {};
     for (const f of templateFiles) {
       templates[path.basename(f, '.yaml')] = await readRepoYAML(f);

--- a/infrastructure/tooling/src/meta/checks/db.js
+++ b/infrastructure/tooling/src/meta/checks/db.js
@@ -1,6 +1,6 @@
 import path from 'node:path';
 import fs from 'node:fs';
-import glob from 'glob';
+import { globSync } from 'glob';
 import { REPO_ROOT } from '../../utils/index.js';
 
 export const tasks = [
@@ -9,7 +9,7 @@ export const tasks = [
     requires: [],
     provides: [],
     run: async () => {
-      const versionFiles = glob.sync('db/versions/*.yml', { cwd: REPO_ROOT }).map(path => path.split('/')[2]);
+      const versionFiles = globSync('db/versions/*.yml', { cwd: REPO_ROOT }).map(path => path.split('/')[2]);
       for (const file of versionFiles) {
         const testFile = `db/test/versions/${path.basename(file, '.yml')}_test.js`;
         if (!fs.existsSync(testFile)) {

--- a/infrastructure/tooling/src/meta/checks/docs-headings.js
+++ b/infrastructure/tooling/src/meta/checks/docs-headings.js
@@ -1,5 +1,5 @@
 import fs from 'node:fs';
-import glob from 'glob';
+import { globSync } from 'glob';
 import { REPO_ROOT } from '../../utils/index.js';
 
 export const tasks = [
@@ -8,7 +8,7 @@ export const tasks = [
     requires: [],
     provides: [],
     run: async (_requirements, _utils) => {
-      const markdowns = glob.sync('ui/docs/**/*.mdx', { cwd: REPO_ROOT });
+      const markdowns = globSync('ui/docs/**/*.mdx', { cwd: REPO_ROOT });
 
       let errors = '';
       let countErrors = 0;

--- a/infrastructure/tooling/src/meta/checks/workspace-packages.js
+++ b/infrastructure/tooling/src/meta/checks/workspace-packages.js
@@ -1,5 +1,5 @@
 import fs from 'node:fs';
-import glob from 'glob';
+import { globSync } from 'glob';
 import { REPO_ROOT } from '../../utils/index.js';
 
 export const tasks = [
@@ -8,7 +8,7 @@ export const tasks = [
     requires: [],
     provides: [],
     run: async (_requirements, _utils) => {
-      const packageJsons = glob.sync('{services,libraries}/*/package.json', { cwd: REPO_ROOT });
+      const packageJsons = globSync('{services,libraries}/*/package.json', { cwd: REPO_ROOT });
 
       const forbidden = ['engines', 'engineStrict', 'engine-strict', 'dependencies', 'files'];
       for (const filename of packageJsons) {

--- a/infrastructure/tooling/src/utils/repo.js
+++ b/infrastructure/tooling/src/utils/repo.js
@@ -1,7 +1,7 @@
 import { promisify } from 'node:util';
 import path from 'node:path';
 import fs from 'node:fs';
-import glob from 'glob';
+import { globSync } from 'glob';
 import yaml from 'js-yaml';
 import stringify from 'json-stable-stringify';
 import { execFile } from 'node:child_process';
@@ -23,8 +23,8 @@ export const REPO_ROOT = path.join(__dirname, '../../../../');
 export const listServices = ({ repoDir } = {}) => {
   // look for package.json's, so that we're not fooled by any
   // stray empty or gitignore'd directories
-  const packageJsons = glob.sync('services/*/package.json', { cwd: repoDir || REPO_ROOT });
-  return packageJsons.map(filename => filename.split('/')[1]);
+  const packageJsons = globSync('services/*/package.json', { cwd: repoDir || REPO_ROOT });
+  return packageJsons.map(filename => filename.split('/')[1]).sort();
 };
 
 /**

--- a/package.json
+++ b/package.json
@@ -150,7 +150,7 @@
     "dockerode": "^3.3.4",
     "error-stack-parser": "^2.0.2",
     "github-slugger": "^2.0.0",
-    "glob": "^8.0.3",
+    "glob": "^13.0.6",
     "graphql-tag": "^2.12.7",
     "gray-matter": "^4.0.3",
     "inquirer": "^8.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4785,6 +4785,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"balanced-match@npm:^4.0.2":
+  version: 4.0.4
+  resolution: "balanced-match@npm:4.0.4"
+  checksum: 10c0/07e86102a3eb2ee2a6a1a89164f29d0dbaebd28f2ca3f5ca786f36b8b23d9e417eb3be45a4acf754f837be5ac0a2317de90d3fcb7f4f4dc95720a1f36b26a17b
+  languageName: node
+  linkType: hard
+
 "base-x@npm:^5.0.0":
   version: 5.0.1
   resolution: "base-x@npm:5.0.1"
@@ -4959,6 +4966,15 @@ __metadata:
   dependencies:
     balanced-match: "npm:^1.0.0"
   checksum: 10c0/6d117a4c793488af86b83172deb6af143e94c17bc53b0b3cec259733923b4ca84679d506ac261f4ba3c7ed37c46018e2ff442f9ce453af8643ecd64f4a54e6cf
+  languageName: node
+  linkType: hard
+
+"brace-expansion@npm:^5.0.5":
+  version: 5.0.7
+  resolution: "brace-expansion@npm:5.0.7"
+  dependencies:
+    balanced-match: "npm:^4.0.2"
+  checksum: 10c0/4769109c3c082de178e449a371bcad50d51ab468f644bce2dd9188efe0cf0a080ed102105d7fc8577382cedc45bad7e6443a91bf3d8102264ee8cf927dbaf205
   languageName: node
   linkType: hard
 
@@ -7062,7 +7078,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"glob@npm:^8.0.3, glob@npm:^8.1.0":
+"glob@npm:^13.0.6":
+  version: 13.0.6
+  resolution: "glob@npm:13.0.6"
+  dependencies:
+    minimatch: "npm:^10.2.2"
+    minipass: "npm:^7.1.3"
+    path-scurry: "npm:^2.0.2"
+  checksum: 10c0/269c236f11a9b50357fe7a8c6aadac667e01deb5242b19c84975628f05f4438d8ee1354bb62c5d6c10f37fd59911b54d7799730633a2786660d8c69f1d18120a
+  languageName: node
+  linkType: hard
+
+"glob@npm:^8.1.0":
   version: 8.1.0
   resolution: "glob@npm:8.1.0"
   dependencies:
@@ -8910,6 +8937,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"minimatch@npm:^10.2.2":
+  version: 10.2.5
+  resolution: "minimatch@npm:10.2.5"
+  dependencies:
+    brace-expansion: "npm:^5.0.5"
+  checksum: 10c0/6bb058bd6324104b9ec2f763476a35386d05079c1f5fe4fbf1f324a25237cd4534d6813ecd71f48208f4e635c1221899bef94c3c89f7df55698fe373aaae20fd
+  languageName: node
+  linkType: hard
+
 "minimatch@npm:^3.0.4, minimatch@npm:^3.1.2":
   version: 3.1.5
   resolution: "minimatch@npm:3.1.5"
@@ -9008,6 +9044,13 @@ __metadata:
   version: 7.1.2
   resolution: "minipass@npm:7.1.2"
   checksum: 10c0/b0fd20bb9fb56e5fa9a8bfac539e8915ae07430a619e4b86ff71f5fc757ef3924b23b2c4230393af1eda647ed3d75739e4e0acb250a6b1eb277cf7f8fe449557
+  languageName: node
+  linkType: hard
+
+"minipass@npm:^7.1.3":
+  version: 7.1.3
+  resolution: "minipass@npm:7.1.3"
+  checksum: 10c0/539da88daca16533211ea5a9ee98dc62ff5742f531f54640dd34429e621955e91cc280a91a776026264b7f9f6735947629f920944e9c1558369e8bf22eb33fbb
   languageName: node
   linkType: hard
 
@@ -9944,6 +9987,16 @@ __metadata:
     lru-cache: "npm:^10.2.0"
     minipass: "npm:^5.0.0 || ^6.0.2 || ^7.0.0"
   checksum: 10c0/32a13711a2a505616ae1cc1b5076801e453e7aae6ac40ab55b388bb91b9d0547a52f5aaceff710ea400205f18691120d4431e520afbe4266b836fadede15872d
+  languageName: node
+  linkType: hard
+
+"path-scurry@npm:^2.0.2":
+  version: 2.0.2
+  resolution: "path-scurry@npm:2.0.2"
+  dependencies:
+    lru-cache: "npm:^11.0.0"
+    minipass: "npm:^7.1.2"
+  checksum: 10c0/b35ad37cf6557a87fd057121ce2be7695380c9138d93e87ae928609da259ea0a170fac6f3ef1eb3ece8a068e8b7f2f3adf5bb2374cf4d4a57fe484954fcc9482
   languageName: node
   linkType: hard
 
@@ -11746,7 +11799,7 @@ __metadata:
     fast-json-stable-stringify: "npm:^2.0.0"
     generate-password: "npm:^1.5.0"
     github-slugger: "npm:^2.0.0"
-    glob: "npm:^8.0.3"
+    glob: "npm:^13.0.6"
     got: "npm:^14.4.7"
     graphql: "npm:^16.14.0"
     graphql-depth-limit: "npm:^1.1.0"


### PR DESCRIPTION
That's a tiny jump. 2 main changes, obviously the import changed, that was a very mechanical change `glob.sync` -> `globSync`. The other change that is a bit insidious is that glob 8 was returning sorted file lists, glob 13 doesn't. Thankfully here this is all in generators where it was very easy to run it 10 times and check that they all returned the same thing or in checks where order clearly didn't matter.