### PR TITLE
fix(generic-worker): avoid nil store in `ExecutionErrors.add`

### DIFF
--- a/changelog/LtTVofPFRriG5Ft8RdfC1g.md
+++ b/changelog/LtTVofPFRriG5Ft8RdfC1g.md
@@ -1,0 +1,2 @@
+level: silent
+---

--- a/workers/generic-worker/main.go
+++ b/workers/generic-worker/main.go
@@ -1114,11 +1114,7 @@ func (e *ExecutionErrors) add(err *CommandExecutionError) {
 	if err == nil {
 		return
 	}
-	if e == nil {
-		*e = ExecutionErrors{err}
-	} else {
-		*e = append(*e, err)
-	}
+	*e = append(*e, err)
 }
 
 func (e *ExecutionErrors) Error() string {

--- a/workers/generic-worker/main_test.go
+++ b/workers/generic-worker/main_test.go
@@ -188,6 +188,22 @@ func TestExecutionErrorsText(t *testing.T) {
 	}
 }
 
+func TestExecutionErrorsAdd(t *testing.T) {
+	errors := &ExecutionErrors{}
+	errors.add(nil)
+	if errors.Occurred() {
+		t.Fatal("adding nil should be a no-op")
+	}
+	errors.add(&CommandExecutionError{Cause: fmt.Errorf("first")})
+	errors.add(&CommandExecutionError{Cause: fmt.Errorf("second")})
+	if got := len(*errors); got != 2 {
+		t.Fatalf("expected 2 errors, got %d", got)
+	}
+	if errors.Error() != "first" {
+		t.Fatalf("Error() should report first error, got %q", errors.Error())
+	}
+}
+
 // If a task tries to execute a file that isn't executable for the current
 // user, it should result in a task failure, rather than a task exception,
 // since the task is at fault, not the worker.


### PR DESCRIPTION
The `e == nil` branch dereferenced a nil pointer. `append` already handles a nil slice.