### PR TITLE
feat(github, web-server): Stop following reference redirect artifacts in services

### DIFF
--- a/changelog/bug-2056618.md
+++ b/changelog/bug-2056618.md
@@ -1,0 +1,14 @@
+audience: users
+level: minor
+reference: bug 2056618
+---
+
+Fixes a possible SSRF in the github and web-server services, which download task artifacts. Both
+now resolve artifacts through the queue's artifact API and refuse to fetch a `reference` artifact,
+whose URL is supplied by the task; `s3`, `link`, and `object` artifacts, whose URLs the queue
+derives itself, are unaffected. The JS client exposes this as `downloadManagedArtifact`.
+
+Two visible consequences:
+
+- An artifact named by `customCheckRun.textArtifactName` or `annotationsArtifactName` must be a stored artifact. A `reference` now produces an explanatory comment on the commit instead of being fetched.
+- The task log profiler cannot read a running task's `live.log`, which is a `reference` to the livelog server by design. It falls back to `live_backing.log`, so resolved tasks are unaffected.

--- a/clients/client-go/tcwebserver/tcwebserver.go
+++ b/clients/client-go/tcwebserver/tcwebserver.go
@@ -139,7 +139,7 @@ func (webServer *WebServer) TaskGroupProfile(taskGroupId string) error {
 
 // Stability: *** EXPERIMENTAL ***
 //
-// Generate a Firefox Profiler–compatible profile from a task's log output.
+// Generate a Firefox Profiler–compatible profile from a task's log output for resolved tasks.
 // Parses `public/logs/live.log` (or `live_backing.log`) for timing data.
 //
 // See #taskProfile

--- a/clients/client-py/taskcluster/generated/aio/webserver.py
+++ b/clients/client-py/taskcluster/generated/aio/webserver.py
@@ -78,7 +78,7 @@ class WebServer(AsyncBaseClient):
         """
         Task Log Profile
 
-        Generate a Firefox Profiler–compatible profile from a task's log output.
+        Generate a Firefox Profiler–compatible profile from a task's log output for resolved tasks.
         Parses `public/logs/live.log` (or `live_backing.log`) for timing data.
 
         This method is ``experimental``

--- a/clients/client-py/taskcluster/generated/webserver.py
+++ b/clients/client-py/taskcluster/generated/webserver.py
@@ -76,7 +76,7 @@ class WebServer(BaseClient):
         """
         Task Log Profile
 
-        Generate a Firefox Profiler–compatible profile from a task's log output.
+        Generate a Firefox Profiler–compatible profile from a task's log output for resolved tasks.
         Parses `public/logs/live.log` (or `live_backing.log`) for timing data.
 
         This method is ``experimental``

--- a/clients/client-rust/client/src/generated/webserver.rs
+++ b/clients/client-rust/client/src/generated/webserver.rs
@@ -163,7 +163,7 @@ impl WebServer {
 
     /// Task Log Profile
     ///
-    /// Generate a Firefox Profiler–compatible profile from a task's log output.
+    /// Generate a Firefox Profiler–compatible profile from a task's log output for resolved tasks.
     /// Parses `public/logs/live.log` (or `live_backing.log`) for timing data.
     pub async fn taskProfile(&self, taskId: &str) -> Result<(), Error> {
         let method = "GET";

--- a/clients/client-shell/apis/services.go
+++ b/clients/client-shell/apis/services.go
@@ -2241,7 +2241,7 @@ var services = map[string]definitions.Service{
 			definitions.Entry{
 				Name:        "taskProfile",
 				Title:       "Task Log Profile",
-				Description: "Generate a Firefox Profiler–compatible profile from a task's log output.\nParses `public/logs/live.log` (or `live_backing.log`) for timing data.",
+				Description: "Generate a Firefox Profiler–compatible profile from a task's log output for resolved tasks.\nParses `public/logs/live.log` (or `live_backing.log`) for timing data.",
 				Stability:   "experimental",
 				Method:      "get",
 				Route:       "/task/<taskId>/profile",

--- a/clients/client-web/src/clients/WebServer.js
+++ b/clients/client-web/src/clients/WebServer.js
@@ -45,7 +45,7 @@ export default class WebServer extends Client {
 
     return this.request(this.taskGroupProfile.entry, args);
   }
-  // Generate a Firefox Profiler–compatible profile from a task's log output.
+  // Generate a Firefox Profiler–compatible profile from a task's log output for resolved tasks.
   // Parses `public/logs/live.log` (or `live_backing.log`) for timing data.
   taskProfile(...args) {
     this.validate(this.taskProfile.entry, args);

--- a/clients/client/README.md
+++ b/clients/client/README.md
@@ -442,6 +442,28 @@ let contentType = await taskcluster.downloadArtifact({
 });
 ```
 
+#### Downloading Untrusted Artifacts
+
+A `reference` artifact is fetched from a URL supplied by the task that published it, so
+downloading one from a place with more network reach than the task itself -- a service in your
+deployment, for example -- is a server-side request forgery.
+
+`downloadManagedArtifact` takes the same options as `downloadArtifact`, but refuses a `reference`
+artifact before reading its URL, throwing an error with `code` of
+`'ArtifactStorageTypeRejected'`:
+
+```javascript
+let contentType = await taskcluster.downloadManagedArtifact({ taskId, name, queue, streamFactory });
+```
+
+Use it whenever the task publishing the artifact is not fully trusted.  `s3` and `object`
+artifacts are unaffected, as the queue derives their URLs itself, and `link` artifacts are
+resolved by the queue, so a link ending at a `reference` is refused as well.
+
+Both functions throw an error with `code` of `'ArtifactError'` for an `error` artifact, and
+report HTTP failures on `err.statusCode` regardless of whether the artifact record or its stored
+content was missing.
+
 ### Inspecting Credentials
 
 Your users may find the options for Taskcluster credentials overwhelming.  You

--- a/clients/client/src/apis.js
+++ b/clients/client/src/apis.js
@@ -4189,7 +4189,7 @@ export default {
             "taskId"
           ],
           "category": "Profiler",
-          "description": "Generate a Firefox Profiler–compatible profile from a task's log output.\nParses `public/logs/live.log` (or `live_backing.log`) for timing data.",
+          "description": "Generate a Firefox Profiler–compatible profile from a task's log output for resolved tasks.\nParses `public/logs/live.log` (or `live_backing.log`) for timing data.",
           "method": "get",
           "name": "taskProfile",
           "query": [

--- a/clients/client/src/download.js
+++ b/clients/client/src/download.js
@@ -26,6 +26,8 @@ const s3 = async ({ url, streamFactory, retryCfg }) => {
     let contentType = 'application/binary';
     try {
       const src = got.stream(url, { retry: { limit: 0 } });
+      // aborted request emits again after pipeline() already rejected, crashes if unhandled
+      src.on('error', () => {});
       src.on('response', res => {
         contentType = res.headers['content-type'] || contentType;
       });
@@ -58,6 +60,8 @@ const getUrl = async ({ object, name, resp, streamFactory, retryCfg }) => {
     try {
       responseUsed = true;
       const src = got.stream(resp.url, { retry: { limit: 0 } });
+      // aborted request emits again after pipeline() already rejected, crashes if unhandled
+      src.on('error', () => {});
       src.on('response', res => {
         contentType = res.headers['content-type'] || contentType;
       });

--- a/clients/client/src/download.js
+++ b/clients/client/src/download.js
@@ -8,7 +8,7 @@ import { clients } from './client.js';
 const makeRetryCfg = ({ retries, delayFactor, randomizationFactor, maxDelay }) => ({
   retries: retries === undefined ? 5 : retries,
   delayFactor: delayFactor === undefined ? 100 : delayFactor,
-  randomizationFactor: randomizationFactor === undefined ? randomizationFactor : 0.25,
+  randomizationFactor: randomizationFactor === undefined ? 0.25 : randomizationFactor,
   maxDelay: maxDelay === undefined ? 30 * 1000 : maxDelay,
 });
 

--- a/clients/client/src/download.js
+++ b/clients/client/src/download.js
@@ -12,6 +12,15 @@ const makeRetryCfg = ({ retries, delayFactor, randomizationFactor, maxDelay }) =
   maxDelay: maxDelay === undefined ? 30 * 1000 : maxDelay,
 });
 
+// got reports an HTTP status on `err.response.statusCode`, while Taskcluster client errors carry
+// it on `err.statusCode`; normalize onto the latter so callers need only check one place.
+const withStatusCode = err => {
+  if (err.statusCode === undefined && err.response?.statusCode !== undefined) {
+    err.statusCode = err.response.statusCode;
+  }
+  return err;
+};
+
 const s3 = async ({ url, streamFactory, retryCfg }) => {
   return await retry(retryCfg, async retriableError => {
     let contentType = 'application/binary';
@@ -122,46 +131,63 @@ export const download = async ({
   }
 };
 
-export const downloadArtifact = async ({
-  taskId,
-  runId,
-  name,
-  queue,
-  streamFactory,
-  retries,
-  delayFactor,
-  randomizationFactor,
-  maxDelay,
-}) => {
+// when managedOnly is set, a `reference` artifact is rejected before its URL is read.  The queue
+// resolves `link` artifacts server-side, so the storageType seen here is always the final one.
+const downloadArtifactImpl = async (
+  { taskId, runId, name, queue, streamFactory, retries, delayFactor, randomizationFactor, maxDelay },
+  managedOnly
+) => {
   const retryCfg = makeRetryCfg({ retries, delayFactor, randomizationFactor, maxDelay });
 
-  const artifact = await (runId === undefined
-    ? queue.latestArtifact(taskId, name)
-    : queue.artifact(taskId, runId, name));
+  try {
+    const artifact = await (runId === undefined
+      ? queue.latestArtifact(taskId, name)
+      : queue.artifact(taskId, runId, name));
 
-  switch (artifact.storageType) {
-    case 'reference':
-    case 's3': {
-      return await s3({ url: artifact.url, streamFactory, retryCfg });
+    switch (artifact.storageType) {
+      case 'reference':
+      case 's3': {
+        if (managedOnly && artifact.storageType === 'reference') {
+          const err = new Error(
+            'Refusing to download a `reference` artifact: its URL is supplied by the task.  Use ' +
+              '`downloadArtifact` if fetching a task-supplied URL is intended.'
+          );
+          err.code = 'ArtifactStorageTypeRejected';
+          err.storageType = 'reference';
+          throw err;
+        }
+
+        return await s3({ url: artifact.url, streamFactory, retryCfg });
+      }
+
+      case 'object': {
+        const object = new clients.Object({
+          rootUrl: queue._options._trueRootUrl,
+          credentials: artifact.credentials,
+        });
+        return await download({ name: artifact.name, object, streamFactory, ...retryCfg });
+      }
+
+      case 'error': {
+        const err = new Error(artifact.message);
+        err.code = 'ArtifactError';
+        err.reason = artifact.reason;
+        throw err;
+      }
+
+      default:
+        throw new Error(`Unsupported artifact storageType '${artifact.storageType}'`);
     }
-
-    case 'object': {
-      const object = new clients.Object({
-        rootUrl: queue._options._trueRootUrl,
-        credentials: artifact.credentials,
-      });
-      return await download({ name: artifact.name, object, streamFactory, ...retryCfg });
-    }
-
-    case 'error': {
-      const err = new Error(artifact.message);
-      err.reason = artifact.reason;
-      throw err;
-    }
-
-    default:
-      throw new Error(`Unsupported artifact storageType '${artifact.storageType}'`);
+  } catch (err) {
+    throw withStatusCode(err);
   }
 };
 
-export default { download, downloadArtifact };
+export const downloadArtifact = async options => await downloadArtifactImpl(options, false);
+
+// as downloadArtifact, but refuses `reference` artifacts, whose content is fetched from a URL of
+// the publishing task's choosing.  Callers reading artifacts of untrusted tasks should use this,
+// so that a task cannot direct them at an arbitrary URL reachable from their network position.
+export const downloadManagedArtifact = async options => await downloadArtifactImpl(options, true);
+
+export default { download, downloadArtifact, downloadManagedArtifact };

--- a/clients/client/src/download.js
+++ b/clients/client/src/download.js
@@ -145,9 +145,8 @@ const downloadArtifactImpl = async (
       : queue.artifact(taskId, runId, name));
 
     switch (artifact.storageType) {
-      case 'reference':
-      case 's3': {
-        if (managedOnly && artifact.storageType === 'reference') {
+      case 'reference': {
+        if (managedOnly) {
           const err = new Error(
             'Refusing to download a `reference` artifact: its URL is supplied by the task.  Use ' +
               '`downloadArtifact` if fetching a task-supplied URL is intended.'
@@ -156,7 +155,9 @@ const downloadArtifactImpl = async (
           err.storageType = 'reference';
           throw err;
         }
-
+        return await s3({ url: artifact.url, streamFactory, retryCfg });
+      }
+      case 's3': {
         return await s3({ url: artifact.url, streamFactory, retryCfg });
       }
 

--- a/clients/client/test/download_error_test.js
+++ b/clients/client/test/download_error_test.js
@@ -1,0 +1,97 @@
+import http from 'node:http';
+import { PassThrough } from 'node:stream';
+import { strict as assert } from 'node:assert';
+import { downloadArtifact, downloadManagedArtifact } from '../src/index.js';
+import testing from './helper.js';
+
+/**
+ * Artifact download behavior that does not require credentials, exercised against a local HTTP
+ * server and a fake queue.
+ */
+suite(testing.suiteName(), () => {
+  let server, base;
+
+  suiteSetup(async () => {
+    server = http.createServer((req, res) => {
+      if (req.url === '/gone') {
+        res.writeHead(404);
+        return res.end('no such object');
+      }
+      if (req.url === '/broken') {
+        res.writeHead(500);
+        return res.end('server error');
+      }
+      res.writeHead(200, { 'content-type': 'text/plain' });
+      res.end('hello, world');
+    });
+    await new Promise(resolve => server.listen(0, '127.0.0.1', resolve));
+    base = `http://127.0.0.1:${server.address().port}`;
+  });
+
+  suiteTeardown(() => server.close());
+
+  // a queue resolving any artifact to the given record
+  const resolvingTo = artifact => ({
+    latestArtifact: async () => artifact,
+    artifact: async () => artifact,
+  });
+
+  const sink = () => {
+    const stream = new PassThrough();
+    stream.resume();
+    return stream;
+  };
+
+  const tryDownload = async (downloader, queue) =>
+    await downloader({ taskId: 'taskid', name: 'public/test.file', queue, streamFactory: sink, retries: 0 });
+
+  test('a stored artifact whose content is missing reports 404', async () => {
+    await assert.rejects(
+      () => tryDownload(downloadManagedArtifact, resolvingTo({ storageType: 's3', url: `${base}/gone` })),
+      err => err.statusCode === 404
+    );
+  });
+
+  test('a missing artifact record reports 404', async () => {
+    const queue = {
+      latestArtifact: async () => {
+        throw Object.assign(new Error('no such artifact'), { statusCode: 404 });
+      },
+    };
+
+    await assert.rejects(
+      () => tryDownload(downloadManagedArtifact, queue),
+      err => err.statusCode === 404
+    );
+  });
+
+  test('a server error reports its status once retries are exhausted', async () => {
+    await assert.rejects(
+      () => tryDownload(downloadArtifact, resolvingTo({ storageType: 's3', url: `${base}/broken` })),
+      err => err.statusCode === 500
+    );
+  });
+
+  test('downloadManagedArtifact refuses a reference artifact', async () => {
+    await assert.rejects(
+      () => tryDownload(downloadManagedArtifact, resolvingTo({ storageType: 'reference', url: base })),
+      err => err.code === 'ArtifactStorageTypeRejected' && err.storageType === 'reference'
+    );
+  });
+
+  test('downloadArtifact still follows a reference artifact', async () => {
+    const contentType = await tryDownload(
+      downloadArtifact,
+      resolvingTo({ storageType: 'reference', url: `${base}/ok` })
+    );
+
+    assert.equal(contentType, 'text/plain');
+  });
+
+  test('an error artifact reports ArtifactError', async () => {
+    await assert.rejects(
+      () => tryDownload(downloadArtifact, resolvingTo({ storageType: 'error', message: 'oh noes', reason: 'test' })),
+      err => err.code === 'ArtifactError' && err.reason === 'test'
+    );
+  });
+});

--- a/clients/client/test/upload_download_test.js
+++ b/clients/client/test/upload_download_test.js
@@ -432,7 +432,7 @@ suite(testing.suiteName(), () => {
 
       await assert.rejects(
         () => tryDownloadArtifact(),
-        err => err.message === 'oh noes' && err.reason === 'test case'
+        err => err.message === 'oh noes' && err.code === 'ArtifactError' && err.reason === 'test case'
       );
     });
   });

