### PR TITLE
Fix the queue client scope narrowing towards the object service

### DIFF
--- a/changelog/f9VIKwAIR5eQ4uGgmLlr3w.md
+++ b/changelog/f9VIKwAIR5eQ4uGgmLlr3w.md
@@ -1,0 +1,2 @@
+level: silent
+---

--- a/services/queue/src/artifacts.js
+++ b/services/queue/src/artifacts.js
@@ -275,7 +275,7 @@ export const loadArtifactsRoutes = builder => {
           uploadId = slugid.nice();
           objectName = artifactToObjectName(taskId, runId, name);
           const objectService = this.objectService.use({
-            authorizedScopes: `object:upload:${projectId}:t/${objectName}`,
+            authorizedScopes: [`object:upload:${projectId}:${objectName}`],
           });
 
           await objectService.createUpload(objectName, {


### PR DESCRIPTION
When uploading an object artifact, the queue service creates an object on the object service. For that it uses the taskcluster client and narrows the scopes for that call to just what it needs. Except it doesn't. Once again, untyped languages show how easy it is to just shoot yourself in the foot. `authorizedScopes` **has to be** an array of scopes or it's just getting ignored by the client. So the queue ended up doing calls towards the object service with its full scope set.

Not an actual security issue, as a user you can't do anything you shouldn't be able to do, the args are properly verified and used to build the scope anyway, but this is still defeating the whole purpose of trying to make calls with clients holding the least amount of scopes possible.

Attentive readers will also notice the `t/` disappeared. That's because `objectName` already contains that prefix (it comes from `artifactToObjectName`), so it was actually trying to use an invalid scope (`t/t/taskId/...`), it was just working because that scope was never actually used.