### PR TITLE
change create task page to use decorator

### DIFF
--- a/changelog/issue-8927.md
+++ b/changelog/issue-8927.md
@@ -1,0 +1,5 @@
+audience: developers
+level: patch
+reference: issue 8927
+---
+UI Create Task page switches to use decorator for api call

--- a/ui/src/views/Tasks/CreateTask/index.jsx
+++ b/ui/src/views/Tasks/CreateTask/index.jsx
@@ -44,8 +44,7 @@ import {
   TASK_PAYLOAD_SCHEMAS,
 } from '../../../utils/constants';
 import urls from '../../../utils/urls';
-import { AuthContext } from '../../../utils/Auth';
-import { getClient } from '../../../utils/client';
+import { withTaskclusterClient } from '../../../utils/TaskclusterClient';
 import Button from '../../../components/Button';
 import db from '../../../utils/db';
 import validateTaskPayloadSchemas from '../../../utils/validateTaskPayloadSchemas';
@@ -90,9 +89,8 @@ const defaultTask = schema => {
     whiteSpace: 'pre',
   },
 }))
+@withTaskclusterClient
 export default class CreateTask extends Component {
-  static contextType = AuthContext;
-
   static defaultProps = {
     interactive: false,
   };
@@ -205,7 +203,7 @@ export default class CreateTask extends Component {
       this.setState({ loading: true });
 
       try {
-        const queue = getClient({ Class: Queue, user: this.context.user });
+        const queue = this.props.createTaskclusterClient({ Class: Queue });
 
         await queue.createTask(taskId, payload);
 


### PR DESCRIPTION
Github Issue: Fixes #8927 

The Create task page was already using the rest api call, moved it to use our decorator
