### PR TITLE
Disable fsync, full_page_writes and synchronous_commit on postgresql on CI

### DIFF
--- a/changelog/LwumgGt5Shuu02EAYbhq2w.md
+++ b/changelog/LwumgGt5Shuu02EAYbhq2w.md
@@ -1,0 +1,2 @@
+level: silent
+---

--- a/taskcluster/docker/ci/Dockerfile
+++ b/taskcluster/docker/ci/Dockerfile
@@ -47,7 +47,9 @@ RUN mkdir -p /builds && \
     # allow postgres to connect locally with no auth -- this is for testing!
     echo 'local all all trust' > /etc/postgresql/15/main/pg_hba.conf && \
     echo 'host all all 127.0.0.1/32 trust' >> /etc/postgresql/15/main/pg_hba.conf && \
-    echo 'host all all ::1/128 trust' >> /etc/postgresql/15/main/pg_hba.conf
+    echo 'host all all ::1/128 trust' >> /etc/postgresql/15/main/pg_hba.conf && \
+    printf '%s\n' 'fsync = off' 'full_page_writes = off' 'synchronous_commit = off' \
+      >> /etc/postgresql/15/main/postgresql.conf
 
 # Set a default command useful for debugging
 CMD ["/bin/bash", "--login"]


### PR DESCRIPTION
We've had a few tasks that failed due to timeouts and the failures were very suspiciously slow around database operations. The clone was also slower than usual on those tasks which makes me think that the disks on those workers were not in a happy place. We can't fix slow disks but we can try to write a bit less and stop waiting for said writes.

The best thing would obviously be to move the database to tmpfs instead, but d2g doesn't allow for that so we take the next best thing.

We don't need [fsync] (or any of its [full_page_writes], [synchronous_commit] friends) on CI, if the database dies it dies forever anyway so there's literally no drawback to disabling it, and it should at least move those writes out of hot paths. See [non-durability] docs for postgresql where they recommend exactly that.

[non-durability]: https://www.postgresql.org/docs/15/non-durability.html
[fsync]: https://www.postgresql.org/docs/15/runtime-config-wal.html#GUC-FSYNC
[full_page_writes]: https://www.postgresql.org/docs/15/runtime-config-wal.html#GUC-FULL-PAGE-WRITES
[synchronous_commit]: https://www.postgresql.org/docs/15/runtime-config-wal.html#GUC-SYNCHRONOUS-COMMIT
