### PR TITLE
Fix claimWork's long poll timers, clear them and stop failing to pool them

### DIFF
--- a/changelog/fBw2096USZq5PF1eW2y1-A.md
+++ b/changelog/fBw2096USZq5PF1eW2y1-A.md
@@ -1,0 +1,2 @@
+level: silent
+---

--- a/services/queue/src/api.js
+++ b/services/queue/src/api.js
@@ -1439,17 +1439,7 @@ builder.declare(
   }
 );
 
-// Hack to get promises that resolve after 20s without creating a setTimeout
-// for each, instead we create a new promise every 2s and reuse that.
-const _lastTime = 0;
-let _sleeping = null;
-const sleep20Seconds = () => {
-  const time = Date.now();
-  if (!_sleeping || time - _lastTime > 2000) {
-    _sleeping = new Promise(accept => setTimeout(accept, 20 * 1000));
-  }
-  return _sleeping;
-};
+const CLAIM_WORK_TIMEOUT_MS = 20 * 1000;
 
 /** Claim any task */
 builder.declare(
@@ -1488,42 +1478,51 @@ builder.declare(
 
     const worker = await Worker.get(this.db, taskQueueId, workerGroup, workerId, new Date());
 
-    // Don't claim tasks when worker is quarantined (but do record the worker
-    // being seen, and be sure to wait the 20 seconds so as not to cause a
-    // tight loop of claimWork calls from the worker
-    if (worker && worker.quarantineUntil.getTime() > Date.now()) {
-      await Promise.all([this.workerInfo.seen(taskQueueId, workerGroup, workerId), sleep20Seconds()]);
+    let timer;
+    const timeout = new Promise(accept => {
+      timer = setTimeout(accept, CLAIM_WORK_TIMEOUT_MS);
+    });
+
+    try {
+      // Don't claim tasks when worker is quarantined (but do record the worker
+      // being seen, and be sure to wait the 20 seconds so as not to cause a
+      // tight loop of claimWork calls from the worker
+      if (worker && worker.quarantineUntil.getTime() > Date.now()) {
+        await Promise.all([this.workerInfo.seen(taskQueueId, workerGroup, workerId), timeout]);
+        return res.reply({
+          tasks: [],
+        });
+      }
+
+      // Allow request to abort their claim request, if the connection closes
+      const aborted = new Promise(accept => {
+        timeout.then(accept);
+        res.once('close', accept);
+      });
+
+      const [result] = await Promise.all([
+        this.workClaimer.claim(taskQueueId, workerGroup, workerId, count, aborted),
+        this.workerInfo.seen(taskQueueId, workerGroup, workerId),
+      ]);
+
+      result.forEach(({ runId, status: { taskId } }) => {
+        this.monitor.log.taskClaimed({
+          taskQueueId,
+          workerGroup,
+          workerId,
+          taskId,
+          runId,
+        });
+      });
+
+      await this.workerInfo.taskSeen(taskQueueId, workerGroup, workerId, result);
+
       return res.reply({
-        tasks: [],
+        tasks: result,
       });
+    } finally {
+      clearTimeout(timer);
     }
-
-    // Allow request to abort their claim request, if the connection closes
-    const aborted = new Promise(accept => {
-      sleep20Seconds().then(accept);
-      res.once('close', accept);
-    });
-
-    const [result] = await Promise.all([
-      this.workClaimer.claim(taskQueueId, workerGroup, workerId, count, aborted),
-      this.workerInfo.seen(taskQueueId, workerGroup, workerId),
-    ]);
-
-    result.forEach(({ runId, status: { taskId } }) => {
-      this.monitor.log.taskClaimed({
-        taskQueueId,
-        workerGroup,
-        workerId,
-        taskId,
-        runId,
-      });
-    });
-
-    await this.workerInfo.taskSeen(taskQueueId, workerGroup, workerId, result);
-
-    return res.reply({
-      tasks: result,
-    });
   }
 );
 


### PR DESCRIPTION
`claimWork` arms a 20s timer for each request, bound to its `accept` which is the base of how long polling works in the queue. That timer was never cleared, even when long polling did return a task early. Clear it in a `finally` block so it's always released. This avoids having to duplicate the release between return paths and has the benefit of releasing the timer if the handler ever throws.

I simplified the whole timer handling by removing the `sleep20Seconds` hack which was supposed to pool timers by creating new ones every 2s. Except that it never did because it never set `_lastTime` so `time - _lastTime > 2000` was always true. That behavior was added in 290861a46d63a49d06d4975c78855f0e4bb5c515 which comes from an unreviewed PR, 9 years ago where there's no justification for doing this except "reduce number of timers". No numbers, no profiling. Given this never worked I'm guessing that timers were never an issue and that this was at best guess work. It also did the exact opposite of what it says because it removed a `clearTimeout` that was doing what I'm adding in this commit.

As such, I didn't even try to fix pooling and instead explicitly give each connection its own timer. This keeps the current behavior but does so in a way that doesn't lie about intention.

Funnily enough, this came up in 8b6799c67d4c97a62cdd67ea65b3f363f9edac38 but I didn't see it back then when I made `_lastTime` const which was a clear indicator that something was wrong.

This commit diff is better viewed by ignoring whitespaces