### PR TITLE
Bug 2057491 - Fix a typo in the scope resolver assume prefix regex

### DIFF
--- a/changelog/faOXWTUMQ92ldYizjEXTQw.md
+++ b/changelog/faOXWTUMQ92ldYizjEXTQw.md
@@ -1,0 +1,7 @@
+audience: admins
+level: patch
+reference: bug 2057491
+---
+Fixed a bug in the auth service's scope resolver where the scopes `:*`, `::*`,
+`:a*`, `:as*`, `:ass*`, `:assu*`, `:assum*` and `:assume*` were expanded as if
+they were `*`

--- a/services/auth/src/scoperesolver.js
+++ b/services/auth/src/scoperesolver.js
@@ -10,7 +10,7 @@ import * as trie from './trie.js';
 import ScopeSetBuilder from './scopesetbuilder.js';
 import { consume } from '@taskcluster/lib-pulse';
 
-const ASSUME_PREFIX = /^(:?(:?|a|as|ass|assu|assum|assum|assume)\*$|assume:)/;
+const ASSUME_PREFIX = /^(?:(?:|a|as|ass|assu|assum|assume)\*$|assume:)/;
 
 /** ZeroCache is an LRU cache instance that contains nothing for caching is disabled */
 const ZeroCache = {

--- a/services/auth/test/scoperesolver_test.js
+++ b/services/auth/test/scoperesolver_test.js
@@ -226,6 +226,31 @@ suite(testing.suiteName(), () => {
       expected: ['assum*', 'A', 'B', 'C'],
     });
 
+    for (const scope of ['as*', 'ass*', 'assu*']) {
+      testResolver(`${scope} get all`, {
+        roles: [
+          { role_id: 'a', scopes: ['A'] },
+          { role_id: 'b', scopes: ['B'] },
+          { role_id: 'c', scopes: ['C'] },
+        ],
+        scopes: [scope],
+        expected: [scope, 'A', 'B', 'C'],
+      });
+    }
+
+    // See Bug 2057491
+    for (const scope of [':*', '::*', ':a*', ':as*', ':ass*', ':assu*', ':assum*', ':assume*']) {
+      testResolver(`${scope} expands nothing`, {
+        roles: [
+          { role_id: 'a', scopes: ['A'] },
+          { role_id: 'b', scopes: ['B'] },
+          { role_id: 'c', scopes: ['C'] },
+        ],
+        scopes: [scope],
+        expected: [scope],
+      });
+    }
+
     testResolver('assume:a works', {
       roles: [
         { role_id: 'a', scopes: ['A'] },


### PR DESCRIPTION
This is pretty self explanatory, the original commit meant to use `?:` (non capturing group), used `:?` (optional `:`). This means that it allowed a bunch of strings starting with `:` as being the equivalent to `assume`, which, while not doing anything on their own are just a general footgun that we don't need.