### PR TITLE
chore(docs): Improve readme wording for security reporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,12 @@
 
 This repository is used to develop, build, and release the Taskcluster services.
 
+## Security
+
+External vulnerability reports for Taskcluster must go through [Mozilla's HackerOne program](https://hackerone.com/mozilla). Please do not open GitHub Security Advisories, GitHub Issues, pull requests, or email threads for potential vulnerabilities.
+
+If you already opened a GitHub Security Advisory, submit the issue through HackerOne and include the GHSA ID, proof of concept or reproduction steps, affected deployment details, and potential impact. See [SECURITY.md](SECURITY.md) for the full policy.
+
 ## Table of Contents
 
 <!-- TOC BEGIN -->

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,7 +6,7 @@ This code and its associated production web page are included in Mozilla's web a
 
 ## Reporting a Potential Vulnerability
 
-Please submit all security-related bugs through [HackerOne](https://hackerone.com/mozilla). Never submit security-related bugs through a GitHub Issue or by email.
+Please submit all security-related bugs through [HackerOne](https://hackerone.com/mozilla). Do not submit security-related bugs through GitHub Issues, GitHub Security Advisories (GHSAs), pull requests, or email. HackerOne is where Mozilla evaluates duplicate status and coordinates disclosure and credit.
 
 ### What to include
 
@@ -14,7 +14,7 @@ To help us triage quickly, please provide:
 
 - A clear description of the issue
 - Steps to reproduce, or a proof of concept
-- Affected versions or environments
+- Affected versions, services, deployments, or environments
 - Potential impact, including what an attacker could achieve
 - Any suggested mitigations or fixes
 

--- a/changelog/dsjE4xEnQO6-6qcpmMytPw.md
+++ b/changelog/dsjE4xEnQO6-6qcpmMytPw.md
@@ -1,0 +1,3 @@
+audience: general
+level: silent
+---


### PR DESCRIPTION
we see an increased number of advisories being drafted where reports should be going through the official SECURITY.md guidelines
