### PR TITLE
Bug 2056592 - Fix auth role modification silently ignoring write conflicts

### DIFF
--- a/changelog/bug-2056592.md
+++ b/changelog/bug-2056592.md
@@ -1,0 +1,6 @@
+audience: users
+level: patch
+reference: bug 2056592
+---
+Fixed a bug in the auth service where a concurrent modification conflict while
+creating, updating, or deleting a role was silently reported as success

--- a/services/auth/src/data.js
+++ b/services/auth/src/data.js
@@ -17,13 +17,13 @@ export const modifyRoles = async (db, modifier) => {
       });
       await modifier({ roles });
       await db.fns.modify_roles(JSON.stringify(roles), etag);
+      return; // success!
     } catch (e) {
       // P0004 means there was a conflict, so try again
       if (e.code !== 'P0004') {
         throw e;
       }
     }
-    return; // success!
   }
 
   throw new Error('Could not modify roles; too many conflicts');

--- a/services/auth/test/modifyRoles_test.js
+++ b/services/auth/test/modifyRoles_test.js
@@ -1,0 +1,60 @@
+import assert from 'node:assert';
+import testing from '@taskcluster/lib-testing';
+import { modifyRoles } from '../src/data.js';
+
+suite(testing.suiteName(), () => {
+  const conflict = () => Object.assign(new Error('unsuccessful update'), { code: 'P0004' });
+
+  const fakeDb = modify_roles => ({
+    fns: {
+      get_roles: async () => [],
+      modify_roles,
+    },
+  });
+
+  test('retries after a conflict', async () => {
+    let writes = 0;
+    let modifierCalls = 0;
+    const db = fakeDb(async () => {
+      if (writes++ === 0) {
+        throw conflict();
+      }
+    });
+
+    await modifyRoles(db, () => {
+      modifierCalls++;
+    });
+
+    assert.equal(modifierCalls, 2, 'modifier should rerun after a conflict');
+    assert.equal(writes, 2);
+  });
+
+  test('rejects when the conflict never resolves', async () => {
+    let modifierCalls = 0;
+    const db = fakeDb(async () => {
+      throw conflict();
+    });
+
+    await assert.rejects(
+      () =>
+        modifyRoles(db, () => {
+          modifierCalls++;
+        }),
+      /too many conflicts/
+    );
+
+    assert.equal(modifierCalls, 5, 'modifier should have been run once per try');
+  });
+
+  test('does not retry or swallow other errors', async () => {
+    let writes = 0;
+    const db = fakeDb(async () => {
+      writes++;
+      throw new Error('Got a croissant when I expected a baguette');
+    });
+
+    await assert.rejects(() => modifyRoles(db, () => {}), /Got a croissant when I expected a baguette/);
+
+    assert.equal(writes, 1);
+  });
+});


### PR DESCRIPTION
`modifyRoles` placed a `return` within its retry loop right after the `try/catch` block that handles whether or not it should retry which means it never did. That means that if it ever had conflicted (P0004 from the database), it would throw in `db.fns.modify_roles`, ignore the error in the `catch`, and then return as if it succeeded instead of looping and trying again. Which means that a role that got removed or modified would stay as it was before but reported to the client as having changed. On top of the state not changing, the caller for `modifyRoles` inserts an audit event that now might not match what actually happened (or didn't).

While not ideal, in practice this is fairly meaningless since the state isn't cached but re-read from database all the time. So any role modification that would've hit this didn't get modified/deleted but stayed as is in database, which means they would just not show as modified/deleted in the UI/API and since all modifications are made through tooling that resolves states based on differences, it would resolve eventually.

The bug was introduced in 3fd060c69c265ecbdf1ef6e6690906dd453c2f5b when the roles moved from the azure style entity tables to a regular postgres one and this commit reverts the behavior to the previous one with the exception that it returns a 500 instead of a 409 when it can't resolve a conflict. Fixing that is unfortunately not entirely trivial and is probably not worth the hassle. I'd rather have it start failing loudly if it does and try fixing the conflict source rather than forcing clients to retry things in the hope that it eventually maybe resolves when stars align.
