### PR TITLE
Fix a bunch of garbage collection related regressions from the capacity > 1 PR

### DIFF
--- a/changelog/G_fwT2ONSUSff9JmP7GbrA.md
+++ b/changelog/G_fwT2ONSUSff9JmP7GbrA.md
@@ -1,0 +1,5 @@
+audience: users
+level: patch
+---
+Workers will now reliably clean task directories / users again. The cleanup
+behavior was regressed in v100.0.0

--- a/changelog/IcuFYnKGRD-PlXaLCA6c_Q.md
+++ b/changelog/IcuFYnKGRD-PlXaLCA6c_Q.md
@@ -1,0 +1,5 @@
+audience: worker-deployers
+level: patch
+---
+Generic worker now continues trying to garbage collect caches even if one
+removal fails for any reason

--- a/changelog/SES85WCcQnytiJD1yDuNDQ.md
+++ b/changelog/SES85WCcQnytiJD1yDuNDQ.md
@@ -1,0 +1,5 @@
+audience: users
+level: patch
+---
+Generic worker will try evicting writable cache directories again when garbage
+collecting. This was regressed in v100.0.0

--- a/changelog/issue-8942.md
+++ b/changelog/issue-8942.md
@@ -1,0 +1,7 @@
+audience: users
+level: patch
+reference: issue 8942
+---
+Fix workers panicking if a task that's not resolved yet would exhaust enough
+disk space for the worker to not meet their minimum disk space required to
+claim new tasks.

--- a/workers/generic-worker/diskspace_posix.go
+++ b/workers/generic-worker/diskspace_posix.go
@@ -3,7 +3,6 @@
 package main
 
 import (
-	"log"
 	"syscall"
 )
 
@@ -14,7 +13,5 @@ func freeDiskSpaceBytes(dir string) (uint64, error) {
 		return 0, err
 	}
 	// Available blocks * size per block = available space in bytes
-	b := uint64(stat.Bavail) * uint64(stat.Bsize)
-	log.Printf("Disk available: %v bytes", b)
-	return b, nil
+	return uint64(stat.Bavail) * uint64(stat.Bsize), nil
 }

--- a/workers/generic-worker/diskspace_windows.go
+++ b/workers/generic-worker/diskspace_windows.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"log"
 	"syscall"
 
 	"github.com/taskcluster/taskcluster/v103/workers/generic-worker/win32"
@@ -17,6 +16,5 @@ func freeDiskSpaceBytes(dir string) (uint64, error) {
 	if err != nil {
 		return 0, err
 	}
-	log.Printf("Disk available: %v bytes", freeBytes)
 	return freeBytes, nil
 }

--- a/workers/generic-worker/garbagecollector.go
+++ b/workers/generic-worker/garbagecollector.go
@@ -103,7 +103,10 @@ func runGarbageCollection(r Resources, tasksRunning bool) error {
 			break
 		}
 
-		if evictErr := r.EvictNext(); evictErr != nil {
+		cacheMutex.Lock()
+		evictErr := r.EvictNext()
+		cacheMutex.Unlock()
+		if evictErr != nil {
 			log.Printf("WARNING: could not evict cache: %v", evictErr)
 		}
 

--- a/workers/generic-worker/garbagecollector.go
+++ b/workers/generic-worker/garbagecollector.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"log"
 
 	"github.com/taskcluster/taskcluster/v103/workers/generic-worker/host"
 )
@@ -60,6 +61,10 @@ func runGarbageCollection(r Resources, tasksRunning bool) error {
 		return fmt.Errorf("could not calculate free disk space in dir %v due to error %#v", config.TasksDir, err)
 	}
 	requiredFreeSpace := requiredSpaceBytes()
