### PR TITLE
Don't let late launch agent results mask an aborted command

### DIFF
--- a/changelog/St7SdOmPQ1K8KHqDKt_3PQ.md
+++ b/changelog/St7SdOmPQ1K8KHqDKt_3PQ.md
@@ -1,0 +1,2 @@
+level: silent
+---

--- a/workers/generic-worker/process/multiuser_darwin.go
+++ b/workers/generic-worker/process/multiuser_darwin.go
@@ -288,10 +288,13 @@ func (c *Command) Wait() error {
 		c.auxFiles = nil
 	}()
 	defer c.conn.Close()
-	if c.result.SystemError != nil {
-		return c.result.SystemError
+	c.mutex.RLock()
+	systemError, pid := c.result.SystemError, c.result.Pid
+	c.mutex.RUnlock()
+	if systemError != nil {
+		return systemError
 	}
-	if c.result.Pid == 0 {
+	if pid == 0 {
 		return errors.New("wait called but PID not set")
 	}
 	resultReceived := false
@@ -307,8 +310,13 @@ func (c *Command) Wait() error {
 			return fmt.Errorf("bad JSON: %w", err)
 		}
 		log.Printf("Daemon: result received: %#v", resp)
-		// update value, not pointer, since other code may be holding onto pointer value
-		*c.result = resp
+		c.mutex.Lock()
+		// Don't clobber the result if the task was already resolved through abortion
+		if !c.result.Aborted {
+			// update value, not pointer, since other code may be holding onto pointer value
+			*c.result = resp
+		}
+		c.mutex.Unlock()
 		resultReceived = true
 	}
 	if !resultReceived {

--- a/workers/generic-worker/process/process.go
+++ b/workers/generic-worker/process/process.go
@@ -90,7 +90,7 @@ func (c *Command) Execute() *Result {
 		return c.result
 	}
 
-	exitErr := make(chan error)
+	exitErr := make(chan error, 1)
 	// wait for command to complete in separate go routine, so we can handle task abortion in parallel to command termination
 	go func() {
 		waitErr := c.Wait()

--- a/workers/generic-worker/process/process.go
+++ b/workers/generic-worker/process/process.go
@@ -67,8 +67,6 @@ func (r *Result) SetExitCode() {
 }
 
 func (c *Command) Execute() *Result {
-	c.result = &Result{}
-
 	if c.ResourceMonitor != nil {
 		usageChan := make(chan *ResourceUsage, 1)
 		usageMeasurementsDone := make(chan struct{})
@@ -82,6 +80,7 @@ func (c *Command) Execute() *Result {
 	}
 
 	c.mutex.Lock()
+	c.result = &Result{}
 	started := time.Now()
 	err := c.Start()
 	c.mutex.Unlock()
@@ -112,8 +111,10 @@ func (c *Command) Execute() *Result {
 			c.result.SetExitCode()
 		}
 	case <-c.abort:
+		c.mutex.Lock()
 		c.result.SystemError = fmt.Errorf("process aborted")
 		c.result.Aborted = true
+		c.mutex.Unlock()
 	}
 
 	finished := time.Now()


### PR DESCRIPTION
This fixes both a leaked goroutine I found while investigating this and a race condition. See each commit for details