### PR TITLE
Bug 2060945 - Prevent renames from overwriting pre-existing files and remove useless chowns on mounts

### DIFF
--- a/changelog/bug-2060945-01.md
+++ b/changelog/bug-2060945-01.md
@@ -1,0 +1,5 @@
+audience: users
+level: major
+reference: bug 2060945
+---
+A writable directory cache will now refuse being mounted at a `directory` that already exists.

--- a/changelog/bug-2060945.md
+++ b/changelog/bug-2060945.md
@@ -1,0 +1,7 @@
+audience: users
+level: major
+reference: bug 2060945
+---
+Moving a directory into place now refuses a destination that already exists on
+every platform: on Windows it no longer replaces an existing file, and on POSIX
+systems it no longer replaces an existing empty directory.

--- a/changelog/issue-7447.md
+++ b/changelog/issue-7447.md
@@ -1,0 +1,6 @@
+audience: worker-deployers
+level: patch
+reference: issue 7447
+---
+Generic-worker no longer chowns read-only content that is mounted as the task
+user.

--- a/generated/references.json
+++ b/generated/references.json
@@ -10571,7 +10571,7 @@
               "title": "Content"
             },
             "directory": {
-              "description": "The filesystem location to mount the directory volume.\nThis can be a path relative to the task directory, or an\nabsolute path. The directory will be created as the task\nuser, so the target location must be writable by the task\nuser.\n\nSince: generic-worker 5.4.0",
+              "description": "The filesystem location to mount the directory volume.\nThis can be a path relative to the task directory, or an\nabsolute path. The directory must not already exist. It\nis created as the task user, so its parent must be\nwritable by the task user.\n\nSince: generic-worker 5.4.0",
               "title": "Directory Volume",
               "type": "string"
             },
@@ -11113,7 +11113,7 @@
               "title": "Content"
             },
             "directory": {
-              "description": "The filesystem location to mount the directory volume.\nThis can be a path relative to the task directory, or an\nabsolute path. The directory will be created as the task\nuser, so the target location must be writable by the task\nuser.\n\nSince: generic-worker 5.4.0",
+              "description": "The filesystem location to mount the directory volume.\nThis can be a path relative to the task directory, or an\nabsolute path. The directory must not already exist. It\nis created as the task user, so its parent must be\nwritable by the task user.\n\nSince: generic-worker 5.4.0",
               "title": "Directory Volume",
               "type": "string"
             },
@@ -11934,7 +11934,7 @@
               "title": "Content"
             },
             "directory": {
-              "description": "The filesystem location to mount the directory volume.\nThis can be a path relative to the task directory, or an\nabsolute path.\n\nSince: generic-worker 5.4.0",
+              "description": "The filesystem location to mount the directory volume.\nThis can be a path relative to the task directory, or an\nabsolute path. The directory must not already exist.\n\nSince: generic-worker 5.4.0",
               "title": "Directory Volume",
               "type": "string"
             },

