### PR TITLE
feat(ci): Switch taskcluster.yml to public_restricted

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -3,43 +3,44 @@ version: 1
 reporting: checks-v1
 policy:
   pullRequests: public_restricted
+  allowComments: collaborators
 autoCancelPreviousChecks: true
 tasks:
   - $let:
       trustDomain: taskcluster
       # We set some of these directly in tc because we don't have some mozilla-specific concepts
       ownerEmail: taskcluster-internal@mozilla.com
-      # Keep writable caches from untrusted code out of the trusted level-1
-      # namespace. The Community-TC role enforces the corresponding scopes.
+      # Match Firefox CI trust levels: external pull requests use level 1,
+      # while trusted code and collaborator-approved runs use level 3.
       level:
         $if: 'tasks_for == "github-pull-request-untrusted"'
-        then: 0
-        else: 1
+        then: 1
+        else: 3
 
       # Github events have this stuff in different places...
       baseRepoUrl:
         $switch:
-          'tasks_for[:19] == "github-pull-request"': '${event.pull_request.base.repo.html_url}'
+          'tasks_for[:19] == "github-pull-request" || tasks_for == "github-issue-comment"': '${event.pull_request.base.repo.html_url}'
           $default: '${event.repository.html_url}'
       repoUrl:
         $switch:
-          'tasks_for[:19] == "github-pull-request"': '${event.pull_request.head.repo.html_url}'
+          'tasks_for[:19] == "github-pull-request" || tasks_for == "github-issue-comment"': '${event.pull_request.head.repo.html_url}'
           'tasks_for in ["cron", "action", "pr-action"]': '${repository.url}'
           $default: '${event.repository.html_url}'
       project:
         $switch:
           'tasks_for in ["github-push", "github-release"]': '${event.repository.name}'
-          'tasks_for[:19] == "github-pull-request"': '${event.pull_request.base.repo.name}'
+          'tasks_for[:19] == "github-pull-request" || tasks_for == "github-issue-comment"': '${event.pull_request.base.repo.name}'
           'tasks_for in ["cron", "action", "pr-action"]': '${repository.project}'
       head_branch:
         $switch:
-          'tasks_for[:19] == "github-pull-request"': ${event.pull_request.head.ref}
+          'tasks_for[:19] == "github-pull-request" || tasks_for == "github-issue-comment"': ${event.pull_request.head.ref}
           'tasks_for == "github-push"': ${event.ref}
           'tasks_for == "github-release"': '${event.release.target_commitish}'
           'tasks_for in ["cron", "action", "pr-action"]': '${push.branch}'
       base_ref:
         $switch:
-          'tasks_for[:19] == "github-pull-request"': ${event.pull_request.base.ref}
+          'tasks_for[:19] == "github-pull-request" || tasks_for == "github-issue-comment"': ${event.pull_request.base.ref}
           # event.base_ref is barely documented[1]. Testing showed it's only
           # defined when creating a new branch. It's null when pushing to an
           # existing branch
@@ -52,7 +53,7 @@ tasks:
           'tasks_for == "pr-action"': '${push.base_branch}'
       head_ref:
         $switch:
-          'tasks_for[:19] == "github-pull-request"': ${event.pull_request.head.ref}
+          'tasks_for[:19] == "github-pull-request" || tasks_for == "github-issue-comment"': ${event.pull_request.head.ref}
           'tasks_for == "github-push"': ${event.ref}
           'tasks_for in ["cron", "action", "pr-action"]': '${push.branch}'
           'tasks_for == "github-release"': ${event.release.tag_name}
@@ -60,12 +61,12 @@ tasks:
         $switch:
           'tasks_for == "github-push"': '${event.before}'
           'tasks_for == "github-release"': '${event.release.target_commitish}'
-          'tasks_for[:19] == "github-pull-request"': '${event.pull_request.base.sha}'
+          'tasks_for[:19] == "github-pull-request" || tasks_for == "github-issue-comment"': '${event.pull_request.base.sha}'
           'tasks_for in ["cron", "action", "pr-action"]': '${push.revision}'
       head_sha:
         $switch:
           'tasks_for == "github-push"': '${event.after}'
-          'tasks_for[:19] == "github-pull-request"': '${event.pull_request.head.sha}'
+          'tasks_for[:19] == "github-pull-request" || tasks_for == "github-issue-comment"': '${event.pull_request.head.sha}'
           'tasks_for in ["cron", "action", "pr-action"]': '${push.revision}'
           'tasks_for == "github-release"': '${event.release.tag_name}'
       head_tag:
@@ -78,11 +79,14 @@ tasks:
           'tasks_for[:19] == "github-pull-request"': ${event.action}
           $default: 'UNDEFINED'
       isPullRequest:
-        $eval: 'tasks_for[:19] == "github-pull-request"'
+        $eval: 'tasks_for[:19] == "github-pull-request" || tasks_for == "github-issue-comment"'
+      isIssueComment:
+        $eval: 'tasks_for == "github-issue-comment"'
 
     in:
       $if: >
         (isPullRequest && pullRequestAction in ["opened", "reopened", "synchronize"])
+        || (isIssueComment && event.taskcluster_comment == "run")
         || (tasks_for == "github-push" && project == "taskcluster" && event["ref"] == "refs/heads/main")
         || (tasks_for == "github-push" && project == "taskcluster" && event["ref"][:11] == "refs/tags/v")
         || (tasks_for == "github-push" && project == "staging-releases" && event["ref"][:27] == "refs/heads/staging-release/")
@@ -115,14 +119,17 @@ tasks:
             in:
               - "assume:repo:${repoUrl[8:]}:branch:${short_head_branch}"
           else:
-            $if: "isPullRequest"
+            $if: 'tasks_for == "github-pull-request-untrusted"'
             then:
-              # `github-` is 7 characters, leaving the repository role suffix.
-              - "assume:repo:github.com/${event.pull_request.base.repo.full_name}:${tasks_for[7:]}"
+              - "assume:repo:github.com/${event.pull_request.base.repo.full_name}:pull-request-untrusted"
             else:
-              $if: 'tasks_for == "github-push" && event["ref"][:11] == "refs/tags/v"'
+              $if: "isPullRequest"
               then:
