### PR TITLE
fix(ui): Improve text editing performance in code editor

### DIFF
--- a/changelog/issue-9066-1.md
+++ b/changelog/issue-9066-1.md
@@ -1,0 +1,5 @@
+audience: users
+level: patch
+reference: issue 9066
+---
+Fixes UI regression in `react-codemirror2` where editing text in any textarea would be very slow.

--- a/ui/src/components/CodeEditor/index.jsx
+++ b/ui/src/components/CodeEditor/index.jsx
@@ -13,6 +13,12 @@ import 'codemirror/theme/material.css';
 import './yaml-lint';
 import './json-lint';
 
+// react-codemirror2 compares option values by identity
+// non-primitive values should be kept stable to avoid rebuild CodeMirror's gutters
+// on every React render (which also included renders caused by unrelated form fields)
+const DEFAULT_EXTRA_KEYS = { Tab: false };
+const DEFAULT_GUTTERS = ['CodeMirror-lint-markers'];
+
 @withStyles({
   root: {
     width: '100%',
@@ -55,8 +61,8 @@ export default class CodeEditor extends Component {
       mode: 'application/json',
       theme: 'material',
       indentWithTabs: false,
-      extraKeys: { Tab: false },
-      gutters: ['CodeMirror-lint-markers'],
+      extraKeys: DEFAULT_EXTRA_KEYS,
+      gutters: DEFAULT_GUTTERS,
       lineNumbers: true,
       ...options,
     };

--- a/ui/src/components/CodeEditor/index.test.jsx
+++ b/ui/src/components/CodeEditor/index.test.jsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { Controlled } from 'react-codemirror2';
+import CodeEditor from './index';
+
+vi.mock('react-codemirror2', () => ({
+  Controlled: vi.fn(() => null),
+}));
+
+beforeEach(() => {
+  vi.mocked(Controlled).mockClear();
+});
+
+it('keeps non-primitive CodeMirror defaults stable across renders', () => {
+  const { rerender } = render(<CodeEditor value="{}" />);
+  const firstOptions = vi.mocked(Controlled).mock.calls.at(-1)[0].options;
+
+  rerender(<CodeEditor value='{"updated": true}' />);
+  const secondOptions = vi.mocked(Controlled).mock.calls.at(-1)[0].options;
+
+  expect(secondOptions.extraKeys).toBe(firstOptions.extraKeys);
+  expect(secondOptions.gutters).toBe(firstOptions.gutters);
+});


### PR DESCRIPTION
Turns out react-codemirror compares some options in a way that made everything re-render on each event
This should make whole UI much faster, because we skip re-rendering everything every time

Fixes #9066
