### PR TITLE
Bug 2062167 - Ensure each interactive session is authenticated against its own secret

### DIFF
--- a/changelog/bug-2062167.md
+++ b/changelog/bug-2062167.md
@@ -1,0 +1,5 @@
+audience: users
+level: patch
+reference: bug 2062167
+---
+Fixed a bug where multiple interactive sessions on a worker with capacity greater than 1 would override eachother's secrets.

--- a/internal/mocktc/queue.go
+++ b/internal/mocktc/queue.go
@@ -530,6 +530,17 @@ func (queue *Queue) Artifact(taskId, runId, name string) (*tcqueue.GetArtifactCo
 			return nil, err
 		}
 
+	case *tcqueue.RedirectArtifactRequest:
+		resp := tcqueue.GetArtifactContentResponse3{
+			StorageType: "reference",
+			URL:         a.URL,
+		}
+		var err error
+		jsonResp, err = json.Marshal(resp)
+		if err != nil {
+			return nil, err
+		}
+
 	case *tcqueue.LinkArtifactRequest:
 		return queue.Artifact(taskId, runId, a.Artifact)
 

--- a/workers/generic-worker/interactive/interactive.go
+++ b/workers/generic-worker/interactive/interactive.go
@@ -3,10 +3,10 @@ package interactive
 
 import (
 	"context"
+	"crypto/subtle"
 	"fmt"
 	"log"
 	"net/http"
-	"os"
 	"os/exec"
 	"strings"
 	"time"
@@ -45,17 +45,13 @@ func New(port uint16, interactiveCommands InteractiveCommands, ctx context.Conte
 	}
 
 	it.setRequestURL()
-	os.Setenv("INTERACTIVE_ACCESS_TOKEN", it.secret)
 
 	return
 }
 
 func (it *Interactive) Handler(w http.ResponseWriter, r *http.Request) {
-	accessToken := os.Getenv("INTERACTIVE_ACCESS_TOKEN")
 	secret := strings.TrimPrefix(r.URL.Path, "/shell/")
-	// Authenticate the request with accessToken, this is good enough because
-	// interactive shells are short-lived.
-	if secret != accessToken {
+	if subtle.ConstantTimeCompare([]byte(secret), []byte(it.secret)) != 1 {
 		http.Error(w, "Access denied", http.StatusUnauthorized)
 		return
 	}

--- a/workers/generic-worker/interactive/interactive_test.go
+++ b/workers/generic-worker/interactive/interactive_test.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
-	"os"
 	"os/exec"
 	"strings"
 	"testing"
@@ -61,7 +60,7 @@ func testInteractive(t *testing.T, port uint16, interactiveCommands InteractiveC
 	defer server.Close()
 
 	// Make a WebSocket connection to the server
-	url := "ws" + strings.TrimPrefix(server.URL, "http") + fmt.Sprintf("/shell/%v", os.Getenv("INTERACTIVE_ACCESS_TOKEN"))
+	url := "ws" + strings.TrimPrefix(server.URL, "http") + fmt.Sprintf("/shell/%v", interactive.secret)
 	conn, _, err := websocket.DefaultDialer.Dial(url, nil)
 	if err != nil {
 		t.Fatal("dial error:", err)
@@ -116,5 +115,35 @@ func testInteractive(t *testing.T, port uint16, interactiveCommands InteractiveC
 	err = conn.Close()
 	if err != nil {
 		t.Fatalf("Error closing WebSocket connection: %v", err)
+	}
+}
+
+func TestInteractiveSecretIsPerSession(t *testing.T) {
+	ctx := t.Context()
+
+	interactiveCommands := InteractiveCommands{
+		IsReadyCmd:     nil,
+		InteractiveCmd: func() (InteractiveCmdType, error) { return exec.CommandContext(ctx, "bash"), nil },
+	}
+
+	first, err := New(53763, interactiveCommands, ctx)
+	if err != nil {
+		t.Fatalf("could not create first interactive session: %v", err)
+	}
+	second, err := New(53764, interactiveCommands, ctx)
+	if err != nil {
+		t.Fatalf("could not create second interactive session: %v", err)
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(first.Handler))
+	defer server.Close()
+
+	resp, err := http.Get(server.URL + "/shell/" + second.secret)
+	if err != nil {
+		t.Fatalf("Failed to connect: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("expected failure when authenticating to the first session with the second session's secret, got %v", resp.StatusCode)
 	}
 }

--- a/workers/generic-worker/interactive_test.go
+++ b/workers/generic-worker/interactive_test.go
@@ -4,14 +4,62 @@ package main
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
+	"net"
+	"net/url"
 	"os"
+	"path"
 	"testing"
 	"time"
 
 	"github.com/gorilla/websocket"
 	"github.com/mcuadros/go-defaults"
+	"github.com/taskcluster/taskcluster/v105/clients/client-go/tcqueue"
 )
+
+func skipWithoutShellArtifactAccess(t *testing.T) {
+	t.Helper()
+	if os.Getenv("GW_TESTS_USE_EXTERNAL_TASKCLUSTER") != "" {
+		t.Skip("This test cannot run against an external taskcluster, it needs scopes to access private artifacts")
+	}
+}
+
+func interactiveShellURL(t *testing.T, taskID string) (*url.URL, error) {
+	t.Helper()
+	const artifactName = "private/generic-worker/shell.html"
+	queue := serviceFactory.Queue(config.Credentials(), config.RootURL)
+	content, err := queue.LatestArtifact(taskID, artifactName)
+	if err != nil {
+		// The artifact is not published yet, the tick loop will retry for us
+		return nil, err
+	}
+
+	var reference tcqueue.GetArtifactContentResponse3
+	if err := json.Unmarshal(*content, &reference); err != nil {
+		t.Fatalf("Could not unmarshal interactive artifact as a reference one: %v", err)
+	}
+
+	shellURL, err := url.Parse(reference.URL)
+	if err != nil {
+		t.Fatalf("Could not parse shell URL %q: %v", reference.URL, err)
+	}
+
+	query := shellURL.Query()
+	if !query.Has("socketUrl") {
+		t.Fatalf("Shell URL %q does not include a socketUrl parameter?", reference.URL)
+	}
+
+	socketURL, err := url.Parse(query.Get("socketUrl"))
+	if err != nil {
+		t.Fatalf("Could not parse socketUrl parameter of shell URL %q: %v", reference.URL, err)
+	}
+
+	// the exposure advertises config.PublicIP which might not be localhost but
+	// it listens on all interfaces.
+	socketURL.Host = net.JoinHostPort("localhost", socketURL.Port())
+	return socketURL, nil
+}
 
 func TestInteractiveArtifact(t *testing.T) {
 	setup(t)
@@ -59,6 +107,7 @@ func TestInteractiveArtifact(t *testing.T) {
 }
 
 func TestInteractiveCommand(t *testing.T) {
+	skipWithoutShellArtifactAccess(t)
 	setup(t)
 
 	oldEnableInteractive := config.EnableInteractive
@@ -77,9 +126,12 @@ func TestInteractiveCommand(t *testing.T) {
 	defaults.SetDefaults(&payload)
 	td := testTask(t)
 
-	done := make(chan string, 1)
+	taskID := scheduleTask(t, td, payload)
+
+	done := make(chan struct{})
 	go func() {
-		done <- submitAndAssert(t, td, payload, "completed", "completed")
+		defer close(done)
+		ensureResolution(t, taskID, "completed", "completed")
 	}()
 	// Ensure we wait for the worker goroutine to finish to avoid race with next test's teardown
 	defer func() { <-done }()
@@ -90,17 +142,22 @@ func TestInteractiveCommand(t *testing.T) {
 
 	var conn *websocket.Conn
 	var err error
+	var lastErr error
 	const SENTINEL = "S3ntin3lValue"
 
 	for {
 		select {
 		case <-timeout:
 			// Timeout reached
-			t.Fatal("timeout waiting for server to start")
+			t.Fatalf("timeout waiting for server to start, last error: %v", lastErr)
 		case <-tick:
 			// Try to connect to the server
-			url := fmt.Sprintf("ws://localhost:%v/shell/%v", config.InteractivePort, os.Getenv("INTERACTIVE_ACCESS_TOKEN"))
-			conn, _, err = websocket.DefaultDialer.Dial(url, nil)
+			shellURL, serr := interactiveShellURL(t, taskID)
+			if serr != nil {
+				lastErr = serr
+				continue
+			}
+			conn, _, err = websocket.DefaultDialer.Dial(shellURL.String(), nil)
 			if err == nil {
 				err = conn.WriteMessage(websocket.TextMessage, fmt.Appendf(nil, "\x01echo %s\n", SENTINEL))
 				if err != nil {
@@ -146,6 +203,7 @@ func TestInteractiveCommand(t *testing.T) {
 				// defer handles waiting for done
 				return
 			} else {
+				lastErr = err
 				t.Logf("error connecting to server: %v", err)
 			}
 		}
@@ -153,6 +211,7 @@ func TestInteractiveCommand(t *testing.T) {
 }
 
 func TestInteractiveWrongSecret(t *testing.T) {
+	skipWithoutShellArtifactAccess(t)
 	setup(t)
 
 	oldEnableInteractive := config.EnableInteractive
@@ -171,35 +230,50 @@ func TestInteractiveWrongSecret(t *testing.T) {
 	defaults.SetDefaults(&payload)
 	td := testTask(t)
 
-	done := make(chan string, 1)
+	taskID := scheduleTask(t, td, payload)
+
+	done := make(chan struct{})
 	go func() {
-		done <- submitAndAssert(t, td, payload, "completed", "completed")
+		defer close(done)
+		ensureResolution(t, taskID, "completed", "completed")
 	}()
+	// Ensure we wait for the worker goroutine to finish to avoid race with next test's teardown
+	defer func() { <-done }()
 
 	// Wait for server to start
 	timeout := time.After(10 * time.Second)
 	tick := time.Tick(500 * time.Millisecond)
 
-	timedOut := false
-	for !timedOut {
+	attempted := false
+	var lastErr error
+loop:
+	for {
 		select {
 		case <-done:
-			return
+			break loop
 		case <-timeout:
 			// Timeout reached, could not connect to server
 			// which should be the case since we are using the wrong secret
-			timedOut = true
+			break loop
 		case <-tick:
 			// Try to connect to the server
-			url := fmt.Sprintf("ws://localhost:%v/shell/%v", config.InteractivePort, "bad-secret")
-			_, _, err := websocket.DefaultDialer.Dial(url, nil)
+			shellURL, err := interactiveShellURL(t, taskID)
+			if err != nil {
+				lastErr = err
+				continue
+			}
+			shellURL.Path = path.Join(path.Dir(shellURL.Path), "bad-secret")
+			attempted = true
+			_, _, err = websocket.DefaultDialer.Dial(shellURL.String(), nil)
 			if err == nil {
 				t.Fatal("expected error connecting to server")
 			}
 		}
 	}
-	// Wait for the worker goroutine to finish to avoid race with next test's teardown
-	<-done
+
+	if !attempted {
+		t.Fatalf("The shell.html artifact was never fetched, last error: %v", lastErr)
+	}
 }
 
 func TestInteractiveNoConfigSetMalformedPayload(t *testing.T) {


### PR DESCRIPTION
This is yet another fallout from the capacity > 1 PR where it was missed  that the interactive feature was using an environment *on the worker* as a way to pass the interactive session secret around instead of reading it from the interactive struct that was right there. That's been the case since the secret check got introduced in https://github.com/taskcluster/taskcluster/commit/ad2c6d5ae7ad46eeacc56ca7bc38e7e38bdfa63c.

With capacity > 1, this becomes a problem because an environment variable is just a hidden global. A worker process that would start two interactive sessions would have that global change on each session,  making the first session not able to authenticate anymore with its own  secret after the second one started. Instead, the second shell could authenticate to the first one with the new secret.

The change in code is fairly simple, as I said before, the struct was right there, just read the secret from it. I also switched the check to use a timing safe compare since I was in the area. It's a secret, it costs nothing to do this right.

Where that got a bit spicy is with tests (which is probably the reason why the environment variable was a thing in the first place). Because integration tests don't have access to the internals of the worker, they can't extract the secret from the interactive struct so I had to find another way. Thankfully extracting the secret from the shell artifact was fairly straightforward since it's a reference artifact with the secret in the URL and it required very little finagling.