### PR TITLE
feat(client-rust): Add `content_length` parameter to AWF

### DIFF
--- a/changelog/issue-8869.md
+++ b/changelog/issue-8869.md
@@ -1,0 +1,6 @@
+audience: users
+level: major
+reference: issue 8869
+---
+
+The client-rust `AsyncWriterFactory` now needs to be `Send` and the `get_writer` method now takes an optional `content_length` parameter that indicates what size the writer should expect. The `get_writer` method is also now only called when the initial request succeeded and the response stream is about to be pulled.

--- a/clients/client-rust/download/src/artifact.rs
+++ b/clients/client-rust/download/src/artifact.rs
@@ -87,7 +87,7 @@ pub async fn download_artifact_to_file(
 /// Download an artifact using an [AsyncWriterFactory].  This is useful for advanced cases where one
 /// of the convenience functions is not adequate.  Returns the artifact's content type.  If
 /// `run_id` is None then the latest run will be used.  Returns the content type.
-pub async fn download_artifact_with_factory<AWF: AsyncWriterFactory>(
+pub async fn download_artifact_with_factory<AWF: AsyncWriterFactory + Send>(
     task_id: &str,
     run_id: Option<&str>,
     name: &str,
@@ -131,7 +131,7 @@ where
     Q: QueueService,
     O: ObjectService,
     OF: FnOnce(&Q, Credentials, &Retry) -> Result<O>,
-    AWF: AsyncWriterFactory,
+    AWF: AsyncWriterFactory + Send,
 {
     let artifact = if let Some(run_id) = run_id {
         queue_service.artifact(task_id, run_id, name).await?
@@ -193,8 +193,7 @@ async fn download_url<AWF: AsyncWriterFactory>(
 
     loop {
         attempts += 1;
-        let mut writer = writer_factory.get_writer().await?;
-        match get_url(url, writer.as_mut()).await {
+        match get_url(url, writer_factory).await {
             RetriableResult::Ok(fetchmeta) => return Ok(fetchmeta.content_type),
             RetriableResult::Retriable(err) => match backoff.next_backoff() {
                 Some(duration) => {

--- a/clients/client-rust/download/src/factory.rs
+++ b/clients/client-rust/download/src/factory.rs
@@ -11,7 +11,16 @@ use tokio::io::{AsyncSeekExt, AsyncWrite, AsyncWriteExt};
 pub trait AsyncWriterFactory {
     /// Get a fresh [AsyncWrite] object, positioned at the point where downloaded data should
     /// be written.
-    async fn get_writer<'a>(&'a mut self) -> Result<Box<dyn AsyncWrite + Unpin + 'a>>;
+    ///
+    /// The `content_length` parameter holds the response's `Content-Length` if it's known (see
+    /// [content_length](reqwest::Response::content_length)). It's only a hint intended for sizing
+    /// the writer, and must not be relied upon. It might be `None` for chunked or decompressed
+    /// responses, and for a compressed body it reflects the compressed size, so the number of bytes
+    /// actually written may differ.
+    async fn get_writer<'a>(
+        &'a mut self,
+        content_length: Option<u64>,
+    ) -> Result<Box<dyn AsyncWrite + Unpin + 'a>>;
 }
 
 /// A CusorWriterFactory creates [AsyncWrite] objects from a [std::io::Cursor], allowing
@@ -21,7 +30,10 @@ pub struct CursorWriterFactory<T>(Cursor<T>);
 
 #[async_trait]
 impl AsyncWriterFactory for CursorWriterFactory<Vec<u8>> {
-    async fn get_writer<'a>(&'a mut self) -> Result<Box<dyn AsyncWrite + Unpin + 'a>> {
+    async fn get_writer<'a>(
+        &'a mut self,
+        _: Option<u64>,
+    ) -> Result<Box<dyn AsyncWrite + Unpin + 'a>> {
         self.0.get_mut().clear();
         self.0.set_position(0);
         Ok(Box::new(&mut self.0))
@@ -30,7 +42,10 @@ impl AsyncWriterFactory for CursorWriterFactory<Vec<u8>> {
 
 #[async_trait]
 impl AsyncWriterFactory for CursorWriterFactory<&mut [u8]> {
-    async fn get_writer<'a>(&'a mut self) -> Result<Box<dyn AsyncWrite + Unpin + 'a>> {
+    async fn get_writer<'a>(
+        &'a mut self,
+        _: Option<u64>,
+    ) -> Result<Box<dyn AsyncWrite + Unpin + 'a>> {
         self.0.set_position(0);
         Ok(Box::new(&mut self.0))
     }
@@ -72,7 +87,10 @@ pub struct FileWriterFactory(File);
 
 #[async_trait]
 impl AsyncWriterFactory for FileWriterFactory {
-    async fn get_writer<'a>(&'a mut self) -> Result<Box<dyn AsyncWrite + Unpin + 'a>> {
+    async fn get_writer<'a>(
+        &'a mut self,
+        _: Option<u64>,
+    ) -> Result<Box<dyn AsyncWrite + Unpin + 'a>> {
         let mut file = self.0.try_clone().await?;
         file.set_len(0).await?;
         file.seek(SeekFrom::Start(0)).await?;
@@ -107,7 +125,7 @@ mod test {
         factory: &mut F,
     ) -> std::io::Result<()> {
         let mut reader = Cursor::new(data);
-        let mut writer = factory.get_writer().await.unwrap();
+        let mut writer = factory.get_writer(Some(data.len() as u64)).await.unwrap();
         copy(&mut reader, &mut writer).await?;
         Ok(())
     }

--- a/clients/client-rust/download/src/geturl.rs
+++ b/clients/client-rust/download/src/geturl.rs
@@ -1,8 +1,10 @@
 use anyhow::Error;
 use futures_util::stream::StreamExt;
 use reqwest::header;
-use tokio::io::{copy, AsyncWrite};
+use tokio::io::copy;
 use tokio_util::io::StreamReader;
+
+use crate::AsyncWriterFactory;
 
 /// A result from a possibly-retriable operation.
 pub(crate) enum RetriableResult<R, E> {
@@ -20,9 +22,9 @@ pub(crate) struct FetchMetadata {
 
 /// Get a URL using `reqwest.get` and write it to an AsyncWriterFactory's factory.  The return
 /// value indicates whether the operation can be retried.  Returns metadata about the fetched data.
-pub(crate) async fn get_url(
+pub(crate) async fn get_url<AWF: AsyncWriterFactory>(
     url: &str,
-    writer: &mut (dyn AsyncWrite + Unpin),
+    writer_factory: &mut AWF,
 ) -> RetriableResult<FetchMetadata, Error> {
     let res = match reqwest::get(url)
         .await
@@ -38,6 +40,11 @@ pub(crate) async fn get_url(
         }
 
         Ok(res) => res,
+    };
+
+    let mut writer = match writer_factory.get_writer(res.content_length()).await {
+        Ok(w) => w,
+        Err(e) => return RetriableResult::Permanent(e),
     };
 
     // determine the content type and length before moving `res`
@@ -56,11 +63,84 @@ pub(crate) async fn get_url(
         .map(|r| r.map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e)));
     let mut reader = StreamReader::new(stream);
 
-    match copy(&mut reader, writer).await {
+    match copy(&mut reader, &mut writer).await {
         Ok(_) => {}
         // an error copying data from the remote is common and retriable
         Err(e) => return RetriableResult::Retriable(e.into()),
     };
 
     return RetriableResult::Ok(FetchMetadata { content_type });
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::test_helpers::FakeDataServer;
+    use async_trait::async_trait;
+    use tokio::io::AsyncWrite;
+
+    #[derive(Default)]
+    struct SpyWriterFactory {
+        content_lengths: Vec<Option<u64>>,
+        buf: Vec<u8>,
+    }
+
+    #[async_trait]
+    impl AsyncWriterFactory for SpyWriterFactory {
+        async fn get_writer<'a>(
+            &'a mut self,
+            content_length: Option<u64>,
+        ) -> anyhow::Result<Box<dyn AsyncWrite + Unpin + 'a>> {
+            self.content_lengths.push(content_length);
+            self.buf.clear();
+            Ok(Box::new(&mut self.buf))
+        }
+    }
+
+    #[tokio::test]
+    async fn get_writer_receives_content_length_on_success() {
+        let server = FakeDataServer::new(false, &[200]);
+        let mut factory = SpyWriterFactory::default();
+
+        match get_url(&server.data_url(), &mut factory).await {
+            RetriableResult::Ok(_) => {}
+            _ => panic!("expected a successful fetch"),
+        }
+
+        assert_eq!(factory.content_lengths, vec![Some(12)]);
+        assert_eq!(&factory.buf, b"hello, world");
+    }
+
+    #[tokio::test]
+    async fn get_writer_only_called_after_retry_success() {
+        let server = FakeDataServer::new(false, &[500, 200]);
+        let mut factory = SpyWriterFactory::default();
+
+        match get_url(&server.data_url(), &mut factory).await {
+            RetriableResult::Retriable(_) => {}
+            _ => panic!("expected a retriable failure"),
+        }
+        assert!(factory.content_lengths.is_empty());
+        assert!(factory.buf.is_empty());
+
+        match get_url(&server.data_url(), &mut factory).await {
+            RetriableResult::Ok(_) => {}
+            _ => panic!("expected a successful fetch"),
+        }
+        assert_eq!(factory.content_lengths, vec![Some(12)]);
+        assert_eq!(&factory.buf, b"hello, world");
+    }
+
+    #[tokio::test]
+    async fn get_writer_not_called_on_client_error() {
+        let server = FakeDataServer::new(false, &[400]);
+        let mut factory = SpyWriterFactory::default();
+
+        match get_url(&server.data_url(), &mut factory).await {
+            RetriableResult::Permanent(_) => {}
+            _ => panic!("expected a permanent failure"),
+        }
+
+        assert!(factory.content_lengths.is_empty());
+    }
 }

--- a/clients/client-rust/download/src/hashing.rs
+++ b/clients/client-rust/download/src/hashing.rs
@@ -1,5 +1,6 @@
 use super::factory::AsyncWriterFactory;
 use anyhow::Result;
+use async_trait::async_trait;
 use sha2::{Digest, Sha256, Sha512};
 use std::collections::HashMap;
 use std::pin::Pin;
@@ -26,17 +27,6 @@ impl<'f, AWF: AsyncWriterFactory> HasherAsyncWriterFactory<'f, AWF> {
         }
     }
 
-    pub(super) async fn get_writer<'a>(&'a mut self) -> Result<Box<dyn AsyncWrite + Unpin + 'a>> {
-        let writer = self.writer_factory.get_writer().await?;
-        let hasher = Arc::new(Hasher::new());
-        self.latest_hasher = Some(hasher.clone());
-
-        Ok(Box::new(HashingAsyncWrite {
-            inner: writer,
-            hasher,
-        }))
-    }
-
     /// Get the hashes determined from the latest writer.
     ///
     /// ## Panics
@@ -49,6 +39,26 @@ impl<'f, AWF: AsyncWriterFactory> HasherAsyncWriterFactory<'f, AWF> {
             .as_ref()
             .expect("no previous calls to get_writer");
         hasher.hashes()
+    }
+}
+
+#[async_trait]
+impl<'f, AWF> AsyncWriterFactory for HasherAsyncWriterFactory<'f, AWF>
+where
+    AWF: AsyncWriterFactory + Send,
+{
+    async fn get_writer<'a>(
+        &'a mut self,
+        content_length: Option<u64>,
+    ) -> Result<Box<dyn AsyncWrite + Unpin + 'a>> {
+        let writer = self.writer_factory.get_writer(content_length).await?;
+        let hasher = Arc::new(Hasher::new());
+        self.latest_hasher = Some(hasher.clone());
+
+        Ok(Box::new(HashingAsyncWrite {
+            inner: writer,
+            hasher,
+        }))
     }
 }
 

