### PR TITLE
fix(tests): expect ACL on loopback video devices in both gw engines

### DIFF
--- a/changelog/TR8YEc4-TGyYnayN-fW6bA.md
+++ b/changelog/TR8YEc4-TGyYnayN-fW6bA.md
@@ -1,0 +1,3 @@
+audience: developers
+level: silent
+---

--- a/workers/generic-worker/loopback_video_linux_test.go
+++ b/workers/generic-worker/loopback_video_linux_test.go
@@ -36,15 +36,8 @@ func TestLoopbackVideo(t *testing.T) {
 	if !strings.Contains(logText, "Device: "+devicePath) {
 		t.Fatalf("Expected log to contain 'Device: %s', but it didn't\n%s", devicePath, logText)
 	}
-	switch engine {
-	case "multiuser":
-		if !strings.Contains(logText, "crw-rw----+ 1 root video") {
-			t.Fatalf("Expected log to contain 'crw-rw----+ 1 root video', but it didn't\n%s", logText)
-		}
-	case "insecure":
-		if !strings.Contains(logText, "crw-rw---- 1 root video") {
-			t.Fatalf("Expected log to contain 'crw-rw---- 1 root video', but it didn't\n%s", logText)
-		}
+	if !strings.Contains(logText, "crw-rw----+ 1 root video") {
+		t.Fatalf("Expected log to contain 'crw-rw----+ 1 root video', but it didn't\n%s", logText)
 	}
 }
 


### PR DESCRIPTION
Worker images now install v4l2loopback via DKMS
(see https://github.com/mozilla-platform-ops/worker-images/pull/910), so `/dev/videoN` consistently has POSIX ACLs on insecure as well as multiuser. The engine split from #7551 is no longer needed.