### PR TITLE
Don't append to `c.auxFiles` from the io copy goroutines

### DIFF
--- a/changelog/EcdKwXK0SVSUgA8lDqT1dA.md
+++ b/changelog/EcdKwXK0SVSUgA8lDqT1dA.md
@@ -1,0 +1,2 @@
+level: silent
+---

--- a/workers/generic-worker/process/multiuser_darwin.go
+++ b/workers/generic-worker/process/multiuser_darwin.go
@@ -164,11 +164,11 @@ func (c *Command) Start() error {
 		gofuncs = append(gofuncs, func() {
 			_, _ = io.Copy(stdinWriter, c.Stdin)
 			stdinWriter.Close()
-			// not sure if this is needed, but let's make sure both ends of the
-			// pipe are not garbage collected until we've finished using them!
-			c.auxFiles = append(c.auxFiles, stdinReader)
 		})
 		fds = append(fds, int(stdinReader.Fd()))
+		// not sure if this is needed, but let's make sure both ends of the
+		// pipe are not garbage collected until we've finished using them!
+		c.auxFiles = append(c.auxFiles, stdinReader)
 	}
 
 	if c.Stdout != nil {
@@ -180,11 +180,11 @@ func (c *Command) Start() error {
 		gofuncs = append(gofuncs, func() {
 			_, _ = io.Copy(c.Stdout, stdoutReader)
 			stdoutReader.Close()
-			// not sure if this is needed, but let's make sure both ends of the
-			// pipe are not garbage collected until we've finished using them!
-			c.auxFiles = append(c.auxFiles, stdoutWriter)
 		})
 		fds = append(fds, int(stdoutWriter.Fd()))
+		// not sure if this is needed, but let's make sure both ends of the
+		// pipe are not garbage collected until we've finished using them!
+		c.auxFiles = append(c.auxFiles, stdoutWriter)
 	}
 
 	if c.Stderr != nil {
@@ -196,11 +196,11 @@ func (c *Command) Start() error {
 		gofuncs = append(gofuncs, func() {
 			_, _ = io.Copy(c.Stderr, stderrReader)
 			stderrReader.Close()
-			// not sure if this is needed, but let's make sure both ends of the
-			// pipe are not garbage collected until we've finished using them!
-			c.auxFiles = append(c.auxFiles, stderrWriter)
 		})
 		fds = append(fds, int(stderrWriter.Fd()))
+		// not sure if this is needed, but let's make sure both ends of the
+		// pipe are not garbage collected until we've finished using them!
+		c.auxFiles = append(c.auxFiles, stderrWriter)
 	}
 
 	log.Printf("FDs: %#v", fds)


### PR DESCRIPTION
Those three goroutines copying stdin/stdout/stderr each append the pipe end we gave the launch agent to `c.auxFiles`. `Wait()` sets that slice back to nil once it's done with it.

That's four goroutines writing to the same place with no synchronisation whatsoever. The appends race with each other and with the nil write.

Append those in `Start()` instead, before the goroutines are even started. Nothing reads the slice in between and `Wait()` runs in a goroutine created after the appends, so that ordering is enough on its own, no locking needed.