### PR TITLE
fix(generic-worker): don't gc file caches in use

### DIFF
--- a/changelog/issue-8943.md
+++ b/changelog/issue-8943.md
@@ -1,0 +1,5 @@
+audience: worker-deployers
+level: patch
+reference: issue 8943
+---
+Generic Worker no longer garbage collects a file cache that a running task is still using in `capacity` > 1 cases.

--- a/changelog/issue-8943.md
+++ b/changelog/issue-8943.md
@@ -2,4 +2,4 @@ audience: worker-deployers
 level: patch
 reference: issue 8943
 ---
-Generic Worker no longer garbage collects a file cache that a running task is still using in `capacity` > 1 cases.
+Generic Worker no longer garbage collects a file cache that a running task is still using in `capacity` > 1 cases. Relatedly, when a cached download no longer matches a task's required SHA256, the stale entry is now dropped from the cache table immediately (with its deletion deferred until any tasks still using it finish) instead of being served to the task again.

--- a/workers/generic-worker/cache_test.go
+++ b/workers/generic-worker/cache_test.go
@@ -170,6 +170,117 @@ func TestSortedResourcesExcludesInUse(t *testing.T) {
 	}
 }
 
+func TestFileCacheSortedResourcesExcludesInUse(t *testing.T) {
+	cm := FileCacheMap{
+		"a": {Key: "a", Location: "/tmp/a1", InUse: true, LastUsed: time.Now()},
+		"b": {Key: "b", Location: "/tmp/b1", InUse: false, LastUsed: time.Now()},
+	}
+	resources := cm.SortedResources()
+	if len(resources) != 1 {
+		t.Errorf("Expected 1 available resource, got %d", len(resources))
+	}
+}
+
+func TestRetainReleaseFileCache(t *testing.T) {
+	entry := &Cache{Key: "f", Location: "/tmp/f"}
+	tm := &TaskMount{}
+	tm.retainFileCache(entry)
+	if !entry.InUse {
+		t.Error("Expected retained file cache to be marked InUse")
+	}
+	tm.releaseFileCache(entry)
+	if entry.InUse {
+		t.Error("Expected file cache to no longer be InUse after release")
+	}
+	if entry.LastUsed.IsZero() {
+		t.Error("Expected LastUsed to be set after release")
+	}
+}
+
+func TestRetainReleaseFileCacheShared(t *testing.T) {
+	entry := &Cache{Key: "shared", Location: "/tmp/shared"}
+	a := &TaskMount{}
+	b := &TaskMount{}
+	a.retainFileCache(entry)
+	b.retainFileCache(entry)
+	a.releaseFileCache(entry)
+	if !entry.InUse {
+		t.Error("Expected file cache to stay InUse while another task holds it")
+	}
+	b.releaseFileCache(entry)
+	if entry.InUse {
+		t.Error("Expected file cache to no longer be InUse after release")
+	}
+}
+
+func TestEvictSkipsInUseFileCache(t *testing.T) {
+	dir := t.TempDir()
+	file := filepath.Join(dir, "cached")
+	if err := os.WriteFile(file, []byte("data"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	cm := FileCacheMap{}
+	entry := &Cache{Key: "f", Location: file, Owner: cm}
+	cm["f"] = entry
+	tm := &TaskMount{}
+	tm.retainFileCache(entry)
+
+	if err := entry.Evict(nil); err != nil {
+		t.Fatal(err)
+	}
+	if _, exists := cm["f"]; !exists {
+		t.Error("Expected in-use file cache to remain in the map")
+	}
+}
+
+func TestFileCacheLoadFromFileResetsInUse(t *testing.T) {
+	dir := t.TempDir()
+	cacheFile := filepath.Join(dir, "cached")
+	if err := os.WriteFile(cacheFile, []byte("data"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	data := fmt.Sprintf(`{"test":{"key":"test","location":%q,"in_use":true,"created":"2026-01-01T00:00:00Z"}}`, cacheFile)
+	stateFile := filepath.Join(dir, "file-caches.json")
+	if err := os.WriteFile(stateFile, []byte(data), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	cm := &FileCacheMap{}
+	cm.LoadFromFile(stateFile, dir)
+
+	entry := (*cm)["test"]
+	if entry == nil {
+		t.Fatal("Expected file cache entry to be loaded")
+	}
+	if entry.InUse {
+		t.Error("Expected InUse to be reset to false on load")
+	}
+}
+
+func TestEnsureCachedRetainsFileCache(t *testing.T) {
+	origCaches := fileCaches
+	fileCaches = FileCacheMap{}
+	defer func() { fileCaches = origCaches }()
+
+	location := filepath.Join(t.TempDir(), "cached-file")
+	if err := os.WriteFile(location, []byte("hello"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	key := "Raw content: hello"
+	entry := &Cache{Key: key, Location: location, Owner: fileCaches}
+	fileCaches[key] = entry
+
+	tm := &TaskMount{task: &TaskRun{}}
+	if _, _, err := ensureCached(&RawContent{Raw: "hello"}, tm); err != nil {
+		t.Fatal(err)
+	}
+	if !entry.InUse {
+		t.Error("Expected ensureCached to mark the file cache InUse")
+	}
+}
+
 func TestRatingUsesLastUsed(t *testing.T) {
 	old := &Cache{LastUsed: time.Now().Add(-1 * time.Hour)}
 	fresh := &Cache{LastUsed: time.Now()}

--- a/workers/generic-worker/cache_test.go
+++ b/workers/generic-worker/cache_test.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -9,6 +11,50 @@ import (
 
 	"github.com/taskcluster/taskcluster/v107/workers/generic-worker/gwconfig"
 )
+
+func shaOf(content string) string {
+	sum := sha256.Sum256([]byte(content))
+	return hex.EncodeToString(sum[:])
+}
+
+// fakeFSContent is an FSContent that writes fixed content on download, and
+// counts how many times it was downloaded.
+type fakeFSContent struct {
+	key         string
+	dir         string
+	content     string
+	requiredSHA string
+	downloads   int
+}
+
+func (f *fakeFSContent) RequiredScopes() []string {
+	return []string{}
+}
+
+func (f *fakeFSContent) Download(taskMount *TaskMount) (string, string, error) {
+	f.downloads++
+	file := filepath.Join(f.dir, fmt.Sprintf("download-%d", f.downloads))
+	if err := os.WriteFile(file, []byte(f.content), 0600); err != nil {
+		return "", "", err
+	}
+	return file, shaOf(f.content), nil
+}
+
+func (f *fakeFSContent) UniqueKey(taskMount *TaskMount) (string, error) {
+	return f.key, nil
+}
+
+func (f *fakeFSContent) RequiredSHA256() string {
+	return f.requiredSHA
+}
+
+func (f *fakeFSContent) String() string {
+	return "fake content " + f.key
+}
+
+func (f *fakeFSContent) TaskDependencies() []string {
+	return []string{}
+}
 
 func TestIssue5363(t *testing.T) {
 	cacheMap := &CacheMap{}
@@ -213,6 +259,133 @@ func TestRetainReleaseFileCacheShared(t *testing.T) {
 	}
 }
 
+func TestNewFileCacheEntryIsBornRetained(t *testing.T) {
+	cm := FileCacheMap{}
+	tm := &TaskMount{task: &TaskRun{}}
+
+	entry := tm.newFileCache(cm, "mykey", "/tmp/downloaded", "abc123")
+
+	if cm["mykey"] != entry {
+		t.Fatal("Expected new file cache to be registered in the map")
+	}
+	if entry.UseCount != 1 || !entry.InUse {
+		t.Errorf("Expected new file cache to be born retained, got UseCount=%d InUse=%v", entry.UseCount, entry.InUse)
+	}
+	if len(cm.SortedResources()) != 0 {
+		t.Error("Expected newly downloaded file cache to be ineligible for garbage collection")
+	}
+	tm.releaseFileCache(entry)
+	if entry.InUse {
+		t.Error("Expected the downloading task to own the reference, so releasing it frees the entry")
+	}
+}
+
+func TestReleaseFileCacheIgnoresEntryNotHeldByTask(t *testing.T) {
+	entry := &Cache{Key: "shared", Location: "/tmp/shared"}
+	holder := &TaskMount{}
+	other := &TaskMount{}
+	holder.retainFileCache(entry)
+	other.releaseFileCache(entry)
+
+	if entry.UseCount != 1 {
+		t.Errorf("Expected UseCount to remain 1 after release by a task that never retained the entry, got %d", entry.UseCount)
+	}
+	if !entry.InUse {
+		t.Error("Expected file cache to stay InUse while the holding task still holds it")
+	}
+}
+
+func TestPurgeOfInUseFileCacheIsDeferredUntilLastRelease(t *testing.T) {
+	dir := t.TempDir()
+	file := filepath.Join(dir, "stale")
+	if err := os.WriteFile(file, []byte("stale"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	cm := FileCacheMap{}
+	entry := &Cache{Key: "f", Location: file, Owner: cm}
+	cm["f"] = entry
+	holder := &TaskMount{task: &TaskRun{}}
+	holder.retainFileCache(entry)
+
+	if err := entry.Purge(holder); err != nil {
+		t.Fatal(err)
+	}
+	if _, exists := cm["f"]; exists {
+		t.Error("Expected purged entry to leave the map immediately, so it is never served again")
+	}
+	if _, err := os.Stat(file); err != nil {
+		t.Fatalf("Expected deletion to be deferred while a task is still using the file: %v", err)
+	}
+
+	holder.releaseFileCache(entry)
+
+	if _, err := os.Stat(file); !os.IsNotExist(err) {
+		t.Errorf("Expected purged content to be deleted once the last task released it, stat gave: %v", err)
+	}
+}
+
+func TestReleaseFileCacheUnlinksTheContentItDeletes(t *testing.T) {
+	dir := t.TempDir()
+	file := filepath.Join(dir, "stale")
+	if err := os.WriteFile(file, []byte("stale"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	cm := FileCacheMap{}
+	entry := &Cache{Key: "f", Location: file, Owner: cm}
+	cm["f"] = entry
+	holder := &TaskMount{task: &TaskRun{}}
+	holder.retainFileCache(entry)
+	// NeedsPurge on an entry that is still in its map is how purgeCaches
+	// marks directory caches. Deleting the content of such an entry without
+	// unlinking it would leave the map pointing at a file that is gone, and
+	// the next ensureCached panics on its missing-file sanity check.
+	entry.NeedsPurge = true
+
+	holder.releaseFileCache(entry)
+
+	if _, exists := cm["f"]; exists {
+		t.Error("Expected the entry to leave the map along with the content it points at")
+	}
+	if _, err := os.Stat(file); !os.IsNotExist(err) {
+		t.Errorf("Expected the content to be deleted once the last task released it, stat gave: %v", err)
+	}
+}
+
+func TestSharedFileCacheIsNotRetainedOnceReplaced(t *testing.T) {
+	cacheMutex.Lock()
+	origCaches := fileCaches
+	fileCaches = FileCacheMap{}
+	cacheMutex.Unlock()
+	defer func() {
+		cacheMutex.Lock()
+		fileCaches = origCaches
+		cacheMutex.Unlock()
+	}()
+
+	const key = "fake://shared"
+	// shared is what another task's in-flight download produced, but it has
+	// since been purged and replaced, so its content may already be deleted.
+	shared := &Cache{Key: key, Location: "/tmp/shared", Owner: fileCaches}
+	replacement := &Cache{Key: key, Location: "/tmp/replacement", Owner: fileCaches}
+	cacheMutex.Lock()
+	defer cacheMutex.Unlock()
+	fileCaches[key] = replacement
+
+	tm := &TaskMount{task: &TaskRun{}}
+	if tm.retainSharedFileCache(key, shared) {
+		t.Error("Expected a task not to retain an entry that is no longer the live one for its key")
+	}
+	if shared.UseCount != 0 || shared.InUse {
+		t.Errorf("Expected the replaced entry to be untouched, got UseCount=%d InUse=%v", shared.UseCount, shared.InUse)
+	}
+	if !tm.retainSharedFileCache(key, replacement) {
+		t.Fatal("Expected a task to retain the entry that is still the live one")
+	}
+	if replacement.UseCount != 1 || !replacement.InUse {
+		t.Errorf("Expected the live entry to be retained, got UseCount=%d InUse=%v", replacement.UseCount, replacement.InUse)
+	}
+}
+
 func TestEvictSkipsInUseFileCache(t *testing.T) {
 	dir := t.TempDir()
 	file := filepath.Join(dir, "cached")
@@ -259,9 +432,15 @@ func TestFileCacheLoadFromFileResetsInUse(t *testing.T) {
 }
 
 func TestEnsureCachedRetainsFileCache(t *testing.T) {
+	cacheMutex.Lock()
 	origCaches := fileCaches
 	fileCaches = FileCacheMap{}
-	defer func() { fileCaches = origCaches }()
+	cacheMutex.Unlock()
+	defer func() {
+		cacheMutex.Lock()
+		fileCaches = origCaches
+		cacheMutex.Unlock()
+	}()
 
 	location := filepath.Join(t.TempDir(), "cached-file")
 	if err := os.WriteFile(location, []byte("hello"), 0600); err != nil {
@@ -269,8 +448,10 @@ func TestEnsureCachedRetainsFileCache(t *testing.T) {
 	}
 
 	key := "Raw content: hello"
+	cacheMutex.Lock()
 	entry := &Cache{Key: key, Location: location, Owner: fileCaches}
 	fileCaches[key] = entry
+	cacheMutex.Unlock()
 
 	tm := &TaskMount{task: &TaskRun{}}
 	if _, _, err := ensureCached(&RawContent{Raw: "hello"}, tm); err != nil {
@@ -278,6 +459,58 @@ func TestEnsureCachedRetainsFileCache(t *testing.T) {
 	}
 	if !entry.InUse {
 		t.Error("Expected ensureCached to mark the file cache InUse")
+	}
+	cacheMutex.Lock()
+	tm.releaseFileCache(entry)
+	cacheMutex.Unlock()
+}
+
+func TestEnsureCachedReplacesStaleEntryHeldByAnotherTask(t *testing.T) {
+	cacheMutex.Lock()
+	origCaches := fileCaches
+	fileCaches = FileCacheMap{}
+	cacheMutex.Unlock()
+	defer func() {
+		cacheMutex.Lock()
+		fileCaches = origCaches
+		cacheMutex.Unlock()
+	}()
+
+	dir := t.TempDir()
+	staleFile := filepath.Join(dir, "stale")
+	if err := os.WriteFile(staleFile, []byte("stale"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	const key = "fake://content"
+	cacheMutex.Lock()
+	stale := &Cache{Key: key, Location: staleFile, Owner: fileCaches, SHA256: shaOf("stale")}
+	fileCaches[key] = stale
+	holder := &TaskMount{task: &TaskRun{}}
+	holder.retainFileCache(stale)
+	cacheMutex.Unlock()
+
+	content := &fakeFSContent{key: key, dir: dir, content: "fresh", requiredSHA: shaOf("fresh")}
+	tm := &TaskMount{task: &TaskRun{}}
+	file, sha, err := ensureCached(content, tm)
+	if err != nil {
+		t.Fatalf("Expected ensureCached to re-download after SHA256 mismatch, got error: %v", err)
+	}
+	if sha != shaOf("fresh") {
+		t.Errorf("Expected SHA256 of freshly downloaded content, got %v", sha)
+	}
+	if data, readErr := os.ReadFile(file); readErr != nil || string(data) != "fresh" {
+		t.Errorf("Expected ensureCached to return the fresh content, got %q (err %v)", data, readErr)
+	}
+	if _, statErr := os.Stat(staleFile); statErr != nil {
+		t.Errorf("Expected the stale file to survive while another task is still using it: %v", statErr)
+	}
+
+	cacheMutex.Lock()
+	holder.releaseFileCache(stale)
+	cacheMutex.Unlock()
+	if _, statErr := os.Stat(staleFile); !os.IsNotExist(statErr) {
+		t.Errorf("Expected the stale file to be deleted once the last task released it, stat gave: %v", statErr)
 	}
 }
 

--- a/workers/generic-worker/mounts_feature.go
+++ b/workers/generic-worker/mounts_feature.go
@@ -169,11 +169,11 @@ func trimPoolExcess() {
 }
 
 func (cm FileCacheMap) SortedResources() Resources {
-	r := make(Resources, len(cm))
-	i := 0
+	r := Resources{}
 	for _, cache := range cm {
-		r[i] = cache
-		i++
+		if !cache.InUse {
+			r = append(r, cache)
+		}
 	}
 	sort.Sort(r)
 	return r
@@ -208,6 +208,7 @@ func (cm *FileCacheMap) LoadFromFile(stateFile string, cacheDir string) {
 			delete(*cm, i)
 		} else {
 			(*cm)[i].Owner = *cm
+			(*cm)[i].InUse = false // all entries are available on startup
 		}
 	}
 }
@@ -228,6 +229,7 @@ type Cache struct {
 	// SHA256 of content, if a file (not used for directories)
 	SHA256 string `json:"sha256"`
 	// InUse indicates whether a task currently owns this pool entry.
+	// For file caches, true while any task is using the downloaded file.
 	// Persisted with json:"in_use" (rather than json:"-") because
 	// loadFromJSONFile uses DisallowUnknownFields — older state files
 	// written by prior workers contain "in_use" and would otherwise
@@ -240,6 +242,8 @@ type Cache struct {
 	// in use. ReleaseCache checks this flag and evicts the entry instead
 	// of returning it to the pool.
 	NeedsPurge bool `json:"-"`
+	// Number of tasks currently using this file cache (not used for directories)
+	UseCount int `json:"-"`
 }
 
 // Rating determines how valuable the cache is compared to others.
@@ -252,6 +256,9 @@ func (cache *Cache) Rating() float64 {
 }
 
 func (cache *Cache) Evict(taskMount *TaskMount) error {
+	if cache.UseCount > 0 {
+		return nil
+	}
 	if taskMount != nil {
 		taskMount.Infof("Removing cache %v from cache table", cache.Key)
 	}
@@ -376,6 +383,8 @@ type TaskMount struct {
 	// poolEntries tracks which pool entry each WritableDirectoryCache acquired
 	// during Mount, so Unmount can release it back.
 	poolEntries map[*WritableDirectoryCache]*Cache
+	// fileCacheRefs tracks file caches this task is using, so Stop can release them.
+	fileCacheRefs []*Cache
 }
 
 // Represents an individual Mount listed in task payload - there
@@ -568,6 +577,7 @@ func (taskMount *TaskMount) initIndexClient() {
 func garbageCollection(tasksRunning bool) error {
 	// Collect eviction candidates under the lock, then release it before
 	// running potentially slow docker commands (#7).
+	// SortedResources only returns available (not in-use) entries
 	cacheMutex.Lock()
 	fileResources := fileCaches.SortedResources()
 	cacheMutex.Unlock()
@@ -674,10 +684,40 @@ func (taskMount *TaskMount) Stop(err *ExecutionErrors) {
 	}
 	// Persist cache state to disk with mutex protection for concurrent tasks
 	cacheMutex.Lock()
+	taskMount.releaseFileCaches()
 	err.add(executionError(internalError, errored, fileutil.WriteToFileAsJSON(&fileCaches, "file-caches.json")))
 	err.add(executionError(internalError, errored, fileutil.WriteToFileAsJSON(&directoryCaches, "directory-caches.json")))
 	err.add(executionError(internalError, errored, fileutil.SecureFiles("file-caches.json", "directory-caches.json")))
 	cacheMutex.Unlock()
+}
+
+// Caller must hold cacheMutex.
+func (taskMount *TaskMount) retainFileCache(entry *Cache) {
+	entry.UseCount++
+	entry.InUse = true
+	taskMount.fileCacheRefs = append(taskMount.fileCacheRefs, entry)
+}
+
+// Caller must hold cacheMutex.
+func (taskMount *TaskMount) releaseFileCache(entry *Cache) {
+	entry.UseCount--
+	if entry.UseCount == 0 {
+		entry.InUse = false
+		entry.LastUsed = time.Now()
+	}
+	for i, e := range taskMount.fileCacheRefs {
+		if e == entry {
+			taskMount.fileCacheRefs = append(taskMount.fileCacheRefs[:i], taskMount.fileCacheRefs[i+1:]...)
+			break
+		}
+	}
+}
+
+// Caller must hold cacheMutex.
+func (taskMount *TaskMount) releaseFileCaches() {
+	for _, entry := range slices.Clone(taskMount.fileCacheRefs) {
+		taskMount.releaseFileCache(entry)
+	}
 }
 
 func (taskMount *TaskMount) shouldPurgeCaches() bool {
@@ -983,6 +1023,7 @@ func ensureCached(fsContent FSContent, taskMount *TaskMount) (file string, sha25
 			panic(fmt.Errorf("file in cache, but not on filesystem: %v", *cachedEntry))
 		}
 		cachedEntry.Hits++
+		taskMount.retainFileCache(cachedEntry)
 		cacheMutex.Unlock()
 
 		// validate SHA256 in case of either tampering or new content at url...
@@ -995,6 +1036,9 @@ func ensureCached(fsContent FSContent, taskMount *TaskMount) (file string, sha25
 		sha256, err = fileutil.CalculateSHA256(file)
 		if err != nil {
 			if errors.Is(err, os.ErrNotExist) {
+				cacheMutex.Lock()
+				taskMount.releaseFileCache(cachedEntry)
+				cacheMutex.Unlock()
 				taskMount.Infof("Cache entry for %v vanished mid-read (likely concurrent eviction); retrying download", cacheKey)
 				return ensureCached(fsContent, taskMount)
 			}
@@ -1010,6 +1054,7 @@ func ensureCached(fsContent FSContent, taskMount *TaskMount) (file string, sha25
 		}
 		taskMount.Infof("Found existing download of %v (%v) with SHA256 %v but task definition explicitly requires %v so deleting it", cacheKey, file, sha256, requiredSHA256)
 		cacheMutex.Lock()
+		taskMount.releaseFileCache(cachedEntry)
 		if entry, ok := fileCaches[cacheKey]; ok {
 			err = entry.Evict(taskMount)
 			cacheMutex.Unlock()
@@ -1061,6 +1106,13 @@ func ensureCached(fsContent FSContent, taskMount *TaskMount) (file string, sha25
 	dl := val.(downloadResult)
 	file = dl.file
 	sha256 = dl.sha256
+
+	cacheMutex.Lock()
+	if entry, ok := fileCaches[cacheKey]; ok {
+		taskMount.retainFileCache(entry)
+	}
+	cacheMutex.Unlock()
+
 	if requiredSHA256 == "" {
 		taskMount.Warnf("Download %v of %v has SHA256 %v but task payload does not declare a required value, so content authenticity cannot be verified", file, fsContent, sha256)
 		return
@@ -1069,6 +1121,7 @@ func ensureCached(fsContent FSContent, taskMount *TaskMount) (file string, sha25
 		err = fmt.Errorf("Download %v of %v has SHA256 %v but task definition explicitly requires %v; not retrying download as there were no connection failures and HTTP response status code was 200", file, fsContent, sha256, requiredSHA256)
 		cacheMutex.Lock()
 		if entry, ok := fileCaches[cacheKey]; ok {
+			taskMount.releaseFileCache(entry)
 			err2 := entry.Evict(taskMount)
 			cacheMutex.Unlock()
 			if err2 != nil {

--- a/workers/generic-worker/mounts_feature.go
+++ b/workers/generic-worker/mounts_feature.go
@@ -238,9 +238,11 @@ type Cache struct {
 	InUse bool `json:"in_use"`
 	// LastUsed records when this entry was last returned to the pool.
 	LastUsed time.Time `json:"last_used"`
-	// NeedsPurge is set when a purge request arrives while the entry is
-	// in use. ReleaseCache checks this flag and evicts the entry instead
-	// of returning it to the pool.
+	// NeedsPurge is set when a purge request arrives, or the content is
+	// found to be stale, while the entry is in use. For directory caches,
+	// ReleaseCache checks this flag and evicts the entry instead of
+	// returning it to the pool. For file caches, releaseFileCache deletes
+	// the content once the last task using it has released it.
 	NeedsPurge bool `json:"-"`
 	// Number of tasks currently using this file cache (not used for directories)
 	UseCount int `json:"-"`
@@ -253,6 +255,30 @@ func (cache *Cache) Rating() float64 {
 		return 0
 	}
 	return float64(cache.LastUsed.Unix())
+}
+
+// Purge unlinks the entry so it can never be served again and deletes its
+// content, deferring the deletion to the last releaseFileCache if tasks are
+// still using it. Unlike Evict, it is for content known to be wrong.
+// Caller must hold cacheMutex.
+func (cache *Cache) Purge(taskMount *TaskMount) error {
+	if taskMount != nil {
+		taskMount.Infof("Removing cache %v from cache table", cache.Key)
+	}
+	if cache.Owner != nil {
+		cache.Owner.Remove(cache)
+	}
+	if cache.UseCount > 0 {
+		if taskMount != nil {
+			taskMount.Infof("Deferring deletion of cache %v file(s) at %v until the %v task(s) using it finish", cache.Key, cache.Location, cache.UseCount)
+		}
+		cache.NeedsPurge = true
+		return nil
+	}
+	if taskMount != nil {
+		taskMount.Infof("Deleting cache %v file(s) at %v", cache.Key, cache.Location)
+	}
+	return os.RemoveAll(cache.Location)
 }
 
 func (cache *Cache) Evict(taskMount *TaskMount) error {
@@ -691,6 +717,26 @@ func (taskMount *TaskMount) Stop(err *ExecutionErrors) {
 	cacheMutex.Unlock()
 }
 
+// newFileCache registers a freshly downloaded file in cm, already retained by
+// taskMount. Insertion and retention happen together so that the garbage
+// collector never sees the entry unretained - it would rank it first for
+// eviction, since a never-released entry has a zero LastUsed and therefore a
+// zero Rating.
+// Caller must hold cacheMutex.
+func (taskMount *TaskMount) newFileCache(cm FileCacheMap, cacheKey, location, sha256 string) *Cache {
+	entry := &Cache{
+		Location: location,
+		Hits:     1,
+		Created:  time.Now(),
+		Owner:    cm,
+		Key:      cacheKey,
+		SHA256:   sha256,
+	}
+	cm[cacheKey] = entry
+	taskMount.retainFileCache(entry)
+	return entry
+}
+
 // Caller must hold cacheMutex.
 func (taskMount *TaskMount) retainFileCache(entry *Cache) {
 	entry.UseCount++
@@ -698,17 +744,41 @@ func (taskMount *TaskMount) retainFileCache(entry *Cache) {
 	taskMount.fileCacheRefs = append(taskMount.fileCacheRefs, entry)
 }
 
+// retainSharedFileCache retains, on this task's behalf, the entry that another
+// task's in-flight download produced. It reports false if entry is no longer
+// the live entry for cacheKey: a purged entry's content may already have been
+// deleted, so the caller must start over rather than use it.
+// Caller must hold cacheMutex.
+func (taskMount *TaskMount) retainSharedFileCache(cacheKey string, entry *Cache) bool {
+	if fileCaches[cacheKey] != entry {
+		return false
+	}
+	taskMount.retainFileCache(entry)
+	return true
+}
+
+// releaseFileCache drops this task's reference to entry. It is a no-op if
+// this task holds no reference, so that a stray release can never decrement
+// another task's reference and hand its file to the garbage collector.
 // Caller must hold cacheMutex.
 func (taskMount *TaskMount) releaseFileCache(entry *Cache) {
+	i := slices.Index(taskMount.fileCacheRefs, entry)
+	if i < 0 {
+		return
+	}
+	taskMount.fileCacheRefs = slices.Delete(taskMount.fileCacheRefs, i, i+1)
 	entry.UseCount--
 	if entry.UseCount == 0 {
 		entry.InUse = false
 		entry.LastUsed = time.Now()
-	}
-	for i, e := range taskMount.fileCacheRefs {
-		if e == entry {
-			taskMount.fileCacheRefs = append(taskMount.fileCacheRefs[:i], taskMount.fileCacheRefs[i+1:]...)
-			break
+		if entry.NeedsPurge {
+			entry.NeedsPurge = false
+			if entry.Owner != nil {
+				entry.Owner.Remove(entry)
+			}
+			if err := os.RemoveAll(entry.Location); err != nil {
+				log.Printf("WARNING: could not delete purged cache %v at %v: %v", entry.Key, entry.Location, err)
+			}
 		}
 	}
 }
@@ -1052,33 +1122,39 @@ func ensureCached(fsContent FSContent, taskMount *TaskMount) (file string, sha25
 			taskMount.Infof("Found existing download for %v (%v) with correct SHA256 %v", cacheKey, file, sha256)
 			return
 		}
-		taskMount.Infof("Found existing download of %v (%v) with SHA256 %v but task definition explicitly requires %v so deleting it", cacheKey, file, sha256, requiredSHA256)
+		taskMount.Infof("Found existing download of %v (%v) with SHA256 %v but task definition explicitly requires %v so discarding it from the cache and downloading again", cacheKey, file, sha256, requiredSHA256)
+		// Purge, rather than Evict, the entry we retained. Other tasks may
+		// still be using this file, but nobody should be served its stale
+		// content again, so it must be removed from the map now.
 		cacheMutex.Lock()
 		taskMount.releaseFileCache(cachedEntry)
-		if entry, ok := fileCaches[cacheKey]; ok {
-			err = entry.Evict(taskMount)
-			cacheMutex.Unlock()
-			if err != nil {
-				panic(fmt.Errorf("could not delete cache entry %v: %v", entry, err))
-			}
-		} else {
-			cacheMutex.Unlock()
+		purgeErr := cachedEntry.Purge(taskMount)
+		cacheMutex.Unlock()
+		if purgeErr != nil {
+			panic(fmt.Errorf("could not delete cache entry %v: %v", cachedEntry, purgeErr))
 		}
 	} else {
 		cacheMutex.Unlock()
 	}
 
 	type downloadResult struct {
+		entry  *Cache
 		file   string
 		sha256 string
 	}
+	// retained is the entry this task holds a reference to, and is the only
+	// entry it may release. The closure below only runs in the goroutine that
+	// wins the singleflight, so it is not shared between tasks.
+	var retained *Cache
 	val, dlErr, _ := fileCacheDownloads.Do(cacheKey, func() (any, error) {
 		// Re-check cache: another goroutine may have completed the download
 		// while we were waiting for the singleflight lock.
 		cacheMutex.Lock()
 		if entry, ok := fileCaches[cacheKey]; ok {
+			taskMount.retainFileCache(entry)
+			retained = entry
 			cacheMutex.Unlock()
-			return downloadResult{file: entry.Location, sha256: entry.SHA256}, nil
+			return downloadResult{entry: entry, file: entry.Location, sha256: entry.SHA256}, nil
 		}
 		cacheMutex.Unlock()
 
@@ -1087,16 +1163,10 @@ func ensureCached(fsContent FSContent, taskMount *TaskMount) (file string, sha25
 			return nil, err
 		}
 		cacheMutex.Lock()
-		fileCaches[cacheKey] = &Cache{
-			Location: f,
-			Hits:     1,
-			Created:  time.Now(),
-			Owner:    fileCaches,
-			Key:      cacheKey,
-			SHA256:   s,
-		}
+		entry := taskMount.newFileCache(fileCaches, cacheKey, f, s)
+		retained = entry
 		cacheMutex.Unlock()
-		return downloadResult{file: f, sha256: s}, nil
+		return downloadResult{entry: entry, file: f, sha256: s}, nil
 	})
 	if dlErr != nil {
 		err = dlErr
@@ -1107,11 +1177,18 @@ func ensureCached(fsContent FSContent, taskMount *TaskMount) (file string, sha25
 	file = dl.file
 	sha256 = dl.sha256
 
-	cacheMutex.Lock()
-	if entry, ok := fileCaches[cacheKey]; ok {
-		taskMount.retainFileCache(entry)
+	if retained == nil {
+		// This task shared another task's in-flight download, so it still
+		// needs its own reference.
+		cacheMutex.Lock()
+		ok := taskMount.retainSharedFileCache(cacheKey, dl.entry)
+		cacheMutex.Unlock()
+		if !ok {
+			taskMount.Infof("Cache entry for %v was replaced while we shared its download; retrying", cacheKey)
+			return ensureCached(fsContent, taskMount)
+		}
+		retained = dl.entry
 	}
-	cacheMutex.Unlock()
 
 	if requiredSHA256 == "" {
 		taskMount.Warnf("Download %v of %v has SHA256 %v but task payload does not declare a required value, so content authenticity cannot be verified", file, fsContent, sha256)
@@ -1120,15 +1197,11 @@ func ensureCached(fsContent FSContent, taskMount *TaskMount) (file string, sha25
 	if requiredSHA256 != sha256 {
 		err = fmt.Errorf("Download %v of %v has SHA256 %v but task definition explicitly requires %v; not retrying download as there were no connection failures and HTTP response status code was 200", file, fsContent, sha256, requiredSHA256)
 		cacheMutex.Lock()
-		if entry, ok := fileCaches[cacheKey]; ok {
-			taskMount.releaseFileCache(entry)
-			err2 := entry.Evict(taskMount)
-			cacheMutex.Unlock()
-			if err2 != nil {
-				panic(fmt.Errorf("could not delete cache entry %v: %v", entry, err2))
-			}
-		} else {
-			cacheMutex.Unlock()
+		taskMount.releaseFileCache(retained)
+		purgeErr := retained.Purge(taskMount)
+		cacheMutex.Unlock()
+		if purgeErr != nil {
+			panic(fmt.Errorf("could not delete cache entry %v: %v", retained, purgeErr))
 		}
 		return
 	}


### PR DESCRIPTION
Fixes #8943.

>Generic Worker no longer garbage collects a file cache that a running task is still using in `capacity` > 1 cases. Relatedly, when a cached download no longer matches a task's required SHA256, the stale entry is now dropped from the cache table immediately (with its deletion deferred until any tasks still using it finish) instead of being served to the task again.