+
+	if currentFreeSpace < requiredFreeSpace {
+		log.Printf("Only %v bytes available in %v but %v required. Garbage collecting", currentFreeSpace, config.TasksDir, requiredFreeSpace)
+	}
 
 	if currentFreeSpace < requiredFreeSpace && config.D2GEnabled() && !tasksRunning {
 		err := host.Run("docker", "volume", "prune", "--all", "--force")

--- a/workers/generic-worker/garbagecollector.go
+++ b/workers/generic-worker/garbagecollector.go
@@ -23,13 +23,13 @@ func (r Resources) Empty() bool {
 	return len(r) == 0
 }
 
+// EvictNext evicts the next resource in deletion order and drops it from
+// the list. It is dropped even if eviction failed, so that a caller which
+// carries on after an error doesn't retry the same failing entry forever.
 func (r *Resources) EvictNext() error {
 	err := (*r)[0].Evict(nil)
-	if err != nil {
-		return err
-	}
 	*r = (*r)[1:]
-	return nil
+	return err
 }
 
 // Implement sort.Interface to sort by deletion order.
@@ -103,9 +103,8 @@ func runGarbageCollection(r Resources, tasksRunning bool) error {
 			break
 		}
 
-		err = r.EvictNext()
-		if err != nil {
-			return err
+		if evictErr := r.EvictNext(); evictErr != nil {
+			log.Printf("WARNING: could not evict cache: %v", evictErr)
 		}
 
 		currentFreeSpace, err = freeDiskSpaceBytes(config.TasksDir)

--- a/workers/generic-worker/garbagecollector.go
+++ b/workers/generic-worker/garbagecollector.go
@@ -53,6 +53,8 @@ func (r Resources) Swap(i, j int) {
 // remove images that a D2G task has loaded but not yet started a
 // container for.
 //
+// It returns an error when a step it attempted failed.
+//
 // It should be independent of mounts feature, but let's go with it here
 // as currently that is the only feature that uses it.
 func runGarbageCollection(r Resources, tasksRunning bool) error {
@@ -110,10 +112,6 @@ func runGarbageCollection(r Resources, tasksRunning bool) error {
 		if err != nil {
 			return fmt.Errorf("could not calculate free disk space in dir %v due to error %#v", config.TasksDir, err)
 		}
-	}
-
-	if currentFreeSpace < requiredFreeSpace {
-		return fmt.Errorf("not able to free up enough disk space - require %v bytes, but only have %v bytes - and nothing left to delete", requiredFreeSpace, currentFreeSpace)
 	}
 
 	return nil

--- a/workers/generic-worker/main.go
+++ b/workers/generic-worker/main.go
@@ -611,23 +611,35 @@ mainLoop:
 			}
 		}
 
+		canClaimTask := claimCount > 0
+
+		// Ensure there is enough disk space *before* claiming a task.
+		if canClaimTask {
+			// Pass tasksRunning so docker prune is skipped when tasks may
+			// have loaded images that are not yet running in a container.
+			tasksRunning := !taskManager.IsIdle()
+			err := garbageCollection(tasksRunning)
+			if err != nil {
+				if !tasksRunning {
+					// If we're not running any task and have no way to claim
+					// one, something is wrong, panic
+					panic(err)
+				}
+
+				log.Printf("Not claiming any task: %v", err)
+				canClaimTask = false
+			}
+		}
+
 		// Make sure at least 5 seconds pass between tcqueue.ClaimWork API
 		// calls. Only back off if we could actually claim a task during that
 		// cycle.
 		var claimBackoff <-chan time.Time
-		if claimCount > 0 || taskManager.IsIdle() {
+		if canClaimTask || taskManager.IsIdle() {
 			claimBackoff = time.NewTimer(time.Second * 5).C
 		}
 
-		if claimCount > 0 {
-			// Ensure there is enough disk space *before* claiming a task.
-			// Pass tasksRunning so docker prune is skipped when tasks may
-			// have loaded images that are not yet running in a container.
-			err := garbageCollection(!taskManager.IsIdle())
-			if err != nil {
-				panic(err)
-			}
-
+		if canClaimTask {
 			// Unified task execution: always use per-task context regardless of capacity
 			tasks := ClaimWork(claimCount)
 			for _, task := range tasks {

--- a/workers/generic-worker/main.go
+++ b/workers/generic-worker/main.go
@@ -561,10 +561,11 @@ func RunWorker() (exitCode ExitCode) {
 		return 0, false
 	}
 
+	processedCompletion := false
+
 mainLoop:
 	for {
 		// Process any completed tasks
-		processedCompletion := false
 		for {
 			select {
 			case result := <-taskCompleteChan:
@@ -578,6 +579,7 @@ mainLoop:
 		}
 	doneProcessingCompletions:
 		if processedCompletion {
+			processedCompletion = false
 			err := purgeOldTasks(taskManager.RunningTaskDirNames()...)
 			if err != nil {
 				log.Printf("ERROR: purging old tasks: %v", err)
@@ -816,6 +818,7 @@ mainLoop:
 			// and rely on the top-of-loop drain to pick it up — that
 			// pattern was sensitive to the chan buffer size and
 			// goroutine count invariants.
+			processedCompletion = true
 			if exit, done := processCompletionAction(processCompletion(result)); done {
 				return exit
 			}

--- a/workers/generic-worker/main.go
+++ b/workers/generic-worker/main.go
@@ -589,14 +589,6 @@ mainLoop:
 			return WORKER_MANAGER_SHUTDOWN
 		}
 
-		// Ensure there is enough disk space *before* claiming a task.
-		// Pass tasksRunning so docker prune is skipped when tasks may
-		// have loaded images that are not yet running in a container.
-		err := garbageCollection(!taskManager.IsIdle())
-		if err != nil {
-			panic(err)
-		}
-
 		if graceful.TerminationRequested() {
 			log.Printf("Graceful termination requested, waiting for %d running tasks...", taskManager.TaskCount())
 			taskManager.WaitForAll()
@@ -628,6 +620,14 @@ mainLoop:
 		}
 
 		if claimCount > 0 {
+			// Ensure there is enough disk space *before* claiming a task.
+			// Pass tasksRunning so docker prune is skipped when tasks may
+			// have loaded images that are not yet running in a container.
+			err := garbageCollection(!taskManager.IsIdle())
+			if err != nil {
+				panic(err)
+			}
+
 			// Unified task execution: always use per-task context regardless of capacity
 			tasks := ClaimWork(claimCount)
 			for _, task := range tasks {

--- a/workers/generic-worker/main.go
+++ b/workers/generic-worker/main.go
@@ -619,8 +619,13 @@ mainLoop:
 			}
 		}
 
-		// make sure at least 5 seconds pass between tcqueue.ClaimWork API calls
-		wait5Seconds := time.NewTimer(time.Second * 5)
+		// Make sure at least 5 seconds pass between tcqueue.ClaimWork API
+		// calls. Only back off if we could actually claim a task during that
+		// cycle.
+		var claimBackoff <-chan time.Time
+		if claimCount > 0 || taskManager.IsIdle() {
+			claimBackoff = time.NewTimer(time.Second * 5).C
+		}
 
 		if claimCount > 0 {
 			// Unified task execution: always use per-task context regardless of capacity
@@ -786,8 +791,10 @@ mainLoop:
 		// between consecutive requests. Note we do this even if a task ran,
 		// since a task could complete in less than that amount of time.
 		// However, if a task completes, we should process it immediately.
+		// claimBackoff is nil when there is nothing to claim until a running
+		// task finishes, in which case this blocks until one does.
 		select {
-		case <-wait5Seconds.C:
+		case <-claimBackoff:
 		case result := <-taskCompleteChan:
 			// Process the completion in-place, then loop back to the
 			// top to drain any siblings and run the post-completion

--- a/workers/generic-worker/main.go
+++ b/workers/generic-worker/main.go
@@ -637,6 +637,8 @@ mainLoop:
 		var claimBackoff <-chan time.Time
 		if canClaimTask || taskManager.IsIdle() {
 			claimBackoff = time.NewTimer(time.Second * 5).C
+		} else {
+			log.Printf("Waiting for one of %v running tasks to complete before claiming again", taskManager.TaskCount())
 		}
 
 		if canClaimTask {

--- a/workers/generic-worker/mounts_feature.go
+++ b/workers/generic-worker/mounts_feature.go
@@ -591,9 +591,8 @@ func garbageCollection(tasksRunning bool) error {
 	dirResources := directoryCaches.SortedResources()
 	for _, res := range dirResources {
 		cache := res.(*Cache)
-		evictErr := cache.Evict(nil)
-		if evictErr != nil {
-			return evictErr
+		if evictErr := cache.Evict(nil); evictErr != nil {
+			log.Printf("WARNING: could not evict cache %v: %v", cache.Key, evictErr)
 		}
 
 		currentFreeSpace, err = freeDiskSpaceBytes(config.TasksDir)
@@ -601,14 +600,12 @@ func garbageCollection(tasksRunning bool) error {
 			return fmt.Errorf("could not calculate free disk space in dir %v due to error %#v", config.TasksDir, err)
 		}
 		if currentFreeSpace >= requiredSpaceBytes() {
+			trimPoolExcess()
 			return nil
 		}
 	}
 
-	if currentFreeSpace < requiredSpaceBytes() {
-		return fmt.Errorf("not able to free up enough disk space - require %v bytes, but only have %v bytes - and nothing left to delete", requiredSpaceBytes(), currentFreeSpace)
-	}
-	return nil
+	return fmt.Errorf("not able to free up enough disk space - require %v bytes, but only have %v bytes - and nothing left to delete", requiredSpaceBytes(), currentFreeSpace)
 }
 
 // called when a task starts

--- a/workers/generic-worker/mounts_feature.go
+++ b/workers/generic-worker/mounts_feature.go
@@ -180,7 +180,9 @@ func (cm FileCacheMap) SortedResources() Resources {
 }
 
 func (cm FileCacheMap) Remove(entry *Cache) {
-	delete(cm, entry.Key)
+	if cm[entry.Key] == entry {
+		delete(cm, entry.Key)
+	}
 }
 
 func (cm *FileCacheMap) LoadFromFile(stateFile string, cacheDir string) {


### PR DESCRIPTION
I was already pretty unhappy about the state of a few things post #8278 and this didn't change my mind at all. I had my eyes very much set on `git revert` while unwinding this whole garbage collection stuff...

I would recommend reviewing this commit by commit as each of them fixes something different. I added changelog entries for changes that are relevant to users/worker deployers.

Note that while fixing these, I found 3 more regressions from that one PR that I didn't have the courage to fix. (#8943, #8944 and #8945).

There's one commit in here that fixes a bug that predates #8278, I included it in the same stack because I was touching relevant code anyway and it's a very small change.

Fixes #8942