--- a/tools/d2g/genericworker/generated_types.go
+++ b/tools/d2g/genericworker/generated_types.go
@@ -783,9 +783,9 @@ type (
 
 		// The filesystem location to mount the directory volume.
 		// This can be a path relative to the task directory, or an
-		// absolute path. The directory will be created as the task
-		// user, so the target location must be writable by the task
-		// user.
+		// absolute path. The directory must not already exist. It
+		// is created as the task user, so its parent must be
+		// writable by the task user.
 		//
 		// Since: generic-worker 5.4.0
 		Directory string `json:"directory"`
@@ -1099,7 +1099,7 @@ func JSONSchema() string {
           "title": "Content"
         },
         "directory": {
-          "description": "The filesystem location to mount the directory volume.\nThis can be a path relative to the task directory, or an\nabsolute path. The directory will be created as the task\nuser, so the target location must be writable by the task\nuser.\n\nSince: generic-worker 5.4.0",
+          "description": "The filesystem location to mount the directory volume.\nThis can be a path relative to the task directory, or an\nabsolute path. The directory must not already exist. It\nis created as the task user, so its parent must be\nwritable by the task user.\n\nSince: generic-worker 5.4.0",
           "title": "Directory Volume",
           "type": "string"
         },

--- a/workers/generic-worker/generated_insecure_darwin.go
+++ b/workers/generic-worker/generated_insecure_darwin.go
@@ -743,7 +743,7 @@ type (
 
 		// The filesystem location to mount the directory volume.
 		// This can be a path relative to the task directory, or an
-		// absolute path.
+		// absolute path. The directory must not already exist.
 		//
 		// Since: generic-worker 5.4.0
 		Directory string `json:"directory"`
@@ -1057,7 +1057,7 @@ func JSONSchema() string {
           "title": "Content"
         },
         "directory": {
-          "description": "The filesystem location to mount the directory volume.\nThis can be a path relative to the task directory, or an\nabsolute path.\n\nSince: generic-worker 5.4.0",
+          "description": "The filesystem location to mount the directory volume.\nThis can be a path relative to the task directory, or an\nabsolute path. The directory must not already exist.\n\nSince: generic-worker 5.4.0",
           "title": "Directory Volume",
           "type": "string"
         },

--- a/workers/generic-worker/generated_insecure_freebsd.go
+++ b/workers/generic-worker/generated_insecure_freebsd.go
@@ -743,7 +743,7 @@ type (
 
 		// The filesystem location to mount the directory volume.
 		// This can be a path relative to the task directory, or an
-		// absolute path.
+		// absolute path. The directory must not already exist.
 		//
 		// Since: generic-worker 5.4.0
 		Directory string `json:"directory"`
@@ -1057,7 +1057,7 @@ func JSONSchema() string {
           "title": "Content"
         },
         "directory": {
-          "description": "The filesystem location to mount the directory volume.\nThis can be a path relative to the task directory, or an\nabsolute path.\n\nSince: generic-worker 5.4.0",
+          "description": "The filesystem location to mount the directory volume.\nThis can be a path relative to the task directory, or an\nabsolute path. The directory must not already exist.\n\nSince: generic-worker 5.4.0",
           "title": "Directory Volume",
           "type": "string"
         },

--- a/workers/generic-worker/generated_insecure_linux.go
+++ b/workers/generic-worker/generated_insecure_linux.go
@@ -743,7 +743,7 @@ type (
 
 		// The filesystem location to mount the directory volume.
 		// This can be a path relative to the task directory, or an
-		// absolute path.
+		// absolute path. The directory must not already exist.
 		//
 		// Since: generic-worker 5.4.0
 		Directory string `json:"directory"`
@@ -1057,7 +1057,7 @@ func JSONSchema() string {
           "title": "Content"
         },
         "directory": {
-          "description": "The filesystem location to mount the directory volume.\nThis can be a path relative to the task directory, or an\nabsolute path.\n\nSince: generic-worker 5.4.0",
+          "description": "The filesystem location to mount the directory volume.\nThis can be a path relative to the task directory, or an\nabsolute path. The directory must not already exist.\n\nSince: generic-worker 5.4.0",
           "title": "Directory Volume",
           "type": "string"
         },

--- a/workers/generic-worker/generated_multiuser_darwin.go
+++ b/workers/generic-worker/generated_multiuser_darwin.go
@@ -785,9 +785,9 @@ type (
 
 		// The filesystem location to mount the directory volume.
 		// This can be a path relative to the task directory, or an
-		// absolute path. The directory will be created as the task
-		// user, so the target location must be writable by the task
-		// user.
+		// absolute path. The directory must not already exist. It
+		// is created as the task user, so its parent must be
+		// writable by the task user.
 		//
 		// Since: generic-worker 5.4.0
 		Directory string `json:"directory"`
@@ -1101,7 +1101,7 @@ func JSONSchema() string {
           "title": "Content"
         },
         "directory": {
-          "description": "The filesystem location to mount the directory volume.\nThis can be a path relative to the task directory, or an\nabsolute path. The directory will be created as the task\nuser, so the target location must be writable by the task\nuser.\n\nSince: generic-worker 5.4.0",
+          "description": "The filesystem location to mount the directory volume.\nThis can be a path relative to the task directory, or an\nabsolute path. The directory must not already exist. It\nis created as the task user, so its parent must be\nwritable by the task user.\n\nSince: generic-worker 5.4.0",
           "title": "Directory Volume",
           "type": "string"
         },

--- a/workers/generic-worker/generated_multiuser_freebsd.go
+++ b/workers/generic-worker/generated_multiuser_freebsd.go
@@ -785,9 +785,9 @@ type (
 
 		// The filesystem location to mount the directory volume.
 		// This can be a path relative to the task directory, or an
-		// absolute path. The directory will be created as the task
-		// user, so the target location must be writable by the task
-		// user.
+		// absolute path. The directory must not already exist. It
+		// is created as the task user, so its parent must be
+		// writable by the task user.
 		//
 		// Since: generic-worker 5.4.0
 		Directory string `json:"directory"`
@@ -1101,7 +1101,7 @@ func JSONSchema() string {
           "title": "Content"
         },
         "directory": {
-          "description": "The filesystem location to mount the directory volume.\nThis can be a path relative to the task directory, or an\nabsolute path. The directory will be created as the task\nuser, so the target location must be writable by the task\nuser.\n\nSince: generic-worker 5.4.0",
+          "description": "The filesystem location to mount the directory volume.\nThis can be a path relative to the task directory, or an\nabsolute path. The directory must not already exist. It\nis created as the task user, so its parent must be\nwritable by the task user.\n\nSince: generic-worker 5.4.0",
           "title": "Directory Volume",
           "type": "string"
         },

--- a/workers/generic-worker/generated_multiuser_linux.go
+++ b/workers/generic-worker/generated_multiuser_linux.go
@@ -785,9 +785,9 @@ type (
 
 		// The filesystem location to mount the directory volume.
 		// This can be a path relative to the task directory, or an
-		// absolute path. The directory will be created as the task
-		// user, so the target location must be writable by the task
-		// user.
+		// absolute path. The directory must not already exist. It
+		// is created as the task user, so its parent must be
+		// writable by the task user.
 		//
 		// Since: generic-worker 5.4.0
 		Directory string `json:"directory"`
@@ -1101,7 +1101,7 @@ func JSONSchema() string {
           "title": "Content"
         },
         "directory": {
-          "description": "The filesystem location to mount the directory volume.\nThis can be a path relative to the task directory, or an\nabsolute path. The directory will be created as the task\nuser, so the target location must be writable by the task\nuser.\n\nSince: generic-worker 5.4.0",
+          "description": "The filesystem location to mount the directory volume.\nThis can be a path relative to the task directory, or an\nabsolute path. The directory must not already exist. It\nis created as the task user, so its parent must be\nwritable by the task user.\n\nSince: generic-worker 5.4.0",
           "title": "Directory Volume",
           "type": "string"
         },

--- a/workers/generic-worker/generated_multiuser_windows.go
+++ b/workers/generic-worker/generated_multiuser_windows.go
@@ -603,9 +603,9 @@ type (
 
 		// The filesystem location to mount the directory volume.
 		// This can be a path relative to the task directory, or an
-		// absolute path. The directory will be created as the task
-		// user, so the target location must be writable by the task
-		// user.
+		// absolute path. The directory must not already exist. It
+		// is created as the task user, so its parent must be
+		// writable by the task user.
 		//
 		// Since: generic-worker 5.4.0
 		Directory string `json:"directory"`
@@ -875,7 +875,7 @@ func JSONSchema() string {
           "title": "Content"
         },
         "directory": {
-          "description": "The filesystem location to mount the directory volume.\nThis can be a path relative to the task directory, or an\nabsolute path. The directory will be created as the task\nuser, so the target location must be writable by the task\nuser.\n\nSince: generic-worker 5.4.0",
+          "description": "The filesystem location to mount the directory volume.\nThis can be a path relative to the task directory, or an\nabsolute path. The directory must not already exist. It\nis created as the task user, so its parent must be\nwritable by the task user.\n\nSince: generic-worker 5.4.0",
           "title": "Directory Volume",
           "type": "string"
         },

--- a/workers/generic-worker/mounts_feature.go
+++ b/workers/generic-worker/mounts_feature.go
@@ -23,6 +23,7 @@ import (
 	"github.com/taskcluster/taskcluster/v109/internal/mocktc/tc"
 	"github.com/taskcluster/taskcluster/v109/internal/scopes"
 	"github.com/taskcluster/taskcluster/v109/workers/generic-worker/fileutil"
+	"github.com/taskcluster/taskcluster/v109/workers/generic-worker/safefs"
 	"golang.org/x/sync/singleflight"
 )
 
@@ -896,6 +897,15 @@ func (f *FileMount) FSContent() (FSContent, error) {
 func (w *WritableDirectoryCache) Mount(taskMount *TaskMount) (err error) {
 	target := fileutil.AbsFrom(taskMount.task.TaskDir(), w.Directory)
 
+	exists, existsErr := safefs.Exists(target)
+	if existsErr != nil {
+		return fmt.Errorf("cannot mount writable directory cache '%v' at %v: %v", w.CacheName, target, existsErr)
+	}
+
+	if exists {
+		return fmt.Errorf("cannot mount writable directory cache '%v' at %v since it already exists", w.CacheName, target)
+	}
+
 	entry, created := acquireOrCreateCache(w.CacheName)
 
 	// released is set before any operation that can panic so recover
@@ -953,8 +963,12 @@ func (w *WritableDirectoryCache) Mount(taskMount *TaskMount) (err error) {
 			return fmt.Errorf("not able to move directory %v to %v: %v", cacheLocation, target, mvErr)
 		}
 		taskMount.poolEntries[w] = entry
+		if chownErr := makeDirReadWritableForTaskUser(taskMount, target); chownErr != nil {
+			_ = evictEntry()
+			return chownErr
+		}
 	} else {
-		taskMount.Infof("No existing writable directory cache '%v' - creating %v", w.CacheName, entry.Location)
+		taskMount.Infof("No existing writable directory cache '%v' - creating %v", w.CacheName, target)
 		if w.Content != nil {
 			c, fsErr := FSContentFrom(w.Content)
 			if fsErr != nil {
@@ -974,15 +988,6 @@ func (w *WritableDirectoryCache) Mount(taskMount *TaskMount) (err error) {
 		taskMount.poolEntries[w] = entry
 	}
 
-	// Regardless of whether we are running as current user, grant task
-	// user access. The mounted folder may be inside the task directory
-	// or at an absolute path outside it. Either way, the file system
-	// resources should be owned by the task user, even if commands
-	// execute as LocalSystem.
-	if chownErr := makeDirReadWritableForTaskUser(taskMount, target); chownErr != nil {
-		_ = evictEntry()
-		return chownErr
-	}
 	taskMount.Infof("Successfully mounted writable directory cache '%v'", target)
 	return nil
 }
@@ -1028,11 +1033,7 @@ func (r *ReadOnlyDirectory) Mount(taskMount *TaskMount) error {
 		return fmt.Errorf("not able to retrieve FSContent: %v", err)
 	}
 	dir := fileutil.AbsFrom(taskMount.task.TaskDir(), r.Directory)
-	err = extract(c, r.Format, dir, taskMount)
-	if err != nil {
-		return err
-	}
-	return makeDirReadWritableForTaskUser(taskMount, dir)
+	return extract(c, r.Format, dir, taskMount)
 }
 
 // Nothing to do - original archive file wasn't moved
@@ -1063,12 +1064,7 @@ func (f *FileMount) Mount(taskMount *TaskMount) error {
 		return handler(cachedFile, sha256)
 	}
 
-	err = decompress(fsContent, f.Format, file, taskMount)
-	if err != nil {
-		return err
-	}
-
-	return makeFileReadWritableForTaskUser(taskMount, file)
+	return decompress(fsContent, f.Format, file, taskMount)
 }
 
 // Nothing to do - original archive file was copied, not moved

--- a/workers/generic-worker/mounts_test.go
+++ b/workers/generic-worker/mounts_test.go
@@ -326,7 +326,6 @@ func TestValidSHA256(t *testing.T) {
 	// Whether permission is granted to task user depends if running multiuser
 	// engine or insecure engine but is independent of whether running as current
 	// user or not.
-	grantingDir, _ := grantingDenying(t, "directory", false, "unknown_issuer_app_1")
 	grantingCacheFile, _ := grantingDenying(t, "file", true)
 
 	// Required text from first task with no cached value
@@ -343,9 +342,6 @@ func TestValidSHA256(t *testing.T) {
 		`Extracting zip file .* to '.*unknown_issuer_app_1'`,
 		`Removing file '.*'`,
 	)
-	pass1 = append(pass1,
-		grantingDir...,
-	)
 
 	// Required text from second task when download is already cached
 	pass2 := append([]string{
@@ -358,9 +354,6 @@ func TestValidSHA256(t *testing.T) {
 	pass2 = append(pass2,
 		`Extracting zip file .* to '.*unknown_issuer_app_1'`,
 		`Removing file '.*'`,
-	)
-	pass2 = append(pass2,
-		grantingDir...,
 	)
 
 	LogTest(
@@ -394,30 +387,21 @@ func TestFileMountNoSHA256(t *testing.T) {
 	setup(t)
 	taskID := CreateArtifactFromFile(t, "unknown_issuer_app_1.zip", "public/build/unknown_issuer_app_1.zip")
 
-	// Whether permission is granted to task user depends if running multiuser
-	// engine or insecure engine but is independent of whether running as current
-	// user or not.
-	granting, _ := grantingDenying(t, "file", false, t.Name())
-
 	// No cache on first pass
-	pass1 := append([]string{
+	pass1 := []string{
 		`Downloading task ` + taskID + ` artifact public/build/unknown_issuer_app_1.zip to .*`,
 		`Downloaded 4220 bytes with SHA256 625554ec8ce731e486a5fb904f3331d18cf84a944dd9e40c19550686d4e8492e from task ` + taskID + ` artifact public/build/unknown_issuer_app_1.zip to .*`,
 		`Download .* of task ` + taskID + ` artifact public/build/unknown_issuer_app_1.zip has SHA256 625554ec8ce731e486a5fb904f3331d18cf84a944dd9e40c19550686d4e8492e but task payload does not declare a required value, so content authenticity cannot be verified`,
 		`Creating directory .*`,
 		`Copying .* to .*` + t.Name(),
-	},
-		granting...,
-	)
+	}
 
 	// On second pass, cache already exists
-	pass2 := append([]string{
+	pass2 := []string{
 		`No SHA256 specified in task mounts for artifact:` + taskID + `:public/build/unknown_issuer_app_1.zip - SHA256 from downloaded file .* is 625554ec8ce731e486a5fb904f3331d18cf84a944dd9e40c19550686d4e8492e.`,
 		`Creating directory .*`,
 		`Copying .* to .*` + t.Name(),
-	},
-		granting...,
-	)
+	}
 
 	LogTest(
 		&MountsLoggingTestCase{
@@ -450,29 +434,21 @@ func TestFileMountWithCompression(t *testing.T) {
 	setup(t)
 	taskID := CreateArtifactFromFile(t, "compressed-file-mount.txt.gz", "public/build/compressed-file-mount.txt.gz")
 
-	// whether permission is granted to task user depends if running under windows or not
-	// and is independent of whether running as current user or not
-	granting, _ := grantingDenying(t, "file", false, t.Name())
-
 	// No cache on first pass
-	pass1 := append([]string{
+	pass1 := []string{
 		`Downloading task ` + taskID + ` artifact public/build/compressed-file-mount.txt.gz to .*`,
 		`Downloaded 89 bytes with SHA256 a37856e8cd10250f76dc076bb03d380b16a870dec31f3461223f753124a4b28a from task ` + taskID + ` artifact public/build/compressed-file-mount.txt.gz to .*`,
 		`Content from task ` + taskID + ` artifact public/build/compressed-file-mount.txt.gz .* matches required SHA256 a37856e8cd10250f76dc076bb03d380b16a870dec31f3461223f753124a4b28a`,
 		`Creating directory .*`,
 		`Decompressing gz file .* to .*` + t.Name(),
-	},
-		granting...,
-	)
+	}
 
 	// On second pass, cache already exists
-	pass2 := append([]string{
+	pass2 := []string{
 		`Found existing download for artifact:` + taskID + `:public/build/compressed-file-mount.txt.gz .* with correct SHA256 a37856e8cd10250f76dc076bb03d380b16a870dec31f3461223f753124a4b28a`,
 		`Creating directory .*`,
 		`Decompressing gz file .* to .*` + t.Name(),
-	},
-		granting...,
-	)
+	}
 
 	payload := GenericWorkerPayload{
 		Command:    printFileContents(t.Name()),
@@ -573,9 +549,6 @@ func TestWritableDirectoryCacheNoSHA256(t *testing.T) {
 	pass1 = append(pass1,
 		`Extracting zip file .* to '.*`+t.Name()+`'`,
 		`Removing file '.*'`,
-	)
-	pass1 = append(pass1,
-		grantingDir...,
 	)
 	pass1 = append(pass1,
 		`Successfully mounted writable directory cache '.*`+t.Name()+`'`,
@@ -907,6 +880,46 @@ func TestCachesCanBeModified(t *testing.T) {
 	})
 }
 
+func TestWritableDirectoryCacheOverExistingDirectory(t *testing.T) {
+	setup(t)
+
+	dir := worldWritableTempDir(t, "existing-cache-dir")
+	existingFile := filepath.Join(dir, "existing.txt")
+	if err := os.WriteFile(existingFile, []byte("data"), 0666); err != nil {
+		t.Fatalf("Could not create %v: %v", existingFile, err)
+	}
+
+	mounts := []MountEntry{
+		&WritableDirectoryCache{
+			CacheName: "tc-test-banana-cache",
+			Directory: dir,
+		},
+	}
+
+	payload := GenericWorkerPayload{
+		Mounts:     toMountArray(t, &mounts),
+		Command:    helloGoodbye(),
+		MaxRunTime: 180,
+	}
+	defaults.SetDefaults(&payload)
+
+	td := testTask(t)
+	td.Scopes = []string{"generic-worker:cache:tc-test-banana-cache"}
+
+	_ = submitAndAssert(t, td, payload, "failed", "failed")
+
+	logtext := LogText(t)
+	if !strings.Contains(logtext, "since it already exists") {
+		t.Fatalf("Was expecting log to report that the cache directory already exists, but it contains:\n%v", logtext)
+	}
+	if _, err := os.Stat(existingFile); err != nil {
+		t.Fatalf("Was expecting %v to be left in place, but: %v", existingFile, err)
+	}
+	if entries := directoryCaches["tc-test-banana-cache"]; len(entries) != 0 {
+		t.Fatalf("Was expecting no cache entry to have been created, but found %v", entries)
+	}
+}
+
 // TestCacheMoved tests that if a test mounts a cache, and then moves it to a
 // different location, that the test fails, and the worker doesn't crash.
 func TestCacheMoved(t *testing.T) {
@@ -917,7 +930,6 @@ func TestCacheMoved(t *testing.T) {
 	// engine or insecure engine but is independent of whether running as current
 	// user or not.
 	grantingCacheFile, _ := grantingDenying(t, "file", true)
-	grantingDir, _ := grantingDenying(t, "directory", false, t.Name())
 
 	// No cache on first pass
 	pass1 := append([]string{
@@ -933,9 +945,6 @@ func TestCacheMoved(t *testing.T) {
 	pass1 = append(pass1,
 		`Extracting zip file .* to '.*`+t.Name()+`'`,
 		`Removing file '.*'`,
-	)
-	pass1 = append(pass1,
-		grantingDir...,
 	)
 	pass1 = append(pass1,
 		`Successfully mounted writable directory cache '.*`+t.Name()+`'`,
@@ -957,9 +966,6 @@ func TestCacheMoved(t *testing.T) {
 	pass2 = append(pass2,
 		`Extracting zip file .* to '.*`+t.Name()+`'`,
 		`Removing file '.*'`,
-	)
-	pass2 = append(pass2,
-		grantingDir...,
 	)
 	pass2 = append(pass2,
 		`Successfully mounted writable directory cache '.*`+t.Name()+`'`,
@@ -1013,21 +1019,14 @@ func TestMountFileAndDirSameLocation(t *testing.T) {
 	setup(t)
 	taskID := CreateArtifactFromFile(t, "unknown_issuer_app_1.zip", "public/build/unknown_issuer_app_1.zip")
 
-	// Whether permission is granted to task user depends if running multiuser
-	// engine or insecure engine but is independent of whether running as current
-	// user or not.
-	granting, _ := grantingDenying(t, "file", false, "file-located-here")
-
 	// No cache on first pass
-	pass1 := append([]string{
+	pass1 := []string{
 		`Downloading task ` + taskID + ` artifact public/build/unknown_issuer_app_1.zip to .*`,
 		`Downloaded 4220 bytes with SHA256 625554ec8ce731e486a5fb904f3331d18cf84a944dd9e40c19550686d4e8492e from task ` + taskID + ` artifact public/build/unknown_issuer_app_1.zip to .*`,
 		`Download .* of task ` + taskID + ` artifact public/build/unknown_issuer_app_1.zip has SHA256 625554ec8ce731e486a5fb904f3331d18cf84a944dd9e40c19550686d4e8492e but task payload does not declare a required value, so content authenticity cannot be verified`,
 		`Creating directory .*`,
 		`Copying .* to .*file-located-here`,
-	},
-		granting...,
-	)
+	}
 
 	pass1 = append(pass1,
 		`Found existing download for artifact:`+taskID+`:public/build/unknown_issuer_app_1.zip \(.*\) with correct SHA256 625554ec8ce731e486a5fb904f3331d18cf84a944dd9e40c19550686d4e8492e`,
@@ -1037,13 +1036,11 @@ func TestMountFileAndDirSameLocation(t *testing.T) {
 	)
 
 	// On second pass, cache already exists
-	pass2 := append([]string{
+	pass2 := []string{
 		`No SHA256 specified in task mounts for artifact:` + taskID + `:public/build/unknown_issuer_app_1.zip - SHA256 from downloaded file .* is 625554ec8ce731e486a5fb904f3331d18cf84a944dd9e40c19550686d4e8492e.`,
 		`Creating directory .*`,
 		`Copying .* to .*file-located-here`,
-	},
-		granting...,
-	)
+	}
 
 	pass2 = append(pass2,
 		`Found existing download for artifact:`+taskID+`:public/build/unknown_issuer_app_1.zip \(.*\) with correct SHA256 625554ec8ce731e486a5fb904f3331d18cf84a944dd9e40c19550686d4e8492e`,

--- a/workers/generic-worker/safefs/exists_posix_test.go
+++ b/workers/generic-worker/safefs/exists_posix_test.go
@@ -1,0 +1,55 @@
+//go:build darwin || linux || freebsd
+
+package safefs
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestExists(t *testing.T) {
+	base := untrustedTempDir(t)
+	write(t, filepath.Join(base, "file"), "x")
+	mkdir(t, filepath.Join(base, "dir"))
+	mkfifo(t, filepath.Join(base, "fifo"))
+	symlink(t, filepath.Join(base, "file"), filepath.Join(base, "tofile"))
+	symlink(t, filepath.Join(base, "narnia"), filepath.Join(base, "dangling"))
+
+	mkdir(t, filepath.Join(base, "elsewhere", "sub"))
+	stage := symlink(t, filepath.Join(base, "elsewhere", "sub"), filepath.Join(base, "stage"))
+	mkdir(t, filepath.Join(base, "target"))
+
+	for _, tc := range []struct {
+		name    string
+		path    string
+		exists  bool
+		refused bool
+	}{
+		{"a file", filepath.Join(base, "file"), true, false},
+		{"a directory", filepath.Join(base, "dir"), true, false},
+		{"a fifo", filepath.Join(base, "fifo"), true, false},
+		{"a symlink to a file", filepath.Join(base, "tofile"), true, false},
+		{"a dangling symlink", filepath.Join(base, "dangling"), true, false},
+		{"an absent leaf", filepath.Join(base, "gonebuyingmilk"), false, false},
+		{"an absent parent", filepath.Join(base, "no", "such", "parent", "leaf"), false, false},
+		{"a symlinked prefix", filepath.Join(stage, "leaf"), false, true},
+		// lstat would walk the symlink and miss this one entirely
+		{"a symlinked prefix cleaned away by ..", stage + "/../target", true, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			exists, err := Exists(tc.path)
+			if tc.refused {
+				if err == nil {
+					t.Fatal("was expecting the path to be refused")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			if exists != tc.exists {
+				t.Errorf("exists = %v, want %v", exists, tc.exists)
+			}
+		})
+	}
+}

--- a/workers/generic-worker/safefs/exists_windows_test.go
+++ b/workers/generic-worker/safefs/exists_windows_test.go
@@ -1,0 +1,45 @@
+package safefs
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestExists(t *testing.T) {
+	base := t.TempDir()
+	write(t, filepath.Join(base, "file"), "x")
+	mkdir(t, filepath.Join(base, "dir"))
+	secret, _ := mksecret(t, base)
+	stage := filepath.Join(base, "stage")
+	mkjunction(t, stage, secret)
+
+	for _, tc := range []struct {
+		name    string
+		path    string
+		exists  bool
+		refused bool
+	}{
+		{"a file", filepath.Join(base, "file"), true, false},
+		{"a directory", filepath.Join(base, "dir"), true, false},
+		{"a junction", stage, true, false},
+		{"an absent leaf", filepath.Join(base, "gonebuyingmilk"), false, false},
+		{"an absent parent", filepath.Join(base, "no", "such", "parent", "leaf"), false, false},
+		{"a junctioned prefix", filepath.Join(stage, "leaf"), false, true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			exists, err := Exists(tc.path)
+			if tc.refused {
+				if err == nil {
+					t.Fatal("was expecting the path to be refused")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			if exists != tc.exists {
+				t.Errorf("exists = %v, want %v", exists, tc.exists)
+			}
+		})
+	}
+}

--- a/workers/generic-worker/safefs/safefs_posix.go
+++ b/workers/generic-worker/safefs/safefs_posix.go
@@ -295,6 +295,28 @@ func isDirAt(dirfd int, name string) bool {
 	return st.Mode&unix.S_IFMT == unix.S_IFDIR
 }
 
+// Returns whether or not a path exists. A path we refuse to follow is an
+// error, not an absence
+func Exists(path string) (bool, error) {
+	parent, name, err := openParent(path)
+	if err != nil {
+		if errors.Is(err, unix.ENOENT) || errors.Is(err, unix.ENOTDIR) {
+			return false, nil
+		}
+		return false, err
+	}
+	defer unix.Close(parent)
+
+	var st unix.Stat_t
+	if err := unix.Fstatat(parent, name, &st, unix.AT_SYMLINK_NOFOLLOW); err != nil {
+		if errors.Is(err, unix.ENOENT) {
+			return false, nil
+		}
+		return false, fmt.Errorf("could not stat %q: %w", path, err)
+	}
+	return true, nil
+}
+
 func IsExistingDir(path string) bool {
 	parent, name, err := openParent(path)
 	if err != nil {

--- a/workers/generic-worker/safefs/safefs_posix.go
+++ b/workers/generic-worker/safefs/safefs_posix.go
@@ -253,6 +253,16 @@ func Rename(oldpath, newpath string) error {
 	}
 	defer unix.Close(targetParent)
 
+	if isDirAt(sourceParent, sourceName) {
+		var st unix.Stat_t
+		switch err := unix.Fstatat(targetParent, targetName, &st, unix.AT_SYMLINK_NOFOLLOW); {
+		case err == nil:
+			return fmt.Errorf("refusing to rename %q to %q: something is already there", oldpath, newpath)
+		case !errors.Is(err, unix.ENOENT):
+			return fmt.Errorf("could not stat %q: %w", newpath, err)
+		}
+	}
+
 	if err := unix.Renameat(sourceParent, sourceName, targetParent, targetName); err != nil {
 		return fmt.Errorf("could not rename %q to %q: %w", oldpath, newpath, err)
 	}

--- a/workers/generic-worker/safefs/safefs_posix_test.go
+++ b/workers/generic-worker/safefs/safefs_posix_test.go
@@ -329,6 +329,33 @@ func TestRename(t *testing.T) {
 		}
 	})
 
+	t.Run("refuses to give a directory an existing empty directory's name", func(t *testing.T) {
+		base := t.TempDir()
+		src := mkdir(t, filepath.Join(base, "src"))
+		write(t, filepath.Join(src, "payload"), "mine")
+		dst := mkdir(t, filepath.Join(base, "dst"))
+
+		if err := Rename(src, dst); err == nil {
+			t.Error("replaced a directory that was already there")
+		}
+		if _, err := os.Stat(filepath.Join(dst, "payload")); err == nil {
+			t.Error("source content landed in the destination")
+		}
+	})
+
+	t.Run("replaces a file with a file", func(t *testing.T) {
+		base := t.TempDir()
+		src := write(t, filepath.Join(base, "src"), "mine")
+		dst := write(t, filepath.Join(base, "dst"), "theirs")
+
+		if err := Rename(src, dst); err != nil {
+			t.Fatal(err)
+		}
+		if b, err := os.ReadFile(dst); err != nil || string(b) != "mine" {
+			t.Errorf("dst = %q, %v", b, err)
+		}
+	})
+
 	t.Run("refuses bad paths", func(t *testing.T) {
 		dst := filepath.Join(t.TempDir(), "moved")
 		for _, src := range []string{"", "/"} {

--- a/workers/generic-worker/safefs/safefs_windows.go
+++ b/workers/generic-worker/safefs/safefs_windows.go
@@ -456,6 +456,36 @@ func Remove(path string) error {
 	return DeleteChild(parent, name, filepath.Dir(path))
 }
 
+// Returns whether or not a path exists. A path we refuse to follow is an
+// error, not an absence
+func Exists(path string) (bool, error) {
+	parent, name, err := OpenParent(path, traverseAccess)
+	if err != nil {
+		if absent(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	defer func() { _ = windows.CloseHandle(parent) }()
+
+	handle, err := OpenChild(parent, name, filepath.Dir(path), windows.FILE_READ_ATTRIBUTES|windows.SYNCHRONIZE)
+	if err != nil {
+		if absent(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	_ = windows.CloseHandle(handle)
+	return true, nil
+}
+
+func absent(err error) bool {
+	return errors.Is(err, windows.ERROR_FILE_NOT_FOUND) ||
+		errors.Is(err, windows.ERROR_PATH_NOT_FOUND) ||
+		errors.Is(err, windows.STATUS_OBJECT_NAME_NOT_FOUND) ||
+		errors.Is(err, windows.STATUS_OBJECT_PATH_NOT_FOUND)
+}
+
 // Whether path is an existing directory
 func IsExistingDir(path string) bool {
 	handle, err := OpenPath(path, windows.FILE_READ_ATTRIBUTES|windows.SYNCHRONIZE)

--- a/workers/generic-worker/safefs/safefs_windows.go
+++ b/workers/generic-worker/safefs/safefs_windows.go
@@ -478,6 +478,11 @@ func Rename(oldpath, newpath string) error {
 	}
 	defer func() { _ = windows.CloseHandle(source) }()
 
+	sourceIsDir, _, err := Kind(source)
+	if err != nil {
+		return fmt.Errorf("could not stat %q: %w", oldpath, err)
+	}
+
 	parent, name, err := OpenParent(newpath, traverseAccess|windows.FILE_WRITE_DATA|windows.FILE_APPEND_DATA)
 	if err != nil {
 		return err
@@ -499,7 +504,9 @@ func Rename(oldpath, newpath string) error {
 
 	buffer := make([]byte, size)
 	rename := (*fileRenameInformation)(unsafe.Pointer(&buffer[0]))
-	rename.ReplaceIfExists = windows.FILE_RENAME_REPLACE_IF_EXISTS
+	if !sourceIsDir {
+		rename.ReplaceIfExists = windows.FILE_RENAME_REPLACE_IF_EXISTS
+	}
 	rename.RootDirectory = parent
 	rename.FileNameLength = uint32(nameLen)
 	// capped at the name itself, the buffer has no room for the terminator

--- a/workers/generic-worker/safefs/safefs_windows_test.go
+++ b/workers/generic-worker/safefs/safefs_windows_test.go
@@ -157,6 +157,47 @@ func TestRename(t *testing.T) {
 			t.Error("planted inside the secret")
 		}
 	})
+
+	t.Run("refuses to replace an existing file", func(t *testing.T) {
+		base := t.TempDir()
+		src := mkdir(t, filepath.Join(base, "src"))
+		write(t, filepath.Join(src, "payload"), "mine")
+		dst := write(t, filepath.Join(base, "dst"), "important")
+
+		if err := Rename(src, dst); err == nil {
+			t.Error("replaced a file that was already there")
+		}
+		if b, err := os.ReadFile(dst); err != nil || string(b) != "important" {
+			t.Errorf("dst = %q, %v", b, err)
+		}
+	})
+
+	t.Run("refuses to replace an existing directory", func(t *testing.T) {
+		base := t.TempDir()
+		src := mkdir(t, filepath.Join(base, "src"))
+		write(t, filepath.Join(src, "payload"), "mine")
+		dst := mkdir(t, filepath.Join(base, "dst"))
+
+		if err := Rename(src, dst); err == nil {
+			t.Error("replaced a directory that was already there")
+		}
+		if _, err := os.Stat(filepath.Join(dst, "payload")); err == nil {
+			t.Error("source content overwritten in the destination")
+		}
+	})
+
+	t.Run("replaces a file with a file", func(t *testing.T) {
+		base := t.TempDir()
+		src := write(t, filepath.Join(base, "src"), "mine")
+		dst := write(t, filepath.Join(base, "dst"), "theirs")
+
+		if err := Rename(src, dst); err != nil {
+			t.Fatal(err)
+		}
+		if b, err := os.ReadFile(dst); err != nil || string(b) != "mine" {
+			t.Errorf("dst = %q, %v", b, err)
+		}
+	})
 }
 
 func TestRemove(t *testing.T) {

--- a/workers/generic-worker/schemas/insecure_posix.yml
+++ b/workers/generic-worker/schemas/insecure_posix.yml
@@ -712,7 +712,7 @@ definitions:
         description: |-
           The filesystem location to mount the directory volume.
           This can be a path relative to the task directory, or an
-          absolute path.
+          absolute path. The directory must not already exist.
 
           Since: generic-worker 5.4.0
       cacheName:

--- a/workers/generic-worker/schemas/multiuser_posix.yml
+++ b/workers/generic-worker/schemas/multiuser_posix.yml
@@ -786,9 +786,9 @@ definitions:
         description: |-
           The filesystem location to mount the directory volume.
           This can be a path relative to the task directory, or an
-          absolute path. The directory will be created as the task
-          user, so the target location must be writable by the task
-          user.
+          absolute path. The directory must not already exist. It
+          is created as the task user, so its parent must be
+          writable by the task user.
 
           Since: generic-worker 5.4.0
       cacheName:

--- a/workers/generic-worker/schemas/multiuser_windows.yml
+++ b/workers/generic-worker/schemas/multiuser_windows.yml
@@ -537,9 +537,9 @@ definitions:
         description: |-
           The filesystem location to mount the directory volume.
           This can be a path relative to the task directory, or an
-          absolute path. The directory will be created as the task
-          user, so the target location must be writable by the task
-          user.
+          absolute path. The directory must not already exist. It
+          is created as the task user, so its parent must be
+          writable by the task user.
 
           Since: generic-worker 5.4.0
       cacheName:


### PR DESCRIPTION
This fixes both the renames and makes chowning anything but hot caches useless which fixes #7447 on the way. See individual commits for more details.