### PR TITLE
Fix the renderTaskclusterYml endpoint to return 400 instead of 500 on templating errors

### DIFF
--- a/changelog/GfIbbn_2TeGylQW5plPCHw.md
+++ b/changelog/GfIbbn_2TeGylQW5plPCHw.md
@@ -1,0 +1,4 @@
+audience: users
+level: patch
+---
+The github YAML debug route now properly reports templating issues as a 400 instead of a 500

--- a/services/github/src/api.js
+++ b/services/github/src/api.js
@@ -982,7 +982,7 @@ builder.declare(
 
       return res.reply({ tasks, scopes });
     } catch (e) {
-      return res.reportError('InvalidInput', e.message, {});
+      return res.reportError('InputError', e.message, {});
     }
   }
 );

--- a/services/github/test/api_test.js
+++ b/services/github/test/api_test.js
@@ -834,5 +834,28 @@ tasks: []
       });
       assert.deepEqual(tasks, []);
     });
+    test('invalid template returns a 400', async () => {
+      const tcYaml = `version: 1
+reporting: checks-v1
+tasks:
+  - metadata:
+      name:
+        $eval: '$string($now())'
+`;
+      await assert.rejects(
+        () =>
+          helper.apiClient.renderTaskclusterYml({
+            body: tcYaml,
+            fakeEvent: { type: 'github-push' },
+            repository: 'repo',
+            organization: 'org',
+          }),
+        err => {
+          assert.equal(err.code, 'InputError');
+          assert.equal(err.statusCode, 400);
+          return true;
+        }
+      );
+    });
   });
 });


### PR DESCRIPTION
`InvalidInput` isn't what's expected to return a 400, `InputError` is. So the former fell back through and ended up as an unknown error -> 500.

Fixes sentry issue `TASKCLUSTER-SERVICES-COMMUNITYTC-EB`