### PR TITLE
Fix expired client purge recording a 'created' audit entry

### DIFF
--- a/changelog/HLbEt32VQKGZtDELPlw_Dg.md
+++ b/changelog/HLbEt32VQKGZtDELPlw_Dg.md
@@ -1,0 +1,5 @@
+audience: users
+level: patch
+---
+Fixed a bug in the auth service where purging an expired client recorded the
+deletion in the audit history as `created` instead of `expired`

--- a/services/auth/src/main.js
+++ b/services/auth/src/main.js
@@ -247,7 +247,7 @@ const load = Loader(
               action: AUDIT_ENTRY_TYPE.CLIENT.EXPIRED,
             });
 
-            await db.fns.insert_auth_audit_history(name, 'client', clientId, AUDIT_ENTRY_TYPE.CLIENT.CREATED);
+            await db.fns.insert_auth_audit_history(name, 'client', clientId, AUDIT_ENTRY_TYPE.CLIENT.EXPIRED);
           }
         });
       },

--- a/services/auth/test/purgeExpiredClients_test.js
+++ b/services/auth/test/purgeExpiredClients_test.js
@@ -29,6 +29,11 @@ helper.secrets.mockSuite(testing.suiteName(), ['azure', 'gcp'], (mock, skipping)
     assume(client.clientId).to.equal(CLIENT_ID);
   };
 
+  const auditActions = async () => {
+    const rows = await helper.db.fns.get_combined_audit_history(null, CLIENT_ID, 'client', 100, 0);
+    return rows.map(({ action_type }) => action_type);
+  };
+
   const assertClientAbsent = async () => {
     try {
       await helper.apiClient.client(CLIENT_ID);
@@ -53,10 +58,13 @@ helper.secrets.mockSuite(testing.suiteName(), ['azure', 'gcp'], (mock, skipping)
 
   test('deletes expired clients with deleteOnExpiration', async () => {
     await testClient({ expires: '-1 hour', deleteOnExpiration: true });
+    const before = await auditActions();
+
     await helper.load('purge-expired-clients');
     await assertClientAbsent();
 
-    const results = await helper.db.fns.get_combined_audit_history(null, CLIENT_ID, 'client', 10, 0);
-    assume(results.map(({ action_type }) => action_type).includes('expired'));
+    const after = await auditActions();
+    // the purge must record exactly one new 'expired' audit entry
+    assume(after.filter(a => a === 'expired')).has.length(before.filter(a => a === 'expired').length + 1);
   });
 });


### PR DESCRIPTION
When purging an expired client, the code properly logged the client as expired through monitor audit events but was inserting the event as created in database.

The bug was introduced in 5a347f63e42543c5e8c0821ed5e17fcec834c1d7, probably due to a bad copy/paste, when the audit trail for purged clients was first added. So every client deleted by expiration since then has been recorded as having been created at the moment it was removed.

Unfortunately the test that was supposed to help catch this didn't because it called `assume` without any assumption added to it (`assume()` is a no-op unless called with a terminator like `.is.something`/`.includes`). The original commit probably meant `assume().includes()` but instead put the `.includes` inside of the `assume()` call, which didn't fail because `Array.includes` is also a thing and ended up resolving to `assume(false)` which did nothing.