### PR TITLE
Return errors from `host.Run*` instead of swallowing them.

### DIFF
--- a/changelog/eCGIu6e4QEmqBfeeacqJbw.md
+++ b/changelog/eCGIu6e4QEmqBfeeacqJbw.md
@@ -1,0 +1,4 @@
+audience: worker-deployers
+level: patch
+---
+Generic-worker will once again report errors if internally ran commands fail

--- a/workers/generic-worker/fileutil/fileutil_windows.go
+++ b/workers/generic-worker/fileutil/fileutil_windows.go
@@ -31,5 +31,5 @@ func GetPermissions(path string) (string, func() error, error) {
 }
 
 func resetPermissions(path string) error {
-	return host.Run("icacls", path, "/reset", "/t")
+	return host.Run("icacls", path, "/reset")
 }

--- a/workers/generic-worker/host/host.go
+++ b/workers/generic-worker/host/host.go
@@ -76,7 +76,7 @@ func RunBatch(allowFail bool, commands ...[]string) (err error) {
 			}
 		}
 	}
-	return nil
+	return err
 }
 
 // RunIgnoreError calls CombinedOutput(comand, args...). If errString is found
@@ -89,7 +89,7 @@ func RunIgnoreError(errString string, command string, args ...string) (found boo
 			return true, nil
 		}
 	}
-	return false, nil
+	return false, err
 }
 
 // runCommand logs cmd.Args, calls cmd.CombinedOutput(), and if an error
@@ -105,5 +105,5 @@ func runCommand(cmd *exec.Cmd) (combinedOutput string, err error) {
 		log.Print("Error running command:")
 		log.Print(string(out))
 	}
-	return string(out), nil
+	return string(out), err
 }

--- a/workers/generic-worker/host/host_test.go
+++ b/workers/generic-worker/host/host_test.go
@@ -1,0 +1,74 @@
+package host
+
+import (
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func failingCommand() []string {
+	if runtime.GOOS == "windows" {
+		return []string{"cmd", "/c", "echo kaboom & exit 1"}
+	}
+	return []string{"/bin/sh", "-c", "echo kaboom; exit 1"}
+}
+
+func successfulCommand() []string {
+	if runtime.GOOS == "windows" {
+		return []string{"cmd", "/c", "exit 0"}
+	}
+	return []string{"/bin/sh", "-c", "exit 0"}
+}
+
+func TestRunReturnsErrorOnFailure(t *testing.T) {
+	cmd := failingCommand()
+	if err := Run(cmd[0], cmd[1:]...); err == nil {
+		t.Fatal("Run didn't return an error despite the command failing")
+	}
+}
+
+func TestCombinedOutputReturnsErrorAndOutput(t *testing.T) {
+	cmd := failingCommand()
+	out, err := CombinedOutput(cmd[0], cmd[1:]...)
+	if err == nil {
+		t.Fatal("CombinedOutput didn't return an error despite the command failing")
+	}
+	if !strings.Contains(out, "kaboom") {
+		t.Fatalf("CombinedOutput did not return command output, got %q", out)
+	}
+}
+
+func TestRunBatchReturnsErrorWhenFailNotAllowed(t *testing.T) {
+	if err := RunBatch(false, failingCommand(), successfulCommand()); err == nil {
+		t.Fatal("RunBatch did not return an error for a failing command")
+	}
+}
+
+func TestRunIgnoreError(t *testing.T) {
+	cmd := failingCommand()
+
+	found, err := RunIgnoreError("kaboom", cmd[0], cmd[1:]...)
+	if err != nil {
+		t.Fatalf("RunIgnoreError returned an error despite the expected output being there: %v", err)
+	}
+	if !found {
+		t.Fatal("RunIgnoreError did not report the expected output as found")
+	}
+
+	found, err = RunIgnoreError("not in output", cmd[0], cmd[1:]...)
+	if err == nil {
+		t.Fatal("RunIgnoreError did not return an error for an unexpected command failure")
+	}
+	if found {
+		t.Fatal("RunIgnoreError reported output as found. It was not")
+	}
+
+	ok := successfulCommand()
+	found, err = RunIgnoreError("kaboom", ok[0], ok[1:]...)
+	if err != nil {
+		t.Fatalf("RunIgnoreError returned an error for a successful command: %v", err)
+	}
+	if found {
+		t.Fatal("RunIgnoreError reported output found for a successful command")
+	}
+}


### PR DESCRIPTION
This fixes three regressions from 712433340f which started returning nil there instead of errors for some reason. That means that any `host.Run*` might have been failing silently, leaving, for example, worker credentials unprotected when they were supposed to be chmod'ed at the worker start.

I added some simple tests to make sure this doesn't happen again
