### PR TITLE
Enable ipv6 on the per-task docker network when it's enabled on the daemon

### DIFF
--- a/changelog/issue-8990.md
+++ b/changelog/issue-8990.md
@@ -1,0 +1,8 @@
+audience: worker-deployers
+level: major
+reference: issue 8990
+---
+Generic worker has ipv6 enabled again for d2g tasks if it's enabled on the
+default bridge. Due to how docker handles ipv6 on networks that are necessary
+for capacity > 1, this raises the minimum docker version supported by generic
+worker to 27.

--- a/workers/generic-worker/taskcluster_proxy_feature.go
+++ b/workers/generic-worker/taskcluster_proxy_feature.go
@@ -57,6 +57,14 @@ func sweepStaleDockerResources() {
 	}
 }
 
+func dockerDefaultBridgeHasIPv6() bool {
+	out, err := host.Output("docker", "network", "inspect", "bridge", "--format", "{{.EnableIPv6}}")
+	if err != nil {
+		return false
+	}
+	return strings.TrimSpace(out) == "true"
+}
+
 func (feature *TaskclusterProxyFeature) IsEnabled() bool {
 	return config.EnableTaskclusterProxy
 }
@@ -102,7 +110,11 @@ func (l *TaskclusterProxyTask) Start() *CommandExecutionError {
 		// Create a per-task Docker network for isolation. Each container
 		// will only be able to reach its own tc-proxy instance.
 		networkName := fmt.Sprintf("gw-task-%s-%d", l.task.TaskID[:12], l.task.RunID)
-		_, err := host.Output("docker", "network", "create", networkName)
+		createArgs := []string{"network", "create"}
+		if dockerDefaultBridgeHasIPv6() {
+			createArgs = append(createArgs, "--ipv6")
+		}
+		_, err := host.Output("docker", append(createArgs, networkName)...)
 		if err != nil {
 			return executionError(internalError, errored, fmt.Errorf("could not create Docker network %s: %s", networkName, err))
 		}


### PR DESCRIPTION
4a5572769f549fd43a72a89b54e0e90b95e2829e moved d2g task containers off of docker's default bridge network so that tasks could have isolated networks. Those per-task networks are created without `--ipv6`, which means that unlike the default bridge that defaults to having an ipv6, task networks did not. Containers therefore lost all ipv6 capabilities which is a problem for fxci.

Pass `--ipv6` to the task network creation only if the default bridge has ipv6 enabled. I wasn't too sure about how to handle configuration for this (I don't want to have it swing the other way and have ipv6 enabled when it shouldn't be), but, tbqh, the per-task docker network feels like an implementation detail that was never communicated in the first place so as a deployer I'd expect configuration done on the docker daemon to stick. Since we have access to that through `docker network inspect` it's fairly easy to check whether or not ipv6 is enabled on the default network, and forward that config option to task networks.

This raises the minimum supported version of docker to 27 since docker didn't want to implicitly declare ipv6 subnets before that. One could technically run on older docker versions by disabling ipv6 on the default bridge but I don't think it's worth documenting this.

I went back and forth, trying to avoid that minimum version but without gutting capacity > 1 or gutting ipv6 support based on version (which I really would rather not do), but docker is very uncooperative on the subject. Versions older than 27, as noted above require passing a `--subnet` with a *unique* subnet per task. That's solvable by hashing the taskID/runID, picking up a few bytes and shoving that into an IPv6 prefix (collision chances were like 10^-14 per task for capacity 16). On the paper that sounds good enough, except that while those tasks ended up with an ipv6 they had no egress over it as docker didn't actually add a `MASQUERADE` rule for ipv6 before version 27... So the containers would boot up with an ipv6, a route saying "bridge IP is next" and packets went there to die silently. Which is a lot worse than no ipv6 since it means producers for said packets would not even be notified about them being dropped and would have to time out. And the fix is to do iptables ourselves and that's a huge fat "no thanks".

Fixes #8990
