### PR TITLE
fix(github): reporting artifact sizes requires correct property name

### DIFF
--- a/changelog/fix-github-artifact-content-length.md
+++ b/changelog/fix-github-artifact-content-length.md
@@ -1,0 +1,3 @@
+audience: developers
+level: silent
+---

--- a/services/github/src/handlers/status.js
+++ b/services/github/src/handlers/status.js
@@ -240,8 +240,8 @@ export async function statusHandler(message) {
         }
         // Add the formatted size to the name if the size exists
         let displayName = element.name;
-        if (element.size !== undefined) {
-          displayName = `${element.name} (${formatBytes(element.size)})`;
+        if (element.contentLength != null) {
+          displayName = `${element.name} (${formatBytes(element.contentLength)})`;
         }
         const ARTIFACT_LINK = markdownAnchor(displayName, artifactUrl);
 

--- a/services/github/test/handler_test.js
+++ b/services/github/test/handler_test.js
@@ -216,7 +216,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], (mock, skipping) => {
         for (let i = 0; i < options.limit; i++) {
           artifacts.push({
             name: `artifact-${i}`,
-            size: deterministicArtifactSize(i),
+            contentLength: deterministicArtifactSize(i),
           });
         }
         return Promise.resolve({ artifacts });


### PR DESCRIPTION
I totally missed that in #8666 and javascript is not so good with types

Correct property name is `contentLength` not `size`
