### PR TITLE
fix(generic-worker): drain remaining task completions on shutdown

### DIFF
--- a/changelog/Tm_0Nl58SyKoOu6f2QhuZA.md
+++ b/changelog/Tm_0Nl58SyKoOu6f2QhuZA.md
@@ -1,0 +1,4 @@
+audience: worker-deployers
+level: patch
+---
+Generic Worker no longer deadlocks on shutdown or when interrupted with Ctrl+C / `SIGINT` while a task is running. Shutdown waits on task completions until no tasks remain, instead of blocking on a wait group that only advanced when those completions were processed.

--- a/workers/generic-worker/main.go
+++ b/workers/generic-worker/main.go
@@ -494,12 +494,9 @@ func RunWorker() (exitCode ExitCode) {
 		log.Printf("WARNING: failed to remove old task directories/users: %v", err)
 	}
 
-	// processCompletion records bookkeeping for a finished task and
-	// reports back what the main loop should do next. Extracted from
-	// inline drain logic so both the top-of-loop drain and the
-	// wait-window completion path can share a single implementation
-	// (avoiding the prior re-put-on-channel pattern, which relied on
-	// a brittle buffer-size / sender-count invariant).
+	// processCompletion applies a completion and reports what the main loop
+	// should do next. Bookkeeping is in recordCompletion so drainUntilIdle
+	// uses the same path.
 	type completionAction int
 	const (
 		completionContinue completionAction = iota
@@ -508,15 +505,23 @@ func RunWorker() (exitCode ExitCode) {
 		completionTasksComplete
 		completionRebootRequired
 	)
-	processCompletion := func(result taskCompletionResult) completionAction {
+	recordCompletion := func(result taskCompletionResult) {
 		taskManager.RemoveTask(result.taskID)
 		tasksResolved++
 		lastActive = time.Now()
+	}
+	drainUntilIdle := func() {
+		for !taskManager.IsIdle() {
+			recordCompletion(<-taskCompleteChan)
+		}
+	}
+	processCompletion := func(result taskCompletionResult) completionAction {
+		recordCompletion(result)
 
 		if result.workerShutdown {
 			log.Printf("Task %s requested worker shutdown, aborting other tasks...", result.taskID)
 			graceful.Terminate(false) // Abort other tasks immediately
-			taskManager.WaitForAll()
+			drainUntilIdle()
 			return completionWorkerShutdown
 		}
 
@@ -529,7 +534,7 @@ func RunWorker() (exitCode ExitCode) {
 		log.Printf("Resolved %v tasks in total so far%v.", tasksResolved, remainingTaskCountText)
 		if remainingTasks == 0 {
 			log.Printf("Completed all task(s) (number of tasks to run = %v)", config.NumberOfTasksToRun)
-			taskManager.WaitForAll()
+			drainUntilIdle()
 			if checkWhetherToTerminate() {
 				return completionWorkerManagerShutdown
 			}
@@ -585,13 +590,13 @@ mainLoop:
 		}
 
 		if checkWhetherToTerminate() {
-			taskManager.WaitForAll()
+			drainUntilIdle()
 			return WORKER_MANAGER_SHUTDOWN
 		}
 
 		if graceful.TerminationRequested() {
 			log.Printf("Graceful termination requested, waiting for %d running tasks...", taskManager.TaskCount())
-			taskManager.WaitForAll()
+			drainUntilIdle()
 			return WORKER_SHUTDOWN
 		}
 
@@ -824,7 +829,7 @@ mainLoop:
 		case <-sigInterrupt:
 			log.Printf("Interrupt received, signaling %d running tasks...", taskManager.TaskCount())
 			graceful.Terminate(true)
-			taskManager.WaitForAll()
+			drainUntilIdle()
 			return WORKER_STOPPED
 		}
 	}

--- a/workers/generic-worker/task_manager.go
+++ b/workers/generic-worker/task_manager.go
@@ -15,7 +15,6 @@ type TaskManager struct {
 	sync.RWMutex
 	runningTasks map[string]*TaskRun
 	capacity     uint8
-	wg           sync.WaitGroup
 	lastActive   time.Time
 }
 
@@ -46,19 +45,17 @@ func (tm *TaskManager) AddTask(task *TaskRun) {
 	tm.Lock()
 	defer tm.Unlock()
 	tm.runningTasks[task.TaskID] = task
-	tm.wg.Add(1)
 	tm.lastActive = time.Now()
 	tm.updateWorkerStatusLocked()
 }
 
-// RemoveTask unregisters a task. Must be called when the task goroutine completes.
+// RemoveTask unregisters a task.
 // Updates the worker status file with remaining running task IDs.
 func (tm *TaskManager) RemoveTask(taskID string) {
 	tm.Lock()
 	defer tm.Unlock()
 	if _, exists := tm.runningTasks[taskID]; exists {
 		delete(tm.runningTasks, taskID)
-		tm.wg.Done()
 		tm.lastActive = time.Now()
 		tm.updateWorkerStatusLocked()
 	}
@@ -85,11 +82,6 @@ func (tm *TaskManager) TaskCount() uint {
 // IsIdle returns true if no tasks are running.
 func (tm *TaskManager) IsIdle() bool {
 	return tm.TaskCount() == 0
-}
-
-// WaitForAll blocks until all running tasks have completed.
-func (tm *TaskManager) WaitForAll() {
-	tm.wg.Wait()
 }
 
 // LastActive returns the time when a task was last added or removed.

--- a/workers/generic-worker/task_manager_test.go
+++ b/workers/generic-worker/task_manager_test.go
@@ -65,47 +65,6 @@ func TestTaskManagerGetTask(t *testing.T) {
 	require.Nil(t, tm.GetTask("nonexistent"))
 }
 
-func TestTaskManagerWaitForAll(t *testing.T) {
-	tm := NewTaskManager(2)
-
-	var wg sync.WaitGroup
-	wg.Add(2)
-
-	task1 := &TaskRun{TaskID: "task1"}
-	task2 := &TaskRun{TaskID: "task2"}
-	tm.AddTask(task1)
-	tm.AddTask(task2)
-
-	// Simulate tasks completing
-	go func() {
-		time.Sleep(10 * time.Millisecond)
-		tm.RemoveTask("task1")
-		wg.Done()
-	}()
-	go func() {
-		time.Sleep(20 * time.Millisecond)
-		tm.RemoveTask("task2")
-		wg.Done()
-	}()
-
-	// WaitForAll should block until all tasks complete
-	done := make(chan struct{})
-	go func() {
-		tm.WaitForAll()
-		close(done)
-	}()
-
-	select {
-	case <-done:
-		// Success
-	case <-time.After(1 * time.Second):
-		t.Fatal("WaitForAll timed out")
-	}
-
-	require.True(t, tm.IsIdle())
-	wg.Wait()
-}
-
 func TestTaskManagerLastActive(t *testing.T) {
 	tm := NewTaskManager(2)
 	initialTime := tm.LastActive()


### PR DESCRIPTION
Shutdown waited on a wait group that only advanced in `RemoveTask`,
which never ran if the main loop had already returned. Shutdown
paths now receive completions until no tasks remain, so the worker
cannot hang and still records those tasks.

>Generic Worker no longer deadlocks on shutdown or when interrupted with Ctrl+C / `SIGINT` while a task is running. Shutdown waits on task completions until no tasks remain, instead of blocking on a wait group that only advanced when those completions were processed.