### PR TITLE
Bug 2065461 - Stop rendering emails through juice's resource inliner

### DIFF
--- a/changelog/bug-2065461.md
+++ b/changelog/bug-2065461.md
@@ -1,0 +1,7 @@
+audience: users
+level: patch
+reference: bug 2065461
+---
+Prevent the notify service from fetching files and remote URLs referenced in
+the content of the emails it sends. This also stops the plain text part of
+those emails from being mangled by the HTML processing.

--- a/package.json
+++ b/package.json
@@ -92,6 +92,7 @@
     "json-e": "^4.8.4",
     "json-parameterization": "^2.0.1",
     "jsonwebtoken": "^9.0.3",
+    "juice": "^11.1.1",
     "jwks-rsa": "^2.1.5",
     "lodash": "4.18.1",
     "loglevel": "^1.9.2",

--- a/services/notify/src/notifier.js
+++ b/services/notify/src/notifier.js
@@ -6,10 +6,26 @@ import crypto from 'node:crypto';
 import sanitizeHtml from 'sanitize-html';
 import { marked } from 'marked';
 import Email from 'email-templates';
+import juice from 'juice';
 import nodemailer from 'nodemailer';
 import { SendEmailCommand } from '@aws-sdk/client-sesv2';
 
 const __dirname = new URL('.', import.meta.url).pathname;