-                - "assume:repo:${repoUrl[8:]}:tag:${head_branch[10:]}"
+                - "assume:repo:github.com/${event.pull_request.base.repo.full_name}:pull-request"
+              else:
+                $if: 'tasks_for == "github-push" && event["ref"][:11] == "refs/tags/v"'
+                then:
+                  - "assume:repo:${repoUrl[8:]}:tag:${head_branch[10:]}"
 
         requires: all-completed
         priority: highest

--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -2,14 +2,19 @@
 version: 1
 reporting: checks-v1
 policy:
-  pullRequests: public
+  pullRequests: public_restricted
 autoCancelPreviousChecks: true
 tasks:
   - $let:
       trustDomain: taskcluster
       # We set some of these directly in tc because we don't have some mozilla-specific concepts
       ownerEmail: taskcluster-internal@mozilla.com
-      level: 1
+      # Keep writable caches from untrusted code out of the trusted level-1
+      # namespace. The Community-TC role enforces the corresponding scopes.
+      level:
+        $if: 'tasks_for == "github-pull-request-untrusted"'
+        then: 0
+        else: 1
 
       # Github events have this stuff in different places...
       baseRepoUrl:
@@ -87,7 +92,10 @@ tasks:
         taskGroupId: "${ownTaskId}" # same as taskId; this is how automation identifies a decision task
         created: { $fromNow: "" }
         deadline: { $fromNow: "1 day" }
-        expires: { $fromNow: "1 year 1 second" } # 1 second so artifacts expire first, despite rounding errors
+        expires:
+          $if: 'tasks_for == "github-pull-request-untrusted"'
+          then: { $fromNow: "28 days 1 second" }
+          else: { $fromNow: "1 year 1 second" } # 1 second so artifacts expire first, despite rounding errors
         metadata:
           owner: "${ownerEmail}"
           source: "${repoUrl}/raw/${head_sha}/.taskcluster.yml"
@@ -109,7 +117,8 @@ tasks:
           else:
             $if: "isPullRequest"
             then:
-              - "assume:repo:github.com/${event.pull_request.base.repo.full_name}:pull-request"
+              # `github-` is 7 characters, leaving the repository role suffix.
+              - "assume:repo:github.com/${event.pull_request.base.repo.full_name}:${tasks_for[7:]}"
             else:
               $if: 'tasks_for == "github-push" && event["ref"][:11] == "refs/tags/v"'
               then:
@@ -135,7 +144,6 @@ tasks:
               - $if: "isPullRequest"
                 then:
                   TASKCLUSTER_PULL_REQUEST_URL: "${event.pull_request.url}"
-
           cache:
             "${trustDomain}-level-${level}-checkouts-sparse-v2": /builds/worker/checkouts
 
@@ -180,7 +188,10 @@ tasks:
             "public":
               type: "directory"
               path: "/builds/worker/artifacts"
-              expires: { $fromNow: "1 year" }
+              expires:
+                $if: 'tasks_for == "github-pull-request-untrusted"'
+                then: { $fromNow: "28 days" }
+                else: { $fromNow: "1 year" }
             "public/docker-contexts":
               type: "directory"
               path: "/builds/worker/checkouts/src/docker-contexts"

--- a/changelog/bug-2066797.md
+++ b/changelog/bug-2066797.md
@@ -2,4 +2,4 @@ audience: developers
 level: patch
 reference: bug 2066797
 ---
-Changes default policy to `public_restricted` and isolates the trusted and untrusted task graphs: untrusted pull requests run at level 0 with their own caches, without secrets, and rebuild docker images every run instead of sharing an image index.
+Changes the pull-request policy to `public_restricted` and isolates trusted and untrusted task graphs. External pull requests run at level 1 with separate caches, without secrets or generic-worker CI, and rebuild Docker images instead of sharing an image index. Collaborators can trigger the full level-3 graph with `/taskcluster run`.

--- a/changelog/bug-2066797.md
+++ b/changelog/bug-2066797.md
@@ -1,0 +1,5 @@
+audience: developers
+level: patch
+reference: bug 2066797
+---
+Changes default policy to `public_restricted` and isolates the trusted and untrusted task graphs: untrusted pull requests run at level 0 with their own caches, without secrets, and rebuild docker images every run instead of sharing an image index.

--- a/clients/client-rust/integration_tests/tests/against_real_deployment.rs
+++ b/clients/client-rust/integration_tests/tests/against_real_deployment.rs
@@ -6,11 +6,12 @@ use std::time::Duration;
 use taskcluster::{err_status_code, Auth, ClientBuilder, Credentials};
 use tokio;
 