--- a/generated/references.json
+++ b/generated/references.json
@@ -20831,7 +20831,7 @@
             "taskId"
           ],
           "category": "Profiler",
-          "description": "Generate a Firefox Profiler–compatible profile from a task's log output.\nParses `public/logs/live.log` (or `live_backing.log`) for timing data.",
+          "description": "Generate a Firefox Profiler–compatible profile from a task's log output for resolved tasks.\nParses `public/logs/live.log` (or `live_backing.log`) for timing data.",
           "method": "get",
           "name": "taskProfile",
           "query": [

--- a/services/github/src/handlers/requestArtifact.js
+++ b/services/github/src/handlers/requestArtifact.js
@@ -1,8 +1,31 @@
 import utils from '../utils.js';
 
-export function buildArtifactUrl(queueClient, { taskId, runId, artifactName }) {
-  const limitedQueueClient = queueClient.use({ authorizedScopes: [`queue:get-artifact:${artifactName}`] });
-  return limitedQueueClient.buildSignedUrl(limitedQueueClient.getArtifact, taskId, runId, artifactName);
+/**
+ * Build the message shown to the repository as a comment when an artifact cannot be fetched.
+ */
+function artifactErrorMessage(artifactName, err) {
+  const requiredScope = `queue:get-artifact:${artifactName}`;
+  const prefix = `Failed to fetch task artifact \`${artifactName}\` for GitHub integration.\n`;
+
+  if (err.code === 'ArtifactStorageTypeRejected') {
+    return prefix.concat(
+      'The GitHub service does not fetch `reference` artifacts, as their URL is chosen by the ' +
+        'task. Publish the content as a stored artifact (storage type `s3` or `object`) instead.'
+    );
+  }
+
+  if (err.code === 'ArtifactError') {
+    return prefix.concat('Make sure the artifact exists on the worker or other location.');
+  }
+
+  switch (err.statusCode) {
+    case 403:
+      return prefix.concat(
+        `The GitHub service does not have permission to read this artifact. Make sure the artifact is public or grant the GitHub service the \`${requiredScope}\` scope.`
+      );
+    default:
+      return err.message ? prefix.concat(err.message) : prefix;
+  }
 }
 
 /**
@@ -10,30 +33,19 @@ export function buildArtifactUrl(queueClient, { taskId, runId, artifactName }) {
  */
 export async function requestArtifact(artifactName, { taskId, runId, debug, instGithub, build }) {
   try {
-    const url = buildArtifactUrl(this.queueClient, { taskId, runId, artifactName });
-    const res = await utils.throttleRequest({ url, method: 'GET' });
+    return await utils.downloadArtifactAsText({
+      queueClient: this.queueClient,
+      taskId,
+      runId,
+      artifactName,
+    });
+  } catch (err) {
+    // a missing artifact just means the task did not publish one
+    if (err.statusCode === 404) {
+      return '';
+    }
 
-    if (res.status >= 400 && res.status !== 404) {
-      const requiredScope = `queue:get-artifact:${artifactName}`;
-      let errorMessage = `Failed to fetch task artifact \`${artifactName}\` for GitHub integration.\n`;
-      switch (res.status) {
-        case 403:
-          errorMessage = errorMessage.concat(
-            `The GitHub service does not have permission to read this artifact. Make sure the artifact is public or grant the GitHub service the \`${requiredScope}\` scope.`
-          );
-          break;
-        case 404:
-          errorMessage = errorMessage.concat('Make sure the artifact exists, and there are no typos in its name.');
-          break;
-        case 424:
-          errorMessage = errorMessage.concat('Make sure the artifact exists on the worker or other location.');
-          break;
-        default:
-          if (res.response?.error?.message) {
-            errorMessage = errorMessage.concat(res.response.error.message);
-          }
-          break;
-      }
+    try {
       const { organization, repository, sha } = build;
       await this.createExceptionComment({
         debug,
@@ -41,18 +53,17 @@ export async function requestArtifact(artifactName, { taskId, runId, debug, inst
         organization,
         repository,
         sha,
-        error: new Error(errorMessage),
+        error: new Error(artifactErrorMessage(artifactName, err)),
       });
 
-      if (res.status < 500) {
-        await this.monitor.reportError(res.response.error);
+      if (!err.statusCode || err.statusCode < 500) {
+        await this.monitor.reportError(err);
       }
-    } else if (res.status >= 200 && res.status < 300) {
-      return res.text.toString();
+    } catch (e) {
+      await this.monitor.reportError(e);
     }
-  } catch (e) {
-    await this.monitor.reportError(e);
   }
+
   return '';
 }
 

--- a/services/github/src/handlers/requestArtifact.js
+++ b/services/github/src/handlers/requestArtifact.js
@@ -7,25 +7,28 @@ function artifactErrorMessage(artifactName, err) {
   const requiredScope = `queue:get-artifact:${artifactName}`;
   const prefix = `Failed to fetch task artifact \`${artifactName}\` for GitHub integration.\n`;
 
-  if (err.code === 'ArtifactStorageTypeRejected') {
-    return prefix.concat(
-      'The GitHub service does not fetch `reference` artifacts, as their URL is chosen by the ' +
-        'task. Publish the content as a stored artifact (storage type `s3` or `object`) instead.'
-    );
-  }
-
-  if (err.code === 'ArtifactError') {
-    return prefix.concat('Make sure the artifact exists on the worker or other location.');
-  }
-
-  switch (err.statusCode) {
-    case 403:
+  switch (err.code) {
+    case 'ArtifactStorageTypeRejected':
       return prefix.concat(
-        `The GitHub service does not have permission to read this artifact. Make sure the artifact is public or grant the GitHub service the \`${requiredScope}\` scope.`
+        'The GitHub service does not fetch `reference` artifacts, as their URL is chosen by the ' +
+          'task. Publish the content as a stored artifact (storage type `s3` or `object`) instead.'
       );
-    default:
-      return err.message ? prefix.concat(err.message) : prefix;
+    case 'ArtifactError':
+      return prefix.concat('Make sure the artifact exists on the worker or other location.');
   }
+
+  // Only errors raised by taskcluster api carry 'body' (see client.js)
+  // everything else is likely a storage backend, transport failure that can contain
+  // signed urls and internal hostnames, so cannot be shown to public
+  if (err.body?.message) {
+    return err.statusCode === 403
+      ? prefix.concat(
+          `The GitHub service does not have permission to read this artifact. Make sure the artifact is public or grant the GitHub service the \`${requiredScope}\` scope.`
+        )
+      : prefix.concat(err.message);
+  }
+
+  return prefix.concat('Internal error. The artifact could not be downloaded');
 }
 
 /**
@@ -45,6 +48,9 @@ export async function requestArtifact(artifactName, { taskId, runId, debug, inst
       return '';
     }
 
+    // report error before commenting
+    await this.monitor.reportError(err);
+
     try {
       const { organization, repository, sha } = build;
       await this.createExceptionComment({
@@ -55,10 +61,6 @@ export async function requestArtifact(artifactName, { taskId, runId, debug, inst
         sha,
         error: new Error(artifactErrorMessage(artifactName, err)),
       });
-
-      if (!err.statusCode || err.statusCode < 500) {
-        await this.monitor.reportError(err);
-      }
     } catch (e) {
       await this.monitor.reportError(e);
     }

--- a/services/github/src/handlers/status.js
+++ b/services/github/src/handlers/status.js
@@ -13,7 +13,7 @@ import {
 import QueueLock from '../queue-lock.js';
 import utils from '../utils.js';
 const { markdownLog, markdownAnchor } = utils;
-import { requestArtifact, buildArtifactUrl } from './requestArtifact.js';
+import { requestArtifact } from './requestArtifact.js';
 import {
   taskUI,
   makeDebug,
@@ -253,18 +253,21 @@ export async function statusHandler(message) {
     }
     if (!taskDefined && runId !== undefined) {
       try {
-        const url = buildArtifactUrl(this.queueClient, { taskId, runId, artifactName: LIVE_BACKING_LOG_ARTIFACT_NAME });
-        const response = await fetch(url, { redirect: 'follow' });
-        if (response.ok) {
-          const logText = await utils.extractLog(response.body, 20, 200, githubCheck.output.getRemainingMaxSize());
-          if (logText) {
-            output.addText(markdownLog(logText));
-          }
-        } else {
-          await response.body?.cancel();
+        const logText = await utils.downloadArtifactAsStream({
+          queueClient: this.queueClient,
+          taskId,
+          runId,
+          artifactName: LIVE_BACKING_LOG_ARTIFACT_NAME,
+          consume: stream => utils.extractLog(stream, 20, 200, githubCheck.output.getRemainingMaxSize()),
+        });
+        if (logText) {
+          output.addText(markdownLog(logText));
         }
       } catch (e) {
-        await this.monitor.reportError(e);
+        // a log that is absent, refused, or an error artifact simply has no excerpt to add
+        if (e.statusCode !== 404 && e.code !== 'ArtifactStorageTypeRejected' && e.code !== 'ArtifactError') {
+          await this.monitor.reportError(e);
+        }
       }
     }
 

--- a/services/github/src/utils.js
+++ b/services/github/src/utils.js
@@ -1,12 +1,8 @@
 import crypto from 'node:crypto';
-import request from 'superagent';
-import util from 'node:util';
 import { PassThrough } from 'node:stream';
 import { downloadManagedArtifact } from '@taskcluster/client';
 
 import { ISSUE_COMMENT_ACTIONS } from './constants.js';
-
-const setTimeoutPromise = util.promisify(setTimeout);
 
 /**
  * Download a task artifact with a queue client limited to reading that one artifact.
@@ -83,51 +79,6 @@ export const downloadArtifactAsStream = async ({ queueClient, taskId, runId, art
 
   return await consumed;
 };
-
-/**
- * Retry a request call with the given URL and method.
- *
- * Responses with status 5xx are retried, and if 5 retries are exceeded then the last
- * response is returned.
- *
- * All other HTTP responses, including 4xx-series responses, are returned (not thrown).
- *
- * All other errors from superagent are thrown.
- */
-export const throttleRequest = async ({ url, method, response = { status: 0 }, attempt = 1, delay = 100 }) => {
-  if (attempt > 5) {
-    return response;
-  }
-
-  let res;
-  try {
-    res = await throttleRequest.request(method, url);
-  } catch (e) {
-    if (e.status >= 400 && e.status < 500) {
-      return e;
-    }
-
-    if (e.status >= 500) {
-      const newDelay = 2 ** attempt * delay;
-      return await setTimeoutPromise(
-        newDelay,
-        throttleRequest({
-          url,
-          method,
-          response: e,
-          attempt: attempt + 1,
-          delay,
-        })
-      );
-    }
-
-    throw e;
-  }
-  return res;
-};
-
-// for overriding in testing..
-throttleRequest.request = request;
 
 export const ciSkipRegexp = /\[(skip ci|ci skip)\]/i;
 
@@ -375,7 +326,6 @@ export const checkGithubSignature = (secret, payload, signature) => {
 };
 
 export default {
-  throttleRequest,
   downloadArtifactAsText,
   downloadArtifactAsStream,
   shouldSkipCommit,

--- a/services/github/src/utils.js
+++ b/services/github/src/utils.js
@@ -1,10 +1,88 @@
 import crypto from 'node:crypto';
 import request from 'superagent';
 import util from 'node:util';
+import { PassThrough } from 'node:stream';
+import { downloadManagedArtifact } from '@taskcluster/client';
 
 import { ISSUE_COMMENT_ACTIONS } from './constants.js';
 
 const setTimeoutPromise = util.promisify(setTimeout);
+
+/**
+ * Download a task artifact with a queue client limited to reading that one artifact.
+ *
+ * This uses downloadManagedArtifact, so a `reference` artifact is refused rather than fetched:
+ * its URL is supplied by the task, and this service can reach hosts no task can.
+ */
+const downloadArtifact = async ({ queueClient, taskId, runId, artifactName, streamFactory, retries }) => {
+  const limitedQueueClient = queueClient.use({
+    authorizedScopes: [`queue:get-artifact:${artifactName}`],
+  });
+
+  return await downloadManagedArtifact({
+    taskId,
+    runId,
+    name: artifactName,
+    queue: limitedQueueClient,
+    streamFactory,
+    retries,
+  });
+};
+
+export const downloadArtifactAsText = async ({ queueClient, taskId, runId, artifactName }) => {
+  let chunks;
+
+  await downloadArtifact({
+    queueClient,
+    taskId,
+    runId,
+    artifactName,
+    streamFactory: async () => {
+      chunks = [];
+      const stream = new PassThrough();
+      stream.on('data', chunk => chunks.push(chunk));
+      return stream;
+    },
+  });
+
+  return Buffer.concat(chunks).toString();
+};
+
+export const downloadArtifactAsStream = async ({ queueClient, taskId, runId, artifactName, consume }) => {
+  const stream = new PassThrough();
+  let consumerError = null;
+
+  stream.on('error', () => {});
+
+  // start consuming before downloading, as the download does not complete until the stream drains
+  const consumed = consume(stream).catch(err => {
+    consumerError = err;
+    stream.destroy();
+    throw err;
+  });
+  consumed.catch(() => {});
+
+  try {
+    await downloadArtifact({
+      queueClient,
+      taskId,
+      runId,
+      artifactName,
+      retries: 0,
+      streamFactory: async () => stream,
+    });
+  } catch (err) {
+    if (consumerError) {
+      throw consumerError;
+    }
+
+    stream.destroy();
+    await consumed.catch(() => {});
+    throw err;
+  }
+
+  return await consumed;
+};
 
 /**
  * Retry a request call with the given URL and method.
@@ -298,6 +376,8 @@ export const checkGithubSignature = (secret, payload, signature) => {
 
 export default {
   throttleRequest,
+  downloadArtifactAsText,
+  downloadArtifactAsStream,
   shouldSkipCommit,
   shouldSkipPullRequest,
   ansi2txt,

--- a/services/github/test/handler_test.js
+++ b/services/github/test/handler_test.js
@@ -46,6 +46,31 @@ helper.secrets.mockSuite(testing.suiteName(), [], (mock, skipping) => {
   const COMMIT_SHA = '03e9577bc1ec60f2ff0929d5f1554de36b8f48cf';
   const INST_ID = 5828;
 
+  // the name the task definitions below ask for, rather than the default text artifact name
+  const CUSTOM_CHECKRUN_TEXT_ARTIFACT = 'public/text.md';
+  const CUSTOM_CHECKRUN_ANNOTATIONS_ARTIFACT = 'public/github/customCheckRunAnnotations.json';
+
+  /**
+   * Stub the artifact downloads the status handler makes.
+   *
+   * `log` is the live_backing.log excerpt, and `artifacts` maps an artifact name to the text
+   * downloaded for it, or to an Error to reject with. Names absent from `artifacts` reject with a
+   * 404, as an unpublished artifact does.
+   */
+  const stubArtifacts = ({ log = '', artifacts = {} } = {}) => {
+    sinon.stub(utils, 'downloadArtifactAsStream').resolves(log);
+    sinon.stub(utils, 'downloadArtifactAsText').callsFake(async ({ artifactName }) => {
+      const content = artifacts[artifactName];
+      if (content === undefined) {
+        throw Object.assign(new Error('artifact not found'), { statusCode: 404 });
+      }
+      if (content instanceof Error) {
+        throw content;
+      }
+      return content;
+    });
+  };
+
   let github = null;
   let handlers = null;
 
@@ -149,7 +174,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], (mock, skipping) => {
               extra: {
                 github: {
                   customCheckRun: {
-                    textArtifactName: 'public/text.md',
+                    textArtifactName: CUSTOM_CHECKRUN_TEXT_ARTIFACT,
                   },
                 },
               },
@@ -1738,11 +1763,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], (mock, skipping) => {
 
     const TASKGROUPID = 'AXB-sjV-SoCyibyq3P32o2';
     setup(() => {
-      sinon.stub(global, 'fetch').resolves({ ok: false, body: { cancel: async () => {} } });
-      sinon.stub(utils, 'extractLog').resolves('');
-      sinon
-        .stub(utils, 'throttleRequest')
-        .returns({ status: 404, response: { error: { text: 'Resource not found' } } });
+      stubArtifacts();
     });
 
     teardown(async () => {
@@ -1908,14 +1929,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], (mock, skipping) => {
       await addBuild({ state: 'pending', taskGroupId: TASKGROUPID });
       await addCheckRun({ taskGroupId: TASKGROUPID, taskId: CUSTOM_CHECKRUN_TASKID });
       sinon.restore();
-      sinon.stub(global, 'fetch').resolves({ ok: true, body: { cancel: async () => {} } });
-      sinon.stub(utils, 'extractLog').resolves('');
-      sinon
-        .stub(utils, 'throttleRequest')
-        .onFirstCall()
-        .returns({ status: 200, text: CUSTOM_CHECKRUN_TEXT })
-        .onSecondCall()
-        .returns({ status: 404 });
+      stubArtifacts({ artifacts: { [CUSTOM_CHECKRUN_TEXT_ARTIFACT]: CUSTOM_CHECKRUN_TEXT } });
       await simulateExchangeMessage({
         taskGroupId: TASKGROUPID,
         exchange: 'exchange/taskcluster-queue/v1/task-completed',
@@ -1940,14 +1954,11 @@ helper.secrets.mockSuite(testing.suiteName(), [], (mock, skipping) => {
       await addBuild({ state: 'pending', taskGroupId: TASKGROUPID });
       await addCheckRun({ taskGroupId: TASKGROUPID, taskId: CUSTOM_CHECKRUN_HOOK_TASKID });
       sinon.restore();
-      sinon.stub(global, 'fetch').resolves({ ok: true, body: { cancel: async () => {} } });
-      sinon.stub(utils, 'extractLog').resolves('');
       sinon.stub(handlers.queueClient, 'task').resolves({
         metadata: { name: 'Task with custom check run', description: 'Task Description' },
-        extra: { github: { customCheckRun: { textArtifactName: 'public/text.md' } } },
+        extra: { github: { customCheckRun: { textArtifactName: CUSTOM_CHECKRUN_TEXT_ARTIFACT } } },
       });
-      const useSpy = sinon.spy(handlers.queueClient, 'use');
-      sinon.stub(utils, 'throttleRequest').returns({ status: 200, text: CUSTOM_CHECKRUN_TEXT });
+      stubArtifacts({ artifacts: { [CUSTOM_CHECKRUN_TEXT_ARTIFACT]: CUSTOM_CHECKRUN_TEXT } });
       await simulateExchangeMessage({
         taskGroupId: TASKGROUPID,
         exchange: 'exchange/taskcluster-queue/v1/task-completed',
@@ -1959,8 +1970,13 @@ helper.secrets.mockSuite(testing.suiteName(), [], (mock, skipping) => {
         resolved: RESOLVED,
       });
       assert(
-        useSpy.getCalls().some(c => c.args[0].authorizedScopes?.[0] === 'queue:get-artifact:public/text.md'),
-        'use should be called with queue:get-artifact scope for the artifact'
+        utils.downloadArtifactAsText
+          .getCalls()
+          .some(
+            c =>
+              c.args[0].artifactName === CUSTOM_CHECKRUN_TEXT_ARTIFACT && c.args[0].queueClient === handlers.queueClient
+          ),
+        'the artifact should be downloaded with the service queue client'
       );
       sinon.restore();
     });
@@ -1969,9 +1985,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], (mock, skipping) => {
       await addBuild({ state: 'pending', taskGroupId: TASKGROUPID });
       await addCheckRun({ taskGroupId: TASKGROUPID, taskId: CUSTOM_CHECKRUN_TASKID });
       sinon.restore();
-      sinon.stub(global, 'fetch').resolves({ ok: true, body: { cancel: async () => {} } });
-      sinon.stub(utils, 'extractLog').resolves(LIVE_LOG_TEXT);
-      sinon.stub(utils, 'throttleRequest').returns({ status: 404 });
+      stubArtifacts({ log: LIVE_LOG_TEXT });
       await simulateExchangeMessage({
         taskGroupId: TASKGROUPID,
         exchange: 'exchange/taskcluster-queue/v1/task-completed',
@@ -1996,9 +2010,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], (mock, skipping) => {
       await addBuild({ state: 'pending', taskGroupId: TASKGROUPID });
       await addCheckRun({ taskGroupId: TASKGROUPID, taskId: CUSTOM_LIVELOG_NAME_TASKID });
       sinon.restore();
-      sinon.stub(global, 'fetch').resolves({ ok: true, body: { cancel: async () => {} } });
-      sinon.stub(utils, 'extractLog').resolves(LIVE_LOG_TEXT);
-      sinon.stub(utils, 'throttleRequest').returns({ status: 404 });
+      stubArtifacts({ log: LIVE_LOG_TEXT });
       await simulateExchangeMessage({
         taskGroupId: TASKGROUPID,
         exchange: 'exchange/taskcluster-queue/v1/task-completed',
@@ -2029,9 +2041,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], (mock, skipping) => {
       await addBuild({ state: 'pending', taskGroupId: TASKGROUPID });
       await addCheckRun({ taskGroupId: TASKGROUPID, taskId: CUSTOM_LIVELOG_NAME_TASKID });
       sinon.restore();
-      sinon.stub(global, 'fetch').resolves({ ok: true, body: { cancel: async () => {} } });
-      sinon.stub(utils, 'extractLog').resolves(LIVE_LOG_TEXT);
-      sinon.stub(utils, 'throttleRequest').returns({ status: 404 });
+      stubArtifacts({ log: LIVE_LOG_TEXT });
       await simulateExchangeMessage({
         taskGroupId: TASKGROUPID,
         exchange: 'exchange/taskcluster-queue/v1/task-completed',
@@ -2058,14 +2068,11 @@ helper.secrets.mockSuite(testing.suiteName(), [], (mock, skipping) => {
       await addBuild({ state: 'pending', taskGroupId: TASKGROUPID });
       await addCheckRun({ taskGroupId: TASKGROUPID, taskId: CUSTOM_CHECKRUN_TASKID });
       sinon.restore();
-      sinon.stub(global, 'fetch').resolves({ ok: true, body: { cancel: async () => {} } });
-      sinon.stub(utils, 'extractLog').resolves('');
-      sinon
-        .stub(utils, 'throttleRequest')
-        .onFirstCall()
-        .returns({ status: 418, response: { error: { text: "I'm a tea pot" } } })
-        .onSecondCall()
-        .returns({ status: 404 });
+      stubArtifacts({
+        artifacts: {
+          [CUSTOM_CHECKRUN_TEXT_ARTIFACT]: Object.assign(new Error("I'm a tea pot"), { statusCode: 418 }),
+        },
+      });
       await simulateExchangeMessage({
         taskGroupId: TASKGROUPID,
         exchange: 'exchange/taskcluster-queue/v1/task-completed',
@@ -2086,14 +2093,10 @@ helper.secrets.mockSuite(testing.suiteName(), [], (mock, skipping) => {
       await addBuild({ state: 'pending', taskGroupId: TASKGROUPID });
       await addCheckRun({ taskGroupId: TASKGROUPID, taskId: CUSTOM_CHECKRUN_TASKID });
       sinon.restore();
-      sinon.stub(global, 'fetch').resolves({ ok: true, body: { cancel: async () => {} } });
-      sinon.stub(utils, 'extractLog').resolves(LIVE_LOG_TEXT);
-      sinon
-        .stub(utils, 'throttleRequest')
-        .onFirstCall()
-        .returns({ status: 404 })
-        .onSecondCall()
-        .returns({ status: 200, text: CUSTOM_CHECKRUN_ANNOTATIONS });
+      stubArtifacts({
+        log: LIVE_LOG_TEXT,
+        artifacts: { [CUSTOM_CHECKRUN_ANNOTATIONS_ARTIFACT]: CUSTOM_CHECKRUN_ANNOTATIONS },
+      });
       await simulateExchangeMessage({
         taskGroupId: TASKGROUPID,
         exchange: 'exchange/taskcluster-queue/v1/task-completed',
@@ -2113,14 +2116,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], (mock, skipping) => {
       await addBuild({ state: 'pending', taskGroupId: TASKGROUPID });
       await addCheckRun({ taskGroupId: TASKGROUPID, taskId: CUSTOM_CHECKRUN_TASKID });
       sinon.restore();
-      sinon.stub(global, 'fetch').resolves({ ok: true, body: { cancel: async () => {} } });
-      sinon.stub(utils, 'extractLog').resolves('');
-      sinon
-        .stub(utils, 'throttleRequest')
-        .onFirstCall()
-        .returns({ status: 404 })
-        .onSecondCall()
-        .returns({ status: 200, text: '{{{invalid json!!' });
+      stubArtifacts({ artifacts: { [CUSTOM_CHECKRUN_ANNOTATIONS_ARTIFACT]: '{{{invalid json!!' } });
 
       await simulateExchangeMessage({
         taskGroupId: TASKGROUPID,
@@ -2147,14 +2143,11 @@ helper.secrets.mockSuite(testing.suiteName(), [], (mock, skipping) => {
       await addBuild({ state: 'pending', taskGroupId: TASKGROUPID });
       await addCheckRun({ taskGroupId: TASKGROUPID, taskId: CUSTOM_CHECKRUN_TASKID });
       sinon.restore();
-      sinon.stub(global, 'fetch').resolves({ ok: true, body: { cancel: async () => {} } });
-      sinon.stub(utils, 'extractLog').resolves('');
-      sinon
-        .stub(utils, 'throttleRequest')
-        .onFirstCall()
-        .returns({ status: 404 })
-        .onSecondCall()
-        .returns({ status: 418, response: { error: { text: "I'm a tea pot" } } });
+      stubArtifacts({
+        artifacts: {
+          [CUSTOM_CHECKRUN_ANNOTATIONS_ARTIFACT]: Object.assign(new Error("I'm a tea pot"), { statusCode: 418 }),
+        },
+      });
       await simulateExchangeMessage({
         taskGroupId: TASKGROUPID,
         exchange: 'exchange/taskcluster-queue/v1/task-completed',
@@ -2187,9 +2180,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], (mock, skipping) => {
       await addBuild({ state: 'pending', taskGroupId: TASKGROUPID });
       await addCheckRun({ taskGroupId: TASKGROUPID, taskId: CUSTOM_LIVELOG_NAME_TASKID });
       sinon.restore();
-      sinon.stub(global, 'fetch').resolves({ ok: true, body: { cancel: async () => {} } });
-      sinon.stub(utils, 'extractLog').resolves(LIVE_LOG_TEXT);
-      sinon.stub(utils, 'throttleRequest').returns({ status: 404 });
+      stubArtifacts({ log: LIVE_LOG_TEXT });
       await simulateExchangeMessage({
         taskGroupId: TASKGROUPID,
         exchange: 'exchange/taskcluster-queue/v1/task-completed',
@@ -2219,11 +2210,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], (mock, skipping) => {
     });
 
     setup(() => {
-      sinon.stub(global, 'fetch').resolves({ ok: false, body: { cancel: async () => {} } });
-      sinon.stub(utils, 'extractLog').resolves('');
-      sinon
-        .stub(utils, 'throttleRequest')
-        .returns({ status: 404, response: { error: { text: 'Resource not found' } } });
+      stubArtifacts();
     });
 
     teardown(async () => {

--- a/services/github/test/utils_test.js
+++ b/services/github/test/utils_test.js
@@ -4,7 +4,6 @@ import { Readable } from 'node:stream';
 import testing from '@taskcluster/lib-testing';
 
 import {
-  throttleRequest,
   downloadArtifactAsText,
   downloadArtifactAsStream,
   shouldSkipCommit,
@@ -21,90 +20,6 @@ import {
 const toStream = str => Readable.from([Buffer.from(str)]);
 
 suite(testing.suiteName(), () => {
-  suite('throttleRequest', () => {
-    let oldRequest;
-
-    suiteSetup(() => {
-      oldRequest = throttleRequest.request;
-    });
-
-    teardown(() => {
-      throttleRequest.request = oldRequest;
-    });
-
-    test('calls with the given method and url and returns a success result immediately', async () => {
-      throttleRequest.request = async (method, url) => {
-        assert.equal(method, 'GET');
-        assert.equal(url, 'https://foo');
-        return { result: true };
-      };
-
-      const res = await throttleRequest({ url: 'https://foo', method: 'GET' });
-      assert.deepEqual(res, { result: true });
-    });
-
-    test('4xx statuses are returned (not thrown) immediately', async () => {
-      let calls = 0;
-
-      throttleRequest.request = async (_method, _url) => {
-        calls++;
-        const err = new Error('uhoh');
-        err.status = 424;
-        throw err;
-      };
-
-      const res = await throttleRequest({ url: 'https://foo', method: 'GET' });
-      assert.equal(res.status, 424);
-      assert.equal(calls, 1); // didn't retry
-    });
-
-    test('5xx statuses are retried', async () => {
-      let calls = 0;
-
-      throttleRequest.request = async (_method, _url) => {
-        calls++;
-        const err = new Error('uhoh');
-        err.status = 543;
-        throw err;
-      };
-
-      // (set delay=10 to retry more quickly than usual)
-      const res = await throttleRequest({ url: 'https://foo', method: 'GET', delay: 10 });
-      assert.equal(res.status, 543);
-      assert.equal(calls, 5);
-    });
-
-    test('5xx status retried once returns successful result', async () => {
-      let calls = 0;
-
-      throttleRequest.request = async (_method, _url) => {
-        calls++;
-        if (calls >= 1) {
-          return { status: 200 };
-        }
-        const err = new Error('uhoh');
-        err.status = 543;
-        throw err;
-      };
-
-      const res = await throttleRequest({ url: 'https://foo', method: 'GET', delay: 10 });
-      assert.equal(res.status, 200);
-      assert.equal(calls, 1);
-    });
-
-    test('connection errors are thrown directly', async () => {
-      throttleRequest.request = async (_method, _url) => {
-        const err = new Error('uhoh');
-        err.code = 'ECONNREFUSED';
-        throw err;
-      };
-
-      await assert.rejects(
-        () => throttleRequest({ url: 'https://foo', method: 'GET', delay: 10 }),
-        err => err.code === 'ECONNREFUSED'
-      );
-    });
-  });
   suite('shouldSkipCommit', () => {
     const skipMessages = [
       '[CI Skip] this is not ready',

--- a/services/github/test/utils_test.js
+++ b/services/github/test/utils_test.js
@@ -1,9 +1,12 @@
 import assert from 'node:assert';
+import http from 'node:http';
 import { Readable } from 'node:stream';
 import testing from '@taskcluster/lib-testing';
 
 import {
   throttleRequest,
+  downloadArtifactAsText,
+  downloadArtifactAsStream,
   shouldSkipCommit,
   shouldSkipPullRequest,
   shouldSkipComment,
@@ -529,6 +532,112 @@ suite(testing.suiteName(), () => {
         ),
         false
       );
+    });
+  });
+
+  suite('artifact downloads', () => {
+    const body = 'first line\nsecond line\n';
+    let server, url;
+
+    suiteSetup(async () => {
+      server = http.createServer((_req, res) => {
+        res.writeHead(200, { 'content-type': 'text/plain' });
+        res.end(body);
+      });
+      await new Promise(resolve => server.listen(0, '127.0.0.1', resolve));
+      url = `http://127.0.0.1:${server.address().port}/artifact`;
+    });
+
+    suiteTeardown(() => server.close());
+
+    // a queue client recording the options it is limited with, and resolving every artifact to the
+    // given result
+    const fakeQueueClient = artifact => {
+      const scopeLimits = [];
+      return {
+        scopeLimits,
+        use: options => {
+          scopeLimits.push(options);
+          return {
+            artifact: async () => artifact,
+            latestArtifact: async () => artifact,
+          };
+        },
+      };
+    };
+
+    const stored = () => ({ storageType: 's3', url });
+    const reference = () => ({ storageType: 'reference', url: 'http://169.254.169.254/metadata' });
+
+    const args = (queueClient, extra = {}) => ({
+      queueClient,
+      taskId: 'taskid',
+      runId: 0,
+      artifactName: 'public/github/customCheckRunText.md',
+      ...extra,
+    });
+
+    test('downloadArtifactAsText returns a stored artifact', async () => {
+      assert.equal(await downloadArtifactAsText(args(fakeQueueClient(stored()))), body);
+    });
+
+    test('downloadArtifactAsText limits the queue client to the one artifact', async () => {
+      const queueClient = fakeQueueClient(stored());
+      await downloadArtifactAsText(args(queueClient));
+
+      assert.deepEqual(queueClient.scopeLimits, [
+        { authorizedScopes: ['queue:get-artifact:public/github/customCheckRunText.md'] },
+      ]);
+    });
+
+    test('downloadArtifactAsText refuses a reference artifact', async () => {
+      await assert.rejects(
+        () => downloadArtifactAsText(args(fakeQueueClient(reference()))),
+        err => err.code === 'ArtifactStorageTypeRejected' && err.storageType === 'reference'
+      );
+    });
+
+    test('downloadArtifactAsStream hands a stored artifact to the consumer', async () => {
+      const excerpt = await downloadArtifactAsStream(
+        args(fakeQueueClient(stored()), { consume: stream => extractLog(stream, 1, 1) })
+      );
+
+      assert.match(excerpt, /first line/);
+    });
+
+    test('downloadArtifactAsStream refuses a reference artifact', async () => {
+      await assert.rejects(
+        () => downloadArtifactAsStream(args(fakeQueueClient(reference()), { consume: stream => extractLog(stream) })),
+        err => err.code === 'ArtifactStorageTypeRejected'
+      );
+    });
+
+    test('downloadArtifactAsStream reports the consumer failure, not the torn-down stream', async () => {
+      await assert.rejects(
+        () =>
+          downloadArtifactAsStream(
+            args(fakeQueueClient(stored()), {
+              consume: async () => {
+                throw new Error('parser exploded');
+              },
+            })
+          ),
+        err => err.message === 'parser exploded'
+      );
+    });
+
+    test('downloadArtifactAsStream does not hang when the consumer stops reading early', async () => {
+      const partial = await downloadArtifactAsStream(
+        args(fakeQueueClient(stored()), {
+          consume: async stream => {
+            for await (const chunk of stream) {
+              return chunk.length;
+            }
+          },
+        })
+      );
+
+      assert.equal(partial, body.length);
     });
   });
 });

--- a/services/github/test/utils_test.js
+++ b/services/github/test/utils_test.js
@@ -451,13 +451,19 @@ suite(testing.suiteName(), () => {
   });
 
   suite('artifact downloads', () => {
-    const body = 'first line\nsecond line\n';
+    const bodyLine1 = 'first line\nsecond line\n';
+    const bodyLine2 = `Lots of x: ${Array.from({ length: 999999 }).fill('x')}`;
     let server, url;
 
     suiteSetup(async () => {
       server = http.createServer((_req, res) => {
         res.writeHead(200, { 'content-type': 'text/plain' });
-        res.end(body);
+        // simulate few chunks
+        res.write(bodyLine1, 'utf-8', () => {
+          res.write(bodyLine2, 'utf-8', () => {
+            res.end();
+          });
+        });
       });
       await new Promise(resolve => server.listen(0, '127.0.0.1', resolve));
       url = `http://127.0.0.1:${server.address().port}/artifact`;
@@ -493,7 +499,7 @@ suite(testing.suiteName(), () => {
     });
 
     test('downloadArtifactAsText returns a stored artifact', async () => {
-      assert.equal(await downloadArtifactAsText(args(fakeQueueClient(stored()))), body);
+      assert.equal(await downloadArtifactAsText(args(fakeQueueClient(stored()))), `${bodyLine1}${bodyLine2}`);
     });
 
     test('downloadArtifactAsText limits the queue client to the one artifact', async () => {
@@ -541,18 +547,20 @@ suite(testing.suiteName(), () => {
       );
     });
 
-    test('downloadArtifactAsStream does not hang when the consumer stops reading early', async () => {
-      const partial = await downloadArtifactAsStream(
-        args(fakeQueueClient(stored()), {
-          consume: async stream => {
-            for await (const chunk of stream) {
-              return chunk.length;
-            }
-          },
-        })
+    test('downloadArtifactAsStream throws if consumer stops reading early', async () => {
+      await assert.rejects(
+        () =>
+          downloadArtifactAsStream(
+            args(fakeQueueClient(stored()), {
+              consume: async stream => {
+                for await (const chunk of stream) {
+                  return chunk.length;
+                }
+              },
+            })
+          ),
+        err => err.code === 'ABORT_ERR'
       );
-
-      assert.equal(partial, body.length);
     });
   });
 });

--- a/services/web-server/src/api.js
+++ b/services/web-server/src/api.js
@@ -105,7 +105,7 @@ builder.declare(
     category: 'Profiler',
     stability: 'experimental',
     description: [
-      "Generate a Firefox Profiler–compatible profile from a task's log output.",
+      "Generate a Firefox Profiler–compatible profile from a task's log output for resolved tasks.",
       'Parses `public/logs/live.log` (or `live_backing.log`) for timing data.',
     ].join('\n'),
   },
@@ -123,8 +123,16 @@ builder.declare(
       throw err;
     }
 
-    const log = await openTaskLog({ queue, taskId });
+    const taskNotResolved = ['running', 'pending', 'unscheduled'].includes(status.state);
+    if (taskNotResolved) {
+      return res.reportError(
+        'ResourceNotFound',
+        'Profiling is only supported on resolved tasks. Wait for the task to finish and retry',
+        {}
+      );
+    }
 
+    const log = await openTaskLog({ queue, taskId });
     if (!log) {
       return res.reportError(
         'ResourceNotFound',
@@ -148,13 +156,7 @@ builder.declare(
 
     const profile = profileBuilder.finalize();
 
-    const isResolved = !['running', 'pending', 'unscheduled'].includes(status.state);
-    if (isResolved) {
-      res.set('Cache-Control', 'public, max-age=86400');
-    } else {
-      res.set('Cache-Control', 'no-cache');
-    }
-
+    res.set('Cache-Control', 'public, max-age=86400');
     res.set('Content-Type', 'application/json');
     res.set('Content-Encoding', 'gzip');
     res.status(200);

--- a/services/web-server/src/api.js
+++ b/services/web-server/src/api.js
@@ -1,11 +1,11 @@
 import { APIBuilder } from '@taskcluster/lib-api';
 import { getProfile } from './profiler/profile.js';
 import zlib from 'node:zlib';
-import { StreamingProfileBuilder, lineIterator } from './profiler/log-profile.js';
+import { StreamingProfileBuilder } from './profiler/log-profile.js';
+import { openTaskLog, readTaskLogLines } from './utils/taskLog.js';
 
 const MAX_TASKS = 20000;
 const MAX_PAGES = 200;
-const MAX_LOG_SIZE = 200 * 1024 * 1024; // 200MB
 
 const SLUGID_PATTERN = /^[A-Za-z0-9_-]{8}[Q-T][A-Za-z0-9_-][CGKOSWaeimquy26-][A-Za-z0-9_-]{10}[AQgw]$/;
 
@@ -123,21 +123,9 @@ builder.declare(
       throw err;
     }
 
-    let response;
-    for (const artifactName of ['public/logs/live.log', 'public/logs/live_backing.log']) {
-      try {
-        const artifactUrl = queue.buildUrl(queue.getLatestArtifact, taskId, artifactName);
-        const resp = await fetch(artifactUrl, { redirect: 'follow' });
-        if (resp.ok) {
-          response = resp;
-          break;
-        }
-      } catch {
-        // Try next artifact name
-      }
-    }
+    const log = await openTaskLog({ queue, taskId });
 
-    if (!response) {
+    if (!log) {
       return res.reportError(
         'ResourceNotFound',
         'Could not fetch task log. The task may not have logs or they may have expired.',
@@ -145,22 +133,17 @@ builder.declare(
       );
     }
 
-    // Check Content-Length if available
-    const contentLength = parseInt(response.headers.get('content-length') || '0', 10);
-    if (contentLength > MAX_LOG_SIZE) {
-      return res.reportError('InputTooLarge', 'Log exceeds 200MB size limit', {});
-    }
-
     // Stream and parse log line-by-line
     const profileBuilder = new StreamingProfileBuilder(task, taskId, this.rootUrl);
-    let bytesRead = 0;
-    for await (const line of lineIterator(response.body, n => {
-      bytesRead += n;
-    })) {
-      if (bytesRead > MAX_LOG_SIZE) {
-        return res.reportError('InputTooLarge', 'Log exceeds 200MB size limit', {});
+    try {
+      for await (const line of readTaskLogLines(log)) {
+        profileBuilder.addLine(line);
       }
-      profileBuilder.addLine(line);
+    } catch (err) {
+      if (err.code === 'LogTooLarge') {
+        return res.reportError('InputTooLarge', err.message, {});
+      }
+      throw err;
     }
 
     const profile = profileBuilder.finalize();

--- a/services/web-server/src/loaders/tasks.js
+++ b/services/web-server/src/loaders/tasks.js
@@ -1,8 +1,8 @@
 import DataLoader from 'dataloader';
-import got from 'got';
+import { downloadManagedArtifact } from '@taskcluster/client';
+import { PassThrough } from 'node:stream';
 import ConnectionLoader from '../ConnectionLoader.js';
 import Task from '../entities/Task.js';
-import maybeSignedUrl from '../utils/maybeSignedUrl.js';
 
 // Task actions were previously filtered with a client-supplied sift query. The
 // UI only ever sent two fixed shapes, encoded here as a `contextScope`:
@@ -21,7 +21,25 @@ const filterTaskActions = (actions, contextScope) =>
       : !isContextSize(action.context, 0);
   });
 
-export default ({ queue, index }, isAuthed, _rootUrl, _monitor, _strategies, _req, _cfg, _requestId) => {
+const downloadArtifactToBuffer = async ({ queue, taskId, name }) => {
+  let chunks;
+
+  await downloadManagedArtifact({
+    taskId,
+    name,
+    queue,
+    streamFactory: async () => {
+      chunks = [];
+      const stream = new PassThrough();
+      stream.on('data', chunk => chunks.push(chunk));
+      return stream;
+    },
+  });
+
+  return Buffer.concat(chunks);
+};
+
+export default ({ queue, index }, _isAuthed, _rootUrl, _monitor, _strategies, _req, _cfg, _requestId) => {
   const task = new DataLoader(taskIds =>
     Promise.all(
       taskIds.map(async taskId => {
@@ -59,13 +77,12 @@ export default ({ queue, index }, isAuthed, _rootUrl, _monitor, _strategies, _re
     Promise.all(
       queries.map(async ({ taskGroupId, contextScope }) => {
         try {
-          const url = await maybeSignedUrl(queue, isAuthed)(
-            queue.getLatestArtifact,
-            taskGroupId,
-            'public/actions.json'
-          );
-
-          const raw = await got(url).json();
+          const content = await downloadArtifactToBuffer({
+            queue,
+            taskId: taskGroupId,
+            name: 'public/actions.json',
+          });
+          const raw = JSON.parse(content);
 
           return raw.actions
             ? {
@@ -74,8 +91,9 @@ export default ({ queue, index }, isAuthed, _rootUrl, _monitor, _strategies, _re
               }
             : null;
         } catch (err) {
-          // if the URL does not exist or is an error artifact, return nothing
-          if (err.response && (err.response.statusCode === 404 || err.response.statusCode === 424)) {
+          // if the artifact does not exist, is an error artifact, or is a `reference`, there are
+          // no actions to report
+          if (err.statusCode === 404 || err.code === 'ArtifactError' || err.code === 'ArtifactStorageTypeRejected') {
             return null;
           }
 

--- a/services/web-server/src/utils/maybeSignedUrl.js
+++ b/services/web-server/src/utils/maybeSignedUrl.js
@@ -1,6 +1,0 @@
-/**
- * Return externalBuildUrl or externalBuildSignedUrl, depending on whether the client has credentials
- */
-export default (client, isAuthed) => {
-  return (isAuthed ? client.externalBuildSignedUrl : client.externalBuildUrl).bind(client);
-};

--- a/services/web-server/src/utils/taskLog.js
+++ b/services/web-server/src/utils/taskLog.js
@@ -1,0 +1,93 @@
+import { downloadManagedArtifact } from '@taskcluster/client';
+import { Transform } from 'node:stream';
+import { lineIterator } from '../profiler/log-profile.js';
+
+export const LOG_ARTIFACT_NAMES = ['public/logs/live.log', 'public/logs/live_backing.log'];
+
+const MAX_LOG_SIZE = 200 * 1024 * 1024; // 200MB
+
+class LogTooLargeError extends Error {
+  constructor(maxBytes) {
+    super(`Log exceeds ${Math.round(maxBytes / (1024 * 1024))}MB size limit`);
+    this.code = 'LogTooLarge';
+  }
+}
+
+/**
+ * Open a task log for reading: live.log or live_backing.log, whichever exists and is not a reference artifact
+ *
+ * Returns `{ name, stream, downloaded }`, or null if no name yielded content, where `downloaded`
+ * resolves to the download's error or to null if it completed.  The caller must read `stream` to
+ * the end or destroy it, or the download blocks forever on backpressure.
+ */
+export const openTaskLog = async ({ queue, taskId }) => {
+  for (const name of LOG_ARTIFACT_NAMES) {
+    const { promise: receivingContent, resolve: onContent } = /** @type {PromiseWithResolvers<void>} */ (
+      Promise.withResolvers()
+    );
+
+    // The download opens its destination before the HTTP response arrives, so being handed the
+    // stream says nothing about whether there is content behind it, wait for the stream itself to
+    // carry a chunk.
+    const stream = new Transform({
+      transform(chunk, _encoding, callback) {
+        onContent();
+        callback(null, chunk);
+      },
+    });
+    // failures are reported through `downloaded`
+    stream.on('error', () => {});
+
+    const downloaded = downloadManagedArtifact({
+      taskId,
+      name,
+      queue,
+      // the destination is a single stream shared with the caller, so it cannot be retried
+      retries: 0,
+      streamFactory: async () => stream,
+    }).then(
+      () => null,
+      err => err
+    );
+
+    // A rejection arriving before any content means this name yielded nothing to read
+    // Empty artifact or response is not a failure: `downloaded` resolves to null and wins the race.
+    const failedBeforeContent = await Promise.race([receivingContent.then(() => null), downloaded]);
+    if (failedBeforeContent) {
+      continue;
+    }
+
+    return { name, stream, downloaded };
+  }
+
+  return null;
+};
+
+/**
+ * Iterate the lines of a log opened by openTaskLog, throwing an error with `code` of `'LogTooLarge'` past `maxBytes`.
+ */
+export const readTaskLogLines = async function* (log, { maxBytes = MAX_LOG_SIZE } = {}) {
+  let bytesRead = 0;
+
+  // counted per chunk rather than per line: a log containing no newline never yields a line, so a
+  // per-line check would not run until lineIterator had buffered the entire artifact
+  const countBytes = n => {
+    bytesRead += n;
+    if (bytesRead > maxBytes) {
+      throw new LogTooLargeError(maxBytes);
+    }
+  };
+
+  try {
+    for await (const line of lineIterator(log.stream, countBytes)) {
+      yield line;
+    }
+  } finally {
+    log.stream.destroy();
+  }
+
+  const downloadError = await log.downloaded;
+  if (downloadError) {
+    throw downloadError;
+  }
+};

--- a/services/web-server/test/loaders/tasks_loader_test.js
+++ b/services/web-server/test/loaders/tasks_loader_test.js
@@ -41,5 +41,20 @@ helper.secrets.mockSuite(testing.suiteName(), [], (mock, skipping) => {
       assert.equal(taskThatDoesNotExist.status, 'rejected');
       assert(taskThatDoesNotExist.reason instanceof Error);
     });
+
+    // An error artifact used to arrive as HTTP 424 from the download endpoint, the typed artifact
+    // endpoint replies 200 with storageType 'error' instead, which the client raises as
+    // `ArtifactError`. A `reference` artifact is refused rather than fetched, since its URL is
+    // chosen by the decision task. Neither is a failure — there are simply no actions to report.
+    test('taskActions reports no actions when actions.json is unusable', async () => {
+      const taskActionsFor = async artifact =>
+        await loader({ queue: { latestArtifact: async () => artifact }, index: {} }).taskActions.load({
+          taskGroupId: taskcluster.slugid(),
+          contextScope: 'task',
+        });
+
+      assert.equal(await taskActionsFor({ storageType: 'error', message: 'gone', reason: 'file-missing' }), null);
+      assert.equal(await taskActionsFor({ storageType: 'reference', url: 'http://169.254.169.254/metadata' }), null);
+    });
   });
 });

--- a/services/web-server/test/profiler/routes_test.js
+++ b/services/web-server/test/profiler/routes_test.js
@@ -1,4 +1,5 @@
 import assert from 'node:assert';
+import http from 'node:http';
 import express from 'express';
 import request from 'superagent';
 import builder from '../../src/api.js';
@@ -243,22 +244,16 @@ suite('profiler/routes', () => {
     });
   });
 
-  // Helper: mock global.fetch for testing artifact downloads
-  function mockFetch(responses) {
-    const original = global.fetch;
-    global.fetch = async url => {
-      for (const [pattern, response] of Object.entries(responses)) {
-        if (url.includes(pattern)) {
-          if (typeof response === 'function') {
-            return response();
-          }
-          return response;
-        }
-      }
-      return { ok: false, status: 404 };
-    };
-    return () => {
-      global.fetch = original;
+  // serve artifact content over loopback, as the endpoint downloads it through the client
+  async function startArtifactServer(content) {
+    const artifactServer = http.createServer((_req, res) => {
+      res.writeHead(200, { 'content-type': 'text/plain' });
+      res.end(content);
+    });
+    await new Promise(resolve => artifactServer.listen(0, '127.0.0.1', resolve));
+    return {
+      artifactServer,
+      artifactUrl: `http://127.0.0.1:${artifactServer.address().port}/log`,
     };
   }
 
@@ -269,34 +264,24 @@ suite('profiler/routes', () => {
       '[taskcluster:info 2024-01-01T10:00:05.000Z] Task complete',
     ].join('\n');
 
-    let server, port, restoreFetch;
+    let server, port, artifactServer;
 
     suiteSetup(async () => {
-      restoreFetch = mockFetch({
-        'live.log': () => ({
-          ok: true,
-          headers: new Headers({ 'content-length': String(logContent.length) }),
-          body: new ReadableStream({
-            start(controller) {
-              controller.enqueue(new TextEncoder().encode(logContent));
-              controller.close();
-            },
-          }),
-        }),
-      });
+      let artifactUrl;
+      ({ artifactServer, artifactUrl } = await startArtifactServer(logContent));
 
       const app = await createTestApp(() => ({
         queue: {
           task: async () => completedTask.task,
           status: async () => ({ status: completedTask.status }),
-          buildUrl: (_method, taskId, name) => `https://queue.test/task/${taskId}/artifacts/${name}`,
+          latestArtifact: async () => ({ storageType: 's3', url: artifactUrl }),
         },
       }));
       ({ server, port } = await startServer(app));
     });
 
     suiteTeardown(done => {
-      restoreFetch();
+      artifactServer.close();
       server.close(done);
     });
 
@@ -328,43 +313,77 @@ suite('profiler/routes', () => {
     });
   });
 
-  suite('task log profile size limit', () => {
-    let server, port, restoreFetch;
+  suite('task log fallback', () => {
+    const logContent = '[taskcluster:info 2024-01-01T10:00:00.000Z] Starting task\n';
+    let server, port, artifactServer, requested;
 
     suiteSetup(async () => {
-      restoreFetch = mockFetch({
-        'live.log': () => ({
-          ok: true,
-          headers: new Headers({ 'content-length': String(300 * 1024 * 1024) }),
-          body: new ReadableStream({
-            start(controller) {
-              controller.close();
-            },
-          }),
-        }),
-      });
+      let artifactUrl;
+      ({ artifactServer, artifactUrl } = await startArtifactServer(logContent));
 
       const app = await createTestApp(() => ({
         queue: {
           task: async () => completedTask.task,
           status: async () => ({ status: completedTask.status }),
-          buildUrl: (_method, taskId, name) => `https://queue.test/task/${taskId}/artifacts/${name}`,
+          latestArtifact: async (_taskId, name) => {
+            requested.push(name);
+            if (name === 'public/logs/live.log') {
+              return { storageType: 'reference', url: 'http://169.254.169.254/metadata' };
+            }
+            return { storageType: 's3', url: artifactUrl };
+          },
         },
       }));
       ({ server, port } = await startServer(app));
     });
 
+    setup(() => {
+      requested = [];
+    });
+
     suiteTeardown(done => {
-      restoreFetch();
+      artifactServer.close();
       server.close(done);
     });
 
-    test('returns 413 for oversized logs', async () => {
+    test('does not fetch a reference live.log, and profiles live_backing.log instead', async () => {
+      const res = await request
+        .get(`http://localhost:${port}/api/web-server/v1/task/${VALID_SLUGID_2}/profile`)
+        .buffer(true)
+        .parse(request.parse['application/octet-stream'])
+        .ok(() => true);
+
+      assert.equal(res.status, 200);
+      assert.deepEqual(requested, ['public/logs/live.log', 'public/logs/live_backing.log']);
+
+      const profile = JSON.parse(res.body.toString());
+      assert.equal(profile.threads.length, 1);
+    });
+  });
+
+  suite('task log profile with no readable log', () => {
+    let server, port;
+
+    suiteSetup(async () => {
+      const app = await createTestApp(() => ({
+        queue: {
+          task: async () => completedTask.task,
+          status: async () => ({ status: completedTask.status }),
+          // every log artifact is a reference, so none may be fetched
+          latestArtifact: async () => ({ storageType: 'reference', url: 'http://169.254.169.254/metadata' }),
+        },
+      }));
+      ({ server, port } = await startServer(app));
+    });
+
+    suiteTeardown(done => server.close(done));
+
+    test('returns 404 when no log artifact may be fetched', async () => {
       const res = await request
         .get(`http://localhost:${port}/api/web-server/v1/task/${VALID_SLUGID_2}/profile`)
         .ok(() => true);
 
-      assert.equal(res.status, 413);
+      assert.equal(res.status, 404);
     });
   });
 });

--- a/services/web-server/test/profiler/routes_test.js
+++ b/services/web-server/test/profiler/routes_test.js
@@ -70,6 +70,30 @@ suite('profiler/routes', () => {
       ],
     },
   };
+  const runningTask = {
+    task: {
+      schedulerId: 'sched',
+      expires: '2025-01-01T00:00:00.000Z',
+      metadata: { name: 'Running', description: '', owner: '', source: '' },
+      retries: 1,
+      taskGroupId: VALID_SLUGID,
+      dependencies: [],
+    },
+    status: {
+      taskId: 'running-task',
+      state: 'running',
+      runs: [
+        {
+          runId: 0,
+          state: 'running',
+          started: '2024-01-01T10:00:00.000Z',
+          resolved: null,
+          reasonCreated: 'scheduled',
+          reasonResolved: null,
+        },
+      ],
+    },
+  };
 
   suite('task group profile endpoint', () => {
     let server, port;
@@ -116,32 +140,7 @@ suite('profiler/routes', () => {
       const app = await createTestApp(() => ({
         queue: {
           listTaskGroup: async () => ({
-            tasks: [
-              {
-                task: {
-                  schedulerId: 'sched',
-                  expires: '2025-01-01T00:00:00.000Z',
-                  metadata: { name: 'Running', description: '', owner: '', source: '' },
-                  retries: 1,
-                  taskGroupId: VALID_SLUGID,
-                  dependencies: [],
-                },
-                status: {
-                  taskId: 'running-task',
-                  state: 'running',
-                  runs: [
-                    {
-                      runId: 0,
-                      state: 'running',
-                      started: '2024-01-01T10:00:00.000Z',
-                      resolved: null,
-                      reasonCreated: 'scheduled',
-                      reasonResolved: null,
-                    },
-                  ],
-                },
-              },
-            ],
+            tasks: [runningTask],
           }),
         },
       }));
@@ -384,6 +383,32 @@ suite('profiler/routes', () => {
         .ok(() => true);
 
       assert.equal(res.status, 404);
+    });
+  });
+
+  suite('running task log profile with no readable log', () => {
+    let server, port;
+
+    suiteSetup(async () => {
+      const app = await createTestApp(() => ({
+        queue: {
+          task: async () => runningTask.task,
+          status: async () => ({ status: runningTask.status }),
+          latestArtifact: async () => ({ storageType: 's3', url: 'xx' }),
+        },
+      }));
+      ({ server, port } = await startServer(app));
+    });
+
+    suiteTeardown(done => server.close(done));
+
+    test('returns 404 when no log artifact may be fetched and task is running', async () => {
+      const res = await request
+        .get(`http://localhost:${port}/api/web-server/v1/task/${VALID_SLUGID_2}/profile`)
+        .ok(() => true);
+
+      assert.equal(res.status, 404);
+      assert.match(res.body.message, /Profiling is only supported on resolved tasks/);
     });
   });
 });

--- a/services/web-server/test/taskLog_test.js
+++ b/services/web-server/test/taskLog_test.js
@@ -1,0 +1,115 @@
+import assert from 'node:assert';
+import http from 'node:http';
+import { Readable } from 'node:stream';
+import testing from '@taskcluster/lib-testing';
+import { openTaskLog, readTaskLogLines, LOG_ARTIFACT_NAMES } from '../src/utils/taskLog.js';
+
+const [LIVE_LOG, LIVE_BACKING_LOG] = LOG_ARTIFACT_NAMES;
+const REFERENCE_ARTIFACT = { storageType: 'reference', url: 'http://169.254.169.254/metadata' };
+
+suite(testing.suiteName(), () => {
+  const body = 'first line\nsecond line\n';
+  let server, url, missingUrl, emptyUrl;
+
+  suiteSetup(async () => {
+    server = http.createServer((req, res) => {
+      if (req.url === '/missing') {
+        // the artifact record exists, but its stored content is gone
+        res.writeHead(404);
+        return res.end('no such object');
+      }
+      res.writeHead(200, { 'content-type': 'text/plain' });
+      res.end(req.url === '/empty' ? '' : body);
+    });
+    await new Promise(resolve => server.listen(0, '127.0.0.1', resolve));
+
+    const origin = `http://127.0.0.1:${server.address().port}`;
+    url = `${origin}/log`;
+    missingUrl = `${origin}/missing`;
+    emptyUrl = `${origin}/empty`;
+  });
+
+  suiteTeardown(() => server.close());
+
+  // a queue resolving each artifact name to the given record, and any other name to a 404
+  const openLog = async resolutions =>
+    await openTaskLog({
+      taskId: 'taskid',
+      queue: {
+        latestArtifact: async (_taskId, name) => {
+          if (!resolutions[name]) {
+            throw Object.assign(new Error('no such artifact'), { statusCode: 404 });
+          }
+          return resolutions[name];
+        },
+      },
+    });
+
+  const readLines = async (log, options) => {
+    const lines = [];
+    for await (const line of readTaskLogLines(log, options)) {
+      lines.push(line);
+    }
+    return lines;
+  };
+
+  test('reads a stored log', async () => {
+    const log = await openLog({ [LIVE_LOG]: { storageType: 's3', url } });
+
+    assert.equal(log.name, LIVE_LOG);
+    assert.deepEqual(await readLines(log), ['first line', 'second line']);
+  });
+
+  test('falls through to live_backing.log unless there is content to read', async () => {
+    const backing = { [LIVE_BACKING_LOG]: { storageType: 's3', url } };
+
+    // first is no no, second ok
+    const reference = await openLog({ [LIVE_LOG]: REFERENCE_ARTIFACT, ...backing });
+    assert.equal(reference.name, LIVE_BACKING_LOG);
+
+    // live.log content is gone, so falling back to backing
+    const contentGone = await openLog({ [LIVE_LOG]: { storageType: 's3', url: missingUrl }, ...backing });
+    assert.equal(contentGone.name, LIVE_BACKING_LOG);
+
+    // but some logs might be empty
+    const empty = await openLog({ [LIVE_LOG]: { storageType: 's3', url: emptyUrl }, ...backing });
+    assert.equal(empty.name, LIVE_LOG);
+    assert.deepEqual(await readLines(empty), []);
+  });
+
+  test('returns null when no log can be read', async () => {
+    assert.equal(await openLog({}), null);
+    assert.equal(await openLog({ [LIVE_LOG]: REFERENCE_ARTIFACT, [LIVE_BACKING_LOG]: REFERENCE_ARTIFACT }), null);
+  });
+
+  test('stops reading at the byte cap, even with no newline in the log', async () => {
+    const chunkSize = 64 * 1024;
+    const maxBytes = 4 * chunkSize;
+    const availableChunks = 80;
+
+    let chunksRead = 0;
+    const stream = new Readable({
+      highWaterMark: chunkSize,
+      read() {
+        if (chunksRead >= availableChunks) {
+          return this.push(null);
+        }
+        chunksRead++;
+        this.push(Buffer.alloc(chunkSize, 'x'));
+      },
+    });
+    const log = { name: LIVE_LOG, stream, downloaded: Promise.resolve(null) };
+
+    await assert.rejects(
+      () => readLines(log, { maxBytes }),
+      err => err.code === 'LogTooLarge'
+    );
+
+    assert(
+      chunksRead * chunkSize <= maxBytes + 2 * chunkSize,
+      `expected reading to stop near the ${maxBytes} byte cap, but ${chunksRead * chunkSize} bytes were pulled`
+    );
+    // the download must be released rather than left blocked on a stream nobody is reading
+    await log.downloaded;
+  });
+});

--- a/ui/src/views/Tasks/ViewTask/index.jsx
+++ b/ui/src/views/Tasks/ViewTask/index.jsx
@@ -47,6 +47,7 @@ import {
   TASK_ADDED_FIELDS,
   TASK_POLL_INTERVAL,
   UI_SCHEDULER_ID,
+  TASK_STATE,
 } from '../../../utils/constants';
 import db from '../../../utils/db';
 import ErrorPanel from '../../../components/ErrorPanel';
@@ -1081,6 +1082,13 @@ export default class ViewTask extends Component {
               <SpeedDialAction
                 tooltipOpen
                 icon={<ChartIcon />}
+                FabProps={{
+                  disabled: [
+                    TASK_STATE.PENDING,
+                    TASK_STATE.RUNNING,
+                    TASK_STATE.UNSCHEDULED,
+                  ].includes(task.status.state),
+                }}
                 tooltipTitle="Profile Task Log"
                 onClick={this.handleOpenLogProfiler}
               />


### PR DESCRIPTION
While fetching live log and actions.json services were following redirects even if artifact had 'reference' type.
That could lead to a possible SSRF where github service or web-server would blindly follow artifact redirect url.

This would only download managed artifacts (the ones that resolve to stored s3 artifact on queue side)

Bugzilla Bug: [2056618](https://bugzilla.mozilla.org/show_bug.cgi?id=2056618)
