### PR TITLE
feat(w-m): worker manager refuses to refresh credentials when worker is not running or expired

### DIFF
--- a/changelog/issue-8947.md
+++ b/changelog/issue-8947.md
@@ -1,0 +1,6 @@
+audience: general
+level: patch
+reference: issue 8947
+---
+
+Worker-manager refuses to re-register worker if it is no longer in Running state or has expired.

--- a/services/worker-manager/src/api.js
+++ b/services/worker-manager/src/api.js
@@ -1294,6 +1294,14 @@ builder.declare(
       return res.reportError('InputError', 'Could not generate credentials for this secret', {});
     }
 
+    if (worker.state !== Worker.states.RUNNING) {
+      return res.reportError('InputError', `Worker ${workerGroup}/${workerId} is not running`, {});
+    }
+
+    if (worker.expires < new Date()) {
+      return res.reportError('InputError', `Worker ${workerGroup}/${workerId} has expired`, {});
+    }
+
     // worker has not been registered yet
     if (!worker.secret) {
       return res.reportError('InputError', 'Could not generate credentials for this secret', {});

--- a/services/worker-manager/src/api.js
+++ b/services/worker-manager/src/api.js
@@ -1294,14 +1294,6 @@ builder.declare(
       return res.reportError('InputError', 'Could not generate credentials for this secret', {});
     }
 
-    if (worker.state !== Worker.states.RUNNING) {
-      return res.reportError('InputError', `Worker ${workerGroup}/${workerId} is not running`, {});
-    }
-
-    if (worker.expires < new Date()) {
-      return res.reportError('InputError', `Worker ${workerGroup}/${workerId} has expired`, {});
-    }
-
     // worker has not been registered yet
     if (!worker.secret) {
       return res.reportError('InputError', 'Could not generate credentials for this secret', {});
@@ -1309,6 +1301,14 @@ builder.declare(
 
     if (this.db.decrypt({ value: worker.secret }).toString('utf8') !== secret) {
       return res.reportError('InputError', 'Could not generate credentials for this secret', {});
+    }
+
+    if (worker.state !== Worker.states.RUNNING) {
+      return res.reportError('InputError', `Worker ${workerGroup}/${workerId} is not running`, {});
+    }
+
+    if (worker.expires < new Date()) {
+      return res.reportError('InputError', `Worker ${workerGroup}/${workerId} has expired`, {});
     }
 
     // defaults to 96 hours if reregistrationTimeout is not defined

--- a/services/worker-manager/test/api_test.js
+++ b/services/worker-manager/test/api_test.js
@@ -2131,6 +2131,56 @@ helper.secrets.mockSuite(testing.suiteName(), [], (mock, skipping) => {
       }, /Could not generate credentials for this secret/);
     });
 
+    test('throws when worker is not running', async () => {
+      await createWorkerPool({});
+      await createWorker({});
+      await helper.workerManager.registerWorker({
+        ...defaultRegisterWorker,
+      });
+
+      await helper.withAdminDbClient(async client => {
+        await client.query(`update workers set state=$1 WHERE worker_pool_id=$2 AND worker_group=$3 AND worker_id=$4`, [
+          Worker.states.STOPPING,
+          workerPoolId,
+          workerGroup,
+          workerId,
+        ]);
+      });
+
+      await assert.rejects(async () => {
+        await helper.workerManager.reregisterWorker({
+          workerPoolId,
+          workerGroup,
+          workerId,
+          secret: `${slug.nice()}${slug.nice()}`,
+        });
+      }, /Worker .+ is not running/);
+    });
+
+    test('throws when worker is expired', async () => {
+      await createWorkerPool({});
+      await createWorker({});
+      await helper.workerManager.registerWorker({
+        ...defaultRegisterWorker,
+      });
+
+      await helper.withAdminDbClient(async client => {
+        await client.query(
+          `update workers set expires=$1 WHERE worker_pool_id=$2 AND worker_group=$3 AND worker_id=$4`,
+          [taskcluster.fromNow('-1 hour'), workerPoolId, workerGroup, workerId]
+        );
+      });
+
+      await assert.rejects(async () => {
+        await helper.workerManager.reregisterWorker({
+          workerPoolId,
+          workerGroup,
+          workerId,
+          secret: `${slug.nice()}${slug.nice()}`,
+        });
+      }, /Worker .+ has expired/);
+    });
+
     test('throws when worker does not exist', async () => {
       await createWorkerPool({});
       await createWorker({

--- a/services/worker-manager/test/api_test.js
+++ b/services/worker-manager/test/api_test.js
@@ -2134,7 +2134,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], (mock, skipping) => {
     test('throws when worker is not running', async () => {
       await createWorkerPool({});
       await createWorker({});
-      await helper.workerManager.registerWorker({
+      const firstResponse = await helper.workerManager.registerWorker({
         ...defaultRegisterWorker,
       });
 
@@ -2152,7 +2152,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], (mock, skipping) => {
           workerPoolId,
           workerGroup,
           workerId,
-          secret: `${slug.nice()}${slug.nice()}`,
+          secret: firstResponse.secret,
         });
       }, /Worker .+ is not running/);
     });
@@ -2160,7 +2160,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], (mock, skipping) => {
     test('throws when worker is expired', async () => {
       await createWorkerPool({});
       await createWorker({});
-      await helper.workerManager.registerWorker({
+      const firstResponse = await helper.workerManager.registerWorker({
         ...defaultRegisterWorker,
       });
 
@@ -2176,7 +2176,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], (mock, skipping) => {
           workerPoolId,
           workerGroup,
           workerId,
-          secret: `${slug.nice()}${slug.nice()}`,
+          secret: firstResponse.secret,
         });
       }, /Worker .+ has expired/);
     });


### PR DESCRIPTION
In some edge cases it was possible for a worker to be stopping/stopped/expired and still request refreshed credentials.

Fixes #8947
