### PR TITLE
fix(cloudbuild): use updated gcp package names and keyring setup

### DIFF
--- a/changelog/a6ZvwxeQRtyXXwtKfTyqqA.md
+++ b/changelog/a6ZvwxeQRtyXXwtKfTyqqA.md
@@ -1,0 +1,6 @@
+audience: developers
+level: silent
+---
+The Cloud Build deploy image now installs the Google Cloud CLI using the current apt package names and keyring setup. The renamed `google-cloud-cli-gke-gcloud-auth-plugin` package replaces the removed `google-cloud-sdk-gke-gcloud-auth-plugin`.
+
+Upgrades to the latest stable `kubectl` version (v1.37.0).

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -44,12 +44,11 @@ steps:
       RUN curl https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
       RUN curl -LO "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl"
       RUN install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl
-      RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] http://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list
-      RUN curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key --keyring /usr/share/keyrings/cloud.google.gpg add -
-      RUN apt-get update -y && apt-get install google-cloud-cli google-cloud-sdk-gke-gcloud-auth-plugin -y
+      RUN apt-get update -y && apt-get install -y ca-certificates gnupg
+      RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list && curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | gpg --dearmor -o /usr/share/keyrings/cloud.google.gpg && apt-get update -y && apt-get install google-cloud-cli google-cloud-cli-gke-gcloud-auth-plugin -y
       EOF
     env:
-      - KUBECTL_VERSION=v1.35.0
+      - KUBECTL_VERSION=v1.37.0
   - name: bash
     args:
       - '-c'


### PR DESCRIPTION
Installation commands come from
https://docs.cloud.google.com/sdk/docs/install-sdk#deb

Cloudbuild was failing at the build deploy image step due to: "Package google-cloud-sdk-gke-gcloud-auth-plugin is not available, but is referred to by another package."

Example failure here https://github.com/taskcluster/taskcluster/runs/100670010508.

>The Cloud Build deploy image now installs the Google Cloud CLI using the current apt package names and keyring setup. The renamed `google-cloud-cli-gke-gcloud-auth-plugin` package replaces the removed `google-cloud-sdk-gke-gcloud-auth-plugin`.
>
>Upgrades to the latest stable `kubectl` version (v1.37.0).