### PR TITLE
fix(generic-worker): don't leak disk space when a cache deletion fails

### DIFF
--- a/changelog/issue-8944.md
+++ b/changelog/issue-8944.md
@@ -1,0 +1,5 @@
+audience: worker-deployers
+level: patch
+reference: issue 8944
+---
+Generic Worker no longer leaks disk space when cache files remain on disk without a cache table entry. Garbage collection and worker startup now delete anything in the caches directory that the worker does not know about, so a failed deletion (or a leftover from a crash) is retried instead of occupying space forever.

--- a/workers/generic-worker/cache_test.go
+++ b/workers/generic-worker/cache_test.go
@@ -585,3 +585,179 @@ func TestTrimPoolExcess(t *testing.T) {
 		t.Errorf("Expected 1 in-use entry, got %d", inUseCount)
 	}
 }
+
+func TestSweepUnknownContentDeletesOrphansAndKeepsKnown(t *testing.T) {
+	cachesDir := t.TempDir()
+	known := filepath.Join(cachesDir, "known")
+	orphan := filepath.Join(cachesDir, "orphan")
+	for _, dir := range []string{known, orphan} {
+		if err := os.Mkdir(dir, 0700); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	cm := CacheMap{
+		"foo": {{Key: "foo", Location: known}},
+	}
+	sweepUnknownContent(cachesDir, cm)
+
+	if _, err := os.Stat(known); err != nil {
+		t.Errorf("Expected known cache %v to be kept: %v", known, err)
+	}
+	if _, err := os.Stat(orphan); !os.IsNotExist(err) {
+		t.Errorf("Expected orphan %v to be deleted, stat gave: %v", orphan, err)
+	}
+}
+
+func TestSweepUnknownContentRetriesFailedDeletion(t *testing.T) {
+	if os.Geteuid() <= 0 {
+		t.Skip("requires a non-root POSIX user, since os.RemoveAll ignores directory permissions otherwise")
+	}
+	cachesDir := t.TempDir()
+	orphan := filepath.Join(cachesDir, "orphan")
+	if err := os.Mkdir(orphan, 0700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(cachesDir, 0500); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(cachesDir, 0700) })
+
+	sweepUnknownContent(cachesDir, CacheMap{})
+	if _, err := os.Stat(orphan); err != nil {
+		t.Fatalf("Expected the orphan to remain while deletion is blocked, stat gave: %v", err)
+	}
+
+	if err := os.Chmod(cachesDir, 0700); err != nil {
+		t.Fatal(err)
+	}
+	sweepUnknownContent(cachesDir, CacheMap{})
+	if _, err := os.Stat(orphan); !os.IsNotExist(err) {
+		t.Errorf("Expected the orphan to be deleted once the parent was writable, stat gave: %v", err)
+	}
+}
+
+func TestFailedCacheEvictionIsReclaimedBySweep(t *testing.T) {
+	if os.Geteuid() <= 0 {
+		t.Skip("requires a non-root POSIX user, since os.RemoveAll ignores directory permissions otherwise")
+	}
+	cachesDir := t.TempDir()
+	location := filepath.Join(cachesDir, "cache")
+	if err := os.Mkdir(location, 0700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(cachesDir, 0500); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(cachesDir, 0700) })
+
+	cm := CacheMap{}
+	entry := &Cache{Key: "foo", Location: location, Owner: cm}
+	cm["foo"] = []*Cache{entry}
+
+	if err := entry.Evict(nil); err == nil {
+		t.Fatal("Expected eviction to fail")
+	}
+	if len(cm["foo"]) != 0 {
+		t.Error("Expected the entry to leave the cache table regardless, as callers rely on")
+	}
+	if _, err := os.Stat(location); err != nil {
+		t.Fatalf("Expected files to remain after the failed deletion, stat gave: %v", err)
+	}
+
+	if err := os.Chmod(cachesDir, 0700); err != nil {
+		t.Fatal(err)
+	}
+	sweepUnknownContent(cachesDir, cm)
+	if _, err := os.Stat(location); !os.IsNotExist(err) {
+		t.Errorf("Expected the leftover to be deleted by the sweep, stat gave: %v", err)
+	}
+}
+
+func TestGarbageCollectionSweepsCachesDir(t *testing.T) {
+	origConfig := config
+	origDirectoryCaches := directoryCaches
+	origFileCaches := fileCaches
+	t.Cleanup(func() {
+		config = origConfig
+		directoryCaches = origDirectoryCaches
+		fileCaches = origFileCaches
+	})
+
+	cachesDir := t.TempDir()
+	known := filepath.Join(cachesDir, "known")
+	orphan := filepath.Join(cachesDir, "orphan")
+	for _, dir := range []string{known, orphan} {
+		if err := os.Mkdir(dir, 0700); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	config = &gwconfig.Config{
+		CachesDir:                  cachesDir,
+		Capacity:                   1,
+		TasksDir:                   t.TempDir(),
+		RequiredDiskSpaceMegabytes: 1,
+	}
+	directoryCaches = CacheMap{
+		"foo": {{Key: "foo", Location: known}},
+	}
+	fileCaches = FileCacheMap{}
+
+	if err := garbageCollection(false); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(known); err != nil {
+		t.Errorf("Expected known cache %v to be kept: %v", known, err)
+	}
+	if _, err := os.Stat(orphan); !os.IsNotExist(err) {
+		t.Errorf("Expected garbage collection to delete orphan %v, stat gave: %v", orphan, err)
+	}
+}
+
+func TestMountsInitialiseSweepsOrphanedCaches(t *testing.T) {
+	origConfig := config
+	origDirectoryCaches := directoryCaches
+	origFileCaches := fileCaches
+	t.Cleanup(func() {
+		config = origConfig
+		directoryCaches = origDirectoryCaches
+		fileCaches = origFileCaches
+	})
+
+	root := t.TempDir()
+	t.Chdir(root)
+	cachesDir := filepath.Join(root, "caches")
+	known := filepath.Join(cachesDir, "known")
+	orphan := filepath.Join(cachesDir, "orphan")
+	for _, dir := range []string{known, orphan} {
+		if err := os.MkdirAll(dir, 0700); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	config = &gwconfig.Config{
+		CachesDir:    cachesDir,
+		DownloadsDir: filepath.Join(root, "downloads"),
+	}
+	directoryCaches = nil
+	fileCaches = nil
+
+	state := fmt.Sprintf(`{"foo":[{"key":"foo","location":%q,"created":"2026-01-01T00:00:00Z"}]}`, known)
+	if err := os.WriteFile("directory-caches.json", []byte(state), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile("file-caches.json", []byte("{}"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := (&MountsFeature{}).Initialise(); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(known); err != nil {
+		t.Errorf("Expected known cache %v to be kept: %v", known, err)
+	}
+	if _, err := os.Stat(orphan); !os.IsNotExist(err) {
+		t.Errorf("Expected Initialise to delete orphan %v, stat gave: %v", orphan, err)
+	}
+}

--- a/workers/generic-worker/mounts_feature.go
+++ b/workers/generic-worker/mounts_feature.go
@@ -414,8 +414,8 @@ func (cm *CacheMap) LoadFromFile(stateFile string, cacheDir string) {
 func (feature *MountsFeature) Initialise() error {
 	cacheMutex.Lock()
 	defer cacheMutex.Unlock()
-	fileCaches.LoadFromFile("file-caches.json", config.CachesDir)
-	directoryCaches.LoadFromFile("directory-caches.json", config.DownloadsDir)
+	fileCaches.LoadFromFile("file-caches.json", config.DownloadsDir)
+	directoryCaches.LoadFromFile("directory-caches.json", config.CachesDir)
 	sweepUnknownContent(config.CachesDir, directoryCaches)
 	return nil
 }

--- a/workers/generic-worker/mounts_feature.go
+++ b/workers/generic-worker/mounts_feature.go
@@ -257,6 +257,30 @@ func (cache *Cache) Rating() float64 {
 	return float64(cache.LastUsed.Unix())
 }
 
+// sweepUnknownContent deletes anything in dir that is not a cache Location.
+// Failed deletions are retried on the next call (see #8944).
+func sweepUnknownContent(dir string, caches CacheMap) {
+	keep := map[string]bool{}
+	for _, entries := range caches {
+		for _, cache := range entries {
+			keep[filepath.Base(cache.Location)] = true
+		}
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return
+	}
+	for _, entry := range entries {
+		if keep[entry.Name()] {
+			continue
+		}
+		path := filepath.Join(dir, entry.Name())
+		if err := os.RemoveAll(path); err != nil {
+			log.Printf("WARNING: could not delete unknown cache content %v: %v", path, err)
+		}
+	}
+}
+
 // Purge unlinks the entry so it can never be served again and deletes its
 // content, deferring the deletion to the last releaseFileCache if tasks are
 // still using it. Unlike Evict, it is for content known to be wrong.
@@ -392,6 +416,7 @@ func (feature *MountsFeature) Initialise() error {
 	defer cacheMutex.Unlock()
 	fileCaches.LoadFromFile("file-caches.json", config.CachesDir)
 	directoryCaches.LoadFromFile("directory-caches.json", config.DownloadsDir)
+	sweepUnknownContent(config.CachesDir, directoryCaches)
 	return nil
 }
 
@@ -605,6 +630,7 @@ func garbageCollection(tasksRunning bool) error {
 	// running potentially slow docker commands (#7).
 	// SortedResources only returns available (not in-use) entries
 	cacheMutex.Lock()
+	sweepUnknownContent(config.CachesDir, directoryCaches)
 	fileResources := fileCaches.SortedResources()
 	cacheMutex.Unlock()
 


### PR DESCRIPTION
Fixes #8944.

>Generic Worker no longer leaks disk space when cache files remain on disk without a cache table entry. Garbage collection and worker startup now delete anything in the caches directory that the worker does not know about, so a failed deletion (or a leftover from a crash) is retried instead of occupying space forever.