### PR TITLE
Bug 2064002 - Add a template allowlist to the notify service

### DIFF
--- a/changelog/bug-2064002.md
+++ b/changelog/bug-2064002.md
@@ -1,0 +1,5 @@
+audience: users
+level: patch
+reference: bug 2064002
+---
+Notifications through task routes now validate the name of the template used just like the rest API

--- a/services/notify/src/notifier.js
+++ b/services/notify/src/notifier.js
@@ -27,6 +27,8 @@ class CssOnlyJuicedEmail extends Email {
   }
 }
 
+const TEMPLATES_ALLOWLIST = new Set(['simple', 'fullscreen']);
+
 /**
  * Object to send notifications, so the logic can be re-used in both the pulse
  * listener and the API implementation.
@@ -69,6 +71,11 @@ class Notifier {
   }
 
   async email({ address, subject, content, link, replyTo, template }) {
+    template = template || 'simple';
+    if (!TEMPLATES_ALLOWLIST.has(template)) {
+      throw new Error(`Unknown email template: ${template}`);
+    }
+
     if (this.isDuplicate(address, subject, content, link, replyTo)) {
       debug('Duplicate email send detected. Not attempting resend.');
       return false;
@@ -102,7 +109,7 @@ class Notifier {
         from: this.sender,
         to: address,
       },
-      template: template || 'simple',
+      template,
       locals: { address, subject, content, formatted, link, rateLimit },
     });
     this.rateLimit.markEvent(address);


### PR DESCRIPTION
Right now a task could ask to render .pug files anywhere on the system instead of being confined to the templates folder. This is pretty much harmless since those don't exist anywhere and would require arbitrary write access. However, LLMs love to overblow this as a "omahgad, RCE" (except as 20 paragraphs of unreadable garbage) and it's a valid bug and an inconsistency with the REST API which does only allow `simple` / `fullscreen` in that field.