-/// Return the TASKCLUSTER_ROOT_URL, or None if the test should be skipped,
-/// or panic if the NO_TEST_SKIP is set and the env var is not.
+/// Return the TASKCLUSTER_ROOT_URL, or None if a credential-free untrusted test
+/// should be skipped, or panic if NO_TEST_SKIP is set and the env var is not.
 fn get_root_url() -> Option<String> {
     match env::var("TASKCLUSTER_ROOT_URL") {
         Ok(v) => Some(v),
+        Err(_) if env::var("TASKCLUSTER_UNTRUSTED_PR").as_deref() == Ok("true") => None,
         Err(_) => match env::var("NO_TEST_SKIP") {
             Ok(_) => panic!("NO_TEST_SKIP is set but TASKCLUSTER_ROOT_URL is not!"),
             Err(_) => None,

--- a/clients/client-rust/integration_tests/tests/upload_download.rs
+++ b/clients/client-rust/integration_tests/tests/upload_download.rs
@@ -11,10 +11,11 @@ use tokio::io::{AsyncReadExt, AsyncSeekExt, AsyncWriteExt};
 use taskcluster_download::{download_to_buf, download_to_file, download_to_vec};
 use taskcluster_upload::{upload_from_buf, upload_from_file};
 
-/// Return a client built with TC credentials from the environment, or panic if the NO_TEST_SKIP is
-/// set and the env vars are not set.  The client is configured with authorized_scopes containing
-/// the scopes required for these tests.  If creating a new client for these tests, consult the
-/// scopes in the function body.
+/// Return a client built with TC credentials from the environment, skip a
+/// credential-free untrusted test, or panic if NO_TEST_SKIP is set and the env
+/// vars are not set. The client is configured with authorized_scopes containing
+/// the scopes required for these tests. If creating a new client for these
+/// tests, consult the scopes in the function body.
 fn get_client() -> Option<ClientBuilder> {
     let (creds, root_url) = if let (Ok(v), Ok(_), Ok(_)) = (
         env::var("TASKCLUSTER_ROOT_URL"),
@@ -26,6 +27,9 @@ fn get_client() -> Option<ClientBuilder> {
             v,
         )
     } else {
+        if env::var("TASKCLUSTER_UNTRUSTED_PR").as_deref() == Ok("true") {
+            return None;
+        }
         match env::var("NO_TEST_SKIP") {
             Ok(_) => panic!(
                 "{}",

--- a/clients/client-web/test/helper.js
+++ b/clients/client-web/test/helper.js
@@ -3,7 +3,7 @@ import { describe } from 'vitest';
 const rootUrl = import.meta.env.TASKCLUSTER_ROOT_URL;
 
 if (!rootUrl) {
-  if (import.meta.env.NO_TEST_SKIP) {
+  if (import.meta.env.NO_TEST_SKIP && import.meta.env.TASKCLUSTER_UNTRUSTED_PR !== 'true') {
     throw new Error('TASKCLUSTER_ROOT_URL not set but NO_TEST_SKIP is set');
   }
 

--- a/clients/client-web/vitest.config.js
+++ b/clients/client-web/vitest.config.js
@@ -3,7 +3,7 @@ import { playwright } from '@vitest/browser-playwright';
 import { nodePolyfills } from 'vite-plugin-node-polyfills';
 
 export default defineConfig({
-  envPrefix: ['TASKCLUSTER_ROOT_URL', 'NO_TEST_SKIP'],
+  envPrefix: ['TASKCLUSTER_ROOT_URL', 'TASKCLUSTER_UNTRUSTED_PR', 'NO_TEST_SKIP'],
   plugins: [nodePolyfills()],
   test: {
     globals: true,

--- a/clients/client/test/upload_download_test.js
+++ b/clients/client/test/upload_download_test.js
@@ -44,7 +44,7 @@ suite(testing.suiteName(), () => {
           'object:download:taskcluster/test/client/*',
         ],
       });
-    } else if (process.env.NO_TEST_SKIP) {
+    } else if (process.env.NO_TEST_SKIP && process.env.TASKCLUSTER_UNTRUSTED_PR !== 'true') {
       throw new Error('NO_TEST_SKIP is set but credentials are not available');
     } else {
       this.skip();

--- a/internal/testrooturl/testrooturl.go
+++ b/internal/testrooturl/testrooturl.go
@@ -5,14 +5,14 @@ import (
 	"testing"
 )
 
-// Get gets the rootURL, or skips the test if a root URL is not available,
-// *unless* NO_TEST_SKIP is set, in which case this is considered a fatal
-// error.
+// Get gets the rootURL, or skips the test if a root URL is not available.
+// Missing configuration is fatal when NO_TEST_SKIP is set, except on
+// deliberately credential-free untrusted pull requests.
 func Get(t *testing.T) string {
 	t.Helper()
 	rootURL := os.Getenv("TASKCLUSTER_ROOT_URL")
 	if rootURL == "" {
-		if os.Getenv("NO_TEST_SKIP") == "" {
+		if os.Getenv("NO_TEST_SKIP") == "" || os.Getenv("TASKCLUSTER_UNTRUSTED_PR") == "true" {
 			t.Skip("Set TASKCLUSTER_ROOT_URL to run tests")
 		} else {
 			t.Fatal("TASKCLUSTER_ROOT_URL must be set when NO_TEST_SKIP is set")
@@ -29,7 +29,7 @@ func GetWithCreds(t *testing.T) (rootURL string, clientID string, accessToken st
 	accessToken = os.Getenv("TASKCLUSTER_ACCESS_TOKEN")
 	certificate = os.Getenv("TASKCLUSTER_CERTIFICATE")
 	if rootURL == "" || clientID == "" || accessToken == "" {
-		if os.Getenv("NO_TEST_SKIP") == "" {
+		if os.Getenv("NO_TEST_SKIP") == "" || os.Getenv("TASKCLUSTER_UNTRUSTED_PR") == "true" {
 			t.Skip("Set TASKCLUSTER_ROOT_URL, TASKCLUSTER_CLIENT_ID, and TASKCLUSTER_ACCESS_TOKEN to run tests")
 		} else {
 			t.Fatal("TASKCLUSTER_ROOT_URL, TASKCLUSTER_CLIENT_ID, and TASKCLUSTER_ACCESS_TOKEN must be set when NO_TEST_SKIP is set")

--- a/libraries/postgres/test/helper.js
+++ b/libraries/postgres/test/helper.js
@@ -37,7 +37,7 @@ if (testDbUrl) {
 } else {
   helper.dbSuite = (...args) => {
     suite(...args.slice(0, -1), () => {
-      if (process.env.NO_TEST_SKIP) {
+      if (process.env.NO_TEST_SKIP && process.env.TASKCLUSTER_UNTRUSTED_PR !== 'true') {
         throw new Error(`TEST_DB_URL not set and NO_TEST_SKIP is set`);
       }
       test.skip('(TEST_DB_URL is not set)', () => {});

--- a/libraries/testing/src/secrets.js
+++ b/libraries/testing/src/secrets.js
@@ -176,7 +176,7 @@ class Secrets {
         await that.setup();
         const missing = secretList.filter(name => !that.have(name));
         if (missing.length) {
-          if (process.env.NO_TEST_SKIP) {
+          if (process.env.NO_TEST_SKIP && process.env.TASKCLUSTER_UNTRUSTED_PR !== 'true') {
             throw new Error(`secrets missing and NO_TEST_SKIP is set: ${missing.join(' ')}`);
           }
           skipping = true;

--- a/taskcluster/kinds/client/kind.yml
+++ b/taskcluster/kinds/client/kind.yml
@@ -18,6 +18,7 @@ task-defaults:
     chain-of-trust: true
   attributes:
     code-review: true
+    run-without-secrets: true
   scopes:
     - secrets:get:project/taskcluster/testing/client-libraries
 

--- a/taskcluster/kinds/go/kind.yml
+++ b/taskcluster/kinds/go/kind.yml
@@ -49,31 +49,6 @@ task-defaults:
         format: tar.gz
 
 tasks:
-  generic-worker-insecure-untrusted:
-    description: test generic-worker's insecure engine against mock Taskcluster services
-    run-on-tasks-for: [github-pull-request-untrusted]
-    # Same pool and user setup as the trusted build/test-insecure task: the
-    # suite needs the gui pool's devices (e.g. /dev/video* for loopback tests)
-    # and runs generic-worker instances as the current user.
-    worker-type: gw-ubuntu-24-04-gui
-    attributes:
-      run-without-secrets: true
-    worker:
-      max-run-time: 1800
-      run-task-as-current-user: true
-    run:
-      command:
-        - |
-          cd workers/generic-worker
-          go mod tidy
-          git status --short
-          test -z "$(git status --porcelain)"
-          go install -tags insecure -v -ldflags "-X main.revision=${{GITHUB_SHA}}" ./...
-          go install ../../tools/taskcluster-proxy
-          go install ../../tools/livelog
-          go vet -tags insecure ./...
-          GORACE=history_size=7 CGO_ENABLED=1 go test -tags insecure -failfast -timeout 20m -ldflags "-X github.com/taskcluster/taskcluster/v107/workers/generic-worker.revision=${{GITHUB_SHA}}" -race -vet=off ./...
-          ../../../golangci-lint/golangci-lint-$GOLANGCI_LINT_VERSION-*/golangci-lint run --build-tags insecure --timeout=5m
   internal-libraries:
     description: test internal go libraries
     run:

--- a/taskcluster/kinds/go/kind.yml
+++ b/taskcluster/kinds/go/kind.yml
@@ -49,6 +49,31 @@ task-defaults:
         format: tar.gz
 
 tasks:
+  generic-worker-insecure-untrusted:
+    description: test generic-worker's insecure engine against mock Taskcluster services
+    run-on-tasks-for: [github-pull-request-untrusted]
+    # Same pool and user setup as the trusted build/test-insecure task: the
+    # suite needs the gui pool's devices (e.g. /dev/video* for loopback tests)
+    # and runs generic-worker instances as the current user.
+    worker-type: gw-ubuntu-24-04-gui
+    attributes:
+      run-without-secrets: true
+    worker:
+      max-run-time: 1800
+      run-task-as-current-user: true
+    run:
+      command:
+        - |
+          cd workers/generic-worker
+          go mod tidy
+          git status --short
+          test -z "$(git status --porcelain)"
+          go install -tags insecure -v -ldflags "-X main.revision=${{GITHUB_SHA}}" ./...
+          go install ../../tools/taskcluster-proxy
+          go install ../../tools/livelog
+          go vet -tags insecure ./...
+          GORACE=history_size=7 CGO_ENABLED=1 go test -tags insecure -failfast -timeout 20m -ldflags "-X github.com/taskcluster/taskcluster/v107/workers/generic-worker.revision=${{GITHUB_SHA}}" -race -vet=off ./...
+          ../../../golangci-lint/golangci-lint-$GOLANGCI_LINT_VERSION-*/golangci-lint run --build-tags insecure --timeout=5m
   internal-libraries:
     description: test internal go libraries
     run:

--- a/taskcluster/kinds/library/kind.yml
+++ b/taskcluster/kinds/library/kind.yml
@@ -18,6 +18,7 @@ task-defaults:
     - secrets:get:project/taskcluster/testing/taskcluster-*
   attributes:
     code-review: true
+    run-without-secrets: true
   worker:
     docker-image: {in-tree: ci}
     taskcluster-proxy: true

--- a/taskcluster/kinds/meta/kind.yml
+++ b/taskcluster/kinds/meta/kind.yml
@@ -51,9 +51,13 @@ tasks:
       command: >-
         corepack yarn --immutable &> /dev/null &&
         corepack yarn build --dry-run
+  taskgraph-security:
+    description: generate task graphs and validate untrusted graph security invariants
+    run:
+      command: python3 taskcluster/test/check_taskgraph.py
   changelog-pr:
     description: taskcluster changelog checks
-    run-on-tasks-for: [github-pull-request]
+    run-on-tasks-for: [github-pull-request, github-pull-request-untrusted]
     run:
       command: >-
         corepack yarn --immutable &> /dev/null &&

--- a/taskcluster/kinds/meta/kind.yml
+++ b/taskcluster/kinds/meta/kind.yml
@@ -57,7 +57,7 @@ tasks:
       command: python3 taskcluster/test/check_taskgraph.py
   changelog-pr:
     description: taskcluster changelog checks
-    run-on-tasks-for: [github-pull-request, github-pull-request-untrusted]
+    run-on-tasks-for: [github-pull-request, github-pull-request-untrusted, github-issue-comment]
     run:
       command: >-
         corepack yarn --immutable &> /dev/null &&

--- a/taskcluster/kinds/pr-generic-worker/kind.yml
+++ b/taskcluster/kinds/pr-generic-worker/kind.yml
@@ -5,17 +5,10 @@ transforms:
     - taskgraph.transforms.task:transforms
 
 kind-dependencies:
-  - client
-  - db
-  - go
-  - library
-  - lint
-  - meta
-  - service
-  - ui
+  - generic-worker
 
 tasks:
     complete:
-        description: PR Summary Task
-        run-on-tasks-for: [github-pull-request, github-pull-request-untrusted, github-issue-comment]
+        description: Generic Worker PR Summary Task
+        run-on-tasks-for: [github-pull-request, github-issue-comment]
         worker-type: succeed

--- a/taskcluster/kinds/service/kind.yml
+++ b/taskcluster/kinds/service/kind.yml
@@ -17,6 +17,7 @@ task-defaults:
     - secrets:get:project/taskcluster/testing/taskcluster-*
   attributes:
     code-review: true
+    run-without-secrets: true
   worker:
     docker-image: {in-tree: ci}
     taskcluster-proxy: true

--- a/taskcluster/src/constants.py
+++ b/taskcluster/src/constants.py
@@ -1,0 +1,6 @@
+UNTRUSTED_PULL_REQUEST = "github-pull-request-untrusted"
+RUN_WITHOUT_SECRETS = "run-without-secrets"
+
+PR_DOCKER_IMAGE_INDEX = "taskcluster.cache.pr.docker-images."
+
+UNTRUSTED_TASK_EXPIRY = "28 days"

--- a/taskcluster/src/scopes.py
+++ b/taskcluster/src/scopes.py
@@ -1,0 +1,12 @@
+def scope_text(scope):
+    if isinstance(scope, str):
+        return scope
+    if isinstance(scope, dict):
+        task_reference = scope.get("task-reference")
+        if isinstance(task_reference, str):
+            return task_reference
+    return ""
+
+
+def is_secret_scope(scope):
+    return scope_text(scope).startswith("secrets:get:")

--- a/taskcluster/src/target_tasks.py
+++ b/taskcluster/src/target_tasks.py
@@ -24,6 +24,10 @@ def target_tasks_taskcluster_branches(full_task_graph, parameters, graph_config)
         if task.attributes.get("only-on", "all") != only_on:
             return False
 
+        if parameters["tasks_for"] == UNTRUSTED_PULL_REQUEST and task.kind == "generic-worker":
+            logger.info("Skipping generic-worker CI task %s in an untrusted pull request", task.label)
+            return False
+
         has_secret_scope = any(is_secret_scope(scope) for scope in task.task.get("scopes", []))
         if parameters["tasks_for"] == UNTRUSTED_PULL_REQUEST and has_secret_scope:
             logger.info("Skipping secret-dependent task %s in an untrusted pull request", task.label)

--- a/taskcluster/src/target_tasks.py
+++ b/taskcluster/src/target_tasks.py
@@ -1,4 +1,12 @@
+import logging
+
 from taskgraph.target_tasks import register_target_task, standard_filter
+from taskgraph.util.verify import verifications
+
+from .constants import UNTRUSTED_PULL_REQUEST
+from .scopes import is_secret_scope, scope_text
+
+logger = logging.getLogger(__name__)
 
 
 @register_target_task("taskcluster-branches")
@@ -11,6 +19,36 @@ def target_tasks_taskcluster_branches(full_task_graph, parameters, graph_config)
             only_on = "release"
 
     def filter(task):
-        return standard_filter(task, parameters) and task.attributes.get("only-on", "all") == only_on
+        if not standard_filter(task, parameters):
+            return False
+        if task.attributes.get("only-on", "all") != only_on:
+            return False
+
+        has_secret_scope = any(is_secret_scope(scope) for scope in task.task.get("scopes", []))
+        if parameters["tasks_for"] == UNTRUSTED_PULL_REQUEST and has_secret_scope:
+            logger.info("Skipping secret-dependent task %s in an untrusted pull request", task.label)
+            return False
+        return True
 
     return [label for label, t in full_task_graph.tasks.items() if filter(t)]
+
+
+@verifications.add("target_task_graph")
+def verify_untrusted_tasks_need_no_secrets(task, taskgraph, scratch_pad, graph_config, parameters):
+    """The target-task filter drops secret-dependent tasks, but the target
+    graph is the transitive closure of the kept labels, so a kept task can
+    pull a secret-scoped dependency back in. Fail generation with a clear
+    error instead of letting createTask fail with an opaque scope error."""
+    if task is None or parameters["tasks_for"] != UNTRUSTED_PULL_REQUEST:
+        return
+    secret_scopes = [
+        scope_text(scope)
+        for scope in task.task.get("scopes", [])
+        if is_secret_scope(scope)
+    ]
+    if secret_scopes:
+        raise Exception(
+            f"untrusted pull request task {task.label} requires secret scopes "
+            f"{secret_scopes}; drop the dependency on it or mark it {UNTRUSTED_PULL_REQUEST!r}-safe "
+            "with the run-without-secrets attribute"
+        )

--- a/taskcluster/src/transforms/__init__.py
+++ b/taskcluster/src/transforms/__init__.py
@@ -4,6 +4,16 @@ import tomllib
 
 from taskgraph.transforms.base import TransformSequence
 
+from taskgraph.transforms.task import transforms as task_transforms
+
+from ..constants import (
+    PR_DOCKER_IMAGE_INDEX,
+    RUN_WITHOUT_SECRETS,
+    UNTRUSTED_PULL_REQUEST,
+    UNTRUSTED_TASK_EXPIRY,
+)
+from ..scopes import is_secret_scope
+
 transforms = TransformSequence()
 
 
@@ -67,16 +77,65 @@ def add_task_env(config, tasks):
         env["TASK_GROUP_ID"] = os.environ.get("TASK_ID", "")
         env["GITHUB_CLONE_URL"] = config.params["head_repository"]
 
-        # We want to set this everywhere other than lib-testing
-        if task["name"] != "testing":
-            env["NO_TEST_SKIP"] = "true"
-
         # Dependabot PRs can saturate contended worker pools (e.g. macOS) and delay
         # human work, so lower the priority of every task they generate.
         if config.params["head_ref"].startswith("dependabot/"):
             task["priority"] = "low"
 
         yield task
+
+
+def configure_task(config, tasks):
+    """Enforce test dependencies and isolate untrusted tasks."""
+    is_untrusted_pull_request = config.params["tasks_for"] == UNTRUSTED_PULL_REQUEST
+
+    for task in tasks:
+        worker = task.get("worker")
+
+        # Require every non-secret dependency to be present on both trusted and
+        # untrusted tasks. Secret-specific test helpers recognize the flag below.
+        # Workerless tasks, such as built-in/succeed, have no payload
+        # environment and must not acquire one implicitly.
+        if worker is not None and task.get("label") != "library-testing":
+            worker.setdefault("env", {})["NO_TEST_SKIP"] = "true"
+
+        if is_untrusted_pull_request:
+            task["expires-after"] = UNTRUSTED_TASK_EXPIRY
+
+            # The restricted Community-TC role is the security boundary. This
+            # only makes explicitly secret-optional tasks creatable by that role.
+            if task.get("attributes", {}).get(RUN_WITHOUT_SECRETS):
+                task["scopes"] = [
+                    scope for scope in task.get("scopes", [])
+                    if not is_secret_scope(scope)
+                ]
+                # Only secret-stripped tasks may treat NO_TEST_SKIP as
+                # advisory, and only for the tests that need the secrets.
+                if worker is not None:
+                    worker.setdefault("env", {})["TASKCLUSTER_UNTRUSTED_PR"] = "true"
+
+            # PR docker-image indexes are not level-qualified upstream, and a
+            # namespace shared by all untrusted pull requests would let one
+            # fork publish a poisoned image at a digest another fork then
+            # consumes. Rebuild images every run instead of publishing to or
+            # searching any index.
+            task["routes"] = [
+                route for route in task.get("routes", [])
+                if PR_DOCKER_IMAGE_INDEX not in route
+            ]
+            optimization = task.get("optimization")
+            if isinstance(optimization, dict) and "index-search" in optimization:
+                del task["optimization"]
+
+        yield task
+
+
+# Untrusted isolation must hold for every kind, so a kind.yml that forgets to
+# list this transform must not silently escape it. Prepend it to the shared
+# task transform sequence: after each kind's run transforms (which set label
+# and worker) and before the payload is built.
+if configure_task not in task_transforms._transforms:
+    task_transforms._transforms.insert(0, configure_task)
 
 
 @transforms.add

--- a/taskcluster/test/check_taskgraph.py
+++ b/taskcluster/test/check_taskgraph.py
@@ -1,0 +1,200 @@
+#!/usr/bin/env python3
+
+import json
+from pathlib import Path
+import re
+import subprocess
+import sys
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT / "taskcluster"))
+
+from src.scopes import is_secret_scope as production_is_secret_scope  # noqa: E402
+
+
+PARAMETERS_DIR = Path(__file__).with_name("params")
+TRUSTED_PARAMETERS = "main-repo-pull-request.yml"
+UNTRUSTED_PARAMETERS = "main-repo-pull-request-untrusted.yml"
+
+DOCKER_IMAGE_INDEX_MARKER = ".docker-images."
+
+ALLOWED_WORKER_POOLS = {
+    ("built-in", "succeed"),
+    ("proj-taskcluster", "gw-ubuntu-24-04"),
+    ("proj-taskcluster", "gw-ubuntu-24-04-gui"),
+    ("proj-taskcluster", "gw-windows-2022"),
+}
+
+# The generic-worker test suite runs generic-worker instances as the current
+# user; nothing else may add non-cache scopes to the untrusted graph.
+ALLOWED_NON_CACHE_SCOPES = {
+    "generic-worker:run-task-as-current-user:proj-taskcluster/gw-ubuntu-24-04-gui",
+}
+
+
+def taskgraph_version():
+    decision_config = (REPO_ROOT / ".taskcluster.yml").read_text()
+    match = re.search(r"taskgraph:decision-v([^@'\"]+)@", decision_config)
+    if not match:
+        raise RuntimeError("Could not find the Taskgraph version in .taskcluster.yml")
+    return match.group(1)
+
+
+def generate_target_graph(parameters, version):
+    command = [
+        "uvx",
+        "--from",
+        f"taskcluster-taskgraph=={version}",
+        "taskgraph",
+        "target-graph",
+        "--root",
+        "taskcluster",
+        "--parameters",
+        str(parameters),
+        "--json",
+        "--quiet",
+        "--no-optimize",
+    ]
+    result = subprocess.run(
+        command,
+        cwd=REPO_ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return json.loads(result.stdout)
+
+
+def scope_text(scope):
+    """Render scopes independently of the taskgraph transform helper."""
+    if isinstance(scope, str):
+        return scope
+    if isinstance(scope, dict):
+        task_reference = scope.get("task-reference")
+        if isinstance(task_reference, str):
+            return task_reference
+        return json.dumps(scope, sort_keys=True)
+    return str(scope)
+
+
+def check_untrusted_graph(tasks):
+    errors = []
+    labels = set(tasks)
+
+    expected_task = "go-generic-worker-insecure-untrusted"
+    if expected_task not in labels:
+        errors.append(f"credential-free generic-worker coverage is missing: {expected_task}")
+
+    forbidden_tasks = {
+        "generic-worker-build/test-insecure-ubuntu-24.04-amd64",
+        "generic-worker-build/test-multiuser-macos-arm64",
+        "generic-worker-build/test-multiuser-ubuntu-24.04-amd64",
+        "generic-worker-build/test-multiuser-windows-server-2022-amd64",
+    }
+    if present := sorted(labels & forbidden_tasks):
+        errors.append(f"credential-dependent tasks are present: {', '.join(present)}")
+
+    for label, task in tasks.items():
+        definition = task["task"]
+        raw_scopes = definition.get("scopes", [])
+        scopes = [scope_text(scope) for scope in raw_scopes]
+
+        secret_scopes = [scope for scope in scopes if scope.startswith("secrets:get:")]
+        if secret_scopes:
+            errors.append(f"{label} requests secret scopes: {secret_scopes}")
+
+        cache_scopes = [
+            scope
+            for scope in scopes
+            if scope.startswith(("docker-worker:cache:", "generic-worker:cache:"))
+        ]
+        wrong_cache_scopes = [
+            scope
+            for scope in cache_scopes
+            if not scope.startswith(
+                (
+                    "docker-worker:cache:taskcluster-level-0-",
+                    "generic-worker:cache:taskcluster-level-0-",
+                )
+            )
+        ]
+        if wrong_cache_scopes:
+            errors.append(f"{label} uses a non-level-0 cache: {wrong_cache_scopes}")
+
+        unexpected_scopes = sorted(
+            set(scopes) - set(cache_scopes) - ALLOWED_NON_CACHE_SCOPES
+        )
+        if unexpected_scopes:
+            errors.append(f"{label} requests unexpected scopes: {unexpected_scopes}")
+
+        worker_pool = (definition.get("provisionerId"), definition.get("workerType"))
+        if worker_pool not in ALLOWED_WORKER_POOLS:
+            errors.append(f"{label} uses an unapproved worker pool: {worker_pool}")
+
+        # A docker-image index namespace shared by all untrusted pull requests
+        # would let one fork poison the image another fork consumes; untrusted
+        # graphs must neither publish to nor search any image index.
+        routes = definition.get("routes", [])
+        unexpected_routes = [route for route in routes if route != "checks"]
+        if unexpected_routes:
+            errors.append(f"{label} publishes unexpected routes: {unexpected_routes}")
+
+        optimization = task.get("optimization") or {}
+        indexes = optimization.get("index-search", []) if isinstance(optimization, dict) else []
+        if any(DOCKER_IMAGE_INDEX_MARKER in index for index in indexes):
+            errors.append(f"{label} searches a docker image index: {indexes}")
+
+        expiry = definition.get("expires", {}).get("relative-datestamp")
+        if expiry != "28 days":
+            errors.append(f"{label} expires after {expiry!r}, expected '28 days'")
+
+        env = definition.get("payload", {}).get("env", {})
+        run_without_secrets = bool(task.get("attributes", {}).get("run-without-secrets"))
+        untrusted_pr_env = env.get("TASKCLUSTER_UNTRUSTED_PR")
+        if run_without_secrets and env and untrusted_pr_env != "true":
+            errors.append(f"{label} runs without secrets but lacks TASKCLUSTER_UNTRUSTED_PR")
+        if not run_without_secrets and untrusted_pr_env is not None:
+            errors.append(
+                f"{label} sets TASKCLUSTER_UNTRUSTED_PR without the run-without-secrets "
+                "attribute, silently neutralizing NO_TEST_SKIP"
+            )
+
+    if errors:
+        raise RuntimeError("Invalid untrusted task graph:\n- " + "\n- ".join(errors))
+
+
+def check_no_test_skip(tasks, graph_name):
+    """Every task with a payload environment must refuse to skip tests, except
+    library-testing, whose secret-specific tests are allowed to skip."""
+    errors = []
+    for label, task in sorted(tasks.items()):
+        env = task["task"].get("payload", {}).get("env")
+        if not env:
+            continue
+        if label == "library-testing":
+            if "NO_TEST_SKIP" in env:
+                errors.append(f"{label} must allow secret-specific tests to skip")
+        elif env.get("NO_TEST_SKIP") != "true":
+            errors.append(f"{label} does not enforce NO_TEST_SKIP")
+    if errors:
+        raise RuntimeError(f"Invalid {graph_name} task graph:\n- " + "\n- ".join(errors))
+
+
+def main():
+    task_reference_scope = {"task-reference": "secrets:get:<dependency>"}
+    if not production_is_secret_scope(task_reference_scope):
+        raise RuntimeError("Task-reference secret scopes are not recognized")
+
+    version = taskgraph_version()
+    for name in (TRUSTED_PARAMETERS, UNTRUSTED_PARAMETERS):
+        tasks = generate_target_graph(PARAMETERS_DIR / name, version)
+        print(f"Generated {name}: {len(tasks)} tasks")
+        check_no_test_skip(tasks, name)
+        print(f"{name} NO_TEST_SKIP settings are enforced")
+        if name == UNTRUSTED_PARAMETERS:
+            check_untrusted_graph(tasks)
+            print("Untrusted task graph security invariants passed")
+
+
+if __name__ == "__main__":
+    main()

--- a/taskcluster/test/check_taskgraph.py
+++ b/taskcluster/test/check_taskgraph.py
@@ -15,20 +15,13 @@ from src.scopes import is_secret_scope as production_is_secret_scope  # noqa: E4
 PARAMETERS_DIR = Path(__file__).with_name("params")
 TRUSTED_PARAMETERS = "main-repo-pull-request.yml"
 UNTRUSTED_PARAMETERS = "main-repo-pull-request-untrusted.yml"
+APPROVED_COMMENT_PARAMETERS = "main-repo-issue-comment.yml"
 
 DOCKER_IMAGE_INDEX_MARKER = ".docker-images."
 
 ALLOWED_WORKER_POOLS = {
     ("built-in", "succeed"),
     ("proj-taskcluster", "gw-ubuntu-24-04"),
-    ("proj-taskcluster", "gw-ubuntu-24-04-gui"),
-    ("proj-taskcluster", "gw-windows-2022"),
-}
-
-# The generic-worker test suite runs generic-worker instances as the current
-# user; nothing else may add non-cache scopes to the untrusted graph.
-ALLOWED_NON_CACHE_SCOPES = {
-    "generic-worker:run-task-as-current-user:proj-taskcluster/gw-ubuntu-24-04-gui",
 }
 
 
@@ -81,18 +74,16 @@ def check_untrusted_graph(tasks):
     errors = []
     labels = set(tasks)
 
-    expected_task = "go-generic-worker-insecure-untrusted"
-    if expected_task not in labels:
-        errors.append(f"credential-free generic-worker coverage is missing: {expected_task}")
+    generic_worker_tasks = sorted(
+        label for label, task in tasks.items() if task.get("kind") == "generic-worker"
+    )
+    if generic_worker_tasks:
+        errors.append(
+            "generic-worker CI tasks are present: " + ", ".join(generic_worker_tasks)
+        )
 
-    forbidden_tasks = {
-        "generic-worker-build/test-insecure-ubuntu-24.04-amd64",
-        "generic-worker-build/test-multiuser-macos-arm64",
-        "generic-worker-build/test-multiuser-ubuntu-24.04-amd64",
-        "generic-worker-build/test-multiuser-windows-server-2022-amd64",
-    }
-    if present := sorted(labels & forbidden_tasks):
-        errors.append(f"credential-dependent tasks are present: {', '.join(present)}")
+    if "pr-generic-worker-complete" in labels:
+        errors.append("generic-worker completion task is present")
 
     for label, task in tasks.items():
         definition = task["task"]
@@ -113,17 +104,15 @@ def check_untrusted_graph(tasks):
             for scope in cache_scopes
             if not scope.startswith(
                 (
-                    "docker-worker:cache:taskcluster-level-0-",
-                    "generic-worker:cache:taskcluster-level-0-",
+                    "docker-worker:cache:taskcluster-level-1-",
+                    "generic-worker:cache:taskcluster-level-1-",
                 )
             )
         ]
         if wrong_cache_scopes:
-            errors.append(f"{label} uses a non-level-0 cache: {wrong_cache_scopes}")
+            errors.append(f"{label} uses a non-level-1 cache: {wrong_cache_scopes}")
 
-        unexpected_scopes = sorted(
-            set(scopes) - set(cache_scopes) - ALLOWED_NON_CACHE_SCOPES
-        )
+        unexpected_scopes = sorted(set(scopes) - set(cache_scopes))
         if unexpected_scopes:
             errors.append(f"{label} requests unexpected scopes: {unexpected_scopes}")
 
@@ -163,6 +152,49 @@ def check_untrusted_graph(tasks):
         raise RuntimeError("Invalid untrusted task graph:\n- " + "\n- ".join(errors))
 
 
+def check_trusted_graph(tasks, graph_name):
+    errors = []
+    labels = set(tasks)
+    expected_tasks = {
+        "pr-generic-worker-complete",
+        "pr-complete",
+        "generic-worker-build/test-insecure-ubuntu-24.04-amd64",
+        "generic-worker-build/test-multiuser-macos-arm64",
+        "generic-worker-build/test-multiuser-ubuntu-24.04-amd64",
+        "generic-worker-build/test-multiuser-windows-server-2022-amd64",
+    }
+    if missing := sorted(expected_tasks - labels):
+        errors.append("missing generic-worker coverage: " + ", ".join(missing))
+    if not missing:
+        regular_dependencies = set(tasks["pr-complete"].get("soft_dependencies", []))
+        generic_worker_dependencies = set(
+            tasks["pr-generic-worker-complete"].get("soft_dependencies", [])
+        )
+        misplaced_regular = sorted(
+            dependency
+            for dependency in regular_dependencies
+            if tasks.get(dependency, {}).get("kind") == "generic-worker"
+        )
+        misplaced_generic_worker = sorted(
+            dependency
+            for dependency in generic_worker_dependencies
+            if dependency in tasks and tasks[dependency].get("kind") != "generic-worker"
+        )
+        if misplaced_regular or misplaced_generic_worker:
+            errors.append("PR completion dependencies are not split by task kind")
+
+    release_tasks = sorted(
+        label
+        for label, task in tasks.items()
+        if task["task"].get("workerType") == "release"
+    )
+    if release_tasks:
+        errors.append("pull-request graph schedules release tasks: " + ", ".join(release_tasks))
+
+    if errors:
+        raise RuntimeError(f"Invalid {graph_name} task graph:\n- " + "\n- ".join(errors))
+
+
 def check_no_test_skip(tasks, graph_name):
     """Every task with a payload environment must refuse to skip tests, except
     library-testing, whose secret-specific tests are allowed to skip."""
@@ -186,12 +218,19 @@ def main():
         raise RuntimeError("Task-reference secret scopes are not recognized")
 
     version = taskgraph_version()
-    for name in (TRUSTED_PARAMETERS, UNTRUSTED_PARAMETERS):
-        tasks = generate_target_graph(PARAMETERS_DIR / name, version)
-        print(f"Generated {name}: {len(tasks)} tasks")
-        check_no_test_skip(tasks, name)
-        print(f"{name} NO_TEST_SKIP settings are enforced")
-        if name == UNTRUSTED_PARAMETERS:
+    graphs = (
+        (TRUSTED_PARAMETERS, "trusted pull request", True),
+        (APPROVED_COMMENT_PARAMETERS, "approved comment", True),
+        (UNTRUSTED_PARAMETERS, "untrusted pull request", False),
+    )
+    for parameter_file, graph_name, trusted in graphs:
+        tasks = generate_target_graph(PARAMETERS_DIR / parameter_file, version)
+        print(f"Generated task graph with {len(tasks)} tasks")
+        check_no_test_skip(tasks, graph_name)
+        if trusted:
+            check_trusted_graph(tasks, graph_name)
+            print("Trusted task graph includes generic-worker CI")
+        else:
             check_untrusted_graph(tasks)
             print("Untrusted task graph security invariants passed")
 

--- a/taskcluster/test/params/main-repo-issue-comment.yml
+++ b/taskcluster/test/params/main-repo-issue-comment.yml
@@ -4,17 +4,17 @@ do_not_optimize: []
 existing_tasks: {}
 filters:
   - target_tasks_method
-head_ref: matt-boris/dockerWorkerReleasePublishDepencency
-head_repository: https://github.com/taskcluster/taskcluster
+head_ref: contributor/approved-change
+head_repository: https://github.com/contributor/taskcluster
 head_rev: 2829821fed0eed5540866094fe41df79a580381b
 head_tag: ""
 level: "3"
 moz_build_date: "20220502180319"
 optimize_target_tasks: true
-owner: taskcluster-internal@mozilla.com
+owner: contributor@users.noreply.github.com
 project: taskcluster
 pushdate: 0
 pushlog_id: "0"
 repository_type: git
 target_tasks_method: taskcluster-branches
-tasks_for: github-pull-request
+tasks_for: github-issue-comment

--- a/taskcluster/test/params/main-repo-pull-request-untrusted.yml
+++ b/taskcluster/test/params/main-repo-pull-request-untrusted.yml
@@ -1,0 +1,20 @@
+base_repository: https://github.com/taskcluster/taskcluster
+build_date: 1651514599
+do_not_optimize: []
+existing_tasks: {}
+filters:
+  - target_tasks_method
+head_ref: contributor/untrusted-change
+head_repository: https://github.com/contributor/taskcluster
+head_rev: 2829821fed0eed5540866094fe41df79a580381b
+head_tag: ""
+level: "0"
+moz_build_date: "20220502180319"
+optimize_target_tasks: true
+owner: contributor@users.noreply.github.com
+project: taskcluster
+pushdate: 0
+pushlog_id: "0"
+repository_type: git
+target_tasks_method: taskcluster-branches
+tasks_for: github-pull-request-untrusted

--- a/taskcluster/test/params/main-repo-pull-request-untrusted.yml
+++ b/taskcluster/test/params/main-repo-pull-request-untrusted.yml
@@ -8,7 +8,7 @@ head_ref: contributor/untrusted-change
 head_repository: https://github.com/contributor/taskcluster
 head_rev: 2829821fed0eed5540866094fe41df79a580381b
 head_tag: ""
-level: "0"
+level: "1"
 moz_build_date: "20220502180319"
 optimize_target_tasks: true
 owner: contributor@users.noreply.github.com

--- a/test/client-library-secrets.py
+++ b/test/client-library-secrets.py
@@ -16,6 +16,11 @@ except ImportError:
     PY27 = True
 import os
 import json
+import sys
+
+if os.environ.get('TASKCLUSTER_UNTRUSTED_PR') == 'true':
+    print('Skipping Taskcluster integration credentials for an untrusted pull request.', file=sys.stderr)
+    raise SystemExit(0)
 
 proxy_url = os.environ['TASKCLUSTER_PROXY_URL'].rstrip('/')
 

--- a/test/py-lint.sh
+++ b/test/py-lint.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
-python_dirs="taskcluster/src"  # Later we can add #clients/client-py/taskcluster clients/client-py/test" if we make them work the same
+python_dirs="taskcluster/src taskcluster/test"  # Later we can add #clients/client-py/taskcluster clients/client-py/test" if we make them work the same
 
 flake8 $python_dirs


### PR DESCRIPTION
This isolates tasks and tests for non-collaborators to only run the ones that don't involve using secrets and use pull-request-untrusted role

This should land together with
https://github.com/taskcluster/community-tc-config/pull/998

Bug: [2066797](https://bugzilla.mozilla.org/show_bug.cgi?id=2066797)