### PR TITLE
Purge task caches when a task gets aborted

### DIFF
--- a/changelog/issue-9008.md
+++ b/changelog/issue-9008.md
@@ -1,0 +1,7 @@
+audience: worker-deployers
+level: patch
+reference: issue 9008
+---
+Generic worker now purges a task's writable directory caches when the worker
+kills the task's commands (cancellation, max runtime, OOM), instead of keeping
+a potentially corrupt cache

--- a/workers/generic-worker/main_test.go
+++ b/workers/generic-worker/main_test.go
@@ -319,8 +319,8 @@ func TestProtocolNull(t *testing.T) {
 func TestAbortAfterMaxRunTime(t *testing.T) {
 	setup(t)
 
-	// Include a writable directory cache, to test that caches can be unmounted
-	// when a task aborts prematurely.
+	// Include a writable directory cache, to test that caches are purged
+	// rather than preserved when a task aborts prematurely.
 	mounts := []MountEntry{
 		// requires scope "generic-worker:cache:banana-cache"
 		&WritableDirectoryCache{
@@ -357,6 +357,10 @@ func TestAbortAfterMaxRunTime(t *testing.T) {
 	}
 	if strings.Contains(logtext, "hello") {
 		t.Log("Task should have been aborted before 'hello' was logged, but log contains 'hello':")
+		t.Fatal(logtext)
+	}
+	if !strings.Contains(logtext, "Purging caches since the task was aborted") {
+		t.Log("Was expecting caches of an aborted task to be purged, but log doesn't mention it:")
 		t.Fatal(logtext)
 	}
 	duration := endTime.Sub(startTime).Seconds()

--- a/workers/generic-worker/mounts_feature.go
+++ b/workers/generic-worker/mounts_feature.go
@@ -687,6 +687,11 @@ func (taskMount *TaskMount) shouldPurgeCaches() bool {
 		return false
 	}
 
+	if taskMount.task.result.Aborted {
+		taskMount.Infof("Purging caches since the task was aborted and may have left them in an inconsistent state")
+		return true
+	}
+
 	if slices.Contains(taskMount.task.Payload.OnExitStatus.PurgeCaches, int64(taskMount.task.result.ExitCode)) {
 		taskMount.Infof("Purging caches since last command had exit code %v which is listed in task.Payload.OnExitStatus.PurgeCaches array", taskMount.task.result.ExitCode)
 		return true

--- a/workers/generic-worker/taskstatus_test.go
+++ b/workers/generic-worker/taskstatus_test.go
@@ -39,7 +39,7 @@ func TestReclaimCancelledTask(t *testing.T) {
 	expectedArtifacts := ExpectedArtifacts{
 		"public/logs/live_backing.log": {
 			Extracts: []string{
-				"Preserving cache: Moving",
+				"Purging caches since the task was aborted",
 			},
 			ContentType:     "text/plain; charset=utf-8",
 			ContentEncoding: "gzip",


### PR DESCRIPTION
Writable directory caches were preserved unconditionally, including when the worker killed the task rather than letting it exit properly (SIGKILL on linux). If a file was halfway through a write, or a command using a file to lock a directory (git clone for exampled) while the task got killed, we'd cache the corrupted/locked state on which future tasks would choke.

While in general the cache is going to be fine, we cannot guarantee it and a retry failure loop on something they have no control over isn't a good experience for a user so instead purge the cache and pay the price for that.

I originally thought only cancellation was aborting commands brutally, but max run time, OOMs and preemption also do. The nice surprise was that they all go through the same path with the same condition that is unique to them, `task.result.Aborted` is set to true. Rely on that in the mount feature to purge caches.

Fixes #9008