### PR TITLE
Fix flaky email notify test

### DIFF
--- a/changelog/ZLmktQtcSqyJwhPlDkP_Pw.md
+++ b/changelog/ZLmktQtcSqyJwhPlDkP_Pw.md
@@ -1,0 +1,2 @@
+level: silent
+---

--- a/services/notify/test/api_test.js
+++ b/services/notify/test/api_test.js
@@ -76,15 +76,14 @@ helper.secrets.mockSuite(testing.suiteName(), ['aws'], (mock, skipping) => {
   });
 
   test('email', async () => {
+    const address = helper.emailAddress();
     await helper.apiClient.email({
-      address: 'success@simulator.amazonses.com',
+      address,
       subject: 'Task Z-tDsP4jQ3OUTjN0Q6LNKQ is Complete',
       content: 'Task Z-tDsP4jQ3OUTjN0Q6LNKQ is finished. It took 124 minutes. <img src=x onerror=alert(1)//>',
       link: { text: 'Inspect Task', href: 'https://taskcluster.net/task-inspector/Z-tDsP4jQ3OUTjN0Q6LNKQ&foo=bar' },
     });
-    await helper.checkEmails(email => {
-      assert.deepEqual(email.delivery.recipients, ['success@simulator.amazonses.com']);
-    });
+    await helper.checkEmails(address);
   });
 
   test('does not send notifications to denylisted email address', async () => {
@@ -111,26 +110,24 @@ helper.secrets.mockSuite(testing.suiteName(), ['aws'], (mock, skipping) => {
   });
 
   test('email without link', async () => {
+    const address = helper.emailAddress();
     await helper.apiClient.email({
-      address: 'success@simulator.amazonses.com',
+      address,
       subject: 'Task Z-tDsP4jQ3OUTjN0Q6LNKo is Complete',
       content: 'Task Z-tDsP4jQ3OUTjN0Q6LNKo is finished. It took 124 minutes.',
     });
-    await helper.checkEmails(email => {
-      assert.deepEqual(email.delivery.recipients, ['success@simulator.amazonses.com']);
-    });
+    await helper.checkEmails(address);
   });
 
   test('email with fullscreen template', async () => {
+    const address = helper.emailAddress();
     await helper.apiClient.email({
-      address: 'success@simulator.amazonses.com',
+      address,
       subject: 'Task Z-tDsP4jQ3OUTjN0Q6LNKp is Complete',
       content: 'Task Z-tDsP4jQ3OUTjN0Q6LNKp is finished. It took 124 minutes.',
       template: 'fullscreen',
     });
-    await helper.checkEmails(email => {
-      assert.deepEqual(email.delivery.recipients, ['success@simulator.amazonses.com']);
-    });
+    await helper.checkEmails(address);
   });
 
   test('matrix', async () => {

--- a/services/notify/test/handler_test.js
+++ b/services/notify/test/handler_test.js
@@ -148,7 +148,8 @@ helper.secrets.mockSuite(testing.suiteName(), ['aws'], (mock, skipping) => {
   });
 
   test('email', async () => {
-    const route = 'test-notify.email.success@simulator.amazonses.com.on-transition';
+    const address = helper.emailAddress();
+    const route = `test-notify.email.${address}.on-transition`;
     helper.queue.addTask(baseStatus.taskId, makeTask([route]));
     await helper.fakePulseMessage({
       payload: {
@@ -158,9 +159,7 @@ helper.secrets.mockSuite(testing.suiteName(), ['aws'], (mock, skipping) => {
       routingKey: 'doesnt-matter',
       routes: [route],
     });
-    await helper.checkEmails(email => {
-      assert.deepEqual(email.delivery.recipients, ['success@simulator.amazonses.com']);
-    });
+    await helper.checkEmails(address);
   });
 
   test('matrix', async () => {

--- a/services/notify/test/helper.js
+++ b/services/notify/test/helper.js
@@ -1,4 +1,5 @@
 import assert from 'node:assert';
+import { randomUUID } from 'node:crypto';
 import path from 'node:path';
 import { SESv2Client, SendEmailCommand } from '@aws-sdk/client-sesv2';
 import { SNSClient, CreateTopicCommand, ListSubscriptionsByTopicCommand, SubscribeCommand } from '@aws-sdk/client-sns';
@@ -7,7 +8,6 @@ import {
   CreateQueueCommand,
   DeleteMessageCommand,
   GetQueueAttributesCommand,
-  PurgeQueueCommand,
   ReceiveMessageCommand,
   SetQueueAttributesCommand,
 } from '@aws-sdk/client-sqs';
@@ -67,6 +67,10 @@ helper.withDenier = skipping => {
   });
 };
 
+const emailToken = randomUUID().slice(0, 8);
+let emailSeq = 0;
+helper.emailAddress = () => `success+${emailToken}-${emailSeq++}@simulator.amazonses.com`;
+
 helper.withSES = (mock, skipping) => {
   let ses;
   let sqs;
@@ -90,9 +94,9 @@ helper.withSES = (mock, skipping) => {
       });
       load.inject('ses', ses);
 
-      helper.checkEmails = check => {
+      helper.checkEmails = address => {
         assert.equal(ses.emails.length, 1, 'Not exactly one email present!');
-        check(ses.emails.pop());
+        assert.deepEqual(ses.emails.pop().delivery.recipients, [address]);
       };
     } else {
       sqs = new SQSClient({
@@ -110,17 +114,9 @@ helper.withSES = (mock, skipping) => {
       const { Attributes: emailAttr } = await sqs.send(
         new GetQueueAttributesCommand({
           QueueUrl: emailSQSQueue,
-          AttributeNames: ['ApproximateNumberOfMessages', 'QueueArn'],
+          AttributeNames: ['QueueArn'],
         })
       );
-      if (emailAttr.ApproximateNumberOfMessages !== '0') {
-        debug(`Detected ${emailAttr.ApproximateNumberOfMessages} messages in email queue. Purging.`);
-        await sqs.send(
-          new PurgeQueueCommand({
-            QueueUrl: emailSQSQueue,
-          })
-        );
-      }
 
       // Send emails to sqs for testing
       const sns = new SNSClient({
@@ -180,27 +176,48 @@ helper.withSES = (mock, skipping) => {
         );
       }
 
-      helper.checkEmails = async check => {
-        const resp = await sqs.send(
-          new ReceiveMessageCommand({
-            QueueUrl: emailSQSQueue,
-            AttributeNames: ['ApproximateReceiveCount'],
-            MaxNumberOfMessages: 10,
-            VisibilityTimeout: 30,
-            WaitTimeSeconds: 20,
-          })
-        );
-        const messages = resp.Messages || [];
-        for (const message of messages) {
-          await sqs.send(
-            new DeleteMessageCommand({
+      helper.checkEmails = async address => {
+        // 25s from now so we dont get past the mocha timeout
+        const deadline = Date.now() + 25000;
+        let email;
+
+        while (!email && Date.now() < deadline) {
+          const remaining = Math.floor((deadline - Date.now()) / 1000);
+          const resp = await sqs.send(
+            new ReceiveMessageCommand({
               QueueUrl: emailSQSQueue,
-              ReceiptHandle: message.ReceiptHandle,
+              MaxNumberOfMessages: 10,
+              VisibilityTimeout: 0,
+              // Don't let that long poll blow past the deadline
+              WaitTimeSeconds: Math.max(1, Math.min(20, remaining)),
             })
           );
+
+          const messages = resp.Messages || [];
+
+          for (const message of messages) {
+            const notification = JSON.parse(JSON.parse(message.Body).Message);
+            if (!notification.delivery.recipients.includes(address)) {
+              debug(`Ignoring email notification for ${notification.delivery.recipients}`);
+              continue;
+            }
+            await sqs.send(
+              new DeleteMessageCommand({
+                QueueUrl: emailSQSQueue,
+                ReceiptHandle: message.ReceiptHandle,
+              })
+            );
+
+            email = notification;
+            break;
+          }
+
+          if (!email && messages.length > 0) {
+            await testing.sleep(1000);
+          }
         }
-        assert.equal(messages.length, 1);
-        check(JSON.parse(JSON.parse(messages[0].Body).Message));
+
+        assert(email, `expected an email delivered to ${address}`);
       };
     }
   });


### PR DESCRIPTION
That test uses a shared SES queue for all jobs running at the same time. The previous code was eagerly deleting everything it found in that queue as soon as it found one message which means 2 tests running concurrently would make one of them fail since its message would've gotten stolen. It also means that a test could pass despite having broken email sending since it could get emails from another concurrent test.

Since I don't want to split queues, both because I have no idea if we have creds that can do that and mostly because I don't want to leak them if a test ever fails to cleanup, I instead went this way. Every message is now sent to `success+<randomID>-<seq>@` and the check loop ignores *anything* that doesn't match. So two tests can't just take eachother messages. This removes both the failure case and fixes the problem where one test could pass for the wrong reason.

Messages that do end up orphaned get cleared up by AWS after `MessageRetentionPeriod` which should be set to something sensible on the test queue.
