### PR TITLE
feat(github): fix unsafe handling in as_slugid helper

### DIFF
--- a/changelog/b6go8XUrRg-EqRUSojTaUw.md
+++ b/changelog/b6go8XUrRg-EqRUSojTaUw.md
@@ -1,0 +1,5 @@
+audience: users
+level: patch
+---
+
+Fixed unsafe handling of inherited JavaScript properties when rendering `.taskcluster.yml` files through v0 parameters and v1 `as_slugid()` labels.

--- a/services/github/src/tc-yaml.js
+++ b/services/github/src/tc-yaml.js
@@ -88,9 +88,11 @@ class VersionZero extends TcYaml {
   }
 
   substituteParameters(config, cfg, payload) {
+    // Ensure template parameters resolve only explicitly defined properties.
+    // block access to Object.prototype properties
     return jparam(
       config,
-      _.merge(payload.details, {
+      Object.assign(Object.create(null), payload.details, {
         $fromNow: text => tc.fromNowJSON(text),
         timestamp: Math.floor(new Date()),
         organization: payload.organization,
@@ -202,15 +204,14 @@ class VersionOne extends TcYaml {
   substituteParameters(config, cfg, payload) {
     branchTest(payload.branch);
 
-    const slugids = {};
+    // Use a null-prototype object to prevent labels such as `constructor` from
+    // resolving inherited properties.
+    const slugids = Object.create(null);
     const as_slugid = label => {
-      const rv = slugids[label];
-      if (rv) {
-        return rv;
-      } else {
+      if (!(label in slugids)) {
         slugids[label] = slugid.nice();
-        return slugids[label];
       }
+      return slugids[label];
     };
 
     try {

--- a/services/github/src/tc-yaml.js
+++ b/services/github/src/tc-yaml.js
@@ -257,7 +257,7 @@ class VersionOne extends TcYaml {
         defaultTaskGroupId = slugid.nice();
       }
 
-      const taskMap = {};
+      const taskMap = Object.create(null);
       const tsort = new TopoSort();
 
       // process tasks and set up topological sorting
@@ -294,7 +294,7 @@ class VersionOne extends TcYaml {
       config.tasks = tsort
         .sort()
         .reverse()
-        .filter(id => taskMap[id])
+        .filter(id => Object.hasOwn(taskMap, id))
         .map(id => taskMap[id]);
     }
     return this.createScopes(cfg, config, payload);

--- a/services/github/test/tc-yaml_test.js
+++ b/services/github/test/tc-yaml_test.js
@@ -104,6 +104,41 @@ suite(testing.suiteName(), () => {
         'queue:scheduler-id:test-sched',
       ]);
     });
+
+    suite('substituteParameters', () => {
+      const v0cfg = { ...cfg, intree: { provisionerId: 'prov', workerType: 'wt' } };
+      const substitute = config =>
+        tcyaml.substituteParameters(config, v0cfg, {
+          organization: 'org',
+          repository: 'repo',
+          details: { 'event.type': 'push' },
+        });
+
+      test('substitutes known parameters', () => {
+        assume(substitute({ p: '{{event.type}}', o: '{{organization}}' })).to.deeply.equal({
+          p: 'push',
+          o: 'org',
+        });
+      });
+
+      for (const name of ['valueOf', 'toString', 'constructor', 'hasOwnProperty', '__proto__']) {
+        test(`does not resolve inherited property {{${name}}}`, () => {
+          assume(substitute({ p: `{{${name}}}` })).to.deeply.equal({ p: `{{${name}}}` });
+        });
+      }
+
+      test('does not call an inherited property via the pipe form', () => {
+        assume(substitute({ p: '{{ "pwn" | isPrototypeOf }}' })).to.deeply.equal({
+          p: '{{ "pwn" | isPrototypeOf }}',
+        });
+      });
+
+      test('does not mutate payload.details', () => {
+        const payload = { organization: 'org', repository: 'repo', details: { 'event.type': 'push' } };
+        tcyaml.substituteParameters({ p: '{{event.type}}' }, v0cfg, payload);
+        assume(payload.details).to.deeply.equal({ 'event.type': 'push' });
+      });
+    });
   });
 
   suite('VersionOne', () => {
@@ -146,6 +181,48 @@ suite(testing.suiteName(), () => {
         },
       ]);
       assume(config.scopes.sort()).to.deeply.equal(['queue:route:statuses-queue', 'queue:scheduler-id:test-sched']);
+    });
+
+    suite('substituteParameters', () => {
+      const v1cfg = { ...cfg, taskcluster: { ...cfg.taskcluster, rootUrl: 'https://tc.example.com' } };
+      const substitute = config =>
+        tcyaml.substituteParameters(config, v1cfg, {
+          tasks_for: 'github-push',
+          branch: 'main',
+          body: { ref: 'refs/heads/main' },
+        });
+      const isSlugid = value => typeof value === 'string' && /^[A-Za-z0-9_-]{22}$/.test(value);
+
+      test('as_slugid returns a stable slugid per label', () => {
+        const { a, b, c } = substitute({
+          a: { $eval: 'as_slugid("x")' },
+          b: { $eval: 'as_slugid("x")' },
+          c: { $eval: 'as_slugid("y")' },
+        });
+        assume(isSlugid(a)).to.equal(true);
+        assume(a).to.equal(b);
+        assume(c).to.not.equal(a);
+      });
+
+      test('as_slugid treats labels that coerce to the same string as equal', () => {
+        const { a, b } = substitute({
+          a: { $eval: 'as_slugid("1")' },
+          b: { $eval: 'as_slugid(1)' },
+        });
+        assume(isSlugid(a)).to.equal(true);
+        assume(a).to.equal(b);
+      });
+
+      for (const label of ['constructor', '__proto__', 'toString', 'valueOf', 'hasOwnProperty']) {
+        test(`as_slugid("${label}") returns a slugid, not a host object`, () => {
+          const { p } = substitute({ p: { $eval: `as_slugid("${label}")` } });
+          assume(isSlugid(p)).to.equal(true);
+        });
+      }
+
+      test('as_slugid result is not callable', () => {
+        assume(() => substitute({ p: { $eval: 'as_slugid("constructor")("pwn")' } })).to.throw();
+      });
     });
 
     suite('scopes', () => {

--- a/services/github/test/tc-yaml_test.js
+++ b/services/github/test/tc-yaml_test.js
@@ -183,6 +183,16 @@ suite(testing.suiteName(), () => {
       assume(config.scopes.sort()).to.deeply.equal(['queue:route:statuses-queue', 'queue:scheduler-id:test-sched']);
     });
 
+    test('compileTasks handles inherited names used as task IDs and dependencies', () => {
+      const config = {
+        tasks: [{ taskId: 'constructor', dependencies: ['toString'] }],
+      };
+
+      tcyaml.compileTasks(config, cfg, {}, now);
+
+      assume(config.tasks.map(task => task.taskId)).to.deeply.equal(['constructor']);
+    });
+
     suite('substituteParameters', () => {
       const v1cfg = { ...cfg, taskcluster: { ...cfg.taskcluster, rootUrl: 'https://tc.example.com' } };
       const substitute = config =>


### PR DESCRIPTION
as_slugid was using `{}` object to store and lookup resolved slugids for tasks, which allowed referencing builtins like valueOf, toString, etc