--- a/clients/client-rust/download/src/object.rs
+++ b/clients/client-rust/download/src/object.rs
@@ -59,7 +59,7 @@ pub async fn download_to_file(
 
 /// Download an object using an [AsyncWriterFactory].  This is useful for advanced cases where one
 /// of the convenience functions is not adequate.  Returns the object's content type.
-pub async fn download_with_factory<AWF: AsyncWriterFactory>(
+pub async fn download_with_factory<AWF: AsyncWriterFactory + Send>(
     name: &str,
     retry: &Retry,
     object_service: &Object,
@@ -71,7 +71,7 @@ pub async fn download_with_factory<AWF: AsyncWriterFactory>(
 
 /// Internal implementation of downloads, using the ObjectService trait to allow
 /// injecting a fake dependency.  Returns the object's content-type.
-pub(crate) async fn download_impl<O: ObjectService, AWF: AsyncWriterFactory>(
+pub(crate) async fn download_impl<O: ObjectService, AWF: AsyncWriterFactory + Send>(
     name: &str,
     retry: &Retry,
     object_service: &O,
@@ -102,7 +102,7 @@ pub(crate) async fn download_impl<O: ObjectService, AWF: AsyncWriterFactory>(
     }
 }
 
-async fn geturl_download<O: ObjectService, AWF: AsyncWriterFactory>(
+async fn geturl_download<O: ObjectService, AWF: AsyncWriterFactory + Send>(
     mut response_json: serde_json::Value,
     name: &str,
     object_service: &O,
@@ -145,8 +145,7 @@ async fn geturl_download<O: ObjectService, AWF: AsyncWriterFactory>(
 
         response_used = true;
         attempts += 1;
-        let mut writer = writer_factory.get_writer().await?;
-        match get_url(start_download_response.url.as_ref(), writer.as_mut()).await {
+        match get_url(start_download_response.url.as_ref(), &mut writer_factory).await {
             RetriableResult::Ok(fetchmeta) => break Ok::<FetchMetadata, anyhow::Error>(fetchmeta),
             RetriableResult::Retriable(err) => match backoff.next_backoff() {
                 Some(duration) => {


### PR DESCRIPTION
The `AsyncWriterFactor::get_writer` method now takes an optional `content_length` parameter that indicates what size the writer should expect.

This means that the `get_writer` is now called after the initial request succeeded so the CONTENT_LENGTH header can be pulled from it.

This PR is #8516 re-opened because I'm a dummy and git branches are hard and I need more coffee. I didn't write any of it
