### PR TITLE
Make sure we throw the right error when client cert signatures have an invalid length

### DIFF
--- a/changelog/UX4wqICcStmM2ihlW63Oug.md
+++ b/changelog/UX4wqICcStmM2ihlW63Oug.md
@@ -1,0 +1,2 @@
+level: silent
+---

--- a/services/auth/src/signaturevalidator.js
+++ b/services/auth/src/signaturevalidator.js
@@ -168,6 +168,7 @@ const limitClientWithExt = (credentialName, issuingClientId, accessToken, scopes
     // Validate signature
     if (
       typeof cert.signature !== 'string' ||
+      Buffer.byteLength(cert.signature) !== Buffer.byteLength(signature) ||
       !crypto.timingSafeEqual(Buffer.from(cert.signature), Buffer.from(signature))
     ) {
       if (cert.issuer) {

--- a/services/auth/test/signaturevalidator_test.js
+++ b/services/auth/test/signaturevalidator_test.js
@@ -685,6 +685,23 @@ suite(testing.suiteName(), () => {
   );
 
   testWithTemp(
+    'invalid: signature too short for temp creds',
+    {
+      id: 'root',
+    },
+    (id, key, certificate) => {
+      certificate.signature = 'baguette';
+      return {
+        authorization: {
+          credentials: { id, key },
+          ext: { certificate },
+        },
+      };
+    },
+    failed('ext.certificate.signature is not valid')
+  );
+
+  testWithTemp(
     'invalid: temp scopes not satisfied by issuing client',
     {
       id: 'unpriv',


### PR DESCRIPTION
`crypto.timingSafeEqual` throws when the inputs are not the same length which with a message that bubbles back up all the way to the user with `Input buffers must have the same byte length` instead of `ext.certificate.signature is not valid`. The length is known in advance so this doesn't change anything security wise but it changes the categorization we make for metrics in that case from `other` to `invalid_signature` and gives a better error message to the user.