### PR TITLE
Add a `pr-complete` task that depends on all other tasks running on PRs

### DIFF
--- a/changelog/LBExUZTQSi6yPPDj0REDKQ.md
+++ b/changelog/LBExUZTQSi6yPPDj0REDKQ.md
@@ -1,0 +1,2 @@
+level: silent
+---

--- a/taskcluster/kinds/client/kind.yml
+++ b/taskcluster/kinds/client/kind.yml
@@ -16,6 +16,8 @@ task-defaults:
     max-run-time: 600
     taskcluster-proxy: true
     chain-of-trust: true
+  attributes:
+    code-review: true
   scopes:
     - secrets:get:project/taskcluster/testing/client-libraries
 

--- a/taskcluster/kinds/db/kind.yml
+++ b/taskcluster/kinds/db/kind.yml
@@ -7,6 +7,8 @@ transforms:
 
 task-defaults:
   worker-type: ubuntu-24-04
+  attributes:
+    code-review: true
   run:
     using: bare
   worker:

--- a/taskcluster/kinds/generic-worker/kind.yml
+++ b/taskcluster/kinds/generic-worker/kind.yml
@@ -17,6 +17,8 @@ task-defaults:
     lint: lint-golang
   run:
     using: bare
+  attributes:
+    code-review: true
   worker:
     max-run-time: 1800
     mounts:

--- a/taskcluster/kinds/go/kind.yml
+++ b/taskcluster/kinds/go/kind.yml
@@ -32,6 +32,8 @@ task-defaults:
         git checkout -f "${{GITHUB_SHA}}"
         git reset --hard "${{GITHUB_SHA}}"
         git clean -fd
+  attributes:
+    code-review: true
   worker:
     max-run-time: 600
     mounts:

--- a/taskcluster/kinds/library/kind.yml
+++ b/taskcluster/kinds/library/kind.yml
@@ -16,6 +16,8 @@ task-defaults:
   scopes:
     - secrets:get:project/taskcluster/testing/azure
     - secrets:get:project/taskcluster/testing/taskcluster-*
+  attributes:
+    code-review: true
   worker:
     docker-image: {in-tree: ci}
     taskcluster-proxy: true

--- a/taskcluster/kinds/lint/kind.yml
+++ b/taskcluster/kinds/lint/kind.yml
@@ -9,6 +9,8 @@ task-defaults:
   worker-type: ubuntu-24-04
   run:
     using: bare
+  attributes:
+    code-review: true
   worker:
     max-run-time: 600
     chain-of-trust: true

--- a/taskcluster/kinds/meta/kind.yml
+++ b/taskcluster/kinds/meta/kind.yml
@@ -13,6 +13,8 @@ task-defaults:
   worker-type: ubuntu-24-04
   run:
     using: bare
+  attributes:
+    code-review: true
   worker:
     docker-image: {in-tree: ci}
     chain-of-trust: true

--- a/taskcluster/kinds/pr/kind.yml
+++ b/taskcluster/kinds/pr/kind.yml
@@ -1,0 +1,22 @@
+loader: taskgraph.loader.transform:loader
+
+transforms:
+    - taskgraph.transforms.code_review:transforms
+    - taskgraph.transforms.task:transforms
+
+kind-dependencies:
+  - client
+  - db
+  - generic-worker
+  - go
+  - library
+  - lint
+  - meta
+  - service
+  - ui
+
+tasks:
+    complete:
+        description: PR Summary Task
+        run-on-tasks-for: [github-pull-request, github-pull-request-untrusted]
+        worker-type: succeed

--- a/taskcluster/kinds/service/kind.yml
+++ b/taskcluster/kinds/service/kind.yml
@@ -15,6 +15,8 @@ task-defaults:
   scopes:
     - secrets:get:project/taskcluster/testing/azure
     - secrets:get:project/taskcluster/testing/taskcluster-*
+  attributes:
+    code-review: true
   worker:
     docker-image: {in-tree: ci}
     taskcluster-proxy: true

--- a/taskcluster/kinds/ui/kind.yml
+++ b/taskcluster/kinds/ui/kind.yml
@@ -10,6 +10,8 @@ task-defaults:
   worker-type: ubuntu-24-04
   run:
     using: bare
+  attributes:
+    code-review: true
   worker:
     docker-image: {in-tree: browser-test}
     chain-of-trust: true


### PR DESCRIPTION
This will help with not having to give github the list of all our tasks in their rulesets for mergeability of PRs... Instead of listing every single one of them ourselves, we can just give it `pr-complete` and maintain the list of task in the dependencies of that task. Taskgraph provides an easy way to do this through the `code-review` attribute, all that is required is setting that attribute and giving the kind as a kind dependency on the `pr` one. Adding tasks to existing kinds doesn't require any change.
