### PR TITLE
Close websocktunnel connections when a client misbehaves

### DIFF
--- a/changelog/RLs250otTEiw0ZjpXrzR_g.md
+++ b/changelog/RLs250otTEiw0ZjpXrzR_g.md
@@ -1,0 +1,4 @@
+audience: deployers
+level: patch
+---
+Websocktunnel will now close sessions when a client sends an invalid packet instead of silently ignoring it

--- a/changelog/eS4FsME_S8GaNhe_S-2MNA.md
+++ b/changelog/eS4FsME_S8GaNhe_S-2MNA.md
@@ -1,0 +1,4 @@
+audience: deployers
+level: patch
+---
+Fixed a potential panic in websocktunnel when a worker sent a malformed ACK

--- a/tools/websocktunnel/wsmux/errors.go
+++ b/tools/websocktunnel/wsmux/errors.go
@@ -40,6 +40,9 @@ var (
 	// ErrMalformedPayload indicates a websocket frame payload was invalid.
 	ErrMalformedPayload = errors.New("malformed payload")
 
+	// ErrUnexpectedMessageType indicates a non-binary ws message was received.
+	ErrUnexpectedMessageType = errors.New("unexpected non-binary websocket message")
+
 	// ErrTooManySyns indicates too many un-accepted new incoming streams
 	ErrTooManySyns = errors.New("too many un-accepted new incoming streams")
 )

--- a/tools/websocktunnel/wsmux/errors.go
+++ b/tools/websocktunnel/wsmux/errors.go
@@ -37,6 +37,9 @@ var (
 	// ErrMalformedHeader indicate a websocket frame header was invalid.
 	ErrMalformedHeader = errors.New("malformed header")
 
+	// ErrMalformedPayload indicates a websocket frame payload was invalid.
+	ErrMalformedPayload = errors.New("malformed payload")
+
 	// ErrTooManySyns indicates too many un-accepted new incoming streams
 	ErrTooManySyns = errors.New("too many un-accepted new incoming streams")
 )

