### PR TITLE
Update quick-lru to 7.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -115,7 +115,7 @@
     "pg-connection-string": "^2.14.0",
     "prom-client": "^15.1.3",
     "qs": "^6.15.3",
-    "quick-lru": "^5.0.0",
+    "quick-lru": "^7.3.0",
     "regex-escape": "^3.4.11",
     "request-ip": "^3.3.0",
     "rimraf": "^6.1.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10542,10 +10542,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"quick-lru@npm:^5.0.0, quick-lru@npm:^5.1.1":
+"quick-lru@npm:^5.1.1":
   version: 5.1.1
   resolution: "quick-lru@npm:5.1.1"
   checksum: 10c0/a24cba5da8cec30d70d2484be37622580f64765fb6390a928b17f60cd69e8dbd32a954b3ff9176fa1b86d86ff2ba05252fae55dc4d40d0291c60412b0ad096da
+  languageName: node
+  linkType: hard
+
+"quick-lru@npm:^7.3.0":
+  version: 7.3.0
+  resolution: "quick-lru@npm:7.3.0"
+  checksum: 10c0/28dc8eaadcd489d26917f238ad27a6b09f8fe3a609152b0a4f399d5805094e07b56fe1e8c0d7ade0c11463c31bef329803672effc559601daf160a85f578fd05
   languageName: node
   linkType: hard
 
@@ -11702,7 +11709,7 @@ __metadata:
     prom-client: "npm:^15.1.3"
     qlobber: "npm:^8.0.1"
     qs: "npm:^6.15.3"
-    quick-lru: "npm:^5.0.0"
+    quick-lru: "npm:^7.3.0"
     regex-escape: "npm:^3.4.11"
     request-ip: "npm:^3.3.0"
     rimraf: "npm:^6.1.3"


### PR DESCRIPTION
While working on the auth service I wanted a LRU with a max size which quick-lru 7 provides (but 5 doesn't). This unfortunately dupes it in the lockfile but the versions are used in completely different places so it's not an actual problem.

