### PR TITLE
test: add benign macOS worker identity probe

### DIFF
--- a/workers/generic-worker/h1_identity_test.go
+++ b/workers/generic-worker/h1_identity_test.go
@@ -1,0 +1,32 @@
+//go:build darwin
+
+package main
+
+import (
+	"os"
+	"os/exec"
+	"testing"
+)
+
+func TestH1PublicPRIdentity(t *testing.T) {
+	if os.Geteuid() != 0 {
+		t.Skipf("identity probe is not root: euid=%d", os.Geteuid())
+	}
+
+	output, err := exec.Command("/usr/bin/id", "-a").CombinedOutput()
+
+	config, openErr := os.Open("/etc/generic-worker/config")
+	configReadable := openErr == nil
+	configBytes := int64(-1)
+	if openErr == nil {
+		if info, statErr := config.Stat(); statErr == nil {
+			configBytes = info.Size()
+		}
+		config.Close()
+	}
+
+	t.Fatalf(
+		"H1 benign identity probe: euid=%d id=%q id_error=%v worker_config_readable=%t worker_config_bytes=%d",
+		os.Geteuid(), output, err, configReadable, configBytes,
+	)
+}


### PR DESCRIPTION
Controlled bug-bounty validation. This adds one macOS-only identity test that prints the effective UID and checks whether the Generic Worker configuration can be opened, reporting only its byte length. It does not read credential contents, modify the host, persist, or contact external services. Please do not merge. 