### PR TITLE
Fix a typo in `finishArtifact`'s error path

### DIFF
--- a/changelog/OCKVV0viQMK39JN15lwBWQ.md
+++ b/changelog/OCKVV0viQMK39JN15lwBWQ.md
@@ -1,0 +1,4 @@
+audience: users
+level: patch
+---
+`finishArtifact` now reports a 400 instead of a 500 when called on a non object artifact

--- a/services/queue/src/artifacts.js
+++ b/services/queue/src/artifacts.js
@@ -508,7 +508,7 @@ export const loadArtifactsRoutes = builder => {
 
       // if this is of a type that is already finished, that's not allowed
       if (!STORAGE_TYPE_NEEDS_FINISH[artifact.storageType]) {
-        return res.resportError('InputError', 'Only object artifacts can be finished', {});
+        return res.reportError('InputError', 'Only object artifacts can be finished', {});
       }
 
       // If already marked present, this is an idempotent call, in which case

--- a/services/queue/test/artifact_test.js
+++ b/services/queue/test/artifact_test.js
@@ -721,6 +721,22 @@ helper.secrets.mockSuite(testing.suiteName(), ['aws'], function (mock, skipping)
       );
     });
 
+    test('finish an artifact that is not an object', async () => {
+      await makeAndClaimTask();
+      await makeArtifact({
+        name: 'public/error.json',
+        storageType: 'error',
+        expires: taskcluster.fromNowJSON('1 day'),
+        reason: 'file-missing-on-worker',
+        message: 'Some user-defined message',
+      });
+
+      await assert.rejects(
+        () => helper.queue.finishArtifact(taskId, 0, 'public/error.json', { uploadId: taskcluster.slugid() }),
+        err => err.code === 'InputError' && err.statusCode === 400
+      );
+    });
+
     test('Post and get error artifact', async () => {
       await makeAndClaimTask();
       await makeArtifact({


### PR DESCRIPTION
I don't think taskcluster sports, let alone resports. Joke aside, this fixes an obvious typo that would make `finishArtifact` return a 500 instead of a 400 when calling it on a non object artifact.