### PR TITLE
feat(ci): trigger trusted CI for Dependabot PRs

### DIFF
--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -24,6 +24,11 @@ jobs:
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
           GITHUB_TOKEN: ${{ secrets.DEPENDABOT_AUTOMERGE_TOKEN }}
+      - name: Trigger trusted CI
+        run: gh pr comment "$PR_URL" --body "/taskcluster run"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GITHUB_TOKEN: ${{ secrets.DEPENDABOT_AUTOMERGE_TOKEN }}
       - name: Enable auto-merge for Dependabot PRs
         if: ${{ contains(fromJson('["version-update:semver-patch", "version-update:semver-minor"]'), steps.metadata.outputs.update-type) }}
         run: gh pr merge --auto --merge "$PR_URL"


### PR DESCRIPTION
Dependabot PRs only get untrusted (level 1) checks under public_restricted, so auto-merge can stall on a graph that never runs. Comment `/taskcluster run` after approval so the trusted graph starts.