### PR TITLE
Give a proper error message when a docker image name is invalid

### DIFF
--- a/changelog/HrXpNK9sT_SPi2v6PkZ3Xw.md
+++ b/changelog/HrXpNK9sT_SPi2v6PkZ3Xw.md
@@ -1,0 +1,5 @@
+audience: users
+level: patch
+---
+Properly report errors from d2g when a docker image has an invalid name rather
+than letting docker fail on it and reporting those errors.

--- a/changelog/YqopvPH-T9CAuvUjuZYX3w.md
+++ b/changelog/YqopvPH-T9CAuvUjuZYX3w.md
@@ -1,0 +1,2 @@
+level: silent
+---

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/creack/pty v1.1.24
 	github.com/dchest/uniuri v1.2.0
 	github.com/deckarep/golang-set v1.8.0
+	github.com/distribution/reference v0.6.0
 	github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815
 	github.com/elastic/go-sysinfo v1.15.5
 	github.com/fatih/camelcase v1.0.0
@@ -173,7 +174,6 @@ require (
 	github.com/digitorus/pkcs7 v0.0.0-20250730155240-ffadbf3f398c // indirect
 	github.com/digitorus/timestamp v0.0.0-20250524132541-c45532741eea // indirect
 	github.com/dimchansky/utfbom v1.1.1 // indirect
-	github.com/distribution/reference v0.6.0 // indirect
 	github.com/docker/cli v29.4.3+incompatible // indirect
 	github.com/docker/docker-credential-helpers v0.9.5 // indirect
 	github.com/docker/go-connections v0.7.0 // indirect

--- a/tools/d2g/d2g.go
+++ b/tools/d2g/d2g.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/distribution/reference"
 	"github.com/taskcluster/slugid-go/slugid"
 	"github.com/taskcluster/taskcluster/v105/internal/scopes"
 	"github.com/taskcluster/taskcluster/v105/tools/d2g/dockerworker"
@@ -644,6 +645,9 @@ func imageObject(payloadImage *json.RawMessage) (Image, error) {
 	}
 	switch val := parsed.(type) {
 	case string:
+		if _, err := reference.ParseNormalizedNamed(val); err != nil {
+			return nil, fmt.Errorf("invalid image name %q: %w", val, err)
+		}
 		din := DockerImageName(val)
 		return &din, nil
 	case map[string]any: // NamedDockerImage|IndexedDockerImage|DockerImageArtifact
@@ -651,7 +655,15 @@ func imageObject(payloadImage *json.RawMessage) (Image, error) {
 		case "docker-image": // NamedDockerImage
 			namedDockerImage := NamedDockerImage{}
 			err = json.Unmarshal(*payloadImage, &namedDockerImage)
-			return &namedDockerImage, err
+			if err != nil {
+				return nil, err
+			}
+
+			if _, err := reference.ParseNormalizedNamed(namedDockerImage.Name); err != nil {
+				return nil, fmt.Errorf("invalid image name %q: %w", namedDockerImage.Name, err)
+			}
+
+			return &namedDockerImage, nil
 		case "indexed-image": // IndexedDockerImage
 			indexDockerImage := IndexedDockerImage{}
 			err = json.Unmarshal(*payloadImage, &indexDockerImage)

--- a/tools/d2g/d2g.go
+++ b/tools/d2g/d2g.go
@@ -474,6 +474,7 @@ func runCommand(
 	args = append(args, nonEnvListArgs...)
 	// Use env file that's created by D2G task feature
 	args = append(args, "--env-file", "env.list")
+	args = append(args, "--")
 	args = append(args, dwImage.String())
 	args = append(args, dwPayload.Command...)
 

--- a/tools/d2g/d2gtest/d2g_test.go
+++ b/tools/d2g/d2gtest/d2g_test.go
@@ -439,3 +439,18 @@ func (tc *TaskDefinitionTestCase) Validate(t *testing.T) {
 	validateAgainstSchema(t, dwRaw, dockerworker.JSONSchema())
 	validateAgainstSchema(t, gwRaw, genericworker.JSONSchema())
 }
+
+func TestConvertPayloadRejectsInvalidImageName(t *testing.T) {
+	dwPayload := dockerworker.DockerWorkerPayload{}
+	defaults.SetDefaults(&dwPayload)
+	dwPayload.Image = json.RawMessage(`"--privileged"`)
+	dwPayload.Command = []string{"busybox", "id"}
+
+	_, _, err := d2g.ConvertPayload(&dwPayload, d2g.Config{}, FakeReadDir)
+	if err == nil {
+		t.Fatal("expected invalid image name to be rejected")
+	}
+	if !strings.Contains(err.Error(), `invalid image name`) {
+		t.Fatalf("expected error to be invalid image name, got: %v", err)
+	}
+}

--- a/tools/d2g/d2gtest/testdata/testcases/artifacts_test.yml
+++ b/tools/d2g/d2gtest/testdata/testcases/artifacts_test.yml
@@ -56,6 +56,7 @@ testSuite:
         - --add-host=localhost.localdomain:127.0.0.1
         - --env-file
         - env.list
+        - --
         - ubuntu
         - echo "Hello world"
       features:
@@ -117,6 +118,7 @@ testSuite:
         - __TASK_DIR__/volume0:/home/worker/artifacts
         - --env-file
         - env.list
+        - --
         - ubuntu
         - echo "Hello world"
       features:

--- a/tools/d2g/d2gtest/testdata/testcases/chain_of_trust_test.yml
+++ b/tools/d2g/d2gtest/testdata/testcases/chain_of_trust_test.yml
@@ -47,6 +47,7 @@ testSuite:
         - --add-host=localhost.localdomain:127.0.0.1
         - --env-file
         - env.list
+        - --
         - my-little/pony:4.1
         - foo
         - bar
@@ -108,6 +109,7 @@ testSuite:
         - --add-host=localhost.localdomain:127.0.0.1
         - --env-file
         - env.list
+        - --
         - __D2G_IMAGE_ID__
         - foo
         - bar
@@ -175,6 +177,7 @@ testSuite:
         - --add-host=localhost.localdomain:127.0.0.1
         - --env-file
         - env.list
+        - --
         - __D2G_IMAGE_ID__
         - foo
         - bar
@@ -238,6 +241,7 @@ testSuite:
         - --add-host=localhost.localdomain:127.0.0.1
         - --env-file
         - env.list
+        - --
         - my-little/pony:4.1
         - foo
         - bar

--- a/tools/d2g/d2gtest/testdata/testcases/container_engine_test.yml
+++ b/tools/d2g/d2gtest/testdata/testcases/container_engine_test.yml
@@ -39,6 +39,7 @@ testSuite:
         - --add-host=localhost.localdomain:127.0.0.1
         - --env-file
         - env.list
+        - --
         - ubuntu
         - echo "Hello world"
       features:

--- a/tools/d2g/d2gtest/testdata/testcases/decision_task_tests.yml
+++ b/tools/d2g/d2gtest/testdata/testcases/decision_task_tests.yml
@@ -96,6 +96,7 @@ testSuite:
         - --add-host=taskcluster:__TASKCLUSTER_PROXY_GATEWAY__
         - --env-file
         - env.list
+        - --
         - mozillareleases/gecko_decision:4.0.0@sha256:9f69fe08c28e3cb3cc296451f0a2735df6e25d0e3c877ea735ef1b7f0b345b06
         - /builds/worker/bin/run-task
         - --gecko-checkout=/builds/worker/checkouts/gecko

--- a/tools/d2g/d2gtest/testdata/testcases/devices_tests.yml
+++ b/tools/d2g/d2gtest/testdata/testcases/devices_tests.yml
@@ -44,6 +44,7 @@ testSuite:
         - /dev/shm:/dev/shm
         - --env-file
         - env.list
+        - --
         - ubuntu
         - echo "Hello world"
       features:
@@ -97,6 +98,7 @@ testSuite:
         - --add-host=localhost.localdomain:127.0.0.1
         - --env-file
         - env.list
+        - --
         - ubuntu
         - echo "Hello world"
       features:
@@ -151,6 +153,7 @@ testSuite:
         - --device=/dev/kvm
         - --env-file
         - env.list
+        - --
         - ubuntu
         - echo "Hello world"
       features:
@@ -204,6 +207,7 @@ testSuite:
         - --add-host=localhost.localdomain:127.0.0.1
         - --env-file
         - env.list
+        - --
         - ubuntu
         - echo "Hello world"
       features:
@@ -258,6 +262,7 @@ testSuite:
         - --device=__TASKCLUSTER_VIDEO_DEVICE__
         - --env-file
         - env.list
+        - --
         - ubuntu
         - echo "Hello world"
       features:
@@ -312,6 +317,7 @@ testSuite:
         - --add-host=localhost.localdomain:127.0.0.1
         - --env-file
         - env.list
+        - --
         - ubuntu
         - echo "Hello world"
       features:
@@ -366,6 +372,7 @@ testSuite:
         - --device=/dev/snd
         - --env-file
         - env.list
+        - --
         - ubuntu
         - echo "Hello world"
       features:
@@ -420,6 +427,7 @@ testSuite:
         - --add-host=localhost.localdomain:127.0.0.1
         - --env-file
         - env.list
+        - --
         - ubuntu
         - echo "Hello world"
       features:
@@ -474,6 +482,7 @@ testSuite:
         - --device=/dev/nvidiactl
         - --env-file
         - env.list
+        - --
         - ubuntu
         - echo "Hello world"
       features:
@@ -528,6 +537,7 @@ testSuite:
         - --device=/dev/nvidiactl
         - --env-file
         - env.list
+        - --
         - ubuntu
         - echo "Hello world"
       features:

--- a/tools/d2g/d2gtest/testdata/testcases/docker_image_tests.yml
+++ b/tools/d2g/d2gtest/testdata/testcases/docker_image_tests.yml
@@ -37,6 +37,7 @@ testSuite:
         - --add-host=localhost.localdomain:127.0.0.1
         - --env-file
         - env.list
+        - --
         - ubuntu
         - echo "Hello world"
       features:
@@ -88,6 +89,7 @@ testSuite:
         - --add-host=localhost.localdomain:127.0.0.1
         - --env-file
         - env.list
+        - --
         - ubuntu
         - echo "Hello world"
       features:
@@ -140,6 +142,7 @@ testSuite:
         - --add-host=localhost.localdomain:127.0.0.1
         - --env-file
         - env.list
+        - --
         - __D2G_IMAGE_ID__
         - echo "Hello world"
       features:
@@ -198,6 +201,7 @@ testSuite:
         - --add-host=localhost.localdomain:127.0.0.1
         - --env-file
         - env.list
+        - --
         - __D2G_IMAGE_ID__
         - echo "Hello world"
       features:
@@ -257,6 +261,7 @@ testSuite:
         - --add-host=localhost.localdomain:127.0.0.1
         - --env-file
         - env.list
+        - --
         - __D2G_IMAGE_ID__
         - echo "Hello world"
       features:
@@ -315,6 +320,7 @@ testSuite:
         - --add-host=localhost.localdomain:127.0.0.1
         - --env-file
         - env.list
+        - --
         - __D2G_IMAGE_ID__
         - echo "Hello world"
       features:
@@ -372,6 +378,7 @@ testSuite:
         - --add-host=localhost.localdomain:127.0.0.1
         - --env-file
         - env.list
+        - --
         - __D2G_IMAGE_ID__
         - echo "Hello world"
       features:
@@ -430,6 +437,7 @@ testSuite:
         - --add-host=localhost.localdomain:127.0.0.1
         - --env-file
         - env.list
+        - --
         - __D2G_IMAGE_ID__
         - echo "Hello world"
       features:
@@ -491,6 +499,7 @@ testSuite:
         - __TASK_DIR__/cache0:/builds/worker/checkouts
         - --env-file
         - env.list
+        - --
         - __D2G_IMAGE_ID__
         - echo "Hello world"
       features:

--- a/tools/d2g/d2gtest/testdata/testcases/dw_features_tests.yml
+++ b/tools/d2g/d2gtest/testdata/testcases/dw_features_tests.yml
@@ -47,6 +47,7 @@ testSuite:
         - --add-host=taskcluster:__TASKCLUSTER_PROXY_GATEWAY__
         - --env-file
         - env.list
+        - --
         - ubuntu
         - echo "Hello world"
       features:
@@ -103,6 +104,7 @@ testSuite:
         - --add-host=localhost.localdomain:127.0.0.1
         - --env-file
         - env.list
+        - --
         - ubuntu
         - echo "Hello world"
       features:
@@ -155,6 +157,7 @@ testSuite:
         - --add-host=localhost.localdomain:127.0.0.1
         - --env-file
         - env.list
+        - --
         - ubuntu
         - echo "Hello world"
       features:
@@ -207,6 +210,7 @@ testSuite:
         - --add-host=localhost.localdomain:127.0.0.1
         - --env-file
         - env.list
+        - --
         - ubuntu
         - echo "Hello world"
       features:

--- a/tools/d2g/d2gtest/testdata/testcases/env_test.yml
+++ b/tools/d2g/d2gtest/testdata/testcases/env_test.yml
@@ -56,6 +56,7 @@ testSuite:
           line2
         - --env-file
         - env.list
+        - --
         - ubuntu
         - echo "Hello world"
       features:

--- a/tools/d2g/d2gtest/testdata/testcases/fuzzing_tests.yml
+++ b/tools/d2g/d2gtest/testdata/testcases/fuzzing_tests.yml
@@ -70,6 +70,7 @@ testSuite:
         - --add-host=taskcluster:__TASKCLUSTER_PROXY_GATEWAY__
         - --env-file
         - env.list
+        - --
         - __D2G_IMAGE_ID__
       features:
         backingLog: true

--- a/tools/d2g/d2gtest/testdata/testcases/no_artifacts_test.yml
+++ b/tools/d2g/d2gtest/testdata/testcases/no_artifacts_test.yml
@@ -45,6 +45,7 @@ testSuite:
         - --add-host=localhost.localdomain:127.0.0.1
         - --env-file
         - env.list
+        - --
         - ubuntu
         - echo "Hello world"
       features:

--- a/tools/d2g/d2gtest/testdata/testcases/task_def_test.yml
+++ b/tools/d2g/d2gtest/testdata/testcases/task_def_test.yml
@@ -81,6 +81,7 @@ testSuite:
           - --device=/dev/kvm
           - --env-file
           - env.list
+          - --
           - ubuntu:latest
           - /bin/bash
           - -c
@@ -192,6 +193,7 @@ testSuite:
           - --device=/dev/kvm
           - --env-file
           - env.list
+          - --
           - ubuntu:latest
           - /bin/bash
           - -c
@@ -306,6 +308,7 @@ testSuite:
           - --device=/dev/kvm
           - --env-file
           - env.list
+          - --
           - ubuntu:latest
           - /bin/bash
           - -c


### PR DESCRIPTION
Also added a `--` in the generated docker run command before positional args so LLMs stop tripping on it and giving either us or the security team even more useless work. See each commit for more details