### PR TITLE
Enforce triggerSchema validation for pulse-triggered hooks

### DIFF
--- a/changelog/issue-8867.md
+++ b/changelog/issue-8867.md
@@ -1,0 +1,9 @@
+audience: users
+level: major
+reference: issue 8867
+---
+Pulse-triggered hooks now validate matching pulse message payloads against the hook's `triggerSchema` before creating a task.
+If a pulse message matches the hook's `bindings` but fails `triggerSchema` validation, the message is discarded and no task is created.
+This is a breaking change: previously `triggerSchema` was only enforced on the API and webhook paths, and pulse messages fired the hook regardless of their payload.
+Validation is unconditional, including for hooks that did not set a `triggerSchema`: the default schema only accepts an empty payload, so such a hook will no longer fire on pulse messages that carry a payload.
+Before upgrading, review all hooks with pulse `bindings` and make sure each `triggerSchema` accepts the pulse payloads that should still create tasks, for example by allowing expected properties or using `additionalProperties: true`.

--- a/clients/client-go/tchooks/types.go
+++ b/clients/client-go/tchooks/types.go
@@ -73,6 +73,14 @@ type (
 		// Additional properties allowed
 		Task json.RawMessage `json:"task"`
 
+		// JSON Schema used to validate payloads supplied when firing the hook.
+		// API calls and webhooks are rejected when their payloads fail validation.
+		// Pulse messages that match the hook's bindings are discarded without
+		// creating a task when their payloads fail validation. When omitted, this
+		// defaults to a schema that only accepts an empty payload, so a hook
+		// without an explicit triggerSchema will not fire on Pulse messages that
+		// carry a payload.
+		//
 		// Default:    {
 		//               "additionalProperties": false,
 		//               "type": "object"
@@ -116,6 +124,11 @@ type (
 		// Additional properties allowed
 		Task json.RawMessage `json:"task"`
 
+		// JSON Schema used to validate payloads supplied when firing the hook.
+		// API calls and webhooks are rejected when their payloads fail validation.
+		// Pulse messages that match the hook's bindings are discarded without
+		// creating a task when their payloads fail validation.
+		//
 		// Additional properties allowed
 		TriggerSchema json.RawMessage `json:"triggerSchema"`
 	}

--- a/generated/references.json
+++ b/generated/references.json
@@ -8152,6 +8152,7 @@
           "type": "object"
         },
         "triggerSchema": {
+          "description": "JSON Schema used to validate payloads supplied when firing the hook.\nAPI calls and webhooks are rejected when their payloads fail validation.\nPulse messages that match the hook's bindings are discarded without\ncreating a task when their payloads fail validation.\n",
           "type": "object"
         }
       },
@@ -8215,6 +8216,7 @@
             "additionalProperties": false,
             "type": "object"
           },
+          "description": "JSON Schema used to validate payloads supplied when firing the hook.\nAPI calls and webhooks are rejected when their payloads fail validation.\nPulse messages that match the hook's bindings are discarded without\ncreating a task when their payloads fail validation. When omitted, this\ndefaults to a schema that only accepts an empty payload, so a hook\nwithout an explicit triggerSchema will not fire on Pulse messages that\ncarry a payload.\n",
           "type": "object"
         }
       },
@@ -25563,6 +25565,24 @@
           "name": "hookFire",
           "title": "A hook was fired",
           "type": "hook-fire",
