### PR TITLE
Fix scope resolve tests misparsing roles.json and silently not doing anything

### DIFF
--- a/changelog/D7LqsNyUT8i730yA-GtNug.md
+++ b/changelog/D7LqsNyUT8i730yA-GtNug.md
@@ -1,0 +1,2 @@
+level: silent
+---

--- a/services/auth/test/scoperesolver_test.js
+++ b/services/auth/test/scoperesolver_test.js
@@ -482,7 +482,10 @@ suite(testing.suiteName(), () => {
     // Test with a snapshot of real roles, captured with
     //   `curl https://auth.taskcluster.net/v1/roles > test/roles.json`
     const __dirname = dirname(fileURLToPath(import.meta.url));
-    const realRoles = JSON.parse(readFileSync(join(__dirname, 'roles.json'), 'utf8'));
+    const realRoles = JSON.parse(readFileSync(join(__dirname, 'roles.json'), 'utf8')).map(({ roleId, scopes }) => ({
+      role_id: roleId,
+      scopes,
+    }));
     const testRealRoles = (scopes, expected) => {
       testResolver(`real roles with scopes ${scopes.join(', ')}`, {
         roles: realRoles,


### PR DESCRIPTION
Found this while working on the fix for bug 2057491. Since 3fd060c69c265ecbdf1ef6e6690906dd453c2f5b, the role ID column was renamed to `role_id` on the scopes side but was still `roleId` in the roles.json dump (and in the current API). Tests in scoperesolver_test rely on parsing that dump and creating scopes out of them to actually test something and ended up instead with 600 `assume:undefined` because javascript is a perfectly cromulent language that will happily destructure non existing fields on an object to `undefined` and then format it like it's a normal Tuesday.

The fix is trivial, I just map the old `roleId` to `role_id` to fix the mismatch between what the API returns and what the role builder expects.