### PR TITLE
Worker Runner (Windows): wait for Windows Setup completion on start up

### DIFF
--- a/changelog/worker-runner-windows-image-state.md
+++ b/changelog/worker-runner-windows-image-state.md
@@ -1,0 +1,7 @@
+level: minor
+audience: worker-deployers
+---
+Worker-runner can now wait for Windows Sysprep and OOBE to complete before it
+registers with worker-manager or starts the worker. Set
+`waitForWindowsImageState: true` in the runner configuration to prevent tasks
+from being claimed before a first-launch OOBE reboot.

--- a/tools/worker-runner/cfg/runnerconfig.go
+++ b/tools/worker-runner/cfg/runnerconfig.go
@@ -11,12 +11,13 @@ import (
 // RunnerConfig defines the configuration for taskcluster-worker-starter.  See the usage
 // string for field descriptions
 type RunnerConfig struct {
-	Provider             ProviderConfig             `yaml:"provider"`
-	WorkerImplementation WorkerImplementationConfig `yaml:"worker"`
-	WorkerConfig         *WorkerConfig              `yaml:"workerConfig"`
-	Logging              *LoggingConfig             `yaml:"logging"`
-	GetSecrets           bool                       `yaml:"getSecrets"`
-	CacheOverRestarts    string                     `yaml:"cacheOverRestarts"`
+	Provider                 ProviderConfig             `yaml:"provider"`
+	WorkerImplementation     WorkerImplementationConfig `yaml:"worker"`
+	WorkerConfig             *WorkerConfig              `yaml:"workerConfig"`
+	Logging                  *LoggingConfig             `yaml:"logging"`
+	GetSecrets               bool                       `yaml:"getSecrets"`
+	CacheOverRestarts        string                     `yaml:"cacheOverRestarts"`
+	WaitForWindowsImageState bool                       `yaml:"waitForWindowsImageState"`
 }
 
 // LoadRunnerConfig loads a worker-runner configuration file.

--- a/tools/worker-runner/cfg/runnerconfig_test.go
+++ b/tools/worker-runner/cfg/runnerconfig_test.go
@@ -40,6 +40,7 @@ func TestLoadConfig(t *testing.T) {
 	assert.Equal(t, "ec2", runnercfg.Provider.ProviderType, "should read providerType correctly")
 	assert.Equal(t, 10.0, runnercfg.WorkerConfig.MustGet("x"), "should read workerConfig correctly")
 	assert.Equal(t, true, runnercfg.GetSecrets, "getSecrets should default to true")
+	assert.True(t, runnercfg.WaitForWindowsImageState, "waitForWindowsImageState should be read correctly")
 }
 
 // TestLoadConfig_InsecurePerms verifies that LoadRunnerConfig tightens the

--- a/tools/worker-runner/cfg/test-config.yml
+++ b/tools/worker-runner/cfg/test-config.yml
@@ -1,4 +1,5 @@
 provider:
     providerType: 'ec2'
+waitForWindowsImageState: true
 workerConfig:
     x: 10

--- a/tools/worker-runner/runner/image_state.go
+++ b/tools/worker-runner/runner/image_state.go
@@ -1,0 +1,21 @@
+package runner
+
+import "log"
+
+const imageStateComplete = "IMAGE_STATE_COMPLETE"
+
+func waitForImageStateComplete(readImageState func() (string, error), wait func()) {
+	for {
+		imageState, err := readImageState()
+		if err != nil {
+			log.Printf("Could not read Windows image state: %v; retrying", err)
+		} else if imageState == imageStateComplete {
+			log.Printf("Windows image state is %s", imageStateComplete)
+			return
+		} else {
+			log.Printf("Windows image state is %q; waiting for %s", imageState, imageStateComplete)
+		}
+
+		wait()
+	}
+}

--- a/tools/worker-runner/runner/image_state_other.go
+++ b/tools/worker-runner/runner/image_state_other.go
@@ -1,0 +1,5 @@
+//go:build !windows
+
+package runner
+
+func waitForWindowsImageState() {}

--- a/tools/worker-runner/runner/image_state_test.go
+++ b/tools/worker-runner/runner/image_state_test.go
@@ -1,0 +1,33 @@
+package runner
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestWaitForImageStateComplete(t *testing.T) {
+	results := []struct {
+		state string
+		err   error
+	}{
+		{err: errors.New("registry key is not available yet")},
+		{state: "IMAGE_STATE_UNDEPLOYABLE"},
+		{state: "IMAGE_STATE_SPECIALIZE_RESEAL_TO_OOBE"},
+		{state: imageStateComplete},
+	}
+
+	reads := 0
+	waits := 0
+	waitForImageStateComplete(func() (string, error) {
+		result := results[reads]
+		reads++
+		return result.state, result.err
+	}, func() {
+		waits++
+	})
+
+	require.Equal(t, len(results), reads)
+	require.Equal(t, len(results)-1, waits)
+}

--- a/tools/worker-runner/runner/image_state_windows.go
+++ b/tools/worker-runner/runner/image_state_windows.go
@@ -1,0 +1,32 @@
+//go:build windows
+
+package runner
+
+import (
+	"time"
+
+	"golang.org/x/sys/windows/registry"
+)
+
+const windowsSetupStateKey = `SOFTWARE\Microsoft\Windows\CurrentVersion\Setup\State`
+
+func readWindowsImageState() (string, error) {
+	key, err := registry.OpenKey(
+		registry.LOCAL_MACHINE,
+		windowsSetupStateKey,
+		registry.QUERY_VALUE|registry.WOW64_64KEY,
+	)
+	if err != nil {
+		return "", err
+	}
+	defer key.Close()
+
+	imageState, _, err := key.GetStringValue("ImageState")
+	return imageState, err
+}
+
+func waitForWindowsImageState() {
+	waitForImageStateComplete(readWindowsImageState, func() {
+		time.Sleep(10 * time.Second)
+	})
+}

--- a/tools/worker-runner/runner/run.go
+++ b/tools/worker-runner/runner/run.go
@@ -31,6 +31,10 @@ func Run(configFile string) (state run.State, err error) {
 
 	logging.Configure(runnercfg)
 
+	if runnercfg.WaitForWindowsImageState {
+		waitForWindowsImageState()
+	}
+
 	runCached := false
 	if runnercfg.CacheOverRestarts != "" {
 		runCached, err = run.ReadCacheFile(&state, runnercfg.CacheOverRestarts)

--- a/tools/worker-runner/runner/usage.go
+++ b/tools/worker-runner/runner/usage.go
@@ -40,6 +40,13 @@ the following fields:
   implementations that restart the system as part of their normal operation
   and expect to start up with the same config after a restart.
 
+* |waitForWindowsImageState|: if true, then on Windows the runner waits until
+  the Sysprep image state in the Windows Setup registry is
+  |IMAGE_STATE_COMPLETE| before contacting worker-manager or starting the
+  worker.  Registry read errors are retried.  This is useful for cloud images
+  where OOBE may reboot the system during its first launch.  This setting has
+  no effect on other operating systems and defaults to false.
+
 **NOTE** for Windows users: the configuration file must be a UNIX-style text file.
 DOS-style newlines and encodings other than utf-8 are not supported.`, "|", "`")
 }

--- a/ui/docs/reference/workers/generic-worker/installing.mdx
+++ b/ui/docs/reference/workers/generic-worker/installing.mdx
@@ -154,6 +154,7 @@ launches generic-worker (set to demand-start) when work is available.
     ```yaml
     provider:
         providerType: azure  # or: aws, google
+   waitForWindowsImageState: true
     worker:
         implementation: generic-worker
         service: "Generic Worker"
@@ -161,6 +162,10 @@ launches generic-worker (set to demand-start) when work is available.
         protocolPipe: \\.\pipe\generic-worker
     cacheOverRestarts: C:\generic-worker\start-worker-cache.json
     ```
+
+   `waitForWindowsImageState` prevents worker-runner from registering or
+   starting generic-worker until Windows reports that Sysprep and OOBE have
+   completed. This avoids claiming work before a first-launch OOBE reboot.
 
     For a __static worker__ (pre-provisioned machine registered with
     worker-manager):

--- a/ui/docs/reference/workers/worker-runner/runner-configuration.mdx
+++ b/ui/docs/reference/workers/worker-runner/runner-configuration.mdx
@@ -47,6 +47,13 @@ the following fields:
   implementations that restart the system as part of their normal operation
   and expect to start up with the same config after a restart.
 
+* `waitForWindowsImageState`: if true, then on Windows the runner waits until
+  the Sysprep image state in the Windows Setup registry is
+  `IMAGE_STATE_COMPLETE` before contacting worker-manager or starting the
+  worker.  Registry read errors are retried.  This is useful for cloud images
+  where OOBE may reboot the system during its first launch.  This setting has
+  no effect on other operating systems and defaults to false.
+
 **NOTE** for Windows users: the configuration file must be a UNIX-style text file.
 DOS-style newlines and encodings other than utf-8 are not supported.
 {/* RUNNER-CONFIG END */}


### PR DESCRIPTION
## Summary

Adds an optional worker-runner startup gate that prevents Windows workers
from registering with worker-manager or accepting work before Windows Setup
has completed the Sysprep `specialize` and OOBE sequence.

Set the following in the worker-runner configuration to enable it:

```yaml
waitForWindowsImageState: true
```

The option is provider-independent and can be used for Windows workers on
AWS, Azure, Google Cloud, or other supported providers.

## Symptoms of the issue this fixes

Windows workers claimed their first task and resulted in CLAIM_EXPIRED frequently, subsequent tasks had no such issue. Said second task would generally start well before the CLAIM ended up actually expiring, suggesting a reboot of the system.

## Root cause

A generalized Windows image can start automatic services while Windows Setup
is still processing its first-boot configuration.

During an observed EC2 first launch, Windows progressed through these image
states:

```text
IMAGE_STATE_GENERALIZE_RESEAL_TO_OOBE
-> IMAGE_STATE_UNDEPLOYABLE
-> IMAGE_STATE_SPECIALIZE_RESEAL_TO_OOBE
-> restart
-> IMAGE_STATE_UNDEPLOYABLE
-> IMAGE_STATE_COMPLETE
```

The Worker Runner service started while the image was
`IMAGE_STATE_UNDEPLOYABLE` or
`IMAGE_STATE_SPECIALIZE_RESEAL_TO_OOBE`. It registered the instance with
worker-manager, allowing Generic Worker to claim a task before Windows
performed the planned Setup restart. The restart then interrupted the task.

The restart was requested by the Windows Setup `specialize` pass and was not
caused by Windows Update or an unexpected operating-system failure.

## Changes

When `waitForWindowsImageState` is enabled, worker-runner now:

- Reads the 64-bit Windows Setup registry value at:

  ```text
  HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Setup\State\ImageState
  ```

- Polls every 10 seconds until the value is:

  ```text
  IMAGE_STATE_COMPLETE
  ```

- Retries registry-read failures rather than allowing the worker to start
  prematurely.
- Performs the check before loading cached runner state, configuring the cloud
  provider, registering with worker-manager, retrieving secrets, or starting
  the worker.
- Leaves existing behavior unchanged by default.
- Treats the setting as a no-op on non-Windows systems.

The polling logic is separated from the Windows registry implementation so it
can be unit tested without requiring a Windows host.

## Expected result

A newly launched generalized Windows instance may still perform its normal,
planned Setup restart.

However, worker-runner will not register the instance or start Generic Worker
until Windows reports `IMAGE_STATE_COMPLETE`. Tasks therefore cannot be
claimed during the first-boot Setup sequence and interrupted by its restart.

## Validation

- [x] Added a unit test covering registry-read errors and intermediate Setup
      states before `IMAGE_STATE_COMPLETE`.
- [x] Verified runner configuration parsing.
- [x] Ran `go test ./tools/worker-runner/...`.
- [x] Ran `go vet ./tools/worker-runner/...`.
- [x] Cross-compiled the runner test package for Windows.

## Not Done

- I have no tested this worker runner go binary on my Windows Workers directly, as our deployment story is strictly tied to taskcluster release versions

## Extra Reviewer Notes
- This code was primarily generated via AI-Assisted-Development using GitHub Copilot with GPT-5.6 Sol.
- I am not a skilled go developer, and have barely done go work, please validate against best practices that my AI tools didn't follow.