### PR TITLE
Guard credentials access in dashboard sidebar

### DIFF
--- a/changelog/UapPn7oHS5WNtcFnbt8uOg.md
+++ b/changelog/UapPn7oHS5WNtcFnbt8uOg.md
@@ -1,0 +1,4 @@
+audience: users
+level: patch
+---
+Fix the UI crashing on a fresh OIDC signin

--- a/ui/src/components/Dashboard/SidebarList.jsx
+++ b/ui/src/components/Dashboard/SidebarList.jsx
@@ -28,7 +28,7 @@ import { withAuth } from '../../utils/Auth';
 export default class SidebarList extends Component {
   render() {
     const { user } = this.props;
-    const clientId = user?.credentials.clientId;
+    const clientId = user?.credentials?.clientId;
 
     return (
       <List disablePadding>


### PR DESCRIPTION
Since #7590, SidebarList reads user.credentials.clientId to build the "Client Audit History" link but missed that `user` might be defined without credentials yet which ends up on a first login as `TypeError: can't access property "clientId", e.credentials is undefined`

A signed-in client without credentials is a normal state since the OIDC flow stores the `UserSession` without credentials, the `AuthController` emits `user-changed` immediately and credentials only arrive later on the `renew()` call. So any fresh OIDC sign-in actually hits that problem.