--- a/tools/websocktunnel/wsmux/frame.go
+++ b/tools/websocktunnel/wsmux/frame.go
@@ -26,6 +26,7 @@ const (
 type header []byte
 
 const HEADER_SIZE = 5
+const ACK_PAYLOAD_SIZE = 4
 
 // id returns the stream ID in a header.
 func (h header) id() uint32 {
@@ -83,10 +84,22 @@ func deserializeFrame(data []byte) (*frame, error) {
 		return nil, ErrMalformedHeader
 	}
 
+	payload := data[HEADER_SIZE:]
+	switch msg {
+	case msgSYN, msgFIN:
+		if len(payload) != 0 {
+			return nil, ErrMalformedPayload
+		}
+	case msgACK:
+		if len(payload) != ACK_PAYLOAD_SIZE {
+			return nil, ErrMalformedPayload
+		}
+	}
+
 	return &frame{
 		id:      hdr.id(),
 		msg:     msg,
-		payload: data[HEADER_SIZE:],
+		payload: payload,
 	}, nil
 }
 
@@ -128,7 +141,7 @@ func newSynFrame(id uint32) frame {
 // newSynFrame creates a new msgACK frame containing the given capacity.
 func newAckFrame(id uint32, cap uint32) frame {
 	frame := frame{id: id, msg: msgACK}
-	frame.payload = make([]byte, 4)
+	frame.payload = make([]byte, ACK_PAYLOAD_SIZE)
 	binary.LittleEndian.PutUint32(frame.payload, cap)
 	return frame
 }

--- a/tools/websocktunnel/wsmux/session.go
+++ b/tools/websocktunnel/wsmux/session.go
@@ -340,14 +340,14 @@ func (s *Session) recvLoop() {
 			break
 		}
 		if t != websocket.BinaryMessage {
-			s.logger.Print("did not receive binary message")
-			continue
+			s.abortProtocol(ErrUnexpectedMessageType)
+			break
 		}
 
 		fr, err := deserializeFrame(msg)
 		if err != nil {
-			s.logger.Print(err)
-			continue
+			s.abortProtocol(err)
+			break
 		}
 
 		if fr.msg == msgSYN {
@@ -401,6 +401,12 @@ func (s *Session) abort(e error) {
 	s.acceptErr = e
 	s.mu.Unlock()
 	s.Close()
+}
+
+func (s *Session) abortProtocol(e error) {
+	closeMsg := websocket.FormatCloseMessage(websocket.ClosePolicyViolation, e.Error())
+	_ = s.conn.WriteControl(websocket.CloseMessage, closeMsg, time.Now().Add(time.Second))
+	s.abort(e)
 }
 
 // loops over streams and removes any streams that are dead

--- a/tools/websocktunnel/wsmux/session_test.go
+++ b/tools/websocktunnel/wsmux/session_test.go
@@ -80,3 +80,63 @@ func TestEchoLarge(t *testing.T) {
 		t.Fatal("message not consistent")
 	}
 }
+
+func TestMalformedAckDoesNotPanic(t *testing.T) {
+	server := httptest.NewServer(genWebSocketHandler(t, echoConn))
+	defer server.Close()
+	conn, _, err := (&websocket.Dialer{}).Dial(util.MakeWsURL(server.URL), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn.Close()
+
+	const id = 1
+	write := func(fr frame) {
+		t.Helper()
+		if err := conn.WriteMessage(websocket.BinaryMessage, fr.serialize()); err != nil {
+			t.Fatal(err)
+		}
+	}
+	read := func() *frame {
+		t.Helper()
+		for {
+			mt, msg, err := conn.ReadMessage()
+			if err != nil {
+				t.Fatal(err)
+			}
+			if mt != websocket.BinaryMessage {
+				continue
+			}
+			fr, err := deserializeFrame(msg)
+			if err != nil {
+				t.Fatal(err)
+			}
+			return fr
+		}
+	}
+
+	write(newSynFrame(id))
+	if fr := read(); fr.msg != msgACK {
+		t.Fatalf("expected ACK for the new stream, got %v", fr)
+	}
+
+	// Send 2 bytes instead of 4 in the ACK
+	write(frame{id: id, msg: msgACK, payload: []byte{0, 0}})
+
+	write(newDataFrame(id, []byte("Hello")))
+	write(newFinFrame(id))
+
+	echoed := new(bytes.Buffer)
+	for {
+		fr := read()
+		if fr.msg == msgFIN {
+			break
+		}
+		if fr.msg == msgDAT {
+			echoed.Write(fr.payload)
+		}
+	}
+	if echoed.String() != "Hello" {
+		t.Fatalf("expected the session to echo \"Hello\", got %q", echoed.String())
+	}
+}

--- a/tools/websocktunnel/wsmux/session_test.go
+++ b/tools/websocktunnel/wsmux/session_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"io"
 	"testing"
+	"time"
 
 	"net/http/httptest"
 
@@ -81,7 +82,7 @@ func TestEchoLarge(t *testing.T) {
 	}
 }
 
-func TestMalformedAckDoesNotPanic(t *testing.T) {
+func TestMalformedAckAbortsSession(t *testing.T) {
 	server := httptest.NewServer(genWebSocketHandler(t, echoConn))
 	defer server.Close()
 	conn, _, err := (&websocket.Dialer{}).Dial(util.MakeWsURL(server.URL), nil)
@@ -97,46 +98,42 @@ func TestMalformedAckDoesNotPanic(t *testing.T) {
 			t.Fatal(err)
 		}
 	}
-	read := func() *frame {
-		t.Helper()
-		for {
-			mt, msg, err := conn.ReadMessage()
-			if err != nil {
-				t.Fatal(err)
-			}
-			if mt != websocket.BinaryMessage {
-				continue
-			}
-			fr, err := deserializeFrame(msg)
-			if err != nil {
-				t.Fatal(err)
-			}
-			return fr
-		}
-	}
 
 	write(newSynFrame(id))
-	if fr := read(); fr.msg != msgACK {
-		t.Fatalf("expected ACK for the new stream, got %v", fr)
+	msgType, msg, err := conn.ReadMessage()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if fr, derr := deserializeFrame(msg); msgType != websocket.BinaryMessage || derr != nil || fr.msg != msgACK {
+		t.Fatalf("expected ACK for the new stream, got type=%d msg=%v err=%v", msgType, msg, derr)
 	}
 
 	// Send 2 bytes instead of 4 in the ACK
 	write(frame{id: id, msg: msgACK, payload: []byte{0, 0}})
 
-	write(newDataFrame(id, []byte("Hello")))
-	write(newFinFrame(id))
-
-	echoed := new(bytes.Buffer)
-	for {
-		fr := read()
-		if fr.msg == msgFIN {
-			break
-		}
-		if fr.msg == msgDAT {
-			echoed.Write(fr.payload)
-		}
+	_ = conn.SetReadDeadline(time.Now().Add(5 * time.Second))
+	_, _, err = conn.ReadMessage()
+	if !websocket.IsCloseError(err, websocket.ClosePolicyViolation) {
+		t.Fatalf("expected a ClosePolicyViolation error close after a malformed frame, got %v", err)
 	}
-	if echoed.String() != "Hello" {
-		t.Fatalf("expected the session to echo \"Hello\", got %q", echoed.String())
+}
+
+func TestNonBinaryMessageAbortsSession(t *testing.T) {
+	server := httptest.NewServer(genWebSocketHandler(t, acceptUntilClosed))
+	defer server.Close()
+	conn, _, err := (&websocket.Dialer{}).Dial(util.MakeWsURL(server.URL), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn.Close()
+
+	if err := conn.WriteMessage(websocket.TextMessage, []byte("hello")); err != nil {
+		t.Fatal(err)
+	}
+
+	_ = conn.SetReadDeadline(time.Now().Add(5 * time.Second))
+	_, _, err = conn.ReadMessage()
+	if !websocket.IsCloseError(err, websocket.ClosePolicyViolation) {
+		t.Fatalf("expected a ClosePolicyViolation error after a text message, got %v", err)
 	}
 }

--- a/tools/websocktunnel/wsmux/util_for_test.go
+++ b/tools/websocktunnel/wsmux/util_for_test.go
@@ -47,6 +47,16 @@ func genWebSocketHandler(t *testing.T, handleConn func(*testing.T, *websocket.Co
 
 // functions for session test
 
+func acceptUntilClosed(t *testing.T, conn *websocket.Conn) {
+	t.Helper()
+	session := Server(conn, Config{Log: genLogger()})
+	for {
+		if _, err := session.Accept(); err != nil {
+			return
+		}
+	}
+}
+
 func echoConn(t *testing.T, conn *websocket.Conn) {
 	t.Helper()
 	session := Server(conn, Config{Log: genLogger()})


### PR DESCRIPTION
Since websockettunnel clients are all on the trusted side of the tunnel, they **MUST** respect the protocol, anything else is a bug in wst-client and should be fixed. Before this, any bug would just get swallowed silently by the tunnel. We now close the connection instead, making it visible. It shouldn't change anything since I'm sure the client is bug free (right?)
