### PR TITLE
Don't ignore upload failures for optional artifacts

### DIFF
--- a/changelog/issue-9056.md
+++ b/changelog/issue-9056.md
@@ -1,0 +1,6 @@
+audience: users
+level: minor
+reference: issue 9056
+---
+Generic worker will now resolve a task as exception if it read the content of an
+optional artifact but then failed to upload it

--- a/internal/mocktc/mocks3/mocks3.go
+++ b/internal/mocktc/mocks3/mocks3.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strings"
 	"sync"
 	"testing"
 
@@ -37,6 +38,10 @@ func New(t *testing.T) *S3 {
 
 func (s3 *S3) Upload(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
+	if strings.Contains(vars["name"], "fail-with-403") {
+		w.WriteHeader(403)
+		return
+	}
 	contentEncoding := r.Header.Get("Content-Encoding")
 	contentType := r.Header.Get("Content-Type")
 	content, err := io.ReadAll(r.Body)

--- a/workers/generic-worker/artifact_feature.go
+++ b/workers/generic-worker/artifact_feature.go
@@ -111,24 +111,21 @@ func (atf *ArtifactTaskFeature) Stop(err *ExecutionErrors) {
 				return nil
 			}
 			e := task.uploadArtifact(taskArtifact)
+			errArtifact, isErrArtifact := taskArtifact.(*artifacts.ErrorArtifact)
+			// An artifact we never got readable content for is published as an
+			// error artifact. Optional means we're fine with the file not
+			// existing, not that we're fine with failing to upload content
+			if isErrArtifact && errArtifact.Optional {
+				return nil
+			}
+
 			if e != nil {
-				// we don't care about optional artifacts failing to upload
-				if taskArtifact.Base().Optional {
-					return nil
-				}
 				uploadErrChan <- e
 			}
-			// Note - the above error only covers not being able to upload an
-			// artifact, but doesn't cover case that an artifact could not be
-			// found, and so an error artifact was uploaded. So we do that
-			// here:
-			switch a := taskArtifact.(type) {
-			case *artifacts.ErrorArtifact:
-				// we don't care about optional artifacts failing to upload
-				if a.Optional {
-					return nil
-				}
-				fail := Failure(fmt.Errorf("%v: %v", a.Reason, a.Message))
+
+			// Non optional error artifacts should fail the task
+			if isErrArtifact {
+				fail := Failure(fmt.Errorf("%v: %v", errArtifact.Reason, errArtifact.Message))
 				failChan <- fail
 				task.Errorf("TASK FAILURE during artifact upload: %v", fail)
 			}

--- a/workers/generic-worker/artifacts_test.go
+++ b/workers/generic-worker/artifacts_test.go
@@ -762,6 +762,33 @@ func TestMissingOptionalFileArtifactDoesNotFailTest(t *testing.T) {
 	expectedArtifacts.Validate(t, taskID, 0)
 }
 
+func TestOptionalArtifactUploadFailureFailsTask(t *testing.T) {
+	if os.Getenv("GW_TESTS_USE_EXTERNAL_TASKCLUSTER") != "" {
+		t.Skip("This test requires mock services")
+	}
+
+	setup(t)
+
+	expires := tcclient.Time(time.Now().Add(time.Minute * 30))
+	payload := GenericWorkerPayload{
+		Command:    copyTestdataFile("SampleArtifacts/_/X.txt"),
+		MaxRunTime: 30,
+		Artifacts: []Artifact{
+			{
+				Path:     "SampleArtifacts/_/X.txt",
+				Expires:  expires,
+				Type:     "file",
+				Name:     "public/fail-with-403/X.txt",
+				Optional: true,
+			},
+		},
+	}
+	defaults.SetDefaults(&payload)
+
+	td := testTask(t)
+	_ = submitAndAssert(t, td, payload, "exception", "resource-unavailable")
+}
+
 func TestMissingOptionalDirectoryArtifactDoesNotFailTest(t *testing.T) {
 
 	setup(t)


### PR DESCRIPTION
An artifact being marked as optional means that the task is allowed to not produce it. When it does produce said artifact though, it should fail the task if it fails to upload it for any given reason.

The previous behavior ignored any upload error if the artifact was marked as optional. That covers every single artifact uploaded by a task using d2g since it marks them all as optional which means that it would resolve as complete despite the artifact being there and S3 saying no.

This changes that behavior to continue ignoring artifact upload failures when the artifact is marked as optional except if it's present on disk. Artifacts that are missing are resolved early on to `ErrorArtifact` so we can just detect that and ignore the upload error in that case.

I moved some code around to avoid matching on `ErrorArtifact` twice, but the behavior is unchanged except for the "optional & content is there" case where it now fails the task.

Fixes #9056
