### PR TITLE
Remove our dependency on dockerode and unused functions in docker tooling

### DIFF
--- a/changelog/SAbCJGo8Q366rDCGA6AwnA.md
+++ b/changelog/SAbCJGo8Q366rDCGA6AwnA.md
@@ -1,0 +1,2 @@
+level: silent
+---

--- a/infrastructure/tooling/src/build/tasks/generic-worker-image.js
+++ b/infrastructure/tooling/src/build/tasks/generic-worker-image.js
@@ -2,7 +2,7 @@ import appRootDir from 'app-root-dir';
 
 import {
   dockerPull,
-  dockerImages,
+  dockerImageExists,
   dockerRegistryCheck,
   ensureTask,
   dockerPush,
@@ -38,9 +38,7 @@ export default ({ tasks, baseDir, cmdOptions, credentials, logsDir }) => {
 
       utils.step({ title: 'Check for Existing Images' });
 
-      const imageLocal = (await dockerImages({ baseDir })).some(
-        image => image.RepoTags && image.RepoTags.indexOf(tag) !== -1
-      );
+      const imageLocal = await dockerImageExists({ tag });
 
       let imageOnRegistry;
       try {
@@ -61,7 +59,7 @@ export default ({ tasks, baseDir, cmdOptions, credentials, logsDir }) => {
 
       // bail out if we can, pulling the image if it's only available remotely
       if (!imageLocal && imageOnRegistry) {
-        await dockerPull({ image: tag, utils, baseDir });
+        await dockerPull({ image: tag, utils });
         return utils.skip({ provides });
       } else if (imageLocal) {
         return utils.skip({ provides });

--- a/infrastructure/tooling/src/build/tasks/monoimage.js
+++ b/infrastructure/tooling/src/build/tasks/monoimage.js
@@ -2,7 +2,7 @@ import appRootDir from 'app-root-dir';
 
 import {
   dockerPull,
-  dockerImages,
+  dockerImageExists,
   dockerRegistryCheck,
   ensureTask,
   dockerPush,
@@ -53,9 +53,7 @@ const generateMonoimageTasks = ({ tasks, baseDir, cmdOptions, credentials, logsD
 
       utils.step({ title: 'Check for Existing Images' });
 
-      const imageLocal = (await dockerImages({ baseDir })).some(
-        image => image.RepoTags && image.RepoTags.indexOf(tag) !== -1
-      );
+      const imageLocal = await dockerImageExists({ tag });
 
       let imageOnRegistry;
       try {
@@ -76,7 +74,7 @@ const generateMonoimageTasks = ({ tasks, baseDir, cmdOptions, credentials, logsD
 
       // bail out if we can, pulling the image if it's only available remotely
       if (!imageLocal && imageOnRegistry) {
-        await dockerPull({ image: tag, utils, baseDir });
+        await dockerPull({ image: tag, utils });
         return utils.skip({ provides });
       } else if (imageLocal) {
         return utils.skip({ provides });
@@ -120,9 +118,7 @@ const generateMonoimageTasks = ({ tasks, baseDir, cmdOptions, credentials, logsD
 
       utils.step({ title: 'Check for Existing Images' });
 
-      const imageLocal = (await dockerImages({ baseDir })).some(
-        image => image.RepoTags && image.RepoTags.indexOf(tag) !== -1
-      );
+      const imageLocal = await dockerImageExists({ tag });
 
       let imageOnRegistry;
       try {
@@ -144,7 +140,7 @@ const generateMonoimageTasks = ({ tasks, baseDir, cmdOptions, credentials, logsD
 
       // bail out if we can, pulling the image if it's only available remotely
       if (!imageLocal && imageOnRegistry) {
-        await dockerPull({ image: tag, utils, baseDir });
+        await dockerPull({ image: tag, utils });
         return utils.skip({ provides });
       } else if (imageLocal) {
         return utils.skip({ provides });

--- a/infrastructure/tooling/src/utils/docker.js
+++ b/infrastructure/tooling/src/utils/docker.js
@@ -1,229 +1,37 @@
-import fs from 'node:fs';
-import os from 'node:os';
 import path from 'node:path';
-import Docker from 'dockerode';
-import Observable from 'zen-observable';
-import { PassThrough, Transform } from 'node:stream';
 import taskcluster from '@taskcluster/client';
 import { REPO_ROOT } from './repo.js';
 import got from 'got';
-import { execCommand } from './command.js';
+import { execCommand, execCommandOutput } from './command.js';
 import mkdirp from 'mkdirp';
 import { rimraf } from 'rimraf';
 
 /**
- * Set up to call docker in the given baseDir (internal use only)
- */
-const _dockerSetup = ({ baseDir }) => {
-  const inner = async ({ baseDir }) => {
-    const docker = new Docker();
-    // when running a docker container, always remove the container when finished,
-    // mount the workdir at /workdir, and run as the current (non-container) user
-    // so that file ownership remains as expected.  Set up /etc/passwd and /etc/group
-    // to define names for those uid/gid, too.
-    const { uid, gid } = os.userInfo();
-    fs.writeFileSync(
-      path.join(baseDir, 'passwd'),
-      `root:x:0:0:root:/root:/bin/bash\nbuilder:x:${uid}:${gid}:builder:/:/bin/bash\n`
-    );
-    fs.writeFileSync(path.join(baseDir, 'group'), `root:x:0:\nbuilder:x:${gid}:\n`);
-    const dockerRunOpts = {
-      AutoRemove: true,
-      User: `${uid}:${gid}`,
-      Env: ['HOME=/base/app'],
-      Mounts: [
-        {
-          Type: 'bind',
-          Target: '/etc/passwd',
-          Source: `${baseDir}/passwd`,
-          ReadOnly: true,
-        },
-        {
-          Type: 'bind',
-          Target: '/etc/group',
-          Source: `${baseDir}/group`,
-          ReadOnly: true,
-        },
-      ],
-    };
-
-    return { docker, dockerRunOpts, uid, gid };
-  };
-
-  if (!(baseDir in _dockerSetup.memos)) {
-    // cache the promise to return multiple times
-    _dockerSetup.memos[baseDir] = inner({ baseDir });
-  }
-  return _dockerSetup.memos[baseDir];
-};
-_dockerSetup.memos = {};
-
-/**
- * Run a command (`docker run`), logging the output to TaskGraph and to a local
- * logfile
- *
- * - baseDir -- base directory for operations
- * - logfile -- name of the file to write the log to
- * - command -- command to run
- * - env -- environment variables to set
- * - workingDir -- directory to run in
- * - image -- image to run it in
- * - asRoot -- run as root
- * - utils -- taskgraph utils (waitFor, etc.)
- */
-export const dockerRun = async ({ baseDir, logfile, command, env, mounts, workingDir, image, asRoot, utils }) => {
-  const { docker, dockerRunOpts } = await _dockerSetup({ baseDir });
-
-  const output = new PassThrough().pipe(new DemuxDockerStream());
-  let errorAddendum = '';
-  if (logfile) {
-    output.pipe(fs.createWriteStream(logfile));
-    errorAddendum = ` Logs available in ${logfile}`;
-  }
-
-  const { Mounts, Env, ...otherOpts } = dockerRunOpts;
-  const containerOpts = {
-    Image: image,
-    AttachStdin: false,
-    AttachStdout: true,
-    AttachStderr: true,
-    OpenStdin: false,
-    StdinOnce: false,
-    Tty: false,
-    Env: [...Env, ...(env || [])],
-    WorkingDir: workingDir,
-    Cmd: command,
-    HostConfig: {
-      Mounts: [...Mounts, ...(mounts || [])],
-      // AutoRemove would help clean up stray containers, but means we cannot reliably
-      // get the exit status of the container
-      AutoRemove: false,
-    },
-    ...otherOpts,
-  };
-
-  if (asRoot) {
-    delete containerOpts.User;
-  }
-
-  // this is roughly the equivalent of `docker run`, performed as individual
-  // docker API calls.
-  const container = await docker.createContainer(containerOpts);
-  const stream = await container.attach({ stream: true, stdout: true, stderr: true });
-  stream.pipe(output, { end: true });
-  await container.start({});
-
-  // wait for the output to close, then wait for the container to exit
-  await utils.waitFor(output);
-  const result = await utils.waitFor(container.wait());
-  await utils.waitFor(container.remove());
-
-  if (result.StatusCode !== 0) {
-    throw new Error(`Container exited with status ${result.StatusCode}.${errorAddendum}`);
-  }
-};
-
-// Decode the multiplexed stream from Docker.  See
-// https://docs.docker.com/engine/api/v1.37/#operation/ContainerAttach
-// for protocol details.
-class DemuxDockerStream extends Transform {
-  constructor() {
-    super();
-    this.buffer = Buffer.alloc(0);
-  }
-
-  _transform(chunk, _encoding, callback) {
-    if (this.buffer.length) {
-      this.buffer = Buffer.concat([this.buffer, chunk]);
-    } else {
-      this.buffer = chunk;
-    }
-
-    // The data stream is an 8-byte header: [type, 0, 0, 0, SIZE1, SIZE2,
-    // SIZE3, SIZE4] followed by the payload.  We don't care about the type, so
-    // just read the size and then dump the payload to the stream output.
-    while (this.buffer.length >= 8) {
-      const len = this.buffer.readUInt32BE(4);
-      if (this.buffer.length < len + 8) {
-        break;
-      }
-      const payload = this.buffer.slice(8, len + 8);
-      this.buffer = this.buffer.slice(len + 8);
-      this.push(payload);
-    }
-    callback();
-  }
-}
-
-/**
  * Pull an image from a docker registry (`docker pull`)
  *
- * - baseDir -- base directory for operations
- * - image -- image to run it in
+ * - image -- image to pull
  * - utils -- taskgraph utils (waitFor, etc.)
  */
-export const dockerPull = async ({ baseDir, image, utils }) => {
-  const { docker } = await _dockerSetup({ baseDir });
-
+export const dockerPull = async ({ image, utils }) => {
   utils.status({ message: `docker pull ${image}` });
-  const dockerStream = await new Promise((resolve, reject) =>
-    docker.pull(image, (err, stream) => (err ? reject(err) : resolve(stream)))
-  );
-
-  await utils.waitFor(
-    new Observable(observer => {
-      const downloading = {},
-        extracting = {},
-        totals = {};
-      docker.modem.followProgress(
-        dockerStream,
-        err => (err ? observer.error(err) : observer.complete()),
-        update => {
-          // The format of this stream appears undocumented, but we can fake it based on observations..
-          // general messages seem to lack progressDetail
-          if (!update.progressDetail) {
-            return;
-          }
-
-          let progressed = false;
-          if (update.status === 'Waiting') {
-            totals[update.id] = 104857600; // a guess: 100MB
-            progressed = true;
-          } else if (update.status === 'Downloading') {
-            downloading[update.id] = update.progressDetail.current;
-            totals[update.id] = update.progressDetail.total;
-            progressed = true;
-          } else if (update.status === 'Extracting') {
-            extracting[update.id] = update.progressDetail.current;
-            totals[update.id] = update.progressDetail.total;
-            progressed = true;
-          }
-
-          if (progressed) {
-            // calculate overall progress by assuming that every image must be
-            // downloaded and extracted, and that those both take the same amount
-            // of time per byte.
-            const total = Object.values(totals).reduce((a, b) => a + b, 0) * 2;
-            const current =
-              Object.values(downloading).reduce((a, b) => a + b, 0) +
-              Object.values(extracting).reduce((a, b) => a + b, 0);
-            utils.status({ progress: (current * 100) / total });
-          }
-        }
-      );
-    })
-  );
+  await execCommand({ command: ['docker', 'pull', image], utils });
 };
 
 /**
- * List locally-loaded docker images (`docker images`)
+ * Check whether an image is present locally (`docker image inspect`)
  *
- * - baseDir -- base directory for operations
+ * - tag -- the tag to check for
  */
-export const dockerImages = async ({ baseDir }) => {
-  const { docker } = await _dockerSetup({ baseDir });
-
-  return docker.listImages();
+export const dockerImageExists = async ({ tag }) => {
+  try {
+    await execCommandOutput({ command: ['docker', 'image', 'inspect', tag] });
+    return true;
+  } catch (err) {
+    if (err.exitCode === undefined) {
+      throw err;
+    }
+    return false;
+  }
 };
 
 /**

--- a/package.json
+++ b/package.json
@@ -147,7 +147,6 @@
     "console-taskgraph": "^1.7.2",
     "cronstrue": "^2.61.0",
     "cross-env": "^10.1.0",
-    "dockerode": "^3.3.4",
     "error-stack-parser": "^2.0.2",
     "github-slugger": "^2.0.0",
     "glob": "^13.0.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1612,13 +1612,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@balena/dockerignore@npm:^1.0.2":
-  version: 1.0.2
-  resolution: "@balena/dockerignore@npm:1.0.2"
-  checksum: 10c0/0bcb067e86f6734ab943ce4ce9a7c8611f2e983a70bccebf9d2309db57695c09dded7faf5be49c929c4c9e9a9174ae55fc625626de0fb9958823c37423d12f4e
-  languageName: node
-  linkType: hard
-
 "@biomejs/biome@npm:^2.5.1":
   version: 2.5.1
   resolution: "@biomejs/biome@npm:2.5.1"
@@ -4613,15 +4606,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"asn1@npm:^0.2.6":
-  version: 0.2.6
-  resolution: "asn1@npm:0.2.6"
-  dependencies:
-    safer-buffer: "npm:~2.1.0"
-  checksum: 10c0/00c8a06c37e548762306bcb1488388d2f76c74c36f70c803f0c081a01d3bdf26090fc088cd812afc5e56a6d49e33765d451a5f8a68ab9c2b087eba65d2e980e0
-  languageName: node
-  linkType: hard
-
 "assert-never@npm:^1.2.1":
   version: 1.4.0
   resolution: "assert-never@npm:1.4.0"
@@ -4764,15 +4748,6 @@ __metadata:
   version: 3.0.1
   resolution: "base64url@npm:3.0.1"
   checksum: 10c0/5ca9d6064e9440a2a45749558dddd2549ca439a305793d4f14a900b7256b5f4438ef1b7a494e1addc66ced5d20f5c010716d353ed267e4b769e6c78074991241
-  languageName: node
-  linkType: hard
-
-"bcrypt-pbkdf@npm:^1.0.2":
-  version: 1.0.2
-  resolution: "bcrypt-pbkdf@npm:1.0.2"
-  dependencies:
-    tweetnacl: "npm:^0.14.3"
-  checksum: 10c0/ddfe85230b32df25aeebfdccfbc61d3bc493ace49c884c9c68575de1f5dcf733a5d7de9def3b0f318b786616b8d85bad50a28b1da1750c43e0012c93badcc148
   languageName: node
   linkType: hard
 
@@ -4959,13 +4934,6 @@ __metadata:
     base64-js: "npm:^1.3.1"
     ieee754: "npm:^1.1.13"
   checksum: 10c0/27cac81cff434ed2876058d72e7c4789d11ff1120ef32c9de48f59eab58179b66710c488987d295ae89a228f835fc66d088652dffeb8e3ba8659f80eb091d55e
-  languageName: node
-  linkType: hard
-
-"buildcheck@npm:~0.0.6":
-  version: 0.0.6
-  resolution: "buildcheck@npm:0.0.6"
-  checksum: 10c0/8cbdb89f41bc484b8325f4828db4135b206a0dffb641eb6cdb2b7022483c45dd0e5aac6d820c9a67bdd2caab3a02c76d7ceec7bd9ec494b5a2270d2806b01a76
   languageName: node
   linkType: hard
 
@@ -5514,17 +5482,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cpu-features@npm:~0.0.10":
-  version: 0.0.10
-  resolution: "cpu-features@npm:0.0.10"
-  dependencies:
-    buildcheck: "npm:~0.0.6"
-    nan: "npm:^2.19.0"
-    node-gyp: "npm:latest"
-  checksum: 10c0/0c4a12904657b22477ffbcfd2b4b2bdd45b174f283616b18d9e1ade495083f9f6098493feb09f4ae2d0b36b240f9ecd32cfb4afe210cf0d0f8f0cc257bd58e54
-  languageName: node
-  linkType: hard
-
 "cron-parser@npm:5.6.0":
   version: 5.6.0
   resolution: "cron-parser@npm:5.6.0"
@@ -5860,29 +5817,6 @@ __metadata:
     escape-string-applescript: "npm:^1.0.0"
     run-applescript: "npm:^3.0.0"
   checksum: 10c0/24a93b8d8f47812f26aa54fe27ffd10b7495ee824425e0a3c45abbd9df243452f28addb9a0d712fa77566f6787b682ac2757071bf6f0a018b49f9d39ca36efed
-  languageName: node
-  linkType: hard
-
-"docker-modem@npm:^3.0.0":
-  version: 3.0.8
-  resolution: "docker-modem@npm:3.0.8"
-  dependencies:
-    debug: "npm:^4.1.1"
-    readable-stream: "npm:^3.5.0"
-    split-ca: "npm:^1.0.1"
-    ssh2: "npm:^1.11.0"
-  checksum: 10c0/5c00592297fabd78454621fe765a5ef0daea4bbb6692e239ad65b111f4da9d750178f448f8efcaf84f9f999598eb735bc14ad6bf5f0a2dcf9c2d453d5b683540
-  languageName: node
-  linkType: hard
-
-"dockerode@npm:^3.3.4":
-  version: 3.3.5
-  resolution: "dockerode@npm:3.3.5"
-  dependencies:
-    "@balena/dockerignore": "npm:^1.0.2"
-    docker-modem: "npm:^3.0.0"
-    tar-fs: "npm:~2.0.1"
-  checksum: 10c0/c45fa8ed3ad76f13fe7799d539a60fe466f8e34bea06b30d75be9e08bc00536cc9ff2d54e38fbb3b2a8a382bf9d4459a27741e6454ce7d0cda5cd35c51224c73
   languageName: node
   linkType: hard
 
@@ -8966,7 +8900,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"nan@npm:^2.19.0, nan@npm:^2.20.0, nan@npm:^2.22.2":
+"nan@npm:^2.22.2":
   version: 2.22.2
   resolution: "nan@npm:2.22.2"
   dependencies:
@@ -10422,7 +10356,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"readable-stream@npm:^3.0.2, readable-stream@npm:^3.1.1, readable-stream@npm:^3.4.0, readable-stream@npm:^3.5.0, readable-stream@npm:^3.6.0, readable-stream@npm:^3.6.1, readable-stream@npm:^3.6.2":
+"readable-stream@npm:^3.0.2, readable-stream@npm:^3.1.1, readable-stream@npm:^3.4.0, readable-stream@npm:^3.6.0, readable-stream@npm:^3.6.1, readable-stream@npm:^3.6.2":
   version: 3.6.2
   resolution: "readable-stream@npm:3.6.2"
   dependencies:
@@ -10691,7 +10625,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"safer-buffer@npm:>= 2.1.2 < 3, safer-buffer@npm:>= 2.1.2 < 3.0.0, safer-buffer@npm:~2.1.0":
+"safer-buffer@npm:>= 2.1.2 < 3, safer-buffer@npm:>= 2.1.2 < 3.0.0":
   version: 2.1.2
   resolution: "safer-buffer@npm:2.1.2"
   checksum: 10c0/7e3c8b2e88a1841c9671094bbaeebd94448111dd90a81a1f606f3f67708a6ec57763b3b47f06da09fc6054193e0e6709e77325415dc8422b04497a8070fa02d4
@@ -11076,13 +11010,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"split-ca@npm:^1.0.1":
-  version: 1.0.1
-  resolution: "split-ca@npm:1.0.1"
-  checksum: 10c0/f339170b84c6b4706fcf4c60cc84acb36574c0447566bd713301a8d9b4feff7f4627efc8c334bec24944a3e2f35bc596bd58c673c9980d6bfe3137aae1116ba7
-  languageName: node
-  linkType: hard
-
 "split2@npm:^4.1.0":
   version: 4.2.0
   resolution: "split2@npm:4.2.0"
@@ -11101,23 +11028,6 @@ __metadata:
   version: 1.0.3
   resolution: "sprintf-js@npm:1.0.3"
   checksum: 10c0/ecadcfe4c771890140da5023d43e190b7566d9cf8b2d238600f31bec0fc653f328da4450eb04bd59a431771a8e9cc0e118f0aa3974b683a4981b4e07abc2a5bb
-  languageName: node
-  linkType: hard
-
-"ssh2@npm:^1.11.0":
-  version: 1.16.0
-  resolution: "ssh2@npm:1.16.0"
-  dependencies:
-    asn1: "npm:^0.2.6"
-    bcrypt-pbkdf: "npm:^1.0.2"
-    cpu-features: "npm:~0.0.10"
-    nan: "npm:^2.20.0"
-  dependenciesMeta:
-    cpu-features:
-      optional: true
-    nan:
-      optional: true
-  checksum: 10c0/d336a85d87501c64ba230b6c1a2901a9b0e376fe7f7a1640a7f8dbdafe674b2e1a5dc6236ffd1329969dc0cf03cd57759b28743075e61229a984065ee1d56bed
   languageName: node
   linkType: hard
 
@@ -11398,30 +11308,18 @@ __metadata:
   linkType: hard
 
 "tar-fs@npm:^2.1.0":
-  version: 2.1.3
-  resolution: "tar-fs@npm:2.1.3"
+  version: 2.1.5
+  resolution: "tar-fs@npm:2.1.5"
   dependencies:
     chownr: "npm:^1.1.1"
     mkdirp-classic: "npm:^0.5.2"
     pump: "npm:^3.0.0"
     tar-stream: "npm:^2.1.4"
-  checksum: 10c0/472ee0c3c862605165163113ab6924f411c07506a1fb24c51a1a80085f0d4d381d86d2fd6b189236c8d932d1cd97b69cce35016767ceb658a35f7584fe77f305
+  checksum: 10c0/b987429214c3ab3be1f439b4e097dc310acf449c35f355956d801f59ef4cfde3b9827797ab2d2f087ed024e459eedc9b3cd860c9190b86e356ba348ade928684
   languageName: node
   linkType: hard
 
-"tar-fs@npm:~2.0.1":
-  version: 2.0.1
-  resolution: "tar-fs@npm:2.0.1"
-  dependencies:
-    chownr: "npm:^1.1.1"
-    mkdirp-classic: "npm:^0.5.2"
-    pump: "npm:^3.0.0"
-    tar-stream: "npm:^2.0.0"
-  checksum: 10c0/0128e888b61c7c4e8e7997d66ceccc3c79d73c01e87cfcc3d9f6b8555b0c88b8d67d91ff167f00b067f726dde497b2d1fb2bba0cfcb3ccb95ae413cb86c715bc
-  languageName: node
-  linkType: hard
-
-"tar-stream@npm:^2.0.0, tar-stream@npm:^2.1.4":
+"tar-stream@npm:^2.1.4":
   version: 2.2.0
   resolution: "tar-stream@npm:2.2.0"
   dependencies:
@@ -11537,7 +11435,6 @@ __metadata:
     dataloader: "npm:^2.2.3"
     debug: "npm:^4.4.3"
     deepmerge: "npm:^4.3.1"
-    dockerode: "npm:^3.3.4"
     ejs: "npm:^3.1.10"
     email-templates: "npm:^10.0.1"
     error-stack-parser: "npm:^2.0.2"
@@ -11777,13 +11674,6 @@ __metadata:
   version: 0.0.6
   resolution: "tunnel@npm:0.0.6"
   checksum: 10c0/e27e7e896f2426c1c747325b5f54efebc1a004647d853fad892b46d64e37591ccd0b97439470795e5262b5c0748d22beb4489a04a0a448029636670bfd801b75
-  languageName: node
-  linkType: hard
-
-"tweetnacl@npm:^0.14.3":
-  version: 0.14.5
-  resolution: "tweetnacl@npm:0.14.5"
-  checksum: 10c0/4612772653512c7bc19e61923fbf42903f5e0389ec76a4a1f17195859d114671ea4aa3b734c2029ce7e1fa7e5cc8b80580f67b071ecf0b46b5636d030a0102a2
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Pulling in a dependency for what we're doing here is way over the top. The only thing it provides over a subprocess is a progress bar iif the image is missing, the working tree is clean and the repo is at the last released tag.

On top of that, the file was already a mishmash of dockerode and docker commands anyway, meaning that if anyone was actually using this command, they had to use docker as a command already. The alternative here is updating the dependency but given the usage I'd rather take the switch to subprocesses.

The one technical regression here is that docker being down would return `false` from `dockerImageExists` instead of throwing since we can't detect a missing image from a command failure. The error would then come up from the `pull` instead. But the behavior and message would be correct so I don't think it's worth even trying, if the daemon isn't up, the image doesn't exist.

I also removed the `dockerRun` function in tooling. It's been unused since we stopped publishing docker worker in
3009d952f64544ab72f636e674ddbc54b67d1d5f but wasn't removed back then.