### PR TITLE
Don't let generic-worker-standalone chown the bind mounted config

### DIFF
--- a/changelog/OmJBm36KSf2ncvOw7gYOtA.md
+++ b/changelog/OmJBm36KSf2ncvOw7gYOtA.md
@@ -1,0 +1,2 @@
+level: silent
+---

--- a/workers/entrypoint.sh
+++ b/workers/entrypoint.sh
@@ -26,8 +26,15 @@ run_standalone() {
     exit 2
   fi
 
+  # Copy the bind-mounted config into the container and chmod it to 0600
+  # before handing it to generic-worker. Without the copy, generic-worker's
+  # auto-tightening would chmod the host-side file via the bind mount.
+  worker_config=/run/config.json
+  cp /etc/generic-worker/config.json "${worker_config}"
+  chmod 0600 "${worker_config}"
+
   generic-worker --version
-  generic-worker run --config /etc/generic-worker/config.json
+  generic-worker run --config "${worker_config}"
 }
 
 run_static() {


### PR DESCRIPTION
Generic worker likes to chown and chmod its config on start which is all fine and dandy until it's a file that is bind mounted in its container and it chowns the config to a user that isn't you. Then it breaks git by always creating a diff (since the mode of the file changes) and git breaks because it sees the change but can't read the file anymore.

```
error: open("docker/generic-worker-config.json"): Permission denied
fatal: cannot hash docker/generic-worker-config.json
```

This has annoyed me one too many times. Turns out that generic-worker-static was already doing something similar for worker-runner's config since #8520 (specifically
06c28e08df4bf1f087a64dbb2ce2f425270db1bc even if it doesn't mention it at all). I just copy/pasted the solution with
`s/worker-runner/generic-worker` since it's correct in this case too.