### PR TITLE
Bug 2069456 - Use safefs when reading/writing during command preparation on windows workers

### DIFF
--- a/changelog/bug-2069456-1.md
+++ b/changelog/bug-2069456-1.md
@@ -1,0 +1,5 @@
+audience: worker-deployers
+level: patch
+reference: bug 2069456
+---
+On Windows multiuser workers, command environment read by generic-worker from the task directory will now refuse to follow links.

--- a/changelog/bug-2069456.md
+++ b/changelog/bug-2069456.md
@@ -1,0 +1,5 @@
+audience: worker-deployers
+level: patch
+reference: bug 2069456
+---
+On Windows multiuser workers, command scripts written by generic-worker into the task directory will now refuse to follow links.

--- a/workers/generic-worker/multiuser_windows.go
+++ b/workers/generic-worker/multiuser_windows.go
@@ -130,7 +130,7 @@ func (task *TaskRun) prepareCommand(index int) *CommandExecutionError {
 
 		// Otherwise get the env from the previous command
 	} else {
-		envFile, err := os.Open(env)
+		envFile, err := safefs.OpenExistingReadonly(env)
 		if err != nil {
 			panic(fmt.Errorf("could not read from env file %v\n%v", env, err))
 		}
@@ -144,12 +144,11 @@ func (task *TaskRun) prepareCommand(index int) *CommandExecutionError {
 			panic(err)
 		}
 
-		dirBytes, err := os.ReadFile(dir)
-		dirString := strings.SplitN(strings.ReplaceAll(string(dirBytes), "\r\n", "\n"), "\n", 2)[0]
-
+		dirBytes, err := safefs.ReadFile(dir)
 		if err != nil {
 			panic(fmt.Errorf("could not read directory location from file %v\n%v", dir, err))
 		}
+		dirString := strings.SplitN(strings.ReplaceAll(string(dirBytes), "\r\n", "\n"), "\n", 2)[0]
 
 		contents += "cd \"" + dirString + "\"\r\n"
 	}

--- a/workers/generic-worker/multiuser_windows.go
+++ b/workers/generic-worker/multiuser_windows.go
@@ -182,7 +182,7 @@ func (task *TaskRun) prepareCommand(index int) *CommandExecutionError {
 	contents += "exit /b %tcexitcode%\r\n"
 
 	// now generate the .bat script that runs all of this
-	err := os.WriteFile(
+	err := safefs.WriteFile(
 		wrapper,
 		[]byte(contents),
 		0755, // note this is mostly ignored on windows
@@ -197,7 +197,7 @@ func (task *TaskRun) prepareCommand(index int) *CommandExecutionError {
 		task.Payload.Command[index],
 	}, "\r\n"))
 
-	err = os.WriteFile(
+	err = safefs.WriteFile(
 		script,
 		fileContents,
 		0755, // note this is mostly ignored on windows


### PR DESCRIPTION
This is fairly trivial since safefs already had the required primitives