### PR TITLE
Rename generic-worker test caches with a tc-test- prefix

### DIFF
--- a/changelog/generic-worker-test-cache-names.md
+++ b/changelog/generic-worker-test-cache-names.md
@@ -1,0 +1,3 @@
+level: silent
+---
+Renames the generic-worker test caches with a `tc-test-` prefix.

--- a/workers/generic-worker/CLAUDE.md
+++ b/workers/generic-worker/CLAUDE.md
@@ -141,8 +141,8 @@ Features implement the `Feature` / `TaskFeature` interfaces:
 - Cache scopes are defined in the
   [community-tc-config](https://github.com/taskcluster/community-tc-config) repo
   at `config/projects/taskcluster.yml`.
-- Available test cache scopes: `apple-cache`, `banana-cache`, `devtools-app`,
-  `test-modifications`, `unknown-issuer-app-cache`.
+- Available test cache scopes: `tc-test-cache-1`, `tc-test-cache-2`, `tc-test-artifact-cache`,
+  `tc-test-url-cache`, `tc-test-modifications-cache`.
 - Adding new cache names requires a PR to the community-tc-config repo.
 
 ### Test helpers

--- a/workers/generic-worker/main_test.go
+++ b/workers/generic-worker/main_test.go
@@ -338,9 +338,9 @@ func TestAbortAfterMaxRunTime(t *testing.T) {
 	// Include a writable directory cache, to test that caches are purged
 	// rather than preserved when a task aborts prematurely.
 	mounts := []MountEntry{
-		// requires scope "generic-worker:cache:banana-cache"
+		// requires scope "generic-worker:cache:tc-test-cache-1"
 		&WritableDirectoryCache{
-			CacheName: "banana-cache",
+			CacheName: "tc-test-cache-1",
 			Directory: filepath.Join("bananas"),
 		},
 	}
@@ -356,7 +356,7 @@ func TestAbortAfterMaxRunTime(t *testing.T) {
 	}
 	defaults.SetDefaults(&payload)
 	td := testTask(t)
-	td.Scopes = []string{"generic-worker:cache:banana-cache"}
+	td.Scopes = []string{"generic-worker:cache:tc-test-cache-1"}
 
 	taskID := scheduleTask(t, td, payload)
 	startTime := time.Now()

--- a/workers/generic-worker/mounts_insecure_test.go
+++ b/workers/generic-worker/mounts_insecure_test.go
@@ -20,7 +20,7 @@ func TestHardLinksInArchive(t *testing.T) {
 	setup(t)
 
 	mounts := []MountEntry{
-		// requires scope "generic-worker:cache:banana-cache"
+		// requires scope "generic-worker:cache:tc-test-cache-1"
 		&ReadOnlyDirectory{
 			Directory: filepath.Join("tools", "git"),
 			Content: json.RawMessage(`{

--- a/workers/generic-worker/mounts_multiuser_test.go
+++ b/workers/generic-worker/mounts_multiuser_test.go
@@ -60,7 +60,7 @@ func TestTaskUserCannotMountInPrivilegedLocation(t *testing.T) {
 
 	mounts := []MountEntry{
 		&WritableDirectoryCache{
-			CacheName: "banana-cache",
+			CacheName: "tc-test-cache-1",
 			Directory: filepath.Join("../../../", filepath.Base(dir)),
 		},
 	}
@@ -73,7 +73,7 @@ func TestTaskUserCannotMountInPrivilegedLocation(t *testing.T) {
 	defaults.SetDefaults(&payload)
 
 	td := testTask(t)
-	td.Scopes = append(td.Scopes, "generic-worker:cache:banana-cache")
+	td.Scopes = append(td.Scopes, "generic-worker:cache:tc-test-cache-1")
 
 	_ = submitAndAssert(t, td, payload, "failed", "failed")
 }
@@ -83,7 +83,7 @@ func TestHardLinksInArchive(t *testing.T) {
 	setup(t)
 
 	mounts := []MountEntry{
-		// requires scope "generic-worker:cache:banana-cache"
+		// requires scope "generic-worker:cache:tc-test-cache-1"
 		&ReadOnlyDirectory{
 			Directory: filepath.Join("tools", "git"),
 			Content: json.RawMessage(`{

--- a/workers/generic-worker/mounts_multiuser_windows_test.go
+++ b/workers/generic-worker/mounts_multiuser_windows_test.go
@@ -28,7 +28,7 @@ func TestWritableDirectoryCacheReclaimsOwnership(t *testing.T) {
 
 	mounts := []MountEntry{
 		&WritableDirectoryCache{
-			CacheName: "banana-cache",
+			CacheName: "tc-test-cache-1",
 			Directory: "ownership-cache",
 		},
 	}
@@ -42,14 +42,14 @@ func TestWritableDirectoryCacheReclaimsOwnership(t *testing.T) {
 
 	runTask := func() {
 		td := testTask(t)
-		td.Scopes = append(td.Scopes, "generic-worker:cache:banana-cache")
+		td.Scopes = append(td.Scopes, "generic-worker:cache:tc-test-cache-1")
 		_ = submitAndAssert(t, td, payload, "completed", "completed")
 	}
 
 	cacheLocation := func() string {
-		entries := directoryCaches["banana-cache"]
+		entries := directoryCaches["tc-test-cache-1"]
 		if len(entries) == 0 {
-			t.Fatal("expected a persisted banana-cache entry after the task ran")
+			t.Fatal("expected a persisted tc-test-cache-1 entry after the task ran")
 		}
 		return entries[0].Location
 	}

--- a/workers/generic-worker/mounts_test.go
+++ b/workers/generic-worker/mounts_test.go
@@ -31,9 +31,9 @@ func TestMissingScopes(t *testing.T) {
 				"artifact": "SampleArtifacts/_/X.txt"
 			}`),
 		},
-		// requires scope "generic-worker:cache:banana-cache"
+		// requires scope "generic-worker:cache:tc-test-cache-1"
 		&WritableDirectoryCache{
-			CacheName: "banana-cache",
+			CacheName: "tc-test-cache-1",
 			Directory: filepath.Join("my-task-caches", "bananas"),
 		},
 	}
@@ -54,7 +54,7 @@ func TestMissingScopes(t *testing.T) {
 	_ = submitAndAssert(t, td, payload, "exception", "malformed-payload")
 
 	logtext := LogText(t)
-	if !strings.Contains(logtext, "generic-worker:cache:banana-cache") {
+	if !strings.Contains(logtext, "generic-worker:cache:tc-test-cache-1") {
 		t.Fatalf("Was expecting log file to contain missing worker-enforced scopes, but it doesn't")
 	}
 }
@@ -74,9 +74,9 @@ func TestMissingMountsDependency(t *testing.T) {
 				"artifact": "SampleArtifacts/_/X.txt"
 			}`),
 		},
-		// requires scope "generic-worker:cache:banana-cache"
+		// requires scope "generic-worker:cache:tc-test-cache-1"
 		&WritableDirectoryCache{
-			CacheName: "banana-cache",
+			CacheName: "tc-test-cache-1",
 			Directory: filepath.Join("my-task-caches", "bananas"),
 		},
 	}
@@ -90,7 +90,7 @@ func TestMissingMountsDependency(t *testing.T) {
 
 	td := testTask(t)
 	td.Scopes = []string{
-		"generic-worker:cache:banana-cache",
+		"generic-worker:cache:tc-test-cache-1",
 		"queue:get-artifact:SampleArtifacts/_/X.txt",
 	}
 
@@ -561,7 +561,7 @@ func TestWritableDirectoryCacheNoSHA256(t *testing.T) {
 
 	// No cache on first pass
 	pass1 := append([]string{
-		`No existing writable directory cache 'banana-cache' - creating .*`,
+		`No existing writable directory cache 'tc-test-cache-1' - creating .*`,
 		`Downloading task ` + taskID + ` artifact public/build/unknown_issuer_app_1.zip to .*`,
 		`Downloaded 4220 bytes with SHA256 625554ec8ce731e486a5fb904f3331d18cf84a944dd9e40c19550686d4e8492e from task ` + taskID + ` artifact public/build/unknown_issuer_app_1.zip to .*`,
 		`Download .* of task ` + taskID + ` artifact public/build/unknown_issuer_app_1.zip has SHA256 625554ec8ce731e486a5fb904f3331d18cf84a944dd9e40c19550686d4e8492e but task payload does not declare a required value, so content authenticity cannot be verified`,
@@ -584,7 +584,7 @@ func TestWritableDirectoryCacheNoSHA256(t *testing.T) {
 
 	// On second pass, cache already exists
 	pass2 := append([]string{
-		`Moving existing writable directory cache banana-cache from .* to .*` + t.Name(),
+		`Moving existing writable directory cache tc-test-cache-1 from .* to .*` + t.Name(),
 		`Creating directory .*`,
 	},
 		grantingDir...,
@@ -599,7 +599,7 @@ func TestWritableDirectoryCacheNoSHA256(t *testing.T) {
 			Test: t,
 			Mounts: []MountEntry{
 				&WritableDirectoryCache{
-					CacheName: "banana-cache",
+					CacheName: "tc-test-cache-1",
 					Directory: t.Name(),
 					Content: json.RawMessage(`{
 						"taskId":   "` + taskID + `",
@@ -619,7 +619,7 @@ func TestWritableDirectoryCacheNoSHA256(t *testing.T) {
 				// Required text from second task when download is already cached
 				pass2,
 			},
-			Scopes: []string{"generic-worker:cache:banana-cache"},
+			Scopes: []string{"generic-worker:cache:tc-test-cache-1"},
 		},
 	)
 }
@@ -682,13 +682,13 @@ func TestMounts(t *testing.T) {
 
 		// empty writable directory cache
 		&WritableDirectoryCache{
-			CacheName: "banana-cache",
+			CacheName: "tc-test-cache-1",
 			Directory: filepath.Join("my-task-caches", "bananas"),
 		},
 
 		// pre-loaded writable directory cache from artifact
 		&WritableDirectoryCache{
-			CacheName: "unknown-issuer-app-cache",
+			CacheName: "tc-test-artifact-cache",
 			Directory: filepath.Join("my-task-caches", "unknown_issuer_app_1"),
 			Content: json.RawMessage(`{
 				"taskId":   "` + taskID3 + `",
@@ -699,7 +699,7 @@ func TestMounts(t *testing.T) {
 
 		// pre-loaded writable directory cache from url
 		&WritableDirectoryCache{
-			CacheName: "devtools-app",
+			CacheName: "tc-test-url-cache",
 			Directory: filepath.Join("my-task-caches", "devtools-app"),
 			Content: json.RawMessage(`{
 				"url": "https://github.com/mozilla/gecko-dev/raw/233f30f2377f3df0f3388721901681f432b813fb/devtools/client/webide/test/app.zip"
@@ -750,8 +750,8 @@ func TestMounts(t *testing.T) {
 
 		// writable directory cache using absolute path (issue #6689)
 		&WritableDirectoryCache{
-			CacheName: "apple-cache",
-			Directory: filepath.Join(absPathTestDir, "apple-cache"),
+			CacheName: "tc-test-cache-2",
+			Directory: filepath.Join(absPathTestDir, "tc-test-cache-2"),
 		},
 	}
 
@@ -776,10 +776,10 @@ func TestMounts(t *testing.T) {
 	}
 	td.Scopes = []string{
 		"queue:get-artifact:SampleArtifacts/_/X.txt",
-		"generic-worker:cache:banana-cache",
-		"generic-worker:cache:unknown-issuer-app-cache",
-		"generic-worker:cache:devtools-app",
-		"generic-worker:cache:apple-cache",
+		"generic-worker:cache:tc-test-cache-1",
+		"generic-worker:cache:tc-test-artifact-cache",
+		"generic-worker:cache:tc-test-url-cache",
+		"generic-worker:cache:tc-test-cache-2",
 	}
 
 	// check task succeeded
@@ -796,10 +796,10 @@ func TestMounts(t *testing.T) {
 		"19168d6dc3cc840bd02658e30d761cd555bb1f2bb42da18edf08917dcaa55cf5",
 		filepath.Join(absPathTestDir, "abs-path-dir", "package.json"),
 	)
-	if entries := directoryCaches["apple-cache"]; len(entries) == 0 {
-		t.Error("Expected apple-cache to be persisted, but no pool entries found")
+	if entries := directoryCaches["tc-test-cache-2"]; len(entries) == 0 {
+		t.Error("Expected tc-test-cache-2 to be persisted, but no pool entries found")
 	} else if _, err := os.Stat(entries[0].Location); err != nil {
-		t.Errorf("Expected apple-cache to be persisted, but got: %v", err)
+		t.Errorf("Expected tc-test-cache-2 to be persisted, but got: %v", err)
 	}
 
 	checkSHA256(
@@ -837,7 +837,7 @@ func TestMounts(t *testing.T) {
 	checkSHA256(
 		t,
 		"51d818981374a447f0876610fd2baeeb911dd5ad60c6e6b4d2b6b6798ba5c071",
-		filepath.Join(directoryCaches["devtools-app"][0].Location, "foo.bar"),
+		filepath.Join(directoryCaches["tc-test-url-cache"][0].Location, "foo.bar"),
 	)
 }
 
@@ -854,7 +854,7 @@ func TestCachesCanBeModified(t *testing.T) {
 
 		mounts := []MountEntry{
 			&WritableDirectoryCache{
-				CacheName: "test-modifications",
+				CacheName: "tc-test-modifications-cache",
 				Directory: cacheDir,
 			},
 		}
@@ -868,12 +868,12 @@ func TestCachesCanBeModified(t *testing.T) {
 
 		execute := func() {
 			td := testTask(t)
-			td.Scopes = []string{"generic-worker:cache:test-modifications"}
+			td.Scopes = []string{"generic-worker:cache:tc-test-modifications-cache"}
 			_ = submitAndAssert(t, td, payload, "completed", "completed")
 		}
 
 		getCounter := func() int {
-			counterFile := filepath.Join(directoryCaches["test-modifications"][0].Location, "counter")
+			counterFile := filepath.Join(directoryCaches["tc-test-modifications-cache"][0].Location, "counter")
 			bytes, err := os.ReadFile(counterFile)
 			if err != nil {
 				t.Fatalf("Error when trying to read cache file: %v", err)
@@ -898,12 +898,12 @@ func TestCachesCanBeModified(t *testing.T) {
 	}
 
 	t.Run("RelativePath", func(t *testing.T) {
-		testCacheModifications(t, filepath.Join("my-task-caches", "test-modifications"))
+		testCacheModifications(t, filepath.Join("my-task-caches", "tc-test-modifications-cache"))
 	})
 
 	t.Run("AbsolutePath", func(t *testing.T) {
 		absPathTestDir := worldWritableTempDir(t, "abs-path-cache-test")
-		testCacheModifications(t, filepath.Join(absPathTestDir, "test-modifications"))
+		testCacheModifications(t, filepath.Join(absPathTestDir, "tc-test-modifications-cache"))
 	})
 }
 
@@ -921,7 +921,7 @@ func TestCacheMoved(t *testing.T) {
 
 	// No cache on first pass
 	pass1 := append([]string{
-		`No existing writable directory cache 'banana-cache' - creating .*`,
+		`No existing writable directory cache 'tc-test-cache-1' - creating .*`,
 		`Downloading task ` + taskID + ` artifact public/build/unknown_issuer_app_1.zip to .*`,
 		`Downloaded 4220 bytes with SHA256 625554ec8ce731e486a5fb904f3331d18cf84a944dd9e40c19550686d4e8492e from task ` + taskID + ` artifact public/build/unknown_issuer_app_1.zip to .*`,
 		`Content from task ` + taskID + ` artifact public/build/unknown_issuer_app_1.zip \(.*\) matches required SHA256 625554ec8ce731e486a5fb904f3331d18cf84a944dd9e40c19550686d4e8492e`,
@@ -940,14 +940,14 @@ func TestCacheMoved(t *testing.T) {
 	pass1 = append(pass1,
 		`Successfully mounted writable directory cache '.*`+t.Name()+`'`,
 		`Preserving cache: Moving ".*`+t.Name()+`" to ".*"`,
-		`Removing cache banana-cache from cache table`,
-		`Deleting cache banana-cache file\(s\) at .*`,
-		`Could not unmount task `+taskID+` artifact public/build/unknown_issuer_app_1.zip due to: 'could not persist cache "banana-cache" due to .*'`,
+		`Removing cache tc-test-cache-1 from cache table`,
+		`Deleting cache tc-test-cache-1 file\(s\) at .*`,
+		`Could not unmount task `+taskID+` artifact public/build/unknown_issuer_app_1.zip due to: 'could not persist cache "tc-test-cache-1" due to .*'`,
 	)
 
 	// On second pass, cache already exists
 	pass2 := append([]string{
-		`No existing writable directory cache 'banana-cache' - creating .*`,
+		`No existing writable directory cache 'tc-test-cache-1' - creating .*`,
 		`Found existing download for artifact:` + taskID + `:public/build/unknown_issuer_app_1.zip \(.*\) with correct SHA256 625554ec8ce731e486a5fb904f3331d18cf84a944dd9e40c19550686d4e8492e`,
 		`Creating directory .*` + t.Name(),
 		`Copying file '.*' to '.*'`,
@@ -964,9 +964,9 @@ func TestCacheMoved(t *testing.T) {
 	pass2 = append(pass2,
 		`Successfully mounted writable directory cache '.*`+t.Name()+`'`,
 		`Preserving cache: Moving ".*`+t.Name()+`" to ".*"`,
-		`Removing cache banana-cache from cache table`,
-		`Deleting cache banana-cache file\(s\) at .*`,
-		`Could not unmount task `+taskID+` artifact public/build/unknown_issuer_app_1.zip due to: 'could not persist cache "banana-cache" due to .*'`,
+		`Removing cache tc-test-cache-1 from cache table`,
+		`Deleting cache tc-test-cache-1 file\(s\) at .*`,
+		`Could not unmount task `+taskID+` artifact public/build/unknown_issuer_app_1.zip due to: 'could not persist cache "tc-test-cache-1" due to .*'`,
 	)
 
 	payload := GenericWorkerPayload{
@@ -980,7 +980,7 @@ func TestCacheMoved(t *testing.T) {
 			Test: t,
 			Mounts: []MountEntry{
 				&WritableDirectoryCache{
-					CacheName: "banana-cache",
+					CacheName: "tc-test-cache-1",
 					Directory: t.Name(),
 					Content: json.RawMessage(`{
 						"taskId": "` + taskID + `",
@@ -993,7 +993,7 @@ func TestCacheMoved(t *testing.T) {
 			Dependencies: []string{
 				taskID,
 			},
-			Scopes:                 []string{"generic-worker:cache:banana-cache"},
+			Scopes:                 []string{"generic-worker:cache:tc-test-cache-1"},
 			Payload:                &payload,
 			TaskRunResolutionState: "failed",
 			TaskRunReasonResolved:  "failed",
@@ -1192,7 +1192,7 @@ func TestInvalidSHADoesNotPreventMountedMountsFromBeingUnmounted(t *testing.T) {
 
 	mounts := []MountEntry{
 		&WritableDirectoryCache{
-			CacheName: "unknown-issuer-app-cache",
+			CacheName: "tc-test-artifact-cache",
 			Directory: filepath.Join(t.Name(), "1"),
 		},
 		&ReadOnlyDirectory{
@@ -1219,7 +1219,7 @@ func TestInvalidSHADoesNotPreventMountedMountsFromBeingUnmounted(t *testing.T) {
 		taskID,
 	}
 	td.Scopes = []string{
-		"generic-worker:cache:unknown-issuer-app-cache",
+		"generic-worker:cache:tc-test-artifact-cache",
 	}
 
 	// check task failed due to bad SHA256
@@ -1227,7 +1227,7 @@ func TestInvalidSHADoesNotPreventMountedMountsFromBeingUnmounted(t *testing.T) {
 
 	mounts = []MountEntry{
 		&WritableDirectoryCache{
-			CacheName: "unknown-issuer-app-cache",
+			CacheName: "tc-test-artifact-cache",
 			Directory: filepath.Join(t.Name(), "1"),
 		},
 	}
@@ -1241,7 +1241,7 @@ func TestInvalidSHADoesNotPreventMountedMountsFromBeingUnmounted(t *testing.T) {
 
 	td = testTask(t)
 	td.Scopes = []string{
-		"generic-worker:cache:unknown-issuer-app-cache",
+		"generic-worker:cache:tc-test-artifact-cache",
 	}
 
 	// check task succeeded, and worker didn't crash when trying to mount cache

--- a/workers/generic-worker/purge_caches_test.go
+++ b/workers/generic-worker/purge_caches_test.go
@@ -12,9 +12,9 @@ import (
 func TestPurgeCaches(t *testing.T) {
 	setup(t)
 	mounts := []MountEntry{
-		// requires scope "generic-worker:cache:banana-cache"
+		// requires scope "generic-worker:cache:tc-test-cache-1"
 		&WritableDirectoryCache{
-			CacheName: "banana-cache",
+			CacheName: "tc-test-cache-1",
 			Directory: filepath.Join("my-task-caches", "bananas"),
 		},
 	}
@@ -28,18 +28,18 @@ func TestPurgeCaches(t *testing.T) {
 	}
 	defaults.SetDefaults(&payload)
 	td := testTask(t)
-	td.Scopes = []string{"generic-worker:cache:banana-cache"}
+	td.Scopes = []string{"generic-worker:cache:tc-test-cache-1"}
 
 	_ = submitAndAssert(t, td, payload, "failed", "failed")
 
 	logtext := LogText(t)
-	substring := "[mounts] Removing cache banana-cache from cache table"
+	substring := "[mounts] Removing cache tc-test-cache-1 from cache table"
 	if !strings.Contains(logtext, substring) {
 		t.Log(logtext)
 		t.Fatalf("Was expecting log to contain string %v.", substring)
 	}
 
-	substring = "[mounts] Deleting cache banana-cache file(s) at"
+	substring = "[mounts] Deleting cache tc-test-cache-1 file(s) at"
 	if !strings.Contains(logtext, substring) {
 		t.Log(logtext)
 		t.Fatalf("Was expecting log to contain string %v.", substring)
@@ -59,9 +59,9 @@ func TestPurgeCaches(t *testing.T) {
 func TestPurgeCachesCommandFailure(t *testing.T) {
 	setup(t)
 	mounts := []MountEntry{
-		// requires scope "generic-worker:cache:banana-cache"
+		// requires scope "generic-worker:cache:tc-test-cache-1"
 		&WritableDirectoryCache{
-			CacheName: "banana-cache",
+			CacheName: "tc-test-cache-1",
 			Directory: filepath.Join("my-task-caches", "bananas"),
 		},
 	}
@@ -75,7 +75,7 @@ func TestPurgeCachesCommandFailure(t *testing.T) {
 	}
 	defaults.SetDefaults(&payload)
 	td := testTask(t)
-	td.Scopes = []string{"generic-worker:cache:banana-cache"}
+	td.Scopes = []string{"generic-worker:cache:tc-test-cache-1"}
 
 	_ = submitAndAssert(t, td, payload, "failed", "failed")
 
@@ -94,9 +94,9 @@ func TestPurgeCachesCommandFailure(t *testing.T) {
 func TestPurgeCachesCommandSuccess(t *testing.T) {
 	setup(t)
 	mounts := []MountEntry{
-		// requires scope "generic-worker:cache:banana-cache"
+		// requires scope "generic-worker:cache:tc-test-cache-1"
 		&WritableDirectoryCache{
-			CacheName: "banana-cache",
+			CacheName: "tc-test-cache-1",
 			Directory: filepath.Join("my-task-caches", "bananas"),
 		},
 	}
@@ -110,7 +110,7 @@ func TestPurgeCachesCommandSuccess(t *testing.T) {
 	}
 	defaults.SetDefaults(&payload)
 	td := testTask(t)
-	td.Scopes = []string{"generic-worker:cache:banana-cache"}
+	td.Scopes = []string{"generic-worker:cache:tc-test-cache-1"}
 
 	_ = submitAndAssert(t, td, payload, "completed", "completed")
 
@@ -129,9 +129,9 @@ func TestPurgeCachesCommandSuccess(t *testing.T) {
 func TestPurgeCachesListCommand(t *testing.T) {
 	setup(t)
 	mounts := []MountEntry{
-		// requires scope "generic-worker:cache:banana-cache"
+		// requires scope "generic-worker:cache:tc-test-cache-1"
 		&WritableDirectoryCache{
-			CacheName: "banana-cache",
+			CacheName: "tc-test-cache-1",
 			Directory: filepath.Join("my-task-caches", "bananas"),
 		},
 	}
@@ -145,18 +145,18 @@ func TestPurgeCachesListCommand(t *testing.T) {
 	}
 	defaults.SetDefaults(&payload)
 	td := testTask(t)
-	td.Scopes = []string{"generic-worker:cache:banana-cache"}
+	td.Scopes = []string{"generic-worker:cache:tc-test-cache-1"}
 
 	_ = submitAndAssert(t, td, payload, "failed", "failed")
 
 	logtext := LogText(t)
-	substring := "[mounts] Removing cache banana-cache from cache table"
+	substring := "[mounts] Removing cache tc-test-cache-1 from cache table"
 	if !strings.Contains(logtext, substring) {
 		t.Log(logtext)
 		t.Fatalf("Was expecting log to contain string %v.", substring)
 	}
 
-	substring = "[mounts] Deleting cache banana-cache file(s) at"
+	substring = "[mounts] Deleting cache tc-test-cache-1 file(s) at"
 	if !strings.Contains(logtext, substring) {
 		t.Log(logtext)
 		t.Fatalf("Was expecting log to contain string %v.", substring)
@@ -176,9 +176,9 @@ func TestPurgeCachesListCommand(t *testing.T) {
 func TestPurgeCachesEmptyListCommandSuccess(t *testing.T) {
 	setup(t)
 	mounts := []MountEntry{
-		// requires scope "generic-worker:cache:banana-cache"
+		// requires scope "generic-worker:cache:tc-test-cache-1"
 		&WritableDirectoryCache{
-			CacheName: "banana-cache",
+			CacheName: "tc-test-cache-1",
 			Directory: filepath.Join("my-task-caches", "bananas"),
 		},
 	}
@@ -192,7 +192,7 @@ func TestPurgeCachesEmptyListCommandSuccess(t *testing.T) {
 	}
 	defaults.SetDefaults(&payload)
 	td := testTask(t)
-	td.Scopes = []string{"generic-worker:cache:banana-cache"}
+	td.Scopes = []string{"generic-worker:cache:tc-test-cache-1"}
 
 	_ = submitAndAssert(t, td, payload, "completed", "completed")
 
@@ -211,9 +211,9 @@ func TestPurgeCachesEmptyListCommandSuccess(t *testing.T) {
 func TestPurgeCachesEmptyListCommandFailure(t *testing.T) {
 	setup(t)
 	mounts := []MountEntry{
-		// requires scope "generic-worker:cache:banana-cache"
+		// requires scope "generic-worker:cache:tc-test-cache-1"
 		&WritableDirectoryCache{
-			CacheName: "banana-cache",
+			CacheName: "tc-test-cache-1",
 			Directory: filepath.Join("my-task-caches", "bananas"),
 		},
 	}
@@ -227,7 +227,7 @@ func TestPurgeCachesEmptyListCommandFailure(t *testing.T) {
 	}
 	defaults.SetDefaults(&payload)
 	td := testTask(t)
-	td.Scopes = []string{"generic-worker:cache:banana-cache"}
+	td.Scopes = []string{"generic-worker:cache:tc-test-cache-1"}
 
 	_ = submitAndAssert(t, td, payload, "failed", "failed")
 
@@ -246,9 +246,9 @@ func TestPurgeCachesEmptyListCommandFailure(t *testing.T) {
 func TestPurgeCachesNegativeExitCode(t *testing.T) {
 	setup(t)
 	mounts := []MountEntry{
-		// requires scope "generic-worker:cache:banana-cache"
+		// requires scope "generic-worker:cache:tc-test-cache-1"
 		&WritableDirectoryCache{
-			CacheName: "banana-cache",
+			CacheName: "tc-test-cache-1",
 			Directory: filepath.Join("my-task-caches", "bananas"),
 		},
 	}
@@ -262,7 +262,7 @@ func TestPurgeCachesNegativeExitCode(t *testing.T) {
 	}
 	defaults.SetDefaults(&payload)
 	td := testTask(t)
-	td.Scopes = []string{"generic-worker:cache:banana-cache"}
+	td.Scopes = []string{"generic-worker:cache:tc-test-cache-1"}
 
 	_ = submitAndAssert(t, td, payload, "exception", "malformed-payload")
 
@@ -278,9 +278,9 @@ func TestPurgeCachesNegativeExitCode(t *testing.T) {
 func TestPurgeTaskCaches(t *testing.T) {
 	setup(t)
 	mounts := []MountEntry{
-		// requires scope "generic-worker:cache:apple-cache"
+		// requires scope "generic-worker:cache:tc-test-cache-2"
 		&WritableDirectoryCache{
-			CacheName: "apple-cache",
+			CacheName: "tc-test-cache-2",
 			Directory: filepath.Join("my-task-caches", "apples"),
 		},
 	}
@@ -291,16 +291,16 @@ func TestPurgeTaskCaches(t *testing.T) {
 	}
 	defaults.SetDefaults(&payload)
 	td := testTask(t)
-	td.Scopes = []string{"generic-worker:cache:apple-cache"}
+	td.Scopes = []string{"generic-worker:cache:tc-test-cache-2"}
 
 	_ = submitAndAssert(t, td, payload, "completed", "completed")
 
 	ensureDirContainsNFiles(t, cachesDir, 1)
 
 	mounts = []MountEntry{
-		// requires scope "generic-worker:cache:banana-cache"
+		// requires scope "generic-worker:cache:tc-test-cache-1"
 		&WritableDirectoryCache{
-			CacheName: "banana-cache",
+			CacheName: "tc-test-cache-1",
 			Directory: filepath.Join("my-task-caches", "bananas"),
 		},
 	}
@@ -314,18 +314,18 @@ func TestPurgeTaskCaches(t *testing.T) {
 	}
 	defaults.SetDefaults(&payload)
 	td = testTask(t)
-	td.Scopes = []string{"generic-worker:cache:banana-cache"}
+	td.Scopes = []string{"generic-worker:cache:tc-test-cache-1"}
 
 	_ = submitAndAssert(t, td, payload, "failed", "failed")
 
 	logtext := LogText(t)
-	substring := "[mounts] Removing cache banana-cache from cache table"
+	substring := "[mounts] Removing cache tc-test-cache-1 from cache table"
 	if !strings.Contains(logtext, substring) {
 		t.Log(logtext)
 		t.Fatalf("Was expecting log to contain string %v.", substring)
 	}
 
-	substring = "[mounts] Deleting cache banana-cache file(s) at"
+	substring = "[mounts] Deleting cache tc-test-cache-1 file(s) at"
 	if !strings.Contains(logtext, substring) {
 		t.Log(logtext)
 		t.Fatalf("Was expecting log to contain string %v.", substring)

--- a/workers/generic-worker/taskstatus_test.go
+++ b/workers/generic-worker/taskstatus_test.go
@@ -16,15 +16,15 @@ func TestResolveResolvedTask(t *testing.T) {
 func TestReclaimCancelledTask(t *testing.T) {
 	setup(t)
 	mounts := []MountEntry{
-		// requires scope "generic-worker:cache:banana-cache"
+		// requires scope "generic-worker:cache:tc-test-cache-1"
 		&WritableDirectoryCache{
-			CacheName: "banana-cache",
+			CacheName: "tc-test-cache-1",
 			Directory: filepath.Join("my-task-caches", "bananas"),
 		},
 	}
 
 	td, payload := CancelTask(t)
-	td.Scopes = []string{"generic-worker:cache:banana-cache"}
+	td.Scopes = []string{"generic-worker:cache:tc-test-cache-1"}
 	payload.Command = append(payload.Command, sleep(300)...)
 	payload.Mounts = toMountArray(t, &mounts)
 	payload.Features.LiveLog = false


### PR DESCRIPTION
This should land at same time as https://github.com/taskcluster/community-tc-config/pull/1010.

Context: https://github.com/mozilla-releng/fxci-config/pull/1062/changes#r3977444751