+
+class CssOnlyJuicedEmail extends Email {
+  async checkAndRender(type, template, locals) {
+    const rendered = await super.checkAndRender(type, template, locals);
+    if (type !== 'html' || !rendered) {
+      return rendered;
+    }
+
+    return juice(rendered, {
+      applyStyleTags: true,
+      removeStyleTags: true,
+      preserveImportant: true,
+    });
+  }
+}
 
 /**
  * Object to send notifications, so the logic can be re-used in both the pulse
@@ -30,20 +46,12 @@ class Notifier {
     const transport = nodemailer.createTransport({
       SES: { sesClient: options.ses, SendEmailCommand },
     });
-    this.emailer = new Email({
+    this.emailer = new CssOnlyJuicedEmail({
       transport,
       send: true,
       preview: false,
       views: { root: path.join(__dirname, 'templates') },
-      juice: true,
-      juiceResources: {
-        applyStyleTags: true,
-        removeStyleTags: true,
-        preserveImportant: true,
-        webResources: {
-          relativeTo: path.join(__dirname, 'templates'),
-        },
-      },
+      juice: false,
     });
   }
 

--- a/services/notify/src/templates/css/common.css
+++ b/services/notify/src/templates/css/common.css
@@ -1,4 +1,4 @@
-// Grabbed from github.com/leemunroe/responsive-html-email-template
+/* Grabbed from github.com/leemunroe/responsive-html-email-template */
 
 /* -------------------------------------
     GLOBAL RESETS

--- a/services/notify/src/templates/fullscreen/html.pug
+++ b/services/notify/src/templates/fullscreen/html.pug
@@ -1,8 +1,10 @@
 doctype html
 html(lang="en")
   head
-    link(rel="stylesheet", href="/css/common.css", data-inline)
-    link(rel="stylesheet", href="/css/fullscreen.css", data-inline)
+    style
+      include ../css/common.css
+    style
+      include ../css/fullscreen.css
     meta(name="viewport", content="width=device-width")
     meta(http-equiv="Content-Type", content="text/html; charset=UTF-8")
     style.

--- a/services/notify/src/templates/simple/html.pug
+++ b/services/notify/src/templates/simple/html.pug
@@ -1,7 +1,8 @@
 doctype html
 html(lang="en")
   head
-    link(rel="stylesheet", href="/css/common.css", data-inline)
+    style
+      include ../css/common.css
     meta(name="viewport", content="width=device-width")
     meta(http-equiv="Content-Type", content="text/html; charset=UTF-8")
     style.

--- a/services/notify/test/notifier_test.js
+++ b/services/notify/test/notifier_test.js
@@ -1,4 +1,8 @@
 import assert from 'node:assert';
+import fs from 'node:fs';
+import http from 'node:http';
+import os from 'node:os';
+import path from 'node:path';
 import helper from './helper.js';
 import testing from '@taskcluster/lib-testing';
 
@@ -72,6 +76,62 @@ helper.secrets.mockSuite(testing.suiteName(), ['aws'], (mock, skipping) => {
         /<body style="[^"]*background-color: #f6f6f6/,
         `${template}: stylesheet rules were not inlined into style attributes`
       );
+    }
+  });
+
+  test('email does not inline resources', async () => {
+    const notifier = await helper.load('notifier');
+
+    const templates = new URL('../src/templates', import.meta.url).pathname;
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'notify'));
+    const resource = 'SHOULDNNOTINLINE';
+
+    // an inlined <img> would be base64 encoded
+    const resourceB64 = Buffer.from(resource).toString('base64');
+    fs.writeFileSync(path.join(tmpDir, 'foo'), resource);
+
+    const requested = [];
+    const server = http.createServer((req, res) => {
+      requested.push(req.url);
+      res.end(resource);
+    });
+    await new Promise(resolve => server.listen(0, '127.0.0.1', resolve));
+
+    try {
+      const local = path.relative(templates, path.join(tmpDir, 'foo'));
+      const remote = `http://127.0.0.1:${server.address().port}/foo`;
+      const elements = [
+        `<script src="${local}"></script>`,
+        `<link rel="stylesheet" href="${local}">`,
+        `<img src="${local}" data-inline>`,
+        `<script src="${remote}"></script>`,
+        `<img src="${remote}" data-inline>`,
+      ];
+
+      for (const [i, element] of elements.entries()) {
+        for (const template of ['simple', 'fullscreen']) {
+          const res = await notifier.email({
+            address: `test+inline${i}-${template}@taskcluster.net`,
+            subject: 'Test',
+            content: element,
+            link: { href: 'https://taskcluster.net', text: 'Click me' },
+            replyTo: 'test@taskcluster.net',
+            template,
+          });
+
+          const { html, text } = res.originalMessage;
+          for (const part of [html, text]) {
+            for (const needle of [resource, resourceB64]) {
+              assert.ok(!part.includes(needle), `${template}: ${element} pulled the resource into the message`);
+            }
+          }
+        }
+      }
+
+      assert.deepEqual(requested, [], 'a resource named in content was fetched');
+    } finally {
+      server.close();
+      fs.rmSync(tmpDir, { recursive: true, force: true });
     }
   });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -8323,7 +8323,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"juice@npm:^11.0.3":
+"juice@npm:^11.0.3, juice@npm:^11.1.1":
   version: 11.1.1
   resolution: "juice@npm:11.1.1"
   dependencies:
@@ -11679,6 +11679,7 @@ __metadata:
     json-parameterization: "npm:^2.0.1"
     json-stable-stringify: "npm:^1.3.0"
     jsonwebtoken: "npm:^9.0.3"
+    juice: "npm:^11.1.1"
     jwks-rsa: "npm:^2.1.5"
     lodash: "npm:4.18.1"
     loglevel: "npm:^1.9.2"


### PR DESCRIPTION
The notify service was rendering emails through juice which would happily fetch resources to inline them before sending the email.

The problem lies in the fact that we embed the original content as `!{content}` in the text part of email, which makes sense, we don't want to escape that, the email marks it as plain text. However, `email-templates` calls `juice.juiceResources` on every single part of the email, including that one, which ends up inlining things in the text content, and mangling the markdown formatted part of the message as well (`<https://example.com/a/b>` is perfectly valid text in markdown and would get mangled as `<https: example.com a b>` by juice. `cmd 2>&1 <input.txt` would lose the `<input.txt` part entirely, which is even worse).

Juice is only used because we need to inline CSS in the email. In 640f39c68d8fca128666b5783f3a4740efbc98bc, I mentioned being scared of removing that inlining because the email ecosystem is a clusterfuck. Turns out I was right. I tried removing juice and then beat gmail into rendering a local email (seriously, why is this so hard...) and lo and behold, it ate the `<style>` block despite mangling class names in the message which suggests that they process it... So removing juice entirely is out of the question.

So instead I switched how the rendering works to call `juice` ourselves, on the html part of the email only since that's the part that requires the CSS inlining. And I disabled `juice` through `email-templates` since there's no way to control what that does.

I have **thoughts** about the naming of that method and the option in `email-templates` that I won't be putting in there but note that I'm talking about `juice` and not `juice.juiceResources`, and that is a very important difference. `juice` only parses the content through `cheerio` and reserializes it, inlining CSS. It cannot embed any resource. `juice.juiceResources` on the other hand, while having a name that is more specific and very inconspicuous, will do that and happily fetch files and network resources in any kind of text.

The rest of the changes are that we have to include the style early through pug now instead of letting juice do it later on and that the CSS was actually invalid which ate the first rule. (`//` isn't a valid CSS comment)