### PR TITLE
chore(biome): migrate version in schema

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.5.1/schema.json",
+  "$schema": "./node_modules/@biomejs/biome/configuration_schema.json",
   "root": true,
   "files": {
     "includes": [

--- a/changelog/akI3cBAER6G8pE1znpYzlg.md
+++ b/changelog/akI3cBAER6G8pE1znpYzlg.md
@@ -1,0 +1,3 @@
+audience: developers
+level: silent
+---


### PR DESCRIPTION
For some reason it complains when you run lint that biome config is of different version.
yarn.lock was upgraded to 2.5.5 at some point

Running `yarn biome migrate --write` fixes this. 
Probably needs to be a part of biome upgrade or yarn generate at some point

UPD: if we set schema to `./node_modules/@biomejs/biome/configuration_schema.json` then we won't have to deal with future upgrades at all, it will always point to the same as the installed version. I think it's fine-ish

