### PR TITLE
fix: rename Client Audit History section

### DIFF
--- a/changelog/pnRaq-FI6aD8J1AerILlT.md
+++ b/changelog/pnRaq-FI6aD8J1AerILlT.md
@@ -1,0 +1,4 @@
+audience: users
+level: silent
+---
+The "Client Audit History" link in the UI sidebar's Authorization section is now labeled "My Client Audit History", making it clearer that the link shows the audit history for your own client rather than an arbitrary one.

--- a/ui/src/components/Dashboard/SidebarList.jsx
+++ b/ui/src/components/Dashboard/SidebarList.jsx
@@ -57,7 +57,7 @@ export default class SidebarList extends Component {
             <SidebarListItem
               to={`/audit/client/history/${encodeURIComponent(clientId)}`}
               icon={<HistoryIcon />}>
-              Client Audit History
+              My Client Audit History
             </SidebarListItem>
           )}
           <SidebarListItem to="/auth/roles" icon={<AccountStarIcon />}>


### PR DESCRIPTION
#7590 added a section Client Audit History which sounded confusing as to which client it is referring to, fixed this.