### PR TITLE
Bug 2069332 - Don't take artifact source path from the task user's stdout

### DIFF
--- a/changelog/bug-2069332-1.md
+++ b/changelog/bug-2069332-1.md
@@ -1,0 +1,7 @@
+audience: users
+level: major
+reference: bug 2069332
+---
+When uploading an optional artifact, if it's not readable (or encounters any
+unreadable file for directory artifacts), the task will now fail instead of
+silently omitting that file.

--- a/changelog/bug-2069332.md
+++ b/changelog/bug-2069332.md
@@ -1,0 +1,10 @@
+audience: worker-deployers
+level: major
+reference: bug 2069456
+---
+When uploading artifacts, Generic Worker multiuser engine will now create
+temporary files as the worker user (`root`/`LocalSystem`) and stream content
+into them as the task user.
+
+The internal `generic-worker copy-to-temp-file` command has been replaced with
+`generic-worker cat-file`

--- a/ui/docs/reference/workers/generic-worker/usage.mdx
+++ b/ui/docs/reference/workers/generic-worker/usage.mdx
@@ -20,7 +20,7 @@ and reports back results to the queue.
                                             [--worker-runner-protocol-pipe PIPE]
     generic-worker show-payload-schema
     generic-worker new-ed25519-keypair      --file ED25519-PRIVATE-KEY-FILE
-    generic-worker copy-to-temp-file        --copy-file COPY-FILE
+    generic-worker cat-file                 --cat-file CAT-FILE
     generic-worker create-file              --create-file CREATE-FILE
     generic-worker create-dir               --create-dir CREATE-DIR
     generic-worker unarchive                --archive-src ARCHIVE-SRC --archive-dst ARCHIVE-DST --archive-fmt ARCHIVE-FMT
@@ -43,9 +43,8 @@ and reports back results to the queue.
                                             compliant private/public key pair. The public
                                             key will be written to stdout and the private
                                             key will be written to the specified file.
