### PR TITLE
Bug 2062170 - Pass proxy credentials from the worker through environment variables

### DIFF
--- a/changelog/bug-2062170.md
+++ b/changelog/bug-2062170.md
@@ -1,0 +1,5 @@
+audience: worker-deployers
+level: patch
+reference: bug 2062170
+---
+Pass taskcluster proxy credentials through environment variables instead of named parameters

--- a/workers/generic-worker/tcproxy/tcproxy.go
+++ b/workers/generic-worker/tcproxy/tcproxy.go
@@ -43,12 +43,7 @@ func New(taskclusterProxyExecutable string, ipAddress string, httpPort uint16, r
 	args := []string{
 		"--port", strconv.Itoa(int(httpPort)),
 		"--root-url", rootURL,
-		"--client-id", creds.ClientID,
-		"--access-token", creds.AccessToken,
 		"--ip-address", ipAddress,
-	}
-	if creds.Certificate != "" {
-		args = append(args, "--certificate", creds.Certificate)
 	}
 	if allowedUser != "" {
 		args = append(args, "--allowed-user", allowedUser)
@@ -61,6 +56,11 @@ func New(taskclusterProxyExecutable string, ipAddress string, httpPort uint16, r
 		command:  exec.Command(taskclusterProxyExecutable, args...),
 		HTTPPort: httpPort,
 	}
+	l.command.Env = append(os.Environ(),
+		"TASKCLUSTER_CLIENT_ID="+creds.ClientID,
+		"TASKCLUSTER_ACCESS_TOKEN="+creds.AccessToken,
+		"TASKCLUSTER_CERTIFICATE="+creds.Certificate,
+	)
 	l.command.Stdout = os.Stdout
 	l.command.Stderr = os.Stderr
 	err := l.command.Start()


### PR DESCRIPTION
Since `capacity > 1`, multiple tasks could be running at the same time. On default configurations, at least on linux, a process can read the cmdline from other processes on the system so 2 tasks running concurrently could read eachothers credentials which would allow a bad actor to act as the other task.

The proxy already allows passing credentials through environment variables and that is inaccessible from other users on any given process.