### PR TITLE
Security: Mutable Default Argument in Exception Constructors

### DIFF
--- a/clients/client-py/taskcluster/exceptions.py
+++ b/clients/client-py/taskcluster/exceptions.py
@@ -10,11 +10,11 @@ class TaskclusterFailure(Exception):
 class TaskclusterRestFailure(TaskclusterFailure):
     """Failures in the HTTP Rest API"""
 
-    def __init__(self, msg, superExc, status_code=500, body={}):
+    def __init__(self, msg, superExc, status_code=500, body=None):
         TaskclusterFailure.__init__(self, msg)
         self.superExc = superExc
         self.status_code = status_code
-        self.body = body
+        self.body = body if body is not None else {}
 
     def __reduce__(self):
         return (
@@ -37,11 +37,11 @@ class TaskclusterConnectionError(TaskclusterFailure):
 class TaskclusterAuthFailure(TaskclusterFailure):
     """Invalid Credentials"""
 
-    def __init__(self, msg, superExc=None, status_code=500, body={}):
+    def __init__(self, msg, superExc=None, status_code=500, body=None):
         TaskclusterFailure.__init__(self, msg)
         self.superExc = superExc
         self.status_code = status_code
-        self.body = body
+        self.body = body if body is not None else {}
 
     def __reduce__(self):
         return (


### PR DESCRIPTION
## Summary

Security: Mutable Default Argument in Exception Constructors

## Problem

**Severity**: `Medium` | **File**: `clients/client-py/taskcluster/exceptions.py:L14`

The `TaskclusterRestFailure` and `TaskclusterAuthFailure` constructors use a mutable dictionary `body={}` as a default argument. In Python, default arguments are evaluated only once at function definition time. If the `body` dictionary is ever mutated within an instance (e.g., `self.body['key'] = 'value'`), the change will persist across all future instances that use the default, leading to shared state and unexpected cross-instance data leakage.

## Solution

Use `None` as the default argument and initialize the dictionary inside the constructor: `def __init__(self, msg, superExc, status_code=500, body=None): ... self.body = body if body is not None else {}`

## Changes

- `clients/client-py/taskcluster/exceptions.py` (modified)