### PR TITLE
Bug 2064901 - Require `github:trigger-hook` to fire hooks from .taskcluster.yml

### DIFF
--- a/changelog/bug-2064901.md
+++ b/changelog/bug-2064901.md
@@ -1,0 +1,6 @@
+audience: users
+level: major
+reference: bug 2064901
+---
+Github hooks triggered from .taskcluster.yml now require the
+`github:trigger-hook:<name>` scope instead of `hooks:trigger-hook:<name>`.

--- a/services/auth/src/static-scopes.json
+++ b/services/auth/src/static-scopes.json
@@ -11,6 +11,8 @@
     "scopes": [
       "assume:repo:github.com/*",
       "assume:scheduler-id:taskcluster-github/*",
+      "auth:expand-scopes",
+      "hooks:trigger-hook:*",
       "queue:cancel-task-group:taskcluster-github/*",
       "queue:get-artifact:public/github/customCheckRunAnnotations.json",
       "queue:get-artifact:public/github/customCheckRunText.md",

--- a/services/github/scopes.yml
+++ b/services/github/scopes.yml
@@ -1,4 +1,6 @@
 - assume:repo:github.com/*
+- auth:expand-scopes
+- hooks:trigger-hook:*
 - queue:scheduler-id:taskcluster-github
 - queue:route:statuses
 - queue:route:checks

--- a/services/github/src/handlers/index.js
+++ b/services/github/src/handlers/index.js
@@ -5,6 +5,7 @@ import taskcluster from '@taskcluster/client';
 import yaml from 'js-yaml';
 import assert from 'node:assert';
 import { consume } from '@taskcluster/lib-pulse';
+import { satisfiesExpression } from 'taskcluster-lib-scopes';
 import { deprecatedStatusHandler } from './deprecatedStatus.js';
 import { taskGroupCreationHandler } from './taskGroupCreation.js';
 import { statusHandler } from './status.js';
@@ -262,31 +263,32 @@ class Handlers {
     const hookGroup = name.slice(0, slashIndex);
     const hookId = name.slice(slashIndex + 1);
 
-    const limitedHooksClient = this.context.hooksClient.use({
-      authorizedScopes: scopes,
-    });
+    const hookScope = `trigger-hook:${name}`;
+    const { scopes: expandedScopes } = await this.context.authClient.expandScopes({ scopes });
 
-    try {
-      const result = await limitedHooksClient.triggerHook(hookGroup, hookId, payload);
-      return result.taskId || null;
-    } catch (err) {
-      // translate InsufficientScopes errors nicely for our users, since they are common and
-      // since we can provide additional context not available from the hooks service.
-      if (err.code === 'InsufficientScopes') {
-        err.message = [
+    if (!satisfiesExpression(expandedScopes, `github:${hookScope}`)) {
+      const err = new Error(
+        [
           'Taskcluster-GitHub attempted to trigger a hook for this event with the following scopes:',
           '',
           '```',
           stringify(scopes, null, 2),
           '```',
           '',
-          'The expansion of these scopes is not sufficient to trigger the hook, leading to the following:',
-          '',
-          err.message,
-        ].join('\n');
-      }
+          `The expansion of these scopes is missing \`github:${hookScope}\`, which is required to`,
+          `trigger the hook \`${name}\`.`,
+        ].join('\n')
+      );
+      err.code = 'InsufficientScopes';
       throw err;
     }
+
+    const limitedHooksClient = this.context.hooksClient.use({
+      authorizedScopes: [`hooks:${hookScope}`],
+    });
+
+    const result = await limitedHooksClient.triggerHook(hookGroup, hookId, payload);
+    return result.taskId || null;
   }
 
   /**

--- a/services/github/src/main.js
+++ b/services/github/src/main.js
@@ -145,6 +145,15 @@ const load = loader(
         }),
     },
 
+    authClient: {
+      requires: ['cfg'],
+      setup: ({ cfg }) =>
+        new taskcluster.Auth({
+          rootUrl: cfg.taskcluster.rootUrl,
+          credentials: cfg.taskcluster.credentials,
+        }),
+    },
+
     api: {
       requires: ['cfg', 'monitor', 'schemaset', 'github', 'publisher', 'db', 'ajv', 'queueClient', 'intree'],
       setup: ({ cfg, monitor, schemaset, github, publisher, db, ajv, queueClient, intree }) => {
@@ -211,6 +220,7 @@ const load = loader(
         'db',
         'queueClient',
         'hooksClient',
+        'authClient',
       ],
       setup: async ({
         cfg,
@@ -224,6 +234,7 @@ const load = loader(
         db,
         queueClient,
         hooksClient,
+        authClient,
       }) =>
         new Handlers({
           rootUrl: cfg.taskcluster.rootUrl,
@@ -236,7 +247,7 @@ const load = loader(
           deprecatedInitialStatusQueueName: cfg.app.deprecatedInitialStatusQueue,
           resultStatusQueueName: cfg.app.resultStatusQueue,
           rerunQueueName: cfg.app.rerunQueue,
-          context: { cfg, github, schemaset, db, publisher, hooksClient },
+          context: { cfg, github, schemaset, db, publisher, hooksClient, authClient },
           pulseClient,
           queueClient,
         }),

--- a/services/github/test/handler_test.js
+++ b/services/github/test/handler_test.js
@@ -1429,11 +1429,19 @@ helper.secrets.mockSuite(testing.suiteName(), [], (mock, skipping) => {
     suite('hooks', () => {
       let mockTriggerHook;
       let mockUse;
+      let mockExpandScopes;
+      let repoExpandedScopes;
 
       setup(() => {
         mockTriggerHook = sinon.stub().resolves({ taskId: taskcluster.slugid() });
         mockUse = sinon.stub().returns({ triggerHook: mockTriggerHook });
         handlers.context.hooksClient = { use: mockUse };
+
+        repoExpandedScopes = ['github:trigger-hook:*'];
+        mockExpandScopes = sinon.stub().callsFake(async ({ scopes }) => ({
+          scopes: [...scopes, ...repoExpandedScopes],
+        }));
+        handlers.context.authClient = { expandScopes: mockExpandScopes };
       });
 
       test('hooks-only config triggers hook and creates build record', async () => {
@@ -1460,7 +1468,7 @@ helper.secrets.mockSuite(testing.suiteName(), [], (mock, skipping) => {
         assert.equal(payload.tasks_for, 'github-push');
 
         assert(mockUse.calledOnce);
-        assert.ok(mockUse.firstCall.args[0].authorizedScopes, 'use() should be called with authorizedScopes');
+        assert.deepEqual(mockUse.firstCall.args[0].authorizedScopes, ['hooks:trigger-hook:project-test/decision-hook']);
 
         const [build] = await helper.db.fns.get_github_build_pr(payload.taskId);
         assert.ok(build, 'build record should exist');
@@ -1566,6 +1574,25 @@ helper.secrets.mockSuite(testing.suiteName(), [], (mock, skipping) => {
         assert.deepEqual(builds, [], 'build record should be deleted when hook trigger fails');
       });
 
+      test('a missing github:trigger-hook is reported on the commit', async () => {
+        repoExpandedScopes = ['github:trigger-hook:project-test/wrong-hook'];
+
+        github.inst(INST_ID).setTaskclusterYml({
+          owner: 'TaskclusterRobot',
+          repo: 'hooks-testing',
+          ref: COMMIT_SHA,
+          content: {
+            version: 1,
+            hooks: [{ name: 'project-test/decision-hook' }],
+          },
+        });
+
+        await simulateJobMessage({ user: 'TaskclusterRobot' });
+
+        assert(mockTriggerHook.notCalled, 'the hook must not be triggered');
+        assert(github.inst(INST_ID).repos.createCommitComment.calledOnce);
+      });
+
       test('hook failure does not prevent tasks from running', async () => {
         mockTriggerHook.rejects(Object.assign(new Error('hook failed'), { body: { error: 'hook error' } }));
 
@@ -1588,22 +1615,57 @@ helper.secrets.mockSuite(testing.suiteName(), [], (mock, skipping) => {
         assert(handlers.createTasks.calledOnce, 'tasks should still run despite hook failure');
       });
 
-      test('triggerHook reformats InsufficientScopes error with context', async () => {
-        const insufficientScopesErr = Object.assign(new Error('original scope error'), { code: 'InsufficientScopes' });
-        mockTriggerHook.rejects(insufficientScopesErr);
+      test('triggerHook does not foward the repository scopes to the hooks service', async () => {
+        await handlers.triggerHook({
+          scopes: ['assume:repo:github.com/TaskclusterRobot/hooks-testing:pull-request'],
+          name: 'project-test/decision-hook',
+          payload: {},
+        });
+
+        assert(mockUse.calledOnce);
+        assert.deepEqual(mockUse.firstCall.args[0].authorizedScopes, ['hooks:trigger-hook:project-test/decision-hook']);
+      });
+
+      test('triggerHook requires the right github:trigger-hook', async () => {
+        repoExpandedScopes = ['github:trigger-hook:project-test/some-other-hook'];
 
         await assert.rejects(
-          () => handlers.triggerHook({ scopes: ['scope:a', 'scope:b'], name: 'group/name', payload: {} }),
+          () =>
+            handlers.triggerHook({
+              scopes: ['assume:repo:github.com/TaskclusterRobot/hooks-testing:pull-request'],
+              name: 'project-test/decision-hook',
+              payload: {},
+            }),
           err => {
+            assert.equal(err.code, 'InsufficientScopes');
             assert(
-              err.message.includes('Taskcluster-GitHub attempted to trigger a hook'),
-              'message should include context'
+              err.message.includes('github:trigger-hook:project-test/decision-hook'),
+              'message should name the missing scope'
             );
-            assert(err.message.includes('scope:a'), 'message should include the scopes');
-            assert(err.message.includes('original scope error'), 'message should include the original error');
+            assert(
+              err.message.includes('assume:repo:github.com/TaskclusterRobot/hooks-testing:pull-request'),
+              'message should include the scopes that were expanded'
+            );
             return true;
           }
         );
+
+        assert(mockUse.notCalled, 'the hook must not have been triggered');
+      });
+
+      test('hooks:trigger-hook is not enough to trigger hooks from the github service', async () => {
+        repoExpandedScopes = ['hooks:trigger-hook:project-test/decision-hook'];
+
+        await assert.rejects(
+          () =>
+            handlers.triggerHook({
+              scopes: ['assume:repo:github.com/TaskclusterRobot/hooks-testing:pull-request'],
+              name: 'project-test/decision-hook',
+              payload: {},
+            }),
+          /InsufficientScopes|github:trigger-hook/
+        );
+        assert(mockUse.notCalled, 'the hook must not have been triggered');
       });
 
       test('triggerHook throws on invalid name format without calling use()', async () => {

--- a/ui/docs/reference/integrations/github/taskcluster-yml-v1.mdx
+++ b/ui/docs/reference/integrations/github/taskcluster-yml-v1.mdx
@@ -291,12 +291,23 @@ Note that hook `context` values are passed as-is and **do not support JSON-e tem
 
 ### Scopes for Hooks
 
-The repository role (e.g. `repo:github.com/<owner>/<repo>:branch:<branch>`) must include the scope `hooks:trigger-hook:<hookGroupId>/<hookId>` for each hook being triggered. For example:
+The repository role (e.g. `repo:github.com/<owner>/<repo>:branch:<branch>`) must include the scope `github:trigger-hook:<hookGroupId>/<hookId>` for each hook being triggered. For example:
 
 ```yaml
 # In the Roles tool, for role repo:github.com/myorg/myrepo:*
-hooks:trigger-hook:project-myproject/decision
+github:trigger-hook:project-myproject/decision
 ```
+
+Note that the `github:` prefix here is intentional. This scope authorizes *the
+taskcluster github service* to trigger the hook with the given name.
+
+<Warning>
+**Do not grant `hooks:trigger-hook:<hookGroupId>/<hookId>` to a repository role
+for this purpose.**. Every scope in a repository role is available to tasks
+that repository events create, including tasks created from any pull request.
+A task holding `hooks:trigger-hook:...` can call `hooks.triggerHook` directly
+with a payload of its own, forging the GitHub event.
+</Warning>
 
 ### Hook Failures
 


### PR DESCRIPTION
This changes the feature that was introduced by #8431 to require `github:trigger-hook:<hook>` instead of `hooks:trigger-hook:<name>`.

This fixes a security oversight of the original implementation. The feature was implemented so that we could run the same task template across trust domain / repositories / levels, all of which are derived from the github event that the github service injects into the created task. Due to how hooks work, the `hook-id:<name>` role needs to hold the sum of all scopes that every github event could trigger it for.

This would be fine except it needs to hold `trigger-hook:<itself>` since the github service could not trigger it with its own credentials unless the event role for which it was trying to trigger said hook also held that scope (which the github service held transitively since it holds `assume:repo:github.com/*`).

A decision task could then call `triggerHook` itself with a fake github event, and since the hook has scopes for every single other repo using said hook, it'd be pretty bad.

The new way of doing this is to add a marker scope `github:trigger-hook:<name>` which allows a github event to trigger a hook of the same name *through* the github service. Since said service verifies that events are legitimately from github and since it forces `event` in the context to be whatever github provided, the hook can then assume the right scopes for the event, which solves the issue described above. The github event role cannot trigger the hook manually anymore, everyone's happy.

This means however that I had to expand the roles of the static github service client to be able to trigger all hooks (and to expand scopes, that one's fine). This is a bit dicey and I'm not thrilled about it but given the very broad `assume:repo:github.com/*` right above, it's not too much of a stretch.
