### PR TITLE
chore(docs): Update task group sealing documentation and endpoint

### DIFF
--- a/changelog/T2542ZhCQwuM-vHVk8Em4g.md
+++ b/changelog/T2542ZhCQwuM-vHVk8Em4g.md
@@ -1,0 +1,3 @@
+audience: users
+level: silent
+---

--- a/clients/client-go/tcqueue/tcqueue.go
+++ b/clients/client-go/tcqueue/tcqueue.go
@@ -385,6 +385,11 @@ func (queue *Queue) GetTaskGroup_SignedURL(taskGroupId string, duration time.Dur
 // Task group can be sealed once and is irreversible. Calling it multiple times
 // will return same result and will not update it again.
 //
+// Sealing makes `cancelTaskGroup` meaningful by stopping task creators
+// from adding more tasks to a group being cancelled. It is not a
+// security feature: the check is not atomic with task creation, so a
+// `createTask` racing this call may still succeed.
+//
 // Required scopes:
 //
 //	queue:seal-task-group:<schedulerId>/<taskGroupId>

--- a/clients/client-py/taskcluster/generated/aio/queue.py
+++ b/clients/client-py/taskcluster/generated/aio/queue.py
@@ -227,6 +227,11 @@ class Queue(AsyncBaseClient):
         Task group can be sealed once and is irreversible. Calling it multiple times
         will return same result and will not update it again.
 
+        Sealing makes `cancelTaskGroup` meaningful by stopping task creators
+        from adding more tasks to a group being cancelled. It is not a
+        security feature: the check is not atomic with task creation, so a
+        `createTask` racing this call may still succeed.
+
         This method is ``experimental``
         """
 

--- a/clients/client-py/taskcluster/generated/queue.py
+++ b/clients/client-py/taskcluster/generated/queue.py
@@ -225,6 +225,11 @@ class Queue(BaseClient):
         Task group can be sealed once and is irreversible. Calling it multiple times
         will return same result and will not update it again.
 
+        Sealing makes `cancelTaskGroup` meaningful by stopping task creators
+        from adding more tasks to a group being cancelled. It is not a
+        security feature: the check is not atomic with task creation, so a
+        `createTask` racing this call may still succeed.
+
         This method is ``experimental``
         """
 

--- a/clients/client-rust/client/src/generated/queue.rs
+++ b/clients/client-rust/client/src/generated/queue.rs
@@ -412,6 +412,11 @@ impl Queue {
     ///
     /// Task group can be sealed once and is irreversible. Calling it multiple times
     /// will return same result and will not update it again.
+    ///
+    /// Sealing makes `cancelTaskGroup` meaningful by stopping task creators
+    /// from adding more tasks to a group being cancelled. It is not a
+    /// security feature: the check is not atomic with task creation, so a
+    /// `createTask` racing this call may still succeed.
     pub async fn sealTaskGroup(&self, taskGroupId: &str) -> Result<Value, Error> {
         let method = "POST";
         let (path, query) = Self::sealTaskGroup_details(taskGroupId);

--- a/clients/client-shell/apis/services.go
+++ b/clients/client-shell/apis/services.go
@@ -1496,7 +1496,7 @@ var services = map[string]definitions.Service{
 			definitions.Entry{
 				Name:        "sealTaskGroup",
 				Title:       "Seal Task Group",
-				Description: "Seal task group to prevent creation of new tasks.\n\nTask group can be sealed once and is irreversible. Calling it multiple times\nwill return same result and will not update it again.",
+				Description: "Seal task group to prevent creation of new tasks.\n\nTask group can be sealed once and is irreversible. Calling it multiple times\nwill return same result and will not update it again.\n\nSealing makes `cancelTaskGroup` meaningful by stopping task creators\nfrom adding more tasks to a group being cancelled. It is not a\nsecurity feature: the check is not atomic with task creation, so a\n`createTask` racing this call may still succeed.",
 				Stability:   "experimental",
 				Method:      "post",
 				Route:       "/task-group/<taskGroupId>/seal",

--- a/clients/client-web/src/clients/Queue.js
+++ b/clients/client-web/src/clients/Queue.js
@@ -157,6 +157,10 @@ export default class Queue extends Client {
   // Seal task group to prevent creation of new tasks.
   // Task group can be sealed once and is irreversible. Calling it multiple times
   // will return same result and will not update it again.
+  // Sealing makes `cancelTaskGroup` meaningful by stopping task creators
+  // from adding more tasks to a group being cancelled. It is not a
+  // security feature: the check is not atomic with task creation, so a
+  // `createTask` racing this call may still succeed.
   sealTaskGroup(...args) {
     this.validate(this.sealTaskGroup.entry, args);
 

--- a/clients/client/src/apis.js
+++ b/clients/client/src/apis.js
@@ -2408,7 +2408,7 @@ export default {
             "taskGroupId"
           ],
           "category": "Task Groups",
-          "description": "Seal task group to prevent creation of new tasks.\n\nTask group can be sealed once and is irreversible. Calling it multiple times\nwill return same result and will not update it again.",
+          "description": "Seal task group to prevent creation of new tasks.\n\nTask group can be sealed once and is irreversible. Calling it multiple times\nwill return same result and will not update it again.\n\nSealing makes `cancelTaskGroup` meaningful by stopping task creators\nfrom adding more tasks to a group being cancelled. It is not a\nsecurity feature: the check is not atomic with task creation, so a\n`createTask` racing this call may still succeed.",
           "method": "post",
           "name": "sealTaskGroup",
           "output": "v1/task-group-response.json#",

--- a/generated/references.json
+++ b/generated/references.json
@@ -22800,7 +22800,7 @@
             "taskGroupId"
           ],
           "category": "Task Groups",
-          "description": "Seal task group to prevent creation of new tasks.\n\nTask group can be sealed once and is irreversible. Calling it multiple times\nwill return same result and will not update it again.",
+          "description": "Seal task group to prevent creation of new tasks.\n\nTask group can be sealed once and is irreversible. Calling it multiple times\nwill return same result and will not update it again.\n\nSealing makes `cancelTaskGroup` meaningful by stopping task creators\nfrom adding more tasks to a group being cancelled. It is not a\nsecurity feature: the check is not atomic with task creation, so a\n`createTask` racing this call may still succeed.",
           "method": "post",
           "name": "sealTaskGroup",
           "output": "v1/task-group-response.json#",

--- a/services/queue/src/api.js
+++ b/services/queue/src/api.js
@@ -582,6 +582,11 @@ builder.declare(
       '',
       'Task group can be sealed once and is irreversible. Calling it multiple times',
       'will return same result and will not update it again.',
+      '',
+      'Sealing makes `cancelTaskGroup` meaningful by stopping task creators',
+      'from adding more tasks to a group being cancelled. It is not a',
+      'security feature: the check is not atomic with task creation, so a',
+      '`createTask` racing this call may still succeed.',
     ].join('\n'),
   },
   async function (req, res) {

--- a/ui/docs/manual/tasks/groups.mdx
+++ b/ui/docs/manual/tasks/groups.mdx
@@ -42,6 +42,10 @@ To seal a task group, you can use the `queue.sealTaskGroup` method.
 Once a task group is sealed, it will no longer accept new tasks and will throw
 an error if new task is being added to it.
 
+Sealing is not a security feature. The check happens in `createTask` outside the
+task-insert transaction, so a call racing `sealTaskGroup` can still slip a task
+in.
+
 
 ## Cancelling Task Groups
 


### PR DESCRIPTION
just to point out that this is not a security feature, and exists primarily to allow cancel task group do it's job without worrying tasks would be added later.
This also allows some race conditions during sealing where createTask might still succeed