-    copy-to-temp-file                       This will copy the specified file to a temporary
-                                            location and will return the temporary file path
-                                            to stdout. Intended for internal use.
+    cat-file                                This will write the contents of the specified
+                                            file to stdout. Intended for internal use.
     create-file                             This will create a file at the specified path.
                                             Intended for internal use.
     create-dir                              This will create a directory (including missing
@@ -74,7 +73,7 @@ and reports back results to the queue.
                                             to. The parent directory must already exist.
                                             If the file exists it will be overwritten,
                                             otherwise it will be created.
-    --copy-file COPY-FILE                   The path to the file to copy.
+    --cat-file CAT-FILE                     The path to the file to write to stdout.
     --create-file CREATE-FILE               The path to the file to create.
     --create-dir CREATE-DIR                 The path to the directory to create.
     --archive-src ARCHIVE-SRC               The path to the archive file to unarchive.
@@ -397,7 +396,7 @@ and reports back results to the queue.
            spot termination notice, and therefore has shut down.
     73     The config provided to the worker is invalid.
     75     Not able to create an ed25519 key pair.
-    76     Not able to copy --copy-file to a temporary file.
+    76     Not able to write --cat-file to stdout.
     77     Not able to apply required file access permissions to the generic-worker config
            file so that task users can't read from or write to it.
     78     Not able to connect to --worker-runner-protocol-pipe.

--- a/workers/generic-worker/CLAUDE.md
+++ b/workers/generic-worker/CLAUDE.md
@@ -163,7 +163,7 @@ Features implement the `Feature` / `TaskFeature` interfaces:
 Generic worker has several subcommands used internally by the multiuser engine:
 - `generic-worker create-file --create-file <path>` — create a file as the task user
 - `generic-worker create-dir --create-dir <path>` — create a directory as the task user
-- `generic-worker copy-to-temp-file --copy-file <path>` — copy file to task user's temp dir
+- `generic-worker cat-file --cat-file <path>` — write the contents of a file to stdout as the task user
 - `generic-worker unarchive --archive-src <src> --archive-dst <dst> --archive-fmt <fmt>` — extract archive
 
 ## Generic Worker Validation Checklist

--- a/workers/generic-worker/README.md
+++ b/workers/generic-worker/README.md
@@ -21,7 +21,7 @@ and reports back results to the queue.
                                             [--worker-runner-protocol-pipe PIPE]
     generic-worker show-payload-schema
     generic-worker new-ed25519-keypair      --file ED25519-PRIVATE-KEY-FILE
-    generic-worker copy-to-temp-file        --copy-file COPY-FILE
+    generic-worker cat-file                 --cat-file CAT-FILE
     generic-worker create-file              --create-file CREATE-FILE
     generic-worker create-dir               --create-dir CREATE-DIR
     generic-worker unarchive                --archive-src ARCHIVE-SRC --archive-dst ARCHIVE-DST --archive-fmt ARCHIVE-FMT
@@ -44,9 +44,8 @@ and reports back results to the queue.
                                             compliant private/public key pair. The public
                                             key will be written to stdout and the private
                                             key will be written to the specified file.
-    copy-to-temp-file                       This will copy the specified file to a temporary
-                                            location and will return the temporary file path
-                                            to stdout. Intended for internal use.
+    cat-file                                This will write the contents of the specified
+                                            file to stdout. Intended for internal use.
     create-file                             This will create a file at the specified path.
                                             Intended for internal use.
     create-dir                              This will create a directory (including missing
@@ -75,7 +74,7 @@ and reports back results to the queue.
                                             to. The parent directory must already exist.
                                             If the file exists it will be overwritten,
                                             otherwise it will be created.
-    --copy-file COPY-FILE                   The path to the file to copy.
+    --cat-file CAT-FILE                     The path to the file to write to stdout.
     --create-file CREATE-FILE               The path to the file to create.
     --create-dir CREATE-DIR                 The path to the directory to create.
     --archive-src ARCHIVE-SRC               The path to the archive file to unarchive.
@@ -398,7 +397,7 @@ and reports back results to the queue.
            spot termination notice, and therefore has shut down.
     73     The config provided to the worker is invalid.
     75     Not able to create an ed25519 key pair.
-    76     Not able to copy --copy-file to a temporary file.
+    76     Not able to write --cat-file to stdout.
     77     Not able to apply required file access permissions to the generic-worker config
            file so that task users can't read from or write to it.
     78     Not able to connect to --worker-runner-protocol-pipe.

--- a/workers/generic-worker/artifact_feature.go
+++ b/workers/generic-worker/artifact_feature.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"mime"
 	"os"
@@ -111,12 +112,30 @@ func (atf *ArtifactTaskFeature) Stop(err *ExecutionErrors) {
 				task.Warnf("Not uploading artifact %v found in task.payload.artifacts section, since this will be uploaded later by %v", taskArtifact.Base().Name, feature)
 				return nil
 			}
+
+			// Read the content *before* telling the queue the artifact
+			// exists, so that a file the task user cannot read is published
+			// as an error artifact rather than as a failed upload.
+			defer taskArtifact.DiscardContent()
+			if e := taskArtifact.PrepareContent(); e != nil {
+				if _, ok := errors.AsType[artifacts.ContentError](e); !ok {
+					uploadErrChan <- executionError(internalError, errored, fmt.Errorf("could not copy artifact %v to temp directory: %w", taskArtifact.Base().Name, e))
+					return nil
+				}
+				taskArtifact = &artifacts.ErrorArtifact{
+					BaseArtifact: taskArtifact.Base(),
+					Message:      fmt.Sprintf("Couldn't read file '%s': %v", taskArtifact.SourcePath(), e),
+					Reason:       "file-not-readable-on-worker",
+					Path:         taskArtifact.SourcePath(),
+				}
+			}
+
 			e := task.uploadArtifact(taskArtifact)
 			errArtifact, isErrArtifact := taskArtifact.(*artifacts.ErrorArtifact)
 			// An artifact we never got readable content for is published as an
 			// error artifact. Optional means we're fine with the file not
 			// existing, not that we're fine with failing to upload content
-			if isErrArtifact && errArtifact.Optional {
+			if isErrArtifact && errArtifact.Optional && errArtifact.Reason != "file-not-readable-on-worker" {
 				return nil
 			}
 
@@ -255,14 +274,13 @@ func (atf *ArtifactTaskFeature) FindArtifacts() {
 	atf.artifacts = payloadArtifacts
 }
 
-// File should be resolved as an S3Artifact if file exists as file and is
-// readable, otherwise i) if it does not exist as a "file-missing-on-worker" ErrorArtifact,
-// or ii) if it cannot be read by the task user, as a "file-not-readable-on-worker" ErrorArtifact,
-// otherwise if it exists as a directory, as an "invalid-resource-on-worker" ErrorArtifact.
-// A directory should resolve as `nil` if directory exists as directory and is readable,
-// otherwise i) if it does not exist or ii) cannot be read, as a "file-missing-on-worker"
-// ErrorArtifact, otherwise if it exists as a file, as
-// "invalid-resource-on-worker" ErrorArtifact
+// File should be resolved as an S3Artifact if file exists as a file, otherwise
+// i) if it does not exist as a "file-missing-on-worker" ErrorArtifact,
+// otherwise if it exists as a directory, as an "invalid-resource-on-worker"
+// ErrorArtifact. A directory should resolve as `nil` if directory exists as
+// directory and is readable, otherwise i) if it does not exist or ii) cannot
+// be read, as a "file-missing-on-worker" ErrorArtifact, otherwise if it exists
+// as a file, as "invalid-resource-on-worker" ErrorArtifact
 // TODO: need to also handle "too-large-file-on-worker"
 func resolve(base *artifacts.BaseArtifact, artifactType, path, contentType, contentEncoding string, pd *process.PlatformData, taskDir string) artifacts.TaskArtifact {
 	fullPath := fileutil.AbsFrom(taskDir, path)
@@ -311,16 +329,6 @@ func resolve(base *artifacts.BaseArtifact, artifactType, path, contentType, cont
 			BaseArtifact: base,
 			Message:      fmt.Sprintf("File artifact '%s' exists but is not a regular file (%v)", fullPath, fileinfo.Mode().Type()),
 			Reason:       "invalid-resource-on-worker",
-			Path:         path,
-		}
-	}
-
-	tempPath, err := copyToTempFileAsTaskUser(fullPath, pd, taskDir)
-	if err != nil {
-		return &artifacts.ErrorArtifact{
-			BaseArtifact: base,
-			Message:      fmt.Sprintf("Could not copy file '%s' to temporary location as task user: %v", fullPath, err),
-			Reason:       "file-not-readable-on-worker",
 			Path:         path,
 		}
 	}
@@ -386,7 +394,7 @@ func resolve(base *artifacts.BaseArtifact, artifactType, path, contentType, cont
 			contentEncoding = "gzip"
 		}
 	}
-	return createDataArtifact(base, fullPath, tempPath, contentType, contentEncoding)
+	return createDataArtifact(base, fullPath, taskUserContentSource(fullPath, pd, taskDir), contentType, contentEncoding)
 }
 
 // The Queue expects paths to use a forward slash, so let's make sure we have a

--- a/workers/generic-worker/artifacts.go
+++ b/workers/generic-worker/artifacts.go
@@ -6,17 +6,13 @@ import (
 	"log"
 	"net"
 	"net/url"
-	"os"
-	"runtime"
 	"strconv"
-	"strings"
 
 	"github.com/taskcluster/httpbackoff/v3"
 	tcurls "github.com/taskcluster/taskcluster-lib-urls"
 	tcclient "github.com/taskcluster/taskcluster/v108/clients/client-go"
 	"github.com/taskcluster/taskcluster/v108/clients/client-go/tcqueue"
 	"github.com/taskcluster/taskcluster/v108/workers/generic-worker/artifacts"
-	"github.com/taskcluster/taskcluster/v108/workers/generic-worker/process"
 )
 
 var (
@@ -38,42 +34,41 @@ var (
 func createDataArtifact(
 	base *artifacts.BaseArtifact,
 	path string,
-	contentPath string,
+	content artifacts.ContentSource,
 	contentType string,
 	contentEncoding string,
 ) artifacts.TaskArtifact {
-	var contentLength int64
-	if info, err := os.Stat(contentPath); err == nil {
-		contentLength = info.Size()
-	}
 	if config.CreateObjectArtifacts {
 		// note that contentEncoding is currently ignored for object artifacts
 		return &artifacts.ObjectArtifact{
-			BaseArtifact:  base,
-			Path:          path,
-			ContentPath:   contentPath,
-			ContentType:   contentType,
-			ContentLength: contentLength,
+			BaseArtifact: base,
+			Path:         path,
+			Content:      content,
+			ContentType:  contentType,
 		}
 	}
 
 	return &artifacts.S3Artifact{
 		BaseArtifact:    base,
 		Path:            path,
-		ContentPath:     contentPath,
+		Content:         content,
 		ContentType:     contentType,
 		ContentEncoding: contentEncoding,
-		ContentLength:   contentLength,
 	}
 }
 
-func (task *TaskRun) uploadLog(name, path string) *CommandExecutionError {
-	contentPath, err := safeReservedCopy(path)
-	if err != nil {
-		return executionError(internalError, errored, fmt.Errorf("could not read reserved artifact %v: %w", path, err))
+// uploadReservedArtifact uploads an artifact the worker created, reading it
+// as the worker user.
+func (task *TaskRun) uploadReservedArtifact(artifact artifacts.TaskArtifact) *CommandExecutionError {
+	defer artifact.DiscardContent()
+	if err := artifact.PrepareContent(); err != nil {
+		return executionError(internalError, errored, fmt.Errorf("could not read reserved artifact %v: %w", artifact.SourcePath(), err))
 	}
-	defer os.Remove(contentPath)
-	return task.uploadArtifact(
+	return task.uploadArtifact(artifact)
+}
+
+func (task *TaskRun) uploadLog(name, path string) *CommandExecutionError {
+	return task.uploadReservedArtifact(
 		createDataArtifact(
 			&artifacts.BaseArtifact{
 				Name: name,
@@ -81,7 +76,7 @@ func (task *TaskRun) uploadLog(name, path string) *CommandExecutionError {
 				Expires: task.Definition.Expires,
 			},
 			path,
-			contentPath,
+			reservedContentSource(path),
 			"text/plain; charset=utf-8",
 			"gzip",
 		),
@@ -173,26 +168,4 @@ func (task *TaskRun) classifyCreateArtifactError(artifact artifacts.TaskArtifact
 	default:
 		panic(fmt.Errorf("WORKER EXCEPTION due to non-recoverable error when requesting url from queue to upload artifact to: %#v", t))
 	}
-}
-
-func copyToTempFileAsTaskUser(filePath string, pd *process.PlatformData, taskDir string) (tempFilePath string, err error) {
-	tempFilePath, err = gwCopyToTempFile(filePath, pd, taskDir)
-
-	if runtime.GOOS == "windows" {
-		// Windows syscall logs are sent to stdout, even though the code appears
-		// to send to stderr through the log package.
-		// TODO: Figure out why this is the case and remove this hack.
-		// https://github.com/taskcluster/taskcluster/issues/6677
-		//
-		// We need to get the filepath from the final line of output.
-		//
-		// Example output:
-		// 2023/11/07 19:56:06Z Making system call GetProfilesDirectoryW with args: [C0000C15F0 C00027E980]
-		// 2023/11/07 19:56:06Z   Result: 1 0 The operation completed successfully.
-		// C:\Windows\SystemTemp\TestPrivilegedFileUpload664016823956663638
-		outputLines := strings.Split(tempFilePath, "\n")
-		tempFilePath = strings.TrimSpace(outputLines[len(outputLines)-1])
-	}
-
-	return
 }

--- a/workers/generic-worker/artifacts/artifacts.go
+++ b/workers/generic-worker/artifacts/artifacts.go
@@ -1,25 +1,31 @@
 package artifacts
 
 import (
+	"io"
 	"os"
 
 	tcclient "github.com/taskcluster/taskcluster/v108/clients/client-go"
 	"github.com/taskcluster/taskcluster/v108/internal/mocktc/tc"
 	"github.com/taskcluster/taskcluster/v108/workers/generic-worker/gwconfig"
-	"github.com/taskcluster/taskcluster/v108/workers/generic-worker/safefs"
 )
 
-// Opens the content of an artifact for uploading. This is safe to use whether
-// we're uploading the task artifact directly or a copy made by the taks user
-// as it'll refuse following any link in the latter case
-func openContent(contentPath, path string) (*os.File, error) {
-	if contentPath == path {
-		return os.Open(contentPath)
-	}
-	return safefs.OpenExistingReadonly(contentPath)
-}
-
 type (
+	// ContentSource streams an artifact's content it opens as the task user.
+	ContentSource interface {
+		WriteContent(w io.Writer) (int64, error)
+	}
+
+	// OpenableContentSource should only be implemented when the worker can open
+	// the content itself safely. It is used to upload artifacts without a
+	// staging copy which means the file is read as the worker user. This
+	// should only ever be used by the insecure engine or for artifacts that
+	// the worker creates itself and open through safefs to avoid a task
+	// redirecting it.
+	OpenableContentSource interface {
+		ContentSource
+		OpenForUpload() (*os.File, error)
+	}
+
 	// TaskArtifact is the interface that all artifact types implement
 	// (S3Artifact, RedirectArtifact, ErrorArtifact), for publishing artifacts
 	// according to the tcqueue.CreateArtifact docs.
@@ -67,6 +73,17 @@ type (
 		// Base returns a *BaseArtifact which stores the properties common to
 		// all implementations
 		Base() *BaseArtifact
+
+		// SourcePath is the path the content was declared from, or "" for
+		// artifact types that have no content.
+		SourcePath() string
+
+		// PrepareContent reads the content into a temporary file owned by the
+		// worker, unless it can be uploaded from where it already is.
+		PrepareContent() error
+
+		// DiscardContent closes and removes what PrepareContent opened.
+		DiscardContent()
 	}
 
 	// Common properties across all implementations.
@@ -80,6 +97,19 @@ type (
 	}
 )
 
+// ContentError distinguishes a failure to read an artifact's content, which
+// the task is responsible for from a failure to copy it on the worker,
+// which it isn't.
+type ContentError struct{ Err error }
+
+func (e ContentError) Error() string {
+	return e.Err.Error()
+}
+
+func (e ContentError) Unwrap() error {
+	return e.Err
+}
+
 func (base *BaseArtifact) Base() *BaseArtifact {
 	return base
 }
@@ -92,3 +122,13 @@ func (base *BaseArtifact) Base() *BaseArtifact {
 func (*BaseArtifact) FinishArtifact(response any, queue tc.Queue, taskID, runID, name string) error {
 	return nil
 }
+
+func (*BaseArtifact) SourcePath() string {
+	return ""
+}
+
+func (*BaseArtifact) PrepareContent() error {
+	return nil
+}
+
+func (*BaseArtifact) DiscardContent() {}

--- a/workers/generic-worker/artifacts/error.go
+++ b/workers/generic-worker/artifacts/error.go
@@ -26,6 +26,10 @@ func (errArtifact *ErrorArtifact) ProcessResponse(response any, logger Logger, s
 	return nil
 }
 
+func (errArtifact *ErrorArtifact) SourcePath() string {
+	return errArtifact.Path
+}
+
 func (errArtifact *ErrorArtifact) RequestObject() any {
 	return &tcqueue.ErrorArtifactRequest{
 		Expires:     errArtifact.Expires,

--- a/workers/generic-worker/artifacts/object.go
+++ b/workers/generic-worker/artifacts/object.go
@@ -2,6 +2,7 @@ package artifacts
 
 import (
 	"fmt"
+	"io"
 	"log"
 	"os"
 	"time"
@@ -16,16 +17,63 @@ type ObjectArtifact struct {
 	*BaseArtifact
 	// Path is the filename of the file declared in the task payload.
 	Path string
-	// ContentPath is the filename of the file containing the data
-	// for this artifact. ContentPath may be equal to Path, or,
-	// in the case where a temporary file is created, it may be different.
-	// ContentPath will always be read from when uploading the artifact.
-	ContentPath string
+	// Content streams the data for this artifact.
+	Content ContentSource
 	// ContentType is used in the Content-Type header.
 	ContentType string
 	// ContentLength is the original file size in bytes, before any
 	// encoding (e.g. gzip). Sent to the queue for monitoring purposes.
 	ContentLength int64
+	body          *os.File
+	stagedPath    string
+}
+
+func (a *ObjectArtifact) SourcePath() string {
+	return a.Path
+}
+
+func (a *ObjectArtifact) PrepareContent() (err error) {
+	defer func() {
+		if err != nil {
+			a.DiscardContent()
+		}
+	}()
+	if o, ok := a.Content.(OpenableContentSource); ok {
+		a.body, err = o.OpenForUpload()
+	} else {
+		err = a.stageContent()
+	}
+	if err != nil {
+		return err
+	}
+	info, err := a.body.Stat()
+	if err != nil {
+		return err
+	}
+	a.ContentLength = info.Size()
+	return nil
+}
+
+func (a *ObjectArtifact) stageContent() error {
+	body, err := os.CreateTemp("", "artifact-")
+	if err != nil {
+		return err
+	}
+	a.body = body
+	a.stagedPath = body.Name()
+	_, err = a.Content.WriteContent(body)
+	return err
+}
+
+func (a *ObjectArtifact) DiscardContent() {
+	if a.body != nil {
+		a.body.Close()
+		a.body = nil
+	}
+	if a.stagedPath != "" {
+		os.Remove(a.stagedPath)
+		a.stagedPath = ""
+	}
 }
 
 func (a *ObjectArtifact) RequestObject() any {
@@ -44,9 +92,6 @@ func (a *ObjectArtifact) ResponseObject() any {
 func (a *ObjectArtifact) ProcessResponse(resp any, logger Logger, serviceFactory tc.ServiceFactory, config *gwconfig.Config) (err error) {
 	response := resp.(*tcqueue.ObjectArtifactResponse)
 	log.Printf("Uploading artifact %v from file %v with content type %q and expiry %v", a.Name, a.Path, a.ContentType, a.Expires)
-	if a.ContentPath != a.Path {
-		defer os.Remove(a.ContentPath)
-	}
 	creds := tcclient.Credentials{
 		ClientID:    response.Credentials.ClientID,
 		AccessToken: response.Credentials.AccessToken,
@@ -54,14 +99,7 @@ func (a *ObjectArtifact) ProcessResponse(resp any, logger Logger, serviceFactory
 	}
 	objsvc := serviceFactory.Object(&creds, config.RootURL)
 
-	content, err := openContent(a.ContentPath, a.Path)
-	if err != nil {
-		return err
-	}
-	defer content.Close()
-
-	info, err := content.Stat()
-	if err != nil {
+	if _, err = a.body.Seek(0, io.SeekStart); err != nil {
 		return err
 	}
 
@@ -69,10 +107,10 @@ func (a *ObjectArtifact) ProcessResponse(resp any, logger Logger, serviceFactory
 		response.ProjectID,
 		response.Name,
 		a.ContentType,
-		info.Size(),
+		a.ContentLength,
 		time.Time(a.Expires),
 		response.UploadID,
-		content,
+		a.body,
 	)
 	if err != nil {
 		return err

--- a/workers/generic-worker/artifacts/s3.go
+++ b/workers/generic-worker/artifacts/s3.go
@@ -23,30 +23,52 @@ type S3Artifact struct {
 	*BaseArtifact
 	// Path is the filename of the file declared in the task payload.
 	Path string
-	// ContentPath is the filename of the file containing the data
-	// for this artifact. ContentPath may be equal to Path, or,
-	// in the case where a temporary file is created, it may be different.
-	// ContentPath will always be read from when uploading the artifact.
-	ContentPath     string
+	// Content streams the data for this artifact.
+	Content         ContentSource
 	ContentEncoding string
 	ContentType     string
 	// ContentLength is the original file size in bytes, before any
 	// encoding (e.g. gzip). Sent to the queue for monitoring purposes.
 	ContentLength int64
+	bodyPath      string
+	bodySHA256    string
 }
 
-// createTempFileForPUTBody gzip-compresses the file at Path and
-// writes it to a temporary file in the same directory. The file path of the
-// generated temporary file is returned, along with the sha256 of the content
-// that went into it. It is the responsibility of the caller to delete the
-// temporary file.
-func (s3Artifact *S3Artifact) createTempFileForPUTBody() (string, string) {
-	baseName := filepath.Base(s3Artifact.Path)
-	tmpFile, err := os.CreateTemp("", baseName)
-	if err != nil {
-		panic(err)
+func (s3Artifact *S3Artifact) SourcePath() string {
+	return s3Artifact.Path
+}
+
+func (s3Artifact *S3Artifact) PrepareContent() (err error) {
+	s3Artifact.bodyPath, s3Artifact.bodySHA256, s3Artifact.ContentLength, err = s3Artifact.createTempFileForPUTBody()
+	return err
+}
+
+func (s3Artifact *S3Artifact) DiscardContent() {
+	if s3Artifact.bodyPath != "" {
+		os.Remove(s3Artifact.bodyPath)
+		s3Artifact.bodyPath = ""
+		s3Artifact.bodySHA256 = ""
 	}
-	defer tmpFile.Close()
+}
+
+// Streams the artifact content into a temporary file owned by the worker,
+// applying ContentEncoding on the way. The path of the temporary file is
+// returned, alongside the sha256 and the length of the uncompressed content
+// that got written.
+func (s3Artifact *S3Artifact) createTempFileForPUTBody() (path string, sha256sum string, contentLength int64, err error) {
+	baseName := filepath.Base(s3Artifact.Path)
+	tmpFile, err := os.CreateTemp("", "artifact-")
+	if err != nil {
+		return
+	}
+	defer func() {
+		if err != nil {
+			tmpFile.Close()
+			if rmErr := os.Remove(tmpFile.Name()); rmErr != nil {
+				log.Printf("WARNING: could not remove temporary file %v: %v", tmpFile.Name(), rmErr)
+			}
+		}
+	}()
 	var target io.Writer = tmpFile
 	var gzipLogWriter *gzip.Writer
 	if s3Artifact.ContentEncoding == "gzip" {
@@ -54,54 +76,25 @@ func (s3Artifact *S3Artifact) createTempFileForPUTBody() (string, string) {
 		gzipLogWriter.Name = baseName
 		target = gzipLogWriter
 	}
-	source, err := openContent(s3Artifact.ContentPath, s3Artifact.Path)
-	if err != nil {
-		panic(err)
-	}
-	defer source.Close()
 	hasher := sha256.New()
-	if _, err := io.Copy(io.MultiWriter(target, hasher), source); err != nil {
-		panic(err)
+	if contentLength, err = s3Artifact.Content.WriteContent(io.MultiWriter(target, hasher)); err != nil {
+		return
 	}
 	if gzipLogWriter != nil {
-		if err := gzipLogWriter.Close(); err != nil {
-			panic(err)
+		if err = gzipLogWriter.Close(); err != nil {
+			return
 		}
 	}
-	if err := tmpFile.Close(); err != nil {
-		panic(err)
+	if err = tmpFile.Close(); err != nil {
+		return
 	}
-	return tmpFile.Name(), hex.EncodeToString(hasher.Sum(nil))
+	return tmpFile.Name(), hex.EncodeToString(hasher.Sum(nil)), contentLength, nil
 }
 
 func (s3Artifact *S3Artifact) ProcessResponse(resp any, logger Logger, serviceFactory tc.ServiceFactory, config *gwconfig.Config) (err error) {
 	response := resp.(*tcqueue.S3ArtifactResponse)
 
 	log.Printf("Uploading artifact %v from file %v with content encoding %q, mime type %q and expiry %v", s3Artifact.Name, s3Artifact.Path, s3Artifact.ContentEncoding, s3Artifact.ContentType, s3Artifact.Expires)
-
-	// Artifacts declared in payload are copied to a temp file
-	// as task user to ensure they are readable by task user.
-	// Reserved artifacts (created by task features) are not,
-	// since their file location is not user-defined, and task
-	// user cannot replace their content with symbolic links.
-	// Thus reserved (trusted) artifacts have Path == ContentPath.
-	tempFileCreated := s3Artifact.Path != s3Artifact.ContentPath
-	if tempFileCreated {
-		defer os.Remove(s3Artifact.ContentPath)
-	}
-
-	var transferContentFile string
-	var contentSHA256 string
-	hashDuringPUT := false
-	if !tempFileCreated || s3Artifact.ContentEncoding == "gzip" {
-		log.Printf("Copying %v to temp file...", s3Artifact.ContentPath)
-		transferContentFile, contentSHA256 = s3Artifact.createTempFileForPUTBody()
-		defer os.Remove(transferContentFile)
-	} else {
-		log.Printf("Not copying %v to temp file", s3Artifact.ContentPath)
-		transferContentFile = s3Artifact.ContentPath
-		hashDuringPUT = true
-	}
 
 	// perform http PUT to upload to S3...
 	httpClient := &http.Client{}
@@ -115,11 +108,7 @@ func (s3Artifact *S3Artifact) ProcessResponse(resp any, logger Logger, serviceFa
 	}
 	httpCall := func() (putResp *http.Response, tempError error, permError error) {
 		var transferContent *os.File
-		if transferContentFile == s3Artifact.ContentPath {
-			transferContent, permError = openContent(s3Artifact.ContentPath, s3Artifact.Path)
-		} else {
-			transferContent, permError = os.Open(transferContentFile)
-		}
+		transferContent, permError = os.Open(s3Artifact.bodyPath)
 		if permError != nil {
 			return
 		}
@@ -131,14 +120,8 @@ func (s3Artifact *S3Artifact) ProcessResponse(resp any, logger Logger, serviceFa
 		}
 		transferContentLength := transferContentFileInfo.Size()
 
-		var body io.Reader = transferContent
-		hasher := sha256.New()
-		if hashDuringPUT {
-			body = io.TeeReader(transferContent, hasher)
-		}
-
 		var httpRequest *http.Request
-		httpRequest, permError = http.NewRequest("PUT", response.PutURL, body)
+		httpRequest, permError = http.NewRequest("PUT", response.PutURL, transferContent)
 		if permError != nil {
 			return
 		}
@@ -157,14 +140,11 @@ func (s3Artifact *S3Artifact) ProcessResponse(resp any, logger Logger, serviceFa
 			tempError = fmt.Errorf("S3 returned status code 400 which could be an intermittent issue - see https://bugzilla.mozilla.org/show_bug.cgi?id=1394557")
 			return
 		}
-		if hashDuringPUT {
-			contentSHA256 = hex.EncodeToString(hasher.Sum(nil))
-		}
 		return
 	}
 	putResp, putAttempts, err := httpbackoff.Retry(httpCall)
 	if err == nil {
-		s3Artifact.SHA256 = contentSHA256
+		s3Artifact.SHA256 = s3Artifact.bodySHA256
 	}
 	formattedUrl, formatURLErr := formatURL(response.PutURL)
 	if formatURLErr != nil {

--- a/workers/generic-worker/artifacts_insecure.go
+++ b/workers/generic-worker/artifacts_insecure.go
@@ -2,8 +2,34 @@
 
 package main
 
-import "github.com/taskcluster/taskcluster/v108/workers/generic-worker/process"
+import (
+	"io"
+	"os"
 
-func gwCopyToTempFile(filePath string, pd *process.PlatformData, taskDir string) (string, error) {
-	return filePath, nil
+	"github.com/taskcluster/taskcluster/v108/workers/generic-worker/artifacts"
+	"github.com/taskcluster/taskcluster/v108/workers/generic-worker/fileutil"
+	"github.com/taskcluster/taskcluster/v108/workers/generic-worker/process"
+)
+
+type taskUserFile string
+
+func taskUserContentSource(filePath string, _ *process.PlatformData, _ string) artifacts.ContentSource {
+	return taskUserFile(filePath)
+}
+
+func (f taskUserFile) OpenForUpload() (*os.File, error) {
+	file, err := fileutil.OpenRegularFile(string(f))
+	if err != nil {
+		return nil, artifacts.ContentError{Err: err}
+	}
+	return file, nil
+}
+
+func (f taskUserFile) WriteContent(w io.Writer) (int64, error) {
+	source, err := f.OpenForUpload()
+	if err != nil {
+		return 0, err
+	}
+	defer source.Close()
+	return io.Copy(w, source)
 }

--- a/workers/generic-worker/artifacts_multiuser.go
+++ b/workers/generic-worker/artifacts_multiuser.go
@@ -3,23 +3,69 @@
 package main
 
 import (
+	"bytes"
+	"errors"
 	"fmt"
+	"io"
+	"os/exec"
 	"strings"
 
+	"github.com/taskcluster/taskcluster/v108/workers/generic-worker/artifacts"
 	"github.com/taskcluster/taskcluster/v108/workers/generic-worker/process"
 	gwruntime "github.com/taskcluster/taskcluster/v108/workers/generic-worker/runtime"
 )
 
-func gwCopyToTempFile(filePath string, pd *process.PlatformData, taskDir string) (string, error) {
-	cmd, err := process.NewCommandNoOutputStreams([]string{gwruntime.GenericWorkerBinary(), "copy-to-temp-file", "--copy-file", filePath}, taskDir, []string{}, pd)
+type taskUserFile struct {
+	path    string
+	pd      *process.PlatformData
+	taskDir string
+}
+
+func taskUserContentSource(filePath string, pd *process.PlatformData, taskDir string) artifacts.ContentSource {
+	return taskUserFile{path: filePath, pd: pd, taskDir: taskDir}
+}
+
+func (f taskUserFile) WriteContent(w io.Writer) (int64, error) {
+	return catFileAsTaskUser(f.path, w, f.pd, f.taskDir)
+}
+
+func catFileAsTaskUser(filePath string, dest io.Writer, pd *process.PlatformData, taskDir string) (int64, error) {
+	cmd, err := process.NewCommandNoOutputStreams([]string{gwruntime.GenericWorkerBinary(), "cat-file", "--cat-file", filePath}, taskDir, []string{}, pd)
 	if err != nil {
-		return "", fmt.Errorf("failed to create new command to copy file %s to temporary location as task user: %v", filePath, err)
+		return 0, fmt.Errorf("failed to create new command to read file %s as task user: %v", filePath, err)
 	}
 
-	output, err := cmd.Output()
-	if err != nil {
-		return "", fmt.Errorf("failed to copy file %s to temporary location as task user: %v", filePath, err)
-	}
+	var stderr bytes.Buffer
+	out := &recordingWriter{Writer: dest}
+	cmd.Stdout = out
+	cmd.Stderr = &stderr
 
-	return strings.TrimSpace(string(output)), nil
+	if err := cmd.Run(); err != nil {
+		if out.err != nil {
+			return out.written, out.err
+		}
+		readErr := fmt.Errorf("failed to read file %s as task user: %v: %s", filePath, err, strings.TrimSpace(stderr.String()))
+
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) && exitErr.ExitCode() == int(CANT_CAT_FILE) {
+			return out.written, artifacts.ContentError{Err: readErr}
+		}
+		return out.written, readErr
+	}
+	return out.written, nil
+}
+
+type recordingWriter struct {
+	io.Writer
+	written int64
+	err     error
+}
+
+func (w *recordingWriter) Write(p []byte) (int, error) {
+	n, err := w.Writer.Write(p)
+	w.written += int64(n)
+	if err != nil {
+		w.err = err
+	}
+	return n, err
 }

--- a/workers/generic-worker/artifacts_multiuser_test.go
+++ b/workers/generic-worker/artifacts_multiuser_test.go
@@ -53,7 +53,10 @@ func TestPrivilegedFileUpload(t *testing.T) {
 	_ = submitAndAssert(t, td, payload, "failed", "failed")
 }
 
-func TestPrivilegedOptionalFileUploadDoesNotFailTest(t *testing.T) {
+func TestPrivilegedOptionalFileUploadFailsTask(t *testing.T) {
+	if os.Getenv("GW_IN_DOCKER") == "1" {
+		t.Skip("Skipping in Docker: file permission isolation requires a non-root environment")
+	}
 	setup(t)
 
 	tempFile, err := os.CreateTemp(testdataDir, t.Name())
@@ -87,7 +90,7 @@ func TestPrivilegedOptionalFileUploadDoesNotFailTest(t *testing.T) {
 	defaults.SetDefaults(&payload)
 	td := testTask(t)
 
-	_ = submitAndAssert(t, td, payload, "completed", "completed")
+	_ = submitAndAssert(t, td, payload, "failed", "failed")
 }
 
 func TestPrivilegedFileUploadAsCurrentUser(t *testing.T) {
@@ -130,4 +133,56 @@ func TestPrivilegedFileUploadAsCurrentUser(t *testing.T) {
 	)
 
 	_ = submitAndAssert(t, td, payload, "completed", "completed")
+}
+
+func TestPrivilegedFileInOptionalDirectoryArtifactFailsTask(t *testing.T) {
+	if os.Getenv("GW_IN_DOCKER") == "1" {
+		t.Skip("Skipping in Docker: file permission isolation requires a non-root environment")
+	}
+	setup(t)
+
+	tempDir, err := os.MkdirTemp(testdataDir, t.Name())
+	if err != nil {
+		t.Fatalf("Could not create temporary directory: %v", err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	makeDirWorldWritable(t, tempDir)
+	readableFile := filepath.Join(tempDir, "readable.txt")
+	if err := os.WriteFile(readableFile, []byte("banana"), 0644); err != nil {
+		t.Fatalf("Could not create readable file: %v", err)
+	}
+
+	unreadableFile := filepath.Join(tempDir, "unreadable.txt")
+	if err := os.WriteFile(unreadableFile, []byte("baguette"), 0644); err != nil {
+		t.Fatalf("Could not create unreadable file: %v", err)
+	}
+	if err := fileutil.SecureFiles(unreadableFile); err != nil {
+		t.Fatalf("Could not secure temporary file: %v", err)
+	}
+
+	expires := tcclient.Time(time.Now().Add(time.Minute * 30))
+
+	payload := GenericWorkerPayload{
+		Command:    helloGoodbye(),
+		MaxRunTime: 30,
+		Artifacts: []Artifact{
+			{
+				Path:     filepath.Join("../../../", filepath.Base(tempDir)),
+				Expires:  expires,
+				Type:     "directory",
+				Name:     fmt.Sprintf("public/build/%s", t.Name()),
+				Optional: true,
+			},
+		},
+	}
+	defaults.SetDefaults(&payload)
+
+	td := testTask(t)
+	taskID := submitAndAssert(t, td, payload, "failed", "failed")
+
+	readableArtifact := fmt.Sprintf("public/build/%s/readable.txt", t.Name())
+	if content := string(getArtifactContent(t, taskID, readableArtifact)); content != "banana" {
+		t.Fatalf("Artifact %v has content %q, expected \"banana\". Something must've gone horribly wrong", readableArtifact, content)
+	}
 }

--- a/workers/generic-worker/artifacts_test.go
+++ b/workers/generic-worker/artifacts_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"encoding/json"
 	"os"
 	"path/filepath"
@@ -54,14 +55,16 @@ func validateArtifacts(t *testing.T, payloadArtifacts []Artifact, expected []art
 	atf.FindArtifacts()
 	got := atf.artifacts
 
-	// remove the ContentPath field from the got artifacts, we can't
-	// compare it as it's non-deterministic
 	for _, a := range got {
+		if err := a.PrepareContent(); err != nil {
+			t.Fatalf("Could not prepare content of artifact %v: %v", a.Base().Name, err)
+		}
+		a.DiscardContent()
 		switch artifact := a.(type) {
 		case *artifacts.S3Artifact:
-			artifact.ContentPath = ""
+			artifact.Content = nil
 		case *artifacts.ObjectArtifact:
-			artifact.ContentPath = ""
+			artifact.Content = nil
 		}
 	}
 
@@ -1337,4 +1340,32 @@ func TestDirectoryArtifactUploadFromAbsolutePath(t *testing.T) {
 		},
 	}
 	expectedArtifacts.Validate(t, taskID, 0)
+}
+
+func TestBinaryFileArtifactUpload(t *testing.T) {
+	setup(t)
+
+	payload := GenericWorkerPayload{
+		Command:    copyTestdataFile("mozharness.zip"),
+		MaxRunTime: 30,
+		Artifacts: []Artifact{
+			{
+				Path: "mozharness.zip",
+				Type: "file",
+				Name: "public/mozharness.zip",
+			},
+		},
+	}
+	defaults.SetDefaults(&payload)
+	td := testTask(t)
+	taskID := submitAndAssert(t, td, payload, "completed", "completed")
+
+	expected, err := os.ReadFile(filepath.Join(testdataDir, "mozharness.zip"))
+	if err != nil {
+		t.Fatalf("Error reading source file: %v", err)
+	}
+	actual := getArtifactContent(t, taskID, "public/mozharness.zip")
+	if !bytes.Equal(expected, actual) {
+		t.Fatalf("Artifact content mismatch: expected %d bytes, got %d bytes", len(expected), len(actual))
+	}
 }

--- a/workers/generic-worker/chain_of_trust_feature.go
+++ b/workers/generic-worker/chain_of_trust_feature.go
@@ -3,6 +3,7 @@
 package main
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -211,20 +212,14 @@ func (feature *ChainOfTrustTaskFeature) Stop(err *ExecutionErrors) {
 		err.add(executionError(internalError, errored, fmt.Errorf("could not write ed25519 signature: %w", e)))
 		return
 	}
-	ed25519Content, cpErr := safeReservedCopy(ed25519SignedCert)
-	if cpErr != nil {
-		err.add(executionError(internalError, errored, fmt.Errorf("could not read ed25519 signature: %w", cpErr)))
-		return
-	}
-	defer os.Remove(ed25519Content)
-	err.add(feature.task.uploadArtifact(
+	err.add(feature.task.uploadReservedArtifact(
 		createDataArtifact(
 			&artifacts.BaseArtifact{
 				Name:    ed25519SignedCertName,
 				Expires: feature.task.TaskClaimResponse.Task.Expires,
 			},
 			ed25519SignedCert,
-			ed25519Content,
+			reservedContentSource(ed25519SignedCert),
 			"application/octet-stream",
 			"gzip",
 		),
@@ -252,18 +247,11 @@ func (cot *ChainOfTrustTaskFeature) MergeAdditionalData(certBytes []byte) (merge
 		return certBytes, nil
 	}
 
-	// Ensure task user can read the data (e.g. in case somebody creates a symbolic link to a json file owned by root)
-	tempPath, err := copyToTempFileAsTaskUser(additionalDataFile, cot.task.pd, cot.task.TaskDir())
-	if err != nil {
+	var additionalDataBuf bytes.Buffer
+	if _, err = catFileAsTaskUser(additionalDataFile, &additionalDataBuf, cot.task.pd, cot.task.TaskDir()); err != nil {
 		return
 	}
-	defer os.Remove(tempPath)
-
-	var additionalDataBytes []byte
-	additionalDataBytes, err = safefs.ReadFile(tempPath)
-	if err != nil {
-		return
-	}
+	additionalDataBytes := additionalDataBuf.Bytes()
 
 	initialCert := map[string]any{}
 	additionalData := map[string]any{}

--- a/workers/generic-worker/d2g_feature.go
+++ b/workers/generic-worker/d2g_feature.go
@@ -263,11 +263,10 @@ func (dtf *D2GTaskFeature) Start() *CommandExecutionError {
 		}
 
 		chainOfTrustAdditionalDataPath := filepath.Join(taskDir, "chain-of-trust-additional-data.json")
-		// 0644 (not 0600): the worker (root) writes this file, then
-		// the task user reads it via copy-to-temp-file when the
-		// chain-of-trust feature folds it into the signed cert. The
-		// task dir is already 0700 owned by the task user, so this
-		// file is not exposed beyond that boundary.
+		// 0644 (not 0600): the worker (root) writes this file, then the task
+		// user reads it via cat-file when the chain-of-trust feature folds it
+		// into the signed cert. The task dir is already 0700 owned by the task
+		// user, so this file is not exposed beyond that boundary.
 		err = safefs.WriteFile(chainOfTrustAdditionalDataPath, []byte(chainOfTrustAdditionalData), 0644)
 		if err != nil {
 			return executionError(internalError, errored, fmt.Errorf("[d2g] could not write chain of trust additional data file: %v", err))

--- a/workers/generic-worker/fileutil/fileutil.go
+++ b/workers/generic-worker/fileutil/fileutil.go
@@ -59,9 +59,25 @@ func CalculateSHA256(file string) (hash string, err error) {
 	return
 }
 
+func OpenRegularFile(src string) (*os.File, error) {
+	source, err := os.OpenFile(src, os.O_RDONLY|syscall.O_NONBLOCK, 0)
+	if err != nil {
+		return nil, err
+	}
+	sourceFileStat, err := source.Stat()
+	if err != nil {
+		source.Close()
+		return nil, err
+	}
+	if !sourceFileStat.Mode().IsRegular() {
+		source.Close()
+		return nil, fmt.Errorf("cannot read %s: it is not a regular file", src)
+	}
+	return source, nil
+}
+
 func Copy(dst, src string) (nBytes int64, err error) {
-	var source *os.File
-	source, err = os.OpenFile(src, os.O_RDONLY|syscall.O_NONBLOCK, 0)
+	source, err := OpenRegularFile(src)
 	if err != nil {
 		return
 	}
@@ -73,17 +89,7 @@ func Copy(dst, src string) (nBytes int64, err error) {
 	}
 	defer closeFile(source)
 
-	var sourceFileStat os.FileInfo
-	sourceFileStat, err = source.Stat()
-	if err != nil {
-		return
-	}
-	if !sourceFileStat.Mode().IsRegular() {
-		err = fmt.Errorf("cannot copy %s to %s: %s is not a regular file", src, dst, src)
-		return
-	}
-	var destination *os.File
-	destination, err = safefs.Create(dst, 0666)
+	destination, err := safefs.Create(dst, 0666)
 	if err != nil {
 		return
 	}
@@ -92,22 +98,15 @@ func Copy(dst, src string) (nBytes int64, err error) {
 	return
 }
 
-func CopyToTempFile(src string) (tempFilePath string, err error) {
-	baseName := filepath.Base(src)
-	var tempFile *os.File
-	tempFile, err = os.CreateTemp("", baseName)
+func CatFile(src string, dst io.Writer) error {
+	source, err := OpenRegularFile(src)
 	if err != nil {
-		return
+		return err
 	}
-	defer func() {
-		err2 := tempFile.Close()
-		if err == nil {
-			err = err2
-		}
-	}()
-	tempFilePath = tempFile.Name()
-	_, err = Copy(tempFilePath, src)
-	return
+	defer source.Close()
+
+	_, err = io.Copy(dst, source)
+	return err
 }
 
 func CreateFile(file string) (err error) {

--- a/workers/generic-worker/main.go
+++ b/workers/generic-worker/main.go
@@ -231,10 +231,9 @@ func main() {
 	case arguments["new-ed25519-keypair"]:
 		err := generateEd25519Keypair(arguments["--file"].(string))
 		exitOnError(CANT_CREATE_ED25519_KEYPAIR, err, "Error generating ed25519 keypair %v for worker", arguments["--file"].(string))
-	case arguments["copy-to-temp-file"]:
-		tempFilePath, err := fileutil.CopyToTempFile(arguments["--copy-file"].(string))
-		exitOnError(CANT_COPY_TO_TEMP_FILE, err, "Error copying file %v to temp file", arguments["--copy-file"].(string))
-		fmt.Println(tempFilePath)
+	case arguments["cat-file"]:
+		err := fileutil.CatFile(arguments["--cat-file"].(string), os.Stdout)
+		exitOnError(CANT_CAT_FILE, err, "Error writing file %v to stdout", arguments["--cat-file"].(string))
 	case arguments["create-file"]:
 		err := fileutil.CreateFile(arguments["--create-file"].(string))
 		exitOnError(CANT_CREATE_FILE, err, "Error creating file %v", arguments["--create-file"].(string))

--- a/workers/generic-worker/rdp_feature_windows.go
+++ b/workers/generic-worker/rdp_feature_windows.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net"
-	"os"
 	"path/filepath"
 	"time"
 
@@ -104,12 +103,7 @@ func (l *RDPTask) createRDPArtifact() *CommandExecutionError {
 func (l *RDPTask) uploadRDPArtifact() *CommandExecutionError {
 	taskDir := l.task.TaskDir()
 	rdpInfoFile := fileutil.AbsFrom(taskDir, rdpInfoPath)
-	contentPath, err := safeReservedCopy(rdpInfoFile)
-	if err != nil {
-		return executionError(internalError, errored, fmt.Errorf("could not read reserved artifact %v: %w", rdpInfoFile, err))
-	}
-	defer os.Remove(contentPath)
-	return l.task.uploadArtifact(
+	return l.task.uploadReservedArtifact(
 		createDataArtifact(
 			&artifacts.BaseArtifact{
 				Name: l.task.Payload.RdpInfo,
@@ -117,7 +111,7 @@ func (l *RDPTask) uploadRDPArtifact() *CommandExecutionError {
 				Expires: tcclient.Time(time.Now().Add(time.Hour * 24)),
 			},
 			rdpInfoFile,
-			contentPath,
+			reservedContentSource(rdpInfoFile),
 			"application/json",
 			"gzip",
 		),

--- a/workers/generic-worker/runtime.go
+++ b/workers/generic-worker/runtime.go
@@ -7,25 +7,17 @@ import (
 	"github.com/taskcluster/taskcluster/v108/workers/generic-worker/safefs"
 )
 
-func safeReservedCopy(path string) (string, error) {
-	src, err := safefs.OpenExistingReadonly(path)
-	if err != nil {
-		return "", err
-	}
-	defer src.Close()
+type reservedContentSource string
 
-	tmp, err := os.CreateTemp("", "reserved-artifact-")
+func (f reservedContentSource) OpenForUpload() (*os.File, error) {
+	return safefs.OpenExistingReadonly(string(f))
+}
+
+func (f reservedContentSource) WriteContent(w io.Writer) (int64, error) {
+	source, err := f.OpenForUpload()
 	if err != nil {
-		return "", err
+		return 0, err
 	}
-	if _, err := io.Copy(tmp, src); err != nil {
-		tmp.Close()
-		os.Remove(tmp.Name())
-		return "", err
-	}
-	if err := tmp.Close(); err != nil {
-		os.Remove(tmp.Name())
-		return "", err
-	}
-	return tmp.Name(), nil
+	defer source.Close()
+	return io.Copy(w, source)
 }

--- a/workers/generic-worker/usage.go
+++ b/workers/generic-worker/usage.go
@@ -17,7 +17,7 @@ const (
 	WORKER_SHUTDOWN             ExitCode = 72
 	INVALID_CONFIG              ExitCode = 73
 	CANT_CREATE_ED25519_KEYPAIR ExitCode = 75
-	CANT_COPY_TO_TEMP_FILE      ExitCode = 76
+	CANT_CAT_FILE               ExitCode = 76
 	CANT_CONNECT_PROTOCOL_PIPE  ExitCode = 78
 	CANT_CREATE_FILE            ExitCode = 79
 	CANT_CREATE_DIRECTORY       ExitCode = 80
@@ -39,7 +39,7 @@ and reports back results to the queue.
                                             [--worker-runner-protocol-pipe PIPE]` + installServiceSummary() + `
     generic-worker show-payload-schema
     generic-worker new-ed25519-keypair      --file ED25519-PRIVATE-KEY-FILE` + customTargetsSummary() + `
-    generic-worker copy-to-temp-file        --copy-file COPY-FILE
+    generic-worker cat-file                 --cat-file CAT-FILE
     generic-worker create-file              --create-file CREATE-FILE
     generic-worker create-dir               --create-dir CREATE-DIR
     generic-worker unarchive                --archive-src ARCHIVE-SRC --archive-dst ARCHIVE-DST --archive-fmt ARCHIVE-FMT
@@ -62,9 +62,8 @@ and reports back results to the queue.
                                             compliant private/public key pair. The public
                                             key will be written to stdout and the private
                                             key will be written to the specified file.` + customTargets() + `
-    copy-to-temp-file                       This will copy the specified file to a temporary
-                                            location and will return the temporary file path
-                                            to stdout. Intended for internal use.
+    cat-file                                This will write the contents of the specified
+                                            file to stdout. Intended for internal use.
     create-file                             This will create a file at the specified path.
                                             Intended for internal use.
     create-dir                              This will create a directory (including missing
@@ -93,7 +92,7 @@ and reports back results to the queue.
                                             to. The parent directory must already exist.
                                             If the file exists it will be overwritten,
                                             otherwise it will be created.` + sidSID() + `
-    --copy-file COPY-FILE                   The path to the file to copy.
+    --cat-file CAT-FILE                     The path to the file to write to stdout.
     --create-file CREATE-FILE               The path to the file to create.
     --create-dir CREATE-DIR                 The path to the directory to create.
     --archive-src ARCHIVE-SRC               The path to the archive file to unarchive.
@@ -369,7 +368,7 @@ and reports back results to the queue.
            spot termination notice, and therefore has shut down.
     73     The config provided to the worker is invalid.` + exitCode74() + `
     75     Not able to create an ed25519 key pair.
-    76     Not able to copy --copy-file to a temporary file.` + exitCode77() + `
+    76     Not able to write --cat-file to stdout.` + exitCode77() + `
     78     Not able to connect to --worker-runner-protocol-pipe.
     79     Not able to create file at --create-file path.
     80     Not able to create directory at --create-dir path.


### PR DESCRIPTION
When copying an artifact as a user on windows through `g-w copy-to-temp-file`, the worker asked for that copy without giving a destination and instead read that back from the *last line* of the user controlled process stdout. That stdout is a pipe and a stray process could write to it since it's entirely task owned, appending a single line and get the worker to then copy an entirely different file.

Posix platforms are just as redirectable for two reasons. There `\n` is a valid character in a filename, and the stray process could just read stdout as well and steal the actual filename and then write its own.

Instead of doing that which is very fragile to begin with, decide on the file path in the privileged process and then go cat the file as the user through `g-w cat-file`. This lead to me having to refactor quite a bit of the artifacts upload because cleanup became quite messy since it was unclear who owned that temporary file.

I had tried adding a `--dest` flag to the `copy-to-temp-file` command at first since it seemed like an easier solution, unfortunately windows had something to say about this because temp directories are scoped per user, so I couldn't easily get the worker to create a temp directory that the task user could write to. So I tried putting it in a reserved directory in the task folder but then we had to ignore that directory on upload in case the task would try to upload the entire task home as artifact... Anyway, it was painful, had many edge cases that I really didn't like. So I came up with this, which doesn't have any of those issues. Better, the task never even sees the actually uploaded file or file structure, so unlike the previous implementation that relied entirely on safefs to not follow planted junctions/links, now we also have default windows ACLs providing some security after the copy.

If you're attentive you'll notice that this removes a very scary workaround, `copy-to-temp-file` used to print some unrelated things on stdout which would corrupt the resulting path. It was never found out why this was happening so I had to dig up some history. Before ed5e9c1f48ec2a4469ed3e3fb10dc7208c12f7b1, which fixed this exact pollution on `--version`, logs from the worker were output to stdout instead of stderr. After that commit, logs go to stderr which fixes the corruption and thus doesn't impact `cat-file`. I still added a test for binary files artifacts and check that there's no stray data in there. I was both concerned about that workaround before digging and about windows messing linebreaks. Both concerns are now properly tested.

There's a few bonus points in this refactor, first of all, when gzipping an artifact, we avoid a full copy. Before this, the file was copied in a temp file, then gzipped in a second one. Since we're streaming the content, we can just pass it directly through gzip. That's one less copy.

Secondly, the code used to copy all files to tmp and then upload them (which is the reason why cleanup was so complex). It'll now copy and then upload in one go, which means the maximum disk space required for tmp isn't the entirety of all artifacts anymore but just space for 10 at a time. This reduces peak usage and should also start uploads earlier which should speed things up quite a bit since copy/upload will now happen in parallel.

Third, artifacts temporary copies are now stored in the worker's temporary directory instead of the user's. Which means the user can't fiddle with them anymore. I don't think this saves us from anything since the content is owned by the user already, but I feel better about internal copies not being in a user owned directory.

Now one change in behavior that I chose to take rather than bend the code in weird ways (it's bent enough as it is...). When uploading an optional artifact, it'll now fail the task if the artifact fails to upload because of a permission issue. That goes against the original implementation of optional artifacts in
5062e7d82b28be3078356394f5787b859c33bf88.
However, neither the commit message nor the documentation state that the intent of resolving tasks failing to upload artifacts due to permission issues was on purpose. I'm assuming it was made to match docker-worker 1-1, but I don't think that this case can happen in normal tasks without someone trying to mess with reserved artifacts or trying to upload files that can't get uploaded anyway, in which case we'd just hide the bug (for a d2g task that generates a 0600 root owned file declared as an artifact, the task will now fail rather than pass and ignore the file). IMHO this is an improvement on behavior, dropping artifacts that do exist silently hides task bugs. It also follows the direction we've taken with 7044b6a9726854f865a1a70683e5bb75be635ca2.

Closes #6677 on the way.