### PR TITLE
Bug 2064373 - Disable slack message link previews by default

### DIFF
--- a/changelog/bhXIk9rISNS9X0EF8ZffLQ.md
+++ b/changelog/bhXIk9rISNS9X0EF8ZffLQ.md
@@ -1,0 +1,8 @@
+audience: users
+level: minor
+reference: bug 2064373
+---
+Slack notifications no longer show link previews by default. You can re-enable
+that through the `unfurlLinks` / `unfurlMedia` fields on the `slack` API endpoint
+or with `task.extra.notify.slackUnfurlLinks` / `slackUnfurlMedia` for route
+based notifications.

--- a/clients/client-go/tcnotify/types.go
+++ b/clients/client-go/tcnotify/types.go
@@ -147,5 +147,15 @@ type (
 		// message text, otherwise this is used as alternative text and the blocks
 		// are used.
 		Text string `json:"text"`
+
+		// Whether Slack should show previews for links in the message.
+		//
+		// Default:    false
+		UnfurlLinks bool `json:"unfurlLinks,omitempty"`
+
+		// Whether Slack should show previews for links to media in the message.
+		//
+		// Default:    false
+		UnfurlMedia bool `json:"unfurlMedia,omitempty"`
 	}
 )

--- a/generated/references.json
+++ b/generated/references.json
@@ -7201,6 +7201,16 @@
         "text": {
           "description": "The main message text. If no blocks are included, this is used as the\nmessage text, otherwise this is used as alternative text and the blocks\nare used.\n",
           "type": "string"
+        },
+        "unfurlLinks": {
+          "default": false,
+          "description": "Whether Slack should show previews for links in the message.\n",
+          "type": "boolean"
+        },
+        "unfurlMedia": {
+          "default": false,
+          "description": "Whether Slack should show previews for links to media in the message.\n",
+          "type": "boolean"
         }
       },
       "required": [

--- a/services/notify/schemas/v1/slack-request.yml
+++ b/services/notify/schemas/v1/slack-request.yml
@@ -26,6 +26,16 @@ properties:
     type: array
     description: |
       An array of Slack attachments. See https://api.slack.com/messaging/composing/layouts#attachments.
+  unfurlLinks:
+    type: boolean
+    default: false
+    description: |
+      Whether Slack should show previews for links in the message.
+  unfurlMedia:
+    type: boolean
+    default: false
+    description: |
+      Whether Slack should show previews for links to media in the message.
 additionalProperties: false
 required:
   - channelId

--- a/services/notify/src/handler.js
+++ b/services/notify/src/handler.js
@@ -199,6 +199,8 @@ class Handler {
               text,
               blocks,
               attachments,
+              unfurlLinks: _.get(task, 'extra.notify.slackUnfurlLinks') === true,
+              unfurlMedia: _.get(task, 'extra.notify.slackUnfurlMedia') === true,
             });
           }
           case 'pulse': {

--- a/services/notify/src/notifier.js
+++ b/services/notify/src/notifier.js
@@ -139,7 +139,7 @@ class Notifier {
     return true;
   }
 
-  async slack({ channelId, text, blocks, attachments }) {
+  async slack({ channelId, text, blocks, attachments, unfurlLinks, unfurlMedia }) {
     if (!this._slack) {
       this.monitor.warning(`Slack message sent to ${channelId} but Slack is not configured.`);
       return false;
@@ -155,7 +155,7 @@ class Notifier {
       return false;
     }
 
-    await this._slack.sendMessage({ channelId, text, blocks, attachments });
+    await this._slack.sendMessage({ channelId, text, blocks, attachments, unfurlLinks, unfurlMedia });
     this.markSent('slack-channel', channelId, text, blocks, attachments);
     this.monitor.log.slack({ channelId });
     return true;

--- a/services/notify/src/slack.js
+++ b/services/notify/src/slack.js
@@ -4,12 +4,14 @@ class SlackBot {
     this.monitor = monitor;
   }
 
-  async sendMessage({ channelId, text, blocks, attachments }) {
+  async sendMessage({ channelId, text, blocks, attachments, unfurlLinks, unfurlMedia }) {
     const response = await this.client.chat.postMessage({
       channel: channelId,
       text,
       blocks,
       attachments,
+      unfurl_links: unfurlLinks,
+      unfurl_media: unfurlMedia,
     });
     if (!response.ok) {
       throw new Error(`Error posting slack message: ${response.error}`);

--- a/services/notify/test/api_test.js
+++ b/services/notify/test/api_test.js
@@ -188,9 +188,29 @@ helper.secrets.mockSuite(testing.suiteName(), ['aws'], (mock, skipping) => {
       blocks: undefined,
       channel: 'C123456',
       text: 'Does this work?',
+      unfurl_links: false,
+      unfurl_media: false,
     });
     const monitor = await helper.load('monitor');
     assert(monitor.manager.messages.find(m => m.Type === 'slack'));
+  });
+
+  test('slack with unfurling enabled', async () => {
+    await helper.apiClient.slack({
+      channelId: 'C123456',
+      text: 'Does this unfurl?',
+      unfurlLinks: true,
+      unfurlMedia: true,
+    });
+    assert.equal(helper.slackClient.chat.postMessage.callCount, 1);
+    assert.deepStrictEqual(helper.slackClient.chat.postMessage.args[0][0], {
+      attachments: undefined,
+      blocks: undefined,
+      channel: 'C123456',
+      text: 'Does this unfurl?',
+      unfurl_links: true,
+      unfurl_media: true,
+    });
   });
 
   test('slack (denylisted)', async () => {

--- a/services/notify/test/handler_test.js
+++ b/services/notify/test/handler_test.js
@@ -256,7 +256,31 @@ helper.secrets.mockSuite(testing.suiteName(), ['aws'], (mock, skipping) => {
       text: `hey hey ${helper.rootUrl}/tasks/${baseStatus.taskId}`,
       blocks: [{}],
       attachments: [{}, {}],
+      unfurl_links: false,
+      unfurl_media: false,
     });
     assert(monitor.manager.messages.find(m => m.Type === 'slack'));
+  });
+
+  test('slack with unfurl', async () => {
+    const route = 'test-notify.slack-channel.C123456.on-transition';
+    const task = makeTask([route]);
+    task.extra = {
+      notify: { slackText: 'somelink', slackUnfurlLinks: true, slackUnfurlMedia: true },
+    };
+    helper.queue.addTask(baseStatus.taskId, task);
+    await helper.fakePulseMessage({
+      payload: {
+        status: baseStatus,
+      },
+      exchange: 'exchange/taskcluster-queue/v1/task-completed',
+      routingKey: 'doesnt-matter',
+      routes: [route],
+    });
+
+    assert.equal(helper.slackClient.chat.postMessage.callCount, 1);
+    const { unfurl_links, unfurl_media } = helper.slackClient.chat.postMessage.args[0][0];
+    assert.equal(unfurl_links, true);
+    assert.equal(unfurl_media, true);
   });
 });

--- a/ui/docs/reference/core/notify/usage.mdx
+++ b/ui/docs/reference/core/notify/usage.mdx
@@ -102,6 +102,10 @@ the `slackText`. If this is specified, `slackText` is only used for fallback ren
 __task.extra.notify.slackAttachments:__ Extra [Slack Attachments](https://api.slack.com/reference/messaging/attachments) which are displayed below the message. These are usually used for context.
 No attachments are rendered by default.
 
+__task.extra.notify.slackUnfurlLinks:__ Whether Slack should show previews for links in the message. Defaults to `false`.
+
+__task.extra.notify.slackUnfurlMedia:__ Whether Slack should show previews for links to media in the message. Defaults to `false`.
+
 __task.extra.notify.email.content:__ This should evaluate to a markdown string and is the body of an email
 
 __task.extra.notify.email.subject:__ This should evaluate to a normal string and is the subject of an email


### PR DESCRIPTION
I chose to disable it by default and add a setting to re-enable them. You most likely want short notifications rather than have half of a 4k screen filled with link previews that have no value whatsoever.

See https://docs.slack.dev/messaging/unfurling-links-in-messages/
