### PR TITLE
Make JS clients throw when authorizedScopes is passed as the wrong type

### DIFF
--- a/changelog/K0i_4srpQd2FKydDFwu02A.md
+++ b/changelog/K0i_4srpQd2FKydDFwu02A.md
@@ -1,0 +1,5 @@
+audience: users
+level: patch
+---
+The JS clients now throw an error if `authorizedScopes` is passed as anything
+but an array (or `null`) instead of outright ignoring it in that case.

--- a/clients/client-web/src/Client.js
+++ b/clients/client-web/src/Client.js
@@ -32,6 +32,10 @@ export default class Client {
       throw new Error('options.randomizationFactor must be between 0 and 1');
     }
 
+    if (this.options.authorizedScopes != null && !Array.isArray(this.options.authorizedScopes)) {
+      throw new Error('options.authorizedScopes must be an array of scopes');
+    }
+
     if (this.options.accessToken) {
       throw new Error('options.accessToken is no longer supported; use options.credentials');
     }
@@ -105,7 +109,7 @@ export default class Client {
 
     // If set of authorized scopes is provided, we'll restrict the request
     // to only use these scopes
-    if (Array.isArray(authorizedScopes)) {
+    if (authorizedScopes) {
       extra.authorizedScopes = authorizedScopes;
     }
 

--- a/clients/client/src/client.js
+++ b/clients/client/src/client.js
@@ -247,6 +247,10 @@ export const createClient = (reference, name) => {
       throw new Error('options.randomizationFactor must be between 0 and 1!');
     }
 
+    if (this._options.authorizedScopes != null && !Array.isArray(this._options.authorizedScopes)) {
+      throw new Error('options.authorizedScopes must be an array of scopes');
+    }
+
     if (this._options.agent) {
       // We have explicit options for new agent create one...
       this._httpAgent = {
@@ -286,7 +290,7 @@ export const createClient = (reference, name) => {
 
       // If set of authorized scopes is provided, we'll restrict the request
       // to only use these scopes
-      if (Array.isArray(this._options.authorizedScopes)) {
+      if (this._options.authorizedScopes) {
         ext.authorizedScopes = this._options.authorizedScopes;
       }
 

--- a/clients/client/test/creds_test.js
+++ b/clients/client/test/creds_test.js
@@ -83,6 +83,13 @@ suite(testing.suiteName(), () => {
     );
   });
 
+  test('authorizedScopes, not an array', () => {
+    assert.throws(
+      () => client({ authorizedScopes: 'scopes:broken' }),
+      /options.authorizedScopes must be an array of scopes/
+    );
+  });
+
   test('authorizedScopes, insufficient', async () => {
     await expectError(
       client({


### PR DESCRIPTION
Since we don't have type to do this, we have to rely on manual checks and runtime errors. Previously, passing `authorizedScopes: 'foo'` didn't do *anything*. And silently. Which means a user could be expecting to make a call with a narrow set of scopes and end up doing with a much wider one (see #9030 for an example). This commit changes it from being silent to throwing an error.

I checked the taskcluster code base and apart from #9030, I didn't find any other misuse of `authorizedScopes`.