+          "version": 1
+        },
+        {
+          "description": "A pulse message matched a hook's bindings, but was discarded before\nfiring the hook. This log type is sampled to avoid being noisy.",
+          "fields": {
+            "discardedCount": "Number of pulse messages discarded by this listener for this reason since it was created",
+            "exchange": "The pulse exchange that delivered the message",
+            "hookGroupId": "The group ID of the hook that matched the pulse message",
+            "hookId": "The ID of the hook that matched the pulse message",
+            "message": "A short human-readable description of the discard",
+            "reason": "The reason the pulse message was discarded",
+            "routingKey": "The pulse routing key that delivered the message",
+            "validationError": "The triggerSchema validation error that caused the discard"
+          },
+          "level": "notice",
+          "name": "hookPulseMessageDiscarded",
+          "title": "A pulse message for a hook was discarded",
+          "type": "hook-pulse-message-discarded",
           "version": 1
         },
         {

--- a/services/hooks/schemas/v1/create-hook-request.yml
+++ b/services/hooks/schemas/v1/create-hook-request.yml
@@ -32,6 +32,14 @@ properties:
       a task definition that is submitted to the Queue service.
     type:                 object
   triggerSchema:
+    description: |
+      JSON Schema used to validate payloads supplied when firing the hook.
+      API calls and webhooks are rejected when their payloads fail validation.
+      Pulse messages that match the hook's bindings are discarded without
+      creating a task when their payloads fail validation. When omitted, this
+      defaults to a schema that only accepts an empty payload, so a hook
+      without an explicit triggerSchema will not fire on Pulse messages that
+      carry a payload.
     type:                 'object'
     default:              {type: "object", additionalProperties: false}
 additionalProperties:     false

--- a/services/hooks/schemas/v1/hook-definition.yml
+++ b/services/hooks/schemas/v1/hook-definition.yml
@@ -17,6 +17,11 @@ properties:
       a task definition that is submitted to the Queue service.
     type:                 object
   triggerSchema:
+    description: |
+      JSON Schema used to validate payloads supplied when firing the hook.
+      API calls and webhooks are rejected when their payloads fail validation.
+      Pulse messages that match the hook's bindings are discarded without
+      creating a task when their payloads fail validation.
     type:                 object
 additionalProperties:     false
 required:

--- a/services/hooks/src/api.js
+++ b/services/hooks/src/api.js
@@ -7,6 +7,7 @@ import _ from 'lodash';
 import Ajv from 'ajv';
 import addFormats from 'ajv-formats';
 import { hookUtils } from './utils.js';
+import { validateTriggerPayload } from './trigger-schema.js';
 
 export const AUDIT_ENTRY_TYPE = Object.freeze({
   HOOK: {
@@ -639,9 +640,6 @@ builder.declare(
  * Common implementation of triggerHook and triggerHookWithToken
  */
 const triggerHookCommon = async function ({ res, hook, payload, clientId, firedBy }) {
-  const ajv = new Ajv.default({ validateFormats: true, verbose: true, allErrors: true });
-  addFormats(ajv);
-
   const context = { firedBy, payload };
   if (clientId) {
     context.clientId = clientId;
@@ -649,13 +647,10 @@ const triggerHookCommon = async function ({ res, hook, payload, clientId, firedB
   let resp;
   let error;
 
-  //Using ajv lib to check if the context respect the triggerSchema
-  const validate = ajv.compile(hook.triggerSchema);
-
-  const valid = validate(payload);
-  if (!valid) {
+  const validationError = validateTriggerPayload(hook.triggerSchema, payload);
+  if (validationError) {
     return res.reportError('InputError', '{{message}}', {
-      message: ajv.errorsText(validate.errors, { separator: '; ' }),
+      message: validationError,
     });
   }
 

--- a/services/hooks/src/listeners.js
+++ b/services/hooks/src/listeners.js
@@ -3,6 +3,9 @@ import pulse from '@taskcluster/lib-pulse';
 import pSynchronize from 'p-synchronize';
 import _ from 'lodash';
 import { queueUtils, hookUtils } from './utils.js';
+import { validateTriggerPayload } from './trigger-schema.js';
+
+const DISCARD_LOG_INTERVAL = 100;
 
 /**
  * Create pulse client and consumers to trigger hooks with pulse messages
@@ -79,6 +82,7 @@ class HookListeners {
     this.monitor.debug(`${queueName}: creating listener (and queue if necessary)`);
 
     const client = this.client;
+    let triggerSchemaDiscards = 0;
     const listener = await pulse.consume(
       {
         client,
@@ -87,10 +91,31 @@ class HookListeners {
         // we manage bindings manually in syncBindings
         bindings: [],
       },
-      async ({ payload }) => {
+      async ({ exchange, routingKey, payload }) => {
         // Get a fresh copy of the hook and fire it, if it still exists
         const latestHook = hookUtils.fromDbRows(await this.db.fns.get_hook(hookGroupId, hookId));
         if (latestHook) {
+          const validationError = validateTriggerPayload(latestHook.triggerSchema, payload);
+          if (validationError) {
+            triggerSchemaDiscards += 1;
+            this.monitor.count('fire.pulseMessage.triggerSchemaInvalid');
+
+            if (triggerSchemaDiscards === 1 || triggerSchemaDiscards % DISCARD_LOG_INTERVAL === 0) {
+              this.monitor.log.hookPulseMessageDiscarded({
+                hookGroupId,
+                hookId,
+                exchange,
+                routingKey,
+                reason: 'triggerSchema',
+                validationError,
+                discardedCount: triggerSchemaDiscards,
+                message: 'Pulse message discarded because payload does not match hook triggerSchema',
+              });
+            }
+
+            return;
+          }
+
           try {
             await this.taskcreator.fire(latestHook, { firedBy: 'pulseMessage', payload });
           } catch {

--- a/services/hooks/src/monitor.js
+++ b/services/hooks/src/monitor.js
@@ -21,3 +21,25 @@ MonitorManager.register({
     result: '"success" (task created), "failure" (task not created), or "declined" (hook did not generate a task)"',
   },
 });
+
+MonitorManager.register({
+  name: 'hookPulseMessageDiscarded',
+  title: 'A pulse message for a hook was discarded',
+  type: 'hook-pulse-message-discarded',
+  version: 1,
+  level: 'notice',
+  description: `
+    A pulse message matched a hook's bindings, but was discarded before
+    firing the hook. This log type is sampled to avoid being noisy.
+  `,
+  fields: {
+    hookGroupId: 'The group ID of the hook that matched the pulse message',
+    hookId: 'The ID of the hook that matched the pulse message',
+    exchange: 'The pulse exchange that delivered the message',
+    routingKey: 'The pulse routing key that delivered the message',
+    reason: 'The reason the pulse message was discarded',
+    validationError: 'The triggerSchema validation error that caused the discard',
+    discardedCount: 'Number of pulse messages discarded by this listener for this reason since it was created',
+    message: 'A short human-readable description of the discard',
+  },
+});

--- a/services/hooks/src/trigger-schema.js
+++ b/services/hooks/src/trigger-schema.js
@@ -1,0 +1,9 @@
+import Ajv from 'ajv';
+import addFormats from 'ajv-formats';
+
+export const validateTriggerPayload = (triggerSchema, payload) => {
+  const ajv = new Ajv.default({ validateFormats: true, verbose: true, allErrors: true });
+  addFormats(ajv);
+  const validate = ajv.compile(triggerSchema);
+  return validate(payload) ? null : ajv.errorsText(validate.errors, { separator: '; ' });
+};

--- a/services/hooks/test/listeners_test.js
+++ b/services/hooks/test/listeners_test.js
@@ -16,7 +16,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], (mock, skipping) => {
   const hookId = 'h';
 
   const makeHookEntities = async (...hooks) => {
-    for (const { hookId, bindings } of hooks) {
+    for (const { hookId, bindings, triggerSchema = {} } of hooks) {
       await helper.db.fns.create_hook(
         hookGroupId,
         hookId,
@@ -27,7 +27,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], (mock, skipping) => {
         helper.db.encrypt({ value: Buffer.from(taskcluster.slugid(), 'utf8') }) /* encrypted_trigger_token */,
         helper.db.encrypt({ value: Buffer.from(taskcluster.slugid(), 'utf8') }) /* encrypted_next_task_id */,
         taskcluster.fromNow('1 day') /* next_scheduled_date */,
-        {} /* trigger_schema */
+        triggerSchema /* trigger_schema */
       );
     }
   };
@@ -327,6 +327,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], (mock, skipping) => {
 
   suite('firing hooks', () => {
     let hookListeners;
+    let monitor;
 
     suiteSetup(function () {
       if (skipping()) {
@@ -338,6 +339,16 @@ helper.secrets.mockSuite(testing.suiteName(), [], (mock, skipping) => {
       // force-reload the listeners component for each test
       helper.load.remove('listeners');
       hookListeners = await helper.load('listeners');
+      monitor = await helper.load('monitor');
+      monitor.manager.reset();
+    });
+
+    teardown(async () => {
+      // stop this test's consumers so they don't stay registered on the shared
+      // fake pulse client and receive messages sent by later tests
+      for (const listener of Object.values(hookListeners.listeners ?? {})) {
+        await listener.stop();
+      }
     });
 
     test('triggers hook with a pulse message', async () => {
@@ -359,6 +370,111 @@ helper.secrets.mockSuite(testing.suiteName(), [], (mock, skipping) => {
           options: {},
         },
       ]);
+    });
+
+    test('discards pulse message when hook has the default triggerSchema', async () => {
+      // Default is defined in ../schemas/v1/create-hook-request.yml#L36
+      await makeHookEntities({
+        hookId,
+        bindings: [{ exchange: 'e', routingKeyPattern: 'rkp' }],
+        triggerSchema: { type: 'object', additionalProperties: false },
+      });
+      await hookListeners.reconcileConsumers();
+
+      await helper.fakePulseMessage({
+        exchange: 'e',
+        routingKey: 'rkp',
+        routes: [],
+        payload: { action: 'opened' },
+      });
+
+      assume(helper.creator.fireCalls).deep.equals([]);
+      assert.equal(monitor.manager.messages.filter(({ Type }) => Type === 'hook-pulse-message-discarded').length, 1);
+    });
+
+    test('triggers hook with a pulse message matching triggerSchema', async () => {
+      await makeHookEntities({
+        hookId,
+        bindings: [{ exchange: 'e', routingKeyPattern: 'rkp' }],
+        triggerSchema: {
+          type: 'object',
+          properties: {
+            action: {
+              enum: ['opened'],
+            },
+          },
+          required: ['action'],
+          additionalProperties: true,
+        },
+      });
+      await hookListeners.reconcileConsumers();
+
+      await helper.fakePulseMessage({
+        exchange: 'e',
+        routingKey: 'rkp',
+        routes: [],
+        payload: { action: 'opened' },
+      });
+
+      assume(helper.creator.fireCalls).deep.equals([
+        {
+          hookGroupId,
+          hookId,
+          context: { firedBy: 'pulseMessage', payload: { action: 'opened' } },
+          options: {},
+        },
+      ]);
+      assert.equal(monitor.manager.messages.filter(({ Type }) => Type === 'hook-pulse-message-discarded').length, 0);
+    });
+
+    test('discards pulse messages failing triggerSchema', async () => {
+      await makeHookEntities({
+        hookId,
+        bindings: [{ exchange: 'e', routingKeyPattern: 'rkp' }],
+        triggerSchema: {
+          type: 'object',
+          properties: {
+            action: {
+              enum: ['opened'],
+            },
+          },
+          required: ['action'],
+          additionalProperties: true,
+        },
+      });
+      await hookListeners.reconcileConsumers();
+
+      for (let i = 0; i < 2; i++) {
+        await helper.fakePulseMessage({
+          exchange: 'e',
+          routingKey: 'rkp',
+          routes: [],
+          payload: { action: 'closed' },
+        });
+      }
+
+      assume(helper.creator.fireCalls).deep.equals([]);
+
+      assert.equal(
+        monitor.manager.messages.filter(
+          ({ Type, Fields }) => Type === 'monitor.count' && Fields.key === 'fire.pulseMessage.triggerSchemaInvalid'
+        ).length,
+        2
+      );
+
+      const discardLogs = monitor.manager.messages.filter(({ Type }) => Type === 'hook-pulse-message-discarded');
+      assert.equal(discardLogs.length, 1);
+      assert.deepEqual(discardLogs[0].Fields, {
+        v: 1,
+        hookGroupId,
+        hookId,
+        exchange: 'e',
+        routingKey: 'rkp',
+        reason: 'triggerSchema',
+        validationError: 'data/action must be equal to one of the allowed values',
+        discardedCount: 1,
+        message: 'Pulse message discarded because payload does not match hook triggerSchema',
+      });
     });
 
     test('does nothing if the hook is gone', async () => {

--- a/services/hooks/test/trigger_schema_test.js
+++ b/services/hooks/test/trigger_schema_test.js
@@ -1,0 +1,24 @@
+import assert from 'node:assert';
+import testing from '@taskcluster/lib-testing';
+import { validateTriggerPayload } from '../src/trigger-schema.js';
+
+suite(testing.suiteName(), () => {
+  const triggerSchema = {
+    type: 'object',
+    properties: {
+      action: {
+        enum: ['opened'],
+      },
+    },
+    required: ['action'],
+    additionalProperties: true,
+  };
+
+  test('accepts payloads matching triggerSchema', () => {
+    assert.equal(validateTriggerPayload(triggerSchema, { action: 'opened' }), null);
+  });
+
+  test('returns an error for payloads failing triggerSchema', () => {
+    assert.match(validateTriggerPayload(triggerSchema, { action: 'closed' }), /data\/action/);
+  });
+});

--- a/ui/docs/reference/core/hooks/README.mdx
+++ b/ui/docs/reference/core/hooks/README.mdx
@@ -22,7 +22,9 @@ By default, the new task has a `taskGroupId` equal to its `taskId`, as is the co
 
 ### Trigger Schema
 
-When a hook is triggered by an API call or a webhook, the user-provided payload is validated against the hook's `triggerSchema`, and the call rejected if validation fails.
+When a hook is triggered by an API call, webhook, or Pulse message, the provided payload is validated against the hook's `triggerSchema`.
+API calls and webhooks are rejected if validation fails; matching Pulse messages are discarded without creating a task.
+A hook that does not define a `triggerSchema` uses the default schema, which only accepts an empty payload, so such a hook will not fire on Pulse messages that carry a payload.
 This provides a reliable way of limiting allowed inputs and ensuring that incorrect inputs do not cause unexpected behavior.
 
 ### Schedule
@@ -37,6 +39,7 @@ For example:
 
 Hooks have a `bindings` property that gives a list of exchanges and routing-key patterns.
 The hooks service binds queues accordingly, and triggers a hook for each message received, with the message body as its payload.
+The message payload must also match the hook's `triggerSchema`, or the message is discarded without creating a task.
 
 ### JSON-e
 

--- a/ui/docs/reference/core/hooks/firing-hooks.mdx
+++ b/ui/docs/reference/core/hooks/firing-hooks.mdx
@@ -90,8 +90,13 @@ The context is similar to that for `triggerHook`:
 
 ### Pulse Messages
 
-When a pulse message arrives that matches the bindings for a hook, the hook's
-task payload is rendered with the following context:
+When a pulse message arrives that matches the bindings for a hook, the payload
+is validated against the hook's `triggerSchema`. If validation fails, the
+message is discarded without creating a task. A hook that does not define a
+`triggerSchema` uses the default schema, which only accepts an empty payload,
+so such a hook will not fire on Pulse messages that carry a payload. If
+validation succeeds, the hook's task payload is rendered with the following
+context:
 
 ```
 {


### PR DESCRIPTION
feat(hooks): triggerSchema is used against Pulse payloads before creating a task

this brings parity between direct hook invocation and pulse-triggered
events. `triggerSchema` enforces both paths, and if hook payload fails
validation, no tasks will be created.

If hook was created with default triggerSchema (additionalProperties:
false) it would likely fail now, hook owners would need to update it

Fixes #8867

this is a breaking change, and there are some hooks that needs closer look before this goes live
high risk candidates are `hg-push/*` hooks