### PR TITLE
chore(lib-iterate): convert from js --> ts

### DIFF
--- a/@types/globals.d.ts
+++ b/@types/globals.d.ts
@@ -9,3 +9,8 @@ declare module 'lodash' {
 declare module 'js-yaml' {
   function load(content: string): any;
 }
+
+declare module 'debug' {
+  function debugFactory(namespace: string): (...args: any[]) => void;
+  export default debugFactory;
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,6 +63,7 @@ yarn lint           # Lint JavaScript/TypeScript
 yarn lint:fix       # Auto-fix linting issues
 yarn lint:go        # Lint Go code
 yarn lint:py        # Lint Python code
+yarn types          # Type-check .ts files (tsc --noEmit; Node does not type-check at runtime)
 ```
 
 ### Building
@@ -258,11 +259,12 @@ yarn start
 1. Run tests locally
 2. Run `yarn generate` if you changed APIs, database, or Go code (requires Postgres running)
 3. Run `yarn lint:fix` to fix style issues
-4. For Go changes, also run `go tool goimports -w <dir>` and `golangci-lint` (see `.golangci.yml`)
-5. Add a changelog entry in `changelog/` (see `dev-docs/best-practices/changelog.md`)
-6. Commit changes (including generated files)
-7. CI will run full test suite and linting
-8. **Verify the change actually works.** Run the affected code path: open a UI page in a browser, hit a service endpoint, run a task. CI passing means code compiled and unit tests ran — not that the feature works. UI work has more specifics in `ui/CLAUDE.md`.
+4. Run `yarn types` if you changed TypeScript (CI runs this; Node type stripping does not)
+5. For Go changes, also run `go tool goimports -w <dir>` and `golangci-lint` (see `.golangci.yml`)
+6. Add a changelog entry in `changelog/` (see `dev-docs/best-practices/changelog.md`)
+7. Commit changes (including generated files)
+8. CI will run full test suite and linting
+9. **Verify the change actually works.** Run the affected code path: open a UI page in a browser, hit a service endpoint, run a task. CI passing means code compiled and unit tests ran — not that the feature works. UI work has more specifics in `ui/CLAUDE.md`.
 
 ## Tools and Workers
 

--- a/biome.json
+++ b/biome.json
@@ -3,7 +3,7 @@
   "root": true,
   "files": {
     "includes": [
-      "{libraries,services,infrastructure,db,clients/client,clients/client-web,clients/client-test}/**/{src,test}/**/*.js",
+      "{libraries,services,infrastructure,db,clients/client,clients/client-web,clients/client-test}/**/{src,test}/**/*.{js,ts}",
       "test/**/*.js",
       "ui/src/**/*.{js,jsx}",
       "!**/clients/client-web/src/clients",

--- a/changelog/YIczDdjvStWwpxN_Fln3mg.md
+++ b/changelog/YIczDdjvStWwpxN_Fln3mg.md
@@ -1,0 +1,6 @@
+audience: developers
+level: silent
+---
+Convert `@taskcluster/lib-iterate` from JavaScript to TypeScript, run natively on Node 24 type stripping.
+
+Run `yarn types` (`tsc --noEmit`) in CI with TypeScript 7. Node type stripping does not type-check, so this is the check that reports type errors.

--- a/libraries/iterate/package.json
+++ b/libraries/iterate/package.json
@@ -3,13 +3,13 @@
   "private": true,
   "version": "108.0.0",
   "description": "A library to share iteration logic",
-  "exports": "./src/index.js",
+  "exports": "./src/index.ts",
   "type": "module",
   "scripts": {
     "lint": "biome check",
     "lint:fix": "biome check --write",
     "format": "biome format --write",
-    "test": "mocha"
+    "test": "mocha test/*_test.js"
   },
   "author": "John Ford <jhford@mozilla.com>",
   "license": "MPL-2.0",

--- a/libraries/iterate/src/index.ts
+++ b/libraries/iterate/src/index.ts
@@ -1,74 +1,113 @@
-import WatchDog from './watchdog.js';
+import WatchDog from './watchdog.ts';
 import debugFactory from 'debug';
-const debug = debugFactory('iterate');
-import events from 'node:events';
+import { EventEmitter } from 'node:events';
 import { hrtime } from 'node:process';
+
+const debug = debugFactory('iterate');
+
+export type IterateHandler = (watchdog: WatchDog) => unknown;
+
+/** Subset of @taskcluster/lib-monitor used by Iterate. */
+export interface IterateMonitor {
+  log: {
+    periodic: (
+      fields: { name: string; duration: number; status: 'exception' | 'success' },
+      opts: { level: string }
+    ) => void;
+  };
+  metric: {
+    iterateDuration: (seconds: number, labels: { name: string; status: string }) => void;
+  };
+  reportError: (err: unknown, level?: string, extra?: Record<string, unknown>) => void;
+}
+
+export interface IterateOptions {
+  name: string;
+  handler: IterateHandler;
+  monitor: IterateMonitor;
+  maxIterationTime: number;
+  waitTime: number;
+  watchdogTime?: number;
+  maxFailures?: number;
+  maxIterations?: number;
+  minIterationTime?: number;
+}
 
 /**
  * The Iterate Class.  See README.md for explanation of constructor
  * arguments and events that are emitted
  */
-class Iterate extends events.EventEmitter {
-  constructor(opts) {
+class Iterate extends EventEmitter {
+  name: string;
+  maxIterations: number;
+  maxFailures: number;
+  maxIterationTime: number;
+  minIterationTime: number;
+  watchdogTime: number;
+  waitTime: number;
+  handler: IterateHandler;
+  monitor: IterateMonitor;
+  keepGoing: boolean;
+  onStopCall: (() => void) | null;
+  stoppedPromise: Promise<void> | null;
+  currentTimeout: ReturnType<typeof setTimeout> | null;
+
+  constructor(opts: IterateOptions) {
     super();
-    events.EventEmitter.call(this);
 
     // Set default values
-    opts = Object.assign(
-      {},
-      {
-        watchdogTime: 0,
-        maxFailures: 0,
-        maxIterations: 0,
-        minIterationTime: 0,
-      },
-      opts
-    );
+    const resolved = {
+      watchdogTime: 0,
+      maxFailures: 0,
+      maxIterations: 0,
+      minIterationTime: 0,
+      ...opts,
+    };
 
-    if (!opts.name) {
+    if (!resolved.name) {
       throw new Error('Must provide a name to iterate');
     }
-    this.name = opts.name;
+    this.name = resolved.name;
 
-    if (typeof opts.maxIterations !== 'number') {
+    if (typeof resolved.maxIterations !== 'number') {
       throw new Error('maxIterations must be number');
     }
-    this.maxIterations = opts.maxIterations;
+    this.maxIterations = resolved.maxIterations;
 
-    if (typeof opts.maxFailures !== 'number') {
+    if (typeof resolved.maxFailures !== 'number') {
       throw new Error('maxFailures must be number');
     }
-    this.maxFailures = opts.maxFailures;
+    this.maxFailures = resolved.maxFailures;
 
-    if (typeof opts.maxIterationTime !== 'number') {
+    if (typeof resolved.maxIterationTime !== 'number') {
       throw new Error('maxIterationTime must be number');
     }
-    this.maxIterationTime = opts.maxIterationTime;
+    this.maxIterationTime = resolved.maxIterationTime;
 
-    if (typeof opts.minIterationTime !== 'number') {
+    if (typeof resolved.minIterationTime !== 'number') {
       throw new Error('minIterationTime must be number');
     }
-    this.minIterationTime = opts.minIterationTime;
+    this.minIterationTime = resolved.minIterationTime;
 
-    if (typeof opts.watchdogTime !== 'number') {
+    if (typeof resolved.watchdogTime !== 'number') {
       throw new Error('watchdogTime must be number');
     }
-    this.watchdogTime = opts.watchdogTime;
+    this.watchdogTime = resolved.watchdogTime;
 
-    if (typeof opts.waitTime !== 'number') {
+    if (typeof resolved.waitTime !== 'number') {
       throw new Error('waitTime must be number');
     }
-    this.waitTime = opts.waitTime;
+    this.waitTime = resolved.waitTime;
 
-    if (typeof opts.handler !== 'function') {
+    if (typeof resolved.handler !== 'function') {
       throw new Error('handler must be a function');
     }
-    this.handler = opts.handler;
+    this.handler = resolved.handler;
 
-    if (!opts.monitor || typeof opts.monitor !== 'object') {
+    if (!resolved.monitor || typeof resolved.monitor !== 'object') {
       throw new Error('monitor is required and must be an object from @taskcluster/lib-monitor');
     }
-    this.monitor = opts.monitor;
+    this.monitor = resolved.monitor;
 
     // Decide whether iteration should continue
     this.keepGoing = false;
@@ -77,7 +116,7 @@ class Iterate extends events.EventEmitter {
     this.onStopCall = null;
 
     // Fires when stopped, only set when started
-    this.stopPromise = null;
+    this.stoppedPromise = null;
 
     // Store the iteration timeout so that a `.stop()` call during an iteration
     // inhibits a handler from running
@@ -88,11 +127,11 @@ class Iterate extends events.EventEmitter {
     debug('running handler');
     const start = new Date();
     const watchdog = new WatchDog(this.watchdogTime);
-    let maxIterationTimeTimer;
+    let maxIterationTimeTimer: ReturnType<typeof setTimeout> | undefined;
 
     // build a promise that will reject when either the watchdog
     // times out or the maxIterationTimeTimer expires
-    const timeoutRejector = new Promise((_resolve, reject) => {
+    const timeoutRejector = new Promise<never>((_resolve, reject) => {
       watchdog.on('expired', () => {
         debug('watchdog expired');
         reject(new Error('watchdog exceeded'));
@@ -112,7 +151,7 @@ class Iterate extends events.EventEmitter {
       watchdog.stop();
     }
 
-    const duration = Date.now() - start;
+    const duration = Date.now() - start.getTime();
     if (this.minIterationTime > 0 && duration < this.minIterationTime) {
       throw new Error('Handler duration was less than minIterationTime');
     }
@@ -121,13 +160,13 @@ class Iterate extends events.EventEmitter {
   // run a single iteration, throwing any errors
   async iterate() {
     let currentIteration = 0;
-    let failures = [];
+    let failures: unknown[] = [];
 
     this.emit('started');
 
     while (true) {
       currentIteration++;
-      let iterError;
+      let iterError: unknown;
 
       this.emit('iteration-start');
 
@@ -183,11 +222,11 @@ class Iterate extends events.EventEmitter {
 
       if (this.waitTime > 0) {
         debug('waiting for next iteration or stop');
-        const stopPromise = new Promise(resolve => {
+        const stopPromise = new Promise<void>(resolve => {
           this.onStopCall = resolve;
         });
-        let waitTimeTimeout;
-        const waitTimePromise = new Promise(resolve => {
+        let waitTimeTimeout: ReturnType<typeof setTimeout> | undefined;
+        const waitTimePromise = new Promise<void>(resolve => {
           waitTimeTimeout = setTimeout(resolve, this.waitTime);
         });
         await Promise.race([stopPromise, waitTimePromise]);
@@ -210,7 +249,7 @@ class Iterate extends events.EventEmitter {
     });
     this.keepGoing = true;
 
-    return new Promise(resolve => {
+    return new Promise<void>(resolve => {
       this.once('started', resolve);
       // start iteration; any failures here are a programming error in this
       // library and so should be considered fatal

--- a/libraries/iterate/src/watchdog.ts
+++ b/libraries/iterate/src/watchdog.ts
@@ -1,12 +1,15 @@
-import events from 'node:events';
+import { EventEmitter } from 'node:events';
 
 /**
  * This is a watch dog timer.  Think of it as a ticking timebomb which will
  * explode when it hasn't been stopped or touched in `maxTime` seconds.  The
  * "explosion" in this case is just an 'expired' event.
  */
-class WatchDog extends events.EventEmitter {
-  constructor(maxTime) {
+class WatchDog extends EventEmitter {
+  maxTime: number;
+  timer: ReturnType<typeof setTimeout> | null;
+
+  constructor(maxTime: number) {
     super();
     this.maxTime = maxTime;
     this.timer = null;

--- a/libraries/iterate/test/iterate_test.js
+++ b/libraries/iterate/test/iterate_test.js
@@ -1,4 +1,4 @@
-import subject from '../src/index.js';
+import subject from '../src/index.ts';
 import assume from 'assume';
 import debugFactory from 'debug';
 const debug = debugFactory('iterate-test');
@@ -83,7 +83,7 @@ suite(testing.suiteName(), () => {
         monitor,
         maxIterationTime: 3000,
         waitTime: 1000,
-        watchDog: 0,
+        watchdogTime: 0,
         handler: async _watchdog => {
           debug('iterate!');
           iterations++;
@@ -124,7 +124,7 @@ suite(testing.suiteName(), () => {
         maxIterationTime: 3000,
         waitTime: 10,
         maxIterations: 5,
-        watchDog: 0,
+        watchdogTime: 0,
         handler: async _watchdog => {
           await testing.sleep(500);
         },
@@ -149,7 +149,7 @@ suite(testing.suiteName(), () => {
         maxIterationTime: 3000,
         waitTime: 1000,
         maxIterations: 2,
-        watchDog: 0,
+        watchdogTime: 0,
         handler: async _watchdog => {
           await testing.sleep(500);
         },
@@ -174,7 +174,7 @@ suite(testing.suiteName(), () => {
         maxIterationTime: 3000,
         waitTime: 10,
         maxIterations: 5,
-        watchDog: 0,
+        watchdogTime: 0,
         handler: async _watchdog => {
           debug('iterate!');
           iterations++;
@@ -320,7 +320,7 @@ suite(testing.suiteName(), () => {
         maxIterationTime: 12000,
         minIterationTime: 10000,
         waitTime: 1000,
-        watchDog: 0,
+        watchdogTime: 0,
         handler: async _watchdog => {
           await testing.sleep(100);
         },

--- a/libraries/iterate/test/watchdog_test.js
+++ b/libraries/iterate/test/watchdog_test.js
@@ -1,4 +1,4 @@
-import subject from '../src/watchdog.js';
+import subject from '../src/watchdog.ts';
 import assume from 'assume';
 import testing from '@taskcluster/lib-testing';
 

--- a/package.json
+++ b/package.json
@@ -168,7 +168,7 @@
     "semver": "^7.8.5",
     "sinon": "^21.1.2",
     "snake-case": "^3.0.3",
-    "typescript": "^5.9.2",
+    "typescript": "^7.0.2",
     "ws": "^7.5.11",
     "zen-observable": "^0.10.0",
     "zurvan": "^0.8.0"
@@ -215,7 +215,7 @@
     "db:renumber": "node db/src/main.js renumber",
     "db:new": "node db/src/main.js new",
     "preinstall": "[ -d clients/client ] && cd clients/client && yarn --immutable || exit 0",
-    "types": "tsc --noEmit"
+    "types": "tsc --noEmit -p tsconfig.types.json"
   },
   "metatests": {
     "specialImports": [

--- a/taskcluster/kinds/lint/kind.yml
+++ b/taskcluster/kinds/lint/kind.yml
@@ -27,6 +27,17 @@ tasks:
       command: >-
         corepack yarn &> /dev/null &&
         corepack yarn lint
+  typescript:
+    description: TypeScript type check (tsc --noEmit)
+    worker:
+      docker-image: {in-tree: ci}
+      caches:
+        - name: taskcluster
+          mount-point: /builds/worker/checkouts
+    run:
+      command: >-
+        corepack yarn &> /dev/null &&
+        corepack yarn types
   golang:
     description: go lint
     priority: very-high

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "module": "NodeNext",
-    "baseUrl": "src",
     "strict": true,
     "allowJs": true,
     "checkJs": true,
@@ -11,12 +10,17 @@
     "target": "esnext",
     "lib": ["esnext", "dom"],
     "esModuleInterop": true,
-    "moduleResolution": "NodeNext"
+    "moduleResolution": "NodeNext",
+    "allowImportingTsExtensions": true,
+    "rewriteRelativeImportExtensions": true,
+    "erasableSyntaxOnly": true,
+    "verbatimModuleSyntax": true
   },
   "include": [
     "./services/**/*.js",
     "./libraries/**/*.d.ts",
     "./libraries/**/*.js",
+    "./libraries/**/*.ts",
     "./db/**/*.js",
     "./clients/client/**/*.js"
   ],

--- a/tsconfig.types.json
+++ b/tsconfig.types.json
@@ -1,0 +1,20 @@
+{
+  // CI / `yarn types`: check TypeScript that Node runs via type stripping.
+  // Root tsconfig.json still enables checkJs for editor/JSDoc work; that
+  // surface is not CI-gated because the JS tree is not fully typed.
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "checkJs": false,
+    "skipLibCheck": true
+  },
+  "include": [
+    "./libraries/**/*.ts",
+    "./services/**/*.ts",
+    "./db/**/*.ts",
+    "./clients/client/**/*.ts"
+  ],
+  "files": [
+    "@types/globals.d.ts"
+  ],
+  "exclude": ["node_modules"]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -4713,6 +4713,146 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@typescript/typescript-aix-ppc64@npm:7.0.2":
+  version: 7.0.2
+  resolution: "@typescript/typescript-aix-ppc64@npm:7.0.2"
+  conditions: os=aix & cpu=ppc64
+  languageName: node
+  linkType: hard
+
+"@typescript/typescript-darwin-arm64@npm:7.0.2":
+  version: 7.0.2
+  resolution: "@typescript/typescript-darwin-arm64@npm:7.0.2"
+  conditions: os=darwin & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@typescript/typescript-darwin-x64@npm:7.0.2":
+  version: 7.0.2
+  resolution: "@typescript/typescript-darwin-x64@npm:7.0.2"
+  conditions: os=darwin & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@typescript/typescript-freebsd-arm64@npm:7.0.2":
+  version: 7.0.2
+  resolution: "@typescript/typescript-freebsd-arm64@npm:7.0.2"
+  conditions: os=freebsd & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@typescript/typescript-freebsd-x64@npm:7.0.2":
+  version: 7.0.2
+  resolution: "@typescript/typescript-freebsd-x64@npm:7.0.2"
+  conditions: os=freebsd & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@typescript/typescript-linux-arm64@npm:7.0.2":
+  version: 7.0.2
+  resolution: "@typescript/typescript-linux-arm64@npm:7.0.2"
+  conditions: os=linux & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@typescript/typescript-linux-arm@npm:7.0.2":
+  version: 7.0.2
+  resolution: "@typescript/typescript-linux-arm@npm:7.0.2"
+  conditions: os=linux & cpu=arm
+  languageName: node
+  linkType: hard
+
+"@typescript/typescript-linux-loong64@npm:7.0.2":
+  version: 7.0.2
+  resolution: "@typescript/typescript-linux-loong64@npm:7.0.2"
+  conditions: os=linux & cpu=loong64
+  languageName: node
+  linkType: hard
+
+"@typescript/typescript-linux-mips64el@npm:7.0.2":
+  version: 7.0.2
+  resolution: "@typescript/typescript-linux-mips64el@npm:7.0.2"
+  conditions: os=linux & cpu=mips64el
+  languageName: node
+  linkType: hard
+
+"@typescript/typescript-linux-ppc64@npm:7.0.2":
+  version: 7.0.2
+  resolution: "@typescript/typescript-linux-ppc64@npm:7.0.2"
+  conditions: os=linux & cpu=ppc64
+  languageName: node
+  linkType: hard
+
+"@typescript/typescript-linux-riscv64@npm:7.0.2":
+  version: 7.0.2
+  resolution: "@typescript/typescript-linux-riscv64@npm:7.0.2"
+  conditions: os=linux & cpu=riscv64
+  languageName: node
+  linkType: hard
+
+"@typescript/typescript-linux-s390x@npm:7.0.2":
+  version: 7.0.2
+  resolution: "@typescript/typescript-linux-s390x@npm:7.0.2"
+  conditions: os=linux & cpu=s390x
+  languageName: node
+  linkType: hard
+
+"@typescript/typescript-linux-x64@npm:7.0.2":
+  version: 7.0.2
+  resolution: "@typescript/typescript-linux-x64@npm:7.0.2"
+  conditions: os=linux & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@typescript/typescript-netbsd-arm64@npm:7.0.2":
+  version: 7.0.2
+  resolution: "@typescript/typescript-netbsd-arm64@npm:7.0.2"
+  conditions: os=netbsd & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@typescript/typescript-netbsd-x64@npm:7.0.2":
+  version: 7.0.2
+  resolution: "@typescript/typescript-netbsd-x64@npm:7.0.2"
+  conditions: os=netbsd & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@typescript/typescript-openbsd-arm64@npm:7.0.2":
+  version: 7.0.2
+  resolution: "@typescript/typescript-openbsd-arm64@npm:7.0.2"
+  conditions: os=openbsd & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@typescript/typescript-openbsd-x64@npm:7.0.2":
+  version: 7.0.2
+  resolution: "@typescript/typescript-openbsd-x64@npm:7.0.2"
+  conditions: os=openbsd & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@typescript/typescript-sunos-x64@npm:7.0.2":
+  version: 7.0.2
+  resolution: "@typescript/typescript-sunos-x64@npm:7.0.2"
+  conditions: os=sunos & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@typescript/typescript-win32-arm64@npm:7.0.2":
+  version: 7.0.2
+  resolution: "@typescript/typescript-win32-arm64@npm:7.0.2"
+  conditions: os=win32 & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@typescript/typescript-win32-x64@npm:7.0.2":
+  version: 7.0.2
+  resolution: "@typescript/typescript-win32-x64@npm:7.0.2"
+  conditions: os=win32 & cpu=x64
+  languageName: node
+  linkType: hard
+
 "@typespec/ts-http-runtime@npm:^0.2.2, @typespec/ts-http-runtime@npm:^0.2.3":
   version: 0.2.3
   resolution: "@typespec/ts-http-runtime@npm:0.2.3"
@@ -11767,7 +11907,7 @@ __metadata:
     taskcluster-lib-urls: "npm:^13.0.2"
     topo-sort: "npm:^1.0.0"
     type-is: "npm:^1.6.15"
-    typescript: "npm:^5.9.2"
+    typescript: "npm:^7.0.2"
     uuid: "npm:^14.0.2"
     walk: "npm:^2.3.9"
     ws: "npm:^7.5.11"
@@ -11982,23 +12122,145 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@npm:^5.9.2":
-  version: 5.9.2
-  resolution: "typescript@npm:5.9.2"
+"typescript@npm:^7.0.2":
+  version: 7.0.2
+  resolution: "typescript@npm:7.0.2"
+  dependencies:
+    "@typescript/typescript-aix-ppc64": "npm:7.0.2"
+    "@typescript/typescript-darwin-arm64": "npm:7.0.2"
+    "@typescript/typescript-darwin-x64": "npm:7.0.2"
+    "@typescript/typescript-freebsd-arm64": "npm:7.0.2"
+    "@typescript/typescript-freebsd-x64": "npm:7.0.2"
+    "@typescript/typescript-linux-arm": "npm:7.0.2"
+    "@typescript/typescript-linux-arm64": "npm:7.0.2"
+    "@typescript/typescript-linux-loong64": "npm:7.0.2"
+    "@typescript/typescript-linux-mips64el": "npm:7.0.2"
+    "@typescript/typescript-linux-ppc64": "npm:7.0.2"
+    "@typescript/typescript-linux-riscv64": "npm:7.0.2"
+    "@typescript/typescript-linux-s390x": "npm:7.0.2"
+    "@typescript/typescript-linux-x64": "npm:7.0.2"
+    "@typescript/typescript-netbsd-arm64": "npm:7.0.2"
+    "@typescript/typescript-netbsd-x64": "npm:7.0.2"
+    "@typescript/typescript-openbsd-arm64": "npm:7.0.2"
+    "@typescript/typescript-openbsd-x64": "npm:7.0.2"
+    "@typescript/typescript-sunos-x64": "npm:7.0.2"
+    "@typescript/typescript-win32-arm64": "npm:7.0.2"
+    "@typescript/typescript-win32-x64": "npm:7.0.2"
+  dependenciesMeta:
+    "@typescript/typescript-aix-ppc64":
+      optional: true
+    "@typescript/typescript-darwin-arm64":
+      optional: true
+    "@typescript/typescript-darwin-x64":
+      optional: true
+    "@typescript/typescript-freebsd-arm64":
+      optional: true
+    "@typescript/typescript-freebsd-x64":
+      optional: true
+    "@typescript/typescript-linux-arm":
+      optional: true
+    "@typescript/typescript-linux-arm64":
+      optional: true
+    "@typescript/typescript-linux-loong64":
+      optional: true
+    "@typescript/typescript-linux-mips64el":
+      optional: true
+    "@typescript/typescript-linux-ppc64":
+      optional: true
+    "@typescript/typescript-linux-riscv64":
+      optional: true
+    "@typescript/typescript-linux-s390x":
+      optional: true
+    "@typescript/typescript-linux-x64":
+      optional: true
+    "@typescript/typescript-netbsd-arm64":
+      optional: true
+    "@typescript/typescript-netbsd-x64":
+      optional: true
+    "@typescript/typescript-openbsd-arm64":
+      optional: true
+    "@typescript/typescript-openbsd-x64":
+      optional: true
+    "@typescript/typescript-sunos-x64":
+      optional: true
+    "@typescript/typescript-win32-arm64":
+      optional: true
+    "@typescript/typescript-win32-x64":
+      optional: true
   bin:
     tsc: bin/tsc
-    tsserver: bin/tsserver
-  checksum: 10c0/cd635d50f02d6cf98ed42de2f76289701c1ec587a363369255f01ed15aaf22be0813226bff3c53e99d971f9b540e0b3cc7583dbe05faded49b1b0bed2f638a18
+  checksum: 10c0/3dcee51ec8c332492325bcdbf7df48b66668751f127e622ae7d41b6c716eb19184424a45e14f7750f50f340232388b69e6287859155f06a5ce2df76f12cb31cf
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@npm%3A^5.9.2#optional!builtin<compat/typescript>":
-  version: 5.9.2
-  resolution: "typescript@patch:typescript@npm%3A5.9.2#optional!builtin<compat/typescript>::version=5.9.2&hash=5786d5"
+"typescript@patch:typescript@npm%3A^7.0.2#optional!builtin<compat/typescript>":
+  version: 7.0.2
+  resolution: "typescript@patch:typescript@npm%3A7.0.2#optional!builtin<compat/typescript>::version=7.0.2&hash=3bafbf"
+  dependencies:
+    "@typescript/typescript-aix-ppc64": "npm:7.0.2"
+    "@typescript/typescript-darwin-arm64": "npm:7.0.2"
+    "@typescript/typescript-darwin-x64": "npm:7.0.2"
+    "@typescript/typescript-freebsd-arm64": "npm:7.0.2"
+    "@typescript/typescript-freebsd-x64": "npm:7.0.2"
+    "@typescript/typescript-linux-arm": "npm:7.0.2"
+    "@typescript/typescript-linux-arm64": "npm:7.0.2"
+    "@typescript/typescript-linux-loong64": "npm:7.0.2"
+    "@typescript/typescript-linux-mips64el": "npm:7.0.2"
+    "@typescript/typescript-linux-ppc64": "npm:7.0.2"
+    "@typescript/typescript-linux-riscv64": "npm:7.0.2"
+    "@typescript/typescript-linux-s390x": "npm:7.0.2"
+    "@typescript/typescript-linux-x64": "npm:7.0.2"
+    "@typescript/typescript-netbsd-arm64": "npm:7.0.2"
+    "@typescript/typescript-netbsd-x64": "npm:7.0.2"
+    "@typescript/typescript-openbsd-arm64": "npm:7.0.2"
+    "@typescript/typescript-openbsd-x64": "npm:7.0.2"
+    "@typescript/typescript-sunos-x64": "npm:7.0.2"
+    "@typescript/typescript-win32-arm64": "npm:7.0.2"
+    "@typescript/typescript-win32-x64": "npm:7.0.2"
+  dependenciesMeta:
+    "@typescript/typescript-aix-ppc64":
+      optional: true
+    "@typescript/typescript-darwin-arm64":
+      optional: true
+    "@typescript/typescript-darwin-x64":
+      optional: true
+    "@typescript/typescript-freebsd-arm64":
+      optional: true
+    "@typescript/typescript-freebsd-x64":
+      optional: true
+    "@typescript/typescript-linux-arm":
+      optional: true
+    "@typescript/typescript-linux-arm64":
+      optional: true
+    "@typescript/typescript-linux-loong64":
+      optional: true
+    "@typescript/typescript-linux-mips64el":
+      optional: true
+    "@typescript/typescript-linux-ppc64":
+      optional: true
+    "@typescript/typescript-linux-riscv64":
+      optional: true
+    "@typescript/typescript-linux-s390x":
+      optional: true
+    "@typescript/typescript-linux-x64":
+      optional: true
+    "@typescript/typescript-netbsd-arm64":
+      optional: true
+    "@typescript/typescript-netbsd-x64":
+      optional: true
+    "@typescript/typescript-openbsd-arm64":
+      optional: true
+    "@typescript/typescript-openbsd-x64":
+      optional: true
+    "@typescript/typescript-sunos-x64":
+      optional: true
+    "@typescript/typescript-win32-arm64":
+      optional: true
+    "@typescript/typescript-win32-x64":
+      optional: true
   bin:
     tsc: bin/tsc
-    tsserver: bin/tsserver
-  checksum: 10c0/34d2a8e23eb8e0d1875072064d5e1d9c102e0bdce56a10a25c0b917b8aa9001a9cf5c225df12497e99da107dc379360bc138163c66b55b95f5b105b50578067e
+  checksum: 10c0/6b3cdc369cd829d46e00734ea64233ee84419c2825ad8fe408915adde77abced4b7a2401f7eed517d54a7a4f5d1c1869753cb99018df1c2159c761d9f33483a6
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Node 24 strips types at runtime and does not report type errors, so `yarn types` (`tsc --noEmit`) now runs as a lint task. That check is scoped to `.ts` files.

>Convert `@taskcluster/lib-iterate` from JavaScript to TypeScript, run natively on Node 24 type stripping.
>
>Run `yarn types` (`tsc --noEmit`) in CI with TypeScript 7. Node type stripping does not type-check, so this is the check that reports type errors.