### PR TITLE
Bug 2056597 - Fix worker panic when declaring a directory artifact with an absolute path

### DIFF
--- a/changelog/bug-2056597.md
+++ b/changelog/bug-2056597.md
@@ -1,0 +1,5 @@
+audience: users
+level: patch
+reference: bug 2056597
+---
+Fixed a worker panic when declaring a directory artifact as an absolute path

--- a/workers/generic-worker/artifact_feature.go
+++ b/workers/generic-worker/artifact_feature.go
@@ -186,13 +186,9 @@ func (atf *ArtifactTaskFeature) FindArtifacts() {
 				payloadArtifacts = append(payloadArtifacts, errArtifact)
 				break
 			}
+			absBasePath := fileutil.AbsFrom(taskDir, basePath)
 			walkFn := func(path string, d os.DirEntry, incomingErr error) error {
-				subPath, err := filepath.Rel(taskDir, path)
-				if err != nil {
-					// this indicates a bug in the code
-					panic(err)
-				}
-				relativePath, err := filepath.Rel(basePath, subPath)
+				relativePath, err := filepath.Rel(absBasePath, path)
 				if err != nil {
 					// this indicates a bug in the code
 					panic(err)
@@ -213,28 +209,27 @@ func (atf *ArtifactTaskFeature) FindArtifacts() {
 				// cause the task to fail, and the cause to be preserved in the
 				// error artifact.
 				case incomingErr != nil:
-					fullPath := fileutil.AbsFrom(taskDir, subPath)
 					payloadArtifacts = append(
 						payloadArtifacts,
 						&artifacts.ErrorArtifact{
 							BaseArtifact: b,
-							Message:      fmt.Sprintf("Error processing file '%s' as artifact: %s", fullPath, incomingErr),
+							Message:      fmt.Sprintf("Error processing file '%s' as artifact: %s", path, incomingErr),
 							Reason:       "invalid-resource-on-worker",
-							Path:         subPath,
+							Path:         path,
 						},
 					)
 				case d.IsDir():
-					if errArtifact := resolve(b, "directory", subPath, artifact.ContentType, artifact.ContentEncoding, task.pd, taskDir); errArtifact != nil {
+					if errArtifact := resolve(b, "directory", path, artifact.ContentType, artifact.ContentEncoding, task.pd, taskDir); errArtifact != nil {
 						payloadArtifacts = append(payloadArtifacts, errArtifact)
 					}
 				default:
-					payloadArtifacts = append(payloadArtifacts, resolve(b, "file", subPath, artifact.ContentType, artifact.ContentEncoding, task.pd, taskDir))
+					payloadArtifacts = append(payloadArtifacts, resolve(b, "file", path, artifact.ContentType, artifact.ContentEncoding, task.pd, taskDir))
 				}
 				return nil
 			}
 			// Any error returned here should already have been handled by
 			// walkFn, so should be safe to ignore.
-			_ = filepath.WalkDir(fileutil.AbsFrom(taskDir, basePath), walkFn)
+			_ = filepath.WalkDir(absBasePath, walkFn)
 		}
 		artifactsChan <- payloadArtifacts
 	}

--- a/workers/generic-worker/artifacts_test.go
+++ b/workers/generic-worker/artifacts_test.go
@@ -1234,3 +1234,49 @@ func TestFileArtifactUploadFromAbsolutePath(t *testing.T) {
 		t.Fatalf("Artifact content mismatch: expected %d bytes, got %d bytes", len(expectedData), len(actualData))
 	}
 }
+
+func TestDirectoryArtifactUploadFromAbsolutePath(t *testing.T) {
+	setup(t)
+	absDir := worldWritableTempDir(t, t.Name())
+	nestedFile := filepath.Join(absDir, "sub", "nested.jpg")
+
+	payload := GenericWorkerPayload{
+		Command:    copyTestdataFileTo("SampleArtifacts/b/c/d.jpg", nestedFile),
+		MaxRunTime: 30,
+		Artifacts: []Artifact{
+			{
+				Path:    absDir,
+				Expires: inAnHour,
+				Type:    "directory",
+				Name:    "public/abs-dir",
+			},
+		},
+	}
+	defaults.SetDefaults(&payload)
+	td := testTask(t)
+
+	taskID := submitAndAssert(t, td, payload, "completed", "completed")
+
+	expectedArtifacts := ExpectedArtifacts{
+		"public/abs-dir/sub/nested.jpg": {
+			ContentType:      "image/jpeg",
+			ContentLength:    17,
+			Expires:          inAnHour,
+			StorageType:      "s3",
+			SkipContentCheck: true,
+		},
+		"public/logs/live_backing.log": {
+			ContentType:      "text/plain; charset=utf-8",
+			ContentEncoding:  "gzip",
+			Expires:          td.Expires,
+			SkipContentCheck: true,
+		},
+		"public/logs/live.log": {
+			ContentType:      "text/plain; charset=utf-8",
+			ContentEncoding:  "gzip",
+			Expires:          td.Expires,
+			SkipContentCheck: true,
+		},
+	}
+	expectedArtifacts.Validate(t, taskID, 0)
+}


### PR DESCRIPTION
A task declaring a `directory` artifact with an absolute path was triggering a panic during artifacts collection because we ended up calling `filepath.Rel(absPathDeclaredInTask, relPathFromTaskDir)` which errored out since it makes no sense to try and find the relative path between an absolute path and a relative path (relative to what?). The walk then treated that error as a bug and panicked with a message along the line of `Rel: can't make ../foo/bar relative to /tmp/foo`, taking down the worker process.

Instead we now resolve the original path to an absolute one (even when it's declared as relative in the task) and then use the absolute path given to us by the walk function to compute the relative path. Since the call always ends up being between 2 absolute paths, it cannot fail.

Because we're now using absolute paths we can also get rid of the first `subPath` calculation which funnily enough fixes a similar panic that would've been exposed by not panicking in the other place if the task directory and the artifact path were on different volumes as `Rel` fails to calculate cross volume relative paths as is somehow not described in filepath documentation. (see
https://cs.opensource.google/go/go/+/refs/tags/go1.26.5:src/path/filepath/path.go;l=205 if you want an explanation as to why it fails and enjoy reading stdlib internals instead of what should actually be documentation)